### PR TITLE
appveyor: minor improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ version: 7.50.0.{build}
 
 environment:
     UNITY: "OFF"
+    SHARED: "OFF"
     matrix:
       # generated CMake-based Visual Studio Release builds
       - job_name: "CMake, VS2008, Release x86, Schannel"
@@ -40,7 +41,6 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: ON
         TESTING: OFF
         SHARED: ON
         DISABLED_TESTS: ""
@@ -54,7 +54,6 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: ON
         TESTING: OFF
         SHARED: ON
         DISABLED_TESTS: ""
@@ -70,9 +69,8 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: ON
+        DEBUG: "ON"
         TESTING: OFF
-        SHARED: OFF
         DISABLED_TESTS: ""
       # generated CMake-based Visual Studio Debug builds
       - job_name: "CMake, VS2010, Debug x64, no SSL, Static"
@@ -84,9 +82,8 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: ON
+        DEBUG: "ON"
         TESTING: ON
-        SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\msys64\\usr\\bin"
       - job_name: "CMake, VS2022, Debug x64, Schannel, Static, Unicode"
@@ -99,9 +96,8 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
-        DEBUG: ON
+        DEBUG: "ON"
         TESTING: ON
-        SHARED: OFF
         DISABLED_TESTS: "~571 !1139 !1501"
         ADD_PATH: "C:\\msys64\\usr\\bin"
       - job_name: "CMake, VS2022, Debug x64, no SSL, Static"
@@ -114,9 +110,8 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: ON
+        DEBUG: "ON"
         TESTING: ON
-        SHARED: OFF
         DISABLED_TESTS: "~571 !1139 !1501"
         ADD_PATH: "C:\\msys64\\usr\\bin"
       - job_name: "CMake, VS2022, Debug x64, no SSL, Static, HTTP only"
@@ -129,9 +124,8 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: ON
-        DEBUG: ON
+        DEBUG: "ON"
         TESTING: ON
-        SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\msys64\\usr\\bin"
       # generated CMake-based MSYS Makefiles builds (mingw cross-compiling)
@@ -144,9 +138,8 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
-        DEBUG: ON
+        DEBUG: "ON"
         TESTING: ON
-        SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\mingw-w64\\x86_64-8.1.0-posix-seh-rt_v6-rev0\\mingw64\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
@@ -160,9 +153,8 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
-        DEBUG: ON
+        DEBUG: "ON"
         TESTING: ON
-        SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
@@ -176,9 +168,8 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: ON
+        DEBUG: "ON"
         TESTING: OFF
-        SHARED: OFF
         ADD_PATH: "C:\\msys64\\mingw64\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
         BUILD_OPT: -k
@@ -192,9 +183,8 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: ON
+        DEBUG: "ON"
         TESTING: ON
-        SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\mingw-w64\\i686-6.3.0-posix-dwarf-rt_v5-rev1\\mingw32\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
@@ -321,7 +311,7 @@ build_script:
         -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
         cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT% &&
         bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
-        if %SHARED%==ON (
+        if "%SHARED%" == "ON" (
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&
         if "%OPENSSL%" == "OFF" (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,6 +40,7 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: OFF
         SHARED: ON
         DISABLED_TESTS: ""
@@ -53,6 +54,7 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: OFF
         SHARED: ON
         DISABLED_TESTS: ""
@@ -68,6 +70,7 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: OFF
         SHARED: OFF
         DISABLED_TESTS: ""
@@ -81,6 +84,7 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: ON
         SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
@@ -95,6 +99,7 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: ON
         SHARED: OFF
         DISABLED_TESTS: "~571 !1139 !1501"
@@ -109,6 +114,7 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: ON
         SHARED: OFF
         DISABLED_TESTS: "~571 !1139 !1501"
@@ -123,6 +129,7 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: ON
+        DEBUG: ON
         TESTING: ON
         SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
@@ -137,6 +144,7 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: ON
         SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
@@ -152,13 +160,14 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: ON
         SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
         BUILD_OPT: -k
-      - job_name: "CMake, mingw-w64, Debug x64, Schannel, Static, Unity"
+      - job_name: "CMake, mingw-w64, gcc 9, Debug x64, Schannel, Static, Unity"
         APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
@@ -167,13 +176,14 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: OFF
         SHARED: OFF
-        ADD_PATH: "C:\\mingw-w64\\x86_64-8.1.0-posix-seh-rt_v6-rev0\\mingw64\\bin;C:\\msys64\\usr\\bin"
+        ADD_PATH: "C:\\msys64\\mingw64\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
         BUILD_OPT: -k
         UNITY: "ON"
-      - job_name: "CMake, mingw-w64, Debug x86, Schannel, Static"
+      - job_name: "CMake, mingw-w64, gcc 6, Debug x86, Schannel, Static"
         APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
@@ -182,6 +192,7 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
+        DEBUG: ON
         TESTING: ON
         SHARED: OFF
         DISABLED_TESTS: "!1139 !1501"
@@ -302,13 +313,17 @@ build_script:
         -DENABLE_WEBSOCKETS=%WEBSOCKETS%
         -DCMAKE_UNITY_BUILD=%UNITY%
         -DCURL_WERROR=ON
-        -DENABLE_DEBUG=ON
+        -DENABLE_DEBUG=%DEBUG%
         -DENABLE_UNICODE=%ENABLE_UNICODE%
         -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=""
         -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=""
         -DCMAKE_INSTALL_PREFIX="C:/CURL"
         -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
-        cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT%
+        cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT% &&
+        if %SHARED%==ON (
+          bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
+          bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&
+        src\curl.exe -V
       ) else (
       if %BUILD_SYSTEM%==VisualStudioSolution (
         cd projects &&
@@ -333,6 +348,9 @@ build_script:
       if %BUILD_SYSTEM%==autotools (
         bash.exe -e -l -c "cd %POSIX_PATH_PREFIX%/c/projects/curl && autoreconf -fi && ./configure %CONFIG_ARGS% && make V=1 && make V=1 examples && cd tests && make V=1"
       )))))
+  # - ps: if(Test-Path CMakeFiles/CMakeConfigureLog.yaml) { cat CMakeFiles/CMakeConfigureLog.yaml }
+  # - ps: if(Test-Path CMakeFiles/CMakeOutput.log) { cat CMakeFiles/CMakeOutput.log }
+  # - ps: if(Test-Path CMakeFiles/CMakeError.log) { cat CMakeFiles/CMakeError.log }
     - if %TESTING%==ON (
         if %BUILD_SYSTEM%==CMake (
           cmake --build . --config %PRJ_CFG% --parallel 2 --target testdeps

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ version: 7.50.0.{build}
 
 environment:
     UNITY: "OFF"
+    DEBUG: "ON"
     SHARED: "OFF"
     matrix:
       # generated CMake-based Visual Studio Release builds
@@ -69,7 +70,6 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: "ON"
         TESTING: OFF
         DISABLED_TESTS: ""
       # generated CMake-based Visual Studio Debug builds
@@ -82,7 +82,6 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: "ON"
         TESTING: ON
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\msys64\\usr\\bin"
@@ -96,7 +95,6 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
-        DEBUG: "ON"
         TESTING: ON
         DISABLED_TESTS: "~571 !1139 !1501"
         ADD_PATH: "C:\\msys64\\usr\\bin"
@@ -110,7 +108,6 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: "ON"
         TESTING: ON
         DISABLED_TESTS: "~571 !1139 !1501"
         ADD_PATH: "C:\\msys64\\usr\\bin"
@@ -124,7 +121,6 @@ environment:
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: ON
-        DEBUG: "ON"
         TESTING: ON
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\msys64\\usr\\bin"
@@ -138,7 +134,6 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
-        DEBUG: "ON"
         TESTING: ON
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\mingw-w64\\x86_64-8.1.0-posix-seh-rt_v6-rev0\\mingw64\\bin;C:\\msys64\\usr\\bin"
@@ -153,7 +148,6 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
-        DEBUG: "ON"
         TESTING: ON
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin;C:\\msys64\\usr\\bin"
@@ -168,7 +162,6 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: "ON"
         TESTING: OFF
         ADD_PATH: "C:\\msys64\\mingw64\\bin;C:\\msys64\\usr\\bin"
         MSYS2_ARG_CONV_EXCL: "/*"
@@ -183,7 +176,6 @@ environment:
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
-        DEBUG: "ON"
         TESTING: ON
         DISABLED_TESTS: "!1139 !1501"
         ADD_PATH: "C:\\mingw-w64\\i686-6.3.0-posix-dwarf-rt_v5-rev1\\mingw32\\bin;C:\\msys64\\usr\\bin"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ environment:
     OPENSSL: "OFF"
     DEBUG: "ON"
     SHARED: "OFF"
+    RUN: "ON"
     matrix:
       # generated CMake-based Visual Studio Release builds
       - job_name: "CMake, VS2008, Release x86, Schannel"
@@ -45,6 +46,7 @@ environment:
         TESTING: OFF
         SHARED: ON
         DISABLED_TESTS: ""
+        RUN: "OFF"
       - job_name: "CMake, VS2022, Release x64, OpenSSL, WebSockets, Unity"
         APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
@@ -270,7 +272,7 @@ environment:
 
 install:
     - if not "%ADD_PATH%"=="" (
-        set "PATH=%ADD_PATH%;C:/OpenSSL-v111-Win64;%PATH%" )
+        set "PATH=%ADD_PATH%;%PATH%" )
 
 build_script:
     - if %BUILD_SYSTEM%==CMake (
@@ -293,19 +295,21 @@ build_script:
         -DCMAKE_INSTALL_PREFIX="C:/CURL"
         -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
         cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT% &&
-        bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/OpenSSL-v111-Win64 -name '*.dll'" &&
         bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
         if "%SHARED%" == "ON" (
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&
-        src\curl.exe -V
+        if "%OPENSSL%" == "ON" (
+          copy /Y C:/OpenSSL-v111-Win64/*.dll src ) &&
+        if "%RUN%" == "ON" (
+          src\curl.exe -V )
       ) else (
       if %BUILD_SYSTEM%==VisualStudioSolution (
         cd projects &&
         .\generate.bat %VC_VERSION% &&
         msbuild.exe /p:Configuration="%PRJ_CFG%" "Windows\\%VC_VERSION%\\curl-all.sln" &&
-        bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
-        src\curl.exe -V
+        cd "build/Win32/%VC_VERSION%/%PRJ_CFG%" &&
+        curld.exe -V
       ) else (
       if %BUILD_SYSTEM%==winbuild_vs2015 (
         call buildconf.bat &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -279,7 +279,7 @@ environment:
 
 install:
     - if not "%ADD_PATH%"=="" (
-        set "PATH=%ADD_PATH%;%PATH%" )
+        set "PATH=%ADD_PATH%;C:/OpenSSL-v111-Win64;%PATH%" )
 
 build_script:
     - if %BUILD_SYSTEM%==CMake (
@@ -302,6 +302,7 @@ build_script:
         -DCMAKE_INSTALL_PREFIX="C:/CURL"
         -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
         cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT% &&
+        bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/OpenSSL-v111-Win64 -name '*.dll'" &&
         bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
         if "%SHARED%" == "ON" (
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
@@ -311,7 +312,7 @@ build_script:
       ) else (
       if %BUILD_SYSTEM%==VisualStudioSolution (
         cd projects &&
-        .\\generate.bat %VC_VERSION% &&
+        .\generate.bat %VC_VERSION% &&
         msbuild.exe /p:Configuration="%PRJ_CFG%" "Windows\\%VC_VERSION%\\curl-all.sln"
       ) else (
       if %BUILD_SYSTEM%==winbuild_vs2015 (
@@ -330,7 +331,8 @@ build_script:
         ..\builds\libcurl-vc14.10-x64-%PATHPART%-dll-ssl-dll-ipv6-sspi\bin\curl.exe -V
       ) else (
       if %BUILD_SYSTEM%==autotools (
-        bash.exe -e -l -c "cd %POSIX_PATH_PREFIX%/c/projects/curl && autoreconf -fi && ./configure %CONFIG_ARGS% && make V=1 && make V=1 examples && cd tests && make V=1"
+        bash.exe -e -l -c "cd %POSIX_PATH_PREFIX%/c/projects/curl && autoreconf -fi && ./configure %CONFIG_ARGS% && make V=1 && make V=1 examples && cd tests && make V=1" &&
+        src\curl.exe -V
       )))))
   # - ps: if(Test-Path CMakeFiles/CMakeConfigureLog.yaml) { cat CMakeFiles/CMakeConfigureLog.yaml }
   # - ps: if(Test-Path CMakeFiles/CMakeOutput.log) { cat CMakeFiles/CMakeOutput.log }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,6 +46,7 @@ environment:
         TESTING: OFF
         SHARED: ON
         DISABLED_TESTS: ""
+        # MSVCR90.dll missing
         RUN: "OFF"
       - job_name: "CMake, VS2022, Release x64, OpenSSL, WebSockets, Unity"
         APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
@@ -62,6 +63,8 @@ environment:
         DISABLED_TESTS: ""
         WEBSOCKETS: ON
         UNITY: "ON"
+        # VCRUNTIME140.dll missing
+        RUN: "OFF"
       - job_name: "CMake, VS2022, Release arm64, Schannel, Static"
         APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
@@ -301,6 +304,7 @@ build_script:
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&
         if "%OPENSSL%" == "ON" (
           copy /Y C:/OpenSSL-v111-Win64/*.dll src ) &&
+        bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
         if "%RUN%" == "ON" (
           src\curl.exe -V )
       ) else (
@@ -308,6 +312,8 @@ build_script:
         cd projects &&
         .\generate.bat %VC_VERSION% &&
         msbuild.exe /p:Configuration="%PRJ_CFG%" "Windows\\%VC_VERSION%\\curl-all.sln" &&
+        bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
+        echo "|build/Win32/%VC_VERSION%/%PRJ_CFG%|" &&
         cd "build/Win32/%VC_VERSION%/%PRJ_CFG%" &&
         curld.exe -V
       ) else (
@@ -317,6 +323,7 @@ build_script:
         call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 &&
         call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64 &&
         nmake /f Makefile.vc mode=dll VC=14 "SSL_PATH=C:\OpenSSL-v111-Win64" WITH_SSL=dll MACHINE=x64 DEBUG=%DEBUG% ENABLE_UNICODE=%ENABLE_UNICODE% &&
+        bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
         ..\builds\libcurl-vc14-x64-%PATHPART%-dll-ssl-dll-ipv6-sspi\bin\curl.exe -V
       ) else (
       if %BUILD_SYSTEM%==winbuild_vs2017 (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,8 +63,6 @@ environment:
         DISABLED_TESTS: ""
         WEBSOCKETS: ON
         UNITY: "ON"
-        # VCRUNTIME140.dll missing?
-        RUN: "ON"
       - job_name: "CMake, VS2022, Release arm64, Schannel, Static"
         APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
@@ -298,7 +296,6 @@ build_script:
         -DCMAKE_INSTALL_PREFIX="C:/CURL"
         -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
         cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT% &&
-        bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
         if "%SHARED%" == "ON" (
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -307,13 +307,14 @@ build_script:
         if "%SHARED%" == "ON" (
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&
-        if "%OPENSSL%" == "OFF" (
-          src\curl.exe -V )
+        src\curl.exe -V
       ) else (
       if %BUILD_SYSTEM%==VisualStudioSolution (
         cd projects &&
         .\generate.bat %VC_VERSION% &&
-        msbuild.exe /p:Configuration="%PRJ_CFG%" "Windows\\%VC_VERSION%\\curl-all.sln"
+        msbuild.exe /p:Configuration="%PRJ_CFG%" "Windows\\%VC_VERSION%\\curl-all.sln" &&
+        bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
+        src\curl.exe -V
       ) else (
       if %BUILD_SYSTEM%==winbuild_vs2015 (
         call buildconf.bat &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -320,11 +320,11 @@ build_script:
         -DCMAKE_INSTALL_PREFIX="C:/CURL"
         -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
         cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT% &&
+        bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
         if %SHARED%==ON (
-          bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&
-        if %OPENSSL%==OFF (
+        if "%OPENSSL%" == "OFF" (
           src\curl.exe -V )
       ) else (
       if %BUILD_SYSTEM%==VisualStudioSolution (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -321,9 +321,11 @@ build_script:
         -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
         cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT% &&
         if %SHARED%==ON (
+          bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&
-        src\curl.exe -V
+        if %OPENSSL%==OFF (
+          src\curl.exe -V )
       ) else (
       if %BUILD_SYSTEM%==VisualStudioSolution (
         cd projects &&

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,8 +63,8 @@ environment:
         DISABLED_TESTS: ""
         WEBSOCKETS: ON
         UNITY: "ON"
-        # VCRUNTIME140.dll missing
-        RUN: "OFF"
+        # VCRUNTIME140.dll missing?
+        RUN: "ON"
       - job_name: "CMake, VS2022, Release arm64, Schannel, Static"
         APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
         BUILD_SYSTEM: CMake
@@ -303,7 +303,7 @@ build_script:
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
           bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&
         if "%OPENSSL%" == "ON" (
-          copy /Y C:/OpenSSL-v111-Win64/*.dll src ) &&
+          bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/OpenSSL-v111-Win64/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" ) &&
         bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
         if "%RUN%" == "ON" (
           src\curl.exe -V )
@@ -313,8 +313,7 @@ build_script:
         .\generate.bat %VC_VERSION% &&
         msbuild.exe /p:Configuration="%PRJ_CFG%" "Windows\\%VC_VERSION%\\curl-all.sln" &&
         bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
-        echo "|build/Win32/%VC_VERSION%/%PRJ_CFG%|" &&
-        cd "build/Win32/%VC_VERSION%/%PRJ_CFG%" &&
+        cd "../build/Win32/%VC_VERSION%/%PRJ_CFG%" &&
         curld.exe -V
       ) else (
       if %BUILD_SYSTEM%==winbuild_vs2015 (

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ version: 7.50.0.{build}
 
 environment:
     UNITY: "OFF"
+    OPENSSL: "OFF"
     DEBUG: "ON"
     SHARED: "OFF"
     matrix:
@@ -38,7 +39,6 @@ environment:
         BUILD_SYSTEM: CMake
         PRJ_GEN: "Visual Studio 9 2008"
         PRJ_CFG: Release
-        OPENSSL: OFF
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
@@ -66,7 +66,6 @@ environment:
         PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A ARM64"
         PRJ_CFG: Release
-        OPENSSL: OFF
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
@@ -78,7 +77,6 @@ environment:
         BUILD_SYSTEM: CMake
         PRJ_GEN: "Visual Studio 10 2010 Win64"
         PRJ_CFG: Debug
-        OPENSSL: OFF
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
@@ -91,7 +89,6 @@ environment:
         PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
         PRJ_CFG: Debug
-        OPENSSL: OFF
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
@@ -104,7 +101,6 @@ environment:
         PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
         PRJ_CFG: Debug
-        OPENSSL: OFF
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
@@ -117,7 +113,6 @@ environment:
         PRJ_GEN: "Visual Studio 17 2022"
         TARGET: "-A x64"
         PRJ_CFG: Debug
-        OPENSSL: OFF
         SCHANNEL: OFF
         ENABLE_UNICODE: OFF
         HTTP_ONLY: ON
@@ -130,7 +125,6 @@ environment:
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug
-        OPENSSL: OFF
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
@@ -144,7 +138,6 @@ environment:
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug
-        OPENSSL: OFF
         SCHANNEL: ON
         ENABLE_UNICODE: ON
         HTTP_ONLY: OFF
@@ -158,7 +151,6 @@ environment:
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug
-        OPENSSL: OFF
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF
@@ -172,7 +164,6 @@ environment:
         BUILD_SYSTEM: CMake
         PRJ_GEN: "MSYS Makefiles"
         PRJ_CFG: Debug
-        OPENSSL: OFF
         SCHANNEL: ON
         ENABLE_UNICODE: OFF
         HTTP_ONLY: OFF


### PR DESCRIPTION
- run `curl -V` after builds to see if they run and with what features.
  Except for one job where a CRT DLL is missing. And ARM64 which should
  fail, but is silently not launched instead.

- copy libcurl DLL next to curl tool and tests binaries in shared mode.
  This makes it possible to run the tests. (We don't run tests after
  these builds yet.)

- list the DLLs and EXEs present after the builds.

- add `DEBUG` variable for CMake builds to allow disabling it, for
  testing non-debug builds. (currently enabled for all)

- add commented lines that dump CMake configuration logs for debugging
  build/auto-detection issues.

- add gcc version to jobs where missing.

- switch a job to the native MSYS2 mingw-w64 toolchain. This adds gcc 9
  to the build mix.

- make `SHARED=OFF` and `OPENSSL=OFF` defaults global.

- delete a duplicate backslash.

Closes #11976
