### PR TITLE
cmake: fix `HAVE_WRITABLE_ARGV` detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1255,6 +1255,19 @@ if(WIN32)
   unset(HAVE_WIN32_WINNT CACHE)
 endif()
 
+if(NOT WIN32 AND NOT CMAKE_CROSSCOMPILING)
+  # on not-Windows and not-crosscompiling, check for writable argv[]
+  include(CheckCSourceRuns)
+  check_c_source_runs("
+int main(int argc, char **argv)
+{
+  (void)argc;
+  argv[0][0] = ' ';
+  return (argv[0][0] == ' ')?0:1;
+}"
+    HAVE_WRITABLE_ARGV)
+endif()
+
 set(CMAKE_REQUIRED_FLAGS)
 
 option(ENABLE_WEBSOCKETS "Set to ON to enable EXPERIMENTAL websockets" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1259,13 +1259,12 @@ if(NOT WIN32 AND NOT CMAKE_CROSSCOMPILING)
   # on not-Windows and not-crosscompiling, check for writable argv[]
   include(CheckCSourceRuns)
   check_c_source_runs("
-int main(int argc, char **argv)
-{
-  (void)argc;
-  argv[0][0] = ' ';
-  return (argv[0][0] == ' ')?0:1;
-}"
-    HAVE_WRITABLE_ARGV)
+    int main(int argc, char **argv)
+    {
+      (void)argc;
+      argv[0][0] = ' ';
+      return (argv[0][0] == ' ')?0:1;
+    }" HAVE_WRITABLE_ARGV)
 endif()
 
 set(CMAKE_REQUIRED_FLAGS)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -85,19 +85,6 @@ else()
   unset(CMAKESONAME)
 endif()
 
-if(NOT WIN32 AND NOT CMAKE_CROSSCOMPILING)
-  # on not-Windows and not-crosscompiling, check for writable argv[]
-    include(CheckCSourceRuns)
-    check_c_source_runs("
-int main(int argc, char **argv)
-{
-  (void)argc;
-  argv[0][0] = ' ';
-  return (argv[0][0] == ' ')?0:1;
-}"
-      HAVE_WRITABLE_ARGV)
-endif()
-
 ## Library definition
 
 # Add "_imp" as a suffix before the extension to avoid conflicting with


### PR DESCRIPTION
Move detection before the creation of detection results in
`curl_config.h`.

Ref: #11964 (effort to sync cmake detections with autotools)

Closes #11978