### PR TITLE
idn: fix WinIDN null ptr deref on bad host

### DIFF
--- a/lib/idn.c
+++ b/lib/idn.c
@@ -91,6 +91,8 @@ static CURLcode win32_idn_to_ascii(const char *in, char **out)
     else
       return CURLE_URL_MALFORMAT;
   }
+  else
+    return CURLE_URL_MALFORMAT;
 
   return CURLE_OK;
 }


### PR DESCRIPTION
- Return CURLE_URL_MALFORMAT if IDN hostname cannot be converted from UTF-8 to UTF-16.

Prior to this change a failed conversion erroneously returned CURLE_OK which meant 'decoded' pointer (what would normally point to the punycode) would not be written to, remain NULL and be dereferenced causing an access violation.

Closes #xxxx
