### PR TITLE
acinclude.m4: Document proper system truststore on FreeBSD

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1446,9 +1446,9 @@ dnl regarding the paths this will scan:
 dnl /etc/ssl/certs/ca-certificates.crt Debian systems
 dnl /etc/pki/tls/certs/ca-bundle.crt Redhat and Mandriva
 dnl /usr/share/ssl/certs/ca-bundle.crt old(er) Redhat
-dnl /usr/local/share/certs/ca-root-nss.crt FreeBSD, MidnightBSD
-dnl /etc/ssl/cert.pem OpenBSD, FreeBSD, MidnightBSD (symlink)
-dnl /etc/ssl/certs/ (ca path) SUSE
+dnl /usr/local/share/certs/ca-root-nss.crt MidnightBSD
+dnl /etc/ssl/cert.pem OpenBSD, MidnightBSD (symlink)
+dnl /etc/ssl/certs/ (CA path) SUSE, FreeBSD
 
 AC_DEFUN([CURL_CHECK_CA_BUNDLE], [
 


### PR DESCRIPTION
The default system truststore on FreeBSD has been `/etc/ssl/certs` for many years now. It is managed canonically through [`certctl(8)`](https://man.freebsd.org/cgi/man.cgi?query=certctl&apropos=0&sektion=0&manpath=FreeBSD+12.4-RELEASE&arch=default&format=html) and contains hashed symlinks for OpenSSL and other TLS providers.
The previous ones require security/ca_root_nss which might not be installed or will not contain any custom CA certificates.