### PR TITLE
docs: replace made up domains with example.com

### DIFF
--- a/docs/FAQ
+++ b/docs/FAQ
@@ -435,19 +435,19 @@ FAQ
 
   3.1 curl: (1) SSL is disabled, https: not supported
 
-  If you get this output when trying to get anything from an https:// server,
-  it means that the instance of curl/libcurl that you are using was built
-  without support for this protocol.
+  If you get this output when trying to get anything from an HTTPS server, it
+  means that the instance of curl/libcurl that you are using was built without
+  support for this protocol.
 
   This could have happened if the configure script that was run at build time
   could not find all libs and include files curl requires for SSL to work. If
   the configure script fails to find them, curl is simply built without SSL
   support.
 
-  To get the https:// support into a curl that was previously built but that
-  reports that https:// is not supported, you should dig through the document
-  and logs and check out why the configure script does not find the SSL libs
-  and/or include files.
+  To get HTTPS support into a curl that was previously built but that reports
+  that HTTPS is not supported, you should dig through the document and logs
+  and check out why the configure script does not find the SSL libs and/or
+  include files.
 
   Also, check out the other paragraph in this FAQ labeled "configure does not
   find OpenSSL even when it is installed".
@@ -505,11 +505,11 @@ FAQ
 
   One example would be to delete a file after you have downloaded it:
 
-     curl -O ftp://download.com/coolfile -Q '-DELE coolfile'
+     curl -O ftp://example.com/coolfile -Q '-DELE coolfile'
 
   or rename a file after upload:
 
-     curl -T infile ftp://upload.com/dir/ -Q "-RNFR infile" -Q "-RNTO newname"
+     curl -T infile ftp://example.com/dir/ -Q "-RNFR infile" -Q "-RNTO newname"
 
   3.8 How do I tell curl to follow HTTP redirects?
 
@@ -517,7 +517,7 @@ FAQ
   that informs the client about this is only interpreted if you are using the
   -L/--location option. As in:
 
-     curl -L http://redirector.com
+     curl -L http://example.com
 
   Not all redirects are HTTP ones, see 4.14
 
@@ -681,12 +681,12 @@ FAQ
   There are two ways. The way defined in the RFC is to use an encoded slash
   in the first path part. List the "/tmp" directory like this:
 
-     curl ftp://ftp.sunet.se/%2ftmp/
+     curl ftp://ftp.example.com/%2ftmp/
 
   or the not-quite-kosher-but-more-readable way, by simply starting the path
   section of the URL with a slash:
 
-     curl ftp://ftp.sunet.se//tmp/
+     curl ftp://ftp.example.com//tmp/
 
   3.18 Can I use curl to send a POST/PUT and not wait for a response?
 
@@ -781,7 +781,7 @@ FAQ
 
   An example that would invoke a remote CGI that uses &-symbols could be:
 
-     curl 'http://www.altavista.com/cgi-bin/query?text=yes&q=curl'
+     curl 'http://www.example.com/cgi-bin/query?text=yes&q=curl'
 
   In Windows, the standard DOS shell treats the percent sign specially and you
   need to use TWO percent signs for each single one you want to use in the

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -8,35 +8,35 @@ Get the main page from a web-server:
 
 Get a README file from an FTP server:
 
-    curl ftp://ftp.funet.fi/README
+    curl ftp://ftp.example.com/README
 
 Get a web page from a server using port 8000:
 
-    curl http://www.weirdserver.com:8000/
+    curl http://www.example.com:8000/
 
 Get a directory listing of an FTP site:
 
-    curl ftp://ftp.funet.fi
+    curl ftp://ftp.example.com/
 
 Get the all terms matching curl from a dictionary:
 
-    curl dict://dict.org/m:curl
+    curl dict://dict.example.com/m:curl
 
 Get the definition of curl from a dictionary:
 
-    curl dict://dict.org/d:curl
+    curl dict://dict.example.com/d:curl
 
 Fetch two documents at once:
 
-    curl ftp://ftp.funet.fi/ http://www.weirdserver.com:8000/
+    curl ftp://ftp.example.com/ http://www.example.com:8000/
 
 Get a file off an FTPS server:
 
-    curl ftps://files.are.secure.com/secrets.txt
+    curl ftps://files.are.example.com/secrets.txt
 
 or use the more appropriate FTPS way to get the same file:
 
-    curl --ftp-ssl ftp://files.are.secure.com/secrets.txt
+    curl --ftp-ssl ftp://files.are.example.com/secrets.txt
 
 Get a file from an SSH server using SFTP:
 
@@ -144,21 +144,21 @@ servers.
 
 Get an ftp file using an HTTP proxy named my-proxy that uses port 888:
 
-    curl -x my-proxy:888 ftp://ftp.leachsite.com/README
+    curl -x my-proxy:888 ftp://ftp.example.com/README
 
 Get a file from an HTTP server that requires user and password, using the
 same proxy as above:
 
-    curl -u user:passwd -x my-proxy:888 http://www.get.this/
+    curl -u user:passwd -x my-proxy:888 http://www.example.com/
 
 Some proxies require special authentication. Specify by using -U as above:
 
-    curl -U user:passwd -x my-proxy:888 http://www.get.this/
+    curl -U user:passwd -x my-proxy:888 http://www.example.com/
 
 A comma-separated list of hosts and domains which do not use the proxy can be
 specified as:
 
-    curl --noproxy localhost,get.this -x my-proxy:888 http://www.get.this/
+    curl --noproxy example.com -x my-proxy:888 http://www.example.com/
 
 If the proxy is specified with `--proxy1.0` instead of `--proxy` or `-x`, then
 curl will use HTTP/1.0 instead of HTTP/1.1 for any `CONNECT` attempts.
@@ -186,7 +186,7 @@ transfers, and curl's `-v` option to see exactly what curl is sending.
 Get a key file and add it with `apt-key` (when on a system that uses `apt` for
 package management):
 
-    curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+    curl -L https://apt.example.org/llvm-snapshot.gpg.key | sudo apt-key add -
 
 The '|' pipes the output to STDIN. `-` tells `apt-key` that the key file
 should be read from STDIN.
@@ -199,18 +199,18 @@ one or more sub-parts of a specified document. Curl supports this with the
 
 Get the first 100 bytes of a document:
 
-    curl -r 0-99 http://www.get.this/
+    curl -r 0-99 http://www.example.com/
 
 Get the last 500 bytes of a document:
 
-    curl -r -500 http://www.get.this/
+    curl -r -500 http://www.example.com/
 
 Curl also supports simple ranges for FTP files as well. Then you can only
 specify start and stop position.
 
 Get the first 100 bytes of a document using FTP:
 
-    curl -r 0-99 ftp://www.get.this/README
+    curl -r 0-99 ftp://www.example.com/README
 
 ## Uploading
 
@@ -218,26 +218,26 @@ Get the first 100 bytes of a document using FTP:
 
 Upload all data on stdin to a specified server:
 
-    curl -T - ftp://ftp.upload.com/myfile
+    curl -T - ftp://ftp.example.com/myfile
 
 Upload data from a specified file, login with user and password:
 
-    curl -T uploadfile -u user:passwd ftp://ftp.upload.com/myfile
+    curl -T uploadfile -u user:passwd ftp://ftp.example.com/myfile
 
 Upload a local file to the remote site, and use the local file name at the
 remote site too:
 
-    curl -T uploadfile -u user:passwd ftp://ftp.upload.com/
+    curl -T uploadfile -u user:passwd ftp://ftp.example.com/
 
 Upload a local file to get appended to the remote file:
 
-    curl -T localfile -a ftp://ftp.upload.com/remotefile
+    curl -T localfile -a ftp://ftp.example.com/remotefile
 
 Curl also supports ftp upload through a proxy, but only if the proxy is
 configured to allow that kind of tunneling. If it does, you can run curl in a
 fashion similar to:
 
-    curl --proxytunnel -x proxy:port -T localfile ftp.upload.com
+    curl --proxytunnel -x proxy:port -T localfile ftp.example.com
 
 ### SMB / SMBS
 
@@ -248,7 +248,7 @@ fashion similar to:
 
 Upload all data on stdin to a specified HTTP site:
 
-    curl -T - http://www.upload.com/myfile
+    curl -T - http://www.example.com/myfile
 
 Note that the HTTP server must have been configured to accept PUT before this
 can be done successfully.
@@ -263,7 +263,7 @@ fetching. Curl will output lots of info and what it sends and receives in
 order to let the user see all client-server interaction (but it will not show you
 the actual data).
 
-    curl -v ftp://ftp.upload.com/
+    curl -v ftp://ftp.example.com/
 
 To get even more details and information on what curl does, try using the
 `--trace` or `--trace-ascii` options with a given file name to log to, like
@@ -300,11 +300,11 @@ The post data must be urlencoded.
 
 Post a simple `name` and `phone` guestbook.
 
-    curl -d "name=Rafael%20Sagula&phone=3320780" http://www.where.com/guest.cgi
+    curl -d "name=Rafael%20Sagula&phone=3320780" http://www.example.com/guest.cgi
 
 Or automatically [URL encode the data](https://everything.curl.dev/http/post/url-encode).
 
-    curl --data-urlencode "name=Rafael Sagula&phone=3320780" http://www.where.com/guest.cgi
+    curl --data-urlencode "name=Rafael Sagula&phone=3320780" http://www.example.com/guest.cgi
 
 How to post a form with curl, lesson #1:
 
@@ -352,7 +352,7 @@ example, the field name `coolfiles` is used to send three files, with
 different content types using the following syntax:
 
     curl -F "coolfiles=@fil1.gif;type=image/gif,fil2.txt,fil3.html"
-      http://www.post.com/postit.cgi
+      http://www.example.com/postit.cgi
 
 If the content-type is not specified, curl will try to guess from the file
 extension (it only knows a few), or use the previously specified type (from an
@@ -369,7 +369,7 @@ the names of the input fields. In our example, the input field names are
 
     curl -F "file=@cooltext.txt" -F "yourname=Daniel"
       -F "filedescription=Cool text file with cool text inside"
-      http://www.post.com/postit.cgi
+      http://www.example.com/postit.cgi
 
 To send two files in one post you can do it in two ways:
 
@@ -395,7 +395,7 @@ used on the command line. It is especially useful to fool or trick stupid
 servers or CGI scripts that rely on that information being available or
 contain certain data.
 
-    curl -e www.coolsite.com http://www.showme.com/
+    curl -e www.exomaple.org http://www.example.com/
 
 ## User Agent
 
@@ -406,7 +406,7 @@ accept certain browsers.
 
 Example:
 
-    curl -A 'Mozilla/3.0 (Win95; I)' http://www.nationsbank.com/
+    curl -A 'Mozilla/3.0 (Win95; I)' http://www.bank.example.com/
 
 Other common strings:
 
@@ -546,7 +546,7 @@ or
 
 Or prevent curl from uploading data faster than 1 megabyte per second:
 
-    curl -T upload --limit-rate 1M ftp://uploadshereplease.com
+    curl -T upload --limit-rate 1M ftp://uploads.example.com
 
 When using the `--limit-rate` option, the transfer rate is regulated on a
 per-second basis, which will cause the total transfer speed to become lower
@@ -589,14 +589,14 @@ Force curl to get and display a local help page in case it is invoked without
 URL by making a config file similar to:
 
     # default url to get
-    url = "http://help.with.curl.com/curlhelp.html"
+    url = "http://help.with.curl.example.com/curlhelp.html"
 
 You can specify another config file to be read by using the `-K`/`--config`
 flag. If you set config file name to `-` it will read the config from stdin,
 which can be handy if you want to hide options from being visible in process
 tables etc:
 
-    echo "user = user:passwd" | curl -K - http://that.secret.site.com
+    echo "user = user:passwd" | curl -K - http://that.secret.example.com
 
 ## Extra Headers
 
@@ -623,12 +623,12 @@ Do note that when getting files with a `ftp://` URL, the given path is
 relative to the directory you enter. To get the file `README` from your home
 directory at your ftp site, do:
 
-    curl ftp://user:passwd@my.site.com/README
+    curl ftp://user:passwd@my.example.com/README
 
 If you want the README file from the root directory of that same site, you
 need to specify the absolute file name:
 
-    curl ftp://user:passwd@my.site.com//README
+    curl ftp://user:passwd@my.example.com//README
 
 (I.e with an extra slash in front of the file name.)
 
@@ -692,7 +692,7 @@ using the HTTPS protocol.
 
 Example:
 
-    curl https://www.secure-site.com
+    curl https://secure.example.com
 
 curl is also capable of using client certificates to get/post files from sites
 that require valid certificates. The only drawback is that the certificate
@@ -705,7 +705,7 @@ formatted certificates to PEM formatted ones.
 Example on how to automatically retrieve a document using a certificate with a
 personal password:
 
-    curl -E /path/to/cert.pem:password https://secure.site.com/
+    curl -E /path/to/cert.pem:password https://secure.example.com/
 
 If you neglect to specify the password on the command line, you will be
 prompted for the correct password before any data can be received.
@@ -714,7 +714,7 @@ Many older HTTPS servers have problems with specific SSL or TLS versions,
 which newer versions of OpenSSL etc use, therefore it is sometimes useful to
 specify what TLS version curl should use.:
 
-    curl --tlv1.0 https://secure.site.com/
+    curl --tlv1.0 https://secure.example.com/
 
 Otherwise, curl will attempt to use a sensible TLS default version.
 
@@ -725,15 +725,15 @@ resume on HTTP(S) downloads as well as FTP uploads and downloads.
 
 Continue downloading a document:
 
-    curl -C - -o file ftp://ftp.server.com/path/file
+    curl -C - -o file ftp://ftp.example.com/path/file
 
 Continue uploading a document:
 
-    curl -C - -T file ftp://ftp.server.com/path/file
+    curl -C - -T file ftp://ftp.example.com/path/file
 
 Continue downloading a document from a web server
 
-    curl -C - -o file http://www.server.com/
+    curl -C - -o file http://www.example.com/
 
 ## Time Conditions
 
@@ -744,17 +744,17 @@ them with the `-z`/`--time-cond` flag.
 For example, you can easily make a download that only gets performed if the
 remote file is newer than a local copy. It would be made like:
 
-    curl -z local.html http://remote.server.com/remote.html
+    curl -z local.html http://remote.example.com/remote.html
 
 Or you can download a file only if the local file is newer than the remote
 one. Do this by prepending the date string with a `-`, as in:
 
-    curl -z -local.html http://remote.server.com/remote.html
+    curl -z -local.html http://remote.example.com/remote.html
 
 You can specify a plain text date as condition. Tell curl to only download the
 file if it was updated since January 12, 2012:
 
-    curl -z "Jan 12 2012" http://remote.server.com/remote.html
+    curl -z "Jan 12 2012" http://remote.example.com/remote.html
 
 curl accepts a wide range of date formats. You always make the date check the
 other way around by prepending it with a dash (`-`).
@@ -797,18 +797,18 @@ Format](https://curl.se/rfc/rfc2255.txt)
 To show you an example, this is how to get all people from an LDAP server that
 has a certain subdomain in their email address:
 
-    curl -B "ldap://ldap.frontec.se/o=frontec??sub?mail=*sth.frontec.se"
+    curl -B "ldap://ldap.example.com/o=frontec??sub?mail=*sth.example.com"
 
 You also can use authentication when accessing LDAP catalog:
 
-    curl -u user:passwd "ldap://ldap.frontec.se/o=frontec??sub?mail=*"
-    curl "ldap://user:passwd@ldap.frontec.se/o=frontec??sub?mail=*"
+    curl -u user:passwd "ldap://ldap.example.com/o=frontec??sub?mail=*"
+    curl "ldap://user:passwd@ldap.example.com/o=frontec??sub?mail=*"
 
 By default, if user and password are provided, OpenLDAP/WinLDAP will use basic
 authentication. On Windows you can control this behavior by providing one of
 `--basic`, `--ntlm` or `--digest` option in curl command line
 
-    curl --ntlm "ldap://user:passwd@ldap.frontec.se/o=frontec??sub?mail=*"
+    curl --ntlm "ldap://user:passwd@ldap.example.com/o=frontec??sub?mail=*"
 
 On Windows, if no user/password specified, auto-negotiation mechanism will be
 used with current logon credentials (SSPI/SPNEGO).
@@ -875,7 +875,7 @@ kerberos package installed and used at curl build time for it to be available.
 First, get the krb-ticket the normal way, like with the `kinit`/`kauth` tool.
 Then use curl in way similar to:
 
-    curl --krb private ftp://krb4site.com -u username:fakepwd
+    curl --krb private ftp://krb4site.example.com -u username:fakepwd
 
 There is no use for a password on the `-u` switch, but a blank one will make
 curl ask for one and you already entered the real password to `kinit`/`kauth`.
@@ -886,7 +886,7 @@ The curl telnet support is basic and easy to use. Curl passes all data passed
 to it on stdin to the remote server. Connect to a remote telnet server using a
 command line similar to:
 
-    curl telnet://remote.server.com
+    curl telnet://remote.example.com
 
 And enter the data to pass to the server on stdin. The result will be sent to
 stdout or to the file you specify with `-o`.
@@ -897,7 +897,7 @@ for slow connections or similar.
 Pass options to the telnet protocol negotiation, by using the `-t` option. To
 tell the server we use a vt100 terminal, try something like:
 
-    curl -tTTYPE=vt100 telnet://remote.server.com
+    curl -tTTYPE=vt100 telnet://remote.example.com
 
 Other interesting options for it `-t` include:
 
@@ -937,11 +937,11 @@ URL you specify. Note that this also goes for the `-O` option (but not
 For example: get two files and use `-O` for the first and a custom file
 name for the second:
 
-    curl -O http://url.com/file.txt ftp://ftp.com/moo.exe -o moo.jpg
+    curl -O http://example.com/file.txt ftp://example.com/moo.exe -o moo.jpg
 
 You can also upload multiple files in a similar fashion:
 
-    curl -T local1 ftp://ftp.com/moo.exe -T local2 ftp://ftp.com/moo2.txt
+    curl -T local1 ftp://example.com/moo.exe -T local2 ftp://example.com/moo2.txt
 
 ## IPv6
 


### PR DESCRIPTION
in FAQ and MANUAL.md

- example.com was made for this purpose.

- reduces the risk that one of those domains suddenly start hosting something nasty and we provide links to them