### PR TITLE
create-dirs.d: clarify it also uses --output-dirs

### DIFF
--- a/docs/cmdline-opts/create-dirs.d
+++ b/docs/cmdline-opts/create-dirs.d
@@ -10,9 +10,9 @@ Multi: boolean
 ---
 When used in conjunction with the --output option, curl creates the necessary
 local directory hierarchy as needed. This option creates the directories
-mentioned with the --output option, nothing else. If the --output file name
-uses no directory, or if the directories it mentions already exist, no
-directories are created.
+mentioned with the --output option combined with the path possibly set with
+--output-dir. If the combined output file name uses no directory, or if the
+directories it mentions already exist, no directories are created.
 
 Created directories are made with mode 0750 on unix style file systems.
 


### PR DESCRIPTION
Reported-by: Robert Simpson
Fixes #11991