### PR TITLE
appveyor: rewrite batch in PowerShell + CI improvements

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ environment:
   SHARED: 'OFF'
   matrix:
     # generated CMake-based Visual Studio Release builds
-    - job_name: 'CMake, VS2008, Release x86, Schannel'
+    - job_name: 'CMake, VS2008, Release x86, Schannel, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 9 2008'
@@ -42,11 +42,11 @@ environment:
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
-      TESTING: 'OFF'
       SHARED: 'ON'
+      TESTING: 'OFF'
       DISABLED_TESTS: ''
       SKIP_RUN: 'Needs missing MSVCR90.dll'
-    - job_name: 'CMake, VS2022, Release x64, OpenSSL, WebSockets, Unity'
+    - job_name: 'CMake, VS2022, Release x64, OpenSSL, WebSockets, Unity, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 17 2022'
@@ -56,12 +56,12 @@ environment:
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
-      TESTING: 'OFF'
       SHARED: 'ON'
+      TESTING: 'OFF'
       DISABLED_TESTS: ''
       WEBSOCKETS: 'ON'
       UNITY: 'ON'
-    - job_name: 'CMake, VS2022, Release arm64, Schannel, Static'
+    - job_name: 'CMake, VS2022, Release arm64, Schannel, Static, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 17 2022'
@@ -155,7 +155,8 @@ environment:
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
-      TESTING: 'OFF'
+      TESTING: 'ON'
+      DISABLED_TESTS: '!1139 !1451 !1501'
       ADD_PATH: 'C:\msys64\mingw64\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -174,56 +175,56 @@ environment:
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
     # winbuild-based builds
-    - job_name: 'winbuild, VS2015, Debug'
+    - job_name: 'winbuild, VS2015, Debug, x64, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: winbuild_vs2015
       DEBUG: 'yes'
       PATHPART: debug
       TESTING: 'OFF'
       ENABLE_UNICODE: 'no'
-    - job_name: 'winbuild, VS2015, Release'
+    - job_name: 'winbuild, VS2015, Release, x64, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: winbuild_vs2015
       DEBUG: 'no'
       PATHPART: release
       TESTING: 'OFF'
       ENABLE_UNICODE: 'no'
-    - job_name: 'winbuild, VS2017, Debug'
+    - job_name: 'winbuild, VS2017, Debug, x64, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: winbuild_vs2017
       DEBUG: 'yes'
       PATHPART: debug
       TESTING: 'OFF'
       ENABLE_UNICODE: 'no'
-    - job_name: 'winbuild, VS2017, Release'
+    - job_name: 'winbuild, VS2017, Release, x64, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: winbuild_vs2017
       DEBUG: 'no'
       PATHPART: release
       TESTING: 'OFF'
       ENABLE_UNICODE: 'no'
-    - job_name: 'winbuild, VS2015, Debug, Unicode'
+    - job_name: 'winbuild, VS2015, Debug, x64, Unicode, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: winbuild_vs2015
       DEBUG: 'yes'
       PATHPART: debug
       TESTING: 'OFF'
       ENABLE_UNICODE: 'yes'
-    - job_name: 'winbuild, VS2015, Release, Unicode'
+    - job_name: 'winbuild, VS2015, Release, x64, Unicode, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: winbuild_vs2015
       DEBUG: 'no'
       PATHPART: release
       TESTING: 'OFF'
       ENABLE_UNICODE: 'yes'
-    - job_name: 'winbuild, VS2017, Debug, Unicode'
+    - job_name: 'winbuild, VS2017, Debug, x64, Unicode, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: winbuild_vs2017
       DEBUG: 'yes'
       PATHPART: debug
       TESTING: 'OFF'
       ENABLE_UNICODE: 'yes'
-    - job_name: 'winbuild, VS2017, Release, Unicode'
+    - job_name: 'winbuild, VS2017, Release, x64, Unicode, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: winbuild_vs2017
       DEBUG: 'no'
@@ -231,28 +232,28 @@ environment:
       TESTING: 'OFF'
       ENABLE_UNICODE: 'yes'
     # generated VisualStudioSolution-based builds
-    - job_name: 'VisualStudioSolution, VS2017, Debug'
+    - job_name: 'VisualStudioSolution, VS2017, Debug, x86, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: VisualStudioSolution
       PRJ_CFG: 'DLL Debug - DLL Windows SSPI - DLL WinIDN'
       TESTING: 'OFF'
       VC_VERSION: VC14.10
     # autotools-based builds (NOT mingw cross-compiling, but msys2 native)
-    - job_name: 'autotools, msys2, Debug, no Proxy, no SSL'
+    - job_name: 'autotools, msys2, Debug, x86_64, no Proxy, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !1233'
       ADD_PATH: 'C:\msys64\usr\bin'
       CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --disable-proxy --without-ssl --enable-websockets'
-    - job_name: 'autotools, msys2, Debug, no SSL'
+    - job_name: 'autotools, msys2, Debug, x86_64, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !504 !704 !705 !1233'
       ADD_PATH: 'C:\msys64\usr\bin'
       CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets'
-    - job_name: 'autotools, msys2, Release, no SSL'
+    - job_name: 'autotools, msys2, Release, x86_64, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
@@ -260,7 +261,7 @@ environment:
       ADD_PATH: 'C:\msys64\usr\bin'
       CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets'
     # autotools-based Cygwin build
-    - job_name: 'autotools, cygwin, Debug, no SSL'
+    - job_name: 'autotools, cygwin, Debug, x86_64, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
@@ -319,7 +320,11 @@ build_script:
         elseif ($env:PRJ_CFG -eq 'Release') {
           $options += '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
         }
+        if($env:PRJ_GEN.Contains('Visual Studio')) {
+          $options += '-DCMAKE_VS_GLOBALS=TrackFileAccess=false'
+        }
 
+        cmake --version
         Write-Host 'CMake options:' $options
         cmake . $options
         cmake --build . --config $env:PRJ_CFG --parallel 2 --clean-first -- $env:BUILD_OPT
@@ -335,7 +340,7 @@ build_script:
       elseif($env:BUILD_SYSTEM -eq 'VisualStudioSolution') {
         cd projects
         .\generate.bat $env:VC_VERSION
-        msbuild.exe "-property:Configuration=$env:PRJ_CFG" "Windows\$env:VC_VERSION\curl-all.sln"
+        msbuild.exe -maxcpucount "-property:Configuration=$env:PRJ_CFG" "Windows\$env:VC_VERSION\curl-all.sln"
         $curl = "..\build\Win32\$env:VC_VERSION\$env:PRJ_CFG\curld.exe"
       }
       elseif($env:BUILD_SYSTEM -eq 'winbuild_vs2015') {
@@ -374,6 +379,7 @@ build_script:
         if(Test-Path CMakeFiles/CMakeConfigureLog.yaml) { cat CMakeFiles/CMakeConfigureLog.yaml }
         if(Test-Path CMakeFiles/CMakeOutput.log) { cat CMakeFiles/CMakeOutput.log }
         if(Test-Path CMakeFiles/CMakeError.log) { cat CMakeFiles/CMakeError.log }
+        if(Test-Path config.log) { cat config.log }
       }
 
       if($env:TESTING -eq 'ON' -and $env:BUILD_SYSTEM -eq 'CMake') {
@@ -400,6 +406,8 @@ test_script:
           & bash -e -c "cd $env:POSIX_PATH_PREFIX/c/projects/curl/tests && ./runtests.pl -a -p !flaky -r -rm $acurl $env:DISABLED_TESTS"
         }
       }
+
+clone_depth: 10
 
 # select branches to avoid testing feature branches twice (as branch and as pull request)
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@ environment:
   OPENSSL: 'OFF'
   DEBUG: 'ON'
   SHARED: 'OFF'
-  RUN: 'ON'
   matrix:
     # generated CMake-based Visual Studio Release builds
     - job_name: 'CMake, VS2008, Release x86, Schannel'
@@ -46,8 +45,7 @@ environment:
       TESTING: 'OFF'
       SHARED: 'ON'
       DISABLED_TESTS: ''
-      # MSVCR90.dll missing
-      RUN: 'OFF'
+      SKIP_RUN: 'Needs missing MSVCR90.dll'
     - job_name: 'CMake, VS2022, Release x64, OpenSSL, WebSockets, Unity'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -132,7 +130,7 @@ environment:
       ENABLE_UNICODE: 'ON'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1501'
+      DISABLED_TESTS: '!1139 !1451 !1501'
       ADD_PATH: 'C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -145,7 +143,7 @@ environment:
       ENABLE_UNICODE: 'ON'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1501'
+      DISABLED_TESTS: '!1139 !1451 !1501'
       ADD_PATH: 'C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -171,7 +169,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1501'
+      DISABLED_TESTS: '!1139 !1451 !1501'
       ADD_PATH: 'C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -272,92 +270,136 @@ environment:
       POSIX_PATH_PREFIX: '/cygdrive'
 
 install:
-  - if not "%ADD_PATH%" == "" (
-      set "PATH=%ADD_PATH%;%PATH%" )
+  - ps: |
+      if($env:ADD_PATH -ne $null) {
+        $env:PATH = "$env:ADD_PATH;$env:PATH"
+      }
 
 build_script:
-  - if "%BUILD_SYSTEM%" == "CMake" (
-      cmake .
-        -G"%PRJ_GEN%"
-        %TARGET%
-        -DCURL_USE_OPENSSL=%OPENSSL%
-        -DOPENSSL_ROOT_DIR=C:/OpenSSL-v111-Win64
-        -DCURL_USE_SCHANNEL=%SCHANNEL%
-        -DHTTP_ONLY=%HTTP_ONLY%
-        -DBUILD_SHARED_LIBS=%SHARED%
-        -DBUILD_TESTING=%TESTING%
-        -DENABLE_WEBSOCKETS=%WEBSOCKETS%
-        -DCMAKE_UNITY_BUILD=%UNITY%
-        -DCURL_WERROR=ON
-        -DENABLE_DEBUG=%DEBUG%
-        -DENABLE_UNICODE=%ENABLE_UNICODE%
-        -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE=""
-        -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG=""
-        -DCMAKE_INSTALL_PREFIX="C:/CURL"
-        -DCMAKE_BUILD_TYPE=%PRJ_CFG% &&
-      cmake --build . --config %PRJ_CFG% --parallel 2 --clean-first -- %BUILD_OPT% &&
-      if "%SHARED%" == "ON" (
-        bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" &&
-        bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/projects/curl/lib/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/tests/libtest/" ) &&
-      if "%OPENSSL%" == "ON" (
-        bash.exe -e -l -c "cp -f -p %POSIX_PATH_PREFIX%/c/OpenSSL-v111-Win64/*.dll %POSIX_PATH_PREFIX%/c/projects/curl/src/" ) &&
-      bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
-      if "%RUN%" == "ON" (
-        src\curl.exe -V )
-    ) else (
-    if "%BUILD_SYSTEM%" == "VisualStudioSolution" (
-      cd projects &&
-      .\generate.bat %VC_VERSION% &&
-      msbuild.exe /p:Configuration="%PRJ_CFG%" "Windows\\%VC_VERSION%\\curl-all.sln" &&
-      bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
-      cd "../build/Win32/%VC_VERSION%/%PRJ_CFG%" &&
-      curld.exe -V
-    ) else (
-    if "%BUILD_SYSTEM%" == "winbuild_vs2015" (
-      call buildconf.bat &&
-      cd winbuild &&
-      call "C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64 &&
-      call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64 &&
-      nmake /f Makefile.vc mode=dll VC=14 "SSL_PATH=C:\OpenSSL-v111-Win64" WITH_SSL=dll MACHINE=x64 DEBUG=%DEBUG% ENABLE_UNICODE=%ENABLE_UNICODE% &&
-      bash.exe -e -l -c "find %POSIX_PATH_PREFIX%/c/projects/curl -name '*.exe' -o -name '*.dll'" &&
-      ..\builds\libcurl-vc14-x64-%PATHPART%-dll-ssl-dll-ipv6-sspi\bin\curl.exe -V
-    ) else (
-    if "%BUILD_SYSTEM%" == "winbuild_vs2017" (
-      call buildconf.bat &&
-      cd winbuild &&
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat" &&
-      nmake /f Makefile.vc mode=dll VC=14.10 "SSL_PATH=C:\OpenSSL-v111-Win64" WITH_SSL=dll MACHINE=x64 DEBUG=%DEBUG% ENABLE_UNICODE=%ENABLE_UNICODE% &&
-      ..\builds\libcurl-vc14.10-x64-%PATHPART%-dll-ssl-dll-ipv6-sspi\bin\curl.exe -V
-    ) else (
-    if "%BUILD_SYSTEM%" == "autotools" (
-      bash.exe -e -l -c "cd %POSIX_PATH_PREFIX%/c/projects/curl && autoreconf -fi && ./configure %CONFIG_ARGS% && make V=1 && make V=1 examples && cd tests && make V=1" &&
-      src\curl.exe -V
-    )))))
-  # - ps: |
-  #     if(Test-Path CMakeFiles/CMakeConfigureLog.yaml) { cat CMakeFiles/CMakeConfigureLog.yaml }
-  #     if(Test-Path CMakeFiles/CMakeOutput.log) { cat CMakeFiles/CMakeOutput.log }
-  #     if(Test-Path CMakeFiles/CMakeError.log) { cat CMakeFiles/CMakeError.log }
-  - if "%TESTING%" == "ON" (
-      if "%BUILD_SYSTEM%" == "CMake" (
-        cmake --build . --config %PRJ_CFG% --parallel 2 --target testdeps
-    ))
+  - ps: |
+      function Pull-BatchFile-Env {
+        param([string]$Path, [string]$Parameters)
+        $tempFile = [IO.Path]::GetTempFileName()
+        cmd.exe /c " `"$Path`" $Parameters && set " > $tempFile
+        Get-Content $tempFile | ForEach-Object { if($_ -match '^(.*?)=(.*)$') { Set-Content "env:\$($matches[1])" $matches[2] } }
+        Remove-Item $tempFile
+      }
+
+      $ErrorActionPreference = 'Stop'
+
+      $openssl_root = 'C:\OpenSSL-v111-Win64'
+
+      if($env:BUILD_SYSTEM -eq 'CMake') {
+
+        $options = @('-DCURL_WERROR=ON')
+        $options += "-G$env:PRJ_GEN"
+        if($env:TARGET -ne $null) {
+          $options += "$env:TARGET"
+          if($env:TARGET.Contains('ARM64')) {
+            $env:SKIP_RUN = 'ARM64 architecture'
+          }
+        }
+        $options += "-DCURL_USE_OPENSSL=$env:OPENSSL"
+        if($env:OPENSSL -eq 'ON') {
+          $options += "-DOPENSSL_ROOT_DIR=$openssl_root"
+        }
+        $options += "-DCURL_USE_SCHANNEL=$env:SCHANNEL"
+        $options += "-DHTTP_ONLY=$env:HTTP_ONLY"
+        $options += "-DBUILD_SHARED_LIBS=$env:SHARED"
+        $options += "-DBUILD_TESTING=$env:TESTING"
+        $options += "-DENABLE_WEBSOCKETS=$env:WEBSOCKETS"
+        $options += "-DCMAKE_UNITY_BUILD=$env:UNITY"
+        $options += "-DENABLE_DEBUG=$env:DEBUG"
+        $options += "-DENABLE_UNICODE=$env:ENABLE_UNICODE"
+        $options += '-DCMAKE_INSTALL_PREFIX=C:/CURL'
+        $options += "-DCMAKE_BUILD_TYPE=$env:PRJ_CFG"
+        if($env:PRJ_CFG -eq 'Debug') {
+          $options += '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
+        }
+        elseif ($env:PRJ_CFG -eq 'Release') {
+          $options += '-DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
+        }
+
+        Write-Host 'CMake options:' $options
+        cmake . $options
+        cmake --build . --config $env:PRJ_CFG --parallel 2 --clean-first -- $env:BUILD_OPT
+        if($env:SHARED -eq 'ON') {
+          Copy-Item -Path 'C:\Projects\curl\lib\*.dll' -Destination 'C:\projects\curl\src'
+          Copy-Item -Path 'C:\Projects\curl\lib\*.dll' -Destination 'C:\projects\curl\tests\libtest'
+        }
+        if($env:OPENSSL -eq 'ON') {
+          Copy-Item -Path "$openssl_root\*.dll" -Destination 'C:\projects\curl\src'
+        }
+        $curl = '.\src\curl.exe'
+      }
+      elseif($env:BUILD_SYSTEM -eq 'VisualStudioSolution') {
+        cd projects
+        .\generate.bat $env:VC_VERSION
+        msbuild.exe "-property:Configuration=$env:PRJ_CFG" "Windows\$env:VC_VERSION\curl-all.sln"
+        $curl = "..\build\Win32\$env:VC_VERSION\$env:PRJ_CFG\curld.exe"
+      }
+      elseif($env:BUILD_SYSTEM -eq 'winbuild_vs2015') {
+        .\buildconf.bat
+        cd winbuild
+        Pull-BatchFile-Env 'C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd' /x64
+        Pull-BatchFile-Env 'C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat' x86_amd64
+        nmake /nologo /f Makefile.vc mode=dll VC=14 "SSL_PATH=$openssl_root" WITH_SSL=dll MACHINE=x64 DEBUG=$env:DEBUG ENABLE_UNICODE=$env:ENABLE_UNICODE
+        $curl = "..\builds\libcurl-vc14-x64-$env:PATHPART-dll-ssl-dll-ipv6-sspi\bin\curl.exe"
+      }
+      elseif($env:BUILD_SYSTEM -eq 'winbuild_vs2017') {
+        .\buildconf.bat
+        cd winbuild
+        Pull-BatchFile-Env 'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat'
+        nmake /nologo /f Makefile.vc mode=dll VC=14.10 "SSL_PATH=$openssl_root" WITH_SSL=dll MACHINE=x64 DEBUG=$env:DEBUG ENABLE_UNICODE=$env:ENABLE_UNICODE
+        $curl = "..\builds\libcurl-vc14.10-x64-$env:PATHPART-dll-ssl-dll-ipv6-sspi\bin\curl.exe"
+      }
+      elseif($env:BUILD_SYSTEM -eq 'autotools') {
+        & bash -e -c "cd $env:POSIX_PATH_PREFIX/c/projects/curl && autoreconf -fi 2>&1 && ./configure $env:CONFIG_ARGS 2>&1 && make V=1 && make V=1 examples && cd tests && make V=1"
+        $curl = '.\src\curl.exe'
+      }
+
+      Get-ChildItem -Path C:\projects\curl -Include ('*.exe', '*.dll') -Recurse -Name
+      if($env:SKIP_RUN -eq $null) {
+        cmd.exe /c "`"$curl`" -V 2>&1"
+        if(-not $?) {
+          Write-Host "Error running curl: '$curl':" ("0x" + $LastExitCode.ToString("X"))
+          exit 1
+        }
+      }
+      else {
+        Write-Host "Skip running curl.exe. Reason: $env:SKIP_RUN"
+      }
+
+      if($false) {
+        if(Test-Path CMakeFiles/CMakeConfigureLog.yaml) { cat CMakeFiles/CMakeConfigureLog.yaml }
+        if(Test-Path CMakeFiles/CMakeOutput.log) { cat CMakeFiles/CMakeOutput.log }
+        if(Test-Path CMakeFiles/CMakeError.log) { cat CMakeFiles/CMakeError.log }
+      }
+
+      if($env:TESTING -eq 'ON' -and $env:BUILD_SYSTEM -eq 'CMake') {
+        cmake --build . --config $env:PRJ_CFG --parallel 2 --target testdeps
+      }
 
 test_script:
-  - if exist C:/msys64/usr/bin/curl.exe (
-      set ACURL=-ac %POSIX_PATH_PREFIX%/c/msys64/usr/bin/curl.exe )
-  - if exist C:/Windows/System32/curl.exe (
-      set ACURL=-ac %POSIX_PATH_PREFIX%/c/Windows/System32/curl.exe )
-  - if "%TESTING%" == "ON" (
-      if "%BUILD_SYSTEM%" == "CMake" (
-        set TFLAGS=%ACURL% %DISABLED_TESTS% &&
-        cmake --build . --config %PRJ_CFG% --target test-ci
-      ) else (
-      if "%BUILD_SYSTEM%" == "autotools" (
-        bash.exe -e -l -c "cd %POSIX_PATH_PREFIX%/c/projects/curl && make V=1 TFLAGS='%ACURL% %DISABLED_TESTS%' test-ci"
-      ) else (
-        bash.exe -e -l -c "cd %POSIX_PATH_PREFIX%/c/projects/curl/tests && ./runtests.pl -a -p !flaky -r -rm %ACURL% %DISABLED_TESTS%"
-      ))
-    )
+  - ps: |
+      if(Test-Path 'C:/msys64/usr/bin/curl.exe') {
+        $acurl="-ac $env:POSIX_PATH_PREFIX/c/msys64/usr/bin/curl.exe"
+      }
+      if(Test-Path 'C:/Windows/System32/curl.exe') {
+        $acurl="-ac $env:POSIX_PATH_PREFIX/c/Windows/System32/curl.exe"
+      }
+      if($env:TESTING -eq 'ON') {
+        if($env:BUILD_SYSTEM -eq 'CMake') {
+          $env:TFLAGS="$acurl $env:DISABLED_TESTS"
+          cmake --build . --config $env:PRJ_CFG --target test-ci
+        }
+        elseif($env:BUILD_SYSTEM -eq 'autotools') {
+          & bash -e -c "cd $env:POSIX_PATH_PREFIX/c/projects/curl && make V=1 TFLAGS='$acurl $env:DISABLED_TESTS' test-ci"
+        }
+        else {
+          & bash -e -c "cd $env:POSIX_PATH_PREFIX/c/projects/curl/tests && ./runtests.pl -a -p !flaky -r -rm $acurl $env:DISABLED_TESTS"
+        }
+      }
 
 # select branches to avoid testing feature branches twice (as branch and as pull request)
 branches:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,248 +28,248 @@
 version: 7.50.0.{build}
 
 environment:
-  UNITY: "OFF"
-  OPENSSL: "OFF"
-  DEBUG: "ON"
-  SHARED: "OFF"
-  RUN: "ON"
+  UNITY: 'OFF'
+  OPENSSL: 'OFF'
+  DEBUG: 'ON'
+  SHARED: 'OFF'
+  RUN: 'ON'
   matrix:
     # generated CMake-based Visual Studio Release builds
-    - job_name: "CMake, VS2008, Release x86, Schannel"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+    - job_name: 'CMake, VS2008, Release x86, Schannel'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "Visual Studio 9 2008"
+      PRJ_GEN: 'Visual Studio 9 2008'
       PRJ_CFG: Release
-      SCHANNEL: "ON"
-      ENABLE_UNICODE: "OFF"
-      HTTP_ONLY: "OFF"
-      TESTING: "OFF"
-      SHARED: "ON"
-      DISABLED_TESTS: ""
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'OFF'
+      SHARED: 'ON'
+      DISABLED_TESTS: ''
       # MSVCR90.dll missing
-      RUN: "OFF"
-    - job_name: "CMake, VS2022, Release x64, OpenSSL, WebSockets, Unity"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      RUN: 'OFF'
+    - job_name: 'CMake, VS2022, Release x64, OpenSSL, WebSockets, Unity'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "Visual Studio 17 2022"
-      TARGET: "-A x64"
+      PRJ_GEN: 'Visual Studio 17 2022'
+      TARGET: '-A x64'
       PRJ_CFG: Release
-      OPENSSL: "ON"
-      SCHANNEL: "OFF"
-      ENABLE_UNICODE: "OFF"
-      HTTP_ONLY: "OFF"
-      TESTING: "OFF"
-      SHARED: "ON"
-      DISABLED_TESTS: ""
-      WEBSOCKETS: "ON"
-      UNITY: "ON"
-    - job_name: "CMake, VS2022, Release arm64, Schannel, Static"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      OPENSSL: 'ON'
+      SCHANNEL: 'OFF'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'OFF'
+      SHARED: 'ON'
+      DISABLED_TESTS: ''
+      WEBSOCKETS: 'ON'
+      UNITY: 'ON'
+    - job_name: 'CMake, VS2022, Release arm64, Schannel, Static'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "Visual Studio 17 2022"
-      TARGET: "-A ARM64"
+      PRJ_GEN: 'Visual Studio 17 2022'
+      TARGET: '-A ARM64'
       PRJ_CFG: Release
-      SCHANNEL: "ON"
-      ENABLE_UNICODE: "OFF"
-      HTTP_ONLY: "OFF"
-      TESTING: "OFF"
-      DISABLED_TESTS: ""
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'OFF'
+      DISABLED_TESTS: ''
     # generated CMake-based Visual Studio Debug builds
-    - job_name: "CMake, VS2010, Debug x64, no SSL, Static"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+    - job_name: 'CMake, VS2010, Debug x64, no SSL, Static'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "Visual Studio 10 2010 Win64"
+      PRJ_GEN: 'Visual Studio 10 2010 Win64'
       PRJ_CFG: Debug
-      SCHANNEL: "OFF"
-      ENABLE_UNICODE: "OFF"
-      HTTP_ONLY: "OFF"
-      TESTING: "ON"
-      DISABLED_TESTS: "!1139 !1501"
-      ADD_PATH: "C:\\msys64\\usr\\bin"
-    - job_name: "CMake, VS2022, Debug x64, Schannel, Static, Unicode"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      SCHANNEL: 'OFF'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'ON'
+      DISABLED_TESTS: '!1139 !1501'
+      ADD_PATH: 'C:\msys64\usr\bin'
+    - job_name: 'CMake, VS2022, Debug x64, Schannel, Static, Unicode'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "Visual Studio 17 2022"
-      TARGET: "-A x64"
+      PRJ_GEN: 'Visual Studio 17 2022'
+      TARGET: '-A x64'
       PRJ_CFG: Debug
-      SCHANNEL: "ON"
-      ENABLE_UNICODE: "ON"
-      HTTP_ONLY: "OFF"
-      TESTING: "ON"
-      DISABLED_TESTS: "~571 !1139 !1501"
-      ADD_PATH: "C:\\msys64\\usr\\bin"
-    - job_name: "CMake, VS2022, Debug x64, no SSL, Static"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'ON'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'ON'
+      DISABLED_TESTS: '~571 !1139 !1501'
+      ADD_PATH: 'C:\msys64\usr\bin'
+    - job_name: 'CMake, VS2022, Debug x64, no SSL, Static'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "Visual Studio 17 2022"
-      TARGET: "-A x64"
+      PRJ_GEN: 'Visual Studio 17 2022'
+      TARGET: '-A x64'
       PRJ_CFG: Debug
-      SCHANNEL: "OFF"
-      ENABLE_UNICODE: "OFF"
-      HTTP_ONLY: "OFF"
-      TESTING: "ON"
-      DISABLED_TESTS: "~571 !1139 !1501"
-      ADD_PATH: "C:\\msys64\\usr\\bin"
-    - job_name: "CMake, VS2022, Debug x64, no SSL, Static, HTTP only"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+      SCHANNEL: 'OFF'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'ON'
+      DISABLED_TESTS: '~571 !1139 !1501'
+      ADD_PATH: 'C:\msys64\usr\bin'
+    - job_name: 'CMake, VS2022, Debug x64, no SSL, Static, HTTP only'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "Visual Studio 17 2022"
-      TARGET: "-A x64"
+      PRJ_GEN: 'Visual Studio 17 2022'
+      TARGET: '-A x64'
       PRJ_CFG: Debug
-      SCHANNEL: "OFF"
-      ENABLE_UNICODE: "OFF"
-      HTTP_ONLY: "ON"
-      TESTING: "ON"
-      DISABLED_TESTS: "!1139 !1501"
-      ADD_PATH: "C:\\msys64\\usr\\bin"
+      SCHANNEL: 'OFF'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'ON'
+      TESTING: 'ON'
+      DISABLED_TESTS: '!1139 !1501'
+      ADD_PATH: 'C:\msys64\usr\bin'
     # generated CMake-based MSYS Makefiles builds (mingw cross-compiling)
-    - job_name: "CMake, mingw-w64, gcc 8, Debug x64, Schannel, Static, Unicode"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+    - job_name: 'CMake, mingw-w64, gcc 8, Debug x64, Schannel, Static, Unicode'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "MSYS Makefiles"
+      PRJ_GEN: 'MSYS Makefiles'
       PRJ_CFG: Debug
-      SCHANNEL: "ON"
-      ENABLE_UNICODE: "ON"
-      HTTP_ONLY: "OFF"
-      TESTING: "ON"
-      DISABLED_TESTS: "!1139 !1501"
-      ADD_PATH: "C:\\mingw-w64\\x86_64-8.1.0-posix-seh-rt_v6-rev0\\mingw64\\bin;C:\\msys64\\usr\\bin"
-      MSYS2_ARG_CONV_EXCL: "/*"
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'ON'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'ON'
+      DISABLED_TESTS: '!1139 !1501'
+      ADD_PATH: 'C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;C:\msys64\usr\bin'
+      MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
-    - job_name: "CMake, mingw-w64, gcc 7, Debug x64, Schannel, Static, Unicode"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+    - job_name: 'CMake, mingw-w64, gcc 7, Debug x64, Schannel, Static, Unicode'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "MSYS Makefiles"
+      PRJ_GEN: 'MSYS Makefiles'
       PRJ_CFG: Debug
-      SCHANNEL: "ON"
-      ENABLE_UNICODE: "ON"
-      HTTP_ONLY: "OFF"
-      TESTING: "ON"
-      DISABLED_TESTS: "!1139 !1501"
-      ADD_PATH: "C:\\mingw-w64\\x86_64-7.2.0-posix-seh-rt_v5-rev1\\mingw64\\bin;C:\\msys64\\usr\\bin"
-      MSYS2_ARG_CONV_EXCL: "/*"
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'ON'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'ON'
+      DISABLED_TESTS: '!1139 !1501'
+      ADD_PATH: 'C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;C:\msys64\usr\bin'
+      MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
-    - job_name: "CMake, mingw-w64, gcc 9, Debug x64, Schannel, Static, Unity"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+    - job_name: 'CMake, mingw-w64, gcc 9, Debug x64, Schannel, Static, Unity'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "MSYS Makefiles"
+      PRJ_GEN: 'MSYS Makefiles'
       PRJ_CFG: Debug
-      SCHANNEL: "ON"
-      ENABLE_UNICODE: "OFF"
-      HTTP_ONLY: "OFF"
-      TESTING: "OFF"
-      ADD_PATH: "C:\\msys64\\mingw64\\bin;C:\\msys64\\usr\\bin"
-      MSYS2_ARG_CONV_EXCL: "/*"
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'OFF'
+      ADD_PATH: 'C:\msys64\mingw64\bin;C:\msys64\usr\bin'
+      MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
-      UNITY: "ON"
-    - job_name: "CMake, mingw-w64, gcc 6, Debug x86, Schannel, Static"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      UNITY: 'ON'
+    - job_name: 'CMake, mingw-w64, gcc 6, Debug x86, Schannel, Static'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: "MSYS Makefiles"
+      PRJ_GEN: 'MSYS Makefiles'
       PRJ_CFG: Debug
-      SCHANNEL: "ON"
-      ENABLE_UNICODE: "OFF"
-      HTTP_ONLY: "OFF"
-      TESTING: "ON"
-      DISABLED_TESTS: "!1139 !1501"
-      ADD_PATH: "C:\\mingw-w64\\i686-6.3.0-posix-dwarf-rt_v5-rev1\\mingw32\\bin;C:\\msys64\\usr\\bin"
-      MSYS2_ARG_CONV_EXCL: "/*"
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'OFF'
+      TESTING: 'ON'
+      DISABLED_TESTS: '!1139 !1501'
+      ADD_PATH: 'C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin;C:\msys64\usr\bin'
+      MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
     # winbuild-based builds
-    - job_name: "winbuild, VS2015, Debug"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+    - job_name: 'winbuild, VS2015, Debug'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: winbuild_vs2015
-      DEBUG: "yes"
+      DEBUG: 'yes'
       PATHPART: debug
-      TESTING: "OFF"
-      ENABLE_UNICODE: "no"
-    - job_name: "winbuild, VS2015, Release"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      TESTING: 'OFF'
+      ENABLE_UNICODE: 'no'
+    - job_name: 'winbuild, VS2015, Release'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: winbuild_vs2015
-      DEBUG: "no"
+      DEBUG: 'no'
       PATHPART: release
-      TESTING: "OFF"
-      ENABLE_UNICODE: "no"
-    - job_name: "winbuild, VS2017, Debug"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      TESTING: 'OFF'
+      ENABLE_UNICODE: 'no'
+    - job_name: 'winbuild, VS2017, Debug'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: winbuild_vs2017
-      DEBUG: "yes"
+      DEBUG: 'yes'
       PATHPART: debug
-      TESTING: "OFF"
-      ENABLE_UNICODE: "no"
-    - job_name: "winbuild, VS2017, Release"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      TESTING: 'OFF'
+      ENABLE_UNICODE: 'no'
+    - job_name: 'winbuild, VS2017, Release'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: winbuild_vs2017
-      DEBUG: "no"
+      DEBUG: 'no'
       PATHPART: release
-      TESTING: "OFF"
-      ENABLE_UNICODE: "no"
-    - job_name: "winbuild, VS2015, Debug, Unicode"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      TESTING: 'OFF'
+      ENABLE_UNICODE: 'no'
+    - job_name: 'winbuild, VS2015, Debug, Unicode'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: winbuild_vs2015
-      DEBUG: "yes"
+      DEBUG: 'yes'
       PATHPART: debug
-      TESTING: "OFF"
-      ENABLE_UNICODE: "yes"
-    - job_name: "winbuild, VS2015, Release, Unicode"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2015"
+      TESTING: 'OFF'
+      ENABLE_UNICODE: 'yes'
+    - job_name: 'winbuild, VS2015, Release, Unicode'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: winbuild_vs2015
-      DEBUG: "no"
+      DEBUG: 'no'
       PATHPART: release
-      TESTING: "OFF"
-      ENABLE_UNICODE: "yes"
-    - job_name: "winbuild, VS2017, Debug, Unicode"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      TESTING: 'OFF'
+      ENABLE_UNICODE: 'yes'
+    - job_name: 'winbuild, VS2017, Debug, Unicode'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: winbuild_vs2017
-      DEBUG: "yes"
+      DEBUG: 'yes'
       PATHPART: debug
-      TESTING: "OFF"
-      ENABLE_UNICODE: "yes"
-    - job_name: "winbuild, VS2017, Release, Unicode"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      TESTING: 'OFF'
+      ENABLE_UNICODE: 'yes'
+    - job_name: 'winbuild, VS2017, Release, Unicode'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: winbuild_vs2017
-      DEBUG: "no"
+      DEBUG: 'no'
       PATHPART: release
-      TESTING: "OFF"
-      ENABLE_UNICODE: "yes"
+      TESTING: 'OFF'
+      ENABLE_UNICODE: 'yes'
     # generated VisualStudioSolution-based builds
-    - job_name: "VisualStudioSolution, VS2017, Debug"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+    - job_name: 'VisualStudioSolution, VS2017, Debug'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: VisualStudioSolution
-      PRJ_CFG: "DLL Debug - DLL Windows SSPI - DLL WinIDN"
-      TESTING: "OFF"
+      PRJ_CFG: 'DLL Debug - DLL Windows SSPI - DLL WinIDN'
+      TESTING: 'OFF'
       VC_VERSION: VC14.10
     # autotools-based builds (NOT mingw cross-compiling, but msys2 native)
-    - job_name: "autotools, msys2, Debug, no Proxy, no SSL"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+    - job_name: 'autotools, msys2, Debug, no Proxy, no SSL'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
-      TESTING: "ON"
-      DISABLED_TESTS: "!19 !1233"
-      ADD_PATH: "C:\\msys64\\usr\\bin"
-      CONFIG_ARGS: "--enable-debug --enable-werror --disable-threaded-resolver --disable-proxy --without-ssl --enable-websockets"
-    - job_name: "autotools, msys2, Debug, no SSL"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      TESTING: 'ON'
+      DISABLED_TESTS: '!19 !1233'
+      ADD_PATH: 'C:\msys64\usr\bin'
+      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --disable-proxy --without-ssl --enable-websockets'
+    - job_name: 'autotools, msys2, Debug, no SSL'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
-      TESTING: "ON"
-      DISABLED_TESTS: "!19 !504 !704 !705 !1233"
-      ADD_PATH: "C:\\msys64\\usr\\bin"
-      CONFIG_ARGS: "--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets"
-    - job_name: "autotools, msys2, Release, no SSL"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2017"
+      TESTING: 'ON'
+      DISABLED_TESTS: '!19 !504 !704 !705 !1233'
+      ADD_PATH: 'C:\msys64\usr\bin'
+      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets'
+    - job_name: 'autotools, msys2, Release, no SSL'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
-      TESTING: "ON"
-      DISABLED_TESTS: "!19 !504 !704 !705 !1233"
-      ADD_PATH: "C:\\msys64\\usr\\bin"
-      CONFIG_ARGS: "--enable-warnings --enable-werror --without-ssl --enable-websockets"
+      TESTING: 'ON'
+      DISABLED_TESTS: '!19 !504 !704 !705 !1233'
+      ADD_PATH: 'C:\msys64\usr\bin'
+      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets'
     # autotools-based Cygwin build
-    - job_name: "autotools, cygwin, Debug, no SSL"
-      APPVEYOR_BUILD_WORKER_IMAGE: "Visual Studio 2022"
+    - job_name: 'autotools, cygwin, Debug, no SSL'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: autotools
-      TESTING: "ON"
-      DISABLED_TESTS: ""
-      ADD_PATH: "C:\\cygwin64\\bin"
-      CONFIG_ARGS: "--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets"
-      POSIX_PATH_PREFIX: "/cygdrive"
+      TESTING: 'ON'
+      DISABLED_TESTS: ''
+      ADD_PATH: 'C:\cygwin64\bin'
+      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets'
+      POSIX_PATH_PREFIX: '/cygdrive'
 
 install:
   - if not "%ADD_PATH%" == "" (


### PR DESCRIPTION
1. Rewrite in PowerShell:

- rewrite MS-DOS batch build script in PowerShell.
- move some bash operations into native PowerShell.
- fixups for PowerShell insisting on failure when a command outputs
  something to stderr.
- fix to actually run `curl -V` after every build.
  (and exclude ARM64 builds.)
- also say why we skipped `curl -V` if we had to skip.
- fix CMake warnings about unused configuration variables, by adapting
  these dynamically for build cases.
- dedupe OpenSSL path into a variable.
- disable `test1451` failing with a warning anyway due to missing python
  impacket. (after trying and failing to install impacket)
  PowerShell promotes these warnings to errors by PowerShell. We can also
  suppress they wholesale if they start causing issues in the future,
  like we already to with `autoreconf` and `./configure`.

PowerShell is better than MS-DOS batches, so the hope is this makes it
easier to extend and maintain the AppVeyor build logic. POSIX/bash isn't
supported inline by AppVeyor on Windows build machines, but we are okay
to keep it in an external script, so it's also an option.

2. CI improvements:

- enable tests for a "unity" build job.
- speed-up CI initialization by using shallow clones of the curl repo.
- speed-up CMake MSVC jobs with `TrackFileAccess=false`.
- enable parallelism in `VisualStudioSolution` builds.
- display CMake version before builds.
- always show the CPU in job names.
- tell which jobs are build-only in job names.
- move `TESTING:` value next to `DISABLED_TESTS:` in two jobs.
- add `config.log` (autotools) to dumped logs (need to enable manually).

3. Style:

- use single-quotes in YAML like we do in other CI YAML files.
  It also allows to drop quoting characters and lighter to write/read.
  (keep double quotes for PowerShell strings needing expansion.)

Closes #11999
