### PR TITLE
cmake: disable unity mode with Windows Unicode + TrackMemory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,16 @@ if(ENABLE_CURLDEBUG)
   set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS CURLDEBUG)
 endif()
 
+# This combination results in curl tool crashing on startup when run on native
+# Windows (it was seen to work when run under WINE though). We disable UNITY
+# mode as a workaround.
+if(ENABLE_UNICODE AND ENABLE_CURLDEBUG)
+  set(CMAKE_UNITY_BUILD OFF)
+  message(WARNING "Unity builds are not supported with Windows Unicode and "
+    "TrackMemory (-DCURLDEBUG) enabled at the same time. Unity mode has been "
+    "disabled.")
+endif()
+
 # For debug libs and exes, add "-d" postfix
 if(NOT DEFINED CMAKE_DEBUG_POSTFIX)
   set(CMAKE_DEBUG_POSTFIX "-d")


### PR DESCRIPTION
"TrackMemory" is `ENABLE_DEBUG=ON` (aka `ENABLE_CURLDEBUG=ON`,
aka `-DCURLDEBUG`).

There is an issue with memory tracking and Unicode when built in "unity"
mode, which results in the curl tool crashing right on startup, even
without any command-line option. Interestingly this doesn't happen under
WINE (at least on the system I tested this on), but consistenly happens
on real Windows machines. Crash is 0xC0000374 heap corruption. Both
shared and static curl executables are affected.

This limitation probably won't hit too many people, but it remains
a TODO to find and fix the root cause and drop this workaround.

Example builds and runs:
https://ci.appveyor.com/project/curlorg/curl/builds/48169111/job/17cptxhtpubd7iwj#L313 (static)
https://ci.appveyor.com/project/curlorg/curl/builds/48169111/job/76e1ge758tbyqu9c#L317 (shared)

Follow-up to 3f8fc25720900b14b7432f4bd93407ca15311719 #11095

Ref #11928
Closes #12005
