### PR TITLE
Increase lib571 timeout from 3s to 30s

### DIFF
--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -138,7 +138,7 @@ int test(char *URL)
   stream_uri = NULL;
 
   test_setopt(curl, CURLOPT_INTERLEAVEFUNCTION, rtp_write);
-  test_setopt(curl, CURLOPT_TIMEOUT, 3L);
+  test_setopt(curl, CURLOPT_TIMEOUT, 30L);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
   test_setopt(curl, CURLOPT_WRITEDATA, protofile);
 


### PR DESCRIPTION
- 3s is too short for our CI, making this test fail occasionally
- test usually experiences no delay run locally, so 30s wont hurt