### PR TITLE
cmake: delete old `HAVE_LDAP_URL_PARSE` logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1237,11 +1237,6 @@ if(NOT HAVE_SIGSETJMP)
   endif()
 endif()
 
-# If there is no stricmp(), do not allow LDAP to parse URLs
-if(NOT HAVE_STRICMP)
-  set(HAVE_LDAP_URL_PARSE 1)
-endif()
-
 # Do curl specific tests
 foreach(CURL_TEST
     HAVE_FCNTL_O_NONBLOCK


### PR DESCRIPTION
Left there by accident after adding proper detection for this.

Follow-up to 772f0d8edf1c3c2745543f42388ccec5a16ee2c0 #12006

Closes #xxxxx
