### PR TITLE
cmake: improve OpenLDAP builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,14 +748,8 @@ if(NOT CURL_DISABLE_LDAP)
     endif()
   endif()
 
-  option(CURL_USE_OPENLDAP "Use OpenLDAP code." OFF)
-  mark_as_advanced(CURL_USE_OPENLDAP)
   set(CMAKE_LDAP_LIB "ldap" CACHE STRING "Name or full path to ldap library")
   set(CMAKE_LBER_LIB "lber" CACHE STRING "Name or full path to lber library")
-
-  if(CURL_USE_OPENLDAP AND USE_WIN32_LDAP)
-    message(FATAL_ERROR "Cannot use USE_WIN32_LDAP and CURL_USE_OPENLDAP at the same time")
-  endif()
 
   # Now that we know, we're not using windows LDAP...
   if(NOT USE_WIN32_LDAP)
@@ -781,9 +775,6 @@ if(NOT CURL_DISABLE_LDAP)
       set(CURL_DISABLE_LDAP ON CACHE BOOL "" FORCE)
       set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_BAK}) #LDAP includes won't be used
     else()
-      if(CURL_USE_OPENLDAP)
-        set(USE_OPENLDAP ON)
-      endif()
       if(CMAKE_LDAP_INCLUDE_DIR)
         include_directories(${CMAKE_LDAP_INCLUDE_DIR})
       endif()
@@ -824,11 +815,15 @@ if(NOT CURL_DISABLE_LDAP)
       endif()
 
       check_function_exists(ldap_url_parse HAVE_LDAP_URL_PARSE)
+      check_function_exists(ldap_init_fd HAVE_LDAP_INIT_FD)
 
       unset(CMAKE_REQUIRED_LIBRARIES)
 
       check_include_file("ldap_ssl.h" HAVE_LDAP_SSL_H)
 
+      if(HAVE_LDAP_INIT_FD)
+        set(USE_OPENLDAP ON)
+      endif()
       if(NOT CURL_DISABLE_LDAPS)
         set(HAVE_LDAP_SSL ON)
       endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -823,6 +823,7 @@ if(NOT CURL_DISABLE_LDAP)
 
       if(HAVE_LDAP_INIT_FD)
         set(USE_OPENLDAP ON)
+        add_definitions("-DLDAP_DEPRECATED=1")
       endif()
       if(NOT CURL_DISABLE_LDAPS)
         set(HAVE_LDAP_SSL ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1567,7 +1567,6 @@ _add_if("FILE"          NOT CURL_DISABLE_FILE)
 _add_if("TELNET"        NOT CURL_DISABLE_TELNET)
 _add_if("LDAP"          NOT CURL_DISABLE_LDAP)
 # CURL_DISABLE_LDAP implies CURL_DISABLE_LDAPS
-# TODO check HAVE_LDAP_SSL (in autoconf this is enabled with --enable-ldaps)
 _add_if("LDAPS"         NOT CURL_DISABLE_LDAPS AND
                         ((USE_OPENLDAP AND SSL_ENABLED) OR
                         (NOT USE_OPENLDAP AND HAVE_LDAP_SSL)))

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -421,7 +421,7 @@ AC_DEFUN([CURL_CHECK_HEADER_LDAP], [
 #endif
 #include <ldap.h>
       ]],[[
-        LDAP *ldp = ldap_init("dummy", LDAP_PORT);
+        LDAP *ldp = ldap_init("0.0.0.0", LDAP_PORT);
         int res = ldap_unbind(ldp);
       ]])
     ],[
@@ -470,7 +470,7 @@ AC_DEFUN([CURL_CHECK_HEADER_LDAP_SSL], [
 #endif
 #include <ldap_ssl.h>
       ]],[[
-        LDAP *ldp = ldapssl_init("dummy", LDAPS_PORT, 1);
+        LDAP *ldp = ldapssl_init("0.0.0.0", LDAPS_PORT, 1);
       ]])
     ],[
       curl_cv_header_ldap_ssl_h="yes"
@@ -547,7 +547,7 @@ AC_DEFUN([CURL_CHECK_LIBS_WINLDAP], [
         ]],[[
           BERVAL *bvp = NULL;
           BerElement *bep = ber_init(bvp);
-          LDAP *ldp = ldap_init("dummy", LDAP_PORT);
+          LDAP *ldp = ldap_init("0.0.0.0", LDAP_PORT);
           ULONG res = ldap_unbind(ldp);
           ber_free(bep, 1);
         ]])
@@ -657,7 +657,7 @@ AC_DEFUN([CURL_CHECK_LIBS_LDAP], [
         ]],[[
           BerValue *bvp = NULL;
           BerElement *bep = ber_init(bvp);
-          LDAP *ldp = ldap_init("dummy", LDAP_PORT);
+          LDAP *ldp = ldap_init("0.0.0.0", LDAP_PORT);
           int res = ldap_unbind(ldp);
           ber_free(bep, 1);
         ]])


### PR DESCRIPTION
- cmake: detect OpenLDAP based on function `ldap_init_fd`.
  autotools does this. autotools also publishes this detection result
  in `HAVE_LDAP_INIT_FD`. We don't mimic that with CMake as the source
  doesn't use this value. (it might need to be remove-listed in
  `scripts/cmp-config.pl` for future OpenLDAP test builds.)
  This also deletes existing self-declaration method via the
  CMake-specific `CURL_USE_OPENLDAP` configuration.

- cmake: define `LDAP_DEPRECATED=1` for OpenLDAP.
  Like autotools does. This fixes a long list of these warnings:
  ```
  /usr/local/opt/openldap/include/ldap.h:1049:5: warning: 'LDAP_DEPRECATED' is not defined, evaluates to 0 [-Wundef]
  ```

- cmake: delete LDAP TODO comment no longer relevant.

Also:

- autotools: replace domain name `dummy` with `0.0.0.0` in LDAP feature
  detection functions.

Ref: #11964 (effort to sync cmake detections with autotools)

Closes #12024
