### PR TITLE
Improve reliability and debuggability of tests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -130,7 +130,7 @@ environment:
       ENABLE_UNICODE: 'ON'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1451 !1501'
+      DISABLED_TESTS: '!1086 !1139 !1451 !1501'
       ADD_PATH: 'C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -144,7 +144,7 @@ environment:
       ENABLE_UNICODE: 'ON'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1451 !1501'
+      DISABLED_TESTS: '!1086 !1139 !1451 !1501'
       ADD_PATH: 'C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -157,7 +157,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1451 !1501'
+      DISABLED_TESTS: '!1086 !1139 !1451 !1501'
       ADD_PATH: 'C:\msys64\mingw64\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -171,7 +171,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1451 !1501'
+      DISABLED_TESTS: '!1086 !1139 !1451 !1501'
       ADD_PATH: 'C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw32\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,8 +48,8 @@ endfunction()
 add_runtests(test-quiet     "-a -s")
 add_runtests(test-am        "-a -am")
 add_runtests(test-full      "-a -p -r")
-# !flaky means that it'll skip all tests using the flaky keyword
-add_runtests(test-nonflaky  "-a -p !flaky")
-add_runtests(test-ci        "-a -p !flaky -r -rm")
+# ~flaky means that it'll ignore results of tests using the flaky keyword
+add_runtests(test-nonflaky  "-a -p ~flaky ~timing-dependent")
+add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r -rm")
 add_runtests(test-torture   "-a -t")
 add_runtests(test-event     "-a -e")

--- a/tests/data/test1070
+++ b/tests/data/test1070
@@ -32,7 +32,7 @@ http
 HTTP POST with server closing connection before (all) data is received
 </name>
 <command>
- -d @%LOGDIR/input%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER -H "Expect: 100-continue"
+-d @%LOGDIR/input%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER -H "Expect: 100-continue"
 </command>
 <file name="%LOGDIR/input%TESTNUMBER">
 This creates the named file with this content before the test case is run,

--- a/tests/data/test1129
+++ b/tests/data/test1129
@@ -51,7 +51,7 @@ http
 HTTP POST expect 100-continue with a 404
 </name>
  <command option="no-output">
--d @%LOGDIR/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001
+-d @%LOGDIR/file%TESTNUMBER --expect100-timeout 99 http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001
 </command>
 </client>
 

--- a/tests/data/test1130
+++ b/tests/data/test1130
@@ -52,7 +52,7 @@ http
 HTTP POST forced expect 100-continue with a 404
 </name>
  <command option="no-output">
--d @%LOGDIR/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001 -H "Expect: 100-continue" --expect100-timeout 999
+-d @%LOGDIR/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001 -H "Expect: 100-continue" --expect100-timeout 99
 </command>
 </client>
 

--- a/tests/data/test1131
+++ b/tests/data/test1131
@@ -52,7 +52,7 @@ http
 HTTP PUT expect 100-continue with a 400
 </name>
  <command option="no-output">
--H "Expect: 100-continue" -T %LOGDIR/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER -T %LOGDIR/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001 --expect100-timeout 999
+-H "Expect: 100-continue" -T %LOGDIR/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER -T %LOGDIR/file%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001 --expect100-timeout 99
 </command>
 </client>
 

--- a/tests/data/test2306
+++ b/tests/data/test2306
@@ -54,6 +54,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0002
 #
 # Verify data after the test has been "shot"
 <verify>
+# hyper doesn't like the bad header in the second request
+<errorcode>
+%if hyper
+1
+%else
+0
+%endif
+</errorcode>
 <protocol>
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT

--- a/tests/data/test357
+++ b/tests/data/test357
@@ -51,7 +51,7 @@ http
 HTTP PUT with Expect: 100-continue and 417 response
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -T %LOGDIR/test%TESTNUMBER.txt --expect100-timeout 999
+http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -T %LOGDIR/test%TESTNUMBER.txt --expect100-timeout 99
 </command>
 # 1053700 x 'x', large enough to invoke the 100-continue behaviour
 <file name="%LOGDIR/test%TESTNUMBER.txt">

--- a/tests/libtest/lib1510.c
+++ b/tests/libtest/lib1510.c
@@ -83,6 +83,8 @@ int test(char *URL)
     easy_setopt(curl, CURLOPT_URL, target_url);
 
     res = curl_easy_perform(curl);
+    if(res)
+      goto test_cleanup;
 
     abort_on_test_timeout();
   }

--- a/tests/libtest/lib1512.c
+++ b/tests/libtest/lib1512.c
@@ -80,8 +80,11 @@ int test(char *URL)
   easy_setopt(curl[0], CURLOPT_RESOLVE, slist);
 
   /* run NUM_HANDLES transfers */
-  for(i = 0; (i < NUM_HANDLES) && !res; i++)
+  for(i = 0; (i < NUM_HANDLES) && !res; i++) {
     res = curl_easy_perform(curl[i]);
+    if(res)
+      goto test_cleanup;
+  }
 
 test_cleanup:
 

--- a/tests/libtest/lib1518.c
+++ b/tests/libtest/lib1518.c
@@ -81,7 +81,7 @@ int test(char *URL)
   curl_easy_getinfo(curl, CURLINFO_REDIRECT_COUNT, &curlRedirectCount);
   curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &effectiveUrl);
   curl_easy_getinfo(curl, CURLINFO_REDIRECT_URL, &redirectUrl);
-  res = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
+  test_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
 
   printf("res %d\n"
          "status %d\n"

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -51,7 +51,7 @@ static int sockopt_callback(void *clientp, curl_socket_t curlfd,
 
 int test(char *URL)
 {
-  CURLcode code;
+  CURLcode code = TEST_ERR_MAJOR_BAD;
   CURLcode res;
   struct curl_slist *pHeaderList = NULL;
   CURL *curl = curl_easy_init();
@@ -97,5 +97,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return 0;
+  return (int)code;
 }

--- a/tests/libtest/lib1533.c
+++ b/tests/libtest/lib1533.c
@@ -106,7 +106,7 @@ static int perform_and_check_connections(CURL *curl, const char *description,
 
   res = curl_easy_perform(curl);
   if(res != CURLE_OK) {
-    fprintf(stderr, "curl_easy_perform() failed\n");
+    fprintf(stderr, "curl_easy_perform() failed with %d\n", (int)res);
     return TEST_ERR_MAJOR_BAD;
   }
 

--- a/tests/libtest/lib1540.c
+++ b/tests/libtest/lib1540.c
@@ -84,7 +84,6 @@ static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userp)
 int test(char *URL)
 {
   CURL *curls = NULL;
-  int i = 0;
   int res = 0;
   struct transfer_status st;
 
@@ -114,8 +113,5 @@ test_cleanup:
   curl_easy_cleanup(curls);
   curl_global_cleanup();
 
-  if(res)
-    i = res;
-
-  return i; /* return the final return code */
+  return (int)res; /* return the final return code */
 }

--- a/tests/libtest/lib1551.c
+++ b/tests/libtest/lib1551.c
@@ -39,11 +39,15 @@ int test(char *URL)
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     res = curl_easy_perform(curl);
+    if(res)
+      goto test_cleanup;
 
     fprintf(stderr, "****************************** Do it again\n");
     res = curl_easy_perform(curl);
-    curl_easy_cleanup(curl);
   }
+
+test_cleanup:
+  curl_easy_cleanup(curl);
   curl_global_cleanup();
   return (int)res;
 }

--- a/tests/libtest/lib1567.c
+++ b/tests/libtest/lib1567.c
@@ -29,26 +29,31 @@
 
 int test(char *URL)
 {
-  CURL *curl;
+  CURL *curl = NULL;
   CURLcode res = CURLE_OK;
+  CURLU *u = NULL;
 
   global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
   if(curl) {
-    CURLU *u = curl_url();
+    u = curl_url();
     if(u) {
       curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
       curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
       curl_url_set(u, CURLUPART_URL, URL, 0);
       curl_easy_setopt(curl, CURLOPT_CURLU, u);
       res = curl_easy_perform(curl);
+      if(res)
+        goto test_cleanup;
 
       fprintf(stderr, "****************************** Do it again\n");
       res = curl_easy_perform(curl);
-      curl_url_cleanup(u);
     }
-    curl_easy_cleanup(curl);
   }
+
+test_cleanup:
+  curl_url_cleanup(u);
+  curl_easy_cleanup(curl);
   curl_global_cleanup();
   return (int)res;
 }

--- a/tests/libtest/lib1569.c
+++ b/tests/libtest/lib1569.c
@@ -28,21 +28,24 @@
 
 int test(char *URL)
 {
-  CURLcode ret;
+  CURLcode res = CURLE_OK;
   CURL *hnd;
-  curl_global_init(CURL_GLOBAL_ALL);
+  global_init(CURL_GLOBAL_ALL);
 
-  hnd = curl_easy_init();
-  curl_easy_setopt(hnd, CURLOPT_URL, URL);
-  curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
-  curl_easy_setopt(hnd, CURLOPT_HEADER, 1L);
+  easy_init(hnd);
+  easy_setopt(hnd, CURLOPT_URL, URL);
+  easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
+  easy_setopt(hnd, CURLOPT_HEADER, 1L);
 
-  ret = curl_easy_perform(hnd);
+  res = curl_easy_perform(hnd);
+  if(res)
+    goto test_cleanup;
 
   curl_easy_setopt(hnd, CURLOPT_URL, libtest_arg2);
-  ret = curl_easy_perform(hnd);
-  curl_easy_cleanup(hnd);
+  res = curl_easy_perform(hnd);
 
+test_cleanup:
+  curl_easy_cleanup(hnd);
   curl_global_cleanup();
-  return (int)ret;
+  return (int)res;
 }

--- a/tests/libtest/lib1903.c
+++ b/tests/libtest/lib1903.c
@@ -30,26 +30,27 @@
 
 int test(char *URL)
 {
+  CURLcode res = CURLE_OK;
   CURL *ch = NULL;
-  curl_global_init(CURL_GLOBAL_ALL);
+  global_init(CURL_GLOBAL_ALL);
 
-  ch = curl_easy_init();
-  if(!ch)
-    goto cleanup;
+  easy_init(ch);
 
-  curl_easy_setopt(ch, CURLOPT_URL, URL);
-  curl_easy_setopt(ch, CURLOPT_COOKIEFILE, libtest_arg2);
-  curl_easy_perform(ch);
+  easy_setopt(ch, CURLOPT_URL, URL);
+  easy_setopt(ch, CURLOPT_COOKIEFILE, libtest_arg2);
+  res = curl_easy_perform(ch);
+  if(res)
+    goto test_cleanup;
 
   curl_easy_reset(ch);
 
-  curl_easy_setopt(ch, CURLOPT_URL, URL);
-  curl_easy_setopt(ch, CURLOPT_COOKIEFILE, libtest_arg2);
-  curl_easy_perform(ch);
+  easy_setopt(ch, CURLOPT_URL, URL);
+  easy_setopt(ch, CURLOPT_COOKIEFILE, libtest_arg2);
+  res = curl_easy_perform(ch);
 
-cleanup:
+test_cleanup:
   curl_easy_cleanup(ch);
   curl_global_cleanup();
 
-  return 0;
+  return (int)res;
 }

--- a/tests/libtest/lib1906.c
+++ b/tests/libtest/lib1906.c
@@ -29,46 +29,55 @@
 
 int test(char *URL)
 {
-  char *url_after;
+  CURLcode res = CURLE_OK;
+  char *url_after = NULL;
   CURLU *curlu = curl_url();
-  CURL *curl = curl_easy_init();
-  CURLcode curl_code;
   char error_buffer[CURL_ERROR_SIZE] = "";
+  CURL *curl;
+
+  easy_init(curl);
 
   curl_url_set(curlu, CURLUPART_URL, URL, CURLU_DEFAULT_SCHEME);
-  curl_easy_setopt(curl, CURLOPT_CURLU, curlu);
-  curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error_buffer);
-  curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+  easy_setopt(curl, CURLOPT_CURLU, curlu);
+  easy_setopt(curl, CURLOPT_ERRORBUFFER, error_buffer);
+  easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   /* set a port number that makes this request fail */
-  curl_easy_setopt(curl, CURLOPT_PORT, 1L);
-  curl_code = curl_easy_perform(curl);
-  if(!curl_code)
+  easy_setopt(curl, CURLOPT_PORT, 1L);
+  res = curl_easy_perform(curl);
+  if(res != CURLE_COULDNT_CONNECT) {
     fprintf(stderr, "failure expected, "
-            "curl_easy_perform returned %ld: <%s>, <%s>\n",
-            (long) curl_code, curl_easy_strerror(curl_code), error_buffer);
+            "curl_easy_perform returned %d: <%s>, <%s>\n",
+            (int) res, curl_easy_strerror(res), error_buffer);
+    if(res == CURLE_OK)
+      res = TEST_ERR_MAJOR_BAD;  /* force an error return */
+    goto test_cleanup;
+  }
+  res = CURLE_OK;  /* reset for next use */
 
   /* print the used url */
   curl_url_get(curlu, CURLUPART_URL, &url_after, 0);
   fprintf(stderr, "curlu now: <%s>\n", url_after);
   curl_free(url_after);
+  url_after = NULL;
 
   /* now reset CURLOP_PORT to go back to originally set port number */
-  curl_easy_setopt(curl, CURLOPT_PORT, 0L);
+  easy_setopt(curl, CURLOPT_PORT, 0L);
 
-  curl_code = curl_easy_perform(curl);
-  if(curl_code)
+  res = curl_easy_perform(curl);
+  if(res)
     fprintf(stderr, "success expected, "
             "curl_easy_perform returned %ld: <%s>, <%s>\n",
-            (long) curl_code, curl_easy_strerror(curl_code), error_buffer);
+            (long) res, curl_easy_strerror(res), error_buffer);
 
   /* print url */
   curl_url_get(curlu, CURLUPART_URL, &url_after, 0);
   fprintf(stderr, "curlu now: <%s>\n", url_after);
-  curl_free(url_after);
 
+test_cleanup:
+  curl_free(url_after);
   curl_easy_cleanup(curl);
   curl_url_cleanup(curlu);
   curl_global_cleanup();
 
-  return 0;
+  return (int)res;
 }

--- a/tests/libtest/lib1906.c
+++ b/tests/libtest/lib1906.c
@@ -44,7 +44,7 @@ int test(char *URL)
   /* set a port number that makes this request fail */
   easy_setopt(curl, CURLOPT_PORT, 1L);
   res = curl_easy_perform(curl);
-  if(res != CURLE_COULDNT_CONNECT) {
+  if(res != CURLE_COULDNT_CONNECT && res != CURLE_OPERATION_TIMEDOUT) {
     fprintf(stderr, "failure expected, "
             "curl_easy_perform returned %d: <%s>, <%s>\n",
             (int) res, curl_easy_strerror(res), error_buffer);

--- a/tests/libtest/lib1907.c
+++ b/tests/libtest/lib1907.c
@@ -31,7 +31,7 @@ int test(char *URL)
 {
   char *url_after;
   CURL *curl;
-  CURLcode curl_code;
+  CURLcode res = CURLE_OK;
   char error_buffer[CURL_ERROR_SIZE] = "";
 
   curl_global_init(CURL_GLOBAL_DEFAULT);
@@ -39,11 +39,11 @@ int test(char *URL)
   curl_easy_setopt(curl, CURLOPT_URL, URL);
   curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, error_buffer);
   curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-  curl_code = curl_easy_perform(curl);
-  if(!curl_code)
+  res = curl_easy_perform(curl);
+  if(!res)
     fprintf(stderr, "failure expected, "
             "curl_easy_perform returned %ld: <%s>, <%s>\n",
-            (long) curl_code, curl_easy_strerror(curl_code), error_buffer);
+            (long) res, curl_easy_strerror(res), error_buffer);
 
   /* print the used url */
   if(!curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url_after))
@@ -52,5 +52,5 @@ int test(char *URL)
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return 0;
+  return (int)res;
 }

--- a/tests/libtest/lib1915.c
+++ b/tests/libtest/lib1915.c
@@ -98,36 +98,39 @@ static CURLSTScode hstswrite(CURL *easy, struct curl_hstsentry *e,
 
 int test(char *URL)
 {
-  CURLcode ret = CURLE_OK;
+  CURLcode res = CURLE_OK;
   CURL *hnd;
   struct state st = {0};
 
-  curl_global_init(CURL_GLOBAL_ALL);
+  global_init(CURL_GLOBAL_ALL);
 
-  hnd = curl_easy_init();
-  if(hnd) {
-    curl_easy_setopt(hnd, CURLOPT_URL, URL);
-    curl_easy_setopt(hnd, CURLOPT_HSTSREADFUNCTION, hstsread);
-    curl_easy_setopt(hnd, CURLOPT_HSTSREADDATA, &st);
-    curl_easy_setopt(hnd, CURLOPT_HSTSWRITEFUNCTION, hstswrite);
-    curl_easy_setopt(hnd, CURLOPT_HSTSWRITEDATA, &st);
-    curl_easy_setopt(hnd, CURLOPT_HSTS_CTRL, CURLHSTS_ENABLE);
-    ret = curl_easy_perform(hnd);
-    curl_easy_cleanup(hnd);
-    printf("First request returned %d\n", (int)ret);
-  }
-  hnd = curl_easy_init();
-  if(hnd) {
-    curl_easy_setopt(hnd, CURLOPT_URL, URL);
-    curl_easy_setopt(hnd, CURLOPT_HSTSREADFUNCTION, hstsreadfail);
-    curl_easy_setopt(hnd, CURLOPT_HSTSREADDATA, &st);
-    curl_easy_setopt(hnd, CURLOPT_HSTSWRITEFUNCTION, hstswrite);
-    curl_easy_setopt(hnd, CURLOPT_HSTSWRITEDATA, &st);
-    curl_easy_setopt(hnd, CURLOPT_HSTS_CTRL, CURLHSTS_ENABLE);
-    ret = curl_easy_perform(hnd);
-    curl_easy_cleanup(hnd);
-    printf("Second request returned %d\n", (int)ret);
-  }
+  easy_init(hnd);
+  easy_setopt(hnd, CURLOPT_URL, URL);
+  easy_setopt(hnd, CURLOPT_HSTSREADFUNCTION, hstsread);
+  easy_setopt(hnd, CURLOPT_HSTSREADDATA, &st);
+  easy_setopt(hnd, CURLOPT_HSTSWRITEFUNCTION, hstswrite);
+  easy_setopt(hnd, CURLOPT_HSTSWRITEDATA, &st);
+  easy_setopt(hnd, CURLOPT_HSTS_CTRL, CURLHSTS_ENABLE);
+  res = curl_easy_perform(hnd);
+  curl_easy_cleanup(hnd);
+  hnd = NULL;
+  printf("First request returned %d\n", (int)res);
+  res = CURLE_OK;
+
+  easy_init(hnd);
+  easy_setopt(hnd, CURLOPT_URL, URL);
+  easy_setopt(hnd, CURLOPT_HSTSREADFUNCTION, hstsreadfail);
+  easy_setopt(hnd, CURLOPT_HSTSREADDATA, &st);
+  easy_setopt(hnd, CURLOPT_HSTSWRITEFUNCTION, hstswrite);
+  easy_setopt(hnd, CURLOPT_HSTSWRITEDATA, &st);
+  easy_setopt(hnd, CURLOPT_HSTS_CTRL, CURLHSTS_ENABLE);
+  res = curl_easy_perform(hnd);
+  curl_easy_cleanup(hnd);
+  hnd = NULL;
+  printf("Second request returned %d\n", (int)res);
+
+test_cleanup:
+  curl_easy_cleanup(hnd);
   curl_global_cleanup();
-  return (int)ret;
+  return (int)res;
 }

--- a/tests/libtest/lib1919.c
+++ b/tests/libtest/lib1919.c
@@ -29,25 +29,28 @@
 
 int test(char *URL)
 {
+  CURLcode res = CURLE_OK;
   CURL *curl;
-  curl_global_init(CURL_GLOBAL_ALL);
+  int i;
 
-  curl = curl_easy_init();
-  if(curl) {
-    int i;
-    curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
-    curl_easy_setopt(curl, CURLOPT_XOAUTH2_BEARER,
-                     "c4e448d652a961fda0ab64f882c8c161d5985f805d45d80c9ddca1");
-    curl_easy_setopt(curl, CURLOPT_SASL_AUTHZID,
-                     "c4e448d652a961fda0ab64f882c8c161d5985f805d45d80c9ddca2");
-    curl_easy_setopt(curl, CURLOPT_URL, URL);
+  global_init(CURL_GLOBAL_ALL);
+  easy_init(curl);
+  easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_BEARER);
+  easy_setopt(curl, CURLOPT_XOAUTH2_BEARER,
+                   "c4e448d652a961fda0ab64f882c8c161d5985f805d45d80c9ddca1");
+  easy_setopt(curl, CURLOPT_SASL_AUTHZID,
+                   "c4e448d652a961fda0ab64f882c8c161d5985f805d45d80c9ddca2");
+  easy_setopt(curl, CURLOPT_URL, URL);
 
-    for(i = 0; i < 2; i++)
-      /* the second request needs to do connection reuse */
-      curl_easy_perform(curl);
-
-    curl_easy_cleanup(curl);
+  for(i = 0; i < 2; i++) {
+    /* the second request needs to do connection reuse */
+    res = curl_easy_perform(curl);
+    if(res)
+      goto test_cleanup;
   }
+
+test_cleanup:
+  curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return 0;
+  return (int)res;
 }

--- a/tests/libtest/lib1940.c
+++ b/tests/libtest/lib1940.c
@@ -83,37 +83,36 @@ static size_t write_cb(char *data, size_t n, size_t l, void *userp)
 }
 int test(char *URL)
 {
-  CURL *easy;
+  CURL *easy = NULL;
+  CURLcode res = CURLE_OK;
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  global_init(CURL_GLOBAL_DEFAULT);
+  easy_init(easy);
+  easy_setopt(easy, CURLOPT_URL, URL);
+  easy_setopt(easy, CURLOPT_VERBOSE, 1L);
+  easy_setopt(easy, CURLOPT_FOLLOWLOCATION, 1L);
+  /* ignores any content */
+  easy_setopt(easy, CURLOPT_WRITEFUNCTION, write_cb);
 
-  easy = curl_easy_init();
-  if(easy) {
-    CURLcode res;
-    curl_easy_setopt(easy, CURLOPT_URL, URL);
-    curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
-    curl_easy_setopt(easy, CURLOPT_FOLLOWLOCATION, 1L);
-    /* ignores any content */
-    curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, write_cb);
-
-    /* if there's a proxy set, use it */
-    if(libtest_arg2 && *libtest_arg2) {
-      curl_easy_setopt(easy, CURLOPT_PROXY, libtest_arg2);
-      curl_easy_setopt(easy, CURLOPT_HTTPPROXYTUNNEL, 1L);
-    }
-    res = curl_easy_perform(easy);
-    if(res) {
-      printf("badness: %d\n", (int)res);
-    }
-    showem(easy, CURLH_HEADER);
-    if(libtest_arg2 && *libtest_arg2) {
-      /* now show connect headers only */
-      showem(easy, CURLH_CONNECT);
-    }
-    showem(easy, CURLH_1XX);
-    showem(easy, CURLH_TRAILER);
-    curl_easy_cleanup(easy);
+  /* if there's a proxy set, use it */
+  if(libtest_arg2 && *libtest_arg2) {
+    easy_setopt(easy, CURLOPT_PROXY, libtest_arg2);
+    easy_setopt(easy, CURLOPT_HTTPPROXYTUNNEL, 1L);
   }
+  res = curl_easy_perform(easy);
+  if(res)
+    goto test_cleanup;
+
+  showem(easy, CURLH_HEADER);
+  if(libtest_arg2 && *libtest_arg2) {
+    /* now show connect headers only */
+    showem(easy, CURLH_CONNECT);
+  }
+  showem(easy, CURLH_1XX);
+  showem(easy, CURLH_TRAILER);
+
+test_cleanup:
+  curl_easy_cleanup(easy);
   curl_global_cleanup();
-  return 0;
+  return (int)res;
 }

--- a/tests/libtest/lib1945.c
+++ b/tests/libtest/lib1945.c
@@ -52,30 +52,30 @@ static size_t write_cb(char *data, size_t n, size_t l, void *userp)
 int test(char *URL)
 {
   CURL *easy;
+  CURLcode res = CURLE_OK;
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  global_init(CURL_GLOBAL_DEFAULT);
 
-  easy = curl_easy_init();
-  if(easy) {
-    CURLcode res;
-    curl_easy_setopt(easy, CURLOPT_URL, URL);
-    curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
-    curl_easy_setopt(easy, CURLOPT_FOLLOWLOCATION, 1L);
-    /* ignores any content */
-    curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, write_cb);
+  easy_init(easy);
+  curl_easy_setopt(easy, CURLOPT_URL, URL);
+  curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
+  curl_easy_setopt(easy, CURLOPT_FOLLOWLOCATION, 1L);
+  /* ignores any content */
+  curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, write_cb);
 
-    /* if there's a proxy set, use it */
-    if(libtest_arg2 && *libtest_arg2) {
-      curl_easy_setopt(easy, CURLOPT_PROXY, libtest_arg2);
-      curl_easy_setopt(easy, CURLOPT_HTTPPROXYTUNNEL, 1L);
-    }
-    res = curl_easy_perform(easy);
-    if(res) {
-      printf("badness: %d\n", (int)res);
-    }
-    showem(easy, CURLH_CONNECT|CURLH_HEADER|CURLH_TRAILER|CURLH_1XX);
-    curl_easy_cleanup(easy);
+  /* if there's a proxy set, use it */
+  if(libtest_arg2 && *libtest_arg2) {
+    curl_easy_setopt(easy, CURLOPT_PROXY, libtest_arg2);
+    curl_easy_setopt(easy, CURLOPT_HTTPPROXYTUNNEL, 1L);
   }
+  res = curl_easy_perform(easy);
+  if(res) {
+    printf("badness: %d\n", (int)res);
+  }
+  showem(easy, CURLH_CONNECT|CURLH_HEADER|CURLH_TRAILER|CURLH_1XX);
+
+test_cleanup:
+  curl_easy_cleanup(easy);
   curl_global_cleanup();
-  return 0;
+  return (int)res;
 }

--- a/tests/libtest/lib1947.c
+++ b/tests/libtest/lib1947.c
@@ -36,54 +36,57 @@ static size_t writecb(char *data, size_t n, size_t l, void *userp)
 int test(char *URL)
 {
   CURL *curl;
-  CURLcode res;
+  CURLcode res = CURLE_OK;
+  struct curl_header *h;
+  int count = 0;
+  int origins;
 
-  curl_global_init(CURL_GLOBAL_DEFAULT);
+  global_init(CURL_GLOBAL_DEFAULT);
 
-  curl = curl_easy_init();
-  if(curl) {
-    struct curl_header *h;
-    int count = 0;
-    int origins;
+  easy_init(curl);
 
-    /* perform a request that involves redirection */
-    curl_easy_setopt(curl, CURLOPT_URL, URL);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
-    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-    res = curl_easy_perform(curl);
-    if(res)
-      fprintf(stderr, "curl_easy_perform() failed: %s\n",
-              curl_easy_strerror(res));
-
-    /* count the number of requests by reading the first header of each
-       request. */
-    origins = (CURLH_HEADER|CURLH_TRAILER|CURLH_CONNECT|
-               CURLH_1XX|CURLH_PSEUDO);
-    do {
-      h = curl_easy_nextheader(curl, origins, count, NULL);
-      if(h)
-        count++;
-    } while(h);
-    printf("count = %u\n", count);
-
-    /* perform another request - without redirect */
-    curl_easy_setopt(curl, CURLOPT_URL, libtest_arg2);
-    res = curl_easy_perform(curl);
-    if(res)
-      fprintf(stderr, "curl_easy_perform() failed: %s\n",
-              curl_easy_strerror(res));
-
-    /* count the number of requests again. */
-    count = 0;
-    do {
-      h = curl_easy_nextheader(curl, origins, count, NULL);
-      if(h)
-        count++;
-    } while(h);
-    printf("count = %u\n", count);
-    curl_easy_cleanup(curl);
+  /* perform a request that involves redirection */
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
+  easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+  res = curl_easy_perform(curl);
+  if(res) {
+    fprintf(stderr, "curl_easy_perform() failed: %s\n",
+            curl_easy_strerror(res));
+    goto test_cleanup;
   }
 
+  /* count the number of requests by reading the first header of each
+     request. */
+  origins = (CURLH_HEADER|CURLH_TRAILER|CURLH_CONNECT|
+             CURLH_1XX|CURLH_PSEUDO);
+  do {
+    h = curl_easy_nextheader(curl, origins, count, NULL);
+    if(h)
+      count++;
+  } while(h);
+  printf("count = %u\n", count);
+
+  /* perform another request - without redirect */
+  easy_setopt(curl, CURLOPT_URL, libtest_arg2);
+  res = curl_easy_perform(curl);
+  if(res) {
+    fprintf(stderr, "curl_easy_perform() failed: %s\n",
+            curl_easy_strerror(res));
+    goto test_cleanup;
+  }
+
+  /* count the number of requests again. */
+  count = 0;
+  do {
+    h = curl_easy_nextheader(curl, origins, count, NULL);
+    if(h)
+      count++;
+  } while(h);
+  printf("count = %u\n", count);
+
+test_cleanup:
+  curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return 0;
+  return (int)res;
 }

--- a/tests/libtest/lib1948.c
+++ b/tests/libtest/lib1948.c
@@ -44,36 +44,35 @@ static size_t put_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 int test(char *URL)
 {
   CURL *curl;
-  CURLcode res = CURLE_OUT_OF_MEMORY;
+  CURLcode res = CURLE_OK;
+  const char *testput = "This is test PUT data\n";
+  put_buffer pbuf;
 
   curl_global_init(CURL_GLOBAL_DEFAULT);
 
-  curl = curl_easy_init();
-  if(curl) {
-    const char *testput = "This is test PUT data\n";
-    put_buffer pbuf;
+  easy_init(curl);
 
-    /* PUT */
-    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
-    curl_easy_setopt(curl, CURLOPT_HEADER, 1L);
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, put_callback);
-    pbuf.buf = (char *)testput;
-    pbuf.len = strlen(testput);
-    curl_easy_setopt(curl, CURLOPT_READDATA, &pbuf);
-    curl_easy_setopt(curl, CURLOPT_INFILESIZE, (long)strlen(testput));
-    res = curl_easy_setopt(curl, CURLOPT_URL, URL);
-    if(!res)
-      res = curl_easy_perform(curl);
-    if(!res) {
-      /* POST */
-      curl_easy_setopt(curl, CURLOPT_POST, 1L);
-      curl_easy_setopt(curl, CURLOPT_POSTFIELDS, testput);
-      curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(testput));
-      res = curl_easy_perform(curl);
-    }
-    curl_easy_cleanup(curl);
-  }
+  /* PUT */
+  easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  easy_setopt(curl, CURLOPT_READFUNCTION, put_callback);
+  pbuf.buf = (char *)testput;
+  pbuf.len = strlen(testput);
+  easy_setopt(curl, CURLOPT_READDATA, &pbuf);
+  easy_setopt(curl, CURLOPT_INFILESIZE, (long)strlen(testput));
+  easy_setopt(curl, CURLOPT_URL, URL);
+  res = curl_easy_perform(curl);
+  if(res)
+    goto test_cleanup;
 
+  /* POST */
+  easy_setopt(curl, CURLOPT_POST, 1L);
+  easy_setopt(curl, CURLOPT_POSTFIELDS, testput);
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(testput));
+  res = curl_easy_perform(curl);
+
+test_cleanup:
+  curl_easy_cleanup(curl);
   curl_global_cleanup();
   return (int)res;
 }

--- a/tests/libtest/lib2306.c
+++ b/tests/libtest/lib2306.c
@@ -33,18 +33,22 @@ int test(char *URL)
 {
   /* first a fine GET response, then a bad one */
   CURL *cl;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
 
-  cl = curl_easy_init();
-  curl_easy_setopt(cl, CURLOPT_URL, URL);
-  curl_easy_setopt(cl, CURLOPT_VERBOSE, 1L);
-  curl_easy_perform(cl);
+  easy_init(cl);
+  easy_setopt(cl, CURLOPT_URL, URL);
+  easy_setopt(cl, CURLOPT_VERBOSE, 1L);
+  res = curl_easy_perform(cl);
+  if(res)
+    goto test_cleanup;
 
   /* reuse handle, do a second transfer */
-  curl_easy_setopt(cl, CURLOPT_URL, URL2);
-  curl_easy_perform(cl);
+  easy_setopt(cl, CURLOPT_URL, URL2);
+  res = curl_easy_perform(cl);
+
+test_cleanup:
   curl_easy_cleanup(cl);
   curl_global_cleanup();
   return res;

--- a/tests/libtest/lib519.c
+++ b/tests/libtest/lib519.c
@@ -49,6 +49,8 @@ int test(char *URL)
 
   /* get first page */
   res = curl_easy_perform(curl);
+  if(res)
+    goto test_cleanup;
 
   test_setopt(curl, CURLOPT_USERPWD, "anothermonster:inwardrobe");
 

--- a/tests/libtest/lib541.c
+++ b/tests/libtest/lib541.c
@@ -99,7 +99,9 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_READDATA, hd_src);
 
   /* Now run off and do what you've been told! */
-  curl_easy_perform(curl);
+  res = curl_easy_perform(curl);
+  if(res)
+    goto test_cleanup;
 
   /* and now upload the exact same again, but without rewinding so it already
      is at end of file */

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -213,7 +213,6 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_PROXYAUTH, (long)CURLAUTH_ANY);
 
   res = curl_easy_perform(curl);
-  fprintf(stderr, "curl_easy_perform = %d\n", (int)res);
 
 test_cleanup:
 

--- a/tests/libtest/lib574.c
+++ b/tests/libtest/lib574.c
@@ -25,6 +25,8 @@
 
 #include "memdebug.h"
 
+#define TEST_HANG_TIMEOUT (60 * 1000)
+
 static int new_fnmatch(void *ptr,
                        const char *pattern, const char *string)
 {
@@ -54,6 +56,7 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
   test_setopt(curl, CURLOPT_FNMATCH_FUNCTION, new_fnmatch);
+  test_setopt(curl, CURLOPT_TIMEOUT_MS, (long) TEST_HANG_TIMEOUT);
 
   res = curl_easy_perform(curl);
   if(res) {

--- a/tests/libtest/lib586.c
+++ b/tests/libtest/lib586.c
@@ -131,7 +131,7 @@ static void *fire(void *ptr)
 /* test function */
 int test(char *URL)
 {
-  int res;
+  CURLcode res = CURLE_OK;
   CURLSHcode scode = CURLSHE_OK;
   char *url;
   struct Tdata tdata;
@@ -184,8 +184,6 @@ int test(char *URL)
   }
 
 
-  res = 0;
-
   /* start treads */
   for(i = 1; i <= THREADS; i++) {
 
@@ -215,7 +213,7 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_SHARE, share);
 
   printf("PERFORM\n");
-  curl_easy_perform(curl);
+  res = curl_easy_perform(curl);
 
   /* try to free share, expect to fail because share is in use */
   printf("try SHARE_CLEANUP...\n");

--- a/tests/libtest/lib589.c
+++ b/tests/libtest/lib589.c
@@ -56,6 +56,8 @@ int test(char *URL)
     test_setopt(curl, CURLOPT_MIMEPOST, mime);
     res = curl_easy_perform(curl);
     curl_mime_free(mime);
+    if(res)
+      goto test_cleanup;
   }
 #endif
 


### PR DESCRIPTION
- Use more test macros to catch errors in libtests early
- Log more in case of errors
- Adjust timeouts for improved reliability
- ignore "timing-dependent" test in CMake CI builds