### PR TITLE
OpenSSL: Include SIG and KEM algorithms in verbose

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -79,6 +79,8 @@
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
 #include <openssl/pkcs12.h>
+#include <openssl/tls1.h>
+#include <openssl/evp.h>
 
 #if (OPENSSL_VERSION_NUMBER >= 0x0090808fL) && !defined(OPENSSL_NO_OCSP)
 #include <openssl/ocsp.h>
@@ -3996,7 +3998,7 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
 #if defined(OPENSSL_VERSION_MAJOR) && defined(OPENSSL_VERSION_MINOR) && \
     (OPENSSL_VERSION_MAJOR >= 3) && (OPENSSL_VERSION_MINOR >= 2)
       negotiated_group_name = SSL_get0_group_name(backend->handle);
-#else
+#elif defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
     negotiated_group_name =
       OBJ_nid2sn(SSL_get_negotiated_group(backend->handle) & 0x0000FFFF);
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3986,21 +3986,23 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
     }
   }
   else {
-    int psigtype_nid;
+    int psigtype_nid = NID_undef;
     const char *negotiated_group_name = NULL;
 
     /* we connected fine, we're not waiting for anything else. */
     connssl->connecting_state = ssl_connect_3;
 
-    /* Informational message */
-    psigtype_nid = NID_undef;
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
     SSL_get_peer_signature_type_nid(backend->handle, &psigtype_nid);
 #if (OPENSSL_VERSION_NUMBER >= 0x30200000L)
-      negotiated_group_name = SSL_get0_group_name(backend->handle);
-#elif (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+    negotiated_group_name = SSL_get0_group_name(backend->handle);
+#else
     negotiated_group_name =
       OBJ_nid2sn(SSL_get_negotiated_group(backend->handle) & 0x0000FFFF);
 #endif
+#endif
+
+    /* Informational message */
     infof(data, "SSL connection using %s / %s / %s / %s",
           SSL_get_version(backend->handle),
           SSL_get_cipher(backend->handle),
@@ -4109,10 +4111,6 @@ static CURLcode servercert(struct Curl_cfilter *cf,
   BIO *mem = BIO_new(BIO_s_mem());
   struct ossl_ssl_backend_data *backend =
     (struct ossl_ssl_backend_data *)connssl->backend;
-  STACK_OF(X509) *certstack;
-  long verify_result;
-  int num_cert_levels;
-  int cert_level;
 
   DEBUGASSERT(backend);
 
@@ -4276,46 +4274,53 @@ static CURLcode servercert(struct Curl_cfilter *cf,
   }
 
 #if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
-  verify_result = SSL_get_verify_result(backend->handle);
-  if(verify_result != X509_V_OK)
-    certstack = SSL_get_peer_cert_chain(backend->handle);
-  else
-    certstack = SSL_get0_verified_chain(backend->handle);
-  num_cert_levels = sk_X509_num(certstack);
-  OpenSSL_add_all_algorithms();
-  OpenSSL_add_all_digests();
+  {
+    STACK_OF(X509) *certstack;
+    long verify_result;
+    int num_cert_levels;
+    int cert_level;
 
-  for(cert_level = 0; cert_level < num_cert_levels; cert_level++) {
-    char cert_algorithm[80] = "";
-    char group_name[80] = "";
-    char group_name_final[80] = "";
-    const X509_ALGOR *palg_cert = NULL;
-    const ASN1_OBJECT *paobj_cert = NULL;
-    X509 *current_cert;
-    EVP_PKEY *current_pkey;
-    int key_bits;
-    int key_sec_bits;
-    int get_group_name;
+    verify_result = SSL_get_verify_result(backend->handle);
+    if(verify_result != X509_V_OK)
+      certstack = SSL_get_peer_cert_chain(backend->handle);
+    else
+      certstack = SSL_get0_verified_chain(backend->handle);
+    num_cert_levels = sk_X509_num(certstack);
+    OpenSSL_add_all_algorithms();
+    OpenSSL_add_all_digests();
 
-    current_cert = sk_X509_value(certstack, cert_level);
+    for(cert_level = 0; cert_level < num_cert_levels; cert_level++) {
+      char cert_algorithm[80] = "";
+      char group_name[80] = "";
+      char group_name_final[80] = "";
+      const X509_ALGOR *palg_cert = NULL;
+      const ASN1_OBJECT *paobj_cert = NULL;
+      X509 *current_cert;
+      EVP_PKEY *current_pkey;
+      int key_bits;
+      int key_sec_bits;
+      int get_group_name;
 
-    X509_get0_signature(NULL, &palg_cert, current_cert);
-    X509_ALGOR_get0(&paobj_cert, NULL, NULL, palg_cert);
-    OBJ_obj2txt(cert_algorithm, sizeof(cert_algorithm), paobj_cert, 0);
+      current_cert = sk_X509_value(certstack, cert_level);
 
-    current_pkey = X509_get0_pubkey(current_cert);
-    key_bits = EVP_PKEY_bits(current_pkey);
-    key_sec_bits = EVP_PKEY_get_security_bits(current_pkey);
-    get_group_name = EVP_PKEY_get_group_name(current_pkey, group_name,
-                                             sizeof(group_name), NULL);
-    msnprintf(group_name_final, sizeof(group_name_final), "/%s", group_name);
+      X509_get0_signature(NULL, &palg_cert, current_cert);
+      X509_ALGOR_get0(&paobj_cert, NULL, NULL, palg_cert);
+      OBJ_obj2txt(cert_algorithm, sizeof(cert_algorithm), paobj_cert, 0);
 
-    infof(data,
-          "  Certificate level %d: "
-          "Public key type %s%s (%d/%d Bits/secBits), signed using %s",
-          cert_level, EVP_PKEY_get0_type_name(current_pkey),
-          get_group_name == 0 ? "" : group_name_final,
-          key_bits, key_sec_bits, cert_algorithm);
+      current_pkey = X509_get0_pubkey(current_cert);
+      key_bits = EVP_PKEY_bits(current_pkey);
+      key_sec_bits = EVP_PKEY_get_security_bits(current_pkey);
+      get_group_name = EVP_PKEY_get_group_name(current_pkey, group_name,
+                                               sizeof(group_name), NULL);
+      msnprintf(group_name_final, sizeof(group_name_final), "/%s", group_name);
+
+      infof(data,
+            "  Certificate level %d: "
+            "Public key type %s%s (%d/%d Bits/secBits), signed using %s",
+            cert_level, EVP_PKEY_get0_type_name(current_pkey),
+            get_group_name == 0 ? "" : group_name_final,
+            key_bits, key_sec_bits, cert_algorithm);
+    }
   }
 #endif
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3988,9 +3988,22 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
     connssl->connecting_state = ssl_connect_3;
 
     /* Informational message */
-    infof(data, "SSL connection using %s / %s",
+    int psigtype_nid;
+    psigtype_nid = NID_undef;
+    SSL_get_peer_signature_type_nid(backend->handle, &psigtype_nid);
+    const char *negotiated_group_name;
+#if defined(OPENSSL_VERSION_MAJOR) && defined(OPENSSL_VERSION_MINOR) && \
+    (OPENSSL_VERSION_MAJOR >= 3) && (OPENSSL_VERSION_MINOR >= 2)
+      negotiated_group_name = SSL_get0_group_name(backend->handle);
+#else
+    negotiated_group_name =
+      OBJ_nid2sn(0x0000FFFF & SSL_get_negotiated_group(backend->handle));
+#endif
+    infof(data, "SSL connection using %s / %s / %s / %s",
           SSL_get_version(backend->handle),
-          SSL_get_cipher(backend->handle));
+          SSL_get_cipher(backend->handle),
+          negotiated_group_name == NULL ? NULL : negotiated_group_name,
+          OBJ_nid2sn(psigtype_nid));
 
 #ifdef HAS_ALPN
     /* Sets data and len to negotiated protocol, len is 0 if no protocol was
@@ -4254,6 +4267,48 @@ static CURLcode servercert(struct Curl_cfilter *cf,
     }
     else
       infof(data, " SSL certificate verify ok.");
+  }
+
+  STACK_OF(X509) *certstack;
+  long verify_result = SSL_get_verify_result(backend->handle);
+  if(verify_result != X509_V_OK)
+    certstack = SSL_get_peer_cert_chain(backend->handle);
+  else
+    certstack = SSL_get0_verified_chain(backend->handle);
+  int num_cert_levels = sk_X509_num(certstack);
+  OpenSSL_add_all_algorithms();
+  OpenSSL_add_all_digests();
+
+  for(int cert_level = 0; cert_level < num_cert_levels; cert_level++) {
+    char cert_algorithm[80];
+    char group_name[80];
+    char group_name_final[80];
+    const X509_ALGOR *palg_cert = NULL;
+    const ASN1_OBJECT *paobj_cert = NULL;
+
+    X509 *current_cert = NULL;
+    current_cert = sk_X509_value(certstack, cert_level);
+
+    X509_get0_signature(NULL, &palg_cert, current_cert);
+    X509_ALGOR_get0(&paobj_cert, NULL, NULL, palg_cert);
+    OBJ_obj2txt(cert_algorithm, sizeof(cert_algorithm), paobj_cert, 0);
+
+    EVP_PKEY *current_pkey;
+    current_pkey = X509_get0_pubkey(current_cert);
+    int key_bits = EVP_PKEY_bits(current_pkey);
+    int key_sec_bits = EVP_PKEY_get_security_bits(current_pkey);
+    int get_group_name = EVP_PKEY_get_group_name(current_pkey,
+                                                 group_name,
+                                                 sizeof(group_name),
+                                                 NULL);
+    msnprintf(group_name_final, sizeof(group_name_final), "/%s", group_name);
+
+    infof(data,
+          "  Certificate level %d: "
+          "Public key type %s%s (%d/%d Bits/secBits), signed using %s",
+          cert_level, EVP_PKEY_get0_type_name(current_pkey),
+          get_group_name == 0 ? "" : group_name_final,
+          key_bits, key_sec_bits, cert_algorithm);
   }
 
 #if (OPENSSL_VERSION_NUMBER >= 0x0090808fL) && !defined(OPENSSL_NO_TLSEXT) && \


### PR DESCRIPTION
Currently the verbose output does not include which algorithms are used for the signature and key exchange when using OpenSSL. Including the algorithms used will enable better debugging when working on using new algorithm implementations. Know what algorithms are used has become more important with the fast growing research into new quantum-safe algorithms.

This implementation includes a build time check for the OpenSSL version to use a new function that will be included in OpenSSL 3.2 that was introduced in openssl/openssl@6866824

Based-on-patch-by: martinschmatz <mrt@zurich.ibm.com>