### PR TITLE
tests: close the shell used to start sshd

### DIFF
--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -1175,7 +1175,8 @@ if ($sshdid =~ /OpenSSH-Windows/) {
 #***************************************************************************
 # Start the ssh server daemon without forking it
 #
-my $rc = system($cmd);
+# "exec" avoids the shell process sticking around
+my $rc = system("exec " . $cmd);
 if($rc == -1) {
     logmsg "\"$sshd\" failed with: $!\n";
 }


### PR DESCRIPTION
This shell isn't needed once sshd starts, so use "exec" so it doesn't
stick around.

Closes #X