### PR TITLE
cf-socket, simulate slow/blocked receives in debug

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -781,6 +781,8 @@ struct cf_socket_ctx {
 #ifdef DEBUGBUILD
   int wblock_percent;                /* percent of writes doing EAGAIN */
   int wpartial_percent;              /* percent of bytes written in send */
+  int rblock_percent;                /* percent of reads doing EAGAIN */
+  size_t recv_max;                  /* max enforced read size */
 #endif
   BIT(got_first_byte);               /* if first byte was received */
   BIT(accepted);                     /* socket was accepted, not connected */
@@ -810,6 +812,18 @@ static void cf_socket_ctx_init(struct cf_socket_ctx *ctx,
       long l = strtol(p, NULL, 10);
       if(l >= 0 && l <= 100)
         ctx->wpartial_percent = (int)l;
+    }
+    p = getenv("CURL_DBG_SOCK_RBLOCK");
+    if(p) {
+      long l = strtol(p, NULL, 10);
+      if(l >= 0 && l <= 100)
+        ctx->rblock_percent = (int)l;
+    }
+    p = getenv("CURL_DBG_SOCK_RMAX");
+    if(p) {
+      long l = strtol(p, NULL, 10);
+      if(l >= 0)
+        ctx->recv_max = (size_t)l;
     }
   }
 #endif
@@ -1357,6 +1371,27 @@ static ssize_t cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   fdsave = cf->conn->sock[cf->sockindex];
   cf->conn->sock[cf->sockindex] = ctx->sock;
+
+#ifdef DEBUGBUILD
+  /* simulate network blocking/partial reads */
+  if(cf->cft != &Curl_cft_udp && ctx->rblock_percent > 0) {
+    unsigned char c;
+    Curl_rand(data, &c, 1);
+    if(c >= ((100-ctx->rblock_percent)*256/100)) {
+      CURL_TRC_CF(data, cf, "recv(len=%zu) SIMULATE EWOULDBLOCK", len);
+      *err = CURLE_AGAIN;
+      nread = -1;
+      cf->conn->sock[cf->sockindex] = fdsave;
+      return nread;
+    }
+  }
+  if(cf->cft != &Curl_cft_udp && ctx->recv_max && ctx->recv_max < len) {
+    size_t orig_len = len;
+    len = ctx->recv_max;
+    CURL_TRC_CF(data, cf, "recv(len=%zu) SIMULATE max read of %zu bytes",
+                orig_len, len);
+  }
+#endif
 
   if(ctx->buffer_recv && !Curl_bufq_is_empty(&ctx->recvbuf)) {
     CURL_TRC_CF(data, cf, "recv from buffer");


### PR DESCRIPTION
Add 2 env variables for non-UDP sockets:
1. CURL_DBG_SOCK_RBLOCK: percentage of receive calls that randomly should return EAGAIN
2. CURL_DBG_SOCK_RMAX: max amount of bytes read from socket

similar to the existing CURL_DBG_SOCK_WBLOCK and CURL_DBG_SOCK_WPARTIAL. Documentation to be added once Jay's doc PR has landed.

### Why?

Tests were run locally on a macOS dev machine with different value for the variables. Only one var was used in tests to isolate problems. 

#### CURL_DBG_SOCK_RBLOCK

X percent of socket recv() calls return CURLE_AGAIN right away.

Interesting for cases where a subsequent read would normally be successful, but now is not.

| CURL_DBG_SOCK_RBLOCK | Failures |
|-------:|---- |
| 0 | - |
| 10 | 823 869 907 2302 |
| 50 | 823 869 907 2302 |
| 90 | 823 869 907 1474 2302 |


#### CURL_DBG_SOCK_RMAX

Calls to socket recv() with a buffer limit the length of the buffer to this value.

Interesting for cases where the network is slow or where the server sends in strange chunks or where a middle box is involved that buffers differently. Note that low values just trigger edge cases in taking in data deterministically. The failures could happen on "real" data as well, only with lower probability.

| CURL_DBG_SOCK_RMAX | Failures | Protocol |
|-------:|---- |---- |
| 500 | - |  |
| 250 | - |  |  	
| 125 | - |  |
| 120 | - |  |
| 118 | - |  |
| 117 | 	571 | RTSP |
| 116 | 	571 | RTSP |
| 115 | 	571 | RTSP |
| 110 | 	571 | RTSP |
| 100 | 	571 | RTSP |
| 75 | 	571 | RTSP |
| 50 | 	571 | RTSP |
| 48 | 	571 | RTSP |
| 45 | 	571 | RTSP |
| 44 | 	571 | RTSP |
| 43 | 	571 3100					 | RTSP |
| 37 | 	571 3100					 | RTSP |
| 25 | 	571 3100	 | RTSP |
| 23 | 	568 571 572 2302 3100 | RTSP WebSockets |
| 20 | 	568 571 572 577 3100	 | RTSP WebSockets |			
| 12 | 	567 568 569 570 571 572 577 1540 3100		 | RTSP WebSockets HTTP |
| 6 | 	457 567 568 569 570 571 572 577 1540 3100 | RTSP WebSockets HTTP |
| 5 | 	567 577 571 568 569 570 572 1540 3100 | RTSP WebSockets HTTP |
| 4 | 	567 569 571 568 570 572 577 981 982 1540 2302 3100 | RTSP WebSockets HTTP |
| 3 | 	232 457 567 568 569 570 571 572 577 980 983 1540 2302 3100 | RTSP WebSockets HTTP |
| 2  | 457 567 568 569 570 571 577 572 981 982 1190 1192 1194 1452 1540 2204 2302 3018 3100 | RTSP WebSockets HTTP IMAP POP3 |
| 1 | 	232 457 567 568 570 569 571 572 577 980 981 982 983 1190 1191 1192 1193 1194 1195 1198 1199 1452 1474 1540 1916 1917 2201 2204 2302 3017 3018 3100 | RTSP WebSockets HTTP IMAP POP3 MQTT TELNET |

command run:
```
make -j20 && (cd tests && make -j20 && ENV_VAR=xxx ./runtests.pl -a -j20)
```

curl build used:
```
curl 8.4.0-DEV (x86_64-apple-darwin22.6.0) libcurl/8.4.0-DEV OpenSSL/3.0.9 zlib/1.2.11 brotli/1.0.9 zstd/1.5.5 c-ares/1.19.1 libidn2/2.3.4 libssh2/1.11.0 nghttp2/1.56.0 ngtcp2/0.19.1 nghttp3/0.15.0 librtmp/2.3
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher gophers http https imap imaps ldap ldaps mqtt pop3 pop3s rtmp rtsp scp sftp smb smbs smtp smtps telnet tftp ws wss
Features: alt-svc AsynchDNS brotli Debug GSS-API HSTS HTTP2 HTTP3 HTTPS-proxy IDN IPv6 Kerberos Largefile libz NTLM SPNEGO SSL threadsafe TLS-SRP TrackMemory UnixSockets zstd
```