### PR TITLE
multi: set CURLM_CALL_MULTI_PERFORM after switch to DOING_MORE

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2221,6 +2221,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
             /* we're supposed to do more, but we need to sit down, relax
                and wait a little while first */
             multistate(data, MSTATE_DOING_MORE);
+            rc = CURLM_CALL_MULTI_PERFORM;
           }
           else {
             /* we're done with the DO, now DID */


### PR DESCRIPTION
Since there is nothing to wait for there. Avoids the hang reported in #12033

Reported-by: Dan Fandrich