### PR TITLE
cmake: re-add missed C89 headers for specific detections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1165,7 +1165,7 @@ check_symbol_exists(utimes        "${CURL_INCLUDES}" HAVE_UTIMES)
 
 check_symbol_exists(gettimeofday  "${CURL_INCLUDES}" HAVE_GETTIMEOFDAY)
 check_symbol_exists(closesocket   "${CURL_INCLUDES}" HAVE_CLOSESOCKET)
-check_symbol_exists(sigsetjmp     "${CURL_INCLUDES}" HAVE_SIGSETJMP)
+check_symbol_exists(sigsetjmp     "${CURL_INCLUDES};setjmp.h" HAVE_SIGSETJMP)
 check_symbol_exists(getpass_r     "${CURL_INCLUDES}" HAVE_GETPASS_R)
 check_symbol_exists(getpwuid      "${CURL_INCLUDES}" HAVE_GETPWUID)
 check_symbol_exists(getpwuid_r    "${CURL_INCLUDES}" HAVE_GETPWUID_R)
@@ -1175,10 +1175,10 @@ check_symbol_exists(gmtime_r      "${CURL_INCLUDES};stdlib.h;time.h" HAVE_GMTIME
 
 check_symbol_exists(gethostbyname_r "${CURL_INCLUDES}" HAVE_GETHOSTBYNAME_R)
 
-check_symbol_exists(signal         "${CURL_INCLUDES}" HAVE_SIGNAL)
+check_symbol_exists(signal         "${CURL_INCLUDES};signal.h" HAVE_SIGNAL)
 check_symbol_exists(strtoll        "${CURL_INCLUDES};stdlib.h" HAVE_STRTOLL)
 check_symbol_exists(strerror_r     "${CURL_INCLUDES};stdlib.h;string.h" HAVE_STRERROR_R)
-check_symbol_exists(siginterrupt   "${CURL_INCLUDES}" HAVE_SIGINTERRUPT)
+check_symbol_exists(siginterrupt   "${CURL_INCLUDES};signal.h" HAVE_SIGINTERRUPT)
 check_symbol_exists(getaddrinfo    "${CURL_INCLUDES};stdlib.h;string.h" HAVE_GETADDRINFO)
 check_symbol_exists(getifaddrs     "${CURL_INCLUDES};stdlib.h" HAVE_GETIFADDRS)
 check_symbol_exists(freeaddrinfo   "${CURL_INCLUDES}" HAVE_FREEADDRINFO)


### PR DESCRIPTION
We removed C89 `setjmp.h` and `signal.h` detections and excluded them
from the global header list we use when detecting functions [1]. Then
missed to re-add these headers to the specific functions which need
them to be detected [2]. Fix this omission in this patch.

[1] Follow-up to 3795fcde995d96db641ddbcc8a04f9f0f03bef9f #11951
[2] Follow-up to 96c29900bcec32dd6bc8e9857c8871ff4b8b8ed9 #11940

Closes #12043

---

`sigsetjmp` has a second detection attempt documented as 'special' in the comments. However this detection uses the same method as the first attempt, with the difference of using `setjmp.h` header only, without including the rest of non-standard headers detected. It detects both function and macro like the first attempt. This second attempt seems redundant. It's been there since the initial commit of CMake support.
