### PR TITLE
appveyor: bump mingw-w64 job to gcc 13 (was: 8)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -121,8 +121,8 @@ environment:
       DISABLED_TESTS: '!1139 !1501'
       ADD_PATH: 'C:\msys64\usr\bin'
     # generated CMake-based MSYS Makefiles builds (mingw cross-compiling)
-    - job_name: 'CMake, mingw-w64, gcc 8, Debug x64, Schannel, Static, Unicode, Unity'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
+    - job_name: 'CMake, mingw-w64, gcc 13, Debug x64, Schannel, Static, Unicode, Unity'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'MSYS Makefiles'
       PRJ_CFG: Debug
@@ -131,7 +131,7 @@ environment:
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
       DISABLED_TESTS: '!1086 !1139 !1451 !1501'
-      ADD_PATH: 'C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0\mingw64\bin;C:\msys64\usr\bin'
+      ADD_PATH: 'C:\msys64\mingw64\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
       UNITY: 'ON'


### PR DESCRIPTION
This sets gcc 6, 7, 9, 13 in our test mix (was: 6, 7, 8, 9).
Adding a modern gcc version to the tests.

(The gcc 8 job used to take around 50 minutes. The new image with gcc 13
finished in 32, 35, 34 minutes in the 3 test runs so far.)

It also adds a modern CMake version and OS env to our mingw-w64 builds.

Closes #12051
