### PR TITLE
multi: do CURLM_CALL_MULTI_PERFORM at two more places

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2125,9 +2125,11 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       }
       if(!result)
         result = protocol_connect(data, &protocol_connected);
-      if(!result && !protocol_connected)
+      if(!result && !protocol_connected) {
         /* switch to waiting state */
         multistate(data, MSTATE_PROTOCONNECTING);
+        rc = CURLM_CALL_MULTI_PERFORM;
+      }
       else if(!result) {
         /* protocol connect has completed, go WAITDO or DO */
         multistate(data, MSTATE_DO);
@@ -2214,6 +2216,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
             /* DO was not completed in one function call, we must continue
                DOING... */
             multistate(data, MSTATE_DOING);
+            rc = CURLM_CALL_MULTI_PERFORM;
           }
 
           /* after DO, go DO_DONE... or DO_MORE */


### PR DESCRIPTION
... when it does a state transition but there is no particular socket or timer activity. This was made apparent when commit b5bb84c remove a superflous timer expiry.

Reported-by: Dan Fandrich.
Fixes #12033