### PR TITLE
setopt: ignore CURLOPT_PRIVATE on internal handles

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2370,7 +2370,15 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     /*
      * Set private data pointer.
      */
-    data->set.private_data = va_arg(param, void *);
+    if(!data->internal)
+      data->set.private_data = va_arg(param, void *);
+    else {
+      /* Ignore setting private data on internal handles since the user is
+         allowed to distinguish their handles from internal handles by setting
+         private data. */
+      DEBUGASSERT(0);
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     break;
 
   case CURLOPT_MAXFILESIZE:


### PR DESCRIPTION
- If CURLOPT_PRIVATE is set on an internal handle then ignore it. Also throw an assertion for debug builds.

It's been documented that the user may set CURLOPT_PRIVATE on their handles to distinguish them from private handles, therefore we cannot allow CURLOPT_PRIVATE to be set on internal handles.

Ref: https://github.com/curl/curl/blob/0dc40b2a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3#L85-L89
Ref: https://github.com/curl/curl/blob/0dc40b2a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3#L73-L79

Closes #xxxx