### PR TITLE
h3: fix BoringSSL build

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -430,6 +430,7 @@ static CURLcode quic_ssl_ctx(SSL_CTX **pssl_ctx,
     }
   }
 
+#ifndef OPENSSL_IS_BORINGSSL
   {
     const char *ciphers13 = conn->ssl_config.cipher_list13 ?
       conn->ssl_config.cipher_list13 : QUIC_CIPHERS;
@@ -439,6 +440,7 @@ static CURLcode quic_ssl_ctx(SSL_CTX **pssl_ctx,
     }
     infof(data, "QUIC cipher selection: %s", ciphers13);
   }
+#endif
 
   /* Open the file if a TLS or QUIC backend has not done this before. */
   Curl_tls_keylog_open();


### PR DESCRIPTION
Add guard around `SSL_CTX_set_ciphersuites()` use.

Bug: https://github.com/curl/curl/pull/12065#issuecomment-1752171885

Follow-up to aa9a6a177017e4b74d33cdf85a3594900f4a7f81

Co-authored-by: Jay Satiro
Closes #xxxxx