### PR TITLE
CI, pytest slow network tests, remove

### DIFF
--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -268,12 +268,3 @@ jobs:
       env:
         TFLAGS: "${{ matrix.build.tflags }}"
         CURL_CI: github
-
-    - run: pytest -v tests
-      name: 'run pytest with slowed network'
-      env:
-        # 33% of sends are EAGAINed
-        CURL_DBG_SOCK_WBLOCK: 33
-        # only 80% of data > 10 bytes is send
-        CURL_DBG_SOCK_WPARTIAL: 80
-        CURL_CI: github


### PR DESCRIPTION
- remove these tests as they are currently not reliable in our CI setups.