### PR TITLE
dynhds: fix null pointer deref compiler warnings

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -929,10 +929,18 @@ static CURLcode proxy_h2_submit(int32_t *pstream_id,
 
   for(i = 0; i < nheader; ++i) {
     struct dynhds_entry *e = Curl_dynhds_getn(&h2_headers, i);
-    nva[i].name = (unsigned char *)e->name;
-    nva[i].namelen = e->namelen;
-    nva[i].value = (unsigned char *)e->value;
-    nva[i].valuelen = e->valuelen;
+    if(e) {
+      nva[i].name = (unsigned char *)e->name;
+      nva[i].namelen = e->namelen;
+      nva[i].value = (unsigned char *)e->value;
+      nva[i].valuelen = e->valuelen;
+    }
+    else {
+      nva[i].name = NULL;
+      nva[i].namelen = 0;
+      nva[i].value = NULL;
+      nva[i].valuelen = 0;
+    }
     nva[i].flags = NGHTTP2_NV_FLAG_NONE;
   }
 

--- a/lib/dynhds.c
+++ b/lib/dynhds.c
@@ -171,7 +171,7 @@ CURLcode Curl_dynhds_add(struct dynhds *dynhds,
   if(dynhds->strs_len + namelen + valuelen > dynhds->max_strs_size)
     return CURLE_OUT_OF_MEMORY;
 
-entry = entry_new(name, namelen, value, valuelen, dynhds->opts);
+  entry = entry_new(name, namelen, value, valuelen, dynhds->opts);
   if(!entry)
     goto out;
 
@@ -364,4 +364,3 @@ CURLcode Curl_dynhds_h1_dprint(struct dynhds *dynhds, struct dynbuf *dbuf)
 
   return result;
 }
-

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2062,10 +2062,18 @@ static ssize_t h2_submit(struct stream_ctx **pstream,
 
   for(i = 0; i < nheader; ++i) {
     struct dynhds_entry *e = Curl_dynhds_getn(&h2_headers, i);
-    nva[i].name = (unsigned char *)e->name;
-    nva[i].namelen = e->namelen;
-    nva[i].value = (unsigned char *)e->value;
-    nva[i].valuelen = e->valuelen;
+    if(e) {
+      nva[i].name = (unsigned char *)e->name;
+      nva[i].namelen = e->namelen;
+      nva[i].value = (unsigned char *)e->value;
+      nva[i].valuelen = e->valuelen;
+    }
+    else {
+      nva[i].name = NULL;
+      nva[i].namelen = 0;
+      nva[i].value = NULL;
+      nva[i].valuelen = 0;
+    }
     nva[i].flags = NGHTTP2_NV_FLAG_NONE;
   }
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1704,10 +1704,18 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
 
   for(i = 0; i < nheader; ++i) {
     struct dynhds_entry *e = Curl_dynhds_getn(&h2_headers, i);
-    nva[i].name = (unsigned char *)e->name;
-    nva[i].namelen = e->namelen;
-    nva[i].value = (unsigned char *)e->value;
-    nva[i].valuelen = e->valuelen;
+    if(e) {
+      nva[i].name = (unsigned char *)e->name;
+      nva[i].namelen = e->namelen;
+      nva[i].value = (unsigned char *)e->value;
+      nva[i].valuelen = e->valuelen;
+    }
+    else {
+      nva[i].name = NULL;
+      nva[i].namelen = 0;
+      nva[i].value = NULL;
+      nva[i].valuelen = 0;
+    }
     nva[i].flags = NGHTTP3_NV_FLAG_NONE;
   }
 


### PR DESCRIPTION
Fix potential NULL pointer dereferences as reported by gcc 9.2.0.

Fixes #12076
Closes #12079

---

Test build with this fix: https://github.com/curl/curl-for-win/actions/runs/6469513801/job/17563723495
