### PR TITLE
checksrc: ban internal assignment of user's private_data

### DIFF
--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -61,10 +61,6 @@ void Curl_debug(struct Curl_easy *data, curl_infotype type,
       "* ", "< ", "> ", "{ ", "} ", "{ ", "} " };
     if(data->set.fdebug) {
       bool inCallback = Curl_is_in_callback(data);
-      /* CURLOPT_DEBUGFUNCTION doc says the user may set CURLOPT_PRIVATE to
-         distinguish their handle from internal handles. */
-      if(data->internal)
-        DEBUGASSERT(!data->set.private_data);
       Curl_set_in_callback(data, true);
       (void)(*data->set.fdebug)(data, type, ptr, size, data->set.debugdata);
       Curl_set_in_callback(data, inCallback);

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -339,9 +339,10 @@ static CURLcode dohprobe(struct Curl_easy *data,
     doh->set.dohfor = data; /* identify for which transfer this is done */
     p->easy = doh;
 
-    /* DoH private_data must be null because the user must have a way to
-       distinguish their transfer's handle from DoH handles in user
-       callbacks (ie SSL CTX callback). */
+    /* DoH handles must not inherit private_data. The handles may be passed to
+       the user via callbacks and the user will be able to identify them as
+       internal handles because private data is not set. The user can then set
+       private_data via CURLOPT_PRIVATE if they so choose. */
     DEBUGASSERT(!doh->set.private_data);
 
     if(curl_multi_add_handle(multi, doh))

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2370,6 +2370,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     /*
      * Set private data pointer.
      */
+    /* !checksrc! disable PRIVATEDATA 1 */
     data->set.private_data = va_arg(param, void *);
     break;
 

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -83,6 +83,7 @@ my %warnings = (
     'ONELINECONDITION' => 'conditional block on the same line as the if()',
     'OPENCOMMENT'      => 'file ended with a /* comment still "open"',
     'PARENBRACE'       => '){ without sufficient space',
+    'PRIVATEDATA'      => 'private_data is user only, not for internal use',
     'RETURNNOSPACE'    => 'return without space',
     'SEMINOSPACE'      => 'semicolon without following space',
     'SIZEOFNOPAREN'    => 'use of sizeof without parentheses',
@@ -757,6 +758,14 @@ sub scanfile {
                           $line, length($1), $file, $ol,
                           "use of non-binary fopen without FOPEN_* macro: $mode");
             }
+        }
+
+        # scan for assignment of private_data
+        # private_data is user only (via CURLOPT_PRIVATE), not for internal use
+        if($l =~ /(.*(?:\.|->))(private_data) *=/) {
+            checkwarn("PRIVATEDATA",
+                      $line, length($1), $file, $ol,
+                      "use of $2 is banned");
         }
 
         # check for open brace first on line but not first column only alert


### PR DESCRIPTION
- Add a rule 'PRIVATEDATA' in checksrc to disallow use of private_data member assignment.

- Remove assertion that private_data is not set on an internal handle, since the user may set it on the handle via CURLOPT_PRIVATE.

This is my second take on a proactive ban to ensure that we do not set private_data on internal handles for our own use, since those handles may at some point be exposed to the user (eg debug callback).

We already tell the user that "If you need to distinguish your curl handle from internal handles then set CURLOPT_PRIVATE on your handle."

Therefore, private_data must not be assigned to for internal handles by libcurl but may later be assigned to by the user (via CURLOPT_PRIVATE).

Ref: https://github.com/curl/curl/pull/12060
Ref: https://github.com/curl/curl/blob/0dc40b2a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.3#L85-L89
Ref: https://github.com/curl/curl/blob/0dc40b2a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.3#L73-L79

Closes #xxxx