### PR TITLE
lib: fix gcc warning

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -693,11 +693,11 @@ evaluate:
   result = CURLE_COULDNT_CONNECT;
   for(i = 0; i < sizeof(ctx->baller)/sizeof(ctx->baller[0]); i++) {
     struct eyeballer *baller = ctx->baller[i];
+    if(!baller)
+      continue;
     CURL_TRC_CF(data, cf, "%s assess started=%d, result=%d",
-                baller?baller->name:NULL,
-                baller?baller->has_started:0,
-                baller?baller->result:0);
-    if(baller && baller->has_started && baller->result) {
+                baller->name, baller->has_started, baller->result);
+    if(baller->has_started && baller->result) {
       result = baller->result;
       break;
     }


### PR DESCRIPTION
Do not pass NULL to printf %s.

Seen with gcc 13.2.0 on Debian:
```
.../curl/lib/connect.c:696:27: warning: '%s' directive argument is null [-Wformat-overflow=]
```
Ref: https://github.com/curl/curl-for-win/actions/runs/6476161689/job/17584426483#step:3:11104

Ref: #10284
Co-authored-by: Jay Satiro
Closes #12082

---

```
In function 'is_connected',
    inlined from 'cf_he_connect' at /home/runner/work/curl-for-win/curl-for-win/curl/lib/connect.c:906:16:
/home/runner/work/curl-for-win/curl-for-win/curl/lib/connect.c:696:27: warning: '%s' directive argument is null [-Wformat-overflow=]
  696 |     CURL_TRC_CF(data, cf, "%s assess started=%d, result=%d",
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/runner/work/curl-for-win/curl-for-win/curl/lib/curl_trc.h:123:38: note: in definition of macro 'CURL_TRC_CF'
  123 |          Curl_trc_cf_infof(data, cf, __VA_ARGS__); } while(0)
      |                                      ^~~~~~~~~~~
In file included from /home/runner/work/curl-for-win/curl-for-win/curl/bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:49:
/home/runner/work/curl-for-win/curl-for-win/curl/lib/connect.c: In function 'cf_he_connect':
/home/runner/work/curl-for-win/curl-for-win/curl/lib/connect.c:696:28: note: format string is defined here
  696 |     CURL_TRC_CF(data, cf, "%s assess started=%d, result=%d",
      |                            ^~
make[2]: Leaving directory '/home/runner/work/curl-for-win/curl-for-win/curl/bld'
```
