### PR TITLE
build: add `src/.checksrc` to source tarball

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -89,7 +89,7 @@ CLEANFILES = tool_hugehelp.c
 NROFF=env LC_ALL=C @NROFF@ @MANOPT@ 2>/dev/null # figured out by the configure script
 
 EXTRA_DIST = mkhelp.pl \
- Makefile.mk curl.rc Makefile.inc CMakeLists.txt
+ Makefile.mk curl.rc Makefile.inc CMakeLists.txt .checksrc
 
 # Use absolute directory to disable VPATH
 MANPAGE=$(abs_top_builddir)/docs/curl.1


### PR DESCRIPTION
Regression from e5bb88b8f824ed87620bd923552534c83c2a516e #11958

Bug: https://github.com/curl/curl/pull/11958#issuecomment-1757079071
Reported-by: Romain Geissler
Fixes #12084
Closes #12085
