### PR TITLE
tool: fix --capath when proxy support is disabled

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1776,7 +1776,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
                                   (config->proxy_capath ?
                                    config->proxy_capath :
                                    config->capath));
-          if(result == CURLE_NOT_BUILT_IN) {
+          if((result == CURLE_NOT_BUILT_IN) ||
+             (result == CURLE_UNKNOWN_OPTION)) {
             if(config->proxy_capath) {
               warnf(global,
                     "ignoring --proxy-capath, not supported by libcurl");


### PR DESCRIPTION
After 95e8515ca0, --capath always sets CURLOPT_PROXY_CAPATH, which fails with CURLE_UNKNOWN_OPTION when proxy support is disabled.