### PR TITLE
cmake: fix CURL_DISABLE_GETOPTIONS

### DIFF
--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -74,6 +74,9 @@
 /* disables FTP */
 #cmakedefine CURL_DISABLE_FTP 1
 
+/* disables curl_easy_options API for existing options to curl_easy_setopt */
+#cmakedefine CURL_DISABLE_GETOPTIONS 1
+
 /* disables GOPHER */
 #cmakedefine CURL_DISABLE_GOPHER 1
 


### PR DESCRIPTION
The option had no effet, since it was not in curl_config.h.cmake.