### PR TITLE
cmake: fix `HAVE_H_ERRNO_ASSIGNABLE` detection

### DIFF
--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -172,12 +172,16 @@ if(NOT DEFINED HAVE_GETADDRINFO_THREADSAFE)
     }" HAVE_H_ERRNO)
 
   if(NOT HAVE_H_ERRNO)
-    check_c_source_runs("${_source_epilogue}
-      int main(void)
-      {
-        h_errno = 2;
-        return h_errno != 0 ? 1 : 0;
-      }" HAVE_H_ERRNO_ASSIGNABLE)
+    if(NOT CMAKE_CROSSCOMPILING)
+      check_c_source_runs("${_source_epilogue}
+        int main(void)
+        {
+          h_errno = 2;
+          return h_errno != 0 ? 1 : 0;
+        }" HAVE_H_ERRNO_ASSIGNABLE)
+    else()
+      set(HAVE_H_ERRNO_ASSIGNABLE FALSE)
+    endif()
 
     if(NOT HAVE_H_ERRNO_ASSIGNABLE)
       check_c_source_compiles("${_source_epilogue}

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -154,6 +154,8 @@ endif()
 
 if(NOT DEFINED HAVE_GETADDRINFO_THREADSAFE)
 
+  # FIXME: This detection is likely broken.
+
   set(_save_epilogue "${_source_epilogue}")
   set(_source_epilogue "#undef inline")
 

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -154,8 +154,6 @@ endif()
 
 if(NOT DEFINED HAVE_GETADDRINFO_THREADSAFE)
 
-  # FIXME: This detection is likely broken.
-
   set(_save_epilogue "${_source_epilogue}")
   set(_source_epilogue "#undef inline")
 
@@ -174,16 +172,12 @@ if(NOT DEFINED HAVE_GETADDRINFO_THREADSAFE)
     }" HAVE_H_ERRNO)
 
   if(NOT HAVE_H_ERRNO)
-    if(NOT CMAKE_CROSSCOMPILING)
-      check_c_source_runs("${_source_epilogue}
-        int main(void)
-        {
-          h_errno = 2;
-          return h_errno != 0 ? 1 : 0;
-        }" HAVE_H_ERRNO_ASSIGNABLE)
-    else()
-      set(HAVE_H_ERRNO_ASSIGNABLE FALSE)
-    endif()
+    check_c_source_compiles("${_source_epilogue}
+      int main(void)
+      {
+        h_errno = 2;
+        return h_errno != 0 ? 1 : 0;
+      }" HAVE_H_ERRNO_ASSIGNABLE)
 
     if(NOT HAVE_H_ERRNO_ASSIGNABLE)
       check_c_source_compiles("${_source_epilogue}


### PR DESCRIPTION
Fix `HAVE_H_ERRNO_ASSIGNABLE` to not run, only compile its test snippet,
aligning this with autotools. This fixes an error when doing
cross-builds and also actually detects this feature. It affected systems
not allowlisted into this, e.g. SerenityOS.

We used this detection result to enable `HAVE_GETADDRINFO_THREADSAFE`.

Follow-up to 04a3a377d83fd72c4cf7a96c9cb6d44785e33264 #11979
Ref: #12095 (closed in favour of this patch)
Ref: #11964 (effort to sync cmake detections with autotools)

Reported-by: Kartatz on Github
Assisted-by: Kartatz on Github
Fixes #12093
Closes #12094
