### PR TITLE
HTTP/2, header conversion tightening

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -909,7 +909,6 @@ static CURLcode proxy_h2_submit(int32_t *pstream_id,
 {
   struct dynhds h2_headers;
   nghttp2_nv *nva = NULL;
-  unsigned int i;
   int32_t stream_id = -1;
   size_t nheader;
   CURLcode result;
@@ -920,20 +919,10 @@ static CURLcode proxy_h2_submit(int32_t *pstream_id,
   if(result)
     goto out;
 
-  nheader = Curl_dynhds_count(&h2_headers);
-  nva = malloc(sizeof(nghttp2_nv) * nheader);
+  nva = Curl_dynhds_to_nva(&h2_headers, &nheader);
   if(!nva) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
-  }
-
-  for(i = 0; i < nheader; ++i) {
-    struct dynhds_entry *e = Curl_dynhds_getn(&h2_headers, i);
-    nva[i].name = (unsigned char *)e->name;
-    nva[i].namelen = e->namelen;
-    nva[i].value = (unsigned char *)e->value;
-    nva[i].valuelen = e->valuelen;
-    nva[i].flags = NGHTTP2_NV_FLAG_NONE;
   }
 
   if(read_callback) {

--- a/lib/dynhds.c
+++ b/lib/dynhds.c
@@ -371,9 +371,6 @@ CURLcode Curl_dynhds_h1_dprint(struct dynhds *dynhds, struct dynbuf *dbuf)
 
 #ifdef USE_NGHTTP2
 
-#include <stdint.h>
-#include <nghttp2/nghttp2.h>
-
 nghttp2_nv *Curl_dynhds_to_nva(struct dynhds *dynhds, size_t *pcount)
 {
   nghttp2_nv *nva = calloc(1, sizeof(nghttp2_nv) * dynhds->hds_len);

--- a/lib/dynhds.c
+++ b/lib/dynhds.c
@@ -27,6 +27,10 @@
 #include "strcase.h"
 
 /* The last 3 #include files should be in this order */
+#ifdef USE_NGHTTP2
+#include <stdint.h>
+#include <nghttp2/nghttp2.h>
+#endif /* USE_NGHTTP2 */
 #include "curl_printf.h"
 #include "curl_memory.h"
 #include "memdebug.h"
@@ -365,3 +369,29 @@ CURLcode Curl_dynhds_h1_dprint(struct dynhds *dynhds, struct dynbuf *dbuf)
   return result;
 }
 
+#ifdef USE_NGHTTP2
+
+#include <stdint.h>
+#include <nghttp2/nghttp2.h>
+
+nghttp2_nv *Curl_dynhds_to_nva(struct dynhds *dynhds, size_t *pcount)
+{
+  nghttp2_nv *nva = calloc(1, sizeof(nghttp2_nv) * dynhds->hds_len);
+  size_t i;
+
+  *pcount = 0;
+  if(!nva)
+    return NULL;
+
+  for(i = 0; i < dynhds->hds_len; ++i) {
+    nva[i].name = (unsigned char *)dynhds->hds[i]->name;
+    nva[i].namelen = dynhds->hds[i]->namelen;
+    nva[i].value = (unsigned char *)dynhds->hds[i]->value;
+    nva[i].valuelen = dynhds->hds[i]->valuelen;
+    nva[i].flags = NGHTTP2_NV_FLAG_NONE;
+  }
+  *pcount = dynhds->hds_len;
+  return nva;
+}
+
+#endif /* USE_NGHTTP2 */

--- a/lib/dynhds.c
+++ b/lib/dynhds.c
@@ -381,10 +381,12 @@ nghttp2_nv *Curl_dynhds_to_nva(struct dynhds *dynhds, size_t *pcount)
     return NULL;
 
   for(i = 0; i < dynhds->hds_len; ++i) {
-    nva[i].name = (unsigned char *)dynhds->hds[i]->name;
-    nva[i].namelen = dynhds->hds[i]->namelen;
-    nva[i].value = (unsigned char *)dynhds->hds[i]->value;
-    nva[i].valuelen = dynhds->hds[i]->valuelen;
+    struct dynhds_entry *e = dynhds->hds[i];
+    DEBUGASSERT(e);
+    nva[i].name = (unsigned char *)e->name;
+    nva[i].namelen = e->namelen;
+    nva[i].value = (unsigned char *)e->value;
+    nva[i].valuelen = e->valuelen;
     nva[i].flags = NGHTTP2_NV_FLAG_NONE;
   }
   *pcount = dynhds->hds_len;

--- a/lib/dynhds.h
+++ b/lib/dynhds.h
@@ -171,4 +171,13 @@ CURLcode Curl_dynhds_h1_add_line(struct dynhds *dynhds,
  */
 CURLcode Curl_dynhds_h1_dprint(struct dynhds *dynhds, struct dynbuf *dbuf);
 
+#ifdef USE_NGHTTP2
+
+#include <stdint.h>
+#include <nghttp2/nghttp2.h>
+
+nghttp2_nv *Curl_dynhds_to_nva(struct dynhds *dynhds, size_t *pcount);
+
+#endif /* USE_NGHTTP2 */
+
 #endif /* HEADER_CURL_DYNHDS_H */

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2057,21 +2057,11 @@ static ssize_t h2_submit(struct stream_ctx **pstream,
   /* no longer needed */
   Curl_h1_req_parse_free(&stream->h1);
 
-  nheader = Curl_dynhds_count(&h2_headers);
-  nva = malloc(sizeof(nghttp2_nv) * nheader);
+  nva = Curl_dynhds_to_nva(&h2_headers, &nheader);
   if(!nva) {
     *err = CURLE_OUT_OF_MEMORY;
     nwritten = -1;
     goto out;
-  }
-
-  for(i = 0; i < nheader; ++i) {
-    struct dynhds_entry *e = Curl_dynhds_getn(&h2_headers, i);
-    nva[i].name = (unsigned char *)e->name;
-    nva[i].namelen = e->namelen;
-    nva[i].value = (unsigned char *)e->value;
-    nva[i].valuelen = e->valuelen;
-    nva[i].flags = NGHTTP2_NV_FLAG_NONE;
   }
 
   h2_pri_spec(data, &pri_spec);


### PR DESCRIPTION
- fold the code to convert dynhds to the nghttp2 structs into a dynhds internal method
- saves code duplication
- pacifies compiler analyzers