### PR TITLE
curl_trc: remove a bad assertion

### DIFF
--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -61,10 +61,6 @@ void Curl_debug(struct Curl_easy *data, curl_infotype type,
       "* ", "< ", "> ", "{ ", "} ", "{ ", "} " };
     if(data->set.fdebug) {
       bool inCallback = Curl_is_in_callback(data);
-      /* CURLOPT_DEBUGFUNCTION doc says the user may set CURLOPT_PRIVATE to
-         distinguish their handle from internal handles. */
-      if(data->internal)
-        DEBUGASSERT(!data->set.private_data);
       Curl_set_in_callback(data, true);
       (void)(*data->set.fdebug)(data, type, ptr, size, data->set.debugdata);
       Curl_set_in_callback(data, inCallback);

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -339,9 +339,10 @@ static CURLcode dohprobe(struct Curl_easy *data,
     doh->set.dohfor = data; /* identify for which transfer this is done */
     p->easy = doh;
 
-    /* DoH private_data must be null because the user must have a way to
-       distinguish their transfer's handle from DoH handles in user
-       callbacks (ie SSL CTX callback). */
+    /* DoH handles must not inherit private_data. The handles may be passed to
+       the user via callbacks and the user will be able to identify them as
+       internal handles because private data is not set. The user can then set
+       private_data via CURLOPT_PRIVATE if they so choose. */
     DEBUGASSERT(!doh->set.private_data);
 
     if(curl_multi_add_handle(multi, doh))


### PR DESCRIPTION
- Remove DEBUGASSERT that an internal handle must not have user private_data set before calling the user's debug callback.

This is a follow-up to 0dc40b2a. The user can distinguish their easy handle from an internal easy handle by setting CURLOPT_PRIVATE on their easy handle. I had wrongly assumed that meant the user couldn't then set CURLOPT_PRIVATE on an internal handle as well.

Bug: https://github.com/curl/curl/pull/12060#issuecomment-1754594697
Reported-by: Daniel Stenberg

Closes #xxxx