### PR TITLE
CI: ignore test 286 on Appveyor gcc 9 build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -157,7 +157,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1086 !1139 !1451 !1501'
+      DISABLED_TESTS: '~286 !1086 !1139 !1451 !1501'
       ADD_PATH: 'C:\msys64\mingw64\bin;C:\msys64\usr\bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k


### PR DESCRIPTION
This test fails sometimes when retries occur due to what may just just
be a compiler bug. The test results are ignored on the one CI job where
it occurs because there seems to be nothing we can do to fix it.

Fixes #12040
Closes #12106