### PR TITLE
wolfssl: require WOLFSSL_SYS_CA_CERTS for loading system CA

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -513,7 +513,7 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     }
   }
 
-#ifndef NO_FILESYSTEM
+#if !defined(NO_FILESYSTEM) && defined(WOLFSSL_SYS_CA_CERTS)
   /* load native CA certificates */
   if(ssl_config->native_ca_store) {
     if(wolfSSL_CTX_load_system_CA_certs(backend->ctx) != WOLFSSL_SUCCESS) {


### PR DESCRIPTION
This define is set in wolfssl's options.h file when this function and feature is present. Handles both builds with the feature explicitly disabled and wolfSSL versions before 5.5.2 - which introduced this API call.