### PR TITLE
curl.h: only include "osreldate.h" on pre v8 FreeBSD

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -65,7 +65,8 @@
 #include <stdio.h>
 #include <limits.h>
 
-#if (defined(__FreeBSD__) && (__FreeBSD__ >= 2)) || defined(__MidnightBSD__)
+#if (defined(__FreeBSD__) && (__FreeBSD__ >= 2) && (__FreeBSD__ < 8)) || \
+  defined(__MidnightBSD__)
 /* Needed for __FreeBSD_version or __MidnightBSD_version symbol definition */
 #include <osreldate.h>
 #endif


### PR DESCRIPTION
Follow-up to b89789d82fdb2df. This header does not exist in all modern versions.

Fixes #12107
Reported-by: Faraz Fallahi