### PR TITLE
tool_getparam: Limit --rate to be smaller than number of ms

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1043,6 +1043,12 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
             break;
           }
         }
+
+        if(denominator > numerator) {
+          err = PARAM_NUMBER_TOO_LARGE;
+          break;
+        }
+
         global->ms_per_transfer = numerator/denominator;
       }
       break;


### PR DESCRIPTION
Currently, curl allows users to specify absurd request rates that might be higher than the number of milliseconds in the unit (ex: `curl --rate 3600050/h http://localhost:8080` does not error out despite there being only 3600000ms in a hour).

This PR adds a conditional check before the millisecond calculation making sure that the number is not higher than the numerator (the unit) If the number is higher, curl errors out with `PARAM_NUMBER_TOO_LARGE`