### PR TITLE
curl.h: on FreeBSD include sys/param.h instead of osreldate.h

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -65,9 +65,9 @@
 #include <stdio.h>
 #include <limits.h>
 
-#if (defined(__FreeBSD__) && (__FreeBSD__ >= 2)) || defined(__MidnightBSD__)
+#if defined(__FreeBSD__) || defined(__MidnightBSD__)
 /* Needed for __FreeBSD_version or __MidnightBSD_version symbol definition */
-#include <osreldate.h>
+#include <sys/param.h>
 #endif
 
 /* The include stuff here below is mainly for time_t! */


### PR DESCRIPTION
Should things build on Playstation as well

Fixes #12107
Reported-by: Faraz Fallahi