### PR TITLE
build: fix 'threadsafe' feature detection for older gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1548,8 +1548,9 @@ _add_if("HTTPS-proxy"   SSL_ENABLED AND (USE_OPENSSL OR USE_GNUTLS
                         OR USE_SCHANNEL OR USE_RUSTLS OR USE_BEARSSL OR
                         USE_MBEDTLS OR USE_SECTRANSP))
 _add_if("unicode"       ENABLE_UNICODE)
-_add_if("threadsafe"    HAVE_ATOMIC OR (WIN32 AND
-                        HAVE_WIN32_WINNT GREATER_EQUAL 0x600))
+_add_if("threadsafe"    HAVE_ATOMIC OR
+                        (USE_THREADS_POSIX AND HAVE_PTHREAD_H) OR
+                        (WIN32 AND HAVE_WIN32_WINNT GREATER_EQUAL 0x600))
 _add_if("PSL"           USE_LIBPSL)
 string(REPLACE ";" " " SUPPORT_FEATURES "${_items}")
 message(STATUS "Enabled features: ${SUPPORT_FEATURES}")

--- a/configure.ac
+++ b/configure.ac
@@ -4612,6 +4612,9 @@ fi
 
 if test "$tst_atomic" = "yes"; then
   SUPPORT_FEATURES="$SUPPORT_FEATURES threadsafe"
+elif test "x$USE_THREADS_POSIX" = "x1" -a \
+     "x$ac_cv_header_pthread_h" = "xyes"; then
+  SUPPORT_FEATURES="$SUPPORT_FEATURES threadsafe"
 else
   AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM([[


### PR DESCRIPTION
- Add 'threadsafe' to the feature list shown during build if POSIX threads are being used.

This is a follow-up to 5adb6000 which added support for building a thread-safe libcurl with older versions of gcc where atomic is not available but pthread is.

Reported-by: Dan Fandrich

Fixes https://github.com/curl/curl/issues/12125
Closes #xxxx