### PR TITLE
tool_urlglob: fix build for old gcc versions

### DIFF
--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -73,7 +73,8 @@ static int multiply(curl_off_t *amount, curl_off_t with)
     sum = 0;
   }
   else {
-#ifdef __GNUC__
+#if defined(__GNUC__) && \
+  ((__GNUC__ > 5) || ((__GNUC__ == 5) && (__GNUC_MINOR__ >= 1)))
     if(__builtin_mul_overflow(*amount, with, &sum))
       return 1;
 #else


### PR DESCRIPTION
- Don't use __builtin_mul_overflow for GCC 4 and earlier.

The function was added in GCC 5.

Ref: https://gcc.gnu.org/gcc-5/changes.html

Reported-by: Dan Fandrich

Fixes https://github.com/curl/curl/issues/12124
Closes #xxxx