### PR TITLE
Added missing parameter 'lpNumberOfCharsWritten' for WriteConsoleW()

### DIFF
--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -237,7 +237,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   if(isatty(fileno(outs->stream)) &&
      GetConsoleScreenBufferInfo((HANDLE)fhnd, &console_info)) {
     wchar_t *wc_buf;
-    DWORD wc_len;
+    DWORD wc_len, chars_written;
     unsigned char *rbuf = (unsigned char *)buffer;
     DWORD rlen = (DWORD)bytes;
 
@@ -292,7 +292,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
               (HANDLE) fhnd,
               prefix,
               prefix[1] ? 2 : 1,
-              NULL,
+              &chars_written,
               NULL)) {
             return CURL_WRITEFUNC_ERROR;
           }
@@ -351,7 +351,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
           (HANDLE) fhnd,
           wc_buf,
           wc_len,
-          NULL,
+          &chars_written,
           NULL)) {
         free(wc_buf);
         return CURL_WRITEFUNC_ERROR;


### PR DESCRIPTION
This is documented as "optional" by Microsoft, I know. But, apparently, this was *not* optional on older Windows versions! On those version, the function verifiably fails with error `ERROR_INVALID_ACCESS`, if parameter is `NULL`.

As a result, we get error:
```
curl: (23) Failure writing output to destination
```

Probably regression from:
https://github.com/curl/curl/commit/af3f4e419b9f339790de281c871640a773c391c0

This PR fixes the error 👍