### PR TITLE
GHA: bump ngtcp2 and nghttp3 to 1.0.x, nghttp2 to 1.58.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,7 +47,7 @@ env:
   mod_h2-version: v2.0.25
   msh3-version: v0.6.0
   openssl3-version: openssl-3.1.3
-  quictls-version: OpenSSL_1_1_1w+quic
+  quictls-version: 3.1.4+quic
   rustls-version: v0.10.0
 
 jobs:

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -50,7 +50,7 @@ env:
   gnutls-version: 3.8.0
   wolfssl-version: master
   nghttp3-version: v1.0.0
-  ngtcp2-version: v1.0.0
+  ngtcp2-version: v1.0.1
   nghttp2-version: v1.58.0
   mod_h2-version: v2.0.25
 

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -46,7 +46,7 @@ permissions: {}
 
 env:
   MAKEFLAGS: -j 3
-  quictls-version: 3.0.10+quic
+  quictls-version: 3.1.4+quic
   gnutls-version: 3.8.0
   wolfssl-version: master
   nghttp3-version: v1.0.0

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -49,9 +49,9 @@ env:
   quictls-version: 3.0.10+quic
   gnutls-version: 3.8.0
   wolfssl-version: master
-  nghttp3-version: v0.15.0
-  ngtcp2-version: v0.19.1
-  nghttp2-version: v1.56.0
+  nghttp3-version: v1.0.0
+  ngtcp2-version: v1.0.0
+  nghttp2-version: v1.58.0
   mod_h2-version: v2.0.25
 
 jobs:

--- a/.github/workflows/quiche-linux.yml
+++ b/.github/workflows/quiche-linux.yml
@@ -47,9 +47,9 @@ permissions: {}
 env:
   MAKEFLAGS: -j 3
   openssl-version: 3.0.10+quic
-  nghttp3-version: v0.15.0
-  ngtcp2-version: v0.19.1
-  nghttp2-version: v1.56.0
+  nghttp3-version: v1.0.0
+  ngtcp2-version: v1.0.0
+  nghttp2-version: v1.58.0
   quiche-version: 0.17.2
   mod_h2-version: v2.0.25
 

--- a/.github/workflows/quiche-linux.yml
+++ b/.github/workflows/quiche-linux.yml
@@ -48,7 +48,7 @@ env:
   MAKEFLAGS: -j 3
   openssl-version: 3.0.10+quic
   nghttp3-version: v1.0.0
-  ngtcp2-version: v1.0.0
+  ngtcp2-version: v1.0.1
   nghttp2-version: v1.58.0
   quiche-version: 0.17.2
   mod_h2-version: v2.0.25

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -36,7 +36,7 @@ Building curl with ngtcp2 involves 3 components: `ngtcp2` itself, `nghttp3` and 
 
 For now, `ngtcp2` and `nghttp3` are still *experimental* which means their evolution bring breaking changes. Therefore, the proper version of both libraries need to be used when building curl. These are
 
- * `ngtcp2`: v1.0.0
+ * `ngtcp2`: v1.0.1
  * `nghttp3`: v1.0.0
 
 ## Build with OpenSSL
@@ -62,7 +62,7 @@ Build nghttp3
 Build ngtcp2
 
      % cd ..
-     % git clone -b v1.0.0 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v1.0.1 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only
@@ -105,7 +105,7 @@ Build nghttp3
 Build ngtcp2
 
      % cd ..
-     % git clone -b v1.0.0 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v1.0.1 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only --with-gnutls
@@ -146,7 +146,7 @@ Build nghttp3
 Build ngtcp2
 
      % cd ..
-     % git clone -b v1.0.0 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v1.0.1 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only --with-wolfssl

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -36,8 +36,8 @@ Building curl with ngtcp2 involves 3 components: `ngtcp2` itself, `nghttp3` and 
 
 For now, `ngtcp2` and `nghttp3` are still *experimental* which means their evolution bring breaking changes. Therefore, the proper version of both libraries need to be used when building curl. These are
 
- * `ngtcp2`: v0.19.1
- * `nghttp3`: v0.15.0
+ * `ngtcp2`: v1.0.0
+ * `nghttp3`: v1.0.0
 
 ## Build with OpenSSL
 
@@ -52,7 +52,7 @@ Build (patched) OpenSSL
 Build nghttp3
 
      % cd ..
-     % git clone -b v0.15.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v1.0.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % autoreconf -fi
      % ./configure --prefix=<somewhere2> --enable-lib-only
@@ -62,7 +62,7 @@ Build nghttp3
 Build ngtcp2
 
      % cd ..
-     % git clone -b v0.19.1 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v1.0.0 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only
@@ -95,7 +95,7 @@ Build GnuTLS
 Build nghttp3
 
      % cd ..
-     % git clone -b v0.15.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v1.0.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % autoreconf -fi
      % ./configure --prefix=<somewhere2> --enable-lib-only
@@ -105,7 +105,7 @@ Build nghttp3
 Build ngtcp2
 
      % cd ..
-     % git clone -b v0.19.1 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v1.0.0 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only --with-gnutls
@@ -136,7 +136,7 @@ Build wolfSSL
 Build nghttp3
 
      % cd ..
-     % git clone -b v0.15.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v1.0.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % autoreconf -fi
      % ./configure --prefix=<somewhere2> --enable-lib-only
@@ -146,7 +146,7 @@ Build nghttp3
 Build ngtcp2
 
      % cd ..
-     % git clone -b v0.19.1 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v1.0.0 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only --with-wolfssl


### PR DESCRIPTION
"No more incompatible changes."