### PR TITLE
tool_operate: fix links in ipfs errors

### DIFF
--- a/docs/IPFS.md
+++ b/docs/IPFS.md
@@ -78,5 +78,5 @@ Alternatively you could set the `IPFS_GATEWAY` environment variable or pass the 
 ### Malformed gateway URL
 The command executed evaluates in an invalid URL. This could be anywhere in the URL, but a likely point is a wrong gateway URL.
 
-Inspect your URL.
-Alternatively opt to go for the [automatic](#Automatic-gateway-detection) gateway detection.
+Inspect the URL set via the `IPFS_GATEWAY` environment variable or passed with the `--ipfs-gateway` flag.
+Alternatively opt to go for the [automatic](#automatic-gateway-detection) gateway detection.

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -865,20 +865,20 @@ clean:
   switch(result) {
   case CURLE_URL_MALFORMAT:
     helpf(tool_stderr, "malformed URL. Visit https://curl.se/"
-          "docs/ipfs.html#Gateway-file-and-"
+          "docs/ipfs.html#gateway-file-and-"
           "environment-variable for more "
           "information");
     break;
   case CURLE_FILE_COULDNT_READ_FILE:
     helpf(tool_stderr, "IPFS automatic gateway detection "
           "failure. Visit https://curl.se/docs/"
-          "ipfs.html#Malformed-gateway-URL for "
+          "ipfs.html#malformed-gateway-url for "
           "more information");
     break;
   case CURLE_BAD_FUNCTION_ARGUMENT:
     helpf(tool_stderr, "--ipfs-gateway argument results in "
           "malformed URL. Visit https://curl.se/"
-          "docs/ipfs.html#Malformed-gateway-URL "
+          "docs/ipfs.html#malformed-gateway-url "
           "for more information");
     break;
   default:


### PR DESCRIPTION
This is a cosmetic fix of errors returned by cli tool.

(URL fragment links generated from headers in https://curl.se/docs/ipfs.html are lowercase)