### PR TITLE
gnutls: support CURLSSLOPT_NATIVE_CA

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.3
@@ -62,12 +62,13 @@ library). If combined with \fICURLSSLOPT_NO_REVOKE\fP, the latter takes
 precedence. (Added in 7.70.0)
 .IP CURLSSLOPT_NATIVE_CA
 Tell libcurl to use the operating system's native CA store for certificate
-verification. Works only on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora,
-RHEL), macOS, Android and iOS when built to use wolfSSL (since 8.3.0) or on
-Windows when built to use OpenSSL. If you set this option and also set a CA
-certificate file or directory then during verification those certificates
-are searched in addition to the native CA store.
-(Added in 7.71.0)
+verification. If you set this option and also set a CA certificate file or
+directory then during verification those certificates are searched in addition
+to the native CA store.
+
+Works with wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora, RHEL),
+macOS, Android and iOS (added in 8.3.0), with GnuTLS (added in 8.5.0) or on
+Windows when built to use OpenSSL (Added in 7.71.0).
 .IP CURLSSLOPT_AUTO_CLIENT_CERT
 Tell libcurl to automatically locate and use a client certificate for
 authentication, when requested by the server. This option is only supported

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.3
@@ -61,12 +61,13 @@ library). If combined with \fICURLSSLOPT_NO_REVOKE\fP, the latter takes
 precedence. (Added in 7.70.0)
 .IP CURLSSLOPT_NATIVE_CA
 Tell libcurl to use the operating system's native CA store for certificate
-verification. Works only on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora,
-RHEL), macOS, Android and iOS when built to use wolfSSL (since 8.3.0) or on
-Windows when built to use OpenSSL. If you set this option and also set a CA
-certificate file or directory then during verification those certificates
-are searched in addition to the native CA store.
-(Added in 7.71.0)
+verification. If you set this option and also set a CA certificate file or
+directory then during verification those certificates are searched in addition
+to the native CA store.
+
+Works with wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora, RHEL),
+macOS, Android and iOS (added in 8.3.0), with GnuTLS (added in 8.5.0) or on
+Windows when built to use OpenSSL (Added in 7.71.0).
 .IP CURLSSLOPT_AUTO_CLIENT_CERT
 Tell libcurl to automatically locate and use a client certificate for
 authentication, when requested by the server. This option is only supported


### PR DESCRIPTION
Remove the CURL_CA_FALLBACK logic. That build option was added to allow primarily OpenSSL to use the default paths for loading the CA certs. For GnuTLS it was instead made to load the "system certs", which is different and not desirable.

The native CA store loading is now asked for with this option.

Follow-up to 7b55279d1d856