### PR TITLE
Chore: Typo fixed in FAQ

### DIFF
--- a/docs/FAQ
+++ b/docs/FAQ
@@ -754,7 +754,7 @@ FAQ
   be disabled or not supported.
 
   Note that this error will also occur if you pass a wrongly spelled protocol
-  part as in "htpt://example.com" or as in the less evident case if you prefix
+  part as in "http://example.com" or as in the less evident case if you prefix
   the protocol part with a space as in " http://example.com/".
 
   3.22 curl -X gives me HTTP problems


### PR DESCRIPTION
This PR fix the typo in `FAQ` file

```pseudo
htpt > http
```