### PR TITLE
PlayStation doesn't have getenv()

### DIFF
--- a/lib/getenv.c
+++ b/lib/getenv.c
@@ -31,7 +31,8 @@
 
 static char *GetEnv(const char *variable)
 {
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP) || \
+  defined(__ORBIS__) || defined(__PROSPERO__) /* PlayStation 4 and 5 */
   (void)variable;
   return NULL;
 #elif defined(WIN32)


### PR DESCRIPTION
Build fails on PlayStation since it doesn't have `getenv()`