### PR TITLE
cookie: branchless comparison for sorting by creation time

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1320,7 +1320,7 @@ static int cookie_sort(const void *p1, const void *p2)
     return (l2 > l1) ? 1 : -1;
 
   /* 4 - compare cookie creation time */
-  return (c2->creationtime > c1->creationtime) ? 1 : -1;
+  return c2->creationtime - c1->creationtime;
 }
 
 /*
@@ -1333,7 +1333,7 @@ static int cookie_sort_ct(const void *p1, const void *p2)
   struct Cookie *c1 = *(struct Cookie **)p1;
   struct Cookie *c2 = *(struct Cookie **)p2;
 
-  return (c2->creationtime > c1->creationtime) ? 1 : -1;
+  return c2->creationtime - c1->creationtime;
 }
 
 #define CLONE(field)                     \


### PR DESCRIPTION
In the cookie module, when sorting cookies by creation time, the comparison logic was previously implemented using a ternary operator, which had room for optimization. This change replaces the ternary operator with a direct subtraction, making the comparison branchless and reducing the number of generated assembly instructions.