### PR TITLE
hostip: show the list of IPs when resolving is done

### DIFF
--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -64,6 +64,10 @@ struct Curl_dns_entry {
   time_t timestamp;
   /* use-counter, use Curl_resolv_unlock to release reference */
   long inuse;
+  /* hostname port number that resolved to addr. */
+  int hostport;
+  /* hostname that resolved to addr. may be NULL (unix domain sockets). */
+  char hostname[1];
 };
 
 bool Curl_host_is_ipnum(const char *hostname);


### PR DESCRIPTION
Getting 'curl.se' today then gets this verbose output which might help debugging connectivity related matters.

* Host curl.se:80 was resolved.
* IPv6: 2a04:4e42:800::347, 2a04:4e42:600::347, 2a04:4e42:400::347, 2a04:4e42:200::347, 2a04:4e42::347, 2a04:4e42:e00::347, 2a04:4e42:c00::347, 2a04:4e42:a00::347
* IPv4: 151.101.193.91, 151.101.129.91, 151.101.65.91, 151.101.1.91
