### PR TITLE
openssl: use OPENSSL_INIT_NO_ATEXIT

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1705,6 +1705,9 @@ static int ossl_init(void)
 #else
     OPENSSL_INIT_LOAD_CONFIG |
 #endif
+#ifdef OPENSSL_INIT_NO_ATEXIT
+    OPENSSL_INIT_NO_ATEXIT |
+#endif
     0;
   OPENSSL_init_ssl(flags, NULL);
 #else
@@ -1748,6 +1751,7 @@ static void ossl_cleanup(void)
   !defined(LIBRESSL_VERSION_NUMBER)
   /* OpenSSL 1.1 deprecates all these cleanup functions and
      turns them into no-ops in OpenSSL 1.0 compatibility mode */
+  OPENSSL_cleanup();
 #else
   /* Free ciphers and digests lists */
   EVP_cleanup();


### PR DESCRIPTION
https://www.openssl.org/docs/man1.1.1/man3/OPENSSL_INIT_set_config_file_flags.html
> OPENSSL_INIT_NO_ATEXIT
> By default OpenSSL will attempt to clean itself up when the process exits via an “atexit” handler. Using this option suppresses that behaviour. This means that the application will have to clean up OpenSSL explicitly using OPENSSL_cleanup().


https://developers.redhat.com/articles/2022/10/31/best-practices-application-shutdown-openssl#recommended_initialization_and_shutdown_procedure
> Recommended initialization and shutdown procedure
> The best option is a properly serialized deinitialization, during which the atexit hooks are executed in the correct order, all the application threads terminate except the main one, etc. This sequence requires you to be thorough in your coding, but it's worth the effort.
> 
> If your application has to shut down manually, OpenSSL authors suggest a procedure with two parts.
> 
> First, the application should use the OPENSSL_INIT_NO_ATEXIT option in the OPENSSL_init_crypto call at OpenSSL initialization, to avoid implicit installation of the OpenSSL cleanup handler. After that, when the application terminates and no further OpenSSL functions will be called, invoke OPENSSL_cleanup explicitly to free resources on shutdown.
> 
> In conclusion, a manual shutdown option is useful for some libraries, but a predictable order of initialization and deinitialization is preferable.