### PR TITLE
transfer: only reset the FTP wildcard engine in CLEAR state

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1430,8 +1430,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
           return CURLE_OUT_OF_MEMORY;
       }
       wc = data->wildcard;
-      if((wc->state < CURLWC_INIT) ||
-         (wc->state >= CURLWC_CLEAN)) {
+      if(wc->state < CURLWC_INIT) {
         if(wc->ftpwc)
           wc->dtor(wc->ftpwc);
         Curl_safefree(wc->pattern);


### PR DESCRIPTION
To avoid the state machine to start over and redownload all the files *again*.

Reported-by: lkordos on github
Regression from 843b3baa3e3cb228 (shipped in 8.1.0)
Bisect-by: Dan Fandrich
Fixes #11775