### PR TITLE
configure: check for the fseeko declaration too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1202,6 +1202,10 @@ check_symbol_exists(setlocale      "${CURL_INCLUDES}" HAVE_SETLOCALE)
 check_symbol_exists(setmode        "${CURL_INCLUDES}" HAVE_SETMODE)
 check_symbol_exists(setrlimit      "${CURL_INCLUDES}" HAVE_SETRLIMIT)
 
+if(HAVE_FSEEKO)
+  set(HAVE_DECL_FSEEKO 1)
+endif()
+
 if(NOT MSVC OR (MSVC_VERSION GREATER_EQUAL 1900))
   # earlier MSVC compilers had faulty snprintf implementations
   check_symbol_exists(snprintf       "stdio.h" HAVE_SNPRINTF)

--- a/configure.ac
+++ b/configure.ac
@@ -3581,7 +3581,6 @@ AC_CHECK_DECLS([getpwuid_r], [], [AC_DEFINE(HAVE_DECL_GETPWUID_R_MISSING, 1, "Se
         [[#include <pwd.h>
           #include <sys/types.h>]])
 
-
 AC_CHECK_FUNCS([\
   _fseeki64 \
   arc4random \
@@ -3627,6 +3626,15 @@ AC_CHECK_FUNCS([\
     ])
   fi
 ])
+
+dnl On Android, the only way to know if fseeko can be used is to see if it is
+dnl declared or not (for this API level), as the symbol always exists in the
+dnl lib.
+AC_CHECK_DECL([fseeko],
+              [AC_DEFINE([HAVE_DECL_FSEEKO], [1],
+               [Define to 1 if you have the fseeko declaration])],
+              [],
+              [[#include <stdio.h>]])
 
 CURL_CHECK_NONBLOCKING_SOCKET
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -211,6 +211,9 @@
 /* Define to 1 if you have the fseeko function. */
 #cmakedefine HAVE_FSEEKO 1
 
+/* Define to 1 if you have the fseeko declaration. */
+#cmakedefine HAVE_DECL_FSEEKO 1
+
 /* Define to 1 if you have the _fseeki64 function. */
 #cmakedefine HAVE__FSEEKI64 1
 

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -792,7 +792,7 @@ static CURLcode setname(curl_mimepart *part, const char *name, size_t len)
 /* wrap call to fseeko so it matches the calling convention of callback */
 static int fseeko_wrapper(void *stream, curl_off_t offset, int whence)
 {
-#if defined(HAVE_FSEEKO)
+#if defined(HAVE_FSEEKO) && defined(HAVE_DECL_FSEEKO)
   return fseeko(stream, (off_t)offset, whence);
 #elif defined(HAVE__FSEEKI64)
   return _fseeki64(stream, (__int64)offset, whence);


### PR DESCRIPTION
... and make the code require both symbol and declaration.

This is because for Android, the symbol is always present in the lib at build-time even when not actually available in run-time.

Reported-by: 12932 on github
Fixes #12086