### PR TITLE
variadic macros with --disable-verbose

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -127,6 +127,7 @@ static void nosigpipe(struct Curl_easy *data,
                       curl_socket_t sockfd)
 {
   int onoff = 1;
+  (void)data;
   if(setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, (void *)&onoff,
                 sizeof(onoff)) < 0) {
 #if !defined(CURL_DISABLE_VERBOSE_STRINGS)
@@ -1288,7 +1289,7 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   struct cf_socket_ctx *ctx = cf->ctx;
   curl_socket_t fdsave;
   ssize_t nwritten;
-  size_t orig_len = len;
+  size_t blen = len;
 
   *err = CURLE_OK;
   fdsave = cf->conn->sock[cf->sockindex];
@@ -1300,7 +1301,7 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     unsigned char c;
     Curl_rand(data, &c, 1);
     if(c >= ((100-ctx->wblock_percent)*256/100)) {
-      CURL_TRC_CF(data, cf, "send(len=%zu) SIMULATE EWOULDBLOCK", orig_len);
+      CURL_TRC_CF(data, cf, "send(len=%zu) SIMULATE EWOULDBLOCK", len);
       *err = CURLE_AGAIN;
       nwritten = -1;
       cf->conn->sock[cf->sockindex] = fdsave;
@@ -1308,24 +1309,24 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     }
   }
   if(cf->cft != &Curl_cft_udp && ctx->wpartial_percent > 0 && len > 8) {
-    len = len * ctx->wpartial_percent / 100;
-    if(!len)
-      len = 1;
+    blen = len * ctx->wpartial_percent / 100;
+    if(!blen)
+      blen = 1;
     CURL_TRC_CF(data, cf, "send(len=%zu) SIMULATE partial write of %zu bytes",
-                orig_len, len);
+                len, blen);
   }
 #endif
 
 #if defined(MSG_FASTOPEN) && !defined(TCP_FASTOPEN_CONNECT) /* Linux */
   if(cf->conn->bits.tcp_fastopen) {
-    nwritten = sendto(ctx->sock, buf, len, MSG_FASTOPEN,
+    nwritten = sendto(ctx->sock, buf, blen, MSG_FASTOPEN,
                       &cf->conn->remote_addr->sa_addr,
                       cf->conn->remote_addr->addrlen);
     cf->conn->bits.tcp_fastopen = FALSE;
   }
   else
 #endif
-    nwritten = swrite(ctx->sock, buf, len);
+    nwritten = swrite(ctx->sock, buf, blen);
 
   if(-1 == nwritten) {
     int sockerr = SOCKERRNO;
@@ -1355,7 +1356,7 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
 
   CURL_TRC_CF(data, cf, "send(len=%zu) -> %d, err=%d",
-              orig_len, (int)nwritten, *err);
+              len, (int)nwritten, *err);
   cf->conn->sock[cf->sockindex] = fdsave;
   return nwritten;
 }

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1389,6 +1389,7 @@ struct Cookie *Curl_cookie_getlist(struct Curl_easy *data,
   bool is_ip;
   const size_t myhash = cookiehash(host);
 
+  (void)data;
   if(!c || !c->cookies[myhash])
     return NULL; /* no cookie struct or no cookies in the struct */
 

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -238,14 +238,4 @@ CURLcode Curl_trc_init(void)
   return CURLE_OK;
 }
 
-#if !defined(__STDC_VERSION__) || (__STDC_VERSION__ < 199901L)
-void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
-                       const char *fmt, ...)
-{
-  (void)data;
-  (void)cf;
-  (void)fmt;
-}
-#endif
-
 #endif /* !DEBUGBUILD */

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -134,13 +134,22 @@ void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
 #define Curl_trc_cf_is_verbose(x,y)   ((void)(x), (void)(y), FALSE)
 
 #if defined(HAVE_VARIADIC_MACROS_C99)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvariadic-macros"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvariadic-macros"
 #define infof(...)  Curl_nop_stmt
 #define CURL_TRC_CF(...)  Curl_nop_stmt
 #define Curl_trc_cf_infof(...)  Curl_nop_stmt
+#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
 #elif defined(HAVE_VARIADIC_MACROS_GCC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvariadic-macros"
 #define infof(x...)  Curl_nop_stmt
 #define CURL_TRC_CF(x...)  Curl_nop_stmt
 #define Curl_trc_cf_infof(x...)  Curl_nop_stmt
+#pragma GCC diagnostic pop
 #else
 #error "missing VARIADIC macro define, fix and rebuild!"
 #endif

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -56,10 +56,6 @@
 #error too old nghttp2 version, upgrade!
 #endif
 
-#ifdef CURL_DISABLE_VERBOSE_STRINGS
-#define nghttp2_session_callbacks_set_error_callback(x,y)
-#endif
-
 #if (NGHTTP2_VERSION_NUM >= 0x010c00)
 #define NGHTTP2_HAS_SET_LOCAL_WINDOW_SIZE 1
 #endif
@@ -398,8 +394,6 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
                      const uint8_t *value, size_t valuelen,
                      uint8_t flags,
                      void *userp);
-static int error_callback(nghttp2_session *session, const char *msg,
-                          size_t len, void *userp);
 
 /*
  * Initialize the cfilter context
@@ -437,7 +431,6 @@ static CURLcode cf_h2_ctx_init(struct Curl_cfilter *cf,
   nghttp2_session_callbacks_set_on_begin_headers_callback(
     cbs, on_begin_headers);
   nghttp2_session_callbacks_set_on_header_callback(cbs, on_header);
-  nghttp2_session_callbacks_set_error_callback(cbs, error_callback);
 
   /* The nghttp2 session is not yet setup, do it */
   rc = h2_client_new(cf, cbs);
@@ -1600,20 +1593,6 @@ static ssize_t req_body_read_callback(nghttp2_session *session,
 
   return nread;
 }
-
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
-static int error_callback(nghttp2_session *session,
-                          const char *msg,
-                          size_t len,
-                          void *userp)
-{
-  (void)session;
-  (void)msg;
-  (void)len;
-  (void)userp;
-  return 0;
-}
-#endif
 
 /*
  * Append headers to ask for an HTTP1.1 to HTTP2 upgrade.

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1880,7 +1880,6 @@ static void ossl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
     if(cf->next && cf->next->connected) {
       char buf[1024];
       int nread, err;
-      long sslerr;
 
       /* Maybe the server has already sent a close notify alert.
          Read it to avoid an RST on the TCP connection. */
@@ -1906,12 +1905,16 @@ static void ossl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
           CURL_TRC_CF(data, cf, "SSL shutdown send blocked");
           break;
         default:
-          sslerr = ERR_get_error();
-          CURL_TRC_CF(data, cf, "SSL shutdown, error: '%s', errno %d",
-                      (sslerr ?
-                       ossl_strerror(sslerr, buf, sizeof(buf)) :
-                       SSL_ERROR_to_str(err)),
-                      SOCKERRNO);
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+          {
+            long sslerr = ERR_get_error();
+            CURL_TRC_CF(data, cf, "SSL shutdown, error: '%s', errno %d",
+                        (sslerr ?
+                         ossl_strerror(sslerr, buf, sizeof(buf)) :
+                         SSL_ERROR_to_str(err)),
+                        SOCKERRNO);
+          }
+#endif /* !CURL_DISABLE_VERBOSE_STRINGS */
           break;
         }
       }

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -75,6 +75,7 @@ static struct ws_frame_meta WS_FRAMES[] = {
   { WSBIT_OPCODE_PONG,  CURLWS_PONG,   "PONG" },
 };
 
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
 static const char *ws_frame_name_of_op(unsigned char proto_opcode)
 {
   unsigned char opcode = proto_opcode & WSBIT_OPCODE_MASK;
@@ -85,6 +86,7 @@ static const char *ws_frame_name_of_op(unsigned char proto_opcode)
   }
   return "???";
 }
+#endif /* !CURL_DISABLE_VERBOSE_STRINGS */
 
 static int ws_frame_op2flags(unsigned char proto_opcode)
 {
@@ -110,6 +112,10 @@ static unsigned char ws_frame_flags2op(int flags)
 static void ws_dec_info(struct ws_decoder *dec, struct Curl_easy *data,
                         const char *msg)
 {
+  (void)dec;
+  (void)data;
+  (void)msg;
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
   switch(dec->head_len) {
   case 0:
     break;
@@ -134,6 +140,7 @@ static void ws_dec_info(struct ws_decoder *dec, struct Curl_easy *data,
     }
     break;
   }
+#endif /* !CURL_DISABLE_VERBOSE_STRINGS */
 }
 
 typedef ssize_t ws_write_payload(const unsigned char *buf, size_t buflen,
@@ -353,6 +360,10 @@ static void update_meta(struct websocket *ws,
 static void ws_enc_info(struct ws_encoder *enc, struct Curl_easy *data,
                         const char *msg)
 {
+  (void)enc;
+  (void)data;
+  (void)msg;
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
   infof(data, "WS-ENC: %s [%s%s%s payload=%" CURL_FORMAT_CURL_OFF_T
               "/%" CURL_FORMAT_CURL_OFF_T "]",
         msg, ws_frame_name_of_op(enc->firstbyte),
@@ -360,6 +371,7 @@ static void ws_enc_info(struct ws_encoder *enc, struct Curl_easy *data,
         " CONT" : "",
         (enc->firstbyte & WSBIT_FIN)? "" : " NON-FIN",
         enc->payload_len - enc->payload_remain, enc->payload_len);
+#endif /* !CURL_DISABLE_VERBOSE_STRINGS */
 }
 
 static void ws_enc_reset(struct ws_encoder *enc)


### PR DESCRIPTION
- add pragmas for gcc and clang to ignore variadic macros pendanteries in C89 mode
- (void)some vars that are not used in --disable-verbose
- ifdef some functions not used in --disable-verbose
- refs #11891