### PR TITLE
easy: remove duplicate wolfSSH init call

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -194,13 +194,6 @@ static CURLcode global_init(long flags, bool memoryfuncs)
   }
 #endif
 
-#ifdef USE_WOLFSSH
-  if(WS_SUCCESS != wolfSSH_Init()) {
-    DEBUGF(fprintf(stderr, "Error: wolfSSH_Init failed\n"));
-    return CURLE_FAILED_INIT;
-  }
-#endif
-
   easy_init_flags = flags;
 
 #ifdef DEBUGBUILD

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -188,11 +188,10 @@ static CURLcode global_init(long flags, bool memoryfuncs)
     goto fail;
   }
 
-#if defined(USE_SSH)
   if(Curl_ssh_init()) {
+    DEBUGF(fprintf(stderr, "Error: Curl_ssh_init failed\n"));
     goto fail;
   }
-#endif
 
   easy_init_flags = flags;
 

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -267,7 +267,7 @@ void Curl_ssh_attach(struct Curl_easy *data,
 /* for non-SSH builds */
 #define Curl_ssh_cleanup()
 #define Curl_ssh_attach(x,y)
-#define Curl_ssh_init() Curl_nop_stmt
+#define Curl_ssh_init() 0
 #endif
 
 #endif /* HEADER_CURL_SSH_H */

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -267,6 +267,7 @@ void Curl_ssh_attach(struct Curl_easy *data,
 /* for non-SSH builds */
 #define Curl_ssh_cleanup()
 #define Curl_ssh_attach(x,y)
+#define Curl_ssh_init() Curl_nop_stmt
 #endif
 
 #endif /* HEADER_CURL_SSH_H */


### PR DESCRIPTION
It is already done in Curl_ssh_init() where it belongs.