### PR TITLE
docs: fix function typo in curl_easy_option_next.3

### DIFF
--- a/docs/libcurl/curl_easy_option_next.3
+++ b/docs/libcurl/curl_easy_option_next.3
@@ -70,10 +70,10 @@ name is provided for backwards compatibility as an alias.
 .nf
 /* iterate over all available options */
 const struct curl_easyoption *opt;
-opt = curl_easy_option_by_next(NULL);
+opt = curl_easy_option_next(NULL);
 while(opt) {
   printf("Name: %s\\n", opt->name);
-  opt = curl_easy_option_by_next(opt);
+  opt = curl_easy_option_next(opt);
 }
 .fi
 .SH AVAILABILITY


### PR DESCRIPTION
Hello,
When I was reading libcurl docs, I noticed that there's a minor mistake in the `curl_easy_option_next` example manpage. In that specific example, `curl_easy_option_by_next()` has been used, however, it doesn't exist in libcurl.

URL: https://curl.se/libcurl/c/curl_easy_option_next.html