### PR TITLE
http: consider resume with CURLOPT_FAILONERRROR and 416 to be fine

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3663,7 +3663,7 @@ CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
           k->content_range = TRUE;
       }
     }
-    else
+    else if(k->httpcode < 300)
       data->state.resume_from = 0; /* get everything */
   }
 #if !defined(CURL_DISABLE_COOKIES)

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -185,7 +185,7 @@ test1439 test1440 test1441 test1442 test1443 test1444 test1445 test1446 \
 test1447 test1448 test1449 test1450 test1451 test1452 test1453 test1454 \
 test1455 test1456 test1457 test1458 test1459 test1460 test1461 test1462 \
 test1463 test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
-test1471 test1472 test1473 test1474 \
+test1471 test1472 test1473 test1474 test1475 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1475
+++ b/tests/data/test1475
@@ -1,0 +1,83 @@
+<testcase>
+# also verified by 1156 in libcurl API terms
+
+<info>
+<keywords>
+HTTP
+HTTP GET
+Resume
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 416 Invalid range
+Connection: close
+Content-Length: 0
+Content-Range: */100
+
+</data>
+
+# The file data that exists at the start of the test must be included in
+# the verification.
+<datacheck>
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+HTTP/1.1 416 Invalid range
+Connection: close
+Content-Length: 0
+Content-Range: */100
+
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<killserver>
+http
+</killserver>
+<name>
+-f and 416 with Content-Range: */size
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -C - -f
+</command>
+<file name="%LOGDIR/curl%TESTNUMBER.out">
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+012345678
+</file>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Range: bytes=100-
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test194
+++ b/tests/data/test194
@@ -64,9 +64,8 @@ User-Agent: curl/%VERSION
 Accept: */*
 
 </protocol>
-# CURLE_HTTP_RETURNED_ERROR
 <errorcode>
-22
+0
 </errorcode>
 </verify>
 </testcase>

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -68,7 +68,7 @@ static const struct testparams params[] = {
   { F_RESUME | F_HTTP416 |          F_CONTENTRANGE | F_IGNOREBODY, CURLE_OK },
   { F_RESUME | F_HTTP416 | F_FAIL |                  F_IGNOREBODY, CURLE_OK },
   { F_RESUME | F_HTTP416 | F_FAIL | F_CONTENTRANGE | F_IGNOREBODY,
-                                                  CURLE_HTTP_RETURNED_ERROR }
+                                                                   CURLE_OK }
 };
 
 static int      hasbody;


### PR DESCRIPTION
Finding a 'Content-Range:' in the response changed the handling.

Add test case 1475 to verify -C - with 416 and Content-Range: header, which is almost exactly like test 194 which instead uses a fixed -C offset. Adjusted test 194 to also be considered fine.

Fixes #10521
Reported-by: Smackd0wn
Fixes #12174
Reported-by: Anubhav Rai