### PR TITLE
http2: provide an error callback and "trace it"

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1607,10 +1607,10 @@ static int error_callback(nghttp2_session *session,
                           size_t len,
                           void *userp)
 {
+  struct Curl_cfilter *cf = userp;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   (void)session;
-  (void)msg;
-  (void)len;
-  (void)userp;
+  CURL_TRC_CF(data, cf, "Error: %.*s", (int)len, msg);
   return 0;
 }
 #endif

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1610,7 +1610,7 @@ static int error_callback(nghttp2_session *session,
   struct Curl_cfilter *cf = userp;
   struct Curl_easy *data = CF_DATA_CURRENT(cf);
   (void)session;
-  CURL_TRC_CF(data, cf, "Error: %.*s", (int)len, msg);
+  failf(data, "Error: %.*s", (int)len, msg);
   return 0;
 }
 #endif

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1610,7 +1610,7 @@ static int error_callback(nghttp2_session *session,
   struct Curl_cfilter *cf = userp;
   struct Curl_easy *data = CF_DATA_CURRENT(cf);
   (void)session;
-  failf(data, "Error: %.*s", (int)len, msg);
+  failf(data, "%.*s", (int)len, msg);
   return 0;
 }
 #endif


### PR DESCRIPTION
Getting nghttp2's error message into the trace output helps a user understand what's going on. For example when the connection is brought down due a forbidden header is used - as that header is then not displayed by curl itself.

Example:

 * [HTTP/2] Error: Invalid HTTP header field was received: frame type: 1,
   stream: 1, name: [upgrade], value: [h2,h2c]

Ref: #12172