### PR TITLE
quiche: use a quiche_conn_peer_transport_params()

### DIFF
--- a/.github/workflows/quiche-linux.yml
+++ b/.github/workflows/quiche-linux.yml
@@ -50,7 +50,7 @@ env:
   nghttp3-version: v1.0.0
   ngtcp2-version: v1.0.1
   nghttp2-version: v1.58.0
-  quiche-version: 0.17.2
+  quiche-version: 0.19.0
   mod_h2-version: v2.0.25
 
 jobs:

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1610,13 +1610,14 @@ static bool cf_quiche_conn_is_alive(struct Curl_cfilter *cf,
    * may have completely purged it and will no longer respond
    * to any packets from us. */
   {
-    quiche_stats qstats;
+    quiche_transport_params qpeerparams;
     timediff_t idletime;
     uint64_t idle_ms = ctx->max_idle_ms;
 
-    quiche_conn_stats(ctx->qconn, &qstats);
-    if(qstats.peer_max_idle_timeout && qstats.peer_max_idle_timeout < idle_ms)
-      idle_ms = qstats.peer_max_idle_timeout;
+    if(quiche_conn_peer_transport_params(ctx->qconn, &qpeerparams) &&
+       qpeerparams.peer_max_idle_timeout &&
+       qpeerparams.peer_max_idle_timeout < idle_ms)
+      idle_ms = qpeerparams.peer_max_idle_timeout;
     idletime = Curl_timediff(Curl_now(), cf->conn->lastused);
     if(idletime > 0 && (uint64_t)idletime > idle_ms)
       return FALSE;


### PR DESCRIPTION
- There was quiche API changes separating quiche_stats and quiche_transport_params(). Use a new API.
- Bump quiche version to master to test it in CI.