### PR TITLE
page-footer: clarify exit code 25

### DIFF
--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -173,8 +173,8 @@ appears if --fail is used.
 .IP 23
 Write error. Curl could not write data to a local filesystem or similar.
 .IP 25
-FTP could not STOR file. The server denied the STOR operation, used for FTP
-uploading.
+Failed starting the upload. For FTP, the server typically denied the STOR
+command.
 .IP 26
 Read error. Various reading problems.
 .IP 27


### PR DESCRIPTION
- Clarify that curl tool exit code 25 means an upload failed to start.

Exit code 25 is equivalent to CURLE_UPLOAD_FAILED (25). Prior to this change the documentation only mentioned the case of FTP STOR failing.

Reported-by: Emanuele Torre

Ref: https://github.com/curl/curl/blob/curl-8_4_0/docs/libcurl/libcurl-errors.3#L113-L115

Fixes https://github.com/curl/curl/issues/12189
Closes #xxxx