### PR TITLE
openssl: fix infof() to avoid compiler warning for %s with null

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4008,7 +4008,7 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
     infof(data, "SSL connection using %s / %s / %s / %s",
           SSL_get_version(backend->handle),
           SSL_get_cipher(backend->handle),
-          negotiated_group_name == NULL ? NULL : negotiated_group_name,
+          negotiated_group_name? negotiated_group_name : "[blank]",
           OBJ_nid2sn(psigtype_nid));
 
 #ifdef HAS_ALPN


### PR DESCRIPTION
vtls/openssl.c: In function ‘ossl_connect_step2’:
../lib/curl_trc.h:120:10: error: ‘%s’ directive argument is null [-Werror=format-overflow=]
  120 |          Curl_infof(data, __VA_ARGS__); } while(0)
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
vtls/openssl.c:4008:5: note: in expansion of macro ‘infof’
 4008 |     infof(data, "SSL connection using %s / %s / %s / %s",
      |     ^~~~~
vtls/openssl.c:4008:49: note: format string is defined here
 4008 |     infof(data, "SSL connection using %s / %s / %s / %s",
      |                                                 ^~

Follow-up to b6e6d4ff8f253c8b8055bab