### PR TITLE
docs: preserve the modification date when copying the prebuilt man page

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -111,7 +111,8 @@ SUFFIXES = .1 .html .pdf
 # have changed.
 $(abs_builddir)/curl.1:
 	if test "$(top_builddir)x" != "$(top_srcdir)x" -a -e "$(srcdir)/curl.1"; then \
-		$(INSTALL_DATA) "$(srcdir)/curl.1" $@; fi
+		$(INSTALL_DATA) "$(srcdir)/curl.1" $@ \
+		&& touch -r "$(srcdir)/curl.1" $@; fi
 	cd cmdline-opts && $(MAKE)
 
 html: $(HTMLPAGES)


### PR DESCRIPTION
The previously built man page "curl.1" must be copied with the original modification date, otherwise the man page is never updated.

This fixes a bug that has been introduced with commit 2568441cab.