### PR TITLE
cmake: speed up threads setup for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,14 +370,14 @@ if(WIN32)
 endif()
 
 if(ENABLE_THREADED_RESOLVER)
-  find_package(Threads REQUIRED)
   if(WIN32)
     set(USE_THREADS_WIN32 ON)
   else()
+    find_package(Threads REQUIRED)
     set(USE_THREADS_POSIX ${CMAKE_USE_PTHREADS_INIT})
     set(HAVE_PTHREAD_H ${CMAKE_USE_PTHREADS_INIT})
+    set(CURL_LIBS ${CURL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
   endif()
-  set(CURL_LIBS ${CURL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 # Check for all needed libraries


### PR DESCRIPTION
Win32 threads are always available. We enabled them unconditionally
(with `ENABLE_THREADED_RESOLVER`). CMake built-in thread detection
logic has this condition hard-coded for Windows as well (since at least
2007).

Instead of doing all the work of detecting pthread combinations on
Windows, then discarding those results, skip these efforts and assume
built-in thread support when building for Windows.

This saves 1-3 slow CMake configuration steps.

Closes #12202

---

The side effect is that on some targets `phtread` is no longer linked
automatically to curl even when curl itself did not require or use it.
This was seen to happen with mingw-w64 on x86 and arm64 targets
(but not with x64), causing the `.map` file referencing `pthread` lib, but
without any actual use. If a curl dependency requires `pthread` and the
dependency's CMake logic doesn't add it automatically, it needs to be
added manually to make it link in all cases, e.g. for BoringSSL with
mingw-w64, where it was already required for x64, but possibly worked
by accident for x86 and arm64.

Ref: https://github.com/curl/curl-for-win/commit/74dd96735ba9bb9089d9d1a070da2a87cbb55d04#diff-98a81cf13297dad2803e548fe3ad9245cd8a732054f6ed89bff7360deaa3dff2R168-R170