### PR TITLE
url: fix build when form API is disabled

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -455,8 +455,8 @@ CURLcode Curl_close(struct Curl_easy **datap)
   }
 #endif
 
+#ifndef CURL_DISABLE_FORM_API
   Curl_mime_cleanpart(data->state.formp);
-#ifndef CURL_DISABLE_HTTP
   Curl_safefree(data->state.formp);
 #endif
 


### PR DESCRIPTION
I checked other places in the codebase where this same cleanup is done and they all seem to be guarded by the same #ifndef so I also changed that to match.