### PR TITLE
DOH, use PIPEWAIT when HTTP/2 is attempted

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -252,6 +252,7 @@ static CURLcode dohprobe(struct Curl_easy *data,
     ERROR_CHECK_SETOPT(CURLOPT_HTTPHEADER, headers);
 #ifdef USE_HTTP2
     ERROR_CHECK_SETOPT(CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
+    ERROR_CHECK_SETOPT(CURLOPT_PIPEWAIT, 1L);
 #endif
 #ifndef CURLDEBUG
     /* enforce HTTPS if not debug */


### PR DESCRIPTION
It this is more/less performant than using 2 connection (A and AAAA records) depends largely on network conditions and handshake time. But using only a single connection seems beneficial in any case.

This does not make any difference once the DOH connection is live in the cache, of course.