### PR TITLE
hostip: silence compiler warning `-Wparentheses-equality`

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1333,9 +1333,9 @@ static void show_resolve_info(struct Curl_easy *data,
   while(a) {
     if(
 #ifdef CURLRES_IPV6
-       (a->ai_family == PF_INET6) ||
+       a->ai_family == PF_INET6 ||
 #endif
-       (a->ai_family == PF_INET)) {
+       a->ai_family == PF_INET) {
       char buf[MAX_IPADR_LEN];
       struct dynbuf *d = &out[(a->ai_family != PF_INET)];
       Curl_printable_address(a, buf, sizeof(buf));


### PR DESCRIPTION
Seen with LLVM 17.

```
hostip.c:1336:22: warning: equality comparison with extraneous parentheses [-Wparentheses-equality]
 1336 |        (a->ai_family == PF_INET)) {
      |         ~~~~~~~~~~~~~^~~~~~~~~~
hostip.c:1336:22: note: remove extraneous parentheses around the comparison to silence this warning
 1336 |        (a->ai_family == PF_INET)) {
      |        ~             ^         ~
hostip.c:1336:22: note: use '=' to turn this equality comparison into an assignment
 1336 |        (a->ai_family == PF_INET)) {
      |                      ^~
      |                      =
1 warning generated.
```

Follow-up to b651aba0962bb31353f55de4dc35f745952a1b10 #12145

Closes #12215