### PR TITLE
Makefile.mk: restore `_mingw.h` for default `_WIN32_WINNT`

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -28,6 +28,11 @@
 #define CURL_NO_OLDIES
 #endif
 
+/* Set default _WIN32_WINNT */
+#ifdef __MINGW32__
+#include <_mingw.h>
+#endif
+
 /*
  * Disable Visual Studio warnings:
  * 4127 "conditional expression is constant"


### PR DESCRIPTION
In 8.4.0 we deleted `_mingw.h` as part of purging old-mingw support.
Turns out `_mingw.h` had the side-effect of setting a default
`_WIN32_WINNT` value expected by `lib/config-win32.h` to enable
`getaddrinfo` support in `Makefile.mk` mingw-w64 builds. This caused
disabling support for this unless specifying the value manually.

Restore this header and update its comment to tell why we continue
to need it.

This triggered a regression in official Windows curl builds starting
with 8.4.0_1. Fixed in 8.4.0_6. (8.5.0 will be using CMake.)

Regression from 38029101e2d78ba125732b3bab6ec267b80a0e72 #11625

Reported-by: zhengqwe on github
Helped-by: Nico Rieck
Fixes #12134
Fixes #12136
Closes #12217
