### PR TITLE
wolfssl: add default case for wolfssl_connect_step1 switch

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -480,6 +480,7 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
       return CURLE_SSL_CONNECT_ERROR;
     }
 #endif
+  default:
     break;
   }
 


### PR DESCRIPTION
Fixes ZD#16824.
Customer is using a strict compiler which requires default cases for all switch statements.