### PR TITLE
websocket: add option to disable auto-pong reply

### DIFF
--- a/docs/internals/WEBSOCKET.md
+++ b/docs/internals/WEBSOCKET.md
@@ -39,7 +39,8 @@ WebSocket with libcurl can be done two ways.
 The new options to `curl_easy_setopt()`:
 
  `CURLOPT_WS_OPTIONS` - to control specific behavior. `CURLWS_RAW_MODE` makes
- libcurl provide all WebSocket traffic raw in the callback.
+ libcurl provide all WebSocket traffic raw in the callback.  `CURLWS_NOAUTOPONG`
+ disables automatic `PONG` replies.
 
 The new function calls:
 

--- a/docs/libcurl/opts/CURLOPT_WS_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_WS_OPTIONS.md
@@ -44,6 +44,12 @@ callback.
 In raw mode, libcurl does not handle pings or any other frame for the
 application.
 
+## CURLWS_NOAUTOPONG (2)
+
+Disable the automatic reply to PING messages. This means users must
+send a PONG message with curl_ws_send(3). This feature is added with
+version 8.10.0.
+
 # DEFAULT
 
 0

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -1145,6 +1145,7 @@ CURLWS_OFFSET                   7.86.0
 CURLWS_PING                     7.86.0
 CURLWS_PONG                     7.86.0
 CURLWS_RAW_MODE                 7.86.0
+CURLWS_NOAUTOPONG               8.10.0
 CURLWS_TEXT                     7.86.0
 LIBCURL_COPYRIGHT               7.18.0
 LIBCURL_TIMESTAMP               7.16.2

--- a/include/curl/websockets.h
+++ b/include/curl/websockets.h
@@ -73,7 +73,8 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *curl, const void *buffer,
                                   unsigned int flags);
 
 /* bits for the CURLOPT_WS_OPTIONS bitmask: */
-#define CURLWS_RAW_MODE (1<<0)
+#define CURLWS_RAW_MODE   (1<<0)
+#define CURLWS_NOAUTOPONG (1<<1)
 
 CURL_EXTERN const struct curl_ws_frame *curl_ws_meta(CURL *curl);
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -3181,9 +3181,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 #ifdef USE_WEBSOCKETS
   case CURLOPT_WS_OPTIONS: {
     bool raw;
+    bool no_auto_pong;
     arg = va_arg(param, long);
     raw = (arg & CURLWS_RAW_MODE);
     data->set.ws_raw_mode = raw;
+    no_auto_pong = (arg & CURLWS_NOAUTOPONG);
+    data->set.ws_no_auto_pong = no_auto_pong;
     break;
   }
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1868,6 +1868,7 @@ struct UserDefined {
   BIT(http09_allowed); /* allow HTTP/0.9 responses */
 #ifdef USE_WEBSOCKETS
   BIT(ws_raw_mode);
+  BIT(ws_no_auto_pong);
 #endif
 #ifdef USE_ECH
   int tls_ech;      /* TLS ECH configuration  */

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -396,10 +396,13 @@ static ssize_t ws_cw_dec_next(const unsigned char *buf, size_t buflen,
   struct ws_cw_dec_ctx *ctx = user_data;
   struct Curl_easy *data = ctx->data;
   struct websocket *ws = ctx->ws;
+  bool auto_pong;
   curl_off_t remain = (payload_len - (payload_offset + buflen));
 
   (void)frame_age;
-  if((frame_flags & CURLWS_PING) && !remain) {
+
+  auto_pong = !data->set.ws_no_auto_pong;
+  if(auto_pong && (frame_flags & CURLWS_PING) && !remain) {
     /* auto-respond to PINGs, only works for single-frame payloads atm */
     size_t bytes;
     infof(data, "WS: auto-respond to PING with a PONG");

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -84,6 +84,7 @@
 2305
 # response body seem not to be handled by hyper
 2307
+2309
 %endif
 2043
 # The CRL test doesn't work with wolfSSL

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -253,7 +253,7 @@ test2100 \
 test2200 test2201 test2202 test2203 test2204 test2205 \
 \
 test2300 test2301 test2302 test2303 test2304 test2305 test2306 test2307 \
-test2308 \
+test2308 test2309 \
 \
 test2400 test2401 test2402 test2403 test2404 test2405 test2406 \
 \

--- a/tests/data/test2309
+++ b/tests/data/test2309
@@ -1,0 +1,66 @@
+<testcase>
+<info>
+<keywords>
+WebSockets
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes" nonewline="yes">
+HTTP/1.1 101 Switching to WebSockets swsclose
+Server: test-server/fake
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
+
+%hex[%89%00]hex%
+</data>
+# allow upgrade
+<servercmd>
+upgrade
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+# for the forced CURL_ENTROPY
+<features>
+debug
+ws
+</features>
+<server>
+http
+</server>
+<name>
+WebSockets no auto ping
+</name>
+<tool>
+lib%TESTNUMBER
+</tool>
+<command>
+ws://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol nocheck="yes">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: webbie-sox/3
+Accept: */*
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Version: 13
+Sec-WebSocket-Key: NDMyMTUzMjE2MzIxNzMyMQ==
+
+</protocol>
+<errorcode>
+0
+</errorcode>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -75,6 +75,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect libprereq      \
  lib1960 lib1964 \
  lib1970 lib1971 lib1972 lib1973 lib1974 lib1975 \
  lib2301 lib2302 lib2304 lib2305 lib2306         lib2308 \
+ lib2309 \
  lib2402 lib2404 lib2405 \
  lib2502 \
  lib3010 lib3025 lib3026 lib3027 \
@@ -683,6 +684,9 @@ lib2306_LDADD = $(TESTUTIL_LIBS)
 
 lib2308_SOURCES = lib2308.c $(SUPPORTFILES)
 lib2308_LDADD = $(TESTUTIL_LIBS)
+
+lib2309_SOURCES = lib2309.c $(SUPPORTFILES)
+lib2309_LDADD = $(TESTUTIL_LIBS)
 
 lib2402_SOURCES = lib2402.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib2402_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib2309.c
+++ b/tests/libtest/lib2309.c
@@ -1,0 +1,102 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "test.h"
+
+#ifdef USE_WEBSOCKETS
+
+struct ping_check {
+  CURL *curl;
+  int pinged;
+};
+
+static size_t write_cb(char *b, size_t size, size_t nitems, void *p)
+{
+  struct ping_check *ping_check = p;
+  CURL *curl = ping_check->curl;
+  const struct curl_ws_frame *frame = curl_ws_meta(curl);
+  size_t sent = 0;
+  size_t i = 0;
+
+  /* upon ping, respond with input data, disconnect, mark a success */
+  if(frame->flags & CURLWS_PING) {
+    fprintf(stderr, "write_cb received ping with %zd bytes\n",
+      size * nitems);
+    fprintf(stderr, "\n");
+    for(i = 0; i < size * nitems; i++) {
+      fprintf(stderr, "%02X%s", (int)b[i],
+          (i % 10 == 0 && i != 0) ? "\n" : " ");
+    }
+    fprintf(stderr, "\n");
+    fprintf(stderr, "write_cb sending pong response\n");
+    curl_ws_send(curl, b, size * nitems, &sent, 0, CURLWS_PONG);
+    fprintf(stderr, "write_cb closing websocket\n");
+    curl_ws_send(curl, NULL, 0, &sent, 0, CURLWS_CLOSE);
+    ping_check->pinged = 1;
+  }
+  else {
+    fprintf(stderr, "ping_check_cb: non-ping message, frame->flags %x\n",
+      frame->flags);
+  }
+
+  return size * nitems;
+}
+
+CURLcode test(char *URL)
+{
+  CURL *curl;
+  CURLcode res = CURLE_OK;
+  struct ping_check state;
+
+  global_init(CURL_GLOBAL_ALL);
+
+  curl = curl_easy_init();
+  if(curl) {
+    state.curl = curl;
+    state.pinged = 0;
+
+    curl_easy_setopt(curl, CURLOPT_URL, URL);
+
+    /* use the callback style, without auto-pong */
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "webbie-sox/3");
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+    curl_easy_setopt(curl, CURLOPT_WS_OPTIONS, (long)CURLWS_NOAUTOPONG);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &state);
+
+    res = curl_easy_perform(curl);
+    fprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
+
+    res = state.pinged ? 0 : 1;
+
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+  }
+  curl_global_cleanup();
+  return (int)res;
+}
+
+#else /* no websockets */
+NO_SUPPORT_BUILT_IN
+#endif


### PR DESCRIPTION
This adds another bitflag on CURLOPT_WS_OPTIONS (CURLWS_NOAUTOPONG (2))
that disables the default and automatic PONG reply in the WebSocket
layer.

Ideally, this will complete the "Provide option to disable PING-PONG automation"
item on the "Future Work" section of [this](https://curl.se/docs/websocket.html).

Authored-by: brimonk on github