### PR TITLE
curl_setup: disallow Windows IPv6 builds missing getaddrinfo

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -581,6 +581,9 @@
 
 #if defined(ENABLE_IPV6) && defined(HAVE_GETADDRINFO)
 #  define CURLRES_IPV6
+#elif defined(ENABLE_IPV6) && (defined(WIN32) || defined(__CYGWIN__))
+/* assume on Windows that IPv6 without getaddrinfo is a broken build */
+#  error "Unexpected build: IPv6 is enabled but getaddrinfo was not found."
 #else
 #  define CURLRES_IPV4
 #endif


### PR DESCRIPTION
- On Windows if IPv6 is enabled but getaddrinfo is missing then #error the build.

curl can be built with IPv6 support (ENABLE_IPV6) but without the ability to resolve hosts to IPv6 addresses (HAVE_GETADDRINFO). On Windows this is highly unlikely and should be considered a bad build configuration.

Such a bad configuration has already given us a bug that was hard to diagnose. See #12134 and #12136 for discussion.

Ref: https://github.com/curl/curl/issues/12134
Ref: https://github.com/curl/curl/pull/12136

Closes #xxxx