### PR TITLE
build: delete support bits for obsolete Windows compilers

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -45,7 +45,7 @@
 #define HAVE_LOCALE_H 1
 
 /* Define if you need <malloc.h> header even with <stdlib.h> header file. */
-#if !defined(__SALFORDC__) && !defined(__POCC__)
+#if !defined(__SALFORDC__)
 #define NEED_MALLOC_H 1
 #endif
 
@@ -97,7 +97,7 @@
 /* #define HAVE_TERMIOS_H 1 */
 
 /* Define if you have the <unistd.h> header file. */
-#if defined(__MINGW32__) || defined(__LCC__) || defined(__POCC__)
+#if defined(__MINGW32__) || defined(__LCC__)
 #define HAVE_UNISTD_H 1
 #endif
 
@@ -187,8 +187,7 @@
 #define HAVE_STRICMP 1
 
 /* Define if you have the strtoll function. */
-#if defined(__MINGW32__) || defined(__POCC__) || \
-    (defined(_MSC_VER) && (_MSC_VER >= 1800))
+#if (defined(_MSC_VER) && (_MSC_VER >= 1800)) || defined(__MINGW32__)
 #define HAVE_STRTOLL 1
 #endif
 
@@ -270,7 +269,7 @@
 
 /* Define if ssize_t is not an available 'typedefed' type. */
 #ifndef _SSIZE_T_DEFINED
-#  if defined(__POCC__) || defined(__MINGW32__)
+#  if defined(__MINGW32__)
 #  elif defined(_WIN64)
 #    define _SSIZE_T_DEFINED
 #    define ssize_t __int64
@@ -447,30 +446,10 @@ Vista
 #  endif
 #endif
 
-/* When no build target is specified Pelles C 5.00 and later default build
-   target is Windows Vista. We override default target to be Windows 2000. */
-#if defined(__POCC__) && (__POCC__ >= 500)
-#  ifndef _WIN32_WINNT
-#    define _WIN32_WINNT 0x0500
-#  endif
-#  ifndef WINVER
-#    define WINVER 0x0500
-#  endif
-#endif
-
 /* Windows XP is required for freeaddrinfo, getaddrinfo */
 #define HAVE_FREEADDRINFO           1
 #define HAVE_GETADDRINFO            1
 #define HAVE_GETADDRINFO_THREADSAFE 1
-
-#if defined(__POCC__)
-#  ifndef _MSC_VER
-#    error Microsoft extensions /Ze compiler option is required
-#  endif
-#  ifndef __POCC__OLDNAMES
-#    error Compatibility names /Go compiler option is required
-#  endif
-#endif
 
 /* ---------------------------------------------------------------- */
 /*                          STRUCT RELATED                          */
@@ -501,10 +480,6 @@ Vista
 
 #if defined(__MINGW32__) && !defined(USE_WIN32_LARGE_FILES)
 #  define USE_WIN32_LARGE_FILES
-#endif
-
-#if defined(__POCC__)
-#  undef USE_WIN32_LARGE_FILES
 #endif
 
 #if !defined(USE_WIN32_LARGE_FILES) && !defined(USE_WIN32_SMALL_FILES)
@@ -568,10 +543,6 @@ Vista
 #define USE_WIN32_LDAP 1
 #endif
 
-#if defined(__POCC__) && defined(USE_WIN32_LDAP)
-#  define CURL_DISABLE_LDAP 1
-#endif
-
 /* Define to use the Windows crypto library. */
 #if !defined(CURL_WINDOWS_APP)
 #define USE_WIN32_CRYPTO
@@ -607,7 +578,7 @@ Vista
 /* If you want to build curl with the built-in manual */
 #define USE_MANUAL 1
 
-#if defined(__POCC__) || defined(USE_IPV6)
+#if defined(USE_IPV6)
 #  define ENABLE_IPV6 1
 #endif
 

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -86,9 +86,7 @@
 #define HAVE_SYS_TYPES_H 1
 
 /* Define if you have the <sys/utime.h> header file. */
-#ifndef __BORLANDC__
 #define HAVE_SYS_UTIME_H 1
-#endif
 
 /* Define if you have the <termio.h> header file. */
 /* #define HAVE_TERMIO_H 1 */
@@ -192,9 +190,7 @@
 #endif
 
 /* Define if you have the utime function. */
-#ifndef __BORLANDC__
 #define HAVE_UTIME 1
-#endif
 
 /* Define if you have the recv function. */
 #define HAVE_RECV 1
@@ -362,9 +358,7 @@
 /* #undef HAVE_GMTIME_R */
 
 /* Define if the compiler supports the 'long long' data type. */
-#if defined(__MINGW32__) || \
-    (defined(_MSC_VER)     && (_MSC_VER     >= 1310)) || \
-    (defined(__BORLANDC__) && (__BORLANDC__ >= 0x561))
+#if (defined(_MSC_VER) && (_MSC_VER >= 1310)) || defined(__MINGW32__)
 #define HAVE_LONGLONG 1
 #endif
 
@@ -456,7 +450,7 @@ Vista
 /* ---------------------------------------------------------------- */
 
 /* Define if you have struct sockaddr_storage. */
-#if !defined(__SALFORDC__) && !defined(__BORLANDC__)
+#if !defined(__SALFORDC__)
 #define HAVE_STRUCT_SOCKADDR_STORAGE 1
 #endif
 

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -95,7 +95,7 @@
 /* #define HAVE_TERMIOS_H 1 */
 
 /* Define if you have the <unistd.h> header file. */
-#if defined(__MINGW32__) || defined(__LCC__)
+#if defined(__MINGW32__)
 #define HAVE_UNISTD_H 1
 #endif
 

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -45,9 +45,7 @@
 #define HAVE_LOCALE_H 1
 
 /* Define if you need <malloc.h> header even with <stdlib.h> header file. */
-#if !defined(__SALFORDC__)
 #define NEED_MALLOC_H 1
-#endif
 
 /* Define if you have the <netdb.h> header file. */
 /* #define HAVE_NETDB_H 1 */
@@ -103,14 +101,10 @@
 #define HAVE_WINDOWS_H 1
 
 /* Define if you have the <winsock2.h> header file. */
-#ifndef __SALFORDC__
 #define HAVE_WINSOCK2_H 1
-#endif
 
 /* Define if you have the <ws2tcpip.h> header file. */
-#ifndef __SALFORDC__
 #define HAVE_WS2TCPIP_H 1
-#endif
 
 /* Define to 1 if you have the <libgen.h> header file. */
 #if defined(__MINGW32__)
@@ -450,9 +444,7 @@ Vista
 /* ---------------------------------------------------------------- */
 
 /* Define if you have struct sockaddr_storage. */
-#if !defined(__SALFORDC__)
 #define HAVE_STRUCT_SOCKADDR_STORAGE 1
-#endif
 
 /* Define if you have struct timeval. */
 #define HAVE_STRUCT_TIMEVAL 1

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -81,7 +81,7 @@
 /* #define HAVE_TERMIOS_H 1 */
 
 /* Define if you have the <unistd.h> header file.  */
-#if defined(__MINGW32__) || defined(__LCC__)
+#if defined(__MINGW32__)
 #define HAVE_UNISTD_H 1
 #endif
 

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -190,8 +190,7 @@
 #define in_addr_t unsigned long
 
 /* Define ssize_t if it is not an available 'typedefed' type */
-#if defined(__POCC__)
-#elif defined(_WIN64)
+#if defined(_WIN64)
 #define ssize_t __int64
 #else
 #define ssize_t int

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -573,15 +573,6 @@
 /* ---------------------------------------------------------------- */
 
 /*
- * lcc-win32 doesn't have _beginthreadex(), lacks threads support.
- */
-
-#if defined(__LCC__) && defined(WIN32)
-#  undef USE_THREADS_POSIX
-#  undef USE_THREADS_WIN32
-#endif
-
-/*
  * MSVC threads support requires a multi-threaded runtime library.
  * _beginthreadex() is not available in single-threaded ones.
  */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -353,12 +353,6 @@
 #include <curl/stdcheaders.h>
 #endif
 
-#ifdef __POCC__
-#  include <sys/types.h>
-#  include <unistd.h>
-#  define sys_nerr EILSEQ
-#endif
-
 /*
  * Salford-C kludge section (mostly borrowed from wxWidgets).
  */
@@ -563,7 +557,7 @@
  * Does not apply if lwIP is used.
  */
 
-#if defined(_MSC_VER) && !defined(__POCC__) && !defined(USE_LWIPSOCK)
+#if defined(_MSC_VER) && !defined(USE_LWIPSOCK)
 #  if !defined(HAVE_WS2TCPIP_H) || \
      ((_MSC_VER < 1300) && !defined(INET6_ADDRSTRLEN))
 #    undef HAVE_GETADDRINFO_THREADSAFE
@@ -592,7 +586,7 @@
  * _beginthreadex() is not available in single-threaded ones.
  */
 
-#if defined(_MSC_VER) && !defined(__POCC__) && !defined(_MT)
+#if defined(_MSC_VER) && !defined(_MT)
 #  undef USE_THREADS_POSIX
 #  undef USE_THREADS_WIN32
 #endif
@@ -631,7 +625,7 @@
  * are available if PSDK is properly installed.
  */
 
-#if defined(_MSC_VER) && !defined(__POCC__)
+#if defined(_MSC_VER)
 #  if !defined(HAVE_WINSOCK2_H) || ((_MSC_VER < 1300) && !defined(IPPROTO_ESP))
 #    undef HAVE_STRUCT_SOCKADDR_STORAGE
 #  endif
@@ -643,7 +637,7 @@
  * in lib/config-win32.h although absolutely discouraged and unsupported.
  */
 
-#if defined(_MSC_VER) && !defined(__POCC__)
+#if defined(_MSC_VER)
 #  if !defined(HAVE_WINDOWS_H) || ((_MSC_VER < 1300) && !defined(_FILETIME_))
 #    if !defined(ALLOW_MSVC6_WITHOUT_PSDK)
 #      error MSVC 6.0 requires "February 2003 Platform SDK" a.k.a. \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -354,17 +354,6 @@
 #endif
 
 /*
- * Salford-C kludge section (mostly borrowed from wxWidgets).
- */
-#ifdef __SALFORDC__
-  #pragma suppress 353             /* Possible nested comments */
-  #pragma suppress 593             /* Define not used */
-  #pragma suppress 61              /* enum has no name */
-  #pragma suppress 106             /* unnamed, unused parameter */
-  #include <clib.h>
-#endif
-
-/*
  * Large file (>2Gb) support using WIN32 functions.
  */
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -540,22 +540,6 @@
 
 #endif /* WIN32 */
 
-/*
- * msvc 6.0 requires PSDK in order to have INET6_ADDRSTRLEN
- * defined in ws2tcpip.h as well as to provide IPv6 support.
- * Does not apply if lwIP is used.
- */
-
-#if defined(_MSC_VER) && !defined(USE_LWIPSOCK)
-#  if !defined(HAVE_WS2TCPIP_H) || \
-     ((_MSC_VER < 1300) && !defined(INET6_ADDRSTRLEN))
-#    undef HAVE_GETADDRINFO_THREADSAFE
-#    undef HAVE_FREEADDRINFO
-#    undef HAVE_GETADDRINFO
-#    undef ENABLE_IPV6
-#  endif
-#endif
-
 /* ---------------------------------------------------------------- */
 /*             resolver specialty compile-time defines              */
 /*         CURLRES_* defines to use in the host*.c sources          */
@@ -598,35 +582,6 @@
 #endif
 
 /* ---------------------------------------------------------------- */
-
-/*
- * msvc 6.0 does not have struct sockaddr_storage and
- * does not define IPPROTO_ESP in winsock2.h. But both
- * are available if PSDK is properly installed.
- */
-
-#if defined(_MSC_VER)
-#  if !defined(HAVE_WINSOCK2_H) || ((_MSC_VER < 1300) && !defined(IPPROTO_ESP))
-#    undef HAVE_STRUCT_SOCKADDR_STORAGE
-#  endif
-#endif
-
-/*
- * Intentionally fail to build when using msvc 6.0 without PSDK installed.
- * The brave of heart can circumvent this, defining ALLOW_MSVC6_WITHOUT_PSDK
- * in lib/config-win32.h although absolutely discouraged and unsupported.
- */
-
-#if defined(_MSC_VER)
-#  if !defined(HAVE_WINDOWS_H) || ((_MSC_VER < 1300) && !defined(_FILETIME_))
-#    if !defined(ALLOW_MSVC6_WITHOUT_PSDK)
-#      error MSVC 6.0 requires "February 2003 Platform SDK" a.k.a. \
-             "Windows Server 2003 PSDK"
-#    else
-#      define CURL_DISABLE_LDAP 1
-#    endif
-#  endif
-#endif
 
 #if defined(HAVE_LIBIDN2) && defined(HAVE_IDN2_H) && !defined(USE_WIN32_IDN)
 /* The lib and header are present */

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -112,7 +112,7 @@ static curl_simple_lock s_lock = CURL_SIMPLE_LOCK_INIT;
 #define system_strdup strdup
 #endif
 
-#if defined(_MSC_VER) && defined(_DLL) && !defined(__POCC__)
+#if defined(_MSC_VER) && defined(_DLL)
 #  pragma warning(disable:4232) /* MSVC extension, dllimport identity */
 #endif
 
@@ -129,7 +129,7 @@ curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
 curl_wcsdup_callback Curl_cwcsdup = Curl_wcsdup;
 #endif
 
-#if defined(_MSC_VER) && defined(_DLL) && !defined(__POCC__)
+#if defined(_MSC_VER) && defined(_DLL)
 #  pragma warning(default:4232) /* MSVC extension, dllimport identity */
 #endif
 

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -67,7 +67,6 @@
  */
 
 #if (defined(__BORLANDC__) && (__BORLANDC__ >= 0x520)) || \
-    (defined(__POCC__) && defined(_MSC_VER)) || \
     (defined(_WIN32_WCE)) || \
     (defined(__MINGW32__)) || \
     (defined(_MSC_VER) && (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64))

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -66,8 +66,7 @@
  * Non-ANSI integer extensions
  */
 
-#if (defined(__BORLANDC__) && (__BORLANDC__ >= 0x520)) || \
-    (defined(_WIN32_WCE)) || \
+#if (defined(_WIN32_WCE)) || \
     (defined(__MINGW32__)) || \
     (defined(_MSC_VER) && (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64))
 #  define MP_HAVE_INT_EXTENSIONS

--- a/lib/share.h
+++ b/lib/share.h
@@ -31,14 +31,6 @@
 #include "urldata.h"
 #include "conncache.h"
 
-/* SalfordC says "A structure member may not be volatile". Hence:
- */
-#ifdef __SALFORDC__
-#define CURL_VOLATILE
-#else
-#define CURL_VOLATILE volatile
-#endif
-
 #define CURL_GOOD_SHARE 0x7e117a1e
 #define GOOD_SHARE_HANDLE(x) ((x) && (x)->magic == CURL_GOOD_SHARE)
 
@@ -46,7 +38,7 @@
 struct Curl_share {
   unsigned int magic; /* CURL_GOOD_SHARE */
   unsigned int specifier;
-  CURL_VOLATILE unsigned int dirty;
+  volatile unsigned int dirty;
 
   curl_lock_function lockfunc;
   curl_unlock_function unlockfunc;

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -48,7 +48,6 @@ AC_DEFUN([CURL_CHECK_COMPILER], [
   CURL_CHECK_COMPILER_INTEL_C
   CURL_CHECK_COMPILER_CLANG
   CURL_CHECK_COMPILER_GNU_C
-  CURL_CHECK_COMPILER_LCC
   CURL_CHECK_COMPILER_SGI_MIPSPRO_C
   CURL_CHECK_COMPILER_SGI_MIPS_C
   CURL_CHECK_COMPILER_SUNPRO_C
@@ -247,26 +246,6 @@ AC_DEFUN([CURL_CHECK_COMPILER_INTEL_C], [
       flags_opt_yes="/O2"
       flags_opt_off="/Od"
     fi
-  else
-    AC_MSG_RESULT([no])
-  fi
-])
-
-
-dnl CURL_CHECK_COMPILER_LCC
-dnl -------------------------------------------------
-dnl Verify if compiler being used is LCC.
-
-AC_DEFUN([CURL_CHECK_COMPILER_LCC], [
-  AC_MSG_CHECKING([if compiler is LCC])
-  CURL_CHECK_DEF([__LCC__], [], [silent])
-  if test "$curl_cv_have_def___LCC__" = "yes"; then
-    AC_MSG_RESULT([yes])
-    compiler_id="LCC"
-    flags_dbg_yes="-g"
-    flags_opt_all=""
-    flags_opt_yes=""
-    flags_opt_off=""
   else
     AC_MSG_RESULT([no])
   fi

--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -98,16 +98,6 @@ int tool_seek_cb(void *userdata, curl_off_t offset, int whence)
 #  define _lseeki64(hnd,ofs,whence) lseek(hnd,ofs,whence)
 #endif
 
-#ifdef __POCC__
-#  if(__POCC__ < 450)
-/* 64-bit lseek-like function unavailable */
-#    define _lseeki64(hnd,ofs,whence) _lseek(hnd,ofs,whence)
-#  else
-#    undef _lseeki64
-#    define _lseeki64(hnd,ofs,whence) _lseek64(hnd,ofs,whence)
-#  endif
-#endif
-
 #ifdef _WIN32_WCE
 /* 64-bit lseek-like function unavailable */
 #  undef _lseeki64

--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -93,11 +93,6 @@ int tool_seek_cb(void *userdata, curl_off_t offset, int whence)
 
 #ifdef USE_TOOL_FTRUNCATE
 
-#ifdef __BORLANDC__
-/* 64-bit lseek-like function unavailable */
-#  define _lseeki64(hnd,ofs,whence) lseek(hnd,ofs,whence)
-#endif
-
 #ifdef _WIN32_WCE
 /* 64-bit lseek-like function unavailable */
 #  undef _lseeki64


### PR DESCRIPTION
- Pelles C: Unclear status, failed to obtain a fresh copy a few months
  ago. Possible website is HTTP-only. ~10 years ago I left this compiler
  dealing with crashes and other issues with no response on the forum
  for years. It has seen some activity in curl back in 2021.
- LCC: Last stable release in September 2002.
- Salford C: Misses winsock2 support, possibly abandoned? Last mentioned
  in 2006.
- Borland C++: We dropped Borland C++ support in 2018.
- MS Visual C++ 6.0: Released in 1998. curl already requires VS 2010
  (or possibly 2008) as a minimum.

Closes #12222

Let me know if any/some of these is still important and we actively support it.
