### PR TITLE
Makefile.mk: drop Windows support

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -481,7 +481,6 @@ Windows:
   - all:
       - changed-files:
           - any-glob-to-all-files:
-              - '**/Makefile.mk'
               - 'appveyor.yml'
               - 'CMake/Platforms/WindowsCache.cmake'
               - 'lib/*win32*'

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -30,27 +30,6 @@ ssl:
 	./configure --with-openssl
 	make
 
-mingw32:
-	$(MAKE) -C lib -f Makefile.mk
-	$(MAKE) -C src -f Makefile.mk
-
-mingw32-clean:
-	$(MAKE) -C lib -f Makefile.mk clean
-	$(MAKE) -C src -f Makefile.mk clean
-	$(MAKE) -C docs/examples -f Makefile.mk clean
-
-mingw32-vclean mingw32-distclean:
-	$(MAKE) -C lib -f Makefile.mk vclean
-	$(MAKE) -C src -f Makefile.mk vclean
-	$(MAKE) -C docs/examples -f Makefile.mk vclean
-
-mingw32-examples%:
-	$(MAKE) -C docs/examples -f Makefile.mk CFG=$@
-
-mingw32%:
-	$(MAKE) -C lib -f Makefile.mk CFG=$@
-	$(MAKE) -C src -f Makefile.mk CFG=$@
-
 vc:
 	cd winbuild
 	nmake /f Makefile.vc MACHINE=x86

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -185,54 +185,6 @@ multi-threaded dynamic C runtime.
 
  If you get linkage errors read section 5.7 of the FAQ document.
 
-## mingw-w64
-
-Make sure that mingw-w64's bin directory is in the search path, for example:
-
-```cmd
-set PATH=c:\mingw-w64\bin;%PATH%
-```
-
-then run `mingw32-make mingw32` in the root dir. There are other
-make targets available to build libcurl with more features, use:
-
- - `mingw32-make mingw32-zlib` to build with Zlib support;
- - `mingw32-make mingw32-ssl-zlib` to build with SSL and Zlib enabled;
- - `mingw32-make mingw32-ssh2-ssl-zlib` to build with SSH2, SSL, Zlib;
- - `mingw32-make mingw32-ssh2-ssl-sspi-zlib` to build with SSH2, SSL, Zlib
-   and SSPI support.
-
-If you have any problems linking libraries or finding header files, be sure
-to verify that the provided `Makefile.mk` files use the proper paths, and
-adjust as necessary. It is also possible to override these paths with
-environment variables, for example:
-
-```cmd
-set ZLIB_PATH=c:\zlib-1.2.12
-set OPENSSL_PATH=c:\openssl-3.0.5
-set LIBSSH2_PATH=c:\libssh2-1.10.0
-```
-
-It is also possible to build with other LDAP installations than MS LDAP;
-currently it is possible to build with native Win32 OpenLDAP, or with the
-*Novell CLDAP* SDK. If you want to use these you need to set these vars:
-
-```cmd
-set CPPFLAGS=-Ic:/openldap/include -DCURL_HAS_OPENLDAP_LDAPSDK
-set LDFLAGS=-Lc:/openldap/lib
-set LIBS=-lldap -llber
-```
-
-or for using the Novell SDK:
-
-```cmd
-set CPPFLAGS=-Ic:/openldapsdk/inc -DCURL_HAS_NOVELL_LDAPSDK
-set LDFLAGS=-Lc:/openldapsdk/lib/mscvc
-set LIBS=-lldapsdk -lldapssl -lldapx
-```
-
-If you want to enable LDAPS support then append `-ldaps` to the make target.
-
 ## Cygwin
 
 Almost identical to the Unix installation. Run the configure script in the

--- a/docs/examples/Makefile.mk
+++ b/docs/examples/Makefile.mk
@@ -26,10 +26,6 @@
 
 PROOT := ../..
 
-ifeq ($(findstring -static,$(CFG)),)
-  DYN := 1
-endif
-
 ### Common
 
 include $(PROOT)/lib/Makefile.mk
@@ -40,28 +36,12 @@ CPPFLAGS += -DCURL_NO_OLDIES
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     := -lcurl $(LIBS)
 
-ifdef DYN
-  curl_DEPENDENCIES += $(PROOT)/lib/libcurl.dll.a
-else
-  curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
-  ifdef WIN32
-    CPPFLAGS += -DCURL_STATICLIB
-    LDFLAGS += -static
-  endif
-endif
-
-ifdef WIN32
-  LIBS += -lws2_32
-endif
+curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
 
 ### Sources and targets
 
 # Provides check_PROGRAMS
 include Makefile.inc
-
-ifdef WIN32
-check_PROGRAMS += synctime
-endif
 
 TARGETS := $(patsubst %,%$(BIN_EXT),$(strip $(check_PROGRAMS)))
 TOCLEAN := $(TARGETS)

--- a/docs/examples/Makefile.mk
+++ b/docs/examples/Makefile.mk
@@ -36,8 +36,6 @@ CPPFLAGS += -DCURL_NO_OLDIES
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     := -lcurl $(LIBS)
 
-curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
-
 ### Sources and targets
 
 # Provides check_PROGRAMS
@@ -48,7 +46,7 @@ TOCLEAN := $(TARGETS)
 
 ### Rules
 
-%$(BIN_EXT): %.c $(curl_DEPENDENCIES)
+%$(BIN_EXT): %.c $(PROOT)/lib/libcurl.a
 	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $< -o $@ $(LIBS)
 
 all: $(TARGETS)

--- a/docs/examples/Makefile.mk
+++ b/docs/examples/Makefile.mk
@@ -49,6 +49,6 @@ TOCLEAN := $(TARGETS)
 ### Rules
 
 %$(BIN_EXT): %.c $(curl_DEPENDENCIES)
-	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $(CURL_LDFLAGS_BIN) $< -o $@ $(LIBS)
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LDFLAGS) $< -o $@ $(LIBS)
 
 all: $(TARGETS)

--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -91,25 +91,22 @@ endif
 # comments below about exceptions). Always include them anyway to match
 # behavior of other build systems.
 
-_LDFLAGS :=
-_LIBS :=
-
 ifneq ($(findstring -sync,$(CFG)),)
   CPPFLAGS += -DUSE_SYNC_DNS
 else ifneq ($(findstring -ares,$(CFG)),)
   LIBCARES_PATH ?= $(PROOT)/../c-ares
   CPPFLAGS += -DUSE_ARES
   CPPFLAGS += -I"$(LIBCARES_PATH)/include"
-  _LDFLAGS += -L"$(LIBCARES_PATH)/lib"
-  _LIBS += -lcares
+  LDFLAGS += -L"$(LIBCARES_PATH)/lib"
+  LIBS += -lcares
 endif
 
 ifneq ($(findstring -rtmp,$(CFG)),)
   LIBRTMP_PATH ?= $(PROOT)/../librtmp
   CPPFLAGS += -DUSE_LIBRTMP
   CPPFLAGS += -I"$(LIBRTMP_PATH)"
-  _LDFLAGS += -L"$(LIBRTMP_PATH)/librtmp"
-  _LIBS += -lrtmp
+  LDFLAGS += -L"$(LIBRTMP_PATH)/librtmp"
+  LIBS += -lrtmp
   ZLIB := 1
 endif
 
@@ -117,20 +114,20 @@ ifneq ($(findstring -ssh2,$(CFG)),)
   LIBSSH2_PATH ?= $(PROOT)/../libssh2
   CPPFLAGS += -DUSE_LIBSSH2
   CPPFLAGS += -I"$(LIBSSH2_PATH)/include"
-  _LDFLAGS += -L"$(LIBSSH2_PATH)/lib"
-  _LIBS += -lssh2
+  LDFLAGS += -L"$(LIBSSH2_PATH)/lib"
+  LIBS += -lssh2
 else ifneq ($(findstring -libssh,$(CFG)),)
   LIBSSH_PATH ?= $(PROOT)/../libssh
   CPPFLAGS += -DUSE_LIBSSH
   CPPFLAGS += -I"$(LIBSSH_PATH)/include"
-  _LDFLAGS += -L"$(LIBSSH_PATH)/lib"
-  _LIBS += -lssh
+  LDFLAGS += -L"$(LIBSSH_PATH)/lib"
+  LIBS += -lssh
 else ifneq ($(findstring -wolfssh,$(CFG)),)
   WOLFSSH_PATH ?= $(PROOT)/../wolfssh
   CPPFLAGS += -DUSE_WOLFSSH
   CPPFLAGS += -I"$(WOLFSSH_PATH)/include"
-  _LDFLAGS += -L"$(WOLFSSH_PATH)/lib"
-  _LIBS += -lwolfssh
+  LDFLAGS += -L"$(WOLFSSH_PATH)/lib"
+  LIBS += -lwolfssh
 endif
 
 ifneq ($(findstring -ssl,$(CFG)),)
@@ -140,9 +137,9 @@ ifneq ($(findstring -ssl,$(CFG)),)
   OPENSSL_INCLUDE ?= $(OPENSSL_PATH)/include
   OPENSSL_LIBPATH ?= $(OPENSSL_PATH)/lib
   CPPFLAGS += -I"$(OPENSSL_INCLUDE)"
-  _LDFLAGS += -L"$(OPENSSL_LIBPATH)"
+  LDFLAGS += -L"$(OPENSSL_LIBPATH)"
   OPENSSL_LIBS ?= -lssl -lcrypto
-  _LIBS += $(OPENSSL_LIBS)
+  LIBS += $(OPENSSL_LIBS)
 
   ifneq ($(findstring -srp,$(CFG)),)
     ifneq ($(wildcard $(OPENSSL_INCLUDE)/openssl/srp.h),)
@@ -157,16 +154,16 @@ ifneq ($(findstring -wolfssl,$(CFG)),)
   CPPFLAGS += -DUSE_WOLFSSL
   CPPFLAGS += -DSIZEOF_LONG_LONG=8
   CPPFLAGS += -I"$(WOLFSSL_PATH)/include"
-  _LDFLAGS += -L"$(WOLFSSL_PATH)/lib"
-  _LIBS += -lwolfssl
+  LDFLAGS += -L"$(WOLFSSL_PATH)/lib"
+  LIBS += -lwolfssl
   SSLLIBS += 1
 endif
 ifneq ($(findstring -mbedtls,$(CFG)),)
   MBEDTLS_PATH ?= $(PROOT)/../mbedtls
   CPPFLAGS += -DUSE_MBEDTLS
   CPPFLAGS += -I"$(MBEDTLS_PATH)/include"
-  _LDFLAGS += -L"$(MBEDTLS_PATH)/lib"
-  _LIBS += -lmbedtls -lmbedx509 -lmbedcrypto
+  LDFLAGS += -L"$(MBEDTLS_PATH)/lib"
+  LIBS += -lmbedtls -lmbedx509 -lmbedcrypto
   SSLLIBS += 1
 endif
 
@@ -174,21 +171,21 @@ ifneq ($(findstring -nghttp2,$(CFG)),)
   NGHTTP2_PATH ?= $(PROOT)/../nghttp2
   CPPFLAGS += -DUSE_NGHTTP2
   CPPFLAGS += -I"$(NGHTTP2_PATH)/include"
-  _LDFLAGS += -L"$(NGHTTP2_PATH)/lib"
-  _LIBS += -lnghttp2
+  LDFLAGS += -L"$(NGHTTP2_PATH)/lib"
+  LIBS += -lnghttp2
 endif
 
 ifeq ($(findstring -nghttp3,$(CFG))$(findstring -ngtcp2,$(CFG)),-nghttp3-ngtcp2)
   NGHTTP3_PATH ?= $(PROOT)/../nghttp3
   CPPFLAGS += -DUSE_NGHTTP3
   CPPFLAGS += -I"$(NGHTTP3_PATH)/include"
-  _LDFLAGS += -L"$(NGHTTP3_PATH)/lib"
-  _LIBS += -lnghttp3
+  LDFLAGS += -L"$(NGHTTP3_PATH)/lib"
+  LIBS += -lnghttp3
 
   NGTCP2_PATH ?= $(PROOT)/../ngtcp2
   CPPFLAGS += -DUSE_NGTCP2
   CPPFLAGS += -I"$(NGTCP2_PATH)/include"
-  _LDFLAGS += -L"$(NGTCP2_PATH)/lib"
+  LDFLAGS += -L"$(NGTCP2_PATH)/lib"
 
   NGTCP2_LIBS ?=
   ifeq ($(NGTCP2_LIBS),)
@@ -203,7 +200,7 @@ ifeq ($(findstring -nghttp3,$(CFG))$(findstring -ngtcp2,$(CFG)),-nghttp3-ngtcp2)
     endif
   endif
 
-  _LIBS += -lngtcp2 $(NGTCP2_LIBS)
+  LIBS += -lngtcp2 $(NGTCP2_LIBS)
 endif
 
 ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)
@@ -211,48 +208,48 @@ ifneq ($(findstring -zlib,$(CFG))$(ZLIB),)
   # These CPPFLAGS are also required when compiling the curl tool via 'src'.
   CPPFLAGS += -DHAVE_LIBZ
   CPPFLAGS += -I"$(ZLIB_PATH)/include"
-  _LDFLAGS += -L"$(ZLIB_PATH)/lib"
+  LDFLAGS += -L"$(ZLIB_PATH)/lib"
   ZLIB_LIBS ?= -lz
-  _LIBS += $(ZLIB_LIBS)
+  LIBS += $(ZLIB_LIBS)
   ZLIB := 1
 endif
 ifneq ($(findstring -zstd,$(CFG)),)
   ZSTD_PATH ?= $(PROOT)/../zstd
   CPPFLAGS += -DHAVE_ZSTD
   CPPFLAGS += -I"$(ZSTD_PATH)/include"
-  _LDFLAGS += -L"$(ZSTD_PATH)/lib"
+  LDFLAGS += -L"$(ZSTD_PATH)/lib"
   ZSTD_LIBS ?= -lzstd
-  _LIBS += $(ZSTD_LIBS)
+  LIBS += $(ZSTD_LIBS)
 endif
 ifneq ($(findstring -brotli,$(CFG)),)
   BROTLI_PATH ?= $(PROOT)/../brotli
   CPPFLAGS += -DHAVE_BROTLI
   CPPFLAGS += -I"$(BROTLI_PATH)/include"
-  _LDFLAGS += -L"$(BROTLI_PATH)/lib"
+  LDFLAGS += -L"$(BROTLI_PATH)/lib"
   BROTLI_LIBS ?= -lbrotlidec -lbrotlicommon
-  _LIBS += $(BROTLI_LIBS)
+  LIBS += $(BROTLI_LIBS)
 endif
 ifneq ($(findstring -gsasl,$(CFG)),)
   LIBGSASL_PATH ?= $(PROOT)/../gsasl
   CPPFLAGS += -DUSE_GSASL
   CPPFLAGS += -I"$(LIBGSASL_PATH)/include"
-  _LDFLAGS += -L"$(LIBGSASL_PATH)/lib"
-  _LIBS += -lgsasl
+  LDFLAGS += -L"$(LIBGSASL_PATH)/lib"
+  LIBS += -lgsasl
 endif
 
 ifneq ($(findstring -idn2,$(CFG)),)
   LIBIDN2_PATH ?= $(PROOT)/../libidn2
   CPPFLAGS += -DUSE_LIBIDN2
   CPPFLAGS += -I"$(LIBIDN2_PATH)/include"
-  _LDFLAGS += -L"$(LIBIDN2_PATH)/lib"
-  _LIBS += -lidn2
+  LDFLAGS += -L"$(LIBIDN2_PATH)/lib"
+  LIBS += -lidn2
 
 ifneq ($(findstring -psl,$(CFG)),)
   LIBPSL_PATH ?= $(PROOT)/../libpsl
   CPPFLAGS += -DUSE_LIBPSL
   CPPFLAGS += -I"$(LIBPSL_PATH)/include"
-  _LDFLAGS += -L"$(LIBPSL_PATH)/lib"
-  _LIBS += -lpsl
+  LDFLAGS += -L"$(LIBPSL_PATH)/lib"
+  LIBS += -lpsl
 endif
 endif
 
@@ -263,16 +260,13 @@ endif
 ifneq ($(findstring -watt,$(CFG))$(MSDOS),)
   WATT_PATH ?= $(PROOT)/../watt
   CPPFLAGS += -I"$(WATT_PATH)/inc"
-  _LDFLAGS += -L"$(WATT_PATH)/lib"
-  _LIBS += -lwatt
+  LDFLAGS += -L"$(WATT_PATH)/lib"
+  LIBS += -lwatt
 endif
 
 ifneq ($(findstring 11,$(subst $(subst ,, ),,$(SSLLIBS))),)
   CPPFLAGS += -DCURL_WITH_MULTI_SSL
 endif
-
-LDFLAGS += $(_LDFLAGS)
-LIBS += $(_LIBS)
 
 ### Common rules
 

--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -24,8 +24,8 @@
 
 # Makefile to build curl parts with GCC-like toolchains and optional features.
 #
-# Usage:   [mingw32-]make -f Makefile.mk CFG=-feat1[-feat2][-feat3][...]
-# Example: [mingw32-]make -f Makefile.mk CFG=-zlib-ssl-libssh2-ipv6
+# Usage:   make -f Makefile.mk CFG=-feat1[-feat2][-feat3][...]
+# Example: make -f Makefile.mk CFG=-zlib-ssl-libssh2-ipv6
 #
 # Look for ' ?=' to find all accepted customization variables.
 
@@ -91,7 +91,6 @@ endif
 # comments below about exceptions). Always include them anyway to match
 # behavior of other build systems.
 
-# Linker options to exclude for shared mode executables.
 _LDFLAGS :=
 _LIBS :=
 
@@ -168,10 +167,6 @@ ifneq ($(findstring -mbedtls,$(CFG)),)
   CPPFLAGS += -I"$(MBEDTLS_PATH)/include"
   _LDFLAGS += -L"$(MBEDTLS_PATH)/lib"
   _LIBS += -lmbedtls -lmbedx509 -lmbedcrypto
-  SSLLIBS += 1
-endif
-ifneq ($(findstring -schannel,$(CFG)),)
-  CPPFLAGS += -DUSE_SCHANNEL
   SSLLIBS += 1
 endif
 

--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -41,8 +41,6 @@ endif
 CFLAGS ?=
 CPPFLAGS ?=
 LDFLAGS ?=
-CURL_LDFLAGS_BIN ?=
-CURL_LDFLAGS_LIB ?=
 LIBS ?=
 
 CROSSPREFIX ?=
@@ -325,7 +323,7 @@ CPPFLAGS += -DBUILDING_LIBCURL
 
 ### Sources and targets
 
-# Provides CSOURCES, HHEADERS, LIB_RCFILES
+# Provides CSOURCES, HHEADERS
 include Makefile.inc
 
 vpath %.c vauth vquic vssh vtls
@@ -337,8 +335,8 @@ TARGETS := $(libcurl_a_LIBRARY)
 libcurl_a_OBJECTS := $(patsubst %.c,$(OBJ_DIR)/%.o,$(notdir $(strip $(CSOURCES))))
 libcurl_a_DEPENDENCIES := $(strip $(CSOURCES) $(HHEADERS))
 
-TOCLEAN := $(libcurl_a_OBJECTS)
-TOVCLEAN := $(libcurl_a_LIBRARY)
+TOCLEAN :=
+TOVCLEAN :=
 
 ### Rules
 

--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -53,21 +53,18 @@ AR := $(CROSSPREFIX)$(AR)
 
 TRIPLET ?= $(shell $(CC) -dumpmachine)
 
-BIN_EXT := .exe
+BIN_EXT :=
 
 ifneq ($(findstring msdos,$(TRIPLET)),)
   # Cross-tools: https://github.com/andrewwutw/build-djgpp
   MSDOS := 1
+  BIN_EXT := .exe
 else ifneq ($(findstring amigaos,$(TRIPLET)),)
   # Cross-tools: https://github.com/bebbo/amiga-gcc
   AMIGA := 1
 endif
 
 CPPFLAGS += -I. -I$(PROOT)/include
-
-ifdef AMIGA
-  BIN_EXT :=
-endif
 
 ### Deprecated settings. For compatibility.
 

--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -36,8 +36,6 @@ CPPFLAGS += -I$(PROOT)/lib
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     := -lcurl $(LIBS)
 
-curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
-
 ### Sources and targets
 
 # Provides CURL_CFILES, CURLX_CFILES
@@ -86,7 +84,7 @@ tool_hugehelp.c:
 endif
 endif
 
-$(TARGETS): $(curl_OBJECTS) $(curl_DEPENDENCIES)
+$(TARGETS): $(curl_OBJECTS) $(PROOT)/lib/libcurl.a
 	$(CC) $(LDFLAGS) -o $@ $(curl_OBJECTS) $(LIBS)
 
 all: $(OBJ_DIR) $(TARGETS)

--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -32,7 +32,6 @@ include $(PROOT)/lib/Makefile.mk
 
 ### Local
 
-RCFLAGS  += -DCURL_EMBED_MANIFEST
 CPPFLAGS += -I$(PROOT)/lib
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     := -lcurl $(LIBS)
@@ -41,7 +40,7 @@ curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
 
 ### Sources and targets
 
-# Provides CURL_CFILES, CURLX_CFILES, CURL_RCFILES
+# Provides CURL_CFILES, CURLX_CFILES
 include Makefile.inc
 
 TARGETS := curl$(BIN_EXT)
@@ -51,7 +50,7 @@ CURL_CFILES += $(notdir $(CURLX_CFILES))
 curl_OBJECTS := $(patsubst %.c,$(OBJ_DIR)/%.o,$(strip $(CURL_CFILES)))
 ifdef MAP
 CURL_MAP := curl.map
-CURL_LDFLAGS_BIN += -Wl,-Map,$(CURL_MAP)
+LDFLAGS += -Wl,-Map,$(CURL_MAP)
 TOVCLEAN := $(CURL_MAP)
 endif
 vpath %.c $(PROOT)/lib
@@ -88,6 +87,6 @@ endif
 endif
 
 $(TARGETS): $(curl_OBJECTS) $(curl_DEPENDENCIES)
-	$(CC) $(LDFLAGS) $(CURL_LDFLAGS_BIN) -o $@ $(curl_OBJECTS) $(LIBS)
+	$(CC) $(LDFLAGS) -o $@ $(curl_OBJECTS) $(LIBS)
 
 all: $(OBJ_DIR) $(TARGETS)

--- a/src/Makefile.mk
+++ b/src/Makefile.mk
@@ -37,22 +37,7 @@ CPPFLAGS += -I$(PROOT)/lib
 LDFLAGS  += -L$(PROOT)/lib
 LIBS     := -lcurl $(LIBS)
 
-ifdef WIN32
-  ifneq ($(findstring -dyn,$(CFG)),)
-    DYN := 1
-  endif
-endif
-
-ifdef DYN
-  curl_DEPENDENCIES := $(PROOT)/lib/libcurl$(CURL_DLL_SUFFIX).dll
-  curl_DEPENDENCIES += $(PROOT)/lib/libcurl.dll.a
-else
-  curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
-  ifdef WIN32
-    CPPFLAGS += -DCURL_STATICLIB
-    LDFLAGS += -static
-  endif
-endif
+curl_DEPENDENCIES := $(PROOT)/lib/libcurl.a
 
 ### Sources and targets
 
@@ -64,9 +49,6 @@ TARGETS := curl$(BIN_EXT)
 CURL_CFILES += $(notdir $(CURLX_CFILES))
 
 curl_OBJECTS := $(patsubst %.c,$(OBJ_DIR)/%.o,$(strip $(CURL_CFILES)))
-ifdef WIN32
-curl_OBJECTS += $(patsubst %.rc,$(OBJ_DIR)/%.res,$(strip $(CURL_RCFILES)))
-endif
 ifdef MAP
 CURL_MAP := curl.map
 CURL_LDFLAGS_BIN += -Wl,-Map,$(CURL_MAP)


### PR DESCRIPTION
And DLL-support with it. This leaves `Makefile.mk` for MS-DOS and Amiga.

We recommend CMake instead. With unity mode it's much faster, and about
the same without.

Ref: https://github.com/curl/curl/pull/12221#issuecomment-1783761806
Closes #12224

---

- [x] Hold off till curl v8.6.0.
