### PR TITLE
build: require Windows XP or newer

### DIFF
--- a/CMake/Platforms/WindowsCache.cmake
+++ b/CMake/Platforms/WindowsCache.cmake
@@ -82,6 +82,10 @@ else()
   endif()
 endif()
 
+# Available in Windows XP and newer
+set(HAVE_GETADDRINFO 1)
+set(HAVE_FREEADDRINFO 1)
+
 set(HAVE_FCHMOD 0)
 set(HAVE_SOCKETPAIR 0)
 set(HAVE_SENDMSG 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1087,22 +1087,24 @@ if(WIN32)
   # avoid storing HAVE_WIN32_WINNT in CMake cache
   unset(HAVE_WIN32_WINNT CACHE)
 
-  if(HAVE_WIN32_WINNT AND HAVE_WIN32_WINNT STRLESS "0x0501")
-    # Windows XP is required for freeaddrinfo, getaddrinfo
-    message(FATAL_ERROR "Building for Windows XP or newer is required.")
-  endif()
-
-  # pre-fill detection results that are based on target OS version
-  if(HAVE_WIN32_WINNT AND (MINGW OR MSVC))
-    if(HAVE_WIN32_WINNT STRLESS "0x0600")
-      set(HAVE_INET_NTOP 0)
-      set(HAVE_INET_PTON 0)
-    else()  # Windows Vista or newer
-      set(HAVE_INET_NTOP 1)
-      set(HAVE_INET_PTON 1)
+  if(HAVE_WIN32_WINNT)
+    if(HAVE_WIN32_WINNT STRLESS "0x0501")
+      # Windows XP is required for freeaddrinfo, getaddrinfo
+      message(FATAL_ERROR "Building for Windows XP or newer is required.")
     endif()
-    unset(HAVE_INET_NTOP CACHE)
-    unset(HAVE_INET_PTON CACHE)
+
+    # pre-fill detection results based on target OS version
+    if(MINGW OR MSVC)
+      if(HAVE_WIN32_WINNT STRLESS "0x0600")
+        set(HAVE_INET_NTOP 0)
+        set(HAVE_INET_PTON 0)
+      else()  # Windows Vista or newer
+        set(HAVE_INET_NTOP 1)
+        set(HAVE_INET_PTON 1)
+      endif()
+      unset(HAVE_INET_NTOP CACHE)
+      unset(HAVE_INET_PTON CACHE)
+    endif()
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1088,7 +1088,7 @@ if(WIN32)
   unset(HAVE_WIN32_WINNT CACHE)
 
   if(HAVE_WIN32_WINNT AND HAVE_WIN32_WINNT STRLESS "0x0501")
-    # We require XP for getaddrinfo and freeaddrinfo
+    # Windows XP is required for freeaddrinfo, getaddrinfo
     message(FATAL_ERROR "Building for Windows XP or newer is required.")
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1087,17 +1087,13 @@ if(WIN32)
   # avoid storing HAVE_WIN32_WINNT in CMake cache
   unset(HAVE_WIN32_WINNT CACHE)
 
+  if(HAVE_WIN32_WINNT AND HAVE_WIN32_WINNT STRLESS "0x0501")
+    # We require XP for getaddrinfo and freeaddrinfo
+    message(FATAL_ERROR "Building for Windows XP or newer is required.")
+  endif()
+
   # pre-fill detection results that are based on target OS version
   if(HAVE_WIN32_WINNT AND (MINGW OR MSVC))
-    if(HAVE_WIN32_WINNT STRLESS "0x0501")
-      set(HAVE_GETADDRINFO 0)
-      set(HAVE_FREEADDRINFO 0)
-    else()  # Windows XP or newer
-      set(HAVE_GETADDRINFO 1)
-      set(HAVE_FREEADDRINFO 1)
-    endif()
-    unset(HAVE_GETADDRINFO CACHE)
-    unset(HAVE_FREEADDRINFO CACHE)
     if(HAVE_WIN32_WINNT STRLESS "0x0600")
       set(HAVE_INET_NTOP 0)
       set(HAVE_INET_PTON 0)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -162,6 +162,8 @@ library check.
 
 # Windows
 
+Building for Windows XP is required as a minimum.
+
 ## Building Windows DLLs and C runtime (CRT) linkage issues
 
  As a general rule, building a DLL with static CRT linkage is highly

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -331,8 +331,6 @@
 #  undef RECV_TYPE_ARG3
 #  undef SEND_TYPE_ARG1
 #  undef SEND_TYPE_ARG3
-#  define HAVE_FREEADDRINFO
-#  define HAVE_GETADDRINFO
 #  define HAVE_GETHOSTBYNAME_R
 #  define HAVE_GETHOSTBYNAME_R_6
 #  define LWIP_POSIX_SOCKETS_IO_NAMES 0
@@ -353,13 +351,11 @@
   #undef USE_WINSOCK
   #undef HAVE_WINSOCK2_H
   #undef HAVE_WS2TCPIP_H
-  #define HAVE_GETADDRINFO
   #define HAVE_SYS_IOCTL_H
   #define HAVE_SYS_SOCKET_H
   #define HAVE_NETINET_IN_H
   #define HAVE_NETDB_H
   #define HAVE_ARPA_INET_H
-  #define HAVE_FREEADDRINFO
   #define SOCKET int
 #endif
 
@@ -473,24 +469,10 @@ Vista
 #  endif
 #endif
 
-/* Availability of freeaddrinfo, getaddrinfo, and if_nametoindex
-   functions is quite convoluted, compiler dependent and even build target
-   dependent. */
-#if defined(HAVE_WS2TCPIP_H)
-#  if defined(__POCC__)
-#    define HAVE_FREEADDRINFO           1
-#    define HAVE_GETADDRINFO            1
-#    define HAVE_GETADDRINFO_THREADSAFE 1
-#  elif defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0501)
-#    define HAVE_FREEADDRINFO           1
-#    define HAVE_GETADDRINFO            1
-#    define HAVE_GETADDRINFO_THREADSAFE 1
-#  elif defined(_MSC_VER) && (_MSC_VER >= 1200)
-#    define HAVE_FREEADDRINFO           1
-#    define HAVE_GETADDRINFO            1
-#    define HAVE_GETADDRINFO_THREADSAFE 1
-#  endif
-#endif
+/* Windows XP is required for freeaddrinfo, getaddrinfo */
+#define HAVE_FREEADDRINFO           1
+#define HAVE_GETADDRINFO            1
+#define HAVE_GETADDRINFO_THREADSAFE 1
 
 #if defined(__POCC__)
 #  ifndef _MSC_VER


### PR DESCRIPTION
After this patch we assume availability of `getaddrinfo` and
`freeaddrinfo`, first introduced in Windows XP. Meaning curl
now requires building for Windows XP as a minimum.

TODO: assume these also in autotools.

Ref: https://github.com/curl/curl/pull/12221#issuecomment-1783761806
Closes #12225

---

https://github.com/curl/curl/pull/12225/files?w=1
