### PR TITLE
HTTP3: ngtcp2 builds are no longer experimental

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3099,7 +3099,6 @@ if test X"$want_nghttp3" != Xno; then
           CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$DIR_NGHTTP3"
           export CURL_LIBRARY_PATH
           AC_MSG_NOTICE([Added $DIR_NGHTTP3 to CURL_LIBRARY_PATH])
-          experimental="$experimental HTTP3"
        )
       ],
         dnl not found, revert back to clean variables

--- a/docs/EXPERIMENTAL.md
+++ b/docs/EXPERIMENTAL.md
@@ -19,6 +19,6 @@ Experimental support in curl means:
 ## Experimental features right now
 
  - The Hyper HTTP backend
- - HTTP/3 support and options
+ - HTTP/3 support (using the quiche or msh3 backends)
  - The rustls backend
  - WebSocket

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -9,18 +9,19 @@ book describing the protocols involved.
 
 ## QUIC libraries
 
-QUIC libraries we are experimenting with:
+QUIC libraries we are using:
 
 [ngtcp2](https://github.com/ngtcp2/ngtcp2)
 
-[quiche](https://github.com/cloudflare/quiche)
+[quiche](https://github.com/cloudflare/quiche) - **EXPERIMENTAL**
 
-[msh3](https://github.com/nibanks/msh3) (with [msquic](https://github.com/microsoft/msquic))
+[msh3](https://github.com/nibanks/msh3) (with [msquic](https://github.com/microsoft/msquic)) - **EXPERIMENTAL**
 
 ## Experimental
 
-HTTP/3 and QUIC support in curl is considered **EXPERIMENTAL** until further
-notice. It needs to be enabled at build-time.
+HTTP/3 support in curl is considered **EXPERIMENTAL** until further notice
+when built to use *quiche* or *msh3*. Only the *ngtcp2* backend is not
+experimental.
 
 Further development and tweaking of the HTTP/3 support in curl will happen in
 the master branch using pull-requests, just like ordinary changes.
@@ -34,14 +35,15 @@ To fix before we remove the experimental label:
 
 Building curl with ngtcp2 involves 3 components: `ngtcp2` itself, `nghttp3` and a QUIC supporting TLS library. The supported TLS libraries are covered below.
 
-For now, `ngtcp2` and `nghttp3` are still *experimental* which means their evolution bring breaking changes. Therefore, the proper version of both libraries need to be used when building curl. These are
-
  * `ngtcp2`: v1.0.1
  * `nghttp3`: v1.0.0
 
 ## Build with quictls
 
-Build quictls (OpenSSL fork)
+OpenSSL does not offer the required APIs for building a QUIC client. You need
+to use a TLS library that has such APIs and that works with *ngtcp2*.
+
+Build quictls
 
      % git clone --depth 1 -b openssl-3.1.4+quic https://github.com/quictls/openssl
      % cd openssl
@@ -165,6 +167,8 @@ Build curl
 
 # quiche version
 
+quiche support is **EXPERIMENTAL**
+
 Since the quiche build manages its dependencies, curl can be built against the latest version. You are *probably* able to build against their main branch, but in case of problems, we recommend their latest release tag.
 
 ## build
@@ -194,6 +198,8 @@ Build curl:
 **Note**: The msquic HTTP/3 backend is immature and is not properly functional
 one as of September 2023. Feel free to help us test it and improve it, but
 there is no point in filing bugs about it just yet.
+
+msh3 support is **EXPERIMENTAL**
 
 ## Build Linux (with quictls fork of OpenSSL)
 


### PR DESCRIPTION
The other HTTP/3 backends are still experimental.