### PR TITLE
http_aws_sigv4: canonicalise valueless query params

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -101,7 +101,6 @@ problems may have been fixed or changed somewhat since this was written.
 
  16. aws-sigv4
  16.1 aws-sigv4 does not sign requests with * correctly
- 16.3 aws-sigv4 is missing the amz-content-sha256 header
  16.6 aws-sigv4 does not behave well with AWS VPC Lattice
 
  17. HTTP/2
@@ -574,10 +573,6 @@ problems may have been fixed or changed somewhat since this was written.
 16.1 aws-sigv4 does not sign requests with * correctly
 
  https://github.com/curl/curl/issues/7559
-
-16.3 aws-sigv4 is missing the amz-content-sha256 header
-
- https://github.com/curl/curl/issues/8810
 
 16.6 aws-sigv4 does not behave well with AWS VPC Lattice
 

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -103,7 +103,6 @@ problems may have been fixed or changed somewhat since this was written.
  16.1 aws-sigv4 does not sign requests with * correctly
  16.2 aws-sigv4 does not sign requests with valueless queries correctly
  16.3 aws-sigv4 is missing the amz-content-sha256 header
- 16.4 aws-sigv4 does not sort query string parameters before signing
  16.5 aws-sigv4 does not sign requests with empty URL query correctly
  16.6 aws-sigv4 does not behave well with AWS VPC Lattice
 
@@ -585,10 +584,6 @@ problems may have been fixed or changed somewhat since this was written.
 16.3 aws-sigv4 is missing the amz-content-sha256 header
 
  https://github.com/curl/curl/issues/8810
-
-16.4 aws-sigv4 does not sort query string parameters before signing
-
- https://github.com/curl/curl/issues/9717
 
 16.5 aws-sigv4 does not sign requests with empty URL query correctly
 

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -12,7 +12,6 @@ check the changelog of the current development status, as one or more of these
 problems may have been fixed or changed somewhat since this was written.
 
  1. HTTP
- 1.1 hyper memory-leaks
  1.2 hyper is slow
  1.5 Expect-100 meets 417
 

--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -101,9 +101,7 @@ problems may have been fixed or changed somewhat since this was written.
 
  16. aws-sigv4
  16.1 aws-sigv4 does not sign requests with * correctly
- 16.2 aws-sigv4 does not sign requests with valueless queries correctly
  16.3 aws-sigv4 is missing the amz-content-sha256 header
- 16.5 aws-sigv4 does not sign requests with empty URL query correctly
  16.6 aws-sigv4 does not behave well with AWS VPC Lattice
 
  17. HTTP/2
@@ -577,17 +575,9 @@ problems may have been fixed or changed somewhat since this was written.
 
  https://github.com/curl/curl/issues/7559
 
-16.2 aws-sigv4 does not sign requests with valueless queries correctly
-
- https://github.com/curl/curl/issues/8107
-
 16.3 aws-sigv4 is missing the amz-content-sha256 header
 
  https://github.com/curl/curl/issues/8810
-
-16.5 aws-sigv4 does not sign requests with empty URL query correctly
-
- https://github.com/curl/curl/issues/10129
 
 16.6 aws-sigv4 does not behave well with AWS VPC Lattice
 

--- a/tests/data/test439
+++ b/tests/data/test439
@@ -38,7 +38,7 @@ debug
 aws-sigv4 with query
 </name>
 <command>
-"http://fake.fake.fake:8000/%TESTNUMBER/?name=me%&aim=b%aad&&&weirdo=*.//-" -u user:secret --aws-sigv4 "aws:amz:us-east-2:es" --connect-to fake.fake.fake:8000:%HOSTIP:%HTTPPORT
+"http://fake.fake.fake:8000/%TESTNUMBER/?name=me%&noval&aim=b%aad&&&weirdo=*.//-" -u user:secret --aws-sigv4 "aws:amz:us-east-2:es" --connect-to fake.fake.fake:8000:%HOSTIP:%HTTPPORT
 </command>
 </client>
 
@@ -46,9 +46,9 @@ aws-sigv4 with query
 # Verify data after the test has been "shot"
 <verify>
 <protocol crlf="yes">
-GET /%TESTNUMBER/?name=me%&aim=b%aad&&&weirdo=*.//- HTTP/1.1
+GET /439/?name=me%&noval&aim=b%aad&&&weirdo=*.//- HTTP/1.1
 Host: fake.fake.fake:8000
-Authorization: AWS4-HMAC-SHA256 Credential=user/19700101/us-east-2/es/aws4_request, SignedHeaders=host;x-amz-date, Signature=88884e3b3142133685b2092d29d8b522b785b1a9ec9e4a90cbea83e882f8dcb6
+Authorization: AWS4-HMAC-SHA256 Credential=user/19700101/us-east-2/es/aws4_request, SignedHeaders=host;x-amz-date, Signature=cbbf4a72764e27e396730f5e56cea046d4ce862a2d91db4856fb086b92f49270
 X-Amz-Date: 19700101T000000Z
 User-Agent: curl/%VERSION
 Accept: */*


### PR DESCRIPTION
Query params with `?novalparam` (i.e. no =) need to be given an empty value while canonicalising

From https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html

```
When a request targets a subresource, the corresponding query parameter value will be an empty string (""). For example, the following URI identifies the ACL subresource on the examplebucket bucket:

http://s3.amazonaws.com/examplebucket?acl 

The CanonicalQueryString in this case is as follows:

UriEncode("acl") + "=" + ""
```

This fixes my issue https://github.com/curl/curl/issues/10129 and I think this other issue is a dupe (?) https://github.com/curl/curl/issues/8107.

In this branch I have also cleaned up some other things in `KNOWN_BUGS` (I can make a different MR if that is easier) ~~ ~and also [http_aws_sigv4: reading too far in canon_query](https://github.com/curl/curl/commit/81272ab30104cc71f13814070a29e8d3c5ac3aee) is a missing length check (I think, but there might be some other guarantee somewhere that we can always read 2 chars after a `%` that I haven't seen.~

EDIT: Removed extra commit with length check as it is not relevant!