### PR TITLE
urlapi: when URL encoding the fragment, pass in the right length

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1224,7 +1224,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
       if(flags & CURLU_URLENCODE) {
         struct dynbuf enc;
         Curl_dyn_init(&enc, CURL_MAX_INPUT_LENGTH);
-        if(urlencode_str(&enc, fragment + 1, fraglen, TRUE, FALSE)) {
+        if(urlencode_str(&enc, fragment + 1, fraglen - 1, TRUE, FALSE)) {
           result = CURLUE_OUT_OF_MEMORY;
           goto fail;
         }

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -151,6 +151,9 @@ struct clearurlcase {
 };
 
 static const struct testcase get_parts_list[] ={
+  {"https://curl.se/#  ",
+   "https | [11] | [12] | [13] | curl.se | [15] | / | [16] | %20%20",
+   CURLU_URLENCODE|CURLU_ALLOW_SPACE, 0, CURLUE_OK},
   {"", "", 0, 0, CURLUE_MALFORMED_INPUT},
   {" ", "", 0, 0, CURLUE_MALFORMED_INPUT},
   {"1h://example.net", "", 0, 0, CURLUE_BAD_SCHEME},


### PR DESCRIPTION
A benign bug because it would only add an extra null terminator.

Made lib1560 get a test that runs this code.