### PR TITLE
lib: add and use Curl_strndup()

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -123,15 +123,13 @@ static struct altsvc *altsvc_createid(const char *srchost,
     dlen -= 2;
   }
 
-  as->src.host = Curl_memdup(srchost, hlen + 1);
+  as->src.host = Curl_strndup(srchost, hlen);
   if(!as->src.host)
     goto error;
-  as->src.host[hlen] = 0;
 
-  as->dst.host = Curl_memdup(dsthost, dlen + 1);
+  as->dst.host = Curl_strndup(dsthost, dlen);
   if(!as->dst.host)
     goto error;
-  as->dst.host[dlen] = 0;
 
   as->src.alpnid = srcalpnid;
   as->dst.alpnid = dstalpnid;

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -365,9 +365,7 @@ static void strstore(char **str, const char *newstr, size_t len)
   DEBUGASSERT(newstr);
   DEBUGASSERT(str);
   free(*str);
-  *str = Curl_memdup(newstr, len + 1);
-  if(*str)
-    (*str)[len] = 0;
+  *str = Curl_strndup(newstr, len);
 }
 
 /*

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -603,9 +603,9 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
            app passed in a bad combo, so we better check for that first. */
         if(form->name) {
           /* copy name (without strdup; possibly not null-terminated) */
-          form->name = Curl_memdup(form->name, form->namelength?
-                                   form->namelength:
-                                   strlen(form->name) + 1);
+          form->name = Curl_strndup(form->name, form->namelength?
+                                    form->namelength:
+                                    strlen(form->name));
         }
         if(!form->name) {
           return_value = CURL_FORMADD_MEMORY;

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -135,12 +135,11 @@ static CURLcode hsts_create(struct hsts *h,
   if(!sts)
     return CURLE_OUT_OF_MEMORY;
 
-  duphost = Curl_memdup(hostname, hlen + 1);
+  duphost = Curl_strndup(hostname, hlen);
   if(!duphost) {
     free(sts);
     return CURLE_OUT_OF_MEMORY;
   }
-  duphost[hlen] = 0; /* might remove a dot */
 
   sts->host = duphost;
   sts->expires = expires;

--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -101,6 +101,24 @@ void *Curl_memdup(const void *src, size_t length)
 
 /***************************************************************************
  *
+ * Curl_strndup(source, length)
+ *
+ * Copies the 'source' data to a newly allocated buffer (that is
+ * returned). Copies 'length' bytes then adds a null terminator.
+ *
+ * Returns the new pointer or NULL on failure.
+ *
+ ***************************************************************************/
+void *Curl_strndup(const void *src, size_t length)
+{
+  char *b = Curl_memdup(src, length + 1);
+  if(b)
+    b[length] = 0;
+  return b;
+}
+
+/***************************************************************************
+ *
  * Curl_saferealloc(ptr, size)
  *
  * Does a normal realloc(), but will free the data pointer if the realloc

--- a/lib/strdup.h
+++ b/lib/strdup.h
@@ -33,5 +33,6 @@ wchar_t* Curl_wcsdup(const wchar_t* src);
 #endif
 void *Curl_memdup(const void *src, size_t buffer_length);
 void *Curl_saferealloc(void *ptr, size_t size);
+void *Curl_strndup(const void *src, size_t length);
 
 #endif /* HEADER_CURL_STRDUP_H */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1231,7 +1231,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
         u->fragment = Curl_dyn_ptr(&enc);
       }
       else {
-        u->fragment = Curl_memdup(fragment + 1, fraglen);
+        u->fragment = Curl_strndup(fragment + 1, fraglen - 1);
         if(!u->fragment) {
           result = CURLUE_OUT_OF_MEMORY;
           goto fail;
@@ -1260,12 +1260,11 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
         u->query = Curl_dyn_ptr(&enc);
       }
       else {
-        u->query = Curl_memdup(query + 1, qlen);
+        u->query = Curl_strndup(query + 1, qlen - 1);
         if(!u->query) {
           result = CURLUE_OUT_OF_MEMORY;
           goto fail;
         }
-        u->query[qlen - 1] = 0;
       }
     }
     else {
@@ -1295,12 +1294,11 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
   }
   else {
     if(!u->path) {
-      u->path = Curl_memdup(path, pathlen + 1);
+      u->path = Curl_strndup(path, pathlen);
       if(!u->path) {
         result = CURLUE_OUT_OF_MEMORY;
         goto fail;
       }
-      u->path[pathlen] = 0;
       path = u->path;
     }
     else if(flags & CURLU_URLENCODE)
@@ -1594,7 +1592,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
   if(ptr) {
     size_t partlen = strlen(ptr);
     size_t i = 0;
-    *part = Curl_memdup(ptr, partlen + 1);
+    *part = Curl_strndup(ptr, partlen);
     if(!*part)
       return CURLUE_OUT_OF_MEMORY;
     if(plusdecode) {


### PR DESCRIPTION
The Curl_strndup() function is similar to strdup(), but copies 'n' bytes then adds a terminating null byte ('\0').