### PR TITLE
HTTP: fix empty-body warning

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -1144,7 +1144,14 @@ CURLcode Curl_http_input_auth(struct Curl_easy *data, bool proxy,
               }
             }
 #else
-           ;
+            {
+              /*
+               * Empty block to terminate the if-else chain correctly.
+               *
+               * A semicolon would yield the same result here, but can cause a
+               * compiler warning when -Wextra is enabled.
+               */
+            }
 #endif
 
     /* there may be multiple methods on one line, so keep reading */


### PR DESCRIPTION
This change fixes a compiler warning with gcc-12.2.0 when `-DCURL_DISABLE_BEARER_AUTH=ON` is used.

    /home/tox/src/curl/lib/http.c: In function 'Curl_http_input_auth':
    /home/tox/src/curl/lib/http.c:1147:12: warning: suggest braces around empty body in an 'else' statement [-Wempty-body]
     1147 |            ;
          |            ^

This is useful as it fixes an issue when libcurl is compiled with `-Werror`.