### PR TITLE
docs: remove bold from some man page SYNOPSIS sections

### DIFF
--- a/docs/libcurl/curl_easy_pause.3
+++ b/docs/libcurl/curl_easy_pause.3
@@ -26,9 +26,9 @@
 curl_easy_pause - pause and unpause a connection
 .SH SYNOPSIS
 .nf
-.B #include <curl/curl.h>
+#include <curl/curl.h>
 
-.BI "CURLcode curl_easy_pause(CURL *"handle ", int "bitmask ");"
+CURLcode curl_easy_pause(CURL *handle, int bitmask );
 .fi
 .SH DESCRIPTION
 Using this function, you can explicitly mark a running connection to get

--- a/docs/libcurl/curl_formget.3
+++ b/docs/libcurl/curl_formget.3
@@ -26,7 +26,7 @@
 curl_formget - serialize a previously built multipart form POST chain
 .SH SYNOPSIS
 .nf
-.B #include <curl/curl.h>
+#include <curl/curl.h>
 
 int curl_formget(struct curl_httppost * form, void *userp,
                   curl_formget_callback append );

--- a/docs/libcurl/curl_multi_strerror.3
+++ b/docs/libcurl/curl_multi_strerror.3
@@ -26,8 +26,9 @@
 curl_multi_strerror - return string describing error code
 .SH SYNOPSIS
 .nf
-.B #include <curl/curl.h>
-.BI "const char *curl_multi_strerror(CURLMcode " errornum ");"
+#include <curl/curl.h>
+
+const char *curl_multi_strerror(CURLMcode errornum);
 .SH DESCRIPTION
 This function returns a string describing the \fICURLMcode\fP error code
 passed in the argument \fIerrornum\fP.

--- a/docs/libcurl/curl_share_strerror.3
+++ b/docs/libcurl/curl_share_strerror.3
@@ -26,8 +26,9 @@
 curl_share_strerror - return string describing error code
 .SH SYNOPSIS
 .nf
-.B #include <curl/curl.h>
-.BI "const char *curl_share_strerror(CURLSHcode " errornum ");"
+#include <curl/curl.h>
+
+const char *curl_share_strerror(CURLSHcode errornum);
 .SH DESCRIPTION
 The \fIcurl_share_strerror(3)\fP function returns a string describing the
 \fICURLSHcode\fP error code passed in the argument \fIerrornum\fP.

--- a/docs/libcurl/curl_url_strerror.3
+++ b/docs/libcurl/curl_url_strerror.3
@@ -26,8 +26,9 @@
 curl_url_strerror - return string describing error code
 .SH SYNOPSIS
 .nf
-.B #include <curl/curl.h>
-.BI "const char *curl_url_strerror(CURLUcode " errornum ");"
+#include <curl/curl.h>
+
+const char *curl_url_strerror(CURLUcode errornum);
 .SH DESCRIPTION
 This function returns a string describing the CURLUcode error code passed in
 the argument \fIerrornum\fP.


### PR DESCRIPTION
In the name of consistency