### PR TITLE
openssl: identify the "quictls" backend correctly

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -240,7 +240,11 @@
 #elif defined(OPENSSL_IS_AWSLC)
 #define OSSL_PACKAGE "AWS-LC"
 #else
-#define OSSL_PACKAGE "OpenSSL"
+# if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
+#   define OSSL_PACKAGE "quictls"
+# else
+#   define OSSL_PACKAGE "OpenSSL"
+#endif
 #endif
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)


### PR DESCRIPTION
Since vanilla OpenSSL does not support the QUIC API I think it helps users to identify the correct OpenSSL fork in version output. The best way to do that right now seems to to check if ngtcp2 support is enabled.