### PR TITLE
rand: fix build error with autotools + LibreSSL

### DIFF
--- a/lib/rand.c
+++ b/lib/rand.c
@@ -32,10 +32,6 @@
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
 #endif
-#ifdef HAVE_ARC4RANDOM
-/* Some platforms might have the prototype missing (ubuntu + libressl) */
-uint32_t arc4random(void);
-#endif
 
 #include <curl/curl.h>
 #include "urldata.h"
@@ -146,7 +142,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
   }
 #endif
 
-#ifdef HAVE_ARC4RANDOM
+#if defined(HAVE_ARC4RANDOM) && !defined(USE_OPENSSL)
   *rnd = (unsigned int)arc4random();
   return CURLE_OK;
 #endif


### PR DESCRIPTION
autotools unexpectedly detects `arc4random` because it is also looking
into dependency libs. One dependency, LibreSSL, happens to publish an
`arc4random` function (via its shared lib before v3.7, also via static
lib as of v3.8.2). When trying to use this function in `lib/rand.c`,
its protoype is missing. To fix that, curl included a prototype, but
that used a C99 type without including `stdint.h`, causing:

```
../../lib/rand.c:37:1: error: unknown type name 'uint32_t'
   37 | uint32_t arc4random(void);
      | ^
1 error generated.
```

This patch improves this by dropping the local prototype and instead
limiting `arc4random` use for non-OpenSSL builds. OpenSSL builds provide
their own random source anyway.

The better fix would be to teach autotools to not link dependency libs
while detecting `arc4random`.

LibreSSL publishing a non-namespaced `arc4random` tracked here:
https://github.com/libressl/portable/issues/928

Regression from 755ddbe901cd0c921fbc3ac5b3775c0dc683bc73 #10672

Fixes #12257
Closes #12274