### PR TITLE
CURLOPT_CAINFO_BLOB.3: explain what CURL_BLOB_COPY does

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.3
@@ -37,6 +37,10 @@ Pass a pointer to a curl_blob structure, which contains information (pointer
 and size) about a memory block with binary data of PEM encoded content holding
 one or more certificates to verify the HTTPS server with.
 
+If the blob is initialized with the flags member of struct curl_blob set to
+CURL_BLOB_COPY, the application does not have to keep the buffer around after
+setting this.
+
 If \fICURLOPT_SSL_VERIFYPEER(3)\fP is zero and you avoid verifying the
 server's certificate, \fICURLOPT_CAINFO_BLOB(3)\fP is not needed.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.3
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.3
@@ -39,6 +39,10 @@ Pass a pointer to a curl_blob structure, which contains information (pointer
 and size) about a memory block with binary data of PEM encoded content holding
 one or more certificates to verify the HTTPS proxy with.
 
+If the blob is initialized with the flags member of struct curl_blob set to
+CURL_BLOB_COPY, the application does not have to keep the buffer around after
+setting this.
+
 If \fICURLOPT_PROXY_SSL_VERIFYPEER(3)\fP is zero and you avoid verifying the
 server's certificate, \fICURLOPT_PROXY_CAINFO_BLOB(3)\fP is not needed.
 


### PR DESCRIPTION
- Add an explanation of the CURL_BLOB_COPY flag to CURLOPT_CAINFO_BLOB and CURLOPT_PROXY_CAINFO_BLOB docs.

All the other _BLOB option docs already have the same explanation.

Closes #xxxxx