### PR TITLE
vtls: use ALPN "http/1.1" for HTTP/1.x, including HTTP/1.0

### DIFF
--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -188,9 +188,6 @@ static CURLcode baller_connected(struct Curl_cfilter *cf,
 #endif
     infof(data, "using HTTP/2");
     break;
-  case CURL_HTTP_VERSION_1_1:
-    infof(data, "using HTTP/1.1");
-    break;
   default:
     infof(data, "using HTTP/1.x");
     break;

--- a/lib/http.c
+++ b/lib/http.c
@@ -3182,7 +3182,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
       DEBUGASSERT(Curl_conn_is_http2(data, conn, FIRSTSOCKET));
     break;
   case CURL_HTTP_VERSION_1_1:
-    /* continue with HTTP/1.1 when explicitly requested */
+    /* continue with HTTP/1.x when explicitly requested */
     break;
   default:
     /* Check if user wants to use HTTP/2 with clear TCP */

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -32,8 +32,6 @@
 /* see https://www.iana.org/assignments/tls-extensiontype-values/ */
 #define ALPN_HTTP_1_1_LENGTH 8
 #define ALPN_HTTP_1_1 "http/1.1"
-#define ALPN_HTTP_1_0_LENGTH 8
-#define ALPN_HTTP_1_0 "http/1.0"
 #define ALPN_H2_LENGTH 2
 #define ALPN_H2 "h2"
 #define ALPN_H3_LENGTH 2


### PR DESCRIPTION
Some servers don't support the ALPN protocol "http/1.0" (e.g. IIS 10), avoid it and use "http/1.1" instead.

This reverts commit df856cb5c9 (#10183).

Fixes #12259
Closes #...