### PR TITLE
Fix for StartTransfer Time

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1938,8 +1938,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         result = CURLE_OK;
         break;
       }
-      else
-      {
+      else {
         /* update the start time when we have left the
            CURLE_NO_CONNECTION_AVAILABLE state */
         Curl_pgrsTimeWas(data, TIMER_STARTSINGLE, *nowp);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1940,9 +1940,10 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       }
       else
       {
-        /* update the start time when we have left the CURLE_NO_CONNECTION_AVAILABLE state */
+        /* update the start time when we have left the
+           CURLE_NO_CONNECTION_AVAILABLE state */
         Curl_pgrsTimeWas(data, TIMER_STARTSINGLE, *nowp);
-        
+
         if(data->state.previouslypending) {
           /* this transfer comes from the pending queue so try move another */
           infof(data, "Transfer was pending, now try another");

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1938,10 +1938,16 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         result = CURLE_OK;
         break;
       }
-      else if(data->state.previouslypending) {
-        /* this transfer comes from the pending queue so try move another */
-        infof(data, "Transfer was pending, now try another");
-        process_pending_handles(data->multi);
+      else
+      {
+        /* update the start time when we have left the CURLE_NO_CONNECTION_AVAILABLE state */
+        Curl_pgrsTimeWas(data, TIMER_STARTSINGLE, *nowp);
+        
+        if(data->state.previouslypending) {
+          /* this transfer comes from the pending queue so try move another */
+          infof(data, "Transfer was pending, now try another");
+          process_pending_handles(data->multi);
+        }
       }
 
       if(!result) {


### PR DESCRIPTION
Ensure that StartTransfer time for a request doesn't include the time spent waiting for a connection when we are constraining concurrent connection quantity.