### PR TITLE
tidy-up: use `OPENSSL_VERSION_NUMBER`

### DIFF
--- a/lib/md4.c
+++ b/lib/md4.c
@@ -32,7 +32,7 @@
 #include "warnless.h"
 
 #ifdef USE_OPENSSL
-#include <openssl/opensslconf.h>
+#include <openssl/opensslv.h>
 #if (OPENSSL_VERSION_NUMBER >= 0x30000000L) && !defined(USE_AMISSL)
 /* OpenSSL 3.0.0 marks the MD4 functions as deprecated */
 #define OPENSSL_NO_MD4

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -33,8 +33,7 @@
 
 #ifdef USE_OPENSSL
 #include <openssl/opensslconf.h>
-#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3) && \
-   !defined(USE_AMISSL)
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L) && !defined(USE_AMISSL)
 /* OpenSSL 3.0.0 marks the MD4 functions as deprecated */
 #define OPENSSL_NO_MD4
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3249,7 +3249,7 @@ static CURLcode populate_x509_store(struct Curl_cfilter *cf,
     }
 
     if(ssl_cafile || ssl_capath) {
-#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
       /* OpenSSL 3.0.0 has deprecated SSL_CTX_load_verify_locations */
       if(ssl_cafile && !X509_STORE_load_file(store, ssl_cafile)) {
         if(!imported_native_ca && !imported_ca_info_blob) {

--- a/m4/curl-amissl.m4
+++ b/m4/curl-amissl.m4
@@ -33,7 +33,7 @@ if test "$HAVE_PROTO_BSDSOCKET_H" = "1"; then
         #include <openssl/opensslv.h>
       ]],[[
         #if defined(AMISSL_CURRENT_VERSION) && defined(AMISSL_V3xx) && \
-            defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3) && \
+            (OPENSSL_VERSION_NUMBER >= 0x30000000L) && \
             defined(PROTO_AMISSL_H)
         return 0;
         #else

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -312,7 +312,7 @@ if test "x$OPT_OPENSSL" != xno; then
       AC_LANG_PROGRAM([[
 #include <openssl/opensslv.h>
       ]],[[
-        #if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+        #if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
         return 0;
         #else
         #error older than 3


### PR DESCRIPTION
Uniformly use `OPENSSL_VERSION_NUMBER` to check for OpenSSL version.
Before this patch some places used `OPENSSL_VERSION_MAJOR`.

Also fix `lib/md4.c`, which included `opensslconf.h`, but that doesn't
define any version number in these implementations: BoringSSL, AWS-LC,
LibreSSL, wolfSSL. (Only in mainline OpenSSL/quictls). Switch that to
`opensslv.h`. This wasn't causing a deeper problem because the code is
looking for v3, which is only provided by OpenSSL/quictls as of now.

According to https://github.com/openssl/openssl/issues/17517, the macro
`OPENSSL_VERSION_NUMBER` is safe to use and not deprecated.

Closes #12298
