### PR TITLE
cmake: Fix multiple include of CURL package

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -34,5 +34,7 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")
 
-# Alias for either shared or static library
-add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+if (NOT TARGET @PROJECT_NAME@::libcurl)
+  # Alias for either shared or static library
+  add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+endif()


### PR DESCRIPTION
Prevent target with the same name already exists error

It can easily happen in larger composed CMake projects that the CURL config is included more than once, the normal targets have code to prevent multiple inclusion (in `CURLTargets.cmake`), but the ALIAS needs a guard as well as it is in `CURLConfig.cmake`

You can test with a basic CMake

```cmake
cmake_minimum_required(VERSION 3.27)

project(curl)

set(CURL_DIR "example/lib/cmake/CURL/")
find_package(CURL CONFIG REQUIRED)
find_package(CURL CONFIG REQUIRED) # fails

add_executable(main main.cpp)
target_link_libraries(main CURL::libcurl)
```