### PR TITLE
allow longer http methods for service-specific custom methods

### DIFF
--- a/lib/http.h
+++ b/lib/http.h
@@ -263,7 +263,7 @@ CURLcode Curl_http_decode_status(int *pstatus, const char *s, size_t len);
  * All about a core HTTP request, excluding body and trailers
  */
 struct httpreq {
-  char method[12];
+  char method[24];
   char *scheme;
   char *authority;
   char *path;


### PR DESCRIPTION
Hi, team! Looks like https://github.com/curl/curl/pull/10720 has accidentally added a new limitation to the length of HTTP methods to `11`, which affects our internal use of curl(1).

This PR doubles the limitation, which is large enough for our usage. Can you take a look at it? 

* [x] Checked whether it works for our usage