### PR TITLE
duphandle: use strdup to clone *COPYPOSTFIELDS if size is not set

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -858,10 +858,13 @@ static CURLcode dupset(struct Curl_easy *dst, struct Curl_easy *src)
 
   /* duplicate memory areas pointed to */
   i = STRING_COPYPOSTFIELDS;
-  if(src->set.postfieldsize && src->set.str[i]) {
-    /* postfieldsize is curl_off_t, Curl_memdup() takes a size_t ... */
-    dst->set.str[i] = Curl_memdup(src->set.str[i],
-                                  curlx_sotouz(src->set.postfieldsize));
+  if(src->set.str[i]) {
+    if(src->set.postfieldsize == -1)
+      dst->set.str[i] = strdup(src->set.str[i]);
+    else
+      /* postfieldsize is curl_off_t, Curl_memdup() takes a size_t ... */
+      dst->set.str[i] = Curl_memdup(src->set.str[i],
+                                    curlx_sotouz(src->set.postfieldsize));
     if(!dst->set.str[i])
       return CURLE_OUT_OF_MEMORY;
     /* point to the new copy */

--- a/tests/libtest/lib544.c
+++ b/tests/libtest/lib544.c
@@ -63,7 +63,6 @@ int test(char *URL)
   /* Update the original data to detect non-copy. */
   strcpy(teststring, "FAIL");
 
-#ifdef LIB545
   {
     CURL *handle2;
     handle2 = curl_easy_duphandle(curl);
@@ -71,7 +70,6 @@ int test(char *URL)
 
     curl = handle2;
   }
-#endif
 
   /* Now, this is a POST request with binary 0 embedded in POST data. */
   res = curl_easy_perform(curl);


### PR DESCRIPTION
Previously it would unconditionally use the size, which is set to -1 when strlen is requested.

Updated test 544 to verify.