### PR TITLE
tool_cb_hdr: add an additional parsing check

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -150,16 +150,19 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
       char *filename;
       size_t len;
 
-      while(*p && (p < end) && !ISALPHA(*p))
+      while((p < end) && *p && !ISALPHA(*p))
         p++;
       if(p > end - 9)
         break;
 
       if(memcmp(p, "filename=", 9)) {
         /* no match, find next parameter */
-        while((p < end) && (*p != ';'))
+        while((p < end) && *p && (*p != ';'))
           p++;
-        continue;
+        if((p < end) && *p)
+          continue;
+        else
+          break;
       }
       p += 9;
 


### PR DESCRIPTION
- Don't dereference the past-the-end element when parsing the server's Content-disposition header.

As 'p' is advanced it can point to the past-the-end element and prior to this change 'p' could be dereferenced in that case.

Technically the past-the-end element is not out of bounds because dynbuf (which manages the header line) automatically adds a null terminator to every buffer and that is not included in the buffer length passed to the header callback.

Closes #xxxxx

---

to force past-the-end dereference set server content-disposition header to max length (102399). 
~~~
while true; do { perl -e 'print ("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: Close\r\nContent-Disposition:");print("A"x102378);print("\n\r\n")'; sleep 2; } | nc -4l 127.0.0.1 8000; done
~~~
~~~
curl -v -OJ http://localhost:8000/foo
~~~

note 102399 comes from [CURL_MAX_HTTP_HEADER](https://github.com/curl/curl/blob/curl-8_4_0/include/curl/curl.h#L266-L271) which is 102400 minus the 1 byte dynbuf uses at the end of every buffer to null terminate. if the server sent a length of 102400 for the header then [dynbuf returns out of memory](https://github.com/curl/curl/blob/d755a5f7c009dd63a61b2c745180d8ba937cbfeb/lib/dynbuf.c#L64-L84). due to this an access violation is not possible.
