### PR TITLE
tool: support bold headers in Windows

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -211,7 +211,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 
     if(hdrcbdata->global->isatty &&
 #ifdef WIN32
-       tool_isVirtualTerminal &&
+       tool_term_has_bold &&
 #endif
        hdrcbdata->global->styled_output)
       value = memchr(ptr, ':', cb);

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -42,8 +42,8 @@
 static char *parse_filename(const char *ptr, size_t len);
 
 #ifdef WIN32
-#define BOLD
-#define BOLDOFF
+#define BOLD "\x1b[1m"
+#define BOLDOFF "\x1b[22m"
 #else
 #define BOLD "\x1b[1m"
 /* Switch off bold by setting "all attributes off" since the explicit
@@ -209,7 +209,11 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
     if(!outs->stream && !tool_create_output_file(outs, per->config))
       return CURL_WRITEFUNC_ERROR;
 
-    if(hdrcbdata->global->isatty && hdrcbdata->global->styled_output)
+    if(hdrcbdata->global->isatty &&
+#ifdef WIN32
+       tool_isVirtualTerminal &&
+#endif
+       hdrcbdata->global->styled_output)
       value = memchr(ptr, ':', cb);
     if(value) {
       size_t namelen = value - ptr;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -714,6 +714,8 @@ static struct TerminalSettings {
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #endif
 
+bool tool_isVirtualTerminal;
+
 static void restore_terminal(void)
 {
   if(InterlockedExchange(&TerminalSettings.valid, (LONG)FALSE))
@@ -733,16 +735,23 @@ static BOOL WINAPI signal_handler(DWORD type)
 static void init_terminal(void)
 {
   TerminalSettings.hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+
   /*
    * Enable VT (Virtual Terminal) output.
    * Note: VT mode flag can be set on any version of Windows, but VT
-   * processing only performed on Win10 >= Creators Update)
+   * processing only performed on Win10 >= version 1709 (OS build 16299)
+   * Creator's Update. Also, ANSI bold on/off supported since then.
    */
-  if((TerminalSettings.hStdOut != INVALID_HANDLE_VALUE) &&
-     GetConsoleMode(TerminalSettings.hStdOut,
-                    &TerminalSettings.dwOutputMode) &&
-     !(TerminalSettings.dwOutputMode &
-       ENABLE_VIRTUAL_TERMINAL_PROCESSING)) {
+  if(TerminalSettings.hStdOut == INVALID_HANDLE_VALUE ||
+     !GetConsoleMode(TerminalSettings.hStdOut,
+                     &TerminalSettings.dwOutputMode) ||
+     !curlx_verify_windows_version(10, 0, 16299, PLATFORM_WINNT,
+                                   VERSION_GREATER_THAN_EQUAL))
+    return;
+
+  if((TerminalSettings.dwOutputMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING))
+    tool_isVirtualTerminal = true;
+  else {
     /* The signal handler is set before attempting to change the console mode
        because otherwise a signal would not be caught after the change but
        before the handler was installed. */
@@ -751,6 +760,7 @@ static void init_terminal(void)
       if(SetConsoleMode(TerminalSettings.hStdOut,
                         (TerminalSettings.dwOutputMode |
                          ENABLE_VIRTUAL_TERMINAL_PROCESSING))) {
+        tool_isVirtualTerminal = true;
         atexit(restore_terminal);
       }
       else {

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -714,7 +714,7 @@ static struct TerminalSettings {
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #endif
 
-bool tool_isVirtualTerminal;
+bool tool_term_has_bold;
 
 static void restore_terminal(void)
 {
@@ -750,7 +750,7 @@ static void init_terminal(void)
     return;
 
   if((TerminalSettings.dwOutputMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING))
-    tool_isVirtualTerminal = true;
+    tool_term_has_bold = true;
   else {
     /* The signal handler is set before attempting to change the console mode
        because otherwise a signal would not be caught after the change but
@@ -760,7 +760,7 @@ static void init_terminal(void)
       if(SetConsoleMode(TerminalSettings.hStdOut,
                         (TerminalSettings.dwOutputMode |
                          ENABLE_VIRTUAL_TERMINAL_PROCESSING))) {
-        tool_isVirtualTerminal = true;
+        tool_term_has_bold = true;
         atexit(restore_terminal);
       }
       else {

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -70,6 +70,8 @@ extern FILE *tool_stderr;
 /* set in win32_init() */
 extern LARGE_INTEGER tool_freq;
 extern bool tool_isVistaOrGreater;
+/* set in init_terminal() */
+extern bool tool_isVirtualTerminal;
 #endif
 
 #endif /* HEADER_CURL_TOOL_SETUP_H */

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -71,7 +71,7 @@ extern FILE *tool_stderr;
 extern LARGE_INTEGER tool_freq;
 extern bool tool_isVistaOrGreater;
 /* set in init_terminal() */
-extern bool tool_isVirtualTerminal;
+extern bool tool_term_has_bold;
 #endif
 
 #endif /* HEADER_CURL_TOOL_SETUP_H */


### PR DESCRIPTION
- If virtual terminal processing is enabled in Windows then use ANSI escape codes Esc[1m and Esc[22m to turn bold on and off.

Suggested-by: Gisle Vanem

Ref: https://github.com/curl/curl/discussions/11770

Closes #xxxx

---

![prompt](https://github.com/curl/curl/assets/965580/73e3ef86-a9f3-41db-97bd-643d33433a11)

/cc @gvanem @dfandrich 