### PR TITLE
sasl: fix unused function compiler warning

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -262,6 +262,8 @@ static void sasl_state(struct SASL *sasl, struct Curl_easy *data,
   sasl->state = newstate;
 }
 
+#if defined(USE_NTLM) || defined(USE_GSASL) || defined(USE_KERBEROS5) || \
+  !defined(CURL_DISABLE_DIGEST_AUTH)
 /* Get the SASL server message and convert it to binary. */
 static CURLcode get_server_message(struct SASL *sasl, struct Curl_easy *data,
                                    struct bufref *out)
@@ -284,6 +286,7 @@ static CURLcode get_server_message(struct SASL *sasl, struct Curl_easy *data,
   }
   return result;
 }
+#endif
 
 /* Encode the outgoing SASL message. */
 static CURLcode build_message(struct SASL *sasl, struct bufref *msg)


### PR DESCRIPTION
In builds with disabled auths.

```
lib/curl_sasl.c:266:17: warning: unused function 'get_server_message' [-Wunused-function]
static CURLcode get_server_message(struct SASL *sasl, struct Curl_easy *data,
                ^
1 warning generated.
```
Ref: https://github.com/curl/trurl/actions/runs/6871732122/job/18689066151#step:3:3822

Closes #xxxxx