### PR TITLE
build: fix libssh2 + `CURL_DISABLE_DIGEST_AUTH` + `CURL_DISABLE_AWS`

### DIFF
--- a/lib/curl_hmac.h
+++ b/lib/curl_hmac.h
@@ -25,7 +25,8 @@
  ***************************************************************************/
 
 #if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI))         \
-  || !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH)
+  || !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH)   \
+  || defined(USE_LIBSSH2)
 
 #include <curl/curl.h>
 


### PR DESCRIPTION
Builds with libssh2 + `-DCURL_DISABLE_DIGEST_AUTH=ON` +
`-DCURL_DISABLE_AWS=ON` in combination with either Schannel on Windows,
or `-DCURL_DISABLE_NTLM=ON` on other operating systems failed while
compiling due to a missing HMAC declaration.

The reason is that HMAC is required by `lib/sha256.c` which publishes
`Curl_sha256it()` which is required by `lib/vssh/libssh2.c` when
building for libssh2 v1.8.2 (2019-05-25) or older.

Make sure to compile the HMAC bits for a successful build.

Both HMAC and `Curl_sha256it()` rely on the same internals, so splitting
them into separate sources isn't practical.

Fixes:
```
[...]
In file included from ./curl/_x64-win-ucrt-cmake-llvm-bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:310:
./curl/lib/sha256.c:527:42: error: array has incomplete element type 'const struct HMAC_params'
  527 | const struct HMAC_params Curl_HMAC_SHA256[] = {
      |                                          ^
./curl/lib/curl_sha256.h:34:21: note: forward declaration of 'struct HMAC_params'
[...]
```

Regression from e92edfbef64448ef461117769881f3ed776dec4e #11490

Fixes #12273
Closes #12332
