### PR TITLE
http: fix `-Wunused-parameter` with no auth and no proxy

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -836,6 +836,7 @@ output_auth_headers(struct Curl_easy *data,
           (data->state.aptr.user ?
            data->state.aptr.user : ""));
 #else
+    (void)proxy;
     infof(data, "Server auth using %s with user '%s'",
           auth, data->state.aptr.user ?
           data->state.aptr.user : "");


### PR DESCRIPTION
```
lib/http.c:734:26: warning: unused parameter 'proxy' [-Wunused-parameter]
                    bool proxy)
                         ^
```

Closes #12338
