### PR TITLE
Fixed "Failed writing received data to disk/application" error when multiple compressed streams are present

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -239,8 +239,7 @@ static CURLcode inflate_stream(struct Curl_easy *data,
       /* No more data to flush: just exit loop. */
       break;
     case Z_STREAM_END:
-      if(!zp->trailerlen && z->avail_in)
-      {
+      if(!zp->trailerlen && z->avail_in) {
         uInt avail_in = z->avail_in;
         Bytef *next_in = z->next_in;
 
@@ -250,9 +249,11 @@ static CURLcode inflate_stream(struct Curl_easy *data,
           z->avail_in = avail_in;
           /* continue with next stream */
           done = FALSE;
-          continue;
+          break;
         }
         zp->zlib_init = ZLIB_UNINIT;
+        result = exit_zlib(data, z, &zp->zlib_init, process_zlib_error(data, z));
+        break;
       }
       result = process_trailer(data, zp);
       break;

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -252,7 +252,8 @@ static CURLcode inflate_stream(struct Curl_easy *data,
           break;
         }
         zp->zlib_init = ZLIB_UNINIT;
-        result = exit_zlib(data, z, &zp->zlib_init, process_zlib_error(data, z));
+        result = exit_zlib(data, z, &zp->zlib_init,
+                            process_zlib_error(data, z));
         break;
       }
       result = process_trailer(data, zp);


### PR DESCRIPTION
Failed writing received data to disk/application error is displayed when using curl and there are multiple compressed streams in response. For example:

curl https://www.fust.ch/ --compressed

Attached data with multiple compression for test:
[output.gz](https://github.com/curl/curl/files/13377925/output.gz)

Also please see:
https://support.zabbix.com/browse/ZBX-23702