### PR TITLE
url: fix builds with `CURL_DISABLE_HTTP`

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -453,8 +453,8 @@ CURLcode Curl_close(struct Curl_easy **datap)
   }
 #endif
 
-  Curl_mime_cleanpart(data->state.formp);
 #ifndef CURL_DISABLE_HTTP
+  Curl_mime_cleanpart(data->state.formp);
   Curl_safefree(data->state.formp);
 #endif
 


### PR DESCRIPTION
Fixes:
```
./lib/url.c:456:35: error: no member named 'formp' in 'struct UrlState'
  456 |   Curl_mime_cleanpart(data->state.formp);
      |                       ~~~~~~~~~~~ ^
```

Regression from 74b87a8af13a155c659227f5acfa78243a8b2aa6 #11682

Closes #12343