### PR TITLE
build: always revert `#pragma GCC diagnostic` after use

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -93,6 +93,7 @@
 #if defined(__GNUC__) &&                        \
   (LIBSSH_VERSION_MINOR >= 10) ||               \
   (LIBSSH_VERSION_MAJOR > 0)
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #endif
 
@@ -2945,5 +2946,11 @@ void Curl_ssh_version(char *buffer, size_t buflen)
 {
   (void)msnprintf(buffer, buflen, "libssh/%s", ssh_version(0));
 }
+
+#if defined(__GNUC__) &&                        \
+  (LIBSSH_VERSION_MINOR >= 10) ||               \
+  (LIBSSH_VERSION_MAJOR > 0)
+#pragma GCC diagnostic pop
+#endif
 
 #endif                          /* USE_LIBSSH */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -46,6 +46,7 @@
 #endif /* __clang__ */
 
 #ifdef __GNUC__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Waddress"
 #pragma GCC diagnostic ignored "-Wundef"
 #endif
@@ -3499,6 +3500,10 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   sectransp_recv,                     /* recv decrypted data */
   sectransp_send,                     /* send data to encrypt */
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef __clang__
 #pragma clang diagnostic pop

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -225,9 +225,6 @@ static void main_free(struct GlobalConfig *config)
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
 #endif
 int wmain(int argc, wchar_t *argv[])
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
 #else
 int main(int argc, char *argv[])
 #endif
@@ -290,5 +287,11 @@ int main(int argc, char *argv[])
   return (int)result;
 #endif
 }
+
+#ifdef _UNICODE
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+#endif
 
 #endif /* ndef UNITTESTS */

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -220,10 +220,14 @@ static void main_free(struct GlobalConfig *config)
 #ifdef _UNICODE
 #if defined(__GNUC__)
 /* GCC doesn't know about wmain() */
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-prototypes"
 #pragma GCC diagnostic ignored "-Wmissing-declarations"
 #endif
 int wmain(int argc, wchar_t *argv[])
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 #else
 int main(int argc, char *argv[])
 #endif

--- a/tests/unit/unit3200.c
+++ b/tests/unit/unit3200.c
@@ -47,6 +47,7 @@ static CURLcode unit_stop(void)
 }
 
 #ifdef __GNUC__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverlength-strings"
 #endif
 
@@ -160,6 +161,10 @@ UNITTEST_START
     fprintf(stderr, "OK\n");
   }
 UNITTEST_STOP
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #else
 static CURLcode unit_setup(void)


### PR DESCRIPTION
Before this patch some source files were overriding gcc warning options,
but without restoring them at the end of the file. In CMake UNITY builds
these options spilled over to the remainder of the source code,
effecitvely disabling them for a larger portion of the codebase than
intended.

`#pragma clang diagnostic` didn't have such issue in the codebase.

Closes #12352
