### PR TITLE
cmake: add test for `DISABLE` options, add `CURL_DISABLE_HEADERS_API`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,8 @@ option(CURL_DISABLE_GETOPTIONS "disables curl_easy_options API for existing opti
 mark_as_advanced(CURL_DISABLE_GETOPTIONS)
 option(CURL_DISABLE_GOPHER "disables Gopher" OFF)
 mark_as_advanced(CURL_DISABLE_GOPHER)
+option(CURL_DISABLE_HEADERS_API "disables headers-api support" OFF)
+mark_as_advanced(CURL_DISABLE_HEADERS_API)
 option(CURL_DISABLE_HSTS "disables HSTS support" OFF)
 mark_as_advanced(CURL_DISABLE_HSTS)
 option(CURL_DISABLE_HTTP "disables HTTP" OFF)

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -80,6 +80,9 @@
 /* disables GOPHER */
 #cmakedefine CURL_DISABLE_GOPHER 1
 
+/* disables headers-api support */
+#cmakedefine CURL_DISABLE_HEADERS_API 1
+
 /* disables HSTS support */
 #cmakedefine CURL_DISABLE_HSTS 1
 

--- a/tests/disable-scan.pl
+++ b/tests/disable-scan.pl
@@ -69,7 +69,9 @@ sub scanconf_cmake {
     while(<S>) {
         if(/(CURL_DISABLE_[A-Z_]+)/g) {
             my ($sym)=($1);
-            $disable_cmake{$sym} = 1;
+            if(not $sym =~ /(CURL_DISABLE_INSTALL|CURL_DISABLE_TESTS|CURL_DISABLE_SRP)/) {
+                $disable_cmake{$sym} = 1;
+            }
         }
     }
     close S;


### PR DESCRIPTION
- tests: verify CMake `DISABLE` options.

  Make an exception for 2 CMake-only ones, and one more that's
  using a different naming scheme, also in autotools and source.

- cmake: add support for `CURL_DISABLE_HEADERS_API`.

Suggested-by: Daniel Stenberg
Ref: https://github.com/curl/curl/pull/12345#pullrequestreview-1736238641

Closes #12353
