### PR TITLE
build: check for C99 extensions with clang

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -102,6 +102,7 @@ if(PICKY_COMPILER)
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
         list(APPEND WPICKY_ENABLE
           ${WPICKY_COMMON}
+          -Wc99-extensions                 # clang  3.1            appleclang  4.3
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -801,6 +801,11 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [no-sign-conversion])
           fi
           #
+          dnl Only clang 3.1 or later (possibly earlier)
+          if test "$compiler_num" -ge "301"; then
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [c99-extensions])
+          fi
+          #
           dnl Only clang 3.2 or later
           if test "$compiler_num" -ge "302"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [enum-conversion])


### PR DESCRIPTION
Use `-Wc99-extensions` to warn for non-C89 syntax.

Follow-up to b23ce2cee7329bbf425f18b49973b7a5f23dfcb4 #9542

Closes #12359

---

Expected it to detect `bool` use, but it didn't.

Like here, which was a result of a compiler detection mixup, ending up enabling this option and detecting `bool` uses: https://github.com/curl/curl-for-win/actions/runs/6831206570/job/18580363613#step:3:6876
