### PR TITLE
autotools: fix/improve gcc and Apple clang version detection

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -93,18 +93,37 @@ AC_DEFUN([CURL_CHECK_COMPILER_CLANG], [
     fi
     AC_MSG_CHECKING([compiler version])
     fullclangver=`$CC -v 2>&1 | grep version`
+    if echo $fullclangver | grep 'Apple' >/dev/null; then
+      appleclang=1
+    else
+      appleclang=0
+    fi
     clangver=`echo $fullclangver | grep "based on LLVM " | "$SED" 's/.*(based on LLVM \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*)/\1/'`
     if test -z "$clangver"; then
-      if echo $fullclangver | grep "Apple LLVM version " >/dev/null; then
-        dnl Starting with Xcode 7 / clang 3.7, Apple clang won't tell its upstream version
-        clangver="3.7"
-      else
-        clangver=`echo $fullclangver | "$SED" 's/.*version \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
-      fi
+      clangver=`echo $fullclangver | "$SED" 's/.*version \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*/\1/'`
+      oldapple=0
+    else
+      oldapple=1
     fi
     clangvhi=`echo $clangver | cut -d . -f1`
     clangvlo=`echo $clangver | cut -d . -f2`
     compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
+    if test "$appleclang" = '1' && test "$oldapple" = '0'; then
+      dnl Starting with Xcode 7 / clang 3.7, Apple clang won't tell its upstream version
+      if   test "$compiler_num" -ge '1300'; then compiler_num='1200'
+      elif test "$compiler_num" -ge '1205'; then compiler_num='1101'
+      elif test "$compiler_num" -ge '1204'; then compiler_num='1000'
+      elif test "$compiler_num" -ge '1107'; then compiler_num='900'
+      elif test "$compiler_num" -ge '1103'; then compiler_num='800'
+      elif test "$compiler_num" -ge '1003'; then compiler_num='700'
+      elif test "$compiler_num" -ge '1001'; then compiler_num='600'
+      elif test "$compiler_num" -ge  '904'; then compiler_num='500'
+      elif test "$compiler_num" -ge  '902'; then compiler_num='400'
+      elif test "$compiler_num" -ge  '803'; then compiler_num='309'
+      elif test "$compiler_num" -ge  '703'; then compiler_num='308'
+      else                                       compiler_num='307'
+      fi
+    fi
     AC_MSG_RESULT([clang '$compiler_num' (raw: '$fullclangver' / '$clangver')])
     flags_dbg_yes="-g"
     flags_opt_all="-O -O0 -O1 -O2 -Os -O3 -O4"

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -158,7 +158,8 @@ AC_DEFUN([CURL_CHECK_COMPILER_GNU_C], [
     test "$compiler_id" = "unknown"; then
     AC_MSG_RESULT([yes])
     compiler_id="GNU_C"
-    gccver=`$CC -dumpversion`
+    # strip '-suffix' parts, e.g. Ubuntu Windows cross-gcc returns '10-win32'
+    gccver=`$CC -dumpversion | sed -E 's/-.+$//'`
     gccvhi=`echo $gccver | cut -d . -f1`
     gccvlo=`echo $gccver | cut -d . -f2`
     compiler_num=`(expr $gccvhi "*" 100 + $gccvlo) 2>/dev/null`

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -161,7 +161,11 @@ AC_DEFUN([CURL_CHECK_COMPILER_GNU_C], [
     # strip '-suffix' parts, e.g. Ubuntu Windows cross-gcc returns '10-win32'
     gccver=`$CC -dumpversion | sed -E 's/-.+$//'`
     gccvhi=`echo $gccver | cut -d . -f1`
-    gccvlo=`echo $gccver | cut -d . -f2`
+    if echo $gccver | grep -F '.' >/dev/null; then
+      gccvlo=`echo $gccver | cut -d . -f2`
+    else
+      gccvlo="0"
+    fi
     compiler_num=`(expr $gccvhi "*" 100 + $gccvlo) 2>/dev/null`
     flags_dbg_yes="-g"
     flags_opt_all="-O -O0 -O1 -O2 -O3 -Os -Og -Ofast"

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -91,6 +91,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_CLANG], [
       AC_MSG_RESULT([no])
       compiler_id="CLANG"
     fi
+    AC_MSG_CHECKING([compiler version])
     fullclangver=`$CC -v 2>&1 | grep version`
     clangver=`echo $fullclangver | grep "based on LLVM " | "$SED" 's/.*(based on LLVM \(@<:@0-9@:>@*\.@<:@0-9@:>@*\).*)/\1/'`
     if test -z "$clangver"; then
@@ -104,6 +105,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_CLANG], [
     clangvhi=`echo $clangver | cut -d . -f1`
     clangvlo=`echo $clangver | cut -d . -f2`
     compiler_num=`(expr $clangvhi "*" 100 + $clangvlo) 2>/dev/null`
+    AC_MSG_RESULT([clang '$compiler_num' (raw: '$fullclangver' / '$clangver')])
     flags_dbg_yes="-g"
     flags_opt_all="-O -O0 -O1 -O2 -Os -O3 -O4"
     flags_opt_yes="-O2"
@@ -158,6 +160,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_GNU_C], [
     test "$compiler_id" = "unknown"; then
     AC_MSG_RESULT([yes])
     compiler_id="GNU_C"
+    AC_MSG_CHECKING([compiler version])
     # strip '-suffix' parts, e.g. Ubuntu Windows cross-gcc returns '10-win32'
     gccver=`$CC -dumpversion | sed -E 's/-.+$//'`
     gccvhi=`echo $gccver | cut -d . -f1`
@@ -167,6 +170,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_GNU_C], [
       gccvlo="0"
     fi
     compiler_num=`(expr $gccvhi "*" 100 + $gccvlo) 2>/dev/null`
+    AC_MSG_RESULT([gcc '$compiler_num' (raw: '$gccver')])
     flags_dbg_yes="-g"
     flags_opt_all="-O -O0 -O1 -O2 -O3 -Os -Og -Ofast"
     flags_opt_yes="-O2"
@@ -236,7 +240,9 @@ AC_DEFUN([CURL_CHECK_COMPILER_INTEL_C], [
   CURL_CHECK_DEF([__INTEL_COMPILER], [], [silent])
   if test "$curl_cv_have_def___INTEL_COMPILER" = "yes"; then
     AC_MSG_RESULT([yes])
+    AC_MSG_CHECKING([compiler version])
     compiler_num="$curl_cv_def___INTEL_COMPILER"
+    AC_MSG_RESULT([Intel C '$compiler_num'])
     CURL_CHECK_DEF([__unix__], [], [silent])
     if test "$curl_cv_have_def___unix__" = "yes"; then
       compiler_id="INTEL_UNIX_C"


### PR DESCRIPTION
- Before this patch we expected `n.n` `-dumpversion` output, but Ubuntu
  may return `n-win32` (also with `-dumpfullversion`). Causing these
  errors and failing to enable picky warnings:
  ```
  ../configure: line 23845: test: : integer expression expected
  ```
  Ref: https://github.com/libssh2/libssh2/actions/runs/6263453828/job/17007893718#step:5:143

  Fix that by stripping any dash-suffix and handling a dotless (major-only)
  version number by assuming `.0` in that case.

  `9.3-posix`, `9.3-win32`, `6`, `9.3.0`, `11`, `11.2`, `11.2.0`
  Ref: https://github.com/mamedev/mame/pull/9767

- fix Apple clang version detection for releases between
  'Apple LLVM version 7.3.0' and 'Apple LLVM version 10.0.1' where the
  version was under-detected as 3.7 llvm/clang equivalent.

- fix Apple clang version detection for 'Apple clang version 11.0.0'
  and newer where the Apple clang version was detected, instead of its
  llvm/clang equivalent.

- display detected clang/gcc/icc compiler version.

Via libssh2:
- https://github.com/libssh2/libssh2/commit/00a3b88c51cdb407fbbb347a2e38c5c7d89875ad
  https://github.com/libssh2/libssh2/pull/1187
- https://github.com/libssh2/libssh2/commit/89ccc83c7da73e7ca3a112e350008131942b592e
  https://github.com/libssh2/libssh2/pull/1232

Closes #12362
