### PR TITLE
transfer: avoid calling the read callback again after EOF

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -231,10 +231,16 @@ CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
     extra_data = data->state.in;
   }
 
-  Curl_set_in_callback(data, true);
-  nread = readfunc(data->req.upload_fromhere, 1,
-                   buffersize, extra_data);
-  Curl_set_in_callback(data, false);
+  if(!data->req.fread_func_eof) {
+    Curl_set_in_callback(data, true);
+    nread = readfunc(data->req.upload_fromhere, 1,
+                     buffersize, extra_data);
+    Curl_set_in_callback(data, false);
+    /* make sure the callback is not called again after EOF */
+    data->req.fread_func_eof = !nread;
+  }
+  else
+    nread = 0;
 
   if(nread == CURL_READFUNC_ABORT) {
     failf(data, "operation aborted by callback");

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -163,9 +163,9 @@ CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
 {
   size_t buffersize = bytes;
   size_t nread;
-
   curl_read_callback readfunc = NULL;
   void *extra_data = NULL;
+  int eof_index = 0;
 
 #ifndef CURL_DISABLE_HTTP
   if(data->state.trailers_state == TRAILERS_INITIALIZED) {
@@ -223,6 +223,7 @@ CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
        */
     readfunc = trailers_read;
     extra_data = (void *)data;
+    eof_index = 1;
   }
   else
 #endif
@@ -231,13 +232,12 @@ CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
     extra_data = data->state.in;
   }
 
-  if(!data->req.fread_func_eof) {
+  if(!data->req.fread_eof[eof_index]) {
     Curl_set_in_callback(data, true);
-    nread = readfunc(data->req.upload_fromhere, 1,
-                     buffersize, extra_data);
+    nread = readfunc(data->req.upload_fromhere, 1, buffersize, extra_data);
     Curl_set_in_callback(data, false);
     /* make sure the callback is not called again after EOF */
-    data->req.fread_func_eof = !nread;
+    data->req.fread_eof[eof_index] = !nread;
   }
   else
     nread = 0;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -753,6 +753,7 @@ struct SingleRequest {
                         specific upload buffers. See readmoredata() in http.c
                         for details. */
   BIT(no_body);      /* the response has no body */
+  BIT(fread_func_eof); /* the read callback has returned EOF */
 };
 
 /*

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -733,6 +733,8 @@ struct SingleRequest {
   struct curltime last_sndbuf_update;  /* last time readwrite_upload called
                                           win_update_buffer_size */
 #endif
+  char fread_eof[2]; /* the body read callback (index 0) returned EOF or
+                        the trailer read callback (index 1) returned EOF */
 #ifndef CURL_DISABLE_COOKIES
   unsigned char setcookies;
 #endif
@@ -753,7 +755,6 @@ struct SingleRequest {
                         specific upload buffers. See readmoredata() in http.c
                         for details. */
   BIT(no_body);      /* the response has no body */
-  BIT(fread_func_eof); /* the read callback has returned EOF */
 };
 
 /*


### PR DESCRIPTION
Regression since 7f43f3dc5994d01b12 (7.84.0)

Bug: https://curl.se/mail/lib-2023-11/0017.html