### PR TITLE
HTTP/2, HTTP/3, handle detach of ongoing transfers

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2483,14 +2483,15 @@ static CURLcode cf_h2_cntrl(struct Curl_cfilter *cf,
   case CF_CTRL_DATA_PAUSE:
     result = http2_data_pause(cf, data, (arg1 != 0));
     break;
-  case CF_CTRL_DATA_DONE_SEND: {
+  case CF_CTRL_DATA_DONE_SEND:
     result = http2_data_done_send(cf, data);
     break;
-  }
-  case CF_CTRL_DATA_DONE: {
+  case CF_CTRL_DATA_DETACH:
+    http2_data_done(cf, data, TRUE);
+    break;
+  case CF_CTRL_DATA_DONE:
     http2_data_done(cf, data, arg1 != 0);
     break;
-  }
   default:
     break;
   }


### PR DESCRIPTION
- refs #12356 where a UAF is reported when closing a connection with a stream whose easy handle was cleaned up already
- handle DETACH events same as DONE events in h2/h3 filters