### PR TITLE
transfer: avoid having an unreachable expression

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -423,9 +423,11 @@ static size_t get_max_body_write_len(struct Curl_easy *data)
       /* already written too much! */
       return 0;
     }
+#if SIZEOF_CURL_OFF_T > SIZEOF_SIZE_T
     else if(remain_diff > SSIZE_T_MAX) {
       return SIZE_T_MAX;
     }
+#endif
     else {
       return (size_t)remain_diff;
     }


### PR DESCRIPTION
If curl_off_t and size_t have the same size (which is common on modern 64 bit systems), a condition cannot occur which Coverity pointed out. Avoid the warning by having the code conditionally only used if curl_off_t actually is larger.

Follow-up to 1cd2f0072fa482e25baa2