### PR TITLE
windows: use built-in `_WIN32` macro to detect Windows

### DIFF
--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -29,7 +29,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef WIN32
+#ifndef _WIN32
 #  include <unistd.h>
 #endif
 #include <curl/curl.h>

--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -33,7 +33,7 @@
 
 #include <curl/curl.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #  define FILENO(fp) _fileno(fp)
 #else
 #  define FILENO(fp) fileno(fp)

--- a/docs/examples/cookie_interface.c
+++ b/docs/examples/cookie_interface.c
@@ -91,7 +91,7 @@ main(void)
 
     printf("-----------------------------------------------\n"
            "Setting a cookie \"PREF\" via cookie interface:\n");
-#ifdef WIN32
+#ifdef _WIN32
 #define snprintf _snprintf
 #endif
     /* Netscape format cookie */

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -30,7 +30,7 @@
 #include <stdlib.h>
 #include <curl/curl.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <windows.h>
 #include <winsock2.h>
 #include <ws2tcpip.h>
@@ -96,7 +96,7 @@ int main(void)
   struct sockaddr_in servaddr;  /*  socket address structure  */
   curl_socket_t sockfd;
 
-#ifdef WIN32
+#ifdef _WIN32
   WSADATA wsaData;
   int initwsa = WSAStartup(MAKEWORD(2, 2), &wsaData);
   if(initwsa) {
@@ -168,7 +168,7 @@ int main(void)
     }
   }
 
-#ifdef WIN32
+#ifdef _WIN32
   WSACleanup();
 #endif
   return 0;

--- a/docs/examples/ftpupload.c
+++ b/docs/examples/ftpupload.c
@@ -29,7 +29,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
-#ifdef WIN32
+#ifdef _WIN32
 #include <io.h>
 #else
 #include <unistd.h>

--- a/docs/examples/ipv6.c
+++ b/docs/examples/ipv6.c
@@ -28,13 +28,13 @@
 #include <stdio.h>
 #include <curl/curl.h>
 
-#ifndef WIN32
+#ifndef _WIN32
 #include <net/if.h>
 #endif
 
 int main(void)
 {
-#ifndef WIN32
+#ifndef _WIN32
   /* Windows users need to find how to use if_nametoindex() */
   CURL *curl;
   CURLcode res;

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -190,7 +190,7 @@ CURL_VERSION_ZSTD               7.72.0
 CURL_WAIT_POLLIN                7.28.0
 CURL_WAIT_POLLOUT               7.28.0
 CURL_WAIT_POLLPRI               7.28.0
-CURL_WIN32                      7.69.0
+CURL_WIN32                      7.69.0                    8.5.0
 CURL_WRITEFUNC_ERROR            7.87.0
 CURL_WRITEFUNC_PAUSE            7.18.0
 CURL_ZERO_TERMINATED            7.56.0

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -190,7 +190,7 @@ CURL_VERSION_ZSTD               7.72.0
 CURL_WAIT_POLLIN                7.28.0
 CURL_WAIT_POLLOUT               7.28.0
 CURL_WAIT_POLLPRI               7.28.0
-CURL_WIN32                      7.69.0                    8.5.0
+CURL_WIN32                      7.69.0        -           8.5.0
 CURL_WRITEFUNC_ERROR            7.87.0
 CURL_WRITEFUNC_PAUSE            7.18.0
 CURL_ZERO_TERMINATED            7.56.0

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -57,7 +57,9 @@
  * Define CURL_WIN32 when build target is Win32 API
  */
 
-#if (defined(_WIN32) || defined(__WIN32__) || defined(WIN32)) &&        \
+#if (defined(_WIN32) || \
+     defined(WIN32) /* !checksrc! disable BANNEDPREPROC 1 */ || \
+     defined(__WIN32__)) && \
   !defined(__SYMBIAN32__)
 #define CURL_WIN32
 #endif

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -53,17 +53,6 @@
 #include "curlver.h"         /* libcurl version defines   */
 #include "system.h"          /* determine things run-time */
 
-/*
- * Define CURL_WIN32 when build target is Win32 API
- */
-
-#if (defined(_WIN32) || \
-     defined(WIN32) /* !checksrc! disable BANNEDPREPROC 1 */ || \
-     defined(__WIN32__)) && \
-  !defined(__SYMBIAN32__)
-#define CURL_WIN32
-#endif
-
 #include <stdio.h>
 #include <limits.h>
 
@@ -76,7 +65,7 @@
 #include <sys/types.h>
 #include <time.h>
 
-#if defined(CURL_WIN32) && !defined(_WIN32_WCE) && !defined(__CYGWIN__)
+#if defined(_WIN32) && !defined(_WIN32_WCE) && !defined(__CYGWIN__)
 #if !(defined(_WINSOCKAPI_) || defined(_WINSOCK_H) || \
       defined(__LWIP_OPT_H__) || defined(LWIP_HDR_OPT_H))
 /* The check above prevents the winsock2 inclusion if winsock.h already was
@@ -99,11 +88,11 @@
 #include <sys/select.h>
 #endif
 
-#if !defined(CURL_WIN32) && !defined(_WIN32_WCE)
+#if !defined(_WIN32) && !defined(_WIN32_WCE)
 #include <sys/socket.h>
 #endif
 
-#if !defined(CURL_WIN32)
+#if !defined(_WIN32)
 #include <sys/time.h>
 #endif
 
@@ -130,7 +119,7 @@ typedef void CURLSH;
 
 #ifdef CURL_STATICLIB
 #  define CURL_EXTERN
-#elif defined(CURL_WIN32) || defined(__SYMBIAN32__) || \
+#elif defined(_WIN32) || defined(__SYMBIAN32__) || \
      (__has_declspec_attribute(dllexport) && \
       __has_declspec_attribute(dllimport))
 #  if defined(BUILDING_LIBCURL)
@@ -146,7 +135,7 @@ typedef void CURLSH;
 
 #ifndef curl_socket_typedef
 /* socket typedef */
-#if defined(CURL_WIN32) && !defined(__LWIP_OPT_H__) && !defined(LWIP_HDR_OPT_H)
+#if defined(_WIN32) && !defined(__LWIP_OPT_H__) && !defined(LWIP_HDR_OPT_H)
 typedef SOCKET curl_socket_t;
 #define CURL_SOCKET_BAD INVALID_SOCKET
 #else

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -60,13 +60,13 @@
 #include "progress.h"
 #include "timediff.h"
 
-#  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) &&   \
-  defined(WIN32)
-#    define CARES_STATICLIB
-#  endif
-#  include <ares.h>
-#  include <ares_version.h> /* really old c-ares didn't include this by
-                               itself */
+#if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) &&   \
+  defined(_WIN32)
+#  define CARES_STATICLIB
+#endif
+#include <ares.h>
+#include <ares_version.h> /* really old c-ares didn't include this by
+                             itself */
 
 #if ARES_VERSION >= 0x010500
 /* c-ares 1.5.0 or later, the callback proto is modified */

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -81,7 +81,7 @@
 #include "memdebug.h"
 
 
-#if defined(ENABLE_IPV6) && defined(IPV6_V6ONLY) && defined(WIN32)
+#if defined(ENABLE_IPV6) && defined(IPV6_V6ONLY) && defined(_WIN32)
 /* It makes support for IPv4-mapped IPv6 addresses.
  * Linux kernel, NetBSD, FreeBSD and Darwin: default is off;
  * Windows Vista and later: default is on;
@@ -659,7 +659,7 @@ static bool verifyconnect(curl_socket_t sockfd, int *error)
   int err = 0;
   curl_socklen_t errSize = sizeof(err);
 
-#ifdef WIN32
+#ifdef _WIN32
   /*
    * In October 2003 we effectively nullified this function on Windows due to
    * problems with it using all CPU in multi-threaded cases.

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -68,7 +68,7 @@
 #undef send
 #undef recv
 
-#ifdef WIN32
+#ifdef _WIN32
 #  ifdef UNICODE
 #    undef wcsdup
 #    undef _wcsdup
@@ -134,7 +134,7 @@ extern curl_free_callback Curl_cfree;
 extern curl_realloc_callback Curl_crealloc;
 extern curl_strdup_callback Curl_cstrdup;
 extern curl_calloc_callback Curl_ccalloc;
-#if defined(WIN32) && defined(UNICODE)
+#if defined(_WIN32) && defined(UNICODE)
 extern curl_wcsdup_callback Curl_cwcsdup;
 #endif
 
@@ -160,7 +160,7 @@ extern curl_wcsdup_callback Curl_cwcsdup;
 #undef free
 #define free(ptr) Curl_cfree(ptr)
 
-#ifdef WIN32
+#ifdef _WIN32
 #  ifdef UNICODE
 #    undef wcsdup
 #    define wcsdup(ptr) Curl_cwcsdup(ptr)

--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -32,7 +32,7 @@
 
 #include "curl_setup.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 #include "curl_multibyte.h"
 
@@ -84,7 +84,7 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w)
   return str_utf8;
 }
 
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 #if defined(USE_WIN32_LARGE_FILES) || defined(USE_WIN32_SMALL_FILES)
 

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
  /*
   * MultiByte conversions using Windows kernel32 library.
@@ -33,7 +33,7 @@
 
 wchar_t *curlx_convert_UTF8_to_wchar(const char *str_utf8);
 char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 /*
  * Macros curlx_convert_UTF8_to_tchar(), curlx_convert_tchar_to_UTF8()
@@ -54,7 +54,7 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w);
  * ensure that the curl memdebug override macros do not replace them.
  */
 
-#if defined(UNICODE) && defined(WIN32)
+#if defined(UNICODE) && defined(_WIN32)
 
 #define curlx_convert_UTF8_to_tchar(ptr) curlx_convert_UTF8_to_wchar((ptr))
 #define curlx_convert_tchar_to_UTF8(ptr) curlx_convert_wchar_to_UTF8((ptr))
@@ -78,7 +78,7 @@ typedef union {
   const unsigned char *const_tbyte_ptr;
 } xcharp_u;
 
-#endif /* UNICODE && WIN32 */
+#endif /* UNICODE && _WIN32 */
 
 #define curlx_unicodefree(ptr)                          \
   do {                                                  \

--- a/lib/curl_path.h
+++ b/lib/curl_path.h
@@ -28,7 +28,7 @@
 #include <curl/curl.h>
 #include "urldata.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #  undef  PATH_MAX
 #  define PATH_MAX MAX_PATH
 #  ifndef R_OK

--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -39,7 +39,7 @@
 /* The last #include file should be: */
 #include "memdebug.h"
 
-#if defined(WIN32) && !defined(USE_LWIPSOCK)
+#if defined(_WIN32) && !defined(USE_LWIPSOCK)
 #define setsockopt(a,b,c,d,e) (setsockopt)(a,b,c,(const char *)d,(int)e)
 #define SET_RCVTIMEO(tv,s)   int tv = s*1000
 #elif defined(LWIP_SO_SNDRCVTIMEO_NONSTANDARD)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -41,15 +41,7 @@
 #pragma warning(disable:4127)
 #endif
 
-/*
- * Define WIN32 when build target is Win32 API
- */
-
-#if (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32)
-#define WIN32
-#endif
-
-#ifdef WIN32
+#ifdef _WIN32
 /*
  * Don't include unneeded stuff in Windows headers to avoid compiler
  * warnings and macro clashes.
@@ -87,7 +79,7 @@
 #ifdef _WIN32_WCE
 #  include "config-win32ce.h"
 #else
-#  ifdef WIN32
+#  ifdef _WIN32
 #    include "config-win32.h"
 #  endif
 #endif
@@ -505,11 +497,11 @@
    5. set dir/file naming defines
    */
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #  define DIR_CHAR      "\\"
 
-#else /* WIN32 */
+#else /* _WIN32 */
 
 #  ifdef MSDOS  /* Watt-32 */
 
@@ -534,7 +526,7 @@
 
 #  define DIR_CHAR      "/"
 
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 /* ---------------------------------------------------------------- */
 /*             resolver specialty compile-time defines              */
@@ -557,7 +549,7 @@
 
 #if defined(ENABLE_IPV6) && defined(HAVE_GETADDRINFO)
 #  define CURLRES_IPV6
-#elif defined(ENABLE_IPV6) && (defined(WIN32) || defined(__CYGWIN__))
+#elif defined(ENABLE_IPV6) && (defined(_WIN32) || defined(__CYGWIN__))
 /* assume on Windows that IPv6 without getaddrinfo is a broken build */
 #  error "Unexpected build: IPv6 is enabled but getaddrinfo was not found."
 #else
@@ -714,7 +706,7 @@
 /* In Windows the default file mode is text but an application can override it.
 Therefore we specify it explicitly. https://github.com/curl/curl/pull/258
 */
-#if defined(WIN32) || defined(MSDOS)
+#if defined(_WIN32) || defined(MSDOS)
 #define FOPEN_READTEXT "rt"
 #define FOPEN_WRITETEXT "wt"
 #define FOPEN_APPENDTEXT "at"
@@ -783,11 +775,11 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 /* Certain Windows implementations are not aligned with what curl expects,
    so always use the local one on this platform. E.g. the mingw-w64
    implementation can return wrong results for non-ASCII inputs. */
-#if defined(HAVE_BASENAME) && defined(WIN32)
+#if defined(HAVE_BASENAME) && defined(_WIN32)
 #undef HAVE_BASENAME
 #endif
 
-#if defined(USE_UNIX_SOCKETS) && defined(WIN32)
+#if defined(USE_UNIX_SOCKETS) && defined(_WIN32)
 #  if !defined(UNIX_PATH_MAX)
      /* Replicating logic present in afunix.h
         (distributed with newer Windows 10 SDK versions only) */

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -56,7 +56,7 @@
 #include <sys/time.h>
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
 #endif

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -125,7 +125,7 @@ curl_free_callback Curl_cfree = (curl_free_callback)free;
 curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)system_strdup;
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
-#if defined(WIN32) && defined(UNICODE)
+#if defined(_WIN32) && defined(UNICODE)
 curl_wcsdup_callback Curl_cwcsdup = Curl_wcsdup;
 #endif
 
@@ -153,7 +153,7 @@ static CURLcode global_init(long flags, bool memoryfuncs)
     Curl_crealloc = (curl_realloc_callback)realloc;
     Curl_cstrdup = (curl_strdup_callback)system_strdup;
     Curl_ccalloc = (curl_calloc_callback)calloc;
-#if defined(WIN32) && defined(UNICODE)
+#if defined(_WIN32) && defined(UNICODE)
     Curl_cwcsdup = (curl_wcsdup_callback)_wcsdup;
 #endif
   }
@@ -287,7 +287,7 @@ void curl_global_cleanup(void)
   Curl_ssl_cleanup();
   Curl_resolver_global_cleanup();
 
-#ifdef WIN32
+#ifdef _WIN32
   Curl_win32_cleanup(easy_init_flags);
 #endif
 

--- a/lib/file.c
+++ b/lib/file.c
@@ -69,7 +69,7 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#if defined(WIN32) || defined(MSDOS) || defined(__EMX__)
+#if defined(_WIN32) || defined(MSDOS) || defined(__EMX__)
 #define DOS_FILESYSTEM 1
 #elif defined(__amigaos4__)
 #define AMIGA_FILESYSTEM 1

--- a/lib/functypes.h
+++ b/lib/functypes.h
@@ -38,7 +38,7 @@
    2. For systems with config-*.h files, define them there.
 */
 
-#ifdef WIN32
+#ifdef _WIN32
 /* int recv(SOCKET, char *, int, int) */
 #define RECV_TYPE_ARG1 SOCKET
 #define RECV_TYPE_ARG2 char *

--- a/lib/getenv.c
+++ b/lib/getenv.c
@@ -35,7 +35,7 @@ static char *GetEnv(const char *variable)
   defined(__ORBIS__) || defined(__PROSPERO__) /* PlayStation 4 and 5 */
   (void)variable;
   return NULL;
-#elif defined(WIN32)
+#elif defined(_WIN32)
   /* This uses Windows API instead of C runtime getenv() to get the environment
      variable since some changes aren't always visible to the latter. #4774 */
   char *buf = NULL;

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -36,7 +36,7 @@
 #ifdef USE_LIBIDN2
 #include <idn2.h>
 
-#if defined(WIN32) && defined(UNICODE)
+#if defined(_WIN32) && defined(UNICODE)
 #define IDN2_LOOKUP(name, host, flags)                                  \
   idn2_lookup_u8((const uint8_t *)name, (uint8_t **)host, flags)
 #else

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -208,7 +208,7 @@ ALLOC_FUNC char *curl_dbg_strdup(const char *str,
   return mem;
 }
 
-#if defined(WIN32) && defined(UNICODE)
+#if defined(_WIN32) && defined(UNICODE)
 ALLOC_FUNC wchar_t *curl_dbg_wcsdup(const wchar_t *str,
                                     int line, const char *source)
 {

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -64,7 +64,7 @@ CURL_EXTERN ALLOC_SIZE(2) void *curl_dbg_realloc(void *ptr,
 CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
 CURL_EXTERN ALLOC_FUNC char *curl_dbg_strdup(const char *str, int line,
                                              const char *src);
-#if defined(WIN32) && defined(UNICODE)
+#if defined(_WIN32) && defined(UNICODE)
 CURL_EXTERN ALLOC_FUNC wchar_t *curl_dbg_wcsdup(const wchar_t *str,
                                                 int line,
                                                 const char *source);
@@ -121,7 +121,7 @@ CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
 #define send(a,b,c,d) curl_dbg_send(a,b,c,d, __LINE__, __FILE__)
 #define recv(a,b,c,d) curl_dbg_recv(a,b,c,d, __LINE__, __FILE__)
 
-#ifdef WIN32
+#ifdef _WIN32
 #  ifdef UNICODE
 #    undef wcsdup
 #    define wcsdup(ptr) curl_dbg_wcsdup(ptr, __LINE__, __FILE__)

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -48,7 +48,7 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 # ifndef R_OK
 #  define R_OK 4
 # endif

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -327,7 +327,7 @@ int Curl_parsenetrc(const char *host, char **loginp, char **passwordp,
     }
     retcode = parsenetrc(host, loginp, passwordp, filealloc);
     free(filealloc);
-#ifdef WIN32
+#ifdef _WIN32
     if(retcode == NETRC_FILE_MISSING) {
       /* fallback to the old-style "_netrc" file */
       filealloc = curl_maprintf("%s%s_netrc", home, DIR_CHAR);

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -46,7 +46,7 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 
 #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600
 #  define HAVE_WIN_BCRYPTGENRANDOM
@@ -133,7 +133,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
 
   /* ---- non-cryptographic version following ---- */
 
-#ifdef WIN32
+#ifdef _WIN32
   if(!seeded) {
     result = Curl_win32_random((unsigned char *)rnd, sizeof(*rnd));
     if(result != CURLE_NOT_BUILT_IN)
@@ -148,7 +148,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd)
   }
 #endif
 
-#if defined(RANDOM_FILE) && !defined(WIN32)
+#if defined(RANDOM_FILE) && !defined(_WIN32)
   if(!seeded) {
     /* if there's a random file to read a seed from, use it */
     int fd = open(RANDOM_FILE, O_RDONLY);

--- a/lib/rand.h
+++ b/lib/rand.h
@@ -41,7 +41,7 @@ CURLcode Curl_rand_hex(struct Curl_easy *data, unsigned char *rnd,
 CURLcode Curl_rand_alnum(struct Curl_easy *data, unsigned char *rnd,
                          size_t num);
 
-#ifdef WIN32
+#ifdef _WIN32
 /* Random generator shared between the Schannel vtls and Curl_rand*()
    functions */
 CURLcode Curl_win32_random(unsigned char *entropy, size_t length);

--- a/lib/rename.c
+++ b/lib/rename.c
@@ -40,7 +40,7 @@
 /* return 0 on success, 1 on error */
 int Curl_rename(const char *oldpath, const char *newpath)
 {
-#ifdef WIN32
+#ifdef _WIN32
   /* rename() on Windows doesn't overwrite, so we can't use it here.
      MoveFileEx() will overwrite and is usually atomic, however it fails
      when there are open handles to the file. */

--- a/lib/select.c
+++ b/lib/select.c
@@ -76,7 +76,7 @@ int Curl_wait_ms(timediff_t timeout_ms)
   }
 #if defined(MSDOS)
   delay(timeout_ms);
-#elif defined(WIN32)
+#elif defined(_WIN32)
   /* prevent overflow, timeout_ms is typecast to ULONG/DWORD. */
 #if TIMEDIFF_T_MAX >= ULONG_MAX
   if(timeout_ms >= ULONG_MAX)

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -27,7 +27,7 @@
 
 #if !defined(CURL_DISABLE_SMB) && defined(USE_CURL_NTLM_CORE)
 
-#ifdef WIN32
+#ifdef _WIN32
 #define getpid GetCurrentProcessId
 #endif
 

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -28,7 +28,7 @@
 #include "rand.h"
 
 #if !defined(HAVE_SOCKETPAIR) && !defined(CURL_DISABLE_SOCKETPAIR)
-#ifdef WIN32
+#ifdef _WIN32
 /*
  * This is a socketpair() implementation for Windows.
  */
@@ -50,7 +50,7 @@
 #ifndef INADDR_LOOPBACK
 #define INADDR_LOOPBACK 0x7f000001
 #endif /* !INADDR_LOOPBACK */
-#endif /* !WIN32 */
+#endif /* !_WIN32 */
 
 #include "nonblock.h" /* for curlx_nonblock */
 #include "timeval.h"  /* needed before select.h */
@@ -87,7 +87,7 @@ int Curl_socketpair(int domain, int type, int protocol,
 
   socks[0] = socks[1] = CURL_SOCKET_BAD;
 
-#if defined(WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
   /* don't set SO_REUSEADDR on Windows */
   (void)reuse;
 #ifdef SO_EXCLUSIVEADDRUSE

--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -26,7 +26,7 @@
 
 #include <curl/curl.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <wchar.h>
 #endif
 
@@ -56,7 +56,7 @@ char *Curl_strdup(const char *str)
 }
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 /***************************************************************************
  *
  * Curl_wcsdup(source)

--- a/lib/strdup.h
+++ b/lib/strdup.h
@@ -28,7 +28,7 @@
 #ifndef HAVE_STRDUP
 char *Curl_strdup(const char *str);
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 wchar_t* Curl_wcsdup(const wchar_t* src);
 #endif
 void *Curl_memdup(const void *src, size_t buffer_length);

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -48,7 +48,7 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#if defined(WIN32) || defined(_WIN32_WCE)
+#if defined(_WIN32) || defined(_WIN32_WCE)
 #define PRESERVE_WINDOWS_ERROR_CODE
 #endif
 
@@ -762,7 +762,7 @@ get_winsock_error (int err, char *buf, size_t len)
 }
 #endif   /* USE_WINSOCK */
 
-#if defined(WIN32) || defined(_WIN32_WCE)
+#if defined(_WIN32) || defined(_WIN32_WCE)
 /* This is a helper function for Curl_strerror that converts Windows API error
  * codes (GetLastError) to error messages.
  * Returns NULL if no error message was found for error code.
@@ -804,7 +804,7 @@ get_winapi_error(int err, char *buf, size_t buflen)
 
   return (*buf ? buf : NULL);
 }
-#endif /* WIN32 || _WIN32_WCE */
+#endif /* _WIN32 || _WIN32_WCE */
 
 /*
  * Our thread-safe and smart strerror() replacement.
@@ -837,15 +837,15 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
   if(!buflen)
     return NULL;
 
-#ifndef WIN32
+#ifndef _WIN32
   DEBUGASSERT(err >= 0);
 #endif
 
   max = buflen - 1;
   *buf = '\0';
 
-#if defined(WIN32) || defined(_WIN32_WCE)
-#if defined(WIN32)
+#if defined(_WIN32) || defined(_WIN32_WCE)
+#if defined(_WIN32)
   /* 'sys_nerr' is the maximum errno number, it is not widely portable */
   if(err >= 0 && err < sys_nerr)
     strncpy(buf, sys_errlist[err], max);
@@ -923,7 +923,7 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
  * Curl_winapi_strerror:
  * Variant of Curl_strerror if the error code is definitely Windows API.
  */
-#if defined(WIN32) || defined(_WIN32_WCE)
+#if defined(_WIN32) || defined(_WIN32_WCE)
 const char *Curl_winapi_strerror(DWORD err, char *buf, size_t buflen)
 {
 #ifdef PRESERVE_WINDOWS_ERROR_CODE
@@ -958,7 +958,7 @@ const char *Curl_winapi_strerror(DWORD err, char *buf, size_t buflen)
 
   return buf;
 }
-#endif /* WIN32 || _WIN32_WCE */
+#endif /* _WIN32 || _WIN32_WCE */
 
 #ifdef USE_WINDOWS_SSPI
 /*

--- a/lib/strerror.h
+++ b/lib/strerror.h
@@ -29,7 +29,7 @@
 #define STRERROR_LEN 256 /* a suitable length */
 
 const char *Curl_strerror(int err, char *buf, size_t buflen);
-#if defined(WIN32) || defined(_WIN32_WCE)
+#if defined(_WIN32) || defined(_WIN32_WCE)
 const char *Curl_winapi_strerror(DWORD err, char *buf, size_t buflen);
 #endif
 #ifdef USE_WINDOWS_SSPI

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 #include <curl/curl.h>
 #include "system_win32.h"
@@ -238,4 +238,4 @@ HMODULE Curl_load_library(LPCTSTR filename)
 #endif
 }
 
-#endif /* WIN32 */
+#endif /* _WIN32 */

--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 extern LARGE_INTEGER Curl_freq;
 extern bool Curl_isVistaOrGreater;
@@ -42,8 +42,8 @@ extern IF_NAMETOINDEX_FN Curl_if_nametoindex;
 
 /* This is used to dynamically load DLLs */
 HMODULE Curl_load_library(LPCTSTR filename);
-#else  /* WIN32 */
+#else  /* _WIN32 */
 #define Curl_win32_init(x) CURLE_OK
-#endif /* !WIN32 */
+#endif /* !_WIN32 */
 
 #endif /* HEADER_CURL_SYSTEM_WIN32_H */

--- a/lib/timediff.c
+++ b/lib/timediff.c
@@ -53,7 +53,7 @@ struct timeval *curlx_mstotv(struct timeval *tv, timediff_t ms)
 #endif
     tv->tv_sec = (time_t)tv_sec;
     tv->tv_usec = (suseconds_t)tv_usec;
-#elif defined(WIN32) /* maybe also others in the future */
+#elif defined(_WIN32) /* maybe also others in the future */
 #if TIMEDIFF_T_MAX > LONG_MAX
     /* tv_sec overflow check on Windows there we know it is long */
     if(tv_sec > LONG_MAX)

--- a/lib/timeval.c
+++ b/lib/timeval.c
@@ -24,7 +24,7 @@
 
 #include "timeval.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 #include <curl/curl.h>
 #include "system_win32.h"

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -820,7 +820,7 @@ CURLcode Curl_done_sending(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#if defined(WIN32) && defined(USE_WINSOCK)
+#if defined(_WIN32) && defined(USE_WINSOCK)
 #ifndef SIO_IDEAL_SEND_BACKLOG_QUERY
 #define SIO_IDEAL_SEND_BACKLOG_QUERY 0x4004747B
 #endif
@@ -1014,7 +1014,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
     if(result)
       return result;
 
-#if defined(WIN32) && defined(USE_WINSOCK)
+#if defined(_WIN32) && defined(USE_WINSOCK)
     {
       struct curltime n = Curl_now();
       if(Curl_timediff(n, k->last_sndbuf_update) > 1000) {

--- a/lib/url.c
+++ b/lib/url.c
@@ -1750,14 +1750,14 @@ static void zonefrom_url(CURLU *uh, struct Curl_easy *data,
       conn->scope_id = (unsigned int)scope;
 #if defined(HAVE_IF_NAMETOINDEX)
     else {
-#elif defined(WIN32)
+#elif defined(_WIN32)
     else if(Curl_if_nametoindex) {
 #endif
 
-#if defined(HAVE_IF_NAMETOINDEX) || defined(WIN32)
+#if defined(HAVE_IF_NAMETOINDEX) || defined(_WIN32)
       /* Zone identifier is not numeric */
       unsigned int scopeidx = 0;
-#if defined(WIN32)
+#if defined(_WIN32)
       scopeidx = Curl_if_nametoindex(zoneid);
 #else
       scopeidx = if_nametoindex(zoneid);
@@ -1772,7 +1772,7 @@ static void zonefrom_url(CURLU *uh, struct Curl_easy *data,
       else
         conn->scope_id = scopeidx;
     }
-#endif /* HAVE_IF_NAMETOINDEX || WIN32 */
+#endif /* HAVE_IF_NAMETOINDEX || _WIN32 */
 
     free(zoneid);
   }

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -206,7 +206,7 @@ size_t Curl_is_absolute_url(const char *url, char *buf, size_t buflen,
   (void)buflen; /* only used in debug-builds */
   if(buf)
     buf[0] = 0; /* always leave a defined value in buf */
-#ifdef WIN32
+#ifdef _WIN32
   if(guess_scheme && STARTS_WITH_DRIVE_PREFIX(url))
     return 0;
 #endif
@@ -1056,7 +1056,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
           ptr += 9; /* now points to the slash after the host */
         }
         else {
-#if defined(WIN32)
+#if defined(_WIN32)
           size_t len;
 
           /* the host name, NetBIOS computer name, can not contain disallowed
@@ -1095,7 +1095,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
       /* no host for file: URLs by default */
       Curl_dyn_reset(&host);
 
-#if !defined(MSDOS) && !defined(WIN32) && !defined(__CYGWIN__)
+#if !defined(_WIN32) && !defined(MSDOS) && !defined(__CYGWIN__)
     /* Don't allow Windows drive letters when not in Windows.
      * This catches both "file:/c:" and "file:c:" */
     if(('/' == path[0] && STARTS_WITH_URL_DRIVE_PREFIX(&path[1])) ||

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -721,7 +721,7 @@ struct SingleRequest {
 #ifndef CURL_DISABLE_DOH
   struct dohdata *doh; /* DoH specific data for this request */
 #endif
-#if defined(WIN32) && defined(USE_WINSOCK)
+#if defined(_WIN32) && defined(USE_WINSOCK)
   struct curltime last_sndbuf_update;  /* last time readwrite_upload called
                                           win_update_buffer_size */
 #endif
@@ -1394,7 +1394,7 @@ struct UrlState {
 
   /* a place to store the most recently set (S)FTP entrypath */
   char *most_recent_ftp_entrypath;
-#if !defined(WIN32) && !defined(MSDOS) && !defined(__EMX__)
+#if !defined(_WIN32) && !defined(MSDOS) && !defined(__EMX__)
 /* do FTP line-end conversions on most platforms */
 #define CURL_DO_LINEEND_CONV
   /* for FTP downloads: track CRLF sequences that span blocks */

--- a/lib/version.c
+++ b/lib/version.c
@@ -39,7 +39,7 @@
 
 #ifdef USE_ARES
 #  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) &&   \
-  defined(WIN32)
+  defined(_WIN32)
 #    define CARES_STATICLIB
 #  endif
 #  include <ares.h>
@@ -512,7 +512,7 @@ static const struct feat features_table[] = {
 #ifdef CURLDEBUG
   FEATURE("TrackMemory", NULL,                CURL_VERSION_CURLDEBUG),
 #endif
-#if defined(WIN32) && defined(UNICODE) && defined(_UNICODE)
+#if defined(_WIN32) && defined(UNICODE) && defined(_UNICODE)
   FEATURE("Unicode",     NULL,                CURL_VERSION_UNICODE),
 #endif
 #ifdef USE_UNIX_SOCKETS

--- a/lib/version_win32.c
+++ b/lib/version_win32.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 #include <curl/curl.h>
 #include "version_win32.h"
@@ -316,4 +316,4 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
   return matched;
 }
 
-#endif /* WIN32 */
+#endif /* _WIN32 */

--- a/lib/version_win32.h
+++ b/lib/version_win32.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 /* Version condition */
 typedef enum {
@@ -51,6 +51,6 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
                                   const PlatformIdentifier platform,
                                   const VersionCondition condition);
 
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 #endif /* HEADER_CURL_VERSION_WIN32_H */

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1406,7 +1406,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
   }
 
   /* Known to not work on Windows */
-#if !defined(WIN32) && defined(HAVE_QUICHE_CONN_SET_QLOG_FD)
+#if !defined(_WIN32) && defined(HAVE_QUICHE_CONN_SET_QLOG_FD)
   {
     int qfd;
     (void)Curl_qlogdir(data, ctx->scid, sizeof(ctx->scid), &qfd);

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -60,7 +60,7 @@ Curl_tls_keylog_open(void)
     if(keylog_file_name) {
       keylog_file_fp = fopen(keylog_file_name, FOPEN_APPENDTEXT);
       if(keylog_file_fp) {
-#ifdef WIN32
+#ifdef _WIN32
         if(setvbuf(keylog_file_fp, NULL, _IONBF, 0))
 #else
         if(setvbuf(keylog_file_fp, NULL, _IOLBF, 4096))

--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -37,7 +37,7 @@
 
 #include "warnless.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #undef read
 #undef write
 #endif
@@ -367,7 +367,7 @@ curl_socket_t curlx_sitosk(int i)
 
 #endif /* USE_WINSOCK */
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 ssize_t curlx_read(int fd, void *buf, size_t count)
 {
@@ -379,7 +379,7 @@ ssize_t curlx_write(int fd, const void *buf, size_t count)
   return (ssize_t)write(fd, buf, curlx_uztoui(count));
 }
 
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 /* Ensure that warnless.h redefinitions continue to have an effect
    in "unity" builds. */

--- a/lib/warnless.h
+++ b/lib/warnless.h
@@ -69,13 +69,13 @@ curl_socket_t curlx_sitosk(int i);
 
 #endif /* USE_WINSOCK */
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 ssize_t curlx_read(int fd, void *buf, size_t count);
 
 ssize_t curlx_write(int fd, const void *buf, size_t count);
 
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 #if defined(__INTEL_COMPILER) && defined(__unix__)
 
@@ -96,7 +96,7 @@ unsigned short curlx_ntohs(unsigned short usnum);
 #ifndef HEADER_CURL_WARNLESS_H_REDEFS
 #define HEADER_CURL_WARNLESS_H_REDEFS
 
-#if defined(WIN32)
+#if defined(_WIN32)
 #undef  read
 #define read(fd, buf, count)  curlx_read(fd, buf, count)
 #undef  write

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -59,6 +59,7 @@ my %warnings = (
     'ASTERISKSPACE'    => 'pointer declared with space after asterisk',
     'BADCOMMAND'       => 'bad !checksrc! instruction',
     'BANNEDFUNC'       => 'a banned function was used',
+    'BANNEDPREPROC'    => 'a banned symbol was used on a preprocessor line',
     'BRACEELSE'        => '} else on the same line',
     'BRACEPOS'         => 'wrong position for an open brace',
     'BRACEWHILE'       => 'A single space between open brace and while',
@@ -892,6 +893,18 @@ sub scanfile {
                       "multiple spaces");
         }
       preproc:
+        if($prep) {
+          # scan for use of banned symbols on a preprocessor line
+          if($l =~ /^(^|.*\W)
+                     (WIN32)
+                     (\W|$)
+                   /x) {
+              checkwarn("BANNEDPREPROC",
+                        $line, length($1), $file, $ol,
+                        "use of $2 is banned from preprocessor lines" .
+                        (($2 eq "WIN32") ? ", use _WIN32 instead" : ""));
+          }
+        }
         $line++;
         $prevp = $prep;
         $prevl = $ol if(!$prep);

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -41,7 +41,7 @@
 
 static char *parse_filename(const char *ptr, size_t len);
 
-#ifdef WIN32
+#ifdef _WIN32
 #define BOLD "\x1b[1m"
 #define BOLDOFF "\x1b[22m"
 #else
@@ -87,7 +87,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
   }
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
   /* Discard incomplete UTF-8 sequence buffered from body */
   if(outs->utf8seq[0])
     memset(outs->utf8seq, 0, sizeof(outs->utf8seq));
@@ -213,7 +213,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
       return CURL_WRITEFUNC_ERROR;
 
     if(hdrcbdata->global->isatty &&
-#ifdef WIN32
+#ifdef _WIN32
        tool_term_has_bold &&
 #endif
        hdrcbdata->global->styled_output)
@@ -304,7 +304,7 @@ static char *parse_filename(const char *ptr, size_t len)
   if(copy != p)
     memmove(copy, p, strlen(p) + 1);
 
-#if defined(MSDOS) || defined(WIN32)
+#if defined(_WIN32) || defined(MSDOS)
   {
     char *sanitized;
     SANITIZEcode sc = sanitize_file_name(&sanitized, copy, 0);
@@ -313,7 +313,7 @@ static char *parse_filename(const char *ptr, size_t len)
       return NULL;
     copy = sanitized;
   }
-#endif /* MSDOS || WIN32 */
+#endif /* _WIN32 || MSDOS */
 
   /* in case we built debug enabled, we allow an environment variable
    * named CURL_TESTDIR to prefix the given file name to put it into a

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -249,7 +249,7 @@ void progressbarinit(struct ProgressData *bar,
     struct winsize ts;
     if(!ioctl(STDIN_FILENO, TIOCGWINSZ, &ts))
       cols = ts.ws_col;
-#elif defined(WIN32)
+#elif defined(_WIN32)
     {
       HANDLE  stderr_hnd = GetStdHandle(STD_ERROR_HANDLE);
       CONSOLE_SCREEN_BUFFER_INFO console_info;

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -62,7 +62,7 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
     if(msdelta > config->timeout_ms)
       /* timeout */
       return 0;
-#ifndef WIN32
+#ifndef _WIN32
     /* this logic waits on read activity on a file descriptor that is not a
        socket which makes it not work with select() on Windows */
     else {

--- a/src/tool_cb_see.h
+++ b/src/tool_cb_see.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#if defined(WIN32) && !defined(HAVE_FTRUNCATE)
+#if defined(_WIN32) && !defined(HAVE_FTRUNCATE)
 
 int tool_ftruncate64(int fd, curl_off_t where);
 
@@ -35,7 +35,7 @@ int tool_ftruncate64(int fd, curl_off_t where);
 #define HAVE_FTRUNCATE 1
 #define USE_TOOL_FTRUNCATE 1
 
-#endif /* WIN32  && ! HAVE_FTRUNCATE */
+#endif /* _WIN32 && ! HAVE_FTRUNCATE */
 
 /*
 ** callback for CURLOPT_SEEKFUNCTION

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -44,7 +44,7 @@
 #ifndef O_BINARY
 #define O_BINARY 0
 #endif
-#ifdef WIN32
+#ifdef _WIN32
 #define OPENMODE S_IREAD | S_IWRITE
 #else
 #define OPENMODE S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH
@@ -159,7 +159,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   struct OperationConfig *config = per->config;
   size_t bytes = sz * nmemb;
   bool is_tty = config->global->isatty;
-#ifdef WIN32
+#ifdef _WIN32
   CONSOLE_SCREEN_BUFFER_INFO console_info;
   intptr_t fhnd;
 #endif
@@ -231,7 +231,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
     }
   }
 
-#ifdef WIN32
+#ifdef _WIN32
   fhnd = _get_osfhandle(fileno(outs->stream));
   /* if windows console then UTF-8 must be converted to UTF-16 */
   if(isatty(fileno(outs->stream)) &&

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -25,7 +25,7 @@
 
 #include <sys/stat.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #  include <direct.h>
 #endif
 
@@ -38,7 +38,7 @@
 
 #include "memdebug.h" /* keep this as LAST include */
 
-#if defined(WIN32) || (defined(MSDOS) && !defined(__DJGPP__))
+#if defined(_WIN32) || (defined(MSDOS) && !defined(__DJGPP__))
 #  define mkdir(x,y) (mkdir)((x))
 #  ifndef F_OK
 #    define F_OK 0
@@ -88,7 +88,7 @@ static void show_dir_errno(struct GlobalConfig *global, const char *name)
  *  should create all the dir* automagically
  */
 
-#if defined(WIN32) || defined(__DJGPP__)
+#if defined(_WIN32) || defined(__DJGPP__)
 /* systems that may use either or when specifying a path */
 #define PATH_DELIMITERS "\\/"
 #else
@@ -132,7 +132,7 @@ CURLcode create_dir_hierarchy(const char *outfile, struct GlobalConfig *global)
         msnprintf(&dirbuildup[dlen], outlen - dlen, "%s%s", DIR_CHAR, tempdir);
       else {
         if(outdup == tempdir) {
-#if defined(MSDOS) || defined(WIN32)
+#if defined(_WIN32) || defined(MSDOS)
           /* Skip creating a drive's current directory.
              It may seem as though that would harmlessly fail but it could be
              a corner case if X: did not exist, since we would be creating it

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -23,13 +23,13 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#if defined(MSDOS) || defined(WIN32)
+#if defined(_WIN32) || defined(MSDOS)
 
 #if defined(HAVE_LIBGEN_H) && defined(HAVE_BASENAME)
 #  include <libgen.h>
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #  include <stdlib.h>
 #  include <tlhelp32.h>
 #  include "tool_cfgable.h"
@@ -42,7 +42,7 @@
 #include "curlx.h"
 #include "memdebug.h" /* keep this as LAST include */
 
-#ifdef WIN32
+#ifdef _WIN32
 #  undef  PATH_MAX
 #  define PATH_MAX MAX_PATH
 #endif
@@ -55,7 +55,7 @@
 #  endif
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #  define _use_lfn(f) (1)   /* long file names always available */
 #elif !defined(__DJGPP__) || (__DJGPP__ < 2)  /* DJGPP 2.0 has _use_lfn() */
 #  define _use_lfn(f) (0)  /* long file names never available */
@@ -597,7 +597,7 @@ char **__crt0_glob_function(char *arg)
 
 #endif /* MSDOS && (__DJGPP__ || __GO32__) */
 
-#ifdef WIN32
+#ifdef _WIN32
 
 /*
  * Function to find CACert bundle on a Win32 platform using SearchPath.
@@ -791,6 +791,6 @@ CURLcode win32_init(void)
   return CURLE_OK;
 }
 
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
-#endif /* MSDOS || WIN32 */
+#endif /* _WIN32 || MSDOS */

--- a/src/tool_doswin.h
+++ b/src/tool_doswin.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#if defined(MSDOS) || defined(WIN32)
+#if defined(_WIN32) || defined(MSDOS)
 
 #define SANITIZE_ALLOW_COLONS    (1<<0)  /* Allow colons */
 #define SANITIZE_ALLOW_PATH      (1<<1)  /* Allow path separators and colons */
@@ -57,7 +57,7 @@ char **__crt0_glob_function(char *arg);
 
 #endif /* MSDOS && (__DJGPP__ || __GO32__) */
 
-#ifdef WIN32
+#ifdef _WIN32
 
 CURLcode FindWin32CACert(struct OperationConfig *config,
                          curl_sslbackend backend,
@@ -65,8 +65,8 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
 struct curl_slist *GetLoadedModulePaths(void);
 CURLcode win32_init(void);
 
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
-#endif /* MSDOS || WIN32 */
+#endif /* _WIN32 || MSDOS */
 
 #endif /* HEADER_CURL_TOOL_DOSWIN_H */

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -41,7 +41,7 @@ int getfiletime(const char *filename, struct GlobalConfig *global,
 /* Windows stat() may attempt to adjust the unix GMT file time by a daylight
    saving time offset and since it's GMT that is bad behavior. When we have
    access to a 64-bit type we can bypass stat and get the times directly. */
-#if defined(WIN32)
+#if defined(_WIN32)
   HANDLE hfile;
   TCHAR *tchar_filename = curlx_convert_UTF8_to_tchar((char *)filename);
 
@@ -87,7 +87,7 @@ int getfiletime(const char *filename, struct GlobalConfig *global,
   return rc;
 }
 
-#if defined(HAVE_UTIME) || defined(HAVE_UTIMES) || defined(WIN32)
+#if defined(HAVE_UTIME) || defined(HAVE_UTIMES) || defined(_WIN32)
 void setfiletime(curl_off_t filetime, const char *filename,
                  struct GlobalConfig *global)
 {
@@ -95,7 +95,7 @@ void setfiletime(curl_off_t filetime, const char *filename,
 /* Windows utime() may attempt to adjust the unix GMT file time by a daylight
    saving time offset and since it's GMT that is bad behavior. When we have
    access to a 64-bit type we can bypass utime and set the times directly. */
-#if defined(WIN32)
+#if defined(_WIN32)
     HANDLE hfile;
     TCHAR *tchar_filename = curlx_convert_UTF8_to_tchar((char *)filename);
 
@@ -153,4 +153,4 @@ void setfiletime(curl_off_t filetime, const char *filename,
   }
 }
 #endif /* defined(HAVE_UTIME) || defined(HAVE_UTIMES) ||        \
-          defined(WIN32) */
+          defined(_WIN32) */

--- a/src/tool_filetime.h
+++ b/src/tool_filetime.h
@@ -31,12 +31,12 @@ int getfiletime(const char *filename, struct GlobalConfig *global,
                 curl_off_t *stamp);
 
 #if defined(HAVE_UTIME) || defined(HAVE_UTIMES) ||      \
-  (defined(WIN32) && (SIZEOF_CURL_OFF_T >= 8))
+  (defined(_WIN32) && (SIZEOF_CURL_OFF_T >= 8))
 void setfiletime(curl_off_t filetime, const char *filename,
                  struct GlobalConfig *global);
 #else
 #define setfiletime(a,b,c) Curl_nop_stmt
 #endif /* defined(HAVE_UTIME) || defined(HAVE_UTIMES) ||        \
-          (defined(WIN32) && (SIZEOF_CURL_OFF_T >= 8)) */
+          (defined(_WIN32) && (SIZEOF_CURL_OFF_T >= 8)) */
 
 #endif /* HEADER_CURL_TOOL_FILETIME_H */

--- a/src/tool_findfile.c
+++ b/src/tool_findfile.c
@@ -53,7 +53,7 @@ static const struct finder conf_list[] = {
   { "CURL_HOME", NULL, FALSE },
   { "XDG_CONFIG_HOME", NULL, FALSE }, /* index == 1, used in the code */
   { "HOME", NULL, FALSE },
-#ifdef WIN32
+#ifdef _WIN32
   { "USERPROFILE", NULL, FALSE },
   { "APPDATA", NULL, FALSE },
   { "USERPROFILE", "\\Application Data", FALSE},

--- a/src/tool_findfile.h
+++ b/src/tool_findfile.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define CURLRC_DOTSCORE 2 /* look for underscore-prefixed name too */
 #else
 #define CURLRC_DOTSCORE 1 /* regular .curlrc check */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -437,7 +437,7 @@ void parse_cert_parameter(const char *cert_parameter,
          needs to work. In order not to break compatibility, we still use : as
          separator, but we try to detect when it is used for a file name! On
          windows. */
-#ifdef WIN32
+#ifdef _WIN32
       if((param_place == &cert_parameter[1]) &&
          (cert_parameter[2] == '\\' || cert_parameter[2] == '/') &&
          (ISALPHA(cert_parameter[0])) ) {

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -46,7 +46,7 @@
 #  include iodef
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #  include <conio.h>
 #endif
 
@@ -94,7 +94,7 @@ char *getpass_r(const char *prompt, char *buffer, size_t buflen)
 #define DONE
 #endif /* __VMS */
 
-#if defined(WIN32)
+#if defined(_WIN32)
 
 char *getpass_r(const char *prompt, char *buffer, size_t buflen)
 {
@@ -122,7 +122,7 @@ char *getpass_r(const char *prompt, char *buffer, size_t buflen)
   return buffer; /* we always return success */
 }
 #define DONE
-#endif /* WIN32 */
+#endif /* _WIN32 */
 
 #ifndef DONE /* not previously provided */
 

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -25,7 +25,7 @@
 
 #include <sys/stat.h>
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <tchar.h>
 #endif
 
@@ -235,7 +235,7 @@ int main(int argc, char *argv[])
 
   tool_init_stderr();
 
-#ifdef WIN32
+#ifdef _WIN32
   /* Undocumented diagnostic option to list the full paths of all loaded
      modules. This is purposely pre-init. */
   if(argc == 2 && !_tcscmp(argv[1], _T("--dump-module-paths"))) {
@@ -276,7 +276,7 @@ int main(int argc, char *argv[])
     main_free(&global);
   }
 
-#ifdef WIN32
+#ifdef _WIN32
   /* Flush buffers of all streams opened in write or update mode */
   fflush(NULL);
 #endif

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -463,7 +463,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     }
   }
 
-#ifdef WIN32
+#ifdef _WIN32
   /* Discard incomplete UTF-8 sequence buffered from body */
   if(outs->utf8seq[0])
     memset(outs->utf8seq, 0, sizeof(outs->utf8seq));
@@ -2636,7 +2636,7 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
 
       if(env)
         curl_free(env);
-#ifdef WIN32
+#ifdef _WIN32
       else {
         result = FindWin32CACert(config, tls_backend_info->backend,
                                  TEXT("curl-ca-bundle.crt"));

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -215,7 +215,7 @@ CURLcode get_url_file_name(char **filename, const char *url)
       if(!*filename)
         return CURLE_OUT_OF_MEMORY;
 
-#if defined(MSDOS) || defined(WIN32)
+#if defined(_WIN32) || defined(MSDOS)
       {
         char *sanitized;
         SANITIZEcode sc = sanitize_file_name(&sanitized, *filename, 0);
@@ -227,7 +227,7 @@ CURLcode get_url_file_name(char **filename, const char *url)
         }
         *filename = sanitized;
       }
-#endif /* MSDOS || WIN32 */
+#endif /* _WIN32 || MSDOS */
 
       /* in case we built debug enabled, we allow an environment variable
        * named CURL_TESTDIR to prefix the given file name to put it into a

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -46,7 +46,7 @@ static const char *unslashquote(const char *line, char *param);
 #define MAX_CONFIG_LINE_LENGTH (10*1024*1024)
 static bool my_get_line(FILE *fp, struct curlx_dynbuf *, bool *error);
 
-#ifdef WIN32
+#ifdef _WIN32
 static FILE *execpath(const char *filename, char **pathp)
 {
   static char filebuffer[512];
@@ -98,7 +98,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       }
       filename = pathalloc = curlrc;
     }
-#ifdef WIN32 /* Windows */
+#ifdef _WIN32 /* Windows */
     else {
       char *fullp;
       /* check for .curlrc then _curlrc in the dir of the executable */

--- a/src/tool_sdecls.h
+++ b/src/tool_sdecls.h
@@ -71,7 +71,7 @@ struct OutStruct {
   FILE *stream;
   curl_off_t bytes;
   curl_off_t init;
-#ifdef WIN32
+#ifdef _WIN32
   unsigned char utf8seq[5];
 #endif
 };

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -66,7 +66,7 @@ extern FILE *tool_stderr;
 #  include "tool_strdup.h"
 #endif
 
-#if defined(WIN32) && !defined(MSDOS)
+#if defined(_WIN32)
 /* set in win32_init() */
 extern LARGE_INTEGER tool_freq;
 extern bool tool_isVistaOrGreater;

--- a/src/tool_sleep.c
+++ b/src/tool_sleep.c
@@ -47,7 +47,7 @@ void tool_go_sleep(long ms)
 {
 #if defined(MSDOS)
   delay(ms);
-#elif defined(WIN32)
+#elif defined(_WIN32)
   Sleep(ms);
 #elif defined(HAVE_POLL_FINE)
   (void)poll((void *)0, 0, (int)ms);

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -702,7 +702,7 @@ CURLcode glob_match_url(char **result, char *filename, struct URLGlob *glob)
   if(curlx_dyn_addn(&dyn, "", 0))
     return CURLE_OUT_OF_MEMORY;
 
-#if defined(MSDOS) || defined(WIN32)
+#if defined(_WIN32) || defined(MSDOS)
   {
     char *sanitized;
     SANITIZEcode sc = sanitize_file_name(&sanitized, curlx_dyn_ptr(&dyn),
@@ -717,5 +717,5 @@ CURLcode glob_match_url(char **result, char *filename, struct URLGlob *glob)
 #else
   *result = curlx_dyn_ptr(&dyn);
   return CURLE_OK;
-#endif /* MSDOS || WIN32 */
+#endif /* _WIN32 || MSDOS */
 }

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -31,7 +31,7 @@
 
 #include "memdebug.h" /* keep this as LAST include */
 
-#if defined(WIN32) && !defined(MSDOS)
+#if defined(_WIN32)
 
 /* In case of bug fix this function has a counterpart in timeval.c */
 struct timeval tvnow(void)

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -174,7 +174,7 @@ int main(int argc, char **argv)
   result = test(URL);
   fprintf(stderr, "Test ended with result %d\n", result);
 
-#ifdef WIN32
+#ifdef _WIN32
   /* flush buffers of all streams regardless of mode */
   _flushall();
 #endif

--- a/tests/libtest/lib1517.c
+++ b/tests/libtest/lib1517.c
@@ -61,7 +61,7 @@ int test(char *URL)
   struct WriteThis pooh;
 
   if(!strcmp(URL, "check")) {
-#if (defined(WIN32) || defined(__CYGWIN__))
+#if (defined(_WIN32) || defined(__CYGWIN__))
     printf("Windows TCP does not deliver response data but reports "
            "CONNABORTED\n");
     return 1; /* skip since test will fail on Windows without workaround */

--- a/tests/libtest/lib1531.c
+++ b/tests/libtest/lib1531.c
@@ -110,7 +110,7 @@ int test(char *URL)
        curl_multi_fdset() doc. */
 
     if(maxfd == -1) {
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
       Sleep(100);
       rc = 0;
 #else

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -319,7 +319,7 @@ static const struct testcase get_parts_list[] ={
    "http | ftp.user | moo | [13] | example.com | [15] | /color/ | [16] | "
    "green?no-red",
    CURLU_GUESS_SCHEME, 0, CURLUE_OK },
-#ifdef WIN32
+#ifdef _WIN32
   {"file:/C:\\programs\\foo",
    "file | [11] | [12] | [13] | [14] | [15] | C:\\programs\\foo | [16] | [17]",
    CURLU_DEFAULT_SCHEME, 0, CURLUE_OK},

--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -25,7 +25,7 @@
 
 #ifdef HAVE_INET_PTON
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <windows.h>

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -28,7 +28,7 @@
 
 #define NUM_THREADS 100
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifdef _WIN32_WCE
 static DWORD WINAPI run_thread(LPVOID ptr)
 #else

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -42,7 +42,7 @@
 #define NUM_OPEN      (FD_SETSIZE + 10)
 #define NUM_NEEDED    (NUM_OPEN + SAFETY_MARGIN)
 
-#if defined(WIN32) || defined(_WIN32) || defined(MSDOS)
+#if defined(_WIN32) || defined(MSDOS)
 #define DEV_NULL "NUL"
 #else
 #define DEV_NULL "/dev/null"

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -42,7 +42,7 @@
 
 #define SAFETY_MARGIN (11)
 
-#if defined(WIN32) || defined(_WIN32) || defined(MSDOS)
+#if defined(_WIN32) || defined(MSDOS)
 #define DEV_NULL "NUL"
 #else
 #define DEV_NULL "/dev/null"

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -215,7 +215,7 @@ int test(char *URL)
     mres = curl_multi_fdset(multi, &fdread, &fdwrite, &fdexcept, &maxfd);
     if(mres)
       break;
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32)
     if(maxfd == -1)
       Sleep(100);
     else

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -42,7 +42,7 @@
 
 #include "curl_printf.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #define sleep(sec) Sleep ((sec)*1000)
 #endif
 

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -26,7 +26,7 @@
 #include "testutil.h"
 #include "memdebug.h"
 
-#if defined(WIN32) && !defined(MSDOS)
+#if defined(_WIN32)
 
 struct timeval tutil_tvnow(void)
 {
@@ -130,7 +130,7 @@ double tutil_tvdiff_secs(struct timeval newer, struct timeval older)
   return (double)(newer.tv_usec-older.tv_usec)/1000000.0;
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 HMODULE win32_load_system_library(const TCHAR *filename)
 {
   size_t filenamelen = _tcslen(filename);

--- a/tests/libtest/testutil.h
+++ b/tests/libtest/testutil.h
@@ -42,7 +42,7 @@ long tutil_tvdiff(struct timeval t1, struct timeval t2);
  */
 double tutil_tvdiff_secs(struct timeval t1, struct timeval t2);
 
-#ifdef WIN32
+#ifdef _WIN32
 HMODULE win32_load_system_library(const TCHAR *filename);
 #endif
 

--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -60,7 +60,7 @@ curl_free_callback Curl_cfree = (curl_free_callback)free;
 curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)strdup;
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
-#if defined(WIN32) && defined(UNICODE)
+#if defined(_WIN32) && defined(UNICODE)
 curl_wcsdup_callback Curl_cwcsdup = (curl_wcsdup_callback)_wcsdup;
 #endif
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -1016,7 +1016,7 @@ int main(int argc, char *argv[])
   msnprintf(loglockfile, sizeof(loglockfile), "%s/%s/mqtt-%s.lock",
             logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
-#ifdef WIN32
+#ifdef _WIN32
   win32_init();
   atexit(win32_cleanup);
 

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -102,7 +102,7 @@ int main(int argc, char *argv[])
     return 1;
   }
 
-#ifdef WIN32
+#ifdef _WIN32
   win32_init();
   atexit(win32_cleanup);
 #endif

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1150,7 +1150,7 @@ int main(int argc, char *argv[])
   msnprintf(loglockfile, sizeof(loglockfile), "%s/%s/rtsp-%s.lock",
             logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
-#ifdef WIN32
+#ifdef _WIN32
   win32_init();
   atexit(win32_cleanup);
 #endif

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -152,7 +152,7 @@ enum sockmode {
   ACTIVE_DISCONNECT  /* as a client, disconnected from server */
 };
 
-#ifdef WIN32
+#ifdef _WIN32
 /*
  * read-wrapper to support reading from stdin on Windows.
  */
@@ -1461,7 +1461,7 @@ int main(int argc, char *argv[])
     }
   }
 
-#ifdef WIN32
+#ifdef _WIN32
   win32_init();
   atexit(win32_cleanup);
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -1076,7 +1076,7 @@ int main(int argc, char *argv[])
     }
   }
 
-#ifdef WIN32
+#ifdef _WIN32
   win32_init();
   atexit(win32_cleanup);
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2119,7 +2119,7 @@ int main(int argc, char *argv[])
             logdir, SERVERLOGS_LOCKDIR, protocol_type,
             is_proxy ? "-proxy" : "", socket_type);
 
-#ifdef WIN32
+#ifdef _WIN32
   win32_init();
   atexit(win32_cleanup);
 #endif

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -453,7 +453,7 @@ static ssize_t write_behind(struct testcase *test, int convert)
   if(!test->ofile) {
     char outfile[256];
     msnprintf(outfile, sizeof(outfile), "%s/upload.%ld", logdir, test->testno);
-#ifdef WIN32
+#ifdef _WIN32
     test->ofile = open(outfile, O_CREAT|O_RDWR|O_BINARY, 0777);
 #else
     test->ofile = open(outfile, O_CREAT|O_RDWR, 0777);
@@ -642,7 +642,7 @@ int main(int argc, char **argv)
   msnprintf(loglockfile, sizeof(loglockfile), "%s/%s/tftp-%s.lock",
             logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
-#ifdef WIN32
+#ifdef _WIN32
   win32_init();
   atexit(win32_cleanup);
 #endif

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -144,7 +144,7 @@ void logmsg(const char *msg, ...)
   }
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 /* use instead of strerror() on generic Windows */
 static const char *win32_strerror(int err, char *buf, size_t buflen)
 {
@@ -208,7 +208,7 @@ const char *sstrerror(int err)
   static char buf[512];
   return win32_strerror(err, buf, sizeof(buf));
 }
-#endif  /* WIN32 */
+#endif  /* _WIN32 */
 
 /* set by the main code to point to where the test dir is */
 const char *path = ".";
@@ -292,7 +292,7 @@ curl_off_t our_getpid(void)
   curl_off_t pid;
 
   pid = (curl_off_t)getpid();
-#if defined(WIN32) || defined(_WIN32)
+#if defined(_WIN32) || defined(_WIN32)
   /* store pid + 65536 to avoid conflict with Cygwin/msys PIDs, see also:
    * - https://cygwin.com/git/?p=newlib-cygwin.git;a=commit; ↵
    *   h=b5e1003722cb14235c4f166be72c09acdffc62ea
@@ -378,7 +378,7 @@ void clear_advisor_read_lock(const char *filename)
 }
 
 
-#if defined(WIN32) && !defined(MSDOS)
+#if defined(_WIN32) && !defined(MSDOS)
 
 static struct timeval tvnow(void)
 {
@@ -501,11 +501,11 @@ static SIGHANDLER_T old_sigint_handler  = SIG_ERR;
 static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
 #endif
 
-#if defined(SIGBREAK) && defined(WIN32)
+#if defined(SIGBREAK) && defined(_WIN32)
 static SIGHANDLER_T old_sigbreak_handler = SIG_ERR;
 #endif
 
-#ifdef WIN32
+#ifdef _WIN32
 #ifdef _WIN32_WCE
 static DWORD thread_main_id = 0;
 #else
@@ -521,7 +521,7 @@ volatile int got_exit_signal = 0;
 /* if next is set indicates the first signal handled in exit_signal_handler */
 volatile int exit_signal = 0;
 
-#ifdef WIN32
+#ifdef _WIN32
 /* event which if set indicates that the program should finish */
 HANDLE exit_event = NULL;
 #endif
@@ -538,7 +538,7 @@ static void exit_signal_handler(int signum)
   if(got_exit_signal == 0) {
     got_exit_signal = 1;
     exit_signal = signum;
-#ifdef WIN32
+#ifdef _WIN32
     if(exit_event)
       (void)SetEvent(exit_event);
 #endif
@@ -547,7 +547,7 @@ static void exit_signal_handler(int signum)
   errno = old_errno;
 }
 
-#ifdef WIN32
+#ifdef _WIN32
 /* CTRL event handler for Windows Console applications to simulate
  * SIGINT, SIGTERM and SIGBREAK on CTRL events and trigger signal handler.
  *
@@ -698,7 +698,7 @@ static SIGHANDLER_T set_signal(int signum, SIGHANDLER_T handler,
 
 void install_signal_handlers(bool keep_sigalrm)
 {
-#ifdef WIN32
+#ifdef _WIN32
 #ifdef _WIN32_WCE
   typedef HANDLE curl_win_thread_handle_t;
 #else
@@ -744,13 +744,13 @@ void install_signal_handlers(bool keep_sigalrm)
   if(old_sigterm_handler == SIG_ERR)
     logmsg("cannot install SIGTERM handler: %s", strerror(errno));
 #endif
-#if defined(SIGBREAK) && defined(WIN32)
+#if defined(SIGBREAK) && defined(_WIN32)
   /* handle SIGBREAK signal with our exit_signal_handler */
   old_sigbreak_handler = set_signal(SIGBREAK, exit_signal_handler, TRUE);
   if(old_sigbreak_handler == SIG_ERR)
     logmsg("cannot install SIGBREAK handler: %s", strerror(errno));
 #endif
-#ifdef WIN32
+#ifdef _WIN32
   if(!SetConsoleCtrlHandler(ctrl_event_handler, TRUE))
     logmsg("cannot install CTRL event handler");
 #ifdef _WIN32_WCE
@@ -792,11 +792,11 @@ void restore_signal_handlers(bool keep_sigalrm)
   if(SIG_ERR != old_sigterm_handler)
     (void) set_signal(SIGTERM, old_sigterm_handler, FALSE);
 #endif
-#if defined(SIGBREAK) && defined(WIN32)
+#if defined(SIGBREAK) && defined(_WIN32)
   if(SIG_ERR != old_sigbreak_handler)
     (void) set_signal(SIGBREAK, old_sigbreak_handler, FALSE);
 #endif
-#ifdef WIN32
+#ifdef _WIN32
   (void)SetConsoleCtrlHandler(ctrl_event_handler, FALSE);
   if(thread_main_window && thread_main_id) {
     if(PostThreadMessage(thread_main_id, WM_APP, 0, 0)) {
@@ -846,7 +846,7 @@ int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
         return rc;
       }
       /* socket server is not alive, now check if it was actually a socket. */
-#ifdef WIN32
+#ifdef _WIN32
       /* Windows does not have lstat function. */
       rc = curlx_win32_stat(unix_socket, &statbuf);
 #else

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -41,7 +41,7 @@ extern const char *serverlogfile;
 
 extern const char *cmdfile;
 
-#ifdef WIN32
+#ifdef _WIN32
 #include <process.h>
 #include <fcntl.h>
 
@@ -54,10 +54,10 @@ void win32_perror(const char *msg);
 void win32_init(void);
 void win32_cleanup(void);
 const char *sstrerror(int err);
-#else   /* WIN32 */
+#else   /* _WIN32 */
 
 #define sstrerror(e) strerror(e)
-#endif  /* WIN32 */
+#endif  /* _WIN32 */
 
 /* fopens the test case file */
 FILE *test2fopen(long testno, const char *logdir);
@@ -75,7 +75,7 @@ extern volatile int got_exit_signal;
 /* global variable which if set indicates the first signal handled */
 extern volatile int exit_signal;
 
-#ifdef WIN32
+#ifdef _WIN32
 /* global event which if set indicates that the program should finish */
 extern HANDLE exit_event;
 #endif

--- a/tests/unit/unit1394.c
+++ b/tests/unit/unit1394.c
@@ -61,7 +61,7 @@ UNITTEST_START
     "pkcs11:foobar",          "pkcs11:foobar",      NULL,
     "PKCS11:foobar",          "PKCS11:foobar",      NULL,
     "PkCs11:foobar",          "PkCs11:foobar",      NULL,
-#ifdef WIN32
+#ifdef _WIN32
     "c:\\foo:bar:baz",        "c:\\foo",            "bar:baz",
     "c:\\foo\\:bar:baz",      "c:\\foo:bar",        "baz",
     "c:\\foo\\\\:bar:baz",    "c:\\foo\\",          "bar:baz",

--- a/tests/unit/unit1604.c
+++ b/tests/unit/unit1604.c
@@ -42,7 +42,7 @@ static void unit_stop(void)
 
 }
 
-#if defined(MSDOS) || defined(WIN32)
+#if defined(_WIN32) || defined(MSDOS)
 
 static char *getflagstr(int flags)
 {
@@ -353,6 +353,6 @@ UNITTEST_START
 {
   fprintf(stderr, "Skipped test not for this platform\n");
 }
-#endif /* MSDOS || WIN32 */
+#endif /* _WIN32 || MSDOS */
 
 UNITTEST_STOP


### PR DESCRIPTION
Windows compilers define `_WIN32` automatically. Windows SDK headers
or build env defines `WIN32`, or we have to take care of it. The
agreement seems to be that `_WIN32` is the preferred practice here.
Make the source code rely on that to detect we're building for Windows.

Public `curl.h` was using `WIN32`, `__WIN32__` and `CURL_WIN32` for
Windows detection, next to the official `_WIN32`. After this patch it
only uses `_WIN32` for this. Also, make it stop defining `CURL_WIN32`.

There is a slight chance these break compatibility with Windows
compilers that fail to define `_WIN32`. I'm not aware of any obsolete
or modern compiler affected, but in case there is one, one possible
solution is to define this macro manually.

grepping for `WIN32` remains useful to discover Windows-specific code.

Also:

- extend `checksrc` to ensure we're not using `WIN32` anymore.

- apply minor formatting here and there.

- delete unnecessary checks for `!MSDOS` when `_WIN32` is present.

Closes #12376
