### PR TITLE
ci: Add minimal permissions to distcheck.yml

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -17,6 +17,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   maketgz-and-verify-in-tree:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Hi! Bringing a simple security change, similar to the one on #11055.

Additionally, I'd like to suggest that you take a look into changing your repository settings to [set read-only permission as default permissions](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository) for newly created workflows. If you make sure the default permissions are restricted, there will be no need to worry if we forget to explicitly list the permissions for any newly created workflow =)
After this change, any workflow that require write permissions will need to have the write permissions explicitly defined in the workflow file.