### PR TITLE
wolfssh: remove superfluous static prototypes

### DIFF
--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -343,9 +343,6 @@ static CURLcode wssh_setup_connection(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-static Curl_recv wscp_recv, wsftp_recv;
-static Curl_send wscp_send, wsftp_send;
-
 static int userauth(byte authtype,
                     WS_UserAuthData* authdata,
                     void *ctx)


### PR DESCRIPTION
vssh/wolfssh.c:346:18: error: redundant redeclaration of ‘wscp_recv’ [-Werror=redundant-decls]