### PR TITLE
CURLMOPT_MAX_CONCURRENT_STREAMS: make sure the set value is within range

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_MAX_CONCURRENT_STREAMS.3
+++ b/docs/libcurl/opts/CURLMOPT_MAX_CONCURRENT_STREAMS.3
@@ -34,8 +34,8 @@ CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAX_CONCURRENT_STREAMS,
 .fi
 .SH DESCRIPTION
 Pass a long indicating the \fBmax\fP. The set number is used as the maximum
-number of concurrent streams for a connections that libcurl should support on
-connections done using HTTP/2.
+number of concurrent streams libcurl should support on connections done using
+HTTP/2 or HTTP/3.
 
 Valid values range from 1 to 2147483647 (2^31 - 1) and defaults to 100.  The
 value passed here would be honored based on other system resources properties.

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3293,9 +3293,9 @@ CURLMcode curl_multi_setopt(struct Curl_multi *multi,
   case CURLMOPT_MAX_CONCURRENT_STREAMS:
     {
       long streams = va_arg(param, long);
-      if(streams < 1)
+      if((streams < 1) || (streams > INT_MAX))
         streams = 100;
-      multi->max_concurrent_streams = curlx_sltoui(streams);
+      multi->max_concurrent_streams = (unsigned int)streams;
     }
     break;
   default:


### PR DESCRIPTION
... or use the default value.

Also clarify the documentation language somewhat.