### PR TITLE
FEATURES: update the URL phrasing

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -12,7 +12,7 @@
 
 ## libcurl
 
- - full URL syntax with no length limit
+ - URL RFC 3986 syntax
  - custom maximum download time
  - custom least download speed acceptable
  - custom output result after completion


### PR DESCRIPTION
The URL is length limited since a while back so "no limit" simply is not true anymore. Mention the URL RFC standard used instead.