### PR TITLE
openssl: fix building with v3 `no-deprecated` + add CI test

### DIFF
--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -107,7 +107,7 @@ jobs:
         cd $HOME
         git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }} https://github.com/quictls/openssl quictls
         cd quictls
-        ./config --prefix=$HOME/nghttpx --libdir=$HOME/nghttpx/lib
+        ./config no-deprecated --prefix=$HOME/nghttpx --libdir=$HOME/nghttpx/lib
         make
       name: 'build quictls'
 

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -66,7 +66,7 @@ jobs:
         - name: quictls
           configure: >-
             PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" LDFLAGS="-Wl,-rpath,$HOME/nghttpx/lib"
-            --with-ngtcp2=$HOME/nghttpx --enable-warnings --enable-werror --enable-debug
+            --with-ngtcp2=$HOME/nghttpx --enable-warnings --enable-werror --enable-debug --disable-ntlm
             --with-test-nghttpx="$HOME/nghttpx/bin/nghttpx"
             --with-openssl=$HOME/nghttpx
         - name: gnutls

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -95,14 +95,14 @@ jobs:
 
     - name: cache quictls
       uses: actions/cache@v3
-      id: cache-quictls
+      id: cache-quictls-no-deprecated
       env:
-        cache-name: cache-quictls
+        cache-name: cache-quictls-no-deprecated
       with:
         path: /home/runner/quictls
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.quictls-version }}
 
-    - if: steps.cache-quictls.outputs.cache-hit != 'true'
+    - if: steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true'
       run: |
         cd $HOME
         git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }} https://github.com/quictls/openssl quictls

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -111,6 +111,7 @@
 #  include <wincrypt.h>
 #else
 #  error "Can't compile NTLM support without a crypto library with DES."
+#  define CURL_NTLM_NOT_SUPPORTED
 #endif
 
 #include "urldata.h"
@@ -130,6 +131,7 @@
 #define NTLMv2_BLOB_SIGNATURE "\x01\x01\x00\x00"
 #define NTLMv2_BLOB_LEN       (44 -16 + ntlm->target_info_len + 4)
 
+#if !defined(CURL_NTLM_NOT_SUPPORTED)
 /*
 * Turns a 56-bit key into being 64-bit wide.
 */
@@ -144,6 +146,7 @@ static void extend_key_56_to_64(const unsigned char *key_56, char *key)
   key[6] = (unsigned char)(((key_56[5] << 2) & 0xFF) | (key_56[6] >> 6));
   key[7] = (unsigned char) ((key_56[6] << 1) & 0xFF);
 }
+#endif
 
 #if defined(USE_OPENSSL_DES) || defined(USE_WOLFSSL)
 /*
@@ -351,9 +354,11 @@ CURLcode Curl_ntlm_core_mk_lm_hash(const char *password,
                                    unsigned char *lmbuffer /* 21 bytes */)
 {
   unsigned char pw[14];
+#if !defined(CURL_NTLM_NOT_SUPPORTED)
   static const unsigned char magic[] = {
     0x4B, 0x47, 0x53, 0x21, 0x40, 0x23, 0x24, 0x25 /* i.e. KGS!@#$% */
   };
+#endif
   size_t len = CURLMIN(strlen(password), 14);
 
   Curl_strntoupper((char *)pw, password, len);

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -337,6 +337,10 @@ void Curl_ntlm_core_lm_resp(const unsigned char *keys,
   encrypt_des(plaintext, results, keys);
   encrypt_des(plaintext, results + 8, keys + 7);
   encrypt_des(plaintext, results + 16, keys + 14);
+#else
+  (void)keys;
+  (void)plaintext;
+  (void)results;
 #endif
 }
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1947,7 +1947,7 @@ static CURLcode qng_verify_peer(struct Curl_cfilter *cf,
   if(conn_config->verifyhost) {
 #ifdef USE_OPENSSL
     X509 *server_cert;
-    server_cert = SSL_get_peer_certificate(ctx->ssl);
+    server_cert = SSL_get1_peer_certificate(ctx->ssl);
     if(!server_cert) {
       return CURLE_PEER_FAILED_VERIFICATION;
     }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -178,8 +178,6 @@
 
 #if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
 #define HAVE_EVP_PKEY_GET_PARAMS 1
-#else
-#define SSL_get1_peer_certificate SSL_get_peer_certificate
 #endif
 
 #ifdef HAVE_EVP_PKEY_GET_PARAMS

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4079,6 +4079,7 @@ static CURLcode ossl_pkp_pin_peer_pubkey(struct Curl_easy *data, X509* cert,
 
   return result;
 }
+
 #if (OPENSSL_VERSION_NUMBER >= 0x30000000L) &&  \
   !defined(CURL_DISABLE_VERBOSE_STRINGS)
 static void infof_certstack(struct Curl_easy *data, const SSL *ssl)
@@ -4094,8 +4095,6 @@ static void infof_certstack(struct Curl_easy *data, const SSL *ssl)
   else
     certstack = SSL_get0_verified_chain(ssl);
   num_cert_levels = sk_X509_num(certstack);
-  OpenSSL_add_all_algorithms();
-  OpenSSL_add_all_digests();
 
   for(cert_level = 0; cert_level < num_cert_levels; cert_level++) {
     char cert_algorithm[80] = "";

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -35,6 +35,10 @@
 
 #include "urldata.h"
 
+#if (OPENSSL_VERSION_NUMBER < 0x30000000L)
+#define SSL_get1_peer_certificate SSL_get_peer_certificate
+#endif
+
 /*
  * In an effort to avoid using 'X509 *' here, we instead use the struct
  * x509_st version of the type so that we can forward-declare it here without


### PR DESCRIPTION
- build quictls with `no-deprecated` in CI to have test coverage for
  this OpenSSL 3 configuration.

- don't call `OpenSSL_add_all_algorithms()`, `OpenSSL_add_all_digests()`.
  The caller code is meant for OpenSSL 3, while these two functions were
  only necessary before OpenSSL 1.1.0. They are missing from OpenSSL 3
  if built with option `no-deprecated`, causing build errors:
  ```
  vtls/openssl.c:4097:3: error: call to undeclared function 'OpenSSL_add_all_algorithms'; ISO C99 and later do not   support implicit function declarations [-Wimplicit-function-declaration]
  vtls/openssl.c:4098:3: error: call to undeclared function 'OpenSSL_add_all_digests'; ISO C99 and later do not   support implicit function declarations [-Wimplicit-function-declaration]
  ```
  Ref: https://ci.appveyor.com/project/curlorg/curl-for-win/builds/48587418?fullLog=true#L7667

  Regression from b6e6d4ff8f253c8b8055bab9d4d6a10f9be109f3 #12030
  Bug: https://github.com/curl/curl/issues/12380#issuecomment-1822944669

- vquic/curl_ngtcp2: fix using `SSL_get_peer_certificate` with
  `no-deprecated` quictls 3 builds.
  Do it by moving an existing solution for this from `vtls/openssl.c`
  to `vtls/openssl.h` and adjusting caller code.
  ```
  vquic/curl_ngtcp2.c:1950:19: error: implicit declaration of function 'SSL_get_peer_certificate'; did you mean   'SSL_get1_peer_certificate'? [-Wimplicit-function-declaration]
  ```
  Ref: https://github.com/curl/curl/actions/runs/6960723097/job/18940818625#step:24:1178

- curl_ntlm_core: fix `-Wunused-parameter`, `-Wunused-variable` and
  `-Wunused-function` when trying to build curl with NTLM enabled but
  without the necessary TLS backend (with DES) support.

Closes #12384

---

- curl_ntlm_core: allow NTLM with `no-deprecated` OpenSSL 3 builds.
  Though OpenSSL 3 deprecated the DES functions needed for the NTLM
  feature, its `no-deprecated` build option doesn't actually disable
  these DES functions. It means we can use them for NTLM even if
  `OPENSSL_NO_DEPRECATED_3_0` is set. Adjust our logic to allow it.
  This failed tests due to some types missing. Dropping this.
  https://github.com/curl/curl/actions/runs/6961417865/job/18942957524?pr=12384#step:24:132
