### PR TITLE
lib: fix three comment typos

### DIFF
--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -382,7 +382,7 @@ bool Curl_conn_data_pending(struct Curl_easy *data,
 curl_socket_t Curl_conn_get_socket(struct Curl_easy *data, int sockindex);
 
 /**
- * Tell filters to forget about the soket at sockindex.
+ * Tell filters to forget about the socket at sockindex.
  */
 void Curl_conn_forget_socket(struct Curl_easy *data, int sockindex);
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -1424,7 +1424,7 @@ CURLcode Curl_buffer_send(struct dynbuf *in,
      *   and install our own `data->state.fread_func` that
      *   on subsequent calls reads `in` empty.
      * - when the whisked away `in` is empty, the `fread_func`
-     *   is restored ot its original state.
+     *   is restored to its original state.
      * The problem is that `fread_func` can only return
      * `upload_buffer_size` lengths. If the send we do here
      * is larger and blocks, we do re-sending with smaller

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -781,7 +781,7 @@ static CURLcode rtsp_rtp_readwrite(struct Curl_easy *data,
     goto out;
   }
 
-  /* If header parsing is not onging, extract RTP messsages */
+  /* If header parsing is not onging, extract RTP messages */
   if(!rtspc->in_header) {
     result = rtsp_filter_rtp(data, conn, buf, blen, in_body, &consumed);
     if(result)

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -405,7 +405,7 @@ CONNECT_REQ_INIT:
       if(plen > 255) {
         /* there is no real size limit to this field in the protocol, but
            SOCKS5 limits the proxy user field to 255 bytes and it seems likely
-           that a longer field is either a mistake or malicous input */
+           that a longer field is either a mistake or malicious input */
         failf(data, "Too long SOCKS proxy user name");
         return CURLPX_LONG_USER;
       }

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -74,7 +74,7 @@ struct per_transfer {
 
   /* NULL or malloced */
   char *uploadfile;
-  char *errorbuffer; /* alloced and assigned while this is used for a
+  char *errorbuffer; /* allocated and assigned while this is used for a
                         transfer */
 };
 


### PR DESCRIPTION
Found by manually running `codespell` on the lib directory and ignoring all the false positives.