### PR TITLE
fopen: create new file using old file's mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1185,7 +1185,6 @@ elseif(HAVE_LIBSOCKET)
   set(CMAKE_REQUIRED_LIBRARIES socket)
 endif()
 
-check_symbol_exists(fchmod        "${CURL_INCLUDES}" HAVE_FCHMOD)
 check_symbol_exists(fnmatch       "${CURL_INCLUDES};fnmatch.h" HAVE_FNMATCH)
 check_symbol_exists(basename      "${CURL_INCLUDES};string.h" HAVE_BASENAME)
 check_symbol_exists(socket        "${CURL_INCLUDES}" HAVE_SOCKET)

--- a/configure.ac
+++ b/configure.ac
@@ -3581,7 +3581,6 @@ AC_CHECK_DECLS([getpwuid_r], [], [AC_DEFINE(HAVE_DECL_GETPWUID_R_MISSING, 1, "Se
 AC_CHECK_FUNCS([\
   _fseeki64 \
   arc4random \
-  fchmod \
   fnmatch \
   fseeko \
   geteuid \

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -177,9 +177,6 @@
 /* Define to 1 if you have _Atomic support. */
 #cmakedefine HAVE_ATOMIC 1
 
-/* Define to 1 if you have the `fchmod' function. */
-#cmakedefine HAVE_FCHMOD 1
-
 /* Define to 1 if you have the `fnmatch' function. */
 #cmakedefine HAVE_FNMATCH 1
 

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -129,7 +129,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   }
 
   result = CURLE_WRITE_ERROR;
-  fd = open(tempstore, O_WRONLY | O_CREAT | O_EXCL, (mode_t)(0600|sb.st_mode));
+  fd = open(tempstore, O_WRONLY | O_CREAT | O_EXCL, 0600|sb.st_mode);
   if(fd == -1)
     goto fail;
 

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -129,21 +129,9 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   }
 
   result = CURLE_WRITE_ERROR;
-  fd = open(tempstore, O_WRONLY | O_CREAT | O_EXCL, 0600);
+  fd = open(tempstore, O_WRONLY | O_CREAT | O_EXCL, (mode_t)(0600|sb.st_mode));
   if(fd == -1)
     goto fail;
-
-#ifdef HAVE_FCHMOD
-  {
-    struct_stat nsb;
-    if((fstat(fd, &nsb) != -1) &&
-       (nsb.st_uid == sb.st_uid) && (nsb.st_gid == sb.st_gid)) {
-      /* if the user and group are the same, clone the original mode */
-      if(fchmod(fd, (mode_t)sb.st_mode) == -1)
-        goto fail;
-    }
-  }
-#endif
 
   *fh = fdopen(fd, FOPEN_WRITETEXT);
   if(!*fh)


### PR DESCRIPTION
Because the function renames the temp file to the target name as a last step, if the file was previously owned by a different user, not ORing the old mode could otherwise end up creating a file that was no longer readable by the original owner after save.

Reported-by: Loïc Yhuel
Fixes #12299