### PR TITLE
fopen: allocate the dir after fopen

### DIFF
--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -116,14 +116,11 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
     goto fail;
 
   dir = dirslash(filename);
-  if(!dir) {
-    result = CURLE_OUT_OF_MEMORY;
-    goto fail;
-  }
+  if(dir)
+    /* The temp file name should not end up too long for the target file
+       system */
+    tempstore = aprintf("%s%s.tmp", dir, randbuf);
 
-  /* The temp file name should not end up too long for the target file
-     system */
-  tempstore = aprintf("%s%s.tmp", dir, randbuf);
   if(!tempstore) {
     result = CURLE_OUT_OF_MEMORY;
     goto fail;

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -94,7 +94,7 @@ static char *dirslash(const char *path)
 CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
                     FILE **fh, char **tempname)
 {
-  CURLcode result = CURLE_WRITE_ERROR;
+  CURLcode result;
   unsigned char randbuf[41];
   char *tempstore = NULL;
   struct_stat sb;

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -116,10 +116,12 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
     goto fail;
 
   dir = dirslash(filename);
-  if(dir)
+  if(dir) {
     /* The temp file name should not end up too long for the target file
        system */
     tempstore = aprintf("%s%s.tmp", dir, randbuf);
+    free(dir);
+  }
 
   if(!tempstore) {
     result = CURLE_OUT_OF_MEMORY;
@@ -135,7 +137,6 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   if(!*fh)
     goto fail;
 
-  free(dir);
   *tempname = tempstore;
   return CURLE_OK;
 
@@ -146,7 +147,6 @@ fail:
   }
 
   free(tempstore);
-  free(dir);
   return result;
 }
 

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -99,18 +99,13 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   char *tempstore = NULL;
   struct_stat sb;
   int fd = -1;
-  char *dir;
+  char *dir = NULL;
   *tempname = NULL;
-
-  dir = dirslash(filename);
-  if(!dir)
-    goto fail;
 
   *fh = fopen(filename, FOPEN_WRITETEXT);
   if(!*fh)
     goto fail;
   if(fstat(fileno(*fh), &sb) == -1 || !S_ISREG(sb.st_mode)) {
-    free(dir);
     return CURLE_OK;
   }
   fclose(*fh);
@@ -118,6 +113,10 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
 
   result = Curl_rand_alnum(data, randbuf, sizeof(randbuf));
   if(result)
+    goto fail;
+
+  dir = dirslash(filename);
+  if(!dir)
     goto fail;
 
   /* The temp file name should not end up too long for the target file

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -116,8 +116,10 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
     goto fail;
 
   dir = dirslash(filename);
-  if(!dir)
+  if(!dir) {
+    result = CURLE_OUT_OF_MEMORY;
     goto fail;
+  }
 
   /* The temp file name should not end up too long for the target file
      system */

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -94,7 +94,7 @@ static char *dirslash(const char *path)
 CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
                     FILE **fh, char **tempname)
 {
-  CURLcode result;
+  CURLcode result = CURLE_WRITE_ERROR;
   unsigned char randbuf[41];
   char *tempstore = NULL;
   struct_stat sb;


### PR DESCRIPTION
Move the allocation of the directory name down to after the fopen() call to allow that shortcut code path to avoid a superfluous malloc+free cycle.

Follow-up to 73b65e94f35311