### PR TITLE
docs/libcurl: SYNSOPSIS cleanup

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -898,6 +898,7 @@ winssl
 Wireshark
 wolfSSH
 wolfSSL
+ws
 WS
 WSS
 www

--- a/.github/scripts/verify-synopsis.pl
+++ b/.github/scripts/verify-synopsis.pl
@@ -73,6 +73,7 @@ sub extract {
 
 my $error;
 for my $m (@files) {
+    print "Verify $m\n";
     extract($m);
     $error |= testcompile($m);
 }

--- a/.github/scripts/verify-synopsis.pl
+++ b/.github/scripts/verify-synopsis.pl
@@ -1,0 +1,80 @@
+#!/usr/bin/env perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+my @files = @ARGV;
+my $cfile = "test.c";
+
+if($files[0] eq "-h") {
+    print "Usage: verify-synopsis [man pages]\n";
+    exit;
+}
+
+sub testcompile {
+    my $rc = system("gcc -c test.c -DCURL_DISABLE_TYPECHECK -DCURL_ALLOW_OLD_MULTI_SOCKET -I include") >> 8;
+    return $rc;
+}
+
+
+sub extract {
+    my($f) = @_;
+    my $syn = 0;
+    my $l = 0;
+    my $iline = 0;
+    open(F, "<$f");
+    open(O, ">$cfile");
+    while(<F>) {
+        $iline++;
+        if(/^.SH SYNOPSIS/) {
+            $syn = 1
+        }
+        elsif($syn == 1) {
+            if(/^.nf/) {
+                $syn++;
+                print O "#line $iline \"$f\"\n";
+            }
+        }
+        elsif($syn == 2) {
+            if(/^.fi/) {
+                last;
+            }
+            # turn the vararg argument into vararg
+            $_ =~ s/, parameter\)\;/, ...);/;
+            print O $_;
+            $l++;
+        }
+    }
+    close(F);
+    close(O);
+
+    return 0;
+}
+
+my $error;
+for my $m (@files) {
+    extract($m);
+    $error |= testcompile($m);
+}
+exit $error;
+

--- a/.github/workflows/synopsis.yml
+++ b/.github/workflows/synopsis.yml
@@ -25,4 +25,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: verify-synopsis
-        run: ./.github/scripits/verify-synopsis.pl docs/libcurl/curl*.3
+        run: ./.github/scripts/verify-synopsis.pl docs/libcurl/curl*.3

--- a/.github/workflows/synopsis.yml
+++ b/.github/workflows/synopsis.yml
@@ -1,0 +1,28 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+name: SYNOPSIS
+
+on:
+  push:
+    branches:
+    - master
+    - '*/ci'
+    paths:
+    - 'docs/libcurl/curl_*.3'
+  pull_request:
+    branches:
+    - master
+    paths:
+    - 'docs/libcurl/curl_*.3'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: verify-synopsis
+        run: ./.github/scripits/verify-synopsis.pl docs/libcurl/curl*.3

--- a/docs/libcurl/curl_easy_header.3
+++ b/docs/libcurl/curl_easy_header.3
@@ -34,6 +34,7 @@ CURLHcode curl_easy_header(CURL *easy,
                            unsigned int origin,
                            int request,
                            struct curl_header **hout);
+.fi
 .SH DESCRIPTION
 \fIcurl_easy_header(3)\fP returns a pointer to a "curl_header" struct in
 \fBhout\fP with data for the HTTP response header \fIname\fP. The case

--- a/docs/libcurl/curl_easy_option_next.3
+++ b/docs/libcurl/curl_easy_option_next.3
@@ -28,6 +28,25 @@ curl_easy_option_next - iterate over easy setopt options
 .nf
 #include <curl/curl.h>
 
+const struct curl_easyoption *
+curl_easy_option_next(const struct curl_easyoption *prev);
+.fi
+.SH DESCRIPTION
+This function returns a pointer to the first or the next \fIcurl_easyoption\fP
+struct, providing an ability to iterate over all known options for
+\fIcurl_easy_setopt(3)\fP in this instance of libcurl.
+
+Pass a \fBNULL\fP argument as \fBprev\fP to get the first option returned, or
+pass in the current option to get the next one returned. If there is no more
+option to return, \fIcurl_easy_option_next(3)\fP returns NULL.
+
+The options returned by this functions are the ones known to this libcurl and
+information about what argument type they want.
+
+If the \fBCURLOT_FLAG_ALIAS\fP bit is set in the flags field, it means the
+name is provided for backwards compatibility as an alias.
+.SH struct
+.nf
 typedef enum {
   CURLOT_LONG,    /* long (a range of values) */
   CURLOT_VALUES,  /*      (a defined set or bitmask) */
@@ -48,24 +67,7 @@ struct curl_easyoption {
   curl_easytype type;
   unsigned int flags;
 };
-
-const struct curl_easyoption *
-curl_easy_option_next(const struct curl_easyoption *prev);
 .fi
-.SH DESCRIPTION
-This function returns a pointer to the first or the next \fIcurl_easyoption\fP
-struct, providing an ability to iterate over all known options for
-\fIcurl_easy_setopt(3)\fP in this instance of libcurl.
-
-Pass a \fBNULL\fP argument as \fBprev\fP to get the first option returned, or
-pass in the current option to get the next one returned. If there is no more
-option to return, \fIcurl_easy_option_next(3)\fP returns NULL.
-
-The options returned by this functions are the ones known to this libcurl and
-information about what argument type they want.
-
-If the \fBCURLOT_FLAG_ALIAS\fP bit is set in the flags field, it means the
-name is provided for backwards compatibility as an alias.
 .SH EXAMPLE
 .nf
 /* iterate over all available options */

--- a/docs/libcurl/curl_easy_recv.3
+++ b/docs/libcurl/curl_easy_recv.3
@@ -27,7 +27,7 @@
 curl_easy_recv - receives raw data on an "easy" connection
 .SH SYNOPSIS
 .nf
-#include <curl/easy.h>
+#include <curl/curl.h>
 
 CURLcode curl_easy_recv(CURL *curl, void *buffer, size_t buflen, size_t *n);
 .fi

--- a/docs/libcurl/curl_easy_send.3
+++ b/docs/libcurl/curl_easy_send.3
@@ -27,7 +27,7 @@
 curl_easy_send - sends raw data over an "easy" connection
 .SH SYNOPSIS
 .nf
-#include <curl/easy.h>
+#include <curl/curl.h>
 
 CURLcode curl_easy_send(CURL *curl, const void *buffer,
                         size_t buflen, size_t *n);

--- a/docs/libcurl/curl_formget.3
+++ b/docs/libcurl/curl_formget.3
@@ -29,7 +29,8 @@ curl_formget - serialize a previously built multipart form POST chain
 #include <curl/curl.h>
 
 int curl_formget(struct curl_httppost * form, void *userp,
-                  curl_formget_callback append );
+                 curl_formget_callback append);
+.fi
 .SH DESCRIPTION
 curl_formget() is used to serialize data previously built/appended with
 \fIcurl_formadd(3)\fP. Accepts a void pointer as second argument named

--- a/docs/libcurl/curl_getdate.3
+++ b/docs/libcurl/curl_getdate.3
@@ -28,7 +28,7 @@ curl_getdate - Convert a date string to number of seconds
 .nf
 #include <curl/curl.h>
 
-time_t curl_getdate(char *datestring, time_t *now);
+time_t curl_getdate(const char *datestring, const time_t *now);
 .fi
 .SH DESCRIPTION
 \fIcurl_getdate(3)\fP returns the number of seconds since the Epoch, January

--- a/docs/libcurl/curl_global_sslset.3
+++ b/docs/libcurl/curl_global_sslset.3
@@ -28,31 +28,9 @@ curl_global_sslset - Select SSL backend to use with libcurl
 .nf
 #include <curl/curl.h>
 
-typedef struct {
-  curl_sslbackend id;
-  const char *name;
-} curl_ssl_backend;
-
-typedef enum {
-  CURLSSLBACKEND_NONE = 0,
-  CURLSSLBACKEND_OPENSSL = 1, /* or one of its forks */
-  CURLSSLBACKEND_GNUTLS = 2,
-  CURLSSLBACKEND_NSS = 3,
-  CURLSSLBACKEND_GSKIT = 5, /* deprecated */
-  CURLSSLBACKEND_POLARSSL = 6, /* deprecated */
-  CURLSSLBACKEND_WOLFSSL = 7,
-  CURLSSLBACKEND_SCHANNEL = 8,
-  CURLSSLBACKEND_SECURETRANSPORT = 9,
-  CURLSSLBACKEND_AXTLS = 10, /* deprecated */
-  CURLSSLBACKEND_MBEDTLS = 11,
-  CURLSSLBACKEND_MESALINK = 12, /* deprecated */
-  CURLSSLBACKEND_BEARSSL = 13,
-  CURLSSLBACKEND_RUSTLS = 14
-} curl_sslbackend;
-
 CURLsslset curl_global_sslset(curl_sslbackend id,
                               const char *name,
-                              curl_ssl_backend ***avail);
+                              const curl_ssl_backend ***avail);
 .fi
 .SH DESCRIPTION
 This function configures at runtime which SSL backend to use with
@@ -99,6 +77,30 @@ provide the same API.
 
 \fIcurl_version_info(3)\fP can return more specific info about the exact
 OpenSSL flavor and version number is use.
+.SH struct
+.nf
+typedef struct {
+  curl_sslbackend id;
+  const char *name;
+} curl_ssl_backend;
+
+typedef enum {
+  CURLSSLBACKEND_NONE = 0,
+  CURLSSLBACKEND_OPENSSL = 1, /* or one of its forks */
+  CURLSSLBACKEND_GNUTLS = 2,
+  CURLSSLBACKEND_NSS = 3,
+  CURLSSLBACKEND_GSKIT = 5, /* deprecated */
+  CURLSSLBACKEND_POLARSSL = 6, /* deprecated */
+  CURLSSLBACKEND_WOLFSSL = 7,
+  CURLSSLBACKEND_SCHANNEL = 8,
+  CURLSSLBACKEND_SECURETRANSPORT = 9,
+  CURLSSLBACKEND_AXTLS = 10, /* deprecated */
+  CURLSSLBACKEND_MBEDTLS = 11,
+  CURLSSLBACKEND_MESALINK = 12, /* deprecated */
+  CURLSSLBACKEND_BEARSSL = 13,
+  CURLSSLBACKEND_RUSTLS = 14
+} curl_sslbackend;
+.fi
 .SH EXAMPLE
 .nf
   /* choose a specific backend */

--- a/docs/libcurl/curl_multi_fdset.3
+++ b/docs/libcurl/curl_multi_fdset.3
@@ -33,7 +33,7 @@ CURLMcode curl_multi_fdset(CURLM *multi_handle,
                            fd_set *write_fd_set,
                            fd_set *exc_fd_set,
                            int *max_fd);
-.ad
+.fi
 .SH DESCRIPTION
 This function extracts file descriptor information from a given multi_handle.
 libcurl returns its \fIfd_set\fP sets. The application can use these to

--- a/docs/libcurl/curl_multi_poll.3
+++ b/docs/libcurl/curl_multi_poll.3
@@ -33,7 +33,7 @@ CURLMcode curl_multi_poll(CURLM *multi_handle,
                           unsigned int extra_nfds,
                           int timeout_ms,
                           int *numfds);
-.ad
+.fi
 .SH DESCRIPTION
 \fIcurl_multi_poll(3)\fP polls all file descriptors used by the curl easy
 handles contained in the given multi handle set. It blocks until activity is

--- a/docs/libcurl/curl_multi_setopt.3
+++ b/docs/libcurl/curl_multi_setopt.3
@@ -28,17 +28,17 @@ curl_multi_setopt \- set options for a curl multi handle
 .nf
 #include <curl/curl.h>
 
-CURLMcode curl_multi_setopt(CURLM *multi_handle, CURLMoption option, param);
+CURLMcode curl_multi_setopt(CURLM *multi_handle, CURLMoption option, parameter);
 .fi
 .SH DESCRIPTION
 \fIcurl_multi_setopt(3)\fP is used to tell a libcurl multi handle how to
 behave. By using the appropriate options to \fIcurl_multi_setopt(3)\fP, you
 can change libcurl's behavior when using that multi handle. All options are
-set with the \fIoption\fP followed by the parameter \fIparam\fP. That
-parameter can be a \fBlong\fP, a \fBfunction pointer\fP, an \fBobject
-pointer\fP or a \fBcurl_off_t\fP type, depending on what the specific option
-expects. Read this manual carefully as bad input values may cause libcurl to
-behave badly. You can only set one option in each function call.
+set with the \fIoption\fP followed by the \fIparameter\fP. That parameter can
+be a \fBlong\fP, a \fBfunction pointer\fP, an \fBobject pointer\fP or a
+\fBcurl_off_t\fP type, depending on what the specific option expects. Read
+this manual carefully as bad input values may cause libcurl to behave
+badly. You can only set one option in each function call.
 
 .SH OPTIONS
 .IP CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE

--- a/docs/libcurl/curl_multi_strerror.3
+++ b/docs/libcurl/curl_multi_strerror.3
@@ -29,6 +29,7 @@ curl_multi_strerror - return string describing error code
 #include <curl/curl.h>
 
 const char *curl_multi_strerror(CURLMcode errornum);
+.fi
 .SH DESCRIPTION
 This function returns a string describing the \fICURLMcode\fP error code
 passed in the argument \fIerrornum\fP.

--- a/docs/libcurl/curl_multi_wait.3
+++ b/docs/libcurl/curl_multi_wait.3
@@ -33,7 +33,7 @@ CURLMcode curl_multi_wait(CURLM *multi_handle,
                           unsigned int extra_nfds,
                           int timeout_ms,
                           int *numfds);
-.ad
+.fi
 .SH DESCRIPTION
 \fIcurl_multi_wait(3)\fP polls all file descriptors used by the curl easy
 handles contained in the given multi handle set. It blocks until activity is

--- a/docs/libcurl/curl_share_strerror.3
+++ b/docs/libcurl/curl_share_strerror.3
@@ -29,6 +29,7 @@ curl_share_strerror - return string describing error code
 #include <curl/curl.h>
 
 const char *curl_share_strerror(CURLSHcode errornum);
+.fi
 .SH DESCRIPTION
 The \fIcurl_share_strerror(3)\fP function returns a string describing the
 \fICURLSHcode\fP error code passed in the argument \fIerrornum\fP.

--- a/docs/libcurl/curl_strequal.3
+++ b/docs/libcurl/curl_strequal.3
@@ -28,8 +28,8 @@ curl_strequal, curl_strnequal - case insensitive string comparisons
 .nf
 #include <curl/curl.h>
 
-int curl_strequal(char *str1, char *str2);
-int curl_strnequal(char *str1, char *str2, size_t length);
+int curl_strequal(const char *str1, const char *str2);
+int curl_strnequal(const char *str1, const char *str2, size_t length);
 .fi
 .SH DESCRIPTION
 The

--- a/docs/libcurl/curl_url_dup.3
+++ b/docs/libcurl/curl_url_dup.3
@@ -28,7 +28,7 @@ curl_url_dup - duplicate a URL handle
 .nf
 #include <curl/curl.h>
 
-CURLU *curl_url_dup(CURLU *inhandle);
+CURLU *curl_url_dup(const CURLU *inhandle);
 .fi
 .SH DESCRIPTION
 Duplicates the URL object the input \fICURLU\fP \fIinhandle\fP identifies and

--- a/docs/libcurl/curl_url_get.3
+++ b/docs/libcurl/curl_url_get.3
@@ -28,7 +28,7 @@ curl_url_get - extract a part from a URL
 .nf
 #include <curl/curl.h>
 
-CURLUcode curl_url_get(CURLU *url,
+CURLUcode curl_url_get(const CURLU *url,
                        CURLUPart part,
                        char **content,
                        unsigned int flags);

--- a/docs/libcurl/curl_url_strerror.3
+++ b/docs/libcurl/curl_url_strerror.3
@@ -29,6 +29,7 @@ curl_url_strerror - return string describing error code
 #include <curl/curl.h>
 
 const char *curl_url_strerror(CURLUcode errornum);
+.fi
 .SH DESCRIPTION
 This function returns a string describing the CURLUcode error code passed in
 the argument \fIerrornum\fP.

--- a/docs/libcurl/curl_ws_meta.3
+++ b/docs/libcurl/curl_ws_meta.3
@@ -27,14 +27,7 @@
 curl_ws_meta - meta data WebSocket information
 .SH SYNOPSIS
 .nf
-#include <curl/easy.h>
-
-struct curl_ws_frame {
-  int age;              /* zero */
-  int flags;            /* See the CURLWS_* defines */
-  curl_off_t offset;    /* the offset of this data into the frame */
-  curl_off_t bytesleft; /* number of pending bytes left of the payload */
-};
+#include <curl/curl.h>
 
 const struct curl_ws_frame *curl_ws_meta(CURL *curl);
 .fi
@@ -53,7 +46,15 @@ what transfer the question is about, but as there is no such pointer provided
 to the callback by libcurl itself, applications that want to use
 \fIcurl_ws_meta(3)\fP need to pass it on to the callback on its own.
 
-.SH "struct fields"
+.SH "struct curl_ws_frame"
+.nf
+struct curl_ws_frame {
+  int age;
+  int flags;
+  curl_off_t offset;
+  curl_off_t bytesleft;
+};
+.fi
 .IP age
 This field specify the age of this struct. It is always zero for now.
 .IP flags

--- a/docs/libcurl/curl_ws_recv.3
+++ b/docs/libcurl/curl_ws_recv.3
@@ -27,7 +27,7 @@
 curl_ws_recv - receive WebSocket data
 .SH SYNOPSIS
 .nf
-#include <curl/easy.h>
+#include <curl/curl.h>
 
 CURLcode curl_ws_recv(CURL *curl, void *buffer, size_t buflen,
                       size_t *recv, const struct curl_ws_frame **meta);

--- a/docs/libcurl/curl_ws_send.3
+++ b/docs/libcurl/curl_ws_send.3
@@ -27,7 +27,7 @@
 curl_ws_send - send WebSocket data
 .SH SYNOPSIS
 .nf
-#include <curl/easy.h>
+#include <curl/curl.h>
 
 CURLcode curl_ws_send(CURL *curl, const void *buffer, size_t buflen,
                       size_t *sent, curl_off_t fragsize,


### PR DESCRIPTION
- use the correct include file
- make sure they are declared as in the header file
- fix minor nroff syntax mistakes (missing .fi)

These were all verified by a local script that extracts the SYNPOSIS code and run them through gcc.