### PR TITLE
curl.rc: switch out the copyright symbol for plain ASCII

### DIFF
--- a/src/curl.rc
+++ b/src/curl.rc
@@ -53,7 +53,7 @@ BEGIN
       VALUE "OriginalFilename", "curl.exe\0"
       VALUE "ProductName",      "The curl executable\0"
       VALUE "ProductVersion",   CURL_VERSION "\0"
-      VALUE "LegalCopyright",   "\xa9 " CURL_COPYRIGHT "\0"  /* a9: Copyright symbol */
+      VALUE "LegalCopyright",   "Copyright (C) " CURL_COPYRIGHT "\0"
       VALUE "License",          "https://curl.se/docs/copyright.html\0"
     END
   END


### PR DESCRIPTION
.. like we already do for libcurl.rc.

libcurl.rc copyright symbol used to cause a "non-ascii 8-bit codepoint" warning so it was switched to ascii.

Ref: https://github.com/curl/curl/commit/1ca62bb5#commitcomment-133474972

Suggested-by: Robert Southee

Closes #xxxx

---

/cc @rksouthee