### PR TITLE
hostcache: Cache negative name resolves

### DIFF
--- a/lib/hostasyn.c
+++ b/lib/hostasyn.c
@@ -72,33 +72,27 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
 
   data->state.async.status = status;
 
-  if(CURL_ASYNC_SUCCESS == status) {
-    if(ai) {
-      if(data->share)
-        Curl_share_lock(data, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SINGLE);
+  if(data->share)
+    Curl_share_lock(data, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SINGLE);
 
-      dns = Curl_cache_addr(data, ai,
-                            data->state.async.hostname, 0,
-                            data->state.async.port);
-      if(data->share)
-        Curl_share_unlock(data, CURL_LOCK_DATA_DNS);
+  dns = Curl_cache_addr(data, ai,
+                        data->state.async.hostname, 0,
+                        data->state.async.port);
+  if(data->share)
+    Curl_share_unlock(data, CURL_LOCK_DATA_DNS);
 
-      if(!dns) {
-        /* failed to store, cleanup and return error */
-        Curl_freeaddrinfo(ai);
-        result = CURLE_OUT_OF_MEMORY;
-      }
-    }
-    else {
-      result = CURLE_OUT_OF_MEMORY;
-    }
+  if(!dns) {
+    /* failed to store, cleanup and return error */
+    Curl_freeaddrinfo(ai);
+    result = CURLE_OUT_OF_MEMORY;
   }
 
-  data->state.async.dns = dns;
+  if(ai)
+    data->state.async.dns = dns;
 
- /* Set async.done TRUE last in this function since it may be used multi-
-    threaded and once this is TRUE the other thread may read fields from the
-    async struct */
+  /* Set async.done TRUE last in this function since it may be used multi-
+     threaded and once this is TRUE the other thread may read fields from the
+     async struct */
   data->state.async.done = TRUE;
 
   /* IPv4: The input hostent struct will be freed by ares when we return from

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -137,7 +137,9 @@ void Curl_hostcache_prune(struct Curl_easy *data);
 /* IPv4 threadsafe resolve function used for synch and asynch builds */
 struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname, int port);
 
-CURLcode Curl_once_resolved(struct Curl_easy *data, bool *protocol_connect);
+CURLcode Curl_once_resolved(struct Curl_easy *data,
+                            struct Curl_dns_entry *dns,
+                            bool *protocol_connect);
 
 /*
  * Curl_addrinfo_callback() is used when we build with any asynch specialty.
@@ -156,19 +158,6 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
  */
 void Curl_printable_address(const struct Curl_addrinfo *ip,
                             char *buf, size_t bufsize);
-
-/*
- * Curl_fetch_addr() fetches a 'Curl_dns_entry' already in the DNS cache.
- *
- * Returns the Curl_dns_entry entry pointer or NULL if not in the cache.
- *
- * The returned data *MUST* be "unlocked" with Curl_resolv_unlock() after
- * use, or we'll leak memory!
- */
-struct Curl_dns_entry *
-Curl_fetch_addr(struct Curl_easy *data,
-                const char *hostname,
-                int port);
 
 /*
  * Curl_cache_addr() stores a 'Curl_addrinfo' struct in the DNS cache.

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1965,34 +1965,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       /* awaiting an asynch name resolve to complete */
     {
       struct Curl_dns_entry *dns = NULL;
-      struct connectdata *conn = data->conn;
-      const char *hostname;
-
-      DEBUGASSERT(conn);
-#ifndef CURL_DISABLE_PROXY
-      if(conn->bits.httpproxy)
-        hostname = conn->http_proxy.host.name;
-      else
-#endif
-        if(conn->bits.conn_to_host)
-          hostname = conn->conn_to_host.name;
-      else
-        hostname = conn->host.name;
-
-      /* check if we have the name resolved by now */
-      dns = Curl_fetch_addr(data, hostname, (int)conn->port);
-
-      if(dns) {
-#ifdef CURLRES_ASYNCH
-        data->state.async.dns = dns;
-        data->state.async.done = TRUE;
-#endif
-        result = CURLE_OK;
-        infof(data, "Hostname '%s' was found in DNS cache", hostname);
-      }
-
-      if(!dns)
-        result = Curl_resolv_check(data, &dns);
+      result = Curl_resolv_check(data, &dns);
 
       /* Update sockets here, because the socket(s) may have been
          closed and the application thus needs to be told, even if it
@@ -2007,7 +1980,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       if(dns) {
         /* Perform the next step in the connection phase, and then move on
            to the WAITCONNECT state */
-        result = Curl_once_resolved(data, &connected);
+        result = Curl_once_resolved(data, dns, &connected);
 
         if(result)
           /* if Curl_once_resolved() returns failure, the connection struct

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -335,23 +335,15 @@ static CURLproxycode do_SOCKS4(struct Curl_cfilter *cf,
 
   case CONNECT_RESOLVING:
     /* check if we have the name resolved by now */
-    dns = Curl_fetch_addr(data, sx->hostname, (int)conn->port);
-
+    result = Curl_resolv_check(data, &dns);
     if(dns) {
-#ifdef CURLRES_ASYNCH
-      data->state.async.dns = dns;
-      data->state.async.done = TRUE;
-#endif
       infof(data, "Hostname '%s' was found", sx->hostname);
       sxstate(sx, data, CONNECT_RESOLVED);
     }
     else {
-      result = Curl_resolv_check(data, &dns);
-      if(!dns) {
-        if(result)
-          return CURLPX_RESOLVE_HOST;
-        return CURLPX_OK;
-      }
+      if(result)
+        return CURLPX_RESOLVE_HOST;
+      return CURLPX_OK;
     }
     FALLTHROUGH();
   case CONNECT_RESOLVED:
@@ -803,23 +795,13 @@ CONNECT_REQ_INIT:
 
   case CONNECT_RESOLVING:
     /* check if we have the name resolved by now */
-    dns = Curl_fetch_addr(data, sx->hostname, sx->remote_port);
-
-    if(dns) {
-#ifdef CURLRES_ASYNCH
-      data->state.async.dns = dns;
-      data->state.async.done = TRUE;
-#endif
+    result = Curl_resolv_check(data, &dns);
+    if(dns)
       infof(data, "SOCKS5: hostname '%s' found", sx->hostname);
-    }
-
-    if(!dns) {
-      result = Curl_resolv_check(data, &dns);
-      if(!dns) {
-        if(result)
-          return CURLPX_RESOLVE_HOST;
-        return CURLPX_OK;
-      }
+    else {
+      if(result)
+        return CURLPX_RESOLVE_HOST;
+      return CURLPX_OK;
     }
     FALLTHROUGH();
   case CONNECT_RESOLVED:


### PR DESCRIPTION
Add failed name resolves to the host cache, so that repeated connection attempts do not immediately repeat the resolve request.

This fixes TODO 1.9.