### PR TITLE
DoH trace configuration

### DIFF
--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -63,6 +63,7 @@ Note that log configuration applies only to transfers where debug logging
 is enabled. See CURLOPT_VERBOSE(3) or CURLOPT_DEBUGFUNCTION(3)
 on how to control that.
 
+<<<<<<< HEAD:docs/libcurl/curl_global_trace.md
 # TRACE COMPONENTS
 
 ## `tcp`
@@ -90,6 +91,10 @@ the proxy.
 In order to find out all components involved in a transfer, run it with "all"
 configured. You can then see all names involved in your libcurl version in the
 trace.
+
+## `doh`
+
+Tracing of DNS-over-HTTP operations to resolve host names.
 
 # EXAMPLE
 

--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -63,7 +63,6 @@ Note that log configuration applies only to transfers where debug logging
 is enabled. See CURLOPT_VERBOSE(3) or CURLOPT_DEBUGFUNCTION(3)
 on how to control that.
 
-<<<<<<< HEAD:docs/libcurl/curl_global_trace.md
 # TRACE COMPONENTS
 
 ## `tcp`

--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -93,7 +93,7 @@ trace.
 
 ## `doh`
 
-Tracing of DNS-over-HTTP operations to resolve host names.
+Tracing of DNS-over-HTTP operations to resolve hostnames.
 
 # EXAMPLE
 

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -36,6 +36,7 @@
 
 #include "cf-socket.h"
 #include "connect.h"
+#include "doh.h"
 #include "http2.h"
 #include "http_proxy.h"
 #include "cf-h1-proxy.h"
@@ -113,12 +114,14 @@ void Curl_failf(struct Curl_easy *data, const char *fmt, ...)
 void Curl_infof(struct Curl_easy *data, const char *fmt, ...)
 {
   DEBUGASSERT(!strchr(fmt, '\n'));
-  if(data && data->set.verbose) {
+  if(Curl_trc_is_verbose(data)) {
     va_list ap;
-    int len;
+    int len = 0;
     char buffer[MAXINFO + 2];
+    if(data->state.feat)
+      len = msnprintf(buffer, MAXINFO, "[%s] ", data->state.feat->name);
     va_start(ap, fmt);
-    len = mvsnprintf(buffer, MAXINFO, fmt, ap);
+    len += mvsnprintf(buffer + len, MAXINFO - len, fmt, ap);
     va_end(ap);
     buffer[len++] = '\n';
     buffer[len] = '\0';
@@ -132,15 +135,25 @@ void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
   DEBUGASSERT(cf);
   if(Curl_trc_cf_is_verbose(cf, data)) {
     va_list ap;
-    int len;
+    int len = 0;
     char buffer[MAXINFO + 2];
+    if(data->state.feat)
+      len += msnprintf(buffer + len, MAXINFO - len, "[%s] ",
+                       data->state.feat->name);
     if(cf->sockindex)
-      len = msnprintf(buffer, MAXINFO, "[%s-%d] ",
+      len += msnprintf(buffer + len, MAXINFO - len, "[%s-%d] ",
                       cf->cft->name, cf->sockindex);
     else
-      len = msnprintf(buffer, MAXINFO, "[%s] ", cf->cft->name);
+      len += msnprintf(buffer + len, MAXINFO - len, "[%s] ", cf->cft->name);
     va_start(ap, fmt);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     len += mvsnprintf(buffer + len, MAXINFO - len, fmt, ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     va_end(ap);
     buffer[len++] = '\n';
     buffer[len] = '\0';
@@ -148,6 +161,10 @@ void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
   }
 }
 
+static struct curl_trc_feat *trc_feats[] = {
+  &Curl_doh_trc,
+  NULL,
+};
 
 static struct Curl_cftype *cf_types[] = {
   &Curl_cft_tcp,
@@ -216,6 +233,15 @@ CURLcode Curl_trc_opt(const char *config)
       }
       else if(strcasecompare(token, cf_types[i]->name)) {
         cf_types[i]->log_level = lvl;
+        break;
+      }
+    }
+    for(i = 0; trc_feats[i]; ++i) {
+      if(strcasecompare(token, "all")) {
+        trc_feats[i]->log_level = lvl;
+      }
+      else if(strcasecompare(token, trc_feats[i]->name)) {
+        trc_feats[i]->log_level = lvl;
         break;
       }
     }

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -162,7 +162,9 @@ void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
 }
 
 static struct curl_trc_feat *trc_feats[] = {
+#ifndef CURL_DISABLE_DOH
   &Curl_doh_trc,
+#endif
   NULL,
 };
 

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -146,14 +146,7 @@ void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
     else
       len += msnprintf(buffer + len, MAXINFO - len, "[%s] ", cf->cft->name);
     va_start(ap, fmt);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
     len += mvsnprintf(buffer + len, MAXINFO - len, fmt, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     va_end(ap);
     buffer[len++] = '\n';
     buffer[len] = '\0';

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -104,7 +104,7 @@ struct curl_trc_feat {
             (cf) && (cf)->cft->log_level >= CURL_LOG_LVL_INFO)
 #define Curl_trc_ft_is_verbose(data, ft) \
                             (Curl_trc_is_verbose(data) && \
-                            (ft) && (ft)->log_level >= CURL_LOG_LVL_INFO)
+                            (ft)->log_level >= CURL_LOG_LVL_INFO)
 
 /**
  * Output an informational message when transfer's verbose logging is enabled.

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -77,19 +77,34 @@ void Curl_failf(struct Curl_easy *data,
 #define CURL_TRC_CF(data, cf, ...) \
   do { if(Curl_trc_cf_is_verbose(cf, data)) \
          Curl_trc_cf_infof(data, cf, __VA_ARGS__); } while(0)
+#define CURL_TRC_FT(data, ft, ...) \
+  do { if(Curl_trc_ft_is_verbose(data, ft)) \
+         Curl_trc_ft_infof(data, ft, __VA_ARGS__); } while(0)
 
 #else
 #define infof Curl_infof
 #define CURL_TRC_CF Curl_trc_cf_infof
+#define CURL_TRC_FT Curl_trc_ft_infof
 #endif
 
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
 /* informational messages enabled */
 
-#define Curl_trc_is_verbose(data)    ((data) && (data)->set.verbose)
+struct curl_trc_feat {
+  const char *name;
+  int log_level;
+};
+
+#define Curl_trc_is_verbose(data) \
+            ((data) && (data)->set.verbose && \
+            (!(data)->state.feat || \
+             ((data)->state.feat->log_level >= CURL_LOG_LVL_INFO)))
 #define Curl_trc_cf_is_verbose(cf, data) \
-                            ((data) && (data)->set.verbose && \
-                            (cf) && (cf)->cft->log_level >= CURL_LOG_LVL_INFO)
+            (Curl_trc_is_verbose(data) && \
+            (cf) && (cf)->cft->log_level >= CURL_LOG_LVL_INFO)
+#define Curl_trc_ft_is_verbose(data, ft) \
+                            (Curl_trc_is_verbose(data) && \
+                            (ft) && (ft)->log_level >= CURL_LOG_LVL_INFO)
 
 /**
  * Output an informational message when transfer's verbose logging is enabled.
@@ -104,11 +119,21 @@ void Curl_infof(struct Curl_easy *data,
 void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
                        const char *fmt, ...) CURL_PRINTF(3, 4);
 
+void Curl_trc_ft_infof(struct Curl_easy *data, struct curl_trc_feat *ft,
+#if defined(__GNUC__) && !defined(printf) && defined(CURL_HAVE_C99) && \
+  !defined(__MINGW32__)
+                      const char *fmt, ...)
+                      __attribute__((format(printf, 3, 4)));
+#else
+                      const char *fmt, ...);
+#endif
+
 #else /* defined(CURL_DISABLE_VERBOSE_STRINGS) */
 /* All informational messages are not compiled in for size savings */
 
 #define Curl_trc_is_verbose(d)        ((void)(d), FALSE)
 #define Curl_trc_cf_is_verbose(x,y)   ((void)(x), (void)(y), FALSE)
+#define Curl_trc_ft_is_verbose(x,y)   ((void)(x), (void)(y), FALSE)
 
 static void Curl_infof(struct Curl_easy *data, const char *fmt, ...)
 {
@@ -120,6 +145,13 @@ static void Curl_trc_cf_infof(struct Curl_easy *data,
                               const char *fmt, ...)
 {
   (void)data; (void)cf; (void)fmt;
+}
+
+static void Curl_trc_ft_infof(struct Curl_easy *data,
+                              struct Curl_trc_ft *ft,
+                              const char *fmt, ...)
+{
+  (void)data; (void)ft; (void)fmt;
 }
 
 #endif /* !defined(CURL_DISABLE_VERBOSE_STRINGS) */

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -77,14 +77,10 @@ void Curl_failf(struct Curl_easy *data,
 #define CURL_TRC_CF(data, cf, ...) \
   do { if(Curl_trc_cf_is_verbose(cf, data)) \
          Curl_trc_cf_infof(data, cf, __VA_ARGS__); } while(0)
-#define CURL_TRC_FT(data, ft, ...) \
-  do { if(Curl_trc_ft_is_verbose(data, ft)) \
-         Curl_trc_ft_infof(data, ft, __VA_ARGS__); } while(0)
 
 #else
 #define infof Curl_infof
 #define CURL_TRC_CF Curl_trc_cf_infof
-#define CURL_TRC_FT Curl_trc_ft_infof
 #endif
 
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
@@ -119,15 +115,6 @@ void Curl_infof(struct Curl_easy *data,
 void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
                        const char *fmt, ...) CURL_PRINTF(3, 4);
 
-void Curl_trc_ft_infof(struct Curl_easy *data, struct curl_trc_feat *ft,
-#if defined(__GNUC__) && !defined(printf) && defined(CURL_HAVE_C99) && \
-  !defined(__MINGW32__)
-                      const char *fmt, ...)
-                      __attribute__((format(printf, 3, 4)));
-#else
-                      const char *fmt, ...);
-#endif
-
 #else /* defined(CURL_DISABLE_VERBOSE_STRINGS) */
 /* All informational messages are not compiled in for size savings */
 
@@ -145,13 +132,6 @@ static void Curl_trc_cf_infof(struct Curl_easy *data,
                               const char *fmt, ...)
 {
   (void)data; (void)cf; (void)fmt;
-}
-
-static void Curl_trc_ft_infof(struct Curl_easy *data,
-                              struct Curl_trc_ft *ft,
-                              const char *fmt, ...)
-{
-  (void)data; (void)ft; (void)fmt;
 }
 
 #endif /* !defined(CURL_DISABLE_VERBOSE_STRINGS) */

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -69,7 +69,12 @@ static const char *doh_strerror(DOHcode code)
     return errors[code];
   return "bad error code";
 }
-#endif
+
+struct curl_trc_feat Curl_doh_trc = {
+  "DoH",
+  CURL_LOG_LVL_NONE,
+};
+#endif /* !CURL_DISABLE_VERBOSE_STRINGS */
 
 /* @unittest 1655
  */
@@ -189,9 +194,9 @@ static int doh_done(struct Curl_easy *doh, CURLcode result)
   struct dohdata *dohp = data->req.doh;
   /* so one of the DoH request done for the 'data' transfer is now complete! */
   dohp->pending--;
-  infof(data, "a DoH request is completed, %u to go", dohp->pending);
+  infof(doh, "a DoH request is completed, %u to go", dohp->pending);
   if(result)
-    infof(data, "DoH request %s", curl_easy_strerror(result));
+    infof(doh, "DoH request %s", curl_easy_strerror(result));
 
   if(!dohp->pending) {
     /* DoH completed */
@@ -242,6 +247,9 @@ static CURLcode dohprobe(struct Curl_easy *data,
        the gcc typecheck helpers */
     struct dynbuf *resp = &p->serverdoh;
     doh->state.internal = true;
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+    doh->state.feat = &Curl_doh_trc;
+#endif
     ERROR_CHECK_SETOPT(CURLOPT_URL, url);
     ERROR_CHECK_SETOPT(CURLOPT_DEFAULT_PROTOCOL, "https");
     ERROR_CHECK_SETOPT(CURLOPT_WRITEFUNCTION, doh_write_cb);
@@ -264,7 +272,7 @@ static CURLcode dohprobe(struct Curl_easy *data,
     ERROR_CHECK_SETOPT(CURLOPT_SHARE, data->share);
     if(data->set.err && data->set.err != stderr)
       ERROR_CHECK_SETOPT(CURLOPT_STDERR, data->set.err);
-    if(data->set.verbose)
+    if(Curl_trc_ft_is_verbose(data, &Curl_doh_trc))
       ERROR_CHECK_SETOPT(CURLOPT_VERBOSE, 1L);
     if(data->set.no_signal)
       ERROR_CHECK_SETOPT(CURLOPT_NOSIGNAL, 1L);
@@ -741,11 +749,11 @@ static void showdoh(struct Curl_easy *data,
                     const struct dohentry *d)
 {
   int i;
-  infof(data, "TTL: %u seconds", d->ttl);
+  infof(data, "[DoH] TTL: %u seconds", d->ttl);
   for(i = 0; i < d->numaddr; i++) {
     const struct dohaddr *a = &d->addr[i];
     if(a->type == DNS_TYPE_A) {
-      infof(data, "DoH A: %u.%u.%u.%u",
+      infof(data, "[DoH] A: %u.%u.%u.%u",
             a->ip.v4[0], a->ip.v4[1],
             a->ip.v4[2], a->ip.v4[3]);
     }
@@ -754,9 +762,9 @@ static void showdoh(struct Curl_easy *data,
       char buffer[128];
       char *ptr;
       size_t len;
-      msnprintf(buffer, 128, "DoH AAAA: ");
-      ptr = &buffer[10];
-      len = 118;
+      len = msnprintf(buffer, 128, "[DoH] AAAA: ");
+      ptr = &buffer[len];
+      len = sizeof(buffer) - len;
       for(j = 0; j < 16; j += 2) {
         size_t l;
         msnprintf(ptr, len, "%s%02x%02x", j?":":"", d->addr[i].ip.v6[j],
@@ -950,8 +958,11 @@ CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
       struct Curl_dns_entry *dns;
       struct Curl_addrinfo *ai;
 
-      infof(data, "DoH Host name: %s", dohp->host);
-      showdoh(data, &de);
+
+      if(Curl_trc_ft_is_verbose(data, &Curl_doh_trc)) {
+        infof(data, "[DoH] Host name: %s", dohp->host);
+        showdoh(data, &de);
+      }
 
       result = doh2ai(&de, dohp->host, dohp->port, &ai);
       if(result) {

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -120,6 +120,8 @@ void de_init(struct dohentry *d);
 void de_cleanup(struct dohentry *d);
 #endif
 
+extern struct curl_trc_feat Curl_doh_trc;
+
 #else /* if DoH is disabled */
 #define Curl_doh(a,b,c,d) NULL
 #define Curl_doh_is_resolved(x,y) CURLE_COULDNT_RESOLVE_HOST

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -53,6 +53,8 @@
 #define PORT_GOPHER 70
 #define PORT_MQTT 1883
 
+struct curl_trc_featt;
+
 #ifdef USE_WEBSOCKETS
 /* CURLPROTO_GOPHERS (29) is the highest publicly used protocol bit number,
  * the rest are internal information. If we use higher bits we only do this on
@@ -1444,6 +1446,10 @@ struct UrlState {
 #ifdef USE_HYPER
   bool hconnect;  /* set if a CONNECT request */
   CURLcode hresult; /* used to pass return codes back from hyper callbacks */
+#endif
+
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+  struct curl_trc_feat *feat; /* opt. trace feature transfer is part of */
 #endif
 
   /* Dynamically allocated strings, MUST be freed before this struct is


### PR DESCRIPTION
- refs #12397 where it is dicussed how to en-/disable verbose output of DoH operations
- introducing `struct curl_trc_feat` to track a curl feature for tracing
- adding `data->state.feat` optionally pointing to the feature a transfer belongs to
- adding trace functions and verbosity checks on features
- using trace feature in DoH code
- documenting `doh` as feature for `--trace-config`