### PR TITLE
tool_parsecfg: make warning output propose double-quoting

### DIFF
--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -210,7 +210,8 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
             break;
           default:
             warnf(operation->global, "%s:%d: warning: '%s' uses unquoted "
-                  "whitespace in the line that may cause side-effects",
+                  "whitespace that may cause side-effects. Consider quoting "
+                  "the value with double quotes?",
                   filename, lineno, option);
           }
         }

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -72,7 +72,7 @@ test417 test418 test419 test420 test421 test422 test423 test424 test425 \
 test426 test427 test428 test429 test430 test431 test432 test433 test434 \
 test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
-test453 test454 test455 test456 test457 test458 \
+test453 test454 test455 test456 test457 test458 test459 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 \

--- a/tests/data/test459
+++ b/tests/data/test459
@@ -1,0 +1,63 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+--config
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+config file with argument using whitespace missing quotes
+</name>
+<file name="%LOGDIR/config">
+data = arg with space
+</file>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --config %LOGDIR/config --silent
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes" nonewline="yes">
+POST /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 3
+Content-Type: application/x-www-form-urlencoded
+
+arg
+</protocol>
+<stderr mode="text">
+Warning: log/config:1: warning: 'data' uses unquoted whitespace that may cause 
+Warning: side-effects. Consider quoting the value with double quotes?
+</stderr>
+</verify>
+</testcase>


### PR DESCRIPTION
When the config file parser detects a word that *probably* should be quoted, mention double-quotes as a possible remedy.

Test 459 verifies.

Proposed-by: Jiehong on github
Fixes #12409