### PR TITLE
test459, fix for parallel runs

### DIFF
--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -210,9 +210,9 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
             break;
           default:
             warnf(operation->global, "%s:%d: warning: '%s' uses unquoted "
-                  "whitespace that may cause side-effects. Consider quoting "
-                  "the value with double quotes?",
-                  filename, lineno, option);
+                  "whitespace", filename, lineno, option);
+            warnf(operation->global, "This may cause side-effects. "
+                  "Consider using double quotes?");
           }
         }
         if(!*param)

--- a/tests/data/test459
+++ b/tests/data/test459
@@ -56,8 +56,8 @@ Content-Type: application/x-www-form-urlencoded
 arg
 </protocol>
 <stderr mode="text">
-Warning: log/config:1: warning: 'data' uses unquoted whitespace that may cause 
-Warning: side-effects. Consider quoting the value with double quotes?
+Warning: %LOGDIR/config:1: warning: 'data' uses unquoted whitespace
+Warning: This may cause side-effects. Consider using double quotes?
 </stderr>
 </verify>
 </testcase>


### PR DESCRIPTION
- change warniing message to work better with varying filename length.
- adapt test output check to new formatting