### PR TITLE
tcp socket, trace local address used in connect

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1158,6 +1158,9 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
 
     /* Connect TCP socket */
     rc = do_connect(cf, data, cf->conn->bits.tcp_fastopen);
+    set_local_ip(cf, data);
+    CURL_TRC_CF(data, cf, "local address %s port %d...",
+                ctx->l_ip, ctx->l_port);
     if(-1 == rc) {
       result = socket_connect_result(data, ctx->r_ip, SOCKERRNO);
       goto out;


### PR DESCRIPTION
adds a cfilter trace of the bound local address during connect attempt. QUIC connects already did that.