### PR TITLE
Aborting pausing send when connection is marked for closing.

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -733,6 +733,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
        on from our side, we need to stop that immediately. */
     infof(data, "we are done reading and this is set to close, stop send");
     k->keepon &= ~KEEP_SEND; /* no writing anymore either */
+    k->keepon &= ~KEEP_SEND_PAUSE; /* no pausing anymore either */
   }
 
 out:


### PR DESCRIPTION
This handles cases of some bi-directional "upgrade" scenarios (i.e. WebSockets) where sending is paused until some "upgrade" handshake is completed, but server rejects the handshake and closes the connection.