### PR TITLE
multi: during ratelimit multi_getsock should return no sockets

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1064,6 +1064,10 @@ static void multi_getsock(struct Curl_easy *data,
   case MSTATE_PERFORMING:
     Curl_pollset_add_socks(data, ps, Curl_single_getsock);
     break;
+
+  case MSTATE_RATELIMITING:
+    /* nothing to wait for */
+    return;
   }
 
   /* Let connection filters add/remove as needed */

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -304,7 +304,7 @@ timediff_t Curl_pgrsLimitWaitTime(curl_off_t cursize,
    * 'actual' is the time in milliseconds it took to actually download the
    * last 'size' bytes.
    */
-  actual = Curl_timediff(now, start);
+  actual = Curl_timediff_ceil(now, start);
   if(actual < minimum) {
     /* if it downloaded the data faster than the limit, make it wait the
        difference */


### PR DESCRIPTION
... as there is nothing to wait for then, it just waits. Otherwise, this causes much more CPU work and updates than necessary during ratelimit periods.

Ref: https://curl.se/mail/lib-2023-11/0056.html