### PR TITLE
CURLINFO_PRETRANSFER_TIME_T.3: fix pretransfer time explanation

### DIFF
--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.3
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.3
@@ -38,7 +38,7 @@ start until the file transfer is just about to begin.
 
 This time-stamp includes all pre-transfer commands and negotiations that are
 specific to the particular protocol(s) involved. It includes the sending of
-the protocol- specific protocol instructions that triggers a transfer.
+the protocol-specific instructions that trigger a transfer.
 
 When a redirect is followed, the time from each request is added together.
 

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.3
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.3
@@ -33,12 +33,12 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PRETRANSFER_TIME_T,
                            curl_off_t *timep);
 .fi
 .SH DESCRIPTION
-Pass a pointer to a curl_off_t to receive the time, in microseconds,
-it took from the
-start until the file transfer is just about to begin. This includes all
-pre-transfer commands and negotiations that are specific to the particular
-protocol(s) involved. It does \fInot\fP involve the sending of the protocol-
-specific request that triggers a transfer.
+Pass a pointer to a curl_off_t to receive the time, in microseconds, it took
+from the start until the file transfer is just about to begin.
+
+This time-stamp includes all pre-transfer commands and negotiations that are
+specific to the particular protocol(s) involved. It includes the sending of
+the protocol-specific instructions that trigger a transfer.
 
 When a redirect is followed, the time from each request is added together.
 


### PR DESCRIPTION
- Change CURLINFO_PRETRANSFER_TIME_T explanation to say that it includes protocol-specific instructions that trigger a transfer.

Prior to this change it explicitly said that it did not include those instructions in the time, but that is incorrect.

The change is a copy of the fixed explanation already in CURLINFO_PRETRANSFER_TIME, fixed by ec8dcd7b.

Reported-by: eeverettrbx@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/12431
Closes #xxxx