### PR TITLE
Marking base64 as a dependency of http digest auth

### DIFF
--- a/lib/base64.c
+++ b/lib/base64.c
@@ -31,6 +31,7 @@
   !defined(CURL_DISABLE_SMTP) || \
   !defined(CURL_DISABLE_POP3) || \
   !defined(CURL_DISABLE_IMAP) || \
+  !defined(CURL_DISABLE_DIGEST_AUTH) || \
   !defined(CURL_DISABLE_DOH) || defined(USE_SSL) || defined(BUILDING_CURL)
 #include "curl/curl.h"
 #include "warnless.h"


### PR DESCRIPTION
This is the PR for #12440 