### PR TITLE
examples/rtsp-options.c: add

### DIFF
--- a/docs/examples/Makefile.inc
+++ b/docs/examples/Makefile.inc
@@ -108,6 +108,7 @@ check_PROGRAMS = \
   progressfunc \
   protofeats \
   resolve \
+  rstp-options \
   sendrecv \
   sepheaders \
   sftpget \

--- a/docs/examples/Makefile.inc
+++ b/docs/examples/Makefile.inc
@@ -108,7 +108,7 @@ check_PROGRAMS = \
   progressfunc \
   protofeats \
   resolve \
-  rstp-options \
+  rtsp-options \
   sendrecv \
   sepheaders \
   sftpget \

--- a/docs/examples/rtsp-options.c
+++ b/docs/examples/rtsp-options.c
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+/* <DESC>
+ * Very simple RTSP request sending OPTIONS.
+ * </DESC>
+ */
+#include <stdio.h>
+#include <curl/curl.h>
+
+int main(void)
+{
+  CURL *curl;
+  CURLcode res;
+
+  curl = curl_easy_init();
+  if(curl) {
+    curl_easy_setopt(curl, CURLOPT_URL, "rtsp://example.com/");
+
+    curl_easy_setopt(curl, CURLOPT_RTSP_SESSION_ID, "12345");
+
+    curl_easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
+
+    /* Perform the request, res will get the return code */
+    res = curl_easy_perform(curl);
+    /* Check for errors */
+    if(res != CURLE_OK)
+      fprintf(stderr, "curl_easy_perform() failed: %s\n",
+              curl_easy_strerror(res));
+
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+  }
+  return 0;
+}


### PR DESCRIPTION
Just a bare bones RTSP example using CURLOPT_RTSP_SESSION_ID and CURLOPT_RTSP_REQUEST set to CURL_RTSPREQ_OPTIONS.