### PR TITLE
tests/Makefile: add `error-codes.pl` to tarball 

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -27,7 +27,7 @@ PDFPAGES = testcurl.pdf runtests.pdf
 MANDISTPAGES = runtests.1.dist testcurl.1.dist
 
 EXTRA_DIST = appveyor.pm azure.pm badsymbols.pl check-deprecated.pl CMakeLists.txt \
- devtest.pl dictserver.py directories.pm disable-scan.pl error-codes.pl extern-scan.pl FILEFORMAT.md \
+ devtest.pl dictserver.py directories.pm disable-scan.pl errorcodes.pl error-codes.pl extern-scan.pl FILEFORMAT.md \
  processhelp.pm ftpserver.pl getpart.pm globalconfig.pm http-server.pl http2-server.pl \
  http3-server.pl manpage-scan.pl manpage-syntax.pl markdown-uppercase.pl mem-include-scan.pl \
  memanalyze.pl negtelnetserver.py nroff-scan.pl option-check.pl options-scan.pl \


### PR DESCRIPTION
`error-codes.pl` is missing in the 8.5.0 release tarball. As a result, test 1477 fails.

```
== Contents of files in the log/ dir after test 1477
=== Start of file check-expected
 Result[LF]
=== End of file check-expected
=== Start of file commands.log
 perl -I../../tests ../../tests/errorcodes.pl ../../tests/.. > log/stdout1477 2> log/stderr1477
=== End of file commands.log
=== Start of file server.cmd
 Testnum 1477
=== End of file server.cmd
=== Start of file stderr1477
 Can't open perl script "../../tests/errorcodes.pl": No such file or directory
=== End of file stderr1477
```