### PR TITLE
url: for disabled protocols, mention if found in redirect

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -1680,7 +1680,8 @@ static CURLcode findprotocol(struct Curl_easy *data,
   /* The protocol was not found in the table, but we don't have to assign it
      to anything since it is already assigned to a dummy-struct in the
      create_conn() function when the connectdata struct is allocated. */
-  failf(data, "Protocol \"%s\" not supported or disabled%s", protostr,
+  failf(data, "Protocol \"%s\" %s%s", protostr,
+        p ? "disabled" : "not supported",
         data->state.this_is_a_follow ? " (in redirect)":"");
 
   return CURLE_UNSUPPORTED_PROTOCOL;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1680,8 +1680,8 @@ static CURLcode findprotocol(struct Curl_easy *data,
   /* The protocol was not found in the table, but we don't have to assign it
      to anything since it is already assigned to a dummy-struct in the
      create_conn() function when the connectdata struct is allocated. */
-  failf(data, "Protocol \"%s\" not supported or disabled in " LIBCURL_NAME,
-        protostr);
+  failf(data, "Protocol \"%s\" not supported or disabled%s", protostr,
+        data->state.this_is_a_follow ? " (in redirect)":"");
 
   return CURLE_UNSUPPORTED_PROTOCOL;
 }

--- a/tests/data/test1268
+++ b/tests/data/test1268
@@ -30,7 +30,7 @@ file name argument looks like a flag
 <verify>
 <file name="%LOGDIR/moo%TESTNUMBER" mode="text">
 Warning: The file name argument '-k' looks like a flag.
-curl: (1) Protocol "hej" not supported or disabled
+curl: (1) Protocol "hej" not supported
 </file>
 
 # we expect an error since we provide a weird URL

--- a/tests/data/test1268
+++ b/tests/data/test1268
@@ -30,7 +30,7 @@ file name argument looks like a flag
 <verify>
 <file name="%LOGDIR/moo%TESTNUMBER" mode="text">
 Warning: The file name argument '-k' looks like a flag.
-curl: (1) Protocol "hej" not supported or disabled in libcurl
+curl: (1) Protocol "hej" not supported or disabled
 </file>
 
 # we expect an error since we provide a weird URL


### PR DESCRIPTION
To help users better understand where the URL (and denied scheme) comes from. Also removed "in libcurl" from the message, since the disabling can be done by the application.

The error message now says "not supported" or "disabled" depending on
why it was denied:

~~~
 Protocol "hej" not supported
 Protocol "http" disabled
~~~
And in redirects:

~~~
 Protocol "hej" not supported (in redirect)
 Protocol "http" disabled (in redirect)
~~~

Reported-by: Mauricio Scheffer
Fixes #12465