### PR TITLE
lib: fix variable undeclared error caused by `infof` changes

### DIFF
--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -211,8 +211,10 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     if(status == SEC_E_INSUFFICIENT_MEMORY)
       return CURLE_OUT_OF_MEMORY;
 
+#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
     infof(data, "schannel: InitializeSecurityContext failed: %s",
           Curl_sspi_strerror(status, buffer, sizeof(buffer)));
+#endif
 
     return CURLE_AUTH_ERROR;
   }
@@ -603,8 +605,10 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
       if(status == SEC_E_INSUFFICIENT_MEMORY)
         return CURLE_OUT_OF_MEMORY;
 
+#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
       infof(data, "schannel: InitializeSecurityContext failed: %s",
             Curl_sspi_strerror(status, buffer, sizeof(buffer)));
+#endif
 
       return CURLE_AUTH_ERROR;
     }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2332,10 +2332,10 @@ schannel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     else {
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
       char buffer[STRERROR_LEN];
-#endif
-      *err = CURLE_RECV_ERROR;
       infof(data, "schannel: failed to read data from server: %s",
             Curl_sspi_strerror(sspi_status, buffer, sizeof(buffer)));
+#endif
+      *err = CURLE_RECV_ERROR;
       goto cleanup;
     }
   }


### PR DESCRIPTION
`--disable-verbose` yields `CURL_DISABLE_VERBOSE_STRINGS` defined.
`infof` isn't `Curl_nop_stmt` anymore: dac293c.

Error like this:
```
H:/Free/curl-8.5.0/lib/vauth/digest_sspi.c:215:38: error: 'buffer' undeclared (first use in this function); did you mean 'bufref'?
           Curl_sspi_strerror(status, buffer, sizeof(buffer)));
```
caused by:
https://github.com/curl/curl/commit/dac293cfb7026b1ca4175d88b80f1432d3d3c684#diff-df9247dc0dd19ac0e65c0d2b8cfd61a9082ca1f8d1efac157cd95111e37b6620L137-R135
