### PR TITLE
configure: resurrect check for fork()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3582,6 +3582,7 @@ AC_CHECK_FUNCS([\
   _fseeki64 \
   arc4random \
   fnmatch \
+  fork \
   fseeko \
   geteuid \
   getpass_r \


### PR DESCRIPTION
The check was removed in 2ba804942fda50bbd385c743309a7ec8aca2cf47 but it appears that broke support for NTLM winbind (NTLM_WB).

Reported-by: Benoit Pierre

Fixes https://github.com/curl/curl/issues/12477
Closes #xxxx