### PR TITLE
asyn-thread: use GetAddrInfoExW on >= Windows 8

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -54,6 +54,7 @@
 #  define RESOLVER_ENOMEM  ENOMEM
 #endif
 
+#include "system_win32.h"
 #include "urldata.h"
 #include "sendf.h"
 #include "hostip.h"
@@ -68,12 +69,6 @@
 #include "curl_printf.h"
 #include "curl_memory.h"
 #include "memdebug.h"
-
-#ifdef _WIN32
-#include "system_win32.h"
-/* set in win32_init() */
-extern bool Curl_isWindows8OrGreater;
-#endif
 
 struct resdata {
   struct curltime start;
@@ -361,8 +356,9 @@ query_complete(DWORD err, DWORD bytes, LPWSAOVERLAPPED overlapped)
       memcpy(ca->ai_addr, ai->ai_addr, ss_size);
 
       if(namelen) {
+        size_t i;
         ca->ai_canonname = (void *)((char *)ca->ai_addr + ss_size);
-        for(size_t i = 0; i < namelen; ++i) /* convert wide string to ascii */
+        for(i = 0; i < namelen; ++i) /* convert wide string to ascii */
           ca->ai_canonname[i] = (char)ai->ai_canonname[i];
         ca->ai_canonname[namelen] = '\0';
       }

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -362,7 +362,9 @@ query_complete(DWORD err, DWORD bytes, LPWSAOVERLAPPED overlapped)
 
       if(namelen) {
         ca->ai_canonname = (void *)((char *)ca->ai_addr + ss_size);
-        curl_msnprintf(ca->ai_canonname, namelen, "%S", ai->ai_canonname);
+        for(size_t i = 0; i < namelen; ++i) /* convert wide string to ascii */
+          ca->ai_canonname[i] = (char)ai->ai_canonname[i];
+        ca->ai_canonname[namelen] = '\0';
       }
 
       /* if the return list is empty, this becomes the first element */

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -155,11 +155,11 @@ static bool init_resolve_thread(struct Curl_easy *data,
 struct thread_sync_data_w8
 {
   OVERLAPPED overlapped;
-  ADDRINFOEXW *res;
+  ADDRINFOEXW_ *res;
   HANDLE cancel_ev;
   WCHAR name[256]; /* max domain name is 253 chars */
   WCHAR port[8]; /* port */
-  ADDRINFOEXW hints;
+  ADDRINFOEXW_ hints;
 };
 #endif
 
@@ -305,14 +305,14 @@ static VOID WINAPI
 query_complete(DWORD err, DWORD bytes, LPWSAOVERLAPPED overlapped)
 {
   size_t ss_size;
-  const ADDRINFOEXW* ai;
+  const ADDRINFOEXW_ *ai;
   struct Curl_addrinfo *ca;
   struct Curl_addrinfo *cafirst = NULL;
   struct Curl_addrinfo *calast = NULL;
   struct thread_sync_data *tsd =
     CONTAINING_RECORD(overlapped, struct thread_sync_data, w8.overlapped);
   struct thread_data *td = tsd->td;
-  const ADDRINFOEXW *res = tsd->w8.res;
+  const ADDRINFOEXW_ *res = tsd->w8.res;
   int error = (int)err;
   (void)bytes;
 

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -38,6 +38,7 @@
 
 LARGE_INTEGER Curl_freq;
 bool Curl_isVistaOrGreater;
+bool Curl_isWindows8OrGreater;
 
 /* Handle of iphlpapp.dll */
 static HMODULE s_hIpHlpApiDll = NULL;
@@ -112,6 +113,13 @@ CURLcode Curl_win32_init(long flags)
   }
   else
     Curl_isVistaOrGreater = FALSE;
+
+  if(curlx_verify_windows_version(6, 2, 0, PLATFORM_WINNT,
+                                  VERSION_GREATER_THAN_EQUAL)) {
+    Curl_isWindows8OrGreater = TRUE;
+  }
+  else
+    Curl_isWindows8OrGreater = FALSE;
 
   QueryPerformanceFrequency(&Curl_freq);
   return CURLE_OK;

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -49,11 +49,11 @@ static HMODULE s_ws2_32Dll = NULL;
 /* Pointer to the if_nametoindex function */
 IF_NAMETOINDEX_FN Curl_if_nametoindex = NULL;
 
-void(WSAAPI *ptrFreeAddrInfoExW)(PADDRINFOEXW pAddrInfoEx) = NULL;
+void(WSAAPI *ptrFreeAddrInfoExW)(ADDRINFOEXW_ *pAddrInfoEx) = NULL;
 INT(WSAAPI *ptrGetAddrInfoExCancel)(LPHANDLE lpHandle) = NULL;
 INT(WSAAPI *ptrGetAddrInfoExW)(PCWSTR pName, PCWSTR pServiceName,
-  DWORD dwNameSpace, LPGUID lpNspId, const ADDRINFOEXW *hints,
-  PADDRINFOEXW *ppResult, struct timeval *timeout, LPOVERLAPPED lpOverlapped,
+  DWORD dwNameSpace, LPGUID lpNspId, const ADDRINFOEXW_ *hints,
+  ADDRINFOEXW_ **ppResult, struct timeval *timeout, LPOVERLAPPED lpOverlapped,
   LOOKUP_COMPLETION lpCompletionRoutine, LPHANDLE lpHandle) = NULL;
 
 /* Curl_win32_init() performs win32 global initialization */

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -49,9 +49,9 @@ static HMODULE s_ws2_32Dll = NULL;
 /* Pointer to the if_nametoindex function */
 IF_NAMETOINDEX_FN Curl_if_nametoindex = NULL;
 
-void(WSAAPI *ptrFreeAddrInfoExW)(ADDRINFOEXW_ *pAddrInfoEx) = NULL;
-INT(WSAAPI *ptrGetAddrInfoExCancel)(LPHANDLE lpHandle) = NULL;
-INT(WSAAPI *ptrGetAddrInfoExW)(PCWSTR pName, PCWSTR pServiceName,
+void(WSAAPI *Curl_FreeAddrInfoExW)(ADDRINFOEXW_ *pAddrInfoEx) = NULL;
+int(WSAAPI *Curl_GetAddrInfoExCancel)(LPHANDLE lpHandle) = NULL;
+int(WSAAPI *Curl_GetAddrInfoExW)(PCWSTR pName, PCWSTR pServiceName,
   DWORD dwNameSpace, LPGUID lpNspId, const ADDRINFOEXW_ *hints,
   ADDRINFOEXW_ **ppResult, struct timeval *timeout, LPOVERLAPPED lpOverlapped,
   LOOKUP_COMPLETION lpCompletionRoutine, LPHANDLE lpHandle) = NULL;
@@ -117,11 +117,11 @@ CURLcode Curl_win32_init(long flags)
 
   s_ws2_32Dll = Curl_load_library(TEXT("ws2_32.dll"));
   if(s_ws2_32Dll) {
-    *(FARPROC*)&ptrFreeAddrInfoExW = GetProcAddress(s_ws2_32Dll,
+    *(FARPROC*)&Curl_FreeAddrInfoExW = GetProcAddress(s_ws2_32Dll,
       "FreeAddrInfoExW");
-    *(FARPROC*)&ptrGetAddrInfoExCancel = GetProcAddress(s_ws2_32Dll,
+    *(FARPROC*)&Curl_GetAddrInfoExCancel = GetProcAddress(s_ws2_32Dll,
       "GetAddrInfoExCancel");
-    *(FARPROC*)&ptrGetAddrInfoExW = GetProcAddress(s_ws2_32Dll,
+    *(FARPROC*)&Curl_GetAddrInfoExW = GetProcAddress(s_ws2_32Dll,
       "GetAddrInfoExW");
   }
 
@@ -151,9 +151,9 @@ void Curl_win32_cleanup(long init_flags)
   if(s_ws2_32Dll) {
     FreeLibrary(s_ws2_32Dll);
     s_ws2_32Dll = NULL;
-    ptrFreeAddrInfoExW = NULL;
-    ptrGetAddrInfoExCancel = NULL;
-    ptrGetAddrInfoExW = NULL;
+    Curl_FreeAddrInfoExW = NULL;
+    Curl_GetAddrInfoExCancel = NULL;
+    Curl_GetAddrInfoExW = NULL;
   }
   if(s_hIpHlpApiDll) {
     FreeLibrary(s_hIpHlpApiDll);

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -43,8 +43,18 @@ bool Curl_isWindows8OrGreater;
 /* Handle of iphlpapp.dll */
 static HMODULE s_hIpHlpApiDll = NULL;
 
+/* Handle of ws2_32.dll */
+static HMODULE s_ws2_32Dll = NULL;
+
 /* Pointer to the if_nametoindex function */
 IF_NAMETOINDEX_FN Curl_if_nametoindex = NULL;
+
+void(WSAAPI *ptrFreeAddrInfoExW)(PADDRINFOEXW pAddrInfoEx) = NULL;
+INT(WSAAPI *ptrGetAddrInfoExCancel)(LPHANDLE lpHandle) = NULL;
+INT(WSAAPI *ptrGetAddrInfoExW)(PCWSTR pName, PCWSTR pServiceName,
+  DWORD dwNameSpace, LPGUID lpNspId, const ADDRINFOEXW *hints,
+  PADDRINFOEXW *ppResult, struct timeval *timeout, LPOVERLAPPED lpOverlapped,
+  LOOKUP_COMPLETION lpCompletionRoutine, LPHANDLE lpHandle) = NULL;
 
 /* Curl_win32_init() performs win32 global initialization */
 CURLcode Curl_win32_init(long flags)
@@ -105,6 +115,16 @@ CURLcode Curl_win32_init(long flags)
       Curl_if_nametoindex = pIfNameToIndex;
   }
 
+  s_ws2_32Dll = Curl_load_library(TEXT("ws2_32.dll"));
+  if(s_ws2_32Dll) {
+    *(FARPROC*)&ptrFreeAddrInfoExW = GetProcAddress(s_ws2_32Dll,
+      "FreeAddrInfoExW");
+    *(FARPROC*)&ptrGetAddrInfoExCancel = GetProcAddress(s_ws2_32Dll,
+      "GetAddrInfoExCancel");
+    *(FARPROC*)&ptrGetAddrInfoExW = GetProcAddress(s_ws2_32Dll,
+      "GetAddrInfoExW");
+  }
+
   /* curlx_verify_windows_version must be called during init at least once
      because it has its own initialization routine. */
   if(curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
@@ -128,6 +148,13 @@ CURLcode Curl_win32_init(long flags)
 /* Curl_win32_cleanup() is the opposite of Curl_win32_init() */
 void Curl_win32_cleanup(long init_flags)
 {
+  if(s_ws2_32Dll) {
+    FreeLibrary(s_ws2_32Dll);
+    s_ws2_32Dll = NULL;
+    ptrFreeAddrInfoExW = NULL;
+    ptrGetAddrInfoExCancel = NULL;
+    ptrGetAddrInfoExW = NULL;
+  }
   if(s_hIpHlpApiDll) {
     FreeLibrary(s_hIpHlpApiDll);
     s_hIpHlpApiDll = NULL;

--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -40,28 +40,27 @@ typedef unsigned int(WINAPI *IF_NAMETOINDEX_FN)(const char *);
 /* This is used instead of if_nametoindex if available on Windows */
 extern IF_NAMETOINDEX_FN Curl_if_nametoindex;
 
-#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0600)
-typedef struct addrinfoexW
+/* Identical copy of addrinfoexW/ADDRINFOEXW */
+typedef struct addrinfoexW_
 {
-  int                 ai_flags;
-  int                 ai_family;
-  int                 ai_socktype;
-  int                 ai_protocol;
-  size_t              ai_addrlen;
-  PWSTR               ai_canonname;
-  struct sockaddr    *ai_addr;
-  void               *ai_blob;
-  size_t              ai_bloblen;
-  LPGUID              ai_provider;
-  struct addrinfoexW *ai_next;
-} ADDRINFOEXW, *PADDRINFOEXW, *LPADDRINFOEXW;
-#endif
+  int                  ai_flags;
+  int                  ai_family;
+  int                  ai_socktype;
+  int                  ai_protocol;
+  size_t               ai_addrlen;
+  PWSTR                ai_canonname;
+  struct sockaddr     *ai_addr;
+  void                *ai_blob;
+  size_t               ai_bloblen;
+  LPGUID               ai_provider;
+  struct addrinfoexW_ *ai_next;
+} ADDRINFOEXW_;
 
 typedef void(CALLBACK *LOOKUP_COMPLETION)(DWORD, DWORD, LPWSAOVERLAPPED);
-extern void(WSAAPI *ptrFreeAddrInfoExW)(PADDRINFOEXW);
+extern void(WSAAPI *ptrFreeAddrInfoExW)(ADDRINFOEXW_*);
 extern int(WSAAPI *ptrGetAddrInfoExCancel)(LPHANDLE);
 extern int(WSAAPI *ptrGetAddrInfoExW)(PCWSTR, PCWSTR, DWORD, LPGUID,
-  const ADDRINFOEXW*, PADDRINFOEXW*, struct timeval*, LPOVERLAPPED,
+  const ADDRINFOEXW_*, ADDRINFOEXW_**, struct timeval*, LPOVERLAPPED,
   LOOKUP_COMPLETION, LPHANDLE);
 
 /* This is used to dynamically load DLLs */

--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -57,9 +57,9 @@ typedef struct addrinfoexW_
 } ADDRINFOEXW_;
 
 typedef void(CALLBACK *LOOKUP_COMPLETION)(DWORD, DWORD, LPWSAOVERLAPPED);
-extern void(WSAAPI *ptrFreeAddrInfoExW)(ADDRINFOEXW_*);
-extern int(WSAAPI *ptrGetAddrInfoExCancel)(LPHANDLE);
-extern int(WSAAPI *ptrGetAddrInfoExW)(PCWSTR, PCWSTR, DWORD, LPGUID,
+extern void(WSAAPI *Curl_FreeAddrInfoExW)(ADDRINFOEXW_*);
+extern int(WSAAPI *Curl_GetAddrInfoExCancel)(LPHANDLE);
+extern int(WSAAPI *Curl_GetAddrInfoExW)(PCWSTR, PCWSTR, DWORD, LPGUID,
   const ADDRINFOEXW_*, ADDRINFOEXW_**, struct timeval*, LPOVERLAPPED,
   LOOKUP_COMPLETION, LPHANDLE);
 

--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -30,6 +30,7 @@
 
 extern LARGE_INTEGER Curl_freq;
 extern bool Curl_isVistaOrGreater;
+extern bool Curl_isWindows8OrGreater;
 
 CURLcode Curl_win32_init(long flags);
 void Curl_win32_cleanup(long init_flags);

--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#if defined(_WIN32)
+#ifdef _WIN32
 
 extern LARGE_INTEGER Curl_freq;
 extern bool Curl_isVistaOrGreater;
@@ -39,6 +39,30 @@ typedef unsigned int(WINAPI *IF_NAMETOINDEX_FN)(const char *);
 
 /* This is used instead of if_nametoindex if available on Windows */
 extern IF_NAMETOINDEX_FN Curl_if_nametoindex;
+
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < 0x0600)
+typedef struct addrinfoexW
+{
+  int                 ai_flags;
+  int                 ai_family;
+  int                 ai_socktype;
+  int                 ai_protocol;
+  size_t              ai_addrlen;
+  PWSTR               ai_canonname;
+  struct sockaddr    *ai_addr;
+  void               *ai_blob;
+  size_t              ai_bloblen;
+  LPGUID              ai_provider;
+  struct addrinfoexW *ai_next;
+} ADDRINFOEXW, *PADDRINFOEXW, *LPADDRINFOEXW;
+#endif
+
+typedef void(CALLBACK *LOOKUP_COMPLETION)(DWORD, DWORD, LPWSAOVERLAPPED);
+extern void(WSAAPI *ptrFreeAddrInfoExW)(PADDRINFOEXW);
+extern int(WSAAPI *ptrGetAddrInfoExCancel)(LPHANDLE);
+extern int(WSAAPI *ptrGetAddrInfoExW)(PCWSTR, PCWSTR, DWORD, LPGUID,
+  const ADDRINFOEXW*, PADDRINFOEXW*, struct timeval*, LPOVERLAPPED,
+  LOOKUP_COMPLETION, LPHANDLE);
 
 /* This is used to dynamically load DLLs */
 HMODULE Curl_load_library(LPCTSTR filename);


### PR DESCRIPTION
Use GetAddrInfoExW if available starting from win8 instead of starting a thread for each DNS request
