### PR TITLE
build: enable missing OpenSSF-recommended warnings, with fixes

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -86,8 +86,10 @@ if(PICKY_COMPILER)
       -Wno-sign-conversion                 # clang  2.9  gcc  4.3
       -Wno-system-headers                  # clang  1.0  gcc  3.0
     # -Wpadded                             # clang  2.9  gcc  4.1               # Not used because we cannot change public structs
-      -Wredundant-decls                    # clang  2.7  gcc  4.1
       -Wold-style-definition               # clang  2.7  gcc  3.4
+      -Wredundant-decls                    # clang  2.7  gcc  4.1
+    # -Wsign-conversion                    # clang  2.9  gcc  4.3               # FIXME
+    #   -Wno-error=sign-conversion                                              # FIXME
       -Wstrict-prototypes                  # clang  1.0  gcc  3.3
     # -Wswitch-enum                        # clang  2.7  gcc  4.1               # Not used because this basically disallows default case
       -Wtype-limits                        # clang  2.7  gcc  4.3
@@ -110,6 +112,7 @@ if(PICKY_COMPILER)
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
         -Wlanguage-extension-token         # clang  3.0
+        -Wformat=2                         # clang  3.0  gcc  4.8
       )
       # Enable based on compiler version
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
@@ -135,6 +138,12 @@ if(PICKY_COMPILER)
           -Wextra-semi-stmt                # clang  7.0            appleclang 10.3
         )
       endif()
+      if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0) OR
+         (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 12.4))
+        list(APPEND WPICKY_ENABLE
+          -Wimplicit-fallthrough           # clang  4.0  gcc  7.0  appleclang 12.4  # we have silencing markup for clang 10.0 and above only
+        )
+      endif()
     else()  # gcc
       list(APPEND WPICKY_DETECT
         ${WPICKY_COMMON}
@@ -147,6 +156,7 @@ if(PICKY_COMPILER)
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
           -Wstrict-aliasing=3              #             gcc  4.0
+          -Wtrampolines                    #             gcc  4.3
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.5 AND MINGW)
@@ -156,7 +166,7 @@ if(PICKY_COMPILER)
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8)
         list(APPEND WPICKY_ENABLE
-          -Wformat=2                       # clang  3.0  gcc  4.8 (clang part-default, enabling it fully causes -Wformat-nonliteral warnings)
+          -Wformat=2                       # clang  3.0  gcc  4.8
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
@@ -179,6 +189,7 @@ if(PICKY_COMPILER)
           -Wduplicated-branches            #             gcc  7.0
           -Wformat-overflow=2              #             gcc  7.0
           -Wformat-truncation=2            #             gcc  7.0
+          -Wimplicit-fallthrough           # clang  4.0  gcc  7.0
           -Wrestrict                       #             gcc  7.0
         )
       endif()

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -23,8 +23,10 @@
 ###########################################################################
 include(CheckCCompilerFlag)
 
+unset(WPICKY)
+
 if(CURL_WERROR AND CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic-errors")
+  set(WPICKY "${WPICKY} -pedantic-errors")
 endif()
 
 if(PICKY_COMPILER)
@@ -206,8 +208,6 @@ if(PICKY_COMPILER)
 
     #
 
-    unset(WPICKY)
-
     foreach(_CCOPT IN LISTS WPICKY_ENABLE)
       set(WPICKY "${WPICKY} ${_CCOPT}")
     endforeach()
@@ -224,8 +224,10 @@ if(PICKY_COMPILER)
         set(WPICKY "${WPICKY} ${_CCOPT}")
       endif()
     endforeach()
-
-    message(STATUS "Picky compiler options:${WPICKY}")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WPICKY}")
   endif()
+endif()
+
+if(WPICKY)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WPICKY}")
+  message(STATUS "Picky compiler options:${WPICKY}")
 endif()

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -23,6 +23,10 @@
 ###########################################################################
 include(CheckCCompilerFlag)
 
+if(CURL_WERROR AND CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pedantic-errors")
+endif()
+
 if(PICKY_COMPILER)
   if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 

--- a/docs/examples/chkspeed.c
+++ b/docs/examples/chkspeed.c
@@ -126,15 +126,17 @@ int main(int argc, char *argv[])
             default:
               fprintf(stderr, "\r%s: invalid parameter %s\n",
                       appname, *argv + 3);
-              exit(1);
+              return 1;
             }
             break;
           }
-          /* FALLTHROUGH */
+          fprintf(stderr, "\r%s: invalid or unknown option %s\n",
+                  appname, *argv);
+          return 1;
         default:
           fprintf(stderr, "\r%s: invalid or unknown option %s\n",
                   appname, *argv);
-          exit(1);
+          return 1;
         }
       }
       else {

--- a/docs/examples/debug.c
+++ b/docs/examples/debug.c
@@ -95,10 +95,7 @@ int my_trace(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "== Info: %s", data);
-    /* FALLTHROUGH */
-  default: /* in case a new one is introduced to shock us */
     return 0;
-
   case CURLINFO_HEADER_OUT:
     text = "=> Send header";
     break;
@@ -117,6 +114,8 @@ int my_trace(CURL *handle, curl_infotype type,
   case CURLINFO_SSL_DATA_IN:
     text = "<= Recv SSL data";
     break;
+  default: /* in case a new one is introduced to shock us */
+    return 0;
   }
 
   dump(text, stderr, (unsigned char *)data, size, config->trace_ascii);

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -115,10 +115,7 @@ int my_trace(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "== %u Info: %s", num, data);
-    /* FALLTHROUGH */
-  default: /* in case a new one is introduced to shock us */
     return 0;
-
   case CURLINFO_HEADER_OUT:
     text = "=> Send header";
     break;
@@ -137,6 +134,8 @@ int my_trace(CURL *handle, curl_infotype type,
   case CURLINFO_SSL_DATA_IN:
     text = "<= Recv SSL data";
     break;
+  default: /* in case a new one is introduced to shock us */
+    return 0;
   }
 
   dump(text, num, (unsigned char *)data, size, 1);

--- a/docs/examples/http2-serverpush.c
+++ b/docs/examples/http2-serverpush.c
@@ -100,10 +100,7 @@ int my_trace(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "== Info: %s", data);
-    /* FALLTHROUGH */
-  default: /* in case a new one is introduced to shock us */
     return 0;
-
   case CURLINFO_HEADER_OUT:
     text = "=> Send header";
     break;
@@ -122,6 +119,8 @@ int my_trace(CURL *handle, curl_infotype type,
   case CURLINFO_SSL_DATA_IN:
     text = "<= Recv SSL data";
     break;
+  default: /* in case a new one is introduced to shock us */
+    return 0;
   }
 
   dump(text, (unsigned char *)data, size, 1);

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -133,10 +133,7 @@ int my_trace(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "%s [%d] Info: %s", timebuf, num, data);
-    /* FALLTHROUGH */
-  default: /* in case a new one is introduced to shock us */
     return 0;
-
   case CURLINFO_HEADER_OUT:
     text = "=> Send header";
     break;
@@ -155,6 +152,8 @@ int my_trace(CURL *handle, curl_infotype type,
   case CURLINFO_SSL_DATA_IN:
     text = "<= Recv SSL data";
     break;
+  default: /* in case a new one is introduced to shock us */
+    return 0;
   }
 
   dump(text, num, (unsigned char *)data, size, 1);

--- a/docs/examples/multi-debugcallback.c
+++ b/docs/examples/multi-debugcallback.c
@@ -100,10 +100,7 @@ int my_trace(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "== Info: %s", data);
-    /* FALLTHROUGH */
-  default: /* in case a new one is introduced to shock us */
     return 0;
-
   case CURLINFO_HEADER_OUT:
     text = "=> Send header";
     break;
@@ -116,6 +113,8 @@ int my_trace(CURL *handle, curl_infotype type,
   case CURLINFO_DATA_IN:
     text = "<= Recv data";
     break;
+  default: /* in case a new one is introduced to shock us */
+    return 0;
   }
 
   dump(text, stderr, data, size, TRUE);

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -36,7 +36,10 @@ extern "C" {
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #ifdef __MINGW32__
-#ifdef __MINGW_PRINTF_FORMAT
+#ifdef __clang__
+#define CURL_TEMP_PRINTF(fmt, arg) \
+  __attribute__((format(printf, fmt, arg)))
+#elif defined(__MINGW_PRINTF_FORMAT)
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -41,7 +41,8 @@ extern "C" {
   __attribute__((format(__MINGW_PRINTF_FORMAT, a, b)))
 #endif
 #else
-#define CURL_TEMP_PRINTF(a,b) __attribute__ ((format(printf, a, b)))
+#define CURL_TEMP_PRINTF(a,b) \
+  __attribute__((format(printf, a, b)))
 #endif
 #else
 #define CURL_TEMP_PRINTF(a,b)

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -37,17 +37,17 @@ extern "C" {
   !defined(CURL_NO_FMT_CHECKS)
 #ifdef __MINGW32__
 #ifdef __MINGW_PRINTF_FORMAT
-#define CURL_TEMP_PRINTF(a,b) \
-  __attribute__((format(__MINGW_PRINTF_FORMAT, a, b)))
+#define CURL_TEMP_PRINTF(fmt, arg) \
+  __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else
-#define CURL_TEMP_PRINTF(a,b)
+#define CURL_TEMP_PRINTF(fmt, arg)
 #endif
 #else
-#define CURL_TEMP_PRINTF(a,b) \
-  __attribute__((format(printf, a, b)))
+#define CURL_TEMP_PRINTF(fmt, arg) \
+  __attribute__((format(printf, fmt, arg)))
 #endif
 #else
-#define CURL_TEMP_PRINTF(a,b)
+#define CURL_TEMP_PRINTF(fmt, arg)
 #endif
 
 CURL_EXTERN int curl_mprintf(const char *format, ...) CURL_TEMP_PRINTF(1, 2);

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -34,8 +34,15 @@ extern "C" {
 
 #if (defined(__GNUC__) || defined(__clang__)) &&                        \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
-  !defined(__MINGW32__) && !defined(CURL_NO_FMT_CHECKS)
+  !defined(CURL_NO_FMT_CHECKS)
+#ifdef __MINGW32__
+#ifdef __MINGW_PRINTF_FORMAT
+#define CURL_TEMP_PRINTF(a,b) \
+  __attribute__((format(__MINGW_PRINTF_FORMAT, a, b)))
+#endif
+#else
 #define CURL_TEMP_PRINTF(a,b) __attribute__ ((format(printf, a, b)))
+#endif
 #else
 #define CURL_TEMP_PRINTF(a,b)
 #endif

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -39,6 +39,8 @@ extern "C" {
 #ifdef __MINGW_PRINTF_FORMAT
 #define CURL_TEMP_PRINTF(a,b) \
   __attribute__((format(__MINGW_PRINTF_FORMAT, a, b)))
+#else
+#define CURL_TEMP_PRINTF(a,b)
 #endif
 #else
 #define CURL_TEMP_PRINTF(a,b) \

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -35,14 +35,9 @@ extern "C" {
 #if (defined(__GNUC__) || defined(__clang__)) &&                        \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
-#ifdef __MINGW32__
-#ifdef __clang__
-#define CURL_TEMP_PRINTF(fmt, arg) \
-  __attribute__((format(printf, fmt, arg)))
-#else
+#if defined(__MINGW32__) && !defined(__clang__)
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((format(gnu_printf, fmt, arg)))
-#endif
 #else
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((format(printf, fmt, arg)))

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -39,11 +39,9 @@ extern "C" {
 #ifdef __clang__
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((format(printf, fmt, arg)))
-#elif defined(__MINGW_PRINTF_FORMAT)
-#define CURL_TEMP_PRINTF(fmt, arg) \
-  __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else
-#define CURL_TEMP_PRINTF(fmt, arg)
+#define CURL_TEMP_PRINTF(fmt, arg) \
+  __attribute__((format(gnu_printf, fmt, arg)))
 #endif
 #else
 #define CURL_TEMP_PRINTF(fmt, arg) \

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -183,7 +183,7 @@ static void h1_tunnel_go_state(struct Curl_cfilter *cf,
     infof(data, "CONNECT phase completed");
     data->state.authproxy.done = TRUE;
     data->state.authproxy.multipass = FALSE;
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case H1_TUNNEL_FAILED:
     if(new_state == H1_TUNNEL_FAILED)
       CURL_TRC_CF(data, cf, "new tunnel state 'failed'");
@@ -912,7 +912,7 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
       if(result)
         goto out;
       h1_tunnel_go_state(cf, ts, H1_TUNNEL_CONNECT, data);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case H1_TUNNEL_CONNECT:
       /* see that the request is completely sent */
@@ -921,7 +921,7 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
       if(result || !done)
         goto out;
       h1_tunnel_go_state(cf, ts, H1_TUNNEL_RECEIVE, data);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case H1_TUNNEL_RECEIVE:
       /* read what is there */
@@ -936,7 +936,7 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
         goto out;
       /* got it */
       h1_tunnel_go_state(cf, ts, H1_TUNNEL_RESPONSE, data);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case H1_TUNNEL_RESPONSE:
       CURL_TRC_CF(data, cf, "CONNECT response");

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -183,7 +183,7 @@ static void h1_tunnel_go_state(struct Curl_cfilter *cf,
     infof(data, "CONNECT phase completed");
     data->state.authproxy.done = TRUE;
     data->state.authproxy.multipass = FALSE;
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case H1_TUNNEL_FAILED:
     if(new_state == H1_TUNNEL_FAILED)
       CURL_TRC_CF(data, cf, "new tunnel state 'failed'");
@@ -912,7 +912,7 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
       if(result)
         goto out;
       h1_tunnel_go_state(cf, ts, H1_TUNNEL_CONNECT, data);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case H1_TUNNEL_CONNECT:
       /* see that the request is completely sent */
@@ -921,7 +921,7 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
       if(result || !done)
         goto out;
       h1_tunnel_go_state(cf, ts, H1_TUNNEL_RECEIVE, data);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case H1_TUNNEL_RECEIVE:
       /* read what is there */
@@ -936,7 +936,7 @@ static CURLcode H1_CONNECT(struct Curl_cfilter *cf,
         goto out;
       /* got it */
       h1_tunnel_go_state(cf, ts, H1_TUNNEL_RESPONSE, data);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case H1_TUNNEL_RESPONSE:
       CURL_TRC_CF(data, cf, "CONNECT response");

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -155,7 +155,7 @@ static void h2_tunnel_go_state(struct Curl_cfilter *cf,
     infof(data, "CONNECT phase completed");
     data->state.authproxy.done = TRUE;
     data->state.authproxy.multipass = FALSE;
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case H2_TUNNEL_FAILED:
     if(new_state == H2_TUNNEL_FAILED)
       CURL_TRC_CF(data, cf, "[%d] new tunnel state 'failed'", ts->stream_id);
@@ -1033,7 +1033,7 @@ static CURLcode H2_CONNECT(struct Curl_cfilter *cf,
       if(result)
         goto out;
       h2_tunnel_go_state(cf, ts, H2_TUNNEL_CONNECT, data);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case H2_TUNNEL_CONNECT:
       /* see that the request is completely sent */
@@ -1052,7 +1052,7 @@ static CURLcode H2_CONNECT(struct Curl_cfilter *cf,
         result = CURLE_OK;
         goto out;
       }
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case H2_TUNNEL_RESPONSE:
       DEBUGASSERT(ts->has_final_response);

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -155,7 +155,7 @@ static void h2_tunnel_go_state(struct Curl_cfilter *cf,
     infof(data, "CONNECT phase completed");
     data->state.authproxy.done = TRUE;
     data->state.authproxy.multipass = FALSE;
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case H2_TUNNEL_FAILED:
     if(new_state == H2_TUNNEL_FAILED)
       CURL_TRC_CF(data, cf, "[%d] new tunnel state 'failed'", ts->stream_id);
@@ -1033,7 +1033,7 @@ static CURLcode H2_CONNECT(struct Curl_cfilter *cf,
       if(result)
         goto out;
       h2_tunnel_go_state(cf, ts, H2_TUNNEL_CONNECT, data);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case H2_TUNNEL_CONNECT:
       /* see that the request is completely sent */
@@ -1052,7 +1052,7 @@ static CURLcode H2_CONNECT(struct Curl_cfilter *cf,
         result = CURLE_OK;
         goto out;
       }
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case H2_TUNNEL_RESPONSE:
       DEBUGASSERT(ts->has_final_response);

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -125,7 +125,7 @@ static CURLcode cf_haproxy_connect(struct Curl_cfilter *cf,
     if(result)
       goto out;
     ctx->state = HAPROXY_SEND;
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case HAPROXY_SEND:
     len = Curl_dyn_len(&ctx->data_out);
     if(len > 0) {
@@ -141,7 +141,7 @@ static CURLcode cf_haproxy_connect(struct Curl_cfilter *cf,
       }
     }
     ctx->state = HAPROXY_DONE;
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   default:
     Curl_dyn_free(&ctx->data_out);
     break;

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -125,7 +125,7 @@ static CURLcode cf_haproxy_connect(struct Curl_cfilter *cf,
     if(result)
       goto out;
     ctx->state = HAPROXY_SEND;
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case HAPROXY_SEND:
     len = Curl_dyn_len(&ctx->data_out);
     if(len > 0) {
@@ -141,7 +141,7 @@ static CURLcode cf_haproxy_connect(struct Curl_cfilter *cf,
       }
     }
     ctx->state = HAPROXY_DONE;
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   default:
     Curl_dyn_free(&ctx->data_out);
     break;

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -266,7 +266,7 @@ static CURLcode cf_hc_connect(struct Curl_cfilter *cf,
       cf_hc_baller_init(&ctx->h21_baller, cf, data, "h21",
                        cf->conn->transport);
     ctx->state = CF_HC_CONNECT;
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
 
   case CF_HC_CONNECT:
     if(cf_hc_baller_is_active(&ctx->h3_baller)) {

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -266,7 +266,7 @@ static CURLcode cf_hc_connect(struct Curl_cfilter *cf,
       cf_hc_baller_init(&ctx->h21_baller, cf, data, "h21",
                        cf->conn->transport);
     ctx->state = CF_HC_CONNECT;
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
 
   case CF_HC_CONNECT:
     if(cf_hc_baller_is_active(&ctx->h3_baller)) {

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -983,20 +983,14 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
   if(result)
     goto out;
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
-  {
-    const char *ipmsg;
 #ifdef ENABLE_IPV6
-    if(ctx->addr.family == AF_INET6) {
-      set_ipv6_v6only(ctx->sock, 0);
-      ipmsg = "  Trying [%s]:%d...";
-    }
-    else
-#endif
-      ipmsg = "  Trying %s:%d...";
-    infof(data, ipmsg, ctx->r_ip, ctx->r_port);
+  if(ctx->addr.family == AF_INET6) {
+    set_ipv6_v6only(ctx->sock, 0);
+    infof(data, "  Trying [%s]:%d...", ctx->r_ip, ctx->r_port);
   }
+  else
 #endif
+    infof(data, "  Trying %s:%d...", ctx->r_ip, ctx->r_port);
 
 #ifdef ENABLE_IPV6
   is_tcp = (ctx->addr.family == AF_INET

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1568,7 +1568,7 @@ static CURLcode cf_socket_query(struct Curl_cfilter *cf,
         *when = ctx->first_byte_at;
         break;
       }
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     default:
       *when = ctx->connected_at;
       break;

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -163,7 +163,8 @@ tcpkeepalive(struct Curl_easy *data,
   /* only set IDLE and INTVL if setting KEEPALIVE is successful */
   if(setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE,
         (void *)&optval, sizeof(optval)) < 0) {
-    infof(data, "Failed to set SO_KEEPALIVE on fd %d", sockfd);
+    infof(data, "Failed to set SO_KEEPALIVE on fd %" CURL_FORMAT_SOCKET_T,
+          sockfd);
   }
   else {
 #if defined(SIO_KEEPALIVE_VALS)
@@ -178,8 +179,9 @@ tcpkeepalive(struct Curl_easy *data,
     vals.keepaliveinterval = optval;
     if(WSAIoctl(sockfd, SIO_KEEPALIVE_VALS, (LPVOID) &vals, sizeof(vals),
                 NULL, 0, &dummy, NULL, NULL) != 0) {
-      infof(data, "Failed to set SIO_KEEPALIVE_VALS on fd %d: %d",
-            (int)sockfd, WSAGetLastError());
+      infof(data, "Failed to set SIO_KEEPALIVE_VALS on fd "
+                  "%" CURL_FORMAT_SOCKET_T ": %d",
+                  sockfd, WSAGetLastError());
     }
 #else
 #ifdef TCP_KEEPIDLE
@@ -187,7 +189,8 @@ tcpkeepalive(struct Curl_easy *data,
     KEEPALIVE_FACTOR(optval);
     if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPIDLE,
           (void *)&optval, sizeof(optval)) < 0) {
-      infof(data, "Failed to set TCP_KEEPIDLE on fd %d", sockfd);
+      infof(data, "Failed to set TCP_KEEPIDLE on fd %" CURL_FORMAT_SOCKET_T,
+            sockfd);
     }
 #elif defined(TCP_KEEPALIVE)
     /* Mac OS X style */
@@ -195,7 +198,8 @@ tcpkeepalive(struct Curl_easy *data,
     KEEPALIVE_FACTOR(optval);
     if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPALIVE,
       (void *)&optval, sizeof(optval)) < 0) {
-      infof(data, "Failed to set TCP_KEEPALIVE on fd %d", sockfd);
+      infof(data, "Failed to set TCP_KEEPALIVE on fd %" CURL_FORMAT_SOCKET_T,
+            sockfd);
     }
 #endif
 #ifdef TCP_KEEPINTVL
@@ -203,7 +207,8 @@ tcpkeepalive(struct Curl_easy *data,
     KEEPALIVE_FACTOR(optval);
     if(setsockopt(sockfd, IPPROTO_TCP, TCP_KEEPINTVL,
           (void *)&optval, sizeof(optval)) < 0) {
-      infof(data, "Failed to set TCP_KEEPINTVL on fd %d", sockfd);
+      infof(data, "Failed to set TCP_KEEPINTVL on fd %" CURL_FORMAT_SOCKET_T,
+            sockfd);
     }
 #endif
 #endif

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1574,7 +1574,7 @@ static CURLcode cf_socket_query(struct Curl_cfilter *cf,
         *when = ctx->first_byte_at;
         break;
       }
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     default:
       *when = ctx->connected_at;
       break;

--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -46,6 +46,8 @@ struct Curl_sockaddr_ex;
 
 #if SIZEOF_CURL_SOCKET_T < 8
 # define CURL_FORMAT_SOCKET_T "d"
+#elif defined(__MINGW32__)
+# define CURL_FORMAT_SOCKET_T "zd"
 #else
 # define CURL_FORMAT_SOCKET_T "qd"
 #endif

--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -34,25 +34,6 @@ struct Curl_easy;
 struct connectdata;
 struct Curl_sockaddr_ex;
 
-#ifndef SIZEOF_CURL_SOCKET_T
-/* configure and cmake check and set the define */
-# ifdef _WIN64
-#  define SIZEOF_CURL_SOCKET_T 8
-# else
-/* default guess */
-#  define SIZEOF_CURL_SOCKET_T 4
-# endif
-#endif
-
-#if SIZEOF_CURL_SOCKET_T < 8
-# define CURL_FORMAT_SOCKET_T "d"
-#elif defined(__MINGW32__)
-# define CURL_FORMAT_SOCKET_T "zd"
-#else
-# define CURL_FORMAT_SOCKET_T "qd"
-#endif
-
-
 /*
  * The Curl_sockaddr_ex structure is basically libcurl's external API
  * curl_sockaddr structure with enough space available to directly hold any

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -908,7 +908,7 @@ static CURLcode cf_he_connect(struct Curl_cfilter *cf,
       if(result)
         return result;
       ctx->state = SCFST_WAITING;
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SCFST_WAITING:
       result = is_connected(cf, data, done);
       if(!result && *done) {

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -908,7 +908,7 @@ static CURLcode cf_he_connect(struct Curl_cfilter *cf,
       if(result)
         return result;
       ctx->state = SCFST_WAITING;
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case SCFST_WAITING:
       result = is_connected(cf, data, done);
       if(!result && *done) {

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -925,7 +925,7 @@ Curl_cookie_add(struct Curl_easy *data,
         if(!co->spath)
           badcookie = TRUE;
         fields++; /* add a field and fall down to secure */
-        CURL_FALLTHROUGH();
+        FALLTHROUGH();
       case 3:
         co->secure = FALSE;
         if(strcasecompare(ptr, "TRUE")) {

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -925,7 +925,7 @@ Curl_cookie_add(struct Curl_easy *data,
         if(!co->spath)
           badcookie = TRUE;
         fields++; /* add a field and fall down to secure */
-        /* FALLTHROUGH */
+        CURL_FALLTHROUGH();
       case 3:
         co->secure = FALSE;
         if(strcasecompare(ptr, "TRUE")) {

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -481,7 +481,7 @@ CURLcode Curl_output_ntlm_wb(struct Curl_easy *data, struct connectdata *conn,
     /* connection is already authenticated,
      * don't send a header in future requests */
     *state = NTLMSTATE_LAST;
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case NTLMSTATE_LAST:
     Curl_safefree(*allocuserpwd);
     authp->done = TRUE;

--- a/lib/curl_ntlm_wb.c
+++ b/lib/curl_ntlm_wb.c
@@ -481,7 +481,7 @@ CURLcode Curl_output_ntlm_wb(struct Curl_easy *data, struct connectdata *conn,
     /* connection is already authenticated,
      * don't send a header in future requests */
     *state = NTLMSTATE_LAST;
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case NTLMSTATE_LAST:
     Curl_safefree(*allocuserpwd);
     authp->done = TRUE;

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -648,6 +648,17 @@
 #endif
 #endif
 
+/* fallthrough attribute */
+
+#if !defined(CURL_FALLTHROUGH)
+#if (defined(__GNUC__) && __GNUC__ >= 7) || \
+    (defined(__clang__) && __clang_major__ >= 10)
+#  define CURL_FALLTHROUGH()  __attribute__((fallthrough))
+#else
+#  define CURL_FALLTHROUGH()  do {} while (0)
+#endif
+#endif
+
 /*
  * Include macros and defines that should only be processed once.
  */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -437,20 +437,20 @@
 
 #ifndef SIZEOF_CURL_SOCKET_T
 /* configure and cmake check and set the define */
-# ifdef _WIN64
-#  define SIZEOF_CURL_SOCKET_T 8
-# else
+#  ifdef _WIN64
+#    define SIZEOF_CURL_SOCKET_T 8
+#  else
 /* default guess */
-#  define SIZEOF_CURL_SOCKET_T 4
-# endif
+#    define SIZEOF_CURL_SOCKET_T 4
+#  endif
 #endif
 
 #if SIZEOF_CURL_SOCKET_T < 8
-# define CURL_FORMAT_SOCKET_T "d"
+#  define CURL_FORMAT_SOCKET_T "d"
 #elif defined(__MINGW32__)
-# define CURL_FORMAT_SOCKET_T "zd"
+#  define CURL_FORMAT_SOCKET_T "zd"
 #else
-# define CURL_FORMAT_SOCKET_T "qd"
+#  define CURL_FORMAT_SOCKET_T "qd"
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -668,6 +668,8 @@
 #ifdef __MINGW_PRINTF_FORMAT
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
+#else
+#define CURL_PRINTF(fmt, arg)
 #endif
 #else
 #define CURL_PRINTF(fmt, arg) \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -650,12 +650,12 @@
 
 /* fallthrough attribute */
 
-#if !defined(CURL_FALLTHROUGH)
+#if !defined(FALLTHROUGH)
 #if (defined(__GNUC__) && __GNUC__ >= 7) || \
     (defined(__clang__) && __clang_major__ >= 10)
-#  define CURL_FALLTHROUGH()  __attribute__((fallthrough))
+#  define FALLTHROUGH()  __attribute__((fallthrough))
 #else
-#  define CURL_FALLTHROUGH()  do {} while (0)
+#  define FALLTHROUGH()  do {} while (0)
 #endif
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -670,11 +670,9 @@
    our local macro. Step in and use `__printf__` instead as a workaround. */
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((format(__printf__, fmt, arg)))
-#elif defined(__MINGW_PRINTF_FORMAT)
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else
-#define CURL_PRINTF(fmt, arg)
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(gnu_printf, fmt, arg)))
 #endif
 #else
 #define CURL_PRINTF(fmt, arg) \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -664,16 +664,9 @@
 #if (defined(__GNUC__) || defined(__clang__)) &&                        \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
-#ifdef __MINGW32__
-#ifdef __clang__
-/* mingw sets __MINGW_PRINTF_FORMAT to `printf` for clang. This collides with
-   our local macro. Step in and use `__printf__` instead as a workaround. */
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(__printf__, fmt, arg)))
-#else
+#if defined(__MINGW32__) && !defined(__clang__)
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((format(gnu_printf, fmt, arg)))
-#endif
 #else
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((format(__printf__, fmt, arg)))

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -663,8 +663,15 @@
 
 #if (defined(__GNUC__) || defined(__clang__)) &&                        \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
-  !defined(__MINGW32__) && !defined(CURL_NO_FMT_CHECKS)
+  !defined(CURL_NO_FMT_CHECKS)
+#ifdef __MINGW32__
+#ifdef __MINGW_PRINTF_FORMAT
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
+#endif
+#else
 #define CURL_PRINTF(fmt, arg)  __attribute__((format(__printf__, fmt, arg)))
+#endif
 #else
 #define CURL_PRINTF(fmt, arg)
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -259,6 +259,13 @@
 
 #include <curl/system.h>
 
+#ifdef  __MINGW32__
+#  undef CURL_FORMAT_CURL_OFF_T
+#  undef CURL_FORMAT_CURL_OFF_TU
+#  define CURL_FORMAT_CURL_OFF_T   "lld"
+#  define CURL_FORMAT_CURL_OFF_TU  "llu"
+#endif
+
 /*
  * Use getaddrinfo to resolve the IPv4 address literal. If the current network
  * interface doesn't support IPv4, but supports IPv6, NAT64, and DNS64,

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -670,7 +670,8 @@
   __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #endif
 #else
-#define CURL_PRINTF(fmt, arg)  __attribute__((format(__printf__, fmt, arg)))
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(__printf__, fmt, arg)))
 #endif
 #else
 #define CURL_PRINTF(fmt, arg)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -435,6 +435,24 @@
 #define SIZEOF_TIME_T 4
 #endif
 
+#ifndef SIZEOF_CURL_SOCKET_T
+/* configure and cmake check and set the define */
+# ifdef _WIN64
+#  define SIZEOF_CURL_SOCKET_T 8
+# else
+/* default guess */
+#  define SIZEOF_CURL_SOCKET_T 4
+# endif
+#endif
+
+#if SIZEOF_CURL_SOCKET_T < 8
+# define CURL_FORMAT_SOCKET_T "d"
+#elif defined(__MINGW32__)
+# define CURL_FORMAT_SOCKET_T "zd"
+#else
+# define CURL_FORMAT_SOCKET_T "qd"
+#endif
+
 /*
  * Default sizeof(off_t) in case it hasn't been defined in config file.
  */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -659,6 +659,16 @@
 #endif
 #endif
 
+/* based on logic in "curl/mprintf.h" */
+
+#if (defined(__GNUC__) || defined(__clang__)) &&                        \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
+  !defined(__MINGW32__) && !defined(CURL_NO_FMT_CHECKS)
+#define CURL_PRINTF(fmt, arg)  __attribute__((format(__printf__, fmt, arg)))
+#else
+#define CURL_PRINTF(fmt, arg)
+#endif
+
 /*
  * Include macros and defines that should only be processed once.
  */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -665,7 +665,12 @@
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #ifdef __MINGW32__
-#ifdef __MINGW_PRINTF_FORMAT
+#ifdef __clang__
+/* mingw sets __MINGW_PRINTF_FORMAT to `printf` for clang. This collides with
+   our local macro. Step in and use `__printf__` instead as a workaround. */
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(__printf__, fmt, arg)))
+#elif defined(__MINGW_PRINTF_FORMAT)
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -92,7 +92,14 @@ void Curl_failf(struct Curl_easy *data, const char *fmt, ...)
     int len;
     char error[CURL_ERROR_SIZE + 2];
     va_start(ap, fmt);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     len = mvsnprintf(error, CURL_ERROR_SIZE, fmt, ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
     if(data->set.errorbuffer && !data->state.errorbuf) {
       strcpy(data->set.errorbuffer, error);
@@ -118,7 +125,14 @@ void Curl_infof(struct Curl_easy *data, const char *fmt, ...)
     int len;
     char buffer[MAXINFO + 2];
     va_start(ap, fmt);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     len = mvsnprintf(buffer, MAXINFO, fmt, ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     va_end(ap);
     buffer[len++] = '\n';
     buffer[len] = '\0';
@@ -136,7 +150,14 @@ void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
     char buffer[MAXINFO + 2];
     len = msnprintf(buffer, MAXINFO, "[%s] ", cf->cft->name);
     va_start(ap, fmt);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     len += mvsnprintf(buffer + len, MAXINFO - len, fmt, ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     va_end(ap);
     buffer[len++] = '\n';
     buffer[len] = '\0';

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -58,14 +58,7 @@ void Curl_debug(struct Curl_easy *data, curl_infotype type,
  * Output a failure message on registered callbacks for transfer.
  */
 void Curl_failf(struct Curl_easy *data,
-#if defined(__GNUC__) && !defined(printf) &&                    \
-  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) && \
-  !defined(__MINGW32__)
-                       const char *fmt, ...)
-                       __attribute__((format(printf, 2, 3)));
-#else
-                       const char *fmt, ...);
-#endif
+                const char *fmt, ...) CURL_PRINTF(2, 3);
 
 #define failf Curl_failf
 
@@ -102,26 +95,14 @@ void Curl_failf(struct Curl_easy *data,
  * Output an informational message when transfer's verbose logging is enabled.
  */
 void Curl_infof(struct Curl_easy *data,
-#if defined(__GNUC__) && !defined(printf) && defined(CURL_HAVE_C99) &&  \
-  !defined(__MINGW32__)
-                       const char *fmt, ...)
-                       __attribute__((format(printf, 2, 3)));
-#else
-                       const char *fmt, ...);
-#endif
+                const char *fmt, ...) CURL_PRINTF(2, 3);
 
 /**
  * Output an informational message when both transfer's verbose logging
  * and connection filters verbose logging are enabled.
  */
 void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
-#if defined(__GNUC__) && !defined(printf) && defined(CURL_HAVE_C99) && \
-  !defined(__MINGW32__)
-                      const char *fmt, ...)
-                      __attribute__((format(printf, 3, 4)));
-#else
-                      const char *fmt, ...);
-#endif
+                       const char *fmt, ...) CURL_PRINTF(3, 4);
 
 #else /* defined(CURL_DISABLE_VERBOSE_STRINGS) */
 /* All informational messages are not compiled in for size savings */

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -132,7 +132,14 @@ static CURLcode sendf(curl_socket_t sockfd, struct Curl_easy *data,
   char *sptr;
   va_list ap;
   va_start(ap, fmt);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
   s = vaprintf(fmt, ap); /* returns an allocated string */
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
   va_end(ap);
   if(!s)
     return CURLE_OUT_OF_MEMORY; /* failure */

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -123,6 +123,9 @@ static char *unescape_word(const char *input)
 
 /* sendf() sends formatted data to the server */
 static CURLcode sendf(curl_socket_t sockfd, struct Curl_easy *data,
+                      const char *fmt, ...) CURL_PRINTF(3, 4);
+
+static CURLcode sendf(curl_socket_t sockfd, struct Curl_easy *data,
                       const char *fmt, ...)
 {
   ssize_t bytes_written;

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -201,7 +201,14 @@ CURLcode Curl_dyn_vaddf(struct dynbuf *s, const char *fmt, va_list ap)
     return CURLE_OK;
 #else
   char *str;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
   str = vaprintf(fmt, ap); /* this allocs a new string to append */
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
   if(str) {
     CURLcode result = dyn_nappend(s, (unsigned char *)str, strlen(str));

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -61,9 +61,9 @@ CURLcode Curl_dyn_addn(struct dynbuf *s, const void *mem, size_t len)
 CURLcode Curl_dyn_add(struct dynbuf *s, const char *str)
   WARN_UNUSED_RESULT;
 CURLcode Curl_dyn_addf(struct dynbuf *s, const char *fmt, ...)
-  WARN_UNUSED_RESULT;
+  WARN_UNUSED_RESULT CURL_PRINTF(2, 3);
 CURLcode Curl_dyn_vaddf(struct dynbuf *s, const char *fmt, va_list ap)
-  WARN_UNUSED_RESULT;
+  WARN_UNUSED_RESULT CURL_PRINTF(2, 0);
 void Curl_dyn_reset(struct dynbuf *s);
 CURLcode Curl_dyn_tail(struct dynbuf *s, size_t trail);
 CURLcode Curl_dyn_setlen(struct dynbuf *s, size_t set);

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -480,13 +480,15 @@ static int events_socket(struct Curl_easy *easy,      /* easy handle */
           ev->list = nxt;
         free(m);
         m = nxt;
-        infof(easy, "socket cb: socket %d REMOVED", s);
+        infof(easy, "socket cb: socket %" CURL_FORMAT_SOCKET_T
+              " REMOVED", s);
       }
       else {
         /* The socket 's' is already being monitored, update the activity
            mask. Convert from libcurl bitmask to the poll one. */
         m->socket.events = socketcb2poll(what);
-        infof(easy, "socket cb: socket %d UPDATED as %s%s", s,
+        infof(easy, "socket cb: socket %" CURL_FORMAT_SOCKET_T
+              " UPDATED as %s%s", s,
               (what&CURL_POLL_IN)?"IN":"",
               (what&CURL_POLL_OUT)?"OUT":"");
       }
@@ -510,7 +512,8 @@ static int events_socket(struct Curl_easy *easy,      /* easy handle */
         m->socket.events = socketcb2poll(what);
         m->socket.revents = 0;
         ev->list = m;
-        infof(easy, "socket cb: socket %d ADDED as %s%s", s,
+        infof(easy, "socket cb: socket %" CURL_FORMAT_SOCKET_T
+              " ADDED as %s%s", s,
               (what&CURL_POLL_IN)?"IN":"",
               (what&CURL_POLL_OUT)?"OUT":"");
       }
@@ -599,8 +602,9 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
         if(fds[i].revents) {
           /* socket activity, tell libcurl */
           int act = poll2cselect(fds[i].revents); /* convert */
-          infof(multi->easyp, "call curl_multi_socket_action(socket %d)",
-                fds[i].fd);
+          infof(multi->easyp,
+                "call curl_multi_socket_action(socket "
+                "%" CURL_FORMAT_SOCKET_T ")", fds[i].fd);
           mcode = curl_multi_socket_action(multi, fds[i].fd, act,
                                            &ev->running_handles);
         }

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -277,7 +277,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
     case CURLFORM_PTRNAME:
       current_form->flags |= HTTPPOST_PTRNAME; /* fall through */
 
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case CURLFORM_COPYNAME:
       if(current_form->name)
         return_value = CURL_FORMADD_OPTION_TWICE;
@@ -303,7 +303,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
        */
     case CURLFORM_PTRCONTENTS:
       current_form->flags |= HTTPPOST_PTRCONTENTS;
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case CURLFORM_COPYCONTENTS:
       if(current_form->value)
         return_value = CURL_FORMADD_OPTION_TWICE;

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -277,7 +277,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
     case CURLFORM_PTRNAME:
       current_form->flags |= HTTPPOST_PTRNAME; /* fall through */
 
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case CURLFORM_COPYNAME:
       if(current_form->name)
         return_value = CURL_FORMADD_OPTION_TWICE;
@@ -303,7 +303,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
        */
     case CURLFORM_PTRCONTENTS:
       current_form->flags |= HTTPPOST_PTRCONTENTS;
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case CURLFORM_COPYCONTENTS:
       if(current_form->value)
         return_value = CURL_FORMADD_OPTION_TWICE;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3256,7 +3256,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
 
     /* until we cope better with prematurely ended requests, let them
      * fallback as if in complete failure */
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   default:       /* by default, an error means the control connection is
                     wedged and should not be used anymore */
     ftpc->ctl_valid = FALSE;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3124,7 +3124,6 @@ static CURLcode ftp_statemachine(struct Curl_easy *data,
       break;
 
     case FTP_QUIT:
-      CURL_FALLTHROUGH();
     default:
       /* internal error */
       ftp_state(data, FTP_STOP);
@@ -3251,7 +3250,6 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
   case CURLE_REMOTE_FILE_NOT_FOUND:
   case CURLE_WRITE_ERROR:
     /* the connection stays alive fine even though this happened */
-    CURL_FALLTHROUGH();
   case CURLE_OK: /* doesn't affect the control connection's status */
     if(!premature)
       break;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3124,7 +3124,7 @@ static CURLcode ftp_statemachine(struct Curl_easy *data,
       break;
 
     case FTP_QUIT:
-      /* fallthrough, just stop! */
+      CURL_FALLTHROUGH();
     default:
       /* internal error */
       ftp_state(data, FTP_STOP);
@@ -3251,14 +3251,14 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
   case CURLE_REMOTE_FILE_NOT_FOUND:
   case CURLE_WRITE_ERROR:
     /* the connection stays alive fine even though this happened */
-    /* fall-through */
+    CURL_FALLTHROUGH();
   case CURLE_OK: /* doesn't affect the control connection's status */
     if(!premature)
       break;
 
     /* until we cope better with prematurely ended requests, let them
      * fallback as if in complete failure */
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   default:       /* by default, an error means the control connection is
                     wedged and should not be used anymore */
     ftpc->ctl_valid = FALSE;

--- a/lib/http.c
+++ b/lib/http.c
@@ -3888,7 +3888,7 @@ CURLcode Curl_http_statusline(struct Curl_easy *data,
      * fields.  */
     if(data->set.timecondition)
       data->info.timecond = TRUE;
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case 204:
     /* (quote from RFC2616, section 10.2.5): The server has
      * fulfilled the request but does not need to return an

--- a/lib/http.c
+++ b/lib/http.c
@@ -3888,7 +3888,7 @@ CURLcode Curl_http_statusline(struct Curl_easy *data,
      * fields.  */
     if(data->set.timecondition)
       data->info.timecond = TRUE;
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case 204:
     /* (quote from RFC2616, section 10.2.5): The server has
      * fulfilled the request but does not need to return an

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1376,7 +1376,6 @@ static CURLcode imap_statemachine(struct Curl_easy *data,
       break;
 
     case IMAP_LOGOUT:
-      CURL_FALLTHROUGH();
     default:
       /* internal error */
       imap_state(data, IMAP_STOP);

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1376,7 +1376,7 @@ static CURLcode imap_statemachine(struct Curl_easy *data,
       break;
 
     case IMAP_LOGOUT:
-      /* fallthrough, just stop! */
+      CURL_FALLTHROUGH();
     default:
       /* internal error */
       imap_state(data, IMAP_STOP);

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1795,7 +1795,14 @@ static CURLcode imap_sendf(struct Curl_easy *data, const char *fmt, ...)
   if(!result) {
     va_list ap;
     va_start(ap, fmt);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     result = Curl_pp_vsendf(data, &imapc->pp, Curl_dyn_ptr(&imapc->dyn), ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     va_end(ap);
   }
   return result;

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -417,7 +417,6 @@ static char level_to_char(int level)
   case PROT_PRIVATE:
     return 'P';
   case PROT_CMD:
-    CURL_FALLTHROUGH();
   default:
     /* Those 2 cases should not be reached! */
     break;

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -417,7 +417,7 @@ static char level_to_char(int level)
   case PROT_PRIVATE:
     return 'P';
   case PROT_CMD:
-    /* Fall through */
+    CURL_FALLTHROUGH();
   default:
     /* Those 2 cases should not be reached! */
     break;

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -137,7 +137,7 @@ static void _ldap_free_urldesc(LDAPURLDesc *ludp);
                             _ldap_trace x; \
                           } while(0)
 
-  static void _ldap_trace(const char *fmt, ...);
+  static void _ldap_trace(const char *fmt, ...) CURL_PRINTF(1, 2);
 #else
   #define LDAP_TRACE(x)   Curl_nop_stmt
 #endif

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -317,8 +317,16 @@ curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
 
   sockfd = socket(domain, type, protocol);
 
-  if(source && (sockfd != CURL_SOCKET_BAD))
+  if(source && (sockfd != CURL_SOCKET_BAD)) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     curl_dbg_log(fmt, source, line, sockfd);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+  }
 
   return sockfd;
 }
@@ -365,8 +373,16 @@ int curl_dbg_socketpair(int domain, int type, int protocol,
 
   int res = socketpair(domain, type, protocol, socket_vector);
 
-  if(source && (0 == res))
+  if(source && (0 == res)) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     curl_dbg_log(fmt, source, line, socket_vector[0], socket_vector[1]);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+  }
 
   return res;
 }
@@ -386,8 +402,16 @@ curl_socket_t curl_dbg_accept(curl_socket_t s, void *saddr, void *saddrlen,
 
   curl_socket_t sockfd = accept(s, addr, addrlen);
 
-  if(source && (sockfd != CURL_SOCKET_BAD))
+  if(source && (sockfd != CURL_SOCKET_BAD)) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     curl_dbg_log(fmt, source, line, sockfd);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+  }
 
   return sockfd;
 }
@@ -401,8 +425,16 @@ void curl_dbg_mark_sclose(curl_socket_t sockfd, int line, const char *source)
     "FD %s:%d sclose(%ld)\n":
     "FD %s:%d sclose(%zd)\n";
 
-  if(source)
+  if(source) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     curl_dbg_log(fmt, source, line, sockfd);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+  }
 }
 
 /* this is our own defined way to close sockets on *ALL* platforms */
@@ -467,7 +499,14 @@ void curl_dbg_log(const char *format, ...)
     return;
 
   va_start(ap, format);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
   nchars = mvsnprintf(buf, LOGLINE_BUFSIZE, format, ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
   va_end(ap);
 
   if(nchars > LOGLINE_BUFSIZE - 1)

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -72,7 +72,7 @@ CURL_EXTERN ALLOC_FUNC wchar_t *curl_dbg_wcsdup(const wchar_t *str,
 
 CURL_EXTERN void curl_dbg_memdebug(const char *logname);
 CURL_EXTERN void curl_dbg_memlimit(long limit);
-CURL_EXTERN void curl_dbg_log(const char *format, ...);
+CURL_EXTERN void curl_dbg_log(const char *format, ...) CURL_PRINTF(1, 2);
 
 /* file descriptor manipulators */
 CURL_EXTERN curl_socket_t curl_dbg_socket(int domain, int type, int protocol,

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1680,7 +1680,14 @@ CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...)
   va_list ap;
 
   va_start(ap, fmt);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
   s = curl_mvaprintf(fmt, ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
   va_end(ap);
 
   if(s) {

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -817,7 +817,7 @@ static size_t read_part_content(curl_mimepart *part,
     case MIMEKIND_FILE:
       if(part->fp && feof(part->fp))
         break;  /* At EOF. */
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     default:
       if(part->readfunc) {
         if(!(part->flags & MIME_FAST_READ)) {
@@ -936,7 +936,7 @@ static size_t readback_part(curl_mimepart *part,
         mimesetstate(&part->state, MIMESTATE_USERHEADERS, hdr->next);
         break;
       }
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case MIMESTATE_CURLHEADERS:
       if(!hdr)
         mimesetstate(&part->state, MIMESTATE_USERHEADERS, part->userheaders);
@@ -970,7 +970,7 @@ static size_t readback_part(curl_mimepart *part,
           fclose(part->fp);
           part->fp = NULL;
         }
-        CURL_FALLTHROUGH();
+        FALLTHROUGH();
       case CURL_READFUNC_ABORT:
       case CURL_READFUNC_PAUSE:
       case READ_ERROR:

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -817,7 +817,7 @@ static size_t read_part_content(curl_mimepart *part,
     case MIMEKIND_FILE:
       if(part->fp && feof(part->fp))
         break;  /* At EOF. */
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     default:
       if(part->readfunc) {
         if(!(part->flags & MIME_FAST_READ)) {
@@ -936,7 +936,7 @@ static size_t readback_part(curl_mimepart *part,
         mimesetstate(&part->state, MIMESTATE_USERHEADERS, hdr->next);
         break;
       }
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case MIMESTATE_CURLHEADERS:
       if(!hdr)
         mimesetstate(&part->state, MIMESTATE_USERHEADERS, part->userheaders);
@@ -970,7 +970,7 @@ static size_t readback_part(curl_mimepart *part,
           fclose(part->fp);
           part->fp = NULL;
         }
-        /* FALLTHROUGH */
+        CURL_FALLTHROUGH();
       case CURL_READFUNC_ABORT:
       case CURL_READFUNC_PAUSE:
       case READ_ERROR:

--- a/lib/mime.h
+++ b/lib/mime.h
@@ -130,7 +130,8 @@ struct curl_mimepart {
   size_t lastreadstatus;           /* Last read callback returned status. */
 };
 
-CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...);
+CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...)
+  CURL_PRINTF(2, 3);
 
 #if !defined(CURL_DISABLE_MIME) && (!defined(CURL_DISABLE_HTTP) ||      \
                                     !defined(CURL_DISABLE_SMTP) ||      \

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -365,7 +365,7 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
         case '0':
           if(!(flags & FLAGS_LEFT))
             flags |= FLAGS_PAD_NIL;
-          /* FALLTHROUGH */
+          CURL_FALLTHROUGH();
         case '1': case '2': case '3': case '4':
         case '5': case '6': case '7': case '8': case '9':
           flags |= FLAGS_WIDTH;
@@ -401,7 +401,7 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
       switch(*fmt) {
       case 'S':
         flags |= FLAGS_ALT;
-        /* FALLTHROUGH */
+        CURL_FALLTHROUGH();
       case 's':
         vto[i].type = FORMAT_STRING;
         break;

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -365,7 +365,7 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
         case '0':
           if(!(flags & FLAGS_LEFT))
             flags |= FLAGS_PAD_NIL;
-          CURL_FALLTHROUGH();
+          FALLTHROUGH();
         case '1': case '2': case '3': case '4':
         case '5': case '6': case '7': case '8': case '9':
           flags |= FLAGS_WIDTH;
@@ -385,7 +385,7 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
           break;
         case '\0':
           fmt--;
-          CURL_FALLTHROUGH();
+          FALLTHROUGH();
         default:
           break;
         }
@@ -402,7 +402,7 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
       switch(*fmt) {
       case 'S':
         flags |= FLAGS_ALT;
-        CURL_FALLTHROUGH();
+        FALLTHROUGH();
       case 's':
         vto[i].type = FORMAT_STRING;
         break;

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -385,6 +385,7 @@ static int dprintf_Pass1(const char *format, struct va_stack *vto,
           break;
         case '\0':
           fmt--;
+          CURL_FALLTHROUGH();
         default:
           break;
         }

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -671,7 +671,7 @@ MQTT_SUBACK_COMING:
     data->req.bytecount = 0;
     data->req.size = remlen;
     mq->npacket = remlen; /* get this many bytes */
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case MQTT_PUB_REMAIN: {
     /* read rest of packet, but no more. Cap to buffer size */
     size_t rest = mq->npacket;
@@ -776,7 +776,7 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
     /* remember the first byte */
     mq->npacket = 0;
     mqstate(data, MQTT_REMAINING_LENGTH, MQTT_NOSTATE);
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case MQTT_REMAINING_LENGTH:
     do {
       result = Curl_read(data, sockfd, (char *)&byte, 1, &nread);

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -671,7 +671,7 @@ MQTT_SUBACK_COMING:
     data->req.bytecount = 0;
     data->req.size = remlen;
     mq->npacket = remlen; /* get this many bytes */
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case MQTT_PUB_REMAIN: {
     /* read rest of packet, but no more. Cap to buffer size */
     size_t rest = mq->npacket;
@@ -776,7 +776,7 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
     /* remember the first byte */
     mq->npacket = 0;
     mqstate(data, MQTT_REMAINING_LENGTH, MQTT_NOSTATE);
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case MQTT_REMAINING_LENGTH:
     do {
       result = Curl_read(data, sockfd, (char *)&byte, 1, &nread);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -672,7 +672,7 @@ static CURLcode multi_done(struct Curl_easy *data,
        many callbacks and protocols work differently, we could potentially do
        this more fine-grained in the future. */
     premature = TRUE;
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   default:
     break;
   }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -672,6 +672,7 @@ static CURLcode multi_done(struct Curl_easy *data,
        many callbacks and protocols work differently, we could potentially do
        this more fine-grained in the future. */
     premature = TRUE;
+    CURL_FALLTHROUGH();
   default:
     break;
   }

--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -216,7 +216,6 @@ bool Curl_check_noproxy(const char *name, const char *no_proxy,
           /* case C passes through, not a match */
           break;
         case TYPE_IPV4:
-          CURL_FALLTHROUGH();
         case TYPE_IPV6: {
           const char *check = token;
           char *slash;

--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -216,7 +216,7 @@ bool Curl_check_noproxy(const char *name, const char *no_proxy,
           /* case C passes through, not a match */
           break;
         case TYPE_IPV4:
-          /* FALLTHROUGH */
+          CURL_FALLTHROUGH();
         case TYPE_IPV6: {
           const char *check = token;
           char *slash;

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -645,7 +645,7 @@ static CURLcode oldap_state_mechs_resp(struct Curl_easy *data,
     switch(code) {
     case LDAP_SIZELIMIT_EXCEEDED:
       infof(data, "Too many authentication mechanisms\n");
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case LDAP_SUCCESS:
     case LDAP_NO_RESULTS_RETURNED:
       if(Curl_sasl_can_authenticate(&li->sasl, data))
@@ -793,7 +793,7 @@ static CURLcode oldap_connecting(struct Curl_easy *data, bool *done)
         result = oldap_perform_bind(data, OLDAP_BIND);
       break;
     }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case OLDAP_TLS:
     result = oldap_ssl_connect(data, OLDAP_TLS);
     if(result && data->set.use_ssl != CURLUSESSL_TRY)
@@ -1014,7 +1014,7 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
     switch(code) {
     case LDAP_SIZELIMIT_EXCEEDED:
       infof(data, "There are more than %d entries", lr->nument);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case LDAP_SUCCESS:
       data->req.size = data->req.bytecount;
       break;

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -645,7 +645,7 @@ static CURLcode oldap_state_mechs_resp(struct Curl_easy *data,
     switch(code) {
     case LDAP_SIZELIMIT_EXCEEDED:
       infof(data, "Too many authentication mechanisms\n");
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case LDAP_SUCCESS:
     case LDAP_NO_RESULTS_RETURNED:
       if(Curl_sasl_can_authenticate(&li->sasl, data))
@@ -793,7 +793,7 @@ static CURLcode oldap_connecting(struct Curl_easy *data, bool *done)
         result = oldap_perform_bind(data, OLDAP_BIND);
       break;
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case OLDAP_TLS:
     result = oldap_ssl_connect(data, OLDAP_TLS);
     if(result && data->set.use_ssl != CURLUSESSL_TRY)
@@ -1014,7 +1014,7 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
     switch(code) {
     case LDAP_SIZELIMIT_EXCEEDED:
       infof(data, "There are more than %d entries", lr->nument);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case LDAP_SUCCESS:
       data->req.size = data->req.bytecount;
       break;

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -113,7 +113,7 @@ timediff_t Curl_pp_state_timeout(struct Curl_easy *data,
  */
 CURLcode Curl_pp_sendf(struct Curl_easy *data,
                        struct pingpong *pp,
-                       const char *fmt, ...);
+                       const char *fmt, ...) CURL_PRINTF(3, 4);
 
 /***********************************************************************
  *
@@ -128,7 +128,7 @@ CURLcode Curl_pp_sendf(struct Curl_easy *data,
 CURLcode Curl_pp_vsendf(struct Curl_easy *data,
                         struct pingpong *pp,
                         const char *fmt,
-                        va_list args);
+                        va_list args) CURL_PRINTF(3, 0);
 
 /*
  * Curl_pp_readresp()

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1268,7 +1268,7 @@ static CURLcode smtp_statemachine(struct Curl_easy *data,
       break;
 
     case SMTP_QUIT:
-      /* fallthrough, just stop! */
+      CURL_FALLTHROUGH();
     default:
       /* internal error */
       smtp_state(data, SMTP_STOP);

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1268,7 +1268,6 @@ static CURLcode smtp_statemachine(struct Curl_easy *data,
       break;
 
     case SMTP_QUIT:
-      CURL_FALLTHROUGH();
     default:
       /* internal error */
       smtp_state(data, SMTP_STOP);

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -353,7 +353,7 @@ static CURLproxycode do_SOCKS4(struct Curl_cfilter *cf,
         return CURLPX_OK;
       }
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_RESOLVED:
 CONNECT_RESOLVED:
   {
@@ -394,7 +394,7 @@ CONNECT_RESOLVED:
     if(!hp)
       return CURLPX_RESOLVE_HOST;
   }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_REQ_INIT:
 CONNECT_REQ_INIT:
     /*
@@ -443,7 +443,7 @@ CONNECT_REQ_INIT:
       sx->outstanding = packetsize;
       sxstate(sx, data, CONNECT_REQ_SENDING);
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_REQ_SENDING:
     /* Send request */
     presult = socks_state_send(cf, sx, data, CURLPX_SEND_CONNECT,
@@ -459,7 +459,7 @@ CONNECT_REQ_INIT:
     sx->outp = socksreq;
     sxstate(sx, data, CONNECT_SOCKS_READ);
 
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_SOCKS_READ:
     /* Receive response */
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_CONNECT,
@@ -641,12 +641,12 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
       /* remain in sending state */
       return CURLPX_OK;
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_SOCKS_READ_INIT:
 CONNECT_SOCKS_READ_INIT:
     sx->outstanding = 2; /* expect two bytes */
     sx->outp = socksreq; /* store it here */
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_SOCKS_READ:
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_CONNECT,
                                "initial SOCKS5 response");
@@ -750,7 +750,7 @@ CONNECT_AUTH_INIT:
     sx->outstanding = len;
     sx->outp = socksreq;
   }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_AUTH_SEND:
     presult = socks_state_send(cf, sx, data, CURLPX_SEND_AUTH,
                                "SOCKS5 sub-negotiation request");
@@ -763,7 +763,7 @@ CONNECT_AUTH_INIT:
     sx->outp = socksreq;
     sx->outstanding = 2;
     sxstate(sx, data, CONNECT_AUTH_READ);
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_AUTH_READ:
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_AUTH,
                                "SOCKS5 sub-negotiation response");
@@ -782,7 +782,7 @@ CONNECT_AUTH_INIT:
 
     /* Everything is good so far, user was authenticated! */
     sxstate(sx, data, CONNECT_REQ_INIT);
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_REQ_INIT:
 CONNECT_REQ_INIT:
     if(socks5_resolve_local) {
@@ -821,7 +821,7 @@ CONNECT_REQ_INIT:
         return CURLPX_OK;
       }
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_RESOLVED:
 CONNECT_RESOLVED:
   {
@@ -925,7 +925,7 @@ CONNECT_RESOLVE_REMOTE:
       infof(data, "SOCKS5 connect to %s:%d (remotely resolved)",
             sx->hostname, sx->remote_port);
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
 
   case CONNECT_REQ_SEND:
 CONNECT_REQ_SEND:
@@ -943,7 +943,7 @@ CONNECT_REQ_SEND:
     sx->outp = socksreq;
     sx->outstanding = len;
     sxstate(sx, data, CONNECT_REQ_SENDING);
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_REQ_SENDING:
     presult = socks_state_send(cf, sx, data, CURLPX_SEND_REQUEST,
                                "SOCKS5 connect request");
@@ -962,7 +962,7 @@ CONNECT_REQ_SEND:
     sx->outstanding = 10; /* minimum packet size is 10 */
     sx->outp = socksreq;
     sxstate(sx, data, CONNECT_REQ_READ);
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_REQ_READ:
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_REQACK,
                                "SOCKS5 connect request ack");
@@ -1051,7 +1051,7 @@ CONNECT_REQ_SEND:
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
     }
 #endif
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CONNECT_REQ_READ_MORE:
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_ADDRESS,
                                "SOCKS5 connect request address");

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -354,8 +354,9 @@ static CURLproxycode do_SOCKS4(struct Curl_cfilter *cf,
       }
     }
     CURL_FALLTHROUGH();
+  case CONNECT_RESOLVED:
 CONNECT_RESOLVED:
-  case CONNECT_RESOLVED: {
+  {
     struct Curl_addrinfo *hp = NULL;
     /*
      * We cannot use 'hostent' as a struct that Curl_resolv() returns.  It
@@ -394,8 +395,8 @@ CONNECT_RESOLVED:
       return CURLPX_RESOLVE_HOST;
   }
     CURL_FALLTHROUGH();
-CONNECT_REQ_INIT:
   case CONNECT_REQ_INIT:
+CONNECT_REQ_INIT:
     /*
      * This is currently not supporting "Identification Protocol (RFC1413)".
      */
@@ -641,8 +642,8 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
       return CURLPX_OK;
     }
     CURL_FALLTHROUGH();
-CONNECT_SOCKS_READ_INIT:
   case CONNECT_SOCKS_READ_INIT:
+CONNECT_SOCKS_READ_INIT:
     sx->outstanding = 2; /* expect two bytes */
     sx->outp = socksreq; /* store it here */
     CURL_FALLTHROUGH();
@@ -782,8 +783,8 @@ CONNECT_AUTH_INIT:
     /* Everything is good so far, user was authenticated! */
     sxstate(sx, data, CONNECT_REQ_INIT);
     CURL_FALLTHROUGH();
-CONNECT_REQ_INIT:
   case CONNECT_REQ_INIT:
+CONNECT_REQ_INIT:
     if(socks5_resolve_local) {
       enum resolve_t rc = Curl_resolv(data, sx->hostname, sx->remote_port,
                                       TRUE, &dns);
@@ -821,8 +822,9 @@ CONNECT_REQ_INIT:
       }
     }
     CURL_FALLTHROUGH();
+  case CONNECT_RESOLVED:
 CONNECT_RESOLVED:
-  case CONNECT_RESOLVED: {
+  {
     char dest[MAX_IPADR_LEN];  /* printable address */
     struct Curl_addrinfo *hp = NULL;
     if(dns)
@@ -925,8 +927,8 @@ CONNECT_RESOLVE_REMOTE:
     }
     CURL_FALLTHROUGH();
 
-CONNECT_REQ_SEND:
   case CONNECT_REQ_SEND:
+CONNECT_REQ_SEND:
     /* PORT MSB */
     socksreq[len++] = (unsigned char)((sx->remote_port >> 8) & 0xff);
     /* PORT LSB */

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -353,7 +353,7 @@ static CURLproxycode do_SOCKS4(struct Curl_cfilter *cf,
         return CURLPX_OK;
       }
     }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
 CONNECT_RESOLVED:
   case CONNECT_RESOLVED: {
     struct Curl_addrinfo *hp = NULL;
@@ -393,7 +393,7 @@ CONNECT_RESOLVED:
     if(!hp)
       return CURLPX_RESOLVE_HOST;
   }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
 CONNECT_REQ_INIT:
   case CONNECT_REQ_INIT:
     /*
@@ -442,7 +442,7 @@ CONNECT_REQ_INIT:
       sx->outstanding = packetsize;
       sxstate(sx, data, CONNECT_REQ_SENDING);
     }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CONNECT_REQ_SENDING:
     /* Send request */
     presult = socks_state_send(cf, sx, data, CURLPX_SEND_CONNECT,
@@ -458,7 +458,7 @@ CONNECT_REQ_INIT:
     sx->outp = socksreq;
     sxstate(sx, data, CONNECT_SOCKS_READ);
 
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CONNECT_SOCKS_READ:
     /* Receive response */
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_CONNECT,
@@ -640,12 +640,12 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
       /* remain in sending state */
       return CURLPX_OK;
     }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
 CONNECT_SOCKS_READ_INIT:
   case CONNECT_SOCKS_READ_INIT:
     sx->outstanding = 2; /* expect two bytes */
     sx->outp = socksreq; /* store it here */
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CONNECT_SOCKS_READ:
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_CONNECT,
                                "initial SOCKS5 response");
@@ -749,7 +749,7 @@ CONNECT_AUTH_INIT:
     sx->outstanding = len;
     sx->outp = socksreq;
   }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CONNECT_AUTH_SEND:
     presult = socks_state_send(cf, sx, data, CURLPX_SEND_AUTH,
                                "SOCKS5 sub-negotiation request");
@@ -762,7 +762,7 @@ CONNECT_AUTH_INIT:
     sx->outp = socksreq;
     sx->outstanding = 2;
     sxstate(sx, data, CONNECT_AUTH_READ);
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CONNECT_AUTH_READ:
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_AUTH,
                                "SOCKS5 sub-negotiation response");
@@ -781,7 +781,7 @@ CONNECT_AUTH_INIT:
 
     /* Everything is good so far, user was authenticated! */
     sxstate(sx, data, CONNECT_REQ_INIT);
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
 CONNECT_REQ_INIT:
   case CONNECT_REQ_INIT:
     if(socks5_resolve_local) {
@@ -820,7 +820,7 @@ CONNECT_REQ_INIT:
         return CURLPX_OK;
       }
     }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
 CONNECT_RESOLVED:
   case CONNECT_RESOLVED: {
     char dest[MAX_IPADR_LEN];  /* printable address */
@@ -923,7 +923,7 @@ CONNECT_RESOLVE_REMOTE:
       infof(data, "SOCKS5 connect to %s:%d (remotely resolved)",
             sx->hostname, sx->remote_port);
     }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
 
 CONNECT_REQ_SEND:
   case CONNECT_REQ_SEND:
@@ -941,7 +941,7 @@ CONNECT_REQ_SEND:
     sx->outp = socksreq;
     sx->outstanding = len;
     sxstate(sx, data, CONNECT_REQ_SENDING);
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CONNECT_REQ_SENDING:
     presult = socks_state_send(cf, sx, data, CURLPX_SEND_REQUEST,
                                "SOCKS5 connect request");
@@ -960,7 +960,7 @@ CONNECT_REQ_SEND:
     sx->outstanding = 10; /* minimum packet size is 10 */
     sx->outp = socksreq;
     sxstate(sx, data, CONNECT_REQ_READ);
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CONNECT_REQ_READ:
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_REQACK,
                                "SOCKS5 connect request ack");
@@ -1049,7 +1049,7 @@ CONNECT_REQ_SEND:
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
     }
 #endif
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CONNECT_REQ_READ_MORE:
     presult = socks_state_recv(cf, sx, data, CURLPX_RECV_ADDRESS,
                                "SOCKS5 connect request address");

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -332,10 +332,12 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     return CURLE_COULDNT_CONNECT;
   }
   else {
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
     char *user_utf8 = curlx_convert_tchar_to_UTF8(names.sUserName);
     infof(data, "SOCKS5 server authenticated user %s with GSS-API.",
           (user_utf8 ? user_utf8 : "(unknown)"));
     curlx_unicodefree(user_utf8);
+#endif
     s_pSecFn->FreeContextBuffer(names.sUserName);
   }
 

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -331,9 +331,13 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     failf(data, "Failed to determine user name.");
     return CURLE_COULDNT_CONNECT;
   }
-  infof(data, "SOCKS5 server authenticated user %s with GSS-API.",
-        names.sUserName);
-  s_pSecFn->FreeContextBuffer(names.sUserName);
+  else {
+    char *user_utf8 = curlx_convert_tchar_to_UTF8(names.sUserName);
+    infof(data, "SOCKS5 server authenticated user %s with GSS-API.",
+          (user_utf8 ? user_utf8 : "(unknown)"));
+    curlx_unicodefree(user_utf8);
+    s_pSecFn->FreeContextBuffer(names.sUserName);
+  }
 
   /* Do encryption */
   socksreq[0] = 1;    /* GSS-API subnegotiation version */

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1546,7 +1546,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     case 0:                     /* timeout */
       pfd[0].revents = 0;
       pfd[1].revents = 0;
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     default:                    /* read! */
       if(pfd[0].revents & POLLIN) {
         /* read data from network */

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -1546,7 +1546,7 @@ static CURLcode telnet_do(struct Curl_easy *data, bool *done)
     case 0:                     /* timeout */
       pfd[0].revents = 0;
       pfd[1].revents = 0;
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     default:                    /* read! */
       if(pfd[0].revents & POLLIN) {
         /* read data from network */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -712,24 +712,30 @@ static int ipv4_normalize(struct dynbuf *host)
     Curl_dyn_reset(host);
 
     result = Curl_dyn_addf(host, "%u.%u.%u.%u",
-                           parts[0] >> 24, (parts[0] >> 16) & 0xff,
-                           (parts[0] >> 8) & 0xff, parts[0] & 0xff);
+                           (unsigned int)(parts[0] >> 24),
+                           (unsigned int)((parts[0] >> 16) & 0xff),
+                           (unsigned int)((parts[0] >> 8) & 0xff),
+                           (unsigned int)(parts[0] & 0xff));
     break;
   case 1: /* a.b -- 8.24 bits */
     if((parts[0] > 0xff) || (parts[1] > 0xffffff))
       return HOST_NAME;
     Curl_dyn_reset(host);
     result = Curl_dyn_addf(host, "%u.%u.%u.%u",
-                           parts[0], (parts[1] >> 16) & 0xff,
-                           (parts[1] >> 8) & 0xff, parts[1] & 0xff);
+                           (unsigned int)(parts[0]),
+                           (unsigned int)((parts[1] >> 16) & 0xff),
+                           (unsigned int)((parts[1] >> 8) & 0xff),
+                           (unsigned int)(parts[1] & 0xff));
     break;
   case 2: /* a.b.c -- 8.8.16 bits */
     if((parts[0] > 0xff) || (parts[1] > 0xff) || (parts[2] > 0xffff))
       return HOST_NAME;
     Curl_dyn_reset(host);
     result = Curl_dyn_addf(host, "%u.%u.%u.%u",
-                           parts[0], parts[1], (parts[2] >> 8) & 0xff,
-                           parts[2] & 0xff);
+                           (unsigned int)(parts[0]),
+                           (unsigned int)(parts[1]),
+                           (unsigned int)((parts[2] >> 8) & 0xff),
+                           (unsigned int)(parts[2] & 0xff));
     break;
   case 3: /* a.b.c.d -- 8.8.8.8 bits */
     if((parts[0] > 0xff) || (parts[1] > 0xff) || (parts[2] > 0xff) ||
@@ -737,7 +743,10 @@ static int ipv4_normalize(struct dynbuf *host)
       return HOST_NAME;
     Curl_dyn_reset(host);
     result = Curl_dyn_addf(host, "%u.%u.%u.%u",
-                           parts[0], parts[1], parts[2], parts[3]);
+                           (unsigned int)(parts[0]),
+                           (unsigned int)(parts[1]),
+                           (unsigned int)(parts[2]),
+                           (unsigned int)(parts[3]));
     break;
   }
   if(result)

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -314,7 +314,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                                &type_3_desc,
                                                &attrs, &expiry);
   if(status != SEC_E_OK) {
-    infof(data, "NTLM handshake failure (type-3 message): Status=%x",
+    infof(data, "NTLM handshake failure (type-3 message): Status=%lx",
           status);
 
     if(status == SEC_E_INSUFFICIENT_MEMORY)

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -179,7 +179,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
         qctx->no_gso = TRUE;
         return send_packet_no_gso(cf, data, qctx, pkt, pktlen, gsolen, psent);
       }
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     default:
       failf(data, "sendmsg() returned %zd (errno %d)", sent, SOCKERRNO);
       return CURLE_SEND_ERROR;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -179,7 +179,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
         qctx->no_gso = TRUE;
         return send_packet_no_gso(cf, data, qctx, pkt, pktlen, gsolen, psent);
       }
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     default:
       failf(data, "sendmsg() returned %zd (errno %d)", sent, SOCKERRNO);
       return CURLE_SEND_ERROR;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -625,7 +625,7 @@ restart:
       if(rc < 0)
         return SSH_ERROR;
 
-    CURL_FALLTHROUGH();
+      CURL_FALLTHROUGH();
     case 1:
       sshc->kbd_state = 1;
 

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -445,11 +445,11 @@ static int myssh_is_known(struct Curl_easy *data)
       keymatch = CURLKHMATCH_OK;
       break;
     case SSH_KNOWN_HOSTS_OTHER:
-      /* fallthrough */
+      CURL_FALLTHROUGH();
     case SSH_KNOWN_HOSTS_NOT_FOUND:
-      /* fallthrough */
+      CURL_FALLTHROUGH();
     case SSH_KNOWN_HOSTS_UNKNOWN:
-      /* fallthrough */
+      CURL_FALLTHROUGH();
     case SSH_KNOWN_HOSTS_ERROR:
       keymatch = CURLKHMATCH_MISSING;
       break;
@@ -465,7 +465,7 @@ static int myssh_is_known(struct Curl_easy *data)
       keymatch = CURLKHMATCH_OK;
       break;
     case SSH_SERVER_FILE_NOT_FOUND:
-      /* fallthrough */
+      CURL_FALLTHROUGH();
     case SSH_SERVER_NOT_KNOWN:
       keymatch = CURLKHMATCH_MISSING;
       break;
@@ -629,7 +629,7 @@ restart:
       if(rc < 0)
         return SSH_ERROR;
 
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
     case 1:
       sshc->kbd_state = 1;
 
@@ -704,7 +704,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       ssh_set_blocking(sshc->ssh_session, 0);
 
       state(data, SSH_S_STARTUP);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case SSH_S_STARTUP:
       rc = ssh_connect(sshc->ssh_session);
@@ -719,7 +719,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
 
       state(data, SSH_HOSTKEY);
 
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SSH_HOSTKEY:
 
       rc = myssh_is_known(data);
@@ -729,7 +729,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       state(data, SSH_AUTHLIST);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SSH_AUTHLIST:{
         sshc->authed = FALSE;
 
@@ -910,7 +910,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         break;
       }
       state(data, SSH_AUTH_PASS);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case SSH_AUTH_PASS:
       rc = ssh_userauth_password(sshc->ssh_session, NULL, conn->passwd);
@@ -973,7 +973,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         break;
       }
       state(data, SSH_SFTP_REALPATH);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SSH_SFTP_REALPATH:
       /*
        * Get the "home" directory
@@ -1560,7 +1560,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       sshc->readdir_longentry = NULL;
 
       state(data, SSH_SFTP_READDIR_BOTTOM);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SSH_SFTP_READDIR_BOTTOM:
       if(Curl_dyn_addn(&sshc->readdir_buf, "\n", 1))
         result = CURLE_OUT_OF_MEMORY;
@@ -1884,7 +1884,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         break;
       }
       state(data, SSH_SCP_DOWNLOAD);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case SSH_SCP_DOWNLOAD:{
         curl_off_t bytecount;
@@ -1948,7 +1948,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       ssh_set_blocking(sshc->ssh_session, 0);
 
       state(data, SSH_SESSION_DISCONNECT);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case SSH_SESSION_DISCONNECT:
       /* during weird times when we've been prematurely aborted, the channel
@@ -1971,7 +1971,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       data->state.most_recent_ftp_entrypath = NULL;
 
       state(data, SSH_SESSION_FREE);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SSH_SESSION_FREE:
       if(sshc->ssh_session) {
         ssh_free(sshc->ssh_session);
@@ -2022,7 +2022,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       break;
 
     case SSH_QUIT:
-      /* fallthrough, just stop! */
+      CURL_FALLTHROUGH();
     default:
       /* internal error */
       sshc->nextstate = SSH_NO_STATE;
@@ -2613,7 +2613,7 @@ static ssize_t sftp_recv(struct Curl_easy *data, int sockindex,
         return -1;
       }
 
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case 1:
       conn->proto.sshc.sftp_recv_state = 1;
 

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -445,11 +445,8 @@ static int myssh_is_known(struct Curl_easy *data)
       keymatch = CURLKHMATCH_OK;
       break;
     case SSH_KNOWN_HOSTS_OTHER:
-      CURL_FALLTHROUGH();
     case SSH_KNOWN_HOSTS_NOT_FOUND:
-      CURL_FALLTHROUGH();
     case SSH_KNOWN_HOSTS_UNKNOWN:
-      CURL_FALLTHROUGH();
     case SSH_KNOWN_HOSTS_ERROR:
       keymatch = CURLKHMATCH_MISSING;
       break;
@@ -465,7 +462,6 @@ static int myssh_is_known(struct Curl_easy *data)
       keymatch = CURLKHMATCH_OK;
       break;
     case SSH_SERVER_FILE_NOT_FOUND:
-      CURL_FALLTHROUGH();
     case SSH_SERVER_NOT_KNOWN:
       keymatch = CURLKHMATCH_MISSING;
       break;
@@ -2022,7 +2018,6 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       break;
 
     case SSH_QUIT:
-      CURL_FALLTHROUGH();
     default:
       /* internal error */
       sshc->nextstate = SSH_NO_STATE;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -625,7 +625,7 @@ restart:
       if(rc < 0)
         return SSH_ERROR;
 
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case 1:
       sshc->kbd_state = 1;
 
@@ -700,7 +700,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       ssh_set_blocking(sshc->ssh_session, 0);
 
       state(data, SSH_S_STARTUP);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case SSH_S_STARTUP:
       rc = ssh_connect(sshc->ssh_session);
@@ -715,7 +715,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
 
       state(data, SSH_HOSTKEY);
 
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case SSH_HOSTKEY:
 
       rc = myssh_is_known(data);
@@ -725,7 +725,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       state(data, SSH_AUTHLIST);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case SSH_AUTHLIST:{
         sshc->authed = FALSE;
 
@@ -906,7 +906,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         break;
       }
       state(data, SSH_AUTH_PASS);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case SSH_AUTH_PASS:
       rc = ssh_userauth_password(sshc->ssh_session, NULL, conn->passwd);
@@ -969,7 +969,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         break;
       }
       state(data, SSH_SFTP_REALPATH);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case SSH_SFTP_REALPATH:
       /*
        * Get the "home" directory
@@ -1556,7 +1556,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       sshc->readdir_longentry = NULL;
 
       state(data, SSH_SFTP_READDIR_BOTTOM);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case SSH_SFTP_READDIR_BOTTOM:
       if(Curl_dyn_addn(&sshc->readdir_buf, "\n", 1))
         result = CURLE_OUT_OF_MEMORY;
@@ -1880,7 +1880,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         break;
       }
       state(data, SSH_SCP_DOWNLOAD);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case SSH_SCP_DOWNLOAD:{
         curl_off_t bytecount;
@@ -1944,7 +1944,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       ssh_set_blocking(sshc->ssh_session, 0);
 
       state(data, SSH_SESSION_DISCONNECT);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case SSH_SESSION_DISCONNECT:
       /* during weird times when we've been prematurely aborted, the channel
@@ -1967,7 +1967,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       data->state.most_recent_ftp_entrypath = NULL;
 
       state(data, SSH_SESSION_FREE);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case SSH_SESSION_FREE:
       if(sshc->ssh_session) {
         ssh_free(sshc->ssh_session);
@@ -2608,7 +2608,7 @@ static ssize_t sftp_recv(struct Curl_easy *data, int sockindex,
         return -1;
       }
 
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case 1:
       conn->proto.sshc.sftp_recv_state = 1;
 

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -600,7 +600,7 @@ static CURLcode ssh_knownhost(struct Curl_easy *data)
       /* remove old host+key that doesn't match */
       if(host)
         libssh2_knownhost_del(sshc->kh, host);
-        CURL_FALLTHROUGH();
+      CURL_FALLTHROUGH();
     case CURLKHSTAT_FINE:
     case CURLKHSTAT_FINE_ADD_TO_FILE:
       /* proceed */

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -589,7 +589,6 @@ static CURLcode ssh_knownhost(struct Curl_easy *data)
 
     switch(rc) {
     default: /* unknown return codes will equal reject */
-      CURL_FALLTHROUGH();
     case CURLKHSTAT_REJECT:
       state(data, SSH_SESSION_FREE);
       CURL_FALLTHROUGH();
@@ -603,7 +602,6 @@ static CURLcode ssh_knownhost(struct Curl_easy *data)
         libssh2_knownhost_del(sshc->kh, host);
         CURL_FALLTHROUGH();
     case CURLKHSTAT_FINE:
-        CURL_FALLTHROUGH();
     case CURLKHSTAT_FINE_ADD_TO_FILE:
       /* proceed */
       if(keycheck != LIBSSH2_KNOWNHOST_CHECK_MATCH) {
@@ -3024,7 +3022,6 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
       break;
 
     case SSH_QUIT:
-      CURL_FALLTHROUGH();
     default:
       /* internal error */
       sshc->nextstate = SSH_NO_STATE;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -591,7 +591,7 @@ static CURLcode ssh_knownhost(struct Curl_easy *data)
     default: /* unknown return codes will equal reject */
     case CURLKHSTAT_REJECT:
       state(data, SSH_SESSION_FREE);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case CURLKHSTAT_DEFER:
       /* DEFER means bail out but keep the SSH_HOSTKEY state */
       result = sshc->actualcode = CURLE_PEER_FAILED_VERIFICATION;
@@ -600,7 +600,7 @@ static CURLcode ssh_knownhost(struct Curl_easy *data)
       /* remove old host+key that doesn't match */
       if(host)
         libssh2_knownhost_del(sshc->kh, host);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case CURLKHSTAT_FINE:
     case CURLKHSTAT_FINE_ADD_TO_FILE:
       /* proceed */
@@ -995,7 +995,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       state(data, SSH_S_STARTUP);
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
 
     case SSH_S_STARTUP:
       rc = session_startup(sshc->ssh_session, sock);
@@ -1014,7 +1014,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
 
       state(data, SSH_HOSTKEY);
 
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case SSH_HOSTKEY:
       /*
        * Before we authenticate we should check the hostkey's fingerprint

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -589,10 +589,10 @@ static CURLcode ssh_knownhost(struct Curl_easy *data)
 
     switch(rc) {
     default: /* unknown return codes will equal reject */
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case CURLKHSTAT_REJECT:
       state(data, SSH_SESSION_FREE);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case CURLKHSTAT_DEFER:
       /* DEFER means bail out but keep the SSH_HOSTKEY state */
       result = sshc->actualcode = CURLE_PEER_FAILED_VERIFICATION;
@@ -601,9 +601,9 @@ static CURLcode ssh_knownhost(struct Curl_easy *data)
       /* remove old host+key that doesn't match */
       if(host)
         libssh2_knownhost_del(sshc->kh, host);
-        /* FALLTHROUGH */
+        CURL_FALLTHROUGH();
     case CURLKHSTAT_FINE:
-        /* FALLTHROUGH */
+        CURL_FALLTHROUGH();
     case CURLKHSTAT_FINE_ADD_TO_FILE:
       /* proceed */
       if(keycheck != LIBSSH2_KNOWNHOST_CHECK_MATCH) {
@@ -997,7 +997,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       state(data, SSH_S_STARTUP);
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
 
     case SSH_S_STARTUP:
       rc = session_startup(sshc->ssh_session, sock);
@@ -1016,7 +1016,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
 
       state(data, SSH_HOSTKEY);
 
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SSH_HOSTKEY:
       /*
        * Before we authenticate we should check the hostkey's fingerprint
@@ -3024,7 +3024,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
       break;
 
     case SSH_QUIT:
-      /* fallthrough, just stop! */
+      CURL_FALLTHROUGH();
     default:
       /* internal error */
       sshc->nextstate = SSH_NO_STATE;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1088,7 +1088,7 @@ static int ssl_ui_reader(UI *ui, UI_STRING *uis)
       UI_set_result(ui, uis, password);
       return 1;
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   default:
     break;
   }
@@ -1107,7 +1107,7 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
        (UI_get_input_flags(uis) & UI_INPUT_FLAG_DEFAULT_PWD)) {
       return 1;
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   default:
     break;
   }
@@ -1525,7 +1525,7 @@ fail:
     case SSL_FILETYPE_PEM:
       if(cert_done)
         break;
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case SSL_FILETYPE_ASN1:
       cert_use_result = key_blob ?
         SSL_CTX_use_PrivateKey_blob(ctx, key_blob, file_type, key_passwd) :
@@ -2851,7 +2851,7 @@ ossl_set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
   failf(data, OSSL_PACKAGE " was built without TLS 1.3 support");
   return CURLE_NOT_BUILT_IN;
 #endif
-  CURL_FALLTHROUGH();
+  FALLTHROUGH();
   case CURL_SSLVERSION_TLSv1_2:
 #if OPENSSL_VERSION_NUMBER >= 0x1000100FL
     *ctx_options |= SSL_OP_NO_TLSv1_1;
@@ -2859,7 +2859,7 @@ ossl_set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
     failf(data, OSSL_PACKAGE " was built without TLS 1.2 support");
     return CURLE_NOT_BUILT_IN;
 #endif
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CURL_SSLVERSION_TLSv1_1:
 #if OPENSSL_VERSION_NUMBER >= 0x1000100FL
     *ctx_options |= SSL_OP_NO_TLSv1;
@@ -2867,7 +2867,7 @@ ossl_set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
     failf(data, OSSL_PACKAGE " was built without TLS 1.1 support");
     return CURLE_NOT_BUILT_IN;
 #endif
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CURL_SSLVERSION_TLSv1_0:
   case CURL_SSLVERSION_TLSv1:
     break;
@@ -2878,12 +2878,12 @@ ossl_set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
 #if OPENSSL_VERSION_NUMBER >= 0x1000100FL
     *ctx_options |= SSL_OP_NO_TLSv1_1;
 #endif
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CURL_SSLVERSION_MAX_TLSv1_1:
 #if OPENSSL_VERSION_NUMBER >= 0x1000100FL
     *ctx_options |= SSL_OP_NO_TLSv1_2;
 #endif
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CURL_SSLVERSION_MAX_TLSv1_2:
 #ifdef TLS1_3_VERSION
     *ctx_options |= SSL_OP_NO_TLSv1_3;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1523,7 +1523,7 @@ fail:
     case SSL_FILETYPE_PEM:
       if(cert_done)
         break;
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SSL_FILETYPE_ASN1:
       cert_use_result = key_blob ?
         SSL_CTX_use_PrivateKey_blob(ctx, key_blob, file_type, key_passwd) :
@@ -2849,7 +2849,7 @@ ossl_set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
   failf(data, OSSL_PACKAGE " was built without TLS 1.3 support");
   return CURLE_NOT_BUILT_IN;
 #endif
-  /* FALLTHROUGH */
+  CURL_FALLTHROUGH();
   case CURL_SSLVERSION_TLSv1_2:
 #if OPENSSL_VERSION_NUMBER >= 0x1000100FL
     *ctx_options |= SSL_OP_NO_TLSv1_1;
@@ -2857,7 +2857,7 @@ ossl_set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
     failf(data, OSSL_PACKAGE " was built without TLS 1.2 support");
     return CURLE_NOT_BUILT_IN;
 #endif
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CURL_SSLVERSION_TLSv1_1:
 #if OPENSSL_VERSION_NUMBER >= 0x1000100FL
     *ctx_options |= SSL_OP_NO_TLSv1;
@@ -2865,7 +2865,7 @@ ossl_set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
     failf(data, OSSL_PACKAGE " was built without TLS 1.1 support");
     return CURLE_NOT_BUILT_IN;
 #endif
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CURL_SSLVERSION_TLSv1_0:
   case CURL_SSLVERSION_TLSv1:
     break;
@@ -2876,12 +2876,12 @@ ossl_set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
 #if OPENSSL_VERSION_NUMBER >= 0x1000100FL
     *ctx_options |= SSL_OP_NO_TLSv1_1;
 #endif
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CURL_SSLVERSION_MAX_TLSv1_1:
 #if OPENSSL_VERSION_NUMBER >= 0x1000100FL
     *ctx_options |= SSL_OP_NO_TLSv1_2;
 #endif
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CURL_SSLVERSION_MAX_TLSv1_2:
 #ifdef TLS1_3_VERSION
     *ctx_options |= SSL_OP_NO_TLSv1_3;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1088,6 +1088,7 @@ static int ssl_ui_reader(UI *ui, UI_STRING *uis)
       UI_set_result(ui, uis, password);
       return 1;
     }
+    CURL_FALLTHROUGH();
   default:
     break;
   }
@@ -1106,6 +1107,7 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
        (UI_get_input_flags(uis) & UI_INPUT_FLAG_DEFAULT_PWD)) {
       return 1;
     }
+    CURL_FALLTHROUGH();
   default:
     break;
   }

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -156,7 +156,7 @@ static ssize_t tls_recv_more(struct Curl_cfilter *cf,
     size_t errorlen;
     rustls_error(rresult, errorbuf, sizeof(errorbuf), &errorlen);
     failf(data, "rustls_connection_process_new_packets: %.*s",
-      errorlen, errorbuf);
+      (int)errorlen, errorbuf);
     *err = map_error(rresult);
     return -1;
   }
@@ -225,7 +225,7 @@ cr_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
       char errorbuf[255];
       size_t errorlen;
       rustls_error(rresult, errorbuf, sizeof(errorbuf), &errorlen);
-      failf(data, "rustls_connection_read: %.*s", errorlen, errorbuf);
+      failf(data, "rustls_connection_read: %.*s", (int)errorlen, errorbuf);
       *err = CURLE_READ_ERROR;
       nread = -1;
       goto out;
@@ -301,7 +301,7 @@ cr_send(struct Curl_cfilter *cf, struct Curl_easy *data,
                                       &plainwritten);
     if(rresult != RUSTLS_RESULT_OK) {
       rustls_error(rresult, errorbuf, sizeof(errorbuf), &errorlen);
-      failf(data, "rustls_connection_write: %.*s", errorlen, errorbuf);
+      failf(data, "rustls_connection_write: %.*s", (int)errorlen, errorbuf);
       *err = CURLE_WRITE_ERROR;
       return -1;
     }
@@ -459,7 +459,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
   if(result != RUSTLS_RESULT_OK) {
     rustls_error(result, errorbuf, sizeof(errorbuf), &errorlen);
-    failf(data, "rustls_client_connection_new: %.*s", errorlen, errorbuf);
+    failf(data, "rustls_client_connection_new: %.*s", (int)errorlen, errorbuf);
     return CURLE_COULDNT_CONNECT;
   }
   rustls_connection_set_userdata(rconn, backend);
@@ -563,8 +563,8 @@ cr_connect_common(struct Curl_cfilter *cf,
       return CURLE_SSL_CONNECT_ERROR;
     }
     if(blocking && 0 == what) {
-      failf(data, "rustls connection timeout after %d ms",
-        socket_check_timeout);
+      failf(data, "rustls connection timeout after %"
+        CURL_FORMAT_TIMEDIFF_T " ms", socket_check_timeout);
       return CURLE_OPERATION_TIMEDOUT;
     }
     if(0 == what) {

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -666,7 +666,7 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
                 cert_showfilename_error);
         else
           failf(data, "schannel: Failed to import cert file %s, "
-                "last error is 0x%x",
+                "last error is 0x%lx",
                 cert_showfilename_error, errorcode);
         return CURLE_SSL_CERTPROBLEM;
       }
@@ -677,7 +677,7 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
 
       if(!client_certs[0]) {
         failf(data, "schannel: Failed to get certificate from file %s"
-              ", last error is 0x%x",
+              ", last error is 0x%lx",
               cert_showfilename_error, GetLastError());
         CertCloseStore(cert_store, 0);
         return CURLE_SSL_CERTPROBLEM;
@@ -690,8 +690,8 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
                       CERT_STORE_OPEN_EXISTING_FLAG | cert_store_name,
                       cert_store_path);
       if(!cert_store) {
-        failf(data, "schannel: Failed to open cert store %x %s, "
-              "last error is 0x%x",
+        failf(data, "schannel: Failed to open cert store %lx %s, "
+              "last error is 0x%lx",
               cert_store_name, cert_store_path, GetLastError());
         free(cert_store_path);
         curlx_unicodefree(cert_path);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -690,10 +690,15 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
                       CERT_STORE_OPEN_EXISTING_FLAG | cert_store_name,
                       cert_store_path);
       if(!cert_store) {
+        char *path_utf8 =
+          curlx_convert_tchar_to_UTF8(cert_store_path);
         failf(data, "schannel: Failed to open cert store %lx %s, "
               "last error is 0x%lx",
-              cert_store_name, cert_store_path, GetLastError());
+              cert_store_name,
+              (path_utf8 ? path_utf8 : "(unknown)"),
+              GetLastError());
         free(cert_store_path);
+        curlx_unicodefree(path_utf8);
         curlx_unicodefree(cert_path);
         return CURLE_SSL_CERTPROBLEM;
       }

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -172,7 +172,7 @@ static CURLcode add_certs_data_to_store(HCERTSTORE trust_store,
           /* Sanity check that the cert_context object is the right type */
           if(CERT_QUERY_CONTENT_CERT != actual_content_type) {
             failf(data,
-                  "schannel: unexpected content type '%d' when extracting "
+                  "schannel: unexpected content type '%lu' when extracting "
                   "certificate from CA file '%s'",
                   actual_content_type, ca_file_text);
             result = CURLE_SSL_CACERT_BADFILE;
@@ -753,7 +753,7 @@ CURLcode Curl_verify_certificate(struct Curl_cfilter *cf,
           failf(data, "schannel: CertGetCertificateChain trust error"
                 " CERT_TRUST_REVOCATION_STATUS_UNKNOWN");
         else
-          failf(data, "schannel: CertGetCertificateChain error mask: 0x%08x",
+          failf(data, "schannel: CertGetCertificateChain error mask: 0x%08lx",
                 dwTrustErrorMask);
         result = CURLE_PEER_FAILED_VERIFICATION;
       }

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1084,9 +1084,7 @@ static ssize_t wolfssl_recv(struct Curl_cfilter *cf,
       *curlcode = CURLE_OK;
       return 0;
     case SSL_ERROR_NONE:
-      CURL_FALLTHROUGH();
     case SSL_ERROR_WANT_READ:
-      CURL_FALLTHROUGH();
     case SSL_ERROR_WANT_WRITE:
       /* there's data pending, re-invoke wolfSSL_read() */
       CURL_TRC_CF(data, cf, "wolfssl_recv(len=%zu) -> AGAIN", blen);

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1084,9 +1084,9 @@ static ssize_t wolfssl_recv(struct Curl_cfilter *cf,
       *curlcode = CURLE_OK;
       return 0;
     case SSL_ERROR_NONE:
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SSL_ERROR_WANT_READ:
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case SSL_ERROR_WANT_WRITE:
       /* there's data pending, re-invoke wolfSSL_read() */
       CURL_TRC_CF(data, cf, "wolfssl_recv(len=%zu) -> AGAIN", blen);

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -606,6 +606,7 @@ static const char *UTime2str(const char *beg, const char *end)
   switch(tzp - sec) {
   case 0:
     sec = "00";
+    CURL_FALLTHROUGH();
   case 2:
     break;
   default:

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -379,10 +379,10 @@ utf8asn1str(char **to, int type, const char *from, const char *end)
       case 4:
         wc = (wc << 8) | *(const unsigned char *) from++;
         wc = (wc << 8) | *(const unsigned char *) from++;
-        CURL_FALLTHROUGH();
+        FALLTHROUGH();
       case 2:
         wc = (wc << 8) | *(const unsigned char *) from++;
-        CURL_FALLTHROUGH();
+        FALLTHROUGH();
       default: /* case 1: */
         wc = (wc << 8) | *(const unsigned char *) from++;
       }
@@ -548,7 +548,7 @@ static const char *GTime2str(const char *beg, const char *end)
     break;
   case 2:
     sec1 = fracp[-2];
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case 1:
     sec2 = fracp[-1];
     break;
@@ -606,7 +606,7 @@ static const char *UTime2str(const char *beg, const char *end)
   switch(tzp - sec) {
   case 0:
     sec = "00";
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case 2:
     break;
   default:

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -379,10 +379,10 @@ utf8asn1str(char **to, int type, const char *from, const char *end)
       case 4:
         wc = (wc << 8) | *(const unsigned char *) from++;
         wc = (wc << 8) | *(const unsigned char *) from++;
-        /* FALLTHROUGH */
+        CURL_FALLTHROUGH();
       case 2:
         wc = (wc << 8) | *(const unsigned char *) from++;
-        /* FALLTHROUGH */
+        CURL_FALLTHROUGH();
       default: /* case 1: */
         wc = (wc << 8) | *(const unsigned char *) from++;
       }
@@ -548,7 +548,7 @@ static const char *GTime2str(const char *beg, const char *end)
     break;
   case 2:
     sec1 = fracp[-2];
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case 1:
     sec2 = fracp[-1];
     break;

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -965,7 +965,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
      */
     const size_t len = ((pubkey->end - pubkey->beg - 2) * 4);
     if(!certnum)
-      infof(data, "   ECC Public Key (%lu bits)", len);
+      infof(data, "   ECC Public Key (%zu bits)", len);
     if(data->set.ssl.certinfo) {
       char q[sizeof(len) * 8 / 3 + 1];
       (void)msnprintf(q, sizeof(q), "%zu", len);
@@ -999,7 +999,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
     if(len > 32)
       elem.beg = q;     /* Strip leading zero bytes. */
     if(!certnum)
-      infof(data, "   RSA Public Key (%lu bits)", len);
+      infof(data, "   RSA Public Key (%zu bits)", len);
     if(data->set.ssl.certinfo) {
       char r[sizeof(len) * 8 / 3 + 1];
       msnprintf(r, sizeof(r), "%zu", len);

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -296,7 +296,7 @@ static CURLcode ws_dec_pass(struct ws_decoder *dec,
   case WS_DEC_INIT:
     ws_dec_reset(dec);
     dec->state = WS_DEC_HEAD;
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case WS_DEC_HEAD:
     result = ws_dec_read_head(dec, data, inraw);
     if(result) {
@@ -321,7 +321,7 @@ static CURLcode ws_dec_pass(struct ws_decoder *dec,
       dec->state = WS_DEC_INIT;
       break;
     }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case WS_DEC_PAYLOAD:
     result = ws_dec_pass_payload(dec, data, inraw, write_payload, write_ctx);
     ws_dec_info(dec, data, "passing");

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -296,7 +296,7 @@ static CURLcode ws_dec_pass(struct ws_decoder *dec,
   case WS_DEC_INIT:
     ws_dec_reset(dec);
     dec->state = WS_DEC_HEAD;
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case WS_DEC_HEAD:
     result = ws_dec_read_head(dec, data, inraw);
     if(result) {
@@ -321,7 +321,7 @@ static CURLcode ws_dec_pass(struct ws_decoder *dec,
       dec->state = WS_DEC_INIT;
       break;
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case WS_DEC_PAYLOAD:
     result = ws_dec_pass_payload(dec, data, inraw, write_payload, write_ctx);
     ws_dec_info(dec, data, "passing");

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -832,6 +832,8 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           dnl Only clang 2.9 or later
           if test "$compiler_num" -ge "209"; then
             tmp_CFLAGS="$tmp_CFLAGS -Wno-sign-conversion"
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [sign-conversion])  # FIXME
+          # tmp_CFLAGS="$tmp_CFLAGS -Wno-error=sign-conversion"          # FIXME
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [shift-sign-overflow])
           # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [padded])  # Not used because we cannot change public structs
           fi
@@ -839,6 +841,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           dnl Only clang 3.0 or later
           if test "$compiler_num" -ge "300"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [language-extension-token])
+            tmp_CFLAGS="$tmp_CFLAGS -Wformat=2"
           fi
           #
           dnl Only clang 3.2 or later
@@ -886,6 +889,10 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           if test "$compiler_num" -ge "700"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [assign-enum])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [extra-semi-stmt])
+          fi
+          dnl clang 10 or later
+          if test "$compiler_num" -ge "1000"; then
+            tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"  # we have silencing markup for clang 10.0 and above only
           fi
         fi
         dnl Disable pointer to bool conversion warnings since they cause
@@ -1016,8 +1023,10 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [type-limits old-style-declaration])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [missing-parameter-type empty-body])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [clobbered ignored-qualifiers])
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conversion])
+            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [conversion trampolines])
             tmp_CFLAGS="$tmp_CFLAGS -Wno-sign-conversion"
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [sign-conversion])  # FIXME
+          # tmp_CFLAGS="$tmp_CFLAGS -Wno-error=sign-conversion"          # FIXME
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [vla])
             dnl required for -Warray-bounds, included in -Wall
             tmp_CFLAGS="$tmp_CFLAGS -ftree-vrp"
@@ -1063,10 +1072,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [alloc-zero])
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-overflow=2"
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-truncation=2"
-            if test "$compiler_num" -lt "1200"; then
-              dnl gcc 12 doesn't acknowledge our comment markups
-              tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough=4"
-            fi
+            tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"
           fi
           #
           dnl Only gcc 10 or later

--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -1282,7 +1282,7 @@ curl_easy_setopt_ccsid(CURL *easy, CURLoption tag, ...)
       result = curl_easy_setopt(easy, tag, &blob);
       break;
     }
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case CURLOPT_ERRORBUFFER:                     /* This is an output buffer. */
     result = Curl_vsetopt(easy, tag, arg);
     break;

--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -1282,7 +1282,7 @@ curl_easy_setopt_ccsid(CURL *easy, CURLoption tag, ...)
       result = curl_easy_setopt(easy, tag, &blob);
       break;
     }
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case CURLOPT_ERRORBUFFER:                     /* This is an output buffer. */
     result = Curl_vsetopt(easy, tag, arg);
     break;

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -217,7 +217,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(output, "%s%s== Info: %.*s", timebuf, idsbuf, (int)size, data);
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   default: /* in case a new one is introduced to shock us */
     return 0;
 

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -217,7 +217,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(output, "%s%s== Info: %.*s", timebuf, idsbuf, (int)size, data);
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   default: /* in case a new one is introduced to shock us */
     return 0;
 

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -208,7 +208,14 @@ int tool_progress_cb(void *clientp,
     memset(line, '#', num);
     line[num] = '\0';
     msnprintf(format, sizeof(format), "\r%%-%ds %%5.1f%%%%", barwidth);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     fprintf(bar->out, format, line, percent);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
   }
   fflush(bar->out);
   bar->prev = point;

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -113,7 +113,14 @@ CURLcode easysrc_addf(struct slist_wc **plist, const char *fmt, ...)
   char *bufp;
   va_list ap;
   va_start(ap, fmt);
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
   bufp = curlx_mvaprintf(fmt, ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
   va_end(ap);
   if(!bufp) {
     ret = CURLE_OUT_OF_MEMORY;

--- a/src/tool_easysrc.h
+++ b/src/tool_easysrc.h
@@ -40,7 +40,7 @@ extern int easysrc_slist_count; /* Number of curl_slist variables */
 extern CURLcode easysrc_init(void);
 extern CURLcode easysrc_add(struct slist_wc **plist, const char *bupf);
 extern CURLcode easysrc_addf(struct slist_wc **plist,
-                             const char *fmt, ...);
+                             const char *fmt, ...) CURL_PRINTF(2, 3);
 extern CURLcode easysrc_perform(void);
 extern CURLcode easysrc_cleanup(void);
 

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -278,7 +278,7 @@ static CURLcode tool2curlparts(CURL *curl, struct tool_mime *m,
       case TOOLMIME_STDIN:
         if(!filename)
           filename = "-";
-        /* FALLTHROUGH */
+        CURL_FALLTHROUGH();
       case TOOLMIME_STDINDATA:
         ret = curl_mime_data_cb(part, m->size,
                                 (curl_read_callback) tool_mime_stdin_read,

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -278,7 +278,7 @@ static CURLcode tool2curlparts(CURL *curl, struct tool_mime *m,
       case TOOLMIME_STDIN:
         if(!filename)
           filename = "-";
-        CURL_FALLTHROUGH();
+        FALLTHROUGH();
       case TOOLMIME_STDINDATA:
         ret = curl_mime_data_cb(part, m->size,
                                 (curl_read_callback) tool_mime_stdin_read,

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2337,7 +2337,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         config->file_clobber_mode = toggle ? CLOBBER_ALWAYS : CLOBBER_NEVER;
         break;
       }
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case 'o': /* --output */
       /* output file */
     {
@@ -2640,7 +2640,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       switch(*nextarg) {
       case '+':
         nextarg++;
-        CURL_FALLTHROUGH();
+        FALLTHROUGH();
       default:
         /* If-Modified-Since: (section 14.28 in RFC2068) */
         config->timecond = CURL_TIMECOND_IFMODSINCE;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2337,7 +2337,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         config->file_clobber_mode = toggle ? CLOBBER_ALWAYS : CLOBBER_NEVER;
         break;
       }
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case 'o': /* --output */
       /* output file */
     {
@@ -2640,7 +2640,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       switch(*nextarg) {
       case '+':
         nextarg++;
-        /* FALLTHROUGH */
+        CURL_FALLTHROUGH();
       default:
         /* If-Modified-Since: (section 14.28 in RFC2068) */
         config->timecond = CURL_TIMECOND_IFMODSINCE;

--- a/src/tool_ipfs.c
+++ b/src/tool_ipfs.c
@@ -275,22 +275,19 @@ clean:
   curl_free(pathbuffer);
   curl_url_cleanup(gatewayurl);
   {
-    const char *msg = NULL;
     switch(result) {
     case CURLE_URL_MALFORMAT:
-      msg = "malformed target URL";
+      helpf(tool_stderr, "malformed target URL");
       break;
     case CURLE_FILE_COULDNT_READ_FILE:
-      msg = "IPFS automatic gateway detection failed";
+      helpf(tool_stderr, "IPFS automatic gateway detection failed");
       break;
     case CURLE_BAD_FUNCTION_ARGUMENT:
-      msg = "--ipfs-gateway was given a malformed URL";
+      helpf(tool_stderr, "--ipfs-gateway was given a malformed URL");
       break;
     default:
       break;
     }
-    if(msg)
-      helpf(tool_stderr, msg);
   }
   return result;
 }

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -48,7 +48,14 @@ static void voutf(struct GlobalConfig *config,
     char *ptr;
     char *print_buffer;
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     print_buffer = curlx_mvaprintf(fmt, ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     if(!print_buffer)
       return;
     len = strlen(print_buffer);
@@ -119,7 +126,14 @@ void helpf(FILE *errors, const char *fmt, ...)
     va_start(ap, fmt);
     DEBUGASSERT(!strchr(fmt, '\n'));
     fputs("curl: ", errors); /* prefix it */
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     vfprintf(errors, fmt, ap);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     va_end(ap);
     fputs("\n", errors); /* newline it */
   }

--- a/src/tool_msgs.h
+++ b/src/tool_msgs.h
@@ -26,9 +26,13 @@
 #include "tool_setup.h"
 #include "tool_cfgable.h"
 
-void warnf(struct GlobalConfig *config, const char *fmt, ...);
-void notef(struct GlobalConfig *config, const char *fmt, ...);
-void helpf(FILE *errors, const char *fmt, ...);
-void errorf(struct GlobalConfig *config, const char *fmt, ...);
+void warnf(struct GlobalConfig *config, const char *fmt, ...)
+  CURL_PRINTF(2, 3);
+void notef(struct GlobalConfig *config, const char *fmt, ...)
+  CURL_PRINTF(2, 3);
+void helpf(FILE *errors, const char *fmt, ...)
+  CURL_PRINTF(2, 3);
+void errorf(struct GlobalConfig *config, const char *fmt, ...)
+  CURL_PRINTF(2, 3);
 
 #endif /* HEADER_CURL_TOOL_MSGS_H */

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -408,7 +408,7 @@ ParameterError proto2num(struct OperationConfig *config,
           break;
         case set:
           protoset[0] = NULL;
-          /* FALLTHROUGH */
+          CURL_FALLTHROUGH();
         case allow:
           protoset_set(protoset, p);
           break;

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -408,7 +408,7 @@ ParameterError proto2num(struct OperationConfig *config,
           break;
         case set:
           protoset[0] = NULL;
-          CURL_FALLTHROUGH();
+          FALLTHROUGH();
         case allow:
           protoset_set(protoset, p);
           break;

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -431,7 +431,7 @@ static CURLcode libcurl_generate_mime_part(CURL *curl,
   case TOOLMIME_STDIN:
     if(!filename)
       filename = "-";
-    /* FALLTHROUGH */
+    CURL_FALLTHROUGH();
   case TOOLMIME_STDINDATA:
     /* Can only be reading stdin in the current context. */
     CODE1("curl_mime_data_cb(part%d, -1, (curl_read_callback) fread, \\",

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -438,7 +438,7 @@ static CURLcode libcurl_generate_mime_part(CURL *curl,
   case TOOLMIME_STDIN:
     if(!filename)
       filename = "-";
-    CURL_FALLTHROUGH();
+    FALLTHROUGH();
   case TOOLMIME_STDINDATA:
     /* Can only be reading stdin in the current context. */
     CODE1("curl_mime_data_cb(part%d, -1, (curl_read_callback) fread, \\",

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -247,8 +247,15 @@ static char *c_escape(const char *str, curl_off_t len)
           format = "\\%03o";
         }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
         result = curlx_dyn_addf(&escaped, format,
                                 (unsigned int) *(unsigned char *) s);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
       }
     }
   }

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -127,7 +127,7 @@ static CURLcode glob_set(struct URLGlob *glob, char **patternp,
       if(multiply(amount, pat->content.Set.size + 1))
         return GLOBERROR("range overflow", 0, CURLE_URL_MALFORMAT);
 
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     case ',':
 
       *buf = '\0';
@@ -171,7 +171,7 @@ static CURLcode glob_set(struct URLGlob *glob, char **patternp,
         ++pattern;
         ++(*posp);
       }
-      /* FALLTHROUGH */
+      CURL_FALLTHROUGH();
     default:
       *buf++ = *pattern++;              /* copy character to set element */
       ++(*posp);

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -127,7 +127,7 @@ static CURLcode glob_set(struct URLGlob *glob, char **patternp,
       if(multiply(amount, pat->content.Set.size + 1))
         return GLOBERROR("range overflow", 0, CURLE_URL_MALFORMAT);
 
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     case ',':
 
       *buf = '\0';
@@ -171,7 +171,7 @@ static CURLcode glob_set(struct URLGlob *glob, char **patternp,
         ++pattern;
         ++(*posp);
       }
-      CURL_FALLTHROUGH();
+      FALLTHROUGH();
     default:
       *buf++ = *pattern++;              /* copy character to set element */
       ++(*posp);

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -56,10 +56,7 @@ int my_trace(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "== Info: %s", data);
-    /* FALLTHROUGH */
-  default: /* in case a new one is introduced to shock us */
     return 0;
-
   case CURLINFO_HEADER_OUT:
     text = "=> Send header";
     break;
@@ -76,6 +73,8 @@ int my_trace(CURL *handle, curl_infotype type,
       return 0;
     text = "<= Recv data";
     break;
+  default: /* in case a new one is introduced to shock us */
+    return 0;
   }
 
   fprintf(stderr, "%s, %lu bytes (0x%lx)\n",

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -102,10 +102,7 @@ int my_trace(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "== Info: %s", data);
-    /* FALLTHROUGH */
-  default: /* in case a new one is introduced to shock us */
     return 0;
-
   case CURLINFO_HEADER_OUT:
     text = "=> Send header";
     break;
@@ -124,6 +121,8 @@ int my_trace(CURL *handle, curl_infotype type,
   case CURLINFO_SSL_DATA_IN:
     text = "<= Recv SSL data";
     break;
+  default: /* in case a new one is introduced to shock us */
+    return 0;
   }
 
   dump(text, (unsigned char *)data, size, 1);

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1662,6 +1662,10 @@ static int huge(void)
 
   for(i = 0; i <  7; i++) {
     char *partp;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
     msnprintf(total, sizeof(total),
               url,
               (i == 0)? &bigpart[1] : smallpart,
@@ -1671,6 +1675,9 @@ static int huge(void)
               (i == 4)? &bigpart[1] : smallpart,
               (i == 5)? &bigpart[1] : smallpart,
               (i == 6)? &bigpart[1] : smallpart);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     rc = curl_url_set(urlp, CURLUPART_URL, total, CURLU_NON_SUPPORT_SCHEME);
     if((!i && (rc != CURLUE_BAD_SCHEME)) ||
        (i && rc)) {

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -84,7 +84,7 @@ int test(char *URL)
     th = _beginthreadex(NULL, 0, run_thread, &results[i], 0, NULL);
 #endif
     if(!th) {
-      fprintf(stderr, "%s:%d Couldn't create thread, errno %d\n",
+      fprintf(stderr, "%s:%d Couldn't create thread, errno %lu\n",
               __FILE__, __LINE__, GetLastError());
       tid_count = i;
       test_failure = -1;

--- a/tests/libtest/lib517.c
+++ b/tests/libtest/lib517.c
@@ -164,7 +164,7 @@ int test(char *URL)
     time_t out = curl_getdate(dates[i].input, NULL);
     if(out != dates[i].output) {
       printf("WRONGLY %s => %ld (instead of %ld)\n",
-             dates[i].input, out, dates[i].output);
+             dates[i].input, (long)out, (long)dates[i].output);
       error++;
     }
   }

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -99,6 +99,11 @@ static int fopen_works(void)
   return ret;
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
+
 static int rlimit(int keep_open)
 {
   int nitems, i;
@@ -458,6 +463,10 @@ static int rlimit(int keep_open)
 
   return 0;
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 int test(char *URL)
 {

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -99,6 +99,11 @@ static int fopen_works(void)
   return ret;
 }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#endif
+
 static int rlimit(int keep_open)
 {
   int *tmpfd;
@@ -459,6 +464,10 @@ static int rlimit(int keep_open)
 
   return 0;
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 int test(char *URL)
 {

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -96,10 +96,7 @@ int my_trace(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "== Info: %s", (char *)data);
-    /* FALLTHROUGH */
-  default: /* in case a new one is introduced to shock us */
     return 0;
-
   case CURLINFO_HEADER_OUT:
     text = "=> Send header";
     break;
@@ -118,6 +115,8 @@ int my_trace(CURL *handle, curl_infotype type,
   case CURLINFO_SSL_DATA_IN:
     text = "<= Recv SSL data";
     break;
+  default: /* in case a new one is introduced to shock us */
+    return 0;
   }
 
   dump(text, stderr, (unsigned char *)data, size, config->trace_ascii);

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1281,7 +1281,7 @@ static int test_weird_arguments(void)
   rc = curl_msnprintf(buf, sizeof(buf), "%d, %.*1$d", 500, 1);
 
   if(rc != sizeof(buf) - 1) {
-    printf("curl_mprintf() returned %d and not %d!\n", rc,
+    printf("curl_mprintf() returned %d and not %zu!\n", rc,
            sizeof(buf) - 1);
     errors++;
   }

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -117,10 +117,7 @@ int libtest_debug_cb(CURL *handle, curl_infotype type,
   switch(type) {
   case CURLINFO_TEXT:
     fprintf(stderr, "%s== Info: %s", timestr, (char *)data);
-    /* FALLTHROUGH */
-  default: /* in case a new one is introduced to shock us */
     return 0;
-
   case CURLINFO_HEADER_OUT:
     text = "=> Send header";
     break;
@@ -139,6 +136,8 @@ int libtest_debug_cb(CURL *handle, curl_infotype type,
   case CURLINFO_SSL_DATA_IN:
     text = "<= Recv SSL data";
     break;
+  default: /* in case a new one is introduced to shock us */
+    return 0;
   }
 
   libtest_debug_dump(timebuf, text, stderr, data, size, trace_cfg->nohex);

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -767,12 +767,12 @@ static bool incoming(curl_socket_t listenfd)
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
-        logmsg("accept(%ld, NULL, NULL) failed with error: (%d) %s",
-               (long)sockfd, error, sstrerror(error));
+        logmsg("accept(%" CURL_FORMAT_SOCKET_T ", NULL, NULL) "
+               "failed with error: (%d) %s", sockfd, error, sstrerror(error));
       }
       else {
-        logmsg("====> Client connect, fd %ld. Read config from %s",
-               (long)newfd, configfile);
+        logmsg("====> Client connect, fd %" CURL_FORMAT_SOCKET_T ". "
+               "Read config from %s", newfd, configfile);
         set_advisor_read_lock(loglockfile);
         (void)mqttit(newfd); /* until done */
         clear_advisor_read_lock(loglockfile);
@@ -910,8 +910,8 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   rc = listen(sock, 5);
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("listen(%ld, 5) failed with error: (%d) %s",
-           (long)sock, error, sstrerror(error));
+    logmsg("listen(%" CURL_FORMAT_SOCKET_T ", 5) failed with error: (%d) %s",
+           sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -546,7 +546,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       buff_size = remaining_length;
       buffer = realloc(buffer, buff_size);
       if(!buffer) {
-        logmsg("Failed realloc of size %lu", buff_size);
+        logmsg("Failed realloc of size %zu", buff_size);
         goto end;
       }
     }
@@ -633,7 +633,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       /* two bytes topic length */
       topic_len = (buffer[2] << 8) | buffer[3];
       if(topic_len != (remaining_length - 5)) {
-        logmsg("Wrong topic length, got %d expected %zu",
+        logmsg("Wrong topic length, got %u expected %zu",
                topic_len, remaining_length - 5);
         goto end;
       }
@@ -767,12 +767,12 @@ static bool incoming(curl_socket_t listenfd)
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
-        logmsg("accept(%d, NULL, NULL) failed with error: (%d) %s",
-               sockfd, error, sstrerror(error));
+        logmsg("accept(%ld, NULL, NULL) failed with error: (%d) %s",
+               (long)sockfd, error, sstrerror(error));
       }
       else {
-        logmsg("====> Client connect, fd %d. Read config from %s",
-               newfd, configfile);
+        logmsg("====> Client connect, fd %ld. Read config from %s",
+               (long)newfd, configfile);
         set_advisor_read_lock(loglockfile);
         (void)mqttit(newfd); /* until done */
         clear_advisor_read_lock(loglockfile);
@@ -910,8 +910,8 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   rc = listen(sock, 5);
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("listen(%d, 5) failed with error: (%d) %s",
-           sock, error, sstrerror(error));
+    logmsg("listen(%ld, 5) failed with error: (%d) %s",
+           (long)sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -246,7 +246,7 @@ static int connack(FILE *dump, curl_socket_t fd)
 
   rc = swrite(fd, (char *)packet, sizeof(packet));
   if(rc > 0) {
-    logmsg("WROTE %d bytes [CONNACK]", rc);
+    logmsg("WROTE %zd bytes [CONNACK]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, "CONNACK", 2, dump, packet, sizeof(packet));
   }
@@ -270,7 +270,7 @@ static int suback(FILE *dump, curl_socket_t fd, unsigned short packetid)
 
   rc = swrite(fd, (char *)packet, sizeof(packet));
   if(rc == sizeof(packet)) {
-    logmsg("WROTE %d bytes [SUBACK]", rc);
+    logmsg("WROTE %zd bytes [SUBACK]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, "SUBACK", 3, dump, packet, rc);
     return 0;
@@ -292,7 +292,7 @@ static int puback(FILE *dump, curl_socket_t fd, unsigned short packetid)
 
   rc = swrite(fd, (char *)packet, sizeof(packet));
   if(rc == sizeof(packet)) {
-    logmsg("WROTE %d bytes [PUBACK]", rc);
+    logmsg("WROTE %zd bytes [PUBACK]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, dump, packet, rc);
     return 0;
@@ -310,7 +310,7 @@ static int disconnect(FILE *dump, curl_socket_t fd)
   };
   ssize_t rc = swrite(fd, (char *)packet, sizeof(packet));
   if(rc == sizeof(packet)) {
-    logmsg("WROTE %d bytes [DISCONNECT]", rc);
+    logmsg("WROTE %zd bytes [DISCONNECT]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, "DISCONNECT", 0, dump, packet, rc);
     return 0;
@@ -439,7 +439,7 @@ static int publish(FILE *dump,
 
   rc = swrite(fd, (char *)packet, sendamount);
   if(rc > 0) {
-    logmsg("WROTE %d bytes [PUBLISH]", rc);
+    logmsg("WROTE %zd bytes [PUBLISH]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, "PUBLISH", remaininglength, dump, packet, rc);
   }
@@ -465,10 +465,10 @@ static int fixedheader(curl_socket_t fd,
   ssize_t rc = sread(fd, (char *)buffer, 2);
   int i;
   if(rc < 2) {
-    logmsg("READ %d bytes [SHORT!]", rc);
+    logmsg("READ %zd bytes [SHORT!]", rc);
     return 1; /* fail */
   }
-  logmsg("READ %d bytes", rc);
+  logmsg("READ %zd bytes", rc);
   loghex(buffer, rc);
   *bytep = buffer[0];
 
@@ -483,7 +483,7 @@ static int fixedheader(curl_socket_t fd,
     }
   }
   *remaining_lengthp = decode_length(&buffer[1], i, remaining_length_bytesp);
-  logmsg("Remaining Length: %ld [%d bytes]", (long) *remaining_lengthp,
+  logmsg("Remaining Length: %zu [%zu bytes]", *remaining_lengthp,
          *remaining_length_bytesp);
   return 0;
 }
@@ -555,7 +555,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       /* reading variable header and payload into buffer */
       rc = sread(fd, (char *)buffer, remaining_length);
       if(rc > 0) {
-        logmsg("READ %d bytes", rc);
+        logmsg("READ %zd bytes", rc);
         loghex(buffer, rc);
       }
     }
@@ -592,7 +592,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
 
       /* check the length of the payload */
       if((ssize_t)payload_len != (rc - 12)) {
-        logmsg("Payload length mismatch, expected %x got %x",
+        logmsg("Payload length mismatch, expected %zx got %zx",
                rc - 12, payload_len);
         goto end;
       }
@@ -633,7 +633,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       /* two bytes topic length */
       topic_len = (buffer[2] << 8) | buffer[3];
       if(topic_len != (remaining_length - 5)) {
-        logmsg("Wrong topic length, got %d expected %d",
+        logmsg("Wrong topic length, got %d expected %zu",
                topic_len, remaining_length - 5);
         goto end;
       }
@@ -677,7 +677,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
                   dump, buffer, rc);
 
       topiclen = (buffer[1 + bytes] << 8) | buffer[2 + bytes];
-      logmsg("Got %d bytes topic", topiclen);
+      logmsg("Got %zu bytes topic", topiclen);
       /* TODO: verify topiclen */
 
 #ifdef QOS
@@ -688,7 +688,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       /* get the request */
       rc = sread(fd, (char *)&buffer[0], 2);
 
-      logmsg("READ %d bytes [DISCONNECT]", rc);
+      logmsg("READ %zd bytes [DISCONNECT]", rc);
       loghex(buffer, rc);
       logprotocol(FROM_CLIENT, "DISCONNECT", 0, dump, buffer, rc);
       goto end;

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -551,14 +551,14 @@ static unsigned int WINAPI select_ws_wait_thread(void *lpParameter)
             continue;
           }
           else {
-            logmsg("[select_ws_wait_thread] PeekNamedPipe len: %d", length);
+            logmsg("[select_ws_wait_thread] PeekNamedPipe len: %lu", length);
           }
         }
         else {
           /* if the pipe has NOT been closed, sleep and continue waiting */
           ret = GetLastError();
           if(ret != ERROR_BROKEN_PIPE) {
-            logmsg("[select_ws_wait_thread] PeekNamedPipe error: %d", ret);
+            logmsg("[select_ws_wait_thread] PeekNamedPipe error: %lu", ret);
             SleepEx(0, FALSE);
             continue;
           }
@@ -1159,8 +1159,8 @@ static bool juggle(curl_socket_t *sockfdp,
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
-        logmsg("accept(%d, NULL, NULL) failed with error: (%d) %s",
-               sockfd, error, sstrerror(error));
+        logmsg("accept(%ld, NULL, NULL) failed with error: (%d) %s",
+               (long)sockfd, error, sstrerror(error));
       }
       else {
         logmsg("====> Client connect");
@@ -1335,8 +1335,8 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   rc = listen(sock, 5);
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("listen(%d, 5) failed with error: (%d) %s",
-           sock, error, sstrerror(error));
+    logmsg("listen(%ld, 5) failed with error: (%d) %s",
+           (long)sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1159,8 +1159,8 @@ static bool juggle(curl_socket_t *sockfdp,
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
-        logmsg("accept(%ld, NULL, NULL) failed with error: (%d) %s",
-               (long)sockfd, error, sstrerror(error));
+        logmsg("accept(%" CURL_FORMAT_SOCKET_T ", NULL, NULL) "
+               "failed with error: (%d) %s", sockfd, error, sstrerror(error));
       }
       else {
         logmsg("====> Client connect");
@@ -1335,8 +1335,8 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   rc = listen(sock, 5);
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("listen(%ld, 5) failed with error: (%d) %s",
-           (long)sock, error, sstrerror(error));
+    logmsg("listen(%" CURL_FORMAT_SOCKET_T ", 5) failed with error: (%d) %s",
+           sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -323,7 +323,7 @@ static curl_socket_t socks4(curl_socket_t fd,
     return CURL_SOCKET_BAD;
   }
   if(rc < 9) {
-    logmsg("SOCKS4 connect message too short: %d", rc);
+    logmsg("SOCKS4 connect message too short: %zd", rc);
     return CURL_SOCKET_BAD;
   }
   if(!config.port)
@@ -350,7 +350,7 @@ static curl_socket_t socks4(curl_socket_t fd,
     logmsg("Sending SOCKS4 response failed!");
     return CURL_SOCKET_BAD;
   }
-  logmsg("Sent %d bytes", rc);
+  logmsg("Sent %zd bytes", rc);
   loghex(response, rc);
 
   if(cd == 90)
@@ -380,18 +380,18 @@ static curl_socket_t sockit(curl_socket_t fd)
 
   rc = recv(fd, (char *)buffer, sizeof(buffer), 0);
   if(rc <= 0) {
-    logmsg("SOCKS identifier message missing, recv returned %d", rc);
+    logmsg("SOCKS identifier message missing, recv returned %zd", rc);
     return CURL_SOCKET_BAD;
   }
 
-  logmsg("READ %d bytes", rc);
+  logmsg("READ %zd bytes", rc);
   loghex(buffer, rc);
 
   if(buffer[SOCKS5_VERSION] == 4)
     return socks4(fd, buffer, rc);
 
   if(rc < 3) {
-    logmsg("SOCKS5 identifier message too short: %d", rc);
+    logmsg("SOCKS5 identifier message too short: %zd", rc);
     return CURL_SOCKET_BAD;
   }
 
@@ -408,7 +408,7 @@ static curl_socket_t sockit(curl_socket_t fd)
   /* after NMETHODS follows that many bytes listing the methods the client
      says it supports */
   if(rc != (buffer[SOCKS5_NMETHODS] + 2)) {
-    logmsg("Expected %d bytes, got %d", buffer[SOCKS5_NMETHODS] + 2, rc);
+    logmsg("Expected %d bytes, got %zd", buffer[SOCKS5_NMETHODS] + 2, rc);
     return CURL_SOCKET_BAD;
   }
   logmsg("Incoming request deemed fine!");
@@ -421,17 +421,17 @@ static curl_socket_t sockit(curl_socket_t fd)
     logmsg("Sending response failed!");
     return CURL_SOCKET_BAD;
   }
-  logmsg("Sent %d bytes", rc);
+  logmsg("Sent %zd bytes", rc);
   loghex(response, rc);
 
   /* expect the request or auth */
   rc = recv(fd, (char *)buffer, sizeof(buffer), 0);
   if(rc <= 0) {
-    logmsg("SOCKS5 request or auth message missing, recv returned %d", rc);
+    logmsg("SOCKS5 request or auth message missing, recv returned %zd", rc);
     return CURL_SOCKET_BAD;
   }
 
-  logmsg("READ %d bytes", rc);
+  logmsg("READ %zd bytes", rc);
   loghex(buffer, rc);
 
   if(config.responsemethod == 2) {
@@ -446,7 +446,7 @@ static curl_socket_t sockit(curl_socket_t fd)
     unsigned char plen;
     bool login = TRUE;
     if(rc < 5) {
-      logmsg("Too short auth input: %d", rc);
+      logmsg("Too short auth input: %zd", rc);
       return CURL_SOCKET_BAD;
     }
     if(buffer[SOCKS5_VERSION] != 1) {
@@ -455,12 +455,12 @@ static curl_socket_t sockit(curl_socket_t fd)
     }
     ulen = buffer[SOCKS5_ULEN];
     if(rc < 4 + ulen) {
-      logmsg("Too short packet for username: %d", rc);
+      logmsg("Too short packet for username: %zd", rc);
       return CURL_SOCKET_BAD;
     }
     plen = buffer[SOCKS5_ULEN + ulen + 1];
     if(rc < 3 + ulen + plen) {
-      logmsg("Too short packet for ulen %d plen %d: %d", ulen, plen, rc);
+      logmsg("Too short packet for ulen %d plen %d: %zd", ulen, plen, rc);
       return CURL_SOCKET_BAD;
     }
     if((ulen != strlen(config.user)) ||
@@ -478,7 +478,7 @@ static curl_socket_t sockit(curl_socket_t fd)
       logmsg("Sending auth response failed!");
       return CURL_SOCKET_BAD;
     }
-    logmsg("Sent %d bytes", rc);
+    logmsg("Sent %zd bytes", rc);
     loghex(response, rc);
     if(!login)
       return CURL_SOCKET_BAD;
@@ -486,15 +486,15 @@ static curl_socket_t sockit(curl_socket_t fd)
     /* expect the request */
     rc = recv(fd, (char *)buffer, sizeof(buffer), 0);
     if(rc <= 0) {
-      logmsg("SOCKS5 request message missing, recv returned %d", rc);
+      logmsg("SOCKS5 request message missing, recv returned %zd", rc);
       return CURL_SOCKET_BAD;
     }
 
-    logmsg("READ %d bytes", rc);
+    logmsg("READ %zd bytes", rc);
     loghex(buffer, rc);
   }
   if(rc < 6) {
-    logmsg("Too short for request: %d", rc);
+    logmsg("Too short for request: %zd", rc);
     return CURL_SOCKET_BAD;
   }
 
@@ -539,7 +539,7 @@ static curl_socket_t sockit(curl_socket_t fd)
     return CURL_SOCKET_BAD;
   }
   if(rc < (4 + len + 2)) {
-    logmsg("Request too short: %d, expected %d", rc, 4 + len + 2);
+    logmsg("Request too short: %zd, expected %d", rc, 4 + len + 2);
     return CURL_SOCKET_BAD;
   }
   logmsg("Received ATYP %d", type);
@@ -625,7 +625,7 @@ static curl_socket_t sockit(curl_socket_t fd)
     logmsg("Sending connect response failed!");
     return CURL_SOCKET_BAD;
   }
-  logmsg("Sent %d bytes", rc);
+  logmsg("Sent %zd bytes", rc);
   loghex(response, rc);
 
   if(!rep)

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -754,13 +754,13 @@ static bool incoming(curl_socket_t listenfd)
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
-        logmsg("accept(%d, NULL, NULL) failed with error: (%d) %s",
-               sockfd, error, sstrerror(error));
+        logmsg("accept(%ld, NULL, NULL) failed with error: (%d) %s",
+               (long)sockfd, error, sstrerror(error));
       }
       else {
         curl_socket_t remotefd;
-        logmsg("====> Client connect, fd %d. Read config from %s",
-               newfd, configfile);
+        logmsg("====> Client connect, fd %ld. Read config from %s",
+               (long)newfd, configfile);
         remotefd = sockit(newfd); /* SOCKS until done */
         if(remotefd == CURL_SOCKET_BAD) {
           logmsg("====> Client disconnect");
@@ -943,8 +943,8 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   rc = listen(sock, 5);
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("listen(%d, 5) failed with error: (%d) %s",
-           sock, error, sstrerror(error));
+    logmsg("listen(%ld, 5) failed with error: (%d) %s",
+           (long)sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -754,13 +754,14 @@ static bool incoming(curl_socket_t listenfd)
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
-        logmsg("accept(%ld, NULL, NULL) failed with error: (%d) %s",
-               (long)sockfd, error, sstrerror(error));
+        logmsg("accept(%" CURL_FORMAT_SOCKET_T ", NULL, NULL) "
+               "failed with error: (%d) %s",
+               sockfd, error, sstrerror(error));
       }
       else {
         curl_socket_t remotefd;
-        logmsg("====> Client connect, fd %ld. Read config from %s",
-               (long)newfd, configfile);
+        logmsg("====> Client connect, fd %" CURL_FORMAT_SOCKET_T ". "
+               "Read config from %s", newfd, configfile);
         remotefd = sockit(newfd); /* SOCKS until done */
         if(remotefd == CURL_SOCKET_BAD) {
           logmsg("====> Client disconnect");
@@ -943,8 +944,8 @@ static curl_socket_t sockdaemon(curl_socket_t sock,
   rc = listen(sock, 5);
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("listen(%ld, 5) failed with error: (%d) %s",
-           (long)sock, error, sstrerror(error));
+    logmsg("listen(%" CURL_FORMAT_SOCKET_T ", 5) failed with error: (%d) %s",
+           sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2334,8 +2334,8 @@ int main(int argc, char *argv[])
       curl_socket_t msgsock;
       do {
         msgsock = accept_connection(sock);
-        logmsg("accept_connection %ld returned %ld",
-               (long)sock, (long)msgsock);
+        logmsg("accept_connection %" CURL_FORMAT_SOCKET_T
+               " returned %" CURL_FORMAT_SOCKET_T, sock, msgsock);
         if(CURL_SOCKET_BAD == msgsock)
           goto sws_cleanup;
         if(req->delay)

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2334,7 +2334,8 @@ int main(int argc, char *argv[])
       curl_socket_t msgsock;
       do {
         msgsock = accept_connection(sock);
-        logmsg("accept_connection %d returned %d", sock, msgsock);
+        logmsg("accept_connection %ld returned %ld",
+               (long)sock, (long)msgsock);
         if(CURL_SOCKET_BAD == msgsock)
           goto sws_cleanup;
         if(req->delay)

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -374,7 +374,7 @@ static int ProcessRequest(struct httprequest *req)
 
   req->callcount++;
 
-  logmsg("Process %d bytes request%s", req->offset,
+  logmsg("Process %zu bytes request%s", req->offset,
          req->callcount > 1?" [CONTINUED]":"");
 
   /* try to figure out the request characteristics as soon as possible, but
@@ -557,14 +557,14 @@ static int ProcessRequest(struct httprequest *req)
     logmsg("request not complete yet");
     return 0; /* not complete yet */
   }
-  logmsg("- request found to be complete (%d)", req->testno);
+  logmsg("- request found to be complete (%ld)", req->testno);
 
   if(req->testno == DOCNUMBER_NOTHING) {
     /* check for a Testno: header with the test case number */
     char *testno = strstr(line, "\nTestno: ");
     if(testno) {
       req->testno = strtol(&testno[9], NULL, 10);
-      logmsg("Found test number %d in Testno: header!", req->testno);
+      logmsg("Found test number %ld in Testno: header!", req->testno);
     }
     else {
       logmsg("No Testno: header");
@@ -702,8 +702,8 @@ static int ProcessRequest(struct httprequest *req)
     /* Negotiate iterations */
     static long prev_testno = -1;
     static long prev_partno = -1;
-    logmsg("Negotiate: prev_testno: %d, prev_partno: %d",
-            prev_testno, prev_partno);
+    logmsg("Negotiate: prev_testno: %ld, prev_partno: %ld",
+           prev_testno, prev_partno);
     if(req->testno != prev_testno) {
       prev_testno = req->testno;
       prev_partno = req->partno;
@@ -1198,8 +1198,8 @@ retry:
       int intervals = msecs_left / MAX_SLEEP_TIME_MS;
       if(msecs_left%MAX_SLEEP_TIME_MS)
         intervals++;
-      logmsg("Pausing %d milliseconds after writing %d bytes",
-         msecs_left, written);
+      logmsg("Pausing %d milliseconds after writing %zd bytes",
+             msecs_left, written);
       while((intervals > 0) && !got_exit_signal) {
         int sleep_time = msecs_left > MAX_SLEEP_TIME_MS ?
           MAX_SLEEP_TIME_MS : msecs_left;

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1129,7 +1129,7 @@ static int validate_access(struct testcase *test,
     if(!stream) {
       int error = errno;
       logmsg("fopen() failed with error: %d %s", error, strerror(error));
-      logmsg("Couldn't open test file for test : %d", testno);
+      logmsg("Couldn't open test file for test: %ld", testno);
       return EACCESS;
     }
     else {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -139,7 +139,7 @@ static const char *win32_strerror(int err, char *buf, size_t buflen)
   if(!FormatMessageA((FORMAT_MESSAGE_FROM_SYSTEM |
                       FORMAT_MESSAGE_IGNORE_INSERTS), NULL, err,
                      LANG_NEUTRAL, buf, (DWORD)buflen, NULL))
-    msnprintf(buf, buflen, "Unknown error %lu (%#lx)", err, err);
+    msnprintf(buf, buflen, "Unknown error %d (%#x)", err, err);
   return buf;
 }
 
@@ -555,7 +555,7 @@ static void exit_signal_handler(int signum)
 static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 {
   int signum = 0;
-  logmsg("ctrl_event_handler: %d", dwCtrlType);
+  logmsg("ctrl_event_handler: %lu", dwCtrlType);
   switch(dwCtrlType) {
 #ifdef SIGINT
     case CTRL_C_EVENT: signum = SIGINT; break;
@@ -569,7 +569,7 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
     default: return FALSE;
   }
   if(signum) {
-    logmsg("ctrl_event_handler: %d -> %d", dwCtrlType, signum);
+    logmsg("ctrl_event_handler: %lu -> %d", dwCtrlType, signum);
     raise(signum);
   }
   return TRUE;

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -26,7 +26,7 @@
 #include "server_setup.h"
 
 char *data_to_hex(char *data, size_t len);
-void logmsg(const char *msg, ...);
+void logmsg(const char *msg, ...) CURL_PRINTF(1, 2);
 long timediff(struct timeval newer, struct timeval older);
 
 #define TEST_DATA_PATH "%s/data/test%ld"

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -105,7 +105,7 @@ fail_unless(verify(result, "Simple Test 42 testing 43\n") == 0,
 /* Variations of empty strings */
 Curl_infof(data, "");
 fail_unless(strlen(result) == 1, "Empty string");
-Curl_infof(data, "%s", NULL);
+Curl_infof(data, "%s", (char *)NULL);
 fail_unless(verify(result, "(nil)") == 0, "Passing NULL as string");
 
 /* A string just long enough to not be truncated */

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -21,6 +21,8 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
+#define CURL_NO_FMT_CHECKS
+
 #include "curlcheck.h"
 
 #include "urldata.h"


### PR DESCRIPTION
https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html
[as of [2023-11-29](https://github.com/ossf/wg-best-practices-os-developers/blob/56c0fde3895bfc55c8a973ef49a2572c507b2ae1/docs/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C%2B%2B.md)]

Enable new recommended warnings (except `-Wsign-conversion`):

- enable `-Wformat=2` for clang (in both cmake and autotools).
- add `CURL_PRINTF()` internal attribute and mark functions accepting
  printf arguments with it. This is a copy of existing
  `CURL_TEMP_PRINTF()` but using `__printf__` to make it compatible
  with redefinting the `printf` symbol:
  https://gcc.gnu.org/onlinedocs/gcc-3.0.4/gcc_5.html#SEC94
- fix `CURL_PRINTF()` and existing `CURL_TEMP_PRINTF()` for
  mingw-w64 and enable it on this platform.
- enable `-Wimplicit-fallthrough`.
- enable `-Wtrampolines`.
- add `-Wsign-conversion` commented with a FIXME.
- cmake: enable `-pedantic-errors` the way we do it with autotools.
  Follow-up to d5c0351055d5709da8f3e16c91348092fdb481aa #2747
- lib/curl_trc.h: use `CURL_FORMAT()`, this also fixes it to enable format
  checks. Previously it was always disabled due to the internal `printf`
  macro.

Fix them:

- fix bug where an `set_ipv6_v6only()` call was missed in builds with
  `--disable-verbose` / `CURL_DISABLE_VERBOSE_STRINGS=ON`.
- add internal `FALLTHROUGH()` macro.
- replace obsolete fall-through comments with `FALLTHROUGH()`.
- fix fallthrough markups: Delete redundant ones (showing up as
  warnings in most cases). Add missing ones. Fix indentation.
- silence `-Wformat-nonliteral` warnings with llvm/clang.
- fix one `-Wformat-nonliteral` warning.
- fix new `-Wformat` and `-Wformat-security` warnings.
- fix `CURL_FORMAT_SOCKET_T` value for mingw-w64. Also move its
  definition to `lib/curl_setup.h` allowing use in `tests/server`.
- lib: fix two wrongly passed string arguments in log outputs.
  Co-authored-by: Jay Satiro
- fix new `-Wformat` warnings on mingw-w64.

Closes #12489

---

TODO:
- [x] fix to enable format checks for mingw.
- [x] fix `-Warith-conversion` warnings. [other PR]
- [x] fix `-Wsign-conversion` warnings. [other PR]
