### PR TITLE
lib: rename Curl_strndup to Curl_memdup0 to avoid misunderstanding

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -123,11 +123,11 @@ static struct altsvc *altsvc_createid(const char *srchost,
     dlen -= 2;
   }
 
-  as->src.host = Curl_memdump0(srchost, hlen);
+  as->src.host = Curl_memdup0(srchost, hlen);
   if(!as->src.host)
     goto error;
 
-  as->dst.host = Curl_memdump0(dsthost, dlen);
+  as->dst.host = Curl_memdup0(dsthost, dlen);
   if(!as->dst.host)
     goto error;
 

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -123,11 +123,11 @@ static struct altsvc *altsvc_createid(const char *srchost,
     dlen -= 2;
   }
 
-  as->src.host = Curl_strndup(srchost, hlen);
+  as->src.host = Curl_memdump0(srchost, hlen);
   if(!as->src.host)
     goto error;
 
-  as->dst.host = Curl_strndup(dsthost, dlen);
+  as->dst.host = Curl_memdump0(dsthost, dlen);
   if(!as->dst.host)
     goto error;
 

--- a/lib/bufref.c
+++ b/lib/bufref.c
@@ -117,7 +117,7 @@ CURLcode Curl_bufref_memdup(struct bufref *br, const void *ptr, size_t len)
   DEBUGASSERT(len <= CURL_MAX_INPUT_LENGTH);
 
   if(ptr) {
-    cpy = Curl_strndup(ptr, len);
+    cpy = Curl_memdump0(ptr, len);
     if(!cpy)
       return CURLE_OUT_OF_MEMORY;
   }

--- a/lib/bufref.c
+++ b/lib/bufref.c
@@ -117,7 +117,7 @@ CURLcode Curl_bufref_memdup(struct bufref *br, const void *ptr, size_t len)
   DEBUGASSERT(len <= CURL_MAX_INPUT_LENGTH);
 
   if(ptr) {
-    cpy = Curl_memdump0(ptr, len);
+    cpy = Curl_memdup0(ptr, len);
     if(!cpy)
       return CURLE_OUT_OF_MEMORY;
   }

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -365,7 +365,7 @@ static void strstore(char **str, const char *newstr, size_t len)
   DEBUGASSERT(newstr);
   DEBUGASSERT(str);
   free(*str);
-  *str = Curl_strndup(newstr, len);
+  *str = Curl_memdump0(newstr, len);
 }
 
 /*
@@ -821,7 +821,7 @@ Curl_cookie_add(struct Curl_easy *data,
         endslash = memrchr(path, '/', (queryp - path));
       if(endslash) {
         size_t pathlen = (endslash-path + 1); /* include end slash */
-        co->path = Curl_strndup(path, pathlen);
+        co->path = Curl_memdump0(path, pathlen);
         if(co->path) {
           co->spath = sanitize_cookie_path(co->path);
           if(!co->spath)

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -365,7 +365,7 @@ static void strstore(char **str, const char *newstr, size_t len)
   DEBUGASSERT(newstr);
   DEBUGASSERT(str);
   free(*str);
-  *str = Curl_memdump0(newstr, len);
+  *str = Curl_memdup0(newstr, len);
 }
 
 /*
@@ -821,7 +821,7 @@ Curl_cookie_add(struct Curl_easy *data,
         endslash = memrchr(path, '/', (queryp - path));
       if(endslash) {
         size_t pathlen = (endslash-path + 1); /* include end slash */
-        co->path = Curl_memdump0(path, pathlen);
+        co->path = Curl_memdup0(path, pathlen);
         if(co->path) {
           co->spath = sanitize_cookie_path(co->path);
           if(!co->spath)

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -603,7 +603,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
            app passed in a bad combo, so we better check for that first. */
         if(form->name) {
           /* copy name (without strdup; possibly not null-terminated) */
-          form->name = Curl_strndup(form->name, form->namelength?
+          form->name = Curl_memdump0(form->name, form->namelength?
                                     form->namelength:
                                     strlen(form->name));
         }
@@ -779,7 +779,7 @@ static CURLcode setname(curl_mimepart *part, const char *name, size_t len)
 
   if(!name || !len)
     return curl_mime_name(part, name);
-  zname = Curl_strndup(name, len);
+  zname = Curl_memdump0(name, len);
   if(!zname)
     return CURLE_OUT_OF_MEMORY;
   res = curl_mime_name(part, zname);

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -603,7 +603,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
            app passed in a bad combo, so we better check for that first. */
         if(form->name) {
           /* copy name (without strdup; possibly not null-terminated) */
-          form->name = Curl_memdump0(form->name, form->namelength?
+          form->name = Curl_memdup0(form->name, form->namelength?
                                     form->namelength:
                                     strlen(form->name));
         }
@@ -779,7 +779,7 @@ static CURLcode setname(curl_mimepart *part, const char *name, size_t len)
 
   if(!name || !len)
     return curl_mime_name(part, name);
-  zname = Curl_memdump0(name, len);
+  zname = Curl_memdup0(name, len);
   if(!zname)
     return CURLE_OUT_OF_MEMORY;
   res = curl_mime_name(part, zname);

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4170,7 +4170,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
           return CURLE_OUT_OF_MEMORY;
         }
 
-        ftpc->dirs[0] = Curl_strndup(rawPath, dirlen);
+        ftpc->dirs[0] = Curl_memdump0(rawPath, dirlen);
         if(!ftpc->dirs[0]) {
           free(rawPath);
           return CURLE_OUT_OF_MEMORY;
@@ -4214,7 +4214,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
              CWD requires a parameter and a non-existent parameter a) doesn't
              work on many servers and b) has no effect on the others. */
           if(compLen > 0) {
-            char *comp = Curl_strndup(curPos, compLen);
+            char *comp = Curl_memdump0(curPos, compLen);
             if(!comp) {
               free(rawPath);
               return CURLE_OUT_OF_MEMORY;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4170,7 +4170,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
           return CURLE_OUT_OF_MEMORY;
         }
 
-        ftpc->dirs[0] = Curl_memdump0(rawPath, dirlen);
+        ftpc->dirs[0] = Curl_memdup0(rawPath, dirlen);
         if(!ftpc->dirs[0]) {
           free(rawPath);
           return CURLE_OUT_OF_MEMORY;
@@ -4214,7 +4214,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
              CWD requires a parameter and a non-existent parameter a) doesn't
              work on many servers and b) has no effect on the others. */
           if(compLen > 0) {
-            char *comp = Curl_memdump0(curPos, compLen);
+            char *comp = Curl_memdup0(curPos, compLen);
             if(!comp) {
               free(rawPath);
               return CURLE_OUT_OF_MEMORY;

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -135,7 +135,7 @@ static CURLcode hsts_create(struct hsts *h,
   if(!sts)
     return CURLE_OUT_OF_MEMORY;
 
-  duphost = Curl_memdump0(hostname, hlen);
+  duphost = Curl_memdup0(hostname, hlen);
   if(!duphost) {
     free(sts);
     return CURLE_OUT_OF_MEMORY;

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -135,7 +135,7 @@ static CURLcode hsts_create(struct hsts *h,
   if(!sts)
     return CURLE_OUT_OF_MEMORY;
 
-  duphost = Curl_strndup(hostname, hlen);
+  duphost = Curl_memdump0(hostname, hlen);
   if(!duphost) {
     free(sts);
     return CURLE_OUT_OF_MEMORY;

--- a/lib/http.c
+++ b/lib/http.c
@@ -329,7 +329,7 @@ char *Curl_copy_header_value(const char *header)
   /* get length of the type */
   len = end - start + 1;
 
-  return Curl_strndup(start, len);
+  return Curl_memdump0(start, len);
 }
 
 #ifndef CURL_DISABLE_HTTP_AUTH
@@ -4617,17 +4617,17 @@ CURLcode Curl_http_req_make(struct httpreq **preq,
     goto out;
   memcpy(req->method, method, m_len);
   if(scheme) {
-    req->scheme = Curl_strndup(scheme, s_len);
+    req->scheme = Curl_memdump0(scheme, s_len);
     if(!req->scheme)
       goto out;
   }
   if(authority) {
-    req->authority = Curl_strndup(authority, a_len);
+    req->authority = Curl_memdump0(authority, a_len);
     if(!req->authority)
       goto out;
   }
   if(path) {
-    req->path = Curl_strndup(path, p_len);
+    req->path = Curl_memdump0(path, p_len);
     if(!req->path)
       goto out;
   }

--- a/lib/http.c
+++ b/lib/http.c
@@ -329,7 +329,7 @@ char *Curl_copy_header_value(const char *header)
   /* get length of the type */
   len = end - start + 1;
 
-  return Curl_memdump0(start, len);
+  return Curl_memdup0(start, len);
 }
 
 #ifndef CURL_DISABLE_HTTP_AUTH
@@ -4617,17 +4617,17 @@ CURLcode Curl_http_req_make(struct httpreq **preq,
     goto out;
   memcpy(req->method, method, m_len);
   if(scheme) {
-    req->scheme = Curl_memdump0(scheme, s_len);
+    req->scheme = Curl_memdup0(scheme, s_len);
     if(!req->scheme)
       goto out;
   }
   if(authority) {
-    req->authority = Curl_memdump0(authority, a_len);
+    req->authority = Curl_memdup0(authority, a_len);
     if(!req->authority)
       goto out;
   }
   if(path) {
-    req->path = Curl_memdump0(path, p_len);
+    req->path = Curl_memdup0(path, p_len);
     if(!req->path)
       goto out;
   }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -934,7 +934,7 @@ CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header)
        */
 
       /* Copy the id substring into a new buffer */
-      data->set.str[STRING_RTSP_SESSION_ID] = Curl_memdump0(start, idlen);
+      data->set.str[STRING_RTSP_SESSION_ID] = Curl_memdup0(start, idlen);
       if(!data->set.str[STRING_RTSP_SESSION_ID])
         return CURLE_OUT_OF_MEMORY;
     }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -934,7 +934,7 @@ CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, char *header)
        */
 
       /* Copy the id substring into a new buffer */
-      data->set.str[STRING_RTSP_SESSION_ID] = Curl_strndup(start, idlen);
+      data->set.str[STRING_RTSP_SESSION_ID] = Curl_memdump0(start, idlen);
       if(!data->set.str[STRING_RTSP_SESSION_ID])
         return CURLE_OUT_OF_MEMORY;
     }

--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -101,7 +101,7 @@ void *Curl_memdup(const void *src, size_t length)
 
 /***************************************************************************
  *
- * Curl_strndup(source, length)
+ * Curl_memdump0(source, length)
  *
  * Copies the 'source' string to a newly allocated buffer (that is returned).
  * Copies 'length' bytes then adds a null terminator.
@@ -109,7 +109,7 @@ void *Curl_memdup(const void *src, size_t length)
  * Returns the new pointer or NULL on failure.
  *
  ***************************************************************************/
-void *Curl_strndup(const char *src, size_t length)
+void *Curl_memdump0(const char *src, size_t length)
 {
   char *buf = malloc(length + 1);
   if(!buf)

--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -101,7 +101,7 @@ void *Curl_memdup(const void *src, size_t length)
 
 /***************************************************************************
  *
- * Curl_memdump0(source, length)
+ * Curl_memdup0(source, length)
  *
  * Copies the 'source' string to a newly allocated buffer (that is returned).
  * Copies 'length' bytes then adds a null terminator.
@@ -109,7 +109,7 @@ void *Curl_memdup(const void *src, size_t length)
  * Returns the new pointer or NULL on failure.
  *
  ***************************************************************************/
-void *Curl_memdump0(const char *src, size_t length)
+void *Curl_memdup0(const char *src, size_t length)
 {
   char *buf = malloc(length + 1);
   if(!buf)

--- a/lib/strdup.h
+++ b/lib/strdup.h
@@ -33,6 +33,6 @@ wchar_t* Curl_wcsdup(const wchar_t* src);
 #endif
 void *Curl_memdup(const void *src, size_t buffer_length);
 void *Curl_saferealloc(void *ptr, size_t size);
-void *Curl_strndup(const char *src, size_t length);
+void *Curl_memdump0(const char *src, size_t length);
 
 #endif /* HEADER_CURL_STRDUP_H */

--- a/lib/strdup.h
+++ b/lib/strdup.h
@@ -33,6 +33,6 @@ wchar_t* Curl_wcsdup(const wchar_t* src);
 #endif
 void *Curl_memdup(const void *src, size_t buffer_length);
 void *Curl_saferealloc(void *ptr, size_t size);
-void *Curl_memdump0(const char *src, size_t length);
+void *Curl_memdup0(const char *src, size_t length);
 
 #endif /* HEADER_CURL_STRDUP_H */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1231,7 +1231,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
         u->fragment = Curl_dyn_ptr(&enc);
       }
       else {
-        u->fragment = Curl_memdump0(fragment + 1, fraglen - 1);
+        u->fragment = Curl_memdup0(fragment + 1, fraglen - 1);
         if(!u->fragment) {
           result = CURLUE_OUT_OF_MEMORY;
           goto fail;
@@ -1260,7 +1260,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
         u->query = Curl_dyn_ptr(&enc);
       }
       else {
-        u->query = Curl_memdump0(query + 1, qlen - 1);
+        u->query = Curl_memdup0(query + 1, qlen - 1);
         if(!u->query) {
           result = CURLUE_OUT_OF_MEMORY;
           goto fail;
@@ -1294,7 +1294,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
   }
   else {
     if(!u->path) {
-      u->path = Curl_memdump0(path, pathlen);
+      u->path = Curl_memdup0(path, pathlen);
       if(!u->path) {
         result = CURLUE_OUT_OF_MEMORY;
         goto fail;
@@ -1592,7 +1592,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
   if(ptr) {
     size_t partlen = strlen(ptr);
     size_t i = 0;
-    *part = Curl_memdump0(ptr, partlen);
+    *part = Curl_memdup0(ptr, partlen);
     if(!*part)
       return CURLUE_OUT_OF_MEMORY;
     if(plusdecode) {

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1231,7 +1231,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
         u->fragment = Curl_dyn_ptr(&enc);
       }
       else {
-        u->fragment = Curl_strndup(fragment + 1, fraglen - 1);
+        u->fragment = Curl_memdump0(fragment + 1, fraglen - 1);
         if(!u->fragment) {
           result = CURLUE_OUT_OF_MEMORY;
           goto fail;
@@ -1260,7 +1260,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
         u->query = Curl_dyn_ptr(&enc);
       }
       else {
-        u->query = Curl_strndup(query + 1, qlen - 1);
+        u->query = Curl_memdump0(query + 1, qlen - 1);
         if(!u->query) {
           result = CURLUE_OUT_OF_MEMORY;
           goto fail;
@@ -1294,7 +1294,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
   }
   else {
     if(!u->path) {
-      u->path = Curl_strndup(path, pathlen);
+      u->path = Curl_memdump0(path, pathlen);
       if(!u->path) {
         result = CURLUE_OUT_OF_MEMORY;
         goto fail;
@@ -1592,7 +1592,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
   if(ptr) {
     size_t partlen = strlen(ptr);
     size_t i = 0;
-    *part = Curl_strndup(ptr, partlen);
+    *part = Curl_memdump0(ptr, partlen);
     if(!*part)
       return CURLUE_OUT_OF_MEMORY;
     if(plusdecode) {

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -214,7 +214,7 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
   }
 
   /* Store the challenge for later use */
-  ntlm->input_token = Curl_memdump0((const char *)Curl_bufref_ptr(type2),
+  ntlm->input_token = Curl_memdup0((const char *)Curl_bufref_ptr(type2),
                                    Curl_bufref_len(type2));
   if(!ntlm->input_token)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -214,7 +214,7 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
   }
 
   /* Store the challenge for later use */
-  ntlm->input_token = Curl_strndup((const char *)Curl_bufref_ptr(type2),
+  ntlm->input_token = Curl_memdump0((const char *)Curl_bufref_ptr(type2),
                                    Curl_bufref_len(type2));
   if(!ntlm->input_token)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -513,7 +513,7 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
         return CURLE_OK;
       }
       else if(name && (rc == WS_SUCCESS)) {
-        sshc->homedir = Curl_strndup(name->fName, name->fSz);
+        sshc->homedir = Curl_memdump0(name->fName, name->fSz);
         if(!sshc->homedir)
           sshc->actualcode = CURLE_OUT_OF_MEMORY;
         wolfSSH_SFTPNAME_list_free(name);

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -513,7 +513,7 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
         return CURLE_OK;
       }
       else if(name && (rc == WS_SUCCESS)) {
-        sshc->homedir = Curl_memdump0(name->fName, name->fSz);
+        sshc->homedir = Curl_memdup0(name->fName, name->fSz);
         if(!sshc->homedir)
           sshc->actualcode = CURLE_OUT_OF_MEMORY;
         wolfSSH_SFTPNAME_list_free(name);

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -368,7 +368,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     /* Unfortunately, mbedtls_x509_crt_parse() requires the data to be null
        terminated even when provided the exact length, forcing us to waste
        extra memory here. */
-    unsigned char *newblob = Curl_strndup(ca_info_blob->data,
+    unsigned char *newblob = Curl_memdump0(ca_info_blob->data,
                                           ca_info_blob->len);
     if(!newblob)
       return CURLE_OUT_OF_MEMORY;
@@ -441,7 +441,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     /* Unfortunately, mbedtls_x509_crt_parse() requires the data to be null
        terminated even when provided the exact length, forcing us to waste
        extra memory here. */
-    unsigned char *newblob = Curl_strndup(ssl_cert_blob->data,
+    unsigned char *newblob = Curl_memdump0(ssl_cert_blob->data,
                                           ssl_cert_blob->len);
     if(!newblob)
       return CURLE_OUT_OF_MEMORY;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -368,7 +368,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     /* Unfortunately, mbedtls_x509_crt_parse() requires the data to be null
        terminated even when provided the exact length, forcing us to waste
        extra memory here. */
-    unsigned char *newblob = Curl_memdump0(ca_info_blob->data,
+    unsigned char *newblob = Curl_memdup0(ca_info_blob->data,
                                           ca_info_blob->len);
     if(!newblob)
       return CURLE_OUT_OF_MEMORY;
@@ -441,7 +441,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     /* Unfortunately, mbedtls_x509_crt_parse() requires the data to be null
        terminated even when provided the exact length, forcing us to waste
        extra memory here. */
-    unsigned char *newblob = Curl_memdump0(ssl_cert_blob->data,
+    unsigned char *newblob = Curl_memdup0(ssl_cert_blob->data,
                                           ssl_cert_blob->len);
     if(!newblob)
       return CURLE_OUT_OF_MEMORY;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2373,7 +2373,7 @@ static CURLcode verify_cert(struct Curl_cfilter *cf,
 
   if(ca_info_blob) {
     CURL_TRC_CF(data, cf, "verify_peer, CA from config blob");
-    certbuf = (unsigned char *)Curl_strndup(ca_info_blob->data,
+    certbuf = (unsigned char *)Curl_memdump0(ca_info_blob->data,
                                             buflen = ca_info_blob->len);
     if(!certbuf)
       return CURLE_OUT_OF_MEMORY;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2373,7 +2373,7 @@ static CURLcode verify_cert(struct Curl_cfilter *cf,
 
   if(ca_info_blob) {
     CURL_TRC_CF(data, cf, "verify_peer, CA from config blob");
-    certbuf = (unsigned char *)Curl_memdump0(ca_info_blob->data,
+    certbuf = (unsigned char *)Curl_memdup0(ca_info_blob->data,
                                             buflen = ca_info_blob->len);
     if(!certbuf)
       return CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
Since the copy does not stop at a null byte, let's not call it anything that makes you think it works like the common strndup() function.

Based on feedback from Jay Satiro, Stefan Eissing and Patrick Monnerat