### PR TITLE
cmdline/gen: fix the sorting of the man page options

### DIFF
--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -675,6 +675,16 @@ sub listglobals {
     }
 }
 
+sub noext {
+    my $in = $_[0];
+    $in =~ s/\.d//;
+    return $in;
+}
+
+sub sortnames {
+    return noext($a) cmp noext($b);
+}
+
 sub mainpage {
     my (@files) = @_;
     my $ret;
@@ -682,7 +692,7 @@ sub mainpage {
     header("page-header");
 
     # output docs for all options
-    foreach my $f (sort @files) {
+    foreach my $f (sort sortnames @files) {
         $ret += single($f, 0);
     }
 


### PR DESCRIPTION
They were previously sorted based on the file names, which use a .d extension, making "data" get placed after "data-binary" etc. Making the sort ignore the extention fixes the ordering.

Reported-by: Boris Verkhovskiy
Bug: https://curl.se/mail/archive-2023-12/0014.html