### PR TITLE
system.h: sync mingw `CURL_TYPEOF_CURL_SOCKLEN_T` with other compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1407,9 +1407,7 @@ if(CMAKE_COMPILER_IS_GNUCC AND APPLE)
 endif()
 
 # TODO test which of these headers are required
-if(WIN32)
-  set(CURL_PULL_WS2TCPIP_H ${HAVE_WS2TCPIP_H})
-else()
+if(NOT WIN32)
   set(CURL_PULL_SYS_TYPES_H ${HAVE_SYS_TYPES_H})
   set(CURL_PULL_SYS_SOCKET_H ${HAVE_SYS_SOCKET_H})
   set(CURL_PULL_SYS_POLL_H ${HAVE_SYS_POLL_H})

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -184,9 +184,8 @@
 #  define CURL_FORMAT_CURL_OFF_TU    PRIu64
 #  define CURL_SUFFIX_CURL_OFF_T     LL
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
-#  define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
+#  define CURL_TYPEOF_CURL_SOCKLEN_T int
 #  define CURL_PULL_SYS_TYPES_H      1
-#  define CURL_PULL_WS2TCPIP_H       1
 
 #elif defined(__VMS)
 #  if defined(__VAX)
@@ -415,15 +414,6 @@
 #ifdef _AIX
 /* AIX needs <sys/poll.h> */
 #define CURL_PULL_SYS_POLL_H
-#endif
-
-
-/* CURL_PULL_WS2TCPIP_H is defined above when inclusion of header file  */
-/* ws2tcpip.h is required here to properly make type definitions below. */
-#ifdef CURL_PULL_WS2TCPIP_H
-#  include <winsock2.h>
-#  include <windows.h>
-#  include <ws2tcpip.h>
 #endif
 
 /* CURL_PULL_SYS_TYPES_H is defined above when inclusion of header file  */


### PR DESCRIPTION
Align mingw with the other Windows compilers and use the `int` type for
`CURL_TYPEOF_CURL_SOCKLEN_T` (and thus for `curl_socklent_t`). This
makes it unnecessary to make a mingw-specific trick and pull all Windows
headers early just for this type definition. This type is specific to
Windows, not to the compiler. mingw-w64's Windows header maps it to
`int` too.

With this we also delete all remaining uses of `CURL_PULL_WS2TCPIP_H`.

[ The official solution is to use `socklen_t` for all Windows compilers.
In this case we may want to update `curl/curl.h` to pull in Windows
headers before `system.h`. ]

Closes #12501