### PR TITLE
build: delete unused `HAVE_{GSSHEIMDAL,GSSMIT,HEIMDAL}`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -929,7 +929,6 @@ if(CURL_USE_GSSAPI)
 
     if(NOT GSS_FLAVOUR STREQUAL "Heimdal")
       # MIT
-      set(HAVE_GSSMIT ON)
       set(_INCLUDE_LIST "")
       if(HAVE_GSSAPI_GSSAPI_H)
         list(APPEND _INCLUDE_LIST "gssapi/gssapi.h")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -927,9 +927,8 @@ if(CURL_USE_GSSAPI)
     check_include_file_concat("gssapi/gssapi_generic.h" HAVE_GSSAPI_GSSAPI_GENERIC_H)
     check_include_file_concat("gssapi/gssapi_krb5.h" HAVE_GSSAPI_GSSAPI_KRB5_H)
 
-    if(GSS_FLAVOUR STREQUAL "Heimdal")
-      set(HAVE_GSSHEIMDAL ON)
-    else() # MIT
+    if(NOT GSS_FLAVOUR STREQUAL "Heimdal")
+      # MIT
       set(HAVE_GSSMIT ON)
       set(_INCLUDE_LIST "")
       if(HAVE_GSSAPI_GSSAPI_H)

--- a/configure.ac
+++ b/configure.ac
@@ -1850,10 +1850,7 @@ AC_INCLUDES_DEFAULT
       if test "x$not_mit" = "x1"; then
         dnl MIT not found, check for Heimdal
         AC_CHECK_HEADER(gssapi.h,
-            [
-              dnl found
-              AC_DEFINE(HAVE_GSSHEIMDAL, 1, [if you have Heimdal])
-            ],
+            [],
             [
               dnl no header found, disabling GSS
               want_gss=no

--- a/configure.ac
+++ b/configure.ac
@@ -1859,7 +1859,6 @@ AC_INCLUDES_DEFAULT
           )
       else
         dnl MIT found
-        AC_DEFINE(HAVE_GSSMIT, 1, [if you have MIT Kerberos])
         dnl check if we have a really old MIT Kerberos version (<= 1.2)
         AC_MSG_CHECKING([if GSS-API headers declare GSS_C_NT_HOSTBASED_SERVICE])
         AC_COMPILE_IFELSE([

--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -116,9 +116,6 @@
 /* Define if you have the GNU gssapi libraries */
 #undef HAVE_GSSGNU
 
-/* Define if you have the Heimdal gssapi libraries */
-#define HAVE_GSSHEIMDAL
-
 /* Define if you have the MIT gssapi libraries */
 #undef HAVE_GSSMIT
 

--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -116,9 +116,6 @@
 /* Define if you have the GNU gssapi libraries */
 #undef HAVE_GSSGNU
 
-/* Define if you have the MIT gssapi libraries */
-#undef HAVE_GSSMIT
-
 /* Define if you need the malloc.h header file even with stdlib.h  */
 /* #define NEED_MALLOC_H 1 */
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -298,9 +298,6 @@
 /* if you have the GNU gssapi libraries */
 #cmakedefine HAVE_GSSGNU 1
 
-/* if you have the MIT gssapi libraries */
-#cmakedefine HAVE_GSSMIT 1
-
 /* Define to 1 if you have the `idna_strerror' function. */
 #cmakedefine HAVE_IDNA_STRERROR 1
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -298,9 +298,6 @@
 /* if you have the GNU gssapi libraries */
 #cmakedefine HAVE_GSSGNU 1
 
-/* if you have the Heimdal gssapi libraries */
-#cmakedefine HAVE_GSSHEIMDAL 1
-
 /* if you have the MIT gssapi libraries */
 #cmakedefine HAVE_GSSMIT 1
 

--- a/packages/vms/config_h.com
+++ b/packages/vms/config_h.com
@@ -1386,22 +1386,6 @@ $			write tf "#define ''key2' 1"
 $			write tf "#endif"
 $			goto cfgh_in_loop1
 $		    endif
-$!
-$!		    Older MIT looks like Heimdal
-$!------------------------------------------------
-$		    if (key2 .eqs. "HAVE_HEIMDAL")
-$		    then
-$			if f$search(test_mit) .eqs. ""
-$			then
-$			    write tf "#ifndef ''key2'"
-$			    write tf "#define ''key2' 1"
-$			else
-$			    write tf "#ifdef ''key2'"
-$			    write tf "#undef ''key2'"
-$			endif
-$			write tf "#endif"
-$			goto cfgh_in_loop1
-$		    endif
 $		endif
 $!
 $	    endif

--- a/packages/vms/config_h.com
+++ b/packages/vms/config_h.com
@@ -1387,22 +1387,6 @@ $			write tf "#endif"
 $			goto cfgh_in_loop1
 $		    endif
 $!
-$!		    This is really do we have the newer MIT Kerberos
-$!----------------------------------------------------------------------
-$		    if (key2 .eqs. "HAVE_GSSMIT")
-$		    then
-$			if f$search(test_mit) .nes. ""
-$			then
-$			    write tf "#ifndef ''key2'"
-$			    write tf "#define ''key2' 1"
-$			else
-$			    write tf "#ifdef ''key2'"
-$			    write tf "#undef ''key2'"
-$			endif
-$			write tf "#endif"
-$			goto cfgh_in_loop1
-$		    endif
-$!
 $!		    Older MIT looks like Heimdal
 $!------------------------------------------------
 $		    if (key2 .eqs. "HAVE_HEIMDAL")


### PR DESCRIPTION
Stop setting `HAVE_GSSHEIMDAL`, `HAVE_GSSMIT` and `HAVE_HEIMDAL`.
There was no place in the build system or source code that used them.

Closes #12506
