### PR TITLE
cmake: delete obsolete TODOs more [ci skip]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,15 +21,7 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-# curl/libcurl CMake script
 # by Tetetest and Sukender (Benoit Neil)
-
-# TODO:
-# The output .so file lacks the soname number which we currently have within the lib/Makefile.am file
-# Add documentation subproject
-#
-# To check:
-# (From Daniel Stenberg) The cmake build selected to run gcc with -fPIC on my box while the plain configure script did not.
 
 # Note: By default this CMake build script detects the version of some
 # dependencies using `check_symbol_exists`.  Those checks do not work
@@ -1524,7 +1516,6 @@ if(NOT CURL_DISABLE_INSTALL)
   endmacro()
 
   # NTLM support requires crypto function adaptions from various SSL libs
-  # TODO alternative SSL libs tests for SSP1, GnuTLS, NSS
   if(NOT (CURL_DISABLE_NTLM) AND
       (USE_OPENSSL OR USE_MBEDTLS OR USE_DARWINSSL OR USE_WIN32_CRYPTO OR USE_GNUTLS))
     set(use_curl_ntlm_core ON)
@@ -1542,26 +1533,20 @@ if(NOT CURL_DISABLE_INSTALL)
   _add_if("IDN"           HAVE_LIBIDN2 OR USE_WIN32_IDN)
   _add_if("Largefile"     (SIZEOF_CURL_OFF_T GREATER 4) AND
                           ((SIZEOF_OFF_T GREATER 4) OR USE_WIN32_LARGE_FILES))
-  # TODO SSP1 (Schannel) check is missing
   _add_if("SSPI"          USE_WINDOWS_SSPI)
   _add_if("GSS-API"       HAVE_GSSAPI)
   _add_if("alt-svc"       NOT CURL_DISABLE_ALTSVC)
   _add_if("HSTS"          NOT CURL_DISABLE_HSTS)
-  # TODO SSP1 missing for SPNEGO
   _add_if("SPNEGO"        NOT CURL_DISABLE_NEGOTIATE_AUTH AND
                           (HAVE_GSSAPI OR USE_WINDOWS_SSPI))
   _add_if("Kerberos"      NOT CURL_DISABLE_KERBEROS_AUTH AND
                           (HAVE_GSSAPI OR USE_WINDOWS_SSPI))
-  # NTLM support requires crypto function adaptions from various SSL libs
-  # TODO alternative SSL libs tests for SSP1, GnuTLS, NSS
   _add_if("NTLM"          NOT (CURL_DISABLE_NTLM) AND
                           (use_curl_ntlm_core OR USE_WINDOWS_SSPI))
-  # TODO missing option (autoconf: --enable-ntlm-wb)
   _add_if("NTLM_WB"       NOT (CURL_DISABLE_NTLM) AND
                           (use_curl_ntlm_core OR USE_WINDOWS_SSPI) AND
                           NOT CURL_DISABLE_HTTP AND NTLM_WB_ENABLED)
   _add_if("TLS-SRP"       USE_TLS_SRP)
-  # TODO option --with-nghttp2 tests for nghttp2 lib and nghttp2/nghttp2.h header
   _add_if("HTTP2"         USE_NGHTTP2)
   _add_if("HTTP3"         USE_NGTCP2 OR USE_QUICHE)
   _add_if("MultiSSL"      CURL_WITH_MULTI_SSL)


### PR DESCRIPTION
- manual completed: 898b012a9bf388590c4be7f526815b5ab74feca1 #1288
- soname completed: 5de6848f104d7cb0017080e31216265ac19d0dde #10023
- bunch of others that are completed
- `NTLM_WB_ENABLED` is implemented in a basic form, and now also
  scheduled for removal, so a TODO at this point isn't useful.

And this 'to-check' item:

Q: "The cmake build selected to run gcc with -fPIC on my box while the
   plain configure script did not."

A: With CMake, since 2ebc74c36a19a1700af394c16855ce144d9878e3 #11546
   and fc9bfb14520712672b4784e8b48256fb29204011 #11627, we explicitly
   enable PIC for libcurl shared lib. Or when building libcurl for
   shared and static lib in a single pass. We do this by default for
   Windows or when enabled by the user via `SHARE_LIB_OBJECT`.
   Otherwise we don't touch this setting. Meaning the default set by
   CMake (if any) or the toolchain is used. On Debian Bookworm, this
   means that PIC is disabled for static libs by default. Some platforms
   (like macOS), has PIC enabled by default.
   autotools supports the double-pass mode only, and in that case
   CMake seems to match PIC behaviour now (as tested on Linux with gcc.)

Follow-up to 5d5dfdbd1a6c40bd75e982b66f49e1fa3a7eeae7 #12500

Closes #12509
