### PR TITLE
Prevented calling fopen for empty cookie file names.

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1227,7 +1227,7 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
 
   if(data) {
     FILE *fp = NULL;
-    if(file) {
+    if(file && *file) {
       if(!strcmp(file, "-"))
         fp = stdin;
       else {


### PR DESCRIPTION
Allows to avoid calling fopen() for cases when the empty file ("") name is used to initialize the cookie engine.