### PR TITLE
lib: move async resolve struct to Curl_easy from connectdata

### DIFF
--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -71,7 +71,7 @@ CURLcode Curl_resolver_init(struct Curl_easy *easy, void **resolver);
  * structure).  Should destroy the handler and free all resources connected to
  * it.
  */
-void Curl_resolver_cleanup(void *resolver);
+void Curl_resolver_cleanup(void **resolver);
 
 /*
  * Curl_resolver_duphandle()

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -901,7 +901,6 @@ UNITTEST void de_cleanup(struct dohentry *d)
 CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
                               struct Curl_dns_entry **dnsp)
 {
-  struct connectdata *conn = data->conn;
   CURLcode result;
   struct dohdata *dohp = data->req.doh;
   *dnsp = NULL; /* defaults to no response */
@@ -910,7 +909,7 @@ CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
 
   if(!dohp->probe[DOH_PROBE_SLOT_IPADDR_V4].easy &&
      !dohp->probe[DOH_PROBE_SLOT_IPADDR_V6].easy) {
-    failf(data, "Could not DoH-resolve: %s", conn->resolve_async.hostname);
+    failf(data, "Could not DoH-resolve: %s", data->resolve_async.hostname);
     return CONN_IS_PROXIED(data->conn)?CURLE_COULDNT_RESOLVE_PROXY:
       CURLE_COULDNT_RESOLVE_HOST;
   }
@@ -973,7 +972,7 @@ CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
         Curl_freeaddrinfo(ai);
       }
       else {
-        conn->resolve_async.dns = dns;
+        data->resolve_async.dns = dns;
         *dnsp = dns;
         result = CURLE_OK;      /* address resolution OK */
       }

--- a/lib/hostasyn.c
+++ b/lib/hostasyn.c
@@ -67,11 +67,10 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
                                 int status,
                                 struct Curl_addrinfo *ai)
 {
-  struct connectdata *conn = data->conn;
   struct Curl_dns_entry *dns = NULL;
   CURLcode result = CURLE_OK;
 
-  conn->resolve_async.status = status;
+  data->resolve_async.status = status;
 
   if(CURL_ASYNC_SUCCESS == status) {
     if(ai) {
@@ -79,8 +78,8 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
         Curl_share_lock(data, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SINGLE);
 
       dns = Curl_cache_addr(data, ai,
-                            conn->resolve_async.hostname, 0,
-                            conn->resolve_async.port);
+                            data->resolve_async.hostname, 0,
+                            data->resolve_async.port);
       if(data->share)
         Curl_share_unlock(data, CURL_LOCK_DATA_DNS);
 
@@ -95,12 +94,12 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
     }
   }
 
-  conn->resolve_async.dns = dns;
+  data->resolve_async.dns = dns;
 
  /* Set async.done TRUE last in this function since it may be used multi-
     threaded and once this is TRUE the other thread may read fields from the
     async struct */
-  conn->resolve_async.done = TRUE;
+  data->resolve_async.done = TRUE;
 
   /* IPv4: The input hostent struct will be freed by ares when we return from
      this function */

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -741,7 +741,7 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
       Curl_set_in_callback(data, true);
       st = data->set.resolver_start(
 #ifdef USE_CURL_ASYNC
-        conn->resolve_async.resolver,
+        data->resolve_async.resolver,
 #else
         NULL,
 #endif
@@ -1421,9 +1421,9 @@ CURLcode Curl_once_resolved(struct Curl_easy *data, bool *protocol_done)
   struct connectdata *conn = data->conn;
 
 #ifdef USE_CURL_ASYNC
-  if(conn->resolve_async.dns) {
-    conn->dns_entry = conn->resolve_async.dns;
-    conn->resolve_async.dns = NULL;
+  if(data->resolve_async.dns) {
+    conn->dns_entry = data->resolve_async.dns;
+    data->resolve_async.dns = NULL;
   }
 #endif
 
@@ -1462,7 +1462,7 @@ CURLcode Curl_resolver_error(struct Curl_easy *data)
   }
 
   failf(data, "Could not resolve %s: %s", host_or_proxy,
-        conn->resolve_async.hostname);
+        data->resolve_async.hostname);
 
   return result;
 }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1983,8 +1983,8 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
 
       if(dns) {
 #ifdef CURLRES_ASYNCH
-        conn->resolve_async.dns = dns;
-        conn->resolve_async.done = TRUE;
+        data->resolve_async.dns = dns;
+        data->resolve_async.done = TRUE;
 #endif
         result = CURLE_OK;
         infof(data, "Hostname '%s' was found in DNS cache", hostname);

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -339,8 +339,8 @@ static CURLproxycode do_SOCKS4(struct Curl_cfilter *cf,
 
     if(dns) {
 #ifdef CURLRES_ASYNCH
-      conn->resolve_async.dns = dns;
-      conn->resolve_async.done = TRUE;
+      data->resolve_async.dns = dns;
+      data->resolve_async.done = TRUE;
 #endif
       infof(data, "Hostname '%s' was found", sx->hostname);
       sxstate(sx, data, CONNECT_RESOLVED);
@@ -806,8 +806,8 @@ CONNECT_REQ_INIT:
 
     if(dns) {
 #ifdef CURLRES_ASYNCH
-      conn->resolve_async.dns = dns;
-      conn->resolve_async.done = TRUE;
+      data->resolve_async.dns = dns;
+      data->resolve_async.done = TRUE;
 #endif
       infof(data, "SOCKS5: hostname '%s' found", sx->hostname);
     }

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -921,9 +921,6 @@ struct connectdata {
      multi_done(). This entry will be NULL if the connection is reused as then
      there is no name resolve done. */
   struct Curl_dns_entry *dns_entry;
-#ifdef USE_CURL_ASYNC
-  struct Curl_async resolve_async;  /* asynchronous name resolver data */
-#endif
 
   /* 'remote_addr' is the particular IP we connected to. it is owned, set
    * and NULLed by the connected socket filter (if there is one). */
@@ -2001,6 +1998,9 @@ struct Curl_easy {
                                     struct to which this "belongs" when used
                                     by the easy interface */
   struct Curl_share *share;    /* Share, handles global variable mutexing */
+#ifdef USE_CURL_ASYNC
+  struct Curl_async resolve_async;  /* asynchronous name resolver data */
+#endif
 #ifdef USE_LIBPSL
   struct PslCache *psl;        /* The associated PSL cache. */
 #endif


### PR DESCRIPTION
The name resolve is done *for* the connection and not *in* it. By keeping the data in the easy handle, we can better reuse the c-ares channel which should be a performance boost instead of creating it and killing it for every new connection.