### PR TITLE
openssl: re-match LibreSSL deinit with init

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1753,7 +1753,7 @@ static int ossl_init(void)
 static void ossl_cleanup(void)
 {
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) &&  \
-  !defined(LIBRESSL_VERSION_NUMBER)
+  (!defined(LIBRESSL_VERSION_NUMBER) || LIBRESSL_VERSION_NUMBER >= 0x2070000fL)
   /* OpenSSL 1.1 deprecates all these cleanup functions and
      turns them into no-ops in OpenSSL 1.0 compatibility mode */
 #else


### PR DESCRIPTION
Earlier we switched to use modern initialization with LibreSSL v2.7.0
and up, but did not touch deinitialization [1]. Fix it in this patch.

Regression from bec0c5bbf34369920598678161d2df8bea0e243b #11611

[1] https://github.com/curl/curl/pull/11611#issuecomment-1668654014

Reported-by: Mike Hommey
Fixes #12525
Closes #12526
