### PR TITLE
Allow the actual use of maximum method name length

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -4609,7 +4609,7 @@ CURLcode Curl_http_req_make(struct httpreq **preq,
   CURLcode result = CURLE_OUT_OF_MEMORY;
 
   DEBUGASSERT(method);
-  if(m_len + 1 >= sizeof(req->method))
+  if(m_len + 1 > sizeof(req->method))
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
   req = calloc(1, sizeof(*req));
@@ -4765,7 +4765,7 @@ CURLcode Curl_http_req_make2(struct httpreq **preq,
   CURLUcode uc;
 
   DEBUGASSERT(method);
-  if(m_len + 1 >= sizeof(req->method))
+  if(m_len + 1 > sizeof(req->method))
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
   req = calloc(1, sizeof(*req));


### PR DESCRIPTION
While reviewing #12311 ("Increase the maximum request method name length from 11 to 23"), I tested a few requests and noticed that, before the change (curl 8.4.0), 11 character request method (which our internal tooling uses) was actually _not_ allowed, while 10 characters did work. After the change (curl 8.5.0), request method with 23 characters long is still not allowed, while 22 characters long is allowed. 

```
➜  curl --version                                                      
curl 8.5.0 (aarch64-apple-darwin23.0.0) libcurl/8.5.0 (SecureTransport) OpenSSL/3.2.0 zlib/1.2.12 brotli/1.1.0 zstd/1.5.5 libidn2/2.3.4 libssh2/1.11.0 nghttp2/1.58.0 librtmp/2.3 OpenLDAP/2.6.6

# 22 characters
➜  curl $URL -X GETGETGETGETGETGETGETG
<html>
<head><title>405 Not Allowed</title></head>
<body bgcolor="white">
<center><h1>405 Not Allowed</h1></center>
<hr><center>nginx/1.6.3</center>
</body>
</html>

# 23 characters
➜  curl $URL -X GETGETGETGETGETGETGETGE
curl: (43) Failed sending HTTP request
```

Looking at the code, it looks like there's an off-by-one error in the length check, disallowing the full use of 23 bytes (+ NUL).