### PR TITLE
windows: delete redundant headers

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -169,7 +169,6 @@ int main(void) { ; return 0; }
 #    define WIN32_LEAN_AND_MEAN
 #  endif
 #  include <winsock2.h>
-#  include <windows.h>
 #endif
 int main(void)
 {
@@ -189,7 +188,6 @@ int main(void)
 #    define WIN32_LEAN_AND_MEAN
 #  endif
 #  include <winsock2.h>
-#  include <windows.h>
 #endif
 int main(void)
 {
@@ -208,7 +206,6 @@ int main(void)
 #    define WIN32_LEAN_AND_MEAN
 #  endif
 #  include <winsock2.h>
-#  include <windows.h>
 #endif
 int main(void)
 {
@@ -228,7 +225,6 @@ int main(void)
 #    define WIN32_LEAN_AND_MEAN
 #  endif
 #  include <winsock2.h>
-#  include <windows.h>
 #endif
 int main(void)
 {
@@ -304,7 +300,6 @@ int main(void)
 #    define WIN32_LEAN_AND_MEAN
 #  endif
 #  include <winsock2.h>
-#  include <windows.h>
 #endif
 /* includes start */
 #ifdef HAVE_SYS_TYPES_H

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -589,7 +589,6 @@ AC_DEFUN([TYPE_SOCKADDR_STORAGE],
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
-#include <windows.h>
 #else
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -625,7 +624,6 @@ AC_DEFUN([CURL_CHECK_FUNC_RECV], [
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
-#include <windows.h>
 #else
 $curl_includes_bsdsocket
 #ifdef HAVE_SYS_TYPES_H
@@ -674,7 +672,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
-#include <windows.h>
 #else
 $curl_includes_bsdsocket
 #ifdef HAVE_SYS_TYPES_H
@@ -719,7 +716,6 @@ AC_DEFUN([CURL_CHECK_MSG_NOSIGNAL], [
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
-#include <windows.h>
 #else
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -762,7 +758,6 @@ AC_DEFUN([CURL_CHECK_STRUCT_TIMEVAL], [
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
-#include <windows.h>
 #endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -815,7 +810,6 @@ AC_DEFUN([TYPE_IN_ADDR_T], [
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
-#include <windows.h>
 #else
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -855,7 +849,6 @@ AC_DEFUN([TYPE_IN_ADDR_T], [
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
-#include <windows.h>
 #else
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
@@ -1134,7 +1127,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SELECT], [
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
-#include <windows.h>
 #endif
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/configure.ac
+++ b/configure.ac
@@ -1125,7 +1125,6 @@ then
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <winsock2.h>
-#include <windows.h>
 #endif
         ]],[[
           gethostbyname("localhost");

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -32,7 +32,6 @@
 
 #ifdef _WIN32
 #include <winsock2.h>
-#include <ws2tcpip.h>
 #include <windows.h>
 #define close closesocket
 #else

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -32,7 +32,6 @@
 
 #ifdef _WIN32
 #include <winsock2.h>
-#include <windows.h>
 #define close closesocket
 #else
 #include <sys/types.h>        /*  socket types              */

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -91,11 +91,11 @@
 
 #include <stdio.h>
 #include <time.h>
-#ifndef __CYGWIN__
-#include <winsock2.h>
+#include <curl/curl.h>
+
+#ifdef _WIN32
 #include <windows.h>
 #endif
-#include <curl/curl.h>
 
 
 #define MAX_STRING              256

--- a/lib/inet_pton.h
+++ b/lib/inet_pton.h
@@ -31,9 +31,6 @@ int Curl_inet_pton(int, const char *, void *);
 #ifdef HAVE_INET_PTON
 #ifdef HAVE_ARPA_INET_H
 #include <arpa/inet.h>
-#elif defined(USE_WINSOCK)
-/* inet_pton() exists in Vista or later */
-#include <ws2tcpip.h>
 #endif
 #define Curl_inet_pton(x,y,z) inet_pton(x,y,z)
 #endif

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -33,9 +33,6 @@
  * This is a socketpair() implementation for Windows.
  */
 #include <string.h>
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#include <windows.h>
 #include <io.h>
 #else
 #ifdef HAVE_NETDB_H

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -419,7 +419,6 @@ curl_includes_winsock2="\
 #    define WIN32_LEAN_AND_MEAN
 #  endif
 #  include <winsock2.h>
-#  include <windows.h>
 #endif
 /* includes end */"
   CURL_CHECK_NATIVE_WINDOWS
@@ -440,7 +439,6 @@ curl_includes_ws2tcpip="\
 #  endif
 #  include <winsock2.h>
 #  include <ws2tcpip.h>
-#  include <windows.h>
 #endif
 /* includes end */"
   CURL_CHECK_NATIVE_WINDOWS

--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -25,11 +25,6 @@
 
 #ifdef HAVE_INET_PTON
 
-#ifdef _WIN32
-#include <winsock2.h>
-#include <ws2tcpip.h>
-#endif
-
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif

--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -28,7 +28,6 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <windows.h>
 #endif
 
 #ifdef HAVE_NETINET_IN_H


### PR DESCRIPTION
`winsock2.h` pulls in `windows.h`. `ws2tcpip.h` pulls in `winsock2.h`.
`winsock2.h` and `ws2tcpip.h` are also pulled by `curl/curl.h`.

Keep only those headers that are not already included, or the code under
it uses something from that specific header.

Closes #12539
