### PR TITLE
build: more `-Wformat` fixes

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -97,7 +97,8 @@ static CURLcode imap_doing(struct Curl_easy *data, bool *dophase_done);
 static CURLcode imap_setup_connection(struct Curl_easy *data,
                                       struct connectdata *conn);
 static char *imap_atom(const char *str, bool escape_only);
-static CURLcode imap_sendf(struct Curl_easy *data, const char *fmt, ...);
+static CURLcode imap_sendf(struct Curl_easy *data, const char *fmt, ...)
+  CURL_PRINTF(2, 3);
 static CURLcode imap_parse_url_options(struct connectdata *conn);
 static CURLcode imap_parse_url_path(struct Curl_easy *data);
 static CURLcode imap_parse_custom_request(struct Curl_easy *data);

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -304,12 +304,6 @@ void curl_dbg_free(void *ptr, int line, const char *source)
 curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
                              int line, const char *source)
 {
-  const char *fmt = (sizeof(curl_socket_t) == sizeof(int)) ?
-    "FD %s:%d socket() = %d\n" :
-    (sizeof(curl_socket_t) == sizeof(long)) ?
-    "FD %s:%d socket() = %ld\n" :
-    "FD %s:%d socket() = %zd\n";
-
   curl_socket_t sockfd;
 
   if(countcheck("socket", line, source))
@@ -317,16 +311,9 @@ curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
 
   sockfd = socket(domain, type, protocol);
 
-  if(source && (sockfd != CURL_SOCKET_BAD)) {
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
-    curl_dbg_log(fmt, source, line, sockfd);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-  }
+  if(source && (sockfd != CURL_SOCKET_BAD))
+    curl_dbg_log("FD %s:%d socket() = %" CURL_FORMAT_SOCKET_T "\n",
+                 source, line, sockfd);
 
   return sockfd;
 }
@@ -365,24 +352,12 @@ int curl_dbg_socketpair(int domain, int type, int protocol,
                        curl_socket_t socket_vector[2],
                        int line, const char *source)
 {
-  const char *fmt = (sizeof(curl_socket_t) == sizeof(int)) ?
-    "FD %s:%d socketpair() = %d %d\n" :
-    (sizeof(curl_socket_t) == sizeof(long)) ?
-    "FD %s:%d socketpair() = %ld %ld\n" :
-    "FD %s:%d socketpair() = %zd %zd\n";
-
   int res = socketpair(domain, type, protocol, socket_vector);
 
-  if(source && (0 == res)) {
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
-    curl_dbg_log(fmt, source, line, socket_vector[0], socket_vector[1]);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-  }
+  if(source && (0 == res))
+    curl_dbg_log("FD %s:%d socketpair() = "
+      "%" CURL_FORMAT_SOCKET_T " %" CURL_FORMAT_SOCKET_T "\n",
+      source, line, socket_vector[0], socket_vector[1]);
 
   return res;
 }
@@ -391,27 +366,14 @@ int curl_dbg_socketpair(int domain, int type, int protocol,
 curl_socket_t curl_dbg_accept(curl_socket_t s, void *saddr, void *saddrlen,
                              int line, const char *source)
 {
-  const char *fmt = (sizeof(curl_socket_t) == sizeof(int)) ?
-    "FD %s:%d accept() = %d\n" :
-    (sizeof(curl_socket_t) == sizeof(long)) ?
-    "FD %s:%d accept() = %ld\n" :
-    "FD %s:%d accept() = %zd\n";
-
   struct sockaddr *addr = (struct sockaddr *)saddr;
   curl_socklen_t *addrlen = (curl_socklen_t *)saddrlen;
 
   curl_socket_t sockfd = accept(s, addr, addrlen);
 
-  if(source && (sockfd != CURL_SOCKET_BAD)) {
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
-    curl_dbg_log(fmt, source, line, sockfd);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-  }
+  if(source && (sockfd != CURL_SOCKET_BAD))
+    curl_dbg_log("FD %s:%d accept() = %" CURL_FORMAT_SOCKET_T "\n",
+                 source, line, sockfd);
 
   return sockfd;
 }
@@ -419,22 +381,9 @@ curl_socket_t curl_dbg_accept(curl_socket_t s, void *saddr, void *saddrlen,
 /* separate function to allow libcurl to mark a "faked" close */
 void curl_dbg_mark_sclose(curl_socket_t sockfd, int line, const char *source)
 {
-  const char *fmt = (sizeof(curl_socket_t) == sizeof(int)) ?
-    "FD %s:%d sclose(%d)\n":
-    (sizeof(curl_socket_t) == sizeof(long)) ?
-    "FD %s:%d sclose(%ld)\n":
-    "FD %s:%d sclose(%zd)\n";
-
-  if(source) {
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
-    curl_dbg_log(fmt, source, line, sockfd);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-  }
+  if(source)
+    curl_dbg_log("FD %s:%d sclose(%" CURL_FORMAT_SOCKET_T ")\n",
+                 source, line, sockfd);
 }
 
 /* this is our own defined way to close sockets on *ALL* platforms */

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -39,6 +39,11 @@
 static void voutf(struct GlobalConfig *config,
                   const char *prefix,
                   const char *fmt,
+                  va_list ap) CURL_PRINTF(3, 0);
+
+static void voutf(struct GlobalConfig *config,
+                  const char *prefix,
+                  const char *fmt,
                   va_list ap)
 {
   size_t width = (79 - strlen(prefix));
@@ -107,7 +112,6 @@ void notef(struct GlobalConfig *config, const char *fmt, ...)
  * Emit warning formatted message on configured 'errors' stream unless
  * mute (--silent) was selected.
  */
-
 void warnf(struct GlobalConfig *config, const char *fmt, ...)
 {
   va_list ap;
@@ -115,6 +119,7 @@ void warnf(struct GlobalConfig *config, const char *fmt, ...)
   voutf(config, WARN_PREFIX, fmt, ap);
   va_end(ap);
 }
+
 /*
  * Emit help formatted message on given stream. This is for errors with or
  * related to command line arguments.


### PR DESCRIPTION
- memdebug: update to not trigger `-Wformat-nonliteral` warnings.
- imap: mark `imap_sendf()` with  `CURL_PRINTF()`.
- tool_msgs: mark static function with `CURL_PRINTF()`.

Follow-up to 3829759bd042c03225ae862062560f568ba1a231 #12489

Closes #12540
