### PR TITLE
tests: Respect $TMPDIR when creating sockets

### DIFF
--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -190,10 +190,10 @@ use File::Temp qw/ tempfile/;
 #######################################################################
 # Initialize configuration variables
 sub initserverconfig {
-    my ($fh, $socks) = tempfile("/tmp/curl-socksd-XXXXXXXX");
+    my ($fh, $socks) = tempfile("curl-socksd-XXXXXXXX", TMPDIR => 1);
     close($fh);
     unlink($socks);
-    my ($f2, $http) = tempfile("/tmp/curl-http-XXXXXXXX");
+    my ($f2, $http) = tempfile("curl-http-XXXXXXXX", TMPDIR => 1);
     close($f2);
     unlink($http);
     $SOCKSUNIXPATH = $socks; # SOCKS Unix domain socket


### PR DESCRIPTION
When running on termux, where $TMPDIR isn't /tmp, running the tests failed, since the server config tried creating sockets in /tmp, without checking the temp dir config. Use the TMPDIR variable that makes it find the correct directory everywhere [0]

[0] https://perldoc.perl.org/File::Temp#tempfile