### PR TITLE
runtests: support -gl. Like -g but for lldb.

### DIFF
--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -945,9 +945,16 @@ sub singletest_run {
     if($gdbthis) {
         my $gdbinit = "$TESTDIR/gdbinit$testnum";
         open(my $gdbcmd, ">", "$LOGDIR/gdbcmd") || die "Failure writing gdb file";
-        print $gdbcmd "set args $cmdargs\n";
-        print $gdbcmd "show args\n";
-        print $gdbcmd "source $gdbinit\n" if -e $gdbinit;
+        if($gdbthis == 1) {
+            # gdb mode
+            print $gdbcmd "set args $cmdargs\n";
+            print $gdbcmd "show args\n";
+            print $gdbcmd "source $gdbinit\n" if -e $gdbinit;
+        }
+        else {
+            # lldb mode
+            print $gdbcmd "set args $cmdargs\n";
+        }
         close($gdbcmd) || die "Failure writing gdb file";
     }
 
@@ -963,9 +970,16 @@ sub singletest_run {
                           $testnum,
                           "$gdb --directory $LIBDIR " . shell_quote($DBGCURL) . " -x $LOGDIR/gdbcmd");
     }
-    elsif($gdbthis) {
+    elsif($gdbthis == 1) {
+        # gdb
         my $GDBW = ($gdbxwin) ? "-w" : "";
         runclient("$gdb --directory $LIBDIR " . shell_quote($DBGCURL) . " $GDBW -x $LOGDIR/gdbcmd");
+        $cmdres=0; # makes it always continue after a debugged run
+    }
+    elsif($gdbthis == 2) {
+        # $gdb is "lldb"
+        print "runs lldb -- $CURL $cmdargs\n";
+        runclient("lldb -- $CURL $cmdargs");
         $cmdres=0; # makes it always continue after a debugged run
     }
     else {

--- a/tests/runtests.1
+++ b/tests/runtests.1
@@ -116,6 +116,11 @@ Run the given test(s) with gdb. This is best used on a single test case and
 curl built --disable-shared. This then fires up gdb with command line set to
 run the specified test case. Simply (set a break-point and) type 'run' to
 start.
+.IP "-gl"
+Run the given test(s) with lldb. This is best used on a single test case and
+curl built --disable-shared. This then fires up lldb with command line set to
+run the specified test case. Simply (set a break-point and) type 'run' to
+start.
 .IP "-gw"
 Run the given test(s) with gdb as a windowed application.
 .IP "-h, --help"

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2215,6 +2215,10 @@ while(@ARGV) {
         # run this test with gdb
         $gdbthis=1;
     }
+    elsif ($ARGV[0] eq "-gl") {
+        # run this test with lldb
+        $gdbthis=2;
+    }
     elsif ($ARGV[0] eq "-gw") {
         # run this test with windowed gdb
         $gdbthis=1;


### PR DESCRIPTION
Invokes the test case via lldb instead of gdb. Since using gdb is such a pain on mac, using lldb is sometimes less quirky.