### PR TITLE
build: fix `-Wconversion`/`-Wsign-conversion` warnings

### DIFF
--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -95,7 +95,7 @@ static size_t write_cb(char *data, size_t n, size_t l, void *userp)
   return n*l;
 }
 
-static void add_transfer(CURLM *cm, int i, int *left)
+static void add_transfer(CURLM *cm, unsigned int i, int *left)
 {
   CURL *eh = curl_easy_init();
   curl_easy_setopt(eh, CURLOPT_WRITEFUNCTION, write_cb);

--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -69,17 +69,15 @@ static int my_seek(void *userp, curl_off_t offset, int origin)
 /* read callback function, fread() look alike */
 static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
-  ssize_t retcode;
-  unsigned long nread;
+  size_t nread;
 
-  retcode = fread(ptr, size, nmemb, stream);
+  nread = fread(ptr, size, nmemb, stream);
 
-  if(retcode > 0) {
-    nread = (unsigned long)retcode;
-    fprintf(stderr, "*** We read %lu bytes from file\n", nread);
+  if(nread > 0) {
+    fprintf(stderr, "*** We read %lu bytes from file\n", (unsigned long)nread);
   }
 
-  return retcode;
+  return nread;
 }
 
 int main(int argc, char **argv)

--- a/docs/examples/ftpget.c
+++ b/docs/examples/ftpget.c
@@ -42,7 +42,7 @@ static size_t my_fwrite(void *buffer, size_t size, size_t nmemb, void *stream)
     /* open file for writing */
     out->stream = fopen(out->filename, "wb");
     if(!out->stream)
-      return -1; /* failure, cannot open file to write */
+      return 0; /* failure, cannot open file to write */
   }
   return fwrite(buffer, size, nmemb, out->stream);
 }

--- a/docs/examples/ftpsget.c
+++ b/docs/examples/ftpsget.c
@@ -44,7 +44,7 @@ static size_t my_fwrite(void *buffer, size_t size, size_t nmemb,
     /* open file for writing */
     out->stream = fopen(out->filename, "wb");
     if(!out->stream)
-      return -1; /* failure, cannot open file to write */
+      return 0; /* failure, cannot open file to write */
   }
   return fwrite(buffer, size, nmemb, out->stream);
 }

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -54,7 +54,7 @@ struct transfer {
 #define NUM_HANDLES 1000
 
 static
-void dump(const char *text, int num, unsigned char *ptr, size_t size,
+void dump(const char *text, unsigned int num, unsigned char *ptr, size_t size,
           char nohex)
 {
   size_t i;
@@ -66,7 +66,7 @@ void dump(const char *text, int num, unsigned char *ptr, size_t size,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stderr, "%d %s, %lu bytes (0x%lx)\n",
+  fprintf(stderr, "%u %s, %lu bytes (0x%lx)\n",
           num, text, (unsigned long)size, (unsigned long)size);
 
   for(i = 0; i<size; i += width) {

--- a/docs/examples/sendrecv.c
+++ b/docs/examples/sendrecv.c
@@ -44,6 +44,13 @@ static int wait_on_socket(curl_socket_t sockfd, int for_recv, long timeout_ms)
   FD_ZERO(&outfd);
   FD_ZERO(&errfd);
 
+/* Avoid this warning with pre-2020 Cygwin/MSYS2 releases:
+ * warning: conversion to 'long unsigned int' from 'curl_socket_t' {aka 'int'} may change the sign of the result [-Wsign-conversion]
+ */
+#if defined(__GNUC__) && defined(__CYGWIN__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   FD_SET(sockfd, &errfd); /* always check for error */
 
   if(for_recv) {
@@ -52,6 +59,9 @@ static int wait_on_socket(curl_socket_t sockfd, int for_recv, long timeout_ms)
   else {
     FD_SET(sockfd, &outfd);
   }
+#if defined(__GNUC__) && defined(__CYGWIN__)
+#pragma GCC diagnostic pop
+#endif
 
   /* select() returns the number of signalled sockets or -1 */
   res = select((int)sockfd + 1, &infd, &outfd, &errfd, &tv);

--- a/docs/examples/sftpget.c
+++ b/docs/examples/sftpget.c
@@ -53,7 +53,7 @@ static size_t my_fwrite(void *buffer, size_t size, size_t nmemb,
     /* open file for writing */
     out->stream = fopen(out->filename, "wb");
     if(!out->stream)
-      return -1; /* failure, cannot open file to write */
+      return 0; /* failure, cannot open file to write */
   }
   return fwrite(buffer, size, nmemb, out->stream);
 }

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -135,7 +135,7 @@ static size_t my_write_cb(char *buf, size_t nitems, size_t buflen,
     fprintf(stderr, "[t-%d] write failure\n", t->idx);
     return 0;
   }
-  t->recv_size += nwritten;
+  t->recv_size += (curl_off_t)nwritten;
   return (size_t)nwritten;
 }
 
@@ -171,7 +171,7 @@ static void usage(const char *msg)
     "  download a url with following options:\n"
     "  -m number  max parallel downloads\n"
     "  -n number  total downloads\n"
-    "  -p number  pause transfer after `number` response bytes\n"
+    "  -P number  pause transfer after `number` response bytes\n"
   );
 }
 
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
   const char *url;
   size_t i, n, max_parallel = 1;
   size_t active_transfers;
-  long pause_offset = 0;
+  size_t pause_offset = 0;
   int abort_paused = 0;
   struct transfer *t;
   int ch;
@@ -205,7 +205,7 @@ int main(int argc, char *argv[])
       transfer_count = (size_t)strtol(optarg, NULL, 10);
       break;
     case 'P':
-      pause_offset = strtol(optarg, NULL, 10);
+      pause_offset = (size_t)strtol(optarg, NULL, 10);
       break;
     default:
      usage("invalid option");

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -112,11 +112,11 @@ static size_t my_write_cb(char *buf, size_t nitems, size_t buflen,
                           void *userdata)
 {
   struct transfer *t = userdata;
-  ssize_t nwritten;
+  size_t nwritten;
 
   if(!t->resumed &&
      t->recv_size < t->pause_at &&
-     ((curl_off_t)(t->recv_size + (nitems * buflen)) >= t->pause_at)) {
+     ((t->recv_size + (curl_off_t)(nitems * buflen)) >= t->pause_at)) {
     fprintf(stderr, "[t-%d] PAUSE\n", t->idx);
     t->paused = 1;
     return CURL_WRITEFUNC_PAUSE;
@@ -131,7 +131,7 @@ static size_t my_write_cb(char *buf, size_t nitems, size_t buflen,
   }
 
   nwritten = fwrite(buf, nitems, buflen, t->out);
-  if(nwritten < 0) {
+  if(nwritten < buflen) {
     fprintf(stderr, "[t-%d] write failure\n", t->idx);
     return 0;
   }
@@ -234,7 +234,7 @@ int main(int argc, char *argv[])
   for(i = 0; i < transfer_count; ++i) {
     t = &transfers[i];
     t->idx = (int)i;
-    t->pause_at = (curl_off_t)pause_offset * i;
+    t->pause_at = (curl_off_t)(pause_offset * i);
   }
 
   n = (max_parallel < transfer_count)? max_parallel : transfer_count;

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -497,7 +497,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
   unsigned short packet_id;
   size_t payload_len;
   size_t client_id_length;
-  unsigned int topic_len;
+  size_t topic_len;
   size_t remaining_length = 0;
   size_t bytes = 0; /* remaining length field size in bytes */
   char client_id[MAX_CLIENT_ID_LENGTH];
@@ -635,7 +635,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       /* two bytes topic length */
       topic_len = (size_t)(buffer[2] << 8) | buffer[3];
       if(topic_len != (remaining_length - 5)) {
-        logmsg("Wrong topic length, got %u expected %zu",
+        logmsg("Wrong topic length, got %zu expected %zu",
                topic_len, remaining_length - 5);
         goto end;
       }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -620,7 +620,7 @@ static curl_socket_t sockit(curl_socket_t fd)
   memcpy(&response[SOCKS5_BNDADDR + len],
          &buffer[SOCKS5_DSTADDR + len], sizeof(socksport));
 
-  rc = (send)(fd, (char *)response, len + 6, 0);
+  rc = (send)(fd, (char *)response, (size_t)(len + 6), 0);
   if(rc != (len + 6)) {
     logmsg("Sending connect response failed!");
     return CURL_SOCKET_BAD;


### PR DESCRIPTION
Fix remaining warnings in examples and tests which are not suppressed
by the pragma in `lib/curl_setup.h`.

Silence a toolchain issue causing warnings in `FD_SET()` calls with
older Cygwin/MSYS2 builds. Likely fixed on 2020-08-03 by:
https://cygwin.com/git/?p=newlib-cygwin.git;a=commitdiff;h=5717262b8ecfed0f7fab63e2c09c78991e36f9dd

Follow-up to 2dbe75bd7f3c36837aa06fd87a442bdf3fb7faef #12492

Closes #12557

---

Red CI after merging to master: https://ci.appveyor.com/project/curlorg/curl/builds/48791215

Edit: The last CI run for the PR skipped the AppVeyor tests, which were not clean yet apparently.
