### PR TITLE
Revert "readwrite_data: loop less"

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -427,8 +427,9 @@ static CURLcode readwrite_data(struct Curl_easy *data,
   char *buf;
   size_t blen;
   size_t consumed;
-  int maxloops = 10;
-  curl_off_t max_recv = data->set.max_recv_speed ? 0 : CURL_OFF_T_MAX;
+  int maxloops = 100;
+  curl_off_t max_recv = data->set.max_recv_speed?
+                        data->set.max_recv_speed : CURL_OFF_T_MAX;
   bool data_eof_handled = FALSE;
 
   DEBUGASSERT(data->state.buffer);


### PR DESCRIPTION
This reverts commit 1da640abb6886aab822ff0c0da71b1df0ca89d0f.

That commit fixed a few issues but it seems it introduced an even worse one. We need to rethink the approach and revert this in the mean time.

Fixes #12559