### PR TITLE
strerror: repair get_winsock_error()

### DIFF
--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -582,11 +582,10 @@ get_winsock_error(int err, char *buf, size_t len)
 {
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
   const char *p;
+  size_t alen;
 #endif
 
-  /* 41 bytes is the longest error string */
-  DEBUGASSERT(len > 41);
-  if(!len || len < 41)
+  if(!len)
     return NULL;
 
   *buf = '\0';
@@ -763,8 +762,11 @@ get_winsock_error(int err, char *buf, size_t len)
   default:
     return NULL;
   }
-  memcpy(buf, p, len - 1);
-  buf[len - 1] = '\0';
+  alen = strlen(p);
+  if(alen < len) {
+    memcpy(buf, p, alen);
+    buf[alen] = '\0';
+  }
   return buf;
 #endif
 }

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -763,10 +763,8 @@ get_winsock_error(int err, char *buf, size_t len)
     return NULL;
   }
   alen = strlen(p);
-  if(alen < len) {
-    memcpy(buf, p, alen);
-    buf[alen] = '\0';
-  }
+  if(alen < len)
+    strcpy(buf, p);
   return buf;
 #endif
 }


### PR DESCRIPTION
It would try to read longer than the provided string and crash.

Follow-up to ff74cef5d4a0cf60106517a1c7384
Reported-by: calvin2021y on github
Fixes #12578