### PR TITLE
Unify code that uses GetProcAddress on Windows

### DIFF
--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -35,11 +35,8 @@ extern bool Curl_isWindows8OrGreater;
 CURLcode Curl_win32_init(long flags);
 void Curl_win32_cleanup(long init_flags);
 
-/* We use our own typedef here since some headers might lack this */
-typedef unsigned int(WINAPI *IF_NAMETOINDEX_FN)(const char *);
-
 /* This is used instead of if_nametoindex if available on Windows */
-extern IF_NAMETOINDEX_FN Curl_if_nametoindex;
+extern unsigned int(WINAPI *Curl_if_nametoindex)(const char *);
 
 /* Identical copy of addrinfoexW/ADDRINFOEXW */
 typedef struct addrinfoexW_

--- a/lib/version_win32.c
+++ b/lib/version_win32.c
@@ -204,14 +204,13 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
   DWORD dwTypeMask = VER_MAJORVERSION | VER_MINORVERSION |
                      VER_SERVICEPACKMAJOR | VER_SERVICEPACKMINOR;
 
-  typedef LONG (APIENTRY *RTLVERIFYVERSIONINFO_FN)
-    (struct OUR_OSVERSIONINFOEXW *, ULONG, ULONGLONG);
-  static RTLVERIFYVERSIONINFO_FN pRtlVerifyVersionInfo;
+  static LONG(WINAPI *pRtlVerifyVersionInfo)
+    (struct OUR_OSVERSIONINFOEXW *, ULONG, ULONGLONG) = NULL;
   static bool onetime = true; /* safe because first call is during init */
 
   if(onetime) {
-    pRtlVerifyVersionInfo = CURLX_FUNCTION_CAST(RTLVERIFYVERSIONINFO_FN,
-      (GetProcAddress(GetModuleHandleA("ntdll"), "RtlVerifyVersionInfo")));
+    *(FARPROC*)&pRtlVerifyVersionInfo =
+      GetProcAddress(GetModuleHandleA("ntdll"), "RtlVerifyVersionInfo");
     onetime = false;
   }
 


### PR DESCRIPTION
 + avoid using CURLX_FUNCTION_CAST, instead dereference destination pointer to FARPROC*
 + remove unnecessary function pointer typedefs required for CURLX_FUNCTION_CAST