### PR TITLE
appveyor: tidy-ups

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -152,7 +152,7 @@ if [ "${TESTING}" = 'ON' ]; then
     )
   else
     (
-      TFLAGS=" -a -p !flaky -r -rm ${TFLAGS}"
+      TFLAGS="-a -p !flaky -r -rm ${TFLAGS}"
       cd _bld/tests
       ./runtests.pl
     )

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -72,7 +72,7 @@ elif [ "${BUILD_SYSTEM}" = 'VisualStudioSolution' ]; then
   (
     cd projects
     ./generate.bat "${VC_VERSION}"
-    msbuild.exe -maxcpucount "-property:Configuration=${PRJ_CFG}" "Windows\\${VC_VERSION}\\curl-all.sln"
+    msbuild.exe -maxcpucount "-property:Configuration=${PRJ_CFG}" "Windows/${VC_VERSION}/curl-all.sln"
   )
   curl="build/Win32/${VC_VERSION}/${PRJ_CFG}/curld.exe"
 elif [ "${BUILD_SYSTEM}" = 'winbuild_vs2015' ]; then

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -152,7 +152,7 @@ if [ "${TESTING}" = 'ON' ]; then
     )
   else
     (
-      TFLAGS=" -a -p !flaky !timing-dependent -r -rm ${TFLAGS}"
+      TFLAGS=" -a -p !flaky -r -rm ${TFLAGS}"
       cd _bld/tests
       ./runtests.pl
     )

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -135,22 +135,26 @@ fi
 # test
 
 if [ "${TESTING}" = 'ON' ]; then
-  acurl=''
-  [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ] && acurl="-ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
-  [ -x "$(cygpath -u "${WINDIR}/System32/curl.exe")" ] && acurl="-ac $(cygpath -u "${WINDIR}/System32/curl.exe")"
+  export TFLAGS=''
+  if [ -x "$(cygpath -u "${WINDIR}/System32/curl.exe")" ]; then
+    TFLAGS+=" -ac $(cygpath -u "${WINDIR}/System32/curl.exe")"
+  elif [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
+    TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
+  fi
+  TFLAGS+=" ${DISABLED_TESTS:-}"
   if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     ls _bld/lib/*.dll >/dev/null 2>&1 && cp -f -p _bld/lib/*.dll _bld/tests/libtest/
-    TFLAGS="${acurl} ${DISABLED_TESTS:-}" cmake --build _bld --config "${PRJ_CFG}" --target test-ci
+    cmake --build _bld --config "${PRJ_CFG}" --target test-ci
   elif [ "${BUILD_SYSTEM}" = 'autotools' ]; then
     (
       cd _bld
-      make -j2 V=1 TFLAGS="${acurl} ${DISABLED_TESTS:-}" test-ci
+      make -j2 V=1 test-ci
     )
   else
     (
+      TFLAGS=" -a -p !flaky !timing-dependent -r -rm ${TFLAGS}"
       cd _bld/tests
-      # shellcheck disable=SC2086
-      ./runtests.pl -a -p !flaky -r -rm ${acurl} ${DISABLED_TESTS:-}
+      ./runtests.pl
     )
   fi
 fi


### PR DESCRIPTION
- replace two remaining backslashes with forward slashes.
- tidy up the way we form and pass `TFLAGS`.

Follow-up to 2d4d0c1fd32f5cc3f946c407c8eccd5477b287df #12572

Closes #12582
