### PR TITLE
mbedtls: free the entropy when threaded

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1206,6 +1206,9 @@ static int mbedtls_init(void)
 
 static void mbedtls_cleanup(void)
 {
+#ifdef THREADING_SUPPORT
+  mbedtls_entropy_free(&ts_entropy);
+#endif /* THREADING_SUPPORT */
   (void)Curl_mbedtlsthreadlock_thread_cleanup();
 }
 


### PR DESCRIPTION
The entropy_free was never done for threaded builds, causing a small (fixed) memory leak.

Reported-by: RevaliQaQ on github
Fixes #12584