### PR TITLE
Documentation: Fix incorrect C string escape in CURLOPT_POSTFIELDS

### DIFF
--- a/docs/libcurl/opts/CURLOPT_POSTFIELDS.3
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDS.3
@@ -97,7 +97,7 @@ int main(void)
   /* send an application/json POST */
   curl = curl_easy_init();
   if(curl) {
-    const char *json = "{\"name\": \"daniel\"}";
+    const char *json = "{\\\"name\\\": \\\"daniel\\\"}";
     struct curl_slist *slist1 = NULL;
     slist1 = curl_slist_append(slist1, "Content-Type: application/json");
     slist1 = curl_slist_append(slist1, "Accept: application/json");


### PR DESCRIPTION
The string literal incorrectly formatted. The backslashes in the JSON string not properly escaped, leading to invalid C syntax:

```c
const char *json = "{"name": "daniel"}";
```

Where it should be:

```c
const char *json = "{\"name\": \"daniel\"}";
```