### PR TITLE
verify-examples.pl: fail verification on unescaped backslash

### DIFF
--- a/.github/scripts/verify-examples.pl
+++ b/.github/scripts/verify-examples.pl
@@ -69,7 +69,7 @@ sub extract {
             if(/^.fi/) {
                 last;
             }
-            if(/\\[^\\]/) {
+            if(/(?<!\\)(?:\\{2})*\\(?!\\)/) {
                 print STDERR
                   "Error while processing file $f line $iline:\n$_" .
                   "Error: Single backslashes \\ are not properly shown in " .

--- a/.github/scripts/verify-examples.pl
+++ b/.github/scripts/verify-examples.pl
@@ -26,6 +26,7 @@
 my @files = @ARGV;
 my $cfile = "test.c";
 my $check = "./scripts/checksrc.pl";
+my $error;
 
 if($files[0] eq "-h") {
     print "Usage: verify-synopsis [man pages]\n";
@@ -75,6 +76,7 @@ sub extract {
                   "Error: Single backslashes \\ are not properly shown in " .
                   "manpage EXAMPLE output unless they are escaped \\\\.\n";
                 $fail = 1;
+                $error = 1;
                 last;
             }
             # two backslashes become one
@@ -89,16 +91,12 @@ sub extract {
     return ($fail ? 0 : $l);
 }
 
-my $error;
 for my $m (@files) {
     print "Verify $m\n";
     my $out = extract($m);
     if($out) {
       $error |= testcompile($m);
       $error |= checksrc($m);
-    }
-    else {
-      $error = 1;
     }
 }
 exit $error;

--- a/.github/workflows/man-examples.yml
+++ b/.github/workflows/man-examples.yml
@@ -12,12 +12,14 @@ on:
     paths:
       - 'docs/libcurl/curl_*.3'
       - 'docs/libcurl/opts/*.3'
+      - '.github/scripts/verify-examples.pl'
   pull_request:
     branches:
       - master
     paths:
       - 'docs/libcurl/curl_*.3'
       - 'docs/libcurl/opts/*.3'
+      - '.github/scripts/verify-examples.pl'
 
 jobs:
   verify:


### PR DESCRIPTION
- Check that all backslashes in EXAMPLE are properly escaped.

eg manpage must always use `\\n` never `\n`.

This is because the manpage requires we always double blackslash to show a single backslash. Prior to this change an erroneous single backslash would pass through and compile even though it would not show correctly in the manpage.

Ref: https://github.com/curl/curl/pull/12588

Closes #xxxx

---

Note I also added `die` for failed `open` of input/output.