### PR TITLE
Fix LDAP hang by reading more

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -963,8 +963,7 @@ static CURLcode client_write(struct Curl_easy *data,
   return result;
 }
 
-static int oldap_recv_single(struct Curl_easy *data, int sockindex, char *buf,
-                             size_t len, CURLcode *err)
+static int oldap_recv_single(struct Curl_easy *data, CURLcode *err)
 {
   struct ldapconninfo *li = data->conn->proto.ldapc;
   struct ldapreqinfo *lr = data->req.p.ldap;
@@ -976,10 +975,6 @@ static int oldap_recv_single(struct Curl_easy *data, int sockindex, char *buf,
   int binary = 0;
   int code;
   char *info = NULL;
-
-  (void)len;
-  (void)buf;
-  (void)sockindex;
 
   rc = ldap_result(li->ld, lr->msgid, LDAP_MSG_ONE, &tv, &msg);
   if(rc < 0) {
@@ -1142,7 +1137,7 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
 
   /* There might be multiple messages so read all the available messages. */
   do {
-    msg_read = oldap_recv_single(data, sockindex, buf, len, err);
+    msg_read = oldap_recv_single(data, err);
 
     if(msg_read)
       read_count++;


### PR DESCRIPTION
This patch fixes known bug `12.4`.

#### Bug
The problem is that libcurl only reads one `ldap` message at a time. So `LDAP_RES_SEARCH_RESULT` msg is never read and hangs until the timeout occurs.

#### Fix
Changed the code to read until there are no messages left or an error occurred in a non-blocking way.

### Loop Condition
`oldap_recv_single` only parses one message at a time even though there might be multiple `ldap` messages in the read buffer. So `oldap_recv_single` parses a single message and outputs the `CURLE_AGAIN` over `err` variable if a message is parsed and no error occurred but its type is not `LDAP_RES_SEARCH_RESULT`.

`LDAP_RES_SEARCH_RESULT` is the query end indicator. In a nutshell, `CURLE_AGAIN` constitutes that there might be remaining messages because query end indicator is not reached yet. So loop continues if a message is read and no error occurred.

`oldap_recv` return code is `CURLE_AGAIN` if at least one message is parsed and no error occurred. Otherwise the actual error is returned.

#### Wireshark trace
[ldap-wireshark.zip](https://github.com/curl/curl/files/13764277/ldap-wireshark.zip)

#### Before fix
https://github.com/curl/curl/assets/35337781/3f80644e-b745-44a2-881e-d77fbdd8468c

#### After fix
https://github.com/curl/curl/assets/35337781/8090e32a-ea71-40fa-ab20-d730067a7d50

