### PR TITLE
macos.yml: use latest xcode version choosen by runner

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,6 @@ concurrency:
 permissions: {}
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
   MAKEFLAGS: -j 5
 
 jobs:


### PR DESCRIPTION
As mentioned here: https://github.com/curl/curl/issues/10356#issuecomment-1763215406 It is possible to use latest version of xcode again.