### PR TITLE
LDAP segfault fix

### DIFF
--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -582,6 +582,12 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
 #ifdef USE_SSL
   if(conn->handler->flags & PROTOPT_SSL)
     return oldap_ssl_connect(data, OLDAP_SSL);
+  else {
+    CURLcode result = oldap_ssl_connect(data, OLDAP_SSL);
+
+    if(result)
+      return result;
+  }
 
   if(data->set.use_ssl) {
     CURLcode result = oldap_perform_starttls(data);


### PR DESCRIPTION
The problem is that `send/recv` methods are `NULL` so I call `oldap_ssl_connect` even though the connection is not `SSL` and somehow it fixed the problem.

Fixes #12593 

#### After fix
``` shell
ozanc@ozanc-dev:~/repo/curl$ ./build/src/curl -vvv --user ozanadmin@corp.sunnyvalley.io:Ozn.1234! ldap://172.16.43.167:389/DC=corp,DC=sunnyva
lley,DC=io??sub?(|(userPrincipalName=ozanadmin@corp.sunnyvalley.io)(sAMAccountName=ozanadmin@corp.sunnyvalley.io))
*   Trying 172.16.43.167:389...
* Connected to 172.16.43.167 (172.16.43.167) port 389
* LDAP local: ldap://172.16.43.167:389/DC=corp,DC=sunnyvalley,DC=io??sub?(|(userPrincipalName=ozanadmin@corp.sunnyvalley.io)(sAMAccountName=ozanadmin@corp.sunnyvalley.io))
DN: CN=Ozan Admin,OU=AdminS,DC=corp,DC=sunnyvalley,DC=io
        objectClass: top
        objectClass: person
        objectClass: organizationalPerson
        objectClass: user

        cn: Ozan Admin

        sn: Admin

        givenName: Ozan

        distinguishedName: CN=Ozan Admin,OU=AdminS,DC=corp,DC=sunnyvalley,DC=io

        instanceType: 4

        whenCreated: 20231221134931.0Z

        whenChanged: 20231222045540.0Z

        displayName: Ozan Admin

        uSNCreated: 49196

        memberOf: CN=Group Policy Creator Owners,CN=Users,DC=corp,DC=sunnyvalley,DC=io
        memberOf: CN=Domain Admins,CN=Users,DC=corp,DC=sunnyvalley,DC=io
        memberOf: CN=Enterprise Admins,CN=Users,DC=corp,DC=sunnyvalley,DC=io
        memberOf: CN=Schema Admins,CN=Users,DC=corp,DC=sunnyvalley,DC=io
        memberOf: CN=Remote Desktop Users,CN=Builtin,DC=corp,DC=sunnyvalley,DC=io
        memberOf: CN=Administrators,CN=Builtin,DC=corp,DC=sunnyvalley,DC=io

        uSNChanged: 49422

        name: Ozan Admin

        objectGUID:: vAzjGRFWaEC0pz1wqJ7kWw==

        userAccountControl: 66048

        badPwdCount: 0

        codePage: 0

        countryCode: 0

        badPasswordTime: 133477191309999559

        lastLogoff: 0

        lastLogon: 133477206211459558

        pwdLastSet: 133476401720319025

        primaryGroupID: 513

        objectSid:: AQUAAAAAAAUVAAAA6FkH+TIyOcvN3Xt3XwQAAA==

        adminCount: 1

        accountExpires: 9223372036854775807

        logonCount: 7

        sAMAccountName: ozanadmin

        sAMAccountType: 805306368

        userPrincipalName: ozanadmin@corp.sunnyvalley.io

        objectCategory: CN=Person,CN=Schema,CN=Configuration,DC=corp,DC=sunnyvalley,DC=io

        dSCorePropagationData: 20231221140012.0Z
        dSCorePropagationData: 20231221134959.0Z
        dSCorePropagationData: 16010101000000.0Z

        lastLogonTimestamp: 133476945409728752


* Connection #0 to host 172.16.43.167 left intact
```