### PR TITLE
quiche: return CURLE_HTTP3 on send to invalid stream

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1894,6 +1894,9 @@ static ssize_t cf_ngtcp2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       sent = (ssize_t)len;
       goto out;
     }
+    CURL_TRC_CF(data, cf, "[%" PRId64 "] send_body(len=%zu) "
+                "-> invalid stream, closed: %s",
+                stream->id, len, (stream->closed ? "true" : "false"));
     *err = CURLE_HTTP3;
     sent = -1;
     goto out;

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1895,8 +1895,7 @@ static ssize_t cf_ngtcp2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       goto out;
     }
     CURL_TRC_CF(data, cf, "[%" PRId64 "] send_body(len=%zu) "
-                "-> invalid stream, closed: %s",
-                stream->id, len, (stream->closed ? "true" : "false"));
+                "-> stream closed", stream->id, len);
     *err = CURLE_HTTP3;
     sent = -1;
     goto out;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1112,6 +1112,9 @@ static ssize_t cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
         nwritten = (ssize_t)len;
         goto out;
       }
+      CURL_TRC_CF(data, cf, "[%" PRId64 "] send_body(len=%zu) "
+                  "-> invalid stream, closed: %s",
+                  stream->id, len, (stream->closed ? "true" : "false"));
       *err = CURLE_HTTP3;
       nwritten = -1;
       goto out;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1095,20 +1095,25 @@ static ssize_t cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       nwritten = -1;
       goto out;
     }
-    else if(nwritten == QUICHE_H3_TRANSPORT_ERR_INVALID_STREAM_STATE &&
-            stream->closed && stream->resp_hds_complete) {
-      /* sending request body on a stream that has been closed by the
-       * server. If the server has send us a final response, we should
-       * silently discard the send data.
-       * This happens for example on redirects where the server, instead
-       * of reading the full request body just closed the stream after
-       * sending the 30x response.
-       * This is sort of a race: had the transfer loop called recv first,
-       * it would see the response and stop/discard sending on its own- */
-      CURL_TRC_CF(data, cf, "[%" PRId64 "] discarding data"
-                  "on closed stream with response", stream->id);
-      *err = CURLE_OK;
-      nwritten = (ssize_t)len;
+    else if(stream->closed ||
+            nwritten == QUICHE_H3_TRANSPORT_ERR_INVALID_STREAM_STATE) {
+      if(stream->closed && stream->resp_hds_complete) {
+        /* sending request body on a stream that has been closed by the
+         * server. If the server has send us a final response, we should
+         * silently discard the send data.
+         * This happens for example on redirects where the server, instead
+         * of reading the full request body just closed the stream after
+         * sending the 30x response.
+         * This is sort of a race: had the transfer loop called recv first,
+         * it would see the response and stop/discard sending on its own- */
+        CURL_TRC_CF(data, cf, "[%" PRId64 "] discarding data"
+                    "on closed stream with response", stream->id);
+        *err = CURLE_OK;
+        nwritten = (ssize_t)len;
+        goto out;
+      }
+      *err = CURLE_HTTP3;
+      nwritten = -1;
       goto out;
     }
     else if(nwritten == QUICHE_H3_TRANSPORT_ERR_FINAL_SIZE) {


### PR DESCRIPTION
Prior to this change if a send failed on a stream in an invalid state (according to quiche) and not marked as closed (according to libcurl) then the send function would return CURLE_SEND_ERROR.

We already have similar code for ngtcp2 to return CURLE_HTTP3 in this case.

Caught by test test_07_upload.py: test_07_22_upload_parallel_fail.

Fixes https://github.com/curl/curl/issues/12590
Closes #xxxx
