### PR TITLE
vtls: fix missing multissl version info

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1413,10 +1413,12 @@ static size_t multissl_version(char *buffer, size_t size)
     backends_len = p - backends;
   }
 
-  if(size && (size < backends_len))
-    strcpy(buffer, backends);
-  else
-    *buffer = 0; /* did not fit */
+  if(size) {
+    if(backends_len < size)
+      strcpy(buffer, backends);
+    else
+      *buffer = 0; /* did not fit */
+  }
   return 0;
 }
 


### PR DESCRIPTION
- Fix erroneous buffer copy logic from ff74cef5.

Prior to this change the MultiSSL version info returned to the user was empty.

Closes #xxxx

---
before: `libcurl/8.6.0-DEV  nghttp2/1.52.0`
after: `libcurl/8.6.0-DEV OpenSSL/3.0.8 (Schannel) nghttp2/1.52.0`