### PR TITLE
system_win32: fix a function pointer assignment warning

### DIFF
--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -57,12 +57,16 @@ typedef struct addrinfoexW_
   struct addrinfoexW_ *ai_next;
 } ADDRINFOEXW_;
 
-typedef void(CALLBACK *LOOKUP_COMPLETION)(DWORD, DWORD, LPWSAOVERLAPPED);
-extern void(WSAAPI *Curl_FreeAddrInfoExW)(ADDRINFOEXW_*);
-extern int(WSAAPI *Curl_GetAddrInfoExCancel)(LPHANDLE);
-extern int(WSAAPI *Curl_GetAddrInfoExW)(PCWSTR, PCWSTR, DWORD, LPGUID,
+typedef void (CALLBACK *LOOKUP_COMPLETION_FN)(DWORD, DWORD, LPWSAOVERLAPPED);
+typedef void (WSAAPI *FREEADDRINFOEXW_FN)(ADDRINFOEXW_*);
+typedef int (WSAAPI *GETADDRINFOEXCANCEL_FN)(LPHANDLE);
+typedef int (WSAAPI *GETADDRINFOEXW_FN)(PCWSTR, PCWSTR, DWORD, LPGUID,
   const ADDRINFOEXW_*, ADDRINFOEXW_**, struct timeval*, LPOVERLAPPED,
-  LOOKUP_COMPLETION, LPHANDLE);
+  LOOKUP_COMPLETION_FN, LPHANDLE);
+
+extern FREEADDRINFOEXW_FN Curl_FreeAddrInfoExW;
+extern GETADDRINFOEXCANCEL_FN Curl_GetAddrInfoExCancel;
+extern GETADDRINFOEXW_FN Curl_GetAddrInfoExW;
 
 /* This is used to dynamically load DLLs */
 HMODULE Curl_load_library(LPCTSTR filename);


### PR DESCRIPTION
- Use CURLX_FUNCTION_CAST to suppress a function pointer assignment warning.

a6bbc87f added lookups of some Windows API functions and then cast them like `*(FARPROC*)&Curl_funcname = address`. Some versions of gcc warn about that as breaking strict-aliasing rules so this PR changes those assignments to use CURLX_FUNCTION_CAST.

Bug: https://github.com/curl/curl/pull/12581#issuecomment-1869804317
Reported-by: Marcel Raad

Closes #xxxx