### PR TITLE
CURLINFO_REFERER.3: clarify that it is the *request* header

### DIFF
--- a/docs/libcurl/opts/CURLINFO_REFERER.3
+++ b/docs/libcurl/opts/CURLINFO_REFERER.3
@@ -24,7 +24,7 @@
 .\"
 .TH CURLINFO_REFERER 3 "11 Feb 2021" libcurl libcurl
 .SH NAME
-CURLINFO_REFERER \- get the referrer header
+CURLINFO_REFERER \- get the used referrer request header
 .SH SYNOPSIS
 .nf
 #include <curl/curl.h>
@@ -32,7 +32,8 @@ CURLINFO_REFERER \- get the referrer header
 CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_REFERER, char **hdrp);
 .fi
 .SH DESCRIPTION
-Pass in a pointer to a char pointer and get the referrer header.
+Pass in a pointer to a char pointer and get the referrer header used in the
+most recent request.
 
 The \fBhdrp\fP pointer is NULL or points to private memory you MUST NOT free -
 it gets freed when you call \fIcurl_easy_cleanup(3)\fP on the corresponding

--- a/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
+++ b/docs/libcurl/opts/CURLOPT_AUTOREFERER.3
@@ -39,6 +39,9 @@ when it follows a Location: redirect to a new destination.
 The automatic referer is set to the full previous URL even when redirects are
 done cross-origin or following redirects to insecure protocols. This is
 considered a minor privacy leak by some.
+
+With \fICURLINFO_REFERER(3)\fP, applications can extract the actually used
+referer header after the transfer.
 .SH DEFAULT
 0, disabled
 .SH PROTOCOLS
@@ -71,5 +74,6 @@ Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
 .SH "SEE ALSO"
 .BR CURLINFO_EFFECTIVE_URL (3),
 .BR CURLINFO_REDIRECT_URL (3),
+.BR CURLINFO_REFERER (3),
 .BR CURLOPT_FOLLOWLOCATION (3),
 .BR CURLOPT_REFERER (3)


### PR DESCRIPTION
That libcurl itself sent in the most recent request