### PR TITLE
Enable IDN on Windows when building with clang

### DIFF
--- a/lib/idn.c
+++ b/lib/idn.c
@@ -53,7 +53,7 @@
 #ifdef USE_WIN32_IDN
 /* using Windows kernel32 and normaliz libraries. */
 
-#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
+#if defined(__clang__) || !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
 WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
                                  const WCHAR *lpUnicodeCharStr,
                                  int cchUnicodeChar,

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -53,7 +53,7 @@
 #ifdef USE_WIN32_IDN
 /* using Windows kernel32 and normaliz libraries. */
 
-#if defined(__clang__) || !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600 || WINVER < 0x600
 WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
                                  const WCHAR *lpUnicodeCharStr,
                                  int cchUnicodeChar,


### PR DESCRIPTION
This PR aims to enable IDN on the Windows platform with CLANG compiler version 17 which is required to successfully 
build TensorFlow-CPU on the Windows
Changed https://github.com/curl/curl/blob/master/lib/idn.c to use an inbuilt Windows function IdnToAscii on the Clang Compiler

Below is the screenshot of the error:

![image](https://github.com/curl/curl/assets/83710963/0de1a42f-c21b-43c1-81f6-78c9d78f642a)

