### PR TITLE
asyn-thread: silence `-Wcast-align` warning for Windows

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -302,8 +302,15 @@ query_complete(DWORD err, DWORD bytes, LPWSAOVERLAPPED overlapped)
   struct Curl_addrinfo *ca;
   struct Curl_addrinfo *cafirst = NULL;
   struct Curl_addrinfo *calast = NULL;
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-align"
+#endif
   struct thread_sync_data *tsd =
     CONTAINING_RECORD(overlapped, struct thread_sync_data, w8.overlapped);
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
   struct thread_data *td = tsd->td;
   const ADDRINFOEXW_ *res = tsd->w8.res;
   int error = (int)err;


### PR DESCRIPTION
Seen with llvm/clang 17:
```
lib/asyn-thread.c:310:5: warning: cast from 'PCHAR' (aka 'char *') to 'struct thread_sync_data *' increases required alignment from 1 to 8 [-Wcast-align]
  310 |     CONTAINING_RECORD(overlapped, struct thread_sync_data, w8.overlapped);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
.../llvm-mingw/aarch64-w64-mingw32/include/winnt.h:717:48: note: expanded from macro 'CONTAINING_RECORD'
  717 | #define CONTAINING_RECORD(address,type,field) ((type *)((PCHAR)(address) - (ULONG_PTR)(&((type *)0)->field)))
      |                                                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Follow-up to a6bbc87f9e9ffb46a1801dfb983e7534825ed56b #12482

Ref: https://github.com/curl/curl/pull/12482#issuecomment-1873017261
Closes #12615
