### PR TITLE
tool: prepend output_dir in header callback 

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -178,10 +178,18 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
           return CURL_WRITEFUNC_ERROR;
         }
 
+        if(per->config->output_dir) {
+          outs->filename = aprintf("%s/%s", per->config->output_dir, filename);
+          free(filename);
+          if(!outs->filename)
+            return CURL_WRITEFUNC_ERROR;
+        }
+        else
+          outs->filename = filename;
+
         outs->is_cd_filename = TRUE;
         outs->s_isreg = TRUE;
         outs->fopened = FALSE;
-        outs->filename = filename;
         outs->alloc_filename = TRUE;
         hdrcbdata->honor_cd_filename = FALSE; /* done now! */
         if(!tool_create_output_file(outs, per->config))

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -57,22 +57,12 @@ bool tool_create_output_file(struct OutStruct *outs,
   struct GlobalConfig *global;
   FILE *file = NULL;
   char *fname = outs->filename;
-  char *aname = NULL;
   DEBUGASSERT(outs);
   DEBUGASSERT(config);
   global = config->global;
   if(!fname || !*fname) {
     warnf(global, "Remote filename has no length");
     return FALSE;
-  }
-
-  if(config->output_dir && outs->is_cd_filename) {
-    aname = aprintf("%s/%s", config->output_dir, fname);
-    if(!aname) {
-      errorf(global, "out of memory");
-      return FALSE;
-    }
-    fname = aname;
   }
 
   if(config->file_clobber_mode == CLOBBER_ALWAYS ||
@@ -94,14 +84,12 @@ bool tool_create_output_file(struct OutStruct *outs,
       char *newname;
       /* Guard against wraparound in new filename */
       if(newlen < len) {
-        free(aname);
         errorf(global, "overflow in filename generation");
         return FALSE;
       }
       newname = malloc(newlen);
       if(!newname) {
         errorf(global, "out of memory");
-        free(aname);
         return FALSE;
       }
       memcpy(newname, fname, len);
@@ -135,10 +123,8 @@ bool tool_create_output_file(struct OutStruct *outs,
   if(!file) {
     warnf(global, "Failed to open the file %s: %s", fname,
           strerror(errno));
-    free(aname);
     return FALSE;
   }
-  free(aname);
   outs->s_isreg = TRUE;
   outs->fopened = TRUE;
   outs->stream = file;

--- a/tests/data/test3012
+++ b/tests/data/test3012
@@ -4,6 +4,7 @@
 -O
 -J
 --output-dir
+--remote-time
 </keywords>
 </info>
 #
@@ -36,10 +37,10 @@ http
 http
 </features>
 <name>
---output-dir with -J
+--output-dir with -J and -R
 </name>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/this/is/the/%TESTNUMBER -OJ --output-dir %PWD/%LOGDIR
+http://%HOSTIP:%HTTPPORT/this/is/the/%TESTNUMBER -OJR --output-dir %PWD/%LOGDIR
 </command>
 </client>
 


### PR DESCRIPTION
When Content-Disposition parsing is used and an output dir is prepended, make sure to store that new file name correctly so that it can be used for setting the file timestamp when --remote-time is used.

Extended test 3012 to verify.

Reported-by: hgdagon on github
Fixes #12614