### PR TITLE
setopt: clear mimepost when formp is freed

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -681,6 +681,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.opt_no_body = FALSE; /* this is implied */
     Curl_mime_cleanpart(data->state.formp);
     Curl_safefree(data->state.formp);
+    data->state.mimepost = NULL;
     break;
 #endif
 
@@ -988,6 +989,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 #ifndef CURL_DISABLE_FORM_API
       Curl_mime_cleanpart(data->state.formp);
       Curl_safefree(data->state.formp);
+      data->state.mimepost = NULL;
 #endif
     }
     break;


### PR DESCRIPTION
A precaution to avoid a possible dangling pointer left behind.

Reported-by: Thomas Ferguson
Fixes #12608