### PR TITLE
CI: Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -96,3 +96,7 @@ License: curl
 Files: .mailmap
 Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
+
+Files: .github/dependabot.yml
+Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
+License: curl


### PR DESCRIPTION
This will cause [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) to open a PR when various actions are updated, provided that the action maintainer has issued a release.
