### PR TITLE
tool_getparam: cmdline option parser refactor

### DIFF
--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -25,6 +25,7 @@
 
 #include "tool_cfgable.h"
 #include "tool_formparse.h"
+#include "tool_paramhlp.h"
 #include "tool_main.h"
 
 #include "memdebug.h" /* keep this as LAST include */
@@ -33,7 +34,6 @@ void config_init(struct OperationConfig *config)
 {
   memset(config, 0, sizeof(struct OperationConfig));
 
-  config->postfieldsize = -1;
   config->use_httpget = FALSE;
   config->create_dirs = FALSE;
   config->maxredirs = DEFAULT_MAXREDIRS;
@@ -45,6 +45,7 @@ void config_init(struct OperationConfig *config)
   config->http09_allowed = FALSE;
   config->ftp_skip_ip = TRUE;
   config->file_clobber_mode = CLOBBER_DEFAULT;
+  curlx_dyn_init(&config->postdata, MAX_FILE2MEMORY);
 }
 
 static void free_config_fields(struct OperationConfig *config)
@@ -59,7 +60,7 @@ static void free_config_fields(struct OperationConfig *config)
   Curl_safefree(config->cookiejar);
   curl_slist_free_all(config->cookiefiles);
 
-  Curl_safefree(config->postfields);
+  Curl_dyn_free(&config->postdata);
   Curl_safefree(config->query);
   Curl_safefree(config->referer);
 

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -68,7 +68,7 @@ struct OperationConfig {
   char *proto_default;
   curl_off_t resume_from;
   char *postfields;
-  curl_off_t postfieldsize;
+  struct curlx_dynbuf postdata;
   char *referer;
   char *query;
   long timeout_ms;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -71,288 +71,558 @@ static ParameterError getstr(char **str, const char *val, bool allowblank)
   return PARAM_OK;
 }
 
-#define OPT_SHORT '\0'
+/* one enum for every command line option. The name is the verbatim long
+   option name, but in uppercase with periods and minuses replaced with
+   underscores using a "C_" prefix. */
+typedef enum {
+  C_ABSTRACT_UNIX_SOCKET,
+  C_ALPN,
+  C_ALT_SVC,
+  C_ANYAUTH,
+  C_APPEND,
+  C_AWS_SIGV4,
+  C_BASIC,
+  C_BUFFER,
+  C_CA_NATIVE,
+  C_CACERT,
+  C_CAPATH,
+  C_CERT,
+  C_CERT_STATUS,
+  C_CERT_TYPE,
+  C_CIPHERS,
+  C_CLOBBER,
+  C_COMPRESSED,
+  C_COMPRESSED_SSH,
+  C_CONFIG,
+  C_CONNECT_TIMEOUT,
+  C_CONNECT_TO,
+  C_CONTINUE_AT,
+  C_COOKIE,
+  C_COOKIE_JAR,
+  C_CREATE_DIRS,
+  C_CREATE_FILE_MODE,
+  C_CRLF,
+  C_CRLFILE,
+  C_CURVES,
+  C_DATA,
+  C_DATA_ASCII,
+  C_DATA_BINARY,
+  C_DATA_RAW,
+  C_DATA_URLENCODE,
+  C_DELEGATION,
+  C_DIGEST,
+  C_DISABLE,
+  C_DISABLE_EPRT,
+  C_DISABLE_EPSV,
+  C_DISALLOW_USERNAME_IN_URL,
+  C_DNS_INTERFACE,
+  C_DNS_IPV4_ADDR,
+  C_DNS_IPV6_ADDR,
+  C_DNS_SERVERS,
+  C_DOH_CERT_STATUS,
+  C_DOH_INSECURE,
+  C_DOH_URL,
+  C_DUMP_HEADER,
+  C_EGD_FILE,
+  C_ENGINE,
+  C_EPRT,
+  C_EPSV,
+  C_ETAG_COMPARE,
+  C_ETAG_SAVE,
+  C_EXPECT100_TIMEOUT,
+  C_FAIL,
+  C_FAIL_EARLY,
+  C_FAIL_WITH_BODY,
+  C_FALSE_START,
+  C_FORM,
+  C_FORM_ESCAPE,
+  C_FORM_STRING,
+  C_FTP_ACCOUNT,
+  C_FTP_ALTERNATIVE_TO_USER,
+  C_FTP_CREATE_DIRS,
+  C_FTP_METHOD,
+  C_FTP_PASV,
+  C_FTP_PORT,
+  C_FTP_PRET,
+  C_FTP_SKIP_PASV_IP,
+  C_FTP_SSL,
+  C_FTP_SSL_CCC,
+  C_FTP_SSL_CCC_MODE,
+  C_FTP_SSL_CONTROL,
+  C_FTP_SSL_REQD,
+  C_GET,
+  C_GLOBOFF,
+  C_HAPPY_EYEBALLS_TIMEOUT_MS,
+  C_HAPROXY_CLIENTIP,
+  C_HAPROXY_PROTOCOL,
+  C_HEAD,
+  C_HEADER,
+  C_HELP,
+  C_HOSTPUBMD5,
+  C_HOSTPUBSHA256,
+  C_HSTS,
+  C_HTTP0_9,
+  C_HTTP1_0,
+  C_HTTP1_1,
+  C_HTTP2,
+  C_HTTP2_PRIOR_KNOWLEDGE,
+  C_HTTP3,
+  C_HTTP3_ONLY,
+  C_IGNORE_CONTENT_LENGTH,
+  C_INCLUDE,
+  C_INSECURE,
+  C_INTERFACE,
+  C_IPFS_GATEWAY,
+  C_IPV4,
+  C_IPV6,
+  C_JSON,
+  C_JUNK_SESSION_COOKIES,
+  C_KEEPALIVE,
+  C_KEEPALIVE_TIME,
+  C_KEY,
+  C_KEY_TYPE,
+  C_KRB,
+  C_KRB4,
+  C_LIBCURL,
+  C_LIMIT_RATE,
+  C_LIST_ONLY,
+  C_LOCAL_PORT,
+  C_LOCATION,
+  C_LOCATION_TRUSTED,
+  C_LOGIN_OPTIONS,
+  C_MAIL_AUTH,
+  C_MAIL_FROM,
+  C_MAIL_RCPT,
+  C_MAIL_RCPT_ALLOWFAILS,
+  C_MANUAL,
+  C_MAX_FILESIZE,
+  C_MAX_REDIRS,
+  C_MAX_TIME,
+  C_METALINK,
+  C_NEGOTIATE,
+  C_NETRC,
+  C_NETRC_FILE,
+  C_NETRC_OPTIONAL,
+  C_NEXT,
+  C_NOPROXY,
+  C_NPN,
+  C_NTLM,
+  C_NTLM_WB,
+  C_OAUTH2_BEARER,
+  C_OUTPUT,
+  C_OUTPUT_DIR,
+  C_PARALLEL,
+  C_PARALLEL_IMMEDIATE,
+  C_PARALLEL_MAX,
+  C_PASS,
+  C_PATH_AS_IS,
+  C_PINNEDPUBKEY,
+  C_POST301,
+  C_POST302,
+  C_POST303,
+  C_PREPROXY,
+  C_PROGRESS_BAR,
+  C_PROGRESS_METER,
+  C_PROTO,
+  C_PROTO_DEFAULT,
+  C_PROTO_REDIR,
+  C_PROXY,
+  C_PROXY_ANYAUTH,
+  C_PROXY_BASIC,
+  C_PROXY_CA_NATIVE,
+  C_PROXY_CACERT,
+  C_PROXY_CAPATH,
+  C_PROXY_CERT,
+  C_PROXY_CERT_TYPE,
+  C_PROXY_CIPHERS,
+  C_PROXY_CRLFILE,
+  C_PROXY_DIGEST,
+  C_PROXY_HEADER,
+  C_PROXY_HTTP2,
+  C_PROXY_INSECURE,
+  C_PROXY_KEY,
+  C_PROXY_KEY_TYPE,
+  C_PROXY_NEGOTIATE,
+  C_PROXY_NTLM,
+  C_PROXY_PASS,
+  C_PROXY_PINNEDPUBKEY,
+  C_PROXY_SERVICE_NAME,
+  C_PROXY_SSL_ALLOW_BEAST,
+  C_PROXY_SSL_AUTO_CLIENT_CERT,
+  C_PROXY_TLS13_CIPHERS,
+  C_PROXY_TLSAUTHTYPE,
+  C_PROXY_TLSPASSWORD,
+  C_PROXY_TLSUSER,
+  C_PROXY_TLSV1,
+  C_PROXY_USER,
+  C_PROXY1_0,
+  C_PROXYTUNNEL,
+  C_PUBKEY,
+  C_QUOTE,
+  C_RANDOM_FILE,
+  C_RANGE,
+  C_RATE,
+  C_RAW,
+  C_REFERER,
+  C_REMOTE_HEADER_NAME,
+  C_REMOTE_NAME,
+  C_REMOTE_NAME_ALL,
+  C_REMOTE_TIME,
+  C_REMOVE_ON_ERROR,
+  C_REQUEST,
+  C_REQUEST_TARGET,
+  C_RESOLVE,
+  C_RETRY,
+  C_RETRY_ALL_ERRORS,
+  C_RETRY_CONNREFUSED,
+  C_RETRY_DELAY,
+  C_RETRY_MAX_TIME,
+  C_SASL_AUTHZID,
+  C_SASL_IR,
+  C_SERVICE_NAME,
+  C_SESSIONID,
+  C_SHOW_ERROR,
+  C_SILENT,
+  C_SOCKS4,
+  C_SOCKS4A,
+  C_SOCKS5,
+  C_SOCKS5_BASIC,
+  C_SOCKS5_GSSAPI,
+  C_SOCKS5_GSSAPI_NEC,
+  C_SOCKS5_GSSAPI_SERVICE,
+  C_SOCKS5_HOSTNAME,
+  C_SPEED_LIMIT,
+  C_SPEED_TIME,
+  C_SSL,
+  C_SSL_ALLOW_BEAST,
+  C_SSL_AUTO_CLIENT_CERT,
+  C_SSL_NO_REVOKE,
+  C_SSL_REQD,
+  C_SSL_REVOKE_BEST_EFFORT,
+  C_SSLV2,
+  C_SSLV3,
+  C_STDERR,
+  C_STYLED_OUTPUT,
+  C_SUPPRESS_CONNECT_HEADERS,
+  C_TCP_FASTOPEN,
+  C_TCP_NODELAY,
+  C_TELNET_OPTION,
+  C_TEST_EVENT,
+  C_TFTP_BLKSIZE,
+  C_TFTP_NO_OPTIONS,
+  C_TIME_COND,
+  C_TLS_MAX,
+  C_TLS13_CIPHERS,
+  C_TLSAUTHTYPE,
+  C_TLSPASSWORD,
+  C_TLSUSER,
+  C_TLSV1,
+  C_TLSV1_0,
+  C_TLSV1_1,
+  C_TLSV1_2,
+  C_TLSV1_3,
+  C_TR_ENCODING,
+  C_TRACE,
+  C_TRACE_ASCII,
+  C_TRACE_CONFIG,
+  C_TRACE_IDS,
+  C_TRACE_TIME,
+  C_UNIX_SOCKET,
+  C_UPLOAD_FILE,
+  C_URL,
+  C_URL_QUERY,
+  C_USE_ASCII,
+  C_USER,
+  C_USER_AGENT,
+  C_VARIABLE,
+  C_VERBOSE,
+  C_VERSION,
+  C_WDEBUG,
+  C_WRITE_OUT,
+  C_XATTR
+} cmdline_t;
+
 struct LongShort {
   const char *lname;  /* long name option */
   enum {
-    ARG_NONE,   /* stand-alone but not a boolean */
-    ARG_BOOL,   /* accepts a --no-[name] prefix */
-    ARG_STRING, /* requires an argument */
-    ARG_FILENAME /* requires an argument, usually a file name */
+    ARG_NONE, /* stand-alone but not a boolean */
+    ARG_BOOL, /* accepts a --no-[name] prefix */
+    ARG_STRG, /* requires an argument */
+    ARG_FILE  /* requires an argument, usually a file name */
   } desc;
-  char letter;    /* short name option */
-  char subletter; /* use OPT_SHORT when 'letter' is the short option */
+  char letter;  /* short name option or ' ' */
+  cmdline_t cmd;
 };
 
 /* this array MUST be alphasorted based on the 'lname' */
 static const struct LongShort aliases[]= {
-  {"abstract-unix-socket",     ARG_FILENAME, '$', 'W'},
-  {"alpn",                     ARG_BOOL,     '*', 'H'},
-  {"alt-svc",                  ARG_STRING,   'b', 'a'},
-  {"anyauth",                  ARG_BOOL,     '*', 'o'},
-  {"append",                   ARG_BOOL,     'a', OPT_SHORT},
-  {"aws-sigv4",                ARG_STRING,   '*', 'V'},
-  {"basic",                    ARG_BOOL,     '*', 'n'},
-  {"buffer",                   ARG_BOOL,     'N', OPT_SHORT},
-  {"ca-native",                ARG_BOOL,     'E', 'G'},
-  {"cacert",                   ARG_FILENAME, 'E', 'a'},
-  {"capath",                   ARG_FILENAME, 'E', 'g'},
-  {"cert",                     ARG_FILENAME, 'E', OPT_SHORT},
-  {"cert-status",              ARG_BOOL,     'E', 'q'},
-  {"cert-type",                ARG_STRING,   'E', 'b'},
-  {"ciphers",                  ARG_STRING,   '*', 'd'},
-  {"clobber",                  ARG_BOOL,     'O', 'c'},
-  {"compressed",               ARG_BOOL,     '*', 'j'},
-  {"compressed-ssh",           ARG_BOOL,     '$', 'Z'},
-  {"config",                   ARG_FILENAME, 'K', OPT_SHORT},
-  {"connect-timeout",          ARG_STRING,   '*', 'c'},
-  {"connect-to",               ARG_STRING,   '$', 'U'},
-  {"continue-at",              ARG_STRING,   'C', OPT_SHORT},
-  {"cookie",                   ARG_STRING,   'b', OPT_SHORT},
-  {"cookie-jar",               ARG_STRING,   'c', OPT_SHORT},
-  {"create-dirs",              ARG_BOOL,     '*', 'r'},
-  {"create-file-mode",         ARG_STRING,   '*', 'R'},
-  {"crlf",                     ARG_BOOL,     '*', 'u'},
-  {"crlfile",                  ARG_FILENAME, 'E', 'j'},
-  {"curves",                   ARG_STRING,   'E', 'E'},
-  {"data",                     ARG_STRING,   'd', OPT_SHORT},
-  {"data-ascii",               ARG_STRING,   'd', 'a'},
-  {"data-binary",              ARG_STRING,   'd', 'b'},
-  {"data-raw",                 ARG_STRING,   'd', 'r'},
-  {"data-urlencode",           ARG_STRING,   'd', 'e'},
-  {"delegation",               ARG_STRING,   '$', 'G'},
-  {"digest",                   ARG_BOOL,     '*', 'k'},
-  {"disable",                  ARG_BOOL,     'q', OPT_SHORT},
-  {"disable-eprt",             ARG_BOOL,     '*', 'z'},
-  {"disable-epsv",             ARG_BOOL,     '*', 'e'},
-  {"disallow-username-in-url", ARG_BOOL,     '*', 'f'},
-  {"dns-interface",            ARG_STRING,   '*', 'D'},
-  {"dns-ipv4-addr",            ARG_STRING,   '*', '4'},
-  {"dns-ipv6-addr",            ARG_STRING,   '*', '6'},
-  {"dns-servers",              ARG_STRING,   '*', 'F'},
-  {"doh-cert-status",          ARG_BOOL,     'E', 'Q'},
-  {"doh-insecure",             ARG_BOOL,     'k', 'd'},
-  {"doh-url"        ,          ARG_STRING,   '*', 'C'},
-  {"dump-header",              ARG_FILENAME, 'D', OPT_SHORT},
-  {"egd-file",                 ARG_STRING,   '*', 'b'},
-  {"engine",                   ARG_STRING,   'E', 'f'},
-  {"eprt",                     ARG_BOOL,     '*', 'Z'},
-  {"epsv",                     ARG_BOOL,     '*', 'E'},
-  {"etag-compare",             ARG_FILENAME, 'E', 'D'},
-  {"etag-save",                ARG_FILENAME, 'E', 'C'},
-  {"expect100-timeout",        ARG_STRING,   '$', 'R'},
-  {"fail",                     ARG_BOOL,     'f', OPT_SHORT},
-  {"fail-early",               ARG_BOOL,     'f', 'a'},
-  {"fail-with-body",           ARG_BOOL,     'f', 'd'},
-  {"false-start",              ARG_BOOL,     'E', 'r'},
-  {"form",                     ARG_STRING,   'F', OPT_SHORT},
-  {"form-escape",              ARG_BOOL,     '$', 'l'},
-  {"form-string",              ARG_STRING,   'F', 's'},
-  {"ftp-account",              ARG_STRING,   '$', 'm'},
-  {"ftp-alternative-to-user",  ARG_STRING,   '$', 'u'},
-  {"ftp-create-dirs",          ARG_BOOL,     '*', 'q'},
-  {"ftp-method",               ARG_STRING,   '$', 'r'},
-  {"ftp-pasv",                 ARG_BOOL,     '$', 'b'},
-  {"ftp-port",                 ARG_STRING,   'P', OPT_SHORT},
-  {"ftp-pret",                 ARG_BOOL,     '$', 'C'},
-  {"ftp-skip-pasv-ip",         ARG_BOOL,     '$', 'q'},
-  {"ftp-ssl",                  ARG_BOOL,     '$', 'a'},
-  {"ftp-ssl-ccc",              ARG_BOOL,     '$', 'y'},
-  {"ftp-ssl-ccc-mode",         ARG_STRING,   '$', 'j'},
-  {"ftp-ssl-control",          ARG_BOOL,     '$', 'x'},
-  {"ftp-ssl-reqd",             ARG_BOOL,     '$', 'v'},
-  {"get",                      ARG_BOOL,     'G', OPT_SHORT},
-  {"globoff",                  ARG_BOOL,     'g', OPT_SHORT},
-  {"happy-eyeballs-timeout-ms", ARG_STRING,  '$', '~'},
-  {"haproxy-clientip",         ARG_STRING,   '*', 'P'},
-  {"haproxy-protocol",         ARG_BOOL,     '*', 'X'},
-  {"head",                     ARG_BOOL,     'I', OPT_SHORT},
-  {"header",                   ARG_STRING,   'H', OPT_SHORT},
-  {"help",                     ARG_BOOL,     'h', OPT_SHORT},
-  {"hostpubmd5",               ARG_STRING,   'E', 'i'},
-  {"hostpubsha256",            ARG_STRING,   'E', 'F'},
-  {"hsts",                     ARG_STRING,   'b', 'b'},
-  {"http0.9",                  ARG_BOOL,     '0', '9'},
-  {"http1.0",                  ARG_NONE,     '0', OPT_SHORT},
-  {"http1.1",                  ARG_NONE,     '0', '1'},
-  {"http2",                    ARG_NONE,     '0', '2'},
-  {"http2-prior-knowledge",    ARG_NONE,     '0', '3'},
-  {"http3",                    ARG_NONE,     '0', '4'},
-  {"http3-only",               ARG_NONE,     '0', '5'},
-  {"ignore-content-length",    ARG_BOOL,     '$', 'p'},
-  {"include",                  ARG_BOOL,     'i', OPT_SHORT},
-  {"insecure",                 ARG_BOOL,     'k', OPT_SHORT},
-  {"interface",                ARG_STRING,   '*', 'w'},
-  {"ipfs-gateway",             ARG_STRING,   '*', 'S'},
-  {"ipv4",                     ARG_NONE,     '4', OPT_SHORT},
-  {"ipv6",                     ARG_NONE,     '6', OPT_SHORT},
-  {"json",                     ARG_STRING,   'd', 'f'},
-  {"junk-session-cookies",     ARG_BOOL,     'j', OPT_SHORT},
-  {"keepalive",                ARG_BOOL,     '$', '1'},
-  {"keepalive-time",           ARG_STRING,   '$', '3'},
-  {"key",                      ARG_FILENAME, 'E', 'c'},
-  {"key-type",                 ARG_STRING,   'E', 'd'},
-  {"krb",                      ARG_STRING,   '*', 'x'},
-  {"krb4",                     ARG_STRING,   '*', 'x'},
-  {"libcurl",                  ARG_STRING,   '$', 'z'},
-  {"limit-rate",               ARG_STRING,   '*', 'i'},
-  {"list-only",                ARG_BOOL,     'l', OPT_SHORT},
-  {"local-port",               ARG_STRING,   '$', 's'},
-  {"location",                 ARG_BOOL,     'L', OPT_SHORT},
-  {"location-trusted",         ARG_BOOL,     'L', 't'},
-  {"login-options",            ARG_STRING,   'E', '5'},
-  {"mail-auth",                ARG_STRING,   '$', 'H'},
-  {"mail-from",                ARG_STRING,   '$', 'A'},
-  {"mail-rcpt",                ARG_STRING,   '$', 'B'},
-  {"mail-rcpt-allowfails",     ARG_BOOL,     'f', 'c'},
-  {"manual",                   ARG_BOOL,     'M', OPT_SHORT},
-  {"max-filesize",             ARG_STRING,   '*', 'y'},
-  {"max-redirs",               ARG_STRING,   '*', 's'},
-  {"max-time",                 ARG_STRING,   'm', OPT_SHORT},
-  {"metalink",                 ARG_BOOL,     '$', 'J'},
-  {"negotiate",                ARG_BOOL,     '*', 'l'},
-  {"netrc",                    ARG_BOOL,     'n', OPT_SHORT},
-  {"netrc-file",               ARG_FILENAME, 'n', 'e'},
-  {"netrc-optional",           ARG_BOOL,     'n', 'o'},
-  {"next",                     ARG_NONE,     ':', OPT_SHORT},
-  {"noproxy",                  ARG_STRING,   '$', '5'},
-  {"npn",                      ARG_BOOL,     '*', 'G'},
-  {"ntlm",                     ARG_BOOL,     '*', 'm'},
-  {"ntlm-wb",                  ARG_BOOL,     '*', 'M'},
-  {"oauth2-bearer",            ARG_STRING,   '*', 'B'},
-  {"output",                   ARG_FILENAME, 'o', OPT_SHORT},
-  {"output-dir",               ARG_STRING,   'O', 'b'},
-  {"parallel",                 ARG_BOOL,     'Z', OPT_SHORT},
-  {"parallel-immediate",       ARG_BOOL,     'Z', 'c'},
-  {"parallel-max",             ARG_STRING,   'Z', 'b'},
-  {"pass",                     ARG_STRING,   'E', 'e'},
-  {"path-as-is",               ARG_BOOL,     '$', 'N'},
-  {"pinnedpubkey",             ARG_STRING,   'E', 'p'},
-  {"post301",                  ARG_BOOL,     '$', '0'},
-  {"post302",                  ARG_BOOL,     '$', '4'},
-  {"post303",                  ARG_BOOL,     '$', 'I'},
-  {"preproxy",                 ARG_STRING,   'x', 'a'},
-  {"progress-bar",             ARG_BOOL,     '#', OPT_SHORT},
-  {"progress-meter",           ARG_BOOL,     '#', 'm'},
-  {"proto",                    ARG_STRING,   '$', 'D'},
-  {"proto-default",            ARG_STRING,   '$', 'Q'},
-  {"proto-redir",              ARG_STRING,   '$', 'E'},
-  {"proxy",                    ARG_STRING,   'x', OPT_SHORT},
-  {"proxy-anyauth",            ARG_BOOL,     '$', 'n'},
-  {"proxy-basic",              ARG_BOOL,     '$', 'f'},
-  {"proxy-ca-native",          ARG_BOOL,     'E', 'H'},
-  {"proxy-cacert",             ARG_FILENAME, 'E', '6'},
-  {"proxy-capath",             ARG_FILENAME, 'E', '7'},
-  {"proxy-cert",               ARG_FILENAME, 'E', 'x'},
-  {"proxy-cert-type",          ARG_STRING,   'E', 'y'},
-  {"proxy-ciphers",            ARG_STRING,   'E', '2'},
-  {"proxy-crlfile",            ARG_FILENAME, 'E', '3'},
-  {"proxy-digest",             ARG_BOOL,     '$', 'e'},
-  {"proxy-header",             ARG_STRING,   'H', 'p'},
-  {"proxy-http2",              ARG_BOOL,     '0', 'a'},
-  {"proxy-insecure",           ARG_BOOL,     'E', '8'},
-  {"proxy-key",                ARG_FILENAME, 'E', 'z'},
-  {"proxy-key-type",           ARG_STRING,   'E', '0'},
-  {"proxy-negotiate",          ARG_BOOL,     '$', 'k'},
-  {"proxy-ntlm",               ARG_BOOL,     '*', 't'},
-  {"proxy-pass",               ARG_STRING,   'E', '1'},
-  {"proxy-pinnedpubkey",       ARG_STRING,   'E', 'P'},
-  {"proxy-service-name",       ARG_STRING,   '$', 'O'},
-  {"proxy-ssl-allow-beast",    ARG_BOOL,     'E', '4'},
-  {"proxy-ssl-auto-client-cert", ARG_BOOL,   'E', 'O'},
-  {"proxy-tls13-ciphers",      ARG_STRING,   '1', 'B'},
-  {"proxy-tlsauthtype",        ARG_STRING,   'E', 'w'},
-  {"proxy-tlspassword",        ARG_STRING,   'E', 'v'},
-  {"proxy-tlsuser",            ARG_STRING,   'E', 'u'},
-  {"proxy-tlsv1",              ARG_NONE,     'E', '9'},
-  {"proxy-user",               ARG_STRING,   'U', OPT_SHORT},
-  {"proxy1.0",                 ARG_STRING,   '$', '8'},
-  {"proxytunnel",              ARG_BOOL,     'p', OPT_SHORT},
-  {"pubkey",                   ARG_STRING,   'E', 'h'},
-  {"quote",                    ARG_STRING,   'Q', OPT_SHORT},
-  {"random-file",              ARG_FILENAME, '*', 'a'},
-  {"range",                    ARG_STRING,   'r', OPT_SHORT},
-  {"rate",                     ARG_STRING,   '*', 'I'},
-  {"raw",                      ARG_BOOL,     '$', '#'},
-  {"referer",                  ARG_STRING,   'e', OPT_SHORT},
-  {"remote-header-name",       ARG_BOOL,     'J', OPT_SHORT},
-  {"remote-name",              ARG_BOOL,     'O', OPT_SHORT},
-  {"remote-name-all",          ARG_BOOL,     'O', 'a'},
-  {"remote-time",              ARG_BOOL,     'R', OPT_SHORT},
-  {"remove-on-error",          ARG_BOOL,     'f', 'e'},
-  {"request",                  ARG_STRING,   'X', OPT_SHORT},
-  {"request-target",           ARG_STRING,   'G', 'a'},
-  {"resolve",                  ARG_STRING,   '$', 'F'},
-  {"retry",                    ARG_STRING,   '$', 'g'},
-  {"retry-all-errors",         ARG_BOOL,     '$', '!'},
-  {"retry-connrefused",        ARG_BOOL,     '$', 'V'},
-  {"retry-delay",              ARG_STRING,   '$', 'h'},
-  {"retry-max-time",           ARG_STRING,   '$', 'i'},
-  {"sasl-authzid",             ARG_STRING,   '$', '6'},
-  {"sasl-ir",                  ARG_BOOL,     '$', 'K'},
-  {"service-name",             ARG_STRING,   '$', 'P'},
-  {"sessionid",                ARG_BOOL,     '$', 'w'},
-  {"show-error",               ARG_BOOL,     'S', OPT_SHORT},
-  {"silent",                   ARG_BOOL,     's', OPT_SHORT},
-  {"socks4",                   ARG_STRING,   '$', 't'},
-  {"socks4a",                  ARG_STRING,   '$', 'T'},
-  {"socks5",                   ARG_STRING,   '$', 'c'},
-  {"socks5-basic",             ARG_BOOL,     'E', 'A'},
-  {"socks5-gssapi",            ARG_BOOL,     'E', 'B'},
-  {"socks5-gssapi-nec",        ARG_BOOL,     '$', '7'},
-  {"socks5-gssapi-service",    ARG_STRING,   '$', 'O'},
-  {"socks5-hostname",          ARG_STRING,   '$', '2'},
-  {"speed-limit",              ARG_STRING,   'Y', OPT_SHORT},
-  {"speed-time",               ARG_STRING,   'y', OPT_SHORT},
-  {"ssl",                      ARG_BOOL,     '$', 'a'},
-  {"ssl-allow-beast",          ARG_BOOL,     'E', 'n'},
-  {"ssl-auto-client-cert",     ARG_BOOL,     'E', 'o'},
-  {"ssl-no-revoke",            ARG_BOOL,     'E', 's'},
-  {"ssl-reqd",                 ARG_BOOL,     '$', 'v'},
-  {"ssl-revoke-best-effort",   ARG_BOOL,     'E', 'S'},
-  {"sslv2",                    ARG_NONE,     '2', OPT_SHORT},
-  {"sslv3",                    ARG_NONE,     '3', OPT_SHORT},
-  {"stderr",                   ARG_FILENAME, '*', 'v'},
-  {"styled-output",            ARG_BOOL,     'f', 'b'},
-  {"suppress-connect-headers", ARG_BOOL,     '$', 'Y'},
-  {"tcp-fastopen",             ARG_BOOL,     'E', 't'},
-  {"tcp-nodelay",              ARG_BOOL,     '$', 'd'},
-  {"telnet-option",            ARG_STRING,   't', OPT_SHORT},
-  {"test-event",               ARG_BOOL,     '$', 'L'},
-  {"tftp-blksize",             ARG_STRING,   '$', '9'},
-  {"tftp-no-options",          ARG_BOOL,     '$', 'S'},
-  {"time-cond",                ARG_STRING,   'z', OPT_SHORT},
-  {"tls-max",                  ARG_STRING,   '$', 'X'},
-  {"tls13-ciphers",            ARG_STRING,   '1', 'A'},
-  {"tlsauthtype",              ARG_STRING,   'E', 'm'},
-  {"tlspassword",              ARG_STRING,   'E', 'l'},
-  {"tlsuser",                  ARG_STRING,   'E', 'k'},
-  {"tlsv1",                    ARG_NONE,     '1', OPT_SHORT},
-  {"tlsv1.0",                  ARG_NONE,     '1', '0'},
-  {"tlsv1.1",                  ARG_NONE,     '1', '1'},
-  {"tlsv1.2",                  ARG_NONE,     '1', '2'},
-  {"tlsv1.3",                  ARG_NONE,     '1', '3'},
-  {"tr-encoding",              ARG_BOOL,     '*', 'J'},
-  {"trace",                    ARG_FILENAME, '*', 'g'},
-  {"trace-ascii",              ARG_FILENAME, '*', 'h'},
-  {"trace-config",             ARG_STRING,   '$', '&'},
-  {"trace-ids",                ARG_BOOL,     '$', '%'},
-  {"trace-time",               ARG_BOOL,     '$', 'o'},
-  {"unix-socket",              ARG_FILENAME, '$', 'M'},
-  {"upload-file",              ARG_FILENAME, 'T', OPT_SHORT},
-  {"url",                      ARG_STRING,   '*', '@'},
-  {"url-query",                ARG_STRING,   'd', 'g'},
-  {"use-ascii",                ARG_BOOL,     'B', OPT_SHORT},
-  {"user",                     ARG_STRING,   'u', OPT_SHORT},
-  {"user-agent",               ARG_STRING,   'A', OPT_SHORT},
-  {"variable",                 ARG_STRING,   ':', 'a'},
-  {"verbose",                  ARG_BOOL,     'v', OPT_SHORT},
-  {"version",                  ARG_BOOL,     'V', OPT_SHORT},
+  {"abstract-unix-socket",       ARG_FILE, ' ', C_ABSTRACT_UNIX_SOCKET},
+  {"alpn",                       ARG_BOOL, ' ', C_ALPN},
+  {"alt-svc",                    ARG_STRG, ' ', C_ALT_SVC},
+  {"anyauth",                    ARG_BOOL, ' ', C_ANYAUTH},
+  {"append",                     ARG_BOOL, 'a', C_APPEND},
+  {"aws-sigv4",                  ARG_STRG, ' ', C_AWS_SIGV4},
+  {"basic",                      ARG_BOOL, ' ', C_BASIC},
+  {"buffer",                     ARG_BOOL, 'N', C_BUFFER},
+  {"ca-native",                  ARG_BOOL, ' ', C_CA_NATIVE},
+  {"cacert",                     ARG_FILE, ' ', C_CACERT},
+  {"capath",                     ARG_FILE, ' ', C_CAPATH},
+  {"cert",                       ARG_FILE, 'E', C_CERT},
+  {"cert-status",                ARG_BOOL, ' ', C_CERT_STATUS},
+  {"cert-type",                  ARG_STRG, ' ', C_CERT_TYPE},
+  {"ciphers",                    ARG_STRG, ' ', C_CIPHERS},
+  {"clobber",                    ARG_BOOL, ' ', C_CLOBBER},
+  {"compressed",                 ARG_BOOL, ' ', C_COMPRESSED},
+  {"compressed-ssh",             ARG_BOOL, ' ', C_COMPRESSED_SSH},
+  {"config",                     ARG_FILE, 'K', C_CONFIG},
+  {"connect-timeout",            ARG_STRG, ' ', C_CONNECT_TIMEOUT},
+  {"connect-to",                 ARG_STRG, ' ', C_CONNECT_TO},
+  {"continue-at",                ARG_STRG, 'C', C_CONTINUE_AT},
+  {"cookie",                     ARG_STRG, 'b', C_COOKIE},
+  {"cookie-jar",                 ARG_STRG, 'c', C_COOKIE_JAR},
+  {"create-dirs",                ARG_BOOL, ' ', C_CREATE_DIRS},
+  {"create-file-mode",           ARG_STRG, ' ', C_CREATE_FILE_MODE},
+  {"crlf",                       ARG_BOOL, ' ', C_CRLF},
+  {"crlfile",                    ARG_FILE, ' ', C_CRLFILE},
+  {"curves",                     ARG_STRG, ' ', C_CURVES},
+  {"data",                       ARG_STRG, 'd', C_DATA},
+  {"data-ascii",                 ARG_STRG, ' ', C_DATA_ASCII},
+  {"data-binary",                ARG_STRG, ' ', C_DATA_BINARY},
+  {"data-raw",                   ARG_STRG, ' ', C_DATA_RAW},
+  {"data-urlencode",             ARG_STRG, ' ', C_DATA_URLENCODE},
+  {"delegation",                 ARG_STRG, ' ', C_DELEGATION},
+  {"digest",                     ARG_BOOL, ' ', C_DIGEST},
+  {"disable",                    ARG_BOOL, 'q', C_DISABLE},
+  {"disable-eprt",               ARG_BOOL, ' ', C_DISABLE_EPRT},
+  {"disable-epsv",               ARG_BOOL, ' ', C_DISABLE_EPSV},
+  {"disallow-username-in-url",   ARG_BOOL, ' ', C_DISALLOW_USERNAME_IN_URL},
+  {"dns-interface",              ARG_STRG, ' ', C_DNS_INTERFACE},
+  {"dns-ipv4-addr",              ARG_STRG, ' ', C_DNS_IPV4_ADDR},
+  {"dns-ipv6-addr",              ARG_STRG, ' ', C_DNS_IPV6_ADDR},
+  {"dns-servers",                ARG_STRG, ' ', C_DNS_SERVERS},
+  {"doh-cert-status",            ARG_BOOL, ' ', C_DOH_CERT_STATUS},
+  {"doh-insecure",               ARG_BOOL, ' ', C_DOH_INSECURE},
+  {"doh-url"        ,            ARG_STRG, ' ', C_DOH_URL},
+  {"dump-header",                ARG_FILE, 'D', C_DUMP_HEADER},
+  {"egd-file",                   ARG_STRG, ' ', C_EGD_FILE},
+  {"engine",                     ARG_STRG, ' ', C_ENGINE},
+  {"eprt",                       ARG_BOOL, ' ', C_EPRT},
+  {"epsv",                       ARG_BOOL, ' ', C_EPSV},
+  {"etag-compare",               ARG_FILE, ' ', C_ETAG_COMPARE},
+  {"etag-save",                  ARG_FILE, ' ', C_ETAG_SAVE},
+  {"expect100-timeout",          ARG_STRG, ' ', C_EXPECT100_TIMEOUT},
+  {"fail",                       ARG_BOOL, 'f', C_FAIL},
+  {"fail-early",                 ARG_BOOL, ' ', C_FAIL_EARLY},
+  {"fail-with-body",             ARG_BOOL, ' ', C_FAIL_WITH_BODY},
+  {"false-start",                ARG_BOOL, ' ', C_FALSE_START},
+  {"form",                       ARG_STRG, 'F', C_FORM},
+  {"form-escape",                ARG_BOOL, ' ', C_FORM_ESCAPE},
+  {"form-string",                ARG_STRG, ' ', C_FORM_STRING},
+  {"ftp-account",                ARG_STRG, ' ', C_FTP_ACCOUNT},
+  {"ftp-alternative-to-user",    ARG_STRG, ' ', C_FTP_ALTERNATIVE_TO_USER},
+  {"ftp-create-dirs",            ARG_BOOL, ' ', C_FTP_CREATE_DIRS},
+  {"ftp-method",                 ARG_STRG, ' ', C_FTP_METHOD},
+  {"ftp-pasv",                   ARG_BOOL, ' ', C_FTP_PASV},
+  {"ftp-port",                   ARG_STRG, 'P', C_FTP_PORT},
+  {"ftp-pret",                   ARG_BOOL, ' ', C_FTP_PRET},
+  {"ftp-skip-pasv-ip",           ARG_BOOL, ' ', C_FTP_SKIP_PASV_IP},
+  {"ftp-ssl",                    ARG_BOOL, ' ', C_FTP_SSL},
+  {"ftp-ssl-ccc",                ARG_BOOL, ' ', C_FTP_SSL_CCC},
+  {"ftp-ssl-ccc-mode",           ARG_STRG, ' ', C_FTP_SSL_CCC_MODE},
+  {"ftp-ssl-control",            ARG_BOOL, ' ', C_FTP_SSL_CONTROL},
+  {"ftp-ssl-reqd",               ARG_BOOL, ' ', C_FTP_SSL_REQD},
+  {"get",                        ARG_BOOL, 'G', C_GET},
+  {"globoff",                    ARG_BOOL, 'g', C_GLOBOFF},
+  {"happy-eyeballs-timeout-ms",  ARG_STRG, ' ', C_HAPPY_EYEBALLS_TIMEOUT_MS},
+  {"haproxy-clientip",           ARG_STRG, ' ', C_HAPROXY_CLIENTIP},
+  {"haproxy-protocol",           ARG_BOOL, ' ', C_HAPROXY_PROTOCOL},
+  {"head",                       ARG_BOOL, 'I', C_HEAD},
+  {"header",                     ARG_STRG, 'H', C_HEADER},
+  {"help",                       ARG_BOOL, 'h', C_HELP},
+  {"hostpubmd5",                 ARG_STRG, ' ', C_HOSTPUBMD5},
+  {"hostpubsha256",              ARG_STRG, ' ', C_HOSTPUBSHA256},
+  {"hsts",                       ARG_STRG, ' ', C_HSTS},
+  {"http0.9",                    ARG_BOOL, ' ', C_HTTP0_9},
+  {"http1.0",                    ARG_NONE, '0', C_HTTP1_0},
+  {"http1.1",                    ARG_NONE, ' ', C_HTTP1_1},
+  {"http2",                      ARG_NONE, ' ', C_HTTP2},
+  {"http2-prior-knowledge",      ARG_NONE, ' ', C_HTTP2_PRIOR_KNOWLEDGE},
+  {"http3",                      ARG_NONE, ' ', C_HTTP3},
+  {"http3-only",                 ARG_NONE, ' ', C_HTTP3_ONLY},
+  {"ignore-content-length",      ARG_BOOL, ' ', C_IGNORE_CONTENT_LENGTH},
+  {"include",                    ARG_BOOL, 'i', C_INCLUDE},
+  {"insecure",                   ARG_BOOL, 'k', C_INSECURE},
+  {"interface",                  ARG_STRG, ' ', C_INTERFACE},
+  {"ipfs-gateway",               ARG_STRG, ' ', C_IPFS_GATEWAY},
+  {"ipv4",                       ARG_NONE, '4', C_IPV4},
+  {"ipv6",                       ARG_NONE, '6', C_IPV6},
+  {"json",                       ARG_STRG, ' ', C_JSON},
+  {"junk-session-cookies",       ARG_BOOL, 'j', C_JUNK_SESSION_COOKIES},
+  {"keepalive",                  ARG_BOOL, ' ', C_KEEPALIVE},
+  {"keepalive-time",             ARG_STRG, ' ', C_KEEPALIVE_TIME},
+  {"key",                        ARG_FILE, ' ', C_KEY},
+  {"key-type",                   ARG_STRG, ' ', C_KEY_TYPE},
+  {"krb",                        ARG_STRG, ' ', C_KRB},
+  {"krb4",                       ARG_STRG, ' ', C_KRB4},
+  {"libcurl",                    ARG_STRG, ' ', C_LIBCURL},
+  {"limit-rate",                 ARG_STRG, ' ', C_LIMIT_RATE},
+  {"list-only",                  ARG_BOOL, 'l', C_LIST_ONLY},
+  {"local-port",                 ARG_STRG, ' ', C_LOCAL_PORT},
+  {"location",                   ARG_BOOL, 'L', C_LOCATION},
+  {"location-trusted",           ARG_BOOL, ' ', C_LOCATION_TRUSTED},
+  {"login-options",              ARG_STRG, ' ', C_LOGIN_OPTIONS},
+  {"mail-auth",                  ARG_STRG, ' ', C_MAIL_AUTH},
+  {"mail-from",                  ARG_STRG, ' ', C_MAIL_FROM},
+  {"mail-rcpt",                  ARG_STRG, ' ', C_MAIL_RCPT},
+  {"mail-rcpt-allowfails",       ARG_BOOL, ' ', C_MAIL_RCPT_ALLOWFAILS},
+  {"manual",                     ARG_BOOL, 'M', C_MANUAL},
+  {"max-filesize",               ARG_STRG, ' ', C_MAX_FILESIZE},
+  {"max-redirs",                 ARG_STRG, ' ', C_MAX_REDIRS},
+  {"max-time",                   ARG_STRG, 'm', C_MAX_TIME},
+  {"metalink",                   ARG_BOOL, ' ', C_METALINK},
+  {"negotiate",                  ARG_BOOL, ' ', C_NEGOTIATE},
+  {"netrc",                      ARG_BOOL, 'n', C_NETRC},
+  {"netrc-file",                 ARG_FILE, ' ', C_NETRC_FILE},
+  {"netrc-optional",             ARG_BOOL, ' ', C_NETRC_OPTIONAL},
+  {"next",                       ARG_NONE, ':', C_NEXT},
+  {"noproxy",                    ARG_STRG, ' ', C_NOPROXY},
+  {"npn",                        ARG_BOOL, ' ', C_NPN},
+  {"ntlm",                       ARG_BOOL, ' ', C_NTLM},
+  {"ntlm-wb",                    ARG_BOOL, ' ', C_NTLM_WB},
+  {"oauth2-bearer",              ARG_STRG, ' ', C_OAUTH2_BEARER},
+  {"output",                     ARG_FILE, 'o', C_OUTPUT},
+  {"output-dir",                 ARG_STRG, ' ', C_OUTPUT_DIR},
+  {"parallel",                   ARG_BOOL, 'Z', C_PARALLEL},
+  {"parallel-immediate",         ARG_BOOL, ' ', C_PARALLEL_IMMEDIATE},
+  {"parallel-max",               ARG_STRG, ' ', C_PARALLEL_MAX},
+  {"pass",                       ARG_STRG, ' ', C_PASS},
+  {"path-as-is",                 ARG_BOOL, ' ', C_PATH_AS_IS},
+  {"pinnedpubkey",               ARG_STRG, ' ', C_PINNEDPUBKEY},
+  {"post301",                    ARG_BOOL, ' ', C_POST301},
+  {"post302",                    ARG_BOOL, ' ', C_POST302},
+  {"post303",                    ARG_BOOL, ' ', C_POST303},
+  {"preproxy",                   ARG_STRG, ' ', C_PREPROXY},
+  {"progress-bar",               ARG_BOOL, '#', C_PROGRESS_BAR},
+  {"progress-meter",             ARG_BOOL, ' ', C_PROGRESS_METER},
+  {"proto",                      ARG_STRG, ' ', C_PROTO},
+  {"proto-default",              ARG_STRG, ' ', C_PROTO_DEFAULT},
+  {"proto-redir",                ARG_STRG, ' ', C_PROTO_REDIR},
+  {"proxy",                      ARG_STRG, 'x', C_PROXY},
+  {"proxy-anyauth",              ARG_BOOL, ' ', C_PROXY_ANYAUTH},
+  {"proxy-basic",                ARG_BOOL, ' ', C_PROXY_BASIC},
+  {"proxy-ca-native",            ARG_BOOL, ' ', C_PROXY_CA_NATIVE},
+  {"proxy-cacert",               ARG_FILE, ' ', C_PROXY_CACERT},
+  {"proxy-capath",               ARG_FILE, ' ', C_PROXY_CAPATH},
+  {"proxy-cert",                 ARG_FILE, ' ', C_PROXY_CERT},
+  {"proxy-cert-type",            ARG_STRG, ' ', C_PROXY_CERT_TYPE},
+  {"proxy-ciphers",              ARG_STRG, ' ', C_PROXY_CIPHERS},
+  {"proxy-crlfile",              ARG_FILE, ' ', C_PROXY_CRLFILE},
+  {"proxy-digest",               ARG_BOOL, ' ', C_PROXY_DIGEST},
+  {"proxy-header",               ARG_STRG, ' ', C_PROXY_HEADER},
+  {"proxy-http2",                ARG_BOOL, ' ', C_PROXY_HTTP2},
+  {"proxy-insecure",             ARG_BOOL, ' ', C_PROXY_INSECURE},
+  {"proxy-key",                  ARG_FILE, ' ', C_PROXY_KEY},
+  {"proxy-key-type",             ARG_STRG, ' ', C_PROXY_KEY_TYPE},
+  {"proxy-negotiate",            ARG_BOOL, ' ', C_PROXY_NEGOTIATE},
+  {"proxy-ntlm",                 ARG_BOOL, ' ', C_PROXY_NTLM},
+  {"proxy-pass",                 ARG_STRG, ' ', C_PROXY_PASS},
+  {"proxy-pinnedpubkey",         ARG_STRG, ' ', C_PROXY_PINNEDPUBKEY},
+  {"proxy-service-name",         ARG_STRG, ' ', C_PROXY_SERVICE_NAME},
+  {"proxy-ssl-allow-beast",      ARG_BOOL, ' ', C_PROXY_SSL_ALLOW_BEAST},
+  {"proxy-ssl-auto-client-cert", ARG_BOOL, ' ', C_PROXY_SSL_AUTO_CLIENT_CERT},
+  {"proxy-tls13-ciphers",        ARG_STRG, ' ', C_PROXY_TLS13_CIPHERS},
+  {"proxy-tlsauthtype",          ARG_STRG, ' ', C_PROXY_TLSAUTHTYPE},
+  {"proxy-tlspassword",          ARG_STRG, ' ', C_PROXY_TLSPASSWORD},
+  {"proxy-tlsuser",              ARG_STRG, ' ', C_PROXY_TLSUSER},
+  {"proxy-tlsv1",                ARG_NONE, ' ', C_PROXY_TLSV1},
+  {"proxy-user",                 ARG_STRG, 'U', C_PROXY_USER},
+  {"proxy1.0",                   ARG_STRG, ' ', C_PROXY1_0},
+  {"proxytunnel",                ARG_BOOL, 'p', C_PROXYTUNNEL},
+  {"pubkey",                     ARG_STRG, ' ', C_PUBKEY},
+  {"quote",                      ARG_STRG, 'Q', C_QUOTE},
+  {"random-file",                ARG_FILE, ' ', C_RANDOM_FILE},
+  {"range",                      ARG_STRG, 'r', C_RANGE},
+  {"rate",                       ARG_STRG, ' ', C_RATE},
+  {"raw",                        ARG_BOOL, ' ', C_RAW},
+  {"referer",                    ARG_STRG, 'e', C_REFERER},
+  {"remote-header-name",         ARG_BOOL, 'J', C_REMOTE_HEADER_NAME},
+  {"remote-name",                ARG_BOOL, 'O', C_REMOTE_NAME},
+  {"remote-name-all",            ARG_BOOL, ' ', C_REMOTE_NAME_ALL},
+  {"remote-time",                ARG_BOOL, 'R', C_REMOTE_TIME},
+  {"remove-on-error",            ARG_BOOL, ' ', C_REMOVE_ON_ERROR},
+  {"request",                    ARG_STRG, 'X', C_REQUEST},
+  {"request-target",             ARG_STRG, ' ', C_REQUEST_TARGET},
+  {"resolve",                    ARG_STRG, ' ', C_RESOLVE},
+  {"retry",                      ARG_STRG, ' ', C_RETRY},
+  {"retry-all-errors",           ARG_BOOL, ' ', C_RETRY_ALL_ERRORS},
+  {"retry-connrefused",          ARG_BOOL, ' ', C_RETRY_CONNREFUSED},
+  {"retry-delay",                ARG_STRG, ' ', C_RETRY_DELAY},
+  {"retry-max-time",             ARG_STRG, ' ', C_RETRY_MAX_TIME},
+  {"sasl-authzid",               ARG_STRG, ' ', C_SASL_AUTHZID},
+  {"sasl-ir",                    ARG_BOOL, ' ', C_SASL_IR},
+  {"service-name",               ARG_STRG, ' ', C_SERVICE_NAME},
+  {"sessionid",                  ARG_BOOL, ' ', C_SESSIONID},
+  {"show-error",                 ARG_BOOL, 'S', C_SHOW_ERROR},
+  {"silent",                     ARG_BOOL, 's', C_SILENT},
+  {"socks4",                     ARG_STRG, ' ', C_SOCKS4},
+  {"socks4a",                    ARG_STRG, ' ', C_SOCKS4A},
+  {"socks5",                     ARG_STRG, ' ', C_SOCKS5},
+  {"socks5-basic",               ARG_BOOL, ' ', C_SOCKS5_BASIC},
+  {"socks5-gssapi",              ARG_BOOL, ' ', C_SOCKS5_GSSAPI},
+  {"socks5-gssapi-nec",          ARG_BOOL, ' ', C_SOCKS5_GSSAPI_NEC},
+  {"socks5-gssapi-service",      ARG_STRG, ' ', C_SOCKS5_GSSAPI_SERVICE},
+  {"socks5-hostname",            ARG_STRG, ' ', C_SOCKS5_HOSTNAME},
+  {"speed-limit",                ARG_STRG, 'Y', C_SPEED_LIMIT},
+  {"speed-time",                 ARG_STRG, 'y', C_SPEED_TIME},
+  {"ssl",                        ARG_BOOL, ' ', C_SSL},
+  {"ssl-allow-beast",            ARG_BOOL, ' ', C_SSL_ALLOW_BEAST},
+  {"ssl-auto-client-cert",       ARG_BOOL, ' ', C_SSL_AUTO_CLIENT_CERT},
+  {"ssl-no-revoke",              ARG_BOOL, ' ', C_SSL_NO_REVOKE},
+  {"ssl-reqd",                   ARG_BOOL, ' ', C_SSL_REQD},
+  {"ssl-revoke-best-effort",     ARG_BOOL, ' ', C_SSL_REVOKE_BEST_EFFORT},
+  {"sslv2",                      ARG_NONE, '2', C_SSLV2},
+  {"sslv3",                      ARG_NONE, '3', C_SSLV3},
+  {"stderr",                     ARG_FILE, ' ', C_STDERR},
+  {"styled-output",              ARG_BOOL, ' ', C_STYLED_OUTPUT},
+  {"suppress-connect-headers",   ARG_BOOL, ' ', C_SUPPRESS_CONNECT_HEADERS},
+  {"tcp-fastopen",               ARG_BOOL, ' ', C_TCP_FASTOPEN},
+  {"tcp-nodelay",                ARG_BOOL, ' ', C_TCP_NODELAY},
+  {"telnet-option",              ARG_STRG, 't', C_TELNET_OPTION},
+  {"test-event",                 ARG_BOOL, ' ', C_TEST_EVENT},
+  {"tftp-blksize",               ARG_STRG, ' ', C_TFTP_BLKSIZE},
+  {"tftp-no-options",            ARG_BOOL, ' ', C_TFTP_NO_OPTIONS},
+  {"time-cond",                  ARG_STRG, 'z', C_TIME_COND},
+  {"tls-max",                    ARG_STRG, ' ', C_TLS_MAX},
+  {"tls13-ciphers",              ARG_STRG, ' ', C_TLS13_CIPHERS},
+  {"tlsauthtype",                ARG_STRG, ' ', C_TLSAUTHTYPE},
+  {"tlspassword",                ARG_STRG, ' ', C_TLSPASSWORD},
+  {"tlsuser",                    ARG_STRG, ' ', C_TLSUSER},
+  {"tlsv1",                      ARG_NONE, '1', C_TLSV1},
+  {"tlsv1.0",                    ARG_NONE, ' ', C_TLSV1_0},
+  {"tlsv1.1",                    ARG_NONE, ' ', C_TLSV1_1},
+  {"tlsv1.2",                    ARG_NONE, ' ', C_TLSV1_2},
+  {"tlsv1.3",                    ARG_NONE, ' ', C_TLSV1_3},
+  {"tr-encoding",                ARG_BOOL, ' ', C_TR_ENCODING},
+  {"trace",                      ARG_FILE, ' ', C_TRACE},
+  {"trace-ascii",                ARG_FILE, ' ', C_TRACE_ASCII},
+  {"trace-config",               ARG_STRG, ' ', C_TRACE_CONFIG},
+  {"trace-ids",                  ARG_BOOL, ' ', C_TRACE_IDS},
+  {"trace-time",                 ARG_BOOL, ' ', C_TRACE_TIME},
+  {"unix-socket",                ARG_FILE, ' ', C_UNIX_SOCKET},
+  {"upload-file",                ARG_FILE, 'T', C_UPLOAD_FILE},
+  {"url",                        ARG_STRG, ' ', C_URL},
+  {"url-query",                  ARG_STRG, ' ', C_URL_QUERY},
+  {"use-ascii",                  ARG_BOOL, 'B', C_USE_ASCII},
+  {"user",                       ARG_STRG, 'u', C_USER},
+  {"user-agent",                 ARG_STRG, 'A', C_USER_AGENT},
+  {"variable",                   ARG_STRG, ' ', C_VARIABLE},
+  {"verbose",                    ARG_BOOL, 'v', C_VERBOSE},
+  {"version",                    ARG_BOOL, 'V', C_VERSION},
 #ifdef USE_WATT32
-  {"wdebug",                   ARG_BOOL,     '*', 'p'},
+  {"wdebug",                     ARG_BOOL, ' ', C_WDEBUG},
 #endif
-  {"write-out",                ARG_STRING,   'w', OPT_SHORT},
-  {"xattr",                    ARG_BOOL,     '*', '~'},
+  {"write-out",                  ARG_STRG, 'w', C_WRITE_OUT},
+  {"xattr",                      ARG_BOOL, ' ', C_XATTR},
 };
 
 /* Split the argument of -E to 'certname' and 'passphrase' separated by colon.
@@ -744,7 +1014,7 @@ static const struct LongShort *single(char letter)
   if(!singles_done) {
     unsigned int j;
     for(j = 0; j < sizeof(aliases)/sizeof(aliases[0]); j++) {
-      if(aliases[j].subletter == OPT_SHORT) {
+      if(aliases[j].letter != ' ') {
         unsigned char l = aliases[j].letter;
         singles[l - ' '] = &aliases[j];
       }
@@ -791,7 +1061,7 @@ static ParameterError url_query(char *nextarg,
   return err;
 }
 
-static ParameterError set_data(char subletter,
+static ParameterError set_data(cmdline_t cmd,
                                char *nextarg,
                                struct GlobalConfig *global,
                                struct OperationConfig *config)
@@ -801,19 +1071,19 @@ static ParameterError set_data(char subletter,
   size_t size = 0;
   ParameterError err = PARAM_OK;
 
-  if(subletter == 'e') { /* --data-urlencode */
+  if(cmd == C_DATA_URLENCODE) { /* --data-urlencode */
     err = data_urlencode(global, nextarg, &postdata, &size);
     if(err)
       return err;
   }
-  else if('@' == *nextarg && (subletter != 'r')) {
+  else if('@' == *nextarg && (cmd != C_DATA_RAW)) {
     /* the data begins with a '@' letter, it means that a file name
        or - (stdin) follows */
     nextarg++; /* pass the @ */
 
     if(!strcmp("-", nextarg)) {
       file = stdin;
-      if(subletter == 'b') /* forced data-binary */
+      if(cmd == C_DATA_BINARY) /* forced data-binary */
         set_binmode(stdin);
     }
     else {
@@ -824,8 +1094,8 @@ static ParameterError set_data(char subletter,
       }
     }
 
-    if((subletter == 'b') || /* --data-binary */
-       (subletter == 'f') /* --json */)
+    if((cmd == C_DATA_BINARY) || /* --data-binary */
+       (cmd == C_JSON) /* --json */)
       /* forced binary */
       err = file2memory(&postdata, &size, file);
     else {
@@ -854,12 +1124,12 @@ static ParameterError set_data(char subletter,
     if(postdata)
       size = strlen(postdata);
   }
-  if(subletter == 'f')
+  if(cmd == C_JSON)
     config->jsoned = TRUE;
 
   if(curlx_dyn_len(&config->postdata)) {
     /* skip separator append for --json */
-    if(!err && (subletter != 'f')  &&
+    if(!err && (cmd != C_JSON)  &&
        curlx_dyn_addn(&config->postdata, "&", 1))
       err = PARAM_NO_MEM;
   }
@@ -873,8 +1143,6 @@ static ParameterError set_data(char subletter,
   return err;
 }
 
-
-#define ONEOPT(x,y) (((int)x << 8) | y)
 
 ParameterError getparameter(const char *flag, /* f or -long-flag */
                             char *nextarg,    /* NULL if unset */
@@ -949,8 +1217,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       struct curlx_dynbuf nbuf;
       bool replaced;
 
-      if((a->desc != ARG_STRING) &&
-         (a->desc != ARG_FILENAME)) {
+      if((a->desc != ARG_STRG) &&
+         (a->desc != ARG_FILE)) {
         /* --expand on an option that isn't a string or a filename */
         err = PARAM_EXPAND_ERROR;
         goto error;
@@ -974,7 +1242,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
   do {
     /* we can loop here if we have multiple single-letters */
     char letter;
-    char subletter;
+    cmdline_t cmd;
 
     if(!longopt && !a) {
       a = single(*parse);
@@ -984,9 +1252,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
     }
     letter = a->letter;
-    subletter = a->subletter;
-
-    if(a->desc >= ARG_STRING) {
+    cmd = a->cmd;
+    if(a->desc >= ARG_STRG) {
       /* this option requires an extra parameter */
       if(!longopt && parse[1]) {
         nextarg = (char *)&parse[1]; /* this is the actual extra parameter */
@@ -1003,7 +1270,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         *usedarg = TRUE; /* mark it as used */
       }
 
-      if((a->desc == ARG_FILENAME) &&
+      if((a->desc == ARG_FILE) &&
          (nextarg[0] == '-') && nextarg[1]) {
         /* if the file name looks like a command line option */
         warnf(global, "The file name argument '%s' looks like a flag.",
@@ -1022,68 +1289,68 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
          that aware of that state */
       nextarg = (char *)"";
 
-    switch(ONEOPT(letter, subletter)) {
-    case ONEOPT('*', '4'): /* --dns-ipv4-addr */
+    switch(cmd) {
+    case C_DNS_IPV4_ADDR: /* --dns-ipv4-addr */
       if(!curlinfo->ares_num) /* c-ares is needed for this */
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         /* addr in dot notation */
         err = getstr(&config->dns_ipv4_addr, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('*', '6'): /* --dns-ipv6-addr */
+    case C_DNS_IPV6_ADDR: /* --dns-ipv6-addr */
       if(!curlinfo->ares_num) /* c-ares is needed for this */
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         /* addr in dot notation */
         err = getstr(&config->dns_ipv6_addr, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('*', 'a'): /* --random-file */
+    case C_RANDOM_FILE: /* --random-file */
       break;
-    case ONEOPT('*', 'b'): /* --egd-file */
+    case C_EGD_FILE: /* --egd-file */
       break;
-    case ONEOPT('*', 'B'): /* --oauth2-bearer */
+    case C_OAUTH2_BEARER: /* --oauth2-bearer */
       err = getstr(&config->oauth_bearer, nextarg, DENY_BLANK);
       if(!err) {
         cleanarg(clearthis);
         config->authtype |= CURLAUTH_BEARER;
       }
       break;
-    case ONEOPT('*', 'c'): /* --connect-timeout */
+    case C_CONNECT_TIMEOUT: /* --connect-timeout */
       err = secs2ms(&config->connecttimeout_ms, nextarg);
       break;
-    case ONEOPT('*', 'C'): /* --doh-url */
+    case C_DOH_URL: /* --doh-url */
       err = getstr(&config->doh_url, nextarg, ALLOW_BLANK);
       if(!err && config->doh_url && !config->doh_url[0])
         /* if given a blank string, make it NULL again */
         Curl_safefree(config->doh_url);
       break;
-    case ONEOPT('*', 'd'): /* -- ciphers */
+    case C_CIPHERS: /* -- ciphers */
       err = getstr(&config->cipher_list, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('*', 'D'): /* --dns-interface */
+    case C_DNS_INTERFACE: /* --dns-interface */
       if(!curlinfo->ares_num) /* c-ares is needed for this */
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         /* interface name */
         err = getstr(&config->dns_interface, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('*', 'e'): /* --disable-epsv */
+    case C_DISABLE_EPSV: /* --disable-epsv */
       config->disable_epsv = toggle;
       break;
-    case ONEOPT('*', 'f'): /* --disallow-username-in-url */
+    case C_DISALLOW_USERNAME_IN_URL: /* --disallow-username-in-url */
       config->disallow_username_in_url = toggle;
       break;
-    case ONEOPT('*', 'E'): /* --epsv */
+    case C_EPSV: /* --epsv */
       config->disable_epsv = (!toggle)?TRUE:FALSE;
       break;
-    case ONEOPT('*', 'F'): /* --dns-servers */
+    case C_DNS_SERVERS: /* --dns-servers */
       if(!curlinfo->ares_num) /* c-ares is needed for this */
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         /* IP addrs of DNS servers */
         err = getstr(&config->dns_servers, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('*', 'g'): /* --trace */
+    case C_TRACE: /* --trace */
       err = getstr(&global->trace_dump, nextarg, DENY_BLANK);
       if(!err) {
         if(global->tracetype && (global->tracetype != TRACE_BIN))
@@ -1091,10 +1358,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         global->tracetype = TRACE_BIN;
       }
       break;
-    case ONEOPT('*', 'G'): /* --npn */
+    case C_NPN: /* --npn */
       warnf(global, "--npn is no longer supported");
       break;
-    case ONEOPT('*', 'h'): /* --trace-ascii */
+    case C_TRACE_ASCII: /* --trace-ascii */
       err = getstr(&global->trace_dump, nextarg, DENY_BLANK);
       if(!err) {
         if(global->tracetype && (global->tracetype != TRACE_ASCII))
@@ -1103,17 +1370,17 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         global->tracetype = TRACE_ASCII;
       }
       break;
-    case ONEOPT('*', 'H'): /* --alpn */
+    case C_ALPN: /* --alpn */
       config->noalpn = (!toggle)?TRUE:FALSE;
       break;
-    case ONEOPT('*', 'i'): /* --limit-rate */
+    case C_LIMIT_RATE: /* --limit-rate */
       err = GetSizeParameter(global, nextarg, "rate", &value);
       if(!err) {
         config->recvpersecond = value;
         config->sendpersecond = value;
       }
       break;
-    case ONEOPT('*', 'I'): { /* --rate */
+    case C_RATE: { /* --rate */
       /* support a few different suffixes, extract the suffix first, then
          get the number and convert to per hour.
          /s == per second
@@ -1170,25 +1437,25 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     }
       break;
 
-    case ONEOPT('*', 'j'): /* --compressed */
+    case C_COMPRESSED: /* --compressed */
       if(toggle && !(feature_libz || feature_brotli || feature_zstd))
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         config->encoding = toggle;
       break;
 
-    case ONEOPT('*', 'J'): /* --tr-encoding */
+    case C_TR_ENCODING: /* --tr-encoding */
       config->tr_encoding = toggle;
       break;
 
-    case ONEOPT('*', 'k'): /* --digest */
+    case C_DIGEST: /* --digest */
       if(toggle)
         config->authtype |= CURLAUTH_DIGEST;
       else
         config->authtype &= ~CURLAUTH_DIGEST;
       break;
 
-    case ONEOPT('*', 'l'): /* --negotiate */
+    case C_NEGOTIATE: /* --negotiate */
       if(!toggle)
         config->authtype &= ~CURLAUTH_NEGOTIATE;
       else if(feature_spnego)
@@ -1197,7 +1464,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       break;
 
-    case ONEOPT('*', 'm'): /* --ntlm */
+    case C_NTLM: /* --ntlm */
       if(!toggle)
         config->authtype &= ~CURLAUTH_NTLM;
       else if(feature_ntlm)
@@ -1206,7 +1473,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       break;
 
-    case ONEOPT('*', 'M'): /* --ntlm-wb */
+    case C_NTLM_WB: /* --ntlm-wb */
       if(!toggle)
         config->authtype &= ~CURLAUTH_NTLM_WB;
       else if(feature_ntlm_wb)
@@ -1215,37 +1482,37 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       break;
 
-    case ONEOPT('*', 'n'): /* --basic */
+    case C_BASIC: /* --basic */
       if(toggle)
         config->authtype |= CURLAUTH_BASIC;
       else
         config->authtype &= ~CURLAUTH_BASIC;
       break;
 
-    case ONEOPT('*', 'o'): /* --anyauth */
+    case C_ANYAUTH: /* --anyauth */
       if(toggle)
         config->authtype = CURLAUTH_ANY;
       /* --no-anyauth simply doesn't touch it */
       break;
 
 #ifdef USE_WATT32
-    case ONEOPT('*', 'p'): /* --wdebug */
+    case C_WDEBUG: /* --wdebug */
       dbug_init();
       break;
 #endif
-    case ONEOPT('*', 'q'): /* --ftp-create-dirs */
+    case C_FTP_CREATE_DIRS: /* --ftp-create-dirs */
       config->ftp_create_dirs = toggle;
       break;
 
-    case ONEOPT('*', 'r'): /* --create-dirs */
+    case C_CREATE_DIRS: /* --create-dirs */
       config->create_dirs = toggle;
       break;
 
-    case ONEOPT('*', 'R'): /* --create-file-mode */
+    case C_CREATE_FILE_MODE: /* --create-file-mode */
       err = oct2nummax(&config->create_file_mode, nextarg, 0777);
       break;
 
-    case ONEOPT('*', 's'): /* --max-redirs */
+    case C_MAX_REDIRS: /* --max-redirs */
       /* specified max no of redirects (http(s)), this accepts -1 as a
          special condition */
       err = str2num(&config->maxredirs, nextarg);
@@ -1253,62 +1520,62 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_BAD_NUMERIC;
       break;
 
-    case ONEOPT('*', 'S'): /* --ipfs-gateway */
+    case C_IPFS_GATEWAY: /* --ipfs-gateway */
       err = getstr(&config->ipfs_gateway, nextarg, DENY_BLANK);
       break;
 
-    case ONEOPT('*', 't'): /* --proxy-ntlm */
+    case C_PROXY_NTLM: /* --proxy-ntlm */
       if(!feature_ntlm)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         config->proxyntlm = toggle;
       break;
 
-    case ONEOPT('*', 'u'): /* --crlf */
+    case C_CRLF: /* --crlf */
       /* LF -> CRLF conversion? */
       config->crlf = toggle;
       break;
 
-    case ONEOPT('*', 'V'): /* --aws-sigv4 */
+    case C_AWS_SIGV4: /* --aws-sigv4 */
       config->authtype |= CURLAUTH_AWS_SIGV4;
       err = getstr(&config->aws_sigv4, nextarg, DENY_BLANK);
       break;
 
-    case ONEOPT('*', 'v'): /* --stderr */
+    case C_STDERR: /* --stderr */
       tool_set_stderr_file(global, nextarg);
       break;
-    case ONEOPT('*', 'w'): /* --interface */
+    case C_INTERFACE: /* --interface */
       /* interface */
       err = getstr(&config->iface, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('*', 'x'): /* --krb */
+    case C_KRB: /* --krb */
       /* kerberos level string */
       if(!feature_spnego)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         err = getstr(&config->krblevel, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('*', 'X'): /* --haproxy-protocol */
+    case C_HAPROXY_PROTOCOL: /* --haproxy-protocol */
       config->haproxy_protocol = toggle;
       break;
-    case ONEOPT('*', 'P'): /* --haproxy-clientip */
+    case C_HAPROXY_CLIENTIP: /* --haproxy-clientip */
       err = getstr(&config->haproxy_clientip, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('*', 'y'): /* --max-filesize */
+    case C_MAX_FILESIZE: /* --max-filesize */
       err = GetSizeParameter(global, nextarg, "max-filesize", &value);
       if(!err)
         config->max_filesize = value;
       break;
-    case ONEOPT('*', 'z'): /* --disable-eprt */
+    case C_DISABLE_EPRT: /* --disable-eprt */
       config->disable_eprt = toggle;
       break;
-    case ONEOPT('*', 'Z'): /* --eprt */
+    case C_EPRT: /* --eprt */
       config->disable_eprt = (!toggle)?TRUE:FALSE;
       break;
-    case ONEOPT('*', '~'): /* --xattr */
+    case C_XATTR: /* --xattr */
       config->xattr = toggle;
       break;
-    case ONEOPT('*', '@'): /* --url */
+    case C_URL: /* --url */
       if(!config->url_get)
         config->url_get = config->url_list;
 
@@ -1328,105 +1595,103 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         /* there was no free node, create one! */
         config->url_get = url = new_getout(config);
 
-      if(!url) {
+      if(!url)
         err = PARAM_NO_MEM;
-        break;
+      else {
+        /* fill in the URL */
+        err = getstr(&url->url, nextarg, DENY_BLANK);
+        url->flags |= GETOUT_URL;
       }
-
-      /* fill in the URL */
-      err = getstr(&url->url, nextarg, DENY_BLANK);
-      url->flags |= GETOUT_URL;
       break;
 
-    case ONEOPT('$', 'a'): /* --ssl */
-      if(toggle && !feature_ssl) {
+    case C_SSL: /* --ssl */
+      if(toggle && !feature_ssl)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
-        break;
+      else {
+        config->ftp_ssl = toggle;
+        if(config->ftp_ssl)
+          warnf(global,
+                "--ssl is an insecure option, consider --ssl-reqd instead");
       }
-      config->ftp_ssl = toggle;
-      if(config->ftp_ssl)
-        warnf(global,
-              "--ssl is an insecure option, consider --ssl-reqd instead");
       break;
-    case ONEOPT('$', 'b'): /* --ftp-pasv */
+    case C_FTP_PASV: /* --ftp-pasv */
       Curl_safefree(config->ftpport);
       break;
-    case ONEOPT('$', 'c'): /* --socks5 */
+    case C_SOCKS5: /* --socks5 */
       /*  socks5 proxy to use, and resolves the name locally and passes on the
           resolved address */
       err = getstr(&config->proxy, nextarg, DENY_BLANK);
       config->proxyver = CURLPROXY_SOCKS5;
       break;
-    case ONEOPT('$', 't'): /* --socks4 */
+    case C_SOCKS4: /* --socks4 */
       err = getstr(&config->proxy, nextarg, DENY_BLANK);
       config->proxyver = CURLPROXY_SOCKS4;
       break;
-    case ONEOPT('$', 'T'): /* --socks4a */
+    case C_SOCKS4A: /* --socks4a */
       err = getstr(&config->proxy, nextarg, DENY_BLANK);
       config->proxyver = CURLPROXY_SOCKS4A;
       break;
-    case ONEOPT('$', '2'): /* --socks5-hostname */
+    case C_SOCKS5_HOSTNAME: /* --socks5-hostname */
       err = getstr(&config->proxy, nextarg, DENY_BLANK);
       config->proxyver = CURLPROXY_SOCKS5_HOSTNAME;
       break;
-    case ONEOPT('$', 'd'): /* --tcp-nodelay */
+    case C_TCP_NODELAY: /* --tcp-nodelay */
       config->tcp_nodelay = toggle;
       break;
-    case ONEOPT('$', 'e'): /* --proxy-digest */
+    case C_PROXY_DIGEST: /* --proxy-digest */
       config->proxydigest = toggle;
       break;
-    case ONEOPT('$', 'f'): /* --proxy-basic */
+    case C_PROXY_BASIC: /* --proxy-basic */
       config->proxybasic = toggle;
       break;
-    case ONEOPT('$', 'g'): /* --retry */
+    case C_RETRY: /* --retry */
       err = str2unum(&config->req_retry, nextarg);
       break;
-    case ONEOPT('$', 'V'): /* --retry-connrefused */
+    case C_RETRY_CONNREFUSED: /* --retry-connrefused */
       config->retry_connrefused = toggle;
       break;
-    case ONEOPT('$', 'h'): /* --retry-delay */
+    case C_RETRY_DELAY: /* --retry-delay */
       err = str2unummax(&config->retry_delay, nextarg, LONG_MAX/1000);
       break;
-    case ONEOPT('$', 'i'): /* --retry-max-time */
+    case C_RETRY_MAX_TIME: /* --retry-max-time */
       err = str2unummax(&config->retry_maxtime, nextarg, LONG_MAX/1000);
       break;
-    case ONEOPT('$', '!'): /* --retry-all-errors */
+    case C_RETRY_ALL_ERRORS: /* --retry-all-errors */
       config->retry_all_errors = toggle;
       break;
 
-    case ONEOPT('$', 'k'): /* --proxy-negotiate */
-      if(!feature_spnego) {
+    case C_PROXY_NEGOTIATE: /* --proxy-negotiate */
+      if(!feature_spnego)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
-        break;
-      }
-      config->proxynegotiate = toggle;
+      else
+        config->proxynegotiate = toggle;
       break;
 
-    case ONEOPT('$', 'l'): /* --form-escape */
+    case C_FORM_ESCAPE: /* --form-escape */
       config->mime_options &= ~CURLMIMEOPT_FORMESCAPE;
       if(toggle)
         config->mime_options |= CURLMIMEOPT_FORMESCAPE;
       break;
 
-    case ONEOPT('$', 'm'): /* --ftp-account */
+    case C_FTP_ACCOUNT: /* --ftp-account */
       err = getstr(&config->ftp_account, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('$', 'n'): /* --proxy-anyauth */
+    case C_PROXY_ANYAUTH: /* --proxy-anyauth */
       config->proxyanyauth = toggle;
       break;
-    case ONEOPT('$', 'o'): /* --trace-time */
+    case C_TRACE_TIME: /* --trace-time */
       global->tracetime = toggle;
       break;
-    case ONEOPT('$', 'p'): /* --ignore-content-length */
+    case C_IGNORE_CONTENT_LENGTH: /* --ignore-content-length */
       config->ignorecl = toggle;
       break;
-    case ONEOPT('$', 'q'): /* --ftp-skip-pasv-ip */
+    case C_FTP_SKIP_PASV_IP: /* --ftp-skip-pasv-ip */
       config->ftp_skip_ip = toggle;
       break;
-    case ONEOPT('$', 'r'): /* --ftp-method */
+    case C_FTP_METHOD: /* --ftp-method */
       config->ftp_filemethod = ftpfilemethod(config, nextarg);
       break;
-    case ONEOPT('$', 's'): { /* --local-port */
+    case C_LOCAL_PORT: { /* --local-port */
       /* 16bit base 10 is 5 digits, but we allow 6 so that this catches
          overflows, not just truncates */
       char lrange[7]="";
@@ -1460,36 +1725,36 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       break;
     }
-    case ONEOPT('$', 'u'): /* --ftp-alternative-to-user */
+    case C_FTP_ALTERNATIVE_TO_USER: /* --ftp-alternative-to-user */
       err = getstr(&config->ftp_alternative_to_user, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('$', 'v'): /* --ssl-reqd */
+    case C_FTP_SSL_REQD: /* --ftp-ssl-reqd */
+    case C_SSL_REQD: /* --ssl-reqd */
       if(toggle && !feature_ssl) {
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
         break;
       }
       config->ftp_ssl_reqd = toggle;
       break;
-    case ONEOPT('$', 'w'): /* --no-sessionid */
+    case C_SESSIONID: /* --sessionid */
       config->disable_sessionid = (!toggle)?TRUE:FALSE;
       break;
-    case ONEOPT('$', 'x'): /* --ftp-ssl-control */
-      if(toggle && !feature_ssl) {
+    case C_FTP_SSL_CONTROL: /* --ftp-ssl-control */
+      if(toggle && !feature_ssl)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
-        break;
-      }
-      config->ftp_ssl_control = toggle;
+      else
+        config->ftp_ssl_control = toggle;
       break;
-    case ONEOPT('$', 'y'): /* --ftp-ssl-ccc */
+    case C_FTP_SSL_CCC: /* --ftp-ssl-ccc */
       config->ftp_ssl_ccc = toggle;
       if(!config->ftp_ssl_ccc_mode)
         config->ftp_ssl_ccc_mode = CURLFTPSSL_CCC_PASSIVE;
       break;
-    case ONEOPT('$', 'j'): /* --ftp-ssl-ccc-mode */
+    case C_FTP_SSL_CCC_MODE: /* --ftp-ssl-ccc-mode */
       config->ftp_ssl_ccc = TRUE;
       config->ftp_ssl_ccc_mode = ftpcccmethod(config, nextarg);
       break;
-    case ONEOPT('$', 'z'): /* --libcurl */
+    case C_LIBCURL: /* --libcurl */
 #ifdef CURL_DISABLE_LIBCURL_OPTION
       warnf(global,
             "--libcurl option was disabled at build-time");
@@ -1498,251 +1763,245 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       err = getstr(&global->libcurl, nextarg, DENY_BLANK);
 #endif
       break;
-    case ONEOPT('$', '#'): /* --raw */
+    case C_RAW: /* --raw */
       config->raw = toggle;
       break;
-    case ONEOPT('$', '0'): /* --post301 */
-      config->post301 = toggle;
-      break;
-    case ONEOPT('$', '1'): /* --no-keepalive */
+    case C_KEEPALIVE: /* --keepalive */
       config->nokeepalive = (!toggle)?TRUE:FALSE;
       break;
-    case ONEOPT('$', '3'): /* --keepalive-time */
+    case C_KEEPALIVE_TIME: /* --keepalive-time */
       err = str2unum(&config->alivetime, nextarg);
       break;
-    case ONEOPT('$', '4'): /* --post302 */
+    case C_POST301: /* --post301 */
+      config->post301 = toggle;
+      break;
+    case C_POST302: /* --post302 */
       config->post302 = toggle;
       break;
-    case ONEOPT('$', 'I'): /* --post303 */
+    case C_POST303: /* --post303 */
       config->post303 = toggle;
       break;
-    case ONEOPT('$', '5'): /* --noproxy */
+    case C_NOPROXY: /* --noproxy */
       /* This specifies the noproxy list */
       err = getstr(&config->noproxy, nextarg, ALLOW_BLANK);
       break;
-    case ONEOPT('$', '7'): /* --socks5-gssapi-nec */
+    case C_SOCKS5_GSSAPI_NEC: /* --socks5-gssapi-nec */
       config->socks5_gssapi_nec = toggle;
       break;
-    case ONEOPT('$', '8'): /* --proxy1.0 */
+    case C_PROXY1_0: /* --proxy1.0 */
       /* http 1.0 proxy */
       err = getstr(&config->proxy, nextarg, DENY_BLANK);
       config->proxyver = CURLPROXY_HTTP_1_0;
       break;
-    case ONEOPT('$', '9'): /* --tftp-blksize */
+    case C_TFTP_BLKSIZE: /* --tftp-blksize */
       err = str2unum(&config->tftp_blksize, nextarg);
       break;
-    case ONEOPT('$', 'A'): /* --mail-from */
+    case C_MAIL_FROM: /* --mail-from */
       err = getstr(&config->mail_from, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('$', 'B'): /* --mail-rcpt */
+    case C_MAIL_RCPT: /* --mail-rcpt */
       /* append receiver to a list */
       err = add2list(&config->mail_rcpt, nextarg);
       break;
-    case ONEOPT('$', 'C'): /* --ftp-pret */
+    case C_FTP_PRET: /* --ftp-pret */
       config->ftp_pret = toggle;
       break;
-    case ONEOPT('$', 'D'): /* --proto */
+    case C_PROTO: /* --proto */
       config->proto_present = TRUE;
       err = proto2num(config, built_in_protos, &config->proto_str, nextarg);
       break;
-    case ONEOPT('$', 'E'): /* --proto-redir */
+    case C_PROTO_REDIR: /* --proto-redir */
       config->proto_redir_present = TRUE;
       if(proto2num(config, redir_protos, &config->proto_redir_str,
-                   nextarg)) {
+                   nextarg))
         err = PARAM_BAD_USE;
-        break;
-      }
       break;
-    case ONEOPT('$', 'F'): /* --resolve */
+    case C_RESOLVE: /* --resolve */
       err = add2list(&config->resolve, nextarg);
       break;
-    case ONEOPT('$', 'G'): /* --delegation */
+    case C_DELEGATION: /* --delegation */
       config->gssapi_delegation = delegation(config, nextarg);
       break;
-    case ONEOPT('$', 'H'): /* --mail-auth */
+    case C_MAIL_AUTH: /* --mail-auth */
       err = getstr(&config->mail_auth, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('$', 'J'): /* --metalink */
+    case C_METALINK: /* --metalink */
       errorf(global, "--metalink is disabled");
       err = PARAM_BAD_USE;
       break;
-    case ONEOPT('$', '6'): /* --sasl-authzid */
+    case C_SASL_AUTHZID: /* --sasl-authzid */
       err = getstr(&config->sasl_authzid, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('$', 'K'): /* --sasl-ir */
+    case C_SASL_IR: /* --sasl-ir */
       config->sasl_ir = toggle;
       break;
-    case ONEOPT('$', 'L'): /* --test-event */
+    case C_TEST_EVENT: /* --test-event */
 #ifdef CURLDEBUG
       global->test_event_based = toggle;
 #else
       warnf(global, "--test-event is ignored unless a debug build");
 #endif
       break;
-    case ONEOPT('$', 'M'): /* --unix-socket */
+    case C_UNIX_SOCKET: /* --unix-socket */
       config->abstract_unix_socket = FALSE;
       err = getstr(&config->unix_socket_path, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('$', 'N'): /* --path-as-is */
+    case C_PATH_AS_IS: /* --path-as-is */
       config->path_as_is = toggle;
       break;
-    case ONEOPT('$', 'O'): /* --proxy-service-name */
+    case C_PROXY_SERVICE_NAME: /* --proxy-service-name */
       err = getstr(&config->proxy_service_name, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('$', 'P'): /* --service-name */
+    case C_SERVICE_NAME: /* --service-name */
       err = getstr(&config->service_name, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('$', 'Q'): /* --proto-default */
+    case C_PROTO_DEFAULT: /* --proto-default */
       err = getstr(&config->proto_default, nextarg, DENY_BLANK);
       if(!err)
         err = check_protocol(config->proto_default);
       break;
-    case ONEOPT('$', 'R'): /* --expect100-timeout */
+    case C_EXPECT100_TIMEOUT: /* --expect100-timeout */
       err = secs2ms(&config->expect100timeout_ms, nextarg);
       break;
-    case ONEOPT('$', 'S'): /* --tftp-no-options */
+    case C_TFTP_NO_OPTIONS: /* --tftp-no-options */
       config->tftp_no_options = toggle;
       break;
-    case ONEOPT('$', 'U'): /* --connect-to */
+    case C_CONNECT_TO: /* --connect-to */
       err = add2list(&config->connect_to, nextarg);
       break;
-    case ONEOPT('$', 'W'): /* --abstract-unix-socket */
+    case C_ABSTRACT_UNIX_SOCKET: /* --abstract-unix-socket */
       config->abstract_unix_socket = TRUE;
       err = getstr(&config->unix_socket_path, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('$', 'X'): /* --tls-max */
+    case C_TLS_MAX: /* --tls-max */
       err = str2tls_max(&config->ssl_version_max, nextarg);
       break;
-    case ONEOPT('$', 'Y'): /* --suppress-connect-headers */
+    case C_SUPPRESS_CONNECT_HEADERS: /* --suppress-connect-headers */
       config->suppress_connect_headers = toggle;
       break;
-    case ONEOPT('$', 'Z'): /* --compressed-ssh */
+    case C_COMPRESSED_SSH: /* --compressed-ssh */
       config->ssh_compression = toggle;
       break;
-    case ONEOPT('$', '~'): /* --happy-eyeballs-timeout-ms */
+    case C_HAPPY_EYEBALLS_TIMEOUT_MS: /* --happy-eyeballs-timeout-ms */
       err = str2unum(&config->happy_eyeballs_timeout_ms, nextarg);
       /* 0 is a valid value for this timeout */
       break;
-    case ONEOPT('$', '%'): /* --trace-ids */
+    case C_TRACE_IDS: /* --trace-ids */
       global->traceids = toggle;
       break;
-    case ONEOPT('$', '&'): /* --trace-config */
-      if(set_trace_config(global, nextarg)) {
+    case C_TRACE_CONFIG: /* --trace-config */
+      if(set_trace_config(global, nextarg))
         err = PARAM_NO_MEM;
-      }
       break;
-    case ONEOPT('#', 'm'): /* --progress-meter */
+    case C_PROGRESS_METER: /* --progress-meter */
       global->noprogress = !toggle;
       break;
-    case ONEOPT('#', OPT_SHORT): /* --progress-bar */
+    case C_PROGRESS_BAR: /* --progress-bar */
       global->progressmode = toggle ? CURL_PROGRESS_BAR : CURL_PROGRESS_STATS;
       break;
-
-    case ONEOPT(':', 'a'): /* --variable */
+    case C_VARIABLE: /* --Variable */
       err = setvariable(global, nextarg);
       break;
-    case ONEOPT(':', OPT_SHORT): /* --next */
+    case C_NEXT: /* --next */
       err = PARAM_NEXT_OPERATION;
       break;
-
-    case ONEOPT('0', OPT_SHORT): /* --http1.0 */
+    case C_HTTP1_0: /* --http1.0 */
       /* HTTP version 1.0 */
       sethttpver(global, config, CURL_HTTP_VERSION_1_0);
       break;
-    case ONEOPT('0', '1'): /* --http1.1 */
+    case C_HTTP1_1: /* --http1.1 */
       /* HTTP version 1.1 */
       sethttpver(global, config, CURL_HTTP_VERSION_1_1);
       break;
-    case ONEOPT('0', '2'): /* --http2 */
+    case C_HTTP2: /* --http2 */
       /* HTTP version 2.0 */
       if(!feature_http2)
         return PARAM_LIBCURL_DOESNT_SUPPORT;
       sethttpver(global, config, CURL_HTTP_VERSION_2_0);
       break;
-    case ONEOPT('0', '3'): /* --http2-prior-knowledge */
+    case C_HTTP2_PRIOR_KNOWLEDGE: /* --http2-prior-knowledge */
       /* HTTP version 2.0 over clean TCP */
       if(!feature_http2)
         return PARAM_LIBCURL_DOESNT_SUPPORT;
       sethttpver(global, config, CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
       break;
-    case ONEOPT('0', '4'): /* --http3: */
+    case C_HTTP3: /* --http3: */
       /* Try HTTP/3, allow fallback */
-      if(!feature_http3) {
+      if(!feature_http3)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
-        break;
-      }
-      sethttpver(global, config, CURL_HTTP_VERSION_3);
+      else
+        sethttpver(global, config, CURL_HTTP_VERSION_3);
       break;
-    case ONEOPT('0', '5'): /* --http3-only */
+    case C_HTTP3_ONLY: /* --http3-only */
       /* Try HTTP/3 without fallback */
-      if(!feature_http3) {
+      if(!feature_http3)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
-        break;
-      }
-      sethttpver(global, config, CURL_HTTP_VERSION_3ONLY);
+      else
+        sethttpver(global, config, CURL_HTTP_VERSION_3ONLY);
       break;
-    case ONEOPT('0', '9'): /* --http0.9 */
+    case C_HTTP0_9: /* --http0.9 */
       /* Allow HTTP/0.9 responses! */
       config->http09_allowed = toggle;
       break;
-    case ONEOPT('0', 'a'): /* --proxy-http2 */
+    case C_PROXY_HTTP2: /* --proxy-http2 */
       if(!feature_httpsproxy || !feature_http2)
-        return PARAM_LIBCURL_DOESNT_SUPPORT;
-      config->proxyver = CURLPROXY_HTTPS2;
+        err = PARAM_LIBCURL_DOESNT_SUPPORT;
+      else
+        config->proxyver = CURLPROXY_HTTPS2;
       break;
-    case ONEOPT('1', OPT_SHORT): /* --tlsv1 */
+    case C_TLSV1: /* --tlsv1 */
       config->ssl_version = CURL_SSLVERSION_TLSv1;
       break;
-    case ONEOPT('1', '0'): /* --tlsv1.0 */
+    case C_TLSV1_0: /* --tlsv1.0 */
       config->ssl_version = CURL_SSLVERSION_TLSv1_0;
       break;
-    case ONEOPT('1', '1'): /* --tlsv1.1 */
+    case C_TLSV1_1: /* --tlsv1.1 */
       config->ssl_version = CURL_SSLVERSION_TLSv1_1;
       break;
-    case ONEOPT('1', '2'): /* --tlsv1.2 */
+    case C_TLSV1_2: /* --tlsv1.2 */
       config->ssl_version = CURL_SSLVERSION_TLSv1_2;
       break;
-    case ONEOPT('1', '3'): /* --tlsv1.3 */
+    case C_TLSV1_3: /* --tlsv1.3 */
       config->ssl_version = CURL_SSLVERSION_TLSv1_3;
       break;
-    case ONEOPT('1', 'A'): /* --tls13-ciphers */
+    case C_TLS13_CIPHERS: /* --tls13-ciphers */
       err = getstr(&config->cipher13_list, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('1', 'B'): /* --proxy-tls13-ciphers */
+    case C_PROXY_TLS13_CIPHERS: /* --proxy-tls13-ciphers */
       err = getstr(&config->proxy_cipher13_list, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('2', OPT_SHORT): /* --sslv2 */
+    case C_SSLV2: /* --sslv2 */
       warnf(global, "Ignores instruction to use SSLv2");
       break;
-    case ONEOPT('3', OPT_SHORT): /* --sslv3 */
+    case C_SSLV3: /* --sslv3 */
       warnf(global, "Ignores instruction to use SSLv3");
       break;
-    case ONEOPT('4', OPT_SHORT): /* --ipv4 */
+    case C_IPV4: /* --ipv4 */
       config->ip_version = CURL_IPRESOLVE_V4;
       break;
-    case ONEOPT('6', OPT_SHORT): /* --ipv6 */
+    case C_IPV6: /* --ipv6 */
       config->ip_version = CURL_IPRESOLVE_V6;
       break;
-    case ONEOPT('a', OPT_SHORT): /* --append */
+    case C_APPEND: /* --append */
       /* This makes the FTP sessions use APPE instead of STOR */
       config->ftp_append = toggle;
       break;
-    case ONEOPT('A', OPT_SHORT): /* --user-agent */
+    case C_USER_AGENT: /* --user-agent */
       err = getstr(&config->useragent, nextarg, ALLOW_BLANK);
       break;
-    case ONEOPT('b', 'a'): /* --alt-svc */
+    case C_ALT_SVC: /* --alt-svc */
       if(!feature_altsvc)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         err = getstr(&config->altsvc, nextarg, ALLOW_BLANK);
       break;
-    case ONEOPT('b', 'b'): /* --hsts */
+    case C_HSTS: /* --hsts */
       if(!feature_hsts)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         err = getstr(&config->hsts, nextarg, ALLOW_BLANK);
       break;
-    case ONEOPT('b', OPT_SHORT): /* --cookie */
+    case C_COOKIE: /* --cookie */
       if(nextarg[0] == '@') {
         nextarg++;
       }
@@ -1754,18 +2013,16 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       /* We have a cookie file to read from! */
       err = add2list(&config->cookiefiles, nextarg);
       break;
-    case ONEOPT('B', OPT_SHORT): /* --use-ascii */
+    case C_USE_ASCII: /* --use-ascii */
       config->use_ascii = toggle;
       break;
-    case ONEOPT('c', OPT_SHORT): /* --cookie-jar */
+    case C_COOKIE_JAR: /* --cookie-jar */
       err = getstr(&config->cookiejar, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('C', OPT_SHORT): /* --continue-at */
+    case C_CONTINUE_AT: /* --continue-at */
       /* This makes us continue an ftp transfer at given position */
       if(strcmp(nextarg, "-")) {
         err = str2offset(&config->resume_from, nextarg);
-        if(err)
-          break;
         config->resume_from_current = FALSE;
       }
       else {
@@ -1774,21 +2031,21 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       config->use_resume = TRUE;
       break;
-    case ONEOPT('d', OPT_SHORT): /* --data */
-    case ONEOPT('d', 'a'):  /* --data-ascii */
-    case ONEOPT('d', 'b'):  /* --data-binary */
-    case ONEOPT('d', 'e'):  /* --data-urlencode */
-    case ONEOPT('d', 'f'):  /* --json */
-    case ONEOPT('d', 'r'):  /* --data-raw */
-      err = set_data(subletter, nextarg, global, config);
+    case C_DATA: /* --data */
+    case C_DATA_ASCII:  /* --data-ascii */
+    case C_DATA_BINARY:  /* --data-binary */
+    case C_DATA_URLENCODE:  /* --data-urlencode */
+    case C_JSON:  /* --json */
+    case C_DATA_RAW:  /* --data-raw */
+      err = set_data(cmd, nextarg, global, config);
       break;
-    case ONEOPT('d', 'g'):  /* --url-query */
+    case C_URL_QUERY:  /* --url-query */
       err = url_query(nextarg, global, config);
       break;
-    case ONEOPT('D', OPT_SHORT): /* --dump-header */
+    case C_DUMP_HEADER: /* --dump-header */
       err = getstr(&config->headerfile, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('e', OPT_SHORT): { /* --referer */
+    case C_REFERER: { /* --referer */
       char *ptr = strstr(nextarg, ";auto");
       if(ptr) {
         /* Automatic referer requested, this may be combined with a
@@ -1802,73 +2059,73 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       err = getstr(&config->referer, ptr, ALLOW_BLANK);
     }
       break;
-    case ONEOPT('E', OPT_SHORT): /* --cert */
+    case C_CERT: /* --cert */
       cleanarg(clearthis);
       GetFileAndPassword(nextarg, &config->cert, &config->key_passwd);
       break;
-    case ONEOPT('E', 'a'): /* --cacert */
+    case C_CACERT: /* --cacert */
       err = getstr(&config->cacert, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('E', 'G'): /* --ca-native */
+    case C_CA_NATIVE: /* --ca-native */
       config->native_ca_store = toggle;
       break;
-    case ONEOPT('E', 'H'): /* --proxy-ca-native */
+    case C_PROXY_CA_NATIVE: /* --proxy-ca-native */
       config->proxy_native_ca_store = toggle;
       break;
-    case ONEOPT('E', 'b'): /* --cert-type */
+    case C_CERT_TYPE: /* --cert-type */
       err = getstr(&config->cert_type, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('E', 'c'): /* --key */
+    case C_KEY: /* --key */
       err = getstr(&config->key, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('E', 'd'): /* --key-type */
+    case C_KEY_TYPE: /* --key-type */
       err = getstr(&config->key_type, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('E', 'e'): /* --pass */
+    case C_PASS: /* --pass */
       err = getstr(&config->key_passwd, nextarg, DENY_BLANK);
       cleanarg(clearthis);
       break;
-    case ONEOPT('E', 'f'): /* --engine */
+    case C_ENGINE: /* --engine */
       err = getstr(&config->engine, nextarg, DENY_BLANK);
       if(!err &&
          config->engine && !strcmp(config->engine, "list")) {
         err = PARAM_ENGINES_REQUESTED;
       }
       break;
-    case ONEOPT('E', 'g'): /* --capath */
+    case C_CAPATH: /* --capath */
       err = getstr(&config->capath, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('E', 'h'): /* --pubkey */
+    case C_PUBKEY: /* --pubkey */
       err = getstr(&config->pubkey, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('E', 'i'): /* --hostpubmd5 */
+    case C_HOSTPUBMD5: /* --hostpubmd5 */
       err = getstr(&config->hostpubmd5, nextarg, DENY_BLANK);
       if(!err) {
         if(!config->hostpubmd5 || strlen(config->hostpubmd5) != 32)
           err = PARAM_BAD_USE;
       }
       break;
-    case ONEOPT('E', 'F'): /* --hostpubsha256 */
+    case C_HOSTPUBSHA256: /* --hostpubsha256 */
       err = getstr(&config->hostpubsha256, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('E', 'j'): /* --crlfile */
+    case C_CRLFILE: /* --crlfile */
       err = getstr(&config->crlfile, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('E', 'k'): /* --tlsuser */
+    case C_TLSUSER: /* --tlsuser */
       if(!feature_tls_srp)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         err = getstr(&config->tls_username, nextarg, DENY_BLANK);
       cleanarg(clearthis);
       break;
-    case ONEOPT('E', 'l'): /* --tlspassword */
+    case C_TLSPASSWORD: /* --tlspassword */
       if(!feature_tls_srp)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         err = getstr(&config->tls_password, nextarg, ALLOW_BLANK);
       cleanarg(clearthis);
       break;
-    case ONEOPT('E', 'm'): /* --tlsauthtype */
+    case C_TLSAUTHTYPE: /* --tlsauthtype */
       if(!feature_tls_srp)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else {
@@ -1877,72 +2134,59 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           err = PARAM_LIBCURL_DOESNT_SUPPORT; /* only support TLS-SRP */
       }
       break;
-    case ONEOPT('E', 'n'): /* --ssl-allow-beast */
+    case C_SSL_ALLOW_BEAST: /* --ssl-allow-beast */
       if(feature_ssl)
         config->ssl_allow_beast = toggle;
       break;
-
-    case ONEOPT('E', 'o'): /* --ssl-auto-client-cert */
+    case C_SSL_AUTO_CLIENT_CERT: /* --ssl-auto-client-cert */
       if(feature_ssl)
         config->ssl_auto_client_cert = toggle;
       break;
-
-    case ONEOPT('E', 'O'): /* --proxy-ssl-auto-client-cert */
+    case C_PROXY_SSL_AUTO_CLIENT_CERT: /* --proxy-ssl-auto-client-cert */
       if(feature_ssl)
         config->proxy_ssl_auto_client_cert = toggle;
       break;
-
-    case ONEOPT('E', 'p'): /* --pinnedpubkey */
+    case C_PINNEDPUBKEY: /* --pinnedpubkey */
       err = getstr(&config->pinnedpubkey, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', 'P'): /* --proxy-pinnedpubkey */
+    case C_PROXY_PINNEDPUBKEY: /* --proxy-pinnedpubkey */
       err = getstr(&config->proxy_pinnedpubkey, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', 'q'): /* --cert-status */
+    case C_CERT_STATUS: /* --cert-status */
       config->verifystatus = TRUE;
       break;
-
-    case ONEOPT('E', 'Q'): /* --doh-cert-status */
+    case C_DOH_CERT_STATUS: /* --doh-cert-status */
       config->doh_verifystatus = TRUE;
       break;
-
-    case ONEOPT('E', 'r'): /* --false-start */
+    case C_FALSE_START: /* --false-start */
       config->falsestart = TRUE;
       break;
-
-    case ONEOPT('E', 's'): /* --ssl-no-revoke */
+    case C_SSL_NO_REVOKE: /* --ssl-no-revoke */
       if(feature_ssl)
         config->ssl_no_revoke = TRUE;
       break;
-
-    case ONEOPT('E', 'S'): /* --ssl-revoke-best-effort */
+    case C_SSL_REVOKE_BEST_EFFORT: /* --ssl-revoke-best-effort */
       if(feature_ssl)
         config->ssl_revoke_best_effort = TRUE;
       break;
-
-    case ONEOPT('E', 't'): /* --tcp-fastopen */
+    case C_TCP_FASTOPEN: /* --tcp-fastopen */
       config->tcp_fastopen = TRUE;
       break;
-
-    case ONEOPT('E', 'u'): /* --proxy-tlsuser */
+    case C_PROXY_TLSUSER: /* --proxy-tlsuser */
       cleanarg(clearthis);
       if(!feature_tls_srp)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         err = getstr(&config->proxy_tls_username, nextarg, ALLOW_BLANK);
       break;
-
-    case ONEOPT('E', 'v'): /* --proxy-tlspassword */
+    case C_PROXY_TLSPASSWORD: /* --proxy-tlspassword */
       cleanarg(clearthis);
       if(!feature_tls_srp)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else
         err = getstr(&config->proxy_tls_password, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', 'w'): /* --proxy-tlsauthtype */
+    case C_PROXY_TLSAUTHTYPE: /* --proxy-tlsauthtype */
       if(!feature_tls_srp)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;
       else {
@@ -1951,100 +2195,81 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           err = PARAM_LIBCURL_DOESNT_SUPPORT; /* only support TLS-SRP */
       }
       break;
-
-    case ONEOPT('E', 'x'): /* --proxy-cert */
+    case C_PROXY_CERT: /* --proxy-cert */
       cleanarg(clearthis);
       GetFileAndPassword(nextarg, &config->proxy_cert,
                          &config->proxy_key_passwd);
       break;
-
-    case ONEOPT('E', 'y'): /* --proxy-cert-type */
+    case C_PROXY_CERT_TYPE: /* --proxy-cert-type */
       err = getstr(&config->proxy_cert_type, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', 'z'): /* --proxy-key */
+    case C_PROXY_KEY: /* --proxy-key */
       err = getstr(&config->proxy_key, nextarg, ALLOW_BLANK);
       break;
-
-    case ONEOPT('E', '0'): /* --proxy-key-type */
+    case C_PROXY_KEY_TYPE: /* --proxy-key-type */
       err = getstr(&config->proxy_key_type, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', '1'): /* --proxy-pass */
+    case C_PROXY_PASS: /* --proxy-pass */
       err = getstr(&config->proxy_key_passwd, nextarg, ALLOW_BLANK);
       cleanarg(clearthis);
       break;
-
-    case ONEOPT('E', '2'): /* --proxy-ciphers */
+    case C_PROXY_CIPHERS: /* --proxy-ciphers */
       err = getstr(&config->proxy_cipher_list, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', '3'): /* --proxy-crlfile */
+    case C_PROXY_CRLFILE: /* --proxy-crlfile */
       err = getstr(&config->proxy_crlfile, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', '4'): /* --proxy-allow-beast */
+    case C_PROXY_SSL_ALLOW_BEAST: /* --proxy-ssl-allow-beast */
       if(feature_ssl)
         config->proxy_ssl_allow_beast = toggle;
       break;
-
-    case ONEOPT('E', '5'): /* --login-options */
+    case C_LOGIN_OPTIONS: /* --login-options */
       err = getstr(&config->login_options, nextarg, ALLOW_BLANK);
       break;
-
-    case ONEOPT('E', '6'): /* --proxy-cacert */
+    case C_PROXY_CACERT: /* --proxy-cacert */
       err = getstr(&config->proxy_cacert, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', '7'): /* --proxy-cainfo */
+    case C_PROXY_CAPATH: /* --proxy-capath */
       err = getstr(&config->proxy_capath, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', '8'): /* --proxy-insecure */
+    case C_PROXY_INSECURE: /* --proxy-insecure */
       config->proxy_insecure_ok = toggle;
       break;
-
-    case ONEOPT('E', '9'): /* --proxy-tlsv1 */
+    case C_PROXY_TLSV1: /* --proxy-tlsv1 */
       /* TLS version 1 for proxy */
       config->proxy_ssl_version = CURL_SSLVERSION_TLSv1;
       break;
-
-    case ONEOPT('E', 'A'): /* --socks5-basic */
+    case C_SOCKS5_BASIC: /* --socks5-basic */
       if(toggle)
         config->socks5_auth |= CURLAUTH_BASIC;
       else
         config->socks5_auth &= ~CURLAUTH_BASIC;
       break;
-
-    case ONEOPT('E', 'B'): /* --socks5-gssapi */
+    case C_SOCKS5_GSSAPI: /* --socks5-gssapi */
       if(toggle)
         config->socks5_auth |= CURLAUTH_GSSAPI;
       else
         config->socks5_auth &= ~CURLAUTH_GSSAPI;
       break;
-
-    case ONEOPT('E', 'C'): /* --etag-save */
+    case C_ETAG_SAVE: /* --etag-save */
       err = getstr(&config->etag_save_file, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', 'D'): /* --etag-compare */
+    case C_ETAG_COMPARE: /* --etag-compare */
       err = getstr(&config->etag_compare_file, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('E', 'E'): /* --curves */
+    case C_CURVES: /* --curves */
       err = getstr(&config->ssl_ec_curves, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('f', 'a'): /* --fail-early */
+    case C_FAIL_EARLY: /* --fail-early */
       global->fail_early = toggle;
       break;
-    case ONEOPT('f', 'b'): /* --styled-output */
+    case C_STYLED_OUTPUT: /* --styled-output */
       global->styled_output = toggle;
       break;
-    case ONEOPT('f', 'c'): /* --mail-rcpt-allowfails */
+    case C_MAIL_RCPT_ALLOWFAILS: /* --mail-rcpt-allowfails */
       config->mail_rcpt_allowfails = toggle;
       break;
-    case ONEOPT('f', 'd'): /* --fail-with-body */
+    case C_FAIL_WITH_BODY: /* --fail-with-body */
       config->failwithbody = toggle;
       if(config->failonerror && config->failwithbody) {
         errorf(config->global, "You must select either --fail or "
@@ -2052,10 +2277,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_BAD_USE;
       }
       break;
-    case ONEOPT('f', 'e'): /* --remove-on-error */
+    case C_REMOVE_ON_ERROR: /* --remove-on-error */
       config->rm_partial = toggle;
       break;
-    case ONEOPT('f', OPT_SHORT): /* --fail */
+    case C_FAIL: /* --fail */
       config->failonerror = toggle;
       if(config->failonerror && config->failwithbody) {
         errorf(config->global, "You must select either --fail or "
@@ -2063,36 +2288,29 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_BAD_USE;
       }
       break;
-
-    case ONEOPT('F', OPT_SHORT): /* --form */
-    case ONEOPT('F', 's'): /* --form-string */
+    case C_FORM: /* --form */
+    case C_FORM_STRING: /* --form-string */
       /* "form data" simulation, this is a little advanced so lets do our best
          to sort this out slowly and carefully */
       if(formparse(config,
                    nextarg,
                    &config->mimeroot,
                    &config->mimecurrent,
-                   (subletter == 's')?TRUE:FALSE)) { /* 's' is literal
-                                                        string */
+                   (cmd == C_FORM_STRING)?TRUE:FALSE)) /* literal string */
         err = PARAM_BAD_USE;
-      }
       else if(SetHTTPrequest(config, HTTPREQ_MIMEPOST, &config->httpreq))
         err = PARAM_BAD_USE;
       break;
-
-    case ONEOPT('g', OPT_SHORT): /* --globoff */
+    case C_GLOBOFF: /* --globoff */
       config->globoff = toggle;
       break;
-
-    case ONEOPT('G', OPT_SHORT): /* --get */
+    case C_GET: /* --get */
       config->use_httpget = toggle;
       break;
-
-    case ONEOPT('G', 'a'): /* --request-target */
+    case C_REQUEST_TARGET: /* --request-target */
       err = getstr(&config->request_target, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('h', OPT_SHORT): /* --help */
+    case C_HELP: /* --help */
       if(toggle) {
         if(*nextarg) {
           global->help_category = strdup(nextarg);
@@ -2105,8 +2323,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       /* we now actually support --no-help too! */
       break;
-    case ONEOPT('H', OPT_SHORT): /* --header */
-    case ONEOPT('H', 'p'): /* --proxy-header */
+    case C_HEADER: /* --header */
+    case C_PROXY_HEADER: /* --proxy-header */
       /* A custom header to append to a list */
       if(nextarg[0] == '@') {
         /* read many headers from a file or stdin */
@@ -2117,7 +2335,6 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         if(!file) {
           errorf(global, "Failed to open %s", &nextarg[1]);
           err = PARAM_READ_ERROR;
-          break;
         }
         else {
           err = file2memory(&string, &len, file);
@@ -2126,7 +2343,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
             /* !checksrc! disable BANNEDFUNC 2 */
             char *h = strtok(string, "\r\n");
             while(h) {
-              if(subletter == 'p') /* --proxy-header */
+              if(cmd == C_PROXY_HEADER) /* --proxy-header */
                 err = add2list(&config->proxyheaders, h);
               else
                 err = add2list(&config->headers, h);
@@ -2138,25 +2355,23 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           }
           if(!use_stdin)
             fclose(file);
-          if(err)
-            break;
         }
       }
       else {
-        if(subletter == 'p') /* --proxy-header */
+        if(cmd == C_PROXY_HEADER) /* --proxy-header */
           err = add2list(&config->proxyheaders, nextarg);
         else
           err = add2list(&config->headers, nextarg);
       }
       break;
-    case ONEOPT('i', OPT_SHORT): /* --include */
+    case C_INCLUDE: /* --include */
       config->show_headers = toggle; /* show the headers as well in the
                                         general output stream */
       break;
-    case ONEOPT('j', OPT_SHORT): /* --junk-session-cookies */
+    case C_JUNK_SESSION_COOKIES: /* --junk-session-cookies */
       config->cookiesession = toggle;
       break;
-    case ONEOPT('I', OPT_SHORT): /* --head */
+    case C_HEAD: /* --head */
       config->no_body = toggle;
       config->show_headers = toggle;
       if(SetHTTPrequest(config,
@@ -2164,37 +2379,37 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
                         &config->httpreq))
         err = PARAM_BAD_USE;
       break;
-    case ONEOPT('J', OPT_SHORT): /* --remote-header-name */
+    case C_REMOTE_HEADER_NAME: /* --remote-header-name */
       config->content_disposition = toggle;
       break;
-    case ONEOPT('k', OPT_SHORT): /* --insecure */
+    case C_INSECURE: /* --insecure */
       config->insecure_ok = toggle;
       break;
-    case ONEOPT('k', 'd'): /* --doh-insecure */
+    case C_DOH_INSECURE: /* --doh-insecure */
       config->doh_insecure_ok = toggle;
       break;
-    case ONEOPT('K', OPT_SHORT): /* --config */
+    case C_CONFIG: /* --config */
       if(parseconfig(nextarg, global)) {
         errorf(global, "cannot read config from '%s'", nextarg);
         err = PARAM_READ_ERROR;
       }
       break;
-    case ONEOPT('l', OPT_SHORT): /* --list-only */
+    case C_LIST_ONLY: /* --list-only */
       config->dirlistonly = toggle; /* only list the names of the FTP dir */
       break;
-    case ONEOPT('L', OPT_SHORT): /* --location */
-    case ONEOPT('L', 't'): /* --location-trusted */
+    case C_LOCATION_TRUSTED: /* --location-trusted */
+      /* Continue to send authentication (user+password) when following
+       * locations, even when hostname changed */
+      config->unrestricted_auth = toggle;
+      FALLTHROUGH();
+    case C_LOCATION: /* --location */
       config->followlocation = toggle; /* Follow Location: HTTP headers */
-      if(subletter == 't')
-        /* Continue to send authentication (user+password) when following
-         * locations, even when hostname changed */
-        config->unrestricted_auth = toggle;
       break;
-    case ONEOPT('m', OPT_SHORT): /* --max-time */
+    case C_MAX_TIME: /* --max-time */
       /* specified max time */
       err = secs2ms(&config->timeout_ms, nextarg);
       break;
-    case ONEOPT('M', OPT_SHORT): /* --manual */
+    case C_MANUAL: /* --manual */
       if(toggle) { /* --no-manual shows no manual... */
 #ifndef USE_MANUAL
         warnf(global,
@@ -2203,39 +2418,33 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_MANUAL_REQUESTED;
       }
       break;
-
-    case ONEOPT('n', 'o'): /* --netrc-optional */
+    case C_NETRC_OPTIONAL: /* --netrc-optional */
       config->netrc_opt = toggle;
       break;
-    case ONEOPT('n', 'e'): /* --netrc-file */
+    case C_NETRC_FILE: /* --netrc-file */
       err = getstr(&config->netrc_file, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('n', OPT_SHORT): /* --netrc */
+    case C_NETRC: /* --netrc */
       /* pick info from .netrc, if this is used for http, curl will
          automatically enforce user+password with the request */
       config->netrc = toggle;
       break;
-
-    case ONEOPT('N', OPT_SHORT): /* --buffer */
+    case C_BUFFER: /* --buffer */
       /* disable the output I/O buffering. note that the option is called
          --buffer but is mostly used in the negative form: --no-buffer */
       config->nobuffer = longopt ? !toggle : TRUE;
       break;
-
-    case ONEOPT('O', 'a'): /* --remote-name-all */
+    case C_REMOTE_NAME_ALL: /* --remote-name-all */
       config->default_node_flags = toggle?GETOUT_USEREMOTE:0;
       break;
-
-    case ONEOPT('O', 'b'): /* --output-dir */
+    case C_OUTPUT_DIR: /* --output-dir */
       err = getstr(&config->output_dir, nextarg, DENY_BLANK);
       break;
-
-    case ONEOPT('O', 'c'): /* --clobber */
+    case C_CLOBBER: /* --clobber */
       config->file_clobber_mode = toggle ? CLOBBER_ALWAYS : CLOBBER_NEVER;
       break;
-
-    case ONEOPT('o', OPT_SHORT): /* --output */
-    case ONEOPT('O', OPT_SHORT): /* --remote-name */
+    case C_OUTPUT: /* --output */
+    case C_REMOTE_NAME: /* --remote-name */
       /* output file */
       if(!config->url_out)
         config->url_out = config->url_list;
@@ -2277,7 +2486,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       url->flags |= GETOUT_OUTFILE;
       break;
-    case ONEOPT('P', OPT_SHORT): /* --ftp-port */
+    case C_FTP_PORT: /* --ftp-port */
       /* This makes the FTP sessions use PORT instead of PASV */
       /* use <eth0> or <192.168.10.10> style addresses. Anything except
          this will make us try to get the "default" address.
@@ -2285,16 +2494,16 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       */
       err = getstr(&config->ftpport, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('p', OPT_SHORT): /* --proxytunnel */
+    case C_PROXYTUNNEL: /* --proxytunnel */
       /* proxy tunnel for non-http protocols */
       config->proxytunnel = toggle;
       break;
 
-    case ONEOPT('q', OPT_SHORT): /* --disable */
+    case C_DISABLE: /* --disable */
       /* if used first, already taken care of, we do it like this so we don't
          cause an error! */
       break;
-    case ONEOPT('Q', OPT_SHORT): /* --quote */
+    case C_QUOTE: /* --quote */
       /* QUOTE command to send to FTP server */
       switch(nextarg[0]) {
       case '-':
@@ -2312,7 +2521,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       }
       break;
-    case ONEOPT('r', OPT_SHORT): /* --range */
+    case C_RANGE: /* --range */
       /* Specifying a range WITHOUT A DASH will create an illegal HTTP range
          (and won't actually be range by definition). The man page previously
          claimed that to be a good way, why this code is added to work-around
@@ -2322,24 +2531,23 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         if(curlx_strtoofft(nextarg, NULL, 10, &value)) {
           warnf(global, "unsupported range point");
           err = PARAM_BAD_USE;
-          break;
         }
-        warnf(global,
-              "A specified range MUST include at least one dash (-). "
-              "Appending one for you");
-        msnprintf(buffer, sizeof(buffer), "%" CURL_FORMAT_CURL_OFF_T "-",
-                  value);
-        Curl_safefree(config->range);
-        config->range = strdup(buffer);
-        if(!config->range) {
-          err = PARAM_NO_MEM;
-          break;
+        else {
+          warnf(global,
+                "A specified range MUST include at least one dash (-). "
+                "Appending one for you");
+          msnprintf(buffer, sizeof(buffer), "%" CURL_FORMAT_CURL_OFF_T "-",
+                    value);
+          Curl_safefree(config->range);
+          config->range = strdup(buffer);
+          if(!config->range)
+            err = PARAM_NO_MEM;
         }
       }
       else {
         /* byte range requested */
         const char *tmp_range = nextarg;
-        while(*tmp_range != OPT_SHORT) {
+        while(*tmp_range) {
           if(!ISDIGIT(*tmp_range) && *tmp_range != '-' && *tmp_range != ',') {
             warnf(global, "Invalid character is found in given range. "
                   "A specified range MUST have only digits in "
@@ -2352,21 +2560,21 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = getstr(&config->range, nextarg, DENY_BLANK);
       }
       break;
-    case ONEOPT('R', OPT_SHORT): /* --remote-time */
+    case C_REMOTE_TIME: /* --remote-time */
       /* use remote file's time */
       config->remote_time = toggle;
       break;
-    case ONEOPT('s', OPT_SHORT): /* --silent */
+    case C_SILENT: /* --silent */
       global->silent = toggle;
       break;
-    case ONEOPT('S', OPT_SHORT): /* --show-error */
+    case C_SHOW_ERROR: /* --show-error */
       global->showerror = toggle;
       break;
-    case ONEOPT('t', OPT_SHORT): /* --telnet-option */
+    case C_TELNET_OPTION: /* --telnet-option */
       /* Telnet options */
       err = add2list(&config->telnet_options, nextarg);
       break;
-    case ONEOPT('T', OPT_SHORT): /* --upload */
+    case C_UPLOAD_FILE: /* --upload-file */
       /* we are uploading */
       if(!config->url_ul)
         config->url_ul = config->url_list;
@@ -2399,17 +2607,17 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = getstr(&url->infile, nextarg, DENY_BLANK);
       }
       break;
-    case ONEOPT('u', OPT_SHORT): /* --user */
+    case C_USER: /* --user */
       /* user:password  */
       err = getstr(&config->userpwd, nextarg, ALLOW_BLANK);
       cleanarg(clearthis);
       break;
-    case ONEOPT('U', OPT_SHORT): /* --proxy-user */
+    case C_PROXY_USER: /* --proxy-user */
       /* Proxy user:password  */
       err = getstr(&config->proxyuserpwd, nextarg, ALLOW_BLANK);
       cleanarg(clearthis);
       break;
-    case ONEOPT('v', OPT_SHORT): /* --verbose */
+    case C_VERBOSE: /* --verbose */
       if(toggle) {
         /* the '%' thing here will cause the trace get sent to stderr */
         Curl_safefree(global->trace_dump);
@@ -2427,12 +2635,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         /* verbose is disabled here */
         global->tracetype = TRACE_NONE;
       break;
-    case ONEOPT('V', OPT_SHORT): /* --version */
+    case C_VERSION: /* --version */
       if(toggle)    /* --no-version yields no output! */
         err = PARAM_VERSION_INFO_REQUESTED;
       break;
-
-    case ONEOPT('w', OPT_SHORT): /* --write-out */
+    case C_WRITE_OUT: /* --write-out */
       /* get the output string */
       if('@' == *nextarg) {
         /* the data begins with a '@' letter, it means that a file name
@@ -2465,36 +2672,35 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       else
         err = getstr(&config->writeout, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('x', 'a'): /* --preproxy */
+    case C_PREPROXY: /* --preproxy */
       err = getstr(&config->preproxy, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('x', OPT_SHORT): /* --proxy */
+    case C_PROXY: /* --proxy */
       /* --proxy */
       err = getstr(&config->proxy, nextarg, ALLOW_BLANK);
       if(config->proxyver != CURLPROXY_HTTPS2)
         config->proxyver = CURLPROXY_HTTP;
       break;
-
-    case ONEOPT('X', OPT_SHORT): /* --request */
+    case C_REQUEST: /* --request */
       /* set custom request */
       err = getstr(&config->customrequest, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('y', OPT_SHORT): /* --speed-limit */
+    case C_SPEED_TIME: /* --speed-time */
       /* low speed time */
       err = str2unum(&config->low_speed_time, nextarg);
       if(!err && !config->low_speed_limit)
         config->low_speed_limit = 1;
       break;
-    case ONEOPT('Y', OPT_SHORT): /* --speed-time */
+    case C_SPEED_LIMIT: /* --speed-limit */
       /* low speed limit */
       err = str2unum(&config->low_speed_limit, nextarg);
       if(!err && !config->low_speed_time)
         config->low_speed_time = 30;
       break;
-    case ONEOPT('Z', OPT_SHORT): /* --parallel */
+    case C_PARALLEL: /* --parallel */
       global->parallel = toggle;
       break;
-    case ONEOPT('Z', 'b'): {  /* --parallel-max */
+    case C_PARALLEL_MAX: {  /* --parallel-max */
       long val;
       err = str2unum(&val, nextarg);
       if(err)
@@ -2507,11 +2713,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         global->parallel_max = (unsigned short)val;
       break;
     }
-    case ONEOPT('Z', 'c'):   /* --parallel-immediate */
+    case C_PARALLEL_IMMEDIATE:   /* --parallel-immediate */
       global->parallel_connect = toggle;
       break;
-
-    case ONEOPT('z', OPT_SHORT): /* --time-cond */
+    case C_TIME_COND: /* --time-cond */
       switch(*nextarg) {
       case '+':
         nextarg++;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -72,7 +72,6 @@ static ParameterError getstr(char **str, const char *val, bool allowblank)
 }
 
 struct LongShort {
-  const char *letter; /* short name option */
   const char *lname;  /* long name option */
   enum {
     ARG_NONE,   /* stand-alone but not a boolean */
@@ -80,292 +79,279 @@ struct LongShort {
     ARG_STRING, /* requires an argument */
     ARG_FILENAME /* requires an argument, usually a file name */
   } desc;
+  const char *letter; /* short name option */
+  /* 'letter' strings with more than one character have *no* short option. */
 };
 
+/* this array MUST be alphasorted based on the 'lname' */
 static const struct LongShort aliases[]= {
-  /* 'letter' strings with more than one character have *no* short option to
-     mention. */
-  {"*@", "url",                      ARG_STRING},
-  {"*4", "dns-ipv4-addr",            ARG_STRING},
-  {"*6", "dns-ipv6-addr",            ARG_STRING},
-  {"*a", "random-file",              ARG_FILENAME},
-  {"*b", "egd-file",                 ARG_STRING},
-  {"*B", "oauth2-bearer",            ARG_STRING},
-  {"*c", "connect-timeout",          ARG_STRING},
-  {"*C", "doh-url"        ,          ARG_STRING},
-  {"*d", "ciphers",                  ARG_STRING},
-  {"*D", "dns-interface",            ARG_STRING},
-  {"*e", "disable-epsv",             ARG_BOOL},
-  {"*f", "disallow-username-in-url", ARG_BOOL},
-  {"*E", "epsv",                     ARG_BOOL},
-         /* 'epsv' made like this to make --no-epsv and --epsv to work
-             although --disable-epsv is the documented option */
-  {"*F", "dns-servers",              ARG_STRING},
-  {"*g", "trace",                    ARG_FILENAME},
-  {"*G", "npn",                      ARG_BOOL},
-  {"*h", "trace-ascii",              ARG_FILENAME},
-  {"*H", "alpn",                     ARG_BOOL},
-  {"*i", "limit-rate",               ARG_STRING},
-  {"*I", "rate",                     ARG_STRING},
-  {"*j", "compressed",               ARG_BOOL},
-  {"*J", "tr-encoding",              ARG_BOOL},
-  {"*k", "digest",                   ARG_BOOL},
-  {"*l", "negotiate",                ARG_BOOL},
-  {"*m", "ntlm",                     ARG_BOOL},
-  {"*M", "ntlm-wb",                  ARG_BOOL},
-  {"*n", "basic",                    ARG_BOOL},
-  {"*o", "anyauth",                  ARG_BOOL},
+  {"abstract-unix-socket",     ARG_FILENAME, "$W"},
+  {"alpn",                     ARG_BOOL,     "*H"},
+  {"alt-svc",                  ARG_STRING,   "ba"},
+  {"anyauth",                  ARG_BOOL,     "*o"},
+  {"append",                   ARG_BOOL,     "a",},
+  {"aws-sigv4",                ARG_STRING,   "*V"},
+  {"basic",                    ARG_BOOL,     "*n"},
+  {"buffer",                   ARG_BOOL,     "N",},
+  {"ca-native",                ARG_BOOL,     "EG"},
+  {"cacert",                   ARG_FILENAME, "Ea"},
+  {"capath",                   ARG_FILENAME, "Eg"},
+  {"cert",                     ARG_FILENAME, "E",},
+  {"cert-status",              ARG_BOOL,     "Eq"},
+  {"cert-type",                ARG_STRING,   "Eb"},
+  {"ciphers",                  ARG_STRING,   "*d"},
+  {"clobber",                  ARG_BOOL,     "Oc"},
+  {"compressed",               ARG_BOOL,     "*j"},
+  {"compressed-ssh",           ARG_BOOL,     "$Z"},
+  {"config",                   ARG_FILENAME, "K",},
+  {"connect-timeout",          ARG_STRING,   "*c"},
+  {"connect-to",               ARG_STRING,   "$U"},
+  {"continue-at",              ARG_STRING,   "C",},
+  {"cookie",                   ARG_STRING,   "b",},
+  {"cookie-jar",               ARG_STRING,   "c",},
+  {"create-dirs",              ARG_BOOL,     "*r"},
+  {"create-file-mode",         ARG_STRING,   "*R"},
+  {"crlf",                     ARG_BOOL,     "*u"},
+  {"crlfile",                  ARG_FILENAME, "Ej"},
+  {"curves",                   ARG_STRING,   "EE"},
+  {"data",                     ARG_STRING,   "d",},
+  {"data-ascii",               ARG_STRING,   "da"},
+  {"data-binary",              ARG_STRING,   "db"},
+  {"data-raw",                 ARG_STRING,   "dr"},
+  {"data-urlencode",           ARG_STRING,   "de"},
+  {"delegation",               ARG_STRING,   "$G"},
+  {"digest",                   ARG_BOOL,     "*k"},
+  {"disable",                  ARG_BOOL,     "q",},
+  {"disable-eprt",             ARG_BOOL,     "*z"},
+  {"disable-epsv",             ARG_BOOL,     "*e"},
+  {"disallow-username-in-url", ARG_BOOL,     "*f"},
+  {"dns-interface",            ARG_STRING,   "*D"},
+  {"dns-ipv4-addr",            ARG_STRING,   "*4"},
+  {"dns-ipv6-addr",            ARG_STRING,   "*6"},
+  {"dns-servers",              ARG_STRING,   "*F"},
+  {"doh-cert-status",          ARG_BOOL,     "EQ"},
+  {"doh-insecure",             ARG_BOOL,     "kd"},
+  {"doh-url"        ,          ARG_STRING,   "*C"},
+  {"dump-header",              ARG_FILENAME, "D",},
+  {"egd-file",                 ARG_STRING,   "*b"},
+  {"engine",                   ARG_STRING,   "Ef"},
+  {"eprt",                     ARG_BOOL,     "*Z"},
+  {"epsv",                     ARG_BOOL,     "*E"},
+  {"etag-compare",             ARG_FILENAME, "ED"},
+  {"etag-save",                ARG_FILENAME, "EC"},
+  {"expect100-timeout",        ARG_STRING,   "$R"},
+  {"fail",                     ARG_BOOL,     "f",},
+  {"fail-early",               ARG_BOOL,     "fa"},
+  {"fail-with-body",           ARG_BOOL,     "fd"},
+  {"false-start",              ARG_BOOL,     "Er"},
+  {"form",                     ARG_STRING,   "F",},
+  {"form-escape",              ARG_BOOL,     "$l"},
+  {"form-string",              ARG_STRING,   "Fs"},
+  {"ftp-account",              ARG_STRING,   "$m"},
+  {"ftp-alternative-to-user",  ARG_STRING,   "$u"},
+  {"ftp-create-dirs",          ARG_BOOL,     "*q"},
+  {"ftp-method",               ARG_STRING,   "$r"},
+  {"ftp-pasv",                 ARG_BOOL,     "$b"},
+  {"ftp-port",                 ARG_STRING,   "P",},
+  {"ftp-pret",                 ARG_BOOL,     "$C"},
+  {"ftp-skip-pasv-ip",         ARG_BOOL,     "$q"},
+  {"ftp-ssl",                  ARG_BOOL,     "$a"},
+  {"ftp-ssl-ccc",              ARG_BOOL,     "$y"},
+  {"ftp-ssl-ccc-mode",         ARG_STRING,   "$j"},
+  {"ftp-ssl-control",          ARG_BOOL,     "$x"},
+  {"ftp-ssl-reqd",             ARG_BOOL,     "$v"},
+  {"get",                      ARG_BOOL,     "G",},
+  {"globoff",                  ARG_BOOL,     "g",},
+  {"happy-eyeballs-timeout-ms", ARG_STRING,  "$~"},
+  {"haproxy-clientip",         ARG_STRING,   "*P"},
+  {"haproxy-protocol",         ARG_BOOL,     "*X"},
+  {"head",                     ARG_BOOL,     "I",},
+  {"header",                   ARG_STRING,   "H",},
+  {"help",                     ARG_BOOL,     "h",},
+  {"hostpubmd5",               ARG_STRING,   "Ei"},
+  {"hostpubsha256",            ARG_STRING,   "EF"},
+  {"hsts",                     ARG_STRING,   "bb"},
+  {"http0.9",                  ARG_BOOL,     "09"},
+  {"http1.0",                  ARG_NONE,     "0",},
+  {"http1.1",                  ARG_NONE,     "01"},
+  {"http2",                    ARG_NONE,     "02"},
+  {"http2-prior-knowledge",    ARG_NONE,     "03"},
+  {"http3",                    ARG_NONE,     "04"},
+  {"http3-only",               ARG_NONE,     "05"},
+  {"ignore-content-length",    ARG_BOOL,     "$p"},
+  {"include",                  ARG_BOOL,     "i",},
+  {"insecure",                 ARG_BOOL,     "k",},
+  {"interface",                ARG_STRING,   "*w"},
+  {"ipfs-gateway",             ARG_STRING,   "*S"},
+  {"ipv4",                     ARG_NONE,     "4",},
+  {"ipv6",                     ARG_NONE,     "6",},
+  {"json",                     ARG_STRING,   "df"},
+  {"junk-session-cookies",     ARG_BOOL,     "j",},
+  {"keepalive",                ARG_BOOL,     "$1"},
+  {"keepalive-time",           ARG_STRING,   "$3"},
+  {"key",                      ARG_FILENAME, "Ec"},
+  {"key-type",                 ARG_STRING,   "Ed"},
+  {"krb",                      ARG_STRING,   "*x"},
+  {"krb4",                     ARG_STRING,   "*x"},
+  {"libcurl",                  ARG_STRING,   "$z"},
+  {"limit-rate",               ARG_STRING,   "*i"},
+  {"list-only",                ARG_BOOL,     "l",},
+  {"local-port",               ARG_STRING,   "$s"},
+  {"location",                 ARG_BOOL,     "L",},
+  {"location-trusted",         ARG_BOOL,     "Lt"},
+  {"login-options",            ARG_STRING,   "E5"},
+  {"mail-auth",                ARG_STRING,   "$H"},
+  {"mail-from",                ARG_STRING,   "$A"},
+  {"mail-rcpt",                ARG_STRING,   "$B"},
+  {"mail-rcpt-allowfails",     ARG_BOOL,     "fc"},
+  {"manual",                   ARG_BOOL,     "M",},
+  {"max-filesize",             ARG_STRING,   "*y"},
+  {"max-redirs",               ARG_STRING,   "*s"},
+  {"max-time",                 ARG_STRING,   "m",},
+  {"metalink",                 ARG_BOOL,     "$J"},
+  {"negotiate",                ARG_BOOL,     "*l"},
+  {"netrc",                    ARG_BOOL,     "n",},
+  {"netrc-file",               ARG_FILENAME, "ne"},
+  {"netrc-optional",           ARG_BOOL,     "no"},
+  {"next",                     ARG_NONE,     ":",},
+  {"noproxy",                  ARG_STRING,   "$5"},
+  {"npn",                      ARG_BOOL,     "*G"},
+  {"ntlm",                     ARG_BOOL,     "*m"},
+  {"ntlm-wb",                  ARG_BOOL,     "*M"},
+  {"oauth2-bearer",            ARG_STRING,   "*B"},
+  {"output",                   ARG_FILENAME, "o",},
+  {"output-dir",               ARG_STRING,   "Ob"},
+  {"parallel",                 ARG_BOOL,     "Z",},
+  {"parallel-immediate",       ARG_BOOL,     "Zc"},
+  {"parallel-max",             ARG_STRING,   "Zb"},
+  {"pass",                     ARG_STRING,   "Ee"},
+  {"path-as-is",               ARG_BOOL,     "$N"},
+  {"pinnedpubkey",             ARG_STRING,   "Ep"},
+  {"post301",                  ARG_BOOL,     "$0"},
+  {"post302",                  ARG_BOOL,     "$4"},
+  {"post303",                  ARG_BOOL,     "$I"},
+  {"preproxy",                 ARG_STRING,   "xa"},
+  {"progress-bar",             ARG_BOOL,     "#",},
+  {"progress-meter",           ARG_BOOL,     "#m"},
+  {"proto",                    ARG_STRING,   "$D"},
+  {"proto-default",            ARG_STRING,   "$Q"},
+  {"proto-redir",              ARG_STRING,   "$E"},
+  {"proxy",                    ARG_STRING,   "x",},
+  {"proxy-anyauth",            ARG_BOOL,     "$n"},
+  {"proxy-basic",              ARG_BOOL,     "$f"},
+  {"proxy-ca-native",          ARG_BOOL,     "EH"},
+  {"proxy-cacert",             ARG_FILENAME, "E6"},
+  {"proxy-capath",             ARG_FILENAME, "E7"},
+  {"proxy-cert",               ARG_FILENAME, "Ex"},
+  {"proxy-cert-type",          ARG_STRING,   "Ey"},
+  {"proxy-ciphers",            ARG_STRING,   "E2"},
+  {"proxy-crlfile",            ARG_FILENAME, "E3"},
+  {"proxy-digest",             ARG_BOOL,     "$e"},
+  {"proxy-header",             ARG_STRING,   "Hp"},
+  {"proxy-http2",              ARG_BOOL,     "0a"},
+  {"proxy-insecure",           ARG_BOOL,     "E8"},
+  {"proxy-key",                ARG_FILENAME, "Ez"},
+  {"proxy-key-type",           ARG_STRING,   "E0"},
+  {"proxy-negotiate",          ARG_BOOL,     "$k"},
+  {"proxy-ntlm",               ARG_BOOL,     "*t"},
+  {"proxy-pass",               ARG_STRING,   "E1"},
+  {"proxy-pinnedpubkey",       ARG_STRING,   "EP"},
+  {"proxy-service-name",       ARG_STRING,   "$O"},
+  {"proxy-ssl-allow-beast",    ARG_BOOL,     "E4"},
+  {"proxy-ssl-auto-client-cert", ARG_BOOL,   "EO"},
+  {"proxy-tls13-ciphers",      ARG_STRING,   "1B"},
+  {"proxy-tlsauthtype",        ARG_STRING,   "Ew"},
+  {"proxy-tlspassword",        ARG_STRING,   "Ev"},
+  {"proxy-tlsuser",            ARG_STRING,   "Eu"},
+  {"proxy-tlsv1",              ARG_NONE,     "E9"},
+  {"proxy-user",               ARG_STRING,   "U",},
+  {"proxy1.0",                 ARG_STRING,   "$8"},
+  {"proxytunnel",              ARG_BOOL,     "p",},
+  {"pubkey",                   ARG_STRING,   "Eh"},
+  {"quote",                    ARG_STRING,   "Q",},
+  {"random-file",              ARG_FILENAME, "*a"},
+  {"range",                    ARG_STRING,   "r",},
+  {"rate",                     ARG_STRING,   "*I"},
+  {"raw",                      ARG_BOOL,     "$#"},
+  {"referer",                  ARG_STRING,   "e",},
+  {"remote-header-name",       ARG_BOOL,     "J",},
+  {"remote-name",              ARG_BOOL,     "O",},
+  {"remote-name-all",          ARG_BOOL,     "Oa"},
+  {"remote-time",              ARG_BOOL,     "R",},
+  {"remove-on-error",          ARG_BOOL,     "fe"},
+  {"request",                  ARG_STRING,   "X",},
+  {"request-target",           ARG_STRING,   "Ga"},
+  {"resolve",                  ARG_STRING,   "$F"},
+  {"retry",                    ARG_STRING,   "$g"},
+  {"retry-all-errors",         ARG_BOOL,     "$!"},
+  {"retry-connrefused",        ARG_BOOL,     "$V"},
+  {"retry-delay",              ARG_STRING,   "$h"},
+  {"retry-max-time",           ARG_STRING,   "$i"},
+  {"sasl-authzid",             ARG_STRING,   "$6"},
+  {"sasl-ir",                  ARG_BOOL,     "$K"},
+  {"service-name",             ARG_STRING,   "$P"},
+  {"sessionid",                ARG_BOOL,     "$w"},
+  {"show-error",               ARG_BOOL,     "S",},
+  {"silent",                   ARG_BOOL,     "s",},
+  {"socks4",                   ARG_STRING,   "$t"},
+  {"socks4a",                  ARG_STRING,   "$T"},
+  {"socks5",                   ARG_STRING,   "$c"},
+  {"socks5-basic",             ARG_BOOL,     "EA"},
+  {"socks5-gssapi",            ARG_BOOL,     "EB"},
+  {"socks5-gssapi-nec",        ARG_BOOL,     "$7"},
+  {"socks5-gssapi-service",    ARG_STRING,   "$O"},
+  {"socks5-hostname",          ARG_STRING,   "$2"},
+  {"speed-limit",              ARG_STRING,   "Y",},
+  {"speed-time",               ARG_STRING,   "y",},
+  {"ssl",                      ARG_BOOL,     "$a"},
+  {"ssl-allow-beast",          ARG_BOOL,     "En"},
+  {"ssl-auto-client-cert",     ARG_BOOL,     "Eo"},
+  {"ssl-no-revoke",            ARG_BOOL,     "Es"},
+  {"ssl-reqd",                 ARG_BOOL,     "$v"},
+  {"ssl-revoke-best-effort",   ARG_BOOL,     "ES"},
+  {"sslv2",                    ARG_NONE,     "2",},
+  {"sslv3",                    ARG_NONE,     "3",},
+  {"stderr",                   ARG_FILENAME, "*v"},
+  {"styled-output",            ARG_BOOL,     "fb"},
+  {"suppress-connect-headers", ARG_BOOL,     "$Y"},
+  {"tcp-fastopen",             ARG_BOOL,     "Et"},
+  {"tcp-nodelay",              ARG_BOOL,     "$d"},
+  {"telnet-option",            ARG_STRING,   "t",},
+  {"test-event",               ARG_BOOL,     "$L"},
+  {"tftp-blksize",             ARG_STRING,   "$9"},
+  {"tftp-no-options",          ARG_BOOL,     "$S"},
+  {"time-cond",                ARG_STRING,   "z",},
+  {"tls-max",                  ARG_STRING,   "$X"},
+  {"tls13-ciphers",            ARG_STRING,   "1A"},
+  {"tlsauthtype",              ARG_STRING,   "Em"},
+  {"tlspassword",              ARG_STRING,   "El"},
+  {"tlsuser",                  ARG_STRING,   "Ek"},
+  {"tlsv1",                    ARG_NONE,     "1",},
+  {"tlsv1.0",                  ARG_NONE,     "10"},
+  {"tlsv1.1",                  ARG_NONE,     "11"},
+  {"tlsv1.2",                  ARG_NONE,     "12"},
+  {"tlsv1.3",                  ARG_NONE,     "13"},
+  {"tr-encoding",              ARG_BOOL,     "*J"},
+  {"trace",                    ARG_FILENAME, "*g"},
+  {"trace-ascii",              ARG_FILENAME, "*h"},
+  {"trace-config",             ARG_STRING,   "$&"},
+  {"trace-ids",                ARG_BOOL,     "$%"},
+  {"trace-time",               ARG_BOOL,     "$o"},
+  {"unix-socket",              ARG_FILENAME, "$M"},
+  {"upload-file",              ARG_FILENAME, "T",},
+  {"url",                      ARG_STRING,   "*@"},
+  {"url-query",                ARG_STRING,   "dg"},
+  {"use-ascii",                ARG_BOOL,     "B",},
+  {"user",                     ARG_STRING,   "u",},
+  {"user-agent",               ARG_STRING,   "A",},
+  {"variable",                 ARG_STRING,   ":a"},
+  {"verbose",                  ARG_BOOL,     "v",},
+  {"version",                  ARG_BOOL,     "V",},
 #ifdef USE_WATT32
-  {"*p", "wdebug",                   ARG_BOOL},
+  {"wdebug",                   ARG_BOOL,     "*p"},
 #endif
-  {"*q", "ftp-create-dirs",          ARG_BOOL},
-  {"*r", "create-dirs",              ARG_BOOL},
-  {"*R", "create-file-mode",         ARG_STRING},
-  {"*s", "max-redirs",               ARG_STRING},
-  {"*S", "ipfs-gateway",             ARG_STRING},
-  {"*t", "proxy-ntlm",               ARG_BOOL},
-  {"*u", "crlf",                     ARG_BOOL},
-  {"*v", "stderr",                   ARG_FILENAME},
-  {"*V", "aws-sigv4",                ARG_STRING},
-  {"*w", "interface",                ARG_STRING},
-  {"*x", "krb",                      ARG_STRING},
-  {"*x", "krb4",                     ARG_STRING},
-         /* 'krb4' is the previous name */
-  {"*X", "haproxy-protocol",         ARG_BOOL},
-  {"*P", "haproxy-clientip",         ARG_STRING},
-  {"*y", "max-filesize",             ARG_STRING},
-  {"*z", "disable-eprt",             ARG_BOOL},
-  {"*Z", "eprt",                     ARG_BOOL},
-         /* 'eprt' made like this to make --no-eprt and --eprt to work
-             although --disable-eprt is the documented option */
-  {"*~", "xattr",                    ARG_BOOL},
-  {"$a", "ftp-ssl",                  ARG_BOOL},
-         /* 'ftp-ssl' deprecated name since 7.20.0 */
-  {"$a", "ssl",                      ARG_BOOL},
-         /* 'ssl' new option name in 7.20.0, previously this was ftp-ssl */
-  {"$b", "ftp-pasv",                 ARG_BOOL},
-  {"$c", "socks5",                   ARG_STRING},
-  {"$d", "tcp-nodelay",              ARG_BOOL},
-  {"$e", "proxy-digest",             ARG_BOOL},
-  {"$f", "proxy-basic",              ARG_BOOL},
-  {"$g", "retry",                    ARG_STRING},
-  {"$V", "retry-connrefused",        ARG_BOOL},
-  {"$h", "retry-delay",              ARG_STRING},
-  {"$i", "retry-max-time",           ARG_STRING},
-  {"$k", "proxy-negotiate",          ARG_BOOL},
-  {"$l", "form-escape",              ARG_BOOL},
-  {"$m", "ftp-account",              ARG_STRING},
-  {"$n", "proxy-anyauth",            ARG_BOOL},
-  {"$o", "trace-time",               ARG_BOOL},
-  {"$p", "ignore-content-length",    ARG_BOOL},
-  {"$q", "ftp-skip-pasv-ip",         ARG_BOOL},
-  {"$r", "ftp-method",               ARG_STRING},
-  {"$s", "local-port",               ARG_STRING},
-  {"$t", "socks4",                   ARG_STRING},
-  {"$T", "socks4a",                  ARG_STRING},
-  {"$u", "ftp-alternative-to-user",  ARG_STRING},
-  {"$v", "ftp-ssl-reqd",             ARG_BOOL},
-         /* 'ftp-ssl-reqd' deprecated name since 7.20.0 */
-  {"$v", "ssl-reqd",                 ARG_BOOL},
-         /* 'ssl-reqd' new in 7.20.0, previously this was ftp-ssl-reqd */
-  {"$w", "sessionid",                ARG_BOOL},
-         /* 'sessionid' listed as --no-sessionid in the help */
-  {"$x", "ftp-ssl-control",          ARG_BOOL},
-  {"$y", "ftp-ssl-ccc",              ARG_BOOL},
-  {"$j", "ftp-ssl-ccc-mode",         ARG_STRING},
-  {"$z", "libcurl",                  ARG_STRING},
-  {"$#", "raw",                      ARG_BOOL},
-  {"$0", "post301",                  ARG_BOOL},
-  {"$1", "keepalive",                ARG_BOOL},
-         /* 'keepalive' listed as --no-keepalive in the help */
-  {"$2", "socks5-hostname",          ARG_STRING},
-  {"$3", "keepalive-time",           ARG_STRING},
-  {"$4", "post302",                  ARG_BOOL},
-  {"$5", "noproxy",                  ARG_STRING},
-  {"$7", "socks5-gssapi-nec",        ARG_BOOL},
-  {"$8", "proxy1.0",                 ARG_STRING},
-  {"$9", "tftp-blksize",             ARG_STRING},
-  {"$A", "mail-from",                ARG_STRING},
-  {"$B", "mail-rcpt",                ARG_STRING},
-  {"$C", "ftp-pret",                 ARG_BOOL},
-  {"$D", "proto",                    ARG_STRING},
-  {"$E", "proto-redir",              ARG_STRING},
-  {"$F", "resolve",                  ARG_STRING},
-  {"$G", "delegation",               ARG_STRING},
-  {"$H", "mail-auth",                ARG_STRING},
-  {"$I", "post303",                  ARG_BOOL},
-  {"$J", "metalink",                 ARG_BOOL},
-  {"$6", "sasl-authzid",             ARG_STRING},
-  {"$K", "sasl-ir",                  ARG_BOOL },
-  {"$L", "test-event",               ARG_BOOL},
-  {"$M", "unix-socket",              ARG_FILENAME},
-  {"$N", "path-as-is",               ARG_BOOL},
-  {"$O", "socks5-gssapi-service",    ARG_STRING},
-         /* 'socks5-gssapi-service' merged with'proxy-service-name' and
-            deprecated since 7.49.0 */
-  {"$O", "proxy-service-name",       ARG_STRING},
-  {"$P", "service-name",             ARG_STRING},
-  {"$Q", "proto-default",            ARG_STRING},
-  {"$R", "expect100-timeout",        ARG_STRING},
-  {"$S", "tftp-no-options",          ARG_BOOL},
-  {"$U", "connect-to",               ARG_STRING},
-  {"$W", "abstract-unix-socket",     ARG_FILENAME},
-  {"$X", "tls-max",                  ARG_STRING},
-  {"$Y", "suppress-connect-headers", ARG_BOOL},
-  {"$Z", "compressed-ssh",           ARG_BOOL},
-  {"$~", "happy-eyeballs-timeout-ms", ARG_STRING},
-  {"$!", "retry-all-errors",         ARG_BOOL},
-  {"$%", "trace-ids",                ARG_BOOL},
-  {"$&", "trace-config",             ARG_STRING},
-  {"0",   "http1.0",                 ARG_NONE},
-  {"01",  "http1.1",                 ARG_NONE},
-  {"02",  "http2",                   ARG_NONE},
-  {"03",  "http2-prior-knowledge",   ARG_NONE},
-  {"04",  "http3",                   ARG_NONE},
-  {"05",  "http3-only",              ARG_NONE},
-  {"09",  "http0.9",                 ARG_BOOL},
-  {"0a",  "proxy-http2",             ARG_BOOL},
-  {"1",  "tlsv1",                    ARG_NONE},
-  {"10",  "tlsv1.0",                 ARG_NONE},
-  {"11",  "tlsv1.1",                 ARG_NONE},
-  {"12",  "tlsv1.2",                 ARG_NONE},
-  {"13",  "tlsv1.3",                 ARG_NONE},
-  {"1A", "tls13-ciphers",            ARG_STRING},
-  {"1B", "proxy-tls13-ciphers",      ARG_STRING},
-  {"2",  "sslv2",                    ARG_NONE},
-  {"3",  "sslv3",                    ARG_NONE},
-  {"4",  "ipv4",                     ARG_NONE},
-  {"6",  "ipv6",                     ARG_NONE},
-  {"a",  "append",                   ARG_BOOL},
-  {"A",  "user-agent",               ARG_STRING},
-  {"b",  "cookie",                   ARG_STRING},
-  {"ba", "alt-svc",                  ARG_STRING},
-  {"bb", "hsts",                     ARG_STRING},
-  {"B",  "use-ascii",                ARG_BOOL},
-  {"c",  "cookie-jar",               ARG_STRING},
-  {"C",  "continue-at",              ARG_STRING},
-  {"d",  "data",                     ARG_STRING},
-  {"dr", "data-raw",                 ARG_STRING},
-  {"da", "data-ascii",               ARG_STRING},
-  {"db", "data-binary",              ARG_STRING},
-  {"de", "data-urlencode",           ARG_STRING},
-  {"df", "json",                     ARG_STRING},
-  {"dg", "url-query",                ARG_STRING},
-  {"D",  "dump-header",              ARG_FILENAME},
-  {"e",  "referer",                  ARG_STRING},
-  {"E",  "cert",                     ARG_FILENAME},
-  {"Ea", "cacert",                   ARG_FILENAME},
-  {"Eb", "cert-type",                ARG_STRING},
-  {"Ec", "key",                      ARG_FILENAME},
-  {"Ed", "key-type",                 ARG_STRING},
-  {"Ee", "pass",                     ARG_STRING},
-  {"Ef", "engine",                   ARG_STRING},
-  {"EG", "ca-native",                ARG_BOOL},
-  {"EH", "proxy-ca-native",          ARG_BOOL},
-  {"Eg", "capath",                   ARG_FILENAME},
-  {"Eh", "pubkey",                   ARG_STRING},
-  {"Ei", "hostpubmd5",               ARG_STRING},
-  {"EF", "hostpubsha256",            ARG_STRING},
-  {"Ej", "crlfile",                  ARG_FILENAME},
-  {"Ek", "tlsuser",                  ARG_STRING},
-  {"El", "tlspassword",              ARG_STRING},
-  {"Em", "tlsauthtype",              ARG_STRING},
-  {"En", "ssl-allow-beast",          ARG_BOOL},
-  {"Eo", "ssl-auto-client-cert",     ARG_BOOL},
-  {"EO", "proxy-ssl-auto-client-cert", ARG_BOOL},
-  {"Ep", "pinnedpubkey",             ARG_STRING},
-  {"EP", "proxy-pinnedpubkey",       ARG_STRING},
-  {"Eq", "cert-status",              ARG_BOOL},
-  {"EQ", "doh-cert-status",          ARG_BOOL},
-  {"Er", "false-start",              ARG_BOOL},
-  {"Es", "ssl-no-revoke",            ARG_BOOL},
-  {"ES", "ssl-revoke-best-effort",   ARG_BOOL},
-  {"Et", "tcp-fastopen",             ARG_BOOL},
-  {"Eu", "proxy-tlsuser",            ARG_STRING},
-  {"Ev", "proxy-tlspassword",        ARG_STRING},
-  {"Ew", "proxy-tlsauthtype",        ARG_STRING},
-  {"Ex", "proxy-cert",               ARG_FILENAME},
-  {"Ey", "proxy-cert-type",          ARG_STRING},
-  {"Ez", "proxy-key",                ARG_FILENAME},
-  {"E0", "proxy-key-type",           ARG_STRING},
-  {"E1", "proxy-pass",               ARG_STRING},
-  {"E2", "proxy-ciphers",            ARG_STRING},
-  {"E3", "proxy-crlfile",            ARG_FILENAME},
-  {"E4", "proxy-ssl-allow-beast",    ARG_BOOL},
-  {"E5", "login-options",            ARG_STRING},
-  {"E6", "proxy-cacert",             ARG_FILENAME},
-  {"E7", "proxy-capath",             ARG_FILENAME},
-  {"E8", "proxy-insecure",           ARG_BOOL},
-  {"E9", "proxy-tlsv1",              ARG_NONE},
-  {"EA", "socks5-basic",             ARG_BOOL},
-  {"EB", "socks5-gssapi",            ARG_BOOL},
-  {"EC", "etag-save",                ARG_FILENAME},
-  {"ED", "etag-compare",             ARG_FILENAME},
-  {"EE", "curves",                   ARG_STRING},
-  {"f",  "fail",                     ARG_BOOL},
-  {"fa", "fail-early",               ARG_BOOL},
-  {"fb", "styled-output",            ARG_BOOL},
-  {"fc", "mail-rcpt-allowfails",     ARG_BOOL},
-  {"fd", "fail-with-body",           ARG_BOOL},
-  {"fe", "remove-on-error",          ARG_BOOL},
-  {"F",  "form",                     ARG_STRING},
-  {"Fs", "form-string",              ARG_STRING},
-  {"g",  "globoff",                  ARG_BOOL},
-  {"G",  "get",                      ARG_BOOL},
-  {"Ga", "request-target",           ARG_STRING},
-  {"h",  "help",                     ARG_BOOL},
-  {"H",  "header",                   ARG_STRING},
-  {"Hp", "proxy-header",             ARG_STRING},
-  {"i",  "include",                  ARG_BOOL},
-  {"I",  "head",                     ARG_BOOL},
-  {"j",  "junk-session-cookies",     ARG_BOOL},
-  {"J",  "remote-header-name",       ARG_BOOL},
-  {"k",  "insecure",                 ARG_BOOL},
-  {"kd", "doh-insecure",             ARG_BOOL},
-  {"K",  "config",                   ARG_FILENAME},
-  {"l",  "list-only",                ARG_BOOL},
-  {"L",  "location",                 ARG_BOOL},
-  {"Lt", "location-trusted",         ARG_BOOL},
-  {"m",  "max-time",                 ARG_STRING},
-  {"M",  "manual",                   ARG_BOOL},
-  {"n",  "netrc",                    ARG_BOOL},
-  {"no", "netrc-optional",           ARG_BOOL},
-  {"ne", "netrc-file",               ARG_FILENAME},
-  {"N",  "buffer",                   ARG_BOOL},
-         /* 'buffer' listed as --no-buffer in the help */
-  {"o",  "output",                   ARG_FILENAME},
-  {"O",  "remote-name",              ARG_BOOL},
-  {"Oa", "remote-name-all",          ARG_BOOL},
-  {"Ob", "output-dir",               ARG_STRING},
-  {"Oc", "clobber",                  ARG_BOOL},
-  {"p",  "proxytunnel",              ARG_BOOL},
-  {"P",  "ftp-port",                 ARG_STRING},
-  {"q",  "disable",                  ARG_BOOL},
-  {"Q",  "quote",                    ARG_STRING},
-  {"r",  "range",                    ARG_STRING},
-  {"R",  "remote-time",              ARG_BOOL},
-  {"s",  "silent",                   ARG_BOOL},
-  {"S",  "show-error",               ARG_BOOL},
-  {"t",  "telnet-option",            ARG_STRING},
-  {"T",  "upload-file",              ARG_FILENAME},
-  {"u",  "user",                     ARG_STRING},
-  {"U",  "proxy-user",               ARG_STRING},
-  {"v",  "verbose",                  ARG_BOOL},
-  {"V",  "version",                  ARG_BOOL},
-  {"w",  "write-out",                ARG_STRING},
-  {"x",  "proxy",                    ARG_STRING},
-  {"xa", "preproxy",                 ARG_STRING},
-  {"X",  "request",                  ARG_STRING},
-  {"Y",  "speed-limit",              ARG_STRING},
-  {"y",  "speed-time",               ARG_STRING},
-  {"z",  "time-cond",                ARG_STRING},
-  {"Z",  "parallel",                 ARG_BOOL},
-  {"Zb", "parallel-max",             ARG_STRING},
-  {"Zc", "parallel-immediate",       ARG_BOOL},
-  {"#",  "progress-bar",             ARG_BOOL},
-  {"#m", "progress-meter",           ARG_BOOL},
-  {":",  "next",                     ARG_NONE},
-  {":a", "variable",                 ARG_STRING},
+  {"write-out",                ARG_STRING,   "w",},
+  {"xattr",                    ARG_BOOL,     "*~"},
 };
 
 /* Split the argument of -E to 'certname' and 'passphrase' separated by colon.
@@ -501,12 +487,14 @@ static void
 GetFileAndPassword(char *nextarg, char **file, char **password)
 {
   char *certname, *passphrase;
-  parse_cert_parameter(nextarg, &certname, &passphrase);
-  Curl_safefree(*file);
-  *file = certname;
-  if(passphrase) {
-    Curl_safefree(*password);
-    *password = passphrase;
+  if(nextarg) {
+    parse_cert_parameter(nextarg, &certname, &passphrase);
+    Curl_safefree(*file);
+    *file = certname;
+    if(passphrase) {
+      Curl_safefree(*password);
+      *password = passphrase;
+    }
   }
 }
 
@@ -746,6 +734,32 @@ out:
   return result;
 }
 
+static int findarg(const void *a, const void *b)
+{
+  const struct LongShort *aa = a;
+  const struct LongShort *bb = b;
+  return strcmp(aa->lname, bb->lname);
+}
+
+static const struct LongShort *single(char letter)
+{
+  static const struct LongShort *singles[128 - ' ']; /* ASCII => pointer */
+  static bool singles_done = FALSE;
+  DEBUGASSERT((letter < 127) && (letter > ' '));
+
+  if(!singles_done) {
+    unsigned int j;
+    for(j = 0; j < sizeof(aliases)/sizeof(aliases[0]); j++) {
+      if(!aliases[j].letter[1]) {
+        unsigned char l = aliases[j].letter[0];
+        singles[l - ' '] = &aliases[j];
+      }
+    }
+    singles_done = TRUE;
+  }
+  return singles[letter - ' '];
+}
+
 ParameterError getparameter(const char *flag, /* f or -long-flag */
                             char *nextarg,    /* NULL if unset */
                             argv_item_t cleararg,
@@ -758,9 +772,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
   char subletter = '\0'; /* subletters can only occur on long options */
   int rc;
   const char *parse = NULL;
-  unsigned int j;
   time_t now;
-  int hit = -1;
   bool longopt = FALSE;
   bool singleopt = FALSE; /* when true means '-o foo' used '-ofoo' */
   ParameterError err = PARAM_OK;
@@ -775,6 +787,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     "ftps",
     NULL
   };
+  const struct LongShort *a = NULL;
 #ifdef HAVE_WRITABLE_ARGV
   argv_item_t clearthis = NULL;
 #else
@@ -786,10 +799,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
   if(('-' != flag[0]) || ('-' == flag[1])) {
     /* this should be a long name */
     const char *word = ('-' == flag[0]) ? flag + 2 : flag;
-    size_t fnam = strlen(word);
-    int numhits = 0;
     bool noflagged = FALSE;
     bool expand = FALSE;
+    struct LongShort key;
 
     if(!strncmp(word, "no-", 3)) {
       /* disable this option but ignore the "no-" part when looking for it */
@@ -802,31 +814,19 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       word += 7;
       expand = TRUE;
     }
+    key.lname = word;
 
-    for(j = 0; j < sizeof(aliases)/sizeof(aliases[0]); j++) {
-      if(curl_strnequal(aliases[j].lname, word, fnam)) {
-        longopt = TRUE;
-        numhits++;
-        if(curl_strequal(aliases[j].lname, word)) {
-          parse = aliases[j].letter;
-          hit = j;
-          numhits = 1; /* a single unique hit */
-          break;
-        }
-        parse = aliases[j].letter;
-        hit = j;
-      }
+    a = bsearch(&key, aliases, sizeof(aliases)/sizeof(aliases[0]),
+                sizeof(aliases[0]), findarg);
+    if(a) {
+      longopt = TRUE;
+      parse = a->letter;
     }
-    if(numhits > 1) {
-      /* this is at least the second match! */
-      err = PARAM_OPTION_AMBIGUOUS;
-      goto error;
-    }
-    else if(hit < 0) {
+    else {
       err = PARAM_OPTION_UNKNOWN;
       goto error;
     }
-    else if(noflagged && (aliases[hit].desc != ARG_BOOL)) {
+    if(noflagged && (a->desc != ARG_BOOL)) {
       /* --no- prefixed an option that isn't boolean! */
       err = PARAM_NO_NOT_BOOLEAN;
       goto error;
@@ -835,8 +835,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       struct curlx_dynbuf nbuf;
       bool replaced;
 
-      if((aliases[hit].desc != ARG_STRING) &&
-         (aliases[hit].desc != ARG_FILENAME)) {
+      if((a->desc != ARG_STRING) &&
+         (a->desc != ARG_FILENAME)) {
         /* --expand on an option that isn't a string or a filename */
         err = PARAM_EXPAND_ERROR;
         goto error;
@@ -854,7 +854,6 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
   }
   else {
     flag++; /* prefixed with one dash, pass it */
-    hit = -1;
     parse = flag;
   }
 
@@ -870,20 +869,15 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       subletter = parse[1];
     }
 
-    if(hit < 0) {
-      for(j = 0; j < sizeof(aliases)/sizeof(aliases[0]); j++) {
-        if(letter == aliases[j].letter[0]) {
-          hit = j;
-          break;
-        }
-      }
-      if(hit < 0) {
+    if(!a) {
+      a = single(letter);
+      if(!a) {
         err = PARAM_OPTION_UNKNOWN;
         break;
       }
     }
 
-    if(aliases[hit].desc >= ARG_STRING) {
+    if(a->desc >= ARG_STRING) {
       /* this option requires an extra parameter */
       if(!longopt && parse[1]) {
         nextarg = (char *)&parse[1]; /* this is the actual extra parameter */
@@ -900,17 +894,24 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         *usedarg = TRUE; /* mark it as used */
       }
 
-      if((aliases[hit].desc == ARG_FILENAME) &&
+      if((a->desc == ARG_FILENAME) &&
          (nextarg[0] == '-') && nextarg[1]) {
         /* if the file name looks like a command line option */
         warnf(global, "The file name argument '%s' looks like a flag.",
               nextarg);
       }
     }
-    else if((aliases[hit].desc == ARG_NONE) && !toggle) {
+    else if((a->desc == ARG_NONE) && !toggle) {
       err = PARAM_NO_PREFIX;
       break;
     }
+
+    if(!nextarg)
+      /* this is a precaution mostly to please scan-build, as all arguments
+         that use nextarg should be marked as such and they will check that
+         nextarg is set before continuing, but code analyzers are not always
+         that aware of that state */
+      nextarg = (char *)"";
 
     switch(letter) {
     case '*': /* options without a short option */
@@ -1919,7 +1920,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       case 'f': /* crypto engine */
         err = getstr(&config->engine, nextarg, DENY_BLANK);
         if(!err &&
-           config->engine && curl_strequal(config->engine, "list")) {
+           config->engine && !strcmp(config->engine, "list")) {
           err = PARAM_ENGINES_REQUESTED;
         }
         break;
@@ -1966,7 +1967,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           break;
         }
         err = getstr(&config->tls_authtype, nextarg, DENY_BLANK);
-        if(!err && !curl_strequal(config->tls_authtype, "SRP"))
+        if(!err && strcmp(config->tls_authtype, "SRP"))
           err = PARAM_LIBCURL_DOESNT_SUPPORT; /* only support TLS-SRP */
         break;
       case 'n': /* no empty SSL fragments, --ssl-allow-beast */
@@ -2042,7 +2043,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           break;
         }
         err = getstr(&config->proxy_tls_authtype, nextarg, DENY_BLANK);
-        if(!err && !curl_strequal(config->proxy_tls_authtype, "SRP"))
+        if(!err && strcmp(config->proxy_tls_authtype, "SRP"))
           err = PARAM_LIBCURL_DOESNT_SUPPORT; /* only support TLS-SRP */
         break;
 
@@ -2196,7 +2197,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
 
     case 'h': /* h for help */
       if(toggle) {
-        if(nextarg) {
+        if(*nextarg) {
           global->help_category = strdup(nextarg);
           if(!global->help_category) {
             err = PARAM_NO_MEM;
@@ -2675,7 +2676,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       err = PARAM_OPTION_UNKNOWN;
       break;
     }
-    hit = -1;
+    a = NULL;
 
   } while(!longopt && !singleopt && *++parse && !*usedarg && !err);
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -71,6 +71,7 @@ static ParameterError getstr(char **str, const char *val, bool allowblank)
   return PARAM_OK;
 }
 
+#define OPT_SHORT '\0'
 struct LongShort {
   const char *lname;  /* long name option */
   enum {
@@ -79,279 +80,279 @@ struct LongShort {
     ARG_STRING, /* requires an argument */
     ARG_FILENAME /* requires an argument, usually a file name */
   } desc;
-  const char *letter; /* short name option */
-  /* 'letter' strings with more than one character have *no* short option. */
+  char letter;    /* short name option */
+  char subletter; /* use OPT_SHORT when 'letter' is the short option */
 };
 
 /* this array MUST be alphasorted based on the 'lname' */
 static const struct LongShort aliases[]= {
-  {"abstract-unix-socket",     ARG_FILENAME, "$W"},
-  {"alpn",                     ARG_BOOL,     "*H"},
-  {"alt-svc",                  ARG_STRING,   "ba"},
-  {"anyauth",                  ARG_BOOL,     "*o"},
-  {"append",                   ARG_BOOL,     "a",},
-  {"aws-sigv4",                ARG_STRING,   "*V"},
-  {"basic",                    ARG_BOOL,     "*n"},
-  {"buffer",                   ARG_BOOL,     "N",},
-  {"ca-native",                ARG_BOOL,     "EG"},
-  {"cacert",                   ARG_FILENAME, "Ea"},
-  {"capath",                   ARG_FILENAME, "Eg"},
-  {"cert",                     ARG_FILENAME, "E",},
-  {"cert-status",              ARG_BOOL,     "Eq"},
-  {"cert-type",                ARG_STRING,   "Eb"},
-  {"ciphers",                  ARG_STRING,   "*d"},
-  {"clobber",                  ARG_BOOL,     "Oc"},
-  {"compressed",               ARG_BOOL,     "*j"},
-  {"compressed-ssh",           ARG_BOOL,     "$Z"},
-  {"config",                   ARG_FILENAME, "K",},
-  {"connect-timeout",          ARG_STRING,   "*c"},
-  {"connect-to",               ARG_STRING,   "$U"},
-  {"continue-at",              ARG_STRING,   "C",},
-  {"cookie",                   ARG_STRING,   "b",},
-  {"cookie-jar",               ARG_STRING,   "c",},
-  {"create-dirs",              ARG_BOOL,     "*r"},
-  {"create-file-mode",         ARG_STRING,   "*R"},
-  {"crlf",                     ARG_BOOL,     "*u"},
-  {"crlfile",                  ARG_FILENAME, "Ej"},
-  {"curves",                   ARG_STRING,   "EE"},
-  {"data",                     ARG_STRING,   "d",},
-  {"data-ascii",               ARG_STRING,   "da"},
-  {"data-binary",              ARG_STRING,   "db"},
-  {"data-raw",                 ARG_STRING,   "dr"},
-  {"data-urlencode",           ARG_STRING,   "de"},
-  {"delegation",               ARG_STRING,   "$G"},
-  {"digest",                   ARG_BOOL,     "*k"},
-  {"disable",                  ARG_BOOL,     "q",},
-  {"disable-eprt",             ARG_BOOL,     "*z"},
-  {"disable-epsv",             ARG_BOOL,     "*e"},
-  {"disallow-username-in-url", ARG_BOOL,     "*f"},
-  {"dns-interface",            ARG_STRING,   "*D"},
-  {"dns-ipv4-addr",            ARG_STRING,   "*4"},
-  {"dns-ipv6-addr",            ARG_STRING,   "*6"},
-  {"dns-servers",              ARG_STRING,   "*F"},
-  {"doh-cert-status",          ARG_BOOL,     "EQ"},
-  {"doh-insecure",             ARG_BOOL,     "kd"},
-  {"doh-url"        ,          ARG_STRING,   "*C"},
-  {"dump-header",              ARG_FILENAME, "D",},
-  {"egd-file",                 ARG_STRING,   "*b"},
-  {"engine",                   ARG_STRING,   "Ef"},
-  {"eprt",                     ARG_BOOL,     "*Z"},
-  {"epsv",                     ARG_BOOL,     "*E"},
-  {"etag-compare",             ARG_FILENAME, "ED"},
-  {"etag-save",                ARG_FILENAME, "EC"},
-  {"expect100-timeout",        ARG_STRING,   "$R"},
-  {"fail",                     ARG_BOOL,     "f",},
-  {"fail-early",               ARG_BOOL,     "fa"},
-  {"fail-with-body",           ARG_BOOL,     "fd"},
-  {"false-start",              ARG_BOOL,     "Er"},
-  {"form",                     ARG_STRING,   "F",},
-  {"form-escape",              ARG_BOOL,     "$l"},
-  {"form-string",              ARG_STRING,   "Fs"},
-  {"ftp-account",              ARG_STRING,   "$m"},
-  {"ftp-alternative-to-user",  ARG_STRING,   "$u"},
-  {"ftp-create-dirs",          ARG_BOOL,     "*q"},
-  {"ftp-method",               ARG_STRING,   "$r"},
-  {"ftp-pasv",                 ARG_BOOL,     "$b"},
-  {"ftp-port",                 ARG_STRING,   "P",},
-  {"ftp-pret",                 ARG_BOOL,     "$C"},
-  {"ftp-skip-pasv-ip",         ARG_BOOL,     "$q"},
-  {"ftp-ssl",                  ARG_BOOL,     "$a"},
-  {"ftp-ssl-ccc",              ARG_BOOL,     "$y"},
-  {"ftp-ssl-ccc-mode",         ARG_STRING,   "$j"},
-  {"ftp-ssl-control",          ARG_BOOL,     "$x"},
-  {"ftp-ssl-reqd",             ARG_BOOL,     "$v"},
-  {"get",                      ARG_BOOL,     "G",},
-  {"globoff",                  ARG_BOOL,     "g",},
-  {"happy-eyeballs-timeout-ms", ARG_STRING,  "$~"},
-  {"haproxy-clientip",         ARG_STRING,   "*P"},
-  {"haproxy-protocol",         ARG_BOOL,     "*X"},
-  {"head",                     ARG_BOOL,     "I",},
-  {"header",                   ARG_STRING,   "H",},
-  {"help",                     ARG_BOOL,     "h",},
-  {"hostpubmd5",               ARG_STRING,   "Ei"},
-  {"hostpubsha256",            ARG_STRING,   "EF"},
-  {"hsts",                     ARG_STRING,   "bb"},
-  {"http0.9",                  ARG_BOOL,     "09"},
-  {"http1.0",                  ARG_NONE,     "0",},
-  {"http1.1",                  ARG_NONE,     "01"},
-  {"http2",                    ARG_NONE,     "02"},
-  {"http2-prior-knowledge",    ARG_NONE,     "03"},
-  {"http3",                    ARG_NONE,     "04"},
-  {"http3-only",               ARG_NONE,     "05"},
-  {"ignore-content-length",    ARG_BOOL,     "$p"},
-  {"include",                  ARG_BOOL,     "i",},
-  {"insecure",                 ARG_BOOL,     "k",},
-  {"interface",                ARG_STRING,   "*w"},
-  {"ipfs-gateway",             ARG_STRING,   "*S"},
-  {"ipv4",                     ARG_NONE,     "4",},
-  {"ipv6",                     ARG_NONE,     "6",},
-  {"json",                     ARG_STRING,   "df"},
-  {"junk-session-cookies",     ARG_BOOL,     "j",},
-  {"keepalive",                ARG_BOOL,     "$1"},
-  {"keepalive-time",           ARG_STRING,   "$3"},
-  {"key",                      ARG_FILENAME, "Ec"},
-  {"key-type",                 ARG_STRING,   "Ed"},
-  {"krb",                      ARG_STRING,   "*x"},
-  {"krb4",                     ARG_STRING,   "*x"},
-  {"libcurl",                  ARG_STRING,   "$z"},
-  {"limit-rate",               ARG_STRING,   "*i"},
-  {"list-only",                ARG_BOOL,     "l",},
-  {"local-port",               ARG_STRING,   "$s"},
-  {"location",                 ARG_BOOL,     "L",},
-  {"location-trusted",         ARG_BOOL,     "Lt"},
-  {"login-options",            ARG_STRING,   "E5"},
-  {"mail-auth",                ARG_STRING,   "$H"},
-  {"mail-from",                ARG_STRING,   "$A"},
-  {"mail-rcpt",                ARG_STRING,   "$B"},
-  {"mail-rcpt-allowfails",     ARG_BOOL,     "fc"},
-  {"manual",                   ARG_BOOL,     "M",},
-  {"max-filesize",             ARG_STRING,   "*y"},
-  {"max-redirs",               ARG_STRING,   "*s"},
-  {"max-time",                 ARG_STRING,   "m",},
-  {"metalink",                 ARG_BOOL,     "$J"},
-  {"negotiate",                ARG_BOOL,     "*l"},
-  {"netrc",                    ARG_BOOL,     "n",},
-  {"netrc-file",               ARG_FILENAME, "ne"},
-  {"netrc-optional",           ARG_BOOL,     "no"},
-  {"next",                     ARG_NONE,     ":",},
-  {"noproxy",                  ARG_STRING,   "$5"},
-  {"npn",                      ARG_BOOL,     "*G"},
-  {"ntlm",                     ARG_BOOL,     "*m"},
-  {"ntlm-wb",                  ARG_BOOL,     "*M"},
-  {"oauth2-bearer",            ARG_STRING,   "*B"},
-  {"output",                   ARG_FILENAME, "o",},
-  {"output-dir",               ARG_STRING,   "Ob"},
-  {"parallel",                 ARG_BOOL,     "Z",},
-  {"parallel-immediate",       ARG_BOOL,     "Zc"},
-  {"parallel-max",             ARG_STRING,   "Zb"},
-  {"pass",                     ARG_STRING,   "Ee"},
-  {"path-as-is",               ARG_BOOL,     "$N"},
-  {"pinnedpubkey",             ARG_STRING,   "Ep"},
-  {"post301",                  ARG_BOOL,     "$0"},
-  {"post302",                  ARG_BOOL,     "$4"},
-  {"post303",                  ARG_BOOL,     "$I"},
-  {"preproxy",                 ARG_STRING,   "xa"},
-  {"progress-bar",             ARG_BOOL,     "#",},
-  {"progress-meter",           ARG_BOOL,     "#m"},
-  {"proto",                    ARG_STRING,   "$D"},
-  {"proto-default",            ARG_STRING,   "$Q"},
-  {"proto-redir",              ARG_STRING,   "$E"},
-  {"proxy",                    ARG_STRING,   "x",},
-  {"proxy-anyauth",            ARG_BOOL,     "$n"},
-  {"proxy-basic",              ARG_BOOL,     "$f"},
-  {"proxy-ca-native",          ARG_BOOL,     "EH"},
-  {"proxy-cacert",             ARG_FILENAME, "E6"},
-  {"proxy-capath",             ARG_FILENAME, "E7"},
-  {"proxy-cert",               ARG_FILENAME, "Ex"},
-  {"proxy-cert-type",          ARG_STRING,   "Ey"},
-  {"proxy-ciphers",            ARG_STRING,   "E2"},
-  {"proxy-crlfile",            ARG_FILENAME, "E3"},
-  {"proxy-digest",             ARG_BOOL,     "$e"},
-  {"proxy-header",             ARG_STRING,   "Hp"},
-  {"proxy-http2",              ARG_BOOL,     "0a"},
-  {"proxy-insecure",           ARG_BOOL,     "E8"},
-  {"proxy-key",                ARG_FILENAME, "Ez"},
-  {"proxy-key-type",           ARG_STRING,   "E0"},
-  {"proxy-negotiate",          ARG_BOOL,     "$k"},
-  {"proxy-ntlm",               ARG_BOOL,     "*t"},
-  {"proxy-pass",               ARG_STRING,   "E1"},
-  {"proxy-pinnedpubkey",       ARG_STRING,   "EP"},
-  {"proxy-service-name",       ARG_STRING,   "$O"},
-  {"proxy-ssl-allow-beast",    ARG_BOOL,     "E4"},
-  {"proxy-ssl-auto-client-cert", ARG_BOOL,   "EO"},
-  {"proxy-tls13-ciphers",      ARG_STRING,   "1B"},
-  {"proxy-tlsauthtype",        ARG_STRING,   "Ew"},
-  {"proxy-tlspassword",        ARG_STRING,   "Ev"},
-  {"proxy-tlsuser",            ARG_STRING,   "Eu"},
-  {"proxy-tlsv1",              ARG_NONE,     "E9"},
-  {"proxy-user",               ARG_STRING,   "U",},
-  {"proxy1.0",                 ARG_STRING,   "$8"},
-  {"proxytunnel",              ARG_BOOL,     "p",},
-  {"pubkey",                   ARG_STRING,   "Eh"},
-  {"quote",                    ARG_STRING,   "Q",},
-  {"random-file",              ARG_FILENAME, "*a"},
-  {"range",                    ARG_STRING,   "r",},
-  {"rate",                     ARG_STRING,   "*I"},
-  {"raw",                      ARG_BOOL,     "$#"},
-  {"referer",                  ARG_STRING,   "e",},
-  {"remote-header-name",       ARG_BOOL,     "J",},
-  {"remote-name",              ARG_BOOL,     "O",},
-  {"remote-name-all",          ARG_BOOL,     "Oa"},
-  {"remote-time",              ARG_BOOL,     "R",},
-  {"remove-on-error",          ARG_BOOL,     "fe"},
-  {"request",                  ARG_STRING,   "X",},
-  {"request-target",           ARG_STRING,   "Ga"},
-  {"resolve",                  ARG_STRING,   "$F"},
-  {"retry",                    ARG_STRING,   "$g"},
-  {"retry-all-errors",         ARG_BOOL,     "$!"},
-  {"retry-connrefused",        ARG_BOOL,     "$V"},
-  {"retry-delay",              ARG_STRING,   "$h"},
-  {"retry-max-time",           ARG_STRING,   "$i"},
-  {"sasl-authzid",             ARG_STRING,   "$6"},
-  {"sasl-ir",                  ARG_BOOL,     "$K"},
-  {"service-name",             ARG_STRING,   "$P"},
-  {"sessionid",                ARG_BOOL,     "$w"},
-  {"show-error",               ARG_BOOL,     "S",},
-  {"silent",                   ARG_BOOL,     "s",},
-  {"socks4",                   ARG_STRING,   "$t"},
-  {"socks4a",                  ARG_STRING,   "$T"},
-  {"socks5",                   ARG_STRING,   "$c"},
-  {"socks5-basic",             ARG_BOOL,     "EA"},
-  {"socks5-gssapi",            ARG_BOOL,     "EB"},
-  {"socks5-gssapi-nec",        ARG_BOOL,     "$7"},
-  {"socks5-gssapi-service",    ARG_STRING,   "$O"},
-  {"socks5-hostname",          ARG_STRING,   "$2"},
-  {"speed-limit",              ARG_STRING,   "Y",},
-  {"speed-time",               ARG_STRING,   "y",},
-  {"ssl",                      ARG_BOOL,     "$a"},
-  {"ssl-allow-beast",          ARG_BOOL,     "En"},
-  {"ssl-auto-client-cert",     ARG_BOOL,     "Eo"},
-  {"ssl-no-revoke",            ARG_BOOL,     "Es"},
-  {"ssl-reqd",                 ARG_BOOL,     "$v"},
-  {"ssl-revoke-best-effort",   ARG_BOOL,     "ES"},
-  {"sslv2",                    ARG_NONE,     "2",},
-  {"sslv3",                    ARG_NONE,     "3",},
-  {"stderr",                   ARG_FILENAME, "*v"},
-  {"styled-output",            ARG_BOOL,     "fb"},
-  {"suppress-connect-headers", ARG_BOOL,     "$Y"},
-  {"tcp-fastopen",             ARG_BOOL,     "Et"},
-  {"tcp-nodelay",              ARG_BOOL,     "$d"},
-  {"telnet-option",            ARG_STRING,   "t",},
-  {"test-event",               ARG_BOOL,     "$L"},
-  {"tftp-blksize",             ARG_STRING,   "$9"},
-  {"tftp-no-options",          ARG_BOOL,     "$S"},
-  {"time-cond",                ARG_STRING,   "z",},
-  {"tls-max",                  ARG_STRING,   "$X"},
-  {"tls13-ciphers",            ARG_STRING,   "1A"},
-  {"tlsauthtype",              ARG_STRING,   "Em"},
-  {"tlspassword",              ARG_STRING,   "El"},
-  {"tlsuser",                  ARG_STRING,   "Ek"},
-  {"tlsv1",                    ARG_NONE,     "1",},
-  {"tlsv1.0",                  ARG_NONE,     "10"},
-  {"tlsv1.1",                  ARG_NONE,     "11"},
-  {"tlsv1.2",                  ARG_NONE,     "12"},
-  {"tlsv1.3",                  ARG_NONE,     "13"},
-  {"tr-encoding",              ARG_BOOL,     "*J"},
-  {"trace",                    ARG_FILENAME, "*g"},
-  {"trace-ascii",              ARG_FILENAME, "*h"},
-  {"trace-config",             ARG_STRING,   "$&"},
-  {"trace-ids",                ARG_BOOL,     "$%"},
-  {"trace-time",               ARG_BOOL,     "$o"},
-  {"unix-socket",              ARG_FILENAME, "$M"},
-  {"upload-file",              ARG_FILENAME, "T",},
-  {"url",                      ARG_STRING,   "*@"},
-  {"url-query",                ARG_STRING,   "dg"},
-  {"use-ascii",                ARG_BOOL,     "B",},
-  {"user",                     ARG_STRING,   "u",},
-  {"user-agent",               ARG_STRING,   "A",},
-  {"variable",                 ARG_STRING,   ":a"},
-  {"verbose",                  ARG_BOOL,     "v",},
-  {"version",                  ARG_BOOL,     "V",},
+  {"abstract-unix-socket",     ARG_FILENAME, '$', 'W'},
+  {"alpn",                     ARG_BOOL,     '*', 'H'},
+  {"alt-svc",                  ARG_STRING,   'b', 'a'},
+  {"anyauth",                  ARG_BOOL,     '*', 'o'},
+  {"append",                   ARG_BOOL,     'a', OPT_SHORT},
+  {"aws-sigv4",                ARG_STRING,   '*', 'V'},
+  {"basic",                    ARG_BOOL,     '*', 'n'},
+  {"buffer",                   ARG_BOOL,     'N', OPT_SHORT},
+  {"ca-native",                ARG_BOOL,     'E', 'G'},
+  {"cacert",                   ARG_FILENAME, 'E', 'a'},
+  {"capath",                   ARG_FILENAME, 'E', 'g'},
+  {"cert",                     ARG_FILENAME, 'E', OPT_SHORT},
+  {"cert-status",              ARG_BOOL,     'E', 'q'},
+  {"cert-type",                ARG_STRING,   'E', 'b'},
+  {"ciphers",                  ARG_STRING,   '*', 'd'},
+  {"clobber",                  ARG_BOOL,     'O', 'c'},
+  {"compressed",               ARG_BOOL,     '*', 'j'},
+  {"compressed-ssh",           ARG_BOOL,     '$', 'Z'},
+  {"config",                   ARG_FILENAME, 'K', OPT_SHORT},
+  {"connect-timeout",          ARG_STRING,   '*', 'c'},
+  {"connect-to",               ARG_STRING,   '$', 'U'},
+  {"continue-at",              ARG_STRING,   'C', OPT_SHORT},
+  {"cookie",                   ARG_STRING,   'b', OPT_SHORT},
+  {"cookie-jar",               ARG_STRING,   'c', OPT_SHORT},
+  {"create-dirs",              ARG_BOOL,     '*', 'r'},
+  {"create-file-mode",         ARG_STRING,   '*', 'R'},
+  {"crlf",                     ARG_BOOL,     '*', 'u'},
+  {"crlfile",                  ARG_FILENAME, 'E', 'j'},
+  {"curves",                   ARG_STRING,   'E', 'E'},
+  {"data",                     ARG_STRING,   'd', OPT_SHORT},
+  {"data-ascii",               ARG_STRING,   'd', 'a'},
+  {"data-binary",              ARG_STRING,   'd', 'b'},
+  {"data-raw",                 ARG_STRING,   'd', 'r'},
+  {"data-urlencode",           ARG_STRING,   'd', 'e'},
+  {"delegation",               ARG_STRING,   '$', 'G'},
+  {"digest",                   ARG_BOOL,     '*', 'k'},
+  {"disable",                  ARG_BOOL,     'q', OPT_SHORT},
+  {"disable-eprt",             ARG_BOOL,     '*', 'z'},
+  {"disable-epsv",             ARG_BOOL,     '*', 'e'},
+  {"disallow-username-in-url", ARG_BOOL,     '*', 'f'},
+  {"dns-interface",            ARG_STRING,   '*', 'D'},
+  {"dns-ipv4-addr",            ARG_STRING,   '*', '4'},
+  {"dns-ipv6-addr",            ARG_STRING,   '*', '6'},
+  {"dns-servers",              ARG_STRING,   '*', 'F'},
+  {"doh-cert-status",          ARG_BOOL,     'E', 'Q'},
+  {"doh-insecure",             ARG_BOOL,     'k', 'd'},
+  {"doh-url"        ,          ARG_STRING,   '*', 'C'},
+  {"dump-header",              ARG_FILENAME, 'D', OPT_SHORT},
+  {"egd-file",                 ARG_STRING,   '*', 'b'},
+  {"engine",                   ARG_STRING,   'E', 'f'},
+  {"eprt",                     ARG_BOOL,     '*', 'Z'},
+  {"epsv",                     ARG_BOOL,     '*', 'E'},
+  {"etag-compare",             ARG_FILENAME, 'E', 'D'},
+  {"etag-save",                ARG_FILENAME, 'E', 'C'},
+  {"expect100-timeout",        ARG_STRING,   '$', 'R'},
+  {"fail",                     ARG_BOOL,     'f', OPT_SHORT},
+  {"fail-early",               ARG_BOOL,     'f', 'a'},
+  {"fail-with-body",           ARG_BOOL,     'f', 'd'},
+  {"false-start",              ARG_BOOL,     'E', 'r'},
+  {"form",                     ARG_STRING,   'F', OPT_SHORT},
+  {"form-escape",              ARG_BOOL,     '$', 'l'},
+  {"form-string",              ARG_STRING,   'F', 's'},
+  {"ftp-account",              ARG_STRING,   '$', 'm'},
+  {"ftp-alternative-to-user",  ARG_STRING,   '$', 'u'},
+  {"ftp-create-dirs",          ARG_BOOL,     '*', 'q'},
+  {"ftp-method",               ARG_STRING,   '$', 'r'},
+  {"ftp-pasv",                 ARG_BOOL,     '$', 'b'},
+  {"ftp-port",                 ARG_STRING,   'P', OPT_SHORT},
+  {"ftp-pret",                 ARG_BOOL,     '$', 'C'},
+  {"ftp-skip-pasv-ip",         ARG_BOOL,     '$', 'q'},
+  {"ftp-ssl",                  ARG_BOOL,     '$', 'a'},
+  {"ftp-ssl-ccc",              ARG_BOOL,     '$', 'y'},
+  {"ftp-ssl-ccc-mode",         ARG_STRING,   '$', 'j'},
+  {"ftp-ssl-control",          ARG_BOOL,     '$', 'x'},
+  {"ftp-ssl-reqd",             ARG_BOOL,     '$', 'v'},
+  {"get",                      ARG_BOOL,     'G', OPT_SHORT},
+  {"globoff",                  ARG_BOOL,     'g', OPT_SHORT},
+  {"happy-eyeballs-timeout-ms", ARG_STRING,  '$', '~'},
+  {"haproxy-clientip",         ARG_STRING,   '*', 'P'},
+  {"haproxy-protocol",         ARG_BOOL,     '*', 'X'},
+  {"head",                     ARG_BOOL,     'I', OPT_SHORT},
+  {"header",                   ARG_STRING,   'H', OPT_SHORT},
+  {"help",                     ARG_BOOL,     'h', OPT_SHORT},
+  {"hostpubmd5",               ARG_STRING,   'E', 'i'},
+  {"hostpubsha256",            ARG_STRING,   'E', 'F'},
+  {"hsts",                     ARG_STRING,   'b', 'b'},
+  {"http0.9",                  ARG_BOOL,     '0', '9'},
+  {"http1.0",                  ARG_NONE,     '0', OPT_SHORT},
+  {"http1.1",                  ARG_NONE,     '0', '1'},
+  {"http2",                    ARG_NONE,     '0', '2'},
+  {"http2-prior-knowledge",    ARG_NONE,     '0', '3'},
+  {"http3",                    ARG_NONE,     '0', '4'},
+  {"http3-only",               ARG_NONE,     '0', '5'},
+  {"ignore-content-length",    ARG_BOOL,     '$', 'p'},
+  {"include",                  ARG_BOOL,     'i', OPT_SHORT},
+  {"insecure",                 ARG_BOOL,     'k', OPT_SHORT},
+  {"interface",                ARG_STRING,   '*', 'w'},
+  {"ipfs-gateway",             ARG_STRING,   '*', 'S'},
+  {"ipv4",                     ARG_NONE,     '4', OPT_SHORT},
+  {"ipv6",                     ARG_NONE,     '6', OPT_SHORT},
+  {"json",                     ARG_STRING,   'd', 'f'},
+  {"junk-session-cookies",     ARG_BOOL,     'j', OPT_SHORT},
+  {"keepalive",                ARG_BOOL,     '$', '1'},
+  {"keepalive-time",           ARG_STRING,   '$', '3'},
+  {"key",                      ARG_FILENAME, 'E', 'c'},
+  {"key-type",                 ARG_STRING,   'E', 'd'},
+  {"krb",                      ARG_STRING,   '*', 'x'},
+  {"krb4",                     ARG_STRING,   '*', 'x'},
+  {"libcurl",                  ARG_STRING,   '$', 'z'},
+  {"limit-rate",               ARG_STRING,   '*', 'i'},
+  {"list-only",                ARG_BOOL,     'l', OPT_SHORT},
+  {"local-port",               ARG_STRING,   '$', 's'},
+  {"location",                 ARG_BOOL,     'L', OPT_SHORT},
+  {"location-trusted",         ARG_BOOL,     'L', 't'},
+  {"login-options",            ARG_STRING,   'E', '5'},
+  {"mail-auth",                ARG_STRING,   '$', 'H'},
+  {"mail-from",                ARG_STRING,   '$', 'A'},
+  {"mail-rcpt",                ARG_STRING,   '$', 'B'},
+  {"mail-rcpt-allowfails",     ARG_BOOL,     'f', 'c'},
+  {"manual",                   ARG_BOOL,     'M', OPT_SHORT},
+  {"max-filesize",             ARG_STRING,   '*', 'y'},
+  {"max-redirs",               ARG_STRING,   '*', 's'},
+  {"max-time",                 ARG_STRING,   'm', OPT_SHORT},
+  {"metalink",                 ARG_BOOL,     '$', 'J'},
+  {"negotiate",                ARG_BOOL,     '*', 'l'},
+  {"netrc",                    ARG_BOOL,     'n', OPT_SHORT},
+  {"netrc-file",               ARG_FILENAME, 'n', 'e'},
+  {"netrc-optional",           ARG_BOOL,     'n', 'o'},
+  {"next",                     ARG_NONE,     ':', OPT_SHORT},
+  {"noproxy",                  ARG_STRING,   '$', '5'},
+  {"npn",                      ARG_BOOL,     '*', 'G'},
+  {"ntlm",                     ARG_BOOL,     '*', 'm'},
+  {"ntlm-wb",                  ARG_BOOL,     '*', 'M'},
+  {"oauth2-bearer",            ARG_STRING,   '*', 'B'},
+  {"output",                   ARG_FILENAME, 'o', OPT_SHORT},
+  {"output-dir",               ARG_STRING,   'O', 'b'},
+  {"parallel",                 ARG_BOOL,     'Z', OPT_SHORT},
+  {"parallel-immediate",       ARG_BOOL,     'Z', 'c'},
+  {"parallel-max",             ARG_STRING,   'Z', 'b'},
+  {"pass",                     ARG_STRING,   'E', 'e'},
+  {"path-as-is",               ARG_BOOL,     '$', 'N'},
+  {"pinnedpubkey",             ARG_STRING,   'E', 'p'},
+  {"post301",                  ARG_BOOL,     '$', '0'},
+  {"post302",                  ARG_BOOL,     '$', '4'},
+  {"post303",                  ARG_BOOL,     '$', 'I'},
+  {"preproxy",                 ARG_STRING,   'x', 'a'},
+  {"progress-bar",             ARG_BOOL,     '#', OPT_SHORT},
+  {"progress-meter",           ARG_BOOL,     '#', 'm'},
+  {"proto",                    ARG_STRING,   '$', 'D'},
+  {"proto-default",            ARG_STRING,   '$', 'Q'},
+  {"proto-redir",              ARG_STRING,   '$', 'E'},
+  {"proxy",                    ARG_STRING,   'x', OPT_SHORT},
+  {"proxy-anyauth",            ARG_BOOL,     '$', 'n'},
+  {"proxy-basic",              ARG_BOOL,     '$', 'f'},
+  {"proxy-ca-native",          ARG_BOOL,     'E', 'H'},
+  {"proxy-cacert",             ARG_FILENAME, 'E', '6'},
+  {"proxy-capath",             ARG_FILENAME, 'E', '7'},
+  {"proxy-cert",               ARG_FILENAME, 'E', 'x'},
+  {"proxy-cert-type",          ARG_STRING,   'E', 'y'},
+  {"proxy-ciphers",            ARG_STRING,   'E', '2'},
+  {"proxy-crlfile",            ARG_FILENAME, 'E', '3'},
+  {"proxy-digest",             ARG_BOOL,     '$', 'e'},
+  {"proxy-header",             ARG_STRING,   'H', 'p'},
+  {"proxy-http2",              ARG_BOOL,     '0', 'a'},
+  {"proxy-insecure",           ARG_BOOL,     'E', '8'},
+  {"proxy-key",                ARG_FILENAME, 'E', 'z'},
+  {"proxy-key-type",           ARG_STRING,   'E', '0'},
+  {"proxy-negotiate",          ARG_BOOL,     '$', 'k'},
+  {"proxy-ntlm",               ARG_BOOL,     '*', 't'},
+  {"proxy-pass",               ARG_STRING,   'E', '1'},
+  {"proxy-pinnedpubkey",       ARG_STRING,   'E', 'P'},
+  {"proxy-service-name",       ARG_STRING,   '$', 'O'},
+  {"proxy-ssl-allow-beast",    ARG_BOOL,     'E', '4'},
+  {"proxy-ssl-auto-client-cert", ARG_BOOL,   'E', 'O'},
+  {"proxy-tls13-ciphers",      ARG_STRING,   '1', 'B'},
+  {"proxy-tlsauthtype",        ARG_STRING,   'E', 'w'},
+  {"proxy-tlspassword",        ARG_STRING,   'E', 'v'},
+  {"proxy-tlsuser",            ARG_STRING,   'E', 'u'},
+  {"proxy-tlsv1",              ARG_NONE,     'E', '9'},
+  {"proxy-user",               ARG_STRING,   'U', OPT_SHORT},
+  {"proxy1.0",                 ARG_STRING,   '$', '8'},
+  {"proxytunnel",              ARG_BOOL,     'p', OPT_SHORT},
+  {"pubkey",                   ARG_STRING,   'E', 'h'},
+  {"quote",                    ARG_STRING,   'Q', OPT_SHORT},
+  {"random-file",              ARG_FILENAME, '*', 'a'},
+  {"range",                    ARG_STRING,   'r', OPT_SHORT},
+  {"rate",                     ARG_STRING,   '*', 'I'},
+  {"raw",                      ARG_BOOL,     '$', '#'},
+  {"referer",                  ARG_STRING,   'e', OPT_SHORT},
+  {"remote-header-name",       ARG_BOOL,     'J', OPT_SHORT},
+  {"remote-name",              ARG_BOOL,     'O', OPT_SHORT},
+  {"remote-name-all",          ARG_BOOL,     'O', 'a'},
+  {"remote-time",              ARG_BOOL,     'R', OPT_SHORT},
+  {"remove-on-error",          ARG_BOOL,     'f', 'e'},
+  {"request",                  ARG_STRING,   'X', OPT_SHORT},
+  {"request-target",           ARG_STRING,   'G', 'a'},
+  {"resolve",                  ARG_STRING,   '$', 'F'},
+  {"retry",                    ARG_STRING,   '$', 'g'},
+  {"retry-all-errors",         ARG_BOOL,     '$', '!'},
+  {"retry-connrefused",        ARG_BOOL,     '$', 'V'},
+  {"retry-delay",              ARG_STRING,   '$', 'h'},
+  {"retry-max-time",           ARG_STRING,   '$', 'i'},
+  {"sasl-authzid",             ARG_STRING,   '$', '6'},
+  {"sasl-ir",                  ARG_BOOL,     '$', 'K'},
+  {"service-name",             ARG_STRING,   '$', 'P'},
+  {"sessionid",                ARG_BOOL,     '$', 'w'},
+  {"show-error",               ARG_BOOL,     'S', OPT_SHORT},
+  {"silent",                   ARG_BOOL,     's', OPT_SHORT},
+  {"socks4",                   ARG_STRING,   '$', 't'},
+  {"socks4a",                  ARG_STRING,   '$', 'T'},
+  {"socks5",                   ARG_STRING,   '$', 'c'},
+  {"socks5-basic",             ARG_BOOL,     'E', 'A'},
+  {"socks5-gssapi",            ARG_BOOL,     'E', 'B'},
+  {"socks5-gssapi-nec",        ARG_BOOL,     '$', '7'},
+  {"socks5-gssapi-service",    ARG_STRING,   '$', 'O'},
+  {"socks5-hostname",          ARG_STRING,   '$', '2'},
+  {"speed-limit",              ARG_STRING,   'Y', OPT_SHORT},
+  {"speed-time",               ARG_STRING,   'y', OPT_SHORT},
+  {"ssl",                      ARG_BOOL,     '$', 'a'},
+  {"ssl-allow-beast",          ARG_BOOL,     'E', 'n'},
+  {"ssl-auto-client-cert",     ARG_BOOL,     'E', 'o'},
+  {"ssl-no-revoke",            ARG_BOOL,     'E', 's'},
+  {"ssl-reqd",                 ARG_BOOL,     '$', 'v'},
+  {"ssl-revoke-best-effort",   ARG_BOOL,     'E', 'S'},
+  {"sslv2",                    ARG_NONE,     '2', OPT_SHORT},
+  {"sslv3",                    ARG_NONE,     '3', OPT_SHORT},
+  {"stderr",                   ARG_FILENAME, '*', 'v'},
+  {"styled-output",            ARG_BOOL,     'f', 'b'},
+  {"suppress-connect-headers", ARG_BOOL,     '$', 'Y'},
+  {"tcp-fastopen",             ARG_BOOL,     'E', 't'},
+  {"tcp-nodelay",              ARG_BOOL,     '$', 'd'},
+  {"telnet-option",            ARG_STRING,   't', OPT_SHORT},
+  {"test-event",               ARG_BOOL,     '$', 'L'},
+  {"tftp-blksize",             ARG_STRING,   '$', '9'},
+  {"tftp-no-options",          ARG_BOOL,     '$', 'S'},
+  {"time-cond",                ARG_STRING,   'z', OPT_SHORT},
+  {"tls-max",                  ARG_STRING,   '$', 'X'},
+  {"tls13-ciphers",            ARG_STRING,   '1', 'A'},
+  {"tlsauthtype",              ARG_STRING,   'E', 'm'},
+  {"tlspassword",              ARG_STRING,   'E', 'l'},
+  {"tlsuser",                  ARG_STRING,   'E', 'k'},
+  {"tlsv1",                    ARG_NONE,     '1', OPT_SHORT},
+  {"tlsv1.0",                  ARG_NONE,     '1', '0'},
+  {"tlsv1.1",                  ARG_NONE,     '1', '1'},
+  {"tlsv1.2",                  ARG_NONE,     '1', '2'},
+  {"tlsv1.3",                  ARG_NONE,     '1', '3'},
+  {"tr-encoding",              ARG_BOOL,     '*', 'J'},
+  {"trace",                    ARG_FILENAME, '*', 'g'},
+  {"trace-ascii",              ARG_FILENAME, '*', 'h'},
+  {"trace-config",             ARG_STRING,   '$', '&'},
+  {"trace-ids",                ARG_BOOL,     '$', '%'},
+  {"trace-time",               ARG_BOOL,     '$', 'o'},
+  {"unix-socket",              ARG_FILENAME, '$', 'M'},
+  {"upload-file",              ARG_FILENAME, 'T', OPT_SHORT},
+  {"url",                      ARG_STRING,   '*', '@'},
+  {"url-query",                ARG_STRING,   'd', 'g'},
+  {"use-ascii",                ARG_BOOL,     'B', OPT_SHORT},
+  {"user",                     ARG_STRING,   'u', OPT_SHORT},
+  {"user-agent",               ARG_STRING,   'A', OPT_SHORT},
+  {"variable",                 ARG_STRING,   ':', 'a'},
+  {"verbose",                  ARG_BOOL,     'v', OPT_SHORT},
+  {"version",                  ARG_BOOL,     'V', OPT_SHORT},
 #ifdef USE_WATT32
-  {"wdebug",                   ARG_BOOL,     "*p"},
+  {"wdebug",                   ARG_BOOL,     '*', 'p'},
 #endif
-  {"write-out",                ARG_STRING,   "w",},
-  {"xattr",                    ARG_BOOL,     "*~"},
+  {"write-out",                ARG_STRING,   'w', OPT_SHORT},
+  {"xattr",                    ARG_BOOL,     '*', '~'},
 };
 
 /* Split the argument of -E to 'certname' and 'passphrase' separated by colon.
@@ -743,8 +744,8 @@ static const struct LongShort *single(char letter)
   if(!singles_done) {
     unsigned int j;
     for(j = 0; j < sizeof(aliases)/sizeof(aliases[0]); j++) {
-      if(!aliases[j].letter[1]) {
-        unsigned char l = aliases[j].letter[0];
+      if(aliases[j].subletter == OPT_SHORT) {
+        unsigned char l = aliases[j].letter;
         singles[l - ' '] = &aliases[j];
       }
     }
@@ -883,8 +884,6 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
                             struct GlobalConfig *global,
                             struct OperationConfig *config)
 {
-  char letter;
-  char subletter = '\0'; /* subletters can only occur on long options */
   int rc;
   const char *parse = NULL;
   time_t now;
@@ -936,7 +935,6 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
                 sizeof(aliases[0]), findarg);
     if(a) {
       longopt = TRUE;
-      parse = a->letter;
     }
     else {
       err = PARAM_OPTION_UNKNOWN;
@@ -975,23 +973,18 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
 
   do {
     /* we can loop here if we have multiple single-letters */
+    char letter;
+    char subletter;
 
-    if(!longopt) {
-      letter = (char)*parse;
-      subletter = '\0';
-    }
-    else {
-      letter = parse[0];
-      subletter = parse[1];
-    }
-
-    if(!a) {
-      a = single(letter);
+    if(!longopt && !a) {
+      a = single(*parse);
       if(!a) {
         err = PARAM_OPTION_UNKNOWN;
         break;
       }
     }
+    letter = a->letter;
+    subletter = a->subletter;
 
     if(a->desc >= ARG_STRING) {
       /* this option requires an extra parameter */
@@ -1641,18 +1634,18 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     case ONEOPT('#', 'm'): /* --progress-meter */
       global->noprogress = !toggle;
       break;
-    case ONEOPT('#', '\0'): /* --progress-bar */
+    case ONEOPT('#', OPT_SHORT): /* --progress-bar */
       global->progressmode = toggle ? CURL_PROGRESS_BAR : CURL_PROGRESS_STATS;
       break;
 
     case ONEOPT(':', 'a'): /* --variable */
       err = setvariable(global, nextarg);
       break;
-    case ONEOPT(':', '\0'): /* --next */
+    case ONEOPT(':', OPT_SHORT): /* --next */
       err = PARAM_NEXT_OPERATION;
       break;
 
-    case ONEOPT('0', '\0'): /* --http1.0 */
+    case ONEOPT('0', OPT_SHORT): /* --http1.0 */
       /* HTTP version 1.0 */
       sethttpver(global, config, CURL_HTTP_VERSION_1_0);
       break;
@@ -1697,7 +1690,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         return PARAM_LIBCURL_DOESNT_SUPPORT;
       config->proxyver = CURLPROXY_HTTPS2;
       break;
-    case ONEOPT('1', '\0'): /* --tlsv1 */
+    case ONEOPT('1', OPT_SHORT): /* --tlsv1 */
       config->ssl_version = CURL_SSLVERSION_TLSv1;
       break;
     case ONEOPT('1', '0'): /* --tlsv1.0 */
@@ -1718,23 +1711,23 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     case ONEOPT('1', 'B'): /* --proxy-tls13-ciphers */
       err = getstr(&config->proxy_cipher13_list, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('2', '\0'): /* --sslv2 */
+    case ONEOPT('2', OPT_SHORT): /* --sslv2 */
       warnf(global, "Ignores instruction to use SSLv2");
       break;
-    case ONEOPT('3', '\0'): /* --sslv3 */
+    case ONEOPT('3', OPT_SHORT): /* --sslv3 */
       warnf(global, "Ignores instruction to use SSLv3");
       break;
-    case ONEOPT('4', '\0'): /* --ipv4 */
+    case ONEOPT('4', OPT_SHORT): /* --ipv4 */
       config->ip_version = CURL_IPRESOLVE_V4;
       break;
-    case ONEOPT('6', '\0'): /* --ipv6 */
+    case ONEOPT('6', OPT_SHORT): /* --ipv6 */
       config->ip_version = CURL_IPRESOLVE_V6;
       break;
-    case ONEOPT('a', '\0'): /* --append */
+    case ONEOPT('a', OPT_SHORT): /* --append */
       /* This makes the FTP sessions use APPE instead of STOR */
       config->ftp_append = toggle;
       break;
-    case ONEOPT('A', '\0'): /* --user-agent */
+    case ONEOPT('A', OPT_SHORT): /* --user-agent */
       err = getstr(&config->useragent, nextarg, ALLOW_BLANK);
       break;
     case ONEOPT('b', 'a'): /* --alt-svc */
@@ -1749,7 +1742,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       else
         err = getstr(&config->hsts, nextarg, ALLOW_BLANK);
       break;
-    case ONEOPT('b', '\0'): /* --cookie */
+    case ONEOPT('b', OPT_SHORT): /* --cookie */
       if(nextarg[0] == '@') {
         nextarg++;
       }
@@ -1761,13 +1754,13 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       /* We have a cookie file to read from! */
       err = add2list(&config->cookiefiles, nextarg);
       break;
-    case ONEOPT('B', '\0'): /* --use-ascii */
+    case ONEOPT('B', OPT_SHORT): /* --use-ascii */
       config->use_ascii = toggle;
       break;
-    case ONEOPT('c', '\0'): /* --cookie-jar */
+    case ONEOPT('c', OPT_SHORT): /* --cookie-jar */
       err = getstr(&config->cookiejar, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('C', '\0'): /* --continue-at */
+    case ONEOPT('C', OPT_SHORT): /* --continue-at */
       /* This makes us continue an ftp transfer at given position */
       if(strcmp(nextarg, "-")) {
         err = str2offset(&config->resume_from, nextarg);
@@ -1781,7 +1774,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       config->use_resume = TRUE;
       break;
-    case ONEOPT('d', '\0'): /* --data */
+    case ONEOPT('d', OPT_SHORT): /* --data */
     case ONEOPT('d', 'a'):  /* --data-ascii */
     case ONEOPT('d', 'b'):  /* --data-binary */
     case ONEOPT('d', 'e'):  /* --data-urlencode */
@@ -1792,10 +1785,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     case ONEOPT('d', 'g'):  /* --url-query */
       err = url_query(nextarg, global, config);
       break;
-    case ONEOPT('D', '\0'): /* --dump-header */
+    case ONEOPT('D', OPT_SHORT): /* --dump-header */
       err = getstr(&config->headerfile, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('e', '\0'): { /* --referer */
+    case ONEOPT('e', OPT_SHORT): { /* --referer */
       char *ptr = strstr(nextarg, ";auto");
       if(ptr) {
         /* Automatic referer requested, this may be combined with a
@@ -1809,7 +1802,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       err = getstr(&config->referer, ptr, ALLOW_BLANK);
     }
       break;
-    case ONEOPT('E', '\0'): /* --cert */
+    case ONEOPT('E', OPT_SHORT): /* --cert */
       cleanarg(clearthis);
       GetFileAndPassword(nextarg, &config->cert, &config->key_passwd);
       break;
@@ -2062,7 +2055,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     case ONEOPT('f', 'e'): /* --remove-on-error */
       config->rm_partial = toggle;
       break;
-    case ONEOPT('f', '\0'): /* --fail */
+    case ONEOPT('f', OPT_SHORT): /* --fail */
       config->failonerror = toggle;
       if(config->failonerror && config->failwithbody) {
         errorf(config->global, "You must select either --fail or "
@@ -2071,7 +2064,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       break;
 
-    case ONEOPT('F', '\0'): /* --form */
+    case ONEOPT('F', OPT_SHORT): /* --form */
     case ONEOPT('F', 's'): /* --form-string */
       /* "form data" simulation, this is a little advanced so lets do our best
          to sort this out slowly and carefully */
@@ -2087,11 +2080,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_BAD_USE;
       break;
 
-    case ONEOPT('g', '\0'): /* --globoff */
+    case ONEOPT('g', OPT_SHORT): /* --globoff */
       config->globoff = toggle;
       break;
 
-    case ONEOPT('G', '\0'): /* --get */
+    case ONEOPT('G', OPT_SHORT): /* --get */
       config->use_httpget = toggle;
       break;
 
@@ -2099,7 +2092,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       err = getstr(&config->request_target, nextarg, DENY_BLANK);
       break;
 
-    case ONEOPT('h', '\0'): /* --help */
+    case ONEOPT('h', OPT_SHORT): /* --help */
       if(toggle) {
         if(*nextarg) {
           global->help_category = strdup(nextarg);
@@ -2112,7 +2105,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       /* we now actually support --no-help too! */
       break;
-    case ONEOPT('H', '\0'): /* --header */
+    case ONEOPT('H', OPT_SHORT): /* --header */
     case ONEOPT('H', 'p'): /* --proxy-header */
       /* A custom header to append to a list */
       if(nextarg[0] == '@') {
@@ -2156,14 +2149,14 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           err = add2list(&config->headers, nextarg);
       }
       break;
-    case ONEOPT('i', '\0'): /* --include */
+    case ONEOPT('i', OPT_SHORT): /* --include */
       config->show_headers = toggle; /* show the headers as well in the
                                         general output stream */
       break;
-    case ONEOPT('j', '\0'): /* --junk-session-cookies */
+    case ONEOPT('j', OPT_SHORT): /* --junk-session-cookies */
       config->cookiesession = toggle;
       break;
-    case ONEOPT('I', '\0'): /* --head */
+    case ONEOPT('I', OPT_SHORT): /* --head */
       config->no_body = toggle;
       config->show_headers = toggle;
       if(SetHTTPrequest(config,
@@ -2171,25 +2164,25 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
                         &config->httpreq))
         err = PARAM_BAD_USE;
       break;
-    case ONEOPT('J', '\0'): /* --remote-header-name */
+    case ONEOPT('J', OPT_SHORT): /* --remote-header-name */
       config->content_disposition = toggle;
       break;
-    case ONEOPT('k', '\0'): /* --insecure */
+    case ONEOPT('k', OPT_SHORT): /* --insecure */
       config->insecure_ok = toggle;
       break;
     case ONEOPT('k', 'd'): /* --doh-insecure */
       config->doh_insecure_ok = toggle;
       break;
-    case ONEOPT('K', '\0'): /* --config */
+    case ONEOPT('K', OPT_SHORT): /* --config */
       if(parseconfig(nextarg, global)) {
         errorf(global, "cannot read config from '%s'", nextarg);
         err = PARAM_READ_ERROR;
       }
       break;
-    case ONEOPT('l', '\0'): /* --list-only */
+    case ONEOPT('l', OPT_SHORT): /* --list-only */
       config->dirlistonly = toggle; /* only list the names of the FTP dir */
       break;
-    case ONEOPT('L', '\0'): /* --location */
+    case ONEOPT('L', OPT_SHORT): /* --location */
     case ONEOPT('L', 't'): /* --location-trusted */
       config->followlocation = toggle; /* Follow Location: HTTP headers */
       if(subletter == 't')
@@ -2197,11 +2190,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
          * locations, even when hostname changed */
         config->unrestricted_auth = toggle;
       break;
-    case ONEOPT('m', '\0'): /* --max-time */
+    case ONEOPT('m', OPT_SHORT): /* --max-time */
       /* specified max time */
       err = secs2ms(&config->timeout_ms, nextarg);
       break;
-    case ONEOPT('M', '\0'): /* --manual */
+    case ONEOPT('M', OPT_SHORT): /* --manual */
       if(toggle) { /* --no-manual shows no manual... */
 #ifndef USE_MANUAL
         warnf(global,
@@ -2217,13 +2210,13 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     case ONEOPT('n', 'e'): /* --netrc-file */
       err = getstr(&config->netrc_file, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('n', '\0'): /* --netrc */
+    case ONEOPT('n', OPT_SHORT): /* --netrc */
       /* pick info from .netrc, if this is used for http, curl will
          automatically enforce user+password with the request */
       config->netrc = toggle;
       break;
 
-    case ONEOPT('N', '\0'): /* --buffer */
+    case ONEOPT('N', OPT_SHORT): /* --buffer */
       /* disable the output I/O buffering. note that the option is called
          --buffer but is mostly used in the negative form: --no-buffer */
       config->nobuffer = longopt ? !toggle : TRUE;
@@ -2241,8 +2234,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       config->file_clobber_mode = toggle ? CLOBBER_ALWAYS : CLOBBER_NEVER;
       break;
 
-    case ONEOPT('o', '\0'): /* --output */
-    case ONEOPT('O', '\0'): /* --remote-name */
+    case ONEOPT('o', OPT_SHORT): /* --output */
+    case ONEOPT('O', OPT_SHORT): /* --remote-name */
       /* output file */
       if(!config->url_out)
         config->url_out = config->url_list;
@@ -2284,7 +2277,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       url->flags |= GETOUT_OUTFILE;
       break;
-    case ONEOPT('P', '\0'): /* --ftp-port */
+    case ONEOPT('P', OPT_SHORT): /* --ftp-port */
       /* This makes the FTP sessions use PORT instead of PASV */
       /* use <eth0> or <192.168.10.10> style addresses. Anything except
          this will make us try to get the "default" address.
@@ -2292,16 +2285,16 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       */
       err = getstr(&config->ftpport, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('p', '\0'): /* --proxytunnel */
+    case ONEOPT('p', OPT_SHORT): /* --proxytunnel */
       /* proxy tunnel for non-http protocols */
       config->proxytunnel = toggle;
       break;
 
-    case ONEOPT('q', '\0'): /* --disable */
+    case ONEOPT('q', OPT_SHORT): /* --disable */
       /* if used first, already taken care of, we do it like this so we don't
          cause an error! */
       break;
-    case ONEOPT('Q', '\0'): /* --quote */
+    case ONEOPT('Q', OPT_SHORT): /* --quote */
       /* QUOTE command to send to FTP server */
       switch(nextarg[0]) {
       case '-':
@@ -2319,7 +2312,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       }
       break;
-    case ONEOPT('r', '\0'): /* --range */
+    case ONEOPT('r', OPT_SHORT): /* --range */
       /* Specifying a range WITHOUT A DASH will create an illegal HTTP range
          (and won't actually be range by definition). The man page previously
          claimed that to be a good way, why this code is added to work-around
@@ -2346,7 +2339,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       else {
         /* byte range requested */
         const char *tmp_range = nextarg;
-        while(*tmp_range != '\0') {
+        while(*tmp_range != OPT_SHORT) {
           if(!ISDIGIT(*tmp_range) && *tmp_range != '-' && *tmp_range != ',') {
             warnf(global, "Invalid character is found in given range. "
                   "A specified range MUST have only digits in "
@@ -2359,21 +2352,21 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = getstr(&config->range, nextarg, DENY_BLANK);
       }
       break;
-    case ONEOPT('R', '\0'): /* --remote-time */
+    case ONEOPT('R', OPT_SHORT): /* --remote-time */
       /* use remote file's time */
       config->remote_time = toggle;
       break;
-    case ONEOPT('s', '\0'): /* --silent */
+    case ONEOPT('s', OPT_SHORT): /* --silent */
       global->silent = toggle;
       break;
-    case ONEOPT('S', '\0'): /* --show-error */
+    case ONEOPT('S', OPT_SHORT): /* --show-error */
       global->showerror = toggle;
       break;
-    case ONEOPT('t', '\0'): /* --telnet-option */
+    case ONEOPT('t', OPT_SHORT): /* --telnet-option */
       /* Telnet options */
       err = add2list(&config->telnet_options, nextarg);
       break;
-    case ONEOPT('T', '\0'): /* --upload */
+    case ONEOPT('T', OPT_SHORT): /* --upload */
       /* we are uploading */
       if(!config->url_ul)
         config->url_ul = config->url_list;
@@ -2406,17 +2399,17 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = getstr(&url->infile, nextarg, DENY_BLANK);
       }
       break;
-    case ONEOPT('u', '\0'): /* --user */
+    case ONEOPT('u', OPT_SHORT): /* --user */
       /* user:password  */
       err = getstr(&config->userpwd, nextarg, ALLOW_BLANK);
       cleanarg(clearthis);
       break;
-    case ONEOPT('U', '\0'): /* --proxy-user */
+    case ONEOPT('U', OPT_SHORT): /* --proxy-user */
       /* Proxy user:password  */
       err = getstr(&config->proxyuserpwd, nextarg, ALLOW_BLANK);
       cleanarg(clearthis);
       break;
-    case ONEOPT('v', '\0'): /* --verbose */
+    case ONEOPT('v', OPT_SHORT): /* --verbose */
       if(toggle) {
         /* the '%' thing here will cause the trace get sent to stderr */
         Curl_safefree(global->trace_dump);
@@ -2434,12 +2427,12 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         /* verbose is disabled here */
         global->tracetype = TRACE_NONE;
       break;
-    case ONEOPT('V', '\0'): /* --version */
+    case ONEOPT('V', OPT_SHORT): /* --version */
       if(toggle)    /* --no-version yields no output! */
         err = PARAM_VERSION_INFO_REQUESTED;
       break;
 
-    case ONEOPT('w', '\0'): /* --write-out */
+    case ONEOPT('w', OPT_SHORT): /* --write-out */
       /* get the output string */
       if('@' == *nextarg) {
         /* the data begins with a '@' letter, it means that a file name
@@ -2475,30 +2468,30 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     case ONEOPT('x', 'a'): /* --preproxy */
       err = getstr(&config->preproxy, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('x', '\0'): /* --proxy */
+    case ONEOPT('x', OPT_SHORT): /* --proxy */
       /* --proxy */
       err = getstr(&config->proxy, nextarg, ALLOW_BLANK);
       if(config->proxyver != CURLPROXY_HTTPS2)
         config->proxyver = CURLPROXY_HTTP;
       break;
 
-    case ONEOPT('X', '\0'): /* --request */
+    case ONEOPT('X', OPT_SHORT): /* --request */
       /* set custom request */
       err = getstr(&config->customrequest, nextarg, DENY_BLANK);
       break;
-    case ONEOPT('y', '\0'): /* --speed-limit */
+    case ONEOPT('y', OPT_SHORT): /* --speed-limit */
       /* low speed time */
       err = str2unum(&config->low_speed_time, nextarg);
       if(!err && !config->low_speed_limit)
         config->low_speed_limit = 1;
       break;
-    case ONEOPT('Y', '\0'): /* --speed-time */
+    case ONEOPT('Y', OPT_SHORT): /* --speed-time */
       /* low speed limit */
       err = str2unum(&config->low_speed_limit, nextarg);
       if(!err && !config->low_speed_time)
         config->low_speed_time = 30;
       break;
-    case ONEOPT('Z', '\0'): /* --parallel */
+    case ONEOPT('Z', OPT_SHORT): /* --parallel */
       global->parallel = toggle;
       break;
     case ONEOPT('Z', 'b'): {  /* --parallel-max */
@@ -2518,7 +2511,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       global->parallel_connect = toggle;
       break;
 
-    case ONEOPT('z', '\0'): /* --time-cond */
+    case ONEOPT('z', OPT_SHORT): /* --time-cond */
       switch(*nextarg) {
       case '+':
         nextarg++;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -372,7 +372,6 @@ void single_transfer_cleanup(struct OperationConfig *config)
       state->urls = NULL;
     }
     Curl_safefree(state->outfiles);
-    Curl_safefree(state->httpgetfields);
     Curl_safefree(state->uploadfile);
     if(state->inglob) {
       /* Free list of globbed upload files */

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -88,8 +88,6 @@ ParameterError file2string(char **bufp, FILE *file)
   return PARAM_OK;
 }
 
-#define MAX_FILE2MEMORY (1024*1024*1024) /* big enough ? */
-
 ParameterError file2memory(char **bufp, size_t *size, FILE *file)
 {
   if(file) {

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -30,6 +30,8 @@ struct getout *new_getout(struct OperationConfig *config);
 
 ParameterError file2string(char **bufp, FILE *file);
 
+#define MAX_FILE2MEMORY (1024*1024*1024) /* big enough ? */
+
 ParameterError file2memory(char **bufp, size_t *size, FILE *file);
 
 ParameterError str2num(long *val, const char *str);

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -660,7 +660,7 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *global,
       if(escape) {
         curl_off_t len = ZERO_TERMINATED;
         if(tag == CURLOPT_POSTFIELDS)
-          len = config->postfieldsize;
+          len = curlx_dyn_len(&config->postdata);
         escaped = c_escape(value, len);
         NULL_CHECK(escaped);
         CODE2("curl_easy_setopt(hnd, %s, \"%s\");", name, escaped);

--- a/tests/data/test285
+++ b/tests/data/test285
@@ -16,7 +16,7 @@ tftp
 TFTP send
 </name>
 <command>
--T %LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT// --connect-time 549
+-T %LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT// --connect-timeout 549
 </command>
 <file name="%LOGDIR/test%TESTNUMBER.txt">
 a chunk of

--- a/tests/data/test498
+++ b/tests/data/test498
@@ -35,7 +35,7 @@ http
 Reject too large HTTP response headers on endless redirects
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER --max-redir 400 --location
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --max-redirs 400 --location
 </command>
 </client>
 

--- a/tests/test1139.pl
+++ b/tests/test1139.pl
@@ -190,8 +190,8 @@ while(<$r>) {
         $list=1;
     }
     elsif($list) {
-        if( /^  \{(\"[^,]*\").*((\"[^ ]*)\")/) {
-            my ($l, $s)=($1, $2);
+        if( /^  \{(\"[^,]*\").*\'(.)\', (.*)\}/) {
+            my ($l, $s, $rd)=($1, $2, $3);
             my $sh;
             my $lo;
             my $title;
@@ -203,9 +203,9 @@ while(<$r>) {
                 $lo = $1;
                 $title="--$lo";
             }
-            if($s =~ /\"(.)\"/) {
+            if($rd eq "OPT_SHORT") {
                 # a short option
-                $sh = $1;
+                $sh = $s;
                 $title="-$sh, $title";
             }
             push @getparam, $title;

--- a/tests/test1139.pl
+++ b/tests/test1139.pl
@@ -181,18 +181,23 @@ open($r, "<", "$root/src/tool_getparam.c") ||
 my $list;
 my @getparam; # store all parsed parameters
 
+my $prevlong = "";
+my $no = 0;
 while(<$r>) {
+    $no++;
     chomp;
-    my $l= $_;
     if(/struct LongShort aliases/) {
         $list=1;
     }
     elsif($list) {
-        if( /^  \{([^,]*), *([^ ]*)/) {
-            my ($s, $l)=($1, $2);
+        if( /^  \{(\"[^,]*\").*((\"[^ ]*)\")/) {
+            my ($l, $s)=($1, $2);
             my $sh;
             my $lo;
             my $title;
+            if(($l cmp $prevlong) < 0) {
+                print STDERR "tool_getparam.c:$no: '$l' is NOT placed in alpha-order\n";
+            }
             if($l =~ /\"(.*)\"/) {
                 # long option
                 $lo = $1;
@@ -205,6 +210,7 @@ while(<$r>) {
             }
             push @getparam, $title;
             $opts{$title} |= 1;
+            $prevlong = $l;
         }
     }
 }

--- a/tests/test1139.pl
+++ b/tests/test1139.pl
@@ -203,7 +203,7 @@ while(<$r>) {
                 $lo = $1;
                 $title="--$lo";
             }
-            if($rd eq "OPT_SHORT") {
+            if($s ne " ") {
                 # a short option
                 $sh = $s;
                 $title="-$sh, $title";


### PR DESCRIPTION
- the option names are now alpha sorted and lookup is a lot faster

- use case sensitive matching. It was previously case insensitive, but that was not documented nor tested.

- remove "partial match" feature. It was not documented, not tested and was always fragile as existing use could break when we add a new option

- lookup short options via a table