### PR TITLE
Revert "CI: run Circle macOS builds on x86 for now"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,42 +54,42 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --without-ssl CFLAGS='-Wno-vla -mmacosx-version-min=10.9' CPPFLAGS="-I$(brew --prefix libpsl)/include" LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   configure-macos-debug:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --enable-debug CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --without-ssl --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   configure-macos-libssh2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --with-libssh2=/opt/homebrew/opt/libssh2 --enable-debug CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --without-ssl --with-libssh2=/opt/homebrew/opt/libssh2 --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   configure-macos-libssh-c-ares:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-ares --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-ares --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   configure-macos-libssh:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || tail -1000 config.log
 
   configure-macos-c-ares:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --enable-ares --enable-debug CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --without-ssl --enable-ares --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   configure-macos-http-only:
     steps:
@@ -103,35 +103,35 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-secure-transport CFLAGS='-Wno-vla -mmacosx-version-min=10.8'
+            ./configure --enable-warnings --enable-websockets --with-secure-transport CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.8' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   configure-macos-openssl-http2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   configure-macos-libressl-http2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix libressl)/lib/pkgconfig" CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix libressl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   configure-macos-torture:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   configure-macos-torture-ftp:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CFLAGS='-Wno-vla -mmacosx-version-min=10.9'
+            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata"
 
   install-cares:
     steps:
@@ -157,7 +157,7 @@ commands:
       - run:
           command: |
             # Drop libressl as long as we're not trying to build it
-            echo libtool autoconf automake pkg-config nghttp2 libssh2 openssl libssh c-ares libpsl | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+            echo libtool autoconf automake pkg-config nghttp2 libssh2 openssl libssh c-ares libpsl icu4c | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
             while [ $? -eq 0 ]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
             sudo python3 -m pip install impacket
 
@@ -220,8 +220,8 @@ commands:
 
   build-macos:
     steps:
-      - run: make -j7 V=1
-      - run: make -j7 V=1 examples
+      - run: make -j5 V=1
+      - run: make -j5 V=1 examples
 
   test:
     steps:
@@ -229,7 +229,7 @@ commands:
 
   test-macos:
     steps:
-      - run: make -j7 V=1 test-ci
+      - run: make -j5 V=1 test-ci
 
   test-torture:
     steps:
@@ -237,7 +237,8 @@ commands:
 
   test-torture-ftp:
     steps:
-      - run: make -j5 V=1 test-ci TFLAGS="-n -t --shallow=20 FTP"
+      # Test 250 takes too long, causing Circle CI to kill the job
+      - run: make -j5 V=1 test-ci TFLAGS="-n -t --shallow=20 FTP !250 !251"
 
 executors:
   ubuntu:
@@ -324,15 +325,10 @@ jobs:
       - build
       - test
 
-  # TODO: All builds with "macos.x86.medium.gen2" must be changed to
-  # "macos.m1.medium.gen1" in January 2024 because the former will be removed
-  # (the names should also be changed from macos-x86-* to macos-arm-*).  We
-  # want the M1 (ARM) machines anyway, for platform diversity.
-  # See https://circleci.com/docs/configuration-reference/#macos-execution-environment
-  macos-x86-normal:
+  macos-arm-normal:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -340,10 +336,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-debug:
+  macos-arm-debug:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -351,10 +347,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-libssh2:
+  macos-arm-libssh2:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -362,10 +358,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-libssh-c-ares:
+  macos-arm-libssh-c-ares:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -373,10 +369,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-libssh:
+  macos-arm-libssh:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -384,10 +380,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-c-ares:
+  macos-arm-c-ares:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -395,10 +391,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-http-only:
+  macos-arm-http-only:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -406,10 +402,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-http-securetransport-http2:
+  macos-arm-http-securetransport-http2:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -417,10 +413,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-http-openssl-http2:
+  macos-arm-http-openssl-http2:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -428,10 +424,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-http-libressl-http2:
+  macos-arm-http-libressl-http2:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -439,10 +435,10 @@ jobs:
       - build-macos
       - test-macos
 
-  macos-x86-http-torture:
+  macos-arm-http-torture:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -450,10 +446,10 @@ jobs:
       - build-macos
       - test-torture
 
-  macos-x86-http-torture-ftp:
+  macos-arm-http-torture-ftp:
     macos:
       xcode: 15.0.0
-    resource_class: macos.x86.medium.gen2
+    resource_class: macos.m1.medium.gen1
     steps:
       - checkout
       - install-deps-brew
@@ -494,52 +490,52 @@ workflows:
     jobs:
       - arm-cares
 
-  macos-x86-normal:
+  macos-arm-normal:
     jobs:
-      - macos-x86-normal
+      - macos-arm-normal
 
-  macos-x86-debug:
+  macos-arm-debug:
     jobs:
-      - macos-x86-debug
+      - macos-arm-debug
 
-  macos-x86-libssh2:
+  macos-arm-libssh2:
     jobs:
-      - macos-x86-libssh2
+      - macos-arm-libssh2
 
-  macos-x86-libssh-c-ares:
+  macos-arm-libssh-c-ares:
     jobs:
-      - macos-x86-libssh-c-ares
+      - macos-arm-libssh-c-ares
 
-  macos-x86-libssh:
+  macos-arm-libssh:
     jobs:
-      - macos-x86-libssh
+      - macos-arm-libssh
 
-  macos-x86-c-ares:
+  macos-arm-c-ares:
     jobs:
-      - macos-x86-c-ares
+      - macos-arm-c-ares
 
-  macos-x86-http-only:
+  macos-arm-http-only:
     jobs:
-      - macos-x86-http-only
+      - macos-arm-http-only
 
-  macos-x86-http-securetransport-http2:
+  macos-arm-http-securetransport-http2:
     jobs:
-      - macos-x86-http-securetransport-http2
+      - macos-arm-http-securetransport-http2
 
-  macos-x86-http-openssl-http2:
+  macos-arm-http-openssl-http2:
     jobs:
-      - macos-x86-http-openssl-http2
+      - macos-arm-http-openssl-http2
 
   # There are problem linking with LibreSSL on the CI boxes that prevent this
   # from working.
-  # macos-x86-http-libressl-http2:
+  # macos-arm-http-libressl-http2:
   #   jobs:
-  #     - macos-x86-http-libressl-http2
+  #     - macos-arm-http-libressl-http2
 
-  macos-x86-http-torture:
+  macos-arm-http-torture:
     jobs:
-      - macos-x86-http-torture
+      - macos-arm-http-torture
 
-  macos-x86-http-torture-ftp:
+  macos-arm-http-torture-ftp:
     jobs:
-      - macos-x86-http-torture-ftp
+      - macos-arm-http-torture-ftp


### PR DESCRIPTION
This reverts commit 2683de3078eadc86d9b182e7417f4ee75a247e2c.
ARM resources are now available in Circle CI, so run these builds on ARM
again.

Follow-up to 2683de30

Closes #12635