### PR TITLE
adjust_pollset improvements

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1240,8 +1240,11 @@ static void cf_socket_adjust_pollset(struct Curl_cfilter *cf,
 {
   struct cf_socket_ctx *ctx = cf->ctx;
 
-  if(!cf->connected && ctx->sock != CURL_SOCKET_BAD) {
-    Curl_pollset_set_out_only(data, ps, ctx->sock);
+  if(ctx->sock != CURL_SOCKET_BAD) {
+    if(!cf->connected)
+      Curl_pollset_set_out_only(data, ps, ctx->sock);
+    else if(!ctx->active)
+      Curl_pollset_add_in(data, ps, ctx->sock);
     CURL_TRC_CF(data, cf, "adjust_pollset -> %d socks", ps->num);
   }
 }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1240,11 +1240,8 @@ static void cf_socket_adjust_pollset(struct Curl_cfilter *cf,
 {
   struct cf_socket_ctx *ctx = cf->ctx;
 
-  if(ctx->sock != CURL_SOCKET_BAD) {
-    if(!cf->connected)
-      Curl_pollset_set_out_only(data, ps, ctx->sock);
-    else if(CURL_WANT_RECV(data))
-      Curl_pollset_add_in(data, ps, ctx->sock);
+  if(!cf->connected && ctx->sock != CURL_SOCKET_BAD) {
+    Curl_pollset_set_out_only(data, ps, ctx->sock);
     CURL_TRC_CF(data, cf, "adjust_pollset -> %d socks", ps->num);
   }
 }

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -760,21 +760,7 @@ static void ps_add(struct Curl_easy *data, struct easy_pollset *ps,
 void Curl_pollset_add_socks(struct Curl_easy *data,
                             struct easy_pollset *ps,
                             int (*get_socks_cb)(struct Curl_easy *data,
-                                                struct connectdata *conn,
                                                 curl_socket_t *socks))
-{
-  curl_socket_t socks[MAX_SOCKSPEREASYHANDLE];
-  int bitmap;
-
-  DEBUGASSERT(data->conn);
-  bitmap = get_socks_cb(data, data->conn, socks);
-  ps_add(data, ps, bitmap, socks);
-}
-
-void Curl_pollset_add_socks2(struct Curl_easy *data,
-                             struct easy_pollset *ps,
-                             int (*get_socks_cb)(struct Curl_easy *data,
-                                                 curl_socket_t *socks))
 {
   curl_socket_t socks[MAX_SOCKSPEREASYHANDLE];
   int bitmap;

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -530,12 +530,7 @@ void Curl_pollset_set(struct Curl_easy *data,
 void Curl_pollset_add_socks(struct Curl_easy *data,
                             struct easy_pollset *ps,
                             int (*get_socks_cb)(struct Curl_easy *data,
-                                                struct connectdata *conn,
                                                 curl_socket_t *socks));
-void Curl_pollset_add_socks2(struct Curl_easy *data,
-                             struct easy_pollset *ps,
-                             int (*get_socks_cb)(struct Curl_easy *data,
-                                                 curl_socket_t *socks));
 
 /**
  * Check if the pollset, as is, wants to read and/or write regarding

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2331,12 +2331,16 @@ static void cf_h2_adjust_pollset(struct Curl_cfilter *cf,
                                  struct easy_pollset *ps)
 {
   struct cf_h2_ctx *ctx = cf->ctx;
-  bool want_recv = CURL_WANT_RECV(data);
-  bool want_send = CURL_WANT_SEND(data);
+  curl_socket_t sock;
+  bool want_recv, want_send;
 
-  if(ctx->h2 && (want_recv || want_send)) {
+  if(!ctx->h2)
+    return;
+
+  sock = Curl_conn_cf_get_socket(cf, data);
+  Curl_pollset_check(data, ps, sock, &want_recv, &want_send);
+  if(want_recv || want_send) {
     struct stream_ctx *stream = H2_STREAM_CTX(data);
-    curl_socket_t sock = Curl_conn_cf_get_socket(cf, data);
     struct cf_call_data save;
     bool c_exhaust, s_exhaust;
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1220,52 +1220,6 @@ out:
   return result;
 }
 
-/*
- * Curl_single_getsock() gets called by the multi interface code when the app
- * has requested to get the sockets for the current connection. This function
- * will then be called once for every connection that the multi interface
- * keeps track of. This function will only be called for connections that are
- * in the proper state to have this information available.
- */
-int Curl_single_getsock(struct Curl_easy *data,
-                        struct connectdata *conn,
-                        curl_socket_t *sock)
-{
-  int bitmap = GETSOCK_BLANK;
-  unsigned sockindex = 0;
-
-  if(conn->handler->perform_getsock)
-    return conn->handler->perform_getsock(data, conn, sock);
-
-  /* don't include HOLD and PAUSE connections */
-  if((data->req.keepon & KEEP_RECVBITS) == KEEP_RECV) {
-
-    DEBUGASSERT(conn->sockfd != CURL_SOCKET_BAD);
-
-    bitmap |= GETSOCK_READSOCK(sockindex);
-    sock[sockindex] = conn->sockfd;
-  }
-
-  /* don't include HOLD and PAUSE connections */
-  if((data->req.keepon & KEEP_SENDBITS) == KEEP_SEND) {
-    if((conn->sockfd != conn->writesockfd) ||
-       bitmap == GETSOCK_BLANK) {
-      /* only if they are not the same socket and we have a readable
-         one, we increase index */
-      if(bitmap != GETSOCK_BLANK)
-        sockindex++; /* increase index if we need two entries */
-
-      DEBUGASSERT(conn->writesockfd != CURL_SOCKET_BAD);
-
-      sock[sockindex] = conn->writesockfd;
-    }
-
-    bitmap |= GETSOCK_WRITESOCK(sockindex);
-  }
-
-  return bitmap;
-}
-
 /* Curl_init_CONNECT() gets called each time the handle switches to CONNECT
    which means this gets called once for each subsequent redirect etc */
 void Curl_init_CONNECT(struct Curl_easy *data)

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -47,8 +47,6 @@ CURLcode Curl_follow(struct Curl_easy *data, char *newurl,
                      followtype type);
 CURLcode Curl_readwrite(struct connectdata *conn,
                         struct Curl_easy *data, bool *done);
-int Curl_single_getsock(struct Curl_easy *data,
-                        struct connectdata *conn, curl_socket_t *socks);
 CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
                              size_t *nreadp);
 CURLcode Curl_retry_request(struct Curl_easy *data, char **url);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -583,7 +583,7 @@ struct hostname {
   (((data)->req.keepon & KEEP_SENDBITS) == KEEP_SEND)
 /* transfer receive is not on PAUSE or HOLD */
 #define CURL_WANT_RECV(data) \
-  (!((data)->req.keepon & (KEEP_RECV_PAUSE|KEEP_RECV_HOLD)))
+  (((data)->req.keepon & KEEP_RECVBITS) == KEEP_RECV)
 
 #if defined(CURLRES_ASYNCH) || !defined(CURL_DISABLE_DOH)
 #define USE_CURL_ASYNC

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1157,10 +1157,13 @@ static void cf_ngtcp2_adjust_pollset(struct Curl_cfilter *cf,
                                       struct easy_pollset *ps)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
-  bool want_recv = CURL_WANT_RECV(data);
-  bool want_send = CURL_WANT_SEND(data);
+  bool want_recv, want_send;
 
-  if(ctx->qconn && (want_recv || want_send)) {
+  if(!ctx->qconn)
+    return;
+
+  Curl_pollset_check(data, ps, ctx->q.sockfd, &want_recv, &want_send);
+  if(want_recv || want_send) {
     struct h3_stream_ctx *stream = H3_STREAM_CTX(data);
     struct cf_call_data save;
     bool c_exhaust, s_exhaust;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1180,10 +1180,13 @@ static void cf_quiche_adjust_pollset(struct Curl_cfilter *cf,
                                      struct easy_pollset *ps)
 {
   struct cf_quiche_ctx *ctx = cf->ctx;
-  bool want_recv = CURL_WANT_RECV(data);
-  bool want_send = CURL_WANT_SEND(data);
+  bool want_recv, want_send;
 
-  if(ctx->qconn && (want_recv || want_send)) {
+  if(!ctx->qconn)
+    return;
+
+  Curl_pollset_check(data, ps, ctx->q.sockfd, &want_recv, &want_send);
+  if(want_recv || want_send) {
     struct stream_ctx *stream = H3_STREAM_CTX(data);
     bool c_exhaust, s_exhaust;
 


### PR DESCRIPTION
There is the possibility in the  existing implementation that for HTTP/2 the pollset adjustment could still lead to cpu busy loops. If HTTP/2 flow control blocks sending, the h2 filter would replace a POLLOUT in the pollset adjustment with a POLLIN. But the underlying cf-socket filter would still add a POLLOUT. A writeable socket would then lead to sends that are blocked in the HTTP/2 filters.

Fix:
- let `multi_getsock()` initialize the pollset in what the transfer state requires in regards to SEND/RECV
- change connection filters `adjust_pollset()` implementation to react on the presence of POLLIN/-OUT in the pollset and no longer check CURL_WANT_SEND/CURL_WANT_RECV
- cf-socket will no longer add POLLIN on its own
- http2 and http/3 filters will only do adjustments if the passed pollset wants to POLLIN/OUT for the transfer on the socket. This is similar to the HTTP/2 proxy filter and works in stacked filters.

