### PR TITLE
tool_getparam: stop supporting `@filename` style for --cookie

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1988,16 +1988,15 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = getstr(&config->hsts, nextarg, ALLOW_BLANK);
       break;
     case C_COOKIE: /* --cookie */
-      if(nextarg[0] == '@') {
-        nextarg++;
-      }
-      else if(strchr(nextarg, '=')) {
+      if(strchr(nextarg, '=')) {
         /* A cookie string must have a =-letter */
         err = add2list(&config->cookies, nextarg);
         break;
       }
-      /* We have a cookie file to read from! */
-      err = add2list(&config->cookiefiles, nextarg);
+      else {
+        /* We have a cookie file to read from! */
+        err = add2list(&config->cookiefiles, nextarg);
+      }
       break;
     case C_USE_ASCII: /* --use-ascii */
       config->use_ascii = toggle;


### PR DESCRIPTION
The `@filename` style was never documented for --cookie <data|filename> but prior to this change curl would accept it anyway and always treat a @ prefixed string as a filename.

That's a problem if the string also contains a = sign because then it is documented to be interpreted as a cookie string and not a filename.

Example:

`--cookie @foo=bar`

Before: Interpreted as load cookies from filename foo=bar.

After: Interpreted as cookie `@foo=bar` (name `@foo` and value `bar`).

Other curl options with a data/filename option-value use the `@filename` to distinguish filenames which is probably how this happened. The --cookie option has never been documented that way.

Ref: https://curl.se/docs/manpage.html#-b

Closes #xxxx