### PR TITLE
connect: remove margin from eyeballer alloc

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -389,7 +389,7 @@ static CURLcode eyeballer_new(struct eyeballer **pballer,
   struct eyeballer *baller;
 
   *pballer = NULL;
-  baller = calloc(1, sizeof(*baller) + 1000);
+  baller = calloc(1, sizeof(*baller));
   if(!baller)
     return CURLE_OUT_OF_MEMORY;
 


### PR DESCRIPTION
Presumably leftovers from debugging