### PR TITLE
ftp: only consider entry path if it has a length

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2892,7 +2892,8 @@ static CURLcode ftp_statemachine(struct Curl_easy *data,
               }
               else {
                 /* end of path */
-                entry_extracted = TRUE;
+                if(Curl_dyn_len(&out))
+                  entry_extracted = TRUE;
                 break; /* get out of this loop */
               }
             }


### PR DESCRIPTION
Follow-up from 8edcfedc1a144f438bd1cdf814a0016cb

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=65631

Avoids a NULL pointer deref.