### PR TITLE
configure: make libpsl detection failure cause an error

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -169,59 +169,59 @@ stages:
               container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
               container_cmd: C:\msys64\usr\bin\sh
               prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
-              configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32     --prefix=/mingw32 --enable-debug --enable-werror --with-libssh2 --with-openssl
+              configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32     --prefix=/mingw32 --enable-debug --enable-werror --with-libssh2 --with-openssl --without-libpsl
               tests: "~571"
             mingw64_openssl:
               name: 64-bit OpenSSL/libssh2
               container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
               container_cmd: C:\msys64\usr\bin\sh
               prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
-              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --with-libssh2 --with-openssl
+              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --with-libssh2 --with-openssl --without-libpsl
               tests: "~571"
             mingw64_libssh:
               name: 64-bit OpenSSL/libssh
               container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
               container_cmd: C:\msys64\usr\bin\sh
               prepare: pacman -S --needed --noconfirm --noprogressbar libssh-devel mingw-w64-x86_64-libssh
-              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --with-libssh --with-openssl
+              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --with-libssh --with-openssl --without-libpsl
               tests: "~571 ~614"
             mingw32:
               name: 32-bit w/o zlib
               container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
               container_cmd: C:\msys64\usr\bin\sh
-              configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32     --prefix=/mingw32 --enable-debug --enable-werror --without-zlib --without-ssl
+              configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32     --prefix=/mingw32 --enable-debug --enable-werror --without-zlib --without-ssl --without-libpsl
               tests: "!203 !1143"
             mingw64:
               name: 64-bit w/o zlib
               container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
               container_cmd: C:\msys64\usr\bin\sh
-              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --without-zlib --without-ssl
+              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --without-zlib --without-ssl --without-libpsl
               tests: "!203 !1143"
             mingw32_schannel:
               name: 32-bit Schannel/SSPI/WinIDN/libssh2
               container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
               container_cmd: C:\msys64\usr\bin\sh
               prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-i686-libssh2
-              configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32     --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
+              configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32     --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --without-libpsl
               tests: "~571"
             mingw64_schannel:
               name: 64-bit Schannel/SSPI/WinIDN/libssh2
               container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
               container_cmd: C:\msys64\usr\bin\sh
               prepare: pacman -S --needed --noconfirm --noprogressbar libssh2-devel mingw-w64-x86_64-libssh2
-              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2
+              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --with-libssh2 --without-libpsl
               tests: "~571"
             mingw32_schannel_nozlib:
               name: 32-bit Schannel/SSPI/WinIDN w/o zlib
               container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw32:ltsc2019
               container_cmd: C:\msys64\usr\bin\sh
-              configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32     --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --without-zlib
+              configure: --host=i686-w64-mingw32 --build=i686-w64-mingw32     --prefix=/mingw32 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --without-zlib --without-libpsl
               tests: "!203 !1143"
             mingw64_schannel_nozlib:
               name: 64-bit Schannel/SSPI/WinIDN w/o zlib
               container_img: ghcr.io/mback2k/curl-docker-winbuildenv/msys2-mingw64:ltsc2019
               container_cmd: C:\msys64\usr\bin\sh
-              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --without-zlib
+              configure: --host=x86_64-w64-mingw32 --build=x86_64-w64-mingw32 --prefix=/mingw64 --enable-debug --enable-werror --enable-sspi --with-schannel --with-winidn --without-zlib --without-libpsl
               tests: "!203 !1143"
         container:
           image: $(container_img)

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -100,7 +100,7 @@ stages:
               configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl
               tests: -n -t --shallow=25 !FTP
         steps:
-          - script: sudo apt-get update && sudo apt-get install -y stunnel4 python3-impacket libzstd-dev libbrotli-dev $(install)
+          - script: sudo apt-get update && sudo apt-get install -y stunnel4 python3-impacket libzstd-dev libbrotli-dev libpsl-dev $(install)
             displayName: 'apt install'
             retryCountOnTaskFailure: 3
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ jobs:
     executor: ubuntu
     steps:
       - checkout
+      - install-deps
       - configure
       - build
       - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ commands:
     steps:
       - run:
           command: |
-            sudo apt-get update && sudo apt-get install -y libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev python3-pip
+            sudo apt-get update && sudo apt-get install -y libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev python3-pip libpsl-dev
             sudo python3 -m pip install impacket
 
   install-deps-brew:
@@ -157,7 +157,7 @@ commands:
       - run:
           command: |
             # Drop libressl as long as we're not trying to build it
-            echo libtool autoconf automake pkg-config nghttp2 libssh2 openssl libssh c-ares | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+            echo libtool autoconf automake pkg-config nghttp2 libssh2 openssl libssh c-ares libpsl | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
             while [ $? -eq 0 ]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
             sudo python3 -m pip install impacket
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,7 @@ jobs:
     executor: ubuntu
     steps:
       - checkout
+      - install-deps
       - install-cares
       - configure-cares
       - build
@@ -293,6 +294,7 @@ jobs:
     executor: ubuntu
     steps:
       - checkout
+      - install-deps
       - install-libssh
       - configure-libssh
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,6 +304,7 @@ jobs:
     resource_class: arm.medium
     steps:
       - checkout
+      - install-deps
       - configure
       - build
       - test
@@ -314,6 +315,7 @@ jobs:
     resource_class: arm.medium
     steps:
       - checkout
+      - install-deps
       - install-cares
       - configure-cares-debug
       - build

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -54,7 +54,7 @@ freebsd_task:
 
   pkginstall_script:
     - pkg update -f
-    - pkg install -y autoconf automake libtool pkgconf brotli openldap26-client heimdal libpsl libssh2 libidn2 librtmp libnghttp2 nghttp2 stunnel py39-openssl py39-impacket py39-cryptography
+    - pkg install -y autoconf automake libtool pkgconf brotli openldap26-client heimdal libpsl libssh2 libidn2 librtmp libnghttp2 nghttp2 stunnel py39-openssl py39-impacket py39-cryptography libpsl
     - pkg delete -y curl
   configure_script:
     - autoreconf -fi

--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - run: |
           sudo apt-get update --yes
-          sudo apt-get install --yes libtool autoconf automake pkg-config stunnel4
+          sudo apt-get install --yes libtool autoconf automake pkg-config stunnel4 libpsl-dev
           # ensure we don't pick up openssl in this build
           sudo apt remove --yes libssl-dev
           sudo python3 -m pip install impacket

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -35,7 +35,7 @@ jobs:
       - name: run configure --with-openssl
         run: |
            autoreconf -fi
-           ./configure --with-openssl
+           ./configure --with-openssl --without-libpsl
 
       - name: run cmake
         run: |

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -30,7 +30,7 @@ jobs:
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure --without-ssl
+      - run: ./configure --without-ssl --without-libpsl
         name: 'configure'
 
       - run: make V=1 && make V=1 clean
@@ -48,7 +48,7 @@ jobs:
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
-          ./configure --prefix=$HOME/temp --without-ssl
+          ./configure --prefix=$HOME/temp --without-ssl --without-libpsl
           make
           make test-ci
           make install
@@ -73,7 +73,7 @@ jobs:
           touch curl-99.98.97/docs/{cmdline-opts,libcurl}/Makefile.inc
           mkdir build
           pushd build
-          ../curl-99.98.97/configure --without-ssl
+          ../curl-99.98.97/configure --without-ssl --without-libpsl
           make
           make test-ci
           popd
@@ -96,7 +96,7 @@ jobs:
           pushd curl-99.98.97
           mkdir build
           pushd build
-          ../configure --without-ssl --enable-debug "--prefix=${PWD}/pkg"
+          ../configure --without-ssl --enable-debug "--prefix=${PWD}/pkg" --without-libpsl
           make -j3
           make -j3 test-ci
           make -j3 install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -154,7 +154,7 @@ jobs:
             singleuse: --unit
 
           - name: rustls
-            install_steps: rust rustls pytest valgrind
+            install_steps: rust rustls pytest valgrind libpsl-dev
             configure: --with-rustls=$HOME/rustls --enable-debug
             singleuse: --unit
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -142,7 +142,7 @@ jobs:
             configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
-      - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+      - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
 
       # Run this command with retries because of spurious failures seen

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -117,7 +117,7 @@ jobs:
             configure: --enable-debug --with-secure-transport --enable-websockets
             macosx-version-min: 10.8
           - name: gcc SecureTransport
-            configure: CC=gcc-12 --enable-debug --with-secure-transport --enable-websockets
+            configure: CC=gcc-12 --enable-debug --with-secure-transport --enable-websockets --without-libpsl
             macosx-version-min: 10.8
           - name: OpenSSL http2
             install: nghttp2 openssl

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - run: |
           sudo apt-get update
-          sudo apt-get install libtool autoconf automake pkg-config stunnel4 ${{ matrix.build.install }}
+          sudo apt-get install libtool autoconf automake pkg-config stunnel4 libpsl-dev ${{ matrix.build.install }}
           sudo python3 -m pip install impacket
         name: 'install prereqs and impacket'
 

--- a/configure.ac
+++ b/configure.ac
@@ -2054,17 +2054,16 @@ dnl **********************************************************************
 
 AC_ARG_WITH(libpsl,
            AS_HELP_STRING([--without-libpsl],
-           [disable support for libpsl cookie checking]),
+           [disable support for libpsl]),
            with_libpsl=$withval,
            with_libpsl=yes)
+curl_psl_msg="no      (libpsl disabled)"
 if test $with_libpsl != "no"; then
   AC_SEARCH_LIBS(psl_builtin, psl,
     [curl_psl_msg="enabled";
      AC_DEFINE([USE_LIBPSL], [1], [PSL support enabled])
      ],
-    [curl_psl_msg="no      (libpsl not found)";
-     AC_MSG_WARN([libpsl was not found])
-     ]
+    [AC_MSG_ERROR([libpsl was not found]) ]
   )
 fi
 AM_CONDITIONAL([USE_LIBPSL], [test "$curl_psl_msg" = "enabled"])


### PR DESCRIPTION
To force users to explictily disable it if they really don't want it used and make it harder to accidentally miss it.