### PR TITLE
slist.c: make get_list_last be O(1)

### DIFF
--- a/lib/slist.c
+++ b/lib/slist.c
@@ -37,16 +37,6 @@ struct curl_slist_head {
    struct curl_slist *tail;
 };
 
-/* returns last node in linked list */
-static struct curl_slist *slist_get_last(struct curl_slist *list)
-{
-  /* if caller passed us a NULL, return now */
-  if(!list)
-    return NULL;
-  else
-    return ((struct curl_slist_head*)list)->tail;
-}
-
 /*
  * Curl_slist_append_nodup() appends a string to the linked list. Rather than
  * copying the string in dynamic storage, it takes its ownership. The string
@@ -80,7 +70,7 @@ struct curl_slist *Curl_slist_append_nodup(struct curl_slist *list, char *data)
     return new_item;
   }
 
-  last = slist_get_last(list);
+  last = ((struct curl_slist_head*)list)->tail;
   last->next = new_item;
   ((struct curl_slist_head*)list)->tail = new_item;
   return list;

--- a/lib/slist.c
+++ b/lib/slist.c
@@ -53,11 +53,11 @@ struct curl_slist *Curl_slist_append_nodup(struct curl_slist *list, char *data)
 
   DEBUGASSERT(data);
 
-  if(list) {
+  if(list)
     new_item = malloc(sizeof(struct curl_slist));
-  } else {
+  else
     new_item = malloc(sizeof(struct curl_slist_head));
-  }
+
   if(!new_item)
     return NULL;
 

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -185,7 +185,7 @@ int main(int argc, char *argv[])
   CURLMsg *msg;
   CURLSH *share;
   CURLU *cu;
-  struct curl_slist resolve;
+  struct curl_slist* resolve = curl_slist_append(NULL, "");
   char resolve_buf[1024];
   int msgs_in_queue;
   int add_more, waits, ongoing = 0;
@@ -215,10 +215,9 @@ int main(int argc, char *argv[])
     exit(1);
   }
 
-   memset(&resolve, 0, sizeof(resolve));
    curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1,
                   "%s:%s:127.0.0.1", host, port);
-  curl_slist_append(&resolve, resolve_buf);
+  curl_slist_append(resolve, resolve_buf);
 
   multi = curl_multi_init();
   if(!multi) {
@@ -234,7 +233,7 @@ int main(int argc, char *argv[])
   curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
 
 
-  add_transfer(multi, share, &resolve, url);
+  add_transfer(multi, share, resolve, url);
   ++ongoing;
   add_more = 6;
   waits = 3;
@@ -260,7 +259,7 @@ int main(int argc, char *argv[])
     }
     else {
       while(add_more) {
-        add_transfer(multi, share, &resolve, url);
+        add_transfer(multi, share, resolve, url);
         ++ongoing;
         --add_more;
       }


### PR DESCRIPTION
Time complexity of `get_list_last` is O(n),  `Curl_slist_append_nodup` and `curl_slist_append` are also O(n).

This PR add an extra field `tail` on list head node, and update `tail` on each append, thus time complexity is O(1).

All existing tests passed, no new tests are required!