### PR TITLE
pollset adjust, init with FIRSTSOCKET during connect

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -998,9 +998,11 @@ static int connecting_getsock(struct Curl_easy *data, curl_socket_t *socks)
 {
   struct connectdata *conn = data->conn;
   (void)socks;
-  if(conn && conn->sockfd != CURL_SOCKET_BAD) {
+  /* Not using `conn->sockfd` as `Curl_setup_transfer()` initializes
+   * that *after* the connect. */
+  if(conn && conn->sock[FIRSTSOCKET] != CURL_SOCKET_BAD) {
     /* Default is to wait to something from the server */
-    socks[0] = conn->sockfd;
+    socks[0] = conn->sock[FIRSTSOCKET];
     return GETSOCK_READSOCK(0);
   }
   return GETSOCK_BLANK;


### PR DESCRIPTION
- `conn->sockfd` is set by `Curl_setup_transfer()`, but that is called *after* the connection has been established
- use `conn->sock[FIRSTSOCKET]` instead