### PR TITLE
multi: fix incorrect multi_easy logic

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1305,7 +1305,7 @@ static int conn_upkeep(struct Curl_easy *data,
     conn->handler->connection_check(data, conn, CONNCHECK_KEEPALIVE);
   }
   else {
-    /* Do the generic action on the FIRSTSOCKE filter chain */
+    /* Do the generic action on the FIRSTSOCKET filter chain */
     Curl_conn_keep_alive(data, conn, FIRSTSOCKET);
   }
   Curl_detach_connection(data);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3706,19 +3706,13 @@ static void process_pending_handles(struct Curl_multi *multi)
 
 void Curl_set_in_callback(struct Curl_easy *data, bool value)
 {
-  /* might get called when there is no data pointer! */
-  if(data) {
-    if(data->multi_easy)
-      data->multi_easy->in_callback = value;
-    else if(data->multi)
-      data->multi->in_callback = value;
-  }
+  if(data && data->multi)
+    data->multi->in_callback = value;
 }
 
-bool Curl_is_in_callback(struct Curl_easy *easy)
+bool Curl_is_in_callback(struct Curl_easy *data)
 {
-  return ((easy->multi && easy->multi->in_callback) ||
-          (easy->multi_easy && easy->multi_easy->in_callback));
+  return (data && data->multi && data->multi->in_callback);
 }
 
 unsigned int Curl_multi_max_concurrent_streams(struct Curl_multi *multi)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3362,7 +3362,7 @@ static bool cached_x509_store_different(
 static X509_STORE *get_cached_x509_store(struct Curl_cfilter *cf,
                                          const struct Curl_easy *data)
 {
-  struct Curl_multi *multi = data->multi_easy ? data->multi_easy : data->multi;
+  struct Curl_multi *multi = data->multi;
   X509_STORE *store = NULL;
 
   DEBUGASSERT(multi);
@@ -3382,7 +3382,7 @@ static void set_cached_x509_store(struct Curl_cfilter *cf,
                                   X509_STORE *store)
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct Curl_multi *multi = data->multi_easy ? data->multi_easy : data->multi;
+  struct Curl_multi *multi = data->multi;
   struct multi_ssl_backend_data *mbackend;
 
   DEBUGASSERT(multi);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2749,7 +2749,7 @@ HCERTSTORE Curl_schannel_get_cached_cert_store(struct Curl_cfilter *cf,
                                                const struct Curl_easy *data)
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct Curl_multi *multi = data->multi_easy ? data->multi_easy : data->multi;
+  struct Curl_multi *multi = data->multi;
   const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
   struct schannel_multi_ssl_backend_data *mbackend;
   const struct ssl_general_config *cfg = &data->set.general_ssl;
@@ -2818,7 +2818,7 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
                                          HCERTSTORE cert_store)
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
-  struct Curl_multi *multi = data->multi_easy ? data->multi_easy : data->multi;
+  struct Curl_multi *multi = data->multi;
   const struct curl_blob *ca_info_blob = conn_config->ca_info_blob;
   struct schannel_multi_ssl_backend_data *mbackend;
   unsigned char *CAinfo_blob_digest = NULL;


### PR DESCRIPTION
- Use data->multi and not data->multi_easy to refer to the active multi.

Prior to this change there were a few places that incorrectly treated data->multi_easy, if != NULL, as the easy handle's active multi.

Background:

The easy handle's active multi is always data->multi. It points to either the user-created multi (if the multi interface is used) or the internally created multi (if the easy interface is used). The internally created multi is always data->multi_easy and is retained until the easy handle is cleaned up.

If an easy handle is used with the easy interface and then the multi interface, data->multi_easy and data->multi will both exist and be different.

Closes #xxxxx

---

There's one other that I didn't change because I'm not sure if the multi_easy should be checked before multi:

https://github.com/curl/curl/blob/8edcfedc1a144f438bd1cdf814a0016cbe678aaf/lib/connect.c#L270-L287

Some logic is used to get what should be the connection cache used by the easy handle. I notice `data->state.conn_cache` is not checked so I assume it's not available at that point.
