### PR TITLE
headers: make sure the trailing newline is not stored

### DIFF
--- a/lib/headers.c
+++ b/lib/headers.c
@@ -295,7 +295,7 @@ CURLcode Curl_headers_push(struct Curl_easy *data, const char *header,
     if(!end)
       return CURLE_BAD_FUNCTION_ARGUMENT;
   }
-  hlen = end - header + 1;
+  hlen = end - header;
 
   if((header[0] == ' ') || (header[0] == '\t')) {
     if(data->state.prevhead)

--- a/tests/data/test1940
+++ b/tests/data/test1940
@@ -19,6 +19,8 @@ Content-Length: 0
 Set-Cookie: onecookie=data;
 Set-Cookie: secondcookie=2data;
 Set-Cookie: cookie3=data3;
+Blank:
+Blank2:
 Location: /%TESTNUMBER0002
 
 </data>
@@ -57,6 +59,8 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 - Set-Cookie == secondcookie=2data; (1/3)
 - Set-Cookie == cookie3=data3; (2/3)
  Fold == is folding a line
+ Blank == 
+ Blank2 == 
 </stdout>
 </verify>
 </testcase>

--- a/tests/data/test421
+++ b/tests/data/test421
@@ -71,7 +71,7 @@ Accept: */*
 "access-control-allow-methods":["GET, POST, PUT, DELETE, OPTIONS"],
 "access-control-max-age":["1728000"],
 "access-control-allow-headers":["Authorization, Content-Type, AuthorizationOauth, X-EARLY-ACCESS"],
-"access-control-expose-headers":["\r"],
+"access-control-expose-headers":[""],
 "etag":["W/\"2678f9ab2ba550d164e7cc014aefd31e\""],
 "cache-control":["max-age=0, private, must-revalidate"],
 "x-request-id":["375b343b3d2ecf9b442c0daf00fc4a9a"],

--- a/tests/libtest/lib1940.c
+++ b/tests/libtest/lib1940.c
@@ -35,6 +35,8 @@ static const char *show[]={
   "set-cookie",
   "silly-thing",
   "fold",
+  "blank",
+  "Blank2",
   NULL
 };
 


### PR DESCRIPTION
extended test1940 to verify blank header fields too

Bug: https://curl.se/mail/lib-2024-01/0019.html
Reported-by: Dmitry Karpov