### PR TITLE
easy: fix curl_easy_upkeep for shared connection caches

### DIFF
--- a/docs/libcurl/curl_easy_upkeep.md
+++ b/docs/libcurl/curl_easy_upkeep.md
@@ -39,6 +39,10 @@ This function must be explicitly called in order to perform the upkeep work.
 The connection upkeep interval is set with
 CURLOPT_UPKEEP_INTERVAL_MS(3).
 
+If you call this function on an easy handle that uses a shared connection cache
+then upkeep is performed on the connections in that cache even if those
+connections were never used by the easy handle. (Added in 8.10.0)
+
 # %PROTOCOLS%
 
 # EXAMPLE

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1334,13 +1334,30 @@ static CURLcode upkeep(struct conncache *conn_cache, void *data)
  */
 CURLcode curl_easy_upkeep(struct Curl_easy *data)
 {
+  struct conncache *conn_cache;
+
   /* Verify that we got an easy handle we can work with. */
   if(!GOOD_EASY_HANDLE(data))
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
-  if(data->multi_easy) {
+  if(Curl_is_in_callback(data))
+    return CURLE_RECURSIVE_API_CALL;
+
+  /* determine the connection cache that will next be used by the easy handle.
+     if the easy handle is currently in a multi then data->state.conn_cache
+     should point to the in-use cache. */
+  DEBUGASSERT(!data->multi || data->state.conn_cache);
+  conn_cache =
+    data->state.conn_cache ?
+      data->state.conn_cache :
+    (data->share && (data->share->specifier & (1<< CURL_LOCK_DATA_CONNECT))) ?
+      &data->share->conn_cache :
+    data->multi_easy ?
+      &data->multi_easy->conn_cache : NULL;
+
+  if(conn_cache) {
     /* Use the common function to keep connections alive. */
-    return upkeep(&data->multi_easy->conn_cache, data);
+    return upkeep(conn_cache, data);
   }
   else {
     /* No connections, so just return success */


### PR DESCRIPTION
- Predict which connection cache is or will be used by the easy handle and perform connection upkeep on that cache.

This change allows curl_easy_upkeep to be effective on easy handles that are using a shared connection cache, either from a user created shared connection cache or a user created multi which has its own shared connection cache.

Prior to this change curl_easy_upkeep would upkeep the connection cache for the easy handle only if that cache was from the multi owned by the easy handle (ie curl_easy_perform was previously called and there's a connection cache exclusive to the easy handle in
data->multi_easy->conn_cache).

Ref: https://curl.se/mail/lib-2024-01/0016.html

Closes #xxxx

---

It's probably a matter of perspective whether this is a bug or not. I didn't find anything to indicate that the function wasn't intended to work with shared connection caches.

Note this change will allow calling on an easy handle that is part of a user created multi, therefore a user of that interface might use this function and not expect it to block? It's unclear to me whether or not the function could actually block.

/cc @maxdymond