### PR TITLE
multi: fix odd total timer reset in file_do() while fetching file://

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -419,8 +419,6 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
 
   *done = TRUE; /* unconditionally */
 
-  Curl_pgrsStartNow(data);
-
   if(data->state.upload)
     return file_upload(data);
 


### PR DESCRIPTION
While working with timings with file:// urls, I've notices an issue: the total time interval is always less than the pre-transfer and the start transfer time intervals. The reason: `Curl_prgsStartNow()` is called twice: in `MSTATE_INIT` (properly) and in `MSTATE_DO` in `file_do()`, and `TIMER_STARTSINGLE` is set between those calls in `MSTATE_CONNECT`.
