### PR TITLE
configure: when enabling QUIC, check that TLS supports QUIC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2776,6 +2776,11 @@ esac
 
 curl_tcp2_msg="no      (--with-ngtcp2)"
 if test X"$want_tcp2" != Xno; then
+
+  if test "$QUIC_ENABLED" != "yes"; then
+    AC_MSG_ERROR([the detected TLS library does not support QUIC, making --with-ngtcp2 a no-no])
+  fi
+
   dnl backup the pre-ngtcp2 variables
   CLEANLDFLAGS="$LDFLAGS"
   CLEANCPPFLAGS="$CPPFLAGS"
@@ -3030,6 +3035,11 @@ esac
 
 curl_http3_msg="no      (--with-nghttp3)"
 if test X"$want_nghttp3" != Xno; then
+
+  if test "$NGTCP2_ENABLED" != "1"; then
+    AC_MSG_ERROR([--with-nghttp3 also requires --with-ntcp2])
+  fi
+
   dnl backup the pre-nghttp3 variables
   CLEANLDFLAGS="$LDFLAGS"
   CLEANCPPFLAGS="$CPPFLAGS"
@@ -3119,6 +3129,10 @@ case "$OPT_QUICHE" in
 esac
 
 if test X"$want_quiche" != Xno; then
+
+  if test "$QUIC_ENABLED" != "yes"; then
+    AC_MSG_ERROR([the detected TLS library does not support QUIC, making --with-quiche a no-no])
+  fi
 
   if test "$NGHTTP3_ENABLED" = 1; then
     AC_MSG_ERROR([--with-quiche and --with-ngtcp2 are mutually exclusive])
@@ -3217,6 +3231,10 @@ case "$OPT_MSH3" in
 esac
 
 if test X"$want_msh3" != Xno; then
+
+  if test "$QUIC_ENABLED" != "yes"; then
+    AC_MSG_ERROR([the detected TLS library does not support QUIC, making --with-quiche a no-no])
+  fi
 
   if test "$NGHTTP3_ENABLED" = 1; then
     AC_MSG_ERROR([--with-msh3 and --with-ngtcp2 are mutually exclusive])

--- a/configure.ac
+++ b/configure.ac
@@ -3232,8 +3232,14 @@ esac
 
 if test X"$want_msh3" != Xno; then
 
-  if test "$QUIC_ENABLED" != "yes"; then
-    AC_MSG_ERROR([the detected TLS library does not support QUIC, making --with-quiche a no-no])
+  dnl msh3 on non-Windows needs an OpenSSL with the QUIC API
+  if test "$curl_cv_native_windows" != "yes"; then
+    if test "$QUIC_ENABLED" != "yes"; then
+      AC_MSG_ERROR([the detected TLS library does not support QUIC, making --with-msh3 a no-no])
+    fi
+    if test "$OPENSSL_ENABLED" != "1"; then
+      AC_MSG_ERROR([msh3 requires OpenSSL])
+    fi
   fi
 
   if test "$NGHTTP3_ENABLED" = 1; then

--- a/m4/curl-gnutls.m4
+++ b/m4/curl-gnutls.m4
@@ -104,6 +104,7 @@ if test "x$OPT_GNUTLS" != xno; then
        GNUTLS_ENABLED=1
        USE_GNUTLS="yes"
        ssl_msg="GnuTLS"
+       QUIC_ENABLED=yes
        test gnutls != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
        ],
        [

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -328,6 +328,15 @@ if test "x$OPT_OPENSSL" != xno; then
     ])
   fi
 
+  dnl is this OpenSSL (fork) providing the original QUIC API?
+  AC_CHECK_FUNCS([SSL_set_quic_use_legacy_codepoint],
+                 [QUIC_ENABLED=yes])
+  if test "$QUIC_ENABLED" = "yes"; then
+    AC_MSG_NOTICE([OpenSSL fork speaks QUIC API])
+  else
+    AC_MSG_NOTICE([OpenSSL version does not speak QUIC API])
+  fi
+
   if test "$OPENSSL_ENABLED" = "1"; then
     if test -n "$LIB_OPENSSL"; then
        dnl when the ssl shared libs were found in a path that the run-time

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -107,6 +107,7 @@ if test "x$OPT_WOLFSSL" != xno; then
          WOLFSSL_ENABLED=1
          USE_WOLFSSL="yes"
          ssl_msg="WolfSSL"
+         QUIC_ENABLED=yes
          test wolfssl != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
        ],
        [


### PR DESCRIPTION
Most importantly perhaps is when using OpenSSL that the used build/flavor has the QUIC API: the vanilla OpenSSL does not, only BoringSSL, libressl, AWS-LC and quictls do.

Ref: https://github.com/curl/curl/commit/5d044ad9480a9f556f4b6a252d7533b1ba7fe57e#r136780413