### PR TITLE
configure.ac: error if --with-winidn and target OS too old

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2473,17 +2473,14 @@ if test "$want_winidn" = "yes"; then
     AC_LANG_PROGRAM([[
       #include <windows.h>
     ]],[[
-      #if (WINVER < 0x600) && (_WIN32_WINNT < 0x600)
+      #if (_WIN32_WINNT < 0x600)
       #error
       #endif
     ]])
   ],[
   ],[
-     CFLAGS=`echo $CFLAGS | $SED -e 's/-DWINVER=[[^ ]]*//g'`
-     CFLAGS=`echo $CFLAGS | $SED -e 's/-D_WIN32_WINNT=[[^ ]]*//g'`
-     CPPFLAGS=`echo $CPPFLAGS | $SED -e 's/-DWINVER=[[^ ]]*//g'`
-     CPPFLAGS=`echo $CPPFLAGS | $SED -e 's/-D_WIN32_WINNT=[[^ ]]*//g'`
-     WINIDN_CPPFLAGS="$WINIDN_CPPFLAGS -DWINVER=0x0600"
+    AC_MSG_RESULT([no])
+    AC_MSG_ERROR([--with-winidn specified but minimum OS is too old])
   ])
   #
   CPPFLAGS="$CPPFLAGS $WINIDN_CPPFLAGS"
@@ -4608,7 +4605,7 @@ else
     AC_LANG_PROGRAM([[
       #include <windows.h>
     ]],[[
-      #if (WINVER < 0x600) && (_WIN32_WINNT < 0x600)
+      #if (_WIN32_WINNT < 0x600)
       #error
       #endif
     ]])


### PR DESCRIPTION
- If the minimum Windows target OS is pre-Vista (_WIN32_WINNT < 0x600) then error.

- Stop comparing against WINVER when making the minimum OS determinations (ie check only _WIN32_WINNT instead of both since that's the one that matters).

Prior to this change, if --with-winidn was used in such a case configure would change the minimum target OS to Vista (0x600) so the build would compile. That was done primarily as a workaround for original MinGW which we no longer support.

Bug: https://github.com/curl/curl/pull/12606#issuecomment-1885381038
Reported-by: Viktor Szakats

Closes #xxxxx