### PR TITLE
gen: do italics/bold for a range of letters, not just single word

### DIFF
--- a/docs/cmdline-opts/cookie.d
+++ b/docs/cmdline-opts/cookie.d
@@ -45,7 +45,7 @@ Users often want to both read cookies from a file and write updated cookies
 back to a file, so using both --cookie and --cookie-jar in the same command
 line is common.
 
-If curl is built with PSL (*Public Suffix List*) support, it detects and
+If curl is built with PSL (**Public Suffix List**) support, it detects and
 discards cookies that are specified for such suffix domains that should not be
 allowed to have cookies. If curl is *not* built with PSL support, it has no
 ability to stop super cookies.

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -98,9 +98,9 @@ sub printdesc {
         }
         if($d !~ /^.\\"/) {
             # **bold**
-            $d =~ s/\*\*([^ ]*)\*\*/\\fB$1\\fP/g;
+            $d =~ s/\*\*(.*?)\*\*/\\fB$1\\fP/g;
             # *italics*
-            $d =~ s/\*([^ ]*)\*/\\fI$1\\fP/g;
+            $d =~ s/\*(.*?)\*/\\fI$1\\fP/g;
         }
         if(!$exam && ($d =~ /^ /)) {
             # start of example


### PR DESCRIPTION
Previously it would match only on a sequence of non-space, which made it miss to highlight for example "public suffix list".

Updated the recent cookie.d edit from 5da57193b732 to use bold instead of italics.