### PR TITLE
transfer: remove warning: Value stored to 'blen' is never read

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -490,7 +490,6 @@ static CURLcode readwrite_data(struct Curl_easy *data,
     }
 
     buf = data->state.buffer;
-    blen = 0;
     bytestoread = data->set.buffer_size;
 
     /* Observe any imposed speed limit */


### PR DESCRIPTION
Detected by scan-build

Follow-up from 1cd2f0072f