### PR TITLE
docs: remove unnecessary line breaks in `.d` files

### DIFF
--- a/docs/cmdline-opts/connect-to.d
+++ b/docs/cmdline-opts/connect-to.d
@@ -9,7 +9,6 @@ Category: connection
 Example: --connect-to example.com:443:example.net:8443 $URL
 Multi: append
 ---
-
 For a request to the given HOST1:PORT1 pair, connect to HOST2:PORT2 instead.
 This option is suitable to direct requests at a specific server, e.g. at a
 specific cluster node in a cluster of servers. This option is only used to

--- a/docs/cmdline-opts/tcp-fastopen.d
+++ b/docs/cmdline-opts/tcp-fastopen.d
@@ -8,7 +8,6 @@ Example: --tcp-fastopen $URL
 See-also: false-start
 Multi: boolean
 ---
-
 Enable use of TCP Fast Open (RFC 7413). TCP Fast Open is a TCP extension that
 allows data to get sent earlier over the connection (before the final
 handshake ACK) if the client and server have been connected previously.


### PR DESCRIPTION
This pull request resolves the issue of inconsistent line breaks for the `--tcp-fastopen` and `--connect-to` options in the manpage.

Script for identifying all affected files:
```
grep -Pzl '\-\-\-\\n\\n' docs/cmdline-opts/*.d
```