### PR TITLE
cf-h1-proxy: no CURLOPT_USERAGENT in CONNECT with hyper

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -725,7 +725,7 @@ static CURLcode start_CONNECT(struct Curl_cfilter *cf,
   }
 
   if(!Curl_checkProxyheaders(data, conn, STRCONST("User-Agent")) &&
-     data->set.str[STRING_USERAGENT]) {
+     data->set.str[STRING_USERAGENT] && *data->set.str[STRING_USERAGENT]) {
     struct dynbuf ua;
     Curl_dyn_init(&ua, DYN_HTTP_REQUEST);
     result = Curl_dyn_addf(&ua, "User-Agent: %s\r\n",


### PR DESCRIPTION
Follow-up to 693cd1679361828a which was incomplete

Ref #12680