### PR TITLE
version: show only the libpsl version, not its dependencies

### DIFF
--- a/lib/version.c
+++ b/lib/version.c
@@ -211,8 +211,12 @@ char *curl_version(void)
 #endif
 
 #ifdef USE_LIBPSL
-  msnprintf(psl_version, sizeof(psl_version), "libpsl/%s", psl_get_version());
-  src[i++] = psl_version;
+  {
+    int num = psl_check_version_number(0);
+    msnprintf(psl_version, sizeof(psl_version), "libpsl/%d.%d.%d",
+              num >> 16, (num >> 8) & 0xff, num & 0xff);
+    src[i++] = psl_version;
+  }
 #endif
 
 #ifdef USE_SSH


### PR DESCRIPTION
The libpsl version output otherwise also includes version number for its dependencies, like IDN lib, but since libcurl does not use libpsl's IDN functionality those components are not important.

Ref: https://github.com/curl/curl-for-win/issues/63