### PR TITLE
asyn-ares: resolver timeout follows the c-ares mechanism

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -173,10 +173,16 @@ CURLcode Curl_resolver_init(struct Curl_easy *easy, void **resolver)
   int status;
   struct ares_options options;
   int optmask = ARES_OPT_SOCK_STATE_CB;
+  static int ares_ver = 0;
   options.sock_state_cb = sock_state_cb;
   options.sock_state_cb_data = easy;
-  options.timeout = CARES_TIMEOUT_PER_ATTEMPT;
-  optmask |= ARES_OPT_TIMEOUTMS;
+  if(ares_ver == 0) {
+    ares_version(&ares_ver);
+  }
+  if(ares_ver < 0x011400) { /* c-ares included similar change since 1.20.0 */
+    options.timeout = CARES_TIMEOUT_PER_ATTEMPT;
+    optmask |= ARES_OPT_TIMEOUTMS;
+  }
 
   status = ares_init_options((ares_channel*)resolver, &options, optmask);
   if(status != ARES_SUCCESS) {


### PR DESCRIPTION
Hi,
The curl should set c-ares's timeout only  for `c-ares` < `1.20.0`.

curl use a fixed  timeout=2s for `c-ares` from commit:
  https://github.com/curl/curl/commit/a181b4a053339c0713f9c31c724f15ec5beb8d56, 
actually  `c-ares` used default timeout to 2s since `c-ares-1.20.0` release (also mentioned on prevous commit).
  https://github.com/c-ares/c-ares/pull/542
and the timeout=2 from curl will overwrite the `option: timeout` from the `/etc/resolv.conf`, which supported since `c-ares-1.23.0`:
  https://github.com/c-ares/c-ares/pull/632/files

So setting c-ares timeout to 2s should only apply to old c-ares < 1.20.0, won't overwrite timeout for c-ares > 1.23.0.

  
