### PR TITLE
rtsp, deal better with borked server responses

### DIFF
--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -822,11 +822,10 @@ static CURLcode rtsp_rtp_write_resp(struct Curl_easy *data,
 
     if(!rtspc->in_header) {
       /* If header parsing is done, extract interleaved RTP messages */
-      if((data->set.rtspreq == RTSPREQ_DESCRIBE) && (data->req.size <= -1)) {
+      if(data->req.size <= -1) {
         /* Respect section 4.4 of rfc2326: If the Content-Length header is
-           absent, a length 0 must be assumed.  It will prevent libcurl from
-           hanging on DESCRIBE request that got refused for whatever
-           reason */
+           absent, a length 0 must be assumed. */
+        data->req.size = 0;
         data->req.download_done = TRUE;
       }
       result = rtsp_filter_rtp(data, buf, blen, &consumed);
@@ -838,13 +837,16 @@ static CURLcode rtsp_rtp_write_resp(struct Curl_easy *data,
 
   if(rtspc->state != RTP_PARSE_SKIP)
     *done = FALSE;
-  /* we MUST have consumed all bytes */
-  DEBUGF(infof(data, "rtsp_rtp_write_resp(len=%zu, in_header=%d, done=%d)",
-               blen, rtspc->in_header, *done));
-  DEBUGASSERT(blen == 0);
-  if(!result && is_eos) {
-    result = Curl_client_write(data, CLIENTWRITE_BODY|CLIENTWRITE_EOS,
-                               (char *)buf, 0);
+  /* we SHOULD have consumed all bytes, unless the response is borked.
+   * In which case we write out the left over bytes, letting the client
+   * writer deal with it (it will report EXCESS and fail the transfer). */
+  DEBUGF(infof(data, "rtsp_rtp_write_resp(len=%zu, in_header=%d, done=%d "
+               " rtspc->state=%d, req.size=%zd)",
+               blen, rtspc->in_header, *done, rtspc->state, data->req.size));
+  if(!result && (is_eos || blen)) {
+    result = Curl_client_write(data, CLIENTWRITE_BODY|
+                               (is_eos? CLIENTWRITE_EOS:0),
+                               (char *)buf, blen);
   }
 
 out:

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -96,7 +96,7 @@ test644 test645 test646 test647 test648 test649 test650 test651 test652 \
 test653 test654 test655 test656 test658 test659 test660 test661 test662 \
 test663 test664 test665 test666 test667 test668 test669 test670 test671 \
 test672 test673 test674 test675 test676 test677 test678 test679 test680 \
-test681 test682 test683 test684 test685 test686 test687 test688 \
+test681 test682 test683 test684 test685 test686 test687 test688 test689 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/test689
+++ b/tests/data/test689
@@ -1,0 +1,53 @@
+<testcase>
+
+#Informational
+<info>
+<keywords>
+RTSP
+OPTIONS
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+RTSP/7.1 786          
+
+RTSP/          
+</data>
+<datacheck>
+</datacheck>
+</reply>
+
+# Client-Side
+<client>
+<server>
+rtsp
+</server>
+<tool>
+lib567
+</tool>
+
+<name>
+fuzzing crash issue #12701
+</name>
+<command>
+rtsp://%HOSTIP:%RTSPPORT/%TESTNUMBER
+</command>
+</client>
+
+<verify>
+<protocol>
+OPTIONS rtsp://%HOSTIP:%RTSPPORT/%TESTNUMBER RTSP/1.0
+CSeq: 1
+User-Agent: test567
+Test-Number: 567
+
+</protocol>
+# 8 == CURLE_WEIRD_SERVER_REPLY
+<errorcode>
+8
+</errorcode>
+</verify>
+
+</testcase>

--- a/tests/libtest/lib567.c
+++ b/tests/libtest/lib567.c
@@ -49,6 +49,7 @@ int test(char *URL)
   /* Dump data to stdout for protocol verification */
   test_setopt(curl, CURLOPT_HEADERDATA, stdout);
   test_setopt(curl, CURLOPT_WRITEDATA, stdout);
+  test_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, URL);


### PR DESCRIPTION
- refs #12701
- enforce a response body length of 0, if the response has no Content-lenght. This is according to the RTSP spec.
- excess bytes in a response body are forwarded to the client writers which will report and fail the transfer