### PR TITLE
websockets, check for negative payload lengths

### DIFF
--- a/lib/ws.c
+++ b/lib/ws.c
@@ -225,7 +225,7 @@ static CURLcode ws_dec_read_head(struct ws_decoder *dec,
       dec->payload_len = (dec->head[2] << 8) | dec->head[3];
       break;
     case 10:
-      if(dec->head[2] > 128) {
+      if(dec->head[2] > 127) {
         failf(data, "WS: frame length longer than 64 signed not supported");
         return CURLE_RECV_ERROR;
       }

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -81,6 +81,8 @@
 2301
 2302
 2305
+# response body seem not to be handled by hyper
+2307
 %endif
 2043
 # The CRL test (313) doesn't work with rustls because rustls doesn't support

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -244,7 +244,7 @@ test2100 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 \
 \
-test2300 test2301 test2302 test2303 test2304 test2305 test2306 \
+test2300 test2301 test2302 test2303 test2304 test2305 test2306 test2307 \
 \
 test2400 test2401 test2402 test2403 test2404 \
 \

--- a/tests/data/test2307
+++ b/tests/data/test2307
@@ -31,6 +31,7 @@ upgrade
 <features>
 debug
 ws
+!hyper
 </features>
 <server>
 http

--- a/tests/data/test2307
+++ b/tests/data/test2307
@@ -1,0 +1,70 @@
+<testcase>
+<info>
+<keywords>
+WebSockets
+</keywords>
+</info>
+
+#
+# Sends a PING with overlong payload
+<reply>
+<data nocheck="yes" nonewline="yes">
+HTTP/1.1 101 Switching to WebSockets
+Server: test-server/fake
+Upgrade: websocket
+Connection: Upgrade
+Something: else
+Sec-WebSocket-Accept: HkPsVga7+8LuxM4RGQ5p9tZHeYs=
+
+%hex[%19%7f%ff%30%30%30%30%30%30%30%30%30%30%30%30]hex%
+</data>
+# allow upgrade
+<servercmd>
+upgrade
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+# require debug for the forced CURL_ENTROPY
+<features>
+debug
+ws
+</features>
+<server>
+http
+</server>
+<name>
+WebSockets, overlong PING payload
+</name>
+<tool>
+lib2302
+</tool>
+<command>
+ws://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# PONG with no data and the 32 bit mask
+#
+<verify>
+<protocol nocheck="yes" nonewline="yes">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: webbie-sox/3
+Accept: */*
+Upgrade: websocket
+Connection: Upgrade
+Sec-WebSocket-Version: 13
+Sec-WebSocket-Key: NDMyMTUzMjE2MzIxNzMyMQ==
+
+
+</protocol>
+# 23 == CURLE_WRITE_ERROR
+<errorcode>
+23
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
- in en- and decoding, check the websocket frame payload lengths for negative values (from curl_off_t) and error the operation in that case