### PR TITLE
tool_operate: stop setting the comment on Amiga

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -343,22 +343,6 @@ static CURLcode pre_transfer(struct GlobalConfig *global,
   return result;
 }
 
-#ifdef __AMIGA__
-static void AmigaSetComment(struct per_transfer *per,
-                            CURLcode result)
-{
-  struct OutStruct *outs = &per->outs;
-  if(!result && outs->s_isreg && outs->filename) {
-    /* Set the url (up to 80 chars) as comment for the file */
-    if(strlen(per->this_url) > 78)
-      per->this_url[79] = '\0';
-    SetComment(outs->filename, per->this_url);
-  }
-}
-#else
-#define AmigaSetComment(x,y) Curl_nop_stmt
-#endif
-
 /* When doing serial transfers, we use a single fixed error area */
 static char global_errorbuffer[CURL_ERROR_SIZE];
 
@@ -657,8 +641,6 @@ noretry:
       unlink(outs->filename);
     }
   }
-
-  AmigaSetComment(per, result);
 
   /* File time can only be set _after_ the file has been closed */
   if(!result && config->remote_time && outs->s_isreg && outs->filename) {


### PR DESCRIPTION
- the URL is capped at 80 cols, which ruins it if longer
- it does not strip off URL credentials
- it is done unconditonally, not on --xattr
- we don't have Amiga in the CI which makes fixing it blindly fragile

Someone who builds and tests on Amiga can add it back correctly in a future if there is a desire.

Reported-by: Harry Sintonen