### PR TITLE
tool_operate: make --remove-on-error only remove "real" files

### DIFF
--- a/docs/cmdline-opts/remove-on-error.d
+++ b/docs/cmdline-opts/remove-on-error.d
@@ -12,4 +12,4 @@ When curl returns an error when told to save output in a local file, this
 option removes that saved file before exiting. This prevents curl from
 leaving a partial file in the case of an error during transfer.
 
-If the output is not a file, this option has no effect.
+If the output is not a regular file, this option has no effect.

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -637,8 +637,14 @@ noretry:
       errorf(config->global, "curl: (%d) Failed writing body", result);
     }
     if(result && config->rm_partial) {
-      notef(global, "Removing output file: %s", outs->filename);
-      unlink(outs->filename);
+      struct_stat st;
+      if(!stat(outs->filename, &st) &&
+         S_ISREG(st.st_mode) &&
+         !unlink(outs->filename)) {
+        notef(global, "Removed output file: %s", outs->filename);
+      }
+      else
+        warnf(global, "Failed removing: %s", outs->filename);
     }
   }
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -639,12 +639,15 @@ noretry:
     if(result && config->rm_partial) {
       struct_stat st;
       if(!stat(outs->filename, &st) &&
-         S_ISREG(st.st_mode) &&
-         !unlink(outs->filename)) {
-        notef(global, "Removed output file: %s", outs->filename);
+         S_ISREG(st.st_mode)) {
+        if(!unlink(outs->filename))
+          notef(global, "Removed output file: %s", outs->filename);
+        else
+          warnf(global, "Failed removing: %s", outs->filename);
       }
       else
-        warnf(global, "Failed removing: %s", outs->filename);
+        warnf(global, "Skipping removal; not a regular file: %s",
+              outs->filename);
     }
   }
 


### PR DESCRIPTION
Reported-by: Harry Sintonen