### PR TITLE
cmdline-opts/page-footer: mention env vars not used by schannel

### DIFF
--- a/docs/SSLCERTS.md
+++ b/docs/SSLCERTS.md
@@ -103,9 +103,9 @@ server, do one of the following:
        certificate store or use it stand-alone as described. Just remember that
        the security is no better than the way you obtained the certificate.
 
- 4. If you are using the curl command line tool, you can specify your own CA
-    cert file by setting the environment variable `CURL_CA_BUNDLE` to the path
-    of your choice.
+ 4. If you are using the curl command line tool and the TLS backend is not
+    Schannel then you can specify your own CA cert file by setting the
+    environment variable `CURL_CA_BUNDLE` to the path of your choice.
 
     If you are using the curl command line tool on Windows, curl will search
     for a CA cert file named "curl-ca-bundle.crt" in these directories and in

--- a/docs/cmdline-opts/cacert.d
+++ b/docs/cmdline-opts/cacert.d
@@ -15,9 +15,9 @@ may contain multiple CA certificates. The certificate(s) must be in PEM
 format. Normally curl is built to use a default file for this, so this option
 is typically used to alter that default file.
 
-curl recognizes the environment variable named 'CURL_CA_BUNDLE' if it is
-set, and uses the given path as a path to a CA cert bundle. This option
-overrides that variable.
+curl recognizes the environment variable named 'CURL_CA_BUNDLE' if it is set
+and the TLS backend is not Schannel, and uses the given path as a path to a CA
+cert bundle. This option overrides that variable.
 
 The windows version of curl automatically looks for a CA certs file named
 'curl-ca-bundle.crt', either in the same directory as curl.exe, or in the

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -49,7 +49,8 @@ If set, the specified number of characters is used as the terminal width when
 the alternative progress-bar is shown. If not set, curl tries to figure it out
 using other ways.
 .IP "CURL_CA_BUNDLE <file>"
-If set, it is used as the --cacert value.
+If set, it is used as the --cacert value. (Unless Schannel is used as TLS
+backend.)
 .IP "CURL_HOME <dir>"
 If set, is the first variable curl checks when trying to find its home
 directory. If not set, it continues to check *XDG_CONFIG_HOME*
@@ -74,9 +75,11 @@ files can become rather large. Works with the ngtcp2 and quiche QUIC backends.
 .IP SHELL
 Used on VMS when trying to detect if using a **DCL** or a **unix** shell.
 .IP "SSL_CERT_DIR <dir>"
-If set, it is used as the --capath value.
+If set, it is used as the --capath value. (Unless Schannel is used as TLS
+backend.)
 .IP "SSL_CERT_FILE <path>"
-If set, it is used as the --cacert value.
+If set, it is used as the --cacert value. (Unless Schannel is used as TLS
+backend.)
 .IP "SSLKEYLOGFILE <file name>"
 If you set this environment variable to a file name, curl stores TLS secrets
 from its connections in that file when invoked to enable you to analyze the

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -49,8 +49,8 @@ If set, the specified number of characters is used as the terminal width when
 the alternative progress-bar is shown. If not set, curl tries to figure it out
 using other ways.
 .IP "CURL_CA_BUNDLE <file>"
-If set, it is used as the --cacert value. (Unless Schannel is used as TLS
-backend.)
+If set, it is used as the --cacert value. This environment variable is ignored
+if Schannel is used as the TLS backend.
 .IP "CURL_HOME <dir>"
 If set, is the first variable curl checks when trying to find its home
 directory. If not set, it continues to check *XDG_CONFIG_HOME*

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -77,7 +77,6 @@ Used on VMS when trying to detect if using a **DCL** or a **unix** shell.
 .IP "SSL_CERT_DIR <dir>"
 If set, it is used as the --capath value. This environment variable is ignored
 if Schannel is used as the TLS backend.
-backend.)
 .IP "SSL_CERT_FILE <path>"
 If set, it is used as the --cacert value. This environment variable is ignored
 if Schannel is used as the TLS backend.

--- a/docs/cmdline-opts/page-footer
+++ b/docs/cmdline-opts/page-footer
@@ -75,11 +75,12 @@ files can become rather large. Works with the ngtcp2 and quiche QUIC backends.
 .IP SHELL
 Used on VMS when trying to detect if using a **DCL** or a **unix** shell.
 .IP "SSL_CERT_DIR <dir>"
-If set, it is used as the --capath value. (Unless Schannel is used as TLS
+If set, it is used as the --capath value. This environment variable is ignored
+if Schannel is used as the TLS backend.
 backend.)
 .IP "SSL_CERT_FILE <path>"
-If set, it is used as the --cacert value. (Unless Schannel is used as TLS
-backend.)
+If set, it is used as the --cacert value. This environment variable is ignored
+if Schannel is used as the TLS backend.
 .IP "SSLKEYLOGFILE <file name>"
 If you set this environment variable to a file name, curl stores TLS secrets
 from its connections in that file when invoked to enable you to analyze the


### PR DESCRIPTION
Ref: #12704