### PR TITLE
test2307: mark as flaky

### DIFF
--- a/tests/data/test2307
+++ b/tests/data/test2307
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 WebSockets
+flaky
 </keywords>
 </info>
 


### PR DESCRIPTION
Added in 49ca84144edf9790 (#12707) the test fails in numerous (unrelated) CI builds.