### PR TITLE
Fix test2307 expected failure code after ws refactoring

### DIFF
--- a/tests/data/test2307
+++ b/tests/data/test2307
@@ -63,9 +63,9 @@ Sec-WebSocket-Key: NDMyMTUzMjE2MzIxNzMyMQ==
 
 
 </protocol>
-# 23 == CURLE_WRITE_ERROR
+# 56 == CURLE_RECV_ERROR
 <errorcode>
-23
+56
 </errorcode>
 </verify>
 </testcase>


### PR DESCRIPTION
PRs for ws refactoring and test2307 were added in parallel, leading to another failure code after both were merged.