### PR TITLE
Convert rtsp assertion into debug log

### DIFF
--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -804,7 +804,9 @@ static CURLcode rtsp_rtp_write_resp(struct Curl_easy *data,
     buf += consumed;
     blen -= consumed;
     /* either we consumed all or are at the start of header parsing */
-    DEBUGASSERT(blen == 0 || data->req.header);
+    if(blen && !data->req.header)
+      DEBUGF(infof(data, "RTSP: %zu bytes, possibly excess in response body",
+                   blen));
   }
 
   /* we want to parse headers, do so */


### PR DESCRIPTION
- write excess bytes to the client where the standard excess bytes checks will report any wrongness and fail the transfer
- refs #12738