### PR TITLE
cmake: fix `ENABLE_MANUAL` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,18 +304,15 @@ if(ENABLE_IPV6 AND NOT WIN32)
   endif()
 endif()
 
-if(USE_MANUAL)
-    #nroff is currently only used when USE_MANUAL is set, so we can prevent the warning of no *NROFF if USE_MANUAL is OFF (or not defined), by not even looking for NROFF..
-    curl_nroff_check()
-endif()
 find_package(Perl)
 
-cmake_dependent_option(ENABLE_MANUAL "to provide the built-in manual"
-    ON "NROFF_USEFUL;PERL_FOUND"
-    OFF)
+option(ENABLE_MANUAL "to provide the built-in manual" OFF)
 
-if(ENABLE_MANUAL)
-  set(USE_MANUAL ON)
+if(ENABLE_MANUAL AND PERL_FOUND)
+  curl_nroff_check()
+  if(NROFF_USEFUL)
+    set(USE_MANUAL ON)
+  endif()
 endif()
 
 if(CURL_STATIC_CRT)


### PR DESCRIPTION
Fix the `ENABLE_MANUAL` option. Set it to default to `OFF`.

Before this patch `ENABLE_MANUAL=ON` was a no-op, even though it was the
option designed to enable building and using the built-in curl manual.
(`USE_MANUAL=ON` option worked for this instead, by accident).

Ref: https://github.com/curl/curl/pull/12730#issuecomment-1902572409
Closes #12749
