### PR TITLE
pingpong: call Curl_pp_init() in the DO actions of the users

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -3997,6 +3997,11 @@ static CURLcode ftp_do(struct Curl_easy *data, bool *done)
   CURLcode result = CURLE_OK;
   struct connectdata *conn = data->conn;
   struct ftp_conn *ftpc = &conn->proto.ftpc;
+  struct pingpong *pp = &ftpc->pp;
+
+  /* in case we come here for a new trasnfer without going through
+     ftp_connect() */
+  pp->linestart_resp = data->state.buffer;
 
   *done = FALSE; /* default to false */
   ftpc->wait_data_conn = FALSE; /* default to no such wait */


### PR DESCRIPTION
... and not in *connect.

The pp_init function stores a pointer to the current download buffer for the handle and if the transfer is performed on a reused connection, the *connect function is not called and as a result then pp_init is not called for this transfer from there.

A second place that calls pp_init is the pingpong sendf() function.

If pp_init is NOT called, the pingpong struct keeps the old pointer set when the connectiom was setup. As the download buffer is allocated on-demand when reaching the CONNECT state and freed in the DONE state, there is a risk that a transfer reusing a connection uses a different buffer which can lead to the the pingpong code accessing the already freed buffer.

Thanks to the backup call in the send function, this bug is hard to trigger: it needs to reuse the connection, not send any commands because of an early failure and yet have the pingpong code attempt reading response data from the server.

This has so far only been achieved by the fuzzer.

Bug: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=66012