### PR TITLE
SingleRequest, a members rename

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1004,9 +1004,9 @@ out:
   if(*done) {
     cf->connected = TRUE;
     /* Restore `data->req` fields that may habe been touched */
-    data->req.header = TRUE; /* assume header */
-    data->req.bytecount = 0;
-    data->req.ignorebody = FALSE;
+    data->req.resp_hds_recv = TRUE; /* assume header */
+    data->req.nrcvd_data = 0;
+    data->req.resp_body_skip = FALSE;
     Curl_client_cleanup(data);
     Curl_pgrsSetUploadCounter(data, 0);
     Curl_pgrsSetDownloadCounter(data, 0);

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -127,7 +127,7 @@ static void h2_tunnel_go_state(struct Curl_cfilter *cf,
   /* leaving this one */
   switch(ts->state) {
   case H2_TUNNEL_CONNECT:
-    data->req.ignorebody = FALSE;
+    data->req.resp_body_skip = FALSE;
     break;
   default:
     break;

--- a/lib/curl_range.c
+++ b/lib/curl_range.c
@@ -60,7 +60,7 @@ CURLcode Curl_range(struct Curl_easy *data)
     }
     else if((from_t == CURL_OFFT_INVAL) && !to_t) {
       /* -Y */
-      data->req.maxdownload = to;
+      data->req.nrecv_data_max = to;
       data->state.resume_from = -to;
       DEBUGF(infof(data, "RANGE the last %" CURL_FORMAT_CURL_OFF_T " bytes",
                    to));
@@ -77,19 +77,19 @@ CURLcode Curl_range(struct Curl_easy *data)
       if(totalsize == CURL_OFF_T_MAX)
         return CURLE_RANGE_ERROR;
 
-      data->req.maxdownload = totalsize + 1; /* include last byte */
+      data->req.nrecv_data_max = totalsize + 1; /* include last byte */
       data->state.resume_from = from;
       DEBUGF(infof(data, "RANGE from %" CURL_FORMAT_CURL_OFF_T
                    " getting %" CURL_FORMAT_CURL_OFF_T " bytes",
-                   from, data->req.maxdownload));
+                   from, data->req.nrecv_data_max));
     }
     DEBUGF(infof(data, "range-download from %" CURL_FORMAT_CURL_OFF_T
                  " to %" CURL_FORMAT_CURL_OFF_T ", totally %"
                  CURL_FORMAT_CURL_OFF_T " bytes",
-                 from, to, data->req.maxdownload));
+                 from, to, data->req.nrecv_data_max));
   }
   else
-    data->req.maxdownload = -1;
+    data->req.nrecv_data_max = -1;
   return CURLE_OK;
 }
 

--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -311,7 +311,7 @@ static ssize_t rtmp_recv(struct Curl_easy *data, int sockindex, char *buf,
   if(nread < 0) {
     if(r->m_read.status == RTMP_READ_COMPLETE ||
        r->m_read.status == RTMP_READ_EOF) {
-      data->req.size = data->req.bytecount;
+      data->req.resp_data_len = data->req.nrcvd_data;
       nread = 0;
     }
     else

--- a/lib/file.c
+++ b/lib/file.c
@@ -479,13 +479,13 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
               tm->tm_hour,
               tm->tm_min,
               tm->tm_sec,
-              data->req.no_body ? "": "\r\n");
+              data->req.resp_body_unwanted ? "": "\r\n");
     result = Curl_client_write(data, CLIENTWRITE_HEADER, header, headerlen);
     if(result)
       return result;
     /* set the file size to make it available post transfer */
     Curl_pgrsSetDownloadSize(data, expected_size);
-    if(data->req.no_body)
+    if(data->req.resp_body_unwanted)
       return result;
   }
 
@@ -517,8 +517,8 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
   }
 
   /* A high water mark has been specified so we obey... */
-  if(data->req.maxdownload > 0)
-    expected_size = data->req.maxdownload;
+  if(data->req.nrecv_data_max > 0)
+    expected_size = data->req.nrecv_data_max;
 
   if(!fstated || (expected_size <= 0))
     size_known = FALSE;

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -931,8 +931,8 @@ static int push_promise(struct Curl_cfilter *cf,
     }
 
     newstream->id = frame->promised_stream_id;
-    newhandle->req.maxdownload = -1;
-    newhandle->req.size = -1;
+    newhandle->req.nrecv_data_max = -1;
+    newhandle->req.resp_data_len = -1;
 
     /* approved, add to the multi handle and immediately switch to PERFORM
        state with the given connection !*/

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -388,7 +388,7 @@ static CURLcode cw_chunked_init(struct Curl_easy *data,
 {
   struct chunked_writer *ctx = (struct chunked_writer *)writer;
 
-  data->req.chunk = TRUE;      /* chunks coming our way. */
+  data->req.resp_body_chunked = TRUE;      /* chunks coming our way. */
   Curl_httpchunk_init(data, &ctx->ch, FALSE);
   return CURLE_OK;
 }
@@ -429,12 +429,12 @@ static CURLcode cw_chunked_write(struct Curl_easy *data,
   blen -= consumed;
   if(CHUNK_DONE == ctx->ch.state) {
     /* chunks read successfully, download is complete */
-    data->req.download_done = TRUE;
+    data->req.resp_rcvd = TRUE;
     if(blen) {
       infof(data, "Leftovers after chunking: %zu bytes", blen);
     }
   }
-  else if((type & CLIENTWRITE_EOS) && !data->req.no_body) {
+  else if((type & CLIENTWRITE_EOS) && !data->req.resp_body_unwanted) {
     failf(data, "transfer closed with outstanding read data remaining");
     return CURLE_PARTIAL_FILE;
   }

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1213,12 +1213,12 @@ static CURLcode imap_state_fetch_resp(struct Curl_easy *data,
       }
     }
 
-    if(data->req.bytecount == size)
+    if(data->req.nrcvd_data == size)
       /* The entire data is already transferred! */
       Curl_setup_transfer(data, -1, -1, FALSE, -1);
     else {
       /* IMAP download */
-      data->req.maxdownload = size;
+      data->req.nrecv_data_max = size;
       /* force a recv/send check of this connection, as the data might've been
        read off the socket already */
       data->state.select_bits = CURL_CSELECT_IN;
@@ -1572,7 +1572,7 @@ static CURLcode imap_perform(struct Curl_easy *data, bool *connected,
 
   DEBUGF(infof(data, "DO phase starts"));
 
-  if(data->req.no_body) {
+  if(data->req.resp_body_unwanted) {
     /* Requested no body means no transfer */
     imap->transfer = PPTRANSFER_INFO;
   }
@@ -1735,7 +1735,7 @@ static CURLcode imap_regular_transfer(struct Curl_easy *data,
   bool connected = FALSE;
 
   /* Make sure size is unknown at this point */
-  data->req.size = -1;
+  data->req.resp_data_len = -1;
 
   /* Set the progress data */
   Curl_pgrsSetUploadCounter(data, 0);

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -670,8 +670,8 @@ MQTT_SUBACK_COMING:
       goto end;
     }
     Curl_pgrsSetDownloadSize(data, remlen);
-    data->req.bytecount = 0;
-    data->req.size = remlen;
+    data->req.nrcvd_data = 0;
+    data->req.resp_data_len = remlen;
     mq->npacket = remlen; /* get this many bytes */
     FALLTHROUGH();
   case MQTT_PUB_REMAIN: {

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -1023,7 +1023,7 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
       infof(data, "There are more than %d entries", lr->nument);
       FALLTHROUGH();
     case LDAP_SUCCESS:
-      data->req.size = data->req.bytecount;
+      data->req.resp_data_len = data->req.nrcvd_data;
       break;
     default:
       failf(data, "LDAP remote: search failed %s %s", ldap_err2string(code),

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -341,7 +341,7 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
       ssize_t clipamount = 0;
       bool restart = FALSE;
 
-      data->req.headerbytecount += (unsigned int)gotbytes;
+      data->req.nrcvd_hds += (curl_off_t)gotbytes;
 
       pp->nread_resp += gotbytes;
       for(i = 0; i < gotbytes; ptr++, i++) {

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -948,7 +948,7 @@ static CURLcode pop3_state_command_resp(struct Curl_easy *data,
          content so send it as such. Note that there may even be additional
          "headers" after the body */
 
-      if(!data->req.no_body) {
+      if(!data->req.resp_body_unwanted) {
         result = Curl_pop3_write(data, pp->cache, pp->cache_size);
         if(result)
           return result;
@@ -1197,7 +1197,7 @@ static CURLcode pop3_perform(struct Curl_easy *data, bool *connected,
 
   DEBUGF(infof(data, "DO phase starts"));
 
-  if(data->req.no_body) {
+  if(data->req.resp_body_unwanted) {
     /* Requested no body means no transfer */
     pop3->transfer = PPTRANSFER_INFO;
   }
@@ -1323,7 +1323,7 @@ static CURLcode pop3_regular_transfer(struct Curl_easy *data,
   bool connected = FALSE;
 
   /* Make sure size is unknown at this point */
-  data->req.size = -1;
+  data->req.resp_data_len = -1;
 
   /* Set the progress data */
   Curl_pgrsSetUploadCounter(data, 0);

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1045,7 +1045,7 @@ static CURLcode smtp_state_command_resp(struct Curl_easy *data, int smtpcode,
   }
   else {
     /* Temporarily add the LF character back and send as body to the client */
-    if(!data->req.no_body) {
+    if(!data->req.resp_body_unwanted) {
       line[len] = '\n';
       result = Curl_client_write(data, CLIENTWRITE_BODY, line, len + 1);
       line[len] = '\0';
@@ -1485,7 +1485,7 @@ static CURLcode smtp_perform(struct Curl_easy *data, bool *connected,
 
   DEBUGF(infof(data, "DO phase starts"));
 
-  if(data->req.no_body) {
+  if(data->req.resp_body_unwanted) {
     /* Requested no body means no transfer */
     smtp->transfer = PPTRANSFER_INFO;
   }
@@ -1633,7 +1633,7 @@ static CURLcode smtp_regular_transfer(struct Curl_easy *data,
   bool connected = FALSE;
 
   /* Make sure size is unknown at this point */
-  data->req.size = -1;
+  data->req.resp_data_len = -1;
 
   /* Set the progress data */
   Curl_pgrsSetUploadCounter(data, 0);

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -790,8 +790,8 @@ static CURLcode tftp_tx(struct tftp_state_data *state, tftp_event_t event)
       return CURLE_SEND_ERROR;
     }
     /* Update the progress meter */
-    k->writebytecount += state->sbytes;
-    Curl_pgrsSetUploadCounter(data, k->writebytecount);
+    k->nsent_data += state->sbytes;
+    Curl_pgrsSetUploadCounter(data, k->nsent_data);
     break;
 
   case TFTP_EVENT_TIMEOUT:
@@ -816,7 +816,7 @@ static CURLcode tftp_tx(struct tftp_state_data *state, tftp_event_t event)
         return CURLE_SEND_ERROR;
       }
       /* since this was a re-send, we remain at the still byte position */
-      Curl_pgrsSetUploadCounter(data, k->writebytecount);
+      Curl_pgrsSetUploadCounter(data, k->nsent_data);
     }
     break;
 

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -51,7 +51,7 @@ int Curl_single_getsock(struct Curl_easy *data,
 CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
                              size_t *nreadp);
 CURLcode Curl_retry_request(struct Curl_easy *data, char **url);
-bool Curl_meets_timecondition(struct Curl_easy *data, time_t timeofdoc);
+bool Curl_meets_timecondition(struct Curl_easy *data, time_t last_modified);
 CURLcode Curl_get_upload_buffer(struct Curl_easy *data);
 
 CURLcode Curl_done_sending(struct Curl_easy *data,
@@ -79,7 +79,7 @@ void
 Curl_setup_transfer (struct Curl_easy *data,
                      int sockindex,     /* socket index to read from or -1 */
                      curl_off_t size,   /* -1 if unknown at this point */
-                     bool getheader,    /* TRUE if header parsing is wanted */
+                     bool resp_hds_expected, /* TRUE iff headers in response */
                      int writesockindex /* socket index to write to. May be
                                            the same we read from. -1
                                            disables */

--- a/lib/url.c
+++ b/lib/url.c
@@ -3866,8 +3866,8 @@ CURLcode Curl_connect(struct Curl_easy *data,
   /* init the single-transfer specific data */
   Curl_free_request_state(data);
   memset(&data->req, 0, sizeof(struct SingleRequest));
-  data->req.size = data->req.maxdownload = -1;
-  data->req.no_body = data->set.opt_no_body;
+  data->req.resp_data_len = data->req.nrecv_data_max = -1;
+  data->req.resp_body_unwanted = data->set.opt_no_body;
 
   /* call the stuff that needs to be called */
   result = create_conn(data, &conn, asyncp);
@@ -3929,14 +3929,14 @@ CURLcode Curl_init_do(struct Curl_easy *data, struct connectdata *conn)
   data->state.done = FALSE; /* *_done() is not called yet */
   data->state.expect100header = FALSE;
 
-  if(data->req.no_body)
+  if(data->req.resp_body_unwanted)
     /* in HTTP lingo, no body means using the HEAD request... */
     data->state.httpreq = HTTPREQ_HEAD;
 
   k->start = Curl_now(); /* start time */
-  k->header = TRUE; /* assume header */
-  k->bytecount = 0;
-  k->ignorebody = FALSE;
+  k->resp_hds_recv = TRUE; /* assume header */
+  k->nrcvd_data = 0;
+  k->resp_body_skip = FALSE;
 
   Curl_client_cleanup(data);
   Curl_speedinit(data);

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1333,7 +1333,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         /* now, decrease the size of the read */
         if(data->state.infilesize > 0) {
           data->state.infilesize -= data->state.resume_from;
-          data->req.size = data->state.infilesize;
+          data->req.resp_data_len = data->state.infilesize;
           Curl_pgrsSetUploadSize(data, data->state.infilesize);
         }
 
@@ -1344,7 +1344,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         }
       }
       if(data->state.infilesize > 0) {
-        data->req.size = data->state.infilesize;
+        data->req.resp_data_len = data->state.infilesize;
         Curl_pgrsSetUploadSize(data, data->state.infilesize);
       }
       /* upload data */
@@ -1419,7 +1419,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
 
     case SSH_SFTP_READDIR_INIT:
       Curl_pgrsSetDownloadSize(data, -1);
-      if(data->req.no_body) {
+      if(data->req.resp_body_unwanted) {
         state(data, SSH_STOP);
         break;
       }
@@ -1613,8 +1613,8 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
          * OR the server doesn't return a file size with a stat()
          * OR file size is 0
          */
-        data->req.size = -1;
-        data->req.maxdownload = -1;
+        data->req.resp_data_len = -1;
+        data->req.nrecv_data_max = -1;
         Curl_pgrsSetDownloadSize(data, -1);
         size = 0;
       }
@@ -1673,8 +1673,8 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
             break;
           }
         }
-        data->req.size = size;
-        data->req.maxdownload = size;
+        data->req.resp_data_len = size;
+        data->req.nrecv_data_max = size;
         Curl_pgrsSetDownloadSize(data, size);
       }
 
@@ -1701,8 +1701,8 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
           }
         }
         /* Now store the number of bytes we are expected to download */
-        data->req.size = size - data->state.resume_from;
-        data->req.maxdownload = size - data->state.resume_from;
+        data->req.resp_data_len = size - data->state.resume_from;
+        data->req.nrecv_data_max = size - data->state.resume_from;
         Curl_pgrsSetDownloadSize(data,
                                  size - data->state.resume_from);
 
@@ -1715,14 +1715,15 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
     }
 
     /* Setup the actual download */
-    if(data->req.size == 0) {
+    if(data->req.resp_data_len == 0) {
       /* no data to transfer */
       Curl_setup_transfer(data, -1, -1, FALSE, -1);
       infof(data, "File already completely downloaded");
       state(data, SSH_STOP);
       break;
     }
-    Curl_setup_transfer(data, FIRSTSOCKET, data->req.size, FALSE, -1);
+    Curl_setup_transfer(data, FIRSTSOCKET, data->req.resp_data_len,
+                        FALSE, -1);
 
     /* not set by Curl_setup_transfer to preserve keepon bits */
     conn->writesockfd = conn->sockfd;
@@ -1846,7 +1847,8 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       /* upload data */
-      Curl_setup_transfer(data, -1, data->req.size, FALSE, FIRSTSOCKET);
+      Curl_setup_transfer(data, -1, data->req.resp_data_len,
+                          FALSE, FIRSTSOCKET);
 
       /* not set by Curl_setup_transfer to preserve keepon bits */
       conn->sockfd = conn->writesockfd;
@@ -1889,7 +1891,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
 
         /* download data */
         bytecount = ssh_scp_request_get_size(sshc->scp_session);
-        data->req.maxdownload = (curl_off_t) bytecount;
+        data->req.nrecv_data_max = (curl_off_t) bytecount;
         Curl_setup_transfer(data, FIRSTSOCKET, bytecount, FALSE, -1);
 
         /* not set by Curl_setup_transfer to preserve keepon bits */
@@ -2322,7 +2324,7 @@ static CURLcode myssh_do_it(struct Curl_easy *data, bool *done)
 
   *done = FALSE;                /* default to false */
 
-  data->req.size = -1;          /* make sure this is unknown at this point */
+  data->req.resp_data_len = -1; /* make sure this is unknown at this point */
 
   sshc->actualcode = CURLE_OK;  /* reset error code */
   sshc->secondCreateDirs = 0;   /* reset the create dir attempt state

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2183,14 +2183,14 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
         /* now, decrease the size of the read */
         if(data->state.infilesize > 0) {
           data->state.infilesize -= data->state.resume_from;
-          data->req.size = data->state.infilesize;
+          data->req.resp_data_len = data->state.infilesize;
           Curl_pgrsSetUploadSize(data, data->state.infilesize);
         }
 
         SFTP_SEEK(sshc->sftp_handle, data->state.resume_from);
       }
       if(data->state.infilesize > 0) {
-        data->req.size = data->state.infilesize;
+        data->req.resp_data_len = data->state.infilesize;
         Curl_pgrsSetUploadSize(data, data->state.infilesize);
       }
       /* upload data */
@@ -2277,7 +2277,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
 
     case SSH_SFTP_READDIR_INIT:
       Curl_pgrsSetDownloadSize(data, -1);
-      if(data->req.no_body) {
+      if(data->req.resp_body_unwanted) {
         state(data, SSH_STOP);
         break;
       }
@@ -2496,8 +2496,8 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
          * OR the server doesn't return a file size with a stat()
          * OR file size is 0
          */
-        data->req.size = -1;
-        data->req.maxdownload = -1;
+        data->req.resp_data_len = -1;
+        data->req.nrecv_data_max = -1;
         Curl_pgrsSetDownloadSize(data, -1);
       }
       else {
@@ -2548,8 +2548,8 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
 
           SFTP_SEEK(sshc->sftp_handle, from);
         }
-        data->req.size = size;
-        data->req.maxdownload = size;
+        data->req.resp_data_len = size;
+        data->req.nrecv_data_max = size;
         Curl_pgrsSetDownloadSize(data, size);
       }
 
@@ -2576,8 +2576,8 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
           }
         }
         /* Now store the number of bytes we are expected to download */
-        data->req.size = attrs.filesize - data->state.resume_from;
-        data->req.maxdownload = attrs.filesize - data->state.resume_from;
+        data->req.resp_data_len = attrs.filesize - data->state.resume_from;
+        data->req.nrecv_data_max = attrs.filesize - data->state.resume_from;
         Curl_pgrsSetDownloadSize(data,
                                  attrs.filesize - data->state.resume_from);
         SFTP_SEEK(sshc->sftp_handle, data->state.resume_from);
@@ -2585,14 +2585,15 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
     }
 
     /* Setup the actual download */
-    if(data->req.size == 0) {
+    if(data->req.resp_data_len == 0) {
       /* no data to transfer */
       Curl_setup_transfer(data, -1, -1, FALSE, -1);
       infof(data, "File already completely downloaded");
       state(data, SSH_STOP);
       break;
     }
-    Curl_setup_transfer(data, FIRSTSOCKET, data->req.size, FALSE, -1);
+    Curl_setup_transfer(data, FIRSTSOCKET, data->req.resp_data_len,
+                        FALSE, -1);
 
     /* not set by Curl_setup_transfer to preserve keepon bits */
     conn->writesockfd = conn->sockfd;
@@ -2736,7 +2737,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       /* upload data */
-      data->req.size = data->state.infilesize;
+      data->req.resp_data_len = data->state.infilesize;
       Curl_pgrsSetUploadSize(data, data->state.infilesize);
       Curl_setup_transfer(data, -1, -1, FALSE, FIRSTSOCKET);
 
@@ -2808,7 +2809,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
 
       /* download data */
       bytecount = (curl_off_t)sb.st_size;
-      data->req.maxdownload = (curl_off_t)sb.st_size;
+      data->req.nrecv_data_max = (curl_off_t)sb.st_size;
       Curl_setup_transfer(data, FIRSTSOCKET, bytecount, FALSE, -1);
 
       /* not set by Curl_setup_transfer to preserve keepon bits */
@@ -3443,7 +3444,7 @@ static CURLcode ssh_do(struct Curl_easy *data, bool *done)
 
   *done = FALSE; /* default to false */
 
-  data->req.size = -1; /* make sure this is unknown at this point */
+  data->req.resp_data_len = -1; /* make sure this is unknown at this point */
 
   sshc->actualcode = CURLE_OK; /* reset error code */
   sshc->secondCreateDirs = 0;   /* reset the create dir attempt state


### PR DESCRIPTION
- rename members of `struct SingleRequest` to use a consistent pattern that clarifies if they apply to request or responses
- No code changes as such, except the type for header byte counters was changed from `unsigned int` to `curl_off_t` to align it with the data byte counters

No naming is perfect. The proposed changes are:

| Old | New |
|---|---|
| bytecount | nrcvd_data |
| maxdownload | nrecv_data_max |
| headerbytecount | nrcvd_hds |
| allheadercount | nrcvd_hds_all |
| deductheadercount | nrcvd_hds_interim |
| writebytecount | nsent_data |
| -- | -- |
| download_done | resp_rcvd | 
| size | resp_data_len |
| offset | resp_data_offset |
| getheader | resp_hds_expected | 
| header | resp_hds_recv |
| headerline | resp_hds_nlines |
| no_body | resp_body_unwanted |
| ignorebody | resp_body_skip |
| http_bodyless | resp_bodyless |
| chunk | resp_body_chunked |
| ignore_cl | resp_clen_ignore |
| timeofdoc | resp_last_modified |
| location | resp_location | 
| content_range | resp_with_content_range |
| -- | -- |
| upload_done | req_sent |
| upload_chunky | req_body_chunked | 
| forbidchunk | req_body_never_chunk | 
| -- | -- |
| writer_stack | cw_stack |
| bodywrites | cw_written |
| eos_written | cw_written_eos |
