### PR TITLE
Scorecard tracking CPU and RSS

### DIFF
--- a/tests/http/requirements.txt
+++ b/tests/http/requirements.txt
@@ -27,3 +27,4 @@ pytest
 cryptography
 multipart
 websockets
+psutil

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -202,10 +202,12 @@ class ScoreCard:
         self.info(f'  {count}x{label}: ')
         props = {
             'single': self.transfer_single(url=url, proto=proto, count=10),
-            'serial': self.transfer_serial(url=url, proto=proto, count=count),
-            'parallel': self.transfer_parallel(url=url, proto=proto,
-                                               count=count),
         }
+        if count > 1:
+            props['serial'] = self.transfer_serial(url=url, proto=proto,
+                                                   count=count)
+            props['parallel'] = self.transfer_parallel(url=url, proto=proto,
+                                                       count=count),
         self.info(f'ok.\n')
         return props
 

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -389,11 +389,11 @@ class ScoreCard:
         return f'{int(tval*1000)} ms' if tval >= 0 else '--'
 
     def fmt_size(self, val):
-        if val > (1024*1024*1024):
+        if val >= (1024*1024*1024):
             return f'{val / (1024*1024*1024):0.000f}GB'
-        elif val > (1024 * 1024):
+        elif val >= (1024 * 1024):
             return f'{val / (1024*1024):0.000f}MB'
-        elif val > 1024:
+        elif val >= 1024:
             return f'{val / 1024:0.000f}KB'
         else:
             return f'{val:0.000f}B'

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -228,8 +228,7 @@ class ScoreCard:
                 'description': descr,
             }
             for fsize in fsizes:
-                label = f'{int(fsize / 1024)}KB' if fsize < 1024*1024 else \
-                    f'{int(fsize / (1024 * 1024))}MB'
+                label = self.fmt_size(fsize)
                 fname = f'score{label}.data'
                 self._make_docs_file(docs_dir=self.httpd.docs_dir,
                                      fname=fname, fsize=fsize)
@@ -246,8 +245,7 @@ class ScoreCard:
                 'description': descr,
             }
             for fsize in fsizes:
-                label = f'{int(fsize / 1024)}KB' if fsize < 1024*1024 else \
-                    f'{int(fsize / (1024 * 1024))}MB'
+                label = self.fmt_size(fsize)
                 fname = f'score{label}.data'
                 self._make_docs_file(docs_dir=self.caddy.docs_dir,
                                      fname=fname, fsize=fsize)
@@ -390,8 +388,15 @@ class ScoreCard:
     def fmt_ms(self, tval):
         return f'{int(tval*1000)} ms' if tval >= 0 else '--'
 
-    def fmt_mb(self, val):
-        return f'{val/(1024*1024):0.000f} MB' if val >= 0 else '--'
+    def fmt_size(self, val):
+        if val > (1024*1024*1024):
+            return f'{val / (1024*1024*1024):0.000f}GB'
+        elif val > (1024 * 1024):
+            return f'{val / (1024*1024):0.000f}MB'
+        elif val > 1024:
+            return f'{val / 1024:0.000f}KB'
+        else:
+            return f'{val:0.000f}B'
 
     def fmt_mbs(self, val):
         return f'{val/(1024*1024):0.000f} MB/s' if val >= 0 else '--'
@@ -448,7 +453,7 @@ class ScoreCard:
                         if m in size_score:
                             print(f' {self.fmt_mbs(size_score[m]["speed"]):>{mcol_width}}', end='')
                             s = f'[{size_score[m]["stats"]["cpu"]:>.1f}%'\
-                                f'/{self.fmt_mb(size_score[m]["stats"]["rss"])}]'
+                                f'/{self.fmt_size(size_score[m]["stats"]["rss"])}]'
                             print(f' {s:<{mcol_sw}}', end='')
                         else:
                             print(' '*mcol_width, end='')
@@ -492,7 +497,7 @@ class ScoreCard:
                         if m in size_score:
                             print(f' {self.fmt_reqs(size_score[m]["speed"]):>{mcol_width}}', end='')
                             s = f'[{size_score[m]["stats"]["cpu"]:>.1f}%'\
-                                f'/{self.fmt_mb(size_score[m]["stats"]["rss"])}]'
+                                f'/{self.fmt_size(size_score[m]["stats"]["rss"])}]'
                             print(f' {s:<{mcol_sw}}', end='')
                         else:
                             print(' '*mcol_width, end='')
@@ -507,7 +512,9 @@ def parse_size(s):
     if m is None:
         raise Exception(f'unrecognized size: {s}')
     size = int(m.group(1))
-    if m.group(2).lower() == 'kb':
+    if not m.group(2):
+        pass
+    elif m.group(2).lower() == 'kb':
         size *= 1024
     elif m.group(2).lower() == 'mb':
         size *= 1024 * 1024

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -207,7 +207,7 @@ class ScoreCard:
             props['serial'] = self.transfer_serial(url=url, proto=proto,
                                                    count=count)
             props['parallel'] = self.transfer_parallel(url=url, proto=proto,
-                                                       count=count),
+                                                       count=count)
         self.info(f'ok.\n')
         return props
 
@@ -424,8 +424,7 @@ class ScoreCard:
             m_names = {}
             mcol_width = 12
             mcol_sw = 17
-            for server in score['downloads']:
-                server_score = score['downloads'][server]
+            for server, server_score in score['downloads'].items():
                 for sskey, ssval in server_score.items():
                     if isinstance(ssval, str):
                         continue

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -33,7 +33,7 @@ import sys
 from statistics import mean
 from typing import Dict, Any, Optional, List
 
-from testenv import Env, Httpd, Nghttpx, CurlClient, Caddy, ExecResult, NghttpxQuic
+from testenv import Env, Httpd, Nghttpx, CurlClient, Caddy, ExecResult, NghttpxQuic, RunProfile
 
 log = logging.getLogger(__name__)
 
@@ -122,57 +122,65 @@ class ScoreCard:
         count = 1
         samples = []
         errors = []
+        profiles = []
         self.info(f'single...')
         for i in range(sample_size):
             curl = CurlClient(env=self.env, silent=self._silent_curl)
             r = curl.http_download(urls=[url], alpn_proto=proto, no_save=True,
-                                   with_headers=False)
+                                   with_headers=False, with_profile=True)
             err = self._check_downloads(r, count)
             if err:
                 errors.append(err)
             else:
                 total_size = sum([s['size_download'] for s in r.stats])
                 samples.append(total_size / r.duration.total_seconds())
+                profiles.append(r.profile)
         return {
             'count': count,
             'samples': sample_size,
             'speed': mean(samples) if len(samples) else -1,
-            'errors': errors
+            'errors': errors,
+            'stats': RunProfile.AverageStats(profiles),
         }
 
     def transfer_serial(self, url: str, proto: str, count: int):
         sample_size = 1
         samples = []
         errors = []
+        profiles = []
         url = f'{url}?[0-{count - 1}]'
         self.info(f'serial...')
         for i in range(sample_size):
             curl = CurlClient(env=self.env, silent=self._silent_curl)
             r = curl.http_download(urls=[url], alpn_proto=proto, no_save=True,
-                                   with_headers=False)
+                                   with_headers=False, with_profile=True)
             err = self._check_downloads(r, count)
             if err:
                 errors.append(err)
             else:
                 total_size = sum([s['size_download'] for s in r.stats])
                 samples.append(total_size / r.duration.total_seconds())
+                profiles.append(r.profile)
         return {
             'count': count,
             'samples': sample_size,
             'speed': mean(samples) if len(samples) else -1,
-            'errors': errors
+            'errors': errors,
+            'stats': RunProfile.AverageStats(profiles),
         }
 
     def transfer_parallel(self, url: str, proto: str, count: int):
         sample_size = 1
         samples = []
         errors = []
+        profiles = []
         url = f'{url}?[0-{count - 1}]'
         self.info(f'parallel...')
         for i in range(sample_size):
             curl = CurlClient(env=self.env, silent=self._silent_curl)
             r = curl.http_download(urls=[url], alpn_proto=proto, no_save=True,
                                    with_headers=False,
+                                   with_profile=True,
                                    extra_args=['--parallel',
                                                '--parallel-max', str(count)])
             err = self._check_downloads(r, count)
@@ -181,11 +189,13 @@ class ScoreCard:
             else:
                 total_size = sum([s['size_download'] for s in r.stats])
                 samples.append(total_size / r.duration.total_seconds())
+                profiles.append(r.profile)
         return {
             'count': count,
             'samples': sample_size,
             'speed': mean(samples) if len(samples) else -1,
-            'errors': errors
+            'errors': errors,
+            'stats': RunProfile.AverageStats(profiles),
         }
 
     def download_url(self, label: str, url: str, proto: str, count: int):
@@ -250,6 +260,7 @@ class ScoreCard:
         sample_size = 1
         samples = []
         errors = []
+        profiles = []
         url = f'{url}?[0-{count - 1}]'
         extra_args = ['--parallel', '--parallel-max', str(max_parallel)] \
             if max_parallel > 1 else []
@@ -257,7 +268,7 @@ class ScoreCard:
         for i in range(sample_size):
             curl = CurlClient(env=self.env, silent=self._silent_curl)
             r = curl.http_download(urls=[url], alpn_proto=proto, no_save=True,
-                                   with_headers=False,
+                                   with_headers=False, with_profile=True,
                                    extra_args=extra_args)
             err = self._check_downloads(r, count)
             if err:
@@ -265,25 +276,27 @@ class ScoreCard:
             else:
                 for _ in r.stats:
                     samples.append(count / r.duration.total_seconds())
+                profiles.append(r.profile)
         return {
             'count': count,
             'samples': sample_size,
             'speed': mean(samples) if len(samples) else -1,
-            'errors': errors
+            'errors': errors,
+            'stats': RunProfile.AverageStats(profiles),
         }
 
     def requests_url(self, url: str, proto: str, count: int):
         self.info(f'  {url}: ')
         props = {
-            'serial': self.do_requests(url=url, proto=proto, count=count),
-            'par-6': self.do_requests(url=url, proto=proto, count=count,
-                                      max_parallel=6),
-            'par-25': self.do_requests(url=url, proto=proto, count=count,
-                                       max_parallel=25),
-            'par-50': self.do_requests(url=url, proto=proto, count=count,
-                                       max_parallel=50),
-            'par-100': self.do_requests(url=url, proto=proto, count=count,
-                                        max_parallel=100),
+            '1': self.do_requests(url=url, proto=proto, count=count),
+            '6': self.do_requests(url=url, proto=proto, count=count,
+                                  max_parallel=6),
+            '25': self.do_requests(url=url, proto=proto, count=count,
+                                   max_parallel=25),
+            '50': self.do_requests(url=url, proto=proto, count=count,
+                                   max_parallel=50),
+            '100': self.do_requests(url=url, proto=proto, count=count,
+                                    max_parallel=100),
         }
         self.info(f'ok.\n')
         return props
@@ -398,46 +411,93 @@ class ScoreCard:
                       f'{"/".join(val["ipv4-errors"] + val["ipv6-errors"]):<20}'
                       )
         if 'downloads' in score:
-            print('Downloads')
-            print(f'  {"Server":<8} {"Size":>8} {"Single":>12} {"Serial":>12}'
-                  f' {"Parallel":>12}    {"Errors":<20}')
-            skeys = {}
-            for dkey, dval in score["downloads"].items():
-                for k in dval.keys():
-                    skeys[k] = True
-            for skey in skeys:
-                for dkey, dval in score["downloads"].items():
-                    if skey in dval:
-                        sval = dval[skey]
-                        if isinstance(sval, str):
-                            continue
-                        errors = []
-                        for key, val in sval.items():
-                            if 'errors' in val:
-                                errors.extend(val['errors'])
-                        print(f'  {dkey:<8} {skey:>8} '
-                              f'{self.fmt_mbs(sval["single"]["speed"]):>12} '
-                              f'{self.fmt_mbs(sval["serial"]["speed"]):>12} '
-                              f'{self.fmt_mbs(sval["parallel"]["speed"]):>12} '
-                              f'   {"/".join(errors):<20}')
-        if 'requests' in score:
-            print('Requests, max in parallel')
-            print(f'  {"Server":<8} {"Size":>8} '
-                  f'{"1    ":>12} {"6    ":>12} {"25    ":>12} '
-                  f'{"50    ":>12} {"100    ":>12}    {"Errors":<20}')
-            for dkey, dval in score["requests"].items():
-                for skey, sval in dval.items():
-                    if isinstance(sval, str):
+            # get the key names of all sizes and measurements made
+            sizes = []
+            measures = []
+            m_names = {}
+            mcol_width = 12
+            mcol_sw = 17
+            for server in score['downloads']:
+                server_score = score['downloads'][server]
+                for sskey, ssval in server_score.items():
+                    if isinstance(ssval, str):
                         continue
+                    if sskey not in sizes:
+                        sizes.append(sskey)
+                    for mkey, mval in server_score[sskey].items():
+                        if mkey not in measures:
+                            measures.append(mkey)
+                            m_names[mkey] = f'{mkey}({mval["count"]}x)'
+
+            print('Downloads')
+            print(f'  {"Server":<8} {"Size":>8}', end='')
+            for m in measures: print(f' {m_names[m]:>{mcol_width}} {"[cpu/rss]":<{mcol_sw}}', end='')
+            print(f' {"Errors":^20}')
+
+            for server in score['downloads']:
+                for size in sizes:
+                    size_score = score['downloads'][server][size]
+                    print(f'  {server:<8} {size:>8}', end='')
                     errors = []
-                    for key, val in sval.items():
+                    for key, val in size_score.items():
                         if 'errors' in val:
                             errors.extend(val['errors'])
-                    line = f'  {dkey:<8} {skey:>8} '
-                    for k in sval.keys():
-                        line += f'{self.fmt_reqs(sval[k]["speed"]):>12} '
-                    line += f'   {"/".join(errors):<20}'
-                    print(line)
+                    for m in measures:
+                        if m in size_score:
+                            print(f' {self.fmt_mbs(size_score[m]["speed"]):>{mcol_width}}', end='')
+                            s = f'[{size_score[m]["stats"]["cpu"]:>.1f}%'\
+                                f'/{self.fmt_mb(size_score[m]["stats"]["rss"])}]'
+                            print(f' {s:<{mcol_sw}}', end='')
+                        else:
+                            print(' '*mcol_width, end='')
+                    if len(errors):
+                        print(f' {"/".join(errors):<20}')
+                    else:
+                        print(f' {"-":^20}')
+
+        if 'requests' in score:
+            sizes = []
+            measures = []
+            m_names = {}
+            mcol_width = 9
+            mcol_sw = 17
+            for server in score['requests']:
+                server_score = score['requests'][server]
+                for sskey, ssval in server_score.items():
+                    if isinstance(ssval, str):
+                        continue
+                    if sskey not in sizes:
+                        sizes.append(sskey)
+                    for mkey, mval in server_score[sskey].items():
+                        if mkey not in measures:
+                            measures.append(mkey)
+                            m_names[mkey] = f'{mkey}'
+
+            print('Requests, max in parallel')
+            print(f'  {"Server":<8} {"Size":>8}', end='')
+            for m in measures: print(f' {m_names[m]:>{mcol_width}} {"[cpu/rss]":<{mcol_sw}}', end='')
+            print(f' {"Errors":^20}')
+
+            for server in score['requests']:
+                for size in sizes:
+                    size_score = score['requests'][server][size]
+                    print(f'  {server:<8} {size:>8}', end='')
+                    errors = []
+                    for key, val in size_score.items():
+                        if 'errors' in val:
+                            errors.extend(val['errors'])
+                    for m in measures:
+                        if m in size_score:
+                            print(f' {self.fmt_reqs(size_score[m]["speed"]):>{mcol_width}}', end='')
+                            s = f'[{size_score[m]["stats"]["cpu"]:>.1f}%'\
+                                f'/{self.fmt_mb(size_score[m]["stats"]["rss"])}]'
+                            print(f' {s:<{mcol_sw}}', end='')
+                        else:
+                            print(' '*mcol_width, end='')
+                    if len(errors):
+                        print(f' {"/".join(errors):<20}')
+                    else:
+                        print(f' {"-":^20}')
 
 
 def parse_size(s):

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -553,7 +553,9 @@ def main():
     handshakes = True
     downloads = [1024 * 1024, 10 * 1024 * 1024, 100 * 1024 * 1024]
     if args.download is not None:
-        downloads = sorted([parse_size(x) for x in args.download])
+        downloads = []
+        for x in args.download:
+            downloads.extend([parse_size(s) for s in x.split(',')])
     requests = True
     if args.downloads or args.requests or args.handshakes:
         handshakes = args.handshakes

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -238,7 +238,7 @@ class TestUpload:
         count = 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put?id=[0-{count-1}]&chunk_delay=2ms'
-        r = curl.http_put(urls=[url], fdata=fdata, alpn_proto=proto, with_profile=True,
+        r = curl.http_put(urls=[url], fdata=fdata, alpn_proto=proto,
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         exp_data = [f'{os.path.getsize(fdata)}']
@@ -246,7 +246,6 @@ class TestUpload:
         for i in range(count):
             respdata = open(curl.response_file(i)).readlines()
             assert respdata == exp_data
-        assert r.profile.avg_cpu < 0.5, f'average cpu too high: {r.profile.avg_cpu*100:.1f}%'
 
     # issue #10591
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -28,6 +28,7 @@ import difflib
 import filecmp
 import logging
 import os
+import time
 import pytest
 
 from testenv import Env, CurlClient
@@ -237,7 +238,7 @@ class TestUpload:
         count = 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put?id=[0-{count-1}]&chunk_delay=2ms'
-        r = curl.http_put(urls=[url], fdata=fdata, alpn_proto=proto,
+        r = curl.http_put(urls=[url], fdata=fdata, alpn_proto=proto, with_profile=True,
                              extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         exp_data = [f'{os.path.getsize(fdata)}']
@@ -245,6 +246,7 @@ class TestUpload:
         for i in range(count):
             respdata = open(curl.response_file(i)).readlines()
             assert respdata == exp_data
+        assert r.profile.avg_cpu < 0.5, f'average cpu too high: {r.profile.avg_cpu*100:.1f}%'
 
     # issue #10591
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])

--- a/tests/http/testenv/__init__.py
+++ b/tests/http/testenv/__init__.py
@@ -32,7 +32,7 @@ from .env import Env
 from .certs import TestCA, Credentials
 from .caddy import Caddy
 from .httpd import Httpd
-from .curl import CurlClient, ExecResult
+from .curl import CurlClient, ExecResult, RunProfile
 from .client import LocalClient
 from .nghttpx import Nghttpx
 from .nghttpx import Nghttpx, NghttpxQuic, NghttpxFwd


### PR DESCRIPTION
Track CPU usage and RSS numbers on `curl` during scorecard runs. Example:

```
> python3 tests/http/scorecard.py -d h2
...
H2 in curl 8.6.0-DEV ...
Downloads
  Server       Size   single(1x) [cpu/rss]          serial(50x) [cpu/rss]         parallel(50x) [cpu/rss]                Errors
  httpd         1MB      21 MB/s [62.9%/3 MB]          397 MB/s [79.7%/9 MB]          395 MB/s [93.2%/38 MB]              -
  httpd        10MB     176 MB/s [74.3%/7 MB]          924 MB/s [95.8%/20 MB]         616 MB/s [99.8%/343 MB]             -
  httpd       100MB     730 MB/s [95.2%/16 MB]        1098 MB/s [98.7%/19 MB]        1099 MB/s [99.9%/283 MB]             -

```
