### PR TITLE
tests: avoid some int/size_t conversion size/sign warnings

### DIFF
--- a/tests/libtest/stub_gssapi.c
+++ b/tests/libtest/stub_gssapi.c
@@ -91,8 +91,8 @@ OM_uint32 gss_init_sec_context(OM_uint32 *min,
             OM_uint32 *time_rec)
 {
   /* The token will be encoded in base64 */
-  int length = APPROX_TOKEN_LEN * 3 / 4;
-  int used = 0;
+  size_t length = APPROX_TOKEN_LEN * 3 / 4;
+  size_t used = 0;
   char *token = NULL;
   const char *creds = NULL;
   gss_ctx_id_t ctx = NULL;
@@ -219,8 +219,8 @@ OM_uint32 gss_init_sec_context(OM_uint32 *min,
   /* Token format: creds:target:type:padding */
   /* Note: this is using the *real* snprintf() and not the curl provided
      one */
-  used = snprintf(token, length, "%s:%s:%d:", creds,
-                  (char *) target_name, ctx->sent);
+  used = (size_t) snprintf(token, length, "%s:%s:%d:", creds,
+                           (char *) target_name, ctx->sent);
 
   if(used >= length) {
     free(token);


### PR DESCRIPTION
Silent the following warnings:
```
stub_gssapi.c: In function 'gss_init_sec_context':
stub_gssapi.c:212:18: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
  212 |   token = malloc(length);
      |                  ^~~~~~
stub_gssapi.c:222:26: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
  222 |   used = snprintf(token, length, "%s:%s:%d:", creds,
      |                          ^~~~~~
stub_gssapi.c:233:36: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
  233 |   memset(token + used, 'A', length - used);
      |                             ~~~~~~~^~~~~~
stub_gssapi.c:238:26: warning: conversion to 'size_t' {aka 'long unsigned int'} from 'int' may change the sign of the result [-Wsign-conversion]
  238 |   output_token->length = length;
      |                          ^~~~~~
```

As a side effect, it also fixes an `snprintf()` error detection.