### PR TITLE
urlapi: remove assert

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1264,7 +1264,6 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
     pathlen -= fraglen;
   }
 
-  DEBUGASSERT(pathlen < urllen);
   query = memchr(path, '?', pathlen);
   if(query) {
     size_t qlen = fragment ? (size_t)(fragment - query) :


### PR DESCRIPTION
This assert triggers wrongly when CURLU_GUESS_SCHEME and CURLU_NO_AUTHORITY are both set and the URL is a single path.

I think this assert has played out its role. It was introduced in a rather big refactor.

Follow-up to 4cfa5bcc9a

Reported-by: promptfuzz_ on hackerone