### PR TITLE
http: check for "Host:" case insensitively

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2192,7 +2192,7 @@ CURLcode Curl_http_host(struct Curl_easy *data, struct connectdata *conn)
     }
 #endif
 
-    if(strcmp("Host:", ptr)) {
+    if(!strcasecompare("Host:", ptr)) {
       aptr->host = aprintf("Host:%s\r\n", &ptr[5]);
       if(!aptr->host)
         return CURLE_OUT_OF_MEMORY;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -72,7 +72,7 @@ test417 test418 test419 test420 test421 test422 test423 test424 test425 \
 test426 test427 test428 test429 test430 test431 test432 test433 test434 \
 test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
-test453 test454 test455 test456 test457 test458 test459 test460 \
+test453 test454 test455 test456 test457 test458 test459 test460 test461 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 \

--- a/tests/data/test461
+++ b/tests/data/test461
@@ -1,0 +1,48 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+--header
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+disable Host: when specified as lower case
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -H host:
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+GET /%TESTNUMBER HTTP/1.1
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
When checking if the user wants to replace the header, the check should be case insensitive.

Adding test 461 to verify

Found-by: Dan Fandrich
Ref: #12782