### PR TITLE
tool: fix the listhelp generation command

### DIFF
--- a/docs/cmdline-opts/Makefile.am
+++ b/docs/cmdline-opts/Makefile.am
@@ -39,3 +39,6 @@ all: $(MANPAGE)
 
 $(MANPAGE): $(DPAGES) $(SUPPORT) mainpage.idx Makefile.inc gen.pl
 	$(GEN)(rm -f $(MANPAGE) && cd $(srcdir) && @PERL@ ./gen.pl mainpage $(DPAGES) > $(builddir)/manpage.tmp && mv $(builddir)/manpage.tmp $(MANPAGE))
+
+listhelp:
+	./gen.pl listhelp $(DPAGES) > $(top_builddir)/src/tool_listhelp.c

--- a/docs/cmdline-opts/gen.pl
+++ b/docs/cmdline-opts/gen.pl
@@ -727,10 +727,10 @@ sub listhelp {
 
 /*
  * DO NOT edit tool_listhelp.c manually.
- * This source file is generated with the following command:
-
-  cd \$srcroot/docs/cmdline-opts
-  ./gen.pl listhelp *.d > \$srcroot/src/tool_listhelp.c
+ * This source file is generated with the following command in an autotools
+ * build:
+ *
+ * "make listhelp"
  */
 
 const struct helptxt helptext[] = {

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -157,7 +157,7 @@ tidy:
 	$(TIDY) $(CURL_CFILES) $(TIDYFLAGS) -- $(curl_CPPFLAGS) $(CPPFLAGS) -DHAVE_CONFIG_H
 
 listhelp:
-	(cd $(top_srcdir)/docs/cmdline-opts && ./gen.pl listhelp *.d) > tool_listhelp.c
+	(cd $(top_srcdir)/docs/cmdline-opts && make listhelp)
 
 if HAVE_WINDRES
 .rc.o:

--- a/src/tool_listhelp.c
+++ b/src/tool_listhelp.c
@@ -26,10 +26,10 @@
 
 /*
  * DO NOT edit tool_listhelp.c manually.
- * This source file is generated with the following command:
-
-  cd $srcroot/docs/cmdline-opts
-  ./gen.pl listhelp *.d > $srcroot/src/tool_listhelp.c
+ * This source file is generated with the following command in an autotools
+ * build:
+ *
+ * "make listhelp"
  */
 
 const struct helptxt helptext[] = {


### PR DESCRIPTION
The previous command line to generate the tool_listhelp.c source file broke with 2494b8dd5175cee7.

Make 'make listhelp' invoked in src/ generate it. Also update the comment in the file to mention the right procedure.