### PR TITLE
sasl: use http authentication mechanisms as a default, not a preset

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -205,18 +205,23 @@ void Curl_sasl_init(struct SASL *sasl, struct Curl_easy *data,
   sasl->force_ir = FALSE;          /* Respect external option */
 
   if(auth != CURLAUTH_BASIC) {
-    sasl->resetprefs = FALSE;
-    sasl->prefmech = SASL_AUTH_NONE;
+    unsigned short mechs = SASL_AUTH_NONE;
+
+    /* If some usable http authentication options have been set, determine
+       new defaults from them. */
     if(auth & CURLAUTH_BASIC)
-      sasl->prefmech |= SASL_MECH_PLAIN | SASL_MECH_LOGIN;
+      mechs |= SASL_MECH_PLAIN | SASL_MECH_LOGIN;
     if(auth & CURLAUTH_DIGEST)
-      sasl->prefmech |= SASL_MECH_DIGEST_MD5;
+      mechs |= SASL_MECH_DIGEST_MD5;
     if(auth & CURLAUTH_NTLM)
-      sasl->prefmech |= SASL_MECH_NTLM;
+      mechs |= SASL_MECH_NTLM;
     if(auth & CURLAUTH_BEARER)
-      sasl->prefmech |= SASL_MECH_OAUTHBEARER | SASL_MECH_XOAUTH2;
+      mechs |= SASL_MECH_OAUTHBEARER | SASL_MECH_XOAUTH2;
     if(auth & CURLAUTH_GSSAPI)
-      sasl->prefmech |= SASL_MECH_GSSAPI;
+      mechs |= SASL_MECH_GSSAPI;
+
+    if(mechs != SASL_AUTH_NONE)
+      sasl->prefmech = mechs;
   }
 }
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -125,7 +125,7 @@ test952 test953 test954 test955 test956 test957 test958 test959 test960 \
 test961 test962 test963 test964 test965 test966 test967 test968 test969 \
 test970 test971 test972 test973 test974 test975 test976 test977 test978 \
 test979 test980 test981 test982 test983 test984 test985 test986 test987 \
-test988 test989 test990 test991 \
+test988 test989 test990 test991 test992 \
 \
 test1000 test1001 test1002 test1003 test1004 test1005 test1006 test1007 \
 test1008 test1009 test1010 test1011 test1012 test1013 test1014 test1015 \

--- a/tests/data/test992
+++ b/tests/data/test992
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+SASL
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<servercmd>
+AUTH OAUTHBEARER XOAUTH2
+REPLY AUTH 334 XOAUTH2 supported
+REPLY dXNlcj11c2VyAWF1dGg9QmVhcmVyIG1GXzkuQjVmLTQuMUpxTQEB 235 Authenticated
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+smtp
+</server>
+<name>
+SASL verify default mechanisms are reset by login options
+</name>
+<stdin>
+mail body
+</stdin>
+<command>
+smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt recipient@example.com --mail-from sender@example.com -u user --oauth2-bearer mF_9.B5f-4.1JqM --login-options "AUTH=XOAUTH2" -T -
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+EHLO %TESTNUMBER
+AUTH XOAUTH2
+dXNlcj11c2VyAWF1dGg9QmVhcmVyIG1GXzkuQjVmLTQuMUpxTQEB
+MAIL FROM:<sender@example.com>
+RCPT TO:<recipient@example.com>
+DATA
+QUIT
+</protocol>
+<upload>
+mail body
+.
+</upload>
+</verify>
+</testcase>


### PR DESCRIPTION
If some are given, sasl maps http authentication options to sasl ones and merges them to the login options.
This may cause problems with the cli tool that sets the http login option CURLAUTH_BEARER as a side-effect of --oauth2-bearer, because this flag maps to more than one sasl mechanisms and the latter cannot be cleared individually by the login options string.
The solution retained here is to consider http authentication options as a default (overriding the hardcoded default mask for the protocol) that is ignored if a login option string is given.

New test 992 checks this.

Fixes #10259