### PR TITLE
krb5: ignore clang warnings on mvsnprintf()

### DIFF
--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -435,6 +435,9 @@ static char level_to_char(int level)
 /* Send an FTP command defined by |message| and the optional arguments. The
    function returns the ftp_code. If an error occurs, -1 is returned. */
 static int ftp_send_command(struct Curl_easy *data, const char *message, ...)
+  CURL_PRINTF(2, 3);
+
+static int ftp_send_command(struct Curl_easy *data, const char *message, ...)
 {
   int ftp_code;
   ssize_t nread = 0;


### PR DESCRIPTION
"error: format string is not a string literal"