### PR TITLE
configure: error out on multissl + http3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -720,6 +720,10 @@ if(USE_MSH3)
   list(APPEND CURL_LIBS ${MSH3_LIBRARIES})
 endif()
 
+if(CURL_WITH_MULTI_SSL AND (USE_NGTCP2 OR USE_QUICHE OR USE_MSH3))
+  message(FATAL_ERROR "MultiSSL cannot be enabled with HTTP/3 and vice versa.")
+endif()
+
 if(NOT CURL_DISABLE_SRP AND (HAVE_GNUTLS_SRP OR HAVE_OPENSSL_SRP))
   set(USE_TLS_SRP 1)
 endif()

--- a/configure.ac
+++ b/configure.ac
@@ -4691,6 +4691,9 @@ fi
 
 if test "x$USE_NGTCP2_H3" = "x1" -o "x$USE_QUICHE" = "x1" \
     -o "x$USE_OPENSSL_H3" = "x1" -o "x$USE_MSH3" = "x1"; then
+  if test "x$CURL_WITH_MULTI_SSL" = "x1"; then
+    AC_MSG_ERROR([MultiSSL cannot be enabled with HTTP/3 and vice versa])
+  fi
   SUPPORT_FEATURES="$SUPPORT_FEATURES HTTP3"
 fi
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -829,6 +829,11 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #if (defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || \
     (defined(USE_OPENSSL_QUIC) && defined(USE_NGHTTP3)) || \
     defined(USE_QUICHE) || defined(USE_MSH3)
+
+#ifdef CURL_WITH_MULTI_SSL
+#error "Multi-SSL combined with QUIC is not supported"
+#endif
+
 #define ENABLE_QUIC
 #define USE_HTTP3
 #endif


### PR DESCRIPTION
Since the QUIC/h3 code has not knowledge or handling of multissl it might bring unintended consequences if we allow it.

Ref: #12806