### PR TITLE
build: delete/replace clang warning pragmas

### DIFF
--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -92,14 +92,7 @@ void Curl_failf(struct Curl_easy *data, const char *fmt, ...)
     int len;
     char error[CURL_ERROR_SIZE + 2];
     va_start(ap, fmt);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
     len = mvsnprintf(error, CURL_ERROR_SIZE, fmt, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
     if(data->set.errorbuffer && !data->state.errorbuf) {
       strcpy(data->set.errorbuffer, error);
@@ -125,14 +118,7 @@ void Curl_infof(struct Curl_easy *data, const char *fmt, ...)
     int len;
     char buffer[MAXINFO + 2];
     va_start(ap, fmt);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
     len = mvsnprintf(buffer, MAXINFO, fmt, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     va_end(ap);
     buffer[len++] = '\n';
     buffer[len] = '\0';
@@ -150,14 +136,7 @@ void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
     char buffer[MAXINFO + 2];
     len = msnprintf(buffer, MAXINFO, "[%s] ", cf->cft->name);
     va_start(ap, fmt);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
     len += mvsnprintf(buffer + len, MAXINFO - len, fmt, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     va_end(ap);
     buffer[len++] = '\n';
     buffer[len] = '\0';

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -135,14 +135,7 @@ static CURLcode sendf(curl_socket_t sockfd, struct Curl_easy *data,
   char *sptr;
   va_list ap;
   va_start(ap, fmt);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
   s = vaprintf(fmt, ap); /* returns an allocated string */
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
   va_end(ap);
   if(!s)
     return CURLE_OUT_OF_MEMORY; /* failure */

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -204,14 +204,7 @@ CURLcode Curl_dyn_vaddf(struct dynbuf *s, const char *fmt, va_list ap)
   return CURLE_OUT_OF_MEMORY;
 #else
   char *str;
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
   str = vaprintf(fmt, ap); /* this allocs a new string to append */
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
   if(str) {
     CURLcode result = dyn_nappend(s, (unsigned char *)str, strlen(str));

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -448,14 +448,7 @@ void curl_dbg_log(const char *format, ...)
     return;
 
   va_start(ap, format);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
   nchars = mvsnprintf(buf, LOGLINE_BUFSIZE, format, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
   va_end(ap);
 
   if(nchars > LOGLINE_BUFSIZE - 1)

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1677,14 +1677,7 @@ CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...)
   va_list ap;
 
   va_start(ap, fmt);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
   s = curl_mvaprintf(fmt, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
   va_end(ap);
 
   if(s) {

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -113,14 +113,7 @@ CURLcode easysrc_addf(struct slist_wc **plist, const char *fmt, ...)
   char *bufp;
   va_list ap;
   va_start(ap, fmt);
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
   bufp = curlx_mvaprintf(fmt, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
   va_end(ap);
   if(!bufp) {
     ret = CURLE_OUT_OF_MEMORY;

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -53,14 +53,7 @@ static void voutf(struct GlobalConfig *config,
     char *ptr;
     char *print_buffer;
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
     print_buffer = curlx_mvaprintf(fmt, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     if(!print_buffer)
       return;
     len = strlen(print_buffer);

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -240,22 +240,15 @@ static char *c_escape(const char *str, curl_off_t len)
       if(p && *p)
         result = curlx_dyn_addn(&escaped, to + 2 * (p - from), 2);
       else {
-        const char *format = "\\x%02x";
-
         if(len > 1 && ISXDIGIT(s[1])) {
           /* Octal escape to avoid >2 digit hex. */
-          format = "\\%03o";
+          result = curlx_dyn_addf(&escaped, "\\%03o",
+                                  (unsigned int) *(unsigned char *) s);
         }
-
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
-        result = curlx_dyn_addf(&escaped, format,
-                                (unsigned int) *(unsigned char *) s);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
+        else {
+          result = curlx_dyn_addf(&escaped, "\\x%02x",
+                                  (unsigned int) *(unsigned char *) s);
+        }
       }
     }
   }

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -240,15 +240,11 @@ static char *c_escape(const char *str, curl_off_t len)
       if(p && *p)
         result = curlx_dyn_addn(&escaped, to + 2 * (p - from), 2);
       else {
-        if(len > 1 && ISXDIGIT(s[1])) {
-          /* Octal escape to avoid >2 digit hex. */
-          result = curlx_dyn_addf(&escaped, "\\%03o",
-                                  (unsigned int) *(unsigned char *) s);
-        }
-        else {
-          result = curlx_dyn_addf(&escaped, "\\x%02x",
-                                  (unsigned int) *(unsigned char *) s);
-        }
+        result = curlx_dyn_addf(&escaped,
+                                /* Octal escape to avoid >2 digit hex. */
+                                (len > 1 && ISXDIGIT(s[1])) ?
+                                  "\\%03o" : "\\x%02x",
+                                (unsigned int) *(unsigned char *) s);
       }
     }
   }

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1639,7 +1639,6 @@ static char bigpart[120000];
  */
 static int huge(void)
 {
-  const char *url = "%s://%s:%s@%s/%s?%s#%s";
   const char *smallpart = "c";
   int i;
   CURLU *urlp = curl_url();
@@ -1662,12 +1661,8 @@ static int huge(void)
 
   for(i = 0; i <  7; i++) {
     char *partp;
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
     msnprintf(total, sizeof(total),
-              url,
+              "%s://%s:%s@%s/%s?%s#%s",
               (i == 0)? &bigpart[1] : smallpart,
               (i == 1)? &bigpart[1] : smallpart,
               (i == 2)? &bigpart[1] : smallpart,
@@ -1675,9 +1670,6 @@ static int huge(void)
               (i == 4)? &bigpart[1] : smallpart,
               (i == 5)? &bigpart[1] : smallpart,
               (i == 6)? &bigpart[1] : smallpart);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     rc = curl_url_set(urlp, CURLUPART_URL, total, CURLU_NON_SUPPORT_SCHEME);
     if((!i && (rc != CURLUE_BAD_SCHEME)) ||
        (i && rc)) {


### PR DESCRIPTION
- delete redundant warning suppressions for `-Wformat-nonliteral`.
  This now relies on `CURL_PRINTF()` and it's theoratically possible
  that this macro isn't active but the warning is. We're ignoring this
  as a corner-case here.

- replace two pragmas with code changes to avoid the warnings.

Follow-up to aee4ebe59161d0a5281743f96e7738ad97fe1cd4 #12803
Follow-up to 09230127589eccc7e01c1a7217787ef8e64f3328 #12540
Follow-up to 3829759bd042c03225ae862062560f568ba1a231 #12489

Closes #12812
