### PR TITLE
build: delete/replace 3 more clang warning pragmas

### DIFF
--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -46,13 +46,15 @@ extern "C" {
 #define CURL_TEMP_PRINTF(fmt, arg)
 #endif
 
-CURL_EXTERN int curl_mprintf(const char *format, ...) CURL_TEMP_PRINTF(1, 2);
+CURL_EXTERN int curl_mprintf(const char *format, ...)
+  CURL_TEMP_PRINTF(1, 2);
 CURL_EXTERN int curl_mfprintf(FILE *fd, const char *format, ...)
   CURL_TEMP_PRINTF(2, 3);
 CURL_EXTERN int curl_msprintf(char *buffer, const char *format, ...)
   CURL_TEMP_PRINTF(2, 3);
 CURL_EXTERN int curl_msnprintf(char *buffer, size_t maxlength,
-                               const char *format, ...) CURL_TEMP_PRINTF(3, 4);
+                               const char *format, ...)
+  CURL_TEMP_PRINTF(3, 4);
 CURL_EXTERN int curl_mvprintf(const char *format, va_list args)
   CURL_TEMP_PRINTF(1, 0);
 CURL_EXTERN int curl_mvfprintf(FILE *fd, const char *format, va_list args)

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -124,14 +124,7 @@ void helpf(FILE *errors, const char *fmt, ...)
     va_start(ap, fmt);
     DEBUGASSERT(!strchr(fmt, '\n'));
     fputs("curl: ", errors); /* prefix it */
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
-#endif
     vfprintf(errors, fmt, ap);
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
     va_end(ap);
     fputs("\n", errors); /* newline it */
   }

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -357,7 +357,7 @@ static int rlimit(int keep_open)
 
       msnprintf(strbuff1, sizeof(strbuff), fmt, num_open.rlim_cur);
       msnprintf(strbuff, sizeof(strbuff), "fds system limit seems close to %s",
-               strbuff1);
+                strbuff1);
       fprintf(stderr, "%s\n", strbuff);
 
       num_open.rlim_max = NUM_NEEDED;
@@ -365,7 +365,7 @@ static int rlimit(int keep_open)
       msnprintf(strbuff2, sizeof(strbuff2), fmt, num_open.rlim_max);
       msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
       msnprintf(strbuff, sizeof(strbuff), "fds needed %s > system limit %s",
-               strbuff2, strbuff1);
+                strbuff2, strbuff1);
       store_errmsg(strbuff, 0);
       fprintf(stderr, "%s\n", msgbuff);
 
@@ -377,9 +377,7 @@ static int rlimit(int keep_open)
       fd = NULL;
       free(memchunk);
       return -9;
-
     }
-
   }
 
   msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
@@ -401,7 +399,7 @@ static int rlimit(int keep_open)
   num_open.rlim_cur = FD_SETSIZE - SAFETY_MARGIN;
   if(num_open.rlim_max > num_open.rlim_cur) {
     msnprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
-             FD_SETSIZE);
+              FD_SETSIZE);
     store_errmsg(strbuff, 0);
     fprintf(stderr, "%s\n", msgbuff);
     close_file_descriptors();
@@ -416,7 +414,7 @@ static int rlimit(int keep_open)
     if((fd[rl.rlim_cur] > 0) &&
        ((unsigned int)fd[rl.rlim_cur] > num_open.rlim_cur)) {
       msnprintf(strbuff, sizeof(strbuff), "select limit is FD_SETSIZE %d",
-               FD_SETSIZE);
+                FD_SETSIZE);
       store_errmsg(strbuff, 0);
       fprintf(stderr, "%s\n", msgbuff);
       close_file_descriptors();
@@ -438,12 +436,10 @@ static int rlimit(int keep_open)
 
   if(!fopen_works()) {
     msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
-    msnprintf(strbuff, sizeof(strbuff),
-             "fopen fails with %s fds open()",
-             strbuff1);
+    msnprintf(strbuff, sizeof(strbuff), "fopen fails with %s fds open()",
+              strbuff1);
     fprintf(stderr, "%s\n", msgbuff);
-    msnprintf(strbuff, sizeof(strbuff),
-             "fopen fails with lots of fds open()");
+    msnprintf(strbuff, sizeof(strbuff), "fopen fails with lots of fds open()");
     store_errmsg(strbuff, 0);
     close_file_descriptors();
     free(memchunk);

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -106,7 +106,7 @@ static int fopen_works(void)
 
 static int rlimit(int keep_open)
 {
-  int nitems, i;
+  rlim_t nitems, i;
   int *memchunk = NULL;
   char *fmt;
   struct rlimit rl;
@@ -263,7 +263,7 @@ static int rlimit(int keep_open)
   if(nitems > 0x7fff)
     nitems = 0x40000;
   do {
-    num_open.rlim_max = sizeof(*memchunk) * (size_t)nitems;
+    num_open.rlim_max = sizeof(*memchunk) * nitems;
     msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
     fprintf(stderr, "allocating memchunk %s byte array\n", strbuff);
     memchunk = malloc(sizeof(*memchunk) * (size_t)nitems);
@@ -355,7 +355,7 @@ static int rlimit(int keep_open)
       msnprintf(strbuff, sizeof(strbuff), "dup() attempt %s failed", strbuff1);
       fprintf(stderr, "%s\n", strbuff);
 
-      msnprintf(strbuff1, sizeof(strbuff), fmt, num_open.rlim_cur);
+      msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
       msnprintf(strbuff, sizeof(strbuff), "fds system limit seems close to %s",
                 strbuff1);
       fprintf(stderr, "%s\n", strbuff);
@@ -436,10 +436,10 @@ static int rlimit(int keep_open)
 
   if(!fopen_works()) {
     msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
-    msnprintf(strbuff, sizeof(strbuff), "fopen fails with %s fds open()",
+    msnprintf(strbuff, sizeof(strbuff), "fopen fails with %s fds open",
               strbuff1);
     fprintf(stderr, "%s\n", msgbuff);
-    msnprintf(strbuff, sizeof(strbuff), "fopen fails with lots of fds open()");
+    msnprintf(strbuff, sizeof(strbuff), "fopen fails with lots of fds open");
     store_errmsg(strbuff, 0);
     close_file_descriptors();
     free(memchunk);

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -99,30 +99,35 @@ static int fopen_works(void)
   return ret;
 }
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
+static void rlim2str(char *buf, size_t len, rlim_t val)
+{
+#ifdef RLIM_INFINITY
+  if(val == RLIM_INFINITY) {
+    msnprintf(buf, len, "INFINITY");
+    return;
+  }
 #endif
+#ifdef HAVE_LONGLONG
+  if(sizeof(rlim_t) > sizeof(long))
+    msnprintf(buf, len, "%llu", (unsigned long long)val);
+  else
+#endif
+  {
+    if(sizeof(rlim_t) < sizeof(long))
+      msnprintf(buf, len, "%u", (unsigned int)val);
+    else
+      msnprintf(buf, len, "%lu", (unsigned long)val);
+  }
+}
 
 static int rlimit(int keep_open)
 {
   int *tmpfd;
   rlim_t nitems, i;
   int *memchunk = NULL;
-  char *fmt;
   struct rlimit rl;
   char strbuff[256];
   char strbuff1[81];
-  char fmt_u[] = "%u";
-  char fmt_lu[] = "%lu";
-#ifdef HAVE_LONGLONG
-  char fmt_llu[] = "%llu";
-
-  if(sizeof(rl.rlim_max) > sizeof(long))
-    fmt = fmt_llu;
-  else
-#endif
-    fmt = (sizeof(rl.rlim_max) < sizeof(long))?fmt_u:fmt_lu;
 
   /* get initial open file limits */
 
@@ -134,20 +139,10 @@ static int rlimit(int keep_open)
 
   /* show initial open file limits */
 
-#ifdef RLIM_INFINITY
-  if(rl.rlim_cur == RLIM_INFINITY)
-    strcpy(strbuff, "INFINITY");
-  else
-#endif
-    msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
+  rlim2str(strbuff, sizeof(strbuff), rl.rlim_cur);
   fprintf(stderr, "initial soft limit: %s\n", strbuff);
 
-#ifdef RLIM_INFINITY
-  if(rl.rlim_max == RLIM_INFINITY)
-    strcpy(strbuff, "INFINITY");
-  else
-#endif
-    msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
+  rlim2str(strbuff, sizeof(strbuff), rl.rlim_max);
   fprintf(stderr, "initial hard limit: %s\n", strbuff);
 
   /*
@@ -194,20 +189,10 @@ static int rlimit(int keep_open)
 
     /* show current open file limits */
 
-#ifdef RLIM_INFINITY
-    if(rl.rlim_cur == RLIM_INFINITY)
-      strcpy(strbuff, "INFINITY");
-    else
-#endif
-      msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_cur);
+    rlim2str(strbuff, sizeof(strbuff), rl.rlim_cur);
     fprintf(stderr, "current soft limit: %s\n", strbuff);
 
-#ifdef RLIM_INFINITY
-    if(rl.rlim_max == RLIM_INFINITY)
-      strcpy(strbuff, "INFINITY");
-    else
-#endif
-      msnprintf(strbuff, sizeof(strbuff), fmt, rl.rlim_max);
+    rlim2str(strbuff, sizeof(strbuff), rl.rlim_max);
     fprintf(stderr, "current hard limit: %s\n", strbuff);
 
   } /* (rl.rlim_cur != rl.rlim_max) */
@@ -237,7 +222,7 @@ static int rlimit(int keep_open)
     nitems = 0x40000;
   do {
     num_open.rlim_max = sizeof(*memchunk) * nitems;
-    msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+    rlim2str(strbuff, sizeof(strbuff), num_open.rlim_max);
     fprintf(stderr, "allocating memchunk %s byte array\n", strbuff);
     memchunk = malloc(sizeof(*memchunk) * (size_t)nitems);
     if(!memchunk) {
@@ -280,7 +265,7 @@ static int rlimit(int keep_open)
   /* verify that we won't overflow size_t in malloc() */
 
   if((size_t)(num_open.rlim_max) > ((size_t)-1) / sizeof(*fd)) {
-    msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
+    rlim2str(strbuff1, sizeof(strbuff1), num_open.rlim_max);
     msnprintf(strbuff, sizeof(strbuff), "unable to allocate an array for %s "
               "file descriptors, would overflow size_t", strbuff1);
     store_errmsg(strbuff, 0);
@@ -292,7 +277,7 @@ static int rlimit(int keep_open)
   /* allocate array for file descriptors */
 
   do {
-    msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+    rlim2str(strbuff, sizeof(strbuff), num_open.rlim_max);
     fprintf(stderr, "allocating array for %s file descriptors\n", strbuff);
 
     fd = malloc(sizeof(*fd) * (size_t)(num_open.rlim_max));
@@ -317,7 +302,7 @@ static int rlimit(int keep_open)
       num_open.rlim_cur++)
     fd[num_open.rlim_cur] = -1;
 
-  msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+  rlim2str(strbuff, sizeof(strbuff), num_open.rlim_max);
   fprintf(stderr, "trying to open %s file descriptors\n", strbuff);
 
   /* open a dummy descriptor */
@@ -345,11 +330,11 @@ static int rlimit(int keep_open)
 
       fd[num_open.rlim_cur] = -1;
 
-      msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
+      rlim2str(strbuff1, sizeof(strbuff1), num_open.rlim_cur);
       msnprintf(strbuff, sizeof(strbuff), "dup() attempt %s failed", strbuff1);
       fprintf(stderr, "%s\n", strbuff);
 
-      msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
+      rlim2str(strbuff1, sizeof(strbuff1), num_open.rlim_cur);
       msnprintf(strbuff, sizeof(strbuff), "fds system limit seems close to %s",
                 strbuff1);
       fprintf(stderr, "%s\n", strbuff);
@@ -357,7 +342,7 @@ static int rlimit(int keep_open)
       num_open.rlim_max = num_open.rlim_cur - SAFETY_MARGIN;
 
       num_open.rlim_cur -= num_open.rlim_max;
-      msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_cur);
+      rlim2str(strbuff1, sizeof(strbuff1), num_open.rlim_cur);
       msnprintf(strbuff, sizeof(strbuff), "closing %s file descriptors",
                 strbuff1);
       fprintf(stderr, "%s\n", strbuff);
@@ -369,7 +354,7 @@ static int rlimit(int keep_open)
         fd[num_open.rlim_cur] = -1;
       }
 
-      msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+      rlim2str(strbuff, sizeof(strbuff), num_open.rlim_max);
       fprintf(stderr, "shrinking array for %s file descriptors\n", strbuff);
 
       /* we don't care if we can't shrink it */
@@ -384,7 +369,7 @@ static int rlimit(int keep_open)
     }
   }
 
-  msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
+  rlim2str(strbuff, sizeof(strbuff), num_open.rlim_max);
   fprintf(stderr, "%s file descriptors open\n", strbuff);
 
 #if !defined(HAVE_POLL_FINE) && !defined(USE_WINSOCK)
@@ -439,7 +424,7 @@ static int rlimit(int keep_open)
    */
 
   if(!fopen_works()) {
-    msnprintf(strbuff1, sizeof(strbuff1), fmt, num_open.rlim_max);
+    rlim2str(strbuff1, sizeof(strbuff1), num_open.rlim_max);
     msnprintf(strbuff, sizeof(strbuff), "fopen fails with %s fds open",
               strbuff1);
     fprintf(stderr, "%s\n", msgbuff);
@@ -463,10 +448,6 @@ static int rlimit(int keep_open)
 
   return 0;
 }
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
 
 int test(char *URL)
 {

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -59,8 +59,8 @@ static void store_errmsg(const char *msg, int err)
   if(!err)
     msnprintf(msgbuff, sizeof(msgbuff), "%s", msg);
   else
-    msnprintf(msgbuff, sizeof(msgbuff), "%s, errno %d, %s", msg, err,
-              strerror(err));
+    msnprintf(msgbuff, sizeof(msgbuff), "%s, errno %d, %s", msg,
+              err, strerror(err));
 }
 
 static void close_file_descriptors(void)
@@ -163,7 +163,7 @@ static int rlimit(int keep_open)
 
 #ifdef OPEN_MAX
     if((rl.rlim_cur > 0) &&
-        (rl.rlim_cur < OPEN_MAX)) {
+       (rl.rlim_cur < OPEN_MAX)) {
       fprintf(stderr, "raising soft limit up to OPEN_MAX\n");
       rl.rlim_cur = OPEN_MAX;
       if(setrlimit(RLIMIT_NOFILE, &rl) != 0) {
@@ -294,6 +294,7 @@ static int rlimit(int keep_open)
   do {
     msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);
     fprintf(stderr, "allocating array for %s file descriptors\n", strbuff);
+
     fd = malloc(sizeof(*fd) * (size_t)(num_open.rlim_max));
     if(!fd) {
       fprintf(stderr, "fd, malloc() failed\n");
@@ -380,9 +381,7 @@ static int rlimit(int keep_open)
       }
 
       break;
-
     }
-
   }
 
   msnprintf(strbuff, sizeof(strbuff), fmt, num_open.rlim_max);


### PR DESCRIPTION
- tool_msgs: delete redundant `-Wformat-nonliteral` suppression pragma.

- whitespace formatting in `mprintf.h`, lib518, lib537.

- lib518: fix wrong variable in `sizeof()`.

- lib518: bump variables to `rlim_t`.
  Follow-up to e2b394106d543c4615a60795b7fdce04bd4e5090 #1469

- lib518: sync error message with lib537
  Follow-up to 365322b8bcf9efb6a361473d227b70f2032212ce

- lib518, lib537: eliminate `-Wformat-nonliteral` suppression pragmas
  by reworking test code.

Follow-up to 5b286c250829e06a135a6ba998e80beb7f43a734 #12812
Follow-up to aee4ebe59161d0a5281743f96e7738ad97fe1cd4 #12803
Follow-up to 09230127589eccc7e01c1a7217787ef8e64f3328 #12540
Follow-up to 3829759bd042c03225ae862062560f568ba1a231 #12489

Closes #12814

---

TODO:
- [x] ~~split to 4 commits: formatting, lib518/lib537 sync-up, drop pragma, replace pragma~~
  Reworked local commits instead.

https://github.com/curl/curl/pull/12814/files?w=1
