### PR TITLE
cd2nroff: use perl 'strict' and 'warnings'

### DIFF
--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -30,12 +30,15 @@ Converts a curldown file to nroff (man page).
 =end comment
 =cut
 
+use strict;
+use warnings;
+
 my $cd2nroff = "0.1"; # to keep check
 my $dir;
 my $extension;
 my $keepfilename;
 
-while(1) {
+while(@ARGV) {
     if($ARGV[0] eq "-d") {
         shift @ARGV;
         $dir = shift @ARGV;
@@ -95,18 +98,26 @@ sub outseealso {
 
 sub single {
     my @seealso;
+    my $d;
     my ($f)=@_;
-    my $title;
+    my $copyright;
+    my $errors = 0;
+    my $fh;
+    my $line;
+    my $salist;
     my $section;
     my $source;
+    my $spdx;
     my $start = 0;
-    my $errors;
-    my $fh;
-    if($f) {
+    my $title;
+
+    if(defined($f)) {
         open($fh, "<:crlf", "$f") || return 1;
     }
     else {
-        $fh = STDIN;
+        $f = "STDIN";
+        $fh = \*STDIN;
+        binmode($fh, ":crlf");
     }
     while(<$fh>) {
         $line++;
@@ -320,7 +331,9 @@ sub single {
             }
         }
     }
-    close($fh);
+    if($fh != \*STDIN) {
+        close($fh);
+    }
     push @desc, outseealso(@seealso);
     if($dir) {
         if($keepfilename) {


### PR DESCRIPTION
- Use strict and warnings pragmas.

- Set STDIN io layer :crlf so that input is properly read on Windows.

- When STDIN is used as input, the filename $f is now set to "STDIN".

Various error messages in single() use $f for the filename and this way it is not undefined when STDIN.

Closes #xxxx

---

~~Also I'm seeing errant carriage returns `\r` when it reads from STDIN in Windows. In other words `cd2nroff curl_escape.md` does not have exactly the same output as `cd2nroff < curl_escape.md`.~~ (Fixed with binmode to add crlf layer to stdin)