### PR TITLE
Correct example for --form-string

### DIFF
--- a/docs/cmdline-opts/form-string.md
+++ b/docs/cmdline-opts/form-string.md
@@ -11,7 +11,7 @@ Multi: append
 See-also:
   - form
 Example:
-  - --form-string "data" $URL
+  - --form-string "name=data" $URL
 ---
 
 # `--form-string`


### PR DESCRIPTION
```
$  curl --form-string "data" example.com
Warning: Illegally formatted input field
curl: option --form-string: is badly used here
curl: try 'curl --help' for more information
$  curl --form-string "name=data" example.com
<!doctype html>
<html>
[...]
```