### PR TITLE
asyn-thread: use wakeup_close to close the read descriptor

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -581,7 +581,7 @@ static void destroy_async_data(struct Curl_async *async)
      * before the FD is invalidated to avoid EBADF on EPOLL_CTL_DEL
      */
     Curl_multi_closed(data, sock_rd);
-    sclose(sock_rd);
+    wakeup_close(sock_rd);
 #endif
   }
   async->tdata = NULL;


### PR DESCRIPTION
Reported-by: Dan Fandrich
Ref: #12834