### PR TITLE
https-proxy, use IP address and cert with ip in alt names

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2242,9 +2242,11 @@ CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
     /* an alternative name matched */
     ;
   else if(dNSName || iPAddress) {
-    infof(data, " subjectAltName does not match %s", peer->dispname);
+    infof(data, " subjectAltName does not match %s %s",
+          peer->is_ip_address? "ip address" : "host name", peer->dispname);
     failf(data, "SSL: no alternative certificate subject name matches "
-          "target host name '%s'", peer->dispname);
+          "target %s '%s'",
+          peer->is_ip_address? "ip address" : "host name", peer->dispname);
     result = CURLE_PEER_FAILED_VERIFICATION;
   }
   else {

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -70,8 +70,7 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.curl_has_feature('HTTPS-proxy'),
                         reason='curl lacks HTTPS-proxy support')
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
-    @pytest.mark.skipif(condition=not Env.have_nghttpx(), reason="no nghttpx available")
-    def test_10_02_proxys_down(self, env: Env, httpd, nghttpx_fwd, proto, repeat):
+    def test_10_02_proxys_down(self, env: Env, httpd, proto, repeat):
         if proto == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         curl = CurlClient(env=env)
@@ -349,3 +348,19 @@ class TestProxy:
                                extra_args=x2_args)
         r2.check_response(count=2, http_status=200)
         assert r2.total_connects == 2
+
+    # download via https: proxy (no tunnel) using IP address
+    @pytest.mark.skipif(condition=not Env.curl_has_feature('HTTPS-proxy'),
+                        reason='curl lacks HTTPS-proxy support')
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
+    def test_10_14_proxys_ip_addr(self, env: Env, httpd, proto, repeat):
+        if proto == 'h2' and not env.curl_uses_lib('nghttp2'):
+            pytest.skip('only supported with nghttp2')
+        curl = CurlClient(env=env)
+        url = f'http://localhost:{env.http_port}/data.json'
+        xargs = curl.get_proxy_args(proto=proto, use_ip=True)
+        r = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
+                               extra_args=xargs)
+        r.check_response(count=1, http_status=200,
+                         protocol='HTTP/2' if proto == 'h2' else 'HTTP/1.1')
+

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -352,6 +352,7 @@ class TestProxy:
     # download via https: proxy (no tunnel) using IP address
     @pytest.mark.skipif(condition=not Env.curl_has_feature('HTTPS-proxy'),
                         reason='curl lacks HTTPS-proxy support')
+    @pytest.mark.skipif(condition=not Env.curl_uses_lib('bearssl'), reason="ip address cert verification not supported")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_10_14_proxys_ip_addr(self, env: Env, httpd, proto, repeat):
         if proto == 'h2' and not env.curl_uses_lib('nghttp2'):

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -352,7 +352,7 @@ class TestProxy:
     # download via https: proxy (no tunnel) using IP address
     @pytest.mark.skipif(condition=not Env.curl_has_feature('HTTPS-proxy'),
                         reason='curl lacks HTTPS-proxy support')
-    @pytest.mark.skipif(condition=not Env.curl_uses_lib('bearssl'), reason="ip address cert verification not supported")
+    @pytest.mark.skipif(condition=Env.curl_uses_lib('bearssl'), reason="ip address cert verification not supported")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_10_14_proxys_ip_addr(self, env: Env, httpd, proto, repeat):
         if proto == 'h2' and not env.curl_uses_lib('nghttp2'):

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -393,20 +393,22 @@ class CurlClient:
             return os.makedirs(path)
 
     def get_proxy_args(self, proto: str = 'http/1.1',
-                       proxys: bool = True, tunnel: bool = False):
+                       proxys: bool = True, tunnel: bool = False,
+                       use_ip: bool = False):
+        proxy_name = '127.0.0.1' if use_ip else self.env.proxy_domain
         if proxys:
             pport = self.env.pts_port(proto) if tunnel else self.env.proxys_port
             xargs = [
-                '--proxy', f'https://{self.env.proxy_domain}:{pport}/',
-                '--resolve', f'{self.env.proxy_domain}:{pport}:127.0.0.1',
+                '--proxy', f'https://{proxy_name}:{pport}/',
+                '--resolve', f'{proxy_name}:{pport}:127.0.0.1',
                 '--proxy-cacert', self.env.ca.cert_file,
             ]
             if proto == 'h2':
                 xargs.append('--proxy-http2')
         else:
             xargs = [
-                '--proxy', f'http://{self.env.proxy_domain}:{self.env.proxy_port}/',
-                '--resolve', f'{self.env.proxy_domain}:{self.env.proxy_port}:127.0.0.1',
+                '--proxy', f'http://{proxy_name}:{self.env.proxy_port}/',
+                '--resolve', f'{proxy_name}:{self.env.proxy_port}:127.0.0.1',
             ]
         if tunnel:
             xargs.append('--proxytunnel')

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -31,6 +31,7 @@ import socket
 import subprocess
 import sys
 from configparser import ConfigParser, ExtendedInterpolation
+from datetime import timedelta
 from typing import Optional
 
 import pytest
@@ -133,7 +134,7 @@ class EnvConfig:
         self.cert_specs = [
             CertificateSpec(domains=[self.domain1, 'localhost'], key_type='rsa2048'),
             CertificateSpec(domains=[self.domain2], key_type='rsa2048'),
-            CertificateSpec(domains=[self.proxy_domain], key_type='rsa2048'),
+            CertificateSpec(domains=[self.proxy_domain, '127.0.0.1'], key_type='rsa2048'),
             CertificateSpec(name="clientsX", sub_specs=[
                CertificateSpec(name="user1", client=True),
             ]),


### PR DESCRIPTION
- improve info logging when peer verification fails to indicate if DNS name or ip address has been tried to match
- add test case for contacting https proxy with ip address
- add pytest env check on loaded credentials and re-issue when they are no longer valid
- refs #12831