### PR TITLE
sendf: just ignore response body to HEAD

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -575,7 +575,10 @@ static CURLcode cw_download_write(struct Curl_easy *data,
     DEBUGF(infof(data, "did not want a BODY, but seeing %zu bytes",
                  nbytes));
     data->req.download_done = TRUE;
-    return CURLE_OK;
+    if(data->info.header_size)
+      /* if headers have been received, this is fine */
+      return CURLE_OK;
+    return CURLE_WEIRD_SERVER_REPLY;
   }
 
   /* Determine if we see any bytes in excess to what is allowed.

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -575,7 +575,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
     DEBUGF(infof(data, "did not want a BODY, but seeing %zu bytes",
                  nbytes));
     data->req.download_done = TRUE;
-    return CURLE_WEIRD_SERVER_REPLY;
+    return CURLE_OK;
   }
 
   /* Determine if we see any bytes in excess to what is allowed.

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -75,28 +75,28 @@ test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
-\
-test500 test501 test502 test503 test504 test505 test506 test507 test508 \
-test509 test510 test511 test512 test513 test514 test515 test516 test517 \
-test518 test519 test520 test521 test522 test523 test524 test525 test526 \
-test527 test528 test529 test530 test531 test532 test533 test534 test535 \
-        test537 test538 test539 test540 test541 test542 test543 test544 \
-test545 test546 test547 test548 test549 test550 test551 test552 test553 \
-test554 test555 test556 test557 test558 test559 test560 test561 test562 \
-test563 test564 test565 test566 test567 test568 test569 test570 test571 \
-test572 test573 test574 test575 test576 test577 test578 test579 test580 \
-test581 test582 test583 test584 test585 test586 test587 test588 test589 \
-test590 test591 test592 test593 test594 test595 test596 test597 test598 \
-test599 test600 test601 test602 test603 test604 test605 test606 test607 \
-test608 test609 test610 test611 test612 test613 test614 test615 test616 \
-test617 test618 test619 test620 test621 test622 test623 test624 test625 \
-test626 test627 test628 test629 test630 test631 test632 test633 test634 \
-test635 test636 test637 test638 test639 test640 test641 test642 test643 \
-test644 test645 test646 test647 test648 test649 test650 test651 test652 \
-test653 test654 test655 test656 test658 test659 test660 test661 test662 \
-test663 test664 test665 test666 test667 test668 test669 test670 test671 \
-test672 test673 test674 test675 test676 test677 test678 test679 test680 \
-test681 test682 test683 test684 test685 test686 test687 test688 test689 \
+test499 test500 test501 test502 test503 test504 test505 test506 test507 \
+test508 test509 test510 test511 test512 test513 test514 test515 test516 \
+test517 test518 test519 test520 test521 test522 test523 test524 test525 \
+test526 test527 test528 test529 test530 test531 test532 test533 test534 \
+test535         test537 test538 test539 test540 test541 test542 test543 \
+test544 test545 test546 test547 test548 test549 test550 test551 test552 \
+test553 test554 test555 test556 test557 test558 test559 test560 test561 \
+test562 test563 test564 test565 test566 test567 test568 test569 test570 \
+test571 test572 test573 test574 test575 test576 test577 test578 test579 \
+test580 test581 test582 test583 test584 test585 test586 test587 test588 \
+test589 test590 test591 test592 test593 test594 test595 test596 test597 \
+test598 test599 test600 test601 test602 test603 test604 test605 test606 \
+test607 test608 test609 test610 test611 test612 test613 test614 test615 \
+test616 test617 test618 test619 test620 test621 test622 test623 test624 \
+test625 test626 test627 test628 test629 test630 test631 test632 test633 \
+test634 test635 test636 test637 test638 test639 test640 test641 test642 \
+test643 test644 test645 test646 test647 test648 test649 test650 test651 \
+test652 test653 test654 test655 test656 test658 test659 test660 test661 \
+test662 test663 test664 test665 test666 test667 test668 test669 test670 \
+test671 test672 test673 test674 test675 test676 test677 test678 test679 \
+test680 test681 test682 test683 test684 test685 test686 test687 test688 \
+test689 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/test499
+++ b/tests/data/test499
@@ -1,0 +1,65 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+<datacheck crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP HEAD to server still sending a body
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -I
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+HEAD /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test689
+++ b/tests/data/test689
@@ -44,9 +44,9 @@ User-Agent: test567
 Test-Number: 567
 
 </protocol>
-# 8 == CURLE_WEIRD_SERVER_REPLY
+# 85 == CURLE_RTSP_CSEQ_ERROR
 <errorcode>
-8
+85
 </errorcode>
 </verify>
 


### PR DESCRIPTION
and mark the stream for close, but return OK since the response this far was ok. Also because this is what curl has done traditionally.

Test 499 verifies.

Reported-by: Sergey Bronnikov
Bug: https://curl.se/mail/lib-2024-02/0000.html