### PR TITLE
fix(docs): remove `mk-ca-bundle.1` from `man_MANS`

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -26,7 +26,7 @@ AUTOMAKE_OPTIONS = foreign no-dependencies
 
 # EXTRA_DIST breaks with $(abs_builddir) so build it using this variable
 # but distribute it (using the relative file name) in the next variable
-man_MANS = $(abs_builddir)/curl.1 mk-ca-bundle.1
+man_MANS = $(abs_builddir)/curl.1
 noinst_man_MANS = curl.1 mk-ca-bundle.1
 dist_man_MANS = curl-config.1
 CURLPAGES = curl-config.md mk-ca-bundle.md


### PR DESCRIPTION
It seems like it was accidentally added in:
- #12730

Co-authored-by: Lukáš Zaoral <lzaoral@redhat.com>
Signed-off-by: Jan Macku <jamacku@redhat.com>

Follow-up to eefcc1bda4bccd800f5a56a0fe17a2f44a96e88b