### PR TITLE
vtls: revert greedy read, add test case for unclean shutdown

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4688,6 +4688,7 @@ static ssize_t ossl_recv(struct Curl_cfilter *cf,
    * after the first successful BIO_read(), we delay reprting this, so
    * that OpenSSL gives us the data it got already. This prevents us
    * from not seeing server reponses when a TLS shutdown failure happens */
+  CURL_TRC_CF(data, cf, "cf_recv: delay possible close");
   backend->io_delay_subsequent_close = TRUE;
   backend->io_read_iterations = 0;
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -305,13 +305,13 @@ struct ossl_ssl_backend_data {
   X509*    server_cert;
   BIO_METHOD *bio_method;
   CURLcode io_result;       /* result of last BIO cfilter operation */
-  size_t io_read_iterations;
-  bool io_delay_subsequent_close;
 #ifndef HAVE_KEYLOG_CALLBACK
   /* Set to true once a valid keylog entry has been created to avoid dupes. */
   bool     keylog_done;
 #endif
   bool x509_store_setup;            /* x509 store has been set up */
+  bool io_read_zero;       /* TRUE iff BIO_read read a 0-length, no error
+                            * indicative that the connection was closed */
 };
 
 #if defined(HAVE_SSL_X509_STORE_SHARE)
@@ -767,21 +767,10 @@ static int ossl_bio_cf_in_read(BIO *bio, char *buf, int blen)
               blen, (int)nread, result);
   BIO_clear_retry_flags(bio);
   backend->io_result = result;
+  backend->io_read_zero = (nread == 0);
   if(nread < 0) {
     if(CURLE_AGAIN == result)
       BIO_set_retry_read(bio);
-  }
-  else if(nread == 0 &&
-          backend->io_delay_subsequent_close &&
-          backend->io_read_iterations) {
-    /* connection closed. We are not in the first read iteration (OpenSSL
-     * may call us several times during one SSL_read()) and we are
-     * asked to delay the closing to the next SSL_read(). */
-    backend->io_result = CURLE_AGAIN;
-    backend->io_delay_subsequent_close = FALSE;
-    BIO_set_retry_read(bio);
-    nread = -1;
-    Curl_expire(data, 0, EXPIRE_RUN_NOW);
   }
 
   /* Before returning server replies to the SSL instance, we need
@@ -794,8 +783,6 @@ static int ossl_bio_cf_in_read(BIO *bio, char *buf, int blen)
     }
     backend->x509_store_setup = TRUE;
   }
-  /* count our read invocations */
-  backend->io_read_iterations++;
 
   return (int)nread;
 }
@@ -4684,14 +4671,6 @@ static ssize_t ossl_recv(struct Curl_cfilter *cf,
 
   ERR_clear_error();
 
-  /* SSL_read() may call our BIO several times. If the connection closes
-   * after the first successful BIO_read(), we delay reprting this, so
-   * that OpenSSL gives us the data it got already. This prevents us
-   * from not seeing server reponses when a TLS shutdown failure happens */
-  CURL_TRC_CF(data, cf, "cf_recv: delay possible close");
-  backend->io_delay_subsequent_close = TRUE;
-  backend->io_read_iterations = 0;
-
   buffsize = (buffersize > (size_t)INT_MAX) ? INT_MAX : (int)buffersize;
   nread = (ssize_t)SSL_read(backend->handle, buf, buffsize);
 
@@ -4723,6 +4702,28 @@ static ssize_t ossl_recv(struct Curl_cfilter *cf,
         *curlcode = CURLE_AGAIN;
         nread = -1;
         goto out;
+      }
+      if(backend->io_read_zero && (err == SSL_ERROR_SYSCALL)) {
+        /* OpenSSL reports an error on seeing the connection closed.
+         * This is most likely caused by the server not performing
+         * a proper TLS shutdown. OpenSSL 3.2+ changed its default
+         * behaviour on this, it used to ignore it.
+         * The reason for the change is that TLS shutdown is needed
+         * for detecting truncation attacks, e.g. if it was really the
+         * server that closed the connection and not some middlemen
+         * messing with us. We need this protection, UNLESS we run a
+         * protocol that is safe against such attacks.
+         * HTTP/2 is always safe, HTTP/1.x may not be, FTP/IMAP etc.
+         * are not. (HTTP/1.1 is safe on most situations, because
+         * server SHOULD use Content-Length or Transfer-Encoding chunked,
+         * but this is only a SHOULD. */
+        if(Curl_conn_is_multiplex(cf->conn, cf->sockindex)) {
+          CURL_TRC_CF(data, cf, "ossl_recv: suppressing SSL error %d on "
+                      "connection close on multiplexed connection", err);
+          *curlcode = CURLE_OK;
+          nread = 0;
+          goto out;
+        }
       }
       sslerror = ERR_get_error();
       if((nread < 0) || sslerror) {

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1715,32 +1715,11 @@ static ssize_t ssl_cf_recv(struct Curl_cfilter *cf,
 {
   struct cf_call_data save;
   ssize_t nread;
-  size_t ntotal = 0;
 
   CF_DATA_SAVE(save, cf, data);
   *err = CURLE_OK;
-  /* Do receive until we fill the buffer somehwhat or EGAIN, error or EOF */
-  while(!ntotal || (len - ntotal) > (4*1024)) {
-    *err = CURLE_OK;
-    nread = Curl_ssl->recv_plain(cf, data, buf + ntotal, len - ntotal, err);
-    if(nread < 0) {
-      if(*err == CURLE_AGAIN && ntotal > 0) {
-        /* we EAGAINed after having reed data, return the success amount */
-        *err = CURLE_OK;
-        break;
-      }
-      /* we have a an error to report */
-      goto out;
-    }
-    else if(nread == 0) {
-      /* eof */
-      break;
-    }
-    ntotal += (size_t)nread;
-    DEBUGASSERT((size_t)ntotal <= len);
-  }
-  nread = (ssize_t)ntotal;
-out:
+  nread = Curl_ssl->recv_plain(cf, data, buf, len, err);
+
   CURL_TRC_CF(data, cf, "cf_recv(len=%zu) -> %zd, %d", len,
               nread, *err);
   CF_DATA_RESTORE(cf, save);

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1719,7 +1719,13 @@ static ssize_t ssl_cf_recv(struct Curl_cfilter *cf,
   CF_DATA_SAVE(save, cf, data);
   *err = CURLE_OK;
   nread = Curl_ssl->recv_plain(cf, data, buf, len, err);
-
+  if(nread > 0) {
+    DEBUGASSERT((size_t)nread <= len);
+  }
+  else if(nread == 0) {
+    /* eof */
+    *err = CURLE_OK;
+  }
   CURL_TRC_CF(data, cf, "cf_recv(len=%zu) -> %zd, %d", len,
               nread, *err);
   CF_DATA_RESTORE(cf, save);

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -109,7 +109,15 @@ class TestErrors:
         # check that we did a downgrade
         assert r.stats[0]['http_version'] == '1.1', r.dump_logs()
 
-    # download 1 file
+    # On the URL used here, Apache is doing an "unclean" TLS shutdown,
+    # meaning it sends no shutdown notice and just closes TCP.
+    # The HTTP response delivers a body without Content-Length. We expect:
+    # - http/1.0 to fail since it relies on a clean connection close to
+    #   detect the end of the body
+    # - http/1.1 to work since it will used "chunked" transfer encoding
+    #   and stop receiving when that signals the end
+    # - h2 to work since it will signal the end of the response before
+    #   and not see the "unclean" close either
     @pytest.mark.parametrize("proto", ['http/1.0', 'http/1.1', 'h2'])
     def test_05_04_unclean_tls_shutdown(self, env: Env, httpd, nghttpx, repeat, proto):
         if proto == 'h3' and not env.have_h3():
@@ -121,6 +129,9 @@ class TestErrors:
         r = curl.http_download(urls=[url], alpn_proto=proto, extra_args=[
             '--parallel',
         ])
-        r.check_exit_code(0)
-        r.check_response(http_status=200, count=count)
+        if proto == 'http/1.0':
+            r.check_exit_code(56)
+        else:
+            r.check_exit_code(0)
+            r.check_response(http_status=200, count=count)
 

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -47,7 +47,7 @@ class Httpd:
         'authn_core', 'authn_file',
         'authz_user', 'authz_core', 'authz_host',
         'auth_basic', 'auth_digest',
-        'alias', 'env', 'filter', 'headers', 'mime',
+        'alias', 'env', 'filter', 'headers', 'mime', 'setenvif',
         'socache_shmcb',
         'rewrite', 'http2', 'ssl', 'proxy', 'proxy_http', 'proxy_connect',
         'mpm_event',
@@ -389,6 +389,11 @@ class Httpd:
                 f'    <Location /curltest/1_1>',
                 f'      SetHandler curltest-1_1-required',
                 f'    </Location>',
+                f'    <Location /curltest/shutdown_unclean>',
+                f'      SetHandler curltest-tweak',
+                f'      SetEnv force-response-1.0 1',
+                f'    </Location>',
+                f'    SetEnvIf Request_URI "/shutdown_unclean" ssl-unclean=1',
             ])
         if self._auth_digest:
             lines.extend([

--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -347,7 +347,7 @@ static int curltest_tweak_handler(request_rec *r)
                 "request, %s", r->args? r->args : "(no args)");
   r->status = http_status;
   r->clength = -1;
-  r->chunked = 1;
+  r->chunked = (r->proto_num >= HTTP_VERSION(1,1));
   apr_table_setn(r->headers_out, "request-id", request_id);
   apr_table_unset(r->headers_out, "Content-Length");
   /* Discourage content-encodings */


### PR DESCRIPTION
Related to #12844, we see an SSL error reported when the server closes the connection without a proper TLS shutdown message. This PR fixes the consequences of such an error in the following way:

In addition, we see #12885 with "hanging" response handling due to the greedy receives in `vtls.c`.

* `vtls/vtls.c` no longer does "greedy", reverts to the state before 9a90c9dd64d2f03601833a70786d485851bd1b53.
* add test_05_04 to verify behaviour of http/1.0, http/1.1 and h2 against an Apache resource that does an unclean TLS shutdown (no shutdown notice, just closing TCP)
