### PR TITLE
docs: Add missing slashes to CURLOPT_SSLCERT documentation

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSLCERT.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.md
@@ -36,9 +36,9 @@ in order to avoid confusion with a nickname.
 
 (Schannel only) Client certificates can be specified by a path expression to a
 certificate store. (You can import *PFX* to a store first). You can use
-"<store location><store name><thumbprint>" to refer to a certificate in the
+"<store location>\\<store name>\\<thumbprint>" to refer to a certificate in the
 system certificates store, for example,
-**"CurrentUserMY934a7ac6f8a5d579285a74fa"**. The thumbprint is usually a SHA-1
+**"CurrentUser\\MY\\934a7ac6f8a5d579285a74fa"**. The thumbprint is usually a SHA-1
 hex string which you can see in certificate details. Following store locations
 are supported: **CurrentUser**, **LocalMachine**, **CurrentService**,
 **Services**, **CurrentUserGroupPolicy**, **LocalMachineGroupPolicy**,


### PR DESCRIPTION
When setting the `CURLOPT_SSLCERT` option to a certificate thumprint, it is required to have a backslash between the "store location", "store name" and "thumbprint" tokens. These slashes were present in the [previous documentation](https://github.com/curl/curl/blob/02f91d5b6408b7972fdadb938fe9a95907a00a1b/docs/libcurl/opts/CURLOPT_SSLCERT.3), but were removed in the transition to curldown documentation.

This _may_ indicate a bug in the `nroff2cd` script, so there may be more missing slashes in other files. Notably, the [--cert](https://curl.se/docs/manpage.html#-E) documentation does not have this problem, despite having almost identical content. Perhaps because it uses single slashes instead of double.

In addition, I'll note that since the files are now `.md` files, the `"<store location><store name><thumbprint>"` text is showing up as `""` when rendered on [github](https://github.com/curl/curl/blob/master/docs/libcurl/opts/CURLOPT_SSLCERT.md), because angle brackets must be escaped in markdown. The text does show up correctly in the [HTML](https://curl.se/libcurl/c/CURLOPT_SSLCERT.html) documentation. (It will have the slashes if you view after this change is merged). If the angle brackets in the file are replaced with `&lt;` and `&gt;`, the file [renders correctly on github](https://github.com/JDepooter/curl/blob/angle_bracket_test_branch/docs/libcurl/opts/CURLOPT_SSLCERT.md). I don't know how adding escaping here would affect the other generated doc formats, so I have not added that change to this pull request. I can do so if desired.