### PR TITLE
configure: add --disable-docs flag

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -241,10 +241,15 @@ cygwinbin:
 	$(MAKE) -C packages/Win32/cygwin cygwinbin
 
 # We extend the standard install with a custom hook:
+if BUILD_DOCS
 install-data-hook:
 	(cd include && $(MAKE) install)
 	(cd docs && $(MAKE) install)
 	(cd docs/libcurl && $(MAKE) install)
+else
+install-data-hook:
+	(cd include && $(MAKE) install)
+endif
 
 # We extend the standard uninstall with a custom hook:
 uninstall-hook:

--- a/configure.ac
+++ b/configure.ac
@@ -159,6 +159,7 @@ curl_tls_srp_msg="no      (--enable-tls-srp)"
    curl_ipv6_msg="no      (--enable-ipv6)"
 curl_unix_sockets_msg="no      (--enable-unix-sockets)"
     curl_idn_msg="no      (--with-{libidn2,winidn})"
+   curl_docs_msg="enabled (--disable-docs)"
  curl_manual_msg="no      (--enable-manual)"
 curl_libcurl_msg="enabled (--disable-libcurl-option)"
 curl_verbose_msg="enabled (--disable-verbose)"
@@ -995,6 +996,27 @@ AS_HELP_STRING([--disable-mqtt],[Disable MQTT support]),
        ;;
   esac ],
        AC_MSG_RESULT(no)
+)
+
+dnl **********************************************************************
+dnl Check whether to build documentation
+dnl **********************************************************************
+
+AC_MSG_CHECKING([whether to build documentation])
+AC_ARG_ENABLE(docs,
+AS_HELP_STRING([--enable-docs],[Enable documentation])
+AS_HELP_STRING([--disable-docs],[Disable documentation]),
+[ case "$enableval" in
+  no)
+       AC_MSG_RESULT(no)
+       BUILD_DOCS=0
+       ;;
+  *)   AC_MSG_RESULT(yes)
+       BUILD_DOCS=1
+       ;;
+  esac ],
+       AC_MSG_RESULT(yes)
+       BUILD_DOCS=1
 )
 
 dnl **********************************************************************
@@ -3753,6 +3775,16 @@ AC_PATH_PROG( PERL, perl, ,
   $PATH:/usr/local/bin/perl:/usr/bin/:/usr/local/bin )
 AC_SUBST(PERL)
 
+if test -z "$PERL"; then
+  dnl if perl was not found then disable building docs
+  AC_MSG_WARN([disabling documentation])
+  BUILD_DOCS=0
+  curl_docs_msg="no"
+fi
+
+dnl set variable for use in automakefile(s)
+AM_CONDITIONAL(BUILD_DOCS, test x"$BUILD_DOCS" = x1)
+
 AC_PATH_PROGS( NROFF, gnroff nroff, ,
   $PATH:/usr/bin/:/usr/local/bin )
 AC_SUBST(NROFF)
@@ -4939,6 +4971,7 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
   IPv6:             ${curl_ipv6_msg}
   Unix sockets:     ${curl_unix_sockets_msg}
   IDN:              ${curl_idn_msg}
+  Build docs:       ${curl_docs_msg}
   Build libcurl:    Shared=${enable_shared}, Static=${enable_static}
   Built-in manual:  ${curl_manual_msg}
   --libcurl option: ${curl_libcurl_msg}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,7 +45,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 
 bin_PROGRAMS = curl
 
+if BUILD_DOCS
 SUBDIRS = ../docs
+endif
 
 if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB


### PR DESCRIPTION
Building man pages from curldown sources now requires perl. Add a `--disable-docs` flag to configure to enable building and installing without documentation where perl is not available or man pages are not required. This is selected automatically (with a warning) when perl is not found by configure.

Fixes #12832