### PR TITLE
docs: add necessary setup for nghttp3

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -58,6 +58,7 @@ Build nghttp3
      % cd ..
      % git clone -b v1.1.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
+     % git submodule update --init
      % autoreconf -fi
      % ./configure --prefix=<somewhere2> --enable-lib-only
      % make


### PR DESCRIPTION
Now nghttp3 has submodules https://github.com/ngtcp2/nghttp3/blob/main/.gitmodules