### PR TITLE
md4: include strdup.h for the memdup proto

### DIFF
--- a/lib/md4.c
+++ b/lib/md4.c
@@ -28,6 +28,7 @@
 
 #include <string.h>
 
+#include "strdup.h"
 #include "curl_md4.h"
 #include "warnless.h"
 


### PR DESCRIPTION
Reported-by: Erik Schnetter
Fixes: #12849