### PR TITLE
tool_operate: change precedence of server Retry-After time

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -554,7 +554,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
           /* store in a 'long', make sure it doesn't overflow */
           if(retry_after > LONG_MAX/1000)
             sleeptime = LONG_MAX;
-          else
+          else if((retry_after * 1000) > sleeptime)
             sleeptime = (long)retry_after * 1000; /* milliseconds */
 
           /* if adding retry_after seconds to the process would exceed the


### PR DESCRIPTION
- When calculating the retry time, no longer allow a server's requested Retry-After time to take precedence over a longer retry time (either default algorithmic or user-specified).

Prior to this change the server's Retry-After time took precedence over curl's retry time in all cases, but that's not always practical for short Retry-After times depending on how busy the server is.

Bug: https://curl.se/mail/archive-2024-01/0022.html
Reported-by: Dirk Hünniger

Closes #xxxx