### PR TITLE
version: allow building with ancient libpsl

### DIFF
--- a/lib/version.c
+++ b/lib/version.c
@@ -212,9 +212,13 @@ char *curl_version(void)
 
 #ifdef USE_LIBPSL
   {
+#if defined PSL_VERSION_MAJOR && (PSL_VERSION_MAJOR > 0 || PSL_VERSION_MINOR >= 11)
     int num = psl_check_version_number(0);
     msnprintf(psl_version, sizeof(psl_version), "libpsl/%d.%d.%d",
               num >> 16, (num >> 8) & 0xff, num & 0xff);
+#else
+    msnprintf(psl_version, sizeof(psl_version), "libpsl/%s", psl_get_version());
+#endif
     src[i++] = psl_version;
   }
 #endif

--- a/lib/version.c
+++ b/lib/version.c
@@ -212,12 +212,14 @@ char *curl_version(void)
 
 #ifdef USE_LIBPSL
   {
-#if defined PSL_VERSION_MAJOR && (PSL_VERSION_MAJOR > 0 || PSL_VERSION_MINOR >= 11)
+#if defined(PSL_VERSION_MAJOR) && (PSL_VERSION_MAJOR > 0 ||     \
+                                   PSL_VERSION_MINOR >= 11)
     int num = psl_check_version_number(0);
     msnprintf(psl_version, sizeof(psl_version), "libpsl/%d.%d.%d",
               num >> 16, (num >> 8) & 0xff, num & 0xff);
 #else
-    msnprintf(psl_version, sizeof(psl_version), "libpsl/%s", psl_get_version());
+    msnprintf(psl_version, sizeof(psl_version), "libpsl/%s",
+              psl_get_version());
 #endif
     src[i++] = psl_version;
   }


### PR DESCRIPTION
The psl_check_version_number() API was added in libpsl 0.11.0. CentOS 7 ships with version 0.7.0 which lacks this API. Revert to using the older versioning API if we detect an old libpsl version.

Follow-up to 72bd88adde0e8cf6e63644a7d6df1da01a399db4 Bug: https://curl.se/mail/archive-2024-02/0004.html Reported-by: Scott Mutter