### PR TITLE
ftp, do lineend conversions in client writer

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -261,7 +261,7 @@ static void freedirs(struct ftp_conn *ftpc)
  * Lineend Conversions
  * On ASCII transfers, e.g. directory listings, we might get lines
  * ending in '\r\n' and we prefer just '\n'.
- * We might also get a lonley '\r' which we convert into a '\n'.
+ * We might also get a lonely '\r' which we convert into a '\n'.
  */
 struct ftp_cw_lc_ctx {
   struct Curl_cwriter super;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -338,7 +338,7 @@ static CURLcode ftp_cw_lc_write(struct Curl_easy *data,
 }
 
 static const struct Curl_cwtype ftp_cw_lc = {
-  "ws-decode",
+  "ftp-lineconv",
   NULL,
   Curl_cwriter_def_init,
   ftp_cw_lc_write,

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1387,8 +1387,6 @@ struct UrlState {
 #if !defined(_WIN32) && !defined(MSDOS) && !defined(__EMX__)
 /* do FTP line-end conversions on most platforms */
 #define CURL_DO_LINEEND_CONV
-  /* for FTP downloads: track CRLF sequences that span blocks */
-  BIT(prev_block_had_trailing_cr);
   /* for FTP downloads: how many CRLFs did we converted to LFs? */
   curl_off_t crlf_conversions;
 #endif


### PR DESCRIPTION
- remove the ftp special handling from sendf.c
- let ftp_do() add a client writer that does the linened conversions
- change the lineend conversion to no longer modify the passed buffer, but write smaller chunks to the next cwriter instead. The inefficiency of this will be mitigated once we add output buffering for all client writes.