### PR TITLE
cmake: fix function description in comment [ci skip]

### DIFF
--- a/CMake/Utilities.cmake
+++ b/CMake/Utilities.cmake
@@ -23,7 +23,7 @@
 ###########################################################################
 # File containing various utilities
 
-# Returns a list of arguments that evaluate to true
+# Returns number of arguments that evaluate to true
 function(count_true output_count_var)
   set(lst_len 0)
   foreach(option_var IN LISTS ARGN)


### PR DESCRIPTION
Closes #12879
