### PR TITLE
badwords: use hostname, not host name

### DIFF
--- a/.github/scripts/badwords.txt
+++ b/.github/scripts/badwords.txt
@@ -23,14 +23,13 @@ isn't:is not
  a http: an http
  a ftp: an ftp
  url =URL
-internet\W=Internet
+internet\b=Internet
 isation:ization
 it's:it is
 there's:there is
 [^.]\. And: Rewrite it somehow?
 ^(And|So|But) = Rewrite it somehow?
 \. But: Rewrite it somehow?
-file name :filename
 \. So : Rewrite without "so" ?
  dir :directory
 you'd:you would
@@ -38,8 +37,12 @@ you'll:you will
 can't:cannot
 that's:that is
 web page:webpage
-host name\W:hostname
-file name\W:filename
+host name\b:hostname
+host names\b:hostnames
+file name\b:filename
+file names\b:filenames
+user name\b:username
+user names\b:usernames
 didn't:did not
 doesn't:does not
 won't:will not

--- a/docs/CHECKSRC.md
+++ b/docs/CHECKSRC.md
@@ -12,7 +12,7 @@ check that it adheres to our [Source Code Style guide](CODE_STYLE.md).
 `-W[file]` skip that file and exclude it from being checked. Helpful
 when, for example, one of the files is generated.
 
-`-D[dir]` directory name to prepend to file names when accessing them.
+`-D[dir]` directory name to prepend to filenames when accessing them.
 
 `-h` shows the help output, that also lists all recognized warnings
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -26,7 +26,7 @@
  - happy eyeballs dual-stack connects
  - persistent connections
  - SOCKS 4 + 5 support, with or without local name resolving
- - supports user name and password in proxy environment variables
+ - supports username and password in proxy environment variables
  - operations through HTTP proxy "tunnel" (using CONNECT)
  - replaceable memory functions (malloc, free, realloc, etc)
  - asynchronous name resolving (6)

--- a/docs/HSTS.md
+++ b/docs/HSTS.md
@@ -38,5 +38,5 @@ The time stamp is when the entry expires.
 
 ## Possible future additions
 
- - `CURLOPT_HSTS_PRELOAD` - provide a set of HSTS host names to load first
+ - `CURLOPT_HSTS_PRELOAD` - provide a set of HSTS hostnames to load first
  - ability to save to something else than a file

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -824,17 +824,17 @@ with
 
     ALL_PROXY
 
-A comma-separated list of host names that should not go through any proxy is
+A comma-separated list of hostnames that should not go through any proxy is
 set in (only an asterisk, `*` matches all hosts)
 
     NO_PROXY
 
-If the hostname matches one of these strings, or the host is within the
-domain of one of these strings, transactions with that node will not be done
-over proxy. When a domain is used, it needs to start with a period. A user can
+If the hostname matches one of these strings, or the host is within the domain
+of one of these strings, transactions with that node will not be done over
+proxy. When a domain is used, it needs to start with a period. A user can
 specify that both www.example.com and foo.example.com should not use a proxy
 by setting `NO_PROXY` to `.example.com`. By including the full name you can
-exclude specific host names, so to make `www.example.com` not use a proxy but
+exclude specific hostnames, so to make `www.example.com` not use a proxy but
 still have `foo.example.com` do it, set `NO_PROXY` to `www.example.com`.
 
 The usage of the `-x`/`--proxy` flag overrides the environment variables.

--- a/docs/TheArtOfHttpScripting.md
+++ b/docs/TheArtOfHttpScripting.md
@@ -119,7 +119,7 @@
 
     curl --proxy http://proxy.example.org:4321 http://remote.example.org/
 
-## User name and password
+## Username and password
 
  Some services are setup to require HTTP authentication and then you need to
  provide name and password which is then transferred to the remote site in

--- a/docs/URL-SYNTAX.md
+++ b/docs/URL-SYNTAX.md
@@ -147,7 +147,7 @@ schemes:
 
 ## Userinfo
 
-The userinfo field can be used to set user name and password for
+The userinfo field can be used to set username and password for
 authentication purposes in this transfer. The use of this field is discouraged
 since it often means passing around the password in plain text and is thus a
 security risk.
@@ -184,7 +184,7 @@ machine.
 ### IDNA
 
 If curl was built with International Domain Name (IDN) support, it can also
-handle host names using non-ASCII characters.
+handle hostnames using non-ASCII characters.
 
 When built with libidn2, curl uses the IDNA 2008 standard. This is equivalent
 to the WHATWG URL spec, but differs from certain browsers that use IDNA 2003
@@ -357,7 +357,7 @@ file. If the path is omitted entirely then the directory listing for the root
 ## SMB
 The path part of a SMB request specifies the file to retrieve and from what
 share and directory or the share to upload to and as such, may not be omitted.
-If the user name is embedded in the URL then it must contain the domain name
+If the username is embedded in the URL then it must contain the domain name
 and as such, the backslash must be URL encoded as %2f.
 
 When uploading to SMB, the size of the file needs to be known ahead of time,

--- a/docs/libcurl/curl_easy_setopt.md
+++ b/docs/libcurl/curl_easy_setopt.md
@@ -435,15 +435,15 @@ Enable .netrc parsing. See CURLOPT_NETRC(3)
 
 ## CURLOPT_USERPWD
 
-User name and password. See CURLOPT_USERPWD(3)
+Username and password. See CURLOPT_USERPWD(3)
 
 ## CURLOPT_PROXYUSERPWD
 
-Proxy user name and password. See CURLOPT_PROXYUSERPWD(3)
+Proxy username and password. See CURLOPT_PROXYUSERPWD(3)
 
 ## CURLOPT_USERNAME
 
-User name. See CURLOPT_USERNAME(3)
+Username. See CURLOPT_USERNAME(3)
 
 ## CURLOPT_PASSWORD
 
@@ -455,7 +455,7 @@ Login options. See CURLOPT_LOGIN_OPTIONS(3)
 
 ## CURLOPT_PROXYUSERNAME
 
-Proxy user name. See CURLOPT_PROXYUSERNAME(3)
+Proxy username. See CURLOPT_PROXYUSERNAME(3)
 
 ## CURLOPT_PROXYPASSWORD
 
@@ -467,11 +467,11 @@ HTTP server authentication methods. See CURLOPT_HTTPAUTH(3)
 
 ## CURLOPT_TLSAUTH_USERNAME
 
-TLS authentication user name. See CURLOPT_TLSAUTH_USERNAME(3)
+TLS authentication username. See CURLOPT_TLSAUTH_USERNAME(3)
 
 ## CURLOPT_PROXY_TLSAUTH_USERNAME
 
-Proxy TLS authentication user name. See CURLOPT_PROXY_TLSAUTH_USERNAME(3)
+Proxy TLS authentication username. See CURLOPT_PROXY_TLSAUTH_USERNAME(3)
 
 ## CURLOPT_TLSAUTH_PASSWORD
 

--- a/docs/libcurl/curl_formadd.md
+++ b/docs/libcurl/curl_formadd.md
@@ -299,12 +299,12 @@ int main(void)
 
 # AVAILABILITY
 
-Deprecated in 7.56.0. Before this release, field names were allowed to
-contain zero-valued bytes. The pseudo-filename "-" to read stdin is
-discouraged although still supported, but data is not read before being
-actually sent: the effective data size can then not be automatically
-determined, resulting in a chunked encoding transfer. Backslashes and
-double quotes in field and file names are now escaped before transmission.
+Deprecated in 7.56.0. Before this release, field names were allowed to contain
+zero-valued bytes. The pseudo-filename "-" to read stdin is discouraged
+although still supported, but data is not read before being actually sent: the
+effective data size can then not be automatically determined, resulting in a
+chunked encoding transfer. Backslashes and double quotes in field and
+filenames are now escaped before transmission.
 
 # RETURN VALUE
 

--- a/docs/libcurl/curl_mime_filename.md
+++ b/docs/libcurl/curl_mime_filename.md
@@ -12,7 +12,7 @@ See-also:
 
 # NAME
 
-curl_mime_filename - set a mime part's remote file name
+curl_mime_filename - set a mime part's remote filename
 
 # SYNOPSIS
 

--- a/docs/libcurl/curl_mime_type.md
+++ b/docs/libcurl/curl_mime_type.md
@@ -42,7 +42,7 @@ a default mime type is determined by the context:
 
 - application/form-data for an HTTP form post.
 
-- If a remote filename is set, the mime type is taken from the file name
+- If a remote filename is set, the mime type is taken from the filename
 extension, or application/octet-stream by default.
 
 - For a multipart part, multipart/mixed.

--- a/docs/libcurl/curl_url_get.md
+++ b/docs/libcurl/curl_url_get.md
@@ -76,9 +76,9 @@ operation returns an error instead.
 
 ## CURLU_URLENCODE
 
-If set, curl_url_get(3) URL encodes the hostname part when a full URL
-is retrieved. If not set (default), libcurl returns the URL with the host name
-"raw" to support IDN names to appear as-is. IDN host names are typically using
+If set, curl_url_get(3) URL encodes the hostname part when a full URL is
+retrieved. If not set (default), libcurl returns the URL with the hostname raw
+to support IDN names to appear as-is. IDN hostnames are typically using
 non-ASCII bytes that otherwise gets percent-encoded.
 
 Note that even when not asking for URL encoding, the '%' (byte 37) is URL
@@ -119,7 +119,7 @@ When asked to return the full URL, curl_url_get(3) returns a normalized
 and possibly cleaned up version using all available URL parts.
 
 We advise using the *CURLU_PUNYCODE* option to get the URL as "normalized"
-as possible since IDN allows host names to be written in many different ways
+as possible since IDN allows hostnames to be written in many different ways
 that still end up the same punycode version.
 
 ## CURLUPART_SCHEME

--- a/docs/libcurl/libcurl-env.md
+++ b/docs/libcurl/libcurl-env.md
@@ -65,7 +65,7 @@ only) in which the .netrc file is likely to exist.
 
 ## LOGNAME
 
-User name to use when invoking the *ntlm-wb* tool, if *NTLMUSER* was
+Username to use when invoking the *ntlm-wb* tool, if *NTLMUSER* was
 not set.
 
 ## NO_PROXY
@@ -76,7 +76,7 @@ should not use a proxy.
 
 ## NTLMUSER
 
-User name to use when invoking the *ntlm-wb* tool.
+Username to use when invoking the *ntlm-wb* tool.
 
 ## SSLKEYLOGFILE
 
@@ -90,8 +90,8 @@ precautions so that they are not stolen or otherwise inadvertently revealed.
 
 ## USER
 
-User name to use when invoking the *ntlm-wb* tool, if *NTLMUSER* and
-*LOGNAME* were not set.
+Username to use when invoking the *ntlm-wb* tool, if *NTLMUSER* and *LOGNAME*
+were not set.
 
 # Debug Variables
 

--- a/docs/libcurl/libcurl-security.md
+++ b/docs/libcurl/libcurl-security.md
@@ -218,15 +218,15 @@ information to be sent to an unknown second server. Applications can mitigate
 against this by disabling CURLOPT_FOLLOWLOCATION(3) and handling
 redirects itself, sanitizing where necessary.
 
-Use of the CURLAUTH_ANY option to CURLOPT_HTTPAUTH(3) could result in
-user name and password being sent in clear text to an HTTP server. Instead,
-use CURLAUTH_ANYSAFE which ensures that the password is encrypted over the
+Use of the CURLAUTH_ANY option to CURLOPT_HTTPAUTH(3) could result in username
+and password being sent in clear text to an HTTP server. Instead, use
+CURLAUTH_ANYSAFE which ensures that the password is encrypted over the
 network, or else fail the request.
 
 Use of the CURLUSESSL_TRY option to CURLOPT_USE_SSL(3) could result in
-user name and password being sent in clear text to an FTP server. Instead,
-use CURLUSESSL_CONTROL to ensure that an encrypted connection is used or else
-fail the request.
+username and password being sent in clear text to an FTP server. Instead, use
+CURLUSESSL_CONTROL to ensure that an encrypted connection is used or else fail
+the request.
 
 # Cookies
 
@@ -419,14 +419,14 @@ plain HTTP connection.
 
 Relatedly, be aware that in situations when you have problems with libcurl and
 ask someone for help, everything you reveal in order to get best possible help
-might also impose certain security related risks. Host names, user names,
-paths, operating system specifics, etc. (not to mention passwords of course)
-may in fact be used by intruders to gain additional information of a potential
+might also impose certain security related risks. Hostnames, usernames, paths,
+operating system specifics, etc. (not to mention passwords of course) may in
+fact be used by intruders to gain additional information of a potential
 target.
 
 Be sure to limit access to application logs if they could hold private or
-security-related data. Besides the obvious candidates like user names and
-passwords, things like URLs, cookies or even file names could also hold
+security-related data. Besides the obvious candidates like usernames and
+passwords, things like URLs, cookies or even filenames could also hold
 sensitive data.
 
 To avoid this problem, you must of course use your common sense. Often, you
@@ -460,7 +460,7 @@ only the trusted and reliable helper program is invoked!
 
 # Secrets in memory
 
-When applications pass user names, passwords or other sensitive data to
+When applications pass usernames, passwords or other sensitive data to
 libcurl to be used for upcoming transfers, those secrets are kept around as-is
 in memory. In many cases they are stored in the heap for as long as the handle
 itself for which the options are set.

--- a/docs/libcurl/libcurl-tutorial.md
+++ b/docs/libcurl/libcurl-tutorial.md
@@ -350,7 +350,7 @@ buffer. Returning 0 signals the end of the upload.
 
 # Passwords
 
-Many protocols use or even require that user name and password are provided
+Many protocols use or even require that username and password are provided
 to be able to download or upload the data of your choice. libcurl offers
 several ways to specify them.
 
@@ -360,10 +360,10 @@ this:
 ~~~c
  protocol://user:password@example.com/path/
 ~~~
-If you need any odd letters in your user name or password, you should enter
+If you need any odd letters in your username or password, you should enter
 them URL encoded, as %XX where XX is a two-digit hexadecimal number.
 
-libcurl also provides options to set various passwords. The user name and
+libcurl also provides options to set various passwords. The username and
 password as shown embedded in the URL can instead get set with the
 CURLOPT_USERPWD(3) option. The argument passed to libcurl should be a
 char * to a string in the format "user:password". In a manner like this:
@@ -381,13 +381,13 @@ to the CURLOPT_USERPWD(3) option like this:
  curl_easy_setopt(handle, CURLOPT_PROXYUSERPWD, "myname:thesecret");
 ~~~
 
-There is a long time Unix "standard" way of storing FTP user names and
+There is a long time Unix "standard" way of storing FTP usernames and
 passwords, namely in the $HOME/.netrc file (on Windows, libcurl also checks
 the *%USERPROFILE% environment* variable if *%HOME%* is unset, and tries
 "_netrc" as name). The file should be made private so that only the user may
 read it (see also the "Security Considerations" chapter), as it might contain
 the password in plain text. libcurl has the ability to use this file to figure
-out what set of user name and password to use for a particular host. As an
+out what set of username and password to use for a particular host. As an
 extension to the normal functionality, libcurl also supports this file for
 non-FTP protocols such as HTTP. To make curl use this file, use the
 CURLOPT_NETRC(3) option:
@@ -416,7 +416,7 @@ To pass the known private key password to libcurl:
 
 # HTTP Authentication
 
-The previous chapter showed how to set user name and password for getting URLs
+The previous chapter showed how to set username and password for getting URLs
 that require authentication. When using the HTTP protocol, there are many
 different ways a client can provide those credentials to the server and you
 can control which way libcurl uses them. The default HTTP authentication
@@ -675,10 +675,10 @@ becomes:
  curl_mime_data_cb(part, (curl_off_t) -1, fread, fseek, NULL, stdin);
 ~~~
 
-curl_mime_name(3) always copies the field name. The special file name
-"-" is not supported by curl_mime_filename(3): to read an open file, use
-a callback source using fread(). The transfer is be chunk-encoded since the
-data size is unknown.
+curl_mime_name(3) always copies the field name. The special filename "-" is
+not supported by curl_mime_filename(3): to read an open file, use a callback
+source using fread(). The transfer is be chunk-encoded since the data size is
+unknown.
 
 ~~~c
  curl_formadd(&post, &last,

--- a/docs/libcurl/opts/CURLMOPT_PUSHDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_PUSHDATA.md
@@ -42,7 +42,7 @@ HTTP(S)
 ~~~c
 #include <string.h>
 
-/* only allow pushes for file names starting with "push-" */
+/* only allow pushes for filenames starting with "push-" */
 int push_callback(CURL *parent,
                   CURL *easy,
                   size_t num_headers,

--- a/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.md
@@ -103,7 +103,7 @@ HTTP(S) (HTTP/2 only)
 ~~~c
 #include <string.h>
 
-/* only allow pushes for file names starting with "push-" */
+/* only allow pushes for filenames starting with "push-" */
 int push_callback(CURL *parent,
                   CURL *easy,
                   size_t num_headers,

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -13,7 +13,7 @@ See-also:
 <!-- markdown-link-check-disable -->
 # NAME
 
-CURLOPT_ALTSVC - alt-svc cache file name
+CURLOPT_ALTSVC - alt-svc cache filename
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
+++ b/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
@@ -34,7 +34,7 @@ curl_url_set(3) function.
 
 # DEFAULT
 
-0 (disabled) - user names are allowed by default.
+0 (disabled) - usernames are allowed by default.
 
 # PROTOCOLS
 

--- a/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.md
@@ -33,8 +33,7 @@ default, libcurl caches this info for 60 seconds.
 
 We recommend users not to tamper with this option unless strictly necessary.
 If you do, be careful of using large values that can make the cache size grow
-significantly if many different host names are used within that timeout
-period.
+significantly if many different hostnames are used within that timeout period.
 
 The name resolve functions of various libc implementations do not re-read name
 server information unless explicitly told so (for example, by calling

--- a/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.md
@@ -39,7 +39,7 @@ NULL
 
 # PROTOCOLS
 
-All protocols except file:// - protocols that resolve host names.
+All protocols except file:// - protocols that resolve hostnames.
 
 # EXAMPLE
 

--- a/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.md
@@ -24,7 +24,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_FTP_ACCOUNT, char *account);
 # DESCRIPTION
 
 Pass a pointer to a null-terminated string (or NULL to disable). When an FTP
-server asks for "account data" after user name and password has been provided,
+server asks for "account data" after username and password has been provided,
 this data is sent off using the ACCT command.
 
 The application does not have to keep the string around after setting this

--- a/docs/libcurl/opts/CURLOPT_HSTS.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS.md
@@ -12,7 +12,7 @@ See-also:
 
 # NAME
 
-CURLOPT_HSTS - HSTS cache file name
+CURLOPT_HSTS - HSTS cache filename
 
 # SYNOPSIS
 
@@ -55,7 +55,7 @@ currently no length or size limit.
 
 # DEFAULT
 
-NULL, no file name
+NULL, no filename
 
 # PROTOCOLS
 

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -40,7 +40,7 @@ For authentication with a proxy, see CURLOPT_PROXYAUTH(3).
 
 HTTP Basic authentication. This is the default choice, and the only method
 that is in wide-spread use and supported virtually everywhere. This sends
-the user name and password over the network in plain text, easily captured by
+the username and password over the network in plain text, easily captured by
 others.
 
 ## CURLAUTH_DIGEST

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -26,7 +26,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_IPRESOLVE, long resolve);
 
 Allows an application to select what kind of IP addresses to use when
 establishing a connection or choosing one from the connection pool. This is
-interesting when using host names that resolve to more than one IP family.
+interesting when using hostnames that resolve to more than one IP family.
 
 If the URL provided for a transfer contains a numerical IP version as a host
 name, this option does not override or prohibit libcurl from using that IP

--- a/docs/libcurl/opts/CURLOPT_MAIL_RCPT.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_RCPT.md
@@ -35,7 +35,7 @@ as the first character libcurl assumes you provided a single email address and
 encloses that address within brackets for you.
 
 When performing an address verification (**VRFY** command), each recipient
-should be specified as the user name or username and domain (as per Section
+should be specified as the username or username plus domain (as per Section
 3.5 of RFC 5321).
 
 When performing a mailing list expand (**EXPN** command), each recipient

--- a/docs/libcurl/opts/CURLOPT_MAIL_RCPT.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_RCPT.md
@@ -35,7 +35,7 @@ as the first character libcurl assumes you provided a single email address and
 encloses that address within brackets for you.
 
 When performing an address verification (**VRFY** command), each recipient
-should be specified as the user name or user name and domain (as per Section
+should be specified as the user name or username and domain (as per Section
 3.5 of RFC 5321).
 
 When performing a mailing list expand (**EXPN** command), each recipient

--- a/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
@@ -30,7 +30,7 @@ Available bits are:
 
 ## CURLMIMEOPT_FORMESCAPE
 
-Tells libcurl to escape multipart form field and file names using the
+Tells libcurl to escape multipart form field and filenames using the
 backslash-escaping algorithm rather than percent-encoding (HTTP only).
 
 Backslash-escaping consists in preceding backslashes and double quotes with

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -25,8 +25,8 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NETRC, long level);
 # DESCRIPTION
 
 This parameter controls the preference *level* of libcurl between using
-user names and passwords from your *~/.netrc* file, relative to usernames
-and passwords in the URL supplied with CURLOPT_URL(3).
+usernames and passwords from your *~/.netrc* file, relative to usernames and
+passwords in the URL supplied with CURLOPT_URL(3).
 
 On Windows, libcurl uses the file as *%HOME%/_netrc*. If *%HOME%* is
 not set on Windows, libcurl falls back to *%USERPROFILE%*.

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -25,7 +25,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NETRC, long level);
 # DESCRIPTION
 
 This parameter controls the preference *level* of libcurl between using
-user names and passwords from your *~/.netrc* file, relative to user names
+user names and passwords from your *~/.netrc* file, relative to usernames
 and passwords in the URL supplied with CURLOPT_URL(3).
 
 On Windows, libcurl uses the file as *%HOME%/_netrc*. If *%HOME%* is
@@ -34,11 +34,11 @@ not set on Windows, libcurl falls back to *%USERPROFILE%*.
 You can also tell libcurl a different filename to use with
 CURLOPT_NETRC_FILE(3).
 
-libcurl uses a user name (and supplied or prompted password) supplied with
+libcurl uses a username (and supplied or prompted password) supplied with
 CURLOPT_USERPWD(3) or CURLOPT_USERNAME(3) in preference to any of
 the options controlled by this parameter.
 
-Only machine name, user name and password are taken into account (init macros
+Only machine name, username and password are taken into account (init macros
 and similar things are not supported).
 
 libcurl does not verify that the file has the correct properties set (as the
@@ -53,15 +53,15 @@ libcurl ignores the *.netrc* file. This is the default.
 ## CURL_NETRC_OPTIONAL (1)
 
 The use of the *.netrc* file is optional, and information in the URL is to
-be preferred. The file is scanned for the host and user name (to find the
-password only) or for the host only, to find the first user name and password
+be preferred. The file is scanned for the host and username (to find the
+password only) or for the host only, to find the first username and password
 after that *machine*, which ever information is not specified.
 
 ## CURL_NETRC_REQUIRED (2)
 
 The use of the *.netrc* file is required, and any credential information
-present in the URL is ignored. The file is scanned for the host and user name
-(to find the password only) or for the host only, to find the first user name
+present in the URL is ignored. The file is scanned for the host and username
+(to find the password only) or for the host only, to find the first username
 and password after that *machine*, which ever information is not
 specified.
 
@@ -74,7 +74,7 @@ Each field is provided as a sequence of letters that ends with a space or
 newline. Starting in 7.84.0, libcurl also supports quoted strings. They start
 and end with double quotes and support the escaped special letters ", n,
 r, and t. Quoted strings are the only way a space character can be used in
-a user name or password.
+a username or password.
 
 ## machine \<name\>
 
@@ -94,7 +94,7 @@ add a line similar to this in the end:
 
 ## login \<name\>
 
-The user name string for the remote machine.
+The username string for the remote machine.
 
 ## password \<secret\>
 

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.md
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.md
@@ -25,18 +25,17 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_NOPROXY, char *noproxy);
 # DESCRIPTION
 
 Pass a pointer to a null-terminated string. The string consists of a comma
-separated list of host names that do not require a proxy to get reached, even
+separated list of hostnames that do not require a proxy to get reached, even
 if one is specified. The only wildcard available is a single * character,
 which matches all hosts, and effectively disables the proxy. Each name in this
 list is matched as either a domain which contains the hostname, or the
 hostname itself. For example, "ample.com" would match ample.com, ample.com:80,
 and www.ample.com, but not www.example.com or ample.com.org.
 
-Setting the *noproxy* string to "" (an empty string) explicitly enables
-the proxy for all host names, even if there is an environment variable set for
-it.
+Setting the *noproxy* string to "" (an empty string) explicitly enables the
+proxy for all hostnames, even if there is an environment variable set for it.
 
-Enter IPv6 numerical addresses in the list of host names without enclosing
+Enter IPv6 numerical addresses in the list of hostnames without enclosing
 brackets:
 
  "example.com,::1,localhost"

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.md
@@ -13,7 +13,7 @@ See-also:
 
 # NAME
 
-CURLOPT_PROXYUSERNAME - user name to use for proxy authentication
+CURLOPT_PROXYUSERNAME - username to use for proxy authentication
 
 # SYNOPSIS
 
@@ -27,9 +27,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXYUSERNAME,
 # DESCRIPTION
 
 Pass a char pointer as parameter, which should be pointing to the
-null-terminated user name to use for the transfer.
+null-terminated username to use for the transfer.
 
-CURLOPT_PROXYUSERNAME(3) sets the user name to be used in protocol
+CURLOPT_PROXYUSERNAME(3) sets the username to be used in protocol
 authentication with the proxy.
 
 To specify the proxy password use the CURLOPT_PROXYPASSWORD(3).

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.md
@@ -13,7 +13,7 @@ See-also:
 
 # NAME
 
-CURLOPT_PROXYUSERPWD - user name and password to use for proxy authentication
+CURLOPT_PROXYUSERPWD - username and password to use for proxy authentication
 
 # SYNOPSIS
 
@@ -25,10 +25,10 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROXYUSERPWD, char *userpwd);
 
 # DESCRIPTION
 
-Pass a char pointer as parameter, which should be [user name]:[password] to
-use for the connection to the HTTP proxy. Both the name and the password are
-URL decoded before used, so to include for example a colon in the user name
-you should encode it as %3A. (This is different to how CURLOPT_USERPWD(3) is
+Pass a char pointer as parameter, which should be [username]:[password] to use
+for the connection to the HTTP proxy. Both the name and the password are URL
+decoded before used, so to include for example a colon in the username you
+should encode it as %3A. (This is different to how CURLOPT_USERPWD(3) is
 used - beware.)
 
 Use CURLOPT_PROXYAUTH(3) to specify the authentication method.

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.md
@@ -13,7 +13,7 @@ See-also:
 
 # NAME
 
-CURLOPT_PROXY_TLSAUTH_USERNAME - user name to use for proxy TLS authentication
+CURLOPT_PROXY_TLSAUTH_USERNAME - username to use for proxy TLS authentication
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -27,7 +27,7 @@ Pass a long as parameter, which is set to a bitmask, to tell libcurl which
 authentication method(s) are allowed for SOCKS5 proxy authentication. The only
 supported flags are *CURLAUTH_BASIC*, which allows username/password
 authentication, *CURLAUTH_GSSAPI*, which allows GSS-API authentication, and
-*CURLAUTH_NONE*, which allows no authentication. Set the actual user name and
+*CURLAUTH_NONE*, which allows no authentication. Set the actual username and
 password with the CURLOPT_PROXYUSERPWD(3) option.
 
 # DEFAULT

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.md
@@ -11,7 +11,7 @@ See-also:
 
 # NAME
 
-CURLOPT_TLSAUTH_USERNAME - user name to use for TLS authentication
+CURLOPT_TLSAUTH_USERNAME - username to use for TLS authentication
 
 # SYNOPSIS
 

--- a/docs/libcurl/opts/CURLOPT_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_USERNAME.md
@@ -13,7 +13,7 @@ See-also:
 
 # NAME
 
-CURLOPT_USERNAME - user name to use in authentication
+CURLOPT_USERNAME - username to use in authentication
 
 # SYNOPSIS
 
@@ -27,9 +27,9 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_USERNAME,
 # DESCRIPTION
 
 Pass a char pointer as parameter, which should be pointing to the
-null-terminated user name to use for the transfer.
+null-terminated username to use for the transfer.
 
-CURLOPT_USERNAME(3) sets the user name to be used in protocol
+CURLOPT_USERNAME(3) sets the username to be used in protocol
 authentication. You should not use this option together with the (older)
 CURLOPT_USERPWD(3) option.
 
@@ -38,9 +38,8 @@ include the domain name in order for the server to successfully obtain a
 Kerberos Ticket. If you do not then the initial part of the authentication
 handshake may fail.
 
-When using NTLM, the user name can be specified simply as the user name
-without the domain name should the server be part of a single domain and
-forest.
+When using NTLM, the user name can be specified simply as the username without
+the domain name should the server be part of a single domain and forest.
 
 To include the domain name use either Down-Level Logon Name or UPN (User
 Principal Name) formats. For example, **EXAMPLE\user** and
@@ -49,7 +48,7 @@ Principal Name) formats. For example, **EXAMPLE\user** and
 Some HTTP servers (on Windows) support inclusion of the domain for Basic
 authentication as well.
 
-To specify the password and login options, along with the user name, use the
+To specify the password and login options, along with the username, use the
 CURLOPT_PASSWORD(3) and CURLOPT_LOGIN_OPTIONS(3) options.
 
 The application does not have to keep the string around after setting this

--- a/docs/libcurl/opts/CURLOPT_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_USERNAME.md
@@ -38,7 +38,7 @@ include the domain name in order for the server to successfully obtain a
 Kerberos Ticket. If you do not then the initial part of the authentication
 handshake may fail.
 
-When using NTLM, the user name can be specified simply as the username without
+When using NTLM, the username can be specified simply as the username without
 the domain name should the server be part of a single domain and forest.
 
 To include the domain name use either Down-Level Logon Name or UPN (User

--- a/docs/libcurl/opts/CURLOPT_USERPWD.md
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.md
@@ -12,7 +12,7 @@ See-also:
 
 # NAME
 
-CURLOPT_USERPWD - user name and password to use in authentication
+CURLOPT_USERPWD - username and password to use in authentication
 
 # SYNOPSIS
 
@@ -25,14 +25,14 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_USERPWD, char *userpwd);
 # DESCRIPTION
 
 Pass a char pointer as parameter, pointing to a null-terminated login details
-string for the connection. The format of which is: [user name]:[password].
+string for the connection. The format of which is: [username]:[password].
 
 When using Kerberos V5 authentication with a Windows based server, you should
-specify the user name part with the domain name in order for the server to
+specify the username part with the domain name in order for the server to
 successfully obtain a Kerberos Ticket. If you do not then the initial part of
 the authentication handshake may fail.
 
-When using NTLM, the user name can be specified simply as the user name
+When using NTLM, the user name can be specified simply as the username
 without the domain name should the server be part of a single domain and
 forest.
 
@@ -55,8 +55,8 @@ based connections or CURLOPT_LOGIN_OPTIONS(3) to control IMAP, POP3 and
 SMTP options.
 
 The user and password strings are not URL decoded, so there is no way to send
-in a user name containing a colon using this option. Use
-CURLOPT_USERNAME(3) for that, or include it in the URL.
+in a username containing a colon using this option. Use CURLOPT_USERNAME(3)
+for that, or include it in the URL.
 
 The application does not have to keep the string around after setting this
 option.

--- a/docs/libcurl/opts/CURLOPT_USERPWD.md
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.md
@@ -32,9 +32,8 @@ specify the username part with the domain name in order for the server to
 successfully obtain a Kerberos Ticket. If you do not then the initial part of
 the authentication handshake may fail.
 
-When using NTLM, the user name can be specified simply as the username
-without the domain name should the server be part of a single domain and
-forest.
+When using NTLM, the username can be specified simply as the username without
+the domain name should the server be part of a single domain and forest.
 
 To specify the domain name use either Down-Level Logon Name or UPN (User
 Principal Name) formats. For example **EXAMPLE\user** and **user@example.com**

--- a/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.md
+++ b/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.md
@@ -27,8 +27,8 @@ Pass a char pointer as parameter, which should point to the null-terminated
 OAuth 2.0 Bearer Access Token for use with HTTP, IMAP, LDAP, POP3 and SMTP
 servers that support the OAuth 2.0 Authorization Framework.
 
-Note: For IMAP, LDAP, POP3 and SMTP, the user name used to generate the
-Bearer Token should be supplied via the CURLOPT_USERNAME(3) option.
+Note: For IMAP, LDAP, POP3 and SMTP, the username used to generate the Bearer
+Token should be supplied via the CURLOPT_USERNAME(3) option.
 
 The application does not have to keep the string around after setting this
 option.


### PR DESCRIPTION
and username, filename - consistently. Fixed the patterns in badwords.txt to catch these.