### PR TITLE
lib582: remove code causing warning that is never run

### DIFF
--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -83,16 +83,10 @@ static void addFd(struct Sockets *sockets, curl_socket_t fd, const char *what)
       return;
     sockets->max_count = 20;
   }
-  else if(sockets->count + 1 > sockets->max_count) {
-    curl_socket_t *oldptr = sockets->sockets;
-    sockets->sockets = realloc(oldptr, sizeof(curl_socket_t) *
-                               (sockets->max_count + 20));
-    if(!sockets->sockets) {
-      /* cleanup in test_cleanup */
-      sockets->sockets = oldptr;
-      return;
-    }
-    sockets->max_count += 20;
+  else if(sockets->count >= sockets->max_count) {
+    /* this can't happen in normal cases */
+    fprintf(stderr, "too many file handles error\n");
+    exit(2);
   }
   /*
    * Add file descriptor to array.


### PR DESCRIPTION
The previous realloc code in this code could trigger a compiler warning, but since that code path cannot happen in normal circumstances it now instead exits with an error message there.

Ref: #12887