### PR TITLE
curl: when allocating variables, add the name into the struct

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -360,20 +360,19 @@ static ParameterError addvariable(struct GlobalConfig *global,
     notef(global, "Overwriting variable '%s'", check->name);
 
   p = calloc(1, sizeof(struct var) + nlen);
-  if(!p)
-    return PARAM_NO_MEM;
+  if(p) {
+    memcpy(p->name, name, nlen);
 
-  memcpy(p->name, name, nlen);
+    p->content = contalloc ? content: Memdup(content, clen);
+    if(p->content) {
+      p->clen = clen;
 
-  p->content = contalloc ? content: Memdup(content, clen);
-  if(p->content) {
-    p->clen = clen;
-
-    p->next = global->variables;
-    global->variables = p;
-    return PARAM_OK;
+      p->next = global->variables;
+      global->variables = p;
+      return PARAM_OK;
+    }
+    free(p);
   }
-  free(p);
   return PARAM_NO_MEM;
 }
 

--- a/src/var.c
+++ b/src/var.c
@@ -355,6 +355,7 @@ static ParameterError addvariable(struct GlobalConfig *global,
 {
   struct var *p;
   const struct var *check = varcontent(global, name, nlen);
+  DEBUGASSERT(nlen);
   if(check)
     notef(global, "Overwriting variable '%s'", check->name);
 
@@ -363,7 +364,6 @@ static ParameterError addvariable(struct GlobalConfig *global,
     return PARAM_NO_MEM;
 
   memcpy(p->name, name, nlen);
-  p->name[nlen] = 0;
 
   p->content = contalloc ? content: Memdup(content, clen);
   if(!p->content)

--- a/src/var.c
+++ b/src/var.c
@@ -342,7 +342,7 @@ ParameterError varexpand(struct GlobalConfig *global,
 }
 
 /*
- * Created in a way that is not revealing how variables is actually stored so
+ * Created in a way that is not revealing how variables are actually stored so
  * that we can improve this if we want better performance when managing many
  * at a later point.
  */

--- a/src/var.c
+++ b/src/var.c
@@ -63,7 +63,6 @@ void varcleanup(struct GlobalConfig *global)
     struct var *t = list;
     list = list->next;
     free((char *)t->content);
-    free((char *)t->name);
     free(t);
   }
 }
@@ -359,13 +358,12 @@ static ParameterError addvariable(struct GlobalConfig *global,
   if(check)
     notef(global, "Overwriting variable '%s'", check->name);
 
-  p = calloc(1, sizeof(struct var));
+  p = calloc(1, sizeof(struct var) + nlen);
   if(!p)
     return PARAM_NO_MEM;
 
-  p->name = Memdup(name, nlen);
-  if(!p->name)
-    goto err;
+  memcpy(p->name, name, nlen);
+  p->name[nlen] = 0;
 
   p->content = contalloc ? content: Memdup(content, clen);
   if(!p->content)
@@ -377,7 +375,6 @@ static ParameterError addvariable(struct GlobalConfig *global,
   return PARAM_OK;
 err:
   free((char *)p->content);
-  free((char *)p->name);
   free(p);
   return PARAM_NO_MEM;
 }

--- a/src/var.c
+++ b/src/var.c
@@ -366,15 +366,13 @@ static ParameterError addvariable(struct GlobalConfig *global,
   memcpy(p->name, name, nlen);
 
   p->content = contalloc ? content: Memdup(content, clen);
-  if(!p->content)
-    goto err;
-  p->clen = clen;
+  if(p->content) {
+    p->clen = clen;
 
-  p->next = global->variables;
-  global->variables = p;
-  return PARAM_OK;
-err:
-  free((char *)p->content);
+    p->next = global->variables;
+    global->variables = p;
+    return PARAM_OK;
+  }
   free(p);
   return PARAM_NO_MEM;
 }

--- a/src/var.h
+++ b/src/var.h
@@ -29,9 +29,9 @@
 
 struct var {
   struct var *next;
-  const char *name;
   const char *content;
   size_t clen; /* content length */
+  char name[1]; /* allocated as part of the struct */
 };
 
 struct GlobalConfig;


### PR DESCRIPTION
This saves the name from being an extra separate allocation.