### PR TITLE
Update HTTP3.md

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -206,6 +206,7 @@ Build OpenSSL 3.2.0
      % git clone -b openssl-3.2.0 https://github.com/openssl/openssl
      % cd openssl
      % ./config enable-tls1_3 --prefix=<somewhere> --libdir=<somewhere>/lib
+     % make
      % make install
 
 Build nghttp3
@@ -213,6 +214,7 @@ Build nghttp3
      % cd ..
      % git clone -b v1.1.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
+     % git submodule update --init
      % autoreconf -fi
      % ./configure --prefix=<somewhere2> --enable-lib-only
      % make
@@ -224,7 +226,7 @@ Build curl:
      % git clone https://github.com/curl/curl
      % cd curl
      % autoreconf -fi
-     % ./configure --with-openssl=<somewhere> --with-openssl-quic --with-nghttp3=<somewhere2> 
+     % LDFLAGS="-Wl,-rpath,<somewhere>/lib" ./configure --with-openssl=<somewhere> --with-openssl-quic --with-nghttp3=<somewhere2> 
      % make
      % make install
 


### PR DESCRIPTION
tried installing with old steps but failed
tried with newly added setps and able to build
```
root@ubuntu:~/curl# ./src/curl -V
/root/curl/src/.libs/curl: /lib/x86_64-linux-gnu/libssl.so.3: version `OPENSSL_3.2.0' not found (required by /root/curl/lib/.libs/libcurl.so.4)
root@ubuntu:~/curl#
```
```
root@ubuntu:~/curl# ./src/curl -V
curl 8.6.1-DEV (x86_64-pc-linux-gnu) libcurl/8.6.1-DEV OpenSSL/3.2.0 zlib/1.2.11 brotli/1.0.9 libpsl/0.21.0 nghttp3/1.1.0 OpenLDAP/2.5.16
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
Features: alt-svc AsynchDNS brotli HSTS HTTP3 HTTPS-proxy IPv6 Largefile libz NTLM PSL SSL threadsafe TLS-SRP UnixSockets
root@ubuntu:~/curl#
```