### PR TITLE
SHA-512/256 real implementation

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -134,6 +134,7 @@ LIB_CFILES =         \
   curl_range.c       \
   curl_rtmp.c        \
   curl_sasl.c        \
+  curl_sha512_256.c  \
   curl_sspi.c        \
   curl_threads.c     \
   curl_trc.c         \
@@ -277,6 +278,7 @@ LIB_HFILES =         \
   curl_setup.h       \
   curl_setup_once.h  \
   curl_sha256.h      \
+  curl_sha512_256.h  \
   curl_sspi.h        \
   curl_threads.h     \
   curl_trc.h         \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -266,6 +266,13 @@
 
 #include <curl/system.h>
 
+/* Helper macro to expand and concatenate two macros.
+ * Direct macros concatenation does not work because macros
+ * are not expanded before direct concatenation.
+ */
+#define CURL_CONC_MACROS_(A,B) A ## B
+#define CURL_CONC_MACROS(A,B) CURL_CONC_MACROS_(A,B)
+
 /* curl uses its own printf() function internally. It understands the GNU
  * format. Use this format, so that is matches the GNU format attribute we
  * use with the mingw compiler, allowing it to verify them at compile-time.
@@ -494,6 +501,18 @@
 #  define CURL_OFF_T_MAX CURL_OFF_T_C(0x7FFFFFFFFFFFFFFF)
 #endif
 #define CURL_OFF_T_MIN (-CURL_OFF_T_MAX - CURL_OFF_T_C(1))
+
+#if (SIZEOF_CURL_OFF_T != 8)
+#  error "curl_off_t must be exactly 64 bits"
+#else
+  typedef unsigned CURL_TYPEOF_CURL_OFF_T curl_uint64_t;
+#  ifndef CURL_SUFFIX_CURL_OFF_TU
+#    error "CURL_SUFFIX_CURL_OFF_TU must be defined"
+#  endif
+#  define CURL_UINT64_SUFFIX  CURL_SUFFIX_CURL_OFF_TU
+#  define CURL_UINT64_C(val)  CURL_CONC_MACROS(val,CURL_UINT64_SUFFIX)
+#  define CURL_UINT64_CAST(expr) ((curl_uint64_t)(expr))
+#endif
 
 #if (SIZEOF_TIME_T == 4)
 #  ifdef HAVE_TIME_T_UNSIGNED

--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -1,0 +1,601 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Evgeny Grin (Karlson2k), <k2k@narod.ru>.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#if !defined(CURL_DISABLE_DIGEST_AUTH) && !defined(CURL_DISABLE_SHA512_256)
+
+#include "curl_sha512_256.h"
+#include "warnless.h"
+
+/* ** This implementation of SHA-512/256 hash calculation was originally ** *
+ * ** written by Evgeny Grin (Karlson2k) for GNU libmicrohttpd.          ** *
+ * ** The author ported the code to libcurl. The ported code is provided ** *
+ * ** under curl license.                                                ** *
+ * ** This is a minimal version with minimal optimisations. Performance  ** *
+ * ** can be significantly improved. Big-endian store and load macros    ** *
+ * ** are obvious targets for optimisation.                              ** */
+
+#ifdef __GNUC__
+#  if defined(__has_attribute) && defined(__STDC_VERSION__)
+#    if __has_attribute(always_inline) && __STDC_VERSION__ >= 199901
+#      define MHDX_INLINE inline __attribute__((always_inline))
+#    endif
+#  endif
+#endif
+
+#if !defined(MHDX_INLINE) && \
+  defined(_MSC_VER) && !defined(__GNUC__) && !defined(__clang__)
+#  if _MSC_VER >= 1400
+#    define MHDX_INLINE __forceinline
+#  else
+#    define MHDX_INLINE /* empty */
+#  endif
+#endif
+
+#if !defined(MHDX_INLINE)
+#  if defined(inline)
+     /* Assume that 'inline' macro was already defined correctly by
+      * the build system. */
+#    define MHDX_INLINE inline
+#  elif defined(__cplusplus)
+     /* The code is compiled with C++ compiler.
+      * C++ always supports 'inline'. */
+#    define MHDX_INLINE inline
+#  elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901
+     /* C99 (and later) supports 'inline' keyword */
+#    define MHDX_INLINE inline
+#  elif defined(__GNUC__) && __GNUC__ >= 3
+     /* GCC supports '__inline__' as an extension */
+#    define MHDX_INLINE __inline__
+#  else
+#    define MHDX_INLINE /* empty */
+#  endif
+#endif
+
+/* Bits manipulation macros and functions.
+   Can be moved to other headers to reuse. */
+
+#define MHDX_GET_64BIT_BE(ptr)                                  \
+  ( ((curl_uint64_t)(((const unsigned char*)(ptr))[0]) << 56) | \
+    ((curl_uint64_t)(((const unsigned char*)(ptr))[1]) << 48) | \
+    ((curl_uint64_t)(((const unsigned char*)(ptr))[2]) << 40) | \
+    ((curl_uint64_t)(((const unsigned char*)(ptr))[3]) << 32) | \
+    ((curl_uint64_t)(((const unsigned char*)(ptr))[4]) << 24) | \
+    ((curl_uint64_t)(((const unsigned char*)(ptr))[5]) << 16) | \
+    ((curl_uint64_t)(((const unsigned char*)(ptr))[6]) << 8)  | \
+    (curl_uint64_t)(((const unsigned char*)(ptr))[7]) )
+
+#define MHDX_PUT_64BIT_BE(ptr,val) do {                                     \
+  ((unsigned char*)(ptr))[7]=(unsigned char)((curl_uint64_t)(val));         \
+  ((unsigned char*)(ptr))[6]=(unsigned char)(((curl_uint64_t)(val)) >> 8);  \
+  ((unsigned char*)(ptr))[5]=(unsigned char)(((curl_uint64_t)(val)) >> 16); \
+  ((unsigned char*)(ptr))[4]=(unsigned char)(((curl_uint64_t)(val)) >> 24); \
+  ((unsigned char*)(ptr))[3]=(unsigned char)(((curl_uint64_t)(val)) >> 32); \
+  ((unsigned char*)(ptr))[2]=(unsigned char)(((curl_uint64_t)(val)) >> 40); \
+  ((unsigned char*)(ptr))[1]=(unsigned char)(((curl_uint64_t)(val)) >> 48); \
+  ((unsigned char*)(ptr))[0]=(unsigned char)(((curl_uint64_t)(val)) >> 56); \
+} while(0)
+
+/* Defined as a function. The macro version may duplicate the binary code
+ * size as each argument is used twice, so if any calculation is used
+ * as an argument, the calculation could be done twice. */
+static MHDX_INLINE curl_uint64_t
+MHDx_rotr64(curl_uint64_t value, unsigned int bits)
+{
+  bits %= 64;
+  if(0 == bits)
+    return value;
+  /* Defined in a form which modern compiler could optimise. */
+  return (value >> bits) | (value << (64 - bits));
+}
+
+/* SHA-512/256 specific data */
+
+/**
+ * Number of bits in single SHA-512/256 word.
+ */
+#define SHA512_256_WORD_SIZE_BITS 64
+
+/**
+ * Number of bytes in single SHA-512/256 word.
+ */
+#define SHA512_256_BYTES_IN_WORD (SHA512_256_WORD_SIZE_BITS / 8)
+
+/**
+ * Hash is kept internally as 8 64-bit words.
+ * This is intermediate hash size, used during computing the final digest.
+ */
+#define SHA512_256_HASH_SIZE_WORDS 8
+
+/**
+ * Size of SHA-512/256 resulting digest in bytes.
+ * This is the final digest size, not intermediate hash.
+ */
+#define SHA512_256_DIGEST_SIZE_WORDS (SHA512_256_HASH_SIZE_WORDS  / 2)
+
+/**
+ * Size of SHA-512/256 resulting digest in bytes
+ * This is the final digest size, not intermediate hash.
+ */
+#define SHA512_256_DIGEST_SIZE \
+  (SHA512_256_DIGEST_SIZE_WORDS * SHA512_256_BYTES_IN_WORD)
+
+/**
+ * Size of SHA-512/256 single processing block in bits.
+ */
+#define SHA512_256_BLOCK_SIZE_BITS 1024
+
+/**
+ * Size of SHA-512/256 single processing block in bytes.
+ */
+#define SHA512_256_BLOCK_SIZE (SHA512_256_BLOCK_SIZE_BITS / 8)
+
+/**
+ * Size of SHA-512/256 single processing block in words.
+ */
+#define SHA512_256_BLOCK_SIZE_WORDS \
+ (SHA512_256_BLOCK_SIZE_BITS / SHA512_256_WORD_SIZE_BITS)
+
+
+/**
+ * SHA-512/256 calculation context
+ */
+struct Sha512_256Ctx
+{
+  /**
+   * Intermediate hash value
+   * The variable is properly aligned. Smart compiler
+   * may automatically use fast load/store instruction
+   * for big endian data on little endian machine.
+   */
+  curl_uint64_t H[SHA512_256_HASH_SIZE_WORDS];
+  /**
+   * SHA-512/256 input data buffer
+   * The buffer is properly aligned. Smart compiler
+   * may automatically use fast load/store instruction
+   * for big endian data on little endian machine.
+   */
+  curl_uint64_t buffer[SHA512_256_BLOCK_SIZE_WORDS];
+  /**
+   * The number of bytes, lower part
+   */
+  curl_uint64_t count;
+  /**
+   * The number of bits, high part.
+   * Unlike lower part, this counts the number of bits, not bytes.
+   */
+  curl_uint64_t count_bits_hi;
+};
+
+
+/**
+ * Initialise structure for SHA-512/256 calculation.
+ *
+ * @param context the calculation context
+ * @return always CURLE_OK
+ */
+static CURLcode
+MHDx_sha512_256_init(void *context)
+{
+  struct Sha512_256Ctx *const ctx = (struct Sha512_256Ctx *) context;
+
+  /* Check whether the header and this file use the same numbers */
+  DEBUGASSERT(SHA512_256_DIGEST_LENGTH == SHA512_256_DIGEST_SIZE);
+
+  DEBUGASSERT(sizeof(curl_uint64_t) == 8);
+
+  /* Initial hash values, see FIPS PUB 180-4 section 5.3.6.2 */
+  /* Values generated by "IV Generation Function" as described in
+   * section 5.3.6 */
+  ctx->H[0] = CURL_UINT64_C(0x22312194FC2BF72C);
+  ctx->H[1] = CURL_UINT64_C(0x9F555FA3C84C64C2);
+  ctx->H[2] = CURL_UINT64_C(0x2393B86B6F53B151);
+  ctx->H[3] = CURL_UINT64_C(0x963877195940EABD);
+  ctx->H[4] = CURL_UINT64_C(0x96283EE2A88EFFE3);
+  ctx->H[5] = CURL_UINT64_C(0xBE5E1E2553863992);
+  ctx->H[6] = CURL_UINT64_C(0x2B0199FC2C85B8AA);
+  ctx->H[7] = CURL_UINT64_C(0x0EB72DDC81C52CA2);
+
+  /* Initialise number of bytes and high part of number of bits. */
+  ctx->count = CURL_UINT64_C(0);
+  ctx->count_bits_hi = CURL_UINT64_C(0);
+
+  return CURLE_OK;
+}
+
+
+/**
+ * Base of SHA-512/256 transformation.
+ * Gets full 128 bytes block of data and updates hash values;
+ * @param H     hash values
+ * @param data  the data buffer with #SHA512_256_BLOCK_SIZE bytes block
+ */
+static void
+MHDx_sha512_256_transform(curl_uint64_t H[SHA512_256_HASH_SIZE_WORDS],
+                            const void *data)
+{
+  /* Working variables,
+     see FIPS PUB 180-4 section 6.7, 6.4. */
+  curl_uint64_t a = H[0];
+  curl_uint64_t b = H[1];
+  curl_uint64_t c = H[2];
+  curl_uint64_t d = H[3];
+  curl_uint64_t e = H[4];
+  curl_uint64_t f = H[5];
+  curl_uint64_t g = H[6];
+  curl_uint64_t h = H[7];
+
+  /* Data buffer, used as a cyclic buffer.
+     See FIPS PUB 180-4 section 5.2.2, 6.7, 6.4. */
+  curl_uint64_t W[16];
+
+  /* 'Ch' and 'Maj' macro functions are defined with
+     widely-used optimisation.
+     See FIPS PUB 180-4 formulae 4.8, 4.9. */
+#define Ch(x,y,z)     ( (z) ^ ((x) & ((y) ^ (z))) )
+#define Maj(x,y,z)    ( ((x) & (y)) ^ ((z) & ((x) ^ (y))) )
+  /* Unoptimized (original) versions: */
+/* #define Ch(x,y,z)  ( ( (x) & (y) ) ^ ( ~(x) & (z) ) )          */
+/* #define Maj(x,y,z) ( ((x) & (y)) ^ ((x) & (z)) ^ ((y) & (z)) ) */
+
+  /* Four 'Sigma' macro functions.
+     See FIPS PUB 180-4 formulae 4.10, 4.11, 4.12, 4.13. */
+#define SIG0(x)  \
+  ( MHDx_rotr64((x), 28) ^ MHDx_rotr64((x), 34) ^ MHDx_rotr64((x), 39) )
+#define SIG1(x)  \
+  ( MHDx_rotr64((x), 14) ^ MHDx_rotr64((x), 18) ^ MHDx_rotr64((x), 41) )
+#define sig0(x)  \
+  ( MHDx_rotr64((x), 1) ^ MHDx_rotr64((x), 8) ^ ((x) >> 7) )
+#define sig1(x)  \
+  ( MHDx_rotr64((x), 19) ^ MHDx_rotr64((x), 61) ^ ((x) >> 6) )
+
+  if(1) {
+    unsigned int t;
+    /* K constants array.
+       See FIPS PUB 180-4 section 4.2.3 for K values. */
+    static const curl_uint64_t K[80] =
+    { CURL_UINT64_C(0x428a2f98d728ae22), CURL_UINT64_C(0x7137449123ef65cd),
+      CURL_UINT64_C(0xb5c0fbcfec4d3b2f), CURL_UINT64_C(0xe9b5dba58189dbbc),
+      CURL_UINT64_C(0x3956c25bf348b538), CURL_UINT64_C(0x59f111f1b605d019),
+      CURL_UINT64_C(0x923f82a4af194f9b), CURL_UINT64_C(0xab1c5ed5da6d8118),
+      CURL_UINT64_C(0xd807aa98a3030242), CURL_UINT64_C(0x12835b0145706fbe),
+      CURL_UINT64_C(0x243185be4ee4b28c), CURL_UINT64_C(0x550c7dc3d5ffb4e2),
+      CURL_UINT64_C(0x72be5d74f27b896f), CURL_UINT64_C(0x80deb1fe3b1696b1),
+      CURL_UINT64_C(0x9bdc06a725c71235), CURL_UINT64_C(0xc19bf174cf692694),
+      CURL_UINT64_C(0xe49b69c19ef14ad2), CURL_UINT64_C(0xefbe4786384f25e3),
+      CURL_UINT64_C(0x0fc19dc68b8cd5b5), CURL_UINT64_C(0x240ca1cc77ac9c65),
+      CURL_UINT64_C(0x2de92c6f592b0275), CURL_UINT64_C(0x4a7484aa6ea6e483),
+      CURL_UINT64_C(0x5cb0a9dcbd41fbd4), CURL_UINT64_C(0x76f988da831153b5),
+      CURL_UINT64_C(0x983e5152ee66dfab), CURL_UINT64_C(0xa831c66d2db43210),
+      CURL_UINT64_C(0xb00327c898fb213f), CURL_UINT64_C(0xbf597fc7beef0ee4),
+      CURL_UINT64_C(0xc6e00bf33da88fc2), CURL_UINT64_C(0xd5a79147930aa725),
+      CURL_UINT64_C(0x06ca6351e003826f), CURL_UINT64_C(0x142929670a0e6e70),
+      CURL_UINT64_C(0x27b70a8546d22ffc), CURL_UINT64_C(0x2e1b21385c26c926),
+      CURL_UINT64_C(0x4d2c6dfc5ac42aed), CURL_UINT64_C(0x53380d139d95b3df),
+      CURL_UINT64_C(0x650a73548baf63de), CURL_UINT64_C(0x766a0abb3c77b2a8),
+      CURL_UINT64_C(0x81c2c92e47edaee6), CURL_UINT64_C(0x92722c851482353b),
+      CURL_UINT64_C(0xa2bfe8a14cf10364), CURL_UINT64_C(0xa81a664bbc423001),
+      CURL_UINT64_C(0xc24b8b70d0f89791), CURL_UINT64_C(0xc76c51a30654be30),
+      CURL_UINT64_C(0xd192e819d6ef5218), CURL_UINT64_C(0xd69906245565a910),
+      CURL_UINT64_C(0xf40e35855771202a), CURL_UINT64_C(0x106aa07032bbd1b8),
+      CURL_UINT64_C(0x19a4c116b8d2d0c8), CURL_UINT64_C(0x1e376c085141ab53),
+      CURL_UINT64_C(0x2748774cdf8eeb99), CURL_UINT64_C(0x34b0bcb5e19b48a8),
+      CURL_UINT64_C(0x391c0cb3c5c95a63), CURL_UINT64_C(0x4ed8aa4ae3418acb),
+      CURL_UINT64_C(0x5b9cca4f7763e373), CURL_UINT64_C(0x682e6ff3d6b2b8a3),
+      CURL_UINT64_C(0x748f82ee5defb2fc), CURL_UINT64_C(0x78a5636f43172f60),
+      CURL_UINT64_C(0x84c87814a1f0ab72), CURL_UINT64_C(0x8cc702081a6439ec),
+      CURL_UINT64_C(0x90befffa23631e28), CURL_UINT64_C(0xa4506cebde82bde9),
+      CURL_UINT64_C(0xbef9a3f7b2c67915), CURL_UINT64_C(0xc67178f2e372532b),
+      CURL_UINT64_C(0xca273eceea26619c), CURL_UINT64_C(0xd186b8c721c0c207),
+      CURL_UINT64_C(0xeada7dd6cde0eb1e), CURL_UINT64_C(0xf57d4f7fee6ed178),
+      CURL_UINT64_C(0x06f067aa72176fba), CURL_UINT64_C(0x0a637dc5a2c898a6),
+      CURL_UINT64_C(0x113f9804bef90dae), CURL_UINT64_C(0x1b710b35131c471b),
+      CURL_UINT64_C(0x28db77f523047d84), CURL_UINT64_C(0x32caab7b40c72493),
+      CURL_UINT64_C(0x3c9ebe0a15c9bebc), CURL_UINT64_C(0x431d67c49c100d4c),
+      CURL_UINT64_C(0x4cc5d4becb3e42b6), CURL_UINT64_C(0x597f299cfc657e2a),
+      CURL_UINT64_C(0x5fcb6fab3ad6faec), CURL_UINT64_C(0x6c44198c4a475817)};
+
+    /* One step of SHA-512/256 computation,
+       see FIPS PUB 180-4 section 6.4.2 step 3.
+     * Note: this macro updates working variables in-place, without rotation.
+     * Note: the first (vH += SIG1(vE) + Ch(vE,vF,vG) + kt + wt) equals T1 in
+             FIPS PUB 180-4 section 6.4.2 step 3.
+             the second (vH += SIG0(vA) + Maj(vE,vF,vC) equals T1 + T2 in
+             FIPS PUB 180-4 section 6.4.2 step 3.
+     * Note: 'wt' must be used exactly one time in this macro as macro for
+             'wt' calculation may change other data as well every time when
+              used. */
+#define SHA2STEP64(vA,vB,vC,vD,vE,vF,vG,vH,kt,wt) do {                  \
+    (vD) += ((vH) += SIG1 ((vE)) + Ch ((vE),(vF),(vG)) + (kt) + (wt));  \
+    (vH) += SIG0 ((vA)) + Maj ((vA),(vB),(vC)); } while (0)
+
+    /* One step of SHA-512/256 computation with working variables rotation,
+       see FIPS PUB 180-4 section 6.4.2 step 3.
+     * Note: this version of macro reassign all working variable on
+             each step. */
+#define SHA2STEP64RV(vA,vB,vC,vD,vE,vF,vG,vH,kt,wt) do {              \
+  curl_uint64_t tmp_h_ = (vH);                                         \
+  SHA2STEP64((vA),(vB),(vC),(vD),(vE),(vF),(vG),tmp_h_,(kt),(wt));    \
+  (vH) = (vG);                                                        \
+  (vG) = (vF);                                                        \
+  (vF) = (vE);                                                        \
+  (vE) = (vD);                                                        \
+  (vD) = (vC);                                                        \
+  (vC) = (vB);                                                        \
+  (vB) = (vA);                                                        \
+  (vA) = tmp_h_;  } while(0)
+
+  /* Get value of W(t) from input data buffer for 0 <= t <= 15,
+     See FIPS PUB 180-4 section 6.2.
+     Input data must be read in big-endian bytes order,
+     see FIPS PUB 180-4 section 3.1.2. */
+#define SHA512_GET_W_FROM_DATA(buf,t) \
+  MHDX_GET_64BIT_BE( \
+    ((const unsigned char*) (buf)) + (t) * SHA512_256_BYTES_IN_WORD)
+
+    /* During first 16 steps, before making any calculations on each step,
+       the W element is read from the input data buffer as big-endian value and
+       stored in the array of W elements. */
+    for(t = 0; t < 16; ++t) {
+      SHA2STEP64RV(a, b, c, d, e, f, g, h, K[t], \
+                   W[t] = SHA512_GET_W_FROM_DATA(data, t));
+    }
+
+  /* 'W' generation and assignment for 16 <= t <= 79.
+     See FIPS PUB 180-4 section 6.4.2.
+     As only last 16 'W' are used in calculations, it is possible to
+     use 16 elements array of W as a cyclic buffer.
+   * Note: ((t-16) & 15) have same value as (t & 15) */
+#define Wgen(w,t) \
+    CURL_UINT64_CAST( (w)[(t - 16) & 15] + sig1((w)[((t) - 2) & 15])   \
+                      + (w)[((t) - 7) & 15] + sig0((w)[((t) - 15) & 15]) )
+
+    /* During last 64 steps, before making any calculations on each step,
+       current W element is generated from other W elements of the cyclic
+       buffer and the generated value is stored back in the cyclic buffer. */
+    for(t = 16; t < 80; ++t) {
+      SHA2STEP64RV(a, b, c, d, e, f, g, h, K[t], \
+                   W[t & 15] = Wgen(W, t));
+    }
+  }
+
+  /* Compute and store the intermediate hash.
+     See FIPS PUB 180-4 section 6.4.2 step 4. */
+  H[0] += a;
+  H[1] += b;
+  H[2] += c;
+  H[3] += d;
+  H[4] += e;
+  H[5] += f;
+  H[6] += g;
+  H[7] += h;
+}
+
+
+/**
+ * Process portion of bytes.
+ *
+ * @param context the calculation context
+ * @param data bytes to add to hash
+ * @param length number of bytes in @a data
+ */
+static void
+MHDx_sha512_256_update(void *context,
+                        const unsigned char *data,
+                        unsigned int length)
+{
+  unsigned int bytes_have; /**< Number of bytes in the context buffer */
+  struct Sha512_256Ctx *const ctx = (struct Sha512_256Ctx *) context;
+  /* Required to mute Intel compiler warning */
+  void *const ctx_buf = ctx->buffer;
+
+  DEBUGASSERT((data != NULL) || (length == 0));
+
+  if(0 == length)
+    return; /* Shortcut, do nothing */
+
+  /* Note: (count & (SHA512_256_BLOCK_SIZE-1))
+           equals (count % SHA512_256_BLOCK_SIZE) for this block size. */
+  bytes_have = (unsigned int) (ctx->count & (SHA512_256_BLOCK_SIZE - 1));
+  ctx->count += length;
+  if(CURL_UINT64_CAST(length) > ctx->count)
+    ctx->count_bits_hi += 1U << 3; /* Value wrap */
+  ctx->count_bits_hi += ctx->count >> 61;
+  ctx->count &= CURL_UINT64_C(0x1FFFFFFFFFFFFFFF);
+
+  if(0 != bytes_have) {
+    unsigned int bytes_left = SHA512_256_BLOCK_SIZE - bytes_have;
+    if(length >= bytes_left) {
+      /* Combine new data with data in the buffer and
+         process the full block. */
+      memcpy(((unsigned char *) ctx_buf) + bytes_have,
+             data,
+             bytes_left);
+      data += bytes_left;
+      length -= bytes_left;
+      MHDx_sha512_256_transform(ctx->H, ctx->buffer);
+      bytes_have = 0;
+    }
+  }
+
+  while(SHA512_256_BLOCK_SIZE <= length) {
+    /* Process any full blocks of new data directly,
+       without copying to the buffer. */
+    MHDx_sha512_256_transform(ctx->H, data);
+    data += SHA512_256_BLOCK_SIZE;
+    length -= SHA512_256_BLOCK_SIZE;
+  }
+
+  if(0 != length) {
+    /* Copy incomplete block of new data (if any)
+       to the buffer. */
+    memcpy(((unsigned char *) ctx_buf) + bytes_have, data, length);
+  }
+}
+
+
+
+/**
+ * Size of "length" insertion in bits.
+ * See FIPS PUB 180-4 section 5.1.2.
+ */
+#define SHA512_256_SIZE_OF_LEN_ADD_BITS 128
+
+/**
+ * Size of "length" insertion in bytes.
+ */
+#define SHA512_256_SIZE_OF_LEN_ADD (SHA512_256_SIZE_OF_LEN_ADD_BITS / 8)
+
+/**
+ * Finalise SHA-512/256 calculation, return digest.
+ *
+ * @param context the calculation context
+ * @param[out] digest set to the hash, must be #SHA512_256_DIGEST_SIZE bytes
+ */
+static void
+MHDx_sha512_256_finish(unsigned char *digest,
+                        void *context)
+{
+  struct Sha512_256Ctx *const ctx = (struct Sha512_256Ctx *) context;
+  curl_uint64_t num_bits;   /**< Number of processed bits */
+  unsigned int bytes_have; /**< Number of bytes in the context buffer */
+  /* Required to mute Intel compiler warning */
+  void *const ctx_buf = ctx->buffer;
+
+
+  /* Memorise the number of processed bits.
+     The padding and other data added here during the postprocessing must
+     not change the amount of hashed data. */
+  num_bits = ctx->count << 3;
+
+  /* Note: (count & (SHA512_256_BLOCK_SIZE-1))
+           equals (count % SHA512_256_BLOCK_SIZE) for this block size. */
+  bytes_have = (unsigned int) (ctx->count & (SHA512_256_BLOCK_SIZE - 1));
+
+  /* Input data must be padded with a single bit "1", then with zeros and
+     the finally the length of data in bits must be added as the final bytes
+     of the last block.
+     See FIPS PUB 180-4 section 5.1.2. */
+
+  /* Data is always processed in form of bytes (not by individual bits),
+     therefore position of the first padding bit in byte is always
+     predefined (0x80). */
+  /* Buffer always have space at least for one byte (as full buffers are
+     processed when formed). */
+  ((unsigned char *) ctx_buf)[bytes_have++] = 0x80U;
+
+  if(SHA512_256_BLOCK_SIZE - bytes_have < SHA512_256_SIZE_OF_LEN_ADD) {
+    /* No space in the current block to put the total length of message.
+       Pad the current block with zeros and process it. */
+    if(bytes_have < SHA512_256_BLOCK_SIZE)
+      memset(((unsigned char *) ctx_buf) + bytes_have, 0,
+             SHA512_256_BLOCK_SIZE - bytes_have);
+    /* Process the full block. */
+    MHDx_sha512_256_transform(ctx->H, ctx->buffer);
+    /* Start the new block. */
+    bytes_have = 0;
+  }
+
+  /* Pad the rest of the buffer with zeros. */
+  memset(((unsigned char *) ctx_buf) + bytes_have, 0,
+         SHA512_256_BLOCK_SIZE - SHA512_256_SIZE_OF_LEN_ADD - bytes_have);
+  /* Put high part of number of bits in processed message and then lower
+     part of number of bits as big-endian values.
+     See FIPS PUB 180-4 section 5.1.2. */
+  /* Note: the target location is predefined and buffer is always aligned */
+  MHDX_PUT_64BIT_BE(((unsigned char *) ctx_buf)  \
+                      + SHA512_256_BLOCK_SIZE         \
+                      - SHA512_256_SIZE_OF_LEN_ADD,   \
+                      ctx->count_bits_hi);
+  MHDX_PUT_64BIT_BE(((unsigned char *) ctx_buf)      \
+                      + SHA512_256_BLOCK_SIZE             \
+                      - SHA512_256_SIZE_OF_LEN_ADD        \
+                      + SHA512_256_BYTES_IN_WORD,         \
+                      num_bits);
+  /* Process the full final block. */
+  MHDx_sha512_256_transform(ctx->H, ctx->buffer);
+
+  /* Put in BE mode the leftmost part of the hash as the final digest.
+     See FIPS PUB 180-4 section 6.7. */
+
+  MHDX_PUT_64BIT_BE((digest + 0 * SHA512_256_BYTES_IN_WORD), ctx->H[0]);
+  MHDX_PUT_64BIT_BE((digest + 1 * SHA512_256_BYTES_IN_WORD), ctx->H[1]);
+  MHDX_PUT_64BIT_BE((digest + 2 * SHA512_256_BYTES_IN_WORD), ctx->H[2]);
+  MHDX_PUT_64BIT_BE((digest + 3 * SHA512_256_BYTES_IN_WORD), ctx->H[3]);
+
+  /* Erase potentially sensitive data. */
+  memset(ctx, 0, sizeof(struct Sha512_256Ctx));
+}
+
+
+/**
+ * Compute SHA-512/256 hash for the given data in one function call
+ * @param[out] output the pointer to put the hash
+ * @param[in] input the pointer to the data to process
+ * @param input_size the size of the data pointed by @a input
+ * @return always #CURLE_OK
+ */
+CURLcode
+Curl_sha512_256it(unsigned char *output, const unsigned char *input,
+                  size_t input_size)
+{
+  struct Sha512_256Ctx ctx;
+  static const unsigned int max_step_size = (unsigned int)(-1);
+
+  (void) MHDx_sha512_256_init(&ctx); /* Always succeed */
+
+  while(input_size >= max_step_size) {
+    MHDx_sha512_256_update(&ctx, (const void *) input, max_step_size);
+    input += max_step_size;
+    input_size -= max_step_size;
+  }
+  MHDx_sha512_256_update(&ctx, (const void *) input,
+                          curlx_uztoui(input_size));
+
+  MHDx_sha512_256_finish(output, &ctx);
+
+  return CURLE_OK;
+}
+
+
+const struct HMAC_params Curl_HMAC_SHA512_256[] = {
+  {
+    /* Initialize context procedure. */
+    MHDx_sha512_256_init,
+    /* Update context with data. */
+    MHDx_sha512_256_update,
+    /* Get final result procedure. */
+    MHDx_sha512_256_finish,
+    /* Context structure size. */
+    sizeof(struct Sha512_256Ctx),
+    /* Maximum key length (bytes). */
+    SHA512_256_BLOCK_SIZE,
+    /* Result length (bytes). */
+    SHA512_256_DIGEST_SIZE
+  }
+};
+
+
+#endif /* !CURL_DISABLE_DIGEST_AUTH && !CURL_DISABLE_SHA512_256 */

--- a/lib/curl_sha512_256.h
+++ b/lib/curl_sha512_256.h
@@ -1,0 +1,44 @@
+#ifndef HEADER_CURL_SHA512_256_H
+#define HEADER_CURL_SHA512_256_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Evgeny Grin (Karlson2k), <k2k@narod.ru>.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#if !defined(CURL_DISABLE_DIGEST_AUTH) && !defined(CURL_DISABLE_SHA512_256)
+
+#include <curl/curl.h>
+#include "curl_hmac.h"
+
+#define CURL_HAVE_SHA512_256
+
+extern const struct HMAC_params Curl_HMAC_SHA512_256[1];
+
+#define SHA512_256_DIGEST_LENGTH 32
+
+CURLcode
+Curl_sha512_256it(unsigned char *output, const unsigned char *input,
+                  size_t input_size);
+
+#endif /* !CURL_DISABLE_DIGEST_AUTH && !CURL_DISABLE_SHA512_256 */
+
+#endif /* HEADER_CURL_SHA256_H */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -203,7 +203,7 @@ test1566 test1567 test1568 test1569 test1570 \
 test1590 test1591 test1592 test1593 test1594 test1595 test1596 test1597 \
 \
 test1600 test1601 test1602 test1603 test1604 test1605 test1606 test1607 \
-test1608 test1609 test1610 test1611 test1612 test1613 test1614 \
+test1608 test1609 test1610 test1611 test1612 test1613 test1614 test1615 \
 \
 test1620 test1621 \
 \

--- a/tests/data/test1615
+++ b/tests/data/test1615
@@ -1,0 +1,23 @@
+<testcase>
+<info>
+<keywords>
+unittest
+SHA-512/256
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+unittest
+sha512-256
+</features>
+<name>
+SHA-512/256 unit tests
+</name>
+</client>
+</testcase>

--- a/tests/data/test2060
+++ b/tests/data/test2060
@@ -67,6 +67,7 @@ http
 !SSPI
 crypto
 proxy
+sha512-256
 </features>
 <name>
 HTTP POST --digest with PUT, resumed upload, modified method, SHA-512-256 and userhash=false
@@ -92,7 +93,7 @@ Content-Length: 0
 
 GET http://%HOSTIP:%HTTPPORT/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="auser", realm="testrealm", nonce="1053604144", uri="/%TESTNUMBER", response="3ce1e25ffa611bdbe90e2ab367b9602fa223db9f6de76ac667f0d6157e2178a6", algorithm=SHA-512-256
+Authorization: Digest username="auser", realm="testrealm", nonce="1053604144", uri="/%TESTNUMBER", response="691867f4a06c79fd0a175c1857e3df7015f6fff3ce8676497d2f1f805b5a8eca", algorithm=SHA-512-256
 Content-Range: bytes 2-4/5
 User-Agent: curl/%VERSION
 Accept: */*

--- a/tests/data/test2062
+++ b/tests/data/test2062
@@ -54,6 +54,7 @@ http
 <features>
 !SSPI
 crypto
+sha512-256
 </features>
 <name>
 HTTP with RFC7616 SHA-512-256 Digest authorization and userhash=false
@@ -73,7 +74,7 @@ Accept: */*
 
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="1053604145", uri="/%TESTNUMBER", response="2af735ec3508f4dff99248ffbbe9de9002bfd7cc770cfa2b026cb334042a54e3", algorithm=SHA-512-256
+Authorization: Digest username="testuser", realm="testrealm", nonce="1053604145", uri="/%TESTNUMBER", response="9d3256ee6526ec40dd48743bb48e51ee9baba587c78f15c3a86166242150af98", algorithm=SHA-512-256
 User-Agent: curl/%VERSION
 Accept: */*
 

--- a/tests/data/test2065
+++ b/tests/data/test2065
@@ -54,6 +54,7 @@ http
 <features>
 !SSPI
 crypto
+sha512-256
 </features>
 <name>
 HTTP with RFC7616 Digest authorization with bad password, SHA-512-256 and userhash=false
@@ -73,7 +74,7 @@ Accept: */*
 
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="testuser", realm="testrealm", nonce="2053604145", uri="/%TESTNUMBER", response="5a5f20b0e601aeddc6f96422c2332d49ff431c49ab143b5f836ef76e9ac78f5e", algorithm=SHA-512-256
+Authorization: Digest username="testuser", realm="testrealm", nonce="2053604145", uri="/%TESTNUMBER", response="0373a49d7d352ff54884faaf762fc6c89281b4112ad8fcbbe1d1ee52dcf7a802", algorithm=SHA-512-256
 User-Agent: curl/%VERSION
 Accept: */*
 

--- a/tests/data/test2068
+++ b/tests/data/test2068
@@ -52,6 +52,7 @@ http
 <features>
 !SSPI
 crypto
+sha512-256
 </features>
 <name>
 HTTP POST --digest with SHA-512-256, userhash=false and user-specified Content-Length header
@@ -76,7 +77,7 @@ Content-Type: application/x-www-form-urlencoded
 
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-Authorization: Digest username="auser", realm="testrealm", nonce="1053604144", uri="/%TESTNUMBER", response="4bc9c97a72f1856bcec9b0e1518c6b7ee28773f91357d56840bdc30bd89ca68f", algorithm=SHA-512-256
+Authorization: Digest username="auser", realm="testrealm", nonce="1053604144", uri="/%TESTNUMBER", response="0ba2f7ec8045446588eea82bb0c3812aedb05f4eac8883ea65040a52e9c5629e", algorithm=SHA-512-256
 User-Agent: curl/%VERSION
 Accept: */*
 Content-Length: 11

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -796,6 +796,7 @@ sub checksystemfeatures {
     $feature{"headers-api"} = 1;
     $feature{"xattr"} = 1;
     $feature{"large-time"} = 1;
+    $feature{"sha512-256"} = 1;
 
     # make each protocol an enabled "feature"
     for my $p (@protocols) {

--- a/tests/server/disabled.c
+++ b/tests/server/disabled.c
@@ -34,6 +34,7 @@
 #include "curl_setup.h"
 #include "multihandle.h" /* for ENABLE_WAKEUP */
 #include "tool_xattr.h" /* for USE_XATTR */
+#include "curl_sha512_256.h" /* for CURL_HAVE_SHA512_256 */
 #include <stdio.h>
 
 static const char *disabled[]={
@@ -99,6 +100,9 @@ static const char *disabled[]={
 #endif
 #if (SIZEOF_TIME_T < 5)
   "large-time",
+#endif
+#ifndef CURL_HAVE_SHA512_256
+  "sha512-256",
 #endif
   NULL
 };

--- a/tests/test1165.pl
+++ b/tests/test1165.pl
@@ -87,7 +87,9 @@ sub scan_file {
     while(<F>) {
         while(s/(CURL_DISABLE_[A-Z0-9_]+)//) {
             my ($sym)=($1);
-            $file{$sym} = $source;
+            if(not $sym =~ /^(CURL_DISABLE_SHA512_256)/) { # Skip this symbol, to be implemented
+                $file{$sym} = $source;
+            }
         }
     }
     close F;

--- a/tests/unit/Makefile.inc
+++ b/tests/unit/Makefile.inc
@@ -34,7 +34,7 @@ UNITPROGS = unit1300          unit1302 unit1303 unit1304 unit1305 unit1307 \
  unit1330 unit1394 unit1395 unit1396 unit1397 unit1398 \
  unit1399 \
  unit1600 unit1601 unit1602 unit1603 unit1604 unit1605 unit1606 unit1607 \
- unit1608 unit1609 unit1610 unit1611 unit1612 unit1614 \
+ unit1608 unit1609 unit1610 unit1611 unit1612 unit1614 unit1615 \
  unit1620 unit1621 \
  unit1650 unit1651 unit1652 unit1653 unit1654 unit1655 \
  unit1660 unit1661 \
@@ -100,6 +100,8 @@ unit1611_SOURCES = unit1611.c $(UNITFILES)
 unit1612_SOURCES = unit1612.c $(UNITFILES)
 
 unit1614_SOURCES = unit1614.c $(UNITFILES)
+
+unit1615_SOURCES = unit1615.c $(UNITFILES)
 
 unit1620_SOURCES = unit1620.c $(UNITFILES)
 

--- a/tests/unit/unit1615.c
+++ b/tests/unit/unit1615.c
@@ -1,0 +1,159 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) Evgeny Grin (Karlson2k), <k2k@narod.ru>.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "curlcheck.h"
+
+#include "curl_sha512_256.h"
+
+static CURLcode unit_setup(void)
+{
+  return CURLE_OK;
+}
+
+static void unit_stop(void)
+{
+
+}
+
+UNITTEST_START
+
+#ifdef CURL_HAVE_SHA512_256
+
+  static const char test_str1[] = "1";
+  static const unsigned char precomp_hash1[SHA512_256_DIGEST_LENGTH] = {
+     0x18, 0xd2, 0x75, 0x66, 0xbd, 0x1a, 0xc6, 0x6b, 0x23, 0x32, 0xd8,
+     0xc5, 0x4a, 0xd4, 0x3f, 0x7b, 0xb2, 0x20, 0x79, 0xc9, 0x06, 0xd0,
+     0x5f, 0x49, 0x1f, 0x3f, 0x07, 0xa2, 0x8d, 0x5c, 0x69, 0x90
+  };
+  static const char test_str2[] = "hello-you-fool";
+  static const unsigned char precomp_hash2[SHA512_256_DIGEST_LENGTH] = {
+      0xaf, 0x6f, 0xb4, 0xb0, 0x13, 0x9b, 0xee, 0x13, 0xd1, 0x95, 0x3c,
+      0xb8, 0xc7, 0xcd, 0x5b, 0x19, 0xf9, 0xcd, 0xcd, 0x21, 0xef, 0xdf,
+      0xa7, 0x42, 0x5c, 0x07, 0x13, 0xea, 0xcc, 0x1a, 0x39, 0x76
+  };
+  static const char test_str3[] = "abc";
+  static const unsigned char precomp_hash3[SHA512_256_DIGEST_LENGTH] = {
+      0x53, 0x04, 0x8E, 0x26, 0x81, 0x94, 0x1E, 0xF9, 0x9B, 0x2E, 0x29,
+      0xB7, 0x6B, 0x4C, 0x7D, 0xAB, 0xE4, 0xC2, 0xD0, 0xC6, 0x34, 0xFC,
+      0x6D, 0x46, 0xE0, 0xE2, 0xF1, 0x31, 0x07, 0xE7, 0xAF, 0x23
+  };
+  static const char test_str4[] = ""; /* empty, zero size input */
+  static const unsigned char precomp_hash4[SHA512_256_DIGEST_LENGTH] = {
+      0xc6, 0x72, 0xb8, 0xd1, 0xef, 0x56, 0xed, 0x28, 0xab, 0x87, 0xc3,
+      0x62, 0x2c, 0x51, 0x14, 0x06, 0x9b, 0xdd, 0x3a, 0xd7, 0xb8, 0xf9,
+      0x73, 0x74, 0x98, 0xd0, 0xc0, 0x1e, 0xce, 0xf0, 0x96, 0x7a
+  };
+  static const char test_str5[] =
+      "abcdefghijklmnopqrstuvwxyzzyxwvutsrqponMLKJIHGFEDCBA" \
+      "abcdefghijklmnopqrstuvwxyzzyxwvutsrqponMLKJIHGFEDCBA";
+  static const unsigned char precomp_hash5[SHA512_256_DIGEST_LENGTH] = {
+      0xad, 0xe9, 0x5d, 0x55, 0x3b, 0x9e, 0x45, 0x69, 0xdb, 0x53, 0xa4,
+      0x04, 0x92, 0xe7, 0x87, 0x94, 0xff, 0xc9, 0x98, 0x5f, 0x93, 0x03,
+      0x86, 0x45, 0xe1, 0x97, 0x17, 0x72, 0x7c, 0xbc, 0x31, 0x15
+  };
+  static const char test_str6[] =
+      "/long/long/long/long/long/long/long/long/long/long/long" \
+      "/long/long/long/long/long/long/long/long/long/long/long" \
+      "/long/long/long/long/long/long/long/long/long/long/long" \
+      "/long/long/long/long/long/long/long/long/long/long/long" \
+      "/long/long/long/long/long/long/long/long/long/long/long" \
+      "/long/long/long/long/long/long/long/long/long/long/long" \
+      "/long/long/long/long/path?with%20some=parameters";
+  static const unsigned char precomp_hash6[SHA512_256_DIGEST_LENGTH] = {
+      0xbc, 0xab, 0xc6, 0x2c, 0x0a, 0x22, 0xd5, 0xcb, 0xac, 0xac, 0xe9,
+      0x25, 0xcf, 0xce, 0xaa, 0xaf, 0x0e, 0xa1, 0xed, 0x42, 0x46, 0x8a,
+      0xe2, 0x01, 0xee, 0x2f, 0xdb, 0x39, 0x75, 0x47, 0x73, 0xf1
+  };
+  static const char test_str7[] = "Simple string.";
+  static const unsigned char precomp_hash7[SHA512_256_DIGEST_LENGTH] = {
+      0xde, 0xcb, 0x3c, 0x81, 0x65, 0x4b, 0xa0, 0xf5, 0xf0, 0x45, 0x6b,
+      0x7e, 0x61, 0xf5, 0x0d, 0xf5, 0x38, 0xa4, 0xfc, 0xb1, 0x8a, 0x95,
+      0xff, 0x59, 0xbc, 0x04, 0x82, 0xcf, 0x23, 0xb2, 0x32, 0x56
+  };
+  static const unsigned char test_seq8[]= {
+      255, 254, 253, 252, 251, 250, 249, 248, 247, 246, 245, 244, 243, 242,
+      241, 240, 239, 238, 237, 236, 235, 234, 233, 232, 231, 230, 229, 228,
+      227, 226, 225, 224, 223, 222, 221, 220, 219, 218, 217, 216, 215, 214,
+      213, 212, 211, 210, 209, 208, 207, 206, 205, 204, 203, 202, 201, 200,
+      199, 198, 197, 196, 195, 194, 193, 192, 191, 190, 189, 188, 187, 186,
+      185, 184, 183, 182, 181, 180, 179, 178, 177, 176, 175, 174, 173, 172,
+      171, 170, 169, 168, 167, 166, 165, 164, 163, 162, 161, 160, 159, 158,
+      157, 156, 155, 154, 153, 152, 151, 150, 149, 148, 147, 146, 145, 144,
+      143, 142, 141, 140, 139, 138, 137, 136, 135, 134, 133, 132, 131, 130,
+      129, 128, 127, 126, 125, 124, 123, 122, 121, 120, 119, 118, 117, 116,
+      115, 114, 113, 112, 111, 110, 109, 108, 107, 106, 105, 104, 103, 102,
+      101, 100, 99, 98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85,
+      84, 83, 82, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67,
+      66, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49,
+      48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31,
+      30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13,
+      12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}; /* 255..1 sequence */
+  static const unsigned char precomp_hash8[SHA512_256_DIGEST_LENGTH] = {
+      0x22, 0x31, 0xf2, 0xa1, 0xb4, 0x89, 0xb2, 0x44, 0xf7, 0x66, 0xa0,
+      0xb8, 0x31, 0xed, 0xb7, 0x73, 0x8a, 0x34, 0xdc, 0x11, 0xc8, 0x2c,
+      0xf2, 0xb5, 0x88, 0x60, 0x39, 0x6b, 0x5c, 0x06, 0x70, 0x37
+  };
+
+  unsigned char output_buf[SHA512_256_DIGEST_LENGTH];
+  unsigned char *computed_hash; /* Just to mute compiler warning */
+
+  /* Mute compiler warnings in 'verify_memory' macros below */
+  computed_hash = output_buf;
+
+  Curl_sha512_256it(output_buf, (const unsigned char *) test_str1,
+                    (sizeof(test_str1) / sizeof(char)) - 1);
+  verify_memory(computed_hash, precomp_hash1, SHA512_256_DIGEST_LENGTH);
+
+  Curl_sha512_256it(output_buf, (const unsigned char *) test_str2,
+                    (sizeof(test_str2) / sizeof(char)) - 1);
+  verify_memory(computed_hash, precomp_hash2, SHA512_256_DIGEST_LENGTH);
+
+  Curl_sha512_256it(output_buf, (const unsigned char *) test_str3,
+                    (sizeof(test_str3) / sizeof(char)) - 1);
+  verify_memory(computed_hash, precomp_hash3, SHA512_256_DIGEST_LENGTH);
+
+  Curl_sha512_256it(output_buf, (const unsigned char *) test_str4,
+                    (sizeof(test_str4) / sizeof(char)) - 1);
+  verify_memory(computed_hash, precomp_hash4, SHA512_256_DIGEST_LENGTH);
+
+  Curl_sha512_256it(output_buf, (const unsigned char *) test_str5,
+                    (sizeof(test_str5) / sizeof(char)) - 1);
+  verify_memory(computed_hash, precomp_hash5, SHA512_256_DIGEST_LENGTH);
+
+  Curl_sha512_256it(output_buf, (const unsigned char *) test_str6,
+                    (sizeof(test_str6) / sizeof(char)) - 1);
+  verify_memory(computed_hash, precomp_hash6, SHA512_256_DIGEST_LENGTH);
+
+  Curl_sha512_256it(output_buf, (const unsigned char *) test_str7,
+                    (sizeof(test_str7) / sizeof(char)) - 1);
+  verify_memory(computed_hash, precomp_hash7, SHA512_256_DIGEST_LENGTH);
+
+  Curl_sha512_256it(output_buf, test_seq8,
+                    sizeof(test_seq8) / sizeof(unsigned char));
+  verify_memory(computed_hash, precomp_hash8, SHA512_256_DIGEST_LENGTH);
+
+#endif /* CURL_HAVE_SHA512_256 */
+
+
+UNITTEST_STOP


### PR DESCRIPTION
This PR adds real support for SHA-512/256 hashing algorithm.
Currently Digest Auth fakes SHA-512/256 by using SHA-256 algorithm which is completely wrong.

The new implementation added as an optional and can be disabled if needed (the related tests are automatically disabled). The disabling machinery is here, but the support for disabling in `configure` and CMake is not implemented and can be added when/if needed.