### PR TITLE
Client Writer cw-out refactor

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -138,6 +138,7 @@ LIB_CFILES =         \
   curl_sspi.c        \
   curl_threads.c     \
   curl_trc.c         \
+  cw-out.c           \
   dict.c             \
   doh.c              \
   dynbuf.c           \
@@ -283,6 +284,7 @@ LIB_HFILES =         \
   curl_threads.h     \
   curl_trc.h         \
   curlx.h            \
+  cw-out.h           \
   dict.h             \
   doh.h              \
   dynbuf.h           \

--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -1,0 +1,248 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#include <curl/curl.h>
+
+#include "urldata.h"
+#include "cfilters.h"
+#include "headers.h"
+#include "multiif.h"
+#include "sendf.h"
+#include "cw-out.h"
+
+/* The last 3 #include files should be in this order */
+#include "curl_printf.h"
+#include "curl_memory.h"
+#include "memdebug.h"
+
+
+static CURLcode pausewrite(struct Curl_easy *data,
+                           int type, /* what type of data */
+                           bool paused_body,
+                           const char *ptr,
+                           size_t len)
+{
+  /* signalled to pause sending on this connection, but since we have data
+     we want to send we need to dup it to save a copy for when the sending
+     is again enabled */
+  struct SingleRequest *k = &data->req;
+  struct UrlState *s = &data->state;
+  unsigned int i;
+  bool newtype = TRUE;
+
+  Curl_conn_ev_data_pause(data, TRUE);
+
+  if(s->tempcount) {
+    for(i = 0; i< s->tempcount; i++) {
+      if(s->tempwrite[i].type == type &&
+         !!s->tempwrite[i].paused_body == !!paused_body) {
+        /* data for this type exists */
+        newtype = FALSE;
+        break;
+      }
+    }
+    DEBUGASSERT(i < 3);
+    if(i >= 3)
+      /* There are more types to store than what fits: very bad */
+      return CURLE_OUT_OF_MEMORY;
+  }
+  else
+    i = 0;
+
+  if(newtype) {
+    /* store this information in the state struct for later use */
+    Curl_dyn_init(&s->tempwrite[i].b, DYN_PAUSE_BUFFER);
+    s->tempwrite[i].type = type;
+    s->tempwrite[i].paused_body = paused_body;
+    s->tempcount++;
+  }
+
+  if(Curl_dyn_addn(&s->tempwrite[i].b, (unsigned char *)ptr, len))
+    return CURLE_OUT_OF_MEMORY;
+
+  /* mark the connection as RECV paused */
+  k->keepon |= KEEP_RECV_PAUSE;
+
+  return CURLE_OK;
+}
+
+
+/* chop_write() writes chunks of data not larger than CURL_MAX_WRITE_SIZE via
+ * client write callback(s) and takes care of pause requests from the
+ * callbacks.
+ */
+static CURLcode chop_write(struct Curl_easy *data,
+                           int type,
+                           bool skip_body_write,
+                           char *optr,
+                           size_t olen)
+{
+  struct connectdata *conn = data->conn;
+  curl_write_callback writeheader = NULL;
+  curl_write_callback writebody = NULL;
+  char *ptr = optr;
+  size_t len = olen;
+  void *writebody_ptr = data->set.out;
+
+  if(!len)
+    return CURLE_OK;
+
+  /* If reading is paused, append this data to the already held data for this
+     type. */
+  if(data->req.keepon & KEEP_RECV_PAUSE)
+    return pausewrite(data, type, !skip_body_write, ptr, len);
+
+  /* Determine the callback(s) to use. */
+  if(!skip_body_write &&
+     ((type & CLIENTWRITE_BODY) ||
+      ((type & CLIENTWRITE_HEADER) && data->set.include_header))) {
+    writebody = data->set.fwrite_func;
+  }
+  if((type & (CLIENTWRITE_HEADER|CLIENTWRITE_INFO)) &&
+     (data->set.fwrite_header || data->set.writeheader)) {
+    /*
+     * Write headers to the same callback or to the especially setup
+     * header callback function (added after version 7.7.1).
+     */
+    writeheader =
+      data->set.fwrite_header? data->set.fwrite_header: data->set.fwrite_func;
+  }
+
+  /* Chop data, write chunks. */
+  while(len) {
+    size_t chunklen = len <= CURL_MAX_WRITE_SIZE? len: CURL_MAX_WRITE_SIZE;
+
+    if(writebody) {
+      size_t wrote;
+      Curl_set_in_callback(data, true);
+      wrote = writebody(ptr, 1, chunklen, writebody_ptr);
+      Curl_set_in_callback(data, false);
+
+      if(CURL_WRITEFUNC_PAUSE == wrote) {
+        if(conn->handler->flags & PROTOPT_NONETWORK) {
+          /* Protocols that work without network cannot be paused. This is
+             actually only FILE:// just now, and it can't pause since the
+             transfer isn't done using the "normal" procedure. */
+          failf(data, "Write callback asked for PAUSE when not supported");
+          return CURLE_WRITE_ERROR;
+        }
+        return pausewrite(data, type, TRUE, ptr, len);
+      }
+      if(wrote != chunklen) {
+        failf(data, "Failure writing output to destination");
+        return CURLE_WRITE_ERROR;
+      }
+    }
+
+    ptr += chunklen;
+    len -= chunklen;
+  }
+
+#ifndef CURL_DISABLE_HTTP
+  /* HTTP header, but not status-line */
+  if((conn->handler->protocol & PROTO_FAMILY_HTTP) &&
+     (type & CLIENTWRITE_HEADER) && !(type & CLIENTWRITE_STATUS) ) {
+    unsigned char htype = (unsigned char)
+      (type & CLIENTWRITE_CONNECT ? CURLH_CONNECT :
+       (type & CLIENTWRITE_1XX ? CURLH_1XX :
+        (type & CLIENTWRITE_TRAILER ? CURLH_TRAILER :
+         CURLH_HEADER)));
+    CURLcode result = Curl_headers_push(data, optr, htype);
+    if(result)
+      return result;
+  }
+#endif
+
+  if(writeheader) {
+    size_t wrote;
+
+    Curl_set_in_callback(data, true);
+    wrote = writeheader(optr, 1, olen, data->set.writeheader);
+    Curl_set_in_callback(data, false);
+
+    if(CURL_WRITEFUNC_PAUSE == wrote)
+      return pausewrite(data, type, FALSE, optr, olen);
+    if(wrote != olen) {
+      failf(data, "Failed writing header");
+      return CURLE_WRITE_ERROR;
+    }
+  }
+
+  return CURLE_OK;
+}
+
+/* Real client writer to installed callbacks. */
+static CURLcode cw_out_write(struct Curl_easy *data,
+                             struct Curl_cwriter *writer, int type,
+                             const char *buf, size_t nbytes)
+{
+  (void)writer;
+  if(!nbytes)
+    return CURLE_OK;
+  return chop_write(data, type, FALSE, (char *)buf, nbytes);
+}
+
+struct Curl_cwtype Curl_cwt_out = {
+  "cw-out",
+  NULL,
+  Curl_cwriter_def_init,
+  cw_out_write,
+  Curl_cwriter_def_close,
+  sizeof(struct Curl_cwriter)
+};
+
+CURLcode Curl_client_unpause(struct Curl_easy *data)
+{
+  CURLcode result = CURLE_OK;
+
+  if(data->state.tempcount) {
+    /* there are buffers for sending that can be delivered as the receive
+       pausing is lifted! */
+    unsigned int i;
+    unsigned int count = data->state.tempcount;
+    struct tempbuf writebuf[3]; /* there can only be three */
+
+    /* copy the structs to allow for immediate re-pausing */
+    for(i = 0; i < data->state.tempcount; i++) {
+      writebuf[i] = data->state.tempwrite[i];
+      Curl_dyn_init(&data->state.tempwrite[i].b, DYN_PAUSE_BUFFER);
+    }
+    data->state.tempcount = 0;
+
+    for(i = 0; i < count; i++) {
+      /* even if one function returns error, this loops through and frees
+         all buffers */
+      if(!result)
+        result = chop_write(data, writebuf[i].type,
+                            !writebuf[i].paused_body,
+                            Curl_dyn_ptr(&writebuf[i].b),
+                            Curl_dyn_len(&writebuf[i].b));
+      Curl_dyn_free(&writebuf[i].b);
+    }
+  }
+  return result;
+}
+

--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -39,211 +39,277 @@
 #include "memdebug.h"
 
 
-struct tempbuf {
-  struct dynbuf b;
-  int type;   /* type of the 'tempwrite' buffer as a bitmask that is used with
-                 Curl_client_write() */
-  BIT(paused_body); /* if PAUSE happened before/during BODY write */
-};
-
 struct cw_out_ctx {
   struct Curl_cwriter super;
-  struct tempbuf tempwrite[3]; /* BOTH, HEADER, BODY */
-  size_t tempcount; /* number of entries in use in tempwrite, 0 - 3 */
+  struct dynbuf buf_body;
+  struct dynbuf buf_hds;
+  BIT(eos);
+  BIT(paused_on_hds);
 };
 
 static CURLcode cw_out_write(struct Curl_easy *data,
                              struct Curl_cwriter *writer, int type,
                              const char *buf, size_t nbytes);
 static void cw_out_close(struct Curl_easy *data, struct Curl_cwriter *writer);
+static CURLcode cw_out_init(struct Curl_easy *data,
+                            struct Curl_cwriter *writer);
 
 struct Curl_cwtype Curl_cwt_out = {
   "cw-out",
   NULL,
-  Curl_cwriter_def_init,
+  cw_out_init,
   cw_out_write,
   cw_out_close,
   sizeof(struct cw_out_ctx)
 };
 
+static CURLcode cw_out_init(struct Curl_easy *data,
+                            struct Curl_cwriter *writer)
+{
+  struct cw_out_ctx *ctx = (struct cw_out_ctx *)writer;
+  (void)data;
+  Curl_dyn_init(&ctx->buf_body, DYN_PAUSE_BUFFER);
+  Curl_dyn_init(&ctx->buf_hds, DYN_PAUSE_BUFFER);
+  return CURLE_OK;
+}
+
 static void cw_out_close(struct Curl_easy *data, struct Curl_cwriter *writer)
 {
   struct cw_out_ctx *ctx = (struct cw_out_ctx *)writer;
-  size_t i;
 
   (void)data;
-  for(i = 0; i < ctx->tempcount; i++) {
-    Curl_dyn_free(&ctx->tempwrite[i].b);
-  }
-  ctx->tempcount = 0;
+  DEBUGF(infof(data, "cw_out_close(buf_hds=%zum, buf_body=%zu",
+         Curl_dyn_len(&ctx->buf_hds), Curl_dyn_len(&ctx->buf_body)));
+  Curl_dyn_free(&ctx->buf_body);
+  Curl_dyn_free(&ctx->buf_hds);
 }
 
-static CURLcode pausewrite(struct cw_out_ctx *ctx,
-                           struct Curl_easy *data,
-                           int type, /* what type of data */
-                           bool paused_body,
-                           const char *ptr,
-                           size_t len)
+static CURLcode cw_out_ptr_flush(struct cw_out_ctx *ctx,
+                                 struct Curl_easy *data,
+                                 curl_write_callback wcb,
+                                 void *wcb_data,
+                                 size_t chunk_max,
+                                 size_t chunk_pref,
+                                 bool flush_all,
+                                 const char *buf, size_t blen,
+                                 size_t *pconsumed)
 {
-  /* signalled to pause sending on this connection, but since we have data
-     we want to send we need to dup it to save a copy for when the sending
-     is again enabled */
-  struct SingleRequest *k = &data->req;
-  unsigned int i;
-  bool newtype = TRUE;
+  size_t wlen, nwritten;
 
-  Curl_conn_ev_data_pause(data, TRUE);
+  DEBUGASSERT(wcb);
+  (void)ctx;
+  *pconsumed = 0;
+  while(blen) {
+    if(!flush_all && blen < chunk_pref)
+      break;
+    wlen = CURLMIN(blen, chunk_max);
+    nwritten = wcb((char *)buf, 1, wlen, wcb_data);
+    if(CURL_WRITEFUNC_PAUSE == nwritten) {
+      if(data->conn && data->conn->handler->flags & PROTOPT_NONETWORK) {
+        /* Protocols that work without network cannot be paused. This is
+           actually only FILE:// just now, and it can't pause since the
+           transfer isn't done using the "normal" procedure. */
+        failf(data, "Write callback asked for PAUSE when not supported");
+        return CURLE_WRITE_ERROR;
+      }
+      /* mark the connection as RECV paused */
+      data->req.keepon |= KEEP_RECV_PAUSE;
+      break;
+    }
+    if(nwritten != wlen) {
+      failf(data, "Failure writing output to destination");
+      return CURLE_WRITE_ERROR;
+    }
+    *pconsumed += nwritten;
+    blen -= nwritten;
+    buf += nwritten;
+  }
+  return CURLE_OK;
+}
 
-  if(ctx->tempcount) {
-    for(i = 0; i< ctx->tempcount; i++) {
-      if(ctx->tempwrite[i].type == type &&
-         !!ctx->tempwrite[i].paused_body == !!paused_body) {
-        /* data for this type exists */
-        newtype = FALSE;
-        break;
+static CURLcode cw_out_buf_flush(struct cw_out_ctx *ctx,
+                                 struct Curl_easy *data,
+                                 curl_write_callback wcb,
+                                 void *wcb_data,
+                                 size_t chunk_max,
+                                 size_t chunk_pref,
+                                 bool flush_all,
+                                 struct dynbuf *buf)
+{
+  CURLcode result = CURLE_OK;
+
+  if(Curl_dyn_len(buf)) {
+    size_t consumed;
+    result = cw_out_ptr_flush(ctx, data, wcb, wcb_data, chunk_max, chunk_pref,
+                              flush_all, Curl_dyn_ptr(buf), Curl_dyn_len(buf),
+                              &consumed);
+    if(result)
+      return result;
+    if(consumed) {
+      if(consumed == Curl_dyn_len(buf)) {
+        Curl_dyn_free(buf);
+      }
+      else {
+        DEBUGASSERT(consumed < Curl_dyn_len(buf));
+        result = Curl_dyn_tail(buf, Curl_dyn_len(buf) - consumed);
+        if(result)
+          return result;
       }
     }
-    DEBUGASSERT(i < 3);
-    if(i >= 3)
-      /* There are more types to store than what fits: very bad */
-      return CURLE_OUT_OF_MEMORY;
   }
-  else
-    i = 0;
+  return result;
+}
 
-  if(newtype) {
-    /* store this information in the state struct for later use */
-    Curl_dyn_init(&ctx->tempwrite[i].b, DYN_PAUSE_BUFFER);
-    ctx->tempwrite[i].type = type;
-    ctx->tempwrite[i].paused_body = paused_body;
-    ctx->tempcount++;
+static CURLcode cw_out_do_write(struct cw_out_ctx *ctx,
+                                struct Curl_easy *data,
+                                curl_write_callback wcb,
+                                void *wcb_data,
+                                size_t chunk_max,
+                                size_t chunk_pref, bool flush_all,
+                                struct dynbuf *dest_buf,
+                                const char *buf, size_t blen)
+{
+  CURLcode result;
+
+  if(!wcb) {
+    /* a client supplied callback might disappear, in which case
+     * we clear `dest_buf` and return success */
+    Curl_dyn_free(dest_buf);
+    return CURLE_OK;
   }
 
-  if(Curl_dyn_addn(&ctx->tempwrite[i].b, (unsigned char *)ptr, len))
-    return CURLE_OUT_OF_MEMORY;
+  if(data->req.keepon & KEEP_RECV_PAUSE) {
+    return Curl_dyn_addn(dest_buf, (unsigned char *)buf, blen);
+  }
+  ctx->paused_on_hds = FALSE;
 
-  /* mark the connection as RECV paused */
-  k->keepon |= KEEP_RECV_PAUSE;
+  if(Curl_dyn_len(dest_buf) > chunk_max) {
+    result = cw_out_buf_flush(ctx, data, wcb, wcb_data, chunk_max, chunk_pref,
+                              flush_all, dest_buf);
+    if(result)
+      return result;
+    if(data->req.keepon & KEEP_RECV_PAUSE) {
+      /* flush did pause us */
+      ctx->paused_on_hds = (dest_buf == &ctx->buf_hds);
+      return Curl_dyn_addn(dest_buf, (unsigned char *)buf, blen);
+    }
+  }
+
+  if(Curl_dyn_len(dest_buf)) {
+  /* If something remained in the buffer, it is smaller than the chunk
+   * size we'd like to write. Add the buffer and flush chunks again. */
+    result = Curl_dyn_addn(dest_buf, (unsigned char *)buf, blen);
+    if(result)
+      return result;
+    result = cw_out_buf_flush(ctx, data, wcb, wcb_data, chunk_max, chunk_pref,
+                              flush_all||ctx->eos, dest_buf);
+    if(result)
+      return result;
+  }
+  else {
+    /* `dest_buf` is empty, write `buf` directly out. This might not
+     * consume all data when remainder is smaller than chunk_size (and EOS
+     * is not set) or when the writing caused pausing. */
+    size_t consumed;
+    result = cw_out_ptr_flush(ctx, data, wcb, wcb_data, chunk_max, chunk_pref,
+                              flush_all||ctx->eos, buf, blen, &consumed);
+    if(result)
+      return result;
+    DEBUGASSERT(consumed <= blen);
+    blen -= consumed;
+    buf += consumed;
+    if(blen) {
+      result = Curl_dyn_addn(dest_buf, (unsigned char *)buf, blen);
+      if(result)
+        return result;
+    }
+  }
+
+  if(data->req.keepon & KEEP_RECV_PAUSE) {
+    ctx->paused_on_hds = (dest_buf == &ctx->buf_hds);
+  }
 
   return CURLE_OK;
 }
 
-
-/* chop_write() writes chunks of data not larger than CURL_MAX_WRITE_SIZE via
- * client write callback(s) and takes care of pause requests from the
- * callbacks.
- */
-static CURLcode chop_write(struct cw_out_ctx *ctx,
-                           struct Curl_easy *data,
-                           int type,
-                           bool skip_body_write,
-                           char *optr,
-                           size_t olen)
+static CURLcode cw_out_write_body(struct cw_out_ctx *ctx,
+                                  struct Curl_easy *data, bool flush_all,
+                                  const char *buf, size_t blen)
 {
-  struct connectdata *conn = data->conn;
-  curl_write_callback writeheader = NULL;
-  curl_write_callback writebody = NULL;
-  char *ptr = optr;
-  size_t len = olen;
-  void *writebody_ptr = data->set.out;
+  /* For header write callbacks, the chunk size is CURL_MAX_WRITE_SIZE
+   * and we may collate smaller writes to that size, depending on
+   * protocol spoken. */
+  size_t chunk_pref = (data->conn &&
+                       (data->conn->handler->protocol & PROTO_FAMILY_HTTP))?
+                       CURL_MAX_WRITE_SIZE/2 : 0;
+  DEBUGF(infof(data, "cw_out_write_body(len=%zu), buffered=%zu, eos=%d",
+               blen, Curl_dyn_len(&ctx->buf_body), ctx->eos));
+  return cw_out_do_write(ctx, data, data->set.fwrite_func, data->set.out,
+                         CURL_MAX_WRITE_SIZE, chunk_pref, flush_all,
+                         &ctx->buf_body, buf, blen);
+}
 
-  if(!len)
-    return CURLE_OK;
-
-  /* If reading is paused, append this data to the already held data for this
-     type. */
-  if(data->req.keepon & KEEP_RECV_PAUSE)
-    return pausewrite(ctx, data, type, !skip_body_write, ptr, len);
-
-  /* Determine the callback(s) to use. */
-  if(!skip_body_write &&
-     ((type & CLIENTWRITE_BODY) ||
-      ((type & CLIENTWRITE_HEADER) && data->set.include_header))) {
-    writebody = data->set.fwrite_func;
+static CURLcode cw_out_write_hds(struct cw_out_ctx *ctx,
+                                 struct Curl_easy *data, bool flush_all,
+                                 const char *buf, size_t blen)
+{
+  /* For header write callbacks, the chunk size is CURL_MAX_HTTP_HEADER
+   * and we write immmediately also small amounts. */
+  DEBUGF(infof(data, "cw_out_write_hds(len=%zu), buffered=%zu, eos=%d",
+               blen, Curl_dyn_len(&ctx->buf_hds), ctx->eos));
+  /* Write headers, but before we do that, we flush any pending
+   * BODY data if a pause was not caused by writeing hds */
+  if(!ctx->paused_on_hds && Curl_dyn_len(&ctx->buf_body)) {
+    CURLcode result = cw_out_write_body(ctx, data, TRUE, buf, 0);
+    if(result)
+      return result;
   }
-  if((type & (CLIENTWRITE_HEADER|CLIENTWRITE_INFO)) &&
-     (data->set.fwrite_header || data->set.writeheader)) {
-    /*
-     * Write headers to the same callback or to the especially setup
-     * header callback function (added after version 7.7.1).
-     */
-    writeheader =
-      data->set.fwrite_header? data->set.fwrite_header: data->set.fwrite_func;
-  }
+  return cw_out_do_write(ctx, data, data->set.fwrite_header?
+                         data->set.fwrite_header:
+                         (data->set.writeheader? data->set.fwrite_func:NULL),
+                         data->set.writeheader, CURL_MAX_HTTP_HEADER, 0,
+                         flush_all, &ctx->buf_hds, buf, blen);
+}
 
-  /* Chop data, write chunks. */
-  while(len) {
-    size_t chunklen = len <= CURL_MAX_WRITE_SIZE? len: CURL_MAX_WRITE_SIZE;
-
-    if(writebody) {
-      size_t wrote;
-      Curl_set_in_callback(data, true);
-      wrote = writebody(ptr, 1, chunklen, writebody_ptr);
-      Curl_set_in_callback(data, false);
-
-      if(CURL_WRITEFUNC_PAUSE == wrote) {
-        if(conn->handler->flags & PROTOPT_NONETWORK) {
-          /* Protocols that work without network cannot be paused. This is
-             actually only FILE:// just now, and it can't pause since the
-             transfer isn't done using the "normal" procedure. */
-          failf(data, "Write callback asked for PAUSE when not supported");
-          return CURLE_WRITE_ERROR;
-        }
-        return pausewrite(ctx, data, type, TRUE, ptr, len);
-      }
-      if(wrote != chunklen) {
-        failf(data, "Failure writing output to destination");
-        return CURLE_WRITE_ERROR;
-      }
-    }
-
-    ptr += chunklen;
-    len -= chunklen;
-  }
+static CURLcode cw_out_write(struct Curl_easy *data,
+                             struct Curl_cwriter *writer, int type,
+                             const char *buf, size_t blen)
+{
+  struct cw_out_ctx *ctx = (struct cw_out_ctx *)writer;
+  CURLcode result;
 
 #ifndef CURL_DISABLE_HTTP
   /* HTTP header, but not status-line */
-  if((conn->handler->protocol & PROTO_FAMILY_HTTP) &&
+  if(data->conn && (data->conn->handler->protocol & PROTO_FAMILY_HTTP) &&
      (type & CLIENTWRITE_HEADER) && !(type & CLIENTWRITE_STATUS) ) {
     unsigned char htype = (unsigned char)
       (type & CLIENTWRITE_CONNECT ? CURLH_CONNECT :
        (type & CLIENTWRITE_1XX ? CURLH_1XX :
         (type & CLIENTWRITE_TRAILER ? CURLH_TRAILER :
          CURLH_HEADER)));
-    CURLcode result = Curl_headers_push(data, optr, htype);
+    result = Curl_headers_push(data, buf, htype);
     if(result)
       return result;
   }
 #endif
 
-  if(writeheader) {
-    size_t wrote;
+  if(type & CLIENTWRITE_EOS)
+    ctx->eos = TRUE;
 
-    Curl_set_in_callback(data, true);
-    wrote = writeheader(optr, 1, olen, data->set.writeheader);
-    Curl_set_in_callback(data, false);
+  if((type & CLIENTWRITE_BODY) ||
+     ((type & CLIENTWRITE_HEADER) && data->set.include_header)) {
+    result = cw_out_write_body(ctx, data, FALSE, buf, blen);
+    if(result)
+      return result;
+  }
 
-    if(CURL_WRITEFUNC_PAUSE == wrote)
-      return pausewrite(ctx, data, type, FALSE, optr, olen);
-    if(wrote != olen) {
-      failf(data, "Failed writing header");
-      return CURLE_WRITE_ERROR;
-    }
+  if(type & (CLIENTWRITE_HEADER|CLIENTWRITE_INFO)) {
+    result = cw_out_write_hds(ctx, data, FALSE, buf, blen);
+    if(result)
+      return result;
   }
 
   return CURLE_OK;
-}
-
-/* Real client writer to installed callbacks. */
-static CURLcode cw_out_write(struct Curl_easy *data,
-                             struct Curl_cwriter *writer, int type,
-                             const char *buf, size_t nbytes)
-{
-  struct cw_out_ctx *ctx = (struct cw_out_ctx *)writer;
-
-  if(!nbytes)
-    return CURLE_OK;
-  return chop_write(ctx, data, type, FALSE, (char *)buf, nbytes);
 }
 
 bool Curl_cw_out_is_paused(struct Curl_easy *data)
@@ -256,44 +322,41 @@ bool Curl_cw_out_is_paused(struct Curl_easy *data)
     return FALSE;
 
   ctx = (struct cw_out_ctx *)cw_out;
-  return ctx->tempcount > 0;
+  return Curl_dyn_len(&ctx->buf_body) || Curl_dyn_len(&ctx->buf_hds);
 }
 
-CURLcode Curl_cw_out_unpause(struct Curl_easy *data)
+static CURLcode cw_out_flush(struct Curl_easy *data, bool eos)
 {
-  CURLcode result = CURLE_OK;
   struct Curl_cwriter *cw_out;
-  struct cw_out_ctx *ctx;
+  CURLcode result = CURLE_OK;
+  char tmp[1];
 
   cw_out = Curl_cwriter_get_by_type(data, &Curl_cwt_out);
-  if(!cw_out)
-    return CURLE_OK;
+  if(cw_out) {
+    struct cw_out_ctx *ctx = (struct cw_out_ctx *)cw_out;
 
-  ctx = (struct cw_out_ctx *)cw_out;
-  if(ctx->tempcount) {
-    /* there are buffers for sending that can be delivered as the receive
-       pausing is lifted! */
-    size_t i, count = ctx->tempcount;
-    struct tempbuf writebuf[3]; /* there can only be three */
+    if(eos)
+      ctx->eos = TRUE;
 
-    /* copy the structs to allow for immediate re-pausing */
-    for(i = 0; i < ctx->tempcount; i++) {
-      writebuf[i] = ctx->tempwrite[i];
-      Curl_dyn_init(&ctx->tempwrite[i].b, DYN_PAUSE_BUFFER);
+    if(ctx->paused_on_hds) {
+      result = cw_out_write_hds(ctx, data, eos, tmp, 0);
     }
-    ctx->tempcount = 0;
-
-    for(i = 0; i < count; i++) {
-      /* even if one function returns error, this loops through and frees
-         all buffers */
-      if(!result)
-        result = chop_write(ctx, data, writebuf[i].type,
-                            !writebuf[i].paused_body,
-                            Curl_dyn_ptr(&writebuf[i].b),
-                            Curl_dyn_len(&writebuf[i].b));
-      Curl_dyn_free(&writebuf[i].b);
+    if(!result && Curl_dyn_len(&ctx->buf_body)) {
+      result = cw_out_write_body(ctx, data, eos, tmp, 0);
+    }
+    if(!result && Curl_dyn_len(&ctx->buf_hds)) {
+      result = cw_out_write_hds(ctx, data, eos, tmp, 0);
     }
   }
   return result;
 }
 
+CURLcode Curl_cw_out_flush(struct Curl_easy *data)
+{
+  return cw_out_flush(data, FALSE);
+}
+
+CURLcode Curl_cw_out_done(struct Curl_easy *data)
+{
+  return cw_out_flush(data, TRUE);
+}

--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -211,7 +211,7 @@ static CURLcode cw_out_ptr_flush(struct cw_out_ctx *ctx,
   size_t wlen, nwritten;
 
   (void)ctx;
-  /* write callbacks may get NULLed by the client inbetween calls. */
+  /* write callbacks may get NULLed by the client between calls. */
   cw_get_writefunc(data, otype, &wcb, &wcb_data, &max_write, &min_write);
   if(!wcb) {
     *pconsumed = blen;

--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -382,21 +382,6 @@ static CURLcode cw_out_write(struct Curl_easy *data,
   CURLcode result;
   bool flush_all;
 
-#ifndef CURL_DISABLE_HTTP
-  /* HTTP header, but not status-line */
-  if(data->conn && (data->conn->handler->protocol & PROTO_FAMILY_HTTP) &&
-     (type & CLIENTWRITE_HEADER) && !(type & CLIENTWRITE_STATUS) ) {
-    unsigned char htype = (unsigned char)
-      (type & CLIENTWRITE_CONNECT ? CURLH_CONNECT :
-       (type & CLIENTWRITE_1XX ? CURLH_1XX :
-        (type & CLIENTWRITE_TRAILER ? CURLH_TRAILER :
-         CURLH_HEADER)));
-    result = Curl_headers_push(data, buf, htype);
-    if(result)
-      return result;
-  }
-#endif
-
   flush_all = (type & CLIENTWRITE_EOS)? TRUE:FALSE;
   if((type & CLIENTWRITE_BODY) ||
      ((type & CLIENTWRITE_HEADER) && data->set.include_header)) {

--- a/lib/cw-out.h
+++ b/lib/cw-out.h
@@ -36,15 +36,18 @@
 extern struct Curl_cwtype Curl_cwt_out;
 
 /**
- * For a paused transfer, there might be buffered data held back.
- * Attempt to flush this data to the client. This *may* trigger
- * another pause of the transfer.
- */
-CURLcode Curl_cw_out_unpause(struct Curl_easy *data);
-
-/**
  * Return TRUE iff 'cw-out' client write has paused data.
  */
 bool Curl_cw_out_is_paused(struct Curl_easy *data);
+
+/**
+ * Flush any buffered date to the client, chunk collation still applies.
+ */
+CURLcode Curl_cw_out_flush(struct Curl_easy *data);
+
+/**
+ * Mark EndOfStream reached and flush ALL data to the client.
+ */
+CURLcode Curl_cw_out_done(struct Curl_easy *data);
 
 #endif /* HEADER_CURL_CW_OUT_H */

--- a/lib/cw-out.h
+++ b/lib/cw-out.h
@@ -28,6 +28,11 @@
 
 #include "sendf.h"
 
+/**
+ * The client writer type "cw-out" that does the actual writing to
+ * the client callbacks. Intended to be the last installed in the
+ * client writer stack of a transfer.
+ */
 extern struct Curl_cwtype Curl_cwt_out;
 
 /**
@@ -35,6 +40,11 @@ extern struct Curl_cwtype Curl_cwt_out;
  * Attempt to flush this data to the client. This *may* trigger
  * another pause of the transfer.
  */
-CURLcode Curl_client_unpause(struct Curl_easy *data);
+CURLcode Curl_cw_out_unpause(struct Curl_easy *data);
+
+/**
+ * Return TRUE iff 'cw-out' client write has paused data.
+ */
+bool Curl_cw_out_is_paused(struct Curl_easy *data);
 
 #endif /* HEADER_CURL_CW_OUT_H */

--- a/lib/cw-out.h
+++ b/lib/cw-out.h
@@ -1,0 +1,40 @@
+#ifndef HEADER_CURL_CW_OUT_H
+#define HEADER_CURL_CW_OUT_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#include "sendf.h"
+
+extern struct Curl_cwtype Curl_cwt_out;
+
+/**
+ * For a paused transfer, there might be buffered data held back.
+ * Attempt to flush this data to the client. This *may* trigger
+ * another pause of the transfer.
+ */
+CURLcode Curl_client_unpause(struct Curl_easy *data);
+
+#endif /* HEADER_CURL_CW_OUT_H */

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1118,7 +1118,7 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
 
   if(!(newstate & KEEP_RECV_PAUSE)) {
     Curl_conn_ev_data_pause(data, FALSE);
-    result = Curl_client_unpause(data);
+    result = Curl_cw_out_unpause(data);
     if(result)
       return result;
   }
@@ -1142,7 +1142,7 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
     /* reset the too-slow time keeper */
     data->state.keeps_speed.tv_sec = 0;
 
-    if(!data->state.tempcount)
+    if(!Curl_cw_out_is_paused(data))
       /* if not pausing again, force a recv/send check of this connection as
          the data might've been read off the socket already */
       data->state.select_bits = CURL_CSELECT_IN | CURL_CSELECT_OUT;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -58,6 +58,7 @@
 #include "multiif.h"
 #include "select.h"
 #include "cfilters.h"
+#include "cw-out.h"
 #include "sendf.h" /* for failf function prototype */
 #include "connect.h" /* for Curl_getconnectinfo */
 #include "slist.h"

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1118,7 +1118,7 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
 
   if(!(newstate & KEEP_RECV_PAUSE)) {
     Curl_conn_ev_data_pause(data, FALSE);
-    result = Curl_cw_out_unpause(data);
+    result = Curl_cw_out_flush(data);
     if(result)
       return result;
   }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -645,7 +645,7 @@ static CURLcode multi_done(struct Curl_easy *data,
                                                 after an error was detected */
                            bool premature)
 {
-  CURLcode result;
+  CURLcode result, r2;
   struct connectdata *conn = data->conn;
 
 #if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
@@ -695,6 +695,11 @@ static CURLcode multi_done(struct Curl_easy *data,
     if(!result && rc)
       result = CURLE_ABORTED_BY_CALLBACK;
   }
+
+  /* Make sure that transfer client writes are really done now. */
+  r2 = Curl_xfer_write_done(data, premature);
+  if(r2 && !result)
+    result = r2;
 
   /* Inform connection filters that this transfer is done */
   Curl_conn_ev_data_done(data, premature);

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -166,7 +166,6 @@ CURLcode Curl_client_write(struct Curl_easy *data,
 void Curl_client_cleanup(struct Curl_easy *data)
 {
   struct Curl_cwriter *writer = data->req.writer_stack;
-  size_t i;
 
   while(writer) {
     data->req.writer_stack = writer->next;
@@ -175,10 +174,6 @@ void Curl_client_cleanup(struct Curl_easy *data)
     writer = data->req.writer_stack;
   }
 
-  for(i = 0; i < data->state.tempcount; i++) {
-    Curl_dyn_free(&data->state.tempwrite[i].b);
-  }
-  data->state.tempcount = 0;
   data->req.bytecount = 0;
   data->req.headerline = 0;
 }
@@ -472,6 +467,17 @@ struct Curl_cwriter *Curl_cwriter_get_by_name(struct Curl_easy *data,
   struct Curl_cwriter *writer;
   for(writer = data->req.writer_stack; writer; writer = writer->next) {
     if(!strcmp(name, writer->cwt->name))
+      return writer;
+  }
+  return NULL;
+}
+
+struct Curl_cwriter *Curl_cwriter_get_by_type(struct Curl_easy *data,
+                                              const struct Curl_cwtype *cwt)
+{
+  struct Curl_cwriter *writer;
+  for(writer = data->req.writer_stack; writer; writer = writer->next) {
+    if(writer->cwt == cwt)
       return writer;
   }
   return NULL;

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -302,7 +302,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
   /* Update stats, write and report progress */
   data->req.bytecount += nwrite;
   ++data->req.bodywrites;
-  if(!data->req.ignorebody && nwrite) {
+  if(!data->req.ignorebody && (nwrite || (type & CLIENTWRITE_EOS))) {
     result = Curl_cwriter_write(data, writer->next, type, buf, nwrite);
     if(result)
       return result;

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -41,6 +41,7 @@
 #include "cfilters.h"
 #include "connect.h"
 #include "content_encoding.h"
+#include "cw-out.h"
 #include "vtls/vtls.h"
 #include "vssh/ssh.h"
 #include "easyif.h"
@@ -133,147 +134,6 @@ CURLcode Curl_write(struct Curl_easy *data,
   return Curl_nwrite(data, num, mem, len, written);
 }
 
-static CURLcode pausewrite(struct Curl_easy *data,
-                           int type, /* what type of data */
-                           bool paused_body,
-                           const char *ptr,
-                           size_t len)
-{
-  /* signalled to pause sending on this connection, but since we have data
-     we want to send we need to dup it to save a copy for when the sending
-     is again enabled */
-  struct SingleRequest *k = &data->req;
-  struct UrlState *s = &data->state;
-  unsigned int i;
-  bool newtype = TRUE;
-
-  Curl_conn_ev_data_pause(data, TRUE);
-
-  if(s->tempcount) {
-    for(i = 0; i< s->tempcount; i++) {
-      if(s->tempwrite[i].type == type &&
-         !!s->tempwrite[i].paused_body == !!paused_body) {
-        /* data for this type exists */
-        newtype = FALSE;
-        break;
-      }
-    }
-    DEBUGASSERT(i < 3);
-    if(i >= 3)
-      /* There are more types to store than what fits: very bad */
-      return CURLE_OUT_OF_MEMORY;
-  }
-  else
-    i = 0;
-
-  if(newtype) {
-    /* store this information in the state struct for later use */
-    Curl_dyn_init(&s->tempwrite[i].b, DYN_PAUSE_BUFFER);
-    s->tempwrite[i].type = type;
-    s->tempwrite[i].paused_body = paused_body;
-    s->tempcount++;
-  }
-
-  if(Curl_dyn_addn(&s->tempwrite[i].b, (unsigned char *)ptr, len))
-    return CURLE_OUT_OF_MEMORY;
-
-  /* mark the connection as RECV paused */
-  k->keepon |= KEEP_RECV_PAUSE;
-
-  return CURLE_OK;
-}
-
-
-/* chop_write() writes chunks of data not larger than CURL_MAX_WRITE_SIZE via
- * client write callback(s) and takes care of pause requests from the
- * callbacks.
- */
-static CURLcode chop_write(struct Curl_easy *data,
-                           int type,
-                           bool skip_body_write,
-                           char *optr,
-                           size_t olen)
-{
-  struct connectdata *conn = data->conn;
-  curl_write_callback writeheader = NULL;
-  curl_write_callback writebody = NULL;
-  char *ptr = optr;
-  size_t len = olen;
-  void *writebody_ptr = data->set.out;
-
-  if(!len)
-    return CURLE_OK;
-
-  /* If reading is paused, append this data to the already held data for this
-     type. */
-  if(data->req.keepon & KEEP_RECV_PAUSE)
-    return pausewrite(data, type, !skip_body_write, ptr, len);
-
-  /* Determine the callback(s) to use. */
-  if(!skip_body_write &&
-     ((type & CLIENTWRITE_BODY) ||
-      ((type & CLIENTWRITE_HEADER) && data->set.include_header))) {
-    writebody = data->set.fwrite_func;
-  }
-  if((type & (CLIENTWRITE_HEADER|CLIENTWRITE_INFO)) &&
-     (data->set.fwrite_header || data->set.writeheader)) {
-    /*
-     * Write headers to the same callback or to the especially setup
-     * header callback function (added after version 7.7.1).
-     */
-    writeheader =
-      data->set.fwrite_header? data->set.fwrite_header: data->set.fwrite_func;
-  }
-
-  /* Chop data, write chunks. */
-  while(len) {
-    size_t chunklen = len <= CURL_MAX_WRITE_SIZE? len: CURL_MAX_WRITE_SIZE;
-
-    if(writebody) {
-      size_t wrote;
-      Curl_set_in_callback(data, true);
-      wrote = writebody(ptr, 1, chunklen, writebody_ptr);
-      Curl_set_in_callback(data, false);
-
-      if(CURL_WRITEFUNC_PAUSE == wrote) {
-        if(conn->handler->flags & PROTOPT_NONETWORK) {
-          /* Protocols that work without network cannot be paused. This is
-             actually only FILE:// just now, and it can't pause since the
-             transfer isn't done using the "normal" procedure. */
-          failf(data, "Write callback asked for PAUSE when not supported");
-          return CURLE_WRITE_ERROR;
-        }
-        return pausewrite(data, type, TRUE, ptr, len);
-      }
-      if(wrote != chunklen) {
-        failf(data, "Failure writing output to destination");
-        return CURLE_WRITE_ERROR;
-      }
-    }
-
-    ptr += chunklen;
-    len -= chunklen;
-  }
-
-  if(writeheader) {
-    size_t wrote;
-
-    Curl_set_in_callback(data, true);
-    wrote = writeheader(optr, 1, olen, data->set.writeheader);
-    Curl_set_in_callback(data, false);
-
-    if(CURL_WRITEFUNC_PAUSE == wrote)
-      return pausewrite(data, type, FALSE, optr, olen);
-    if(wrote != olen) {
-      failf(data, "Failed writing header");
-      return CURLE_WRITE_ERROR;
-    }
-  }
-
-  return CURLE_OK;
-}
-
-
 /* Curl_client_write() sends data to the write callback(s)
 
    The bit pattern defines to what "streams" to write to. Body and/or header.
@@ -301,38 +161,6 @@ CURLcode Curl_client_write(struct Curl_easy *data,
   }
 
   return Curl_cwriter_write(data, data->req.writer_stack, type, buf, blen);
-}
-
-CURLcode Curl_client_unpause(struct Curl_easy *data)
-{
-  CURLcode result = CURLE_OK;
-
-  if(data->state.tempcount) {
-    /* there are buffers for sending that can be delivered as the receive
-       pausing is lifted! */
-    unsigned int i;
-    unsigned int count = data->state.tempcount;
-    struct tempbuf writebuf[3]; /* there can only be three */
-
-    /* copy the structs to allow for immediate re-pausing */
-    for(i = 0; i < data->state.tempcount; i++) {
-      writebuf[i] = data->state.tempwrite[i];
-      Curl_dyn_init(&data->state.tempwrite[i].b, DYN_PAUSE_BUFFER);
-    }
-    data->state.tempcount = 0;
-
-    for(i = 0; i < count; i++) {
-      /* even if one function returns error, this loops through and frees
-         all buffers */
-      if(!result)
-        result = chop_write(data, writebuf[i].type,
-                            !writebuf[i].paused_body,
-                            Curl_dyn_ptr(&writebuf[i].b),
-                            Curl_dyn_len(&writebuf[i].b));
-      Curl_dyn_free(&writebuf[i].b);
-    }
-  }
-  return result;
 }
 
 void Curl_client_cleanup(struct Curl_easy *data)
@@ -387,26 +215,6 @@ void Curl_cwriter_def_close(struct Curl_easy *data,
   (void) data;
   (void) writer;
 }
-
-/* Real client writer to installed callbacks. */
-static CURLcode cw_client_write(struct Curl_easy *data,
-                                struct Curl_cwriter *writer, int type,
-                                const char *buf, size_t nbytes)
-{
-  (void)writer;
-  if(!nbytes)
-    return CURLE_OK;
-  return chop_write(data, type, FALSE, (char *)buf, nbytes);
-}
-
-static const struct Curl_cwtype cw_client = {
-  "client",
-  NULL,
-  Curl_cwriter_def_init,
-  cw_client_write,
-  Curl_cwriter_def_close,
-  sizeof(struct Curl_cwriter)
-};
 
 static size_t get_max_body_write_len(struct Curl_easy *data, curl_off_t limit)
 {
@@ -615,7 +423,7 @@ static CURLcode do_init_stack(struct Curl_easy *data)
 
   DEBUGASSERT(!data->req.writer_stack);
   result = Curl_cwriter_create(&data->req.writer_stack,
-                               data, &cw_client, CURL_CW_CLIENT);
+                               data, &Curl_cwt_out, CURL_CW_CLIENT);
   if(result)
     return result;
 

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -299,14 +299,14 @@ static CURLcode cw_download_write(struct Curl_easy *data,
     }
   }
 
-  /* Update stats, write and report progress */
-  data->req.bytecount += nwrite;
-  ++data->req.bodywrites;
   if(!data->req.ignorebody && (nwrite || (type & CLIENTWRITE_EOS))) {
     result = Curl_cwriter_write(data, writer->next, type, buf, nwrite);
     if(result)
       return result;
   }
+  /* Update stats, write and report progress */
+  data->req.bytecount += nwrite;
+  ++data->req.bodywrites;
   result = Curl_pgrsSetDownloadCounter(data, data->req.bytecount);
   if(result)
     return result;

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -141,6 +141,13 @@ size_t Curl_cwriter_count(struct Curl_easy *data, Curl_cwriter_phase phase);
 CURLcode Curl_cwriter_add(struct Curl_easy *data,
                           struct Curl_cwriter *writer);
 
+/**
+ * Look up an installed client writer on `data` by its type.
+ * @return first writer with that type or NULL
+ */
+struct Curl_cwriter *Curl_cwriter_get_by_type(struct Curl_easy *data,
+                                              const struct Curl_cwtype *cwt);
+
 void Curl_cwriter_remove_by_name(struct Curl_easy *data,
                                  const char *name);
 

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -59,13 +59,6 @@ CURLcode Curl_client_write(struct Curl_easy *data, int type, const char *ptr,
                            size_t len) WARN_UNUSED_RESULT;
 
 /**
- * For a paused transfer, there might be buffered data held back.
- * Attempt to flush this data to the client. This *may* trigger
- * another pause of the transfer.
- */
-CURLcode Curl_client_unpause(struct Curl_easy *data);
-
-/**
  * Free all resources related to client writing.
  */
 void Curl_client_cleanup(struct Curl_easy *data);

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -63,6 +63,7 @@
 #include "content_encoding.h"
 #include "hostip.h"
 #include "cfilters.h"
+#include "cw-out.h"
 #include "transfer.h"
 #include "sendf.h"
 #include "speedcheck.h"
@@ -1719,4 +1720,10 @@ CURLcode Curl_xfer_write_resp(struct Curl_easy *data,
     data->req.download_done = TRUE;
   }
   return result;
+}
+
+CURLcode Curl_xfer_write_done(struct Curl_easy *data, bool premature)
+{
+  (void)premature;
+  return Curl_cw_out_done(data);
 }

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -85,4 +85,10 @@ Curl_setup_transfer (struct Curl_easy *data,
                                            disables */
   );
 
+/**
+ * Multi has set transfer to DONE. Last chance to trigger
+ * missing response things like writing an EOS to the client.
+ */
+CURLcode Curl_xfer_write_done(struct Curl_easy *data, bool premature);
+
 #endif /* HEADER_CURL_TRANSFER_H */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1273,18 +1273,6 @@ struct Curl_data_priority {
 #endif
 };
 
-/*
- * This struct is for holding data that was attempted to get sent to the user's
- * callback but is held due to pausing. One instance per type (BOTH, HEADER,
- * BODY).
- */
-struct tempbuf {
-  struct dynbuf b;
-  int type;   /* type of the 'tempwrite' buffer as a bitmask that is used with
-                 Curl_client_write() */
-  BIT(paused_body); /* if PAUSE happened before/during BODY write */
-};
-
 /* Timers */
 typedef enum {
   EXPIRE_100_TIMEOUT,
@@ -1362,8 +1350,6 @@ struct UrlState {
   int retrycount; /* number of retries on a new connection */
   struct Curl_ssl_session *session; /* array of 'max_ssl_sessions' size */
   long sessionage;                  /* number of the most recent session */
-  struct tempbuf tempwrite[3]; /* BOTH, HEADER, BODY */
-  unsigned int tempcount; /* number of entries in use in tempwrite, 0 - 3 */
   int os_errno;  /* filled in with errno whenever an error occurs */
   char *scratch; /* huge buffer[set.buffer_size*2] for upload CRLF replacing */
   long followlocation; /* redirect counter */


### PR DESCRIPTION
Refactoring of the client writer that passes the data to the client/application's callback functions.

- split out into own source `cw-out.[ch]` from `sendf.c`
- move `tempwrite` and `tempcount` from `data->state` into the context of the client writer
- redesign the 3 `tempwrite` dynbufs as a linked list of dynbufs. On paused transfers, this allows to "record" interleaved HEADER/BODY chunks to be "played back" in the same order on unpausing.
- keep the overall size limit of all buffered data to `DYN_PAUSE_BUFFER`. On exceeding that, return `CURLE_TOO_LARGE` instead of `CURLE_OUT_OF_MEMORY` as before.
- add method to be called when a transfer is `DONE` to allow writing of any data still buffered
- when paused, record HEADER writes exactly as they come for later playback. HEADERs are documented to be written one-by-one.

### body write buffering

The implementation is capable of buffering body output and aggregate date into larger writes. This is disabled since applications expect to see data at the time it arrives. Should the need from apps to
have curl aggregate date first, we'd need to add a `CURLOPT_` for this.