### PR TITLE
transfer: improve Windows SO_SNDBUF update limit

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -777,9 +777,9 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
 #if defined(_WIN32) && defined(USE_WINSOCK)
     {
       struct curltime n = Curl_now();
-      if(Curl_timediff(n, k->last_sndbuf_update) > 1000) {
+      if(Curl_timediff(n, conn->last_sndbuf_update) > 1000) {
         win_update_buffer_size(conn->writesockfd);
-        k->last_sndbuf_update = n;
+        conn->last_sndbuf_update = n;
       }
     }
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -722,10 +722,6 @@ struct SingleRequest {
 #ifndef CURL_DISABLE_DOH
   struct dohdata *doh; /* DoH specific data for this request */
 #endif
-#if defined(_WIN32) && defined(USE_WINSOCK)
-  struct curltime last_sndbuf_update;  /* last time readwrite_upload called
-                                          win_update_buffer_size */
-#endif
   char fread_eof[2]; /* the body read callback (index 0) returned EOF or
                         the trailer read callback (index 1) returned EOF */
 #ifndef CURL_DISABLE_COOKIES
@@ -996,6 +992,11 @@ struct connectdata {
   /*************** Request - specific items ************/
 #if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
   CtxtHandle *sslContext;
+#endif
+
+#if defined(_WIN32) && defined(USE_WINSOCK)
+  struct curltime last_sndbuf_update;  /* last time readwrite_upload called
+                                          win_update_buffer_size */
 #endif
 
 #ifdef USE_GSASL


### PR DESCRIPTION
- Change the 1 second SO_SNDBUF update limit from per transfer to per connection.

Prior to this change many transfers over the same connection could cause many SO_SNDBUF updates made to that connection per second, which was unnecessary.

Closes #xxxxx