### PR TITLE
.gitattributes: set .checksrc as LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,6 +9,7 @@ configure.ac eol=lf
 *.in eol=lf
 *.am eol=lf
 *.sh eol=lf
+.checksrc eol=lf
 *.[ch] whitespace=tab-in-indent
 
 # Batch files (bat,btm,cmd) must be run with CRLF line endings.

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -120,6 +120,7 @@ sub readlocalfile {
     open(my $rcfile, "<", "$dir/.checksrc") or return;
 
     while(<$rcfile>) {
+        $windows_os ? $_ =~ s/\r?\n$// : chomp;
         $i++;
 
         # Lines starting with '#' are considered comments


### PR DESCRIPTION
This PR fixes debug builds on Windows.

CRLF line ending in `.checksrc` files is not handled by `scripts/checksrc.pl`