### PR TITLE
GHA: adjust parallel job counts

### DIFF
--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -41,7 +41,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 4
 
   # renovate: datasource=github-tags depName=awslabs/aws-lc versioning=semver registryUrl=https://github.com
   awslc-version: 1.28.0

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,7 +40,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 4
   # unhandled
   bearssl-version: 0.6
   # renovate: datasource=github-tags depName=libressl-portable/portable versioning=semver registryUrl=https://github.com

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -44,7 +44,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 4
 
 jobs:
   linux-i686:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,7 +41,7 @@ permissions: {}
 
 env:
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
-  MAKEFLAGS: -j 5
+  MAKEFLAGS: -j 3
 
 jobs:
   autotools:

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -45,7 +45,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 4
   # unhandled
   quictls-version: 3.1.4+quic
   # renovate: datasource=github-tags depName=gnutls/gnutls versioning=semver registryUrl=https://github.com

--- a/.github/workflows/osslq-linux.yml
+++ b/.github/workflows/osslq-linux.yml
@@ -45,7 +45,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 4
   # handled in renovate.json
   openssl3-version: openssl-3.3.0
   # unhandled

--- a/.github/workflows/quiche-linux.yml
+++ b/.github/workflows/quiche-linux.yml
@@ -45,7 +45,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 4
   # unhandled
   openssl-version: 3.1.4+quic
   # renovate: datasource=github-tags depName=ngtcp2/nghttp3 versioning=semver registryUrl=https://github.com

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -45,7 +45,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 4
 
 jobs:
   autotools:

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -45,7 +45,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 4
 
 jobs:
   autotools:


### PR DESCRIPTION
Adjusts the `make -j` flag to match the latest GitHub-hosted runner
hardware specs[^1]:

 - `ubuntu-latest` on 4 CPU cores
 - `macos-latest` on 3 CPU cores

The processor count is ideally obtained from `nproc`, but setting env
vars from the current CI yaml files is not possible because they expect
literal strings.

[^1]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Closes #12927
