### PR TITLE
websocket, fix curl_ws_recv()

### DIFF
--- a/lib/ws.c
+++ b/lib/ws.c
@@ -886,7 +886,7 @@ static ssize_t ws_client_collect(const unsigned char *buf, size_t buflen,
       return -1;
     }
     *err = CURLE_OK;
-    memcpy(ctx->buffer, buf, nwritten);
+    memcpy(ctx->buffer + ctx->bufidx, buf, nwritten);
     ctx->bufidx += nwritten;
   }
   return nwritten;


### PR DESCRIPTION
- when data arrived in several chunks, the collection into the passed buffer always started at offset 0, overwriting the data already there.