### PR TITLE
Remove curl_mimepart object from UserDefined structure when CURL_DISABLE_MIME flag is active

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2344,9 +2344,11 @@ CURLcode Curl_http_body(struct Curl_easy *data, struct connectdata *conn,
   http->postsize = 0;
 
   switch(httpreq) {
+#ifndef CURL_DISABLE_MIME
   case HTTPREQ_POST_MIME:
     data->state.mimepost = &data->set.mimepost;
     break;
+#endif
 #ifndef CURL_DISABLE_FORM_API
   case HTTPREQ_POST_FORM:
     /* Convert the form structure into a mime structure, then keep
@@ -2514,6 +2516,7 @@ CURLcode Curl_http_bodysend(struct Curl_easy *data, struct connectdata *conn,
       return result;
     break;
 
+#if !defined(CURL_DISABLE_MIME) || !defined(CURL_DISABLE_FORM_API)
   case HTTPREQ_POST_FORM:
   case HTTPREQ_POST_MIME:
     /* This is form posting using mime data. */
@@ -2594,7 +2597,7 @@ CURLcode Curl_http_bodysend(struct Curl_easy *data, struct connectdata *conn,
       return result;
 
     break;
-
+#endif
   case HTTPREQ_POST:
     /* this is the simple POST, using x-www-form-urlencoded style */
 

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -770,6 +770,7 @@ static CURLcode imap_perform_append(struct Curl_easy *data)
     return CURLE_URL_MALFORMAT;
   }
 
+#ifndef CURL_DISABLE_MIME
   /* Prepare the mime data if some. */
   if(data->set.mimepost.kind != MIMEKIND_NONE) {
     /* Use the whole structure as data. */
@@ -798,6 +799,7 @@ static CURLcode imap_perform_append(struct Curl_easy *data)
     data->state.fread_func = (curl_read_callback) Curl_mime_read;
     data->state.in = (void *) &data->set.mimepost;
   }
+#endif
 
   /* Check we know the size of the upload */
   if(data->state.infilesize < 0) {
@@ -1513,10 +1515,10 @@ static CURLcode imap_done(struct Curl_easy *data, CURLcode status,
   }
   else if(!data->set.connect_only && !imap->custom &&
           (imap->uid || imap->mindex || data->state.upload ||
-          data->set.mimepost.kind != MIMEKIND_NONE)) {
+          IS_MIME_POST(data))) {
     /* Handle responses after FETCH or APPEND transfer has finished */
 
-    if(!data->state.upload && data->set.mimepost.kind == MIMEKIND_NONE)
+    if(!data->state.upload && !IS_MIME_POST(data))
       imap_state(data, IMAP_FETCH_FINAL);
     else {
       /* End the APPEND command first by sending an empty line */
@@ -1582,7 +1584,7 @@ static CURLcode imap_perform(struct Curl_easy *data, bool *connected,
     selected = TRUE;
 
   /* Start the first command in the DO phase */
-  if(data->state.upload || data->set.mimepost.kind != MIMEKIND_NONE)
+  if(data->state.upload || IS_MIME_POST(data))
     /* APPEND can be executed directly */
     result = imap_perform_append(data);
   else if(imap->custom && (selected || !imap->mailbox))

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1812,7 +1812,9 @@ static CURLcode protocol_connect(struct Curl_easy *data,
  */
 static CURLcode readrewind(struct Curl_easy *data)
 {
+#if !defined(CURL_DISABLE_MIME) || !defined(CURL_DISABLE_FORM_API)
   curl_mimepart *mimepart = &data->set.mimepost;
+#endif
   DEBUGASSERT(data->conn);
 
   data->state.rewindbeforesend = FALSE; /* we rewind now */
@@ -1826,7 +1828,7 @@ static CURLcode readrewind(struct Curl_easy *data)
   /* We have sent away data. If not using CURLOPT_POSTFIELDS or
      CURLOPT_HTTPPOST, call app to rewind
   */
-#ifndef CURL_DISABLE_HTTP
+#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_MIME)
   if(data->conn->handler->protocol & PROTO_FAMILY_HTTP) {
     if(data->state.mimepost)
       mimepart = data->state.mimepost;
@@ -1836,6 +1838,7 @@ static CURLcode readrewind(struct Curl_easy *data)
      (data->state.httpreq == HTTPREQ_GET) ||
      (data->state.httpreq == HTTPREQ_HEAD))
     ; /* no need to rewind */
+#if !defined(CURL_DISABLE_MIME) || !defined(CURL_DISABLE_FORM_API)
   else if(data->state.httpreq == HTTPREQ_POST_MIME ||
           data->state.httpreq == HTTPREQ_POST_FORM) {
     CURLcode result = Curl_mime_rewind(mimepart);
@@ -1844,6 +1847,7 @@ static CURLcode readrewind(struct Curl_easy *data)
       return result;
     }
   }
+#endif
   else {
     if(data->set.seek_func) {
       int err;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -690,6 +690,7 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data)
     }
   }
 
+#ifndef CURL_DISABLE_MIME
   /* Prepare the mime data if some. */
   if(data->set.mimepost.kind != MIMEKIND_NONE) {
     /* Use the whole structure as data. */
@@ -722,6 +723,7 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data)
     data->state.fread_func = (curl_read_callback) Curl_mime_read;
     data->state.in = (void *) &data->set.mimepost;
   }
+#endif
 
   /* Calculate the optional SIZE parameter */
   if(conn->proto.smtpc.size_supported && data->state.infilesize > 0) {
@@ -1410,7 +1412,7 @@ static CURLcode smtp_done(struct Curl_easy *data, CURLcode status,
     result = status;         /* use the already set error code */
   }
   else if(!data->set.connect_only && data->set.mail_rcpt &&
-          (data->state.upload || data->set.mimepost.kind)) {
+          (data->state.upload || IS_MIME_POST(data))) {
     /* Calculate the EOB taking into account any terminating CRLF from the
        previous line of the email or the CRLF of the DATA command when there
        is "no mail data". RFC-5321, sect. 4.1.1.4.
@@ -1502,7 +1504,7 @@ static CURLcode smtp_perform(struct Curl_easy *data, bool *connected,
   smtp->eob = 2;
 
   /* Start the first command in the DO phase */
-  if((data->state.upload || data->set.mimepost.kind) && data->set.mail_rcpt)
+  if((data->state.upload || IS_MIME_POST(data)) && data->set.mail_rcpt)
     /* MAIL transfer */
     result = smtp_perform_mail(data);
   else

--- a/lib/url.c
+++ b/lib/url.c
@@ -334,7 +334,7 @@ CURLcode Curl_close(struct Curl_easy **datap)
   }
 #endif
 
-#ifndef CURL_DISABLE_HTTP
+#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_FORM_API)
   Curl_mime_cleanpart(data->state.formp);
   Curl_safefree(data->state.formp);
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1426,8 +1426,10 @@ struct UrlState {
                                  this should be dealt with in pretransfer */
 #ifndef CURL_DISABLE_HTTP
   curl_mimepart *mimepost;
+#ifndef CURL_DISABLE_FORM_API
   curl_mimepart *formp; /* storage for old API form-posting, allocated on
                            demand */
+#endif
   size_t trailers_bytes_sent;
   struct dynbuf trailers_buf; /* a buffer containing the compiled trailing
                                  headers */
@@ -1724,7 +1726,9 @@ struct UserDefined {
   curl_off_t set_resume_from;  /* continue [ftp] transfer from here */
   struct curl_slist *headers; /* linked list of extra headers */
   struct curl_httppost *httppost;  /* linked list of old POST data */
+#if !defined(CURL_DISABLE_MIME) || !defined(CURL_DISABLE_FORM_API)
   curl_mimepart mimepost;  /* MIME/POST data. */
+#endif
 #ifndef CURL_DISABLE_TELNET
   struct curl_slist *telnet_options; /* linked list of telnet options */
 #endif
@@ -1936,6 +1940,12 @@ struct UserDefined {
   BIT(ws_raw_mode);
 #endif
 };
+
+#ifndef CURL_DISABLE_MIME
+#define IS_MIME_POST(a) ((a)->set.mimepost.kind != MIMEKIND_NONE)
+#else
+#define IS_MIME_POST(a) FALSE
+#endif
 
 struct Names {
   struct Curl_hash *hostcache;


### PR DESCRIPTION
Reduce size of UserDefined structure. For the x86 architecture, the structure size decreased by 368 bytes, for x64 440 bytes. It is therefore a significant reduction in the size of the structure.

Also remove unreachable code: when CURL_DISABLE_MIME is set, httpreq can never have HTTPREQ_POST_MIME value and the same goes for the CURL_DISABLE_FORM_API flag and the HTTPREQ_POST_FORM value.

As for the name of the function I created in smtp.c and imap.c I am open to suggestions.