### PR TITLE
move authneg bit

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -710,7 +710,7 @@ static int uploadstreamed(void *userdata, hyper_context *ctx,
     return HYPER_POLL_PENDING;
   }
 
-  if(data->req.upload_chunky && conn->bits.authneg) {
+  if(data->req.upload_chunky && data->req.authneg) {
     fillcount = 0;
     data->req.upload_chunky = FALSE;
     result = CURLE_OK;
@@ -1166,7 +1166,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
 
   Curl_debug(data, CURLINFO_HEADER_OUT, (char *)"\r\n", 2);
 
-  if(data->req.upload_chunky && conn->bits.authneg) {
+  if(data->req.upload_chunky && data->req.authneg) {
     data->req.upload_chunky = TRUE;
   }
   else {

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -695,7 +695,6 @@ static int uploadstreamed(void *userdata, hyper_context *ctx,
 {
   size_t fillcount;
   struct Curl_easy *data = (struct Curl_easy *)userdata;
-  struct connectdata *conn = (struct connectdata *)data->conn;
   CURLcode result;
   (void)ctx;
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -519,10 +519,6 @@ struct ConnectBits {
                          the TCP layer connect */
   BIT(retry);         /* this connection is about to get closed and then
                          re-attempted at another connection. */
-  BIT(authneg);       /* TRUE when the auth phase has started, which means
-                         that we are creating a request with an auth header,
-                         but it is not the final request in the auth
-                         negotiation. */
 #ifndef CURL_DISABLE_FTP
   BIT(ftp_use_epsv);  /* As set with CURLOPT_FTP_USE_EPSV, but if we find out
                          EPSV doesn't work we disable it for the forthcoming
@@ -745,6 +741,10 @@ struct SingleRequest {
                         specific upload buffers. See readmoredata() in http.c
                         for details. */
   BIT(no_body);      /* the response has no body */
+  BIT(authneg);      /* TRUE when the auth phase has started, which means
+                        that we are creating a request with an auth header,
+                        but it is not the final request in the auth
+                        negotiation. */
 };
 
 /*


### PR DESCRIPTION
- from `conn->bits.authneg` to `data->req.authneg`
- AFAICT, this is a property of the request about to be made and not a property of the connection
- in multiuse connections, transfer could step on each others toes here potentially.