### PR TITLE
mprintf: fix format prefix I32/I64 for all windows compilers

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -49,16 +49,6 @@
 #endif
 
 /*
- * Non-ANSI integer extensions
- */
-
-#if (defined(_WIN32_WCE)) || \
-    (defined(__MINGW32__)) || \
-    (defined(_MSC_VER) && (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64))
-#  define MP_HAVE_INT_EXTENSIONS
-#endif
-
-/*
  * Max integer data types that mprintf.c is capable
  */
 
@@ -349,8 +339,9 @@ static int parsefmt(const char *format,
         case 'h':
           flags |= FLAGS_SHORT;
           break;
-#if defined(MP_HAVE_INT_EXTENSIONS)
+#if defined(_WIN32) || defined(_WIN32_WCE)
         case 'I':
+          /* Non-ANSI integer extensions I32 I64 */
           if((fmt[0] == '3') && (fmt[1] == '2')) {
             flags |= FLAGS_LONG;
             fmt += 2;
@@ -367,7 +358,7 @@ static int parsefmt(const char *format,
 #endif
           }
           break;
-#endif
+#endif /* _WIN32 || _WIN32_WCE */
         case 'l':
           if(flags & FLAGS_LONG)
             flags |= FLAGS_LONGLONG;


### PR DESCRIPTION
- Support I32 & I64 (eg: %I64d) for all Win32 builds.

Prior to this change mprintf support for the I format prefix, which is a Microsoft extension, was dependent on the compiler used.

When Borland support was removed in fd7ef00f the prefix was then no longer supported for that compiler; however since it's still possible to build with Borland I'm restoring support for the prefix in this way.

Reported-by: Paweł Witas

Fixes https://github.com/curl/curl/issues/12944
Closes #xxxx