### PR TITLE
spellcheck.yml: remove .1/.3 handling, clean all man page .md files

### DIFF
--- a/.github/scripts/cleancmd.pl
+++ b/.github/scripts/cleancmd.pl
@@ -47,6 +47,8 @@ while(<F>) {
 }
 close(F);
 
-open(O, ">$f") or die;
-print O @out;
-close(O);
+if(!$ignore) {
+    open(O, ">$f") or die;
+    print O @out;
+    close(O);
+}

--- a/.github/scripts/cleanspell.pl
+++ b/.github/scripts/cleanspell.pl
@@ -3,38 +3,31 @@
 #
 # SPDX-License-Identifier: curl
 #
-# Input: a libcurl nroff man page
-# Output: the same file, minus the SYNOPSIS and the EXAMPLE sections
+# Given: a libcurl curldown man page
+# Outputs: the same file, minus the SYNOPSIS and the EXAMPLE sections
 #
 
 my $f = $ARGV[0];
-my $o = $ARGV[1];
 
 open(F, "<$f") or die;
-open(O, ">$o") or die;
 
+my @out;
 my $ignore = 0;
 while(<F>) {
-    if($_ =~ /^.SH (SYNOPSIS|EXAMPLE|\"SEE ALSO\"|SEE ALSO)/) {
+    if($_ =~ /^# (SYNOPSIS|EXAMPLE)/) {
         $ignore = 1;
     }
-    elsif($ignore && ($_ =~ /^.SH/)) {
+    elsif($ignore && ($_ =~ /^# [A-Z]/)) {
         $ignore = 0;
     }
     elsif(!$ignore) {
-        # filter out mentioned CURLE_ names
+        # **bold**
+        $_ =~ s/\*\*(\S.*?)\*\*//g;
+        # *italics*
+        $_ =~ s/\*(\S.*?)\*//g;
+
         $_ =~ s/CURL(M|SH|U|H)code//g;
-        $_ =~ s/CURL_(READ|WRITE)FUNC_[A-Z0-9_]*//g;
-        $_ =~ s/CURL_CSELECT_[A-Z0-9_]*//g;
-        $_ =~ s/CURL_DISABLE_[A-Z0-9_]*//g;
-        $_ =~ s/CURL_FORMADD_[A-Z0-9_]*//g;
-        $_ =~ s/CURL_HET_DEFAULT//g;
-        $_ =~ s/CURL_IPRESOLVE_[A-Z0-9_]*//g;
-        $_ =~ s/CURL_PROGRESSFUNC_CONTINUE//g;
-        $_ =~ s/CURL_REDIR_[A-Z0-9_]*//g;
-        $_ =~ s/CURL_RTSPREQ_[A-Z0-9_]*//g;
-        $_ =~ s/CURL_TIMECOND_[A-Z0-9_]*//g;
-        $_ =~ s/CURL_VERSION_[A-Z0-9_]*//g;
+        $_ =~ s/CURL_[A-Z0-9_]*//g;
         $_ =~ s/CURLALTSVC_[A-Z0-9_]*//g;
         $_ =~ s/CURLAUTH_[A-Z0-9_]*//g;
         $_ =~ s/CURLE_[A-Z0-9_]*//g;
@@ -56,25 +49,38 @@ while(<F>) {
         $_ =~ s/CURLPX_[A-Z0-9_]*//g;
         $_ =~ s/CURLSHE_[A-Z0-9_]*//g;
         $_ =~ s/CURLSHOPT_[A-Z0-9_]*//g;
+        $_ =~ s/CURLSSLOPT_[A-Z0-9_]*//g;
         $_ =~ s/CURLSSH_[A-Z0-9_]*//g;
         $_ =~ s/CURLSSLBACKEND_[A-Z0-9_]*//g;
         $_ =~ s/CURLU_[A-Z0-9_]*//g;
+        $_ =~ s/CURLUPART_[A-Z0-9_]*//g;
+        #$_ =~ s/\bCURLU\b//g; # stand-alone CURLU
         $_ =~ s/CURLUE_[A-Z0-9_]*//g;
+        $_ =~ s/CURLHE_[A-Z0-9_]*//g;
+        $_ =~ s/CURLWS_[A-Z0-9_]*//g;
+        $_ =~ s/CURLKH[A-Z0-9_]*//g;
         $_ =~ s/CURLUPART_[A-Z0-9_]*//g;
         $_ =~ s/CURLUSESSL_[A-Z0-9_]*//g;
-        $_ =~ s/curl_global_(init_mem|sslset|cleanup)//g;
+        $_ =~ s/CURLPAUSE_[A-Z0-9_]*//g;
+        $_ =~ s/CURLHSTS_[A-Z0-9_]*//g;
+        $_ =~ s/curl_global_([a-z_]*)//g;
         $_ =~ s/curl_(strequal|strnequal|formadd|waitfd|formget|getdate|formfree)//g;
-        $_ =~ s/curl_easy_(nextheader|duphandle)//g;
-        $_ =~ s/curl_multi_fdset//g;
+        $_ =~ s/curl_easy_([a-z]*)//g;
+        $_ =~ s/curl_multi_([a-z_]*)//g;
         $_ =~ s/curl_mime_(subparts|addpart|filedata|data_cb)//g;
         $_ =~ s/curl_ws_(send|recv|meta)//g;
         $_ =~ s/curl_url_(dup)//g;
         $_ =~ s/curl_pushheader_by(name|num)//g;
         $_ =~ s/libcurl-(env|ws)//g;
         $_ =~ s/libcurl\\-(env|ws)//g;
-        $_ =~ s/(^|\W)((tftp|https|http|ftp):\/\/[a-z0-9\-._~%:\/?\#\[\]\@!\$&'()*+,;=]+)//gi;
-        print O $_;
+        $_ =~ s/(^|\W)((tftp|https|http|ftp):\/\/[a-z0-9\-._~%:\/?\#\[\]\@!\$&'()*+,;=\\]+)//gi;
+        push @out, $_;
     }
 }
 close(F);
+
+open(O, ">$f") or die;
+for my $l (@out) {
+    print O $l;
+}
 close(O);

--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -39,6 +39,7 @@ auth
 autobuild
 autobuilds
 Autoconf
+autoconf
 Automake
 Autotools
 autotools
@@ -111,8 +112,8 @@ clientp
 cliget
 closesocket
 CMake
-CMake's
 cmake
+CMake's
 cmake's
 CMakeLists
 CodeQL
@@ -283,6 +284,7 @@ GPL
 GPLed
 Greear
 groff
+gsasl
 GSKit
 gskit
 GSS
@@ -795,6 +797,7 @@ Tekniska
 testability
 TFTP
 tftp
+threadsafe
 Tizen
 TLS
 tlsv

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -29,9 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: install pandoc
-        run: sudo apt-get install pandoc
-
       - name: trim all man page *.md files
         run: find docs -name "*.md" ! -name "_*" | xargs -n1 ./.github/scripts/cleancmd.pl
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,7 +11,7 @@ on:
       - '**.md'
       - '**/spellcheck.yml'
       - '**/spellcheck.yaml'
-      - '**/wordlist.txt'
+      - '.github/scripts/*'
   pull_request:
     branches:
       - master
@@ -19,7 +19,7 @@ on:
       - '**.md'
       - '**/spellcheck.yml'
       - '**/spellcheck.yaml'
-      - '**/wordlist.txt'
+      - '.github/scripts/*'
 
 permissions: {}
 

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -9,8 +9,6 @@ on:
       - master
     paths:
       - '**.md'
-      - '**.3'
-      - '**.1'
       - '**/spellcheck.yml'
       - '**/spellcheck.yaml'
       - '**/wordlist.txt'
@@ -19,8 +17,6 @@ on:
       - master
     paths:
       - '**.md'
-      - '**.3'
-      - '**.1'
       - '**/spellcheck.yml'
       - '**/spellcheck.yaml'
       - '**/wordlist.txt'
@@ -36,31 +32,16 @@ jobs:
       - name: install pandoc
         run: sudo apt-get install pandoc
 
-      - name: build curl.1
-        run: |
-           autoreconf -fi
-           ./configure --without-ssl --without-libpsl
-           make -C docs
+      - name: trim all man page *.md files
+        run: find docs -name "*.md" ! -name "_*" | xargs -n1 ./.github/scripts/cleancmd.pl
 
-      - name: strip "uncheckable" sections from .3 pages
-        run: find docs -name "*.3" -size +40c | sed 's/\.3//' | xargs -t -n1 -I OO  ./.github/scripts/cleanspell.pl OO.3 OO.33
+      - name: trim libcurl man page *.md files
+        run: find docs/libcurl -name "curl_*.md" -o -name "libcurl*.md" | xargs -n1 ./.github/scripts/cleanspell.pl
 
-      - name: convert .3 man pages to markdown
-        run: find docs -name "*.33" -size +40c | sed 's/\.33//' | xargs -t -n1 -I OO pandoc -f man -t markdown OO.33 -o OO.md
+      - name: trim libcurl option man page *.md files
+        run: find docs/libcurl/opts -name "CURL*.md" | xargs -n1 ./.github/scripts/cleanspell.pl
 
-      - name: convert .1 man pages to markdown
-        run: find docs -name "*.1" -size +40c | sed 's/\.1//' | xargs -t -n1 -I OO pandoc OO.1 -o OO.md
-
-      - name: trim the curl.1 markdown file
-        run: |
-          perl -pi -e 's/^    .*//' docs/curl.md
-          perl -pi -e 's/\-\-[\a-z0-9-]*//ig' docs/curl.md
-          perl -pi -e 's!https://[a-z0-9%/.-]*!!ig' docs/curl.md
-
-      - name: trim the cmdline docs markdown files
-        run: find docs/cmdline-opts -name "*.md" ! -name "_*" ! -name MANPAGE.md | xargs -n1 ./.github/scripts/cleancmd.pl
-
-      - name: trim the cmdline docs markdown _*.md files
+      - name: trim cmdline docs markdown _*.md files
         run: find docs/cmdline-opts -name "_*.md" | xargs -n1 ./.github/scripts/cleancmd.pl --no-header
 
       - name: setup the custom wordlist

--- a/docs/libcurl/curl_easy_getinfo.md
+++ b/docs/libcurl/curl_easy_getinfo.md
@@ -388,59 +388,57 @@ See CURLINFO_XFER_ID(3)
 
 An overview of the time values available from curl_easy_getinfo(3)
 
-~~~
-curl_easy_perform()
-    |
-    |--QUEUE_TIME
-    |--|--NAMELOOKUP
-    |--|--|--CONNECT
-    |--|--|--|--APPCONNECT
-    |--|--|--|--|--PRETRANSFER
-    |--|--|--|--|--|--STARTTRANSFER
-    |--|--|--|--|--|--|--TOTAL
-    |--|--|--|--|--|--|--REDIRECT
-~~~
+    curl_easy_perform()
+        |
+        |--QUEUE
+        |--|--NAMELOOKUP
+        |--|--|--CONNECT
+        |--|--|--|--APPCONNECT
+        |--|--|--|--|--PRETRANSFER
+        |--|--|--|--|--|--STARTTRANSFER
+        |--|--|--|--|--|--|--TOTAL
+        |--|--|--|--|--|--|--REDIRECT
 
-## QUEUE_TIME
+## CURLINFO_QUEUE_TIME
 
 CURLINFO_QUEUE_TIME_T(3). The time during which the transfer was held in a
 waiting queue before it could start for real. (Added in 8.6.0)
 
-## NAMELOOKUP
+## CURLINFO_NAMELOOKUP_TIME
 
 CURLINFO_NAMELOOKUP_TIME(3) and CURLINFO_NAMELOOKUP_TIME_T(3). The time it
 took from the start until the name resolving was completed.
 
-## CONNECT
+## CURLINFO_CONNECT_TIME
 
 CURLINFO_CONNECT_TIME(3) and CURLINFO_CONNECT_TIME_T(3). The time it took from
 the start until the connect to the remote host (or proxy) was completed.
 
-## APPCONNECT
+## CURLINFO_APPCONNECT_TIME
 
 CURLINFO_APPCONNECT_TIME(3) and CURLINFO_APPCONNECT_TIME_T(3). The time it
 took from the start until the SSL connect/handshake with the remote host was
 completed. (Added in 7.19.0) The latter is the integer version (measuring
 microseconds). (Added in 7.60.0)
 
-## PRETRANSFER
+## CURLINFO_PRETRANSFER_TIME
 
 CURLINFO_PRETRANSFER_TIME(3) and CURLINFO_PRETRANSFER_TIME_T(3). The time it
 took from the start until the file transfer is just about to begin. This
 includes all pre-transfer commands and negotiations that are specific to the
 particular protocol(s) involved.
 
-## STARTTRANSFER
+## CURLINFO_STARTTRANSFER_TIME
 
 CURLINFO_STARTTRANSFER_TIME(3) and CURLINFO_STARTTRANSFER_TIME_T(3). The time
 it took from the start until the first byte is received by libcurl.
 
-## TOTAL
+## CURLINFO_TOTAL_TIME
 
 CURLINFO_TOTAL_TIME(3) and CURLINFO_TOTAL_TIME_T(3). Total time
 of the previous request.
 
-## REDIRECT
+## CURLINFO_REDIRECT_TIME
 
 CURLINFO_REDIRECT_TIME(3) and CURLINFO_REDIRECT_TIME_T(3). The time it took
 for all redirection steps include name lookup, connect, pretransfer and

--- a/docs/libcurl/curl_global_init_mem.md
+++ b/docs/libcurl/curl_global_init_mem.md
@@ -40,23 +40,23 @@ default) so we strongly urge you to make your callback functions thread safe.
 All callback arguments must be set to valid function pointers. The
 prototypes for the given callbacks must match these:
 
-## void *malloc_callback(size_t size);
+## `void *malloc_callback(size_t size);`
 
 To replace malloc()
 
-## void free_callback(void *ptr);
+## `void free_callback(void *ptr);`
 
 To replace free()
 
-## void *realloc_callback(void *ptr, size_t size);
+## `void *realloc_callback(void *ptr, size_t size);`
 
 To replace realloc()
 
-## char *strdup_callback(const char *str);
+## `char *strdup_callback(const char *str);`
 
 To replace strdup()
 
-## void *calloc_callback(size_t nmemb, size_t size);
+## `void *calloc_callback(size_t nmemb, size_t size);`
 
 To replace calloc()
 

--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -65,23 +65,23 @@ on how to control that.
 
 # TRACE COMPONENTS
 
-## tcp
+## `tcp`
 
 Tracing of TCP socket handling: connect, reads, writes.
 
-## ssl
+## `ssl`
 
 Tracing of SSL/TLS operations, whichever SSL backend is used in your build.
 
-## http/2
+## `http/2`
 
 Details about HTTP/2 handling: frames, events, I/O, etc.
 
-## http/3
+## `http/3`
 
 Details about HTTP/3 handling: connect, frames, events, I/O etc.
 
-## http-proxy
+## `http-proxy`
 
 Involved when transfers are tunneled through an HTTP proxy. "h1-proxy" or
 "h2-proxy" are also involved, depending on the HTTP version negotiated with

--- a/docs/libcurl/curl_ws_meta.md
+++ b/docs/libcurl/curl_ws_meta.md
@@ -51,25 +51,24 @@ struct curl_ws_frame {
 };
 ~~~
 
-## age
+## `age`
 
 This field specify the age of this struct. It is always zero for now.
 
-## flags
+## `flags`
 
-This is a bitmask with individual bits set that describes the WebSocket
-data. See the list below.
+This is a bitmask with individual bits set that describes the WebSocket data.
+See the list below.
 
-## offset
+## `offset`
 
 When this frame is a continuation of fragment data already delivered, this is
 the offset into the final fragment where this piece belongs.
 
-## bytesleft
+## `bytesleft`
 
-If this is not a complete fragment, the *bytesleft* field informs about
-how many additional bytes are expected to arrive before this fragment is
-complete.
+If this is not a complete fragment, the *bytesleft* field informs about how
+many additional bytes are expected to arrive before this fragment is complete.
 
 # FLAGS
 

--- a/docs/libcurl/libcurl-env.md
+++ b/docs/libcurl/libcurl-env.md
@@ -19,7 +19,7 @@ controls and changes behaviors. This is the full list of variables to set and
 description of what they do. Also note that curl, the command line tool,
 supports a set of additional environment variables independently of this.
 
-## [scheme]_proxy
+## `[scheme]_proxy`
 
 When libcurl is given a URL to use in a transfer, it first extracts the scheme
 part from the URL and checks if there is a given proxy set for that in its
@@ -36,12 +36,12 @@ An exception exists for the WebSocket **ws** and **wss** URL schemes,
 where libcurl first checks **ws_proxy** or **wss_proxy** but if they are
 not set, it will fall back and try the http and https versions instead if set.
 
-## ALL_PROXY
+## `ALL_PROXY`
 
 This is a setting to set proxy for all URLs, independently of what scheme is
 being used. Note that the scheme specific variables overrides this one if set.
 
-## CURL_SSL_BACKEND
+## `CURL_SSL_BACKEND`
 
 When libcurl is built to support multiple SSL backends, it selects a specific
 backend at first use. If no selection is done by the program using libcurl,
@@ -51,34 +51,34 @@ alternative makes libcurl stay with the default.
 SSL backend names (case-insensitive): BearSSL, GnuTLS, mbedTLS,
 nss, OpenSSL, rustls, Schannel, Secure-Transport, wolfSSL
 
-## HOME
+## `HOME`
 
 When the netrc feature is used (CURLOPT_NETRC(3)), this variable is
 checked as the primary way to find the "current" home directory in which
 the .netrc file is likely to exist.
 
-## USERPROFILE
+## `USERPROFILE`
 
 When the netrc feature is used (CURLOPT_NETRC(3)), this variable is
 checked as the secondary way to find the "current" home directory (on Windows
 only) in which the .netrc file is likely to exist.
 
-## LOGNAME
+## `LOGNAME`
 
 Username to use when invoking the *ntlm-wb* tool, if *NTLMUSER* was
 not set.
 
-## NO_PROXY
+## `NO_PROXY`
 
 This has the same functionality as the CURLOPT_NOPROXY(3) option: it
 gives libcurl a comma-separated list of hostname patterns for which libcurl
 should not use a proxy.
 
-## NTLMUSER
+## `NTLMUSER`
 
 Username to use when invoking the *ntlm-wb* tool.
 
-## SSLKEYLOGFILE
+## `SSLKEYLOGFILE`
 
 When set and libcurl runs with a SSL backend that supports this feature,
 libcurl saves SSL secrets into the given filename. Using those SSL secrets,
@@ -88,7 +88,7 @@ analyze/view the traffic.
 These secrets and this file might be sensitive. Users are advised to take
 precautions so that they are not stolen or otherwise inadvertently revealed.
 
-## USER
+## `USER`
 
 Username to use when invoking the *ntlm-wb* tool, if *NTLMUSER* and *LOGNAME*
 were not set.

--- a/docs/libcurl/libcurl-tutorial.md
+++ b/docs/libcurl/libcurl-tutorial.md
@@ -1021,14 +1021,16 @@ manners. You may need to change words, headers or various data.
 
 libcurl is your friend here too.
 
-## CUSTOMREQUEST
+## CURLOPT_CUSTOMREQUEST
 
 If just changing the actual HTTP request keyword is what you want, like when
 GET, HEAD or POST is not good enough for you, CURLOPT_CUSTOMREQUEST(3)
 is there for you. It is simple to use:
+
 ~~~c
 curl_easy_setopt(handle, CURLOPT_CUSTOMREQUEST, "MYOWNREQUEST");
 ~~~
+
 When using the custom request, you change the request keyword of the actual
 request you are performing. Thus, by default you make a GET request but you
 can also make a POST operation (as described before) and then replace the POST
@@ -1141,20 +1143,20 @@ The option to enable headers or to run custom FTP commands may be useful to
 combine with CURLOPT_NOBODY(3). If this option is set, no actual file
 content transfer is performed.
 
-## FTP Custom CUSTOMREQUEST
+## FTP Custom CURLOPT_CUSTOMREQUEST
 
 If you do want to list the contents of an FTP directory using your own defined
-FTP command, CURLOPT_CUSTOMREQUEST(3) does just that. "NLST" is the
-default one for listing directories but you are free to pass in your idea of a
-good alternative.
+FTP command, CURLOPT_CUSTOMREQUEST(3) does just that. "NLST" is the default
+one for listing directories but you are free to pass in your idea of a good
+alternative.
 
 # Cookies Without Chocolate Chips
 
 In the HTTP sense, a cookie is a name with an associated value. A server sends
 the name and value to the client, and expects it to get sent back on every
-subsequent request to the server that matches the particular conditions
-set. The conditions include that the domain name and path match and that the
-cookie has not become too old.
+subsequent request to the server that matches the particular conditions set.
+The conditions include that the domain name and path match and that the cookie
+has not become too old.
 
 In real-world cases, servers send new cookies to replace existing ones to
 update them. Server use cookies to "track" users and to keep "sessions".
@@ -1164,12 +1166,14 @@ they are sent from clients to servers with the Cookie: header.
 
 To just send whatever cookie you want to a server, you can use
 CURLOPT_COOKIE(3) to set a cookie string like this:
+
 ~~~c
  curl_easy_setopt(handle, CURLOPT_COOKIE, "name1=var1; name2=var2;");
 ~~~
-In many cases, that is not enough. You might want to dynamically save
-whatever cookies the remote server passes to you, and make sure those cookies
-are then used accordingly on later requests.
+
+In many cases, that is not enough. You might want to dynamically save whatever
+cookies the remote server passes to you, and make sure those cookies are then
+used accordingly on later requests.
 
 One way to do this, is to save all headers you receive in a plain file and
 when you make a request, you tell libcurl to read the previous headers to

--- a/docs/libcurl/opts/CURLMOPT_SOCKETDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETDATA.md
@@ -28,7 +28,7 @@ A data *pointer* to pass to the socket callback set with the
 CURLMOPT_SOCKETFUNCTION(3) option.
 
 This pointer is not touched by libcurl but is only passed in as the socket
-callbacks's **clientp** argument.
+callback's **clientp** argument.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
@@ -27,7 +27,7 @@ A data **pointer** to pass to the timer callback set with the
 CURLMOPT_TIMERFUNCTION(3) option.
 
 This pointer is not touched by libcurl but is only be passed in to the timer
-callbacks's **clientp** argument.
+callback's **clientp** argument.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_COOKIELIST.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIELIST.md
@@ -29,37 +29,37 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_COOKIELIST,
 Pass a char pointer to a *cookie* string.
 
 Such a cookie can be either a single line in Netscape / Mozilla format or just
-regular HTTP-style header (Set-Cookie: ...) format. This option also enables
-the cookie engine. This adds that single cookie to the internal cookie store.
+regular HTTP-style header (`Set-Cookie:`) format. This option also enables the
+cookie engine. This adds that single cookie to the internal cookie store.
 
 We strongly advice against loading cookies from an HTTP header file, as that
 is an inferior data exchange format.
 
 Exercise caution if you are using this option and multiple transfers may
-occur. If you use the Set-Cookie format and the string does not specify a
+occur. If you use the `Set-Cookie` format and the string does not specify a
 domain, then the cookie is sent for any domain (even after redirects are
 followed) and cannot be modified by a server-set cookie. If a server sets a
 cookie of the same name (or maybe you have imported one) then both are sent on
 future transfers to that server, likely not what you intended. To address
-these issues set a domain in Set-Cookie (doing that includes subdomains) or
+these issues set a domain in `Set-Cookie` (doing that includes subdomains) or
 much better: use the Netscape file format.
 
 Additionally, there are commands available that perform actions if you pass in
 these exact strings:
 
-## ALL
+## `ALL`
 
 erases all cookies held in memory
 
-## SESS
+## `SESS`
 
 erases all session cookies held in memory
 
-## FLUSH
+## `FLUSH`
 
 writes all known cookies to the file specified by CURLOPT_COOKIEJAR(3)
 
-## RELOAD
+## `RELOAD`
 
 loads all cookies from the files specified by CURLOPT_COOKIEFILE(3)
 

--- a/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
@@ -52,30 +52,30 @@ The callback function must return *CURL_PREREQFUNC_OK* on success, or
 
 This function is passed the following arguments:
 
-## conn_primary_ip
+## `conn_primary_ip`
 
 A null-terminated pointer to a C string containing the primary IP of the
 remote server established with this connection. For FTP, this is the IP for
 the control connection. IPv6 addresses are represented without surrounding
 brackets.
 
-## conn_local_ip
+## `conn_local_ip`
 
 A null-terminated pointer to a C string containing the originating IP for this
 connection. IPv6 addresses are represented without surrounding brackets.
 
-## conn_primary_port
+## `conn_primary_port`
 
 The primary port number on the remote server established with this connection.
 For FTP, this is the port for the control connection. This can be a TCP or a
 UDP port number depending on the protocol.
 
-## conn_local_port
+## `conn_local_port`
 
 The originating port number for this connection. This can be a TCP or a UDP
 port number depending on the protocol.
 
-## clientp
+## `clientp`
 
 The pointer you set with CURLOPT_PREREQDATA(3).
 

--- a/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
@@ -28,10 +28,10 @@ Pass a long specifying whether the *TCP_NODELAY* option is to be set or
 cleared (1L = set, 0 = clear). The option is set by default. This has no
 effect after the connection has been established.
 
-Setting this option to 1L disables TCP's Nagle algorithm on connections
-created using this handle. The purpose of this algorithm is to try to minimize
-the number of small packets on the network (where "small packets" means TCP
-segments less than the Maximum Segment Size for the network).
+Setting this option to 1L disables the Nagle algorithm on connections created
+using this handle. The purpose of this algorithm is to minimize the number of
+small packets on the network (where "small packets" means TCP segments less
+than the Maximum Segment Size for the network).
 
 Maximizing the amount of data sent per TCP segment is good because it
 amortizes the overhead of the send. However, in some cases small segments may

--- a/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.md
+++ b/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.md
@@ -40,8 +40,8 @@ A brief introduction of its syntax follows:
 
     ftp://example.com/some/path/*.txt
 
-for all txt's from the root directory. Only two asterisks are allowed within
-the same pattern string.
+matches all `.txt` files in the root directory. Only two asterisks are allowed
+within the same pattern string.
 
 ## ? - QUESTION MARK
 

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -266,7 +266,7 @@ sub single {
         if(/^## (.*)/) {
             my $word = $1;
             # if there are enclosing quotes, remove them first
-            $word =~ s/[\"\'](.*)[\"\']\z/$1/;
+            $word =~ s/[\"\'\`](.*)[\"\'\`]\z/$1/;
 
             # enclose in double quotes if there is a space present
             if($word =~ / /) {


### PR DESCRIPTION
Since we generate all .1 and .3 files from markdown now, we can limit the spellcheck to the markdown versions only.