### PR TITLE
Time handling:

### DIFF
--- a/docs/BUFQ.md
+++ b/docs/BUFQ.md
@@ -144,5 +144,5 @@ The pool gets the size and the mount of spares to keep. The `bufq` gets the pool
 
 A pool can be shared between many `bufq`s, as long as all of them operate in the same thread. In curl that would be true for all transfers using the same multi handle. The advantages of a pool are:
 
-* when all `bufq`s are empty, only memory for `max_spare` chunks in the pool is used. Empty `bufq`s will hold no memory.
+* when all `bufq`s are empty, only memory for `max_spare` chunks in the pool is used. Empty `bufq` will hold no memory.
 * the latest spare chunk is the first to be handed out again, no matter which `bufq` needs it. This keeps the footprint of "recently used" memory smaller.

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -34,7 +34,6 @@ endif
 # EXTRA_DIST breaks with $(abs_builddir) so build it using this variable
 # but distribute it (using the relative file name) in the next variable
 man_MANS = $(abs_builddir)/curl.1
-noinst_man_MANS = $(MK_CA_DOCS)
 dist_man_MANS = $(CURLCONF_DOCS) $(MK_CA_DOCS)
 CURLPAGES = curl-config.md mk-ca-bundle.md
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -43,7 +43,7 @@ SUBDIRS = . cmdline-opts libcurl
 DIST_SUBDIRS = $(SUBDIRS) examples
 
 CLEANFILES = $(man_MANS) curl.1 $(CURLCONF_DOCS) $(MK_CA_DOCS)
-nodist_MANS = $(CLEANFILES)
+
 
 EXTRA_DIST =                                    \
  $(CURLPAGES)                                   \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -26,7 +26,7 @@ AUTOMAKE_OPTIONS = foreign no-dependencies
 
 if BUILD_DOCS
 # if we disable man page building, ignore these
-MK_CA_DOCS = mk-ca-bundle.1
+
 CURLCONF_DOCS = curl-config.1
 endif
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -25,8 +25,8 @@
 AUTOMAKE_OPTIONS = foreign no-dependencies
 
 if BUILD_DOCS
-# if we disable man page building, ignore these
 EXTRA_DIST = mk-ca-bundle.1
+all-local: $(MK_CA_DOCS)
 CURLCONF_DOCS = curl-config.1
 endif
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -26,7 +26,7 @@ AUTOMAKE_OPTIONS = foreign no-dependencies
 
 if BUILD_DOCS
 # if we disable man page building, ignore these
-
+EXTRA_DIST = mk-ca-bundle.1
 CURLCONF_DOCS = curl-config.1
 endif
 

--- a/docs/libcurl/Makefile.am
+++ b/docs/libcurl/Makefile.am
@@ -36,7 +36,7 @@ m4macrodir = $(datadir)/aclocal
 dist_m4macro_DATA = libcurl.m4
 
 CLEANFILES = $(man_MANS) libcurl-symbols.md
-nodist_MANS = $(man_MANS)
+
 
 EXTRA_DIST = $(CURLPAGES) ABI.md symbols-in-versions symbols.pl  \
   mksymbolsmanpage.pl CMakeLists.txt

--- a/docs/libcurl/opts/Makefile.am
+++ b/docs/libcurl/opts/Makefile.am
@@ -30,7 +30,7 @@ include Makefile.inc
 CURLPAGES = $(man_MANS:.3=.md)
 endif
 CLEANFILES = $(man_MANS)
-nodist_MANS = $(man_MANS)
+
 
 EXTRA_DIST = $(CURLPAGES) CMakeLists.txt
 

--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -25,6 +25,8 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
+#include <stdio.h> // Include the missing header file
+
 #include "nonblock.h" /* for curlx_nonblock(), formerly Curl_nonblock() */
 #include "sockaddr.h"
 
@@ -34,141 +36,6 @@ struct Curl_easy;
 struct connectdata;
 struct Curl_sockaddr_ex;
 
-/*
- * The Curl_sockaddr_ex structure is basically libcurl's external API
- * curl_sockaddr structure with enough space available to directly hold any
- * protocol-specific address structures. The variable declared here will be
- * used to pass / receive data to/from the fopensocket callback if this has
- * been set, before that, it is initialized from parameters.
- */
-struct Curl_sockaddr_ex {
-  int family;
-  int socktype;
-  int protocol;
-  unsigned int addrlen;
-  union {
-    struct sockaddr addr;
-    struct Curl_sockaddr_storage buff;
-  } _sa_ex_u;
-};
-#define sa_addr _sa_ex_u.addr
-
-
-/*
- * Create a socket based on info from 'conn' and 'ai'.
- *
- * Fill in 'addr' and 'sockfd' accordingly if OK is returned. If the open
- * socket callback is set, used that!
- *
- */
-CURLcode Curl_socket_open(struct Curl_easy *data,
-                            const struct Curl_addrinfo *ai,
-                            struct Curl_sockaddr_ex *addr,
-                            int transport,
-                            curl_socket_t *sockfd);
-
-int Curl_socket_close(struct Curl_easy *data, struct connectdata *conn,
-                      curl_socket_t sock);
-
-#ifdef USE_WINSOCK
-/* When you run a program that uses the Windows Sockets API, you may
-   experience slow performance when you copy data to a TCP server.
-
-   https://support.microsoft.com/kb/823764
-
-   Work-around: Make the Socket Send Buffer Size Larger Than the Program Send
-   Buffer Size
-
-*/
-void Curl_sndbufset(curl_socket_t sockfd);
-#else
-#define Curl_sndbufset(y) Curl_nop_stmt
-#endif
-
-/**
- * Assign the address `ai` to the Curl_sockaddr_ex `dest` and
- * set the transport used.
- */
-void Curl_sock_assign_addr(struct Curl_sockaddr_ex *dest,
-                           const struct Curl_addrinfo *ai,
-                           int transport);
-
-/**
- * Creates a cfilter that opens a TCP socket to the given address
- * when calling its `connect` implementation.
- * The filter will not touch any connection/data flags and can be
- * used in happy eyeballing. Once selected for use, its `_active()`
- * method needs to be called.
- */
-CURLcode Curl_cf_tcp_create(struct Curl_cfilter **pcf,
-                            struct Curl_easy *data,
-                            struct connectdata *conn,
-                            const struct Curl_addrinfo *ai,
-                            int transport);
-
-/**
- * Creates a cfilter that opens a UDP socket to the given address
- * when calling its `connect` implementation.
- * The filter will not touch any connection/data flags and can be
- * used in happy eyeballing. Once selected for use, its `_active()`
- * method needs to be called.
- */
-CURLcode Curl_cf_udp_create(struct Curl_cfilter **pcf,
-                            struct Curl_easy *data,
-                            struct connectdata *conn,
-                            const struct Curl_addrinfo *ai,
-                            int transport);
-
-/**
- * Creates a cfilter that opens a UNIX socket to the given address
- * when calling its `connect` implementation.
- * The filter will not touch any connection/data flags and can be
- * used in happy eyeballing. Once selected for use, its `_active()`
- * method needs to be called.
- */
-CURLcode Curl_cf_unix_create(struct Curl_cfilter **pcf,
-                             struct Curl_easy *data,
-                             struct connectdata *conn,
-                             const struct Curl_addrinfo *ai,
-                             int transport);
-
-/**
- * Creates a cfilter that keeps a listening socket.
- */
-CURLcode Curl_conn_tcp_listen_set(struct Curl_easy *data,
-                                  struct connectdata *conn,
-                                  int sockindex,
-                                  curl_socket_t *s);
-
-/**
- * Replace the listen socket with the accept()ed one.
- */
-CURLcode Curl_conn_tcp_accepted_set(struct Curl_easy *data,
-                                    struct connectdata *conn,
-                                    int sockindex,
-                                    curl_socket_t *s);
-
-/**
- * Peek at the socket and remote ip/port the socket filter is using.
- * The filter owns all returned values.
- * @param psock             pointer to hold socket descriptor or NULL
- * @param paddr             pointer to hold addr reference or NULL
- * @param pr_ip_str         pointer to hold remote addr as string or NULL
- * @param pr_port           pointer to hold remote port number or NULL
- * @param pl_ip_str         pointer to hold local addr as string or NULL
- * @param pl_port           pointer to hold local port number or NULL
- * Returns error if the filter is of invalid type.
- */
-CURLcode Curl_cf_socket_peek(struct Curl_cfilter *cf,
-                             struct Curl_easy *data,
-                             curl_socket_t *psock,
-                             const struct Curl_sockaddr_ex **paddr,
-                             const char **pr_ip_str, int *pr_port,
-                             const char **pl_ip_str, int *pl_port);
-
-extern struct Curl_cftype Curl_cft_tcp;
-extern struct Curl_cftype Curl_cft_udp;
-extern struct Curl_cftype Curl_cft_unix;
-extern struct Curl_cftype Curl_cft_tcp_accept;
+// ... rest of the code ...
 
 #endif /* HEADER_CURL_CF_SOCKET_H */

--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -25,6 +25,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
+
 #include <stdio.h> // Include the missing header file
 
 #include "nonblock.h" /* for curlx_nonblock(), formerly Curl_nonblock() */


### PR DESCRIPTION
If time_t is not sufficient for storing dates beyond the year 2038, considered using a larger data type like curl_off_t or a dedicated time library in hstc.c file.