### PR TITLE
Send Rework, Part 2

### DIFF
--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -19,7 +19,7 @@ CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
 ```
 The arguments are the transfer to read for, a buffer to hold the read data, its length, the actual number of bytes placed into the buffer and the `eos` flag indicating that no more data will be available. The `eos` flag may be set for a read amount, if that amount was the last. That way curl can avoid to read an additional time.
 
-The implementation of `Curl_client_read()` uses a chain of *client reader* instances to get the data. This is very similar to the design of *client writers*. The chain of readers allows processing of the data to send.
+The implementation of `Curl_client_read()` uses a chain of *client reader* instances to get the data. This is similar to the design of *client writers*. The chain of readers allows processing of the data to send.
 
 The definition of a reader is:
 

--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -11,13 +11,13 @@ With this naming established, client readers are concerned with providing data f
 
 ## Invoking
 
-The transfer loop that sends and receives, will use `Curl_client_read()` to get more data to send for a transfer. If no specific reader has been installed yet, the default one that uses `CURLOPT_READFUNCTION`, will be added. The prototype is
+The transfer loop that sends and receives, is using `Curl_client_read()` to get more data to send for a transfer. If no specific reader has been installed yet, the default one that uses `CURLOPT_READFUNCTION` is added. The prototype is
 
 ```
 CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
                           size_t *nread, bool *eos);
 ```
-The arguments are the transfer to read for, a buffer to hold the read data, its length, the actual number of bytes placed into the buffer and the `eos` flag indicating that no more data will be available. The `eos` flag may be set for a read amount, if that amount was the last. That way curl can avoid to read an additional time.
+The arguments are the transfer to read for, a buffer to hold the read data, its length, the actual number of bytes placed into the buffer and the `eos` flag indicating that no more data is available. The `eos` flag may be set for a read amount, if that amount was the last. That way curl can avoid to read an additional time.
 
 The implementation of `Curl_client_read()` uses a chain of *client reader* instances to get the data. This is similar to the design of *client writers*. The chain of readers allows processing of the data to send.
 
@@ -56,11 +56,11 @@ typedef enum {
 } Curl_creader_phase;
 ```
 
-If a reader for phase `PROTOCOL` is added to the chain, it is always added *after* any `NET` or `TRANSFER_ENCODE` readers and *before* and `CONTENT_ENCODE` and `CLIENT` readers. If there is already a reader for the same phase, the new reader will be added before the existing one(s).
+If a reader for phase `PROTOCOL` is added to the chain, it is always added *after* any `NET` or `TRANSFER_ENCODE` readers and *before* and `CONTENT_ENCODE` and `CLIENT` readers. If there is already a reader for the same phase, the new reader is added before the existing one(s).
 
 ### Example: `chunked` reader
 
-In `http_chunks.c` a client reader for chunked uploads is implemented. This one operates at phase `CURL_CR_TRANSFER_ENCODE`. Any data coming from the reader "below" will have the HTTP/1.1 chunk handling applied and returned to the caller.
+In `http_chunks.c` a client reader for chunked uploads is implemented. This one operates at phase `CURL_CR_TRANSFER_ENCODE`. Any data coming from the reader "below" has the HTTP/1.1 chunk handling applied and returned to the caller.
 
 When this reader sees an `eos` from below, it generates the terminal chunk, adding trailers if provided by the application. When that last chunk is fully returned, it also sets `eos` to the caller.
 
@@ -74,11 +74,11 @@ Implemented in `sendf.c` for phase `CURL_CR_CLIENT`, this reader has the simple 
 
 ### Example: `buf` reader
 
-Implemented in `sendf.c` for phase `CURL_CR_CLIENT`, this reader get a buffer pointer and a length and will provide exactly these bytes. This one is used in HTTP for sending `postfields` provided by the application.
+Implemented in `sendf.c` for phase `CURL_CR_CLIENT`, this reader get a buffer pointer and a length and provides exactly these bytes. This one is used in HTTP for sending `postfields` provided by the application.
 
 ## Request retries
 
-Sometimes it is necessary to send a request with client data again. Transfer handling can inquire via `Curl_client_read_needs_rewind()` if a rewind (e.g. a reset of the client data) is necessary. This will ask all installed readers if they need it and give `FALSE` of none does.
+Sometimes it is necessary to send a request with client data again. Transfer handling can inquire via `Curl_client_read_needs_rewind()` if a rewind (e.g. a reset of the client data) is necessary. This asks all installed readers if they need it and give `FALSE` of none does.
 
 ## Summary and Outlook
 

--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -17,7 +17,7 @@ The transfer loop that sends and receives, is using `Curl_client_read()` to get 
 CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
                           size_t *nread, bool *eos);
 ```
-The arguments are the transfer to read for, a buffer to hold the read data, its length, the actual number of bytes placed into the buffer and the `eos` flag indicating that no more data is available. The `eos` flag may be set for a read amount, if that amount was the last. That way curl can avoid to read an additional time.
+The arguments are the transfer to read for, a buffer to hold the read data, its length, the actual number of bytes placed into the buffer and the `eos` (*end of stream*) flag indicating that no more data is available. The `eos` flag may be set for a read amount, if that amount was the last. That way curl can avoid to read an additional time.
 
 The implementation of `Curl_client_read()` uses a chain of *client reader* instances to get the data. This is similar to the design of *client writers*. The chain of readers allows processing of the data to send.
 

--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -5,7 +5,7 @@ in curl v8.7.0. This document describes the concepts, its high level implementat
 
 ## Naming
 
-`libcurl` operates between clients and servers. A *client* is the application using libcurl, like the command line tool `curl` itself. Data to be uploaded to a server is **read** from the client and **send** to the server, the servers response is **received** by `libcurl` and then **written** to the client.
+`libcurl` operates between clients and servers. A *client* is the application using libcurl, like the command line tool `curl` itself. Data to be uploaded to a server is **read** from the client and **sent** to the server, the servers response is **received** by `libcurl` and then **written** to the client.
 
 With this naming established, client readers are concerned with providing data from the application to the server. Applications register callbacks via `CURLOPT_READFUNCTION`, data via `CURLOPT_POSTFIELDS` and other options to be used by `libcurl` when the request is send.
 
@@ -40,7 +40,7 @@ struct Curl_creader {
 };
 ```
 
-`Curl_creader` is a reader instance with a `next`pointer to form the chain. It as a type `crt`which provides the implementation. The main callback is `do_read()` which provides the data to the caller. The others are for setup and tear down. `needs_rewind()` is explained further below.
+`Curl_creader` is a reader instance with a `next` pointer to form the chain. It as a type `crt` which provides the implementation. The main callback is `do_read()` which provides the data to the caller. The others are for setup and tear down. `needs_rewind()` is explained further below.
 
 ## Phases and Ordering
 

--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -1,0 +1,93 @@
+# curl client readers
+
+Client readers is a design in the internals of libcurl, not visible in its public API. They were started
+in curl v8.7.0. This document describes the concepts, its high level implementation and the motivations.
+
+## Naming
+
+`libcurl` operates between clients and servers. A *client* is the application using libcurl, like the command line tool `curl` itself. Data to be uploaded to a server is **read** from the client and **send** to the server, the servers response is **received** by `libcurl` and then **written** to the client.
+
+With this naming established, client readers are concerned with providing data from the application to the server. Applications register callbacks via `CURLOPT_READFUNCTION`, data via `CURLOPT_POSTFIELDS` and other options to be used by `libcurl` when the request is send.
+
+## Invoking
+
+The transfer loop that sends and receives, will use `Curl_client_read()` to get more data to send for a transfer. If no specific reader has been installed yet, the default one that uses `CURLOPT_READFUNCTION`, will be added. The prototype is
+
+```
+CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
+                          size_t *nread, bool *eos);
+```
+The arguments are the transfer to read for, a buffer to hold the read data, its length, the actual number of bytes placed into the buffer and the `eos` flag indicating that no more data will be available. The `eos` flag may be set for a read amount, if that amount was the last. That way curl can avoid to read an additional time.
+
+The implementation of `Curl_client_read()` uses a chain of *client reader* instances to get the data. This is very similar to the design of *client writers*. The chain of readers allows processing of the data to send.
+
+The definition of a reader is:
+
+```
+struct Curl_crtype {
+  const char *name;        /* writer name. */
+  CURLcode (*do_init)(struct Curl_easy *data, struct Curl_creader *writer);
+  CURLcode (*do_read)(struct Curl_easy *data, struct Curl_creader *reader,
+                      char *buf, size_t blen, size_t *nread, bool *eos);
+  void (*do_close)(struct Curl_easy *data, struct Curl_creader *reader);
+  bool (*needs_rewind)(struct Curl_easy *data, struct Curl_creader *reader);
+};
+
+struct Curl_creader {
+  const struct Curl_crtype *crt;  /* type implementation */
+  struct Curl_creader *next;  /* Downstream reader. */
+  Curl_creader_phase phase; /* phase at which it operates */
+};
+```
+
+`Curl_creader` is a reader instance with a `next`pointer to form the chain. It as a type `crt`which provides the implementation. The main callback is `do_read()` which provides the data to the caller. The others are for setup and teardown. `needs_rewind()` is explained further below.
+
+## Phases and Ordering
+
+Since client readers may transform the data being read through the chain, the order in which they are called is relevant for the outcome. When a reader is created, it gets the `phase` property in which it operates. Reader phases are defined like:
+
+```
+typedef enum {
+  CURL_CR_NET,  /* data send to the network (connection filters) */
+  CURL_CR_TRANSFER_ENCODE, /* add transfer-encodings */
+  CURL_CR_PROTOCOL, /* before transfer, but after content decoding */
+  CURL_CR_CONTENT_ENCODE, /* add content-encodings */
+  CURL_CR_CLIENT  /* data read from client */
+} Curl_creader_phase;
+```
+
+If a reader for phase `PROTOCOL` is added to the chain, it is always added *after* any `NET` or `TRANSFER_ENCODE` readers and *before* and `CONTENT_ENCODE` and `CLIENT` readers. If there is already a reader for the same phase, the new reader will be added before the existing one(s).
+
+### Example: 'chunked' reader
+
+In `http_chunks.c` a client reader for chunked uploads is implemented. This one operates at phase `CURL_CR_TRANSFER_ENCODE`. Any data coming from the reader "below" will have the HTTP/1.1 chunk handling applied and returned to the caller.
+
+When this reader sees an `eos` from below, it generates the terminal chunk, adding trailers if provided by the application. When that last chunk is fully returned, it also sets `eos` to the caller.
+
+### Example: 'lineconv' reader
+
+In `sendf.c` a client reader that does line-end conversions is implemented. It operates at `CURL_CR_CONTENT_ENCODE` and converts any "\n" to "\r\n". This is used for FTP ASCII uploads or when the general `crlf` options has been set.
+
+### Example: 'null' reader
+
+Implemented in `sendf.c` for phase `CURL_CR_CLIENT`, this reader has the simple job of providing transfer bytes of length 0 to the caller, immediately indicating an `eos`. This reader is installed by HTTP for all GET/HEAD requests and when authentication is being negotiated.
+
+### Example: 'buf' reader
+
+Implemented in `sendf.c` for phase `CURL_CR_CLIENT`, this reader get a buffer pointer and a length and will provide exactly these bytes. This one is used in HTTP for sending `postfields` provided by the application.
+
+## Request retries
+
+Sometimes it is necessary to send a request with client data again. Transfer handling can inquire via `Curl_client_read_needs_rewind()` if a rewind (e.g. a reset of the client data) is necessary. This will ask all installed readers if they need it and give `FALSE` of none does.
+
+## Summary and Outlook
+
+By adding the client reader interface, any protocol can control how/if it wants the curl transfer to send bytes for a request. The transfer loop becomes then blissfully ignorant of the specifics. 
+
+The protocols on the other hand no longer have to care to package data most efficiently. At any time, should more data be needed, it can be read from the client. This is used when sending HTTP requests headers to add as much request body data to the initial sending as there is room for.
+
+Future enhancements based on the client readers:
+* delegate the actual "rewinding" to the readers. The should know how it is done, eliminating the `readrewind.c` protocol specifics in `multi.c`.
+* `expect-100` handling: place that into a HTTP specific reader at `CURL_CR_PROTOCOL` and eliminate the checks in the generic transfer parts.
+* `eos` detection: `upload_done` is partly triggered now by comparing the number of bytes sent to a known size. This is no longer necessary since the core readers obey length restrictions.
+* `eos forwarding`: transfer should forward an `eos` flag to the connection filters. Filters like HTTP/2 and HTTP/3 can make use of that, terminating streams early. This would also eliminate length checks in stream handling.

--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -40,7 +40,7 @@ struct Curl_creader {
 };
 ```
 
-`Curl_creader` is a reader instance with a `next`pointer to form the chain. It as a type `crt`which provides the implementation. The main callback is `do_read()` which provides the data to the caller. The others are for setup and teardown. `needs_rewind()` is explained further below.
+`Curl_creader` is a reader instance with a `next`pointer to form the chain. It as a type `crt`which provides the implementation. The main callback is `do_read()` which provides the data to the caller. The others are for setup and tear down. `needs_rewind()` is explained further below.
 
 ## Phases and Ordering
 
@@ -58,21 +58,21 @@ typedef enum {
 
 If a reader for phase `PROTOCOL` is added to the chain, it is always added *after* any `NET` or `TRANSFER_ENCODE` readers and *before* and `CONTENT_ENCODE` and `CLIENT` readers. If there is already a reader for the same phase, the new reader will be added before the existing one(s).
 
-### Example: 'chunked' reader
+### Example: `chunked` reader
 
 In `http_chunks.c` a client reader for chunked uploads is implemented. This one operates at phase `CURL_CR_TRANSFER_ENCODE`. Any data coming from the reader "below" will have the HTTP/1.1 chunk handling applied and returned to the caller.
 
 When this reader sees an `eos` from below, it generates the terminal chunk, adding trailers if provided by the application. When that last chunk is fully returned, it also sets `eos` to the caller.
 
-### Example: 'lineconv' reader
+### Example: `lineconv` reader
 
 In `sendf.c` a client reader that does line-end conversions is implemented. It operates at `CURL_CR_CONTENT_ENCODE` and converts any "\n" to "\r\n". This is used for FTP ASCII uploads or when the general `crlf` options has been set.
 
-### Example: 'null' reader
+### Example: `null` reader
 
 Implemented in `sendf.c` for phase `CURL_CR_CLIENT`, this reader has the simple job of providing transfer bytes of length 0 to the caller, immediately indicating an `eos`. This reader is installed by HTTP for all GET/HEAD requests and when authentication is being negotiated.
 
-### Example: 'buf' reader
+### Example: `buf` reader
 
 Implemented in `sendf.c` for phase `CURL_CR_CLIENT`, this reader get a buffer pointer and a length and will provide exactly these bytes. This one is used in HTTP for sending `postfields` provided by the application.
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -56,6 +56,7 @@ EXTRA_DIST =                                    \
  CODE_OF_CONDUCT.md                             \
  CODE_REVIEW.md                                 \
  CODE_STYLE.md                                  \
+ CLIENT-READERS.md                              \
  CLIENT-WRITERS.md                              \
  CONNECTION-FILTERS.md                          \
  CONTRIBUTE.md                                  \

--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -418,8 +418,8 @@ ssize_t Curl_bufq_write(struct bufq *q,
 }
 
 CURLcode Curl_bufq_cwrite(struct bufq *q,
-                         const char *buf, size_t len,
-                         size_t *pnwritten)
+                          const char *buf, size_t len,
+                          size_t *pnwritten)
 {
   ssize_t n;
   CURLcode result;

--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -417,6 +417,17 @@ ssize_t Curl_bufq_write(struct bufq *q,
   return nwritten;
 }
 
+CURLcode Curl_bufq_cwrite(struct bufq *q,
+                         const char *buf, size_t len,
+                         size_t *pnwritten)
+{
+  ssize_t n;
+  CURLcode result;
+  n = Curl_bufq_write(q, (const unsigned char *)buf, len, &result);
+  *pnwritten = (n < 0)? 0 : (size_t)n;
+  return result;
+}
+
 ssize_t Curl_bufq_read(struct bufq *q, unsigned char *buf, size_t len,
                        CURLcode *err)
 {
@@ -438,6 +449,16 @@ ssize_t Curl_bufq_read(struct bufq *q, unsigned char *buf, size_t len,
     return -1;
   }
   return nread;
+}
+
+CURLcode Curl_bufq_cread(struct bufq *q, char *buf, size_t len,
+                         size_t *pnread)
+{
+  ssize_t n;
+  CURLcode result;
+  n = Curl_bufq_read(q, (unsigned char *)buf, len, &result);
+  *pnread = (n < 0)? 0 : (size_t)n;
+  return result;
 }
 
 bool Curl_bufq_peek(struct bufq *q,

--- a/lib/bufq.h
+++ b/lib/bufq.h
@@ -178,6 +178,10 @@ ssize_t Curl_bufq_write(struct bufq *q,
                         const unsigned char *buf, size_t len,
                         CURLcode *err);
 
+CURLcode Curl_bufq_cwrite(struct bufq *q,
+                         const char *buf, size_t len,
+                         size_t *pnwritten);
+
 /**
  * Read buf from the start of the buffer queue. The buf is copied
  * and the amount of copied bytes is returned.
@@ -186,6 +190,9 @@ ssize_t Curl_bufq_write(struct bufq *q,
  */
 ssize_t Curl_bufq_read(struct bufq *q, unsigned char *buf, size_t len,
                         CURLcode *err);
+
+CURLcode Curl_bufq_cread(struct bufq *q, char *buf, size_t len,
+                         size_t *pnread);
 
 /**
  * Peek at the head chunk in the buffer queue. Returns a pointer to

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -84,8 +84,7 @@ size_t Curl_hyper_recv(void *userp, hyper_context *ctx,
   (void)ctx;
 
   DEBUGF(infof(data, "Curl_hyper_recv(%zu)", buflen));
-  result = Curl_conn_recv(data, io_ctx->sockindex,
-                          (char *)buf, buflen, &nread);
+  result = Curl_xfer_recv(data, (char *)buf, buflen, &nread);
   if(result == CURLE_AGAIN) {
     /* would block, register interest */
     DEBUGF(infof(data, "Curl_hyper_recv(%zu) -> EAGAIN", buflen));
@@ -115,8 +114,9 @@ size_t Curl_hyper_send(void *userp, hyper_context *ctx,
   size_t nwrote;
 
   DEBUGF(infof(data, "Curl_hyper_send(%zu)", buflen));
-  result = Curl_conn_send(data, io_ctx->sockindex,
-                          (void *)buf, buflen, &nwrote);
+  result = Curl_xfer_send(data, (void *)buf, buflen, &nwrote);
+  if(!result && !nwrote)
+    result = CURLE_AGAIN;
   if(result == CURLE_AGAIN) {
     DEBUGF(infof(data, "Curl_hyper_send(%zu) -> EAGAIN", buflen));
     /* would block, register interest */

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -84,7 +84,8 @@ size_t Curl_hyper_recv(void *userp, hyper_context *ctx,
   (void)ctx;
 
   DEBUGF(infof(data, "Curl_hyper_recv(%zu)", buflen));
-  result = Curl_xfer_recv(data, (char *)buf, buflen, &nread);
+  result = Curl_conn_recv(data, io_ctx->sockindex,
+                          (char *)buf, buflen, &nread);
   if(result == CURLE_AGAIN) {
     /* would block, register interest */
     DEBUGF(infof(data, "Curl_hyper_recv(%zu) -> EAGAIN", buflen));
@@ -116,8 +117,6 @@ size_t Curl_hyper_send(void *userp, hyper_context *ctx,
   DEBUGF(infof(data, "Curl_hyper_send(%zu)", buflen));
   result = Curl_conn_send(data, io_ctx->sockindex,
                           (void *)buf, buflen, &nwrote);
-  if(!result && !nwrote)
-    result = CURLE_AGAIN;
   if(result == CURLE_AGAIN) {
     DEBUGF(infof(data, "Curl_hyper_send(%zu) -> EAGAIN", buflen));
     /* would block, register interest */

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -771,7 +771,7 @@ static CURLcode bodysend(struct Curl_easy *data,
   else {
     hyper_body *body;
     Curl_dyn_init(&req, DYN_HTTP_REQUEST);
-    result = Curl_http_req_send(data, &req, httpreq);
+    result = Curl_http_req_complete(data, &req, httpreq);
 
     if(!result)
       result = Curl_hyper_header(data, headers, Curl_dyn_ptr(&req));

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -84,7 +84,8 @@ size_t Curl_hyper_recv(void *userp, hyper_context *ctx,
   (void)ctx;
 
   DEBUGF(infof(data, "Curl_hyper_recv(%zu)", buflen));
-  result = Curl_xfer_recv(data, (char *)buf, buflen, &nread);
+  result = Curl_conn_recv(data, io_ctx->sockindex,
+                          (char *)buf, buflen, &nread);
   if(result == CURLE_AGAIN) {
     /* would block, register interest */
     DEBUGF(infof(data, "Curl_hyper_recv(%zu) -> EAGAIN", buflen));
@@ -114,7 +115,8 @@ size_t Curl_hyper_send(void *userp, hyper_context *ctx,
   size_t nwrote;
 
   DEBUGF(infof(data, "Curl_hyper_send(%zu)", buflen));
-  result = Curl_xfer_send(data, (void *)buf, buflen, &nwrote);
+  result = Curl_conn_send(data, io_ctx->sockindex,
+                          (void *)buf, buflen, &nwrote);
   if(!result && !nwrote)
     result = CURLE_AGAIN;
   if(result == CURLE_AGAIN) {

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -117,8 +117,6 @@ size_t Curl_hyper_send(void *userp, hyper_context *ctx,
   DEBUGF(infof(data, "Curl_hyper_send(%zu)", buflen));
   result = Curl_conn_send(data, io_ctx->sockindex,
                           (void *)buf, buflen, &nwrote);
-  if(!result && !nwrote)
-    result = CURLE_AGAIN;
   if(result == CURLE_AGAIN) {
     DEBUGF(infof(data, "Curl_hyper_send(%zu) -> EAGAIN", buflen));
     /* would block, register interest */

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -84,8 +84,7 @@ size_t Curl_hyper_recv(void *userp, hyper_context *ctx,
   (void)ctx;
 
   DEBUGF(infof(data, "Curl_hyper_recv(%zu)", buflen));
-  result = Curl_conn_recv(data, io_ctx->sockindex,
-                          (char *)buf, buflen, &nread);
+  result = Curl_xfer_recv(data, (char *)buf, buflen, &nread);
   if(result == CURLE_AGAIN) {
     /* would block, register interest */
     DEBUGF(infof(data, "Curl_hyper_recv(%zu) -> EAGAIN", buflen));

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -886,7 +886,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
      may be parts of the request that is not yet sent, since we can deal with
      the rest of the request in the PERFORM phase. */
   *done = TRUE;
-  Curl_cw_reset(data);
+  Curl_client_reset(data);
 
   /* Add collecting of headers written to client. For a new connection,
    * we might have done that already, but reuse

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1013,7 +1013,7 @@ out:
     data->req.header = TRUE; /* assume header */
     data->req.bytecount = 0;
     data->req.ignorebody = FALSE;
-    Curl_cw_reset(data);
+    Curl_client_reset(data);
     Curl_pgrsSetUploadCounter(data, 0);
     Curl_pgrsSetDownloadCounter(data, 0);
 

--- a/lib/http.c
+++ b/lib/http.c
@@ -1233,7 +1233,6 @@ static size_t readmoredata(char *buffer,
   return fullsize;
 }
 
-#ifndef USE_HYPER
 /*
  * Curl_buffer_send() sends a header buffer and frees all associated
  * memory.  Body data may be appended to the header data if desired.

--- a/lib/http.c
+++ b/lib/http.c
@@ -1233,6 +1233,7 @@ static size_t readmoredata(char *buffer,
   return fullsize;
 }
 
+#ifndef USE_HYPER
 /*
  * Curl_buffer_send() sends a header buffer and frees all associated
  * memory.  Body data may be appended to the header data if desired.

--- a/lib/http.c
+++ b/lib/http.c
@@ -1444,51 +1444,6 @@ enum proxy_use {
   HEADER_CONNECT  /* sending CONNECT to a proxy */
 };
 
-/* used to compile the provided trailers into one buffer
-   will return an error code if one of the headers is
-   not formatted correctly */
-CURLcode Curl_http_compile_trailers(struct curl_slist *trailers,
-                                    struct dynbuf *b,
-                                    struct Curl_easy *handle)
-{
-  char *ptr = NULL;
-  CURLcode result = CURLE_OK;
-  const char *endofline_native = NULL;
-  const char *endofline_network = NULL;
-
-  if(
-#ifdef CURL_DO_LINEEND_CONV
-     (handle->state.prefer_ascii) ||
-#endif
-     (handle->set.crlf)) {
-    /* \n will become \r\n later on */
-    endofline_native  = "\n";
-    endofline_network = "\x0a";
-  }
-  else {
-    endofline_native  = "\r\n";
-    endofline_network = "\x0d\x0a";
-  }
-
-  while(trailers) {
-    /* only add correctly formatted trailers */
-    ptr = strchr(trailers->data, ':');
-    if(ptr && *(ptr + 1) == ' ') {
-      result = Curl_dyn_add(b, trailers->data);
-      if(result)
-        return result;
-      result = Curl_dyn_add(b, endofline_native);
-      if(result)
-        return result;
-    }
-    else
-      infof(handle, "Malformatted trailing header, skipping trailer");
-    trailers = trailers->next;
-  }
-  result = Curl_dyn_add(b, endofline_network);
-  return result;
-}
-
 static bool hd_name_eq(const char *n1, size_t n1len,
                        const char *n2, size_t n2len)
 {

--- a/lib/http.h
+++ b/lib/http.h
@@ -108,8 +108,8 @@ CURLcode Curl_transferencode(struct Curl_easy *data);
 CURLcode Curl_http_body(struct Curl_easy *data, struct connectdata *conn,
                         Curl_HttpReq httpreq,
                         const char **teep);
-CURLcode Curl_http_req_send(struct Curl_easy *data,
-                            struct dynbuf *r, Curl_HttpReq httpreq);
+CURLcode Curl_http_req_complete(struct Curl_easy *data,
+                                struct dynbuf *r, Curl_HttpReq httpreq);
 bool Curl_use_http_1_1plus(const struct Curl_easy *data,
                            const struct connectdata *conn);
 #ifndef CURL_DISABLE_COOKIES

--- a/lib/http.h
+++ b/lib/http.h
@@ -94,10 +94,6 @@ CURLcode Curl_dynhds_add_custom(struct Curl_easy *data,
                                 bool is_connect,
                                 struct dynhds *hds);
 
-CURLcode Curl_http_compile_trailers(struct curl_slist *trailers,
-                                    struct dynbuf *buf,
-                                    struct Curl_easy *handle);
-
 void Curl_http_method(struct Curl_easy *data, struct connectdata *conn,
                       const char **method, Curl_HttpReq *);
 CURLcode Curl_http_useragent(struct Curl_easy *data);

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -572,7 +572,7 @@ static CURLcode add_chunk(struct Curl_easy *data,
     int hdlen;
     size_t n;
 
-    hdlen = msnprintf(hd, sizeof(hd), "%zx\r\n", blen);
+    hdlen = msnprintf(hd, sizeof(hd), "%zx\r\n", nread);
     if(hdlen <= 0)
       return CURLE_READ_ERROR;
     /* On a soft-limited bufq, we do not need to check that all was written */
@@ -632,5 +632,20 @@ const struct Curl_crtype Curl_httpchunk_encoder = {
   cr_chunked_close,
   sizeof(struct chunked_reader)
 };
+
+CURLcode Curl_httpchunk_add_reader(struct Curl_easy *data)
+{
+  struct Curl_creader *reader = NULL;
+  CURLcode result;
+
+  result = Curl_creader_create(&reader, data, &Curl_httpchunk_encoder,
+                               CURL_CR_TRANSFER_ENCODE);
+  if(!result)
+    result = Curl_creader_add(data, reader);
+
+  if(result && reader)
+    Curl_creader_free(data, reader);
+  return result;
+}
 
 #endif /* CURL_DISABLE_HTTP */

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -27,10 +27,12 @@
 #ifndef CURL_DISABLE_HTTP
 
 #include "urldata.h" /* it includes http_chunks.h */
+#include "curl_printf.h"
 #include "sendf.h"   /* for the client write stuff */
 #include "dynbuf.h"
 #include "content_encoding.h"
 #include "http.h"
+#include "multiif.h"
 #include "strtoofft.h"
 #include "warnless.h"
 
@@ -456,6 +458,179 @@ const struct Curl_cwtype Curl_httpchunk_unencoder = {
   cw_chunked_write,
   cw_chunked_close,
   sizeof(struct chunked_writer)
+};
+
+/* max length of a HTTP chunk that we want to generate */
+#define CURL_CHUNKED_MINLEN   (1024)
+#define CURL_CHUNKED_MAXLEN   (64 * 1024)
+
+struct chunked_reader {
+  struct Curl_creader super;
+  struct bufq chunkbuf;
+  BIT(read_eos);  /* we read an EOS from the next reader */
+  BIT(eos);       /* we have returned an EOS */
+};
+
+static CURLcode cr_chunked_init(struct Curl_easy *data,
+                                struct Curl_creader *reader)
+{
+  struct chunked_reader *ctx = (struct chunked_reader *)reader;
+  (void)data;
+  Curl_bufq_init2(&ctx->chunkbuf, CURL_CHUNKED_MAXLEN, 2, BUFQ_OPT_SOFT_LIMIT);
+  return CURLE_OK;
+}
+
+static void cr_chunked_close(struct Curl_easy *data,
+                             struct Curl_creader *reader)
+{
+  struct chunked_reader *ctx = (struct chunked_reader *)reader;
+  (void)data;
+  Curl_bufq_free(&ctx->chunkbuf);
+}
+
+static CURLcode add_last_chunk(struct Curl_easy *data,
+                               struct Curl_creader *reader)
+{
+  struct chunked_reader *ctx = (struct chunked_reader *)reader;
+  struct curl_slist *trailers = NULL, *tr;
+  CURLcode result;
+  size_t n;
+  int rc;
+
+  if(!data->set.trailer_callback) {
+    return Curl_bufq_cwrite(&ctx->chunkbuf, STRCONST("0\r\n\r\n"), &n);
+  }
+
+  result = Curl_bufq_cwrite(&ctx->chunkbuf, STRCONST("0\r\n"), &n);
+  if(result)
+    goto out;
+
+  Curl_set_in_callback(data, true);
+  rc = data->set.trailer_callback(&trailers, data->set.trailer_data);
+  Curl_set_in_callback(data, false);
+
+  if(rc != CURL_TRAILERFUNC_OK) {
+    failf(data, "operation aborted by trailing headers callback");
+    result = CURLE_ABORTED_BY_CALLBACK;
+    goto out;
+  }
+
+  for(tr = trailers; tr; tr = tr->next) {
+    /* only add correctly formatted trailers */
+    char *ptr = strchr(tr->data, ':');
+    if(!ptr || *(ptr + 1) != ' ') {
+      infof(data, "Malformatted trailing header, skipping trailer");
+      continue;
+    }
+
+    result = Curl_bufq_cwrite(&ctx->chunkbuf, tr->data,
+                              strlen(tr->data), &n);
+    if(!result)
+      result = Curl_bufq_cwrite(&ctx->chunkbuf, STRCONST("\r\n"), &n);
+    if(result)
+      goto out;
+  }
+
+  result = Curl_bufq_cwrite(&ctx->chunkbuf, STRCONST("\r\n"), &n);
+
+out:
+  curl_slist_free_all(trailers);
+  return result;
+}
+
+static CURLcode add_chunk(struct Curl_easy *data,
+                          struct Curl_creader *reader,
+                          char *buf, size_t blen)
+{
+  struct chunked_reader *ctx = (struct chunked_reader *)reader;
+  CURLcode result;
+  char tmp[CURL_CHUNKED_MINLEN];
+  size_t nread;
+  bool eos;
+
+  DEBUGASSERT(!ctx->read_eos);
+  blen = CURLMIN(blen, CURL_CHUNKED_MAXLEN); /* respect our buffer pref */
+  if(blen < sizeof(tmp)) {
+    /* small read, make a chunk of decent size */
+    buf = tmp;
+    blen = sizeof(tmp);
+  }
+  else {
+    /* larger read, make a chunk that will fit when read back */
+    blen -= (8 + 2 + 2); /* deduct max overhead, 8 hex + 2*crlf */
+  }
+
+  result = Curl_creader_read(data, reader->next, buf, blen, &nread, &eos);
+  if(result)
+    return result;
+  if(eos)
+    ctx->read_eos = TRUE;
+
+  if(nread) {
+    /* actually got bytes, wrap them into the chunkbuf */
+    char hd[11] = "";
+    int hdlen;
+    size_t n;
+
+    hdlen = msnprintf(hd, sizeof(hd), "%zx\r\n", blen);
+    if(hdlen <= 0)
+      return CURLE_READ_ERROR;
+    /* On a soft-limited bufq, we do not need to check that all was written */
+    result = Curl_bufq_cwrite(&ctx->chunkbuf, hd, hdlen, &n);
+    if(!result)
+      result = Curl_bufq_cwrite(&ctx->chunkbuf, buf, nread, &n);
+    if(!result)
+      result = Curl_bufq_cwrite(&ctx->chunkbuf, "\r\n", 2, &n);
+    if(result)
+      return result;
+  }
+
+  if(ctx->read_eos)
+    return add_last_chunk(data, reader);
+  return CURLE_OK;
+}
+
+static CURLcode cr_chunked_read(struct Curl_easy *data,
+                                struct Curl_creader *reader,
+                                char *buf, size_t blen,
+                                size_t *pnread, bool *peos)
+{
+  struct chunked_reader *ctx = (struct chunked_reader *)reader;
+  CURLcode result = CURLE_READ_ERROR;
+
+  *pnread = 0;
+  *peos = ctx->eos;
+
+  if(!ctx->eos) {
+    if(!ctx->read_eos && Curl_bufq_is_empty(&ctx->chunkbuf)) {
+      /* Still getting data form the next reader, buffer is empty */
+      result = add_chunk(data, reader, buf, blen);
+      if(result)
+        return result;
+    }
+
+    if(!Curl_bufq_is_empty(&ctx->chunkbuf)) {
+      result = Curl_bufq_cread(&ctx->chunkbuf, buf, blen, pnread);
+      if(!result && ctx->read_eos && Curl_bufq_is_empty(&ctx->chunkbuf)) {
+        /* no more data, read all, done. */
+        ctx->eos = TRUE;
+        *peos = TRUE;
+      }
+      return result;
+    }
+  }
+  /* We may get here, because we are done or because callbacks paused */
+  DEBUGASSERT(ctx->eos || !ctx->read_eos);
+  return CURLE_OK;
+}
+
+/* HTTP chunked Transfer-Encoding encoder */
+const struct Curl_crtype Curl_httpchunk_encoder = {
+  "chunked",
+  cr_chunked_init,
+  cr_chunked_read,
+  cr_chunked_close,
+  sizeof(struct chunked_reader)
 };
 
 #endif /* CURL_DISABLE_HTTP */

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -630,6 +630,7 @@ const struct Curl_crtype Curl_httpchunk_encoder = {
   cr_chunked_init,
   cr_chunked_read,
   cr_chunked_close,
+  Curl_creader_def_needs_rewind,
   sizeof(struct chunked_reader)
 };
 

--- a/lib/http_chunks.h
+++ b/lib/http_chunks.h
@@ -135,6 +135,11 @@ extern const struct Curl_cwtype Curl_httpchunk_unencoder;
 
 extern const struct Curl_crtype Curl_httpchunk_encoder;
 
+/**
+ * Add a transfer-encoding "chunked" reader to the transfers reader stack
+ */
+CURLcode Curl_httpchunk_add_reader(struct Curl_easy *data);
+
 #endif /* !CURL_DISABLE_HTTP */
 
 #endif /* HEADER_CURL_HTTP_CHUNKS_H */

--- a/lib/http_chunks.h
+++ b/lib/http_chunks.h
@@ -133,6 +133,8 @@ bool Curl_httpchunk_is_done(struct Curl_easy *data, struct Curl_chunker *ch);
 
 extern const struct Curl_cwtype Curl_httpchunk_unencoder;
 
+extern const struct Curl_crtype Curl_httpchunk_encoder;
+
 #endif /* !CURL_DISABLE_HTTP */
 
 #endif /* HEADER_CURL_HTTP_CHUNKS_H */

--- a/lib/request.c
+++ b/lib/request.c
@@ -48,7 +48,7 @@ CURLcode Curl_req_start(struct SingleRequest *req,
                         struct Curl_easy *data)
 {
   req->start = Curl_now();
-  Curl_cw_reset(data);
+  Curl_client_reset(data);
   if(!req->sendbuf_init) {
     Curl_bufq_init2(&req->sendbuf, data->set.upload_buffer_size, 1,
                     BUFQ_OPT_SOFT_LIMIT);
@@ -72,7 +72,7 @@ CURLcode Curl_req_done(struct SingleRequest *req,
   (void)req;
   if(!aborted)
     (void)Curl_req_flush(data);
-  Curl_cw_reset(data);
+  Curl_client_reset(data);
   return CURLE_OK;
 }
 
@@ -85,7 +85,7 @@ void Curl_req_reset(struct SingleRequest *req, struct Curl_easy *data)
    * free this safely without leaks. */
   Curl_safefree(req->p.http);
   Curl_safefree(req->newurl);
-  Curl_cw_reset(data);
+  Curl_client_reset(data);
 
 #ifndef CURL_DISABLE_DOH
   if(req->doh) {
@@ -114,7 +114,7 @@ void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)
   Curl_safefree(req->newurl);
   if(req->sendbuf_init)
     Curl_bufq_free(&req->sendbuf);
-  Curl_cw_reset(data);
+  Curl_client_reset(data);
 
 #ifndef CURL_DISABLE_DOH
   if(req->doh) {

--- a/lib/request.c
+++ b/lib/request.c
@@ -27,6 +27,7 @@
 #include "urldata.h"
 #include "dynbuf.h"
 #include "doh.h"
+#include "multiif.h"
 #include "progress.h"
 #include "request.h"
 #include "sendf.h"
@@ -184,8 +185,19 @@ static CURLcode req_send_buffer_flush(struct Curl_easy *data)
       break;
 
     Curl_bufq_skip(&data->req.sendbuf, nwritten);
-    if(hds_len)
+    if(hds_len) {
       data->req.sendbuf_hds_len -= CURLMIN(hds_len, nwritten);
+      if(!data->req.sendbuf_hds_len) {
+        /* all request headers sent */
+        if(data->req.exp100 == EXP100_SENDING_REQUEST) {
+          /* We are now waiting for a reply from the server or
+           * a timeout on our side */
+          data->req.exp100 = EXP100_AWAITING_CONTINUE;
+          data->req.start100 = Curl_now();
+          Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);
+        }
+      }
+    }
     /* leave if we could not send all. Maybe network blocking or
      * speed limits on transfer */
     if(nwritten < blen)
@@ -230,9 +242,23 @@ static CURLcode req_send_buffer_add(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-CURLcode Curl_req_send(struct Curl_easy *data,
-                       const char *buf, size_t blen,
-                       size_t hds_len)
+static ssize_t add_from_client(void *reader_ctx,
+                               unsigned char *buf, size_t buflen,
+                               CURLcode *err)
+{
+  struct Curl_easy *data = reader_ctx;
+  size_t nread;
+  bool eos;
+
+  *err = Curl_client_read(data, (char *)buf, buflen, &nread, &eos);
+  if(*err)
+    return -1;
+  if(eos)
+    data->req.eos_read = TRUE;
+  return (ssize_t)nread;
+}
+
+CURLcode Curl_req_send(struct Curl_easy *data, struct dynbuf *buf)
 {
   CURLcode result;
 
@@ -244,9 +270,19 @@ CURLcode Curl_req_send(struct Curl_easy *data,
    * important for TLS libraries that expect this.
    * We *could* optimized for non-TLS transfers, but that would mean
    * separate code paths and seems not worth it. */
-  result = req_send_buffer_add(data, buf, blen, hds_len);
+  result = req_send_buffer_add(data, Curl_dyn_ptr(buf), Curl_dyn_len(buf),
+                               Curl_dyn_len(buf));
   if(result)
     return result;
+
+  if((data->req.exp100 == EXP100_SEND_DATA) &&
+     !Curl_bufq_is_full(&data->req.sendbuf)) {
+    ssize_t nread = Curl_bufq_sipn(&data->req.sendbuf, 0,
+                                   add_from_client, data, &result);
+    if(nread < 0 && result != CURLE_AGAIN)
+      return result;
+  }
+
   result = req_send_buffer_flush(data);
   if(result == CURLE_AGAIN)
     result = CURLE_OK;

--- a/lib/request.c
+++ b/lib/request.c
@@ -171,22 +171,6 @@ static CURLcode req_send(struct Curl_easy *data,
   return result;
 }
 
-static CURLcode req_send_buffer_add(struct Curl_easy *data,
-                                    const char *buf, size_t blen,
-                                    size_t hds_len)
-{
-  CURLcode result = CURLE_OK;
-  ssize_t n;
-  n = Curl_bufq_write(&data->req.sendbuf,
-                      (const unsigned char *)buf, blen, &result);
-  if(n < 0)
-    return result;
-  /* We rely on a SOFTLIMIT on sendbuf, so it can take all data in */
-  DEBUGASSERT((size_t)n == blen);
-  data->req.sendbuf_hds_len += hds_len;
-  return CURLE_OK;
-}
-
 static CURLcode req_send_buffer_flush(struct Curl_easy *data)
 {
   CURLcode result = CURLE_OK;
@@ -228,6 +212,24 @@ CURLcode Curl_req_flush(struct Curl_easy *data)
   return CURLE_OK;
 }
 
+#ifndef USE_HYPER
+
+static CURLcode req_send_buffer_add(struct Curl_easy *data,
+                                    const char *buf, size_t blen,
+                                    size_t hds_len)
+{
+  CURLcode result = CURLE_OK;
+  ssize_t n;
+  n = Curl_bufq_write(&data->req.sendbuf,
+                      (const unsigned char *)buf, blen, &result);
+  if(n < 0)
+    return result;
+  /* We rely on a SOFTLIMIT on sendbuf, so it can take all data in */
+  DEBUGASSERT((size_t)n == blen);
+  data->req.sendbuf_hds_len += hds_len;
+  return CURLE_OK;
+}
+
 CURLcode Curl_req_send(struct Curl_easy *data,
                        const char *buf, size_t blen,
                        size_t hds_len)
@@ -250,6 +252,7 @@ CURLcode Curl_req_send(struct Curl_easy *data,
     result = CURLE_OK;
   return result;
 }
+#endif /* !USE_HYPER */
 
 bool Curl_req_want_send(struct Curl_easy *data)
 {

--- a/lib/request.h
+++ b/lib/request.h
@@ -64,8 +64,6 @@ struct SingleRequest {
   curl_off_t bytecount;         /* total number of bytes read */
   curl_off_t writebytecount;    /* number of bytes written */
 
-  size_t pendingheader;         /* this many bytes left to send is actually
-                                    header and not body */
   struct curltime start;         /* transfer started at this time */
   unsigned int headerbytecount;  /* received server headers (not CONNECT
                                     headers) */
@@ -140,6 +138,7 @@ struct SingleRequest {
   BIT(content_range); /* set TRUE if Content-Range: was found */
   BIT(download_done); /* set to TRUE when download is complete */
   BIT(eos_written);   /* iff EOS has been written to client */
+  BIT(eos_read);      /* iff EOS has been read from the client */
   BIT(upload_done);   /* set to TRUE when doing chunked transfer-encoding
                          upload and we're uploading the last chunk */
   BIT(ignorebody);    /* we read a response-body but we ignore it! */
@@ -195,22 +194,14 @@ void Curl_req_reset(struct SingleRequest *req, struct Curl_easy *data);
 
 #ifndef USE_HYPER
 /**
- * Send request bytes for transfer. If not all could be sent
+ * Send request headers. If not all could be sent
  * they will be buffered. Use `Curl_req_flush()` to make sure
  * bytes are really send.
  * @param data      the transfer making the request
- * @param buf       the bytes to send
- * @param blen      the number of bytes to send
- * @param hds_len   the number of bytes from the start that are headers
+ * @param buf       the complete header bytes, no body
  * @return CURLE_OK (on blocking with *pnwritten == 0) or error.
  */
-CURLcode Curl_req_send(struct Curl_easy *data,
-                        const char *buf, size_t blen,
-                        size_t hds_len);
-
-/* Convenience for sending only header bytes */
-#define Curl_req_send_hds(data, buf, blen) \
-          Curl_req_send((data), (buf), (blen), (blen))
+CURLcode Curl_req_send(struct Curl_easy *data, struct dynbuf *buf);
 
 #endif /* !USE_HYPER */
 

--- a/lib/request.h
+++ b/lib/request.h
@@ -87,9 +87,12 @@ struct SingleRequest {
   enum expect100 exp100;        /* expect 100 continue state */
   enum upgrade101 upgr101;      /* 101 upgrade state */
 
-  /* Client Writer stack, handles trasnfer- and content-encodings, protocol
+  /* Client Writer stack, handles transfer- and content-encodings, protocol
    * checks, pausing by client callbacks. */
   struct Curl_cwriter *writer_stack;
+  /* Client Reader stack, handles transfer- and content-encodings, protocol
+   * checks, pausing by client callbacks. */
+  struct Curl_creader *reader_stack;
   struct bufq sendbuf; /* data which needs to be send to the server */
   size_t sendbuf_hds_len; /* amount of header bytes in sendbuf */
   time_t timeofdoc;

--- a/lib/request.h
+++ b/lib/request.h
@@ -193,7 +193,7 @@ void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data);
  */
 void Curl_req_reset(struct SingleRequest *req, struct Curl_easy *data);
 
-
+#ifndef USE_HYPER
 /**
  * Send request bytes for transfer. If not all could be sent
  * they will be buffered. Use `Curl_req_flush()` to make sure
@@ -211,6 +211,8 @@ CURLcode Curl_req_send(struct Curl_easy *data,
 /* Convenience for sending only header bytes */
 #define Curl_req_send_hds(data, buf, blen) \
           Curl_req_send((data), (buf), (blen), (blen))
+
+#endif /* !USE_HYPER */
 
 /**
  * Flush all buffered request bytes.

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -241,6 +241,8 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   const char *p_userpwd = NULL;
 
   *done = TRUE;
+  /* Initialize a dynamic send buffer */
+  Curl_dyn_init(&req_buffer, DYN_RTSP_REQ_HEADER);
 
   rtsp->CSeq_sent = data->state.rtsp_next_client_CSeq;
   rtsp->CSeq_recv = 0;
@@ -311,8 +313,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
 
   if(rtspreq == RTSPREQ_RECEIVE) {
     Curl_xfer_setup(data, FIRSTSOCKET, -1, TRUE, -1);
-
-    return result;
+    goto out;
   }
 
   p_session_id = data->set.str[STRING_RTSP_SESSION_ID];
@@ -320,7 +321,8 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
      (rtspreq & ~(RTSPREQ_OPTIONS | RTSPREQ_DESCRIBE | RTSPREQ_SETUP))) {
     failf(data, "Refusing to issue an RTSP request [%s] without a session ID.",
           p_request);
-    return CURLE_BAD_FUNCTION_ARGUMENT;
+    result = CURLE_BAD_FUNCTION_ARGUMENT;
+    goto out;
   }
 
   /* Stream URI. Default to server '*' if not specified */
@@ -347,7 +349,8 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     else {
       failf(data,
             "Refusing to issue an RTSP SETUP without a Transport: header.");
-      return CURLE_BAD_FUNCTION_ARGUMENT;
+      result = CURLE_BAD_FUNCTION_ARGUMENT;
+      goto out;
     }
 
     p_transport = data->state.aptr.rtsp_transport;
@@ -366,9 +369,10 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
       data->state.aptr.accept_encoding =
         aprintf("Accept-Encoding: %s\r\n", data->set.str[STRING_ENCODING]);
 
-      if(!data->state.aptr.accept_encoding)
-        return CURLE_OUT_OF_MEMORY;
-
+      if(!data->state.aptr.accept_encoding) {
+        result = CURLE_OUT_OF_MEMORY;
+        goto out;
+      }
       p_accept_encoding = data->state.aptr.accept_encoding;
     }
   }
@@ -390,7 +394,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   result = Curl_http_output_auth(data, conn, p_request, HTTPREQ_GET,
                                  p_stream_uri, FALSE);
   if(result)
-    return result;
+    goto out;
 
   p_proxyuserpwd = data->state.aptr.proxyuserpwd;
   p_userpwd = data->state.aptr.userpwd;
@@ -424,15 +428,14 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
    */
   if(Curl_checkheaders(data, STRCONST("CSeq"))) {
     failf(data, "CSeq cannot be set as a custom header.");
-    return CURLE_RTSP_CSEQ_ERROR;
+    result = CURLE_RTSP_CSEQ_ERROR;
+    goto out;
   }
   if(Curl_checkheaders(data, STRCONST("Session"))) {
     failf(data, "Session ID cannot be set as a custom header.");
-    return CURLE_BAD_FUNCTION_ARGUMENT;
+    result = CURLE_BAD_FUNCTION_ARGUMENT;
+    goto out;
   }
-
-  /* Initialize a dynamic send buffer */
-  Curl_dyn_init(&req_buffer, DYN_RTSP_REQ_HEADER);
 
   result =
     Curl_dyn_addf(&req_buffer,
@@ -440,7 +443,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
                   "CSeq: %ld\r\n", /* CSeq */
                   p_request, p_stream_uri, rtsp->CSeq_sent);
   if(result)
-    return result;
+    goto out;
 
   /*
    * Rather than do a normal alloc line, keep the session_id unformatted
@@ -449,7 +452,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   if(p_session_id) {
     result = Curl_dyn_addf(&req_buffer, "Session: %s\r\n", p_session_id);
     if(result)
-      return result;
+      goto out;
   }
 
   /*
@@ -481,17 +484,17 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   Curl_safefree(data->state.aptr.userpwd);
 
   if(result)
-    return result;
+    goto out;
 
   if((rtspreq == RTSPREQ_SETUP) || (rtspreq == RTSPREQ_DESCRIBE)) {
     result = Curl_add_timecondition(data, &req_buffer);
     if(result)
-      return result;
+      goto out;
   }
 
   result = Curl_add_custom_headers(data, FALSE, &req_buffer);
   if(result)
-    return result;
+    goto out;
 
   if(rtspreq == RTSPREQ_ANNOUNCE ||
      rtspreq == RTSPREQ_SET_PARAMETER ||
@@ -502,7 +505,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
       data->state.httpreq = HTTPREQ_PUT;
       result = Client_reader_set_fread(data, putsize);
       if(result)
-        return result;
+        goto out;
     }
     else {
       postsize = (data->state.infilesize != -1)?
@@ -517,7 +520,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
       else
         result = Client_reader_set_fread(data, postsize);
       if(result)
-        return result;
+        goto out;
     }
 
     if(putsize > 0 || postsize > 0) {
@@ -529,7 +532,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
                         "Content-Length: %" CURL_FORMAT_CURL_OFF_T"\r\n",
                         (data->state.upload ? putsize : postsize));
         if(result)
-          return result;
+          goto out;
       }
 
       if(rtspreq == RTSPREQ_SET_PARAMETER ||
@@ -539,7 +542,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
                                  STRCONST("Content-Type: "
                                           "text/parameters\r\n"));
           if(result)
-            return result;
+            goto out;
         }
       }
 
@@ -549,7 +552,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
                                  STRCONST("Content-Type: "
                                           "application/sdp\r\n"));
           if(result)
-            return result;
+            goto out;
         }
       }
 
@@ -564,7 +567,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   else {
     result = Client_reader_set_null(data);
     if(result)
-      return result;
+      goto out;
   }
 
   /* RTSP never allows chunked transfer */
@@ -572,14 +575,13 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   /* Finish the request buffer */
   result = Curl_dyn_addn(&req_buffer, STRCONST("\r\n"));
   if(result)
-    return result;
+    goto out;
 
   /* issue the request */
   result = Curl_req_send(data, &req_buffer);
-  Curl_dyn_free(&req_buffer);
   if(result) {
     failf(data, "Failed sending RTSP request");
-    return result;
+    goto out;
   }
 
   Curl_xfer_setup(data, FIRSTSOCKET, -1, TRUE, FIRSTSOCKET);
@@ -594,7 +596,8 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     if(Curl_pgrsUpdate(data))
       result = CURLE_ABORTED_BY_CALLBACK;
   }
-
+out:
+  Curl_dyn_free(&req_buffer);
   return result;
 }
 

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -559,15 +559,14 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     return result;
 
   if(postsize > 0) {
-    result = Curl_dyn_addn(&req_buffer, data->set.postfields,
-                           (size_t)postsize);
+    result = Client_reader_set_buf(data, data->set.postfields,
+                                   (size_t)postsize);
     if(result)
       return result;
   }
 
   /* issue the request */
-  result = Curl_req_send_hds(data, Curl_dyn_ptr(&req_buffer),
-                             Curl_dyn_len(&req_buffer));
+  result = Curl_req_send(data, &req_buffer);
   Curl_dyn_free(&req_buffer);
   if(result) {
     failf(data, "Failed sending RTSP request");

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -114,8 +114,6 @@ static void cl_reset_reader(struct Curl_easy *data)
 
 void Curl_client_reset(struct Curl_easy *data)
 {
-  size_t i;
-
   DEBUGF(infof(data, "Curl_client_reset()"));
   cl_reset_reader(data);
   cl_reset_writer(data);

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -452,13 +452,6 @@ CURLcode Curl_creader_def_init(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-CURLcode Curl_creader_def_read(struct Curl_easy *data,
-                               struct Curl_creader *reader, char *buf,
-                               size_t blen, size_t *nread, bool *eos)
-{
-  return Curl_creader_read(data, reader->next, buf, blen, nread, eos);
-}
-
 void Curl_creader_def_close(struct Curl_easy *data,
                             struct Curl_creader *reader)
 {
@@ -505,7 +498,8 @@ static CURLcode cr_in_read(struct Curl_easy *data,
   switch(nread) {
   case 0:
     *pnread = 0;
-    *peos = ctx->seen_eos = TRUE;
+    *peos = TRUE;
+    ctx->seen_eos = TRUE;
     break;
 
   case CURL_READFUNC_ABORT:

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -489,7 +489,8 @@ static CURLcode cr_in_read(struct Curl_easy *data,
 
   /* no read callback installed, simulate empty read */
   nread = 0;
-  if(data->state.fread_func && data->state.infilesize) {
+  if(data->state.fread_func && data->state.infilesize &&
+     !data->req.authneg) {
     Curl_set_in_callback(data, true);
     nread = data->state.fread_func(buf, 1, blen, data->state.in);
     Curl_set_in_callback(data, false);

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -178,13 +178,11 @@ void Curl_cwriter_def_close(struct Curl_easy *data,
 /* Client Reader Type, provides the implementation */
 struct Curl_crtype {
   const char *name;        /* writer name. */
-  CURLcode (*do_init)(struct Curl_easy *data,
-                      struct Curl_creader *writer);
-  CURLcode (*do_read)(struct Curl_easy *data,
-                      struct Curl_creader *reader,
+  CURLcode (*do_init)(struct Curl_easy *data, struct Curl_creader *writer);
+  CURLcode (*do_read)(struct Curl_easy *data, struct Curl_creader *reader,
                       char *buf, size_t blen, size_t *nread, bool *eos);
-  void (*do_close)(struct Curl_easy *data,
-                   struct Curl_creader *reader);
+  void (*do_close)(struct Curl_easy *data, struct Curl_creader *reader);
+  bool (*needs_rewind)(struct Curl_easy *data, struct Curl_creader *reader);
   size_t creader_size;  /* sizeof() allocated struct Curl_creader */
 };
 
@@ -212,6 +210,8 @@ CURLcode Curl_creader_def_init(struct Curl_easy *data,
                                struct Curl_creader *reader);
 void Curl_creader_def_close(struct Curl_easy *data,
                             struct Curl_creader *reader);
+bool Curl_creader_def_needs_rewind(struct Curl_easy *data,
+                                   struct Curl_creader *reader);
 
 /**
  * Convenience method for calling `reader->do_read()` that
@@ -256,5 +256,15 @@ CURLcode Curl_creader_add(struct Curl_easy *data,
 CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
                           size_t *nread, bool *eos) WARN_UNUSED_RESULT;
 
+/**
+ * TRUE iff client reader needs rewing before it can be used for
+ * a retry request.
+ */
+bool Curl_client_read_needs_rewind(struct Curl_easy *data);
+
+/**
+ * Set the client reader to provide 0 bytes, immediate EOS.
+ */
+CURLcode Client_reader_set_null(struct Curl_easy *data);
 
 #endif /* HEADER_CURL_SENDF_H */

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -270,7 +270,7 @@ CURLcode Client_reader_set_null(struct Curl_easy *data);
 /**
  * Set the client reader the reads from fread callback.
  */
-CURLcode Client_reader_set_fread(struct Curl_easy *data);
+CURLcode Client_reader_set_fread(struct Curl_easy *data, curl_off_t len);
 
 /**
  * Set the client reader the reads from the supplied buf (NOT COPIED).

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -267,4 +267,15 @@ bool Curl_client_read_needs_rewind(struct Curl_easy *data);
  */
 CURLcode Client_reader_set_null(struct Curl_easy *data);
 
+/**
+ * Set the client reader the reads from fread callback.
+ */
+CURLcode Client_reader_set_fread(struct Curl_easy *data);
+
+/**
+ * Set the client reader the reads from the supplied buf (NOT COPIED).
+ */
+CURLcode Client_reader_set_buf(struct Curl_easy *data,
+                               const char *buf, size_t blen);
+
 #endif /* HEADER_CURL_SENDF_H */

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -210,9 +210,6 @@ struct Curl_creader {
  */
 CURLcode Curl_creader_def_init(struct Curl_easy *data,
                                struct Curl_creader *reader);
-CURLcode Curl_creader_def_read(struct Curl_easy *data,
-                               struct Curl_creader *reader, char *buf,
-                               size_t blen, size_t *nread, bool *eos);
 void Curl_creader_def_close(struct Curl_easy *data,
                             struct Curl_creader *reader);
 

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -811,8 +811,9 @@ static CURLcode smb_send_and_recv(struct Curl_easy *data, void **msg)
   if(!smbc->send_size && smbc->upload_size) {
     size_t nread = smbc->upload_size > (size_t)data->set.upload_buffer_size ?
       (size_t)data->set.upload_buffer_size : smbc->upload_size;
-    data->req.upload_fromhere = data->state.ulbuf;
-    result = Curl_fillreadbuffer(data, nread, &nread);
+    bool eos;
+
+    result = Curl_client_read(data, data->state.ulbuf, nread, &nread, &eos);
     if(result && result != CURLE_AGAIN)
       return result;
     if(!nread)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1290,8 +1290,7 @@ CURLcode Curl_retry_request(struct Curl_easy *data, char **url)
                                 transferred! */
 
 
-    if((conn->handler->protocol&PROTO_FAMILY_HTTP) &&
-       data->req.writebytecount) {
+    if(Curl_client_read_needs_rewind(data)) {
       data->state.rewindbeforesend = TRUE;
       infof(data, "state.rewindbeforesend = TRUE");
     }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -390,6 +390,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
   ssize_t nread; /* number of bytes read */
   struct SingleRequest *k = &data->req;
 
+  (void)conn;
   *didwhat |= KEEP_SEND;
 
   if(!(k->keepon & KEEP_SEND_PAUSE)) {

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -778,6 +778,9 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
          that instead of reading more data */
     }
 
+    if(!Curl_bufq_is_empty(&k->sendbuf)) {
+      DEBUGASSERT(0);
+    }
     /* write to socket (send away data) */
     result = Curl_xfer_send(data,
                             k->upload_fromhere, /* buffer pointer */

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -125,248 +125,17 @@ CURLcode Curl_get_upload_buffer(struct Curl_easy *data)
   return CURLE_OK;
 }
 
-#ifndef CURL_DISABLE_HTTP
-/*
- * This function will be called to loop through the trailers buffer
- * until no more data is available for sending.
- */
-static size_t trailers_read(char *buffer, size_t size, size_t nitems,
-                            void *raw)
+CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t len,
+                             size_t *pnread)
 {
-  struct Curl_easy *data = (struct Curl_easy *)raw;
-  struct dynbuf *trailers_buf = &data->state.trailers_buf;
-  size_t bytes_left = Curl_dyn_len(trailers_buf) -
-    data->state.trailers_bytes_sent;
-  size_t to_copy = (size*nitems < bytes_left) ? size*nitems : bytes_left;
-  if(to_copy) {
-    memcpy(buffer,
-           Curl_dyn_ptr(trailers_buf) + data->state.trailers_bytes_sent,
-           to_copy);
-    data->state.trailers_bytes_sent += to_copy;
-  }
-  return to_copy;
-}
+  char *buf = data->req.upload_fromhere;
+  CURLcode result;
+  bool eos;
 
-static size_t trailers_left(void *raw)
-{
-  struct Curl_easy *data = (struct Curl_easy *)raw;
-  struct dynbuf *trailers_buf = &data->state.trailers_buf;
-  return Curl_dyn_len(trailers_buf) - data->state.trailers_bytes_sent;
-}
-#endif
-
-/*
- * This function will call the read callback to fill our buffer with data
- * to upload.
- */
-CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
-                             size_t *nreadp)
-{
-  size_t buffersize = bytes;
-  size_t nread;
-  curl_read_callback readfunc = NULL;
-  void *extra_data = NULL;
-  int eof_index = 0;
-
-#ifndef CURL_DISABLE_HTTP
-  if(data->state.trailers_state == TRAILERS_INITIALIZED) {
-    struct curl_slist *trailers = NULL;
-    CURLcode result;
-    int trailers_ret_code;
-
-    /* at this point we already verified that the callback exists
-       so we compile and store the trailers buffer, then proceed */
-    infof(data,
-          "Moving trailers state machine from initialized to sending.");
-    data->state.trailers_state = TRAILERS_SENDING;
-    Curl_dyn_init(&data->state.trailers_buf, DYN_TRAILERS);
-
-    data->state.trailers_bytes_sent = 0;
-    Curl_set_in_callback(data, true);
-    trailers_ret_code = data->set.trailer_callback(&trailers,
-                                                   data->set.trailer_data);
-    Curl_set_in_callback(data, false);
-    if(trailers_ret_code == CURL_TRAILERFUNC_OK) {
-      result = Curl_http_compile_trailers(trailers, &data->state.trailers_buf,
-                                          data);
-    }
-    else {
-      failf(data, "operation aborted by trailing headers callback");
-      *nreadp = 0;
-      result = CURLE_ABORTED_BY_CALLBACK;
-    }
-    if(result) {
-      Curl_dyn_free(&data->state.trailers_buf);
-      curl_slist_free_all(trailers);
-      return result;
-    }
-    infof(data, "Successfully compiled trailers.");
-    curl_slist_free_all(trailers);
-  }
-#endif
-
-#ifndef CURL_DISABLE_HTTP
-  /* if we are transmitting trailing data, we don't need to write
-     a chunk size so we skip this */
-  if(data->req.upload_chunky &&
-     data->state.trailers_state == TRAILERS_NONE) {
-    /* if chunked Transfer-Encoding */
-    buffersize -= (8 + 2 + 2);   /* 32bit hex + CRLF + CRLF */
-    data->req.upload_fromhere += (8 + 2); /* 32bit hex + CRLF */
-  }
-
-  if(data->state.trailers_state == TRAILERS_SENDING) {
-    /* if we're here then that means that we already sent the last empty chunk
-       but we didn't send a final CR LF, so we sent 0 CR LF. We then start
-       pulling trailing data until we have no more at which point we
-       simply return to the previous point in the state machine as if
-       nothing happened.
-       */
-    readfunc = trailers_read;
-    extra_data = (void *)data;
-    eof_index = 1;
-  }
-  else
-#endif
-  {
-    readfunc = data->state.fread_func;
-    extra_data = data->state.in;
-  }
-
-  if(!data->req.fread_eof[eof_index]) {
-    Curl_set_in_callback(data, true);
-    nread = readfunc(data->req.upload_fromhere, 1, buffersize, extra_data);
-    Curl_set_in_callback(data, false);
-    /* make sure the callback is not called again after EOF */
-    data->req.fread_eof[eof_index] = !nread;
-  }
-  else
-    nread = 0;
-
-  if(nread == CURL_READFUNC_ABORT) {
-    failf(data, "operation aborted by callback");
-    *nreadp = 0;
-    return CURLE_ABORTED_BY_CALLBACK;
-  }
-  if(nread == CURL_READFUNC_PAUSE) {
-    struct SingleRequest *k = &data->req;
-
-    if(data->conn->handler->flags & PROTOPT_NONETWORK) {
-      /* protocols that work without network cannot be paused. This is
-         actually only FILE:// just now, and it can't pause since the transfer
-         isn't done using the "normal" procedure. */
-      failf(data, "Read callback asked for PAUSE when not supported");
-      return CURLE_READ_ERROR;
-    }
-
-    /* CURL_READFUNC_PAUSE pauses read callbacks that feed socket writes */
-    k->keepon |= KEEP_SEND_PAUSE; /* mark socket send as paused */
-    if(data->req.upload_chunky) {
-        /* Back out the preallocation done above */
-      data->req.upload_fromhere -= (8 + 2);
-    }
-    *nreadp = 0;
-
-    return CURLE_OK; /* nothing was read */
-  }
-  else if(nread > buffersize) {
-    /* the read function returned a too large value */
-    *nreadp = 0;
-    failf(data, "read function returned funny value");
-    return CURLE_READ_ERROR;
-  }
-
-#ifndef CURL_DISABLE_HTTP
-  if(!data->req.forbidchunk && data->req.upload_chunky) {
-    /* if chunked Transfer-Encoding
-     *    build chunk:
-     *
-     *        <HEX SIZE> CRLF
-     *        <DATA> CRLF
-     */
-    /* On non-ASCII platforms the <DATA> may or may not be
-       translated based on state.prefer_ascii while the protocol
-       portion must always be translated to the network encoding.
-       To further complicate matters, line end conversion might be
-       done later on, so we need to prevent CRLFs from becoming
-       CRCRLFs if that's the case.  To do this we use bare LFs
-       here, knowing they'll become CRLFs later on.
-     */
-
-    bool added_crlf = FALSE;
-    int hexlen = 0;
-    const char *endofline_native;
-    const char *endofline_network;
-
-    if(
-#ifdef CURL_DO_LINEEND_CONV
-       (data->state.prefer_ascii) ||
-#endif
-       (data->set.crlf)) {
-      /* \n will become \r\n later on */
-      endofline_native  = "\n";
-      endofline_network = "\x0a";
-    }
-    else {
-      endofline_native  = "\r\n";
-      endofline_network = "\x0d\x0a";
-    }
-
-    /* if we're not handling trailing data, proceed as usual */
-    if(data->state.trailers_state != TRAILERS_SENDING) {
-      char hexbuffer[11] = "";
-      hexlen = msnprintf(hexbuffer, sizeof(hexbuffer),
-                         "%zx%s", nread, endofline_native);
-
-      /* move buffer pointer */
-      data->req.upload_fromhere -= hexlen;
-      nread += hexlen;
-
-      /* copy the prefix to the buffer, leaving out the NUL */
-      memcpy(data->req.upload_fromhere, hexbuffer, hexlen);
-
-      /* always append ASCII CRLF to the data unless
-         we have a valid trailer callback */
-      if((nread-hexlen) == 0 &&
-          data->set.trailer_callback != NULL &&
-          data->state.trailers_state == TRAILERS_NONE) {
-        data->state.trailers_state = TRAILERS_INITIALIZED;
-      }
-      else {
-        memcpy(data->req.upload_fromhere + nread,
-               endofline_network,
-               strlen(endofline_network));
-        added_crlf = TRUE;
-      }
-    }
-
-    if(data->state.trailers_state == TRAILERS_SENDING &&
-       !trailers_left(data)) {
-      Curl_dyn_free(&data->state.trailers_buf);
-      data->state.trailers_state = TRAILERS_DONE;
-      data->set.trailer_data = NULL;
-      data->set.trailer_callback = NULL;
-      /* mark the transfer as done */
-      data->req.upload_done = TRUE;
-      infof(data, "Signaling end of chunked upload after trailers.");
-    }
-    else
-      if((nread - hexlen) == 0 &&
-         data->state.trailers_state != TRAILERS_INITIALIZED) {
-        /* mark this as done once this chunk is transferred */
-        data->req.upload_done = TRUE;
-        infof(data,
-              "Signaling end of chunked upload via terminating chunk.");
-      }
-
-    if(added_crlf)
-      nread += strlen(endofline_network); /* for the added end of line */
-  }
-#endif
-
-  *nreadp = nread;
-
-  return CURLE_OK;
+  result = Curl_client_read(data, buf, len, pnread, &eos);
+  DEBUGF(infof(data, "Curl_fillreadbuffer(len=%zu) -> %d, %zu, %d",
+         len, result, *pnread, eos));
+  return result;
 }
 
 static int data_pending(struct Curl_easy *data)
@@ -616,11 +385,9 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
                                  struct connectdata *conn,
                                  int *didwhat)
 {
-  ssize_t i, si;
   size_t bytes_written;
   CURLcode result;
   ssize_t nread; /* number of bytes read */
-  bool sending_http_headers = FALSE;
   struct SingleRequest *k = &data->req;
 
   *didwhat |= KEEP_SEND;
@@ -661,10 +428,8 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
         /* HTTP pollution, this should be written nicer to become more
            protocol agnostic. */
         size_t fillcount;
-        struct HTTP *http = k->p.http;
 
-        if((k->exp100 == EXP100_SENDING_REQUEST) &&
-           (http->sending == HTTPSEND_BODY)) {
+        if(k->exp100 == EXP100_SENDING_REQUEST) {
           /* If this call is to send body data, we must take some action:
              We have sent off the full HTTP 1.1 request, and we shall now
              go into the Expect: 100 state and await such a header */
@@ -675,15 +440,6 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
           /* set a timeout for the multi interface */
           Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);
           break;
-        }
-
-        if(conn->handler->protocol&(PROTO_FAMILY_HTTP|CURLPROTO_RTSP)) {
-          if(http->sending == HTTPSEND_REQUEST)
-            /* We're sending the HTTP request headers, not the data.
-               Remember that so we don't change the line endings. */
-            sending_http_headers = TRUE;
-          else
-            sending_http_headers = FALSE;
         }
 
         k->upload_fromhere += offset;
@@ -711,59 +467,6 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
 
       /* store number of bytes available for upload */
       k->upload_present = nread;
-
-      /* convert LF to CRLF if so asked */
-      if((!sending_http_headers) && (
-#ifdef CURL_DO_LINEEND_CONV
-         /* always convert if we're FTPing in ASCII mode */
-         (data->state.prefer_ascii) ||
-#endif
-         (data->set.crlf))) {
-        /* Do we need to allocate a scratch buffer? */
-        if(!data->state.scratch) {
-          data->state.scratch = malloc(2 * data->set.upload_buffer_size);
-          if(!data->state.scratch) {
-            failf(data, "Failed to alloc scratch buffer");
-
-            return CURLE_OUT_OF_MEMORY;
-          }
-        }
-
-        /*
-         * ASCII/EBCDIC Note: This is presumably a text (not binary)
-         * transfer so the data should already be in ASCII.
-         * That means the hex values for ASCII CR (0x0d) & LF (0x0a)
-         * must be used instead of the escape sequences \r & \n.
-         */
-        if(offset)
-          memcpy(data->state.scratch, k->upload_fromhere, offset);
-        for(i = offset, si = offset; i < nread; i++, si++) {
-          if(k->upload_fromhere[i] == 0x0a) {
-            data->state.scratch[si++] = 0x0d;
-            data->state.scratch[si] = 0x0a;
-            if(!data->set.crlf) {
-              /* we're here only because FTP is in ASCII mode...
-                 bump infilesize for the LF we just added */
-              if(data->state.infilesize != -1)
-                data->state.infilesize++;
-            }
-          }
-          else
-            data->state.scratch[si] = k->upload_fromhere[i];
-        }
-
-        if(si != nread) {
-          /* only perform the special operation if we really did replace
-             anything */
-          nread = si;
-
-          /* upload from the new (replaced) buffer instead */
-          k->upload_fromhere = data->state.scratch;
-
-          /* set the new amount too */
-          k->upload_present = nread;
-        }
-      }
 
 #ifndef CURL_DISABLE_SMTP
       if(conn->handler->protocol & PROTO_FAMILY_SMTP) {
@@ -1014,7 +717,6 @@ CURLcode Curl_readwrite(struct Curl_easy *data,
      * The transfer has been performed. Just make some general checks before
      * returning.
      */
-
     if(!(data->req.no_body) && (k->size != -1) &&
        (k->bytecount != k->size) &&
 #ifdef CURL_DO_LINEEND_CONV
@@ -1611,7 +1313,6 @@ void Curl_xfer_setup(
 {
   struct SingleRequest *k = &data->req;
   struct connectdata *conn = data->conn;
-  struct HTTP *http = data->req.p.http;
   bool want_send = Curl_req_want_send(data);
 
   DEBUGASSERT(conn != NULL);
@@ -1664,8 +1365,7 @@ void Curl_xfer_setup(
          state info where we wait for the 100-return code
       */
       if((data->state.expect100header) &&
-         (conn->handler->protocol&PROTO_FAMILY_HTTP) &&
-         (http->sending == HTTPSEND_BODY)) {
+         (conn->handler->protocol&PROTO_FAMILY_HTTP)) {
         /* wait with write until we either got 100-continue or a timeout */
         k->exp100 = EXP100_AWAITING_CONTINUE;
         k->start100 = Curl_now();

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -397,8 +397,8 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
        k->upload_present < curl_upload_refill_watermark(data) &&
        !k->upload_chunky &&/*(variable sized chunked header; append not safe)*/
        !k->upload_done &&  /*!(k->upload_done once k->upload_present sent)*/
-       !(k->writebytecount + (curl_off_t)k->upload_present -
-         (curl_off_t)k->pendingheader == data->state.infilesize)) {
+       !(k->writebytecount + (curl_off_t)k->upload_present ==
+         data->state.infilesize)) {
       offset = k->upload_present;
     }
 
@@ -489,17 +489,7 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
     }
 #endif
 
-    if(k->pendingheader) {
-      /* parts of what was sent was header */
-      size_t n = CURLMIN(k->pendingheader, bytes_written);
-      /* show the data before we change the pointer upload_fromhere */
-      Curl_debug(data, CURLINFO_HEADER_OUT, k->upload_fromhere, n);
-      k->pendingheader -= n;
-      nbody = bytes_written - n; /* size of the written body part */
-    }
-    else
-      nbody = bytes_written;
-
+    nbody = bytes_written;
     if(nbody) {
       /* show the data before we change the pointer upload_fromhere */
       Curl_debug(data, CURLINFO_DATA_OUT,

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -778,9 +778,6 @@ static CURLcode readwrite_upload(struct Curl_easy *data,
          that instead of reading more data */
     }
 
-    if(!Curl_bufq_is_empty(&k->sendbuf)) {
-      DEBUGASSERT(0);
-    }
     /* write to socket (send away data) */
     result = Curl_xfer_send(data,
                             k->upload_fromhere, /* buffer pointer */

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -48,8 +48,6 @@ CURLcode Curl_follow(struct Curl_easy *data, char *newurl,
 CURLcode Curl_readwrite(struct Curl_easy *data, bool *done);
 int Curl_single_getsock(struct Curl_easy *data,
                         struct connectdata *conn, curl_socket_t *socks);
-CURLcode Curl_fillreadbuffer(struct Curl_easy *data, size_t bytes,
-                             size_t *nreadp);
 CURLcode Curl_retry_request(struct Curl_easy *data, char **url);
 bool Curl_meets_timecondition(struct Curl_easy *data, time_t timeofdoc);
 CURLcode Curl_get_upload_buffer(struct Curl_easy *data);

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -108,14 +108,4 @@ CURLcode Curl_xfer_recv(struct Curl_easy *data,
                         char *buf, size_t blen,
                         ssize_t *pnrcvd);
 
-/**
- * Send data on the socket/connection filter designated
- * for transfer's outgoing data. If the data could not be
- * sent immediately, it will be buffered.
- * Will never return CURLE_AGAIN.
- */
-CURLcode Curl_xfer_send_buffered(struct Curl_easy *data,
-                                 const void *buf, size_t blen);
-
-
 #endif /* HEADER_CURL_TRANSFER_H */

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -108,4 +108,14 @@ CURLcode Curl_xfer_recv(struct Curl_easy *data,
                         char *buf, size_t blen,
                         ssize_t *pnrcvd);
 
+/**
+ * Send data on the socket/connection filter designated
+ * for transfer's outgoing data. If the data could not be
+ * sent immediately, it will be buffered.
+ * Will never return CURLE_AGAIN.
+ */
+CURLcode Curl_xfer_send_buffered(struct Curl_easy *data,
+                                 const void *buf, size_t blen);
+
+
 #endif /* HEADER_CURL_TRANSFER_H */

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -44,6 +44,8 @@ my $file = $ARGV[0];
 my %wl = (
     'curlx_uztoso' => 'cmdline tool use',
     'Curl_xfer_write_resp' => 'internal api',
+    'Curl_creader_def_init' => 'internal api',
+    'Curl_creader_def_close' => 'internal api',
     );
 
 my %api = (

--- a/tests/data/test513
+++ b/tests/data/test513
@@ -34,14 +34,6 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <protocol>
-%if !hyper
-POST /%TESTNUMBER HTTP/1.1
-Host: %HOSTIP:%HTTPPORT
-Accept: */*
-Content-Length: 1
-Content-Type: application/x-www-form-urlencoded
-
-%endif
 </protocol>
 # 42 - aborted by callback
 <errorcode>

--- a/tests/data/test579
+++ b/tests/data/test579
@@ -77,6 +77,8 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER %LOGDIR/ip%TESTNUMBER
 <verify>
 <file name="%LOGDIR/ip%TESTNUMBER">
 Progress callback called with UL 0 out of 0
+Progress callback called with UL 5 out of 0
+Progress callback called with UL 0 out of 0
 Progress callback called with UL 8 out of 0
 Progress callback called with UL 16 out of 0
 Progress callback called with UL 26 out of 0

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -103,9 +103,9 @@ class TestAuth:
     def test_14_05_basic_large_pw(self, env: Env, httpd, nghttpx, repeat, proto):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
-        if proto == 'h3' and env.curl_uses_lib('quiche'):
+        if proto == 'h3' and not env.curl_uses_lib('ngtcp2'):
             # See <https://github.com/cloudflare/quiche/issues/1573>
-            pytest.skip("quiche has problems with large requests")
+            pytest.skip("quiche/openssl-quic have problems with large requests")
         # just large enough that nghttp2 will submit
         password = 'x' * (47 * 1024)
         fdata = os.path.join(env.gen_dir, 'data-10m')

--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -47,7 +47,7 @@ static size_t readcallback(char  *ptr,
   }
   (*counter)++; /* bump */
 
-  if(size * nmemb > strlen(UPLOADTHIS)) {
+  if(size * nmemb >= strlen(UPLOADTHIS)) {
     fprintf(stderr, "READ!\n");
     strcpy(ptr, UPLOADTHIS);
     return strlen(UPLOADTHIS);

--- a/tests/libtest/lib555.c
+++ b/tests/libtest/lib555.c
@@ -54,7 +54,7 @@ static size_t readcallback(char  *ptr,
   }
   (*counter)++; /* bump */
 
-  if(size * nmemb > strlen(uploadthis)) {
+  if(size * nmemb >= strlen(uploadthis)) {
     fprintf(stderr, "READ!\n");
     strcpy(ptr, uploadthis);
     return strlen(uploadthis);


### PR DESCRIPTION
This is the second part of reworking curl's "send" or "upload" handling. The changes will arrive in a series of PRs, based on top of each other, similar to the client writer ones. For part 0 see #12963, part 1 is #12964.

### Client Reader

Added as documented [in CLIENT-READER.md](https://github.com/curl/curl/blob/5b1f31dfbab8aef467c419c68aa06dc738cb75d4/docs/CLIENT-READERS.md).

- old `Curl_buffer_send()` completely replaced by new `Curl_req_send()`
- old `Curl_fillreadbuffer()` replaced with `Curl_client_read()`
- HTTP chunked uploads are now formatted in a client reader added when needed.
- FTP line-end conversions are done in a client reader added when needed.
- when sending requests headers, remaining buffer space is filled with body data for sending in "one go". This is independent of the request body size. Resolves  #12938 as now small and large requests have the same code path.

Changes done to test cases:
- test513: now fails before sending request headers as this initial "client read" triggers the setup fault. Behaves now the same as in hyper build
- test547, test555, test1620: fix the length check in the lib code to only fail for reads *smaller* than expected. This was a bug in the test code that never triggered in the old implementation.
