### PR TITLE
fix multi_sock handling of select_bits

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3243,7 +3243,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
 
         if(data->conn && !(data->conn->handler->flags & PROTOPT_DIRLOCK))
           /* set socket event bitmask if they're not locked */
-          data->state.select_bits = (unsigned char)ev_bitmask;
+          data->state.select_bits |= (unsigned char)ev_bitmask;
 
         Curl_expire(data, 0, EXPIRE_RUN_NOW);
       }


### PR DESCRIPTION
- refs #12971
- add the event bitmask to data->state.select_bits instead of overwriting them. They are cleared again on use.