### PR TITLE
fopen: fix narrowing conversion warning on 32-bit Android

### DIFF
--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -129,7 +129,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   }
 
   result = CURLE_WRITE_ERROR;
-  fd = open(tempstore, O_WRONLY | O_CREAT | O_EXCL, 0600|sb.st_mode);
+  fd = open(tempstore, O_WRONLY | O_CREAT | O_EXCL, (mode_t)(0600|sb.st_mode));
   if(fd == -1)
     goto fail;
 


### PR DESCRIPTION
This was fixed in commit 06dc599405f, but came back in commit 03cb1ff4d62.

When building for 32-bit ARM or x86 Android, `st_mode` is defined as `unsigned int` instead of `mode_t`, resulting in a -Wimplicit-int-conversion clang warning because `mode_t` is `unsigned short`. Add a cast to silence the warning.

Ref: https://android.googlesource.com/platform/bionic/+/refs/tags/ndk-r25c/libc/include/sys/stat.h#86