### PR TITLE
examples/websocket.c: check for CURLE_AGAIN on recv_pong()

### DIFF
--- a/docs/examples/websocket.c
+++ b/docs/examples/websocket.c
@@ -36,6 +36,13 @@
  */
 #ifdef __GNUC__
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#ifdef __DJGPP__
+#pragma GCC diagnostic ignored "-Warith-conversion"
+#endif
+#elif defined(_MSC_VER)
+#pragma warning(disable:4127)  /* conditional expression is constant */
 #endif
 
 /* Auxiliary function that waits on the socket. */


### PR DESCRIPTION
Description
-----------
The example file [docs/examples/websocket.c] does not work out of the box, because the recv_pong() function does not consider that the `curl_ws_recv()` function might return CURLE_AGAIN if there is no data to read, causing the program to terminate prematurely.

This commit addresses this by using `select(2)` to make receiving pong blocking, and thus being able to continue with the main loop.

This also occurs in the example file [sendrecv.c], which also makes use of select(2) for sending and receiving data, which I based on for this commit.

[docs/examples/websocket.c]: https://github.com/curl/curl/blob/master/docs/examples/websocket.c
[sendrecv.c]: https://github.com/curl/curl/blob/master/docs/examples/sendrecv.c