### PR TITLE
strtoofft: fix the overflow check

### DIFF
--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -79,11 +79,10 @@ static int get_char(char c, int base);
 static curl_off_t strtooff(const char *nptr, char **endptr, int base)
 {
   char *end;
-  int is_negative = 0;
-  int overflow;
+  bool is_negative = FALSE;
+  bool overflow = FALSE;
   int i;
   curl_off_t value = 0;
-  curl_off_t newval;
 
   /* Skip leading whitespace. */
   end = (char *)nptr;
@@ -93,7 +92,7 @@ static curl_off_t strtooff(const char *nptr, char **endptr, int base)
 
   /* Handle the sign, if any. */
   if(end[0] == '-') {
-    is_negative = 1;
+    is_negative = TRUE;
     end++;
   }
   else if(end[0] == '+') {
@@ -129,19 +128,15 @@ static curl_off_t strtooff(const char *nptr, char **endptr, int base)
   }
 
   /* Loop handling digits. */
-  value = 0;
-  overflow = 0;
   for(i = get_char(end[0], base);
       i != -1;
       end++, i = get_char(end[0], base)) {
-    newval = base * value + i;
-    if(newval < value) {
-      /* We've overflowed. */
-      overflow = 1;
+
+    if(value > CURL_OFF_T_MAX / base - i) {
+      overflow = TRUE;
       break;
     }
-    else
-      value = newval;
+    value = base * value + i;
   }
 
   if(!overflow) {

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -132,7 +132,7 @@ static curl_off_t strtooff(const char *nptr, char **endptr, int base)
       i != -1;
       end++, i = get_char(end[0], base)) {
 
-    if(value > CURL_OFF_T_MAX / base - i) {
+    if(value > (CURL_OFF_T_MAX - i) / base) {
       overflow = TRUE;
       break;
     }


### PR DESCRIPTION
... to not rely on wrapping, since it is an undefined behavior that is not what always might happen.

Reported-by: vulnerabilityspotter on hackerone