### PR TITLE
Add back check for fork function, needed for NTLM_WB feature

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3772,6 +3772,7 @@ AC_CHECK_FUNCS([\
   _fseeki64 \
   arc4random \
   fnmatch \
+  fork \
   fseeko \
   geteuid \
   getpass_r \


### PR DESCRIPTION
With commit 592107fa16781db47e61618e503bac2e2ea68c9e (cfr "configure: require fork for NTLM-WB") a check in m4/curl-confopts.m4 was added for fork function; however fork presence check was removed in commit 2ba804942fda50bbd385c743309a7ec8aca2cf47 (cfr "configure: remove unused checks") causing NTLM_WB to be disabled.
Reinstate the check for fork function to solve NTLM_WB detection.