### PR TITLE
lib: initialize output pointers to NULL before calling strto[ff,l,ul]

### DIFF
--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -212,7 +212,7 @@ static int get_char(char c, int base)
 CURLofft curlx_strtoofft(const char *str, char **endp, int base,
                          curl_off_t *num)
 {
-  char *end;
+  char *end = NULL;
   curl_off_t number;
   errno = 0;
   *num = 0; /* clear by default */

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -531,7 +531,7 @@ UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,
     portptr = strchr(hostname, ':');
 
   if(portptr) {
-    char *rest;
+    char *rest = NULL;
     long port;
     size_t keep = portptr - hostname;
 
@@ -681,7 +681,7 @@ static int ipv4_normalize(struct dynbuf *host)
     return HOST_IPV6;
 
   while(!done) {
-    char *endp;
+    char *endp = NULL;
     unsigned long l;
     if(!ISDIGIT(*c))
       /* most importantly this doesn't allow a leading plus or minus */


### PR DESCRIPTION
In order to make MSAN happy:

    ==2200945==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x596f3b3ed246 in curlx_strtoofft [...]/libcurl/src/lib/strtoofft.c:239:11
    #1 0x596f3b402156 in Curl_httpchunk_read [...]/libcurl/src/lib/http_chunks.c:149:12
    #2 0x596f3b348550 in readwrite_data [...]/libcurl/src/lib/transfer.c:607:11
    [...]

    ==2202041==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x5a3fab66a72a in Curl_parse_port [...]/libcurl/src/lib/urlapi.c:547:8
    #1 0x5a3fab650645 in parse_authority [...]/libcurl/src/lib/urlapi.c:796:12
    #2 0x5a3fab6740f6 in parseurl [...]/libcurl/src/lib/urlapi.c:1176:16
    #3 0x5a3fab664fc5 in parseurl_and_replace [...]/libcurl/src/lib/urlapi.c:1342:12
    [...]

    ==2202320==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x569076a0d6b0 in ipv4_normalize [...]/libcurl/src/lib/urlapi.c:683:12
    #1 0x5690769f2820 in parse_authority [...]/libcurl/src/lib/urlapi.c:803:10
    #2 0x569076a160f6 in parseurl [...]/libcurl/src/lib/urlapi.c:1176:16
    #3 0x569076a06fc5 in parseurl_and_replace [...]/libcurl/src/lib/urlapi.c:1342:12
    [...]