### PR TITLE
curldown: Fix email address in Copyright

### DIFF
--- a/docs/CURLDOWN.md
+++ b/docs/CURLDOWN.md
@@ -62,7 +62,7 @@ the nroff format does not carry a distinction.
 Each curldown starts with a header with meta-data:
 
     ---
-    c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+    c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
     SPDX-License-Identifier: curl
     Title: CURLOPT_AWS_SIGV4
     Section: 3

--- a/docs/curl-config.md
+++ b/docs/curl-config.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl-config
 Section: 1

--- a/docs/libcurl/curl_easy_cleanup.md
+++ b/docs/libcurl/curl_easy_cleanup.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_cleanup
 Section: 3

--- a/docs/libcurl/curl_easy_duphandle.md
+++ b/docs/libcurl/curl_easy_duphandle.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_duphandle
 Section: 3

--- a/docs/libcurl/curl_easy_escape.md
+++ b/docs/libcurl/curl_easy_escape.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_escape
 Section: 3

--- a/docs/libcurl/curl_easy_getinfo.md
+++ b/docs/libcurl/curl_easy_getinfo.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_getinfo
 Section: 3

--- a/docs/libcurl/curl_easy_header.md
+++ b/docs/libcurl/curl_easy_header.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_header
 Section: 3

--- a/docs/libcurl/curl_easy_init.md
+++ b/docs/libcurl/curl_easy_init.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_init
 Section: 3

--- a/docs/libcurl/curl_easy_nextheader.md
+++ b/docs/libcurl/curl_easy_nextheader.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_nextheader
 Section: 3

--- a/docs/libcurl/curl_easy_option_by_id.md
+++ b/docs/libcurl/curl_easy_option_by_id.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_option_by_id
 Section: 3

--- a/docs/libcurl/curl_easy_option_by_name.md
+++ b/docs/libcurl/curl_easy_option_by_name.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_option_by_name
 Section: 3

--- a/docs/libcurl/curl_easy_option_next.md
+++ b/docs/libcurl/curl_easy_option_next.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_option_next
 Section: 3

--- a/docs/libcurl/curl_easy_pause.md
+++ b/docs/libcurl/curl_easy_pause.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_pause
 Section: 3

--- a/docs/libcurl/curl_easy_perform.md
+++ b/docs/libcurl/curl_easy_perform.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_perform
 Section: 3

--- a/docs/libcurl/curl_easy_recv.md
+++ b/docs/libcurl/curl_easy_recv.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_recv
 Section: 3

--- a/docs/libcurl/curl_easy_reset.md
+++ b/docs/libcurl/curl_easy_reset.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_reset
 Section: 3

--- a/docs/libcurl/curl_easy_send.md
+++ b/docs/libcurl/curl_easy_send.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_send
 Section: 3

--- a/docs/libcurl/curl_easy_setopt.md
+++ b/docs/libcurl/curl_easy_setopt.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_setopt
 Section: 3

--- a/docs/libcurl/curl_easy_strerror.md
+++ b/docs/libcurl/curl_easy_strerror.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_strerror
 Section: 3

--- a/docs/libcurl/curl_easy_unescape.md
+++ b/docs/libcurl/curl_easy_unescape.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_unescape
 Section: 3

--- a/docs/libcurl/curl_easy_upkeep.md
+++ b/docs/libcurl/curl_easy_upkeep.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_easy_upkeep
 Section: 3

--- a/docs/libcurl/curl_escape.md
+++ b/docs/libcurl/curl_escape.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_escape
 Section: 3

--- a/docs/libcurl/curl_formadd.md
+++ b/docs/libcurl/curl_formadd.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_formadd
 Section: 3

--- a/docs/libcurl/curl_formfree.md
+++ b/docs/libcurl/curl_formfree.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_formfree
 Section: 3

--- a/docs/libcurl/curl_formget.md
+++ b/docs/libcurl/curl_formget.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_formget
 Section: 3

--- a/docs/libcurl/curl_free.md
+++ b/docs/libcurl/curl_free.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_free
 Section: 3

--- a/docs/libcurl/curl_getdate.md
+++ b/docs/libcurl/curl_getdate.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_getdate
 Section: 3

--- a/docs/libcurl/curl_getenv.md
+++ b/docs/libcurl/curl_getenv.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_getenv
 Section: 3

--- a/docs/libcurl/curl_global_cleanup.md
+++ b/docs/libcurl/curl_global_cleanup.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_global_cleanup
 Section: 3

--- a/docs/libcurl/curl_global_init.md
+++ b/docs/libcurl/curl_global_init.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_global_init
 Section: 3

--- a/docs/libcurl/curl_global_init_mem.md
+++ b/docs/libcurl/curl_global_init_mem.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_global_init_mem
 Section: 3

--- a/docs/libcurl/curl_global_sslset.md
+++ b/docs/libcurl/curl_global_sslset.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_global_sslset
 Section: 3

--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_global_trace
 Section: 3

--- a/docs/libcurl/curl_mime_addpart.md
+++ b/docs/libcurl/curl_mime_addpart.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_addpart
 Section: 3

--- a/docs/libcurl/curl_mime_data.md
+++ b/docs/libcurl/curl_mime_data.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_data
 Section: 3

--- a/docs/libcurl/curl_mime_data_cb.md
+++ b/docs/libcurl/curl_mime_data_cb.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_data_cb
 Section: 3

--- a/docs/libcurl/curl_mime_encoder.md
+++ b/docs/libcurl/curl_mime_encoder.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_encoder
 Section: 3

--- a/docs/libcurl/curl_mime_filedata.md
+++ b/docs/libcurl/curl_mime_filedata.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_filedata
 Section: 3

--- a/docs/libcurl/curl_mime_filename.md
+++ b/docs/libcurl/curl_mime_filename.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_filename
 Section: 3

--- a/docs/libcurl/curl_mime_free.md
+++ b/docs/libcurl/curl_mime_free.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_free
 Section: 3

--- a/docs/libcurl/curl_mime_headers.md
+++ b/docs/libcurl/curl_mime_headers.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_headers
 Section: 3

--- a/docs/libcurl/curl_mime_init.md
+++ b/docs/libcurl/curl_mime_init.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_init
 Section: 3

--- a/docs/libcurl/curl_mime_name.md
+++ b/docs/libcurl/curl_mime_name.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_name
 Section: 3

--- a/docs/libcurl/curl_mime_subparts.md
+++ b/docs/libcurl/curl_mime_subparts.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_subparts
 Section: 3

--- a/docs/libcurl/curl_mime_type.md
+++ b/docs/libcurl/curl_mime_type.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_mime_type
 Section: 3

--- a/docs/libcurl/curl_mprintf.md
+++ b/docs/libcurl/curl_mprintf.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_printf
 Section: 3

--- a/docs/libcurl/curl_multi_add_handle.md
+++ b/docs/libcurl/curl_multi_add_handle.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_add_handle
 Section: 3

--- a/docs/libcurl/curl_multi_assign.md
+++ b/docs/libcurl/curl_multi_assign.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_assign
 Section: 3

--- a/docs/libcurl/curl_multi_cleanup.md
+++ b/docs/libcurl/curl_multi_cleanup.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_cleanup
 Section: 3

--- a/docs/libcurl/curl_multi_fdset.md
+++ b/docs/libcurl/curl_multi_fdset.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_fdset
 Section: 3

--- a/docs/libcurl/curl_multi_get_handles.md
+++ b/docs/libcurl/curl_multi_get_handles.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_get_handles
 Section: 3

--- a/docs/libcurl/curl_multi_info_read.md
+++ b/docs/libcurl/curl_multi_info_read.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_info_read
 Section: 3

--- a/docs/libcurl/curl_multi_init.md
+++ b/docs/libcurl/curl_multi_init.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_init
 Section: 3

--- a/docs/libcurl/curl_multi_perform.md
+++ b/docs/libcurl/curl_multi_perform.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_perform
 Section: 3

--- a/docs/libcurl/curl_multi_poll.md
+++ b/docs/libcurl/curl_multi_poll.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_poll
 Section: 3

--- a/docs/libcurl/curl_multi_remove_handle.md
+++ b/docs/libcurl/curl_multi_remove_handle.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_remove_handle
 Section: 3

--- a/docs/libcurl/curl_multi_setopt.md
+++ b/docs/libcurl/curl_multi_setopt.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_setopt
 Section: 3

--- a/docs/libcurl/curl_multi_socket.md
+++ b/docs/libcurl/curl_multi_socket.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_socket
 Section: 3

--- a/docs/libcurl/curl_multi_socket_action.md
+++ b/docs/libcurl/curl_multi_socket_action.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_socket_action
 Section: 3

--- a/docs/libcurl/curl_multi_socket_all.md
+++ b/docs/libcurl/curl_multi_socket_all.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_socket
 Section: 3

--- a/docs/libcurl/curl_multi_strerror.md
+++ b/docs/libcurl/curl_multi_strerror.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_strerror
 Section: 3

--- a/docs/libcurl/curl_multi_timeout.md
+++ b/docs/libcurl/curl_multi_timeout.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_timeout
 Section: 3

--- a/docs/libcurl/curl_multi_wait.md
+++ b/docs/libcurl/curl_multi_wait.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_wait
 Section: 3

--- a/docs/libcurl/curl_multi_wakeup.md
+++ b/docs/libcurl/curl_multi_wakeup.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_multi_wakeup
 Section: 3

--- a/docs/libcurl/curl_pushheader_byname.md
+++ b/docs/libcurl/curl_pushheader_byname.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_pushheader_byname
 Section: 3

--- a/docs/libcurl/curl_pushheader_bynum.md
+++ b/docs/libcurl/curl_pushheader_bynum.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_pushheader_bynum
 Section: 3

--- a/docs/libcurl/curl_share_cleanup.md
+++ b/docs/libcurl/curl_share_cleanup.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_share_cleanup
 Section: 3

--- a/docs/libcurl/curl_share_init.md
+++ b/docs/libcurl/curl_share_init.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_share_init
 Section: 3

--- a/docs/libcurl/curl_share_setopt.md
+++ b/docs/libcurl/curl_share_setopt.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_share_setopt
 Section: 3

--- a/docs/libcurl/curl_share_strerror.md
+++ b/docs/libcurl/curl_share_strerror.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_share_strerror
 Section: 3

--- a/docs/libcurl/curl_slist_append.md
+++ b/docs/libcurl/curl_slist_append.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_slist_append
 Section: 3

--- a/docs/libcurl/curl_slist_free_all.md
+++ b/docs/libcurl/curl_slist_free_all.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_slist_free_all
 Section: 3

--- a/docs/libcurl/curl_strequal.md
+++ b/docs/libcurl/curl_strequal.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_strequal
 Section: 3

--- a/docs/libcurl/curl_strnequal.md
+++ b/docs/libcurl/curl_strnequal.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_strequal
 Section: 3

--- a/docs/libcurl/curl_unescape.md
+++ b/docs/libcurl/curl_unescape.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_unescape
 Section: 3

--- a/docs/libcurl/curl_url.md
+++ b/docs/libcurl/curl_url.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_url
 Section: 3

--- a/docs/libcurl/curl_url_cleanup.md
+++ b/docs/libcurl/curl_url_cleanup.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_url_cleanup
 Section: 3

--- a/docs/libcurl/curl_url_dup.md
+++ b/docs/libcurl/curl_url_dup.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_url_dup
 Section: 3

--- a/docs/libcurl/curl_url_get.md
+++ b/docs/libcurl/curl_url_get.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_url_get
 Section: 3

--- a/docs/libcurl/curl_url_set.md
+++ b/docs/libcurl/curl_url_set.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_url_set
 Section: 3

--- a/docs/libcurl/curl_url_strerror.md
+++ b/docs/libcurl/curl_url_strerror.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_url_strerror
 Section: 3

--- a/docs/libcurl/curl_version.md
+++ b/docs/libcurl/curl_version.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_version
 Section: 3

--- a/docs/libcurl/curl_version_info.md
+++ b/docs/libcurl/curl_version_info.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_version_info
 Section: 3

--- a/docs/libcurl/curl_ws_meta.md
+++ b/docs/libcurl/curl_ws_meta.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_ws_meta
 Section: 3

--- a/docs/libcurl/curl_ws_recv.md
+++ b/docs/libcurl/curl_ws_recv.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_ws_recv
 Section: 3

--- a/docs/libcurl/curl_ws_send.md
+++ b/docs/libcurl/curl_ws_send.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: curl_ws_send
 Section: 3

--- a/docs/libcurl/libcurl-easy.md
+++ b/docs/libcurl/libcurl-easy.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl
 Section: 3

--- a/docs/libcurl/libcurl-env-dbg.md
+++ b/docs/libcurl/libcurl-env-dbg.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl-env-dbg
 Section: 3

--- a/docs/libcurl/libcurl-env.md
+++ b/docs/libcurl/libcurl-env.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl-env
 Section: 3

--- a/docs/libcurl/libcurl-errors.md
+++ b/docs/libcurl/libcurl-errors.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl-errors
 Section: 3

--- a/docs/libcurl/libcurl-multi.md
+++ b/docs/libcurl/libcurl-multi.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl-multi
 Section: 3

--- a/docs/libcurl/libcurl-security.md
+++ b/docs/libcurl/libcurl-security.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl-security
 Section: 3

--- a/docs/libcurl/libcurl-share.md
+++ b/docs/libcurl/libcurl-share.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl-share
 Section: 3

--- a/docs/libcurl/libcurl-thread.md
+++ b/docs/libcurl/libcurl-thread.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl-thread
 Section: 3

--- a/docs/libcurl/libcurl-tutorial.md
+++ b/docs/libcurl/libcurl-tutorial.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl-tutorial
 Section: 3

--- a/docs/libcurl/libcurl-url.md
+++ b/docs/libcurl/libcurl-url.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl
 Section: 3

--- a/docs/libcurl/libcurl-ws.md
+++ b/docs/libcurl/libcurl-ws.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl
 Section: 3

--- a/docs/libcurl/libcurl.md
+++ b/docs/libcurl/libcurl.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: libcurl
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_ACTIVESOCKET
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_APPCONNECT_TIME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_APPCONNECT_TIME_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CAINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CAINFO.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CAINFO
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CAPATH.md
+++ b/docs/libcurl/opts/CURLINFO_CAPATH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CAPATH
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CERTINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CERTINFO
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CONDITION_UNMET
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CONNECT_TIME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CONNECT_TIME_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CONN_ID.md
+++ b/docs/libcurl/opts/CURLINFO_CONN_ID.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CONN_ID
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CONTENT_LENGTH_DOWNLOAD
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CONTENT_LENGTH_DOWNLOAD_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CONTENT_LENGTH_UPLOAD
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CONTENT_LENGTH_UPLOAD_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_CONTENT_TYPE
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_COOKIELIST.md
+++ b/docs/libcurl/opts/CURLINFO_COOKIELIST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_COOKIELIST
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.md
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_EFFECTIVE_METHOD
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.md
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_EFFECTIVE_URL
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_FILETIME.md
+++ b/docs/libcurl/opts/CURLINFO_FILETIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_FILETIME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_FILETIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_FILETIME_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_FILETIME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.md
+++ b/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_FTP_ENTRY_PATH
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_HEADER_SIZE
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.md
+++ b/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_HTTPAUTH_AVAIL
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.md
+++ b/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_HTTP_CONNECTCODE
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLINFO_HTTP_VERSION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_HTTP_VERSION
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_LASTSOCKET
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_LOCAL_IP.md
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_IP.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_LOCAL_IP
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_LOCAL_PORT.md
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_PORT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_LOCAL_PORT
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_NAMELOOKUP_TIME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_NAMELOOKUP_TIME_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
+++ b/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_NUM_CONNECTS
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_OS_ERRNO
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_PRETRANSFER_TIME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_PRETRANSFER_TIME_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_IP.md
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_IP.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_PRIMARY_IP
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.md
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_PRIMARY_PORT
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_PRIVATE.md
+++ b/docs/libcurl/opts/CURLINFO_PRIVATE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_PRIVATE
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_PROTOCOL.md
+++ b/docs/libcurl/opts/CURLINFO_PROTOCOL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_PROTOCOL
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.md
+++ b/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_PROXYAUTH_AVAIL
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_PROXY_ERROR.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_ERROR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_PROXY_ERROR
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_PROXY_SSL_VERIFYRESULT
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_QUEUE_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_QUEUE_TIME_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_QUEUE_TIME_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_REDIRECT_COUNT
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_REDIRECT_TIME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_REDIRECT_TIME_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_URL.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_URL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_REDIRECT_URL
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_REFERER.md
+++ b/docs/libcurl/opts/CURLINFO_REFERER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_REFERER
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_REQUEST_SIZE
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.md
+++ b/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_RESPONSE_CODE
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_RETRY_AFTER.md
+++ b/docs/libcurl/opts/CURLINFO_RETRY_AFTER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_RETRY_AFTER
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_RTSP_CLIENT_CSEQ
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_RTSP_CSEQ_RECV
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_RTSP_SERVER_CSEQ
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_RTSP_SESSION_ID
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SCHEME.md
+++ b/docs/libcurl/opts/CURLINFO_SCHEME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SCHEME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SIZE_DOWNLOAD
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SIZE_DOWNLOAD_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SIZE_UPLOAD
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SIZE_UPLOAD_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SPEED_DOWNLOAD
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SPEED_DOWNLOAD_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SPEED_UPLOAD
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SPEED_UPLOAD_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SSL_ENGINES.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_ENGINES.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SSL_ENGINES
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_SSL_VERIFYRESULT
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_STARTTRANSFER_TIME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_STARTTRANSFER_TIME_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_TLS_SESSION
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_TLS_SSL_PTR
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_TOTAL_TIME
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_TOTAL_TIME_T
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_USED_PROXY.md
+++ b/docs/libcurl/opts/CURLINFO_USED_PROXY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_USED_PROXY
 Section: 3

--- a/docs/libcurl/opts/CURLINFO_XFER_ID.md
+++ b/docs/libcurl/opts/CURLINFO_XFER_ID.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLINFO_XFER_ID
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE.md
+++ b/docs/libcurl/opts/CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE.md
+++ b/docs/libcurl/opts/CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_MAXCONNECTS
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_MAX_CONCURRENT_STREAMS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_CONCURRENT_STREAMS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_MAX_CONCURRENT_STREAMS
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_MAX_HOST_CONNECTIONS
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_MAX_PIPELINE_LENGTH.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_PIPELINE_LENGTH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_MAX_PIPELINE_LENGTH
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_MAX_TOTAL_CONNECTIONS
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING.md
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_PIPELINING
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING_SERVER_BL.md
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING_SERVER_BL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_PIPELINING_SERVER_BL
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING_SITE_BL.md
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING_SITE_BL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_PIPELINING_SITE_BL
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_PUSHDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_PUSHDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_PUSHDATA
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_PUSHFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_SOCKETDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_SOCKETDATA
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_SOCKETFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_TIMERDATA
 Section: 3

--- a/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLMOPT_TIMERFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.md
+++ b/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_ABSTRACT_UNIX_SOCKET
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_ACCEPTTIMEOUT_MS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.md
+++ b/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_ACCEPT_ENCODING
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.md
+++ b/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_ADDRESS_SCOPE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_ALTSVC
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_ALTSVC_CTRL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_APPEND.md
+++ b/docs/libcurl/opts/CURLOPT_APPEND.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_APPEND
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_AUTOREFERER.md
+++ b/docs/libcurl/opts/CURLOPT_AUTOREFERER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_AUTOREFERER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_AWS_SIGV4.md
+++ b/docs/libcurl/opts/CURLOPT_AWS_SIGV4.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_AWS_SIGV4
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_BUFFERSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_BUFFERSIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_BUFFERSIZE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CAINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CAINFO
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CAINFO_BLOB
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CAPATH.md
+++ b/docs/libcurl/opts/CURLOPT_CAPATH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CAPATH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CA_CACHE_TIMEOUT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CERTINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CERTINFO.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CERTINFO
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CHUNK_BGN_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_BGN_FUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CHUNK_BGN_FUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CHUNK_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_DATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CHUNK_DATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CHUNK_END_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_END_FUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CHUNK_END_FUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CLOSESOCKETDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CLOSESOCKETFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CONNECTTIMEOUT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CONNECTTIMEOUT_MS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CONNECT_ONLY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CONNECT_TO.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_TO.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CONNECT_TO
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CONV_FROM_NETWORK_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CONV_FROM_NETWORK_FUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CONV_FROM_NETWORK_FUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CONV_FROM_UTF8_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CONV_FROM_UTF8_FUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CONV_FROM_UTF8_FUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CONV_TO_NETWORK_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CONV_TO_NETWORK_FUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CONV_TO_NETWORK_FUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_COOKIE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_COOKIE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_COOKIEFILE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_COOKIEJAR
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_COOKIELIST.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIELIST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_COOKIELIST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_COOKIESESSION.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIESESSION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_COOKIESESSION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.md
+++ b/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_COPYPOSTFIELDS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CRLF.md
+++ b/docs/libcurl/opts/CURLOPT_CRLF.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CRLF
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CRLFILE.md
+++ b/docs/libcurl/opts/CURLOPT_CRLFILE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CRLFILE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CURLU.md
+++ b/docs/libcurl/opts/CURLOPT_CURLU.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CURLU
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_CUSTOMREQUEST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DEBUGDATA.md
+++ b/docs/libcurl/opts/CURLOPT_DEBUGDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DEBUGDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DEBUGFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.md
+++ b/docs/libcurl/opts/CURLOPT_DEFAULT_PROTOCOL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DEFAULT_PROTOCOL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DIRLISTONLY.md
+++ b/docs/libcurl/opts/CURLOPT_DIRLISTONLY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DIRLISTONLY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
+++ b/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DISALLOW_USERNAME_IN_URL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DNS_CACHE_TIMEOUT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DNS_INTERFACE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DNS_LOCAL_IP4
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DNS_LOCAL_IP6
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DNS_SERVERS.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_SERVERS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DNS_SERVERS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DNS_SHUFFLE_ADDRESSES.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_SHUFFLE_ADDRESSES.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DNS_SHUFFLE_ADDRESSES
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DNS_USE_GLOBAL_CACHE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DOH_SSL_VERIFYHOST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DOH_SSL_VERIFYPEER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DOH_SSL_VERIFYSTATUS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_DOH_URL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_EGDSOCKET.md
+++ b/docs/libcurl/opts/CURLOPT_EGDSOCKET.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_EGDSOCKET
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_ERRORBUFFER.md
+++ b/docs/libcurl/opts/CURLOPT_ERRORBUFFER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_ERRORBUFFER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_EXPECT_100_TIMEOUT_MS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FAILONERROR.md
+++ b/docs/libcurl/opts/CURLOPT_FAILONERROR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FAILONERROR
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FILETIME.md
+++ b/docs/libcurl/opts/CURLOPT_FILETIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FILETIME
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FNMATCH_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_FNMATCH_DATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FNMATCH_DATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FNMATCH_FUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.md
+++ b/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FOLLOWLOCATION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
+++ b/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FORBID_REUSE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.md
+++ b/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FRESH_CONNECT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTPPORT.md
+++ b/docs/libcurl/opts/CURLOPT_FTPPORT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTPPORT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTPSSLAUTH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTP_ACCOUNT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTP_ALTERNATIVE_TO_USER.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_ALTERNATIVE_TO_USER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTP_ALTERNATIVE_TO_USER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTP_CREATE_MISSING_DIRS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTP_FILEMETHOD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTP_SKIP_PASV_IP.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SKIP_PASV_IP.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTP_SKIP_PASV_IP
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTP_SSL_CCC
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTP_USE_EPRT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_EPSV.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_EPSV.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTP_USE_EPSV
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_FTP_USE_PRET
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.md
+++ b/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_GSSAPI_DELEGATION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.md
+++ b/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HAPROXYPROTOCOL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HAPROXY_CLIENT_IP.md
+++ b/docs/libcurl/opts/CURLOPT_HAPROXY_CLIENT_IP.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HAPROXY_CLIENT_IP
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HEADER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HEADER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HEADERDATA.md
+++ b/docs/libcurl/opts/CURLOPT_HEADERDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HEADERDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HEADERFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HEADEROPT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HSTS.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HSTS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HSTSREADDATA.md
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HSTSREADDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_HSTSREADFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HSTSREADFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HSTSWRITEDATA.md
+++ b/docs/libcurl/opts/CURLOPT_HSTSWRITEDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HSTSWRITEDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_HSTSWRITEFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HSTSWRITEFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HSTS_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS_CTRL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HSTS_CTRL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTP09_ALLOWED
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTP200ALIASES
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTPAUTH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTPGET.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPGET.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTPGET
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTPHEADER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTPPOST.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPPOST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTPPOST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTPPROXYTUNNEL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTP_CONTENT_DECODING.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_CONTENT_DECODING.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTP_CONTENT_DECODING
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTP_TRANSFER_DECODING.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_TRANSFER_DECODING.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTP_TRANSFER_DECODING
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_HTTP_VERSION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.md
+++ b/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_IGNORE_CONTENT_LENGTH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_INFILESIZE.md
+++ b/docs/libcurl/opts/CURLOPT_INFILESIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_INFILESIZE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_INFILESIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_INFILESIZE_LARGE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_INFILESIZE_LARGE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_INTERFACE.md
+++ b/docs/libcurl/opts/CURLOPT_INTERFACE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_INTERFACE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.md
+++ b/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_INTERLEAVEDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_INTERLEAVEFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_INTERLEAVEFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_INTERLEAVEFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_IOCTLDATA.md
+++ b/docs/libcurl/opts/CURLOPT_IOCTLDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_IOCTLDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_IOCTLFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_IOCTLFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_IOCTLFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_IPRESOLVE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT.md
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_ISSUERCERT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_ISSUERCERT_BLOB
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_KEEP_SENDING_ON_ERROR.md
+++ b/docs/libcurl/opts/CURLOPT_KEEP_SENDING_ON_ERROR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_KEEP_SENDING_ON_ERROR
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_KEYPASSWD.md
+++ b/docs/libcurl/opts/CURLOPT_KEYPASSWD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_KEYPASSWD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_KRBLEVEL.md
+++ b/docs/libcurl/opts/CURLOPT_KRBLEVEL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_KRBLEVEL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_LOCALPORT.md
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_LOCALPORT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.md
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_LOCALPORTRANGE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_LOGIN_OPTIONS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.md
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_LOW_SPEED_LIMIT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.md
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_LOW_SPEED_TIME
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAIL_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_AUTH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAIL_AUTH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAIL_FROM.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_FROM.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAIL_FROM
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAIL_RCPT.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_RCPT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAIL_RCPT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAIL_RCPT_ALLOWFAILS.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_RCPT_ALLOWFAILS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAIL_RCPT_ALLOWFAILS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.md
+++ b/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAXAGE_CONN
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAXCONNECTS.md
+++ b/docs/libcurl/opts/CURLOPT_MAXCONNECTS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAXCONNECTS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAXFILESIZE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAXFILESIZE_LARGE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.md
+++ b/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAXLIFETIME_CONN
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAXREDIRS.md
+++ b/docs/libcurl/opts/CURLOPT_MAXREDIRS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAXREDIRS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAX_RECV_SPEED_LARGE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MAX_SEND_SPEED_LARGE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MIMEPOST.md
+++ b/docs/libcurl/opts/CURLOPT_MIMEPOST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MIMEPOST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_MIME_OPTIONS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_NETRC
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_NETRC_FILE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_NEW_DIRECTORY_PERMS.md
+++ b/docs/libcurl/opts/CURLOPT_NEW_DIRECTORY_PERMS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_NEW_DIRECTORY_PERMS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_NEW_FILE_PERMS.md
+++ b/docs/libcurl/opts/CURLOPT_NEW_FILE_PERMS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_NEW_FILE_PERMS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_NOBODY.md
+++ b/docs/libcurl/opts/CURLOPT_NOBODY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_NOBODY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_NOPROGRESS.md
+++ b/docs/libcurl/opts/CURLOPT_NOPROGRESS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_NOPROGRESS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.md
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_NOPROXY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_NOSIGNAL.md
+++ b/docs/libcurl/opts/CURLOPT_NOSIGNAL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_NOSIGNAL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.md
+++ b/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_OPENSOCKETDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_OPENSOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_OPENSOCKETFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_OPENSOCKETFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_PASSWORD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PASSWORD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
+++ b/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PATH_AS_IS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PINNEDPUBLICKEY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PIPEWAIT.md
+++ b/docs/libcurl/opts/CURLOPT_PIPEWAIT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PIPEWAIT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PORT.md
+++ b/docs/libcurl/opts/CURLOPT_PORT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PORT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_POST.md
+++ b/docs/libcurl/opts/CURLOPT_POST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_POST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDS.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_POSTFIELDS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_POSTFIELDSIZE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_POSTFIELDSIZE_LARGE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_POSTQUOTE.md
+++ b/docs/libcurl/opts/CURLOPT_POSTQUOTE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_POSTQUOTE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_POSTREDIR
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PREQUOTE.md
+++ b/docs/libcurl/opts/CURLOPT_PREQUOTE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PREQUOTE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PREREQDATA.md
+++ b/docs/libcurl/opts/CURLOPT_PREREQDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PREREQDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PREREQFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PRE_PROXY.md
+++ b/docs/libcurl/opts/CURLOPT_PRE_PROXY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PRE_PROXY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PRIVATE.md
+++ b/docs/libcurl/opts/CURLOPT_PRIVATE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PRIVATE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROGRESSDATA.md
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROGRESSDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROGRESSFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROTOCOLS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS_STR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROTOCOLS_STR
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXYAUTH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXYHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYHEADER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXYHEADER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXYPASSWORD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXYPORT.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYPORT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXYPORT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXYTYPE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXYUSERNAME
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXYUSERPWD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_CAINFO
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_CAINFO_BLOB
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_CAPATH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_CRLFILE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_ISSUERCERT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_ISSUERCERT_BLOB
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_KEYPASSWD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_PINNEDPUBLICKEY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SERVICE_NAME
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSLCERT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSLCERTTYPE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSLCERT_BLOB
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSLKEY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSLKEYTYPE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSLKEY_BLOB
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSLVERSION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSL_CIPHER_LIST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSL_OPTIONS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSL_VERIFYHOST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_SSL_VERIFYPEER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_TLS13_CIPHERS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_TLSAUTH_PASSWORD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_TLSAUTH_TYPE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_TLSAUTH_USERNAME
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PROXY_TRANSFER_MODE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TRANSFER_MODE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PROXY_TRANSFER_MODE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_PUT.md
+++ b/docs/libcurl/opts/CURLOPT_PUT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_PUT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_QUICK_EXIT.md
+++ b/docs/libcurl/opts/CURLOPT_QUICK_EXIT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_QUICK_EXIT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_QUOTE.md
+++ b/docs/libcurl/opts/CURLOPT_QUOTE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_QUOTE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RANDOM_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_RANDOM_FILE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RANDOM_FILE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RANGE.md
+++ b/docs/libcurl/opts/CURLOPT_RANGE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RANGE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_READDATA.md
+++ b/docs/libcurl/opts/CURLOPT_READDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_READDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_READFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_READFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_READFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_REDIR_PROTOCOLS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS_STR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_REDIR_PROTOCOLS_STR
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_REFERER.md
+++ b/docs/libcurl/opts/CURLOPT_REFERER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_REFERER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.md
+++ b/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_REQUEST_TARGET
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RESOLVE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RESOLVER_START_DATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RESOLVER_START_FUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RESUME_FROM.md
+++ b/docs/libcurl/opts/CURLOPT_RESUME_FROM.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RESUME_FROM
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RESUME_FROM_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_RESUME_FROM_LARGE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RESUME_FROM_LARGE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RTSP_CLIENT_CSEQ.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_CLIENT_CSEQ.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RTSP_CLIENT_CSEQ
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RTSP_REQUEST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RTSP_SERVER_CSEQ.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SERVER_CSEQ.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RTSP_SERVER_CSEQ
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RTSP_SESSION_ID
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RTSP_STREAM_URI
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_RTSP_TRANSPORT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.md
+++ b/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SASL_AUTHZID
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SASL_IR.md
+++ b/docs/libcurl/opts/CURLOPT_SASL_IR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SASL_IR
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SEEKDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SEEKDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SEEKDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SEEKFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SERVER_RESPONSE_TIMEOUT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT_MS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SERVER_RESPONSE_TIMEOUT_MS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SERVICE_NAME.md
+++ b/docs/libcurl/opts/CURLOPT_SERVICE_NAME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SERVICE_NAME
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLOPT_SHARE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SHARE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SOCKOPTDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SOCKOPTDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SOCKOPTFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SOCKS5_AUTH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SOCKS5_GSSAPI_NEC
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SOCKS5_GSSAPI_SERVICE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_AUTH_TYPES
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_COMPRESSION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_KEYDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_HOSTKEYFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_HOST_PUBLIC_KEY_MD5
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_KEYDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_KEYFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_KNOWNHOSTS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_PRIVATE_KEYFILE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSH_PUBLIC_KEYFILE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSLCERT.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSLCERT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSLCERTTYPE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSLCERT_BLOB
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE.md
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSLENGINE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE_DEFAULT.md
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE_DEFAULT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSLENGINE_DEFAULT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSLKEY.md
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSLKEY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSLKEYTYPE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSLKEY_BLOB
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSLVERSION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_CIPHER_LIST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_CTX_DATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_CTX_FUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_EC_CURVES
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_ENABLE_ALPN
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_ENABLE_NPN
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_FALSESTART
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_OPTIONS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_SESSIONID_CACHE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_VERIFYHOST
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_VERIFYPEER
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SSL_VERIFYSTATUS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_STDERR.md
+++ b/docs/libcurl/opts/CURLOPT_STDERR.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_STDERR
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.md
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_STREAM_DEPENDS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.md
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_STREAM_DEPENDS_E
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.md
+++ b/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_STREAM_WEIGHT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_SUPPRESS_CONNECT_HEADERS.md
+++ b/docs/libcurl/opts/CURLOPT_SUPPRESS_CONNECT_HEADERS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_SUPPRESS_CONNECT_HEADERS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TCP_FASTOPEN
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TCP_KEEPALIVE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TCP_KEEPIDLE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TCP_KEEPINTVL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TCP_NODELAY
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TELNETOPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_TELNETOPTIONS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TELNETOPTIONS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TFTP_BLKSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_TFTP_BLKSIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TFTP_BLKSIZE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TFTP_NO_OPTIONS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TIMECONDITION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TIMEOUT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TIMEOUT_MS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TIMEVALUE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TIMEVALUE_LARGE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TLS13_CIPHERS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TLSAUTH_PASSWORD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TLSAUTH_TYPE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TLSAUTH_USERNAME
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TRAILERDATA.md
+++ b/docs/libcurl/opts/CURLOPT_TRAILERDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TRAILERDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TRAILERFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TRANSFERTEXT.md
+++ b/docs/libcurl/opts/CURLOPT_TRANSFERTEXT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TRANSFERTEXT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.md
+++ b/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_TRANSFER_ENCODING
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.md
+++ b/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_UNIX_SOCKET_PATH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_UNRESTRICTED_AUTH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.md
+++ b/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_UPKEEP_INTERVAL_MS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_UPLOAD.md
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_UPLOAD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_UPLOAD_BUFFERSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD_BUFFERSIZE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_UPLOAD_BUFFERSIZE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_URL.md
+++ b/docs/libcurl/opts/CURLOPT_URL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_URL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_USERAGENT.md
+++ b/docs/libcurl/opts/CURLOPT_USERAGENT.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_USERAGENT
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_USERNAME.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_USERNAME
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_USERPWD.md
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_USERPWD
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_USE_SSL
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_VERBOSE.md
+++ b/docs/libcurl/opts/CURLOPT_VERBOSE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_VERBOSE
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.md
+++ b/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_WILDCARDMATCH
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_WRITEDATA.md
+++ b/docs/libcurl/opts/CURLOPT_WRITEDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_WRITEDATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_WRITEFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_WS_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_WS_OPTIONS.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_WS_OPTIONS
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_XFERINFODATA.md
+++ b/docs/libcurl/opts/CURLOPT_XFERINFODATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_XFERINFODATA
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_XFERINFOFUNCTION
 Section: 3

--- a/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.md
+++ b/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLOPT_XOAUTH2_BEARER
 Section: 3

--- a/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.md
+++ b/docs/libcurl/opts/CURLSHOPT_LOCKFUNC.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLSHOPT_LOCKFUNC
 Section: 3

--- a/docs/libcurl/opts/CURLSHOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLSHOPT_SHARE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLSHOPT_SHARE
 Section: 3

--- a/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.md
+++ b/docs/libcurl/opts/CURLSHOPT_UNLOCKFUNC.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLSHOPT_UNLOCKFUNC
 Section: 3

--- a/docs/libcurl/opts/CURLSHOPT_UNSHARE.md
+++ b/docs/libcurl/opts/CURLSHOPT_UNSHARE.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLSHOPT_UNSHARE
 Section: 3

--- a/docs/libcurl/opts/CURLSHOPT_USERDATA.md
+++ b/docs/libcurl/opts/CURLSHOPT_USERDATA.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: CURLSHOPT_USERDATA
 Section: 3

--- a/docs/mk-ca-bundle.md
+++ b/docs/mk-ca-bundle.md
@@ -1,5 +1,5 @@
 ---
-c: Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Title: mk-ca-bundle
 Section: 1

--- a/lib/easygetopt.c
+++ b/lib/easygetopt.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             ___|___/|_| ______|
  *
- * Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/easyoptions.c
+++ b/lib/easyoptions.c
@@ -5,7 +5,7 @@
  *                            | (__| |_| |  _ <| |___
  *                             \___|\___/|_| \_\_____|
  *
- * Copyright (C) Daniel Stenberg, <daniel.se>, et al.
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/optiontable.pl
+++ b/lib/optiontable.pl
@@ -8,7 +8,7 @@ print <<HEAD
  *                            | (__| |_| |  _ <| |___
  *                             \\___|\\___/|_| \\_\\_____|
  *
- * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ * Copyright (C) Daniel Stenberg, <daniel\@haxx.se>, et al.
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms


### PR DESCRIPTION
The curldown conversion accidentally replaced daniel@haxx.se with just daniel.se.  This reverts back to the proper email address in the curldown docs as well as in a few other stray places.

Closes: #xxxx