### PR TITLE
fopen: fix narrowing conversion warning on 32-bit Android

### DIFF
--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -129,7 +129,12 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   }
 
   result = CURLE_WRITE_ERROR;
+#if (defined(ANDROID) || defined(__ANDROID__)) && \
+    (defined(__i386__) || defined(__arm__))
+  fd = open(tempstore, O_WRONLY | O_CREAT | O_EXCL, (mode_t)(0600|sb.st_mode));
+#else
   fd = open(tempstore, O_WRONLY | O_CREAT | O_EXCL, 0600|sb.st_mode);
+#endif
   if(fd == -1)
     goto fail;
 


### PR DESCRIPTION
This was fixed in commit 06dc599405fd8a87147eddcdb89dab62ce200d9b, but came back in commit 03cb1ff4d629d6110dab787c75c187626d58323d.

When building for 32-bit ARM or x86 Android, `st_mode` is defined as `unsigned int` instead of `mode_t`, resulting in a `-Wimplicit-int-conversion` clang warning because `mode_t` is `unsigned short`. Add a cast to silence the warning, but only for Android builds, because other architectures and platforms are not affected.

Ref: https://android.googlesource.com/platform/bionic/+/refs/tags/ndk-r25c/libc/include/sys/stat.h#86