### PR TITLE
getparam: make --ftp-ssl work again

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1593,6 +1593,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         url->flags |= GETOUT_URL;
       }
       break;
+    case C_FTP_SSL: /* --ftp-ssl */
     case C_SSL: /* --ssl */
       if(toggle && !feature_ssl)
         err = PARAM_LIBCURL_DOESNT_SUPPORT;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1601,7 +1601,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         config->ftp_ssl = toggle;
         if(config->ftp_ssl)
           warnf(global,
-                "--ssl is an insecure option, consider --ssl-reqd instead");
+                "--%s is an insecure option, consider --ssl-reqd instead",
+                a->lname);
       }
       break;
     case C_FTP_PASV: /* --ftp-pasv */


### PR DESCRIPTION
Follow-up to 9e4e527 which accidentally broke it

Reported-by: Jordan Brown
Fixes #13006