### PR TITLE
cmdline-opts/_VERSION: provide %VERSION correctly

### DIFF
--- a/docs/cmdline-opts/_VERSION.md
+++ b/docs/cmdline-opts/_VERSION.md
@@ -2,10 +2,10 @@
 <!-- SPDX-License-Identifier: curl -->
 # VERSION
 
-This man page describes curl %VERSION. If you use a later version, chances are
-this man page does not fully document it. If you use an earlier version, this
-document tries to include version information about which specific version
-that introduced changes.
+This man page describes curl `%VERSION`. If you use a later version, chances
+are this man page does not fully document it. If you use an earlier version,
+this document tries to include version information about which specific
+version that introduced changes.
 
 You can always learn which the latest curl version is by running
 

--- a/docs/cmdline-opts/form.md
+++ b/docs/cmdline-opts/form.md
@@ -29,10 +29,10 @@ message to transmit.
 
 This enables uploading of binary files etc. To force the 'content' part to be
 a file, prefix the filename with an @ sign. To just get the content part from
-a file, prefix the filename with the symbol \<. The difference between @ and <
-is then that @ makes a file get attached in the post as a file upload, while
-the \< makes a text field and just get the contents for that text field from a
-file.
+a file, prefix the filename with the symbol \<. The difference between @ and
+\< is then that @ makes a file get attached in the post as a file upload,
+while the \< makes a text field and just get the contents for that text field
+from a file.
 
 Tell curl to read content from stdin instead of a file by using - as
 filename. This goes for both @ and \< constructs. When stdin is used, the


### PR DESCRIPTION
... so that it does not get included verbatim in the output.

Also fix a format mistake in form.md