### PR TITLE
[RFC] lib: bypass proxy when unresolvable

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2090,6 +2090,17 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       if(!dns)
         result = Curl_resolv_check(data, &dns);
 
+#ifndef CURL_DISABLE_PROXY
+      if (CURLE_COULDNT_RESOLVE_PROXY == result) {
+          rc = CURLM_CALL_MULTI_PERFORM;
+          data->state.proxy_unresolvable = TRUE;
+          result = CURLE_OK;
+          infof(data, "Proxy '%s' was not resolvable, attempting to bypass", hostname);
+          multi_done(data, CURLE_OK, FALSE);  // try again without proxy
+          multistate(data, MSTATE_CONNECT);
+      }
+#endif
+
       /* Update sockets here, because the socket(s) may have been
          closed and the application thus needs to be told, even if it
          is likely that the same socket(s) will again be used further

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1395,6 +1395,11 @@ struct UrlState {
   BIT(internal); /* internal: true if this easy handle was created for
                     internal use and the user does not have ownership of the
                     handle. */
+#ifndef CURL_DISABLE_PROXY
+  BIT(proxy_unresolvable); /* proxy_unresolvable: true if a proxy was detected but was
+                            unresol
+                         */
+#endif
 };
 
 /*


### PR DESCRIPTION
In lieu of more complete proxy detection (ala. https://github.com/curl/curl/pull/11393), I noticed that my organization uses split DNS for their proxy, so `CURLE_COULDNT_RESOLVE_PROXY` is a fast and simple way of detecting that the proxy is not needed. So retry without the proxy (sometimes called "direct" or "bypass") in this case.

Works on my machine! 😅

Open questions:

1. Should this be configurable? 
    <ol type=a>
      <li>A direct connection may be dangerous if unexpected, so should it be 'opt-in'?
      <li>A new environment variable? `protocol_NOPROXY_UNRESOLVABLE=0/1`. Perhaps extending the `NO_PROXY` syntax, to support something like `some_web.dom:UNRESOLVED_PROXY,internal.dom`, which would hopefully be backwards compatible/ignored if not supported, and also not require new plumbing in each caller.
    </ol>
2. Which error to return if both the proxy and the destination are unreachable? Simplest thing to do would be to just return the "last" error (for the destination), but a new combined error code might be less confusing.
3. Would this make sense as a command line flag?

PS. My motivation is to get git to work without messing around with environment variables each time I switch networks. Also, this is the first time I've attempted C "in anger" so please be understanding.

Thanks for your time and consideration! 