### PR TITLE
_EXITCODES.md: sync with libcurl-errors

### DIFF
--- a/docs/cmdline-opts/_EXITCODES.md
+++ b/docs/cmdline-opts/_EXITCODES.md
@@ -196,6 +196,8 @@ Proxy handshake error.
 A client-side certificate is required to complete the TLS handshake.
 ## 99
 Poll or select returned fatal error.
+## 100
+A value or data field grew larger than allowed.
 ## XX
 More error codes might appear here in future releases. The existing ones are
 meant to never change.


### PR DESCRIPTION
- Add error code 100 (CURLE_TOO_LARGE) to the list of error codes that can be returned by the curl tool.

Closes #xxxx