### PR TITLE
bufq, writing into a softlimit queue cannot be partial

### DIFF
--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -396,7 +396,7 @@ ssize_t Curl_bufq_write(struct bufq *q,
   while(len) {
     tail = get_non_full_tail(q);
     if(!tail) {
-      if(q->chunk_count < q->max_chunks) {
+      if((q->chunk_count < q->max_chunks) || (q->opts & BUFQ_OPT_SOFT_LIMIT)) {
         *err = CURLE_OUT_OF_MEMORY;
         return -1;
       }


### PR DESCRIPTION
- refs #13020
- when unable to obtain a new chunk on a softlimit bufq, this is an allocation error and needs to be reported as such.
- writes into a soflimit bufq never must be partial success