### PR TITLE
Send part 4, resume+rewind

### DIFF
--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -31,6 +31,11 @@ struct Curl_crtype {
                       char *buf, size_t blen, size_t *nread, bool *eos);
   void (*do_close)(struct Curl_easy *data, struct Curl_creader *reader);
   bool (*needs_rewind)(struct Curl_easy *data, struct Curl_creader *reader);
+  curl_off_t (*total_length)(struct Curl_easy *data,
+                             struct Curl_creader *reader);
+  CURLcode (*resume_from)(struct Curl_easy *data,
+                          struct Curl_creader *reader, curl_off_t offset);
+  CURLcode (*rewind)(struct Curl_easy *data, struct Curl_creader *reader);
 };
 
 struct Curl_creader {
@@ -80,6 +85,36 @@ Implemented in `sendf.c` for phase `CURL_CR_CLIENT`, this reader get a buffer po
 
 Sometimes it is necessary to send a request with client data again. Transfer handling can inquire via `Curl_client_read_needs_rewind()` if a rewind (e.g. a reset of the client data) is necessary. This asks all installed readers if they need it and give `FALSE` of none does.
 
+## Upload Size
+
+Many protocols need to know the amount of bytes delivered by the client readers in advance. They may invoke `Curl_creader_total_length(data)` to retrieve that. However, not all reader chains know the exact value beforehand. In that case, the call returns `-1` for "unknown".
+
+Even if the length of the "raw" data is known, the length that is send may not. Example: with option `--crlf` the uploaded content undergoes line-end conversion. The line converting reader does not know in advance how many newlines it may encounter. Therefore it must return `-1` for any positive raw content length.
+
+In HTTP, once the correct client readers are installed, the protocol asks the readers for the total length. If that is known, it can set `Content-Length:` accordingly. If not, it may choose to add a HTTP "chunked" reader.
+
+In addition, there is `Curl_creader_client_length(data)` which gives the total length as reported by the reader in phase `CURL_CR_CLIENT` without asking other readers that may transform the raw data. This is useful in estimating the size of an upload. The HTTP protocol uses this to determine if `Expect: 100-continue` shall be done.
+
+## Resuming
+
+Uploads can start at a specific offset, if so requested. The "resume from" that offset. This applies to the reader in phase `CURL_CR_CLIENT` that delivers the "raw" content. Resumption can fail if the installed reader does not support it or if the offset is too large.
+
+The total length reported by the reader changes when resuming. Example: resuming an upload of 100 bytes by 25 reports a total length of 75 afterwards.
+
+If `resume_from()` is invoked twice, it is additive. There is currently no way to undo a resume.
+
+## Rewinding
+
+When a request is retried, installed client readers are discarded and replaced by new ones. This works only if the new readers upload the same data. For many readers, this is not an issue. The "null" reader always does the same. Also the "buf" reader, initialized with the same buffer, does this.
+
+Readers operating on callbacks to the application need to "rewind" the underlying content. For example, when reading from a `FILE*`, the reader needs to `fseek()` to the beginning. The following methods are used:
+
+1. `Curl_creader_needs_rewind(data)`: tells iff a rewind is necessary, given the current state of the reader chain. If nothing really has been read so far, this returns `FALSE`.
+2. `Curl_creader_will_rewind(data)`: tells iff the reader chain rewinds at the start of the next request.
+3. `Curl_creader_set_rewind(data, TRUE)`: marks the reader chain for rewinding at the start of the next request.
+4. `Curl_client_start(data)`: tells the readers that a new request starts and they need to rewind if requested.
+
+
 ## Summary and Outlook
 
 By adding the client reader interface, any protocol can control how/if it wants the curl transfer to send bytes for a request. The transfer loop becomes then blissfully ignorant of the specifics. 
@@ -87,7 +122,5 @@ By adding the client reader interface, any protocol can control how/if it wants 
 The protocols on the other hand no longer have to care to package data most efficiently. At any time, should more data be needed, it can be read from the client. This is used when sending HTTP requests headers to add as much request body data to the initial sending as there is room for.
 
 Future enhancements based on the client readers:
-* delegate the actual "rewinding" to the readers. The should know how it is done, eliminating the `readrewind.c` protocol specifics in `multi.c`.
 * `expect-100` handling: place that into a HTTP specific reader at `CURL_CR_PROTOCOL` and eliminate the checks in the generic transfer parts.
-* `eos` detection: `upload_done` is partly triggered now by comparing the number of bytes sent to a known size. This is no longer necessary since the core readers obey length restrictions.
 * `eos forwarding`: transfer should forward an `eos` flag to the connection filters. Filters like HTTP/2 and HTTP/3 can make use of that, terminating streams early. This would also eliminate length checks in stream handling.

--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -91,7 +91,7 @@ Many protocols need to know the amount of bytes delivered by the client readers 
 
 Even if the length of the "raw" data is known, the length that is send may not. Example: with option `--crlf` the uploaded content undergoes line-end conversion. The line converting reader does not know in advance how many newlines it may encounter. Therefore it must return `-1` for any positive raw content length.
 
-In HTTP, once the correct client readers are installed, the protocol asks the readers for the total length. If that is known, it can set `Content-Length:` accordingly. If not, it may choose to add a HTTP "chunked" reader.
+In HTTP, once the correct client readers are installed, the protocol asks the readers for the total length. If that is known, it can set `Content-Length:` accordingly. If not, it may choose to add an HTTP "chunked" reader.
 
 In addition, there is `Curl_creader_client_length(data)` which gives the total length as reported by the reader in phase `CURL_CR_CLIENT` without asking other readers that may transform the raw data. This is useful in estimating the size of an upload. The HTTP protocol uses this to determine if `Expect: 100-continue` shall be done.
 
@@ -109,8 +109,8 @@ When a request is retried, installed client readers are discarded and replaced b
 
 Readers operating on callbacks to the application need to "rewind" the underlying content. For example, when reading from a `FILE*`, the reader needs to `fseek()` to the beginning. The following methods are used:
 
-1. `Curl_creader_needs_rewind(data)`: tells iff a rewind is necessary, given the current state of the reader chain. If nothing really has been read so far, this returns `FALSE`.
-2. `Curl_creader_will_rewind(data)`: tells iff the reader chain rewinds at the start of the next request.
+1. `Curl_creader_needs_rewind(data)`: tells if a rewind is necessary, given the current state of the reader chain. If nothing really has been read so far, this returns `FALSE`.
+2. `Curl_creader_will_rewind(data)`: tells if the reader chain rewinds at the start of the next request.
 3. `Curl_creader_set_rewind(data, TRUE)`: marks the reader chain for rewinding at the start of the next request.
 4. `Curl_client_start(data)`: tells the readers that a new request starts and they need to rewind if requested.
 

--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -105,7 +105,7 @@ If `resume_from()` is invoked twice, it is additive. There is currently no way t
 
 ## Rewinding
 
-When a request is retried, installed client readers are discarded and replaced by new ones. This works only if the new readers upload the same data. For many readers, this is not an issue. The "null" reader always does the same. Also the "buf" reader, initialized with the same buffer, does this.
+When a request is retried, installed client readers are discarded and replaced by new ones. This works only if the new readers upload the same data. For many readers, this is not an issue. The "null" reader always does the same. Also the `buf` reader, initialized with the same buffer, does this.
 
 Readers operating on callbacks to the application need to "rewind" the underlying content. For example, when reading from a `FILE*`, the reader needs to `fseek()` to the beginning. The following methods are used:
 

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -883,9 +883,9 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
       return result;
   }
 
-  result = Curl_http_resume(data, conn, httpreq);
+  result = Curl_http_req_set_reader(data, httpreq, &te);
   if(result)
-    return result;
+    goto error;
 
   result = Curl_http_range(data, httpreq);
   if(result)
@@ -1005,10 +1005,6 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
     result = CURLE_OUT_OF_MEMORY;
     goto error;
   }
-
-  result = Curl_http_body(data, conn, httpreq, &te);
-  if(result)
-    goto error;
 
   if(data->state.aptr.host) {
     result = Curl_hyper_header(data, headers, data->state.aptr.host);

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -363,7 +363,7 @@ CURLcode Curl_hyper_stream(struct Curl_easy *data,
       k->exp100 = EXP100_SEND_DATA;
       k->keepon |= KEEP_SEND;
       Curl_expire_done(data, EXPIRE_100_TIMEOUT);
-      infof(data, "Done waiting for 100-continue");
+      infof(data, "Done waiting for 100-continue after %ldms", (long)ms);
       if(data->hyp.exp100_waker) {
         hyper_waker_wake(data->hyp.exp100_waker);
         data->hyp.exp100_waker = NULL;

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -848,7 +848,9 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
      may be parts of the request that is not yet sent, since we can deal with
      the rest of the request in the PERFORM phase. */
   *done = TRUE;
-  Curl_client_reset(data);
+  result = Curl_client_start(data);
+  if(result)
+    return result;
 
   /* Add collecting of headers written to client. For a new connection,
    * we might have done that already, but reuse

--- a/lib/http.c
+++ b/lib/http.c
@@ -2305,6 +2305,8 @@ CURLcode Curl_http_req_complete(struct Curl_easy *data,
       }
     }
     result = addexpect(data, r);
+    if(result)
+      goto out;
     break;
   default:
     break;

--- a/lib/http.c
+++ b/lib/http.c
@@ -2187,9 +2187,9 @@ CURLcode Curl_http_req_complete(struct Curl_easy *data,
     /* set the upload size to the progress meter */
     Curl_pgrsSetUploadSize(data, http->postsize);
     if(!http->postsize)
-      result = Client_reader_set_null(data);
+      result = Curl_creader_set_null(data);
     else
-      result = Client_reader_set_fread(data, data->state.infilesize);
+      result = Curl_creader_set_fread(data, data->state.infilesize);
     break;
 
 #if !defined(CURL_DISABLE_MIME) || !defined(CURL_DISABLE_FORM_API)
@@ -2200,7 +2200,7 @@ CURLcode Curl_http_req_complete(struct Curl_easy *data,
       /* nothing to post! */
       result = Curl_dyn_addn(r, STRCONST("Content-Length: 0\r\n\r\n"));
       if(!result)
-        result = Client_reader_set_null(data);
+        result = Curl_creader_set_null(data);
       if(result)
         return result;
       /* setup variables for the upcoming transfer */
@@ -2249,13 +2249,13 @@ CURLcode Curl_http_req_complete(struct Curl_easy *data,
     /* set the upload size to the progress meter */
     Curl_pgrsSetUploadSize(data, http->postsize);
     if(!http->postsize)
-      result = Client_reader_set_null(data);
+      result = Curl_creader_set_null(data);
     else {
       /* Read from mime structure. We could do a special client reader
        * for this, but replacing the callback seems to work fine. */
       data->state.fread_func = (curl_read_callback) Curl_mime_read;
       data->state.in = (void *) data->state.mimepost;
-      result = Client_reader_set_fread(data, data->state.infilesize);
+      result = Curl_creader_set_fread(data, data->state.infilesize);
     }
     break;
 #endif
@@ -2299,19 +2299,19 @@ CURLcode Curl_http_req_complete(struct Curl_easy *data,
 
     if(!http->postsize) {
       Curl_pgrsSetUploadSize(data, 0);
-      result = Client_reader_set_null(data);
+      result = Curl_creader_set_null(data);
     }
     else if(data->set.postfields) {
       Curl_pgrsSetUploadSize(data, http->postsize);
       if(http->postsize > 0)
-        result = Client_reader_set_buf(data, data->set.postfields,
+        result = Curl_creader_set_buf(data, data->set.postfields,
                                        (size_t)http->postsize);
       else
-        result = Client_reader_set_null(data);
+        result = Curl_creader_set_null(data);
     }
     else { /* we read the bytes from the callback */
       Curl_pgrsSetUploadSize(data, http->postsize);
-      result = Client_reader_set_fread(data, http->postsize);
+      result = Curl_creader_set_fread(data, http->postsize);
     }
     break;
 
@@ -2319,7 +2319,7 @@ CURLcode Curl_http_req_complete(struct Curl_easy *data,
     /* HTTP GET/HEAD download, has no body, needs no Content-Length */
     result = Curl_dyn_addn(r, STRCONST("\r\n"));
     if(!result)
-      result = Client_reader_set_null(data);
+      result = Curl_creader_set_null(data);
     break;
   }
 

--- a/lib/http.h
+++ b/lib/http.h
@@ -105,9 +105,9 @@ CURLcode Curl_http_statusline(struct Curl_easy *data,
 CURLcode Curl_http_header(struct Curl_easy *data, struct connectdata *conn,
                           char *headp);
 CURLcode Curl_transferencode(struct Curl_easy *data);
-CURLcode Curl_http_body(struct Curl_easy *data, struct connectdata *conn,
-                        Curl_HttpReq httpreq,
-                        const char **teep);
+CURLcode Curl_http_req_set_reader(struct Curl_easy *data,
+                                  Curl_HttpReq httpreq,
+                                  const char **tep);
 CURLcode Curl_http_req_complete(struct Curl_easy *data,
                                 struct dynbuf *r, Curl_HttpReq httpreq);
 bool Curl_use_http_1_1plus(const struct Curl_easy *data,
@@ -119,9 +119,6 @@ CURLcode Curl_http_cookies(struct Curl_easy *data,
 #else
 #define Curl_http_cookies(a,b,c) CURLE_OK
 #endif
-CURLcode Curl_http_resume(struct Curl_easy *data,
-                          struct connectdata *conn,
-                          Curl_HttpReq httpreq);
 CURLcode Curl_http_range(struct Curl_easy *data,
                          Curl_HttpReq httpreq);
 CURLcode Curl_http_firstwrite(struct Curl_easy *data,
@@ -188,11 +185,11 @@ CURLcode Curl_http_auth_act(struct Curl_easy *data);
  * HTTP unique setup
  ***************************************************************************/
 struct HTTP {
-  curl_off_t postsize; /* off_t to handle large file sizes */
-
 #ifndef CURL_DISABLE_HTTP
   void *h2_ctx;              /* HTTP/2 implementation context */
   void *h3_ctx;              /* HTTP/3 implementation context */
+#else
+  char unused;
 #endif
 };
 

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -641,6 +641,7 @@ const struct Curl_crtype Curl_httpchunk_encoder = {
   cr_chunked_close,
   Curl_creader_def_needs_rewind,
   cr_chunked_total_length,
+  Curl_creader_def_resume_from,
   sizeof(struct chunked_reader)
 };
 

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -642,6 +642,7 @@ const struct Curl_crtype Curl_httpchunk_encoder = {
   Curl_creader_def_needs_rewind,
   cr_chunked_total_length,
   Curl_creader_def_resume_from,
+  Curl_creader_def_rewind,
   sizeof(struct chunked_reader)
 };
 

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -624,6 +624,15 @@ static CURLcode cr_chunked_read(struct Curl_easy *data,
   return CURLE_OK;
 }
 
+static curl_off_t cr_chunked_total_length(struct Curl_easy *data,
+                                          struct Curl_creader *reader)
+{
+  /* this reader changes length depending on input */
+  (void)data;
+  (void)reader;
+  return -1;
+}
+
 /* HTTP chunked Transfer-Encoding encoder */
 const struct Curl_crtype Curl_httpchunk_encoder = {
   "chunked",
@@ -631,6 +640,7 @@ const struct Curl_crtype Curl_httpchunk_encoder = {
   cr_chunked_read,
   cr_chunked_close,
   Curl_creader_def_needs_rewind,
+  cr_chunked_total_length,
   sizeof(struct chunked_reader)
 };
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1817,93 +1817,6 @@ static CURLcode protocol_connect(struct Curl_easy *data,
 }
 
 /*
- * readrewind() rewinds the read stream. This is typically used for HTTP
- * POST/PUT with multi-pass authentication when a sending was denied and a
- * resend is necessary.
- */
-static CURLcode readrewind(struct Curl_easy *data)
-{
-#if !defined(CURL_DISABLE_MIME) || !defined(CURL_DISABLE_FORM_API)
-  curl_mimepart *mimepart = &data->set.mimepost;
-#endif
-  DEBUGASSERT(data->conn);
-
-  data->state.rewindbeforesend = FALSE; /* we rewind now */
-
-  /* explicitly switch off sending data on this connection now since we are
-     about to restart a new transfer and thus we want to avoid inadvertently
-     sending more data on the existing connection until the next transfer
-     starts */
-  data->req.keepon &= ~KEEP_SEND;
-
-  /* We have sent away data. If not using CURLOPT_POSTFIELDS or
-     CURLOPT_HTTPPOST, call app to rewind
-  */
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_MIME)
-  if(data->conn->handler->protocol & PROTO_FAMILY_HTTP) {
-    if(data->state.mimepost)
-      mimepart = data->state.mimepost;
-  }
-#endif
-  if(data->set.postfields ||
-     (data->state.httpreq == HTTPREQ_GET) ||
-     (data->state.httpreq == HTTPREQ_HEAD))
-    ; /* no need to rewind */
-#if !defined(CURL_DISABLE_MIME) || !defined(CURL_DISABLE_FORM_API)
-  else if(data->state.httpreq == HTTPREQ_POST_MIME ||
-          data->state.httpreq == HTTPREQ_POST_FORM) {
-    CURLcode result = Curl_mime_rewind(mimepart);
-    if(result) {
-      failf(data, "Cannot rewind mime/post data");
-      return result;
-    }
-  }
-#endif
-  else {
-    if(data->set.seek_func) {
-      int err;
-
-      Curl_set_in_callback(data, true);
-      err = (data->set.seek_func)(data->set.seek_client, 0, SEEK_SET);
-      Curl_set_in_callback(data, false);
-      if(err) {
-        failf(data, "seek callback returned error %d", (int)err);
-        return CURLE_SEND_FAIL_REWIND;
-      }
-    }
-    else if(data->set.ioctl_func) {
-      curlioerr err;
-
-      Curl_set_in_callback(data, true);
-      err = (data->set.ioctl_func)(data, CURLIOCMD_RESTARTREAD,
-                                   data->set.ioctl_client);
-      Curl_set_in_callback(data, false);
-      infof(data, "the ioctl callback returned %d", (int)err);
-
-      if(err) {
-        failf(data, "ioctl callback returned error %d", (int)err);
-        return CURLE_SEND_FAIL_REWIND;
-      }
-    }
-    else {
-      /* If no CURLOPT_READFUNCTION is used, we know that we operate on a
-         given FILE * stream and we can actually attempt to rewind that
-         ourselves with fseek() */
-      if(data->state.fread_func == (curl_read_callback)fread) {
-        if(-1 != fseek(data->state.in, 0, SEEK_SET))
-          /* successful rewind */
-          return CURLE_OK;
-      }
-
-      /* no callback set or failure above, makes us fail at once */
-      failf(data, "necessary data rewind wasn't possible");
-      return CURLE_SEND_FAIL_REWIND;
-    }
-  }
-  return CURLE_OK;
-}
-
-/*
  * Curl_preconnect() is called immediately before a connect starts. When a
  * redirect is followed, this is then called multiple times during a single
  * transfer.
@@ -2169,9 +2082,6 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       break;
 
     case MSTATE_PROTOCONNECT:
-      if(data->state.rewindbeforesend)
-        result = readrewind(data);
-
       if(!result && data->conn->bits.reuse) {
         /* ftp seems to hang when protoconnect on reused connection
          * since we handle PROTOCONNECT in general inside the filers, it

--- a/lib/request.c
+++ b/lib/request.c
@@ -49,8 +49,13 @@ CURLcode Curl_req_init(struct SingleRequest *req)
 CURLcode Curl_req_start(struct SingleRequest *req,
                         struct Curl_easy *data)
 {
+  CURLcode result;
+
   req->start = Curl_now();
-  Curl_client_reset(data);
+  result = Curl_client_start(data);
+  if(result)
+    return result;
+
   if(!req->sendbuf_init) {
     Curl_bufq_init2(&req->sendbuf, data->set.upload_buffer_size, 1,
                     BUFQ_OPT_SOFT_LIMIT);
@@ -82,14 +87,15 @@ CURLcode Curl_req_done(struct SingleRequest *req,
 
 void Curl_req_reset(struct SingleRequest *req, struct Curl_easy *data)
 {
-  struct bufq savebuf;
-  bool save_init;
+  struct curltime t0 = {0, 0};
 
   /* This is a bit ugly. `req->p` is a union and we assume we can
    * free this safely without leaks. */
   Curl_safefree(req->p.http);
   Curl_safefree(req->newurl);
   Curl_client_reset(data);
+  if(req->sendbuf_init)
+    Curl_bufq_reset(&req->sendbuf);
 
 #ifndef CURL_DISABLE_DOH
   if(req->doh) {
@@ -97,17 +103,45 @@ void Curl_req_reset(struct SingleRequest *req, struct Curl_easy *data)
     Curl_close(&req->doh->probe[1].easy);
   }
 #endif
-
-  savebuf = req->sendbuf;
-  save_init = req->sendbuf_init;
-
-  memset(req, 0, sizeof(*req));
-  data->req.size = data->req.maxdownload = -1;
-  data->req.no_body = data->set.opt_no_body;
-  if(save_init) {
-    req->sendbuf = savebuf;
-    req->sendbuf_init = save_init;
-  }
+  /* Can no longer memset() this struct as we need to keep some state */
+  req->size = -1;
+  req->maxdownload = -1;
+  req->bytecount = 0;
+  req->writebytecount = 0;
+  req->start = t0;
+  req->headerbytecount = 0;
+  req->allheadercount =  0;
+  req->deductheadercount = 0;
+  req->headerline = 0;
+  req->offset = 0;
+  req->httpcode = 0;
+  req->keepon = 0;
+  req->start100 = t0;
+  req->exp100 = 0;
+  req->upgr101 = 0;
+  req->timeofdoc = 0;
+  req->bodywrites = 0;
+  req->location = NULL;
+  req->newurl = NULL;
+#ifndef CURL_DISABLE_COOKIES
+  req->setcookies = 0;
+#endif
+  req->header = FALSE;
+  req->content_range = FALSE;
+  req->download_done = FALSE;
+  req->eos_written = FALSE;
+  req->eos_read = FALSE;
+  req->upload_done = FALSE;
+  req->upload_aborted = FALSE;
+  req->ignorebody = FALSE;
+  req->http_bodyless = FALSE;
+  req->chunk = FALSE;
+  req->ignore_cl = FALSE;
+  req->upload_chunky = FALSE;
+  req->getheader = FALSE;
+  req->forbidchunk = FALSE;
+  req->no_body = data->set.opt_no_body;
+  req->authneg = FALSE;
 }
 
 void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)
@@ -118,7 +152,7 @@ void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)
   Curl_safefree(req->newurl);
   if(req->sendbuf_init)
     Curl_bufq_free(&req->sendbuf);
-  Curl_client_reset(data);
+  Curl_client_cleanup(data);
 
 #ifndef CURL_DISABLE_DOH
   if(req->doh) {

--- a/lib/request.c
+++ b/lib/request.c
@@ -117,8 +117,8 @@ void Curl_req_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->httpcode = 0;
   req->keepon = 0;
   req->start100 = t0;
-  req->exp100 = 0;
-  req->upgr101 = 0;
+  req->exp100 = EXP100_SEND_DATA;
+  req->upgr101 = UPGR101_INIT;
   req->timeofdoc = 0;
   req->bodywrites = 0;
   req->location = NULL;

--- a/lib/request.h
+++ b/lib/request.h
@@ -119,8 +119,6 @@ struct SingleRequest {
 #ifndef CURL_DISABLE_DOH
   struct dohdata *doh; /* DoH specific data for this request */
 #endif
-  char fread_eof[2]; /* the body read callback (index 0) returned EOF or
-                        the trailer read callback (index 1) returned EOF */
 #ifndef CURL_DISABLE_COOKIES
   unsigned char setcookies;
 #endif
@@ -129,6 +127,7 @@ struct SingleRequest {
   BIT(download_done); /* set to TRUE when download is complete */
   BIT(eos_written);   /* iff EOS has been written to client */
   BIT(eos_read);      /* iff EOS has been read from the client */
+  BIT(rewind_read);   /* iff reader needs rewind at next start */
   BIT(upload_done);   /* set to TRUE when all request data has been sent */
   BIT(upload_aborted); /* set to TRUE when upload was aborted. Will also
                         * show `upload_done` as TRUE. */

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -225,8 +225,6 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   Curl_RtspReq rtspreq = data->set.rtspreq;
   struct RTSP *rtsp = data->req.p.rtsp;
   struct dynbuf req_buffer;
-  curl_off_t req_clen = 0; /* request content length,
-                              for ANNOUNCE and SET_PARAMETER */
 
   const char *p_request = NULL;
   const char *p_session_id = NULL;
@@ -496,10 +494,10 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   if(result)
     goto out;
 
-  req_clen = 0;
   if(rtspreq == RTSPREQ_ANNOUNCE ||
      rtspreq == RTSPREQ_SET_PARAMETER ||
      rtspreq == RTSPREQ_GET_PARAMETER) {
+    curl_off_t req_clen; /* request content length */
 
     if(data->state.upload) {
       req_clen = data->state.infilesize;

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -225,8 +225,8 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   Curl_RtspReq rtspreq = data->set.rtspreq;
   struct RTSP *rtsp = data->req.p.rtsp;
   struct dynbuf req_buffer;
-  curl_off_t postsize = 0; /* for ANNOUNCE and SET_PARAMETER */
-  curl_off_t putsize = 0; /* for ANNOUNCE and SET_PARAMETER */
+  curl_off_t req_clen = 0; /* request content length,
+                              for ANNOUNCE and SET_PARAMETER */
 
   const char *p_request = NULL;
   const char *p_session_id = NULL;
@@ -496,41 +496,43 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   if(result)
     goto out;
 
+  req_clen = 0;
   if(rtspreq == RTSPREQ_ANNOUNCE ||
      rtspreq == RTSPREQ_SET_PARAMETER ||
      rtspreq == RTSPREQ_GET_PARAMETER) {
 
     if(data->state.upload) {
-      putsize = data->state.infilesize;
+      req_clen = data->state.infilesize;
       data->state.httpreq = HTTPREQ_PUT;
-      result = Client_reader_set_fread(data, putsize);
+      result = Client_reader_set_fread(data, req_clen);
       if(result)
         goto out;
     }
     else {
-      postsize = (data->state.infilesize != -1)?
-        data->state.infilesize:
-        (data->set.postfields? (curl_off_t)strlen(data->set.postfields):0);
-      data->state.httpreq = HTTPREQ_POST;
-      if(postsize > 0 && data->set.postfields)
-        result = Client_reader_set_buf(data, data->set.postfields,
-                                       (size_t)postsize);
-      else if(!postsize)
+      if(data->set.postfields) {
+        req_clen = (curl_off_t)strlen(data->set.postfields);
+        result = Client_reader_set_buf(data, data->set.postfields, req_clen);
+      }
+      else if(data->state.infilesize >= 0) {
+        req_clen = data->state.infilesize;
+        result = Client_reader_set_fread(data, req_clen);
+      }
+      else {
+        req_clen = 0;
         result = Client_reader_set_null(data);
-      else
-        result = Client_reader_set_fread(data, postsize);
+      }
       if(result)
         goto out;
     }
 
-    if(putsize > 0 || postsize > 0) {
+    if(req_clen > 0) {
       /* As stated in the http comments, it is probably not wise to
        * actually set a custom Content-Length in the headers */
       if(!Curl_checkheaders(data, STRCONST("Content-Length"))) {
         result =
           Curl_dyn_addf(&req_buffer,
                         "Content-Length: %" CURL_FORMAT_CURL_OFF_T"\r\n",
-                        (data->state.upload ? putsize : postsize));
+                        req_clen);
         if(result)
           goto out;
       }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -504,22 +504,22 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     if(data->state.upload) {
       req_clen = data->state.infilesize;
       data->state.httpreq = HTTPREQ_PUT;
-      result = Client_reader_set_fread(data, req_clen);
+      result = Curl_creader_set_fread(data, req_clen);
       if(result)
         goto out;
     }
     else {
       if(data->set.postfields) {
         req_clen = (curl_off_t)strlen(data->set.postfields);
-        result = Client_reader_set_buf(data, data->set.postfields, req_clen);
+        result = Curl_creader_set_buf(data, data->set.postfields, req_clen);
       }
       else if(data->state.infilesize >= 0) {
         req_clen = data->state.infilesize;
-        result = Client_reader_set_fread(data, req_clen);
+        result = Curl_creader_set_fread(data, req_clen);
       }
       else {
         req_clen = 0;
-        result = Client_reader_set_null(data);
+        result = Curl_creader_set_null(data);
       }
       if(result)
         goto out;
@@ -567,7 +567,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     }
   }
   else {
-    result = Client_reader_set_null(data);
+    result = Curl_creader_set_null(data);
     if(result)
       goto out;
   }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -510,8 +510,9 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     }
     else {
       if(data->set.postfields) {
-        req_clen = (curl_off_t)strlen(data->set.postfields);
-        result = Curl_creader_set_buf(data, data->set.postfields, req_clen);
+        size_t plen = strlen(data->set.postfields);
+        req_clen = (curl_off_t)plen;
+        result = Curl_creader_set_buf(data, data->set.postfields, plen);
       }
       else if(data->state.infilesize >= 0) {
         req_clen = data->state.infilesize;

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1186,6 +1186,7 @@ static CURLcode cr_buf_resume_from(struct Curl_easy *data,
   struct cr_buf_ctx *ctx = (struct cr_buf_ctx *)reader;
   size_t boffset;
 
+  (void)data;
   DEBUGASSERT(data->conn);
   /* already started reading? */
   if(ctx->index)

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -779,7 +779,7 @@ static CURLcode do_init_reader_stack(struct Curl_easy *data,
   return result;
 }
 
-CURLcode Client_reader_set_fread(struct Curl_easy *data, curl_off_t len)
+CURLcode Curl_creader_set_fread(struct Curl_easy *data, curl_off_t len)
 {
   CURLcode result;
   struct Curl_creader *r;
@@ -801,7 +801,7 @@ CURLcode Curl_creader_add(struct Curl_easy *data,
   struct Curl_creader **anchor = &data->req.reader_stack;
 
   if(!*anchor) {
-    result = Client_reader_set_fread(data, data->state.infilesize);
+    result = Curl_creader_set_fread(data, data->state.infilesize);
     if(result)
       return result;
   }
@@ -826,7 +826,7 @@ CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
   DEBUGASSERT(eos);
 
   if(!data->req.reader_stack) {
-    result = Client_reader_set_fread(data, data->state.infilesize);
+    result = Curl_creader_set_fread(data, data->state.infilesize);
     if(result)
       return result;
     DEBUGASSERT(data->req.reader_stack);
@@ -871,7 +871,7 @@ static const struct Curl_crtype cr_null = {
   sizeof(struct Curl_creader)
 };
 
-CURLcode Client_reader_set_null(struct Curl_easy *data)
+CURLcode Curl_creader_set_null(struct Curl_easy *data)
 {
   struct Curl_creader *r;
 
@@ -927,7 +927,7 @@ static const struct Curl_crtype cr_buf = {
   sizeof(struct cr_buf_ctx)
 };
 
-CURLcode Client_reader_set_buf(struct Curl_easy *data,
+CURLcode Curl_creader_set_buf(struct Curl_easy *data,
                                const char *buf, size_t blen)
 {
   CURLcode result;

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -298,7 +298,7 @@ void Curl_creader_set_rewind(struct Curl_easy *data, bool enable);
 
 /**
  * Get the total length of bytes provided by the installed readers.
- * This is independant of the amount already delivered and is calculated
+ * This is independent of the amount already delivered and is calculated
  * by all readers in the stack. If a reader like "chunked" or
  * "crlf conversion" is installed, the returned length will be -1.
  * @return -1 if length is indeterminate

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -183,6 +183,8 @@ struct Curl_crtype {
                       char *buf, size_t blen, size_t *nread, bool *eos);
   void (*do_close)(struct Curl_easy *data, struct Curl_creader *reader);
   bool (*needs_rewind)(struct Curl_easy *data, struct Curl_creader *reader);
+  curl_off_t (*total_length)(struct Curl_easy *data,
+                             struct Curl_creader *reader);
   size_t creader_size;  /* sizeof() allocated struct Curl_creader */
 };
 
@@ -212,6 +214,8 @@ void Curl_creader_def_close(struct Curl_easy *data,
                             struct Curl_creader *reader);
 bool Curl_creader_def_needs_rewind(struct Curl_easy *data,
                                    struct Curl_creader *reader);
+curl_off_t Curl_creader_def_total_length(struct Curl_easy *data,
+                                         struct Curl_creader *reader);
 
 /**
  * Convenience method for calling `reader->do_read()` that
@@ -260,7 +264,14 @@ CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
  * TRUE iff client reader needs rewing before it can be used for
  * a retry request.
  */
-bool Curl_client_read_needs_rewind(struct Curl_easy *data);
+bool Curl_creader_needs_rewind(struct Curl_easy *data);
+
+/**
+ * Get the total length of bytes provided by the installed readers.
+ * This is independant of the amount already delivered.
+ * @return -1 if length is indeterminate
+ */
+curl_off_t Curl_creader_total_length(struct Curl_easy *data);
 
 /**
  * Set the client reader to provide 0 bytes, immediate EOS.

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -265,17 +265,17 @@ bool Curl_client_read_needs_rewind(struct Curl_easy *data);
 /**
  * Set the client reader to provide 0 bytes, immediate EOS.
  */
-CURLcode Client_reader_set_null(struct Curl_easy *data);
+CURLcode Curl_creader_set_null(struct Curl_easy *data);
 
 /**
  * Set the client reader the reads from fread callback.
  */
-CURLcode Client_reader_set_fread(struct Curl_easy *data, curl_off_t len);
+CURLcode Curl_creader_set_fread(struct Curl_easy *data, curl_off_t len);
 
 /**
  * Set the client reader the reads from the supplied buf (NOT COPIED).
  */
-CURLcode Client_reader_set_buf(struct Curl_easy *data,
-                               const char *buf, size_t blen);
+CURLcode Curl_creader_set_buf(struct Curl_easy *data,
+                              const char *buf, size_t blen);
 
 #endif /* HEADER_CURL_SENDF_H */

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -747,7 +747,7 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data)
   }
 
   /* Setup client reader for size and EOB conversion */
-  result = Client_reader_set_fread(data, data->state.infilesize);
+  result = Curl_creader_set_fread(data, data->state.infilesize);
   if(result)
     goto out;
   /* Add the client reader doing STMP EOB escaping */

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1908,12 +1908,22 @@ static CURLcode cr_eob_read(struct Curl_easy *data,
   return CURLE_OK;
 }
 
+static curl_off_t cr_eob_total_length(struct Curl_easy *data,
+                                      struct Curl_creader *reader)
+{
+  /* this reader changes length depending on input */
+  (void)data;
+  (void)reader;
+  return -1;
+}
+
 static const struct Curl_crtype cr_eob = {
   "cr-smtp-eob",
   cr_eob_init,
   cr_eob_read,
   cr_eob_close,
   Curl_creader_def_needs_rewind,
+  cr_eob_total_length,
   sizeof(struct cr_eob_ctx)
 };
 

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1924,6 +1924,7 @@ static const struct Curl_crtype cr_eob = {
   cr_eob_close,
   Curl_creader_def_needs_rewind,
   cr_eob_total_length,
+  Curl_creader_def_resume_from,
   sizeof(struct cr_eob_ctx)
 };
 

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1925,6 +1925,7 @@ static const struct Curl_crtype cr_eob = {
   Curl_creader_def_needs_rewind,
   cr_eob_total_length,
   Curl_creader_def_resume_from,
+  Curl_creader_def_rewind,
   sizeof(struct cr_eob_ctx)
 };
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -982,6 +982,7 @@ CURLcode Curl_follow(struct Curl_easy *data,
        && !(data->set.keep_post & CURL_REDIR_POST_301)) {
       infof(data, "Switch from POST to GET");
       data->state.httpreq = HTTPREQ_GET;
+      Curl_creader_set_rewind(data, FALSE);
     }
     break;
   case 302: /* Found */
@@ -1007,6 +1008,7 @@ CURLcode Curl_follow(struct Curl_easy *data,
        && !(data->set.keep_post & CURL_REDIR_POST_302)) {
       infof(data, "Switch from POST to GET");
       data->state.httpreq = HTTPREQ_GET;
+      Curl_creader_set_rewind(data, FALSE);
     }
     break;
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1109,12 +1109,7 @@ CURLcode Curl_retry_request(struct Curl_easy *data, char **url)
                                 prevent i.e HTTP transfers to return
                                 error just because nothing has been
                                 transferred! */
-
-
-    if(Curl_creader_needs_rewind(data)) {
-      data->state.rewindbeforesend = TRUE;
-      infof(data, "state.rewindbeforesend = TRUE");
-    }
+    Curl_creader_set_rewind(data, TRUE);
   }
   return CURLE_OK;
 }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1111,7 +1111,7 @@ CURLcode Curl_retry_request(struct Curl_easy *data, char **url)
                                 transferred! */
 
 
-    if(Curl_client_read_needs_rewind(data)) {
+    if(Curl_creader_needs_rewind(data)) {
       data->state.rewindbeforesend = TRUE;
       infof(data, "state.rewindbeforesend = TRUE");
     }

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1387,9 +1387,6 @@ struct UrlState {
   BIT(url_alloc);   /* URL string is malloc()'ed */
   BIT(referer_alloc); /* referer string is malloc()ed */
   BIT(wildcard_resolve); /* Set to true if any resolve change is a wildcard */
-  BIT(rewindbeforesend);/* TRUE when the sending couldn't be stopped even
-                           though it will be discarded. We must call the data
-                           rewind callback before trying to send again. */
   BIT(upload);         /* upload request */
   BIT(internal); /* internal: true if this easy handle was created for
                     internal use and the user does not have ownership of the

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -46,7 +46,8 @@ my %wl = (
     'Curl_xfer_write_resp' => 'internal api',
     'Curl_creader_def_init' => 'internal api',
     'Curl_creader_def_close' => 'internal api',
-    );
+    'Curl_creader_def_total_length' => 'internal api',
+);
 
 my %api = (
     'curl_easy_cleanup' => 'API',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), 'http'))
 import pytest
 from testenv import Env
 
-def pytest_report_header(config, startdir):
+
+def pytest_report_header(config):
     # Env inits its base properties only once, we can report them here
     env = Env()
     report = [


### PR DESCRIPTION
On top of #13010:

- update client reader documentation
- client reader, add rewind capabilities
    - tell creader to rewind on next start
    - Curl_client_reset() will keep reader for future rewind if requested
    - add Curl_client_cleanup() for freeing all resources independent of rewinds
    - add Curl_client_start() to trigger rewinds
    - move rewind code from multi.c to sendf.c and make  part of "cr-in"'s implementation
- http, move the "resume_from" handling into the client readers
    - the setup of a HTTP request is reshuffled to follow:
      * determine method, target, auth negotiation
      * install the client reader(s) for the request, including crlf conversions and "chunked" encoding
      * apply ranges to client reader
      * concat request headers, upgrades, cookies, etc.
      * complete request by determining Content-Length of  installed readers in combination with method
      * send
    - add methods for client readers to
      * return the overall length they will generate (or -1 when unknown)
      * return the amount of data on the CLIENT level, so that  expect-100 can decide if it want to apply itself
      * set a "resume_from" offset or fail if unsupported
    - struct HTTP has become largely empty now
- rename `Client_reader_*` to `Curl_creader_*`
