### PR TITLE
configure: Don't build shell completions when disabled

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -29,13 +29,18 @@ ZSH_FUNCTIONS_DIR = @ZSH_FUNCTIONS_DIR@
 FISH_FUNCTIONS_DIR = @FISH_FUNCTIONS_DIR@
 PERL = @PERL@
 
+if USE_ZSH_COMPLETION
 ZSH_COMPLETION_FUNCTION_FILENAME = _curl
+endif
+if USE_FISH_COMPLETION
 FISH_COMPLETION_FUNCTION_FILENAME = curl.fish
+endif
 
 CLEANFILES = $(ZSH_COMPLETION_FUNCTION_FILENAME) $(FISH_COMPLETION_FUNCTION_FILENAME)
 
 all-local: $(ZSH_COMPLETION_FUNCTION_FILENAME) $(FISH_COMPLETION_FUNCTION_FILENAME)
 
+if USE_ZSH_COMPLETION
 $(ZSH_COMPLETION_FUNCTION_FILENAME): completion.pl
 if CROSSCOMPILING
 	@echo "NOTICE: we can't generate zsh completion when cross-compiling!"
@@ -43,13 +48,16 @@ else # if not cross-compiling:
 	if test -z "$(PERL)"; then echo "No perl: can't install completion script"; else \
 	$(PERL) $(srcdir)/completion.pl --curl $(top_builddir)/src/curl$(EXEEXT) --shell zsh > $@ ; fi
 endif
+endif
 
+if USE_FISH_COMPLETION
 $(FISH_COMPLETION_FUNCTION_FILENAME): completion.pl
 if CROSSCOMPILING
 	@echo "NOTICE: we can't generate fish completion when cross-compiling!"
 else # if not cross-compiling:
 	if test -z "$(PERL)"; then echo "No perl: can't install completion script"; else \
 	$(PERL) $(srcdir)/completion.pl --curl $(top_builddir)/src/curl$(EXEEXT) --shell fish > $@ ; fi
+endif
 endif
 
 install-data-local:


### PR DESCRIPTION
With the recent changes to completion file building, the files were
built always and only installation was selectively disabled.  Now, when
they are disabled they aren't even built, avoiding a build-time error in
environments where it's not possible to run the curl binary that was
just created (e.g. if library paths were not set up correctly).

Follow-up to 0f7aba83c

Reported-by: av223119 on github
Fixes #13027
Closes #13030