### PR TITLE
trace-config.md: remove the mutexed options list

### DIFF
--- a/docs/cmdline-opts/trace-config.md
+++ b/docs/cmdline-opts/trace-config.md
@@ -4,7 +4,6 @@ SPDX-License-Identifier: curl
 Long: trace-config
 Arg: <string>
 Help: Details to log in trace/verbose output
-Mutexed: trace verbose
 Category: verbose
 Added: 8.3.0
 Multi: append


### PR DESCRIPTION
- Remove the rendered manpage message that says: "[--trace-config] is mutually exclusive to --trace and -v, --verbose".

Actually it can be used with either of those options, which are mutually exclusive to each other but not to --trace-config.

Ref: https://curl.se/docs/manpage.html#--trace-config

Closes #xxxx