### PR TITLE
cookie: if psl fails, reject the cookie

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -426,6 +426,7 @@ static void remove_expired(struct CookieInfo *cookies)
   }
 }
 
+#ifndef USE_LIBPSL
 /* Make sure domain contains a dot or is localhost. */
 static bool bad_domain(const char *domain, size_t len)
 {
@@ -443,6 +444,7 @@ static bool bad_domain(const char *domain, size_t len)
   }
   return TRUE;
 }
+#endif
 
 /*
   RFC 6265 section 4.1.1 says a server should accept this range:
@@ -1040,7 +1042,7 @@ Curl_cookie_add(struct Curl_easy *data,
         Curl_psl_release(data);
       }
       else
-        acceptable = !bad_domain(domain, strlen(domain));
+        infof(data, "libpsl problem, rejecting cookie for satety");
     }
 
     if(!acceptable) {


### PR DESCRIPTION
A libpsl install without data and no built-in database is now considered bad enough to reject all cookies since they cannot be checked. It is somewhat of a user error, but still.

Reported-by: Dan Fandrich