### PR TITLE
pytest adaptation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,10 +26,10 @@ import sys, os
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'http'))
 
-import pytest
 from testenv import Env
 
-def pytest_report_header(config, startdir):
+
+def pytest_report_header(config):
     # Env inits its base properties only once, we can report them here
     env = Env()
     report = [


### PR DESCRIPTION
- pytest has changed the signature of the hook pytest_report_header() for some obscure reason and that change landed in our CI now
- remove the changed param that we never used anyway