### PR TITLE
smtp: free a temp resource

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -677,6 +677,7 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data)
         /* An invalid mailbox was provided but we'll simply let the server
            worry about it */
         auth = aprintf("<%s>", address);
+      free(address);
     }
     else
       /* Empty AUTH, RFC-2554, sect. 5 */


### PR DESCRIPTION
The returned address needs to be freed.

Follow-up to e3905de8196d67b89df1602feb84c1f993211b20 Spotted by Coverity