### PR TITLE
openssl-quic: fix BIO leak and Windows warning

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1092,7 +1092,6 @@ static CURLcode cf_osslq_ctx_start(struct Curl_cfilter *cf,
 #else
   bio = BIO_new_dgram(ctx->q.sockfd, BIO_NOCLOSE);
 #endif
-  bio = BIO_new_dgram(ctx->q.sockfd, BIO_NOCLOSE);
   if(!bio) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;


### PR DESCRIPTION
Caused by an accidentally duplicated line in
d6825df334def106f735ce7e0c1a2ea87bddffb0.

```
.../lib/vquic/curl_osslq.c:1095:30: warning: implicit conversion loses integer precision: 'curl_socket_t' (aka 'unsigned long long') to 'int' [-Wshorten-64-to-32]
 1095 |   bio = BIO_new_dgram(ctx->q.sockfd, BIO_NOCLOSE);
      |         ~~~~~~~~~~~~~ ~~~~~~~^~~~~~
1 warning and 2 errors generated.
```

Closes #13043