### PR TITLE
http: better error message for HTTP/1.x response without status line

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3505,6 +3505,10 @@ static CURLcode http_rw_headers(struct Curl_easy *data,
           /* this is not the beginning of a protocol first header line */
           k->header = FALSE;
           streamclose(conn, "bad HTTP: No end-of-message indicator");
+          if(conn->httpversion >= 10) {
+            failf(data, "Invalid status line");
+            return CURLE_WEIRD_SERVER_REPLY;
+          }
           if(!data->set.http09_allowed) {
             failf(data, "Received HTTP/0.9 when not allowed");
             return CURLE_UNSUPPORTED_PROTOCOL;
@@ -3538,6 +3542,10 @@ static CURLcode http_rw_headers(struct Curl_easy *data,
       if(st == STATUS_BAD) {
         streamclose(conn, "bad HTTP: No end-of-message indicator");
         /* this is not the beginning of a protocol first header line */
+        if(conn->httpversion >= 10) {
+          failf(data, "Invalid status line");
+          return CURLE_WEIRD_SERVER_REPLY;
+        }
         if(!data->set.http09_allowed) {
           failf(data, "Received HTTP/0.9 when not allowed");
           return CURLE_UNSUPPORTED_PROTOCOL;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -188,6 +188,7 @@ test1447 test1448 test1449 test1450 test1451 test1452 test1453 test1454 \
 test1455 test1456 test1457 test1458 test1459 test1460 test1461 test1462 \
 test1463 test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
 test1471 test1472 test1473 test1474 test1475 test1476 test1477 test1478 \
+test1479 test1480 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1479
+++ b/tests/data/test1479
@@ -1,0 +1,67 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP/0.9
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Content-Length: 5
+
+Data
+</data>
+<data2>
+Data
+Data
+Data
+</data2>
+<datacheck>
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP/1.1 response followed by an HTTP/0.9 response over the same connection
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER http://%HOSTIP:%HTTPPORT/%TESTNUMBER0002
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER0002 HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+
+# Hyper curl returns unsupported protocol
+# built-in curl returns weird_server_reply
+<errorcode>
+%if hyper
+1
+%else
+8
+%endif
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test1480
+++ b/tests/data/test1480
@@ -1,0 +1,58 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 100 Continue
+Foo: Bar
+
+Data
+Data
+Data
+</data>
+<datacheck>
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP Continue response without final response
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+
+# Hyper curl returns unsupported protocol
+# built-in curl returns weird_server_reply
+<errorcode>
+%if hyper
+1
+%else
+8
+%endif
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
If a response without a status line is received, and the connection is known to use HTTP/1.x (not HTTP/0.9), report the error "Invalid status line" instead of "Received HTTP/0.9 when not allowed".