### PR TITLE
docs: ascii version of manpage without nroff

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -68,35 +68,6 @@ macro(curl_internal_test CURL_TEST)
   endif()
 endmacro()
 
-macro(curl_nroff_check)
-  find_program(NROFF NAMES gnroff nroff)
-  if(NROFF)
-    # Need a way to write to stdin, this will do
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/nroff-input.txt" "test")
-    # Tests for a valid nroff option to generate a manpage
-    foreach(_MANOPT "-man" "-mandoc")
-      execute_process(COMMAND "${NROFF}" ${_MANOPT}
-        OUTPUT_VARIABLE NROFF_MANOPT_OUTPUT
-        INPUT_FILE "${CMAKE_CURRENT_BINARY_DIR}/nroff-input.txt"
-        ERROR_QUIET)
-      # Save the option if it was valid
-      if(NROFF_MANOPT_OUTPUT)
-        message("Found *nroff option: -- ${_MANOPT}")
-        set(NROFF_MANOPT ${_MANOPT})
-        set(NROFF_USEFUL ON)
-        break()
-      endif()
-    endforeach()
-    # No need for the temporary file
-    file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/nroff-input.txt")
-    if(NOT NROFF_USEFUL)
-      message(WARNING "Found no *nroff option to get plaintext from man pages")
-    endif()
-  else()
-    message(WARNING "Found no *nroff program")
-  endif()
-endmacro()
-
 macro(optional_dependency DEPENDENCY)
   set(CURL_${DEPENDENCY} AUTO CACHE STRING "Build curl with ${DEPENDENCY} support (AUTO, ON or OFF)")
   set_property(CACHE CURL_${DEPENDENCY} PROPERTY STRINGS AUTO ON OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,13 +312,10 @@ option(ENABLE_CURL_MANUAL "to build the man page for curl and enable its -M/--ma
 
 if(ENABLE_CURL_MANUAL OR BUILD_LIBCURL_DOCS)
   if(PERL_FOUND)
-    curl_nroff_check()
-    if(NROFF_USEFUL)
-      set(HAVE_MANUAL_TOOLS ON)
-    endif()
+    set(HAVE_MANUAL_TOOLS ON)
   endif()
   if(NOT HAVE_MANUAL_TOOLS)
-    message(WARNING "Perl not found, or nroff not useful. Will not build manuals.")
+    message(WARNING "Perl not found. Will not build manuals.")
   endif()
 endif()
 

--- a/GIT-INFO
+++ b/GIT-INFO
@@ -36,9 +36,9 @@ following software installed:
  o libtool  1.4.2 (or later)
  o GNU m4 (required by autoconf)
 
- o nroff + perl
+ o perl
 
-   If you don't have nroff and perl and you for some reason don't want to
-   install them, you can rename the source file src/tool_hugehelp.c.cvs to
-   src/tool_hugehelp.c and avoid having to generate this file. This will
-   give you a stubbed version of the file that doesn't contain actual content.
+   If you don't have perl and don't want to install it, you can rename the
+   source file src/tool_hugehelp.c.cvs to src/tool_hugehelp.c and avoid having
+   to generate this file. This will give you a stubbed version of the file
+   that doesn't contain actual content.

--- a/Makefile.am
+++ b/Makefile.am
@@ -134,7 +134,7 @@ CLEANFILES = $(VC14_LIBVCXPROJ) $(VC14_SRCVCXPROJ) \
 
 bin_SCRIPTS = curl-config
 
-SUBDIRS = lib src scripts
+SUBDIRS = lib docs src scripts
 DIST_SUBDIRS = $(SUBDIRS) tests packages scripts include docs
 
 pkgconfigdir = $(libdir)/pkgconfig

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -60,7 +60,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     '-DCMAKE_INSTALL_PREFIX=C:/CURL' \
     "-DCMAKE_BUILD_TYPE=${PRJ_CFG}"
   # shellcheck disable=SC2086
-  cmake --build _bld --config "${PRJ_CFG}" -- ${BUILD_OPT:-}
+  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --clean-first -- ${BUILD_OPT:-}
   if [ "${SHARED}" = 'ON' ]; then
     cp -f -p _bld/lib/*.dll _bld/src/
   fi

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -60,7 +60,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     '-DCMAKE_INSTALL_PREFIX=C:/CURL' \
     "-DCMAKE_BUILD_TYPE=${PRJ_CFG}"
   # shellcheck disable=SC2086
-  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --clean-first -- ${BUILD_OPT:-}
+  cmake --build _bld --config "${PRJ_CFG}" -- ${BUILD_OPT:-}
   if [ "${SHARED}" = 'ON' ]; then
     cp -f -p _bld/lib/*.dll _bld/src/
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -3826,10 +3826,6 @@ AC_CHECK_DECL([fseeko],
 
 CURL_CHECK_NONBLOCKING_SOCKET
 
-dnl ************************************************************
-dnl nroff tool stuff
-dnl
-
 AC_PATH_PROG( PERL, perl, ,
   $PATH:/usr/local/bin/perl:/usr/bin/:/usr/local/bin )
 AC_SUBST(PERL)
@@ -3843,40 +3839,6 @@ fi
 
 dnl set variable for use in automakefile(s)
 AM_CONDITIONAL(BUILD_DOCS, test x"$BUILD_DOCS" = x1)
-
-AC_PATH_PROGS( NROFF, gnroff nroff, ,
-  $PATH:/usr/bin/:/usr/local/bin )
-AC_SUBST(NROFF)
-
-if test -n "$NROFF"; then
-  dnl only check for nroff options if an nroff command was found
-
-  AC_MSG_CHECKING([how to use *nroff to get plain text from man pages])
-  MANOPT="-man"
-  mancheck=`echo foo | $NROFF $MANOPT 2>/dev/null`
-  if test -z "$mancheck"; then
-    MANOPT="-mandoc"
-   mancheck=`echo foo | $NROFF $MANOPT 2>/dev/null`
-    if test -z "$mancheck"; then
-      MANOPT=""
-      AC_MSG_RESULT([failed])
-      AC_MSG_WARN([found no *nroff option to get plaintext from man pages])
-    else
-      AC_MSG_RESULT([$MANOPT])
-    fi
-  else
-    AC_MSG_RESULT([$MANOPT])
-  fi
-  AC_SUBST(MANOPT)
-fi
-
-if test -z "$MANOPT"
-then
-  dnl if no nroff tool was found, or no option that could convert man pages
-  dnl was found, then disable the built-in manual stuff
-  AC_MSG_WARN([disabling built-in manual])
-  USE_MANUAL="no";
-fi
 
 dnl *************************************************************************
 dnl If the manual variable still is set, then we go with providing a built-in

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -43,7 +43,6 @@ versions of libs and build tools.
  - GNU M4       1.4
  - perl         5.6
  - roffit       0.5
- - nroff        any version that supports `-man [in] [out]`
  - cmake        3.7
 
 Library Symbols

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -30,16 +30,14 @@ MK_CA_DOCS = mk-ca-bundle.1
 CURLCONF_DOCS = curl-config.1
 endif
 
-man_MANS = $(abs_builddir)/curl.1 curl-config.1
+man_MANS = curl-config.1
 CURLPAGES = curl-config.md mk-ca-bundle.md
 
-# Build targets in this file (.) before cmdline-opts to ensure that
-# the curl.1 rule below runs first
 SUBDIRS = . cmdline-opts libcurl
 DIST_SUBDIRS = $(SUBDIRS) examples
 
 if BUILD_DOCS
-CLEANFILES = curl.1 mk-ca-bundle.1 curl-config.1
+CLEANFILES = mk-ca-bundle.1 curl-config.1
 endif
 
 EXTRA_DIST =                                    \
@@ -112,20 +110,6 @@ SUFFIXES = .1 .md
 
 all: $(MK_CA_DOCS)
 
-# $(abs_builddir) is to disable VPATH when searching for this file, which
-# would otherwise find the copy in $(srcdir) which breaks the $(HUGE)
-# rule in src/Makefile.am in out-of-tree builds that references the file in the
-# build directory.
-#
-# First, seed the used copy of curl.1 with the prebuilt copy (in an out-of-tree
-# build), then run make recursively to rebuild it only if its dependencies
-# have changed.
-$(abs_builddir)/curl.1:
-	if test "$(top_builddir)x" != "$(top_srcdir)x" -a -e "$(srcdir)/curl.1"; then \
-		$(INSTALL_DATA) "$(srcdir)/curl.1" $@ \
-		&& touch -r "$(srcdir)/curl.1" $@; fi
-	cd cmdline-opts && $(MAKE)
-
 .md.1:
 	$(CD2)$(CD2NROFF)
 
@@ -135,6 +119,3 @@ mk-ca-bundle.1: mk-ca-bundle.md
 
 distclean:
 	rm -f $(CLEANFILES)
-
-dist-hook:
-	cp $(builddir)/curl.1 $(builddir)/curl.1.dist

--- a/docs/TODO
+++ b/docs/TODO
@@ -177,7 +177,6 @@
  18.29 --retry and transfer timeouts
 
  19. Build
- 19.1 avoid nroff
  19.2 Enable PIE and RELRO by default
  19.3 Do not use GNU libtool on OpenBSD
  19.4 Package curl for Windows in a signed installer
@@ -1290,14 +1289,6 @@
 
 
 19. Build
-
-19.1 avoid nroff
-
- With the switch to the markdown-like documentation format since curl 8.6.0,
- it should (with a manageable amount of work) be possible to render an ASCII
- version of the man page without involving nroff and thus remove that
- dependency for building the hugehelp file, used to build in the man page into
- the curl command line tool.
 
 19.2 Enable PIE and RELRO by default
 

--- a/docs/cmdline-opts/CMakeLists.txt
+++ b/docs/cmdline-opts/CMakeLists.txt
@@ -21,7 +21,8 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-set(MANPAGE "${CURL_BINARY_DIR}/docs/curl.1")
+set(MANPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1")
+set(ASCIIPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt")
 
 # Load DPAGES and OTHERPAGES from shared file
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
@@ -29,6 +30,7 @@ include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 add_custom_command(OUTPUT "${MANPAGE}"
   COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && "${PERL_EXECUTABLE}" "./gen.pl" mainpage ${DPAGES} > "${MANPAGE}"
+  COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && "${PERL_EXECUTABLE}" "./gen.pl" ascii ${DPAGES} > "${ASCIIPAGE}"
   VERBATIM
 )
 add_custom_target(generate-curl.1 ALL DEPENDS "${MANPAGE}")

--- a/docs/cmdline-opts/Makefile.am
+++ b/docs/cmdline-opts/Makefile.am
@@ -24,7 +24,10 @@
 
 AUTOMAKE_OPTIONS = foreign no-dependencies
 
-MANPAGE = $(top_builddir)/docs/curl.1
+MANPAGE = curl.1
+ASCIIPAGE = curl.txt
+
+man_MANS = $(MANPAGE)
 
 include Makefile.inc
 
@@ -35,10 +38,21 @@ GN_0 = @echo "  GENERATE" $@;
 GN_1 =
 GN_ = $(GN_0)
 
-all: $(MANPAGE)
+if BUILD_DOCS
+CLEANFILES = $(MANPAGE) $(ASCIIPAGE)
+
+all: $(MANPAGE) $(ASCIIPAGE)
+
+endif
 
 $(MANPAGE): $(DPAGES) $(SUPPORT) mainpage.idx Makefile.inc gen.pl
-	$(GEN)(rm -f $(MANPAGE) && cd $(srcdir) && @PERL@ ./gen.pl mainpage $(DPAGES) > $(builddir)/manpage.tmp.$$$$ && mv $(builddir)/manpage.tmp.$$$$ $(MANPAGE))
+	$(GEN)(rm -f $(MANPAGE) && (cd $(srcdir) && @PERL@ ./gen.pl mainpage $(DPAGES)) > manpage.tmp.$$$$ && mv manpage.tmp.$$$$ $(MANPAGE))
+
+$(ASCIIPAGE): $(DPAGES) $(SUPPORT) mainpage.idx Makefile.inc gen.pl
+	$(GEN)(rm -f $(ASCIIPAGE) && (cd $(srcdir) && @PERL@ ./gen.pl ascii $(DPAGES)) > asciipage.tmp.$$$$ && mv asciipage.tmp.$$$$ $(ASCIIPAGE))
 
 listhelp:
 	./gen.pl listhelp $(DPAGES) > $(top_builddir)/src/tool_listhelp.c
+
+dist-hook: $(MANPAGE)
+	cp $(MANPAGE) $(MANPAGE).dist

--- a/docs/cmdline-opts/_PROGRESS.md
+++ b/docs/cmdline-opts/_PROGRESS.md
@@ -1,6 +1,6 @@
 <!-- Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al. -->
 <!-- SPDX-License-Identifier: curl -->
-# "PROGRESS METER"
+# PROGRESS METER
 
 curl normally displays a progress meter during operations, indicating the
 amount of transferred data, transfer speeds and estimated time left, etc. The

--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -32,7 +32,7 @@ function(add_manual_pages _listname)
       # Special case, an auto-generated file.
       string(REPLACE ".3" ".md" _mdfile "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
     else()
-      string(REPLACE ".3" ".md" _mdfile "${_file}")
+      string(REPLACE ".3" ".md" _mdfile "${CMAKE_CURRENT_SOURCE_DIR}/${_file}")
     endif()
     add_custom_command(OUTPUT "${_rofffile}"
       COMMAND ${PROJECT_SOURCE_DIR}/scripts/cd2nroff ${_mdfile} > ${_rofffile}

--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -35,7 +35,7 @@ function(add_manual_pages _listname)
       string(REPLACE ".3" ".md" _mdfile "${CMAKE_CURRENT_SOURCE_DIR}/${_file}")
     endif()
     add_custom_command(OUTPUT "${_rofffile}"
-      COMMAND ${PROJECT_SOURCE_DIR}/scripts/cd2nroff ${_mdfile} > ${_rofffile}
+      COMMAND "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff ${_mdfile} > ${_rofffile}
       DEPENDS "${_mdfile}"
       VERBATIM
     )

--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -41,7 +41,7 @@ function(add_manual_pages _listname)
 
   add_custom_command(OUTPUT ${_rofffiles}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMAND ${PROJECT_SOURCE_DIR}/scripts/cd2nroff -k -d "${CMAKE_CURRENT_BINARY_DIR}" ${_mdfiles}
+    COMMAND "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff -k -d "${CMAKE_CURRENT_BINARY_DIR}" ${_mdfiles}
     DEPENDS ${_mdfiles}
     VERBATIM
   )

--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -26,25 +26,20 @@ transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 function(add_manual_pages _listname)
-  unset(_rofffiles)
-  unset(_mdfiles)
   foreach(_file IN LISTS ${_listname})
-    list(APPEND _rofffiles "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
+    set(_rofffile "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
     if(_file STREQUAL "libcurl-symbols.3")
       # Special case, an auto-generated file.
       string(REPLACE ".3" ".md" _mdfile "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
     else()
       string(REPLACE ".3" ".md" _mdfile "${_file}")
     endif()
-    list(APPEND _mdfiles "${_mdfile}")
+    add_custom_command(OUTPUT "${_rofffile}"
+      COMMAND ${PROJECT_SOURCE_DIR}/scripts/cd2nroff ${_mdfile} > ${_rofffile}
+      DEPENDS "${_mdfile}"
+      VERBATIM
+    )
   endforeach()
-
-  add_custom_command(OUTPUT ${_rofffiles}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMAND "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff -k -d "${CMAKE_CURRENT_BINARY_DIR}" ${_mdfiles}
-    DEPENDS ${_mdfiles}
-    VERBATIM
-  )
 
 endfunction()
 

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -77,3 +77,6 @@ if USE_FISH_COMPLETION
   fi
 endif
 endif
+
+distclean:
+	rm -f $(CLEANFILES)

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -113,7 +113,7 @@ sub single {
 
     if(defined($f)) {
         if(!open($fh, "<:crlf", "$f")) {
-            print STDERR "Failed to open $f : $!\n";
+            print STDERR "cd2nroff failed to open '$f' for reading: $!\n";
             return 1;
         }
     }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,23 +26,18 @@ add_definitions(-DBUILDING_CURL)
 
 if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
   add_definitions("-DUSE_MANUAL")
-  # Use the C locale to ensure that only ASCII characters appear in the
-  # embedded text. NROFF and MANOPT are set in the parent CMakeLists.txt
   add_custom_command(
     OUTPUT tool_hugehelp.c
     COMMAND ${CMAKE_COMMAND} -E echo "#include \"tool_setup.h\"" > tool_hugehelp.c
     COMMAND ${CMAKE_COMMAND} -E echo "#ifndef HAVE_LIBZ" >> tool_hugehelp.c
-    COMMAND env LC_ALL=C "${NROFF}" ${NROFF_MANOPT}
-            "${CURL_BINARY_DIR}/docs/curl.1" |
-            "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" >> tool_hugehelp.c
+    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" < "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt" >> tool_hugehelp.c
+
     COMMAND ${CMAKE_COMMAND} -E echo "#else" >> tool_hugehelp.c
-    COMMAND env LC_ALL=C "${NROFF}" ${NROFF_MANOPT}
-            "${CURL_BINARY_DIR}/docs/curl.1" |
-            "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c >> tool_hugehelp.c
+    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c < "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt" >> tool_hugehelp.c
     COMMAND ${CMAKE_COMMAND} -E echo "#endif /* HAVE_LIBZ */" >> tool_hugehelp.c
     DEPENDS
       generate-curl.1
-      "${CURL_BINARY_DIR}/docs/curl.1"
+      "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1"
       "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
     VERBATIM)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -96,7 +96,7 @@ EXTRA_DIST = mkhelp.pl \
  Makefile.mk curl.rc Makefile.inc CMakeLists.txt .checksrc
 
 # Use absolute directory to disable VPATH
-MANPAGE=$(abs_top_builddir)/docs/curl.1
+ASCIIPAGE=$(abs_top_builddir)/docs/cmdline-opts/curl.txt
 MKHELP=$(top_srcdir)/src/mkhelp.pl
 HUGE=tool_hugehelp.c
 
@@ -113,24 +113,24 @@ CS_ = $(CS_0)
 if USE_MANUAL
 # Here are the stuff to create a built-in manual
 
-$(MANPAGE):
+$(ASCIIPAGE):
 	cd $(top_builddir)/docs && $(MAKE)
 
 if HAVE_LIBZ
 # This generates the tool_hugehelp.c file in both uncompressed and
 # compressed formats.
-$(HUGE): $(MANPAGE) $(MKHELP)
+$(HUGE): $(ASCIIPAGE) $(MKHELP)
 	$(HUGECMD) (echo '#include "tool_setup.h"' > $(HUGE);   \
 	echo '#ifndef HAVE_LIBZ' >> $(HUGE);                    \
-	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) >> $(HUGE);     \
+	$(PERL) $(MKHELP) < $(ASCIIPAGE) >> $(HUGE);     \
 	echo '#else' >> $(HUGE);                                \
-	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) -c >> $(HUGE);  \
+	$(PERL) $(MKHELP) -c < $(ASCIIPAGE) >> $(HUGE);  \
 	echo '#endif /* HAVE_LIBZ */' >> $(HUGE) )
 else # HAVE_LIBZ
 # This generates the tool_hugehelp.c file uncompressed only
-$(HUGE): $(MANPAGE) $(MKHELP)
+$(HUGE): $(ASCIIPAGE) $(MKHELP)
 	$(HUGECMD)(echo '#include "tool_setup.h"' > $(HUGE);    \
-	$(NROFF) $(MANPAGE) | $(PERL) $(MKHELP) >> $(HUGE) )
+	$(PERL) $(MKHELP) < $(ASCIIPAGE) >> $(HUGE) )
 endif
 
 else # USE_MANUAL

--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -35,11 +35,11 @@ if($ARGV[0] eq "-c") {
     shift @ARGV;
 }
 
-push @out, "                                  _   _ ____  _\n";
-push @out, "  Project                     ___| | | |  _ \\| |\n";
-push @out, "                             / __| | | | |_) | |\n";
-push @out, "                            | (__| |_| |  _ <| |___\n";
-push @out, "                             \\___|\\___/|_| \\_\\_____|\n";
+push @out, "          _   _ ____  _\n";
+push @out, "      ___| | | |  _ \\| |\n";
+push @out, "     / __| | | | |_) | |\n";
+push @out, "    | (__| |_| |  _ <| |___\n";
+push @out, "     \\___|\\___/|_| \\_\\_____|\n";
 
 my $olen=0;
 while (<STDIN>) {
@@ -157,40 +157,43 @@ exit;
 }
 else {
     print <<HEAD
+static const char * const m[] = {
+HEAD
+        ;
+}
+
+my $blank;
+for my $n (@out) {
+    chomp $n;
+    $n =~ s/\\/\\\\/g;
+    $n =~ s/\"/\\\"/g;
+
+    if(!$n) {
+        $blank++;
+    }
+    else {
+        $n =~ s/        /\\t/g;
+        printf("  \"%s%s\",\n", $blank?"\\n":"", $n);
+        $blank = 0;
+    }
+}
+
+print <<ENDLINE
+  NULL
+};
 void hugehelp(void)
 {
-   fputs(
-HEAD
-         ;
+  int i = 0;
+  while(m[i])
+    puts(m[i++]);
 }
-
-$outsize=0;
-for(@out) {
-    chop;
-
-    $new = $_;
-
-    $outsize += length($new)+1; # one for the newline
-
-    $new =~ s/\\/\\\\/g;
-    $new =~ s/\"/\\\"/g;
-
-    # gcc 2.96 claims ISO C89 only is required to support 509 letter strings
-    if($outsize > 500) {
-        # terminate and make another fputs() call here
-        print ", stdout);\n fputs(\n";
-        $outsize=length($new)+1;
-    }
-    printf("\"%s\\n\"\n", $new);
-
-}
-
-print ", stdout) ;\n}\n";
+ENDLINE
+    ;
 
 foot();
 
 sub foot {
-  print <<FOOT
+    print <<FOOT
 #endif /* USE_MANUAL */
 FOOT
   ;

--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -44,45 +44,8 @@ push @out, "                             \\___|\\___/|_| \\_\\_____|\n";
 my $olen=0;
 while (<STDIN>) {
     my $line = $_;
-
-    # this should be removed:
-    $line =~ s/(.|_)//g;
-
-    # remove trailing CR from line. msysgit checks out files as line+CRLF
-    $line =~ s/\r$//;
-
-    $line =~ s/\x1b\x5b[0-9]+m//g; # escape sequence
-    if($line =~ /^([ \t]*\n|curl)/i) {
-        # cut off headers and empty lines
-        $wline++; # count number of cut off lines
-        next;
-    }
-
-    my $text = $line;
-    $text =~ s/^\s+//g; # cut off preceding...
-    $text =~ s/\s+$//g; # and trailing whitespaces
-
-    $tlen = length($text);
-
-    if($wline && ($olen == $tlen)) {
-        # if the previous line with contents was exactly as long as
-        # this line, then we ignore the newlines!
-
-        # We do this magic because a header may abort a paragraph at
-        # any line, but we don't want that to be noticed in the output
-        # here
-        $wline=0;
-    }
-    $olen = $tlen;
-
-    if($wline) {
-        # we only make one empty line max
-        $wline = 0;
-        push @out, "\n";
-    }
     push @out, $line;
 }
-push @out, "\n"; # just an extra newline
 
 print <<HEAD
 /*

--- a/tests/test1139.pl
+++ b/tests/test1139.pl
@@ -220,8 +220,8 @@ close($r);
 #########################################################################
 # parse the curl.1 man page, extract all documented command line options
 # The man page may or may not be rebuilt, so check both possible locations
-open($r, "<", "$buildroot/docs/curl.1") || open($r, "<", "$root/docs/curl.1") ||
-    die "no input file";
+open($r, "<", "$buildroot/docs/cmdline-opts/curl.1") || open($r, "<", "$root/docs/cmdline-opts/curl.1") ||
+    die "failed getting curl.1";
 my @manpage; # store all parsed parameters
 while(<$r>) {
     chomp;


### PR DESCRIPTION
# create ascii version of the manpage without nroff
 
 - build src/tool_hugegelp.c from the ascii manpage
 - the newly generated tool_hugehelp is 3K lines shorter and 50K smaller
 - move the the manpage and the ascii version build to docs/cmdline-opts
 - remove all use of nroff from the build process
 - should make the build entirely reproducible (by avoiding nroff)
    
## The ascii version of the manpage:
    
  - is built with gen.pl, just like the manpage is
  - has a right-justified column making the appearance similar to the previous version
  - uses a 4-space indent per level (instead of the old version's 7)
  - does not do hyphenation of words (which nroff does)

## history

We first made the curl build use nroff for building the hugehelp file in December 1998, for curl 5.2.

## `curl -M` sample

This is what the top of new version looks like in my terminal:

![curl-txt](https://github.com/curl/curl/assets/177011/302efee1-48a4-46a7-8db0-7f947f029801)
