### PR TITLE
cmake: enable `ENABLE_CURL_MANUAL` by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,8 +307,7 @@ endif()
 find_package(Perl)
 
 option(BUILD_LIBCURL_DOCS "to build libcurl man pages" ON)
-# curl source release tarballs come with the curl man page pre-built.
-option(ENABLE_CURL_MANUAL "to build the man page for curl and enable its -M/--manual option" OFF)
+option(ENABLE_CURL_MANUAL "to build the man page for curl and enable its -M/--manual option" ON)
 
 if(ENABLE_CURL_MANUAL OR BUILD_LIBCURL_DOCS)
   if(PERL_FOUND)


### PR DESCRIPTION
Meaning `curl.1` and `src/tool_hugehelp.c` are built by default, and `--manual` in curl tool is also enabled by default.

This syncs behaviour with autotools.

For a reproducible `curl.1`, `SOURCE_DATE_EPOCH` needs to be set to a consistent date, e.g. the timestamp of `CHANGES`.

A pre-built manual (e.g. the one distributed in the official source tarball) will be ignored and rebuilt after this patch, unless explicitly disabling this option.

Fixes #13028
Closes #13069