### PR TITLE
hyper, implement unpausing via client reader

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1126,16 +1126,6 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
       return result;
   }
 
-#ifdef USE_HYPER
-  if(!(newstate & KEEP_SEND_PAUSE)) {
-    /* need to wake the send body waker */
-    if(data->hyp.send_body_waker) {
-      hyper_waker_wake(data->hyp.send_body_waker);
-      data->hyp.send_body_waker = NULL;
-    }
-  }
-#endif
-
   /* if there's no error and we're not pausing both directions, we want
      to have this handle checked soon */
   if((newstate & (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) !=

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -523,6 +523,21 @@ void Curl_creader_def_close(struct Curl_easy *data,
   (void)reader;
 }
 
+CURLcode Curl_creader_def_read(struct Curl_easy *data,
+                               struct Curl_creader *reader,
+                               char *buf, size_t blen,
+                               size_t *nread, bool *eos)
+{
+  if(reader->next)
+    return reader->next->crt->do_read(data, reader->next, buf, blen,
+                                      nread, eos);
+  else {
+    *nread = 0;
+    *eos = FALSE;
+    return CURLE_READ_ERROR;
+  }
+}
+
 bool Curl_creader_def_needs_rewind(struct Curl_easy *data,
                                    struct Curl_creader *reader)
 {

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -241,6 +241,10 @@ CURLcode Curl_creader_def_init(struct Curl_easy *data,
                                struct Curl_creader *reader);
 void Curl_creader_def_close(struct Curl_easy *data,
                             struct Curl_creader *reader);
+CURLcode Curl_creader_def_read(struct Curl_easy *data,
+                               struct Curl_creader *reader,
+                               char *buf, size_t blen,
+                               size_t *nread, bool *eos);
 bool Curl_creader_def_needs_rewind(struct Curl_easy *data,
                                    struct Curl_creader *reader);
 curl_off_t Curl_creader_def_total_length(struct Curl_easy *data,

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -46,6 +46,7 @@ my %wl = (
     'Curl_xfer_write_resp' => 'internal api',
     'Curl_creader_def_init' => 'internal api',
     'Curl_creader_def_close' => 'internal api',
+    'Curl_creader_def_read' => 'internal api',
     'Curl_creader_def_total_length' => 'internal api',
 );
 


### PR DESCRIPTION
Just a tidy up to contain 'ifdef' pollution of common code parts with implementation specifics.

- remove the ifdef hyper unpausing in easy.c
- add hyper client reader for CURL_CR_PROTOCOL phase that implements the unpause method for calling the hyper waker if it is set