### PR TITLE
mkhelp: rename variable to fix compiler warnings

### DIFF
--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -157,7 +157,7 @@ exit;
 }
 else {
     print <<HEAD
-static const char * const m[] = {
+static const char * const curlman[] = {
 HEAD
         ;
 }
@@ -184,8 +184,8 @@ print <<ENDLINE
 void hugehelp(void)
 {
   int i = 0;
-  while(m[i])
-    puts(m[i++]);
+  while(curlman[i])
+    puts(curlman[i++]);
 }
 ENDLINE
     ;


### PR DESCRIPTION
```
src\tool_operate.c(541,33): warning C4459: declaration of 'm' hides global declaration [_bld\src\curl.vcxproj]
  _bld\src\tool_hugehelp.c(8,27):
  see declaration of 'm'
src\tool_paramhlp.c(307,14): warning C4459: declaration of 'm' hides global declaration [_bld\src\curl.vcxproj]
src\tool_progress.c(118,16): warning C4459: declaration of 'm' hides global declaration [_bld\src\curl.vcxproj]
src\tool_writeout.c(288,31): warning C4459: declaration of 'm' hides global declaration [_bld\src\curl.vcxproj]
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/49348159/job/51ee75cd2n0wj6lc#L614

Closes #13077