### PR TITLE
test1140/1173: extend wildcards to find curl.1

### DIFF
--- a/docs/cmdline-opts/Makefile.am
+++ b/docs/cmdline-opts/Makefile.am
@@ -53,6 +53,3 @@ $(ASCIIPAGE): $(DPAGES) $(SUPPORT) mainpage.idx Makefile.inc gen.pl
 
 listhelp:
 	./gen.pl listhelp $(DPAGES) > $(top_builddir)/src/tool_listhelp.c
-
-dist-hook: $(MANPAGE)
-	cp $(MANPAGE) $(MANPAGE).dist

--- a/tests/data/test1140
+++ b/tests/data/test1140
@@ -19,7 +19,7 @@ Verify the nroff of manpages
 </name>
 
 <command type="perl">
-%SRCDIR/test1140.pl %PWD/../docs/ %PWD/../docs/libcurl/*.3 %PWD/../docs/libcurl/opts/*.3 %PWD/../docs/*.1
+%SRCDIR/test1140.pl %PWD/../docs/ %PWD/../docs/libcurl/*.3 %PWD/../docs/libcurl/opts/*.3 %PWD/../docs/*.1 %PWD/../docs/cmdline-opts/*.1
 </command>
 </client>
 

--- a/tests/data/test1173
+++ b/tests/data/test1173
@@ -19,7 +19,7 @@ Man page syntax checks
 </name>
 
 <command type="perl">
-%SRCDIR/test1173.pl %SRCDIR/../docs/libcurl/symbols-in-versions %PWD/../docs/*.1  %PWD/../docs/libcurl/*.3 %PWD/../docs/libcurl/opts/*.3
+%SRCDIR/test1173.pl %SRCDIR/../docs/libcurl/symbols-in-versions %PWD/../docs/*.1  %PWD/../docs/cmdline-opts/*.1 %PWD/../docs/libcurl/*.3 %PWD/../docs/libcurl/opts/*.3
 </command>
 </client>
 

--- a/tests/test1140.pl
+++ b/tests/test1140.pl
@@ -57,7 +57,7 @@ sub manpresent {
 sub file {
     my ($f) = @_;
     open(my $fh, "<", "$f") ||
-        die "no file";
+        die "test1140.pl could not open $f";
     my $line = 1;
     while(<$fh>) {
         chomp;

--- a/tests/test1173.pl
+++ b/tests/test1173.pl
@@ -132,7 +132,8 @@ sub scanmanpage {
     my @separators;
     my @sepline;
 
-    open(my $m, "<", "$file") || die "no such file: $file";
+    open(my $m, "<", "$file") ||
+        die "test1173.pl could not open $file";
     if($file =~ /[\/\\](CURL|curl_)[^\/\\]*.3/) {
         # This is a man page for libcurl. It requires an example!
         $reqex = 1;


### PR DESCRIPTION
... in its new build path.

Also update the test scripts to be more precise in error messages to help us understand CI errors better.

Ref: #13029

Follow-up to f03c85635f35269f1