### PR TITLE
lib1598: fix `CURLOPT_POSTFIELDSIZE` usage

### DIFF
--- a/tests/libtest/lib1598.c
+++ b/tests/libtest/lib1598.c
@@ -87,7 +87,7 @@ int test(char *URL)
 
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, strlen(post_data));
+  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(post_data));
   test_setopt(curl, CURLOPT_POSTFIELDS, post_data);
   test_setopt(curl, CURLOPT_TRAILERFUNCTION, trailers_callback);
   test_setopt(curl, CURLOPT_TRAILERDATA, NULL);


### PR DESCRIPTION
It requires a `long` argument.