### PR TITLE
tool_getparam: handle non-existing (out of range) short-options

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1009,7 +1009,8 @@ static const struct LongShort *single(char letter)
 {
   static const struct LongShort *singles[128 - ' ']; /* ASCII => pointer */
   static bool singles_done = FALSE;
-  DEBUGASSERT((letter < 127) && (letter > ' '));
+  if((letter >= 127) || (letter <= ' '))
+    return NULL;
 
   if(!singles_done) {
     unsigned int j;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -73,7 +73,7 @@ test426 test427 test428 test429 test430 test431 test432 test433 test434 \
 test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
-test462 test463 \
+test462 test463 test467 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \

--- a/tests/data/test467
+++ b/tests/data/test467
@@ -1,0 +1,31 @@
+<testcase>
+<info>
+<keywords>
+cmdline
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<name>
+use a bad short option letter that does not exist (after one does exist)
+</name>
+
+# the second option is outside the normal accepted range
+<command>
+curl -v http://example.com
+</command>
+</client>
+
+#
+# Verify errorcode
+<verify>
+<errorcode>
+2
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
... correctly, even when they follow an existing one without a space in between.

Verify with test 467

Follow-up to 07dd60c05b
Reported-by: Geeknik Labs
Fixes #13101
Closes #13102