### PR TITLE
managen: remove space before protocols

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -232,7 +232,7 @@ sub protocols {
         return ".SH \"PROTOCOLS\"\n$data\n";
     }
     else {
-        return " ($data) " if($manpage);
+        return "($data) " if($manpage);
         return "[1]($data) " if(!$manpage);
     }
 }


### PR DESCRIPTION
For options that are listed for specific protocols, the protocols (shown first within parentheses) are now output without the leading space. In the manpage output.