### PR TITLE
HTTP Expect 100-continue rework

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -219,17 +219,16 @@ static int hyper_body_chunk(void *userdata, const hyper_buf *chunk)
       Curl_safefree(data->req.newurl);
     }
 #endif
-    if(data->req.expect100header) {
-      Curl_expire_done(data, EXPIRE_100_TIMEOUT);
+    if(Curl_http_exp100_is_selected(data)) {
       if(data->req.httpcode < 400) {
-        k->exp100 = EXP100_SEND_DATA;
-        if(data->hyp.exp100_waker) {
-          hyper_waker_wake(data->hyp.exp100_waker);
-          data->hyp.exp100_waker = NULL;
+        Curl_http_exp100_got100(data);
+        if(data->hyp.send_body_waker) {
+          hyper_waker_wake(data->hyp.send_body_waker);
+          data->hyp.send_body_waker = NULL;
         }
       }
       else { /* >= 4xx */
-        k->exp100 = EXP100_FAILED;
+        Curl_req_abort_sending(data);
       }
     }
     if(data->state.hconnect && (data->req.httpcode/100 != 2) &&
@@ -353,20 +352,9 @@ CURLcode Curl_hyper_stream(struct Curl_easy *data,
   struct SingleRequest *k = &data->req;
   (void)conn;
 
-  if(k->exp100 > EXP100_SEND_DATA) {
-    struct curltime now = Curl_now();
-    timediff_t ms = Curl_timediff(now, k->start100);
-    if(ms >= data->set.expect_100_timeout) {
-      /* we've waited long enough, continue anyway */
-      k->exp100 = EXP100_SEND_DATA;
-      k->keepon |= KEEP_SEND;
-      Curl_expire_done(data, EXPIRE_100_TIMEOUT);
-      infof(data, "Done waiting for 100-continue after %ldms", (long)ms);
-      if(data->hyp.exp100_waker) {
-        hyper_waker_wake(data->hyp.exp100_waker);
-        data->hyp.exp100_waker = NULL;
-      }
-    }
+  if(data->hyp.send_body_waker) {
+    hyper_waker_wake(data->hyp.send_body_waker);
+    data->hyp.send_body_waker = NULL;
   }
 
   if(select_res & CURL_CSELECT_IN) {
@@ -461,7 +449,7 @@ CURLcode Curl_hyper_stream(struct Curl_easy *data,
     reasonp = hyper_response_reason_phrase(resp);
     reason_len = hyper_response_reason_phrase_len(resp);
 
-    if(http_status == 417 && data->req.expect100header) {
+    if(http_status == 417 && Curl_http_exp100_is_selected(data)) {
       infof(data, "Got 417 while waiting for a 100");
       data->state.disableexpect = TRUE;
       data->req.newurl = strdup(data->state.url);
@@ -664,17 +652,6 @@ static int uploadstreamed(void *userdata, hyper_context *ctx,
   bool eos;
   int rc = HYPER_POLL_ERROR;
   (void)ctx;
-
-  if(data->req.exp100 > EXP100_SEND_DATA) {
-    if(data->req.exp100 == EXP100_FAILED)
-      return HYPER_POLL_ERROR;
-
-    /* still waiting confirmation */
-    if(data->hyp.exp100_waker)
-      hyper_waker_free(data->hyp.exp100_waker);
-    data->hyp.exp100_waker = hyper_context_waker(ctx);
-    return HYPER_POLL_PENDING;
-  }
 
   result = Curl_multi_xfer_ulbuf_borrow(data, &xfer_ulbuf, &xfer_ulblen);
   if(result)
@@ -974,11 +951,6 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
       goto error;
     }
   }
-  else {
-    if(!data->state.disableexpect) {
-      data->req.expect100header = TRUE;
-    }
-  }
 
   if(hyper_request_set_method(req, (uint8_t *)method, strlen(method))) {
     failf(data, "error setting method");
@@ -1203,10 +1175,6 @@ void Curl_hyper_done(struct Curl_easy *data)
     hyper_waker_free(h->write_waker);
     h->write_waker = NULL;
   }
-  if(h->exp100_waker) {
-    hyper_waker_free(h->exp100_waker);
-    h->exp100_waker = NULL;
-  }
   if(h->send_body_waker) {
     hyper_waker_free(h->send_body_waker);
     h->send_body_waker = NULL;
@@ -1235,6 +1203,7 @@ static const struct Curl_crtype cr_hyper_protocol = {
   Curl_creader_def_resume_from,
   Curl_creader_def_rewind,
   cr_hyper_unpause,
+  Curl_creader_def_done,
   sizeof(struct Curl_creader)
 };
 

--- a/lib/c-hyper.h
+++ b/lib/c-hyper.h
@@ -39,7 +39,6 @@ struct hyptransfer {
   hyper_waker *write_waker;
   hyper_waker *read_waker;
   const hyper_executor *exec;
-  hyper_waker *exp100_waker;
   hyper_waker *send_body_waker;
   struct hyp_io_ctx io_ctx;
 };

--- a/lib/http.c
+++ b/lib/http.c
@@ -4399,6 +4399,11 @@ static CURLcode cr_exp100_read(struct Curl_easy *data,
     *nread = 0;
     *eos = FALSE;
     return CURLE_OK;
+  case EXP100_FAILED:
+    DEBUGF(infof(data, "cr_exp100_read, expectation failed, error"));
+    *nread = 0;
+    *eos = FALSE;
+    return CURLE_READ_ERROR;
   case EXP100_AWAITING_CONTINUE:
     ms = Curl_timediff(Curl_now(), ctx->start);
     if(ms < data->set.expect_100_timeout) {

--- a/lib/http.h
+++ b/lib/http.h
@@ -176,6 +176,9 @@ CURLcode Curl_http_auth_act(struct Curl_easy *data);
    version. This count includes CONNECT response headers. */
 #define MAX_HTTP_RESP_HEADER_SIZE (300*1024)
 
+bool Curl_http_exp100_is_selected(struct Curl_easy *data);
+void Curl_http_exp100_got100(struct Curl_easy *data);
+
 #endif /* CURL_DISABLE_HTTP */
 
 /****************************************************************************

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -644,6 +644,7 @@ const struct Curl_crtype Curl_httpchunk_encoder = {
   Curl_creader_def_resume_from,
   Curl_creader_def_rewind,
   Curl_creader_def_unpause,
+  Curl_creader_def_done,
   sizeof(struct chunked_reader)
 };
 

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -2106,6 +2106,7 @@ static const struct Curl_crtype cr_mime = {
   cr_mime_resume_from,
   cr_mime_rewind,
   cr_mime_unpause,
+  Curl_creader_def_done,
   sizeof(struct cr_mime_ctx)
 };
 

--- a/lib/request.c
+++ b/lib/request.c
@@ -159,6 +159,7 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->getheader = FALSE;
   req->no_body = data->set.opt_no_body;
   req->authneg = FALSE;
+  req->expect100header = FALSE;
 }
 
 void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)

--- a/lib/request.c
+++ b/lib/request.c
@@ -134,8 +134,6 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->offset = 0;
   req->httpcode = 0;
   req->keepon = 0;
-  req->start100 = t0;
-  req->exp100 = EXP100_SEND_DATA;
   req->upgr101 = UPGR101_INIT;
   req->timeofdoc = 0;
   req->bodywrites = 0;
@@ -159,7 +157,6 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->getheader = FALSE;
   req->no_body = data->set.opt_no_body;
   req->authneg = FALSE;
-  req->expect100header = FALSE;
 }
 
 void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)
@@ -242,16 +239,6 @@ static CURLcode req_send_buffer_flush(struct Curl_easy *data)
     Curl_bufq_skip(&data->req.sendbuf, nwritten);
     if(hds_len) {
       data->req.sendbuf_hds_len -= CURLMIN(hds_len, nwritten);
-      if(!data->req.sendbuf_hds_len) {
-        /* all request headers sent */
-        if(data->req.exp100 == EXP100_SENDING_REQUEST) {
-          /* We are now waiting for a reply from the server or
-           * a timeout on our side */
-          data->req.exp100 = EXP100_AWAITING_CONTINUE;
-          data->req.start100 = Curl_now();
-          Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);
-        }
-      }
     }
     /* leave if we could not send all. Maybe network blocking or
      * speed limits on transfer */
@@ -265,11 +252,9 @@ static CURLcode req_set_upload_done(struct Curl_easy *data)
 {
   DEBUGASSERT(!data->req.upload_done);
   data->req.upload_done = TRUE;
-  data->req.keepon &= ~KEEP_SEND; /* we're done sending */
+  data->req.keepon &= ~(KEEP_SEND|KEEP_SEND_TIMED); /* we're done sending */
 
-  /* FIXME: http specific stuff, need to go somewhere else */
-  data->req.exp100 = EXP100_SEND_DATA;
-  Curl_expire_done(data, EXPIRE_100_TIMEOUT);
+  Curl_creader_done(data, data->req.upload_aborted);
 
   if(data->req.upload_aborted) {
     if(data->req.writebytecount)
@@ -385,10 +370,8 @@ CURLcode Curl_req_send_more(struct Curl_easy *data)
 {
   CURLcode result;
 
-  /* Fill our send buffer if more from client can be read and
-   * we are not in a "expect-100" situation. */
-  if(!data->req.eos_read && !Curl_bufq_is_full(&data->req.sendbuf) &&
-     (data->req.exp100 == EXP100_SEND_DATA)) {
+  /* Fill our send buffer if more from client can be read. */
+  if(!data->req.eos_read && !Curl_bufq_is_full(&data->req.sendbuf)) {
     ssize_t nread = Curl_bufq_sipn(&data->req.sendbuf, 0,
                                    add_from_client, data, &result);
     if(nread < 0 && result != CURLE_AGAIN)

--- a/lib/request.h
+++ b/lib/request.h
@@ -81,8 +81,6 @@ struct SingleRequest {
   int httpcode;                 /* error code from the 'HTTP/1.? XXX' or
                                    'RTSP/1.? XXX' line */
   int keepon;
-  struct curltime start100;      /* time stamp to wait for the 100 code from */
-  enum expect100 exp100;        /* expect 100 continue state */
   enum upgrade101 upgr101;      /* 101 upgrade state */
 
   /* Client Writer stack, handles transfer- and content-encodings, protocol
@@ -148,7 +146,6 @@ struct SingleRequest {
                         but it is not the final request in the auth
                         negotiation. */
   BIT(sendbuf_init); /* sendbuf is initialized */
-  BIT(expect100header); /* TRUE if we added Expect: 100-continue */
 };
 
 /**

--- a/lib/request.h
+++ b/lib/request.h
@@ -148,6 +148,7 @@ struct SingleRequest {
                         but it is not the final request in the auth
                         negotiation. */
   BIT(sendbuf_init); /* sendbuf is initialized */
+  BIT(expect100header); /* TRUE if we added Expect: 100-continue */
 };
 
 /**

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -555,8 +555,6 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
             goto out;
         }
       }
-
-      data->state.expect100header = FALSE; /* RTSP posts are simple/small */
     }
     else if(rtspreq == RTSPREQ_GET_PARAMETER) {
       /* Check for an empty GET_PARAMETER (heartbeat) request */

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -208,6 +208,8 @@ struct Curl_crtype {
                           struct Curl_creader *reader, curl_off_t offset);
   CURLcode (*rewind)(struct Curl_easy *data, struct Curl_creader *reader);
   CURLcode (*unpause)(struct Curl_easy *data, struct Curl_creader *reader);
+  void (*done)(struct Curl_easy *data,
+               struct Curl_creader *reader, int premature);
   size_t creader_size;  /* sizeof() allocated struct Curl_creader */
 };
 
@@ -256,6 +258,8 @@ CURLcode Curl_creader_def_rewind(struct Curl_easy *data,
                                  struct Curl_creader *reader);
 CURLcode Curl_creader_def_unpause(struct Curl_easy *data,
                                   struct Curl_creader *reader);
+void Curl_creader_def_done(struct Curl_easy *data,
+                           struct Curl_creader *reader, int premature);
 
 /**
  * Convenience method for calling `reader->do_read()` that
@@ -360,6 +364,19 @@ CURLcode Curl_creader_resume_from(struct Curl_easy *data, curl_off_t offset);
  * Unpause all installed readers.
  */
 CURLcode Curl_creader_unpause(struct Curl_easy *data);
+
+/**
+ * Tell all client readers that they are done.
+ */
+void Curl_creader_done(struct Curl_easy *data, int premature);
+
+/**
+ * Look up an installed client reader on `data` by its type.
+ * @return first reader with that type or NULL
+ */
+struct Curl_creader *Curl_creader_get_by_type(struct Curl_easy *data,
+                                              const struct Curl_crtype *crt);
+
 
 /**
  * Set the client reader to provide 0 bytes, immediate EOS.

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1923,6 +1923,7 @@ static const struct Curl_crtype cr_eob = {
   Curl_creader_def_resume_from,
   Curl_creader_def_rewind,
   Curl_creader_def_unpause,
+  Curl_creader_def_done,
   sizeof(struct cr_eob_ctx)
 };
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1182,8 +1182,8 @@ void Curl_xfer_setup(
          Thus, we must check if the request has been sent before we set the
          state info where we wait for the 100-return code
       */
-      if((data->state.expect100header) &&
-         (conn->handler->protocol&PROTO_FAMILY_HTTP)) {
+      if(k->expect100header) {
+        DEBUGASSERT(conn->handler->protocol&PROTO_FAMILY_HTTP);
         /* wait with write until we either got 100-continue or a timeout */
         k->exp100 = EXP100_AWAITING_CONTINUE;
         k->start100 = Curl_now();
@@ -1193,11 +1193,6 @@ void Curl_xfer_setup(
         Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);
       }
       else {
-        if(data->state.expect100header)
-          /* when we've sent off the rest of the headers, we must await a
-             100-continue but first finish sending the request */
-          k->exp100 = EXP100_SENDING_REQUEST;
-
         /* enable the write bit when we're not waiting for continue */
         k->keepon |= KEEP_SEND;
       }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -463,7 +463,8 @@ CURLcode Curl_readwrite(struct Curl_easy *data)
   }
 
   /* If we still have writing to do, we check if we have a writable socket. */
-  if((k->keepon & KEEP_SEND) && (select_bits & CURL_CSELECT_OUT)) {
+  if(((k->keepon & KEEP_SEND) && (select_bits & CURL_CSELECT_OUT)) ||
+     (k->keepon & KEEP_SEND_TIMED)) {
     /* write */
 
     result = readwrite_upload(data, &didwhat);
@@ -476,31 +477,6 @@ CURLcode Curl_readwrite(struct Curl_easy *data)
 
   now = Curl_now();
   if(!didwhat) {
-    /* no read no write, this is a timeout? */
-    if(k->exp100 == EXP100_AWAITING_CONTINUE) {
-      /* This should allow some time for the header to arrive, but only a
-         very short time as otherwise it'll be too much wasted time too
-         often. */
-
-      /* Quoting RFC2616, section "8.2.3 Use of the 100 (Continue) Status":
-
-         Therefore, when a client sends this header field to an origin server
-         (possibly via a proxy) from which it has never seen a 100 (Continue)
-         status, the client SHOULD NOT wait for an indefinite period before
-         sending the request body.
-
-      */
-
-      timediff_t ms = Curl_timediff(now, k->start100);
-      if(ms >= data->set.expect_100_timeout) {
-        /* we've waited long enough, continue anyway */
-        k->exp100 = EXP100_SEND_DATA;
-        k->keepon |= KEEP_SEND;
-        Curl_expire_done(data, EXPIRE_100_TIMEOUT);
-        infof(data, "Done waiting for 100-continue");
-      }
-    }
-
     result = Curl_conn_ev_data_idle(data);
     if(result)
       goto out;
@@ -1172,31 +1148,8 @@ void Curl_xfer_setup(
     if(sockindex != -1)
       k->keepon |= KEEP_RECV;
 
-    if(writesockindex != -1) {
-      /* HTTP 1.1 magic:
-
-         Even if we require a 100-return code before uploading data, we might
-         need to write data before that since the REQUEST may not have been
-         finished sent off just yet.
-
-         Thus, we must check if the request has been sent before we set the
-         state info where we wait for the 100-return code
-      */
-      if(k->expect100header) {
-        DEBUGASSERT(conn->handler->protocol&PROTO_FAMILY_HTTP);
-        /* wait with write until we either got 100-continue or a timeout */
-        k->exp100 = EXP100_AWAITING_CONTINUE;
-        k->start100 = Curl_now();
-
-        /* Set a timeout for the multi interface. Add the inaccuracy margin so
-           that we don't fire slightly too early and get denied to run. */
-        Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);
-      }
-      else {
-        /* enable the write bit when we're not waiting for continue */
-        k->keepon |= KEEP_SEND;
-      }
-    } /* if(writesockindex != -1) */
+    if(writesockindex != -1)
+      k->keepon |= KEEP_SEND;
   } /* if(k->getheader || !data->req.no_body) */
 
 }

--- a/lib/url.c
+++ b/lib/url.c
@@ -3898,7 +3898,6 @@ CURLcode Curl_init_do(struct Curl_easy *data, struct connectdata *conn)
   }
 
   data->state.done = FALSE; /* *_done() is not called yet */
-  data->state.expect100header = FALSE;
 
   if(data->req.no_body)
     /* in HTTP lingo, no body means using the HEAD request... */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -579,6 +579,14 @@ struct hostname {
 #define KEEP_RECV_PAUSE (1<<4) /* reading is paused */
 #define KEEP_SEND_PAUSE (1<<5) /* writing is paused */
 
+/* KEEP_SEND_TIMED is set when the transfer should attempt sending
+ * at timer (or other) events. A transfer waiting on a timer will
+  * remove KEEP_SEND to suppress POLLOUTs of the connection.
+  * Adding KEEP_SEND_TIMED will then attempt to send whenever the transfer
+  * enters the "readwrite" loop, e.g. when a timer fires.
+  * This is used in HTTP for 'Expect: 100-continue' waiting. */
+#define KEEP_SEND_TIMED (1<<6)
+
 #define KEEP_RECVBITS (KEEP_RECV | KEEP_RECV_HOLD | KEEP_RECV_PAUSE)
 #define KEEP_SENDBITS (KEEP_SEND | KEEP_SEND_HOLD | KEEP_SEND_PAUSE)
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1364,7 +1364,6 @@ struct UrlState {
   BIT(authproblem); /* TRUE if there's some problem authenticating */
   /* set after initial USER failure, to prevent an authentication loop */
   BIT(wildcardmatch); /* enable wildcard matching */
-  BIT(expect100header);  /* TRUE if we added Expect: 100-continue */
   BIT(disableexpect);    /* TRUE if Expect: is disabled due to a previous
                             417 response */
   BIT(use_range);

--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -425,7 +425,7 @@ static int curltest_put_handler(request_rec *r)
   apr_off_t rbody_len = 0;
   const char *s_rbody_len;
   const char *request_id = "none";
-  apr_time_t chunk_delay = 0;
+  apr_time_t read_delay = 0, chunk_delay = 0;
   apr_array_header_t *args = NULL;
   long l;
   int i;
@@ -449,6 +449,12 @@ static int curltest_put_handler(request_rec *r)
           /* just an id for repeated requests with curl's url globbing */
           request_id = val;
           continue;
+        }
+        else if(!strcmp("read_delay", arg)) {
+          rv = duration_parse(&read_delay, val, "s");
+          if(APR_SUCCESS == rv) {
+            continue;
+          }
         }
         else if(!strcmp("chunk_delay", arg)) {
           rv = duration_parse(&chunk_delay, val, "s");
@@ -478,6 +484,9 @@ static int curltest_put_handler(request_rec *r)
   ct = apr_table_get(r->headers_in, "content-type");
   ap_set_content_type(r, ct? ct : "text/plain");
 
+  if(read_delay) {
+    apr_sleep(read_delay);
+  }
   bb = apr_brigade_create(r->pool, c->bucket_alloc);
   /* copy any request body into the response */
   if((rv = ap_setup_client_block(r, REQUEST_CHUNKED_DECHUNK))) goto cleanup;


### PR DESCRIPTION
Move all handling of HTTP's `Expect: 100-continue` feature into a client reader. Add sending flag `KEEP_SEND_TIMED` that triggers transfer sending on general events like a timer.

HTTP installs a `CURL_CR_PROTOCOL` reader when announcing `Expect: 100-continue`. That reader works as follows:
- on first invocation, records time, starts the `EXPIRE_100_TIMEOUT` timer, disables `KEEP_SEND`, enables `KEEP_SEND_TIMER` and returns 0, eos=FALSE like a paused upload.
- on subsequent invocation it checks if the timer has expired. If so, it enables `KEEP_SEND` and switches to passing through reads to the underlying readers. 

Transfer handling's `readwrite()` will be invoked when a timer expires (like `EXPIRE_100_TIMEOUT`) or when data from the server arrives. Seeing `KEEP_SEND_TIMER`, it will try to upload more data, which triggers reading from the client readers again. Which then may lead to a new pausing or cause the upload to start.

Flags and timestamps connected to this have been moved from `SingleRequest` into the reader's context.