### PR TITLE
tool_getparam: accept a blank -w ""

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2658,7 +2658,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
           warnf(global, "Failed to read %s", fname);
       }
       else
-        err = getstr(&config->writeout, nextarg, DENY_BLANK);
+        err = getstr(&config->writeout, nextarg, ALLOW_BLANK);
       break;
     case C_PREPROXY: /* --preproxy */
       err = getstr(&config->preproxy, nextarg, DENY_BLANK);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -73,7 +73,7 @@ test426 test427 test428 test429 test430 test431 test432 test433 test434 \
 test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
-test462 test463 test467 \
+test462 test463 test467 test468 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \

--- a/tests/data/test468
+++ b/tests/data/test468
@@ -1,0 +1,60 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+--write-out
+--config
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes" crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+set -w in config, then reset -w to blank on cmdline
+</name>
+<file name="%LOGDIR/cmd%TESTNUMBER">
+-w "output\n"
+</file>
+<command option="no-include">
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -K %LOGDIR/cmd%TESTNUMBER -w ""
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<stdout>
+-foo-
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
Added test 468 to verify.

Regression from 07bcae89d5d00 (shipped in 8.6.0)
Reported-by: Thomas Pyle
Fixes #13144