### PR TITLE
RELEASE-NOTES: corrected

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -308,7 +308,7 @@ References to bug reports and discussions on issues:
  [115] = https://curl.se/bug/?i=6169
  [116] = https://curl.se/bug/?i=13063
  [117] = https://curl.se/bug/?i=13061
- [118] = https://curl.se/bug/?i=13070
+ [118] = https://curl.se/bug/?i=12897
  [119] = https://curl.se/bug/?i=13031
  [120] = https://curl.se/bug/?i=13047
  [121] = https://curl.se/bug/?i=13047


### PR DESCRIPTION
Corrected link for item 118. This is correct link for SHA-512/256 fix.