### PR TITLE
wolfSSL: do not call the stub function wolfSSL_BIO_set_init()

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -232,7 +232,6 @@ static const struct group_name_map gnm[] = {
 static int wolfssl_bio_cf_create(WOLFSSL_BIO *bio)
 {
   wolfSSL_BIO_set_shutdown(bio, 1);
-  wolfSSL_BIO_set_init(bio, 1);
   wolfSSL_BIO_set_data(bio, NULL);
   return 1;
 }


### PR DESCRIPTION
Calling the function isn't necessary and causes the build to fail when wolfSSL has been compiled with NO_WOLFSSL_STUB:

     Making all in opts
       CCLD     curl
     ld: error: undefined symbol: wolfSSL_BIO_set_init
     >>> referenced by wolfssl.c:235 (vtls/wolfssl.c:235)
     >>>               libcurl_la-wolfssl.o:(wolfssl_bio_cf_create) in archive ../lib/.libs/libcurl.a
     cc: error: linker command failed with exit code 1 (use -v to see invocation)
     *** Error code 1