### PR TITLE
docs/libcurl: add TLS backend info for all TLS options

### DIFF
--- a/docs/CURLDOWN.md
+++ b/docs/CURLDOWN.md
@@ -72,6 +72,8 @@ Each curldown starts with a header with meta-data:
     See-also:
       - CURLOPT_HEADEROPT (3)
       - CURLOPT_HTTPAUTH (3)
+    TLS-backend:
+      - [name]
     ---
 
 All curldown files *must* have all the headers present and at least one
@@ -80,7 +82,21 @@ All curldown files *must* have all the headers present and at least one
 If the man page is for section 3 (library related). The `Protocol` list must
 contain at least one protocol, which can be `*` if the option is virtually for
 everything. If `*` is used, it must be the only listed protocol. Recognized
-protocols are either URL schemes (in uppercase) or `TLS`.
+protocols are either URL schemes (in uppercase), `TLS` or `TCP`.
+
+If the `Protocol` list contains `TLS`, then there must also be a `TLS-backend`
+list, specifying `*` or a list of what TLS backends that work with this
+option. The available TLS backends are:
+
+- `BearSSL`
+- `GnuTLS`
+- `mbedTLS`
+- `OpenSSL` (also covers BoringSSL, libressl, quictls, AWS-LC and AmiSSL)
+- `rustls`
+- `Schannel`
+- `Secure Transport`
+- `wolfSSL`
+- `*`: all TLS backends
 
 Following the header in the file, is the manual page using markdown-like
 syntax:

--- a/docs/CURLDOWN.md
+++ b/docs/CURLDOWN.md
@@ -96,7 +96,7 @@ option. The available TLS backends are:
 - `Schannel`
 - `Secure Transport`
 - `wolfSSL`
-- `*`: all TLS backends
+- `All`: all TLS backends
 
 Following the header in the file, is the manual page using markdown-like
 syntax:

--- a/docs/libcurl/curl_ws_recv.md
+++ b/docs/libcurl/curl_ws_recv.md
@@ -11,7 +11,7 @@ See-also:
   - curl_ws_send (3)
   - libcurl-ws (3)
 Protocol:
-  - Ws
+  - WS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLINFO_CAINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CAINFO.md
@@ -11,7 +11,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLINFO_CAINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CAINFO.md
@@ -10,6 +10,8 @@ See-also:
   - curl_easy_setopt (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLINFO_CAPATH.md
+++ b/docs/libcurl/opts/CURLINFO_CAPATH.md
@@ -10,6 +10,11 @@ See-also:
   - curl_easy_setopt (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - mbedTLS
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLINFO_CERTINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.md
@@ -10,6 +10,11 @@ See-also:
   - curl_easy_setopt (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - Schannel
+  - Secure Transport
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
@@ -10,6 +10,9 @@ See-also:
   - curl_easy_setopt (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLINFO_SSL_ENGINES.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_ENGINES.md
@@ -10,6 +10,8 @@ See-also:
   - curl_easy_setopt (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
@@ -10,6 +10,9 @@ See-also:
   - curl_easy_setopt (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
@@ -10,6 +10,9 @@ See-also:
   - curl_easy_setopt (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
@@ -10,6 +10,14 @@ See-also:
   - curl_easy_setopt (3)
 Protocol:
   - TLS
+TLS-backend:
+  - BearSSL
+  - GnuTLS
+  - mbedTLS
+  - OpenSSL
+  - Schannel
+  - Secure Transport
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_CAINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.md
@@ -14,7 +14,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_CAINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.md
@@ -13,6 +13,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.md
@@ -11,6 +11,14 @@ See-also:
   - CURLOPT_CAPATH (3)
   - CURLOPT_SSL_VERIFYHOST (3)
   - CURLOPT_SSL_VERIFYPEER (3)
+TLS-backend:
+  - BearSSL
+  - OpenSSL
+  - mbedTLS
+  - rustls
+  - wolfSSL
+  - Secure Transport
+  - Schannel
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_CAPATH.md
+++ b/docs/libcurl/opts/CURLOPT_CAPATH.md
@@ -11,6 +11,11 @@ See-also:
   - CURLOPT_STDERR (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - mbedTLS
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
@@ -12,6 +12,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_CERTINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CERTINFO.md
@@ -12,6 +12,11 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - Schannel
+  - Secure Transport
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_CRLFILE.md
+++ b/docs/libcurl/opts/CURLOPT_CRLFILE.md
@@ -10,6 +10,10 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - GnuTLS
+  - mbedTLS
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
@@ -12,6 +12,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
@@ -13,7 +13,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
@@ -14,6 +14,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
@@ -15,7 +15,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.md
@@ -10,6 +10,9 @@ See-also:
   - CURLOPT_SSL_VERIFYSTATUS (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_EGDSOCKET.md
+++ b/docs/libcurl/opts/CURLOPT_EGDSOCKET.md
@@ -8,6 +8,8 @@ See-also:
   - CURLOPT_RANDOM_FILE (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT.md
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT.md
@@ -10,6 +10,9 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.md
@@ -11,6 +11,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_KEYPASSWD.md
+++ b/docs/libcurl/opts/CURLOPT_KEYPASSWD.md
@@ -9,6 +9,11 @@ See-also:
   - CURLOPT_SSLKEY (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - mbedTLS
+  - Schannel
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
@@ -11,6 +11,13 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - wolfSSL
+  - mbedTLS
+  - Secure Transport
+  - Schannel
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.md
@@ -16,6 +16,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.md
@@ -17,7 +17,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.md
@@ -16,6 +16,11 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - rustls
+  - Secure Transport
+  - Schannel
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAPATH.md
@@ -12,6 +12,10 @@ See-also:
   - CURLOPT_STDERR (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - mbedTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.md
@@ -11,6 +11,10 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - GnuTLS
+  - mbedTLS
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.md
@@ -12,6 +12,9 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME
@@ -76,7 +79,7 @@ int main(void)
 
 # AVAILABILITY
 
-Added in 7.71.0. This option is supported by the OpenSSL backends.
+Added in 7.71.0. This option is supported by the OpenSSL and GnuTLS backends.
 
 # RETURN VALUE
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.md
@@ -12,6 +12,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.md
@@ -11,6 +11,11 @@ See-also:
   - CURLOPT_SSLKEY (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - mbedTLS
+  - Schannel
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.md
@@ -12,6 +12,11 @@ See-also:
   - CURLOPT_PROXY_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - mbedTLS
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.md
@@ -10,6 +10,13 @@ See-also:
   - CURLOPT_SSLCERT (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - mbedTLS
+  - Schannel
+  - Secure Transport
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.md
@@ -10,6 +10,13 @@ See-also:
   - CURLOPT_SSLCERTTYPE (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - mbedTLS
+  - Schannel
+  - Secure Transport
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.md
@@ -11,6 +11,10 @@ See-also:
   - CURLOPT_SSLCERT_BLOB (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - Schannel
+  - Secure Transport
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.md
@@ -12,6 +12,11 @@ See-also:
   - CURLOPT_SSLKEYTYPE (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - mbedTLS
+  - Schannel
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.md
@@ -10,6 +10,10 @@ See-also:
   - CURLOPT_SSLKEYTYPE (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - BearSSL
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.md
@@ -10,6 +10,8 @@ See-also:
   - CURLOPT_SSLKEY_BLOB (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
@@ -11,6 +11,8 @@ See-also:
   - CURLOPT_USE_SSL (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
@@ -12,7 +12,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.md
@@ -18,6 +18,7 @@ TLS-backend:
   - Schannel
   - Secure Transport
   - wolfSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.md
@@ -12,6 +12,12 @@ See-also:
   - CURLOPT_TLS13_CIPHERS (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - BearSSL
+  - Schannel
+  - Secure Transport
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -11,6 +11,8 @@ See-also:
   - CURLOPT_SSL_CIPHER_LIST (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -12,7 +12,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
@@ -11,6 +11,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
@@ -12,7 +12,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
@@ -10,6 +10,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
@@ -11,7 +11,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
@@ -12,6 +12,10 @@ See-also:
   - CURLOPT_TLS13_CIPHERS (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - rustls
+  - Schannel
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.md
@@ -11,6 +11,9 @@ See-also:
   - CURLOPT_TLSAUTH_USERNAME (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.md
@@ -11,6 +11,9 @@ See-also:
   - CURLOPT_TLSAUTH_USERNAME (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.md
@@ -11,6 +11,9 @@ See-also:
   - CURLOPT_TLSAUTH_TYPE (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_RANDOM_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_RANDOM_FILE.md
@@ -8,6 +8,8 @@ See-also:
   - CURLOPT_EGDSOCKET (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
@@ -9,7 +9,7 @@ See-also:
   - CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256 (3)
   - CURLOPT_SSH_PUBLIC_KEYFILE (3)
 Protocol:
-  - SFP
+  - SFTP
   - SCP
 ---
 

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.md
@@ -8,7 +8,8 @@ See-also:
   - CURLOPT_SSH_KEYDATA (3)
   - CURLOPT_SSH_KNOWNHOSTS (3)
 Protocol:
-  - TLS
+  - SFTP
+  - SCP
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLCERT.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.md
@@ -10,6 +10,13 @@ See-also:
   - CURLOPT_SSLKEY (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - mbedTLS
+  - Schannel
+  - Secure Transport
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.md
@@ -9,6 +9,13 @@ See-also:
   - CURLOPT_SSLKEY (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
+  - mbedTLS
+  - Schannel
+  - Secure Transport
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.md
@@ -10,6 +10,11 @@ See-also:
   - CURLOPT_SSLKEY (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - Secure Transport
+  - Schannel
+  - mbedTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE.md
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE.md
@@ -10,6 +10,8 @@ See-also:
   - CURLOPT_SSLKEY (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLENGINE_DEFAULT.md
+++ b/docs/libcurl/opts/CURLOPT_SSLENGINE_DEFAULT.md
@@ -9,6 +9,8 @@ See-also:
   - CURLOPT_SSLENGINE (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLKEY.md
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY.md
@@ -10,6 +10,11 @@ See-also:
   - CURLOPT_SSLKEY_BLOB (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - mbedTLS
+  - Schannel
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.md
@@ -10,6 +10,10 @@ See-also:
   - CURLOPT_SSLKEY (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - BearSSL
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.md
@@ -9,6 +9,8 @@ See-also:
   - CURLOPT_SSLKEYTYPE (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.md
@@ -11,6 +11,8 @@ See-also:
   - CURLOPT_USE_SSL (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.md
@@ -12,7 +12,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.md
@@ -18,6 +18,7 @@ TLS-backend:
   - Schannel
   - Secure Transport
   - wolfSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.md
@@ -12,6 +12,12 @@ See-also:
   - CURLOPT_USE_SSL (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - BearSSL
+  - Schannel
+  - Secure Transport
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_DATA.md
@@ -9,6 +9,11 @@ See-also:
   - CURLOPT_SSL_CTX_FUNCTION (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - wolfSSL
+  - mbedTLS
+  - BearSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CTX_FUNCTION.md
@@ -10,6 +10,11 @@ See-also:
   - CURLOPT_CAINFO (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - wolfSSL
+  - mbedTLS
+  - BearSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.md
@@ -10,6 +10,9 @@ See-also:
   - CURLOPT_TLS13_CIPHERS (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - wolfSSL
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.md
@@ -9,6 +9,8 @@ See-also:
   - CURLOPT_SSL_OPTIONS (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.md
@@ -10,7 +10,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
@@ -9,6 +9,8 @@ See-also:
   - CURLOPT_SSL_OPTIONS (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
@@ -10,7 +10,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.md
@@ -8,6 +8,8 @@ See-also:
   - CURLOPT_TCP_FASTOPEN (3)
 Protocol:
   - TLS
+TLS-backend:
+  - Secure Transport
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -10,6 +10,8 @@ See-also:
   - CURLOPT_SSL_CIPHER_LIST (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -11,7 +11,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
@@ -11,6 +11,8 @@ See-also:
   - CURLOPT_SSLVERSION (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
@@ -12,7 +12,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
@@ -10,6 +10,8 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
@@ -11,7 +11,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
@@ -13,6 +13,8 @@ See-also:
   - CURLOPT_SSL_VERIFYHOST (3)
 Protocol:
   - TLS
+TLS-backend:
+  - *
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
@@ -14,7 +14,7 @@ See-also:
 Protocol:
   - TLS
 TLS-backend:
-  - *
+  - All
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.md
@@ -10,6 +10,9 @@ See-also:
   - CURLOPT_SSL_VERIFYPEER (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
@@ -13,6 +13,10 @@ See-also:
   - CURLOPT_USE_SSL (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - rustls
+  - Schannel
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.md
@@ -10,6 +10,9 @@ See-also:
   - CURLOPT_TLSAUTH_USERNAME (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.md
@@ -9,6 +9,9 @@ See-also:
   - CURLOPT_TLSAUTH_USERNAME (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.md
@@ -9,6 +9,9 @@ See-also:
   - CURLOPT_TLSAUTH_TYPE (3)
 Protocol:
   - TLS
+TLS-backend:
+  - OpenSSL
+  - GnuTLS
 ---
 
 # NAME

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -96,17 +96,64 @@ sub outseealso {
     return @o;
 }
 
+my %knownprotos = (
+    'DICT' => 1,
+    'FILE' => 1,
+    'FTP' => 1,
+    'FTPS' => 1,
+    'GOPHER' => 1,
+    'GOPHERS' => 1,
+    'HTTP' => 1,
+    'HTTPS' => 1,
+    'IMAP' => 1,
+    'IMAPS' => 1,
+    'LDAP' => 1,
+    'LDAPS' => 1,
+    'MQTT' => 1,
+    'POP3' => 1,
+    'POP3S' => 1,
+    'RTMP' => 1,
+    'RTMPS' => 1,
+    'RTSP' => 1,
+    'SCP' => 1,
+    'SFTP' => 1,
+    'SMB' => 1,
+    'SMBS' => 1,
+    'SMTP' => 1,
+    'SMTPS' => 1,
+    'TELNET' => 1,
+    'TFTP' => 1,
+    'WS' => 1,
+    'WSS' => 1,
+    'TLS' => 1,
+    'TCP' => 1,
+    '*' => 1
+    );
+
+my %knowntls = (
+    'BearSSL' => 1,
+    'GnuTLS' => 1,
+    'mbedTLS' => 1,
+    'OpenSSL' => 1,
+    'rustls' => 1,
+    'Schannel' => 1,
+    'Secure Transport' => 1,
+    'wolfSSL' => 1,
+    '*' => 1,
+    );
+
 sub single {
     my @seealso;
     my @proto;
+    my @tls;
     my $d;
     my ($f)=@_;
     my $copyright;
     my $errors = 0;
     my $fh;
     my $line;
-    my $salist;
-    my $protolist;
+    my $list;
+    my $tlslist;
     my $section;
     my $source;
     my $spdx;
@@ -143,7 +190,7 @@ sub single {
             $source=$1;
         }
         elsif(/^See-also: +(.*)/i) {
-            $salist = 0;
+            $list = 1; # 1 for see-also
             push @seealso, $1;
         }
         elsif(/^See-also: */i) {
@@ -151,20 +198,24 @@ sub single {
                 print STDERR "$f:$line:1:ERROR: bad See-Also, needs list\n";
                 return 2;
             }
-            $salist = 1;
-            $protolist = 0;
+            $list = 1; # 1 for see-also
         }
         elsif(/^Protocol:/i) {
-            $salist = 0;
-            $protolist = 1;
+            $list = 2; # 2 for protocol
+        }
+        elsif(/^TLS-backend:/i) {
+            $list = 3; # 3 for TLS backend
         }
         elsif(/^ +- (.*)/i) {
             # the only lists we support are see-also and protocol
-            if($salist) {
+            if($list == 1) {
                 push @seealso, $1;
             }
-            elsif($protolist) {
+            elsif($list == 2) {
                 push @proto, $1;
+            }
+            elsif($list == 3) {
+                push @tls, $1;
             }
             else {
                 print STDERR "$f:$line:1:ERROR: list item without owner?\n";
@@ -201,9 +252,34 @@ sub single {
                 print STDERR "$f:$line:1:ERROR: no 'SPDX-License-Identifier:' field present\n";
                 return 2;
             }
-            if(!$proto[0] && ($section == 3)) {
-                printf STDERR "$f:$line:1:ERROR: missing Protocol:\n";
-                exit 2;
+            if($section == 3) {
+                if(!$proto[0]) {
+                    printf STDERR "$f:$line:1:ERROR: missing Protocol:\n";
+                    exit 2;
+                }
+                my $tls = 0;
+                for my $p (@proto) {
+                    if($p eq "TLS") {
+                        $tls = 1;
+                    }
+                    if(!$knownprotos{$p}) {
+                        printf STDERR "$f:$line:1:ERROR: invalid protocol used: $p:\n";
+                        exit 2;
+                    }
+                }
+                # This is for TLS, require TLS-backend:
+                if($tls) {
+                    if(!$tls[0]) {
+                        printf STDERR "$f:$line:1:ERROR: missing TLS-backend:\n";
+                        exit 2;
+                    }
+                    for my $t (@tls) {
+                        if(!$knowntls{$t}) {
+                            printf STDERR "$f:$line:1:ERROR: invalid TLS backend: $t:\n";
+                            exit 2;
+                        }
+                    }
+                }
             }
             last;
         }

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -139,7 +139,7 @@ my %knowntls = (
     'Schannel' => 1,
     'Secure Transport' => 1,
     'wolfSSL' => 1,
-    '*' => 1,
+    'All' => 1,
     );
 
 sub single {


### PR DESCRIPTION
All man pages that are listed to be for TLS now must also specify exactly what TLS backends the option works for, or use `*` if they all work.

cd2nroff makes sure this is done and that the listed backends(s) exist.