### PR TITLE
openssl+gnutls, use shared code for TCP+QUIC

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1068,7 +1068,7 @@ static void cf_h1_proxy_close(struct Curl_cfilter *cf,
 
 struct Curl_cftype Curl_cft_h1_proxy = {
   "H1-PROXY",
-  CF_TYPE_IP_CONNECT,
+  CF_TYPE_IP_CONNECT|CF_TYPE_PROXY,
   0,
   cf_h1_proxy_destroy,
   cf_h1_proxy_connect,

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -1532,7 +1532,7 @@ static bool cf_h2_proxy_is_alive(struct Curl_cfilter *cf,
 
 struct Curl_cftype Curl_cft_h2_proxy = {
   "H2-PROXY",
-  CF_TYPE_IP_CONNECT,
+  CF_TYPE_IP_CONNECT|CF_TYPE_PROXY,
   CURL_LOG_LVL_NONE,
   cf_h2_proxy_destroy,
   cf_h2_proxy_connect,

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -189,7 +189,7 @@ static void cf_haproxy_adjust_pollset(struct Curl_cfilter *cf,
 
 struct Curl_cftype Curl_cft_haproxy = {
   "HAPROXY",
-  0,
+  CF_TYPE_PROXY,
   0,
   cf_haproxy_destroy,
   cf_haproxy_connect,

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -178,10 +178,12 @@ typedef CURLcode Curl_cft_query(struct Curl_cfilter *cf,
  *                     connection, etc.
  * CF_TYPE_SSL:        provide SSL/TLS
  * CF_TYPE_MULTIPLEX:  provides multiplexing of easy handles
+ * CF_TYPE_PROXY       provides proxying
  */
 #define CF_TYPE_IP_CONNECT  (1 << 0)
 #define CF_TYPE_SSL         (1 << 1)
 #define CF_TYPE_MULTIPLEX   (1 << 2)
+#define CF_TYPE_PROXY       (1 << 3)
 
 /* A connection filter type, e.g. specific implementation. */
 struct Curl_cftype {

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -293,7 +293,7 @@ static void http_proxy_cf_close(struct Curl_cfilter *cf,
 
 struct Curl_cftype Curl_cft_http_proxy = {
   "HTTP-PROXY",
-  CF_TYPE_IP_CONNECT,
+  CF_TYPE_IP_CONNECT|CF_TYPE_PROXY,
   0,
   http_proxy_cf_destroy,
   http_proxy_cf_connect,

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1244,7 +1244,7 @@ static void socks_cf_get_host(struct Curl_cfilter *cf,
 
 struct Curl_cftype Curl_cft_socks_proxy = {
   "SOCKS-PROXYY",
-  CF_TYPE_IP_CONNECT,
+  CF_TYPE_IP_CONNECT|CF_TYPE_PROXY,
   0,
   socks_proxy_cf_destroy,
   socks_proxy_cf_connect,

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -279,6 +279,8 @@ struct ssl_peer {
   char *dispname;        /* display version of hostname */
   char *sni;             /* SNI version of hostname or NULL if not usable */
   ssl_peer_type type;    /* type of the peer information */
+  int port;              /* port we are talking to */
+  int transport;         /* TCP or QUIC */
 };
 
 struct ssl_primary_config {
@@ -344,6 +346,7 @@ struct Curl_ssl_session {
   long age;         /* just a number, the higher the more recent */
   int remote_port;  /* remote port */
   int conn_to_port; /* remote port for the connection (may be -1) */
+  int transport;    /* TCP or QUIC */
   struct ssl_primary_config ssl_config; /* setup for this session */
 };
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1983,6 +1983,10 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
   if(result)
     return result;
 
+#ifdef USE_OPENSSL
+    SSL_set_quic_use_legacy_codepoint(ctx->tls.ossl.ssl, 0);
+#endif
+
   ctx->dcid.datalen = NGTCP2_MAX_CIDLEN;
   result = Curl_rand(data, ctx->dcid.data, NGTCP2_MAX_CIDLEN);
   if(result)

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1972,7 +1972,7 @@ static CURLcode tls_ctx_setup(struct Curl_cfilter *cf,
   SSL_CTX_sess_set_new_cb(ctx->ossl.ssl_ctx, ossl_new_session_cb);
 
 #elif defined(USE_GNUTLS)
-  if(ngtcp2_crypto_gnutls_configure_client_session(ctx->gtls->session) != 0) {
+  if(ngtcp2_crypto_gnutls_configure_client_session(ctx->gtls.session) != 0) {
     failf(data, "ngtcp2_crypto_gnutls_configure_client_session failed");
     return CURLE_FAILED_INIT;
   }
@@ -2064,7 +2064,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
 #ifdef USE_OPENSSL
   ngtcp2_conn_set_tls_native_handle(ctx->qconn, ctx->tls.ossl.ssl);
 #elif defined(USE_GNUTLS)
-  ngtcp2_conn_set_tls_native_handle(ctx->qconn, ctx->tls.gtls->session);
+  ngtcp2_conn_set_tls_native_handle(ctx->qconn, ctx->tls.gtls.session);
 #else
   ngtcp2_conn_set_tls_native_handle(ctx->qconn, ctx->tls.ssl);
 #endif

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1055,7 +1055,7 @@ static CURLcode cf_osslq_ctx_start(struct Curl_cfilter *cf,
 
   Curl_bufcp_init(&ctx->stream_bufcp, H3_STREAM_CHUNK_SIZE,
                   H3_STREAM_POOL_SPARES);
-  result = Curl_ssl_peer_init(&ctx->peer, cf);
+  result = Curl_ssl_peer_init(&ctx->peer, cf, TRNSPRT_QUIC);
   if(result)
     goto out;
 

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -318,7 +318,7 @@ static void cf_osslq_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   struct cf_call_data save;
 
   CF_DATA_SAVE(save, cf, data);
-  if(ctx && ctx->tls.ssl) {
+  if(ctx && ctx->tls.ossl.ssl) {
     /* TODO: send connection close */
     CURL_TRC_CF(data, cf, "cf_osslq_close()");
     cf_osslq_ctx_clear(ctx);
@@ -406,7 +406,7 @@ static CURLcode cf_osslq_ssl_err(struct Curl_cfilter *cf,
       (reason == SSL_R_SSLV3_ALERT_CERTIFICATE_EXPIRED))) {
     result = CURLE_PEER_FAILED_VERIFICATION;
 
-    lerr = SSL_get_verify_result(ctx->tls.ssl);
+    lerr = SSL_get_verify_result(ctx->tls.ossl.ssl);
     if(lerr != X509_V_OK) {
       ssl_config->certverifyresult = lerr;
       msnprintf(ebuf, sizeof(ebuf),
@@ -1106,12 +1106,12 @@ static CURLcode cf_osslq_ctx_start(struct Curl_cfilter *cf,
     goto out;
   }
 
-  if(!SSL_set1_initial_peer_addr(ctx->tls.ssl, baddr)) {
+  if(!SSL_set1_initial_peer_addr(ctx->tls.ossl.ssl, baddr)) {
     failf(data, "failed to set the initial peer address");
     result = CURLE_FAILED_INIT;
     goto out;
   }
-  if(!SSL_set_blocking_mode(ctx->tls.ssl, 0)) {
+  if(!SSL_set_blocking_mode(ctx->tls.ossl.ssl, 0)) {
     failf(data, "failed to turn off blocking mode");
     result = CURLE_FAILED_INIT;
     goto out;
@@ -1119,7 +1119,8 @@ static CURLcode cf_osslq_ctx_start(struct Curl_cfilter *cf,
 
 #ifdef SSL_VALUE_QUIC_IDLE_TIMEOUT
   /* Added in OpenSSL v3.3.x */
-  if(!SSL_set_feature_request_uint(ctx->tls.ssl, SSL_VALUE_QUIC_IDLE_TIMEOUT,
+  if(!SSL_set_feature_request_uint(ctx->tls.ossl.ssl,
+                                   SSL_VALUE_QUIC_IDLE_TIMEOUT,
                                    CURL_QUIC_MAX_IDLE_MS)) {
     CURL_TRC_CF(data, cf, "error setting idle timeout, ");
     result = CURLE_FAILED_INIT;
@@ -1127,13 +1128,13 @@ static CURLcode cf_osslq_ctx_start(struct Curl_cfilter *cf,
   }
 #endif
 
-  SSL_set_bio(ctx->tls.ssl, bio, bio);
+  SSL_set_bio(ctx->tls.ossl.ssl, bio, bio);
   bio = NULL;
-  SSL_set_connect_state(ctx->tls.ssl);
-  SSL_set_incoming_stream_policy(ctx->tls.ssl,
+  SSL_set_connect_state(ctx->tls.ossl.ssl);
+  SSL_set_incoming_stream_policy(ctx->tls.ossl.ssl,
                                  SSL_INCOMING_STREAM_POLICY_ACCEPT, 0);
   /* setup the H3 things on top of the QUIC connection */
-  result = cf_osslq_h3conn_init(ctx, ctx->tls.ssl, cf);
+  result = cf_osslq_h3conn_init(ctx, ctx->tls.ossl.ssl, cf);
 
 out:
   if(bio)
@@ -1305,22 +1306,23 @@ static CURLcode cf_progress_ingress(struct Curl_cfilter *cf,
   struct cf_osslq_ctx *ctx = cf->ctx;
   CURLcode result = CURLE_OK;
 
-  if(!ctx->tls.ssl)
+  if(!ctx->tls.ossl.ssl)
     goto out;
 
   ERR_clear_error();
 
   /* 1. Check for new incoming streams */
   while(1) {
-    SSL *snew = SSL_accept_stream(ctx->tls.ssl, SSL_ACCEPT_STREAM_NO_BLOCK);
+    SSL *snew = SSL_accept_stream(ctx->tls.ossl.ssl,
+                                  SSL_ACCEPT_STREAM_NO_BLOCK);
     if(!snew)
       break;
 
     (void)cf_osslq_h3conn_add_stream(&ctx->h3, snew, cf, data);
   }
 
-  if(!SSL_handle_events(ctx->tls.ssl)) {
-    int detail = SSL_get_error(ctx->tls.ssl, 0);
+  if(!SSL_handle_events(ctx->tls.ossl.ssl)) {
+    int detail = SSL_get_error(ctx->tls.ossl.ssl, 0);
     result = cf_osslq_ssl_err(cf, data, detail, CURLE_RECV_ERROR);
   }
 
@@ -1387,7 +1389,7 @@ static CURLcode h3_send_streams(struct Curl_cfilter *cf,
   struct cf_osslq_ctx *ctx = cf->ctx;
   CURLcode result = CURLE_OK;
 
-  if(!ctx->tls.ssl || !ctx->h3.conn)
+  if(!ctx->tls.ossl.ssl || !ctx->h3.conn)
     goto out;
 
   for(;;) {
@@ -1514,7 +1516,7 @@ static CURLcode cf_progress_egress(struct Curl_cfilter *cf,
   struct cf_osslq_ctx *ctx = cf->ctx;
   CURLcode result = CURLE_OK;
 
-  if(!ctx->tls.ssl)
+  if(!ctx->tls.ossl.ssl)
     goto out;
 
   ERR_clear_error();
@@ -1522,8 +1524,8 @@ static CURLcode cf_progress_egress(struct Curl_cfilter *cf,
   if(result)
     goto out;
 
-  if(!SSL_handle_events(ctx->tls.ssl)) {
-    int detail = SSL_get_error(ctx->tls.ssl, 0);
+  if(!SSL_handle_events(ctx->tls.ossl.ssl)) {
+    int detail = SSL_get_error(ctx->tls.ossl.ssl, 0);
     result = cf_osslq_ssl_err(cf, data, detail, CURLE_SEND_ERROR);
   }
 
@@ -1543,8 +1545,8 @@ static CURLcode check_and_set_expiry(struct Curl_cfilter *cf,
   timediff_t timeoutms;
   int is_infinite = TRUE;
 
-  if(ctx->tls.ssl &&
-    SSL_get_event_timeout(ctx->tls.ssl, &tv, &is_infinite) &&
+  if(ctx->tls.ossl.ssl &&
+    SSL_get_event_timeout(ctx->tls.ossl.ssl, &tv, &is_infinite) &&
     !is_infinite) {
     timeoutms = curlx_tvtoms(&tv);
     /* QUIC want to be called again latest at the returned timeout */
@@ -1555,7 +1557,7 @@ static CURLcode check_and_set_expiry(struct Curl_cfilter *cf,
       result = cf_progress_egress(cf, data);
       if(result)
         goto out;
-      if(SSL_get_event_timeout(ctx->tls.ssl, &tv, &is_infinite)) {
+      if(SSL_get_event_timeout(ctx->tls.ossl.ssl, &tv, &is_infinite)) {
         timeoutms = curlx_tvtoms(&tv);
       }
     }
@@ -1600,7 +1602,7 @@ static CURLcode cf_osslq_connect(struct Curl_cfilter *cf,
     goto out;
   }
 
-  if(!ctx->tls.ssl) {
+  if(!ctx->tls.ossl.ssl) {
     ctx->started_at = now;
     result = cf_osslq_ctx_start(cf, data);
     if(result)
@@ -1616,7 +1618,7 @@ static CURLcode cf_osslq_connect(struct Curl_cfilter *cf,
   }
 
   ERR_clear_error();
-  err = SSL_do_handshake(ctx->tls.ssl);
+  err = SSL_do_handshake(ctx->tls.ossl.ssl);
 
   if(err == 1) {
     /* connected */
@@ -1634,7 +1636,7 @@ static CURLcode cf_osslq_connect(struct Curl_cfilter *cf,
     }
   }
   else {
-    int detail = SSL_get_error(ctx->tls.ssl, err);
+    int detail = SSL_get_error(ctx->tls.ossl.ssl, err);
     switch(detail) {
     case SSL_ERROR_WANT_READ:
       ctx->q.last_io = now;
@@ -1665,7 +1667,8 @@ static CURLcode cf_osslq_connect(struct Curl_cfilter *cf,
   }
 
 out:
-  if(result == CURLE_RECV_ERROR && ctx->tls.ssl && ctx->protocol_shutdown) {
+  if(result == CURLE_RECV_ERROR && ctx->tls.ossl.ssl &&
+     ctx->protocol_shutdown) {
     /* When a QUIC server instance is shutting down, it may send us a
      * CONNECTION_CLOSE right away. Our connection then enters the DRAINING
      * state. The CONNECT may work in the near future again. Indicate
@@ -1753,7 +1756,7 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
   }
 
   DEBUGASSERT(stream->s.id == -1);
-  *err = cf_osslq_stream_open(&stream->s, ctx->tls.ssl, 0,
+  *err = cf_osslq_stream_open(&stream->s, ctx->tls.ossl.ssl, 0,
                               &ctx->stream_bufcp, data);
   if(*err) {
     failf(data, "can't get bidi streams");
@@ -1832,7 +1835,7 @@ static ssize_t cf_osslq_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   CF_DATA_SAVE(save, cf, data);
   DEBUGASSERT(cf->connected);
-  DEBUGASSERT(ctx->tls.ssl);
+  DEBUGASSERT(ctx->tls.ossl.ssl);
   DEBUGASSERT(ctx->h3.conn);
   *err = CURLE_OK;
 
@@ -1975,7 +1978,7 @@ static ssize_t cf_osslq_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   CF_DATA_SAVE(save, cf, data);
   DEBUGASSERT(cf->connected);
   DEBUGASSERT(ctx);
-  DEBUGASSERT(ctx->tls.ssl);
+  DEBUGASSERT(ctx->tls.ossl.ssl);
   DEBUGASSERT(ctx->h3.conn);
   *err = CURLE_OK;
 
@@ -2114,7 +2117,7 @@ static bool cf_osslq_conn_is_alive(struct Curl_cfilter *cf,
 
   CF_DATA_SAVE(save, cf, data);
   *input_pending = FALSE;
-  if(!ctx->tls.ssl)
+  if(!ctx->tls.ossl.ssl)
     goto out;
 
 #ifdef SSL_VALUE_QUIC_IDLE_TIMEOUT
@@ -2122,7 +2125,8 @@ static bool cf_osslq_conn_is_alive(struct Curl_cfilter *cf,
   {
     timediff_t idletime;
     uint64_t idle_ms = ctx->max_idle_ms;
-    if(!SSL_get_value_uint(ctx->tls.ssl, SSL_VALUE_CLASS_FEATURE_NEGOTIATED,
+    if(!SSL_get_value_uint(ctx->tls.ossl.ssl,
+                           SSL_VALUE_CLASS_FEATURE_NEGOTIATED,
                            SSL_VALUE_QUIC_IDLE_TIMEOUT, &idle_ms)) {
       CURL_TRC_CF(data, cf, "error getting negotiated idle timeout, "
                   "assume connection is dead.");
@@ -2162,15 +2166,15 @@ static void cf_osslq_adjust_pollset(struct Curl_cfilter *cf,
 {
   struct cf_osslq_ctx *ctx = cf->ctx;
 
-  if(!ctx->tls.ssl) {
+  if(!ctx->tls.ossl.ssl) {
     /* NOP */
   }
   else if(!cf->connected) {
     /* during handshake, transfer has not started yet. we always
      * add our socket for polling if SSL wants to send/recv */
     Curl_pollset_set(data, ps, ctx->q.sockfd,
-                     SSL_net_read_desired(ctx->tls.ssl),
-                     SSL_net_write_desired(ctx->tls.ssl));
+                     SSL_net_read_desired(ctx->tls.ossl.ssl),
+                     SSL_net_write_desired(ctx->tls.ossl.ssl));
   }
   else {
     /* once connected, we only modify the socket if it is present.
@@ -2179,8 +2183,8 @@ static void cf_osslq_adjust_pollset(struct Curl_cfilter *cf,
     Curl_pollset_check(data, ps, ctx->q.sockfd, &want_recv, &want_send);
     if(want_recv || want_send) {
       Curl_pollset_set(data, ps, ctx->q.sockfd,
-                       SSL_net_read_desired(ctx->tls.ssl),
-                       SSL_net_write_desired(ctx->tls.ssl));
+                       SSL_net_read_desired(ctx->tls.ossl.ssl),
+                       SSL_net_write_desired(ctx->tls.ossl.ssl));
     }
   }
 }
@@ -2196,7 +2200,7 @@ static CURLcode cf_osslq_query(struct Curl_cfilter *cf,
 #ifdef SSL_VALUE_QUIC_STREAM_BIDI_LOCAL_AVAIL
     /* Added in OpenSSL v3.3.x */
     uint64_t v;
-    if(!SSL_get_value_uint(ctx->tls.ssl, SSL_VALUE_CLASS_GENERIC,
+    if(!SSL_get_value_uint(ctx->tls.ossl.ssl, SSL_VALUE_CLASS_GENERIC,
                            SSL_VALUE_QUIC_STREAM_BIDI_LOCAL_AVAIL, &v)) {
       CURL_TRC_CF(data, cf, "error getting available local bidi streams");
       return CURLE_HTTP3;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -281,7 +281,7 @@ static void cf_osslq_h3conn_cleanup(struct cf_osslq_h3conn *h3)
 struct cf_osslq_ctx {
   struct cf_quic_ctx q;
   struct ssl_peer peer;
-  struct quic_tls_ctx tls;
+  struct curl_tls_ctx tls;
   struct cf_call_data call_data;
   struct cf_osslq_h3conn h3;
   struct curltime started_at;        /* time the current attempt started */
@@ -1062,7 +1062,7 @@ static CURLcode cf_osslq_ctx_start(struct Curl_cfilter *cf,
 #define H3_ALPN "\x2h3"
   result = Curl_vquic_tls_init(&ctx->tls, cf, data, &ctx->peer,
                                H3_ALPN, sizeof(H3_ALPN) - 1,
-                               NULL, NULL);
+                               NULL, NULL, NULL);
   if(result)
     goto out;
 

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1200,7 +1200,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
   if(result)
     return result;
 
-  result = Curl_ssl_peer_init(&ctx->peer, cf);
+  result = Curl_ssl_peer_init(&ctx->peer, cf, TRNSPRT_QUIC);
   if(result)
     return result;
 

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -123,8 +123,8 @@ static void cf_quiche_ctx_clear(struct cf_quiche_ctx *ctx)
       quiche_conn_free(ctx->qconn);
     if(ctx->cfg)
       quiche_config_free(ctx->cfg);
-    /* quiche just freed ctx->tls.ssl */
-    ctx->tls.ssl = NULL;
+    /* quiche just freed it */
+    ctx->tls.ossl.ssl = NULL;
     Curl_vquic_tls_cleanup(&ctx->tls);
     Curl_ssl_peer_cleanup(&ctx->peer);
     vquic_ctx_free(&ctx->q);
@@ -564,7 +564,7 @@ static CURLcode recv_pkt(const unsigned char *pkt, size_t pktlen,
       return CURLE_OK;
     }
     else if(QUICHE_ERR_TLS_FAIL == nread) {
-      long verify_ok = SSL_get_verify_result(ctx->tls.ssl);
+      long verify_ok = SSL_get_verify_result(ctx->tls.ossl.ssl);
       if(verify_ok != X509_V_OK) {
         failf(r->data, "SSL certificate problem: %s",
               X509_verify_cert_error_string(verify_ok));
@@ -1255,7 +1255,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
                                       (struct sockaddr *)&ctx->q.local_addr,
                                       ctx->q.local_addrlen,
                                       &sockaddr->sa_addr, sockaddr->addrlen,
-                                      ctx->cfg, ctx->tls.ssl, false);
+                                      ctx->cfg, ctx->tls.ossl.ssl, false);
   if(!ctx->qconn) {
     failf(data, "can't create quiche connection");
     return CURLE_OUT_OF_MEMORY;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -88,7 +88,7 @@ void Curl_quiche_ver(char *p, size_t len)
 struct cf_quiche_ctx {
   struct cf_quic_ctx q;
   struct ssl_peer peer;
-  struct quic_tls_ctx tls;
+  struct curl_tls_ctx tls;
   quiche_conn *qconn;
   quiche_config *cfg;
   quiche_h3_conn *h3c;
@@ -1235,7 +1235,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
   result = Curl_vquic_tls_init(&ctx->tls, cf, data, &ctx->peer,
                                QUICHE_H3_APPLICATION_PROTOCOL,
                                sizeof(QUICHE_H3_APPLICATION_PROTOCOL) - 1,
-                               NULL, cf);
+                               NULL, NULL, cf);
   if(result)
     return result;
 

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -343,7 +343,7 @@ CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
   (void)result;
   return Curl_ossl_ctx_init(&ctx->ossl, cf, data, peer, TRNSPRT_QUIC,
                             (const unsigned char *)alpn, alpn_len,
-                            cb_setup, cb_user_data, ssl_user_data);
+                            cb_setup, cb_user_data, NULL, ssl_user_data);
 #elif defined(USE_GNUTLS)
   (void)result;
   return curl_gtls_init_ctx(ctx, cf, data, peer, alpn, alpn_len,

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -63,6 +63,11 @@
 
 #if defined(USE_WOLFSSL)
 
+#define QUIC_CIPHERS                                                          \
+  "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_"               \
+  "POLY1305_SHA256:TLS_AES_128_CCM_SHA256"
+#define QUIC_GROUPS "P-256:P-384:P-521"
+
 #if defined(HAVE_SECRET_CALLBACK)
 static void keylog_callback(const WOLFSSL *ssl, const char *line)
 {
@@ -311,6 +316,7 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
       return result;
   }
 #elif defined(USE_WOLFSSL)
+  (void)data;
   if(conn_config->verifyhost) {
     if(!peer->sni ||
        wolfSSL_check_domain_name(ctx->ssl, peer->sni) == SSL_FAILURE)

--- a/lib/vquic/vquic-tls.h
+++ b/lib/vquic/vquic-tls.h
@@ -26,21 +26,20 @@
 
 #include "curl_setup.h"
 #include "bufq.h"
+#include "vtls/openssl.h"
 
 #if defined(ENABLE_QUIC) && \
   (defined(USE_OPENSSL) || defined(USE_GNUTLS) || defined(USE_WOLFSSL))
 
-struct quic_tls_ctx {
+struct curl_tls_ctx {
 #ifdef USE_OPENSSL
-  SSL_CTX *ssl_ctx;
-  SSL *ssl;
+  struct ossl_ctx ossl;
 #elif defined(USE_GNUTLS)
   struct gtls_instance *gtls;
 #elif defined(USE_WOLFSSL)
   WOLFSSL_CTX *ssl_ctx;
   WOLFSSL *ssl;
 #endif
-  BIT(x509_store_setup);             /* if x509 store has been set up */
 };
 
 /**
@@ -50,9 +49,9 @@ struct quic_tls_ctx {
  * - openssl/wolfssl: SSL_CTX* has just been created
  * - gnutls: gtls_client_init() has run
  */
-typedef CURLcode Curl_vquic_tls_ctx_setup(struct quic_tls_ctx *ctx,
-                                          struct Curl_cfilter *cf,
-                                          struct Curl_easy *data);
+typedef CURLcode Curl_vquic_tls_ctx_setup(struct Curl_cfilter *cf,
+                                          struct Curl_easy *data,
+                                          void *cb_user_data);
 
 /**
  * Initialize the QUIC TLS instances based of the SSL configurations
@@ -64,23 +63,25 @@ typedef CURLcode Curl_vquic_tls_ctx_setup(struct quic_tls_ctx *ctx,
  * @param alpn        the ALPN string in protocol format ((len+bytes+)+),
  *                    may be NULL
  * @param alpn_len    the overall number of bytes in `alpn`
- * @param ctx_setup   optional callback for very early TLS config
- * @param user_data   optional pointer to set in TLS application context
+ * @param cb_setup    optional callback for very early TLS config
+ ± @param cb_user_data user_data param for callback
+ * @param ssl_user_data  optional pointer to set in TLS application context
  */
-CURLcode Curl_vquic_tls_init(struct quic_tls_ctx *ctx,
+CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
                              struct Curl_cfilter *cf,
                              struct Curl_easy *data,
                              struct ssl_peer *peer,
                              const char *alpn, size_t alpn_len,
-                             Curl_vquic_tls_ctx_setup *ctx_setup,
-                             void *user_data);
+                             Curl_vquic_tls_ctx_setup *cb_setup,
+                             void *cb_user_data,
+                             void *ssl_user_data);
 
 /**
  * Cleanup all data that has been initialized.
  */
-void Curl_vquic_tls_cleanup(struct quic_tls_ctx *ctx);
+void Curl_vquic_tls_cleanup(struct curl_tls_ctx *ctx);
 
-CURLcode Curl_vquic_tls_before_recv(struct quic_tls_ctx *ctx,
+CURLcode Curl_vquic_tls_before_recv(struct curl_tls_ctx *ctx,
                                     struct Curl_cfilter *cf,
                                     struct Curl_easy *data);
 
@@ -88,7 +89,7 @@ CURLcode Curl_vquic_tls_before_recv(struct quic_tls_ctx *ctx,
  * After the QUIC basic handshake has been, verify that the peer
  * (and its certificate) fulfill our requirements.
  */
-CURLcode Curl_vquic_tls_verify_peer(struct quic_tls_ctx *ctx,
+CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
                                     struct Curl_cfilter *cf,
                                     struct Curl_easy *data,
                                     struct ssl_peer *peer);

--- a/lib/vquic/vquic-tls.h
+++ b/lib/vquic/vquic-tls.h
@@ -35,7 +35,7 @@ struct curl_tls_ctx {
 #ifdef USE_OPENSSL
   struct ossl_ctx ossl;
 #elif defined(USE_GNUTLS)
-  struct gtls_instance *gtls;
+  struct gtls_ctx gtls;
 #elif defined(USE_WOLFSSL)
   WOLFSSL_CTX *ssl_ctx;
   WOLFSSL *ssl;

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -686,7 +686,7 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
 
     CURL_TRC_CF(data, cf, "connect_step1, check session cache");
     Curl_ssl_sessionid_lock(data);
-    if(!Curl_ssl_getsessionid(cf, data, &session, NULL)) {
+    if(!Curl_ssl_getsessionid(cf, data, &connssl->peer, &session, NULL)) {
       br_ssl_engine_set_session_parameters(&backend->ctx.eng, session);
       session_set = 1;
       infof(data, "BearSSL: reusing session ID");
@@ -905,10 +905,11 @@ static CURLcode bearssl_connect_step3(struct Curl_cfilter *cf,
       return CURLE_OUT_OF_MEMORY;
     br_ssl_engine_get_session_parameters(&backend->ctx.eng, session);
     Curl_ssl_sessionid_lock(data);
-    incache = !(Curl_ssl_getsessionid(cf, data, &oldsession, NULL));
+    incache = !(Curl_ssl_getsessionid(cf, data, &connssl->peer,
+                                      &oldsession, NULL));
     if(incache)
       Curl_ssl_delsessionid(data, oldsession);
-    ret = Curl_ssl_addsessionid(cf, data, session, 0, &added);
+    ret = Curl_ssl_addsessionid(cf, data, &connssl->peer, session, 0, &added);
     Curl_ssl_sessionid_unlock(data);
     if(!added)
       free(session);

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -726,7 +726,8 @@ gtls_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     size_t ssl_idsize;
 
     Curl_ssl_sessionid_lock(data);
-    if(!Curl_ssl_getsessionid(cf, data, &ssl_sessionid, &ssl_idsize)) {
+    if(!Curl_ssl_getsessionid(cf, data, &connssl->peer,
+                              &ssl_sessionid, &ssl_idsize)) {
       /* we got a session id, use it! */
       gnutls_session_set_data(backend->gtls.session,
                               ssl_sessionid, ssl_idsize);
@@ -1287,7 +1288,8 @@ static CURLcode gtls_verifyserver(struct Curl_cfilter *cf,
       gnutls_session_get_data(session, connect_sessionid, &connect_idsize);
 
       Curl_ssl_sessionid_lock(data);
-      incache = !(Curl_ssl_getsessionid(cf, data, &ssl_sessionid, NULL));
+      incache = !(Curl_ssl_getsessionid(cf, data, &connssl->peer,
+                                        &ssl_sessionid, NULL));
       if(incache) {
         /* there was one before in the cache, so instead of risking that the
            previous one was rejected, we just kill that and store the new */
@@ -1295,8 +1297,9 @@ static CURLcode gtls_verifyserver(struct Curl_cfilter *cf,
       }
 
       /* store this session id */
-      result = Curl_ssl_addsessionid(cf, data, connect_sessionid,
-                                     connect_idsize, &added);
+      result = Curl_ssl_addsessionid(cf, data, &connssl->peer,
+                                     connect_sessionid, connect_idsize,
+                                     &added);
       Curl_ssl_sessionid_unlock(data);
       if(!added)
         free(connect_sessionid);

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -45,7 +45,7 @@ struct ssl_primary_config;
 struct ssl_config_data;
 struct ssl_peer;
 
-struct gtls_instance {
+struct gtls_ctx {
   gnutls_session_t session;
   gnutls_certificate_credentials_t cred;
 #ifdef USE_GNUTLS_SRP
@@ -53,13 +53,18 @@ struct gtls_instance {
 #endif
 };
 
-CURLcode
-gtls_client_init(struct Curl_easy *data,
-                 struct ssl_primary_config *config,
-                 struct ssl_config_data *ssl_config,
-                 struct ssl_peer *peer,
-                 struct gtls_instance *gtls,
-                 long *pverifyresult);
+typedef CURLcode Curl_gtls_ctx_setup_cb(struct Curl_cfilter *cf,
+                                        struct Curl_easy *data,
+                                        void *user_data);
+
+CURLcode Curl_gtls_ctx_init(struct gtls_ctx *gctx,
+                            struct Curl_cfilter *cf,
+                            struct Curl_easy *data,
+                            struct ssl_peer *peer,
+                            const unsigned char *alpn, size_t alpn_len,
+                            Curl_gtls_ctx_setup_cb *cb_setup,
+                            void *cb_user_data,
+                            void *ssl_user_data);
 
 CURLcode
 Curl_gtls_verifyserver(struct Curl_easy *data,

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -24,6 +24,7 @@
 #include "curl_setup.h"
 
 #if defined(USE_OPENSSL) || \
+  defined(USE_GNUTLS) || \
   defined(USE_WOLFSSL) || \
   (defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || \
   defined(USE_QUICHE)

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -662,7 +662,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     void *old_session = NULL;
 
     Curl_ssl_sessionid_lock(data);
-    if(!Curl_ssl_getsessionid(cf, data, &old_session, NULL)) {
+    if(!Curl_ssl_getsessionid(cf, data, &connssl->peer, &old_session, NULL)) {
       ret = mbedtls_ssl_set_session(&backend->ssl, old_session);
       if(ret) {
         Curl_ssl_sessionid_unlock(data);
@@ -946,11 +946,12 @@ mbed_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
 
     /* If there's already a matching session in the cache, delete it */
     Curl_ssl_sessionid_lock(data);
-    if(!Curl_ssl_getsessionid(cf, data, &old_ssl_sessionid, NULL))
+    if(!Curl_ssl_getsessionid(cf, data, &connssl->peer,
+                              &old_ssl_sessionid, NULL))
       Curl_ssl_delsessionid(data, old_ssl_sessionid);
 
-    retcode = Curl_ssl_addsessionid(cf, data, our_ssl_sessionid,
-                                    0, &added);
+    retcode = Curl_ssl_addsessionid(cf, data, &connssl->peer,
+                                    our_ssl_sessionid, 0, &added);
     Curl_ssl_sessionid_unlock(data);
     if(!added) {
       mbedtls_ssl_session_free(our_ssl_sessionid);

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -589,7 +589,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   }
 #endif
 
-  infof(data, "mbedTLS: Connecting to %s:%d", hostname, connssl->port);
+  infof(data, "mbedTLS: Connecting to %s:%d", hostname, connssl->peer.port);
 
   mbedtls_ssl_config_init(&backend->config);
   ret = mbedtls_ssl_config_defaults(&backend->config,

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3532,7 +3532,11 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
     }
     break;
   case TRNSPRT_QUIC:
-    /* TODO: should probably check invalid version specs here also */
+    if((ssl_version != CURL_SSLVERSION_DEFAULT) &&
+       (ssl_version < CURL_SSLVERSION_TLSv1_3)) {
+      failf(data, "QUIC needs at least TLS version 1.3");
+      return CURLE_SSL_CONNECT_ERROR;
+     }
 #ifdef USE_OPENSSL_QUIC
     req_method = OSSL_QUIC_client_method();
 #else

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3698,9 +3698,8 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   }
 
   ciphers = conn_config->cipher_list;
-  if(!ciphers)
-    ciphers = (peer->transport == TRNSPRT_QUIC)?
-              NULL : DEFAULT_CIPHER_SELECTION;
+  if(!ciphers && (peer->transport != TRNSPRT_QUIC))
+    ciphers = DEFAULT_CIPHER_SELECTION;
   if(ciphers) {
     if(!SSL_CTX_set_cipher_list(octx->ssl_ctx, ciphers)) {
       failf(data, "failed setting cipher list: %s", ciphers);
@@ -4465,7 +4464,6 @@ static CURLcode ossl_connect_step3(struct Curl_cfilter *cf,
   CURLcode result = CURLE_OK;
   struct ssl_connect_data *connssl = cf->ctx;
   struct ossl_ctx *octx = (struct ossl_ctx *)connssl->backend;
-  struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
 
   DEBUGASSERT(ssl_connect_3 == connssl->connecting_state);
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3817,12 +3817,6 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
 
   SSL_set_connect_state(octx->ssl);
 
-  if(transport == TRNSPRT_QUIC) {
-#ifndef USE_OPENSSL_QUIC
-    SSL_set_quic_use_legacy_codepoint(octx->ssl, 0);
-#endif
-  }
-
   octx->server_cert = 0x0;
 #ifdef SSL_CTRL_SET_TLSEXT_HOSTNAME
   if(peer->sni) {

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -107,5 +107,15 @@ CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
                                const struct ssl_peer *peer,
                                SSL_SESSION *ssl_sessionid);
 
+/*
+ * Get the server cert, verify it and show it, etc., only call failf() if
+ * ssl config verifypeer or -host is set. Otherwise all this is for
+ * informational purposes only!
+ */
+CURLcode Curl_oss_check_peer_cert(struct Curl_cfilter *cf,
+                                  struct Curl_easy *data,
+                                  struct ossl_ctx *octx,
+                                  struct ssl_peer *peer);
+
 #endif /* USE_OPENSSL */
 #endif /* HEADER_CURL_SSLUSE_H */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1129,7 +1129,8 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   /* check for an existing reusable credential handle */
   if(ssl_config->primary.sessionid) {
     Curl_ssl_sessionid_lock(data);
-    if(!Curl_ssl_getsessionid(cf, data, (void **)&old_cred, NULL)) {
+    if(!Curl_ssl_getsessionid(cf, data, &connssl->peer,
+                              (void **)&old_cred, NULL)) {
       backend->cred = old_cred;
       DEBUGF(infof(data, "schannel: reusing existing credential handle"));
 
@@ -1751,7 +1752,8 @@ schannel_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
     struct Curl_schannel_cred *old_cred = NULL;
 
     Curl_ssl_sessionid_lock(data);
-    incache = !(Curl_ssl_getsessionid(cf, data, (void **)&old_cred, NULL));
+    incache = !(Curl_ssl_getsessionid(cf, data, &connssl->peer,
+                                      (void **)&old_cred, NULL));
     if(incache) {
       if(old_cred != backend->cred) {
         DEBUGF(infof(data,
@@ -1762,7 +1764,7 @@ schannel_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
       }
     }
     if(!incache) {
-      result = Curl_ssl_addsessionid(cf, data, backend->cred,
+      result = Curl_ssl_addsessionid(cf, &connssl->peer, data, backend->cred,
                                      sizeof(struct Curl_schannel_cred),
                                      &added);
       if(result) {

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1071,7 +1071,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   DEBUGASSERT(backend);
   DEBUGF(infof(data,
                "schannel: SSL/TLS connection with %s port %d (step 1/3)",
-               connssl->peer.hostname, connssl->port));
+               connssl->peer.hostname, connssl->peer.port));
 
   if(curlx_verify_windows_version(5, 1, 0, PLATFORM_WINNT,
                                   VERSION_LESS_THAN_EQUAL)) {
@@ -1336,7 +1336,7 @@ schannel_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   DEBUGF(infof(data,
                "schannel: SSL/TLS connection with %s port %d (step 2/3)",
-               connssl->peer.hostname, connssl->port));
+               connssl->peer.hostname, connssl->peer.port));
 
   if(!backend->cred || !backend->ctxt)
     return CURLE_SSL_CONNECT_ERROR;
@@ -1690,7 +1690,7 @@ schannel_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   DEBUGF(infof(data,
                "schannel: SSL/TLS connection with %s port %d (step 3/3)",
-               connssl->peer.hostname, connssl->port));
+               connssl->peer.hostname, connssl->peer.port));
 
   if(!backend->cred)
     return CURLE_SSL_CONNECT_ERROR;
@@ -1764,7 +1764,7 @@ schannel_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
       }
     }
     if(!incache) {
-      result = Curl_ssl_addsessionid(cf, &connssl->peer, data, backend->cred,
+      result = Curl_ssl_addsessionid(cf, data, &connssl->peer, backend->cred,
                                      sizeof(struct Curl_schannel_cred),
                                      &added);
       if(result) {
@@ -2491,7 +2491,7 @@ static int schannel_shutdown(struct Curl_cfilter *cf,
 
   if(backend->ctxt) {
     infof(data, "schannel: shutting down SSL/TLS connection with %s port %d",
-          connssl->peer.hostname, connssl->port);
+          connssl->peer.hostname, connssl->peer.port);
   }
 
   if(backend->cred && backend->ctxt) {

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2048,7 +2048,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
 
     Curl_ssl_sessionid_lock(data);
     if(!Curl_ssl_getsessionid(cf, data, &connssl->peer,
-                              (void **)&ssl_sessionid, ssl_sessionid_len)) {
+                              (void **)&ssl_sessionid, &ssl_sessionid_len)) {
       /* we got a session id, use it! */
       err = SSLSetPeerID(backend->ssl_ctx, ssl_sessionid, ssl_sessionid_len);
       Curl_ssl_sessionid_unlock(data);
@@ -2067,7 +2067,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
         aprintf("%s:%d:%d:%s:%d",
                 ssl_cafile ? ssl_cafile : "(blob memory)",
                 verifypeer, conn_config->verifyhost, connssl->peer.hostname,
-                connssl->port);
+                connssl->peer.port);
       ssl_sessionid_len = strlen(ssl_sessionid);
 
       err = SSLSetPeerID(backend->ssl_ctx, ssl_sessionid, ssl_sessionid_len);

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2047,8 +2047,8 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
     size_t ssl_sessionid_len;
 
     Curl_ssl_sessionid_lock(data);
-    if(!Curl_ssl_getsessionid(cf, data, (void **)&ssl_sessionid,
-                              &ssl_sessionid_len)) {
+    if(!Curl_ssl_getsessionid(cf, data, &connssl->peer,
+                              (void **)&ssl_sessionid, ssl_sessionid_len)) {
       /* we got a session id, use it! */
       err = SSLSetPeerID(backend->ssl_ctx, ssl_sessionid, ssl_sessionid_len);
       Curl_ssl_sessionid_unlock(data);
@@ -2077,7 +2077,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
         return CURLE_SSL_CONNECT_ERROR;
       }
 
-      result = Curl_ssl_addsessionid(cf, data, ssl_sessionid,
+      result = Curl_ssl_addsessionid(cf, data, &connssl->peer, ssl_sessionid,
                                      ssl_sessionid_len, NULL);
       Curl_ssl_sessionid_unlock(data);
       if(result) {

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -107,7 +107,8 @@ void Curl_ssl_conn_config_update(struct Curl_easy *data, bool for_proxy);
 /**
  * Init SSL peer information for filter. Can be called repeatedly.
  */
-CURLcode Curl_ssl_peer_init(struct ssl_peer *peer, struct Curl_cfilter *cf);
+CURLcode Curl_ssl_peer_init(struct ssl_peer *peer,
+                            struct Curl_cfilter *cf, int transport);
 /**
  * Free all allocated data and reset peer information.
  */

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -75,7 +75,6 @@ struct ssl_connect_data {
   struct curltime handshake_done;   /* time when handshake finished */
   int port;                         /* remote port at origin */
   BIT(use_alpn);                    /* if ALPN shall be used in handshake */
-  BIT(reused_session);              /* session-ID was reused for this */
   BIT(peer_closed);                 /* peer has closed connection */
 };
 

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -73,7 +73,6 @@ struct ssl_connect_data {
   void *backend;                    /* vtls backend specific props */
   struct cf_call_data call_data;    /* data handle used in current call */
   struct curltime handshake_done;   /* time when handshake finished */
-  int port;                         /* remote port at origin */
   BIT(use_alpn);                    /* if ALPN shall be used in handshake */
   BIT(peer_closed);                 /* peer has closed connection */
 };
@@ -180,6 +179,7 @@ bool Curl_ssl_cf_is_proxy(struct Curl_cfilter *cf);
  */
 bool Curl_ssl_getsessionid(struct Curl_cfilter *cf,
                            struct Curl_easy *data,
+                           const struct ssl_peer *peer,
                            void **ssl_sessionid,
                            size_t *idsize); /* set 0 if unknown */
 /* add a new session ID
@@ -189,6 +189,7 @@ bool Curl_ssl_getsessionid(struct Curl_cfilter *cf,
  */
 CURLcode Curl_ssl_addsessionid(struct Curl_cfilter *cf,
                                struct Curl_easy *data,
+                               const struct ssl_peer *peer,
                                void *ssl_sessionid,
                                size_t idsize,
                                bool *added);

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -409,11 +409,11 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
 #if defined(WOLFSSL_ALLOW_TLSV10) && !defined(NO_OLD_TLS)
     req_method = TLSv1_client_method();
     use_sni(TRUE);
+    break;
 #else
     failf(data, "wolfSSL does not support TLS 1.0");
     return CURLE_NOT_BUILT_IN;
 #endif
-    break;
   case CURL_SSLVERSION_TLSv1_1:
 #ifndef NO_OLD_TLS
     req_method = TLSv1_1_client_method();
@@ -481,6 +481,7 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
       return CURLE_SSL_CONNECT_ERROR;
     }
 #endif
+    FALLTHROUGH();
   default:
     break;
   }

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -711,7 +711,8 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     void *ssl_sessionid = NULL;
 
     Curl_ssl_sessionid_lock(data);
-    if(!Curl_ssl_getsessionid(cf, data, &ssl_sessionid, NULL)) {
+    if(!Curl_ssl_getsessionid(cf, data, &connssl->peer,
+                              &ssl_sessionid, NULL)) {
       /* we got a session id, use it! */
       if(!SSL_set_session(backend->handle, ssl_sessionid)) {
         Curl_ssl_delsessionid(data, ssl_sessionid);
@@ -964,7 +965,8 @@ wolfssl_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
 
     if(our_ssl_sessionid) {
       Curl_ssl_sessionid_lock(data);
-      incache = !(Curl_ssl_getsessionid(cf, data, &old_ssl_sessionid, NULL));
+      incache = !(Curl_ssl_getsessionid(cf, data, &connssl->peer,
+                                        &old_ssl_sessionid, NULL));
       if(incache) {
         if(old_ssl_sessionid != our_ssl_sessionid) {
           infof(data, "old SSL session ID is stale, removing");
@@ -974,7 +976,8 @@ wolfssl_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
       }
 
       if(!incache) {
-        result = Curl_ssl_addsessionid(cf, data, our_ssl_sessionid, 0, NULL);
+        result = Curl_ssl_addsessionid(cf, data, &connssl->peer,
+                                       our_ssl_sessionid, 0, NULL);
         if(result) {
           Curl_ssl_sessionid_unlock(data);
           wolfSSL_SESSION_free(our_ssl_sessionid);

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -376,13 +376,14 @@ class TestDownload:
         assert r.exit_code == 0, f'{client.dump_logs()}'
 
     # Special client that tests TLS session reuse in parallel transfers
-    def test_02_26_session_shared_reuse(self, env: Env, httpd, repeat):
-        curl = CurlClient(env=env)
-        url = f'https://{env.domain1}:{env.https_port}/data-100k'
+    # TODO: just uses a single connection for h2/h3. Not sure how to prevent that
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    def test_02_26_session_shared_reuse(self, env: Env, proto, httpd, nghttpx, repeat):
+        url = f'https://{env.authority_for(env.domain1, proto)}/data-100k'
         client = LocalClient(name='tls-session-reuse', env=env)
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
-        r = client.run(args=[url])
+        r = client.run(args=[proto, url])
         r.check_exit_code(0)
 
     # test on paused transfers, based on issue #11982


### PR DESCRIPTION
Having TCP TLS and QUIC TLS use shared code.

- OpenSSL TCP+QUIC filters now have a common init and cert verify.
- gnuTLS with common init and verify
- SSL session storage also used in QUIC Openssl filter
- `struct ssl_peer` has added `port` and `transport` members
- `peer` is passed in session lookup and storage
- sessions only used when transport matches
