### PR TITLE
remember protocol handler at easy requests

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -129,6 +129,7 @@ static CURLcode file_setup_connection(struct Curl_easy *data,
 {
   (void)conn;
   /* allocate the FILE specific struct */
+  data->req.handler = conn->handler;
   data->req.p.file = calloc(1, sizeof(struct FILEPROTO));
   if(!data->req.p.file)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4519,6 +4519,7 @@ static CURLcode ftp_setup_connection(struct Curl_easy *data,
       return CURLE_OUT_OF_MEMORY;
     }
   }
+  data->req.handler = conn->handler;
   data->req.p.ftp = ftp;
 
   ftp->path = &data->state.up.path[1]; /* don't include the initial slash */

--- a/lib/http.c
+++ b/lib/http.c
@@ -175,6 +175,7 @@ CURLcode Curl_http_setup_conn(struct Curl_easy *data,
   if(!http)
     return CURLE_OUT_OF_MEMORY;
 
+  data->req.handler = conn->handler;
   data->req.p.http = http;
   connkeep(conn, "HTTP default");
 

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -198,10 +198,11 @@ struct h2_stream_ctx {
                        buffered data in stream->sendbuf to upload. */
 };
 
-#define H2_STREAM_CTX(d)    ((struct h2_stream_ctx *)(((d) && \
-                              (d)->req.p.http)? \
-                             ((struct HTTP *)(d)->req.p.http)->h2_ctx \
-                               : NULL))
+#define REQ_IS_HTTP(d)      ((d) && (d)->req.handler && \
+                             ((d)->req.handler->protocol & PROTO_FAMILY_HTTP))
+#define H2_STREAM_CTX(d)    ((struct h2_stream_ctx *)( \
+                             (REQ_IS_HTTP(d) && (d)->req.p.http)? \
+                              (d)->req.p.http->h2_ctx : NULL))
 #define H2_STREAM_LCTX(d)   ((struct HTTP *)(d)->req.p.http)->h2_ctx
 #define H2_STREAM_ID(d)     (H2_STREAM_CTX(d)? \
                              H2_STREAM_CTX(d)->id : -2)

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1419,11 +1419,12 @@ static CURLcode imap_block_statemach(struct Curl_easy *data,
 
 /* Allocate and initialize the struct IMAP for the current Curl_easy if
    required */
-static CURLcode imap_init(struct Curl_easy *data)
+static CURLcode imap_init(struct Curl_easy *data, struct connectdata *conn)
 {
   CURLcode result = CURLE_OK;
   struct IMAP *imap;
 
+  data->req.handler = conn->handler;
   imap = data->req.p.imap = calloc(1, sizeof(struct IMAP));
   if(!imap)
     result = CURLE_OUT_OF_MEMORY;
@@ -1751,7 +1752,7 @@ static CURLcode imap_setup_connection(struct Curl_easy *data,
                                       struct connectdata *conn)
 {
   /* Initialise the IMAP layer */
-  CURLcode result = imap_init(data);
+  CURLcode result = imap_init(data, conn);
   if(result)
     return result;
 

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -110,6 +110,7 @@ static CURLcode mqtt_setup_conn(struct Curl_easy *data,
   if(!mq)
     return CURLE_OUT_OF_MEMORY;
   Curl_dyn_init(&mq->recvbuf, DYN_MQTT_RECV);
+  data->req.handler = conn->handler;
   data->req.p.mqtt = mq;
   return CURLE_OK;
 }

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -915,6 +915,7 @@ static CURLcode oldap_do(struct Curl_easy *data, bool *done)
       }
       else {
         lr->msgid = msgid;
+        data->req.handler = conn->handler;
         data->req.p.ldap = lr;
         Curl_xfer_setup(data, FIRSTSOCKET, -1, FALSE, -1);
         *done = TRUE;

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1079,11 +1079,12 @@ static CURLcode pop3_block_statemach(struct Curl_easy *data,
 
 /* Allocate and initialize the POP3 struct for the current Curl_easy if
    required */
-static CURLcode pop3_init(struct Curl_easy *data)
+static CURLcode pop3_init(struct Curl_easy *data, struct connectdata *conn)
 {
   CURLcode result = CURLE_OK;
   struct POP3 *pop3;
 
+  data->req.handler = conn->handler;
   pop3 = data->req.p.pop3 = calloc(1, sizeof(struct POP3));
   if(!pop3)
     result = CURLE_OUT_OF_MEMORY;
@@ -1341,7 +1342,7 @@ static CURLcode pop3_setup_connection(struct Curl_easy *data,
                                       struct connectdata *conn)
 {
   /* Initialise the POP3 layer */
-  CURLcode result = pop3_init(data);
+  CURLcode result = pop3_init(data, conn);
   if(result)
     return result;
 

--- a/lib/request.c
+++ b/lib/request.c
@@ -109,6 +109,7 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
 
   /* This is a bit ugly. `req->p` is a union and we assume we can
    * free this safely without leaks. */
+  data->req.handler = NULL;
   Curl_safefree(req->p.http);
   Curl_safefree(req->newurl);
   Curl_client_reset(data);

--- a/lib/request.h
+++ b/lib/request.h
@@ -101,6 +101,7 @@ struct SingleRequest {
 
   /* Allocated protocol-specific data. Each protocol handler makes sure this
      points to data it needs. */
+  const struct Curl_handler *handler;
   union {
     struct FILEPROTO *file;
     struct FTP *ftp;

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -130,6 +130,7 @@ static CURLcode rtsp_setup_connection(struct Curl_easy *data,
   struct RTSP *rtsp;
   (void)conn;
 
+  data->req.handler = conn->handler;
   data->req.p.rtsp = rtsp = calloc(1, sizeof(struct RTSP));
   if(!rtsp)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -431,6 +431,7 @@ static CURLcode smb_setup_connection(struct Curl_easy *data,
   struct smb_request *req;
 
   /* Initialize the request state */
+  data->req.handler = conn->handler;
   data->req.p.smb = req = calloc(1, sizeof(struct smb_request));
   if(!req)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1309,11 +1309,12 @@ static CURLcode smtp_block_statemach(struct Curl_easy *data,
 
 /* Allocate and initialize the SMTP struct for the current Curl_easy if
    required */
-static CURLcode smtp_init(struct Curl_easy *data)
+static CURLcode smtp_init(struct Curl_easy *data, struct connectdata *conn)
 {
   CURLcode result = CURLE_OK;
   struct SMTP *smtp;
 
+  data->req.handler = conn->handler;
   smtp = data->req.p.smtp = calloc(1, sizeof(struct SMTP));
   if(!smtp)
     result = CURLE_OUT_OF_MEMORY;
@@ -1612,7 +1613,7 @@ static CURLcode smtp_setup_connection(struct Curl_easy *data,
   conn->bits.tls_upgraded = FALSE;
 
   /* Initialise the SMTP layer */
-  result = smtp_init(data);
+  result = smtp_init(data, conn);
   if(result)
     return result;
 

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -206,6 +206,7 @@ CURLcode init_telnet(struct Curl_easy *data)
     return CURLE_OUT_OF_MEMORY;
 
   Curl_dyn_init(&tn->out, 0xffff);
+  data->req.handler = data->conn->handler;
   data->req.p.telnet = tn; /* make us known */
 
   tn->telrcv_state = CURL_TS_DATA;

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -153,7 +153,10 @@ struct stream_ctx {
   bool recv_header_complete;
 };
 
-#define H3_STREAM_CTX(d)    ((struct stream_ctx *)(((d) && (d)->req.p.http)? \
+#define REQ_IS_HTTP(d)      ((d) && (d)->req.handler && \
+                             ((d)->req.handler->protocol & PROTO_FAMILY_HTTP))
+#define H3_STREAM_CTX(d)    ((struct stream_ctx *)(\
+                             (REQ_IS_HTTP(d) && (d)->req.p.http)? \
                              ((struct HTTP *)(d)->req.p.http)->h3_ctx \
                                : NULL))
 #define H3_STREAM_LCTX(d)   ((struct HTTP *)(d)->req.p.http)->h3_ctx

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -159,7 +159,10 @@ struct h3_stream_ctx {
   BIT(quic_flow_blocked); /* stream is blocked by QUIC flow control */
 };
 
-#define H3_STREAM_CTX(d)  ((struct h3_stream_ctx *)(((d) && (d)->req.p.http)? \
+#define REQ_IS_HTTP(d)      ((d) && (d)->req.handler && \
+                             ((d)->req.handler->protocol & PROTO_FAMILY_HTTP))
+#define H3_STREAM_CTX(d)  ((struct h3_stream_ctx *)(\
+                           (REQ_IS_HTTP(d) && (d)->req.p.http)? \
                            ((struct HTTP *)(d)->req.p.http)->h3_ctx \
                              : NULL))
 #define H3_STREAM_LCTX(d) ((struct HTTP *)(d)->req.p.http)->h3_ctx

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -493,7 +493,10 @@ struct h3_stream_ctx {
   BIT(quic_flow_blocked); /* stream is blocked by QUIC flow control */
 };
 
-#define H3_STREAM_CTX(d)  ((struct h3_stream_ctx *)(((d) && (d)->req.p.http)? \
+#define REQ_IS_HTTP(d)      ((d) && (d)->req.handler && \
+                             ((d)->req.handler->protocol & PROTO_FAMILY_HTTP))
+#define H3_STREAM_CTX(d)  ((struct h3_stream_ctx *)(
+                           (REQ_IS_HTTP(d) && (d)->req.p.http)? \
                            ((struct HTTP *)(d)->req.p.http)->h3_ctx \
                              : NULL))
 #define H3_STREAM_LCTX(d) ((struct HTTP *)(d)->req.p.http)->h3_ctx

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -151,7 +151,10 @@ struct stream_ctx {
   BIT(quic_flow_blocked); /* stream is blocked by QUIC flow control */
 };
 
-#define H3_STREAM_CTX(d)    ((struct stream_ctx *)(((d) && (d)->req.p.http)? \
+#define REQ_IS_HTTP(d)      ((d) && (d)->req.handler && \
+                             ((d)->req.handler->protocol & PROTO_FAMILY_HTTP))
+#define H3_STREAM_CTX(d)    ((struct stream_ctx *)(\
+                             (REQ_IS_HTTP(d) && (d)->req.p.http)? \
                              ((struct HTTP *)(d)->req.p.http)->h3_ctx \
                                : NULL))
 #define H3_STREAM_LCTX(d)   ((struct HTTP *)(d)->req.p.http)->h3_ctx

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2145,6 +2145,7 @@ static CURLcode myssh_setup_connection(struct Curl_easy *data,
   struct SSHPROTO *ssh;
   struct ssh_conn *sshc = &conn->proto.sshc;
 
+  data->req.handler = conn->handler;
   data->req.p.ssh = ssh = calloc(1, sizeof(struct SSHPROTO));
   if(!ssh)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3173,6 +3173,7 @@ static CURLcode ssh_setup_connection(struct Curl_easy *data,
   struct SSHPROTO *ssh;
   (void)conn;
 
+  data->req.handler = conn->handler;
   data->req.p.ssh = ssh = calloc(1, sizeof(struct SSHPROTO));
   if(!ssh)
     return CURLE_OUT_OF_MEMORY;

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -337,6 +337,7 @@ static CURLcode wssh_setup_connection(struct Curl_easy *data,
   struct SSHPROTO *ssh;
   (void)conn;
 
+  data->req.handler = conn->handler;
   data->req.p.ssh = ssh = calloc(1, sizeof(struct SSHPROTO));
   if(!ssh)
     return CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
- remember protocol handler at `data->req` so that members in `data->req.p.*` can be accessed more safely
- used in connection filters to not access information for "foreign" handlers