### PR TITLE
cmake: generate misc manpages and install `mk-ca-bundle.pl`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ endif()
 find_package(Perl)
 
 option(BUILD_LIBCURL_DOCS "to build libcurl man pages" ON)
+option(BUILD_MISC_DOCS "to build misc man pages (e.g. curl-config and mk-ca-bundle)" ON)
 option(ENABLE_CURL_MANUAL "to build the man page for curl and enable its -M/--manual option" ON)
 
 if(ENABLE_CURL_MANUAL OR BUILD_LIBCURL_DOCS)
@@ -1513,6 +1514,13 @@ if(BUILD_TESTING)
 endif()
 
 if(NOT CURL_DISABLE_INSTALL)
+
+  install(FILES "${PROJECT_SOURCE_DIR}/scripts/mk-ca-bundle.pl"
+          DESTINATION ${CMAKE_INSTALL_BINDIR}
+          PERMISSIONS
+            OWNER_READ OWNER_WRITE OWNER_EXECUTE
+            GROUP_READ GROUP_EXECUTE
+            WORLD_READ WORLD_EXECUTE)
 
   # Helper to populate a list (_items) with a label when conditions (the remaining
   # args) are satisfied

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,7 +84,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1501 !1140 !1173 !1177 !1477'
+      DISABLED_TESTS: '!1139 !1501 !1177 !1477'
     - job_name: 'CMake, VS2022, Debug, x64, Schannel, Static, Unicode'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -95,7 +95,7 @@ environment:
       ENABLE_UNICODE: 'ON'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1501 !1140 !1173 !1177 !1477'
+      DISABLED_TESTS: '!1139 !1501 !1177 !1477'
     - job_name: 'CMake, VS2022, Debug, x64, no SSL, Static'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -106,7 +106,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1501 !1140 !1173 !1177 !1477'
+      DISABLED_TESTS: '!1139 !1501 !1177 !1477'
     - job_name: 'CMake, VS2022, Debug, x64, no SSL, Static, HTTP only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -117,7 +117,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'ON'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1501 !1140 !1173 !1177 !1477'
+      DISABLED_TESTS: '!1139 !1501 !1177 !1477'
     # generated CMake-based MSYS Makefiles builds (mingw cross-compiling)
     - job_name: 'CMake, mingw-w64, gcc 13, Debug, x64, Schannel, Static, Unicode, Unity'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
@@ -128,7 +128,7 @@ environment:
       ENABLE_UNICODE: 'ON'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1086 !1139 !1451 !1501 !1140 !1173 !1177 !1477'
+      DISABLED_TESTS: '!1086 !1139 !1451 !1501 !1177 !1477'
       ADD_PATH: 'C:/msys64/mingw64/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -142,7 +142,7 @@ environment:
       ENABLE_UNICODE: 'ON'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1086 !1139 !1451 !1501 !1140 !1173 !1177 !1477'
+      DISABLED_TESTS: '!1086 !1139 !1451 !1501 !1177 !1477'
       ADD_PATH: 'C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1/mingw64/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -156,7 +156,7 @@ environment:
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
       # test 286 disabled due to https://github.com/curl/curl/issues/12040
-      DISABLED_TESTS: '~286 !1086 !1139 !1451 !1501 !1140 !1173 !1177 !1477'
+      DISABLED_TESTS: '~286 !1086 !1139 !1451 !1501 !1177 !1477'
       ADD_PATH: 'C:/msys64/mingw64/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
@@ -170,7 +170,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
-      DISABLED_TESTS: '!1086 !1139 !1451 !1501 !1140 !1173 !1177 !1477'
+      DISABLED_TESTS: '!1086 !1139 !1451 !1501 !1177 !1477'
       ADD_PATH: 'C:/mingw-w64/i686-6.3.0-posix-dwarf-rt_v5-rev1/mingw32/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -33,7 +33,9 @@ if(BUILD_MISC_DOCS)
   foreach(_man_misc IN ITEMS "curl-config" "mk-ca-bundle")
     set(_man_target "${CURL_BINARY_DIR}/docs/${_man_misc}.1")
     add_custom_command(OUTPUT "${_man_target}"
-      COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff "${_man_misc}.md" > "${_man_target}"
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      COMMAND "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff "${_man_misc}.md" > "${_man_target}"
+      DEPENDS ${_man_target}
       VERBATIM
     )
     add_custom_target("generate-${_man_misc}.1" ALL DEPENDS "${_man_target}")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -28,3 +28,17 @@ endif()
 if(ENABLE_CURL_MANUAL AND BUILD_CURL_EXE)
   add_subdirectory(cmdline-opts)
 endif()
+
+if(BUILD_MISC_DOCS)
+  foreach(_man_misc IN ITEMS "curl-config" "mk-ca-bundle")
+    set(_man_target "${CURL_BINARY_DIR}/docs/${_man_misc}.1")
+    add_custom_command(OUTPUT "${_man_target}"
+      COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff "${_man_misc}.md" > "${_man_target}"
+      VERBATIM
+    )
+    add_custom_target("generate-${_man_misc}.1" ALL DEPENDS "${_man_target}")
+    if(NOT CURL_DISABLE_INSTALL)
+      install(FILES "${_man_target}" DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+    endif()
+  endforeach()
+endif()


### PR DESCRIPTION
- install `mk-ca-bundle.pl` like autotools does.

- generate and install `mk-ca-bundle.1` and `curl-config.1` like autotools. This fixes tests 1140 and 1173.

  Fixes #13194

- add option `BUILD_MISC_DOCS` to control building the above two manpages. Enabled by default.

- appveyor: stop disabling tests 1140 and 1173.

Closes #13197
