### PR TITLE
cmdline-docs: fix make install with configure --disable-docs

### DIFF
--- a/docs/cmdline-opts/Makefile.am
+++ b/docs/cmdline-opts/Makefile.am
@@ -27,8 +27,6 @@ AUTOMAKE_OPTIONS = foreign no-dependencies
 MANPAGE = curl.1
 ASCIIPAGE = curl.txt
 
-man_MANS = $(MANPAGE)
-
 include Makefile.inc
 
 EXTRA_DIST = $(DPAGES) MANPAGE.md $(SUPPORT) CMakeLists.txt mainpage.idx
@@ -42,6 +40,7 @@ MANAGEN=$(abs_top_srcdir)/scripts/managen
 
 if BUILD_DOCS
 CLEANFILES = $(MANPAGE) $(ASCIIPAGE)
+man_MANS = $(MANPAGE)
 
 all: $(MANPAGE) $(ASCIIPAGE)
 


### PR DESCRIPTION
`make -C docs/cmdline-opts install` depends on `all-am`, which in turn depends on `$(MANS)`, unconditionally defined to be `$(man_MANS)`.

As with `CLEANFILES`, only add `curl.1` to `man_MANS` when `BUILD_DOCS` is true so we don't try to build `curl.1` unnecessarily.