### PR TITLE
m4: fix rustls pkg-config codepath

### DIFF
--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -100,9 +100,6 @@ if test "x$OPT_RUSTLS" != xno; then
           AC_MSG_ERROR([--with-rustls was specified but could not find rustls.]),
           -lpthread -ldl -lm)
 
-        USE_RUSTLS="yes"
-        ssl_msg="rustls"
-
         LIB_RUSTLS="$PREFIX_RUSTLS/lib$libsuff"
         if test "$PREFIX_RUSTLS" != "/usr" ; then
           SSL_LDFLAGS="-L$LIB_RUSTLS"
@@ -142,6 +139,10 @@ if test "x$OPT_RUSTLS" != xno; then
       LIBS="$SSL_LIBS $LIBS"
       USE_RUSTLS="yes"
       ssl_msg="rustls"
+      AC_DEFINE(USE_RUSTLS, 1, [if rustls is enabled])
+      AC_SUBST(USE_RUSTLS, [1])
+      RUSTLS_ENABLED=1
+      test rustls != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
     else
       AC_MSG_ERROR([pkg-config: Could not find rustls])
     fi
@@ -174,5 +175,15 @@ if test "x$OPT_RUSTLS" != xno; then
   fi
 
   test -z "$ssl_msg" || ssl_backends="${ssl_backends:+$ssl_backends, }$ssl_msg"
+
+  if test X"$OPT_RUSTLS" != Xno &&
+    test "$RUSTLS_ENABLED" != "1"; then
+    AC_MSG_NOTICE([OPT_RUSTLS: $OPT_RUSTLS])
+    AC_MSG_NOTICE([RUSTLS_ENABLED: $RUSTLS_ENABLED])
+    AC_MSG_ERROR([--with-rustls was given but Rustls could not be detected])
+  fi
 fi
 ])
+
+
+RUSTLS_ENABLED


### PR DESCRIPTION
The previous pkg-config code would successfully detect rustls but did not set all appropriate variables and call the right macros to properly configure cURL.

Closes: #13200