### PR TITLE
cmake: speed up libcurl doc builds again

### DIFF
--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -26,21 +26,39 @@ transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 function(add_manual_pages _listname)
-  foreach(_file IN LISTS ${_listname})
-    set(_rofffile "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
+  # Maximum number of files per command to stay within shell/OS limits
+  if(UNIX)
+    set(_files_per_batch 10000)
+  else()  # e.g. Windows with cmd.exe and other obsolete/unknown shells
+    set(_files_per_batch 200)
+  endif()
+  set(_file_count 0)
+  unset(_rofffiles)
+  unset(_mdfiles)
+  set(_eol "_EOL_")
+  foreach(_file IN LISTS ${_listname} _eol)
+    math(EXPR _file_count "${_file_count} + 1")
+    if(NOT _file_count LESS ${_files_per_batch} OR _file STREQUAL "_EOL_")
+      add_custom_command(OUTPUT ${_rofffiles}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMAND "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff -k -d "${CMAKE_CURRENT_BINARY_DIR}" ${_mdfiles}
+        DEPENDS ${_mdfiles}
+        VERBATIM
+      )
+      set(_file_count 0)
+      unset(_rofffiles)
+      unset(_mdfiles)
+    endif()
+
+    list(APPEND _rofffiles "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
     if(_file STREQUAL "libcurl-symbols.3")
       # Special case, an auto-generated file.
       string(REPLACE ".3" ".md" _mdfile "${CMAKE_CURRENT_BINARY_DIR}/${_file}")
     else()
-      string(REPLACE ".3" ".md" _mdfile "${CMAKE_CURRENT_SOURCE_DIR}/${_file}")
+      string(REPLACE ".3" ".md" _mdfile "${_file}")
     endif()
-    add_custom_command(OUTPUT "${_rofffile}"
-      COMMAND "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff ${_mdfile} > ${_rofffile}
-      DEPENDS "${_mdfile}"
-      VERBATIM
-    )
+    list(APPEND _mdfiles "${_mdfile}")
   endforeach()
-
 endfunction()
 
 add_custom_command(OUTPUT libcurl-symbols.md


### PR DESCRIPTION
This time limit the number of files per command to avoid exceeding limitations of certain OS/shell envs.

Such known env is Windows with the `cmd.exe` shell, which features an 8K command-line length limit to this day.

Allowlisting `UNIX` to have no limit and using a limit of 200 for all other envs to be safe. If there is a way to detect `cmd.exe` and/or we know which precise envs are sensitive to this, we can tweak these conditions further.

Even with the low limit, this patch reduces external commands by 200x, making full and CI builds much faster.

Ref: #12762 2620aa930bc73af1e4c70b10e3125b957b96ecfb (initial)
Ref: #13047 f03c85635f35269f1f45b983bf216624f541760a (revert)

Closes #13207
