### PR TITLE
Fix detection of OpenSSL 1.1.1 or later in curl_sha512_256.c

### DIFF
--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -44,7 +44,7 @@
 #  include <openssl/opensslv.h>
 #  if (!defined(LIBRESSL_VERSION_NUMBER) && \
         defined(OPENSSL_VERSION_NUMBER) && \
-        (OPENSSL_VERSION_NUMBER >= 0x10100010L)) || \
+        (OPENSSL_VERSION_NUMBER >= 0x10101000L)) || \
       (defined(LIBRESSL_VERSION_NUMBER) && \
         (LIBRESSL_VERSION_NUMBER >= 0x3080000fL))
 #    include <openssl/opensslconf.h>


### PR DESCRIPTION
Use the same OPENSSL_VERSION_NUMBER comparison as in lib/vtls/openssl.c.

As it stands, builds using an OpenSSL 1.1.0 release fail due to trying to use the unavailable symbol EVP_sha512_256.