### PR TITLE
tool_getparam: output warning for leading unicode quote character

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1337,6 +1337,11 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         warnf(global, "The file name argument '%s' looks like a flag.",
               nextarg);
       }
+      else if(!strncmp("\xe2\x80\x9c", nextarg, 3)) {
+        warnf(global, "The argument '%s' starts with a unicode quote where "
+              "maybe an ASCII \" was intended?",
+              nextarg);
+      }
     }
     else if((a->desc == ARG_NONE) && !toggle) {
       err = PARAM_NO_PREFIX;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -73,7 +73,7 @@ test426 test427 test428 test429 test430 test431 test432 test433 test434 \
 test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
-test462 test463 test467 test468 test469 \
+test462 test463 test467 test468 test469 test470 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -73,7 +73,7 @@ test426 test427 test428 test429 test430 test431 test432 test433 test434 \
 test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
-test462 test463 test467 test468 \
+test462 test463 test467 test468 test469 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \

--- a/tests/data/test469
+++ b/tests/data/test469
@@ -28,6 +28,9 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
+<features>
+!win32
+</features>
 <server>
 http
 </server>

--- a/tests/data/test469
+++ b/tests/data/test469
@@ -1,0 +1,50 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+warn about unicode quote character
+</name>
+<command>
+-H “host: %HOSTIP:%HTTPPORT/” -s
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<stderr>
+%hex[Warning: The argument '%e2%80%9chost:' starts with a unicode quote where maybe an ]hex%
+Warning: ASCII " was intended?
+</stderr>
+</verify>
+</testcase>

--- a/tests/data/test470
+++ b/tests/data/test470
@@ -1,0 +1,53 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+warn about unicode quote character read from config file
+</name>
+<file name="%LOGDIR/input%TESTNUMBER">
+-H “host:fake”
+</file>
+<command>
+%HOSTIP:%HTTPPORT --no-progress-meter -K "%LOGDIR/input%TESTNUMBER"
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<stderr>
+%hex[Warning: The argument '%e2%80%9chost:fake%e2%80%9d' starts with a unicode quote where ]hex%
+Warning: maybe an ASCII " was intended?
+</stderr>
+</verify>
+</testcase>

--- a/tests/data/test470
+++ b/tests/data/test470
@@ -28,6 +28,9 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
+<features>
+!hyper
+</features>
 <server>
 http
 </server>

--- a/tests/data/test470
+++ b/tests/data/test470
@@ -45,7 +45,7 @@ warn about unicode quote character read from config file
 #
 # Verify data after the test has been "shot"
 <verify>
-<stderr>
+<stderr mode="text">
 %hex[Warning: The argument '%e2%80%9chost:fake%e2%80%9d' starts with a unicode quote where ]hex%
 Warning: maybe an ASCII " was intended?
 </stderr>


### PR DESCRIPTION
... in the option argument.

Typically this is a mistake done when copying example command lines from online documentation using the wrong quote character.

Presumably there are also other potential quote characters that might be used, and this check is done without even knowing that unicode is used!

Reported-by: Sanjay Pujare
Fixes #13214