### PR TITLE
RELEASE-PROCEDURE: mention an initial working build

### DIFF
--- a/docs/RELEASE-PROCEDURE.md
+++ b/docs/RELEASE-PROCEDURE.md
@@ -4,7 +4,8 @@ curl release procedure - how to do a release
 in the source code repo
 -----------------------
 
-- run `./scripts/copyright.pl` and correct possible omissions
+- do a *regular build* with a sensible build config to make sure the
+  `src/tool_hugehelp.c` file etc is correctly generated
 
 - edit `RELEASE-NOTES` to be accurate
 


### PR DESCRIPTION
This is the step that was not done and caused the 8.7.0 mishap (it lacked the correctly generated hugehelp file).

Remove the mention of the copyright script as this is verified by a CI job these days: the REUSE one.