### PR TITLE
appveyor: enable cmake unity mode by default

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,7 +131,7 @@ environment:
       ADD_PATH: 'C:/msys64/mingw64/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
-    - job_name: 'CMake, mingw-w64, gcc 7, Debug, x64, Schannel, Static, Unicode, no-unity'
+    - job_name: 'CMake, mingw-w64, gcc 7, Debug, x64, Schannel, Static, Unicode'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'MSYS Makefiles'
@@ -144,7 +144,6 @@ environment:
       ADD_PATH: 'C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1/mingw64/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
-      UNITY: 'OFF'
     - job_name: 'CMake, mingw-w64, gcc 9, Debug, x64, Schannel, Static'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
@@ -159,7 +158,7 @@ environment:
       ADD_PATH: 'C:/msys64/mingw64/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
-    - job_name: 'CMake, mingw-w64, gcc 6, Debug, x86, Schannel, Static'
+    - job_name: 'CMake, mingw-w64, gcc 6, Debug, x86, Schannel, Static, no-unity'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'MSYS Makefiles'
@@ -172,6 +171,7 @@ environment:
       ADD_PATH: 'C:/mingw-w64/i686-6.3.0-posix-dwarf-rt_v5-rev1/mingw32/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
+      UNITY: 'OFF'
     # winbuild-based builds
     - job_name: 'winbuild, VS2015, Debug, x64, OpenSSL 1.1.1, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@
 version: 7.50.0.{build}
 
 environment:
-  UNITY: 'OFF'
+  UNITY: 'ON'
   OPENSSL: 'OFF'
   DEBUG: 'ON'
   SHARED: 'OFF'
@@ -48,7 +48,7 @@ environment:
       SHARED: 'ON'
       TESTING: 'OFF'
       DISABLED_TESTS: ''
-    - job_name: 'CMake, VS2022, Release, x64, OpenSSL 1.1.1, WebSockets, Unity, Build-only'
+    - job_name: 'CMake, VS2022, Release, x64, OpenSSL 1.1.1, WebSockets, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 17 2022'
@@ -62,7 +62,6 @@ environment:
       TESTING: 'OFF'
       DISABLED_TESTS: ''
       WEBSOCKETS: 'ON'
-      UNITY: 'ON'
     - job_name: 'CMake, VS2022, Release, arm64, Schannel, Static, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -119,7 +118,7 @@ environment:
       TESTING: 'ON'
       DISABLED_TESTS: '!1139 !1501 !1177 !1477'
     # generated CMake-based MSYS Makefiles builds (mingw cross-compiling)
-    - job_name: 'CMake, mingw-w64, gcc 13, Debug, x64, Schannel, Static, Unicode, Unity'
+    - job_name: 'CMake, mingw-w64, gcc 13, Debug, x64, Schannel, Static, Unicode'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'MSYS Makefiles'
@@ -132,8 +131,7 @@ environment:
       ADD_PATH: 'C:/msys64/mingw64/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
-      UNITY: 'ON'
-    - job_name: 'CMake, mingw-w64, gcc 7, Debug, x64, Schannel, Static, Unicode'
+    - job_name: 'CMake, mingw-w64, gcc 7, Debug, x64, Schannel, Static, Unicode, no-unity'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'MSYS Makefiles'
@@ -146,7 +144,8 @@ environment:
       ADD_PATH: 'C:/mingw-w64/x86_64-7.2.0-posix-seh-rt_v5-rev1/mingw64/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
-    - job_name: 'CMake, mingw-w64, gcc 9, Debug, x64, Schannel, Static, Unity'
+      UNITY: 'OFF'
+    - job_name: 'CMake, mingw-w64, gcc 9, Debug, x64, Schannel, Static'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'MSYS Makefiles'
@@ -160,7 +159,6 @@ environment:
       ADD_PATH: 'C:/msys64/mingw64/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
-      UNITY: 'ON'
     - job_name: 'CMake, mingw-w64, gcc 6, Debug, x86, Schannel, Static'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -248,13 +248,13 @@ environment:
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !504 !704 !705 !1233'
-      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets  --without-libpsl'
+      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets --without-libpsl'
     - job_name: 'autotools, msys2, Release, x86_64, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !504 !704 !705 !1233'
-      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets  --without-libpsl'
+      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl'
     # autotools-based Cygwin build
     - job_name: 'autotools, cygwin, Debug, x86_64, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
@@ -262,7 +262,7 @@ environment:
       TESTING: 'ON'
       DISABLED_TESTS: ''
       ADD_SHELL: 'C:/cygwin64/bin'
-      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets  --without-libpsl'
+      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets --without-libpsl'
 
 install:
   - ps: |


### PR DESCRIPTION
Leave one non-unity cmake job. This makes the jobs finish slightly
quicker, while giving more coverage for unity issues.

Before:
https://ci.appveyor.com/project/curlorg/curl/builds/49496977
https://ci.appveyor.com/project/curlorg/curl/builds/49500372
After:
https://ci.appveyor.com/project/curlorg/curl/builds/49500338

Also fixup unrelated whitespace.

Closes #13217
