### PR TITLE
tool_xattr: "guess" URL scheme if none is provided

### DIFF
--- a/src/tool_xattr.c
+++ b/src/tool_xattr.c
@@ -55,7 +55,7 @@ char *stripcredentials(const char *url)
   char *nurl;
   u = curl_url();
   if(u) {
-    uc = curl_url_set(u, CURLUPART_URL, url, 0);
+    uc = curl_url_set(u, CURLUPART_URL, url, CURLU_GUESS_SCHEME);
     if(uc)
       goto error;
 


### PR DESCRIPTION
... when figuring out the source URL to store.

Reported-by: Dagfinn Ilmari Mannsåker
Fixes #13205