### PR TITLE
curl: use curl_getenv instead of the curlx_ version

### DIFF
--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -77,7 +77,6 @@
 
 */
 
-#define curlx_getenv curl_getenv
 #define curlx_mvsnprintf curl_mvsnprintf
 #define curlx_msnprintf curl_msnprintf
 #define curlx_maprintf curl_maprintf

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -336,7 +336,7 @@ static char *parse_filename(const char *ptr, size_t len)
    */
 #ifdef DEBUGBUILD
   {
-    char *tdir = curlx_getenv("CURL_TESTDIR");
+    char *tdir = curl_getenv("CURL_TESTDIR");
     if(tdir) {
       char buffer[512]; /* suitably large */
       msnprintf(buffer, sizeof(buffer), "%s/%s", tdir, copy);

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -237,7 +237,7 @@ int tool_progress_cb(void *clientp,
 unsigned int get_terminal_columns(void)
 {
   unsigned int width = 0;
-  char *colp = curlx_getenv("COLUMNS");
+  char *colp = curl_getenv("COLUMNS");
   if(colp) {
     char *endptr;
     long num = strtol(colp, &endptr, 10);

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -152,7 +152,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 
 #ifdef DEBUGBUILD
   {
-    char *tty = curlx_getenv("CURL_ISATTY");
+    char *tty = curl_getenv("CURL_ISATTY");
     if(tty) {
       is_tty = TRUE;
       curl_free(tty);

--- a/src/tool_ipfs.c
+++ b/src/tool_ipfs.c
@@ -65,7 +65,7 @@ static char *ipfs_gateway(void)
   char *ipfs_path = NULL;
   char *gateway_composed_file_path = NULL;
   FILE *gateway_file = NULL;
-  char *gateway = curlx_getenv("IPFS_GATEWAY");
+  char *gateway = curl_getenv("IPFS_GATEWAY");
 
   /* Gateway is found from environment variable. */
   if(gateway) {
@@ -75,15 +75,15 @@ static char *ipfs_gateway(void)
   }
 
   /* Try to find the gateway in the IPFS data folder. */
-  ipfs_path = curlx_getenv("IPFS_PATH");
+  ipfs_path = curl_getenv("IPFS_PATH");
 
   if(!ipfs_path) {
-    char *home = curlx_getenv("HOME");
+    char *home = curl_getenv("HOME");
     if(home && *home)
       ipfs_path = aprintf("%s/.ipfs/", home);
     /* fallback to "~/.ipfs", as that's the default location. */
 
-    Curl_safefree(home);
+    curl_free(home);
   }
 
   if(!ipfs_path || ensure_trailing_slash(&ipfs_path))

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -108,7 +108,7 @@ static void memory_tracking_init(void)
 {
   char *env;
   /* if CURL_MEMDEBUG is set, this starts memory tracking message logging */
-  env = curlx_getenv("CURL_MEMDEBUG");
+  env = curl_getenv("CURL_MEMDEBUG");
   if(env) {
     /* use the value as file name */
     char fname[CURL_MT_LOGFNAME_BUFSIZE];
@@ -122,7 +122,7 @@ static void memory_tracking_init(void)
        without an alloc! */
   }
   /* if CURL_MEMLIMIT is set, this enables fail-on-alloc-number-N feature */
-  env = curlx_getenv("CURL_MEMLIMIT");
+  env = curl_getenv("CURL_MEMLIMIT");
   if(env) {
     char *endptr;
     long num = strtol(env, &endptr, 10);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2585,22 +2585,22 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
      */
     if(tls_backend_info->backend != CURLSSLBACKEND_SCHANNEL) {
       char *env;
-      env = curlx_getenv("CURL_CA_BUNDLE");
+      env = curl_getenv("CURL_CA_BUNDLE");
       if(env) {
         config->cacert = strdup(env);
+        curl_free(env);
         if(!config->cacert) {
-          curl_free(env);
           curl_easy_cleanup(curltls);
           errorf(global, "out of memory");
           return CURLE_OUT_OF_MEMORY;
         }
       }
       else {
-        env = curlx_getenv("SSL_CERT_DIR");
+        env = curl_getenv("SSL_CERT_DIR");
         if(env) {
           config->capath = strdup(env);
+          curl_free(env);
           if(!config->capath) {
-            curl_free(env);
             curl_easy_cleanup(curltls);
             errorf(global, "out of memory");
             return CURLE_OUT_OF_MEMORY;
@@ -2608,11 +2608,11 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
           curl_free(env);
           capath_from_env = true;
         }
-        env = curlx_getenv("SSL_CERT_FILE");
+        env = curl_getenv("SSL_CERT_FILE");
         if(env) {
           config->cacert = strdup(env);
+          curl_free(env);
           if(!config->cacert) {
-            curl_free(env);
             if(capath_from_env)
               free(config->capath);
             curl_easy_cleanup(curltls);
@@ -2622,13 +2622,10 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
         }
       }
 
-      if(env)
-        curl_free(env);
 #ifdef _WIN32
-      else {
+      if(!env)
         result = FindWin32CACert(config, tls_backend_info->backend,
                                  TEXT("curl-ca-bundle.crt"));
-      }
 #endif
     }
     curl_easy_cleanup(curltls);

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -235,7 +235,7 @@ CURLcode get_url_file_name(char **filename, const char *url)
        */
 #ifdef DEBUGBUILD
       {
-        char *tdir = curlx_getenv("CURL_TESTDIR");
+        char *tdir = curl_getenv("CURL_TESTDIR");
         if(tdir) {
           char *alt = aprintf("%s/%s", tdir, *filename);
           Curl_safefree(*filename);


### PR DESCRIPTION
The curlx one was once introduced when we still considered dropping the libcurl function at some point. To reduce confusion and to make it easier to understand when curl_free() should be used, use the actual libcurl function call directly instead.