### PR TITLE
Enabling IDN via macOS/iOS DNS services

### DIFF
--- a/lib/idn.c
+++ b/lib/idn.c
@@ -181,6 +181,18 @@ static CURLcode idn_decode(const char *input, char **output)
     result = CURLE_NOT_BUILT_IN;
 #elif defined(USE_WIN32_IDN)
   result = win32_idn_to_ascii(input, &decoded);
+#elif defined(HAVE_NETDB_H) && defined(__APPLE__)
+    /* let MacOS/iOS do this as part of DNS service */
+    struct hostent *p = gethostbyname(input);
+    if(p) {
+      if(p->h_name && (p->h_name[0])) {
+        /* host name is idn encoded by MacOS */
+        char *name = strdup(p->h_name);
+        if(name) {
+          decoded = name;
+        }
+      }
+    }
 #endif
   if(!result)
     *output = decoded;


### PR DESCRIPTION
If no IDN2 library available and no Windows, we can leverage the resolving of UTF-8 encoded domains by macOS/iOS network services.

We regularly patch this into new CURL versions and I'd just like to pass it to the source code.

This is a fallback for when building curl for iOS or MacOS without LibIDN2 and still make domains work with umlauts.
