### PR TITLE
deps: update librustls 0.12.0 -> 0.13.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -48,7 +48,7 @@ env:
   msh3-version: v0.6.0
   openssl3-version: openssl-3.1.3
   quictls-version: 3.1.4+quic
-  rustls-version: v0.12.0
+  rustls-version: v0.13.0
 
 jobs:
   autotools:

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -3,7 +3,7 @@
 [Rustls is a TLS backend written in Rust](https://docs.rs/rustls/). Curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
 the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
-version of curl depends on version v0.12.0 of rustls-ffi.
+version of curl depends on version v0.13.0 of rustls-ffi.
 
 # Building with rustls
 
@@ -11,8 +11,7 @@ First, [install Rust](https://rustup.rs/).
 
 Next, check out, build, and install the appropriate version of rustls-ffi:
 
-    % cargo install cbindgen
-    % git clone https://github.com/rustls/rustls-ffi -b v0.12.0
+    % git clone https://github.com/rustls/rustls-ffi -b v0.13.0
     % cd rustls-ffi
     % make
     % make DESTDIR=${HOME}/rustls-ffi-built/ install


### PR DESCRIPTION
This branch updates the optional rustls-ffi librustls dependency from 0.12.0 to [0.13.0](https://github.com/rustls/rustls-ffi/releases/tag/v0.13.0). This version is based on the latest available rustls release ([0.23.4](https://github.com/rustls/rustls/releases/tag/v%2F0.23.4)).

The [breaking API changes](https://github.com/rustls/rustls-ffi/blob/main/CHANGELOG.md#0130-2024-03-28) from 0.12.0 to 0.13.0 are in API surface unused by curl, so I believe this can be a straight forward in-place update without any code changes.

The `RUSTLS.md` documentation is also updated to reflect the new version in use, and to clarify that `cbindgen` isn't required to build `librustls` - it's only used by developers to update the vendored `rustls.h` header file maintained upstream.

I've lightly tested this locally using a static `librustls.a` build without `pkg-config` (see [my other comment](https://github.com/curl/curl/pull/13202#issuecomment-2028442442) - I'm sorting through some build issues with the `pkg-config` approach):

```
$ ./src/curl --version
curl 8.7.2-DEV (x86_64-pc-linux-gnu) libcurl/8.7.2-DEV rustls-ffi/0.13.0/rustls/0.23.4 zlib/1.3
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns mqtt pop3 pop3s rtsp smtp smtps telnet tftp
Features: alt-svc AsynchDNS HSTS HTTPS-proxy IPv6 Largefile libz SSL threadsafe UnixSockets

$ ./src/curl -o /dev/null -s -w "%{http_code}\n" https://example.com
200
```