### PR TITLE
maketgz: put docs/RELEASE-TOOLS.md into the tarball

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -158,6 +158,9 @@ make -s vc-ide
 echo "produce CHANGES"
 git log --pretty=fuller --no-color --date=short --decorate=full -1000 | ./scripts/log2changes.pl > CHANGES.dist
 
+echo "produce RELEASE-TOOLS.md"
+./scripts/release-tools.sh > docs/RELEASE-TOOLS.md.dist
+
 ############################################################################
 #
 # Now run make dist to generate a tar.gz archive

--- a/scripts/release-tools.sh
+++ b/scripts/release-tools.sh
@@ -1,4 +1,27 @@
 #!/bin/sh
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
 
 cat <<MOO
 # Release tools

--- a/scripts/release-tools.sh
+++ b/scripts/release-tools.sh
@@ -34,7 +34,7 @@ MOO
 exists=`which dpkg`
 if test ! -e "$exists"; then
     echo "(unknown, could not find dpkg)"
-    exit
+    exit 1
 fi
 
 debian() {

--- a/scripts/release-tools.sh
+++ b/scripts/release-tools.sh
@@ -31,7 +31,7 @@ produce this release tarball.
 
 MOO
 
-exists=`which dpkg`;
+exists=`which dpkg`
 if test ! -e "$exists"; then
     echo "(unknown, could not find dpkg)"
     exit

--- a/scripts/release-tools.sh
+++ b/scripts/release-tools.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+cat <<MOO
+# Release tools
+
+The following tools and their Debian package version numbers were used to
+produce this release tarball.
+
+MOO
+
+exists=`which dpkg`;
+if test ! -e "$exists"; then
+    echo "(unknown, could not find dpkg)"
+    exit
+fi
+
+debian() {
+    echo - $1: `dpkg -l $1 | grep ^ii | awk '{print $3}'`
+}
+debian autoconf
+debian automake
+debian libtool
+debian make
+debian perl
+debian git
+
+cat <<MOO
+
+# Reproduce the tarball
+
+- Clone the repo and checkout the release tag
+- Install the same set of tools + versions as listed above
+
+## Do a standard build
+
+- autoreconf -fi
+- ./configure [...]
+- make
+
+## Generate the tarball
+
+- ./maketgz [version]
+
+MOO


### PR DESCRIPTION
Generated with scripts/release-tools.sh

The script lists the exact Debian package names and version numbers for the tools that are used to generate the tarball.

## `docs/RELEASE-TOOLS.md`

~~~
# Release tools

The following tools and their Debian package version numbers were used to
produce this release tarball.

- autoconf: 2.71-3
- automake: 1:1.16.5-1.3
- libtool: 2.4.7-7
- make: 4.3-4.1
- perl: 5.38.2-3.2
- git: 1:2.43.0-1+b1

# Reproduce the tarball

- Clone the repo and checkout the release tag
- Install the same set of tools + versions as listed above

## Do a standard build

- autoreconf -fi
- ./configure [...]
- make

## Generate the tarball

- ./maketgz [version]

