### PR TITLE
curl-confopts.m4: define CARES_NO_DEPRECATED when c-ares is used

### DIFF
--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -561,6 +561,7 @@ AC_DEFUN([CURL_CHECK_LIB_ARES], [
     if test "$want_ares" = "yes"; then
       dnl finally c-ares will be used
       AC_DEFINE(USE_ARES, 1, [Define to enable c-ares support])
+      AC_DEFINE(CARES_NO_DEPRECATED, 1, [Ignore c-ares deprecation warnings])
       AC_SUBST([USE_ARES], [1])
       curl_res_msg="c-ares"
     fi


### PR DESCRIPTION
Starting in 1.28.0 c-ares added deprecation warnings for some API calls libcurl uses.