### PR TITLE
tool: follow-up getenv fix

### DIFF
--- a/src/tool_ipfs.c
+++ b/src/tool_ipfs.c
@@ -78,12 +78,10 @@ static char *ipfs_gateway(void)
   ipfs_path = curl_getenv("IPFS_PATH");
 
   if(!ipfs_path) {
-    char *home = curl_getenv("HOME");
+    char *home = getenv("HOME");
     if(home && *home)
       ipfs_path = aprintf("%s/.ipfs/", home);
     /* fallback to "~/.ipfs", as that's the default location. */
-
-    curl_free(home);
   }
 
   if(!ipfs_path || ensure_trailing_slash(&ipfs_path))

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2605,7 +2605,6 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
             errorf(global, "out of memory");
             return CURLE_OUT_OF_MEMORY;
           }
-          curl_free(env);
           capath_from_env = true;
         }
         env = curl_getenv("SSL_CERT_FILE");


### PR DESCRIPTION
Remove a double free. Change the IPFS env use to a plain getenv() simply because coverity gets confused.

Follow-up to 9126b141c9398fe