### PR TITLE
cd2nroff: use UTC timezone when SOURCE_DATE_EPOCH is set

### DIFF
--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -77,7 +77,7 @@ HELP
 use POSIX qw(strftime);
 my @ts;
 if (defined($ENV{SOURCE_DATE_EPOCH})) {
-    @ts = localtime($ENV{SOURCE_DATE_EPOCH});
+    @ts = gmtime($ENV{SOURCE_DATE_EPOCH});
 } else {
     @ts = localtime;
 }

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -81,7 +81,7 @@ if (defined($ENV{SOURCE_DATE_EPOCH})) {
 } else {
     @ts = localtime;
 }
-my $date = strftime "%B %d %Y", @ts;
+my $date = strftime "%Y-%m-%d", @ts;
 
 sub outseealso {
     my (@sa) = @_;

--- a/scripts/managen
+++ b/scripts/managen
@@ -50,11 +50,11 @@ my %catlong;
 use POSIX qw(strftime);
 my @ts;
 if (defined($ENV{SOURCE_DATE_EPOCH})) {
-    @ts = localtime($ENV{SOURCE_DATE_EPOCH});
+    @ts = gmtime($ENV{SOURCE_DATE_EPOCH});
 } else {
     @ts = localtime;
 }
-my $date = strftime "%B %d %Y", @ts;
+my $date = strftime "%Y-%m-%d", @ts;
 my $year = strftime "%Y", @ts;
 my $version = "unknown";
 my $globals;


### PR DESCRIPTION
Makes it independent of the TZ setting.

Reported-by: Carlos Henrique Lima Melara
Ref: #13242