### PR TITLE
INSTALL-CMAKE.md: explain `cmake -G <generator-name>`

### DIFF
--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -68,6 +68,13 @@ If you want to build in the source tree, it is enough to do this:
 
     $ cmake .
 
+### Build system generator selection
+
+You can override CMake's default by using `-G <generator-name>`. For example
+on Windows with multiple build systems if you have MinGW-w64 then you could use
+`-G "MinGW Makefiles"`.
+[List of generator names](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html).
+
 ## Using `ccmake`
 
 CMake comes with a curses based interface called `ccmake`. To run `ccmake`


### PR DESCRIPTION
- Explain that CMake's -G option can be used to specify which build system to generate files for.

Example: cmake ../curl -G "MinGW Makefiles"

Ref: https://github.com/curl/curl/pull/12224#issuecomment-2026813645

Closes #xxxx