### PR TITLE
reuse: add copyright + license info to individual docs/*.md files

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -8,13 +8,8 @@ Files: tests/data/test* tests/certs/* tests/stunnel.pem tests/valgrind.supp
 Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
-# Markdown documentation in docs/
-Files: docs/*.md
-Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
-License: curl
-
 # Docs in docs/
-Files: docs/FAQ docs/INSTALL docs/INSTALL.cmake docs/KNOWN_BUGS docs/MAIL-ETIQUETTE docs/THANKS docs/TODO docs/cmdline-opts/page-footer docs/libcurl/curl_multi_socket_all.3 docs/libcurl/curl_strnequal.3 docs/libcurl/symbols-in-versions docs/options-in-versions
+Files: docs/FAQ docs/INSTALL docs/KNOWN_BUGS docs/MAIL-ETIQUETTE docs/THANKS docs/TODO docs/libcurl/symbols-in-versions docs/options-in-versions
 Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
@@ -89,14 +84,6 @@ Files: README
 Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl
 
-Files: .github/ISSUE_TEMPLATE/bug_report.md
-Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
-License: curl
-
 Files: .mailmap
-Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
-License: curl
-
-Files: .github/dependabot.yml
 Copyright: Daniel Stenberg, <daniel@haxx.se>, et al.
 License: curl

--- a/docs/ALTSVC.md
+++ b/docs/ALTSVC.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Alt-Svc
 
 curl features support for the Alt-Svc: HTTP header.

--- a/docs/BINDINGS.md
+++ b/docs/BINDINGS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 libcurl bindings
 ================
 

--- a/docs/BUFQ.md
+++ b/docs/BUFQ.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # bufq
 
 This is an internal module for managing I/O buffers. A `bufq` can be written

--- a/docs/BUFREF.md
+++ b/docs/BUFREF.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # bufref
 
 This is an internal module for handling buffer references. A referenced

--- a/docs/BUG-BOUNTY.md
+++ b/docs/BUG-BOUNTY.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # The curl bug bounty
 
 The curl project runs a bug bounty program in association with

--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # BUGS
 
 ## There are still bugs

--- a/docs/CHECKSRC.md
+++ b/docs/CHECKSRC.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # checksrc
 
 This is the tool we use within the curl project to scan C source code and

--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Ciphers
 
 With curl's options

--- a/docs/CLIENT-READERS.md
+++ b/docs/CLIENT-READERS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl client readers
 
 Client readers is a design in the internals of libcurl, not visible in its public API. They were started

--- a/docs/CLIENT-WRITERS.md
+++ b/docs/CLIENT-WRITERS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl client writers
 
 Client writers is a design in the internals of libcurl, not visible in its public API. They were started

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 Contributor Code of Conduct
 ===========================
 

--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # How to do code reviews for curl
 
 Anyone and everyone is encouraged and welcome to review code submissions in

--- a/docs/CODE_STYLE.md
+++ b/docs/CODE_STYLE.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl C code style
 
 Source code that has a common style is easier to read than code that uses

--- a/docs/CONNECTION-FILTERS.md
+++ b/docs/CONNECTION-FILTERS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl connection filters
 
 Connection filters is a design in the internals of curl, not visible in its

--- a/docs/CONTRIBUTE.md
+++ b/docs/CONTRIBUTE.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Contributing to the curl project
 
 This document is intended to offer guidelines on how to best contribute to the

--- a/docs/CURL-DISABLE.md
+++ b/docs/CURL-DISABLE.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Code defines to disable features and protocols
 
 ## `CURL_DISABLE_ALTSVC`

--- a/docs/CURLDOWN.md
+++ b/docs/CURLDOWN.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curldown
 
 A markdown-like syntax for libcurl man pages.

--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Items to be removed from future curl releases
 
 If any of these deprecated features is a cause for concern for you, please

--- a/docs/DISTROS.md
+++ b/docs/DISTROS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl distros
 
 <!-- markdown-link-check-disable -->

--- a/docs/DYNBUF.md
+++ b/docs/DYNBUF.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # dynbuf
 
 This is the internal module for creating and handling "dynamic buffers". This

--- a/docs/EARLY-RELEASE.md
+++ b/docs/EARLY-RELEASE.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # How to determine if an early patch release is warranted
 
 In the curl project we do releases every 8 weeks. Unless we break the cycle

--- a/docs/EXPERIMENTAL.md
+++ b/docs/EXPERIMENTAL.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Experimental
 
 Some features and functionality in curl and libcurl are considered

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Features -- what curl can do
 
 ## curl tool

--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Decision making in the curl project
 
 A rough guide to how we make decisions and who does what.

--- a/docs/HELP-US.md
+++ b/docs/HELP-US.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # How to get started helping out in the curl project
 
 We are always in need of more help. If you are new to the project and are

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 How curl Became Like This
 =========================
 

--- a/docs/HSTS.md
+++ b/docs/HSTS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # HSTS support
 
 HTTP Strict-Transport-Security. Added as experimental in curl

--- a/docs/HTTP-COOKIES.md
+++ b/docs/HTTP-COOKIES.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # HTTP Cookies
 
 ## Cookie overview

--- a/docs/HTTP2.md
+++ b/docs/HTTP2.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 HTTP/2 with curl
 ================
 

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # HTTP3 (and QUIC)
 
 ## Resources

--- a/docs/HYPER.md
+++ b/docs/HYPER.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Hyper
 
 Hyper is a separate HTTP library written in Rust. curl can be told to use this

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -1,10 +1,8 @@
-                                  _   _ ____  _
-                              ___| | | |  _ \| |
-                             / __| | | | |_) | |
-                            | (__| |_| |  _ <| |___
-                             \___|\___/|_| \_\_____|
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 
-                                How To Compile with CMake
+SPDX-License-Identifier: curl
+-->
 
 # Building with CMake
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # how to install curl and libcurl
 
 ## Installing Binary Packages

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl internals
 
 The canonical libcurl internals documentation is now in the [everything

--- a/docs/IPFS.md
+++ b/docs/IPFS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # IPFS
 For an overview about IPFS, visit the [IPFS project site](https://ipfs.tech/).
 

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl tutorial
 
 ## Simple Usage

--- a/docs/MQTT.md
+++ b/docs/MQTT.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # MQTT in curl
 
 ## Usage

--- a/docs/NEW-PROTOCOL.md
+++ b/docs/NEW-PROTOCOL.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Adding a new protocol?
 
 Every once in a while, someone comes up with the idea of adding support for yet

--- a/docs/PARALLEL-TRANSFERS.md
+++ b/docs/PARALLEL-TRANSFERS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Parallel transfers
 
 curl 7.66.0 introduced support for doing multiple transfers simultaneously; in

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 ![curl logo](https://curl.se/logo/curl-logo.svg)
 
 # Documentation

--- a/docs/RELEASE-PROCEDURE.md
+++ b/docs/RELEASE-PROCEDURE.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 curl release procedure - how to do a release
 ============================================
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl the next few years - perhaps
 
 Roadmap of things Daniel Stenberg wants to work on next. It is intended to

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Rustls
 
 [Rustls is a TLS backend written in Rust](https://docs.rs/rustls/). Curl can

--- a/docs/SECURITY-ADVISORY.md
+++ b/docs/SECURITY-ADVISORY.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # Anatomy of a curl security advisory
 
 As described in the [Security Process](https://curl.se/dev/secprocess.html)

--- a/docs/SPONSORS.md
+++ b/docs/SPONSORS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl sponsors
 
 A sponsor is someone who donates money or resources to the curl project for no

--- a/docs/SSL-PROBLEMS.md
+++ b/docs/SSL-PROBLEMS.md
@@ -1,8 +1,8 @@
-                                  _   _ ____  _
-                              ___| | | |  _ \| |
-                             / __| | | | |_) | |
-                            | (__| |_| |  _ <| |___
-                             \___|\___/|_| \_\_____|
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
 
 # SSL problems
 

--- a/docs/SSLCERTS.md
+++ b/docs/SSLCERTS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 SSL Certificate Verification
 ============================
 

--- a/docs/TheArtOfHttpScripting.md
+++ b/docs/TheArtOfHttpScripting.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # The Art Of Scripting HTTP Requests Using Curl
 
 ## Background

--- a/docs/URL-SYNTAX.md
+++ b/docs/URL-SYNTAX.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # URL syntax and their use in curl
 
 ## Specifications

--- a/docs/VERSIONS.md
+++ b/docs/VERSIONS.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 Version Numbers and Releases
 ============================
 

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -1,3 +1,9 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
 # curl vulnerability disclosure policy
 
 This document describes how security vulnerabilities are handled in the curl

--- a/scripts/copyright.pl
+++ b/scripts/copyright.pl
@@ -135,7 +135,13 @@ sub dep5 {
     while(<F>) {
         $line++;
         if(/^Files: (.*)/i) {
-            push @files, `git ls-files $1`;
+            my @all = `git ls-files $1`;
+            if(!$all[0]) {
+                print STDERR "$1 matches no files\n";
+            }
+            else {
+                push @files, @all;
+            }
         }
         elsif(/^Copyright: (.*)/i) {
             $copy = $1;


### PR DESCRIPTION
Instead of use 'docs/*.md' in dep5. For clarity and avoiding a wide- matching wildcard.

+ Remove mention of old files from .reuse/dep5
+ add info to .github/dependabot.yml
+ make scripts/copyright.pl warn on non-matching patterns