### PR TITLE
m4: reposition USE_RUSTLS="yes" for pkg-config 

### DIFF
--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -137,10 +137,10 @@ if test "x$OPT_RUSTLS" != xno; then
       dnl additional libs may be necessary.  Hope that we
       dnl don't need any.
       LIBS="$SSL_LIBS $LIBS"
-      USE_RUSTLS="yes"
       ssl_msg="rustls"
       AC_DEFINE(USE_RUSTLS, 1, [if rustls is enabled])
       AC_SUBST(USE_RUSTLS, [1])
+      USE_RUSTLS="yes"
       RUSTLS_ENABLED=1
       test rustls != "$DEFAULT_SSL_BACKEND" || VALID_DEFAULT_SSL_BACKEND=yes
     else


### PR DESCRIPTION
It's necessary to set this var to "yes" _after_ AC_DEFINE and AC_SUBST in order for a later `test` to pass so that `check_for_ca_bundle=1` ends up being set. This is in turn required for the default CA certificate bundle to be set when building w/ rustls & pkg-config.

Before the pkg-config changes [the success case configuration](https://github.com/curl/curl/blob/b564a5f5d5280387a88025c5f90260017847add4/m4/curl-rustls.m4#L55-L58) looked like:

1. AC_DEFINE...
2. AC_SUBST...
3. RUSTLS_ENABLED=1
4. USE_RUSTLS=yes

I think that while that order of operations was preserved in https://github.com/curl/curl/commit/647e86a3efe1eea7a2a456c009cfe1eb55fe48eb, in https://github.com/curl/curl/commit/9c4209837094781d5eef69ae6bcad0e86b64bf99 the order changed to:

1. USE_RUSTLS="yes"
2. AC_DEFINE...
3. AC_SUBST...
4. RUSTLS_ENABLED=1

This in turn seems to result in no default CA certificate bundle being set when using rustls & pkg-config. Moving the `USE_RUSTLS` back to the position it was before seems to resolve the issue.

Resolves https://github.com/curl/curl/issues/13248