### PR TITLE
libcurl-opts: mention pipelining less

### DIFF
--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.md
@@ -29,9 +29,9 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_APPCONNECT_TIME,
 
 Pass a pointer to a double to receive the time, in seconds, it took from the
 start until the SSL/SSH connect/handshake to the remote host was completed.
-This time is most often close to the CURLINFO_PRETRANSFER_TIME(3) time,
-except for cases such as HTTP pipelining where the pretransfer time can be
-delayed due to waits in line for the pipeline and more.
+This time is most often close to the CURLINFO_PRETRANSFER_TIME(3) time, except
+for cases such as HTTP multiplexing where the pretransfer time can be delayed
+due to waits in line for the stream and more.
 
 When a redirect is followed, the time from each request is added together.
 

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.md
@@ -29,10 +29,9 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_APPCONNECT_TIME_T,
 
 Pass a pointer to a curl_off_t to receive the time, in microseconds, it took
 from the start until the SSL/SSH connect/handshake to the remote host was
-completed. This time is most often close to the
-CURLINFO_PRETRANSFER_TIME_T(3) time, except for cases such as HTTP
-pipelining where the pretransfer time can be delayed due to waits in line for
-the pipeline and more.
+completed. This time is most often close to the CURLINFO_PRETRANSFER_TIME_T(3)
+time, except for cases such as HTTP multiplexing where the pretransfer time
+can be delayed due to waits in line for the stream and more.
 
 When a redirect is followed, the time from each request is added together.
 

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING.md
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING.md
@@ -17,7 +17,7 @@ Protocol:
 
 # NAME
 
-CURLMOPT_PIPELINING - enable HTTP pipelining and multiplexing
+CURLMOPT_PIPELINING - enable HTTP multiplexing
 
 # SYNOPSIS
 
@@ -29,8 +29,8 @@ CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_PIPELINING, long bitmask);
 
 # DESCRIPTION
 
-Pass in the correct value in the **bitmask** parameter to instruct libcurl
-to enable multiplexing for this multi handle.
+Pass in the correct value in the **bitmask** parameter to instruct libcurl to
+enable multiplexing for this multi handle.
 
 With multiplexing enabled, libcurl attempts to do multiple transfers over the
 same connection when doing parallel transfers to the same hosts.

--- a/docs/libcurl/opts/CURLSHOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLSHOPT_SHARE.md
@@ -61,9 +61,9 @@ this share object share the connection cache.
 
 It is not supported to share connections between multiple concurrent threads.
 
-Connections that are used for HTTP/1.1 Pipelining or HTTP/2 multiplexing only
-get additional transfers added to them if the existing connection is held by
-the same multi or easy handle. libcurl does not support doing HTTP/2 streams
+Connections that are used for HTTP/2 or HTTP/3 multiplexing only get
+additional transfers added to them if the existing connection is held by the
+same multi or easy handle. libcurl does not support doing multiplexed streams
 in different threads using a shared connection.
 
 Support for **CURL_LOCK_DATA_CONNECT** was added in 7.57.0, but the symbol


### PR DESCRIPTION
libcurl has not supported HTTP pipelining since many years. Remove a few (more) mentions of the feature.