### PR TITLE
cmake: check fseeko after detecting HAVE_FILE_OFFSET_BITS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1229,7 +1229,6 @@ check_symbol_exists(getifaddrs     "${CURL_INCLUDES};stdlib.h" HAVE_GETIFADDRS)
 check_symbol_exists(freeaddrinfo   "${CURL_INCLUDES}" HAVE_FREEADDRINFO)
 check_symbol_exists(pipe           "${CURL_INCLUDES}" HAVE_PIPE)
 check_symbol_exists(ftruncate      "${CURL_INCLUDES}" HAVE_FTRUNCATE)
-check_symbol_exists(fseeko         "${CURL_INCLUDES};stdio.h" HAVE_FSEEKO)
 check_symbol_exists(_fseeki64      "${CURL_INCLUDES};stdio.h" HAVE__FSEEKI64)
 check_symbol_exists(getpeername    "${CURL_INCLUDES}" HAVE_GETPEERNAME)
 check_symbol_exists(getsockname    "${CURL_INCLUDES}" HAVE_GETSOCKNAME)
@@ -1238,10 +1237,6 @@ check_symbol_exists(getrlimit      "${CURL_INCLUDES}" HAVE_GETRLIMIT)
 check_symbol_exists(setlocale      "${CURL_INCLUDES}" HAVE_SETLOCALE)
 check_symbol_exists(setmode        "${CURL_INCLUDES}" HAVE_SETMODE)
 check_symbol_exists(setrlimit      "${CURL_INCLUDES}" HAVE_SETRLIMIT)
-
-if(HAVE_FSEEKO)
-  set(HAVE_DECL_FSEEKO 1)
-endif()
 
 if(NOT MSVC OR (MSVC_VERSION GREATER_EQUAL 1900))
   # earlier MSVC compilers had faulty snprintf implementations
@@ -1304,6 +1299,14 @@ if(HAVE_FILE_OFFSET_BITS)
   set(CMAKE_REQUIRED_FLAGS "-D_FILE_OFFSET_BITS=64")
 endif()
 check_type_size("off_t"  SIZEOF_OFF_T)
+
+# fseeko may not exist with _FILE_OFFSET_BITS=64 but can exist with _FILE_OFFSET_BITS unset or 32 (e.g. Android ARMv7 with NDK 26b and API level < 24)
+# so we need to test fseeko after testing for _FILE_OFFSEt_BITS
+check_symbol_exists(fseeko         "${CURL_INCLUDES};stdio.h" HAVE_FSEEKO)
+
+if(HAVE_FSEEKO)
+  set(HAVE_DECL_FSEEKO 1)
+endif()
 
 # include this header to get the type
 set(CMAKE_REQUIRED_INCLUDES "${CURL_SOURCE_DIR}/include")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1300,8 +1300,9 @@ if(HAVE_FILE_OFFSET_BITS)
 endif()
 check_type_size("off_t"  SIZEOF_OFF_T)
 
-# fseeko may not exist with _FILE_OFFSET_BITS=64 but can exist with _FILE_OFFSET_BITS unset or 32 (e.g. Android ARMv7 with NDK 26b and API level < 24)
-# so we need to test fseeko after testing for _FILE_OFFSEt_BITS
+# fseeko may not exist with _FILE_OFFSET_BITS=64 but can exist with
+# _FILE_OFFSET_BITS unset or 32 (e.g. Android ARMv7 with NDK 26b and API level < 24)
+# so we need to test fseeko after testing for _FILE_OFFSET_BITS
 check_symbol_exists(fseeko         "${CURL_INCLUDES};stdio.h" HAVE_FSEEKO)
 
 if(HAVE_FSEEKO)


### PR DESCRIPTION
On Android, `fseeko` is defined as is (I omitted other functions for clarity):
```c
/* See https://android.googlesource.com/platform/bionic/+/master/docs/32-bit-abi.md */
#if defined(__USE_FILE_OFFSET64)

#if __ANDROID_API__ >= 24
int fseeko(FILE* _Nonnull __fp, off_t __offset, int __whence) __RENAME(fseeko64) __INTRODUCED_IN(24);
#endif /* __ANDROID_API__ >= 24 */

#else
int fseeko(FILE* _Nonnull __fp, off_t __offset, int __whence);

#if __ANDROID_API__ >= 24
int fseeko64(FILE* _Nonnull __fp, off64_t __offset, int __whence) __INTRODUCED_IN(24);
#endif /* __ANDROID_API__ >= 24 */

#endif
```

Which means that on Android 32bits (armv7), fseeko is only available in 32bits mode, if `__USE_FILE_OFFSET64` (`_FILE_OFFSET_BITS=64`) is set then `fseeko` is not available.

CMake detects `fseeko` as available because `_FILE_OFFSET_BITS=64` is not yet defined when it tests for this function existence, but then it defines `_FILE_OFFSET_BITS=64` which makes `fseeko` unavailable and [fails compilation](https://github.com/xmake-io/xmake-repo/actions/runs/8505995757/job/23295444726):
```
/home/runner/.xmake/cache/packages/2404/l/libcurl/8.6.0/source/lib/formdata.c:794:10: error: call to undeclared function 'fseeko'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  return fseeko(stream, (off_t)offset, whence);
         ^
/home/runner/.xmake/cache/packages/2404/l/libcurl/8.6.0/source/lib/formdata.c:794:10: note: did you mean 'fseek'?
/home/runner/work/xmake-repo/xmake-repo/android-ndk-r26b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/stdio.h:215:5: note: 'fseek' declared here
int fseek(FILE* _Nonnull __fp, long __offset, int __whence);
    ^
```

A simple fix is to test for `fseeko` existence after testing `HAVE_FILE_OFFSET_BITS` and especially after
```cmake
  set(CMAKE_REQUIRED_FLAGS "-D_FILE_OFFSET_BITS=64")
```

[tested here](https://github.com/xmake-io/xmake-repo/actions/runs/8525420134/job/23352310954)

Fix #12086 for good