### PR TITLE
appveyor: OpenSSL 3 no longer found by CMake, revert to 1.1.1

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -29,7 +29,8 @@ set -eux; [ -n "${BASH:-}${ZSH_NAME:-}" ] && set -o pipefail
 # build
 
 if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
-  openssl_root_win='C:/OpenSSL-v31-Win64'
+  # v31 and v32 not recognized by CMake 3.27.0
+  openssl_root_win='C:/OpenSSL-v111-Win64'
 else
   openssl_root_win='C:/OpenSSL-v111-Win64'
 fi

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -29,7 +29,7 @@ set -eux; [ -n "${BASH:-}${ZSH_NAME:-}" ] && set -o pipefail
 # build
 
 if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
-  openssl_root_win='C:/OpenSSL-v30-Win64'
+  openssl_root_win='C:/OpenSSL-v31-Win64'
 else
   openssl_root_win='C:/OpenSSL-v111-Win64'
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,7 @@ environment:
       SHARED: 'ON'
       TESTING: 'OFF'
       DISABLED_TESTS: ''
-    - job_name: 'CMake, VS2022, Release, x64, OpenSSL 3, WebSockets, Unity, Build-only'
+    - job_name: 'CMake, VS2022, Release, x64, OpenSSL 1.1.1, WebSockets, Unity, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 17 2022'


### PR DESCRIPTION
OpenSSL moved directories, and bumped versions in AppVeyor CI.

Downgrading is not an ideal solution, but however trivial the solution
may be, I failed to come with anything that made CMake recognize either
OpenSSL 3.1 or 3.2.

Possibly caused by:
https://github.com/appveyor/build-images/commit/702e8cdca01f28f6a40687783f493c786cebbe2c
https://github.com/appveyor/build-images/pull/149

Closes #13266
