### PR TITLE
winbuild: fix RC path was wrong if we have modified it at the beginning。

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -690,7 +690,7 @@ $(CURL_DIROBJ)\dynbuf.obj: ../lib/dynbuf.c
 $(CURL_DIROBJ)\base64.obj: ../lib/base64.c
 	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/base64.c
 $(CURL_DIROBJ)\curl.res: $(CURL_SRC_DIR)\curl.rc
-	rc $(CURL_RC_FLAGS)
+	$(RC) $(CURL_RC_FLAGS)
 
 !ENDIF  # End of case where a config was provided.
 


### PR DESCRIPTION
#Utilities.
#If a path is required that contains characters such as space, quote the path.
MT         = mt.exe
RC         = rc.exe
If we modified the RC path at the beginning， the rc $(CURL_RC_FLAGS) could be failed。