### PR TITLE
wolfssl: plug memory leak in wolfssl_connect_step2()

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -898,6 +898,7 @@ wolfssl_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
                                   pinnedpubkey,
                                   (const unsigned char *)pubkey->header,
                                   (size_t)(pubkey->end - pubkey->header));
+    wolfSSL_FreeX509(x509);
     if(result) {
       failf(data, "SSL: public key does not match pinned public key");
       return result;


### PR DESCRIPTION
Fixes:

     test 2034...[simple HTTPS GET with DER public key pinning]
     ==61829== 22,610 (3,744 direct, 18,866 indirect) bytes in 1 blocks are definitely lost in loss record 51 of 54
     ==61829==    at 0x484BB74: malloc (vg_replace_malloc.c:446)
     ==61829==    by 0x4B53A80: wolfSSL_Malloc (memory.c:344)
     ==61829==    by 0x4C1C8E1: wolfSSL_X509_new (x509.c:5326)
     ==61829==    by 0x4C3977D: d2i_X509orX509REQ (x509.c:3628)
     ==61829==    by 0x4C1D1F4: wolfSSL_X509_d2i (x509.c:3664)
     ==61829==    by 0x4C1C37B: wolfSSL_X509_dup (x509.c:13425)
     ==61829==    by 0x4C197DB: wolfSSL_get_peer_certificate (ssl.c:18765)
     ==61829==    by 0x33297C: wolfssl_connect_step2 (wolfssl.c:875)
     ==61829==    by 0x331669: wolfssl_connect_common (wolfssl.c:1287)
     ==61829==    by 0x3303E9: wolfssl_connect_nonblocking (wolfssl.c:1319)
     ==61829==    by 0x32FE89: ssl_connect_nonblocking (vtls.c:510)
     ==61829==    by 0x32DBE5: ssl_cf_connect (vtls.c:1679)
     ==61829==    by 0x27ABD7: Curl_conn_cf_connect (cfilters.c:307)
     ==61829==    by 0x27D9CF: cf_setup_connect (connect.c:1199)
     ==61829==    by 0x27ABD7: Curl_conn_cf_connect (cfilters.c:307)
     ==61829==    by 0x283CEA: cf_hc_baller_connect (cf-https-connect.c:135)