### PR TITLE
GHA: enable unity mode for cmake jobs + tidy-ups

### DIFF
--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -141,7 +141,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - run: cmake -Bbuild -DOPENSSL_ROOT_DIR=$HOME/awslc -DBUILD_SHARED_LIBS=ON -DCURL_WERROR=ON .
+      - run: cmake -Bbuild -DCMAKE_UNITY_BUILD=ON -DOPENSSL_ROOT_DIR=$HOME/awslc -DBUILD_SHARED_LIBS=ON -DCURL_WERROR=ON .
         name: 'cmake generate out-of-tree'
 
       - run: cmake --build build --parallel

--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -141,7 +141,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - run: cmake -Bbuild -DCMAKE_UNITY_BUILD=ON -DOPENSSL_ROOT_DIR=$HOME/awslc -DBUILD_SHARED_LIBS=ON -DCURL_WERROR=ON .
+      - run: cmake -Bbuild -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DOPENSSL_ROOT_DIR=$HOME/awslc -DBUILD_SHARED_LIBS=ON .
         name: 'cmake generate out-of-tree'
 
       - run: cmake --build build --parallel

--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -141,8 +141,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      # CMAKE_COMPILE_WARNING_AS_ERROR is available in cmake 3.24 or later
-      - run: cmake -Bbuild -DOPENSSL_ROOT_DIR=$HOME/awslc -DBUILD_SHARED_LIBS=ON -DCMAKE_COMPILE_WARNING_AS_ERROR=ON .
+      - run: cmake -Bbuild -DOPENSSL_ROOT_DIR=$HOME/awslc -DBUILD_SHARED_LIBS=ON -DCURL_WERROR=ON .
         name: 'cmake generate out-of-tree'
 
       - run: cmake --build build --parallel

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON ..
+          cmake -DCMAKE_UNITY_BUILD=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON ..
 
       - name: 'build'
         run: make -C build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -236,7 +236,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - run: cmake -S. -Bbuild -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DPICKY_COMPILER=ON ${{ matrix.build.generate }}
+      - run: cmake -S. -Bbuild -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON ${{ matrix.build.generate }}
         name: 'cmake generate'
 
       - run: cmake --build build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -209,7 +209,7 @@ jobs:
             generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
           - name: LibreSSL
             install: nghttp2 libressl
-            generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_UNITY_BUILD=ON
+            generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
           - name: libssh2
             install: nghttp2 openssl libssh2
             generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
@@ -236,7 +236,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - run: cmake -S. -Bbuild -DCURL_WERROR=ON -DPICKY_COMPILER=ON ${{ matrix.build.generate }}
+      - run: cmake -S. -Bbuild -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DPICKY_COMPILER=ON ${{ matrix.build.generate }}
         name: 'cmake generate'
 
       - run: cmake --build build


### PR DESCRIPTION
Unity mode is not supported by CMake v3.7.2 used in linux-old, but
enable it anyway for consistency and to kick in automatically once
migrating to a newer old Linux in the future.

Also:
- replace `CMAKE_COMPILE_WARNING_AS_ERROR` with `CURL_WERROR`.
- delete default build option `PICKY_COMPILER=ON`.

Closes #13277
