### PR TITLE
dist: add SOURCE_DATE_EPOCH env var to maketgz script

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -26,6 +26,8 @@
 #
 ###########################################################################
 
+export TZ=UTC
+
 version=$1
 
 if [ -z "$version" ]; then
@@ -78,7 +80,8 @@ if test -z "$only"; then
 fi
 
 # requires a date command that knows + for format
-datestamp=`date +"%F"`
+timestamp=${SOURCE_DATE_EPOCH:-`date +"%s"`}
+datestamp=`date -d @$timestamp +"%F"`
 
 # Replace version number in header file:
 sed -i.bak \


### PR DESCRIPTION
The `SOURCE_DATE_EPOCH` env var is needed to date-stamp releases
properly with the release date when re-creating official releases.


    $ export SOURCE_DATE_EPOCH=1711526400
    $ ./maketgz 8.7.1
    ..
    datestamp 2024-03-27
    ..


Ref: #13250