### PR TITLE
docs/cmdline-opts: invoke managen using a relative path

### DIFF
--- a/docs/cmdline-opts/Makefile.am
+++ b/docs/cmdline-opts/Makefile.am
@@ -36,7 +36,7 @@ GN_0 = @echo "  GENERATE" $@;
 GN_1 =
 GN_ = $(GN_0)
 
-MANAGEN=$(abs_top_srcdir)/scripts/managen
+MANAGEN=$(top_srcdir)/scripts/managen
 
 if BUILD_DOCS
 CLEANFILES = $(MANPAGE) $(ASCIIPAGE)

--- a/docs/cmdline-opts/Makefile.am
+++ b/docs/cmdline-opts/Makefile.am
@@ -37,6 +37,7 @@ GN_1 =
 GN_ = $(GN_0)
 
 MANAGEN=$(top_srcdir)/scripts/managen
+INCDIR=$(top_srcdir)/include
 
 if BUILD_DOCS
 CLEANFILES = $(MANPAGE) $(ASCIIPAGE)
@@ -47,10 +48,10 @@ all: $(MANPAGE) $(ASCIIPAGE)
 endif
 
 $(MANPAGE): $(DPAGES) $(SUPPORT) mainpage.idx Makefile.inc $(MANAGEN)
-	$(GEN)(rm -f $(MANPAGE) && (cd $(srcdir) && @PERL@ $(MANAGEN) mainpage $(DPAGES)) > manpage.tmp.$$$$ && mv manpage.tmp.$$$$ $(MANPAGE))
+	$(GEN)(rm -f $(MANPAGE) && @PERL@ $(MANAGEN) -d $(srcdir) -I $(INCDIR) mainpage $(DPAGES) > manpage.tmp.$$$$ && mv manpage.tmp.$$$$ $(MANPAGE))
 
 $(ASCIIPAGE): $(DPAGES) $(SUPPORT) mainpage.idx Makefile.inc $(MANAGEN)
-	$(GEN)(rm -f $(ASCIIPAGE) && (cd $(srcdir) && @PERL@ $(MANAGEN) ascii $(DPAGES)) > asciipage.tmp.$$$$ && mv asciipage.tmp.$$$$ $(ASCIIPAGE))
+	$(GEN)(rm -f $(ASCIIPAGE) && @PERL@ $(MANAGEN) -d $(srcdir) -I $(INCDIR) ascii $(DPAGES) > asciipage.tmp.$$$$ && mv asciipage.tmp.$$$$ $(ASCIIPAGE))
 
 listhelp:
 	$(MANAGEN) listhelp $(DPAGES) > $(top_builddir)/src/tool_listhelp.c

--- a/scripts/managen
+++ b/scripts/managen
@@ -59,15 +59,6 @@ my $year = strftime "%Y", @ts;
 my $version = "unknown";
 my $globals;
 
-open(INC, "<../../include/curl/curlver.h");
-while(<INC>) {
-    if($_ =~ /^#define LIBCURL_VERSION \"([0-9.]*)/) {
-        $version = $1;
-        last;
-    }
-}
-close(INC);
-
 # get the long name version, return the man page string
 sub manpageify {
     my ($k)=@_;
@@ -448,10 +439,10 @@ sub render {
 }
 
 sub single {
-    my ($manpage, $f, $standalone)=@_;
+    my ($dir, $manpage, $f, $standalone)=@_;
     my $fh;
-    open($fh, "<:crlf", "$f") ||
-        return 1;
+    open($fh, "<:crlf", "$dir/$f") ||
+        die "could not find $dir/$f";
     my $short;
     my $long;
     my $tags;
@@ -781,8 +772,9 @@ sub single {
 }
 
 sub getshortlong {
-    my ($f)=@_;
-    open(F, "<:crlf", "$f");
+    my ($dir, $f)=@_;
+    open(F, "<:crlf", "$dir/$f") ||
+        die "could not find $dir/$f";
     my $short;
     my $long;
     my $help;
@@ -833,16 +825,17 @@ sub getshortlong {
 }
 
 sub indexoptions {
-    my (@files) = @_;
+    my ($dir, @files) = @_;
     foreach my $f (@files) {
-        getshortlong($f);
+        getshortlong($dir, $f);
     }
 }
 
 sub header {
-    my ($manpage, $f)=@_;
+    my ($dir, $manpage, $f)=@_;
     my $fh;
-    open($fh, "<:crlf", "$f");
+    open($fh, "<:crlf", "$dir/$f") ||
+        die "could not find $dir/$f";
     my @d = render($manpage, $fh, $f, 1);
     close($fh);
     printdesc($manpage, 0, @d);
@@ -952,13 +945,13 @@ sub listcats {
 }
 
 sub listglobals {
-    my (@files) = @_;
+    my ($dir, @files) = @_;
     my @globalopts;
 
     # Find all global options and output them
     foreach my $f (sort @files) {
-        open(F, "<:crlf", "$f") ||
-            next;
+        open(F, "<:crlf", "$dir/$f") ||
+            die "could not read $dir/$f";
         my $long;
         my $start = 0;
         while(<F>) {
@@ -999,12 +992,12 @@ sub sortnames {
 }
 
 sub mainpage {
-    my ($manpage, @files) = @_;
+    my ($dir, $manpage, @files) = @_;
     # $manpage is 1 for nroff, 0 for ASCII
     my $ret;
     my $fh;
-    open($fh, "<:crlf", "mainpage.idx") ||
-        return 1;
+    open($fh, "<:crlf", "$dir/mainpage.idx") ||
+        die "no $dir/mainpage.idx file";
 
     print <<HEADER
 .\\" **************************************************************************
@@ -1047,12 +1040,12 @@ HEADER
         if(/^%options/) {
             # output docs for all options
             foreach my $f (sort sortnames @files) {
-                $ret += single($manpage, $f, 0);
+                $ret += single($dir, $manpage, $f, 0);
             }
         }
         else {
             # render the file
-            header($manpage, $f);
+            header($dir, $manpage, $f);
         }
     }
     close($fh);
@@ -1080,15 +1073,15 @@ sub showprotocols {
 }
 
 sub getargs {
-    my ($f, @s) = @_;
+    my ($dir, $f, @s) = @_;
     if($f eq "mainpage") {
-        listglobals(@s);
-        mainpage(1, @s);
+        listglobals($dir, @s);
+        mainpage($dir, 1, @s);
         return;
     }
     elsif($f eq "ascii") {
-        listglobals(@s);
-        mainpage(0, @s);
+        listglobals($dir, @s);
+        mainpage($dir, 0, @s);
         return;
     }
     elsif($f eq "listhelp") {
@@ -1108,15 +1101,44 @@ sub getargs {
         return;
     }
 
-    print "Usage: managen <mainpage/ascii/listhelp/single FILE/protos/listcats> [files]\n";
+    print "Usage: managen ".
+        "[-d dir] <mainpage/ascii/listhelp/single FILE/protos/listcats> [files]\n";
 }
 
 #------------------------------------------------------------------------
 
+my $dir = ".";
+my $include = "../../include";
 my $cmd = shift @ARGV;
+
+ check:
+if($cmd eq "-d") {
+    # specifies source directory
+    $dir = shift @ARGV;
+    $cmd = shift @ARGV;
+    print STDERR "man page file source dir: $dir\n";
+    goto check;
+}
+elsif($cmd eq "-I") {
+    # include path root
+    $include = shift @ARGV;
+    $cmd = shift @ARGV;
+    print STDERR "include file path: $include\n";
+    goto check;
+}
+
 my @files = @ARGV; # the rest are the files
 
-# learn all existing options
-indexoptions(@files);
+open(INC, "<$include/curl/curlver.h");
+while(<INC>) {
+    if($_ =~ /^#define LIBCURL_VERSION \"([0-9.]*)/) {
+        $version = $1;
+        last;
+    }
+}
+close(INC);
 
-getargs($cmd, @files);
+# learn all existing options
+indexoptions($dir, @files);
+
+getargs($dir, $cmd, @files);

--- a/scripts/managen
+++ b/scripts/managen
@@ -773,6 +773,7 @@ sub single {
 
 sub getshortlong {
     my ($dir, $f)=@_;
+    $f =~ s/^.*\///;
     open(F, "<:crlf", "$dir/$f") ||
         die "could not find $dir/$f";
     my $short;
@@ -1116,14 +1117,12 @@ if($cmd eq "-d") {
     # specifies source directory
     $dir = shift @ARGV;
     $cmd = shift @ARGV;
-    print STDERR "man page file source dir: $dir\n";
     goto check;
 }
 elsif($cmd eq "-I") {
     # include path root
     $include = shift @ARGV;
     $cmd = shift @ARGV;
-    print STDERR "include file path: $include\n";
     goto check;
 }
 

--- a/tests/data/test1478
+++ b/tests/data/test1478
@@ -19,7 +19,7 @@ src/tool_listhelp.c is in sync with docs/cmdline-opts
 </name>
 
 <command type="perl">
-%SRCDIR/../scripts/managen listhelp %SRCDIR/../docs/cmdline-opts/*.md
+%SRCDIR/../scripts/managen -d %SRCDIR/../docs/cmdline-opts -I %SRCDIR/../include listhelp %SRCDIR/../docs/cmdline-opts/*.md
 </command>
 </client>
 


### PR DESCRIPTION
... no need to use an absolute path, that makes the build unncessarily fail if invoked using a different mount point