### PR TITLE
cmake: fixup `DEPENDS` filename

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -35,7 +35,7 @@ if(BUILD_MISC_DOCS)
     add_custom_command(OUTPUT "${_man_target}"
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff "${_man_misc}.md" > "${_man_target}"
-      DEPENDS ${_man_target}
+      DEPENDS "${_man_misc}.md"
       VERBATIM
     )
     add_custom_target("generate-${_man_misc}.1" ALL DEPENDS "${_man_target}")


### PR DESCRIPTION
Fixing:
```
make[2]: Circular docs/curl-config.1 <- docs/curl-config.1 dependency dropped.
make[2]: Circular docs/mk-ca-bundle.1 <- docs/mk-ca-bundle.1 dependency dropped.
```
Ref: https://github.com/curl/curl/actions/runs/8559617487/job/23456740844?pr=13282#step:6:18

Follow-up to 5023ffad2c27d4b916ddb91800f99ecc5d3aad07 #13197
Closes #13283
