### PR TITLE
GHA: on macOS remove $HOME/.curlrc

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -167,6 +167,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - run: rm -f $HOME/.curlrc
+        name: remove $HOME/.curlrc
+
       - run: autoreconf -fi
         name: 'autoreconf'
 


### PR DESCRIPTION
Ref: https://github.com/actions/runner-images/pull/9586
Ref: #13284