### PR TITLE
cmake: enable `-pedantic-errors` for clang when  `CURL_WERROR=ON`

### DIFF
--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_UNITY_BUILD=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON ..
+          cmake -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON ..
 
       - name: 'build'
         run: make -C build

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -26,9 +26,10 @@ include(CheckCCompilerFlag)
 unset(WPICKY)
 
 if(CURL_WERROR AND
-   CMAKE_COMPILER_IS_GNUCC AND
-   NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0 AND
-   NOT CMAKE_VERSION VERSION_LESS 3.23.0)  # check_symbol_exists() incompatible with GCC -pedantic-errors in earlier CMake versions
+   ((CMAKE_COMPILER_IS_GNUCC AND
+     NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0 AND
+     NOT CMAKE_VERSION VERSION_LESS 3.23.0) OR  # check_symbol_exists() incompatible with GCC -pedantic-errors in earlier CMake versions
+   CMAKE_C_COMPILER_ID MATCHES "Clang"))
   set(WPICKY "${WPICKY} -pedantic-errors")
 endif()
 

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -25,7 +25,10 @@ include(CheckCCompilerFlag)
 
 unset(WPICKY)
 
-if(CURL_WERROR AND CMAKE_COMPILER_IS_GNUCC AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
+if(CURL_WERROR AND
+   CMAKE_COMPILER_IS_GNUCC AND
+   NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0 AND
+   NOT CMAKE_VERSION VERSION_LESS 3.23.0)  # check_symbol_exists() incompatible with GCC -pedantic-errors in earlier CMake versions
   set(WPICKY "${WPICKY} -pedantic-errors")
 endif()
 


### PR DESCRIPTION
clang doesn't have the issues of GCC and old CMake versions.

Note: This introduces asymmetry with autotools, which only enables
this for GCC.

Closes #13286
