### PR TITLE
lib: use `#error` instead of invalid syntax in `curl_setup_once.h`

### DIFF
--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -164,9 +164,7 @@ struct timeval {
                                    (RECV_TYPE_ARG4)(0))
 #else /* HAVE_RECV */
 #ifndef sread
-  /* */
-  Error Missing_definition_of_macro_sread
-  /* */
+#error "Missing definition of macro sread!"
 #endif
 #endif /* HAVE_RECV */
 
@@ -184,9 +182,7 @@ struct timeval {
                                     (SEND_TYPE_ARG4)(SEND_4TH_ARG))
 #else /* HAVE_SEND */
 #ifndef swrite
-  /* */
-  Error Missing_definition_of_macro_swrite
-  /* */
+#error "Missing definition of macro swrite!"
 #endif
 #endif /* HAVE_SEND */
 


### PR DESCRIPTION
Closes #13287