### PR TITLE
introducing internal type for 64bit signed

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -506,11 +506,14 @@
 #  error "curl_off_t must be exactly 64 bits"
 #else
   typedef unsigned CURL_TYPEOF_CURL_OFF_T curl_uint64_t;
+  typedef CURL_TYPEOF_CURL_OFF_T  curl_int64_t;
 #  ifndef CURL_SUFFIX_CURL_OFF_TU
 #    error "CURL_SUFFIX_CURL_OFF_TU must be defined"
 #  endif
 #  define CURL_UINT64_SUFFIX  CURL_SUFFIX_CURL_OFF_TU
 #  define CURL_UINT64_C(val)  CURL_CONC_MACROS(val,CURL_UINT64_SUFFIX)
+# define CURL_PRId64  CURL_FORMAT_CURL_OFF_T
+# define CURL_PRIu64  CURL_FORMAT_CURL_OFF_TU
 #endif
 
 #if (SIZEOF_TIME_T == 4)

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -210,7 +210,7 @@ out:
 
 /* QUIC stream (not necessarily H3) */
 struct cf_osslq_stream {
-  int64_t id;
+  curl_int64_t id;
   SSL *ssl;
   struct bufq recvbuf; /* QUIC war data recv buffer */
   BIT(recvd_eos);
@@ -355,9 +355,8 @@ static CURLcode cf_osslq_h3conn_add_stream(struct cf_osslq_h3conn *h3,
 
   if(h3->remote_ctrl_n >= ARRAYSIZE(h3->remote_ctrl)) {
     /* rejected, we are full */
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                "] rejecting additional remote stream",
-                stream_id);
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] rejecting remote stream",
+                (curl_int64_t)stream_id);
     SSL_free(stream_ssl);
     return CURLE_FAILED_INIT;
   }
@@ -367,15 +366,13 @@ static CURLcode cf_osslq_h3conn_add_stream(struct cf_osslq_h3conn *h3,
       nstream->id = stream_id;
       nstream->ssl = stream_ssl;
       Curl_bufq_initp(&nstream->recvbuf, &ctx->stream_bufcp, 1, BUFQ_OPT_NONE);
-      CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                  "] accepted new remote uni stream",
-                  stream_id);
+      CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] accepted remote uni stream",
+                  (curl_int64_t)stream_id);
       break;
     }
     default:
-      CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                  "] rejecting remote non-uni-read"
-                  " stream", stream_id);
+      CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] reject remote non-uni-read"
+                  " stream", (curl_int64_t)stream_id);
       SSL_free(stream_ssl);
       return CURLE_FAILED_INIT;
   }
@@ -485,7 +482,7 @@ struct h3_stream_ctx {
   size_t sendbuf_len_in_flight; /* sendbuf amount "in flight" */
   size_t upload_blocked_len; /* the amount written last and EGAINed */
   size_t recv_buf_nonflow; /* buffered bytes, not counting for flow control */
-  uint64_t error3; /* HTTP/3 stream error code */
+  curl_uint64_t error3; /* HTTP/3 stream error code */
   curl_off_t upload_left; /* number of request bytes left to upload */
   curl_off_t download_recvd; /* number of response DATA bytes received */
   int status_code; /* HTTP status code */
@@ -544,7 +541,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   (void)cf;
   if(stream) {
-    CURL_TRC_CF(data, cf, "[%"CURL_FORMAT_CURL_OFF_T"] easy handle is done",
+    CURL_TRC_CF(data, cf, "[%"CURL_PRId64"] easy handle is done",
                 stream->s.id);
     if(ctx->h3.conn && !stream->closed) {
       nghttp3_conn_shutdown_stream_read(ctx->h3.conn, stream->s.id);
@@ -642,13 +639,11 @@ static int cb_h3_stream_close(nghttp3_conn *conn, int64_t stream_id,
   if(stream->error3 != NGHTTP3_H3_NO_ERROR) {
     stream->reset = TRUE;
     stream->send_closed = TRUE;
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] RESET: error %"
-                CURL_FORMAT_CURL_OFF_T,
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] RESET: error %" CURL_PRIu64,
                 stream->s.id, stream->error3);
   }
   else {
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] CLOSED",
-                stream->s.id);
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] CLOSED", stream->s.id);
   }
   h3_drain_stream(cf, data);
   return 0;
@@ -706,14 +701,12 @@ static int cb_h3_recv_data(nghttp3_conn *conn, int64_t stream3_id,
 
   result = write_resp_raw(cf, data, buf, buflen, TRUE);
   if(result) {
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                "] DATA len=%zu, ERROR receiving %d",
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] DATA len=%zu, ERROR %d",
                 stream->s.id, buflen, result);
     return NGHTTP3_ERR_CALLBACK_FAILURE;
   }
   stream->download_recvd += (curl_off_t)buflen;
-  CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-              "] DATA len=%zu, total=%zd",
+  CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] DATA len=%zu, total=%zd",
               stream->s.id, buflen, stream->download_recvd);
   h3_drain_stream(cf, data);
   return 0;
@@ -730,18 +723,18 @@ static int cb_h3_deferred_consume(nghttp3_conn *conn, int64_t stream_id,
   (void)conn;
   (void)stream_id;
   if(stream)
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                "] deferred consume %zu bytes",
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] deferred consume %zu bytes",
                 stream->s.id, consumed);
   return 0;
 }
 
-static int cb_h3_recv_header(nghttp3_conn *conn, int64_t stream_id,
+static int cb_h3_recv_header(nghttp3_conn *conn, int64_t sid,
                              int32_t token, nghttp3_rcbuf *name,
                              nghttp3_rcbuf *value, uint8_t flags,
                              void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
+  curl_int64_t stream_id = sid;
   nghttp3_vec h3name = nghttp3_rcbuf_get_buf(name);
   nghttp3_vec h3val = nghttp3_rcbuf_get_buf(value);
   struct Curl_easy *data = stream_user_data;
@@ -767,8 +760,7 @@ static int cb_h3_recv_header(nghttp3_conn *conn, int64_t stream_id,
       return -1;
     ncopy = msnprintf(line, sizeof(line), "HTTP/3 %03d \r\n",
                       stream->status_code);
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] status: %s",
-                stream_id, line);
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] status: %s", stream_id, line);
     result = write_resp_raw(cf, data, line, ncopy, FALSE);
     if(result) {
       return -1;
@@ -776,7 +768,7 @@ static int cb_h3_recv_header(nghttp3_conn *conn, int64_t stream_id,
   }
   else {
     /* store as an HTTP1-style header */
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] header: %.*s: %.*s",
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] header: %.*s: %.*s",
                 stream_id, (int)h3name.len, h3name.base,
                 (int)h3val.len, h3val.base);
     result = write_resp_raw(cf, data, h3name.base, h3name.len, FALSE);
@@ -799,11 +791,12 @@ static int cb_h3_recv_header(nghttp3_conn *conn, int64_t stream_id,
   return 0;
 }
 
-static int cb_h3_end_headers(nghttp3_conn *conn, int64_t stream_id,
+static int cb_h3_end_headers(nghttp3_conn *conn, int64_t sid,
                              int fin, void *user_data, void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct Curl_easy *data = stream_user_data;
+  curl_int64_t stream_id = sid;
   struct h3_stream_ctx *stream = H3_STREAM_CTX(data);
   CURLcode result = CURLE_OK;
   (void)conn;
@@ -819,7 +812,7 @@ static int cb_h3_end_headers(nghttp3_conn *conn, int64_t stream_id,
     return -1;
   }
 
-  CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] end_headers, status=%d",
+  CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] end_headers, status=%d",
               stream_id, stream->status_code);
   if(stream->status_code / 100 != 1) {
     stream->resp_hds_complete = TRUE;
@@ -828,12 +821,13 @@ static int cb_h3_end_headers(nghttp3_conn *conn, int64_t stream_id,
   return 0;
 }
 
-static int cb_h3_stop_sending(nghttp3_conn *conn, int64_t stream_id,
+static int cb_h3_stop_sending(nghttp3_conn *conn, int64_t sid,
                               uint64_t app_error_code, void *user_data,
                               void *stream_user_data)
 {
   struct Curl_cfilter *cf = user_data;
   struct Curl_easy *data = stream_user_data;
+  curl_int64_t stream_id = sid;
   struct h3_stream_ctx *stream = H3_STREAM_CTX(data);
   (void)conn;
   (void)app_error_code;
@@ -841,17 +835,17 @@ static int cb_h3_stop_sending(nghttp3_conn *conn, int64_t stream_id,
   if(!stream || !stream->s.ssl)
     return 0;
 
-  CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] stop_sending",
-              stream_id);
+  CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] stop_sending", stream_id);
   cf_osslq_stream_close(&stream->s);
   return 0;
 }
 
-static int cb_h3_reset_stream(nghttp3_conn *conn, int64_t stream_id,
+static int cb_h3_reset_stream(nghttp3_conn *conn, int64_t sid,
                               uint64_t app_error_code, void *user_data,
                               void *stream_user_data) {
   struct Curl_cfilter *cf = user_data;
   struct Curl_easy *data = stream_user_data;
+  curl_int64_t stream_id = sid;
   struct h3_stream_ctx *stream = H3_STREAM_CTX(data);
   int rv;
   (void)conn;
@@ -860,8 +854,7 @@ static int cb_h3_reset_stream(nghttp3_conn *conn, int64_t stream_id,
     SSL_STREAM_RESET_ARGS args = {0};
     args.quic_error_code = app_error_code;
     rv = !SSL_stream_reset(stream->s.ssl, &args, sizeof(args));
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] reset -> %d",
-                stream_id, rv);
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] reset -> %d", stream_id, rv);
     if(!rv) {
       return NGHTTP3_ERR_CALLBACK_FAILURE;
     }
@@ -920,13 +913,12 @@ cb_h3_read_req_body(nghttp3_conn *conn, int64_t stream_id,
   }
   else if(!nwritten) {
     /* Not EOF, and nothing to give, we signal WOULDBLOCK. */
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                "] read req body -> AGAIN",
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] read req body -> AGAIN",
                 stream->s.id);
     return NGHTTP3_ERR_WOULDBLOCK;
   }
 
-  CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] read req body -> "
+  CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] read req body -> "
               "%d vecs%s with %zu (buffered=%zu, left=%"
               CURL_FORMAT_CURL_OFF_T ")",
               stream->s.id, (int)nvecs,
@@ -1167,8 +1159,8 @@ static ssize_t h3_quic_recv(void *reader_ctx,
       return -1;
     }
     else if(detail == SSL_ERROR_ZERO_RETURN) {
-      CURL_TRC_CF(x->data, x->cf, "[%" CURL_FORMAT_CURL_OFF_T
-                  "] h3_quic_recv -> EOS", x->s->id);
+      CURL_TRC_CF(x->data, x->cf, "[%" CURL_PRId64 "] h3_quic_recv -> EOS",
+                  x->s->id);
       x->s->recvd_eos = TRUE;
       return 0;
     }
@@ -1176,10 +1168,9 @@ static ssize_t h3_quic_recv(void *reader_ctx,
             SSL_STREAM_STATE_RESET_REMOTE) {
       uint64_t app_error_code = NGHTTP3_H3_NO_ERROR;
       SSL_get_stream_read_error_code(x->s->ssl, &app_error_code);
-      CURL_TRC_CF(x->data, x->cf, "[%" CURL_FORMAT_CURL_OFF_T
-                  "] h3_quic_recv -> RESET, rv=%d, app_err=%"
-                  CURL_FORMAT_CURL_OFF_TU,
-                  x->s->id, rv, app_error_code);
+      CURL_TRC_CF(x->data, x->cf, "[%" CURL_PRId64 "] h3_quic_recv -> RESET, "
+                  "rv=%d, app_err=%" CURL_PRIu64,
+                  x->s->id, rv, (curl_uint64_t)app_error_code);
       if(app_error_code != NGHTTP3_H3_NO_ERROR) {
         x->s->reset = TRUE;
       }
@@ -1190,11 +1181,6 @@ static ssize_t h3_quic_recv(void *reader_ctx,
       *err = cf_osslq_ssl_err(x->cf, x->data, detail, CURLE_RECV_ERROR);
       return -1;
     }
-  }
-  else {
-    /* CURL_TRC_CF(x->data, x->cf, "[%" CURL_FORMAT_CURL_OFF_T
-                   "] h3_quic_recv -> %zu bytes",
-                   x->s->id, nread); */
   }
   return (ssize_t)nread;
 }
@@ -1239,8 +1225,7 @@ static CURLcode cf_osslq_stream_recv(struct cf_osslq_stream *s,
       while(Curl_bufq_peek(&s->recvbuf, &buf, &blen)) {
         nread = nghttp3_conn_read_stream(ctx->h3.conn, s->id,
                                          buf, blen, 0);
-        CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                    "] forward %zu bytes "
+        CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] forward %zu bytes "
                     "to nghttp3 -> %zd", s->id, blen, nread);
         if(nread < 0) {
           failf(data, "nghttp3_conn_read_stream(len=%zu) error: %s",
@@ -1279,8 +1264,7 @@ static CURLcode cf_osslq_stream_recv(struct cf_osslq_stream *s,
         rv = nghttp3_conn_close_stream(ctx->h3.conn, s->id,
                                        NGHTTP3_H3_NO_ERROR);
         s->closed = TRUE;
-        CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                    "] close nghttp3 stream -> %d",
+        CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] close nghttp3 stream -> %d",
                     s->id, rv);
         if(rv < 0 && rv != NGHTTP3_ERR_STREAM_NOT_FOUND) {
           failf(data, "nghttp3_conn_close_stream returned error: %s",
@@ -1293,8 +1277,7 @@ static CURLcode cf_osslq_stream_recv(struct cf_osslq_stream *s,
   }
 out:
   if(result)
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                "] cf_osslq_stream_recv -> %d",
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] cf_osslq_stream_recv -> %d",
                 s->id, result);
   return result;
 }
@@ -1417,7 +1400,7 @@ static CURLcode h3_send_streams(struct Curl_cfilter *cf,
     s = cf_osslq_get_qstream(cf, data, stream_id);
     if(!s) {
       failf(data, "nghttp3_conn_writev_stream gave unknown stream %"
-            CURL_FORMAT_CURL_OFF_T, stream_id);
+            CURL_PRId64, (curl_int64_t)stream_id);
       result = CURLE_SEND_ERROR;
       goto out;
     }
@@ -1445,8 +1428,8 @@ static CURLcode h3_send_streams(struct Curl_cfilter *cf,
       if(ok) {
         /* As OpenSSL buffers the data, we count this as acknowledged
          * from nghttp3's point of view */
-        CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                    "] send %zu bytes to QUIC ok", s->id, vec[i].len);
+        CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] send %zu bytes to QUIC ok",
+                    s->id, vec[i].len);
         acked_len += vec[i].len;
       }
       else {
@@ -1455,16 +1438,14 @@ static CURLcode h3_send_streams(struct Curl_cfilter *cf,
         case SSL_ERROR_WANT_WRITE:
         case SSL_ERROR_WANT_READ:
           /* QUIC blocked us from writing more */
-          CURL_TRC_CF(data, cf, "[%"CURL_FORMAT_CURL_OFF_T
-                      "] send %zu bytes to QUIC blocked",
-                      s->id, vec[i].len);
+          CURL_TRC_CF(data, cf, "[%"CURL_PRId64 "] send %zu bytes to "
+                      "QUIC blocked", s->id, vec[i].len);
           written = 0;
           nghttp3_conn_block_stream(ctx->h3.conn, s->id);
           s->send_blocked = blocked = TRUE;
           break;
         default:
-          failf(data, "[%"CURL_FORMAT_CURL_OFF_T
-                "] send %zu bytes to QUIC, SSL error %d",
+          failf(data, "[%"CURL_PRId64 "] send %zu bytes to QUIC, SSL error %d",
                 s->id, vec[i].len, detail);
           result = cf_osslq_ssl_err(cf, data, detail, CURLE_SEND_ERROR);
           goto out;
@@ -1490,15 +1471,13 @@ static CURLcode h3_send_streams(struct Curl_cfilter *cf,
         result = CURLE_SEND_ERROR;
         goto out;
       }
-      CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                  "] forwarded %zu/%zu h3 bytes to QUIC, eos=%d",
-                  s->id, acked_len, total_len, eos);
+      CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] forwarded %zu/%zu h3 bytes "
+                  "to QUIC, eos=%d", s->id, acked_len, total_len, eos);
     }
 
     if(eos && !s->send_blocked && !eos_written) {
       /* wrote everything and H3 indicates end of stream */
-      CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                  "] closing QUIC stream", s->id);
+      CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] closing QUIC stream", s->id);
       SSL_stream_conclude(s->ssl, 0);
     }
   }
@@ -1790,12 +1769,11 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
   if(rc) {
     switch(rc) {
     case NGHTTP3_ERR_CONN_CLOSING:
-      CURL_TRC_CF(data, cf, "h3sid[%"CURL_FORMAT_CURL_OFF_T"] failed to send, "
+      CURL_TRC_CF(data, cf, "h3sid[%"CURL_PRId64"] failed to send, "
                   "connection is closing", stream->s.id);
       break;
     default:
-      CURL_TRC_CF(data, cf, "h3sid[%"CURL_FORMAT_CURL_OFF_T
-                  "] failed to send -> %d (%s)",
+      CURL_TRC_CF(data, cf, "h3sid[%"CURL_PRId64 "] failed to send -> %d (%s)",
                   stream->s.id, rc, nghttp3_strerror(rc));
       break;
     }
@@ -1805,10 +1783,10 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
   }
 
   if(Curl_trc_is_verbose(data)) {
-    infof(data, "[HTTP/3] [%" CURL_FORMAT_CURL_OFF_T "] OPENED stream for %s",
+    infof(data, "[HTTP/3] [%" CURL_PRId64 "] OPENED stream for %s",
           stream->s.id, data->state.url);
     for(i = 0; i < nheader; ++i) {
-      infof(data, "[HTTP/3] [%" CURL_FORMAT_CURL_OFF_T "] [%.*s: %.*s]",
+      infof(data, "[HTTP/3] [%" CURL_PRId64 "] [%.*s: %.*s]",
             stream->s.id,
             (int)nva[i].namelen, nva[i].name,
             (int)nva[i].valuelen, nva[i].value);
@@ -1880,13 +1858,13 @@ static ssize_t cf_osslq_send(struct Curl_cfilter *cf, struct Curl_easy *data,
        * body. This happens on 30x or 40x responses.
        * We silently discard the data sent, since this is not a transport
        * error situation. */
-      CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] discarding data"
+      CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] discarding data"
                   "on closed stream with response", stream->s.id);
       *err = CURLE_OK;
       nwritten = (ssize_t)len;
       goto out;
     }
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] send_body(len=%zu) "
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] send_body(len=%zu) "
                 "-> stream closed", stream->s.id, len);
     *err = CURLE_HTTP3;
     nwritten = -1;
@@ -1894,7 +1872,7 @@ static ssize_t cf_osslq_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
   else {
     nwritten = Curl_bufq_write(&stream->sendbuf, buf, len, err);
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] cf_send, add to "
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] cf_send, add to "
                 "sendbuf(len=%zu) -> %zd, %d",
                 stream->s.id, len, nwritten, *err);
     if(nwritten < 0) {
@@ -1915,7 +1893,7 @@ static ssize_t cf_osslq_send(struct Curl_cfilter *cf, struct Curl_easy *data,
      * caller. Instead we EAGAIN and remember how much we have already
      * "written" into our various internal connection buffers. */
     stream->upload_blocked_len = nwritten;
-    CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T "] cf_send(len=%zu), "
+    CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] cf_send(len=%zu), "
                 "%zu bytes in flight -> EGAIN", stream->s.id, len,
                 stream->sendbuf_len_in_flight);
     *err = CURLE_AGAIN;
@@ -1924,8 +1902,7 @@ static ssize_t cf_osslq_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
 out:
   result = check_and_set_expiry(cf, data);
-  CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-              "] cf_send(len=%zu) -> %zd, %d",
+  CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] cf_send(len=%zu) -> %zd, %d",
               stream? stream->s.id : -1, len, nwritten, *err);
   CF_DATA_RESTORE(cf, save);
   return nwritten;
@@ -1941,14 +1918,14 @@ static ssize_t recv_closed_stream(struct Curl_cfilter *cf,
   (void)cf;
   if(stream->reset) {
     failf(data,
-          "HTTP/3 stream %" CURL_FORMAT_CURL_OFF_T " reset by server",
+          "HTTP/3 stream %" CURL_PRId64 " reset by server",
           stream->s.id);
     *err = data->req.bytecount? CURLE_PARTIAL_FILE : CURLE_HTTP3;
     goto out;
   }
   else if(!stream->resp_hds_complete) {
     failf(data,
-          "HTTP/3 stream %" CURL_FORMAT_CURL_OFF_T
+          "HTTP/3 stream %" CURL_PRId64
           " was closed cleanly, but before getting"
           " all response header fields, treated as error",
           stream->s.id);
@@ -1988,8 +1965,7 @@ static ssize_t cf_osslq_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     nread = Curl_bufq_read(&stream->recvbuf,
                            (unsigned char *)buf, len, err);
     if(nread < 0) {
-      CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                  "] read recvbuf(len=%zu) "
+      CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] read recvbuf(len=%zu) "
                   "-> %zd, %d", stream->s.id, len, nread, *err);
       goto out;
     }
@@ -2007,8 +1983,7 @@ static ssize_t cf_osslq_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     nread = Curl_bufq_read(&stream->recvbuf,
                            (unsigned char *)buf, len, err);
     if(nread < 0) {
-      CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-                  "] read recvbuf(len=%zu) "
+      CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] read recvbuf(len=%zu) "
                   "-> %zd, %d", stream->s.id, len, nread, *err);
       goto out;
     }
@@ -2038,8 +2013,7 @@ out:
       nread = -1;
     }
   }
-  CURL_TRC_CF(data, cf, "[%" CURL_FORMAT_CURL_OFF_T
-              "] cf_recv(len=%zu) -> %zd, %d",
+  CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] cf_recv(len=%zu) -> %zd, %d",
               stream? stream->s.id : -1, len, nread, *err);
   CF_DATA_RESTORE(cf, save);
   return nread;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1447,7 +1447,7 @@ static CURLcode h3_send_streams(struct Curl_cfilter *cf,
         default:
           failf(data, "[%"CURL_PRId64 "] send %zu bytes to QUIC, SSL error %d",
                 s->id, vec[i].len, detail);
-          result = cf_osslq_ssl_err(cf, data, detail, CURLE_SEND_ERROR);
+          result = cf_osslq_ssl_err(cf, data, detail, CURLE_HTTP3);
           goto out;
         }
       }

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -99,7 +99,7 @@ struct cf_quiche_ctx {
   struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
   curl_off_t data_recvd;
-  uint64_t max_idle_ms;              /* max idle time for QUIC conn */
+  curl_uint64_t max_idle_ms;         /* max idle time for QUIC conn */
   BIT(goaway);                       /* got GOAWAY from server */
   BIT(x509_store_setup);             /* if x509 store has been set up */
 };
@@ -138,16 +138,17 @@ static void cf_quiche_ctx_clear(struct cf_quiche_ctx *ctx)
  * All about the H3 internals of a stream
  */
 struct stream_ctx {
-  int64_t id; /* HTTP/3 protocol stream identifier */
+  curl_uint64_t id; /* HTTP/3 protocol stream identifier */
   struct bufq recvbuf; /* h3 response */
   struct h1_req_parser h1; /* h1 request parsing */
-  uint64_t error3; /* HTTP/3 stream error code */
+  curl_uint64_t error3; /* HTTP/3 stream error code */
   curl_off_t upload_left; /* number of request bytes left to upload */
-  bool closed; /* TRUE on stream close */
-  bool reset;  /* TRUE on stream reset */
-  bool send_closed; /* stream is locally closed */
-  bool resp_hds_complete;  /* complete, final response has been received */
-  bool resp_got_header; /* TRUE when h3 stream has recvd some HEADER */
+  BIT(opened); /* TRUE after stream has been opened */
+  BIT(closed); /* TRUE on stream close */
+  BIT(reset);  /* TRUE on stream reset */
+  BIT(send_closed); /* stream is locally closed */
+  BIT(resp_hds_complete);  /* final response has been received */
+  BIT(resp_got_header); /* TRUE when h3 stream has recvd some HEADER */
   BIT(quic_flow_blocked); /* stream is blocked by QUIC flow control */
 };
 
@@ -171,7 +172,7 @@ static void check_resumes(struct Curl_cfilter *cf,
       if(stream && stream->quic_flow_blocked) {
         stream->quic_flow_blocked = FALSE;
         Curl_expire(data, 0, EXPIRE_RUN_NOW);
-        CURL_TRC_CF(data, cf, "[%"PRId64"] unblock", stream->id);
+        CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] unblock", stream->id);
       }
     }
   }
@@ -205,7 +206,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   (void)cf;
   if(stream) {
-    CURL_TRC_CF(data, cf, "[%"PRId64"] easy handle is done", stream->id);
+    CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] easy handle is done", stream->id);
     if(ctx->qconn && !stream->closed) {
       quiche_conn_stream_shutdown(ctx->qconn, stream->id,
                                   QUICHE_SHUTDOWN_READ, CURL_H3_NO_ERROR);
@@ -241,7 +242,7 @@ static void drain_stream(struct Curl_cfilter *cf,
 
 static struct Curl_easy *get_stream_easy(struct Curl_cfilter *cf,
                                          struct Curl_easy *data,
-                                         int64_t stream3_id)
+                                         curl_uint64_t stream3_id)
 {
   struct Curl_easy *sdata;
 
@@ -306,7 +307,7 @@ static int cb_each_header(uint8_t *name, size_t name_len,
     return CURLE_OK;
 
   if((name_len == 7) && !strncmp(HTTP_PSEUDO_STATUS, (char *)name, 7)) {
-    CURL_TRC_CF(x->data, x->cf, "[%" PRId64 "] status: %.*s",
+    CURL_TRC_CF(x->data, x->cf, "[%" CURL_PRIu64 "] status: %.*s",
                 stream->id, (int)value_len, value);
     result = write_resp_raw(x->cf, x->data, "HTTP/3 ", sizeof("HTTP/3 ") - 1);
     if(!result)
@@ -315,7 +316,7 @@ static int cb_each_header(uint8_t *name, size_t name_len,
       result = write_resp_raw(x->cf, x->data, " \r\n", 3);
   }
   else {
-    CURL_TRC_CF(x->data, x->cf, "[%" PRId64 "] header: %.*s: %.*s",
+    CURL_TRC_CF(x->data, x->cf, "[%" CURL_PRIu64 "] header: %.*s: %.*s",
                 stream->id, (int)name_len, name,
                 (int)value_len, value);
     result = write_resp_raw(x->cf, x->data, name, name_len);
@@ -327,7 +328,7 @@ static int cb_each_header(uint8_t *name, size_t name_len,
       result = write_resp_raw(x->cf, x->data, "\r\n", 2);
   }
   if(result) {
-    CURL_TRC_CF(x->data, x->cf, "[%"PRId64"] on header error %d",
+    CURL_TRC_CF(x->data, x->cf, "[%"CURL_PRIu64"] on header error %d",
                 stream->id, result);
   }
   return result;
@@ -383,9 +384,9 @@ static CURLcode cf_recv_body(struct Curl_cfilter *cf,
                              stream_resp_read, &cb_ctx, &result);
 
   if(nwritten < 0 && result != CURLE_AGAIN) {
-    CURL_TRC_CF(data, cf, "[%"PRId64"] recv_body error %zd",
+    CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] recv_body error %zd",
                 stream->id, nwritten);
-    failf(data, "Error %d in HTTP/3 response body for stream[%"PRId64"]",
+    failf(data, "Error %d in HTTP/3 response body for stream[%"CURL_PRIu64"]",
           result, stream->id);
     stream->closed = TRUE;
     stream->reset = TRUE;
@@ -420,7 +421,7 @@ static const char *cf_ev_name(quiche_h3_event *ev)
 
 static CURLcode h3_process_event(struct Curl_cfilter *cf,
                                  struct Curl_easy *data,
-                                 int64_t stream3_id,
+                                 curl_uint64_t stream3_id,
                                  quiche_h3_event *ev)
 {
   struct stream_ctx *stream = H3_STREAM_CTX(data);
@@ -438,11 +439,11 @@ static CURLcode h3_process_event(struct Curl_cfilter *cf,
     cb_ctx.data = data;
     rc = quiche_h3_event_for_each_header(ev, cb_each_header, &cb_ctx);
     if(rc) {
-      failf(data, "Error %d in HTTP/3 response header for stream[%"PRId64"]",
-            rc, stream3_id);
+      failf(data, "Error %d in HTTP/3 response header for stream[%"
+            CURL_PRIu64"]", rc, stream3_id);
       return CURLE_RECV_ERROR;
     }
-    CURL_TRC_CF(data, cf, "[%"PRId64"] <- [HEADERS]", stream3_id);
+    CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] <- [HEADERS]", stream3_id);
     break;
 
   case QUICHE_H3_EVENT_DATA:
@@ -452,7 +453,7 @@ static CURLcode h3_process_event(struct Curl_cfilter *cf,
     break;
 
   case QUICHE_H3_EVENT_RESET:
-    CURL_TRC_CF(data, cf, "[%"PRId64"] RESET", stream3_id);
+    CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] RESET", stream3_id);
     stream->closed = TRUE;
     stream->reset = TRUE;
     stream->send_closed = TRUE;
@@ -460,7 +461,7 @@ static CURLcode h3_process_event(struct Curl_cfilter *cf,
     break;
 
   case QUICHE_H3_EVENT_FINISHED:
-    CURL_TRC_CF(data, cf, "[%"PRId64"] CLOSED", stream3_id);
+    CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] CLOSED", stream3_id);
     if(!stream->resp_hds_complete) {
       result = write_resp_raw(cf, data, "\r\n", 2);
       if(result)
@@ -472,11 +473,11 @@ static CURLcode h3_process_event(struct Curl_cfilter *cf,
     break;
 
   case QUICHE_H3_EVENT_GOAWAY:
-    CURL_TRC_CF(data, cf, "[%"PRId64"] <- [GOAWAY]", stream3_id);
+    CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] <- [GOAWAY]", stream3_id);
     break;
 
   default:
-    CURL_TRC_CF(data, cf, "[%"PRId64"] recv, unhandled event %d",
+    CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] recv, unhandled event %d",
                 stream3_id, quiche_h3_event_type(ev));
     break;
   }
@@ -494,28 +495,28 @@ static CURLcode cf_poll_events(struct Curl_cfilter *cf,
 
   /* Take in the events and distribute them to the transfers. */
   while(ctx->h3c) {
-    int64_t stream3_id = quiche_h3_conn_poll(ctx->h3c, ctx->qconn, &ev);
+    curl_int64_t stream3_id = quiche_h3_conn_poll(ctx->h3c, ctx->qconn, &ev);
     if(stream3_id == QUICHE_H3_ERR_DONE) {
       break;
     }
     else if(stream3_id < 0) {
-      CURL_TRC_CF(data, cf, "[%"PRId64"] error poll: %"PRId64,
+      CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] error poll: %"CURL_PRIu64,
                   stream? stream->id : -1, stream3_id);
       return CURLE_HTTP3;
     }
 
     sdata = get_stream_easy(cf, data, stream3_id);
     if(!sdata) {
-      CURL_TRC_CF(data, cf, "[%"PRId64"] discard event %s for "
-                  "unknown [%"PRId64"]",
+      CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] discard event %s for "
+                  "unknown [%"CURL_PRIu64"]",
                   stream? stream->id : -1, cf_ev_name(ev), stream3_id);
     }
     else {
       result = h3_process_event(cf, sdata, stream3_id, ev);
       drain_stream(cf, sdata);
       if(result) {
-        CURL_TRC_CF(data, cf, "[%"PRId64"] error processing event %s "
-                    "for [%"PRId64"] -> %d",
+        CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] error processing event %s "
+                    "for [%"CURL_PRIu64"] -> %d",
                     stream? stream->id : -1, cf_ev_name(ev),
                     stream3_id, result);
         if(data == sdata) {
@@ -651,8 +652,8 @@ static CURLcode cf_flush_egress(struct Curl_cfilter *cf,
   struct cf_quiche_ctx *ctx = cf->ctx;
   ssize_t nread;
   CURLcode result;
-  int64_t expiry_ns;
-  int64_t timeout_ns;
+  curl_int64_t expiry_ns;
+  curl_int64_t timeout_ns;
   struct read_ctx readx;
   size_t pkt_count, gsolen;
 
@@ -731,19 +732,19 @@ static ssize_t recv_closed_stream(struct Curl_cfilter *cf,
   DEBUGASSERT(stream);
   if(stream->reset) {
     failf(data,
-          "HTTP/3 stream %" PRId64 " reset by server", stream->id);
+          "HTTP/3 stream %" CURL_PRIu64 " reset by server", stream->id);
     *err = data->req.bytecount? CURLE_PARTIAL_FILE : CURLE_HTTP3;
-    CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_recv, was reset -> %d",
+    CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] cf_recv, was reset -> %d",
                 stream->id, *err);
   }
   else if(!stream->resp_got_header) {
     failf(data,
-          "HTTP/3 stream %" PRId64 " was closed cleanly, but before getting"
-          " all response header fields, treated as error",
+          "HTTP/3 stream %" CURL_PRIu64 " was closed cleanly, but before "
+          "getting all response header fields, treated as error",
           stream->id);
     /* *err = CURLE_PARTIAL_FILE; */
     *err = CURLE_HTTP3;
-    CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_recv, closed incomplete"
+    CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] cf_recv, closed incomplete"
                 " -> %d", stream->id, *err);
   }
   else {
@@ -771,7 +772,7 @@ static ssize_t cf_quiche_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(!Curl_bufq_is_empty(&stream->recvbuf)) {
     nread = Curl_bufq_read(&stream->recvbuf,
                            (unsigned char *)buf, len, err);
-    CURL_TRC_CF(data, cf, "[%" PRId64 "] read recvbuf(len=%zu) "
+    CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] read recvbuf(len=%zu) "
                 "-> %zd, %d", stream->id, len, nread, *err);
     if(nread < 0)
       goto out;
@@ -788,7 +789,7 @@ static ssize_t cf_quiche_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(nread < 0 && !Curl_bufq_is_empty(&stream->recvbuf)) {
     nread = Curl_bufq_read(&stream->recvbuf,
                            (unsigned char *)buf, len, err);
-    CURL_TRC_CF(data, cf, "[%" PRId64 "] read recvbuf(len=%zu) "
+    CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] read recvbuf(len=%zu) "
                 "-> %zd, %d", stream->id, len, nread, *err);
     if(nread < 0)
       goto out;
@@ -822,7 +823,7 @@ out:
   }
   if(nread > 0)
     ctx->data_recvd += nread;
-  CURL_TRC_CF(data, cf, "[%"PRId64"] cf_recv(total=%"
+  CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] cf_recv(total=%"
               CURL_FORMAT_CURL_OFF_T ") -> %zd, %d",
               stream->id, ctx->data_recvd, nread, *err);
   return nread;
@@ -840,7 +841,7 @@ static ssize_t h3_open_stream(struct Curl_cfilter *cf,
   struct cf_quiche_ctx *ctx = cf->ctx;
   struct stream_ctx *stream = H3_STREAM_CTX(data);
   size_t nheader, i;
-  int64_t stream3_id;
+  curl_int64_t stream3_id;
   struct dynhds h2_headers;
   quiche_h3_header *nva = NULL;
   ssize_t nwritten;
@@ -915,14 +916,14 @@ static ssize_t h3_open_stream(struct Curl_cfilter *cf,
     if(QUICHE_H3_ERR_STREAM_BLOCKED == stream3_id) {
       /* quiche seems to report this error if the connection window is
        * exhausted. Which happens frequently and intermittent. */
-      CURL_TRC_CF(data, cf, "[%"PRId64"] blocked", stream->id);
+      CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] blocked", stream->id);
       stream->quic_flow_blocked = TRUE;
       *err = CURLE_AGAIN;
       nwritten = -1;
       goto out;
     }
     else {
-      CURL_TRC_CF(data, cf, "send_request(%s) -> %" PRId64,
+      CURL_TRC_CF(data, cf, "send_request(%s) -> %" CURL_PRIu64,
                   data->state.url, stream3_id);
     }
     *err = CURLE_SEND_ERROR;
@@ -930,17 +931,18 @@ static ssize_t h3_open_stream(struct Curl_cfilter *cf,
     goto out;
   }
 
-  DEBUGASSERT(stream->id == -1);
+  DEBUGASSERT(!stream->opened);
   *err = CURLE_OK;
   stream->id = stream3_id;
+  stream->opened = TRUE;
   stream->closed = FALSE;
   stream->reset = FALSE;
 
   if(Curl_trc_is_verbose(data)) {
-    infof(data, "[HTTP/3] [%" PRId64 "] OPENED stream for %s",
+    infof(data, "[HTTP/3] [%" CURL_PRIu64 "] OPENED stream for %s",
           stream->id, data->state.url);
     for(i = 0; i < nheader; ++i) {
-      infof(data, "[HTTP/3] [%" PRId64 "] [%.*s: %.*s]", stream->id,
+      infof(data, "[HTTP/3] [%" CURL_PRIu64 "] [%.*s: %.*s]", stream->id,
             (int)nva[i].name_len, nva[i].name,
             (int)nva[i].value_len, nva[i].value);
     }
@@ -968,7 +970,7 @@ static ssize_t cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     goto out;
   }
 
-  if(!stream || stream->id < 0) {
+  if(!stream || !stream->opened) {
     nwritten = h3_open_stream(cf, data, buf, len, err);
     if(nwritten < 0)
       goto out;
@@ -984,13 +986,13 @@ static ssize_t cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
        * sending the 30x response.
        * This is sort of a race: had the transfer loop called recv first,
        * it would see the response and stop/discard sending on its own- */
-      CURL_TRC_CF(data, cf, "[%" PRId64 "] discarding data"
+      CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] discarding data"
                   "on closed stream with response", stream->id);
       *err = CURLE_OK;
       nwritten = (ssize_t)len;
       goto out;
     }
-    CURL_TRC_CF(data, cf, "[%" PRId64 "] send_body(len=%zu) "
+    CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] send_body(len=%zu) "
                 "-> stream closed", stream->id, len);
     *err = CURLE_HTTP3;
     nwritten = -1;
@@ -1005,7 +1007,7 @@ static ssize_t cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       /* TODO: we seem to be blocked on flow control and should HOLD
        * sending. But when do we open again? */
       if(!quiche_conn_stream_writable(ctx->qconn, stream->id, len)) {
-        CURL_TRC_CF(data, cf, "[%" PRId64 "] send_body(len=%zu) "
+        CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] send_body(len=%zu) "
                     "-> window exhausted", stream->id, len);
         stream->quic_flow_blocked = TRUE;
       }
@@ -1014,21 +1016,21 @@ static ssize_t cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       goto out;
     }
     else if(nwritten == QUICHE_H3_TRANSPORT_ERR_INVALID_STREAM_STATE) {
-      CURL_TRC_CF(data, cf, "[%" PRId64 "] send_body(len=%zu) "
+      CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] send_body(len=%zu) "
                   "-> invalid stream state", stream->id, len);
       *err = CURLE_HTTP3;
       nwritten = -1;
       goto out;
     }
     else if(nwritten == QUICHE_H3_TRANSPORT_ERR_FINAL_SIZE) {
-      CURL_TRC_CF(data, cf, "[%" PRId64 "] send_body(len=%zu) "
+      CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] send_body(len=%zu) "
                   "-> exceeds size", stream->id, len);
       *err = CURLE_SEND_ERROR;
       nwritten = -1;
       goto out;
     }
     else if(nwritten < 0) {
-      CURL_TRC_CF(data, cf, "[%" PRId64 "] send_body(len=%zu) "
+      CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] send_body(len=%zu) "
                   "-> quiche err %zd", stream->id, len, nwritten);
       *err = CURLE_SEND_ERROR;
       nwritten = -1;
@@ -1043,7 +1045,7 @@ static ssize_t cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       if(stream->upload_left == 0)
         stream->send_closed = TRUE;
 
-      CURL_TRC_CF(data, cf, "[%" PRId64 "] send body(len=%zu, "
+      CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] send body(len=%zu, "
                   "left=%" CURL_FORMAT_CURL_OFF_T ") -> %zd",
                   stream->id, len, stream->upload_left, nwritten);
       *err = CURLE_OK;
@@ -1056,7 +1058,7 @@ out:
     *err = result;
     nwritten = -1;
   }
-  CURL_TRC_CF(data, cf, "[%" PRId64 "] cf_send(len=%zu) -> %zd, %d",
+  CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] cf_send(len=%zu) -> %zd, %d",
               stream? stream->id : -1, len, nwritten, *err);
   return nwritten;
 }
@@ -1067,8 +1069,8 @@ static bool stream_is_writeable(struct Curl_cfilter *cf,
   struct cf_quiche_ctx *ctx = cf->ctx;
   struct stream_ctx *stream = H3_STREAM_CTX(data);
 
-  return stream && (quiche_conn_stream_writable(ctx->qconn,
-                                                (uint64_t)stream->id, 1) > 0);
+  return stream && (quiche_conn_stream_writable(
+    ctx->qconn, (curl_uint64_t)stream->id, 1) > 0);
 }
 
 static void cf_quiche_adjust_pollset(struct Curl_cfilter *cf,
@@ -1088,7 +1090,7 @@ static void cf_quiche_adjust_pollset(struct Curl_cfilter *cf,
 
     c_exhaust = FALSE; /* Have not found any call in quiche that tells
                           us if the connection itself is blocked */
-    s_exhaust = want_send && stream && stream->id >= 0 &&
+    s_exhaust = want_send && stream && stream->opened &&
                 (stream->quic_flow_blocked || !stream_is_writeable(cf, data));
     want_recv = (want_recv || c_exhaust || s_exhaust);
     want_send = (!s_exhaust && want_send) ||
@@ -1153,7 +1155,7 @@ static CURLcode cf_quiche_data_event(struct Curl_cfilter *cf,
       stream->upload_left = 0;
       body[0] = 'X';
       sent = cf_quiche_send(cf, data, body, 0, &result);
-      CURL_TRC_CF(data, cf, "[%"PRId64"] DONE_SEND -> %zd, %d",
+      CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] DONE_SEND -> %zd, %d",
                   stream->id, sent, result);
     }
     break;
@@ -1433,7 +1435,7 @@ static CURLcode cf_quiche_query(struct Curl_cfilter *cf,
 
   switch(query) {
   case CF_QUERY_MAX_CONCURRENT: {
-    uint64_t max_streams = CONN_INUSE(cf->conn);
+    curl_uint64_t max_streams = CONN_INUSE(cf->conn);
     if(!ctx->goaway) {
       max_streams += quiche_conn_peer_streams_left_bidi(ctx->qconn);
     }
@@ -1488,14 +1490,14 @@ static bool cf_quiche_conn_is_alive(struct Curl_cfilter *cf,
   {
     quiche_transport_params qpeerparams;
     timediff_t idletime;
-    uint64_t idle_ms = ctx->max_idle_ms;
+    curl_uint64_t idle_ms = ctx->max_idle_ms;
 
     if(quiche_conn_peer_transport_params(ctx->qconn, &qpeerparams) &&
        qpeerparams.peer_max_idle_timeout &&
        qpeerparams.peer_max_idle_timeout < idle_ms)
       idle_ms = qpeerparams.peer_max_idle_timeout;
     idletime = Curl_timediff(Curl_now(), cf->conn->lastused);
-    if(idletime > 0 && (uint64_t)idletime > idle_ms)
+    if(idletime > 0 && (curl_uint64_t)idletime > idle_ms)
       return FALSE;
   }
 


### PR DESCRIPTION
- typedef curl_int64_t
- define CURL_PRId64, CURL_PRIu64 format ids
- use in vquic

Note that `curl_int64_t` and `int64_t` are assignable from each other but not identical. Some platforms with 64 long type defint int64_t as "long long" (staring at macOS) which messes up things like pointers and format identifiers.