### PR TITLE
tests/http: fix compiler warning

### DIFF
--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -168,7 +168,7 @@ static void websocket_close(CURL *curl)
 
 static CURLcode data_echo(CURL *curl, size_t plen_min, size_t plen_max)
 {
-  CURLcode res;
+  CURLcode res = CURLE_OK;
   size_t len;
   char *send_buf;
   size_t i;


### PR DESCRIPTION
- Init result code variable to fix clang warning that it may be used uninitialized.

Fixes https://github.com/curl/curl/issues/13301
Closes #xxxx