### PR TITLE
dist: do not require Perl in `maketgz`

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -66,8 +66,7 @@ fi
 echo "removing all old *.dist files"
 find . -name "*.dist" -a ! -name Makefile.dist -exec rm {} \;
 
-numeric=$(perl -e \
-  'printf("%02x%02x%02x\n", '"$major, $minor, $patch);")
+numeric="$(printf "%02x%02x%02x\n" "$major" "$minor" "$patch")"
 
 HEADER=include/curl/curlver.h
 CHEADER=src/tool_version.h


### PR DESCRIPTION
Perl remains required for the tarball build process.

Follow-up to 860cd5fc2dc8e165fadd2c19a9b7c73b3ae5069d #13299
Closes #13310
