### PR TITLE
release-tools.sh: store the timestamp and release tag too

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -168,7 +168,7 @@ echo "produce CHANGES"
 git log --pretty=fuller --no-color --date=short --decorate=full -1000 | ./scripts/log2changes.pl > CHANGES.dist
 
 echo "produce RELEASE-TOOLS.md"
-./scripts/release-tools.sh > docs/RELEASE-TOOLS.md.dist
+./scripts/release-tools.sh "$timestamp" "$version" > docs/RELEASE-TOOLS.md.dist
 
 ############################################################################
 #

--- a/scripts/release-tools.sh
+++ b/scripts/release-tools.sh
@@ -25,8 +25,13 @@
 
 set -eu
 
+# this should ideally be passed in
+timestamp=${1:-unknown}
+version=${2:-unknown}
+tag=$(echo "curl-$version" | tr '.' '_')
+
 cat <<MOO
-# Release tools
+# Release tools used for curl $version
 
 The following tools and their Debian package version numbers were used to
 produce this release tarball.
@@ -53,7 +58,7 @@ cat <<MOO
 
 # Reproduce the tarball
 
-- Clone the repo and checkout the release tag
+- Clone the repo and checkout the tag: $tag
 - Install the same set of tools + versions as listed above
 
 ## Do a standard build
@@ -62,8 +67,9 @@ cat <<MOO
 - ./configure [...]
 - make
 
-## Generate the tarball
+## Generate the tarball with the same timestamp
 
+- export SOURCE_DATE_EPOCH=$timestamp
 - ./maketgz [version]
 
 MOO


### PR DESCRIPTION
When maketgz invokes this script to generate the docs/RELEASE-TOOLS.md file that gets bundled in the release, it now also passes on the exact timestamp and version number so that those details also get mentioned in the document. They will help users reproduce an identical tarball.