### PR TITLE
src/Makefile.am: access curl.txt using a relative path, not abs

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -96,7 +96,7 @@ EXTRA_DIST = mkhelp.pl \
  Makefile.mk curl.rc Makefile.inc CMakeLists.txt .checksrc
 
 # Use absolute directory to disable VPATH
-ASCIIPAGE=$(abs_top_builddir)/docs/cmdline-opts/curl.txt
+ASCIIPAGE=$(top_builddir)/docs/cmdline-opts/curl.txt
 MKHELP=$(top_srcdir)/src/mkhelp.pl
 HUGE=tool_hugehelp.c
 


### PR DESCRIPTION
... to make it work when mounted using different mount points. Like when generated/used inside and outside of a docker image.