### PR TITLE
dist: add reproducible dir entries to tarballs

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -186,7 +186,8 @@ retar() {
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
   find curl-* -type f -exec touch -c -t "$filestamp" '{}' +
-  find curl-* -type f | sort | tar --create --format=ustar --owner=0 --group=0 --numeric-owner --files-from - | gzip --best --no-name > out.tar.gz
+  find curl-* -depth -type d -exec touch -c -t "$filestamp" '{}' +
+  find curl-* | sort | tar --create --format=ustar --owner=0 --group=0 --numeric-owner --no-recursion --files-from - | gzip --best --no-name > out.tar.gz
   mv out.tar.gz ../
   cd ..
   rm -rf "$tempdir"
@@ -223,7 +224,6 @@ makezip() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
-  find . -depth -type d -exec touch -c -t "$filestamp" '{}' +
   find . | sort | zip -9 -X "$zip" -@ >/dev/null
   mv "$zip" ../
   cd ..

--- a/maketgz
+++ b/maketgz
@@ -187,7 +187,7 @@ retar() {
   gzip -dc "../$targz" | tar -xf -
   find curl-* -type f -exec touch -c -t "$filestamp" '{}' +
   find curl-* -depth -type d -exec touch -c -t "$filestamp" '{}' +
-  find curl-* | sort | tar --create --format=ustar --owner=0 --group=0 --numeric-owner --no-recursion --files-from - | gzip --best --no-name > out.tar.gz
+  tar --create --format=ustar --owner=0 --group=0 --numeric-owner --sort=name curl-* | gzip --best --no-name > out.tar.gz
   mv out.tar.gz ../
   cd ..
   rm -rf "$tempdir"

--- a/maketgz
+++ b/maketgz
@@ -185,8 +185,7 @@ retar() {
   mkdir "$tempdir"
   cd "$tempdir"
   gzip -dc "../$targz" | tar -xf -
-  find curl-* -type f -exec touch -c -t "$filestamp" '{}' +
-  find curl-* -depth -type d -exec touch -c -t "$filestamp" '{}' +
+  find curl-* -depth -exec touch -c -t "$filestamp" '{}' +
   tar --create --format=ustar --owner=0 --group=0 --numeric-owner --sort=name curl-* | gzip --best --no-name > out.tar.gz
   mv out.tar.gz ../
   cd ..


### PR DESCRIPTION
In the initial implementation of reproducible tarballs, they were
missing directory entries, while .zip archives had them. It meant
that on extracting the tarball, on-disk directory entries got the
current timestamp.

This patch fixes this by including directory entries in the tarball,
with reproducible timestamps. It also moves sorting inside tar,
to ensure reproducible directory entry timestamps on extract
(without the need of `--delay-directory-restore` option, when
extracting with GNU tar. BSD tar got that right by default.)

`--sort=` option was introduced in GNU tar 1.28 (2014-07-28)

Ref: https://github.com/curl/curl/pull/13299#discussion_r1555957350
Follow-up to 860cd5fc2dc8e165fadd2c19a9b7c73b3ae5069d #13299
Closes #13322

---

/cc @bagder
