### PR TITLE
appveyor: make VS2010 job build-only, enable Schannel, fix compiler warnings

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,16 +74,16 @@ environment:
       TESTING: 'OFF'
       DISABLED_TESTS: ''
     # generated CMake-based Visual Studio Debug builds
-    - job_name: 'CMake, VS2010, Debug, x64, no SSL, Static'
+    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 10 2010 Win64'
       PRJ_CFG: Debug
-      SCHANNEL: 'OFF'
+      SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
-      TESTING: 'ON'
-      DISABLED_TESTS: '!1139 !1501 !1177 !1477'
+      TESTING: 'OFF'
+      DISABLED_TESTS: ''
     - job_name: 'CMake, VS2022, Debug, x64, Schannel, Static, Unicode'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -53,6 +53,16 @@
 #define CERT_ALT_NAME_IP_ADDRESS 8
 #endif
 
+#if defined(_MSC_VER) && (_MSC_VER <= 1600)
+/* Workaround for warning:
+   'type cast' : conversion from 'int' to 'LPCSTR' of greater size */
+#undef CERT_STORE_PROV_MEMORY
+#undef CERT_STORE_PROV_SYSTEM_A
+#undef CERT_STORE_PROV_SYSTEM_W
+#define CERT_STORE_PROV_MEMORY    ((LPCSTR)(size_t)2)
+#define CERT_STORE_PROV_SYSTEM_A  ((LPCSTR)(size_t)9)
+#define CERT_STORE_PROV_SYSTEM_W  ((LPCSTR)(size_t)10)
+#endif
 
 #ifndef SCH_CREDENTIALS_VERSION
 


### PR DESCRIPTION
Tests were consistently flaky for a while.

Also fix compiler warnings in `CertOpenStore()` calls for old MSVC compilers:
```
C:/projects/curl/lib/vtls/schannel.c(688):
  warning C4306: 'type cast' : conversion from 'int' to 'LPCSTR' of greater size
C:/projects/curl/lib/vtls/schannel_verify.c(642):
  warning C4306: 'type cast' : conversion from 'int' to 'LPCSTR' of greater size
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/49580310/job/ywu2y44kymgc0nif#L106

Closes #13330
