### PR TITLE
quic: fixup duplicate static function name (for cmake unity)

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1913,7 +1913,7 @@ static void cf_ngtcp2_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 /* The "new session" callback must return zero if the session can be removed
  * or non-zero if the session has been put into the session cache.
  */
-static int ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
+static int quic_ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
 {
   struct Curl_cfilter *cf;
   struct cf_ngtcp2_ctx *ctx;
@@ -1959,7 +1959,7 @@ static CURLcode tls_ctx_setup(struct Curl_cfilter *cf,
   SSL_CTX_set_session_cache_mode(ctx->ossl.ssl_ctx,
                                  SSL_SESS_CACHE_CLIENT |
                                  SSL_SESS_CACHE_NO_INTERNAL);
-  SSL_CTX_sess_set_new_cb(ctx->ossl.ssl_ctx, ossl_new_session_cb);
+  SSL_CTX_sess_set_new_cb(ctx->ossl.ssl_ctx, quic_ossl_new_session_cb);
 
 #elif defined(USE_GNUTLS)
   if(ngtcp2_crypto_gnutls_configure_client_session(ctx->gtls.session) != 0) {


### PR DESCRIPTION
Visible in daily curl-for-win builds:
https://github.com/curl/curl-for-win/actions/runs/8621925870

```
lib/vquic/curl_ngtcp2.c:1916:12: error: redefinition of 'ossl_new_session_cb'
static int ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
           ^
lib/vtls/openssl.c:2978:12: note: previous definition is here
static int ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
           ^
```
https://github.com/curl/curl-for-win/actions/runs/8621925870/job/23631885439#step:3:6965

Follow-up to 3210101088dfa3d6a125d213226b092f2f866722 #13172
Closes #13332
