### PR TITLE
Deterministic archives via Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,6 @@ FROM stagex/autoconf@sha256:e42cb175aa5739b511d4ab75a6dd24797bcaa957f12082240b87
 FROM stagex/automake@sha256:749940b3c06e7e1f80f667a0870d59a00c86298e865530f6d11c85b1d05fc548 as automake
 FROM stagex/pkgconf@sha256:470052019202f89aa8a63cf227364beb2e23e3e5d3e15d413c7df48cdb891aef as pkgconf
 FROM stagex/libtool@sha256:40037dd8aba84b58e9c08390043e53cc90b4d6e2f4abfb4978674030f63fe219 as libtool
-FROM stagex/openssl@sha256:859f892877f29972d468d5077817402c7aec1ad4b1e5c25e7cba8bcab79ea7ce as openssl
 FROM stagex/file@sha256:1195ad7a437d5a2b2cfe8f5319945111d730baf62838718f5d4aa5b54240d3af as file
 FROM stagex/m4@sha256:2c8b055ce71cc5452b519b5b0540ce5e0ef9d36fc14164d5609e35dff85d2ce9 as m4
 FROM stagex/gcc@sha256:a5c3774cb42719d308f98fc9311fea3a73f638353a7ed81bc9bef39803c8dadd as gcc
@@ -25,7 +24,6 @@ COPY --from=binutils . /
 COPY --from=autoconf . /
 COPY --from=automake . /
 COPY --from=libtool . /
-COPY --from=openssl . /
 COPY --from=m4 . /
 COPY --from=file . /
 COPY --from=gcc . /
@@ -38,7 +36,7 @@ ENV SOURCE_DATE_EPOCH=1
 RUN --network=none <<-EOF
     set -eux
     autoreconf -fvi
-    ./configure --with-openssl
+    ./configure --without-ssl --without-libpsl
     ./maketgz ${VERSION}
     mkdir /rootfs
     mv curl-${VERSION}.* /rootfs

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,49 @@
+FROM stagex/busybox@sha256:2006bf09c974d842ebc62476074f01181c092022b2a1fdfa63b32d6aed5db323 as busybox
+FROM stagex/make@sha256:e9aef80a9b2bd7003c7fb040cb875d4cee94eab777de93a798ed000ea5ee5fc1 as make
+FROM stagex/musl@sha256:e52da07cf7e2824fcfc7563e5b8792edc296e8ee37dcb59397ad183e742a6dc0 as musl
+FROM stagex/perl@sha256:fc4c642ea8aaf6d9f68b2f01ea5073f781e8994ac2c8267e98b4623d5b2ef752 as perl
+FROM stagex/binutils@sha256:47c9449f655b43e3da5fb6ab1694a9d0a513bfa36cae88b27008a8d95f4df943 as binutils
+FROM stagex/autoconf@sha256:e42cb175aa5739b511d4ab75a6dd24797bcaa957f12082240b875f8ab68c1fa0 as autoconf
+FROM stagex/automake@sha256:749940b3c06e7e1f80f667a0870d59a00c86298e865530f6d11c85b1d05fc548 as automake
+FROM stagex/pkgconf@sha256:470052019202f89aa8a63cf227364beb2e23e3e5d3e15d413c7df48cdb891aef as pkgconf
+FROM stagex/libtool@sha256:40037dd8aba84b58e9c08390043e53cc90b4d6e2f4abfb4978674030f63fe219 as libtool
+FROM stagex/openssl@sha256:859f892877f29972d468d5077817402c7aec1ad4b1e5c25e7cba8bcab79ea7ce as openssl
+FROM stagex/file@sha256:1195ad7a437d5a2b2cfe8f5319945111d730baf62838718f5d4aa5b54240d3af as file
+FROM stagex/m4@sha256:2c8b055ce71cc5452b519b5b0540ce5e0ef9d36fc14164d5609e35dff85d2ce9 as m4
+FROM stagex/gcc@sha256:a5c3774cb42719d308f98fc9311fea3a73f638353a7ed81bc9bef39803c8dadd as gcc
+FROM stagex/bzip2@sha256:79b9f18b94fe2dd27709ff5960849c7b40482b64ed8a64c6f5c1992e0c08d85a as bzip2
+FROM stagex/xz@sha256:8a8843cd206bcf8322f5d1446284e05e7db282a1deeeab02ec7aeaca23a0f858 as xz
+FROM stagex/tar@sha256:45d9dd30aa7a447755d5671654b22ae7aabf43048e694f098ade81aba0878959 as tar
+
+FROM scratch as build
+ARG VERSION=unknown
+COPY --from=musl . /
+COPY --from=busybox . /
+COPY --from=make . /
+COPY --from=perl . /
+COPY --from=binutils . /
+COPY --from=autoconf . /
+COPY --from=automake . /
+COPY --from=libtool . /
+COPY --from=openssl . /
+COPY --from=m4 . /
+COPY --from=file . /
+COPY --from=gcc . /
+COPY --from=bzip2 . /
+COPY --from=xz . /
+COPY --from=tar . /
+ADD . /src
+WORKDIR /src
+ENV SOURCE_DATE_EPOCH=1
+RUN --network=none <<-EOF
+    set -eux
+    autoreconf -fvi
+    ./configure --with-openssl
+    ./maketgz ${VERSION}
+    mkdir /rootfs
+    mv curl-${VERSION}.* /rootfs
+    find /rootfs -exec touch -hcd "@0" "{}" +
+EOF
+
+FROM scratch as package
+COPY --from=build /rootfs/. /

--- a/Containerfile
+++ b/Containerfile
@@ -1,3 +1,7 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
 FROM stagex/busybox@sha256:2006bf09c974d842ebc62476074f01181c092022b2a1fdfa63b32d6aed5db323 as busybox
 FROM stagex/make@sha256:e9aef80a9b2bd7003c7fb040cb875d4cee94eab777de93a798ed000ea5ee5fc1 as make
 FROM stagex/musl@sha256:e52da07cf7e2824fcfc7563e5b8792edc296e8ee37dcb59397ad183e742a6dc0 as musl

--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,7 @@ FROM stagex/automake@sha256:749940b3c06e7e1f80f667a0870d59a00c86298e865530f6d11c
 FROM stagex/pkgconf@sha256:470052019202f89aa8a63cf227364beb2e23e3e5d3e15d413c7df48cdb891aef as pkgconf
 FROM stagex/libtool@sha256:40037dd8aba84b58e9c08390043e53cc90b4d6e2f4abfb4978674030f63fe219 as libtool
 FROM stagex/file@sha256:1195ad7a437d5a2b2cfe8f5319945111d730baf62838718f5d4aa5b54240d3af as file
+FROM stagex/zlib@sha256:d5c4a74d4c0a71fece685ec5e8f8a7d37b14fbbe79d00611585030c6b0542182 as zlib
 FROM stagex/m4@sha256:2c8b055ce71cc5452b519b5b0540ce5e0ef9d36fc14164d5609e35dff85d2ce9 as m4
 FROM stagex/gcc@sha256:a5c3774cb42719d308f98fc9311fea3a73f638353a7ed81bc9bef39803c8dadd as gcc
 FROM stagex/bzip2@sha256:79b9f18b94fe2dd27709ff5960849c7b40482b64ed8a64c6f5c1992e0c08d85a as bzip2
@@ -26,6 +27,7 @@ COPY --from=automake . /
 COPY --from=libtool . /
 COPY --from=m4 . /
 COPY --from=file . /
+COPY --from=zlib . /
 COPY --from=gcc . /
 COPY --from=bzip2 . /
 COPY --from=xz . /
@@ -37,10 +39,10 @@ RUN --network=none <<-EOF
     set -eux
     autoreconf -fvi
     ./configure --without-ssl --without-libpsl
+    make
     ./maketgz ${VERSION}
     mkdir /rootfs
     mv curl-${VERSION}.* /rootfs
-    find /rootfs -exec touch -hcd "@0" "{}" +
 EOF
 
 FROM scratch as package

--- a/maketgz
+++ b/maketgz
@@ -220,7 +220,8 @@ makezip() {
 zip="curl-$version.zip"
 echo "Generating $zip"
 tempdir=".builddir"
-makezip
+# FIXME: add zip package to stagex
+#makezip
 
 # Set deterministic timestamp
 touch -c -t "$filestamp" "$targz" "$bzip2" "$xz" "$zip"
@@ -228,8 +229,11 @@ touch -c -t "$filestamp" "$targz" "$bzip2" "$xz" "$zip"
 echo "------------------"
 echo "maketgz report:"
 echo ""
-ls -l "$targz" "$bzip2" "$xz" "$zip"
-sha256sum "$targz" "$bzip2" "$xz" "$zip"
+# FIXME: add zip package to stagex
+#ls -l "$targz" "$bzip2" "$xz" "$zip"
+ls -l "$targz" "$bzip2" "$xz"
+#sha256sum "$targz" "$bzip2" "$xz" "$zip"
+sha256sum "$targz" "$bzip2" "$xz"
 
 echo "Run this:"
 echo "gpg -b -a '$targz' && gpg -b -a '$bzip2' && gpg -b -a '$xz' && gpg -b -a '$zip'"


### PR DESCRIPTION
Generates deterministic dist archives with full-source-bootstrapped, deterministic, and hash-locked dependencies.

All dependencies are from stagex and a simple "make" (and a fair bit of waiting) in the stagex repo should produce the exact same digests as the dependencies in the included Containerfile.

This is IMO much more futureproof than a debian based approach, as package versions change from one day to the next so something reproducible today will not be tomorrow. Stagex was created to address use cases exactly like this one.

See: https://codeberg.org/stagex/stagex for more background

Usage:
```
docker build --progress=plain --build-arg VERSION=1.2.3 --output=rewrite-timestamp=true,./dist/ -f Containerfile .
```

Resulting archives will be found in the "dist" directory

NOTE: zip support is not yet packaged in stagex, so zip support is currently disabled until the next stagex release in a few days. Will include it and drop "DRAFT" status then.