### PR TITLE
cw-out, error and pause handling

### DIFF
--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -297,7 +297,7 @@ static CURLcode cw_out_flush_chain(struct cw_out_ctx *ctx,
 
   if(!cwbuf)
     return CURLE_OK;
-  if(data->req.keepon & KEEP_RECV_PAUSE)
+  if(ctx->paused)
     return CURLE_OK;
 
   /* write the end of the chain until it blocks or gets empty */
@@ -310,7 +310,7 @@ static CURLcode cw_out_flush_chain(struct cw_out_ctx *ctx,
       return result;
     if(*plast) {
       /* could not write last, paused again? */
-      DEBUGASSERT(data->req.keepon & KEEP_RECV_PAUSE);
+      DEBUGASSERT(ctx->paused);
       return CURLE_OK;
     }
   }

--- a/lib/cw-out.h
+++ b/lib/cw-out.h
@@ -43,7 +43,7 @@ bool Curl_cw_out_is_paused(struct Curl_easy *data);
 /**
  * Flush any buffered date to the client, chunk collation still applies.
  */
-CURLcode Curl_cw_out_flush(struct Curl_easy *data);
+CURLcode Curl_cw_out_unpause(struct Curl_easy *data);
 
 /**
  * Mark EndOfStream reached and flush ALL data to the client.

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2512,7 +2512,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         Curl_posttransfer(data);
         multi_done(data, result, TRUE);
       }
-      else if(data->req.done) {
+      else if(data->req.done && !Curl_cwriter_is_paused(data)) {
 
         /* call this even if the readwrite function returned error */
         Curl_posttransfer(data);

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -506,6 +506,16 @@ void Curl_cwriter_remove_by_name(struct Curl_easy *data,
   }
 }
 
+bool Curl_cwriter_is_paused(struct Curl_easy *data)
+{
+  return Curl_cw_out_is_paused(data);
+}
+
+CURLcode Curl_cwriter_unpause(struct Curl_easy *data)
+{
+  return Curl_cw_out_unpause(data);
+}
+
 CURLcode Curl_creader_read(struct Curl_easy *data,
                            struct Curl_creader *reader,
                            char *buf, size_t blen, size_t *nread, bool *eos)

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -181,6 +181,16 @@ CURLcode Curl_cwriter_write(struct Curl_easy *data,
                             const char *buf, size_t nbytes);
 
 /**
+ * Return TRUE iff client writer is paused.
+ */
+bool Curl_cwriter_is_paused(struct Curl_easy *data);
+
+/**
+ * Unpause client writer and flush any buffered date to the client.
+ */
+CURLcode Curl_cwriter_unpause(struct Curl_easy *data);
+
+/**
  * Default implementations for do_init, do_write, do_close that
  * do nothing and pass the data through.
  */

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
   int all_paused = 0;
   int resume_round = -1;
   int http_version = CURL_HTTP_VERSION_2_0;
-  char ch;
+  int ch;
 
   while((ch = getopt(argc, argv, "hV:")) != -1) {
     switch(ch) {

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -168,6 +168,7 @@ static size_t cb(void *data, size_t size, size_t nmemb, void *clientp)
     ++handle->paused;
     fprintf(stderr, "INFO: [%d] write, PAUSING %d time on %lu bytes\n",
             handle->idx, handle->paused, (long)realsize);
+    assert(handle->paused == 1);
     return CURL_WRITEFUNC_PAUSE;
   }
   if(handle->fail_write) {
@@ -244,6 +245,7 @@ int main(int argc, char *argv[])
         != CURLE_OK ||
       curl_easy_setopt(handles[i].h, CURLOPT_SSL_VERIFYPEER, 0L) != CURLE_OK ||
       curl_easy_setopt(handles[i].h, CURLOPT_RESOLVE, resolve) != CURLE_OK ||
+      curl_easy_setopt(handles[i].h, CURLOPT_PIPEWAIT, 1L) ||
       curl_easy_setopt(handles[i].h, CURLOPT_URL, url) != CURLE_OK) {
       err();
     }
@@ -324,7 +326,7 @@ int main(int argc, char *argv[])
       if(all_paused) {
         fprintf(stderr, "INFO: all transfers paused\n");
         /* give transfer some rounds to mess things up */
-        resume_round = rounds + 3;
+        resume_round = rounds + 2;
       }
     }
     if(resume_round > 0 && rounds == resume_round) {

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -275,7 +275,6 @@ int main(int argc, char *argv[])
     handles[i].fail_write = 1;
     handles[i].h = curl_easy_init();
     if(!handles[i].h ||
-      curl_easy_setopt(handles[i].h, CURLOPT_HTTP_VERSION, http_version) ||
       curl_easy_setopt(handles[i].h, CURLOPT_WRITEFUNCTION, cb) != CURLE_OK ||
       curl_easy_setopt(handles[i].h, CURLOPT_WRITEDATA, &handles[i])
         != CURLE_OK ||
@@ -289,6 +288,7 @@ int main(int argc, char *argv[])
       curl_easy_setopt(handles[i].h, CURLOPT_URL, url) != CURLE_OK) {
       err();
     }
+    curl_easy_setopt(handles[i].h, CURLOPT_HTTP_VERSION, (long)http_version);
   }
 
   multi_handle = curl_multi_init();

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -448,7 +448,25 @@ class TestDownload:
     def test_02_27_paused_no_cl(self, env: Env, httpd, nghttpx, repeat):
         proto = 'h2'
         url = f'https://{env.authority_for(env.domain1, proto)}' \
-            '/tweak?&chunks=2&chunk_size=16000'
+            '/curltest/tweak/?&chunks=6&chunk_size=8000'
+        client = LocalClient(env=env, name='h2-pausing')
+        r = client.run(args=[url])
+        r.check_exit_code(0)
+
+    # test on paused transfers, based on issue #11982
+    def test_02_27b_paused_no_cl(self, env: Env, httpd, nghttpx, repeat):
+        proto = 'h2'
+        url = f'https://{env.authority_for(env.domain1, proto)}' \
+            '/curltest/tweak/?error=502'
+        client = LocalClient(env=env, name='h2-pausing')
+        r = client.run(args=[url])
+        r.check_exit_code(0)
+
+    # test on paused transfers, based on issue #11982
+    def test_02_27c_paused_no_cl(self, env: Env, httpd, nghttpx, repeat):
+        proto = 'h2'
+        url = f'https://{env.authority_for(env.domain1, proto)}' \
+            '/curltest/tweak/?status=200&chunks=1&chunk_size=100'
         client = LocalClient(env=env, name='h2-pausing')
         r = client.run(args=[url])
         r.check_exit_code(0)

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -445,30 +445,30 @@ class TestDownload:
         r.check_exit_code(0)
 
     # test on paused transfers, based on issue #11982
-    def test_02_27_paused_no_cl(self, env: Env, httpd, nghttpx, repeat):
-        proto = 'h2'
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    def test_02_27a_paused_no_cl(self, env: Env, httpd, nghttpx, proto, repeat):
         url = f'https://{env.authority_for(env.domain1, proto)}' \
             '/curltest/tweak/?&chunks=6&chunk_size=8000'
         client = LocalClient(env=env, name='h2-pausing')
-        r = client.run(args=[url])
+        r = client.run(args=['-V', proto, url])
         r.check_exit_code(0)
 
     # test on paused transfers, based on issue #11982
-    def test_02_27b_paused_no_cl(self, env: Env, httpd, nghttpx, repeat):
-        proto = 'h2'
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    def test_02_27b_paused_no_cl(self, env: Env, httpd, nghttpx, proto, repeat):
         url = f'https://{env.authority_for(env.domain1, proto)}' \
             '/curltest/tweak/?error=502'
         client = LocalClient(env=env, name='h2-pausing')
-        r = client.run(args=[url])
+        r = client.run(args=['-V', proto, url])
         r.check_exit_code(0)
 
     # test on paused transfers, based on issue #11982
-    def test_02_27c_paused_no_cl(self, env: Env, httpd, nghttpx, repeat):
-        proto = 'h2'
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    def test_02_27c_paused_no_cl(self, env: Env, httpd, nghttpx, proto, repeat):
         url = f'https://{env.authority_for(env.domain1, proto)}' \
             '/curltest/tweak/?status=200&chunks=1&chunk_size=100'
         client = LocalClient(env=env, name='h2-pausing')
-        r = client.run(args=[url])
+        r = client.run(args=['-V', proto, url])
         r.check_exit_code(0)
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])


### PR DESCRIPTION
- remember error encountered in invoking write callback and always fail afterwards without further invokes
- do not "finish" transfers that have send/received everything but still paused data waiting to be delivered to the client
- check behaviour in test_02_17 with h2-pausing client
- refs #13337

Further stability improvements:
- go not clear `data->req.keepon` at the end of send/recv. Instead leave any PAUSE bits there to hold transfers until the app unpauses
- move unpausing action of client writer into `Curl_readwrite()`, since errors encountered there are transfer error. Applications do not always check errrors on `curl_easy_unpaus()` and may keep a transfer going even though it has failed.