### PR TITLE
docs: add CURLOPT_NOPROGRESS to CURLOPT_XFERINFOFUNCTION example

### DIFF
--- a/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.md
@@ -104,6 +104,9 @@ int main(void)
     /* pass struct to callback  */
     curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &data);
 
+    /* enable progress callback getting called */
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+
     curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, progress_callback);
   }
 }


### PR DESCRIPTION
It's important to set `CURLOPT_NOPROGRESS` to `0` if you want your transfer callback function, set by `CURLOPT_XFERINFOFUNCTION`, getting called. To emphasize this to the users, add this to the code example.