### PR TITLE
lib: merge `ENABLE_QUIC` C macro into `USE_HTTP3`

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -303,7 +303,7 @@ struct altsvcinfo *Curl_altsvc_init(void)
 #ifdef USE_HTTP2
     | CURLALTSVC_H2
 #endif
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
     | CURLALTSVC_H3
 #endif
     ;

--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -237,7 +237,7 @@
 
 /* Define to enable HTTP3 support (experimental, requires NGTCP2, QUICHE or
    MSH3) */
-#undef ENABLE_QUIC
+#undef USE_HTTP3
 
 /* Version number of package */
 #undef VERSION

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1117,7 +1117,7 @@ const
 #endif
 struct transport_provider transport_providers[] = {
   { TRNSPRT_TCP, Curl_cf_tcp_create },
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
   { TRNSPRT_QUIC, Curl_cf_quic_create },
 #endif
 #ifndef CURL_DISABLE_TFTP

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -855,7 +855,6 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #error "Multi-SSL combined with QUIC is not supported"
 #endif
 
-#define ENABLE_QUIC
 #define USE_HTTP3
 #endif
 

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -230,7 +230,7 @@ static struct Curl_cftype *cf_types[] = {
   &Curl_cft_haproxy,
   &Curl_cft_socks_proxy,
 #endif /* !CURL_DISABLE_PROXY */
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
   &Curl_cft_http3,
 #endif
 #if !defined(CURL_DISABLE_HTTP) && !defined(USE_HYPER)

--- a/lib/http.c
+++ b/lib/http.c
@@ -3199,7 +3199,7 @@ CURLcode Curl_http_statusline(struct Curl_easy *data,
 #ifdef USE_HTTP2
   case 20:
 #endif
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
   case 30:
 #endif
     /* TODO: we should verify that responses do not switch major

--- a/lib/http.h
+++ b/lib/http.h
@@ -44,7 +44,7 @@ typedef enum {
 
 #ifndef CURL_DISABLE_HTTP
 
-#if defined(ENABLE_QUIC)
+#if defined(USE_HTTP3)
 #include <stdint.h>
 #endif
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -915,7 +915,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
       /* accepted */
       break;
 #endif
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
     case CURL_HTTP_VERSION_3:
     case CURL_HTTP_VERSION_3ONLY:
       /* accepted */

--- a/lib/url.c
+++ b/lib/url.c
@@ -3085,7 +3085,7 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
 #ifdef USE_HTTP2
                                    | ALPN_h2
 #endif
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
                                    | ALPN_h3
 #endif
       ) & data->asi->flags;

--- a/lib/version.c
+++ b/lib/version.c
@@ -152,7 +152,7 @@ char *curl_version(void)
 #ifdef USE_NGHTTP2
   char h2_version[40];
 #endif
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
   char h3_version[40];
 #endif
 #ifdef USE_LIBRTMP
@@ -233,7 +233,7 @@ char *curl_version(void)
   Curl_http2_ver(h2_version, sizeof(h2_version));
   src[i++] = h2_version;
 #endif
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
   Curl_quic_ver(h3_version, sizeof(h3_version));
   src[i++] = h3_version;
 #endif
@@ -468,7 +468,7 @@ static const struct feat features_table[] = {
 #if defined(USE_NGHTTP2)
   FEATURE("HTTP2",       NULL,                CURL_VERSION_HTTP2),
 #endif
-#if defined(ENABLE_QUIC)
+#if defined(USE_HTTP3)
   FEATURE("HTTP3",       NULL,                CURL_VERSION_HTTP3),
 #endif
 #if defined(USE_SSL) && !defined(CURL_DISABLE_PROXY) && \
@@ -643,7 +643,7 @@ curl_version_info_data *curl_version_info(CURLversion stamp)
   }
 #endif
 
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
   {
     static char quicbuffer[80];
     Curl_quic_ver(quicbuffer, sizeof(quicbuffer));

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#if defined(ENABLE_QUIC) && \
+#if defined(USE_HTTP3) && \
   (defined(USE_OPENSSL) || defined(USE_GNUTLS) || defined(USE_WOLFSSL))
 
 #ifdef USE_OPENSSL
@@ -333,4 +333,4 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
 }
 
 
-#endif /* !ENABLE_QUIC && (USE_OPENSSL || USE_GNUTLS || USE_WOLFSSL) */
+#endif /* !USE_HTTP3 && (USE_OPENSSL || USE_GNUTLS || USE_WOLFSSL) */

--- a/lib/vquic/vquic-tls.h
+++ b/lib/vquic/vquic-tls.h
@@ -28,7 +28,7 @@
 #include "bufq.h"
 #include "vtls/openssl.h"
 
-#if defined(ENABLE_QUIC) && \
+#if defined(USE_HTTP3) && \
   (defined(USE_OPENSSL) || defined(USE_GNUTLS) || defined(USE_WOLFSSL))
 
 struct curl_tls_ctx {
@@ -94,6 +94,6 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
                                     struct Curl_easy *data,
                                     struct ssl_peer *peer);
 
-#endif /* !ENABLE_QUIC && (USE_OPENSSL || USE_GNUTLS || USE_WOLFSSL) */
+#endif /* !USE_HTTP3 && (USE_OPENSSL || USE_GNUTLS || USE_WOLFSSL) */
 
 #endif /* HEADER_CURL_VQUIC_TLS_H */

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -59,7 +59,7 @@
 #include "memdebug.h"
 
 
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
 
 #ifdef O_BINARY
 #define QLOGMODE O_WRONLY|O_CREAT|O_BINARY
@@ -663,7 +663,7 @@ CURLcode Curl_conn_may_http3(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#else /* ENABLE_QUIC */
+#else /* USE_HTTP3 */
 
 CURLcode Curl_conn_may_http3(struct Curl_easy *data,
                              const struct connectdata *conn)
@@ -674,4 +674,4 @@ CURLcode Curl_conn_may_http3(struct Curl_easy *data,
   return CURLE_NOT_BUILT_IN;
 }
 
-#endif /* !ENABLE_QUIC */
+#endif /* !USE_HTTP3 */

--- a/lib/vquic/vquic.h
+++ b/lib/vquic/vquic.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
 struct Curl_cfilter;
 struct Curl_easy;
 struct connectdata;
@@ -52,11 +52,11 @@ bool Curl_conn_is_http3(const struct Curl_easy *data,
 
 extern struct Curl_cftype Curl_cft_http3;
 
-#else /* ENABLE_QUIC */
+#else /* USE_HTTP3 */
 
 #define Curl_conn_is_http3(a,b,c)   FALSE
 
-#endif /* !ENABLE_QUIC */
+#endif /* !USE_HTTP3 */
 
 CURLcode Curl_conn_may_http3(struct Curl_easy *data,
                              const struct connectdata *conn);

--- a/lib/vquic/vquic_int.h
+++ b/lib/vquic/vquic_int.h
@@ -27,7 +27,7 @@
 #include "curl_setup.h"
 #include "bufq.h"
 
-#ifdef ENABLE_QUIC
+#ifdef USE_HTTP3
 
 #define MAX_PKT_BURST 10
 #define MAX_UDP_PAYLOAD_SIZE  1452
@@ -88,6 +88,6 @@ CURLcode vquic_recv_packets(struct Curl_cfilter *cf,
                             size_t max_pkts,
                             vquic_recv_pkt_cb *recv_cb, void *userp);
 
-#endif /* !ENABLE_QUIC */
+#endif /* !USE_HTTP3 */
 
 #endif /* HEADER_CURL_VQUIC_QUIC_INT_H */


### PR DESCRIPTION
Before this patch `lib/curl_setup.h` defined these two macros right
next to each other, then the source code used them interchangeably.

After this patch, `USE_HTTP3` guards all HTTP/3 / QUIC features.
(Like `USE_HTTP2` does for HTTP/2.) `ENABLE_QUIC` is no longer used.

This patch doesn't change the way HTTP/3 is enabled via autotools
or CMake. Builders who enabled HTTP/3 manually by defining both of
these macros via `CPPFLAGS` can now delete `-DENABLE_QUIC`.

Closes #13352

---

I could not spot the difference between the meaning of these two macros
in context of curl's HTTP/3 support. Let me know if I missed something.
