### PR TITLE
build: detect `inline` keyword

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -497,9 +497,6 @@ fi
 AC_SUBST(REQUIRE_LIB_DEPS)
 AM_CONDITIONAL(USE_EXPLICIT_LIB_DEPS, test x$REQUIRE_LIB_DEPS = xyes)
 
-dnl check if there's a way to force code inline
-AC_C_INLINE
-
 dnl **********************************************************************
 dnl platform/compiler/architecture specific checks/flags
 dnl **********************************************************************

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -776,12 +776,6 @@ ${SIZEOF_TIME_T_CODE}
 /* Type to use in place of in_addr_t when system does not provide it. */
 #cmakedefine in_addr_t ${in_addr_t}
 
-/* Define to `__inline__' or `__inline' if that's what the C compiler
-   calls it, or to nothing if 'inline' is not supported under any name.  */
-#ifndef __cplusplus
-#undef inline
-#endif
-
 /* Define to `unsigned int' if <sys/types.h> does not define. */
 #cmakedefine size_t ${size_t}
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -891,4 +891,26 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #define OPENSSL_SUPPRESS_DEPRECATED
 #endif
 
+#if defined(inline)
+  /* 'inline' is defined as macro and assumed to be correct */
+  /* No need for 'inline' replacement */
+#elif defined(__cplusplus)
+  /* The code is compiled with C++ compiler.
+     C++ always supports 'inline'. */
+  /* No need for 'inline' replacement */
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901
+  /* C99 (and later) supports 'inline' keyword */
+  /* No need for 'inline' replacement */
+#elif defined(__GNUC__) && __GNUC__ >= 3
+  /* GCC supports '__inline__' as an extension */
+#  define inline __inline__
+#elif defined(_MSC_VER) && _MSC_VER >= 1400
+  /* MSC supports '__inline' from VS 2005 (or even earlier) */
+#  define inline __inline
+#else
+  /* Probably 'inline' is not supported by compiler.
+     Define to the empty string to be on the safe side. */
+#  define inline /* empty */
+#endif
+
 #endif /* HEADER_CURL_SETUP_H */

--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -286,29 +286,13 @@ Curl_sha512_256_finish(unsigned char *digest,
   defined(_MSC_VER) && !defined(__GNUC__) && !defined(__clang__)
 #  if _MSC_VER >= 1400
 #    define MHDX_INLINE __forceinline
-#  else
-#    define MHDX_INLINE /* empty */
 #  endif
 #endif
 
 #if !defined(MHDX_INLINE)
-#  if defined(inline)
-     /* Assume that 'inline' macro was already defined correctly by
-      * the build system. */
-#    define MHDX_INLINE inline
-#  elif defined(__cplusplus)
-     /* The code is compiled with C++ compiler.
-      * C++ always supports 'inline'. */
-#    define MHDX_INLINE inline
-#  elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901
-     /* C99 (and later) supports 'inline' keyword */
-#    define MHDX_INLINE inline
-#  elif defined(__GNUC__) && __GNUC__ >= 3
-     /* GCC supports '__inline__' as an extension */
-#    define MHDX_INLINE __inline__
-#  else
-#    define MHDX_INLINE /* empty */
-#  endif
+   /* Assume that 'inline' keyword works or the
+    * macro was already defined correctly. */
+#  define MHDX_INLINE inline
 #endif
 
 /* Bits manipulation macros and functions.


### PR DESCRIPTION
As I discovered during work on #12897, libcurl does not support use of `inline` keyword because libcurl can be built with unusual combination of old compiler and cmake.
When built by old compiler and autotools (configure), `inline` macro is defined to a suitable replacement (or empty string) if need.
The missing part is cmake checks for `inline` support.
This PR adds support for cmake detection of `inline`.
As a fallback path, `inline` compiler-time detection is implemented in `curl_setup.h`, so even if build system does not check for inline support for any reason the header will substitute a suitable replacement.

With this PR merged, libcurl and curl code can freely use `inline` keyword.