### PR TITLE
openvms: look for `USE_IPV6` in `config.h` (was: `ENABLE_IPV6`)

### DIFF
--- a/packages/vms/config_h.com
+++ b/packages/vms/config_h.com
@@ -847,7 +847,7 @@ $	    goto cfgh_in_loop1
 $	endif
 $!
 $	if (key2a .eqs. "HAVE") .or. (key2a .eqs. "STAT") .or. -
-	   (key2 .eqs. "ENABLE_IPV6") .or. (key2b .eqs. "LDAP")
+	   (key2 .eqs. "USE_IPV6") .or. (key2b .eqs. "LDAP")
 $	then
 $!
 $!	    Process extra underscores
@@ -866,7 +866,7 @@ $		    double_under = 1
 $		endif
 $	    endif
 $!
-$	    if (key2_h .eqs. "_H") .or. (key2 .eqs. "ENABLE_IPV6") .or. -
+$	    if (key2_h .eqs. "_H") .or. (key2 .eqs. "USE_IPV6") .or. -
 	       (key2b .eqs. "LDAP")
 $	    then
 $!
@@ -892,7 +892,7 @@ $		endif
 $!
 $!		And of course what's life with out some special cases
 $!--------------------------------------------------------------------
-$		if key2 .eqs. "ENABLE_IPV6"
+$		if key2 .eqs. "USE_IPV6"
 $		then
 $		    headf = "in6"
 $		endif


### PR DESCRIPTION
The OpenVMS script `config_h.com` is parsing the config header
generated by autotools. Let's make it look for the macro name we now
use universally across the codebase.

Follow-up to e411c98f702f0fb38dceec95e7507ef15a00d12c #13349
Closes #13360

---

~~Untested, please check me.~~ Thank you @wb8tyw!

/cc @captain-caveman2k
