### PR TITLE
ci: add CMake build variation, fixup libssh detection in `linux-old`

### DIFF
--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -79,19 +79,19 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: 'cmake build-only (libssh2)'
+      - name: 'cmake build-only (out-of-tree, libssh2)'
         run: |
           mkdir bld-1
           cd bld-1
-          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_LIBSSH=OFF -DCURL_USE_GSSAPI=OFF
+          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=OFF -DCURL_ZSTD=OFF -DCURL_USE_GSSAPI=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_LIBSSH=OFF
           make install
           src/curl --disable --version
 
-      - name: 'cmake generate out-of-tree (c-ares, libssh, zstd, gssapi)'
+      - name: 'cmake generate (out-of-tree, c-ares, libssh, zstd, gssapi)'
         run: |
           mkdir bld-cares
           cd bld-cares
-          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_GSSAPI=ON \
+          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_GSSAPI=ON -DCURL_USE_LIBSSH2=OFF \
             -DUSE_LIBSSH=ON '-DCMAKE_C_FLAGS=-I/usr/include -L/usr/lib -lssh'
 
       - name: 'build'

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -79,11 +79,17 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: 'cmake generate out-of-tree (c-ares)'
+        run: |
+          mkdir bld-cares
+          cd bld-cares
+          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON -DENABLE_ARES=ON
+
       - name: 'cmake generate out-of-tree'
         run: |
-          mkdir build
-          cd build
-          cmake -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON ..
+          mkdir bld
+          cd bld
+          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON -DENABLE_ARES=OFF
 
       - name: 'build'
         run: make -C build

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           mkdir bld-1
           cd bld-1
-          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_GSSAPI=OFF
+          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_LIBSSH=OFF -DCURL_USE_GSSAPI=OFF
           make install
           src/curl --disable --version
 
@@ -91,7 +91,8 @@ jobs:
         run: |
           mkdir bld-cares
           cd bld-cares
-          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON
+          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_GSSAPI=ON \
+            -DUSE_LIBSSH=ON '-DCMAKE_C_FLAGS=-I/usr/include -L/usr/lib -lssh'
 
       - name: 'build'
         run: |

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -71,7 +71,7 @@ jobs:
           dpkg -i freexian-archive-keyring_2022.06.08_all.deb
           echo 'deb http://deb.freexian.com/extended-lts stretch-lts main contrib non-free' | tee /etc/apt/sources.list.d/extended-lts.list
           apt-get update
-          apt-get install -y --no-install-suggests --no-install-recommends cmake make gcc pkg-config libpsl-dev libzstd-dev zlib1g-dev libssl1.0-dev libssh-dev libc-ares-dev heimdal-dev libldap2-dev stunnel4 groff
+          apt-get install -y --no-install-suggests --no-install-recommends cmake make gcc pkg-config libpsl-dev libzstd-dev zlib1g-dev libssl1.0-dev libssh-dev libssh2-1-dev libc-ares-dev heimdal-dev libldap2-dev stunnel4 groff
           # GitHub's actions/checkout needs a newer glibc. This one is the
           # latest available for buster, the next stable release after stretch.
           httrack --get https://security.debian.org/debian-security/pool/updates/main/g/glibc/libc6_2.28-10+deb10u2_amd64.deb
@@ -79,23 +79,27 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: 'cmake generate out-of-tree (c-ares)'
+      - name: 'cmake build-only (libssh2)'
+        run: |
+          mkdir bld-1
+          cd bld-1
+          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=OFF -DCURL_ZSTD=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_GSSAPI=OFF
+          make install
+          src/curl --disable --version
+
+      - name: 'cmake generate out-of-tree (c-ares, libssh, zstd, gssapi)'
         run: |
           mkdir bld-cares
           cd bld-cares
-          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON -DENABLE_ARES=ON
-
-      - name: 'cmake generate out-of-tree'
-        run: |
-          mkdir bld
-          cd bld
-          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON -DENABLE_ARES=OFF
+          cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH=ON -DCURL_USE_GSSAPI=ON
 
       - name: 'build'
-        run: make -C build
+        run: |
+          make -C bld-cares
+          bld-cares/src/curl --disable --version
 
       - name: 'install'
-        run: make -C build install
+        run: make -C bld-cares install
 
       - name: 'tests'
-        run: make -C build test-ci
+        run: make -C bld-cares test-ci


### PR DESCRIPTION
To test without c-ares and hit `easy_lock.h` on an old system. Use this
new build step to introduce small variations, and also test libssh2.

Also add workaround to existing job to enable libssh. (CMake's generic
auto-detection doesn't seem to work here.):
```
CMake Warning at CMakeLists.txt:908 (find_package):
  Could not find a package configuration file provided by "libssh" with any
  of the following names:

    libsshConfig.cmake
    libssh-config.cmake
```
Ref: https://github.com/curl/curl/actions/runs/8661316091/job/23750974358#step:5:69

Closes #13361
