### PR TITLE
mprintf: check fputc error rather than matching returned character

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -1160,9 +1160,7 @@ static int fputc_wrapper(unsigned char outc, void *f)
   int out = outc;
   FILE *s = f;
   int rc = fputc(out, s);
-  if(rc == out)
-    return 0;
-  return 1;
+  return rc == EOF;
 }
 
 int curl_mprintf(const char *format, ...)


### PR DESCRIPTION
OS/400 ascii fputc wrapper deviates from the posix standard by the fact that it returns the ebcdic encoding of the original ascii character. Testing for a matching value for success will then always fail.

This commit replaces the chariacter comparison by an explicit error return check.

Fixup to ef2cf58c77fc92960695d6669648f92ca4792e9c