### PR TITLE
h3, extend download abort tests, fixes in ngtcp2

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -393,6 +393,7 @@ static int cb_recv_stream_data(ngtcp2_conn *tconn, uint32_t flags,
   nghttp3_ssize nconsumed;
   int fin = (flags & NGTCP2_STREAM_DATA_FLAG_FIN) ? 1 : 0;
   struct Curl_easy *data = stream_user_data;
+  struct h3_stream_ctx *stream = H3_STREAM_CTX(data);
   (void)offset;
   (void)data;
 
@@ -401,10 +402,14 @@ static int cb_recv_stream_data(ngtcp2_conn *tconn, uint32_t flags,
   CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] read_stream(len=%zu) -> %zd",
               stream_id, buflen, nconsumed);
   if(nconsumed < 0) {
-    if(!data) {
+    /* consume all bytes */
+    ngtcp2_conn_extend_max_stream_offset(tconn, stream_id, buflen);
+    ngtcp2_conn_extend_max_offset(tconn, buflen);
+    if(!data || (stream && stream->reset) ||
+      NGHTTP3_ERR_H3_STREAM_CREATION_ERROR == (int)nconsumed) {
       struct Curl_easy *cdata = CF_DATA_CURRENT(cf);
-      CURL_TRC_CF(cdata, cf, "[%" CURL_PRId64 "] nghttp3 error on stream not "
-                  "used by us, ignored", stream_id);
+      CURL_TRC_CF(cdata, cf, "[%" CURL_PRId64 "] discard data for stream %s",
+                  stream_id, (data && stream)? "reset" : "unkown");
       return 0;
     }
     ngtcp2_ccerr_set_application_error(
@@ -786,7 +791,11 @@ static int cb_h3_recv_data(nghttp3_conn *conn, int64_t stream3_id,
   if(result) {
     CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] DATA len=%zu, ERROR %d",
                 stream->id, blen, result);
-    return NGHTTP3_ERR_CALLBACK_FAILURE;
+    nghttp3_conn_close_stream(ctx->h3conn, stream->id,
+                              NGHTTP3_H3_REQUEST_CANCELLED);
+    ngtcp2_conn_extend_max_stream_offset(ctx->qconn, stream->id, blen);
+    ngtcp2_conn_extend_max_offset(ctx->qconn, blen);
+    return 0;
   }
   if(blen) {
     CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] ACK %zu bytes of DATA",
@@ -1288,6 +1297,7 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
   if(rc) {
     failf(data, "can get bidi streams");
     *err = CURLE_SEND_ERROR;
+    nwritten = -1;
     goto out;
   }
   stream->id = (curl_int64_t)sid;

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -409,7 +409,7 @@ static int cb_recv_stream_data(ngtcp2_conn *tconn, uint32_t flags,
       NGHTTP3_ERR_H3_STREAM_CREATION_ERROR == (int)nconsumed) {
       struct Curl_easy *cdata = CF_DATA_CURRENT(cf);
       CURL_TRC_CF(cdata, cf, "[%" CURL_PRId64 "] discard data for stream %s",
-                  stream_id, (data && stream)? "reset" : "unkown");
+                  stream_id, (data && stream)? "reset" : "unknown");
       return 0;
     }
     ngtcp2_ccerr_set_application_error(

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -328,9 +328,11 @@ class TestDownload:
         self.check_downloads(client, srcfile, count)
 
     # download, several at a time, pause and abort paused
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_23a_lib_abort_paused(self, env: Env, httpd, nghttpx, proto, repeat):
-        if proto == 'h2':
+        if proto == 'h3' and env.curl_uses_ossl_quic():
+            pytest.skip('OpenSSL QUIC fails here')
+        if proto in ['h2', 'h3']:
             count = 200
             max_parallel = 100
             pause_offset = 64 * 1024
@@ -353,9 +355,11 @@ class TestDownload:
         self.check_downloads(client, srcfile, count, complete=False)
 
     # download, several at a time, abort after n bytes
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_23b_lib_abort_offset(self, env: Env, httpd, nghttpx, proto, repeat):
-        if proto == 'h2':
+        if proto == 'h3' and env.curl_uses_ossl_quic():
+            pytest.skip('OpenSSL QUIC fails here')
+        if proto in ['h2', 'h3']:
             count = 200
             max_parallel = 100
             abort_offset = 64 * 1024
@@ -378,9 +382,11 @@ class TestDownload:
         self.check_downloads(client, srcfile, count, complete=False)
 
     # download, several at a time, abort after n bytes
-    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_23c_lib_fail_offset(self, env: Env, httpd, nghttpx, proto, repeat):
-        if proto == 'h2':
+        if proto == 'h3' and env.curl_uses_ossl_quic():
+            pytest.skip('OpenSSL QUIC fails here')
+        if proto in ['h2', 'h3']:
             count = 200
             max_parallel = 100
             fail_offset = 64 * 1024

--- a/tests/http/test_03_goaway.py
+++ b/tests/http/test_03_goaway.py
@@ -85,6 +85,8 @@ class TestGoAway:
             pytest.skip("msh3 stalls here")
         if proto == 'h3' and env.curl_uses_lib('quiche'):
             pytest.skip("does not work in CI, but locally for some reason")
+        if proto == 'h3' and env.curl_uses_ossl_quic():
+            pytest.skip('OpenSSL QUIC fails here')
         count = 3
         self.r = None
         def long_run():

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -261,6 +261,12 @@ class Env:
         return libname.lower() in Env.CONFIG.curl_props['libs']
 
     @staticmethod
+    def curl_uses_ossl_quic() -> bool:
+        if Env.have_h3_curl():
+            return not Env.curl_uses_lib('ngtcp2') and Env.curl_uses_lib('nghttp3')
+        return False
+
+    @staticmethod
     def curl_has_feature(feature: str) -> bool:
         return feature.lower() in Env.CONFIG.curl_props['features']
 


### PR DESCRIPTION
- fix flow handling in ngtcp2 to ACK data on streams we abort ourself.
- extend test_02_23* cases to also run for h3
- skip test_02_23* for OpenSSL QUIC as it gets stalled on progressing the connection