### PR TITLE
mbedtls: fix building with v3 in CMake Unity mode

### DIFF
--- a/lib/md4.c
+++ b/lib/md4.c
@@ -55,7 +55,8 @@
 #else
 #include <mbedtls/config.h>
 #endif
-#if(MBEDTLS_VERSION_NUMBER >= 0x02070000)
+#if(MBEDTLS_VERSION_NUMBER >= 0x02070000) && \
+   (MBEDTLS_VERSION_NUMBER < 0x03000000)
   #define HAS_MBEDTLS_RESULT_CODE_BASED_FUNCTIONS
 #endif
 #endif /* USE_MBEDTLS */


### PR DESCRIPTION
Before this patch the internal feature detection macro
`HAS_MBEDTLS_RESULT_CODE_BASED_FUNCTIONS` was defined in three files,
with an incomplete logic in one of them. In Unity mode that spilled
into another source file and broke the build.

Closes #13377
