### PR TITLE
tests: add -q as first option when invoking curl for tests

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -531,7 +531,7 @@ command has been run.
 If the variable name has no assignment, no `=`, then that variable is just
 deleted.
 
-### `<command [option="no-output/no-include/force-output/binary-trace"] [timeout="secs"][delay="secs"][type="perl/shell"]>`
+### `<command [option="no-q/no-output/no-include/force-output/binary-trace"] [timeout="secs"][delay="secs"][type="perl/shell"]>`
 Command line to run.
 
 Note that the URL that gets passed to the server actually controls what data
@@ -561,6 +561,9 @@ otherwise written to verify stdout.
 
 Set `option="no-include"` to prevent the test script to slap on the
 `--include` argument.
+
+Set `option="no-q"` avoid using `-q` as the first argument in the curl command
+line.
 
 Set `option="binary-trace"` to use `--trace` instead of `--trace-ascii` for
 tracing. Suitable for binary-oriented protocols such as MQTT.

--- a/tests/data/test433
+++ b/tests/data/test433
@@ -36,7 +36,7 @@ CURL_HOME=
 <name>
 Verify XDG_CONFIG_HOME use to find .curlrc
 </name>
-<command>
+<command option="no-q">
 %HOSTIP:%HTTPPORT/%TESTNUMBER
 </command>
 </client>

--- a/tests/data/test436
+++ b/tests/data/test436
@@ -35,7 +35,7 @@ XDG_CONFIG_HOME=
 <name>
 Find .curlrc in .config/curlrc via CURL_HOME
 </name>
-<command>
+<command option="no-q">
 %HOSTIP:%HTTPPORT/%TESTNUMBER
 </command>
 </client>

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -919,7 +919,7 @@ sub singletest_run {
     }
 
     if(!$tool) {
-        $CMDLINE=shell_quote($CURL);
+        $CMDLINE=shell_quote($CURL)." -q";
     }
 
     if(use_valgrind() && !$disablevalgrind) {

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -919,7 +919,10 @@ sub singletest_run {
     }
 
     if(!$tool) {
-        $CMDLINE=shell_quote($CURL)." -q";
+        $CMDLINE=shell_quote($CURL);
+        if($cmdhash{'option'} !~ /no-q/) {
+            $CMDLINE .= " -q";
+        }
     }
 
     if(use_valgrind() && !$disablevalgrind) {


### PR DESCRIPTION
To reduce the risk that the user running the tests has a .curlrc present that messes things up.

Ref: #13284