### PR TITLE
Silence warning on comma misuse

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -886,7 +886,8 @@ Curl_cookie_add(struct Curl_easy *data,
      * Now loop through the fields and init the struct we already have
      * allocated
      */
-    for(ptr = firstptr, fields = 0; ptr && !badcookie;
+    fields = 0;
+    for(ptr = firstptr; ptr && !badcookie;
         ptr = strtok_r(NULL, "\t", &tok_buf), fields++) {
       switch(fields) {
       case 0:

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -546,7 +546,8 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     goto quit;
   }
 
-  for(num = 0, entryIterator = ldap_first_entry(server, ldapmsg);
+  num = 0;
+  for(entryIterator = ldap_first_entry(server, ldapmsg);
       entryIterator;
       entryIterator = ldap_next_entry(server, entryIterator), num++) {
     BerElement *ber = NULL;


### PR DESCRIPTION
Building curl with -Wcomma, I see warnings about "possible misuse of comma operator here" and moving fields assignment out of the for() fixes it.