### PR TITLE
result of Curl_bufq_cread is not used

### DIFF
--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1891,7 +1891,7 @@ static CURLcode cr_eob_read(struct Curl_easy *data,
 
   *peos = FALSE;
   if(!Curl_bufq_is_empty(&ctx->buf)) {
-    result = Curl_bufq_cread(&ctx->buf, buf, blen, pnread);
+    (void) Curl_bufq_cread(&ctx->buf, buf, blen, pnread);
   }
   else
     *pnread = 0;


### PR DESCRIPTION
Since result is not used, we can ignore it.
Curl_bufq_cread will not return an error since the the empty check is done before.

Alternatively we can use `if (result) return result;` to exit there right away and pass up the error code.

This silences a warning in my Xcode curl test project.