### PR TITLE
urlapi: remove unused flags argument from Curl_url_set_authority

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -832,7 +832,7 @@ static int set_transfer_url(struct Curl_easy *data,
 
   v = curl_pushheader_byname(hp, HTTP_PSEUDO_AUTHORITY);
   if(v) {
-    uc = Curl_url_set_authority(u, v, CURLU_DISALLOW_USER);
+    uc = Curl_url_set_authority(u, v);
     if(uc) {
       rc = 2;
       goto fail;

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -28,8 +28,7 @@
 size_t Curl_is_absolute_url(const char *url, char *buf, size_t buflen,
                             bool guess_scheme);
 
-CURLUcode Curl_url_set_authority(CURLU *u, const char *authority,
-                                 unsigned int flags);
+CURLUcode Curl_url_set_authority(CURLU *u, const char *authority);
 
 #ifdef DEBUGBUILD
 CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -851,8 +851,8 @@ out:
   return uc;
 }
 
-CURLUcode Curl_url_set_authority(CURLU *u, const char *authority,
-                                 unsigned int flags)
+/* used for HTTP/2 server push */
+CURLUcode Curl_url_set_authority(CURLU *u, const char *authority)
 {
   CURLUcode result;
   struct dynbuf host;
@@ -860,8 +860,8 @@ CURLUcode Curl_url_set_authority(CURLU *u, const char *authority,
   DEBUGASSERT(authority);
   Curl_dyn_init(&host, CURL_MAX_INPUT_LENGTH);
 
-  result = parse_authority(u, authority, strlen(authority), flags,
-                           &host, !!u->scheme);
+  result = parse_authority(u, authority, strlen(authority),
+                           CURLU_DISALLOW_USER, &host, !!u->scheme);
   if(result)
     Curl_dyn_free(&host);
   else {


### PR DESCRIPTION
The function is only called from a single place (for HTTP/2 server push) so might as well just assume this fixed option every time.