### PR TITLE
config: add custom include file in curl_setup.h

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -891,4 +891,14 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #define OPENSSL_SUPPRESS_DEPRECATED
 #endif
 
+/* Optionally #include a user-defined header, whereby compilation options
+   may be set prior to where they take effect, but after platform setup.
+   If CURL_CUSTOM_INCLUDE=? is defined, its value names the #include
+   file. */
+#ifdef CURL_CUSTOM_INCLUDE
+#  define INC_STRINGIFY_(f) #f
+#  define INC_STRINGIFY(f) INC_STRINGIFY_(f)
+#  include INC_STRINGIFY(CURL_CUSTOM_INCLUDE)
+#endif
+
 #endif /* HEADER_CURL_SETUP_H */


### PR DESCRIPTION
This allows us to optionally inject a custom header file in curl to help with platform compatibility issues.
Code is taken from SQLite: https://github.com/sqlite/sqlite/blob/master/src/sqliteInt.h#L184
