### PR TITLE
http2: pass CURLcode errors from callback

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -135,7 +135,7 @@ struct cf_h2_ctx {
   uint32_t max_concurrent_streams;
   int32_t goaway_error;
   int32_t last_stream_id;
-  CURLcode real_result; /* pass errors back from a failing nghttp2 callback */
+  CURLcode cb_result; /* pass errors back from a failing nghttp2 callback */
   BIT(conn_closed);
   BIT(goaway);
   BIT(enable_push);
@@ -570,7 +570,7 @@ static int h2_process_pending_input(struct Curl_cfilter *cf,
       failf(data,
             "process_pending_input: nghttp2_session_mem_recv() returned "
             "%zd:%s", rv, nghttp2_strerror((int)rv));
-      *err = ctx->real_result;
+      *err = ctx->cb_result;
       return -1;
     }
     Curl_bufq_skip(&ctx->inbufq, (size_t)rv);
@@ -1241,8 +1241,8 @@ static int on_frame_recv(nghttp2_session *session, const nghttp2_frame *frame,
     return 0;
   }
 
-  ctx->real_result = on_stream_frame(cf, data_s, frame);
-  return ctx->real_result ? NGHTTP2_ERR_CALLBACK_FAILURE : 0;
+  ctx->cb_result = on_stream_frame(cf, data_s, frame);
+  return ctx->cb_result ? NGHTTP2_ERR_CALLBACK_FAILURE : 0;
 }
 
 static int on_data_chunk_recv(nghttp2_session *session, uint8_t flags,

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -248,7 +248,7 @@ test2200 test2201 test2202 test2203 test2204 test2205 \
 \
 test2300 test2301 test2302 test2303 test2304 test2305 test2306 test2307 \
 \
-test2400 test2401 test2402 test2403 test2404 test2405 \
+test2400 test2401 test2402 test2403 test2404 test2405 test2406 \
 \
 test2500 test2501 test2502 test2503 \
 \

--- a/tests/data/test2406
+++ b/tests/data/test2406
@@ -1,0 +1,66 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP/2
+HTTPS
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 404 nope
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+debug
+h2c
+SSL
+</features>
+<server>
+http
+http/2
+</server>
+<name>
+HTTP/2 with -f
+</name>
+<setenv>
+</setenv>
+<command>
+-k --http2 -f "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER"
+</command>
+
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<stdout crlf="yes">
+HTTP/2 404 
+date: Tue, 09 Nov 2010 14:49:00 GMT
+content-length: 6
+content-type: text/html
+funny-head: yesyes
+server: nghttpx
+via: 1.1 nghttpx
+
+</stdout>
+<errorcode>
+22
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
When the nghttp2 callback on_frame_recv() returns error, we now set an extra "real" return code to pass that value back to return.

This avoids all callback errors sloppily get reported as CURLE_RECV_ERROR. For example for 4xx responses when CURLOPT_FAILONERROR is set.

Reported-by: Laramie Leavitt
Fixes #13411