### PR TITLE
ftp: fix socket leak on rare error

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -388,8 +388,10 @@ static CURLcode AcceptServerConnect(struct Curl_easy *data)
   (void)curlx_nonblock(s, TRUE); /* enable non-blocking */
   /* Replace any filter on SECONDARY with one listening on this socket */
   result = Curl_conn_tcp_accepted_set(data, conn, SECONDARYSOCKET, &s);
-  if(result)
+  if(result) {
+    sclose(s);
     return result;
+  }
 
   if(data->set.fsockopt) {
     int error = 0;


### PR DESCRIPTION
In the function AcceptServerConnect() the newly created socket would leak if Curl_conn_tcp_accepted_set() returns error. Which basically should never happen.

Spotted by CodeSonar.