### PR TITLE
mqtt: when Curl_xfer_recv returns error, don't use nread

### DIFF
--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -777,12 +777,12 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
   case MQTT_REMAINING_LENGTH:
     do {
       result = Curl_xfer_recv(data, (char *)&byte, 1, &nread);
-      if(!nread)
+      if(result || !nread)
         break;
       Curl_debug(data, CURLINFO_HEADER_IN, (char *)&byte, 1);
       mq->pkt_hd[mq->npacket++] = byte;
     } while((byte & 0x80) && (mq->npacket < 4));
-    if(nread && (byte & 0x80))
+    if(!result && nread && (byte & 0x80))
       /* MQTT supports up to 127 * 128^0 + 127 * 128^1 + 127 * 128^2 +
          127 * 128^3 bytes. server tried to send more */
       result = CURLE_WEIRD_SERVER_REPLY;


### PR DESCRIPTION
A returned error code makes other return value unreliable, and in this case potentially uninitialized. On error, do not read other return values like the nread counter.

Spotted by CodeSonar