### PR TITLE
multi: remove the unused Curl_preconnect function

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1881,19 +1881,6 @@ static CURLcode protocol_connect(struct Curl_easy *data,
   return result; /* pass back status */
 }
 
-/*
- * Curl_preconnect() is called immediately before a connect starts. When a
- * redirect is followed, this is then called multiple times during a single
- * transfer.
- */
-CURLcode Curl_preconnect(struct Curl_easy *data)
-{
-  /* this used to do data->state.buffer allocation,
-     maybe remove completely now? */
-  (void)data;
-  return CURLE_OK;
-}
-
 static void set_in_callback(struct Curl_multi *multi, bool value)
 {
   multi->in_callback = value;
@@ -1985,10 +1972,6 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     case MSTATE_CONNECT:
       /* Connect. We want to get a connection identifier filled in. This state
          can be entered from SETUP and from PENDING. */
-      result = Curl_preconnect(data);
-      if(result)
-        break;
-
       result = Curl_connect(data, &async, &connected);
       if(CURLE_NO_CONNECTION_AVAILABLE == result) {
         /* There was no connection available. We will go to the pending

--- a/lib/url.c
+++ b/lib/url.c
@@ -3888,9 +3888,7 @@ CURLcode Curl_connect(struct Curl_easy *data,
 CURLcode Curl_init_do(struct Curl_easy *data, struct connectdata *conn)
 {
   /* if this is a pushed stream, we need this: */
-  CURLcode result = Curl_preconnect(data);
-  if(result)
-    return result;
+  CURLcode result;
 
   if(conn) {
     conn->bits.do_more = FALSE; /* by default there's no curl_do_more() to
@@ -3908,14 +3906,12 @@ CURLcode Curl_init_do(struct Curl_easy *data, struct connectdata *conn)
     data->state.httpreq = HTTPREQ_HEAD;
 
   result = Curl_req_start(&data->req, data);
-  if(result)
-    return result;
-
-  Curl_speedinit(data);
-  Curl_pgrsSetUploadCounter(data, 0);
-  Curl_pgrsSetDownloadCounter(data, 0);
-
-  return CURLE_OK;
+  if(!result) {
+    Curl_speedinit(data);
+    Curl_pgrsSetUploadCounter(data, 0);
+    Curl_pgrsSetDownloadCounter(data, 0);
+  }
+  return result;
 }
 
 #if defined(USE_HTTP2) || defined(USE_HTTP3)

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -950,10 +950,6 @@ CURL_EXTERN CURLcode curl_ws_recv(struct Curl_easy *data, void *buffer,
 
   *nread = 0;
   *metap = NULL;
-  /* get a download buffer */
-  result = Curl_preconnect(data);
-  if(result)
-    return result;
 
   memset(&ctx, 0, sizeof(ctx));
   ctx.data = data;


### PR DESCRIPTION
The implementation has been removed, no point in keeping it around.

Follow-up to 476adfeac019ed