### PR TITLE
request: make Curl_req_init return void

### DIFF
--- a/lib/request.c
+++ b/lib/request.c
@@ -40,10 +40,9 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-CURLcode Curl_req_init(struct SingleRequest *req)
+void Curl_req_init(struct SingleRequest *req)
 {
   memset(req, 0, sizeof(*req));
-  return CURLE_OK;
 }
 
 CURLcode Curl_req_soft_reset(struct SingleRequest *req,

--- a/lib/request.h
+++ b/lib/request.h
@@ -152,7 +152,7 @@ struct SingleRequest {
 /**
  * Initialize the state of the request for first use.
  */
-CURLcode Curl_req_init(struct SingleRequest *req);
+void Curl_req_init(struct SingleRequest *req);
 
 /**
  * The request is about to start. Record time and do a soft reset.

--- a/lib/url.c
+++ b/lib/url.c
@@ -516,12 +516,7 @@ CURLcode Curl_open(struct Curl_easy **curl)
 
   data->magic = CURLEASY_MAGIC_NUMBER;
 
-  result = Curl_req_init(&data->req);
-  if(result) {
-    DEBUGF(fprintf(stderr, "Error: request init failed\n"));
-    free(data);
-    return result;
-  }
+  Curl_req_init(&data->req);
 
   result = Curl_resolver_init(data, &data->state.async.resolver);
   if(result) {


### PR DESCRIPTION
Since it could not return error and therefore this change removes dead code for the caller.

Spotted by CodeSonar.