### PR TITLE
explicitly include `MacTypes.h`

### DIFF
--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -54,6 +54,7 @@
 
 #include <limits.h>
 
+#include <MacTypes.h>
 #include <Security/Security.h>
 /* For some reason, when building for iOS, the omnibus header above does
  * not include SecureTransport.h as of iOS SDK 5.1. */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -56,7 +56,6 @@
 
 #include <MacTypes.h>
 #include <Security/Security.h>
-#include <Security/SecCertificate.h>
 /* For some reason, when building for iOS, the omnibus header above does
  * not include SecureTransport.h as of iOS SDK 5.1. */
 #include <Security/SecureTransport.h>

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -56,6 +56,7 @@
 
 #include <MacTypes.h>
 #include <Security/Security.h>
+#include <Security/SecCertificate.h>
 /* For some reason, when building for iOS, the omnibus header above does
  * not include SecureTransport.h as of iOS SDK 5.1. */
 #include <Security/SecureTransport.h>


### PR DESCRIPTION
The latest macos sdk release - 15.3, seems to have broken a transitive include for OSStatus types used in sectransp.c

The fix here is to explicitly include the header that declares these symbols.