### PR TITLE
tool_operate: init vars unconditionally in post_per_transfer

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -379,11 +379,11 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
   struct OperationConfig *config = per->config;
   int rc;
 
-  if(!curl || !config)
-    return result;
-
   *retryp = FALSE;
   *delay = 0; /* for no retry, keep it zero */
+
+  if(!curl || !config)
+    return result;
 
   if(per->infdopen)
     close(per->infd);


### PR DESCRIPTION
In case of (the unlikely) early return, they could otherwise remain uninitialized

Spotted by CodeSonar