### PR TITLE
tool_operate: don't truncate the etag save file by default

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -925,7 +925,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->etag_save_file) {
           /* open file for output: */
           if(strcmp(config->etag_save_file, "-")) {
-            FILE *newfile = fopen(config->etag_save_file, "wb");
+            FILE *newfile = fopen(config->etag_save_file, "ab");
             if(!newfile) {
               warnf(global, "Failed creating file for saving etags: \"%s\". "
                     "Skip this transfer", config->etag_save_file);

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -261,4 +261,4 @@ test3024 test3025 test3026 test3027 test3028 test3029 test3030 \
 \
 test3100 test3101 test3102 test3103 \
 test3200 \
-test3201 test3202 test3203
+test3201 test3202 test3203 test3204

--- a/tests/data/test3204
+++ b/tests/data/test3204
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 304 Not Modified
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+ETag: "21025-dc7-39462498"
+
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+Use --etag-compare and --etag-save on a existing file that has a matching etag value with the server.
+</name>
+<file name="%LOGDIR/etag%TESTNUMBER">
+"21025-dc7-39462498"
+</file>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --etag-compare %LOGDIR/etag%TESTNUMBER --etag-save %LOGDIR/etag%TESTNUMBER
+</command>
+</client>
+
+# Verify that the file still exists with the correct etag value.
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+If-None-Match: "21025-dc7-39462498"
+
+</protocol>
+<file name="%LOGDIR/etag%TESTNUMBER">
+"21025-dc7-39462498"
+</file>
+</verify>
+</testcase>


### PR DESCRIPTION
This fixes a regression of 75d79a4486b279100209ddf8c7fdb12955fb66e9. The code in tool-operate truncated the etag save file, under the assumption that the file would be written with a new etag value. However since 75d79a4486b279100209ddf8c7fdb12955fb66e9 that might not be the case anymore and could result in the file being truncated when --etag-compare and --etag-save was used and that the etag value matched with what the server responded. Instead the truncation should not be done when a new etag value should be written.

Test 3204 was added to verify that the file with the etag value doesn't change the contents when used by --etag-compare and --etage-save and that value matches with what the server returns on a non 2xx response.

A simple reproducer of this bug is using the command as advertised in [the blog post](https://daniel.haxx.se/blog/2019/12/06/curl-speaks-etag/):
```
curl --etag-compare etag.txt --etag-save etag.txt https://example.com -o saved-file
```

Run it three times and notice that for the second time it indeed doesn't download anything but for the third time it does, because on the second time the `etag.txt` is being truncated and nothing is being written back.