### PR TITLE
Enable test 1117 for hyper HTTP backend as it currently works

### DIFF
--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -72,7 +72,6 @@
 587
 # 1021 re-added here due to flakiness
 1021
-1117
 1417
 1533
 1540


### PR DESCRIPTION
This PR is intended to test the CICD for now, as when I tried this test with the latest hyper it worked.

Edit:
It seems the test is successful on CICD, so it may be enabled. (Sorry If I missed something)