### PR TITLE
rustls: remove incorrect SSLSUPP_TLS13_CIPHERSUITES flag

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
@@ -14,7 +14,6 @@ Protocol:
   - TLS
 TLS-backend:
   - OpenSSL
-  - rustls
   - Schannel
 ---
 

--- a/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
@@ -15,7 +15,6 @@ Protocol:
   - TLS
 TLS-backend:
   - OpenSSL
-  - rustls
   - Schannel
 ---
 

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -725,7 +725,6 @@ static size_t cr_version(char *buffer, size_t size)
 const struct Curl_ssl Curl_ssl_rustls = {
   { CURLSSLBACKEND_RUSTLS, "rustls" },
   SSLSUPP_CAINFO_BLOB |            /* supports */
-  SSLSUPP_TLS13_CIPHERSUITES |
   SSLSUPP_HTTPS_PROXY,
   sizeof(struct rustls_ssl_backend_data),
 


### PR DESCRIPTION
The rustls backend advertises SSLSUPP_TLS13_CIPHERSUITES, but the code does not actually seem to support it (yet?). Removed the flag and corrected documentation.