### PR TITLE
tool: move tool_ftruncate64 to tool_util.c

### DIFF
--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -90,32 +90,3 @@ int tool_seek_cb(void *userdata, curl_off_t offset, int whence)
 
   return CURL_SEEKFUNC_OK;
 }
-
-#ifdef USE_TOOL_FTRUNCATE
-
-#ifdef _WIN32_WCE
-/* 64-bit lseek-like function unavailable */
-#  undef _lseeki64
-#  define _lseeki64(hnd,ofs,whence) lseek(hnd,ofs,whence)
-#  undef _get_osfhandle
-#  define _get_osfhandle(fd) (fd)
-#endif
-
-/*
- * Truncate a file handle at a 64-bit position 'where'.
- */
-
-int tool_ftruncate64(int fd, curl_off_t where)
-{
-  intptr_t handle = _get_osfhandle(fd);
-
-  if(_lseeki64(fd, where, SEEK_SET) < 0)
-    return -1;
-
-  if(!SetEndOfFile((HANDLE)handle))
-    return -1;
-
-  return 0;
-}
-
-#endif /* USE_TOOL_FTRUNCATE */

--- a/src/tool_cb_see.h
+++ b/src/tool_cb_see.h
@@ -25,18 +25,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#if defined(_WIN32) && !defined(HAVE_FTRUNCATE)
-
-int tool_ftruncate64(int fd, curl_off_t where);
-
-#undef  ftruncate
-#define ftruncate(fd,where) tool_ftruncate64(fd,where)
-
-#define HAVE_FTRUNCATE 1
-#define USE_TOOL_FTRUNCATE 1
-
-#endif /* _WIN32 && ! HAVE_FTRUNCATE */
-
 /*
 ** callback for CURLOPT_SEEKFUNCTION
 */

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -74,4 +74,17 @@ extern bool tool_isVistaOrGreater;
 extern bool tool_term_has_bold;
 #endif
 
+#if defined(_WIN32) && !defined(HAVE_FTRUNCATE)
+
+int tool_ftruncate64(int fd, curl_off_t where);
+
+#undef  ftruncate
+#define ftruncate(fd,where) tool_ftruncate64(fd,where)
+
+#define HAVE_FTRUNCATE 1
+#define USE_TOOL_FTRUNCATE 1
+
+#endif /* _WIN32 && ! HAVE_FTRUNCATE */
+
+
 #endif /* HEADER_CURL_TOOL_SETUP_H */

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -159,3 +159,32 @@ int struplocompare4sort(const void *p1, const void *p2)
 {
   return struplocompare(* (char * const *) p1, * (char * const *) p2);
 }
+
+#ifdef USE_TOOL_FTRUNCATE
+
+#ifdef _WIN32_WCE
+/* 64-bit lseek-like function unavailable */
+#  undef _lseeki64
+#  define _lseeki64(hnd,ofs,whence) lseek(hnd,ofs,whence)
+#  undef _get_osfhandle
+#  define _get_osfhandle(fd) (fd)
+#endif
+
+/*
+ * Truncate a file handle at a 64-bit position 'where'.
+ */
+
+int tool_ftruncate64(int fd, curl_off_t where)
+{
+  intptr_t handle = _get_osfhandle(fd);
+
+  if(_lseeki64(fd, where, SEEK_SET) < 0)
+    return -1;
+
+  if(!SetEndOfFile((HANDLE)handle))
+    return -1;
+
+  return 0;
+}
+
+#endif /* USE_TOOL_FTRUNCATE */


### PR DESCRIPTION
... and the prototype to tool_setup.h, to make them both available more widely and accurately.

Fixes #13458 ?