### PR TITLE
http chunked decoding, ignore duplicates

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -1009,6 +1009,13 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
       }
 
       cwt = find_unencode_writer(name, namelen, phase);
+      if(is_transfer && cwt && strncasecompare(name, "chunked", 7) &&
+         Curl_cwriter_get_by_type(data, cwt)) {
+        /* A 'chunked' transfer encoding has alreay been added.
+         * Ignore duplicates. See #13451. */
+        return CURLE_OK;
+      }
+
       if(!cwt)
         cwt = &error_writer;  /* Defer error at use. */
 

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -1011,7 +1011,7 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
       cwt = find_unencode_writer(name, namelen, phase);
       if(is_transfer && cwt && strncasecompare(name, "chunked", 7) &&
          Curl_cwriter_get_by_type(data, cwt)) {
-        /* A 'chunked' transfer encoding has alreay been added.
+        /* A 'chunked' transfer encoding has already been added.
          * Ignore duplicates. See #13451. */
         return CURLE_OK;
       }

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -188,7 +188,7 @@ test1447 test1448 test1449 test1450 test1451 test1452 test1453 test1454 \
 test1455 test1456 test1457 test1458 test1459 test1460 test1461 test1462 \
 test1463 test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
 test1471 test1472 test1473 test1474 test1475 test1476 test1477 test1478 \
-test1479 test1480 test1481 \
+test1479 test1480 test1481 test1482 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -188,7 +188,7 @@ test1447 test1448 test1449 test1450 test1451 test1452 test1453 test1454 \
 test1455 test1456 test1457 test1458 test1459 test1460 test1461 test1462 \
 test1463 test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
 test1471 test1472 test1473 test1474 test1475 test1476 test1477 test1478 \
-test1479 test1480 test1481 test1482 \
+test1479 test1480 test1481 test1482 test1483 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1482
+++ b/tests/data/test1482
@@ -1,0 +1,87 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+chunked Transfer-Encoding
+DELAY
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked, chunked
+Connection: mooo
+
+40
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+30
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+21;heresatest=moooo
+cccccccccccccccccccccccccccccccc
+
+0
+%if !hyper
+chunky-trailer: header data
+another-header: yes
+%endif
+
+</data>
+<datacheck>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked, chunked
+Connection: mooo
+
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccc
+%if !hyper
+chunky-trailer: header data
+another-header: yes
+%endif
+</datacheck>
+<servercmd>
+writedelay: 10
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP GET with double chunked in TE header
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -D %LOGDIR/heads%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<file name="%LOGDIR/heads%TESTNUMBER">
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked, chunked
+Connection: mooo
+
+%if !hyper
+chunky-trailer: header data
+another-header: yes
+%endif
+</file>
+</verify>
+
+</testcase>

--- a/tests/data/test1483
+++ b/tests/data/test1483
@@ -1,0 +1,90 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+chunked Transfer-Encoding
+DELAY
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked
+Transfer-Encoding: chunked
+Connection: mooo
+
+40
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+30
+bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+21;heresatest=moooo
+cccccccccccccccccccccccccccccccc
+
+0
+%if !hyper
+chunky-trailer: header data
+another-header: yes
+%endif
+
+</data>
+<datacheck>
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked
+Transfer-Encoding: chunked
+Connection: mooo
+
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccccccccccccc
+%if !hyper
+chunky-trailer: header data
+another-header: yes
+%endif
+</datacheck>
+<servercmd>
+writedelay: 10
+</servercmd>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP GET with double chunked in TE header
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -D %LOGDIR/heads%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<file name="%LOGDIR/heads%TESTNUMBER">
+HTTP/1.1 200 funky chunky!
+Server: fakeit/0.9 fakeitbad/1.0
+Transfer-Encoding: chunked
+Transfer-Encoding: chunked
+Connection: mooo
+
+%if !hyper
+chunky-trailer: header data
+another-header: yes
+%endif
+</file>
+</verify>
+
+</testcase>


### PR DESCRIPTION
- ignore duplicate "chunked" transfer-encodings from a server to accomodate for broken implementations
- add test1482
- refs #13451