### PR TITLE
bearssl: Use common code for cipher suite lookup

### DIFF
--- a/lib/vtls/cipher_suite.c
+++ b/lib/vtls/cipher_suite.c
@@ -23,7 +23,7 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#if defined(USE_MBEDTLS)
+#if defined(USE_MBEDTLS) || defined(USE_BEARSSL)
 #include "cipher_suite.h"
 #include "curl_printf.h"
 #include "strcase.h"
@@ -81,12 +81,14 @@ static const char *cs_txt =
   "SHA" "\0"
   "SHA256" "\0"
   "SHA384" "\0"
+#if defined(USE_MBEDTLS)
   "ARIA" "\0"
   "ARIA128" "\0"
   "ARIA256" "\0"
   "CAMELLIA" "\0"
   "CAMELLIA128" "\0"
   "CAMELLIA256" "\0"
+#endif
 ;
 /* Indexes of above cs_txt */
 enum {
@@ -120,12 +122,14 @@ enum {
   CS_TXT_IDX_SHA,
   CS_TXT_IDX_SHA256,
   CS_TXT_IDX_SHA384,
+#if defined(USE_MBEDTLS)
   CS_TXT_IDX_ARIA,
   CS_TXT_IDX_ARIA128,
   CS_TXT_IDX_ARIA256,
   CS_TXT_IDX_CAMELLIA,
   CS_TXT_IDX_CAMELLIA128,
   CS_TXT_IDX_CAMELLIA256,
+#endif
   CS_TXT_LEN,
 };
 
@@ -220,7 +224,7 @@ static const struct cs_entry cs_list [] = {
   CS_ENTRY(0xCCA8, ECDHE,RSA,CHACHA20,POLY1305,,,,),
   CS_ENTRY(0xCCA9, TLS,ECDHE,ECDSA,WITH,CHACHA20,POLY1305,SHA256,),
   CS_ENTRY(0xCCA9, ECDHE,ECDSA,CHACHA20,POLY1305,,,,),
-
+#if defined(USE_MBEDTLS)
   CS_ENTRY(0x0001, TLS,RSA,WITH,NULL,MD5,,,),
   CS_ENTRY(0x0001, NULL,MD5,,,,,,),
   CS_ENTRY(0x0002, TLS,RSA,WITH,NULL,SHA,,,),
@@ -312,7 +316,19 @@ static const struct cs_entry cs_list [] = {
   CS_ENTRY(0xC036, ECDHE,PSK,AES256,CBC,SHA,,,),
   CS_ENTRY(0xCCAB, TLS,PSK,WITH,CHACHA20,POLY1305,SHA256,,),
   CS_ENTRY(0xCCAB, PSK,CHACHA20,POLY1305,,,,,),
-
+#endif
+#if defined(USE_BEARSSL)
+  CS_ENTRY(0x000A, TLS,RSA,WITH,3DES,EDE,CBC,SHA,),
+  CS_ENTRY(0x000A, DES,CBC3,SHA,,,,,),
+  CS_ENTRY(0xC003, TLS,ECDH,ECDSA,WITH,3DES,EDE,CBC,SHA),
+  CS_ENTRY(0xC003, ECDH,ECDSA,DES,CBC3,SHA,,,),
+  CS_ENTRY(0xC008, TLS,ECDHE,ECDSA,WITH,3DES,EDE,CBC,SHA),
+  CS_ENTRY(0xC008, ECDHE,ECDSA,DES,CBC3,SHA,,,),
+  CS_ENTRY(0xC00D, TLS,ECDH,RSA,WITH,3DES,EDE,CBC,SHA),
+  CS_ENTRY(0xC00D, ECDH,RSA,DES,CBC3,SHA,,,),
+  CS_ENTRY(0xC012, TLS,ECDHE,RSA,WITH,3DES,EDE,CBC,SHA),
+  CS_ENTRY(0xC012, ECDHE,RSA,DES,CBC3,SHA,,,),
+#endif
   CS_ENTRY(0xC09C, TLS,RSA,WITH,AES,128,CCM,,),
   CS_ENTRY(0xC09C, AES128,CCM,,,,,,),
   CS_ENTRY(0xC09D, TLS,RSA,WITH,AES,256,CCM,,),
@@ -329,7 +345,7 @@ static const struct cs_entry cs_list [] = {
   CS_ENTRY(0xC0AE, ECDHE,ECDSA,AES128,CCM8,,,,),
   CS_ENTRY(0xC0AF, TLS,ECDHE,ECDSA,WITH,AES,256,CCM,8),
   CS_ENTRY(0xC0AF, ECDHE,ECDSA,AES256,CCM8,,,,),
-
+#if defined(USE_MBEDTLS)
   /* entries marked ns are "non-standard", they are not in openssl */
   CS_ENTRY(0x0041, TLS,RSA,WITH,CAMELLIA,128,CBC,SHA,),
   CS_ENTRY(0x0041, CAMELLIA128,SHA,,,,,,),
@@ -533,6 +549,7 @@ static const struct cs_entry cs_list [] = {
   CS_ENTRY(0xCCAD, DHE,PSK,CHACHA20,POLY1305,,,,),
   CS_ENTRY(0xCCAE, TLS,RSA,PSK,WITH,CHACHA20,POLY1305,SHA256,),
   CS_ENTRY(0xCCAE, RSA,PSK,CHACHA20,POLY1305,,,,),
+#endif
 };
 #define CS_LIST_LEN (sizeof(cs_list) / sizeof(cs_list[0]))
 
@@ -696,4 +713,4 @@ int Curl_cipher_suite_get_str(uint16_t id, char *buf, size_t buf_size,
   return r;
 }
 
-#endif /* defined(USE_MBEDTLS) */
+#endif /* defined(USE_MBEDTLS) || defined(USE_BEARSSL) */

--- a/lib/vtls/cipher_suite.h
+++ b/lib/vtls/cipher_suite.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_MBEDTLS)
+#if defined(USE_MBEDTLS) || defined(USE_BEARSSL)
 #include <stdint.h>
 
 /* Lookup IANA id for cipher suite string, returns 0 if not recognized */
@@ -42,5 +42,5 @@ uint16_t Curl_cipher_suite_walk_str(const char **str, const char **end);
 int Curl_cipher_suite_get_str(uint16_t id, char *buf, size_t buf_size,
                               bool prefer_rfc);
 
-#endif /* defined(USE_MBEDTLS) */
+#endif /* defined(USE_MBEDTLS) || defined(USE_BEARSSL) */
 #endif /* HEADER_CURL_CIPHER_SUITE_H */

--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -34,7 +34,7 @@ static void unit_stop(void)
 {
 }
 
-#if defined(USE_MBEDTLS)
+#if defined(USE_MBEDTLS) || defined(USE_BEARSSL)
 
 struct test_cs_entry {
   uint16_t id;
@@ -106,7 +106,7 @@ static const struct test_cs_entry test_cs_list[] = {
             "ECDHE-RSA-CHACHA20-POLY1305" },
   { 0xCCA9, "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
             "ECDHE-ECDSA-CHACHA20-POLY1305" },
-
+#if defined(USE_MBEDTLS)
   { 0x0001, "TLS_RSA_WITH_NULL_MD5",
             "NULL-MD5" },
   { 0x0002, "TLS_RSA_WITH_NULL_SHA",
@@ -203,7 +203,19 @@ static const struct test_cs_entry test_cs_list[] = {
             "ECDHE-PSK-AES256-CBC-SHA" },
   { 0xCCAB, "TLS_PSK_WITH_CHACHA20_POLY1305_SHA256",
             "PSK-CHACHA20-POLY1305" },
-
+#endif
+#if defined(USE_BEARSSL)
+  { 0x000A, "TLS_RSA_WITH_3DES_EDE_CBC_SHA",
+            "DES-CBC3-SHA" },
+  { 0xC003, "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
+            "ECDH-ECDSA-DES-CBC3-SHA" },
+  { 0xC008, "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
+            "ECDHE-ECDSA-DES-CBC3-SHA" },
+  { 0xC00D, "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
+            "ECDH-RSA-DES-CBC3-SHA" },
+  { 0xC012, "TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA",
+            "ECDHE-RSA-DES-CBC3-SHA" },
+#endif
   { 0xC09C, "TLS_RSA_WITH_AES_128_CCM",
             "AES128-CCM" },
   { 0xC09D, "TLS_RSA_WITH_AES_256_CCM",
@@ -220,7 +232,7 @@ static const struct test_cs_entry test_cs_list[] = {
             "ECDHE-ECDSA-AES128-CCM8" },
   { 0xC0AF, "TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8",
             "ECDHE-ECDSA-AES256-CCM8" },
-
+#if defined(USE_MBEDTLS)
   /* entries marked ns are non-"standard", they are not in openssl */
   { 0x0041, "TLS_RSA_WITH_CAMELLIA_128_CBC_SHA",
             "CAMELLIA128-SHA" },
@@ -424,6 +436,7 @@ static const struct test_cs_entry test_cs_list[] = {
             "DHE-PSK-CHACHA20-POLY1305" },
   { 0xCCAE, "TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256",
             "RSA-PSK-CHACHA20-POLY1305" },
+#endif
 };
 #define TEST_CS_LIST_LEN (sizeof(test_cs_list) / sizeof(test_cs_list[0]))
 
@@ -448,18 +461,30 @@ struct test_str_entry {
   const char *str;
 };
 static const struct test_str_entry test_str_list[] = {
+#if defined(USE_MBEDTLS)
   { 0x1301, "TLS_AES_128_GCM_SHA256"},
   { 0x1302, "TLS_AES_256_GCM_SHA384"},
   { 0x1303, "TLS_CHACHA20_POLY1305_SHA256"},
+#else
+  { 0x0000, "TLS_AES_128_GCM_SHA256"},
+  { 0x0000, "TLS_AES_256_GCM_SHA384"},
+  { 0x0000, "TLS_CHACHA20_POLY1305_SHA256"},
+#endif
   { 0xC02B, "ECDHE-ECDSA-AES128-GCM-SHA256"},
   { 0xC02F, "ECDHE-RSA-AES128-GCM-SHA256"},
   { 0xC02C, "ECDHE-ECDSA-AES256-GCM-SHA384"},
   { 0xC030, "ECDHE-RSA-AES256-GCM-SHA384"},
   { 0xCCA9, "ECDHE-ECDSA-CHACHA20-POLY1305"},
   { 0xCCA8, "ECDHE-RSA-CHACHA20-POLY1305"},
+#if defined(USE_MBEDTLS)
   { 0x009E, "DHE-RSA-AES128-GCM-SHA256"},
   { 0x009F, "DHE-RSA-AES256-GCM-SHA384"},
   { 0xCCAA, "DHE-RSA-CHACHA20-POLY1305"},
+#else
+  { 0x0000, "DHE-RSA-AES128-GCM-SHA256"},
+  { 0x0000, "DHE-RSA-AES256-GCM-SHA384"},
+  { 0x0000, "DHE-RSA-CHACHA20-POLY1305"},
+#endif
   { 0xC023, "ECDHE-ECDSA-AES128-SHA256" },
   { 0xC027, "ECDHE-RSA-AES128-SHA256" },
   { 0xC009, "ECDHE-ECDSA-AES128-SHA" },
@@ -468,15 +493,24 @@ static const struct test_str_entry test_str_list[] = {
   { 0xC028, "ECDHE-RSA-AES256-SHA384" },
   { 0xC00A, "ECDHE-ECDSA-AES256-SHA" },
   { 0xC014, "ECDHE-RSA-AES256-SHA" },
+#if defined(USE_MBEDTLS)
   { 0x0067, "DHE-RSA-AES128-SHA256" },
   { 0x006B, "DHE-RSA-AES256-SHA256" },
+#else
+  { 0x0000, "DHE-RSA-AES128-SHA256" },
+  { 0x0000, "DHE-RSA-AES256-SHA256" },
+#endif
   { 0x009C, "AES128-GCM-SHA256" },
   { 0x009D, "AES256-GCM-SHA384" },
   { 0x003C, "AES128-SHA256" },
   { 0x003D, "AES256-SHA256" },
   { 0x002F, "AES128-SHA" },
   { 0x0035, "AES256-SHA" },
+#if defined(USE_BEARSSL)
+  { 0x000A, "DES-CBC3-SHA" },
+#else
   { 0x0000, "DES-CBC3-SHA" },
+#endif
   { 0x0000, "GIBBERISH" },
   { 0x0000, "" },
 };
@@ -573,9 +607,9 @@ UNITTEST_START
 }
 UNITTEST_STOP
 
-#else /* defined(USE_MBEDTLS) */
+#else /* defined(USE_MBEDTLS) || defined(USE_BEARSSL) */
 
 UNITTEST_START
 UNITTEST_STOP
 
-#endif /* defined(USE_MBEDTLS) */
+#endif /* defined(USE_MBEDTLS) || defined(USE_BEARSSL) */


### PR DESCRIPTION
Take advantage of the Curl_cipher_suite_walk_str() and Curl_cipher_suite_get_str() functions introduced in commit fba9afeb.

This also fixes CURLOPT_SSL_CIPHER_LIST not working at all for bearssl due to commit ff74cef5.