### PR TITLE
mqtt: Read variable header indepentenly from payload

### DIFF
--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -714,12 +714,8 @@ static CURLcode mqtt_read_pub_varheader(struct Curl_easy *data)
   if(rest > sizeof(buffer))
     rest = sizeof(buffer);
   result = Curl_xfer_recv(data, buffer, rest, &nread);
-  if(result) {
-    if(CURLE_AGAIN == result) {
-      infof(data, "E AGAIN");
-    }
+  if(result)
     goto end;
-  }
   if(!nread) {
     infof(data, "server disconnected");
     result = CURLE_PARTIAL_FILE;
@@ -794,12 +790,8 @@ static CURLcode mqtt_read_pub_varheader(struct Curl_easy *data)
       mq->npacket -= nread;
       nprocessed = 0;
       result = Curl_xfer_recv(data, buffer, sizeof(buffer), &nread);
-      if(result) {
-        if(CURLE_AGAIN == result) {
-          infof(data, "E AGAIN");
-        }
+      if(result)
         goto end;
-      }
       if(!nread) {
         infof(data, "server disconnected");
         result = CURLE_PARTIAL_FILE;
@@ -898,6 +890,7 @@ MQTT_SUBACK_COMING:
     data->req.bytecount = 0;
     data->req.size = remlen;
     mq->npacket = remlen; /* get this many bytes */
+
     /* we are at the very start of the packet an need to read the header */
     result = mqtt_read_pub_varheader(data);
     if(result)
@@ -915,12 +908,8 @@ MQTT_SUBACK_COMING:
     if(rest > sizeof(buffer))
       rest = sizeof(buffer);
     result = Curl_xfer_recv(data, buffer, rest, &nread);
-    if(result) {
-      if(CURLE_AGAIN == result) {
-        infof(data, "E AGAIN");
-      }
+    if(result)
       goto end;
-    }
     if(!nread) {
       infof(data, "server disconnected");
       result = CURLE_PARTIAL_FILE;


### PR DESCRIPTION
# MQTT read variable header indepentenly from payload


Started by me in a discussion at https://github.com/curl/curl/discussions/13448

---

## current upstream implementation

The MQTT _publish_ packet sent by a broker to a subscribing client is only parsed for the fixed header indicating the packet type.

However, the packet itself still contains a variable header indicating the topic length, topic and packet ID. http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718039 (Section 3.3.2)

The whole variable header and the following payload is output by the curl tool. Yet, we know that the first two bytes are the topic length, which, given that it is significantly short, results in the first byte being `x00`. That results in curl aborting the output and warning of binary output. This makes curl unsuitable for testing any MQTT functionality on the command line.

## proposed change

Break the current implementation and provide the variable header values topic and header ID as header values hidden behind a -v flag like with HTTP.

The output will now only be the actual payload of the packet.

You may want to test this with the `-N` flag. Otherwise you won't see the output immediately.

### further help needed

- The topic name can be up to 32KB. What is the correct cURL way to accumulate that data and provide it back to the user? Is a dynbuf the correct approach? Or can we allocate it all on the stack?
- The reading from the socket and the accompanying error handling is duplicated throughout the code. What is the correct cURL approach to minimize this?