### PR TITLE
altsvc: silence `-Wsign-conversion`

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -189,7 +189,7 @@ static CURLcode altsvc_add(struct altsvcinfo *asi, char *line)
     as = altsvc_create(srchost, dsthost, srcalpn, dstalpn, srcport, dstport);
     if(as) {
       as->expires = expires;
-      as->prio = prio;
+      as->prio = (int)prio;
       as->persist = persist ? 1 : 0;
       Curl_llist_append(&asi->list, as, &as->node);
     }
@@ -409,7 +409,7 @@ static CURLcode getalnum(const char **ptr, char *alpnbuf, size_t buflen)
   protop = p;
   while(*p && !ISBLANK(*p) && (*p != ';') && (*p != '='))
     p++;
-  len = p - protop;
+  len = (size_t)(p - protop);
   *ptr = p;
 
   if(!len || (len >= buflen))
@@ -462,7 +462,7 @@ static time_t altsvc_debugtime(void *unused)
   char *timestr = getenv("CURL_TIME");
   (void)unused;
   if(timestr) {
-    unsigned long val = strtol(timestr, NULL, 10);
+    long val = strtol(timestr, NULL, 10);
     return (time_t)val;
   }
   return time(NULL);
@@ -546,7 +546,7 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
           else {
             while(*p && (ISALNUM(*p) || (*p == '.') || (*p == '-')))
               p++;
-            len = p - hostp;
+            len = (size_t)(p - hostp);
           }
           if(!len || (len >= MAX_ALTSVC_HOSTLEN)) {
             infof(data, "Excessive alt-svc host name, ignoring.");
@@ -624,7 +624,7 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
           num = strtoul(value_ptr, &end_ptr, 10);
           if((end_ptr != value_ptr) && (num < ULONG_MAX)) {
             if(strcasecompare("ma", option))
-              maxage = num;
+              maxage = (time_t)num;
             else if(strcasecompare("persist", option) && (num == 1))
               persist = TRUE;
           }
@@ -696,7 +696,7 @@ bool Curl_altsvc_lookup(struct altsvcinfo *asi,
     if((as->src.alpnid == srcalpnid) &&
        hostcompare(srchost, as->src.host) &&
        (as->src.port == srcport) &&
-       (versions & as->dst.alpnid)) {
+       (versions & (int)as->dst.alpnid)) {
       /* match */
       *dstentry = as;
       return TRUE;


### PR DESCRIPTION
```
altsvc.c: In function ‘altsvc_add’:
altsvc.c:192:18: warning: conversion to ‘int’ from ‘unsigned int’ may change the sign of the result [-Wsign-conversion]
  192 |       as->prio = prio;
      |                  ^~~~
altsvc.c: In function ‘getalnum’:
altsvc.c:412:9: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘long int’ may change the sign of the result [-Wsign-conversion]
  412 |   len = p - protop;
      |         ^
altsvc.c: In function ‘altsvc_debugtime’:
altsvc.c:465:25: warning: conversion to ‘long unsigned int’ from ‘long int’ may change the sign of the result [-Wsign-conversion]
  465 |     unsigned long val = strtol(timestr, NULL, 10);
      |                         ^~~~~~
altsvc.c: In function ‘Curl_altsvc_parse’:
altsvc.c:549:19: warning: conversion to ‘size_t’ {aka ‘long unsigned int’} from ‘long int’ may change the sign of the result [-Wsign-conversion]
  549 |             len = p - hostp;
      |                   ^
altsvc.c:627:24: warning: conversion to ‘time_t’ {aka ‘long int’} from ‘long unsigned int’ may change the sign of the result [-Wsign-conversion]
  627 |               maxage = num;
      |                        ^~~
altsvc.c: In function ‘Curl_altsvc_lookup’:
altsvc.c:699:18: warning: conversion to ‘unsigned int’ from ‘int’ may change the sign of the result [-Wsign-conversion]
  699 |        (versions & as->dst.alpnid)) {
      |                  ^
```
Ref: https://github.com/curl/curl/actions/runs/8819398779/job/24210519501#step:30:25

Closes #13466