### PR TITLE
tests: silence `-Wsign-conversion`, type tidy-ups

### DIFF
--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -225,8 +225,8 @@ int main(int argc, char *argv[])
     fprintf(stderr, "maxlen must be >= 0, got %ld\n", l2);
     return 2;
   }
-  plen_min = l1;
-  plen_max = l2;
+  plen_min = (size_t)l1;
+  plen_max = (size_t)l2;
   if(plen_max < plen_min) {
     fprintf(stderr, "maxlen must be >= minlen, got %ld-%ld\n",
             (long)plen_min, (long)plen_max);

--- a/tests/libtest/lib1537.c
+++ b/tests/libtest/lib1537.c
@@ -58,7 +58,7 @@ CURLcode test(char *URL)
   raw = curl_easy_unescape(NULL, ptr, (int)strlen(ptr), &outlen);
   printf("outlen == %d\n", outlen);
   printf("unescape == original? %s\n",
-         memcmp(raw, a, outlen) ? "no" : "YES");
+         memcmp(raw, a, (size_t)outlen) ? "no" : "YES");
   curl_free(raw);
 
   /* deprecated API */
@@ -70,7 +70,7 @@ CURLcode test(char *URL)
   outlen = (int)strlen(raw);
   printf("[old] outlen == %d\n", outlen);
   printf("[old] unescape == original? %s\n",
-         memcmp(raw, a, outlen) ? "no" : "YES");
+         memcmp(raw, a, (size_t)outlen) ? "no" : "YES");
   curl_free(raw);
   curl_free(ptr);
 

--- a/tests/libtest/lib1597.c
+++ b/tests/libtest/lib1597.c
@@ -88,7 +88,8 @@ CURLcode test(char *URL)
       res = TEST_ERR_FAILURE;
       goto test_cleanup;
     }
-    n += msnprintf(protolist + n, sizeof(protolist) - n, ",%s", *proto);
+    n += msnprintf(protolist + n, sizeof(protolist) - (size_t)n, ",%s",
+                   *proto);
     if(curl_strequal(*proto, "http"))
       httpcode = CURLE_OK;
     if(curl_strequal(*proto, "https"))

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -64,7 +64,7 @@ static void removeFd(struct Sockets *sockets, curl_socket_t fd, int mention)
     if(sockets->sockets[i] == fd) {
       if(i < sockets->count - 1)
         memmove(&sockets->sockets[i], &sockets->sockets[i + 1],
-              sizeof(curl_socket_t) * (sockets->count - (i + 1)));
+              sizeof(curl_socket_t) * (size_t)(sockets->count - (i + 1)));
       --sockets->count;
     }
   }
@@ -93,7 +93,7 @@ static int addFd(struct Sockets *sockets, curl_socket_t fd, const char *what)
   }
   else if(sockets->count + 1 > sockets->max_count) {
     curl_socket_t *ptr = realloc(sockets->sockets, sizeof(curl_socket_t) *
-                                 (sockets->max_count + 20));
+                                 (size_t)(sockets->max_count + 20));
     if(!ptr)
       /* cleanup in test_cleanup */
       return 1;

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -220,7 +220,14 @@ static void updateFdSet(struct Sockets *sockets, fd_set* fdset,
 {
   int i;
   for(i = 0; i < sockets->count; ++i) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(sockets->sockets[i], fdset);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     if(*maxFd < sockets->sockets[i] + 1) {
       *maxFd = sockets->sockets[i] + 1;
     }
@@ -249,7 +256,14 @@ static int checkFdSet(CURLM *curl,
   int i;
   int result = 0;
   for(i = 0; i < sockets->count; ++i) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(sockets->sockets[i], fdset)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       result = socket_action(curl, sockets->sockets[i], evBitmask, name);
       if(result)
         break;

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -80,7 +80,7 @@ static size_t rtp_write(void *ptr, size_t size, size_t nmemb, void *stream)
       }
     }
     else {
-      if(memcmp(RTP_DATA, data + i, message_size - i) != 0) {
+      if(memcmp(RTP_DATA, data + i, (size_t)(message_size - i)) != 0) {
         printf("RTP PAYLOAD END CORRUPTED (%d), [%s]\n",
                message_size - i, data + i);
         /* return failure; */

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -188,7 +188,14 @@ static void updateFdSet(struct Sockets *sockets, fd_set* fdset,
 {
   int i;
   for(i = 0; i < sockets->count; ++i) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(sockets->sockets[i], fdset);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     if(*maxFd < sockets->sockets[i] + 1) {
       *maxFd = sockets->sockets[i] + 1;
     }
@@ -214,7 +221,14 @@ static void checkFdSet(CURLM *curl, struct Sockets *sockets, fd_set *fdset,
 {
   int i;
   for(i = 0; i < sockets->count; ++i) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(sockets->sockets[i], fdset)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       notifyCurl(curl, sockets->sockets[i], evBitmask, name);
     }
   }

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -57,7 +57,7 @@ static void removeFd(struct Sockets *sockets, curl_socket_t fd, int mention)
     if(sockets->sockets[i] == fd) {
       if(i < sockets->count - 1)
         memmove(&sockets->sockets[i], &sockets->sockets[i + 1],
-              sizeof(curl_socket_t) * (sockets->count - (i + 1)));
+              sizeof(curl_socket_t) * (size_t)(sockets->count - (i + 1)));
       --sockets->count;
     }
   }

--- a/tests/libtest/lib677.c
+++ b/tests/libtest/lib677.c
@@ -82,7 +82,8 @@ CURLcode test(char *URL)
 
       if(!state) {
         CURLcode ec;
-        ec = curl_easy_send(curl, cmd + pos, sizeof(cmd) - 1 - pos, &len);
+        ec = curl_easy_send(curl, cmd + pos, sizeof(cmd) - 1 - (size_t)pos,
+                            &len);
         if(ec != CURLE_OK) {
           fprintf(stderr, "curl_easy_send() failed, with code %d (%s)\n",
                   (int)ec, curl_easy_strerror(ec));
@@ -90,7 +91,7 @@ CURLcode test(char *URL)
           goto test_cleanup;
         }
         if(len > 0)
-          pos += len;
+          pos += (ssize_t)len;
         else
           pos = 0;
         if(pos == sizeof(cmd) - 1) {
@@ -100,7 +101,7 @@ CURLcode test(char *URL)
       }
       else if(pos < (ssize_t)sizeof(buf)) {
         CURLcode ec;
-        ec = curl_easy_recv(curl, buf + pos, sizeof(buf) - pos, &len);
+        ec = curl_easy_recv(curl, buf + pos, sizeof(buf) - (size_t)pos, &len);
         if(ec != CURLE_OK) {
           fprintf(stderr, "curl_easy_recv() failed, with code %d (%s)\n",
                   (int)ec, curl_easy_strerror(ec));
@@ -108,7 +109,7 @@ CURLcode test(char *URL)
           goto test_cleanup;
         }
         if(len > 0)
-          pos += len;
+          pos += (ssize_t)len;
       }
       if(len <= 0)
         sock = CURL_SOCKET_BAD;
@@ -116,7 +117,7 @@ CURLcode test(char *URL)
   }
 
   if(state) {
-    fwrite(buf, pos, 1, stdout);
+    fwrite(buf, (size_t)pos, 1, stdout);
     putchar('\n');
   }
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -747,8 +747,15 @@ static bool incoming(curl_socket_t listenfd)
     FD_ZERO(&fds_write);
     FD_ZERO(&fds_err);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     /* there's always a socket to wait for */
     FD_SET(sockfd, &fds_read);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     do {
       /* select() blocking behavior call on blocking descriptors please */
@@ -765,7 +772,14 @@ static bool incoming(curl_socket_t listenfd)
       return FALSE;
     }
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(sockfd, &fds_read)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -193,10 +193,10 @@ static void loghex(unsigned char *buffer, ssize_t len)
   unsigned char *ptr = buffer;
   char *optr = data;
   ssize_t width = 0;
-  int left = sizeof(data);
+  ssize_t left = sizeof(data);
 
   for(i = 0; i<len && (left >= 0); i++) {
-    msnprintf(optr, left, "%02x", ptr[i]);
+    msnprintf(optr, (size_t)left, "%02x", ptr[i]);
     width += 2;
     optr += 2;
     left -= 2;
@@ -219,10 +219,10 @@ static void logprotocol(mqttdir dir,
   ssize_t i;
   unsigned char *ptr = buffer;
   char *optr = data;
-  int left = sizeof(data);
+  ssize_t left = sizeof(data);
 
   for(i = 0; i<len && (left >= 0); i++) {
-    msnprintf(optr, left, "%02x", ptr[i]);
+    msnprintf(optr, (size_t)left, "%02x", ptr[i]);
     optr += 2;
     left -= 2;
   }
@@ -343,10 +343,10 @@ static int disconnect(FILE *dump, curl_socket_t fd)
 */
 
 /* return number of bytes used */
-static int encode_length(size_t packetlen,
-                         unsigned char *remlength) /* 4 bytes */
+static size_t encode_length(size_t packetlen,
+                            unsigned char *remlength) /* 4 bytes */
 {
-  int bytes = 0;
+  size_t bytes = 0;
   unsigned char encode;
 
   do {
@@ -396,12 +396,12 @@ static int publish(FILE *dump,
   size_t topiclen = strlen(topic);
   unsigned char *packet;
   size_t payloadindex;
-  ssize_t remaininglength = topiclen + 2 + payloadlen;
-  ssize_t packetlen;
-  ssize_t sendamount;
+  size_t remaininglength = topiclen + 2 + payloadlen;
+  size_t packetlen;
+  size_t sendamount;
   ssize_t rc;
   unsigned char rembuffer[4];
-  int encodedlen;
+  size_t encodedlen;
 
   if(config.excessive_remaining) {
     /* manually set illegal remaining length */
@@ -443,7 +443,7 @@ static int publish(FILE *dump,
     loghex(packet, rc);
     logprotocol(FROM_SERVER, "PUBLISH", remaininglength, dump, packet, rc);
   }
-  if(rc == packetlen)
+  if((size_t)rc == packetlen)
     return 0;
   return 1;
 }
@@ -463,7 +463,7 @@ static int fixedheader(curl_socket_t fd,
 
   /* get the first two bytes */
   ssize_t rc = sread(fd, (char *)buffer, 2);
-  int i;
+  size_t i;
   if(rc < 2) {
     logmsg("READ %zd bytes [SHORT!]", rc);
     return 1; /* fail */

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -694,6 +694,10 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
     FD_ZERO(&writesock);
     FD_ZERO(&exceptsock);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(wsasock, readfds)) {
       FD_SET(wsasock, &readsock);
       wsaevents.lNetworkEvents |= FD_READ|FD_ACCEPT|FD_CLOSE;
@@ -708,6 +712,9 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
       FD_SET(wsasock, &exceptsock);
       wsaevents.lNetworkEvents |= FD_OOB;
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* only wait for events for which we actually care */
     if(wsaevents.lNetworkEvents) {
@@ -755,12 +762,19 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
             if(select(fd + 1, &readsock, &writesock, &exceptsock, tv) == 1) {
               logmsg("[select_ws] socket %d is ready", fd);
               WSASetEvent(wsaevent);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
               if(FD_ISSET(wsasock, &readsock))
                 data[nfd].wsastate |= FD_READ;
               if(FD_ISSET(wsasock, &writesock))
                 data[nfd].wsastate |= FD_WRITE;
               if(FD_ISSET(wsasock, &exceptsock))
                 data[nfd].wsastate |= FD_OOB;
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             }
             nfd++;
             nws++;
@@ -852,10 +866,17 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
       }
 
       /* check if the event has not been filtered using specific tests */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       if(FD_ISSET(wsasock, readfds) || FD_ISSET(wsasock, writefds) ||
          FD_ISSET(wsasock, exceptfds)) {
         ret++;
       }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     }
     else {
       /* remove from all descriptor sets since this handle did not trigger */
@@ -866,12 +887,19 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
   }
 
   for(fd = 0; fd < nfds; fd++) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(fd, readfds))
       logmsg("[select_ws] %d is readable", fd);
     if(FD_ISSET(fd, writefds))
       logmsg("[select_ws] %d is writable", fd);
     if(FD_ISSET(fd, exceptfds))
       logmsg("[select_ws] %d is exceptional", fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   }
 
   for(i = 0; i < nws; i++) {
@@ -992,6 +1020,10 @@ static bool juggle(curl_socket_t *sockfdp,
   FD_ZERO(&fds_write);
   FD_ZERO(&fds_err);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   FD_SET((curl_socket_t)fileno(stdin), &fds_read);
 
   switch(*mode) {
@@ -1042,6 +1074,9 @@ static bool juggle(curl_socket_t *sockfdp,
     break;
 
   } /* switch(*mode) */
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 
   do {
@@ -1068,7 +1103,14 @@ static bool juggle(curl_socket_t *sockfdp,
     return TRUE;
 
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   if(FD_ISSET(fileno(stdin), &fds_read)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     ssize_t buffer_len;
     /* read from stdin, commands/data to be dealt with and possibly passed on
        to the socket
@@ -1152,7 +1194,14 @@ static bool juggle(curl_socket_t *sockfdp,
   }
 
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   if((sockfd != CURL_SOCKET_BAD) && (FD_ISSET(sockfd, &fds_read)) ) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     ssize_t nread_socket;
     if(*mode == PASSIVE_LISTEN) {
       /* there's no stream set up yet, this is an indication that there's a

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -235,7 +235,8 @@ static ssize_t fullread(int filedes, void *buffer, size_t nbytes)
 
   do {
     ssize_t rc = read(filedes,
-                      (unsigned char *)buffer + nread, nbytes - nread);
+                      (unsigned char *)buffer + nread,
+                      nbytes - (size_t)nread);
 
     if(got_exit_signal) {
       logmsg("signalled to die");
@@ -281,7 +282,7 @@ static ssize_t fullwrite(int filedes, const void *buffer, size_t nbytes)
 
   do {
     ssize_t wc = write(filedes, (const unsigned char *)buffer + nwrite,
-                       nbytes - nwrite);
+                       nbytes - (size_t)nwrite);
 
     if(got_exit_signal) {
       logmsg("signalled to die");
@@ -354,7 +355,7 @@ static void lograw(unsigned char *buffer, ssize_t len)
   unsigned char *ptr = buffer;
   char *optr = data;
   ssize_t width = 0;
-  int left = sizeof(data);
+  size_t left = sizeof(data);
 
   for(i = 0; i<len; i++) {
     switch(ptr[i]) {
@@ -411,7 +412,7 @@ static bool read_data_block(unsigned char *buffer, ssize_t maxlen,
   }
   logmsg("> %zd bytes data, server => client", *buffer_len);
 
-  if(!read_stdin(buffer, *buffer_len))
+  if(!read_stdin(buffer, (size_t)*buffer_len))
     return FALSE;
 
   lograw(buffer, *buffer_len);
@@ -1104,7 +1105,7 @@ static bool juggle(curl_socket_t *sockfdp,
       msnprintf(data, sizeof(data), "PORT\n%04zx\n", buffer_len);
       if(!write_stdout(data, 10))
         return FALSE;
-      if(!write_stdout(buffer, buffer_len))
+      if(!write_stdout(buffer, (size_t)buffer_len))
         return FALSE;
     }
     else if(!memcmp("QUIT", buffer, 4)) {
@@ -1179,7 +1180,7 @@ static bool juggle(curl_socket_t *sockfdp,
       msnprintf(data, sizeof(data), "DATA\n%04zx\n", nread_socket);
       if(!write_stdout(data, 10))
         return FALSE;
-      if(!write_stdout(buffer, nread_socket))
+      if(!write_stdout(buffer, (size_t)nread_socket))
         return FALSE;
 
       logmsg("< %zd bytes data, client => server", nread_socket);

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -176,10 +176,10 @@ static ssize_t read_wincon(int fd, void *buf, size_t count)
     success = ReadFile(handle, buf, curlx_uztoul(count), &rcount, NULL);
   }
   if(success) {
-    return rcount;
+    return (ssize_t)rcount;
   }
 
-  errno = GetLastError();
+  errno = (int)GetLastError();
   return -1;
 }
 #undef  read
@@ -211,10 +211,10 @@ static ssize_t write_wincon(int fd, const void *buf, size_t count)
     success = WriteFile(handle, buf, curlx_uztoul(count), &wcount, NULL);
   }
   if(success) {
-    return wcount;
+    return (ssize_t)wcount;
   }
 
-  errno = GetLastError();
+  errno = (int)GetLastError();
   return -1;
 }
 #undef  write
@@ -484,7 +484,7 @@ static unsigned int WINAPI select_ws_wait_thread(void *lpParameter)
         size.LowPart = GetFileSize(handle, &length);
         if((size.LowPart != INVALID_FILE_SIZE) ||
             (GetLastError() == NO_ERROR)) {
-          size.HighPart = length;
+          size.HighPart = (LONG)length;
           /* get the current position within the file */
           pos.QuadPart = 0;
           pos.LowPart = SetFilePointer(handle, 0, &pos.HighPart, FILE_CURRENT);
@@ -665,7 +665,7 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
   }
 
   /* allocate internal array for the internal data */
-  data = calloc(nfds, sizeof(struct select_ws_data));
+  data = calloc((size_t)nfds, sizeof(struct select_ws_data));
   if(!data) {
     CloseHandle(abort);
     errno = ENOMEM;
@@ -673,7 +673,7 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
   }
 
   /* allocate internal array for the internal event handles */
-  handles = calloc(nfds + 1, sizeof(HANDLE));
+  handles = calloc((size_t)nfds + 1, sizeof(HANDLE));
   if(!handles) {
     CloseHandle(abort);
     free(data);

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -620,7 +620,7 @@ static curl_socket_t sockit(curl_socket_t fd)
   memcpy(&response[SOCKS5_BNDADDR + len],
          &buffer[SOCKS5_DSTADDR + len], sizeof(socksport));
 
-  rc = (send)(fd, (char *)response, (size_t)(len + 6), 0);
+  rc = (send)(fd, (char *)response, (SEND_TYPE_ARG3)(len + 6), 0);
   if(rc != (len + 6)) {
     logmsg("Sending connect response failed!");
     return CURL_SOCKET_BAD;

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -249,10 +249,10 @@ static void loghex(unsigned char *buffer, ssize_t len)
   unsigned char *ptr = buffer;
   char *optr = data;
   ssize_t width = 0;
-  int left = sizeof(data);
+  ssize_t left = sizeof(data);
 
   for(i = 0; i<len && (left >= 0); i++) {
-    msnprintf(optr, left, "%02x", ptr[i]);
+    msnprintf(optr, (size_t)left, "%02x", ptr[i]);
     width += 2;
     optr += 2;
     left -= 2;
@@ -659,7 +659,7 @@ static int tunnel(struct perclient *cp, fd_set *fds)
                     (SEND_TYPE_ARG3)nread, 0);
       if(nwrite != nread)
         return 1;
-      cp->fromclient += nwrite;
+      cp->fromclient += (size_t)nwrite;
     }
     else
       return 1;
@@ -672,7 +672,7 @@ static int tunnel(struct perclient *cp, fd_set *fds)
                     (SEND_TYPE_ARG3)nread, 0);
       if(nwrite != nread)
         return 1;
-      cp->fromremote += nwrite;
+      cp->fromremote += (size_t)nwrite;
     }
     else
       return 1;

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -651,7 +651,14 @@ static int tunnel(struct perclient *cp, fd_set *fds)
   ssize_t nread;
   ssize_t nwrite;
   char buffer[512];
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   if(FD_ISSET(cp->clientfd, fds)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     /* read from client, send to remote */
     nread = recv(cp->clientfd, buffer, sizeof(buffer), 0);
     if(nread > 0) {
@@ -664,7 +671,14 @@ static int tunnel(struct perclient *cp, fd_set *fds)
     else
       return 1;
   }
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   if(FD_ISSET(cp->remotefd, fds)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     /* read from remote, send to client */
     nread = recv(cp->remotefd, buffer, sizeof(buffer), 0);
     if(nread > 0) {
@@ -719,6 +733,10 @@ static bool incoming(curl_socket_t listenfd)
     FD_ZERO(&fds_write);
     FD_ZERO(&fds_err);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     /* there's always a socket to wait for */
     FD_SET(sockfd, &fds_read);
 
@@ -734,6 +752,9 @@ static bool incoming(curl_socket_t listenfd)
           maxfd = (int)fd;
       }
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     do {
       /* select() blocking behavior call on blocking descriptors please */
@@ -750,7 +771,14 @@ static bool incoming(curl_socket_t listenfd)
       return FALSE;
     }
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if((clients < 2) && FD_ISSET(sockfd, &fds_read)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -910,7 +910,14 @@ static int get_request(curl_socket_t sock, struct httprequest *req)
           FD_ZERO(&input);
           FD_ZERO(&output);
           got = 0;
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           FD_SET(sock, &input);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
           do {
             logmsg("Wait until readable");
             rc = select((int)sock + 1, &input, &output, NULL, &timeout);
@@ -1450,6 +1457,12 @@ static void http_connect(curl_socket_t *infdp,
     FD_ZERO(&input);
     FD_ZERO(&output);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+/* 'error: conversion to 'long unsigned int' from 'int'
+   may change the sign of the result' in FD_SET() calls */
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if((clientfd[DATA] == CURL_SOCKET_BAD) &&
        (serverfd[DATA] == CURL_SOCKET_BAD) &&
        poll_client_rd[CTRL] && poll_client_wr[CTRL] &&
@@ -1496,6 +1509,9 @@ static void http_connect(curl_socket_t *infdp,
         }
       }
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     if(got_exit_signal)
       break;
 
@@ -1514,8 +1530,15 @@ static void http_connect(curl_socket_t *infdp,
       /* ---------------------------------------------------------- */
 
       /* passive mode FTP may establish a secondary tunnel */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       if((clientfd[DATA] == CURL_SOCKET_BAD) &&
          (serverfd[DATA] == CURL_SOCKET_BAD) && FD_ISSET(rootfd, &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
         /* a new connection on listener socket (most likely from client) */
         curl_socket_t datafd = accept(rootfd, NULL, NULL);
         if(datafd != CURL_SOCKET_BAD) {
@@ -1590,7 +1613,14 @@ static void http_connect(curl_socket_t *infdp,
         size_t len;
         if(clientfd[i] != CURL_SOCKET_BAD) {
           len = sizeof(readclient[i]) - (size_t)tos[i];
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           if(len && FD_ISSET(clientfd[i], &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             /* read from client */
             rc = sread(clientfd[i], &readclient[i][tos[i]], len);
             if(rc <= 0) {
@@ -1608,7 +1638,14 @@ static void http_connect(curl_socket_t *infdp,
         }
         if(serverfd[i] != CURL_SOCKET_BAD) {
           len = sizeof(readserver[i]) - (size_t)toc[i];
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           if(len && FD_ISSET(serverfd[i], &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             /* read from server */
             rc = sread(serverfd[i], &readserver[i][toc[i]], len);
             if(rc <= 0) {
@@ -1625,7 +1662,14 @@ static void http_connect(curl_socket_t *infdp,
           }
         }
         if(clientfd[i] != CURL_SOCKET_BAD) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           if(toc[i] && FD_ISSET(clientfd[i], &output)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             /* write to client */
             rc = swrite(clientfd[i], readserver[i], toc[i]);
             if(rc <= 0) {
@@ -1646,7 +1690,14 @@ static void http_connect(curl_socket_t *infdp,
           }
         }
         if(serverfd[i] != CURL_SOCKET_BAD) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           if(tos[i] && FD_ISSET(serverfd[i], &output)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             /* write to server */
             rc = swrite(serverfd[i], readclient[i], tos[i]);
             if(rc <= 0) {
@@ -2304,7 +2355,14 @@ int main(int argc, char *argv[])
 
     for(socket_idx = 0; socket_idx < num_sockets; ++socket_idx) {
       /* Listen on all sockets */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       FD_SET(all_sockets[socket_idx], &input);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       if(all_sockets[socket_idx] > maxfd)
         maxfd = all_sockets[socket_idx];
     }
@@ -2332,7 +2390,14 @@ int main(int argc, char *argv[])
     active = rc; /* a positive number */
 
     /* Check if the listening socket is ready to accept */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(all_sockets[0], &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       /* Service all queued connections */
       curl_socket_t msgsock;
       do {
@@ -2349,7 +2414,14 @@ int main(int argc, char *argv[])
 
     /* Service all connections that are ready */
     for(socket_idx = 1; (socket_idx < num_sockets) && active; ++socket_idx) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       if(FD_ISSET(all_sockets[socket_idx], &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
         active--;
         if(got_exit_signal)
           goto sws_cleanup;

--- a/tests/server/tftp.h
+++ b/tests/server/tftp.h
@@ -42,9 +42,9 @@
    things build. */
 
 struct tftphdr {
-  short th_opcode;         /* packet type */
-  unsigned short th_block; /* all sorts of things */
-  char th_data[1];         /* data or error string */
+  unsigned short th_opcode; /* packet type */
+  unsigned short th_block;  /* all sorts of things */
+  char th_data[1];          /* data or error string */
 } PACKED_STRUCT;
 
 #define th_stuff th_block

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -147,7 +147,7 @@ static const char *win32_strerror(int err, char *buf, size_t buflen)
 void win32_perror(const char *msg)
 {
   char buf[512];
-  DWORD err = SOCKERRNO;
+  int err = SOCKERRNO;
   win32_strerror(err, buf, sizeof(buf));
   if(msg)
     fprintf(stderr, "%s: ", msg);

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -87,7 +87,7 @@ UNITTEST_START
 
     key.tv_sec = 0;
     key.tv_usec = (541*i)%1023;
-    storage[i] = key.tv_usec;
+    storage[i] = (size_t)key.tv_usec;
     nodes[i].payload = &storage[i];
     root = Curl_splayinsert(key, root, &nodes[i]);
   }
@@ -120,7 +120,7 @@ UNITTEST_START
 
     /* add some nodes with the same key */
     for(j = 0; j <= i % 3; j++) {
-      storage[i * 3 + j] = key.tv_usec*10 + j;
+      storage[i * 3 + j] = (size_t)(key.tv_usec*10 + j);
       nodes[i * 3 + j].payload = &storage[i * 3 + j];
       root = Curl_splayinsert(key, root, &nodes[i * 3 + j]);
     }

--- a/tests/unit/unit1396.c
+++ b/tests/unit/unit1396.c
@@ -91,7 +91,7 @@ UNITTEST_START
 
     abort_unless(out != NULL, "returned NULL!");
     fail_unless(outlen == list1[i].outlen, "wrong output length returned");
-    fail_unless(!memcmp(out, list1[i].out, list1[i].outlen),
+    fail_unless(!memcmp(out, list1[i].out, (size_t)list1[i].outlen),
                 "bad output data returned");
 
     printf("curl_easy_unescape test %d DONE\n", i);
@@ -106,7 +106,7 @@ UNITTEST_START
 
     outlen = (int)strlen(out);
     fail_unless(outlen == list2[i].outlen, "wrong output length returned");
-    fail_unless(!memcmp(out, list2[i].out, list2[i].outlen),
+    fail_unless(!memcmp(out, list2[i].out, (size_t)list2[i].outlen),
                 "bad output data returned");
 
     printf("curl_easy_escape test %d DONE (%s)\n", i, out);

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -89,7 +89,7 @@ static int verify(const char *info, const char *two)
   char *nl = strchr(info, '\n');
   if(!nl)
     return 1; /* nope */
-  return strncmp(info, two, nl - info);
+  return strncmp(info, two, (size_t)(nl - info));
 }
 
 UNITTEST_START


### PR DESCRIPTION
Silence and fix sign conversion issues and compiler warnings 
in tests. Also switch all unit tests to return `CURLcode`. Before
this patch all unit tests and about a third of libtests did this.

Also fix mask signedness and/or types in some `printf` calls.

Ref: #13467
Cherry-picked from #13489
Follow-up to 3829759bd042c03225ae862062560f568ba1a231 #12489
Closes #13469
