### PR TITLE
src: silence `-Wsign-conversion`, type tidy-ups

### DIFF
--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -126,7 +126,7 @@ void hugehelp(void)
   memset(&z, 0, sizeof(z_stream));
   z.zalloc = (alloc_func)zalloc_func;
   z.zfree = (free_func)zfree_func;
-  z.avail_in = (unsigned int)(sizeof(hugehelpgz) - headerlen);
+  z.avail_in = (unsigned int)(sizeof(hugehelpgz) - (size_t)headerlen);
   z.next_in = (unsigned char *)hugehelpgz + headerlen;
 
   if(inflateInit2(&z, -MAX_WBITS) != Z_OK)

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -132,7 +132,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
           eot--;
 
         if(eot >= etag_h) {
-          size_t etag_length = eot - etag_h + 1;
+          size_t etag_length = (size_t)(eot - etag_h + 1);
           /*
            * Truncate the etag save stream, it can have an existing etag value.
            */
@@ -187,10 +187,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
         }
         p += 9;
 
-        /* this expression below typecasts 'cb' only to avoid
-           warning: signed and unsigned type in conditional expression
-        */
-        len = (ssize_t)cb - (p - str);
+        len = cb - (size_t)(p - str);
         filename = parse_filename(p, len);
         if(filename) {
           if(outs->stream) {
@@ -250,7 +247,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
        hdrcbdata->global->styled_output)
       value = memchr(ptr, ':', cb);
     if(value) {
-      size_t namelen = value - ptr;
+      size_t namelen = (size_t)(value - ptr);
       fprintf(outs->stream, BOLD "%.*s" BOLDOFF ":", (int)namelen, ptr);
 #ifndef LINK
       fwrite(&value[1], cb - namelen - 1, 1, outs->stream);

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -53,7 +53,7 @@
      printf "%d, ", sin($i/200 * 2 * $pi) * 500000 + 500000;
    }
 */
-static const unsigned int sinus[] = {
+static const int sinus[] = {
   515704, 531394, 547052, 562664, 578214, 593687, 609068, 624341, 639491,
   654504, 669364, 684057, 698568, 712883, 726989, 740870, 754513, 767906,
   781034, 793885, 806445, 818704, 830647, 842265, 853545, 864476, 875047,
@@ -86,7 +86,7 @@ static void fly(struct ProgressData *bar, bool moved)
 
   /* bar->width is range checked when assigned */
   DEBUGASSERT(bar->width <= MAX_BARLENGTH);
-  memset(buf, ' ', bar->width);
+  memset(buf, ' ', (size_t)bar->width);
   buf[bar->width] = '\r';
   buf[bar->width + 1] = '\0';
 
@@ -194,7 +194,7 @@ int tool_progress_cb(void *clientp,
     double frac;
     double percent;
     int barwidth;
-    int num;
+    size_t num;
     if(point > total)
       /* we have got more than the expected total! */
       total = point;
@@ -202,7 +202,7 @@ int tool_progress_cb(void *clientp,
     frac = (double)point / (double)total;
     percent = frac * 100.0;
     barwidth = bar->width - 7;
-    num = (int) (((double)barwidth) * frac);
+    num = (size_t) (((double)barwidth) * frac);
     if(num > MAX_BARLENGTH)
       num = MAX_BARLENGTH;
     memset(line, '#', num);
@@ -257,7 +257,7 @@ unsigned int get_terminal_columns(void)
 #elif defined(TIOCGWINSZ)
     struct winsize ts;
     if(!ioctl(STDIN_FILENO, TIOCGWINSZ, &ts))
-      cols = ts.ws_col;
+      cols = (int)ts.ws_col;
 #elif defined(_WIN32)
     {
       HANDLE  stderr_hnd = GetStdHandle(STD_ERROR_HANDLE);
@@ -274,8 +274,8 @@ unsigned int get_terminal_columns(void)
       }
     }
 #endif /* TIOCGSIZE */
-    if(cols < 10000)
-      width = cols;
+    if(cols >= 0 && cols < 10000)
+      width = (unsigned int)cols;
   }
   if(!width)
     width = 79;
@@ -285,7 +285,7 @@ unsigned int get_terminal_columns(void)
 void progressbarinit(struct ProgressData *bar,
                      struct OperationConfig *config)
 {
-  int cols;
+  unsigned int cols;
   memset(bar, 0, sizeof(struct ProgressData));
 
   /* pass the resume from value through to the progress function so it can
@@ -297,7 +297,7 @@ void progressbarinit(struct ProgressData *bar,
   if(cols > MAX_BARLENGTH)
     bar->width = MAX_BARLENGTH;
   else if(cols > 20)
-    bar->width = cols;
+    bar->width = (int)cols;
 
   bar->out = tool_stderr;
   bar->tick = 150;

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -75,7 +75,16 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
       timeout.tv_usec = (int)((wait%1000)*1000);
 
       FD_ZERO(&bits);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+/* error: conversion to 'long unsigned int' from 'int'
+          may change the sign of the result */
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       FD_SET(per->infd, &bits);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       if(!select(per->infd + 1, &bits, NULL, NULL, &timeout))
         return 0; /* timeout */
     }

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -318,7 +318,8 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 
     if(rlen) {
       /* calculate buffer size for wide characters */
-      wc_len = MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)rbuf, rlen, NULL, 0);
+      wc_len = (DWORD)MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)rbuf, (int)rlen,
+                                          NULL, 0);
       if(!wc_len)
         return CURL_WRITEFUNC_ERROR;
 
@@ -326,8 +327,8 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
       if(!wc_buf)
         return CURL_WRITEFUNC_ERROR;
 
-      wc_len = MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)rbuf, rlen, wc_buf,
-                                   wc_len);
+      wc_len = (DWORD)MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)rbuf, (int)rlen,
+                                          wc_buf, (int)wc_len);
       if(!wc_len) {
         free(wc_buf);
         return CURL_WRITEFUNC_ERROR;

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -353,7 +353,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 
   if(bytes == rc)
     /* we added this amount of data to the output */
-    outs->bytes += bytes;
+    outs->bytes += (curl_off_t)bytes;
 
   if(config->readbusy) {
     config->readbusy = FALSE;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -198,7 +198,7 @@ SANITIZEcode sanitize_file_name(char **const sanitized, const char *file_name,
 
     if(clip) {
       *clip = '\0';
-      len = clip - target;
+      len = (size_t)(clip - target);
     }
   }
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -340,7 +340,7 @@ SANITIZEcode msdosify(char **const sanitized, const char *file_name,
   /* Support for Windows 9X VFAT systems, when available. */
   if(_use_lfn(file_name)) {
     illegal_aliens = illegal_chars_w95;
-    len -= (illegal_chars_w95 - illegal_chars_dos);
+    len -= (size_t)(illegal_chars_w95 - illegal_chars_dos);
   }
 
   /* Get past the drive letter, if any. */
@@ -435,7 +435,7 @@ SANITIZEcode msdosify(char **const sanitized, const char *file_name,
        specifically truncating a filename suffixed by an alternate data stream
        or truncating the entire filename is not allowed. */
     if(!(flags & SANITIZE_ALLOW_TRUNCATE) || strpbrk(s, "\\/:") ||
-       truncate_dryrun(dos_name, d - dos_name))
+       truncate_dryrun(dos_name, (size_t)(d - dos_name)))
       return SANITIZE_ERR_INVALID_PATH;
   }
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -860,12 +860,13 @@ static ParameterError data_urlencode(struct GlobalConfig *global,
     /* there was no '=' letter, check for a '@' instead */
     p = strchr(nextarg, '@');
   if(p) {
-    nlen = p - nextarg; /* length of the name part */
+    nlen = (size_t)(p - nextarg); /* length of the name part */
     is_file = *p++; /* pass the separator */
   }
   else {
     /* neither @ nor =, so no name and it isn't a file */
-    nlen = is_file = 0;
+    nlen = 0;
+    is_file = 0;
     p = nextarg;
   }
   if('@' == is_file) {
@@ -1018,7 +1019,7 @@ static const struct LongShort *single(char letter)
     unsigned int j;
     for(j = 0; j < sizeof(aliases)/sizeof(aliases[0]); j++) {
       if(aliases[j].letter != ' ') {
-        unsigned char l = aliases[j].letter;
+        unsigned char l = (unsigned char)aliases[j].letter;
         singles[l - ' '] = &aliases[j];
       }
     }

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -146,12 +146,12 @@ static bool ttyecho(bool enable, int fd)
 #ifdef HAVE_TERMIOS_H
     tcgetattr(fd, &withecho);
     noecho = withecho;
-    noecho.c_lflag &= ~ECHO;
+    noecho.c_lflag &= ~(tcflag_t)ECHO;
     tcsetattr(fd, TCSANOW, &noecho);
 #elif defined(HAVE_TERMIO_H)
     ioctl(fd, TCGETA, &withecho);
     noecho = withecho;
-    noecho.c_lflag &= ~ECHO;
+    noecho.c_lflag &= ~(tcflag_t)ECHO;
     ioctl(fd, TCSETA, &noecho);
 #else
     /* neither HAVE_TERMIO_H nor HAVE_TERMIOS_H, we can't disable echo! */

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -97,15 +97,15 @@ static void print_category(curlhelp_t category, unsigned int cols)
 
   for(i = 0; helptext[i].opt; ++i)
     if(helptext[i].categories & category) {
-      int opt = (int)longopt;
+      size_t opt = longopt;
       size_t desclen = strlen(helptext[i].desc);
       if(opt + desclen >= (cols - 2)) {
         if(desclen < (cols - 2))
-          opt = (cols - 3) - (int)desclen;
+          opt = (cols - 3) - desclen;
         else
           opt = 0;
       }
-      printf(" %-*s  %s\n", opt, helptext[i].opt, helptext[i].desc);
+      printf(" %-*s  %s\n", (int)opt, helptext[i].opt, helptext[i].desc);
     }
 }
 

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -40,9 +40,8 @@
 ** Helper functions that are used from more than one source file.
 */
 
-const char *param2text(int res)
+const char *param2text(ParameterError error)
 {
-  ParameterError error = (ParameterError)res;
   switch(error) {
   case PARAM_GOT_EXTRA_PARAMETER:
     return "had unsupported trailing garbage";

--- a/src/tool_helpers.h
+++ b/src/tool_helpers.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-const char *param2text(int res);
+const char *param2text(ParameterError error);
 
 int SetHTTPrequest(struct OperationConfig *config, HttpReq req,
                    HttpReq *store);

--- a/src/tool_libinfo.c
+++ b/src/tool_libinfo.c
@@ -157,7 +157,7 @@ CURLcode get_libcurl_info(void)
           break;
         }
     }
-    proto_count = builtin - built_in_protos;
+    proto_count = (size_t)(builtin - built_in_protos);
   }
 
   if(curlinfo->age >= CURLVERSION_ELEVENTH && curlinfo->feature_names)

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
   result = win32_init();
   if(result) {
     errorf(&global, "(%d) Windows-specific init failed", result);
-    return result;
+    return (int)result;
   }
 #endif
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -975,7 +975,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         *added = TRUE;
         per->config = config;
         per->curl = curl;
-        per->urlnum = urlnode->num;
+        per->urlnum = (unsigned int)urlnode->num;
 
         /* default headers output stream is stdout */
         heads = &per->heads;

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -85,7 +85,7 @@ static size_t memcrlf(char *orig,
   for(ptr = orig; max; max--, ptr++) {
     bool crlf = ISCRLF(*ptr);
     if(countcrlf ^ crlf)
-      return ptr - orig;
+      return (size_t)(ptr - orig);
   }
   return total; /* no delimiter found */
 }
@@ -319,7 +319,7 @@ static size_t protoset_index(const char * const *protoset, const char *proto)
   for(; *p; p++)
     if(proto == *p)
       break;
-  return p - protoset;
+  return (size_t)(p - protoset);
 }
 
 /* Include protocol token in set. */

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -130,7 +130,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
     DEBUGASSERT(filename);
 
     while(!rc && my_get_line(file, &buf, &fileerror)) {
-      int res;
+      ParameterError res;
       bool alloced_param = FALSE;
       lineno++;
       line = curlx_dyn_ptr(&buf);
@@ -266,7 +266,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
           const char *reason = param2text(res);
           errorf(operation->global, "%s:%d: '%s' %s",
                  filename, lineno, option, reason);
-          rc = res;
+          rc = (int)res;
         }
       }
 

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -223,7 +223,7 @@ static char *c_escape(const char *str, curl_off_t len)
   curlx_dyn_init(&escaped, 4 * MAX_STRING_LENGTH_OUTPUT + 3);
 
   if(len == ZERO_TERMINATED)
-    len = strlen(str);
+    len = (curl_off_t)strlen(str);
 
   if(len > MAX_STRING_LENGTH_OUTPUT) {
     /* cap ridiculously long strings */
@@ -242,7 +242,7 @@ static char *c_escape(const char *str, curl_off_t len)
     if(!p && ISPRINT(*s))
       continue;
 
-    result = curlx_dyn_addn(&escaped, str, s - str);
+    result = curlx_dyn_addn(&escaped, str, (size_t)(s - str));
     str = s + 1;
 
     if(!result) {
@@ -259,7 +259,7 @@ static char *c_escape(const char *str, curl_off_t len)
   }
 
   if(!result)
-    result = curlx_dyn_addn(&escaped, str, s - str);
+    result = curlx_dyn_addn(&escaped, str, (size_t)(s - str));
 
   if(!result)
     (void) !curlx_dyn_addn(&escaped, "...", cutoff);
@@ -702,7 +702,7 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *global,
       if(escape) {
         curl_off_t len = ZERO_TERMINATED;
         if(tag == CURLOPT_POSTFIELDS)
-          len = curlx_dyn_len(&config->postdata);
+          len = (curl_off_t)curlx_dyn_len(&config->postdata);
         escaped = c_escape(value, len);
         NULL_CHECK(escaped);
         CODE2("curl_easy_setopt(hnd, %s, \"%s\");", name, escaped);

--- a/src/tool_sleep.c
+++ b/src/tool_sleep.c
@@ -48,7 +48,7 @@ void tool_go_sleep(long ms)
 #if defined(MSDOS)
   delay(ms);
 #elif defined(_WIN32)
-  Sleep(ms);
+  Sleep((DWORD)ms);
 #elif defined(HAVE_POLL_FINE)
   (void)poll((void *)0, 0, (int)ms);
 #else

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -229,7 +229,7 @@ static CURLcode glob_range(struct URLGlob *glob, char **patternp,
         pattern += 4;
     }
 
-    *posp += (pattern - *patternp);
+    *posp += (size_t)(pattern - *patternp);
 
     if(rc != 3 || !step || step > (unsigned)INT_MAX ||
        (min_c == max_c && step != 1) ||
@@ -307,7 +307,7 @@ static CURLcode glob_range(struct URLGlob *glob, char **patternp,
     }
 
 fail:
-    *posp += (pattern - *patternp);
+    *posp += (size_t)(pattern - *patternp);
 
     if(!endp || !step_n ||
        (min_n == max_n && step_n != 1) ||
@@ -317,9 +317,10 @@ fail:
 
     /* typecasting to ints are fine here since we make sure above that we
        are within 31 bits */
-    pat->content.NumRange.ptr_n = pat->content.NumRange.min_n = min_n;
-    pat->content.NumRange.max_n = max_n;
-    pat->content.NumRange.step = step_n;
+    pat->content.NumRange.ptr_n = pat->content.NumRange.min_n =
+                                    (curl_off_t)min_n;
+    pat->content.NumRange.max_n = (curl_off_t)max_n;
+    pat->content.NumRange.step = (curl_off_t)step_n;
 
     if(multiply(amount, ((pat->content.NumRange.max_n -
                           pat->content.NumRange.min_n) /
@@ -350,7 +351,7 @@ static bool peek_ipv6(const char *str, size_t *skip)
   if(!endbr)
     return FALSE;
 
-  hlen = endbr - str + 1;
+  hlen = (size_t)(endbr - str + 1);
   if(hlen >= MAX_IP6LEN)
     return FALSE;
 

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -443,7 +443,7 @@ static int writeLong(FILE *stream, const struct writeoutvar *wovar,
       valid = true;
       break;
     case VAR_EXITCODE:
-      longinfo = per_result;
+      longinfo = (long)per_result;
       valid = true;
       break;
     case VAR_URLNUM:

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -546,7 +546,7 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
             fputs("%{", stream);
             continue;
           }
-          vlen = end - ptr;
+          vlen = (size_t)(end - ptr);
           for(i = 0; variables[i].name; i++) {
             if((strlen(variables[i].name) == vlen) &&
                curl_strnequal(ptr, variables[i].name, vlen)) {
@@ -596,7 +596,7 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
           if(end) {
             char hname[256]; /* holds the longest header field name */
             struct curl_header *header;
-            vlen = end - ptr;
+            vlen = (size_t)(end - ptr);
             if(vlen < sizeof(hname)) {
               memcpy(hname, ptr, vlen);
               hname[vlen] = 0;
@@ -619,7 +619,7 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
           end = strchr(ptr, '}');
           if(end) {
             char fname[512]; /* holds the longest file name */
-            size_t flen = end - ptr;
+            size_t flen = (size_t)(end - ptr);
             if(flen < sizeof(fname)) {
               FILE *stream2;
               memcpy(fname, ptr, flen);

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -72,7 +72,7 @@ int jsonquoted(const char *in, size_t len,
       if(*i < 32)
         result = curlx_dyn_addf(out, "\\u%04x", *i);
       else {
-        char o = *i;
+        char o = (char)*i;
         if(lowercase && (o >= 'A' && o <= 'Z'))
           /* do not use tolower() since that's locale specific */
           o |= ('a' - 'A');

--- a/src/var.c
+++ b/src/var.c
@@ -222,7 +222,7 @@ ParameterError varexpand(struct GlobalConfig *global,
       /* preceding backslash, we want this verbatim */
 
       /* insert the text up to this point, minus the backslash */
-      result = curlx_dyn_addn(out, line, envp - line - 1);
+      result = curlx_dyn_addn(out, line, (size_t)(envp - line - 1));
       if(result)
         return PARAM_NO_MEM;
 
@@ -250,21 +250,21 @@ ParameterError varexpand(struct GlobalConfig *global,
       envp += 2; /* move over the {{ */
 
       /* if there is a function, it ends the name with a colon */
-      funcp = memchr(envp, ':', clp - envp);
+      funcp = memchr(envp, ':', (size_t)(clp - envp));
       if(funcp)
-        nlen = funcp - envp;
+        nlen = (size_t)(funcp - envp);
       else
-        nlen = clp - envp;
+        nlen = (size_t)(clp - envp);
       if(!nlen || (nlen >= sizeof(name))) {
         warnf(global, "bad variable name length '%s'", input);
         /* insert the text as-is since this is not an env variable */
-        result = curlx_dyn_addn(out, line, clp - line + prefix);
+        result = curlx_dyn_addn(out, line, (size_t)(clp - line) + prefix);
         if(result)
           return PARAM_NO_MEM;
       }
       else {
         /* insert the text up to this point */
-        result = curlx_dyn_addn(out, line, envp - prefix - line);
+        result = curlx_dyn_addn(out, line, (size_t)(envp - line) - prefix);
         if(result)
           return PARAM_NO_MEM;
 
@@ -279,7 +279,7 @@ ParameterError varexpand(struct GlobalConfig *global,
           warnf(global, "bad variable name: %s", name);
           /* insert the text as-is since this is not an env variable */
           result = curlx_dyn_addn(out, envp - prefix,
-                                  clp - envp + prefix + 2);
+                                  (size_t)(clp - envp) + prefix + 2);
           if(result)
             return PARAM_NO_MEM;
         }
@@ -298,7 +298,7 @@ ParameterError varexpand(struct GlobalConfig *global,
           curlx_dyn_init(&buf, MAX_EXPAND_CONTENT);
           if(funcp) {
             /* apply the list of functions on the value */
-            size_t flen = clp - funcp;
+            size_t flen = (size_t)(clp - funcp);
             ParameterError err = varfunc(global, value, vlen, funcp, flen,
                                          &buf);
             if(err)
@@ -397,7 +397,7 @@ ParameterError setvariable(struct GlobalConfig *global,
   name = line;
   while(*line && (ISALNUM(*line) || (*line == '_')))
     line++;
-  nlen = line - name;
+  nlen = (size_t)(line - name);
   if(!nlen || (nlen >= MAX_VAR_LEN)) {
     warnf(global, "Bad variable name length (%zd), skipping", nlen);
     return PARAM_OK;


### PR DESCRIPTION
`src` (curl tool) building without signedness warnings after this PR.

Also:
- add a negative check to `get_terminal_columns()`.
- tool_parsecfg: fix ParameterError mix-up.

Cherry-picked from #13489
Follow-up to 3829759bd042c03225ae862062560f568ba1a231 #12489
Closes #13470
