### PR TITLE
lib/v*: silence `-Wsign-conversion`, tidy-ups, fixes

### DIFF
--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -482,9 +482,9 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   size_t size;
   unsigned char ntlmbuf[NTLM_BUFSIZE];
-  int lmrespoff;
+  unsigned int lmrespoff;
   unsigned char lmresp[24]; /* fixed-size */
-  int ntrespoff;
+  unsigned int ntrespoff;
   unsigned int ntresplen = 24;
   unsigned char ntresp[24]; /* fixed-size */
   unsigned char *ptr_ntresp = &ntresp[0];
@@ -508,7 +508,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 
   if(user) {
     domain = userp;
-    domlen = (user - domain);
+    domlen = (size_t)(user - domain);
     user++;
   }
   else
@@ -585,7 +585,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
       return result;
 
     Curl_ntlm_core_lm_resp(lmbuffer, &ntlm->nonce[0], lmresp);
-    ntlm->flags &= ~NTLMFLAG_NEGOTIATE_NTLM2_KEY;
+    ntlm->flags &= ~(unsigned int)NTLMFLAG_NEGOTIATE_NTLM2_KEY;
 
     /* A safer but less compatible alternative is:
      *   Curl_ntlm_core_lm_resp(ntbuffer, &ntlm->nonce[0], lmresp);
@@ -605,7 +605,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   hostoff = useroff + userlen;
 
   /* Create the big type-3 message binary blob */
-  size = msnprintf((char *)ntlmbuf, NTLM_BUFSIZE,
+  size = (size_t)msnprintf((char *)ntlmbuf, NTLM_BUFSIZE,
                    NTLMSSP_SIGNATURE "%c"
                    "\x03%c%c%c"  /* 32-bit type = 3 */
 
@@ -683,7 +683,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                    LONGQUARTET(ntlm->flags));
 
   DEBUGASSERT(size == 64);
-  DEBUGASSERT(size == (size_t)lmrespoff);
+  DEBUGASSERT(size == lmrespoff);
 
   /* We append the binary hashes */
   if(size < (NTLM_BUFSIZE - 0x18)) {
@@ -701,7 +701,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
     failf(data, "incoming NTLM message too big");
     return CURLE_OUT_OF_MEMORY;
   }
-  DEBUGASSERT(size == (size_t)ntrespoff);
+  DEBUGASSERT(size == ntrespoff);
   memcpy(&ntlmbuf[size], ptr_ntresp, ntresplen);
   size += ntresplen;
 

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -375,8 +375,8 @@ static void MSH3_CALL msh3_header_received(MSH3_REQUEST *Request,
     DEBUGASSERT(!stream->firstheader);
     stream->status_code = decode_status_code(hd->Value, hd->ValueLength);
     DEBUGASSERT(stream->status_code != -1);
-    ncopy = msnprintf(line, sizeof(line), "HTTP/3 %03d \r\n",
-                      stream->status_code);
+    ncopy = (size_t)msnprintf(line, sizeof(line), "HTTP/3 %03d \r\n",
+                              stream->status_code);
     result = write_resp_raw(data, line, ncopy);
     if(result)
       stream->recv_error = result;
@@ -672,7 +672,7 @@ static ssize_t cf_msh3_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       goto out;
     }
     *err = CURLE_OK;
-    nwritten = len;
+    nwritten = (ssize_t)len;
     goto out;
   }
   else {
@@ -691,7 +691,7 @@ static ssize_t cf_msh3_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     /* TODO - msh3/msquic will hold onto this memory until the send complete
        event. How do we make sure curl doesn't free it until then? */
     *err = CURLE_OK;
-    nwritten = len;
+    nwritten = (ssize_t)len;
   }
 
 out:

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -211,7 +211,7 @@ static CURLcode curl_wssl_init_ssl(struct curl_tls_ctx *ctx,
 
   if(alpn)
     wolfSSL_set_alpn_protos(ctx->ssl, (const unsigned char *)alpn,
-                            (int)alpn_len);
+                            (unsigned int)alpn_len);
 
   if(peer->sni) {
     wolfSSL_UseSNI(ctx->ssl, WOLFSSL_SNI_HOST_NAME,

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -163,7 +163,7 @@ struct ssh_conn {
   unsigned kbd_state; /* 0 or 1 */
   ssh_key privkey;
   ssh_key pubkey;
-  int auth_methods;
+  unsigned int auth_methods;
   ssh_session ssh_session;
   ssh_scp scp_session;
   sftp_session sftp_session;

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -951,7 +951,7 @@ static ssize_t bearssl_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     if(backend->pending_write) {
       applen = backend->pending_write;
       backend->pending_write = 0;
-      return applen;
+      return (ssize_t)applen;
     }
     if(applen > len)
       applen = len;
@@ -984,7 +984,7 @@ static ssize_t bearssl_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   memcpy(buf, app, applen);
   br_ssl_engine_recvapp_ack(&backend->ctx.eng, applen);
 
-  return applen;
+  return (ssize_t)applen;
 }
 
 static CURLcode bearssl_connect_common(struct Curl_cfilter *cf,
@@ -1091,7 +1091,7 @@ static CURLcode bearssl_connect_common(struct Curl_cfilter *cf,
 
 static size_t bearssl_version(char *buffer, size_t size)
 {
-  return msnprintf(buffer, size, "BearSSL");
+  return (size_t)msnprintf(buffer, size, "BearSSL");
 }
 
 static bool bearssl_data_pending(struct Curl_cfilter *cf,

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -327,7 +327,7 @@ static unsigned x509_end_chain(const br_x509_class **ctx)
   struct x509_context *x509 = (struct x509_context *)ctx;
 
   if(!x509->verifypeer) {
-    return br_x509_decoder_last_error(&x509->decoder);
+    return (unsigned)br_x509_decoder_last_error(&x509->decoder);
   }
 
   return x509->minimal.vtable->end_chain(&x509->minimal.vtable);
@@ -529,7 +529,7 @@ static CURLcode bearssl_set_selected_ciphers(struct Curl_easy *data,
     while(*cipher_end && !bearssl_is_separator(*cipher_end))
       ++cipher_end;
 
-    clen = cipher_end - cipher_start;
+    clen = (size_t)(cipher_end - cipher_start);
     cipher = cipher_start;
 
     cipher_start = cipher_end;
@@ -822,7 +822,7 @@ static CURLcode bearssl_run_until(struct Curl_cfilter *cf,
       if(ret <= 0) {
         return result;
       }
-      br_ssl_engine_sendrec_ack(&backend->ctx.eng, ret);
+      br_ssl_engine_sendrec_ack(&backend->ctx.eng, (size_t)ret);
     }
     else if(state & BR_SSL_RECVREC) {
       buf = br_ssl_engine_recvrec_buf(&backend->ctx.eng, &len);
@@ -835,7 +835,7 @@ static CURLcode bearssl_run_until(struct Curl_cfilter *cf,
       if(ret <= 0) {
         return result;
       }
-      br_ssl_engine_recvrec_ack(&backend->ctx.eng, ret);
+      br_ssl_engine_recvrec_ack(&backend->ctx.eng, (size_t)ret);
     }
   }
 }

--- a/lib/vtls/cipher_suite.c
+++ b/lib/vtls/cipher_suite.c
@@ -558,7 +558,7 @@ static int cs_str_to_zip(const char *cs_str, size_t cs_len,
     /* determine the length of the part */
     cur = nxt;
     for(; nxt < end && *nxt != '\0' && *nxt != separator; nxt++);
-    len = nxt - cur;
+    len = (size_t)(nxt - cur);
 
     /* lookup index for the part (skip empty string at 0) */
     for(idx = 1, entry = cs_txt + 1; idx < CS_TXT_LEN; idx++) {
@@ -624,7 +624,7 @@ static int cs_zip_to_str(const uint8_t zip[6],
 
     if(r < 0)
       return -1;
-    len += r;
+    len += (size_t)r;
   }
 
   return 0;
@@ -667,7 +667,7 @@ uint16_t Curl_cipher_suite_walk_str(const char **str, const char **end)
   /* move end pointer to next separator or end of string */
   for(*end = *str; *end[0] != '\0' && !cs_is_separator(*end[0]); (*end)++);
 
-  return Curl_cipher_suite_lookup_id(*str, *end - *str);
+  return Curl_cipher_suite_lookup_id(*str, (size_t)(*end - *str));
 }
 
 int Curl_cipher_suite_get_str(uint16_t id, char *buf, size_t buf_size,

--- a/lib/vtls/hostcheck.c
+++ b/lib/vtls/hostcheck.c
@@ -112,8 +112,8 @@ static bool hostmatch(const char *hostname,
   else {
     const char *hostname_label_end = memchr(hostname, '.', hostlen);
     if(hostname_label_end) {
-      size_t skiphost = hostname_label_end - hostname;
-      size_t skiplen = pattern_label_end - pattern;
+      size_t skiphost = (size_t)(hostname_label_end - hostname);
+      size_t skiplen = (size_t)(pattern_label_end - pattern);
       return pmatch(hostname_label_end, hostlen - skiphost,
                     pattern_label_end, patternlen - skiplen);
     }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2858,6 +2858,9 @@ ossl_set_ssl_version_min_max(struct Curl_cfilter *cf, SSL_CTX *ctx)
 typedef uint32_t ctx_option_t;
 #elif OPENSSL_VERSION_NUMBER >= 0x30000000L
 typedef uint64_t ctx_option_t;
+#elif OPENSSL_VERSION_NUMBER >= 0x10100000L && \
+  !defined(LIBRESSL_VERSION_NUMBER)
+typedef unsigned long ctx_option_t;
 #else
 typedef long ctx_option_t;
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3692,11 +3692,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
-  SSL_CTX_set_options(octx->ssl_ctx, (uint64_t)ctx_options);
-#else
   SSL_CTX_set_options(octx->ssl_ctx, ctx_options);
-#endif
 
 #ifdef HAS_ALPN
   if(alpn && alpn_len) {

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -256,6 +256,13 @@
 #endif
 #endif
 
+#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
+typedef size_t numcert_t;
+#else
+typedef int numcert_t;
+#endif
+#define ossl_valsize_t numcert_t
+
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
 /* up2date versions of OpenSSL maintain reasonably secure defaults without
  * breaking compatibility, so it is better not to override the defaults in curl
@@ -320,9 +327,9 @@ struct multi_ssl_backend_data {
 #define push_certinfo(_label, _num)             \
 do {                              \
   long info_len = BIO_get_mem_data(mem, &ptr); \
-  Curl_ssl_push_certinfo_len(data, _num, _label, ptr, info_len); \
-  if(1 != BIO_reset(mem))                                        \
-    break;                                                       \
+  Curl_ssl_push_certinfo_len(data, _num, _label, ptr, (size_t)info_len); \
+  if(1 != BIO_reset(mem))                                                \
+    break;                                                               \
 } while(0)
 
 static void pubkey_show(struct Curl_easy *data,
@@ -383,7 +390,7 @@ static void X509V3_ext(struct Curl_easy *data,
 
   for(i = 0; i < (int)sk_X509_EXTENSION_num(exts); i++) {
     ASN1_OBJECT *obj;
-    X509_EXTENSION *ext = sk_X509_EXTENSION_value(exts, i);
+    X509_EXTENSION *ext = sk_X509_EXTENSION_value(exts, (ossl_valsize_t)i);
     BUF_MEM *biomem;
     char namebuf[128];
     BIO *bio_out = BIO_new(BIO_s_mem());
@@ -404,12 +411,6 @@ static void X509V3_ext(struct Curl_easy *data,
     BIO_free(bio_out);
   }
 }
-
-#if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)
-typedef size_t numcert_t;
-#else
-typedef int numcert_t;
-#endif
 
 CURLcode Curl_ossl_certchain(struct Curl_easy *data, SSL *ssl)
 {
@@ -440,7 +441,7 @@ CURLcode Curl_ossl_certchain(struct Curl_easy *data, SSL *ssl)
 
   for(i = 0; i < (int)numcerts; i++) {
     ASN1_INTEGER *num;
-    X509 *x = sk_X509_value(sk, i);
+    X509 *x = sk_X509_value(sk, (ossl_valsize_t)i);
     EVP_PKEY *pubkey = NULL;
     int j;
     char *ptr;
@@ -729,7 +730,10 @@ static int ossl_bio_cf_out_write(BIO *bio, const char *buf, int blen)
   CURLcode result = CURLE_SEND_ERROR;
 
   DEBUGASSERT(data);
-  nwritten = Curl_conn_cf_send(cf->next, data, buf, blen, &result);
+  if(blen < 0)
+    return 0;
+
+  nwritten = Curl_conn_cf_send(cf->next, data, buf, (size_t)blen, &result);
   CURL_TRC_CF(data, cf, "ossl_bio_cf_out_write(len=%d) -> %d, err=%d",
               blen, (int)nwritten, result);
   BIO_clear_retry_flags(bio);
@@ -754,8 +758,10 @@ static int ossl_bio_cf_in_read(BIO *bio, char *buf, int blen)
   /* OpenSSL catches this case, so should we. */
   if(!buf)
     return 0;
+  if(blen < 0)
+    return 0;
 
-  nread = Curl_conn_cf_recv(cf->next, data, buf, blen, &result);
+  nread = Curl_conn_cf_recv(cf->next, data, buf, (size_t)blen, &result);
   CURL_TRC_CF(data, cf, "ossl_bio_cf_in_read(len=%d) -> %d, err=%d",
               blen, (int)nread, result);
   BIO_clear_retry_flags(bio);
@@ -870,7 +876,8 @@ ossl_log_tls12_secret(const SSL *ssl, bool *keylog_done)
 #else
   if(ssl->s3 && session->master_key_length > 0) {
     master_key_length = session->master_key_length;
-    memcpy(master_key, session->master_key, session->master_key_length);
+    memcpy(master_key, session->master_key,
+           (size_t)session->master_key_length);
     memcpy(client_random, ssl->s3->client_random, SSL3_RANDOM_SIZE);
   }
 #endif
@@ -883,7 +890,7 @@ ossl_log_tls12_secret(const SSL *ssl, bool *keylog_done)
 
   *keylog_done = true;
   Curl_tls_keylog_write("CLIENT_RANDOM", client_random,
-                        master_key, master_key_length);
+                        master_key, (size_t)master_key_length);
 }
 #endif /* !HAVE_KEYLOG_CALLBACK */
 
@@ -965,10 +972,10 @@ static int passwd_callback(char *buf, int num, int encrypting,
 {
   DEBUGASSERT(0 == encrypting);
 
-  if(!encrypting) {
+  if(!encrypting && num >= 0) {
     int klen = curlx_uztosi(strlen((char *)global_passwd));
     if(num > klen) {
-      memcpy(buf, global_passwd, klen + 1);
+      memcpy(buf, global_passwd, (size_t)(klen + 1));
       return klen;
     }
   }
@@ -1016,13 +1023,12 @@ static CURLcode ossl_seed(struct Curl_easy *data)
     for(i = 0, i_max = len / sizeof(struct curltime); i < i_max; ++i) {
       struct curltime tv = Curl_now();
       Curl_wait_ms(1);
-      tv.tv_sec *= i + 1;
-      tv.tv_usec *= (unsigned int)i + 2;
-      tv.tv_sec ^= ((Curl_now().tv_sec + Curl_now().tv_usec) *
-                    (i + 3)) << 8;
-      tv.tv_usec ^= (unsigned int) ((Curl_now().tv_sec +
-                                     Curl_now().tv_usec) *
-                                    (i + 4)) << 16;
+      tv.tv_sec *= (time_t)i + 1;
+      tv.tv_usec *= (int)i + 2;
+      tv.tv_sec ^= ((Curl_now().tv_sec + (time_t)Curl_now().tv_usec) *
+                    (time_t)(i + 3)) << 8;
+      tv.tv_usec ^= (int) ((Curl_now().tv_sec + (time_t)Curl_now().tv_usec) *
+                           (time_t)(i + 4)) << 16;
       memcpy(&randb[i * sizeof(struct curltime)], &tv,
              sizeof(struct curltime));
     }
@@ -1889,7 +1895,7 @@ static void ossl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
     if(cf->next && cf->next->connected && !connssl->peer_closed) {
       char buf[1024];
       int nread, err;
-      long sslerr;
+      unsigned long sslerr;
 
       /* Maybe the server has already sent a close notify alert.
          Read it to avoid an RST on the TCP connection. */
@@ -2312,9 +2318,9 @@ CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
         if(ASN1_STRING_type(tmp) == V_ASN1_UTF8STRING) {
           peerlen = ASN1_STRING_length(tmp);
           if(peerlen >= 0) {
-            peer_CN = OPENSSL_malloc(peerlen + 1);
+            peer_CN = OPENSSL_malloc((size_t)(peerlen + 1));
             if(peer_CN) {
-              memcpy(peer_CN, ASN1_STRING_get0_data(tmp), peerlen);
+              memcpy(peer_CN, ASN1_STRING_get0_data(tmp), (size_t)peerlen);
               peer_CN[peerlen] = '\0';
             }
             else
@@ -2342,7 +2348,7 @@ CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
       result = CURLE_PEER_FAILED_VERIFICATION;
     }
     else if(!Curl_cert_hostcheck((const char *)peer_CN,
-                                 peerlen, peer->hostname, hostlen)) {
+                                 (size_t)peerlen, peer->hostname, hostlen)) {
       failf(data, "SSL: certificate subject name '%s' does not match "
             "target host name '%s'", peer_CN, peer->dispname);
       result = CURLE_PEER_FAILED_VERIFICATION;
@@ -2385,7 +2391,7 @@ static CURLcode verifystatus(struct Curl_cfilter *cf,
 
   DEBUGASSERT(octx);
 
-  len = SSL_get_tlsext_status_ocsp_resp(octx->ssl, &status);
+  len = (long)SSL_get_tlsext_status_ocsp_resp(octx->ssl, &status);
 
   if(!status) {
     failf(data, "No OCSP response received");
@@ -2466,7 +2472,7 @@ static CURLcode verifystatus(struct Curl_cfilter *cf,
   }
 
   for(i = 0; i < (int)sk_X509_num(ch); i++) {
-    X509 *issuer = sk_X509_value(ch, i);
+    X509 *issuer = sk_X509_value(ch, (ossl_valsize_t)i);
     if(X509_check_issued(issuer, cert) == X509_V_OK) {
       id = OCSP_cert_to_id(EVP_sha1(), cert, issuer);
       break;
@@ -2811,7 +2817,7 @@ ossl_set_ssl_version_min_max(struct Curl_cfilter *cf, SSL_CTX *ctx)
   }
 
   /* ... then, TLS max version */
-  curl_ssl_version_max = conn_config->version_max;
+  curl_ssl_version_max = (long)conn_config->version_max;
 
   /* convert curl max SSL version option to OpenSSL constant */
   switch(curl_ssl_version_max) {
@@ -3019,7 +3025,7 @@ static CURLcode load_cacert_from_memory(X509_STORE *store,
 
   /* add each entry from PEM file to x509_store */
   for(i = 0; i < (int)sk_X509_INFO_num(inf); ++i) {
-    itmp = sk_X509_INFO_value(inf, i);
+    itmp = sk_X509_INFO_value(inf, (ossl_valsize_t)i);
     if(itmp->x509) {
       if(X509_STORE_add_cert(store, itmp->x509)) {
         ++count;
@@ -3166,7 +3172,7 @@ static CURLcode import_windows_cert_store(struct Curl_easy *data,
       else
         continue;
 
-      x509 = d2i_X509(NULL, &encoded_cert, pContext->cbCertEncoded);
+      x509 = d2i_X509(NULL, &encoded_cert, (long)pContext->cbCertEncoded);
       if(!x509)
         continue;
 
@@ -3642,14 +3648,14 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
 
 #ifdef SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG
   /* mitigate CVE-2010-4180 */
-  ctx_options &= ~SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG;
+  ctx_options &= ~(ctx_option_t)SSL_OP_NETSCAPE_REUSE_CIPHER_CHANGE_BUG;
 #endif
 
 #ifdef SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS
   /* unless the user explicitly asks to allow the protocol vulnerability we
      use the work-around */
   if(!ssl_config->enable_beast)
-    ctx_options &= ~SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
+    ctx_options &= ~(ctx_option_t)SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS;
 #endif
 
   switch(ssl_version) {
@@ -3683,11 +3689,15 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
     return CURLE_SSL_CONNECT_ERROR;
   }
 
+#if (OPENSSL_VERSION_NUMBER >= 0x30000000L)
+  SSL_CTX_set_options(octx->ssl_ctx, (uint64_t)ctx_options);
+#else
   SSL_CTX_set_options(octx->ssl_ctx, ctx_options);
+#endif
 
 #ifdef HAS_ALPN
   if(alpn && alpn_len) {
-    if(SSL_CTX_set_alpn_protos(octx->ssl_ctx, alpn, (int)alpn_len)) {
+    if(SSL_CTX_set_alpn_protos(octx->ssl_ctx, alpn, (unsigned int)alpn_len)) {
       failf(data, "Error setting ALPN");
       return CURLE_SSL_CONNECT_ERROR;
     }
@@ -4026,7 +4036,7 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
 #endif
 
   result = Curl_ossl_ctx_init(octx, cf, data, &connssl->peer, TRNSPRT_TCP,
-                              proto.data, proto.len, NULL, NULL,
+                              proto.data, (size_t)proto.len, NULL, NULL,
                               ossl_new_session_cb, cf);
   if(result)
     return result;
@@ -4417,7 +4427,7 @@ static CURLcode ossl_pkp_pin_peer_pubkey(struct Curl_easy *data, X509* cert,
     if(len1 < 1)
       break; /* failed */
 
-    buff1 = temp = malloc(len1);
+    buff1 = temp = malloc((size_t)len1);
     if(!buff1)
       break; /* failed */
 
@@ -4435,7 +4445,7 @@ static CURLcode ossl_pkp_pin_peer_pubkey(struct Curl_easy *data, X509* cert,
     /* End Gyrations */
 
     /* The one good exit point */
-    result = Curl_pin_peer_pubkey(data, pinnedpubkey, buff1, len1);
+    result = Curl_pin_peer_pubkey(data, pinnedpubkey, buff1, (size_t)len1);
   } while(0);
 
   if(buff1)
@@ -5101,40 +5111,41 @@ static size_t ossl_version(char *buffer, size_t size)
 #ifdef LIBRESSL_VERSION_NUMBER
 #ifdef HAVE_OPENSSL_VERSION
   char *p;
-  int count;
+  size_t count;
   const char *ver = OpenSSL_version(OPENSSL_VERSION);
   const char expected[] = OSSL_PACKAGE " "; /* ie "LibreSSL " */
   if(strncasecompare(ver, expected, sizeof(expected) - 1)) {
     ver += sizeof(expected) - 1;
   }
-  count = msnprintf(buffer, size, "%s/%s", OSSL_PACKAGE, ver);
+  count = (size_t)msnprintf(buffer, size, "%s/%s", OSSL_PACKAGE, ver);
   for(p = buffer; *p; ++p) {
     if(ISBLANK(*p))
       *p = '_';
   }
   return count;
 #else
-  return msnprintf(buffer, size, "%s/%lx.%lx.%lx",
-                   OSSL_PACKAGE,
-                   (LIBRESSL_VERSION_NUMBER>>28)&0xf,
-                   (LIBRESSL_VERSION_NUMBER>>20)&0xff,
-                   (LIBRESSL_VERSION_NUMBER>>12)&0xff);
+  return (size_t)msnprintf(buffer, size, "%s/%lx.%lx.%lx",
+                           OSSL_PACKAGE,
+                           (LIBRESSL_VERSION_NUMBER>>28)&0xf,
+                           (LIBRESSL_VERSION_NUMBER>>20)&0xff,
+                           (LIBRESSL_VERSION_NUMBER>>12)&0xff);
 #endif
 #elif defined(OPENSSL_IS_BORINGSSL)
 #ifdef CURL_BORINGSSL_VERSION
-  return msnprintf(buffer, size, "%s/%s",
-                   OSSL_PACKAGE,
-                   CURL_BORINGSSL_VERSION);
+  return (size_t)msnprintf(buffer, size, "%s/%s",
+                           OSSL_PACKAGE,
+                           CURL_BORINGSSL_VERSION);
 #else
-  return msnprintf(buffer, size, OSSL_PACKAGE);
+  return (size_t)msnprintf(buffer, size, OSSL_PACKAGE);
 #endif
 #elif defined(OPENSSL_IS_AWSLC)
-  return msnprintf(buffer, size, "%s/%s",
-                   OSSL_PACKAGE,
-                   AWSLC_VERSION_NUMBER_STRING);
+  return (size_t)msnprintf(buffer, size, "%s/%s",
+                           OSSL_PACKAGE,
+                           AWSLC_VERSION_NUMBER_STRING);
 #elif defined(HAVE_OPENSSL_VERSION) && defined(OPENSSL_VERSION_STRING)
-  return msnprintf(buffer, size, "%s/%s",
-                   OSSL_PACKAGE, OpenSSL_version(OPENSSL_VERSION_STRING));
+  return (size_t)msnprintf(buffer, size, "%s/%s",
+                           OSSL_PACKAGE,
+                           OpenSSL_version(OPENSSL_VERSION_STRING));
 #else
   /* not LibreSSL, BoringSSL and not using OpenSSL_version */
 
@@ -5163,16 +5174,16 @@ static size_t ossl_version(char *buffer, size_t size)
       sub[0]='\0';
   }
 
-  return msnprintf(buffer, size, "%s/%lx.%lx.%lx%s"
+  return (size_t)msnprintf(buffer, size, "%s/%lx.%lx.%lx%s"
 #ifdef OPENSSL_FIPS
-                   "-fips"
+                           "-fips"
 #endif
-                   ,
-                   OSSL_PACKAGE,
-                   (ssleay_value>>28)&0xf,
-                   (ssleay_value>>20)&0xff,
-                   (ssleay_value>>12)&0xff,
-                   sub);
+                           ,
+                           OSSL_PACKAGE,
+                           (ssleay_value>>28)&0xf,
+                           (ssleay_value>>20)&0xff,
+                           (ssleay_value>>12)&0xff,
+                           sub);
 #endif /* OPENSSL_IS_BORINGSSL */
 }
 
@@ -5190,7 +5201,7 @@ static CURLcode ossl_random(struct Curl_easy *data,
       return CURLE_FAILED_INIT;
   }
   /* RAND_bytes() returns 1 on success, 0 otherwise.  */
-  rc = RAND_bytes(entropy, curlx_uztosi(length));
+  rc = RAND_bytes(entropy, (ossl_valsize_t)curlx_uztosi(length));
   return (rc == 1 ? CURLE_OK : CURLE_FAILED_INIT);
 }
 

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -100,7 +100,7 @@ read_cb(void *userdata, uint8_t *buf, uintptr_t len, uintptr_t *out_n)
   }
   else if(nread == 0)
     connssl->peer_closed = TRUE;
-  *out_n = (int)nread;
+  *out_n = (uintptr_t)nread;
   return ret;
 }
 
@@ -119,10 +119,10 @@ write_cb(void *userdata, const uint8_t *buf, uintptr_t len, uintptr_t *out_n)
     else
       ret = EINVAL;
   }
-  *out_n = (int)nwritten;
+  *out_n = (uintptr_t)nwritten;
   /*
   CURL_TRC_CFX(io_ctx->data, io_ctx->cf, "cf->next send(len=%zu) -> %zd, %d",
-                len, nwritten, result));
+               len, nwritten, result));
   */
   return ret;
 }
@@ -341,7 +341,7 @@ cr_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     tlswritten_total += tlswritten;
   }
 
-  return plainwritten;
+  return (ssize_t)plainwritten;
 }
 
 /* A server certificate verify callback for rustls that always returns
@@ -389,7 +389,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
   const char *hostname = connssl->peer.hostname;
   char errorbuf[256];
   size_t errorlen;
-  int result;
+  rustls_result result;
 
   DEBUGASSERT(backend);
   rconn = backend->conn;
@@ -714,7 +714,7 @@ cr_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 static size_t cr_version(char *buffer, size_t size)
 {
   struct rustls_str ver = rustls_version();
-  return msnprintf(buffer, size, "%.*s", (int)ver.len, ver.data);
+  return (size_t)msnprintf(buffer, size, "%.*s", (int)ver.len, ver.data);
 }
 
 const struct Curl_ssl Curl_ssl_rustls = {

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -118,7 +118,7 @@ static CURLcode add_certs_data_to_store(HCERTSTORE trust_store,
 
   while(more_certs && (current_ca_file_ptr<ca_buffer_limit)) {
     const char *begin_cert_ptr = c_memmem(current_ca_file_ptr,
-                                          ca_buffer_limit-current_ca_file_ptr,
+                               (size_t)(ca_buffer_limit - current_ca_file_ptr),
                                           BEGIN_CERT,
                                           begin_cert_len);
     if(!begin_cert_ptr || !is_cr_or_lf(begin_cert_ptr[begin_cert_len])) {
@@ -126,7 +126,7 @@ static CURLcode add_certs_data_to_store(HCERTSTORE trust_store,
     }
     else {
       const char *end_cert_ptr = c_memmem(begin_cert_ptr,
-                                          ca_buffer_limit-begin_cert_ptr,
+                                    (size_t)(ca_buffer_limit - begin_cert_ptr),
                                           END_CERT,
                                           end_cert_len);
       if(!end_cert_ptr) {
@@ -448,7 +448,7 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
     /* pwszDNSName is in ia5 string format and hence doesn't contain any
      * non-ascii characters. */
     while(*dns_w != '\0') {
-      *current_pos++ = (char)(*dns_w++);
+      *current_pos++ = (TCHAR)(*dns_w++);
     }
     *current_pos++ = '\0';
     actual_length += (DWORD)current_length;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -868,7 +868,7 @@ static OSStatus sectransp_bio_cf_in_read(SSLConnectionRef connection,
   else if((size_t)nread < *dataLength) {
     rtn = errSSLWouldBlock;
   }
-  *dataLength = nread;
+  *dataLength = (size_t)nread;
   return rtn;
 }
 
@@ -902,7 +902,7 @@ static OSStatus sectransp_bio_cf_out_write(SSLConnectionRef connection,
   else if((size_t)nwritten < *dataLength) {
     rtn = errSSLWouldBlock;
   }
-  *dataLength = nwritten;
+  *dataLength = (size_t)nwritten;
   return rtn;
 }
 
@@ -1015,7 +1015,7 @@ static CURLcode CopyCertSubject(struct Curl_easy *data,
     size_t cbuf_size = ((size_t)CFStringGetLength(c) * 4) + 1;
     cbuf = calloc(1, cbuf_size);
     if(cbuf) {
-      if(!CFStringGetCString(c, cbuf, cbuf_size,
+      if(!CFStringGetCString(c, cbuf, (CFIndex)cbuf_size,
                              kCFStringEncodingUTF8)) {
         failf(data, "SSL: invalid CA certificate subject");
         result = CURLE_PEER_FAILED_VERIFICATION;
@@ -1194,7 +1194,8 @@ static OSStatus CopyIdentityFromPKCS12File(const char *cPath,
 
   if(blob) {
     pkcs_data = CFDataCreate(kCFAllocatorDefault,
-                             (const unsigned char *)blob->data, blob->len);
+                             (const unsigned char *)blob->data,
+                             (CFIndex)blob->len);
     status = (pkcs_data != NULL) ? errSecSuccess : errSecAllocate;
     resource_imported = (pkcs_data != NULL);
   }
@@ -1202,7 +1203,7 @@ static OSStatus CopyIdentityFromPKCS12File(const char *cPath,
     pkcs_url =
       CFURLCreateFromFileSystemRepresentation(NULL,
                                               (const UInt8 *)cPath,
-                                              strlen(cPath), false);
+                                              (CFIndex)strlen(cPath), false);
     resource_imported =
       CFURLCreateDataAndPropertiesFromResource(NULL,
                                                pkcs_url, &pkcs_data,
@@ -1581,7 +1582,7 @@ static CURLcode sectransp_set_selected_ciphers(struct Curl_easy *data,
     }
     /* Iterate through the cipher table and look for the cipher, starting
        the cipher number 0x01 because the 0x00 is not the real cipher */
-    cipher_len = cipher_end - cipher_start;
+    cipher_len = (size_t)(cipher_end - cipher_start);
     for(i = 1; i < NUM_OF_CIPHERS; ++i) {
       const char *table_cipher_name = NULL;
       if(tls_name) {
@@ -1665,6 +1666,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
   const struct curl_blob *ssl_cert_blob = ssl_config->primary.cert_blob;
   char *ciphers;
   OSStatus err = noErr;
+  CURLcode result;
 #if CURL_BUILD_MAC
   int darwinver_maj = 0, darwinver_min = 0;
 
@@ -1730,12 +1732,10 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
     case CURL_SSLVERSION_TLSv1_1:
     case CURL_SSLVERSION_TLSv1_2:
     case CURL_SSLVERSION_TLSv1_3:
-      {
-        CURLcode result = set_ssl_version_min_max(cf, data);
-        if(result != CURLE_OK)
-          return result;
-        break;
-      }
+      result = set_ssl_version_min_max(cf, data);
+      if(result != CURLE_OK)
+        return result;
+      break;
     case CURL_SSLVERSION_SSLv3:
     case CURL_SSLVERSION_SSLv2:
       failf(data, "SSL versions not supported");
@@ -1767,12 +1767,10 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
     case CURL_SSLVERSION_TLSv1_1:
     case CURL_SSLVERSION_TLSv1_2:
     case CURL_SSLVERSION_TLSv1_3:
-      {
-        CURLcode result = set_ssl_version_min_max(cf, data);
-        if(result != CURLE_OK)
-          return result;
-        break;
-      }
+      result = set_ssl_version_min_max(cf, data);
+      if(result != CURLE_OK)
+        return result;
+      break;
     case CURL_SSLVERSION_SSLv3:
     case CURL_SSLVERSION_SSLv2:
       failf(data, "SSL versions not supported");
@@ -1886,7 +1884,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
       err = SecIdentityCopyCertificate(cert_and_key, &cert);
       if(err == noErr) {
         char *certp;
-        CURLcode result = CopyCertSubject(data, cert, &certp);
+        result = CopyCertSubject(data, cert, &certp);
         if(!result) {
           infof(data, "Client certificate: %s", certp);
           free(certp);
@@ -2031,14 +2029,14 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
 
   ciphers = conn_config->cipher_list;
   if(ciphers) {
-    err = sectransp_set_selected_ciphers(data, backend->ssl_ctx, ciphers);
+    result = sectransp_set_selected_ciphers(data, backend->ssl_ctx, ciphers);
   }
   else {
-    err = sectransp_set_default_ciphers(data, backend->ssl_ctx);
+    result = sectransp_set_default_ciphers(data, backend->ssl_ctx);
   }
-  if(err != noErr) {
+  if(result != CURLE_OK) {
     failf(data, "SSL: Unable to set ciphers for SSL/TLS handshake. "
-          "Error code: %d", err);
+          "Error code: %d", (int)result);
     return CURLE_SSL_CIPHER;
   }
 
@@ -2074,7 +2072,6 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
     /* If there isn't one, then let's make one up! This has to be done prior
        to starting the handshake. */
     else {
-      CURLcode result;
       ssl_sessionid =
         aprintf("%s:%d:%d:%s:%d",
                 ssl_cafile ? ssl_cafile : "(blob memory)",
@@ -2121,7 +2118,7 @@ static long pem_to_der(const char *in, unsigned char **out, size_t *outlen)
   char *sep_start, *sep_end, *cert_start, *cert_end;
   size_t i, j, err;
   size_t len;
-  unsigned char *b64;
+  char *b64;
 
   /* Jump through the separators at the beginning of the certificate. */
   sep_start = strstr(in, "-----");
@@ -2143,7 +2140,7 @@ static long pem_to_der(const char *in, unsigned char **out, size_t *outlen)
     return -1;
   sep_end += 5;
 
-  len = cert_end - cert_start;
+  len = (size_t)(cert_end - cert_start);
   b64 = malloc(len + 1);
   if(!b64)
     return -1;
@@ -2189,7 +2186,7 @@ static int read_cert(const char *file, unsigned char **out, size_t *outlen)
       Curl_dyn_free(&certs);
       return -1;
     }
-    if(Curl_dyn_addn(&certs, buf, n)) {
+    if(Curl_dyn_addn(&certs, buf, (size_t)n)) {
       close(fd);
       return -1;
     }
@@ -2202,16 +2199,16 @@ static int read_cert(const char *file, unsigned char **out, size_t *outlen)
   return 0;
 }
 
-static int append_cert_to_array(struct Curl_easy *data,
-                                const unsigned char *buf, size_t buflen,
-                                CFMutableArrayRef array)
+static CURLcode append_cert_to_array(struct Curl_easy *data,
+                                     const unsigned char *buf, size_t buflen,
+                                     CFMutableArrayRef array)
 {
     char *certp;
     CURLcode result;
     SecCertificateRef cacert;
     CFDataRef certdata;
 
-    certdata = CFDataCreate(kCFAllocatorDefault, buf, buflen);
+    certdata = CFDataCreate(kCFAllocatorDefault, buf, (CFIndex)buflen);
     if(!certdata) {
       failf(data, "SSL: failed to allocate array for CA certificate");
       return CURLE_OUT_OF_MEMORY;
@@ -2248,7 +2245,8 @@ static CURLcode verify_cert_buf(struct Curl_cfilter *cf,
                                 const unsigned char *certbuf, size_t buflen,
                                 SSLContextRef ctx)
 {
-  int n = 0, rc;
+  int n = 0;
+  CURLcode rc;
   long res;
   unsigned char *der;
   size_t derlen, offset = 0;
@@ -2288,7 +2286,7 @@ static CURLcode verify_cert_buf(struct Curl_cfilter *cf,
       result = CURLE_SSL_CACERT_BADFILE;
       goto out;
     }
-    offset += res;
+    offset += (size_t)res;
 
     if(res == 0 && offset == 0) {
       /* This is not a PEM file, probably a certificate in DER format. */
@@ -2451,17 +2449,17 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
 #elif SECTRANSP_PINNEDPUBKEY_V2
 
     {
-        OSStatus success;
-        success = SecItemExport(keyRef, kSecFormatOpenSSL, 0, NULL,
-                                &publicKeyBits);
-        CFRelease(keyRef);
-        if(success != errSecSuccess || !publicKeyBits)
-          break;
+      OSStatus success;
+      success = SecItemExport(keyRef, kSecFormatOpenSSL, 0, NULL,
+                              &publicKeyBits);
+      CFRelease(keyRef);
+      if(success != errSecSuccess || !publicKeyBits)
+        break;
     }
 
 #endif /* SECTRANSP_PINNEDPUBKEY_V2 */
 
-    pubkeylen = CFDataGetLength(publicKeyBits);
+    pubkeylen = (size_t)CFDataGetLength(publicKeyBits);
     pubkey = (unsigned char *)CFDataGetBytePtr(publicKeyBits);
 
     switch(pubkeylen) {
@@ -3238,7 +3236,7 @@ static int sectransp_shutdown(struct Curl_cfilter *cf,
 
 static size_t sectransp_version(char *buffer, size_t size)
 {
-  return msnprintf(buffer, size, "SecureTransport");
+  return (size_t)msnprintf(buffer, size, "SecureTransport");
 }
 
 static bool sectransp_data_pending(struct Curl_cfilter *cf,

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -946,7 +946,7 @@ static CURLcode pubkey_pem_to_der(const char *pem,
   if(!begin_pos)
     return CURLE_BAD_CONTENT_ENCODING;
 
-  pem_count = begin_pos - pem;
+  pem_count = (size_t)(begin_pos - pem);
   /* Invalid if not at beginning AND not directly following \n */
   if(0 != pem_count && '\n' != pem[pem_count - 1])
     return CURLE_BAD_CONTENT_ENCODING;
@@ -959,7 +959,7 @@ static CURLcode pubkey_pem_to_der(const char *pem,
   if(!end_pos)
     return CURLE_BAD_CONTENT_ENCODING;
 
-  pem_len = end_pos - pem;
+  pem_len = (size_t)(end_pos - pem);
 
   stripped_pem = malloc(pem_len - pem_count + 1);
   if(!stripped_pem)
@@ -1418,12 +1418,13 @@ static size_t multissl_version(char *buffer, size_t size)
       bool paren = (selected != available_backends[i]);
 
       if(available_backends[i]->version(vb, sizeof(vb))) {
-        p += msnprintf(p, end - p, "%s%s%s%s", (p != backends ? " " : ""),
+        p += msnprintf(p, (size_t)(end - p), "%s%s%s%s",
+                       (p != backends ? " " : ""),
                        (paren ? "(" : ""), vb, (paren ? ")" : ""));
       }
     }
 
-    backends_len = p - backends;
+    backends_len = (size_t)(p - backends);
   }
 
   if(size) {
@@ -1983,10 +1984,10 @@ CURLcode Curl_cf_ssl_proxy_insert_after(struct Curl_cfilter *cf_at,
 
 #endif /* !CURL_DISABLE_PROXY */
 
-bool Curl_ssl_supports(struct Curl_easy *data, int option)
+bool Curl_ssl_supports(struct Curl_easy *data, unsigned int ssl_option)
 {
   (void)data;
-  return (Curl_ssl->supports & option)? TRUE : FALSE;
+  return (Curl_ssl->supports & ssl_option)? TRUE : FALSE;
 }
 
 static struct Curl_cfilter *get_ssl_filter(struct Curl_cfilter *cf)

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -205,7 +205,7 @@ CURLcode Curl_cf_ssl_proxy_insert_after(struct Curl_cfilter *cf_at,
  * Option is one of the defined SSLSUPP_* values.
  * `data` maybe NULL for the features of the default implementation.
  */
-bool Curl_ssl_supports(struct Curl_easy *data, int ssl_option);
+bool Curl_ssl_supports(struct Curl_easy *data, unsigned int ssl_option);
 
 /**
  * Get the internal ssl instance (like OpenSSL's SSL*) from the filter

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -956,7 +956,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
       if(ssl_push_certinfo(data, certnum, "ECC Public Key", q))
         return 1;
     }
-    return do_pubkey_field(data, certnum, "ecPublicKey", pubkey);
+    return (int)do_pubkey_field(data, certnum, "ecPublicKey", pubkey);
   }
 
   /* Get the public key (single element). */

--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -551,7 +551,7 @@ UNITTEST_START
       abort_if(i == TEST_STR_LIST_LEN, "should have been done");
 
       id = Curl_cipher_suite_walk_str(&ptr, &end);
-      len = end - ptr;
+      len = (size_t)(end - ptr);
 
       if(id != test->id) {
         fprintf(stderr, "Curl_cipher_suite_walk_str FAILED for \"%s\" "


### PR DESCRIPTION
`lib/v*` building without signedness warnings after this PR.

Also:
- openssl: fix `ctx_option_t` type for openssl 1.1.x.
- openssl: add three missing negative checks.
- sectransp: fix `CURLcode`/`OSStatus` mix-up.
- gtls: add FIXMEs to `Curl_gtls_verifyserver()`.

Cherry-picked from #13489
Follow-up to 3829759bd042c03225ae862062560f568ba1a231 #12489
Closes #13472
