### PR TITLE
Python PEP-0668 fallout

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -121,8 +121,8 @@ jobs:
             configure: CC=gcc-12 --enable-debug --with-secure-transport --enable-websockets --without-libpsl
             macosx-version-min: 10.8
           - name: OpenSSL http2
-            install: nghttp2 openssl
-            configure: --enable-debug --with-openssl=$BREW/opt/openssl --enable-websockets
+            install: nghttp2 openssl@3
+            configure: --enable-debug --with-openssl=$BREW/opt/openssl@3 --enable-websockets
             macosx-version-min: 10.9
           - name: LibreSSL http2
             install: nghttp2 libressl

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -142,7 +142,7 @@ jobs:
             configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
-      - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+      - run: echo libtool gm4 autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
 
       # Run this command with retries because of spurious failures seen
@@ -162,7 +162,10 @@ jobs:
           esac
         name: 'brew unlink openssl'
 
-      - run: python3 -m pip install --break-system-packages impacket
+      - run: |
+          python3 -m venv $HOME/venv
+          source $HOME/venv/bin/activate
+          python3 -m pip install impacket
         name: 'pip3 install'
 
       - uses: actions/checkout@v4

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -67,11 +67,11 @@ jobs:
             macosx-version-min: 10.9
           - name: libssh-c-ares
             install: openssl nghttp2 libssh
-            configure: --enable-debug --with-libssh --with-openssl=${{ env.BREW }}/opt/openssl --enable-ares --enable-websockets
+            configure: --enable-debug --with-libssh --with-openssl=$BREW/opt/openssl --enable-ares --enable-websockets
             macosx-version-min: 10.9
           - name: libssh
             install: openssl nghttp2 libssh
-            configure: --enable-debug --with-libssh --with-openssl=${{ env.BREW }}/opt/openssl --enable-websockets
+            configure: --enable-debug --with-libssh --with-openssl=$BREW/opt/openssl --enable-websockets
             macosx-version-min: 10.9
           - name: c-ares
             install: nghttp2
@@ -126,21 +126,21 @@ jobs:
             macosx-version-min: 10.9
           - name: LibreSSL http2
             install: nghttp2 libressl
-            configure: --enable-debug --with-openssl=${{ env.BREW }}/opt/libressl --enable-websockets
+            configure: --enable-debug --with-openssl=$BREW/opt/libressl --enable-websockets
             macosx-version-min: 10.9
           - name: torture
             install: nghttp2 openssl
-            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=${{ env.BREW }}/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=$BREW/opt/openssl --enable-websockets
             tflags: -n -t --shallow=25 !FTP
             macosx-version-min: 10.9
           - name: torture-ftp
             install: nghttp2 openssl
-            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=${{ env.BREW }}/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=$BREW/opt/openssl --enable-websockets
             tflags: -n -t --shallow=20 FTP
             macosx-version-min: 10.9
           - name: macOS 10.15
             install: nghttp2 libssh2 openssl
-            configure: --enable-debug --disable-ldap --with-openssl=${{ env.BREW }}/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-ldap --with-openssl=$BREW/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
       - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
@@ -157,7 +157,7 @@ jobs:
             *openssl*)
               ;;
             *)
-              if test -d ${{ env.BREW }}/include/openssl; then
+              if test -d $BREW/include/openssl; then
                 brew unlink openssl
               fi;;
           esac
@@ -213,16 +213,16 @@ jobs:
         build:
           - name: OpenSSL
             install: nghttp2 openssl
-            generate: -DOPENSSL_ROOT_DIR=${{ env.BREW }}/opt/openssl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
+            generate: -DOPENSSL_ROOT_DIR=$BREW/opt/openssl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
           - name: LibreSSL
             install: nghttp2 libressl
-            generate: -DOPENSSL_ROOT_DIR=${{ env.BREW }}/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
+            generate: -DOPENSSL_ROOT_DIR=$BREW/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
           - name: libssh2
             install: nghttp2 openssl libssh2
-            generate: -DOPENSSL_ROOT_DIR=${{ env.BREW }}/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
+            generate: -DOPENSSL_ROOT_DIR=$BREW/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
           - name: GnuTLS
             install: gnutls
-            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_SHARED_LINKER_FLAGS=-L${{ env.BREW }}/lib -DCMAKE_EXE_LINKER_FLAGS=-L${{ env.BREW }}/lib
+            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_SHARED_LINKER_FLAGS=-L$BREW/lib -DCMAKE_EXE_LINKER_FLAGS=-L$BREW/lib
     steps:
       - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
@@ -235,7 +235,7 @@ jobs:
             *openssl*)
               ;;
             *)
-              if test -d ${{ env.BREW }}/include/openssl; then
+              if test -d $BREW/include/openssl; then
                 brew unlink openssl
               fi;;
           esac

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -175,6 +175,8 @@ jobs:
 
       - run: autoreconf -fi
         name: 'autoreconf'
+        env:
+          M4: "/usr/local/opt/m4/bin/m4"
 
       - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -162,10 +162,7 @@ jobs:
           esac
         name: 'brew unlink openssl'
 
-      - run: |
-          python3 -m venv $HOME/pyenv
-          source $HOME/pyenv/bin/activate
-          python3 -m pip install impacket
+      - run: python3 -m pip install --break-system-packages impacket
         name: 'pip3 install'
 
       - uses: actions/checkout@v4
@@ -190,9 +187,7 @@ jobs:
       - run: make V=1 -C tests
         name: 'make tests'
 
-      - run: |
-          source $HOME/pyenv/bin/activate
-          make V=1 test-ci
+      - run: make V=1 test-ci
         name: 'run tests'
         env:
           TFLAGS: "${{ matrix.build.tflags }} ~1452"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -142,7 +142,7 @@ jobs:
             configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
-      - run: echo m4 libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+      - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
 
       # Run this command with retries because of spurious failures seen
@@ -175,10 +175,11 @@ jobs:
 
       - run: |
           type -a m4
-          ls /usr/local/opt/
-          ls /usr/local/opt/m4
+          m4 --version
           autoreconf -fi
         name: 'autoreconf'
+        env:
+          M4: "/usr/bin/m4"
 
       - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,7 +40,7 @@ concurrency:
 permissions: {}
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_14.0.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
   MAKEFLAGS: -j 5
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -142,9 +142,6 @@ jobs:
             configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
-      - run: sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
-        name: xcode select
-
       - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
 
@@ -155,6 +152,7 @@ jobs:
         name: 'brew install'
 
       - run: |
+          which brew
           case "${{ matrix.build.install }}" in
             *openssl*)
               ;;
@@ -176,14 +174,8 @@ jobs:
       - run: rm -f $HOME/.curlrc
         name: remove $HOME/.curlrc
 
-      - run: |
-          type -a m4
-          ls -l /Applications
-          m4 --version
-          autoreconf -fi
+      - run: autoreconf -fi
         name: 'autoreconf'
-        env:
-          DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
 
       - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -173,7 +173,9 @@ jobs:
       - run: rm -f $HOME/.curlrc
         name: remove $HOME/.curlrc
 
-      - run: autoreconf -fi
+      - run: |
+          /usr/local/opt/m4/bin/m4 --version
+          autoreconf -fi
         name: 'autoreconf'
         env:
           M4: "/usr/local/opt/m4/bin/m4"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -162,7 +162,10 @@ jobs:
           esac
         name: 'brew unlink openssl'
 
-      - run: python3 -m pip install impacket
+      - run: |
+          python3 -m venv $HOME/pyenv
+          source $HOME/pyenv/bin/activate
+          python3 -m pip install impacket
         name: 'pip3 install'
 
       - uses: actions/checkout@v4
@@ -187,7 +190,9 @@ jobs:
       - run: make V=1 -C tests
         name: 'make tests'
 
-      - run: make V=1 test-ci
+      - run: |
+          source $HOME/pyenv/bin/activate
+          make V=1 test-ci
         name: 'run tests'
         env:
           TFLAGS: "${{ matrix.build.tflags }} ~1452"

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -142,7 +142,7 @@ jobs:
             configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
-      - run: echo libtool m4 autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+      - run: echo m4 libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
 
       # Run this command with retries because of spurious failures seen

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,6 +42,7 @@ permissions: {}
 env:
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
   MAKEFLAGS: -j 5
+  BREW: /opt/homebrew
 
 jobs:
   autotools:
@@ -66,11 +67,11 @@ jobs:
             macosx-version-min: 10.9
           - name: libssh-c-ares
             install: openssl nghttp2 libssh
-            configure: --enable-debug --with-libssh --with-openssl=/usr/local/opt/openssl --enable-ares --enable-websockets
+            configure: --enable-debug --with-libssh --with-openssl=$BREW/opt/openssl --enable-ares --enable-websockets
             macosx-version-min: 10.9
           - name: libssh
             install: openssl nghttp2 libssh
-            configure: --enable-debug --with-libssh --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --with-libssh --with-openssl=$BREW/opt/openssl --enable-websockets
             macosx-version-min: 10.9
           - name: c-ares
             install: nghttp2
@@ -121,25 +122,25 @@ jobs:
             macosx-version-min: 10.8
           - name: OpenSSL http2
             install: nghttp2 openssl
-            configure: --enable-debug --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --with-openssl=$BREW/opt/openssl --enable-websockets
             macosx-version-min: 10.9
           - name: LibreSSL http2
             install: nghttp2 libressl
-            configure: --enable-debug --with-openssl=/usr/local/opt/libressl --enable-websockets
+            configure: --enable-debug --with-openssl=$BREW/opt/libressl --enable-websockets
             macosx-version-min: 10.9
           - name: torture
             install: nghttp2 openssl
-            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=$BREW/opt/openssl --enable-websockets
             tflags: -n -t --shallow=25 !FTP
             macosx-version-min: 10.9
           - name: torture-ftp
             install: nghttp2 openssl
-            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=$BREW/opt/openssl --enable-websockets
             tflags: -n -t --shallow=20 FTP
             macosx-version-min: 10.9
           - name: macOS 10.15
             install: nghttp2 libssh2 openssl
-            configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-ldap --with-openssl=$BREW/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
       - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
@@ -157,7 +158,7 @@ jobs:
             *openssl*)
               ;;
             *)
-              if test -d /usr/local/include/openssl; then
+              if test -d $BREW/include/openssl; then
                 brew unlink openssl
               fi;;
           esac
@@ -213,16 +214,16 @@ jobs:
         build:
           - name: OpenSSL
             install: nghttp2 openssl
-            generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
+            generate: -DOPENSSL_ROOT_DIR=$BREW/opt/openssl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
           - name: LibreSSL
             install: nghttp2 libressl
-            generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
+            generate: -DOPENSSL_ROOT_DIR=$BREW/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
           - name: libssh2
             install: nghttp2 openssl libssh2
-            generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
+            generate: -DOPENSSL_ROOT_DIR=$BREW/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
           - name: GnuTLS
             install: gnutls
-            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_SHARED_LINKER_FLAGS=-L/usr/local/lib -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/lib
+            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_SHARED_LINKER_FLAGS=-L$BREW/lib -DCMAKE_EXE_LINKER_FLAGS=-L$BREW/lib
     steps:
       - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
@@ -235,7 +236,7 @@ jobs:
             *openssl*)
               ;;
             *)
-              if test -d /usr/local/include/openssl; then
+              if test -d $BREW/include/openssl; then
                 brew unlink openssl
               fi;;
           esac

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -155,10 +155,14 @@ jobs:
       - run: |
           case "${{ matrix.build.install }}" in
             *openssl*)
-              ls -l $BREW/opt/openssl
-              ls -l $BREW/opt/openssl/lib
-              ls -l $BREW/opt/openssl/lib/pkgconfig
-              cat $BREW/opt/openssl/lib/pkgconfig/libssl.pc
+              (
+                cd $BREW/opt/openssl/lib/pkgconfig/
+                for i in libssl.pc libcrypto.pc; do
+                  cp $i $i.orig
+                  sed 's,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0$,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0/lib,g' < $i.orig > $i
+                  cat $i
+                done
+              )
               ;;
             *)
               if test -d $BREW/include/openssl; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -142,7 +142,7 @@ jobs:
             configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
-      - run: xcode-select -switch /Applications/Xcode.app/Contents/Developer
+      - run: sudo xcode-select -switch /Applications/Xcode.app/Contents/Developer
         name: xcode select
 
       - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -142,7 +142,7 @@ jobs:
             configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
-      - run: echo libtool gm4 autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+      - run: echo libtool m4 autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
 
       # Run this command with retries because of spurious failures seen

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -122,7 +122,7 @@ jobs:
             macosx-version-min: 10.8
           - name: OpenSSL http2
             install: nghttp2 openssl@3
-            configure: --enable-debug --with-openssl=$BREW/opt/openssl@3 --enable-websockets
+            configure: --enable-debug --with-openssl=$BREW/opt/openssl --enable-websockets
             macosx-version-min: 10.9
           - name: LibreSSL http2
             install: nghttp2 libressl
@@ -153,7 +153,8 @@ jobs:
         name: 'brew install'
 
       - run: |
-          which brew
+          ls -l $BREW/opt/
+          ls -l $BREW/opt/openssl/
           case "${{ matrix.build.install }}" in
             *openssl*)
               ;;

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -158,8 +158,8 @@ jobs:
               (
                 cd $BREW/opt/openssl/lib/pkgconfig/
                 for i in libssl.pc libcrypto.pc; do
-                  cp $i $i.orig
-                  sed 's,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0$,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0/lib,g' < $i.orig > $i
+                  sudo cp $i $i.orig
+                  sudo sed 's,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0$,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0/lib,g' < $i.orig > $i
                   cat $i
                 done
               )

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -178,11 +178,12 @@ jobs:
 
       - run: |
           type -a m4
+          ls -l /Applications
           m4 --version
           autoreconf -fi
         name: 'autoreconf'
         env:
-          M4: "/usr/bin/m4"
+          DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
 
       - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -63,7 +63,7 @@ jobs:
             macosx-version-min: 10.9
           - name: libssh2
             install: nghttp2 libssh2
-            configure: --enable-debug --with-libssh2 --without-ssl --enable-websockets
+            configure: --enable-debug --with-libssh2=$BREW/opt/libssh2 --without-ssl --enable-websockets
             macosx-version-min: 10.9
           - name: libssh-c-ares
             install: openssl nghttp2 libssh
@@ -117,9 +117,10 @@ jobs:
             install: nghttp2
             configure: --enable-debug --with-secure-transport --enable-websockets
             macosx-version-min: 10.8
-          - name: gcc SecureTransport
-            configure: CC=gcc-12 --enable-debug --with-secure-transport --enable-websockets --without-libpsl
-            macosx-version-min: 10.8
+          # Fails now with linker errors on missing symbols
+          # - name: gcc SecureTransport
+          #  configure: CC=gcc-12 --enable-debug --with-secure-transport --enable-websockets --without-libpsl
+          #  macosx-version-min: 10.8
           - name: OpenSSL http2
             install: nghttp2 openssl
             configure: --enable-debug --with-openssl=$BREW/opt/openssl --enable-websockets

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -67,11 +67,11 @@ jobs:
             macosx-version-min: 10.9
           - name: libssh-c-ares
             install: openssl nghttp2 libssh
-            configure: --enable-debug --with-libssh --with-openssl=$BREW/opt/openssl --enable-ares --enable-websockets
+            configure: --enable-debug --with-libssh --with-openssl=${{ env.BREW }}/opt/openssl --enable-ares --enable-websockets
             macosx-version-min: 10.9
           - name: libssh
             install: openssl nghttp2 libssh
-            configure: --enable-debug --with-libssh --with-openssl=$BREW/opt/openssl --enable-websockets
+            configure: --enable-debug --with-libssh --with-openssl=${{ env.BREW }}/opt/openssl --enable-websockets
             macosx-version-min: 10.9
           - name: c-ares
             install: nghttp2
@@ -121,26 +121,26 @@ jobs:
             configure: CC=gcc-12 --enable-debug --with-secure-transport --enable-websockets --without-libpsl
             macosx-version-min: 10.8
           - name: OpenSSL http2
-            install: nghttp2 openssl@3
-            configure: --enable-debug --with-openssl=$BREW/opt/openssl --enable-websockets
+            install: nghttp2 openssl
+            configure: --enable-debug --with-openssl=/opt/homebrew/opt/openssl --enable-websockets
             macosx-version-min: 10.9
           - name: LibreSSL http2
             install: nghttp2 libressl
-            configure: --enable-debug --with-openssl=$BREW/opt/libressl --enable-websockets
+            configure: --enable-debug --with-openssl=${{ env.BREW }}/opt/libressl --enable-websockets
             macosx-version-min: 10.9
           - name: torture
             install: nghttp2 openssl
-            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=$BREW/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=${{ env.BREW }}/opt/openssl --enable-websockets
             tflags: -n -t --shallow=25 !FTP
             macosx-version-min: 10.9
           - name: torture-ftp
             install: nghttp2 openssl
-            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=$BREW/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=${{ env.BREW }}/opt/openssl --enable-websockets
             tflags: -n -t --shallow=20 FTP
             macosx-version-min: 10.9
           - name: macOS 10.15
             install: nghttp2 libssh2 openssl
-            configure: --enable-debug --disable-ldap --with-openssl=$BREW/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-ldap --with-openssl=${{ env.BREW }}/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
       - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
@@ -153,13 +153,11 @@ jobs:
         name: 'brew install'
 
       - run: |
-          ls -l $BREW/opt/
-          ls -l $BREW/opt/openssl/
           case "${{ matrix.build.install }}" in
             *openssl*)
               ;;
             *)
-              if test -d $BREW/include/openssl; then
+              if test -d ${{ env.BREW }}/include/openssl; then
                 brew unlink openssl
               fi;;
           esac
@@ -215,16 +213,16 @@ jobs:
         build:
           - name: OpenSSL
             install: nghttp2 openssl
-            generate: -DOPENSSL_ROOT_DIR=$BREW/opt/openssl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
+            generate: -DOPENSSL_ROOT_DIR=${{ env.BREW }}/opt/openssl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
           - name: LibreSSL
             install: nghttp2 libressl
-            generate: -DOPENSSL_ROOT_DIR=$BREW/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
+            generate: -DOPENSSL_ROOT_DIR=${{ env.BREW }}/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
           - name: libssh2
             install: nghttp2 openssl libssh2
-            generate: -DOPENSSL_ROOT_DIR=$BREW/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
+            generate: -DOPENSSL_ROOT_DIR=${{ env.BREW }}/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
           - name: GnuTLS
             install: gnutls
-            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_SHARED_LINKER_FLAGS=-L$BREW/lib -DCMAKE_EXE_LINKER_FLAGS=-L$BREW/lib
+            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_SHARED_LINKER_FLAGS=-L${{ env.BREW }}/lib -DCMAKE_EXE_LINKER_FLAGS=-L${{ env.BREW }}/lib
     steps:
       - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
@@ -237,7 +235,7 @@ jobs:
             *openssl*)
               ;;
             *)
-              if test -d $BREW/include/openssl; then
+              if test -d ${{ env.BREW }}/include/openssl; then
                 brew unlink openssl
               fi;;
           esac

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -142,6 +142,9 @@ jobs:
             configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
+      - run: xcode-select -switch /Applications/Xcode.app/Contents/Developer
+        name: xcode select
+
       - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -122,7 +122,7 @@ jobs:
             macosx-version-min: 10.8
           - name: OpenSSL http2
             install: nghttp2 openssl
-            configure: --enable-debug --with-openssl=/opt/homebrew/opt/openssl --enable-websockets
+            configure: --enable-debug --with-openssl=$BREW/opt/openssl --enable-websockets
             macosx-version-min: 10.9
           - name: LibreSSL http2
             install: nghttp2 libressl
@@ -155,6 +155,10 @@ jobs:
       - run: |
           case "${{ matrix.build.install }}" in
             *openssl*)
+              ls -l $BREW/opt/openssl
+              ls -l $BREW/opt/openssl/lib
+              ls -l $BREW/opt/openssl/lib/pkgconfig
+              cat $BREW/opt/openssl/lib/pkgconfig/libssl.pc
               ;;
             *)
               if test -d $BREW/include/openssl; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -174,11 +174,11 @@ jobs:
         name: remove $HOME/.curlrc
 
       - run: |
-          /usr/local/opt/m4/bin/m4 --version
+          type -a m4
+          ls /usr/local/opt/
+          ls /usr/local/opt/m4
           autoreconf -fi
         name: 'autoreconf'
-        env:
-          M4: "/usr/local/opt/m4/bin/m4"
 
       - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -159,7 +159,8 @@ jobs:
                 cd $BREW/opt/openssl/lib/pkgconfig/
                 for i in libssl.pc libcrypto.pc; do
                   sudo cp $i $i.orig
-                  sudo sed 's,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0$,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0/lib,g' < $i.orig > $i
+                  sudo sed 's,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0$,libdir=/opt/homebrew/Cellar/openssl@3/3.3.0/lib,g' < $i.orig > /tmp/$i
+                  sudo cp /tmp/$i $i
                   cat $i
                 done
               )

--- a/xxx.pc
+++ b/xxx.pc
@@ -1,9 +1,0 @@
-libdir=/opt/homebrew/Cellar/openssl@3/3.3.0
-includedir=/opt/homebrew/Cellar/openssl@3/3.3.0/include
-
-Name: OpenSSL-libssl
-Description: Secure Sockets Layer and cryptography libraries
-Version: 3.3.0
-Requires.private: libcrypto
-Libs: -L${libdir} -lssl
-Cflags: -I${includedir}

--- a/xxx.pc
+++ b/xxx.pc
@@ -1,0 +1,9 @@
+libdir=/opt/homebrew/Cellar/openssl@3/3.3.0
+includedir=/opt/homebrew/Cellar/openssl@3/3.3.0/include
+
+Name: OpenSSL-libssl
+Description: Secure Sockets Layer and cryptography libraries
+Version: 3.3.0
+Requires.private: libcrypto
+Libs: -L${libdir} -lssl
+Cflags: -I${includedir}


### PR DESCRIPTION
- brew's python follows PEP-0668 which no longer allows using 'pip' to install packages system-wide
- add a venv to the macos CI, see if that works for us