### PR TITLE
GHA: prepare macos for ARM runners

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -66,11 +66,11 @@ jobs:
             macosx-version-min: 10.9
           - name: libssh-c-ares
             install: openssl nghttp2 libssh
-            configure: --enable-debug --with-libssh --with-openssl=/usr/local/opt/openssl --enable-ares --enable-websockets
+            configure: --enable-debug --with-libssh --with-openssl=$(brew --prefix)/opt/openssl --enable-ares --enable-websockets
             macosx-version-min: 10.9
           - name: libssh
             install: openssl nghttp2 libssh
-            configure: --enable-debug --with-libssh --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --with-libssh --with-openssl=$(brew --prefix)/opt/openssl --enable-websockets
             macosx-version-min: 10.9
           - name: c-ares
             install: nghttp2
@@ -121,25 +121,25 @@ jobs:
             macosx-version-min: 10.8
           - name: OpenSSL http2
             install: nghttp2 openssl
-            configure: --enable-debug --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --with-openssl=$(brew --prefix)/opt/openssl --enable-websockets
             macosx-version-min: 10.9
           - name: LibreSSL http2
             install: nghttp2 libressl
-            configure: --enable-debug --with-openssl=/usr/local/opt/libressl --enable-websockets
+            configure: --enable-debug --with-openssl=$(brew --prefix)/opt/libressl --enable-websockets
             macosx-version-min: 10.9
           - name: torture
             install: nghttp2 openssl
-            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=$(brew --prefix)/opt/openssl --enable-websockets
             tflags: -n -t --shallow=25 !FTP
             macosx-version-min: 10.9
           - name: torture-ftp
             install: nghttp2 openssl
-            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=$(brew --prefix)/opt/openssl --enable-websockets
             tflags: -n -t --shallow=20 FTP
             macosx-version-min: 10.9
           - name: macOS 10.15
             install: nghttp2 libssh2 openssl
-            configure: --enable-debug --disable-ldap --with-openssl=/usr/local/opt/openssl --enable-websockets
+            configure: --enable-debug --disable-ldap --with-openssl=$(brew --prefix)/opt/openssl --enable-websockets
             macosx-version-min: 10.15
     steps:
       - run: echo libtool autoconf automake pkg-config libpsl ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
@@ -156,7 +156,7 @@ jobs:
             *openssl*)
               ;;
             *)
-              if test -d /usr/local/include/openssl; then
+              if test -d $(brew --prefix)/include/openssl; then
                 brew unlink openssl
               fi;;
           esac
@@ -209,16 +209,16 @@ jobs:
         build:
           - name: OpenSSL
             install: nghttp2 openssl
-            generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
+            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
           - name: LibreSSL
             install: nghttp2 libressl
-            generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
+            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
           - name: libssh2
             install: nghttp2 openssl libssh2
-            generate: -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
+            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON
           - name: GnuTLS
             install: gnutls
-            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_SHARED_LINKER_FLAGS=-L/usr/local/lib -DCMAKE_EXE_LINKER_FLAGS=-L/usr/local/lib
+            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DCMAKE_SHARED_LINKER_FLAGS=-L$(brew --prefix)/lib -DCMAKE_EXE_LINKER_FLAGS=-L$(brew --prefix)/lib
     steps:
       - run: echo libtool autoconf automake pkg-config ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
         name: 'brew bundle'
@@ -231,7 +231,7 @@ jobs:
             *openssl*)
               ;;
             *)
-              if test -d /usr/local/include/openssl; then
+              if test -d $(brew --prefix)/include/openssl; then
                 brew unlink openssl
               fi;;
           esac


### PR DESCRIPTION
GHA switched macOS runners to ARM64. Fixup hard-coded
Homebrew package dependency paths to dynamic ones.

```
Current runner version: '2.316.0'
Operating System
  macOS
  14.4.1
  23E224
Runner Image
  Image: macos-14-arm64
```
Ref: https://github.com/curl/curl/actions/runs/8834067375/job/24254892013?pr=13478#step:1:1

Closes #13478
