### PR TITLE
TODO: add TLS channel binding

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -127,6 +127,7 @@
  13.14 Support the clienthello extension
  13.15 Select signature algorithms
  13.16 QUIC peer verification with wolfSSL
+ 13.17 TLS channel binding
 
  14. GnuTLS
  14.2 check connection
@@ -926,6 +927,23 @@
 
  Peer certificate verification is missing in the QUIC (ngtcp2) implementation
  using wolfSSL.
+
+13.17 TLS channel binding
+
+ TLS 1.2 and 1.3 provide the ability to extract some secret data from the TLS
+ connection and use it in the client request (usually in some sort of
+ authentication) to ensure that the data sent is bound to the specific TLS
+ connection and cannot be successfully intercepted by a proxy.  This
+ functionality can be used in a standard authentication mechanism such as
+ GSS-API or SCRAM, or in custom approaches like custom HTTP Authentication
+ headers.
+
+ For TLS 1.2, the binding type is usually tls-unique, and for TLS 1.3 it is
+ tls-exporter.
+
+ https://datatracker.ietf.org/doc/html/rfc5929
+ https://datatracker.ietf.org/doc/html/rfc9266
+ https://github.com/curl/curl/issues/9226
 
 14. GnuTLS
 


### PR DESCRIPTION
TLS channel binding is a security improvement that cryptographically ties authentication to a specific TLS connection, preventing TLS MITM proxies from successfully authenticating.  This would be valuable for many security-sensitive users, so add it to the TODO list.