### PR TITLE
Add tests for SNI and peer name checks

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -126,6 +126,7 @@
  13.13 Make sure we forbid TLS 1.3 post-handshake authentication
  13.14 Support the clienthello extension
  13.15 Select signature algorithms
+ 13.16 QUIC peer verification with wolfSSL
 
  14. GnuTLS
  14.2 check connection
@@ -920,6 +921,11 @@
  supported signature algorithm in the client hello message.
 
  https://github.com/curl/curl/issues/12982
+
+13.16 QUIC peer verification with wolfSSL
+
+ Peer certificate verification is missing in the QUIC (ngtcp2) implementation
+ using wolfSSL.
 
 14. GnuTLS
 

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -324,7 +324,11 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
 #elif defined(USE_WOLFSSL)
   (void)data;
   if(conn_config->verifyhost) {
-    if(!peer->sni ||
+    /* TODO: this does not really verify the peer certificate.
+     * On TCP connection this works as it is wired into the wolfSSL
+     * connect() implementation and gives a special return code on
+     * such a fail. */
+    if(peer->sni &&
        wolfSSL_check_domain_name(ctx->ssl, peer->sni) == SSL_FAILURE)
       return CURLE_PEER_FAILED_VERIFICATION;
   }

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -479,13 +479,8 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   backend->config = rustls_client_config_builder_build(config_builder);
   DEBUGASSERT(rconn == NULL);
-  {
-    /* rustls claims to manage ip address hostnames as well here. So,
-     * if we have an SNI, we use it, otherwise we pass the hostname */
-    char *server = connssl->peer.sni?
-                   connssl->peer.sni : connssl->peer.hostname;
-    result = rustls_client_connection_new(backend->config, server, &rconn);
-  }
+  result = rustls_client_connection_new(backend->config,
+                                        connssl->peer.hostname, &rconn);
   if(result != RUSTLS_RESULT_OK) {
     rustls_error(result, errorbuf, sizeof(errorbuf), &errorlen);
     failf(data, "rustls_client_connection_new: %.*s", (int)errorlen, errorbuf);

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -133,7 +133,7 @@ class EnvConfig:
         self.domain2 = f"two.{self.tld}"
         self.proxy_domain = f"proxy.{self.tld}"
         self.cert_specs = [
-            CertificateSpec(domains=[self.domain1, self.domain1brotli, 'localhost'], key_type='rsa2048'),
+            CertificateSpec(domains=[self.domain1, self.domain1brotli, 'localhost', '127.0.0.1'], key_type='rsa2048'),
             CertificateSpec(domains=[self.domain2], key_type='rsa2048'),
             CertificateSpec(domains=[self.proxy_domain, '127.0.0.1'], key_type='rsa2048'),
             CertificateSpec(name="clientsX", sub_specs=[

--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -709,6 +709,7 @@ static int curltest_sslinfo_handler(request_rec *r)
   brigade_env_var(r, bb, "SSL_SESSION_RESUMED");
   brigade_env_var(r, bb, "SSL_SRP_USER");
   brigade_env_var(r, bb, "SSL_SRP_USERINFO");
+  brigade_env_var(r, bb, "SSL_TLS_SNI");
   apr_brigade_puts(bb, NULL, NULL, "}\n");
 
   /* flush response */


### PR DESCRIPTION
- connect to DNS names with trailing dot
- connect to DNS names with double trailing dot
- rustls, always give `peer->hostname` and let it figure out SNI itself
- add SNI tests for ip address and localhost
- document in code and TODO that QUIC with ngtcp2+wolfssl does not do proper peer verification of the certificate
- mbedtls, skip tests with ip address verification as not supported by the library