### PR TITLE
cmake: FindNGHTTP2 add static lib name to find_library call

### DIFF
--- a/CMake/FindNGHTTP2.cmake
+++ b/CMake/FindNGHTTP2.cmake
@@ -25,7 +25,7 @@ include(FindPackageHandleStandardArgs)
 
 find_path(NGHTTP2_INCLUDE_DIR "nghttp2/nghttp2.h")
 
-find_library(NGHTTP2_LIBRARY NAMES nghttp2)
+find_library(NGHTTP2_LIBRARY NAMES nghttp2 nghttp2_static)
 
 find_package_handle_standard_args(NGHTTP2
     FOUND_VAR


### PR DESCRIPTION
Adds the static library name, nghttp2_static as a name to search.

This provides cmake parity with the winbuild Makefile.vc allowing the cmake build to find and allow the link to static nghttp2 library

https://github.com/curl/curl/blob/dfdd978f7c60224dffe2aac25b436dc0a5cd0186/winbuild/Makefile.vc#L147-L158