### PR TITLE
mime: avoid using access()

### DIFF
--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1421,7 +1421,7 @@ CURLcode curl_mime_filedata(curl_mimepart *part, const char *filename)
         result = CURLE_OUT_OF_MEMORY;
 
       part->datasize = -1;
-      if(!result && S_ISREG(sbuf.st_mode)) {
+      if(S_ISREG(sbuf.st_mode)) {
         part->datasize = filesize(filename, sbuf);
         part->seekfunc = mime_file_seek;
       }

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1419,30 +1419,28 @@ CURLcode curl_mime_filedata(curl_mimepart *part, const char *filename)
       part->data = strdup(filename);
       if(!part->data)
         result = CURLE_OUT_OF_MEMORY;
-
-      part->datasize = -1;
-      if(S_ISREG(sbuf.st_mode)) {
-        part->datasize = filesize(filename, sbuf);
-        part->seekfunc = mime_file_seek;
-      }
-
-      part->readfunc = mime_file_read;
-      part->freefunc = mime_file_free;
-      part->kind = MIMEKIND_FILE;
-
-      /* As a side effect, set the filename to the current file's base name.
-         It is possible to withdraw this by explicitly calling
-         curl_mime_filename() with a NULL filename argument after the current
-         call. */
-      base = strippath(filename);
-      if(!base)
-        result = CURLE_OUT_OF_MEMORY;
       else {
-        CURLcode res = curl_mime_filename(part, base);
+        part->datasize = -1;
+        if(S_ISREG(sbuf.st_mode)) {
+          part->datasize = filesize(filename, sbuf);
+          part->seekfunc = mime_file_seek;
+        }
 
-        if(res)
-          result = res;
-        free(base);
+        part->readfunc = mime_file_read;
+        part->freefunc = mime_file_free;
+        part->kind = MIMEKIND_FILE;
+
+        /* As a side effect, set the filename to the current file's base name.
+           It is possible to withdraw this by explicitly calling
+           curl_mime_filename() with a NULL filename argument after the current
+           call. */
+        base = strippath(filename);
+        if(!base)
+          result = CURLE_OUT_OF_MEMORY;
+        else {
+          result = curl_mime_filename(part, base);
+          free(base);
+        }
       }
     }
   }

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1413,36 +1413,37 @@ CURLcode curl_mime_filedata(curl_mimepart *part, const char *filename)
     char *base;
     struct_stat sbuf;
 
-    if(stat(filename, &sbuf) || access(filename, R_OK))
+    if(stat(filename, &sbuf))
       result = CURLE_READ_ERROR;
-
-    part->data = strdup(filename);
-    if(!part->data)
-      result = CURLE_OUT_OF_MEMORY;
-
-    part->datasize = -1;
-    if(!result && S_ISREG(sbuf.st_mode)) {
-      part->datasize = filesize(filename, sbuf);
-      part->seekfunc = mime_file_seek;
-    }
-
-    part->readfunc = mime_file_read;
-    part->freefunc = mime_file_free;
-    part->kind = MIMEKIND_FILE;
-
-    /* As a side effect, set the filename to the current file's base name.
-       It is possible to withdraw this by explicitly calling
-       curl_mime_filename() with a NULL filename argument after the current
-       call. */
-    base = strippath(filename);
-    if(!base)
-      result = CURLE_OUT_OF_MEMORY;
     else {
-      CURLcode res = curl_mime_filename(part, base);
+      part->data = strdup(filename);
+      if(!part->data)
+        result = CURLE_OUT_OF_MEMORY;
 
-      if(res)
-        result = res;
-      free(base);
+      part->datasize = -1;
+      if(!result && S_ISREG(sbuf.st_mode)) {
+        part->datasize = filesize(filename, sbuf);
+        part->seekfunc = mime_file_seek;
+      }
+
+      part->readfunc = mime_file_read;
+      part->freefunc = mime_file_free;
+      part->kind = MIMEKIND_FILE;
+
+      /* As a side effect, set the filename to the current file's base name.
+         It is possible to withdraw this by explicitly calling
+         curl_mime_filename() with a NULL filename argument after the current
+         call. */
+      base = strippath(filename);
+      if(!base)
+        result = CURLE_OUT_OF_MEMORY;
+      else {
+        CURLcode res = curl_mime_filename(part, base);
+
+        if(res)
+          result = res;
+        free(base);
+      }
     }
   }
   return result;


### PR DESCRIPTION
If stat() fails, there is no point in calling access()

Also: return error immediately if the stat() fails.

Ref: #13482