### PR TITLE
DISTROS: add patch and issues link for curl-for-win

### DIFF
--- a/docs/DISTROS.md
+++ b/docs/DISTROS.md
@@ -85,6 +85,8 @@ mailing list](https://lists.haxx.se/listinfo/curl-distros).
 *Rolling Release*
 
 - curl: https://curl.se/windows/
+- curl patches: https://github.com/curl/curl-for-win/blob/main/curl.patch (if any)
+- build-specific issues: https://github.com/curl/curl-for-win/issues
 
 Issues and patches for this are managed in the main curl project.
 


### PR DESCRIPTION
curl-for-win sometimes includes curl patches that were already merged in
master, but not yet part of a stable release.

Also include the Issues link. Build-specific issues are handled there.

Ref: #13493
Closes #13499
