### PR TITLE
cf-https-connect: use timeouts as unsigned ints

### DIFF
--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -102,8 +102,8 @@ struct cf_hc_ctx {
   CURLcode result;          /* overall result */
   struct cf_hc_baller h3_baller;
   struct cf_hc_baller h21_baller;
-  int soft_eyeballs_timeout_ms;
-  int hard_eyeballs_timeout_ms;
+  unsigned int soft_eyeballs_timeout_ms;
+  unsigned int hard_eyeballs_timeout_ms;
 };
 
 static void cf_hc_baller_init(struct cf_hc_baller *b,


### PR DESCRIPTION
To match the type used in 'set.happy_eyeballs_timeout'.

Ref: #13489