### PR TITLE
file: make _wopen() and _open() able to handle long legacy DOS paths

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -261,4 +261,4 @@ test3024 test3025 test3026 test3027 test3028 test3029 test3030 \
 \
 test3100 test3101 test3102 test3103 \
 test3200 \
-test3201 test3202 test3203 test3204 test3205
+test3201 test3202 test3203 test3204 test3205 test3206

--- a/tests/data/test3206
+++ b/tests/data/test3206
@@ -1,0 +1,39 @@
+<testcase>
+<info>
+<keywords>
+FILE
+long_path
+</keywords>
+</info>
+
+<reply>
+<data>
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+file
+</features>
+<name>
+file:// with long path
+</name>
+<command option="no-include">
+file://localhost%FILE_PWD/%LOGDIR/veryloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongdir/verylooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongfile%TESTNUMBER.txt
+</command>
+<file name="%LOGDIR/veryloooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongdir/verylooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooongfile%TESTNUMBER.txt">
+foo
+</file>
+</client>
+
+# Verify data after the test has been retrieved
+<verify>
+<stdout>
+foo
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
Issue: #8361

Perl in `C:\Program Files\Git\usr\bin` supports long paths w/o any manifest or registry changes. Why not let curl support long paths.

BTW the solution offered by "5.13 long paths are not fully supported on Windows" in the [known bugs](https://github.com/curl/curl/blob/master/docs/KNOWN_BUGS) does not work, because there is no way how to specify `//?/` in `file://`. [RFC 8089](https://datatracker.ietf.org/doc/html/rfc8089#appendix-C) excludes such paths `\\?\` and `\\.\`. `file://localhost///?/C:/foo` or `file://localhost/\\?\C:\foo` are also invalid URLs.