### PR TITLE
curl_multibyte: remove access() function wrapper for Windows

### DIFF
--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -159,21 +159,4 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
 #endif
 }
 
-int curlx_win32_access(const char *path, int mode)
-{
-#if defined(_UNICODE)
-  int result = -1;
-  wchar_t *path_w = curlx_convert_UTF8_to_wchar(path);
-  if(path_w) {
-    result = _waccess(path_w, mode);
-    curlx_unicodefree(path_w);
-  }
-  else
-    errno = EINVAL;
-  return result;
-#else
-  return _access(path, mode);
-#endif
-}
-
 #endif /* USE_WIN32_LARGE_FILES || USE_WIN32_SMALL_FILES */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -409,11 +409,9 @@
 #  define LSEEK_ERROR                (__int64)-1
 #  define open                       curlx_win32_open
 #  define fopen(fname,mode)          curlx_win32_fopen(fname, mode)
-#  define access(fname,mode)         curlx_win32_access(fname, mode)
    int curlx_win32_open(const char *filename, int oflag, ...);
    int curlx_win32_stat(const char *path, struct_stat *buffer);
    FILE *curlx_win32_fopen(const char *filename, const char *mode);
-   int curlx_win32_access(const char *path, int mode);
 #endif
 
 /*
@@ -432,11 +430,9 @@
 #    define struct_stat                struct _stat
 #    define open                       curlx_win32_open
 #    define fopen(fname,mode)          curlx_win32_fopen(fname, mode)
-#    define access(fname,mode)         curlx_win32_access(fname, mode)
      int curlx_win32_stat(const char *path, struct_stat *buffer);
      int curlx_win32_open(const char *filename, int oflag, ...);
      FILE *curlx_win32_fopen(const char *filename, const char *mode);
-     int curlx_win32_access(const char *path, int mode);
 #  endif
 #  define LSEEK_ERROR                (long)-1
 #endif

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -721,7 +721,7 @@ sub scanfile {
                     v?sprintf|
                     (str|_mbs|_tcs|_wcs)n?cat|
                     LoadLibrary(Ex)?(A|W)?|
-                    access)
+                    _?w?access)
                    \s*\(
                  /x) {
             checkwarn("BANNEDFUNC",


### PR DESCRIPTION
- Remove curlx_win32_access() which was a wrapper to use access() in Windows.

This is a follow-up to 602fc213, one of two commits which removed access() calls from the codebase and banned use of the function.

Closes #xxxx