### PR TITLE
Curl_dyn_vaddf should return error instead of OK if memory fails

### DIFF
--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -213,7 +213,7 @@ CURLcode Curl_dyn_vaddf(struct dynbuf *s, const char *fmt, va_list ap)
   }
   /* If we failed, we cleanup the whole buffer and return error */
   Curl_dyn_free(s);
-  return CURLE_OK;
+  return CURLE_OUT_OF_MEMORY;
 #endif
 }
 


### PR DESCRIPTION
I think you meant CURLE_OUT_OF_MEMORY to report if you are out of memory for vaprintf returning NULL.

Looks strange to return CURLE_OK after calling Curl_dyn_free.