### PR TITLE
tests: Mark tftpd timer function as noreturn

### DIFF
--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -276,6 +276,9 @@ static void mysignal(int sig, void (*handler)(int))
   sigaction(sig, &sa, NULL);
 }
 
+#ifdef HAVE_SIGSETJMP
+CURL_NORETURN
+#endif
 static void timer(int signum)
 {
   (void)signum;


### PR DESCRIPTION
This avoids the below compiler warning:
```
tftpd.c:280:1: warning: function 'timer' could be declared with attribute 'noreturn' [-Wmissing-noreturn]
```