### PR TITLE
mbedtls: support TLS 1.3

### DIFF
--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -77,7 +77,8 @@ class TestSSLUse:
             exp_resumed = 'Initial'  # rustls does not support sessions, TODO
         if env.curl_uses_lib('bearssl') and tls_max == '1.3':
             pytest.skip('BearSSL does not support TLSv1.3')
-        if env.curl_uses_lib('mbedtls') and tls_max == '1.3':
+        if env.curl_uses_lib('mbedtls') and tls_max == '1.3' and \
+                not env.curl_lib_version_at_least('mbedtls', '3.6.0'):
             pytest.skip('mbedtls does not support TLSv1.3')
 
         curl = CurlClient(env=env)


### PR DESCRIPTION
See #12876.

Question, where in the documentation can I write down the information that the required version of the mbedtls library is 3.6.0?
Should the tests be modified?