### PR TITLE
Remove examples from deprecated options

### DIFF
--- a/docs/libcurl/opts/CURLOPT_EGDSOCKET.md
+++ b/docs/libcurl/opts/CURLOPT_EGDSOCKET.md
@@ -28,39 +28,14 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_EGDSOCKET, char *path);
 
 Deprecated option. It serves no purpose anymore.
 
-Pass a char pointer to the null-terminated path name to the Entropy Gathering
-Daemon socket. It is used to seed the random engine for TLS.
-
-The application does not have to keep the string around after setting this
-option.
-
 # DEFAULT
 
 NULL
 
-# EXAMPLE
-
-~~~c
-int main(void)
-{
-  CURL *curl = curl_easy_init();
-  if(curl) {
-    CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
-    curl_easy_setopt(curl, CURLOPT_EGDSOCKET, "/var/egd.socket");
-    res = curl_easy_perform(curl);
-    curl_easy_cleanup(curl);
-  }
-}
-~~~
-
 # AVAILABILITY
-
-Only with OpenSSL versions before 1.1.0.
 
 This option was deprecated in 7.84.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+Returns CURLE_OK.

--- a/docs/libcurl/opts/CURLOPT_RANDOM_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_RANDOM_FILE.md
@@ -28,39 +28,14 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_RANDOM_FILE, char *path);
 
 Deprecated option. It serves no purpose anymore.
 
-Pass a char pointer to a null-terminated filename. The file might be used to
-read from to seed the random engine for SSL and more.
-
-The application does not have to keep the string around after setting this
-option.
-
 # DEFAULT
 
 NULL, not used
 
-# EXAMPLE
-
-~~~c
-int main(void)
-{
-  CURL *curl = curl_easy_init();
-  if(curl) {
-    CURLcode res;
-    curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
-    curl_easy_setopt(curl, CURLOPT_RANDOM_FILE, "junk.txt");
-    res = curl_easy_perform(curl);
-    curl_easy_cleanup(curl);
-  }
-}
-~~~
-
 # AVAILABILITY
-
-Only with OpenSSL versions before 1.1.0.
 
 This option was deprecated in 7.84.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK on success or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+Returns CURLE_OK.

--- a/tests/test1173.pl
+++ b/tests/test1173.pl
@@ -75,6 +75,8 @@ my %deprecated = (
     CURLINFO_DATA_OUT => 1,
     CURLINFO_SSL_DATA_IN => 1,
     CURLINFO_SSL_DATA_OUT => 1,
+    CURLOPT_EGDSOCKET => 1,
+    CURLOPT_RANDOM_FILE => 1,
     );
 sub allsymbols {
     open(my $f, "<", "$symbolsinversions") ||

--- a/tests/test1173.pl
+++ b/tests/test1173.pl
@@ -134,9 +134,10 @@ sub scanmanpage {
 
     open(my $m, "<", "$file") ||
         die "test1173.pl could not open $file";
-    if($file =~ /[\/\\](CURL|curl_)[^\/\\]*.3/) {
-        # This is a man page for libcurl. It requires an example!
-        $reqex = 1;
+    if($file =~ /[\/\\](CURL|curl_)([^\/\\]*).3/) {
+        # This is a man page for libcurl. It requires an example unless it's
+        # considered deprecated.
+        $reqex = 1 unless defined $deprecated{'CURL'.$2};
         if($1 eq "CURL") {
             $optpage = 1;
         }


### PR DESCRIPTION
Manpages which document deprecated `CURLOPT_` or `CURLINFO_` should not be required to have an EXAMPLE section since they might effectively be dead no-ops which we don't want to trick users into believing they can use by copying example code.

`CURLOPT_EGDSOCKET` and `CURLOPT_RANDOM_FILE` are both completely dead so remove their example sections since the code there is useless. There is still a way to inject a random file for OpenSSL older than 1.1.0 but it's not what the example showed (and it's not even done with this option) so we refrain from documenting it here.