### PR TITLE
EXPERIMENTAL: add graduation requirements for each feature

### DIFF
--- a/docs/EXPERIMENTAL.md
+++ b/docs/EXPERIMENTAL.md
@@ -21,8 +21,16 @@ Experimental support in curl means:
    to our API/ABI rules as we do for regular features, as long as it is marked
    experimental.
 5. Experimental features are clearly marked so in documentation. Beware.
-6. Experimental features should have a set of documented requirements of
-   what is needed for the feature to graduate.
+
+## Graduation
+
+1. Each experimental feature should have a set of documented requirements of
+   what is needed for that feature to graduate. Graduation means being removed
+   from the list of experiments.
+2. An experiment should NOT graduate if it needs test cases to be disabled,
+   unless they are for minor features that are clearly documented as not
+   provided by the experiment and then the disabling should be managed inside
+   each affected test case.
 
 ## Experimental features right now
 
@@ -30,8 +38,6 @@ Experimental support in curl means:
 
 Graduation requirements:
 
-- no test cases disabled - unless the test features hyper itself just does not
-  support
 - HTTP/1 and HTTP/2 support, including multiplexing
 
 ###  HTTP/3 support (non-ngtcp2 backends)
@@ -46,8 +52,6 @@ Graduation requirements:
 ### The rustls backend
 
 Graduation requirements:
-
-- no test cases disabled for rustls
 
 - a reasonable expectation of a stable API going forward.
 

--- a/docs/EXPERIMENTAL.md
+++ b/docs/EXPERIMENTAL.md
@@ -21,11 +21,56 @@ Experimental support in curl means:
    to our API/ABI rules as we do for regular features, as long as it is marked
    experimental.
 5. Experimental features are clearly marked so in documentation. Beware.
+6. Experimental features should have a set of documented requirements of
+   what is needed for the feature to graduate.
 
 ## Experimental features right now
 
- - The Hyper HTTP backend
- - HTTP/3 support (using the quiche or msh3 backends)
- - The rustls backend
- - WebSocket
- - Use of the HTTPS resource record and Encrypted Client Hello (ECH) when using DoH
+### The Hyper HTTP backend
+
+Graduation requirements:
+
+- no test cases disabled - unless the test features hyper itself just does not
+  support
+- HTTP/1 and HTTP/2 support, including multiplexing
+
+###  HTTP/3 support (non-ngtcp2 backends)
+
+Graduation requirements:
+
+- The used libraries should be considered out-of-beta with a reasonable
+  expectation of a stable API going forward.
+
+- Using HTTP/3 with the given build should perform without risking busy-loops
+
+### The rustls backend
+
+Graduation requirements:
+
+- no test cases disabled for rustls
+
+- a reasonable expectation of a stable API going forward.
+
+### WebSocket
+
+Graduation requirements:
+
+- feedback from users saying that the API works for their specific use cases
+
+- unless the above happens, we consider WebSocket silently working by
+  September 2024 when it has been stewing as EXPERIMENTAL for two years.
+
+## ECH
+
+Use of the HTTPS resource record and Encrypted Client Hello (ECH) when using
+DoH
+
+Graduation requirements:
+
+- ECH support exists in at least one widely used TLS library apart from
+  BoringSSL and wolfSSL.
+
+- feedback from users saying that ECH works for their use cases
+
+- it has been given time to mature, so no earlier than April 2025 (twelve
+  months after being added here)


### PR DESCRIPTION
Starting now, experimental features should have a set of documented requirements of what is needed for the feature to graduate.

This adds requirements to all existing experiments.