### PR TITLE
asyn-thread: fix Curl_thread_create result check

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -672,7 +672,7 @@ static bool init_resolve_thread(struct Curl_easy *data,
   td->thread_hnd = Curl_thread_create(gethostbyname_thread, &td->tsd);
 #endif
 
-  if(!td->thread_hnd) {
+  if(td->thread_hnd == curl_thread_t_null) {
     /* The thread never started, so mark it as done here for proper cleanup. */
     td->tsd.done = 1;
     err = errno;


### PR DESCRIPTION
- Compare to curl_thread_t_null instead of 0 for error.

Currently for both supported thread libraries (pthreads and Windows) curl_thread_t_null is defined as 0. However, the pattern throughout the code is to check against curl_thread_t_null and not 0 since for posterity some thread library may not use 0 for error.

Closes #xxxx