### PR TITLE
DEPRECATE.md: TLS libraries without 1.3 support

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -12,6 +12,16 @@ email the
 as soon as possible and explain to us why this is a problem for you and
 how your use case cannot be satisfied properly using a workaround.
 
+## TLS libraries without 1.3 support
+
+curl drops support for TLS libraries without TLS 1.3 capability in May 2025.
+
+It requires that a curl build using the library should be able to negotiate
+and use TLS 1.3, or else it is not good enough.
+
+As of May 2024, the three libraries that need to get fixed to remain supported
+after May 2025 are: BearSSL, mbedTLS and Secure Transport.
+
 ## space-separated `NOPROXY` patterns
 
 When specifying patterns/domain names for curl that should *not* go through a

--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -19,8 +19,8 @@ curl drops support for TLS libraries without TLS 1.3 capability in May 2025.
 It requires that a curl build using the library should be able to negotiate
 and use TLS 1.3, or else it is not good enough.
 
-As of May 2024, the three libraries that need to get fixed to remain supported
-after May 2025 are: BearSSL, mbedTLS and Secure Transport.
+As of May 2024, the libraries that need to get fixed to remain supported after
+May 2025 are: BearSSL and Secure Transport.
 
 ## space-separated `NOPROXY` patterns
 


### PR DESCRIPTION
Brought to [the curl-library list](https://curl.se/mail/lib-2024-03/0006.html) on March 7, 2024. Discussed since then. No particular objections have been heard except the worry that apple device people might miss Secure Transport.

Once #13539 merges, we need to update the text.