### PR TITLE
Deprioritize SecureTransport on macOS

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1349,8 +1349,6 @@ const struct Curl_ssl *Curl_ssl =
   &Curl_ssl_multi;
 #elif defined(USE_WOLFSSL)
   &Curl_ssl_wolfssl;
-#elif defined(USE_SECTRANSP)
-  &Curl_ssl_sectransp;
 #elif defined(USE_GNUTLS)
   &Curl_ssl_gnutls;
 #elif defined(USE_MBEDTLS)
@@ -1359,6 +1357,8 @@ const struct Curl_ssl *Curl_ssl =
   &Curl_ssl_rustls;
 #elif defined(USE_OPENSSL)
   &Curl_ssl_openssl;
+#elif defined(USE_SECTRANSP)
+  &Curl_ssl_sectransp;
 #elif defined(USE_SCHANNEL)
   &Curl_ssl_schannel;
 #elif defined(USE_BEARSSL)
@@ -1371,9 +1371,6 @@ static const struct Curl_ssl *available_backends[] = {
 #if defined(USE_WOLFSSL)
   &Curl_ssl_wolfssl,
 #endif
-#if defined(USE_SECTRANSP)
-  &Curl_ssl_sectransp,
-#endif
 #if defined(USE_GNUTLS)
   &Curl_ssl_gnutls,
 #endif
@@ -1382,6 +1379,9 @@ static const struct Curl_ssl *available_backends[] = {
 #endif
 #if defined(USE_OPENSSL)
   &Curl_ssl_openssl,
+#endif
+#if defined(USE_SECTRANSP)
+  &Curl_ssl_sectransp,
 #endif
 #if defined(USE_SCHANNEL)
   &Curl_ssl_schannel,


### PR DESCRIPTION
Moved SecureTransport behind OpenSSL, so we can build CURL with both and prefer using OpenSSL over SecureChannel. Our users still can opt-in to use SecureTransport, but a curl build with both will default to OpenSSL.