### PR TITLE
version: use msnprintf instead of strncpy

### DIFF
--- a/lib/version.c
+++ b/lib/version.c
@@ -175,8 +175,7 @@ char *curl_version(void)
   /* Override version string when environment variable CURL_VERSION is set */
   const char *debugversion = getenv("CURL_VERSION");
   if(debugversion) {
-    strncpy(out, debugversion, sizeof(out)-1);
-    out[sizeof(out)-1] = '\0';
+    msnprintf(out, sizeof(out), "%s", debugversion);
     return out;
   }
 #endif


### PR DESCRIPTION
- to ensure a terminating null byte
- to avoid zero-padding the target

debug code only.