### PR TITLE
bufq: remove duplicate word in comment

### DIFF
--- a/lib/bufq.h
+++ b/lib/bufq.h
@@ -85,7 +85,7 @@ void Curl_bufcp_free(struct bufc_pool *pool);
  * preferably never fail (except for memory exhaustion).
  *
  * By default and without a pool, a bufq will keep chunks that read
- * read empty in its `spare` list. Option `BUFQ_OPT_NO_SPARES` will
+ * empty in its `spare` list. Option `BUFQ_OPT_NO_SPARES` will
  * disable that and free chunks once they become empty.
  *
  * When providing a pool to a bufq, all chunk creation and spare handling


### PR DESCRIPTION
Inspired by #13552 I had a look and found one more instance it seems.