### PR TITLE
lib/cf-h1-proxy: silence compiler warnings (gcc 14)

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -195,14 +195,16 @@ static void h1_tunnel_go_state(struct Curl_cfilter *cf,
 static void tunnel_free(struct Curl_cfilter *cf,
                         struct Curl_easy *data)
 {
-  struct h1_tunnel_state *ts = cf->ctx;
-  if(ts) {
-    h1_tunnel_go_state(cf, ts, H1_TUNNEL_FAILED, data);
-    Curl_dyn_free(&ts->rcvbuf);
-    Curl_dyn_free(&ts->request_data);
-    Curl_httpchunk_free(data, &ts->ch);
-    free(ts);
-    cf->ctx = NULL;
+  if(cf) {
+    struct h1_tunnel_state *ts = cf->ctx;
+    if(ts) {
+      h1_tunnel_go_state(cf, ts, H1_TUNNEL_FAILED, data);
+      Curl_dyn_free(&ts->rcvbuf);
+      Curl_dyn_free(&ts->request_data);
+      Curl_httpchunk_free(data, &ts->ch);
+      free(ts);
+      cf->ctx = NULL;
+    }
   }
 }
 
@@ -1057,12 +1059,14 @@ static void cf_h1_proxy_close(struct Curl_cfilter *cf,
                               struct Curl_easy *data)
 {
   CURL_TRC_CF(data, cf, "close");
-  cf->connected = FALSE;
-  if(cf->ctx) {
-    h1_tunnel_go_state(cf, cf->ctx, H1_TUNNEL_INIT, data);
+  if(cf) {
+    cf->connected = FALSE;
+    if(cf->ctx) {
+      h1_tunnel_go_state(cf, cf->ctx, H1_TUNNEL_INIT, data);
+    }
+    if(cf->next)
+      cf->next->cft->do_close(cf->next, data);
   }
-  if(cf->next)
-    cf->next->cft->do_close(cf->next, data);
 }
 
 


### PR DESCRIPTION
They came up ealier with gcc 12 (Windows), but apparently gcc 14 is still reporting them, also under Linux.

```
/home/runner/work/curl-for-win/curl-for-win/curl/lib/cf-h1-proxy.c: In function 'cf_h1_proxy_close':
/home/runner/work/curl-for-win/curl-for-win/curl/lib/cf-h1-proxy.c:1060:17: warning: null pointer dereference [-Wnull-dereference]
 1060 |   cf->connected = FALSE;
/home/runner/work/curl-for-win/curl-for-win/curl/lib/cf-h1-proxy.c:1061:8: warning: null pointer dereference [-Wnull-dereference]
 1061 |   if(cf->ctx) {
      |      ~~^~~~~
In function 'tunnel_free',
    inlined from 'cf_h1_proxy_destroy' at /home/runner/work/curl-for-win/curl-for-win/curl/lib/cf-h1-proxy.c:1053:3:
/home/runner/work/curl-for-win/curl-for-win/curl/lib/cf-h1-proxy.c:198:27: warning: null pointer dereference [-Wnull-dereference]
  198 |   struct h1_tunnel_state *ts = cf->ctx;
      |                           ^~
```
Ref: https://github.com/curl/curl-for-win/actions/runs/8985369476/job/24679219528#step:3:6320

Fixes #13237
Closes #13555