### PR TITLE
docs: fix some CURLINFO examples

### DIFF
--- a/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
@@ -54,14 +54,19 @@ int main(void)
     /* Do not do the transfer - only connect to host */
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);
     res = curl_easy_perform(curl);
+    if(res != CURLE_OK) {
+      printf("Error: %s\n", curl_easy_strerror(res));
+      curl_easy_cleanup(curl);
+      return 1;
+    }
 
     /* Extract the socket from the curl handle */
     res = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);
-
-    if(res != CURLE_OK) {
-      printf("Error: %s\n", curl_easy_strerror(res));
-      return 1;
+    if(!res && sockfd != CURL_SOCKET_BAD) {
+      /* operate on sockfd */
     }
+
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
@@ -54,14 +54,19 @@ int main(void)
     /* Do not do the transfer - only connect to host */
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);
     res = curl_easy_perform(curl);
+    if(res != CURLE_OK) {
+      printf("Error: %s\n", curl_easy_strerror(res));
+      curl_easy_cleanup(curl);
+      return 1;
+    }
 
     /* Extract the socket from the curl handle */
     res = curl_easy_getinfo(curl, CURLINFO_LASTSOCKET, &sockfd);
-
-    if(res != CURLE_OK) {
-      printf("Error: %s\n", curl_easy_strerror(res));
-      return 1;
+    if(!res && sockfd != -1) {
+      /* operate on sockfd */
     }
+
+    curl_easy_cleanup(curl);
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
+++ b/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
@@ -46,7 +46,7 @@ int main(void)
     if(res == CURLE_OK) {
       long connects;
       res = curl_easy_getinfo(curl, CURLINFO_NUM_CONNECTS, &connects);
-      if(res)
+      if(!res)
         printf("It needed %ld connects\n", connects);
     }
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
@@ -42,7 +42,7 @@ int main(void)
     if(res != CURLE_OK) {
       long error;
       res = curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &error);
-      if(res && error) {
+      if(!res && error) {
         printf("Errno: %ld\n", error);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
@@ -34,6 +34,8 @@ Pass a pointer to a long to receive the result of the certificate verification
 that was requested (using the CURLOPT_PROXY_SSL_VERIFYPEER(3)
 option. This is only used for HTTPS proxies.
 
+0 is a positive result. Non-zero is an error.
+
 # EXAMPLE
 
 ~~~c
@@ -43,14 +45,23 @@ int main(void)
   if(curl) {
     CURLcode res;
     long verifyresult;
+
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_PROXY, "https://proxy:443");
+
     res = curl_easy_perform(curl);
-    if(res)
+    if(res) {
       printf("error: %s\n", curl_easy_strerror(res));
-    curl_easy_getinfo(curl, CURLINFO_PROXY_SSL_VERIFYRESULT, &verifyresult);
-    printf("The peer verification said %s\n", verifyresult?
-           "fine" : "bad");
+      curl_easy_cleanup(curl);
+      return 1;
+    }
+
+    res = curl_easy_getinfo(curl, CURLINFO_PROXY_SSL_VERIFYRESULT,
+                            &verifyresult);
+    if(!res) {
+      printf("The peer verification said %s\n",
+             (verifyresult ? "bad" : "fine"));
+    }
     curl_easy_cleanup(curl);
   }
 }

--- a/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
@@ -45,13 +45,22 @@ int main(void)
   if(curl) {
     CURLcode res;
     long verifyresult;
+
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
+
     res = curl_easy_perform(curl);
-    if(res)
+    if(res) {
       printf("error: %s\n", curl_easy_strerror(res));
-    curl_easy_getinfo(curl, CURLINFO_SSL_VERIFYRESULT, &verifyresult);
-    printf("The peer verification said %s\n", verifyresult?
-           "BAAAD":"fine");
+      curl_easy_cleanup(curl);
+      return 1;
+    }
+
+    res = curl_easy_getinfo(curl, CURLINFO_SSL_VERIFYRESULT,
+                            &verifyresult);
+    if(!res) {
+      printf("The peer verification said %s\n",
+             (verifyresult ? "bad" : "fine"));
+    }
     curl_easy_cleanup(curl);
   }
 }


### PR DESCRIPTION
- improve getinfo result check for example sections: CURLINFO_ACTIVESOCKET, CURLINFO_LASTSOCKET, CURLINFO_SSL_VERIFYRESULT, CURLINFO_PROXY_SSL_VERIFYRESULT

- fix getinfo result check for example sections: CURLINFO_NUM_CONNECTS, CURLINFO_OS_ERRNO

- fix verify result check for example sections: CURLINFO_PROXY_SSL_VERIFYRESULT

Bug: https://github.com/curl/curl/discussions/13557#discussion-6625507
Reported-by: farazrbx@users.noreply.github.com

Closes #xxxx