### PR TITLE
h3, ngtcp2, error handling

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -564,7 +564,7 @@ static int cb_stream_close(ngtcp2_conn *tconn, uint32_t flags,
   }
 
   rv = nghttp3_conn_close_stream(ctx->h3conn, stream_id, app_error_code);
-  CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] quic close(err=%"
+  CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] quic close(app_error=%"
               CURL_PRIu64 ") -> %d", stream_id, (curl_uint64_t)app_error_code,
               rv);
   if(rv && rv != NGHTTP3_ERR_STREAM_NOT_FOUND) {

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -493,7 +493,7 @@ static int cb_recv_stream_data(ngtcp2_conn *tconn, uint32_t flags,
                   stream_id, (curl_int64_t)nconsumed);
     }
     if(!data) {
-      CURL_TRC_CF(cdata, cf, "[%" CURL_PRId64 "] discard data for unkown "
+      CURL_TRC_CF(cdata, cf, "[%" CURL_PRId64 "] discard data for unknown "
                   "stream", stream_id);
       return 0;
     }

--- a/tests/http/test_16_info.py
+++ b/tests/http/test_16_info.py
@@ -62,7 +62,7 @@ class TestInfo:
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-{count-1}]'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_stats=True)
-        r.check_stats(count=count, http_status=200)
+        r.check_stats(count=count, http_status=200, exitcode=0)
         for s in r.stats:
             self.check_stat(s, dl_size=30, ul_size=0)
 
@@ -77,7 +77,7 @@ class TestInfo:
         r = curl.http_download(urls=[url], alpn_proto=proto, with_stats=True, extra_args=[
             '--location'
         ])
-        r.check_stats(count=count, http_status=200)
+        r.check_stats(count=count, http_status=200, exitcode=0)
         for s in r.stats:
             self.check_stat(s, dl_size=30, ul_size=0)
 
@@ -93,7 +93,7 @@ class TestInfo:
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto,
                              with_headers=True)
         r.check_response(count=count, http_status=200)
-        r.check_stats(count=count, http_status=200)
+        r.check_stats(count=count, http_status=200, exitcode=0)
         for s in r.stats:
             self.check_stat(s, dl_size=fsize, ul_size=fsize)
 
@@ -104,7 +104,7 @@ class TestInfo:
         curl = CurlClient(env=env)
         url = f'http://{env.domain1}:{env.http_port}/data.json?[0-{count-1}]'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_stats=True)
-        r.check_stats(count=count, http_status=200)
+        r.check_stats(count=count, http_status=200, exitcode=0)
         for s in r.stats:
             self.check_stat(s, dl_size=30, ul_size=0)
 

--- a/tests/http/test_16_info.py
+++ b/tests/http/test_16_info.py
@@ -63,8 +63,8 @@ class TestInfo:
         url = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-{count-1}]'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_stats=True)
         r.check_stats(count=count, http_status=200, exitcode=0)
-        for s in r.stats:
-            self.check_stat(s, dl_size=30, ul_size=0)
+        for idx, s in enumerate(r.stats):
+            self.check_stat(idx, s, r, dl_size=30, ul_size=0)
 
     # download plain file with a 302 redirect
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
@@ -78,8 +78,8 @@ class TestInfo:
             '--location'
         ])
         r.check_stats(count=count, http_status=200, exitcode=0)
-        for s in r.stats:
-            self.check_stat(s, dl_size=30, ul_size=0)
+        for idx, s in enumerate(r.stats):
+            self.check_stat(idx, s, r, dl_size=30, ul_size=0)
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_16_03_info_upload(self, env: Env, httpd, nghttpx, proto, repeat):
@@ -91,11 +91,13 @@ class TestInfo:
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-{count-1}]'
         r = curl.http_upload(urls=[url], data=f'@{fdata}', alpn_proto=proto,
-                             with_headers=True)
+                             with_headers=True, extra_args=[
+                                '--trace-config', 'http/2,http/3'
+                             ])
         r.check_response(count=count, http_status=200)
         r.check_stats(count=count, http_status=200, exitcode=0)
-        for s in r.stats:
-            self.check_stat(s, dl_size=fsize, ul_size=fsize)
+        for idx, s in enumerate(r.stats):
+            self.check_stat(idx, s, r, dl_size=fsize, ul_size=fsize)
 
     # download plain file via http: ('time_appconnect' is 0)
     @pytest.mark.parametrize("proto", ['http/1.1'])
@@ -105,20 +107,21 @@ class TestInfo:
         url = f'http://{env.domain1}:{env.http_port}/data.json?[0-{count-1}]'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_stats=True)
         r.check_stats(count=count, http_status=200, exitcode=0)
-        for s in r.stats:
-            self.check_stat(s, dl_size=30, ul_size=0)
+        for idx, s in enumerate(r.stats):
+            self.check_stat(idx, s, r, dl_size=30, ul_size=0)
 
-    def check_stat(self, s, dl_size=None, ul_size=None):
+    def check_stat(self, idx, s, r, dl_size=None, ul_size=None):
         self.check_stat_times(s)
         # we always send something
         self.check_stat_positive(s, 'size_request')
         # we always receive response headers
         self.check_stat_positive(s, 'size_header')
         if ul_size is not None:
-            assert s['size_upload'] == ul_size  # the file we sent
-        assert s['size_request'] >= s['size_upload'], f'"size_request" smaller than "size_upload", {s}'
+            assert s['size_upload'] == ul_size, f'stat #{idx}\n{r.dump_logs()}'  # the file we sent
+        assert s['size_request'] >= s['size_upload'], \
+            f'stat #{idx}, "size_request" smaller than "size_upload", {s}\n{r.dump_logs()}'
         if dl_size is not None:
-            assert s['size_download'] == dl_size  # the file we received
+            assert s['size_download'] == dl_size, f'stat #{idx}\n{r.dump_logs()}'  # the file we received
 
     def check_stat_positive(self, s, key):
         assert key in s, f'stat "{key}" missing: {s}'


### PR DESCRIPTION
- identify ngtcp2 and nghttp3 error codes that are fatal
- close quic connection on fatal errors
- refuse further filter operations once connection is closed