### PR TITLE
appveyor: make gcc 6 mingw64 job build-only

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -166,8 +166,8 @@ environment:
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
-      TESTING: 'ON'
-      DISABLED_TESTS: '!1086 !1139 !1451 !1501 !1177 !1477'
+      TESTING: 'OFF'
+      DISABLED_TESTS: ''
       ADD_PATH: 'C:/mingw-w64/i686-6.3.0-posix-dwarf-rt_v5-rev1/mingw32/bin'
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k


### PR DESCRIPTION
This job has proven to be the flakiest of all, and it's also the oldest
Windows runner we had tests running on: 'Visual Studio 2015', that is
running on Windows Server 2012 R2:
  https://www.appveyor.com/docs/windows-images-software/

Turn off tests on this job to help stabilizing CI runs.

This was also one of the slowest running job amongst the AppVeyor CI ones.

Flakiness data:
  https://testclutch.curl.se/static/reports/summary.html
Entries:
  Appveyor / CMake, mingw-w64, gcc 6, Debug, x86, Schannel, Static, no-unity (curl) [current]
  Appveyor / CMake, mingw-w64, gcc 6, Debug, x86, Schannel, Static (curl) [former]

Closes #13566
