### PR TITLE
managen: fix the option sort order

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -984,7 +984,7 @@ sub listglobals {
 
 sub noext {
     my $in = $_[0];
-    $in =~ s/\.d//;
+    $in =~ s/\.md//;
     return $in;
 }
 


### PR DESCRIPTION
... it used to strip off the .d file extension to sort correctly but ever since the extension changed to .md the operation failed and the sort got wrong.

Follow-up to 2494b8dd5175cee7f2e
