### PR TITLE
krb5: use dynbuf

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -241,8 +241,7 @@ typedef CURLcode (*Curl_datastream)(struct Curl_easy *data,
 #ifdef HAVE_GSSAPI
 /* Types needed for krb5-ftp connections */
 struct krb5buffer {
-  void *data;
-  size_t size;
+  struct dynbuf buf;
   size_t index;
   BIT(eof_flag);
 };


### PR DESCRIPTION
We lack tests for krb5 for FTP and I can't run any manual tests. This edit was done "in the blind" but I think it is generally a good idea even if there is a risk that I broke something here.

- saves having to do repeated reallocs by reusing the dynbuf
- avoids direct uses of realloc + memcpy
