### PR TITLE
libssh2: also try `fopen()` when looking for implicit keys

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -960,12 +960,15 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data)
 
 static int libssh2_open_key(const char *filename)
 {
-  FILE *fd = fopen(filename, FOPEN_READTEXT);
-  if(!fd) {
-    return 1;
+  struct_stat sbuf;
+  if(!stat(filename, &sbuf)) {
+    FILE *fd = fopen(filename, FOPEN_READTEXT);
+    if(fd) {
+      fclose(fd);
+      return 0;
+    }
   }
-  fclose(fd);
-  return 0;
+  return 1;
 }
 
 /*


### PR DESCRIPTION
Replace `stat()` calls with `fopen(.., FOPEN_READTEXT)`, which is
how libssh2 opens these files at a later point.

Follow-up to 602fc213aeda9e9bb2879143942d850e000b2ea6 #13498

Bug: https://github.com/curl/curl/commit/602fc213aeda9e9bb2879143942d850e000b2ea6#r141676880
Reported-by: Harry Sintonen
Closes #13571

---

/cc @piru