### PR TITLE
lib: clear the easy handle's saved errno before transfer

### DIFF
--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
@@ -29,6 +29,14 @@ Pass a pointer to a long to receive the errno variable from a connect failure.
 Note that the value is only set on failure, it is not reset upon a successful
 operation. The number is OS and system specific.
 
+libcurl network-related errors that may have a saved errno are:
+CURLE_COULDNT_CONNECT, CURLE_FAILED_INIT, CURLE_INTERFACE_FAILED,
+CURLE_OPERATION_TIMEDOUT, CURLE_RECV_ERROR, CURLE_SEND_ERROR.
+
+Since 8.8.0 libcurl clears the easy handle's saved errno before performing the
+transfer. Prior versions did not clear the saved errno, which means if a saved
+errno is retrieved it could be from a previous transfer on the same handle.
+
 # EXAMPLE
 
 ~~~c

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -728,6 +728,8 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
     /* clear this as early as possible */
     data->set.errorbuffer[0] = 0;
 
+  data->state.os_errno = 0;
+
   if(data->multi) {
     failf(data, "easy handle already used in multi handle");
     return CURLE_FAILED_INIT;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -552,6 +552,8 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
   if(data->set.errorbuffer)
     data->set.errorbuffer[0] = 0;
 
+  data->state.os_errno = 0;
+
   /* make the Curl_easy refer back to this multi handle - before Curl_expire()
      is called. */
   data->multi = multi;


### PR DESCRIPTION
- Clear data->state.os_errno before transfer.

- Explain the change in behavior in the CURLINFO_OS_ERRNO doc.

- Add to the CURLINFO_OS_ERRNO doc the list of libcurl network-related errors that may cause the errno to be saved.

data->state.os_errno is saved before libcurl returns a network-related failure such as connection failure. It is accessible to the user via CURLINFO_OS_ERRNO so they can get more information about the failure.

Prior to this change it wasn't cleared before transfer so if a user retrieved the saved errno it could be from a previous transfer. That is because an errno is not always saved for network-related errors.

Closes #xxxxx