### PR TITLE
tool_getparam: remove two redundant conditions

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -894,8 +894,7 @@ static ParameterError data_urlencode(struct GlobalConfig *global,
     err = getstr(&postdata, p, ALLOW_BLANK);
     if(err)
       goto error;
-    if(postdata)
-      size = strlen(postdata);
+    size = strlen(postdata);
   }
 
   if(!postdata) {
@@ -1124,8 +1123,7 @@ static ParameterError set_data(cmdline_t cmd,
     err = getstr(&postdata, nextarg, ALLOW_BLANK);
     if(err)
       return err;
-    if(postdata)
-      size = strlen(postdata);
+    size = strlen(postdata);
   }
   if(cmd == C_JSON)
     config->jsoned = TRUE;


### PR DESCRIPTION
When getstr() does not return error, it returns a valid pointer.

Spotted by CodeSonar