### PR TITLE
cf-socket: don't try getting local IP without socket

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -923,7 +923,8 @@ static CURLcode set_local_ip(struct Curl_cfilter *cf,
   struct cf_socket_ctx *ctx = cf->ctx;
 
 #ifdef HAVE_GETSOCKNAME
-  if(!(data->conn->handler->protocol & CURLPROTO_TFTP)) {
+  if((ctx->sock != CURL_SOCKET_BAD) &&
+     !(data->conn->handler->protocol & CURLPROTO_TFTP)) {
     /* TFTP does not connect, so it cannot get the IP like this */
 
     char buffer[STRERROR_LEN];


### PR DESCRIPTION
In cf_tcp_connect(), it might fail and not get a socket assigned to ctx->sock but set_local_ip() is still called which would make getsockname() get invoked with a negative file desriptor and fail.

By adding this check, set_local_ip() will now instead blank out the fields correctly.

Spotted by CodeSonar