### PR TITLE
cmake: Fix build with GCC 14 + MinGW

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -228,7 +228,7 @@ int main(void)
 #endif
 int main(void)
 {
-  int flags = 0;
+  unsigned long flags = 0;
   if(0 != ioctlsocket(0, FIONBIO, &flags))
     return 1;
   ;


### PR DESCRIPTION
The function signature has had u_long flags since ever. This is how it is defined in the documentation, and implemented in MinGW.

The code that uses ioctlsocket in nonblock.c also has unsigned long.

Error:
```
CurlTests.c:275:41: error: passing argument 3 of 'ioctlsocket' from incompatible pointer type [-Wincompatible-pointer-types]
  275 |         if(0 != ioctlsocket(0, FIONBIO, &flags))
      |                                         ^~~~~~
      |                                         |
      |                                         int *
In file included from CurlTests.c:266:
/opt/mxe/usr/i686-w64-mingw32.static/include/winsock2.h:1007:76: note: expected 'u_long *' {aka 'long unsigned int *'} but argument is of type 'int *'
 1007 |   WINSOCK_API_LINKAGE int WSAAPI ioctlsocket(SOCKET s,__LONG32 cmd,u_long *argp);
      |                                                                    ~~~~~~~~^~~~
```

Closes #13578
