### PR TITLE
GHA: add NetBSD, OpenBSD, FreeBSD/arm64 and OmniOS jobs

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -63,8 +63,8 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=ON \
-              -DBUILD_TESTING=ON
+              -DBUILD_TESTING=ON \
+              -DBUILD_EXAMPLES=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -95,8 +95,8 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=ON \
-              -DBUILD_TESTING=ON
+              -DBUILD_TESTING=ON \
+              -DBUILD_EXAMPLES=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -156,8 +156,8 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=ON \
-              -DBUILD_TESTING=ON
+              -DBUILD_TESTING=ON \
+              -DBUILD_EXAMPLES=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -67,6 +67,7 @@ jobs:
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             cmake --build bld --config Debug --parallel 3 --target testdeps
+            export TFLAGS='-j12'
             cmake --build bld --config Debug --target test-ci
 
   openbsd:
@@ -96,7 +97,7 @@ jobs:
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             cmake --build bld --config Debug --parallel 3 --target testdeps
-            export TFLAGS='~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
+            export TFLAGS='-j12 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
             cmake --build bld --config Debug --target test-ci
 
   freebsd:
@@ -178,4 +179,5 @@ jobs:
               --disable-dependency-tracking
             gmake -j3
             src/curl --disable --version
+            export TFLAGS='-j12'
             gmake check V=1

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -63,9 +63,11 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=ON
+              -DBUILD_EXAMPLES=ON \
+              -DCURL_BROTLI=ON
             cmake --build bld --config Debug --parallel 3
-            bld/src/curl --disable --version
+            export CURL=$(pwd)/bld/src/curl
+            "${CURL}" --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
               cmake --build bld --config Debug --target test-ci
@@ -94,9 +96,11 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=ON
+              -DBUILD_EXAMPLES=ON \
+              -DCURL_BROTLI=ON
             cmake --build bld --config Debug --parallel 3
-            bld/src/curl --disable --version
+            export CURL=$(pwd)/bld/src/curl
+            "${CURL}" --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j12 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
@@ -124,7 +128,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y autoconf automake libtool brotli openldap26-client libssh2 libidn2 libnghttp2 perl5 python3
+            sudo pkg install -y autoconf automake libtool pkgconf brotli openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
@@ -148,7 +152,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y cmake brotli openldap26-client libssh2 libidn2 libnghttp2 perl5 python3
+            sudo pkg install -y cmake pkgconf brotli openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             cmake -B bld \
               -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
@@ -156,7 +160,8 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=ON
+              -DBUILD_EXAMPLES=ON \
+              -DCURL_BROTLI=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -176,7 +181,7 @@ jobs:
         with:
           usesh: true
           # https://pkg.omnios.org/r151048/core/en/index.shtml
-          prepare: pkg install build-essential libtool brotli nghttp2
+          prepare: pkg install build-essential libtool
           run: |
             pkg uninstall curl
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -128,13 +128,15 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y autoconf automake libtool brotli openldap26-client libidn2 libnghttp2 perl5 python3
+            # FIXME: brotli + --with-brotli results in:
+            #        configure: error: BROTLI libs and/or directories were not found where specified!
+            sudo pkg install -y autoconf automake libtool openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --with-openssl \
-              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 \
+              --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             make -j3
             src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -103,7 +103,7 @@ jobs:
             "${CURL}" --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
-              export TFLAGS='-j12 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
+              export TFLAGS='-j8 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
               cmake --build bld --config Debug --target test-ci
             fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -99,28 +99,30 @@ jobs:
             export TFLAGS='~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
             cmake --build bld --config Debug --target test-ci
 
-  freebsd_autotools:
-    name: 'FreeBSD (autotools, openssl, clang, build-only)'
+  freebsd:
+    name: 'FreeBSD (cmake, openssl, clang, build-only)'
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    env:
-      CC: clang
     strategy:
       matrix:
-        arch: ['arm64']
+        include:
+          - { build: 'autotools', arch: 'arm64' , compiler: 'clang' }
+          - { build: 'cmake'    , arch: 'x86_64', compiler: 'clang' }
     steps:
       - uses: actions/checkout@v4
+
       - name: 'autotools'
+        if: ${{ matrix.build == 'autotools' }}
         uses: cross-platform-actions/action@v0.24.0
         with:
           operating_system: 'freebsd'
           version: '14.0'
           architecture: ${{ matrix.arch }}
-          environment_variables: 'CC'
           run: |
             # https://ports.freebsd.org/
             sudo pkg install -y autoconf automake libtool
             autoreconf -fi
+            export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --with-openssl \
               --disable-dependency-tracking
@@ -128,29 +130,18 @@ jobs:
             src/curl --disable --version
             #make check V=1  # Slow, let's skip building/running tests for now
 
-  freebsd_cmake:
-    name: 'FreeBSD (cmake, openssl, clang, build-only)'
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      CC: clang
-    strategy:
-      matrix:
-        arch: ['arm64']
-    steps:
-      - uses: actions/checkout@v4
-      - name: 'autotools'
+      - name: 'cmake'
+        if: ${{ matrix.build == 'cmake' }}
         uses: cross-platform-actions/action@v0.24.0
         with:
           operating_system: 'freebsd'
           version: '14.0'
           architecture: ${{ matrix.arch }}
-          environment_variables: 'CC'
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y cmake
+            sudo pkg install -y cmake perl
             cmake -B bld \
-              "-DCMAKE_C_COMPILER=${CC}" \
+              -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
@@ -158,8 +149,9 @@ jobs:
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
+            # Slow, let's skip building/running tests for now
             cmake --build bld --config Debug --parallel 3 --target testdeps
-            #cmake --build bld --config Debug --target test-ci  # Slow, let's skip building/running tests for now
+            #cmake --build bld --config Debug --target test-ci
 
   omnios:
     name: 'OmniOS (autotools, openssl, gcc, amd64)'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -128,7 +128,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y autoconf automake libtool pkgconf brotli openldap26-client libidn2 libnghttp2 perl5 python3
+            sudo pkg install -y autoconf automake libtool brotli openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
@@ -153,7 +153,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y cmake pkgconf brotli openldap26-client libidn2 libnghttp2 perl5 python3
+            sudo pkg install -y cmake brotli openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             cmake -B bld \
               -DCMAKE_C_COMPILER=${{ matrix.compiler }} \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -57,7 +57,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake perl python312 py-impacket
+            sudo pkgin -y install cmake perl python311 py311-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -109,7 +109,6 @@ jobs:
         include:
           - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
           - { build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
-          - { build: 'cmake'    , arch: 'x86_64', compiler: 'gcc' }
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -128,15 +128,17 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            # FIXME: brotli + --with-brotli results in:
-            #        configure: error: BROTLI libs and/or directories were not found where specified!
-            sudo pkg install -y autoconf automake libtool openldap26-client libidn2 libnghttp2 perl5 python3
+            # FIXME: brotli + --with-brotli breaks ./configure:
+            #          configure: error: BROTLI libs and/or directories were not found where specified!
+            #        also openldap26-client + --enable-ldap --enable-ldaps
+            #          configure: error: couldn't detect the LDAP libraries
+            sudo pkg install -y autoconf automake libtool pkgconf brotli openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --with-openssl \
-              --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 \
+              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             make -j3
             src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -108,9 +108,9 @@ jobs:
         include:
           - { build: 'autotools', arch: 'arm64' , compiler: 'clang' }
           - { build: 'cmake'    , arch: 'x86_64', compiler: 'clang' }
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
-
       - name: 'autotools'
         if: ${{ matrix.build == 'autotools' }}
         uses: cross-platform-actions/action@v0.24.0
@@ -139,7 +139,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y cmake perl
+            sudo pkg install -y cmake perl5
             cmake -B bld \
               -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
               -DCMAKE_UNITY_BUILD=ON \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -63,7 +63,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=OFF \
+              -DBUILD_EXAMPLES=ON \
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
@@ -93,7 +93,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=OFF \
+              -DBUILD_EXAMPLES=ON \
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
@@ -152,7 +152,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=OFF \
+              -DBUILD_EXAMPLES=ON \
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -128,7 +128,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y autoconf automake libtool pkgconf brotli openldap26-client libidn2 libnghttp2 perl5 python3
+            sudo pkg install -y autoconf automake libtool pkgconf brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel py39-openssl py39-impacket py39-cryptography
             sudo pkg delete -y curl
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
@@ -153,7 +153,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y cmake brotli openldap26-client libidn2 libnghttp2 perl5 python3
+            sudo pkg install -y cmake brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel py39-openssl py39-impacket py39-cryptography
             sudo pkg delete -y curl
             cmake -B bld \
               -DCMAKE_C_COMPILER=${{ matrix.compiler }} \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -67,8 +67,10 @@ jobs:
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
-            cmake --build bld --config Debug --parallel 3 --target testdeps
-            cmake --build bld --config Debug --target test-ci
+            if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
+              cmake --build bld --config Debug --parallel 3 --target testdeps
+              cmake --build bld --config Debug --target test-ci
+            fi
 
   openbsd:
     name: 'OpenBSD (cmake, libressl, clang)'
@@ -97,9 +99,11 @@ jobs:
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
-            cmake --build bld --config Debug --parallel 3 --target testdeps
-            export TFLAGS='-j12 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
-            cmake --build bld --config Debug --target test-ci
+            if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
+              cmake --build bld --config Debug --parallel 3 --target testdeps
+              export TFLAGS='-j12 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
+              cmake --build bld --config Debug --target test-ci
+            fi
 
   freebsd:
     name: 'FreeBSD (${{ matrix.build }}, openssl, ${{ matrix.compiler }}, ${{ matrix.arch }})'
@@ -131,7 +135,7 @@ jobs:
             make -j3
             src/curl --disable --version
             make -j3 examples
-            if [ '${{ matrix.arch }}' = 'x86_64' ]; then
+            if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               export TFLAGS='-j12'
               make check V=1
             fi
@@ -156,7 +160,7 @@ jobs:
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
-            if [ '${{ matrix.arch }}' = 'x86_64' ]; then
+            if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j12'
               cmake --build bld --config Debug --target test-ci

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -97,7 +97,6 @@ jobs:
             bld/src/curl --disable --version
             cmake --build bld --config Debug --parallel 3 --target testdeps
             export TFLAGS='~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
-            find . -type d -exec chmod 777 {} \;
             cmake --build bld --config Debug --target test-ci
 
   freebsd:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -98,6 +98,7 @@ jobs:
             cmake --build bld --config Debug --parallel 3 --target testdeps
             # FIXME: TFTP requests executed twice?
             #export TFLAGS='!TFTP'
+            find . -type d -exec chmod 777 {} \;
             cmake --build bld --config Debug --target test-ci
 
   build_freebsd:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -57,7 +57,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake perl python py-impacket
+            sudo pkgin -y install cmake perl python312 py-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -99,7 +99,7 @@ jobs:
             export TFLAGS='~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
             cmake --build bld --config Debug --target test-ci
 
-  freebsd:
+  freebsd_autotools:
     name: 'FreeBSD (autotools, openssl, clang, build-only)'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -127,6 +127,39 @@ jobs:
             make -j3
             src/curl --disable --version
             #make check V=1  # Slow, let's skip building/running tests for now
+
+  freebsd_cmake:
+    name: 'FreeBSD (autotools, openssl, clang, build-only)'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      CC: clang
+    strategy:
+      matrix:
+        arch: ['arm64']
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'autotools'
+        uses: cross-platform-actions/action@v0.24.0
+        with:
+          operating_system: 'freebsd'
+          version: '14.0'
+          architecture: ${{ matrix.arch }}
+          environment_variables: 'CC'
+          run: |
+            # https://ports.freebsd.org/
+            #sudo pkg install -y cmake
+            cmake -B bld \
+              "-DCMAKE_C_COMPILER=${CC}" \
+              -DCMAKE_UNITY_BUILD=ON \
+              -DCURL_USE_OPENSSL=ON \
+              -DCURL_WERROR=ON \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DBUILD_TESTING=ON
+            cmake --build bld --config Debug --parallel 3
+            bld/src/curl --disable --version
+            cmake --build bld --config Debug --parallel 3 --target testdeps
+            #cmake --build bld --config Debug --target test-ci  # Slow, let's skip building/running tests for now
 
   omnios:
     name: 'OmniOS (autotools, openssl, gcc, amd64)'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -133,10 +133,11 @@ jobs:
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
+              --prefix="${HOME}"/install \
               --with-openssl \
               --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
-            make -j3
+            make -j3 install
             src/curl --disable --version
             make -j3 examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -188,9 +189,10 @@ jobs:
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
             autoreconf -fi
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
+              --prefix="${HOME}"/install \
               --with-openssl \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
-            gmake -j3
+            gmake -j3 install
             src/curl --disable --version
             gmake -j3 examples
             export TFLAGS='-j12'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -57,7 +57,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake perl  # python311 py311-impacket
+            sudo pkgin -y install cmake perl brotli openldap-client libssh2 libidn2 nghttp2  # python311 py311-impacket
             sudo pkgin -y remove curl
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
@@ -89,7 +89,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake perl python3 py3-impacket
+            sudo pkg_add cmake perl brotli openldap-client libssh2 libidn2 nghttp2 python3 py3-impacket
             sudo pkg_delete curl
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
@@ -126,7 +126,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y autoconf automake libtool perl5 python3
+            sudo pkg install -y autoconf automake libtool brotli openldap26-client libssh2 libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
@@ -150,7 +150,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y cmake perl5 python3
+            sudo pkg install -y cmake brotli openldap26-client libssh2 libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             cmake -B bld \
               -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
@@ -178,7 +178,7 @@ jobs:
         with:
           usesh: true
           # https://pkg.omnios.org/r151048/core/en/index.shtml
-          prepare: pkg install build-essential libtool
+          prepare: pkg install build-essential libtool brotli nghttp2
           run: |
             pkg uninstall curl
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -57,7 +57,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake perl python
+            sudo pkgin -y install cmake perl python py-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -87,7 +87,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake perl python3
+            sudo pkg_add cmake perl python3 py3-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -172,7 +172,7 @@ jobs:
         with:
           usesh: true
           # https://pkg.omnios.org/r151048/core/en/index.shtml
-          prepare: pkg install build-essential libtool
+          prepare: pkg install build-essential libtool python-3
           run: |
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
             autoreconf -fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -128,6 +128,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
+            sudo pkg update -f
             sudo pkg install -y autoconf automake libtool brotli openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             autoreconf -fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -57,7 +57,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake perl brotli openldap-client libssh2 libidn2 nghttp2  # python311 py311-impacket
+            sudo pkgin -y install cmake perl brotli openldap-client libssh2 libidn2 libpsl nghttp2  # python311 py311-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -90,7 +90,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake perl brotli openldap-client libssh2 libidn2 nghttp2 python3 py3-impacket
+            sudo pkg_add cmake perl brotli openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -134,6 +134,7 @@ jobs:
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --with-openssl \
+              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             make -j3
             src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -101,7 +101,7 @@ jobs:
             cmake --build bld --config Debug --target test-ci
 
   freebsd:
-    name: 'FreeBSD (${{ matrix.build }}, ${{ matric.arch }}, openssl, ${{ matrix.compiler }})'
+    name: 'FreeBSD (${{ matrix.build }}, ${{ matrix.arch }}, openssl, ${{ matrix.compiler }})'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -135,7 +135,7 @@ jobs:
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
               --with-openssl \
-              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 \
+              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 --with-gssapi \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             make -j3 install
             src/curl --disable --version
@@ -163,7 +163,7 @@ jobs:
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
-              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -63,7 +63,6 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_TESTING=ON \
               -DBUILD_EXAMPLES=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
@@ -95,7 +94,6 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_TESTING=ON \
               -DBUILD_EXAMPLES=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
@@ -156,7 +154,6 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_TESTING=ON \
               -DBUILD_EXAMPLES=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -107,10 +107,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', arch: 'arm64' , compiler: 'clang' }
           - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
           - { build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
-          - { build: 'cmake'    , arch: 'x86_64', compiler: 'clang' }
+          - { build: 'cmake'    , arch: 'x86_64', compiler: 'gcc' }
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -58,6 +58,7 @@ jobs:
           run: |
             # https://pkgsrc.se/
             sudo pkgin -y install cmake perl  # python311 py311-impacket
+            sudo pkgin -y remove curl
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -89,6 +90,7 @@ jobs:
           run: |
             # https://openbsd.app/
             sudo pkg_add cmake perl python3 py3-impacket
+            sudo pkg_delete curl
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -125,6 +127,7 @@ jobs:
           run: |
             # https://ports.freebsd.org/
             sudo pkg install -y autoconf automake libtool perl5 python3
+            sudo pkg delete -y curl
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
@@ -148,6 +151,7 @@ jobs:
           run: |
             # https://ports.freebsd.org/
             sudo pkg install -y cmake perl5 python3
+            sudo pkg delete -y curl
             cmake -B bld \
               -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
               -DCMAKE_UNITY_BUILD=ON \
@@ -176,6 +180,7 @@ jobs:
           # https://pkg.omnios.org/r151048/core/en/index.shtml
           prepare: pkg install build-essential libtool
           run: |
+            pkg uninstall curl
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
             autoreconf -fi
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -106,8 +106,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
-          - { build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
+          - { build: 'autotools', arch: 'arm64', compiler: 'clang' }
+          - { build: 'cmake'    , arch: 'arm64', compiler: 'clang' }
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -64,7 +64,7 @@ jobs:
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
-              -DCURL_BROTLI=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
             cmake --build bld --config Debug --parallel 3
             export CURL=$(pwd)/bld/src/curl
             "${CURL}" --disable --version
@@ -97,7 +97,7 @@ jobs:
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
-              -DCURL_BROTLI=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
             cmake --build bld --config Debug --parallel 3
             export CURL=$(pwd)/bld/src/curl
             "${CURL}" --disable --version
@@ -161,7 +161,7 @@ jobs:
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
-              -DCURL_BROTLI=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -129,7 +129,7 @@ jobs:
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --with-openssl \
-              --disable-dependency-tracking
+              --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             make -j3
             src/curl --disable --version
             make -j3 examples
@@ -180,7 +180,7 @@ jobs:
             autoreconf -fi
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --with-openssl \
-              --disable-dependency-tracking
+              --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             gmake -j3
             src/curl --disable --version
             gmake -j3 examples

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -64,7 +64,7 @@ jobs:
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
               -DCURL_USE_OPENSSL=ON \
-              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
             cmake --build bld --config Debug --parallel 3
             export CURL=$(pwd)/bld/src/curl
             "${CURL}" --disable --version
@@ -97,7 +97,7 @@ jobs:
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
               -DCURL_USE_OPENSSL=ON \
-              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
             cmake --build bld --config Debug --parallel 3
             export CURL=$(pwd)/bld/src/curl
             "${CURL}" --disable --version
@@ -191,6 +191,7 @@ jobs:
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
               --with-openssl \
+              --with-libidn2 --with-gssapi \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             gmake -j3 install
             src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -187,7 +187,7 @@ jobs:
         with:
           usesh: true
           # https://pkg.omnios.org/r151048/core/en/index.shtml
-          prepare: pkg install build-essential libtool gss
+          prepare: pkg install build-essential libtool library/security/gss
           run: |
             pkg uninstall curl
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -170,7 +170,7 @@ jobs:
         with:
           usesh: true
           # https://pkg.omnios.org/r151048/core/en/index.shtml
-          prepare: pkg install build-essential libtool python-3
+          prepare: pkg install build-essential libtool python
           run: |
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
             autoreconf -fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -127,8 +127,7 @@ jobs:
               --disable-dependency-tracking
             make -j3
             src/curl --disable --version
-            # Slow, let's skip building/running tests for now
-            #make check V=1
+            #make check V=1  # Slow, let's skip building/running tests for now
 
   build_omnios:
     name: 'OmniOS (autotools, openssl, gcc, amd64)'
@@ -143,8 +142,7 @@ jobs:
           # https://pkg.omnios.org/r151048/core/en/index.shtml
           prepare: pkg install build-essential libtool
           run: |
-            # Some tests expect `cpp`, which is named `gcpp` in this env.
-            ln -s /usr/bin/gcpp /usr/bin/cpp
+            ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
             autoreconf -fi
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --with-openssl \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -57,7 +57,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake perl
+            sudo pkgin -y install cmake perl python
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -87,7 +87,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake perl
+            sudo pkg_add cmake perl python3
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -101,13 +101,15 @@ jobs:
             cmake --build bld --config Debug --target test-ci
 
   freebsd:
-    name: 'FreeBSD (${{ matrix.build }}, ${{ matrix.arch }}, openssl, ${{ matrix.compiler }})'
+    name: 'FreeBSD (${{ matrix.build }}, openssl, ${{ matrix.compiler }}, ${{ matrix.arch }})'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       matrix:
         include:
           - { build: 'autotools', arch: 'arm64' , compiler: 'clang' }
+          - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
+          - { build: 'cmake'    , arch: 'arm64' , compiler: 'clang' }
           - { build: 'cmake'    , arch: 'x86_64', compiler: 'clang' }
       fail-fast: false
     steps:
@@ -121,7 +123,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y autoconf automake libtool
+            sudo pkg install -y autoconf automake libtool perl5 python3
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
@@ -143,7 +145,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y cmake perl5
+            sudo pkg install -y cmake perl5 python3
             cmake -B bld \
               -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
               -DCMAKE_UNITY_BUILD=ON \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -100,7 +100,7 @@ jobs:
             cmake --build bld --config Debug --target test-ci
 
   freebsd:
-    name: 'FreeBSD (cmake, openssl, clang, build-only)'
+    name: 'FreeBSD (${{ matrix.build }}, ${{ matric.arch }}, openssl, ${{ matrix.compiler }})'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -128,7 +128,10 @@ jobs:
               --disable-dependency-tracking
             make -j3
             src/curl --disable --version
-            #make check V=1  # Slow, let's skip building/running tests for now
+            if [ '${{ matrix.arch }}' = 'x86_64' ]; then
+              export TFLAGS='-j12'
+              make check V=1
+            fi
 
       - name: 'cmake'
         if: ${{ matrix.build == 'cmake' }}
@@ -149,9 +152,11 @@ jobs:
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
-            # Slow, let's skip building/running tests for now
-            cmake --build bld --config Debug --parallel 3 --target testdeps
-            #cmake --build bld --config Debug --target test-ci
+            if [ '${{ matrix.arch }}' = 'x86_64' ]; then
+              cmake --build bld --config Debug --parallel 3 --target testdeps
+              export TFLAGS='-j12'
+              cmake --build bld --config Debug --target test-ci
+            fi
 
   omnios:
     name: 'OmniOS (autotools, openssl, gcc, amd64)'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -57,7 +57,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake perl brotli openldap-client libssh2 libidn2 libpsl nghttp2  # python311 py311-impacket
+            sudo pkgin -y install cmake perl brotli heimdal openldap-client libssh2 libidn2 libpsl nghttp2  # python311 py311-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \
@@ -91,7 +91,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake perl brotli openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
+            sudo pkg_add cmake perl brotli heimdal-libs openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \
@@ -187,7 +187,7 @@ jobs:
         with:
           usesh: true
           # https://pkg.omnios.org/r151048/core/en/index.shtml
-          prepare: pkg install build-essential libtool
+          prepare: pkg install build-essential libtool gss
           run: |
             pkg uninstall curl
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
@@ -196,7 +196,7 @@ jobs:
               --prefix="${HOME}"/install \
               --enable-websockets \
               --with-openssl \
-              --with-libidn2 --with-gssapi \
+              --with-gssapi \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             gmake -j3 install
             src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -58,7 +58,6 @@ jobs:
           run: |
             # https://pkgsrc.se/
             sudo pkgin -y install cmake perl brotli openldap-client libssh2 libidn2 nghttp2  # python311 py311-impacket
-            sudo pkgin -y remove curl
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
@@ -90,7 +89,6 @@ jobs:
           run: |
             # https://openbsd.app/
             sudo pkg_add cmake perl brotli openldap-client libssh2 libidn2 nghttp2 python3 py3-impacket
-            sudo pkg_delete curl
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -60,10 +60,10 @@ jobs:
             sudo pkgin -y install cmake perl brotli openldap-client libssh2 libidn2 libpsl nghttp2  # python311 py311-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
+              -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
             cmake --build bld --config Debug --parallel 3
             export CURL=$(pwd)/bld/src/curl
@@ -93,10 +93,10 @@ jobs:
             sudo pkg_add cmake perl brotli openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
+              -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
             cmake --build bld --config Debug --parallel 3
             export CURL=$(pwd)/bld/src/curl
@@ -159,10 +159,10 @@ jobs:
             cmake -B bld \
               -DCMAKE_C_COMPILER=${{ matrix.compiler }} \
               -DCMAKE_UNITY_BUILD=ON \
-              -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
+              -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -187,7 +187,7 @@ jobs:
         with:
           usesh: true
           # https://pkg.omnios.org/r151048/core/en/index.shtml
-          prepare: pkg install build-essential libtool library/security/gss
+          prepare: pkg install build-essential libtool
           run: |
             pkg uninstall curl
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
@@ -196,7 +196,6 @@ jobs:
               --prefix="${HOME}"/install \
               --enable-websockets \
               --with-openssl \
-              --with-gssapi \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             gmake -j3 install
             src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -91,7 +91,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake perl brotli heimdal-libs openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
+            sudo pkg_add cmake perl brotli heimdal openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -63,6 +63,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DBUILD_EXAMPLES=OFF \
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
@@ -92,6 +93,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DBUILD_EXAMPLES=OFF \
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
@@ -128,6 +130,7 @@ jobs:
               --disable-dependency-tracking
             make -j3
             src/curl --disable --version
+            make -j3 examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then
               export TFLAGS='-j12'
               make check V=1
@@ -149,6 +152,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DBUILD_EXAMPLES=OFF \
               -DBUILD_TESTING=ON
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
@@ -178,5 +182,6 @@ jobs:
               --disable-dependency-tracking
             gmake -j3
             src/curl --disable --version
+            gmake -j3 examples
             export TFLAGS='-j12'
             gmake check V=1

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -128,7 +128,6 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg update -f
             sudo pkg install -y autoconf automake libtool brotli openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             autoreconf -fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -67,7 +67,7 @@ jobs:
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             cmake --build bld --config Debug --parallel 3 --target testdeps
-            export TFLAGS='-j8'
+            export TFLAGS='-j2'
             cmake --build bld --config Debug --target test-ci
 
   openbsd:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -97,7 +97,7 @@ jobs:
             bld/src/curl --disable --version
             cmake --build bld --config Debug --parallel 3 --target testdeps
             # FIXME: TFTP requests executed twice?
-            export TFLAGS='!TFTP'
+            #export TFLAGS='!TFTP'
             cmake --build bld --config Debug --target test-ci
 
   build_freebsd:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -63,6 +63,7 @@ jobs:
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
+              -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
             cmake --build bld --config Debug --parallel 3
@@ -96,6 +97,7 @@ jobs:
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
+              -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
             cmake --build bld --config Debug --parallel 3
@@ -134,6 +136,7 @@ jobs:
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
+              --enable-websockets \
               --with-openssl \
               --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 --with-gssapi \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
@@ -162,6 +165,7 @@ jobs:
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_EXAMPLES=ON \
+              -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
             cmake --build bld --config Debug --parallel 3
@@ -190,6 +194,7 @@ jobs:
             autoreconf -fi
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
+              --enable-websockets \
               --with-openssl \
               --with-libidn2 --with-gssapi \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -91,7 +91,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake perl brotli heimdal openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
+            sudo pkg_add cmake perl brotli openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \
@@ -99,7 +99,7 @@ jobs:
               -DBUILD_EXAMPLES=ON \
               -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
-              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
             cmake --build bld --config Debug --parallel 3
             export CURL=$(pwd)/bld/src/curl
             "${CURL}" --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -134,7 +134,7 @@ jobs:
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --with-openssl \
-              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2
+              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             make -j3
             src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -57,7 +57,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake perl python311 py311-impacket
+            sudo pkgin -y install cmake perl  # python311 py311-impacket
             cmake -B bld \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -128,15 +128,13 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            # FIXME: brotli + --with-brotli results in:
-            #        configure: error: BROTLI libs and/or directories were not found where specified!
-            sudo pkg install -y autoconf automake libtool openldap26-client libidn2 libnghttp2 perl5 python3
+            sudo pkg install -y autoconf automake libtool brotli openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
               --with-openssl \
-              --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 \
+              --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             make -j3
             src/curl --disable --version

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -62,14 +62,14 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_C_FLAGS=-DDEBUGBUILD \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_TESTING=ON \
               -DBUILD_EXAMPLES=ON
-            cmake --build bld --parallel 3
+            cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              cmake --build bld --parallel 3 --target testdeps
-              cmake --build bld --target test-ci
+              cmake --build bld --config Debug --parallel 3 --target testdeps
+              cmake --build bld --config Debug --target test-ci
             fi
 
   openbsd:
@@ -94,15 +94,15 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_C_FLAGS=-DDEBUGBUILD \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_TESTING=ON \
               -DBUILD_EXAMPLES=ON
-            cmake --build bld --parallel 3
+            cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              cmake --build bld --parallel 3 --target testdeps
+              cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j12 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
-              cmake --build bld --target test-ci
+              cmake --build bld --config Debug --target test-ci
             fi
 
   freebsd:
@@ -155,15 +155,15 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_C_FLAGS=-DDEBUGBUILD \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
               -DBUILD_TESTING=ON \
               -DBUILD_EXAMPLES=ON
-            cmake --build bld --parallel 3
+            cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              cmake --build bld --parallel 3 --target testdeps
+              cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j12'
-              cmake --build bld --target test-ci
+              cmake --build bld --config Debug --target test-ci
             fi
 
   omnios:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -170,7 +170,7 @@ jobs:
         with:
           usesh: true
           # https://pkg.omnios.org/r151048/core/en/index.shtml
-          prepare: pkg install build-essential libtool python3
+          prepare: pkg install build-essential libtool
           run: |
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
             autoreconf -fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -62,14 +62,14 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DENABLE_DEBUG=ON -DCMAKE_C_FLAGS=-DDEBUGBUILD \
               -DBUILD_TESTING=ON \
               -DBUILD_EXAMPLES=ON
-            cmake --build bld --config Debug --parallel 3
+            cmake --build bld --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              cmake --build bld --config Debug --parallel 3 --target testdeps
-              cmake --build bld --config Debug --target test-ci
+              cmake --build bld --parallel 3 --target testdeps
+              cmake --build bld --target test-ci
             fi
 
   openbsd:
@@ -94,15 +94,15 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DENABLE_DEBUG=ON -DCMAKE_C_FLAGS=-DDEBUGBUILD \
               -DBUILD_TESTING=ON \
               -DBUILD_EXAMPLES=ON
-            cmake --build bld --config Debug --parallel 3
+            cmake --build bld --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              cmake --build bld --config Debug --parallel 3 --target testdeps
+              cmake --build bld --parallel 3 --target testdeps
               export TFLAGS='-j12 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
-              cmake --build bld --config Debug --target test-ci
+              cmake --build bld --target test-ci
             fi
 
   freebsd:
@@ -155,15 +155,15 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DENABLE_DEBUG=ON -DCMAKE_C_FLAGS=-DDEBUGBUILD \
               -DBUILD_TESTING=ON \
               -DBUILD_EXAMPLES=ON
-            cmake --build bld --config Debug --parallel 3
+            cmake --build bld --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              cmake --build bld --config Debug --parallel 3 --target testdeps
+              cmake --build bld --parallel 3 --target testdeps
               export TFLAGS='-j12'
-              cmake --build bld --config Debug --target test-ci
+              cmake --build bld --target test-ci
             fi
 
   omnios:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -128,10 +128,6 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            # FIXME: brotli + --with-brotli breaks ./configure:
-            #          configure: error: BROTLI libs and/or directories were not found where specified!
-            #        also openldap26-client + --enable-ldap --enable-ldaps
-            #          configure: error: couldn't detect the LDAP libraries
             sudo pkg install -y autoconf automake libtool pkgconf brotli openldap26-client libidn2 libnghttp2 perl5 python3
             sudo pkg delete -y curl
             autoreconf -fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -40,7 +40,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  build_netbsd:
+  netbsd:
     name: 'NetBSD (cmake, openssl, clang)'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -69,7 +69,7 @@ jobs:
             cmake --build bld --config Debug --parallel 3 --target testdeps
             cmake --build bld --config Debug --target test-ci
 
-  build_openbsd:
+  openbsd:
     name: 'OpenBSD (cmake, libressl, clang)'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -100,7 +100,7 @@ jobs:
             find . -type d -exec chmod 777 {} \;
             cmake --build bld --config Debug --target test-ci
 
-  build_freebsd:
+  freebsd:
     name: 'FreeBSD (autotools, openssl, clang, build-only)'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -129,7 +129,7 @@ jobs:
             src/curl --disable --version
             #make check V=1  # Slow, let's skip building/running tests for now
 
-  build_omnios:
+  omnios:
     name: 'OmniOS (autotools, openssl, gcc, amd64)'
     runs-on: ubuntu-22.04
     timeout-minutes: 30

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -67,7 +67,6 @@ jobs:
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             cmake --build bld --config Debug --parallel 3 --target testdeps
-            export TFLAGS='-j2'
             cmake --build bld --config Debug --target test-ci
 
   openbsd:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -170,7 +170,7 @@ jobs:
         with:
           usesh: true
           # https://pkg.omnios.org/r151048/core/en/index.shtml
-          prepare: pkg install build-essential libtool python
+          prepare: pkg install build-essential libtool python3
           run: |
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
             autoreconf -fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -96,8 +96,7 @@ jobs:
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             cmake --build bld --config Debug --parallel 3 --target testdeps
-            # FIXME: TFTP requests executed twice?
-            #export TFLAGS='!TFTP'
+            export TFLAGS='~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
             find . -type d -exec chmod 777 {} \;
             cmake --build bld --config Debug --target test-ci
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -129,7 +129,7 @@ jobs:
             #make check V=1  # Slow, let's skip building/running tests for now
 
   freebsd_cmake:
-    name: 'FreeBSD (autotools, openssl, clang, build-only)'
+    name: 'FreeBSD (cmake, openssl, clang, build-only)'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -148,7 +148,7 @@ jobs:
           environment_variables: 'CC'
           run: |
             # https://ports.freebsd.org/
-            #sudo pkg install -y cmake
+            sudo pkg install -y cmake
             cmake -B bld \
               "-DCMAKE_C_COMPILER=${CC}" \
               -DCMAKE_UNITY_BUILD=ON \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -67,7 +67,7 @@ jobs:
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             cmake --build bld --config Debug --parallel 3 --target testdeps
-            export TFLAGS='-j12'
+            export TFLAGS='-j8'
             cmake --build bld --config Debug --target test-ci
 
   openbsd:

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1345,6 +1345,8 @@ static CURLcode tftp_do(struct Curl_easy *data, bool *done)
   CURLcode result;
   struct connectdata *conn = data->conn;
 
+  fputs("DEBUG: tftp_do() begin\n", stderr);
+
   *done = FALSE;
 
   if(!conn->proto.tftpc) {
@@ -1364,6 +1366,9 @@ static CURLcode tftp_do(struct Curl_easy *data, bool *done)
   if(!result)
     /* If we have encountered an internal tftp error, translate it. */
     result = tftp_translate_code(state->error);
+
+  fprintf(stderr, "DEBUG: tftp_do() end result:|%d| done:|%d|\n",
+                  (int)result, (int)*done);
 
   return result;
 }

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1345,8 +1345,6 @@ static CURLcode tftp_do(struct Curl_easy *data, bool *done)
   CURLcode result;
   struct connectdata *conn = data->conn;
 
-  fputs("DEBUG: tftp_do() begin\n", stderr);
-
   *done = FALSE;
 
   if(!conn->proto.tftpc) {
@@ -1366,9 +1364,6 @@ static CURLcode tftp_do(struct Curl_easy *data, bool *done)
   if(!result)
     /* If we have encountered an internal tftp error, translate it. */
     result = tftp_translate_code(state->error);
-
-  fprintf(stderr, "DEBUG: tftp_do() end result:|%d| done:|%d|\n",
-                  (int)result, (int)*done);
 
   return result;
 }

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -910,21 +910,32 @@ static CURLcode tftp_state_machine(struct tftp_state_data *state,
   switch(state->state) {
   case TFTP_STATE_START:
     DEBUGF(infof(data, "TFTP_STATE_START"));
+    fputs("DEBUG: tftp_state_machine() TFTP_STATE_START begin\n", stderr);
     result = tftp_send_first(state, event);
+    fprintf(stderr, "DEBUG: tftp_state_machine() TFTP_STATE_START |%d|\n",
+                    (int)result);
     break;
   case TFTP_STATE_RX:
     DEBUGF(infof(data, "TFTP_STATE_RX"));
+    fputs("DEBUG: tftp_state_machine() TFTP_STATE_RX begin\n", stderr);
     result = tftp_rx(state, event);
+    fprintf(stderr, "DEBUG: tftp_state_machine() TFTP_STATE_RX |%d|\n",
+                    (int)result);
     break;
   case TFTP_STATE_TX:
     DEBUGF(infof(data, "TFTP_STATE_TX"));
+    fputs("DEBUG: tftp_state_machine() TFTP_STATE_TX begin\n", stderr);
     result = tftp_tx(state, event);
+    fprintf(stderr, "DEBUG: tftp_state_machine() TFTP_STATE_TX |%d|\n",
+                    (int)result);
     break;
   case TFTP_STATE_FIN:
+    fputs("DEBUG: tftp_state_machine() TFTP_STATE_FIN\n", stderr);
     infof(data, "%s", "TFTP finished");
     break;
   default:
     DEBUGF(infof(data, "STATE: %d", state->state));
+    fputs("DEBUG: tftp_state_machine() default / error\n", stderr);
     failf(data, "%s", "Internal state machine error");
     result = CURLE_TFTP_ILLEGAL;
     break;

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -910,32 +910,21 @@ static CURLcode tftp_state_machine(struct tftp_state_data *state,
   switch(state->state) {
   case TFTP_STATE_START:
     DEBUGF(infof(data, "TFTP_STATE_START"));
-    fputs("DEBUG: tftp_state_machine() TFTP_STATE_START begin\n", stderr);
     result = tftp_send_first(state, event);
-    fprintf(stderr, "DEBUG: tftp_state_machine() TFTP_STATE_START |%d|\n",
-                    (int)result);
     break;
   case TFTP_STATE_RX:
     DEBUGF(infof(data, "TFTP_STATE_RX"));
-    fputs("DEBUG: tftp_state_machine() TFTP_STATE_RX begin\n", stderr);
     result = tftp_rx(state, event);
-    fprintf(stderr, "DEBUG: tftp_state_machine() TFTP_STATE_RX |%d|\n",
-                    (int)result);
     break;
   case TFTP_STATE_TX:
     DEBUGF(infof(data, "TFTP_STATE_TX"));
-    fputs("DEBUG: tftp_state_machine() TFTP_STATE_TX begin\n", stderr);
     result = tftp_tx(state, event);
-    fprintf(stderr, "DEBUG: tftp_state_machine() TFTP_STATE_TX |%d|\n",
-                    (int)result);
     break;
   case TFTP_STATE_FIN:
-    fputs("DEBUG: tftp_state_machine() TFTP_STATE_FIN\n", stderr);
     infof(data, "%s", "TFTP finished");
     break;
   default:
     DEBUGF(infof(data, "STATE: %d", state->state));
-    fputs("DEBUG: tftp_state_machine() default / error\n", stderr);
     failf(data, "%s", "Internal state machine error");
     result = CURLE_TFTP_ILLEGAL;
     break;


### PR DESCRIPTION
Add these jobs to GHA:
- NetBSD, cmake-unity, clang, OpenSSL, x86_64, with tests, w/o python,
  no parallelism (was flaky sometimes)
- OpenBSD, cmake-unity, clang, LibreSSL, x86_64, with tests,
  with python, -j8, TFTP results ignored due to #13623.
- FreeBSD, cmake-unity and autotools, clang, OpenSSL, arm64
  (Tests disabled for arm64, because they are slow. It's available for
  x86_64 with python, -j12.)
  Configuration matches our existing Cirrus CI one.
- OmniOS, autotools, gcc, OpenSSL, x86_64, with tests, -j12.

All build with websockets and examples.

Closes #13583

---

- [x] cmake debug configuration might be simplified once #13592 (or a variant) landed.
- [x] see how to make `cpp` work on OmniOS. [FIXED by symlinking `cpp` to `gcpp`.]
- [x] fix test1167 on OpenBSD. → #13634
- [x] FIXME: TFTP tests on OpenBSD: https://github.com/curl/curl/actions/runs/9042288591/job/24855020568?pr=13583#step:3:3443 → #13623 → converted to a FIXME comment and executing these test but ignoring the result.
- [x] convert FreeBSD job to cmake for more variation.