### PR TITLE
autotools: fix `HAVE_IOCTLSOCKET_FIONBIO` test for gcc 14

### DIFF
--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3592,7 +3592,7 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_FIONBIO], [
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
       ]],[[
-        int flags = 0;
+        unsigned long flags = 0;
         if(0 != ioctlsocket(0, FIONBIO, &flags))
           return 1;
       ]])


### PR DESCRIPTION
```
conftest.c:152:41: error: passing argument 3 of 'ioctlsocket' from incompatible pointer type [-Wincompatible-pointer-types]
  152 |         if(0 != ioctlsocket(0, FIONBIO, &flags))
      |                                         ^~~~~~
      |                                         |
      |                                         int *
```

Reported-by: LigH
Fixes #13579
Closes #13587