### PR TITLE
ldap: fix unused variables (seen on OmniOS)

### DIFF
--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -485,6 +485,8 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     }
 */
 #else
+    (void)ldap_option;
+    (void)ldap_ca;
     /* we should probably never come up to here since configure
        should check in first place if we can support LDAP SSL/TLS */
     failf(data, "LDAP local: SSL/TLS not supported with this version "


### PR DESCRIPTION
```
../../lib/ldap.c: In function 'ldap_do':
  ../../lib/ldap.c:380:11: error: unused variable 'ldap_ca' [-Werror=unused-variable]
    380 |     char *ldap_ca = conn->ssl_config.CAfile;
        |           ^~~~~~~
  ../../lib/ldap.c:379:9: error: unused variable 'ldap_option' [-Werror=unused-variable]
    379 |     int ldap_option;
        |         ^~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/9033564377/job/24824192730#step:3:6059

Ref: #13583
Closes #xxxxx