### PR TITLE
docs/cmdline-opts: mention STARTTLS for --ssl and --ssl-reqd

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -785,6 +785,7 @@ stdin
 stdout
 Steinar
 Stenberg
+STLS
 STOR
 strcat
 strcpy

--- a/docs/cmdline-opts/ssl-reqd.md
+++ b/docs/cmdline-opts/ssl-reqd.md
@@ -16,7 +16,8 @@ Example:
 
 # `--ssl-reqd`
 
-Require SSL/TLS for the connection. Terminates the connection if the transfer
+Require SSL/TLS for the connection - often referred to as STARTTLS or STLS
+because of the involved commands. Terminates the connection if the transfer
 cannot be upgraded to use SSL/TLS.
 
 This option is handled in LDAP (added in 7.81.0). It is fully supported by the

--- a/docs/cmdline-opts/ssl.md
+++ b/docs/cmdline-opts/ssl.md
@@ -20,9 +20,10 @@ Example:
 Warning: this is considered an insecure option. Consider using --ssl-reqd
 instead to be sure curl upgrades to a secure connection.
 
-Try to use SSL/TLS for the connection. Reverts to a non-secure connection if
-the server does not support SSL/TLS. See also --ftp-ssl-control and --ssl-reqd
-for different levels of encryption required.
+Try to use SSL/TLS for the connection - often referred to as STARTTLS or STLS
+because of the involved commands. Reverts to a non-secure connection if the
+server does not support SSL/TLS. See also --ftp-ssl-control and --ssl-reqd for
+different levels of encryption required.
 
 This option is handled in LDAP (added in 7.81.0). It is fully supported by the
 OpenLDAP backend and ignored by the generic ldap backend.


### PR DESCRIPTION
... since users might look for those terms in the manpage.