### PR TITLE
setopt: warn on Curl_set*opt() uses not using the return value

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -520,11 +520,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
            data.
         */
         char *p = Curl_memdup0(argptr, (size_t)data->set.postfieldsize);
-        (void) Curl_setstropt(&data->set.str[STRING_COPYPOSTFIELDS], NULL);
         if(!p)
           result = CURLE_OUT_OF_MEMORY;
-        else
+        else {
+          free(data->set.str[STRING_COPYPOSTFIELDS]);
           data->set.str[STRING_COPYPOSTFIELDS] = p;
+        }
       }
     }
 
@@ -538,7 +539,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      */
     data->set.postfields = va_arg(param, void *);
     /* Release old copied data. */
-    (void) Curl_setstropt(&data->set.str[STRING_COPYPOSTFIELDS], NULL);
+    Curl_safefree(data->set.str[STRING_COPYPOSTFIELDS]);
     data->set.method = HTTPREQ_POST;
     break;
 
@@ -554,7 +555,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     if(data->set.postfieldsize < bigsize &&
        data->set.postfields == data->set.str[STRING_COPYPOSTFIELDS]) {
       /* Previous CURLOPT_COPYPOSTFIELDS is no longer valid. */
-      (void) Curl_setstropt(&data->set.str[STRING_COPYPOSTFIELDS], NULL);
+      Curl_safefree(data->set.str[STRING_COPYPOSTFIELDS]);
       data->set.postfields = NULL;
     }
 
@@ -573,7 +574,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     if(data->set.postfieldsize < bigsize &&
        data->set.postfields == data->set.str[STRING_COPYPOSTFIELDS]) {
       /* Previous CURLOPT_COPYPOSTFIELDS is no longer valid. */
-      (void) Curl_setstropt(&data->set.str[STRING_COPYPOSTFIELDS], NULL);
+      Curl_safefree(data->set.str[STRING_COPYPOSTFIELDS]);
       data->set.postfields = NULL;
     }
 
@@ -1860,7 +1861,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     /*
      * flag to set engine as default.
      */
-    Curl_setstropt(&data->set.str[STRING_SSL_ENGINE], NULL);
+    Curl_safefree(data->set.str[STRING_SSL_ENGINE]);
     result = Curl_ssl_set_engine_default(data);
     break;
   case CURLOPT_CRLF:

--- a/lib/setopt.h
+++ b/lib/setopt.h
@@ -24,9 +24,10 @@
  *
  ***************************************************************************/
 
-CURLcode Curl_setstropt(char **charp, const char *s);
+CURLcode Curl_setstropt(char **charp, const char *s) WARN_UNUSED_RESULT;
 CURLcode Curl_setblobopt(struct curl_blob **blobp,
-                         const struct curl_blob *blob);
-CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list arg);
+                         const struct curl_blob *blob) WARN_UNUSED_RESULT;
+CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list arg)
+  WARN_UNUSED_RESULT;
 
 #endif /* HEADER_CURL_SETOPT_H */


### PR DESCRIPTION
And switch the invokes that would "set" NULL to instead just plainly free the pointer, as those were otherwise the invokes that would ignore the return code. And possibly confuse static code analyzers.