### PR TITLE
cmake: `ENABLE_DEBUG=ON` to always set `-DDEBUGBUILD`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -240,7 +240,6 @@ jobs:
           fi
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
-          [ '${{ matrix.type }}' = 'Release' ] && [[ '${{ matrix.config }}' = *'ENABLE_DEBUG=ON'* ]] && cflags+=' -DDEBUGBUILD'
           cmake -B bld ${options} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -292,7 +292,7 @@ jobs:
             env: '9.5.0-x86_64'
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/9.5.0-10.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-9.5.0-mingw-w64msvcrt-10.0.0-r1.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
-            type: 'Debug'
+            type: 'Release'
             tflags: '~1139 ~1177 ~1477 ~2301 ~2302 ~3027'
           - build: 'cmake'
             env: '7.3.0-x86_64'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,7 @@ option(ENABLE_CURLDEBUG "Set to ON to build with TrackMemory feature enabled" OF
 include(PickyWarnings)
 
 if(ENABLE_DEBUG)
-  # DEBUGBUILD will be defined only for Debug builds
-  set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS $<$<CONFIG:Debug>:DEBUGBUILD>)
+  set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS DEBUGBUILD)
   set(ENABLE_CURLDEBUG ON)
 endif()
 

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -43,7 +43,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   [ "${PRJ_CFG}" = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
   [[ "${PRJ_GEN}" = *'Visual Studio'* ]] && options+=' -DCMAKE_VS_GLOBALS=TrackFileAccess=false'
   if [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ]; then
-    [ "${PRJ_CFG}" = 'Debug' ] && [ "${DEBUG}" = 'ON' ] && [ "${SHARED}" = 'ON' ] && SKIP_RUN='Crash on startup in -DDEBUGBUILD shared builds'
+    [ "${DEBUG}" = 'ON' ] && [ "${SHARED}" = 'ON' ] && SKIP_RUN='Crash on startup in -DDEBUGBUILD shared builds'
     # Fails to run without this due to missing MSVCR90.dll / MSVCR90D.dll
     options+=' -DCURL_STATIC_CRT=ON'
   fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,7 @@ environment:
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 9 2008'
       PRJ_CFG: Release
+      DEBUG: 'OFF'
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'


### PR DESCRIPTION
Before this patch `ENABLE_DEBUG=ON` always enabled the TrackMemory
(aka `ENABLE_CURLDEBUG=ON`) feature, but required the `Debug` CMake
configration to actually enable curl debug features
(aka `-DDEBUGBUILD`).

Curl debug features do not require compiling with C debug options. This
also made enabling debug features unintuitive and complicated to use.
Due to other issues (subject to PR #13694) it also caused an error in
default (and `Release`/`MinSizeRel`/`RelWithDebInfo`) configs, when
building the `testdeps` target:
```
ld: CMakeFiles/unit1395.dir/unit1395.c.o: in function `test':
unit1395.c:(.text+0x1a0): undefined reference to `dedotdotify'
```
Ref: https://github.com/curl/curl/actions/runs/9037287098/job/24835990826#step:3:2483

Fix it by always defining `DEBUGBUILD` when setting `ENABLE_DEBUG=ON`.
Decoupling this option from the selected CMake configuration.

Note that after this patch `ENABLE_DEBUG=ON` unconditionally enables
curl debug features. These features are insecure and unsuited for
production. Make sure to omit this option when building for production
in default, `Release` (and other not-`Debug`) modes.

Also delete a workaround no longer necessary in GHA CI jobs.

Ref: 1a62b6e68c08c7e471ff22dd92932aba7e026817 (2015-03-03)
Ref: #13583
Closes #13592

---

- [x] Depends on #13643.
- [x] Rebase on #13654.
- [x] Rebase on #13668.
- [x] settle on `ENABLE_DEBUG` to always set `DEBUGBUILD`
- [x] try untangling `DEBUGBUILD` / `CURLDEBUG` / `UNITTESTS` guards. AFAIU the first two should work independently of each other, whether we are building/running tests or not, whether we are building with debug info or not. → in separate PR.
