### PR TITLE
appveyor: tidy-ups

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -39,7 +39,6 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   options=''
   [[ "${TARGET:-}" = *'ARM64'* ]] && SKIP_RUN='ARM64 architecture'
   [ "${OPENSSL}" = 'ON' ] && options+=" -DOPENSSL_ROOT_DIR=${openssl_root_win}"
-  [ "${OPENSSL}" = 'ON' ] && options+=" -DOPENSSL_ROOT_DIR=${openssl_root_win}"
   [ "${PRJ_CFG}" = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
   [ "${PRJ_CFG}" = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
   [[ "${PRJ_GEN}" = *'Visual Studio'* ]] && options+=' -DCMAKE_VS_GLOBALS=TrackFileAccess=false'

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -56,7 +56,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     '-DCURL_WERROR=ON' \
     "-DENABLE_DEBUG=${DEBUG}" \
     "-DENABLE_UNICODE=${ENABLE_UNICODE}" \
-    '-DCMAKE_INSTALL_PREFIX=C:/CURL' \
+    '-DCMAKE_INSTALL_PREFIX=C:/curl' \
     "-DCMAKE_BUILD_TYPE=${PRJ_CFG}"
   # shellcheck disable=SC2086
   cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --clean-first -- ${BUILD_OPT:-}

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -127,10 +127,6 @@ if false; then
   done
 fi
 
-if [ "${TESTING}" = 'ON' ] && [ "${BUILD_SYSTEM}" = 'CMake' ]; then
-  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --target testdeps
-fi
-
 # test
 
 if [ "${TESTING}" = 'ON' ]; then
@@ -142,6 +138,7 @@ if [ "${TESTING}" = 'ON' ]; then
   fi
   TFLAGS+=" ${DISABLED_TESTS:-}"
   if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
+    cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --target testdeps
     ls _bld/lib/*.dll >/dev/null 2>&1 && cp -f -p _bld/lib/*.dll _bld/tests/libtest/
     cmake --build _bld --config "${PRJ_CFG}" --target test-ci
   elif [ "${BUILD_SYSTEM}" = 'autotools' ]; then

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -145,10 +145,7 @@ if [ "${TESTING}" = 'ON' ]; then
     ls _bld/lib/*.dll >/dev/null 2>&1 && cp -f -p _bld/lib/*.dll _bld/tests/libtest/
     cmake --build _bld --config "${PRJ_CFG}" --target test-ci
   elif [ "${BUILD_SYSTEM}" = 'autotools' ]; then
-    (
-      cd _bld
-      make -j2 V=1 test-ci
-    )
+    make -C _bld -j2 V=1 test-ci
   else
     (
       TFLAGS="-a -p !flaky -r -rm ${TFLAGS}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -117,7 +117,9 @@ environment:
       HTTP_ONLY: 'ON'
       TESTING: 'ON'
       DISABLED_TESTS: '!1139 !1501 !1177 !1477'
+
     # generated CMake-based MSYS Makefiles builds (mingw cross-compiling)
+
     - job_name: 'CMake, mingw-w64, gcc 13, Debug, x64, Schannel, Static, Unicode'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -173,7 +175,9 @@ environment:
       MSYS2_ARG_CONV_EXCL: '/*'
       BUILD_OPT: -k
       UNITY: 'OFF'
+
     # winbuild-based builds
+
     - job_name: 'winbuild, VS2015, Debug, x64, OpenSSL 1.1.1, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: winbuild_vs2015
@@ -230,14 +234,18 @@ environment:
       PATHPART: release
       TESTING: 'OFF'
       ENABLE_UNICODE: 'yes'
+
     # generated VisualStudioSolution-based builds
+
     - job_name: 'VisualStudioSolution, VS2013, Debug, x86, Schannel, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: VisualStudioSolution
       PRJ_CFG: 'DLL Debug - DLL Windows SSPI - DLL WinIDN'
       TESTING: 'OFF'
       VC_VERSION: VC12
+
     # autotools-based builds (NOT mingw cross-compiling, but msys2 native)
+
     - job_name: 'autotools, msys2, x86_64, no SSL, Debug, no Proxy'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
@@ -256,7 +264,9 @@ environment:
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !504 !704 !705 !1233'
       CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl'
+
     # autotools-based Cygwin build
+
     - job_name: 'autotools, cygwin, x86_64, no SSL, Debug'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: autotools

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -246,7 +246,7 @@ environment:
 
     # autotools-based builds (NOT mingw cross-compiling, but msys2 native)
 
-    - job_name: 'autotools, msys2, x86_64, no SSL, Debug, no Proxy'
+    - job_name: 'autotools, msys2, Debug, x86_64, no Proxy, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
@@ -267,7 +267,7 @@ environment:
 
     # autotools-based Cygwin build
 
-    - job_name: 'autotools, cygwin, x86_64, no SSL, Debug'
+    - job_name: 'autotools, cygwin, Debug, x86_64, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -238,32 +238,32 @@ environment:
       TESTING: 'OFF'
       VC_VERSION: VC12
     # autotools-based builds (NOT mingw cross-compiling, but msys2 native)
-    - job_name: 'autotools, msys2, Debug, x86_64, no Proxy, no SSL'
+    - job_name: 'autotools, msys2, x86_64, no SSL, Debug, no Proxy'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !1233'
-      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --disable-proxy --without-ssl --enable-websockets --without-libpsl'
-    - job_name: 'autotools, msys2, Debug, x86_64, no SSL'
+      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl --enable-debug --disable-threaded-resolver --disable-proxy'
+    - job_name: 'autotools, msys2, x86_64, no SSL, Debug'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !504 !704 !705 !1233'
-      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets --without-libpsl'
-    - job_name: 'autotools, msys2, Release, x86_64, no SSL'
+      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl --enable-debug --disable-threaded-resolver'
+    - job_name: 'autotools, msys2, x86_64, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !504 !704 !705 !1233'
       CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl'
     # autotools-based Cygwin build
-    - job_name: 'autotools, cygwin, Debug, x86_64, no SSL'
+    - job_name: 'autotools, cygwin, x86_64, no SSL, Debug'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
       DISABLED_TESTS: ''
       ADD_SHELL: 'C:/cygwin64/bin'
-      CONFIG_ARGS: '--enable-debug --enable-werror --disable-threaded-resolver --without-ssl --enable-websockets --without-libpsl'
+      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl --enable-debug --disable-threaded-resolver'
 
 install:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -252,13 +252,13 @@ environment:
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !1233'
       CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl --enable-debug --disable-threaded-resolver --disable-proxy'
-    - job_name: 'autotools, msys2, x86_64, no SSL, Debug'
+    - job_name: 'autotools, msys2, Debug, x86_64, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'
       DISABLED_TESTS: '!19 !504 !704 !705 !1233'
       CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl --enable-debug --disable-threaded-resolver'
-    - job_name: 'autotools, msys2, x86_64, no SSL'
+    - job_name: 'autotools, msys2, Release, x86_64, no SSL'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: autotools
       TESTING: 'ON'


### PR DESCRIPTION
- delete a duplicate line.
- simplify a `make` call.
- merge two `if` branches.
- reorder autotools options for clarity.
- add `--enable-warnings` where missing (it's also the default.)
- add empty lines to YAML for readability.
- use lowercase install prefix/directory.

Closes #13598
