### PR TITLE
GHA: add MSYS, mingw-w64, Cygwin jobs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -255,4 +255,4 @@ Windows:
   - all:
       - changed-files:
           - any-glob-to-all-files:
-              - '{appveyor.*,CMake/Platforms/WindowsCache.cmake,lib/*win32*,lib/curl_multibyte.*,lib/rename.*,lib/vtls/schannel*,m4/curl-schannel.m4,projects/**,src/tool_doswin.c,winbuild/**,libcurl.def}'
+              - '{appveyor.*,.github/workflows/windows.yml,CMake/Platforms/WindowsCache.cmake,lib/*win32*,lib/curl_multibyte.*,lib/rename.*,lib/vtls/schannel*,m4/curl-schannel.m4,projects/**,src/tool_doswin.c,winbuild/**,libcurl.def}'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: non-native
+name: windows
 
 on:
   push:
@@ -40,8 +40,7 @@ concurrency:
 permissions: {}
 
 jobs:
-  build_cygwin:
-    name: 'cygwin'
+  cygwin:
     runs-on: windows-latest
     timeout-minutes: 30
     env:
@@ -79,8 +78,7 @@ jobs:
           make -j3 -C tests V=1
           make -j3 V=1 test-ci
 
-  build_msys2:
-    name: 'msys2'
+  msys2:
     runs-on: windows-latest
     timeout-minutes: 30
     strategy:
@@ -100,6 +98,7 @@ jobs:
 
       - name: 'autotools'
         if: ${{ matrix.build == 'autotools' }}
+        timeout-minutes: 30
         shell: msys2 {0}
         run: |
           autoreconf -fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -206,7 +206,6 @@ jobs:
         timeout-minutes: 5
         shell: msys2 {0}
         run: |
-          export MSYS2_ARG_CONV_EXCL='/*'
           export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -135,11 +135,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', sys: 'msys'   , env: 'x86_64', tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
-          - { build: 'autotools', sys: 'msys'   , env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
-          - { build: 'autotools', sys: 'msys'   , env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
-          - { build: 'cmake'    , sys: 'ucrt64' , env: 'x86_64',                                     config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
+          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64',                                     config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -92,6 +92,7 @@ jobs:
           - { build: 'autotools', sys: 'msys', env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '' }
       fail-fast: false
     steps:
+      - run: git config --global core.autocrlf input
       - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.sys == 'msys' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='-j16 ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -163,7 +163,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='-j16 ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi
@@ -207,7 +207,7 @@ jobs:
         shell: msys2 {0}
         run: |
           export MSYS2_ARG_CONV_EXCL='/*'
-          export TFLAGS='-j16 ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,7 +70,7 @@ jobs:
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
-            --with-openssl --with-libpsl ${{ matrix.config }}
+            --with-openssl --with-libpsl ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'automake' }}
@@ -167,7 +167,7 @@ jobs:
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
-            --with-openssl --with-libpsl ${{ matrix.config }}
+            --with-openssl --with-libpsl ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: cygwin/cygwin-install-action@v4
         with:
           platform: ${{ matrix.platform }}
-          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel libpsl-devel libssh2-devel
+          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel libnghttp2-devel libpsl-devel libssh2-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
       - name: 'autotools configure'
@@ -150,7 +150,7 @@ jobs:
         if: ${{ matrix.sys == 'msys' }}
         with:
           msystem: ${{ matrix.sys }}
-          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel libpsl-devel libssh2-devel
+          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel libnghttp2-devel libpsl-devel libssh2-devel
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.sys != 'msys' }}
         with:
@@ -237,7 +237,7 @@ jobs:
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
-            -DCURL_BROTLI=ON \
+            -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON \
             "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
 
       - name: 'cmake build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -88,9 +88,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', sys: 'msys', env: 'x86_64', tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
-          - { build: 'autotools', sys: 'msys', env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
-          - { build: 'autotools', sys: 'msys', env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64', tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -100,6 +101,14 @@ jobs:
         with:
           msystem: ${{ matrix.sys }}
           install: gcc ${{ matrix.build }} make openssl-devel zlib-devel libpsl-devel
+      - uses: msys2/setup-msys2@v2
+        if: ${{ matrix.sys != 'msys' }}
+        with:
+          msystem: ${{ matrix.sys }}
+          install: >-
+            mingw-w64-${{ matrix.env }}-cc
+            mingw-w64-${{ matrix.env }}-${{ matrix.build }} make
+            mingw-w64-${{ matrix.env }}-openssl
 
       - name: 'autotools'
         if: ${{ matrix.build == 'autotools' }}
@@ -108,8 +117,8 @@ jobs:
         run: |
           autoreconf -fi
           export TFLAGS='-j16 ${{ matrix.tflags }}'
-          if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
-            TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
+          if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
+            TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
@@ -120,3 +129,48 @@ jobs:
           make -j3 V=1 examples
           make -j3 -C tests V=1
           make -j3 V=1 test-ci
+
+      - name: 'cmake'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 30
+        shell: msys2 {0}
+        run: |
+          export MSYS2_ARG_CONV_EXCL='/*'
+          export TFLAGS='-j16 ${{ matrix.tflags }}'
+          if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
+            TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
+          fi
+          if [[ '${{ matrix.env }}' = 'clang'* ]]; then
+            options='-DCMAKE_C_COMPILER=clang'
+          else
+            options='-DCMAKE_C_COMPILER=gcc'
+          fi
+          if [ '${{ matrix.test }}' = 'uwp' ]; then
+            options+='-DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
+            pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
+            specs="$(realpath gcc-specs-uwp)"
+            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
+            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
+            # CMake (as of v3.26.4) gets confused and applies the MSVC rc.exe command-line
+            # template to windres. Reset it to the windres template manually:
+            rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
+          else
+            cflags=''
+            rcopts=''
+          fi
+          [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
+          [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
+          cmake -B bld ${options} ${{ matrix.config }} \
+            "-DCMAKE_C_FLAGS=${cflags}" \
+            "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
+            '-DCMAKE_UNITY_BUILD=ON' \
+            '-DCURL_WERROR=ON' \
+            '-DBUILD_TESTING=ON' \
+            "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
+          cmake --build bld --config '${{ matrix.type }}' --parallel 3
+          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
+          find . -name '*.exe' -o -name '*.dll'
+          bld/src/curl.exe --disable --version
+          cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
+          ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
+          cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -66,13 +66,13 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='${{ tflags }}'
+          export TFLAGS='${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
-            --with-openssl --with-libpsl ${{ config }}
+            --with-openssl --with-libpsl ${{ matrix.config }}
           make -j3 V=1
           make -j3 V=1 examples
           make -j3 -C tests V=1
@@ -102,13 +102,13 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='${{ tflags }}'
+          export TFLAGS='${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
-            --with-openssl --with-libpsl ${{ config }}
+            --with-openssl --with-libpsl ${{ matrix.config }}
           make -j3 V=1
           make -j3 V=1 examples
           make -j3 -C tests V=1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -235,7 +235,6 @@ jobs:
             '-DCMAKE_UNITY_BUILD=ON' \
             '-DCURL_WERROR=ON' \
             '-DBUILD_EXAMPLES=ON' \
-            '-DBUILD_TESTING=ON' \
             "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
 
       - name: 'cmake build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -117,6 +117,7 @@ jobs:
             "-DCMAKE_C_FLAGS=${cflags}" \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
+            -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON \
             -DBUILD_EXAMPLES=ON
 
       - name: 'cmake build'
@@ -236,8 +237,8 @@ jobs:
             "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
-            -DBUILD_EXAMPLES=ON \
             -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON \
+            -DBUILD_EXAMPLES=ON \
             "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
 
       - name: 'cmake build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -144,6 +144,7 @@ jobs:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19                !1233'            , config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233'            , config: '--enable-debug --disable-threaded-resolver' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233'            , config: '' }
+          # FIXME: WebSockets test results ignored due to frequent failures on native Windows:
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233 ~2301 ~2305', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skip'                                , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release' }
           - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skip'                                , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: cygwin/cygwin-install-action@v4
         with:
           platform: ${{ matrix.platform }}
+          # https://cygwin.com/cgi-bin2/package-grep.cgi
           packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel libnghttp2-devel libpsl-devel libssh2-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
@@ -151,6 +152,7 @@ jobs:
         if: ${{ matrix.sys == 'msys' }}
         with:
           msystem: ${{ matrix.sys }}
+          # https://packages.msys2.org/search
           install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel libnghttp2-devel libpsl-devel libssh2-devel
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.sys != 'msys' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,10 +68,6 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='-j14 ${{ matrix.tflags }}'
-          if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
-            TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
-          fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
             --with-openssl --with-libpsl ${{ matrix.config }}
@@ -104,6 +100,10 @@ jobs:
         timeout-minutes: 30
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
+            TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
+          fi
           make -C bld -j3 V=1 test-ci
 
       - name: 'cmake configure'
@@ -163,10 +163,6 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='-j14 ${{ matrix.tflags }}'
-          if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
-            TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
-          fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
             --with-openssl --with-libpsl ${{ matrix.config }}
@@ -199,6 +195,10 @@ jobs:
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
+            TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
+          fi
           make -C bld -j3 V=1 test-ci
 
       - name: 'cmake configure'
@@ -206,10 +206,6 @@ jobs:
         timeout-minutes: 5
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j14 ${{ matrix.tflags }}'
-          if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
-            TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
-          fi
           if [[ '${{ matrix.env }}' = 'clang'* ]]; then
             options='-DCMAKE_C_COMPILER=clang'
           else
@@ -257,9 +253,13 @@ jobs:
           cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
 
       - name: 'cmake run tests'
-        if: ${{ matrix.build == 'cmake' }}
+        if: ${{ matrix.build == 'cmake' && matrix.tflags }}
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
+            TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
+          fi
           ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='-j6 ${{ matrix.tflags }}'
+          export TFLAGS='-j12 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -107,7 +107,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='-j6 ${{ matrix.tflags }}'
+          export TFLAGS='-j12 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,6 +41,7 @@ permissions: {}
 
 jobs:
   cygwin:
+    name: "cygwin (${{ matrix.build }}, ${{ matrix.platform }}, ${{ matrix.config }})"
     runs-on: windows-latest
     timeout-minutes: 30
     env:
@@ -74,11 +75,13 @@ jobs:
             --enable-websockets \
             --with-openssl --with-libpsl ${{ matrix.config }}
           make -j3 V=1
+          bld/src/curl.exe --disable --version
           make -j3 V=1 examples
           make -j3 -C tests V=1
           make -j3 V=1 test-ci
 
   msys2:
+    name: "msys2 (${{ matrix.build }}, ${{ matrix.sys }}, ${{ matrix.env }}, ${{ matrix.config }})"
     runs-on: windows-latest
     timeout-minutes: 30
     strategy:
@@ -110,6 +113,7 @@ jobs:
             --enable-websockets \
             --with-openssl --with-libpsl ${{ matrix.config }}
           make -j3 V=1
+          bld/src/curl.exe --disable --version
           make -j3 V=1 examples
           make -j3 -C tests V=1
           make -j3 V=1 test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,206 @@
+# Copyright (C) Viktor Szakats
+#
+# SPDX-License-Identifier: curl
+
+name: non-native
+
+on:
+  push:
+    branches:
+      - master
+      - '*/ci'
+    paths-ignore:
+      - '**/*.md'
+      - '.azure-pipelines.yml'
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - 'appveyor.*'
+      - 'packages/**'
+      - 'plan9/**'
+      - 'projects/**'
+      - 'winbuild/**'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - '.azure-pipelines.yml'
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - 'appveyor.*'
+      - 'packages/**'
+      - 'plan9/**'
+      - 'projects/**'
+      - 'winbuild/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build_cygwin:
+    name: 'cygwin'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      SHELLOPTS: 'igncr'
+    strategy:
+      matrix:
+        include:
+          - { build: 'automake', platform: 'x86_64', compiler: 'gcc' }
+          - { build: 'cmake'   , platform: 'x86_64', compiler: 'gcc' }
+      fail-fast: false
+    steps:
+      - run: git config --global core.autocrlf input
+      - uses: actions/checkout@v4
+      - uses: cygwin/cygwin-install-action@v4
+        with:
+          platform: ${{ matrix.platform }}
+          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel
+          site: https://mirrors.kernel.org/sourceware/cygwin/
+
+      - name: 'autotools'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 10
+        shell: C:\cygwin\bin\bash.exe '{0}'
+        run: |
+          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
+          autoreconf -fi
+          mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
+            --with-crypto=openssl \
+            --disable-docker-tests
+          make -j3
+          make check V=1
+
+      - name: 'cmake'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 10
+        shell: C:\cygwin\bin\bash.exe '{0}'
+        run: |
+          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
+          cmake -B bld \
+            -DCMAKE_UNITY_BUILD=ON \
+            -DENABLE_WERROR=ON \
+            -DENABLE_DEBUG_LOGGING=ON \
+            -DCRYPTO_BACKEND=OpenSSL \
+            -DOPENSSL_ROOT_DIR=/usr/lib \
+            -DENABLE_ZLIB_COMPRESSION=ON \
+            -DRUN_DOCKER_TESTS=OFF \
+            -DRUN_SSHD_TESTS=OFF
+          cmake --build bld --parallel 3
+          cd bld && ctest -VV --output-on-failure
+
+  build_msys2:
+    name: 'msys2'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - { build: 'autotools', sys: msys   , crypto: openssl, env: x86_64 }
+          - { build: 'cmake'    , sys: msys   , crypto: OpenSSL, env: x86_64 }
+          - { build: 'autotools', sys: mingw64, crypto: wincng , env: x86_64 }
+          - { build: 'autotools', sys: mingw64, crypto: openssl, env: x86_64 }
+          - { build: 'autotools', sys: mingw32, crypto: openssl, env: i686 }
+          - { build: 'autotools', sys: ucrt64 , crypto: openssl, env: ucrt-x86_64 }
+          - { build: 'autotools', sys: clang64, crypto: openssl, env: clang-x86_64 }
+          - { build: 'autotools', sys: clang64, crypto: wincng , env: clang-x86_64 }
+          - { build: 'cmake'    , sys: ucrt64 , crypto: OpenSSL, env: ucrt-x86_64 }
+          - { build: 'cmake'    , sys: clang64, crypto: OpenSSL, env: clang-x86_64 }
+          - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'uwp' }
+          - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'no-options' }
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: msys2/setup-msys2@v2
+        if: ${{ matrix.sys == 'msys' }}
+        with:
+          msystem: ${{ matrix.sys }}
+          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel
+      - uses: msys2/setup-msys2@v2
+        if: ${{ matrix.sys != 'msys' }}
+        with:
+          msystem: ${{ matrix.sys }}
+          install: >-
+            mingw-w64-${{ matrix.env }}-cc
+            mingw-w64-${{ matrix.env }}-${{ matrix.build }} make
+            mingw-w64-${{ matrix.env }}-openssl
+
+      - name: 'autotools autoreconf'
+        if: ${{ matrix.build == 'autotools' }}
+        shell: msys2 {0}
+        run: autoreconf -fi
+      - name: 'autotools configure'
+        if: ${{ matrix.build == 'autotools' }}
+        env:
+          SSHD: 'C:/Program Files/Git/usr/bin/sshd.exe'
+        shell: msys2 {0}
+        run: |
+          if [ '${{ matrix.crypto }}' = 'wincng' ] && [[ '${{ matrix.env }}' = 'clang'* ]]; then
+            options='--enable-ecdsa-wincng'
+          fi
+          # sshd tests sometimes hang
+          mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
+            --with-crypto=${{ matrix.crypto }} \
+            --disable-docker-tests \
+            --disable-sshd-tests \
+            ${options}
+
+      - name: 'autotools build'
+        if: ${{ matrix.build == 'autotools' }}
+        shell: msys2 {0}
+        run: make -C bld -j3
+      - name: 'autotools tests'
+        if: ${{ matrix.build == 'autotools' }}
+        timeout-minutes: 10
+        shell: msys2 {0}
+        run: make -C bld check V=1
+      - name: 'cmake configure'
+        if: ${{ matrix.build == 'cmake' }}
+        shell: msys2 {0}
+        run: |
+          if [[ '${{ matrix.env }}' = 'clang'* ]]; then
+            options='-DCMAKE_C_COMPILER=clang'
+          else
+            options='-DCMAKE_C_COMPILER=gcc'
+          fi
+          if [ '${{ matrix.test }}' = 'uwp' ]; then
+            options="${options} -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
+            pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
+            specs="$(realpath gcc-specs-uwp)"
+            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
+            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
+            # CMake (as of v3.26.4) gets confused and applies the MSVC rc.exe command-line
+            # template to windres. Reset it to the windres template manually:
+            rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
+          elif [ '${{ matrix.test }}' = 'no-options' ]; then
+            options="${options} -DLIBSSH2_NO_DEPRECATED=ON"
+            cflags='-DLIBSSH2_NO_MD5 -DLIBSSH2_NO_MD5_PEM -DLIBSSH2_NO_HMAC_RIPEMD -DLIBSSH2_NO_DSA -DLIBSSH2_NO_AES_CBC -DLIBSSH2_NO_AES_CTR -DLIBSSH2_NO_BLOWFISH -DLIBSSH2_NO_RC4 -DLIBSSH2_NO_CAST -DLIBSSH2_NO_3DES'
+          else
+            cflags=''
+            rcopts=''
+          fi
+          cmake -B bld ${options} \
+            "-DCMAKE_C_FLAGS=${cflags}" \
+            "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
+            -DCMAKE_UNITY_BUILD=ON \
+            -DENABLE_WERROR=ON \
+            -DENABLE_DEBUG_LOGGING=ON \
+            -DCRYPTO_BACKEND=${{ matrix.crypto }} \
+            -DENABLE_ZLIB_COMPRESSION=ON \
+            -DRUN_DOCKER_TESTS=OFF \
+            -DRUN_SSHD_TESTS=OFF \
+            -DCMAKE_VERBOSE_MAKEFILE=ON
+
+      - name: 'cmake build'
+        if: ${{ matrix.build == 'cmake' }}
+        shell: msys2 {0}
+        run: cmake --build bld --parallel 3
+      - name: 'cmake tests'
+        # UWP missing 'msvcr120_app.dll', fails with exit code 0xc0000135
+        if: ${{ matrix.build == 'cmake' && matrix.test != 'uwp' }}
+        timeout-minutes: 10
+        shell: msys2 {0}
+        run: cd bld && ctest -VV --output-on-failure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -139,6 +139,7 @@ jobs:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '' }
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      ,                                     config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release' }
           - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64',                                     config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
       fail-fast: false
     steps:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='-j4 ${{ matrix.tflags }}'
+          export TFLAGS='-j5 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -107,7 +107,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='-j4 ${{ matrix.tflags }}'
+          export TFLAGS='-j5 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,7 +72,8 @@ jobs:
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --prefix="${HOME}"/install \
             --enable-websockets \
-            --with-openssl --with-libssh2 \
+            --with-openssl \
+            --with-libssh2 \
             ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'
@@ -119,8 +120,8 @@ jobs:
             "-DCMAKE_C_FLAGS=${cflags}" \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
-            -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON \
-            -DBUILD_EXAMPLES=ON
+            -DBUILD_EXAMPLES=ON \
+            -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -173,7 +174,8 @@ jobs:
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --prefix="${HOME}"/install \
             --enable-websockets \
-            --with-openssl --with-libssh2 \
+            --with-openssl \
+            --with-libssh2 \
             ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'
@@ -239,11 +241,11 @@ jobs:
           cmake -B bld ${options} ${{ matrix.config }} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
+            "-DCMAKE_BUILD_TYPE=${{ matrix.type }}" \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
-            -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON \
             -DBUILD_EXAMPLES=ON \
-            "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
+            -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='-j2 ${{ matrix.tflags }}'
+          export TFLAGS='-j3 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -107,7 +107,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='-j2 ${{ matrix.tflags }}'
+          export TFLAGS='-j3 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,7 +101,7 @@ jobs:
         timeout-minutes: 30
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,7 +70,7 @@ jobs:
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
-            --with-openssl \
+            --with-openssl --with-libssh2 \
             ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'
@@ -169,7 +169,7 @@ jobs:
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
-            --with-openssl \
+            --with-openssl --with-libssh2 \
             ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,7 +43,7 @@ jobs:
   cygwin:
     name: "cygwin (${{ matrix.build }}, ${{ matrix.platform }}, ${{ matrix.config }})"
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       SHELLOPTS: 'igncr'
     strategy:
@@ -60,9 +60,9 @@ jobs:
           packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libpsl-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
-      - name: 'autotools'
+      - name: 'autotools configure'
         if: ${{ matrix.build == 'automake' }}
-        timeout-minutes: 30
+        timeout-minutes: 5
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
@@ -74,12 +74,36 @@ jobs:
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
             --with-openssl --with-libpsl ${{ matrix.config }}
-          make -j3 V=1
+
+      - name: 'autotools build'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 10
+        shell: C:\cygwin\bin\bash.exe '{0}'
+        run: |
+          make -C bld -j3 V=1
           find . -name '*.exe' -o -name '*.dll'
-          src/curl.exe --disable --version
-          make -j3 V=1 examples
-          make -j3 -C tests V=1
-          make -j3 V=1 test-ci
+          bld/src/curl.exe --disable --version
+
+      - name: 'autotools build examples'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 5
+        shell: C:\cygwin\bin\bash.exe '{0}'
+        run: |
+          make -C bld -j3 V=1 examples
+
+      - name: 'autotools build tests'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 10
+        shell: C:\cygwin\bin\bash.exe '{0}'
+        run: |
+          make -C bld -j3 -C tests V=1
+
+      - name: 'autotools run tests'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 30
+        shell: C:\cygwin\bin\bash.exe '{0}'
+        run: |
+          make -C bld -j3 V=1 test-ci
 
   msys2:
     name: "msys2 (${{ matrix.build }}, ${{ matrix.sys }}, ${{ matrix.env }}, ${{ matrix.config }})"
@@ -110,9 +134,9 @@ jobs:
             mingw-w64-${{ matrix.env }}-${{ matrix.build }} make
             mingw-w64-${{ matrix.env }}-openssl
 
-      - name: 'autotools'
+      - name: 'autotools configure'
         if: ${{ matrix.build == 'autotools' }}
-        timeout-minutes: 30
+        timeout-minutes: 5
         shell: msys2 {0}
         run: |
           autoreconf -fi
@@ -123,16 +147,40 @@ jobs:
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
             --with-openssl --with-libpsl ${{ matrix.config }}
-          make -j3 V=1
-          find . -name '*.exe' -o -name '*.dll'
-          src/curl.exe --disable --version
-          make -j3 V=1 examples
-          make -j3 -C tests V=1
-          make -j3 V=1 test-ci
 
-      - name: 'cmake'
-        if: ${{ matrix.build == 'cmake' }}
+      - name: 'autotools build'
+        if: ${{ matrix.build == 'autotools' }}
+        timeout-minutes: 10
+        shell: msys2 {0}
+        run: |
+          make -C bld -j3 V=1
+          find . -name '*.exe' -o -name '*.dll'
+          bld/src/curl.exe --disable --version
+
+      - name: 'autotools build examples'
+        if: ${{ matrix.build == 'autotools' }}
+        timeout-minutes: 5
+        shell: msys2 {0}
+        run: |
+          make -C bld -j3 V=1 examples
+
+      - name: 'autotools build tests'
+        if: ${{ matrix.build == 'autotools' }}
+        timeout-minutes: 10
+        shell: msys2 {0}
+        run: |
+          make -C bld -j3 -C tests V=1
+
+      - name: 'autotools run tests'
+        if: ${{ matrix.build == 'autotools' }}
         timeout-minutes: 30
+        shell: msys2 {0}
+        run: |
+          make -C bld -j3 V=1 test-ci
+
+      - name: 'cmake configure'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 5
         shell: msys2 {0}
         run: |
           export MSYS2_ARG_CONV_EXCL='/*'
@@ -145,17 +193,17 @@ jobs:
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi
+          cflags='-Wno-deprecated-declarations'
           if [ '${{ matrix.test }}' = 'uwp' ]; then
-            options+='-DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
+            options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
-            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
+            cflags+=" -specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
             # CMake (as of v3.26.4) gets confused and applies the MSVC rc.exe command-line
             # template to windres. Reset it to the windres template manually:
             rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
           else
-            cflags=''
             rcopts=''
           fi
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
@@ -165,12 +213,31 @@ jobs:
             "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
             '-DCMAKE_UNITY_BUILD=ON' \
             '-DCURL_WERROR=ON' \
+            '-DBUILD_EXAMPLES=ON' \
             '-DBUILD_TESTING=ON' \
             "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
+
+      - name: 'cmake build'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 10
+        shell: msys2 {0}
+        run: |
           cmake --build bld --config '${{ matrix.type }}' --parallel 3
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
+
+      - name: 'cmake build tests'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 10
+        shell: msys2 {0}
+        run: |
           cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
+
+      - name: 'cmake run tests'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 30
+        shell: msys2 {0}
+        run: |
           ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -207,7 +207,7 @@ jobs:
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          export TFLAGS='-j10 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi
@@ -271,7 +271,7 @@ jobs:
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          export TFLAGS='-j10 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -207,7 +207,7 @@ jobs:
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j10 ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi
@@ -271,7 +271,7 @@ jobs:
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j10 ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: cygwin/cygwin-install-action@v4
         with:
           platform: ${{ matrix.platform }}
-          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libpsl-devel
+          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel libpsl-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
       - name: 'autotools configure'
@@ -150,7 +150,7 @@ jobs:
         if: ${{ matrix.sys == 'msys' }}
         with:
           msystem: ${{ matrix.sys }}
-          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel libpsl-devel
+          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel libpsl-devel
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.sys != 'msys' }}
         with:
@@ -237,6 +237,7 @@ jobs:
             '-DCMAKE_UNITY_BUILD=ON' \
             '-DCURL_WERROR=ON' \
             '-DBUILD_EXAMPLES=ON' \
+            '-DCURL_BROTLI=ON' \
             "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
 
       - name: 'cmake build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -121,6 +121,7 @@ jobs:
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
+            -DENABLE_WEBSOCKETS=ON \
             -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
 
       - name: 'cmake build'
@@ -245,6 +246,7 @@ jobs:
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
+            -DENABLE_WEBSOCKETS=ON \
             -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
 
       - name: 'cmake build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='-j3 ${{ matrix.tflags }}'
+          export TFLAGS='-j4 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -107,7 +107,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='-j3 ${{ matrix.tflags }}'
+          export TFLAGS='-j4 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           # https://cygwin.com/cgi-bin2/package-grep.cgi
-          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel nghttp2 libnghttp2-devel libpsl-devel libssh2-devel
+          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel libnghttp2-devel libpsl-devel libssh2-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
       - name: 'autotools configure'
@@ -153,7 +153,7 @@ jobs:
         with:
           msystem: ${{ matrix.sys }}
           # https://packages.msys2.org/search
-          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel nghttp2 libnghttp2-devel libpsl-devel libssh2-devel
+          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel libnghttp2-devel libpsl-devel libssh2-devel
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.sys != 'msys' }}
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,8 +49,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'automake', platform: 'x86_64', compiler: 'gcc' }
-          - { build: 'cmake'   , platform: 'x86_64', compiler: 'gcc' }
+          - { build: 'automake', platform: 'x86_64', tflags: '', config: '--enable-debug --disable-threaded-resolver' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -58,39 +57,27 @@ jobs:
       - uses: cygwin/cygwin-install-action@v4
         with:
           platform: ${{ matrix.platform }}
-          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel
+          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libpsl-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
       - name: 'autotools'
         if: ${{ matrix.build == 'automake' }}
-        timeout-minutes: 10
+        timeout-minutes: 30
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
-            --with-crypto=openssl \
-            --disable-docker-tests
-          make -j3
-          make check V=1
-
-      - name: 'cmake'
-        if: ${{ matrix.build == 'cmake' }}
-        timeout-minutes: 10
-        shell: C:\cygwin\bin\bash.exe '{0}'
-        run: |
-          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
-          cmake -B bld \
-            -DCMAKE_UNITY_BUILD=ON \
-            -DENABLE_WERROR=ON \
-            -DENABLE_DEBUG_LOGGING=ON \
-            -DCRYPTO_BACKEND=OpenSSL \
-            -DOPENSSL_ROOT_DIR=/usr/lib \
-            -DENABLE_ZLIB_COMPRESSION=ON \
-            -DRUN_DOCKER_TESTS=OFF \
-            -DRUN_SSHD_TESTS=OFF
-          cmake --build bld --parallel 3
-          cd bld && ctest -VV --output-on-failure
+          export TFLAGS='${{ tflags }}'
+          if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
+            TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
+          fi
+          mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
+            --enable-websockets \
+            --with-openssl --with-libpsl ${{ config }}
+          make -j3 V=1
+          make -j3 V=1 examples
+          make -j3 -C tests V=1
+          make -j3 V=1 test-ci
 
   build_msys2:
     name: 'msys2'
@@ -99,18 +86,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', sys: msys   , crypto: openssl, env: x86_64 }
-          - { build: 'cmake'    , sys: msys   , crypto: OpenSSL, env: x86_64 }
-          - { build: 'autotools', sys: mingw64, crypto: wincng , env: x86_64 }
-          - { build: 'autotools', sys: mingw64, crypto: openssl, env: x86_64 }
-          - { build: 'autotools', sys: mingw32, crypto: openssl, env: i686 }
-          - { build: 'autotools', sys: ucrt64 , crypto: openssl, env: ucrt-x86_64 }
-          - { build: 'autotools', sys: clang64, crypto: openssl, env: clang-x86_64 }
-          - { build: 'autotools', sys: clang64, crypto: wincng , env: clang-x86_64 }
-          - { build: 'cmake'    , sys: ucrt64 , crypto: OpenSSL, env: ucrt-x86_64 }
-          - { build: 'cmake'    , sys: clang64, crypto: OpenSSL, env: clang-x86_64 }
-          - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'uwp' }
-          - { build: 'cmake'    , sys: mingw64, crypto: OpenSSL, env: x86_64, test: 'no-options' }
+          - { build: 'autotools', sys: 'msys', env: 'x86_64', tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
+          - { build: 'autotools', sys: 'msys', env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
+          - { build: 'autotools', sys: 'msys', env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '' }
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -118,89 +96,21 @@ jobs:
         if: ${{ matrix.sys == 'msys' }}
         with:
           msystem: ${{ matrix.sys }}
-          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel
-      - uses: msys2/setup-msys2@v2
-        if: ${{ matrix.sys != 'msys' }}
-        with:
-          msystem: ${{ matrix.sys }}
-          install: >-
-            mingw-w64-${{ matrix.env }}-cc
-            mingw-w64-${{ matrix.env }}-${{ matrix.build }} make
-            mingw-w64-${{ matrix.env }}-openssl
+          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel libpsl-devel
 
-      - name: 'autotools autoreconf'
+      - name: 'autotools'
         if: ${{ matrix.build == 'autotools' }}
-        shell: msys2 {0}
-        run: autoreconf -fi
-      - name: 'autotools configure'
-        if: ${{ matrix.build == 'autotools' }}
-        env:
-          SSHD: 'C:/Program Files/Git/usr/bin/sshd.exe'
         shell: msys2 {0}
         run: |
-          if [ '${{ matrix.crypto }}' = 'wincng' ] && [[ '${{ matrix.env }}' = 'clang'* ]]; then
-            options='--enable-ecdsa-wincng'
+          autoreconf -fi
+          export TFLAGS='${{ tflags }}'
+          if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
+            TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi
-          # sshd tests sometimes hang
-          mkdir bld && cd bld && ../configure --enable-werror --enable-debug \
-            --with-crypto=${{ matrix.crypto }} \
-            --disable-docker-tests \
-            --disable-sshd-tests \
-            ${options}
-
-      - name: 'autotools build'
-        if: ${{ matrix.build == 'autotools' }}
-        shell: msys2 {0}
-        run: make -C bld -j3
-      - name: 'autotools tests'
-        if: ${{ matrix.build == 'autotools' }}
-        timeout-minutes: 10
-        shell: msys2 {0}
-        run: make -C bld check V=1
-      - name: 'cmake configure'
-        if: ${{ matrix.build == 'cmake' }}
-        shell: msys2 {0}
-        run: |
-          if [[ '${{ matrix.env }}' = 'clang'* ]]; then
-            options='-DCMAKE_C_COMPILER=clang'
-          else
-            options='-DCMAKE_C_COMPILER=gcc'
-          fi
-          if [ '${{ matrix.test }}' = 'uwp' ]; then
-            options="${options} -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0"
-            pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
-            specs="$(realpath gcc-specs-uwp)"
-            gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
-            cflags="-specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
-            # CMake (as of v3.26.4) gets confused and applies the MSVC rc.exe command-line
-            # template to windres. Reset it to the windres template manually:
-            rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
-          elif [ '${{ matrix.test }}' = 'no-options' ]; then
-            options="${options} -DLIBSSH2_NO_DEPRECATED=ON"
-            cflags='-DLIBSSH2_NO_MD5 -DLIBSSH2_NO_MD5_PEM -DLIBSSH2_NO_HMAC_RIPEMD -DLIBSSH2_NO_DSA -DLIBSSH2_NO_AES_CBC -DLIBSSH2_NO_AES_CTR -DLIBSSH2_NO_BLOWFISH -DLIBSSH2_NO_RC4 -DLIBSSH2_NO_CAST -DLIBSSH2_NO_3DES'
-          else
-            cflags=''
-            rcopts=''
-          fi
-          cmake -B bld ${options} \
-            "-DCMAKE_C_FLAGS=${cflags}" \
-            "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
-            -DCMAKE_UNITY_BUILD=ON \
-            -DENABLE_WERROR=ON \
-            -DENABLE_DEBUG_LOGGING=ON \
-            -DCRYPTO_BACKEND=${{ matrix.crypto }} \
-            -DENABLE_ZLIB_COMPRESSION=ON \
-            -DRUN_DOCKER_TESTS=OFF \
-            -DRUN_SSHD_TESTS=OFF \
-            -DCMAKE_VERBOSE_MAKEFILE=ON
-
-      - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' }}
-        shell: msys2 {0}
-        run: cmake --build bld --parallel 3
-      - name: 'cmake tests'
-        # UWP missing 'msvcr120_app.dll', fails with exit code 0xc0000135
-        if: ${{ matrix.build == 'cmake' && matrix.test != 'uwp' }}
-        timeout-minutes: 10
-        shell: msys2 {0}
-        run: cd bld && ctest -VV --output-on-failure
+          mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
+            --enable-websockets \
+            --with-openssl --with-libpsl ${{ config }}
+          make -j3 V=1
+          make -j3 V=1 examples
+          make -j3 -C tests V=1
+          make -j3 V=1 test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='-j8 ${{ matrix.tflags }}'
+          export TFLAGS='-j16 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -107,7 +107,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='-j8 ${{ matrix.tflags }}'
+          export TFLAGS='-j16 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: 'autotools run tests'
         if: ${{ matrix.build == 'automake' && matrix.tflags != 'skip' }}
-        timeout-minutes: 30
+        timeout-minutes: 40
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
           export TFLAGS='-j8 ${{ matrix.tflags }}'
@@ -269,7 +269,7 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skip' }}
-        timeout-minutes: 30
+        timeout-minutes: 40
         shell: msys2 {0}
         run: |
           export TFLAGS='-j14 ${{ matrix.tflags }}'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,7 +70,8 @@ jobs:
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
-            --with-openssl --with-libpsl ${{ matrix.config }} || { tail -n 1200 config.log; false; }
+            --with-openssl \
+            ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'automake' }}
@@ -167,7 +168,8 @@ jobs:
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --enable-websockets \
-            --with-openssl --with-libpsl ${{ matrix.config }} || { tail -n 1200 config.log; false; }
+            --with-openssl \
+            ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -138,9 +138,9 @@ jobs:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release' }
-          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON' }
+          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -226,24 +226,21 @@ jobs:
           else
             rcopts=''
           fi
-          [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
-          [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
-          [ '${{ matrix.type }}' = 'Release' ] && [[ '${{ matrix.config }}' = *'ENABLE_DEBUG=ON'* ]] && cflags+=' -DDEBUGBUILD'
+          [[ '${{ matrix.config }}' = *'ENABLE_DEBUG=ON'* ]] && cflags+=' -DDEBUGBUILD'
           cmake -B bld ${options} ${{ matrix.config }} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
             '-DCMAKE_UNITY_BUILD=ON' \
             '-DCURL_WERROR=ON' \
             '-DBUILD_EXAMPLES=ON' \
-            '-DBUILD_TESTING=ON' \
-            "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
+            '-DBUILD_TESTING=ON'
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 10
         shell: msys2 {0}
         run: |
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3
+          cmake --build bld --parallel 3
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
@@ -253,7 +250,7 @@ jobs:
         timeout-minutes: 10
         shell: msys2 {0}
         run: |
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
+          cmake --build bld --parallel 3 --target testdeps
 
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skip' }}
@@ -265,4 +262,4 @@ jobs:
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi
           ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
-          cmake --build bld --config '${{ matrix.type }}' --target test-ci
+          cmake --build bld --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='-j5 ${{ matrix.tflags }}'
+          export TFLAGS='-j6 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -107,7 +107,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='-j5 ${{ matrix.tflags }}'
+          export TFLAGS='-j6 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -115,9 +115,9 @@ jobs:
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           cmake -B bld ${options} ${{ matrix.config }} \
             "-DCMAKE_C_FLAGS=${cflags}" \
-            '-DCMAKE_UNITY_BUILD=ON' \
-            '-DCURL_WERROR=ON' \
-            '-DBUILD_EXAMPLES=ON'
+            -DCMAKE_UNITY_BUILD=ON \
+            -DCURL_WERROR=ON \
+            -DBUILD_EXAMPLES=ON
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -234,10 +234,10 @@ jobs:
           cmake -B bld ${options} ${{ matrix.config }} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
-            '-DCMAKE_UNITY_BUILD=ON' \
-            '-DCURL_WERROR=ON' \
-            '-DBUILD_EXAMPLES=ON' \
-            '-DCURL_BROTLI=ON' \
+            -DCMAKE_UNITY_BUILD=ON \
+            -DCURL_WERROR=ON \
+            -DBUILD_EXAMPLES=ON \
+            -DCURL_BROTLI=ON \
             "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
 
       - name: 'cmake build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -141,12 +141,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
-          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
-          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release' }
-          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19                !1233'            , config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233'            , config: '--enable-debug --disable-threaded-resolver' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233'            , config: '' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233 ~2301 ~2305', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skip'                                , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release' }
+          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skip'                                , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -207,7 +207,7 @@ jobs:
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j8 ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi
@@ -271,7 +271,7 @@ jobs:
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j8 ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='${{ matrix.tflags }}'
+          export TFLAGS='-j2 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -107,7 +107,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='${{ matrix.tflags }}'
+          export TFLAGS='-j2 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           # https://cygwin.com/cgi-bin2/package-grep.cgi
-          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel libnghttp2-devel libpsl-devel libssh2-devel
+          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel nghttp2 libnghttp2-devel libpsl-devel libssh2-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
       - name: 'autotools configure'
@@ -153,7 +153,7 @@ jobs:
         with:
           msystem: ${{ matrix.sys }}
           # https://packages.msys2.org/search
-          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel libnghttp2-devel libpsl-devel libssh2-devel
+          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel nghttp2 libnghttp2-devel libpsl-devel libssh2-devel
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.sys != 'msys' }}
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,7 +58,7 @@ jobs:
       - uses: cygwin/cygwin-install-action@v4
         with:
           platform: ${{ matrix.platform }}
-          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel libpsl-devel
+          packages: autoconf libtool ${{ matrix.build }} gcc-core gcc-g++ binutils make libssl-devel zlib-devel libbrotli-devel libpsl-devel libssh2-devel
           site: https://mirrors.kernel.org/sourceware/cygwin/
 
       - name: 'autotools configure'
@@ -150,7 +150,7 @@ jobs:
         if: ${{ matrix.sys == 'msys' }}
         with:
           msystem: ${{ matrix.sys }}
-          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel libpsl-devel
+          install: gcc ${{ matrix.build }} make openssl-devel zlib-devel brotli-devel libpsl-devel libssh2-devel
       - uses: msys2/setup-msys2@v2
         if: ${{ matrix.sys != 'msys' }}
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -138,9 +138,9 @@ jobs:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON' }
-          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release' }
+          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -226,21 +226,24 @@ jobs:
           else
             rcopts=''
           fi
-          [[ '${{ matrix.config }}' = *'ENABLE_DEBUG=ON'* ]] && cflags+=' -DDEBUGBUILD'
+          [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
+          [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
+          [ '${{ matrix.type }}' = 'Release' ] && [[ '${{ matrix.config }}' = *'ENABLE_DEBUG=ON'* ]] && cflags+=' -DDEBUGBUILD'
           cmake -B bld ${options} ${{ matrix.config }} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
             '-DCMAKE_UNITY_BUILD=ON' \
             '-DCURL_WERROR=ON' \
             '-DBUILD_EXAMPLES=ON' \
-            '-DBUILD_TESTING=ON'
+            '-DBUILD_TESTING=ON' \
+            "-DCMAKE_BUILD_TYPE=${{ matrix.type }}"
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 10
         shell: msys2 {0}
         run: |
-          cmake --build bld --parallel 3
+          cmake --build bld --config '${{ matrix.type }}' --parallel 3
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
@@ -250,7 +253,7 @@ jobs:
         timeout-minutes: 10
         shell: msys2 {0}
         run: |
-          cmake --build bld --parallel 3 --target testdeps
+          cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
 
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skip' }}
@@ -262,4 +265,4 @@ jobs:
             TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
           fi
           ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
-          cmake --build bld --target test-ci
+          cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -131,7 +131,7 @@ jobs:
   msys2:
     name: "msys2 (${{ matrix.build }}, ${{ matrix.sys }}, ${{ matrix.env }}, ${{ matrix.config }})"
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     strategy:
       matrix:
         include:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -75,7 +75,8 @@ jobs:
             --enable-websockets \
             --with-openssl --with-libpsl ${{ matrix.config }}
           make -j3 V=1
-          bld/src/curl.exe --disable --version
+          find . -name '*.exe' -o -name '*.dll'
+          src/curl.exe --disable --version
           make -j3 V=1 examples
           make -j3 -C tests V=1
           make -j3 V=1 test-ci
@@ -114,7 +115,8 @@ jobs:
             --enable-websockets \
             --with-openssl --with-libpsl ${{ matrix.config }}
           make -j3 V=1
-          bld/src/curl.exe --disable --version
+          find . -name '*.exe' -o -name '*.dll'
+          src/curl.exe --disable --version
           make -j3 V=1 examples
           make -j3 -C tests V=1
           make -j3 V=1 test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
-          export TFLAGS='-j12 ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -107,7 +107,7 @@ jobs:
         shell: msys2 {0}
         run: |
           autoreconf -fi
-          export TFLAGS='-j12 ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,7 +96,7 @@ jobs:
           make -C bld -j3 -C tests V=1
 
       - name: 'autotools run tests'
-        if: ${{ matrix.build == 'automake' }}
+        if: ${{ matrix.build == 'automake' && matrix.tflags != 'skip' }}
         timeout-minutes: 30
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
@@ -139,8 +139,8 @@ jobs:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '' }
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      ,                                     config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release' }
-          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64',                                     config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release' }
+          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skip'                    , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -193,7 +193,7 @@ jobs:
           make -C bld -j3 -C tests V=1
 
       - name: 'autotools run tests'
-        if: ${{ matrix.build == 'autotools' }}
+        if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skip' }}
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
@@ -256,7 +256,7 @@ jobs:
           cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
 
       - name: 'cmake run tests'
-        if: ${{ matrix.build == 'cmake' && matrix.tflags }}
+        if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skip' }}
         timeout-minutes: 30
         shell: msys2 {0}
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,6 +50,7 @@ jobs:
       matrix:
         include:
           - { build: 'automake', platform: 'x86_64', tflags: '', config: '--enable-debug --disable-threaded-resolver' }
+          - { build: 'cmake'   , platform: 'x86_64', tflags: '', config: '-DCURL_USE_OPENSSL=ON' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -104,6 +105,28 @@ jobs:
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
           make -C bld -j3 V=1 test-ci
+
+      - name: 'cmake configure'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 5
+        shell: C:\cygwin\bin\bash.exe '{0}'
+        run: |
+          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
+          cmake -B bld ${options} ${{ matrix.config }} \
+            "-DCMAKE_C_FLAGS=${cflags}" \
+            '-DCMAKE_UNITY_BUILD=ON' \
+            '-DCURL_WERROR=ON' \
+            '-DBUILD_EXAMPLES=ON'
+
+      - name: 'cmake build'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 10
+        shell: C:\cygwin\bin\bash.exe '{0}'
+        run: |
+          cmake --build bld --config '${{ matrix.type }}' --parallel 3
+          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
+          find . -name '*.exe' -o -name '*.dll'
+          bld/src/curl.exe --disable --version
 
   msys2:
     name: "msys2 (${{ matrix.build }}, ${{ matrix.sys }}, ${{ matrix.env }}, ${{ matrix.config }})"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -139,6 +139,7 @@ jobs:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '' }
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64', tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
+          - { build: 'cmake'    , sys: 'ucrt64' , env: 'x86_64',                                     config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -226,6 +227,7 @@ jobs:
           fi
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
+          [ '${{ matrix.type }}' = 'Release' ] && [[ '${{ matrix.config }}' = *'ENABLE_DEBUG=ON'* ]] && cflags+=' -DDEBUGBUILD'
           cmake -B bld ${options} ${{ matrix.config }} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,6 +70,7 @@ jobs:
           export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
+            --prefix="${HOME}"/install \
             --enable-websockets \
             --with-openssl --with-libssh2 \
             ${{ matrix.config }} || { tail -n 1200 config.log; false; }
@@ -79,7 +80,7 @@ jobs:
         timeout-minutes: 10
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          make -C bld -j3 V=1
+          make -C bld -j3 V=1 install
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 
@@ -170,6 +171,7 @@ jobs:
         run: |
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
+            --prefix="${HOME}"/install \
             --enable-websockets \
             --with-openssl --with-libssh2 \
             ${{ matrix.config }} || { tail -n 1200 config.log; false; }
@@ -179,7 +181,7 @@ jobs:
         timeout-minutes: 10
         shell: msys2 {0}
         run: |
-          make -C bld -j3 V=1
+          make -C bld -j3 V=1 install
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -102,19 +102,6 @@ EOF
     rm _make.bat
   )
   curl="builds/libcurl-vc14.10-x64-${PATHPART}-dll-ssl-dll-ipv6-sspi/bin/curl.exe"
-elif [ "${BUILD_SYSTEM}" = 'autotools' ]; then
-  autoreconf -fi
-  (
-    mkdir _bld
-    cd _bld
-    # shellcheck disable=SC2086
-    ../configure ${CONFIG_ARGS:-}
-    make -j2 V=1
-    make -j2 V=1 examples
-    cd tests
-    make -j2 V=1
-  )
-  curl='_bld/src/curl.exe'
 fi
 
 find . -name '*.exe' -o -name '*.dll'
@@ -144,8 +131,6 @@ if [ "${TESTING}" = 'ON' ]; then
     cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --target testdeps
     ls _bld/lib/*.dll >/dev/null 2>&1 && cp -f -p _bld/lib/*.dll _bld/tests/libtest/
     cmake --build _bld --config "${PRJ_CFG}" --target test-ci
-  elif [ "${BUILD_SYSTEM}" = 'autotools' ]; then
-    make -C _bld -j2 V=1 test-ci
   else
     (
       TFLAGS="-a -p !flaky -r -rm ${TFLAGS}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -131,19 +131,6 @@ environment:
 
     # generated CMake-based MSYS Makefiles builds (mingw cross-compiling)
 
-    - job_name: 'CMake, mingw-w64, gcc 13, Debug, x64, Schannel, Static, Unicode'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
-      BUILD_SYSTEM: CMake
-      PRJ_GEN: 'MSYS Makefiles'
-      PRJ_CFG: Debug
-      SCHANNEL: 'ON'
-      ENABLE_UNICODE: 'ON'
-      HTTP_ONLY: 'OFF'
-      TESTING: 'ON'
-      DISABLED_TESTS: '!1086 !1139 !1451 !1501 !1177 !1477'
-      ADD_PATH: 'C:/msys64/mingw64/bin'
-      MSYS2_ARG_CONV_EXCL: '/*'
-      BUILD_OPT: -k
     - job_name: 'CMake, mingw-w64, gcc 7, Debug, x64, Schannel, Static, Unicode'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
@@ -254,37 +241,6 @@ environment:
       PRJ_CFG: 'DLL Debug - DLL Windows SSPI - DLL WinIDN'
       TESTING: 'OFF'
       VC_VERSION: VC12
-
-    # autotools-based builds (NOT mingw cross-compiling, but msys2 native)
-
-    - job_name: 'autotools, msys2, Debug, x86_64, no Proxy, no SSL'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
-      BUILD_SYSTEM: autotools
-      TESTING: 'ON'
-      DISABLED_TESTS: '!19 !1233'
-      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl --enable-debug --disable-threaded-resolver --disable-proxy'
-    - job_name: 'autotools, msys2, Debug, x86_64, no SSL'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
-      BUILD_SYSTEM: autotools
-      TESTING: 'ON'
-      DISABLED_TESTS: '!19 !504 !704 !705 !1233'
-      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl --enable-debug --disable-threaded-resolver'
-    - job_name: 'autotools, msys2, Release, x86_64, no SSL'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
-      BUILD_SYSTEM: autotools
-      TESTING: 'ON'
-      DISABLED_TESTS: '!19 !504 !704 !705 !1233'
-      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl'
-
-    # autotools-based Cygwin build
-
-    - job_name: 'autotools, cygwin, Debug, x86_64, no SSL'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
-      BUILD_SYSTEM: autotools
-      TESTING: 'ON'
-      DISABLED_TESTS: ''
-      ADD_SHELL: 'C:/cygwin64/bin'
-      CONFIG_ARGS: '--enable-warnings --enable-werror --without-ssl --enable-websockets --without-libpsl --enable-debug --disable-threaded-resolver'
 
 install:
   - ps: |


### PR DESCRIPTION
- re-implement autotools MSYS and Cygwin AppVeyor jobs in GHA.
  Now build with SSL and PSL to improve test coverage.
- re-implement MSYS2 mingw-w64 gcc 13 AppVeyor job in GHA.
  `CMake, mingw-w64, gcc 13, Debug, x64, Schannel, Static, Unicode`
- add new cmake Cygwin job (build-only).
- enable `-j14` parallelism when running tests.
- delete the 5 migrated jobs from AppVeyor CI.
- add 2 build-only mingw-w64 builds, gcc Release and clang OpenSSL.
- also enable brotli, libssh2, nghttp2 for more test coverage.

These jobs offer better performance, more flexibility and
parallelization compared to the AppVeyor ones they replace. It also
offloads AppVeyor, allowing to iterate faster. They also appear more
reliable than e.g. Azure Windows jobs, where runners are prone to fail
[^1].

Closes #13599

[^1]: `Exit code 143 returned from process: file name 'C:\Windows\system32\docker.EXE', arguments 'exec -i   6b13a669c6dfe7fb9f59414369872fd64d61c7182f880c3d39c135cb4c115c8f C:\__a\externals\node\bin\node.exe C:\__w\_temp\containerHandlerInvoker.js'.`

---

- [x] Also migrate the mingw-w64 gcc 13 AppVeyor job?
- [x] Delete the 5 AppVeyor CI jobs if these ones work as expected?
- [x] Test mingw-w64 in `Release` CMake configuration.
- [x] Depends on #13643.