### PR TITLE
tests: make the unit test result type `CURLcode`

### DIFF
--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -136,7 +136,7 @@ char *hexdump(const unsigned char *buffer, size_t len)
 int main(int argc, char **argv)
 {
   char *URL;
-  int result;
+  CURLcode result;
 
 #ifdef O_BINARY
 #  ifdef __HIGHC__
@@ -185,5 +185,5 @@ int main(int argc, char **argv)
 
   /* Regular program status codes are limited to 0..127 and 126 and 127 have
    * special meanings by the shell, so limit a normal return code to 125 */
-  return result <= 125 ? result : 125;
+  return (int)result <= 125 ? (int)result : 125;
 }

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -131,7 +131,7 @@ test_cleanup:
 /* for debugging: */
 /* #define SINGLETEST 9 */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -162,12 +162,12 @@ int test(char *URL)
 
   curl_global_cleanup();
   printf("%d\n", status);
-  return status;
+  return (CURLcode)status;
 
 test_cleanup:
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1301.c
+++ b/tests/libtest/lib1301.c
@@ -28,11 +28,11 @@
     if(!(expr)) {                                          \
       fprintf(stderr, "%s:%d Assertion '%s' failed: %s\n", \
               __FILE__, __LINE__, #expr, msg);             \
-      return 1;                                            \
+      return (CURLcode)1;                                  \
     }                                                      \
   } while(0)
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   int rc;
   (void)URL;
@@ -58,5 +58,5 @@ int test(char *URL)
   rc = curl_strnequal("ii", "II", 3);
   fail_unless(rc != 0, "return code should be non-zero");
 
-  return 0;
+  return CURLE_OK;
 }

--- a/tests/libtest/lib1500.c
+++ b/tests/libtest/lib1500.c
@@ -29,13 +29,13 @@
 
 #define TEST_HANG_TIMEOUT 60 * 1000
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curls = NULL;
   CURLM *multi = NULL;
   int still_running;
-  int i = TEST_ERR_FAILURE;
-  int res = 0;
+  CURLcode i = TEST_ERR_FAILURE;
+  CURLcode res = CURLE_OK;
   CURLMsg *msg;
 
   start_test_timing();
@@ -56,10 +56,11 @@ int test(char *URL)
   abort_on_test_timeout();
 
   while(still_running) {
+    CURLMcode mres;
     int num;
-    res = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
-    if(res != CURLM_OK) {
-      printf("curl_multi_wait() returned %d\n", res);
+    mres = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
+    if(mres != CURLM_OK) {
+      printf("curl_multi_wait() returned %d\n", mres);
       res = TEST_ERR_MAJOR_BAD;
       goto test_cleanup;
     }

--- a/tests/libtest/lib1501.c
+++ b/tests/libtest/lib1501.c
@@ -35,11 +35,11 @@
    to allow old and slow machines to run this test too */
 #define MAX_BLOCKED_TIME_MS 500
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *handle = NULL;
   CURLM *mhandle = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   int still_running = 0;
 
   start_test_timing();
@@ -96,7 +96,7 @@ int test(char *URL)
     fprintf(stderr, "pong = %ld\n", e);
 
     if(e > MAX_BLOCKED_TIME_MS) {
-      res = 100;
+      res = (CURLcode) 100;
       break;
     }
   }

--- a/tests/libtest/lib1502.c
+++ b/tests/libtest/lib1502.c
@@ -39,13 +39,13 @@
 
 #define TEST_HANG_TIMEOUT 60 * 1000
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy = NULL;
   CURL *dup;
   CURLM *multi = NULL;
   int still_running;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   char redirect[160];
 

--- a/tests/libtest/lib1506.c
+++ b/tests/libtest/lib1506.c
@@ -31,9 +31,9 @@
 
 #define NUM_HANDLES 4
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl[NUM_HANDLES] = {0};
   int running;
   CURLM *m = NULL;

--- a/tests/libtest/lib1507.c
+++ b/tests/libtest/lib1507.c
@@ -47,9 +47,9 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return CURL_READFUNC_ABORT;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-   int res = 0;
+   CURLcode res = CURLE_OK;
    CURL *curl = NULL;
    CURLM *mcurl = NULL;
    int still_running = 1;

--- a/tests/libtest/lib1508.c
+++ b/tests/libtest/lib1508.c
@@ -27,9 +27,9 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURLM *m = NULL;
 
   (void)URL;

--- a/tests/libtest/lib1509.c
+++ b/tests/libtest/lib1509.c
@@ -32,12 +32,12 @@ size_t WriteHeader(void *ptr, size_t size, size_t nmemb, void *stream);
 
 static unsigned long realHeaderSize = 0;
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   long headerSize;
   CURLcode code;
   CURL *curl = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
 
@@ -57,7 +57,7 @@ int test(char *URL)
   if(CURLE_OK != code) {
     fprintf(stderr, "%s:%d curl_easy_perform() failed, "
             "with code %d (%s)\n",
-            __FILE__, __LINE__, (int)code, curl_easy_strerror(code));
+            __FILE__, __LINE__, code, curl_easy_strerror(code));
     res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
@@ -66,7 +66,7 @@ int test(char *URL)
   if(CURLE_OK != code) {
     fprintf(stderr, "%s:%d curl_easy_getinfo() failed, "
             "with code %d (%s)\n",
-            __FILE__, __LINE__, (int)code, curl_easy_strerror(code));
+            __FILE__, __LINE__, code, curl_easy_strerror(code));
     res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }

--- a/tests/libtest/lib1510.c
+++ b/tests/libtest/lib1510.c
@@ -31,9 +31,9 @@
 
 #define NUM_URLS 4
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl = NULL;
   int i;
   char target_url[256];

--- a/tests/libtest/lib1511.c
+++ b/tests/libtest/lib1511.c
@@ -25,11 +25,11 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   long unmet;
   CURL *curl = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
 

--- a/tests/libtest/lib1512.c
+++ b/tests/libtest/lib1512.c
@@ -34,9 +34,9 @@
 
 #define NUM_HANDLES 2
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl[NUM_HANDLES] = {NULL, NULL};
   char *port = libtest_arg3;
   char *address = libtest_arg2;

--- a/tests/libtest/lib1513.c
+++ b/tests/libtest/lib1513.c
@@ -47,10 +47,10 @@ static int progressKiller(void *arg,
   return 1;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
 

--- a/tests/libtest/lib1514.c
+++ b/tests/libtest/lib1514.c
@@ -54,11 +54,11 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return 0;                         /* no more data left to deliver */
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode result = CURLE_OK;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   struct WriteThis pooh = { data, sizeof(data)-1 };
 
   global_init(CURL_GLOBAL_ALL);
@@ -82,5 +82,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)result;
+  return result;
 }

--- a/tests/libtest/lib1515.c
+++ b/tests/libtest/lib1515.c
@@ -49,12 +49,12 @@ static int debug_callback(CURL *curl, curl_infotype info, char *msg,
   return 0;
 }
 
-static int do_one_request(CURLM *m, char *URL, char *resolve)
+static CURLcode do_one_request(CURLM *m, char *URL, char *resolve)
 {
   CURL *curls;
   struct curl_slist *resolve_list = NULL;
   int still_running;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURLMsg *msg;
   int msgs_left;
 
@@ -110,10 +110,10 @@ test_cleanup:
   return res;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLM *multi = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   char *address = libtest_arg2;
   char *port = libtest_arg3;
   char *path = URL;
@@ -136,8 +136,9 @@ int test(char *URL)
 
     /* second request must succeed like the first one */
     res = do_one_request(multi, target_url, dns_entry);
-    if(res)
+    if(res != CURLE_OK) {
       goto test_cleanup;
+    }
 
     if(i < count)
       sleep(DNS_TIMEOUT + 1);
@@ -148,5 +149,5 @@ test_cleanup:
   curl_multi_cleanup(multi);
   curl_global_cleanup();
 
-  return (int) res;
+  return res;
 }

--- a/tests/libtest/lib1517.c
+++ b/tests/libtest/lib1517.c
@@ -53,7 +53,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return tocopy;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -64,9 +64,9 @@ int test(char *URL)
 #if (defined(_WIN32) || defined(__CYGWIN__))
     printf("Windows TCP does not deliver response data but reports "
            "CONNABORTED\n");
-    return 1; /* skip since test will fail on Windows without workaround */
+    return (CURLcode)1; /* skip since it fails on Windows without workaround */
 #else
-    return 0; /* sure, run this! */
+    return CURLE_OK; /* sure, run this! */
 #endif
   }
 

--- a/tests/libtest/lib1518.c
+++ b/tests/libtest/lib1518.c
@@ -37,7 +37,7 @@ static size_t writecb(char *buffer, size_t size, size_t nitems,
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -84,13 +84,13 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
 
   printf("res %d\n"
-         "status %d\n"
-         "redirects %d\n"
+         "status %ld\n"
+         "redirects %ld\n"
          "effectiveurl %s\n"
          "redirecturl %s\n",
-         (int)res,
-         (int)curlResponseCode,
-         (int)curlRedirectCount,
+         res,
+         curlResponseCode,
+         curlRedirectCount,
          effectiveUrl,
          redirectUrl ? redirectUrl : "blank");
 

--- a/tests/libtest/lib1520.c
+++ b/tests/libtest/lib1520.c
@@ -71,7 +71,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -111,5 +111,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -49,7 +49,7 @@ static int sockopt_callback(void *clientp, curl_socket_t curlfd,
   return CURL_SOCKOPT_OK;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode code = TEST_ERR_MAJOR_BAD;
   CURLcode res;
@@ -97,5 +97,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)code;
+  return code;
 }

--- a/tests/libtest/lib1523.c
+++ b/tests/libtest/lib1523.c
@@ -55,7 +55,7 @@ static CURLcode run(CURL *hnd, long limit, long time)
   return curl_easy_perform(hnd);
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode ret;
   CURL *hnd;
@@ -81,5 +81,5 @@ int test(char *URL)
   curl_easy_cleanup(hnd);
   curl_global_cleanup();
 
-  return (int)ret;
+  return ret;
 }

--- a/tests/libtest/lib1525.c
+++ b/tests/libtest/lib1525.c
@@ -46,7 +46,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 }
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_FAILED_INIT;
@@ -96,5 +96,5 @@ test_cleanup:
 
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1526.c
+++ b/tests/libtest/lib1526.c
@@ -44,7 +44,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
   return strlen(data);
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_FAILED_INIT;
@@ -101,5 +101,5 @@ test_cleanup:
 
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1527.c
+++ b/tests/libtest/lib1527.c
@@ -45,7 +45,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 }
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_FAILED_INIT;
@@ -98,5 +98,5 @@ test_cleanup:
 
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1528.c
+++ b/tests/libtest/lib1528.c
@@ -26,7 +26,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_FAILED_INIT;
@@ -71,5 +71,5 @@ test_cleanup:
   curl_slist_free_all(phl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1529.c
+++ b/tests/libtest/lib1529.c
@@ -26,7 +26,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_FAILED_INIT;
@@ -59,5 +59,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1530.c
+++ b/tests/libtest/lib1530.c
@@ -37,7 +37,7 @@ static curl_socket_t opensocket(void *clientp,
   return CURL_SOCKET_BAD;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_FAILED_INIT;
@@ -66,5 +66,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1531.c
+++ b/tests/libtest/lib1531.c
@@ -33,14 +33,14 @@
 static char const testData[] = ".abc\0xyz";
 static off_t const testDataSize = sizeof(testData) - 1;
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy;
   CURLM *multi_handle;
   int still_running; /* keep number of running handles */
   CURLMsg *msg; /* for picking up messages with the transfer status */
   int msgs_left; /* how many messages are left */
-  int res = CURLE_OK;
+  CURLcode res = CURLE_OK;
 
   start_test_timing();
 

--- a/tests/libtest/lib1532.c
+++ b/tests/libtest/lib1532.c
@@ -27,7 +27,7 @@
 
 /* Test CURLINFO_RESPONSE_CODE */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   long httpcode;
@@ -78,5 +78,5 @@ int test(char *URL)
 test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1533.c
+++ b/tests/libtest/lib1533.c
@@ -106,7 +106,7 @@ static int perform_and_check_connections(CURL *curl, const char *description,
 
   res = curl_easy_perform(curl);
   if(res != CURLE_OK) {
-    fprintf(stderr, "curl_easy_perform() failed with %d\n", (int)res);
+    fprintf(stderr, "curl_easy_perform() failed with %d\n", res);
     return TEST_ERR_MAJOR_BAD;
   }
 
@@ -127,11 +127,12 @@ static int perform_and_check_connections(CURL *curl, const char *description,
 }
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   struct cb_data data;
   CURL *curl = NULL;
-  int res = TEST_ERR_FAILURE;
+  CURLcode res = TEST_ERR_FAILURE;
+  int result;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     fprintf(stderr, "curl_global_init() failed\n");
@@ -157,17 +158,19 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
   test_setopt(curl, CURLOPT_WRITEDATA, &data);
 
-  res = perform_and_check_connections(curl,
+  result = perform_and_check_connections(curl,
     "First request without CURLOPT_KEEP_SENDING_ON_ERROR", 1);
-  if(res != TEST_ERR_SUCCESS) {
+  if(result != TEST_ERR_SUCCESS) {
+    res = (CURLcode) result;
     goto test_cleanup;
   }
 
   reset_data(&data, curl);
 
-  res = perform_and_check_connections(curl,
+  result = perform_and_check_connections(curl,
     "Second request without CURLOPT_KEEP_SENDING_ON_ERROR", 1);
-  if(res != TEST_ERR_SUCCESS) {
+  if(result != TEST_ERR_SUCCESS) {
+    res = (CURLcode) result;
     goto test_cleanup;
   }
 
@@ -175,17 +178,19 @@ int test(char *URL)
 
   reset_data(&data, curl);
 
-  res = perform_and_check_connections(curl,
+  result = perform_and_check_connections(curl,
     "First request with CURLOPT_KEEP_SENDING_ON_ERROR", 1);
-  if(res != TEST_ERR_SUCCESS) {
+  if(result != TEST_ERR_SUCCESS) {
+    res = (CURLcode) result;
     goto test_cleanup;
   }
 
   reset_data(&data, curl);
 
-  res = perform_and_check_connections(curl,
+  result = perform_and_check_connections(curl,
     "Second request with CURLOPT_KEEP_SENDING_ON_ERROR", 0);
-  if(res != TEST_ERR_SUCCESS) {
+  if(result != TEST_ERR_SUCCESS) {
+    res = (CURLcode) result;
     goto test_cleanup;
   }
 
@@ -197,5 +202,5 @@ test_cleanup:
 
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1534.c
+++ b/tests/libtest/lib1534.c
@@ -27,7 +27,7 @@
 
 /* Test CURLINFO_FILETIME */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl, *dupe = NULL;
   long filetime;
@@ -127,5 +127,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_easy_cleanup(dupe);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1535.c
+++ b/tests/libtest/lib1535.c
@@ -27,7 +27,7 @@
 
 /* Test CURLINFO_PROTOCOL */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl, *dupe = NULL;
   long protocol;
@@ -134,5 +134,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_easy_cleanup(dupe);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1536.c
+++ b/tests/libtest/lib1536.c
@@ -27,7 +27,7 @@
 
 /* Test CURLINFO_SCHEME */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl, *dupe = NULL;
   char *scheme;
@@ -127,5 +127,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_easy_cleanup(dupe);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1537.c
+++ b/tests/libtest/lib1537.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   const unsigned char a[] = {0x2f, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
                              0x91, 0xa2, 0xb3, 0xc4, 0xd5, 0xe6, 0xf7};
@@ -87,5 +87,5 @@ test_cleanup:
   curl_free(ptr);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1538.c
+++ b/tests/libtest/lib1538.c
@@ -25,9 +25,9 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURLcode easyret;
   CURLMcode multiret;
   CURLSHcode shareret;
@@ -56,5 +56,5 @@ int test(char *URL)
     printf("u%d: %s\n", (int)urlret, curl_url_strerror(urlret));
   }
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1540.c
+++ b/tests/libtest/lib1540.c
@@ -82,10 +82,10 @@ static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userp)
   return CURL_WRITEFUNC_PAUSE;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curls = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   struct transfer_status st;
 
   start_test_timing();
@@ -114,5 +114,5 @@ test_cleanup:
   curl_easy_cleanup(curls);
   curl_global_cleanup();
 
-  return (int)res; /* return the final return code */
+  return res; /* return the final return code */
 }

--- a/tests/libtest/lib1541.c
+++ b/tests/libtest/lib1541.c
@@ -110,10 +110,10 @@ static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userp)
   return size * nmemb;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curls = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   struct transfer_status st;
 
   start_test_timing();
@@ -148,5 +148,5 @@ test_cleanup:
   curl_easy_cleanup(curls);
   curl_global_cleanup();
 
-  return (int)res; /* return the final return code */
+  return res; /* return the final return code */
 }

--- a/tests/libtest/lib1542.c
+++ b/tests/libtest/lib1542.c
@@ -36,10 +36,10 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
 

--- a/tests/libtest/lib1545.c
+++ b/tests/libtest/lib1545.c
@@ -26,10 +26,10 @@
 #endif
 #include "test.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *eh = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   struct curl_httppost *lastptr = NULL;
   struct curl_httppost *m_formpost = NULL;
 

--- a/tests/libtest/lib1550.c
+++ b/tests/libtest/lib1550.c
@@ -27,10 +27,10 @@
 
 #include <curl/multi.h>
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLM *handle;
-  int res = CURLE_OK;
+  CURLcode res = CURLE_OK;
   static const char * const bl_servers[] =
      {"Microsoft-IIS/6.0", "nginx/0.8.54", NULL};
   static const char * const bl_sites[] =
@@ -44,5 +44,5 @@ int test(char *URL)
   curl_multi_setopt(handle, CURLMOPT_PIPELINING_SITE_BL, bl_sites);
   curl_multi_cleanup(handle);
   curl_global_cleanup();
-  return 0;
+  return CURLE_OK;
 }

--- a/tests/libtest/lib1551.c
+++ b/tests/libtest/lib1551.c
@@ -27,7 +27,7 @@
 
 #include <curl/multi.h>
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -49,5 +49,5 @@ int test(char *URL)
 test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1552.c
+++ b/tests/libtest/lib1552.c
@@ -29,13 +29,13 @@
 
 #define TEST_HANG_TIMEOUT 60 * 1000
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curls = NULL;
   CURLM *multi = NULL;
   int still_running;
-  int i = 0;
-  int res = 0;
+  CURLcode i = CURLE_OK;
+  CURLcode res = CURLE_OK;
   CURLMsg *msg;
   int counter = 3;
 
@@ -59,10 +59,11 @@ int test(char *URL)
   abort_on_test_timeout();
 
   while(still_running && counter--) {
+    CURLMcode mres;
     int num;
-    res = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
-    if(res != CURLM_OK) {
-      printf("curl_multi_wait() returned %d\n", res);
+    mres = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
+    if(mres != CURLM_OK) {
+      printf("curl_multi_wait() returned %d\n", mres);
       res = TEST_ERR_MAJOR_BAD;
       goto test_cleanup;
     }

--- a/tests/libtest/lib1553.c
+++ b/tests/libtest/lib1553.c
@@ -42,13 +42,13 @@ static int xferinfo(void *p,
   return 1; /* fail as fast as we can */
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curls = NULL;
   CURLM *multi = NULL;
   int still_running;
-  int i = 0;
-  int res = 0;
+  CURLcode i = CURLE_OK;
+  CURLcode res = CURLE_OK;
   curl_mimepart *field = NULL;
   curl_mime *mime = NULL;
   int counter = 1;
@@ -81,10 +81,11 @@ int test(char *URL)
   abort_on_test_timeout();
 
   while(still_running && counter--) {
+    CURLMcode mres;
     int num;
-    res = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
-    if(res != CURLM_OK) {
-      printf("curl_multi_wait() returned %d\n", res);
+    mres = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
+    if(mres != CURLM_OK) {
+      printf("curl_multi_wait() returned %d\n", mres);
       res = TEST_ERR_MAJOR_BAD;
       goto test_cleanup;
     }

--- a/tests/libtest/lib1554.c
+++ b/tests/libtest/lib1554.c
@@ -43,7 +43,7 @@ static void my_unlock(CURL *handle, curl_lock_data data, void *useptr)
 }
 
 /* test function */
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURLSH *share = NULL;
@@ -91,5 +91,5 @@ test_cleanup:
   curl_share_cleanup(share);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1555.c
+++ b/tests/libtest/lib1555.c
@@ -53,9 +53,9 @@ static int progressCallback(void *arg,
   return 1;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
 

--- a/tests/libtest/lib1556.c
+++ b/tests/libtest/lib1556.c
@@ -44,11 +44,11 @@ static size_t header(void *ptr, size_t size, size_t nmemb, void *stream)
   return nmemb * size;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode code;
   CURL *curl = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   struct headerinfo info = {0};
 
   global_init(CURL_GLOBAL_ALL);
@@ -64,7 +64,7 @@ int test(char *URL)
   if(CURLE_OK != code) {
     fprintf(stderr, "%s:%d curl_easy_perform() failed, "
             "with code %d (%s)\n",
-            __FILE__, __LINE__, (int)code, curl_easy_strerror(code));
+            __FILE__, __LINE__, code, curl_easy_strerror(code));
     res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }

--- a/tests/libtest/lib1557.c
+++ b/tests/libtest/lib1557.c
@@ -27,13 +27,13 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLM *curlm = NULL;
   CURL *curl1 = NULL;
   CURL *curl2 = NULL;
   int running_handles = 0;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
 

--- a/tests/libtest/lib1558.c
+++ b/tests/libtest/lib1558.c
@@ -27,7 +27,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURL *curl = NULL;
@@ -58,7 +58,7 @@ int test(char *URL)
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return 0;
+  return CURLE_OK;
 
 test_cleanup:
 

--- a/tests/libtest/lib1559.c
+++ b/tests/libtest/lib1559.c
@@ -28,7 +28,7 @@
 #include "memdebug.h"
 
 #define EXCESSIVE 10*1000*1000
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURL *curl = NULL;
@@ -37,7 +37,7 @@ int test(char *URL)
   (void)URL;
 
   if(!longurl)
-    return 1;
+    return (CURLcode)1;
 
   memset(longurl, 'a', EXCESSIVE);
   longurl[EXCESSIVE-1] = 0;
@@ -47,11 +47,11 @@ int test(char *URL)
 
   res = curl_easy_setopt(curl, CURLOPT_URL, longurl);
   printf("CURLOPT_URL %d bytes URL == %d\n",
-         EXCESSIVE, (int)res);
+         EXCESSIVE, res);
 
   res = curl_easy_setopt(curl, CURLOPT_POSTFIELDS, longurl);
   printf("CURLOPT_POSTFIELDS %d bytes data == %d\n",
-         EXCESSIVE, (int)res);
+         EXCESSIVE, res);
 
   u = curl_url();
   if(u) {

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1847,43 +1847,43 @@ err:
   return 1;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   (void)URL; /* not used */
 
   if(urldup())
-    return 11;
+    return (CURLcode)11;
 
   if(setget_parts())
-    return 10;
+    return (CURLcode)10;
 
   if(get_url())
-    return 3;
+    return (CURLcode)3;
 
   if(huge())
-    return 9;
+    return (CURLcode)9;
 
   if(get_nothing())
-    return 7;
+    return (CURLcode)7;
 
   if(scopeid())
-    return 6;
+    return (CURLcode)6;
 
   if(append())
-    return 5;
+    return (CURLcode)5;
 
   if(set_url())
-    return 1;
+    return (CURLcode)1;
 
   if(set_parts())
-    return 2;
+    return (CURLcode)2;
 
   if(get_parts())
-    return 4;
+    return (CURLcode)4;
 
   if(clear_url())
-    return 8;
+    return (CURLcode)8;
 
   printf("success\n");
-  return 0;
+  return CURLE_OK;
 }

--- a/tests/libtest/lib1564.c
+++ b/tests/libtest/lib1564.c
@@ -30,12 +30,12 @@
 #define TEST_HANG_TIMEOUT 60 * 1000
 #define WAKEUP_NUM 10
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLM *multi = NULL;
   int numfds;
   int i;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   struct timeval time_before_wait, time_after_wait;
 
   (void)URL;

--- a/tests/libtest/lib1565.c
+++ b/tests/libtest/lib1565.c
@@ -38,7 +38,7 @@
 static pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;
 static CURL *pending_handles[CONN_NUM];
 static int pending_num = 0;
-static int test_failure = 0;
+static CURLcode test_failure = CURLE_OK;
 
 static CURLM *multi = NULL;
 static const char *url;
@@ -46,7 +46,7 @@ static const char *url;
 static void *run_thread(void *ptr)
 {
   CURL *easy = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   int i;
 
   (void)ptr;
@@ -89,12 +89,13 @@ test_cleanup:
   return NULL;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   int still_running;
   int num;
   int i;
-  int res = 0;
+  int result;
+  CURLcode res = CURLE_OK;
   CURL *started_handles[CONN_NUM];
   int started_num = 0;
   int finished_num = 0;
@@ -110,12 +111,12 @@ int test(char *URL)
 
   url = URL;
 
-  res = pthread_create(&tid, NULL, run_thread, NULL);
-  if(!res)
+  result = pthread_create(&tid, NULL, run_thread, NULL);
+  if(!result)
     tid_valid = true;
   else {
     fprintf(stderr, "%s:%d Couldn't create thread, errno %d\n",
-            __FILE__, __LINE__, res);
+            __FILE__, __LINE__, result);
     goto test_cleanup;
   }
 
@@ -201,7 +202,7 @@ test_cleanup:
 }
 
 #else /* without pthread, this test doesn't work */
-int test(char *URL)
+CURLcode test(char *URL)
 {
   (void)URL;
   return 0;

--- a/tests/libtest/lib1567.c
+++ b/tests/libtest/lib1567.c
@@ -27,7 +27,7 @@
 
 #include <curl/multi.h>
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_OK;
@@ -55,5 +55,5 @@ test_cleanup:
   curl_url_cleanup(u);
   curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1568.c
+++ b/tests/libtest/lib1568.c
@@ -26,7 +26,7 @@
 #include "testtrace.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode ret;
   CURL *hnd;
@@ -48,5 +48,5 @@ int test(char *URL)
   hnd = NULL;
 
   curl_global_cleanup();
-  return (int)ret;
+  return ret;
 }

--- a/tests/libtest/lib1569.c
+++ b/tests/libtest/lib1569.c
@@ -26,7 +26,7 @@
 #include "testtrace.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURL *hnd;
@@ -47,5 +47,5 @@ int test(char *URL)
 test_cleanup:
   curl_easy_cleanup(hnd);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1591.c
+++ b/tests/libtest/lib1591.c
@@ -73,7 +73,7 @@ static int trailers_callback(struct curl_slist **list, void *userdata)
   }
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_FAILED_INIT;
@@ -116,5 +116,5 @@ test_cleanup:
 
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1592.c
+++ b/tests/libtest/lib1592.c
@@ -41,7 +41,7 @@
 
 #include <sys/stat.h>
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   int stillRunning;
   CURLM *multiHandle = NULL;
@@ -103,8 +103,7 @@ int test(char *URL)
   start_test_timing();
   mres = curl_multi_remove_handle(multiHandle, curl);
   if(mres) {
-    fprintf(stderr, "curl_multi_remove_handle() failed, "
-            "with code %d\n", (int)res);
+    fprintf(stderr, "curl_multi_remove_handle() failed, with code %d\n", mres);
     res = TEST_ERR_MULTI;
     goto test_cleanup;
   }
@@ -120,5 +119,5 @@ test_cleanup:
   curl_multi_cleanup(multiHandle);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1593.c
+++ b/tests/libtest/lib1593.c
@@ -28,12 +28,12 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   struct curl_slist *header = NULL;
   long unmet;
   CURL *curl = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
 

--- a/tests/libtest/lib1594.c
+++ b/tests/libtest/lib1594.c
@@ -28,12 +28,12 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   struct curl_slist *header = NULL;
   curl_off_t retry;
   CURL *curl = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
 

--- a/tests/libtest/lib1597.c
+++ b/tests/libtest/lib1597.c
@@ -33,10 +33,10 @@ struct pair {
   CURLcode *exp;
 };
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURLcode result = CURLE_OK;
   curl_version_info_data *curlinfo;
   const char *const *proto;
@@ -77,7 +77,7 @@ int test(char *URL)
   curlinfo = curl_version_info(CURLVERSION_NOW);
   if(!curlinfo) {
     fputs("curl_version_info failed\n", stderr);
-    res = (int) TEST_ERR_FAILURE;
+    res = TEST_ERR_FAILURE;
     goto test_cleanup;
   }
 
@@ -85,7 +85,7 @@ int test(char *URL)
   for(proto = curlinfo->protocols; *proto; proto++) {
     if((size_t) n >= sizeof(protolist)) {
       puts("protolist buffer too small\n");
-      res = (int) TEST_ERR_FAILURE;
+      res = TEST_ERR_FAILURE;
       goto test_cleanup;
     }
     n += msnprintf(protolist + n, sizeof(protolist) - n, ",%s", *proto);
@@ -99,17 +99,15 @@ int test(char *URL)
   for(i = 0; prots[i].in; i++) {
     result = curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, prots[i].in);
     if(result != *prots[i].exp) {
-      printf("unexpectedly '%s' returned %u\n",
-             prots[i].in, result);
+      printf("unexpectedly '%s' returned %d\n", prots[i].in, result);
       break;
     }
   }
   printf("Tested %u strings\n", i);
-  res = (int)result;
 
 test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)result;
+  return result;
 }

--- a/tests/libtest/lib1598.c
+++ b/tests/libtest/lib1598.c
@@ -54,7 +54,7 @@ static int trailers_callback(struct curl_slist **list, void *userdata)
 
 static const char *post_data = "xxx=yyy&aaa=bbbbb";
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_FAILED_INIT;
@@ -103,5 +103,5 @@ test_cleanup:
 
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1662.c
+++ b/tests/libtest/lib1662.c
@@ -47,7 +47,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 }
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURL *hnd;
@@ -86,5 +86,5 @@ int test(char *URL)
   curl_easy_cleanup(hnd);
   curl_mime_free(mime1);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1900.c
+++ b/tests/libtest/lib1900.c
@@ -27,7 +27,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURL *hnd = NULL;
@@ -45,11 +45,11 @@ int test(char *URL)
   curl_easy_cleanup(hnd);
   curl_easy_cleanup(second);
   curl_global_cleanup();
-  return 0;
+  return CURLE_OK;
 
 test_cleanup:
   curl_easy_cleanup(hnd);
   curl_easy_cleanup(second);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1901.c
+++ b/tests/libtest/lib1901.c
@@ -53,7 +53,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -91,5 +91,5 @@ test_cleanup:
   curl_slist_free_all(chunk);
 
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1903.c
+++ b/tests/libtest/lib1903.c
@@ -28,7 +28,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURL *ch = NULL;
@@ -53,5 +53,5 @@ test_cleanup:
   curl_easy_cleanup(ch);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1905.c
+++ b/tests/libtest/lib1905.c
@@ -28,7 +28,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLSH *sh = NULL;
   CURL *ch = NULL;
@@ -40,7 +40,7 @@ int test(char *URL)
   cm = curl_multi_init();
   if(!cm) {
     curl_global_cleanup();
-    return 1;
+    return (CURLcode)1;
   }
   sh = curl_share_init();
   if(!sh)
@@ -96,5 +96,5 @@ cleanup:
   curl_multi_cleanup(cm);
   curl_global_cleanup();
 
-  return 0;
+  return CURLE_OK;
 }

--- a/tests/libtest/lib1906.c
+++ b/tests/libtest/lib1906.c
@@ -27,7 +27,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   char *url_after = NULL;
@@ -49,7 +49,7 @@ int test(char *URL)
   if(res != CURLE_COULDNT_CONNECT && res != CURLE_OPERATION_TIMEDOUT) {
     fprintf(stderr, "failure expected, "
             "curl_easy_perform returned %d: <%s>, <%s>\n",
-            (int) res, curl_easy_strerror(res), error_buffer);
+            res, curl_easy_strerror(res), error_buffer);
     if(res == CURLE_OK)
       res = TEST_ERR_MAJOR_BAD;  /* force an error return */
     goto test_cleanup;
@@ -68,8 +68,8 @@ int test(char *URL)
   res = curl_easy_perform(curl);
   if(res)
     fprintf(stderr, "success expected, "
-            "curl_easy_perform returned %ld: <%s>, <%s>\n",
-            (long) res, curl_easy_strerror(res), error_buffer);
+            "curl_easy_perform returned %d: <%s>, <%s>\n",
+            res, curl_easy_strerror(res), error_buffer);
 
   /* print url */
   curl_url_get(curlu, CURLUPART_URL, &url_after, 0);
@@ -81,5 +81,5 @@ test_cleanup:
   curl_url_cleanup(curlu);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1907.c
+++ b/tests/libtest/lib1907.c
@@ -27,7 +27,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   char *url_after;
   CURL *curl;
@@ -52,5 +52,5 @@ int test(char *URL)
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1908.c
+++ b/tests/libtest/lib1908.c
@@ -27,7 +27,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode ret = CURLE_OK;
   CURL *hnd;
@@ -60,5 +60,5 @@ int test(char *URL)
     curl_easy_cleanup(hnd);
   }
   curl_global_cleanup();
-  return (int)ret;
+  return ret;
 }

--- a/tests/libtest/lib1910.c
+++ b/tests/libtest/lib1910.c
@@ -27,7 +27,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode ret = CURLE_OK;
   CURL *hnd;
@@ -45,5 +45,5 @@ int test(char *URL)
     curl_easy_cleanup(hnd);
   }
   curl_global_cleanup();
-  return (int)ret;
+  return ret;
 }

--- a/tests/libtest/lib1911.c
+++ b/tests/libtest/lib1911.c
@@ -33,7 +33,7 @@
 
 static char buffer[MAX_INPUT_LENGTH + 2];
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   const struct curl_easyoption *o;
   CURL *easy;
@@ -44,7 +44,7 @@ int test(char *URL)
   easy = curl_easy_init();
   if(!easy) {
     curl_global_cleanup();
-    return 1;
+    return (CURLcode)1;
   }
 
   /* make it a null-terminated C string with just As */
@@ -86,7 +86,7 @@ int test(char *URL)
       default:
         /* all other return codes are unexpected */
         fprintf(stderr, "curl_easy_setopt(%s...) returned %d\n",
-                o->name, (int)result);
+                o->name, result);
         error++;
         break;
       }
@@ -94,5 +94,5 @@ int test(char *URL)
   }
   curl_easy_cleanup(easy);
   curl_global_cleanup();
-  return error;
+  return error == 0 ? CURLE_OK : TEST_ERR_FAILURE;
 }

--- a/tests/libtest/lib1912.c
+++ b/tests/libtest/lib1912.c
@@ -30,7 +30,7 @@
 #define print_err(name, exp) \
   fprintf(stderr, "Type mismatch for CURLOPT_%s (expected %s)\n", name, exp);
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
 /* Only test if GCC typechecking is available */
   int error = 0;
@@ -80,5 +80,5 @@ int test(char *URL)
   }
 #endif
   (void)URL;
-  return error;
+  return error == 0 ? CURLE_OK : TEST_ERR_FAILURE;
 }

--- a/tests/libtest/lib1913.c
+++ b/tests/libtest/lib1913.c
@@ -27,7 +27,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode ret = CURLE_OK;
   CURL *hnd;
@@ -46,5 +46,5 @@ int test(char *URL)
     curl_easy_cleanup(hnd);
   }
   curl_global_cleanup();
-  return (int)ret;
+  return ret;
 }

--- a/tests/libtest/lib1915.c
+++ b/tests/libtest/lib1915.c
@@ -96,7 +96,7 @@ static CURLSTScode hstswrite(CURL *easy, struct curl_hstsentry *e,
  * Read/write HSTS cache entries via callback.
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURL *hnd;
@@ -114,7 +114,7 @@ int test(char *URL)
   res = curl_easy_perform(hnd);
   curl_easy_cleanup(hnd);
   hnd = NULL;
-  printf("First request returned %d\n", (int)res);
+  printf("First request returned %d\n", res);
   res = CURLE_OK;
 
   easy_init(hnd);
@@ -127,10 +127,10 @@ int test(char *URL)
   res = curl_easy_perform(hnd);
   curl_easy_cleanup(hnd);
   hnd = NULL;
-  printf("Second request returned %d\n", (int)res);
+  printf("Second request returned %d\n", res);
 
 test_cleanup:
   curl_easy_cleanup(hnd);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1916.c
+++ b/tests/libtest/lib1916.c
@@ -26,7 +26,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -52,5 +52,5 @@ int test(char *URL)
     curl_easy_cleanup(curl);
   }
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1918.c
+++ b/tests/libtest/lib1918.c
@@ -27,10 +27,9 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   const struct curl_easyoption *o;
-  int error = 0;
   (void)URL;
 
   curl_global_init(CURL_GLOBAL_ALL);
@@ -53,5 +52,5 @@ int test(char *URL)
     }
   }
   curl_global_cleanup();
-  return error;
+  return CURLE_OK;
 }

--- a/tests/libtest/lib1919.c
+++ b/tests/libtest/lib1919.c
@@ -27,7 +27,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURL *curl;
@@ -52,5 +52,5 @@ int test(char *URL)
 test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1933.c
+++ b/tests/libtest/lib1933.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1934.c
+++ b/tests/libtest/lib1934.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1935.c
+++ b/tests/libtest/lib1935.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1936.c
+++ b/tests/libtest/lib1936.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1937.c
+++ b/tests/libtest/lib1937.c
@@ -26,7 +26,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1938.c
+++ b/tests/libtest/lib1938.c
@@ -26,7 +26,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1939.c
+++ b/tests/libtest/lib1939.c
@@ -26,7 +26,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLM *multi;
   CURL *easy;

--- a/tests/libtest/lib1940.c
+++ b/tests/libtest/lib1940.c
@@ -83,7 +83,7 @@ static size_t write_cb(char *data, size_t n, size_t l, void *userp)
   (void)userp;
   return n*l;
 }
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy = NULL;
   CURLcode res = CURLE_OK;
@@ -116,5 +116,5 @@ int test(char *URL)
 test_cleanup:
   curl_easy_cleanup(easy);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1945.c
+++ b/tests/libtest/lib1945.c
@@ -49,7 +49,7 @@ static size_t write_cb(char *data, size_t n, size_t l, void *userp)
   (void)userp;
   return n*l;
 }
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy;
   CURLcode res = CURLE_OK;
@@ -70,12 +70,12 @@ int test(char *URL)
   }
   res = curl_easy_perform(easy);
   if(res) {
-    printf("badness: %d\n", (int)res);
+    printf("badness: %d\n", res);
   }
   showem(easy, CURLH_CONNECT|CURLH_HEADER|CURLH_TRAILER|CURLH_1XX);
 
 test_cleanup:
   curl_easy_cleanup(easy);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1947.c
+++ b/tests/libtest/lib1947.c
@@ -33,7 +33,7 @@ static size_t writecb(char *data, size_t n, size_t l, void *userp)
   (void)userp;
   return n*l;
 }
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -88,5 +88,5 @@ int test(char *URL)
 test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1948.c
+++ b/tests/libtest/lib1948.c
@@ -41,7 +41,7 @@ static size_t put_callback(char *ptr, size_t size, size_t nmemb, void *stream)
   return tocopy;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -74,5 +74,5 @@ int test(char *URL)
 test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib1955.c
+++ b/tests/libtest/lib1955.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1956.c
+++ b/tests/libtest/lib1956.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1957.c
+++ b/tests/libtest/lib1957.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1958.c
+++ b/tests/libtest/lib1958.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1959.c
+++ b/tests/libtest/lib1959.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -68,7 +68,7 @@ static int sockopt_cb(void *clientp,
 }
 
 /* Expected args: URL IP PORT */
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = TEST_ERR_MAJOR_BAD;
@@ -78,7 +78,7 @@ int test(char *URL)
   unsigned short port;
 
   if(!strcmp("check", URL))
-    return 0; /* no output makes it not skipped */
+    return CURLE_OK; /* no output makes it not skipped */
 
   port = (unsigned short)atoi(libtest_arg3);
 
@@ -140,10 +140,10 @@ test_cleanup:
   return res;
 }
 #else
-int test(char *URL)
+CURLcode test(char *URL)
 {
   (void)URL;
   printf("lacks inet_pton\n");
-  return 0;
+  return CURLE_OK;
 }
 #endif

--- a/tests/libtest/lib1964.c
+++ b/tests/libtest/lib1964.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib1970.c
+++ b/tests/libtest/lib1970.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1971.c
+++ b/tests/libtest/lib1971.c
@@ -35,7 +35,7 @@ static size_t read_callback(char *buffer, size_t size, size_t nitems,
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1972.c
+++ b/tests/libtest/lib1972.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   curl_mime *mime = NULL;

--- a/tests/libtest/lib1973.c
+++ b/tests/libtest/lib1973.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1974.c
+++ b/tests/libtest/lib1974.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib1975.c
+++ b/tests/libtest/lib1975.c
@@ -35,7 +35,7 @@ static size_t read_callback(char *buffer, size_t size, size_t nitems,
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib2301.c
+++ b/tests/libtest/lib2301.c
@@ -27,18 +27,18 @@
 #ifdef USE_WEBSOCKETS
 #if 0
 
-static int ping(CURL *curl, const char *send_payload)
+static CURLcode ping(CURL *curl, const char *send_payload)
 {
   size_t sent;
   CURLcode result =
     curl_ws_send(curl, send_payload, strlen(send_payload), &sent, CURLWS_PING);
   fprintf(stderr,
-          "ws: curl_ws_send returned %u, sent %u\n", (int)result, (int)sent);
+          "ws: curl_ws_send returned %d, sent %d\n", result, (int)sent);
 
-  return (int)result;
+  return result;
 }
 
-static int recv_pong(CURL *curl, const char *expected_payload)
+static CURLcode recv_pong(CURL *curl, const char *expected_payload)
 {
   size_t rlen;
   unsigned int rflags;
@@ -58,11 +58,11 @@ static int recv_pong(CURL *curl, const char *expected_payload)
       fprintf(stderr, "ws: did NOT get the same payload back\n");
   }
   else {
-    fprintf(stderr, "recv_pong: got %u bytes rflags %x\n", (int)rlen, rflags);
+    fprintf(stderr, "recv_pong: got %d bytes rflags %x\n", (int)rlen, rflags);
   }
-  fprintf(stderr, "ws: curl_ws_recv returned %u, received %u\n", (int)result,
-         rlen);
-  return (int)result;
+  fprintf(stderr, "ws: curl_ws_recv returned %d, received %d\n", result,
+          (int)rlen);
+  return result;
 }
 
 /* just close the connection */
@@ -72,7 +72,7 @@ static void websocket_close(CURL *curl)
   CURLcode result =
     curl_ws_send(curl, "", 0, &sent, CURLWS_CLOSE);
   fprintf(stderr,
-          "ws: curl_ws_send returned %u, sent %u\n", (int)result, (int)sent);
+          "ws: curl_ws_send returned %d, sent %d\n", result, (int)sent);
 }
 
 static void websocket(CURL *curl)
@@ -101,7 +101,7 @@ static size_t writecb(char *b, size_t size, size_t nitems, void *p)
     0x8a, 0x0
   };
   size_t incoming = nitems;
-  fprintf(stderr, "Called CURLOPT_WRITEFUNCTION with %u bytes: ",
+  fprintf(stderr, "Called CURLOPT_WRITEFUNCTION with %d bytes: ",
           (int)nitems);
   for(i = 0; i < nitems; i++)
     fprintf(stderr, "%02x ", (unsigned char)buffer[i]);
@@ -119,7 +119,7 @@ static size_t writecb(char *b, size_t size, size_t nitems, void *p)
   return nitems;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -137,7 +137,7 @@ int test(char *URL)
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, curl);
     res = curl_easy_perform(curl);
-    fprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
+    fprintf(stderr, "curl_easy_perform() returned %d\n", res);
 #if 0
     if(res == CURLE_OK)
       websocket(curl);
@@ -146,7 +146,7 @@ int test(char *URL)
     curl_easy_cleanup(curl);
   }
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }
 
 #else /* no websockets */

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -91,7 +91,7 @@ static size_t writecb(char *buffer, size_t size, size_t nitems, void *p)
   return nitems;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -112,13 +112,13 @@ int test(char *URL)
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ws_data);
     res = curl_easy_perform(curl);
-    fprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
+    fprintf(stderr, "curl_easy_perform() returned %d\n", res);
     /* always cleanup */
     curl_easy_cleanup(curl);
     flush_data(&ws_data);
   }
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }
 
 #else

--- a/tests/libtest/lib2304.c
+++ b/tests/libtest/lib2304.c
@@ -26,19 +26,19 @@
 
 #ifdef USE_WEBSOCKETS
 
-static int ping(CURL *curl, const char *send_payload)
+static CURLcode ping(CURL *curl, const char *send_payload)
 {
   size_t sent;
   CURLcode result =
     curl_ws_send(curl, send_payload, strlen(send_payload), &sent, 0,
                  CURLWS_PING);
   fprintf(stderr,
-          "ws: curl_ws_send returned %u, sent %u\n", (int)result, (int)sent);
+          "ws: curl_ws_send returned %d, sent %d\n", result, (int)sent);
 
-  return (int)result;
+  return result;
 }
 
-static int recv_pong(CURL *curl, const char *expected_payload)
+static CURLcode recv_pong(CURL *curl, const char *expected_payload)
 {
   size_t rlen;
   const struct curl_ws_frame *meta;
@@ -58,16 +58,16 @@ static int recv_pong(CURL *curl, const char *expected_payload)
         fprintf(stderr, "ws: did NOT get the same payload back\n");
     }
     else {
-      fprintf(stderr, "recv_pong: got %u bytes rflags %x\n", (int)rlen,
+      fprintf(stderr, "recv_pong: got %d bytes rflags %x\n", (int)rlen,
               meta->flags);
     }
   }
-  fprintf(stderr, "ws: curl_ws_recv returned %u, received %u\n", (int)result,
+  fprintf(stderr, "ws: curl_ws_recv returned %d, received %d\n", result,
           (int)rlen);
-  return (int)result;
+  return result;
 }
 
-static int recv_any(CURL *curl)
+static CURLcode recv_any(CURL *curl)
 {
   size_t rlen;
   const struct curl_ws_frame *meta;
@@ -78,7 +78,7 @@ static int recv_any(CURL *curl)
 
   fprintf(stderr, "recv_any: got %u bytes rflags %x\n", (int)rlen,
           meta->flags);
-  return 0;
+  return CURLE_OK;
 }
 
 /* just close the connection */
@@ -88,7 +88,7 @@ static void websocket_close(CURL *curl)
   CURLcode result =
     curl_ws_send(curl, "", 0, &sent, 0, CURLWS_CLOSE);
   fprintf(stderr,
-          "ws: curl_ws_send returned %u, sent %u\n", (int)result, (int)sent);
+          "ws: curl_ws_send returned %d, sent %u\n", result, (int)sent);
 }
 
 static void websocket(CURL *curl)
@@ -110,7 +110,7 @@ static void websocket(CURL *curl)
   websocket_close(curl);
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -126,7 +126,7 @@ int test(char *URL)
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
     res = curl_easy_perform(curl);
-    fprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
+    fprintf(stderr, "curl_easy_perform() returned %d\n", res);
     if(res == CURLE_OK)
       websocket(curl);
 
@@ -134,7 +134,7 @@ int test(char *URL)
     curl_easy_cleanup(curl);
   }
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }
 
 #else

--- a/tests/libtest/lib2305.c
+++ b/tests/libtest/lib2305.c
@@ -34,7 +34,7 @@ static void websocket_close(CURL *curl)
   CURLcode result =
     curl_ws_send(curl, "", 0, &sent, 0, CURLWS_CLOSE);
   fprintf(stderr,
-          "ws: curl_ws_send returned %u, sent %u\n", (int)result, (int)sent);
+          "ws: curl_ws_send returned %d, sent %d\n", result, (int)sent);
 }
 
 static void websocket(CURL *curl)
@@ -55,10 +55,10 @@ static void websocket(CURL *curl)
       if(result == CURLE_AGAIN)
         /* crude busy-loop */
         continue;
-      printf("curl_ws_recv returned %d\n", (int)result);
+      printf("curl_ws_recv returned %d\n", result);
       return;
     }
-    printf("%u: nread %zu Age %u Flags %x "
+    printf("%d: nread %zu Age %d Flags %x "
            "Offset %" CURL_FORMAT_CURL_OFF_T " "
            "Bytesleft %" CURL_FORMAT_CURL_OFF_T "\n",
            (int)i,
@@ -71,7 +71,7 @@ static void websocket(CURL *curl)
   websocket_close(curl);
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -91,7 +91,7 @@ int test(char *URL)
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
     res = curl_easy_perform(curl);
-    fprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
+    fprintf(stderr, "curl_easy_perform() returned %d\n", res);
     if(res == CURLE_OK)
       websocket(curl);
 
@@ -99,7 +99,7 @@ int test(char *URL)
     curl_easy_cleanup(curl);
   }
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }
 
 #else

--- a/tests/libtest/lib2306.c
+++ b/tests/libtest/lib2306.c
@@ -29,7 +29,7 @@
 
 #define URL2 libtest_arg2
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   /* first a fine GET response, then a bad one */
   CURL *cl;

--- a/tests/libtest/lib2402.c
+++ b/tests/libtest/lib2402.c
@@ -31,9 +31,9 @@
 
 #define NUM_HANDLES 4
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl[NUM_HANDLES] = {0};
   int running;
   CURLM *m = NULL;

--- a/tests/libtest/lib2404.c
+++ b/tests/libtest/lib2404.c
@@ -31,9 +31,9 @@
 
 #define NUM_HANDLES 4
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl[NUM_HANDLES] = {0};
   int running;
   CURLM *m = NULL;

--- a/tests/libtest/lib2405.c
+++ b/tests/libtest/lib2405.c
@@ -73,9 +73,9 @@ static size_t emptyWriteFunc(void *ptr, size_t size, size_t nmemb,
   return size * nmemb;
 }
 
-static int set_easy(char *URL, CURL *easy, long option)
+static CURLcode set_easy(char *URL, CURL *easy, long option)
 {
-  int res = CURLE_OK;
+  CURLcode res = CURLE_OK;
 
   /* First set the URL that is about to receive our POST. */
   easy_setopt(easy, CURLOPT_URL, URL);
@@ -115,7 +115,7 @@ test_cleanup:
   return res;
 }
 
-static int test_run(char *URL, long option, unsigned int *max_fd_count)
+static CURLcode test_run(char *URL, long option, unsigned int *max_fd_count)
 {
   CURLMcode mc = CURLM_OK;
   CURLM *multi = NULL;
@@ -131,7 +131,7 @@ static int test_run(char *URL, long option, unsigned int *max_fd_count)
   int msgs_left; /* how many messages are left */
 
   CURLcode result;
-  int res = CURLE_OK;
+  CURLcode res = CURLE_OK;
 
   struct curl_waitfd ufds[10];
   struct curl_waitfd ufds1[10];
@@ -205,7 +205,7 @@ static int test_run(char *URL, long option, unsigned int *max_fd_count)
       result = msg->data.result;
 
       if(!res)
-        res = (int)result;
+        res = result;
     }
   }
 
@@ -221,10 +221,11 @@ test_cleanup:
 
   if(max_fd_count)
     *max_fd_count = max_count;
+
   return res;
 }
 
-static int empty_multi_test(void)
+static CURLcode empty_multi_test(void)
 {
   CURLMcode mc = CURLM_OK;
   CURLM *multi = NULL;
@@ -232,7 +233,7 @@ static int empty_multi_test(void)
 
   struct curl_waitfd ufds[10];
 
-  int res = CURLE_OK;
+  CURLcode res = CURLE_OK;
   unsigned int fd_count = 0;
 
   multi_init(multi);
@@ -282,9 +283,9 @@ test_cleanup:
   return res;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = CURLE_OK;
+  CURLcode res = CURLE_OK;
   unsigned int fd_count = 0;
 
   global_init(CURL_GLOBAL_ALL);

--- a/tests/libtest/lib2502.c
+++ b/tests/libtest/lib2502.c
@@ -31,9 +31,9 @@
 
 #define NUM_HANDLES 4
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl[NUM_HANDLES] = {0};
   int running;
   CURLM *m = NULL;

--- a/tests/libtest/lib3010.c
+++ b/tests/libtest/lib3010.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode ret = CURLE_OK;
   CURL *curl = NULL;

--- a/tests/libtest/lib3025.c
+++ b/tests/libtest/lib3025.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -57,5 +57,5 @@ test_cleanup:
   curl_slist_free_all(icy);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -45,7 +45,7 @@ static unsigned int WINAPI run_thread(void *ptr)
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
 #ifdef _WIN32_WCE
   typedef HANDLE curl_win_thread_handle_t;
@@ -64,7 +64,7 @@ int test(char *URL)
     fprintf(stderr, "%s:%d On Windows but the "
             "CURL_VERSION_THREADSAFE feature flag is not set\n",
             __FILE__, __LINE__);
-    return -1;
+    return (CURLcode)-1;
   }
 
   /* On Windows libcurl global init/cleanup calls LoadLibrary/FreeLibrary for
@@ -105,7 +105,7 @@ cleanup:
     }
   }
 
-  return test_failure;
+  return (CURLcode)test_failure;
 }
 
 #elif defined(HAVE_PTHREAD_H)
@@ -123,12 +123,12 @@ static void *run_thread(void *ptr)
   return NULL;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode results[NUM_THREADS];
   pthread_t tids[NUM_THREADS];
   unsigned tid_count = NUM_THREADS, i;
-  int test_failure = 0;
+  CURLcode test_failure = CURLE_OK;
   curl_version_info_data *ver;
   (void) URL;
 
@@ -137,7 +137,7 @@ int test(char *URL)
     fprintf(stderr, "%s:%d Have pthread but the "
             "CURL_VERSION_THREADSAFE feature flag is not set\n",
             __FILE__, __LINE__);
-    return -1;
+    return (CURLcode)-1;
   }
 
   for(i = 0; i < tid_count; i++) {
@@ -148,7 +148,7 @@ int test(char *URL)
       fprintf(stderr, "%s:%d Couldn't create thread, errno %d\n",
               __FILE__, __LINE__, res);
       tid_count = i;
-      test_failure = -1;
+      test_failure = (CURLcode)-1;
       goto cleanup;
     }
   }
@@ -160,7 +160,7 @@ cleanup:
       fprintf(stderr, "%s:%d thread[%u]: curl_global_init() failed,"
               "with code %d (%s)\n", __FILE__, __LINE__,
               i, (int) results[i], curl_easy_strerror(results[i]));
-      test_failure = -1;
+      test_failure = (CURLcode)-1;
     }
   }
 
@@ -168,7 +168,7 @@ cleanup:
 }
 
 #else /* without pthread or Windows, this test doesn't work */
-int test(char *URL)
+CURLcode test(char *URL)
 {
   curl_version_info_data *ver;
   (void)URL;
@@ -178,8 +178,8 @@ int test(char *URL)
     fprintf(stderr, "%s:%d No pthread but the "
             "CURL_VERSION_THREADSAFE feature flag is set\n",
             __FILE__, __LINE__);
-    return -1;
+    return (CURLcode)-1;
   }
-  return 0;
+  return CURLE_OK;
 }
 #endif

--- a/tests/libtest/lib3027.c
+++ b/tests/libtest/lib3027.c
@@ -27,7 +27,7 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode ret = CURLE_OK;
   CURL *hnd;
@@ -52,5 +52,5 @@ int test(char *URL)
     curl_easy_cleanup(hnd);
   }
   curl_global_cleanup();
-  return (int)ret;
+  return ret;
 }

--- a/tests/libtest/lib3100.c
+++ b/tests/libtest/lib3100.c
@@ -24,9 +24,9 @@
 #include "test.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
   CURL *curl;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
@@ -54,7 +54,7 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);
 
   res = curl_easy_perform(curl);
-  if(res != (int)CURLE_OK) {
+  if(res != CURLE_OK) {
     fprintf(stderr, "Failed to send DESCRIBE: %d\n", res);
     res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;

--- a/tests/libtest/lib3101.c
+++ b/tests/libtest/lib3101.c
@@ -24,9 +24,9 @@
 #include "test.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
   CURL *curl;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
@@ -51,7 +51,7 @@ int test(char *URL)
   test_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "https");
 
   res = curl_easy_perform(curl);
-  if(res != (int)CURLE_OK) {
+  if(res != CURLE_OK) {
     res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }

--- a/tests/libtest/lib3102.c
+++ b/tests/libtest/lib3102.c
@@ -88,7 +88,7 @@ static size_t wrfu(void *ptr,  size_t  size,  size_t  nmemb,  void *stream)
   return size * nmemb;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib3103.c
+++ b/tests/libtest/lib3103.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURLSH *share;
@@ -59,8 +59,8 @@ test_cleanup:
 
   /* always cleanup */
   curl_easy_cleanup(curl);
-    curl_share_cleanup(share);
+  curl_share_cleanup(share);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib500.c
+++ b/tests/libtest/lib500.c
@@ -59,7 +59,7 @@ static void setupcallbacks(CURL *curl)
 #endif
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -154,5 +154,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib501.c
+++ b/tests/libtest/lib501.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -56,5 +56,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib502.c
+++ b/tests/libtest/lib502.c
@@ -33,11 +33,11 @@
  * Get a single URL without select().
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *c = NULL;
   CURLM *m = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   int running;
 
   start_test_timing();

--- a/tests/libtest/lib503.c
+++ b/tests/libtest/lib503.c
@@ -37,11 +37,11 @@
  * auth info.
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *c = NULL;
   CURLM *m = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   int running;
 
   start_test_timing();

--- a/tests/libtest/lib504.c
+++ b/tests/libtest/lib504.c
@@ -36,10 +36,10 @@
  * Use multi interface to get document over proxy with bad port number.
  * This caused the interface to "hang" in libcurl 7.10.2.
  */
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *c = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURLM *m = NULL;
   fd_set rd, wr, exc;
   int running;

--- a/tests/libtest/lib505.c
+++ b/tests/libtest/lib505.c
@@ -36,7 +36,7 @@
  * Example based on source code provided by Erick Nuwendam. Thanks!
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -172,9 +172,9 @@ static char *suburl(const char *base, int i)
 
 
 /* test function */
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
   CURLSHcode scode = CURLSHE_OK;
   CURLcode code = CURLE_OK;
   char *url = NULL;
@@ -261,7 +261,7 @@ int test(char *URL)
   curl_easy_cleanup(curl);
 
 
-  res = 0;
+  res = CURLE_OK;
 
   /* start treads */
   for(i = 1; i <= THREADS; i++) {

--- a/tests/libtest/lib507.c
+++ b/tests/libtest/lib507.c
@@ -29,13 +29,13 @@
 
 #define TEST_HANG_TIMEOUT 60 * 1000
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curls = NULL;
   CURLM *multi = NULL;
   int still_running;
-  int i = -1;
-  int res = 0;
+  CURLcode i = (CURLcode)-1;
+  CURLcode res = CURLE_OK;
   CURLMsg *msg;
 
   start_test_timing();

--- a/tests/libtest/lib508.c
+++ b/tests/libtest/lib508.c
@@ -49,7 +49,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return 0;                         /* no more data left to deliver */
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib509.c
+++ b/tests/libtest/lib509.c
@@ -69,7 +69,7 @@ static void custom_free(void *ptr)
 }
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   unsigned char a[] = {0x2f, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
                        0x91, 0xa2, 0xb3, 0xc4, 0xd5, 0xe6, 0xf7};
@@ -113,5 +113,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib510.c
+++ b/tests/libtest/lib510.c
@@ -61,7 +61,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return 0;                         /* no more data left to deliver */
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib511.c
+++ b/tests/libtest/lib511.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -54,5 +54,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib512.c
+++ b/tests/libtest/lib512.c
@@ -28,7 +28,7 @@
 /* Test case code based on source in a bug report filed by James Bursa on
    28 Apr 2004 */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode code;
   int rc = 99;
@@ -72,5 +72,5 @@ int test(char *URL)
   else
     rc = 5;
 
-  return rc;
+  return (CURLcode)rc;
 }

--- a/tests/libtest/lib513.c
+++ b/tests/libtest/lib513.c
@@ -34,7 +34,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return CURL_READFUNC_ABORT;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -81,5 +81,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib514.c
+++ b/tests/libtest/lib514.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -77,5 +77,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib515.c
+++ b/tests/libtest/lib515.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -58,5 +58,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib516.c
+++ b/tests/libtest/lib516.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -59,5 +59,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib517.c
+++ b/tests/libtest/lib517.c
@@ -153,7 +153,7 @@ static const struct dcheck dates[] = {
   { NULL, 0 }
 };
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   int i;
   int error = 0;
@@ -169,5 +169,5 @@ int test(char *URL)
     }
   }
 
-  return error;
+  return error == 0 ? CURLE_OK : TEST_ERR_FAILURE;
 }

--- a/tests/libtest/lib518.c
+++ b/tests/libtest/lib518.c
@@ -445,7 +445,7 @@ static int rlimit(int keep_open)
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -454,9 +454,9 @@ int test(char *URL)
     /* used by the test script to ask if we can run this test or not */
     if(rlimit(FALSE)) {
       fprintf(stdout, "rlimit problem: %s\n", msgbuff);
-      return 1;
+      return (CURLcode)1;
     }
-    return 0; /* sure, run this! */
+    return CURLE_OK; /* sure, run this! */
   }
 
   if(rlimit(TRUE)) {
@@ -492,12 +492,12 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }
 
 #else /* defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT) */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   (void)URL;
   printf("system lacks necessary system function(s)");

--- a/tests/libtest/lib519.c
+++ b/tests/libtest/lib519.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -62,5 +62,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib520.c
+++ b/tests/libtest/lib520.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -53,5 +53,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib521.c
+++ b/tests/libtest/lib521.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -54,5 +54,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib523.c
+++ b/tests/libtest/lib523.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -55,5 +55,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib524.c
+++ b/tests/libtest/lib524.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -53,5 +53,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib525.c
+++ b/tests/libtest/lib525.c
@@ -31,9 +31,9 @@
 
 #define TEST_HANG_TIMEOUT 60 * 1000
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl = NULL;
   FILE *hd_src = NULL;
   int hd;

--- a/tests/libtest/lib526.c
+++ b/tests/libtest/lib526.c
@@ -52,9 +52,9 @@
 
 #define NUM_HANDLES 4
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl[NUM_HANDLES];
   int running;
   CURLM *m = NULL;
@@ -163,7 +163,7 @@ test_cleanup:
      cleanup'ed yet, in this case we have to cleanup them or otherwise these
      will be leaked, let's use undocumented cleanup sequence - type UB */
 
-  if(res)
+  if(res != CURLE_OK)
     for(i = 0; i < NUM_HANDLES; i++)
       curl_easy_cleanup(curl[i]);
 

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -191,7 +191,7 @@ static int checkForCompletion(CURLM *curl, int *success)
     }
     else {
       fprintf(stderr, "Got an unexpected message from curl: %i\n",
-              (int)message->msg);
+              message->msg);
       result = 1;
       *success = 0;
     }
@@ -228,7 +228,7 @@ static void updateFdSet(struct Sockets *sockets, fd_set* fdset,
 }
 
 static int socket_action(CURLM *curl, curl_socket_t s, int evBitmask,
-                               const char *info)
+                         const char *info)
 {
   int numhandles = 0;
   CURLMcode result = curl_multi_socket_action(curl, s, evBitmask, &numhandles);
@@ -258,9 +258,9 @@ static int checkFdSet(CURLM *curl,
   return result;
 }
 
-static int testone(char *URL, int timercb, int socketcb)
+static CURLcode testone(char *URL, int timercb, int socketcb)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl = NULL;  CURLM *m = NULL;
   struct ReadWriteSockets sockets = {{NULL, 0, 0}, {NULL, 0, 0}};
   struct timeval timeout = {-1, 0};
@@ -276,7 +276,7 @@ static int testone(char *URL, int timercb, int socketcb)
   start_test_timing();
 
   res_global_init(CURL_GLOBAL_ALL);
-  if(res)
+  if(res != CURLE_OK)
     return res;
 
   easy_init(curl);
@@ -297,9 +297,10 @@ static int testone(char *URL, int timercb, int socketcb)
 
   multi_add_handle(m, curl);
 
-  res = socket_action(m, CURL_SOCKET_TIMEOUT, 0, "timeout");
-  if(res)
+  if(socket_action(m, CURL_SOCKET_TIMEOUT, 0, "timeout")) {
+    res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
+  }
 
   while(!checkForCompletion(m, &success)) {
     fd_set readSet, writeSet;
@@ -325,18 +326,21 @@ static int testone(char *URL, int timercb, int socketcb)
     select_test((int)maxFd, &readSet, &writeSet, NULL, &tv);
 
     /* Check the sockets for reading / writing */
-    res = checkFdSet(m, &sockets.read, &readSet, CURL_CSELECT_IN, "read");
-    if(res)
+    if(checkFdSet(m, &sockets.read, &readSet, CURL_CSELECT_IN, "read")) {
+      res = TEST_ERR_MAJOR_BAD;
       goto test_cleanup;
-    res = checkFdSet(m, &sockets.write, &writeSet, CURL_CSELECT_OUT, "write");
-    if(res)
+    }
+    if(checkFdSet(m, &sockets.write, &writeSet, CURL_CSELECT_OUT, "write")) {
+      res = TEST_ERR_MAJOR_BAD;
       goto test_cleanup;
+    }
 
     if(timeout.tv_sec != -1 && getMicroSecondTimeout(&timeout) == 0) {
       /* Curl's timer has elapsed. */
-      res = socket_action(m, CURL_SOCKET_TIMEOUT, 0, "timeout");
-      if(res)
+      if(socket_action(m, CURL_SOCKET_TIMEOUT, 0, "timeout")) {
+        res = TEST_ERR_BAD_TIMEOUT;
         goto test_cleanup;
+      }
     }
 
     abort_on_test_timeout();
@@ -362,9 +366,9 @@ test_cleanup:
   return res;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int rc;
+  CURLcode rc;
   /* rerun the same transfer multiple times and make it fail in different
      callback calls */
   rc = testone(URL, 0, 0);
@@ -387,5 +391,5 @@ int test(char *URL)
   if(!rc)
     fprintf(stderr, "test 0/2 failed: %d\n", rc);
 
-  return 0;
+  return CURLE_OK;
 }

--- a/tests/libtest/lib533.c
+++ b/tests/libtest/lib533.c
@@ -33,9 +33,9 @@
 
 #define TEST_HANG_TIMEOUT 60 * 1000
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl = NULL;
   int running;
   CURLM *m = NULL;

--- a/tests/libtest/lib536.c
+++ b/tests/libtest/lib536.c
@@ -37,7 +37,7 @@ static void proxystat(CURL *curl)
   }
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURL *curl;
@@ -80,5 +80,5 @@ test_cleanup:
   curl_slist_free_all(host);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib537.c
+++ b/tests/libtest/lib537.c
@@ -449,7 +449,7 @@ static int rlimit(int keep_open)
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -458,9 +458,9 @@ int test(char *URL)
     /* used by the test script to ask if we can run this test or not */
     if(rlimit(FALSE)) {
       fprintf(stdout, "rlimit problem: %s\n", msgbuff);
-      return 1;
+      return (CURLcode)1;
     }
-    return 0; /* sure, run this! */
+    return CURLE_OK; /* sure, run this! */
   }
 
   if(rlimit(TRUE)) {
@@ -496,16 +496,16 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }
 
 #else /* defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT) */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   (void)URL;
   printf("system lacks necessary system function(s)");
-  return 1; /* skip test */
+  return (CURLcode)1; /* skip test */
 }
 
 #endif /* defined(HAVE_GETRLIMIT) && defined(HAVE_SETRLIMIT) */

--- a/tests/libtest/lib539.c
+++ b/tests/libtest/lib539.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
    CURLcode res;
    CURL *curl;
@@ -89,5 +89,5 @@ test_cleanup:
    curl_easy_cleanup(curl);
    curl_global_cleanup();
 
-   return (int)res;
+   return res;
 }

--- a/tests/libtest/lib540.c
+++ b/tests/libtest/lib540.c
@@ -48,10 +48,10 @@
 
 static CURL *eh[NUM_HANDLES];
 
-static int init(int num, CURLM *cm, const char *url, const char *userpwd,
-                struct curl_slist *headers)
+static CURLcode init(int num, CURLM *cm, const char *url, const char *userpwd,
+                     struct curl_slist *headers)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   res_easy_init(eh[num]);
   if(res)
@@ -89,7 +89,7 @@ static int init(int num, CURLM *cm, const char *url, const char *userpwd,
   if(res)
     goto init_failed;
 
-  return 0; /* success */
+  return CURLE_OK; /* success */
 
 init_failed:
 
@@ -99,15 +99,15 @@ init_failed:
   return res; /* failure */
 }
 
-static int loop(int num, CURLM *cm, const char *url, const char *userpwd,
-                struct curl_slist *headers)
+static CURLcode loop(int num, CURLM *cm, const char *url, const char *userpwd,
+                     struct curl_slist *headers)
 {
   CURLMsg *msg;
   long L;
   int Q, U = -1;
   fd_set R, W, E;
   struct timeval T;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   res = init(num, cm, url, userpwd, headers);
   if(res)
@@ -189,15 +189,15 @@ static int loop(int num, CURLM *cm, const char *url, const char *userpwd,
       return res;
   }
 
-  return 0; /* success */
+  return CURLE_OK;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLM *cm = NULL;
   struct curl_slist *headers = NULL;
   char buffer[246]; /* naively fixed-size */
-  int res = 0;
+  CURLcode res = CURLE_OK;
   int i;
 
   for(i = 0; i < NUM_HANDLES; i++)
@@ -206,7 +206,7 @@ int test(char *URL)
   start_test_timing();
 
   if(test_argc < 4)
-    return 99;
+    return (CURLcode)99;
 
   msnprintf(buffer, sizeof(buffer), "Host: %s", HOST);
 

--- a/tests/libtest/lib541.c
+++ b/tests/libtest/lib541.c
@@ -33,7 +33,7 @@
  * Two FTP uploads, the second with no content sent.
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -51,7 +51,7 @@ int test(char *URL)
     fprintf(stderr, "fopen failed with error: %d %s\n",
             errno, strerror(errno));
     fprintf(stderr, "Error opening file: %s\n", libtest_arg2);
-    return -2; /* if this happens things are major weird */
+    return (CURLcode)-2; /* if this happens things are major weird */
   }
 
   /* get the file size of the local file */

--- a/tests/libtest/lib542.c
+++ b/tests/libtest/lib542.c
@@ -33,7 +33,7 @@
  * FTP get with NOBODY but no HEADER
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib543.c
+++ b/tests/libtest/lib543.c
@@ -27,7 +27,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   static const unsigned char a[] = {
       0x9c, 0x26, 0x4b, 0x3d, 0x49, 0x4, 0xa1, 0x1,
@@ -68,5 +68,5 @@ int test(char *URL)
   }
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib544.c
+++ b/tests/libtest/lib544.c
@@ -31,7 +31,7 @@ static char teststring[] =
     'w', 'i', 't', 'h', ' ', 'a', 'n', ' ',
     'e', 'm', 'b', 'e', 'd', 'd', 'e', 'd', ' ', 'N', 'U', 'L'};
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -80,5 +80,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -72,7 +72,7 @@ static curlioerr ioctlcallback(CURL *handle,
 
 #endif
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -123,5 +123,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib549.c
+++ b/tests/libtest/lib549.c
@@ -30,7 +30,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -63,5 +63,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -166,7 +166,7 @@ static curlioerr ioctl_callback(CURL *handle, int cmd, void *clientp)
 
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -217,5 +217,5 @@ test_cleanup:
 
   curl_easy_cleanup(curl);
   curl_global_cleanup();
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib553.c
+++ b/tests/libtest/lib553.c
@@ -57,7 +57,7 @@ static size_t myreadfunc(char *ptr, size_t size, size_t nmemb, void *stream)
 
 static char buf[SIZE_HEADERS + 100];
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_FAILED_INIT;
@@ -109,5 +109,5 @@ test_cleanup:
 
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib554.c
+++ b/tests/libtest/lib554.c
@@ -60,7 +60,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 #endif
 }
 
-static int once(char *URL, bool oldstyle)
+static CURLcode once(char *URL, bool oldstyle)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -189,9 +189,9 @@ test_cleanup:
   return res;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     fprintf(stderr, "curl_global_init() failed\n");

--- a/tests/libtest/lib555.c
+++ b/tests/libtest/lib555.c
@@ -76,9 +76,9 @@ static curlioerr ioctlcallback(CURL *handle,
 }
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl = NULL;
   int counter = 0;
   CURLM *m = NULL;

--- a/tests/libtest/lib556.c
+++ b/tests/libtest/lib556.c
@@ -37,7 +37,7 @@
   #define STDERR_FILENO 2
 #endif
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -87,7 +87,7 @@ int test(char *URL)
     }
 
     if(iolen)
-      res = (CURLcode)TEST_ERR_FAILURE;
+      res = TEST_ERR_FAILURE;
   }
 
 test_cleanup:
@@ -95,5 +95,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1464,7 +1464,8 @@ static int test_return_codes(void)
 
   return 0;
 }
-int test(char *URL)
+
+CURLcode test(char *URL)
 {
   int errors = 0;
   (void)URL; /* not used */
@@ -1504,5 +1505,5 @@ int test(char *URL)
   if(errors)
     return TEST_ERR_MAJOR_BAD;
   else
-    return 0;
+    return CURLE_OK;
 }

--- a/tests/libtest/lib558.c
+++ b/tests/libtest/lib558.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   unsigned char a[] = {0x2f, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f,
                        0x91, 0xa2, 0xb3, 0xc4, 0xd5, 0xe6, 0xf7};
@@ -50,5 +50,5 @@ int test(char *URL)
 
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib559.c
+++ b/tests/libtest/lib559.c
@@ -26,7 +26,7 @@
 #include "testtrace.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -53,5 +53,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib560.c
+++ b/tests/libtest/lib560.c
@@ -39,11 +39,11 @@
  * fast/different compared to the real/distant servers we saw the bug happen
  * with.
  */
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *http_handle = NULL;
   CURLM *multi_handle = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   int still_running; /* keep number of running handles */
 

--- a/tests/libtest/lib562.c
+++ b/tests/libtest/lib562.c
@@ -37,7 +37,7 @@
 
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib564.c
+++ b/tests/libtest/lib564.c
@@ -31,9 +31,9 @@
 
 #define TEST_HANG_TIMEOUT 60 * 1000
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl = NULL;
   int running;
   CURLM *m = NULL;

--- a/tests/libtest/lib566.c
+++ b/tests/libtest/lib566.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -67,5 +67,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib567.c
+++ b/tests/libtest/lib567.c
@@ -28,7 +28,7 @@
 /*
  * Test a simple OPTIONS request with a custom header
  */
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -68,5 +68,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib568.c
+++ b/tests/libtest/lib568.c
@@ -41,9 +41,9 @@ static char *suburl(const char *base, int i)
 /*
  * Test the Client->Server ANNOUNCE functionality (PUT style)
  */
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
   CURL *curl;
   int sdp;
   FILE *sdpf = NULL;

--- a/tests/libtest/lib569.c
+++ b/tests/libtest/lib569.c
@@ -33,9 +33,9 @@ static char *suburl(const char *base, int i)
 /*
  * Test Session ID capture
  */
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
   CURL *curl;
   char *stream_uri = NULL;
   char *rtsp_session_id;

--- a/tests/libtest/lib570.c
+++ b/tests/libtest/lib570.c
@@ -30,9 +30,9 @@ static char *suburl(const char *base, int i)
   return curl_maprintf("%s%.4d", base, i);
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
   CURL *curl;
   int request = 1;
   char *stream_uri = NULL;
@@ -104,11 +104,11 @@ int test(char *URL)
 
   res = curl_easy_perform(curl);
   if(res == CURLE_RTSP_SESSION_ERROR) {
-    res = 0;
+    res = CURLE_OK;
   }
   else {
     fprintf(stderr, "Failed to detect a Session ID mismatch");
-    res = 1;
+    res = (CURLcode)1;
   }
 
 test_cleanup:

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -100,9 +100,9 @@ static char *suburl(const char *base, int i)
   return curl_maprintf("%s%.4d", base, i);
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
   CURL *curl;
   char *stream_uri = NULL;
   int request = 1;

--- a/tests/libtest/lib572.c
+++ b/tests/libtest/lib572.c
@@ -41,9 +41,9 @@ static char *suburl(const char *base, int i)
 /*
  * Test GET_PARAMETER: PUT, HEARTBEAT, and POST
  */
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
   CURL *curl;
   int params;
   FILE *paramsf = NULL;

--- a/tests/libtest/lib573.c
+++ b/tests/libtest/lib573.c
@@ -34,11 +34,11 @@
  * Get a single URL without select().
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *c = NULL;
   CURLM *m = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   int running = 1;
   double connect_time = 0.0;
   double dbl_epsilon;

--- a/tests/libtest/lib574.c
+++ b/tests/libtest/lib574.c
@@ -36,9 +36,9 @@ static int new_fnmatch(void *ptr,
   return CURL_FNMATCHFUNC_MATCH;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
   CURL *curl;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {

--- a/tests/libtest/lib575.c
+++ b/tests/libtest/lib575.c
@@ -37,12 +37,12 @@
  * 3. with multi interface
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *handle = NULL;
   CURL *duphandle = NULL;
   CURLM *mhandle = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   int still_running = 0;
 
   start_test_timing();

--- a/tests/libtest/lib576.c
+++ b/tests/libtest/lib576.c
@@ -94,7 +94,7 @@ long chunk_end(void *ptr)
   return CURL_CHUNK_END_FUNC_OK;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *handle = NULL;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib578.c
+++ b/tests/libtest/lib578.c
@@ -50,7 +50,7 @@ static int progress_callback(void *clientp, double dltotal, double dlnow,
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib579.c
+++ b/tests/libtest/lib579.c
@@ -85,7 +85,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return 0;                         /* no more data left to deliver */
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -220,9 +220,9 @@ static void checkFdSet(CURLM *curl, struct Sockets *sockets, fd_set *fdset,
   }
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   CURL *curl = NULL;
   FILE *hd_src = NULL;
   int hd;

--- a/tests/libtest/lib583.c
+++ b/tests/libtest/lib583.c
@@ -32,7 +32,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   int stillRunning;
   CURLM *multiHandle = NULL;
@@ -87,5 +87,5 @@ test_cleanup:
   curl_multi_cleanup(multiHandle);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib586.c
+++ b/tests/libtest/lib586.c
@@ -129,7 +129,7 @@ static void *fire(void *ptr)
 }
 
 /* test function */
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res = CURLE_OK;
   CURLSHcode scode = CURLSHE_OK;

--- a/tests/libtest/lib589.c
+++ b/tests/libtest/lib589.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -72,5 +72,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib590.c
+++ b/tests/libtest/lib590.c
@@ -38,7 +38,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -69,5 +69,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib591.c
+++ b/tests/libtest/lib591.c
@@ -35,11 +35,11 @@
 
 #define TEST_HANG_TIMEOUT 60 * 1000
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy = NULL;
   CURLM *multi = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   int running;
   int msgs_left;
   CURLMsg *msg;

--- a/tests/libtest/lib597.c
+++ b/tests/libtest/lib597.c
@@ -40,11 +40,11 @@
  * with function curl_multi_info_read().
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy = NULL;
   CURLM *multi = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   int running;
   int msgs_left;
   CURLMsg *msg;

--- a/tests/libtest/lib598.c
+++ b/tests/libtest/lib598.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -70,5 +70,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib599.c
+++ b/tests/libtest/lib599.c
@@ -41,7 +41,7 @@ static int progress_callback(void *clientp, double dltotal,
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib643.c
+++ b/tests/libtest/lib643.c
@@ -56,7 +56,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return 0;                         /* no more data left to deliver */
 }
 
-static int once(char *URL, bool oldstyle)
+static CURLcode once(char *URL, bool oldstyle)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -223,7 +223,7 @@ test_cleanup:
   return res;
 }
 
-static int cyclic_add(void)
+static CURLcode cyclic_add(void)
 {
   CURL *easy = curl_easy_init();
   curl_mime *mime = curl_mime_init(easy);
@@ -242,14 +242,14 @@ static int cyclic_add(void)
   curl_easy_cleanup(easy);
   if(a1 != CURLE_BAD_FUNCTION_ARGUMENT)
     /* that should have failed */
-    return 1;
+    return (CURLcode)1;
 
-  return 0;
+  return CURLE_OK;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res;
+  CURLcode res;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     fprintf(stderr, "curl_global_init() failed\n");

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -47,7 +47,7 @@ static size_t count_chars(void *userp, const char *buf, size_t len)
 }
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib651.c
+++ b/tests/libtest/lib651.c
@@ -28,7 +28,7 @@
 
 static char buffer[17000]; /* more than 16K */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib652.c
+++ b/tests/libtest/lib652.c
@@ -27,7 +27,7 @@
 
 static char buffer[17000]; /* more than 16K */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_OK;
@@ -50,7 +50,7 @@ int test(char *URL)
   curl = curl_easy_init();
   if(!curl) {
     fprintf(stderr, "curl_easy_init() failed\n");
-    res = (CURLcode) TEST_ERR_MAJOR_BAD;
+    res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
 
@@ -58,13 +58,13 @@ int test(char *URL)
   mime = curl_mime_init(curl);
   if(!mime) {
     fprintf(stderr, "curl_mime_init() failed\n");
-    res = (CURLcode) TEST_ERR_MAJOR_BAD;
+    res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
   part = curl_mime_addpart(mime);
   if(!part) {
     fprintf(stderr, "curl_mime_addpart() failed\n");
-    res = (CURLcode) TEST_ERR_MAJOR_BAD;
+    res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
   res = curl_mime_filename(part, "myfile.jpg");

--- a/tests/libtest/lib653.c
+++ b/tests/libtest/lib653.c
@@ -28,10 +28,10 @@
 #include "memdebug.h"
 
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curls = NULL;
-  int res = 0;
+  CURLcode res = CURLE_OK;
   curl_mimepart *field = NULL;
   curl_mime *mime = NULL;
 
@@ -61,5 +61,5 @@ test_cleanup:
   curl_mime_free(mime);
   curl_easy_cleanup(curls);
   curl_global_cleanup();
-  return (int) res; /* return the final return code */
+  return res; /* return the final return code */
 }

--- a/tests/libtest/lib654.c
+++ b/tests/libtest/lib654.c
@@ -62,15 +62,14 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return 0;                         /* no more data left to deliver */
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy = NULL;
   CURL *easy2 = NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part;
   struct curl_slist *hdrs = NULL;
-  CURLcode result;
-  int res = TEST_ERR_FAILURE;
+  CURLcode res = TEST_ERR_FAILURE;
   struct WriteThis pooh;
 
   /*
@@ -131,19 +130,17 @@ int test(char *URL)
   mime = NULL;  /* Already cleaned up. */
 
   /* Perform on the first handle: should not send any data. */
-  result = curl_easy_perform(easy);
-  if(result) {
+  res = curl_easy_perform(easy);
+  if(res != CURLE_OK) {
     fprintf(stderr, "curl_easy_perform(original) failed\n");
-    res = (int) result;
     goto test_cleanup;
   }
 
   /* Perform on the second handle: if the bound mime structure has not been
      duplicated properly, it should cause a valgrind error. */
-  result = curl_easy_perform(easy2);
-  if(result) {
+  res = curl_easy_perform(easy2);
+  if(res != CURLE_OK) {
     fprintf(stderr, "curl_easy_perform(duplicated) failed\n");
-    res = (int) result;
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib655.c
+++ b/tests/libtest/lib655.c
@@ -58,7 +58,7 @@ resolver_alloc_cb_pass(void *resolver_state, void *reserved, void *userdata)
   return 0;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
@@ -110,5 +110,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib658.c
+++ b/tests/libtest/lib658.c
@@ -31,7 +31,7 @@
  * Get a single URL without select().
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *handle = NULL;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib659.c
+++ b/tests/libtest/lib659.c
@@ -31,7 +31,7 @@
  * Get a single URL without select().
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *handle = NULL;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib661.c
+++ b/tests/libtest/lib661.c
@@ -24,7 +24,7 @@
 #include "test.h"
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
    CURLcode res;
    CURL *curl = NULL;
@@ -164,5 +164,5 @@ test_cleanup:
    curl_easy_cleanup(curl);
    curl_global_cleanup();
 
-   return (int)res;
+   return res;
 }

--- a/tests/libtest/lib666.c
+++ b/tests/libtest/lib666.c
@@ -27,7 +27,7 @@
 
 static char buffer[17000]; /* more than 16K */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURLcode res = CURLE_OK;
@@ -52,7 +52,7 @@ int test(char *URL)
   curl = curl_easy_init();
   if(!curl) {
     fprintf(stderr, "curl_easy_init() failed\n");
-    res = (CURLcode) TEST_ERR_MAJOR_BAD;
+    res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
 
@@ -60,13 +60,13 @@ int test(char *URL)
   mime = curl_mime_init(curl);
   if(!mime) {
     fprintf(stderr, "curl_mime_init() failed\n");
-    res = (CURLcode) TEST_ERR_MAJOR_BAD;
+    res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
   part = curl_mime_addpart(mime);
   if(!part) {
     fprintf(stderr, "curl_mime_addpart() failed\n");
-    res = (CURLcode) TEST_ERR_MAJOR_BAD;
+    res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }
   res = curl_mime_name(part, "upfile");

--- a/tests/libtest/lib667.c
+++ b/tests/libtest/lib667.c
@@ -54,13 +54,12 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return 0;                         /* no more data left to deliver */
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy = NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part;
-  CURLcode result;
-  int res = TEST_ERR_FAILURE;
+  CURLcode res = TEST_ERR_FAILURE;
   struct WriteThis pooh;
 
   /*
@@ -100,10 +99,9 @@ int test(char *URL)
   test_setopt(easy, CURLOPT_MIMEPOST, mime);
 
   /* Send data. */
-  result = curl_easy_perform(easy);
-  if(result) {
+  res = curl_easy_perform(easy);
+  if(res != CURLE_OK) {
     fprintf(stderr, "curl_easy_perform() failed\n");
-    res = (int) result;
   }
 
 test_cleanup:

--- a/tests/libtest/lib668.c
+++ b/tests/libtest/lib668.c
@@ -48,13 +48,12 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
   return len;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *easy = NULL;
   curl_mime *mime = NULL;
   curl_mimepart *part;
-  CURLcode result;
-  int res = TEST_ERR_FAILURE;
+  CURLcode res = TEST_ERR_FAILURE;
   struct WriteThis pooh1, pooh2;
 
   /*
@@ -104,10 +103,9 @@ int test(char *URL)
   test_setopt(easy, CURLOPT_MIMEPOST, mime);
 
   /* Send data. */
-  result = curl_easy_perform(easy);
-  if(result) {
+  res = curl_easy_perform(easy);
+  if(res != CURLE_OK) {
     fprintf(stderr, "curl_easy_perform() failed\n");
-    res = (int) result;
   }
 
 test_cleanup:

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -97,7 +97,7 @@ static int xferinfo(void *clientp, curl_off_t dltotal, curl_off_t dlnow,
 }
 #endif
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
 #if defined(LIB670) || defined(LIB671)
   curl_mime *mime = NULL;
@@ -116,8 +116,7 @@ int test(char *URL)
 #endif
 
   struct ReadThis pooh;
-  CURLcode result;
-  int res = TEST_ERR_FAILURE;
+  CURLcode res = TEST_ERR_FAILURE;
 
   /*
    * Check proper pausing/unpausing from a mime or form read callback.
@@ -145,11 +144,11 @@ int test(char *URL)
   /* Build the mime tree. */
   mime = curl_mime_init(pooh.easy);
   part = curl_mime_addpart(mime);
-  result = curl_mime_name(part, name);
-  if(result) {
+  res = curl_mime_name(part, name);
+  if(res != CURLE_OK) {
     fprintf(stderr,
             "Something went wrong when building the mime structure: %d\n",
-            (int) result);
+            res);
     goto test_cleanup;
   }
 
@@ -157,7 +156,7 @@ int test(char *URL)
                           NULL, NULL, &pooh);
 
   /* Bind mime data to its easy handle. */
-  if(!res)
+  if(res == CURLE_OK)
     test_setopt(pooh.easy, CURLOPT_MIMEPOST, mime);
 #else
   /* Build the form. */
@@ -233,8 +232,7 @@ int test(char *URL)
       if(!msg)
         break;
       if(msg->msg == CURLMSG_DONE) {
-        result = msg->data.result;
-        res = (int) result;
+        res = msg->data.result;
       }
     }
 
@@ -246,8 +244,7 @@ int test(char *URL)
   test_setopt(pooh.easy, CURLOPT_XFERINFODATA, &pooh);
   test_setopt(pooh.easy, CURLOPT_XFERINFOFUNCTION, xferinfo);
   test_setopt(pooh.easy, CURLOPT_NOPROGRESS, 0L);
-  result = curl_easy_perform(pooh.easy);
-  res = (int) result;
+  res = curl_easy_perform(pooh.easy);
 #endif
 
 

--- a/tests/libtest/lib674.c
+++ b/tests/libtest/lib674.c
@@ -31,7 +31,7 @@
  * Get a single URL without select().
  */
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *handle = NULL;
   CURL *handle2;

--- a/tests/libtest/lib676.c
+++ b/tests/libtest/lib676.c
@@ -25,7 +25,7 @@
 
 #include "memdebug.h"
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLcode res;
   CURL *curl;
@@ -66,5 +66,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/lib677.c
+++ b/tests/libtest/lib677.c
@@ -30,7 +30,7 @@
 static const char cmd[] = "A1 IDLE\r\n";
 static char buf[1024];
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURLM *mcurl;
   CURL *curl = NULL;
@@ -39,7 +39,7 @@ int test(char *URL)
   time_t start = time(NULL);
   int state = 0;
   ssize_t pos = 0;
-  int res = 0;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_DEFAULT);
   multi_init(mcurl);

--- a/tests/libtest/lib678.c
+++ b/tests/libtest/lib678.c
@@ -63,7 +63,7 @@ static int loadfile(const char *filename, void **filedata, size_t *filesize)
   return data ? 1 : 0;
 }
 
-static int test_cert_blob(const char *url, const char *cafile)
+static CURLcode test_cert_blob(const char *url, const char *cafile)
 {
   CURLcode code = CURLE_OUT_OF_MEMORY;
   CURL *curl;
@@ -94,12 +94,12 @@ static int test_cert_blob(const char *url, const char *cafile)
   }
   curl_easy_cleanup(curl);
 
-  return (int)code;
+  return code;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
-  int res = 0;
+  CURLcode res = CURLE_OK;
   curl_global_init(CURL_GLOBAL_DEFAULT);
   if(!strcmp("check", URL)) {
     CURL *e;
@@ -112,7 +112,7 @@ int test(char *URL)
         printf("CURLOPT_CAINFO_BLOB is not supported\n");
       curl_easy_cleanup(e);
     }
-    res = (int)w;
+    res = w;
   }
   else
     res = test_cert_blob(URL, libtest_arg2);

--- a/tests/libtest/libauthretry.c
+++ b/tests/libtest/libauthretry.c
@@ -60,13 +60,13 @@ test_cleanup:
 static CURLcode send_wrong_password(CURL *curl, const char *url, int seq,
                                     long auth_scheme)
 {
-    return send_request(curl, url, seq, auth_scheme, "testuser:wrongpass");
+  return send_request(curl, url, seq, auth_scheme, "testuser:wrongpass");
 }
 
 static CURLcode send_right_password(CURL *curl, const char *url, int seq,
                                     long auth_scheme)
 {
-    return send_request(curl, url, seq, auth_scheme, "testuser:testpass");
+  return send_request(curl, url, seq, auth_scheme, "testuser:testpass");
 }
 
 static long parse_auth_name(const char *arg)
@@ -82,7 +82,7 @@ static long parse_auth_name(const char *arg)
   return CURLAUTH_NONE;
 }
 
-int test(char *url)
+CURLcode test(char *url)
 {
   CURLcode res;
   CURL *curl = NULL;
@@ -145,5 +145,5 @@ test_cleanup:
   curl_easy_cleanup(curl);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }

--- a/tests/libtest/libntlmconnect.c
+++ b/tests/libtest/libntlmconnect.c
@@ -36,7 +36,7 @@
 static int counter[MAX_EASY_HANDLES];
 static CURL *easy[MAX_EASY_HANDLES];
 static curl_socket_t sockets[MAX_EASY_HANDLES];
-static int res = 0;
+static CURLcode res = CURLE_OK;
 
 static size_t callback(char *ptr, size_t size, size_t nmemb, void *data)
 {
@@ -89,7 +89,7 @@ enum HandleState {
   NoMoreHandles
 };
 
-int test(char *url)
+CURLcode test(char *url)
 {
   CURLM *multi = NULL;
   int running;

--- a/tests/libtest/libprereq.c
+++ b/tests/libtest/libprereq.c
@@ -51,7 +51,7 @@ static int prereq_callback(void *clientp,
   return prereq_cb->prereq_retcode;
 }
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   PRCS prereq_cb;
   CURLcode ret = CURLE_OK;

--- a/tests/libtest/mk-lib1521.pl
+++ b/tests/libtest/mk-lib1521.pl
@@ -146,7 +146,7 @@ static curl_hstswrite_callback hstswritecb;
 static curl_resolver_start_callback resolver_start_cb;
 static curl_prereq_callback prereqcb;
 
-int test(char *URL)
+CURLcode test(char *URL)
 {
   CURL *curl = NULL;
   CURL *dep = NULL;
@@ -363,7 +363,7 @@ test_cleanup:
   curl_share_cleanup(share);
   curl_global_cleanup();
 
-  return (int)res;
+  return res;
 }
 FOOTER
     ;

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -68,8 +68,8 @@ extern int select_wrapper(int nfds, fd_set *rd, fd_set *wr, fd_set *exc,
 
 extern void wait_ms(int ms); /* wait this many milliseconds */
 
-extern int test(char *URL); /* the actual test function provided by each
-                               individual libXXX.c file */
+extern CURLcode test(char *URL); /* the actual test function provided by each
+                                    individual libXXX.c file */
 
 extern char *hexdump(const unsigned char *buffer, size_t len);
 
@@ -490,11 +490,11 @@ extern int unitfail;
   chk_global_init((A), (__FILE__), (__LINE__))
 
 #define NO_SUPPORT_BUILT_IN                     \
-  int test(char *URL)                           \
+  CURLcode test(char *URL)                      \
   {                                             \
     (void)URL;                                  \
     fprintf(stderr, "Missing support\n");       \
-    return 1;                                   \
+    return (CURLcode)1;                         \
   }
 
 /* ---------------------------------------------------------------- */

--- a/tests/unit/curlcheck.h
+++ b/tests/unit/curlcheck.h
@@ -94,7 +94,7 @@
 
 
 #define UNITTEST_START                          \
-  int test(char *arg)                           \
+  CURLcode test(char *arg)                      \
   {                                             \
     (void)arg;                                  \
     if(unit_setup()) {                          \
@@ -107,5 +107,5 @@
 unit_test_abort:                                \
     unit_stop();                                \
   }                                             \
-  return unitfail;                              \
+  return (CURLcode)unitfail;                    \
   }

--- a/tests/unit/unit1303.c
+++ b/tests/unit/unit1303.c
@@ -69,8 +69,8 @@ static void unit_stop(void)
 struct timetest {
   int now_s;
   int now_us;
-  int timeout_ms;
-  int connecttimeout_ms;
+  unsigned int timeout_ms;
+  unsigned int connecttimeout_ms;
   bool connecting;
   timediff_t result;
   const char *comment;

--- a/tests/unit/unit1308.c
+++ b/tests/unit/unit1308.c
@@ -44,7 +44,8 @@ static size_t print_httppost_callback(void *arg, const char *buf, size_t len)
 }
 
 UNITTEST_START
-  int rc;
+  CURLFORMcode rc;
+  int res;
   struct curl_httppost *post = NULL;
   struct curl_httppost *last = NULL;
   size_t total_size = 0;
@@ -70,9 +71,9 @@ UNITTEST_START
 
   fail_unless(rc == 0, "curl_formadd returned error");
 
-  rc = curl_formget(post, &total_size, print_httppost_callback);
+  res = curl_formget(post, &total_size, print_httppost_callback);
 
-  fail_unless(rc == 0, "curl_formget returned error");
+  fail_unless(res == 0, "curl_formget returned error");
 
   fail_unless(total_size == 518, "curl_formget got wrong size back");
 
@@ -89,8 +90,8 @@ UNITTEST_START
 
   fail_unless(rc == 0, "curl_formadd returned error");
 
-  rc = curl_formget(post, &total_size, print_httppost_callback);
-  fail_unless(rc == 0, "curl_formget returned error");
+  res = curl_formget(post, &total_size, print_httppost_callback);
+  fail_unless(res == 0, "curl_formget returned error");
   fail_unless(total_size == 899, "curl_formget got wrong size back");
 
   curl_formfree(post);

--- a/tests/unit/unit1603.c
+++ b/tests/unit/unit1603.c
@@ -31,7 +31,7 @@
 #include "memdebug.h" /* LAST include file */
 
 static struct Curl_hash hash_static;
-static const int slots = 3;
+static const size_t slots = 3;
 
 static void mydtor(void *p)
 {

--- a/tests/unit/unit1620.c
+++ b/tests/unit/unit1620.c
@@ -42,7 +42,7 @@ static void unit_stop(void)
 
 UNITTEST_START
 {
-  int rc;
+  CURLcode rc;
   struct Curl_easy *empty;
   const char *hostname = "hostname";
   enum dupstring i;

--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -57,13 +57,13 @@ struct dohrequest {
   /* output */
   const char *packet;
   size_t size;
-  int rc;
+  DOHcode rc;
 };
 
 
 static const struct dohrequest req[] = {
-  {"test.host.name", DNS_TYPE_A, DNS_Q1, sizeof(DNS_Q1)-1, 0 },
-  {"test.host.name", DNS_TYPE_AAAA, DNS_Q2, sizeof(DNS_Q2)-1, 0 },
+  {"test.host.name", DNS_TYPE_A, DNS_Q1, sizeof(DNS_Q1)-1, DOH_OK },
+  {"test.host.name", DNS_TYPE_AAAA, DNS_Q2, sizeof(DNS_Q2)-1, DOH_OK },
   {"zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
    ".host.name",
    DNS_TYPE_AAAA, NULL, 0, DOH_DNS_BAD_LABEL }
@@ -76,7 +76,7 @@ struct dohresp {
   DNStype type;
 
   /* output */
-  int rc;
+  DOHcode rc;
   const char *out;
 };
 
@@ -161,8 +161,8 @@ UNITTEST_START
   unsigned char *p;
 
   for(i = 0; i < sizeof(req) / sizeof(req[0]); i++) {
-    int rc = doh_encode(req[i].name, req[i].type,
-                        buffer, sizeof(buffer), &size);
+    DOHcode rc = doh_encode(req[i].name, req[i].type,
+                            buffer, sizeof(buffer), &size);
     if(rc != req[i].rc) {
       fprintf(stderr, "req %zu: Expected return code %d got %d\n", i,
               req[i].rc, rc);
@@ -185,7 +185,7 @@ UNITTEST_START
 
   for(i = 0; i < sizeof(resp) / sizeof(resp[0]); i++) {
     struct dohentry d;
-    int rc;
+    DOHcode rc;
     char *ptr;
     size_t len;
     int u;
@@ -243,7 +243,7 @@ UNITTEST_START
   /* pass all sizes into the decoder until full */
   for(i = 0; i < sizeof(full49)-1; i++) {
     struct dohentry d;
-    int rc;
+    DOHcode rc;
     memset(&d, 0, sizeof(d));
     rc = doh_decode((const unsigned char *)full49, i, DNS_TYPE_A, &d);
     if(!rc) {
@@ -256,7 +256,7 @@ UNITTEST_START
   /* and try all pieces from the other end of the packet */
   for(i = 1; i < sizeof(full49); i++) {
     struct dohentry d;
-    int rc;
+    DOHcode rc;
     memset(&d, 0, sizeof(d));
     rc = doh_decode((const unsigned char *)&full49[i], sizeof(full49)-i-1,
                     DNS_TYPE_A, &d);
@@ -268,7 +268,7 @@ UNITTEST_START
   }
 
   {
-    int rc;
+    DOHcode rc;
     struct dohentry d;
     struct dohaddr *a;
     memset(&d, 0, sizeof(d));

--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -41,7 +41,7 @@ unit_stop(void)
 #if defined(CURL_DISABLE_HTTP) || defined(CURL_DISABLE_HSTS)
 UNITTEST_START
 {
-  return 0; /* nothing to do when HTTP or HSTS are disabled */
+  return CURLE_OK; /* nothing to do when HTTP or HSTS are disabled */
 }
 UNITTEST_STOP
 #else

--- a/tests/unit/unit2604.c
+++ b/tests/unit/unit2604.c
@@ -104,7 +104,7 @@ UNITTEST_START
   }
 
   free((void *)list[0].cp);
-  return error;
+  return error == 0 ? CURLE_OK : TEST_ERR_FAILURE;
 }
 #endif
 

--- a/tests/unit/unit3200.c
+++ b/tests/unit/unit3200.c
@@ -88,7 +88,7 @@ UNITTEST_START
   for(i = 0; i < NUMTESTS; i++) {
     FILE *fp;
     struct dynbuf buf;
-    int len = 4096;
+    size_t len = 4096;
     char *line;
     Curl_dyn_init(&buf, len);
 
@@ -169,7 +169,7 @@ UNITTEST_START
     fclose(fp);
     fprintf(stderr, "OK\n");
   }
-  return rc;
+  return (CURLcode)rc;
 UNITTEST_STOP
 
 #ifdef __GNUC__


### PR DESCRIPTION
Before this patch, the result code was a mixture of `int` and
`CURLcode`.

Also adjust casts and fix a couple of minor issues found along the way.

Cherry-picked from #13489
Closes #13600