### PR TITLE
lib: bump hash sizes to `size_t`

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -108,7 +108,7 @@ int Curl_conncache_init(struct conncache *connc, int size)
     return 1; /* bad */
   connc->closure_handle->state.internal = true;
 
-  Curl_hash_init(&connc->hash, size, Curl_hash_str,
+  Curl_hash_init(&connc->hash, (size_t)size, Curl_hash_str,
                  Curl_str_key_compare, free_bundle_hash_entry);
   connc->closure_handle->state.conn_cache = connc;
 

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -100,7 +100,7 @@ static void free_bundle_hash_entry(void *freethis)
   bundle_destroy(b);
 }
 
-int Curl_conncache_init(struct conncache *connc, int size)
+int Curl_conncache_init(struct conncache *connc, size_t size)
 {
   /* allocate a new easy handle to use when closing cached connections */
   connc->closure_handle = curl_easy_init();
@@ -108,7 +108,7 @@ int Curl_conncache_init(struct conncache *connc, int size)
     return 1; /* bad */
   connc->closure_handle->state.internal = true;
 
-  Curl_hash_init(&connc->hash, (size_t)size, Curl_hash_str,
+  Curl_hash_init(&connc->hash, size, Curl_hash_str,
                  Curl_str_key_compare, free_bundle_hash_entry);
   connc->closure_handle->state.conn_cache = connc;
 

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -85,7 +85,7 @@ struct connectbundle {
 };
 
 /* returns 1 on error, 0 is fine */
-int Curl_conncache_init(struct conncache *, int size);
+int Curl_conncache_init(struct conncache *, size_t size);
 void Curl_conncache_destroy(struct conncache *connc);
 
 /* return the correct bundle, to a host or a proxy */

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1094,7 +1094,7 @@ static void freednsentry(void *freethis)
 /*
  * Curl_init_dnscache() inits a new DNS cache.
  */
-void Curl_init_dnscache(struct Curl_hash *hash, int size)
+void Curl_init_dnscache(struct Curl_hash *hash, size_t size)
 {
   Curl_hash_init(hash, size, Curl_hash_str, Curl_str_key_compare,
                  freednsentry);

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -166,7 +166,7 @@ void Curl_resolv_unlock(struct Curl_easy *data,
                         struct Curl_dns_entry *dns);
 
 /* init a new dns cache */
-void Curl_init_dnscache(struct Curl_hash *hash, int hashsize);
+void Curl_init_dnscache(struct Curl_hash *hash, size_t hashsize);
 
 /* prune old entries from the DNS cache */
 void Curl_hostcache_prune(struct Curl_easy *data);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -383,7 +383,7 @@ static void multi_addmsg(struct Curl_multi *multi, struct Curl_message *msg)
 
 struct Curl_multi *Curl_multi_handle(int hashsize, /* socket hash */
                                      int chashsize, /* connection hash */
-                                     int dnssize) /* dns hash */
+                                     size_t dnssize) /* dns hash */
 {
   struct Curl_multi *multi = calloc(1, sizeof(struct Curl_multi));
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -382,7 +382,7 @@ static void multi_addmsg(struct Curl_multi *multi, struct Curl_message *msg)
 }
 
 struct Curl_multi *Curl_multi_handle(size_t hashsize, /* socket hash */
-                                     int chashsize, /* connection hash */
+                                     size_t chashsize, /* connection hash */
                                      size_t dnssize) /* dns hash */
 {
   struct Curl_multi *multi = calloc(1, sizeof(struct Curl_multi));

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -364,7 +364,7 @@ static size_t hash_fd(void *key, size_t key_length, size_t slots_num)
  * per call."
  *
  */
-static void sh_init(struct Curl_hash *hash, int hashsize)
+static void sh_init(struct Curl_hash *hash, size_t hashsize)
 {
   Curl_hash_init(hash, hashsize, hash_fd, fd_key_compare,
                  sh_freeentry);
@@ -381,7 +381,7 @@ static void multi_addmsg(struct Curl_multi *multi, struct Curl_message *msg)
   Curl_llist_append(&multi->msglist, msg, &msg->list);
 }
 
-struct Curl_multi *Curl_multi_handle(int hashsize, /* socket hash */
+struct Curl_multi *Curl_multi_handle(size_t hashsize, /* socket hash */
                                      int chashsize, /* connection hash */
                                      size_t dnssize) /* dns hash */
 {

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -46,7 +46,7 @@ void Curl_multi_connchanged(struct Curl_multi *multi);
 /* Internal version of curl_multi_init() accepts size parameters for the
    socket, connection and dns hashes */
 struct Curl_multi *Curl_multi_handle(int hashsize, int chashsize,
-                                     int dnssize);
+                                     size_t dnssize);
 
 /* the write bits start at bit 16 for the *getsock() bitmap */
 #define GETSOCK_WRITEBITSTART 16

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -45,7 +45,8 @@ void Curl_multi_connchanged(struct Curl_multi *multi);
 
 /* Internal version of curl_multi_init() accepts size parameters for the
    socket, connection and dns hashes */
-struct Curl_multi *Curl_multi_handle(size_t hashsize, int chashsize,
+struct Curl_multi *Curl_multi_handle(size_t hashsize,
+                                     size_t chashsize,
                                      size_t dnssize);
 
 /* the write bits start at bit 16 for the *getsock() bitmap */

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -45,7 +45,7 @@ void Curl_multi_connchanged(struct Curl_multi *multi);
 
 /* Internal version of curl_multi_init() accepts size parameters for the
    socket, connection and dns hashes */
-struct Curl_multi *Curl_multi_handle(int hashsize, int chashsize,
+struct Curl_multi *Curl_multi_handle(size_t hashsize, int chashsize,
                                      size_t dnssize);
 
 /* the write bits start at bit 16 for the *getsock() bitmap */


### PR DESCRIPTION
Follow-up to cc907e80a2498c0599253271a6f657f614b52a4e #13502
Cherry-picked from #13489
Closes #13601
