### PR TITLE
hsts: Remove single-use single-line function

### DIFF
--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -107,11 +107,6 @@ void Curl_hsts_cleanup(struct hsts **hp)
   }
 }
 
-static struct stsentry *hsts_entry(void)
-{
-  return calloc(1, sizeof(struct stsentry));
-}
-
 static CURLcode hsts_create(struct hsts *h,
                             const char *hostname,
                             bool subdomains,
@@ -127,7 +122,7 @@ static CURLcode hsts_create(struct hsts *h,
     --hlen;
   if(hlen) {
     char *duphost;
-    struct stsentry *sts = hsts_entry();
+    struct stsentry *sts = calloc(1, sizeof(struct stsentry));
     if(!sts)
       return CURLE_OUT_OF_MEMORY;
 


### PR DESCRIPTION
The hsts_entry() function contains of a single line and is only used in a single place in the code, so move the allocation into hsts_create instead to improve code readability. C code usually don't use the factory abstraction for object creation, and this small example wasn't following our usual code style.