### PR TITLE
setopt: make the setstropt_userpwd args compulsory

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -115,6 +115,9 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
   char *user = NULL;
   char *passwd = NULL;
 
+  DEBUGASSERT(userp);
+  DEBUGASSERT(passwdp);
+
   /* Parse the login details if specified. It not then we treat NULL as a hint
      to clear the existing data */
   if(option) {
@@ -122,31 +125,24 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
     if(len > CURL_MAX_INPUT_LENGTH)
       return CURLE_BAD_FUNCTION_ARGUMENT;
 
-    result = Curl_parse_login_details(option, len,
-                                      (userp ? &user : NULL),
-                                      (passwdp ? &passwd : NULL),
-                                      NULL);
+    result = Curl_parse_login_details(option, len, &user, &passwd, NULL);
   }
 
   if(!result) {
-    /* Store the username part of option if required */
-    if(userp) {
-      if(!user && option && option[0] == ':') {
-        /* Allocate an empty string instead of returning NULL as user name */
-        user = strdup("");
-        if(!user)
-          result = CURLE_OUT_OF_MEMORY;
-      }
-
-      Curl_safefree(*userp);
-      *userp = user;
+    /* Store the username part */
+    if(!user && option && option[0] == ':') {
+      /* Allocate an empty string instead of returning NULL as user name */
+      user = strdup("");
+      if(!user)
+        result = CURLE_OUT_OF_MEMORY;
     }
 
-    /* Store the password part of option if required */
-    if(passwdp) {
-      Curl_safefree(*passwdp);
-      *passwdp = passwd;
-    }
+    Curl_safefree(*userp);
+    *userp = user;
+
+    /* Store the password part */
+    Curl_safefree(*passwdp);
+    *passwdp = passwd;
   }
 
   return result;


### PR DESCRIPTION
They were always used so no point in allowing them to be optional.

follow-up to 0e37b42dc956bd8a