### PR TITLE
vauth: make two functions void that always just returned OK

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -376,7 +376,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
     sasl->authused = SASL_MECH_EXTERNAL;
 
     if(force_ir || data->set.sasl_ir)
-      result = Curl_auth_create_external_message(conn->user, &resp);
+      Curl_auth_create_external_message(conn->user, &resp);
   }
   else if(data->state.aptr.user) {
 #if defined(USE_KERBEROS5)
@@ -498,7 +498,7 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
       sasl->authused = SASL_MECH_LOGIN;
 
       if(force_ir || data->set.sasl_ir)
-        result = Curl_auth_create_login_message(conn->user, &resp);
+        Curl_auth_create_login_message(conn->user, &resp);
     }
   }
 
@@ -576,14 +576,14 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
                                             conn->user, conn->passwd, &resp);
     break;
   case SASL_LOGIN:
-    result = Curl_auth_create_login_message(conn->user, &resp);
+    Curl_auth_create_login_message(conn->user, &resp);
     newstate = SASL_LOGIN_PASSWD;
     break;
   case SASL_LOGIN_PASSWD:
-    result = Curl_auth_create_login_message(conn->passwd, &resp);
+    Curl_auth_create_login_message(conn->passwd, &resp);
     break;
   case SASL_EXTERNAL:
-    result = Curl_auth_create_external_message(conn->user, &resp);
+    Curl_auth_create_external_message(conn->user, &resp);
     break;
 #ifdef USE_GSASL
   case SASL_GSASL:

--- a/lib/vauth/cleartext.c
+++ b/lib/vauth/cleartext.c
@@ -107,12 +107,11 @@ CURLcode Curl_auth_create_plain_message(const char *authzid,
  * valuep  [in]     - The user name or user's password.
  * out     [out]    - The result storage.
  *
- * Returns CURLE_OK on success.
+ * Returns void.
  */
-CURLcode Curl_auth_create_login_message(const char *valuep, struct bufref *out)
+void Curl_auth_create_login_message(const char *valuep, struct bufref *out)
 {
   Curl_bufref_set(out, valuep, strlen(valuep), NULL);
-  return CURLE_OK;
 }
 
 /*
@@ -126,13 +125,13 @@ CURLcode Curl_auth_create_login_message(const char *valuep, struct bufref *out)
  * user    [in]     - The user name.
  * out     [out]    - The result storage.
  *
- * Returns CURLE_OK on success.
+ * Returns void.
  */
-CURLcode Curl_auth_create_external_message(const char *user,
+void Curl_auth_create_external_message(const char *user,
                                            struct bufref *out)
 {
   /* This is the same formatting as the login message */
-  return Curl_auth_create_login_message(user, out);
+  Curl_auth_create_login_message(user, out);
 }
 
 #endif /* if no users */

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -79,12 +79,10 @@ CURLcode Curl_auth_create_plain_message(const char *authzid,
                                         struct bufref *out);
 
 /* This is used to generate a LOGIN cleartext message */
-CURLcode Curl_auth_create_login_message(const char *value,
-                                        struct bufref *out);
+void Curl_auth_create_login_message(const char *value, struct bufref *out);
 
 /* This is used to generate an EXTERNAL cleartext message */
-CURLcode Curl_auth_create_external_message(const char *user,
-                                           struct bufref *out);
+void Curl_auth_create_external_message(const char *user, struct bufref *out);
 
 #ifndef CURL_DISABLE_DIGEST_AUTH
 /* This is used to generate a CRAM-MD5 response message */


### PR DESCRIPTION
Removes the need to check return values when they can never fail.

Pointed out by CodeSonar