### PR TITLE
vtls: remove duplicate assign

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1603,7 +1603,6 @@ CURLcode Curl_ssl_peer_init(struct ssl_peer *peer, struct Curl_cfilter *cf,
       }
     }
 
-    peer->sni = NULL;
     peer->type = get_peer_type(peer->hostname);
     if(peer->type == CURL_SSL_PEER_DNS && peer->hostname[0]) {
       /* not an IP address, normalize according to RCC 6066 ch. 3,


### PR DESCRIPTION
Curl_ssl_peer_cleanup() already clears the ->sni field, no point in assigning it again.

Spotted by CodeSonar