### PR TITLE
tests: fix test 1167 to skip digit-only symbols

### DIFF
--- a/tests/test1167.pl
+++ b/tests/test1167.pl
@@ -104,6 +104,7 @@ sub scanenums {
                ($_ ne "typedef") &&
                ($_ ne "enum") &&
                ($_ ne "=") &&
+               ($_ !~ /^\d+$/) &&
                ($_ !~ /^[ \t]*$/)) {
                 if($verbose) {
                     print "Source: $Cpreprocessor $i$file\n";


### PR DESCRIPTION
This avoids mistaking symbols with their numeric value when using
certain C preprocessors which output these numeric values at the
beginning of the line as part of an expression.

Seen on OpenBSD 7.5 + clang.

Example `test1167.pl -v` output, before this patch:
```
Source: cpp /home/runner/work/curl/curl/tests/../include/curl/curl.h
Symbol: 20000
Line #3835:   20000 +  142,
[...]
Bad symbols in public header files:
   20000
   [...]
```
Ref: https://github.com/curl/curl/actions/runs/9069136530/job/24918015357#step:3:7513

Ref: #13583
Closes #13634