### PR TITLE
ci: Reconfigure renovate and pre-emptively fix mbedTLS

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -279,6 +279,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/ARMmbed/mbedtls
           cd mbedtls
+          git submodule update --init
           make DESTDIR=$HOME/mbedtls install
 
       - name: cache openssl3

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices",
-    "group:allNonMajor"
+    "config:best-practices"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "commitMessagePrefix": "gha: ",
+      "labels": ["CI"]
+    },
+    {
+      "matchUpdateTypes": ["pin", "pinDigest"],
+      "commitMessagePrefix": "ci: ",
+      "labels": ["CI"]
+    },
+    {
+      "matchManagers": ["regex"],
+      "commitMessagePrefix": "ci: ",
+      "labels": ["CI"]
+    },
+    {
+      "matchDepNames": ["debian"],
+      "matchFileNames": [".github/workflows/linux-old.yml"],
+      "enabled": false
+    }
   ],
   "customManagers": [
     {


### PR DESCRIPTION
Reconfigure renovate:
    
    - set prefix for github actions updates to be gha:
    - set prefix for other renovate actions to be ci:
    - disable debian updates in linux-old.yml

Also handle git submodules for mbedTLS