### PR TITLE
warnless: delete orphan declarations

### DIFF
--- a/lib/warnless.h
+++ b/lib/warnless.h
@@ -77,20 +77,6 @@ ssize_t curlx_write(int fd, const void *buf, size_t count);
 
 #endif /* _WIN32 */
 
-#if defined(__INTEL_COMPILER) && defined(__unix__)
-
-int curlx_FD_ISSET(int fd, fd_set *fdset);
-
-void curlx_FD_SET(int fd, fd_set *fdset);
-
-void curlx_FD_ZERO(fd_set *fdset);
-
-unsigned short curlx_htons(unsigned short usnum);
-
-unsigned short curlx_ntohs(unsigned short usnum);
-
-#endif /* __INTEL_COMPILER && __unix__ */
-
 #endif /* HEADER_CURL_WARNLESS_H */
 
 #ifndef HEADER_CURL_WARNLESS_H_REDEFS


### PR DESCRIPTION
Follow-up to 358f7e757781857c4b498a68634726609fa3884a #11932
Closes #13639

---

These functions had a point not just for the Intel compiler but for envs that don't compile `FD_SET()/FS_ISSET()` cleanly with `-Wsign-conversion`. E.g. OmniOS and older Cygwin.
Ref: #13489
Ref: https://github.com/curl/curl/blob/d84a95de116d5547baa8f816e0e6a1050eaa7ac5/docs/examples/sendrecv.c#L51-L65