### PR TITLE
lib: fix compiler warnings (gcc)

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1289,7 +1289,7 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 #ifdef DEBUGBUILD
   /* simulate network blocking/partial writes */
   if(ctx->wblock_percent > 0) {
-    unsigned char c;
+    unsigned char c = 0;
     Curl_rand(data, &c, 1);
     if(c >= ((100-ctx->wblock_percent)*256/100)) {
       CURL_TRC_CF(data, cf, "send(len=%zu) SIMULATE EWOULDBLOCK", orig_len);
@@ -1367,7 +1367,7 @@ static ssize_t cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 #ifdef DEBUGBUILD
   /* simulate network blocking/partial reads */
   if(cf->cft != &Curl_cft_udp && ctx->rblock_percent > 0) {
-    unsigned char c;
+    unsigned char c = 0;
     Curl_rand(data, &c, 1);
     if(c >= ((100-ctx->rblock_percent)*256/100)) {
       CURL_TRC_CF(data, cf, "recv(len=%zu) SIMULATE EWOULDBLOCK", len);

--- a/lib/curl_gethostname.c
+++ b/lib/curl_gethostname.c
@@ -68,7 +68,7 @@ int Curl_gethostname(char * const name, GETHOSTNAME_TYPE_ARG2 namelen)
   /* Override host name when environment variable CURL_GETHOSTNAME is set */
   const char *force_hostname = getenv("CURL_GETHOSTNAME");
   if(force_hostname) {
-    strncpy(name, force_hostname, namelen);
+    strncpy(name, force_hostname, namelen - 1);
     err = 0;
   }
   else {

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -244,6 +244,7 @@ void Curl_hostcache_prune(struct Curl_easy *data)
   if(data->share)
     Curl_share_lock(data, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SINGLE);
 
+  now = time(NULL);
   time(&now);
 
   do {
@@ -298,6 +299,7 @@ static struct Curl_dns_entry *fetch_addr(struct Curl_easy *data,
     /* See whether the returned entry is stale. Done before we release lock */
     struct hostcache_prune_data user;
 
+    user.now = time(NULL);
     time(&user.now);
     user.cache_timeout = data->set.dns_cache_timeout;
     user.oldest = 0;

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -245,7 +245,6 @@ void Curl_hostcache_prune(struct Curl_easy *data)
     Curl_share_lock(data, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SINGLE);
 
   now = time(NULL);
-  time(&now);
 
   do {
     /* Remove outdated and unused entries from the hostcache */
@@ -300,7 +299,6 @@ static struct Curl_dns_entry *fetch_addr(struct Curl_easy *data,
     struct hostcache_prune_data user;
 
     user.now = time(NULL);
-    time(&user.now);
     user.cache_timeout = data->set.dns_cache_timeout;
     user.oldest = 0;
 

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1205,7 +1205,6 @@ static timediff_t tftp_state_timeout(struct Curl_easy *data,
     return 0;
   }
   current = time(NULL);
-  time(&current);
   if(current > state->rx_time + state->retry_time) {
     if(event)
       *event = TFTP_EVENT_TIMEOUT;

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -1204,6 +1204,7 @@ static timediff_t tftp_state_timeout(struct Curl_easy *data,
     state->state = TFTP_STATE_FIN;
     return 0;
   }
+  current = time(NULL);
   time(&current);
   if(current > state->rx_time + state->retry_time) {
     if(event)


### PR DESCRIPTION
Seen when setting `ENABLE_DEBUG=ON` and `-DDEBUGBUILD` for mingw-w64
gcc 13.2.0 CMake unity builds in 'Release' configurations.

```
curl/lib/curl_gethostname.c:71:5: error: 'strncpy' specified bound 1025 equals destination size [-Werror=stringop-truncation]
   71 |     strncpy(name, force_hostname, namelen);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from curl/_bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:175:
In function 'hostcache_timestamp_remove',
    inlined from 'Curl_hash_clean_with_criterium' at curl/lib/hash.c:265:19,
    inlined from 'Curl_hash_clean_with_criterium' at curl/lib/hash.c:247:1,
    inlined from 'hostcache_prune' at curl/lib/hostip.c:228:3,
    inlined from 'Curl_hostcache_prune' at curl/lib/hostip.c:256:21:
curl/lib/hostip.c:205:12: error: 'now' may be used uninitialized [-Werror=maybe-uninitialized]
  205 |     time_t age = prune->now - c->timestamp;
      |            ^~~
curl/lib/hostip.c: In function 'Curl_hostcache_prune':
curl/lib/hostip.c:241:10: note: 'now' was declared here
  241 |   time_t now;
      |          ^~~
In function 'hostcache_timestamp_remove',
    inlined from 'fetch_addr' at curl/lib/hostip.c:310:8:
curl/lib/hostip.c:205:23: error: 'user.now' may be used uninitialized [-Werror=maybe-uninitialized]
  205 |     time_t age = prune->now - c->timestamp;
      |                  ~~~~~^~~~~
curl/lib/hostip.c: In function 'fetch_addr':
curl/lib/hostip.c:304:33: note: 'user' declared here
  304 |     struct hostcache_prune_data user;
      |                                 ^~~~
In file included from curl/_bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:40:
curl/lib/cf-socket.c: In function 'cf_socket_send':
curl/lib/cf-socket.c:1294:10: error: 'c' may be used uninitialized [-Werror=maybe-uninitialized]
 1294 |     if(c >= ((100-ctx->wblock_percent)*256/100)) {
      |        ~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
curl/lib/cf-socket.c:1292:19: note: 'c' was declared here
 1292 |     unsigned char c;
      |                   ^
In file included from curl/_bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:364:
In function 'tftp_state_timeout',
    inlined from 'tftp_multi_statemach' at curl/lib/tftp.c:1230:27:
curl/lib/tftp.c:1208:5: error: 'current' may be used uninitialized [-Werror=maybe-uninitialized]
 1208 |   if(current > state->rx_time + state->retry_time) {
      |     ^
curl/lib/tftp.c: In function 'tftp_multi_statemach':
curl/lib/tftp.c:1192:10: note: 'current' was declared here
 1192 |   time_t current;
      |          ^~~~~~~
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/49792835/job/91c8dj5qb36spfe0#L112
Ref: https://github.com/curl/curl/actions/runs/9082968838/job/24960616145#step:12:62

Ref: #13592
Closes #13643
