### PR TITLE
ci: set semantic type as CI and include digests as CI operations

### DIFF
--- a/.github/scripts/VERSIONS
+++ b/.github/scripts/VERSIONS
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: curl
 
-# renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver registryUrl=https://github.com
+# renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
 WOLFSSL_VER=5.6.0
 
-# renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver registryUrl=https://github.com
+# renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
 WOLFSSH_VER=1.4.12

--- a/renovate.json
+++ b/renovate.json
@@ -3,25 +3,44 @@
   "extends": [
     "config:best-practices"
   ],
+  "semanticCommitType": "ci",
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "commitMessagePrefix": "gha: ",
-      "labels": ["CI"]
+      "labels": [
+        "CI"
+      ]
     },
     {
-      "matchUpdateTypes": ["pin", "pinDigest"],
+      "matchUpdateTypes": [
+        "pin",
+        "pinDigest",
+        "digest"
+      ],
       "commitMessagePrefix": "ci: ",
-      "labels": ["CI"]
+      "labels": [
+        "CI"
+      ]
     },
     {
-      "matchManagers": ["regex"],
+      "matchManagers": [
+        "regex"
+      ],
       "commitMessagePrefix": "ci: ",
-      "labels": ["CI"]
+      "labels": [
+        "CI"
+      ]
     },
     {
-      "matchDepNames": ["debian"],
-      "matchFileNames": [".github/workflows/linux-old.yml"],
+      "matchDepNames": [
+        "debian"
+      ],
+      "matchFileNames": [
+        ".github/workflows/linux-old.yml"
+      ],
       "enabled": false
     }
   ],


### PR DESCRIPTION
Hopefully removing the last of the "chores" from Renovate.