### PR TITLE
appveyor: guard against crash-build with VS2008

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -42,8 +42,11 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   [ "${PRJ_CFG}" = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
   [ "${PRJ_CFG}" = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
   [[ "${PRJ_GEN}" = *'Visual Studio'* ]] && options+=' -DCMAKE_VS_GLOBALS=TrackFileAccess=false'
-  # Fails to run without this run due to missing MSVCR90.dll
-  [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ] && options+=' -DCURL_STATIC_CRT=ON'
+  if [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ]; then
+    [ "${PRJ_CFG}" = 'Debug' ] && [ "${DEBUG}" = 'ON' ] && [ "${SHARED}" = 'ON' ] && SKIP_RUN='Crash on startup in -DDEBUGBUILD shared builds'
+    # Fails to run without this due to missing MSVCR90.dll / MSVCR90D.dll
+    options+=' -DCURL_STATIC_CRT=ON'
+  fi
   # shellcheck disable=SC2086
   cmake -B _bld "-G${PRJ_GEN}" ${TARGET:-} ${options} \
     "-DCURL_USE_OPENSSL=${OPENSSL}" \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,17 @@ environment:
       SHARED: 'ON'
       TESTING: 'OFF'
       DISABLED_TESTS: ''
+    - job_name: 'CMake, VS2008, Debug, x86, Schannel, Build-only'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 9 2008'
+      PRJ_CFG: Debug
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'OFF'
+      SHARED: 'ON'
+      TESTING: 'OFF'
+      DISABLED_TESTS: ''
     - job_name: 'CMake, VS2022, Release, x64, OpenSSL 3.2, WebSockets, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,6 +95,17 @@ environment:
       HTTP_ONLY: 'OFF'
       TESTING: 'OFF'
       DISABLED_TESTS: ''
+    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Shared, Build-only'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 10 2010 Win64'
+      PRJ_CFG: Debug
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'OFF'
+      HTTP_ONLY: 'OFF'
+      SHARED: 'ON'
+      TESTING: 'OFF'
+      DISABLED_TESTS: ''
     - job_name: 'CMake, VS2022, Debug, x64, Schannel, Static, Unicode'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -106,6 +117,18 @@ environment:
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
       DISABLED_TESTS: '!1139 !1501 !1177 !1477'
+    - job_name: 'CMake, VS2022, Debug, x64, Schannel, Shared, Unicode, Build-only'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 17 2022'
+      TARGET: '-A x64'
+      PRJ_CFG: Debug
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'ON'
+      HTTP_ONLY: 'OFF'
+      SHARED: 'ON'
+      TESTING: 'OFF'
+      DISABLED_TESTS: ''
     - job_name: 'CMake, VS2022, Debug, x64, no SSL, Static'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,17 +95,6 @@ environment:
       HTTP_ONLY: 'OFF'
       TESTING: 'OFF'
       DISABLED_TESTS: ''
-    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Shared, Build-only'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
-      BUILD_SYSTEM: CMake
-      PRJ_GEN: 'Visual Studio 10 2010 Win64'
-      PRJ_CFG: Debug
-      SCHANNEL: 'ON'
-      ENABLE_UNICODE: 'OFF'
-      HTTP_ONLY: 'OFF'
-      SHARED: 'ON'
-      TESTING: 'OFF'
-      DISABLED_TESTS: ''
     - job_name: 'CMake, VS2022, Debug, x64, Schannel, Static, Unicode'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -117,18 +106,6 @@ environment:
       HTTP_ONLY: 'OFF'
       TESTING: 'ON'
       DISABLED_TESTS: '!1139 !1501 !1177 !1477'
-    - job_name: 'CMake, VS2022, Debug, x64, Schannel, Shared, Unicode, Build-only'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
-      BUILD_SYSTEM: CMake
-      PRJ_GEN: 'Visual Studio 17 2022'
-      TARGET: '-A x64'
-      PRJ_CFG: Debug
-      SCHANNEL: 'ON'
-      ENABLE_UNICODE: 'ON'
-      HTTP_ONLY: 'OFF'
-      SHARED: 'ON'
-      TESTING: 'OFF'
-      DISABLED_TESTS: ''
     - job_name: 'CMake, VS2022, Debug, x64, no SSL, Static'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake


### PR DESCRIPTION
The combination of `-DDEBUGBUILD`, a shared `curl.exe`, and the VS2008
compiler creates a `curl.exe` segfaulting on startup:

```
+ _bld/src/curl.exe --version
./appveyor.sh: line 122:   793 Segmentation fault      "${curl}" --version
Command exited with code 139
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/49817266/job/651iy6qn1e238pqj#L191

Add job that triggers the issue and add the necessary logic to skip
running the affected `curl.exe`.

Ref: #13592
Closes #13654

---

Fixing the actual problem would be nicer, but it would require a local 
environment like the affected one and a will/need to track this down.
