### PR TITLE
appveyor: more tidy-ups

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -119,7 +119,7 @@ fi
 
 find . -name '*.exe' -o -name '*.dll'
 if [ -z "${SKIP_RUN:-}" ]; then
-  "${curl}" --version
+  "${curl}" --disable --version
 else
   echo "Skip running curl.exe. Reason: ${SKIP_RUN}"
 fi

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -136,8 +136,8 @@ if [ "${TESTING}" = 'ON' ]; then
   export TFLAGS=''
   if [ -x "$(cygpath -u "${WINDIR}/System32/curl.exe")" ]; then
     TFLAGS+=" -ac $(cygpath -u "${WINDIR}/System32/curl.exe")"
-  elif [ -x "$(cygpath -u "C:/msys64/usr/bin/curl.exe")" ]; then
-    TFLAGS+=" -ac $(cygpath -u "C:/msys64/usr/bin/curl.exe")"
+  elif [ -x "$(cygpath -u 'C:/msys64/usr/bin/curl.exe')" ]; then
+    TFLAGS+=" -ac $(cygpath -u 'C:/msys64/usr/bin/curl.exe')"
   fi
   TFLAGS+=" ${DISABLED_TESTS:-}"
   if [ "${BUILD_SYSTEM}" = 'CMake' ]; then


### PR DESCRIPTION
- use `--disable` when calling `curl --version`. Just in case.

- use single-quotes for a constant.

Closes #13662
