### PR TITLE
cmake: initialize `BUILD_TESTING` before first use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1565,6 +1565,10 @@ set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
 set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
 
+cmake_dependent_option(BUILD_TESTING "Build tests"
+  ON "PERL_FOUND;NOT CURL_DISABLE_TESTS"
+  OFF)
+
 if(HAVE_MANUAL_TOOLS)
   add_subdirectory(docs)
 endif()
@@ -1580,9 +1584,6 @@ if(BUILD_EXAMPLES)
   add_subdirectory(docs/examples)
 endif()
 
-cmake_dependent_option(BUILD_TESTING "Build tests"
-  ON "PERL_FOUND;NOT CURL_DISABLE_TESTS"
-  OFF)
 if(BUILD_TESTING)
   add_subdirectory(tests)
 endif()


### PR DESCRIPTION
Before this patch `BUILD_TESTING` was used once, then initialized, then
used again. This caused the `curlu` library not being built when relying
on an implicit `BUILD_TESTING=ON` setting, and ending up with a link
error when building the `testdeps` target.

It did not cause issues when `BUILD_TESTING` was explicitly set.

Move the initialization before the first use to fix it.

Regression from aace27b0965c10394544d1dacc9c2cb2fe0de3d3 #12287

Closes #13668
