### PR TITLE
libtest: 2308 verifies CURLE_WRITE_ERROR after write callback error

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -247,6 +247,7 @@ test2100 \
 test2200 test2201 test2202 test2203 test2204 test2205 \
 \
 test2300 test2301 test2302 test2303 test2304 test2305 test2306 test2307 \
+test2308 \
 \
 test2400 test2401 test2402 test2403 test2404 test2405 test2406 \
 \

--- a/tests/data/test2308
+++ b/tests/data/test2308
@@ -1,0 +1,57 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+#
+# This reproduces the #13669 issue
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+# tool to run
+<tool>
+lib%TESTNUMBER
+</tool>
+
+<name>
+verify return code when write callback returns error
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Accept: */*
+
+</protocol>
+<stdout mode="text">
+Returned 23, should be 23.
+</stdout>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -73,7 +73,7 @@ noinst_PROGRAMS = chkhostname libauthretry libntlmconnect libprereq      \
  lib1945 lib1946 lib1947 lib1948 lib1955 lib1956 lib1957 lib1958 lib1959 \
  lib1960 lib1964 \
  lib1970 lib1971 lib1972 lib1973 lib1974 lib1975 \
- lib2301 lib2302 lib2304 lib2305 lib2306 \
+ lib2301 lib2302 lib2304 lib2305 lib2306         lib2308 \
  lib2402 lib2404 lib2405 \
  lib2502 \
  lib3010 lib3025 lib3026 lib3027 \
@@ -676,6 +676,9 @@ lib2305_LDADD = $(TESTUTIL_LIBS)
 
 lib2306_SOURCES = lib2306.c $(SUPPORTFILES)
 lib2306_LDADD = $(TESTUTIL_LIBS)
+
+lib2308_SOURCES = lib2308.c $(SUPPORTFILES)
+lib2308_LDADD = $(TESTUTIL_LIBS)
 
 lib2402_SOURCES = lib2402.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib2402_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib2308.c
+++ b/tests/libtest/lib2308.c
@@ -39,7 +39,7 @@ static size_t cb_curl(void *buffer, size_t size, size_t nmemb, void *userp)
 CURLcode test(char *URL)
 {
   CURL *curl;
-  CURLcode res;
+  CURLcode res = CURLE_OK;
 
   global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();

--- a/tests/libtest/lib2308.c
+++ b/tests/libtest/lib2308.c
@@ -41,7 +41,7 @@ CURLcode test(char *URL)
   CURL *curl;
   CURLcode res;
 
-  curl_global_init(CURL_GLOBAL_SSL);
+  global_init(CURL_GLOBAL_ALL);
   curl = curl_easy_init();
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, cb_curl);
   curl_easy_setopt(curl, CURLOPT_URL, URL);

--- a/tests/libtest/lib2308.c
+++ b/tests/libtest/lib2308.c
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "test.h"
+#include "testtrace.h"
+
+#include <curl/curl.h>
+
+static size_t cb_curl(void *buffer, size_t size, size_t nmemb, void *userp)
+{
+  (void)buffer;
+  (void)size;
+  (void)nmemb;
+  (void)userp;
+  return CURL_WRITEFUNC_ERROR;
+}
+
+CURLcode test(char *URL)
+{
+  CURL *curl;
+  CURLcode res;
+
+  curl_global_init(CURL_GLOBAL_SSL);
+  curl = curl_easy_init();
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, cb_curl);
+  curl_easy_setopt(curl, CURLOPT_URL, URL);
+  res = curl_easy_perform(curl);
+  printf("Returned %d, should be %d.\n", res, CURLE_WRITE_ERROR);
+  fflush(stdout);
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+  return CURLE_OK;
+}


### PR DESCRIPTION
Verifies that the issue in #13669 actually is fixed. This return code is what the CURLOPT_WRITEFUNCTION manpage documents should be returned.

This code is mostly from the
Source-written-by: Trumeet at github