### PR TITLE
openssl: revert keylog_callback support for LibreSSL

### DIFF
--- a/docs/cmdline-opts/_ENVIRONMENT.md
+++ b/docs/cmdline-opts/_ENVIRONMENT.md
@@ -101,8 +101,8 @@ if Schannel is used as the TLS backend.
 If you set this environment variable to a filename, curl stores TLS secrets
 from its connections in that file when invoked to enable you to analyze the
 TLS traffic in real time using network analyzing tools such as Wireshark. This
-works with the following TLS backends: OpenSSL, libressl, BoringSSL, GnuTLS
-and wolfSSL.
+works with the following TLS backends: OpenSSL, LibreSSL (TLS 1.2 max),
+BoringSSL, GnuTLS and wolfSSL.
 
 ## `USERPROFILE` <dir>
 On Windows, this variable is used when trying to find the home directory. If

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -204,12 +204,10 @@
  * Whether SSL_CTX_set_keylog_callback is available.
  * OpenSSL: supported since 1.1.1 https://github.com/openssl/openssl/pull/2287
  * BoringSSL: supported since d28f59c27bac (committed 2015-11-19)
- * LibreSSL: supported since 3.5.0 (released 2022-02-24)
+ * LibreSSL: not supported. 3.5.0+ has a stub function that does nothing.
  */
 #if (OPENSSL_VERSION_NUMBER >= 0x10101000L && \
      !defined(LIBRESSL_VERSION_NUMBER)) || \
-    (defined(LIBRESSL_VERSION_NUMBER) && \
-     LIBRESSL_VERSION_NUMBER >= 0x3050000fL) || \
     defined(OPENSSL_IS_BORINGSSL)
 #define HAVE_KEYLOG_CALLBACK
 #endif


### PR DESCRIPTION
- Revert to the legacy TLS 1.2 key logging code for LibreSSL.

Prior to this change if the user specified a filename in the SSLKEYLOGFILE environment variable and was using LibreSSL 3.5.0+ then an empty file would be created and no keys would be logged.

This is effectively a revert of e43474b4 which changed openssl.c to use SSL_CTX_set_keylog_callback for LibreSSL 3.5.0+. Unfortunately LibreSSL added that function only as a stub that doesn't actually do anything.

Reported-by: Gonçalo Carvalho

Fixes https://github.com/curl/curl/issues/13672
Closes #xxxx

---

This means we don't have TLS 1.3 key logging for LibreSSL? The legacy TLS 1.2 logging records only CLIENT_RANDOM, but I think for TLS 1.3 we need all of the secrets to decrypt that SSL_CTX_set_keylog_callback would record (ie SERVER_HANDSHAKE_TRAFFIC_SECRET, EXPORTER_SECRET, SERVER_TRAFFIC_SECRET_0, CLIENT_HANDSHAKE_TRAFFIC_SECRET, CLIENT_TRAFFIC_SECRET_0)