### PR TITLE
openssl: stop duplicate ssl key logging for legacy OpenSSL

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4152,14 +4152,11 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
   }
 
 #ifndef HAVE_KEYLOG_CALLBACK
-  if(Curl_tls_keylog_enabled()) {
-    /* If key logging is enabled, wait for the handshake to complete and then
-     * proceed with logging secrets (for TLS 1.2 or older).
-     */
-    bool done = FALSE;
-    ossl_log_tls12_secret(octx->ssl, &done);
-    octx->keylog_done = done;
-  }
+  /* If key logging is enabled, wait for the handshake to complete and then
+   * proceed with logging secrets (for TLS 1.2 or older).
+   */
+  if(Curl_tls_keylog_enabled() && !octx->keylog_done)
+    ossl_log_tls12_secret(octx->ssl, &octx->keylog_done);
 #endif
 
   /* 1  is fine

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -45,8 +45,9 @@ struct ossl_ctx {
   BIO_METHOD *bio_method;
   CURLcode io_result;       /* result of last BIO cfilter operation */
 #ifndef HAVE_KEYLOG_CALLBACK
-  /* Set to true once a valid keylog entry has been created to avoid dupes. */
-  BIT(keylog_done);
+  /* Set to true once a valid keylog entry has been created to avoid dupes.
+     This is a bool and not a bitfield because it is passed by address. */
+  bool keylog_done;
 #endif
   BIT(x509_store_setup);            /* x509 store has been set up */
   BIT(reused_session);              /* session-ID was reused for this */


### PR DESCRIPTION
- Don't call the keylog function if it has already logged the key.

For old OpenSSL versions and its forks that do not have support for OpenSSL's keylog callback, libcurl has its own legacy key logging function that logs the TLS 1.2 (and earlier) key (client random + master key) on a single line.

Prior to this change, since e7de80e8 (not in a release), the legacy key logging function could write the same key line more than once (usually twice) due to some incorrect logic.

Closes #xxxx