### PR TITLE
build: untangle `UNITTESTS` and `DEBUGBUILD` macros

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -39,6 +39,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   options=''
   [[ "${TARGET:-}" = *'ARM64'* ]] && SKIP_RUN='ARM64 architecture'
   [ "${OPENSSL}" = 'ON' ] && options+=" -DOPENSSL_ROOT_DIR=${openssl_root_win}"
+  [ -n "${CURLDEBUG:-}" ] && options+=" -DENABLE_CURLDEBUG=${CURLDEBUG}"
   [ "${PRJ_CFG}" = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
   [ "${PRJ_CFG}" = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
   [[ "${PRJ_GEN}" = *'Visual Studio'* ]] && options+=' -DCMAKE_VS_GLOBALS=TrackFileAccess=false'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,6 +80,9 @@ environment:
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
+      DEBUG: 'OFF'
+      CURLDEBUG: 'ON'
+      TFLAGS: 'skiprun'
     - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -45,7 +45,7 @@
 #define ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
 #endif
 
-#ifdef DEBUGBUILD
+#ifdef UNITTESTS
 /* used by unit2600.c */
 void Curl_cf_def_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 {

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -486,7 +486,9 @@ CURLcode Curl_conn_keep_alive(struct Curl_easy *data,
                               struct connectdata *conn,
                               int sockindex);
 
+#ifdef UNITTESTS
 void Curl_cf_def_close(struct Curl_cfilter *cf, struct Curl_easy *data);
+#endif
 void Curl_conn_get_host(struct Curl_easy *data, int sockindex,
                         const char **phost, const char **pdisplay_host,
                         int *pport);

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1112,7 +1112,7 @@ struct transport_provider {
 };
 
 static
-#ifndef DEBUGBUILD
+#ifndef UNITTESTS
 const
 #endif
 struct transport_provider transport_providers[] = {
@@ -1378,7 +1378,7 @@ out:
   return result;
 }
 
-#ifdef DEBUGBUILD
+#ifdef UNITTESTS
 /* used by unit2600.c */
 void Curl_debug_set_transport_provider(int transport,
                                        cf_ip_connect_create *cf_create)
@@ -1391,7 +1391,7 @@ void Curl_debug_set_transport_provider(int transport,
     }
   }
 }
-#endif /* DEBUGBUILD */
+#endif /* UNITTESTS */
 
 CURLcode Curl_cf_setup_insert_after(struct Curl_cfilter *cf_at,
                                     struct Curl_easy *data,

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -125,7 +125,7 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
 extern struct Curl_cftype Curl_cft_happy_eyeballs;
 extern struct Curl_cftype Curl_cft_setup;
 
-#ifdef DEBUGBUILD
+#ifdef UNITTESTS
 void Curl_debug_set_transport_provider(int transport,
                                        cf_ip_connect_create *cf_create);
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -847,7 +847,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
                size_t buflen, struct passwd **result);
 #endif
 
-#ifdef DEBUGBUILD
+#ifdef UNITTESTS
 #define UNITTEST
 #else
 #define UNITTEST static

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -141,18 +141,19 @@ struct dohentry {
 };
 
 
-#ifdef DEBUGBUILD
-DOHcode doh_encode(const char *host,
-                   DNStype dnstype,
-                   unsigned char *dnsp, /* buffer */
-                   size_t len,  /* buffer size */
-                   size_t *olen); /* output length */
-DOHcode doh_decode(const unsigned char *doh,
-                   size_t dohlen,
-                   DNStype dnstype,
-                   struct dohentry *d);
-void de_init(struct dohentry *d);
-void de_cleanup(struct dohentry *d);
+#ifdef UNITTESTS
+UNITTEST DOHcode doh_encode(const char *host,
+                            DNStype dnstype,
+                            unsigned char *dnsp, /* buffer */
+                            size_t len,  /* buffer size */
+                            size_t *olen); /* output length */
+UNITTEST DOHcode doh_decode(const unsigned char *doh,
+                            size_t dohlen,
+                            DNStype dnstype,
+                            struct dohentry *d);
+
+UNITTEST void de_init(struct dohentry *d);
+UNITTEST void de_cleanup(struct dohentry *d);
 #endif
 
 extern struct curl_trc_feat Curl_doh_trc;

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -144,9 +144,9 @@ struct dohentry {
 #ifdef UNITTESTS
 UNITTEST DOHcode doh_encode(const char *host,
                             DNStype dnstype,
-                            unsigned char *dnsp, /* buffer */
+                            unsigned char *dnsp,  /* buffer */
                             size_t len,  /* buffer size */
-                            size_t *olen); /* output length */
+                            size_t *olen);  /* output length */
 UNITTEST DOHcode doh_decode(const unsigned char *doh,
                             size_t dohlen,
                             DNStype dnstype,

--- a/lib/dynhds.c
+++ b/lib/dynhds.c
@@ -275,7 +275,7 @@ CURLcode Curl_dynhds_h1_cadd_line(struct dynhds *dynhds, const char *line)
   return Curl_dynhds_h1_add_line(dynhds, line, line? strlen(line) : 0);
 }
 
-#ifdef DEBUGBUILD
+#ifdef UNITTESTS
 /* used by unit2602.c */
 
 bool Curl_dynhds_contains(struct dynhds *dynhds,

--- a/lib/dynhds.h
+++ b/lib/dynhds.h
@@ -95,6 +95,9 @@ struct dynhds_entry *Curl_dynhds_get(struct dynhds *dynhds,
                                      const char *name, size_t namelen);
 struct dynhds_entry *Curl_dynhds_cget(struct dynhds *dynhds, const char *name);
 
+#ifdef UNITTESTS
+/* used by unit2602.c */
+
 /**
  * Return TRUE iff one or more headers with the given name exist.
  */
@@ -116,20 +119,6 @@ size_t Curl_dynhds_count_name(struct dynhds *dynhds,
 size_t Curl_dynhds_ccount_name(struct dynhds *dynhds, const char *name);
 
 /**
- * Add a header, name + value, to `dynhds` at the end. Does *not*
- * check for duplicate names.
- */
-CURLcode Curl_dynhds_add(struct dynhds *dynhds,
-                         const char *name, size_t namelen,
-                         const char *value, size_t valuelen);
-
-/**
- * Add a header, c-string name + value, to `dynhds` at the end.
- */
-CURLcode Curl_dynhds_cadd(struct dynhds *dynhds,
-                          const char *name, const char *value);
-
-/**
  * Remove all entries with the given name.
  * Returns number of entries removed.
  */
@@ -146,8 +135,23 @@ size_t Curl_dynhds_cremove(struct dynhds *dynhds, const char *name);
 CURLcode Curl_dynhds_set(struct dynhds *dynhds,
                          const char *name, size_t namelen,
                          const char *value, size_t valuelen);
+#endif
 
 CURLcode Curl_dynhds_cset(struct dynhds *dynhds,
+                          const char *name, const char *value);
+
+/**
+ * Add a header, name + value, to `dynhds` at the end. Does *not*
+ * check for duplicate names.
+ */
+CURLcode Curl_dynhds_add(struct dynhds *dynhds,
+                         const char *name, size_t namelen,
+                         const char *value, size_t valuelen);
+
+/**
+ * Add a header, c-string name + value, to `dynhds` at the end.
+ */
+CURLcode Curl_dynhds_cadd(struct dynhds *dynhds,
                           const char *name, const char *value);
 
 /**

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -54,7 +54,7 @@
 #define MAX_HSTS_DATELENSTR "64"
 #define UNLIMITED "unlimited"
 
-#ifdef DEBUGBUILD
+#ifdef UNITTESTS
 /* to play well with debug builds, we can *set* a fixed time this will
    return */
 time_t deltatime; /* allow for "adjustments" for unit test purposes */

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -54,7 +54,7 @@
 #define MAX_HSTS_DATELENSTR "64"
 #define UNLIMITED "unlimited"
 
-#ifdef UNITTESTS
+#if defined(DEBUGBUILD) || defined(UNITTESTS)
 /* to play well with debug builds, we can *set* a fixed time this will
    return */
 time_t deltatime; /* allow for "adjustments" for unit test purposes */

--- a/lib/hsts.h
+++ b/lib/hsts.h
@@ -29,7 +29,7 @@
 #include <curl/curl.h>
 #include "llist.h"
 
-#ifdef DEBUGBUILD
+#ifdef UNITTESTS
 extern time_t deltatime;
 #endif
 

--- a/lib/hsts.h
+++ b/lib/hsts.h
@@ -29,7 +29,7 @@
 #include <curl/curl.h>
 #include "llist.h"
 
-#ifdef UNITTESTS
+#if defined(DEBUGBUILD) || defined(UNITTESTS)
 extern time_t deltatime;
 #endif
 

--- a/lib/noproxy.h
+++ b/lib/noproxy.h
@@ -27,7 +27,7 @@
 
 #ifndef CURL_DISABLE_PROXY
 
-#ifdef DEBUGBUILD
+#ifdef UNITTESTS
 
 UNITTEST bool Curl_cidr4_match(const char *ipv4,    /* 1.2.3.4 address */
                                const char *network, /* 1.2.3.4 address */

--- a/lib/urlapi-int.h
+++ b/lib/urlapi-int.h
@@ -30,9 +30,9 @@ size_t Curl_is_absolute_url(const char *url, char *buf, size_t buflen,
 
 CURLUcode Curl_url_set_authority(CURLU *u, const char *authority);
 
-#ifdef DEBUGBUILD
-CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,
-                          bool has_scheme);
+#ifdef UNITTESTS
+UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,
+                                   bool has_scheme);
 #endif
 
 #endif /* HEADER_CURL_URLAPI_INT_H */

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -72,8 +72,6 @@ static void unit_stop(void)
   curl_global_cleanup();
 }
 
-#ifdef DEBUGBUILD
-
 struct test_case {
   int id;
   const char *url;
@@ -329,8 +327,6 @@ static void test_connect(struct test_case *tc)
   check_result(tc, &tr);
 }
 
-#endif /* DEBUGBUILD */
-
 /*
  * How these test cases work:
  * - replace the creation of the TCP socket filter with our test filter
@@ -385,15 +381,10 @@ static struct test_case TEST_CASES[] = {
 
 UNITTEST_START
 
-#if defined(DEBUGBUILD)
   size_t i;
 
   for(i = 0; i < sizeof(TEST_CASES)/sizeof(TEST_CASES[0]); ++i) {
     test_connect(&TEST_CASES[i]);
   }
-#else
-  (void)TEST_CASES;
-  (void)test_connect;
-#endif
 
 UNITTEST_STOP


### PR DESCRIPTION
- fix `DEBUGBUILD` guards that should be `UNITTESTS`, in libcurl
  code used by unit tests.
- fix guards for libcurl functions used in unit tests only.
- sync `UNITTEST` attribute between declarations and definitions.
- drop `DEBUGBUILD` guard from test `unit2600`.
- fix guards for libcurl HSTS code used by both a unit test (`unit1660`)
  and `test0446`.
- update an existing AppVeyor CI job to test the issues fixed.

This fixes building tests with `CURLDEBUG` enabled but `DEBUGBUILD`
disabled. This can happen when building tests with CMake with
`ENABLE_DEBUG=ON` in Release config, or with `ENABLE_CURLDEBUG=ON`
and _without_ `ENABLE_DEBUG=ON`. Possibly also with autotools
when using `--enable-curldebug` without `--enable-debug`.

Test results:
- before: https://ci.appveyor.com/project/curlorg/curl/builds/49835609
- after: https://ci.appveyor.com/project/curlorg/curl/builds/49839255
  (the two failures are unrelated, subject to PR #13705)

Ref: #13592 (issue discovery)
Ref: #13689 (CI testing this PR with `DEBUGBUILD`/`CURLDEBUG` combinations)
Closes #13694
