### PR TITLE
cmake: always build unit tests with the `testdeps` target

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -33,10 +33,8 @@ include_directories(
   ${CURL_BINARY_DIR}/include      # for "curl/curl.h"
 )
 
-if(ENABLE_CURLDEBUG)  # running unittests require curl to compiled with CURLDEBUG
-  foreach(_testfile ${UNITPROGS})
-    add_executable(${_testfile} EXCLUDE_FROM_ALL ${_testfile}.c ${UNITFILES})
-    add_dependencies(testdeps ${_testfile})
-    target_link_libraries(${_testfile} curltool curlu)
-  endforeach()
-endif()
+foreach(_testfile ${UNITPROGS})
+  add_executable(${_testfile} EXCLUDE_FROM_ALL ${_testfile}.c ${UNITFILES})
+  add_dependencies(testdeps ${_testfile})
+  target_link_libraries(${_testfile} curltool curlu)
+endforeach()


### PR DESCRIPTION
Before this patch, the `testdeps` build target required `-DCURLDEBUG`
be set either via `ENABLE_DEBUG=ON` or `ENABLE_CURLDEBUG=ON` to build
the curl unit tests.

After fixing build issues in #13694, we can drop this requirement and
build unit tests unconditionally.

Depends-on: #13694
Depends-on: #13697 (fix unit test issue revealed by Old Linux CI job)
Follow-up to 39e7c22bb459c2e818f079984989a26a09741860 #11446
Closes #13698

---

Depends-on (to fix the failing Old Linux build):
- [x] #13694
- [x] #13697
