### PR TITLE
GHA: bump nghttp2 to v1.62.1

### DIFF
--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -56,7 +56,7 @@ env:
   # renovate: datasource=github-tags depName=ngtcp2/ngtcp2 versioning=semver registryUrl=https://github.com
   ngtcp2-version: 1.5.0
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com
-  nghttp2-version: 1.61.0
+  nghttp2-version: 1.62.1
   # renovate: datasource=github-tags depName=icing/mod_h2 versioning=semver registryUrl=https://github.com
   mod_h2-version: 2.0.27
 
@@ -98,6 +98,8 @@ jobs:
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \
             texinfo texlive texlive-extra-utils autopoint libev-dev \
             apache2 apache2-dev libnghttp2-dev
+          echo 'CC=gcc-12' >> $GITHUB_ENV
+          echo 'CXX=g++-12' >> $GITHUB_ENV
         name: 'install prereqs and impacket, pytest, crypto, apache2'
 
       - name: cache quictls

--- a/.github/workflows/osslq-linux.yml
+++ b/.github/workflows/osslq-linux.yml
@@ -55,7 +55,7 @@ env:
   # renovate: datasource=github-tags depName=ngtcp2/ngtcp2 versioning=semver registryUrl=https://github.com
   ngtcp2-version: 1.5.0
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com
-  nghttp2-version: 1.61.0
+  nghttp2-version: 1.62.1
   # renovate: datasource=github-tags depName=icing/mod_h2 versioning=semver registryUrl=https://github.com
   mod_h2-version: 2.0.27
 
@@ -86,6 +86,8 @@ jobs:
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \
             texinfo texlive texlive-extra-utils autopoint libev-dev \
             apache2 apache2-dev libnghttp2-dev
+          echo 'CC=gcc-12' >> $GITHUB_ENV
+          echo 'CXX=g++-12' >> $GITHUB_ENV
         name: 'install prereqs and impacket, pytest, crypto, apache2'
 
       - name: cache openssl3

--- a/.github/workflows/quiche-linux.yml
+++ b/.github/workflows/quiche-linux.yml
@@ -53,7 +53,7 @@ env:
   # renovate: datasource=github-tags depName=ngtcp2/ngtcp2 versioning=semver registryUrl=https://github.com
   ngtcp2-version: 1.5.0
   # renovate: datasource=github-tags depName=nghttp2/nghttp2 versioning=semver registryUrl=https://github.com
-  nghttp2-version: 1.61.0
+  nghttp2-version: 1.62.1
   # renovate: datasource=github-tags depName=cloudflare/quiche versioning=semver registryUrl=https://github.com
   quiche-version: 0.21.0
   # renovate: datasource=github-tags depName=icing/mod_h2 versioning=semver registryUrl=https://github.com
@@ -86,6 +86,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install libtool autoconf automake pkg-config stunnel4 ${{ matrix.build.install }}
           sudo apt-get install apache2 apache2-dev libnghttp2-dev
+          echo 'CC=gcc-12' >> $GITHUB_ENV
+          echo 'CXX=g++-12' >> $GITHUB_ENV
         name: 'install prereqs and impacket, pytest, crypto'
 
       - name: cache nghttpx


### PR DESCRIPTION
Use gcc-12 explicitly to compile C++20 source files.

Closes #13702