### PR TITLE
get.d: explain separators used in URL

### DIFF
--- a/docs/cmdline-opts/get.md
+++ b/docs/cmdline-opts/get.md
@@ -22,7 +22,11 @@ Example:
 When used, this option makes all data specified with --data, --data-binary
 or --data-urlencode to be used in an HTTP GET request instead of the POST
 request that otherwise would be used. The data is appended to the URL
-with a '?' separator.
+with a '?' as a separator. Or with '&' if more data is provided (check
+--data for details).
+
+Prior to 7.86.0 curl could again use '?' as a separator in some
+edge cases even if '?' was already in place.
 
 If used in combination with --head, the POST data is instead appended to the
 URL with a HEAD request.

--- a/docs/cmdline-opts/get.md
+++ b/docs/cmdline-opts/get.md
@@ -21,12 +21,11 @@ Example:
 
 When used, this option makes all data specified with --data, --data-binary
 or --data-urlencode to be used in an HTTP GET request instead of the POST
-request that otherwise would be used. The data is appended to the URL
-with a '?' as a separator. Or with '&' if more data is provided (check
---data for details).
+request that otherwise would be used. curl will append provided data to URL
+as a query string.
 
-Prior to 7.86.0 curl could again use '?' as a separator in some
-edge cases even if '?' was already in place.
+Prior to 7.86.0 curl could use '?' as a separator between data fields in some
+edge cases.
 
 If used in combination with --head, the POST data is instead appended to the
 URL with a HEAD request.

--- a/docs/cmdline-opts/get.md
+++ b/docs/cmdline-opts/get.md
@@ -24,8 +24,5 @@ or --data-urlencode to be used in an HTTP GET request instead of the POST
 request that otherwise would be used. curl will append provided data to URL
 as a query string.
 
-Prior to 7.86.0 curl could use '?' as a separator between data fields in some
-edge cases.
-
 If used in combination with --head, the POST data is instead appended to the
 URL with a HEAD request.


### PR DESCRIPTION
Prior to 7.86.0 symbol '?' could be used again as a separator in some edge cases.  
This behavior was fixed by b82eb72 (precedes 7.86.0).

This is **NOK** example for curl `7.74.0` (`?` used twice as a separator):
```shell
$ curl --silent --get --data key=value 'https://httpbin.org/get?foo/bar=baz' -v
[...]
> GET /get?foo/bar=baz?key=value HTTP/1.1
[...]
```

This is **OK** example for curl `8.4.0` (`&` properly used in front of `key=value`):
```shell
$ curl --silent --get --data key=value 'https://httpbin.org/get?foo/bar=baz' -v
[...]
> GET /get?foo/bar=baz&key=value HTTP/1.1
[...]
```

The problem was very edge case. I managed to reproduce it only when using `/` (forward slash) in name or value of data provided in URL.

I tried to update documentation to:
* briefly explain that sometimes `?` is to be expected as a separator and sometimes `&`
* mark that there were edge cases that before `7.86.0` curl could use `?` instead of `&`. But without going into details when exactly to not overwhelm user.