### PR TITLE
appveyor: drop unnecessary `--clean-first` cmake option

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -62,7 +62,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     '-DCMAKE_INSTALL_PREFIX=C:/curl' \
     "-DCMAKE_BUILD_TYPE=${PRJ_CFG}"
   # shellcheck disable=SC2086
-  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --clean-first -- ${BUILD_OPT:-}
+  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 -- ${BUILD_OPT:-}
   if [ "${SHARED}" = 'ON' ]; then
     cp -f -p _bld/lib/*.dll _bld/src/
   fi


### PR DESCRIPTION
In CI all machines are fresh on startup, making the `clean` operation
unnecessary. This can save some time/energy for each job run.

Closes #13707
