### PR TITLE
Fix compilation for static windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -914,21 +914,6 @@ if(APPLE)
   endif()
 endif()
 
-#libpsl
-option(CURL_USE_LIBPSL "Use libPSL" ON)
-mark_as_advanced(CURL_USE_LIBPSL)
-set(USE_LIBPSL OFF)
-
-if(CURL_USE_LIBPSL)
-  find_package(LibPSL)
-  if(LIBPSL_FOUND)
-    list(APPEND CURL_LIBS ${LIBPSL_LIBRARY})
-    list(APPEND CMAKE_REQUIRED_INCLUDES "${LIBPSL_INCLUDE_DIR}")
-    include_directories("${LIBPSL_INCLUDE_DIR}")
-    set(USE_LIBPSL ON)
-  endif()
-endif()
-
 #libSSH2
 option(CURL_USE_LIBSSH2 "Use libSSH2" ON)
 mark_as_advanced(CURL_USE_LIBSSH2)
@@ -1585,6 +1570,21 @@ endif()
 
 if(BUILD_TESTING)
   add_subdirectory(tests)
+endif()
+
+#libpsl
+option(CURL_USE_LIBPSL "Use libPSL" ON)
+mark_as_advanced(CURL_USE_LIBPSL)
+set(USE_LIBPSL OFF)
+
+if(CURL_USE_LIBPSL)
+  find_package(LibPSL)
+  if(LIBPSL_FOUND)
+    list(APPEND CURL_LIBS ${LIBPSL_LIBRARY})
+    list(APPEND CMAKE_REQUIRED_INCLUDES "${LIBPSL_INCLUDE_DIR}")
+    include_directories("${LIBPSL_INCLUDE_DIR}")
+    set(USE_LIBPSL ON)
+  endif()
 endif()
 
 if(NOT CURL_DISABLE_INSTALL)


### PR DESCRIPTION
I am not sure where is the correct place to put the psl feature inside the cmake file,
But it fix the compilation error on windows static that it connected to flags order.
I compile curl with vcpkg:
`vcpkg install curl[psl,tool]:x64-windows-static`

my fix on vcpkg:
https://github.com/microsoft/vcpkg/pull/38786

The error before this change:
```
[217/218] C:\WINDOWS\system32\cmd.exe /C "cd . && C:\src\vcpkg\downloads\tools\cmake-3.29.2-windows\cmake-3.29.2-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=src\CMakeFiles\curl.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1435~1.322\bin\Hostx64\x64\link.exe  src\CMakeFiles\curl.dir\slist_wc.c.obj src\CMakeFiles\curl.dir\tool_binmode.c.obj src\CMakeFiles\curl.dir\tool_bname.c.obj src\CMakeFiles\curl.dir\tool_cb_dbg.c.obj src\CMakeFiles\curl.dir\tool_cb_hdr.c.obj src\CMakeFiles\curl.dir\tool_cb_prg.c.obj src\CMakeFiles\curl.dir\tool_cb_rea.c.obj src\CMakeFiles\curl.dir\tool_cb_see.c.obj src\CMakeFiles\curl.dir\tool_cb_wrt.c.obj src\CMakeFiles\curl.dir\tool_cfgable.c.obj src\CMakeFiles\curl.dir\tool_dirhie.c.obj src\CMakeFiles\curl.dir\tool_doswin.c.obj src\CMakeFiles\curl.dir\tool_easysrc.c.obj src\CMakeFiles\curl.dir\tool_filetime.c.obj src\CMakeFiles\curl.dir\tool_findfile.c.obj src\CMakeFiles\curl.dir\tool_formparse.c.obj src\CMakeFiles\curl.dir\tool_getparam.c.obj src\CMakeFiles\curl.dir\tool_getpass.c.obj src\CMakeFiles\curl.dir\tool_help.c.obj src\CMakeFiles\curl.dir\tool_helpers.c.obj src\CMakeFiles\curl.dir\tool_hugehelp.c.obj src\CMakeFiles\curl.dir\tool_ipfs.c.obj src\CMakeFiles\curl.dir\tool_libinfo.c.obj src\CMakeFiles\curl.dir\tool_listhelp.c.obj src\CMakeFiles\curl.dir\tool_main.c.obj src\CMakeFiles\curl.dir\tool_msgs.c.obj src\CMakeFiles\curl.dir\tool_operate.c.obj src\CMakeFiles\curl.dir\tool_operhlp.c.obj src\CMakeFiles\curl.dir\tool_paramhlp.c.obj src\CMakeFiles\curl.dir\tool_parsecfg.c.obj src\CMakeFiles\curl.dir\tool_progress.c.obj src\CMakeFiles\curl.dir\tool_setopt.c.obj src\CMakeFiles\curl.dir\tool_sleep.c.obj src\CMakeFiles\curl.dir\tool_stderr.c.obj src\CMakeFiles\curl.dir\tool_strdup.c.obj src\CMakeFiles\curl.dir\tool_urlglob.c.obj src\CMakeFiles\curl.dir\tool_util.c.obj src\CMakeFiles\curl.dir\tool_vms.c.obj src\CMakeFiles\curl.dir\tool_writeout.c.obj src\CMakeFiles\curl.dir\tool_writeout_json.c.obj src\CMakeFiles\curl.dir\tool_xattr.c.obj src\CMakeFiles\curl.dir\var.c.obj src\CMakeFiles\curl.dir\curl.rc.res src\CMakeFiles\curl.dir\__\lib\base64.c.obj src\CMakeFiles\curl.dir\__\lib\dynbuf.c.obj  /out:src\curl.exe /implib:src\curl.lib /pdb:src\curl.pdb /version:0.0 /machine:x64 /MANIFEST:NO /nologo    /debug /INCREMENTAL /subsystem:console  lib\libcurl-d.lib  ws2_32.lib  bcrypt.lib  C:\src\vcpkg\installed\x64-windows-static\debug\lib\zlibd.lib  C:\src\vcpkg\installed\x64-windows-static\debug\lib\psl.lib  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\WS2_32.Lib"  C:\src\vcpkg\installed\x64-windows-static\debug\lib\icuucd.lib  C:\src\vcpkg\installed\x64-windows-static\debug\lib\icudtd.lib  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\kernel32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\User32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\Gdi32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\WinSpool.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\shell32.lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\Ole32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\OleAut32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\ComDlg32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\AdvAPI32.Lib"  advapi32.lib  crypt32.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
FAILED: src/curl.exe 
C:\WINDOWS\system32\cmd.exe /C "cd . && C:\src\vcpkg\downloads\tools\cmake-3.29.2-windows\cmake-3.29.2-windows-i386\bin\cmake.exe -E vs_link_exe --intdir=src\CMakeFiles\curl.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100220~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1435~1.322\bin\Hostx64\x64\link.exe  src\CMakeFiles\curl.dir\slist_wc.c.obj src\CMakeFiles\curl.dir\tool_binmode.c.obj src\CMakeFiles\curl.dir\tool_bname.c.obj src\CMakeFiles\curl.dir\tool_cb_dbg.c.obj src\CMakeFiles\curl.dir\tool_cb_hdr.c.obj src\CMakeFiles\curl.dir\tool_cb_prg.c.obj src\CMakeFiles\curl.dir\tool_cb_rea.c.obj src\CMakeFiles\curl.dir\tool_cb_see.c.obj src\CMakeFiles\curl.dir\tool_cb_wrt.c.obj src\CMakeFiles\curl.dir\tool_cfgable.c.obj src\CMakeFiles\curl.dir\tool_dirhie.c.obj src\CMakeFiles\curl.dir\tool_doswin.c.obj src\CMakeFiles\curl.dir\tool_easysrc.c.obj src\CMakeFiles\curl.dir\tool_filetime.c.obj src\CMakeFiles\curl.dir\tool_findfile.c.obj src\CMakeFiles\curl.dir\tool_formparse.c.obj src\CMakeFiles\curl.dir\tool_getparam.c.obj src\CMakeFiles\curl.dir\tool_getpass.c.obj src\CMakeFiles\curl.dir\tool_help.c.obj src\CMakeFiles\curl.dir\tool_helpers.c.obj src\CMakeFiles\curl.dir\tool_hugehelp.c.obj src\CMakeFiles\curl.dir\tool_ipfs.c.obj src\CMakeFiles\curl.dir\tool_libinfo.c.obj src\CMakeFiles\curl.dir\tool_listhelp.c.obj src\CMakeFiles\curl.dir\tool_main.c.obj src\CMakeFiles\curl.dir\tool_msgs.c.obj src\CMakeFiles\curl.dir\tool_operate.c.obj src\CMakeFiles\curl.dir\tool_operhlp.c.obj src\CMakeFiles\curl.dir\tool_paramhlp.c.obj src\CMakeFiles\curl.dir\tool_parsecfg.c.obj src\CMakeFiles\curl.dir\tool_progress.c.obj src\CMakeFiles\curl.dir\tool_setopt.c.obj src\CMakeFiles\curl.dir\tool_sleep.c.obj src\CMakeFiles\curl.dir\tool_stderr.c.obj src\CMakeFiles\curl.dir\tool_strdup.c.obj src\CMakeFiles\curl.dir\tool_urlglob.c.obj src\CMakeFiles\curl.dir\tool_util.c.obj src\CMakeFiles\curl.dir\tool_vms.c.obj src\CMakeFiles\curl.dir\tool_writeout.c.obj src\CMakeFiles\curl.dir\tool_writeout_json.c.obj src\CMakeFiles\curl.dir\tool_xattr.c.obj src\CMakeFiles\curl.dir\var.c.obj src\CMakeFiles\curl.dir\curl.rc.res src\CMakeFiles\curl.dir\__\lib\base64.c.obj src\CMakeFiles\curl.dir\__\lib\dynbuf.c.obj  /out:src\curl.exe /implib:src\curl.lib /pdb:src\curl.pdb /version:0.0 /machine:x64 /MANIFEST:NO /nologo    /debug /INCREMENTAL /subsystem:console  lib\libcurl-d.lib  ws2_32.lib  bcrypt.lib  C:\src\vcpkg\installed\x64-windows-static\debug\lib\zlibd.lib  C:\src\vcpkg\installed\x64-windows-static\debug\lib\psl.lib  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\WS2_32.Lib"  C:\src\vcpkg\installed\x64-windows-static\debug\lib\icuucd.lib  C:\src\vcpkg\installed\x64-windows-static\debug\lib\icudtd.lib  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\kernel32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\User32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\Gdi32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\WinSpool.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\shell32.lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\Ole32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\OleAut32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\ComDlg32.Lib"  "C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\AdvAPI32.Lib"  advapi32.lib  crypt32.lib  kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib && cd ."
LINK: command "C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1435~1.322\bin\Hostx64\x64\link.exe src\CMakeFiles\curl.dir\slist_wc.c.obj src\CMakeFiles\curl.dir\tool_binmode.c.obj src\CMakeFiles\curl.dir\tool_bname.c.obj src\CMakeFiles\curl.dir\tool_cb_dbg.c.obj src\CMakeFiles\curl.dir\tool_cb_hdr.c.obj src\CMakeFiles\curl.dir\tool_cb_prg.c.obj src\CMakeFiles\curl.dir\tool_cb_rea.c.obj src\CMakeFiles\curl.dir\tool_cb_see.c.obj src\CMakeFiles\curl.dir\tool_cb_wrt.c.obj src\CMakeFiles\curl.dir\tool_cfgable.c.obj src\CMakeFiles\curl.dir\tool_dirhie.c.obj src\CMakeFiles\curl.dir\tool_doswin.c.obj src\CMakeFiles\curl.dir\tool_easysrc.c.obj src\CMakeFiles\curl.dir\tool_filetime.c.obj src\CMakeFiles\curl.dir\tool_findfile.c.obj src\CMakeFiles\curl.dir\tool_formparse.c.obj src\CMakeFiles\curl.dir\tool_getparam.c.obj src\CMakeFiles\curl.dir\tool_getpass.c.obj src\CMakeFiles\curl.dir\tool_help.c.obj src\CMakeFiles\curl.dir\tool_helpers.c.obj src\CMakeFiles\curl.dir\tool_hugehelp.c.obj src\CMakeFiles\curl.dir\tool_ipfs.c.obj src\CMakeFiles\curl.dir\tool_libinfo.c.obj src\CMakeFiles\curl.dir\tool_listhelp.c.obj src\CMakeFiles\curl.dir\tool_main.c.obj src\CMakeFiles\curl.dir\tool_msgs.c.obj src\CMakeFiles\curl.dir\tool_operate.c.obj src\CMakeFiles\curl.dir\tool_operhlp.c.obj src\CMakeFiles\curl.dir\tool_paramhlp.c.obj src\CMakeFiles\curl.dir\tool_parsecfg.c.obj src\CMakeFiles\curl.dir\tool_progress.c.obj src\CMakeFiles\curl.dir\tool_setopt.c.obj src\CMakeFiles\curl.dir\tool_sleep.c.obj src\CMakeFiles\curl.dir\tool_stderr.c.obj src\CMakeFiles\curl.dir\tool_strdup.c.obj src\CMakeFiles\curl.dir\tool_urlglob.c.obj src\CMakeFiles\curl.dir\tool_util.c.obj src\CMakeFiles\curl.dir\tool_vms.c.obj src\CMakeFiles\curl.dir\tool_writeout.c.obj src\CMakeFiles\curl.dir\tool_writeout_json.c.obj src\CMakeFiles\curl.dir\tool_xattr.c.obj src\CMakeFiles\curl.dir\var.c.obj src\CMakeFiles\curl.dir\curl.rc.res src\CMakeFiles\curl.dir\__\lib\base64.c.obj src\CMakeFiles\curl.dir\__\lib\dynbuf.c.obj /out:src\curl.exe /implib:src\curl.lib /pdb:src\curl.pdb /version:0.0 /machine:x64 /MANIFEST:NO /nologo /debug /INCREMENTAL /subsystem:console lib\libcurl-d.lib ws2_32.lib bcrypt.lib C:\src\vcpkg\installed\x64-windows-static\debug\lib\zlibd.lib C:\src\vcpkg\installed\x64-windows-static\debug\lib\psl.lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\WS2_32.Lib C:\src\vcpkg\installed\x64-windows-static\debug\lib\icuucd.lib C:\src\vcpkg\installed\x64-windows-static\debug\lib\icudtd.lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\kernel32.Lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\User32.Lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\Gdi32.Lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\WinSpool.Lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\shell32.lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\Ole32.Lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\OleAut32.Lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\ComDlg32.Lib C:\Program Files (x86)\Windows Kits\10\Lib\10.0.22000.0\um\x64\AdvAPI32.Lib advapi32.lib crypt32.lib kernel32.lib user32.lib gdi32.lib winspool.lib shell32.lib ole32.lib oleaut32.lib uuid.lib comdlg32.lib advapi32.lib" failed (exit code 1120) with the following output:
libcurl-d.lib(version.c.obj) : error LNK2019: unresolved external symbol __imp_psl_check_version_number referenced in function curl_version
libcurl-d.lib(cookie.c.obj) : error LNK2019: unresolved external symbol __imp_psl_is_cookie_domain_acceptable referenced in function Curl_cookie_add
libcurl-d.lib(psl.c.obj) : error LNK2019: unresolved external symbol __imp_psl_free referenced in function Curl_psl_destroy
libcurl-d.lib(psl.c.obj) : error LNK2019: unresolved external symbol __imp_psl_builtin referenced in function Curl_psl_use
libcurl-d.lib(psl.c.obj) : error LNK2019: unresolved external symbol __imp_psl_latest referenced in function Curl_psl_use

src\curl.exe : fatal error LNK1120: 5 unresolved externals

ninja: build stopped: subcommand failed.
```

