### PR TITLE
cmake: set `ENABLE_DEBUG=ON` by default for `Debug` builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,9 @@ cmake_dependent_option(ENABLE_THREADED_RESOLVER "Set to ON to enable threaded DN
         ON "NOT ENABLE_ARES"
         OFF)
 
-option(ENABLE_DEBUG "Set to ON to enable curl debug features" OFF)
+cmake_dependent_option(ENABLE_DEBUG "Set to ON to enable curl debug features"
+                       ON "CMAKE_BUILD_TYPE STREQUAL Debug"
+                       OFF)
 option(ENABLE_CURLDEBUG "Set to ON to build with TrackMemory feature enabled" OFF)
 
 include(PickyWarnings)


### PR DESCRIPTION
When `CMAKE_BUILD_TYPE` is set to `Debug`, enable curl debug features
by default. We do this to more closely match how autotools builds
work, where `--enable-debug` enables both compiler debug feature and
curl ones.

You can override this by explicitly setting `ENABLE_DEBUG=OFF` and
disable curl debug feature while leaving compiler debug enabled.

Ref: https://github.com/curl/curl/pull/13592#issuecomment-2119876734
Closes #13717

---

/cc @jay 
