### PR TITLE
curl_setup.h: add support for IAR compiler

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -291,8 +291,9 @@
 
 /* based on logic in "curl/mprintf.h" */
 
-#if (defined(__GNUC__) || defined(__clang__) || defined(__IAR_SYSTEMS_ICC__)) &&    \
-  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&                     \
+#if (defined(__GNUC__) || defined(__clang__) ||                         \
+  defined(__IAR_SYSTEMS_ICC__)) &&                                      \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__) && !defined(__clang__)
 #define CURL_PRINTF(fmt, arg) \
@@ -721,7 +722,8 @@
 /* noreturn attribute */
 
 #if !defined(CURL_NORETURN)
-#if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__clang__) || defined(__IAR_SYSTEMS_ICC__)
+#if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__clang__) || \
+  defined(__IAR_SYSTEMS_ICC__)
 #  define CURL_NORETURN  __attribute__((__noreturn__))
 #elif defined(_MSC_VER) && (_MSC_VER >= 1200)
 #  define CURL_NORETURN  __declspec(noreturn)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -291,8 +291,8 @@
 
 /* based on logic in "curl/mprintf.h" */
 
-#if (defined(__GNUC__) || defined(__clang__)) &&                        \
-  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
+#if (defined(__GNUC__) || defined(__clang__) || defined(__IAR_SYSTEMS_ICC__)) &&    \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&                     \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__) && !defined(__clang__)
 #define CURL_PRINTF(fmt, arg) \
@@ -706,6 +706,13 @@
   ((__GNUC__ == 2) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 7)))
 #  define UNUSED_PARAM __attribute__((__unused__))
 #  define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#elif defined(__IAR_SYSTEMS_ICC__)
+#  define UNUSED_PARAM __attribute__((__unused__))
+#  if (__VER__ >= 9040001)
+#    define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#  else
+#    define WARN_UNUSED_RESULT
+#  endif
 #else
 #  define UNUSED_PARAM /* NOTHING */
 #  define WARN_UNUSED_RESULT
@@ -714,7 +721,7 @@
 /* noreturn attribute */
 
 #if !defined(CURL_NORETURN)
-#if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__clang__)
+#if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__clang__) || defined(__IAR_SYSTEMS_ICC__)
 #  define CURL_NORETURN  __attribute__((__noreturn__))
 #elif defined(_MSC_VER) && (_MSC_VER >= 1200)
 #  define CURL_NORETURN  __declspec(noreturn)


### PR DESCRIPTION
Enable some supported GCC attributes for IAR compiler.