### PR TITLE
hash: delete unused debug function

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -192,25 +192,6 @@ Curl_hash_pick(struct Curl_hash *h, void *key, size_t key_len)
   return NULL;
 }
 
-#if defined(DEBUGBUILD) && defined(AGGRESSIVE_TEST)
-void
-Curl_hash_apply(Curl_hash *h, void *user,
-                void (*cb)(void *user, void *ptr))
-{
-  struct Curl_llist_element  *le;
-  size_t i;
-
-  for(i = 0; i < h->slots; ++i) {
-    for(le = (h->table[i])->head;
-        le;
-        le = le->next) {
-      Curl_hash_element *el = le->ptr;
-      cb(user, el->ptr);
-    }
-  }
-}
-#endif
-
 /* Destroys all the entries in the given hash and resets its attributes,
  * prepping the given hash for [static|dynamic] deallocation.
  *

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -80,8 +80,6 @@ void Curl_hash_init(struct Curl_hash *h,
 void *Curl_hash_add(struct Curl_hash *h, void *key, size_t key_len, void *p);
 int Curl_hash_delete(struct Curl_hash *h, void *key, size_t key_len);
 void *Curl_hash_pick(struct Curl_hash *, void *key, size_t key_len);
-void Curl_hash_apply(struct Curl_hash *h, void *user,
-                     void (*cb)(void *user, void *ptr));
 #define Curl_hash_count(h) ((h)->size)
 void Curl_hash_destroy(struct Curl_hash *h);
 void Curl_hash_clean(struct Curl_hash *h);


### PR DESCRIPTION
It had no use in the curl codebase and was also protected by the macro
`AGGRESSIVE_TEST` (renamed in 2020), also with no local reference.

Added in ca6e77083768858aa34207f8c5dce38b3c05336d (2002-11-11)

Closes #13729

---

If we still need this function, this PR should be converted to guard the 
declaration with the macros used for definition.