### PR TITLE
HEAD response body tolerance

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1716,6 +1716,15 @@ static ssize_t http2_handle_stream_close(struct Curl_cfilter *cf,
     return -1;
   }
   else if(stream->error != NGHTTP2_NO_ERROR) {
+    if(stream->resp_hds_complete && data->req.no_body) {
+      CURL_TRC_CF(data, cf, "[%d] error after response headers, but we did "
+                  "not want a body anyway, ignore: %s (err %u)",
+                  stream->id, nghttp2_http2_strerror(stream->error),
+                  stream->error);
+      stream->close_handled = TRUE;
+      *err = CURLE_OK;
+      goto out;
+    }
     failf(data, "HTTP/2 stream %u was not closed cleanly: %s (err %u)",
           stream->id, nghttp2_http2_strerror(stream->error),
           stream->error);


### PR DESCRIPTION
- as reported in #13725, some servers wrongly send body bytes in responses to a HEAD request. This used to be tolerated in curl 8.4 and before and leads to failed transfers in newer versions.
- restore previous behaviour for HTTP/1.1 and HTTP/2:
  * 1.1: do not add 'Transfer-Encoding' writers from HEAD responses. RFC 9112 says they do not apply.
  * 2: when the transfer expects 'no_body', to not report stream resets as error when all response headers have been received.