### PR TITLE
pytest, add ftp upload tests

### DIFF
--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -67,6 +67,9 @@ class TestVsFTPD:
         self._make_docs_file(docs_dir=vsftpd.docs_dir, fname='data-10k', fsize=10*1024)
         self._make_docs_file(docs_dir=vsftpd.docs_dir, fname='data-1m', fsize=1024*1024)
         self._make_docs_file(docs_dir=vsftpd.docs_dir, fname='data-10m', fsize=10*1024*1024)
+        env.make_data_file(indir=env.gen_dir, fname="upload-1k", fsize=1024)
+        env.make_data_file(indir=env.gen_dir, fname="upload-100k", fsize=100*1024)
+        env.make_data_file(indir=env.gen_dir, fname="upload-1m", fsize=1024*1024)
 
     def test_30_01_list_dir(self, env: Env, vsftpd: VsFTPD, repeat):
         curl = CurlClient(env=env)

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -579,6 +579,37 @@ class CurlClient:
                             with_profile=with_profile, no_save=no_save,
                             extra_args=extra_args)
 
+    def ftp_upload(self, urls: List[str], fupload,
+                   with_stats: bool = True,
+                   with_profile: bool = False,
+                   extra_args: List[str] = None):
+        if extra_args is None:
+            extra_args = []
+        extra_args.extend([
+            '--upload-file', fupload
+        ])
+        if with_stats:
+            extra_args.extend([
+                '-w', '%{json}\\n'
+            ])
+        return self._raw(urls, options=extra_args,
+                         with_stats=with_stats,
+                         with_headers=False,
+                         with_profile=with_profile)
+
+    def ftp_ssl_upload(self, urls: List[str], fupload,
+                       with_stats: bool = True,
+                       with_profile: bool = False,
+                       extra_args: List[str] = None):
+        if extra_args is None:
+            extra_args = []
+        extra_args.extend([
+            '--ssl-reqd',
+        ])
+        return self.ftp_upload(urls=urls, fupload=fupload,
+                               with_stats=with_stats, with_profile=with_profile,
+                               extra_args=extra_args)
+
     def response_file(self, idx: int):
         return os.path.join(self._run_dir, f'download_{idx}.data')
 

--- a/tests/http/testenv/vsftpd.py
+++ b/tests/http/testenv/vsftpd.py
@@ -194,14 +194,15 @@ class VsFTPD:
             f'anon_upload_enable=YES',
             f'log_ftp_protocol=YES',
             f'xferlog_enable=YES',
-            f'xferlog_std_format=YES',
-            f'xferlog_file={self._error_log}',
+            f'xferlog_std_format=NO',
+            f'vsftpd_log_file={self._error_log}',
             f'\n',
         ]
         if self._with_ssl:
             creds = self.env.get_credentials(self.domain)
             conf.extend([
                 f'ssl_enable=YES',
+                f'debug_ssl=YES',
                 f'allow_anon_ssl=YES',
                 f'rsa_cert_file={creds.cert_file}',
                 f'rsa_private_key_file={creds.pkey_file}',

--- a/tests/http/testenv/vsftpd.py
+++ b/tests/http/testenv/vsftpd.py
@@ -190,6 +190,8 @@ class VsFTPD:
             f'anonymous_enable=YES',
             f'anon_root={self._docs_dir}',
             f'dirmessage_enable=YES',
+            f'write_enable=YES',
+            f'anon_upload_enable=YES',
             f'log_ftp_protocol=YES',
             f'xferlog_enable=YES',
             f'xferlog_std_format=YES',


### PR DESCRIPTION
- refs #13556
- allow anon uploads on vsftpd test server
- add test_30_05 for plain upload of 1k, 100k, 1m
- add test_31_05 for SSL upload of 1k, 100k, 1m
- verify file size and contents