### PR TITLE
test1546, chunked not last transfer encoding

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -994,6 +994,8 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
       const struct Curl_cwtype *cwt;
       struct Curl_cwriter *writer;
 
+      CURL_TRC_WRITE(data, "looking for %s decoder: %.*s",
+                     is_transfer? "transfer" : "content", (int)namelen, name);
       is_chunked = (is_transfer && (namelen == 7) &&
                     strncasecompare(name, "chunked", 7));
       /* if we skip the decoding in this phase, do not look further.
@@ -1001,6 +1003,8 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
       if((is_transfer && !data->set.http_transfer_encoding && !is_chunked) ||
          (!is_transfer && data->set.http_ce_skip)) {
         /* not requested, ignore */
+        CURL_TRC_WRITE(data, "decoder not requested, ignored: %.*s",
+                       (int)namelen, name);
         return CURLE_OK;
       }
 
@@ -1018,6 +1022,7 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
          * "A sender MUST NOT apply the chunked transfer coding more than
          *  once to a message body."
          */
+        CURL_TRC_WRITE(data, "ignoring duplicate 'chunked' decoder");
         return CURLE_OK;
       }
 
@@ -1040,6 +1045,8 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
         cwt = &error_writer;  /* Defer error at use. */
 
       result = Curl_cwriter_create(&writer, data, cwt, phase);
+      CURL_TRC_WRITE(data, "added %s decoder %s -> %d",
+                     is_transfer? "transfer" : "content", cwt->name, result);
       if(result)
         return result;
 

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -195,7 +195,7 @@ test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \
 test1516 test1517 test1518 test1519 test1520 test1521 test1522 test1523 \
 test1524 test1525 test1526 test1527 test1528 test1529 test1530 test1531 \
 test1532 test1533 test1534 test1535 test1536 test1537 test1538 test1539 \
-test1540 test1541 test1542 test1543 test1544 test1545 \
+test1540 test1541 test1542 test1543 test1544 test1545 test1546 \
 \
 test1550 test1551 test1552 test1553 test1554 test1555 test1556 test1557 \
 test1558 test1559 test1560 test1561 test1562 test1563 test1564 test1565 \

--- a/tests/data/test1546
+++ b/tests/data/test1546
@@ -1,0 +1,63 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+Transfer-Encoding
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Mon, 29 Nov 2004 21:56:53 GMT
+Server: Apache
+Transfer-Encoding: chunked, gzip
+
+0
+
+</data>
+
+<datacheck>
+HTTP/1.1 200 OK
+Date: Mon, 29 Nov 2004 21:56:53 GMT
+Server: Apache
+</datacheck>
+
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+libz
+</features>
+<server>
+http
+</server>
+<name>
+HTTP transfer-encoding wrong order
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --tr-encoding
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Connection: TE
+TE: gzip
+
+</protocol>
+<errorcode>
+61
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
- with more than one transfer-encoding, 'chunked' must be the last added to the writer stack (and therefore the first to decode). RFC 9112, ch. 6.1.