### PR TITLE
cmake: fix building with both md4 and md5 in unity mode

### DIFF
--- a/lib/md4.c
+++ b/lib/md4.c
@@ -277,14 +277,14 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx);
  * F and G are optimized compared to their RFC 1320 definitions, with the
  * optimization for F borrowed from Colin Plumb's MD5 implementation.
  */
-#define F(x, y, z)                      ((z) ^ ((x) & ((y) ^ (z))))
-#define G(x, y, z)                      (((x) & ((y) | (z))) | ((y) & (z)))
-#define H(x, y, z)                      ((x) ^ (y) ^ (z))
+#define MD4_F(x, y, z)                  ((z) ^ ((x) & ((y) ^ (z))))
+#define MD4_G(x, y, z)                  (((x) & ((y) | (z))) | ((y) & (z)))
+#define MD4_H(x, y, z)                  ((x) ^ (y) ^ (z))
 
 /*
  * The MD4 transformation for all three rounds.
  */
-#define STEP(f, a, b, c, d, x, s) \
+#define MD4_STEP(f, a, b, c, d, x, s) \
         (a) += f((b), (c), (d)) + (x); \
         (a) = (((a) << (s)) | (((a) & 0xffffffff) >> (32 - (s))));
 
@@ -297,18 +297,18 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx);
  * doesn't work.
  */
 #if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
-#define SET(n) \
+#define MD4_SET(n) \
         (*(MD4_u32plus *)(void *)&ptr[(n) * 4])
-#define GET(n) \
-        SET(n)
+#define MD4_GET(n) \
+        MD4_SET(n)
 #else
-#define SET(n) \
+#define MD4_SET(n) \
         (ctx->block[(n)] = \
         (MD4_u32plus)ptr[(n) * 4] | \
         ((MD4_u32plus)ptr[(n) * 4 + 1] << 8) | \
         ((MD4_u32plus)ptr[(n) * 4 + 2] << 16) | \
         ((MD4_u32plus)ptr[(n) * 4 + 3] << 24))
-#define GET(n) \
+#define MD4_GET(n) \
         (ctx->block[(n)])
 #endif
 
@@ -316,7 +316,7 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx);
  * This processes one or more 64-byte data blocks, but does NOT update
  * the bit counters.  There are no alignment requirements.
  */
-static const void *body(MD4_CTX *ctx, const void *data, unsigned long size)
+static const void *my_md4_body(MD4_CTX *ctx, const void *data, unsigned long size)
 {
   const unsigned char *ptr;
   MD4_u32plus a, b, c, d;
@@ -337,58 +337,58 @@ static const void *body(MD4_CTX *ctx, const void *data, unsigned long size)
     saved_d = d;
 
 /* Round 1 */
-    STEP(F, a, b, c, d, SET(0), 3)
-    STEP(F, d, a, b, c, SET(1), 7)
-    STEP(F, c, d, a, b, SET(2), 11)
-    STEP(F, b, c, d, a, SET(3), 19)
-    STEP(F, a, b, c, d, SET(4), 3)
-    STEP(F, d, a, b, c, SET(5), 7)
-    STEP(F, c, d, a, b, SET(6), 11)
-    STEP(F, b, c, d, a, SET(7), 19)
-    STEP(F, a, b, c, d, SET(8), 3)
-    STEP(F, d, a, b, c, SET(9), 7)
-    STEP(F, c, d, a, b, SET(10), 11)
-    STEP(F, b, c, d, a, SET(11), 19)
-    STEP(F, a, b, c, d, SET(12), 3)
-    STEP(F, d, a, b, c, SET(13), 7)
-    STEP(F, c, d, a, b, SET(14), 11)
-    STEP(F, b, c, d, a, SET(15), 19)
+    MD4_STEP(MD4_F, a, b, c, d, MD4_SET(0), 3)
+    MD4_STEP(MD4_F, d, a, b, c, MD4_SET(1), 7)
+    MD4_STEP(MD4_F, c, d, a, b, MD4_SET(2), 11)
+    MD4_STEP(MD4_F, b, c, d, a, MD4_SET(3), 19)
+    MD4_STEP(MD4_F, a, b, c, d, MD4_SET(4), 3)
+    MD4_STEP(MD4_F, d, a, b, c, MD4_SET(5), 7)
+    MD4_STEP(MD4_F, c, d, a, b, MD4_SET(6), 11)
+    MD4_STEP(MD4_F, b, c, d, a, MD4_SET(7), 19)
+    MD4_STEP(MD4_F, a, b, c, d, MD4_SET(8), 3)
+    MD4_STEP(MD4_F, d, a, b, c, MD4_SET(9), 7)
+    MD4_STEP(MD4_F, c, d, a, b, MD4_SET(10), 11)
+    MD4_STEP(MD4_F, b, c, d, a, MD4_SET(11), 19)
+    MD4_STEP(MD4_F, a, b, c, d, MD4_SET(12), 3)
+    MD4_STEP(MD4_F, d, a, b, c, MD4_SET(13), 7)
+    MD4_STEP(MD4_F, c, d, a, b, MD4_SET(14), 11)
+    MD4_STEP(MD4_F, b, c, d, a, MD4_SET(15), 19)
 
 /* Round 2 */
-    STEP(G, a, b, c, d, GET(0) + 0x5a827999, 3)
-    STEP(G, d, a, b, c, GET(4) + 0x5a827999, 5)
-    STEP(G, c, d, a, b, GET(8) + 0x5a827999, 9)
-    STEP(G, b, c, d, a, GET(12) + 0x5a827999, 13)
-    STEP(G, a, b, c, d, GET(1) + 0x5a827999, 3)
-    STEP(G, d, a, b, c, GET(5) + 0x5a827999, 5)
-    STEP(G, c, d, a, b, GET(9) + 0x5a827999, 9)
-    STEP(G, b, c, d, a, GET(13) + 0x5a827999, 13)
-    STEP(G, a, b, c, d, GET(2) + 0x5a827999, 3)
-    STEP(G, d, a, b, c, GET(6) + 0x5a827999, 5)
-    STEP(G, c, d, a, b, GET(10) + 0x5a827999, 9)
-    STEP(G, b, c, d, a, GET(14) + 0x5a827999, 13)
-    STEP(G, a, b, c, d, GET(3) + 0x5a827999, 3)
-    STEP(G, d, a, b, c, GET(7) + 0x5a827999, 5)
-    STEP(G, c, d, a, b, GET(11) + 0x5a827999, 9)
-    STEP(G, b, c, d, a, GET(15) + 0x5a827999, 13)
+    MD4_STEP(MD4_G, a, b, c, d, MD4_GET(0) + 0x5a827999, 3)
+    MD4_STEP(MD4_G, d, a, b, c, MD4_GET(4) + 0x5a827999, 5)
+    MD4_STEP(MD4_G, c, d, a, b, MD4_GET(8) + 0x5a827999, 9)
+    MD4_STEP(MD4_G, b, c, d, a, MD4_GET(12) + 0x5a827999, 13)
+    MD4_STEP(MD4_G, a, b, c, d, MD4_GET(1) + 0x5a827999, 3)
+    MD4_STEP(MD4_G, d, a, b, c, MD4_GET(5) + 0x5a827999, 5)
+    MD4_STEP(MD4_G, c, d, a, b, MD4_GET(9) + 0x5a827999, 9)
+    MD4_STEP(MD4_G, b, c, d, a, MD4_GET(13) + 0x5a827999, 13)
+    MD4_STEP(MD4_G, a, b, c, d, MD4_GET(2) + 0x5a827999, 3)
+    MD4_STEP(MD4_G, d, a, b, c, MD4_GET(6) + 0x5a827999, 5)
+    MD4_STEP(MD4_G, c, d, a, b, MD4_GET(10) + 0x5a827999, 9)
+    MD4_STEP(MD4_G, b, c, d, a, MD4_GET(14) + 0x5a827999, 13)
+    MD4_STEP(MD4_G, a, b, c, d, MD4_GET(3) + 0x5a827999, 3)
+    MD4_STEP(MD4_G, d, a, b, c, MD4_GET(7) + 0x5a827999, 5)
+    MD4_STEP(MD4_G, c, d, a, b, MD4_GET(11) + 0x5a827999, 9)
+    MD4_STEP(MD4_G, b, c, d, a, MD4_GET(15) + 0x5a827999, 13)
 
 /* Round 3 */
-    STEP(H, a, b, c, d, GET(0) + 0x6ed9eba1, 3)
-    STEP(H, d, a, b, c, GET(8) + 0x6ed9eba1, 9)
-    STEP(H, c, d, a, b, GET(4) + 0x6ed9eba1, 11)
-    STEP(H, b, c, d, a, GET(12) + 0x6ed9eba1, 15)
-    STEP(H, a, b, c, d, GET(2) + 0x6ed9eba1, 3)
-    STEP(H, d, a, b, c, GET(10) + 0x6ed9eba1, 9)
-    STEP(H, c, d, a, b, GET(6) + 0x6ed9eba1, 11)
-    STEP(H, b, c, d, a, GET(14) + 0x6ed9eba1, 15)
-    STEP(H, a, b, c, d, GET(1) + 0x6ed9eba1, 3)
-    STEP(H, d, a, b, c, GET(9) + 0x6ed9eba1, 9)
-    STEP(H, c, d, a, b, GET(5) + 0x6ed9eba1, 11)
-    STEP(H, b, c, d, a, GET(13) + 0x6ed9eba1, 15)
-    STEP(H, a, b, c, d, GET(3) + 0x6ed9eba1, 3)
-    STEP(H, d, a, b, c, GET(11) + 0x6ed9eba1, 9)
-    STEP(H, c, d, a, b, GET(7) + 0x6ed9eba1, 11)
-    STEP(H, b, c, d, a, GET(15) + 0x6ed9eba1, 15)
+    MD4_STEP(MD4_H, a, b, c, d, MD4_GET(0) + 0x6ed9eba1, 3)
+    MD4_STEP(MD4_H, d, a, b, c, MD4_GET(8) + 0x6ed9eba1, 9)
+    MD4_STEP(MD4_H, c, d, a, b, MD4_GET(4) + 0x6ed9eba1, 11)
+    MD4_STEP(MD4_H, b, c, d, a, MD4_GET(12) + 0x6ed9eba1, 15)
+    MD4_STEP(MD4_H, a, b, c, d, MD4_GET(2) + 0x6ed9eba1, 3)
+    MD4_STEP(MD4_H, d, a, b, c, MD4_GET(10) + 0x6ed9eba1, 9)
+    MD4_STEP(MD4_H, c, d, a, b, MD4_GET(6) + 0x6ed9eba1, 11)
+    MD4_STEP(MD4_H, b, c, d, a, MD4_GET(14) + 0x6ed9eba1, 15)
+    MD4_STEP(MD4_H, a, b, c, d, MD4_GET(1) + 0x6ed9eba1, 3)
+    MD4_STEP(MD4_H, d, a, b, c, MD4_GET(9) + 0x6ed9eba1, 9)
+    MD4_STEP(MD4_H, c, d, a, b, MD4_GET(5) + 0x6ed9eba1, 11)
+    MD4_STEP(MD4_H, b, c, d, a, MD4_GET(13) + 0x6ed9eba1, 15)
+    MD4_STEP(MD4_H, a, b, c, d, MD4_GET(3) + 0x6ed9eba1, 3)
+    MD4_STEP(MD4_H, d, a, b, c, MD4_GET(11) + 0x6ed9eba1, 9)
+    MD4_STEP(MD4_H, c, d, a, b, MD4_GET(7) + 0x6ed9eba1, 11)
+    MD4_STEP(MD4_H, b, c, d, a, MD4_GET(15) + 0x6ed9eba1, 15)
 
     a += saved_a;
     b += saved_b;
@@ -442,11 +442,11 @@ static void MD4_Update(MD4_CTX *ctx, const void *data, unsigned long size)
     memcpy(&ctx->buffer[used], data, available);
     data = (const unsigned char *)data + available;
     size -= available;
-    body(ctx, ctx->buffer, 64);
+    my_md4_body(ctx, ctx->buffer, 64);
   }
 
   if(size >= 64) {
-    data = body(ctx, data, size & ~(unsigned long)0x3f);
+    data = my_md4_body(ctx, data, size & ~(unsigned long)0x3f);
     size &= 0x3f;
   }
 
@@ -465,7 +465,7 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
   if(available < 8) {
     memset(&ctx->buffer[used], 0, available);
-    body(ctx, ctx->buffer, 64);
+    my_md4_body(ctx, ctx->buffer, 64);
     used = 0;
     available = 64;
   }
@@ -482,7 +482,7 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
   ctx->buffer[62] = curlx_ultouc((ctx->hi >> 16)&0xff);
   ctx->buffer[63] = curlx_ultouc(ctx->hi >> 24);
 
-  body(ctx, ctx->buffer, 64);
+  my_md4_body(ctx, ctx->buffer, 64);
 
   result[0] = curlx_ultouc((ctx->a)&0xff);
   result[1] = curlx_ultouc((ctx->a >> 8)&0xff);

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -316,7 +316,8 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx);
  * This processes one or more 64-byte data blocks, but does NOT update
  * the bit counters.  There are no alignment requirements.
  */
-static const void *my_md4_body(MD4_CTX *ctx, const void *data, unsigned long size)
+static const void *my_md4_body(MD4_CTX *ctx,
+                               const void *data, unsigned long size)
 {
   const unsigned char *ptr;
   MD4_u32plus a, b, c, d;

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -346,7 +346,8 @@ static void my_md5_final(unsigned char *result, my_md5_ctx *ctx);
  * This processes one or more 64-byte data blocks, but does NOT update
  * the bit counters.  There are no alignment requirements.
  */
-static const void *my_md5_body(my_md5_ctx *ctx, const void *data, unsigned long size)
+static const void *my_md5_body(my_md5_ctx *ctx,
+                               const void *data, unsigned long size)
 {
   const unsigned char *ptr;
   MD5_u32plus a, b, c, d;

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -304,16 +304,16 @@ static void my_md5_final(unsigned char *result, my_md5_ctx *ctx);
  * architectures that lack an AND-NOT instruction, just like in Colin Plumb's
  * implementation.
  */
-#define F(x, y, z)                      ((z) ^ ((x) & ((y) ^ (z))))
-#define G(x, y, z)                      ((y) ^ ((z) & ((x) ^ (y))))
-#define H(x, y, z)                      (((x) ^ (y)) ^ (z))
-#define H2(x, y, z)                     ((x) ^ ((y) ^ (z)))
-#define I(x, y, z)                      ((y) ^ ((x) | ~(z)))
+#define MD5_F(x, y, z)                  ((z) ^ ((x) & ((y) ^ (z))))
+#define MD5_G(x, y, z)                  ((y) ^ ((z) & ((x) ^ (y))))
+#define MD5_H(x, y, z)                  (((x) ^ (y)) ^ (z))
+#define MD5_H2(x, y, z)                 ((x) ^ ((y) ^ (z)))
+#define MD5_I(x, y, z)                  ((y) ^ ((x) | ~(z)))
 
 /*
  * The MD5 transformation for all four rounds.
  */
-#define STEP(f, a, b, c, d, x, t, s) \
+#define MD5_STEP(f, a, b, c, d, x, t, s) \
         (a) += f((b), (c), (d)) + (x) + (t); \
         (a) = (((a) << (s)) | (((a) & 0xffffffff) >> (32 - (s)))); \
         (a) += (b);
@@ -327,18 +327,18 @@ static void my_md5_final(unsigned char *result, my_md5_ctx *ctx);
  * doesn't work.
  */
 #if defined(__i386__) || defined(__x86_64__) || defined(__vax__)
-#define SET(n) \
+#define MD5_SET(n) \
         (*(MD5_u32plus *)(void *)&ptr[(n) * 4])
-#define GET(n) \
-        SET(n)
+#define MD5_GET(n) \
+        MD5_SET(n)
 #else
-#define SET(n) \
+#define MD5_SET(n) \
         (ctx->block[(n)] = \
         (MD5_u32plus)ptr[(n) * 4] | \
         ((MD5_u32plus)ptr[(n) * 4 + 1] << 8) | \
         ((MD5_u32plus)ptr[(n) * 4 + 2] << 16) | \
         ((MD5_u32plus)ptr[(n) * 4 + 3] << 24))
-#define GET(n) \
+#define MD5_GET(n) \
         (ctx->block[(n)])
 #endif
 
@@ -346,7 +346,7 @@ static void my_md5_final(unsigned char *result, my_md5_ctx *ctx);
  * This processes one or more 64-byte data blocks, but does NOT update
  * the bit counters.  There are no alignment requirements.
  */
-static const void *body(my_md5_ctx *ctx, const void *data, unsigned long size)
+static const void *my_md5_body(my_md5_ctx *ctx, const void *data, unsigned long size)
 {
   const unsigned char *ptr;
   MD5_u32plus a, b, c, d;
@@ -367,76 +367,76 @@ static const void *body(my_md5_ctx *ctx, const void *data, unsigned long size)
     saved_d = d;
 
 /* Round 1 */
-    STEP(F, a, b, c, d, SET(0), 0xd76aa478, 7)
-    STEP(F, d, a, b, c, SET(1), 0xe8c7b756, 12)
-    STEP(F, c, d, a, b, SET(2), 0x242070db, 17)
-    STEP(F, b, c, d, a, SET(3), 0xc1bdceee, 22)
-    STEP(F, a, b, c, d, SET(4), 0xf57c0faf, 7)
-    STEP(F, d, a, b, c, SET(5), 0x4787c62a, 12)
-    STEP(F, c, d, a, b, SET(6), 0xa8304613, 17)
-    STEP(F, b, c, d, a, SET(7), 0xfd469501, 22)
-    STEP(F, a, b, c, d, SET(8), 0x698098d8, 7)
-    STEP(F, d, a, b, c, SET(9), 0x8b44f7af, 12)
-    STEP(F, c, d, a, b, SET(10), 0xffff5bb1, 17)
-    STEP(F, b, c, d, a, SET(11), 0x895cd7be, 22)
-    STEP(F, a, b, c, d, SET(12), 0x6b901122, 7)
-    STEP(F, d, a, b, c, SET(13), 0xfd987193, 12)
-    STEP(F, c, d, a, b, SET(14), 0xa679438e, 17)
-    STEP(F, b, c, d, a, SET(15), 0x49b40821, 22)
+    MD5_STEP(MD5_F, a, b, c, d, MD5_SET(0), 0xd76aa478, 7)
+    MD5_STEP(MD5_F, d, a, b, c, MD5_SET(1), 0xe8c7b756, 12)
+    MD5_STEP(MD5_F, c, d, a, b, MD5_SET(2), 0x242070db, 17)
+    MD5_STEP(MD5_F, b, c, d, a, MD5_SET(3), 0xc1bdceee, 22)
+    MD5_STEP(MD5_F, a, b, c, d, MD5_SET(4), 0xf57c0faf, 7)
+    MD5_STEP(MD5_F, d, a, b, c, MD5_SET(5), 0x4787c62a, 12)
+    MD5_STEP(MD5_F, c, d, a, b, MD5_SET(6), 0xa8304613, 17)
+    MD5_STEP(MD5_F, b, c, d, a, MD5_SET(7), 0xfd469501, 22)
+    MD5_STEP(MD5_F, a, b, c, d, MD5_SET(8), 0x698098d8, 7)
+    MD5_STEP(MD5_F, d, a, b, c, MD5_SET(9), 0x8b44f7af, 12)
+    MD5_STEP(MD5_F, c, d, a, b, MD5_SET(10), 0xffff5bb1, 17)
+    MD5_STEP(MD5_F, b, c, d, a, MD5_SET(11), 0x895cd7be, 22)
+    MD5_STEP(MD5_F, a, b, c, d, MD5_SET(12), 0x6b901122, 7)
+    MD5_STEP(MD5_F, d, a, b, c, MD5_SET(13), 0xfd987193, 12)
+    MD5_STEP(MD5_F, c, d, a, b, MD5_SET(14), 0xa679438e, 17)
+    MD5_STEP(MD5_F, b, c, d, a, MD5_SET(15), 0x49b40821, 22)
 
 /* Round 2 */
-    STEP(G, a, b, c, d, GET(1), 0xf61e2562, 5)
-    STEP(G, d, a, b, c, GET(6), 0xc040b340, 9)
-    STEP(G, c, d, a, b, GET(11), 0x265e5a51, 14)
-    STEP(G, b, c, d, a, GET(0), 0xe9b6c7aa, 20)
-    STEP(G, a, b, c, d, GET(5), 0xd62f105d, 5)
-    STEP(G, d, a, b, c, GET(10), 0x02441453, 9)
-    STEP(G, c, d, a, b, GET(15), 0xd8a1e681, 14)
-    STEP(G, b, c, d, a, GET(4), 0xe7d3fbc8, 20)
-    STEP(G, a, b, c, d, GET(9), 0x21e1cde6, 5)
-    STEP(G, d, a, b, c, GET(14), 0xc33707d6, 9)
-    STEP(G, c, d, a, b, GET(3), 0xf4d50d87, 14)
-    STEP(G, b, c, d, a, GET(8), 0x455a14ed, 20)
-    STEP(G, a, b, c, d, GET(13), 0xa9e3e905, 5)
-    STEP(G, d, a, b, c, GET(2), 0xfcefa3f8, 9)
-    STEP(G, c, d, a, b, GET(7), 0x676f02d9, 14)
-    STEP(G, b, c, d, a, GET(12), 0x8d2a4c8a, 20)
+    MD5_STEP(MD5_G, a, b, c, d, MD5_GET(1), 0xf61e2562, 5)
+    MD5_STEP(MD5_G, d, a, b, c, MD5_GET(6), 0xc040b340, 9)
+    MD5_STEP(MD5_G, c, d, a, b, MD5_GET(11), 0x265e5a51, 14)
+    MD5_STEP(MD5_G, b, c, d, a, MD5_GET(0), 0xe9b6c7aa, 20)
+    MD5_STEP(MD5_G, a, b, c, d, MD5_GET(5), 0xd62f105d, 5)
+    MD5_STEP(MD5_G, d, a, b, c, MD5_GET(10), 0x02441453, 9)
+    MD5_STEP(MD5_G, c, d, a, b, MD5_GET(15), 0xd8a1e681, 14)
+    MD5_STEP(MD5_G, b, c, d, a, MD5_GET(4), 0xe7d3fbc8, 20)
+    MD5_STEP(MD5_G, a, b, c, d, MD5_GET(9), 0x21e1cde6, 5)
+    MD5_STEP(MD5_G, d, a, b, c, MD5_GET(14), 0xc33707d6, 9)
+    MD5_STEP(MD5_G, c, d, a, b, MD5_GET(3), 0xf4d50d87, 14)
+    MD5_STEP(MD5_G, b, c, d, a, MD5_GET(8), 0x455a14ed, 20)
+    MD5_STEP(MD5_G, a, b, c, d, MD5_GET(13), 0xa9e3e905, 5)
+    MD5_STEP(MD5_G, d, a, b, c, MD5_GET(2), 0xfcefa3f8, 9)
+    MD5_STEP(MD5_G, c, d, a, b, MD5_GET(7), 0x676f02d9, 14)
+    MD5_STEP(MD5_G, b, c, d, a, MD5_GET(12), 0x8d2a4c8a, 20)
 
 /* Round 3 */
-    STEP(H, a, b, c, d, GET(5), 0xfffa3942, 4)
-    STEP(H2, d, a, b, c, GET(8), 0x8771f681, 11)
-    STEP(H, c, d, a, b, GET(11), 0x6d9d6122, 16)
-    STEP(H2, b, c, d, a, GET(14), 0xfde5380c, 23)
-    STEP(H, a, b, c, d, GET(1), 0xa4beea44, 4)
-    STEP(H2, d, a, b, c, GET(4), 0x4bdecfa9, 11)
-    STEP(H, c, d, a, b, GET(7), 0xf6bb4b60, 16)
-    STEP(H2, b, c, d, a, GET(10), 0xbebfbc70, 23)
-    STEP(H, a, b, c, d, GET(13), 0x289b7ec6, 4)
-    STEP(H2, d, a, b, c, GET(0), 0xeaa127fa, 11)
-    STEP(H, c, d, a, b, GET(3), 0xd4ef3085, 16)
-    STEP(H2, b, c, d, a, GET(6), 0x04881d05, 23)
-    STEP(H, a, b, c, d, GET(9), 0xd9d4d039, 4)
-    STEP(H2, d, a, b, c, GET(12), 0xe6db99e5, 11)
-    STEP(H, c, d, a, b, GET(15), 0x1fa27cf8, 16)
-    STEP(H2, b, c, d, a, GET(2), 0xc4ac5665, 23)
+    MD5_STEP(MD5_H, a, b, c, d, MD5_GET(5), 0xfffa3942, 4)
+    MD5_STEP(MD5_H2, d, a, b, c, MD5_GET(8), 0x8771f681, 11)
+    MD5_STEP(MD5_H, c, d, a, b, MD5_GET(11), 0x6d9d6122, 16)
+    MD5_STEP(MD5_H2, b, c, d, a, MD5_GET(14), 0xfde5380c, 23)
+    MD5_STEP(MD5_H, a, b, c, d, MD5_GET(1), 0xa4beea44, 4)
+    MD5_STEP(MD5_H2, d, a, b, c, MD5_GET(4), 0x4bdecfa9, 11)
+    MD5_STEP(MD5_H, c, d, a, b, MD5_GET(7), 0xf6bb4b60, 16)
+    MD5_STEP(MD5_H2, b, c, d, a, MD5_GET(10), 0xbebfbc70, 23)
+    MD5_STEP(MD5_H, a, b, c, d, MD5_GET(13), 0x289b7ec6, 4)
+    MD5_STEP(MD5_H2, d, a, b, c, MD5_GET(0), 0xeaa127fa, 11)
+    MD5_STEP(MD5_H, c, d, a, b, MD5_GET(3), 0xd4ef3085, 16)
+    MD5_STEP(MD5_H2, b, c, d, a, MD5_GET(6), 0x04881d05, 23)
+    MD5_STEP(MD5_H, a, b, c, d, MD5_GET(9), 0xd9d4d039, 4)
+    MD5_STEP(MD5_H2, d, a, b, c, MD5_GET(12), 0xe6db99e5, 11)
+    MD5_STEP(MD5_H, c, d, a, b, MD5_GET(15), 0x1fa27cf8, 16)
+    MD5_STEP(MD5_H2, b, c, d, a, MD5_GET(2), 0xc4ac5665, 23)
 
 /* Round 4 */
-    STEP(I, a, b, c, d, GET(0), 0xf4292244, 6)
-    STEP(I, d, a, b, c, GET(7), 0x432aff97, 10)
-    STEP(I, c, d, a, b, GET(14), 0xab9423a7, 15)
-    STEP(I, b, c, d, a, GET(5), 0xfc93a039, 21)
-    STEP(I, a, b, c, d, GET(12), 0x655b59c3, 6)
-    STEP(I, d, a, b, c, GET(3), 0x8f0ccc92, 10)
-    STEP(I, c, d, a, b, GET(10), 0xffeff47d, 15)
-    STEP(I, b, c, d, a, GET(1), 0x85845dd1, 21)
-    STEP(I, a, b, c, d, GET(8), 0x6fa87e4f, 6)
-    STEP(I, d, a, b, c, GET(15), 0xfe2ce6e0, 10)
-    STEP(I, c, d, a, b, GET(6), 0xa3014314, 15)
-    STEP(I, b, c, d, a, GET(13), 0x4e0811a1, 21)
-    STEP(I, a, b, c, d, GET(4), 0xf7537e82, 6)
-    STEP(I, d, a, b, c, GET(11), 0xbd3af235, 10)
-    STEP(I, c, d, a, b, GET(2), 0x2ad7d2bb, 15)
-    STEP(I, b, c, d, a, GET(9), 0xeb86d391, 21)
+    MD5_STEP(MD5_I, a, b, c, d, MD5_GET(0), 0xf4292244, 6)
+    MD5_STEP(MD5_I, d, a, b, c, MD5_GET(7), 0x432aff97, 10)
+    MD5_STEP(MD5_I, c, d, a, b, MD5_GET(14), 0xab9423a7, 15)
+    MD5_STEP(MD5_I, b, c, d, a, MD5_GET(5), 0xfc93a039, 21)
+    MD5_STEP(MD5_I, a, b, c, d, MD5_GET(12), 0x655b59c3, 6)
+    MD5_STEP(MD5_I, d, a, b, c, MD5_GET(3), 0x8f0ccc92, 10)
+    MD5_STEP(MD5_I, c, d, a, b, MD5_GET(10), 0xffeff47d, 15)
+    MD5_STEP(MD5_I, b, c, d, a, MD5_GET(1), 0x85845dd1, 21)
+    MD5_STEP(MD5_I, a, b, c, d, MD5_GET(8), 0x6fa87e4f, 6)
+    MD5_STEP(MD5_I, d, a, b, c, MD5_GET(15), 0xfe2ce6e0, 10)
+    MD5_STEP(MD5_I, c, d, a, b, MD5_GET(6), 0xa3014314, 15)
+    MD5_STEP(MD5_I, b, c, d, a, MD5_GET(13), 0x4e0811a1, 21)
+    MD5_STEP(MD5_I, a, b, c, d, MD5_GET(4), 0xf7537e82, 6)
+    MD5_STEP(MD5_I, d, a, b, c, MD5_GET(11), 0xbd3af235, 10)
+    MD5_STEP(MD5_I, c, d, a, b, MD5_GET(2), 0x2ad7d2bb, 15)
+    MD5_STEP(MD5_I, b, c, d, a, MD5_GET(9), 0xeb86d391, 21)
 
     a += saved_a;
     b += saved_b;
@@ -492,11 +492,11 @@ static void my_md5_update(my_md5_ctx *ctx, const void *data,
     memcpy(&ctx->buffer[used], data, available);
     data = (const unsigned char *)data + available;
     size -= available;
-    body(ctx, ctx->buffer, 64);
+    my_md5_body(ctx, ctx->buffer, 64);
   }
 
   if(size >= 64) {
-    data = body(ctx, data, size & ~(unsigned long)0x3f);
+    data = my_md5_body(ctx, data, size & ~(unsigned long)0x3f);
     size &= 0x3f;
   }
 
@@ -515,7 +515,7 @@ static void my_md5_final(unsigned char *result, my_md5_ctx *ctx)
 
   if(available < 8) {
     memset(&ctx->buffer[used], 0, available);
-    body(ctx, ctx->buffer, 64);
+    my_md5_body(ctx, ctx->buffer, 64);
     used = 0;
     available = 64;
   }
@@ -532,7 +532,7 @@ static void my_md5_final(unsigned char *result, my_md5_ctx *ctx)
   ctx->buffer[62] = curlx_ultouc((ctx->hi >> 16)&0xff);
   ctx->buffer[63] = curlx_ultouc(ctx->hi >> 24);
 
-  body(ctx, ctx->buffer, 64);
+  my_md5_body(ctx, ctx->buffer, 64);
 
   result[0] = curlx_ultouc((ctx->a)&0xff);
   result[1] = curlx_ultouc((ctx->a >> 8)&0xff);


### PR DESCRIPTION
Macro and static function names were colliding between
`lib/md4.c` and
`lib/md5.c`.

Fix it by namespacing these symbols.

Seen with a basic macOS build using these options:
`-DCMAKE_UNITY_BUILD=ON -DCURL_USE_SECTRANSP=ON`

Closes #13737
