### PR TITLE
Avoid using GetAddrInfoExW when impersonation is used

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -638,7 +638,8 @@ static bool init_resolve_thread(struct Curl_easy *data,
 
 #ifdef _WIN32
   if(Curl_isWindows8OrGreater && Curl_FreeAddrInfoExW &&
-     Curl_GetAddrInfoExCancel && Curl_GetAddrInfoExW) {
+     Curl_GetAddrInfoExCancel && Curl_GetAddrInfoExW &&
+     !Curl_win32_impersonating()) {
 #define MAX_NAME_LEN 256 /* max domain name is 253 chars */
 #define MAX_PORT_LEN 8
     WCHAR namebuf[MAX_NAME_LEN];

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -267,4 +267,14 @@ HMODULE Curl_load_library(LPCTSTR filename)
 #endif
 }
 
+bool Curl_win32_impersonating(void)
+{
+  HANDLE token = NULL;
+  if(OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, TRUE, &token)) {
+    CloseHandle(token);
+    return TRUE;
+  }
+  return FALSE;
+}
+
 #endif /* _WIN32 */

--- a/lib/system_win32.h
+++ b/lib/system_win32.h
@@ -68,6 +68,8 @@ extern FREEADDRINFOEXW_FN Curl_FreeAddrInfoExW;
 extern GETADDRINFOEXCANCEL_FN Curl_GetAddrInfoExCancel;
 extern GETADDRINFOEXW_FN Curl_GetAddrInfoExW;
 
+bool Curl_win32_impersonating(void);
+
 /* This is used to dynamically load DLLs */
 HMODULE Curl_load_library(LPCTSTR filename);
 #else  /* _WIN32 */


### PR DESCRIPTION
Multiple reports suggest that GetAddrInfoExW fails when impersonation is used. This PR checks if thread is impersonating and avoids using GetAddrInfoExW api.

fixes #13612