### PR TITLE
winbuild: fix PE version info debug flag

### DIFF
--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -428,13 +428,13 @@ CFGSET = true
 # CURL_XX macros are for the curl.exe command
 
 !IF "$(DEBUG)"=="yes"
-RC_FLAGS = /dDEBUGBUILD=1 /Fo $@ $(LIBCURL_SRC_DIR)\libcurl.rc
+RC_FLAGS = /d_DEBUG /Fo $@ $(LIBCURL_SRC_DIR)\libcurl.rc
 CURL_CC       = $(CC_DEBUG) $(RTLIB_DEBUG)
-CURL_RC_FLAGS = $(CURL_RC_FLAGS) /i../include /dDEBUGBUILD=1 /Fo $@ $(CURL_SRC_DIR)\curl.rc
+CURL_RC_FLAGS = $(CURL_RC_FLAGS) /i../include /d_DEBUG /Fo $@ $(CURL_SRC_DIR)\curl.rc
 !ELSE
-RC_FLAGS = /dDEBUGBUILD=0 /Fo $@ $(LIBCURL_SRC_DIR)\libcurl.rc
+RC_FLAGS = /Fo $@ $(LIBCURL_SRC_DIR)\libcurl.rc
 CURL_CC       = $(CC_NODEBUG) $(RTLIB)
-CURL_RC_FLAGS = $(CURL_RC_FLAGS) /i../include /dDEBUGBUILD=0 /Fo $@ $(CURL_SRC_DIR)\curl.rc
+CURL_RC_FLAGS = $(CURL_RC_FLAGS) /i../include /Fo $@ $(CURL_SRC_DIR)\curl.rc
 !ENDIF
 
 !IF "$(AS_DLL)" == "true"


### PR DESCRIPTION
- Only set PE file flag VS_FF_DEBUG if curl.exe and libcurl.dll were built with winbuild option DEBUG=yes which builds with debug info.

VS_FF_DEBUG is a PE flag (Portable Executable file flag - dll, exe, etc) that indicates the file contains or was built with debug info.

Prior to this change when winbuild was used to build curl, curl.exe and libcurl.dll always had VS_FF_DEBUG set, regardless of build option DEBUG=yes/no, due to some bad logic.

Closes #xxxx

---

The bad logic defined DEBUGBUILD=0 for resource file compilations that did not contain debug information. Those resource files then guarded the VS_FF_DEBUG flag with defined(DEBUGBUILD) which of course is defined even when DEBUGBUILD is 0. Even if that was fixed it still wouldn't make sense because winbuild doesn't define DEBUGBUILD for building curl or libcurl --only for building their respective resource files-- so I moved to defining and checking _DEBUG instead for resource file compilations.

caught while reviewing #13730 