### PR TITLE
cmake: fix building with both sha256 and sha512 in unity mode

### DIFF
--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -476,8 +476,8 @@ MHDx_sha512_256_transform(curl_uint64_t H[SHA512_256_HASH_SIZE_WORDS],
 
   /* 'Ch' and 'Maj' macro functions are defined with widely-used optimisation.
      See FIPS PUB 180-4 formulae 4.8, 4.9. */
-#define Ch(x,y,z)     ( (z) ^ ((x) & ((y) ^ (z))) )
-#define Maj(x,y,z)    ( ((x) & (y)) ^ ((z) & ((x) ^ (y))) )
+#define Sha512_Ch(x,y,z)     ( (z) ^ ((x) & ((y) ^ (z))) )
+#define Sha512_Maj(x,y,z)    ( ((x) & (y)) ^ ((z) & ((x) ^ (y))) )
 
   /* Four 'Sigma' macro functions.
      See FIPS PUB 180-4 formulae 4.10, 4.11, 4.12, 4.13. */
@@ -547,9 +547,9 @@ MHDx_sha512_256_transform(curl_uint64_t H[SHA512_256_HASH_SIZE_WORDS],
        * Note: 'wt' must be used exactly one time in this macro as macro for
        'wt' calculation may change other data as well every time when
        used. */
-#define SHA2STEP64(vA,vB,vC,vD,vE,vF,vG,vH,kt,wt) do {                  \
-      (vD) += ((vH) += SIG1 ((vE)) + Ch ((vE),(vF),(vG)) + (kt) + (wt)); \
-      (vH) += SIG0 ((vA)) + Maj ((vA),(vB),(vC)); } while (0)
+#define SHA2STEP64(vA,vB,vC,vD,vE,vF,vG,vH,kt,wt) do {                       \
+     (vD) += ((vH) += SIG1((vE)) + Sha512_Ch((vE),(vF),(vG)) + (kt) + (wt)); \
+     (vH) += SIG0((vA)) + Sha512_Maj((vA),(vB),(vC)); } while (0)
 
     /* One step of SHA-512/256 computation with working variables rotation,
        see FIPS PUB 180-4 section 6.4.2 step 3. This macro version reassigns

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -334,14 +334,14 @@ static const unsigned long K[64] = {
 #define RORc(x, y) \
 (((((unsigned long)(x) & 0xFFFFFFFFUL) >> (unsigned long)((y) & 31)) | \
    ((unsigned long)(x) << (unsigned long)(32 - ((y) & 31)))) & 0xFFFFFFFFUL)
-#define Ch(x,y,z)   (z ^ (x & (y ^ z)))
-#define Maj(x,y,z)  (((x | y) & z) | (x & y))
-#define S(x, n)     RORc((x), (n))
-#define R(x, n)     (((x)&0xFFFFFFFFUL)>>(n))
-#define Sigma0(x)   (S(x, 2) ^ S(x, 13) ^ S(x, 22))
-#define Sigma1(x)   (S(x, 6) ^ S(x, 11) ^ S(x, 25))
-#define Gamma0(x)   (S(x, 7) ^ S(x, 18) ^ R(x, 3))
-#define Gamma1(x)   (S(x, 17) ^ S(x, 19) ^ R(x, 10))
+#define Sha256_Ch(x,y,z)  (z ^ (x & (y ^ z)))
+#define Sha256_Maj(x,y,z) (((x | y) & z) | (x & y))
+#define Sha256_S(x, n)    RORc((x), (n))
+#define Sha256_R(x, n)    (((x)&0xFFFFFFFFUL)>>(n))
+#define Sigma0(x)         (Sha256_S(x, 2) ^ Sha256_S(x, 13) ^ Sha256_S(x, 22))
+#define Sigma1(x)         (Sha256_S(x, 6) ^ Sha256_S(x, 11) ^ Sha256_S(x, 25))
+#define Gamma0(x)         (Sha256_S(x, 7) ^ Sha256_S(x, 18) ^ Sha256_R(x, 3))
+#define Gamma1(x)         (Sha256_S(x, 17) ^ Sha256_S(x, 19) ^ Sha256_R(x, 10))
 
 /* Compress 512-bits */
 static int sha256_compress(struct sha256_state *md,
@@ -364,12 +364,12 @@ static int sha256_compress(struct sha256_state *md,
   }
 
   /* Compress */
-#define RND(a,b,c,d,e,f,g,h,i)                                          \
-  do {                                                                  \
-    unsigned long t0 = h + Sigma1(e) + Ch(e, f, g) + K[i] + W[i];       \
-    unsigned long t1 = Sigma0(a) + Maj(a, b, c);                        \
-    d += t0;                                                            \
-    h = t0 + t1;                                                        \
+#define RND(a,b,c,d,e,f,g,h,i)                                           \
+  do {                                                                   \
+    unsigned long t0 = h + Sigma1(e) + Sha256_Ch(e, f, g) + K[i] + W[i]; \
+    unsigned long t1 = Sigma0(a) + Sha256_Maj(a, b, c);                  \
+    d += t0;                                                             \
+    h = t0 + t1;                                                         \
   } while(0)
 
   for(i = 0; i < 64; ++i) {


### PR DESCRIPTION
+ `Ch` and `Maj` are also defined in curl_sha512_256.c.
 + Avoid defining short defines like `R`, `S`