### PR TITLE
GHA: increase timeout for Cygwin autotools build tests step

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: 'autotools build tests'
         if: ${{ matrix.build == 'automake' }}
-        timeout-minutes: 10
+        timeout-minutes: 14
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
           make -C bld -j3 -C tests V=1


### PR DESCRIPTION
Apparently 10 minutes are not (always) enough:
https://github.com/curl/curl/actions/runs/9197003907/job/25296439556#step:8:1936

Closes #13753