### PR TITLE
winsock, move sendbuf update into cf-socket.c

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -908,11 +908,6 @@ struct connectdata {
   CtxtHandle *sslContext;
 #endif
 
-#if defined(_WIN32) && defined(USE_WINSOCK)
-  struct curltime last_sndbuf_update;  /* last time readwrite_upload called
-                                          win_update_buffer_size */
-#endif
-
 #ifdef USE_GSASL
   struct gsasldata gsasl;
 #endif


### PR DESCRIPTION
- we updated the WINSOCK sendbuf in the transfer loop, but cf-socket.c seems a much better place.
- moving code and timestamp into the socket filter

I am not a Windows dev, hope this works as intended.