### PR TITLE
GHA: add three MSVC jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -382,3 +382,68 @@ jobs:
           fi
           ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
+
+  msvc:
+    name: 'msvc (${{ matrix.arch }}, ${{ matrix.plat }}, ${{ matrix.config }})'
+    runs-on: windows-latest
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - { arch: 'x64', plat: 'windows', tflags: '~1516 ~2301 ~2302 ~2303 ~2307', config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=ON  -DBUILD_SHARED_LIBS=OFF -DENABLE_UNICODE=ON ', type: 'Debug' }
+          - { arch: 'x64', plat: 'windows', tflags: '~1516 ~2301 ~2302 ~2303 ~2307', config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=OFF -DBUILD_SHARED_LIBS=OFF -DENABLE_UNICODE=OFF', type: 'Debug' }
+          - { arch: 'x64', plat: 'windows', tflags: '~1516 ~2301 ~2302 ~2303 ~2307', config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=OFF -DHTTP_ONLY=ON          -DENABLE_UNICODE=OFF', type: 'Debug' }
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - name: 'cmake configure'
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          archgen=${{ matrix.arch }}; [ "${archgen}" = 'x86' ] && archgen='Win32'
+          if [ '${{ matrix.plat }}' = 'uwp' ]; then
+            system='WindowsStore'
+            options='-DCMAKE_SYSTEM_VERSION=10.0'
+          else
+            system='Windows'
+          fi
+          [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
+          [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
+          cmake -B bld ${options} \
+            "-DCMAKE_SYSTEM_NAME=${system}" \
+            -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake \
+            "-DCMAKE_GENERATOR_PLATFORM=${archgen}" \
+            '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
+            -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
+            '-DCMAKE_UNITY_BUILD=${{ matrix.unity }}' \
+            "-DCMAKE_C_FLAGS=${cflags}" \
+            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
+            -DCMAKE_UNITY_BUILD=ON \
+            -DCURL_WERROR=ON \
+            -DBUILD_EXAMPLES=ON \
+            -DENABLE_WEBSOCKETS=ON \
+            ${{ matrix.config }}
+
+      - name: 'cmake build'
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          cmake --build bld --config '${{ matrix.type }}' --parallel 3
+          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
+          bld/src/curl.exe --disable --version
+
+      - name: 'cmake build tests'
+        if: ${{ matrix.tflags != 'skipall' }}
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
+
+      - name: 'cmake run tests'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        timeout-minutes: 30
+        shell: bash
+        run: |
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
+          cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -95,7 +95,7 @@ environment:
       HTTP_ONLY: 'OFF'
       TESTING: 'OFF'
       DISABLED_TESTS: ''
-    - job_name: 'CMake, VS2022, Debug, x64, Schannel, Static, Unicode'
+    - job_name: 'CMake, VS2022, Debug, x64, Schannel, Static, Unicode, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 17 2022'
@@ -104,9 +104,9 @@ environment:
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'ON'
       HTTP_ONLY: 'OFF'
-      TESTING: 'ON'
+      TESTING: 'OFF'
       DISABLED_TESTS: '!1139 !1501 !1177 !1477'
-    - job_name: 'CMake, VS2022, Debug, x64, no SSL, Static'
+    - job_name: 'CMake, VS2022, Debug, x64, no SSL, Static, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 17 2022'
@@ -115,9 +115,9 @@ environment:
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
-      TESTING: 'ON'
+      TESTING: 'OFF'
       DISABLED_TESTS: '!1139 !1501 !1177 !1477'
-    - job_name: 'CMake, VS2022, Debug, x64, no SSL, Static, HTTP only'
+    - job_name: 'CMake, VS2022, Debug, x64, no SSL, Static, HTTP only, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 17 2022'
@@ -126,7 +126,7 @@ environment:
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'ON'
-      TESTING: 'ON'
+      TESTING: 'OFF'
       DISABLED_TESTS: '!1139 !1501 !1177 !1477'
 
     # winbuild-based builds


### PR DESCRIPTION
Continuing the theme, add 3 MSVC jobs with tests, matching
configurations used on AppVeyor. MSVC versions are identical:
19.39.33523.0 + Windows SDK 10.0.22621.0.

Also enable websockets, and build examples. Tests are run in parallel
(`-j14`), with improved performance.

Job performance:
```
                                                       AppVeyor  GHA
                                                                 w/examples
                                                       --------  ----------
CMake, VS2022, Debug, x64, Schannel, Static, Unicode   38m 4s    11m57s
CMake, VS2022, Debug, x64, no SSL, Static              35m15s    12m 6s
CMake, VS2022, Debug, x64, no SSL, Static, HTTP only   25m25s    10m36s
```
Based on these runs:
https://ci.appveyor.com/project/curlorg/curl/builds/49884748
https://github.com/curl/curl/actions/runs/9229448468

This is the first time examples are built in CI with MSVC: Fix all
warnings and errors that came up via
d4b85890555388bec212b75f47a5c1a48705b156 #13771.

Closes #13766

---

- [x] Rebase once #13759 landed
- [x] Rebase once #13771 landed.
- [x] Disable tests for these jobs on AppVeyor.
