### PR TITLE
tests: use exec when spawning nghttpx

### DIFF
--- a/tests/http2-server.pl
+++ b/tests/http2-server.pl
@@ -116,4 +116,4 @@ my $cmdline="$nghttpx --backend=$connect ".
     "--errorlog-file=$logfile ".
     "$keyfile $certfile";
 print "RUN: $cmdline\n" if($verbose);
-system("$cmdline 2>/dev/null");
+exec("exec $cmdline 2>/dev/null");

--- a/tests/http3-server.pl
+++ b/tests/http3-server.pl
@@ -116,4 +116,4 @@ my $cmdline="$nghttpx --http2-proxy --backend=$connect ".
     "--conf=$conf ".
     "$keyfile $certfile";
 print "RUN: $cmdline\n" if($verbose);
-system("$cmdline 2>/dev/null");
+exec("exec $cmdline 2>/dev/null");


### PR DESCRIPTION
This eliminates keeping both perl and shell processes around that
are no longer needed, plus it eliminates an unneeded message from the
shell when the server is later terminated.

Closes #13772