### PR TITLE
docs/cmdline-opts: fix mail-auth example TLD typo

### DIFF
--- a/docs/cmdline-opts/mail-auth.md
+++ b/docs/cmdline-opts/mail-auth.md
@@ -12,7 +12,7 @@ See-also:
   - mail-rcpt
   - mail-from
 Example:
-  - --mail-auth user@example.come -T mail smtp://example.com/
+  - --mail-auth user@example.com -T mail smtp://example.com/
 ---
 
 # `--mail-auth`


### PR DESCRIPTION
This fixes a one-char typo in the docs' example use of `--mail-auth`.