### PR TITLE
examples: delete unused includes

### DIFF
--- a/docs/examples/10-at-a-time.c
+++ b/docs/examples/10-at-a-time.c
@@ -26,12 +26,8 @@
  * </DESC>
  */
 
-#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
-#ifndef _WIN32
-#  include <unistd.h>
-#endif
 #include <curl/curl.h>
 
 static const char *urls[] = {

--- a/docs/examples/cookie_interface.c
+++ b/docs/examples/cookie_interface.c
@@ -29,7 +29,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <errno.h>
 #include <time.h>
 
 #include <curl/curl.h>

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -30,12 +30,6 @@
 #include <string.h>
 #include <errno.h>
 
-/* somewhat unix-specific */
-#ifndef _WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
 /* curl stuff */
 #include <curl/curl.h>
 #include <curl/mprintf.h>

--- a/docs/examples/http2-pushinmemory.c
+++ b/docs/examples/http2-pushinmemory.c
@@ -29,12 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* somewhat unix-specific */
-#ifndef _WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
 /* curl stuff */
 #include <curl/curl.h>
 

--- a/docs/examples/http2-serverpush.c
+++ b/docs/examples/http2-serverpush.c
@@ -29,12 +29,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* somewhat unix-specific */
-#ifndef _WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
 /* curl stuff */
 #include <curl/curl.h>
 

--- a/docs/examples/multi-app.c
+++ b/docs/examples/multi-app.c
@@ -30,12 +30,6 @@
 #include <stdio.h>
 #include <string.h>
 
-/* somewhat unix-specific */
-#ifndef _WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
 /* curl stuff */
 #include <curl/curl.h>
 

--- a/docs/examples/multi-debugcallback.c
+++ b/docs/examples/multi-debugcallback.c
@@ -29,12 +29,6 @@
 #include <stdio.h>
 #include <string.h>
 
-/* somewhat unix-specific */
-#ifndef _WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
 /* curl stuff */
 #include <curl/curl.h>
 

--- a/docs/examples/multi-double.c
+++ b/docs/examples/multi-double.c
@@ -28,12 +28,6 @@
 #include <stdio.h>
 #include <string.h>
 
-/* somewhat unix-specific */
-#ifndef _WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
 /* curl stuff */
 #include <curl/curl.h>
 

--- a/docs/examples/multi-formadd.c
+++ b/docs/examples/multi-formadd.c
@@ -33,9 +33,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#ifndef _WIN32
-#include <sys/time.h>
-#endif
 
 #include <curl/curl.h>
 

--- a/docs/examples/multi-post.c
+++ b/docs/examples/multi-post.c
@@ -28,9 +28,6 @@
 
 #include <stdio.h>
 #include <string.h>
-#ifndef _WIN32
-#include <sys/time.h>
-#endif
 
 #include <curl/curl.h>
 

--- a/docs/examples/multi-single.c
+++ b/docs/examples/multi-single.c
@@ -29,12 +29,6 @@
 #include <stdio.h>
 #include <string.h>
 
-/* somewhat unix-specific */
-#ifndef _WIN32
-#include <sys/time.h>
-#include <unistd.h>
-#endif
-
 /* curl stuff */
 #include <curl/curl.h>
 

--- a/docs/examples/persistent.c
+++ b/docs/examples/persistent.c
@@ -26,9 +26,6 @@
  * </DESC>
  */
 #include <stdio.h>
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 
 #include <curl/curl.h>
 

--- a/docs/examples/sepheaders.c
+++ b/docs/examples/sepheaders.c
@@ -27,9 +27,6 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 
 #include <curl/curl.h>
 

--- a/docs/examples/url2file.c
+++ b/docs/examples/url2file.c
@@ -27,9 +27,6 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#ifndef _WIN32
-#include <unistd.h>
-#endif
 
 #include <curl/curl.h>
 

--- a/docs/examples/xmlstream.c
+++ b/docs/examples/xmlstream.c
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include <expat.h>
 #include <curl/curl.h>


### PR DESCRIPTION
Delete a bunch of unnecessary-looking headers from some examples. This
is known to be tricky on AIX (perhaps also in other less-tested envs).

Let me know if any of this looks incorrect or outright fails on some
systems.

Follow-up to d4b85890555388bec212b75f47a5c1a48705b156 #13771
Closes #13785
