### PR TITLE
wolfssl: support CA caching

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
@@ -14,6 +14,8 @@ Protocol:
   - TLS
 TLS-backend:
   - OpenSSL
+  - Schannel
+  - wolfSSL
 ---
 
 # NAME
@@ -31,16 +33,17 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_CA_CACHE_TIMEOUT, long age);
 # DESCRIPTION
 
 Pass a long, this sets the timeout in seconds. This tells libcurl the maximum
-time any cached certificate store it has in memory may be kept and reused for
-new connections. Once the timeout has expired, a subsequent fetch requiring a
-certificate has to reload it.
+time any cached CA certificate store it has in memory may be kept and reused
+for new connections. Once the timeout has expired, a subsequent fetch
+requiring a CA certificate has to reload it.
 
-Building a certificate store from a CURLOPT_CAINFO(3) file is a slow
-operation so curl may cache the generated certificate store internally to speed
-up future connections.
+Building a CA certificate store from a CURLOPT_CAINFO(3) file is a slow
+operation so curl may cache the generated certificate store internally to
+speed up future connections.
 
-Set to zero to completely disable caching, or set to -1 to retain the cached
-store remain forever. By default, libcurl caches this info for 24 hours.
+Set the timeout to zero to completely disable caching, or set to -1 to retain
+the cached store remain forever. By default, libcurl caches this info for 24
+hours.
 
 # DEFAULT
 
@@ -74,8 +77,8 @@ int main(void)
 
 This option was added in curl 7.87.0.
 
-This option is supported by OpenSSL and its forks (since 7.87.0) and Schannel
-(since 8.5.0).
+This option is supported by OpenSSL and its forks (since 7.87.0), Schannel
+(since 8.5.0) and wolfSSL (since 8.9.0).
 
 # RETURN VALUE
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -203,13 +203,17 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     data->set.dns_cache_timeout = (int)arg;
     break;
   case CURLOPT_CA_CACHE_TIMEOUT:
-    arg = va_arg(param, long);
-    if(arg < -1)
-      return CURLE_BAD_FUNCTION_ARGUMENT;
-    else if(arg > INT_MAX)
-      arg = INT_MAX;
+    if(Curl_ssl_supports(data, SSLSUPP_CA_CACHE)) {
+      arg = va_arg(param, long);
+      if(arg < -1)
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+      else if(arg > INT_MAX)
+        arg = INT_MAX;
 
-    data->set.general_ssl.ca_cache_timeout = (int)arg;
+      data->set.general_ssl.ca_cache_timeout = (int)arg;
+    }
+    else
+      return CURLE_NOT_BUILT_IN;
     break;
   case CURLOPT_DNS_USE_GLOBAL_CACHE:
     /* deprecated */

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2120,7 +2120,7 @@ static CURLcode tls_ctx_setup(struct Curl_cfilter *cf,
     return CURLE_FAILED_INIT;
   }
 #elif defined(USE_WOLFSSL)
-  if(ngtcp2_crypto_wolfssl_configure_client_context(ctx->ssl_ctx) != 0) {
+  if(ngtcp2_crypto_wolfssl_configure_client_context(ctx->wssl.ctx) != 0) {
     failf(data, "ngtcp2_crypto_wolfssl_configure_client_context failed");
     return CURLE_FAILED_INIT;
   }
@@ -2211,7 +2211,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
 #elif defined(USE_GNUTLS)
   ngtcp2_conn_set_tls_native_handle(ctx->qconn, ctx->tls.gtls.session);
 #else
-  ngtcp2_conn_set_tls_native_handle(ctx->qconn, ctx->tls.ssl);
+  ngtcp2_conn_set_tls_native_handle(ctx->qconn, ctx->tls.wssl.handle);
 #endif
 
   ngtcp2_ccerr_default(&ctx->last_error);

--- a/lib/vquic/vquic-tls.h
+++ b/lib/vquic/vquic-tls.h
@@ -31,14 +31,15 @@
 #if defined(USE_HTTP3) && \
   (defined(USE_OPENSSL) || defined(USE_GNUTLS) || defined(USE_WOLFSSL))
 
+#include "vtls/wolfssl.h"
+
 struct curl_tls_ctx {
 #ifdef USE_OPENSSL
   struct ossl_ctx ossl;
 #elif defined(USE_GNUTLS)
   struct gtls_ctx gtls;
 #elif defined(USE_WOLFSSL)
-  WOLFSSL_CTX *ssl_ctx;
-  WOLFSSL *ssl;
+  struct wolfssl_ctx wssl;
 #endif
 };
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2849,8 +2849,8 @@ typedef long ctx_option_t;
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L) /* 1.1.0 */
 static CURLcode
 ossl_set_ssl_version_min_max_legacy(ctx_option_t *ctx_options,
-                                       struct Curl_cfilter *cf,
-                                       struct Curl_easy *data)
+                                    struct Curl_cfilter *cf,
+                                    struct Curl_easy *data)
 {
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
   long ssl_version = conn_config->version;
@@ -5273,6 +5273,7 @@ const struct Curl_ssl Curl_ssl_openssl = {
 #ifdef USE_ECH
   SSLSUPP_ECH |
 #endif
+  SSLSUPP_CA_CACHE |
   SSLSUPP_HTTPS_PROXY,
 
   sizeof(struct ossl_ctx),

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2910,6 +2910,7 @@ const struct Curl_ssl Curl_ssl_schannel = {
 #endif
   SSLSUPP_PINNEDPUBKEY |
   SSLSUPP_TLS13_CIPHERSUITES |
+  SSLSUPP_CA_CACHE |
   SSLSUPP_HTTPS_PROXY,
 
   sizeof(struct schannel_ssl_backend_data),

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -453,7 +453,7 @@ static bool ssl_prefs_check(struct Curl_easy *data)
 }
 
 static struct ssl_connect_data *cf_ctx_new(struct Curl_easy *data,
-                                     const struct alpn_spec *alpn)
+                                           const struct alpn_spec *alpn)
 {
   struct ssl_connect_data *ctx;
 

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -38,6 +38,7 @@ struct Curl_ssl_session;
 #define SSLSUPP_TLS13_CIPHERSUITES (1<<5) /* supports TLS 1.3 ciphersuites */
 #define SSLSUPP_CAINFO_BLOB  (1<<6)
 #define SSLSUPP_ECH          (1<<7)
+#define SSLSUPP_CA_CACHE     (1<<8)
 
 #define ALPN_ACCEPTED "ALPN: server accepted "
 

--- a/lib/vtls/wolfssl.h
+++ b/lib/vtls/wolfssl.h
@@ -26,8 +26,25 @@
 #include "curl_setup.h"
 
 #ifdef USE_WOLFSSL
+#include <wolfssl/version.h>
+#include <wolfssl/options.h>
+#include <wolfssl/ssl.h>
+#include <wolfssl/error-ssl.h>
+
+#include "urldata.h"
 
 extern const struct Curl_ssl Curl_ssl_wolfssl;
+
+struct wolfssl_ctx {
+  WOLFSSL_CTX *ctx;
+  WOLFSSL     *handle;
+  CURLcode    io_result;   /* result of last BIO cfilter operation */
+  BIT(x509_store_setup);   /* x509 store has been set up */
+};
+
+CURLcode Curl_wssl_setup_x509_store(struct Curl_cfilter *cf,
+                                    struct Curl_easy *data,
+                                    struct wolfssl_ctx *wssl);
 
 #endif /* USE_WOLFSSL */
 #endif /* HEADER_CURL_WOLFSSL_H */


### PR DESCRIPTION
As a bonus, add SSLSUPP_CA_CACHE to let TLS backends signal its support for this so that *setopt() return error if there is no support.