### PR TITLE
CI: disable dependency tracking in most autotools builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -104,7 +104,7 @@ stages:
             displayName: 'apt install'
             retryCountOnTaskFailure: 3
 
-          - script: autoreconf -fi && ./configure --enable-warnings --enable-werror $(configure)
+          - script: autoreconf -fi && ./configure --disable-dependency-tracking --enable-warnings --enable-werror $(configure)
             displayName: 'configure $(name)'
 
           - script: make V=1 && make V=1 examples && cd tests && make V=1
@@ -131,7 +131,7 @@ stages:
           - script: autoreconf -fi
             displayName: 'autoreconf'
 
-          - script: scan-build ./configure --enable-debug --enable-werror --with-openssl --with-libssh2
+          - script: scan-build ./configure --disable-dependency-tracking --enable-debug --enable-werror --with-openssl --with-libssh2
             displayName: 'configure'
             env:
               CC: "clang"
@@ -233,7 +233,7 @@ stages:
             condition: variables.prepare
             retryCountOnTaskFailure: 3
 
-          - script: $(container_cmd) -l -c "cd $(echo '%cd%') && autoreconf -fi && ./configure $(configure)"
+          - script: $(container_cmd) -l -c "cd $(echo '%cd%') && autoreconf -fi && ./configure --disable-dependency-tracking $(configure)"
             displayName: 'configure $(name)'
 
           - script: $(container_cmd) -l -c "cd $(echo '%cd%') && make V=1 && make V=1 examples && cd tests && make V=1"

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -66,7 +66,7 @@ freebsd_task:
     #     export CXXFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g";
     #     export LDFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined,integer" ;;
     #   esac
-    - ./configure --prefix="${HOME}"/install --enable-debug --with-openssl --with-libssh2 --with-brotli --with-gssapi --with-libidn2 --enable-manual --enable-ldap --enable-ldaps --with-librtmp --with-libpsl --with-nghttp2 || { tail -300 config.log; false; }
+    - ./configure --prefix="${HOME}"/install --disable-dependency-tracking --enable-debug --with-openssl --with-libssh2 --with-brotli --with-gssapi --with-libidn2 --enable-manual --enable-ldap --enable-ldaps --with-librtmp --with-libpsl --with-nghttp2 || { tail -300 config.log; false; }
   compile_script:
     - make V=1 && make V=1 examples && cd tests && make V=1
   test_script:

--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -91,7 +91,7 @@ jobs:
       - run: |
           mkdir build
           cd build
-          ../configure --enable-warnings --enable-werror --with-openssl=$HOME/awslc
+          ../configure --disable-dependency-tracking --enable-warnings --enable-werror --with-openssl=$HOME/awslc
           cd ..
         name: 'configure out-of-tree'
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -261,7 +261,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.libressl-version }} https://github.com/libressl-portable/portable.git libressl-git
           cd libressl-git
           ./autogen.sh
-          ./configure --prefix=$HOME/libressl
+          ./configure --disable-dependency-tracking --prefix=$HOME/libressl
           make install
 
       - name: cache mbedtls
@@ -416,7 +416,7 @@ jobs:
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
+      - run: ./configure --disable-dependency-tracking --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'
 
       - run: make V=1

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -73,7 +73,7 @@ jobs:
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
+      - run: ./configure --disable-dependency-tracking --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'
 
       - run: make V=1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -186,7 +186,7 @@ jobs:
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
+      - run: ./configure --disable-dependency-tracking --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'
         env:
           CFLAGS: "-mmacosx-version-min=${{ matrix.build.macosx-version-min }}"

--- a/.github/workflows/ngtcp2-linux.yml
+++ b/.github/workflows/ngtcp2-linux.yml
@@ -141,7 +141,7 @@ jobs:
           git clone --quiet --depth=1 -b ${{ env.gnutls-version }} https://github.com/gnutls/gnutls.git
           cd gnutls
           ./bootstrap
-          ./configure  --prefix=$HOME/nghttpx \
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx \
             PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" LDFLAGS="-Wl,-rpath,$HOME/nghttpx/lib -L$HOME/nghttpx/lib" \
             --with-included-libtasn1 --with-included-unistring \
             --disable-guile --disable-doc --disable-tests --disable-tools
@@ -169,7 +169,7 @@ jobs:
           git clone --quiet --depth=1 -b ${{ env.wolfssl-version }} https://github.com/wolfSSL/wolfssl.git
           cd wolfssl
           ./autogen.sh
-          ./configure --enable-all --enable-quic --prefix=$HOME/nghttpx
+          ./configure --disable-dependency-tracking --enable-all --enable-quic --prefix=$HOME/nghttpx
           make
         name: 'build wolfssl'
 
@@ -195,7 +195,7 @@ jobs:
           cd nghttp3
           git submodule update --init
           autoreconf -fi
-          ./configure --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only
           make
         name: 'build nghttp3'
 
@@ -209,7 +209,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.ngtcp2-version }} https://github.com/ngtcp2/ngtcp2
           cd ngtcp2
           autoreconf -fi
-          ./configure --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only --with-openssl --with-gnutls --with-wolfssl
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only --with-openssl --with-gnutls --with-wolfssl
           make install
         name: 'install ngtcp2'
 
@@ -218,7 +218,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.nghttp2-version }} https://github.com/nghttp2/nghttp2
           cd nghttp2
           autoreconf -fi
-          ./configure --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-http3
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-http3
           make install
         name: 'install nghttp2'
 
@@ -255,7 +255,7 @@ jobs:
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure ${{ matrix.build.configure }}
+      - run: ./configure --disable-dependency-tracking ${{ matrix.build.configure }}
         name: 'configure'
 
       - run: make V=1

--- a/.github/workflows/osslq-linux.yml
+++ b/.github/workflows/osslq-linux.yml
@@ -159,7 +159,7 @@ jobs:
           cd nghttp3
           git submodule update --init
           autoreconf -fi
-          ./configure --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only
           make
         name: 'build nghttp3'
 
@@ -173,7 +173,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.ngtcp2-version }} https://github.com/ngtcp2/ngtcp2
           cd ngtcp2
           autoreconf -fi
-          ./configure --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only --with-openssl
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only --with-openssl
           make install
         name: 'install ngtcp2'
 
@@ -182,7 +182,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.nghttp2-version }} https://github.com/nghttp2/nghttp2
           cd nghttp2
           autoreconf -fi
-          ./configure --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-http3
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-http3
           make install
         name: 'install nghttp2'
 
@@ -219,7 +219,7 @@ jobs:
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure ${{ matrix.build.configure }}
+      - run: ./configure --disable-dependency-tracking ${{ matrix.build.configure }}
         name: 'configure'
 
       - run: make V=1

--- a/.github/workflows/quiche-linux.yml
+++ b/.github/workflows/quiche-linux.yml
@@ -113,7 +113,7 @@ jobs:
           cd nghttp3
           git submodule update --init
           autoreconf -fi
-          ./configure --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only
           make install
         name: 'install nghttp3'
 
@@ -122,7 +122,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.ngtcp2-version }} https://github.com/ngtcp2/ngtcp2
           cd ngtcp2
           autoreconf -fi
-          ./configure --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only --with-openssl
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-lib-only --with-openssl
           make install
         name: 'install ngtcp2'
 
@@ -131,7 +131,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.nghttp2-version }} https://github.com/nghttp2/nghttp2
           cd nghttp2
           autoreconf -fi
-          ./configure --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-http3
+          ./configure --disable-dependency-tracking --prefix=$HOME/nghttpx PKG_CONFIG_PATH="$HOME/nghttpx/lib/pkgconfig" --enable-http3
           make install
         name: 'install nghttp2'
 
@@ -196,7 +196,7 @@ jobs:
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure ${{ matrix.build.configure }}
+      - run: ./configure --disable-dependency-tracking ${{ matrix.build.configure }}
         name: 'configure'
 
       - run: make V=1

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -78,7 +78,7 @@ jobs:
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
+      - run: ./configure --disable-dependency-tracking --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'
 
       - run: make V=1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -74,6 +74,7 @@ jobs:
             --enable-websockets \
             --with-openssl \
             --with-libssh2 \
+            --disable-dependency-tracking \
             ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'
@@ -181,6 +182,7 @@ jobs:
             --enable-websockets \
             --with-openssl \
             --with-libssh2 \
+            --disable-dependency-tracking \
             ${{ matrix.config }} || { tail -n 1200 config.log; false; }
 
       - name: 'autotools build'

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -81,14 +81,14 @@ jobs:
           tar -xzf v$WOLFSSL_VER-stable.tar.gz
           cd wolfssl-$WOLFSSL_VER-stable
           ./autogen.sh
-          ./configure --enable-tls13 ${{ matrix.build.wolfssl-configure }} --enable-harden --prefix=$HOME/wssl
+          ./configure --disable-dependency-tracking --enable-tls13 ${{ matrix.build.wolfssl-configure }} --enable-harden --prefix=$HOME/wssl
           make install
         name: 'install wolfssl'
 
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure --enable-warnings --enable-werror ${{ matrix.build.configure }}
+      - run: ./configure --disable-dependency-tracking --enable-warnings --enable-werror ${{ matrix.build.configure }}
         name: 'configure'
 
       - run: make V=1


### PR DESCRIPTION
For better build performance. Dependency tracking causes a build
overhead while compiling to help a subsequent build, but in CI there is
never one and the extra work is discarded.

Closes #13794
