### PR TITLE
lib: fix gcc warning in certain debug builds

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -668,7 +668,7 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
       time(&clock);
   }
 #else
-  time(&clock);
+  clock = time(NULL);
 #endif
   result = Curl_gmtime(clock, &tm);
   if(result) {


### PR DESCRIPTION
```
curl/lib/http_aws_sigv4.c:536:10: error: 'clock' may be used uninitialized [-Werror=maybe-uninitialized]
  536 |   time_t clock;
      |          ^~~~~
```
Ref: https://github.com/curl/curl/actions/runs/9158755123/job/25177765000#step:13:79

Cherry-picked from #13718
Closes #13800