### PR TITLE
cd2nroff: use an empty "##" to signal end of .IP sequence

### DIFF
--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
@@ -95,6 +95,8 @@ as well:
 
 **SSL ***
 
+##
+
 If the *internals* pointer is NULL then either the SSL backend is not
 supported, an SSL session has not yet been established or the connection is no
 longer associated with the easy handle (e.g. curl_easy_perform(3) has

--- a/docs/libcurl/opts/CURLOPT_AWS_SIGV4.md
+++ b/docs/libcurl/opts/CURLOPT_AWS_SIGV4.md
@@ -50,13 +50,15 @@ It is extracted from the hostname specified in the URL if omitted.
 The argument is a function provided by a cloud. It is extracted from the
 hostname specified in the URL if omitted.
 
-NOTE: This call set CURLOPT_HTTPAUTH(3) to CURLAUTH_AWS_SIGV4.
-Calling CURLOPT_HTTPAUTH(3) with CURLAUTH_AWS_SIGV4 is the same
-as calling this with **"aws:amz"** in parameter.
+##
+
+NOTE: This call set CURLOPT_HTTPAUTH(3) to CURLAUTH_AWS_SIGV4. Calling
+CURLOPT_HTTPAUTH(3) with CURLAUTH_AWS_SIGV4 is the same as calling this with
+**"aws:amz"** in parameter.
 
 Example with "Test:Try", when curl uses the algorithm, it generates
-**"TEST-HMAC-SHA256"** for "Algorithm", **"x-try-date"** and
-**"X-Try-Date"** for "date", **"test4_request"** for "request type",
+**"TEST-HMAC-SHA256"** for "Algorithm", **"x-try-date"** and **"X-Try-Date"**
+for "date", **"test4_request"** for "request type",
 **"SignedHeaders=content-type;host;x-try-date"** for "signed headers"
 
 If you use just "test", instead of "test:try", test is used for every

--- a/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.md
@@ -95,9 +95,6 @@ with CURLOPT_MAIL_RCPT(3), to specify an EXPN request. If the
 CURLOPT_NOBODY(3) option is specified then the request can be used to
 issue **NOOP** and **RSET** commands.
 
-The application does not have to keep the string around after setting this
-option.
-
 # DEFAULT
 
 NULL

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
@@ -91,11 +91,13 @@ The data is SSL/TLS (binary) data sent to the peer.
 
 The data is SSL/TLS (binary) data received from the peer.
 
-WARNING: This callback may be called with the curl *handle* set to an
-internal handle. (Added in 8.4.0)
+##
 
-If you need to distinguish your curl *handle* from internal handles then
-set CURLOPT_PRIVATE(3) on your handle.
+WARNING: This callback may be called with the curl *handle* set to an internal
+handle. (Added in 8.4.0)
+
+If you need to distinguish your curl *handle* from internal handles then set
+CURLOPT_PRIVATE(3) on your handle.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
@@ -114,9 +114,11 @@ MIME mail is only composed of alternative representations of the same data
 In all cases the value must be of the form "multipart/*" to respect the
 document structure and may not include the "boundary=" parameter.
 
+##
+
 Other specific headers that do not have a libcurl default value but are
 strongly desired by mail delivery and user agents should also be included.
-These are "From:", "To:", "Date:" and "Subject:" among others and their
+These are `From:`, `To:`, `Date:` and `Subject:` among others and their
 presence and value is generally checked by anti-spam utilities.
 
 # SECURITY CONCERNS

--- a/docs/libcurl/opts/CURLOPT_PROXY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY.md
@@ -69,15 +69,16 @@ SOCKS5 Proxy.
 
 SOCKS5 Proxy. Proxy resolves URL hostname.
 
-Without a scheme prefix, CURLOPT_PROXYTYPE(3) can be used to specify
-which kind of proxy the string identifies.
+##
+
+Without a scheme prefix, CURLOPT_PROXYTYPE(3) can be used to specify which
+kind of proxy the string identifies.
 
 When you tell the library to use an HTTP proxy, libcurl transparently converts
 operations to HTTP even if you specify an FTP URL etc. This may have an impact
-on what other features of the library you can use, such as
-CURLOPT_QUOTE(3) and similar FTP specifics that do not work unless you
-tunnel through the HTTP proxy. Such tunneling is activated with
-CURLOPT_HTTPPROXYTUNNEL(3).
+on what other features of the library you can use, such as CURLOPT_QUOTE(3)
+and similar FTP specifics that do not work unless you tunnel through the HTTP
+proxy. Such tunneling is activated with CURLOPT_HTTPPROXYTUNNEL(3).
 
 Setting the proxy string to "" (an empty string) explicitly disables the use
 of a proxy, even if there is an environment variable set for it.
@@ -87,9 +88,6 @@ user + password.
 
 Unix domain sockets are supported for socks proxies since 7.84.0. Set
 localhost for the host part. e.g. socks5h://localhost/path/to/socket.sock
-
-The application does not have to keep the string around after setting this
-option.
 
 When a proxy is used, the active FTP mode as set with *CUROPT_FTPPORT(3)*,
 cannot be used.

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -63,6 +63,8 @@ SOCKS5 Proxy.
 
 SOCKS5 Proxy. Proxy resolves URL hostname.
 
+##
+
 Often it is more convenient to specify the proxy type with the scheme part of
 the CURLOPT_PROXY(3) string.
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
@@ -59,10 +59,13 @@ TLSv1.2
 ## CURL_SSLVERSION_TLSv1_3
 
 TLSv1.3
-The maximum TLS version can be set by using *one* of the
-CURL_SSLVERSION_MAX_ macros below. It is also possible to OR *one* of the
-CURL_SSLVERSION_ macros with *one* of the CURL_SSLVERSION_MAX_ macros.
-The MAX macros are not supported for WolfSSL.
+
+##
+
+The maximum TLS version can be set by using *one* of the CURL_SSLVERSION_MAX_
+macros below. It is also possible to OR *one* of the CURL_SSLVERSION_ macros
+with *one* of the CURL_SSLVERSION_MAX_ macros. The MAX macros are not
+supported for WolfSSL.
 
 ## CURL_SSLVERSION_MAX_DEFAULT
 
@@ -89,6 +92,8 @@ The flag defines maximum supported TLS version as TLSv1.2.
 
 The flag defines maximum supported TLS version as TLSv1.3.
 (Added in 7.54.0)
+
+##
 
 In versions of curl prior to 7.54 the CURL_SSLVERSION_TLS options were
 documented to allow *only* the specified TLS version, but behavior was

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.md
@@ -40,11 +40,8 @@ method is "SRP".
 TLS-SRP authentication. Secure Remote Password authentication for TLS is
 defined in RFC 5054 and provides mutual authentication if both sides have a
 shared secret. To use TLS-SRP, you must also set the
-CURLOPT_PROXY_TLSAUTH_USERNAME(3) and
-CURLOPT_PROXY_TLSAUTH_PASSWORD(3) options.
-
-The application does not have to keep the string around after setting this
-option.
+CURLOPT_PROXY_TLSAUTH_USERNAME(3) and CURLOPT_PROXY_TLSAUTH_PASSWORD(3)
+options.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.md
@@ -71,6 +71,8 @@ TLS v1.2 or later (Added in 7.34.0)
 
 TLS v1.3 or later (Added in 7.52.0)
 
+##
+
 The maximum TLS version can be set by using *one* of the
 CURL_SSLVERSION_MAX_ macros below. It is also possible to OR *one* of the
 CURL_SSLVERSION_ macros with *one* of the CURL_SSLVERSION_MAX_ macros.
@@ -102,6 +104,8 @@ The flag defines maximum supported TLS version as TLS v1.2.
 
 The flag defines maximum supported TLS version as TLS v1.3.
 (Added in 7.54.0)
+
+##
 
 In versions of curl prior to 7.54 the CURL_SSLVERSION_TLS options were
 documented to allow *only* the specified TLS version, but behavior was

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.md
@@ -36,11 +36,7 @@ the method of the TLS authentication. Supported method is "SRP".
 TLS-SRP authentication. Secure Remote Password authentication for TLS is
 defined in RFC 5054 and provides mutual authentication if both sides have a
 shared secret. To use TLS-SRP, you must also set the
-CURLOPT_TLSAUTH_USERNAME(3) and CURLOPT_TLSAUTH_PASSWORD(3)
-options.
-
-The application does not have to keep the string around after setting this
-option.
+CURLOPT_TLSAUTH_USERNAME(3) and CURLOPT_TLSAUTH_PASSWORD(3) options.
 
 TLS SRP does not work with TLS 1.3.
 

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -412,6 +412,11 @@ sub single {
             }
             $header = 1;
         }
+        elsif(/^##/) {
+            # end of IP sequence
+            push @desc, ".PP\n";
+            $header = 1;
+        }
         elsif(/^# (.*)/) {
             my $word = $1;
             # if there are enclosing quotes, remove them first


### PR DESCRIPTION
Like when we list a series of options and then want to add "normal" text again afterwards.

Without this, the indentation level wrongly continues even after the final "##" header, making following text wrongly appear to belong to the header above.

Adjusted multiple curldown files to use this to show the idea.

Fixes #13803
Reported-by: Jay Satiro