### PR TITLE
GHA: bump all build jobs to nproc+1

### DIFF
--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -41,7 +41,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 4
+  MAKEFLAGS: -j 5
 
   # renovate: datasource=github-tags depName=awslabs/aws-lc versioning=semver registryUrl=https://github.com
   awslc-version: 1.28.0

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -22,7 +22,7 @@ permissions: {}
 env:
   CW_NOGET: 'curl trurl'
   CW_MAP: '0'
-  CW_JOBS: '3'
+  CW_JOBS: '5'
   CW_NOPKG: '1'
   DOCKER_CONTENT_TRUST: '1'
 
@@ -54,6 +54,8 @@ jobs:
   mac-clang:
     runs-on: macos-latest
     timeout-minutes: 30
+    env:
+      CW_JOBS: '4'
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
         with:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -60,9 +60,9 @@ jobs:
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
           ./configure --prefix=$HOME/temp --without-ssl --without-libpsl
-          make -j3
-          make -j3 test-ci
-          make -j3 install
+          make -j5
+          make -j5 test-ci
+          make -j5 install
           popd
           # basic check of the installed files
           bash scripts/installcheck.sh $HOME/temp
@@ -85,8 +85,8 @@ jobs:
           mkdir build
           pushd build
           ../curl-99.98.97/configure --without-ssl --without-libpsl
-          make -j3
-          make -j3 test-ci
+          make -j5
+          make -j5 test-ci
           popd
           rm -rf build
           rm -rf curl-99.98.97
@@ -108,9 +108,9 @@ jobs:
           mkdir build
           pushd build
           ../configure --without-ssl --enable-debug "--prefix=${PWD}/pkg" --without-libpsl
-          make -j3
-          make -j3 test-ci
-          make -j3 install
+          make -j5
+          make -j5 test-ci
+          make -j5 install
         name: 'verify out-of-tree autotools debug build'
 
   verify-out-of-tree-cmake:
@@ -127,5 +127,5 @@ jobs:
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
           cmake -B build -DCURL_WERROR=ON
-          make -C build -j3
+          make -C build -j5
         name: 'verify out-of-tree cmake build'

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -45,7 +45,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 4
+  MAKEFLAGS: -j 5
   # handled in renovate.json
   openssl3-version: openssl-3.3.0
   # unhandled

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -50,7 +50,7 @@ on:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 5
   DEBIAN_FRONTEND: noninteractive
 
 jobs:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,7 +40,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 4
+  MAKEFLAGS: -j 5
   # unhandled
   bearssl-version: 0.6
   # renovate: datasource=github-tags depName=libressl-portable/portable versioning=semver registryUrl=https://github.com

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -44,7 +44,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 4
+  MAKEFLAGS: -j 5
 
 jobs:
   linux-i686:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,7 +41,7 @@ permissions: {}
 
 env:
   DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
-  MAKEFLAGS: -j 3
+  MAKEFLAGS: -j 4
 
 jobs:
   autotools:

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -45,7 +45,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 4
+  MAKEFLAGS: -j 5
 
 jobs:
   autotools:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,7 +82,7 @@ jobs:
         timeout-minutes: 10
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          make -C bld -j3 V=1 install
+          make -C bld -j5 V=1 install
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 
@@ -91,14 +91,14 @@ jobs:
         timeout-minutes: 5
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          make -C bld -j3 V=1 examples
+          make -C bld -j5 V=1 examples
 
       - name: 'autotools build tests'
         if: ${{ matrix.build == 'automake' && matrix.tflags != 'skipall' }}
         timeout-minutes: 15
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          make -C bld -j3 -C tests V=1
+          make -C bld -j5 -C tests V=1
 
       - name: 'autotools run tests'
         if: ${{ matrix.build == 'automake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -109,7 +109,7 @@ jobs:
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
-          make -C bld -j3 V=1 test-ci
+          make -C bld -j5 V=1 test-ci
 
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
@@ -131,7 +131,7 @@ jobs:
         timeout-minutes: 10
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
@@ -141,7 +141,7 @@ jobs:
         timeout-minutes: 15
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -209,7 +209,7 @@ jobs:
         timeout-minutes: 10
         shell: msys2 {0}
         run: |
-          make -C bld -j3 V=1 install
+          make -C bld -j5 V=1 install
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 
@@ -218,14 +218,14 @@ jobs:
         timeout-minutes: 5
         shell: msys2 {0}
         run: |
-          make -C bld -j3 V=1 examples
+          make -C bld -j5 V=1 examples
 
       - name: 'autotools build tests'
         if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' }}
         timeout-minutes: 10
         shell: msys2 {0}
         run: |
-          make -C bld -j3 -C tests V=1
+          make -C bld -j5 -C tests V=1
 
       - name: 'autotools run tests'
         if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -236,7 +236,7 @@ jobs:
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
-          make -C bld -j3 V=1 test-ci
+          make -C bld -j5 V=1 test-ci
 
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
@@ -279,7 +279,7 @@ jobs:
         timeout-minutes: 10
         shell: msys2 {0}
         run: |
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
@@ -289,7 +289,7 @@ jobs:
         timeout-minutes: 10
         shell: msys2 {0}
         run: |
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -380,7 +380,7 @@ jobs:
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
           export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           bld/src/curl.exe --disable --version
 
@@ -390,7 +390,7 @@ jobs:
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
           export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -450,7 +450,7 @@ jobs:
         timeout-minutes: 5
         shell: bash
         run: |
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           bld/src/curl.exe --disable --version
 
@@ -459,7 +459,7 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
-          cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -45,7 +45,7 @@ concurrency:
 permissions: {}
 
 env:
-  MAKEFLAGS: -j 4
+  MAKEFLAGS: -j 5
 
 jobs:
   autotools:

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -62,7 +62,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     '-DCMAKE_INSTALL_PREFIX=C:/curl' \
     "-DCMAKE_BUILD_TYPE=${PRJ_CFG}"
   # shellcheck disable=SC2086
-  cmake --build _bld --config "${PRJ_CFG}" --parallel 3 -- ${BUILD_OPT:-}
+  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 -- ${BUILD_OPT:-}
   if [ "${SHARED}" = 'ON' ]; then
     cp -f -p _bld/lib/*.dll _bld/src/
   fi
@@ -74,7 +74,7 @@ elif [ "${BUILD_SYSTEM}" = 'VisualStudioSolution' ]; then
   (
     cd projects
     ./generate.bat "${VC_VERSION}"
-    msbuild.exe -maxcpucount:3 "-property:Configuration=${PRJ_CFG}" "Windows/${VC_VERSION}/curl-all.sln"
+    msbuild.exe -maxcpucount "-property:Configuration=${PRJ_CFG}" "Windows/${VC_VERSION}/curl-all.sln"
   )
   curl="build/Win32/${VC_VERSION}/${PRJ_CFG}/curld.exe"
 elif [ "${BUILD_SYSTEM}" = 'winbuild_vs2015' ]; then
@@ -121,7 +121,7 @@ fi
 
 if [[ "${TFLAGS}" != 'skipall' ]] && \
    [ "${BUILD_SYSTEM}" = 'CMake' ]; then
-  cmake --build _bld --config "${PRJ_CFG}" --parallel 3 --target testdeps
+  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --target testdeps
 fi
 
 # run tests

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -62,7 +62,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     '-DCMAKE_INSTALL_PREFIX=C:/curl' \
     "-DCMAKE_BUILD_TYPE=${PRJ_CFG}"
   # shellcheck disable=SC2086
-  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 -- ${BUILD_OPT:-}
+  cmake --build _bld --config "${PRJ_CFG}" --parallel 3 -- ${BUILD_OPT:-}
   if [ "${SHARED}" = 'ON' ]; then
     cp -f -p _bld/lib/*.dll _bld/src/
   fi
@@ -74,7 +74,7 @@ elif [ "${BUILD_SYSTEM}" = 'VisualStudioSolution' ]; then
   (
     cd projects
     ./generate.bat "${VC_VERSION}"
-    msbuild.exe -maxcpucount "-property:Configuration=${PRJ_CFG}" "Windows/${VC_VERSION}/curl-all.sln"
+    msbuild.exe -maxcpucount:3 "-property:Configuration=${PRJ_CFG}" "Windows/${VC_VERSION}/curl-all.sln"
   )
   curl="build/Win32/${VC_VERSION}/${PRJ_CFG}/curld.exe"
 elif [ "${BUILD_SYSTEM}" = 'winbuild_vs2015' ]; then
@@ -121,7 +121,7 @@ fi
 
 if [[ "${TFLAGS}" != 'skipall' ]] && \
    [ "${BUILD_SYSTEM}" = 'CMake' ]; then
-  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --target testdeps
+  cmake --build _bld --config "${PRJ_CFG}" --parallel 3 --target testdeps
 fi
 
 # run tests


### PR DESCRIPTION
- bump rest of the workflows (windows, macos, distrocheck).

- non-native virtualized envs have 2 CPUs, bump down accordingly.
  (for `vmactions/omnios-vm` it's just a guess.)

- bump all to nproc + 1.

Follow-up to e838b341a08b44d4a8486fb0d3f15d12fc794c62 #12927
Closes #13807

---

- [x] rebase on #12927
