### PR TITLE
curl: offer a default 'random' variable

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2711,6 +2711,8 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
   setlocale(LC_NUMERIC, "C");
 #endif
 
+  defaultvariables(global);
+
   /* Parse .curlrc if necessary */
   if((argc == 1) ||
      (first_arg && strncmp(first_arg, "-q", 2) &&

--- a/src/var.c
+++ b/src/var.c
@@ -524,7 +524,7 @@ int defaultvariables(struct GlobalConfig *global)
   int junk[4];
   int err;
   struct timeval now = tvnow();
-  srandom((int)now.tv_usec);
+  srand((int)now.tv_usec);
   junk[0] = rand();
   junk[1] = rand();
   junk[2] = rand();

--- a/src/var.h
+++ b/src/var.h
@@ -44,4 +44,6 @@ ParameterError varexpand(struct GlobalConfig *global,
 /* free everything */
 void varcleanup(struct GlobalConfig *global);
 
+int defaultvariables(struct GlobalConfig *global);
+
 #endif /* HEADER_CURL_VAR_H */


### PR DESCRIPTION
... and two new output functions: `uuid` and `hex`

The variable holds a 128 bit semi-random value. Output it like

- `{{random:hex}}` to get it all as a 32 byte hex sequence
- `{{random:uuid}}` shows it as a UUID sequence
- `{{random:url}}` shows it URL encoded
- `{{random:b64}}` shows it base64 encoded

For now, this holds fixed content, meaning that if you use it several times in the command line it will have the same value.

- is this useful and wanted at all?
- should we use a "reserved" prefix for internally provided variables?
- if so, this needs to be documented
- test cases needed