### PR TITLE
aws-sigv4: fix canonical path encoding

### DIFF
--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -73,7 +73,7 @@ test426 test427 test428 test429 test430 test431 test432 test433 test434 \
 test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
-test462 test463 test467 test468 test469 test470 test471 \
+test462 test463 test467 test468 test469 test470 test471 test472 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \

--- a/tests/data/test472
+++ b/tests/data/test472
@@ -1,0 +1,59 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+aws-sigv4
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+debug
+Unicode
+</features>
+<name>
+aws-sigv4 with query
+</name>
+<command>
+"http://fake.fake.fake:8000/%TESTNUMBER/a=あ" -u user:secret --aws-sigv4 "aws:amz:us-east-2:es" --connect-to fake.fake.fake:8000:%HOSTIP:%HTTPPORT
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+GET /472/a=%e3%81%82 HTTP/1.1
+Host: fake.fake.fake:8000
+Authorization: AWS4-HMAC-SHA256 Credential=user/19700101/us-east-2/es/aws4_request, SignedHeaders=host;x-amz-date, Signature=c63315c199922f7ee00141869a250389405d19e205057249fb74726d940b1fc3
+X-Amz-Date: 19700101T000000Z
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
fix: #13754

I refactor canon_query, so I could use the encoding part of the function to use it in the path.

As the path doesn't encode '/', but encode '=', I had to add some conditions to know If I was doing the query or path encoding.

Also, instead of adding a `bool in_path` variable, I use `bool *found_equals` to know if the function was called for the query or path, as found_equals is used only in query_encoding.

Note: When I try replacing manually `=` with `%3D`, curl without this patch worked, so they might still be a bug out-there. 