### PR TITLE
lib: prefer `var = time(NULL)` over `time(&var)`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -232,7 +232,7 @@ jobs:
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -296,7 +296,7 @@ jobs:
         timeout-minutes: 40
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -398,7 +398,7 @@ jobs:
         timeout-minutes: 40
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -466,6 +466,6 @@ jobs:
         timeout-minutes: 30
         shell: bash
         run: |
-          export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
           ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -665,7 +665,7 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
     if(force_timestamp)
       clock = 0;
     else
-      time(&clock);
+      clock = time(NULL);
   }
 #else
   clock = time(NULL);

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -245,7 +245,7 @@ static CURLcode tftp_set_timeouts(struct tftp_state_data *state)
         (int)state->state, timeout_ms, state->retry_time, state->retry_max);
 
   /* init RX time */
-  time(&state->rx_time);
+  state->rx_time = time(NULL);
 
   return CURLE_OK;
 }
@@ -626,7 +626,7 @@ static CURLcode tftp_rx(struct tftp_state_data *state,
     else {
       state->state = TFTP_STATE_RX;
     }
-    time(&state->rx_time);
+    state->rx_time = time(NULL);
     break;
 
   case TFTP_EVENT_OACK:
@@ -646,7 +646,7 @@ static CURLcode tftp_rx(struct tftp_state_data *state,
 
     /* we're ready to RX data */
     state->state = TFTP_STATE_RX;
-    time(&state->rx_time);
+    state->rx_time = time(NULL);
     break;
 
   case TFTP_EVENT_TIMEOUT:
@@ -753,7 +753,7 @@ static CURLcode tftp_tx(struct tftp_state_data *state, tftp_event_t event)
       }
       /* This is the expected packet.  Reset the counters and send the next
          block */
-      time(&state->rx_time);
+      state->rx_time = time(NULL);
       state->block++;
     }
     else
@@ -1208,7 +1208,7 @@ static timediff_t tftp_state_timeout(struct Curl_easy *data,
   if(current > state->rx_time + state->retry_time) {
     if(event)
       *event = TFTP_EVENT_TIMEOUT;
-    time(&state->rx_time); /* update even though we received nothing */
+    state->rx_time = time(NULL); /* update even though we received nothing */
   }
 
   return timeout_ms;


### PR DESCRIPTION
Following up on previous occurrences showing up as gcc warnings, replace
the remaining `time(&var)` calls with `var = time(NULL)`, though these
aren't specifically causing compiler warnings. These are in the TFTP
client code (`lib/tftp.c`), except one which is in a debug branch in
`lib/http_aws_sigv4.c`.

What's unexplainable is that this patch seems to mitigate TFTP tests
often hanging or going into an infinite loop on GHA windows workflows
with MSYS2, mingw-w64 and MSVC (Cygwin is unaffected):
  https://github.com/curl/curl/pull/13599#issuecomment-2119372376
TFTP hangs did not entirely disappear though, so could be unrelated.

`time()` docs:
https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/time-time32-time64
https://manpages.debian.org/bookworm/manpages-dev/time.2.en.html

Follow-up to 58ca0a2f0743a586716ca357c382b29e3f08db69 #13800
Follow-up to d0728c9109629ee82b855b350a4c3f1f52ee61df #13643
Closes #13815

---

More test runs here: https://github.com/vszakats/curl/pull/1
