### PR TITLE
openssl: fix format type in ECH code

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3940,7 +3940,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
 # endif
           else {
             trying_ech_now = 1;
-            infof(data, "ECH: imported ECHConfigList of length %ld", elen);
+            infof(data, "ECH: imported ECHConfigList of length %zu", elen);
           }
         }
         else {


### PR DESCRIPTION
 ``` 
curl-android/curl/src/main/native/curl/lib/vtls/openssl.c:3943:70: error: format specifies type 'long' but the argument has type 'size_t' (aka 'unsigned int') [-Werror,-Wformat]
   3943 |             infof(data, "ECH: imported ECHConfigList of length %ld", elen);
        |                                                                ~~~   ^~~~
        |                                                                %zu
curl-android/curl/src/main/native/curl/lib/curl_trc.h:76:27: note: expanded from macro 'infof'
     76 |          Curl_infof(data, __VA_ARGS__); } while(0)
        |                           ^~~~~~~~~~~
  1 error generated.
```