### PR TITLE
cf-socket: improve SO_SNDBUF update for Winsock

### DIFF
--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -81,9 +81,9 @@ int Curl_socket_close(struct Curl_easy *data, struct connectdata *conn,
    Buffer Size
 
 */
-void Curl_sndbufset(curl_socket_t sockfd);
+void Curl_sndbuf_init(curl_socket_t sockfd);
 #else
-#define Curl_sndbufset(y) Curl_nop_stmt
+#define Curl_sndbuf_init(y) Curl_nop_stmt
 #endif
 
 /**

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -654,7 +654,7 @@ static CURLcode InitiateTransfer(struct Curl_easy *data)
     Curl_pgrsSetUploadSize(data, data->state.infilesize);
 
     /* set the SO_SNDBUF for the secondary socket for those who need it */
-    Curl_sndbufset(conn->sock[SECONDARYSOCKET]);
+    Curl_sndbuf_init(conn->sock[SECONDARYSOCKET]);
 
     Curl_xfer_setup(data, -1, -1, FALSE, SECONDARYSOCKET);
   }


### PR DESCRIPTION
- Rename: Curl_sndbufset => Curl_sndbuf_init

- Rename: win_update_buffer_size => win_update_sndbuf_size

- Save the last set SO_SNDBUF size to compare against so that we can avoid setsockopt calls every second.

This is a follow-up to 0b520e12 which moved the SO_SNDBUF update check into cf-socket. This change improves it further by making the function names easier to understand and reducing the amount of setsockopt calls.

Closes #xxxx