### PR TITLE
Autoconf: Remove 'deeper' checks for `AC_CHECK_FUNCS`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3800,26 +3800,6 @@ AC_CHECK_FUNCS([\
   snprintf \
   utime \
   utimes \
-],[
-],[
-  func="$ac_func"
-  eval skipcheck=\$skipcheck_$func
-  if test "x$skipcheck" != "xyes"; then
-    AC_MSG_CHECKING([deeper for $func])
-    AC_LINK_IFELSE([
-      AC_LANG_PROGRAM([[
-      ]],[[
-        $func ();
-      ]])
-    ],[
-      AC_MSG_RESULT([yes])
-      eval "ac_cv_func_$func=yes"
-      AC_DEFINE_UNQUOTED(XC_SH_TR_CPP([HAVE_$func]), [1],
-        [Define to 1 if you have the $func function.])
-    ],[
-      AC_MSG_RESULT([but still no])
-    ])
-  fi
 ])
 
 dnl On Android, the only way to know if fseeko can be used is to see if it is


### PR DESCRIPTION
The net effect of the deeper checks is to raise implicit function decls on modern compilers.

These checks appear to have been added ~20 years ago, relating to an unverifiable claim about HP-UX. Autoconf support for the platform has grown in leaps and bounds since.

It didn't cause a real problem here, but when investigating a FP this came up. No evidence has been identified that this was actually broken in the past, and there is no evidence that this is necessary now.

`-Werror=implicit-function-declarations` is enabled for both checks; without a working prototype they will both fail regardless. In the second case there will in fact never be a working prototype and therefore it will always fail unconditionally.

`AC_CHECK_FUNCS` does effectively the same thing as the removed checks, except it actually defines a dummy prototype to see if it links.

If `AC_CHECK_FUNCS` is broken on a given platform we have bigger problems than trying to build cURL. This should also be faster.

CC @thesamesam @eli-schwartz 

Bug: https://bugs.gentoo.org/932827