### PR TITLE
tidy-up: use consistent casing for Windows directories

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         timeout-minutes: 5
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
+          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/System32"
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --prefix="${HOME}"/install \
@@ -116,7 +116,7 @@ jobs:
         timeout-minutes: 5
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/system32"
+          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/System32"
           cmake -B bld ${options} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             -DCMAKE_UNITY_BUILD=ON \

--- a/docs/SSLCERTS.md
+++ b/docs/SSLCERTS.md
@@ -117,8 +117,8 @@ server, do one of the following:
     order:
       1. application's directory
       2. current working directory
-      3. Windows System directory (e.g. C:\windows\system32)
-      4. Windows Directory (e.g. C:\windows)
+      3. Windows System directory (e.g. C:\Windows\System32)
+      4. Windows Directory (e.g. C:\Windows)
       5. all directories along %PATH%
 
  5. Get another CA cert bundle. One option is to extract the one a recent

--- a/projects/README.md
+++ b/projects/README.md
@@ -104,29 +104,29 @@ environment. To do that:
  1. Open the 'curl-all.sln' or 'curl.sln' solutions
  2. Right-click on the 'curl' project and select Properties
  3. Navigate to 'Configuration Properties > Debugging > Environment'
- 4. Add `PATH='Path to DLL';C:\Windows\system32;C:\Windows;C:\Windows\System32\Wbem`
+ 4. Add `PATH='Path to DLL';C:\Windows\System32;C:\Windows;C:\Windows\System32\Wbem`
 
 ... where 'Path to DLL` is the configuration specific path. For example the
 following configurations in Visual Studio 2010 might be:
 
 DLL Debug - DLL OpenSSL (Win32):
 
-    PATH=..\..\..\..\..\openssl\build\Win32\VC10\DLL Debug;C:\Windows\system32;
+    PATH=..\..\..\..\..\openssl\build\Win32\VC10\DLL Debug;C:\Windows\System32;
     C:\Windows;C:\Windows\System32\Wbem
 
 DLL Debug - DLL OpenSSL (x64):
 
-    PATH=..\..\..\..\..\openssl\build\Win64\VC10\DLL Debug;C:\Windows\system32;
+    PATH=..\..\..\..\..\openssl\build\Win64\VC10\DLL Debug;C:\Windows\System32;
     C:\Windows;C:\Windows\System32\Wbem
 
 DLL Debug - DLL wolfSSL (Win32):
 
-    PATH=..\..\..\..\..\wolfssl\build\Win32\VC10\DLL Debug;C:\Windows\system32;
+    PATH=..\..\..\..\..\wolfssl\build\Win32\VC10\DLL Debug;C:\Windows\System32;
     C:\Windows;C:\Windows\System32\Wbem
 
 DLL Debug - DLL wolfSSL (x64):
 
-    PATH=..\..\..\..\..\wolfssl\build\Win64\VC10\DLL Debug;C:\Windows\system32;
+    PATH=..\..\..\..\..\wolfssl\build\Win64\VC10\DLL Debug;C:\Windows\System32;
     C:\Windows;C:\Windows\System32\Wbem
 
 If you are using a configuration that uses multiple third-party library DLLs

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -606,8 +606,8 @@ char **__crt0_glob_function(char *arg)
  * The order of the directories it searches is:
  *  1. application's directory
  *  2. current working directory
- *  3. Windows System directory (e.g. C:\windows\system32)
- *  4. Windows Directory (e.g. C:\windows)
+ *  3. Windows System directory (e.g. C:\Windows\System32)
+ *  4. Windows Directory (e.g. C:\Windows)
  *  5. all directories along %PATH%
  *
  * For WinXP and later search order actually depends on registry value:


### PR DESCRIPTION
C:\Windows\System32

Closes #13832