### PR TITLE
dragonfly: change tcp keepalive options from ms to seconds

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -53,6 +53,11 @@
 #include <inet.h>
 #endif
 
+#ifdef __DragonFly__
+/* Required for __DragonFly_version */
+#include <sys/param.h>
+#endif
+
 #include "urldata.h"
 #include "bufq.h"
 #include "sendf.h"
@@ -137,8 +142,8 @@ static void nosigpipe(struct Curl_easy *data,
 #define nosigpipe(x,y) Curl_nop_stmt
 #endif
 
-#if defined(__DragonFly__) || defined(USE_WINSOCK)
-/* DragonFlyBSD and Windows use millisecond units */
+#if (defined(__DragonFly__) && __DragonFly_version < 500702) || defined(USE_WINSOCK)
+/* DragonFlyBSD < 500702 and Windows use millisecond units */
 #define KEEPALIVE_FACTOR(x) (x *= 1000)
 #else
 #define KEEPALIVE_FACTOR(x)

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -142,7 +142,8 @@ static void nosigpipe(struct Curl_easy *data,
 #define nosigpipe(x,y) Curl_nop_stmt
 #endif
 
-#if (defined(__DragonFly__) && __DragonFly_version < 500702) || defined(USE_WINSOCK)
+#if defined(USE_WINSOCK) || \
+   (defined(__DragonFly__) && __DragonFly_version < 500702)
 /* DragonFlyBSD < 500702 and Windows use millisecond units */
 #define KEEPALIVE_FACTOR(x) (x *= 1000)
 #else


### PR DESCRIPTION
DragonFly BSD changed the time unit for TCP keep-alive from milliseconds to seconds since v5.8, thus setting the keepalive options with milliseconds with curl/libcurl will result in unexpected behaviors on DragonFlyBSD 5.8+

Distinguish the DragonFly BSD versions and use the proper time units accordingly.

Ref:
  https://lists.dragonflybsd.org/pipermail/commits/2019-July/719125.html
  https://github.com/DragonFlyBSD/DragonFlyBSD/blob/965b380e960908836b97aa034fa2753091e0172e/sys/sys/param.h#L207

Fixes #13847