### PR TITLE
examples/threaded-ssl: explain pthread thread ID method will vary

### DIFF
--- a/docs/examples/threaded-ssl.c
+++ b/docs/examples/threaded-ssl.c
@@ -65,6 +65,8 @@ static unsigned long thread_id(void)
 {
   unsigned long ret;
 
+  /* pthreads_self() returns a pthread_t that for most pthreads libraries is
+     equivalent to an integer thread ID. Others may use different methods. */
   ret = (unsigned long)pthread_self();
   return ret;
 }


### PR DESCRIPTION
- Add a comment explaining that pthread_self(), which returns pthread_t, is not necessarily an integer thread ID.

pthread_t type varies depending on the pthread library. For some pthread libraries, such as PThreads4W, it is a struct and not integer thread ID.

Rather than update the example to handle every pthread implementation of thread ID we now explain that it varies depending on the library.

Bug: https://github.com/curl/curl/issues/13532
Reported-by: Gisle Vanem

Closes #xxxx