### PR TITLE
GHA: fix caching old mingw-w64 toolchains in the Windows workflow

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -334,7 +334,7 @@ jobs:
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         id: cache-compiler
         with:
-          path: C:\my-cache\mingw-w64-${{ matrix.env }}
+          path: ~\my-cache
           key: ${{ runner.os }}-mingw-w64-${{ matrix.env }}
 
       - name: 'install compiler (gcc ${{ matrix.env }})'
@@ -342,13 +342,14 @@ jobs:
         timeout-minutes: 5
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          mkdir -p /c/my-cache/
-          cd /c/my-cache/ || exit 1
+          cd "${USERPROFILE}" || exit 1
+          mkdir my-cache
+          cd my-cache || exit 1
           curl --fail --silent --show-error --retry 3 --retry-connrefused --output pack.bin --location --proto-redir =https '${{ matrix.url }}'
-          mkdir -p mingw-w64-${{ matrix.env }}
-          cd mingw-w64-${{ matrix.env }} || exit 1
           pwd
-          7z x -y ../pack.bin >/dev/null
+          7z x -y pack.bin >/dev/null
+          rm -r -f pack.bin
+          ls -l
 
       - run: git config --global core.autocrlf input
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
@@ -356,7 +357,7 @@ jobs:
       - name: 'update PATH (gcc ${{ matrix.env }})'
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          echo "PATH=/c/my-cache/mingw-w64-${{ matrix.env }}/mingw64/bin:/c/msys64/usr/bin:$PATH" >> "$GITHUB_ENV"
+          echo "PATH=$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -354,16 +354,12 @@ jobs:
       - run: git config --global core.autocrlf input
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
 
-      - name: 'update PATH (gcc ${{ matrix.env }})'
-        shell: C:\msys64\usr\bin\bash.exe {0}
-        run: |
-          echo "PATH=$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH" >> "$GITHUB_ENV"
-
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 5
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
+          export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
           cflags='-Wno-deprecated-declarations'  # for examples
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
@@ -383,6 +379,7 @@ jobs:
         timeout-minutes: 10
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
+          export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 3
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           bld/src/curl.exe --disable --version
@@ -392,6 +389,7 @@ jobs:
         timeout-minutes: 10
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
+          export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 3 --target testdeps
 
       - name: 'cmake run tests'
@@ -399,6 +397,7 @@ jobs:
         timeout-minutes: 40
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
+          export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
           export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,7 +67,7 @@ jobs:
         timeout-minutes: 5
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/System32"
+          export PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
           autoreconf -fi
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --prefix="${HOME}"/install \
@@ -116,7 +116,7 @@ jobs:
         timeout-minutes: 5
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          export PATH="/usr/bin:$(cygpath ${SYSTEMROOT})/System32"
+          export PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
           cmake -B bld ${options} \
             "-DCMAKE_C_FLAGS=${cflags}" \
             -DCMAKE_UNITY_BUILD=ON \
@@ -356,7 +356,7 @@ jobs:
       - name: 'update PATH (gcc ${{ matrix.env }})'
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          echo "PATH=/c/my-cache/mingw-w64-${{ matrix.env }}/mingw64/bin:/c/msys64/usr/bin:$PATH" >> $GITHUB_ENV
+          echo "PATH=/c/my-cache/mingw-w64-${{ matrix.env }}/mingw64/bin:/c/msys64/usr/bin:$PATH" >> "$GITHUB_ENV"
 
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}


### PR DESCRIPTION
- stop altering the `PATH` via `GITHUB_ENV`. This confused the
  `actions/cache` post-job, which needs to run in the exact same
  environment as its pre-job, to have a consistent cache entry "version"
  hash. Altering the `PATH` via `GITHUB_ENV` spills into the the
  post-job and breaks this hash. GHA doesn't reset the env automatically
  and I have not found a way to do it manually.

- add double-quotes where missing.

- move cache directory under `USERPROFILE` to not rely on absolute
  paths.

- make cache directory flatter and versionless.

Follow-up to 0914d8aadddac0d1459673d5b7f77e8f3378b22b #13759
Closes #13856
