### PR TITLE
x509asn1: fallback to dotted OID representation

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -469,7 +469,7 @@ static CURLcode OID2str(struct dynbuf *store,
         if(op)
           result = Curl_dyn_add(store, op->textoid);
         else
-          result = CURLE_BAD_FUNCTION_ARGUMENT;
+          result = Curl_dyn_add(store, Curl_dyn_ptr(&buf));
         Curl_dyn_free(&buf);
       }
     }


### PR DESCRIPTION
This restores the pre-8.6.0 behaviour of falling back to the dotted OID representation.
In 8.6.0 and 8.7.0 this returned an empty buffer.
In 8.8.0 this was changed to be a fatal error, but this isn't future proof and the OID list we have is not exhaustive enough (even after #13857).

Fixes #13845