### PR TITLE
GHA: fix old mingw-w64 32-bit job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -312,18 +312,21 @@ jobs:
         include:
           - build: 'cmake'
             env: '9.5.0-x86_64'
+            dir: 'mingw64'
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/9.5.0-10.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-9.5.0-mingw-w64msvcrt-10.0.0-r1.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
             type: 'Release'
             tflags: '~2301 ~2302 ~3027'
           - build: 'cmake'
             env: '7.3.0-x86_64'
+            dir: 'mingw64'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON'
             type: 'Debug'
             tflags: '~2301 ~2302 ~3027'
           - build: 'cmake'
             env: '6.4.0-i686'
+            dir: 'mingw32'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF'
             type: 'Debug'
@@ -359,7 +362,7 @@ jobs:
         timeout-minutes: 5
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
+          export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           cflags='-Wno-deprecated-declarations'  # for examples
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
@@ -379,7 +382,7 @@ jobs:
         timeout-minutes: 10
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
+          export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           bld/src/curl.exe --disable --version
@@ -389,7 +392,7 @@ jobs:
         timeout-minutes: 10
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
+          export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'cmake run tests'
@@ -397,7 +400,7 @@ jobs:
         timeout-minutes: 40
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          export PATH="$(cygpath "${USERPROFILE}")/my-cache/mingw64/bin:/c/msys64/usr/bin:$PATH"
+          export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"


### PR DESCRIPTION
This toolchain resides in the `mingw32` directory. Make sure to
configure `PATH` accordingly.

Before this patch, it pointed to a non-existing `mingw64` directory,
making the job use the wrong compiler (gcc 12, 64-bit).

Follow-up to e838b341a08b44d4a8486fb0d3f15d12fc794c62 #12927
Closes #13863
