### PR TITLE
tcpkeepalive: support setting TCP keep-alive parameters on Solaris <11.4

### DIFF
--- a/docs/cmdline-opts/keepalive-time.md
+++ b/docs/cmdline-opts/keepalive-time.md
@@ -19,9 +19,10 @@ Example:
 Set the time a connection needs to remain idle before sending keepalive probes
 and the time between individual keepalive probes. It is currently effective on
 operating systems offering the `TCP_KEEPIDLE` and `TCP_KEEPINTVL` socket
-options (meaning Linux, recent AIX, HP-UX and more). Keepalive is used by the
-TCP stack to detect broken networks on idle connections. The number of missed
-keepalive probes before declaring the connection down is OS dependent and is
-commonly 9 or 10. This option has no effect if --no-keepalive is used.
+options (meaning Linux, *BSD/macOS, Windows, Solaris, and recent AIX, HP-UX and more).
+Keepalive is used by the TCP stack to detect broken networks on idle connections.
+The number of missed keepalive probes before declaring the connection down is OS
+dependent and is commonly 8 (*BSD/macOS/AIX), 9 (Linux/AIX) or 5/10 (Windows).
+This option has no effect if --no-keepalive is used.
 
 If unspecified, the option defaults to 60 seconds.


### PR DESCRIPTION
Solaris didn't support TCP_KEEPIDLE and TCP_KEEPINTVL until 11.4, before that it use TCP_KEEPALIVE_THRESHOLD and TCP_KEEPALIVE_ABORT_THRESHOLD as the substitute. Therefore, for Solaris <11.4 we need to use this substitute for setting TCP keep-alive parameters.

Ref:
https://docs.oracle.com/cd/E86824_01/html/E54777/tcp-7p.html
https://docs.oracle.com/cd/E88353_01/html/E37851/tcp-4p.html