### PR TITLE
windows: fix UWP builds, add GHA job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -170,7 +170,7 @@ jobs:
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release' }
           - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DBUILD_EXAMPLES=OFF', type: 'Release', test: 'uwp' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skipall'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DBUILD_EXAMPLES=OFF', type: 'Release', test: 'uwp' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -281,9 +281,9 @@ jobs:
         shell: msys2 {0}
         run: |
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
-          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
+          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && [ '${{ matrix.test }}' != 'uwp' ] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll'
-          [ '${{ matrix.test }}' = 'uwp' ] || bld/src/curl.exe --disable --version
+          [ '${{ matrix.test }}' != 'uwp' ] && bld/src/curl.exe --disable --version
 
       - name: 'cmake build tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -281,9 +281,11 @@ jobs:
         shell: msys2 {0}
         run: |
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
-          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && [ '${{ matrix.test }}' != 'uwp' ] && cp -f -p bld/lib/*.dll bld/src/
-          find . -name '*.exe' -o -name '*.dll'
-          [ '${{ matrix.test }}' != 'uwp' ] && bld/src/curl.exe --disable --version
+          if [ '${{ matrix.test }}' != 'uwp' ]; then
+            [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
+            find . -name '*.exe' -o -name '*.dll'
+            bld/src/curl.exe --disable --version
+          fi
 
       - name: 'cmake build tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -170,7 +170,7 @@ jobs:
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release' }
           - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skipall'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DBUILD_EXAMPLES=OFF', type: 'Release', test: 'uwp' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DBUILD_EXAMPLES=OFF', type: 'Release', test: 'uwp' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -281,9 +281,9 @@ jobs:
         shell: msys2 {0}
         run: |
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
-          if [ '${{ matrix.test }}' != 'uwp' ]; then
-            [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
-            find . -name '*.exe' -o -name '*.dll'
+          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
+          find . -name '*.exe' -o -name '*.dll'
+          if [ '${{ matrix.test }}' != 'uwp' ]; then  # UWP missing 'msvcr120_app.dll', fails with exit code 0xc0000135
             bld/src/curl.exe --disable --version
           fi
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -283,7 +283,6 @@ jobs:
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll'
-          # UWP missing 'msvcr120_app.dll', fails with exit code 0xc0000135
           [ '${{ matrix.test }}' = 'uwp' ] || bld/src/curl.exe --disable --version
 
       - name: 'cmake build tests'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -156,7 +156,7 @@ jobs:
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
   msys2:
-    name: 'msys2 (${{ matrix.build }}, ${{ matrix.sys }}, ${{ matrix.env }}, ${{ matrix.config }})'
+    name: 'msys2 (${{ matrix.build }}, ${{ matrix.sys }}, ${{ matrix.env }}, ${{ matrix.config }}, ${{ matrix.test }})'
     runs-on: windows-latest
     timeout-minutes: 45
     strategy:
@@ -170,6 +170,7 @@ jobs:
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release' }
           - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DBUILD_EXAMPLES=OFF', type: 'Release', test: 'uwp' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -254,7 +255,7 @@ jobs:
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
-            cflags+=" -specs=${specs} -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
+            cflags+=" -specs=$(cygpath -w "${specs}") -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
             # CMake (as of v3.26.4) gets confused and applies the MSVC rc.exe command-line
             # template to windres. Reset it to the windres template manually:
             rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
@@ -282,7 +283,8 @@ jobs:
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
           [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll'
-          bld/src/curl.exe --disable --version
+          # UWP missing 'msvcr120_app.dll', fails with exit code 0xc0000135
+          [ '${{ matrix.test }}' = 'uwp' ] || bld/src/curl.exe --disable --version
 
       - name: 'cmake build tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,6 +278,7 @@ endif()
 
 if(WINDOWS_STORE)
   set(CURL_DISABLE_TELNET ON)
+  set(BUILD_CURL_EXE OFF)
 endif()
 
 option(ENABLE_IPV6 "Define if you want to enable IPv6 support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,10 @@ if(HTTP_ONLY)
   set(CURL_DISABLE_TFTP ON)
 endif()
 
+if(WINDOWS_STORE)
+  set(CURL_DISABLE_TELNET ON)
+endif()
+
 option(ENABLE_IPV6 "Define if you want to enable IPv6 support" ON)
 mark_as_advanced(ENABLE_IPV6)
 if(ENABLE_IPV6 AND NOT WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -769,7 +769,7 @@ if(NOT CURL_DISABLE_SRP AND (HAVE_GNUTLS_SRP OR HAVE_OPENSSL_SRP))
 endif()
 
 if(NOT CURL_DISABLE_LDAP)
-  if(WIN32)
+  if(WIN32 AND NOT WINDOWS_STORE)
     option(USE_WIN32_LDAP "Use Windows LDAP implementation" ON)
     if(USE_WIN32_LDAP)
       list(APPEND CURL_LIBS "wldap32")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,8 +277,7 @@ if(HTTP_ONLY)
 endif()
 
 if(WINDOWS_STORE)
-  set(CURL_DISABLE_TELNET ON)
-  set(BUILD_CURL_EXE OFF)
+  set(CURL_DISABLE_TELNET ON)  # telnet code need fixing to compile successfully for UWP.
 endif()
 
 option(ENABLE_IPV6 "Define if you want to enable IPv6 support" ON)

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -448,7 +448,7 @@ query_complete(DWORD err, DWORD bytes, LPWSAOVERLAPPED overlapped)
  * and wait on it.
  */
 static
-#if defined(_WIN32_WCE)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
 DWORD
 #else
 unsigned int
@@ -507,7 +507,7 @@ CURL_STDCALL getaddrinfo_thread(void *arg)
  * gethostbyname_thread() resolves a name and then exits.
  */
 static
-#if defined(_WIN32_WCE)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
 DWORD
 #else
 unsigned int

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -101,7 +101,7 @@ int Curl_thread_join(curl_thread_t *hnd)
 #elif defined(USE_THREADS_WIN32)
 
 curl_thread_t Curl_thread_create(
-#if defined(_WIN32_WCE)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
                                  DWORD
 #else
                                  unsigned int
@@ -109,14 +109,14 @@ curl_thread_t Curl_thread_create(
                                  (CURL_STDCALL *func) (void *),
                                  void *arg)
 {
-#ifdef _WIN32_WCE
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
   typedef HANDLE curl_win_thread_handle_t;
 #else
   typedef uintptr_t curl_win_thread_handle_t;
 #endif
   curl_thread_t t;
   curl_win_thread_handle_t thread_handle;
-#ifdef _WIN32_WCE
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
   thread_handle = CreateThread(NULL, 0, func, arg, 0, NULL);
 #else
   thread_handle = _beginthreadex(NULL, 0, func, arg, 0, NULL);

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -53,7 +53,7 @@
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
 
 curl_thread_t Curl_thread_create(
-#if defined(_WIN32_WCE)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
                                  DWORD
 #else
                                  unsigned int

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -48,7 +48,8 @@
 
 #ifdef _WIN32
 
-#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600
+#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600 && \
+  !defined(CURL_WINDOWS_APP)
 #  define HAVE_WIN_BCRYPTGENRANDOM
 #  include <bcrypt.h>
 #  ifdef _MSC_VER

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -269,11 +269,13 @@ HMODULE Curl_load_library(LPCTSTR filename)
 
 bool Curl_win32_impersonating(void)
 {
+#ifndef CURL_WINDOWS_APP
   HANDLE token = NULL;
   if(OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, TRUE, &token)) {
     CloseHandle(token);
     return TRUE;
   }
+#endif
   return FALSE;
 }
 

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -112,7 +112,11 @@ CURLcode Curl_win32_init(long flags)
   }
 
 #ifdef USE_WINSOCK
+#ifdef CURL_WINDOWS_APP
+  ws2_32Dll = Curl_load_library(TEXT("ws2_32.dll"));
+#else
   ws2_32Dll = GetModuleHandleA("ws2_32");
+#endif
   if(ws2_32Dll) {
     Curl_FreeAddrInfoExW = CURLX_FUNCTION_CAST(FREEADDRINFOEXW_FN,
       GetProcAddress(ws2_32Dll, "FreeAddrInfoExW"));

--- a/lib/version_win32.c
+++ b/lib/version_win32.c
@@ -80,12 +80,12 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
   bool matched = FALSE;
 
 #if defined(CURL_WINDOWS_APP)
-  (void)buildVersion;
-
   /* We have no way to determine the Windows version from Windows apps,
      so let's assume we're running on the target Windows version. */
   const WORD fullVersion = MAKEWORD(minorVersion, majorVersion);
   const WORD targetVersion = (WORD)_WIN32_WINNT;
+
+  (void)buildVersion;
 
   switch(condition) {
   case VERSION_LESS_THAN:

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2682,6 +2682,13 @@ static void schannel_checksum(const unsigned char *input,
                               DWORD provType,
                               const unsigned int algId)
 {
+#ifdef CURL_WINDOWS_APP
+  (void)input;
+  (void)inputlen;
+  (void)provType;
+  (void)algId;
+  memset(checksum, 0, checksumlen);
+#else
   HCRYPTPROV hProv = 0;
   HCRYPTHASH hHash = 0;
   DWORD cbHashSize = 0;
@@ -2722,6 +2729,7 @@ static void schannel_checksum(const unsigned char *input,
 
   if(hProv)
     CryptReleaseContext(hProv, 0);
+#endif
 }
 
 static CURLcode schannel_sha256sum(const unsigned char *input,
@@ -2906,7 +2914,9 @@ const struct Curl_ssl Curl_ssl_schannel = {
 #ifdef HAS_MANUAL_VERIFY_API
   SSLSUPP_CAINFO_BLOB |
 #endif
+#ifndef CURL_WINDOWS_APP
   SSLSUPP_PINNEDPUBKEY |
+#endif
   SSLSUPP_TLS13_CIPHERSUITES |
   SSLSUPP_CA_CACHE |
   SSLSUPP_HTTPS_PROXY,

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -28,7 +28,8 @@
 
 #ifdef USE_SCHANNEL
 
-#if defined(__MINGW32__) || defined(CERT_CHAIN_REVOCATION_CHECK_CHAIN)
+#if (defined(__MINGW32__) || defined(CERT_CHAIN_REVOCATION_CHECK_CHAIN)) \
+  && !defined(CURL_WINDOWS_APP)
 #define HAS_MANUAL_VERIFY_API
 #endif
 

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -346,6 +346,12 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
                                   DWORD length)
 {
   DWORD actual_length = 0;
+#if defined(CURL_WINDOWS_APP)
+  (void)data;
+  (void)cert_context;
+  (void)host_names;
+  (void)length;
+#else
   BOOL compute_content = FALSE;
   CERT_INFO *cert_info = NULL;
   CERT_EXTENSION *extension = NULL;
@@ -457,6 +463,7 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
     /* Last string has double null-terminator. */
     *current_pos = '\0';
   }
+#endif
   return actual_length;
 }
 

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -66,7 +66,7 @@ unsigned int get_terminal_columns(void)
     struct winsize ts;
     if(!ioctl(STDIN_FILENO, TIOCGWINSZ, &ts))
       cols = (int)ts.ws_col;
-#elif defined(_WIN32)
+#elif defined(_WIN32) && !defined(CURL_WINDOWS_APP)
     {
       HANDLE  stderr_hnd = GetStdHandle(STD_ERROR_HANDLE);
       CONSOLE_SCREEN_BUFFER_INFO console_info;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -620,6 +620,11 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
 {
   CURLcode result = CURLE_OK;
 
+#ifdef CURL_WINDOWS_APP
+  (void)config;
+  (void)backend;
+  (void)bundle_file;
+#else
   /* Search and set cert file only if libcurl supports SSL.
    *
    * If Schannel is the selected SSL backend then these locations are
@@ -645,6 +650,7 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
         result = CURLE_OUT_OF_MEMORY;
     }
   }
+#endif
 
   return result;
 }

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -709,6 +709,9 @@ cleanup:
   return slist;
 }
 
+bool tool_term_has_bold;
+
+#ifndef CURL_WINDOWS_APP
 /* The terminal settings to restore on exit */
 static struct TerminalSettings {
   HANDLE hStdOut;
@@ -719,8 +722,6 @@ static struct TerminalSettings {
 #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
 #define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
 #endif
-
-bool tool_term_has_bold;
 
 static void restore_terminal(void)
 {
@@ -776,6 +777,7 @@ static void init_terminal(void)
     }
   }
 }
+#endif
 
 LARGE_INTEGER tool_freq;
 bool tool_isVistaOrGreater;
@@ -792,7 +794,9 @@ CURLcode win32_init(void)
 
   QueryPerformanceFrequency(&tool_freq);
 
+#ifndef CURL_WINDOWS_APP
   init_terminal();
+#endif
 
   return CURLE_OK;
 }

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -41,7 +41,7 @@ int getfiletime(const char *filename, struct GlobalConfig *global,
 /* Windows stat() may attempt to adjust the unix GMT file time by a daylight
    saving time offset and since it's GMT that is bad behavior. When we have
    access to a 64-bit type we can bypass stat and get the times directly. */
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(CURL_WINDOWS_APP)
   HANDLE hfile;
   TCHAR *tchar_filename = curlx_convert_UTF8_to_tchar((char *)filename);
 
@@ -95,7 +95,7 @@ void setfiletime(curl_off_t filetime, const char *filename,
 /* Windows utime() may attempt to adjust the unix GMT file time by a daylight
    saving time offset and since it's GMT that is bad behavior. When we have
    access to a 64-bit type we can bypass utime and set the times directly. */
-#if defined(_WIN32)
+#if defined(_WIN32) && !defined(CURL_WINDOWS_APP)
     HANDLE hfile;
     TCHAR *tchar_filename = curlx_convert_UTF8_to_tchar((char *)filename);
 

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -29,7 +29,7 @@
 #define NUM_THREADS 100
 
 #ifdef _WIN32
-#ifdef _WIN32_WCE
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
 static DWORD WINAPI run_thread(LPVOID ptr)
 #else
 #include <process.h>
@@ -47,7 +47,7 @@ static unsigned int WINAPI run_thread(void *ptr)
 
 CURLcode test(char *URL)
 {
-#ifdef _WIN32_WCE
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
   typedef HANDLE curl_win_thread_handle_t;
 #else
   typedef uintptr_t curl_win_thread_handle_t;
@@ -78,7 +78,7 @@ CURLcode test(char *URL)
   for(i = 0; i < tid_count; i++) {
     curl_win_thread_handle_t th;
     results[i] = CURL_LAST; /* initialize with invalid value */
-#ifdef _WIN32_WCE
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
     th = CreateThread(NULL, 0, run_thread, &results[i], 0, NULL);
 #else
     th = _beginthreadex(NULL, 0, run_thread, &results[i], 0, NULL);

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -133,6 +133,10 @@ double tutil_tvdiff_secs(struct timeval newer, struct timeval older)
 #ifdef _WIN32
 HMODULE win32_load_system_library(const TCHAR *filename)
 {
+#ifdef CURL_WINDOWS_APP
+  (void)filename;
+  return NULL;
+#else
   size_t filenamelen = _tcslen(filename);
   size_t systemdirlen = GetSystemDirectory(NULL, 0);
   size_t written;
@@ -158,5 +162,6 @@ HMODULE win32_load_system_library(const TCHAR *filename)
   _tcscpy(path + written, filename);
 
   return LoadLibrary(path);
+#endif
 }
 #endif

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -152,7 +152,7 @@ enum sockmode {
   ACTIVE_DISCONNECT  /* as a client, disconnected from server */
 };
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(CURL_WINDOWS_APP)
 /*
  * read-wrapper to support reading from stdin on Windows.
  */
@@ -420,7 +420,7 @@ static bool read_data_block(unsigned char *buffer, ssize_t maxlen,
 }
 
 
-#ifdef USE_WINSOCK
+#if defined(USE_WINSOCK) && !defined(CURL_WINDOWS_APP)
 /*
  * WinSock select() does not support standard file descriptors,
  * it can only check SOCKETs. The following function is an attempt


### PR DESCRIPTION
Add new job to test building for UWP (aka `CURL_WINDOWS_APP`).

Fix fallouts when building for UWP:
- rand: do not use `BCryptGenRandom()`.
- cmake: disable using win32 LDAP.
- cmake: disable telnet.
- version_win32: fix code before declaration.
- schannel: disable `HAS_MANUAL_VERIFY_API`.
- schannel: disable `SSLSUPP_PINNEDPUBKEY`
  and make `schannel_checksum()` a stub.
  Ref: e178fbd40a896f2098278ae61e1166c88e7b31d0 #1429
- schannel: make `cert_get_name_string()` a failing stub.
- system_win32: make `Curl_win32_impersonating()` a failing stub.
- system_win32: try to fix `Curl_win32_init()` (untested).
- threads: fix to use `CreateThread()`.
- src: disable searching `PATH` for the CA bundle.
- src: disable bold text support and capability detection.
- src: disable `getfiletime()`/`setfiletime()`.
- tests: make `win32_load_system_library()` a failing stub.
- tests/server/util: make it compile.
- tests/server/sockfilt: make it compile.
- tests/lib3026: fix to use `CreateThread()`.

See individual commits for build error details.

Some of these fixes may have better solutions, and some may not work
as expected. The goal of this patch is to make curl build for UWP.

Closes #13870

---

- [x] move cmake error log dump to separate commit → #13872
- [x] rebase on WinCE thread entry point result fix → #13877
- [x] rebase on `_WIN32 && !MSDOS` guard tidy-up → #13878
