### PR TITLE
curl-config: revert to backticks to support old target envs

### DIFF
--- a/curl-config.in
+++ b/curl-config.in
@@ -23,6 +23,8 @@
 #
 ###########################################################################
 
+# shellcheck disable=SC2006
+
 prefix="@prefix@"
 # Used in @libdir@
 # shellcheck disable=SC2034
@@ -100,17 +102,17 @@ while test "$#" -gt 0; do
 
   --checkfor)
     checkfor=$2
-    cmajor=$(echo "$checkfor" | cut -d. -f1)
-    cminor=$(echo "$checkfor" | cut -d. -f2)
+    cmajor=`echo "$checkfor" | cut -d. -f1`
+    cminor=`echo "$checkfor" | cut -d. -f2`
     # when extracting the patch part we strip off everything after a
     # dash as that's used for things like version 1.2.3-pre1
-    cpatch=$(echo "$checkfor" | cut -d. -f3 | cut -d- -f1)
+    cpatch=`echo "$checkfor" | cut -d. -f3 | cut -d- -f1`
 
-    vmajor=$(echo '@CURLVERSION@' | cut -d. -f1)
-    vminor=$(echo '@CURLVERSION@' | cut -d. -f2)
+    vmajor=`echo '@CURLVERSION@' | cut -d. -f1`
+    vminor=`echo '@CURLVERSION@' | cut -d. -f2`
     # when extracting the patch part we strip off everything after a
     # dash as that's used for things like version 1.2.3-pre1
-    vpatch=$(echo '@CURLVERSION@' | cut -d. -f3 | cut -d- -f1)
+    vpatch=`echo '@CURLVERSION@' | cut -d. -f3 | cut -d- -f1`
 
     if test "$vmajor" -gt "$cmajor"; then
       exit 0


### PR DESCRIPTION
Make an exception for `curl-config` because this script that may be
running on any target system, including old ones, e.g. SunOS 5.10.

Reported-by: Alejandro R. Sedeño
Ref: https://github.com/curl/curl/pull/13307#issuecomment-2146427358
Follow-up to fa69b41c7790fab86fd363242c81d8ef2e89e183 #13307
Closes #13871
