### PR TITLE
GHA: show cmake error log in Windows and non-native workflows

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -65,7 +65,8 @@ jobs:
               -DBUILD_EXAMPLES=ON \
               -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
-              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON \
+              || { cat bld/CMakeFiles/CMake*.yaml; false; }
             cmake --build bld --config Debug --parallel 3
             "$(pwd)/bld/src/curl" --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -98,7 +99,8 @@ jobs:
               -DBUILD_EXAMPLES=ON \
               -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
-              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON \
+              || { cat bld/CMakeFiles/CMake*.yaml; false; }
             cmake --build bld --config Debug --parallel 3
             "$(pwd)/bld/src/curl" --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -163,7 +165,8 @@ jobs:
               -DBUILD_EXAMPLES=ON \
               -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
-              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON
+              -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON -DCURL_USE_GSSAPI=ON \
+              || { cat bld/CMakeFiles/CMake*.yaml; false; }
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -124,7 +124,7 @@ jobs:
             -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
             -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON \
-            ${{ matrix.config }}
+            ${{ matrix.config }} || { cat bld/CMakeFiles/CMake*.yaml; false; }
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -272,7 +272,7 @@ jobs:
             -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
             -DCURL_BROTLI=ON -DUSE_NGHTTP2=ON \
-            ${{ matrix.config }}
+            ${{ matrix.config }} || { cat bld/CMakeFiles/CMake*.yaml; false; }
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -375,7 +375,7 @@ jobs:
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
-            ${{ matrix.config }}
+            ${{ matrix.config }} || { cat bld/CMakeFiles/CMake*.yaml; false; }
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -447,7 +447,7 @@ jobs:
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
-            ${{ matrix.config }}
+            ${{ matrix.config }} || { cat bld/CMakeFiles/CMake*.yaml; false; }
 
       - name: 'cmake build'
         timeout-minutes: 5


### PR DESCRIPTION
CMake configure doesn't fail often, but when it does, it helps to see
its `CMakeFiles/CMakeConfigureLog.yaml` output. This file is present
since CMake v3.26:
  https://cmake.org/cmake/help/v3.26/manual/cmake-configure-log.7.html

(Older CMake versions save similar contend to
`CMakeFiles\CMakeOutput.log` and
`CMakeFiles\CMakeError.log`. This patch doesn't deal with that because
the workflows touched are all running a newer CMake.)

After this patch, we dump the content if cmake fails. Syncing this with
autotools, where we already did that.

Closes #13872
