### PR TITLE
tests: delete redundant `!MSDOS` guard

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -366,7 +366,7 @@ void clear_advisor_read_lock(const char *filename)
 }
 
 
-#if defined(_WIN32) && !defined(MSDOS)
+#if defined(_WIN32)
 
 static struct timeval tvnow(void)
 {


### PR DESCRIPTION
This fix was supposed to be committed earlier, but ended up missing from
the final commit.

Follow-up to e9a7d4a1c8377dbcf9a2d94365f60e3e5dff48f8 #12376
Closes #13878
