### PR TITLE
url: allow DoH transfers to override max connection limit

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3662,14 +3662,16 @@ static CURLcode create_conn(struct Curl_easy *data,
       conn_candidate = Curl_conncache_extract_oldest(data);
       if(conn_candidate)
         Curl_disconnect(data, conn_candidate, FALSE);
-      else {
+      else
+#ifndef CURL_DISABLE_DOH
         if(data->set.dohfor)
           infof(data, "Allowing DoH to override max connection limit");
-        else {
+        else
+#endif
+        {
           infof(data, "No connections available in cache");
           connections_available = FALSE;
         }
-      }
     }
 
     if(!connections_available) {

--- a/lib/url.c
+++ b/lib/url.c
@@ -3663,8 +3663,12 @@ static CURLcode create_conn(struct Curl_easy *data,
       if(conn_candidate)
         Curl_disconnect(data, conn_candidate, FALSE);
       else {
-        infof(data, "No connections available in cache");
-        connections_available = FALSE;
+        if(data->set.dohfor)
+          infof(data, "Allowing DoH to override max connection limit");
+        else {
+          infof(data, "No connections available in cache");
+          connections_available = FALSE;
+        }
       }
     }
 


### PR DESCRIPTION
When reaching the set maximum limit of allowed connections, allow a new connection anyway if the transfer is created for the (internal) purpose of doing a DoH name resolve. Otherwise, unrelated "normal" transfers can starve out new DoH requests making it impossible to name resolve for new transfers.

Bug: https://curl.se/mail/lib-2024-06/0001.html
Reported-by: kartatz