### PR TITLE
cfilters: make Curl_conn_connect always assign 'done'

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -345,8 +345,10 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
 
   cf = data->conn->cfilter[sockindex];
   DEBUGASSERT(cf);
-  if(!cf)
+  if(!cf) {
+    *done = FALSE;
     return CURLE_FAILED_INIT;
+  }
 
   *done = cf->connected;
   if(!*done) {


### PR DESCRIPTION
It could return error without assigning it, and we have a caller in multi.c that assumes it gets set.

Spotted by CodeSonar