### PR TITLE
connection shutdown, basics and first use

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1077,6 +1077,7 @@ struct Curl_cftype Curl_cft_h1_proxy = {
   cf_h1_proxy_destroy,
   cf_h1_proxy_connect,
   cf_h1_proxy_close,
+  Curl_cf_def_shutdown,
   Curl_cf_http_proxy_get_host,
   cf_h1_proxy_adjust_pollset,
   Curl_cf_def_data_pending,

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -194,6 +194,7 @@ struct Curl_cftype Curl_cft_haproxy = {
   cf_haproxy_destroy,
   cf_haproxy_connect,
   cf_haproxy_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_haproxy_adjust_pollset,
   Curl_cf_def_data_pending,

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1019,7 +1019,6 @@ static CURLcode cf_socket_shutdown(struct Curl_cfilter *cf,
 
     CURL_TRC_CF(data, cf, "cf_socket_shutdown(%" CURL_FORMAT_SOCKET_T
                 ")", ctx->sock);
-#if 0
     /* Temporarily disable this to check if this causes the test
      * hangers on Windows CI jobs */
     if(ctx->sock != CURL_SOCKET_BAD && ctx->transport == TRNSPRT_TCP) {
@@ -1032,7 +1031,6 @@ static CURLcode cf_socket_shutdown(struct Curl_cfilter *cf,
       rctx.data = data;
       (void)nw_in_read(&rctx, buf, sizeof(buf), &result);
     }
-#endif
     cf_socket_close(cf, data);
   }
   *done = TRUE;

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1117,7 +1117,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
   (void)data;
   DEBUGASSERT(ctx->sock == CURL_SOCKET_BAD);
   ctx->started_at = Curl_now();
-#ifdef SOCK_NONBLOCK
+#ifdef USE_SOCK_NONBLOCK
   /* Don't tuck SOCK_NONBLOCK into socktype when opensocket callback is set
    * because we wouldn't know how socketype is about to be used in the
    * callback, SOCK_NONBLOCK might get factored out before calling socket().
@@ -1126,7 +1126,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
     ctx->addr.socktype |= SOCK_NONBLOCK;
 #endif
   result = socket_open(data, &ctx->addr, &ctx->sock);
-#ifdef SOCK_NONBLOCK
+#ifdef USE_SOCK_NONBLOCK
   /* Restore the socktype after the socket is created. */
   if(!data->set.fopensocket)
     ctx->addr.socktype &= ~SOCK_NONBLOCK;
@@ -1201,7 +1201,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
   }
 #endif
 
-#ifndef SOCK_NONBLOCK
+#ifndef USE_SOCK_NONBLOCK
   /* set socket non-blocking */
   (void)curlx_nonblock(ctx->sock, TRUE);
 #else

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1022,9 +1022,11 @@ static CURLcode cf_socket_shutdown(struct Curl_cfilter *cf,
     if(ctx->sock != CURL_SOCKET_BAD && ctx->transport == TRNSPRT_TCP) {
       /* To avoid unwanted TCP RSTs, we do a final receive to discard
        * any bytes before we close the socket. */
-      struct reader_ctx rctx = {cf, data};
+      struct reader_ctx rctx;
       unsigned char buf[1024];
       CURLcode result;
+      rctx.cf = cf;
+      rctx.data = data;
       (void)nw_in_read(&rctx, buf, sizeof(buf), &result);
     }
     cf_socket_close(cf, data);

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1024,12 +1024,10 @@ static CURLcode cf_socket_shutdown(struct Curl_cfilter *cf,
     if(ctx->sock != CURL_SOCKET_BAD && ctx->transport == TRNSPRT_TCP) {
       /* To avoid unwanted TCP RSTs, we do a final receive to discard
        * any bytes before we close the socket. */
-      struct reader_ctx rctx;
       unsigned char buf[1024];
-      CURLcode result;
-      rctx.cf = cf;
-      rctx.data = data;
-      (void)nw_in_read(&rctx, buf, sizeof(buf), &result);
+      /* make double sure we are not blocking */
+      curlx_nonblock(ctx->sock, TRUE);
+      (void)sread(ctx->sock, buf, sizeof(buf));
     }
     cf_socket_close(cf, data);
   }

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1019,6 +1019,9 @@ static CURLcode cf_socket_shutdown(struct Curl_cfilter *cf,
 
     CURL_TRC_CF(data, cf, "cf_socket_shutdown(%" CURL_FORMAT_SOCKET_T
                 ")", ctx->sock);
+#if 0
+    /* Temporarily disable this to check if this causes the test
+     * hangers on Windows CI jobs */
     if(ctx->sock != CURL_SOCKET_BAD && ctx->transport == TRNSPRT_TCP) {
       /* To avoid unwanted TCP RSTs, we do a final receive to discard
        * any bytes before we close the socket. */
@@ -1029,6 +1032,7 @@ static CURLcode cf_socket_shutdown(struct Curl_cfilter *cf,
       rctx.data = data;
       (void)nw_in_read(&rctx, buf, sizeof(buf), &result);
     }
+#endif
     cf_socket_close(cf, data);
   }
   *done = TRUE;

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1113,7 +1113,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
   (void)data;
   DEBUGASSERT(ctx->sock == CURL_SOCKET_BAD);
   ctx->started_at = Curl_now();
-#ifdef USE_SOCK_NONBLOCK
+#ifdef SOCK_NONBLOCK
   /* Don't tuck SOCK_NONBLOCK into socktype when opensocket callback is set
    * because we wouldn't know how socketype is about to be used in the
    * callback, SOCK_NONBLOCK might get factored out before calling socket().
@@ -1122,7 +1122,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
     ctx->addr.socktype |= SOCK_NONBLOCK;
 #endif
   result = socket_open(data, &ctx->addr, &ctx->sock);
-#ifdef USE_SOCK_NONBLOCK
+#ifdef SOCK_NONBLOCK
   /* Restore the socktype after the socket is created. */
   if(!data->set.fopensocket)
     ctx->addr.socktype &= ~SOCK_NONBLOCK;
@@ -1197,7 +1197,7 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
   }
 #endif
 
-#ifndef USE_SOCK_NONBLOCK
+#ifndef SOCK_NONBLOCK
   /* set socket non-blocking */
   (void)curlx_nonblock(ctx->sock, TRUE);
 #else

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -55,6 +55,15 @@ void Curl_cf_def_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 }
 #endif
 
+CURLcode Curl_cf_def_shutdown(struct Curl_cfilter *cf,
+                              struct Curl_easy *data, bool *done)
+{
+  (void)cf;
+  (void)data;
+  *done = TRUE;
+  return CURLE_OK;
+}
+
 static void conn_report_connect_stats(struct Curl_easy *data,
                                       struct connectdata *conn);
 
@@ -166,6 +175,61 @@ void Curl_conn_close(struct Curl_easy *data, int index)
   if(cf) {
     cf->cft->do_close(cf, data);
   }
+}
+
+CURLcode Curl_conn_shutdown_blocking(struct Curl_easy *data, int sockindex)
+{
+  struct Curl_cfilter *cf;
+  CURLcode result = CURLE_OK;
+
+  DEBUGASSERT(data->conn);
+  /* it is valid to call that without filters being present */
+  cf = data->conn->cfilter[sockindex];
+  if(cf) {
+    timediff_t timeout_ms;
+    bool done = FALSE;
+    int what;
+
+    DEBUGF(infof(data, "shutdown start on%s connection",
+           sockindex? " secondary" : ""));
+    Curl_shutdown_start(data, sockindex, NULL);
+    while(cf) {
+      while(!done && !result) {
+        result = cf->cft->do_shutdown(cf, data, &done);
+        if(!result && !done) {
+          timeout_ms = Curl_shutdown_timeleft(data->conn, sockindex, NULL);
+          if(timeout_ms < 0) {
+            failf(data, "SSL shutdown timeout");
+            result = CURLE_OPERATION_TIMEDOUT;
+            goto out;
+          }
+
+          what = Curl_conn_cf_poll(cf, data, timeout_ms);
+          if(what < 0) {
+            /* fatal error */
+            failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);
+            result = CURLE_RECV_ERROR;
+            goto out;
+          }
+          else if(0 == what) {
+            failf(data, "SSL shutdown timeout");
+            result = CURLE_OPERATION_TIMEDOUT;
+            goto out;
+          }
+        }
+      }
+      if(result)
+        break;
+      CURL_TRC_CF(data, cf, "shut down successfully");
+      cf = cf->next;
+      done = FALSE;
+    }
+    Curl_shutdown_clear(data, sockindex);
+    DEBUGF(infof(data, "shutdown done on%s connection -> %d",
+           sockindex? " secondary" : "", result));
+  }
+out:
+  return result;
 }
 
 ssize_t Curl_cf_recv(struct Curl_easy *data, int num, char *buf,
@@ -462,6 +526,39 @@ void Curl_conn_adjust_pollset(struct Curl_easy *data,
   for(i = 0; i < 2; ++i) {
     Curl_conn_cf_adjust_pollset(data->conn->cfilter[i], data, ps);
   }
+}
+
+int Curl_conn_cf_poll(struct Curl_cfilter *cf,
+                      struct Curl_easy *data,
+                      timediff_t timeout_ms)
+{
+  struct easy_pollset ps;
+  struct pollfd pfds[MAX_SOCKSPEREASYHANDLE];
+  unsigned int i, npfds = 0;
+
+  DEBUGASSERT(cf);
+  DEBUGASSERT(data);
+  DEBUGASSERT(data->conn);
+  memset(&ps, 0, sizeof(ps));
+  memset(pfds, 0, sizeof(pfds));
+
+  Curl_conn_cf_adjust_pollset(cf, data, &ps);
+  DEBUGASSERT(ps.num <= MAX_SOCKSPEREASYHANDLE);
+  for(i = 0; i < ps.num; ++i) {
+    short events = 0;
+    if(ps.actions[i] & CURL_POLL_IN) {
+      events |= POLLIN;
+    }
+    if(ps.actions[i] & CURL_POLL_OUT) {
+      events |= POLLOUT;
+    }
+    if(events) {
+      pfds[npfds].fd = ps.sockets[i];
+      pfds[npfds].events = events;
+      ++npfds;
+    }
+  }
+  return Curl_poll(pfds, npfds, timeout_ms);
 }
 
 void Curl_conn_get_host(struct Curl_easy *data, int sockindex,

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -558,6 +558,9 @@ int Curl_conn_cf_poll(struct Curl_cfilter *cf,
       ++npfds;
     }
   }
+
+  if(!npfds)
+    DEBUGF(infof(data, "no sockets to poll!"));
   return Curl_poll(pfds, npfds, timeout_ms);
 }
 

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -24,6 +24,7 @@
  *
  ***************************************************************************/
 
+#include "timediff.h"
 
 struct Curl_cfilter;
 struct Curl_easy;

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -36,8 +36,16 @@ struct connectdata;
 typedef void     Curl_cft_destroy_this(struct Curl_cfilter *cf,
                                        struct Curl_easy *data);
 
+/* Callback to close the connection immediately. */
 typedef void     Curl_cft_close(struct Curl_cfilter *cf,
                                 struct Curl_easy *data);
+
+/* Callback to close the connection filter gracefully, non-blocking.
+ * Implementations MUST NOT chain calls to cf->next.
+ */
+typedef CURLcode Curl_cft_shutdown(struct Curl_cfilter *cf,
+                                   struct Curl_easy *data,
+                                   bool *done);
 
 typedef CURLcode Curl_cft_connect(struct Curl_cfilter *cf,
                                   struct Curl_easy *data,
@@ -194,6 +202,7 @@ struct Curl_cftype {
   Curl_cft_destroy_this *destroy;         /* destroy resources of this cf */
   Curl_cft_connect *do_connect;           /* establish connection */
   Curl_cft_close *do_close;               /* close conn */
+  Curl_cft_shutdown *do_shutdown;         /* shutdown conn */
   Curl_cft_get_host *get_host;            /* host filter talks to */
   Curl_cft_adjust_pollset *adjust_pollset; /* adjust transfer poll set */
   Curl_cft_data_pending *has_data_pending;/* conn has data pending */
@@ -244,6 +253,8 @@ CURLcode Curl_cf_def_conn_keep_alive(struct Curl_cfilter *cf,
 CURLcode Curl_cf_def_query(struct Curl_cfilter *cf,
                            struct Curl_easy *data,
                            int query, int *pres1, void *pres2);
+CURLcode Curl_cf_def_shutdown(struct Curl_cfilter *cf,
+                              struct Curl_easy *data, bool *done);
 
 /**
  * Create a new filter instance, unattached to the filter chain.
@@ -372,6 +383,12 @@ bool Curl_conn_is_multiplex(struct connectdata *conn, int sockindex);
 void Curl_conn_close(struct Curl_easy *data, int sockindex);
 
 /**
+ * Shutdown the connection at `sockindex` blocking with timeout
+ * from `data->set.shutdowntimeout`, default DEFAULT_SHUTDOWN_TIMEOUT_MS
+ */
+CURLcode Curl_conn_shutdown_blocking(struct Curl_easy *data, int sockindex);
+
+/**
  * Return if data is pending in some connection filter at chain
  * `sockindex` for connection `data->conn`.
  */
@@ -401,6 +418,15 @@ void Curl_conn_cf_adjust_pollset(struct Curl_cfilter *cf,
  */
 void Curl_conn_adjust_pollset(struct Curl_easy *data,
                                struct easy_pollset *ps);
+
+/**
+ * Curl_poll() the filter chain at `cf` with timeout `timeout_ms`.
+ * Returns 0 on timeout, negative on error or number of sockets
+ * with requested poll events.
+ */
+int Curl_conn_cf_poll(struct Curl_cfilter *cf,
+                      struct Curl_easy *data,
+                      timediff_t timeout_ms);
 
 /**
  * Receive data through the filter chain at `sockindex` for connection

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -40,6 +40,18 @@ timediff_t Curl_timeleft(struct Curl_easy *data,
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
 
+#define DEFAULT_SHUTDOWN_TIMEOUT_MS   (2 * 1000)
+
+void Curl_shutdown_start(struct Curl_easy *data, int sockindex,
+                         struct curltime *nowp);
+
+/* return how much time there's left to shutdown the connection at
+ * sockindex. */
+timediff_t Curl_shutdown_timeleft(struct connectdata *conn, int sockindex,
+                                  struct curltime *nowp);
+
+void Curl_shutdown_clear(struct Curl_easy *data, int sockindex);
+
 /*
  * Used to extract socket and connectdata struct for the most recent
  * transfer on the given Curl_easy.

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -290,12 +290,15 @@ const struct Curl_handler Curl_handler_ftps = {
 };
 #endif
 
-static void close_secondarysocket(struct Curl_easy *data,
-                                  struct connectdata *conn)
+static void close_secondarysocket(struct Curl_easy *data, bool premature)
 {
+  if(!premature) {
+    CURL_TRC_FTP(data, "[%s] shutting down DATA connection", FTP_DSTATE(data));
+    Curl_conn_shutdown_blocking(data, SECONDARYSOCKET);
+  }
   CURL_TRC_FTP(data, "[%s] closing DATA connection", FTP_DSTATE(data));
   Curl_conn_close(data, SECONDARYSOCKET);
-  Curl_conn_cf_discard_all(data, conn, SECONDARYSOCKET);
+  Curl_conn_cf_discard_all(data, data->conn, SECONDARYSOCKET);
 }
 
 /*
@@ -475,7 +478,7 @@ static CURLcode AcceptServerConnect(struct Curl_easy *data)
     Curl_set_in_callback(data, false);
 
     if(error) {
-      close_secondarysocket(data, conn);
+      close_secondarysocket(data, TRUE);
       return CURLE_ABORTED_BY_CALLBACK;
     }
   }
@@ -2980,7 +2983,13 @@ static CURLcode ftp_statemachine(struct Curl_easy *data,
     case FTP_CCC:
       if(ftpcode < 500) {
         /* First shut down the SSL layer (note: this call will block) */
-        result = Curl_ssl_cfilter_remove(data, FIRSTSOCKET);
+        /* This has only been tested on the proftpd server, and the mod_tls
+         * code sends a close notify alert without waiting for a close notify
+         * alert in response. Thus we wait for a close notify alert from the
+         * server, but we do not send one. Let's hope other servers do
+         * the same... */
+        bool send_shutdown = (data->set.ftp_ccc == CURLFTPSSL_CCC_ACTIVE);
+        result = Curl_ssl_cfilter_remove(data, FIRSTSOCKET, send_shutdown);
 
         if(result)
           failf(data, "Failed to clear the command channel (CCC)");
@@ -3457,7 +3466,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
       }
     }
 
-    close_secondarysocket(data, conn);
+    close_secondarysocket(data, result != CURLE_OK);
   }
 
   if(!result && (ftp->transfer == PPTRANSFER_BODY) && ftpc->ctl_valid &&
@@ -4425,7 +4434,7 @@ static CURLcode ftp_dophase_done(struct Curl_easy *data, bool connected)
     CURLcode result = ftp_do_more(data, &completed);
 
     if(result) {
-      close_secondarysocket(data, conn);
+      close_secondarysocket(data, TRUE);
       return result;
     }
   }

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2988,8 +2988,8 @@ static CURLcode ftp_statemachine(struct Curl_easy *data,
          * alert in response. Thus we wait for a close notify alert from the
          * server, but we do not send one. Let's hope other servers do
          * the same... */
-        bool send_shutdown = (data->set.ftp_ccc == CURLFTPSSL_CCC_ACTIVE);
-        result = Curl_ssl_cfilter_remove(data, FIRSTSOCKET, send_shutdown);
+        result = Curl_ssl_cfilter_remove(data, FIRSTSOCKET,
+          (data->set.ftp_ccc == CURLFTPSSL_CCC_ACTIVE));
 
         if(result)
           failf(data, "Failed to clear the command channel (CCC)");

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -298,6 +298,7 @@ struct Curl_cftype Curl_cft_http_proxy = {
   http_proxy_cf_destroy,
   http_proxy_cf_connect,
   http_proxy_cf_close,
+  Curl_cf_def_shutdown,
   Curl_cf_http_proxy_get_host,
   Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,

--- a/lib/nonblock.h
+++ b/lib/nonblock.h
@@ -26,6 +26,13 @@
 
 #include <curl/curl.h> /* for curl_socket_t */
 
+#if defined(SOCK_NONBLOCK) && !defined(_WIN32)
+/* While SOCK_NONBLOCK may be defined on Windows, it does not
+ * seem to work reliably on all such platforms. Better pay
+ * the price of setting it explicitly via curlx_nonblock(). */
+#define USE_SOCK_NONBLOCK
+#endif
+
 int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
                    int nonblock   /* TRUE or FALSE */);
 

--- a/lib/nonblock.h
+++ b/lib/nonblock.h
@@ -26,13 +26,6 @@
 
 #include <curl/curl.h> /* for curl_socket_t */
 
-#if defined(SOCK_NONBLOCK) && !defined(_WIN32)
-/* While SOCK_NONBLOCK may be defined on Windows, it does not
- * seem to work reliably on all such platforms. Better pay
- * the price of setting it explicitly via curlx_nonblock(). */
-#define USE_SOCK_NONBLOCK
-#endif
-
 int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
                    int nonblock   /* TRUE or FALSE */);
 

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -242,12 +242,12 @@ error:
 int Curl_socketpair(int domain, int type, int protocol,
                     curl_socket_t socks[2], bool nonblocking)
 {
-#ifdef USE_SOCK_NONBLOCK
+#ifdef SOCK_NONBLOCK
   type = nonblocking ? type | SOCK_NONBLOCK : type;
 #endif
   if(socketpair(domain, type, protocol, socks))
     return -1;
-#ifndef USE_SOCK_NONBLOCK
+#ifndef SOCK_NONBLOCK
   if(nonblocking) {
     if(curlx_nonblock(socks[0], TRUE) < 0 ||
        curlx_nonblock(socks[1], TRUE) < 0) {

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -242,12 +242,12 @@ error:
 int Curl_socketpair(int domain, int type, int protocol,
                     curl_socket_t socks[2], bool nonblocking)
 {
-#ifdef SOCK_NONBLOCK
+#ifdef USE_SOCK_NONBLOCK
   type = nonblocking ? type | SOCK_NONBLOCK : type;
 #endif
   if(socketpair(domain, type, protocol, socks))
     return -1;
-#ifndef SOCK_NONBLOCK
+#ifndef USE_SOCK_NONBLOCK
   if(nonblocking) {
     if(curlx_nonblock(socks[0], TRUE) < 0 ||
        curlx_nonblock(socks[1], TRUE) < 0) {

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1249,6 +1249,7 @@ struct Curl_cftype Curl_cft_socks_proxy = {
   socks_proxy_cf_destroy,
   socks_proxy_cf_connect,
   socks_proxy_cf_close,
+  Curl_cf_def_shutdown,
   socks_cf_get_host,
   socks_cf_adjust_pollset,
   Curl_cf_def_data_pending,

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -847,6 +847,10 @@ struct connectdata {
   Curl_recv *recv[2];
   Curl_send *send[2];
   struct Curl_cfilter *cfilter[2]; /* connection filters */
+  struct {
+    struct curltime start[2]; /* when filter shutdown started */
+    unsigned int timeout_ms; /* 0 means no timeout */
+  } shutdown;
 
   struct ssl_primary_config ssl_config;
 #ifndef CURL_DISABLE_PROXY
@@ -1614,9 +1618,10 @@ struct UserDefined {
   void *progress_client; /* pointer to pass to the progress callback */
   void *ioctl_client;   /* pointer to pass to the ioctl callback */
   unsigned int timeout;        /* ms, 0 means no timeout */
-  unsigned int connecttimeout; /* ms, 0 means no timeout */
+  unsigned int connecttimeout; /* ms, 0 means default timeout */
   unsigned int happy_eyeballs_timeout; /* ms, 0 is a valid value */
   unsigned int server_response_timeout; /* ms, 0 means no timeout */
+  unsigned int shutdowntimeout; /* ms, 0 means default timeout */
   long maxage_conn;     /* in seconds, max idle time to allow a connection that
                            is to be reused */
   long maxlifetime_conn; /* in seconds, max time since creation to allow a

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -1038,6 +1038,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_msh3_destroy,
   cf_msh3_connect,
   cf_msh3_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_msh3_adjust_pollset,
   cf_msh3_data_pending,

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2438,6 +2438,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_ngtcp2_destroy,
   cf_ngtcp2_connect,
   cf_ngtcp2_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_ngtcp2_adjust_pollset,
   cf_ngtcp2_data_pending,

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -2252,6 +2252,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_osslq_destroy,
   cf_osslq_connect,
   cf_osslq_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_osslq_adjust_pollset,
   cf_osslq_data_pending,

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1580,6 +1580,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_quiche_destroy,
   cf_quiche_connect,
   cf_quiche_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_quiche_adjust_pollset,
   cf_quiche_data_pending,

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1816,7 +1816,7 @@ static CURLcode gtls_shutdown(struct Curl_cfilter *cf,
   size_t i;
 
   DEBUGASSERT(backend);
-  if(!backend->gtls.session || backend->gtls.shutdown) {
+  if(!backend->gtls.session || connssl->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -1878,7 +1878,7 @@ static void gtls_close(struct Curl_cfilter *cf,
   DEBUGASSERT(backend);
   CURL_TRC_CF(data, cf, "close");
   if(backend->gtls.session) {
-    if(!backend->gtls.shutdown) {
+    if(!connssl->shutdown) {
       bool done;
       gtls_shutdown(cf, data, TRUE, &done);
     }

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1799,6 +1799,74 @@ static ssize_t gtls_send(struct Curl_cfilter *cf,
   return rc;
 }
 
+/*
+ * This function is called to shut down the SSL layer but keep the
+ * socket open (CCC - Clear Command Channel)
+ */
+static CURLcode gtls_shutdown(struct Curl_cfilter *cf,
+                              struct Curl_easy *data,
+                              bool send_shutdown, bool *done)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct gtls_ssl_backend_data *backend =
+    (struct gtls_ssl_backend_data *)connssl->backend;
+  char buf[1024];
+  CURLcode result = CURLE_OK;
+  ssize_t nread;
+  size_t i;
+
+  DEBUGASSERT(backend);
+  if(!backend->gtls.session || backend->gtls.shutdown) {
+    *done = TRUE;
+    goto out;
+  }
+
+  connssl->io_need = CURL_SSL_IO_NEED_NONE;
+  *done = FALSE;
+
+  if(!backend->gtls.sent_shutdown) {
+    /* do this only once */
+    backend->gtls.sent_shutdown = TRUE;
+    if(send_shutdown) {
+      int ret = gnutls_bye(backend->gtls.session, GNUTLS_SHUT_RDWR);
+      if(ret != GNUTLS_E_SUCCESS) {
+        CURL_TRC_CF(data, cf, "SSL shutdown, gnutls_bye error: '%s'(%d)",
+                    gnutls_strerror((int)ret), (int)ret);
+        result = CURLE_RECV_ERROR;
+        goto out;
+      }
+    }
+  }
+
+  /* SSL should now have started the shutdown from our side. Since it
+   * was not complete, we are lacking the close notify from the server. */
+  for(i = 0; i < 10; ++i) {
+    nread = gnutls_record_recv(backend->gtls.session, buf, sizeof(buf));
+    if(nread <= 0)
+      break;
+  }
+  if(nread > 0) {
+    /* still data coming in? */
+  }
+  else if(nread == 0) {
+    /* We got the close notify alert and are done. */
+    *done = TRUE;
+  }
+  else if((nread == GNUTLS_E_AGAIN) || (nread == GNUTLS_E_INTERRUPTED)) {
+    connssl->io_need = gnutls_record_get_direction(backend->gtls.session)?
+      CURL_SSL_IO_NEED_SEND : CURL_SSL_IO_NEED_RECV;
+  }
+  else {
+    CURL_TRC_CF(data, cf, "SSL shutdown, error: '%s'(%d)",
+                gnutls_strerror((int)nread), (int)nread);
+    result = CURLE_RECV_ERROR;
+  }
+
+out:
+  connssl->shutdown = (result || *done);
+  return result;
+}
+
 static void gtls_close(struct Curl_cfilter *cf,
                        struct Curl_easy *data)
 {
@@ -1810,16 +1878,10 @@ static void gtls_close(struct Curl_cfilter *cf,
   DEBUGASSERT(backend);
   CURL_TRC_CF(data, cf, "close");
   if(backend->gtls.session) {
-    char buf[32];
-    /* Maybe the server has already sent a close notify alert.
-       Read it to avoid an RST on the TCP connection. */
-    CURL_TRC_CF(data, cf, "close, try receive before bye");
-    (void)gnutls_record_recv(backend->gtls.session, buf, sizeof(buf));
-    CURL_TRC_CF(data, cf, "close, send bye");
-    gnutls_bye(backend->gtls.session, GNUTLS_SHUT_RDWR);
-    /* try one last receive */
-    CURL_TRC_CF(data, cf, "close, receive after bye");
-    (void)gnutls_record_recv(backend->gtls.session, buf, sizeof(buf));
+    if(!backend->gtls.shutdown) {
+      bool done;
+      gtls_shutdown(cf, data, TRUE, &done);
+    }
     gnutls_deinit(backend->gtls.session);
     backend->gtls.session = NULL;
   }
@@ -1832,88 +1894,6 @@ static void gtls_close(struct Curl_cfilter *cf,
     backend->gtls.srp_client_cred = NULL;
   }
 #endif
-}
-
-/*
- * This function is called to shut down the SSL layer but keep the
- * socket open (CCC - Clear Command Channel)
- */
-static int gtls_shutdown(struct Curl_cfilter *cf,
-                         struct Curl_easy *data)
-{
-  struct ssl_connect_data *connssl = cf->ctx;
-  struct gtls_ssl_backend_data *backend =
-    (struct gtls_ssl_backend_data *)connssl->backend;
-  int retval = 0;
-
-  DEBUGASSERT(backend);
-
-#ifndef CURL_DISABLE_FTP
-  /* This has only been tested on the proftpd server, and the mod_tls code
-     sends a close notify alert without waiting for a close notify alert in
-     response. Thus we wait for a close notify alert from the server, but
-     we do not send one. Let's hope other servers do the same... */
-
-  if(data->set.ftp_ccc == CURLFTPSSL_CCC_ACTIVE)
-    gnutls_bye(backend->gtls.session, GNUTLS_SHUT_WR);
-#endif
-
-  if(backend->gtls.session) {
-    ssize_t result;
-    bool done = FALSE;
-    char buf[120];
-
-    while(!done && !connssl->peer_closed) {
-      int what = SOCKET_READABLE(Curl_conn_cf_get_socket(cf, data),
-                                 SSL_SHUTDOWN_TIMEOUT);
-      if(what > 0) {
-        /* Something to read, let's do it and hope that it is the close
-           notify alert from the server */
-        result = gnutls_record_recv(backend->gtls.session,
-                                    buf, sizeof(buf));
-        switch(result) {
-        case 0:
-          /* This is the expected response. There was no data but only
-             the close notify alert */
-          done = TRUE;
-          break;
-        case GNUTLS_E_AGAIN:
-        case GNUTLS_E_INTERRUPTED:
-          infof(data, "GNUTLS_E_AGAIN || GNUTLS_E_INTERRUPTED");
-          break;
-        default:
-          retval = -1;
-          done = TRUE;
-          break;
-        }
-      }
-      else if(0 == what) {
-        /* timeout */
-        failf(data, "SSL shutdown timeout");
-        done = TRUE;
-      }
-      else {
-        /* anything that gets here is fatally bad */
-        failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);
-        retval = -1;
-        done = TRUE;
-      }
-    }
-    gnutls_deinit(backend->gtls.session);
-  }
-
-#ifdef USE_GNUTLS_SRP
-  {
-    struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-    if(ssl_config->primary.username)
-      gnutls_srp_free_client_credentials(backend->gtls.srp_client_cred);
-  }
-#endif
-
-  backend->gtls.session = NULL;
-  Curl_gtls_shared_creds_free(&backend->gtls.shared_creds);
-
-  return retval;
 }
 
 static ssize_t gtls_recv(struct Curl_cfilter *cf,

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -67,7 +67,6 @@ struct gtls_ctx {
 #endif
   CURLcode io_result; /* result of last IO cfilter operation */
   BIT(sent_shutdown);
-  BIT(shutdown);
 };
 
 typedef CURLcode Curl_gtls_ctx_setup_cb(struct Curl_cfilter *cf,

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -66,6 +66,8 @@ struct gtls_ctx {
   gnutls_srp_client_credentials_t srp_client_cred;
 #endif
   CURLcode io_result; /* result of last IO cfilter operation */
+  BIT(sent_shutdown);
+  BIT(shutdown);
 };
 
 typedef CURLcode Curl_gtls_ctx_setup_cb(struct Curl_cfilter *cf,

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -111,6 +111,7 @@ struct mbed_ssl_backend_data {
 #endif
   int *ciphersuites;
   BIT(initialized); /* mbedtls_ssl_context is initialized */
+  BIT(sent_shutdown);
 };
 
 /* apply threading? */
@@ -1198,23 +1199,108 @@ static void mbedtls_close_all(struct Curl_easy *data)
   (void)data;
 }
 
+static CURLcode mbedtls_shutdown(struct Curl_cfilter *cf,
+                                 struct Curl_easy *data,
+                                 bool send_shutdown, bool *done)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct mbed_ssl_backend_data *backend =
+    (struct mbed_ssl_backend_data *)connssl->backend;
+  unsigned char buf[1024];
+  CURLcode result = CURLE_OK;
+  int ret;
+  size_t i;
+
+  DEBUGASSERT(backend);
+
+  if(!backend->initialized || connssl->shutdown) {
+    *done = TRUE;
+    return CURLE_OK;
+  }
+
+  connssl->io_need = CURL_SSL_IO_NEED_NONE;
+  *done = FALSE;
+
+  if(!backend->sent_shutdown) {
+    /* do this only once */
+    backend->sent_shutdown = TRUE;
+    if(send_shutdown) {
+      ret = mbedtls_ssl_close_notify(&backend->ssl);
+      switch(ret) {
+      case 0: /* we sent it, receive from the server */
+        break;
+      case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY: /* server also closed */
+        *done = TRUE;
+        goto out;
+      case MBEDTLS_ERR_SSL_WANT_READ:
+        connssl->io_need = CURL_SSL_IO_NEED_RECV;
+        goto out;
+      case MBEDTLS_ERR_SSL_WANT_WRITE:
+        connssl->io_need = CURL_SSL_IO_NEED_SEND;
+        goto out;
+      default:
+        CURL_TRC_CF(data, cf, "mbedtls_shutdown error -0x%04X", -ret);
+        result = CURLE_RECV_ERROR;
+        goto out;
+      }
+    }
+  }
+
+  /* SSL should now have started the shutdown from our side. Since it
+   * was not complete, we are lacking the close notify from the server. */
+  for(i = 0; i < 10; ++i) {
+    ret = mbedtls_ssl_read(&backend->ssl, buf, sizeof(buf));
+    /* This seems to be a bug in mbedTLS TLSv1.3 where it reports
+     * WANT_READ, but has not encountered an EAGAIN. */
+    if(ret == MBEDTLS_ERR_SSL_WANT_READ)
+      ret = mbedtls_ssl_read(&backend->ssl, buf, sizeof(buf));
+#ifdef TLS13_SUPPORT
+    if(ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)
+      continue;
+#endif
+    if(ret <= 0)
+      break;
+  }
+
+  if(ret > 0) {
+    /* still data coming in? */
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown, still getting data");
+  }
+  else if(ret == 0 || (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)) {
+    /* We got the close notify alert and are done. */
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown done");
+    *done = TRUE;
+  }
+  else if(ret == MBEDTLS_ERR_SSL_WANT_READ) {
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown, need RECV");
+    connssl->io_need = CURL_SSL_IO_NEED_RECV;
+  }
+  else if(ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown, need SEND");
+    connssl->io_need = CURL_SSL_IO_NEED_SEND;
+  }
+  else {
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown error -0x%04X", -ret);
+    result = CURLE_RECV_ERROR;
+  }
+
+out:
+  connssl->shutdown = (result || *done);
+  return result;
+}
+
 static void mbedtls_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;
 
-  (void)data;
   DEBUGASSERT(backend);
   if(backend->initialized) {
-    char buf[32];
-    int ret;
-
-    /* Maybe the server has already sent a close notify alert.
-       Read it to avoid an RST on the TCP connection. */
-    (void)mbedtls_ssl_read(&backend->ssl, (unsigned char *)buf, sizeof(buf));
-    ret = mbedtls_ssl_close_notify(&backend->ssl);
-    CURL_TRC_CF(data, cf, "close_notify() -> %04x", -ret);
+    if(!connssl->shutdown) {
+      bool done;
+      mbedtls_shutdown(cf, data, TRUE, &done);
+    }
 
     mbedtls_pk_free(&backend->pk);
     mbedtls_x509_crt_free(&backend->clicert);
@@ -1535,7 +1621,7 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   mbedtls_cleanup,                  /* cleanup */
   mbedtls_version,                  /* version */
   Curl_none_check_cxn,              /* check_cxn */
-  Curl_none_shutdown,               /* shutdown */
+  mbedtls_shutdown,                 /* shutdown */
   mbedtls_data_pending,             /* data_pending */
   mbedtls_random,                   /* random */
   Curl_none_cert_status_request,    /* cert_status_request */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -785,6 +785,7 @@ cr_shutdown(struct Curl_cfilter *cf,
   }
   else if(result == CURLE_AGAIN) {
     connssl->io_need = CURL_SSL_IO_NEED_RECV;
+    result = CURLE_OK;
   }
   else {
     DEBUGASSERT(result);

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -48,6 +48,7 @@ struct rustls_ssl_backend_data
   struct rustls_connection *conn;
   size_t plain_out_buffered;
   BIT(data_in_pending);
+  BIT(sent_shutdown);
 };
 
 /* For a given rustls_result error code, return the best-matching CURLcode. */
@@ -727,22 +728,89 @@ cr_get_internals(struct ssl_connect_data *connssl,
   return &backend->conn;
 }
 
+static CURLcode
+cr_shutdown(struct Curl_cfilter *cf,
+            struct Curl_easy *data,
+            bool send_shutdown, bool *done)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct rustls_ssl_backend_data *backend =
+    (struct rustls_ssl_backend_data *)connssl->backend;
+  CURLcode result = CURLE_OK;
+  ssize_t nwritten, nread;
+  char buf[1024];
+  size_t i;
+
+  DEBUGASSERT(backend);
+  if(!backend->conn || connssl->shutdown) {
+    *done = TRUE;
+    goto out;
+  }
+
+  connssl->io_need = CURL_SSL_IO_NEED_NONE;
+  *done = FALSE;
+
+  if(!backend->sent_shutdown) {
+    /* do this only once */
+    backend->sent_shutdown = TRUE;
+    if(send_shutdown) {
+      rustls_connection_send_close_notify(backend->conn);
+    }
+  }
+
+  nwritten = cr_send(cf, data, NULL, 0, &result);
+  if(nwritten < 0) {
+    if(result == CURLE_AGAIN) {
+      connssl->io_need = CURL_SSL_IO_NEED_SEND;
+      result = CURLE_OK;
+      goto out;
+    }
+    DEBUGASSERT(result);
+    CURL_TRC_CF(data, cf, "shutdown send failed: %d", result);
+    goto out;
+  }
+
+  for(i = 0; i < 10; ++i) {
+    nread = cr_recv(cf, data, buf, (int)sizeof(buf), &result);
+    if(nread <= 0)
+      break;
+  }
+
+  if(nread > 0) {
+    /* still data coming in? */
+  }
+  else if(nread == 0) {
+    /* We got the close notify alert and are done. */
+    *done = TRUE;
+  }
+  else if(result == CURLE_AGAIN) {
+    connssl->io_need = CURL_SSL_IO_NEED_RECV;
+  }
+  else {
+    DEBUGASSERT(result);
+    CURL_TRC_CF(data, cf, "shutdown, error: %d", result);
+  }
+
+out:
+  connssl->shutdown = (result || *done);
+  return result;
+}
+
 static void
 cr_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
   struct rustls_ssl_backend_data *backend =
     (struct rustls_ssl_backend_data *)connssl->backend;
-  CURLcode tmperr = CURLE_OK;
-  ssize_t n = 0;
 
   DEBUGASSERT(backend);
-  if(backend->conn && !connssl->peer_closed) {
-    CURL_TRC_CF(data, cf, "closing connection, send notify");
-    rustls_connection_send_close_notify(backend->conn);
-    n = cr_send(cf, data, NULL, 0, &tmperr);
-    if(n < 0) {
-      failf(data, "rustls: error sending close_notify: %d", tmperr);
+  if(backend->conn) {
+    /* Send the TLS shutdown if have not done so already and are still
+     * connected *and* if the peer did not already close the connection. */
+    if(cf->connected && !connssl->shutdown &&
+       cf->next && cf->next->connected && !connssl->peer_closed) {
+      bool done;
+      (void)cr_shutdown(cf, data, TRUE, &done);
     }
 
     rustls_connection_free(backend->conn);
@@ -770,7 +838,7 @@ const struct Curl_ssl Curl_ssl_rustls = {
   Curl_none_cleanup,               /* cleanup */
   cr_version,                      /* version */
   Curl_none_check_cxn,             /* check_cxn */
-  Curl_none_shutdown,              /* shutdown */
+  cr_shutdown,                     /* shutdown */
   cr_data_pending,                 /* data_pending */
   Curl_none_random,                /* random */
   Curl_none_cert_status_request,   /* cert_status_request */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2470,8 +2470,9 @@ static bool schannel_data_pending(struct Curl_cfilter *cf,
 /* shut down the SSL connection and clean up related memory.
    this function can be called multiple times on the same connection including
    if the SSL connection failed (eg connection made but failed handshake). */
-static int schannel_shutdown(struct Curl_cfilter *cf,
-                             struct Curl_easy *data)
+static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
+                                  struct Curl_easy *data,
+                                  bool send_shutdown, bool *done)
 {
   /* See https://msdn.microsoft.com/en-us/library/windows/desktop/aa380138.aspx
    * Shutting Down an Schannel Connection
@@ -2479,10 +2480,17 @@ static int schannel_shutdown(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct schannel_ssl_backend_data *backend =
     (struct schannel_ssl_backend_data *)connssl->backend;
+  CURLcode result = CURLE_OK;
+
+  if(connssl->shutdown) {
+    *done = TRUE;
+    return CURLE_OK;
+  }
 
   DEBUGASSERT(data);
   DEBUGASSERT(backend);
 
+  *done = FALSE;
   if(backend->ctxt) {
     infof(data, "schannel: shutting down SSL/TLS connection with %s port %d",
           connssl->peer.hostname, connssl->peer.port);
@@ -2507,6 +2515,8 @@ static int schannel_shutdown(struct Curl_cfilter *cf,
       char buffer[STRERROR_LEN];
       failf(data, "schannel: ApplyControlToken failure: %s",
             Curl_sspi_strerror(sspi_status, buffer, sizeof(buffer)));
+      result = CURLE_SEND_ERROR;
+      goto out;
     }
 
     /* setup output buffer */
@@ -2536,8 +2546,30 @@ static int schannel_shutdown(struct Curl_cfilter *cf,
       if((result != CURLE_OK) || (outbuf.cbBuffer != (size_t) written)) {
         infof(data, "schannel: failed to send close msg: %s"
               " (bytes written: %zd)", curl_easy_strerror(result), written);
+        result = CURLE_SEND_ERROR;
       }
     }
+  }
+
+out:
+  connssl->shutdown = (result || *done);
+  return result;
+}
+
+static void schannel_close(struct Curl_cfilter *cf, struct Curl_easy *data)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct schannel_ssl_backend_data *backend =
+    (struct schannel_ssl_backend_data *)connssl->backend;
+
+  DEBUGASSERT(data);
+  DEBUGASSERT(backend);
+
+  if(backend->cred && backend->ctxt &&
+     cf->connected && !connssl->shutdown &&
+     cf->next && cf->next->connected && !connssl->peer_closed) {
+    bool done;
+    (void)schannel_shutdown(cf, data, TRUE, &done);
   }
 
   /* free SSPI Schannel API security context handle */
@@ -2570,12 +2602,7 @@ static int schannel_shutdown(struct Curl_cfilter *cf,
     backend->decdata_offset = 0;
   }
 
-  return CURLE_OK;
-}
-
-static void schannel_close(struct Curl_cfilter *cf, struct Curl_easy *data)
-{
-  schannel_shutdown(cf, data);
+    schannel_shutdown(cf, data);
 }
 
 static int schannel_init(void)

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2490,6 +2490,9 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
   DEBUGASSERT(data);
   DEBUGASSERT(backend);
 
+  /* Not supported in schannel */
+  (void)send_shutdown;
+
   *done = FALSE;
   if(backend->ctxt) {
     infof(data, "schannel: shutting down SSL/TLS connection with %s port %d",
@@ -2502,7 +2505,6 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
     SECURITY_STATUS sspi_status;
     SecBuffer outbuf;
     SecBufferDesc outbuf_desc;
-    CURLcode result;
     DWORD dwshut = SCHANNEL_SHUTDOWN;
 
     InitSecBuffer(&Buffer, SECBUFFER_TOKEN, &dwshut, sizeof(dwshut));
@@ -2601,8 +2603,6 @@ static void schannel_close(struct Curl_cfilter *cf, struct Curl_easy *data)
     backend->decdata_length = 0;
     backend->decdata_offset = 0;
   }
-
-    schannel_shutdown(cf, data);
 }
 
 static int schannel_init(void)

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -153,6 +153,7 @@ struct st_ssl_backend_data {
   SSLContextRef ssl_ctx;
   bool ssl_direction; /* true if writing, false if reading */
   size_t ssl_write_buffered_length;
+  BIT(sent_shutdown);
 };
 
 /* Create the list of default ciphers to use by making an intersection of the
@@ -2555,6 +2556,92 @@ static CURLcode sectransp_connect(struct Curl_cfilter *cf,
   return CURLE_OK;
 }
 
+static ssize_t sectransp_recv(struct Curl_cfilter *cf,
+                              struct Curl_easy *data,
+                              char *buf,
+                              size_t buffersize,
+                              CURLcode *curlcode);
+
+static CURLcode sectransp_shutdown(struct Curl_cfilter *cf,
+                                   struct Curl_easy *data,
+                                   bool send_shutdown, bool *done)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct st_ssl_backend_data *backend =
+    (struct st_ssl_backend_data *)connssl->backend;
+  CURLcode result = CURLE_OK;
+  ssize_t nread;
+  char buf[1024];
+  size_t i;
+
+  DEBUGASSERT(backend);
+  if(!backend->ssl_ctx || connssl->shutdown) {
+    *done = TRUE;
+    goto out;
+  }
+
+  connssl->io_need = CURL_SSL_IO_NEED_NONE;
+  *done = FALSE;
+
+  if(send_shutdown && !backend->sent_shutdown) {
+    OSStatus err;
+
+    CURL_TRC_CF(data, cf, "shutdown, send close notify");
+    err = SSLClose(backend->ssl_ctx);
+    switch(err) {
+      case noErr:
+        backend->sent_shutdown = TRUE;
+        break;
+      case errSSLWouldBlock:
+        connssl->io_need = CURL_SSL_IO_NEED_SEND;
+        result = CURLE_OK;
+        goto out;
+      default:
+        CURL_TRC_CF(data, cf, "shutdown, error: %d", (int)err);
+        result = CURLE_SEND_ERROR;
+        goto out;
+    }
+  }
+
+  for(i = 0; i < 10; ++i) {
+    if(!backend->sent_shutdown) {
+      nread = sectransp_recv(cf, data, buf, (int)sizeof(buf), &result);
+    }
+    else {
+      /* We would like to read the close notify from the server using
+       * secure transport, however SSLRead() no longer works after we
+       * sent the notify from our side. So, we just read from the
+       * underlying filter and hope it will end. */
+      nread = Curl_conn_cf_recv(cf->next, data, buf, sizeof(buf), &result);
+    }
+    CURL_TRC_CF(data, cf, "shutdown read -> %zd, %d", nread, result);
+    if(nread <= 0)
+      break;
+  }
+
+  if(nread > 0) {
+    /* still data coming in? */
+    connssl->io_need = CURL_SSL_IO_NEED_RECV;
+  }
+  else if(nread == 0) {
+    /* We got the close notify alert and are done. */
+    CURL_TRC_CF(data, cf, "shutdown done");
+    *done = TRUE;
+  }
+  else if(result == CURLE_AGAIN) {
+    connssl->io_need = CURL_SSL_IO_NEED_RECV;
+    result = CURLE_OK;
+  }
+  else {
+    DEBUGASSERT(result);
+    CURL_TRC_CF(data, cf, "shutdown, error: %d", result);
+  }
+
+out:
+  connssl->shutdown = (result || *done);
+  return result;
+}
+
 static void sectransp_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
@@ -2567,7 +2654,12 @@ static void sectransp_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   if(backend->ssl_ctx) {
     CURL_TRC_CF(data, cf, "close");
-    (void)SSLClose(backend->ssl_ctx);
+    if(cf->connected && !connssl->shutdown &&
+       cf->next && cf->next->connected && !connssl->peer_closed) {
+      bool done;
+      (void)sectransp_shutdown(cf, data, TRUE, &done);
+    }
+
 #if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
     if(SSLCreateContext)
       CFRelease(backend->ssl_ctx);
@@ -2580,69 +2672,6 @@ static void sectransp_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 #endif /* CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS */
     backend->ssl_ctx = NULL;
   }
-}
-
-static int sectransp_shutdown(struct Curl_cfilter *cf,
-                              struct Curl_easy *data)
-{
-  struct ssl_connect_data *connssl = cf->ctx;
-  struct st_ssl_backend_data *backend =
-    (struct st_ssl_backend_data *)connssl->backend;
-  ssize_t nread;
-  int what;
-  int rc;
-  char buf[120];
-  int loop = 10; /* avoid getting stuck */
-  CURLcode result;
-
-  DEBUGASSERT(backend);
-
-  if(!backend->ssl_ctx)
-    return 0;
-
-#ifndef CURL_DISABLE_FTP
-  if(data->set.ftp_ccc != CURLFTPSSL_CCC_ACTIVE)
-    return 0;
-#endif
-
-  sectransp_close(cf, data);
-
-  rc = 0;
-
-  what = SOCKET_READABLE(Curl_conn_cf_get_socket(cf, data),
-                         SSL_SHUTDOWN_TIMEOUT);
-
-  CURL_TRC_CF(data, cf, "shutdown");
-  while(loop--) {
-    if(what < 0) {
-      /* anything that gets here is fatally bad */
-      failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);
-      rc = -1;
-      break;
-    }
-
-    if(!what) {                                /* timeout */
-      failf(data, "SSL shutdown timeout");
-      break;
-    }
-
-    /* Something to read, let's do it and hope that it is the close
-     notify alert from the server. No way to SSL_Read now, so use read(). */
-
-    nread = Curl_conn_cf_recv(cf->next, data, buf, sizeof(buf), &result);
-
-    if(nread < 0) {
-      failf(data, "read: %s", curl_easy_strerror(result));
-      rc = -1;
-    }
-
-    if(nread <= 0)
-      break;
-
-    what = SOCKET_READABLE(Curl_conn_cf_get_socket(cf, data), 0);
-  }
-
-  return rc;
 }
 
 static size_t sectransp_version(char *buffer, size_t size)

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -2058,6 +2058,7 @@ static CURLcode vtls_shutdown_blocking(struct Curl_cfilter *cf,
   }
   CF_DATA_SAVE(save, cf, data);
 
+  *done = FALSE;
   while(!result && !*done && loop--) {
     timeout_ms = Curl_shutdown_timeleft(cf->conn, cf->sockindex, NULL);
 

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1778,11 +1778,9 @@ static void ssl_cf_adjust_pollset(struct Curl_cfilter *cf,
 {
   struct cf_call_data save;
 
-  if(!cf->connected) {
-    CF_DATA_SAVE(save, cf, data);
-    Curl_ssl->adjust_pollset(cf, data, ps);
-    CF_DATA_RESTORE(cf, save);
-  }
+  CF_DATA_SAVE(save, cf, data);
+  Curl_ssl->adjust_pollset(cf, data, ps);
+  CF_DATA_RESTORE(cf, save);
 }
 
 static CURLcode ssl_cf_cntrl(struct Curl_cfilter *cf,

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -68,6 +68,8 @@
 #include "curl_base64.h"
 #include "curl_printf.h"
 #include "inet_pton.h"
+#include "connect.h"
+#include "select.h"
 #include "strdup.h"
 
 /* The last #include files should be: */
@@ -1168,12 +1170,18 @@ int Curl_none_init(void)
 void Curl_none_cleanup(void)
 { }
 
-int Curl_none_shutdown(struct Curl_cfilter *cf UNUSED_PARAM,
-                       struct Curl_easy *data UNUSED_PARAM)
+CURLcode Curl_none_shutdown(struct Curl_cfilter *cf UNUSED_PARAM,
+                            struct Curl_easy *data UNUSED_PARAM,
+                            bool send_shutdown UNUSED_PARAM,
+                            bool *done)
 {
   (void)data;
   (void)cf;
-  return 0;
+  (void)send_shutdown;
+  /* Every SSL backend should have a shutdown implementation. Until we
+   * have implemented that, we put this fake in place. */
+  *done = TRUE;
+  return CURLE_OK;
 }
 
 int Curl_none_check_cxn(struct Curl_cfilter *cf, struct Curl_easy *data)
@@ -1745,9 +1753,28 @@ static ssize_t ssl_cf_recv(struct Curl_cfilter *cf,
   return nread;
 }
 
+static CURLcode ssl_cf_shutdown(struct Curl_cfilter *cf,
+                                struct Curl_easy *data,
+                                bool *done)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct cf_call_data save;
+  CURLcode result = CURLE_OK;
+
+  *done = TRUE;
+  if(!connssl->shutdown) {
+    CF_DATA_SAVE(save, cf, data);
+    result = Curl_ssl->shut_down(cf, data, TRUE, done);
+    CURL_TRC_CF(data, cf, "cf_shutdown -> %d, done=%d", result, *done);
+    CF_DATA_RESTORE(cf, save);
+    connssl->shutdown = (result || *done);
+  }
+  return result;
+}
+
 static void ssl_cf_adjust_pollset(struct Curl_cfilter *cf,
-                                   struct Curl_easy *data,
-                                   struct easy_pollset *ps)
+                                  struct Curl_easy *data,
+                                  struct easy_pollset *ps)
 {
   struct cf_call_data save;
 
@@ -1845,6 +1872,7 @@ struct Curl_cftype Curl_cft_ssl = {
   ssl_cf_destroy,
   ssl_cf_connect,
   ssl_cf_close,
+  ssl_cf_shutdown,
   Curl_cf_def_get_host,
   ssl_cf_adjust_pollset,
   ssl_cf_data_pending,
@@ -1865,6 +1893,7 @@ struct Curl_cftype Curl_cft_ssl_proxy = {
   ssl_cf_destroy,
   ssl_cf_connect,
   ssl_cf_close,
+  ssl_cf_shutdown,
   Curl_cf_def_get_host,
   ssl_cf_adjust_pollset,
   ssl_cf_data_pending,
@@ -2015,19 +2044,76 @@ void *Curl_ssl_get_internals(struct Curl_easy *data, int sockindex,
   return result;
 }
 
+static CURLcode vtls_shutdown_blocking(struct Curl_cfilter *cf,
+                                       struct Curl_easy *data,
+                                       bool send_shutdown, bool *done)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct cf_call_data save;
+  CURLcode result = CURLE_OK;
+  timediff_t timeout_ms;
+  int what, loop = 10;
+
+  if(connssl->shutdown) {
+    *done = TRUE;
+    return CURLE_OK;
+  }
+  CF_DATA_SAVE(save, cf, data);
+
+  while(!result && !*done && loop--) {
+    timeout_ms = Curl_shutdown_timeleft(cf->conn, cf->sockindex, NULL);
+
+    if(timeout_ms < 0) {
+      /* no need to continue if time is already up */
+      failf(data, "SSL shutdown timeout");
+      return CURLE_OPERATION_TIMEDOUT;
+    }
+
+    result = Curl_ssl->shut_down(cf, data, send_shutdown, done);
+    if(result ||*done)
+      goto out;
+
+    if(connssl->io_need) {
+      what = Curl_conn_cf_poll(cf, data, timeout_ms);
+      if(what < 0) {
+        /* fatal error */
+        failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);
+        result = CURLE_RECV_ERROR;
+        goto out;
+      }
+      else if(0 == what) {
+        /* timeout */
+        failf(data, "SSL shutdown timeout");
+        result = CURLE_OPERATION_TIMEDOUT;
+        goto out;
+      }
+      /* socket is readable or writable */
+    }
+  }
+out:
+  CF_DATA_RESTORE(cf, save);
+  connssl->shutdown = (result || *done);
+  return result;
+}
+
 CURLcode Curl_ssl_cfilter_remove(struct Curl_easy *data,
-                                 int sockindex)
+                                 int sockindex, bool send_shutdown)
 {
   struct Curl_cfilter *cf, *head;
   CURLcode result = CURLE_OK;
 
-  (void)data;
   head = data->conn? data->conn->cfilter[sockindex] : NULL;
   for(cf = head; cf; cf = cf->next) {
     if(cf->cft == &Curl_cft_ssl) {
-      if(Curl_ssl->shut_down(cf, data))
+      bool done;
+      CURL_TRC_CF(data, cf, "shutdown and remove SSL, start");
+      Curl_shutdown_start(data, sockindex, NULL);
+      result = vtls_shutdown_blocking(cf, data, send_shutdown, &done);
+      Curl_shutdown_clear(data, sockindex);
+      if(!result && !done) /* blocking failed? */
         result = CURLE_SSL_SHUTDOWN_FAILED;
       Curl_conn_cf_discard_sub(head, cf, data, FALSE);
+      CURL_TRC_CF(data, cf, "shutdown and remove SSL, done -> %d", result);
       break;
     }
   }

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -191,7 +191,7 @@ CURLcode Curl_cf_ssl_insert_after(struct Curl_cfilter *cf_at,
                                   struct Curl_easy *data);
 
 CURLcode Curl_ssl_cfilter_remove(struct Curl_easy *data,
-                                 int sockindex);
+                                 int sockindex, bool send_shutdown);
 
 #ifndef CURL_DISABLE_PROXY
 CURLcode Curl_cf_ssl_proxy_insert_after(struct Curl_cfilter *cf_at,
@@ -250,7 +250,7 @@ extern struct Curl_cftype Curl_cft_ssl_proxy;
 #define Curl_ssl_get_internals(a,b,c,d) NULL
 #define Curl_ssl_supports(a,b) FALSE
 #define Curl_ssl_cfilter_add(a,b,c) CURLE_NOT_BUILT_IN
-#define Curl_ssl_cfilter_remove(a,b) CURLE_OK
+#define Curl_ssl_cfilter_remove(a,b,c) CURLE_OK
 #define Curl_ssl_cf_get_config(a,b) NULL
 #define Curl_ssl_cf_get_primary_config(a) NULL
 #endif

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1341,6 +1341,99 @@ static ssize_t wolfssl_send(struct Curl_cfilter *cf,
   return rc;
 }
 
+static CURLcode wolfssl_shutdown(struct Curl_cfilter *cf,
+                                 struct Curl_easy *data,
+                                 bool send_shutdown, bool *done)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct wolfssl_ctx *wctx = (struct wolfssl_ctx *)connssl->backend;
+  CURLcode result = CURLE_OK;
+  char buf[1024];
+  int nread, err;
+
+  DEBUGASSERT(wctx);
+  if(!wctx->handle || connssl->shutdown) {
+    *done = TRUE;
+    goto out;
+  }
+
+  connssl->io_need = CURL_SSL_IO_NEED_NONE;
+  *done = FALSE;
+  if(!(wolfSSL_get_shutdown(wctx->handle) & SSL_SENT_SHUTDOWN)) {
+    /* We have not started the shutdown from our side yet. Check
+     * if the server already sent us one. */
+    ERR_clear_error();
+    nread = wolfSSL_read(wctx->handle, buf, (int)sizeof(buf));
+    err = wolfSSL_get_error(wctx->handle, nread);
+    if(!nread && err == SSL_ERROR_ZERO_RETURN) {
+      bool input_pending;
+      /* Yes, it did. */
+      if(!send_shutdown) {
+        connssl->shutdown = TRUE;
+        CURL_TRC_CF(data, cf, "SSL shutdown received, not sending");
+        goto out;
+      }
+      else if(!cf->next->cft->is_alive(cf->next, data, &input_pending)) {
+        /* Server closed the connection after its closy notify. It
+         * seems not interested to see our close notify, so do not
+         * send it. We are done. */
+        connssl->peer_closed = TRUE;
+        connssl->shutdown = TRUE;
+        CURL_TRC_CF(data, cf, "peer closed connection");
+        goto out;
+      }
+    }
+  }
+
+  if(send_shutdown && wolfSSL_shutdown(wctx->handle) == 1) {
+    CURL_TRC_CF(data, cf, "SSL shutdown finished");
+    *done = TRUE;
+    goto out;
+  }
+  else {
+    size_t i;
+    /* SSL should now have started the shutdown from our side. Since it
+     * was not complete, we are lacking the close notify from the server. */
+    for(i = 0; i < 10; ++i) {
+      ERR_clear_error();
+      nread = wolfSSL_read(wctx->handle, buf, (int)sizeof(buf));
+      if(nread <= 0)
+        break;
+    }
+    err = wolfSSL_get_error(wctx->handle, nread);
+    switch(err) {
+    case SSL_ERROR_ZERO_RETURN: /* no more data */
+      CURL_TRC_CF(data, cf, "SSL shutdown received");
+      *done = TRUE;
+      break;
+    case SSL_ERROR_NONE: /* just did not get anything */
+    case SSL_ERROR_WANT_READ:
+      /* SSL has send its notify and now wants to read the reply
+       * from the server. We are not really interested in that. */
+      CURL_TRC_CF(data, cf, "SSL shutdown sent, want receive");
+      connssl->io_need = CURL_SSL_IO_NEED_RECV;
+      break;
+    case SSL_ERROR_WANT_WRITE:
+      CURL_TRC_CF(data, cf, "SSL shutdown send blocked");
+      connssl->io_need = CURL_SSL_IO_NEED_SEND;
+      break;
+    default: {
+      char error_buffer[WOLFSSL_MAX_ERROR_SZ];
+      int detail = wolfSSL_get_error(wctx->handle, err);
+      CURL_TRC_CF(data, cf, "SSL shutdown, error: '%s'(%d)",
+                  wolfSSL_ERR_error_string((unsigned long)err, error_buffer),
+                  detail);
+      result = CURLE_RECV_ERROR;
+      break;
+    }
+    }
+  }
+
+out:
+  connssl->shutdown = (result || *done);
+  return result;
+}
+
 static void wolfssl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
@@ -1352,12 +1445,11 @@ static void wolfssl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   DEBUGASSERT(backend);
 
   if(backend->handle) {
-    char buf[32];
-    /* Maybe the server has already sent a close notify alert.
-       Read it to avoid an RST on the TCP connection. */
-    (void)wolfSSL_read(backend->handle, buf, (int)sizeof(buf));
-    if(!connssl->peer_closed)
-      (void)wolfSSL_shutdown(backend->handle);
+    if(cf->connected && !connssl->shutdown &&
+       cf->next && cf->next->connected && !connssl->peer_closed) {
+      bool done;
+      (void)wolfssl_shutdown(cf, data, TRUE, &done);
+    }
     wolfSSL_free(backend->handle);
     backend->handle = NULL;
   }
@@ -1658,7 +1750,7 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   wolfssl_cleanup,                 /* cleanup */
   wolfssl_version,                 /* version */
   Curl_none_check_cxn,             /* check_cxn */
-  Curl_none_shutdown,              /* shutdown */
+  wolfssl_shutdown,                /* shutdown */
   wolfssl_data_pending,            /* data_pending */
   wolfssl_random,                  /* random */
   Curl_none_cert_status_request,   /* cert_status_request */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1468,31 +1468,6 @@ static bool wolfssl_data_pending(struct Curl_cfilter *cf,
     return FALSE;
 }
 
-
-/*
- * This function is called to shut down the SSL layer but keep the
- * socket open (CCC - Clear Command Channel)
- */
-static int wolfssl_shutdown(struct Curl_cfilter *cf,
-                            struct Curl_easy *data)
-{
-  struct ssl_connect_data *ctx = cf->ctx;
-  struct wolfssl_ctx *backend;
-  int retval = 0;
-
-  (void)data;
-  DEBUGASSERT(ctx && ctx->backend);
-
-  backend = (struct wolfssl_ctx *)ctx->backend;
-  if(backend->handle) {
-    wolfSSL_ERR_clear_error();
-    wolfSSL_free(backend->handle);
-    backend->handle = NULL;
-  }
-  return retval;
-}
-
-
 static CURLcode
 wolfssl_connect_common(struct Curl_cfilter *cf,
                        struct Curl_easy *data,
@@ -1683,7 +1658,7 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   wolfssl_cleanup,                 /* cleanup */
   wolfssl_version,                 /* version */
   Curl_none_check_cxn,             /* check_cxn */
-  wolfssl_shutdown,                /* shutdown */
+  Curl_none_shutdown,              /* shutdown */
   wolfssl_data_pending,            /* data_pending */
   wolfssl_random,                  /* random */
   Curl_none_cert_status_request,   /* cert_status_request */

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -38,9 +38,6 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.skipif(condition=not Env.has_vsftpd(), reason=f"missing vsftpd")
-# rustsl: transfers sometimes fail with "received corrupt message of type InvalidContentType"
-# sporadic, never seen when filter tracing is on
-@pytest.mark.skipif(condition=Env.curl_uses_lib('rustls-ffi'), reason=f"rustls unreliable here")
 class TestVsFTPD:
 
     SUPPORTS_SSL = True

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -159,6 +159,7 @@ static struct Curl_cftype cft_test = {
   cf_test_destroy,
   cf_test_connect,
   Curl_cf_def_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,


### PR DESCRIPTION
This adds connection shutdown infrastructure and first use for FTP in combination with OpenSSL. FTP data connections, when not encountering an error, are now shut down in a blocking way with a 2sec timeout.

- add cfilter `Curl_cft_shutdown` callback
- keep a shutdown start timestamp and timeout at connectdata
- provide shutdown timeout default and member in `data->set.shutdowntimeout`.
- provide methods for starting, interrogating and clearing shutdown timers
- provide `Curl_conn_shutdown_blocking()` to shutdown the `sockindex` filter chain in a blocking way. Use that in FTP.
- add `Curl_conn_cf_poll()` to wait for socket events during shutdown of a connection filter chain. This gets the monitoring sockets and events via the filters "adjust_pollset()" methods. This gives correct behaviour when shutting down a TLS connection through a HTTP/2 proxy.
- Implement shutdown for socket, http/2 and openssl filters
- add shutdown forwarding to happy eyeballers and https connect ballers when applicable.
- have dummy implementation for other TLS backends until we get to implement them.

Update: added shutdown support in gnutls, bearssl, mbedtls, wolfssl and rustls.
Update: added shutdown support in schannel