### PR TITLE
cmdline-opts/ech.md: shorten the help text

### DIFF
--- a/docs/cmdline-opts/ech.md
+++ b/docs/cmdline-opts/ech.md
@@ -3,7 +3,7 @@ c: Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 Long: ech
 Arg: <config>
-Help: Configure Encrypted Client Hello (ECH) for use with the TLS session
+Help: Configure ECH
 Added: 8.8.0
 Category: tls ECH
 Protocols: HTTPS

--- a/src/tool_listhelp.c
+++ b/src/tool_listhelp.c
@@ -169,7 +169,7 @@ const struct helptxt helptext[] = {
    "Write the received headers to <filename>",
    CURLHELP_HTTP | CURLHELP_FTP},
   {"    --ech <config>",
-   "Configure Encrypted Client Hello (ECH) for use with the TLS session",
+   "Configure ECH",
    CURLHELP_TLS | CURLHELP_ECH},
   {"    --egd-file <file>",
    "EGD socket path for random data",


### PR DESCRIPTION
To make --help look sensible again