### PR TITLE
managen: warn on excessively long help texts

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -783,7 +783,9 @@ sub getshortlong {
     my $protocols;
     my $category;
     my $start = 0;
+    my $line = 0;
     while(<F>) {
+        $line++;
         if(!$start) {
             if(/^---/) {
                 $start = 1;
@@ -798,6 +800,11 @@ sub getshortlong {
         }
         elsif(/^Help: (.*)/i) {
             $help=$1;
+            my $len = length($help);
+            if($len >= 49) {
+                printf STDERR "$f:$line:1:WARN: oversized help text: %d characters\n",
+                    $len;
+            }
         }
         elsif(/^Arg: (.*)/i) {
             $arg=$1;


### PR DESCRIPTION
Help texts at 49 characters or longer get a warning displayed because they make --help output uglier and we should make an effort to keep the help texts short and succinct.

The warning is only for display, it does not break the build. That is left for the future if necessary.

I picked 49 because the longest current text is 48.