### PR TITLE
build: silence `-Wsign-conversion` in `FD_SET()`/`FD_ISSET()`

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1207,10 +1207,19 @@ CURLMcode curl_multi_fdset(struct Curl_multi *multi,
       if(!FDSET_SOCK(ps.sockets[i]))
         /* pretend it doesn't exist */
         continue;
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+/* error: conversion to 'long unsigned int' from 'curl_socket_t'
+          {aka 'int'} may change the sign of the result */
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       if(ps.actions[i] & CURL_POLL_IN)
         FD_SET(ps.sockets[i], read_fd_set);
       if(ps.actions[i] & CURL_POLL_OUT)
         FD_SET(ps.sockets[i], write_fd_set);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       if((int)ps.sockets[i] > this_max_fd)
         this_max_fd = (int)ps.sockets[i];
     }

--- a/lib/select.c
+++ b/lib/select.c
@@ -347,12 +347,19 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
                          POLLRDNORM|POLLWRNORM|POLLRDBAND)) {
       if(ufds[i].fd > maxfd)
         maxfd = ufds[i].fd;
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       if(ufds[i].events & (POLLRDNORM|POLLIN))
         FD_SET(ufds[i].fd, &fds_read);
       if(ufds[i].events & (POLLWRNORM|POLLOUT))
         FD_SET(ufds[i].fd, &fds_write);
       if(ufds[i].events & (POLLRDBAND|POLLPRI))
         FD_SET(ufds[i].fd, &fds_err);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     }
   }
 
@@ -375,6 +382,10 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
     ufds[i].revents = 0;
     if(ufds[i].fd == CURL_SOCKET_BAD)
       continue;
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(ufds[i].fd, &fds_read)) {
       if(ufds[i].events & POLLRDNORM)
         ufds[i].revents |= POLLRDNORM;
@@ -393,6 +404,9 @@ int Curl_poll(struct pollfd ufds[], unsigned int nfds, timediff_t timeout_ms)
       if(ufds[i].events & POLLPRI)
         ufds[i].revents |= POLLPRI;
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     if(ufds[i].revents)
       r++;
   }

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -76,7 +76,16 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
       timeout.tv_usec = (int)((wait%1000)*1000);
 
       FD_ZERO(&bits);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+/* error: conversion to 'long unsigned int' from 'int'
+          may change the sign of the result */
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       FD_SET(per->infd, &bits);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       if(!select(per->infd + 1, &bits, NULL, NULL, &timeout))
         return 0; /* timeout */
     }

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -220,7 +220,14 @@ static void updateFdSet(struct Sockets *sockets, fd_set* fdset,
 {
   int i;
   for(i = 0; i < sockets->count; ++i) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(sockets->sockets[i], fdset);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     if(*maxFd < sockets->sockets[i] + 1) {
       *maxFd = sockets->sockets[i] + 1;
     }
@@ -249,7 +256,14 @@ static int checkFdSet(CURLM *curl,
   int i;
   int result = 0;
   for(i = 0; i < sockets->count; ++i) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(sockets->sockets[i], fdset)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       result = socket_action(curl, sockets->sockets[i], evBitmask, name);
       if(result)
         break;

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -188,7 +188,14 @@ static void updateFdSet(struct Sockets *sockets, fd_set* fdset,
 {
   int i;
   for(i = 0; i < sockets->count; ++i) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     FD_SET(sockets->sockets[i], fdset);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     if(*maxFd < sockets->sockets[i] + 1) {
       *maxFd = sockets->sockets[i] + 1;
     }
@@ -214,7 +221,14 @@ static void checkFdSet(CURLM *curl, struct Sockets *sockets, fd_set *fdset,
 {
   int i;
   for(i = 0; i < sockets->count; ++i) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(sockets->sockets[i], fdset)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       notifyCurl(curl, sockets->sockets[i], evBitmask, name);
     }
   }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -747,8 +747,15 @@ static bool incoming(curl_socket_t listenfd)
     FD_ZERO(&fds_write);
     FD_ZERO(&fds_err);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     /* there's always a socket to wait for */
     FD_SET(sockfd, &fds_read);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     do {
       /* select() blocking behavior call on blocking descriptors please */
@@ -765,7 +772,14 @@ static bool incoming(curl_socket_t listenfd)
       return FALSE;
     }
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(sockfd, &fds_read)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -693,6 +693,10 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
     FD_ZERO(&writesock);
     FD_ZERO(&exceptsock);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(wsasock, readfds)) {
       FD_SET(wsasock, &readsock);
       wsaevents.lNetworkEvents |= FD_READ|FD_ACCEPT|FD_CLOSE;
@@ -707,6 +711,9 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
       FD_SET(wsasock, &exceptsock);
       wsaevents.lNetworkEvents |= FD_OOB;
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     /* only wait for events for which we actually care */
     if(wsaevents.lNetworkEvents) {
@@ -754,12 +761,19 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
             if(select(fd + 1, &readsock, &writesock, &exceptsock, tv) == 1) {
               logmsg("[select_ws] socket %d is ready", fd);
               WSASetEvent(wsaevent);
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
               if(FD_ISSET(wsasock, &readsock))
                 data[nfd].wsastate |= FD_READ;
               if(FD_ISSET(wsasock, &writesock))
                 data[nfd].wsastate |= FD_WRITE;
               if(FD_ISSET(wsasock, &exceptsock))
                 data[nfd].wsastate |= FD_OOB;
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             }
             nfd++;
             nws++;
@@ -851,10 +865,17 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
       }
 
       /* check if the event has not been filtered using specific tests */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       if(FD_ISSET(wsasock, readfds) || FD_ISSET(wsasock, writefds) ||
          FD_ISSET(wsasock, exceptfds)) {
         ret++;
       }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     }
     else {
       /* remove from all descriptor sets since this handle did not trigger */
@@ -865,12 +886,19 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
   }
 
   for(fd = 0; fd < nfds; fd++) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(fd, readfds))
       logmsg("[select_ws] %d is readable", fd);
     if(FD_ISSET(fd, writefds))
       logmsg("[select_ws] %d is writable", fd);
     if(FD_ISSET(fd, exceptfds))
       logmsg("[select_ws] %d is exceptional", fd);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
   }
 
   for(i = 0; i < nws; i++) {
@@ -990,6 +1018,10 @@ static bool juggle(curl_socket_t *sockfdp,
   FD_ZERO(&fds_write);
   FD_ZERO(&fds_err);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   FD_SET((curl_socket_t)fileno(stdin), &fds_read);
 
   switch(*mode) {
@@ -1040,6 +1072,9 @@ static bool juggle(curl_socket_t *sockfdp,
     break;
 
   } /* switch(*mode) */
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 
   do {
@@ -1066,7 +1101,14 @@ static bool juggle(curl_socket_t *sockfdp,
     return TRUE;
 
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   if(FD_ISSET(fileno(stdin), &fds_read)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     ssize_t buffer_len;
     /* read from stdin, commands/data to be dealt with and possibly passed on
        to the socket
@@ -1150,7 +1192,14 @@ static bool juggle(curl_socket_t *sockfdp,
   }
 
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   if((sockfd != CURL_SOCKET_BAD) && (FD_ISSET(sockfd, &fds_read)) ) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     ssize_t nread_socket;
     if(*mode == PASSIVE_LISTEN) {
       /* there's no stream set up yet, this is an indication that there's a

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -651,7 +651,14 @@ static int tunnel(struct perclient *cp, fd_set *fds)
   ssize_t nread;
   ssize_t nwrite;
   char buffer[512];
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   if(FD_ISSET(cp->clientfd, fds)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     /* read from client, send to remote */
     nread = recv(cp->clientfd, buffer, sizeof(buffer), 0);
     if(nread > 0) {
@@ -664,7 +671,14 @@ static int tunnel(struct perclient *cp, fd_set *fds)
     else
       return 1;
   }
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
   if(FD_ISSET(cp->remotefd, fds)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     /* read from remote, send to client */
     nread = recv(cp->remotefd, buffer, sizeof(buffer), 0);
     if(nread > 0) {
@@ -719,6 +733,10 @@ static bool incoming(curl_socket_t listenfd)
     FD_ZERO(&fds_write);
     FD_ZERO(&fds_err);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     /* there's always a socket to wait for */
     FD_SET(sockfd, &fds_read);
 
@@ -734,6 +752,9 @@ static bool incoming(curl_socket_t listenfd)
           maxfd = (int)fd;
       }
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
     do {
       /* select() blocking behavior call on blocking descriptors please */
@@ -750,7 +771,14 @@ static bool incoming(curl_socket_t listenfd)
       return FALSE;
     }
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if((clients < 2) && FD_ISSET(sockfd, &fds_read)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -909,7 +909,14 @@ static int get_request(curl_socket_t sock, struct httprequest *req)
           FD_ZERO(&input);
           FD_ZERO(&output);
           got = 0;
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           FD_SET(sock, &input);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
           do {
             logmsg("Wait until readable");
             rc = select((int)sock + 1, &input, &output, NULL, &timeout);
@@ -1449,6 +1456,12 @@ static void http_connect(curl_socket_t *infdp,
     FD_ZERO(&input);
     FD_ZERO(&output);
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+/* 'error: conversion to 'long unsigned int' from 'int'
+   may change the sign of the result' in FD_SET() calls */
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if((clientfd[DATA] == CURL_SOCKET_BAD) &&
        (serverfd[DATA] == CURL_SOCKET_BAD) &&
        poll_client_rd[CTRL] && poll_client_wr[CTRL] &&
@@ -1495,6 +1508,9 @@ static void http_connect(curl_socket_t *infdp,
         }
       }
     }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     if(got_exit_signal)
       break;
 
@@ -1513,8 +1529,15 @@ static void http_connect(curl_socket_t *infdp,
       /* ---------------------------------------------------------- */
 
       /* passive mode FTP may establish a secondary tunnel */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       if((clientfd[DATA] == CURL_SOCKET_BAD) &&
          (serverfd[DATA] == CURL_SOCKET_BAD) && FD_ISSET(rootfd, &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
         /* a new connection on listener socket (most likely from client) */
         curl_socket_t datafd = accept(rootfd, NULL, NULL);
         if(datafd != CURL_SOCKET_BAD) {
@@ -1589,7 +1612,14 @@ static void http_connect(curl_socket_t *infdp,
         size_t len;
         if(clientfd[i] != CURL_SOCKET_BAD) {
           len = sizeof(readclient[i]) - tos[i];
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           if(len && FD_ISSET(clientfd[i], &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             /* read from client */
             rc = sread(clientfd[i], &readclient[i][tos[i]], len);
             if(rc <= 0) {
@@ -1607,7 +1637,14 @@ static void http_connect(curl_socket_t *infdp,
         }
         if(serverfd[i] != CURL_SOCKET_BAD) {
           len = sizeof(readserver[i])-toc[i];
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           if(len && FD_ISSET(serverfd[i], &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             /* read from server */
             rc = sread(serverfd[i], &readserver[i][toc[i]], len);
             if(rc <= 0) {
@@ -1624,7 +1661,14 @@ static void http_connect(curl_socket_t *infdp,
           }
         }
         if(clientfd[i] != CURL_SOCKET_BAD) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           if(toc[i] && FD_ISSET(clientfd[i], &output)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             /* write to client */
             rc = swrite(clientfd[i], readserver[i], toc[i]);
             if(rc <= 0) {
@@ -1644,7 +1688,14 @@ static void http_connect(curl_socket_t *infdp,
           }
         }
         if(serverfd[i] != CURL_SOCKET_BAD) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
           if(tos[i] && FD_ISSET(serverfd[i], &output)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             /* write to server */
             rc = swrite(serverfd[i], readclient[i], tos[i]);
             if(rc <= 0) {
@@ -2301,7 +2352,14 @@ int main(int argc, char *argv[])
 
     for(socket_idx = 0; socket_idx < num_sockets; ++socket_idx) {
       /* Listen on all sockets */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       FD_SET(all_sockets[socket_idx], &input);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       if(all_sockets[socket_idx] > maxfd)
         maxfd = all_sockets[socket_idx];
     }
@@ -2329,7 +2387,14 @@ int main(int argc, char *argv[])
     active = rc; /* a positive number */
 
     /* Check if the listening socket is ready to accept */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
     if(FD_ISSET(all_sockets[0], &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
       /* Service all queued connections */
       curl_socket_t msgsock;
       do {
@@ -2346,7 +2411,14 @@ int main(int argc, char *argv[])
 
     /* Service all connections that are ready */
     for(socket_idx = 1; (socket_idx < num_sockets) && active; ++socket_idx) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
       if(FD_ISSET(all_sockets[socket_idx], &input)) {
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
         active--;
         if(got_exit_signal)
           goto sws_cleanup;


### PR DESCRIPTION
Silence toolchain bugs causing warnings in `FD_SET()`/`FD_ISSET()` calls.

Seen with older Cygwin/MSYS2 builds. Likely fixed on 2020-08-03 by:
https://cygwin.com/git/?p=newlib-cygwin.git;a=commitdiff;h=5717262b8ecfed0f7fab63e2c09c78991e36f9dd

Also seen on Alpine MUSL:
```
multi.c:1201:9: error: conversion to 'long unsigned int' from 'curl_socket_t' {aka 'int'} may change the sign of the result [-Werror=sign-conversion]
 1201 |         FD_SET(ps.sockets[i], read_fd_set);
      |         ^~~~~~
multi.c:1201:9: error: conversion to 'long unsigned int' from 'curl_socket_t' {aka 'int'} may change the sign of the result [-Werror=sign-conversion]
multi.c:1203:9: error: conversion to 'long unsigned int' from 'curl_socket_t' {aka 'int'} may change the sign of the result [-Werror=sign-conversion]
 1203 |         FD_SET(ps.sockets[i], write_fd_set);
      |         ^~~~~~
multi.c:1203:9: error: conversion to 'long unsigned int' from 'curl_socket_t' {aka 'int'} may change the sign of the result [-Werror=sign-conversion]
```
Ref: https://github.com/curl/curl/actions/runs/8867959370/job/24347027402?pr=13489#step:31:373

And on OmniOS:
```
example/direct_tcpip.c:251:9: warning: conversion to 'long unsigned int' from 'libssh2_socket_t' {aka 'int'} may change the sign of the result [-Wsign-conversion]
    251 |         FD_SET(forwardsock, &fds);
        |         ^~~~~~
example/direct_tcpip.c:251:9: warning: conversion to 'long unsigned int' from 'libssh2_socket_t' {aka 'int'} may change the sign of the result [-Wsign-conversion]
example/direct_tcpip.c:251:9: warning: conversion to 'long unsigned int' from 'long int' may change the sign of the result [-Wsign-conversion]
example/direct_tcpip.c:251:9: warning: conversion to 'long int' from 'long unsigned int' may change the sign of the result [-Wsign-conversion]
```
Ref: https://github.com/libssh2/libssh2/actions/runs/8854199687/job/24316762831#step:3:2021

Ref: 5b9955e0bdc600d167814daa1e4a57767e248ca0 #13501
Ref: 95a882d26844745f1776fb6c7522b3df57dc9821 #12557
Cherry-picked from #13489
Closes #13896

---

The fix is ugly. ~~Perhaps creating a macro for it would be nicer, and then putting the original ones on the checksrc blocklist.~~ [macro will not work, wrapper function problematic to match types, and performance.]
