### PR TITLE
cmake: bring `curl-config.cmake` closer to `FindCURL`

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -37,4 +37,7 @@ check_required_components("@PROJECT_NAME@")
 # Alias for either shared or static library
 if(NOT TARGET @PROJECT_NAME@::libcurl)
   add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
+
+  # For compatibility with CMake's FindCURL.cmake
+  set(CURL_LIBRARIES @PROJECT_NAME@::libcurl)
 endif()

--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -37,7 +37,7 @@ check_required_components("@PROJECT_NAME@")
 # Alias for either shared or static library
 if(NOT TARGET @PROJECT_NAME@::libcurl)
   add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
-
-  # For compatibility with CMake's FindCURL.cmake
-  set(CURL_LIBRARIES @PROJECT_NAME@::libcurl)
 endif()
+
+# For compatibility with CMake's FindCURL.cmake
+set(CURL_LIBRARIES @PROJECT_NAME@::libcurl)

--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -41,3 +41,4 @@ endif()
 
 # For compatibility with CMake's FindCURL.cmake
 set(CURL_LIBRARIES @PROJECT_NAME@::libcurl)
+set_and_check(CURL_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1855,6 +1855,7 @@ if(NOT CURL_DISABLE_INSTALL)
   configure_package_config_file(CMake/curl-config.cmake.in
     "${project_config}"
     INSTALL_DESTINATION ${CURL_INSTALL_CMAKE_DIR}
+    PATH_VARS CMAKE_INSTALL_INCLUDEDIR
   )
 
   if(CURL_ENABLE_EXPORT_TARGET)


### PR DESCRIPTION
Set `CURL_LIBRARIES` and `CURL_INCLUDE_DIRS` variables
for compatibility with CMake's `FindCURL.cmake`:
https://github.com/Kitware/CMake/blob/b411d0146c2e06acfb0c823bb039e99f0191b611/Modules/FindCURL.cmake#L209

For dependent projects, CMake's suggestion is to replace
`CURL_LIBRARIES` with `CURL::libcurl`, and drop `CURL_INCLUDE_DIRS`.

Reported-by: Aurélien Pierre
Ref: https://curl.se/mail/lib-2024-06/0014.html
Ref: https://gitlab.kitware.com/cmake/cmake/-/issues/24580
Closes #13897

---

/cc @aurelienpierre Do you think this would help with this issue?

Ref: https://github.com/aurelienpierreeng/ansel/pull/334