### PR TITLE
connection shutdown, basics and first use

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -65,8 +65,6 @@ problems may have been fixed or changed somewhat since this was written.
  7.2 Implicit FTPS upload timeout
  7.3 FTP with NOBODY and FAILONERROR
  7.4 FTP with ACCT
- 7.5 FTPS upload, FileZilla, GnuTLS and close_notify
- 7.11 FTPS upload data loss with TLS 1.3
  7.12 FTPS directory listing hangs on Windows with Schannel
 
  9. SFTP and SCP
@@ -409,30 +407,6 @@ problems may have been fixed or changed somewhat since this was written.
  logging in), the operation will fail since libcurl does not detect this and
  thus fails to issue the correct command:
  https://curl.se/bug/view.cgi?id=635
-
-7.5 FTPS upload, FileZilla, GnuTLS and close_notify
-
- An issue where curl does not send the TLS alert close_notify, which triggers
- the wrath of GnuTLS in FileZilla server, and a FTP reply 426 ECONNABORTED.
-
- https://github.com/curl/curl/issues/11383
-
-7.11 FTPS upload data loss with TLS 1.3
-
- During FTPS upload curl does not attempt to read TLS handshake messages sent
- after the initial handshake. OpenSSL servers running TLS 1.3 may send such a
- message. When curl closes the upload connection if unread data has been
- received (such as a TLS handshake message) then the TCP protocol sends an
- RST to the server, which may cause the server to discard or truncate the
- upload if it has not read all sent data yet, and then return an error to curl
- on the control channel connection.
-
- Since 7.78.0 this is mostly fixed. curl will do a single read before closing
- TLS connections (which causes the TLS library to read handshake messages),
- however there is still possibility of an RST if more messages need to be read
- or a message arrives after the read but before close (network race condition).
-
- https://github.com/curl/curl/issues/6149
 
 7.12 FTPS server compatibility on Windows with Schannel
 

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1077,6 +1077,7 @@ struct Curl_cftype Curl_cft_h1_proxy = {
   cf_h1_proxy_destroy,
   cf_h1_proxy_connect,
   cf_h1_proxy_close,
+  Curl_cf_def_shutdown,
   Curl_cf_http_proxy_get_host,
   cf_h1_proxy_adjust_pollset,
   Curl_cf_def_data_pending,

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -194,6 +194,7 @@ struct Curl_cftype Curl_cft_haproxy = {
   cf_haproxy_destroy,
   cf_haproxy_connect,
   cf_haproxy_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_haproxy_adjust_pollset,
   Curl_cf_def_data_pending,

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1010,6 +1010,30 @@ static void cf_socket_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   cf->connected = FALSE;
 }
 
+static CURLcode cf_socket_shutdown(struct Curl_cfilter *cf,
+                                   struct Curl_easy *data,
+                                   bool *done)
+{
+  if(cf->connected) {
+    struct cf_socket_ctx *ctx = cf->ctx;
+
+    CURL_TRC_CF(data, cf, "cf_socket_shutdown(%" CURL_FORMAT_SOCKET_T
+                ")", ctx->sock);
+    /* On TPC, and when the socket looks well and non-blocking mode
+     * can be enabled, receive dangling bytes before close to avoid
+     * TCP entering RST states unnecessarily. */
+    if(ctx->sock != CURL_SOCKET_BAD &&
+       ctx->transport == TRNSPRT_TCP &&
+       (curlx_nonblock(ctx->sock, TRUE) >= 0)) {
+      unsigned char buf[1024];
+      (void)sread(ctx->sock, buf, sizeof(buf));
+    }
+    cf_socket_close(cf, data);
+  }
+  *done = TRUE;
+  return CURLE_OK;
+}
+
 static void cf_socket_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct cf_socket_ctx *ctx = cf->ctx;
@@ -1729,6 +1753,7 @@ struct Curl_cftype Curl_cft_tcp = {
   cf_socket_destroy,
   cf_tcp_connect,
   cf_socket_close,
+  cf_socket_shutdown,
   cf_socket_get_host,
   cf_socket_adjust_pollset,
   cf_socket_data_pending,
@@ -1872,6 +1897,7 @@ struct Curl_cftype Curl_cft_udp = {
   cf_socket_destroy,
   cf_udp_connect,
   cf_socket_close,
+  cf_socket_shutdown,
   cf_socket_get_host,
   cf_socket_adjust_pollset,
   cf_socket_data_pending,
@@ -1923,6 +1949,7 @@ struct Curl_cftype Curl_cft_unix = {
   cf_socket_destroy,
   cf_tcp_connect,
   cf_socket_close,
+  cf_socket_shutdown,
   cf_socket_get_host,
   cf_socket_adjust_pollset,
   cf_socket_data_pending,
@@ -1987,6 +2014,7 @@ struct Curl_cftype Curl_cft_tcp_accept = {
   cf_socket_destroy,
   cf_tcp_accept_connect,
   cf_socket_close,
+  cf_socket_shutdown,
   cf_socket_get_host,              /* TODO: not accurate */
   cf_socket_adjust_pollset,
   cf_socket_data_pending,

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1019,9 +1019,9 @@ static CURLcode cf_socket_shutdown(struct Curl_cfilter *cf,
 
     CURL_TRC_CF(data, cf, "cf_socket_shutdown(%" CURL_FORMAT_SOCKET_T
                 ")", ctx->sock);
-    /* On TPC, and when the socket looks well and non-blocking mode
+    /* On TCP, and when the socket looks well and non-blocking mode
      * can be enabled, receive dangling bytes before close to avoid
-     * TCP entering RST states unnecessarily. */
+     * entering RST states unnecessarily. */
     if(ctx->sock != CURL_SOCKET_BAD &&
        ctx->transport == TRNSPRT_TCP &&
        (curlx_nonblock(ctx->sock, TRUE) >= 0)) {

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -40,6 +40,18 @@ timediff_t Curl_timeleft(struct Curl_easy *data,
 
 #define DEFAULT_CONNECT_TIMEOUT 300000 /* milliseconds == five minutes */
 
+#define DEFAULT_SHUTDOWN_TIMEOUT_MS   (2 * 1000)
+
+void Curl_shutdown_start(struct Curl_easy *data, int sockindex,
+                         struct curltime *nowp);
+
+/* return how much time there's left to shutdown the connection at
+ * sockindex. */
+timediff_t Curl_shutdown_timeleft(struct connectdata *conn, int sockindex,
+                                  struct curltime *nowp);
+
+void Curl_shutdown_clear(struct Curl_easy *data, int sockindex);
+
 /*
  * Used to extract socket and connectdata struct for the most recent
  * transfer on the given Curl_easy.

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -290,12 +290,15 @@ const struct Curl_handler Curl_handler_ftps = {
 };
 #endif
 
-static void close_secondarysocket(struct Curl_easy *data,
-                                  struct connectdata *conn)
+static void close_secondarysocket(struct Curl_easy *data, bool premature)
 {
+  if(!premature) {
+    CURL_TRC_FTP(data, "[%s] shutting down DATA connection", FTP_DSTATE(data));
+    Curl_conn_shutdown_blocking(data, SECONDARYSOCKET);
+  }
   CURL_TRC_FTP(data, "[%s] closing DATA connection", FTP_DSTATE(data));
   Curl_conn_close(data, SECONDARYSOCKET);
-  Curl_conn_cf_discard_all(data, conn, SECONDARYSOCKET);
+  Curl_conn_cf_discard_all(data, data->conn, SECONDARYSOCKET);
 }
 
 /*
@@ -475,7 +478,7 @@ static CURLcode AcceptServerConnect(struct Curl_easy *data)
     Curl_set_in_callback(data, false);
 
     if(error) {
-      close_secondarysocket(data, conn);
+      close_secondarysocket(data, TRUE);
       return CURLE_ABORTED_BY_CALLBACK;
     }
   }
@@ -2980,7 +2983,13 @@ static CURLcode ftp_statemachine(struct Curl_easy *data,
     case FTP_CCC:
       if(ftpcode < 500) {
         /* First shut down the SSL layer (note: this call will block) */
-        result = Curl_ssl_cfilter_remove(data, FIRSTSOCKET);
+        /* This has only been tested on the proftpd server, and the mod_tls
+         * code sends a close notify alert without waiting for a close notify
+         * alert in response. Thus we wait for a close notify alert from the
+         * server, but we do not send one. Let's hope other servers do
+         * the same... */
+        result = Curl_ssl_cfilter_remove(data, FIRSTSOCKET,
+          (data->set.ftp_ccc == CURLFTPSSL_CCC_ACTIVE));
 
         if(result)
           failf(data, "Failed to clear the command channel (CCC)");
@@ -3457,7 +3466,7 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
       }
     }
 
-    close_secondarysocket(data, conn);
+    close_secondarysocket(data, result != CURLE_OK);
   }
 
   if(!result && (ftp->transfer == PPTRANSFER_BODY) && ftpc->ctl_valid &&
@@ -4425,7 +4434,7 @@ static CURLcode ftp_dophase_done(struct Curl_easy *data, bool connected)
     CURLcode result = ftp_do_more(data, &completed);
 
     if(result) {
-      close_secondarysocket(data, conn);
+      close_secondarysocket(data, TRUE);
       return result;
     }
   }

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -298,6 +298,7 @@ struct Curl_cftype Curl_cft_http_proxy = {
   http_proxy_cf_destroy,
   http_proxy_cf_connect,
   http_proxy_cf_close,
+  Curl_cf_def_shutdown,
   Curl_cf_http_proxy_get_host,
   Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1249,6 +1249,7 @@ struct Curl_cftype Curl_cft_socks_proxy = {
   socks_proxy_cf_destroy,
   socks_proxy_cf_connect,
   socks_proxy_cf_close,
+  Curl_cf_def_shutdown,
   socks_cf_get_host,
   socks_cf_adjust_pollset,
   Curl_cf_def_data_pending,

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -847,6 +847,10 @@ struct connectdata {
   Curl_recv *recv[2];
   Curl_send *send[2];
   struct Curl_cfilter *cfilter[2]; /* connection filters */
+  struct {
+    struct curltime start[2]; /* when filter shutdown started */
+    unsigned int timeout_ms; /* 0 means no timeout */
+  } shutdown;
 
   struct ssl_primary_config ssl_config;
 #ifndef CURL_DISABLE_PROXY
@@ -1614,9 +1618,10 @@ struct UserDefined {
   void *progress_client; /* pointer to pass to the progress callback */
   void *ioctl_client;   /* pointer to pass to the ioctl callback */
   unsigned int timeout;        /* ms, 0 means no timeout */
-  unsigned int connecttimeout; /* ms, 0 means no timeout */
+  unsigned int connecttimeout; /* ms, 0 means default timeout */
   unsigned int happy_eyeballs_timeout; /* ms, 0 is a valid value */
   unsigned int server_response_timeout; /* ms, 0 means no timeout */
+  unsigned int shutdowntimeout; /* ms, 0 means default timeout */
   long maxage_conn;     /* in seconds, max idle time to allow a connection that
                            is to be reused */
   long maxlifetime_conn; /* in seconds, max time since creation to allow a

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -1038,6 +1038,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_msh3_destroy,
   cf_msh3_connect,
   cf_msh3_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_msh3_adjust_pollset,
   cf_msh3_data_pending,

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2438,6 +2438,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_ngtcp2_destroy,
   cf_ngtcp2_connect,
   cf_ngtcp2_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_ngtcp2_adjust_pollset,
   cf_ngtcp2_data_pending,

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -2252,6 +2252,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_osslq_destroy,
   cf_osslq_connect,
   cf_osslq_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_osslq_adjust_pollset,
   cf_osslq_data_pending,

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1580,6 +1580,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_quiche_destroy,
   cf_quiche_connect,
   cf_quiche_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_quiche_adjust_pollset,
   cf_quiche_data_pending,

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -66,6 +66,7 @@ struct gtls_ctx {
   gnutls_srp_client_credentials_t srp_client_cred;
 #endif
   CURLcode io_result; /* result of last IO cfilter operation */
+  BIT(sent_shutdown);
 };
 
 typedef CURLcode Curl_gtls_ctx_setup_cb(struct Curl_cfilter *cf,

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -111,6 +111,7 @@ struct mbed_ssl_backend_data {
 #endif
   int *ciphersuites;
   BIT(initialized); /* mbedtls_ssl_context is initialized */
+  BIT(sent_shutdown);
 };
 
 /* apply threading? */
@@ -1198,23 +1199,108 @@ static void mbedtls_close_all(struct Curl_easy *data)
   (void)data;
 }
 
+static CURLcode mbedtls_shutdown(struct Curl_cfilter *cf,
+                                 struct Curl_easy *data,
+                                 bool send_shutdown, bool *done)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct mbed_ssl_backend_data *backend =
+    (struct mbed_ssl_backend_data *)connssl->backend;
+  unsigned char buf[1024];
+  CURLcode result = CURLE_OK;
+  int ret;
+  size_t i;
+
+  DEBUGASSERT(backend);
+
+  if(!backend->initialized || connssl->shutdown) {
+    *done = TRUE;
+    return CURLE_OK;
+  }
+
+  connssl->io_need = CURL_SSL_IO_NEED_NONE;
+  *done = FALSE;
+
+  if(!backend->sent_shutdown) {
+    /* do this only once */
+    backend->sent_shutdown = TRUE;
+    if(send_shutdown) {
+      ret = mbedtls_ssl_close_notify(&backend->ssl);
+      switch(ret) {
+      case 0: /* we sent it, receive from the server */
+        break;
+      case MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY: /* server also closed */
+        *done = TRUE;
+        goto out;
+      case MBEDTLS_ERR_SSL_WANT_READ:
+        connssl->io_need = CURL_SSL_IO_NEED_RECV;
+        goto out;
+      case MBEDTLS_ERR_SSL_WANT_WRITE:
+        connssl->io_need = CURL_SSL_IO_NEED_SEND;
+        goto out;
+      default:
+        CURL_TRC_CF(data, cf, "mbedtls_shutdown error -0x%04X", -ret);
+        result = CURLE_RECV_ERROR;
+        goto out;
+      }
+    }
+  }
+
+  /* SSL should now have started the shutdown from our side. Since it
+   * was not complete, we are lacking the close notify from the server. */
+  for(i = 0; i < 10; ++i) {
+    ret = mbedtls_ssl_read(&backend->ssl, buf, sizeof(buf));
+    /* This seems to be a bug in mbedTLS TLSv1.3 where it reports
+     * WANT_READ, but has not encountered an EAGAIN. */
+    if(ret == MBEDTLS_ERR_SSL_WANT_READ)
+      ret = mbedtls_ssl_read(&backend->ssl, buf, sizeof(buf));
+#ifdef TLS13_SUPPORT
+    if(ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)
+      continue;
+#endif
+    if(ret <= 0)
+      break;
+  }
+
+  if(ret > 0) {
+    /* still data coming in? */
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown, still getting data");
+  }
+  else if(ret == 0 || (ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)) {
+    /* We got the close notify alert and are done. */
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown done");
+    *done = TRUE;
+  }
+  else if(ret == MBEDTLS_ERR_SSL_WANT_READ) {
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown, need RECV");
+    connssl->io_need = CURL_SSL_IO_NEED_RECV;
+  }
+  else if(ret == MBEDTLS_ERR_SSL_WANT_WRITE) {
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown, need SEND");
+    connssl->io_need = CURL_SSL_IO_NEED_SEND;
+  }
+  else {
+    CURL_TRC_CF(data, cf, "mbedtls_shutdown error -0x%04X", -ret);
+    result = CURLE_RECV_ERROR;
+  }
+
+out:
+  connssl->shutdown = (result || *done);
+  return result;
+}
+
 static void mbedtls_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;
 
-  (void)data;
   DEBUGASSERT(backend);
   if(backend->initialized) {
-    char buf[32];
-    int ret;
-
-    /* Maybe the server has already sent a close notify alert.
-       Read it to avoid an RST on the TCP connection. */
-    (void)mbedtls_ssl_read(&backend->ssl, (unsigned char *)buf, sizeof(buf));
-    ret = mbedtls_ssl_close_notify(&backend->ssl);
-    CURL_TRC_CF(data, cf, "close_notify() -> %04x", -ret);
+    if(!connssl->shutdown) {
+      bool done;
+      mbedtls_shutdown(cf, data, TRUE, &done);
+    }
 
     mbedtls_pk_free(&backend->pk);
     mbedtls_x509_crt_free(&backend->clicert);
@@ -1535,7 +1621,7 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   mbedtls_cleanup,                  /* cleanup */
   mbedtls_version,                  /* version */
   Curl_none_check_cxn,              /* check_cxn */
-  Curl_none_shutdown,               /* shutdown */
+  mbedtls_shutdown,                 /* shutdown */
   mbedtls_data_pending,             /* data_pending */
   mbedtls_random,                   /* random */
   Curl_none_cert_status_request,    /* cert_status_request */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -153,6 +153,7 @@ struct st_ssl_backend_data {
   SSLContextRef ssl_ctx;
   bool ssl_direction; /* true if writing, false if reading */
   size_t ssl_write_buffered_length;
+  BIT(sent_shutdown);
 };
 
 /* Create the list of default ciphers to use by making an intersection of the
@@ -2555,6 +2556,92 @@ static CURLcode sectransp_connect(struct Curl_cfilter *cf,
   return CURLE_OK;
 }
 
+static ssize_t sectransp_recv(struct Curl_cfilter *cf,
+                              struct Curl_easy *data,
+                              char *buf,
+                              size_t buffersize,
+                              CURLcode *curlcode);
+
+static CURLcode sectransp_shutdown(struct Curl_cfilter *cf,
+                                   struct Curl_easy *data,
+                                   bool send_shutdown, bool *done)
+{
+  struct ssl_connect_data *connssl = cf->ctx;
+  struct st_ssl_backend_data *backend =
+    (struct st_ssl_backend_data *)connssl->backend;
+  CURLcode result = CURLE_OK;
+  ssize_t nread;
+  char buf[1024];
+  size_t i;
+
+  DEBUGASSERT(backend);
+  if(!backend->ssl_ctx || connssl->shutdown) {
+    *done = TRUE;
+    goto out;
+  }
+
+  connssl->io_need = CURL_SSL_IO_NEED_NONE;
+  *done = FALSE;
+
+  if(send_shutdown && !backend->sent_shutdown) {
+    OSStatus err;
+
+    CURL_TRC_CF(data, cf, "shutdown, send close notify");
+    err = SSLClose(backend->ssl_ctx);
+    switch(err) {
+      case noErr:
+        backend->sent_shutdown = TRUE;
+        break;
+      case errSSLWouldBlock:
+        connssl->io_need = CURL_SSL_IO_NEED_SEND;
+        result = CURLE_OK;
+        goto out;
+      default:
+        CURL_TRC_CF(data, cf, "shutdown, error: %d", (int)err);
+        result = CURLE_SEND_ERROR;
+        goto out;
+    }
+  }
+
+  for(i = 0; i < 10; ++i) {
+    if(!backend->sent_shutdown) {
+      nread = sectransp_recv(cf, data, buf, (int)sizeof(buf), &result);
+    }
+    else {
+      /* We would like to read the close notify from the server using
+       * secure transport, however SSLRead() no longer works after we
+       * sent the notify from our side. So, we just read from the
+       * underlying filter and hope it will end. */
+      nread = Curl_conn_cf_recv(cf->next, data, buf, sizeof(buf), &result);
+    }
+    CURL_TRC_CF(data, cf, "shutdown read -> %zd, %d", nread, result);
+    if(nread <= 0)
+      break;
+  }
+
+  if(nread > 0) {
+    /* still data coming in? */
+    connssl->io_need = CURL_SSL_IO_NEED_RECV;
+  }
+  else if(nread == 0) {
+    /* We got the close notify alert and are done. */
+    CURL_TRC_CF(data, cf, "shutdown done");
+    *done = TRUE;
+  }
+  else if(result == CURLE_AGAIN) {
+    connssl->io_need = CURL_SSL_IO_NEED_RECV;
+    result = CURLE_OK;
+  }
+  else {
+    DEBUGASSERT(result);
+    CURL_TRC_CF(data, cf, "shutdown, error: %d", result);
+  }
+
+out:
+  connssl->shutdown = (result || *done);
+  return result;
+}
+
 static void sectransp_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
@@ -2567,7 +2654,12 @@ static void sectransp_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   if(backend->ssl_ctx) {
     CURL_TRC_CF(data, cf, "close");
-    (void)SSLClose(backend->ssl_ctx);
+    if(cf->connected && !connssl->shutdown &&
+       cf->next && cf->next->connected && !connssl->peer_closed) {
+      bool done;
+      (void)sectransp_shutdown(cf, data, TRUE, &done);
+    }
+
 #if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
     if(SSLCreateContext)
       CFRelease(backend->ssl_ctx);
@@ -2580,69 +2672,6 @@ static void sectransp_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 #endif /* CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS */
     backend->ssl_ctx = NULL;
   }
-}
-
-static int sectransp_shutdown(struct Curl_cfilter *cf,
-                              struct Curl_easy *data)
-{
-  struct ssl_connect_data *connssl = cf->ctx;
-  struct st_ssl_backend_data *backend =
-    (struct st_ssl_backend_data *)connssl->backend;
-  ssize_t nread;
-  int what;
-  int rc;
-  char buf[120];
-  int loop = 10; /* avoid getting stuck */
-  CURLcode result;
-
-  DEBUGASSERT(backend);
-
-  if(!backend->ssl_ctx)
-    return 0;
-
-#ifndef CURL_DISABLE_FTP
-  if(data->set.ftp_ccc != CURLFTPSSL_CCC_ACTIVE)
-    return 0;
-#endif
-
-  sectransp_close(cf, data);
-
-  rc = 0;
-
-  what = SOCKET_READABLE(Curl_conn_cf_get_socket(cf, data),
-                         SSL_SHUTDOWN_TIMEOUT);
-
-  CURL_TRC_CF(data, cf, "shutdown");
-  while(loop--) {
-    if(what < 0) {
-      /* anything that gets here is fatally bad */
-      failf(data, "select/poll on SSL socket, errno: %d", SOCKERRNO);
-      rc = -1;
-      break;
-    }
-
-    if(!what) {                                /* timeout */
-      failf(data, "SSL shutdown timeout");
-      break;
-    }
-
-    /* Something to read, let's do it and hope that it is the close
-     notify alert from the server. No way to SSL_Read now, so use read(). */
-
-    nread = Curl_conn_cf_recv(cf->next, data, buf, sizeof(buf), &result);
-
-    if(nread < 0) {
-      failf(data, "read: %s", curl_easy_strerror(result));
-      rc = -1;
-    }
-
-    if(nread <= 0)
-      break;
-
-    what = SOCKET_READABLE(Curl_conn_cf_get_socket(cf, data), 0);
-  }
-
-  return rc;
 }
 
 static size_t sectransp_version(char *buffer, size_t size)

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -191,7 +191,7 @@ CURLcode Curl_cf_ssl_insert_after(struct Curl_cfilter *cf_at,
                                   struct Curl_easy *data);
 
 CURLcode Curl_ssl_cfilter_remove(struct Curl_easy *data,
-                                 int sockindex);
+                                 int sockindex, bool send_shutdown);
 
 #ifndef CURL_DISABLE_PROXY
 CURLcode Curl_cf_ssl_proxy_insert_after(struct Curl_cfilter *cf_at,
@@ -250,7 +250,7 @@ extern struct Curl_cftype Curl_cft_ssl_proxy;
 #define Curl_ssl_get_internals(a,b,c,d) NULL
 #define Curl_ssl_supports(a,b) FALSE
 #define Curl_ssl_cfilter_add(a,b,c) CURLE_NOT_BUILT_IN
-#define Curl_ssl_cfilter_remove(a,b) CURLE_OK
+#define Curl_ssl_cfilter_remove(a,b,c) CURLE_OK
 #define Curl_ssl_cf_get_config(a,b) NULL
 #define Curl_ssl_cf_get_primary_config(a) NULL
 #endif

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -38,9 +38,6 @@ log = logging.getLogger(__name__)
 
 
 @pytest.mark.skipif(condition=not Env.has_vsftpd(), reason=f"missing vsftpd")
-# rustsl: transfers sometimes fail with "received corrupt message of type InvalidContentType"
-# sporadic, never seen when filter tracing is on
-@pytest.mark.skipif(condition=Env.curl_uses_lib('rustls-ffi'), reason=f"rustls unreliable here")
 class TestVsFTPD:
 
     SUPPORTS_SSL = True

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -159,6 +159,7 @@ static struct Curl_cftype cft_test = {
   cf_test_destroy,
   cf_test_connect,
   Curl_cf_def_close,
+  Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   Curl_cf_def_adjust_pollset,
   Curl_cf_def_data_pending,


### PR DESCRIPTION
This adds connection shutdown infrastructure and first use for FTP. FTP data connections, when not encountering an error, are now shut down in a blocking way with a 2sec timeout.

- add cfilter `Curl_cft_shutdown` callback
- keep a shutdown start timestamp and timeout at connectdata
- provide shutdown timeout default and member in
  `data->set.shutdowntimeout`.
- provide methods for starting, interrogating and clearing shutdown timers
- provide `Curl_conn_shutdown_blocking()` to shutdown the
  `sockindex` filter chain in a blocking way. Use that in FTP.
- add `Curl_conn_cf_poll()` to wait for socket events during
  shutdown of a connection filter chain.
  This gets the monitoring sockets and events via the filters
  "adjust_pollset()" methods. This gives correct behaviour when
  shutting down a TLS connection through a HTTP/2 proxy.
- Implement shutdown for all socket filters
  - for HTTP/2 and h2 proxying to send GOAWAY
  - for TLS backends to the best of their capabilities 
  - for tcp socket filter to make a final, nonblocking receive to avoid unwanted RST states 
  - add shutdown forwarding to happy eyeballers and https connect ballers when applicable.

Test coverage of the FTP blocking shutdown of its data connection is covered in `test_30_5` and `test_31_05` ftp upload tests.

Update: removed known bugs 7.5 and 7.11 fixed by this PR. Verified by local upload tests with `vsftpd` and confirmation on #13556.
