### PR TITLE
cmdline-opts: tidy up --ip-tos and --mptcp

### DIFF
--- a/docs/cmdline-opts/ip-tos.md
+++ b/docs/cmdline-opts/ip-tos.md
@@ -21,34 +21,6 @@ Set Type of Service (TOS) for IPv4 or Traffic Class for IPv6. (Added in 8.9.0).
 The values allowed for \<string\> can be a numeric value between 1 and 255
 or one of the following:
 
-* CS0
-* CS1
-* CS2
-* CS3
-* CS4
-* CS5
-* CS6
-* CS7
-* AF11
-* AF12
-* AF13
-* AF21
-* AF22
-* AF23
-* AF31
-* AF32
-* AF33
-* AF41
-* AF42
-* AF43
-* EF
-* VOICE-ADMIT
-* ECT1
-* ECT0
-* CE
-* LE
-* LOWCOST
-* LOWDELAY
-* THROUGHPUT
-* RELIABILITY
-* MINCOST
+CS0, CS1, CS2, CS3, CS4, CS5, CS6, CS7, AF11, AF12, AF13, AF21, AF22, AF23,
+AF31, AF32, AF33, AF41, AF42, AF43, EF, VOICE-ADMIT, ECT1, ECT0, CE, LE,
+LOWCOST, LOWDELAY, THROUGHPUT, RELIABILITY, MINCOST

--- a/docs/cmdline-opts/mptcp.md
+++ b/docs/cmdline-opts/mptcp.md
@@ -23,19 +23,9 @@ MPTCP is beneficial in networks where multiple paths exist between clients and
 servers, such as mobile networks where a device may switch between WiFi and
 cellular data or in wired networks with multiple Internet Service Providers.
 
-## Usage
-
-To use MPTCP for your connections, add the `--mptcp` option when using `curl'.
-
-## Requirements
-
-This feature is currently only supported on Linux starting from kernel 5.6. Only
+This option is currently only supported on Linux starting from kernel 5.6. Only
 TCP connections are modified, hence this option does not effect HTTP/3 (QUIC)
-connections.
+or UDP connections.
 
-The server you are connecting to must also support MPTCP. If not, the connection
+The server curl connects to must also support MPTCP. If not, the connection
 seamlessly falls back to TCP.
-
-## Availability
-
-The `--mptcp` option is available starting from `curl` version 8.9.0.


### PR DESCRIPTION
To make them render nicer in the manpage and minor polish.