### PR TITLE
transfers, do not EXPIRE_NOW blocked

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -1206,6 +1206,7 @@ static const struct Curl_crtype cr_hyper_protocol = {
   Curl_creader_def_resume_from,
   Curl_creader_def_rewind,
   cr_hyper_unpause,
+  Curl_creader_def_is_paused,
   Curl_creader_def_done,
   sizeof(struct Curl_creader)
 };

--- a/lib/http.c
+++ b/lib/http.c
@@ -4500,6 +4500,7 @@ static const struct Curl_crtype cr_exp100 = {
   Curl_creader_def_resume_from,
   Curl_creader_def_rewind,
   Curl_creader_def_unpause,
+  Curl_creader_def_is_paused,
   cr_exp100_done,
   sizeof(struct cr_exp100_ctx)
 };

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -659,6 +659,7 @@ const struct Curl_crtype Curl_httpchunk_encoder = {
   Curl_creader_def_resume_from,
   Curl_creader_def_rewind,
   Curl_creader_def_unpause,
+  Curl_creader_def_is_paused,
   Curl_creader_def_done,
   sizeof(struct chunked_reader)
 };

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -2096,6 +2096,14 @@ static CURLcode cr_mime_unpause(struct Curl_easy *data,
   return CURLE_OK;
 }
 
+static bool cr_mime_is_paused(struct Curl_easy *data,
+                              struct Curl_creader *reader)
+{
+  struct cr_mime_ctx *ctx = reader->ctx;
+  (void)data;
+  return (ctx->part && ctx->part->lastreadstatus == CURL_READFUNC_PAUSE);
+}
+
 static const struct Curl_crtype cr_mime = {
   "cr-mime",
   cr_mime_init,
@@ -2106,6 +2114,7 @@ static const struct Curl_crtype cr_mime = {
   cr_mime_resume_from,
   cr_mime_rewind,
   cr_mime_unpause,
+  cr_mime_is_paused,
   Curl_creader_def_done,
   sizeof(struct cr_mime_ctx)
 };

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2495,7 +2495,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
           }
         }
       }
-      else if(data->state.select_bits) {
+      else if(data->state.select_bits && !Curl_xfer_is_blocked(data)) {
         /* This avoids CURLM_CALL_MULTI_PERFORM so that a very fast transfer
            won't get stuck on this transfer at the expense of other concurrent
            transfers */

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -218,6 +218,7 @@ struct Curl_crtype {
                           struct Curl_creader *reader, curl_off_t offset);
   CURLcode (*rewind)(struct Curl_easy *data, struct Curl_creader *reader);
   CURLcode (*unpause)(struct Curl_easy *data, struct Curl_creader *reader);
+  bool (*is_paused)(struct Curl_easy *data, struct Curl_creader *reader);
   void (*done)(struct Curl_easy *data,
                struct Curl_creader *reader, int premature);
   size_t creader_size;  /* sizeof() allocated struct Curl_creader */
@@ -268,6 +269,8 @@ CURLcode Curl_creader_def_rewind(struct Curl_easy *data,
                                  struct Curl_creader *reader);
 CURLcode Curl_creader_def_unpause(struct Curl_easy *data,
                                   struct Curl_creader *reader);
+bool Curl_creader_def_is_paused(struct Curl_easy *data,
+                                struct Curl_creader *reader);
 void Curl_creader_def_done(struct Curl_easy *data,
                            struct Curl_creader *reader, int premature);
 
@@ -374,6 +377,11 @@ CURLcode Curl_creader_resume_from(struct Curl_easy *data, curl_off_t offset);
  * Unpause all installed readers.
  */
 CURLcode Curl_creader_unpause(struct Curl_easy *data);
+
+/**
+ * Return TRUE iff any of the installed readers is paused.
+ */
+bool Curl_creader_is_paused(struct Curl_easy *data);
 
 /**
  * Tell all client readers that they are done.

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1925,6 +1925,7 @@ static const struct Curl_crtype cr_eob = {
   Curl_creader_def_resume_from,
   Curl_creader_def_rewind,
   Curl_creader_def_unpause,
+  Curl_creader_def_is_paused,
   Curl_creader_def_done,
   sizeof(struct cr_eob_ctx)
 };

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1326,10 +1326,12 @@ CURLcode Curl_xfer_send_shutdown(struct Curl_easy *data, bool *done)
 
 bool Curl_xfer_is_blocked(struct Curl_easy *data)
 {
-  if(!CURL_WANT_SEND(data))
-    return (CURL_WANT_RECV(data) && Curl_cwriter_is_paused(data));
-  else if(!CURL_WANT_RECV(data))
-    return (CURL_WANT_SEND(data) && Curl_creader_is_paused(data));
+  bool want_send = ((data)->req.keepon & KEEP_SEND);
+  bool want_recv = ((data)->req.keepon & KEEP_RECV);
+  if(!want_send)
+    return (want_recv && Curl_cwriter_is_paused(data));
+  else if(!want_recv)
+    return (want_send && Curl_creader_is_paused(data));
   else
     return Curl_creader_is_paused(data) && Curl_cwriter_is_paused(data);
 }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1323,3 +1323,13 @@ CURLcode Curl_xfer_send_shutdown(struct Curl_easy *data, bool *done)
   sockindex = (data->conn->writesockfd == data->conn->sock[SECONDARYSOCKET]);
   return Curl_conn_shutdown(data, sockindex, done);
 }
+
+bool Curl_xfer_is_blocked(struct Curl_easy *data)
+{
+  if(!CURL_WANT_SEND(data))
+    return (CURL_WANT_RECV(data) && Curl_cwriter_is_paused(data));
+  else if(!CURL_WANT_RECV(data))
+    return (CURL_WANT_SEND(data) && Curl_creader_is_paused(data));
+  else
+    return Curl_creader_is_paused(data) && Curl_cwriter_is_paused(data);
+}

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -135,4 +135,11 @@ CURLcode Curl_xfer_recv(struct Curl_easy *data,
 CURLcode Curl_xfer_send_close(struct Curl_easy *data);
 CURLcode Curl_xfer_send_shutdown(struct Curl_easy *data, bool *done);
 
+/**
+ * Return TRUE iff the transfer is not done, but further progress
+ * is blocked. For example when it is only receiving and its writer
+ * is PAUSED.
+ */
+bool Curl_xfer_is_blocked(struct Curl_easy *data);
+
 #endif /* HEADER_CURL_TRANSFER_H */


### PR DESCRIPTION
- When a transfer sets `data->state.select_bits`, it is scheduled for rerun with EXPIRE_NOW. If such a transfer is blocked (due to PAUSE, for example), this will lead to a busy loop.
- multi.c: check for transfer block
- sendf.*: add Curl_xfer_is_blocked()
- sendf.*: add client reader `is_paused()` callback
- implement is_paused()` callback where needed