### PR TITLE
vms: fixed language in comment

### DIFF
--- a/packages/vms/compare_curl_source.com
+++ b/packages/vms/compare_curl_source.com
@@ -17,9 +17,9 @@ $!
 $! First the files in the original source directory which is assumed to be
 $! under source code control are compared with the copy directory.
 $!
-$! Then the files are are only in the copy directory are listed.
+$! Only files present in the copy directory are listed.
 $!
-$! The result will five diagnostics about of files:
+$! Diagnostics are displayed about the files:
 $!    1. Files that are not generation 1.
 $!    2. Files missing in the copy directory.
 $!    3. Files in the copy directory not in the source directory.


### PR DESCRIPTION
It started with me fixing a repeated "are are" but the wording was incomprehensible so I tried to untangle it.