### PR TITLE
urlapi: use a correct value for CURLU_NO_GUESS_SCHEME

### DIFF
--- a/include/curl/urlapi.h
+++ b/include/curl/urlapi.h
@@ -102,7 +102,7 @@ typedef enum {
 #define CURLU_GET_EMPTY (1<<14)         /* allow empty queries and fragments
                                            when extracting the URL or the
                                            components */
-#define CURLU_NO_GUESS_SCHEME (1<<14)   /* for get, don't accept a guess */
+#define CURLU_NO_GUESS_SCHEME (1<<15)   /* for get, don't accept a guess */
 
 typedef struct Curl_URL CURLU;
 


### PR DESCRIPTION
It was mistakenly set to the same value as CURLU_GET_EMPTY uses.

Reported-by: Patrick Monnerat
Bug: https://github.com/curl/curl/commit/655d44d139489625e77cf6790d36