### PR TITLE
http: remove "struct HTTP"

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -65,7 +65,6 @@ typedef enum {
 
 /* struct for HTTP CONNECT tunneling */
 struct h1_tunnel_state {
-  struct HTTP CONNECT;
   struct dynbuf rcvbuf;
   struct dynbuf request_data;
   size_t nsent;

--- a/lib/http.c
+++ b/lib/http.c
@@ -169,14 +169,6 @@ CURLcode Curl_http_setup_conn(struct Curl_easy *data,
 {
   /* allocate the HTTP-specific struct for the Curl_easy, only to survive
      during this request */
-  struct HTTP *http;
-  DEBUGASSERT(data->req.p.http == NULL);
-
-  http = calloc(1, sizeof(struct HTTP));
-  if(!http)
-    return CURLE_OUT_OF_MEMORY;
-
-  data->req.p.http = http;
   connkeep(conn, "HTTP default");
 
   if(data->state.httpwant == CURL_HTTP_VERSION_3ONLY) {
@@ -1174,15 +1166,11 @@ CURLcode Curl_http_done(struct Curl_easy *data,
                         CURLcode status, bool premature)
 {
   struct connectdata *conn = data->conn;
-  struct HTTP *http = data->req.p.http;
 
   /* Clear multipass flag. If authentication isn't done yet, then it will get
    * a chance to be set back to true when we output the next auth header */
   data->state.authhost.multipass = FALSE;
   data->state.authproxy.multipass = FALSE;
-
-  if(!http)
-    return CURLE_OK;
 
   Curl_dyn_reset(&data->state.headerb);
   Curl_hyper_done(data);

--- a/lib/http.h
+++ b/lib/http.h
@@ -73,7 +73,6 @@ char *Curl_checkProxyheaders(struct Curl_easy *data,
                              const struct connectdata *conn,
                              const char *thisheader,
                              const size_t thislen);
-struct HTTP; /* see below */
 
 CURLcode Curl_add_timecondition(struct Curl_easy *data,
 #ifndef USE_HYPER

--- a/lib/http.h
+++ b/lib/http.h
@@ -187,10 +187,6 @@ void Curl_http_exp100_got100(struct Curl_easy *data);
 /****************************************************************************
  * HTTP unique setup
  ***************************************************************************/
-struct HTTP {
-  /* TODO: no longer used, we should remove it from SingleRequest */
-  char unused;
-};
 
 CURLcode Curl_http_size(struct Curl_easy *data);
 

--- a/lib/request.c
+++ b/lib/request.c
@@ -109,7 +109,7 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
 
   /* This is a bit ugly. `req->p` is a union and we assume we can
    * free this safely without leaks. */
-  Curl_safefree(req->p.http);
+  Curl_safefree(req->p.ftp);
   Curl_safefree(req->newurl);
   Curl_client_reset(data);
   if(req->sendbuf_init)
@@ -164,7 +164,7 @@ void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)
 {
   /* This is a bit ugly. `req->p` is a union and we assume we can
    * free this safely without leaks. */
-  Curl_safefree(req->p.http);
+  Curl_safefree(req->p.ftp);
   Curl_safefree(req->newurl);
   if(req->sendbuf_init)
     Curl_bufq_free(&req->sendbuf);

--- a/lib/request.h
+++ b/lib/request.h
@@ -104,7 +104,6 @@ struct SingleRequest {
   union {
     struct FILEPROTO *file;
     struct FTP *ftp;
-    struct HTTP *http;
     struct IMAP *imap;
     struct ldapreqinfo *ldap;
     struct MQTT *mqtt;

--- a/lib/rtsp.h
+++ b/lib/rtsp.h
@@ -62,16 +62,6 @@ struct rtsp_conn {
  * RTSP unique setup
  ***************************************************************************/
 struct RTSP {
-  /*
-   * http_wrapper MUST be the first element of this structure for the wrap
-   * logic to work. In this way, we get a cheap polymorphism because
-   * &(data->state.proto.rtsp) == &(data->state.proto.http) per the C spec
-   *
-   * HTTP functions can safely treat this as an HTTP struct, but RTSP aware
-   * functions can also index into the later elements.
-   */
-  struct HTTP http_wrapper; /* wrap HTTP to do the heavy lifting */
-
   long CSeq_sent; /* CSeq of this request */
   long CSeq_recv; /* CSeq received */
 };

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -198,7 +198,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
   struct h3_stream_ctx *stream = H3_STREAM_CTX(ctx, data);
 
-  if(!data || !data->req.p.http) {
+  if(!data) {
     failf(data, "initialization failure, transfer not http initialized");
     return CURLE_FAILED_INIT;
   }

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -521,7 +521,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   struct cf_osslq_ctx *ctx = cf->ctx;
   struct h3_stream_ctx *stream = H3_STREAM_CTX(ctx, data);
 
-  if(!data || !data->req.p.http) {
+  if(!data) {
     failf(data, "initialization failure, transfer not http initialized");
     return CURLE_FAILED_INIT;
   }


### PR DESCRIPTION
It was not used anymore, this removes all traces and uses of it.