### PR TITLE
request: change the struct field bodywrites to a bool, only for hyper

### DIFF
--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -206,7 +206,7 @@ static int hyper_body_chunk(void *userdata, const hyper_buf *chunk)
   struct SingleRequest *k = &data->req;
   CURLcode result = CURLE_OK;
 
-  if(0 == k->bodywrites) {
+  if(!k->bodywritten) {
 #if defined(USE_NTLM)
     struct connectdata *conn = data->conn;
     if(conn->bits.close &&
@@ -420,7 +420,7 @@ CURLcode Curl_hyper_stream(struct Curl_easy *data,
         /* end of transfer */
         data->req.done = TRUE;
         infof(data, "hyperstream is done");
-        if(!k->bodywrites) {
+        if(!k->bodywritten) {
           /* hyper doesn't always call the body write callback */
           result = Curl_http_firstwrite(data);
         }

--- a/lib/request.c
+++ b/lib/request.c
@@ -136,7 +136,6 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->keepon = 0;
   req->upgr101 = UPGR101_INIT;
   req->timeofdoc = 0;
-  req->bodywrites = 0;
   req->location = NULL;
   req->newurl = NULL;
 #ifndef CURL_DISABLE_COOKIES
@@ -158,6 +157,9 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->no_body = data->set.opt_no_body;
   req->authneg = FALSE;
   req->shutdown = FALSE;
+#ifdef USE_HYPER
+  req->bodywritten = 0;
+#endif
 }
 
 void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)

--- a/lib/request.c
+++ b/lib/request.c
@@ -158,7 +158,7 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->authneg = FALSE;
   req->shutdown = FALSE;
 #ifdef USE_HYPER
-  req->bodywritten = 0;
+  req->bodywritten = FALSE;
 #endif
 }
 

--- a/lib/request.h
+++ b/lib/request.h
@@ -93,7 +93,6 @@ struct SingleRequest {
   struct bufq sendbuf; /* data which needs to be send to the server */
   size_t sendbuf_hds_len; /* amount of header bytes in sendbuf */
   time_t timeofdoc;
-  long bodywrites;
   char *location;   /* This points to an allocated version of the Location:
                        header data */
   char *newurl;     /* Set to the new URL to use when a redirect or a retry is
@@ -148,6 +147,9 @@ struct SingleRequest {
                         negotiation. */
   BIT(sendbuf_init); /* sendbuf is initialized */
   BIT(shutdown);     /* request end will shutdown connection */
+#ifdef USE_HYPER
+  BIT(bodywritten);
+#endif
 };
 
 /**

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -316,7 +316,9 @@ static CURLcode cw_download_write(struct Curl_easy *data,
   }
   /* Update stats, write and report progress */
   data->req.bytecount += nwrite;
-  ++data->req.bodywrites;
+#ifdef USE_HYPER
+  data->req.bodywritten = TRUE;
+#endif
   result = Curl_pgrsSetDownloadCounter(data, data->req.bytecount);
   if(result)
     return result;


### PR DESCRIPTION
Only hyper needs to know this, and it can use it as a boolean.