### PR TITLE
os400: make it compilable again

### DIFF
--- a/lib/setup-os400.h
+++ b/lib/setup-os400.h
@@ -46,6 +46,8 @@ typedef unsigned long   u_int32_t;
 #include <qsoasync.h>
 #include <gssapi.h>
 
+#ifdef BUILDING_LIBCURL
+
 extern int Curl_getaddrinfo_a(const char *nodename,
                               const char *servname,
                               const struct addrinfo *hints,
@@ -140,5 +142,7 @@ extern int Curl_os400_getsockname(int sd, struct sockaddr *addr, int *addrlen);
 #define inflate                 Curl_os400_inflate
 #define inflateEnd              Curl_os400_inflateEnd
 #endif
+
+#endif /* BUILDING_LIBCURL */
 
 #endif /* HEADER_CURL_SETUP_OS400_H */

--- a/packages/OS400/curl.inc.in
+++ b/packages/OS400/curl.inc.in
@@ -443,8 +443,12 @@
      d                 c                   X'00000400'
      d CURLU_ALLOW_SPACE...
      d                 c                   X'00000800'
-     d CURLU_PUNYCODE...
-     d                 c                   X'00001000'
+     d CURLU_PUNYCODE  c                   X'00001000'
+     d CURLU_PUNY2IDN  c                   X'00002000'
+     d CURLU_GET_EMPTY...
+     d                 c                   X'00004000'
+     d CURLU_NO_GUESS_SCHEME...
+     d                 c                   X'00008000'
       *
      d CURLOT_FLAG_ALIAS...
      d                 c                   X'00000001'
@@ -1666,6 +1670,8 @@
      d  CURLOPT_SERVER_RESPONSE_TIMEOUT_MS...
      d                 c                   00324
      d  CURLOPT_ECH    c                   10325
+     d  CURLOPT_TCP_KEEPCNT...
+     d                 c                   00326
       *
       /if not defined(CURL_NO_OLDIES)
      d  CURLOPT_FILE   c                   10001

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -178,14 +178,13 @@ static int sockopt_callback(void *clientp, curl_socket_t curlfd,
     switch(get_address_family(curlfd)) {
     case AF_INET:
 #ifdef IP_TOS
-      result = setsockopt(curlfd, SOL_IP, IP_TOS,
-                          (const char *)&tos, sizeof(tos));
+      result = setsockopt(curlfd, SOL_IP, IP_TOS, (void *)&tos, sizeof(tos));
 #endif
       break;
     case AF_INET6:
 #ifdef IPV6_TCLASS
       result = setsockopt(curlfd, IPPROTO_IPV6, IPV6_TCLASS,
-                          (const char *)&tos, sizeof(tos));
+                          (void *)&tos, sizeof(tos));
 #endif
       break;
     }
@@ -201,7 +200,7 @@ static int sockopt_callback(void *clientp, curl_socket_t curlfd,
   if(config->vlan_priority > 0) {
     int priority = (int)config->vlan_priority;
     if(setsockopt(curlfd, SOL_SOCKET, SO_PRIORITY,
-      (const char *)&priority, sizeof(priority)) != 0) {
+      (void *)&priority, sizeof(priority)) != 0) {
       int error = errno;
       warnf(config->global, "VLAN priority %d failed with errno %d: %s;\n",
             priority, error, strerror(error));


### PR DESCRIPTION
A newly introduced use of getsockname() in the cli tool makes it require the ascii wrapper module, which is not available outside of the library: as the tool only uses the address family field (binary), disable wrappers outside of libcurl.

Fix setsockopt() parameter type mismatch using a (void *) cast.

Sync ILE/RPG binding.