### PR TITLE
connections graceful shutdown

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -183,7 +183,6 @@ struct cf_h2_proxy_ctx {
   BIT(conn_closed);
   BIT(rcvd_goaway);
   BIT(sent_goaway);
-  BIT(shutdown);
   BIT(nw_out_blocked);
 };
 
@@ -1172,13 +1171,16 @@ static CURLcode cf_h2_proxy_shutdown(struct Curl_cfilter *cf,
                                      struct Curl_easy *data, bool *done)
 {
   struct cf_h2_proxy_ctx *ctx = cf->ctx;
+  struct cf_call_data save;
   CURLcode result;
   int rv;
 
-  if(!cf->connected || !ctx->h2 || ctx->shutdown) {
+  if(!cf->connected || !ctx->h2 || cf->shutdown || ctx->conn_closed) {
     *done = TRUE;
     return CURLE_OK;
   }
+
+  CF_DATA_SAVE(save, cf, data);
 
   if(!ctx->sent_goaway) {
     rv = nghttp2_submit_goaway(ctx->h2, NGHTTP2_FLAG_NONE,
@@ -1187,7 +1189,8 @@ static CURLcode cf_h2_proxy_shutdown(struct Curl_cfilter *cf,
     if(rv) {
       failf(data, "nghttp2_submit_goaway() failed: %s(%d)",
             nghttp2_strerror(rv), rv);
-      return CURLE_SEND_ERROR;
+      result = CURLE_SEND_ERROR;
+      goto out;
     }
     ctx->sent_goaway = TRUE;
   }
@@ -1198,9 +1201,12 @@ static CURLcode cf_h2_proxy_shutdown(struct Curl_cfilter *cf,
   if(!result && nghttp2_session_want_read(ctx->h2))
     result = proxy_h2_progress_ingress(cf, data);
 
-  *done = !result && !nghttp2_session_want_write(ctx->h2) &&
-          !nghttp2_session_want_read(ctx->h2);
-  ctx->shutdown = (result || *done);
+  *done = (ctx->conn_closed ||
+           (!result && !nghttp2_session_want_write(ctx->h2) &&
+            !nghttp2_session_want_read(ctx->h2)));
+out:
+  CF_DATA_RESTORE(cf, save);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1240,7 +1246,7 @@ static void cf_h2_proxy_adjust_pollset(struct Curl_cfilter *cf,
     Curl_pollset_set(data, ps, sock, want_recv, want_send);
     CF_DATA_RESTORE(cf, save);
   }
-  else if(ctx->sent_goaway && !ctx->shutdown) {
+  else if(ctx->sent_goaway && !cf->shutdown) {
     /* shutdown in progress */
     CF_DATA_SAVE(save, cf, data);
     want_send = nghttp2_session_want_write(ctx->h2);

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -223,6 +223,7 @@ struct Curl_cfilter {
   struct connectdata *conn;      /* the connection this filter belongs to */
   int sockindex;                 /* the index the filter is installed at */
   BIT(connected);                /* != 0 iff this filter is connected */
+  BIT(shutdown);                 /* != 0 iff this filter has shut down */
 };
 
 /* Default implementations for the type functions, implementing nop. */

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -900,6 +900,7 @@ static void conncache_shutdown_discard_all(struct conncache *connc)
   connc->shutdowns.iter_locked = FALSE;
 }
 
+#ifdef DEBUGBUILD
 static void conncache_shutdown_all(struct conncache *connc, int timeout_ms)
 {
   struct connectdata *conn;
@@ -945,7 +946,7 @@ static void conncache_shutdown_all(struct conncache *connc, int timeout_ms)
   /* Due to errors/timeout, we might come here without being full ydone. */
   conncache_shutdown_discard_all(connc);
 }
-
+#endif
 
 #if 0
 /* Useful for debugging the connection cache */

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -659,7 +659,7 @@ static void conncache_shutdown_conn(struct conncache *connc,
      (data->multi->max_shutdown_connections >=
       (long)Curl_llist_count(&connc->shutdowns.conn_list))) {
     DEBUGF(infof(data, "conncache_shutdown discard oldest, shutdown limit "
-                 "%zu reached", data->multi->max_shutdown_connections));
+                 "%ld reached", data->multi->max_shutdown_connections));
     connc_shutdown_discard_oldest(connc);
   }
   Curl_llist_append(&connc->shutdowns.conn_list, conn, &conn->bundle_node);

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -774,20 +774,20 @@ CURLcode Curl_conncache_add_pollfds(struct conncache *connc,
   DEBUGASSERT(!connc->shutdowns.iter_locked);
   connc->shutdowns.iter_locked = TRUE;
   if(connc->shutdowns.conn_list.head) {
-    struct Curl_llist_element *e = connc->shutdowns.conn_list.head;
+    struct Curl_llist_element *e;
     struct easy_pollset ps;
+    struct connectdata *conn;
 
     for(e = connc->shutdowns.conn_list.head; e; e = e->next) {
-      struct connectdata *conn = e->ptr;
-
+      conn = e->ptr;
       memset(&ps, 0, sizeof(ps));
       Curl_attach_connection(connc->closure_handle, conn);
       Curl_conn_adjust_pollset(connc->closure_handle, &ps);
       Curl_detach_connection(connc->closure_handle);
 
-      if(Curl_pollfds_add_ps(cpfds, &ps)) {
+      result = Curl_pollfds_add_ps(cpfds, &ps);
+      if(result) {
         Curl_pollfds_cleanup(cpfds);
-        result = CURLE_OUT_OF_MEMORY;
         goto out;
       }
     }
@@ -805,21 +805,20 @@ CURLcode Curl_conncache_add_waitfds(struct conncache *connc,
   DEBUGASSERT(!connc->shutdowns.iter_locked);
   connc->shutdowns.iter_locked = TRUE;
   if(connc->shutdowns.conn_list.head) {
-    struct Curl_llist_element *e = connc->shutdowns.conn_list.head;
+    struct Curl_llist_element *e;
     struct easy_pollset ps;
+    struct connectdata *conn;
 
     for(e = connc->shutdowns.conn_list.head; e; e = e->next) {
-      struct connectdata *conn = e->ptr;
-
+      conn = e->ptr;
       memset(&ps, 0, sizeof(ps));
       Curl_attach_connection(connc->closure_handle, conn);
       Curl_conn_adjust_pollset(connc->closure_handle, &ps);
       Curl_detach_connection(connc->closure_handle);
 
-      if(Curl_waitfds_add_ps(cwfds, &ps)) {
-        result = CURLE_OUT_OF_MEMORY;
+      result = Curl_waitfds_add_ps(cwfds, &ps);
+      if(result)
         goto out;
-      }
     }
   }
 out:

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -689,8 +689,14 @@ void Curl_conncache_shutdown_conn(struct Curl_easy *data,
                                   struct connectdata *conn,
                                   bool is_dead, bool lock)
 {
+  DEBUGASSERT(data);
   infof(data, "Closing connection");
-  conncache_shutdown_conn(data->state.conn_cache, data, conn, is_dead, lock);
+  if(data->state.conn_cache) {
+    conncache_shutdown_conn(data->state.conn_cache, data, conn, is_dead, lock);
+  }
+  else {
+    connc_disconnect(data, conn, !is_dead);
+  }
 }
 
 static void connc_run_conn_shutdown_handler(struct Curl_easy *data,

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -132,7 +132,7 @@ void Curl_conncache_print(struct conncache *connc);
 
 void Curl_conncache_shutdown_conn(struct Curl_easy *data,
                                   struct connectdata *conn,
-                                  bool is_dead, bool lock);
+                                  bool aborted, bool lock);
 
 CURLcode Curl_conncache_add_pollfds(struct conncache *connc,
                                     struct curl_pollfds *cpfds);

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1443,8 +1443,7 @@ CURLcode Curl_once_resolved(struct Curl_easy *data, bool *protocol_done)
 
   if(result) {
     Curl_detach_connection(data);
-    Curl_conncache_remove_conn(data, conn, TRUE);
-    Curl_disconnect(data, conn, TRUE);
+    Curl_conncache_shutdown_conn(data, conn, TRUE, TRUE);
   }
   return result;
 }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1246,6 +1246,7 @@ static void conncaches_tmp_add(struct Curl_llist *list,
         break;
       }
     }
+    (void)found; /* some Windows builds complains about found not used. */
     DEBUGASSERT(found);
   }
 #endif

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1338,6 +1338,9 @@ static CURLMcode multi_wait(struct Curl_multi *multi,
   struct pollfd a_few_on_stack[NUM_POLLS_ON_STACK];
   struct curl_pollfds cpfds;
   unsigned int curl_nfds = 0; /* how many pfds are for curl transfers */
+  struct Curl_llist conn_caches;
+  struct Curl_llist_element *le;
+  CURLMcode result = CURLM_OK;
 #ifdef USE_WINSOCK
   WSANETWORKEVENTS wsa_events;
   DEBUGASSERT(multi->wsa_event != WSA_INVALID_EVENT);
@@ -1345,9 +1348,6 @@ static CURLMcode multi_wait(struct Curl_multi *multi,
 #ifndef ENABLE_WAKEUP
   (void)use_wakeup;
 #endif
-  struct Curl_llist conn_caches;
-  struct Curl_llist_element *le;
-  CURLMcode result = CURLM_OK;
 
   if(!GOOD_MULTI_HANDLE(multi))
     return CURLM_BAD_HANDLE;

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -148,6 +148,8 @@ struct Curl_multi {
 
   long max_total_connections; /* if >0, a fixed limit of the maximum number
                                  of connections in total */
+  long max_shutdown_connections; /* if >0, a fixed limit of the maximum number
+                                 of connections in shutdown handling */
 
   /* timer callback and user data pointer for the *socket() API */
   curl_multi_timer_callback timer_cb;

--- a/lib/share.c
+++ b/lib/share.c
@@ -26,6 +26,7 @@
 
 #include <curl/curl.h>
 #include "urldata.h"
+#include "connect.h"
 #include "share.h"
 #include "psl.h"
 #include "vtls/vtls.h"

--- a/lib/url.c
+++ b/lib/url.c
@@ -740,6 +740,7 @@ static bool prune_if_dead(struct connectdata *conn,
          * any time (HTTP/2 PING for example), the protocol handler needs
          * to install its own `connection_check` callback.
          */
+        DEBUGF(infof(data, "connection has input pending, not reusable"));
         dead = TRUE;
       }
       Curl_detach_connection(data);
@@ -798,7 +799,7 @@ static void prune_dead_connections(struct Curl_easy *data)
       /* connection previously removed from cache in prune_if_dead() */
 
       /* shut it down */
-      Curl_conncache_shutdown_conn(data, pruned, TRUE, TRUE);
+      Curl_conncache_shutdown_conn(data, pruned, FALSE, TRUE);
     }
     CONNCACHE_LOCK(data);
     data->state.conn_cache->last_cleanup = now;
@@ -1211,7 +1212,7 @@ ConnectionExists(struct Curl_easy *data,
     }
     else if(prune_if_dead(check, data)) {
       /* disconnect it */
-      Curl_conncache_shutdown_conn(data, check, TRUE, TRUE);
+      Curl_conncache_shutdown_conn(data, check, FALSE, TRUE);
       continue;
     }
 

--- a/lib/url.h
+++ b/lib/url.h
@@ -37,10 +37,9 @@ void Curl_freeset(struct Curl_easy *data);
 CURLcode Curl_uc_to_curlcode(CURLUcode uc);
 CURLcode Curl_close(struct Curl_easy **datap); /* opposite of curl_open() */
 CURLcode Curl_connect(struct Curl_easy *, bool *async, bool *protocol_connect);
-void Curl_disconnect(struct Curl_easy *data,
-                     struct connectdata *, bool dead_connection);
 CURLcode Curl_setup_conn(struct Curl_easy *data,
                          bool *protocol_done);
+void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn);
 CURLcode Curl_parse_login_details(const char *login, const size_t len,
                                   char **userptr, char **passwdptr,
                                   char **optionsptr);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -546,7 +546,7 @@ struct ConnectBits {
                          accept() */
   BIT(parallel_connect); /* set TRUE when a parallel connect attempt has
                             started (happy eyeballs) */
-  BIT(shutdown_maybe_dead); /* connection shutdown: conn suspected dead */
+  BIT(aborted); /* connection was aborted, e.g. in unclean state */
   BIT(shutdown_handler); /* connection shutdown: handler shut down */
   BIT(shutdown_filters); /* connection shutdown: filters shut down */
 };

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -546,6 +546,9 @@ struct ConnectBits {
                          accept() */
   BIT(parallel_connect); /* set TRUE when a parallel connect attempt has
                             started (happy eyeballs) */
+  BIT(shutdown_maybe_dead); /* connection shutdown: conn suspected dead */
+  BIT(shutdown_handler); /* connection shutdown: handler shut down */
+  BIT(shutdown_filters); /* connection shutdown: filters shut down */
 };
 
 struct hostname {

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -1080,7 +1080,7 @@ static CURLcode bearssl_shutdown(struct Curl_cfilter *cf,
   CURLcode result;
 
   DEBUGASSERT(backend);
-  if(!backend->active || connssl->shutdown) {
+  if(!backend->active || cf->shutdown) {
     *done = TRUE;
     return CURLE_OK;
   }
@@ -1101,7 +1101,7 @@ static CURLcode bearssl_shutdown(struct Curl_cfilter *cf,
   else
     CURL_TRC_CF(data, cf, "shutdown error: %d", result);
 
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1114,13 +1114,7 @@ static void bearssl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   DEBUGASSERT(backend);
 
-  if(backend->active) {
-    if(!connssl->shutdown) {
-      bool done;
-      bearssl_shutdown(cf, data, TRUE, &done);
-    }
-    backend->active = FALSE;
-  }
+  backend->active = FALSE;
   if(backend->anchors) {
     for(i = 0; i < backend->anchors_len; ++i)
       free(backend->anchors[i].dn.data);

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -1112,6 +1112,7 @@ static void bearssl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
     (struct bearssl_ssl_backend_data *)connssl->backend;
   size_t i;
 
+  (void)data;
   DEBUGASSERT(backend);
 
   backend->active = FALSE;

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1822,7 +1822,7 @@ static CURLcode gtls_shutdown(struct Curl_cfilter *cf,
   size_t i;
 
   DEBUGASSERT(backend);
-  if(!backend->gtls.session || connssl->shutdown) {
+  if(!backend->gtls.session || cf->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -1876,7 +1876,7 @@ static CURLcode gtls_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1891,10 +1891,6 @@ static void gtls_close(struct Curl_cfilter *cf,
   DEBUGASSERT(backend);
   CURL_TRC_CF(data, cf, "close");
   if(backend->gtls.session) {
-    if(!connssl->shutdown) {
-      bool done;
-      gtls_shutdown(cf, data, TRUE, &done);
-    }
     gnutls_deinit(backend->gtls.session);
     backend->gtls.session = NULL;
   }

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1295,6 +1295,7 @@ static void mbedtls_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;
 
+  (void)data;
   DEBUGASSERT(backend);
   if(backend->initialized) {
     mbedtls_pk_free(&backend->pk);

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1213,7 +1213,7 @@ static CURLcode mbedtls_shutdown(struct Curl_cfilter *cf,
 
   DEBUGASSERT(backend);
 
-  if(!backend->initialized || connssl->shutdown) {
+  if(!backend->initialized || cf->shutdown) {
     *done = TRUE;
     return CURLE_OK;
   }
@@ -1285,7 +1285,7 @@ static CURLcode mbedtls_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1297,11 +1297,6 @@ static void mbedtls_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   DEBUGASSERT(backend);
   if(backend->initialized) {
-    if(!connssl->shutdown) {
-      bool done;
-      mbedtls_shutdown(cf, data, TRUE, &done);
-    }
-
     mbedtls_pk_free(&backend->pk);
     mbedtls_x509_crt_free(&backend->clicert);
     mbedtls_x509_crt_free(&backend->cacert);

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -804,6 +804,7 @@ cr_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   struct rustls_ssl_backend_data *backend =
     (struct rustls_ssl_backend_data *)connssl->backend;
 
+  (void)data;
   DEBUGASSERT(backend);
   if(backend->conn) {
     rustls_connection_free(backend->conn);

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -742,7 +742,7 @@ cr_shutdown(struct Curl_cfilter *cf,
   size_t i;
 
   DEBUGASSERT(backend);
-  if(!backend->conn || connssl->shutdown) {
+  if(!backend->conn || cf->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -793,7 +793,7 @@ cr_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -806,14 +806,6 @@ cr_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   DEBUGASSERT(backend);
   if(backend->conn) {
-    /* Send the TLS shutdown if have not done so already and are still
-     * connected *and* if the peer did not already close the connection. */
-    if(cf->connected && !connssl->shutdown &&
-       cf->next && cf->next->connected && !connssl->peer_closed) {
-      bool done;
-      (void)cr_shutdown(cf, data, TRUE, &done);
-    }
-
     rustls_connection_free(backend->conn);
     backend->conn = NULL;
   }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2482,7 +2482,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
     (struct schannel_ssl_backend_data *)connssl->backend;
   CURLcode result = CURLE_OK;
 
-  if(connssl->shutdown) {
+  if(cf->shutdown) {
     *done = TRUE;
     return CURLE_OK;
   }
@@ -2499,7 +2499,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
           connssl->peer.hostname, connssl->peer.port);
   }
 
-  if(!backend->ctxt || connssl->shutdown) {
+  if(!backend->ctxt || cf->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -2606,7 +2606,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -2618,13 +2618,6 @@ static void schannel_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   DEBUGASSERT(data);
   DEBUGASSERT(backend);
-
-  if(backend->cred && backend->ctxt &&
-     cf->connected && !connssl->shutdown &&
-     cf->next && cf->next->connected && !connssl->peer_closed) {
-    bool done;
-    (void)schannel_shutdown(cf, data, TRUE, &done);
-  }
 
   /* free SSPI Schannel API security context handle */
   if(backend->ctxt) {

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2575,7 +2575,7 @@ static CURLcode sectransp_shutdown(struct Curl_cfilter *cf,
   size_t i;
 
   DEBUGASSERT(backend);
-  if(!backend->ssl_ctx || connssl->shutdown) {
+  if(!backend->ssl_ctx || cf->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -2638,7 +2638,7 @@ static CURLcode sectransp_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -2654,12 +2654,6 @@ static void sectransp_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   if(backend->ssl_ctx) {
     CURL_TRC_CF(data, cf, "close");
-    if(cf->connected && !connssl->shutdown &&
-       cf->next && cf->next->connected && !connssl->peer_closed) {
-      bool done;
-      (void)sectransp_shutdown(cf, data, TRUE, &done);
-    }
-
 #if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
     if(SSLCreateContext)
       CFRelease(backend->ssl_ctx);

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1757,17 +1757,17 @@ static CURLcode ssl_cf_shutdown(struct Curl_cfilter *cf,
                                 struct Curl_easy *data,
                                 bool *done)
 {
-  struct ssl_connect_data *connssl = cf->ctx;
-  struct cf_call_data save;
   CURLcode result = CURLE_OK;
 
   *done = TRUE;
-  if(!connssl->shutdown) {
+  if(!cf->shutdown) {
+    struct cf_call_data save;
+
     CF_DATA_SAVE(save, cf, data);
     result = Curl_ssl->shut_down(cf, data, TRUE, done);
     CURL_TRC_CF(data, cf, "cf_shutdown -> %d, done=%d", result, *done);
     CF_DATA_RESTORE(cf, save);
-    connssl->shutdown = (result || *done);
+    cf->shutdown = (result || *done);
   }
   return result;
 }
@@ -2052,7 +2052,7 @@ static CURLcode vtls_shutdown_blocking(struct Curl_cfilter *cf,
   timediff_t timeout_ms;
   int what, loop = 10;
 
-  if(connssl->shutdown) {
+  if(cf->shutdown) {
     *done = TRUE;
     return CURLE_OK;
   }
@@ -2091,7 +2091,7 @@ static CURLcode vtls_shutdown_blocking(struct Curl_cfilter *cf,
   }
 out:
   CF_DATA_RESTORE(cf, save);
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -94,7 +94,6 @@ struct ssl_connect_data {
   int io_need;                      /* TLS signals special SEND/RECV needs */
   BIT(use_alpn);                    /* if ALPN shall be used in handshake */
   BIT(peer_closed);                 /* peer has closed connection */
-  BIT(shutdown);                    /* graceful close notify finished */
 };
 
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1352,7 +1352,7 @@ static CURLcode wolfssl_shutdown(struct Curl_cfilter *cf,
   int nread, err;
 
   DEBUGASSERT(wctx);
-  if(!wctx->handle || connssl->shutdown) {
+  if(!wctx->handle || cf->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -1369,17 +1369,17 @@ static CURLcode wolfssl_shutdown(struct Curl_cfilter *cf,
       bool input_pending;
       /* Yes, it did. */
       if(!send_shutdown) {
-        connssl->shutdown = TRUE;
         CURL_TRC_CF(data, cf, "SSL shutdown received, not sending");
+        *done = TRUE;
         goto out;
       }
       else if(!cf->next->cft->is_alive(cf->next, data, &input_pending)) {
         /* Server closed the connection after its closy notify. It
          * seems not interested to see our close notify, so do not
          * send it. We are done. */
-        connssl->peer_closed = TRUE;
-        connssl->shutdown = TRUE;
         CURL_TRC_CF(data, cf, "peer closed connection");
+        connssl->peer_closed = TRUE;
+        *done = TRUE;
         goto out;
       }
     }
@@ -1430,7 +1430,7 @@ static CURLcode wolfssl_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1445,11 +1445,6 @@ static void wolfssl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   DEBUGASSERT(backend);
 
   if(backend->handle) {
-    if(cf->connected && !connssl->shutdown &&
-       cf->next && cf->next->connected && !connssl->peer_closed) {
-      bool done;
-      (void)wolfssl_shutdown(cf, data, TRUE, &done);
-    }
     wolfSSL_free(backend->handle);
     backend->handle = NULL;
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def pytest_report_header(config):
         ])
     if env.has_vsftpd():
         report.extend([
-            f'  VsFTPD: {env.vsftpd_version()}, ftp:{env.ftp_port}'
+            f'  VsFTPD: {env.vsftpd_version()}, ftp:{env.ftp_port}, ftps:{env.ftps_port}'
         ])
     return '\n'.join(report)
 

--- a/tests/data/test1542
+++ b/tests/data/test1542
@@ -58,11 +58,11 @@ Accept: */*
 == Info: Connection #0 to host %HOSTIP left intact
 == Info: Connection #0 to host %HOSTIP left intact
 == Info: Connection #0 to host %HOSTIP left intact
-== Info: Closing connection
+== Info: Shutting down connection #0
 == Info: Connection #1 to host %HOSTIP left intact
 </file>
 <stripfile>
-$_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))
+$_ = '' if (($_ !~ /left intact/) && ($_ !~ /(Closing|Shutting down) connection/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -568,6 +568,8 @@ class TestDownload:
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     @pytest.mark.parametrize("proto", ['http/1.1'])
     def test_02_30_check_tcp_rst(self, env: Env, httpd, repeat, proto):
+        if env.ci_run:
+            pytest.skip("seems not to work in CI")
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-1]'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_tcpdump=True, extra_args=[

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -136,6 +136,33 @@ class TestVsFTPD:
         if os.path.exists(path):
             return os.remove(path)
 
+    # check with `tcpdump` if curl causes any TCP RST packets
+    @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
+    def test_30_06_shutdownh_download(self, env: Env, vsftpd: VsFTPD, repeat):
+        docname = 'data-1k'
+        curl = CurlClient(env=env)
+        count = 1
+        url = f'ftp://{env.ftp_domain}:{vsftpd.port}/{docname}?[0-{count-1}]'
+        r = curl.ftp_get(urls=[url], with_stats=True, with_tcpdump=True)
+        r.check_stats(count=count, http_status=226)
+        assert r.tcpdump
+        assert len(r.tcpdump.stats) == 0, f'Unexpected TCP RSTs packets'
+
+    # check with `tcpdump` if curl causes any TCP RST packets
+    @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
+    def test_30_07_shutdownh_upload(self, env: Env, vsftpd: VsFTPD, repeat):
+        docname = 'upload-1k'
+        curl = CurlClient(env=env)
+        srcfile = os.path.join(env.gen_dir, docname)
+        dstfile = os.path.join(vsftpd.docs_dir, docname)
+        self._rmf(dstfile)
+        count = 1
+        url = f'ftp://{env.ftp_domain}:{vsftpd.port}/'
+        r = curl.ftp_upload(urls=[url], fupload=f'{srcfile}', with_stats=True, with_tcpdump=True)
+        r.check_stats(count=count, http_status=226)
+        assert r.tcpdump
+        assert len(r.tcpdump.stats) == 0, f'Unexpected TCP RSTs packets'
+
     def check_downloads(self, client, srcfile: str, count: int,
                         complete: bool = True):
         for i in range(count):

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -27,6 +27,9 @@
 import json
 import logging
 import os
+import time
+from threading import Thread
+
 import psutil
 import re
 import shutil
@@ -103,6 +106,73 @@ class RunProfile:
                f'stats={self.stats}]'
 
 
+class RunTcpDump:
+
+    def __init__(self, env, run_dir):
+        self._env = env
+        self._run_dir = run_dir
+        self._proc = None
+        self._stdoutfile = os.path.join(self._run_dir, 'tcpdump.out')
+        self._stderrfile = os.path.join(self._run_dir, 'tcpdump.err')
+
+    @property
+    def stats(self) -> Optional[List[str]]:
+        if self._proc:
+            raise Exception('tcpdump still running')
+        lines = []
+        for l in open(self._stdoutfile).readlines():
+            if re.match(r'.* IP 127\.0\.0\.1\.\d+ [<>] 127\.0\.0\.1\.\d+:.*', l):
+                lines.append(l)
+        return lines
+
+    def stats_excluding(self, src_port) -> Optional[List[str]]:
+        if self._proc:
+            raise Exception('tcpdump still running')
+        lines = []
+        for l in self.stats:
+            if not re.match(r'.* IP 127\.0\.0\.1\.' + str(src_port) + ' >.*', l):
+                lines.append(l)
+        return lines
+
+    def sample(self):
+        local_if = 'lo0'
+        try:
+            tcpdump = self._env.tcpdump()
+            if tcpdump is None:
+                raise Exception('tcpdump not available')
+            # look with tcpdump for TCP RST packets which indicate
+            # we did not shut down connections cleanly
+            args = [
+                tcpdump, '-i', local_if, '-n', 'tcp[tcpflags] & (tcp-rst)!=0'
+            ]
+            with open(self._stdoutfile, 'w') as cout:
+                with open(self._stderrfile, 'w') as cerr:
+                    self._proc = subprocess.Popen(args, stdout=cout, stderr=cerr,
+                                                  text=True, cwd=self._run_dir,
+                                                  shell=False)
+                    assert self._proc
+                    assert self._proc.returncode is None
+                    while self._proc:
+                        try:
+                            self._proc.wait(timeout=1)
+                        except subprocess.TimeoutExpired:
+                            pass
+        except Exception as e:
+            log.error(f'Tcpdump: {e}')
+
+    def start(self):
+        def do_sample():
+            self.sample()
+        t = Thread(target=do_sample)
+        t.start()
+
+    def finish(self):
+        if self._proc:
+            time.sleep(1)
+            self._proc.terminate()
+            self._proc = None
+
+
 class ExecResult:
 
     def __init__(self, args: List[str], exit_code: int,
@@ -110,13 +180,15 @@ class ExecResult:
                  duration: Optional[timedelta] = None,
                  with_stats: bool = False,
                  exception: Optional[str] = None,
-                 profile: Optional[RunProfile] = None):
+                 profile: Optional[RunProfile] = None,
+                 tcpdump: Optional[RunTcpDump] = None):
         self._args = args
         self._exit_code = exit_code
         self._exception = exception
         self._stdout = stdout
         self._stderr = stderr
         self._profile = profile
+        self._tcpdump = tcpdump
         self._duration = duration if duration is not None else timedelta()
         self._response = None
         self._responses = []
@@ -184,6 +256,10 @@ class ExecResult:
     @property
     def profile(self) -> Optional[RunProfile]:
         return self._profile
+
+    @property
+    def tcpdump(self) -> Optional[RunTcpDump]:
+        return self._tcpdump
 
     @property
     def response(self) -> Optional[Dict]:
@@ -359,8 +435,11 @@ class CurlClient:
         'h3': '--http3-only',
     }
 
-    def __init__(self, env: Env, run_dir: Optional[str] = None,
-                 timeout: Optional[float] = None, silent: bool = False):
+    def __init__(self, env: Env,
+                 run_dir: Optional[str] = None,
+                 timeout: Optional[float] = None,
+                 silent: bool = False,
+                 run_env: Optional[Dict[str, str]] = None):
         self.env = env
         self._timeout = timeout if timeout else env.test_timeout
         self._curl = os.environ['CURL'] if 'CURL' in os.environ else env.curl
@@ -370,6 +449,7 @@ class CurlClient:
         self._headerfile = f'{self._run_dir}/curl.headers'
         self._log_path = f'{self._run_dir}/curl.log'
         self._silent = silent
+        self._run_env = run_env
         self._rmrf(self._run_dir)
         self._mkpath(self._run_dir)
 
@@ -418,18 +498,21 @@ class CurlClient:
                  alpn_proto: Optional[str] = None,
                  def_tracing: bool = True,
                  with_stats: bool = False,
-                 with_profile: bool = False):
+                 with_profile: bool = False,
+                 with_tcpdump: bool = False):
         return self._raw(url, options=extra_args,
                          with_stats=with_stats,
                          alpn_proto=alpn_proto,
                          def_tracing=def_tracing,
-                         with_profile=with_profile)
+                         with_profile=with_profile,
+                         with_tcpdump=with_tcpdump)
 
     def http_download(self, urls: List[str],
                       alpn_proto: Optional[str] = None,
                       with_stats: bool = True,
                       with_headers: bool = False,
                       with_profile: bool = False,
+                      with_tcpdump: bool = False,
                       no_save: bool = False,
                       extra_args: List[str] = None):
         if extra_args is None:
@@ -452,13 +535,15 @@ class CurlClient:
         return self._raw(urls, alpn_proto=alpn_proto, options=extra_args,
                          with_stats=with_stats,
                          with_headers=with_headers,
-                         with_profile=with_profile)
+                         with_profile=with_profile,
+                         with_tcpdump=with_tcpdump)
 
     def http_upload(self, urls: List[str], data: str,
                     alpn_proto: Optional[str] = None,
                     with_stats: bool = True,
                     with_headers: bool = False,
                     with_profile: bool = False,
+                    with_tcpdump: bool = False,
                     extra_args: Optional[List[str]] = None):
         if extra_args is None:
             extra_args = []
@@ -472,7 +557,8 @@ class CurlClient:
         return self._raw(urls, alpn_proto=alpn_proto, options=extra_args,
                          with_stats=with_stats,
                          with_headers=with_headers,
-                         with_profile=with_profile)
+                         with_profile=with_profile,
+                         with_tcpdump=with_tcpdump)
 
     def http_delete(self, urls: List[str],
                     alpn_proto: Optional[str] = None,
@@ -541,6 +627,7 @@ class CurlClient:
     def ftp_get(self, urls: List[str],
                       with_stats: bool = True,
                       with_profile: bool = False,
+                      with_tcpdump: bool = False,
                       no_save: bool = False,
                       extra_args: List[str] = None):
         if extra_args is None:
@@ -563,11 +650,13 @@ class CurlClient:
         return self._raw(urls, options=extra_args,
                          with_stats=with_stats,
                          with_headers=False,
-                         with_profile=with_profile)
+                         with_profile=with_profile,
+                         with_tcpdump=with_tcpdump)
 
     def ftp_ssl_get(self, urls: List[str],
                       with_stats: bool = True,
                       with_profile: bool = False,
+                      with_tcpdump: bool = False,
                       no_save: bool = False,
                       extra_args: List[str] = None):
         if extra_args is None:
@@ -577,11 +666,13 @@ class CurlClient:
         ])
         return self.ftp_get(urls=urls, with_stats=with_stats,
                             with_profile=with_profile, no_save=no_save,
+                            with_tcpdump=with_tcpdump,
                             extra_args=extra_args)
 
     def ftp_upload(self, urls: List[str], fupload,
                    with_stats: bool = True,
                    with_profile: bool = False,
+                   with_tcpdump: bool = False,
                    extra_args: List[str] = None):
         if extra_args is None:
             extra_args = []
@@ -595,11 +686,13 @@ class CurlClient:
         return self._raw(urls, options=extra_args,
                          with_stats=with_stats,
                          with_headers=False,
-                         with_profile=with_profile)
+                         with_profile=with_profile,
+                         with_tcpdump=with_tcpdump)
 
     def ftp_ssl_upload(self, urls: List[str], fupload,
                        with_stats: bool = True,
                        with_profile: bool = False,
+                       with_tcpdump: bool = False,
                        extra_args: List[str] = None):
         if extra_args is None:
             extra_args = []
@@ -608,6 +701,7 @@ class CurlClient:
         ])
         return self.ftp_upload(urls=urls, fupload=fupload,
                                with_stats=with_stats, with_profile=with_profile,
+                               with_tcpdump=with_tcpdump,
                                extra_args=extra_args)
 
     def response_file(self, idx: int):
@@ -625,14 +719,18 @@ class CurlClient:
         my_args.extend(args)
         return self._run(args=my_args, with_stats=with_stats, with_profile=with_profile)
 
-    def _run(self, args, intext='', with_stats: bool = False, with_profile: bool = True):
+    def _run(self, args, intext='', with_stats: bool = False,
+             with_profile: bool = True, with_tcpdump: bool = False):
         self._rmf(self._stdoutfile)
         self._rmf(self._stderrfile)
         self._rmf(self._headerfile)
-        started_at = datetime.now()
         exception = None
         profile = None
+        tcpdump = None
         started_at = datetime.now()
+        if with_tcpdump:
+            tcpdump = RunTcpDump(self.env, self._run_dir)
+            tcpdump.start()
         try:
             with open(self._stdoutfile, 'w') as cout:
                 with open(self._stderrfile, 'w') as cerr:
@@ -641,7 +739,8 @@ class CurlClient:
                             if self._timeout else None
                         log.info(f'starting: {args}')
                         p = subprocess.Popen(args, stderr=cerr, stdout=cout,
-                                             cwd=self._run_dir, shell=False)
+                                             cwd=self._run_dir, shell=False,
+                                             env=self._run_env)
                         profile = RunProfile(p.pid, started_at, self._run_dir)
                         if intext is not None and False:
                             p.communicate(input=intext.encode(), timeout=1)
@@ -663,7 +762,8 @@ class CurlClient:
                         p = subprocess.run(args, stderr=cerr, stdout=cout,
                                            cwd=self._run_dir, shell=False,
                                            input=intext.encode() if intext else None,
-                                           timeout=self._timeout)
+                                           timeout=self._timeout,
+                                           env=self._run_env)
                         exitcode = p.returncode
         except subprocess.TimeoutExpired:
             now = datetime.now()
@@ -672,13 +772,15 @@ class CurlClient:
                         f'(configured {self._timeout}s): {args}')
             exitcode = -1
             exception = 'TimeoutExpired'
+        if tcpdump:
+            tcpdump.finish()
         coutput = open(self._stdoutfile).readlines()
         cerrput = open(self._stderrfile).readlines()
         return ExecResult(args=args, exit_code=exitcode, exception=exception,
                           stdout=coutput, stderr=cerrput,
                           duration=datetime.now() - started_at,
                           with_stats=with_stats,
-                          profile=profile)
+                          profile=profile, tcpdump=tcpdump)
 
     def _raw(self, urls, intext='', timeout=None, options=None, insecure=False,
              alpn_proto: Optional[str] = None,
@@ -686,13 +788,14 @@ class CurlClient:
              with_stats=False,
              with_headers=True,
              def_tracing=True,
-             with_profile=False):
+             with_profile=False,
+             with_tcpdump=False):
         args = self._complete_args(
             urls=urls, timeout=timeout, options=options, insecure=insecure,
             alpn_proto=alpn_proto, force_resolve=force_resolve,
             with_headers=with_headers, def_tracing=def_tracing)
         r = self._run(args, intext=intext, with_stats=with_stats,
-                      with_profile=with_profile)
+                      with_profile=with_profile, with_tcpdump=with_tcpdump)
         if r.exit_code == 0 and with_headers:
             self._parse_headerfile(self._headerfile, r=r)
             if r.json:

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -27,6 +27,7 @@
 import logging
 import os
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -203,6 +204,8 @@ class EnvConfig:
             except Exception as e:
                 self.vsftpd = None
 
+        self._tcpdump = shutil.which('tcpdump')
+
     @property
     def httpd_version(self):
         if self._httpd_version is None and self.apxs is not None:
@@ -263,6 +266,10 @@ class EnvConfig:
     @property
     def vsftpd_version(self):
         return self._vsftpd_version
+
+    @property
+    def tcpdmp(self) -> Optional[str]:
+        return self._tcpdump
 
 
 class Env:
@@ -382,6 +389,10 @@ class Env:
     @staticmethod
     def vsftpd_version() -> str:
         return Env.CONFIG.vsftpd_version
+
+    @staticmethod
+    def tcpdump() -> Optional[str]:
+        return Env.CONFIG.tcpdmp
 
     def __init__(self, pytestconfig=None):
         self._verbose = pytestconfig.option.verbose \


### PR DESCRIPTION
Implement graceful shutdown of connections in libcurl:
- when a connection is ready to be discarded, run a non-blocking shutdown on all connection filters. If that returns errors, discard the connection. If that sucessfully shuts down all filters, discard as well. Otherwise, add it to a "shutdown" list in the transfers connection cache.
- limit the shutdown list to the same maximum length as the connection cache's live limit. When shutdown down a new connection at the limit, the oldest one is discarded.
- In multi_wait() and multi_waitfds(), collect all connection caches involved (each transfer might carry its own) into a temporary list. Let each connection cache on the list contribute sockets and POLLIN/OUT events it's connections are waiting for.
- in multi_perform() collect the connection caches the same way and let them peform their maintenance. This will make another non-blocking attempt to shutdown all connections on its shutdown list.
- when a connection cache is destroyed, discard all connections on the shutdown list. In debug builds, with the envionment variable CURL_GRACEFUL_SHUTDOWN, run a blocking shutdown (using poll) and the default 2 second timeout. This is for testing (see below) and might be exposed as an option to new libcurl API function.

**TODO**: multi_socket() does not know how to handle sockets from connection caches.

Details
- similar to `connected` add a `shutdown` bit at the connection filter instance to remember it has already shutdown and need not be invoked again when we do repeated, non-blocking attempts to shut down the complete filter chain.
- conncache structs have a `tmp_list` member that allows collecting caches onto a temporary list inside multi_wait and multi_perform handling. The list is always cleared before calls return.
- replace `Curl_discard(data, conn)` with `Curl_conncache_shutdown_conn(data, conn,...) to handle keeping connections for non-blocking shutdown handling.
- When CURL_DEBUG is in the environment and  curl is a debug build, make the conncache closing handle verbose.
- fix openssl shutdown to be way more careful about still receiving data after its side has shut down. HTTP/2 connections may have a server-side GOAWAY in transit. We need to cope with that without error.

Testing
- add test cases using `tcpdump` to check if a curl run caused TCP RST packets. These checks are used in test_02_30, test_30_06 and test_31_06.