### PR TITLE
configure: use AC_MSG_WARN for TLS/experimental warning texts

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5044,15 +5044,15 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
   Features:         ${SUPPORT_FEATURES}
 ])
 
-non13=`echo "$TLSCHOICE" | $EGREP -i 'bearssl|secure-transport|mbedtls'`;
+non13=`echo "$TLSCHOICE" | $EGREP -io 'bearssl|secure-transport'`;
 if test -n "$non13"; then
- cat >&2 << _EOF
-  WARNING: A selected TLS library ($TLSCHOICE) does not support TLS 1.3!
-_EOF
+ for a in $non13; do
+   AC_MSG_WARN([$a is enabled for TLS but it does not support TLS 1.3])
+ done
 fi
 
 if test -n "$experimental"; then
- cat >&2 << _EOF
-  WARNING: $experimental enabled but marked EXPERIMENTAL. Use with caution!
-_EOF
+ for a in $experimental; do
+   AC_MSG_WARN([$a is enabled but marked EXPERIMENTAL. Use with caution!])
+ done
 fi

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -662,7 +662,6 @@ AS_HELP_STRING([--disable-httpsrr],[Disable HTTPSRR support]),
       dnl --enable-httpsrr option used
       want_httpsrr="yes"
       curl_httpsrr_msg="enabled (--disable-httpsrr)"
-      experimental="httpsrr"
       AC_MSG_RESULT([yes])
       ;;
   esac
@@ -698,7 +697,6 @@ AS_HELP_STRING([--disable-ech],[Disable ECH support]),
       dnl --enable-ech option used
       want_ech="yes"
       curl_ech_msg="enabled (--disable-ech)"
-      experimental="ech"
       AC_MSG_RESULT([yes])
       ;;
   esac


### PR DESCRIPTION
- no longer warns for mbedtls
- warns for each item on individual lines
- no longer shows irrelevant TLS libraries when multiple are selected
- removes ech repetition