### PR TITLE
transfer: set CSELECT_IN if there is data pending

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -338,8 +338,9 @@ static CURLcode readwrite_data(struct Curl_easy *data,
 
   } while(maxloops-- && data_pending(data));
 
-  if(maxloops <= 0) {
-    /* did not read until EAGAIN, mark read-again-please */
+  if((maxloops <= 0) || data_pending(data)) {
+    /* did not read until EAGAIN or there is still pending data, mark as
+       read-again-please */
     data->state.select_bits = CURL_CSELECT_IN;
     if((k->keepon & KEEP_SENDBITS) == KEEP_SEND)
       data->state.select_bits |= CURL_CSELECT_OUT;


### PR DESCRIPTION
When aborting the transfer loop early, like when there is rate limiting in effect, there might be buffered data already read off the socket so the socket might not signal reability. Therefore we must set the CSELECT_IN manually if data_pending_() suggests there might be more data to get. This is particularly noticeable with SSH when the underlying library has drained the socket and holds pending data in its buffer.

Reported-by: alervd on github
Fixes #13695