### PR TITLE
cmake: allow SOVERSION override with `CURL_LIBCURL_SOVERSION`

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -201,7 +201,14 @@ if(BUILD_SHARED_LIBS)
     # up to v3.x and ELF from v3.x. I cannot imagine someone running CMake
     # on those ancient systems.
     CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+    set(soversion_default TRUE)
+  else()
+    set(soversion_default FALSE)
+  endif()
 
+  option(CURL_LIBCURL_SOVERSION "Enable libcurl SOVERSION" ${soversion_default})
+
+  if(CURL_LIBCURL_SOVERSION)
     transform_makefile_inc("Makefile.soname" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.soname.cmake")
     include(${CMAKE_CURRENT_BINARY_DIR}/Makefile.soname.cmake)
 


### PR DESCRIPTION
Allow overriding SOVERSION with the new CMake option:
`CURL_LIBCURL_SOVERSION=ON/OFF`.

For certain target platforms the shared libcurl library filename
contains the SOVERSION. This new option allows to enable/disable
this behavior manually. If set, it takes precedence over the
default setting.

Ref: #13898
Closes #13944