### PR TITLE
build: enable AppleIDN / WinIDN by default

### DIFF
--- a/.github/scripts/cmp-config.pl
+++ b/.github/scripts/cmp-config.pl
@@ -72,6 +72,7 @@ my %remove = (
     '#define HAVE_STDLIB_H 1' => 1,
     '#define HAVE_STRING_H 1' => 1,
     '#define HAVE_SYS_XATTR_H 1' => 1,
+    '#define HAVE_UNICODE_UIDNA_H 1' => 1,
     '#define HAVE_ZSTD 1' => 1,
     '#define HAVE_ZSTD_H 1' => 1,
     '#define LT_OBJDIR ".libs/"' => 1,

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -81,9 +81,9 @@ jobs:
             compiler: clang
             configure: --enable-debug --without-ssl
             macos-version-min: '10.9'
-          - name: '!ssl libssh2 AppleIDN'
+          - name: '!ssl libssh2'
             compiler: clang
-            configure: --enable-debug --with-libssh2=$(brew --prefix libssh2) --without-ssl --with-apple-idn
+            configure: --enable-debug --with-libssh2=$(brew --prefix libssh2) --without-ssl
             macos-version-min: '10.9'
           - name: 'OpenSSL libssh c-ares'
             compiler: clang
@@ -142,9 +142,9 @@ jobs:
             configure: --enable-debug --disable-ldap --with-openssl=$(brew --prefix openssl)
             macos-version-min: '10.15'
           # cmake
-          - name: 'OpenSSL gsasl AppleIDN'
+          - name: 'OpenSSL gsasl'
             install: gsasl
-            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix openssl) -DCURL_USE_GSASL=ON -DUSE_APPLE_IDN=ON
+            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix openssl) -DCURL_USE_GSASL=ON
             macos-version-min: '10.9'
           - name: 'OpenSSL +static libssh +examples'
             install: libssh
@@ -459,24 +459,24 @@ jobs:
             [ '${{ matrix.config }}' = 'OpenSSL' ]         && options+=" --with-openssl=$(brew --prefix openssl)"
             [ '${{ matrix.config }}' = 'SecureTransport' ] && options+=' --with-secure-transport'
             CFLAGS+=' -mmacosx-version-min=${{ matrix.macos-version-min }}'
-            # would pick up nghttp2, libidn2, but libssh2 is disabled by default
+            # would pick up nghttp2, but libssh2 is disabled by default
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
               --disable-dependency-tracking \
               --disable-docs --disable-manual \
-              --without-nghttp2 --without-libidn2 \
+              --without-nghttp2 \
               --without-libpsl \
               ${options}
           else
             [ '${{ matrix.config }}' = 'OpenSSL' ]         && options+=' -DCURL_USE_OPENSSL=ON'
             [ '${{ matrix.config }}' = 'SecureTransport' ] && options+=' -DCURL_USE_SECTRANSP=ON'
-            # would pick up nghttp2, libidn2, and libssh2
+            # would pick up nghttp2, libssh2
             cmake -B bld -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
               -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.macos-version-min }} \
               "-DCMAKE_OSX_SYSROOT=${sysroot}" \
               "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
               "-DCMAKE_IGNORE_PREFIX_PATH=$(brew --prefix)" \
               -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF \
-              -DUSE_NGHTTP2=OFF -DUSE_LIBIDN2=OFF \
+              -DUSE_NGHTTP2=OFF \
               -DCURL_USE_LIBPSL=OFF -DCURL_USE_LIBSSH2=OFF \
               ${options}
           fi

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -77,9 +77,9 @@ jobs:
             compiler: gcc-12
             configure: --without-ssl
             macos-version-min: '10.9'
-          - name: '!ssl'
+          - name: '!ssl !AppleIDN'
             compiler: clang
-            configure: --enable-debug --without-ssl
+            configure: --enable-debug --without-ssl --without-apple-idn
             macos-version-min: '10.9'
           - name: '!ssl libssh2'
             compiler: clang
@@ -157,9 +157,9 @@ jobs:
             install: libressl heimdal
             generate: -DOPENSSL_ROOT_DIR=$(brew --prefix libressl) -DENABLE_ARES=ON -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=$(brew --prefix heimdal) -DCURL_DISABLE_LDAP=ON
             macos-version-min: '10.15'
-          - name: 'wolfSSL !ldap brotli zstd'
+          - name: 'wolfSSL !ldap brotli zstd !AppleIDN'
             install: brotli wolfssl zstd
-            generate: -DCURL_USE_WOLFSSL=ON -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON
+            generate: -DCURL_USE_WOLFSSL=ON -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON -DUSE_APPLE_IDN=OFF
             macos-version-min: '10.15'
           - name: 'mbedTLS !ldap brotli zstd'
             install: brotli mbedtls zstd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -567,7 +567,7 @@ jobs:
             config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
-              -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
+              -DCURL_USE_GSASL=ON -DENABLE_UNICODE=ON
 
           - name: 'openssl'
             install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv krb5'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -523,9 +523,9 @@ jobs:
       - name: 'build'
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld
+            cmake --build bld --verbose
           else
-            make -C bld -j5
+            make -C bld -j5 V=1
           fi
 
       - name: 'build tests'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -173,7 +173,7 @@ jobs:
           - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '', name: 'default R' }
           - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver --disable-curldebug --enable-static=no --without-zlib', name: 'default' }
-          - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: ''                        , config: '--enable-debug --enable-windows-unicode --enable-ares', name: 'c-ares U' }
+          - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: ''                        , config: '--enable-debug --enable-windows-unicode --enable-ares --without-winidn', name: 'c-ares U' }
           # FIXME: WebSockets test results ignored due to frequent failures on native Windows:
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: ''                        , config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_ARES=ON', type: 'Debug', name: 'schannel c-ares U' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }
@@ -374,7 +374,7 @@ jobs:
             env: '6.4.0-i686'
             dir: 'mingw32'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF'
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -DUSE_WIN32_IDN=OFF'
             type: 'Debug'
             tflags: 'skiprun'
       fail-fast: false
@@ -638,7 +638,7 @@ jobs:
             config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_MBEDTLS=ON
-              -DCURL_USE_GSASL=ON
+              -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=OFF
 
           - name: 'msh3'
             install: 'brotli zlib zstd libpsl nghttp2 msh3 libssh2 pkgconf gsasl'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -472,7 +472,7 @@ jobs:
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
 
   linux-cross-mingw-w64:
-    name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
+    name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }} ${{ matrix.options }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -480,6 +480,7 @@ jobs:
       matrix:
         build: [autotools, cmake]
         compiler: [gcc]
+        options: ['!WinIDN', '']
     env:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
@@ -495,20 +496,24 @@ jobs:
       - name: 'configure'
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
+            [[ '${{ matrix.options }}' = *'!WinIDN'* ]] && options+=' -DUSE_WIN32_IDN=OFF'
             cmake -B bld -G Ninja \
               -DCMAKE_SYSTEM_NAME=Windows \
               -DCMAKE_C_COMPILER_TARGET=${TRIPLET} \
               -DCMAKE_C_COMPILER=${TRIPLET}-gcc \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
-              -DCURL_USE_SCHANNEL=ON -DUSE_WIN32_IDN=ON \
-              -DCURL_USE_LIBPSL=OFF
+              -DCURL_USE_SCHANNEL=ON \
+              -DCURL_USE_LIBPSL=OFF \
+              ${options}
           else
+            [[ '${{ matrix.options }}' = *'!WinIDN'* ]] && options+=' --without-winidn'
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
               --host=${TRIPLET} \
-              --with-schannel --with-winidn \
+              --with-schannel \
               --without-libpsl \
-              --disable-dependency-tracking
+              --disable-dependency-tracking \
+              ${options}
           fi
 
       - name: 'configure log'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1094,7 +1094,13 @@ if(CURL_DISABLE_LDAP)
 endif()
 
 if(WIN32)
-  option(USE_WIN32_IDN "Use WinIDN for IDN support" OFF)
+  # MSVC 2008 does not have the necessary symbols in the normaliz library.
+  if(HAVE_WIN32_WINNT LESS 0x0600 OR (MSVC AND MSVC_VERSION LESS_EQUAL 1500))
+    set(_use_win32_idn_default OFF)
+  else()
+    set(_use_win32_idn_default ON)  # Windows Vista / Server 2008 or newer
+  endif()
+  option(USE_WIN32_IDN "Use WinIDN for IDN support" ${_use_win32_idn_default})
   if(USE_WIN32_IDN)
     list(APPEND CURL_LIBS "normaliz")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1109,7 +1109,7 @@ else()
 endif()
 
 if(APPLE)
-  option(USE_APPLE_IDN "Use Apple built-in IDN support" OFF)
+  option(USE_APPLE_IDN "Use Apple built-in IDN support" ON)
   if(USE_APPLE_IDN)
     cmake_push_check_state()
     set(CMAKE_REQUIRED_LIBRARIES "icucore")

--- a/configure.ac
+++ b/configure.ac
@@ -2844,8 +2844,11 @@ AS_HELP_STRING([--with-apple-idn],[Enable AppleIDN])
 AS_HELP_STRING([--without-apple-idn],[Disable AppleIDN]),
       [OPT_IDN=$withval])
     case "$OPT_IDN" in
-      yes)
-        dnl --with-apple-idn option used
+      no)
+        dnl --without-apple-idn option used
+        AC_MSG_RESULT([no])
+        ;;
+      *)
         AC_MSG_RESULT([yes, check])
         AC_CHECK_LIB(icucore, uidna_openUTS46,
         [
@@ -2858,9 +2861,6 @@ AS_HELP_STRING([--without-apple-idn],[Disable AppleIDN]),
             tst_links_appleidn='yes'
           )
         ])
-        ;;
-      *)
-        AC_MSG_RESULT([no])
         ;;
     esac
     ;;

--- a/configure.ac
+++ b/configure.ac
@@ -610,6 +610,23 @@ case $host_os in
   cygwin*|msys*) curl_cv_cygwin='yes';;
 esac
 
+dnl Check if native Windows targeting Vista or newer
+curl_cv_windows_vista='no'
+if test "$curl_cv_native_windows" = 'yes'; then
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
+      #include <windows.h>
+    ]],[[
+      #if _WIN32_WINNT < 0x0600
+      #error
+      #endif
+    ]])
+  ],[
+    curl_cv_windows_vista='yes'
+  ],[
+  ])
+fi
+
 AM_CONDITIONAL([HAVE_WINDRES],
   [test "$curl_cv_native_windows" = "yes" && test -n "${RC}"])
 
@@ -5296,19 +5313,8 @@ if test "$tst_atomic" = "yes"; then
 elif test "x$USE_THREADS_POSIX" = "x1" -a \
      "x$ac_cv_header_pthread_h" = "xyes"; then
   SUPPORT_FEATURES="$SUPPORT_FEATURES threadsafe"
-else
-  AC_COMPILE_IFELSE([
-    AC_LANG_PROGRAM([[
-      #include <windows.h>
-    ]],[[
-      #if (WINVER < 0x600) && (_WIN32_WINNT < 0x600)
-      #error
-      #endif
-    ]])
-  ],[
-    SUPPORT_FEATURES="$SUPPORT_FEATURES threadsafe"
-  ],[
-  ])
+elif test "$curl_cv_windows_vista" = 'yes'; then
+  SUPPORT_FEATURES="$SUPPORT_FEATURES threadsafe"
 fi
 
 if test "x$want_winuni" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -2743,7 +2743,17 @@ AS_HELP_STRING([--with-winidn=PATH],[enable Windows native IDN])
 AS_HELP_STRING([--without-winidn], [disable Windows native IDN]),
     OPT_WINIDN=$withval)
   case "$OPT_WINIDN" in
-    no|default)
+    default)
+      dnl enable by default on native Windows
+      if test "$curl_cv_native_windows" = "yes"; then
+        want_winidn="yes"
+        want_winidn_path="default"
+      else
+        want_winidn="no"
+      fi
+      AC_MSG_RESULT([no])
+      ;;
+    no)
       dnl --without-winidn option used or configure option not specified
       want_winidn="no"
       AC_MSG_RESULT([no])

--- a/configure.ac
+++ b/configure.ac
@@ -2765,10 +2765,11 @@ AS_HELP_STRING([--without-winidn], [disable Windows native IDN]),
       if test "$curl_cv_windows_vista" = 'yes'; then
         want_winidn="yes"
         want_winidn_path="default"
+        AC_MSG_RESULT([yes])
       else
         want_winidn="no"
+        AC_MSG_RESULT([no])
       fi
-      AC_MSG_RESULT([no])
       ;;
     no)
       dnl --without-winidn option used or configure option not specified

--- a/configure.ac
+++ b/configure.ac
@@ -2761,8 +2761,8 @@ AS_HELP_STRING([--without-winidn], [disable Windows native IDN]),
     OPT_WINIDN=$withval)
   case "$OPT_WINIDN" in
     default)
-      dnl enable by default on native Windows
-      if test "$curl_cv_native_windows" = "yes"; then
+      dnl enable by default on native Windows with Vista and newer
+      if test "$curl_cv_windows_vista" = 'yes'; then
         want_winidn="yes"
         want_winidn_path="default"
       else

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -286,7 +286,7 @@ Details via CMake
 - `CURL_ZSTD`:                              Use zstd. Default: `OFF`
 - `ENABLE_ARES`:                            Enable c-ares support. Default: `OFF`
 - `USE_APPLE_IDN`:                          Use Apple built-in IDN support. Default: `ON`
-- `USE_LIBIDN2`:                            Use libidn2 for IDN support. Default: `ON`, or `OFF` if Apple IDN or WinIDN is enabled
+- `USE_LIBIDN2`:                            Use libidn2 for IDN support. Default: `ON`. Apple IDN or WinIDN takes priority if enabled.
 - `USE_LIBRTMP`:                            Enable librtmp from rtmpdump. Default: `OFF`
 - `USE_MSH3`:                               Use msh3/msquic library for HTTP/3 support. Default: `OFF`
 - `USE_NGHTTP2`:                            Use nghttp2 library. Default: `ON`

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -285,14 +285,14 @@ Details via CMake
 - `CURL_ZLIB`:                              Use zlib (`ON`, `OFF` or `AUTO`). Default: `AUTO`
 - `CURL_ZSTD`:                              Use zstd. Default: `OFF`
 - `ENABLE_ARES`:                            Enable c-ares support. Default: `OFF`
-- `USE_APPLE_IDN`:                          Use Apple built-in IDN support. Default: `OFF`
-- `USE_LIBIDN2`:                            Use libidn2 for IDN support. Default: `ON`
+- `USE_APPLE_IDN`:                          Use Apple built-in IDN support. Default: `ON`
+- `USE_LIBIDN2`:                            Use libidn2 for IDN support. Default: `ON`, or `OFF` if Apple IDN or WinIDN is enabled
 - `USE_LIBRTMP`:                            Enable librtmp from rtmpdump. Default: `OFF`
 - `USE_MSH3`:                               Use msh3/msquic library for HTTP/3 support. Default: `OFF`
 - `USE_NGHTTP2`:                            Use nghttp2 library. Default: `ON`
 - `USE_NGTCP2`:                             Use ngtcp2 and nghttp3 libraries for HTTP/3 support. Default: `OFF`
 - `USE_QUICHE`:                             Use quiche library for HTTP/3 support. Default: `OFF`
-- `USE_WIN32_IDN`:                          Use WinIDN for IDN support. Default: `OFF`
+- `USE_WIN32_IDN`:                          Use WinIDN for IDN support. Default: `ON`
 - `USE_WIN32_LDAP`:                         Use Windows LDAP implementation. Default: `ON`
 
 ## Dependency options (via CMake)


### PR DESCRIPTION
Enable and use WinIDN and AppleIDN by default on these platforms,
if they can be used.

Compatibility warning: This change can make default builds incompatible
with Windows XP by default. WinIDN requires `Normaliz.dll`. Windows XP
isn't shipping with it and the necessary extra package is no longer
offered by Microsoft. Thus, for Windows XP compatibility, we recommend
building with `-DUSE_WIN32_IDN=OFF`.

Discussion: #13565
Closes #13947

---

Cleaner diff without whitespace changes: https://github.com/curl/curl/pull/13947/files?w=1

There are a few ways to resolve compatibility with existing builds
and also to handle interactions with the `USE_LIBIDN2` option.
This is an initial attempt.

TODO:
- [ ] rethink defaulting logic to honor an explicitly selected libidn2?
- [x] is WinIDN useful without Unicode? [YES] Enable it only in Unicode builds by default? (Also needs reshuffling options in Azure and GHA/Windows)
Downside: it makes the defaulting logic difficult to predict.
- [x] rebase on #14680. (delete explicit WinIDN options added to GHA/Windows/cross.)
- [x] rebase on #14693.
- [x] add jobs that disable AppleIDN/WinIDN for both autotools and cmake.
- [x] configure: enable WinIDN by default for `HAVE_WIN32_WINNT >= 0x0600`, as cmake.
- [x] review and fixup AppleIDN/WinIDN and libidn2 interactions in autotools and cmake.
- [x] tackle AppleIDN.
- [x] cmake: detect WinXP target using `HAVE_WIN32_WINNT` and adjust default `USE_WIN32_IDN` setting accordingly?
- [x] review and update CI jobs where/if necessary.
- [x] fix autotools logic to only make WinIDN the default when targeting native Windows.
- [x] figure out how to make IDN tests work on Windows. [SKIP]
- [x] split off VS2008 log dump on failure in AppVeyor into separate PR. → #13957
