### PR TITLE
docs: Reference non deprecated curl options

### DIFF
--- a/docs/libcurl/libcurl-security.md
+++ b/docs/libcurl/libcurl-security.md
@@ -121,7 +121,7 @@ user running the libcurl application, SCP: or SFTP: URLs could access password
 or private-key protected resources,
 e.g. **sftp://user@some-internal-server/etc/passwd**
 
-The CURLOPT_REDIR_PROTOCOLS(3) and CURLOPT_NETRC(3) options can be
+The CURLOPT_REDIR_PROTOCOLS_STR(3) and CURLOPT_NETRC(3) options can be
 used to mitigate against this kind of attack.
 
 A redirect can also specify a location available only on the machine running
@@ -132,7 +132,7 @@ E.g. **http://127.0.0.1/** or **http://intranet/delete-stuff.cgi?delete=all** or
 Applications can mitigate against this by disabling
 CURLOPT_FOLLOWLOCATION(3) and handling redirects itself, sanitizing URLs
 as necessary. Alternately, an app could leave CURLOPT_FOLLOWLOCATION(3)
-enabled but set CURLOPT_REDIR_PROTOCOLS(3) and install a
+enabled but set CURLOPT_REDIR_PROTOCOLS_STR(3) and install a
 CURLOPT_OPENSOCKETFUNCTION(3) or CURLOPT_PREREQFUNCTION(3) callback
 function in which addresses are sanitized before use.
 
@@ -164,7 +164,7 @@ non-redirected URLs, if the user is allowed to specify an arbitrary URL that
 could point to a private resource. For example, a web app providing a
 translation service might happily translate **file://localhost/etc/passwd**
 and display the result. Applications can mitigate against this with the
-CURLOPT_PROTOCOLS(3) option as well as by similar mitigation techniques
+CURLOPT_PROTOCOLS_STR(3) option as well as by similar mitigation techniques
 for redirections.
 
 A malicious FTP server could in response to the PASV command return an IP
@@ -308,9 +308,9 @@ Remedies:
 
 curl command lines can use *--proto* to limit what URL schemes it accepts
 
-## Use CURLOPT_PROTOCOLS
+## Use CURLOPT_PROTOCOLS_STR
 
-libcurl programs can use CURLOPT_PROTOCOLS(3) to limit what URL schemes it accepts
+libcurl programs can use CURLOPT_PROTOCOLS_STR(3) to limit what URL schemes it accepts
 
 ## consider not allowing the user to set the full URL
 

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
@@ -60,8 +60,8 @@ struct curl_tlssessioninfo {
 The *backend* struct member is one of the defines in the CURLSSLBACKEND_*
 series: CURLSSLBACKEND_NONE (when built without TLS support),
 CURLSSLBACKEND_WOLFSSL, CURLSSLBACKEND_SECURETRANSPORT, CURLSSLBACKEND_GNUTLS,
-CURLSSLBACKEND_MBEDTLS, CURLSSLBACKEND_NSS, CURLSSLBACKEND_OPENSSL,
-CURLSSLBACKEND_SCHANNEL or CURLSSLBACKEND_MESALINK. (Note that the OpenSSL
+CURLSSLBACKEND_MBEDTLS, CURLSSLBACKEND_NSS, CURLSSLBACKEND_OPENSSL or
+CURLSSLBACKEND_SCHANNEL. (Note that the OpenSSL
 forks are all reported as just OpenSSL here.)
 
 The *internals* struct member points to a TLS library specific pointer for

--- a/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
+++ b/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
@@ -5,7 +5,7 @@ Title: CURLOPT_DISALLOW_USERNAME_IN_URL
 Section: 3
 Source: libcurl
 See-also:
-  - CURLOPT_PROTOCOLS (3)
+  - CURLOPT_PROTOCOLS_STR (3)
   - CURLOPT_URL (3)
   - curl_url_set (3)
   - libcurl-security (3)

--- a/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.md
+++ b/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.md
@@ -8,8 +8,8 @@ See-also:
   - CURLINFO_REDIRECT_COUNT (3)
   - CURLINFO_REDIRECT_URL (3)
   - CURLOPT_POSTREDIR (3)
-  - CURLOPT_PROTOCOLS (3)
-  - CURLOPT_REDIR_PROTOCOLS (3)
+  - CURLOPT_PROTOCOLS_STR (3)
+  - CURLOPT_REDIR_PROTOCOLS_STR (3)
 Protocol:
   - HTTP
 ---
@@ -38,7 +38,7 @@ maximum limit is reached. CURLOPT_MAXREDIRS(3) is used to limit the
 number of redirects libcurl follows.
 
 libcurl restricts what protocols it automatically follow redirects to. The
-accepted target protocols are set with CURLOPT_REDIR_PROTOCOLS(3). By
+accepted target protocols are set with CURLOPT_REDIR_PROTOCOLS_STR(3). By
 default libcurl allows HTTP, HTTPS, FTP and FTPS on redirects.
 
 When following a redirect, the specific 30x response code also dictates which

--- a/docs/libcurl/opts/CURLOPT_POST.md
+++ b/docs/libcurl/opts/CURLOPT_POST.md
@@ -9,7 +9,7 @@ Protocol:
 See-also:
   - CURLOPT_HTTPPOST (3)
   - CURLOPT_POSTFIELDS (3)
-  - CURLOPT_PUT (3)
+  - CURLOPT_UPLOAD (3)
 ---
 
 # NAME

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.md
@@ -6,7 +6,7 @@ Section: 3
 Source: libcurl
 See-also:
   - CURLOPT_PROXY (3)
-  - CURLOPT_SOCKS5_GSSAPI_SERVICE (3)
+  - CURLOPT_PROXY_SERVICE_NAME (3)
 Protocol:
   - All
 ---

--- a/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.md
@@ -77,7 +77,7 @@ int main(void)
     /* Set the URL of the request */
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     /* Now set it as a put */
-    curl_easy_setopt(curl, CURLOPT_PUT, 1L);
+    curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
 
     /* Assuming we have a function that returns the data to be pushed
        Let that function be read_cb */

--- a/docs/libcurl/opts/CURLOPT_URL.md
+++ b/docs/libcurl/opts/CURLOPT_URL.md
@@ -10,7 +10,7 @@ See-also:
   - CURLOPT_FORBID_REUSE (3)
   - CURLOPT_FRESH_CONNECT (3)
   - CURLOPT_PATH_AS_IS (3)
-  - CURLOPT_PROTOCOLS (3)
+  - CURLOPT_PROTOCOLS_STR (3)
   - curl_easy_perform (3)
   - curl_url_get (3)
   - curl_url_set (3)
@@ -109,11 +109,11 @@ custom port number can allow external users to play tricks with your local
 services.
 
 Accepting external URLs may also use other protocols than http:// or other
-common ones. Restrict what accept with CURLOPT_PROTOCOLS(3).
+common ones. Restrict what accept with CURLOPT_PROTOCOLS_STR(3).
 
 User provided URLs can also be made to point to sites that redirect further on
 (possibly to other protocols too). Consider your
-CURLOPT_FOLLOWLOCATION(3) and CURLOPT_REDIR_PROTOCOLS(3) settings.
+CURLOPT_FOLLOWLOCATION(3) and CURLOPT_REDIR_PROTOCOLS_STR(3) settings.
 
 # EXAMPLE
 


### PR DESCRIPTION
There are a places where man pages reference deprecated CURLOPT options, where it doesn't make sense, replace them with the reccomended replacement option.