### PR TITLE
cmake: fix quotes when appending multiple options (SecureTransport)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,7 +465,7 @@ if(use_core_foundation_and_core_services)
     message(FATAL_ERROR "CoreServices framework not found")
   endif()
 
-  list(APPEND CURL_LIBS "-framework CoreFoundation -framework CoreServices")
+  list(APPEND CURL_LIBS "-framework CoreFoundation" "-framework CoreServices")
 endif()
 
 if(CURL_USE_OPENSSL)


### PR DESCRIPTION
Copied from a vcpkg distro patch:
https://github.com/microsoft/vcpkg/blob/02745e0f4749d1f51d2025824209408f5a6c3614/ports/curl/dependencies.patch#L43C38-L44

Ref: https://github.com/microsoft/vcpkg/pull/38847
Ref: https://github.com/microsoft/vcpkg/commit/795f2f137e6cf6d985fcc927bffcaf9c0a96e4ac
Ref: https://github.com/microsoft/vcpkg/pull/38847/commits/36f0c917de5319e95361451fc0aef0698b264874#diff-ab5c23e5dc5df412539cc93e24b37abbc588e1918236f8abc019d676b270c85fR39 (sub-commit)

Authored-by: Kai Pastor
Closes #13953

---

/cc @dg0yt
