### PR TITLE
x509asn1: make Curl_extract_certinfo store error message

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -1228,6 +1228,8 @@ CURLcode Curl_extract_certinfo(struct Curl_easy *data,
       result = ssl_push_certinfo_dyn(data, certnum, "Cert", &out);
 
 done:
+  if(result)
+    failf(data, "Failed extracting certificate chain");
   Curl_dyn_free(&out);
   return result;
 }


### PR DESCRIPTION
To help us all better understand where the error actually comes from.

Ref: #13958