### PR TITLE
Add vcpkg ci

### DIFF
--- a/.github/workflows/vcpkg-linux.yml
+++ b/.github/workflows/vcpkg-linux.yml
@@ -1,0 +1,165 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+name: vcpkg Linux
+
+on:
+  push:
+    branches:
+      - master
+      - '*/ci'
+    paths-ignore:
+      - '**/*.md'
+      - '.azure-pipelines.yml'
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - 'appveyor.*'
+      - 'packages/**'
+      - 'plan9/**'
+      - 'projects/**'
+      - 'winbuild/**'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - '.azure-pipelines.yml'
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - 'appveyor.*'
+      - 'packages/**'
+      - 'plan9/**'
+      - 'projects/**'
+      - 'winbuild/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  OS: linux
+  BUILD_DIR: vcpkg/cache
+  VCPKG_ROOT: vcpkg/cache/vcpkg
+  VCPKG_LINK: https://github.com/microsoft/vcpkg/
+  BINARY_CACHE: vcpkg/cache/linux
+
+jobs:
+  build:
+    name: vcpkg-ubuntu-${{ matrix.PROCESSOR }}-${{ matrix.BUILD_OPTION }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - BUILD_OPTION: openssl
+          PROCESSOR: x64
+          CMAKE_OPTIONS: -DCURL_USE_LIBSSH2=ON
+        - BUILD_OPTION: libressl
+          PROCESSOR: x64
+          CMAKE_OPTIONS: -DCURL_USE_LIBSSH2=OFF
+    env:
+      PROCESSOR: ${{ matrix.PROCESSOR }}
+      BUILD_OPTION: ${{ matrix.BUILD_OPTION }}
+      CMAKE_OPTIONS: ${{ matrix.CMAKE_OPTIONS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{env.BINARY_CACHE }}/${{ matrix.BUILD_OPTION }}
+          key: ${{ env.OS }}-${{ matrix.BUILD_OPTION }}-${{ hashFiles('.github/workflows/vcpkg-linux.yml') }}
+          restore-keys: ${{ env.OS }}-${{ matrix.BUILD_OPTION }}-${{ hashFiles('.github/workflows/vcpkg-linux.yml') }}
+
+      - name: Install ninja
+        if: success()
+        run: |   
+          sudo apt install -y ninja-build
+          ninja --version
+          whereis ninja
+
+      - name: Init vcpkg
+        if: success()
+        run: |        
+          mkdir -p $BUILD_DIR
+          git -C $BUILD_DIR clone $VCPKG_LINK
+          $VCPKG_ROOT/bootstrap-vcpkg.sh
+  
+      - name: vcpkg build openssl
+        if: ${{ success() && matrix.BUILD_OPTION == 'openssl' }}
+        run: |
+          export CURRENT_BINARY_CACHE="$BINARY_CACHE/$BUILD_OPTION"
+          mkdir -p $CURRENT_BINARY_CACHE
+          export VCPKG_BINARY_SOURCES="clear;files,$PWD/$CURRENT_BINARY_CACHE,readwrite;"
+          $VCPKG_ROOT/vcpkg x-set-installed libssh2[core,openssl] nghttp2 openldap openssl zstd --triplet=$PROCESSOR-$OS-release
+
+      - name: vcpkg build libressl
+        if: ${{ success() && matrix.BUILD_OPTION == 'libressl' }}
+        run: |
+          export CURRENT_BINARY_CACHE="$BINARY_CACHE/$BUILD_OPTION"
+          mkdir -p $CURRENT_BINARY_CACHE
+          export VCPKG_BINARY_SOURCES="clear;files,$PWD/$CURRENT_BINARY_CACHE,readwrite;"
+          $VCPKG_ROOT/vcpkg x-set-installed libressl nghttp2 zstd --triplet=$PROCESSOR-$OS-release
+
+      - name: cmake config
+        if: success() 
+        run: |
+          export CMAKE_GENERATOR=Ninja
+          cmake . -B build \
+              -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+              -DVCPKG_INSTALLED_DIR=$VCPKG_ROOT/installed \
+              -DVCPKG_TARGET_TRIPLET=$PROCESSOR-$OS-release \
+              -DCMAKE_UNITY_BUILD=ON \
+              -DCURL_WERROR=ON \
+              -DBUILD_SHARED_LIBS=OFF \
+              -DCURL_ZSTD=ON \
+              -DUSE_NGHTTP2=ON \
+              -DCURL_USE_LIBPSL=OFF \
+              -DCURL_USE_GSSAPI=OFF \
+              -DENABLE_ARES=OFF \
+              -DCURL_USE_LIBSSH=OFF \
+              $CMAKE_OPTIONS
+
+      - name: Prepare logs on failure
+        if: failure()
+        run: |
+          7z a -t7z -r -mx=9 logs.7z \
+              $VCPKG_ROOT/buildtrees/*.log \
+              build/.ninja_log \
+              build/build.ninja \
+              build/install_manifest.txt \
+              build/vcpkg-manifest-install.log
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux_logs_${{matrix.BUILD_OPTION}}_${{github.event.pull_request.head.sha}}
+          path: logs.7z
+
+      - name: Save cache dependencies
+        id: cache-save
+        uses: actions/cache/save@v4
+        with:
+          path: ${{env.BINARY_CACHE }}/${{ matrix.BUILD_OPTION }}
+          key: ${{ env.OS }}-${{ matrix.BUILD_OPTION }}-${{ hashFiles('.github/workflows/vcpkg-linux.yml') }}-${{ hashFiles('vcpkg/cache/vcpkg/installed/vcpkg/updates/*') }}
+
+      - name: Cmake build
+        if: success()
+        run: |
+          cmake --build build --config Release -j2
+          build/src/curl --disable --version
+
+      - name: Cmake install
+        if: success()
+        run: |
+          sudo cmake --install build --config Release
+
+      - name: Run tests
+        if: success() 
+        run: |
+          cmake --build build --target test-ci -j2

--- a/.github/workflows/vcpkg-osx.yml
+++ b/.github/workflows/vcpkg-osx.yml
@@ -1,0 +1,180 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+name: vcpkg macOS
+
+on:
+  push:
+    branches:
+      - master
+      - '*/ci'
+    paths-ignore:
+      - '**/*.md'
+      - '.azure-pipelines.yml'
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - 'appveyor.*'
+      - 'packages/**'
+      - 'plan9/**'
+      - 'projects/**'
+      - 'winbuild/**'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - '.azure-pipelines.yml'
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - 'appveyor.*'
+      - 'packages/**'
+      - 'plan9/**'
+      - 'projects/**'
+      - 'winbuild/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  OS: osx
+  BUILD_DIR: vcpkg/cache
+  VCPKG_ROOT: vcpkg/cache/vcpkg
+  VCPKG_LINK: https://github.com/microsoft/vcpkg/
+  BINARY_CACHE: vcpkg/cache/linux
+  CFLAGS: "-mmacosx-version-min=10.8"
+
+jobs:
+  build:
+    name: vcpkg-macos-${{ matrix.PROCESSOR }}-${{ matrix.BUILD_OPTION }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - BUILD_OPTION: openssl
+          PROCESSOR: arm64
+          CMAKE_OPTIONS: -DCURL_USE_LIBSSH2=ON 
+        - BUILD_OPTION: libressl
+          PROCESSOR: arm64
+          CMAKE_OPTIONS: -DCURL_USE_LIBSSH2=OFF
+        - BUILD_OPTION: secure_transport
+          PROCESSOR: arm64
+          CMAKE_OPTIONS: -DCURL_USE_LIBSSH2=ON -DCURL_USE_SECTRANSP=ON -DCURL_USE_OPENSSL=OFF
+    env:
+      PROCESSOR: ${{ matrix.PROCESSOR }}
+      BUILD_OPTION: ${{ matrix.BUILD_OPTION }}
+      CMAKE_OPTIONS: ${{ matrix.CMAKE_OPTIONS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{env.BINARY_CACHE }}/${{ matrix.BUILD_OPTION }}
+          key: ${{ env.OS }}-${{ matrix.BUILD_OPTION }}-${{ hashFiles('.github/workflows/vcpkg-osx.yml') }}
+          restore-keys: ${{ env.OS }}-${{ matrix.BUILD_OPTION }}-${{ hashFiles('.github/workflows/vcpkg-osx.yml') }}
+
+      - name: Install Dependencies
+        run: |
+          sudo xcode-select -switch /Applications/Xcode.app
+      - name: Install ninja
+        if: success()
+        run: |   
+          brew install ninja
+          ninja --version
+          whereis ninja
+
+      - name: Init vcpkg
+        if: success()
+        run: |        
+          mkdir -p $BUILD_DIR
+          git -C $BUILD_DIR clone $VCPKG_LINK
+          $VCPKG_ROOT/bootstrap-vcpkg.sh
+  
+      - name: vcpkg build openssl
+        if: ${{ success() && matrix.BUILD_OPTION == 'openssl' }}
+        run: |
+          export CURRENT_BINARY_CACHE="$BINARY_CACHE/$BUILD_OPTION"
+          mkdir -p $CURRENT_BINARY_CACHE
+          export VCPKG_BINARY_SOURCES="clear;files,$PWD/$CURRENT_BINARY_CACHE,readwrite;"
+          $VCPKG_ROOT/vcpkg x-set-installed libssh2[core,openssl] nghttp2 openssl zstd --triplet=$PROCESSOR-$OS-release
+
+      - name: vcpkg build libressl
+        if: ${{ success() && matrix.BUILD_OPTION == 'libressl' }}
+        run: |
+          export CURRENT_BINARY_CACHE="$BINARY_CACHE/$BUILD_OPTION"
+          mkdir -p $CURRENT_BINARY_CACHE
+          export VCPKG_BINARY_SOURCES="clear;files,$PWD/$CURRENT_BINARY_CACHE,readwrite;"
+          $VCPKG_ROOT/vcpkg x-set-installed libressl nghttp2 zstd --triplet=$PROCESSOR-$OS-release
+
+      - name: vcpkg build secure_transport
+        if: ${{ success() && matrix.BUILD_OPTION == 'secure_transport' }}
+        run: |
+          export CURRENT_BINARY_CACHE="$BINARY_CACHE/$BUILD_OPTION"
+          mkdir -p $CURRENT_BINARY_CACHE
+          export VCPKG_BINARY_SOURCES="clear;files,$PWD/$CURRENT_BINARY_CACHE,readwrite;"
+          $VCPKG_ROOT/vcpkg x-set-installed nghttp2 zstd --triplet=$PROCESSOR-$OS-release
+
+      - name: cmake config
+        if: success() 
+        run: |
+          export CMAKE_GENERATOR=Ninja
+          cmake . -B build \
+              -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+              -DVCPKG_INSTALLED_DIR=$VCPKG_ROOT/installed \
+              -DVCPKG_TARGET_TRIPLET=$PROCESSOR-$OS-release \
+              -DCMAKE_UNITY_BUILD=ON \
+              -DCURL_WERROR=ON \
+              -DBUILD_SHARED_LIBS=OFF \
+              -DCURL_ZSTD=ON \
+              -DUSE_NGHTTP2=ON \
+              -DCURL_USE_LIBPSL=OFF \
+              -DCURL_USE_GSSAPI=OFF \
+              -DENABLE_ARES=OFF \
+              -DCURL_USE_LIBSSH=OFF \
+              $CMAKE_OPTIONS
+
+      - name: Prepare logs on failure
+        if: failure()
+        run: |
+          7z a -t7z -r -mx=9 logs.7z \
+              $VCPKG_ROOT/buildtrees/*.log \
+              build/.ninja_log \
+              build/build.ninja \
+              build/install_manifest.txt \
+              build/vcpkg-manifest-install.log
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: osx_logs_${{matrix.BUILD_OPTION}}_${{github.event.pull_request.head.sha}}
+          path: logs.7z
+
+      - name: Save cache dependencies
+        id: cache-save
+        uses: actions/cache/save@v4
+        with:
+          path: ${{env.BINARY_CACHE }}/${{ matrix.BUILD_OPTION }}
+          key: ${{ env.OS }}-${{ matrix.BUILD_OPTION }}-${{ hashFiles('.github/workflows/vcpkg-osx.yml') }}-${{ hashFiles('vcpkg/cache/vcpkg/installed/vcpkg/updates/*') }}
+
+      - name: Cmake build
+        if: success()
+        run: |
+          cmake --build build --config Release -j2
+          build/src/curl --disable --version
+
+      - name: Cmake install
+        if: success()
+        run: |
+          sudo cmake --install build --config Release
+
+      - name: Run tests
+        if: success() 
+        run: |
+          cmake --build build --target test-ci -j2

--- a/.github/workflows/vcpkg-windows.yml
+++ b/.github/workflows/vcpkg-windows.yml
@@ -1,0 +1,186 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+name: vcpkg Windows
+
+on:
+  push:
+    branches:
+      - master
+      - '*/ci'
+    paths-ignore:
+      - '**/*.md'
+      - '.azure-pipelines.yml'
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - 'appveyor.*'
+      - 'packages/**'
+      - 'plan9/**'
+      - 'projects/**'
+      - 'winbuild/**'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**/*.md'
+      - '.azure-pipelines.yml'
+      - '.circleci/**'
+      - '.cirrus.yml'
+      - 'appveyor.*'
+      - 'packages/**'
+      - 'plan9/**'
+      - 'projects/**'
+      - 'winbuild/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+env:
+  OS: windows
+  BUILD_DIR: vcpkg/cache
+  VCPKG_LINK: https://github.com/microsoft/vcpkg/
+  BINARY_CACHE: vcpkg/cache/linux
+  VCPKG_ROOT_WINDOWS: vcpkg/cache/vcpkg
+
+jobs:
+  build:
+    name: vcpkg-windows-${{ matrix.PROCESSOR }}-${{ matrix.BUILD_OPTION }}
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - BUILD_OPTION: openssl
+          PROCESSOR: x64
+          CMAKE_OPTIONS: -DCURL_USE_LIBSSH2=ON 
+        - BUILD_OPTION: libressl
+          PROCESSOR: x64
+          CMAKE_OPTIONS: -DCURL_USE_LIBSSH2=OFF
+    env:
+      PROCESSOR: ${{ matrix.PROCESSOR }}
+      BUILD_OPTION: ${{ matrix.BUILD_OPTION }}
+      CMAKE_OPTIONS: ${{ matrix.CMAKE_OPTIONS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Cache dependencies
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{env.BINARY_CACHE }}/${{ matrix.BUILD_OPTION }}
+          key: ${{ env.OS }}-${{ matrix.BUILD_OPTION }}-${{ hashFiles('.github/workflows/vcpkg-windows.yml') }}
+          restore-keys: ${{ env.OS }}-${{ matrix.BUILD_OPTION }}-${{ hashFiles('.github/workflows/vcpkg-windows.yml') }}
+
+      - name: Setup msbuild
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.PROCESSOR }}    
+
+      - name: cl version
+        shell: cmd
+        run: |
+          cl
+
+      - name: Fix vcpkg
+        shell: cmd
+        run: vcpkg.exe integrate remove
+
+      - name: Init vcpkg
+        if: success()
+        shell: bash
+        run: |
+          mkdir -p $BUILD_DIR
+          git -C $BUILD_DIR clone $VCPKG_LINK
+          $VCPKG_ROOT_WINDOWS/bootstrap-vcpkg.sh
+  
+      - name: vcpkg build openssl
+        shell: bash
+        if: ${{ success() && matrix.BUILD_OPTION == 'openssl' }}
+        run: |
+          export VCPKG_ROOT=$VCPKG_ROOT_WINDOWS
+          export CURRENT_BINARY_CACHE="$BINARY_CACHE/$BUILD_OPTION"
+          mkdir -p $CURRENT_BINARY_CACHE
+          export VCPKG_BINARY_SOURCES="clear;files,${GITHUB_WORKSPACE}/$CURRENT_BINARY_CACHE,readwrite;"
+          $VCPKG_ROOT_WINDOWS/vcpkg x-set-installed libssh2[core,openssl] nghttp2 openssl zstd --triplet=$PROCESSOR-$OS-release
+
+      - name: vcpkg build libressl
+        shell: bash
+        if: ${{ success() && matrix.BUILD_OPTION == 'libressl' }}
+        run: |
+          export VCPKG_ROOT=$VCPKG_ROOT_WINDOWS
+          export CURRENT_BINARY_CACHE="$BINARY_CACHE/$BUILD_OPTION"
+          mkdir -p $CURRENT_BINARY_CACHE
+          export VCPKG_BINARY_SOURCES="clear;files,${GITHUB_WORKSPACE}/$CURRENT_BINARY_CACHE,readwrite;"
+          $VCPKG_ROOT_WINDOWS/vcpkg x-set-installed libressl nghttp2 zstd --triplet=$PROCESSOR-$OS-release
+
+      - name: cmake config
+        if: success() 
+        shell: bash
+        run: |
+          export VCPKG_ROOT=$VCPKG_ROOT_WINDOWS
+          export CMAKE_GENERATOR=Ninja
+          cmake . -B build \
+              -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT_WINDOWS/scripts/buildsystems/vcpkg.cmake \
+              -DVCPKG_INSTALLED_DIR=$VCPKG_ROOT_WINDOWS/installed \
+              -DVCPKG_TARGET_TRIPLET=$PROCESSOR-$OS-release \
+              -DCMAKE_UNITY_BUILD=ON \
+              -DCURL_WERROR=ON \
+              -DBUILD_SHARED_LIBS=OFF \
+              -DCURL_ZSTD=ON \
+              -DUSE_NGHTTP2=ON \
+              -DCURL_USE_OPENSSL=ON \
+              -DCURL_USE_LIBPSL=OFF \
+              -DCURL_USE_GSSAPI=OFF \
+              -DENABLE_ARES=OFF \
+              -DCURL_USE_LIBSSH=OFF \
+              $CMAKE_OPTIONS
+
+      - name: Prepare logs on failure
+        if: failure()
+        shell: bash
+        run: |
+          7z a -t7z -r -mx=9 logs.7z \
+              $VCPKG_ROOT_WINDOWS/buildtrees/*.log \
+              build/.ninja_log \
+              build/build.ninja \
+              build/install_manifest.txt \
+              build/vcpkg-manifest-install.log
+
+      - name: Upload logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: windows_logs_${{matrix.BUILD_OPTION}}_${{github.event.pull_request.head.sha}}
+          path: logs.7z
+
+      - name: Save cache dependencies
+        id: cache-save
+        uses: actions/cache/save@v4
+        with:
+          path: ${{env.BINARY_CACHE }}/${{ matrix.BUILD_OPTION }}
+          key: ${{ env.OS }}-${{ matrix.BUILD_OPTION }}-${{ hashFiles('.github/workflows/vcpkg-windows.yml') }}-${{ hashFiles('vcpkg/cache/vcpkg/installed/vcpkg/updates/*') }}
+
+      - name: Cmake build
+        if: success()
+        shell: bash
+        run: |
+          cmake --build build --config Release -j2
+          export PATH=$PWD/$VCPKG_ROOT_WINDOWS/installed/x64-windows-release/bin:$PATH
+          build/src/curl --disable --version
+
+      - name: Cmake install
+        if: success()
+        shell: bash
+        run: |
+          cmake --install build --config Release
+
+      - name: Run tests
+        if: success() 
+        shell: bash
+        run: |
+          export PATH=$PWD/$VCPKG_ROOT_WINDOWS/installed/x64-windows-release/bin:$PATH
+          cmake --build build --target test-ci -j2


### PR DESCRIPTION
Add vcpkg ci. I bring you the power of vcpkg. It can build 3rd parties on many os, and can help build curl features and configuration. It can integrate with cmake. 
I also add a cache that when it will be other PR and hit the same cache, it will automatic draw the last time compilation. leaving most of the ci time for compile curl and testing.
I also add an upload logs as artifact in case of failing, to see what cause the vpckg to fail. 
vcpkg set to the latest, but it can changed. Also most of the time vpckg is stable, but it can have port fails. Usually vcpkg very responsive, especially in the very popular ports (packages) that needed for curl. 

I added a tests. tests in osx and windows are  fails, not sure why. Maybe I did something in my side. Maybe it can improve curl that way.
Note, I didn't add all the other features for curl because:
1. curl cmake needed to adapt to be more general (and vcpkg friendly).
2. libressl is conflict with openssl. by vcpkg rules it cannot compile togther because they conflict in the functions names and more. many ports (packages) that curl needed also compile with them openssl, that mean I cannot add them because of that conflicts.  

I fix one of the test. I hope I did it correctly, because on windows it complain that the last line is a dead code that cannot reach. 

I will happy to read your feedback and your thoughts. 