### PR TITLE
hostip: refuse to resolve the .i2p TLD

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -694,6 +694,12 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
     failf(data, "Not resolving .onion address (RFC 7686)");
     return CURLRESOLV_ERROR;
   }
+  if(hostname_len >= 5 &&
+     (curl_strequal(&hostname[hostname_len - 4], ".i2p") ||
+      curl_strequal(&hostname[hostname_len - 5], ".i2p."))) {
+    failf(data, "Not resolving .i2p address");
+    return CURLRESOLV_ERROR;
+  }
   *entry = NULL;
 #ifndef CURL_DISABLE_DOH
   conn->bits.doh = FALSE; /* default is not */

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -189,7 +189,7 @@ test1455 test1456 test1457 test1458 test1459 test1460 test1461 test1462 \
 test1463 test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
 test1471 test1472 test1473 test1474 test1475 test1476 test1477 test1478 \
 test1479 test1480 test1481 test1482 test1483 test1484 test1485 test1486 \
-test1487 \
+test1487 test1488 test1489 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1488
+++ b/tests/data/test1488
@@ -1,0 +1,41 @@
+<testcase>
+<info>
+<keywords>
+I2P
+FAILURE
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+http
+</features>
+<name>
+Fail to resolve .i2p TLD
+</name>
+<command>
+proxy.i2p
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# Couldn't resolve host name
+<errorcode>
+6
+</errorcode>
+<stderr mode="text">
+curl: (6) Not resolving .i2p address
+</stderr>
+</verify>
+</testcase>

--- a/tests/data/test1489
+++ b/tests/data/test1489
@@ -1,0 +1,41 @@
+<testcase>
+<info>
+<keywords>
+I2P
+FAILURE
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<features>
+http
+</features>
+<name>
+Fail to resolve .i2p TLD
+</name>
+<command>
+router.i2p
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# Couldn't resolve host name
+<errorcode>
+6
+</errorcode>
+<stderr mode="text">
+curl: (6) Not resolving .i2p address
+</stderr>
+</verify>
+</testcase>


### PR DESCRIPTION
Following the issue https://github.com/curl/curl/issues/543 and the discussion in https://github.com/curl/curl/discussions/13964 as well as the comments in https://daniel.haxx.se/blog/2024/05/17/curl-tor-dot-onion-and-socks/, this commit implements that curl no longer resolves .i2p domains.

Closes https://github.com/curl/curl/discussions/13964

(And yes, I "stole" the content itself from the commit https://github.com/curl/curl/commit/0ae0abbe72514a75c10bfc4108d9f254f594c086.)