### PR TITLE
Fix unreachable code warning in test for windows msvc compilation

### DIFF
--- a/tests/unit/unit2604.c
+++ b/tests/unit/unit2604.c
@@ -104,7 +104,10 @@ UNITTEST_START
   }
 
   free((void *)list[0].cp);
-  return error == 0 ? CURLE_OK : TEST_ERR_FAILURE;
+  if(error == 0) {
+    return CURLE_OK;
+  }
+  fail("TEST_ERR_FAILURE");
 }
 #endif
 


### PR DESCRIPTION
After run vcpkg-windows ci with openssl build option, I found this compilation error:

```
D:\a\curl\curl\tests\unit\unit2604.c(111) : error C2220: the following warning is treated as an error
D:\a\curl\curl\tests\unit\unit2604.c(111) : warning C4702: unreachable code
```

I fix the test.