### PR TITLE
x509asn1: remove two static variables

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -110,9 +110,6 @@ struct Curl_OID {
 };
 
 /* ASN.1 OIDs. */
-static const char       cnOID[] = "2.5.4.3";    /* Common name. */
-static const char       sanOID[] = "2.5.29.17"; /* Subject alternative name. */
-
 static const struct Curl_OID OIDtable[] = {
   { "1.2.840.10040.4.1",        "dsa" },
   { "1.2.840.10040.4.3",        "dsa-with-sha1" },
@@ -136,7 +133,7 @@ static const struct Curl_OID OIDtable[] = {
   { "1.2.840.113549.2.2",       "md2" },
   { "1.2.840.113549.2.5",       "md5" },
   { "1.3.14.3.2.26",            "sha1" },
-  { cnOID,                      "CN" },
+  { "2.5.4.3",                  "CN" },
   { "2.5.4.4",                  "SN" },
   { "2.5.4.5",                  "serialNumber" },
   { "2.5.4.6",                  "C" },
@@ -157,7 +154,7 @@ static const struct Curl_OID OIDtable[] = {
   { "2.5.4.65",                 "pseudonym" },
   { "1.2.840.113549.1.9.1",     "emailAddress" },
   { "2.5.4.72",                 "role" },
-  { sanOID,                     "subjectAltName" },
+  { "2.5.29.17",                "subjectAltName" },
   { "2.5.29.18",                "issuerAltName" },
   { "2.5.29.19",                "basicConstraints" },
   { "2.16.840.1.101.3.4.2.4",   "sha224" },


### PR DESCRIPTION
cnOID and sanOID were not used outside of the OID table anyway