### PR TITLE
x509asn1: ASN1tostr() should fail when 'constructed' is set

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -602,7 +602,7 @@ static CURLcode ASN1tostr(struct dynbuf *store,
 {
   CURLcode result = CURLE_BAD_FUNCTION_ARGUMENT;
   if(elem->constructed)
-    return CURLE_OK; /* No conversion of structured elements. */
+    return result; /* No conversion of structured elements. */
 
   if(!type)
     type = elem->tag;   /* Type not forced: use element tag as type. */


### PR DESCRIPTION
This is a regression from my refactor in 623c3a8fa0bdb.

Follow-up to 623c3a8fa0bdb2751f14b37417