### PR TITLE
VULN-DISCLOSURE-POLICY: NULL dereferences and crashes

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -174,6 +174,7 @@ decrypting
 deepcode
 DELE
 DER
+dereference
 deselectable
 deserialization
 Deserialized
@@ -508,8 +509,8 @@ monospace
 MorphOS
 MPE
 MPL
-MPTCP
 mprintf
+MPTCP
 MQTT
 mqtt
 mqtts

--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -175,6 +175,7 @@ deepcode
 DELE
 DER
 dereference
+dereferences
 deselectable
 deserialization
 Deserialized

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -298,3 +298,18 @@ is curl working as designed and is not a curl security problem. Escape
 sequences, moving cursor, changing color etc, is also frequently used for
 good. To reduce the risk of getting fooled, save files and browse them after
 download using a display method that minimizes risks.
+
+## NULL dereferences and crashes
+
+If a malicious server can trigger a NULL dereference in curl or otherwise
+cause curl to crash (and nothing worse), chances are big that we do not
+consider that a security problem.
+
+Malicious servers can already cause considerable harm and denial of service
+like scenarios without having to trigger such code paths. For example by
+stalling, being terribly slow or by delivering enormous amounts of data.
+Additionally, applications are expected to handle "normal" crashes without
+that being the end of the world.
+
+There need to be more and special circumstances to treat such problems as
+security issues.


### PR DESCRIPTION
If a malicious server can trigger a NULL dereference in curl or otherwise cause curl to crash (and nothing worse), chances are big that we do not consider that a security problem.