### PR TITLE
graceful connection shutdown

### DIFF
--- a/docs/libcurl/libcurl-env-dbg.md
+++ b/docs/libcurl/libcurl-env-dbg.md
@@ -123,3 +123,16 @@ greater. There is a number of debug levels, refer to *openldap.c* comments.
 
 Used to influence the buffer chunk size used for WebSocket encoding and
 decoding.
+
+## CURL_FORBID_REUSE
+
+Used to set the CURLOPT_FORBID_REUSE flag on each transfer initiated
+by the curl command line tool. The value of the environment variable
+does not matter.
+
+## CURL_GRACEFUL_SHUTDOWN
+
+Make a blocking, graceful shutdown of all remaining connections when
+a multi handle is destroyed. This implicitly triggers for easy handles
+that are run via easy_perform. The value of the environment variable
+gives the shutdown timeout in milliseconds.

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -183,7 +183,6 @@ struct cf_h2_proxy_ctx {
   BIT(conn_closed);
   BIT(rcvd_goaway);
   BIT(sent_goaway);
-  BIT(shutdown);
   BIT(nw_out_blocked);
 };
 
@@ -1172,13 +1171,16 @@ static CURLcode cf_h2_proxy_shutdown(struct Curl_cfilter *cf,
                                      struct Curl_easy *data, bool *done)
 {
   struct cf_h2_proxy_ctx *ctx = cf->ctx;
+  struct cf_call_data save;
   CURLcode result;
   int rv;
 
-  if(!cf->connected || !ctx->h2 || ctx->shutdown) {
+  if(!cf->connected || !ctx->h2 || cf->shutdown || ctx->conn_closed) {
     *done = TRUE;
     return CURLE_OK;
   }
+
+  CF_DATA_SAVE(save, cf, data);
 
   if(!ctx->sent_goaway) {
     rv = nghttp2_submit_goaway(ctx->h2, NGHTTP2_FLAG_NONE,
@@ -1187,7 +1189,8 @@ static CURLcode cf_h2_proxy_shutdown(struct Curl_cfilter *cf,
     if(rv) {
       failf(data, "nghttp2_submit_goaway() failed: %s(%d)",
             nghttp2_strerror(rv), rv);
-      return CURLE_SEND_ERROR;
+      result = CURLE_SEND_ERROR;
+      goto out;
     }
     ctx->sent_goaway = TRUE;
   }
@@ -1198,9 +1201,12 @@ static CURLcode cf_h2_proxy_shutdown(struct Curl_cfilter *cf,
   if(!result && nghttp2_session_want_read(ctx->h2))
     result = proxy_h2_progress_ingress(cf, data);
 
-  *done = !result && !nghttp2_session_want_write(ctx->h2) &&
-          !nghttp2_session_want_read(ctx->h2);
-  ctx->shutdown = (result || *done);
+  *done = (ctx->conn_closed ||
+           (!result && !nghttp2_session_want_write(ctx->h2) &&
+            !nghttp2_session_want_read(ctx->h2)));
+out:
+  CF_DATA_RESTORE(cf, save);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1240,7 +1246,7 @@ static void cf_h2_proxy_adjust_pollset(struct Curl_cfilter *cf,
     Curl_pollset_set(data, ps, sock, want_recv, want_send);
     CF_DATA_RESTORE(cf, save);
   }
-  else if(ctx->sent_goaway && !ctx->shutdown) {
+  else if(ctx->sent_goaway && !cf->shutdown) {
     /* shutdown in progress */
     CF_DATA_SAVE(save, cf, data);
     want_send = nghttp2_session_want_write(ctx->h2);

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -223,6 +223,7 @@ struct Curl_cfilter {
   struct connectdata *conn;      /* the connection this filter belongs to */
   int sockindex;                 /* the index the filter is installed at */
   BIT(connected);                /* != 0 iff this filter is connected */
+  BIT(shutdown);                 /* != 0 iff this filter has shut down */
 };
 
 /* Default implementations for the type functions, implementing nop. */

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -29,13 +29,17 @@
 
 #include "urldata.h"
 #include "url.h"
+#include "cfilters.h"
 #include "progress.h"
 #include "multiif.h"
 #include "sendf.h"
 #include "conncache.h"
+#include "http_negotiate.h"
+#include "http_ntlm.h"
 #include "share.h"
 #include "sigpipe.h"
 #include "connect.h"
+#include "select.h"
 #include "strcase.h"
 
 /* The last 3 #include files should be in this order */
@@ -44,6 +48,26 @@
 #include "memdebug.h"
 
 #define HASHKEY_SIZE 128
+
+static void conncache_discard_conn(struct conncache *connc,
+                                   struct Curl_easy *last_data,
+                                   struct connectdata *conn,
+                                   bool aborted);
+static void connc_disconnect(struct Curl_easy *data,
+                             struct connectdata *conn,
+                             struct conncache *connc,
+                             bool do_shutdown);
+static void connc_run_conn_shutdown(struct Curl_easy *data,
+                                    struct connectdata *conn,
+                                    bool *done);
+static void connc_run_conn_shutdown_handler(struct Curl_easy *data,
+                                            struct connectdata *conn);
+static CURLcode conncache_update_shutdown_ev(struct Curl_multi *multi,
+                                             struct Curl_easy *data,
+                                             struct connectdata *conn);
+#ifdef DEBUGBUILD
+static void conncache_shutdown_all(struct conncache *connc, int timeout_ms);
+#endif
 
 static CURLcode bundle_create(struct connectbundle **bundlep)
 {
@@ -100,25 +124,38 @@ static void free_bundle_hash_entry(void *freethis)
   bundle_destroy(b);
 }
 
-int Curl_conncache_init(struct conncache *connc, size_t size)
+static curl_off_t next_cache_id;
+
+int Curl_conncache_init(struct conncache *connc,
+                        struct Curl_multi *multi, size_t size)
 {
+  connc->cache_id = next_cache_id++;
   /* allocate a new easy handle to use when closing cached connections */
   connc->closure_handle = curl_easy_init();
   if(!connc->closure_handle)
     return 1; /* bad */
   connc->closure_handle->state.internal = true;
+ #ifdef DEBUGBUILD
+  if(getenv("CURL_DEBUG"))
+    connc->closure_handle->set.verbose = true;
+#endif
 
   Curl_hash_init(&connc->hash, size, Curl_hash_str,
                  Curl_str_key_compare, free_bundle_hash_entry);
   connc->closure_handle->state.conn_cache = connc;
+  connc->multi = multi;
+  Curl_llist_init(&connc->shutdowns.conn_list, NULL);
 
   return 0; /* good */
 }
 
 void Curl_conncache_destroy(struct conncache *connc)
 {
-  if(connc)
+  if(connc) {
     Curl_hash_destroy(&connc->hash);
+    connc->multi = NULL;
+    DEBUGASSERT(!Curl_llist_count(&connc->shutdowns.conn_list));
+  }
 }
 
 /* creates a key to find a bundle for this connection */
@@ -252,6 +289,23 @@ unlock:
   return result;
 }
 
+static void conncache_remove_conn(struct conncache *connc,
+                                  struct connectdata *conn)
+{
+  struct connectbundle *bundle = conn->bundle;
+
+  /* The bundle pointer can be NULL, since this function can be called
+     due to a failed connection attempt, before being added to a bundle */
+  if(bundle) {
+    bundle_remove_conn(bundle, conn);
+    if(connc && bundle->num_connections == 0)
+      conncache_remove_bundle(connc, bundle);
+    conn->bundle = NULL; /* removed from it */
+    if(connc)
+      connc->num_conn--;
+  }
+}
+
 /*
  * Removes the connectdata object from the connection cache, but the transfer
  * still owns this connection.
@@ -262,28 +316,16 @@ unlock:
 void Curl_conncache_remove_conn(struct Curl_easy *data,
                                 struct connectdata *conn, bool lock)
 {
-  struct connectbundle *bundle = conn->bundle;
   struct conncache *connc = data->state.conn_cache;
 
-  /* The bundle pointer can be NULL, since this function can be called
-     due to a failed connection attempt, before being added to a bundle */
-  if(bundle) {
-    if(lock) {
-      CONNCACHE_LOCK(data);
-    }
-    bundle_remove_conn(bundle, conn);
-    if(bundle->num_connections == 0)
-      conncache_remove_bundle(connc, bundle);
-    conn->bundle = NULL; /* removed from it */
-    if(connc) {
-      connc->num_conn--;
-      DEBUGF(infof(data, "The cache now contains %zu members",
-                   connc->num_conn));
-    }
-    if(lock) {
-      CONNCACHE_UNLOCK(data);
-    }
-  }
+  if(lock)
+    CONNCACHE_LOCK(data);
+  conncache_remove_conn(connc, conn);
+  if(lock)
+    CONNCACHE_UNLOCK(data);
+  if(connc)
+    DEBUGF(infof(data, "The cache now contains %zu members",
+                 connc->num_conn));
 }
 
 /* This function iterates the entire connection cache and calls the function
@@ -394,8 +436,7 @@ bool Curl_conncache_return_conn(struct Curl_easy *data,
          important that details from this (unrelated) disconnect does not
          taint meta-data in the data handle. */
       struct conncache *connc = data->state.conn_cache;
-      Curl_disconnect(connc->closure_handle, conn_candidate,
-                      /* dead_connection */ FALSE);
+      connc_disconnect(NULL, conn_candidate, connc, TRUE);
     }
   }
 
@@ -516,32 +557,611 @@ Curl_conncache_extract_oldest(struct Curl_easy *data)
   return conn_candidate;
 }
 
-void Curl_conncache_close_all_connections(struct conncache *connc)
+static void conncache_shutdown_discard_all(struct conncache *connc)
 {
+  struct Curl_llist_element *e = connc->shutdowns.conn_list.head;
   struct connectdata *conn;
-  SIGPIPE_VARIABLE(pipe_st);
-  if(!connc->closure_handle)
+
+  if(!e)
     return;
 
+  DEBUGF(infof(connc->closure_handle, "conncache_shutdown_discard_all"));
+  DEBUGASSERT(!connc->shutdowns.iter_locked);
+  connc->shutdowns.iter_locked = TRUE;
+  while(e) {
+    conn = e->ptr;
+    Curl_llist_remove(&connc->shutdowns.conn_list, e, NULL);
+    DEBUGF(infof(connc->closure_handle, "discard connection #%"
+                 CURL_FORMAT_CURL_OFF_T, conn->connection_id));
+    connc_disconnect(NULL, conn, connc, FALSE);
+    e = connc->shutdowns.conn_list.head;
+  }
+  connc->shutdowns.iter_locked = FALSE;
+}
+
+static void conncache_close_all(struct conncache *connc)
+{
+  struct Curl_easy *data = connc->closure_handle;
+  struct connectdata *conn;
+  SIGPIPE_VARIABLE(pipe_st);
+
+  if(!data)
+    return;
+
+  /* Move all connections to the shutdown list */
   conn = conncache_find_first_connection(connc);
   while(conn) {
-    sigpipe_ignore(connc->closure_handle, &pipe_st);
+    conncache_remove_conn(connc, conn);
+    sigpipe_ignore(data, &pipe_st);
     /* This will remove the connection from the cache */
     connclose(conn, "kill all");
-    Curl_conncache_remove_conn(connc->closure_handle, conn, TRUE);
-    Curl_disconnect(connc->closure_handle, conn, FALSE);
+    conncache_discard_conn(connc, NULL, conn, FALSE);
     sigpipe_restore(&pipe_st);
 
     conn = conncache_find_first_connection(connc);
   }
 
-  sigpipe_ignore(connc->closure_handle, &pipe_st);
+    /* Just for testing, run graceful shutdown */
+#ifdef DEBUGBUILD
+  {
+    char *p = getenv("CURL_GRACEFUL_SHUTDOWN");
+    if(p) {
+      long l = strtol(p, NULL, 10);
+      if(l > 0 && l < INT_MAX)
+        conncache_shutdown_all(connc, (int)l);
+    }
+  }
+#endif
 
-  Curl_hostcache_clean(connc->closure_handle,
-                       connc->closure_handle->dns.hostcache);
-  Curl_close(&connc->closure_handle);
+  /* discard all connections in the shutdown list */
+  conncache_shutdown_discard_all(connc);
+
+  sigpipe_ignore(data, &pipe_st);
+  Curl_hostcache_clean(data, data->dns.hostcache);
+  Curl_close(&data);
   sigpipe_restore(&pipe_st);
 }
+
+void Curl_conncache_close_all_connections(struct conncache *connc)
+{
+  conncache_close_all(connc);
+}
+
+static void connc_shutdown_discard_oldest(struct conncache *connc)
+{
+  struct Curl_llist_element *e;
+  struct connectdata *conn;
+  SIGPIPE_VARIABLE(pipe_st);
+
+  DEBUGASSERT(!connc->shutdowns.iter_locked);
+  if(connc->shutdowns.iter_locked)
+    return;
+
+  e = connc->shutdowns.conn_list.head;
+  if(e) {
+    conn = e->ptr;
+    Curl_llist_remove(&connc->shutdowns.conn_list, e, NULL);
+    sigpipe_ignore(connc->closure_handle, &pipe_st);
+    connc_disconnect(NULL, conn, connc, FALSE);
+    sigpipe_restore(&pipe_st);
+  }
+}
+
+static void conncache_discard_conn(struct conncache *connc,
+                                   struct Curl_easy *last_data,
+                                   struct connectdata *conn,
+                                   bool aborted)
+{
+  /* `last_data`, if present, is the transfer that last worked with
+   * the connection. It is present when the connection is being shut down
+   * via `Curl_conncache_discard_conn()`, e.g. when the transfer failed
+   * or does not allow connection reuse.
+   * Using the original handle is necessary for shutting down the protocol
+   * handler belonging to the connection. Protocols like 'file:' rely on
+   * being invoked to clean up their allocations in the easy handle.
+   * When a connection comes from the cache, the transfer is no longer
+   * there and we use the cache's own closure handle.
+   */
+  struct Curl_easy *data = last_data? last_data : connc->closure_handle;
+  bool done = FALSE;
+
+  DEBUGASSERT(connc);
+  DEBUGASSERT(!conn->bundle);
+
+  /*
+   * If this connection isn't marked to force-close, leave it open if there
+   * are other users of it
+   */
+  if(CONN_INUSE(conn) && !aborted) {
+    DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] not discarding "
+                       "#%" CURL_FORMAT_CURL_OFF_T " still in use by %zu "
+                       "transfers", connc->cache_id, conn->connection_id,
+                       CONN_INUSE(conn)));
+    return;
+  }
+
+  /* treat the connection as aborted in CONNECT_ONLY situations, we do
+   * not know what the APP did with it. */
+  if(conn->connect_only)
+    aborted = TRUE;
+  conn->bits.aborted = aborted;
+
+  /* We do not shutdown dead connections. The term 'dead' can be misleading
+   * here, as we also mark errored connections/transfers as 'dead'.
+   * If we do a shutdown for an aborted transfer, the server might think
+   * it was successful otherwise (for example an ftps: upload). This is
+   * not what we want. */
+  if(aborted)
+    done = TRUE;
+  else if(!done) {
+    /* Attempt to shutdown the connection right away. */
+    Curl_attach_connection(data, conn);
+    connc_run_conn_shutdown(data, conn, &done);
+    DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] shutdown "
+                       "#%" CURL_FORMAT_CURL_OFF_T ", done=%d",
+                       connc->cache_id, conn->connection_id, done));
+    Curl_detach_connection(data);
+  }
+
+  if(done) {
+    connc_disconnect(data, conn, connc, FALSE);
+    return;
+  }
+
+  DEBUGASSERT(!connc->shutdowns.iter_locked);
+  if(connc->shutdowns.iter_locked) {
+    DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] discarding "
+                       "#%" CURL_FORMAT_CURL_OFF_T ", list locked",
+                       connc->cache_id, conn->connection_id));
+    connc_disconnect(data, conn, connc, FALSE);
+    return;
+  }
+
+  /* Add the connection to our shutdown list for non-blocking shutdown
+   * during multi processing. */
+  if(data->multi && data->multi->max_shutdown_connections > 0 &&
+     (data->multi->max_shutdown_connections >=
+      (long)Curl_llist_count(&connc->shutdowns.conn_list))) {
+    DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] discarding"
+                 " oldest shutdown connection due to limit of %ld",
+                 connc->cache_id, data->multi->max_shutdown_connections));
+    connc_shutdown_discard_oldest(connc);
+  }
+
+  if(data->multi && data->multi->socket_cb) {
+    DEBUGASSERT(connc == &data->multi->conn_cache);
+    if(conncache_update_shutdown_ev(data->multi, data, conn)) {
+      DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] update events"
+                   " for shutdown failed, discarding #%"
+                   CURL_FORMAT_CURL_OFF_T,
+                   connc->cache_id, conn->connection_id));
+      connc_disconnect(data, conn, connc, FALSE);
+      return;
+    }
+  }
+
+  Curl_llist_append(&connc->shutdowns.conn_list, conn, &conn->bundle_node);
+  DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] added"
+               " #%" CURL_FORMAT_CURL_OFF_T " to shutdown list of length %zu",
+               connc->cache_id, conn->connection_id,
+               Curl_llist_count(&connc->shutdowns.conn_list)));
+
+  /* Forget what this transfer last polled, the connection is ours now.
+   * If we do not clear this, the event handling for `data` will tell
+   * the callback to remove the connection socket after we return here. */
+  memset(&data->last_poll, 0, sizeof(data->last_poll));
+}
+
+void Curl_conncache_discard_conn(struct Curl_easy *data,
+                                 struct connectdata *conn,
+                                 bool aborted, bool lock)
+{
+  DEBUGASSERT(data);
+  /* Remove it from the conncache it is in. */
+  if(conn->bundle)
+    Curl_conncache_remove_conn(data, conn, lock);
+
+  if(data->multi) {
+    /* Add it to the multi's conncache for shutdown handling */
+    infof(data, "%s connection #%" CURL_FORMAT_CURL_OFF_T,
+          aborted? "Closing" : "Shutting down", conn->connection_id);
+    conncache_discard_conn(&data->multi->conn_cache, data, conn, aborted);
+  }
+  else {
+    /* No multi available. Make a best-effort shutdown + close */
+    infof(data, "Closing connection #%" CURL_FORMAT_CURL_OFF_T,
+          conn->connection_id);
+    DEBUGASSERT(!conn->bundle);
+    connc_run_conn_shutdown_handler(data, conn);
+    connc_disconnect(data, conn, NULL, !aborted);
+  }
+}
+
+static void connc_run_conn_shutdown_handler(struct Curl_easy *data,
+                                            struct connectdata *conn)
+{
+  if(!conn->bits.shutdown_handler) {
+    if(conn->dns_entry) {
+      Curl_resolv_unlock(data, conn->dns_entry);
+      conn->dns_entry = NULL;
+    }
+
+    /* Cleanup NTLM connection-related data */
+    Curl_http_auth_cleanup_ntlm(conn);
+
+    /* Cleanup NEGOTIATE connection-related data */
+    Curl_http_auth_cleanup_negotiate(conn);
+
+    if(conn->handler && conn->handler->disconnect) {
+      /* This is set if protocol-specific cleanups should be made */
+      DEBUGF(infof(data, "connection #%" CURL_FORMAT_CURL_OFF_T
+                   ", shutdown protocol handler (aborted=%d)",
+                   conn->connection_id, conn->bits.aborted));
+      conn->handler->disconnect(data, conn, conn->bits.aborted);
+    }
+
+    /* possible left-overs from the async name resolvers */
+    Curl_resolver_cancel(data);
+
+    conn->bits.shutdown_handler = TRUE;
+  }
+}
+
+static void connc_run_conn_shutdown(struct Curl_easy *data,
+                                    struct connectdata *conn,
+                                    bool *done)
+{
+  CURLcode r1, r2;
+  bool done1, done2;
+
+  /* We expect to be attached when called */
+  DEBUGASSERT(data->conn == conn);
+
+  connc_run_conn_shutdown_handler(data, conn);
+
+  if(conn->bits.shutdown_filters) {
+    *done = TRUE;
+    return;
+  }
+
+  if(!conn->connect_only && Curl_conn_is_connected(conn, FIRSTSOCKET))
+    r1 = Curl_conn_shutdown(data, FIRSTSOCKET, &done1);
+  else {
+    r1 = CURLE_OK;
+    done1 = TRUE;
+  }
+
+  if(!conn->connect_only && Curl_conn_is_connected(conn, SECONDARYSOCKET))
+    r2 = Curl_conn_shutdown(data, SECONDARYSOCKET, &done2);
+  else {
+    r2 = CURLE_OK;
+    done2 = TRUE;
+  }
+
+  /* we are done when any failed or both report success */
+  *done = (r1 || r2 || (done1 && done2));
+  if(*done)
+    conn->bits.shutdown_filters = TRUE;
+}
+
+CURLcode Curl_conncache_add_pollfds(struct conncache *connc,
+                                    struct curl_pollfds *cpfds)
+{
+  CURLcode result = CURLE_OK;
+
+  DEBUGASSERT(!connc->shutdowns.iter_locked);
+  connc->shutdowns.iter_locked = TRUE;
+  if(connc->shutdowns.conn_list.head) {
+    struct Curl_llist_element *e;
+    struct easy_pollset ps;
+    struct connectdata *conn;
+
+    for(e = connc->shutdowns.conn_list.head; e; e = e->next) {
+      conn = e->ptr;
+      memset(&ps, 0, sizeof(ps));
+      Curl_attach_connection(connc->closure_handle, conn);
+      Curl_conn_adjust_pollset(connc->closure_handle, &ps);
+      Curl_detach_connection(connc->closure_handle);
+
+      result = Curl_pollfds_add_ps(cpfds, &ps);
+      if(result) {
+        Curl_pollfds_cleanup(cpfds);
+        goto out;
+      }
+    }
+  }
+out:
+  connc->shutdowns.iter_locked = FALSE;
+  return result;
+}
+
+CURLcode Curl_conncache_add_waitfds(struct conncache *connc,
+                                    struct curl_waitfds *cwfds)
+{
+  CURLcode result = CURLE_OK;
+
+  DEBUGASSERT(!connc->shutdowns.iter_locked);
+  connc->shutdowns.iter_locked = TRUE;
+  if(connc->shutdowns.conn_list.head) {
+    struct Curl_llist_element *e;
+    struct easy_pollset ps;
+    struct connectdata *conn;
+
+    for(e = connc->shutdowns.conn_list.head; e; e = e->next) {
+      conn = e->ptr;
+      memset(&ps, 0, sizeof(ps));
+      Curl_attach_connection(connc->closure_handle, conn);
+      Curl_conn_adjust_pollset(connc->closure_handle, &ps);
+      Curl_detach_connection(connc->closure_handle);
+
+      result = Curl_waitfds_add_ps(cwfds, &ps);
+      if(result)
+        goto out;
+    }
+  }
+out:
+  connc->shutdowns.iter_locked = FALSE;
+  return result;
+}
+
+static void conncache_perform(struct conncache *connc)
+{
+  struct Curl_easy *data = connc->closure_handle;
+  struct Curl_llist_element *e = connc->shutdowns.conn_list.head;
+  struct Curl_llist_element *enext;
+  struct connectdata *conn;
+  bool done;
+
+  if(!e)
+    return;
+
+  DEBUGASSERT(!connc->shutdowns.iter_locked);
+  DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] perform, "
+               "%zu connections being shutdown", connc->cache_id,
+               Curl_llist_count(&connc->shutdowns.conn_list)));
+  connc->shutdowns.iter_locked = TRUE;
+  while(e) {
+    enext = e->next;
+    conn = e->ptr;
+    Curl_attach_connection(data, conn);
+    connc_run_conn_shutdown(data, conn, &done);
+    DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] shutdown"
+                 " #%" CURL_FORMAT_CURL_OFF_T ", done=%d",
+                 connc->cache_id, conn->connection_id, done));
+    Curl_detach_connection(data);
+    if(done) {
+      Curl_llist_remove(&connc->shutdowns.conn_list, e, NULL);
+      connc_disconnect(NULL, conn, connc, FALSE);
+    }
+    e = enext;
+  }
+  connc->shutdowns.iter_locked = FALSE;
+}
+
+void Curl_conncache_multi_perform(struct Curl_multi *multi)
+{
+  conncache_perform(&multi->conn_cache);
+}
+
+
+/*
+ * Disconnects the given connection. Note the connection may not be the
+ * primary connection, like when freeing room in the connection cache or
+ * killing of a dead old connection.
+ *
+ * A connection needs an easy handle when closing down. We support this passed
+ * in separately since the connection to get closed here is often already
+ * disassociated from an easy handle.
+ *
+ * This function MUST NOT reset state in the Curl_easy struct if that
+ * isn't strictly bound to the life-time of *this* particular connection.
+ *
+ */
+static void connc_disconnect(struct Curl_easy *data,
+                             struct connectdata *conn,
+                             struct conncache *connc,
+                             bool do_shutdown)
+{
+  bool done;
+
+  /* there must be a connection to close */
+  DEBUGASSERT(conn);
+  /* it must be removed from the connection cache */
+  DEBUGASSERT(!conn->bundle);
+  /* there must be an associated transfer */
+  DEBUGASSERT(data || connc);
+  if(!data)
+    data = connc->closure_handle;
+
+  /* the transfer must be detached from the connection */
+  DEBUGASSERT(!data->conn);
+
+  if(connc && connc->multi && connc->multi->socket_cb) {
+    unsigned int i;
+    for(i = 0; i < 2; ++i) {
+      if(CURL_SOCKET_BAD == conn->sock[i])
+        continue;
+      /* remove all connection's sockets from event handling */
+      connc->multi->in_callback = TRUE;
+      connc->multi->socket_cb(data, conn->sock[i], CURL_POLL_REMOVE,
+                              connc->multi->socket_userp, NULL);
+      connc->multi->in_callback = FALSE;
+    }
+  }
+
+  Curl_attach_connection(data, conn);
+
+  connc_run_conn_shutdown_handler(data, conn);
+  if(do_shutdown) {
+    /* Make a last attempt to shutdown handlers and filters, if
+     * not done so already. */
+    connc_run_conn_shutdown(data, conn, &done);
+  }
+
+  if(connc)
+    DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] closing #%"
+                 CURL_FORMAT_CURL_OFF_T,
+                 connc->cache_id, conn->connection_id));
+  else
+    DEBUGF(infof(data, "closing connection #%" CURL_FORMAT_CURL_OFF_T,
+                 conn->connection_id));
+  Curl_conn_close(data, SECONDARYSOCKET);
+  Curl_conn_close(data, FIRSTSOCKET);
+  Curl_detach_connection(data);
+
+  Curl_conn_free(data, conn);
+}
+
+
+static CURLcode conncache_update_shutdown_ev(struct Curl_multi *multi,
+                                             struct Curl_easy *data,
+                                             struct connectdata *conn)
+{
+  struct conncache *connc = &multi->conn_cache;
+  struct easy_pollset ps;
+  unsigned int i;
+  int rc;
+
+  DEBUGASSERT(data);
+  DEBUGASSERT(multi);
+  DEBUGASSERT(multi->socket_cb);
+
+  memset(&ps, 0, sizeof(ps));
+  Curl_attach_connection(data, conn);
+  Curl_conn_adjust_pollset(data, &ps);
+  Curl_detach_connection(data);
+
+  if(!ps.num)
+    return CURLE_FAILED_INIT;
+
+  for(i = 0; i < ps.num; ++i) {
+    /* TODO: compare with previous pollset and update events */
+    DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] "
+                 "set socket=%d events=%d on #%" CURL_FORMAT_CURL_OFF_T,
+                 connc->cache_id, ps.sockets[i], ps.actions[i],
+                 conn->connection_id));
+    multi->in_callback = TRUE;
+    rc = multi->socket_cb(data, ps.sockets[i], ps.actions[i],
+                          multi->socket_userp, NULL);
+    multi->in_callback = FALSE;
+    if(rc == -1)
+      return CURLE_FAILED_INIT;
+  }
+
+  return CURLE_OK;
+}
+
+void Curl_conncache_multi_socket(struct Curl_multi *multi,
+                                 curl_socket_t s, int ev_bitmask)
+{
+  struct conncache *connc = &multi->conn_cache;
+  struct Curl_easy *data = connc->closure_handle;
+  struct Curl_llist_element *e = connc->shutdowns.conn_list.head;
+  struct connectdata *conn;
+  bool done;
+
+  (void)ev_bitmask;
+  DEBUGASSERT(multi->socket_cb);
+  if(!e)
+    return;
+
+  connc->shutdowns.iter_locked = TRUE;
+  while(e) {
+    conn = e->ptr;
+    if(s == conn->sock[FIRSTSOCKET] || s == conn->sock[SECONDARYSOCKET]) {
+      Curl_attach_connection(data, conn);
+      connc_run_conn_shutdown(data, conn, &done);
+      DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] shutdown"
+                   " #%" CURL_FORMAT_CURL_OFF_T ", done=%d",
+                   connc->cache_id, conn->connection_id, done));
+      Curl_detach_connection(data);
+      if(done || conncache_update_shutdown_ev(multi, data, conn)) {
+        Curl_llist_remove(&connc->shutdowns.conn_list, e, NULL);
+        connc_disconnect(NULL, conn, connc, FALSE);
+      }
+      break;
+    }
+    e = e->next;
+  }
+  connc->shutdowns.iter_locked = FALSE;
+}
+
+void Curl_conncache_multi_close_all(struct Curl_multi *multi)
+{
+  conncache_close_all(&multi->conn_cache);
+}
+
+
+#ifdef DEBUGBUILD
+
+#define NUM_POLLS_ON_STACK 10
+
+static CURLcode conncache_shutdown_wait(struct conncache *connc,
+                                        int timeout_ms)
+{
+  struct pollfd a_few_on_stack[NUM_POLLS_ON_STACK];
+  struct curl_pollfds cpfds;
+  CURLcode result;
+
+  Curl_pollfds_init(&cpfds, a_few_on_stack, NUM_POLLS_ON_STACK);
+
+  result = Curl_conncache_add_pollfds(connc, &cpfds);
+  if(result)
+    goto out;
+
+  Curl_poll(cpfds.pfds, cpfds.n, CURLMIN(timeout_ms, 1000));
+
+out:
+  return result;
+}
+
+static void conncache_shutdown_all(struct conncache *connc, int timeout_ms)
+{
+  struct connectdata *conn;
+  struct curltime started = Curl_now();
+
+  if(!connc->closure_handle)
+    return;
+
+  /* Move all connections into the shutdown queue */
+  conn = conncache_find_first_connection(connc);
+  while(conn) {
+    /* This will remove the connection from the cache */
+    DEBUGF(infof(connc->closure_handle, "moving connection %"
+           CURL_FORMAT_CURL_OFF_T " to shutdown queue", conn->connection_id));
+    conncache_remove_conn(connc, conn);
+    conncache_discard_conn(connc, NULL, conn, FALSE);
+    conn = conncache_find_first_connection(connc);
+  }
+
+  DEBUGASSERT(!connc->shutdowns.iter_locked);
+  while(connc->shutdowns.conn_list.head) {
+    timediff_t timespent;
+    int remain_ms;
+
+    conncache_perform(connc);
+
+    if(!connc->shutdowns.conn_list.head) {
+      DEBUGF(infof(connc->closure_handle, "conncache shutdown ok"));
+      break;
+    }
+
+    /* wait for activity, timeout or "nothing" */
+    timespent = Curl_timediff(Curl_now(), started);
+    if(timespent >= (timediff_t)timeout_ms) {
+      DEBUGF(infof(connc->closure_handle, "conncache shutdown timeout"));
+      break;
+    }
+
+    remain_ms = timeout_ms - (int)timespent;
+    if(conncache_shutdown_wait(connc, remain_ms))
+      break;
+  }
+
+  /* Due to errors/timeout, we might come here without being full ydone. */
+  conncache_shutdown_discard_all(connc);
+}
+#endif
 
 #if 0
 /* Useful for debugging the connection cache */

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -65,9 +65,7 @@ static void connc_run_conn_shutdown_handler(struct Curl_easy *data,
 static CURLcode connc_update_shutdown_ev(struct Curl_multi *multi,
                                          struct Curl_easy *data,
                                          struct connectdata *conn);
-#ifdef DEBUGBUILD
 static void connc_shutdown_all(struct conncache *connc, int timeout_ms);
-#endif
 
 static CURLcode bundle_create(struct connectbundle **bundlep)
 {
@@ -1078,8 +1076,6 @@ void Curl_conncache_multi_close_all(struct Curl_multi *multi)
 }
 
 
-#ifdef DEBUGBUILD
-
 #define NUM_POLLS_ON_STACK 10
 
 static CURLcode connc_shutdown_wait(struct conncache *connc, int timeout_ms)
@@ -1153,7 +1149,6 @@ static void connc_shutdown_all(struct conncache *connc, int timeout_ms)
   /* Due to errors/timeout, we might come here without being full ydone. */
   connc_shutdown_discard_all(connc);
 }
-#endif
 
 #if 0
 /* Useful for debugging the connection cache */

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -1093,6 +1093,7 @@ static CURLcode connc_shutdown_wait(struct conncache *connc, int timeout_ms)
   Curl_poll(cpfds.pfds, cpfds.n, CURLMIN(timeout_ms, 1000));
 
 out:
+  Curl_pollfds_cleanup(&cpfds);
   return result;
 }
 

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -1017,7 +1017,6 @@ static CURLcode conncache_update_shutdown_ev(struct Curl_multi *multi,
                                              struct Curl_easy *data,
                                              struct connectdata *conn)
 {
-  struct conncache *connc = &multi->conn_cache;
   struct easy_pollset ps;
   unsigned int i;
   int rc;
@@ -1038,7 +1037,7 @@ static CURLcode conncache_update_shutdown_ev(struct Curl_multi *multi,
     /* TODO: compare with previous pollset and update events */
     DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] "
                  "set socket=%d events=%d on #%" CURL_FORMAT_CURL_OFF_T,
-                 connc->cache_id, ps.sockets[i], ps.actions[i],
+                 multi->conn_cache.cache_id, ps.sockets[i], ps.actions[i],
                  conn->connection_id));
     multi->in_callback = TRUE;
     rc = multi->socket_cb(data, ps.sockets[i], ps.actions[i],

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -974,7 +974,7 @@ static void connc_disconnect(struct Curl_easy *data,
     data = connc->closure_handle;
 
   /* the transfer must be detached from the connection */
-  DEBUGASSERT(!data->conn);
+  DEBUGASSERT(data && !data->conn);
 
   if(connc && connc->multi && connc->multi->socket_cb) {
     unsigned int i;

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -754,14 +754,14 @@ void Curl_conncache_disconnect(struct Curl_easy *data,
 
   if(data->multi) {
     /* Add it to the multi's conncache for shutdown handling */
-    DEBUGF(infof(data, "[CCACHE] %s #%" CURL_FORMAT_CURL_OFF_T,
-                 aborted? "closing" : "shutting down", conn->connection_id));
+    infof(data, "%s connection #%" CURL_FORMAT_CURL_OFF_T,
+          aborted? "closing" : "shutting down", conn->connection_id);
     connc_discard_conn(&data->multi->conn_cache, data, conn, aborted);
   }
   else {
     /* No multi available. Make a best-effort shutdown + close */
-    DEBUGF(infof(data, "[CCACHE] closing #%" CURL_FORMAT_CURL_OFF_T,
-                 conn->connection_id));
+    infof(data, "closing connection #%" CURL_FORMAT_CURL_OFF_T,
+          conn->connection_id);
     DEBUGASSERT(!conn->bundle);
     connc_run_conn_shutdown_handler(data, conn);
     connc_disconnect(data, conn, NULL, !aborted);

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -1034,9 +1034,9 @@ static CURLcode conncache_update_shutdown_ev(struct Curl_multi *multi,
     return CURLE_FAILED_INIT;
 
   for(i = 0; i < ps.num; ++i) {
-    /* TODO: compare with previous pollset and update events */
     DEBUGF(infof(data, "[CCACHE-%" CURL_FORMAT_CURL_OFF_T "] "
-                 "set socket=%d events=%d on #%" CURL_FORMAT_CURL_OFF_T,
+                 "set socket=%" CURL_FORMAT_SOCKET_T
+                 " events=%d on #%" CURL_FORMAT_CURL_OFF_T,
                  multi->conn_cache.cache_id, ps.sockets[i], ps.actions[i],
                  conn->connection_id));
     multi->in_callback = TRUE;

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -35,15 +35,26 @@
 #include "timeval.h"
 
 struct connectdata;
+struct curl_pollfds;
+struct curl_waitfds;
+struct Curl_multi;
+
+struct connshutdowns {
+  struct Curl_llist conn_list;  /* The connectdata to shut down */
+  BIT(iter_locked);  /* TRUE while iterating the list */
+};
 
 struct conncache {
   struct Curl_hash hash;
   size_t num_conn;
+  curl_off_t cache_id;
   curl_off_t next_connection_id;
   curl_off_t next_easy_id;
   struct curltime last_cleanup;
+  struct connshutdowns shutdowns;
   /* handle used for closing cached connections */
   struct Curl_easy *closure_handle;
+  struct Curl_multi *multi; /* Optional, set if cache belongs to multi */
 };
 
 #define BUNDLE_NO_MULTIUSE -1
@@ -84,8 +95,12 @@ struct connectbundle {
   struct Curl_llist conn_list;  /* The connectdata members of the bundle */
 };
 
-/* returns 1 on error, 0 is fine */
-int Curl_conncache_init(struct conncache *, size_t size);
+/* Init the cache, pass multi only if cache is owned by it.
+ * returns 1 on error, 0 is fine.
+ */
+int Curl_conncache_init(struct conncache *,
+                        struct Curl_multi *multi,
+                        size_t size);
 void Curl_conncache_destroy(struct conncache *connc);
 
 /* return the correct bundle, to a host or a proxy */
@@ -118,5 +133,33 @@ struct connectdata *
 Curl_conncache_extract_oldest(struct Curl_easy *data);
 void Curl_conncache_close_all_connections(struct conncache *connc);
 void Curl_conncache_print(struct conncache *connc);
+
+/**
+ * Discard the connection. If `aborted` is FALSE, the connection
+ * will be shut down first before discarding. If the shutdown
+ * is not immediately complete, the connection
+ * will be placed into the cache's shutdown queue.
+ */
+void Curl_conncache_discard_conn(struct Curl_easy *data,
+                                 struct connectdata *conn,
+                                 bool aborted, bool lock);
+
+/**
+ * Add sockets and POLLIN/OUT flags for connections handled by the cache.
+ */
+CURLcode Curl_conncache_add_pollfds(struct conncache *connc,
+                                    struct curl_pollfds *cpfds);
+CURLcode Curl_conncache_add_waitfds(struct conncache *connc,
+                                    struct curl_waitfds *cwfds);
+
+/**
+ * Perform maintenance on connections in the cache. Specifically,
+ * progress the shutdown of connections in the queue.
+ */
+void Curl_conncache_multi_perform(struct Curl_multi *multi);
+
+void Curl_conncache_multi_socket(struct Curl_multi *multi,
+                                 curl_socket_t s, int ev_bitmask);
+void Curl_conncache_multi_close_all(struct Curl_multi *multi);
 
 #endif /* HEADER_CURL_CONNCACHE_H */

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -134,14 +134,14 @@ void Curl_conncache_close_all_connections(struct conncache *connc);
 void Curl_conncache_print(struct conncache *connc);
 
 /**
- * Discard the connection. If `aborted` is FALSE, the connection
+ * Tear down the connection. If `aborted` is FALSE, the connection
  * will be shut down first before discarding. If the shutdown
  * is not immediately complete, the connection
  * will be placed into the cache's shutdown queue.
  */
-void Curl_conncache_discard_conn(struct Curl_easy *data,
-                                 struct connectdata *conn,
-                                 bool aborted, bool lock);
+void Curl_conncache_disconnect(struct Curl_easy *data,
+                               struct connectdata *conn,
+                               bool aborted);
 
 /**
  * Add sockets and POLLIN/OUT flags for connections handled by the cache.

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -47,7 +47,6 @@ struct connshutdowns {
 struct conncache {
   struct Curl_hash hash;
   size_t num_conn;
-  curl_off_t cache_id;
   curl_off_t next_connection_id;
   curl_off_t next_easy_id;
   struct curltime last_cleanup;

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1443,8 +1443,7 @@ CURLcode Curl_once_resolved(struct Curl_easy *data, bool *protocol_done)
 
   if(result) {
     Curl_detach_connection(data);
-    Curl_conncache_remove_conn(data, conn, TRUE);
-    Curl_disconnect(data, conn, TRUE);
+    Curl_conncache_discard_conn(data, conn, TRUE, TRUE);
   }
   return result;
 }

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1443,7 +1443,8 @@ CURLcode Curl_once_resolved(struct Curl_easy *data, bool *protocol_done)
 
   if(result) {
     Curl_detach_connection(data);
-    Curl_conncache_discard_conn(data, conn, TRUE, TRUE);
+    Curl_conncache_remove_conn(data, conn, TRUE);
+    Curl_disconnect(data, conn, TRUE);
   }
   return result;
 }

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -148,6 +148,8 @@ struct Curl_multi {
 
   long max_total_connections; /* if >0, a fixed limit of the maximum number
                                  of connections in total */
+  long max_shutdown_connections; /* if >0, a fixed limit of the maximum number
+                                 of connections in shutdown handling */
 
   /* timer callback and user data pointer for the *socket() API */
   curl_multi_timer_callback timer_cb;

--- a/lib/share.c
+++ b/lib/share.c
@@ -26,6 +26,7 @@
 
 #include <curl/curl.h>
 #include "urldata.h"
+#include "connect.h"
 #include "share.h"
 #include "psl.h"
 #include "vtls/vtls.h"
@@ -119,7 +120,7 @@ curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
       break;
 
     case CURL_LOCK_DATA_CONNECT:
-      if(Curl_conncache_init(&share->conn_cache, 103))
+      if(Curl_conncache_init(&share->conn_cache, NULL, 103))
         res = CURLSHE_NOMEM;
       break;
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -556,19 +556,7 @@ CURLcode Curl_open(struct Curl_easy **curl)
   return result;
 }
 
-static void conn_shutdown(struct Curl_easy *data)
-{
-  DEBUGASSERT(data);
-  infof(data, "Closing connection");
-
-  /* possible left-overs from the async name resolvers */
-  Curl_resolver_cancel(data);
-
-  Curl_conn_close(data, SECONDARYSOCKET);
-  Curl_conn_close(data, FIRSTSOCKET);
-}
-
-static void conn_free(struct Curl_easy *data, struct connectdata *conn)
+void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
 {
   size_t i;
 
@@ -607,78 +595,6 @@ static void conn_free(struct Curl_easy *data, struct connectdata *conn)
 #endif
 
   free(conn); /* free all the connection oriented data */
-}
-
-/*
- * Disconnects the given connection. Note the connection may not be the
- * primary connection, like when freeing room in the connection cache or
- * killing of a dead old connection.
- *
- * A connection needs an easy handle when closing down. We support this passed
- * in separately since the connection to get closed here is often already
- * disassociated from an easy handle.
- *
- * This function MUST NOT reset state in the Curl_easy struct if that
- * isn't strictly bound to the life-time of *this* particular connection.
- *
- */
-
-void Curl_disconnect(struct Curl_easy *data,
-                     struct connectdata *conn, bool dead_connection)
-{
-  /* there must be a connection to close */
-  DEBUGASSERT(conn);
-
-  /* it must be removed from the connection cache */
-  DEBUGASSERT(!conn->bundle);
-
-  /* there must be an associated transfer */
-  DEBUGASSERT(data);
-
-  /* the transfer must be detached from the connection */
-  DEBUGASSERT(!data->conn);
-
-  DEBUGF(infof(data, "Curl_disconnect(conn #%"
-         CURL_FORMAT_CURL_OFF_T ", dead=%d)",
-         conn->connection_id, dead_connection));
-  /*
-   * If this connection isn't marked to force-close, leave it open if there
-   * are other users of it
-   */
-  if(CONN_INUSE(conn) && !dead_connection) {
-    DEBUGF(infof(data, "Curl_disconnect when inuse: %zu", CONN_INUSE(conn)));
-    return;
-  }
-
-  if(conn->dns_entry) {
-    Curl_resolv_unlock(data, conn->dns_entry);
-    conn->dns_entry = NULL;
-  }
-
-  /* Cleanup NTLM connection-related data */
-  Curl_http_auth_cleanup_ntlm(conn);
-
-  /* Cleanup NEGOTIATE connection-related data */
-  Curl_http_auth_cleanup_negotiate(conn);
-
-  if(conn->connect_only)
-    /* treat the connection as dead in CONNECT_ONLY situations */
-    dead_connection = TRUE;
-
-  /* temporarily attach the connection to this transfer handle for the
-     disconnect and shutdown */
-  Curl_attach_connection(data, conn);
-
-  if(conn->handler && conn->handler->disconnect)
-    /* This is set if protocol-specific cleanups should be made */
-    conn->handler->disconnect(data, conn, dead_connection);
-
-  conn_shutdown(data);
-
-  /* detach it again */
-  Curl_detach_connection(data);
-
-  conn_free(data, conn);
 }
 
 /*
@@ -824,6 +740,7 @@ static bool prune_if_dead(struct connectdata *conn,
          * any time (HTTP/2 PING for example), the protocol handler needs
          * to install its own `connection_check` callback.
          */
+        DEBUGF(infof(data, "connection has input pending, not reusable"));
         dead = TRUE;
       }
       Curl_detach_connection(data);
@@ -881,8 +798,8 @@ static void prune_dead_connections(struct Curl_easy *data)
 
       /* connection previously removed from cache in prune_if_dead() */
 
-      /* disconnect it */
-      Curl_disconnect(data, pruned, TRUE);
+      /* shut it down */
+      Curl_conncache_discard_conn(data, pruned, FALSE, TRUE);
     }
     CONNCACHE_LOCK(data);
     data->state.conn_cache->last_cleanup = now;
@@ -1295,7 +1212,7 @@ ConnectionExists(struct Curl_easy *data,
     }
     else if(prune_if_dead(check, data)) {
       /* disconnect it */
-      Curl_disconnect(data, check, TRUE);
+      Curl_conncache_discard_conn(data, check, FALSE, TRUE);
       continue;
     }
 
@@ -3333,7 +3250,7 @@ static void reuse_conn(struct Curl_easy *data,
   /* reuse init */
   existing->bits.reuse = TRUE; /* yes, we're reusing here */
 
-  conn_free(data, temp);
+  Curl_conn_free(data, temp);
 }
 
 /**
@@ -3642,7 +3559,7 @@ static CURLcode create_conn(struct Curl_easy *data,
         CONNCACHE_UNLOCK(data);
 
         if(conn_candidate)
-          Curl_disconnect(data, conn_candidate, FALSE);
+          Curl_conncache_discard_conn(data, conn_candidate, FALSE, FALSE);
         else {
           infof(data, "No more connections allowed to host: %zu",
                 max_host_connections);
@@ -3662,7 +3579,7 @@ static CURLcode create_conn(struct Curl_easy *data,
       /* The cache is full. Let's see if we can kill a connection. */
       conn_candidate = Curl_conncache_extract_oldest(data);
       if(conn_candidate)
-        Curl_disconnect(data, conn_candidate, FALSE);
+        Curl_conncache_discard_conn(data, conn_candidate, FALSE, FALSE);
       else
 #ifndef CURL_DISABLE_DOH
         if(data->set.dohfor)
@@ -3678,7 +3595,7 @@ static CURLcode create_conn(struct Curl_easy *data,
     if(!connections_available) {
       infof(data, "No connections available.");
 
-      conn_free(data, conn);
+      Curl_conn_free(data, conn);
       *in_connect = NULL;
 
       result = CURLE_NO_CONNECTION_AVAILABLE;
@@ -3828,8 +3745,7 @@ CURLcode Curl_connect(struct Curl_easy *data,
     /* We're not allowed to return failure with memory left allocated in the
        connectdata struct, free those here */
     Curl_detach_connection(data);
-    Curl_conncache_remove_conn(data, conn, TRUE);
-    Curl_disconnect(data, conn, TRUE);
+    Curl_conncache_discard_conn(data, conn, TRUE, TRUE);
   }
 
   return result;

--- a/lib/url.h
+++ b/lib/url.h
@@ -37,6 +37,8 @@ void Curl_freeset(struct Curl_easy *data);
 CURLcode Curl_uc_to_curlcode(CURLUcode uc);
 CURLcode Curl_close(struct Curl_easy **datap); /* opposite of curl_open() */
 CURLcode Curl_connect(struct Curl_easy *, bool *async, bool *protocol_connect);
+void Curl_disconnect(struct Curl_easy *data,
+                     struct connectdata *, bool aborted);
 CURLcode Curl_setup_conn(struct Curl_easy *data,
                          bool *protocol_done);
 void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn);

--- a/lib/url.h
+++ b/lib/url.h
@@ -37,10 +37,9 @@ void Curl_freeset(struct Curl_easy *data);
 CURLcode Curl_uc_to_curlcode(CURLUcode uc);
 CURLcode Curl_close(struct Curl_easy **datap); /* opposite of curl_open() */
 CURLcode Curl_connect(struct Curl_easy *, bool *async, bool *protocol_connect);
-void Curl_disconnect(struct Curl_easy *data,
-                     struct connectdata *, bool dead_connection);
 CURLcode Curl_setup_conn(struct Curl_easy *data,
                          bool *protocol_done);
+void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn);
 CURLcode Curl_parse_login_details(const char *login, const size_t len,
                                   char **userptr, char **passwdptr,
                                   char **optionsptr);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -546,6 +546,9 @@ struct ConnectBits {
                          accept() */
   BIT(parallel_connect); /* set TRUE when a parallel connect attempt has
                             started (happy eyeballs) */
+  BIT(aborted); /* connection was aborted, e.g. in unclean state */
+  BIT(shutdown_handler); /* connection shutdown: handler shut down */
+  BIT(shutdown_filters); /* connection shutdown: filters shut down */
 };
 
 struct hostname {

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -1080,7 +1080,7 @@ static CURLcode bearssl_shutdown(struct Curl_cfilter *cf,
   CURLcode result;
 
   DEBUGASSERT(backend);
-  if(!backend->active || connssl->shutdown) {
+  if(!backend->active || cf->shutdown) {
     *done = TRUE;
     return CURLE_OK;
   }
@@ -1101,7 +1101,7 @@ static CURLcode bearssl_shutdown(struct Curl_cfilter *cf,
   else
     CURL_TRC_CF(data, cf, "shutdown error: %d", result);
 
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1112,15 +1112,10 @@ static void bearssl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
     (struct bearssl_ssl_backend_data *)connssl->backend;
   size_t i;
 
+  (void)data;
   DEBUGASSERT(backend);
 
-  if(backend->active) {
-    if(!connssl->shutdown) {
-      bool done;
-      bearssl_shutdown(cf, data, TRUE, &done);
-    }
-    backend->active = FALSE;
-  }
+  backend->active = FALSE;
   if(backend->anchors) {
     for(i = 0; i < backend->anchors_len; ++i)
       free(backend->anchors[i].dn.data);

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1822,7 +1822,7 @@ static CURLcode gtls_shutdown(struct Curl_cfilter *cf,
   size_t i;
 
   DEBUGASSERT(backend);
-  if(!backend->gtls.session || connssl->shutdown) {
+  if(!backend->gtls.session || cf->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -1876,7 +1876,7 @@ static CURLcode gtls_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1891,10 +1891,6 @@ static void gtls_close(struct Curl_cfilter *cf,
   DEBUGASSERT(backend);
   CURL_TRC_CF(data, cf, "close");
   if(backend->gtls.session) {
-    if(!connssl->shutdown) {
-      bool done;
-      gtls_shutdown(cf, data, TRUE, &done);
-    }
     gnutls_deinit(backend->gtls.session);
     backend->gtls.session = NULL;
   }

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1274,7 +1274,7 @@ static CURLcode mbedtls_shutdown(struct Curl_cfilter *cf,
 
   DEBUGASSERT(backend);
 
-  if(!backend->initialized || connssl->shutdown) {
+  if(!backend->initialized || cf->shutdown) {
     *done = TRUE;
     return CURLE_OK;
   }
@@ -1346,7 +1346,7 @@ static CURLcode mbedtls_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1356,13 +1356,9 @@ static void mbedtls_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;
 
+  (void)data;
   DEBUGASSERT(backend);
   if(backend->initialized) {
-    if(!connssl->shutdown) {
-      bool done;
-      mbedtls_shutdown(cf, data, TRUE, &done);
-    }
-
     mbedtls_pk_free(&backend->pk);
     mbedtls_x509_crt_free(&backend->clicert);
     mbedtls_x509_crt_free(&backend->cacert);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2482,7 +2482,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
     (struct schannel_ssl_backend_data *)connssl->backend;
   CURLcode result = CURLE_OK;
 
-  if(connssl->shutdown) {
+  if(cf->shutdown) {
     *done = TRUE;
     return CURLE_OK;
   }
@@ -2499,7 +2499,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
           connssl->peer.hostname, connssl->peer.port);
   }
 
-  if(!backend->ctxt || connssl->shutdown) {
+  if(!backend->ctxt || cf->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -2606,7 +2606,7 @@ static CURLcode schannel_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -2618,13 +2618,6 @@ static void schannel_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   DEBUGASSERT(data);
   DEBUGASSERT(backend);
-
-  if(backend->cred && backend->ctxt &&
-     cf->connected && !connssl->shutdown &&
-     cf->next && cf->next->connected && !connssl->peer_closed) {
-    bool done;
-    (void)schannel_shutdown(cf, data, TRUE, &done);
-  }
 
   /* free SSPI Schannel API security context handle */
   if(backend->ctxt) {

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2575,7 +2575,7 @@ static CURLcode sectransp_shutdown(struct Curl_cfilter *cf,
   size_t i;
 
   DEBUGASSERT(backend);
-  if(!backend->ssl_ctx || connssl->shutdown) {
+  if(!backend->ssl_ctx || cf->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -2638,7 +2638,7 @@ static CURLcode sectransp_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -2654,12 +2654,6 @@ static void sectransp_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   if(backend->ssl_ctx) {
     CURL_TRC_CF(data, cf, "close");
-    if(cf->connected && !connssl->shutdown &&
-       cf->next && cf->next->connected && !connssl->peer_closed) {
-      bool done;
-      (void)sectransp_shutdown(cf, data, TRUE, &done);
-    }
-
 #if CURL_BUILD_MAC_10_8 || CURL_BUILD_IOS
     if(SSLCreateContext)
       CFRelease(backend->ssl_ctx);

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1757,17 +1757,17 @@ static CURLcode ssl_cf_shutdown(struct Curl_cfilter *cf,
                                 struct Curl_easy *data,
                                 bool *done)
 {
-  struct ssl_connect_data *connssl = cf->ctx;
-  struct cf_call_data save;
   CURLcode result = CURLE_OK;
 
   *done = TRUE;
-  if(!connssl->shutdown) {
+  if(!cf->shutdown) {
+    struct cf_call_data save;
+
     CF_DATA_SAVE(save, cf, data);
     result = Curl_ssl->shut_down(cf, data, TRUE, done);
     CURL_TRC_CF(data, cf, "cf_shutdown -> %d, done=%d", result, *done);
     CF_DATA_RESTORE(cf, save);
-    connssl->shutdown = (result || *done);
+    cf->shutdown = (result || *done);
   }
   return result;
 }
@@ -2052,7 +2052,7 @@ static CURLcode vtls_shutdown_blocking(struct Curl_cfilter *cf,
   timediff_t timeout_ms;
   int what, loop = 10;
 
-  if(connssl->shutdown) {
+  if(cf->shutdown) {
     *done = TRUE;
     return CURLE_OK;
   }
@@ -2091,7 +2091,7 @@ static CURLcode vtls_shutdown_blocking(struct Curl_cfilter *cf,
   }
 out:
   CF_DATA_RESTORE(cf, save);
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -94,7 +94,6 @@ struct ssl_connect_data {
   int io_need;                      /* TLS signals special SEND/RECV needs */
   BIT(use_alpn);                    /* if ALPN shall be used in handshake */
   BIT(peer_closed);                 /* peer has closed connection */
-  BIT(shutdown);                    /* graceful close notify finished */
 };
 
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1352,7 +1352,7 @@ static CURLcode wolfssl_shutdown(struct Curl_cfilter *cf,
   int nread, err;
 
   DEBUGASSERT(wctx);
-  if(!wctx->handle || connssl->shutdown) {
+  if(!wctx->handle || cf->shutdown) {
     *done = TRUE;
     goto out;
   }
@@ -1369,17 +1369,17 @@ static CURLcode wolfssl_shutdown(struct Curl_cfilter *cf,
       bool input_pending;
       /* Yes, it did. */
       if(!send_shutdown) {
-        connssl->shutdown = TRUE;
         CURL_TRC_CF(data, cf, "SSL shutdown received, not sending");
+        *done = TRUE;
         goto out;
       }
       else if(!cf->next->cft->is_alive(cf->next, data, &input_pending)) {
         /* Server closed the connection after its closy notify. It
          * seems not interested to see our close notify, so do not
          * send it. We are done. */
-        connssl->peer_closed = TRUE;
-        connssl->shutdown = TRUE;
         CURL_TRC_CF(data, cf, "peer closed connection");
+        connssl->peer_closed = TRUE;
+        *done = TRUE;
         goto out;
       }
     }
@@ -1430,7 +1430,7 @@ static CURLcode wolfssl_shutdown(struct Curl_cfilter *cf,
   }
 
 out:
-  connssl->shutdown = (result || *done);
+  cf->shutdown = (result || *done);
   return result;
 }
 
@@ -1445,11 +1445,6 @@ static void wolfssl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   DEBUGASSERT(backend);
 
   if(backend->handle) {
-    if(cf->connected && !connssl->shutdown &&
-       cf->next && cf->next->connected && !connssl->peer_closed) {
-      bool done;
-      (void)wolfssl_shutdown(cf, data, TRUE, &done);
-    }
     wolfSSL_free(backend->handle);
     backend->handle = NULL;
   }

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2579,6 +2579,9 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
     }
     start = tvnow();
 #ifdef DEBUGBUILD
+    if(getenv("CURL_FORBID_REUSE"))
+      (void)curl_easy_setopt(per->curl, CURLOPT_FORBID_REUSE, 1L);
+
     if(global->test_event_based)
       result = curl_easy_perform_ev(per->curl);
     else

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,7 +47,7 @@ def pytest_report_header(config):
         ])
     if env.has_vsftpd():
         report.extend([
-            f'  VsFTPD: {env.vsftpd_version()}, ftp:{env.ftp_port}'
+            f'  VsFTPD: {env.vsftpd_version()}, ftp:{env.ftp_port}, ftps:{env.ftps_port}'
         ])
     return '\n'.join(report)
 

--- a/tests/data/test1542
+++ b/tests/data/test1542
@@ -58,11 +58,11 @@ Accept: */*
 == Info: Connection #0 to host %HOSTIP left intact
 == Info: Connection #0 to host %HOSTIP left intact
 == Info: Connection #0 to host %HOSTIP left intact
-== Info: Closing connection
+== Info: Shutting down connection #0
 == Info: Connection #1 to host %HOSTIP left intact
 </file>
 <stripfile>
-$_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))
+$_ = '' if (($_ !~ /left intact/) && ($_ !~ /(Closing|Shutting down) connection/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test1542
+++ b/tests/data/test1542
@@ -58,12 +58,11 @@ Accept: */*
 == Info: Connection #0 to host %HOSTIP left intact
 == Info: Connection #0 to host %HOSTIP left intact
 == Info: Connection #0 to host %HOSTIP left intact
-== Info: [CCACHE] shutting down #0
-== Info: [CCACHE] closing #0
+== Info: shutting down connection #0
 == Info: Connection #1 to host %HOSTIP left intact
 </file>
 <stripfile>
-$_ = '' if (($_ !~ /left intact/) && ($_ !~ /(closing|shutting down) #\d+/))
+$_ = '' if (($_ !~ /left intact/) && ($_ !~ /(closing|shutting down) connection #\d+/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/data/test1542
+++ b/tests/data/test1542
@@ -58,11 +58,12 @@ Accept: */*
 == Info: Connection #0 to host %HOSTIP left intact
 == Info: Connection #0 to host %HOSTIP left intact
 == Info: Connection #0 to host %HOSTIP left intact
-== Info: Shutting down connection #0
+== Info: [CCACHE] shutting down #0
+== Info: [CCACHE] closing #0
 == Info: Connection #1 to host %HOSTIP left intact
 </file>
 <stripfile>
-$_ = '' if (($_ !~ /left intact/) && ($_ !~ /(Closing|Shutting down) connection/))
+$_ = '' if (($_ !~ /left intact/) && ($_ !~ /(closing|shutting down) #\d+/))
 </stripfile>
 </verify>
 </testcase>

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -159,6 +159,7 @@ struct transfer {
 
 static size_t transfer_count = 1;
 static struct transfer *transfers;
+static int forbid_reuse = 0;
 
 static struct transfer *get_transfer_for_easy(CURL *easy)
 {
@@ -239,6 +240,8 @@ static int setup(CURL *hnd, const char *url, struct transfer *t,
   curl_easy_setopt(hnd, CURLOPT_NOPROGRESS, 0L);
   curl_easy_setopt(hnd, CURLOPT_XFERINFOFUNCTION, my_progress_cb);
   curl_easy_setopt(hnd, CURLOPT_XFERINFODATA, t);
+  if(forbid_reuse)
+    curl_easy_setopt(hnd, CURLOPT_FORBID_REUSE, 1L);
 
   /* please be verbose */
   if(verbose) {
@@ -288,13 +291,16 @@ int main(int argc, char *argv[])
   int http_version = CURL_HTTP_VERSION_2_0;
   int ch;
 
-  while((ch = getopt(argc, argv, "ahm:n:A:F:P:V:")) != -1) {
+  while((ch = getopt(argc, argv, "afhm:n:A:F:P:V:")) != -1) {
     switch(ch) {
     case 'h':
       usage(NULL);
       return 2;
     case 'a':
       abort_paused = 1;
+      break;
+    case 'f':
+      forbid_reuse = 1;
       break;
     case 'm':
       max_parallel = (size_t)strtol(optarg, NULL, 10);

--- a/tests/http/test_19_shutdown.py
+++ b/tests/http/test_19_shutdown.py
@@ -76,7 +76,8 @@ class TestShutdown:
         if not env.curl_is_debug():
             pytest.skip('only works for curl debug builds')
         curl = CurlClient(env=env, run_env={
-            'CURL_GRACEFUL_SHUTDOWN': '2000'
+            'CURL_GRACEFUL_SHUTDOWN': '2000',
+            'CURL_DEBUG': 'ssl'
         })
         url = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-1]'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_tcpdump=True, extra_args=[

--- a/tests/http/test_19_shutdown.py
+++ b/tests/http/test_19_shutdown.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+import difflib
+import filecmp
+import logging
+import os
+import re
+from datetime import timedelta
+import pytest
+
+from testenv import Env, CurlClient, LocalClient
+
+
+log = logging.getLogger(__name__)
+
+
+class TestShutdown:
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, httpd, nghttpx):
+        if env.have_h3():
+            nghttpx.start_if_needed()
+        httpd.clear_extra_configs()
+        httpd.reload()
+
+    @pytest.fixture(autouse=True, scope='class')
+    def _class_scope(self, env, httpd):
+        indir = httpd.docs_dir
+        env.make_data_file(indir=indir, fname="data-10k", fsize=10*1024)
+        env.make_data_file(indir=indir, fname="data-100k", fsize=100*1024)
+        env.make_data_file(indir=indir, fname="data-1m", fsize=1024*1024)
+
+    # check with `tcpdump` that we see curl TCP RST packets
+    @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
+    @pytest.mark.parametrize("proto", ['http/1.1'])
+    def test_19_01_check_tcp_rst(self, env: Env, httpd, repeat, proto):
+        if env.ci_run:
+            pytest.skip("seems not to work in CI")
+        curl = CurlClient(env=env)
+        url = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-1]'
+        r = curl.http_download(urls=[url], alpn_proto=proto, with_tcpdump=True, extra_args=[
+            '--parallel'
+        ])
+        r.check_response(http_status=200, count=2)
+        assert r.tcpdump
+        assert len(r.tcpdump.stats) != 0, f'Expected TCP RSTs packets: {r.tcpdump.stderr}'
+
+    # check with `tcpdump` that we do NOT see TCP RST when CURL_GRACEFUL_SHUTDOWN set
+    @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
+    def test_19_02_check_shutdown(self, env: Env, httpd, repeat, proto):
+        if not env.curl_is_debug():
+            pytest.skip('only works for curl debug builds')
+        curl = CurlClient(env=env, run_env={
+            'CURL_GRACEFUL_SHUTDOWN': '2000'
+        })
+        url = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-1]'
+        r = curl.http_download(urls=[url], alpn_proto=proto, with_tcpdump=True, extra_args=[
+            '--parallel'
+        ])
+        r.check_response(http_status=200, count=2)
+        assert r.tcpdump
+        assert len(r.tcpdump.stats) == 0, f'Unexpected TCP RSTs packets'
+
+    # run downloads where the server closes the connection after each request
+    @pytest.mark.parametrize("proto", ['http/1.1'])
+    def test_19_03_shutdown_by_server(self, env: Env, httpd, repeat, proto):
+        if not env.curl_is_debug():
+            pytest.skip('only works for curl debug builds')
+        count = 10
+        curl = CurlClient(env=env, run_env={
+            'CURL_GRACEFUL_SHUTDOWN': '2000',
+            'CURL_DEBUG': 'ssl'
+        })
+        url = f'https://{env.authority_for(env.domain1, proto)}/curltest/tweak/?'\
+            f'id=[0-{count-1}]&with_cl&close'
+        r = curl.http_download(urls=[url], alpn_proto=proto)
+        r.check_response(http_status=200, count=count)
+        shutdowns = [l for l in r.trace_lines if re.match(r'.*CCACHE-\d+\] shutdown #\d+, done=1', l)]
+        assert len(shutdowns) == count, f'{shutdowns}'
+
+    # run downloads with CURLOPT_FORBID_REUSE set, meaning *we* close
+    # the connection after each request
+    @pytest.mark.parametrize("proto", ['http/1.1'])
+    def test_19_04_shutdown_by_curl(self, env: Env, httpd, proto, repeat):
+        if not env.curl_is_debug():
+            pytest.skip('only works for curl debug builds')
+        count = 10
+        docname = 'data.json'
+        url = f'https://localhost:{env.https_port}/{docname}'
+        client = LocalClient(name='h2-download', env=env, run_env={
+            'CURL_GRACEFUL_SHUTDOWN': '2000',
+            'CURL_DEBUG': 'ssl'
+        })
+        if not client.exists():
+            pytest.skip(f'example client not built: {client.name}')
+        r = client.run(args=[
+             '-n', f'{count}', '-f', '-V', proto, url
+        ])
+        r.check_exit_code(0)
+        shutdowns = [l for l in r.trace_lines if re.match(r'.*CCACHE-\d+\] shutdown #\d+, done=1', l)]
+        assert len(shutdowns) == count, f'{shutdowns}'
+
+    # run event-based downloads with CURLOPT_FORBID_REUSE set, meaning *we* close
+    # the connection after each request
+    @pytest.mark.parametrize("proto", ['http/1.1'])
+    def test_19_05_event_shutdown_by_server(self, env: Env, httpd, proto, repeat):
+        if not env.curl_is_debug():
+            pytest.skip('only works for curl debug builds')
+        count = 10
+        curl = CurlClient(env=env, run_env={
+            # forbid connection reuse to trigger shutdowns after transfer
+            'CURL_FORBID_REUSE': '1',
+            # make socket receives block 50% of the time to delay shutdown
+            'CURL_DBG_SOCK_RBLOCK': '50',
+            'CURL_DEBUG': 'ssl'
+        })
+        url = f'https://{env.authority_for(env.domain1, proto)}/curltest/tweak/?'\
+            f'id=[0-{count-1}]&with_cl&'
+        r = curl.http_download(urls=[url], alpn_proto=proto, extra_args=[
+            '--test-event'
+        ])
+        r.check_response(http_status=200, count=count)
+        # check that we closed all connections
+        closings = [l for l in r.trace_lines if re.match(r'.*CCACHE-\d+\] closing #\d+', l)]
+        assert len(closings) == count, f'{closings}'
+        # check that all connection sockets were removed from event
+        removes = [l for l in r.trace_lines if re.match(r'.*socket cb: socket \d+ REMOVED', l)]
+        assert len(removes) == count, f'{removes}'
+
+

--- a/tests/http/test_19_shutdown.py
+++ b/tests/http/test_19_shutdown.py
@@ -100,7 +100,7 @@ class TestShutdown:
             f'id=[0-{count-1}]&with_cl&close'
         r = curl.http_download(urls=[url], alpn_proto=proto)
         r.check_response(http_status=200, count=count)
-        shutdowns = [l for l in r.trace_lines if re.match(r'.*CCACHE-\d+\] shutdown #\d+, done=1', l)]
+        shutdowns = [l for l in r.trace_lines if re.match(r'.*CCACHE\] shutdown #\d+, done=1', l)]
         assert len(shutdowns) == count, f'{shutdowns}'
 
     # run downloads with CURLOPT_FORBID_REUSE set, meaning *we* close
@@ -122,7 +122,7 @@ class TestShutdown:
              '-n', f'{count}', '-f', '-V', proto, url
         ])
         r.check_exit_code(0)
-        shutdowns = [l for l in r.trace_lines if re.match(r'.*CCACHE-\d+\] shutdown #\d+, done=1', l)]
+        shutdowns = [l for l in r.trace_lines if re.match(r'.*CCACHE\] shutdown #\d+, done=1', l)]
         assert len(shutdowns) == count, f'{shutdowns}'
 
     # run event-based downloads with CURLOPT_FORBID_REUSE set, meaning *we* close
@@ -146,7 +146,7 @@ class TestShutdown:
         ])
         r.check_response(http_status=200, count=count)
         # check that we closed all connections
-        closings = [l for l in r.trace_lines if re.match(r'.*CCACHE-\d+\] closing #\d+', l)]
+        closings = [l for l in r.trace_lines if re.match(r'.*CCACHE\] closing #\d+', l)]
         assert len(closings) == count, f'{closings}'
         # check that all connection sockets were removed from event
         removes = [l for l in r.trace_lines if re.match(r'.*socket cb: socket \d+ REMOVED', l)]

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -136,6 +136,33 @@ class TestVsFTPD:
         if os.path.exists(path):
             return os.remove(path)
 
+    # check with `tcpdump` if curl causes any TCP RST packets
+    @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
+    def test_30_06_shutdownh_download(self, env: Env, vsftpd: VsFTPD, repeat):
+        docname = 'data-1k'
+        curl = CurlClient(env=env)
+        count = 1
+        url = f'ftp://{env.ftp_domain}:{vsftpd.port}/{docname}?[0-{count-1}]'
+        r = curl.ftp_get(urls=[url], with_stats=True, with_tcpdump=True)
+        r.check_stats(count=count, http_status=226)
+        assert r.tcpdump
+        assert len(r.tcpdump.stats) == 0, f'Unexpected TCP RSTs packets'
+
+    # check with `tcpdump` if curl causes any TCP RST packets
+    @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
+    def test_30_07_shutdownh_upload(self, env: Env, vsftpd: VsFTPD, repeat):
+        docname = 'upload-1k'
+        curl = CurlClient(env=env)
+        srcfile = os.path.join(env.gen_dir, docname)
+        dstfile = os.path.join(vsftpd.docs_dir, docname)
+        self._rmf(dstfile)
+        count = 1
+        url = f'ftp://{env.ftp_domain}:{vsftpd.port}/'
+        r = curl.ftp_upload(urls=[url], fupload=f'{srcfile}', with_stats=True, with_tcpdump=True)
+        r.check_stats(count=count, http_status=226)
+        assert r.tcpdump
+        assert len(r.tcpdump.stats) == 0, f'Unexpected TCP RSTs packets'
+
     def check_downloads(self, client, srcfile: str, count: int,
                         complete: bool = True):
         for i in range(count):

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -27,6 +27,7 @@
 import logging
 import os
 import re
+import shutil
 import socket
 import subprocess
 import sys
@@ -203,6 +204,8 @@ class EnvConfig:
             except Exception as e:
                 self.vsftpd = None
 
+        self._tcpdump = shutil.which('tcpdump')
+
     @property
     def httpd_version(self):
         if self._httpd_version is None and self.apxs is not None:
@@ -263,6 +266,10 @@ class EnvConfig:
     @property
     def vsftpd_version(self):
         return self._vsftpd_version
+
+    @property
+    def tcpdmp(self) -> Optional[str]:
+        return self._tcpdump
 
 
 class Env:
@@ -382,6 +389,10 @@ class Env:
     @staticmethod
     def vsftpd_version() -> str:
         return Env.CONFIG.vsftpd_version
+
+    @staticmethod
+    def tcpdump() -> Optional[str]:
+        return Env.CONFIG.tcpdmp
 
     def __init__(self, pytestconfig=None):
         self._verbose = pytestconfig.option.verbose \


### PR DESCRIPTION
When libcurl discards a connection there are two phases this may go through: "shutdown" and "closing". If a connection is aborted, the shutdown phase is skipped and it is closed right away.

The connection filters attached to the connection implement the phases in their `do_shutdown()` and `do_close()` callbacks. Filters carry now a `shutdown` flag next to `connected` to keep track of the shutdown operation.

Filters are shut down from top to bottom. If a filter is not connected, its shutdown is skipped. Notable filters that *do* something during shutdown are HTTP/2 and TLS. HTTP/2 sends the GOAWAY frame. TLS sends its close notify and expects to receive a close notify from the server.

As sends and receives may EAGAIN on the network, a shutdown is often not successful right away and needs to poll the connection's socket(s). To facilitate this, such connections are placed on a new shutdown list inside the connection cache.

Since managing this list requires the cooperation of a multi handle, only the connection cache belonging to a multi handle is used. If a connection was in another cache when being discarded, it is removed there and added to the multi's cache shutdown list. If no multi handle is available at that time, the connection is shutdown and closed in a one-time, best-effort attempt.

When a multi handle is destroyed, all connection still on the shutdown list are discarded with a final shutdown attempt and close. In curl debug builds, the environment variable `CURL_GRACEFUL_SHUTDOWN` can be set to make this graceful with a timeout in milliseconds given by the variable.

The shutdown list is limited to the max number of connections configured for a multi cache. Set via CURLMOPT_MAX_TOTAL_CONNECTIONS. When the limit is reached, the oldest connection on the shutdown list is discarded.

### Operation
- In multi_wait() and multi_waitfds(), iterate over all shutdown connections in the multi's cache. Each such connection contributes sockets and POLLIN/OUT events.
- in multi_perform() call perform on the multi's cache to process the shutdown list.
- for event based multis (multi->socket_cb set), add the sockets and their poll events via the callback. When `multi_socket()` is invoked for a socket not known by an active transfer, forward this to the multi's cache for processing. On closing a connection, remove its socket(s) via the callback.

### TLS
TLS connection filters MUST NOT send close nofity messages in their `do_close()` implementation. The reason is that a TLS close notify signals a success. When a connection is aborted and skips its shutdown phase, the server needs to see a missing close notify to detect something has gone wrong.

### FTP
A graceful shutdown of FTP's data connection is performed implicitly before regarding the upload/download as complete and continuing on the control connection. For FTP without TLS, there is just the socket close happening. But with TLS, the sent/received close notify signals that the transfer is complete and healthy. Servers like `vsftpd` verify that and reject uploads without a TLS close notify.

### Tests
- added test_19_* for shutdown related tests
- test_19_01 and test_19_02 test for TCP RST packets which happen without a graceful shutdown and should no longer appear otherwise.
- add test_19_03 for handling shutdowns by the server
- add test_19_04 for handling shutdowns by curl
- add test_19_05 for event based shutdowny by server
- add test_30_06/07 and test_31_06/07 for shutdown checks on FTP up- and downloads.

## TODO

This PR handles graceful shutdown during `multi` operations without changes visible in the API. Enabling a graceful shutdown when a cache is destroyed is available to debug builds via environment variables only.

The maximum number of connections in shutdown is the maximum number configured or a connection cache. This is only available for caches owned by a multi handle, where `CURLMOPT_MAX_TOTAL_CONNECTIONS` can be used. 

There is a `data->set.shutdowntimeout`, but there is no `CURLOPT_SHUTDOWN_TIMEOUT_MS` to set it. Instead, the default, internal `DEFAULT_SHUTDOWN_TIMEOUT_MS` of 2 seconds it used then.

### Non-Features

For share caches, the discarded connections move into the multi's cache (if there is a multi, otherwise they are shut down and closed right away). If the multi is an "easy multi", the easy cleans up the multi when done and that in turns shutdown+closes all pending shutdowns. So with serial easy handles, as used in `curl`, there is no graceful shutdown going on in the background. I presume we can live with that.

