### PR TITLE
curl verbose option, repeated use

### DIFF
--- a/docs/cmdline-opts/verbose.md
+++ b/docs/cmdline-opts/verbose.md
@@ -28,8 +28,28 @@ and a line starting with * means additional info provided by curl.
 If you only want HTTP headers in the output, --include or --dump-header might
 be more suitable options.
 
-If you think this option still does not give you enough details, consider using
---trace or --trace-ascii instead.
+Since curl 8.10, mentioning this option several times in the same argument
+increases the level of the trace output. However, as before,
+a single `-v`, `--verbose` or `--no-verbose` reverts any additions by
+previous `-vv` again. This means that `-vv -v` is equivalent to `-v`. This
+avoids unwanted verbosity when the option is mentioned in the command line
+*and* curl config files.
+
+Using it twice, e.g. `-vv`, outputs time (`--trace-time`) and transfer
+ids (`--trace-ids`), as well as enable tracing for all protocols
+(`--trace-config protocol`).
+
+Adding a third verbose outputs transfer content (`--trace-ascii %`) and
+enable tracing of more components (`--trace-config read,write,ssl`).
+
+A forth time adds tracing of all network components.
+(`--trace-config network`).
+
+Any addition of the verbose option after that has no effect.
+
+If you think this option does not give you the right details, consider using
+--trace or --trace-ascii instead. Or use it only once and use `--trace-config`
+to trace the specific components you wish to see.
 
 Note that verbose output of curl activities and network traffic might contain
 sensitive data, including usernames, credentials or secret data content. Be

--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -109,6 +109,27 @@ Traces reading of upload data from the application in order to send it to the se
 
 Traces writing of download data, received from the server, to the application.
 
+# TRACE GROUPS
+
+Besides the specific component names there are the following group names
+defined:
+
+## `all`
+
+## `network`
+
+All components involved in bare network I/O, including the SSL layer.
+
+All components that your libcurl is built with.
+
+## `protocol`
+
+All components involved in transfer protocols, such as 'ftp' and 'http/2'.
+
+## `proxy`
+
+All components involved in use of proxies.
+
 # %PROTOCOLS%
 
 # EXAMPLE

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -316,6 +316,7 @@ struct GlobalConfig {
   bool silent;                    /* do not show messages, --silent given */
   bool noprogress;                /* do not show progress bar */
   bool isatty;                    /* Updated internally if output is a tty */
+  unsigned char verbosity;        /* How verbose we should be */
   char *trace_dump;               /* file to dump the network trace to */
   FILE *trace_stream;
   bool trace_fopened;


### PR DESCRIPTION
- make mentioning `-vv` on the curl command line increase the verbosity of the trace output
- related discussion https://github.com/curl/curl/discussions/13810
- add trace group names for components: `network`, `protocol`, `proxy`. Usable in `--trace-config`.

Extract from curl's manpage on `--verbose:`

...
Since curl 8.10, mentioning this option several times in the same argument
increases the level of the trace output. However, as before,
a single `-v`, `--verbose` or `--no-verbose` reverts any additions by
previous `-vv` again. This means that `-vv -v` is equivalent to `-v`. This
avoids unwanted verbosity when the option is mentioned in the command line
*and* curl config files.

Using it twice, e.g. `-vv`, will output time (`--trace-time`) and transfer
ids (`--trace-ids`), as well as enable tracing for all protocols 
(`--trace-config protocol`).

Adding a third verbose will output transfer content (`--trace-ascii %`) and
enable tracing of more components (`--trace-config read,write,ssl`).

A forth time will add tracing of all network components 
(`--trace-config network`).
...