### PR TITLE
More NULL dereferences in x509asn1.c

### DIFF
--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -695,6 +695,11 @@ static CURLcode encodeDN(struct dynbuf *store, struct Curl_asn1Element *dn)
 
       str = Curl_dyn_ptr(&temp);
 
+      if(!str) {
+        result = CURLE_BAD_FUNCTION_ARGUMENT;
+        goto error;
+      }
+
       /* Encode delimiter.
          If attribute has a short uppercase name, delimiter is ", ". */
       for(p3 = str; ISUPPER(*p3); p3++)


### PR DESCRIPTION
Hello,

in #13972 you fixed a possible NULL dereference in the `ASN1tostr()` function.
The root cause was that when converting a `Curl_asn1Element` with length = 0 to a string,
the dynbuf `temp` in `ASN1tostr()` does not get initialized through
one path of the `ASN1tostr()` function such that `Curl_dyn_ptr(&temp)` then returns NULL.

Unfortunately there are at least 4 more paths through `ASN1tostr()` and its helper functions that lead to the same
outcome, involving the functions: 
- `utf8asn1str()`
- `octet2str()`
- `OID2str()`

This PR tries to fix the NULL derefs in one place instead of all the helper functions above.

For reference, I attached all 4 certificates that cause a NULL dereference:
[crash-ecf257c87027696ed7f041bb764e0028adb95408](https://github.com/user-attachments/files/15919629/crash-ecf257c87027696ed7f041bb764e0028adb95408.txt)
[crash-26e2227eeeac47626b14bedfa6793b7c85223fca](https://github.com/user-attachments/files/15919630/crash-26e2227eeeac47626b14bedfa6793b7c85223fca.txt)
[crash-da35663a566f4c1ccd929bb658b64e2ab925cd07](https://github.com/user-attachments/files/15919631/crash-da35663a566f4c1ccd929bb658b64e2ab925cd07.txt)
[crash-fddfc08fd1b21a188f99692c8aaf85fdc560ef5d](https://github.com/user-attachments/files/15919632/crash-fddfc08fd1b21a188f99692c8aaf85fdc560ef5d.txt)
