### PR TITLE
GHA: use vcpkg to install packages for MSVC jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -493,8 +493,8 @@ jobs:
             "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
             "-DVCPKG_INSTALLED_DIR=$VCPKG_ROOT/installed" \
             '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
-            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
+            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
@@ -511,7 +511,7 @@ jobs:
           export VCPKG_ROOT="$GITHUB_WORKSPACE/vcpkg"
           mkdir -p bld
           7z a -t7z -r -mx=9 logs.7z \
-            "$VCPKG_ROOT/buildtrees/*.log" \
+            "$VCPKG_ROOT"/buildtrees/*.log \
             bld/.ninja_log \
             bld/build.ninja \
             bld/install_manifest.txt \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -488,8 +488,8 @@ jobs:
             system='Windows'
           fi
           export VCPKG_ROOT="$PWD/vcpkg"
-          cmake . -B bld ${options} \
-            "-DCMAKE_SYSTEM_NAME=$system" \
+          cmake -B bld ${options} \
+            "-DCMAKE_SYSTEM_NAME=${system}" \
             "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
             "-DVCPKG_INSTALLED_DIR=$VCPKG_ROOT/installed" \
             '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -413,52 +413,129 @@ jobs:
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
   msvc:
-    name: 'msvc (${{ matrix.arch }}, ${{ matrix.plat }}, ${{ matrix.config }})'
+    name: 'msvc (${{ matrix.arch }}, ${{ matrix.plat }}, ${{ matrix.name }})'
     runs-on: windows-latest
     timeout-minutes: 30
     strategy:
       matrix:
         include:
-          - { arch: 'x64', plat: 'windows', tflags: '~1516 ~2301 ~2302 ~2303 ~2307', config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=ON  -DBUILD_SHARED_LIBS=OFF -DENABLE_UNICODE=ON ', type: 'Debug' }
-          - { arch: 'x64', plat: 'windows', tflags: '~1516 ~2301 ~2302 ~2303 ~2307', config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=OFF -DBUILD_SHARED_LIBS=OFF -DENABLE_UNICODE=OFF', type: 'Debug' }
-          - { arch: 'x64', plat: 'windows', tflags: '~1516 ~2301 ~2302 ~2303 ~2307', config: '-DENABLE_DEBUG=ON -DCURL_USE_SCHANNEL=OFF -DHTTP_ONLY=ON          -DENABLE_UNICODE=OFF', type: 'Debug' }
+          # name should be unique and without special chars. It creates a folder with that name for the cache.
+        - name: 'schannel'
+          install: 'zstd zlib nghttp2 libssh2[core,zlib]'
+          arch: 'x64'
+          plat: 'windows'
+          type: 'Debug'
+          tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=ON  -DCURL_USE_SCHANNEL=ON  -DCURL_ZSTD=ON -DUSE_NGHTTP2=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON'
+        - name: 'openssl'
+          install: 'zstd zlib nghttp2 nghttp3 openssl libssh2'
+          arch: 'x64'
+          plat: 'windows'
+          type: 'Debug'
+          tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_ZSTD=ON -DUSE_NGHTTP2=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON'
+        - name: 'no ssl'
+          install: 'zstd zlib'
+          arch: 'x64'
+          plat: 'windows'
+          type: 'Debug'
+          tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_ZSTD=ON -DHTTP_ONLY=ON'
       fail-fast: false
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: 'restore cache dependencies'
+        uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: 'cache/${{ matrix.name }}'
+          key: ${{ matrix.plat }}-${{ matrix.name }}
+          restore-keys: ${{ matrix.plat }}-${{ matrix.name }}
+
+      - name: 'vcpkg init'
+        timeout-minutes: 5      
+        if: success()
+        shell: bash
+        run: |
+          git clone --quiet --depth 1 https://github.com/microsoft/vcpkg/
+          vcpkg/bootstrap-vcpkg.sh
+
+      - name: 'vcpkg build'
+        timeout-minutes: 10
+        shell: bash
+        run: |
+          export VCPKG_ROOT="$PWD/vcpkg"
+          export CURRENT_BINARY_CACHE='cache/${{ matrix.name }}'
+          mkdir -p "$CURRENT_BINARY_CACHE"
+          export VCPKG_BINARY_SOURCES="clear;files,$GITHUB_WORKSPACE/$CURRENT_BINARY_CACHE,readwrite;"
+          vcpkg/vcpkg x-set-installed ${{ matrix.install }} --triplet=${{ matrix.arch }}-${{ matrix.plat }}
+
+      - name: 'save cache dependencies'
+        id: cache-save
+        uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
+        with:
+          path: 'cache/${{ matrix.name }}'
+          key: ${{ matrix.plat }}-${{ matrix.name }}-${{ hashFiles('vcpkg/installed/vcpkg/info/*', 'vcpkg/installed/vcpkg/updates/*') }}
+
       - name: 'cmake configure'
         timeout-minutes: 5
         shell: bash
         run: |
-          archgen=${{ matrix.arch }}; [ "${archgen}" = 'x86' ] && archgen='Win32'
           if [ '${{ matrix.plat }}' = 'uwp' ]; then
             system='WindowsStore'
             options='-DCMAKE_SYSTEM_VERSION=10.0'
           else
             system='Windows'
           fi
-          [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
-          [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
-          cmake -B bld ${options} \
-            "-DCMAKE_SYSTEM_NAME=${system}" \
-            -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake \
-            "-DCMAKE_GENERATOR_PLATFORM=${archgen}" \
-            '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
+          export VCPKG_ROOT="$PWD/vcpkg"
+          cmake . -B bld ${options} \
+            -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
+            -DVCPKG_INSTALLED_DIR=$VCPKG_ROOT/installed \
+            -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }} \
+            -DCMAKE_BUILD_TYPE=${{ matrix.type }} \
+            -DCMAKE_SYSTEM_NAME=$system \
             -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
-            '-DCMAKE_UNITY_BUILD=${{ matrix.unity }}' \
-            "-DCMAKE_C_FLAGS=${cflags}" \
-            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
+            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE= \
             ${{ matrix.config }} || { cat bld/CMakeFiles/CMake*.yaml; false; }
+
+      - name: 'prepare logs on failure'
+        timeout-minutes: 5
+        if: failure()
+        shell: bash
+        run: |
+          export VCPKG_ROOT="$GITHUB_WORKSPACE/vcpkg"
+          mkdir -p bld
+          7z a -t7z -r -mx=9 logs.7z \
+            $VCPKG_ROOT/buildtrees/*.log \
+            bld/.ninja_log \
+            bld/build.ninja \
+            bld/install_manifest.txt \
+            bld/vcpkg-manifest-install.log \
+            bld/CMakeFiles/CMake*.yaml
+
+      - name: 'upload logs on failure'
+        timeout-minutes: 10
+        if: failure()
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
+        with:
+          name: windows_logs_${{matrix.name}}_${{github.event.pull_request.head.sha}}
+          path: logs.7z
 
       - name: 'cmake build'
         timeout-minutes: 5
         shell: bash
         run: |
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
-          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
+          export VCPKG_ROOT="$PWD/vcpkg"
+          export VCPKG_TRIPLED_DIR="$VCPKG_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
+          export debug_lib="$VCPKG_TRIPLED_DIR/debug/bin"
+          export release_lib="$VCPKG_TRIPLED_DIR/bin"
+          export PATH="$PWD/bld/lib/:$release_lib:$debug_lib:$PATH"
           bld/src/curl.exe --disable --version
 
       - name: 'cmake build tests'
@@ -474,5 +551,9 @@ jobs:
         shell: bash
         run: |
           export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
-          ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
+          export VCPKG_ROOT="$PWD/vcpkg"
+          export VCPKG_TRIPLED_DIR="$VCPKG_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
+          export debug_lib="$VCPKG_TRIPLED_DIR/debug/bin"
+          export release_lib="$VCPKG_TRIPLED_DIR/bin"
+          export PATH="$PWD/bld/lib/:$release_lib:$debug_lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -453,7 +453,7 @@ jobs:
           restore-keys: ${{ matrix.plat }}-${{ matrix.name }}
 
       - name: 'vcpkg init'
-        timeout-minutes: 5      
+        timeout-minutes: 5
         if: success()
         shell: bash
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -489,11 +489,11 @@ jobs:
           fi
           export VCPKG_ROOT="$PWD/vcpkg"
           cmake . -B bld ${options} \
-            -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
-            -DVCPKG_INSTALLED_DIR=$VCPKG_ROOT/installed \
-            -DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }} \
-            -DCMAKE_BUILD_TYPE=${{ matrix.type }} \
-            -DCMAKE_SYSTEM_NAME=$system \
+            "-DCMAKE_SYSTEM_NAME=$system" \
+            "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" \
+            "-DVCPKG_INSTALLED_DIR=$VCPKG_ROOT/installed" \
+            '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
+            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
@@ -511,7 +511,7 @@ jobs:
           export VCPKG_ROOT="$GITHUB_WORKSPACE/vcpkg"
           mkdir -p bld
           7z a -t7z -r -mx=9 logs.7z \
-            $VCPKG_ROOT/buildtrees/*.log \
+            "$VCPKG_ROOT/buildtrees/*.log" \
             bld/.ninja_log \
             bld/build.ninja \
             bld/install_manifest.txt \
@@ -532,9 +532,9 @@ jobs:
         run: |
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
           export VCPKG_ROOT="$PWD/vcpkg"
-          export VCPKG_TRIPLED_DIR="$VCPKG_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
-          export debug_lib="$VCPKG_TRIPLED_DIR/debug/bin"
-          export release_lib="$VCPKG_TRIPLED_DIR/bin"
+          export VCPKG_TRIPLET_DIR="$VCPKG_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
+          export debug_lib="$VCPKG_TRIPLET_DIR/debug/bin"
+          export release_lib="$VCPKG_TRIPLET_DIR/bin"
           export PATH="$PWD/bld/lib/:$release_lib:$debug_lib:$PATH"
           bld/src/curl.exe --disable --version
 
@@ -552,8 +552,8 @@ jobs:
         run: |
           export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
           export VCPKG_ROOT="$PWD/vcpkg"
-          export VCPKG_TRIPLED_DIR="$VCPKG_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
-          export debug_lib="$VCPKG_TRIPLED_DIR/debug/bin"
-          export release_lib="$VCPKG_TRIPLED_DIR/bin"
+          export VCPKG_TRIPLET_DIR="$VCPKG_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
+          export debug_lib="$VCPKG_TRIPLET_DIR/debug/bin"
+          export release_lib="$VCPKG_TRIPLET_DIR/bin"
           export PATH="$PWD/bld/lib/:$release_lib:$debug_lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci


### PR DESCRIPTION
You already have vcpkg in your msvc jobs in your ci. You didn't aware of it.
I refactor the vcpkg and add more libraries that can compile with curl.
I added cache that can be restore, and not building every library from scratch every PR, it will use the cache. (save ~7min on openssl and schannel build).

