### PR TITLE
CURLOPT_RESOLVE: support "*" for port number

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -22,7 +22,6 @@
  1.3 struct lifreq
  1.4 alt-svc sharing
  1.5 get rid of PATH_MAX
- 1.8 CURLOPT_RESOLVE for any port number
  1.9 Cache negative name resolves
  1.10 auto-detect proxy
  1.11 minimize dependencies with dynamically loaded modules
@@ -246,14 +245,6 @@
  Currently the libssh2 SSH based code uses it, but to remove PATH_MAX from
  there we need libssh2 to properly tell us when we pass in a too small buffer
  and its current API (as of libssh2 1.2.7) does not.
-
-1.8 CURLOPT_RESOLVE for any port number
-
- This option allows applications to set a replacement IP address for a given
- host + port pair. Consider making support for providing a replacement address
- for the hostname on all port numbers.
-
- See https://github.com/curl/curl/issues/1264
 
 1.9 Cache negative name resolves
 

--- a/docs/cmdline-opts/resolve.md
+++ b/docs/cmdline-opts/resolve.md
@@ -28,6 +28,11 @@ By specifying `*` as host you can tell curl to resolve any host and specific
 port pair to the specified address. Wildcard is resolved last so any --resolve
 with a specific host and port is used first.
 
+Starting in curl version 8.10.0, the port number can be specified as an
+asterisk (`*`) to make the address used for the specified hostname for any
+port number. A resolve entry for a fixed port number still has priority if
+existing. Also works if the hostname is a wildcard.
+
 The provided address set by this option is used even if --ipv4 or --ipv6 is
 set to make curl use another IP version.
 

--- a/docs/libcurl/opts/CURLOPT_RESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.md
@@ -60,6 +60,11 @@ entries added with `+HOST:...` times out just like ordinary DNS cache entries.
 If the DNS cache already has an entry for the given host+port pair, the new
 entry overrides the former one.
 
+Starting in version 8.10.0, the port number can be specified as an asterisk
+(`*`) to make the address used for the specified hostname for any port number.
+A resolve entry for a fixed port number still has priority if existing. Also
+works if the hostname is a wildcard.
+
 An ADDRESS provided by this option is only used if not restricted by the
 setting of CURLOPT_IPRESOLVE(3) to a different IP version.
 

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -383,10 +383,10 @@ static CURLcode socket_open(struct Curl_easy *data,
  *
  */
 CURLcode Curl_socket_open(struct Curl_easy *data,
-                            const struct Curl_addrinfo *ai,
-                            struct Curl_sockaddr_ex *addr,
-                            int transport,
-                            curl_socket_t *sockfd)
+                          const struct Curl_addrinfo *ai,
+                          struct Curl_sockaddr_ex *addr,
+                          int transport,
+                          curl_socket_t *sockfd)
 {
   struct Curl_sockaddr_ex dummy;
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -358,12 +358,12 @@ static struct Curl_dns_entry *fetch_addr(struct Curl_easy *data,
     while(ai) {
 #ifdef USE_IPV6
       if(ai->ai_family == AF_INET6) {
-        struct sockaddr_in6 *si6 = (struct sockaddr_in6 *)ai->ai_addr;
+        struct sockaddr_in6 *si6 = (void *)ai->ai_addr;
         si6->sin6_port = htons((unsigned short)port);
       }
 #endif
       if(ai->ai_family == AF_INET) {
-        struct sockaddr_in *si4 = (struct sockaddr_in *)ai->ai_addr;
+        struct sockaddr_in *si4 = (void *)ai->ai_addr;
         si4->sin_port = htons((unsigned short)port);
       }
       ai = ai->ai_next;

--- a/tests/data/Makefile.inc
+++ b/tests/data/Makefile.inc
@@ -189,7 +189,7 @@ test1455 test1456 test1457 test1458 test1459 test1460 test1461 test1462 \
 test1463 test1464 test1465 test1466 test1467 test1468 test1469 test1470 \
 test1471 test1472 test1473 test1474 test1475 test1476 test1477 test1478 \
 test1479 test1480 test1481 test1482 test1483 test1484 test1485 test1486 \
-test1487 \
+test1487 test1488 test1489 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1488
+++ b/tests/data/test1488
@@ -33,10 +33,10 @@ Funny-head: yesyes
 http
 </server>
 <name>
-HTTP with host wildcard --resolve
+HTTP with port wildcard --resolve
 </name>
 <command>
---resolve *:%HTTPPORT:%HOSTIP http://example.com:%HTTPPORT/%TESTNUMBER
+--resolve example.com:*:%HOSTIP http://example.com:%HTTPPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test1489
+++ b/tests/data/test1489
@@ -33,10 +33,10 @@ Funny-head: yesyes
 http
 </server>
 <name>
-HTTP with host wildcard --resolve
+HTTP with host and port wildcards --resolve
 </name>
 <command>
---resolve *:%HTTPPORT:%HOSTIP http://example.com:%HTTPPORT/%TESTNUMBER
+--resolve "*:*:%HOSTIP" http://example.com:%HTTPPORT/%TESTNUMBER
 </command>
 </client>
 


### PR DESCRIPTION
Allow resolves for a hostname independent of port number, to a fixed address. Resolves to a fixed port number have priority.

Also works if the hostname itself is using "*" to catch all hostnames.

A key to this change is to no longer use the port number from the DNS struct stored in the cache when connecting since it is not the correct one when a wildcard port is used for CURLOPT_RESOLVE.

Removes TODO item 1.8

Verified by test 1488 and 1489