### PR TITLE
docs/cmdline-opts: remove two superfluous "Added in" mentions

### DIFF
--- a/docs/cmdline-opts/ip-tos.md
+++ b/docs/cmdline-opts/ip-tos.md
@@ -17,7 +17,7 @@ Example:
 
 # `--ip-tos`
 
-Set Type of Service (TOS) for IPv4 or Traffic Class for IPv6. (Added in 8.9.0).
+Set Type of Service (TOS) for IPv4 or Traffic Class for IPv6.
 
 The values allowed for \<string\> can be a numeric value between 1 and 255
 or one of the following:

--- a/docs/cmdline-opts/vlan-priority.md
+++ b/docs/cmdline-opts/vlan-priority.md
@@ -16,7 +16,7 @@ Example:
 
 # `--vlan-priority`
 
-Set VLAN priority as defined in IEEE 802.1Q. (Added in 8.9.0).
+Set VLAN priority as defined in IEEE 802.1Q.
 
 This field is set on Ethernet level, and only works within a local network.
 


### PR DESCRIPTION
The key "added in" phrase for the option itself is added automatically.