### PR TITLE
managen: "added in" fixes

### DIFF
--- a/docs/cmdline-opts/crlf.md
+++ b/docs/cmdline-opts/crlf.md
@@ -17,5 +17,3 @@ Example:
 
 Convert line feeds to carriage return plus line feeds in upload. Useful for
 **MVS (OS/390)**.
-
-(SMTP added in 7.40.0)

--- a/docs/cmdline-opts/header.md
+++ b/docs/cmdline-opts/header.md
@@ -52,8 +52,8 @@ Please note that most anti-spam utilities check the presence and value of
 several MIME mail headers: these are `From:`, `To:`, `Date:` and `Subject:`
 among others and should be added with this option.
 
-You need --proxy-header to send custom headers intended for an HTTP
-proxy. Added in 7.37.0.
+You need --proxy-header to send custom headers intended for an HTTP proxy.
+(Added in 7.37.0)
 
 Passing on a "Transfer-Encoding: chunked" header when doing an HTTP request
 with a request body, makes curl send the data using chunked encoding.

--- a/docs/cmdline-opts/proto-redir.md
+++ b/docs/cmdline-opts/proto-redir.md
@@ -22,6 +22,6 @@ Example, allow only HTTP and HTTPS on redirect:
 
     curl --proto-redir -all,http,https http://example.com
 
-By default curl only allows HTTP, HTTPS, FTP and FTPS on redirects (added in
-7.65.2). Specifying *all* or *+all* enables all protocols on redirects, which
-is not good for security.
+By default curl only allows HTTP, HTTPS, FTP and FTPS on redirects
+(added in 7.65.2). Specifying *all* or *+all* enables all protocols on
+redirects, which is not good for security.

--- a/docs/cmdline-opts/url.md
+++ b/docs/cmdline-opts/url.md
@@ -22,8 +22,8 @@ If the given URL is missing a scheme name (such as `http://` or `ftp://` etc)
 then curl makes a guess based on the host. If the outermost subdomain name
 matches DICT, FTP, IMAP, LDAP, POP3 or SMTP then that protocol is used,
 otherwise HTTP is used. Guessing can be avoided by providing a full URL
-including the scheme, or disabled by setting a default protocol (added in
-7.45.0), see --proto-default for details.
+including the scheme, or disabled by setting a default protocol, see
+--proto-default for details.
 
 To control where this URL is written, use the --output or the --remote-name
 options.

--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -80,8 +80,8 @@ The numerical exit code of the transfer. (Added in 7.75.0)
 ## `filename_effective`
 The ultimate filename that curl writes out to. This is only meaningful if curl
 is told to write to a file with the --remote-name or --output option. It is
-most useful in combination with the --remote-header-name option. (Added in
-7.26.0)
+most useful in combination with the --remote-header-name option.
+(Added in 7.26.0)
 
 ## `ftp_entry_path`
 The initial path curl ended up in when logging on to the remote FTP

--- a/scripts/managen
+++ b/scripts/managen
@@ -237,8 +237,8 @@ sub too_old {
     elsif($version =~ /^(\d+)\.(\d+)/) {
         $a = $1 * 1000 + $2 * 10;
     }
-    if($a < 7500) {
-        # we consider everything before 7.50.0 to be too old to mention
+    if($a < 7600) {
+        # we consider everything before 7.60.0 to be too old to mention
         # specific changes for
         return 1;
     }
@@ -375,10 +375,19 @@ sub render {
         # convert backticks to double quotes
         $d =~ s/\`/\"/g;
 
+        if($d =~ /\(added in(.*)/i) {
+            if(length($1) < 2) {
+                print STDERR "$f:$line:1:ERROR: broken up added-in line:\n";
+                print STDERR "$f:$line:1:ERROR: $d";
+                return 3;
+            }
+        }
+      again:
         if($d =~ /\(Added in ([0-9.]+)\)/i) {
             my $ver = $1;
             if(too_old($ver)) {
                 $d =~ s/ *\(Added in $ver\)//gi;
+                goto again;
             }
         }
 


### PR DESCRIPTION
 - up the limit: remove all mentions of 7.60 or earlier from manpage 7.60 is 6 years old now.
 - warn on "broken" added in lines, as they avoid detection
 - fixup added in markup in a few curldown files