### PR TITLE
managen: output leading tabs for 8 spaces

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -89,6 +89,12 @@ sub manpageify {
 
 my $colwidth=79; # max number of columns
 
+sub prefixline {
+    my ($num) = @_;
+    print "\t" x ($num/8);
+    print ' ' x ($num%8);
+}
+
 sub justline {
     my ($lvl, @line) = @_;
     my $w = -1;
@@ -105,7 +111,7 @@ sub justline {
         $ratio = $inject / $spaces;
     }
     my $spare = 0;
-    print ' ' x ($lvl * $indent);
+    prefixline($lvl * $indent);
     my $prev;
     for(@line) {
         while($spare >= 0.90) {
@@ -121,7 +127,7 @@ sub justline {
 
 sub lastline {
     my ($lvl, @line) = @_;
-    print ' ' x ($lvl * $indent);
+    prefixline($lvl * $indent);
     my $prev = 0;
     for(@line) {
         printf "%s%s", $prev?" ":"", $_;

--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -167,6 +167,7 @@ for my $n (@out) {
     chomp $n;
     $n =~ s/\\/\\\\/g;
     $n =~ s/\"/\\\"/g;
+    $n =~ s/\t/\\t/g;
 
     if(!$n) {
         $blank++;


### PR DESCRIPTION
This replacing of eight leading spaces into tabs was already done for the embedded uncompressed version in tool_hugehelp.c so it does not save anything there. But the gzip compressed version ends up almost 2K smaller.

The output in a terminal should be identical.

Before using TABs:

curl.txt 282492 bytes
curl.txt.gz 73261 bytes

With this change applied:

curl.txt 249382 bytes
curl.txt.gz 71470 bytes