### PR TITLE
managen: fix blank line detection

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -276,13 +276,13 @@ sub render {
     my $top = ($line == 1);
     my $quote;
     my $level;
-    my $blankline;
+    my $finalblank;
     $start = 0;
 
     while(<$fh>) {
         my $d = $_;
         $line++;
-        $blankline = ($d eq "\n");
+        $finalblank = ($d eq "\n");
         if($d =~ /^\.(SH|BR|IP|B)/) {
             print STDERR "$f:$line:1:ERROR: nroff instruction in input: \".$1\"\n";
             return 4;
@@ -450,7 +450,7 @@ sub render {
         $header = 0;
 
     }
-    if($blankline) {
+    if($finalblank) {
         print STDERR "$f:$line:1:ERROR: trailing blank line\n";
         exit 3;
     }


### PR DESCRIPTION
Follow-up to d14a53eea7b87 which ruined the output somewhat.