### PR TITLE
OpenSSL QUIC, require at least v3.3.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3189,7 +3189,7 @@ if test "x$want_openssl_quic" = "xyes"; then
     AC_MSG_ERROR([--with-openssl-quic and --with-ngtcp2 are mutually exclusive])
   fi
   if test "$HAVE_OPENSSL_QUIC" != 1; then
-    AC_MSG_ERROR([--with-openssl-quic requires quic support in OpenSSL])
+    AC_MSG_ERROR([--with-openssl-quic requires quic support and OpenSSL >= 3.3.0])
   fi
   AC_DEFINE(USE_OPENSSL_QUIC, 1, [if openssl QUIC is in use])
   AC_SUBST(USE_OPENSSL_QUIC, [1])

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1856,18 +1856,12 @@ static CURLcode cf_udp_setup_quic(struct Curl_cfilter *cf,
   /* QUIC needs a connected socket, nonblocking */
   DEBUGASSERT(ctx->sock != CURL_SOCKET_BAD);
 
-#if defined(__APPLE__) && defined(USE_OPENSSL_QUIC)
-  (void)rc;
-  /* On macOS OpenSSL QUIC fails on connected sockets.
-   * see: <https://github.com/openssl/openssl/issues/23251> */
-#else
   rc = connect(ctx->sock, &ctx->addr.sa_addr,
                (curl_socklen_t)ctx->addr.addrlen);
   if(-1 == rc) {
     return socket_connect_result(data, ctx->ip.remote_ip, SOCKERRNO);
   }
   ctx->sock_connected = TRUE;
-#endif
   set_local_ip(cf, data);
   CURL_TRC_CF(data, cf, "%s socket %" CURL_FORMAT_SOCKET_T
               " connected: [%s:%d] -> [%s:%d]",

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1442,19 +1442,12 @@ static CURLcode h3_send_streams(struct Curl_cfilter *cf,
     for(i = 0; (i < n) && !blocked; ++i) {
       /* Without stream->s.ssl, we closed that already, so
        * pretend the write did succeed. */
-#ifdef SSL_WRITE_FLAG_CONCLUDE
-      /* Since OpenSSL v3.3.x, on last chunk set EOS if needed  */
       uint64_t flags = (eos && ((i + 1) == n))? SSL_WRITE_FLAG_CONCLUDE : 0;
       written = vec[i].len;
       ok = !s->ssl || SSL_write_ex2(s->ssl, vec[i].base, vec[i].len, flags,
                                    &written);
       if(ok && flags & SSL_WRITE_FLAG_CONCLUDE)
         eos_written = TRUE;
-#else
-      written = vec[i].len;
-      ok = !s->ssl || SSL_write_ex(s->ssl, vec[i].base, vec[i].len,
-                                   &written);
-#endif
       if(ok) {
         /* As OpenSSL buffers the data, we count this as acknowledged
          * from nghttp3's point of view */

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -429,11 +429,14 @@ dnl ---
 dnl We may use OpenSSL QUIC.
 dnl ---
 if test "$OPENSSL_ENABLED" = "1"; then
-  AC_MSG_CHECKING([for QUIC support in OpenSSL])
+  AC_MSG_CHECKING([for QUIC support and OpenSSL >= 3.3])
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
 #include <openssl/ssl.h>
     ]],[[
+      #if (OPENSSL_VERSION_NUMBER < 0x30300000L)
+      #error need at least version 3.3.0
+      #endif
       OSSL_QUIC_client_method();
     ]])
   ],[


### PR DESCRIPTION
- when checking for QUIC support in OpenSSL, also check for it being at least 3.3.0
- remove workarounds for features buggy or missing in 3.2