### PR TITLE
runtests: fix %VERNUM

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -523,7 +523,7 @@ sub checksystemfeatures {
             $curl = $_;
             $CURLVERSION = $1;
             $CURLVERNUM = $CURLVERSION;
-            $CURLVERNUM =~ s/[^0-9.]//g; # dots and numbers only
+            $CURLVERNUM =~ s/^([0-9.]+)(.*)/$1/; # leading dots and numbers
             $curl =~ s/^(.*)(libcurl.*)/$1/g || die "Failure determining curl binary version";
 
             $libcurl = $2;


### PR DESCRIPTION
It needs to be set to the leading digits and dots only, so that the `-[date]` suffix strings are not included, as those used in the daily snapshots.

Fixes #14035
Reported-by: Marcel Raad