### PR TITLE
Updates to build with quiche 0.22.0

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -412,6 +412,7 @@ jobs:
           sed -i -e 's/cmake = "0.1"/cmake = "=0.1.45"/' quiche/Cargo.toml
 
           cargo build -v --package quiche --release --features ffi,pkg-config-meta,qlog --verbose
+          ln -s libquiche.so target/release/libquiche.so.0
           mkdir -v quiche/deps/boringssl/src/lib
           ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) quiche/deps/boringssl/src/lib/
 

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -189,6 +189,7 @@ Build quiche and BoringSSL:
      % git clone --recursive -b 0.20.0 https://github.com/cloudflare/quiche
      % cd quiche
      % cargo build --package quiche --release --features ffi,pkg-config-meta,qlog
+     % ln -s libquiche.so target/release/libquiche.so.0
      % mkdir quiche/deps/boringssl/src/lib
      % ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) quiche/deps/boringssl/src/lib/
 


### PR DESCRIPTION
quiche 0.22.0 will set SONAME in libquiche.so (libquiche.so.0). Install a symlink with SONAME.