### PR TITLE
managen: insert final .fi for files ending with a quote

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -454,6 +454,10 @@ sub render {
         print STDERR "$f:$line:1:ERROR: trailing blank line\n";
         exit 3;
     }
+    if($quote) {
+        # don't leave the quote "hanging"
+        push @desc, ".fi\n" if($manpage);
+    }
     if($tablemode) {
         # end of table
         push @desc, ".RE\n.IP\n" if($manpage);
@@ -673,9 +677,6 @@ sub single {
         }
     }
 
-    printdesc($manpage, 2, (@leading, @desc));
-    undef @desc;
-
     my @extra;
     if($multi eq "single") {
         push @extra, "${pre}If --$long is provided several times, the last set ".
@@ -706,7 +707,7 @@ sub single {
     }
     elsif($multi eq "per-URL") {
         push @extra,
-            "${pre}--$long is associated with a single URL. Use it once per URL\n".
+            "${pre}--$long is associated with a single URL. Use it once per URL ".
             "when you use several URLs in a command line.\n";
     }
     else {
@@ -714,7 +715,8 @@ sub single {
         return 2;
     }
 
-    printdesc($manpage, 2, @extra);
+    printdesc($manpage, 2, (@leading, @desc, @extra));
+    undef @desc;
 
     my @foot;
 

--- a/tests/data/test1705
+++ b/tests/data/test1705
@@ -74,6 +74,10 @@ If you think this option still does not give you enough details, consider using
 Note that verbose output of curl activities and network traffic might contain
 sensitive data, including usernames, credentials or secret data content. Be
 aware and be careful when sharing trace logs with others.
+
+End with a quote
+
+    hello
 </file2>
 <file3 name="%LOGDIR/option2.md">
 ---
@@ -216,6 +220,12 @@ If you think this option still does not give you enough details, consider using
 Note that verbose output of curl activities and network traffic might contain
 sensitive data, including usernames, credentials or secret data content. Be
 aware and be careful when sharing trace logs with others.
+
+End with a quote
+.nf
+
+hello
+.fi
 
 This option is global and does not need to be specified for each use of --next.
 

--- a/tests/data/test1706
+++ b/tests/data/test1706
@@ -195,10 +195,8 @@ DESCRIPTION
 	    logs with others.
 
 	    This option is global  and does not need  to be specified for  each
-	    use of --next.
-
-	    Providing --fakeitreal multiple times has no extra effect.  Disable
-	    it again with --no-fakeitreal.
+	    use of --next. Providing --fakeitreal  multiple times has no  extra
+	    effect. Disable it again with --no-fakeitreal.
 
 	    Example:
 	     curl --verbose https://example.com


### PR DESCRIPTION
When an individual file ended with a quote (typically an example), the render function would return without ending the quote correctly with a ".fi" (fill in) in the manpage output.

This made the additional text provided below to render wrongly.