### PR TITLE
src/Makefile.am: remove SUBDIRS assignment

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,10 +45,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 
 bin_PROGRAMS = curl
 
-if BUILD_DOCS
-SUBDIRS = ../docs
-endif
-
 if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif


### PR DESCRIPTION
It was once used to continue into ../docs but is just leftovers now.