### PR TITLE
curl: list categories in --help

### DIFF
--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -9,7 +9,7 @@
 # Debian stretch is chosen as it closely matches some of the oldest major
 # versions we support (especially cmake); see docs/INTERNALS.md and it
 # is still supported (as of this writing).
-# stretch has ELTS support from Feexian until 2027-06-30
+# stretch has ELTS support from Freexian until 2027-06-30
 # For ELTS info see https://www.freexian.com/lts/extended/docs/how-to-use-extended-lts/
 # The Debian key will expire 2025-05-20, after which package signature
 # verification may need to be disabled.

--- a/tests/data/test1461
+++ b/tests/data/test1461
@@ -45,8 +45,11 @@ Usage: curl [options...] <url>
  -v, --verbose               Make the operation more talkative
  -V, --version               Show version number and quit
 
-This is not the full help, this menu is stripped into categories.
-Use "--help category" to get an overview of all categories.
+This is not the full help; this menu is split into categories.
+Use "--help category" to get an overview of all categories, which are:
+auth, connection, curl, deprecated, dns, file, ftp, global, http, imap, ldap, 
+output, pop3, post, proxy, scp, sftp, smtp, ssh, telnet, tftp, timeout, tls, 
+upload, verbose.
 For all options use the manual or "--help all".
 </stdout>
 </verify>


### PR DESCRIPTION
This eliminates the need to run an extra help subcommand to get the
possible categories, reducing the friction in getting relevant help. The
help wording was also slightly tweaked for grammatical accuracy.

Closes #14055