### PR TITLE
Fix UDP_GRO struct cmsghdr data type

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1899,7 +1899,8 @@ static CURLcode cf_udp_setup_quic(struct Curl_cfilter *cf,
 #endif
   }
 
-#if defined(UDP_GRO) && (defined(HAVE_SENDMMSG) || defined(HAVE_SENDMSG)) &&  \
+#if defined(__linux__) && defined(UDP_GRO) &&                                 \
+  (defined(HAVE_SENDMMSG) || defined(HAVE_SENDMSG)) &&                        \
   ((defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || defined(USE_QUICHE))
   (void)setsockopt(ctx->sock, IPPROTO_UDP, UDP_GRO, &one,
                    (socklen_t)sizeof(one));

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -335,8 +335,8 @@ CURLcode vquic_send_tail_split(struct Curl_cfilter *cf, struct Curl_easy *data,
 #if defined(HAVE_SENDMMSG) || defined(HAVE_SENDMSG)
 static size_t msghdr_get_udp_gro(struct msghdr *msg)
 {
-  uint16_t gso_size = 0;
-#ifdef UDP_GRO
+  int gso_size = 0;
+#if defined(__linux__) && defined(UDP_GRO)
   struct cmsghdr *cmsg;
 
   /* Workaround musl CMSG_NXTHDR issue */
@@ -358,7 +358,7 @@ static size_t msghdr_get_udp_gro(struct msghdr *msg)
 #endif
   (void)msg;
 
-  return gso_size;
+  return (size_t)gso_size;
 }
 #endif
 


### PR DESCRIPTION
The data type for UDP_GRO in struct cmsghdr is int.  Limit the usage of UDP_GRO to linux only because it is not portable.