### PR TITLE
mk-ca-bundle.pl: delay 'curl -V' execution until it is needed

### DIFF
--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -136,8 +136,6 @@ else {
   $url = $opt_d;
 }
 
-my $curl = `curl -V`;
-
 if ($opt_i) {
   print ("=" x 78 . "\n");
   print "Script Version                   : $version\n";
@@ -314,6 +312,7 @@ if(!$opt_n) {
 
   # If we have an HTTPS URL then use curl
   if($url =~ /^https:\/\//i) {
+    my $curl = `curl -V`;
     if($curl) {
       if($curl =~ /^Protocols:.* https( |$)/m) {
         report "Get certdata with curl!";


### PR DESCRIPTION
Avoid an `Can't exec "curl"` message when curl is not actually needed.