### PR TITLE
cmake: improve wolfSSL detection

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -225,6 +225,9 @@ jobs:
           - name: LibreSSL
             install: nghttp2 libressl
             generate: -DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/libressl -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON -DBUILD_EXAMPLES=ON
+          - name: wolfSSL
+            install: nghttp2 wolfssl
+            generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
           - name: libssh2
             install: nghttp2 openssl libssh2
             generate: -DOPENSSL_ROOT_DIR=$(brew --prefix)/opt/openssl -DCURL_USE_LIBSSH2=ON -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON

--- a/CMake/FindWolfSSL.cmake
+++ b/CMake/FindWolfSSL.cmake
@@ -21,16 +21,40 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-find_path(WolfSSL_INCLUDE_DIR NAMES wolfssl/ssl.h)
-find_library(WolfSSL_LIBRARY NAMES wolfssl)
-mark_as_advanced(WolfSSL_INCLUDE_DIR WolfSSL_LIBRARY)
+
+find_package(PkgConfig QUIET)
+pkg_check_modules(PC_WOLFSSL QUIET "wolfssl")
+
+find_path(WolfSSL_INCLUDE_DIR
+  NAMES "wolfssl/ssl.h"
+  HINTS ${PC_WOLFSSL_INCLUDE_DIRS}
+)
+
+find_library(WolfSSL_LIBRARY
+  NAMES "wolfssl"
+  HINTS ${PC_WOLFSSL_LIBRARY_DIRS}
+)
+
+if(WolfSSL_INCLUDE_DIR)
+  set(_version_regex "^#define[ \t]+LIBWOLFSSL_VERSION_STRING[ \t]+\"([^\"]+)\".*")
+  file(STRINGS "${WolfSSL_INCLUDE_DIR}/wolfssl/version.h"
+    WolfSSL_VERSION REGEX "${_version_regex}")
+  string(REGEX REPLACE "${_version_regex}" "\\1"
+    WolfSSL_VERSION "${WolfSSL_VERSION}")
+  unset(_version_regex)
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(WolfSSL
-  REQUIRED_VARS WolfSSL_INCLUDE_DIR WolfSSL_LIBRARY
-  )
+  REQUIRED_VARS
+    WolfSSL_INCLUDE_DIR
+    WolfSSL_LIBRARY
+  VERSION_VAR WolfSSL_VERSION
+)
 
 if(WolfSSL_FOUND)
   set(WolfSSL_INCLUDE_DIRS ${WolfSSL_INCLUDE_DIR})
-  set(WolfSSL_LIBRARIES ${WolfSSL_LIBRARY})
+  set(WolfSSL_LIBRARIES    ${WolfSSL_LIBRARY})
 endif()
+
+mark_as_advanced(WolfSSL_INCLUDE_DIR WolfSSL_LIBRARY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1673,10 +1673,10 @@ if(NOT CURL_DISABLE_INSTALL)
   _add_if("HTTP2"         USE_NGHTTP2)
   _add_if("HTTP3"         USE_NGTCP2 OR USE_QUICHE OR USE_OPENSSL_QUIC)
   _add_if("MultiSSL"      CURL_WITH_MULTI_SSL)
-  # TODO wolfSSL only support this from v5.0.0 onwards
   _add_if("HTTPS-proxy"   SSL_ENABLED AND (USE_OPENSSL OR USE_GNUTLS
                           OR USE_SCHANNEL OR USE_RUSTLS OR USE_BEARSSL OR
-                          USE_MBEDTLS OR USE_SECTRANSP))
+                          USE_MBEDTLS OR USE_SECTRANSP OR
+                          (USE_WOLFSSL AND NOT WolfSSL_VERSION VERSION_LESS 5.0.0)))
   _add_if("unicode"       ENABLE_UNICODE)
   _add_if("threadsafe"    HAVE_ATOMIC OR
                           (USE_THREADS_POSIX AND HAVE_PTHREAD_H) OR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1681,7 +1681,7 @@ if(NOT CURL_DISABLE_INSTALL)
   _add_if("HTTPS-proxy"   SSL_ENABLED AND (USE_OPENSSL OR USE_GNUTLS
                           OR USE_SCHANNEL OR USE_RUSTLS OR USE_BEARSSL OR
                           USE_MBEDTLS OR USE_SECTRANSP OR
-                          (USE_WOLFSSL AND NOT WolfSSL_VERSION VERSION_LESS 5.0.0)))
+                          (USE_WOLFSSL AND HAVE_WOLFSSL_FULL_BIO)))
   _add_if("unicode"       ENABLE_UNICODE)
   _add_if("threadsafe"    HAVE_ATOMIC OR
                           (USE_THREADS_POSIX AND HAVE_PTHREAD_H) OR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -656,6 +656,11 @@ macro(openssl_check_quic)
   endif()
 endmacro()
 
+if(USE_WOLFSSL)
+  openssl_check_symbol_exists(wolfSSL_DES_ecb_encrypt "wolfssl/openssl/des.h" HAVE_WOLFSSL_DES_ECB_ENCRYPT "")
+  openssl_check_symbol_exists(wolfSSL_BIO_set_shutdown "wolfssl/ssl.h" HAVE_WOLFSSL_FULL_BIO "")
+endif()
+
 if(USE_OPENSSL OR USE_WOLFSSL)
   if(NOT DEFINED HAVE_SSL_SET0_WBIO)
     openssl_check_symbol_exists(SSL_set0_wbio "openssl/ssl.h" HAVE_SSL_SET0_WBIO "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1645,9 +1645,15 @@ if(NOT CURL_DISABLE_INSTALL)
     endif()
   endmacro()
 
-  # NTLM support requires crypto function adaptions from various SSL libs
-  if(NOT (CURL_DISABLE_NTLM) AND
-      (USE_OPENSSL OR USE_MBEDTLS OR USE_SECTRANSP OR USE_WIN32_CRYPTO OR USE_GNUTLS))
+  # NTLM support requires crypto functions from various SSL libs.
+  # These conditions must match those in lib/curl_setup.h.
+  if(NOT CURL_DISABLE_NTLM AND
+     (USE_OPENSSL OR
+      USE_MBEDTLS OR
+      USE_GNUTLS OR
+      USE_SECTRANSP OR
+      USE_WIN32_CRYPTO OR
+      (USE_WOLFSSL AND HAVE_WOLFSSL_DES_ECB_ENCRYPT)))
     set(use_curl_ntlm_core ON)
   endif()
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -698,8 +698,14 @@ ${SIZEOF_TIME_T_CODE}
 /* if BearSSL is enabled */
 #cmakedefine USE_BEARSSL 1
 
-/* if WolfSSL is enabled */
+/* if wolfSSL is enabled */
 #cmakedefine USE_WOLFSSL 1
+
+/* if wolfSSL has the wolfSSL_DES_ecb_encrypt function. */
+#cmakedefine HAVE_WOLFSSL_DES_ECB_ENCRYPT 1
+
+/* if wolfSSL has the wolfSSL_BIO_set_shutdown function. */
+#cmakedefine HAVE_WOLFSSL_FULL_BIO 1
 
 /* if libSSH is in use */
 #cmakedefine USE_LIBSSH 1

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -743,7 +743,7 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
   struct mqtt_conn *mqtt = &conn->proto.mqtt;
   struct MQTT *mq = data->req.p.mqtt;
   ssize_t nread;
-  unsigned char byte;
+  unsigned char recvbyte;
 
   *done = FALSE;
 
@@ -776,13 +776,13 @@ static CURLcode mqtt_doing(struct Curl_easy *data, bool *done)
     FALLTHROUGH();
   case MQTT_REMAINING_LENGTH:
     do {
-      result = Curl_xfer_recv(data, (char *)&byte, 1, &nread);
+      result = Curl_xfer_recv(data, (char *)&recvbyte, 1, &nread);
       if(result || !nread)
         break;
-      Curl_debug(data, CURLINFO_HEADER_IN, (char *)&byte, 1);
-      mq->pkt_hd[mq->npacket++] = byte;
-    } while((byte & 0x80) && (mq->npacket < 4));
-    if(!result && nread && (byte & 0x80))
+      Curl_debug(data, CURLINFO_HEADER_IN, (char *)&recvbyte, 1);
+      mq->pkt_hd[mq->npacket++] = recvbyte;
+    } while((recvbyte & 0x80) && (mq->npacket < 4));
+    if(!result && nread && (recvbyte & 0x80))
       /* MQTT supports up to 127 * 128^0 + 127 * 128^1 + 127 * 128^2 +
          127 * 128^3 bytes. server tried to send more */
       result = CURLE_WEIRD_SERVER_REPLY;


### PR DESCRIPTION
- support detecting wolfSSL via pkg-config (like autotools.)

- detect wolfSSL version.

- detect `HAVE_WOLFSSL_DES_ECB_ENCRYPT`.
  (needs e.g. `--enable-curl` when building wolfSSL)

- detect `HAVE_WOLFSSL_FULL_BIO` and enable HTTPS-proxy feature.
  (needs e.g. `--enable-opensslall` when building wolfSSL)

- fix to show `HTTPS-proxy` in cmake feature list.
  Ref: 55807e6c056f27846d70cec70ee6ac3f0e5b3bbe #9962

- fix to show `NTLM` in cmake feature list.

- fix to show `smb` and `smbs` in cmake protocol list.

- add wolfSSL CMake job to GHA (for macOS).

- fix mqtt and wolfSSL symbol clash.
  ```
  ./curl/lib/mqtt.c: In function 'mqtt_doing':
  ./curl/lib/mqtt.c:746:17: error: declaration of 'byte' shadows a global declaration [-Werror=shadow]
    746 |   unsigned char byte;
        |                 ^~~~
  /opt/homebrew/Cellar/wolfssl/5.7.0_1/include/wolfssl/wolfcrypt/types.h:85:36: note: shadowed declaration is here
     85 |             typedef unsigned char  byte;
        |                                    ^~~~
  ```
 
- format `FindWolfSSL.cmake` closer to neighbours.

Closes #14064

---

- [x] rebase on #14065.
