### PR TITLE
cmake: fix feature and protocol lists for SecureTransport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1642,7 +1642,7 @@ if(NOT CURL_DISABLE_INSTALL)
 
   # NTLM support requires crypto function adaptions from various SSL libs
   if(NOT (CURL_DISABLE_NTLM) AND
-      (USE_OPENSSL OR USE_MBEDTLS OR USE_DARWINSSL OR USE_WIN32_CRYPTO OR USE_GNUTLS))
+      (USE_OPENSSL OR USE_MBEDTLS OR USE_SECTRANSP OR USE_WIN32_CRYPTO OR USE_GNUTLS))
     set(use_curl_ntlm_core ON)
   endif()
 


### PR DESCRIPTION
NTLM was missing from the features list, and SMB/SMBS from
the protocols list in SecureTransport builds.

Follow-up to 76a9c3c4be10b3d4d379d5b23ca76806bbae536a #3619

Reported-by: Tal Regev
Bug: https://github.com/curl/curl/pull/13963#issuecomment-2178791390
Closes #14065
