### PR TITLE
 cmdline-docs: fix `--proxy-ca-native` example + tidy-ups

### DIFF
--- a/docs/cmdline-opts/proxy-ca-native.md
+++ b/docs/cmdline-opts/proxy-ca-native.md
@@ -12,7 +12,7 @@ See-also:
   - capath
   - insecure
 Example:
-  - --ca-native $URL
+  - --proxy-ca-native $URL
 ---
 
 # `--proxy-ca-native`

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1961,7 +1961,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     case C_PROGRESS_BAR: /* --progress-bar */
       global->progressmode = toggle ? CURL_PROGRESS_BAR : CURL_PROGRESS_STATS;
       break;
-    case C_VARIABLE: /* --Variable */
+    case C_VARIABLE: /* --variable */
       err = setvariable(global, nextarg);
       break;
     case C_NEXT: /* --next */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -104,10 +104,10 @@
 #  define SOL_IP IPPROTO_IP
 #endif
 
-#define CURL_CA_CERT_ERRORMSG                                           \
-  "More details here: https://curl.se/docs/sslcerts.html\n\n"           \
-  "curl failed to verify the legitimacy of the server and therefore "   \
-  "could not\nestablish a secure connection to it. To learn more about " \
+#define CURL_CA_CERT_ERRORMSG                                              \
+  "More details here: https://curl.se/docs/sslcerts.html\n\n"              \
+  "curl failed to verify the legitimacy of the server and therefore "      \
+  "could not\nestablish a secure connection to it. To learn more about "   \
   "this situation and\nhow to fix it, please visit the webpage mentioned " \
   "above.\n"
 


### PR DESCRIPTION
Also:
- fix an indentation.
- fix capitalized option in comment.

Closes #14078
