### PR TITLE
winbuild: MS-DOS batch tidy-ups

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,6 @@ configure.ac eol=lf
 *.sh eol=lf
 *.[ch] whitespace=tab-in-indent
 
-# Batch files (bat,cmd) must be run with CRLF line endings.
+# Batch files must be run with CRLF line endings.
 # Refer to https://github.com/curl/curl/pull/6442
 *.bat text eol=crlf
-*.cmd text eol=crlf

--- a/.github/scripts/spacecheck.pl
+++ b/.github/scripts/spacecheck.pl
@@ -30,7 +30,7 @@ my @tabs = (
     "^m4/zz40-xc-ovr.m4",
     "Makefile\\.[a-z]+\$",
     "/mkfile",
-    "\\.(bat|cmd|sln|vc)\$",
+    "\\.(bat|sln|vc)\$",
     "^tests/certs/.+\\.der\$",
     "^tests/data/test",
 );
@@ -43,7 +43,7 @@ my @mixed_eol = (
 
 my @need_crlf = (
     "\\.(bat|sln)\$",
-    "^winbuild/.+\\.(cmd|md)\$",
+    "^winbuild/.+\\.md\$",
 );
 
 my @space_at_eol = (

--- a/Makefile.am
+++ b/Makefile.am
@@ -62,7 +62,7 @@ VC_DIST = projects/README.md                           \
  projects/wolfssl_override.props
 
 WINBUILD_DIST = winbuild/README.md winbuild/gen_resp_file.bat \
- winbuild/MakefileBuild.vc winbuild/Makefile.vc winbuild/makedebug.cmd
+ winbuild/MakefileBuild.vc winbuild/Makefile.vc winbuild/makedebug.bat
 
 PLAN9_DIST = plan9/include/mkfile \
  plan9/include/mkfile             \

--- a/packages/OS400/.gitattributes
+++ b/packages/OS400/.gitattributes
@@ -1,6 +1,0 @@
-# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
-#
-# SPDX-License-Identifier: curl
-
-# OS400 .cmd files are not windows scripts.
-*.cmd text eol=auto

--- a/winbuild/makedebug.bat
+++ b/winbuild/makedebug.bat
@@ -25,12 +25,9 @@ rem ***************************************************************************
 
 where.exe nmake.exe >nul 2>&1
 
-IF %ERRORLEVEL% == 1 (
-  ECHO Error: Can't find `nmake.exe` - be sure to run this script from within a Developer Command-Prompt
-  ECHO.
-) ELSE (
-  nmake /f Makefile.vc mode=static DEBUG=yes GEN_PDB=yes
-  IF %ERRORLEVEL% NEQ 0 (
-    ECHO "Error: Build Failed"
-  )
+if %ERRORLEVEL% EQU 1 (
+  echo Error: Cannot find nmake.exe - be sure to run this script from within a Developer Command-Prompt
+) else (
+  nmake.exe /f Makefile.vc mode=static DEBUG=yes GEN_PDB=yes
+  if %ERRORLEVEL% NEQ 0 echo Error: Build Failed
 )


### PR DESCRIPTION
- prefer `.bat` extension over `.cmd` for MS-DOS batch, which also avoids
  confusion with OS/400 `.cmd` files.
- cleanup `echo` quotes, drop them consistently.
- delete empty output line from one of the error branches.
- prefer lowercase commands like the rest of MS-DOS batches.
- delete a contraction.
- drop backticks from error message.
- use `nmake.exe` consistently.
- use equal/not-equal operator style consistently.
- inline a single-line `if` branch.
- delete exceptions and rules dealing with Windows `.cmd` extension.

Closes #14084