### PR TITLE
GHA: Windows job exclusions tweaks

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -466,7 +466,7 @@ jobs:
         shell: bash
         run: |
           git clone --quiet --depth 1 https://github.com/microsoft/vcpkg/
-          vcpkg/bootstrap-vcpkg.sh
+          vcpkg/bootstrap-vcpkg.sh -disableMetrics
 
       - name: 'vcpkg build'
         timeout-minutes: 10

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -235,6 +235,7 @@ jobs:
         shell: msys2 {0}
         run: |
           export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
+          [ '${{ matrix.sys }}' != 'msys' ] && TFLAGS+=' !3005 !3006'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -301,6 +302,7 @@ jobs:
         shell: msys2 {0}
         run: |
           export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
+          [ '${{ matrix.sys }}' != 'msys' ] && TFLAGS+=' !3005 !3006'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -422,6 +422,8 @@ jobs:
     name: 'msvc (${{ matrix.arch }}, ${{ matrix.plat }}, ${{ matrix.name }})'
     runs-on: windows-latest
     timeout-minutes: 30
+    env:
+      VCPKG_DISABLE_METRICS: '1'
     strategy:
       matrix:
         include:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -556,7 +556,7 @@ jobs:
         timeout-minutes: 30
         shell: bash
         run: |
-          export TFLAGS='-j14 !TFTP !SMTP ${{ matrix.tflags }}'
+          export TFLAGS='-j14 !TFTP !MQTT !WebSockets !SMTP ${{ matrix.tflags }}'
           export VCPKG_ROOT="$PWD/vcpkg"
           export VCPKG_TRIPLET_DIR="$VCPKG_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
           export debug_lib="$VCPKG_TRIPLET_DIR/debug/bin"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -236,7 +236,7 @@ jobs:
         run: |
           export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
-            TFLAGS+=' !TFTP !MQTT !WebSockets !3005 !3006'
+            TFLAGS+=' !TFTP !MQTT !WebSockets !SMTP'
           fi
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
@@ -305,7 +305,7 @@ jobs:
         run: |
           export TFLAGS='-j14 ${{ matrix.tflags }}'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
-            TFLAGS+=' !TFTP !MQTT !WebSockets !3005 !3006'
+            TFLAGS+=' !TFTP !MQTT !WebSockets !SMTP'
           fi
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
@@ -556,7 +556,7 @@ jobs:
         timeout-minutes: 30
         shell: bash
         run: |
-          export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
+          export TFLAGS='-j14 !TFTP !SMTP ${{ matrix.tflags }}'
           export VCPKG_ROOT="$PWD/vcpkg"
           export VCPKG_TRIPLET_DIR="$VCPKG_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
           export debug_lib="$VCPKG_TRIPLET_DIR/debug/bin"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -332,7 +332,7 @@ jobs:
             dir: 'mingw64'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON'
-            type: 'Debug'
+            type: 'Release'
             tflags: '~2301 ~2302 ~3027'
           - build: 'cmake'
             env: '6.4.0-i686'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -411,7 +411,7 @@ jobs:
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
           export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
+          export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -234,8 +234,10 @@ jobs:
         timeout-minutes: 30
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
-          [ '${{ matrix.sys }}' != 'msys' ] && TFLAGS+=' !3005 !3006'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          if [ '${{ matrix.sys }}' != 'msys' ]; then
+            TFLAGS+=' !TFTP !MQTT !WebSockets !3005 !3006'
+          fi
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -301,8 +303,10 @@ jobs:
         timeout-minutes: 40
         shell: msys2 {0}
         run: |
-          export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
-          [ '${{ matrix.sys }}' != 'msys' ] && TFLAGS+=' !3005 !3006'
+          export TFLAGS='-j14 ${{ matrix.tflags }}'
+          if [ '${{ matrix.sys }}' != 'msys' ]; then
+            TFLAGS+=' !TFTP !MQTT !WebSockets !3005 !3006'
+          fi
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -407,7 +411,7 @@ jobs:
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
           export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
+          export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -552,7 +556,7 @@ jobs:
         timeout-minutes: 30
         shell: bash
         run: |
-          export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
+          export TFLAGS='-j14 !TFTP ${{ matrix.tflags }}'
           export VCPKG_ROOT="$PWD/vcpkg"
           export VCPKG_TRIPLET_DIR="$VCPKG_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
           export debug_lib="$VCPKG_TRIPLET_DIR/debug/bin"


### PR DESCRIPTION
- disable SMTP tests in MSYS2/mingw-w64 and MSVC jobs.
  On the suspicion of sometimes hanging:
  https://github.com/curl/curl/actions/runs/9346162475/job/25720437944?pr=13855#step:14:2838
  https://github.com/curl/curl/actions/runs/9758011305/job/26931678639?pr=14084#step:14:2834
  https://github.com/curl/curl/actions/runs/9774468536/job/26982805294#step:11:4731

- run TFTP, MQTT, WebSockets tests in MSYS2/msys jobs again.

- switch hanging old-mingw-w64 7.3.0 job to Release (from Debug).
  Guessing here, 9.5.0 is more solid, and one difference is
  Debug/Release mode. Let's match 7.3.0 with that and see how it changes
  hangs and flakiness.
  The other difference is Unicode ON in 7.3.0. Flaky 6.3.0 was also
  Debug, with Unicode OFF:
  217878bade884202ee5fb2e80186c5fd130392e8 #13566.
  (Unicode unlikely to play a role here IMO.)
  If 7.3.0 keeps hanging / remains flaky I'll consider disabling its
  test runs.

- opt-out from vcpkg telemetry.

Ref: https://github.com/curl/curl/pull/13599#issuecomment-2119372376
Closes #14085
