### PR TITLE
connection filters, turn 2 methods into query

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -378,7 +378,7 @@ static CURLcode recv_CONNECT_resp(struct Curl_cfilter *cf,
   error = SELECT_OK;
   *done = FALSE;
 
-  if(!Curl_conn_data_pending(data, cf->sockindex))
+  if(!Curl_conn_input_pending(data, cf->sockindex))
     return CURLE_OK;
 
   while(ts->keepon) {
@@ -1079,7 +1079,6 @@ struct Curl_cftype Curl_cft_h1_proxy = {
   Curl_cf_def_shutdown,
   Curl_cf_http_proxy_get_host,
   cf_h1_proxy_adjust_pollset,
-  Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -1083,7 +1083,6 @@ struct Curl_cftype Curl_cft_h1_proxy = {
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,
-  Curl_cf_def_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   Curl_cf_def_query,
 };

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -201,7 +201,6 @@ struct Curl_cftype Curl_cft_haproxy = {
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,
-  Curl_cf_def_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   Curl_cf_def_query,
 };

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -197,7 +197,6 @@ struct Curl_cftype Curl_cft_haproxy = {
   Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_haproxy_adjust_pollset,
-  Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -485,7 +485,6 @@ struct Curl_cftype Curl_cft_http_connect = {
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,
-  Curl_cf_def_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   cf_hc_query,
 };

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1791,12 +1791,13 @@ static CURLcode cf_socket_query(struct Curl_cfilter *cf,
     }
     return CURLE_OK;
   }
+  case CF_QUERY_IS_ALIVE:
+    *pres1 = cf_socket_conn_is_alive(cf, data, (bool *)pres2);
+    return CURLE_OK;
   default:
     break;
   }
-  return cf->next?
-    cf->next->cft->query(cf->next, data, query, pres1, pres2) :
-    CURLE_UNKNOWN_OPTION;
+  return Curl_cf_def_query(cf, data, query, pres1, pres2);
 }
 
 struct Curl_cftype Curl_cft_tcp = {
@@ -1813,7 +1814,6 @@ struct Curl_cftype Curl_cft_tcp = {
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
-  cf_socket_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   cf_socket_query,
 };
@@ -1962,7 +1962,6 @@ struct Curl_cftype Curl_cft_udp = {
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
-  cf_socket_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   cf_socket_query,
 };
@@ -2014,7 +2013,6 @@ struct Curl_cftype Curl_cft_unix = {
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
-  cf_socket_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   cf_socket_query,
 };
@@ -2079,7 +2077,6 @@ struct Curl_cftype Curl_cft_tcp_accept = {
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
-  cf_socket_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   cf_socket_query,
 };

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1461,8 +1461,8 @@ static void cf_socket_adjust_pollset(struct Curl_cfilter *cf,
   }
 }
 
-static bool cf_socket_data_pending(struct Curl_cfilter *cf,
-                                   const struct Curl_easy *data)
+static bool cf_socket_input_pending(struct Curl_cfilter *cf,
+                                    struct Curl_easy *data)
 {
   struct cf_socket_ctx *ctx = cf->ctx;
   int readable;
@@ -1794,6 +1794,9 @@ static CURLcode cf_socket_query(struct Curl_cfilter *cf,
   case CF_QUERY_IS_ALIVE:
     *pres1 = cf_socket_conn_is_alive(cf, data, (bool *)pres2);
     return CURLE_OK;
+  case CF_QUERY_INPUT_PENDING:
+    *pres1 = cf_socket_input_pending(cf, data);
+    return CURLE_OK;
   default:
     break;
   }
@@ -1810,7 +1813,6 @@ struct Curl_cftype Curl_cft_tcp = {
   cf_socket_shutdown,
   cf_socket_get_host,
   cf_socket_adjust_pollset,
-  cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
@@ -1958,7 +1960,6 @@ struct Curl_cftype Curl_cft_udp = {
   cf_socket_shutdown,
   cf_socket_get_host,
   cf_socket_adjust_pollset,
-  cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
@@ -2009,7 +2010,6 @@ struct Curl_cftype Curl_cft_unix = {
   cf_socket_shutdown,
   cf_socket_get_host,
   cf_socket_adjust_pollset,
-  cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
@@ -2073,7 +2073,6 @@ struct Curl_cftype Curl_cft_tcp_accept = {
   cf_socket_shutdown,
   cf_socket_get_host,              /* TODO: not accurate */
   cf_socket_adjust_pollset,
-  cf_socket_data_pending,
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -755,10 +755,9 @@ bool Curl_conn_cf_is_alive(struct Curl_cfilter *cf,
   return FALSE;
 }
 
-bool Curl_conn_is_alive(struct Curl_easy *data, struct connectdata *conn,
-                        bool *input_pending)
+bool Curl_conn_is_alive(struct Curl_easy *data, bool *input_pending)
 {
-  struct Curl_cfilter *cf = conn->cfilter[FIRSTSOCKET];
+  struct Curl_cfilter *cf = data->conn->cfilter[FIRSTSOCKET];
 
   *input_pending = FALSE;
   if(cf->conn->bits.close)

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -90,13 +90,6 @@ void Curl_cf_def_adjust_pollset(struct Curl_cfilter *cf,
   (void)ps;
 }
 
-bool Curl_cf_def_data_pending(struct Curl_cfilter *cf,
-                              const struct Curl_easy *data)
-{
-  return cf->next?
-    cf->next->cft->has_data_pending(cf->next, data) : FALSE;
-}
-
 ssize_t  Curl_cf_def_send(struct Curl_cfilter *cf, struct Curl_easy *data,
                           const void *buf, size_t len, CURLcode *err)
 {
@@ -474,22 +467,33 @@ bool Curl_conn_is_multiplex(struct connectdata *conn, int sockindex)
   return FALSE;
 }
 
-bool Curl_conn_data_pending(struct Curl_easy *data, int sockindex)
+bool Curl_conn_cf_input_pending(struct Curl_cfilter *cf,
+                                struct Curl_easy *data)
+{
+  if(cf) {
+    int input_pending = FALSE;
+    CURLcode result = cf->cft->query(cf, data, CF_QUERY_INPUT_PENDING,
+                                     &input_pending, NULL);
+    return !result && !!input_pending;
+  }
+  return FALSE;
+}
+
+bool Curl_conn_input_pending(struct Curl_easy *data, int sockindex)
 {
   struct Curl_cfilter *cf;
 
-  (void)data;
   DEBUGASSERT(data);
   DEBUGASSERT(data->conn);
-
   cf = data->conn->cfilter[sockindex];
-  while(cf && !cf->connected) {
+  /* Get the lowest not-connected filter, if there is one */
+  while(cf && !cf->connected && cf->next && !cf->next->connected)
     cf = cf->next;
-  }
-  if(cf) {
-    return cf->cft->has_data_pending(cf, data);
-  }
-  return FALSE;
+  /* Skip all filters already shut down */
+  while(cf && cf->shutdown)
+    cf = cf->next;
+
+  return Curl_conn_cf_input_pending(cf, data);
 }
 
 void Curl_conn_cf_adjust_pollset(struct Curl_cfilter *cf,

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -98,9 +98,6 @@ typedef void     Curl_cft_adjust_pollset(struct Curl_cfilter *cf,
                                           struct Curl_easy *data,
                                           struct easy_pollset *ps);
 
-typedef bool     Curl_cft_data_pending(struct Curl_cfilter *cf,
-                                       const struct Curl_easy *data);
-
 typedef ssize_t  Curl_cft_send(struct Curl_cfilter *cf,
                                struct Curl_easy *data, /* transfer */
                                const void *buf,        /* data to write */
@@ -167,6 +164,7 @@ typedef CURLcode Curl_cft_cntrl(struct Curl_cfilter *cf,
 #define CF_QUERY_TIMER_APPCONNECT   5  /* -          struct curltime */
 #define CF_QUERY_STREAM_ERROR       6  /* error code - */
 #define CF_QUERY_IS_ALIVE           7  /* TRUE/FALSE bool* input_pending */
+#define CF_QUERY_INPUT_PENDING      8  /* TRUE/FALSE - */
 
 /**
  * Query the cfilter for properties. Filters ignorant of a query will
@@ -203,7 +201,6 @@ struct Curl_cftype {
   Curl_cft_shutdown *do_shutdown;         /* shutdown conn */
   Curl_cft_get_host *get_host;            /* host filter talks to */
   Curl_cft_adjust_pollset *adjust_pollset; /* adjust transfer poll set */
-  Curl_cft_data_pending *has_data_pending;/* conn has data pending */
   Curl_cft_send *do_send;                 /* send data */
   Curl_cft_recv *do_recv;                 /* receive data */
   Curl_cft_cntrl *cntrl;                  /* events/control */
@@ -234,8 +231,6 @@ void     Curl_cf_def_get_host(struct Curl_cfilter *cf, struct Curl_easy *data,
 void     Curl_cf_def_adjust_pollset(struct Curl_cfilter *cf,
                                      struct Curl_easy *data,
                                      struct easy_pollset *ps);
-bool     Curl_cf_def_data_pending(struct Curl_cfilter *cf,
-                                  const struct Curl_easy *data);
 ssize_t  Curl_cf_def_send(struct Curl_cfilter *cf, struct Curl_easy *data,
                           const void *buf, size_t len, CURLcode *err);
 ssize_t  Curl_cf_def_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
@@ -384,12 +379,18 @@ void Curl_conn_close(struct Curl_easy *data, int sockindex);
  */
 CURLcode Curl_conn_shutdown(struct Curl_easy *data, int sockindex, bool *done);
 
+
 /**
- * Return if data is pending in some connection filter at chain
+ * Return if the filter chain starting at `cf` has input data pending.
+ */
+bool Curl_conn_cf_input_pending(struct Curl_cfilter *cf,
+                                struct Curl_easy *data);
+
+/**
+ * Return if input data is pending in the connection filter chain at
  * `sockindex` for connection `data->conn`.
  */
-bool Curl_conn_data_pending(struct Curl_easy *data,
-                            int sockindex);
+bool Curl_conn_input_pending(struct Curl_easy *data, int sockindex);
 
 /**
  * Return the socket used on data's connection for the index.

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -506,8 +506,7 @@ bool Curl_conn_cf_is_alive(struct Curl_cfilter *cf,
 /**
  * Check if FIRSTSOCKET's cfilter chain deems connection alive.
  */
-bool Curl_conn_is_alive(struct Curl_easy *data, struct connectdata *conn,
-                        bool *input_pending);
+bool Curl_conn_is_alive(struct Curl_easy *data, bool *input_pending);
 
 /**
  * Try to upkeep the connection filters at sockindex.

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -113,10 +113,6 @@ typedef ssize_t  Curl_cft_recv(struct Curl_cfilter *cf,
                                size_t len,             /* amount to read */
                                CURLcode *err);         /* error to return */
 
-typedef bool     Curl_cft_conn_is_alive(struct Curl_cfilter *cf,
-                                        struct Curl_easy *data,
-                                        bool *input_pending);
-
 typedef CURLcode Curl_cft_conn_keep_alive(struct Curl_cfilter *cf,
                                           struct Curl_easy *data);
 
@@ -170,6 +166,7 @@ typedef CURLcode Curl_cft_cntrl(struct Curl_cfilter *cf,
 #define CF_QUERY_TIMER_CONNECT      4  /* -          struct curltime */
 #define CF_QUERY_TIMER_APPCONNECT   5  /* -          struct curltime */
 #define CF_QUERY_STREAM_ERROR       6  /* error code - */
+#define CF_QUERY_IS_ALIVE           7  /* TRUE/FALSE bool* input_pending */
 
 /**
  * Query the cfilter for properties. Filters ignorant of a query will
@@ -210,7 +207,6 @@ struct Curl_cftype {
   Curl_cft_send *do_send;                 /* send data */
   Curl_cft_recv *do_recv;                 /* receive data */
   Curl_cft_cntrl *cntrl;                  /* events/control */
-  Curl_cft_conn_is_alive *is_alive;       /* FALSE if conn is dead, Jim! */
   Curl_cft_conn_keep_alive *keep_alive;   /* try to keep it alive */
   Curl_cft_query *query;                  /* query filter chain */
 };
@@ -247,9 +243,6 @@ ssize_t  Curl_cf_def_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 CURLcode Curl_cf_def_cntrl(struct Curl_cfilter *cf,
                                 struct Curl_easy *data,
                                 int event, int arg1, void *arg2);
-bool     Curl_cf_def_conn_is_alive(struct Curl_cfilter *cf,
-                                   struct Curl_easy *data,
-                                   bool *input_pending);
 CURLcode Curl_cf_def_conn_keep_alive(struct Curl_cfilter *cf,
                                      struct Curl_easy *data);
 CURLcode Curl_cf_def_query(struct Curl_cfilter *cf,
@@ -501,6 +494,13 @@ CURLcode Curl_conn_ev_data_pause(struct Curl_easy *data, bool do_pause);
  */
 void Curl_conn_ev_update_info(struct Curl_easy *data,
                               struct connectdata *conn);
+
+/**
+ * Check if a connection filter deems the connection to be alive.
+ */
+bool Curl_conn_cf_is_alive(struct Curl_cfilter *cf,
+                           struct Curl_easy *data,
+                           bool *input_pending);
 
 /**
  * Check if FIRSTSOCKET's cfilter chain deems connection alive.

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1143,7 +1143,6 @@ struct Curl_cftype Curl_cft_happy_eyeballs = {
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,
-  Curl_cf_def_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   cf_he_query,
 };
@@ -1408,7 +1407,6 @@ struct Curl_cftype Curl_cft_setup = {
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,
-  Curl_cf_def_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   Curl_cf_def_query,
 };

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1306,7 +1306,7 @@ static int conn_upkeep(struct Curl_easy *data,
   Curl_attach_connection(data, conn);
   if(conn->handler->connection_check) {
     /* Do a protocol-specific keepalive check on the connection. */
-    conn->handler->connection_check(data, conn, CONNCHECK_KEEPALIVE);
+    conn->handler->connection_check(data, CONNCHECK_KEEPALIVE);
   }
   else {
     /* Do the generic action on the FIRSTSOCKET filter chain */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -863,7 +863,7 @@ CURLcode Curl_GetFTPResponse(struct Curl_easy *data,
        * wait for more data anyway.
        */
     }
-    else if(!Curl_conn_data_pending(data, FIRSTSOCKET)) {
+    else if(!Curl_conn_input_pending(data, FIRSTSOCKET)) {
       switch(SOCKET_READABLE(sockfd, interval_ms)) {
       case -1: /* select() error, stop reading */
         failf(data, "FTP response aborted due to select/poll error: %d",

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -305,7 +305,6 @@ struct Curl_cftype Curl_cft_http_proxy = {
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,
-  Curl_cf_def_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   Curl_cf_def_query,
 };

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -301,7 +301,6 @@ struct Curl_cftype Curl_cft_http_proxy = {
   Curl_cf_def_shutdown,
   Curl_cf_http_proxy_get_host,
   Curl_cf_def_adjust_pollset,
-  Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -1166,7 +1166,7 @@ ldapsb_tls_ctrl(Sockbuf_IO_Desc *sbiod, int opt, void *arg)
   (void)arg;
   if(opt == LBER_SB_OPT_DATA_READY) {
     struct Curl_easy *data = sbiod->sbiod_pvt;
-    return Curl_conn_data_pending(data, FIRSTSOCKET);
+    return Curl_conn_input_pending(data, FIRSTSOCKET);
   }
   return 0;
 }

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -104,12 +104,12 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data,
   else
     interval_ms = 0; /* immediate */
 
-  if(Curl_conn_data_pending(data, FIRSTSOCKET))
+  if(Curl_conn_input_pending(data, FIRSTSOCKET))
     rc = 1;
   else if(pp->overflow)
     /* We are receiving and there is data in the cache so just read it */
     rc = 1;
-  else if(!pp->sendleft && Curl_conn_data_pending(data, FIRSTSOCKET))
+  else if(!pp->sendleft && Curl_conn_input_pending(data, FIRSTSOCKET))
     /* We are receiving and there is data ready in the SSL library */
     rc = 1;
   else

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -75,7 +75,6 @@ static CURLcode rtsp_rtp_write_resp(struct Curl_easy *data,
 static CURLcode rtsp_setup_connection(struct Curl_easy *data,
                                       struct connectdata *conn);
 static unsigned int rtsp_conncheck(struct Curl_easy *data,
-                                   struct connectdata *check,
                                    unsigned int checks_to_perform);
 
 /* this returns the socket to wait for in the DO and DOING state for the multi
@@ -144,18 +143,15 @@ static CURLcode rtsp_setup_connection(struct Curl_easy *data,
  * Function to check on various aspects of a connection.
  */
 static unsigned int rtsp_conncheck(struct Curl_easy *data,
-                                   struct connectdata *conn,
                                    unsigned int checks_to_perform)
 {
   unsigned int ret_val = CONNRESULT_NONE;
-  (void)data;
 
   if(checks_to_perform & CONNCHECK_ISDEAD) {
     bool input_pending;
-    if(!Curl_conn_is_alive(data, conn, &input_pending))
+    if(!Curl_conn_is_alive(data, &input_pending))
       ret_val |= CONNRESULT_DEAD;
   }
-
   return ret_val;
 }
 

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1256,7 +1256,6 @@ struct Curl_cftype Curl_cft_socks_proxy = {
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,
-  Curl_cf_def_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   Curl_cf_def_query,
 };

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1252,7 +1252,6 @@ struct Curl_cftype Curl_cft_socks_proxy = {
   Curl_cf_def_shutdown,
   socks_cf_get_host,
   socks_cf_adjust_pollset,
-  Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -120,12 +120,12 @@ static int data_pending(struct Curl_easy *data)
   struct connectdata *conn = data->conn;
 
   if(conn->handler->protocol&PROTO_FAMILY_FTP)
-    return Curl_conn_data_pending(data, SECONDARYSOCKET);
+    return Curl_conn_input_pending(data, SECONDARYSOCKET);
 
   /* in the case of libssh2, we can never be really sure that we have emptied
      its internal buffers so we MUST always try until we get EAGAIN back */
   return conn->handler->protocol&(CURLPROTO_SCP|CURLPROTO_SFTP) ||
-    Curl_conn_data_pending(data, FIRSTSOCKET);
+    Curl_conn_input_pending(data, FIRSTSOCKET);
 }
 
 /*

--- a/lib/url.c
+++ b/lib/url.c
@@ -778,7 +778,7 @@ static bool prune_if_dead(struct connectdata *conn,
          checking it */
       Curl_attach_connection(data, conn);
 
-      state = conn->handler->connection_check(data, conn, CONNCHECK_ISDEAD);
+      state = conn->handler->connection_check(data, CONNCHECK_ISDEAD);
       dead = (state & CONNRESULT_DEAD);
       /* detach the connection again */
       Curl_detach_connection(data);
@@ -788,7 +788,7 @@ static bool prune_if_dead(struct connectdata *conn,
       bool input_pending = FALSE;
 
       Curl_attach_connection(data, conn);
-      dead = !Curl_conn_is_alive(data, conn, &input_pending);
+      dead = !Curl_conn_is_alive(data, &input_pending);
       if(input_pending) {
         /* For reuse, we want a "clean" connection state. The includes
          * that we expect - in general - no waiting input data. Input

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -718,7 +718,6 @@ struct Curl_handler {
      CONNCHECK_* for more information about the checks that can be performed,
      and CONNRESULT_* for the results that can be returned. */
   unsigned int (*connection_check)(struct Curl_easy *data,
-                                   struct connectdata *conn,
                                    unsigned int checks_to_perform);
 
   /* attach() attaches this transfer to this connection */

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -724,8 +724,8 @@ static void cf_msh3_adjust_pollset(struct Curl_cfilter *cf,
   }
 }
 
-static bool cf_msh3_data_pending(struct Curl_cfilter *cf,
-                                 const struct Curl_easy *data)
+static bool cf_msh3_input_pending(struct Curl_cfilter *cf,
+                                  struct Curl_easy *data)
 {
   struct cf_msh3_ctx *ctx = cf->ctx;
   struct stream_ctx *stream = H3_STREAM_CTX(ctx, data);
@@ -1014,6 +1014,9 @@ static CURLcode cf_msh3_query(struct Curl_cfilter *cf,
   case CF_QUERY_IS_ALIVE:
     *pres1 = cf_msh3_conn_is_alive(cf, data, (bool *)pres2);
     return CURLE_OK;
+  case CF_QUERY_INPUT_PENDING:
+    *pres1 = cf_msh3_input_pending(cf, data);
+    return CURLE_OK;
   default:
     break;
   }
@@ -1042,7 +1045,6 @@ struct Curl_cftype Curl_cft_http3 = {
   Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_msh3_adjust_pollset,
-  cf_msh3_data_pending,
   cf_msh3_send,
   cf_msh3_recv,
   cf_msh3_data_event,

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -985,6 +985,18 @@ static void cf_msh3_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 
 }
 
+static bool cf_msh3_conn_is_alive(struct Curl_cfilter *cf,
+                                  struct Curl_easy *data,
+                                  bool *input_pending)
+{
+  struct cf_msh3_ctx *ctx = cf->ctx;
+
+  (void)data;
+  *input_pending = FALSE;
+  return ctx && ctx->sock[SP_LOCAL] != CURL_SOCKET_BAD && ctx->qconn &&
+         ctx->connected;
+}
+
 static CURLcode cf_msh3_query(struct Curl_cfilter *cf,
                               struct Curl_easy *data,
                               int query, int *pres1, void *pres2)
@@ -1021,18 +1033,6 @@ static CURLcode cf_msh3_query(struct Curl_cfilter *cf,
     break;
   }
   return Curl_cf_def_query(cf, data, query, pres1, pres2);
-}
-
-static bool cf_msh3_conn_is_alive(struct Curl_cfilter *cf,
-                                  struct Curl_easy *data,
-                                  bool *input_pending)
-{
-  struct cf_msh3_ctx *ctx = cf->ctx;
-
-  (void)data;
-  *input_pending = FALSE;
-  return ctx && ctx->sock[SP_LOCAL] != CURL_SOCKET_BAD && ctx->qconn &&
-         ctx->connected;
 }
 
 struct Curl_cftype Curl_cft_http3 = {

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -1011,12 +1011,13 @@ static CURLcode cf_msh3_query(struct Curl_cfilter *cf,
       *when = ctx->handshake_at;
     return CURLE_OK;
   }
+  case CF_QUERY_IS_ALIVE:
+    *pres1 = cf_msh3_conn_is_alive(cf, data, (bool *)pres2);
+    return CURLE_OK;
   default:
     break;
   }
-  return cf->next?
-    cf->next->cft->query(cf->next, data, query, pres1, pres2) :
-    CURLE_UNKNOWN_OPTION;
+  return Curl_cf_def_query(cf, data, query, pres1, pres2);
 }
 
 static bool cf_msh3_conn_is_alive(struct Curl_cfilter *cf,
@@ -1045,7 +1046,6 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_msh3_send,
   cf_msh3_recv,
   cf_msh3_data_event,
-  cf_msh3_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   cf_msh3_query,
 };

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1913,18 +1913,6 @@ out:
   return CURLE_OK;
 }
 
-/*
- * Called from transfer.c:data_pending to know if we should keep looping
- * to receive more data from the connection.
- */
-static bool cf_ngtcp2_data_pending(struct Curl_cfilter *cf,
-                                   const struct Curl_easy *data)
-{
-  (void)cf;
-  (void)data;
-  return FALSE;
-}
-
 static CURLcode h3_data_pause(struct Curl_cfilter *cf,
                               struct Curl_easy *data,
                               bool pause)
@@ -2497,6 +2485,9 @@ static CURLcode cf_ngtcp2_query(struct Curl_cfilter *cf,
   case CF_QUERY_IS_ALIVE:
     *pres1 = cf_ngtcp2_conn_is_alive(cf, data, (bool *)pres2);
     return CURLE_OK;
+  case CF_QUERY_INPUT_PENDING:
+    /* we never buffer */
+    break;
   default:
     break;
   }
@@ -2513,7 +2504,6 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_ngtcp2_shutdown,
   Curl_cf_def_get_host,
   cf_ngtcp2_adjust_pollset,
-  cf_ngtcp2_data_pending,
   cf_ngtcp2_send,
   cf_ngtcp2_recv,
   cf_ngtcp2_data_event,

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -2123,8 +2123,8 @@ out:
  * Called from transfer.c:data_pending to know if we should keep looping
  * to receive more data from the connection.
  */
-static bool cf_osslq_data_pending(struct Curl_cfilter *cf,
-                                  const struct Curl_easy *data)
+static bool cf_osslq_input_pending(struct Curl_cfilter *cf,
+                                   struct Curl_easy *data)
 {
   struct cf_osslq_ctx *ctx = cf->ctx;
   const struct h3_stream_ctx *stream = H3_STREAM_CTX(ctx, data);
@@ -2313,6 +2313,9 @@ static CURLcode cf_osslq_query(struct Curl_cfilter *cf,
   case CF_QUERY_IS_ALIVE:
     *pres1 = cf_osslq_conn_is_alive(cf, data, (bool *)pres2);
     return CURLE_OK;
+  case CF_QUERY_INPUT_PENDING:
+    *pres1 = cf_osslq_input_pending(cf, data);
+    return CURLE_OK;
   default:
     break;
   }
@@ -2329,7 +2332,6 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_osslq_shutdown,
   Curl_cf_def_get_host,
   cf_osslq_adjust_pollset,
-  cf_osslq_data_pending,
   cf_osslq_send,
   cf_osslq_recv,
   cf_osslq_data_event,

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -2179,6 +2179,39 @@ static CURLcode cf_osslq_data_event(struct Curl_cfilter *cf,
   return result;
 }
 
+static void cf_osslq_adjust_pollset(struct Curl_cfilter *cf,
+                                    struct Curl_easy *data,
+                                    struct easy_pollset *ps)
+{
+  struct cf_osslq_ctx *ctx = cf->ctx;
+
+  if(!ctx->tls.ossl.ssl) {
+    /* NOP */
+  }
+  else if(!cf->connected) {
+    /* during handshake, transfer has not started yet. we always
+     * add our socket for polling if SSL wants to send/recv */
+    Curl_pollset_set(data, ps, ctx->q.sockfd,
+                     SSL_net_read_desired(ctx->tls.ossl.ssl),
+                     SSL_net_write_desired(ctx->tls.ossl.ssl));
+  }
+  else {
+    /* once connected, we only modify the socket if it is present.
+     * this avoids adding it for paused transfers. */
+    bool want_recv, want_send;
+    Curl_pollset_check(data, ps, ctx->q.sockfd, &want_recv, &want_send);
+    if(want_recv || want_send) {
+      Curl_pollset_set(data, ps, ctx->q.sockfd,
+                       SSL_net_read_desired(ctx->tls.ossl.ssl),
+                       SSL_net_write_desired(ctx->tls.ossl.ssl));
+    }
+    else if(ctx->need_recv || ctx->need_send) {
+      Curl_pollset_set(data, ps, ctx->q.sockfd,
+                       ctx->need_recv, ctx->need_send);
+    }
+  }
+}
+
 static bool cf_osslq_conn_is_alive(struct Curl_cfilter *cf,
                                    struct Curl_easy *data,
                                    bool *input_pending)
@@ -2212,7 +2245,7 @@ static bool cf_osslq_conn_is_alive(struct Curl_cfilter *cf,
 
 #endif
 
-  if(!cf->next || !cf->next->cft->is_alive(cf->next, data, input_pending))
+  if(!Curl_conn_cf_is_alive(cf->next, data, input_pending))
     goto out;
 
   alive = TRUE;
@@ -2230,39 +2263,6 @@ static bool cf_osslq_conn_is_alive(struct Curl_cfilter *cf,
 out:
   CF_DATA_RESTORE(cf, save);
   return alive;
-}
-
-static void cf_osslq_adjust_pollset(struct Curl_cfilter *cf,
-                                    struct Curl_easy *data,
-                                    struct easy_pollset *ps)
-{
-  struct cf_osslq_ctx *ctx = cf->ctx;
-
-  if(!ctx->tls.ossl.ssl) {
-    /* NOP */
-  }
-  else if(!cf->connected) {
-    /* during handshake, transfer has not started yet. we always
-     * add our socket for polling if SSL wants to send/recv */
-    Curl_pollset_set(data, ps, ctx->q.sockfd,
-                     SSL_net_read_desired(ctx->tls.ossl.ssl),
-                     SSL_net_write_desired(ctx->tls.ossl.ssl));
-  }
-  else {
-    /* once connected, we only modify the socket if it is present.
-     * this avoids adding it for paused transfers. */
-    bool want_recv, want_send;
-    Curl_pollset_check(data, ps, ctx->q.sockfd, &want_recv, &want_send);
-    if(want_recv || want_send) {
-      Curl_pollset_set(data, ps, ctx->q.sockfd,
-                       SSL_net_read_desired(ctx->tls.ossl.ssl),
-                       SSL_net_write_desired(ctx->tls.ossl.ssl));
-    }
-    else if(ctx->need_recv || ctx->need_send) {
-      Curl_pollset_set(data, ps, ctx->q.sockfd,
-                       ctx->need_recv, ctx->need_send);
-    }
-  }
 }
 
 static CURLcode cf_osslq_query(struct Curl_cfilter *cf,
@@ -2310,12 +2310,13 @@ static CURLcode cf_osslq_query(struct Curl_cfilter *cf,
       *when = ctx->handshake_at;
     return CURLE_OK;
   }
+  case CF_QUERY_IS_ALIVE:
+    *pres1 = cf_osslq_conn_is_alive(cf, data, (bool *)pres2);
+    return CURLE_OK;
   default:
     break;
   }
-  return cf->next?
-    cf->next->cft->query(cf->next, data, query, pres1, pres2) :
-    CURLE_UNKNOWN_OPTION;
+  return Curl_cf_def_query(cf, data, query, pres1, pres2);
 }
 
 struct Curl_cftype Curl_cft_http3 = {
@@ -2332,7 +2333,6 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_osslq_send,
   cf_osslq_recv,
   cf_osslq_data_event,
-  cf_osslq_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   cf_osslq_query,
 };

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1165,8 +1165,8 @@ static void cf_quiche_adjust_pollset(struct Curl_cfilter *cf,
  * Called from transfer.c:data_pending to know if we should keep looping
  * to receive more data from the connection.
  */
-static bool cf_quiche_data_pending(struct Curl_cfilter *cf,
-                                   const struct Curl_easy *data)
+static bool cf_quiche_input_pending(struct Curl_cfilter *cf,
+                                    struct Curl_easy *data)
 {
   struct cf_quiche_ctx *ctx = cf->ctx;
   const struct stream_ctx *stream = H3_STREAM_CTX(ctx, data);
@@ -1610,6 +1610,9 @@ static CURLcode cf_quiche_query(struct Curl_cfilter *cf,
   case CF_QUERY_IS_ALIVE:
     *pres1 = cf_quiche_conn_is_alive(cf, data, (bool *)pres2);
     return CURLE_OK;
+  case CF_QUERY_INPUT_PENDING:
+    *pres1 = cf_quiche_input_pending(cf, data);
+    return CURLE_OK;
   default:
     break;
   }
@@ -1626,7 +1629,6 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_quiche_shutdown,
   Curl_cf_def_get_host,
   cf_quiche_adjust_pollset,
-  cf_quiche_data_pending,
   cf_quiche_send,
   cf_quiche_recv,
   cf_quiche_data_event,

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1909,7 +1909,7 @@ static CURLcode ossl_shutdown(struct Curl_cfilter *cf,
         *done = TRUE;
         goto out;
       }
-      else if(!cf->next->cft->is_alive(cf->next, data, &input_pending)) {
+      else if(!Curl_conn_cf_is_alive(cf->next, data, &input_pending)) {
         /* Server closed the connection after its closy notify. It
          * seems not interested to see our close notify, so do not
          * send it. We are done. */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1701,8 +1701,8 @@ out:
   return result;
 }
 
-static bool ssl_cf_data_pending(struct Curl_cfilter *cf,
-                                const struct Curl_easy *data)
+static bool cf_ssl_input_pending(struct Curl_cfilter *cf,
+                                 struct Curl_easy *data)
 {
   struct cf_call_data save;
   bool result;
@@ -1711,7 +1711,7 @@ static bool ssl_cf_data_pending(struct Curl_cfilter *cf,
   if(Curl_ssl->data_pending(cf, data))
     result = TRUE;
   else
-    result = cf->next->cft->has_data_pending(cf->next, data);
+    result = Curl_conn_cf_input_pending(cf->next, data);
   CF_DATA_RESTORE(cf, save);
   return result;
 }
@@ -1858,6 +1858,9 @@ static CURLcode cf_ssl_query(struct Curl_cfilter *cf,
   case CF_QUERY_IS_ALIVE:
     *pres1 = cf_ssl_is_alive(cf, data, (bool *)pres2);
     return CURLE_OK;
+  case CF_QUERY_INPUT_PENDING:
+    *pres1 = cf_ssl_input_pending(cf, data);
+    return CURLE_OK;
   default:
     break;
   }
@@ -1874,7 +1877,6 @@ struct Curl_cftype Curl_cft_ssl = {
   ssl_cf_shutdown,
   Curl_cf_def_get_host,
   ssl_cf_adjust_pollset,
-  ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,
   ssl_cf_cntrl,
@@ -1894,7 +1896,6 @@ struct Curl_cftype Curl_cft_ssl_proxy = {
   ssl_cf_shutdown,
   Curl_cf_def_get_host,
   ssl_cf_adjust_pollset,
-  ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,
   ssl_cf_cntrl,

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1378,7 +1378,7 @@ static CURLcode wolfssl_shutdown(struct Curl_cfilter *cf,
         *done = TRUE;
         goto out;
       }
-      else if(!cf->next->cft->is_alive(cf->next, data, &input_pending)) {
+      else if(!Curl_conn_cf_is_alive(cf->next, data, &input_pending)) {
         /* Server closed the connection after its closy notify. It
          * seems not interested to see our close notify, so do not
          * send it. We are done. */

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -175,7 +175,6 @@ static struct Curl_cftype cft_test = {
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,
-  Curl_cf_def_conn_is_alive,
   Curl_cf_def_conn_keep_alive,
   Curl_cf_def_query,
 };

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -171,7 +171,6 @@ static struct Curl_cftype cft_test = {
   Curl_cf_def_shutdown,
   Curl_cf_def_get_host,
   cf_test_adjust_pollset,
-  Curl_cf_def_data_pending,
   Curl_cf_def_send,
   Curl_cf_def_recv,
   Curl_cf_def_cntrl,


### PR DESCRIPTION
Two connection filter callback methods fit the query pattern. Remove the methods and define query constants for them.

- eliminate connection filters 'data_pending()' callback. Add query method `CF_QUERY_INPUT_PENDING`.
- eliminate connection filters 'is_alive()' callback. Add  query method `CF_QUERY_IS_ALIVE`.
- add helper method `Curl_conn_cf_input_pending()`, `Curl_conn_cf_is_alive()` to query a specific filter chain
- change filter implementations

Remove `struct connectdata *conn` parameter from `is_alive()` methods and protocol callback `conncheck()`, since `data` needs to be attached to the connection anyway.
