### PR TITLE
improve download performance, minimal effort

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -336,7 +336,7 @@ static CURLcode readwrite_data(struct Curl_easy *data,
     if((k->keepon & KEEP_RECV_PAUSE) || !(k->keepon & KEEP_RECV))
       break;
 
-  } while(maxloops-- && data_pending(data));
+  } while(maxloops--);
 
   if((maxloops <= 0) || data_pending(data)) {
     /* did not read until EAGAIN or there is still pending data, mark as


### PR DESCRIPTION
Do not poll the socket for pending data every transfer loop iteration. This gives 10-20% performance gains on large HTTP/1.1 downloads (on my machine).

```sh
> python3 tests/http/scorecard.py --httpd -d --download=100mb h1

         Size  single(1x1) [cpu/rss]         serial(50x1) [cpu/rss]         parallel(50x50) [cpu/rss]                Errors
before  100MB     781 MB/s [94.0%/8MB]          1163 MB/s [98.9%/9MB]          1450 MB/s [99.9%/18MB]
after   100MB     796 MB/s [94.1%/8MB]          1184 MB/s [98.8%/9MB]          1694 MB/s [100.0%/18MB]