### PR TITLE
openssl, configure libdir as 'lib' only

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -180,7 +180,7 @@ jobs:
           cd $HOME
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }} https://github.com/quictls/openssl quictls
           cd quictls
-          ./config no-deprecated --prefix=$PWD/build --libdir=$PWD/build/lib
+          ./config no-deprecated --prefix=$PWD/build --libdir=lib
           make
           make -j1 install_sw
         name: 'build quictls'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -297,7 +297,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b ${{ env.openssl3-version }} https://github.com/openssl/openssl
           cd openssl
-          ./config --prefix=$HOME/openssl3 --libdir=$HOME/openssl3/lib
+          ./config --prefix=$HOME/openssl3 --libdir=lib
           make -j1 install_sw
 
       - name: cache quictls
@@ -315,7 +315,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }} https://github.com/quictls/openssl
           cd openssl
-          ./config --prefix=$HOME/quictls --libdir=$HOME/quictls/lib
+          ./config --prefix=$HOME/quictls --libdir=lib
           make -j1 install_sw
 
       - name: cache msh3

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -215,7 +215,7 @@ Build OpenSSL 3.3.1
      % cd ..
      % git clone -b openssl-3.3.1 https://github.com/openssl/openssl
      % cd openssl
-     % ./config enable-tls1_3 --prefix=<somewhere> --libdir=<somewhere>/lib
+     % ./config enable-tls1_3 --prefix=<somewhere> --libdir=lib
      % make
      % make install
 


### PR DESCRIPTION
OpenSSL has a bug that messes the config `--libdir=path` to become the wrong path in its pkgconfig files. If we just pass `--libdir=lib` it should avoid this.

See also: https://github.com/openssl/openssl/issues/23569

refs #14099