### PR TITLE
tool_operate: simplify return code handling from url_proto()

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1338,9 +1338,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(result)
           break;
 
-        /* result is only used when for ipfs and ipns, ignored otherwise */
         result = url_proto(&per->this_url, config, &use_proto);
-        if(result && (use_proto == proto_ipfs || use_proto == proto_ipns))
+        if(result)
           break;
 
 #ifndef DEBUGBUILD


### PR DESCRIPTION
The additional checks were superfluous as it would only ever return error if one of those protocols were set. Also: a returned error *should* mean get out of there, without having to check more conditions.