### PR TITLE
openssl 1.3 ciphers

### DIFF
--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -22,12 +22,12 @@ suites by using the respective regular cipher option.
 
 With curl 8.10 you may specify TLS 1.3 ciphers also via `CURLOPT_SSL_CIPHER_LIST`
 and `--ciphers` if they are *only* 1.3 ones. Mixing 1.2 and 1.3 ciphers in
-the same argument does not work. 
+the same argument does not work.
 
 Note that when 1.3 ciphers are configured
 using these options, they implicitly raise the minimum TLS version to 1.3.
 It the minimum TLS version is configured to be lower, setting 1.3 ciphers
-with these options will fail.
+with these options fails.
 
 The names of the known ciphers differ depending on which TLS backend that
 libcurl was built to use. This is an attempt to list known cipher names.

--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -20,6 +20,15 @@ and
 . If you are using a different SSL backend you can try setting TLS 1.3 cipher
 suites by using the respective regular cipher option.
 
+With curl 8.10 you may specify TLS 1.3 ciphers also via `CURLOPT_SSL_CIPHER_LIST`
+and `--ciphers` if they are *only* 1.3 ones. Mixing 1.2 and 1.3 ciphers in
+the same argument does not work. 
+
+Note that when 1.3 ciphers are configured
+using these options, they implicitly raise the minimum TLS version to 1.3.
+It the minimum TLS version is configured to be lower, setting 1.3 ciphers
+with these options will fail.
+
 The names of the known ciphers differ depending on which TLS backend that
 libcurl was built to use. This is an attempt to list known cipher names.
 

--- a/docs/cmdline-opts/tls13-ciphers.md
+++ b/docs/cmdline-opts/tls13-ciphers.md
@@ -27,3 +27,11 @@ https://curl.se/docs/ssl-ciphers.html
 This option is currently used only when curl is built to use OpenSSL 1.1.1 or
 later, or Schannel. If you are using a different SSL backend you can try
 setting TLS 1.3 cipher suites by using the --ciphers option.
+
+With curl 8.10 or newer, TLS 1.3 ciphers for OpenSSL may be configured with
+`--ciphers` also under the following conditions:
+- only 1.3 ciphers are mentioned
+- the minimum and maximum TLS versions are unspecified or at least 1.3
+
+Setting 1.3 ciphers via `--ciphers` implies that the minimum TLS version
+to negotiate is at least 1.3.

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1120,7 +1120,7 @@ out:
     nwritten = -1;
   }
   CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] cf_send(len=%zu) -> %zd, %d",
-              stream? stream->id : (uint64_t)~0, len, nwritten, *err);
+              stream? stream->id : (curl_uint64_t)~0, len, nwritten, *err);
   return nwritten;
 }
 

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -326,6 +326,7 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason=f"curl without SSL")
     @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])
     @pytest.mark.skipif(condition=not Env.have_nghttpx(), reason="no nghttpx available")
+    @pytest.mark.skipif(condition=Env.curl_uses_lib('boringssl'), reason="BoringSSL TLS 1.3 ciphers not supported")
     def test_10_13_noreuse_https(self, env: Env, httpd, nghttpx_fwd, tunnel, repeat):
         # different --tls13-ciphers on https: same proxy config
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -326,7 +326,6 @@ class TestProxy:
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason=f"curl without SSL")
     @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])
     @pytest.mark.skipif(condition=not Env.have_nghttpx(), reason="no nghttpx available")
-    @pytest.mark.skipif(condition=not Env.curl_uses_lib('openssl'), reason="tls13-ciphers not supported")
     def test_10_13_noreuse_https(self, env: Env, httpd, nghttpx_fwd, tunnel, repeat):
         # different --tls13-ciphers on https: same proxy config
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
@@ -343,9 +342,9 @@ class TestProxy:
         x2_args = r1.args[1:]
         x2_args.append('--next')
         x2_args.extend(proxy_args)
-        x2_args.extend(['--tls13-ciphers', 'TLS_AES_128_GCM_SHA256'])
+        x2_args.extend(['--ciphers', 'TLS_AES_128_GCM_SHA256'])
         r2 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
-                               extra_args=x2_args)
+                                extra_args=x2_args)
         r2.check_response(count=2, http_status=200)
         assert r2.total_connects == 2
 

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -217,7 +217,7 @@ class TestSSLUse:
                 if not env.curl_lib_version_at_least('mbedtls', '3.6.0'):
                     pytest.skip('mbedTLS TLSv1.3 support requires at least 3.6.0')
                 extra_args = ['--ciphers', ':'.join(cipher_names)]
-            elif env.curl_uses_lib('wolfssl'):
+            elif not env.curl_uses_lib('schannel'):
                 extra_args = ['--ciphers', ':'.join(cipher_names)]
             else:
                 extra_args = ['--tls13-ciphers', ':'.join(cipher_names)]


### PR DESCRIPTION
Allow TLS 1.3 ciphers in CURLOPT_SSL_CIPHER_LIST and --ciphers for OpenSSL iff:

- no CURLOPT_TLS13_CIPHERS or --tls13-ciphers is used
- the minimum and maximum TLS versions are either default or at least 1.3

When 1.3 ciphers are set this way, the minimum TLS version is raised to 1.3, e.g. a 1.2 handshake will not longer work.

refs #13873