### PR TITLE
pollset assertion only when IP connected

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1198,7 +1198,8 @@ static void multi_getsock(struct Curl_easy *data,
   }
 
   if(expect_sockets && !ps->num &&
-     !(data->req.keepon & (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE))) {
+     !(data->req.keepon & (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) &&
+     Curl_conn_is_ip_connected(data, FIRSTSOCKET)) {
     infof(data, "WARNING: no socket in pollset, transfer may stall!");
     DEBUGASSERT(0);
   }


### PR DESCRIPTION
Give warning for an empty pollset only when the connection has at least IP connectivity. There are cases where the connect in QUIC makes another attempt on a timeout and no socket will be available during that.