### PR TITLE
Update GIT-INFO.md for perl version requirements.

### DIFF
--- a/GIT-INFO.md
+++ b/GIT-INFO.md
@@ -30,11 +30,11 @@ In environments that don't support configure (i.e. Windows), do this:
 For `autoreconf` and `configure` (not `buildconf.bat`) to work, you need the
 following software installed:
 
- o autoconf 2.57  (or later)
- o automake 1.7   (or later)
- o libtool  1.4.2 (or later)
- o GNU m4 (required by autoconf)
- o perl 5.8.0 (or later)
+ - autoconf 2.57  (or later)
+ - automake 1.7   (or later)
+ - libtool  1.4.2 (or later)
+ - GNU m4 (required by autoconf)
+ - perl 5.8.0 (or later)
 
 If you don't have perl and don't want to install it, you can rename the source
 file `src/tool_hugehelp.c.cvs` to `src/tool_hugehelp.c` and avoid having to

--- a/GIT-INFO.md
+++ b/GIT-INFO.md
@@ -27,12 +27,6 @@ In environments that don't support configure (i.e. Windows), do this:
 
 ## REQUIREMENTS
 
-See [docs/INTERNALS.md][0] for information on the requirements that you'll
-need or `autoreconf` and `configure` (not `buildconf.bat`) to work.
-
-If you don't have perl and don't want to install it, you can rename the source
-file `src/tool_hugehelp.c.cvs` to `src/tool_hugehelp.c` and avoid having to
-generate this file. This will give you a stubbed version of the file that
-doesn't contain actual content.
+See [docs/INTERNALS.md][0] for requirement details.
 
 [0]: docs/INTERNALS.md

--- a/GIT-INFO.md
+++ b/GIT-INFO.md
@@ -34,7 +34,7 @@ following software installed:
  - automake 1.7   (or later)
  - libtool  1.4.2 (or later)
  - GNU m4 (required by autoconf)
- - perl 5.8.0 (or later)
+ - perl     5.8.0 (or later)
 
 If you don't have perl and don't want to install it, you can rename the source
 file `src/tool_hugehelp.c.cvs` to `src/tool_hugehelp.c` and avoid having to

--- a/GIT-INFO.md
+++ b/GIT-INFO.md
@@ -27,16 +27,12 @@ In environments that don't support configure (i.e. Windows), do this:
 
 ## REQUIREMENTS
 
-For `autoreconf` and `configure` (not `buildconf.bat`) to work, you need the
-following software installed:
-
- - autoconf 2.57  (or later)
- - automake 1.7   (or later)
- - libtool  1.4.2 (or later)
- - GNU m4 (required by autoconf)
- - perl     5.8.0 (or later)
+See [docs/INTERNALS.md][0] for information on the requirements that you'll
+need or `autoreconf` and `configure` (not `buildconf.bat`) to work.
 
 If you don't have perl and don't want to install it, you can rename the source
 file `src/tool_hugehelp.c.cvs` to `src/tool_hugehelp.c` and avoid having to
 generate this file. This will give you a stubbed version of the file that
 doesn't contain actual content.
+
+[0]: docs/INTERNALS.md

--- a/GIT-INFO.md
+++ b/GIT-INFO.md
@@ -34,7 +34,7 @@ following software installed:
  o automake 1.7   (or later)
  o libtool  1.4.2 (or later)
  o GNU m4 (required by autoconf)
- o perl
+ o perl 5.8.0 (or later)
 
 If you don't have perl and don't want to install it, you can rename the source
 file `src/tool_hugehelp.c.cvs` to `src/tool_hugehelp.c` and avoid having to

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -47,7 +47,7 @@ versions of libs and build tools.
  - GNU Autoconf 2.59
  - GNU Automake 1.7
  - GNU M4       1.4
- - perl         5.6
+ - perl         5.8
  - roffit       0.5
  - cmake        3.7
 


### PR DESCRIPTION
[Per ChatGPT](https://chatgpt.com/share/5e1b4cd8-a10e-40d4-8049-abf1bed2a31e), the `<:crlf` discipline was added to `open()` in Perl 5.8.0. I tried running `scripts/managen` on a machine that has Perl 5.6.1 and got an error:

```
Unknown open() mode ':<crlf' at ../../scripts/managen line 777.
```

While I was in there, I also made the list of requirements a valid Markdown list, so it displays properly when viewed in GitHub.

## Before:

<img width="835" alt="Screenshot 2024-07-05 at 6 45 37 PM" src="https://github.com/curl/curl/assets/1000135/612babb3-977f-4081-b1e7-c22cfb1c3ab7">


## After:

<img width="281" alt="Screenshot 2024-07-05 at 6 45 23 PM" src="https://github.com/curl/curl/assets/1000135/0bddc24e-45e8-4560-8ef9-fb51893b917b">

I made these separate commits, so you can not take either change if you wish.

Thanks!