### PR TITLE
tests: fix sshd IdentityFile path for MinGW/Cygwin

### DIFF
--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -847,7 +847,7 @@ if ($sshdid =~ /OpenSSH-Windows/) {
 }
 elsif (pathhelp::os_is_win()) {
     # Ensure to use MinGW/Cygwin paths
-    $identity_config = pathhelp::build_sys_abs_path($identity_config);
+    $identity_config = pathhelp::build_sys_abs_path($identity);
     $knownhosts_config = pathhelp::build_sys_abs_path($knownhosts_config);
 }
 else {


### PR DESCRIPTION
This was missed during some refactoring more than a year ago and is
causing a warning "Use of uninitialized value $path in pattern match".

Follow-up to 70d2fca2

Ref: #10818
Closes #14113