### PR TITLE
wolfssl: use larger error buffer when formatting errors

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1009,6 +1009,23 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
 }
 
 
+static char *wolfssl_strerror(unsigned long error, char *buf, size_t size)
+{
+  DEBUGASSERT(size);
+  *buf = '\0';
+
+  wolfSSL_ERR_error_string_n(error, buf, size);
+
+  if(!*buf) {
+    const char *msg = error ? "Unknown error" : "No error";
+    strncpy(buf, msg, size - 1);
+    buf[size - 1] = '\0';
+  }
+
+  return buf;
+}
+
+
 static CURLcode
 wolfssl_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
@@ -1080,8 +1097,7 @@ wolfssl_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
 #endif  /* OPENSSL_EXTRA */
 
   if(ret != 1) {
-    char error_buffer[WOLFSSL_MAX_ERROR_SZ];
-    int  detail = wolfSSL_get_error(backend->handle, ret);
+    int detail = wolfSSL_get_error(backend->handle, ret);
 
     if(SSL_ERROR_WANT_READ == detail) {
       connssl->io_need = CURL_SSL_IO_NEED_RECV;
@@ -1163,8 +1179,10 @@ wolfssl_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
       return CURLE_OK;
     }
     else {
+      char error_buffer[256];
       failf(data, "SSL_connect failed with error %d: %s", detail,
-            wolfSSL_ERR_error_string((unsigned long)detail, error_buffer));
+            wolfssl_strerror((unsigned long)detail, error_buffer,
+                             sizeof(error_buffer)));
       return CURLE_SSL_CONNECT_ERROR;
     }
   }
@@ -1309,7 +1327,6 @@ static ssize_t wolfssl_send(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct wolfssl_ctx *backend =
     (struct wolfssl_ctx *)connssl->backend;
-  char error_buffer[WOLFSSL_MAX_ERROR_SZ];
   int memlen = (len > (size_t)INT_MAX) ? INT_MAX : (int)len;
   int rc;
 
@@ -1335,9 +1352,13 @@ static ssize_t wolfssl_send(struct Curl_cfilter *cf,
         return -1;
       }
       CURL_TRC_CF(data, cf, "wolfssl_send(len=%zu) -> %d, %d", len, rc, err);
-      failf(data, "SSL write: %s, errno %d",
-            wolfSSL_ERR_error_string((unsigned long)err, error_buffer),
-            SOCKERRNO);
+      {
+        char error_buffer[256];
+        failf(data, "SSL write: %s, errno %d",
+              wolfssl_strerror((unsigned long)err, error_buffer,
+                               sizeof(error_buffer)),
+              SOCKERRNO);
+      }
       *curlcode = CURLE_SEND_ERROR;
       return -1;
     }
@@ -1423,10 +1444,11 @@ static CURLcode wolfssl_shutdown(struct Curl_cfilter *cf,
       connssl->io_need = CURL_SSL_IO_NEED_SEND;
       break;
     default: {
-      char error_buffer[WOLFSSL_MAX_ERROR_SZ];
+      char error_buffer[256];
       int detail = wolfSSL_get_error(wctx->handle, err);
       CURL_TRC_CF(data, cf, "SSL shutdown, error: '%s'(%d)",
-                  wolfSSL_ERR_error_string((unsigned long)err, error_buffer),
+                  wolfssl_strerror((unsigned long)err, error_buffer,
+                                   sizeof(error_buffer)),
                   detail);
       result = CURLE_RECV_ERROR;
       break;
@@ -1467,7 +1489,6 @@ static ssize_t wolfssl_recv(struct Curl_cfilter *cf,
   struct ssl_connect_data *connssl = cf->ctx;
   struct wolfssl_ctx *backend =
     (struct wolfssl_ctx *)connssl->backend;
-  char error_buffer[WOLFSSL_MAX_ERROR_SZ];
   int buffsize = (blen > (size_t)INT_MAX) ? INT_MAX : (int)blen;
   int nread;
 
@@ -1499,9 +1520,13 @@ static ssize_t wolfssl_recv(struct Curl_cfilter *cf,
         *curlcode = CURLE_AGAIN;
         return -1;
       }
-      failf(data, "SSL read: %s, errno %d",
-            wolfSSL_ERR_error_string((unsigned long)err, error_buffer),
-            SOCKERRNO);
+      {
+        char error_buffer[256];
+        failf(data, "SSL read: %s, errno %d",
+              wolfssl_strerror((unsigned long)err, error_buffer,
+                               sizeof(error_buffer)),
+              SOCKERRNO);
+      }
       *curlcode = CURLE_RECV_ERROR;
       return -1;
     }


### PR DESCRIPTION
Currently we're using WOLFSSL_MAX_ERROR_SZ to define the error buffer size, this value is user defined which means it can be overwritten with -DWOLFSSL_MAX_ERROR_SZ=512 when building wolfssl and this overwrite is not exported to the users of wolfssl.

Instead of relying on WOLFSSL_MAX_ERROR_SZ we'll just use a 256 bytes error buffer and use wolfSSL_ERR_error_string_n to fill it thus dropping the dependency on WOLFSSL_MAX_ERROR_SZ altogether.