### PR TITLE
docs: Start markdown headers with capital letter where applicable

### DIFF
--- a/docs/CURLDOWN.md
+++ b/docs/CURLDOWN.md
@@ -147,7 +147,7 @@ readable.
 To make sure curldown documents render correctly as markdown, all literal
 occurrences of `<` or `>` need to be escaped by a leading backslash.
 
-## symbols
+## Symbols
 
 All mentioned curl symbols that have their own man pages, like
 `curl_easy_perform(3)` are automatically rendered using italics in the output

--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -23,7 +23,7 @@ and use TLS 1.3, or else it is not good enough.
 As of May 2024, the libraries that need to get fixed to remain supported after
 May 2025 are: BearSSL and Secure Transport.
 
-## past removals
+## Past removals
 
  - Pipelining
  - axTLS

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -182,7 +182,7 @@ quiche support is **EXPERIMENTAL**
 
 Since the quiche build manages its dependencies, curl can be built against the latest version. You are *probably* able to build against their main branch, but in case of problems, we recommend their latest release tag.
 
-## build
+## Build
 
 Build quiche and BoringSSL:
 

--- a/docs/HYPER.md
+++ b/docs/HYPER.md
@@ -21,7 +21,7 @@ in the master branch using pull-requests, just like ordinary changes.
 
 The C API for Hyper is brand new and is still under development.
 
-## build curl with hyper
+## Build curl with hyper
 
 Using Rust 1.64.0 or later, build hyper and enable its C API like this:
 
@@ -39,7 +39,7 @@ Build curl to use hyper's C API:
      % ./configure LDFLAGS="-Wl,-rpath,<hyper-dir>/target/debug -Wl,-rpath,<hyper-dir>/target/release" --with-openssl --with-hyper=<hyper-dir>
      % make
 
-# using Hyper internally
+# Using Hyper internally
 
 Hyper is a low level HTTP transport library. curl itself provides all HTTP
 headers and Hyper provides all received headers back to curl.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -4,7 +4,7 @@ Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 -->
 
-# how to install curl and libcurl
+# How to install curl and libcurl
 
 ## Installing Binary Packages
 
@@ -154,7 +154,7 @@ conflicting identical symbol names.
 When you build with multiple TLS backends, you can select the active one at
 runtime when curl starts up.
 
-## configure finding libs in wrong directory
+## Configure finding libs in wrong directory
 
 When the configure script checks for third-party libraries, it adds those
 directories to the `LDFLAGS` variable and then tries linking to see if it

--- a/docs/URL-SYNTAX.md
+++ b/docs/URL-SYNTAX.md
@@ -67,7 +67,7 @@ and curl using scripts remain working.
 curl's URL parser allows a few deviations from the spec in order to
 inter-operate better with URLs that appear in the wild.
 
-### spaces
+### Spaces
 
 A URL provided to curl cannot contain spaces. They need to be provided URL
 encoded to be accepted in a URL by curl.
@@ -77,12 +77,12 @@ client where a resource has been redirected to, sometimes contain spaces. This
 is a violation of RFC 3986 but is fine in the WHATWG spec. curl handles these
 by re-encoding them to `%20`.
 
-### non-ASCII
+### Non-ASCII
 
 Byte values in a provided URL that are outside of the printable ASCII range
 are percent-encoded by curl.
 
-### multiple slashes
+### Multiple slashes
 
 An absolute URL always starts with a "scheme" followed by a colon. For all the
 schemes curl supports, the colon must be followed by two slashes according to
@@ -108,7 +108,7 @@ Based on what the hostname starts with, curl "guesses" what protocol to use:
  - `pop3.` means POP3
  - all other means HTTP
 
-### globbing letters
+### Globbing letters
 
 The curl command line tool supports "globbing" of URLs. It means that you can
 create ranges and lists using `[N-M]` and `{one,two,three}` sequences. The


### PR DESCRIPTION
This patch consistently capitalizes the first word of each markdown header where applicable.