### PR TITLE
Make variable example use it with expand

### DIFF
--- a/docs/cmdline-opts/variable.md
+++ b/docs/cmdline-opts/variable.md
@@ -10,7 +10,7 @@ Multi: append
 See-also:
   - config
 Example:
-  - --variable name=smith $URL
+  - --variable name=smith --expand-url "$URL/{{name}}"
 ---
 
 # `--variable`


### PR DESCRIPTION
I used double quotes since it seemed required for powershell, so this example works in both (ba)sh and powershell as well as cmd.exe.