### PR TITLE
macos: add workaround for gcc, non-c-ares, IPv6, compile error

### DIFF
--- a/lib/macos.c
+++ b/lib/macos.c
@@ -30,7 +30,17 @@
 
 #include "macos.h"
 
+/* Certain Apple SDK v13.0+ headers are incompatible with the GCC compiler.
+   As a workaround, use a minimal header and define the function we need,
+   to avoid hitting those incompatibilities when compiling with GCC. */
+#if defined(__clang__)
 #include <SystemConfiguration/SCDynamicStoreCopySpecific.h>
+#else
+#include <CoreFoundation/CFDictionary.h>
+typedef const struct CF_BRIDGED_TYPE(id) __SCDynamicStore * SCDynamicStoreRef;
+CFDictionaryRef __nullable
+SCDynamicStoreCopyProxies(SCDynamicStoreRef __nullable store);
+#endif
 
 CURLcode Curl_macos_init(void)
 {


### PR DESCRIPTION
Apple macOS SDK 13.0 and later are increasingly incompatible with gcc,
which started causing CI errors with the 20240701.9 revision of the
`macos-latest` (= `macos-14-arm64`) runner image.

This error is happening inside an Apple SDK header. We use the header
for calling a function in a resolver-related hack, in non-c-ares, IPv6
builds. You can avoid the problem by using c-ares or disabling IPv6
(or using clang, llvm, or a compatible gcc + SDK combination).

This patch fixes affected builds by declaring the ncessary framework
function manually, and not including the problematic header.

This workaround is ugly, doesn't cover all combinations, and fragile.

Other options are to disable this resolver-related hack for GCC, or to
replace it with a solution that doesn't rely on Apple SDK.

If you are aware of a stable fix or workaround, let us know.

gcc 12.4.0 + macOS SDK 14.0 (Xcode 15.0.1) error example:
```
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CoreFoundation.h:54,
                 from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/SystemConfiguration.framework/Headers/SCDynamicStoreCopySpecific.h:30,
                 from /Users/runner/work/curl/curl/lib/macos.c:33,
                 from /Users/runner/work/curl/curl/build/lib/CMakeFiles/libcurl_shared.dir/Unity/unity_0_c.c:244:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFUserNotification.h:126:1: error: attributes should be specified before the declarator in a function definition
  126 | CF_INLINE CFOptionFlags CFUserNotificationCheckBoxChecked(CFIndex i) API_AVAILABLE(macos(10.0)) API_UNAVAILABLE(ios, watchos, tvos) {return ((CFOptionFlags)(1UL << (8 + i)));}
      | ^~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFUserNotification.h:127:1: error: attributes should be specified before the declarator in a function definition
  127 | CF_INLINE CFOptionFlags CFUserNotificationSecureTextField(CFIndex i) API_AVAILABLE(macos(10.0)) API_UNAVAILABLE(ios, watchos, tvos) {return ((CFOptionFlags)(1UL << (16 + i)));}
      | ^~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.0.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFUserNotification.h:128:1: error: attributes should be specified before the declarator in a function definition
  128 | CF_INLINE CFOptionFlags CFUserNotificationPopUpSelection(CFIndex n) API_AVAILABLE(macos(10.0)) API_UNAVAILABLE(ios, watchos, tvos) {return ((CFOptionFlags)(n << 24));}
      | ^~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/9787982387/job/27025351601?pr=14096#step:7:18

The exact conditions are fuzzy. Oddly enough gcc 12.3.0 and the SDK
same as above are _compatible_:
https://github.com/curl/curl/actions/runs/9791701214/job/27036037162

Also notice that similar errors can also happen in SecureTransport
builds, due to the SDK headers required.

Ref: https://github.com/curl/curl/pull/14097#issuecomment-2208639046
Ref: https://github.com/curl/curl/pull/14091#issuecomment-2205870854
Cherry-picked from #14097
Closes #14119
