### PR TITLE
examples: suppress deprecation warnings locally

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -210,7 +210,7 @@ jobs:
     runs-on: 'macos-latest'
     env:
       CC: ${{ matrix.compiler.CC }}
-      CFLAGS: '-Wno-deprecated-declarations'  # Required for LDAP and BUILD_EXAMPLES
+      CFLAGS: '-Wno-deprecated-declarations'  # Required for LDAP
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -141,7 +141,6 @@ jobs:
         run: |
           export PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
           cmake -B bld ${options} \
-            "-DCMAKE_C_FLAGS=${cflags}" \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
@@ -318,13 +317,12 @@ jobs:
           else
             options='-DCMAKE_C_COMPILER=gcc'
           fi
-          cflags='-Wno-deprecated-declarations'  # for examples
           if [ '${{ matrix.test }}' = 'uwp' ]; then
             options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             pacman --noconfirm --ask 20 --noprogressbar --sync --needed 'mingw-w64-${{ matrix.env }}-winstorecompat-git'
             specs="$(realpath gcc-specs-uwp)"
             gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp -lwindowsappcompat/' -e 's/-lmsvcrt/-lmsvcr120_app/' > "${specs}"
-            cflags+=" -specs=$(cygpath -w "${specs}") -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
+            cflags="-specs=$(cygpath -w "${specs}") -DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP"
             # CMake (as of v3.26.4) gets confused and applies the MSVC rc.exe command-line
             # template to windres. Reset it to the windres template manually:
             rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
@@ -456,13 +454,11 @@ jobs:
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
           export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          cflags='-Wno-deprecated-declarations'  # for examples
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
           cmake -B bld ${options} \
             '-GMSYS Makefiles' \
             -DCMAKE_C_COMPILER=gcc \
-            "-DCMAKE_C_FLAGS=${cflags}" \
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \

--- a/docs/examples/multi-formadd.c
+++ b/docs/examples/multi-formadd.c
@@ -36,6 +36,11 @@
 
 #include <curl/curl.h>
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 int main(void)
 {
   CURL *curl;
@@ -112,3 +117,7 @@ int main(void)
   }
   return 0;
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/docs/examples/postit2-formadd.c
+++ b/docs/examples/postit2-formadd.c
@@ -47,6 +47,11 @@
 
 #include <curl/curl.h>
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 int main(int argc, char *argv[])
 {
   CURL *curl;
@@ -110,3 +115,7 @@ int main(int argc, char *argv[])
   }
   return 0;
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif


### PR DESCRIPTION
Simplify making clean builds by silencing deprecation warnings inside
the example code where these may occur.

Drop related build tweaks/comments from GHA jobs.

Example warning:
```
curl/docs/examples/postit2-formadd.c:65:16: error: 'CURLFORM_COPYNAME' is deprecated: since 7.56.0. Use curl_mime_name() [-Werror=deprecated-declarations]
   65 |                CURLFORM_COPYNAME, "sendfile",
      |                ^~~~~~~~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/9841099503/job/27166970904#step:10:829

Closes #14123
