### PR TITLE
tests: include current directory when running test Perl commands

### DIFF
--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -90,7 +90,7 @@ our $randseed = 0;    # random number seed
 # paths
 our $pwd = getcwd();  # current working directory
 our $srcdir = $ENV{'srcdir'} || '.';  # root of the test source code
-our $perl="perl -I$srcdir"; # invoke perl like this
+our $perl="perl -I. -I$srcdir"; # invoke perl like this
 our $LOGDIR="log";  # root of the log directory; this will be different for
                     # each runner in multiprocess mode
 our $LIBDIR="./libtest";


### PR DESCRIPTION
Necessary to find generated files in the out-of-tree build directory.
E.g. `tests/configurehelp.pm`, for tests 1119 and 1167.

Before this patch macOS autotools builds were failing these two tests
due to falling back to the default preprocessor (`cpp`) instead of
the actual one configured. Then `cpp` failing to compile Apple SDK
headers referenced by curl headers.

Cherry-picked from #14097
Closes #14124
