### PR TITLE
test1119: adapt for `.md` input

### DIFF
--- a/tests/test1119.pl
+++ b/tests/test1119.pl
@@ -109,7 +109,7 @@ sub checkmanpage {
     my $line = 1;
     while(<$mh>) {
         # strip off formatting
-        $_ =~ s/\\f[BPRI]//;
+        $_ =~ s/(^|[^A-Z0-9])[*_]+/ /;
         # detect global-looking 'CURL[BLABLA]_*' symbols
         while(s/\W(CURL(AUTH|E|H|MOPT|OPT|SHOPT|UE|M|SSH|SSLBACKEND|HEADER|FORM|FTP|PIPE|MIMEOPT|GSSAPI|ALTSVC|PROTO|PROXY|UPART|USESSL|_READFUNC|_WRITEFUNC|_CSELECT|_FORMADD|_IPRESOLVE|_REDIR|_RTSPREQ|_TIMECOND|_VERSION)_[a-zA-Z0-9_]+)//) {
             my $s = $1;
@@ -123,11 +123,11 @@ sub checkmanpage {
     close($mh);
 }
 
-sub scanman3dir {
+sub scanman_md_dir {
     my ($d) = @_;
     opendir(my $dh, $d) ||
         die "Can't opendir: $!";
-    my @mans = grep { /.3\z/ } readdir($dh);
+    my @mans = grep { /.md\z/ } readdir($dh);
     closedir $dh;
     for my $m (@mans) {
         checkmanpage("$d/$m");
@@ -136,8 +136,8 @@ sub scanman3dir {
 
 
 scanallheaders();
-scanman3dir("$root/docs/libcurl");
-scanman3dir("$root/docs/libcurl/opts");
+scanman_md_dir("$root/docs/libcurl");
+scanman_md_dir("$root/docs/libcurl/opts");
 
 open my $s, "<", "$root/docs/libcurl/symbols-in-versions";
 while(<$s>) {


### PR DESCRIPTION
Replace logic dealing with `.3` files to handle the Markdown syntax.

Follow-up to eefcc1bda4bccd800f5a56a0fe17a2f44a96e88b #12730
Cherry-picked from #14097
Closes #14125
