### PR TITLE
configure: limit `SystemConfiguration` test to non-c-ares, IPv6 builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -595,7 +595,6 @@ CURL_CHECK_WIN32_LARGEFILE
 CURL_CHECK_WIN32_CRYPTO
 
 CURL_DARWIN_CFLAGS
-CURL_DARWIN_SYSTEMCONFIGURATION
 CURL_SUPPORTS_BUILTIN_AVAILABLE
 
 AM_CONDITIONAL([HAVE_WINDRES],
@@ -3873,6 +3872,10 @@ AM_CONDITIONAL(BUILD_LIBHOSTNAME, test x$build_libhostname = xyes)
 
 if test "x$want_ares" != xyes; then
   CURL_CHECK_OPTION_THREADED_RESOLVER
+
+  if test "$ipv6" = yes; then
+    CURL_DARWIN_SYSTEMCONFIGURATION
+  fi
 fi
 
 dnl ************************************************************


### PR DESCRIPTION
The framework this check detects is necessary for the function
`SCDynamicStoreCopyProxies()` used in `lib/macos.c`. Non-c-ares,
IPv6-enabled builds touch this codepath.

Limit the feature check for builds that actually need it.

It brings this in sync with CMake which already worked this way.

Cherry-picked from #14097
Closes #14126
