### PR TITLE
configure: fix `SystemConfiguration` detection (Apple)

### DIFF
--- a/m4/curl-sysconfig.m4
+++ b/m4/curl-sysconfig.m4
@@ -28,6 +28,7 @@ case $host_os in
   darwin*)
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
+#include <sys/types.h>
 #include <TargetConditionals.h>
       ]],[[
 #if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)


### PR DESCRIPTION
Before this patch, `SystemConfiguration` detection failed due to this
error when compiling the detection snippet:
```
/Applications/Xcode_15.3.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/TargetConditionals.h:140:50: error: missing binary operator before token "("
  140 | #if !defined(__has_extension) || !__has_extension(define_target_os_macros)
      |                                                  ^
```
Ref: https://github.com/curl/curl/actions/runs/9821817534/job/27117929218#step:6:1079

It occured with gcc-11 when combined with macOS SDK 14.4 and 14.5
(default SDKs in Xcode 15.3 and 15.4 respectively). It did not happen
with earlier releases.

Despite the failure in `./configure`, `lib/macos.c` compiled with
Apple's `TargetConditionals.h` just fine.

Turns out that including the `sys/types.h` header before the SDK
header fixes the error and makes the detection snippet compile.

Cherry-picked from #14097
Closes #14130
