### PR TITLE
build: fix llvm 16 or older + Xcode 15 or newer, and gcc

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -306,6 +306,17 @@
 #define CURL_PRINTF(fmt, arg)
 #endif
 
+/* Workaround for mainline llvm v16 and earlier missing a built-in macro
+   expected by macOS SDK v14 / Xcode v15 (2023) and newer. */
+#if defined(__APPLE__) &&                                   \
+  !defined(__apple_build_version__) &&                      \
+  defined(__clang__) && __clang_major__ < 17 &&             \
+  defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && \
+  !defined(__ENVIRONMENT_OS_VERSION_MIN_REQUIRED__)
+#define __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__             \
+  __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__
+#endif
+
 /*
  * Use getaddrinfo to resolve the IPv4 address literal. If the current network
  * interface does not support IPv4, but supports IPv6, NAT64, and DNS64,

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -307,10 +307,12 @@
 #endif
 
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro
-   expected by macOS SDK v14 / Xcode v15 (2023) and newer. */
+   expected by macOS SDK v14 / Xcode v15 (2023) and newer.
+   gcc (as of v14) is also missing it. */
 #if defined(__APPLE__) &&                                   \
-  !defined(__apple_build_version__) &&                      \
-  defined(__clang__) && __clang_major__ < 17 &&             \
+  ((!defined(__apple_build_version__) &&                    \
+    defined(__clang__) && __clang_major__ < 17) ||          \
+   (defined(__GNUC__) && __GNUC__ <= 14)) &&                \
   defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && \
   !defined(__ENVIRONMENT_OS_VERSION_MIN_REQUIRED__)
 #define __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__             \


### PR DESCRIPTION
Xcode v15 (2023) or newer requires the built-in macro
`__ENVIRONMENT_OS_VERSION_MIN_REQUIRED__`. This macro is missing from
mainline llvm versions released earlier. llvm v17 introduced it here:
https://github.com/llvm/llvm-project/commit/c8e2dd8c6f490b68e41fe663b44535a8a21dfeab

This patch defines the missing macro when the necessary conditions
align, by using the value via the macro's old name.

The issue affected SecureTransport builds: The SecureTransport code,
`lib/md4.c` and `lib/md5.c`.

Existing gcc versions (as of v14) also don't define this macro, so apply
the patch to it as well. Even though gcc is incompatible in other ways,
so this isn't fixing an actual curl build case that I could find yet.

GHA macOS runner images have llvm v15 pre-installed, which broke builds
when building with an affected Xcode:
```
curl/lib/md4.c:80:14: error: '__ENVIRONMENT_OS_VERSION_MIN_REQUIRED__' is not defined, evaluates to 0 [-Werror,-Wundef]
            (__MAC_OS_X_VERSION_MIN_REQUIRED < 101500)) || \
             ^
/Applications/Xcode_15.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/usr/include/AvailabilityInternal.h:40:53: note: expanded from macro '__MAC_OS_X_VERSION_MIN_REQUIRED'
            #define __MAC_OS_X_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
                                                    ^
In file included from curl/build/lib/CMakeFiles/libcurl_shared.dir/Unity/unity_0_c.c:250:
curl/lib/md5.c:75:14: error: '__ENVIRONMENT_OS_VERSION_MIN_REQUIRED__' is not defined, evaluates to 0 [-Werror,-Wundef]
            (__MAC_OS_X_VERSION_MIN_REQUIRED < 101500)) || \
             ^
/Applications/Xcode_15.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.2.sdk/usr/include/AvailabilityInternal.h:40:53: note: expanded from macro '__MAC_OS_X_VERSION_MIN_REQUIRED'
            #define __MAC_OS_X_VERSION_MIN_REQUIRED __ENVIRONMENT_OS_VERSION_MIN_REQUIRED__
                                                    ^
2 errors generated.
```
Ref: https://github.com/curl/curl/actions/runs/9811974634/job/27095218578#step:4:20

Cherry-picked from #14097
Closes #14134
