### PR TITLE
cmake: enable `pkg-config` search on non-UNIX platforms

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -51,11 +51,11 @@ set(_GSS_ROOT_HINTS
 
 # try to find library using system pkg-config if user didn't specify root dir
 if(NOT GSS_ROOT_DIR AND NOT "$ENV{GSS_ROOT_DIR}")
-  if(UNIX)
-    find_package(PkgConfig QUIET)
-    pkg_search_module(_GSS_PKG ${_MIT_MODNAME} ${_HEIMDAL_MODNAME})
-    list(APPEND _GSS_ROOT_HINTS "${_GSS_PKG_PREFIX}")
-  elseif(WIN32)
+  find_package(PkgConfig QUIET)
+  pkg_search_module(_GSS_PKG ${_MIT_MODNAME} ${_HEIMDAL_MODNAME})
+  list(APPEND _GSS_ROOT_HINTS "${_GSS_PKG_PREFIX}")
+
+  if(WIN32)
     list(APPEND _GSS_ROOT_HINTS "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MIT\\Kerberos;InstallDir]")
   endif()
 endif()

--- a/CMake/FindMSH3.cmake
+++ b/CMake/FindMSH3.cmake
@@ -38,10 +38,8 @@ Result Variables
 ``MSH3_LIBRARIES``
   The libraries needed to use msh3
 #]=======================================================================]
-if(UNIX)
-  find_package(PkgConfig QUIET)
-  pkg_search_module(PC_MSH3 libmsh3)
-endif()
+find_package(PkgConfig QUIET)
+pkg_search_module(PC_MSH3 libmsh3)
 
 find_path(MSH3_INCLUDE_DIR msh3.h
   HINTS

--- a/CMake/FindNGHTTP3.cmake
+++ b/CMake/FindNGHTTP3.cmake
@@ -41,10 +41,8 @@ Result Variables
   version of nghttp3.
 #]=======================================================================]
 
-if(UNIX)
-  find_package(PkgConfig QUIET)
-  pkg_search_module(PC_NGHTTP3 libnghttp3)
-endif()
+find_package(PkgConfig QUIET)
+pkg_search_module(PC_NGHTTP3 libnghttp3)
 
 find_path(NGHTTP3_INCLUDE_DIR nghttp3/nghttp3.h
   HINTS

--- a/CMake/FindNGTCP2.cmake
+++ b/CMake/FindNGTCP2.cmake
@@ -49,10 +49,8 @@ Result Variables
   version of ngtcp2.
 #]=======================================================================]
 
-if(UNIX)
-  find_package(PkgConfig QUIET)
-  pkg_search_module(PC_NGTCP2 libngtcp2)
-endif()
+find_package(PkgConfig QUIET)
+pkg_search_module(PC_NGTCP2 libngtcp2)
 
 find_path(NGTCP2_INCLUDE_DIR ngtcp2/ngtcp2.h
   HINTS
@@ -83,9 +81,7 @@ if(NGTCP2_FIND_COMPONENTS)
 
   if(NGTCP2_CRYPTO_BACKEND)
     string(TOLOWER "ngtcp2_crypto_${NGTCP2_CRYPTO_BACKEND}" _crypto_library)
-    if(UNIX)
-      pkg_search_module(PC_${_crypto_library} lib${_crypto_library})
-    endif()
+    pkg_search_module(PC_${_crypto_library} lib${_crypto_library})
     find_library(${_crypto_library}_LIBRARY
       NAMES
         ${_crypto_library}

--- a/CMake/FindNettle.cmake
+++ b/CMake/FindNettle.cmake
@@ -28,11 +28,9 @@
 # NETTLE_INCLUDE_DIRS - nettle include directories
 # NETTLE_LIBRARIES - nettle library names
 
-if(UNIX)
-  find_package(PkgConfig QUIET)
-  if(PKG_CONFIG_FOUND)
-    pkg_check_modules(NETTLE "nettle")
-  endif()
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(NETTLE "nettle")
 endif()
 
 if(NETTLE_FOUND)

--- a/CMake/FindQUICHE.cmake
+++ b/CMake/FindQUICHE.cmake
@@ -38,10 +38,9 @@ Result Variables
 ``QUICHE_LIBRARIES``
   The libraries needed to use quiche
 #]=======================================================================]
-if(UNIX)
-  find_package(PkgConfig QUIET)
-  pkg_search_module(PC_QUICHE quiche)
-endif()
+
+find_package(PkgConfig QUIET)
+pkg_search_module(PC_QUICHE quiche)
 
 find_path(QUICHE_INCLUDE_DIR quiche.h
   HINTS

--- a/CMake/FindZstd.cmake
+++ b/CMake/FindZstd.cmake
@@ -39,10 +39,8 @@ Result Variables
   The libraries needed to use zstd
 #]=======================================================================]
 
-if(UNIX)
-  find_package(PkgConfig QUIET)
-  pkg_search_module(PC_Zstd libzstd)
-endif()
+find_package(PkgConfig QUIET)
+pkg_search_module(PC_Zstd libzstd)
 
 find_path(Zstd_INCLUDE_DIR zstd.h
   HINTS


### PR DESCRIPTION
Suggested-by: Tal Regev
Ref: https://github.com/curl/curl/pull/14136#discussion_r1671110219
Closes #14140

---

TODO:
- [ ] apply to `FindNghttp2` once #14136 merged.
- [x] apply to `FindNettle` once #14285 merged.
- [ ] apply logic to other pkg-config lookups, e.g. `pkg_check_modules(LIBSSH "libssh")`.
