### PR TITLE
CI: simplify running curl with DLLs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,7 @@ jobs:
         timeout-minutes: 5
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          export PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
+          PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --prefix="${HOME}"/install \
             --enable-websockets \
@@ -139,7 +139,7 @@ jobs:
         timeout-minutes: 5
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          export PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
+          PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
           cmake -B bld ${options} \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
@@ -174,8 +174,8 @@ jobs:
         timeout-minutes: 1
         shell: C:\cygwin\bin\bash.exe '{0}'
         run: |
-          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll' | grep -v '/examples/'
+          PATH="$PWD/bld/lib:$PATH"
           bld/src/curl.exe --disable --version
 
       - name: 'cmake build tests'
@@ -193,7 +193,7 @@ jobs:
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
-          ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
+          PATH="$PWD/bld/lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
   msys2:  # both msys and mingw-w64
@@ -368,9 +368,9 @@ jobs:
         timeout-minutes: 1
         shell: msys2 {0}
         run: |
-          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll' | grep -v '/examples/'
           if [ '${{ matrix.test }}' != 'uwp' ]; then  # UWP missing 'msvcr120_app.dll', fails with exit code 0xc0000135
+            PATH="$PWD/bld/lib:$PATH"
             bld/src/curl.exe --disable --version
           fi
 
@@ -392,7 +392,7 @@ jobs:
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
-          ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
+          PATH="$PWD/bld/lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
   old-mingw-w64:
@@ -453,7 +453,7 @@ jobs:
         timeout-minutes: 5
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
           cmake -B bld ${options} \
@@ -483,15 +483,15 @@ jobs:
         timeout-minutes: 10
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
         timeout-minutes: 1
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          [[ '${{ matrix.config }}' != *'BUILD_SHARED_LIBS=OFF'* ]] && cp -f -p bld/lib/*.dll bld/src/
           find . -name '*.exe' -o -name '*.dll' | grep -v '/examples/'
+          PATH="$PWD/bld/lib:$PATH"
           bld/src/curl.exe --disable --version
 
       - name: 'cmake build tests'
@@ -499,7 +499,7 @@ jobs:
         timeout-minutes: 10
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'cmake run tests'
@@ -507,12 +507,12 @@ jobs:
         timeout-minutes: 40
         shell: C:\msys64\usr\bin\bash.exe {0}
         run: |
-          export PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           export TFLAGS='-j14 !TFTP !MQTT !WebSockets ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
-          ls bld/lib/*.dll >/dev/null 2>&1 && cp -f -p bld/lib/*.dll bld/tests/libtest/
+          PATH="$PWD/bld/lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
   msvc:
@@ -637,7 +637,7 @@ jobs:
         run: |
           find . -name '*.exe' -o -name '*.dll' | grep -v '/examples/'
           if [ '${{ matrix.plat }}' != 'uwp' ]; then
-            export PATH="$PWD/bld/lib/:$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}/bin:$PATH"
+            PATH="$PWD/bld/lib:$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}/bin:$PATH"
             bld/src/curl.exe --disable --version
           fi
 
@@ -656,5 +656,5 @@ jobs:
           if [[ '${{ matrix.config }}' = *'-DUSE_WIN32_IDN=ON'* ]]; then
             TFLAGS+=' ~165 ~1448 ~2046 ~2047'
           fi
-          export PATH="$PWD/bld/lib/:$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}/bin:$PATH"
+          PATH="$PWD/bld/lib:$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -70,10 +70,10 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     false
   fi
   if [ "${SHARED}" = 'ON' ]; then
-    cp -f -p _bld/lib/*.dll _bld/src/
+    PATH="$PWD/_bld/lib:$PATH"
   fi
   if [ "${OPENSSL}" = 'ON' ]; then
-    cp -f -p "${openssl_root}"/*.dll _bld/src/
+    PATH="$PWD/_bld/lib:${openssl_root}:$PATH"
   fi
   curl='_bld/src/curl.exe'
 elif [ "${BUILD_SYSTEM}" = 'VisualStudioSolution' ]; then
@@ -140,7 +140,6 @@ if [[ "${TFLAGS}" != 'skipall' ]] && \
     TFLAGS+=" -ac $(cygpath 'C:/msys64/usr/bin/curl.exe')"
   fi
   if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
-    ls _bld/lib/*.dll >/dev/null 2>&1 && cp -f -p _bld/lib/*.dll _bld/tests/libtest/
     cmake --build _bld --config "${PRJ_CFG}" --target test-ci
   else
     (


### PR DESCRIPTION
- update `PATH` instead of copying DLLs around.
- drop redundant `export` from `export PATH`.
- delete ending pathseps.

Closes #14143
