### PR TITLE
Small memory leak fix in hostip.c

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -537,6 +537,7 @@ static struct Curl_addrinfo *get_localhost6(int port, const char *name)
   sa6.sin6_flowinfo = 0;
   sa6.sin6_scope_id = 0;
   if(Curl_inet_pton(AF_INET6, "::1", ipv6) < 1)
+    free(ca);
     return NULL;
   memcpy(&sa6.sin6_addr, ipv6, sizeof(ipv6));
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -536,9 +536,10 @@ static struct Curl_addrinfo *get_localhost6(int port, const char *name)
   sa6.sin6_port = htons(port16);
   sa6.sin6_flowinfo = 0;
   sa6.sin6_scope_id = 0;
-  if(Curl_inet_pton(AF_INET6, "::1", ipv6) < 1)
+  if(Curl_inet_pton(AF_INET6, "::1", ipv6) < 1) {
     free(ca);
     return NULL;
+  }
   memcpy(&sa6.sin6_addr, ipv6, sizeof(ipv6));
 
   ca->ai_flags     = 0;


### PR DESCRIPTION
Hi!

First time looking at the curl source code, and I think I found a (most likely insignificant) memory leak.
Either way, I added a `free(ca);` to prevent memory leaks if `Curl_inet_pton(AF_INET6, "::1", ipv6)` fails in `*get_localhost6(int port, const char *name)`.