### PR TITLE
Wrap 2 Example URLs that Overrun Styling in Docs

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -309,7 +309,8 @@ Post a simple `name` and `phone` guestbook.
 
 Or automatically [URL encode the data](https://everything.curl.dev/http/post/url-encode).
 
-    curl --data-urlencode "name=Rafael Sagula&phone=3320780" http://www.example.com/guest.cgi
+    curl --data-urlencode "name=Rafael Sagula&phone=3320780"
+      http://www.example.com/guest.cgi
 
 How to post a form with curl, lesson #1:
 
@@ -343,7 +344,8 @@ We want to enter user `foobar` with password `12345`.
 
 To post to this, you would enter a curl command line like:
 
-    curl -d "user=foobar&pass=12345&id=blablabla&ding=submit" http://example.com/post.cgi
+    curl -d "user=foobar&pass=12345&id=blablabla&ding=submit"
+      http://example.com/post.cgi
 
 While `-d` uses the application/x-www-form-urlencoded mime-type, generally
 understood by CGI's and similar, curl also supports the more capable


### PR DESCRIPTION
Within MANUAL.md there are two example urls where it is impossible to read the end of the sample because the text overruns the styling. Both appear in the `POST (HTTP)` section of the document, and illustration of the issue is shown below (I have selected the text in question so that the hidden text is visible):

## Example 1
![image](https://github.com/curl/curl/assets/1524451/fd39b198-df0d-4a61-ba4f-c51587780ad0)

## Example 2
![image](https://github.com/curl/curl/assets/1524451/7aa770b0-31be-417a-9799-4bb12334257d)

The issue appears to occur regardless of zoom.

To address this I have simply forced these examples to wrap onto two lines, using the same indentation style as other examples within this document.