### PR TITLE
Fix 1-byte overflow in asyn-ares.c

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -771,7 +771,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
   size_t namelen = strlen(hostname);
   *waitp = 0; /* default to synchronous response */
 
-  res = calloc(1, sizeof(struct thread_data) + namelen);
+  res = calloc(1, sizeof(struct thread_data) + namelen + 1);
   if(res) {
     strcpy(res->hostname, hostname);
     data->state.async.hostname = res->hostname;


### PR DESCRIPTION
I am not entirely sure if I got this right, so apologies if this is wrong.

Looking at [around this line in lib/asyn-ares.c](https://github.com/curl/curl/blob/bf251cc0d23c3be63a08c8fa383d9de883190033/lib/asyn-ares.c#L774), I believe I found a potential issue. Here's the original code with some comments added:

 ```C
  size_t namelen = strlen(hostname); // counts the characters in hostname, excluding null ending 
  *waitp = 0;

  // the next line allocates enough bytes for struct thread_data
  // and enough bytes for the hostname, excluding the null terminator
  res = calloc(1, sizeof(struct thread_data) + namelen); 
  
  if(res) {
    strcpy(res->hostname, hostname); // copies hostname into the structure and appends a null terminator 
```

The issue here is that calloc does not allocate enough space for the null terminator, which is added by `strcpy()`. This can potentially overwrite some other data on the heap with a null character and lead to some memory corruption issues.

So the fix would be to account for the null character like this:
```C
res = calloc(1, sizeof(struct thread_data) + namelen + 1);
``` 