### PR TITLE
macos: undo `availability` macro enabled by Homebrew gcc

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -54,7 +54,7 @@
   !defined(__clang__) &&                 \
   defined(__GNUC__) && __GNUC__ >= 12 && \
   defined(__has_attribute)
-#define availability curl_invalid
+#define availability curl_pp_attribute_disabled
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -40,6 +40,23 @@
 #include <_mingw.h>
 #endif
 
+/* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0 and newer (as of 14.1.0)
+   that started advertising the `availability` attribute, which then gets used
+   by Apple SDK, but, in a way incompatible with gcc, resulting in a misc
+   errors inside SDK headers, e.g.:
+     error: attributes should be specified before the declarator in a function
+            definition
+     error: expected ',' or '}' before
+   Followed by missing declarations.
+   Fix it by overriding the built-in feature-check macro used by the headers
+   to enable the problematic attributes. This makes the feature check fail. */
+#if defined(__APPLE__) &&                \
+  !defined(__clang__) &&                 \
+  defined(__GNUC__) && __GNUC__ >= 12 && \
+  defined(__has_attribute)
+#define availability curl_invalid
+#endif
+
 /*
  * Disable Visual Studio warnings:
  * 4127 "conditional expression is constant"

--- a/lib/macos.c
+++ b/lib/macos.c
@@ -30,17 +30,7 @@
 
 #include "macos.h"
 
-/* Certain Apple SDK v13.0+ headers are incompatible with the GCC compiler.
-   As a workaround, use a minimal header and define the function we need,
-   to avoid hitting those incompatibilities when compiling with GCC. */
-#if defined(__clang__)
 #include <SystemConfiguration/SCDynamicStoreCopySpecific.h>
-#else
-#include <CoreFoundation/CFDictionary.h>
-typedef const struct CF_BRIDGED_TYPE(id) __SCDynamicStore * SCDynamicStoreRef;
-CFDictionaryRef __nullable
-SCDynamicStoreCopyProxies(SCDynamicStoreRef __nullable store);
-#endif
 
 CURLcode Curl_macos_init(void)
 {


### PR DESCRIPTION
Homebrew gcc builds starting with 12.4.0, 13.3.0 and 14.1.0 enabled
the `availability` attribute.

This broke builds because the way the Apple SDK uses attributes (when
available) are incompatible with how gcc accepts them. Causing these
errors:
```
  error: attributes should be specified before the declarator in a function definition
  error: expected ',' or '}' before
```

Upstream commits implementing the `availability` macro:
gcc-12: https://github.com/iains/gcc-12-branch/commit/fd5530b7cb0012bf4faeddd45e13054a1dfa6783
gcc-13: https://github.com/iains/gcc-13-branch/commit/cb7e4eca68cfc4763474e2eb0935a844458842a8
gcc-14: https://github.com/iains/gcc-14-branch/commit/ff62a108865a6403f5017380d7018250c1d3306f

The project above is a Darwin gcc compatibility pack, that is applied
to Homebrew gcc builds.

This patch works by redefining the `availability` macro to an invalid
value, making `__has_attribute(availability)` checks fail, stopping
Apple SDK from inserting the incompatible attributes.

It also replaces the previous, local workaround for `lib/macos.c`.

Example with gcc 12.4.0 with macOS SDK 14.0 (Xcode 15.0.1):
```
In file included from <path-to-sdk>/MacOSX14.0.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CoreFoundation.h:54,
                 from <path-to-sdk>/MacOSX14.0.sdk/System/Library/Frameworks/SystemConfiguration.framework/Headers/SCDynamicStoreCopySpecific.h:30,
                 from /Users/runner/work/curl/curl/lib/macos.c:33,
                 from /Users/runner/work/curl/curl/build/lib/CMakeFiles/libcurl_shared.dir/Unity/unity_0_c.c:244:
<path-to-sdk>/MacOSX14.0.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFUserNotification.h:126:1: error: attributes should be specified before the declarator in a function definition
  126 | CF_INLINE CFOptionFlags CFUserNotificationCheckBoxChecked(CFIndex i) API_AVAILABLE(macos(10.0)) API_UNAVAILABLE(ios, watchos, tvos) {return ((CFOptionFlags)(1UL << (8 + i)));}
      | ^~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/9787982387/job/27025351601?pr=14096#step:7:18

The gcc vs. llvm/clang incompatibility possibly tracked here upstream:
  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108796
More info:
  https://github.com/llvm/llvm-project/issues/81767
  https://github.com/gcc-mirror/gcc/commit/8433baadec88e5f31fa141b6d78094e91256079d
  https://discourse.llvm.org/t/changing-attribute-ast-printing-location-for-gcc-compatibility/73215
  https://reviews.llvm.org/D159362

Follow-up to db135f8d7207b20d531e7e2100a49f3e16bdcfab #14119
Ref: https://github.com/curl/curl/pull/14091#issuecomment-2222703468
Fixes #13700
Cherry-picked from #14097
Closes #14155
