### PR TITLE
libcurl-docs: make option lists alpha-sorted

### DIFF
--- a/docs/libcurl/curl_easy_getinfo.md
+++ b/docs/libcurl/curl_easy_getinfo.md
@@ -39,8 +39,7 @@ The following information can be extracted:
 
 ## CURLINFO_ACTIVESOCKET
 
-The session's active socket.
-See CURLINFO_ACTIVESOCKET(3)
+The session's active socket. See CURLINFO_ACTIVESOCKET(3)
 
 ## CURLINFO_APPCONNECT_TIME
 
@@ -110,8 +109,7 @@ curl_easy_header(3) instead. See CURLINFO_CONTENT_TYPE(3)
 
 ## CURLINFO_COOKIELIST
 
-List of all known cookies.
-See CURLINFO_COOKIELIST(3)
+List of all known cookies. See CURLINFO_COOKIELIST(3)
 
 ## CURLINFO_EFFECTIVE_METHOD
 
@@ -179,8 +177,7 @@ See CURLINFO_NUM_CONNECTS(3)
 
 ## CURLINFO_OS_ERRNO
 
-The errno from the last failure to connect.
-See CURLINFO_OS_ERRNO(3)
+The errno from the last failure to connect. See CURLINFO_OS_ERRNO(3)
 
 ## CURLINFO_PRETRANSFER_TIME
 
@@ -233,8 +230,7 @@ CURLINFO_QUEUE_TIME_T(3)
 
 ## CURLINFO_REDIRECT_COUNT
 
-Total number of redirects that were followed.
-See CURLINFO_REDIRECT_COUNT(3)
+Total number of redirects that were followed. See CURLINFO_REDIRECT_COUNT(3)
 
 ## CURLINFO_REDIRECT_TIME
 

--- a/docs/libcurl/curl_easy_getinfo.md
+++ b/docs/libcurl/curl_easy_getinfo.md
@@ -33,202 +33,61 @@ performed transfer if you want to get transfer related data.
 You should not free the memory returned by this function unless it is
 explicitly mentioned below.
 
-# AVAILABLE INFORMATION
+# OPTIONS
 
 The following information can be extracted:
 
-## CURLINFO_EFFECTIVE_METHOD
+## CURLINFO_ACTIVESOCKET
 
-Last used HTTP method. See CURLINFO_EFFECTIVE_METHOD(3)
-
-## CURLINFO_EFFECTIVE_URL
-
-Last used URL. See CURLINFO_EFFECTIVE_URL(3)
-
-## CURLINFO_RESPONSE_CODE
-
-Last received response code. See CURLINFO_RESPONSE_CODE(3)
-
-## CURLINFO_REFERER
-
-Referrer header. See CURLINFO_REFERER(3)
-
-## CURLINFO_HTTP_CONNECTCODE
-
-Last proxy CONNECT response code. See CURLINFO_HTTP_CONNECTCODE(3)
-
-## CURLINFO_HTTP_VERSION
-
-The http version used in the connection. See CURLINFO_HTTP_VERSION(3)
-
-## CURLINFO_FILETIME
-
-Remote time of the retrieved document. See CURLINFO_FILETIME(3)
-
-## CURLINFO_FILETIME_T
-
-Remote time of the retrieved document. See CURLINFO_FILETIME_T(3)
-
-## CURLINFO_TOTAL_TIME
-
-Total time of previous transfer. See CURLINFO_TOTAL_TIME(3)
-
-## CURLINFO_TOTAL_TIME_T
-
-Total time of previous transfer. See CURLINFO_TOTAL_TIME_T(3)
-
-## CURLINFO_NAMELOOKUP_TIME
-
-Time from start until name resolving completed. See
-CURLINFO_NAMELOOKUP_TIME(3)
-
-## CURLINFO_NAMELOOKUP_TIME_T
-
-Time from start until name resolving completed. See
-CURLINFO_NAMELOOKUP_TIME_T(3)
-
-## CURLINFO_CONNECT_TIME
-
-Time from start until remote host or proxy completed.
-See CURLINFO_CONNECT_TIME(3)
-
-## CURLINFO_CONNECT_TIME_T
-
-Time from start until remote host or proxy completed.
-See CURLINFO_CONNECT_TIME_T(3)
+The session's active socket.
+See CURLINFO_ACTIVESOCKET(3)
 
 ## CURLINFO_APPCONNECT_TIME
 
-Time from start until SSL/SSH handshake completed.
-See CURLINFO_APPCONNECT_TIME(3)
+The time it took from the start until the SSL connect/handshake with the
+remote host was completed as a double in number of seconds. (Added in 7.19.0)
 
 ## CURLINFO_APPCONNECT_TIME_T
 
-Time from start until SSL/SSH handshake completed.
-See CURLINFO_APPCONNECT_TIME_T(3)
+The time it took from the start until the SSL connect/handshake with the
+remote host was completed in number of microseconds. (Added in 7.60.0) See
+CURLINFO_APPCONNECT_TIME_T(3)
 
-## CURLINFO_PRETRANSFER_TIME
+## CURLINFO_CAINFO
 
-Time from start until just before the transfer begins.
-See CURLINFO_PRETRANSFER_TIME(3)
+Get the default value for CURLOPT_CAINFO(3). See CURLINFO_CAINFO(3)
 
-## CURLINFO_PRETRANSFER_TIME_T
+## CURLINFO_CAPATH
 
-Time from start until just before the transfer begins.
-See CURLINFO_PRETRANSFER_TIME_T(3)
+Get the default value for CURLOPT_CAPATH(3). See CURLINFO_CAPATH(3)
 
-## CURLINFO_QUEUE_TIME_T
+## CURLINFO_CERTINFO
 
-Time during which this transfer was held in a waiting queue.
-See CURLINFO_QUEUE_TIME_T(3)
+Certificate chain. See CURLINFO_CERTINFO(3)
 
-## CURLINFO_USED_PROXY
+## CURLINFO_CONDITION_UNMET
 
-Whether the proxy was used (Added in 8.7.0). See CURLINFO_USED_PROXY(3)
+Whether or not a time conditional was met or 304 HTTP response.
+See CURLINFO_CONDITION_UNMET(3)
 
-## CURLINFO_STARTTRANSFER_TIME
+## CURLINFO_CONNECT_TIME
 
-Time from start until just when the first byte is received.
-See CURLINFO_STARTTRANSFER_TIME(3)
+The time it took from the start until the connect to the remote host (or
+proxy) was completed. As a double. See CURLINFO_CONNECT_TIME(3)
 
-## CURLINFO_STARTTRANSFER_TIME_T
+## CURLINFO_CONNECT_TIME_T
 
-Time from start until just when the first byte is received.
-See CURLINFO_STARTTRANSFER_TIME_T(3)
+The time it took from the start until the connect to the remote host (or
+proxy) was completed. In microseconds. See CURLINFO_CONNECT_TIME_T(3).
 
-## CURLINFO_REDIRECT_TIME
+## CURLINFO_CONN_ID
 
-Time taken for all redirect steps before the final transfer.
-See CURLINFO_REDIRECT_TIME(3)
-
-## CURLINFO_REDIRECT_TIME_T
-
-Time taken for all redirect steps before the final transfer.
-See CURLINFO_REDIRECT_TIME_T(3)
-
-## CURLINFO_REDIRECT_COUNT
-
-Total number of redirects that were followed.
-See CURLINFO_REDIRECT_COUNT(3)
-
-## CURLINFO_REDIRECT_URL
-
-URL a redirect would take you to, had you enabled redirects.
-See CURLINFO_REDIRECT_URL(3)
-
-## CURLINFO_SIZE_UPLOAD
-
-(Deprecated) Number of bytes uploaded.
-See CURLINFO_SIZE_UPLOAD(3)
-
-## CURLINFO_SIZE_UPLOAD_T
-
-Number of bytes uploaded.
-See CURLINFO_SIZE_UPLOAD_T(3)
-
-## CURLINFO_SIZE_DOWNLOAD
-
-(Deprecated) Number of bytes downloaded.
-See CURLINFO_SIZE_DOWNLOAD(3)
-
-## CURLINFO_SIZE_DOWNLOAD_T
-
-Number of bytes downloaded.
-See CURLINFO_SIZE_DOWNLOAD_T(3)
-
-## CURLINFO_SPEED_DOWNLOAD
-
-(Deprecated) Average download speed.
-See CURLINFO_SPEED_DOWNLOAD(3)
-
-## CURLINFO_SPEED_DOWNLOAD_T
-
-Average download speed.
-See CURLINFO_SPEED_DOWNLOAD_T(3)
-
-## CURLINFO_SPEED_UPLOAD
-
-(Deprecated) Average upload speed.
-See CURLINFO_SPEED_UPLOAD(3)
-
-## CURLINFO_SPEED_UPLOAD_T
-
-Average upload speed.
-See CURLINFO_SPEED_UPLOAD_T(3)
-
-## CURLINFO_HEADER_SIZE
-
-Number of bytes of all headers received.
-See CURLINFO_HEADER_SIZE(3)
-
-## CURLINFO_REQUEST_SIZE
-
-Number of bytes sent in the issued HTTP requests.
-See CURLINFO_REQUEST_SIZE(3)
-
-## CURLINFO_SSL_VERIFYRESULT
-
-Certificate verification result.
-See CURLINFO_SSL_VERIFYRESULT(3)
-
-## CURLINFO_PROXY_ERROR
-
-Detailed proxy error.
-See CURLINFO_PROXY_ERROR(3)
-
-## CURLINFO_PROXY_SSL_VERIFYRESULT
-
-Proxy certificate verification result.
-See CURLINFO_PROXY_SSL_VERIFYRESULT(3)
-
-## CURLINFO_SSL_ENGINES
-
-A list of OpenSSL crypto engines.
-See CURLINFO_SSL_ENGINES(3)
+The ID of the last connection used by the transfer. (Added in 8.2.0)
+See CURLINFO_CONN_ID(3)
 
 ## CURLINFO_CONTENT_LENGTH_DOWNLOAD
 
-(Deprecated) Content length from the Content-Length header.
+(**Deprecated**) Content length from the Content-Length header.
 See CURLINFO_CONTENT_LENGTH_DOWNLOAD(3)
 
 ## CURLINFO_CONTENT_LENGTH_DOWNLOAD_T
@@ -238,7 +97,7 @@ See CURLINFO_CONTENT_LENGTH_DOWNLOAD_T(3)
 
 ## CURLINFO_CONTENT_LENGTH_UPLOAD
 
-(Deprecated) Upload size. See CURLINFO_CONTENT_LENGTH_UPLOAD(3)
+(**Deprecated**) Upload size. See CURLINFO_CONTENT_LENGTH_UPLOAD(3)
 
 ## CURLINFO_CONTENT_LENGTH_UPLOAD_T
 
@@ -246,149 +105,267 @@ Upload size. See CURLINFO_CONTENT_LENGTH_UPLOAD_T(3)
 
 ## CURLINFO_CONTENT_TYPE
 
-Content type from the Content-Type header.
-See CURLINFO_CONTENT_TYPE(3)
-
-## CURLINFO_RETRY_AFTER
-
-The value from the Retry-After header.
-See CURLINFO_RETRY_AFTER(3)
-
-## CURLINFO_PRIVATE
-
-User's private data pointer.
-See CURLINFO_PRIVATE(3)
-
-## CURLINFO_HTTPAUTH_AVAIL
-
-Available HTTP authentication methods.
-See CURLINFO_HTTPAUTH_AVAIL(3)
-
-## CURLINFO_PROXYAUTH_AVAIL
-
-Available HTTP proxy authentication methods.
-See CURLINFO_PROXYAUTH_AVAIL(3)
-
-## CURLINFO_OS_ERRNO
-
-The errno from the last failure to connect.
-See CURLINFO_OS_ERRNO(3)
-
-## CURLINFO_NUM_CONNECTS
-
-Number of new successful connections used for previous transfer.
-See CURLINFO_NUM_CONNECTS(3)
-
-## CURLINFO_PRIMARY_IP
-
-Destination IP address of the last connection.
-See CURLINFO_PRIMARY_IP(3)
-
-## CURLINFO_PRIMARY_PORT
-
-Destination port of the last connection.
-See CURLINFO_PRIMARY_PORT(3)
-
-## CURLINFO_LOCAL_IP
-
-Source IP address of the last connection.
-See CURLINFO_LOCAL_IP(3)
-
-## CURLINFO_LOCAL_PORT
-
-Source port number of the last connection.
-See CURLINFO_LOCAL_PORT(3)
+Content type from the `Content-Type:` header. We recommend using
+curl_easy_header(3) instead. See CURLINFO_CONTENT_TYPE(3)
 
 ## CURLINFO_COOKIELIST
 
 List of all known cookies.
 See CURLINFO_COOKIELIST(3)
 
-## CURLINFO_LASTSOCKET
+## CURLINFO_EFFECTIVE_METHOD
 
-(Deprecated) Last socket used.
-See CURLINFO_LASTSOCKET(3)
+Last used HTTP method. See CURLINFO_EFFECTIVE_METHOD(3)
 
-## CURLINFO_ACTIVESOCKET
+## CURLINFO_EFFECTIVE_URL
 
-The session's active socket.
-See CURLINFO_ACTIVESOCKET(3)
+Last used URL. See CURLINFO_EFFECTIVE_URL(3)
+
+## CURLINFO_FILETIME
+
+Remote time of the retrieved document. See CURLINFO_FILETIME(3)
+
+## CURLINFO_FILETIME_T
+
+Remote time of the retrieved document. See CURLINFO_FILETIME_T(3)
 
 ## CURLINFO_FTP_ENTRY_PATH
 
-The entry path after logging in to an FTP server.
-See CURLINFO_FTP_ENTRY_PATH(3)
+The entry path after logging in to an FTP server. See
+CURLINFO_FTP_ENTRY_PATH(3)
 
-## CURLINFO_CAPATH
+## CURLINFO_HEADER_SIZE
 
-Get the default value for CURLOPT_CAPATH(3).
-See CURLINFO_CAPATH(3)
+Number of bytes of all headers received. See CURLINFO_HEADER_SIZE(3)
 
-## CURLINFO_CAINFO
+## CURLINFO_HTTPAUTH_AVAIL
 
-Get the default value for CURLOPT_CAINFO(3).
-See CURLINFO_CAINFO(3)
+Available HTTP authentication methods. See CURLINFO_HTTPAUTH_AVAIL(3)
 
-## CURLINFO_CERTINFO
+## CURLINFO_HTTP_CONNECTCODE
 
-Certificate chain.
-See CURLINFO_CERTINFO(3)
+Last proxy CONNECT response code. See CURLINFO_HTTP_CONNECTCODE(3)
 
-## CURLINFO_TLS_SSL_PTR
+## CURLINFO_HTTP_VERSION
 
-TLS session info that can be used for further processing.
-See CURLINFO_TLS_SSL_PTR(3)
+The http version used in the connection. See CURLINFO_HTTP_VERSION(3)
 
-## CURLINFO_TLS_SESSION
+## CURLINFO_LASTSOCKET
 
-TLS session info that can be used for further processing. See
-CURLINFO_TLS_SESSION(3). Deprecated option, use
-CURLINFO_TLS_SSL_PTR(3) instead!
+(**Deprecated**) Last socket used. See CURLINFO_LASTSOCKET(3)
 
-## CURLINFO_CONDITION_UNMET
+## CURLINFO_LOCAL_IP
 
-Whether or not a time conditional was met or 304 HTTP response.
-See CURLINFO_CONDITION_UNMET(3)
+Source IP address of the last connection. See CURLINFO_LOCAL_IP(3)
 
-## CURLINFO_RTSP_SESSION_ID
+## CURLINFO_LOCAL_PORT
 
-RTSP session ID.
-See CURLINFO_RTSP_SESSION_ID(3)
+Source port number of the last connection. See CURLINFO_LOCAL_PORT(3)
 
-## CURLINFO_RTSP_CLIENT_CSEQ
+## CURLINFO_NAMELOOKUP_TIME
 
-The RTSP client CSeq that is expected next.
-See CURLINFO_RTSP_CLIENT_CSEQ(3)
+Time from start until name resolving completed as a double. See
+CURLINFO_NAMELOOKUP_TIME(3)
 
-## CURLINFO_RTSP_SERVER_CSEQ
+## CURLINFO_NAMELOOKUP_TIME_T
 
-The RTSP server CSeq that is expected next.
-See CURLINFO_RTSP_SERVER_CSEQ(3)
+Time from start until name resolving completed in number of microseconds. See
+CURLINFO_NAMELOOKUP_TIME_T(3)
 
-## CURLINFO_RTSP_CSEQ_RECV
+## CURLINFO_NUM_CONNECTS
 
-RTSP CSeq last received.
-See CURLINFO_RTSP_CSEQ_RECV(3)
+Number of new successful connections used for previous transfer.
+See CURLINFO_NUM_CONNECTS(3)
+
+## CURLINFO_OS_ERRNO
+
+The errno from the last failure to connect.
+See CURLINFO_OS_ERRNO(3)
+
+## CURLINFO_PRETRANSFER_TIME
+
+The time it took from the start until the file transfer is just about to
+begin. This includes all pre-transfer commands and negotiations that are
+specific to the particular protocol(s) involved. See
+CURLINFO_PRETRANSFER_TIME(3)
+
+## CURLINFO_PRETRANSFER_TIME_T
+
+The time it took from the start until the file transfer is just about to
+begin. This includes all pre-transfer commands and negotiations that are
+specific to the particular protocol(s) involved. In microseconds. See
+CURLINFO_PRETRANSFER_TIME_T(3)
+
+## CURLINFO_PRIMARY_IP
+
+Destination IP address of the last connection. See CURLINFO_PRIMARY_IP(3)
+
+## CURLINFO_PRIMARY_PORT
+
+Destination port of the last connection. See CURLINFO_PRIMARY_PORT(3)
+
+## CURLINFO_PRIVATE
+
+User's private data pointer. See CURLINFO_PRIVATE(3)
 
 ## CURLINFO_PROTOCOL
 
-(Deprecated) The protocol used for the connection. (Added in 7.52.0)
-See CURLINFO_PROTOCOL(3)
+(**Deprecated**) The protocol used for the connection. (Added in 7.52.0) See
+CURLINFO_PROTOCOL(3)
+
+## CURLINFO_PROXYAUTH_AVAIL
+
+Available HTTP proxy authentication methods. See CURLINFO_PROXYAUTH_AVAIL(3)
+
+## CURLINFO_PROXY_ERROR
+
+Detailed proxy error. See CURLINFO_PROXY_ERROR(3)
+
+## CURLINFO_PROXY_SSL_VERIFYRESULT
+
+Proxy certificate verification result. See CURLINFO_PROXY_SSL_VERIFYRESULT(3)
+
+## CURLINFO_QUEUE_TIME_T
+
+The time during which the transfer was held in a waiting queue before it could
+start for real in number of microseconds. (Added in 8.6.0) See
+CURLINFO_QUEUE_TIME_T(3)
+
+## CURLINFO_REDIRECT_COUNT
+
+Total number of redirects that were followed.
+See CURLINFO_REDIRECT_COUNT(3)
+
+## CURLINFO_REDIRECT_TIME
+
+The time it took for all redirection steps include name lookup, connect,
+pretransfer and transfer before final transaction was started. So, this is
+zero if no redirection took place. As a double. See CURLINFO_REDIRECT_TIME(3)
+
+## CURLINFO_REDIRECT_TIME_T
+
+The time it took for all redirection steps include name lookup, connect,
+pretransfer and transfer before final transaction was started. So, this is
+zero if no redirection took place. In number of microseconds. See
+CURLINFO_REDIRECT_TIME_T(3)
+
+## CURLINFO_REDIRECT_URL
+
+URL a redirect would take you to, had you enabled redirects. See
+CURLINFO_REDIRECT_URL(3)
+
+## CURLINFO_REFERER
+
+Referrer header. See CURLINFO_REFERER(3)
+
+## CURLINFO_REQUEST_SIZE
+
+Number of bytes sent in the issued HTTP requests. See CURLINFO_REQUEST_SIZE(3)
+
+## CURLINFO_RESPONSE_CODE
+
+Last received response code. See CURLINFO_RESPONSE_CODE(3)
+
+## CURLINFO_RETRY_AFTER
+
+The value from the Retry-After header. See CURLINFO_RETRY_AFTER(3)
+
+## CURLINFO_RTSP_CLIENT_CSEQ
+
+The RTSP client CSeq that is expected next. See CURLINFO_RTSP_CLIENT_CSEQ(3)
+
+## CURLINFO_RTSP_CSEQ_RECV
+
+RTSP CSeq last received. See CURLINFO_RTSP_CSEQ_RECV(3)
+
+## CURLINFO_RTSP_SERVER_CSEQ
+
+The RTSP server CSeq that is expected next. See CURLINFO_RTSP_SERVER_CSEQ(3)
+
+## CURLINFO_RTSP_SESSION_ID
+
+RTSP session ID. See CURLINFO_RTSP_SESSION_ID(3)
 
 ## CURLINFO_SCHEME
 
-The scheme used for the connection. (Added in 7.52.0)
-See CURLINFO_SCHEME(3)
+The scheme used for the connection. (Added in 7.52.0) See CURLINFO_SCHEME(3)
 
-## CURLINFO_CONN_ID
+## CURLINFO_SIZE_DOWNLOAD
 
-The ID of the last connection used by the transfer. (Added in 8.2.0)
-See CURLINFO_CONN_ID(3)
+(**Deprecated**) Number of bytes downloaded. See CURLINFO_SIZE_DOWNLOAD(3)
+
+## CURLINFO_SIZE_DOWNLOAD_T
+
+Number of bytes downloaded. See CURLINFO_SIZE_DOWNLOAD_T(3)
+
+## CURLINFO_SIZE_UPLOAD
+
+(**Deprecated**) Number of bytes uploaded. See CURLINFO_SIZE_UPLOAD(3)
+
+## CURLINFO_SIZE_UPLOAD_T
+
+Number of bytes uploaded. See CURLINFO_SIZE_UPLOAD_T(3)
+
+## CURLINFO_SPEED_DOWNLOAD
+
+(**Deprecated**) Average download speed. See CURLINFO_SPEED_DOWNLOAD(3)
+
+## CURLINFO_SPEED_DOWNLOAD_T
+
+Average download speed. See CURLINFO_SPEED_DOWNLOAD_T(3)
+
+## CURLINFO_SPEED_UPLOAD
+
+(**Deprecated**) Average upload speed. See CURLINFO_SPEED_UPLOAD(3)
+
+## CURLINFO_SPEED_UPLOAD_T
+
+Average upload speed in number of bytes per second. See
+CURLINFO_SPEED_UPLOAD_T(3)
+
+## CURLINFO_SSL_ENGINES
+
+A list of OpenSSL crypto engines. See CURLINFO_SSL_ENGINES(3)
+
+## CURLINFO_SSL_VERIFYRESULT
+
+Certificate verification result. See CURLINFO_SSL_VERIFYRESULT(3)
+
+## CURLINFO_STARTTRANSFER_TIME
+
+The time it took from the start until the first byte is received by libcurl.
+As a double. See CURLINFO_STARTTRANSFER_TIME(3)
+
+## CURLINFO_STARTTRANSFER_TIME_T
+
+The time it took from the start until the first byte is received by libcurl.
+In microseconds. See CURLINFO_STARTTRANSFER_TIME_T(3)
+
+## CURLINFO_TLS_SESSION
+
+(**Deprecated**) TLS session info that can be used for further processing. See
+CURLINFO_TLS_SESSION(3). Use CURLINFO_TLS_SSL_PTR(3) instead!
+
+## CURLINFO_TLS_SSL_PTR
+
+TLS session info that can be used for further processing. See
+CURLINFO_TLS_SSL_PTR(3)
+
+## CURLINFO_TOTAL_TIME
+
+Total time of previous transfer. See CURLINFO_TOTAL_TIME(3)
+
+## CURLINFO_TOTAL_TIME_T
+
+Total time of previous transfer. See CURLINFO_TOTAL_TIME_T(3)
+
+## CURLINFO_USED_PROXY
+
+Whether the proxy was used (Added in 8.7.0). See CURLINFO_USED_PROXY(3)
 
 ## CURLINFO_XFER_ID
 
-The ID of the transfer. (Added in 8.2.0)
-See CURLINFO_XFER_ID(3)
+The ID of the transfer. (Added in 8.2.0) See CURLINFO_XFER_ID(3)
 
 # TIMES
 
@@ -405,51 +382,11 @@ An overview of the time values available from curl_easy_getinfo(3)
         |--|--|--|--|--|--|--TOTAL
         |--|--|--|--|--|--|--REDIRECT
 
-## CURLINFO_QUEUE_TIME
 
-CURLINFO_QUEUE_TIME_T(3). The time during which the transfer was held in a
-waiting queue before it could start for real. (Added in 8.6.0)
-
-## CURLINFO_NAMELOOKUP_TIME
-
-CURLINFO_NAMELOOKUP_TIME(3) and CURLINFO_NAMELOOKUP_TIME_T(3). The time it
-took from the start until the name resolving was completed.
-
-## CURLINFO_CONNECT_TIME
-
-CURLINFO_CONNECT_TIME(3) and CURLINFO_CONNECT_TIME_T(3). The time it took from
-the start until the connect to the remote host (or proxy) was completed.
-
-## CURLINFO_APPCONNECT_TIME
-
-CURLINFO_APPCONNECT_TIME(3) and CURLINFO_APPCONNECT_TIME_T(3). The time it
-took from the start until the SSL connect/handshake with the remote host was
-completed. (Added in 7.19.0) The latter is the integer version (measuring
-microseconds). (Added in 7.60.0)
-
-## CURLINFO_PRETRANSFER_TIME
-
-CURLINFO_PRETRANSFER_TIME(3) and CURLINFO_PRETRANSFER_TIME_T(3). The time it
-took from the start until the file transfer is just about to begin. This
-includes all pre-transfer commands and negotiations that are specific to the
-particular protocol(s) involved.
-
-## CURLINFO_STARTTRANSFER_TIME
-
-CURLINFO_STARTTRANSFER_TIME(3) and CURLINFO_STARTTRANSFER_TIME_T(3). The time
-it took from the start until the first byte is received by libcurl.
-
-## CURLINFO_TOTAL_TIME
-
-CURLINFO_TOTAL_TIME(3) and CURLINFO_TOTAL_TIME_T(3). Total time
-of the previous request.
-
-## CURLINFO_REDIRECT_TIME
-
-CURLINFO_REDIRECT_TIME(3) and CURLINFO_REDIRECT_TIME_T(3). The time it took
-for all redirection steps include name lookup, connect, pretransfer and
-transfer before final transaction was started. So, this is zero if no
-redirection took place.
+ CURLINFO_QUEUE_TIME_T(3), CURLINFO_NAMELOOKUP_TIME_T(3),
+ CURLINFO_CONNECT_TIME_T(3), CURLINFO_APPCONNECT_TIME_T(3),
+ CURLINFO_PRETRANSFER_TIME_T(3), CURLINFO_STARTTRANSFER_TIME_T(3),
+ CURLINFO_TOTAL_TIME_T(3), CURLINFO_REDIRECT_TIME_T(3)
 
 # EXAMPLE
 

--- a/docs/libcurl/curl_easy_setopt.md
+++ b/docs/libcurl/curl_easy_setopt.md
@@ -62,134 +62,107 @@ keep them available until libcurl no longer needed them.
 The *handle* is the return code from a curl_easy_init(3) or
 curl_easy_duphandle(3) call.
 
-# BEHAVIOR OPTIONS
+# OPTIONS
 
-## CURLOPT_VERBOSE
+## CURLOPT_ABSTRACT_UNIX_SOCKET
 
-Display verbose information. See CURLOPT_VERBOSE(3)
+Path to an abstract Unix domain socket. See CURLOPT_ABSTRACT_UNIX_SOCKET(3)
 
-## CURLOPT_HEADER
+## CURLOPT_ACCEPTTIMEOUT_MS
 
-Include the header in the body output. See CURLOPT_HEADER(3)
+Timeout for waiting for the server's connect back to be accepted. See
+CURLOPT_ACCEPTTIMEOUT_MS(3)
 
-## CURLOPT_NOPROGRESS
+## CURLOPT_ACCEPT_ENCODING
 
-Shut off the progress meter. See CURLOPT_NOPROGRESS(3)
+Accept-Encoding and automatic decompressing data. See
+CURLOPT_ACCEPT_ENCODING(3)
 
-## CURLOPT_NOSIGNAL
+## CURLOPT_ADDRESS_SCOPE
 
-Do not install signal handlers. See CURLOPT_NOSIGNAL(3)
+IPv6 scope for local addresses. See CURLOPT_ADDRESS_SCOPE(3)
 
-## CURLOPT_WILDCARDMATCH
+## CURLOPT_ALTSVC
 
-Transfer multiple files according to a filename pattern. See
-CURLOPT_WILDCARDMATCH(3)
+Specify the Alt-Svc: cache filename. See CURLOPT_ALTSVC(3)
 
-# CALLBACK OPTIONS
+## CURLOPT_ALTSVC_CTRL
 
-## CURLOPT_WRITEFUNCTION
+Enable and configure Alt-Svc: treatment. See CURLOPT_ALTSVC_CTRL(3)
 
-Callback for writing data. See CURLOPT_WRITEFUNCTION(3)
+## CURLOPT_APPEND
 
-## CURLOPT_WRITEDATA
+Append to remote file. See CURLOPT_APPEND(3)
 
-Data pointer to pass to the write callback. See CURLOPT_WRITEDATA(3)
+## CURLOPT_AUTOREFERER
 
-## CURLOPT_READFUNCTION
+Automatically set Referer: header. See CURLOPT_AUTOREFERER(3)
 
-Callback for reading data. See CURLOPT_READFUNCTION(3)
+## CURLOPT_AWS_SIGV4
 
-## CURLOPT_READDATA
+AWS HTTP V4 Signature. See CURLOPT_AWS_SIGV4(3)
 
-Data pointer to pass to the read callback. See CURLOPT_READDATA(3)
+## CURLOPT_BUFFERSIZE
 
-## CURLOPT_IOCTLFUNCTION
+Ask for alternate buffer size. See CURLOPT_BUFFERSIZE(3)
 
-**Deprecated option** Callback for I/O operations.
-See CURLOPT_IOCTLFUNCTION(3)
+## CURLOPT_CAINFO
 
-## CURLOPT_IOCTLDATA
+CA cert bundle. See CURLOPT_CAINFO(3)
 
-**Deprecated option** Data pointer to pass to the I/O callback.
-See CURLOPT_IOCTLDATA(3)
+## CURLOPT_CAINFO_BLOB
 
-## CURLOPT_SEEKFUNCTION
+CA cert bundle memory buffer. See CURLOPT_CAINFO_BLOB(3)
 
-Callback for seek operations. See CURLOPT_SEEKFUNCTION(3)
+## CURLOPT_CAPATH
 
-## CURLOPT_SEEKDATA
+Path to CA cert bundle. See CURLOPT_CAPATH(3)
 
-Data pointer to pass to the seek callback. See CURLOPT_SEEKDATA(3)
+## CURLOPT_CA_CACHE_TIMEOUT
 
-## CURLOPT_SOCKOPTFUNCTION
+Timeout for CA cache. See CURLOPT_CA_CACHE_TIMEOUT(3)
 
-Callback for sockopt operations. See CURLOPT_SOCKOPTFUNCTION(3)
+## CURLOPT_CERTINFO
 
-## CURLOPT_SOCKOPTDATA
+Extract certificate info. See CURLOPT_CERTINFO(3)
 
-Data pointer to pass to the sockopt callback. See CURLOPT_SOCKOPTDATA(3)
+## CURLOPT_CHUNK_BGN_FUNCTION
 
-## CURLOPT_OPENSOCKETFUNCTION
+Callback for wildcard download start of chunk. See
+CURLOPT_CHUNK_BGN_FUNCTION(3)
 
-Callback for socket creation. See CURLOPT_OPENSOCKETFUNCTION(3)
+## CURLOPT_CHUNK_DATA
 
-## CURLOPT_OPENSOCKETDATA
+Data pointer to pass to the chunk callbacks. See CURLOPT_CHUNK_DATA(3)
 
-Data pointer to pass to the open socket callback. See CURLOPT_OPENSOCKETDATA(3)
+## CURLOPT_CHUNK_END_FUNCTION
+
+Callback for wildcard download end of chunk. See CURLOPT_CHUNK_END_FUNCTION(3)
+
+## CURLOPT_CLOSESOCKETDATA
+
+Data pointer to pass to the close socket callback. See
+CURLOPT_CLOSESOCKETDATA(3)
 
 ## CURLOPT_CLOSESOCKETFUNCTION
 
 Callback for closing socket. See CURLOPT_CLOSESOCKETFUNCTION(3)
 
-## CURLOPT_CLOSESOCKETDATA
+## CURLOPT_CONNECTTIMEOUT
 
-Data pointer to pass to the close socket callback. See CURLOPT_CLOSESOCKETDATA(3)
+Timeout for the connection phase. See CURLOPT_CONNECTTIMEOUT(3)
 
-## CURLOPT_PROGRESSFUNCTION
+## CURLOPT_CONNECTTIMEOUT_MS
 
-**OBSOLETE** callback for progress meter.
-See CURLOPT_PROGRESSFUNCTION(3)
+Millisecond timeout for the connection phase. See CURLOPT_CONNECTTIMEOUT_MS(3)
 
-## CURLOPT_PROGRESSDATA
+## CURLOPT_CONNECT_ONLY
 
-Data pointer to pass to the progress meter callback. See CURLOPT_PROGRESSDATA(3)
+Only connect, nothing else. See CURLOPT_CONNECT_ONLY(3)
 
-## CURLOPT_XFERINFOFUNCTION
+## CURLOPT_CONNECT_TO
 
-Callback for progress meter. See CURLOPT_XFERINFOFUNCTION(3)
-
-## CURLOPT_XFERINFODATA
-
-Data pointer to pass to the progress meter callback. See CURLOPT_XFERINFODATA(3)
-
-## CURLOPT_HEADERFUNCTION
-
-Callback for writing received headers. See CURLOPT_HEADERFUNCTION(3)
-
-## CURLOPT_HEADERDATA
-
-Data pointer to pass to the header callback. See CURLOPT_HEADERDATA(3)
-
-## CURLOPT_DEBUGFUNCTION
-
-Callback for debug information. See CURLOPT_DEBUGFUNCTION(3)
-
-## CURLOPT_DEBUGDATA
-
-Data pointer to pass to the debug callback. See CURLOPT_DEBUGDATA(3)
-
-## CURLOPT_SSL_CTX_FUNCTION
-
-Callback for SSL context logic. See CURLOPT_SSL_CTX_FUNCTION(3)
-
-## CURLOPT_SSL_CTX_DATA
-
-Data pointer to pass to the SSL context callback. See CURLOPT_SSL_CTX_DATA(3)
-
-## CURLOPT_CONV_TO_NETWORK_FUNCTION
-
-**OBSOLETE** Callback for code base conversion.
-See CURLOPT_CONV_TO_NETWORK_FUNCTION(3)
+Connect to a specific host and port. See CURLOPT_CONNECT_TO(3)
 
 ## CURLOPT_CONV_FROM_NETWORK_FUNCTION
 
@@ -201,402 +174,10 @@ See CURLOPT_CONV_FROM_NETWORK_FUNCTION(3)
 **OBSOLETE** Callback for code base conversion.
 See CURLOPT_CONV_FROM_UTF8_FUNCTION(3)
 
-## CURLOPT_INTERLEAVEFUNCTION
+## CURLOPT_CONV_TO_NETWORK_FUNCTION
 
-Callback for RTSP interleaved data. See CURLOPT_INTERLEAVEFUNCTION(3)
-
-## CURLOPT_INTERLEAVEDATA
-
-Data pointer to pass to the RTSP interleave callback. See CURLOPT_INTERLEAVEDATA(3)
-
-## CURLOPT_CHUNK_BGN_FUNCTION
-
-Callback for wildcard download start of chunk. See CURLOPT_CHUNK_BGN_FUNCTION(3)
-
-## CURLOPT_CHUNK_END_FUNCTION
-
-Callback for wildcard download end of chunk. See CURLOPT_CHUNK_END_FUNCTION(3)
-
-## CURLOPT_CHUNK_DATA
-
-Data pointer to pass to the chunk callbacks. See CURLOPT_CHUNK_DATA(3)
-
-## CURLOPT_FNMATCH_FUNCTION
-
-Callback for wildcard matching. See CURLOPT_FNMATCH_FUNCTION(3)
-
-## CURLOPT_FNMATCH_DATA
-
-Data pointer to pass to the wildcard matching callback. See CURLOPT_FNMATCH_DATA(3)
-
-## CURLOPT_SUPPRESS_CONNECT_HEADERS
-
-Suppress proxy CONNECT response headers from user callbacks. See
-CURLOPT_SUPPRESS_CONNECT_HEADERS(3)
-
-## CURLOPT_RESOLVER_START_FUNCTION
-
-Callback to be called before a new resolve request is started. See
-CURLOPT_RESOLVER_START_FUNCTION(3)
-
-## CURLOPT_RESOLVER_START_DATA
-
-Data pointer to pass to resolver start callback. See CURLOPT_RESOLVER_START_DATA(3)
-
-## CURLOPT_PREREQFUNCTION
-
-Callback to be called after a connection is established but before a request
-is made on that connection. See CURLOPT_PREREQFUNCTION(3)
-
-## CURLOPT_PREREQDATA
-
-Data pointer to pass to the CURLOPT_PREREQFUNCTION callback. See
-CURLOPT_PREREQDATA(3)
-
-# ERROR OPTIONS
-
-## CURLOPT_ERRORBUFFER
-
-Error message buffer. See CURLOPT_ERRORBUFFER(3)
-
-## CURLOPT_STDERR
-
-stderr replacement stream. See CURLOPT_STDERR(3)
-
-## CURLOPT_FAILONERROR
-
-Fail on HTTP 4xx errors. CURLOPT_FAILONERROR(3)
-
-## CURLOPT_KEEP_SENDING_ON_ERROR
-
-Keep sending on HTTP \>= 300 errors. CURLOPT_KEEP_SENDING_ON_ERROR(3)
-
-# NETWORK OPTIONS
-
-## CURLOPT_URL
-
-URL to work on. See CURLOPT_URL(3)
-
-## CURLOPT_PATH_AS_IS
-
-Disable squashing /../ and /./ sequences in the path. See CURLOPT_PATH_AS_IS(3)
-
-## CURLOPT_PROTOCOLS
-
-**Deprecated option** Allowed protocols. See CURLOPT_PROTOCOLS(3)
-
-## CURLOPT_PROTOCOLS_STR
-
-Allowed protocols. See CURLOPT_PROTOCOLS_STR(3)
-
-## CURLOPT_REDIR_PROTOCOLS
-
-**Deprecated option** Protocols to allow redirects to. See
-CURLOPT_REDIR_PROTOCOLS(3)
-
-## CURLOPT_REDIR_PROTOCOLS_STR
-
-Protocols to allow redirects to. See CURLOPT_REDIR_PROTOCOLS_STR(3)
-
-## CURLOPT_DEFAULT_PROTOCOL
-
-Default protocol. See CURLOPT_DEFAULT_PROTOCOL(3)
-
-## CURLOPT_PROXY
-
-Proxy to use. See CURLOPT_PROXY(3)
-
-## CURLOPT_PRE_PROXY
-
-Socks proxy to use. See CURLOPT_PRE_PROXY(3)
-
-## CURLOPT_PROXYPORT
-
-Proxy port to use. See CURLOPT_PROXYPORT(3)
-
-## CURLOPT_PROXYTYPE
-
-Proxy type. See CURLOPT_PROXYTYPE(3)
-
-## CURLOPT_NOPROXY
-
-Filter out hosts from proxy use. CURLOPT_NOPROXY(3)
-
-## CURLOPT_HTTPPROXYTUNNEL
-
-Tunnel through the HTTP proxy. CURLOPT_HTTPPROXYTUNNEL(3)
-
-## CURLOPT_CONNECT_TO
-
-Connect to a specific host and port. See CURLOPT_CONNECT_TO(3)
-
-## CURLOPT_SOCKS5_AUTH
-
-Socks5 authentication methods. See CURLOPT_SOCKS5_AUTH(3)
-
-## CURLOPT_SOCKS5_GSSAPI_SERVICE
-
-**Deprecated option** Socks5 GSSAPI service name.
-See CURLOPT_SOCKS5_GSSAPI_SERVICE(3)
-
-## CURLOPT_SOCKS5_GSSAPI_NEC
-
-Socks5 GSSAPI NEC mode. See CURLOPT_SOCKS5_GSSAPI_NEC(3)
-
-## CURLOPT_PROXY_SERVICE_NAME
-
-Proxy authentication service name. CURLOPT_PROXY_SERVICE_NAME(3)
-
-## CURLOPT_HAPROXYPROTOCOL
-
-Send an HAProxy PROXY protocol v1 header. See CURLOPT_HAPROXYPROTOCOL(3)
-
-## CURLOPT_HAPROXY_CLIENT_IP
-
-Spoof the client IP in an HAProxy PROXY protocol v1 header. See
-CURLOPT_HAPROXY_CLIENT_IP(3)
-
-## CURLOPT_SERVICE_NAME
-
-Authentication service name. CURLOPT_SERVICE_NAME(3)
-
-## CURLOPT_INTERFACE
-
-Bind connection locally to this. See CURLOPT_INTERFACE(3)
-
-## CURLOPT_LOCALPORT
-
-Bind connection locally to this port. See CURLOPT_LOCALPORT(3)
-
-## CURLOPT_LOCALPORTRANGE
-
-Bind connection locally to port range. See CURLOPT_LOCALPORTRANGE(3)
-
-## CURLOPT_DNS_CACHE_TIMEOUT
-
-Timeout for DNS cache. See CURLOPT_DNS_CACHE_TIMEOUT(3)
-
-## CURLOPT_DNS_USE_GLOBAL_CACHE
-
-**OBSOLETE** Enable global DNS cache.
-See CURLOPT_DNS_USE_GLOBAL_CACHE(3)
-
-## CURLOPT_DOH_URL
-
-Use this DoH server for name resolves. See CURLOPT_DOH_URL(3)
-
-## CURLOPT_BUFFERSIZE
-
-Ask for alternate buffer size. See CURLOPT_BUFFERSIZE(3)
-
-## CURLOPT_PORT
-
-Port number to connect to. See CURLOPT_PORT(3)
-
-## CURLOPT_TCP_FASTOPEN
-
-Enable TCP Fast Open. See CURLOPT_TCP_FASTOPEN(3)
-
-## CURLOPT_TCP_NODELAY
-
-Disable the Nagle algorithm. See CURLOPT_TCP_NODELAY(3)
-
-## CURLOPT_ADDRESS_SCOPE
-
-IPv6 scope for local addresses. See CURLOPT_ADDRESS_SCOPE(3)
-
-## CURLOPT_TCP_KEEPALIVE
-
-Enable TCP keep-alive. See CURLOPT_TCP_KEEPALIVE(3)
-
-## CURLOPT_TCP_KEEPIDLE
-
-Idle time before sending keep-alive. See CURLOPT_TCP_KEEPIDLE(3)
-
-## CURLOPT_TCP_KEEPINTVL
-
-Interval between keep-alive probes. See CURLOPT_TCP_KEEPINTVL(3)
-
-## CURLOPT_TCP_KEEPCNT
-
-Maximum number of keep-alive probes. See CURLOPT_TCP_KEEPCNT(3)
-
-## CURLOPT_UNIX_SOCKET_PATH
-
-Path to a Unix domain socket. See CURLOPT_UNIX_SOCKET_PATH(3)
-
-## CURLOPT_ABSTRACT_UNIX_SOCKET
-
-Path to an abstract Unix domain socket. See CURLOPT_ABSTRACT_UNIX_SOCKET(3)
-
-# NAMES and PASSWORDS OPTIONS (Authentication)
-
-## CURLOPT_NETRC
-
-Enable .netrc parsing. See CURLOPT_NETRC(3)
-
-## CURLOPT_NETRC_FILE
-
-.netrc filename. See CURLOPT_NETRC_FILE(3)
-
-## CURLOPT_USERPWD
-
-Username and password. See CURLOPT_USERPWD(3)
-
-## CURLOPT_PROXYUSERPWD
-
-Proxy username and password. See CURLOPT_PROXYUSERPWD(3)
-
-## CURLOPT_USERNAME
-
-Username. See CURLOPT_USERNAME(3)
-
-## CURLOPT_PASSWORD
-
-Password. See CURLOPT_PASSWORD(3)
-
-## CURLOPT_LOGIN_OPTIONS
-
-Login options. See CURLOPT_LOGIN_OPTIONS(3)
-
-## CURLOPT_PROXYUSERNAME
-
-Proxy username. See CURLOPT_PROXYUSERNAME(3)
-
-## CURLOPT_PROXYPASSWORD
-
-Proxy password. See CURLOPT_PROXYPASSWORD(3)
-
-## CURLOPT_HTTPAUTH
-
-HTTP server authentication methods. See CURLOPT_HTTPAUTH(3)
-
-## CURLOPT_TLSAUTH_USERNAME
-
-TLS authentication username. See CURLOPT_TLSAUTH_USERNAME(3)
-
-## CURLOPT_PROXY_TLSAUTH_USERNAME
-
-Proxy TLS authentication username. See CURLOPT_PROXY_TLSAUTH_USERNAME(3)
-
-## CURLOPT_TLSAUTH_PASSWORD
-
-TLS authentication password. See CURLOPT_TLSAUTH_PASSWORD(3)
-
-## CURLOPT_PROXY_TLSAUTH_PASSWORD
-
-Proxy TLS authentication password. See CURLOPT_PROXY_TLSAUTH_PASSWORD(3)
-
-## CURLOPT_TLSAUTH_TYPE
-
-TLS authentication methods. See CURLOPT_TLSAUTH_TYPE(3)
-
-## CURLOPT_PROXY_TLSAUTH_TYPE
-
-Proxy TLS authentication methods. See CURLOPT_PROXY_TLSAUTH_TYPE(3)
-
-## CURLOPT_PROXYAUTH
-
-HTTP proxy authentication methods. See CURLOPT_PROXYAUTH(3)
-
-## CURLOPT_SASL_AUTHZID
-
-SASL authorization identity (identity to act as). See CURLOPT_SASL_AUTHZID(3)
-
-## CURLOPT_SASL_IR
-
-Enable SASL initial response. See CURLOPT_SASL_IR(3)
-
-## CURLOPT_XOAUTH2_BEARER
-
-OAuth2 bearer token. See CURLOPT_XOAUTH2_BEARER(3)
-
-## CURLOPT_DISALLOW_USERNAME_IN_URL
-
-Do not allow username in URL. See CURLOPT_DISALLOW_USERNAME_IN_URL(3)
-
-# HTTP OPTIONS
-
-## CURLOPT_AUTOREFERER
-
-Automatically set Referer: header. See CURLOPT_AUTOREFERER(3)
-
-## CURLOPT_ACCEPT_ENCODING
-
-Accept-Encoding and automatic decompressing data. See CURLOPT_ACCEPT_ENCODING(3)
-
-## CURLOPT_TRANSFER_ENCODING
-
-Request Transfer-Encoding. See CURLOPT_TRANSFER_ENCODING(3)
-
-## CURLOPT_FOLLOWLOCATION
-
-Follow HTTP redirects. See CURLOPT_FOLLOWLOCATION(3)
-
-## CURLOPT_UNRESTRICTED_AUTH
-
-Do not restrict authentication to original host. CURLOPT_UNRESTRICTED_AUTH(3)
-
-## CURLOPT_MAXREDIRS
-
-Maximum number of redirects to follow. See CURLOPT_MAXREDIRS(3)
-
-## CURLOPT_POSTREDIR
-
-How to act on redirects after POST. See CURLOPT_POSTREDIR(3)
-
-## CURLOPT_PUT
-
-**Deprecated option** Issue an HTTP PUT request. See CURLOPT_PUT(3)
-
-## CURLOPT_POST
-
-Issue an HTTP POST request. See CURLOPT_POST(3)
-
-## CURLOPT_POSTFIELDS
-
-Send a POST with this data. See CURLOPT_POSTFIELDS(3)
-
-## CURLOPT_POSTFIELDSIZE
-
-The POST data is this big. See CURLOPT_POSTFIELDSIZE(3)
-
-## CURLOPT_POSTFIELDSIZE_LARGE
-
-The POST data is this big. See CURLOPT_POSTFIELDSIZE_LARGE(3)
-
-## CURLOPT_COPYPOSTFIELDS
-
-Send a POST with this data - and copy it. See CURLOPT_COPYPOSTFIELDS(3)
-
-## CURLOPT_HTTPPOST
-
-**Deprecated option** Multipart formpost HTTP POST.
-See CURLOPT_HTTPPOST(3)
-
-## CURLOPT_REFERER
-
-Referer: header. See CURLOPT_REFERER(3)
-
-## CURLOPT_USERAGENT
-
-User-Agent: header. See CURLOPT_USERAGENT(3)
-
-## CURLOPT_HTTPHEADER
-
-Custom HTTP headers. See CURLOPT_HTTPHEADER(3)
-
-## CURLOPT_HEADEROPT
-
-Control custom headers. See CURLOPT_HEADEROPT(3)
-
-## CURLOPT_PROXYHEADER
-
-Custom HTTP headers sent to proxy. See CURLOPT_PROXYHEADER(3)
-
-## CURLOPT_HTTP200ALIASES
-
-Alternative versions of 200 OK. See CURLOPT_HTTP200ALIASES(3)
+**OBSOLETE** Callback for code base conversion.
+See CURLOPT_CONV_TO_NETWORK_FUNCTION(3)
 
 ## CURLOPT_COOKIE
 
@@ -610,259 +191,25 @@ File to read cookies from. See CURLOPT_COOKIEFILE(3)
 
 File to write cookies to. See CURLOPT_COOKIEJAR(3)
 
-## CURLOPT_COOKIESESSION
-
-Start a new cookie session. See CURLOPT_COOKIESESSION(3)
-
 ## CURLOPT_COOKIELIST
 
 Add or control cookies. See CURLOPT_COOKIELIST(3)
 
-## CURLOPT_ALTSVC
+## CURLOPT_COOKIESESSION
 
-Specify the Alt-Svc: cache filename. See CURLOPT_ALTSVC(3)
+Start a new cookie session. See CURLOPT_COOKIESESSION(3)
 
-## CURLOPT_ALTSVC_CTRL
+## CURLOPT_COPYPOSTFIELDS
 
-Enable and configure Alt-Svc: treatment. See CURLOPT_ALTSVC_CTRL(3)
-
-## CURLOPT_HSTS
-
-Set HSTS cache file. See CURLOPT_HSTS(3)
-
-## CURLOPT_HSTS_CTRL
-
-Enable HSTS. See CURLOPT_HSTS_CTRL(3)
-
-## CURLOPT_HSTSREADFUNCTION
-
-Set HSTS read callback. See CURLOPT_HSTSREADFUNCTION(3)
-
-## CURLOPT_HSTSREADDATA
-
-Pass pointer to the HSTS read callback. See CURLOPT_HSTSREADDATA(3)
-
-## CURLOPT_HSTSWRITEFUNCTION
-
-Set HSTS write callback. See CURLOPT_HSTSWRITEFUNCTION(3)
-
-## CURLOPT_HSTSWRITEDATA
-
-Pass pointer to the HSTS write callback. See CURLOPT_HSTSWRITEDATA(3)
-
-## CURLOPT_HTTPGET
-
-Do an HTTP GET request. See CURLOPT_HTTPGET(3)
-
-## CURLOPT_REQUEST_TARGET
-
-Set the request target. CURLOPT_REQUEST_TARGET(3)
-
-## CURLOPT_HTTP_VERSION
-
-HTTP version to use. CURLOPT_HTTP_VERSION(3)
-
-## CURLOPT_HTTP09_ALLOWED
-
-Allow HTTP/0.9 responses. CURLOPT_HTTP09_ALLOWED(3)
-
-## CURLOPT_IGNORE_CONTENT_LENGTH
-
-Ignore Content-Length. See CURLOPT_IGNORE_CONTENT_LENGTH(3)
-
-## CURLOPT_HTTP_CONTENT_DECODING
-
-Disable Content decoding. See CURLOPT_HTTP_CONTENT_DECODING(3)
-
-## CURLOPT_HTTP_TRANSFER_DECODING
-
-Disable Transfer decoding. See CURLOPT_HTTP_TRANSFER_DECODING(3)
-
-## CURLOPT_EXPECT_100_TIMEOUT_MS
-
-100-continue timeout. See CURLOPT_EXPECT_100_TIMEOUT_MS(3)
-
-## CURLOPT_TRAILERFUNCTION
-
-Set callback for sending trailing headers. See
-CURLOPT_TRAILERFUNCTION(3)
-
-## CURLOPT_TRAILERDATA
-
-Custom pointer passed to the trailing headers callback. See
-CURLOPT_TRAILERDATA(3)
-
-## CURLOPT_PIPEWAIT
-
-Wait on connection to pipeline on it. See CURLOPT_PIPEWAIT(3)
-
-## CURLOPT_STREAM_DEPENDS
-
-This HTTP/2 stream depends on another. See CURLOPT_STREAM_DEPENDS(3)
-
-## CURLOPT_STREAM_DEPENDS_E
-
-This HTTP/2 stream depends on another exclusively. See
-CURLOPT_STREAM_DEPENDS_E(3)
-
-## CURLOPT_STREAM_WEIGHT
-
-Set this HTTP/2 stream's weight. See CURLOPT_STREAM_WEIGHT(3)
-
-# SMTP OPTIONS
-
-## CURLOPT_MAIL_FROM
-
-Address of the sender. See CURLOPT_MAIL_FROM(3)
-
-## CURLOPT_MAIL_RCPT
-
-Address of the recipients. See CURLOPT_MAIL_RCPT(3)
-
-## CURLOPT_MAIL_AUTH
-
-Authentication address. See CURLOPT_MAIL_AUTH(3)
-
-## CURLOPT_MAIL_RCPT_ALLOWFAILS
-
-Allow RCPT TO command to fail for some recipients. See
-CURLOPT_MAIL_RCPT_ALLOWFAILS(3)
-
-# TFTP OPTIONS
-
-## CURLOPT_TFTP_BLKSIZE
-
-TFTP block size. See CURLOPT_TFTP_BLKSIZE(3)
-
-## CURLOPT_TFTP_NO_OPTIONS
-
-Do not send TFTP options requests. See CURLOPT_TFTP_NO_OPTIONS(3)
-
-# FTP OPTIONS
-
-## CURLOPT_FTPPORT
-
-Use active FTP. See CURLOPT_FTPPORT(3)
-
-## CURLOPT_QUOTE
-
-Commands to run before transfer. See CURLOPT_QUOTE(3)
-
-## CURLOPT_POSTQUOTE
-
-Commands to run after transfer. See CURLOPT_POSTQUOTE(3)
-
-## CURLOPT_PREQUOTE
-
-Commands to run just before transfer. See CURLOPT_PREQUOTE(3)
-
-## CURLOPT_APPEND
-
-Append to remote file. See CURLOPT_APPEND(3)
-
-## CURLOPT_FTP_USE_EPRT
-
-Use EPRT. See CURLOPT_FTP_USE_EPRT(3)
-
-## CURLOPT_FTP_USE_EPSV
-
-Use EPSV. See CURLOPT_FTP_USE_EPSV(3)
-
-## CURLOPT_FTP_USE_PRET
-
-Use PRET. See CURLOPT_FTP_USE_PRET(3)
-
-## CURLOPT_FTP_CREATE_MISSING_DIRS
-
-Create missing directories on the remote server. See CURLOPT_FTP_CREATE_MISSING_DIRS(3)
-
-## CURLOPT_SERVER_RESPONSE_TIMEOUT
-
-Timeout for server responses. See CURLOPT_SERVER_RESPONSE_TIMEOUT(3)
-
-## CURLOPT_SERVER_RESPONSE_TIMEOUT_MS
-
-Timeout for server responses. See CURLOPT_SERVER_RESPONSE_TIMEOUT_MS(3)
-
-## CURLOPT_FTP_ALTERNATIVE_TO_USER
-
-Alternative to USER. See CURLOPT_FTP_ALTERNATIVE_TO_USER(3)
-
-## CURLOPT_FTP_SKIP_PASV_IP
-
-Ignore the IP address in the PASV response. See CURLOPT_FTP_SKIP_PASV_IP(3)
-
-## CURLOPT_FTPSSLAUTH
-
-Control how to do TLS. See CURLOPT_FTPSSLAUTH(3)
-
-## CURLOPT_FTP_SSL_CCC
-
-Back to non-TLS again after authentication. See CURLOPT_FTP_SSL_CCC(3)
-
-## CURLOPT_FTP_ACCOUNT
-
-Send ACCT command. See CURLOPT_FTP_ACCOUNT(3)
-
-## CURLOPT_FTP_FILEMETHOD
-
-Specify how to reach files. See CURLOPT_FTP_FILEMETHOD(3)
-
-# RTSP OPTIONS
-
-## CURLOPT_RTSP_REQUEST
-
-RTSP request. See CURLOPT_RTSP_REQUEST(3)
-
-## CURLOPT_RTSP_SESSION_ID
-
-RTSP session-id. See CURLOPT_RTSP_SESSION_ID(3)
-
-## CURLOPT_RTSP_STREAM_URI
-
-RTSP stream URI. See CURLOPT_RTSP_STREAM_URI(3)
-
-## CURLOPT_RTSP_TRANSPORT
-
-RTSP Transport: header. See CURLOPT_RTSP_TRANSPORT(3)
-
-## CURLOPT_RTSP_CLIENT_CSEQ
-
-Client CSEQ number. See CURLOPT_RTSP_CLIENT_CSEQ(3)
-
-## CURLOPT_RTSP_SERVER_CSEQ
-
-CSEQ number for RTSP Server-\>Client request. See CURLOPT_RTSP_SERVER_CSEQ(3)
-
-## CURLOPT_AWS_SIGV4
-
-AWS HTTP V4 Signature. See CURLOPT_AWS_SIGV4(3)
-
-# PROTOCOL OPTIONS
-
-## CURLOPT_TRANSFERTEXT
-
-Use text transfer. See CURLOPT_TRANSFERTEXT(3)
-
-## CURLOPT_PROXY_TRANSFER_MODE
-
-Add transfer mode to URL over proxy. See CURLOPT_PROXY_TRANSFER_MODE(3)
+Send a POST with this data - and copy it. See CURLOPT_COPYPOSTFIELDS(3)
 
 ## CURLOPT_CRLF
 
 Convert newlines. See CURLOPT_CRLF(3)
 
-## CURLOPT_RANGE
+## CURLOPT_CRLFILE
 
-Range requests. See CURLOPT_RANGE(3)
-
-## CURLOPT_RESUME_FROM
-
-Resume a transfer. See CURLOPT_RESUME_FROM(3)
-
-## CURLOPT_RESUME_FROM_LARGE
-
-Resume a transfer. See CURLOPT_RESUME_FROM_LARGE(3)
+Certificate Revocation List. See CURLOPT_CRLFILE(3)
 
 ## CURLOPT_CURLU
 
@@ -872,132 +219,29 @@ Set URL to work on with a URL handle. See CURLOPT_CURLU(3)
 
 Custom request/method. See CURLOPT_CUSTOMREQUEST(3)
 
-## CURLOPT_FILETIME
+## CURLOPT_DEBUGDATA
 
-Request file modification date and time. See CURLOPT_FILETIME(3)
+Data pointer to pass to the debug callback. See CURLOPT_DEBUGDATA(3)
+
+## CURLOPT_DEBUGFUNCTION
+
+Callback for debug information. See CURLOPT_DEBUGFUNCTION(3)
+
+## CURLOPT_DEFAULT_PROTOCOL
+
+Default protocol. See CURLOPT_DEFAULT_PROTOCOL(3)
 
 ## CURLOPT_DIRLISTONLY
 
 List only. See CURLOPT_DIRLISTONLY(3)
 
-## CURLOPT_NOBODY
+## CURLOPT_DISALLOW_USERNAME_IN_URL
 
-Do not get the body contents. See CURLOPT_NOBODY(3)
+Do not allow username in URL. See CURLOPT_DISALLOW_USERNAME_IN_URL(3)
 
-## CURLOPT_INFILESIZE
+## CURLOPT_DNS_CACHE_TIMEOUT
 
-Size of file to send. CURLOPT_INFILESIZE(3)
-
-## CURLOPT_INFILESIZE_LARGE
-
-Size of file to send. CURLOPT_INFILESIZE_LARGE(3)
-
-## CURLOPT_UPLOAD
-
-Upload data. See CURLOPT_UPLOAD(3)
-
-## CURLOPT_UPLOAD_BUFFERSIZE
-
-Set upload buffer size. See CURLOPT_UPLOAD_BUFFERSIZE(3)
-
-## CURLOPT_MIMEPOST
-
-Post/send MIME data. See CURLOPT_MIMEPOST(3)
-
-## CURLOPT_MIME_OPTIONS
-
-Set MIME option flags. See CURLOPT_MIME_OPTIONS(3)
-
-## CURLOPT_MAXFILESIZE
-
-Maximum file size to get. See CURLOPT_MAXFILESIZE(3)
-
-## CURLOPT_MAXFILESIZE_LARGE
-
-Maximum file size to get. See CURLOPT_MAXFILESIZE_LARGE(3)
-
-## CURLOPT_TIMECONDITION
-
-Make a time conditional request. See CURLOPT_TIMECONDITION(3)
-
-## CURLOPT_TIMEVALUE
-
-Time value for the time conditional request. See CURLOPT_TIMEVALUE(3)
-
-## CURLOPT_TIMEVALUE_LARGE
-
-Time value for the time conditional request. See CURLOPT_TIMEVALUE_LARGE(3)
-
-# CONNECTION OPTIONS
-
-## CURLOPT_TIMEOUT
-
-Timeout for the entire request. See CURLOPT_TIMEOUT(3)
-
-## CURLOPT_TIMEOUT_MS
-
-Millisecond timeout for the entire request. See CURLOPT_TIMEOUT_MS(3)
-
-## CURLOPT_LOW_SPEED_LIMIT
-
-Low speed limit to abort transfer. See CURLOPT_LOW_SPEED_LIMIT(3)
-
-## CURLOPT_LOW_SPEED_TIME
-
-Time to be below the speed to trigger low speed abort. See CURLOPT_LOW_SPEED_TIME(3)
-
-## CURLOPT_MAX_SEND_SPEED_LARGE
-
-Cap the upload speed to this. See CURLOPT_MAX_SEND_SPEED_LARGE(3)
-
-## CURLOPT_MAX_RECV_SPEED_LARGE
-
-Cap the download speed to this. See CURLOPT_MAX_RECV_SPEED_LARGE(3)
-
-## CURLOPT_MAXCONNECTS
-
-Maximum number of connections in the connection pool. See CURLOPT_MAXCONNECTS(3)
-
-## CURLOPT_FRESH_CONNECT
-
-Use a new connection. CURLOPT_FRESH_CONNECT(3)
-
-## CURLOPT_FORBID_REUSE
-
-Prevent subsequent connections from reusing this. See CURLOPT_FORBID_REUSE(3)
-
-## CURLOPT_MAXAGE_CONN
-
-Limit the age (idle time) of connections for reuse. See CURLOPT_MAXAGE_CONN(3)
-
-## CURLOPT_MAXLIFETIME_CONN
-
-Limit the age (since creation) of connections for reuse. See
-CURLOPT_MAXLIFETIME_CONN(3)
-
-## CURLOPT_CONNECTTIMEOUT
-
-Timeout for the connection phase. See CURLOPT_CONNECTTIMEOUT(3)
-
-## CURLOPT_CONNECTTIMEOUT_MS
-
-Millisecond timeout for the connection phase. See CURLOPT_CONNECTTIMEOUT_MS(3)
-
-## CURLOPT_IPRESOLVE
-
-IP version to use. See CURLOPT_IPRESOLVE(3)
-
-## CURLOPT_CONNECT_ONLY
-
-Only connect, nothing else. See CURLOPT_CONNECT_ONLY(3)
-
-## CURLOPT_USE_SSL
-
-Use TLS/SSL. See CURLOPT_USE_SSL(3)
-
-## CURLOPT_RESOLVE
-
-Provide fixed/fake name resolves. See CURLOPT_RESOLVE(3)
+Timeout for DNS cache. See CURLOPT_DNS_CACHE_TIMEOUT(3)
 
 ## CURLOPT_DNS_INTERFACE
 
@@ -1019,77 +263,845 @@ Preferred DNS servers. See CURLOPT_DNS_SERVERS(3)
 
 Shuffle addresses before use. See CURLOPT_DNS_SHUFFLE_ADDRESSES(3)
 
-## CURLOPT_ACCEPTTIMEOUT_MS
+## CURLOPT_DNS_USE_GLOBAL_CACHE
 
-Timeout for waiting for the server's connect back to be accepted. See
-CURLOPT_ACCEPTTIMEOUT_MS(3)
+**OBSOLETE** Enable global DNS cache. See CURLOPT_DNS_USE_GLOBAL_CACHE(3)
+
+## CURLOPT_DOH_SSL_VERIFYHOST
+
+Verify the hostname in the DoH (DNS-over-HTTPS) SSL certificate. See
+CURLOPT_DOH_SSL_VERIFYHOST(3)
+
+## CURLOPT_DOH_SSL_VERIFYPEER
+
+Verify the DoH (DNS-over-HTTPS) SSL certificate. See
+CURLOPT_DOH_SSL_VERIFYPEER(3)
+
+## CURLOPT_DOH_SSL_VERIFYSTATUS
+
+Verify the DoH (DNS-over-HTTPS) SSL certificate's status. See
+CURLOPT_DOH_SSL_VERIFYSTATUS(3)
+
+## CURLOPT_DOH_URL
+
+Use this DoH server for name resolves. See CURLOPT_DOH_URL(3)
+
+## CURLOPT_ECH
+
+Set the configuration for ECH. See CURLOPT_ECH(3)
+
+## CURLOPT_EGDSOCKET
+
+**OBSOLETE** Identify EGD socket for entropy. See CURLOPT_EGDSOCKET(3)
+
+## CURLOPT_ERRORBUFFER
+
+Error message buffer. See CURLOPT_ERRORBUFFER(3)
+
+## CURLOPT_EXPECT_100_TIMEOUT_MS
+
+100-continue timeout. See CURLOPT_EXPECT_100_TIMEOUT_MS(3)
+
+## CURLOPT_FAILONERROR
+
+Fail on HTTP 4xx errors. CURLOPT_FAILONERROR(3)
+
+## CURLOPT_FILETIME
+
+Request file modification date and time. See CURLOPT_FILETIME(3)
+
+## CURLOPT_FNMATCH_DATA
+
+Data pointer to pass to the wildcard matching callback. See
+CURLOPT_FNMATCH_DATA(3)
+
+## CURLOPT_FNMATCH_FUNCTION
+
+Callback for wildcard matching. See CURLOPT_FNMATCH_FUNCTION(3)
+
+## CURLOPT_FOLLOWLOCATION
+
+Follow HTTP redirects. See CURLOPT_FOLLOWLOCATION(3)
+
+## CURLOPT_FORBID_REUSE
+
+Prevent subsequent connections from reusing this. See CURLOPT_FORBID_REUSE(3)
+
+## CURLOPT_FRESH_CONNECT
+
+Use a new connection. CURLOPT_FRESH_CONNECT(3)
+
+## CURLOPT_FTPPORT
+
+Use active FTP. See CURLOPT_FTPPORT(3)
+
+## CURLOPT_FTPSSLAUTH
+
+Control how to do TLS. See CURLOPT_FTPSSLAUTH(3)
+
+## CURLOPT_FTP_ACCOUNT
+
+Send ACCT command. See CURLOPT_FTP_ACCOUNT(3)
+
+## CURLOPT_FTP_ALTERNATIVE_TO_USER
+
+Alternative to USER. See CURLOPT_FTP_ALTERNATIVE_TO_USER(3)
+
+## CURLOPT_FTP_CREATE_MISSING_DIRS
+
+Create missing directories on the remote server. See
+CURLOPT_FTP_CREATE_MISSING_DIRS(3)
+
+## CURLOPT_FTP_FILEMETHOD
+
+Specify how to reach files. See CURLOPT_FTP_FILEMETHOD(3)
+
+## CURLOPT_FTP_SKIP_PASV_IP
+
+Ignore the IP address in the PASV response. See CURLOPT_FTP_SKIP_PASV_IP(3)
+
+## CURLOPT_FTP_SSL_CCC
+
+Back to non-TLS again after authentication. See CURLOPT_FTP_SSL_CCC(3)
+
+## CURLOPT_FTP_USE_EPRT
+
+Use EPRT. See CURLOPT_FTP_USE_EPRT(3)
+
+## CURLOPT_FTP_USE_EPSV
+
+Use EPSV. See CURLOPT_FTP_USE_EPSV(3)
+
+## CURLOPT_FTP_USE_PRET
+
+Use PRET. See CURLOPT_FTP_USE_PRET(3)
+
+## CURLOPT_GSSAPI_DELEGATION
+
+Disable GSS-API delegation. See CURLOPT_GSSAPI_DELEGATION(3)
 
 ## CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS
 
 Timeout for happy eyeballs. See CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS(3)
 
-## CURLOPT_UPKEEP_INTERVAL_MS
+## CURLOPT_HAPROXYPROTOCOL
 
-Sets the interval at which connection upkeep are performed. See
-CURLOPT_UPKEEP_INTERVAL_MS(3)
+Send an HAProxy PROXY protocol v1 header. See CURLOPT_HAPROXYPROTOCOL(3)
 
-# SSL and SECURITY OPTIONS
+## CURLOPT_HAPROXY_CLIENT_IP
 
-## CURLOPT_SSLCERT
+Spoof the client IP in an HAProxy PROXY protocol v1 header. See
+CURLOPT_HAPROXY_CLIENT_IP(3)
 
-Client cert. See CURLOPT_SSLCERT(3)
+## CURLOPT_HEADER
 
-## CURLOPT_SSLCERT_BLOB
+Include the header in the body output. See CURLOPT_HEADER(3)
 
-Client cert memory buffer. See CURLOPT_SSLCERT_BLOB(3)
+## CURLOPT_HEADERDATA
 
-## CURLOPT_PROXY_SSLCERT
+Data pointer to pass to the header callback. See CURLOPT_HEADERDATA(3)
 
-Proxy client cert. See CURLOPT_PROXY_SSLCERT(3)
+## CURLOPT_HEADERFUNCTION
 
-## CURLOPT_PROXY_SSLCERT_BLOB
+Callback for writing received headers. See CURLOPT_HEADERFUNCTION(3)
 
-Proxy client cert memory buffer. See CURLOPT_PROXY_SSLCERT_BLOB(3)
+## CURLOPT_HEADEROPT
 
-## CURLOPT_SSLCERTTYPE
+Control custom headers. See CURLOPT_HEADEROPT(3)
 
-Client cert type. See CURLOPT_SSLCERTTYPE(3)
+## CURLOPT_HSTS
 
-## CURLOPT_PROXY_SSLCERTTYPE
+Set HSTS cache file. See CURLOPT_HSTS(3)
 
-Proxy client cert type. See CURLOPT_PROXY_SSLCERTTYPE(3)
+## CURLOPT_HSTSREADDATA
 
-## CURLOPT_SSLKEY
+Pass pointer to the HSTS read callback. See CURLOPT_HSTSREADDATA(3)
 
-Client key. See CURLOPT_SSLKEY(3)
+## CURLOPT_HSTSREADFUNCTION
 
-## CURLOPT_SSLKEY_BLOB
+Set HSTS read callback. See CURLOPT_HSTSREADFUNCTION(3)
 
-Client key memory buffer. See CURLOPT_SSLKEY_BLOB(3)
+## CURLOPT_HSTSWRITEDATA
 
-## CURLOPT_PROXY_SSLKEY
+Pass pointer to the HSTS write callback. See CURLOPT_HSTSWRITEDATA(3)
 
-Proxy client key. See CURLOPT_PROXY_SSLKEY(3)
+## CURLOPT_HSTSWRITEFUNCTION
 
-## CURLOPT_PROXY_SSLKEY_BLOB
+Set HSTS write callback. See CURLOPT_HSTSWRITEFUNCTION(3)
 
-Proxy client key. See CURLOPT_PROXY_SSLKEY_BLOB(3)
+## CURLOPT_HSTS_CTRL
 
-## CURLOPT_SSLKEYTYPE
+Enable HSTS. See CURLOPT_HSTS_CTRL(3)
 
-Client key type. See CURLOPT_SSLKEYTYPE(3)
+## CURLOPT_HTTP09_ALLOWED
 
-## CURLOPT_PROXY_SSLKEYTYPE
+Allow HTTP/0.9 responses. CURLOPT_HTTP09_ALLOWED(3)
 
-Proxy client key type. See CURLOPT_PROXY_SSLKEYTYPE(3)
+## CURLOPT_HTTP200ALIASES
+
+Alternative versions of 200 OK. See CURLOPT_HTTP200ALIASES(3)
+
+## CURLOPT_HTTPAUTH
+
+HTTP server authentication methods. See CURLOPT_HTTPAUTH(3)
+
+## CURLOPT_HTTPGET
+
+Do an HTTP GET request. See CURLOPT_HTTPGET(3)
+
+## CURLOPT_HTTPHEADER
+
+Custom HTTP headers. See CURLOPT_HTTPHEADER(3)
+
+## CURLOPT_HTTPPOST
+
+**Deprecated option** Multipart formpost HTTP POST.
+See CURLOPT_HTTPPOST(3)
+
+## CURLOPT_HTTPPROXYTUNNEL
+
+Tunnel through the HTTP proxy. CURLOPT_HTTPPROXYTUNNEL(3)
+
+## CURLOPT_HTTP_CONTENT_DECODING
+
+Disable Content decoding. See CURLOPT_HTTP_CONTENT_DECODING(3)
+
+## CURLOPT_HTTP_TRANSFER_DECODING
+
+Disable Transfer decoding. See CURLOPT_HTTP_TRANSFER_DECODING(3)
+
+## CURLOPT_HTTP_VERSION
+
+HTTP version to use. CURLOPT_HTTP_VERSION(3)
+
+## CURLOPT_IGNORE_CONTENT_LENGTH
+
+Ignore Content-Length. See CURLOPT_IGNORE_CONTENT_LENGTH(3)
+
+## CURLOPT_INFILESIZE
+
+Size of file to send. CURLOPT_INFILESIZE(3)
+
+## CURLOPT_INFILESIZE_LARGE
+
+Size of file to send. CURLOPT_INFILESIZE_LARGE(3)
+
+## CURLOPT_INTERFACE
+
+Bind connection locally to this. See CURLOPT_INTERFACE(3)
+
+## CURLOPT_INTERLEAVEDATA
+
+Data pointer to pass to the RTSP interleave callback. See
+CURLOPT_INTERLEAVEDATA(3)
+
+## CURLOPT_INTERLEAVEFUNCTION
+
+Callback for RTSP interleaved data. See CURLOPT_INTERLEAVEFUNCTION(3)
+
+## CURLOPT_IOCTLDATA
+
+**Deprecated option** Data pointer to pass to the I/O callback.
+See CURLOPT_IOCTLDATA(3)
+
+## CURLOPT_IOCTLFUNCTION
+
+**Deprecated option** Callback for I/O operations.
+See CURLOPT_IOCTLFUNCTION(3)
+
+## CURLOPT_IPRESOLVE
+
+IP version to use. See CURLOPT_IPRESOLVE(3)
+
+## CURLOPT_ISSUERCERT
+
+Issuer certificate. See CURLOPT_ISSUERCERT(3)
+
+## CURLOPT_ISSUERCERT_BLOB
+
+Issuer certificate memory buffer. See CURLOPT_ISSUERCERT_BLOB(3)
+
+## CURLOPT_KEEP_SENDING_ON_ERROR
+
+Keep sending on HTTP \>= 300 errors. CURLOPT_KEEP_SENDING_ON_ERROR(3)
 
 ## CURLOPT_KEYPASSWD
 
 Client key password. See CURLOPT_KEYPASSWD(3)
 
+## CURLOPT_KRBLEVEL
+
+Kerberos security level. See CURLOPT_KRBLEVEL(3)
+
+## CURLOPT_LOCALPORT
+
+Bind connection locally to this port. See CURLOPT_LOCALPORT(3)
+
+## CURLOPT_LOCALPORTRANGE
+
+Bind connection locally to port range. See CURLOPT_LOCALPORTRANGE(3)
+
+## CURLOPT_LOGIN_OPTIONS
+
+Login options. See CURLOPT_LOGIN_OPTIONS(3)
+
+## CURLOPT_LOW_SPEED_LIMIT
+
+Low speed limit to abort transfer. See CURLOPT_LOW_SPEED_LIMIT(3)
+
+## CURLOPT_LOW_SPEED_TIME
+
+Time to be below the speed to trigger low speed abort. See
+CURLOPT_LOW_SPEED_TIME(3)
+
+## CURLOPT_MAIL_AUTH
+
+Authentication address. See CURLOPT_MAIL_AUTH(3)
+
+## CURLOPT_MAIL_FROM
+
+Address of the sender. See CURLOPT_MAIL_FROM(3)
+
+## CURLOPT_MAIL_RCPT
+
+Address of the recipients. See CURLOPT_MAIL_RCPT(3)
+
+## CURLOPT_MAIL_RCPT_ALLOWFAILS
+
+Allow RCPT TO command to fail for some recipients. See
+CURLOPT_MAIL_RCPT_ALLOWFAILS(3)
+
+## CURLOPT_MAXAGE_CONN
+
+Limit the age (idle time) of connections for reuse. See CURLOPT_MAXAGE_CONN(3)
+
+## CURLOPT_MAXCONNECTS
+
+Maximum number of connections in the connection pool. See
+CURLOPT_MAXCONNECTS(3)
+
+## CURLOPT_MAXFILESIZE
+
+Maximum file size to get. See CURLOPT_MAXFILESIZE(3)
+
+## CURLOPT_MAXFILESIZE_LARGE
+
+Maximum file size to get. See CURLOPT_MAXFILESIZE_LARGE(3)
+
+## CURLOPT_MAXLIFETIME_CONN
+
+Limit the age (since creation) of connections for reuse. See
+CURLOPT_MAXLIFETIME_CONN(3)
+
+## CURLOPT_MAXREDIRS
+
+Maximum number of redirects to follow. See CURLOPT_MAXREDIRS(3)
+
+## CURLOPT_MAX_RECV_SPEED_LARGE
+
+Cap the download speed to this. See CURLOPT_MAX_RECV_SPEED_LARGE(3)
+
+## CURLOPT_MAX_SEND_SPEED_LARGE
+
+Cap the upload speed to this. See CURLOPT_MAX_SEND_SPEED_LARGE(3)
+
+## CURLOPT_MIMEPOST
+
+Post/send MIME data. See CURLOPT_MIMEPOST(3)
+
+## CURLOPT_MIME_OPTIONS
+
+Set MIME option flags. See CURLOPT_MIME_OPTIONS(3)
+
+## CURLOPT_NETRC
+
+Enable .netrc parsing. See CURLOPT_NETRC(3)
+
+## CURLOPT_NETRC_FILE
+
+.netrc filename. See CURLOPT_NETRC_FILE(3)
+
+## CURLOPT_NEW_DIRECTORY_PERMS
+
+Mode for creating new remote directories. See CURLOPT_NEW_DIRECTORY_PERMS(3)
+
+## CURLOPT_NEW_FILE_PERMS
+
+Mode for creating new remote files. See CURLOPT_NEW_FILE_PERMS(3)
+
+## CURLOPT_NOBODY
+
+Do not get the body contents. See CURLOPT_NOBODY(3)
+
+## CURLOPT_NOPROGRESS
+
+Shut off the progress meter. See CURLOPT_NOPROGRESS(3)
+
+## CURLOPT_NOPROXY
+
+Filter out hosts from proxy use. CURLOPT_NOPROXY(3)
+
+## CURLOPT_NOSIGNAL
+
+Do not install signal handlers. See CURLOPT_NOSIGNAL(3)
+
+## CURLOPT_OPENSOCKETDATA
+
+Data pointer to pass to the open socket callback. See CURLOPT_OPENSOCKETDATA(3)
+
+## CURLOPT_OPENSOCKETFUNCTION
+
+Callback for socket creation. See CURLOPT_OPENSOCKETFUNCTION(3)
+
+## CURLOPT_PASSWORD
+
+Password. See CURLOPT_PASSWORD(3)
+
+## CURLOPT_PATH_AS_IS
+
+Disable squashing /../ and /./ sequences in the path. See CURLOPT_PATH_AS_IS(3)
+
+## CURLOPT_PINNEDPUBLICKEY
+
+Set pinned SSL public key . See CURLOPT_PINNEDPUBLICKEY(3)
+
+## CURLOPT_PIPEWAIT
+
+Wait on connection to pipeline on it. See CURLOPT_PIPEWAIT(3)
+
+## CURLOPT_PORT
+
+Port number to connect to. See CURLOPT_PORT(3)
+
+## CURLOPT_POST
+
+Make an HTTP POST. See CURLOPT_POST(3)
+
+## CURLOPT_POSTFIELDSIZE
+
+The POST data is this big. See CURLOPT_POSTFIELDSIZE(3)
+
+## CURLOPT_POSTFIELDSIZE_LARGE
+
+The POST data is this big. See CURLOPT_POSTFIELDSIZE_LARGE(3)
+
+## CURLOPT_POSTQUOTE
+
+Commands to run after transfer. See CURLOPT_POSTQUOTE(3)
+
+## CURLOPT_POSTREDIR
+
+How to act on redirects after POST. See CURLOPT_POSTREDIR(3)
+
+## CURLOPT_PREQUOTE
+
+Commands to run just before transfer. See CURLOPT_PREQUOTE(3)
+
+## CURLOPT_PREREQDATA
+
+Data pointer to pass to the CURLOPT_PREREQFUNCTION callback. See
+CURLOPT_PREREQDATA(3)
+
+## CURLOPT_PREREQFUNCTION
+
+Callback to be called after a connection is established but before a request
+is made on that connection. See CURLOPT_PREREQFUNCTION(3)
+
+## CURLOPT_PRE_PROXY
+
+Socks proxy to use. See CURLOPT_PRE_PROXY(3)
+
+## CURLOPT_PRIVATE
+
+Private pointer to store. See CURLOPT_PRIVATE(3)
+
+## CURLOPT_PROGRESSDATA
+
+Data pointer to pass to the progress meter callback. See
+CURLOPT_PROGRESSDATA(3)
+
+## CURLOPT_PROGRESSFUNCTION
+
+**OBSOLETE** callback for progress meter. See CURLOPT_PROGRESSFUNCTION(3)
+
+## CURLOPT_PROTOCOLS
+
+**Deprecated option** Allowed protocols. See CURLOPT_PROTOCOLS(3)
+
+## CURLOPT_PROTOCOLS_STR
+
+Allowed protocols. See CURLOPT_PROTOCOLS_STR(3)
+
+## CURLOPT_PROXY
+
+Proxy to use. See CURLOPT_PROXY(3)
+
+## CURLOPT_PROXYAUTH
+
+HTTP proxy authentication methods. See CURLOPT_PROXYAUTH(3)
+
+## CURLOPT_PROXYHEADER
+
+Custom HTTP headers sent to proxy. See CURLOPT_PROXYHEADER(3)
+
+## CURLOPT_PROXYPASSWORD
+
+Proxy password. See CURLOPT_PROXYPASSWORD(3)
+
+## CURLOPT_PROXYPORT
+
+Proxy port to use. See CURLOPT_PROXYPORT(3)
+
+## CURLOPT_PROXYTYPE
+
+Proxy type. See CURLOPT_PROXYTYPE(3)
+
+## CURLOPT_PROXYUSERNAME
+Proxy username. See CURLOPT_PROXYUSERNAME(3)
+
+## CURLOPT_PROXYUSERPWD
+
+Proxy username and password. See CURLOPT_PROXYUSERPWD(3)
+
+## CURLOPT_PROXY_CAINFO
+
+Proxy CA cert bundle. See CURLOPT_PROXY_CAINFO(3)
+
+## CURLOPT_PROXY_CAINFO_BLOB
+
+Proxy CA cert bundle memory buffer. See CURLOPT_PROXY_CAINFO_BLOB(3)
+
+## CURLOPT_PROXY_CAPATH
+
+Path to proxy CA cert bundle. See CURLOPT_PROXY_CAPATH(3)
+
+## CURLOPT_PROXY_CRLFILE
+
+Proxy Certificate Revocation List. See CURLOPT_PROXY_CRLFILE(3)
+
+## CURLOPT_PROXY_ISSUERCERT
+
+Proxy issuer certificate. See CURLOPT_PROXY_ISSUERCERT(3)
+
+## CURLOPT_PROXY_ISSUERCERT_BLOB
+
+Proxy issuer certificate memory buffer. See CURLOPT_PROXY_ISSUERCERT_BLOB(3)
+
 ## CURLOPT_PROXY_KEYPASSWD
 
 Proxy client key password. See CURLOPT_PROXY_KEYPASSWD(3)
+
+## CURLOPT_PROXY_PINNEDPUBLICKEY
+
+Set the proxy's pinned SSL public key. See
+CURLOPT_PROXY_PINNEDPUBLICKEY(3)
+
+## CURLOPT_PROXY_SERVICE_NAME
+
+Proxy authentication service name. CURLOPT_PROXY_SERVICE_NAME(3)
+
+## CURLOPT_PROXY_SSLCERT
+
+Proxy client cert. See CURLOPT_PROXY_SSLCERT(3)
+
+## CURLOPT_PROXY_SSLCERTTYPE
+
+Proxy client cert type. See CURLOPT_PROXY_SSLCERTTYPE(3)
+
+## CURLOPT_PROXY_SSLCERT_BLOB
+
+Proxy client cert memory buffer. See CURLOPT_PROXY_SSLCERT_BLOB(3)
+
+## CURLOPT_PROXY_SSLKEY
+
+Proxy client key. See CURLOPT_PROXY_SSLKEY(3)
+
+## CURLOPT_PROXY_SSLKEYTYPE
+
+Proxy client key type. See CURLOPT_PROXY_SSLKEYTYPE(3)
+
+## CURLOPT_PROXY_SSLKEY_BLOB
+
+Proxy client key. See CURLOPT_PROXY_SSLKEY_BLOB(3)
+
+## CURLOPT_PROXY_SSLVERSION
+
+Proxy SSL version to use. See CURLOPT_PROXY_SSLVERSION(3)
+
+## CURLOPT_PROXY_SSL_CIPHER_LIST
+
+Proxy ciphers to use. See CURLOPT_PROXY_SSL_CIPHER_LIST(3)
+
+## CURLOPT_PROXY_SSL_OPTIONS
+
+Control proxy SSL behavior. See CURLOPT_PROXY_SSL_OPTIONS(3)
+
+## CURLOPT_PROXY_SSL_VERIFYHOST
+
+Verify the hostname in the proxy SSL certificate. See
+CURLOPT_PROXY_SSL_VERIFYHOST(3)
+
+## CURLOPT_PROXY_SSL_VERIFYPEER
+
+Verify the proxy SSL certificate. See CURLOPT_PROXY_SSL_VERIFYPEER(3)
+
+## CURLOPT_PROXY_TLS13_CIPHERS
+
+Proxy TLS 1.3 cipher suites to use. See CURLOPT_PROXY_TLS13_CIPHERS(3)
+
+## CURLOPT_PROXY_TLSAUTH_PASSWORD
+
+Proxy TLS authentication password. See CURLOPT_PROXY_TLSAUTH_PASSWORD(3)
+
+## CURLOPT_PROXY_TLSAUTH_TYPE
+
+Proxy TLS authentication methods. See CURLOPT_PROXY_TLSAUTH_TYPE(3)
+
+## CURLOPT_PROXY_TLSAUTH_USERNAME
+
+Proxy TLS authentication username. See CURLOPT_PROXY_TLSAUTH_USERNAME(3)
+
+## CURLOPT_PROXY_TRANSFER_MODE
+
+Add transfer mode to URL over proxy. See CURLOPT_PROXY_TRANSFER_MODE(3)
+
+## CURLOPT_PUT
+
+**Deprecated option** Issue an HTTP PUT request. See CURLOPT_PUT(3)
+
+## CURLOPT_QUICK_EXIT
+
+To be set by toplevel tools like "curl" to skip lengthy cleanups when they are
+about to call exit() anyway. See CURLOPT_QUICK_EXIT(3)
+
+## CURLOPT_QUOTE
+
+Commands to run before transfer. See CURLOPT_QUOTE(3)
+
+## CURLOPT_RANDOM_FILE
+
+**OBSOLETE** Provide source for entropy random data.
+See CURLOPT_RANDOM_FILE(3)
+
+## CURLOPT_RANGE
+
+Range requests. See CURLOPT_RANGE(3)
+
+## CURLOPT_READDATA
+
+Data pointer to pass to the read callback. See CURLOPT_READDATA(3)
+
+## CURLOPT_READFUNCTION
+
+Callback for reading data. See CURLOPT_READFUNCTION(3)
+
+## CURLOPT_REDIR_PROTOCOLS
+
+**Deprecated option** Protocols to allow redirects to. See
+CURLOPT_REDIR_PROTOCOLS(3)
+
+## CURLOPT_REDIR_PROTOCOLS_STR
+
+Protocols to allow redirects to. See CURLOPT_REDIR_PROTOCOLS_STR(3)
+
+## CURLOPT_REFERER
+
+Referer: header. See CURLOPT_REFERER(3)
+
+## CURLOPT_REQUEST_TARGET
+
+Set the request target. CURLOPT_REQUEST_TARGET(3)
+
+## CURLOPT_RESOLVE
+
+Provide fixed/fake name resolves. See CURLOPT_RESOLVE(3)
+
+## CURLOPT_RESOLVER_START_DATA
+
+Data pointer to pass to resolver start callback. See
+CURLOPT_RESOLVER_START_DATA(3)
+
+## CURLOPT_RESOLVER_START_FUNCTION
+
+Callback to be called before a new resolve request is started. See
+CURLOPT_RESOLVER_START_FUNCTION(3)
+
+## CURLOPT_RESUME_FROM
+
+Resume a transfer. See CURLOPT_RESUME_FROM(3)
+
+## CURLOPT_RESUME_FROM_LARGE
+
+Resume a transfer. See CURLOPT_RESUME_FROM_LARGE(3)
+
+## CURLOPT_RTSP_CLIENT_CSEQ
+
+Client CSEQ number. See CURLOPT_RTSP_CLIENT_CSEQ(3)
+
+## CURLOPT_RTSP_REQUEST
+
+RTSP request. See CURLOPT_RTSP_REQUEST(3)
+
+## CURLOPT_RTSP_SERVER_CSEQ
+
+CSEQ number for RTSP Server-\>Client request. See CURLOPT_RTSP_SERVER_CSEQ(3)
+
+## CURLOPT_RTSP_SESSION_ID
+
+RTSP session-id. See CURLOPT_RTSP_SESSION_ID(3)
+
+## CURLOPT_RTSP_STREAM_URI
+
+RTSP stream URI. See CURLOPT_RTSP_STREAM_URI(3)
+
+## CURLOPT_RTSP_TRANSPORT
+
+RTSP Transport: header. See CURLOPT_RTSP_TRANSPORT(3)
+
+## CURLOPT_SASL_AUTHZID
+
+SASL authorization identity (identity to act as). See CURLOPT_SASL_AUTHZID(3)
+
+## CURLOPT_SASL_IR
+
+Enable SASL initial response. See CURLOPT_SASL_IR(3)
+
+## CURLOPT_SEEKDATA
+
+Data pointer to pass to the seek callback. See CURLOPT_SEEKDATA(3)
+
+## CURLOPT_SEEKFUNCTION
+
+Callback for seek operations. See CURLOPT_SEEKFUNCTION(3)
+
+## CURLOPT_SERVER_RESPONSE_TIMEOUT
+
+Timeout for server responses. See CURLOPT_SERVER_RESPONSE_TIMEOUT(3)
+
+## CURLOPT_SERVER_RESPONSE_TIMEOUT_MS
+
+Timeout for server responses. See CURLOPT_SERVER_RESPONSE_TIMEOUT_MS(3)
+
+## CURLOPT_SERVICE_NAME
+
+Authentication service name. CURLOPT_SERVICE_NAME(3)
+
+## CURLOPT_SHARE
+
+Share object to use. See CURLOPT_SHARE(3)
+
+## CURLOPT_SOCKOPTDATA
+
+Data pointer to pass to the sockopt callback. See CURLOPT_SOCKOPTDATA(3)
+
+## CURLOPT_SOCKOPTFUNCTION
+
+Callback for sockopt operations. See CURLOPT_SOCKOPTFUNCTION(3)
+
+## CURLOPT_SOCKS5_AUTH
+
+Socks5 authentication methods. See CURLOPT_SOCKS5_AUTH(3)
+
+## CURLOPT_SOCKS5_GSSAPI_NEC
+
+Socks5 GSSAPI NEC mode. See CURLOPT_SOCKS5_GSSAPI_NEC(3)
+
+## CURLOPT_SOCKS5_GSSAPI_SERVICE
+
+**Deprecated option** Socks5 GSSAPI service name.
+See CURLOPT_SOCKS5_GSSAPI_SERVICE(3)
+
+## CURLOPT_SSH_AUTH_TYPES
+
+SSH authentication types. See CURLOPT_SSH_AUTH_TYPES(3)
+
+## CURLOPT_SSH_COMPRESSION
+
+Enable SSH compression. See CURLOPT_SSH_COMPRESSION(3)
+
+## CURLOPT_SSH_HOSTKEYDATA
+
+Custom pointer to pass to ssh host key callback. See CURLOPT_SSH_HOSTKEYDATA(3)
+
+## CURLOPT_SSH_HOSTKEYFUNCTION
+
+Callback for checking host key handling. See CURLOPT_SSH_HOSTKEYFUNCTION(3)
+
+## CURLOPT_SSH_HOST_PUBLIC_KEY_MD5
+
+MD5 of host's public key. See CURLOPT_SSH_HOST_PUBLIC_KEY_MD5(3)
+
+## CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256
+
+SHA256 of host's public key. See CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256(3)
+
+## CURLOPT_SSH_KEYDATA
+
+Custom pointer to pass to ssh key callback. See CURLOPT_SSH_KEYDATA(3)
+
+## CURLOPT_SSH_KEYFUNCTION
+
+Callback for known hosts handling. See CURLOPT_SSH_KEYFUNCTION(3)
+
+## CURLOPT_SSH_KNOWNHOSTS
+
+Filename with known hosts. See CURLOPT_SSH_KNOWNHOSTS(3)
+
+## CURLOPT_SSH_PRIVATE_KEYFILE
+
+Filename of the private key. See CURLOPT_SSH_PRIVATE_KEYFILE(3)
+
+## CURLOPT_SSH_PUBLIC_KEYFILE
+
+Filename of the public key. See CURLOPT_SSH_PUBLIC_KEYFILE(3)
+
+## CURLOPT_SSLCERT
+
+Client cert. See CURLOPT_SSLCERT(3)
+
+## CURLOPT_SSLCERTTYPE
+
+Client cert type. See CURLOPT_SSLCERTTYPE(3)
+
+## CURLOPT_SSLCERT_BLOB
+
+Client cert memory buffer. See CURLOPT_SSLCERT_BLOB(3)
+
+## CURLOPT_SSLENGINE
+
+Use identifier with SSL engine. See CURLOPT_SSLENGINE(3)
+
+## CURLOPT_SSLENGINE_DEFAULT
+
+Default SSL engine. See CURLOPT_SSLENGINE_DEFAULT(3)
+
+## CURLOPT_SSLKEY
+
+Client key. See CURLOPT_SSLKEY(3)
+
+## CURLOPT_SSLKEYTYPE
+
+Client key type. See CURLOPT_SSLKEYTYPE(3)
+
+## CURLOPT_SSLKEY_BLOB
+
+Client key memory buffer. See CURLOPT_SSLKEY_BLOB(3)
+
+## CURLOPT_SSLVERSION
+
+SSL version to use. See CURLOPT_SSLVERSION(3)
+
+## CURLOPT_SSL_CIPHER_LIST
+
+Ciphers to use. See CURLOPT_SSL_CIPHER_LIST(3)
+
+## CURLOPT_SSL_CTX_DATA
+
+Data pointer to pass to the SSL context callback. See CURLOPT_SSL_CTX_DATA(3)
+
+## CURLOPT_SSL_CTX_FUNCTION
+
+Callback for SSL context logic. See CURLOPT_SSL_CTX_FUNCTION(3)
 
 ## CURLOPT_SSL_EC_CURVES
 
@@ -1103,252 +1115,216 @@ Enable use of ALPN. See CURLOPT_SSL_ENABLE_ALPN(3)
 
 **OBSOLETE** Enable use of NPN. See CURLOPT_SSL_ENABLE_NPN(3)
 
-## CURLOPT_SSLENGINE
-
-Use identifier with SSL engine. See CURLOPT_SSLENGINE(3)
-
-## CURLOPT_SSLENGINE_DEFAULT
-
-Default SSL engine. See CURLOPT_SSLENGINE_DEFAULT(3)
-
 ## CURLOPT_SSL_FALSESTART
 
 Enable TLS False Start. See CURLOPT_SSL_FALSESTART(3)
-
-## CURLOPT_SSLVERSION
-
-SSL version to use. See CURLOPT_SSLVERSION(3)
-
-## CURLOPT_PROXY_SSLVERSION
-
-Proxy SSL version to use. See CURLOPT_PROXY_SSLVERSION(3)
-
-## CURLOPT_SSL_VERIFYHOST
-
-Verify the hostname in the SSL certificate. See CURLOPT_SSL_VERIFYHOST(3)
-
-## CURLOPT_DOH_SSL_VERIFYHOST
-
-Verify the hostname in the DoH (DNS-over-HTTPS) SSL certificate. See
-CURLOPT_DOH_SSL_VERIFYHOST(3)
-
-## CURLOPT_PROXY_SSL_VERIFYHOST
-
-Verify the hostname in the proxy SSL certificate. See
-CURLOPT_PROXY_SSL_VERIFYHOST(3)
-
-## CURLOPT_SSL_VERIFYPEER
-
-Verify the SSL certificate. See CURLOPT_SSL_VERIFYPEER(3)
-
-## CURLOPT_DOH_SSL_VERIFYPEER
-
-Verify the DoH (DNS-over-HTTPS) SSL certificate. See
-CURLOPT_DOH_SSL_VERIFYPEER(3)
-
-## CURLOPT_PROXY_SSL_VERIFYPEER
-
-Verify the proxy SSL certificate. See CURLOPT_PROXY_SSL_VERIFYPEER(3)
-
-## CURLOPT_SSL_VERIFYSTATUS
-
-Verify the SSL certificate's status. See CURLOPT_SSL_VERIFYSTATUS(3)
-
-## CURLOPT_DOH_SSL_VERIFYSTATUS
-
-Verify the DoH (DNS-over-HTTPS) SSL certificate's status. See
-CURLOPT_DOH_SSL_VERIFYSTATUS(3)
-
-## CURLOPT_CAINFO
-
-CA cert bundle. See CURLOPT_CAINFO(3)
-
-## CURLOPT_CAINFO_BLOB
-
-CA cert bundle memory buffer. See CURLOPT_CAINFO_BLOB(3)
-
-## CURLOPT_PROXY_CAINFO
-
-Proxy CA cert bundle. See CURLOPT_PROXY_CAINFO(3)
-
-## CURLOPT_PROXY_CAINFO_BLOB
-
-Proxy CA cert bundle memory buffer. See CURLOPT_PROXY_CAINFO_BLOB(3)
-
-## CURLOPT_ISSUERCERT
-
-Issuer certificate. See CURLOPT_ISSUERCERT(3)
-
-## CURLOPT_ISSUERCERT_BLOB
-
-Issuer certificate memory buffer. See CURLOPT_ISSUERCERT_BLOB(3)
-
-## CURLOPT_PROXY_ISSUERCERT
-
-Proxy issuer certificate. See CURLOPT_PROXY_ISSUERCERT(3)
-
-## CURLOPT_PROXY_ISSUERCERT_BLOB
-
-Proxy issuer certificate memory buffer. See CURLOPT_PROXY_ISSUERCERT_BLOB(3)
-
-## CURLOPT_CAPATH
-
-Path to CA cert bundle. See CURLOPT_CAPATH(3)
-
-## CURLOPT_PROXY_CAPATH
-
-Path to proxy CA cert bundle. See CURLOPT_PROXY_CAPATH(3)
-
-## CURLOPT_CRLFILE
-
-Certificate Revocation List. See CURLOPT_CRLFILE(3)
-
-## CURLOPT_PROXY_CRLFILE
-
-Proxy Certificate Revocation List. See CURLOPT_PROXY_CRLFILE(3)
-
-## CURLOPT_CA_CACHE_TIMEOUT
-
-Timeout for CA cache. See CURLOPT_CA_CACHE_TIMEOUT(3)
-
-## CURLOPT_CERTINFO
-
-Extract certificate info. See CURLOPT_CERTINFO(3)
-
-## CURLOPT_PINNEDPUBLICKEY
-
-Set pinned SSL public key . See CURLOPT_PINNEDPUBLICKEY(3)
-
-## CURLOPT_PROXY_PINNEDPUBLICKEY
-
-Set the proxy's pinned SSL public key. See
-CURLOPT_PROXY_PINNEDPUBLICKEY(3)
-
-## CURLOPT_RANDOM_FILE
-
-**OBSOLETE** Provide source for entropy random data.
-See CURLOPT_RANDOM_FILE(3)
-
-## CURLOPT_EGDSOCKET
-
-**OBSOLETE** Identify EGD socket for entropy. See CURLOPT_EGDSOCKET(3)
-
-## CURLOPT_SSL_CIPHER_LIST
-
-Ciphers to use. See CURLOPT_SSL_CIPHER_LIST(3)
-
-## CURLOPT_PROXY_SSL_CIPHER_LIST
-
-Proxy ciphers to use. See CURLOPT_PROXY_SSL_CIPHER_LIST(3)
-
-## CURLOPT_TLS13_CIPHERS
-
-TLS 1.3 cipher suites to use. See CURLOPT_TLS13_CIPHERS(3)
-
-## CURLOPT_PROXY_TLS13_CIPHERS
-
-Proxy TLS 1.3 cipher suites to use. See CURLOPT_PROXY_TLS13_CIPHERS(3)
-
-## CURLOPT_SSL_SESSIONID_CACHE
-
-Disable SSL session-id cache. See CURLOPT_SSL_SESSIONID_CACHE(3)
 
 ## CURLOPT_SSL_OPTIONS
 
 Control SSL behavior. See CURLOPT_SSL_OPTIONS(3)
 
-## CURLOPT_PROXY_SSL_OPTIONS
+## CURLOPT_SSL_SESSIONID_CACHE
 
-Control proxy SSL behavior. See CURLOPT_PROXY_SSL_OPTIONS(3)
+Disable SSL session-id cache. See CURLOPT_SSL_SESSIONID_CACHE(3)
 
-## CURLOPT_KRBLEVEL
+## CURLOPT_SSL_VERIFYHOST
 
-Kerberos security level. See CURLOPT_KRBLEVEL(3)
+Verify the hostname in the SSL certificate. See CURLOPT_SSL_VERIFYHOST(3)
 
-## CURLOPT_GSSAPI_DELEGATION
+## CURLOPT_SSL_VERIFYPEER
 
-Disable GSS-API delegation. See CURLOPT_GSSAPI_DELEGATION(3)
+Verify the SSL certificate. See CURLOPT_SSL_VERIFYPEER(3)
 
-# SSH OPTIONS
+## CURLOPT_SSL_VERIFYSTATUS
 
-## CURLOPT_SSH_AUTH_TYPES
+Verify the SSL certificate's status. See CURLOPT_SSL_VERIFYSTATUS(3)
 
-SSH authentication types. See CURLOPT_SSH_AUTH_TYPES(3)
+## CURLOPT_STDERR
 
-## CURLOPT_SSH_COMPRESSION
+Redirect stderr to another stream. See CURLOPT_STDERR(3)
 
-Enable SSH compression. See CURLOPT_SSH_COMPRESSION(3)
+## CURLOPT_STREAM_DEPENDS
 
-## CURLOPT_SSH_HOST_PUBLIC_KEY_MD5
+This HTTP/2 stream depends on another. See CURLOPT_STREAM_DEPENDS(3)
 
-MD5 of host's public key. See CURLOPT_SSH_HOST_PUBLIC_KEY_MD5(3)
+## CURLOPT_STREAM_DEPENDS_E
 
-## CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256
+This HTTP/2 stream depends on another exclusively. See
+CURLOPT_STREAM_DEPENDS_E(3)
 
-SHA256 of host's public key. See CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256(3)
+## CURLOPT_STREAM_WEIGHT
 
-## CURLOPT_SSH_PUBLIC_KEYFILE
+Set this HTTP/2 stream's weight. See CURLOPT_STREAM_WEIGHT(3)
 
-Filename of the public key. See CURLOPT_SSH_PUBLIC_KEYFILE(3)
+## CURLOPT_SUPPRESS_CONNECT_HEADERS
 
-## CURLOPT_SSH_PRIVATE_KEYFILE
+Suppress proxy CONNECT response headers from user callbacks. See
+CURLOPT_SUPPRESS_CONNECT_HEADERS(3)
 
-Filename of the private key. See CURLOPT_SSH_PRIVATE_KEYFILE(3)
+## CURLOPT_TCP_FASTOPEN
 
-## CURLOPT_SSH_KNOWNHOSTS
+Enable TCP Fast Open. See CURLOPT_TCP_FASTOPEN(3)
 
-Filename with known hosts. See CURLOPT_SSH_KNOWNHOSTS(3)
+## CURLOPT_TCP_KEEPALIVE
 
-## CURLOPT_SSH_KEYFUNCTION
+Enable TCP keep-alive. See CURLOPT_TCP_KEEPALIVE(3)
 
-Callback for known hosts handling. See CURLOPT_SSH_KEYFUNCTION(3)
+## CURLOPT_TCP_KEEPCNT
 
-## CURLOPT_SSH_KEYDATA
+Maximum number of keep-alive probes. See CURLOPT_TCP_KEEPCNT(3)
 
-Custom pointer to pass to ssh key callback. See CURLOPT_SSH_KEYDATA(3)
+## CURLOPT_TCP_KEEPIDLE
 
-## CURLOPT_SSH_HOSTKEYFUNCTION
+Idle time before sending keep-alive. See CURLOPT_TCP_KEEPIDLE(3)
 
-Callback for checking host key handling. See CURLOPT_SSH_HOSTKEYFUNCTION(3)
+## CURLOPT_TCP_KEEPINTVL
 
-## CURLOPT_SSH_HOSTKEYDATA
+Interval between keep-alive probes. See CURLOPT_TCP_KEEPINTVL(3)
 
-Custom pointer to pass to ssh host key callback. See CURLOPT_SSH_HOSTKEYDATA(3)
+## CURLOPT_TCP_NODELAY
 
-# WEBSOCKET
-
-## CURLOPT_WS_OPTIONS
-
-Set WebSocket options. See CURLOPT_WS_OPTIONS(3)
-
-# OTHER OPTIONS
-
-## CURLOPT_PRIVATE
-
-Private pointer to store. See CURLOPT_PRIVATE(3)
-
-## CURLOPT_SHARE
-
-Share object to use. See CURLOPT_SHARE(3)
-
-## CURLOPT_NEW_FILE_PERMS
-
-Mode for creating new remote files. See CURLOPT_NEW_FILE_PERMS(3)
-
-## CURLOPT_NEW_DIRECTORY_PERMS
-
-Mode for creating new remote directories. See CURLOPT_NEW_DIRECTORY_PERMS(3)
-
-## CURLOPT_QUICK_EXIT
-
-To be set by toplevel tools like "curl" to skip lengthy cleanups when they are
-about to call exit() anyway. See CURLOPT_QUICK_EXIT(3)
-
-# TELNET OPTIONS
+Disable the Nagle algorithm. See CURLOPT_TCP_NODELAY(3)
 
 ## CURLOPT_TELNETOPTIONS
 
 TELNET options. See CURLOPT_TELNETOPTIONS(3)
+
+## CURLOPT_TFTP_BLKSIZE
+
+TFTP block size. See CURLOPT_TFTP_BLKSIZE(3)
+
+## CURLOPT_TFTP_NO_OPTIONS
+
+Do not send TFTP options requests. See CURLOPT_TFTP_NO_OPTIONS(3)
+
+## CURLOPT_TIMECONDITION
+
+Make a time conditional request. See CURLOPT_TIMECONDITION(3)
+
+## CURLOPT_TIMEOUT
+
+Timeout for the entire request. See CURLOPT_TIMEOUT(3)
+
+## CURLOPT_TIMEOUT_MS
+
+Millisecond timeout for the entire request. See CURLOPT_TIMEOUT_MS(3)
+
+## CURLOPT_TIMEVALUE
+
+Time value for the time conditional request. See CURLOPT_TIMEVALUE(3)
+
+## CURLOPT_TIMEVALUE_LARGE
+
+Time value for the time conditional request. See CURLOPT_TIMEVALUE_LARGE(3)
+
+## CURLOPT_TLS13_CIPHERS
+
+TLS 1.3 cipher suites to use. See CURLOPT_TLS13_CIPHERS(3)
+
+## CURLOPT_TLSAUTH_PASSWORD
+
+TLS authentication password. See CURLOPT_TLSAUTH_PASSWORD(3)
+
+## CURLOPT_TLSAUTH_TYPE
+
+TLS authentication methods. See CURLOPT_TLSAUTH_TYPE(3)
+
+## CURLOPT_TLSAUTH_USERNAME
+
+TLS authentication username. See CURLOPT_TLSAUTH_USERNAME(3)
+
+## CURLOPT_TRAILERDATA
+
+Custom pointer passed to the trailing headers callback. See
+CURLOPT_TRAILERDATA(3)
+
+## CURLOPT_TRAILERFUNCTION
+
+Set callback for sending trailing headers. See
+CURLOPT_TRAILERFUNCTION(3)
+
+## CURLOPT_TRANSFERTEXT
+
+Use text transfer. See CURLOPT_TRANSFERTEXT(3)
+
+## CURLOPT_TRANSFER_ENCODING
+
+Request Transfer-Encoding. See CURLOPT_TRANSFER_ENCODING(3)
+
+## CURLOPT_UNIX_SOCKET_PATH
+
+Path to a Unix domain socket. See CURLOPT_UNIX_SOCKET_PATH(3)
+
+## CURLOPT_UNRESTRICTED_AUTH
+
+Do not restrict authentication to original host. CURLOPT_UNRESTRICTED_AUTH(3)
+
+## CURLOPT_UPKEEP_INTERVAL_MS
+
+Sets the interval at which connection upkeep are performed. See
+CURLOPT_UPKEEP_INTERVAL_MS(3)
+
+## CURLOPT_UPLOAD
+
+Upload data. See CURLOPT_UPLOAD(3)
+
+## CURLOPT_UPLOAD_BUFFERSIZE
+
+Set upload buffer size. See CURLOPT_UPLOAD_BUFFERSIZE(3)
+
+## CURLOPT_URL
+
+URL to work on. See CURLOPT_URL(3)
+
+## CURLOPT_USERAGENT
+
+User-Agent: header. See CURLOPT_USERAGENT(3)
+
+## CURLOPT_USERNAME
+
+Username. See CURLOPT_USERNAME(3)
+
+## CURLOPT_USERPWD
+
+Username and password. See CURLOPT_USERPWD(3)
+
+## CURLOPT_USE_SSL
+
+Use TLS/SSL. See CURLOPT_USE_SSL(3)
+
+## CURLOPT_VERBOSE
+
+Display verbose information. See CURLOPT_VERBOSE(3)
+
+## CURLOPT_WILDCARDMATCH
+
+Transfer multiple files according to a filename pattern. See
+CURLOPT_WILDCARDMATCH(3)
+
+## CURLOPT_WRITEDATA
+
+Data pointer to pass to the write callback. See CURLOPT_WRITEDATA(3)
+
+## CURLOPT_WRITEFUNCTION
+
+Callback for writing data. See CURLOPT_WRITEFUNCTION(3)
+
+## CURLOPT_WS_OPTIONS
+
+Set WenSocket options. See CURLOPT_WS_OPTIONS(3)
+
+## CURLOPT_XFERINFODATA
+
+Data pointer to pass to the progress meter callback. See
+CURLOPT_XFERINFODATA(3)
+
+## CURLOPT_XFERINFOFUNCTION
+
+Callback for progress meter. See CURLOPT_XFERINFOFUNCTION(3)
+
+## CURLOPT_XOAUTH2_BEARER
+
+OAuth2 bearer token. See CURLOPT_XOAUTH2_BEARER(3)
 
 # EXAMPLE
 
@@ -1366,10 +1342,6 @@ int main(void)
 ~~~
 
 # ENCRYPTED CLIENT HELLO OPTIONS
-
-## CURLOPT_ECH
-
-Set the configuration for ECH. See CURLOPT_ECH(3)
 
 # AVAILABILITY
 

--- a/docs/libcurl/curl_easy_setopt.md
+++ b/docs/libcurl/curl_easy_setopt.md
@@ -1311,7 +1311,7 @@ Callback for writing data. See CURLOPT_WRITEFUNCTION(3)
 
 ## CURLOPT_WS_OPTIONS
 
-Set WenSocket options. See CURLOPT_WS_OPTIONS(3)
+Set WebSocket options. See CURLOPT_WS_OPTIONS(3)
 
 ## CURLOPT_XFERINFODATA
 

--- a/docs/libcurl/curl_multi_setopt.md
+++ b/docs/libcurl/curl_multi_setopt.md
@@ -22,85 +22,86 @@ curl_multi_setopt - set options for a curl multi handle
 ~~~c
 #include <curl/curl.h>
 
-CURLMcode curl_multi_setopt(CURLM *multi_handle, CURLMoption option, parameter);
+CURLMcode curl_multi_setopt(CURLM *multi, CURLMoption option, parameter);
 ~~~
 
 # DESCRIPTION
 
-curl_multi_setopt(3) is used to tell a libcurl multi handle how to
-behave. By using the appropriate options to curl_multi_setopt(3), you
-can change libcurl's behavior when using that multi handle. All options are
-set with the *option* followed by the *parameter*. That parameter can
-be a **long**, a **function pointer**, an **object pointer** or a
-**curl_off_t** type, depending on what the specific option expects. Read
-this manual carefully as bad input values may cause libcurl to behave
-badly. You can only set one option in each function call.
+curl_multi_setopt(3) is used to tell a libcurl multi handle how to behave. By
+using the appropriate options to curl_multi_setopt(3), you can change
+libcurl's behavior when using that multi handle. All options are set with the
+*option* followed by the *parameter*. That parameter can be a **long**, a
+**function pointer**, an **object pointer** or a **curl_off_t** type,
+depending on what the specific option expects. Read this manual carefully as
+bad input values may cause libcurl to behave badly. You can only set one
+option in each function call.
 
 # OPTIONS
 
 ## CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE
 
-See CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE(3)
+**deprecated** See CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE(3)
 
 ## CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE
 
-See CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE(3)
-
-## CURLMOPT_MAX_HOST_CONNECTIONS
-
-See CURLMOPT_MAX_HOST_CONNECTIONS(3)
-
-## CURLMOPT_MAX_PIPELINE_LENGTH
-
-See CURLMOPT_MAX_PIPELINE_LENGTH(3)
-
-## CURLMOPT_MAX_TOTAL_CONNECTIONS
-
-See CURLMOPT_MAX_TOTAL_CONNECTIONS(3)
+**deprecated** See CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE(3)
 
 ## CURLMOPT_MAXCONNECTS
 
-See CURLMOPT_MAXCONNECTS(3)
-
-## CURLMOPT_PIPELINING
-
-See CURLMOPT_PIPELINING(3)
-
-## CURLMOPT_PIPELINING_SITE_BL
-
-See CURLMOPT_PIPELINING_SITE_BL(3)
-
-## CURLMOPT_PIPELINING_SERVER_BL
-
-See CURLMOPT_PIPELINING_SERVER_BL(3)
-
-## CURLMOPT_PUSHFUNCTION
-
-See CURLMOPT_PUSHFUNCTION(3)
-
-## CURLMOPT_PUSHDATA
-
-See CURLMOPT_PUSHDATA(3)
-
-## CURLMOPT_SOCKETFUNCTION
-
-See CURLMOPT_SOCKETFUNCTION(3)
-
-## CURLMOPT_SOCKETDATA
-
-See CURLMOPT_SOCKETDATA(3)
-
-## CURLMOPT_TIMERFUNCTION
-
-See CURLMOPT_TIMERFUNCTION(3)
-
-## CURLMOPT_TIMERDATA
-
-See CURLMOPT_TIMERDATA(3)
+Size of connection cache. See CURLMOPT_MAXCONNECTS(3)
 
 ## CURLMOPT_MAX_CONCURRENT_STREAMS
 
-See CURLMOPT_MAX_CONCURRENT_STREAMS(3)
+Max concurrent streams for http2. See CURLMOPT_MAX_CONCURRENT_STREAMS(3)
+
+## CURLMOPT_MAX_HOST_CONNECTIONS
+
+Max number of connections to a single host. See
+CURLMOPT_MAX_HOST_CONNECTIONS(3)
+
+## CURLMOPT_MAX_PIPELINE_LENGTH
+
+**deprecated**. See CURLMOPT_MAX_PIPELINE_LENGTH(3)
+
+## CURLMOPT_MAX_TOTAL_CONNECTIONS
+
+Max simultaneously open connections. See CURLMOPT_MAX_TOTAL_CONNECTIONS(3)
+
+## CURLMOPT_PIPELINING
+
+Enable HTTP multiplexing. See CURLMOPT_PIPELINING(3)
+
+## CURLMOPT_PIPELINING_SERVER_BL
+
+**deprecated**. See CURLMOPT_PIPELINING_SERVER_BL(3)
+
+## CURLMOPT_PIPELINING_SITE_BL
+
+**deprecated**. See CURLMOPT_PIPELINING_SITE_BL(3)
+
+## CURLMOPT_PUSHDATA
+
+Pointer to pass to push callback. See CURLMOPT_PUSHDATA(3)
+
+## CURLMOPT_PUSHFUNCTION
+
+Callback that approves or denies server pushes. See CURLMOPT_PUSHFUNCTION(3)
+
+## CURLMOPT_SOCKETDATA
+
+Custom pointer passed to the socket callback. See CURLMOPT_SOCKETDATA(3)
+
+## CURLMOPT_SOCKETFUNCTION
+
+Callback informed about what to wait for. See CURLMOPT_SOCKETFUNCTION(3)
+
+## CURLMOPT_TIMERDATA
+
+Custom pointer to pass to timer callback. See CURLMOPT_TIMERDATA(3)
+
+## CURLMOPT_TIMERFUNCTION
+
+Callback to receive timeout values. See CURLMOPT_TIMERFUNCTION(3)
 
 # EXAMPLE
 

--- a/tests/test1139.pl
+++ b/tests/test1139.pl
@@ -80,6 +80,15 @@ sub scanmdpage {
     }
     close($mh);
 
+    my @ms = sort @m;
+    for my $i (0 .. $#m) {
+        if($ms[$i] ne $m[$i]) {
+            print STDERR "$file:1:ERROR: $m[$i] is not alphabetical (expected $ms[$i])\n";
+            $errors++;
+            # no point in reporting many
+            last;
+        }
+    }
     foreach my $m (@words) {
         my @g = grep(/$m/, @m);
         if(!$g[0]) {


### PR DESCRIPTION
The man pages for curl_easy_getinfo, curl_easy_setopt and curl_multi_setopt now feature the lists of options alphabetically sorted. Test 1139 verify that they are.

The curl_multi_setopt page also got brief explanations of the listed options.