### PR TITLE
build: fix llvm 17 and older + macOS SDK 14.4 and newer

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -40,6 +40,26 @@
 #include <_mingw.h>
 #endif
 
+#if defined(__APPLE__)
+#include <sys/types.h>
+#include <TargetConditionals.h>
+/* Fixup faulty target macro initialization in Apple SDK since v14.4 (as of
+   15.0 beta). The SDK target detection in `TargetConditionals.h` correctly
+   detects macOS, but fails to set the macro's old name `TARGET_OS_OSX`, then
+   continues to set it to a default value of 0. Other parts of the SDK still
+   rely on the old name, and with this inconsistency our builds fail due to
+   missing declarations. It happens when using mainline llvm older than v18.
+   Later versions fixed it by predefining these target macros, avoiding the
+   faulty dynamic detection. gcc is not affected (for now) because it lacks
+   the necessary dynamic detection features, so the SDK falls back to
+   a codepath that sets both the old and new macro to 1. */
+#if defined(TARGET_OS_MAC) && TARGET_OS_MAC && \
+  defined(TARGET_OS_OSX) && !TARGET_OS_OSX
+#undef TARGET_OS_OSX
+#define TARGET_OS_OSX TARGET_OS_MAC
+#endif
+#endif
+
 /*
  * Disable Visual Studio warnings:
  * 4127 "conditional expression is constant"
@@ -325,7 +345,6 @@
  * performing this task will result in a synthesized IPv6 address.
  */
 #if defined(__APPLE__) && !defined(USE_ARES)
-#include <TargetConditionals.h>
 #define USE_RESOLVE_ON_IPS 1
 #  if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE) && \
      defined(USE_IPV6)


### PR DESCRIPTION
Fixup faulty target macro initialization in macOS SDK since v14.4 (as of
15.0 beta). The SDK target detection in `TargetConditionals.h` correctly
detects macOS, but fails to set the macro's old name `TARGET_OS_OSX`,
then continues to set it to a default value of 0. Other parts of the SDK
still rely on the old name, and with this inconsistency our builds fail
due to missing declarations. It happens when using mainline llvm older
than v18. Later versions fixed it by predefining these target macros,
avoiding the faulty dynamic detection. gcc is not affected (for now)
because it lacks the necessary dynamic detection features, so the SDK
falls back to a codepath that sets both the old and new macro to 1.

Also move the `TargetConditionals.h` include to the top of to make sure
including it also for c-ares builds, combined with SecureTransport or
other curl features that may call use an Apple SDK.

Before this patch, affected build combinations (e.g. in GHA runners,
llvm@15 + Xcode 15.3, 15.4, 16.0 with their default SDKs +
SecureTransport) fail with:
```
  error: use of undeclared identifier 'noErr'
    or 'SecCertificateCopyLongDescription'
    or 'SecItemImportExportKeyParameters'
    or 'SecExternalFormat'
    or 'SecExternalItemType'
    or 'SEC_KEY_IMPORT_EXPORT_PARAMS_VERSION'
```

Example:
```
curl/lib/vtls/sectransp.c:311:18: error: use of undeclared identifier 'noErr'
  OSStatus rtn = noErr;
                 ^
curl/lib/vtls/sectransp.c:379:7: error: use of undeclared identifier 'SecCertificateCopyLongDescription'
  if(&SecCertificateCopyLongDescription)
      ^
curl/lib/vtls/sectransp.c:381:7: error: call to undeclared function 'SecCertificateCopyLongDescription'; ISO C99 and later do not support implicit function declarations [-Werror,-Wimplicit-function-declaration]
      SecCertificateCopyLongDescription(NULL, cert, NULL);
      ^
curl/lib/vtls/sectransp.c:380:25: error: incompatible integer to pointer conversion assigning to 'CFStringRef' (aka 'const struct __CFString *') from 'int' [-Wint-conversion]
    server_cert_summary =
                        ^
[...]
```
Ref: https://github.com/curl/curl/actions/runs/9893867519/job/27330135969#step:10:22

llvm v18 patches implementing the predefined macros:
https://github.com/llvm/llvm-project/pull/74676
https://github.com/llvm/llvm-project/commit/6e1f19168bca7e3bd4eefda50ba03eac8441dbbf
https://github.com/llvm/llvm-project/pull/82833
https://github.com/llvm/llvm-project/commit/e5ed7b6e2fd368b722b6359556cd0125881e7638

Cherry-picked from #14097
Closes #14159
