### PR TITLE
ISSUE_TEMPLATE/docs: add a separate GitHub issue template for docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: curl
 
-name: Bug Report
-description: Create a report to help us improve
+name: Bug Report on code
+description: Tell us about your problem with curl or libcurl
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,32 @@
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+
+name: Bug Report on documentation
+description: Problems, errors, mistakes or typos in documentation.
+labels: documentation
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        Only file documentation bugs here! Ask questions on the mailing lists https://curl.se/mail/
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Specify which documentation you found a problem with
+      description: |
+        Include function name, URL, tarball version and all other relevant
+        details that identify the documentation source.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: The problem
+    validations:
+      required: true


### PR DESCRIPTION
As such problems don't really fit the code related template