### PR TITLE
CI/circleci: config tidy-ups, bump up test parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,84 +57,84 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl CFLAGS='-Wno-vla -mmacosx-version-min=10.9' CPPFLAGS="-I$(brew --prefix libpsl)/include" LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --without-ssl CFLAGS='-mmacosx-version-min=10.9' CPPFLAGS="-I$(brew --prefix libpsl)/include" LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-debug:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --without-ssl --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-libssh2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --with-libssh2=/opt/homebrew/opt/libssh2 --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --without-ssl --with-libssh2=/opt/homebrew/opt/libssh2 --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-libssh-c-ares:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-ares --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-ares --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-libssh:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-c-ares:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --enable-ares --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --without-ssl --enable-ares --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-http-only:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-maintainer-mode --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap --disable-ldap --disable-mqtt --disable-pop3 --disable-rtsp --disable-smb --disable-smtp --disable-telnet --disable-tftp --disable-unix-sockets --disable-shared --without-brotli --without-gssapi --without-libidn2 --without-libpsl --without-librtmp --without-libssh2 --without-nghttp2 --without-ssl --without-zlib --enable-debug CFLAGS='-Wno-vla -mmacosx-version-min=10.15' || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-maintainer-mode --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap --disable-ldap --disable-mqtt --disable-pop3 --disable-rtsp --disable-smb --disable-smtp --disable-telnet --disable-tftp --disable-unix-sockets --disable-shared --without-brotli --without-gssapi --without-libidn2 --without-libpsl --without-librtmp --without-libssh2 --without-nghttp2 --without-ssl --without-zlib --enable-debug CFLAGS='-mmacosx-version-min=10.15' || { tail -1000 config.log; false; }
 
   configure-macos-securetransport-http2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-secure-transport CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.8' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-secure-transport CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.8' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-openssl-http2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-libressl-http2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix libressl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix libressl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-torture:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   configure-macos-torture-ftp:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-Wno-vla -mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
 
   install-cares:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --with-libssh2=/opt/homebrew/opt/libssh2 --enable-debug \
+            ./configure --enable-warnings --enable-websockets --without-ssl --with-libssh2=$(brew --prefix libssh2) --enable-debug \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,105 +36,176 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-werror --with-openssl || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-werror --with-openssl \
+              || { tail -1000 config.log; false; }
 
   configure-openssl-no-verbose:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --disable-verbose --enable-werror --with-openssl || { tail -1000 config.log; false; }
+            ./configure --disable-verbose --enable-werror --with-openssl \
+              || { tail -1000 config.log; false; }
 
   configure-no-proxy:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --disable-proxy --enable-werror --with-openssl || { tail -1000 config.log; false; }
+            ./configure --disable-proxy --enable-werror --with-openssl \
+              || { tail -1000 config.log; false; }
 
   configure-macos-normal:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl CFLAGS='-mmacosx-version-min=10.9' CPPFLAGS="-I$(brew --prefix libpsl)/include" LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --without-ssl \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-debug:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --without-ssl --enable-debug \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-libssh2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --with-libssh2=/opt/homebrew/opt/libssh2 --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --without-ssl --with-libssh2=/opt/homebrew/opt/libssh2 --enable-debug \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-libssh-c-ares:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-ares --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-ares --enable-debug \
+              PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-libssh:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-debug \
+              PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-c-ares:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --enable-ares --enable-debug CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --without-ssl --enable-ares --enable-debug \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-http-only:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-maintainer-mode --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap --disable-ldap --disable-mqtt --disable-pop3 --disable-rtsp --disable-smb --disable-smtp --disable-telnet --disable-tftp --disable-unix-sockets --disable-shared --without-brotli --without-gssapi --without-libidn2 --without-libpsl --without-librtmp --without-libssh2 --without-nghttp2 --without-ssl --without-zlib --enable-debug CFLAGS='-mmacosx-version-min=10.15' || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-maintainer-mode \
+              --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap --disable-ldap \
+              --disable-mqtt --disable-pop3 --disable-rtsp --disable-smb --disable-smtp --disable-telnet \
+              --disable-tftp --disable-unix-sockets --disable-shared --without-brotli --without-gssapi \
+              --without-libidn2 --without-libpsl --without-librtmp --without-libssh2 --without-nghttp2 \
+              --without-ssl --without-zlib --enable-debug \
+              CFLAGS='-mmacosx-version-min=10.15' \
+              || { tail -1000 config.log; false; }
 
   configure-macos-securetransport-http2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-secure-transport CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.8' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-secure-transport \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.8' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-openssl-http2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug \
+              PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-libressl-http2:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix libressl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug \
+              PKG_CONFIG_PATH="$(brew --prefix libressl)/lib/pkgconfig" \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-torture:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug \
+              PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   configure-macos-torture-ftp:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" CPPFLAGS="-I$(brew --prefix libpsl)/include" CFLAGS='-mmacosx-version-min=10.9' LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" LIBS="-licuuc -licudata" || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug \
+              PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
+              CPPFLAGS="-I$(brew --prefix libpsl)/include" \
+              CFLAGS='-mmacosx-version-min=10.9' \
+              LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
+              LIBS="-licuuc -licudata" \
+              || { tail -1000 config.log; false; }
 
   install-cares:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@
 # The macOS builds use M1 (ARM) machines for platform diversity.
 # See https://circleci.com/docs/configuration-reference/#macos-execution-environment
 
-# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/2.0/configuration-reference
+# Use the latest 2.1 version of CircleCI pipeline process engine. See: https://circleci.com/docs/configuration-reference/
 version: 2.1
 
 commands:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,7 +84,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --with-libssh2=$(brew --prefix libssh2) --enable-debug \
+            ./configure --enable-warnings --enable-websockets --without-ssl "--with-libssh2=$(brew --prefix libssh2)" --enable-debug \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
@@ -135,11 +135,31 @@ commands:
           command: |
             autoreconf -fi
             ./configure --enable-warnings \
-              --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap --disable-ldap \
-              --disable-mqtt --disable-pop3 --disable-rtsp --disable-smb --disable-smtp --disable-telnet \
-              --disable-tftp --disable-unix-sockets --disable-shared --without-brotli --without-gssapi \
-              --without-libidn2 --without-libpsl --without-librtmp --without-libssh2 --without-nghttp2 \
-              --without-ssl --without-zlib --enable-debug \
+              --disable-dict \
+              --disable-file \
+              --disable-ftp \
+              --disable-gopher \
+              --disable-imap \
+              --disable-ldap \
+              --disable-mqtt \
+              --disable-pop3 \
+              --disable-rtsp \
+              --disable-smb \
+              --disable-smtp \
+              --disable-telnet \
+              --disable-tftp \
+              --disable-unix-sockets \
+              --disable-shared \
+              --without-brotli \
+              --without-gssapi \
+              --without-libidn2 \
+              --without-libpsl \
+              --without-librtmp \
+              --without-libssh2 \
+              --without-nghttp2 \
+              --without-ssl \
+              --without-zlib \
+              --enable-debug \
               CFLAGS='-mmacosx-version-min=10.15' \
               || { tail -1000 config.log; false; }
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --enable-debug \
+            ./configure --enable-debug --enable-warnings --enable-websockets --without-ssl \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
@@ -84,7 +84,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl "--with-libssh2=$(brew --prefix libssh2)" --enable-debug \
+            ./configure --enable-debug --enable-warnings --enable-websockets --without-ssl "--with-libssh2=$(brew --prefix libssh2)" \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
@@ -96,7 +96,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-ares --enable-debug \
+            ./configure --enable-debug --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-ares \
               PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
@@ -109,7 +109,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --with-libssh --enable-debug \
+            ./configure --enable-debug --enable-warnings --enable-websockets --with-openssl --with-libssh \
               PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
@@ -122,7 +122,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --without-ssl --enable-ares --enable-debug \
+            ./configure --enable-debug --enable-warnings --enable-websockets --without-ssl --enable-ares \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
@@ -134,7 +134,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings \
+            ./configure --enable-debug --enable-warnings \
               --disable-dict \
               --disable-file \
               --disable-ftp \
@@ -159,7 +159,6 @@ commands:
               --without-nghttp2 \
               --without-ssl \
               --without-zlib \
-              --enable-debug \
               CFLAGS='-mmacosx-version-min=10.15' \
               || { tail -1000 config.log; false; }
 
@@ -180,7 +179,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug \
+            ./configure --enable-debug --enable-warnings --enable-websockets --with-openssl \
               PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
@@ -193,7 +192,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --with-openssl --enable-debug \
+            ./configure --enable-debug --enable-warnings --enable-websockets --with-openssl \
               PKG_CONFIG_PATH="$(brew --prefix libressl)/lib/pkgconfig" \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
@@ -206,7 +205,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug \
+            ./configure --enable-debug --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl \
               PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
@@ -219,7 +218,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl --enable-debug \
+            ./configure --enable-debug --enable-warnings --enable-websockets --disable-shared --disable-threaded-resolver --with-openssl \
               PKG_CONFIG_PATH="$(brew --prefix openssl)/lib/pkgconfig" \
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-maintainer-mode \
+            ./configure --enable-warnings \
               --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap --disable-ldap \
               --disable-mqtt --disable-pop3 --disable-rtsp --disable-smb --disable-smtp --disable-telnet \
               --disable-tftp --disable-unix-sockets --disable-shared --without-brotli --without-gssapi \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,16 +328,16 @@ commands:
 
   test-macos:
     steps:
-      - run: make -j5 V=1 test-ci
+      - run: make -j5 V=1 test-ci TFLAGS='-j10'
 
   test-torture:
     steps:
-      - run: make -j5 V=1 test-ci TFLAGS="-n -t --shallow=25 !FTP"
+      - run: make -j5 V=1 test-ci TFLAGS='-j10 -n -t --shallow=25 !FTP'
 
   test-torture-ftp:
     steps:
       # Test 250 takes too long, causing Circle CI to kill the job
-      - run: make -j5 V=1 test-ci TFLAGS="-n -t --shallow=20 FTP !250 !251"
+      - run: make -j5 V=1 test-ci TFLAGS='-j10 -n -t --shallow=20 FTP !250 !251'
 
 executors:
   ubuntu:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,7 @@ commands:
 
   test:
     steps:
-      - run: make -j3 V=1 test-ci
+      - run: make -j3 V=1 test-ci TFLAGS='-j14'
 
   test-macos:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-debug:
@@ -76,7 +76,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-libssh2:
@@ -88,7 +88,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-libssh-c-ares:
@@ -101,7 +101,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-libssh:
@@ -114,7 +114,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-c-ares:
@@ -126,7 +126,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-http-only:
@@ -152,7 +152,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.8' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-openssl-http2:
@@ -165,7 +165,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-libressl-http2:
@@ -178,7 +178,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-torture:
@@ -191,7 +191,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   configure-macos-torture-ftp:
@@ -204,7 +204,7 @@ commands:
               CPPFLAGS="-I$(brew --prefix libpsl)/include" \
               CFLAGS='-mmacosx-version-min=10.9' \
               LDFLAGS="-L$(brew --prefix libpsl)/lib -L$(brew --prefix icu4c)/lib" \
-              LIBS="-licuuc -licudata" \
+              LIBS='-licuuc -licudata' \
               || { tail -1000 config.log; false; }
 
   install-cares:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,8 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-werror --with-openssl --with-libssh || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-werror --with-openssl --with-libssh \
+              || { tail -1000 config.log; false; }
 
   install-wolfssl:
     steps:
@@ -292,21 +293,24 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-werror --with-openssl --enable-ares || { tail -1000 config.log; false; }
+            ./configure --enable-warnings --enable-werror --with-openssl --enable-ares \
+              || { tail -1000 config.log; false; }
 
   configure-wolfssh:
     steps:
       - run:
           command: |
             autoreconf -fi
-            LDFLAGS="-Wl,-rpath,$HOME/wssh/lib" ./configure --enable-warnings --enable-werror --with-wolfssl=$HOME/wssl --with-wolfssh=$HOME/wssh || { tail -1000 config.log; false; }
+            LDFLAGS="-Wl,-rpath,$HOME/wssh/lib" ./configure --enable-warnings --enable-werror --with-wolfssl=$HOME/wssl --with-wolfssh=$HOME/wssh \
+              || { tail -1000 config.log; false; }
 
   configure-cares-debug:
     steps:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-debug --enable-werror --with-openssl --enable-ares || { tail -1000 config.log; false; }
+            ./configure --enable-debug --enable-werror --with-openssl --enable-ares \
+              || { tail -1000 config.log; false; }
 
   build:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,12 +144,12 @@ commands:
               --disable-mqtt \
               --disable-pop3 \
               --disable-rtsp \
+              --disable-shared \
               --disable-smb \
               --disable-smtp \
               --disable-telnet \
               --disable-tftp \
               --disable-unix-sockets \
-              --disable-shared \
               --without-brotli \
               --without-gssapi \
               --without-libidn2 \


### PR DESCRIPTION
- bump parallel test for Linux jobs.
  Credit-to: Dan Fandrich
  Cherry-picked from #11510
- bump parallel test for macOS jobs.
- drop no longer necessary `-Wno-vla` option.
- fold long lines.
- drop `--enable-maintainer-mode` `./configure` option.
- replace a hard-coded prefix with `brew --prefix`.
- update documentation link.
- move `--enable-debug` in front.
- tidy up quotes.

Closes #14171
