### PR TITLE
cmake: fix building `unit1600` due to missing `ssl/openssl.h`

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -26,6 +26,13 @@
 
 #if defined(USE_CURL_NTLM_CORE)
 
+#if defined(USE_OPENSSL)
+#  include <openssl/ssl.h>
+#elif defined(USE_WOLFSSL)
+#  include <wolfssl/options.h>
+#  include <wolfssl/openssl/ssl.h>
+#endif
+
 /*
  * NTLM details:
  *

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -26,13 +26,6 @@
 
 #if defined(USE_CURL_NTLM_CORE)
 
-#if defined(USE_OPENSSL)
-#  include <openssl/ssl.h>
-#elif defined(USE_WOLFSSL)
-#  include <wolfssl/options.h>
-#  include <wolfssl/openssl/ssl.h>
-#endif
-
 /*
  * NTLM details:
  *

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -28,13 +28,6 @@
 
 #if defined(USE_CURL_NTLM_CORE)
 
-#if defined(USE_OPENSSL)
-#  include <openssl/ssl.h>
-#elif defined(USE_WOLFSSL)
-#  include <wolfssl/options.h>
-#  include <wolfssl/openssl/ssl.h>
-#endif
-
 /* Helpers to generate function byte arguments in little endian order */
 #define SHORTPAIR(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff))
 #define LONGQUARTET(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff)), \


### PR DESCRIPTION
In specific builds configs, cmake failed to build test `unit1600`,
due missing an OpenSSL (or wolfSSL) header.

The test code relies on `lib/curl_ntlm_core.h`, which in turn included
TLS library headers. But, dependency header directories are not setup
in cmake for tests, because they should not normally be needed.

The issue was hidden in most builds because TLS headers are usually
found under the system prefix. One counterexample is macOS + Homebrew
LibreSSL builds, where OpenSSL is purposefully unlinked from there to
avoid a mixup with LibreSSL that resides under its own prefix. It was
also hidden in autotools, possibly because it sets up header directories
globally, tests included.

The actual bug however is that `lib/curl_ntlm_core.h` should not include
TLS headers. None of its internal users need it, and `curl_ntlm_core.c`
included them already directly.

Fix it by deleting the TLS header includes from this internal header.

Fixes:
```
In file included from curl/tests/unit/unit1600.c:27:
curl/lib/curl_ntlm_core.h:32:12: fatal error: 'openssl/ssl.h' file not found
#  include <openssl/ssl.h>
           ^~~~~~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/9912684737/job/27388041520#step:12:1694

Follow-up to 48eb71ade41d4b37f416b643063cab846ac027a2 #10322
Cherry-picked from #14097
Closes #14172
