### PR TITLE
runtests: show name and keywords for failed tests in summary

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3039,9 +3039,28 @@ if(%skipped && !$short) {
     }
 }
 
+sub testnumdetails {
+    my ($desc, $numlist) = @_;
+    logmsg "\n";
+    foreach my $testnum (split(' ', $numlist)) {
+        if(!loadtest("${TESTDIR}/test${testnum}")) {
+            my @info_keywords = getpart("info", "keywords");
+            my $testname = (getpart("client", "name"))[0];
+            chomp $testname;
+            logmsg "$desc $testnum: '$testname'";
+            for my $k (@info_keywords) {
+                chomp $k;
+                logmsg ",$k";
+            }
+            logmsg "\n";
+        }
+    }
+}
+
 if($total) {
     if($failedign) {
         my $failedignsorted = numsortwords($failedign);
+        testnumdetails("FAIL-IGNORED", $failedignsorted);
         logmsg "IGNORED: failed tests: $failedignsorted\n";
     }
     logmsg sprintf("TESTDONE: $ok tests out of $total reported OK: %d%%\n",
@@ -3049,20 +3068,7 @@ if($total) {
 
     if($failed && ($ok != $total)) {
         my $failedsorted = numsortwords($failed);
-        logmsg "\n";
-        foreach my $testnum (split(' ', $failedsorted)) {
-            if(!loadtest("${TESTDIR}/test${testnum}")) {
-                my @info_keywords = getpart("info", "keywords");
-                my $testname = (getpart("client", "name"))[0];
-                chomp $testname;
-                logmsg "FAIL $testnum: '$testname'";
-                for my $k (@info_keywords) {
-                    chomp $k;
-                    logmsg ",$k";
-                }
-                logmsg "\n";
-            }
-        }
+        testnumdetails("FAIL", $failedsorted);
         logmsg "\nTESTFAIL: These test cases failed: $failedsorted\n\n";
     }
 }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3049,6 +3049,20 @@ if($total) {
 
     if($failed && ($ok != $total)) {
         my $failedsorted = numsortwords($failed);
+        logmsg "\n";
+        foreach my $testnum (split(' ', $failedsorted)) {
+            if(!loadtest("${TESTDIR}/test${testnum}")) {
+                my @info_keywords = getpart("info", "keywords");
+                my $testname = (getpart("client", "name"))[0];
+                chomp $testname;
+                logmsg "FAIL $testnum: [$testname]";
+                for my $k (@info_keywords) {
+                    chomp $k;
+                    logmsg " $k";
+                }
+                logmsg "\n";
+            }
+        }
         logmsg "\nTESTFAIL: These test cases failed: $failedsorted\n\n";
     }
 }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3058,7 +3058,7 @@ if($total) {
                 logmsg "FAIL $testnum: [$testname]";
                 for my $k (@info_keywords) {
                     chomp $k;
-                    logmsg ", $k";
+                    logmsg ",$k";
                 }
                 logmsg "\n";
             }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3047,9 +3047,12 @@ sub testnumdetails {
             my $testname = (getpart("client", "name"))[0];
             chomp $testname;
             logmsg "$desc $testnum: '$testname'";
+            my $first = 1;
             for my $k (@info_keywords) {
                 chomp $k;
-                logmsg ",$k";
+                my $sep = ($first == 1) ? " " : ",";
+                logmsg "$sep$k";
+                $first = 0;
             }
             logmsg "\n";
         }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3055,7 +3055,7 @@ if($total) {
                 my @info_keywords = getpart("info", "keywords");
                 my $testname = (getpart("client", "name"))[0];
                 chomp $testname;
-                logmsg "FAIL $testnum: [$testname]";
+                logmsg "FAIL $testnum: '$testname'";
                 for my $k (@info_keywords) {
                     chomp $k;
                     logmsg ",$k";

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3058,7 +3058,7 @@ if($total) {
                 logmsg "FAIL $testnum: [$testname]";
                 for my $k (@info_keywords) {
                     chomp $k;
-                    logmsg " $k";
+                    logmsg ", $k";
                 }
                 logmsg "\n";
             }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3050,7 +3050,7 @@ sub testnumdetails {
             my $first = 1;
             for my $k (@info_keywords) {
                 chomp $k;
-                my $sep = ($first == 1) ? " " : ",";
+                my $sep = ($first == 1) ? " " : ", ";
                 logmsg "$sep$k";
                 $first = 0;
             }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3041,7 +3041,6 @@ if(%skipped && !$short) {
 
 sub testnumdetails {
     my ($desc, $numlist) = @_;
-    logmsg "\n";
     foreach my $testnum (split(' ', $numlist)) {
         if(!loadtest("${TESTDIR}/test${testnum}")) {
             my @info_keywords = getpart("info", "keywords");
@@ -3068,7 +3067,7 @@ if($total) {
 
     if($failed && ($ok != $total)) {
         my $failedsorted = numsortwords($failed);
-        testnumdetails("FAIL", $failedsorted);
+        testnumdetails("\nFAIL", $failedsorted);
         logmsg "\nTESTFAIL: These test cases failed: $failedsorted\n\n";
     }
 }


### PR DESCRIPTION
Useful to see what the numbers listed in the `TESTFAIL:` and `IGNORED:`
lines mean. Also list test keywords to help catching failure patterns.

Example:
```
FAIL 1034: 'HTTP over proxy with malformatted IDN host name' HTTP, HTTP GET, HTTP proxy, IDN, FAILURE, config file
FAIL 1035: 'HTTP over proxy with too long IDN host name' HTTP, HTTP GET, HTTP proxy, IDN, FAILURE

TESTFAIL: These test cases failed: 1034 1035
```

Closes #14174
