### PR TITLE
cmake: delete unused `HAVE_LIBSSH2`, `HAVE_LIBSOCKET` macros

### DIFF
--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -107,9 +107,6 @@
 /* Define if you have the <io.h> header file. */
 #undef HAVE_IO_H
 
-/* Define if you have the `socket' library (-lsocket). */
-#undef HAVE_LIBSOCKET
-
 /* Define if you have GSS API. */
 #define HAVE_GSSAPI
 

--- a/lib/config-riscos.h
+++ b/lib/config-riscos.h
@@ -108,9 +108,6 @@
 /* Define if you have the <io.h> header file. */
 #undef HAVE_IO_H
 
-/* Define if you have the `socket' library (-lsocket). */
-#undef HAVE_LIBSOCKET
-
 /* Define if you need the malloc.h header file even with stdlib.h  */
 /* #define NEED_MALLOC_H 1 */
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -371,9 +371,6 @@
 /* Define to 1 if you have the `socket' library (-lsocket). */
 #cmakedefine HAVE_LIBSOCKET 1
 
-/* Define to 1 if you have the `ssh2' library (-lssh2). */
-#cmakedefine HAVE_LIBSSH2 1
-
 /* if zlib is available */
 #cmakedefine HAVE_LIBZ 1
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -368,9 +368,6 @@
 /* Define to 1 if you have the idn2.h header file. */
 #cmakedefine HAVE_IDN2_H 1
 
-/* Define to 1 if you have the `socket' library (-lsocket). */
-#cmakedefine HAVE_LIBSOCKET 1
-
 /* if zlib is available */
 #cmakedefine HAVE_LIBZ 1
 

--- a/scripts/cmp-config.pl
+++ b/scripts/cmp-config.pl
@@ -47,6 +47,7 @@ my %remove = (
     '#define HAVE_IOCTL 1' => 1,
     '#define HAVE_LDAP_SSL 1' => 1,
     '#define HAVE_LIBBROTLIDEC 1' => 1,
+    '#define HAVE_LIBSOCKET 1' => 1,
     '#define HAVE_LIBSSH2 1' => 1,
     '#define HAVE_LIBSSL 1' => 1,
     '#define HAVE_LIBZSTD 1' => 1,

--- a/scripts/cmp-config.pl
+++ b/scripts/cmp-config.pl
@@ -47,6 +47,7 @@ my %remove = (
     '#define HAVE_IOCTL 1' => 1,
     '#define HAVE_LDAP_SSL 1' => 1,
     '#define HAVE_LIBBROTLIDEC 1' => 1,
+    '#define HAVE_LIBSSH2 1' => 1,
     '#define HAVE_LIBSSL 1' => 1,
     '#define HAVE_LIBZSTD 1' => 1,
     '#define HAVE_OPENSSL3 1' => 1,


### PR DESCRIPTION
- `HAVE_LIBSSH2`: unused in source. Not defined in CMake.

- `HAVE_LIBSOCKET`: unused in source. Used internally in CMake.

autotools sets them implicitly, so add them to the flag comparison
ignore-list.

Closes #14178
