### PR TITLE
build: use `#error` instead of invalid syntax

### DIFF
--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -137,7 +137,7 @@ if(NOT DEFINED HAVE_GETADDRINFO_THREADSAFE)
     #ifdef h_errno
       return 0;
     #else
-      force compilation error
+      #error force compilation error
     #endif
     }" HAVE_H_ERRNO)
 
@@ -158,7 +158,7 @@ if(NOT DEFINED HAVE_GETADDRINFO_THREADSAFE)
         #elif defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 700)
           return 0;
         #else
-          force compilation error
+          #error force compilation error
         #endif
         }" HAVE_H_ERRNO_SBS_ISSUE_7)
     endif()

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -94,7 +94,7 @@ int main (void)
 #ifdef $1
   return 0;
 #else
-  force compilation error
+  #error force compilation error
 #endif
 }
     ]])
@@ -130,7 +130,7 @@ int main (void)
 #elif defined(__hpux) && defined(_XOPEN_SOURCE_EXTENDED)
   return 0;
 #else
-  force compilation error
+  #error force compilation error
 #endif
 }
     ]])

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1563,7 +1563,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
 #elif defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 700)
           return 0;
 #else
-          force compilation error
+          #error force compilation error
 #endif
         ]])
       ],[

--- a/m4/curl-reentrant.m4
+++ b/m4/curl-reentrant.m4
@@ -58,7 +58,7 @@ AC_DEFUN([CURL_CHECK_NEED_REENTRANT_ERRNO], [
 #ifdef errno
         int dummy=1;
 #else
-        force compilation error
+        #error force compilation error
 #endif
       ]])
     ],[
@@ -72,7 +72,7 @@ AC_DEFUN([CURL_CHECK_NEED_REENTRANT_ERRNO], [
 #ifdef errno
           int dummy=1;
 #else
-          force compilation error
+          #error force compilation error
 #endif
         ]])
       ],[
@@ -413,7 +413,7 @@ AC_DEFUN([CURL_CONFIGURE_REENTRANT], [
 #ifdef _REENTRANT
       int dummy=1;
 #else
-      force compilation error
+      #error force compilation error
 #endif
     ]])
   ],[
@@ -473,7 +473,7 @@ AC_DEFUN([CURL_CONFIGURE_THREAD_SAFE], [
 #ifdef _THREAD_SAFE
       int dummy=1;
 #else
-      force compilation error
+      #error force compilation error
 #endif
     ]])
   ],[


### PR DESCRIPTION
It reduces configure log noise.

Follow-up to 20c1b2d75ee38189ffa75d21ed04108e1e0630ae #13287
Closes #14181
