### PR TITLE
runtests: add `-qs` (quiet success) option

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -69,7 +69,7 @@ jobs:
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
-              export TFLAGS='-j0'  # flakies: ~389 ~392 ~TFTP and more
+              export TFLAGS='-j0 -qs'  # flakies: ~389 ~392 ~TFTP and more
               cmake --build bld --config Debug --target test-ci
             fi
 
@@ -104,7 +104,7 @@ jobs:
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
-              export TFLAGS='-j8 ~3017 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
+              export TFLAGS='-j8 -qs ~3017 ~TFTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
               cmake --build bld --config Debug --target test-ci
             fi
 
@@ -152,7 +152,7 @@ jobs:
               make -j3 -C tests
               # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
               # therefore the SFTP and SCP tests are disabled right away from the beginning.
-              make test-ci V=1 TFLAGS='-j12 !SFTP !SCP'
+              make test-ci V=1 TFLAGS='-j12 -qs !SFTP !SCP'
             fi
 
       - name: 'cmake'
@@ -187,7 +187,7 @@ jobs:
               cmake --build bld --config Debug --parallel 3 --target testdeps
               # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
               # therefore the SFTP and SCP tests are disabled right away from the beginning.
-              make test-ci V=1 TFLAGS='-j12 !SFTP !SCP'
+              make test-ci V=1 TFLAGS='-j12 -qs !SFTP !SCP'
             fi
 
   omnios:
@@ -214,4 +214,4 @@ jobs:
             src/curl --disable --version
             gmake -j3 examples
             gmake -j3 -C tests
-            gmake test-ci V=1 TFLAGS='-j12 ~MQTT ~FTP'
+            gmake test-ci V=1 TFLAGS='-j12 -qs ~MQTT ~FTP'

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -52,6 +52,7 @@ BEGIN {
         $proxy_address
         $PROXYIN
         $pwd
+        $quietsuccess
         $randseed
         $run_event_based
         $SERVERCMD
@@ -82,6 +83,7 @@ our $proxy_address;   # external HTTP proxy address
 our $listonly;        # only list the tests
 our $run_event_based; # run curl with --test-event to test the event API
 our $automakestyle;   # use automake-like test status output format
+our $quietsuccess;    # reduce output for successful test runs
 our $anyway;          # continue anyway, even if a test fail
 our $CURLVERSION="";  # curl's reported version number
 our $CURLVERNUM="";   # curl's reported version number (without -DEV)


### PR DESCRIPTION
Add `-qs` quiet success option. It omits the two log lines for tests
that run successfully. It makes logs ~3500 lines shorter in most cases.

Apply this option to GHA/non-native CI jobs.

Example runs:
- no failure: https://github.com/curl/curl/actions/runs/10021979612
- with failure: https://github.com/curl/curl/actions/runs/10021785141

Closes #14185
