### PR TITLE
configure: CA bundle/path detection fixes

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1259,8 +1259,8 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
     capath="$want_capath"
     ca="no"
   else
-    dnl first try autodetecting a CA bundle , then a CA path
-    dnl both autodetections can be skipped by --without-ca-*
+    dnl first try auto-detecting a CA bundle, then a CA path
+    dnl both auto-detections can be skipped by --without-ca-*
     ca="no"
     capath="no"
     if test "x$cross_compiling" != "xyes"; then

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1258,9 +1258,10 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
     dnl --with-ca-path given
     if test "x$OPENSSL_ENABLED" != "x1" -a \
             "x$GNUTLS_ENABLED" != "x1" -a \
+            "x$BEARSSL_ENABLED" != "x1" -a \
             "x$MBEDTLS_ENABLED" != "x1" -a \
             "x$WOLFSSL_ENABLED" != "x1"; then
-      AC_MSG_ERROR([--with-ca-path only works with OpenSSL, GnuTLS, mbedTLS or wolfSSL])
+      AC_MSG_ERROR([--with-ca-path only works with OpenSSL, GnuTLS, BearSSL, mbedTLS or wolfSSL])
     fi
     capath="$want_capath"
     ca="no"

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1263,7 +1263,8 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
     dnl Both auto-detections can be skipped by --without-ca-*
     ca="no"
     capath="no"
-    if test "x$cross_compiling" != "xyes"; then
+    if test "x$cross_compiling" != "xyes" -a \
+            "x$curl_cv_native_windows" != "xyes"; then
       dnl NOT cross-compiling and...
       dnl neither of the --with-ca-* options are provided
       if test "x$want_ca" = "xunset"; then
@@ -1306,16 +1307,19 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
     check_capath="$capath"
   fi
 
-  if test ! -z "$check_capath"; then
-    for a in "$check_capath"; do
-      if test -d "$a" && ls "$a"/[[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]].0 >/dev/null 2>/dev/null; then
-        if test "x$capath" = "xno"; then
-          capath="$a"
+  if test "x$cross_compiling" != "xyes" -a \
+          "x$curl_cv_native_windows" != "xyes"; then
+    if test ! -z "$check_capath"; then
+      for a in "$check_capath"; do
+        if test -d "$a" && ls "$a"/[[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]].0 >/dev/null 2>/dev/null; then
+          if test "x$capath" = "xno"; then
+            capath="$a"
+          fi
+          capath_warning=""
+          break
         fi
-        capath_warning=""
-        break
-      fi
-    done
+      done
+    fi
   fi
 
   if test "x$capath" = "xno"; then

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1307,19 +1307,16 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
     check_capath="$capath"
   fi
 
-  if test "x$cross_compiling" != "xyes" -a \
-          "x$curl_cv_native_windows" != "xyes"; then
-    if test ! -z "$check_capath"; then
-      for a in "$check_capath"; do
-        if test -d "$a" && ls "$a"/[[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]].0 >/dev/null 2>/dev/null; then
-          if test "x$capath" = "xno"; then
-            capath="$a"
-          fi
-          capath_warning=""
-          break
+  if test ! -z "$check_capath"; then
+    for a in "$check_capath"; do
+      if test -d "$a" && ls "$a"/[[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]].0 >/dev/null 2>/dev/null; then
+        if test "x$capath" = "xno"; then
+          capath="$a"
         fi
-      done
-    fi
+        capath_warning=""
+        break
+      fi
+    done
   fi
 
   if test "x$capath" = "xno"; then

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1259,15 +1259,15 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
     capath="$want_capath"
     ca="no"
   else
-    dnl first try auto-detecting a CA bundle, then a CA path
-    dnl both auto-detections can be skipped by --without-ca-*
+    dnl First try auto-detecting a CA bundle, then a CA path.
+    dnl Both auto-detections can be skipped by --without-ca-*
     ca="no"
     capath="no"
     if test "x$cross_compiling" != "xyes"; then
       dnl NOT cross-compiling and...
       dnl neither of the --with-ca-* options are provided
       if test "x$want_ca" = "xunset"; then
-        dnl the path we previously would have installed the curl ca bundle
+        dnl the path we previously would have installed the curl CA bundle
         dnl to, and thus we now check for an already existing cert in that
         dnl place in case we find no other
         if test "x$prefix" != xNONE; then

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1299,6 +1299,7 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
       if test "x$want_capath" = "xunset"; then
         if test "x$OPENSSL_ENABLED" = "x1" -o \
                 "x$GNUTLS_ENABLED" = "x1" -o \
+                "x$BEARSSL_ENABLED" = "x1" -o \
                 "x$MBEDTLS_ENABLED" = "x1" -o \
                 "x$WOLFSSL_ENABLED" = "x1"; then
           check_capath="/etc/ssl/certs"

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1256,13 +1256,6 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
     capath="no"
   elif test "x$want_capath" != "xno" -a "x$want_capath" != "xunset"; then
     dnl --with-ca-path given
-    if test "x$OPENSSL_ENABLED" != "x1" -a \
-            "x$GNUTLS_ENABLED" != "x1" -a \
-            "x$BEARSSL_ENABLED" != "x1" -a \
-            "x$MBEDTLS_ENABLED" != "x1" -a \
-            "x$WOLFSSL_ENABLED" != "x1"; then
-      AC_MSG_ERROR([--with-ca-path only works with OpenSSL, GnuTLS, BearSSL, mbedTLS or wolfSSL])
-    fi
     capath="$want_capath"
     ca="no"
   else
@@ -1297,13 +1290,7 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
       fi
       AC_MSG_NOTICE([want $want_capath ca $ca])
       if test "x$want_capath" = "xunset"; then
-        if test "x$OPENSSL_ENABLED" = "x1" -o \
-                "x$GNUTLS_ENABLED" = "x1" -o \
-                "x$BEARSSL_ENABLED" = "x1" -o \
-                "x$MBEDTLS_ENABLED" = "x1" -o \
-                "x$WOLFSSL_ENABLED" = "x1"; then
-          check_capath="/etc/ssl/certs"
-        fi
+        check_capath="/etc/ssl/certs"
       fi
     else
       dnl no option given and cross-compiling


### PR DESCRIPTION
- fix to not auto-detect CA bundle/path on Windows.

- two checks missed BearSSL, but they were only run for supported
  TLS backends anyway. Delete these redundant checks.

- fix typos in a comment nearby.

Follow-up to 082bb41311a832ae1b83bb8fe1dfdefcf4e68ea5 #2545
Closes #14186

---

Nicer without whitespaces:
https://github.com/curl/curl/pull/14186/files?w=1
