### PR TITLE
GHA/windows: verify 1448 2046 2047 in IDN Unicode jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -654,7 +654,10 @@ jobs:
         run: |
           export TFLAGS='-j14 !TFTP !MQTT !WebSockets !SMTP ~FTP ${{ matrix.tflags }}'
           if [[ '${{ matrix.config }}' = *'-DUSE_WIN32_IDN=ON'* ]]; then
-            TFLAGS+=' ~165 ~1448 ~2046 ~2047'
+            TFLAGS+=' ~165'
+            if [[ '${{ matrix.config }}' != *'-DENABLE_UNICODE=ON'* ]]; then
+              TFLAGS+=' ~1448 ~2046 ~2047'
+            fi
           fi
           PATH="$PWD/bld/lib:$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci


### PR DESCRIPTION
These tests pass with Unicode and fail without.

Follow-up to cb22cfca69bded45bf7f9c72c8e6764990490f11 #14077
Closes #14188
