### PR TITLE
GHA/windows: add MSVC wolfSSL job with test

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -572,7 +572,7 @@ jobs:
           arch: 'x64'
           plat: 'windows'
           type: 'Debug'
-          tflags: ''
+          tflags: '~1516 ~2600'
           config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DUSE_NGHTTP2=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_WOLFSSL=ON -DCURL_USE_GSASL=ON'
 
       fail-fast: false

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -567,6 +567,14 @@ jobs:
           type: 'Debug'
           tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
           config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DHTTP_ONLY=ON'
+        - name: 'wolfssl'
+          install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl'
+          arch: 'x64'
+          plat: 'windows'
+          type: 'Debug'
+          tflags: ''
+          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DUSE_NGHTTP2=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_WOLFSSL=ON -DCURL_USE_GSASL=ON'
+
       fail-fast: false
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -572,9 +572,8 @@ jobs:
           arch: 'x64'
           plat: 'windows'
           type: 'Debug'
-          tflags: '~1516 ~2600'
+          tflags: '~1516'
           config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DUSE_NGHTTP2=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_WOLFSSL=ON -DCURL_USE_GSASL=ON'
-
       fail-fast: false
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1009,7 +1009,8 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
 }
 
 
-static char *wolfssl_strerror(unsigned long error, char *buf, size_t size)
+static char *wolfssl_strerror(unsigned long error, char *buf,
+                              unsigned long size)
 {
   DEBUGASSERT(size);
   *buf = '\0';


### PR DESCRIPTION
Fix the file of wolfssl.c because of this warning/error:
```
curl\lib\vtls\wolfssl.c(1017,42): error C2220: the following warning is treated as an error [curl\bld\lib\libcurl_object.vcxproj]
curl\lib\vtls\wolfssl.c(1017,42): warning C4267: 'function': conversion from 'size_t' to 'unsigned long', possible loss of data [curl\bld\lib\libcurl_object.vcxproj]
```

`size_t` in MSVC is different. Change it to `unsigned long` because
`wolfSSL_ERR_error_string_n` last argument is defined as
`unsigned long`.

Closes #14193
