### PR TITLE
configure: limit `__builtin_available` test to Darwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -597,7 +597,11 @@ CURL_CHECK_WIN32_LARGEFILE
 CURL_CHECK_WIN32_CRYPTO
 
 CURL_DARWIN_CFLAGS
-CURL_SUPPORTS_BUILTIN_AVAILABLE
+case $host_os in
+  darwin*)
+    CURL_SUPPORTS_BUILTIN_AVAILABLE
+    ;;
+esac
 
 AM_CONDITIONAL([HAVE_WINDRES],
   [test "$curl_cv_native_windows" = "yes" && test -n "${RC}"])


### PR DESCRIPTION
This feature test always fails on non-Apple systems. (For Apple targets
it's supported by llvm and Apple clang.)

Syncs behaviour with CMake.

Follow-up to cfd6f43d6ca7e57670b422bab7bbf10221a2cf3e #14127
Cherry-picked from #14097
Closes #14196
