### PR TITLE
GHA/windows: add mbedTLS MSVC job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -351,12 +351,12 @@ jobs:
       matrix:
         include:
         - name: 'schannel U'
-          install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl openssl'
+          install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl openssl mbedtls'
           arch: 'x64'
           plat: 'windows'
           type: 'Debug'
           tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=ON  -DCURL_USE_SCHANNEL=ON  -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DUSE_WIN32_IDN=ON -DCURL_USE_GSASL=ON -DCURL_USE_OPENSSL=ON -DCURL_DEFAULT_SSL_BACKEND=schannel'
+          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=ON  -DCURL_USE_SCHANNEL=ON  -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DUSE_WIN32_IDN=ON -DCURL_USE_GSASL=ON -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel'
         - name: 'openssl'
           install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl'
           arch: 'x64'


### PR DESCRIPTION
This job fails with these warnings/errors:
```
D:\a\curl\curl\lib\vtls\cipher_suite.c(193,3): error C2220: the following warning is treated as an error [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj]
D:\a\curl\curl\lib\vtls\cipher_suite.c(193,3): warning C4310: cast truncates constant value [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj]
... the same warning between these lines: 193-718. not continuously. 
D:\a\curl\curl\lib\vtls\cipher_suite.c(718,3): warning C4310: cast truncates constant value [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj]
D:\a\curl\curl\lib\vtls\mbedtls.c(1016,17): warning C4013: 'mbedtls_ssl_get_version_number' undefined; assuming extern returning int [D:\a\curl\curl\bld\lib\libcurl_object.vcxproj
```

Ref: 92e28f2897dc4adf0014af197e88fd8e1ccc6aeb #14228
Closes #14203
