### PR TITLE
multi: fix timing metrics on connect failure

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2643,6 +2643,7 @@ statemachine_end:
         else if(data->mstate == MSTATE_CONNECT) {
           /* Curl_connect() failed */
           (void)Curl_posttransfer(data);
+          (void)Curl_pgrsUpdate(data);
         }
 
         multistate(data, MSTATE_COMPLETED);

--- a/tests/data/test1268
+++ b/tests/data/test1268
@@ -23,7 +23,7 @@ UnixSockets
 filename argument looks like a flag
 </name>
 <command>
---stderr %LOGDIR/moo%TESTNUMBER --unix-socket -k hej://moo
+--no-progress-meter --stderr %LOGDIR/moo%TESTNUMBER --unix-socket -k hej://moo
 </command>
 </client>
 

--- a/tests/data/test1471
+++ b/tests/data/test1471
@@ -24,7 +24,7 @@ http
 Fail to resolve .onion TLD
 </name>
 <command>
-red.onion
+--no-progress-meter red.onion
 </command>
 </client>
 

--- a/tests/data/test1472
+++ b/tests/data/test1472
@@ -24,7 +24,7 @@ http
 Fail to resolve .onion. TLD
 </name>
 <command>
-tasty.onion.
+--no-progress-meter tasty.onion.
 </command>
 </client>
 


### PR DESCRIPTION
On platforms without AsynchDNS, if name resolution fails for a transaction, CURLINFO_TOTAL_TIME (and all other timing metrics) return 0, which is rather misleading.

This commit adds a final Curl_pgrsUpdate() call before returning to update the timing metrics.