### PR TITLE
scorecard upload tests

### DIFF
--- a/tests/http/testenv/caddy.py
+++ b/tests/http/testenv/caddy.py
@@ -141,6 +141,8 @@ class Caddy:
     def _write_config(self):
         domain1 = self.env.domain1
         creds1 = self.env.get_credentials(domain1)
+        domain2 = self.env.domain2
+        creds2 = self.env.get_credentials(domain2)
         self._mkpath(self._docs_dir)
         self._mkpath(self._tmp_dir)
         with open(os.path.join(self._docs_dir, 'data.json'), 'w') as fd:
@@ -162,6 +164,11 @@ class Caddy:
                 f'    root {self._docs_dir}',
                 f'  }}',
                 f'  tls {creds1.cert_file} {creds1.pkey_file}',
+                f'}}',
+                f'{domain2} {{',
+                f'  reverse_proxy /* http://localhost:{self.env.http_port} {{',
+                f'  }}',
+                f'  tls {creds2.cert_file} {creds2.pkey_file}',
                 f'}}',
             ]
             fd.write("\n".join(conf))

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #***************************************************************************
 #                                  _   _ ____  _
@@ -309,6 +310,18 @@ class Httpd:
             conf.extend(self._curltest_conf(domain1))
             if domain1 in self._extra_configs:
                 conf.extend(self._extra_configs[domain1])
+            conf.extend([
+                f'</VirtualHost>',
+                f'',
+            ])
+            conf.extend([  # plain http host for domain2
+                f'<VirtualHost *:{self.env.http_port}>',
+                f'    ServerName {domain2}',
+                f'    ServerAlias localhost',
+                f'    DocumentRoot "{self._docs_dir}"',
+                f'    Protocols h2c http/1.1',
+            ])
+            conf.extend(self._curltest_conf(domain2))
             conf.extend([
                 f'</VirtualHost>',
                 f'',

--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -522,7 +522,7 @@ static int curltest_put_handler(request_rec *r)
   apr_bucket_brigade *bb;
   apr_bucket *b;
   apr_status_t rv;
-  char buffer[16*1024];
+  char buffer[128*1024];
   const char *ct;
   apr_off_t rbody_len = 0;
   const char *s_rbody_len;


### PR DESCRIPTION
- add upload tests to scorecard, invoke with
  > python3 tests/http/scorecard.py -u h1|h2|h3
- add a reverse proxy setup from Caddy to httpd for upload tests since Caddy does not have other PUT/POST handling
- add caddy tests in test_08 for POST/PUT
- increase read buffer in mod_curltest for larger reads