### PR TITLE
docs/examples/websocket: fix "socket not ready" on recv

### DIFF
--- a/docs/examples/websocket.c
+++ b/docs/examples/websocket.c
@@ -25,16 +25,67 @@
  * WebSocket using CONNECT_ONLY
  * </DESC>
  */
+#ifdef _WIN32
+#include <winsock2.h>
+#include <windows.h>
+#endif
+
 #include <stdio.h>
 #include <string.h>
+
 #ifdef _WIN32
-#include <windows.h>
-#define sleep(s) Sleep((DWORD)(s))
+#define sleep(s) Sleep((DWORD)((s)*1000))
 #else
 #include <unistd.h>
 #endif
 
 #include <curl/curl.h>
+
+/* Auxiliary function that waits on the socket.
+   If 'for_recv' is true it waits until data is received, if false it waits
+   until data can be sent on the socket.
+   If 'timeout_ms' is negative then it waits indefinitely.
+   */
+static int wait_on_socket(curl_socket_t sockfd, int for_recv, long timeout_ms)
+{
+  struct timeval tv;
+  fd_set infd, outfd, errfd;
+  int res;
+
+  if(timeout_ms >= 0) {
+    tv.tv_sec = timeout_ms / 1000;
+    tv.tv_usec = (int)(timeout_ms % 1000) * 1000;
+  }
+
+  FD_ZERO(&infd);
+  FD_ZERO(&outfd);
+  FD_ZERO(&errfd);
+
+/* Avoid this warning with pre-2020 Cygwin/MSYS releases:
+ * warning: conversion to 'long unsigned int' from 'curl_socket_t' {aka 'int'}
+ * may change the sign of the result [-Wsign-conversion]
+ */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+  FD_SET(sockfd, &errfd); /* always check for error */
+
+  if(for_recv) {
+    FD_SET(sockfd, &infd);
+  }
+  else {
+    FD_SET(sockfd, &outfd);
+  }
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
+  /* select() returns the number of signalled sockets or -1 */
+  res = select((int)sockfd + 1, &infd, &outfd, &errfd,
+               ((timeout_ms >= 0) ? &tv : NULL));
+  return res;
+}
 
 static int ping(CURL *curl, const char *send_payload)
 {
@@ -45,44 +96,6 @@ static int ping(CURL *curl, const char *send_payload)
   return (int)result;
 }
 
-static int recv_pong(CURL *curl, const char *expected_payload)
-{
-  size_t rlen;
-  const struct curl_ws_frame *meta;
-  char buffer[256];
-  CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
-  if(!result) {
-    if(meta->flags & CURLWS_PONG) {
-      int same = 0;
-      fprintf(stderr, "ws: got PONG back\n");
-      if(rlen == strlen(expected_payload)) {
-        if(!memcmp(expected_payload, buffer, rlen)) {
-          fprintf(stderr, "ws: got the same payload back\n");
-          same = 1;
-        }
-      }
-      if(!same)
-        fprintf(stderr, "ws: did NOT get the same payload back\n");
-    }
-    else {
-      fprintf(stderr, "recv_pong: got %u bytes rflags %x\n", (int)rlen,
-              meta->flags);
-    }
-  }
-  fprintf(stderr, "ws: curl_ws_recv returned %u, received %u\n",
-          (unsigned int)result, (unsigned int)rlen);
-  return (int)result;
-}
-
-static CURLcode recv_any(CURL *curl)
-{
-  size_t rlen;
-  const struct curl_ws_frame *meta;
-  char buffer[256];
-
-  return curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
-}
-
 /* close the connection */
 static void websocket_close(CURL *curl)
 {
@@ -90,11 +103,207 @@ static void websocket_close(CURL *curl)
   (void)curl_ws_send(curl, "", 0, &sent, 0, CURLWS_CLOSE);
 }
 
+/* recv_any waits indefinitely for a complete websocket message of any
+   known type CURLWS_TEXT, CURLWS_BINARY, CURLWS_PING, CURLWS_PONG or
+   CURLWS_CLOSE.
+
+   if a control message (PING/PONG/CLOSE) interrupts receipt of a non-control
+   message (TEXT/BINARY) then the control message is either handled by libcurl
+   or this function. the control message is not returned to the caller in that
+   case. if possible this function will continue to wait for the complete
+   non-control message to return to the caller.
+
+   wstype receives the type. */
+static CURLcode recv_any(CURL *curl, char *buffer, size_t bufsize,
+  size_t *written, int *wstype)
+{
+  size_t rlen;
+  const struct curl_ws_frame *meta;
+  CURLcode result;
+  int rtype = 0;
+  curl_socket_t sockfd = CURL_SOCKET_BAD;
+
+  *written = 0;
+  *wstype = 0;
+
+  if(!bufsize)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+
+  if(curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd) ||
+     sockfd == CURL_SOCKET_BAD) {
+    fprintf(stderr, "ws: unexpected dead connection\n");
+    return CURLE_RECV_ERROR;
+  }
+
+  for(;;) {
+    result = curl_ws_recv(curl, &buffer[*written], bufsize - *written,
+                          &rlen, &meta);
+    if(!result) {
+      if((meta->flags & CURLWS_TEXT))
+        rtype = CURLWS_TEXT;
+      else if((meta->flags & CURLWS_BINARY))
+        rtype = CURLWS_BINARY;
+      else if((meta->flags & CURLWS_PING))
+        rtype = CURLWS_PING;
+      else if((meta->flags & CURLWS_PONG))
+        rtype = CURLWS_PONG;
+      else if((meta->flags & CURLWS_CLOSE))
+        rtype = CURLWS_CLOSE;
+      else {
+        fprintf(stderr, "ws: unknown message type\n");
+        return CURLE_RECV_ERROR;
+      }
+
+      /* if the received message type is different from the previous received
+         type of an incomplete message then that may or may not be an error.
+         websockets allows a control message (PING/PONG/CLOSE) to interrupt a
+         non-control message (TEXT/BINARY). */
+      if(*wstype && *wstype != rtype) {
+        if((*wstype == CURLWS_TEXT || *wstype == CURLWS_BINARY) &&
+           (rtype == CURLWS_PING || rtype == CURLWS_PONG ||
+            rtype == CURLWS_CLOSE)) {
+          /* PING and PONG can be ignored. libcurl auto-replies to PINGs unless
+             raw mode is used. CLOSE should not be ignored. */
+          if(rtype == CURLWS_CLOSE) {
+            websocket_close(curl);
+            fprintf(stderr, "ws: incomplete message interrupted by close\n");
+            return CURLE_RECV_ERROR;
+          }
+          continue;
+        }
+        fprintf(stderr, "ws: incomplete message interrupted by bad type\n");
+        return CURLE_RECV_ERROR;
+      }
+
+      *written += rlen;
+      *wstype = rtype;
+
+      /* the message is incomplete if the current fragment is incomplete
+         (meta->bytesleft) or there are more fragments to come (CURLWS_CONT) */
+      if(meta->bytesleft || (meta->flags & CURLWS_CONT)) {
+        if(*written == bufsize) {
+          fprintf(stderr, "ws: buffer size exceeded\n");
+          /* a more robust way to handle this would be use a dynamic buffer
+             that you can expand here and then continue to append to the
+             incomplete message */
+          return CURLE_OUT_OF_MEMORY;
+        }
+        continue;
+      }
+
+      /* done */
+      break;
+    }
+    else if(result == CURLE_AGAIN) {
+      /* wait indefinitely for the socket to be readable */
+      int sockres = wait_on_socket(sockfd, 1, -1);
+      if(sockres == 1)
+        continue;
+      else {
+        fprintf(stderr, "ws: socket error\n");
+        return CURLE_RECV_ERROR;
+      }
+    }
+    else {
+      fprintf(stderr, "ws: curl_ws_recv failed: (%d) %s\n",
+              result, curl_easy_strerror(result));
+      return CURLE_RECV_ERROR;
+    }
+  }
+
+  fprintf(stderr, "ws: recv_any received a complete message of type %d\n",
+          rtype);
+  return CURLE_OK;
+}
+
+static int recv_header(CURL *curl)
+{
+  CURLcode result;
+  char buffer[256];
+  size_t written;
+  int wstype;
+
+  /* note libcurl auto responds to PINGs unless websocket raw mode is used */
+  do {
+    result = recv_any(curl, buffer, sizeof(buffer), &written, &wstype);
+  } while(!result && (wstype == CURLWS_PING));
+
+  if(!result) {
+    /* echo.websocket.org first non-control message is a TEXT header like:
+       "Request served by xyz123" */
+    if(wstype == CURLWS_TEXT) {
+      fprintf(stderr, "ws: received server header: %.*s\n",
+              (int)written, buffer);
+    }
+    else if(wstype == CURLWS_CLOSE) {
+      websocket_close(curl);
+      fprintf(stderr, "ws: didn't receive server header, "
+              "server sent CLOSE message instead.\n");
+      result = CURLE_RECV_ERROR;
+    }
+    else {
+      fprintf(stderr, "ws: didn't receive server header, "
+              "server sent unexpected message type %d instead.\n",
+              wstype);
+    }
+  }
+  else {
+    fprintf(stderr, "ws: recv_any() failed: (%d) %s\n",
+            result, curl_easy_strerror(result));
+  }
+
+  return (int)result;
+}
+
+static int recv_pong(CURL *curl, const char *expected_payload)
+{
+  CURLcode result;
+  char buffer[256];
+  size_t written;
+  int wstype;
+
+  /* note libcurl auto responds to PINGs unless websocket raw mode is used */
+  do {
+    result = recv_any(curl, buffer, sizeof(buffer), &written, &wstype);
+  } while(!result && (wstype == CURLWS_PING));
+
+  if(!result) {
+    if(wstype == CURLWS_PONG) {
+      fprintf(stderr, "ws: received server PONG: %.*s\n",
+              (int)written, buffer);
+      if(written == strlen(expected_payload) &&
+         !memcmp(expected_payload, buffer, written))
+        fprintf(stderr, "ws: OK: server PONG same as PING payload\n");
+      else
+        fprintf(stderr, "ws: BAD: server PONG is NOT same as PING payload\n");
+    }
+    else if(wstype == CURLWS_CLOSE) {
+      websocket_close(curl);
+      fprintf(stderr, "ws: didn't receive server PONG, "
+              "server sent CLOSE message instead.\n");
+      result = CURLE_RECV_ERROR;
+    }
+    else {
+      fprintf(stderr, "ws: didn't receive server PONG, "
+              "server sent unexpected message type %d instead.\n",
+              wstype);
+    }
+  }
+  else {
+    fprintf(stderr, "ws: recv_any() failed: (%d) %s\n",
+            result, curl_easy_strerror(result));
+  }
+
+  return (int)result;
+}
+
 static void websocket(CURL *curl)
 {
   int i = 0;
+
+  recv_header(curl);
+
   do {
-    recv_any(curl);
     if(ping(curl, "foobar"))
       return;
     if(recv_pong(curl, "foobar")) {
@@ -112,7 +321,7 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
-    curl_easy_setopt(curl, CURLOPT_URL, "wss://example.com");
+    curl_easy_setopt(curl, CURLOPT_URL, "wss://echo.websocket.org");
 
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
 

--- a/docs/libcurl/curl_ws_recv.md
+++ b/docs/libcurl/curl_ws_recv.md
@@ -36,13 +36,26 @@ Retrieves as much as possible of a received WebSocket data fragment into the
 **buffer**, but not more than **buflen** bytes. *recv* is set to the
 number of bytes actually stored.
 
-If there is more fragment data to deliver than what fits in the provided
-*buffer*, libcurl returns a full buffer and the application needs to call
-this function again to continue draining the buffer.
-
 The *meta* pointer gets set to point to a *const struct curl_ws_frame*
 that contains information about the received data. See the
 curl_ws_meta(3) for details on that struct.
+
+If there is more fragment data to deliver than what fits in the provided
+*buffer*, libcurl returns a full buffer. The bytesleft member of *meta*
+indicates how many additional bytes are expected to arrive as part of the
+current fragment. The application needs to call this function again to continue
+to retrieve more bytes.
+
+The call returns **CURLE_AGAIN** if there is no data to read - the socket is
+used in non-blocking mode internally. When **CURLE_AGAIN** is returned, use
+your operating system facilities like *select(2)* to wait for data. The
+socket may be obtained using curl_easy_getinfo(3) with
+CURLINFO_ACTIVESOCKET(3).
+
+Wait on the socket only if curl_ws_recv(3) returns **CURLE_AGAIN**.
+The reason for this is libcurl or the SSL library may internally cache some
+data, therefore you should call curl_ws_recv(3) until all data is
+read which would include any cached data.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/curl_ws_send.md
+++ b/docs/libcurl/curl_ws_send.md
@@ -53,6 +53,16 @@ If **CURLWS_RAW_MODE** is enabled in CURLOPT_WS_OPTIONS(3), the
 To send a message consisting of multiple frames, set the *CURLWS_CONT* bit
 in all frames except the final one.
 
+The call returns **CURLE_AGAIN** if it is not possible to send data right now
+- the socket is used in non-blocking mode internally. When **CURLE_AGAIN**
+is returned, use your operating system facilities like *select(2)* to wait
+until the socket is writable. The socket may be obtained using
+curl_easy_getinfo(3) with CURLINFO_ACTIVESOCKET(3).
+
+Furthermore if you wait on the socket and it tells you it is writable,
+curl_ws_send(3) may return **CURLE_AGAIN** if the only data that was sent
+was for internal SSL processing, and no other data could be sent.
+
 # FLAGS
 
 ## CURLWS_TEXT
@@ -121,3 +131,6 @@ int main(void)
 *CURLE_OK* (zero) means that the data was sent properly, non-zero means an
 error occurred as *\<curl/curl.h\>* defines. See the libcurl-errors(3) man
 page for the full list with descriptions.
+
+This function may return **CURLE_AGAIN**. In this case, use your operating
+system facilities to wait until the socket is writable, and retry.


### PR DESCRIPTION
- Overhaul the recv_any function to block waiting for a complete websocket message from the server.

- Have recv_pong and recv_header call recv_any to retrieve a complete message, rather than duplicate the efforts in each function.

- Fix sleep() macro for Windows to treat the parameter as seconds instead of milliseconds.

- Improve documentation of curl_ws_recv/send to better explain CURLE_AGAIN behavior.

- Use echo.websocket.org instead of example.com as the example websocket server since it is a server the example actually works on.

recv_any now calls curl_ws_recv repeatedly, waiting until the socket is readable and a full websocket message is read from the server.

Prior to this change the example did not handle the non-blocking behavior of curl_ws_recv. When curl_ws_recv returned CURLE_AGAIN the example would fail with "socket not ready".

Fixes https://github.com/curl/curl/issues/13288
Closes #xxxx

---

This is the second take. The first take is in [jay:curl:fix_websocket_example__alternate_take](https://github.com/curl/curl/compare/master...jay:curl:fix_websocket_example__alternate_take). The first take is more thorough because I wrote a blocking function that can return incomplete non-control messages when they are disrupted by a control message. However after I wrote it I thought it was too complicated for the example.

This only fixes the example for recv. Neither take covers partial sends. It's unclear to me what to do in that case. For example let's say curl_ws_send is called to send a PING with a payload of 6 bytes, but when it returns only 5 of the 6 bytes of payload were sent. What is the caller supposed to do in that case, has the PING been sent with just the 5 bytes or is it waiting to send the remaining byte and curl_ws_send has to be called again with offset?