### PR TITLE
ssl: Fix compilation with OpenSSL 1.x with md4 disabled

### DIFF
--- a/lib/md4.c
+++ b/lib/md4.c
@@ -37,6 +37,9 @@
 #if (OPENSSL_VERSION_NUMBER >= 0x30000000L) && !defined(USE_AMISSL)
 /* OpenSSL 3.0.0 marks the MD4 functions as deprecated */
 #define OPENSSL_NO_MD4
+#else
+/* Cover also OPENSSL_NO_MD4 configured in openssl */
+#include <openssl/opensslconf.h>
 #endif
 #endif /* USE_OPENSSL */
 


### PR DESCRIPTION
If OpenSSL 1.x is used, and it is configured with md4 disabled, OPENSSL_NO_MD4 is defined in opensslconf.h, but this header was not included before checking for this define.

Later in md4.c, openssl/md4.h is included, and it includes that header indirectly, leading to inconsistency within md4.c.

Since the md4.h branch was taken, wincrypt.h (or others) is not included, and later below the USE_WIN32_CRYPTO branch is taken, but the types are not defined.