### PR TITLE
GHA/windows: enable libssh in !ssl MSVC job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -530,12 +530,16 @@ jobs:
           tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
           config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DUSE_NGHTTP2=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_HTTPSRR=ON -DUSE_ECH=ON'
         - name: '!ssl'
-          install: 'brotli zlib zstd libpsl pkgconf libidn2'
+          install: 'brotli zlib zstd libpsl pkgconf libidn2 libssh'
           arch: 'x64'
           plat: 'windows'
           type: 'Debug'
           tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DHTTP_ONLY=ON -DUSE_LIBIDN2=ON'
+          # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
+          #          read its configuration from, making it vulnerable to attacks on
+          #          Windows. Do not use this component till there is a fix for these.
+          # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
+          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DHTTP_ONLY=ON -DUSE_LIBIDN2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON'
         - name: 'wolfssl'
           install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl'
           arch: 'x64'


### PR DESCRIPTION
GHA/windows: add MSVC libssh to openssl job