### PR TITLE
getparam: make --rate accept "number of units"

### DIFF
--- a/docs/cmdline-opts/rate.md
+++ b/docs/cmdline-opts/rate.md
@@ -40,3 +40,7 @@ more than 1000 per second, it instead runs unrestricted.
 
 When retrying transfers, enabled with --retry, the separate retry delay logic
 is used and not this setting.
+
+Starting in version 8.10.0, you can specify number of time units in the rate
+expression. Make curl do no more than 5 transfers per 15 seconds with "5/15s"
+or limit it to 3 transfers per 4 hours with "3/4h".

--- a/docs/cmdline-opts/rate.md
+++ b/docs/cmdline-opts/rate.md
@@ -43,4 +43,4 @@ is used and not this setting.
 
 Starting in version 8.10.0, you can specify number of time units in the rate
 expression. Make curl do no more than 5 transfers per 15 seconds with "5/15s"
-or limit it to 3 transfers per 4 hours with "3/4h".
+or limit it to 3 transfers per 4 hours with "3/4h". No spaces allowed.

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1230,6 +1230,20 @@ static ParameterError set_rate(struct GlobalConfig *global,
 
   if(div) {
     char unit = div[1];
+    curl_off_t numunits;
+    char *endp;
+
+    if(curlx_strtoofft(&div[1], &endp, 10, &numunits)) {
+      /* if it fails, there is no legit number specified */
+      if(endp == &div[1])
+        /* if endp did not move, accept it as a 1 */
+        numunits = 1;
+      else
+        return PARAM_BAD_USE;
+    }
+    else
+      unit = *endp;
+
     switch(unit) {
     case 's': /* per second */
       numerator = 1000;
@@ -1247,6 +1261,13 @@ static ParameterError set_rate(struct GlobalConfig *global,
       err = PARAM_BAD_USE;
       break;
     }
+
+    if((LONG_MAX / numerator) < numunits) {
+      /* overflow, too large number */
+      errorf(global, "too large --rate unit");
+      err = PARAM_NUMBER_TOO_LARGE;
+    }
+    numerator *= numunits;
   }
 
   if(err)

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1267,7 +1267,8 @@ static ParameterError set_rate(struct GlobalConfig *global,
       errorf(global, "too large --rate unit");
       err = PARAM_NUMBER_TOO_LARGE;
     }
-    numerator *= numunits;
+    /* this typecast is okay based on the check above */
+    numerator *= (long)numunits;
   }
 
   if(err)


### PR DESCRIPTION
Do no more than 5 transfers per 15 seconds with "5/15s" or limit it to 3 transfers per 4 hours with "3/4h" etc.

Previously it would always only work with a single time unit.

Ref: #14242