### PR TITLE
tool_cb_prg: output "flying saucers" with leading carriage return

### DIFF
--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -77,19 +77,19 @@ static void fly(struct ProgressData *bar, bool moved)
 
   /* bar->width is range checked when assigned */
   DEBUGASSERT(bar->width <= MAX_BARLENGTH);
-  memset(buf, ' ', bar->width);
-  buf[bar->width] = '\r';
+  buf[0] = '\r';
+  memset(&buf[1], ' ', bar->width);
   buf[bar->width + 1] = '\0';
 
-  memcpy(&buf[bar->bar], "-=O=-", 5);
+  memcpy(&buf[bar->bar + 1], "-=O=-", 5);
 
-  pos = sinus[bar->tick%200] / (1000000 / check);
+  pos = sinus[bar->tick%200] / (1000000 / check) + 1;
   buf[pos] = '#';
-  pos = sinus[(bar->tick + 5)%200] / (1000000 / check);
+  pos = sinus[(bar->tick + 5)%200] / (1000000 / check) + 1;
   buf[pos] = '#';
-  pos = sinus[(bar->tick + 10)%200] / (1000000 / check);
+  pos = sinus[(bar->tick + 10)%200] / (1000000 / check) + 1;
   buf[pos] = '#';
-  pos = sinus[(bar->tick + 15)%200] / (1000000 / check);
+  pos = sinus[(bar->tick + 15)%200] / (1000000 / check) + 1;
   buf[pos] = '#';
 
   fputs(buf, bar->out);


### PR DESCRIPTION
Because that is how the progress-bar is output, so when the progress-bar has been shown at least once and the information is reset, like for a redirect, there might be a moment where the size goes from known to unknown and then the flying saucerts are shown after a brief display of the progress-bar.

It could previously cause accidental character leftovers on the right side of the bar when using a narrow display.

Reported-by: Chris Webb
Fixes #14213