### PR TITLE
connection shutdown, multi_socket handling

### DIFF
--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -84,6 +84,15 @@ void Curl_multiuse_state(struct Curl_easy *data,
 
 void Curl_multi_closed(struct Curl_easy *data, curl_socket_t s);
 
+/* Compare the two pollsets to notify the multi_socket API of changes
+ * in socket polling, e.g calling multi->socket_cb() with the changes if
+ * differences are seen.
+ */
+CURLMcode Curl_multi_pollset_ev(struct Curl_multi *multi,
+                                struct Curl_easy *data,
+                                struct easy_pollset *ps,
+                                struct easy_pollset *last_ps);
+
 /*
  * Add a handle and move it into PERFORM state at once. For pushed streams.
  */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -854,6 +854,9 @@ struct connectdata {
     struct curltime start[2]; /* when filter shutdown started */
     unsigned int timeout_ms; /* 0 means no timeout */
   } shutdown;
+  /* Last pollset used in connection shutdown. Used to detect changes
+   * for multi_socket API. */
+  struct easy_pollset shutdown_poll;
 
   struct ssl_primary_config ssl_config;
 #ifndef CURL_DISABLE_PROXY


### PR DESCRIPTION
- implement the socket hash user/reader/writer processing also for connections that are being shut down by the connection cache.
- split out handling of current vs. last pollset socket event handling into a function available in other code parts
- add `shutdown_poll` pollset to `connectdata` struct so that changes in the pollset can be recorded during shutdown. (The internal handle cannot keep it since it might be used for many connections)