### PR TITLE
docs/libcurl: add to cleanup docs that their inputs go invalid

### DIFF
--- a/docs/libcurl/curl_multi_cleanup.md
+++ b/docs/libcurl/curl_multi_cleanup.md
@@ -28,10 +28,10 @@ CURLMcode curl_multi_cleanup(CURLM *multi_handle);
 
 # DESCRIPTION
 
-Cleans up and removes a whole multi stack. It does not free or touch any
-individual easy handles in any way - they still need to be closed
-individually, using the usual curl_easy_cleanup(3) way. The order of
-cleaning up should be:
+This function is the opposite of curl_multi_init(3). Cleans up and removes a
+whole multi stack. It does not free or touch any individual easy handles in
+any way - they still need to be closed individually, using the usual
+curl_easy_cleanup(3) way. The order of cleaning up should be:
 
 1 - curl_multi_remove_handle(3) before any easy handles are cleaned up
 
@@ -44,6 +44,8 @@ removed
 Passing in a NULL pointer in *multi_handle* makes this function return
 CURLM_BAD_HANDLE immediately with no other action.
 
+Any use of the **multi_handle** after this function has been called and have
+returned, is illegal.
 # %PROTOCOLS%
 
 # EXAMPLE

--- a/docs/libcurl/curl_share_cleanup.md
+++ b/docs/libcurl/curl_share_cleanup.md
@@ -32,6 +32,9 @@ when this function has been called.
 Passing in a NULL pointer in *share_handle* makes this function return
 immediately with no action.
 
+Any use of the **share_handle** after this function has been called and have
+returned, is illegal.
+
 # %PROTOCOLS%
 
 # EXAMPLE

--- a/docs/libcurl/curl_slist_free_all.md
+++ b/docs/libcurl/curl_slist_free_all.md
@@ -31,6 +31,9 @@ linked list.
 Passing in a NULL pointer in *list* makes this function return immediately
 with no action.
 
+Any use of the **list** after this function has been called and have returned,
+is illegal.
+
 # %PROTOCOLS%
 
 # EXAMPLE

--- a/docs/libcurl/curl_url_cleanup.md
+++ b/docs/libcurl/curl_url_cleanup.md
@@ -34,6 +34,9 @@ Frees all the resources associated with the given *CURLU* handle!
 Passing in a NULL pointer in *handle* makes this function return
 immediately with no action.
 
+Any use of the **handle** after this function has been called and have
+returned, is illegal.
+
 # %PROTOCOLS%
 
 # EXAMPLE


### PR DESCRIPTION
Reported-by: icy17 on github
Fixes #14248