### PR TITLE
lib: survive some NULL input args

### DIFF
--- a/lib/escape.c
+++ b/lib/escape.c
@@ -60,7 +60,7 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
   struct dynbuf d;
   (void)data;
 
-  if(inlength < 0)
+  if(!string || (inlength < 0))
     return NULL;
 
   Curl_dyn_init(&d, CURL_MAX_INPUT_LENGTH * 3);
@@ -181,7 +181,7 @@ char *curl_easy_unescape(struct Curl_easy *data, const char *string,
 {
   char *str = NULL;
   (void)data;
-  if(length >= 0) {
+  if(string && (length >= 0)) {
     size_t inputlen = (size_t)length;
     size_t outputlen;
     CURLcode res = Curl_urldecode(string, inputlen, &str, &outputlen,

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2778,7 +2778,8 @@ CURLMcode curl_multi_perform(struct Curl_multi *multi, int *running_handles)
     }
   } while(t);
 
-  *running_handles = (int)multi->num_alive;
+  if(running_handles)
+    *running_handles = (int)multi->num_alive;
 
   if(CURLM_OK >= returncode)
     returncode = Curl_update_timer(multi);
@@ -3302,7 +3303,8 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
   if(first)
     sigpipe_restore(&pipe_st);
 
-  *running_handles = (int)multi->num_alive;
+  if(running_handles)
+    *running_handles = (int)multi->num_alive;
   return result;
 }
 


### PR DESCRIPTION
The input string pointer to:

curl_escape
curl_easy_escape
curl_unescape
curl_easy_unescape

The running_handles pointer to:

curl_multi_perform
curl_multi_socket_action
curl_multi_socket_all
curl_multi_socket

Fixes #14247