### PR TITLE
Curl_rand_bytes to control env override

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1464,7 +1464,7 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   /* simulate network blocking/partial writes */
   if(ctx->wblock_percent > 0) {
     unsigned char c = 0;
-    Curl_rand(data, &c, 1);
+    Curl_rand_bytes(data, FALSE, &c, 1);
     if(c >= ((100-ctx->wblock_percent)*256/100)) {
       CURL_TRC_CF(data, cf, "send(len=%zu) SIMULATE EWOULDBLOCK", orig_len);
       *err = CURLE_AGAIN;

--- a/lib/rand.h
+++ b/lib/rand.h
@@ -24,7 +24,17 @@
  *
  ***************************************************************************/
 
-CURLcode Curl_rand(struct Curl_easy *data, unsigned char *rnd, size_t num);
+CURLcode Curl_rand_bytes(struct Curl_easy *data,
+#ifdef DEBUGBUILD
+                         bool allow_env_override,
+#endif
+                         unsigned char *rnd, size_t num);
+
+#ifdef DEBUGBUILD
+#define Curl_rand(a,b,c)   Curl_rand_bytes((a), TRUE, (b), (c))
+#else
+#define Curl_rand(a,b,c)   Curl_rand_bytes((a), (b), (c))
+#endif
 
 /*
  * Curl_rand_hex() fills the 'rnd' buffer with a given 'num' size with random


### PR DESCRIPTION
- in DEBUGBUILD, all specifying if true random numbers are desired or simulated ones via CURL_ENTROPY
- allows to use randoms in other DEBUG checks to not interfere with the CURL_ENTROPY
- without this change, any Curl_rand() use will alter results of some AUTHENTICATION methods like DIGEST