### PR TITLE
vtls: stop offering alpn http/1.1 for http2-prior-knowledge

### DIFF
--- a/docs/cmdline-opts/http2-prior-knowledge.md
+++ b/docs/cmdline-opts/http2-prior-knowledge.md
@@ -23,3 +23,7 @@ Issue a non-TLS HTTP requests using HTTP/2 directly without HTTP/1.1 Upgrade.
 It requires prior knowledge that the server supports HTTP/2 straight away.
 HTTPS requests still do HTTP/2 the standard way with negotiated protocol
 version in the TLS handshake.
+
+Since 8.10.0 if this option is set for an HTTPS request then the application
+layer protocol version (ALPN) offered to the server is only HTTP/2. Prior to
+that both HTTP/1.1 and HTTP/2 were offered.

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -73,6 +73,10 @@ prior knowledge that the server supports HTTP/2 straight away. HTTPS requests
 still do HTTP/2 the standard way with negotiated protocol version in the TLS
 handshake. (Added in 7.49.0)
 
+Since 8.10.0 if this option is set for an HTTPS request then the application
+layer protocol version (ALPN) offered to the server is only HTTP/2. Prior to
+that both HTTP/1.1 and HTTP/2 were offered.
+
 ## CURL_HTTP_VERSION_3
 
 (Added in 7.66.0) This option makes libcurl attempt to use HTTP/3 to the host

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -138,6 +138,9 @@ static const struct alpn_spec ALPN_SPEC_H11 = {
   { ALPN_HTTP_1_1 }, 1
 };
 #ifdef USE_HTTP2
+static const struct alpn_spec ALPN_SPEC_H2 = {
+  { ALPN_H2 }, 1
+};
 static const struct alpn_spec ALPN_SPEC_H2_H11 = {
   { ALPN_H2, ALPN_HTTP_1_1 }, 2
 };
@@ -148,6 +151,8 @@ static const struct alpn_spec *alpn_get_spec(int httpwant, bool use_alpn)
   if(!use_alpn)
     return NULL;
 #ifdef USE_HTTP2
+  if(httpwant == CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE)
+    return &ALPN_SPEC_H2;
   if(httpwant >= CURL_HTTP_VERSION_2)
     return &ALPN_SPEC_H2_H11;
 #else


### PR DESCRIPTION
- For HTTPS if http2-prior-knowledge is set then only offer h2 (HTTP/2) alpn to the server for protocol negotiation.

Prior to this change both HTTP/2 ("h2") and HTTP/1.1 ("http/1.1") were offered for ALPN when http2-prior-knowledge was set.

CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE (tool: --http2-prior-knowledge) is meant to send non-TLS HTTP requests HTTP/2 when it is known the server supports them. However when HTTPS is used then it attempts to first negotiate the connection with ALPN. In that case the user likely does not want to offer http/1.1 to the server as an acceptable protocol.

Reported-by: kit-ty-kate@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/9963
Closes #xxxxx