### PR TITLE
Support __ss_family use on NonStop platforms.

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -157,7 +157,11 @@ static int get_address_family(curl_socket_t sockfd)
   struct sockaddr_storage addr;
   socklen_t addrlen = sizeof(addr);
   if(getsockname(sockfd, (struct sockaddr *)&addr, &addrlen) == 0)
+# ifdef __TANDEM
+    return addr.__ss_family;
+# else
     return addr.ss_family;
+# endif
   return AF_UNSPEC;
 }
 #endif


### PR DESCRIPTION
The definition of sockaddr_storage incorrectly specifies the ss_family field as __ss_family. This fix conditionally allows builds to succeed on all NonStop platforms.