### PR TITLE
curl.h: lower happy eyeballs timeout from 200ms to 40ms

### DIFF
--- a/docs/cmdline-opts/happy-eyeballs-timeout-ms.md
+++ b/docs/cmdline-opts/happy-eyeballs-timeout-ms.md
@@ -25,4 +25,6 @@ first connection to be established is the one that is used.
 The range of suggested useful values is limited. Happy Eyeballs RFC 6555 says
 "It is RECOMMENDED that connection attempts be paced 150-250 ms apart to
 balance human factors against network load." libcurl currently defaults to
-200 ms. Firefox and Chrome currently default to 300 ms.
+40 ms.
+
+(Up until curl 8.9.0, curl's default was 200ms.)

--- a/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md
@@ -34,14 +34,14 @@ milliseconds. If the IPv6 address cannot be connected to within that time then
 a connection attempt is made to the IPv4 address in parallel. The first
 connection to be established is the one that is used.
 
-The range of suggested useful values for *timeout* is limited. Happy
-Eyeballs RFC 6555 says "It is RECOMMENDED that connection attempts be paced
-150-250 ms apart to balance human factors against network load." libcurl
-currently defaults to 200 ms. Firefox and Chrome currently default to 300 ms.
+The range of suggested useful values for *timeout* is limited. Happy Eyeballs
+RFC 6555 says "It is RECOMMENDED that connection attempts be paced 150-250 ms
+apart to balance human factors against network load." libcurl currently
+defaults to 40 ms.
 
 # DEFAULT
 
-CURL_HET_DEFAULT (currently defined as 200L)
+CURL_HET_DEFAULT (defined as 40L)
 
 # %PROTOCOLS%
 
@@ -64,6 +64,10 @@ int main(void)
 ~~~
 
 # %AVAILABILITY%
+
+# HISTORY
+
+Up until curl 8.9.0, libcurl's default was 200ms.
 
 # RETURN VALUE
 

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -941,9 +941,9 @@ typedef enum {
 #define CURLSSLOPT_AUTO_CLIENT_CERT (1<<5)
 
 /* The default connection attempt delay in milliseconds for happy eyeballs.
-   CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.3 and happy-eyeballs-timeout-ms.d document
-   this value, keep them in sync. */
-#define CURL_HET_DEFAULT 200L
+   CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md and happy-eyeballs-timeout-ms.md
+   document this value, keep them in sync. */
+#define CURL_HET_DEFAULT 40L
 
 /* The default connection upkeep interval in milliseconds. */
 #define CURL_UPKEEP_INTERVAL_DEFAULT 60000L


### PR DESCRIPTION
- because if IPv6 is somehow not working correctly or quickly, we want the IPv4 attempt to kick in and cover for the issue

- this is for example notable on Windows where failing to connect to a non-listening port can take way longer than 200 milliseconds even on localhost

A downside with more aggressive shorter timeout is that libcurl is likely to do parallel connects more frequently. (thus using more resources in the client side but possibly also in the server side)