### PR TITLE
macos: fix Apple SDK bug workaround for non-macOS targets

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -71,7 +71,9 @@
    the necessary dynamic detection features, so the SDK falls back to
    a codepath that sets both the old and new macro to 1. */
 #if defined(TARGET_OS_MAC) && TARGET_OS_MAC && \
-  defined(TARGET_OS_OSX) && !TARGET_OS_OSX
+  defined(TARGET_OS_OSX) && !TARGET_OS_OSX && \
+  (!defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE) && \
+  (!defined(TARGET_OS_SIMULATOR) || !TARGET_OS_SIMULATOR)
 #undef TARGET_OS_OSX
 #define TARGET_OS_OSX TARGET_OS_MAC
 #endif


### PR DESCRIPTION
Turns out that MAC != OSX, despite what these names otherwise mean and
what's suggested by source code comments. "MAC" in fact means Darwin
(aka Apple), not macOS. "OSX" means macOS.

GitHub bumped the macos-14 runner default to Xcode 15.4, hitting the
llvm@15 incompatibility bug by default. Meaning the previous workaround
for the SDK bug is necessary.

This patch extend the workaround to not apply to mobile OS variants.

Follow-up to ff784af461175584c73e7e2b65af00b1a5a6f67f #14159
Fixes #14269
Closes #14275

---

CI fails without ff784af461175584c73e7e2b65af00b1a5a6f67f in place:
https://github.com/curl/curl/actions/runs/10102407245
