### PR TITLE
wolfssl, x509 store share fix

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -601,7 +601,7 @@ CURLcode Curl_wssl_setup_x509_store(struct Curl_cfilter *cf,
     }
   }
   else {
-   /* We'll never share the CTX's store, use it. */
+   /* We never share the CTX's store, use it. */
    X509_STORE *store = wolfSSL_CTX_get_cert_store(wssl->ctx);
    result = populate_x509_store(cf, data, store, wssl);
   }


### PR DESCRIPTION
When sharing the x509 store in wolfSSL, always use an explicitly constructed one, as the SSLCTX might have "only" an internal one which is not obeying reference count lifetimes.

- refs #14278