### PR TITLE
os400: workaround an IBM ASCII run-time library bug

### DIFF
--- a/lib/setup-os400.h
+++ b/lib/setup-os400.h
@@ -38,6 +38,15 @@ typedef unsigned long   u_int32_t;
 #define isatty(fd)      0
 
 
+/* Workaround bug in IBM QADRT runtime library:
+ * function puts() does not output the implicit trailing newline.
+ */
+
+#include <stdio.h>      /* Be sure it is loaded. */
+#undef puts
+#define puts(s) (fputs((s), stdout) == EOF? EOF: putchar('\n'))
+
+
 /* System API wrapper prototypes & definitions to support ASCII parameters. */
 
 #include <sys/socket.h>

--- a/packages/OS400/README.OS400
+++ b/packages/OS400/README.OS400
@@ -226,8 +226,7 @@ in fact, very few common utilities are available. As a consequence, the
 config-os400.h has been coded manually and the compilation scripts are
 a set of shell scripts stored in subdirectory packages/OS400.
 
-  The "curl" command and the test environment are currently not supported on
-OS/400.
+  The test environment is currently not supported on OS/400.
 
 
 Protocols currently implemented on OS/400:


### PR DESCRIPTION
IBM-provided ASCII function puts() does not output an expected trailing newline: emulate the correct behavior using other functions.