### PR TITLE
runtests: fold timing details with GHA, sync `-r` tflags

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -127,7 +127,7 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -rm
+TEST_CI = $(TEST_NF) -r -rm
 endif
 
 # make sure that PERL is pointing to an executable

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1983,6 +1983,8 @@ sub runtimestats {
 
     return if(not $timestats);
 
+    logmsg "::group::Run Time Stats\n";
+
     logmsg "\nTest suite total running time breakdown per task...\n\n";
 
     my @timesrvr;
@@ -2109,6 +2111,8 @@ sub runtimestats {
     }
 
     logmsg "\n";
+
+    logmsg "::endgroup::\n";
 }
 
 #######################################################################


### PR DESCRIPTION
- move timing details into a foldable group when run in GitHub Actions.
  Spec:
  https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines

- enable `-r` (run time stats) option in autotools' `test-ci` target,
  syncing it with cmake.

Ref: #14185
Closes #14284

---

Example:
![Screen Shot 2024-07-21 14185](https://github.com/user-attachments/assets/44e214c2-8b55-42ea-a80c-820681e39a33)
