### PR TITLE
os400: build cli manual.

### DIFF
--- a/packages/Makefile.am
+++ b/packages/Makefile.am
@@ -33,6 +33,7 @@ EXTRA_DIST = README.md \
   OS400/curl.inc.in \
   OS400/initscript.sh \
   OS400/config400.default \
+  OS400/make-docs.sh \
   OS400/make-include.sh \
   OS400/make-lib.sh \
   OS400/make-src.sh \

--- a/packages/OS400/config400.default
+++ b/packages/OS400/config400.default
@@ -39,6 +39,7 @@ setenv OUTPUT           '*NONE'                 # Compilation output option.
 setenv TGTRLS           '*CURRENT'              # Target OS release.
 setenv IFSDIR           '/curl'                 # Installation IFS directory.
 setenv QADRTDIR         '/QIBM/ProdData/qadrt'  # QADRT IFS directory.
+setenv PASEPERL         '/QOpenSys/pkgs/bin/perl'       # PASE Perl interpreter.
 
 #       Define ZLIB availability and locations.
 

--- a/packages/OS400/initscript.sh
+++ b/packages/OS400/initscript.sh
@@ -69,6 +69,9 @@ if [ -f "${SCRIPTDIR}/config400.override" ]
 then    . "${SCRIPTDIR}/config400.override"
 fi
 
+#       Check if perl available.
+{ [ -n "${PASEPERL}" ] && [ -x "${PASEPERL}" ]; } || PASEPERL=
+
 #       Need to get the version definitions.
 
 LIBCURL_VERSION=$(grep '^#define  *LIBCURL_VERSION '                    \

--- a/packages/OS400/make-docs.sh
+++ b/packages/OS400/make-docs.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+#
+#       Documentation build script for the OS/400.
+#
+
+
+SCRIPTDIR=$(dirname "${0}")
+. "${SCRIPTDIR}/initscript.sh"
+
+[ -n "${PASEPERL}" ] || exit 0  # Perl needed for doc build.
+cd "${TOPDIR}/docs" || exit 1
+[ -d "${IFSDIR}/docs" ] || mkdir "${IFSDIR}/docs"
+
+
+#       Command line options.
+
+(
+        cd cmdline-opts || exit 1
+        MANPAGE=curl.1
+        TEXTPAGE=curl.txt
+        get_make_vars Makefile.inc
+        rm -f "${IFSDIR}/docs/${MANPAGE}" "${IFSDIR}/docs/${TEXTPAGE}"
+
+        #       Prepare online manual.
+        # shellcheck disable=SC2086
+        ${PASEPERL} "${TOPDIR}/scripts/managen" -c 75                   \
+                listhelp ${DPAGES} > "${TOPDIR}/src/tool_listhelp.c"
+
+        #       Generate text manual and copy it to DB2.
+        # shellcheck disable=SC2086
+        ${PASEPERL} "${TOPDIR}/scripts/managen" -I "${TOPDIR}/include"  \
+               -c 75 ascii ${DPAGES} > "${IFSDIR}/docs/${TEXTPAGE}"
+        MEMBER="${LIBIFSNAME}/DOCS.FILE/MANUAL.MBR"
+        CMD="CPY OBJ('${IFSDIR}/docs/${TEXTPAGE}') TOOBJ('${MEMBER}')"
+        CMD="${CMD} TOCCSID(${TGTCCSID}) DTAFMT(*TEXT) REPLACE(*YES)"
+        CLcommand "${CMD}"
+
+#       Man page is useless as OS/400 has no man command.
+#       # shellcheck disable=SC2086
+#       ${PASEPERL} "${TOPDIR}/scripts/managen" -I "${TOPDIR}/include"  \
+#               mainpage ${DPAGES} > "${IFSDIR}/docs/${MANPAGE}"
+)

--- a/packages/OS400/make-src.sh
+++ b/packages/OS400/make-src.sh
@@ -30,6 +30,15 @@ SCRIPTDIR=$(dirname "${0}")
 cd "${TOPDIR}/src" || exit 1
 
 
+#       Check if built-in manual can be generated.
+
+USE_MANUAL=
+if [ -f "${IFSDIR}/docs/curl.txt" ] && [ -n "${PASEPERL}" ]
+then    "${PASEPERL}" ./mkhelp.pl < "${IFSDIR}/docs/curl.txt" > tool_hugehelp.c
+        USE_MANUAL="'USE_MANUAL'"
+fi
+
+
 #       Get source lists.
 #       CURL_CFILES are in the current directory.
 #       CURLX_CFILES are in the lib directory and need to be recompiled because
@@ -49,12 +58,12 @@ INCLUDES="'${TOPDIR}/lib'"
 for SRC in ${CURLX_CFILES}
 do      MODULE=$(db2_name "${SRC}")
         MODULE=$(db2_name "X${MODULE}")
-        make_module "${MODULE}" "${SRC}"
+        make_module "${MODULE}" "${SRC}" "${USE_MANUAL}"
 done
 
 for SRC in ${CURL_CFILES}
 do      MODULE=$(db2_name "${SRC}")
-        make_module "${MODULE}" "${SRC}"
+        make_module "${MODULE}" "${SRC}" "${USE_MANUAL}"
 done
 
 

--- a/packages/OS400/makefile.sh
+++ b/packages/OS400/makefile.sh
@@ -33,6 +33,18 @@ SCRIPTDIR=$(dirname "${0}")
 cd "${TOPDIR}" || exit 1
 
 
+#       Make sure all files are UTF8-encoded.
+
+# shellcheck disable=SC2038
+find "${TOPDIR}" -type f -print | xargs ls -S | while read -r CCSID FILE
+do      if [ "${CCSID}" != 1208 ]
+        then    CMD="CPY OBJ('${FILE}') TOOBJ('${FILE}') FROMCCSID(*OBJ)"
+                CMD="${CMD} TOCCSID(1208) DTAFMT(*TEXT) REPLACE(*YES)"
+                (CLcommand "${CMD}")
+        fi
+done
+
+
 #       Create the OS/400 library if it does not exist.
 
 if action_needed "${LIBIFSNAME}"
@@ -117,7 +129,7 @@ fi
 
 #       Build in each directory.
 
-# for SUBDIR in include lib src tests
-for SUBDIR in include lib src
+# for SUBDIR in include lib docs src tests
+for SUBDIR in include lib docs src
 do      "${SCRIPTDIR}/make-${SUBDIR}.sh"
 done

--- a/scripts/managen
+++ b/scripts/managen
@@ -1196,6 +1196,12 @@ elsif($cmd eq "-I") {
     $cmd = shift @ARGV;
     goto check;
 }
+elsif($cmd eq "-c") {
+    # Column width
+    $colwidth = 0 + shift @ARGV;
+    $cmd = shift @ARGV;
+    goto check;
+}
 
 my @files = @ARGV; # the rest are the files
 


### PR DESCRIPTION
This is my first attempt to use PASE perl in the build process.

Unfortunately perl does not deal properly with all the various possible OS/400 file encodings , thus I now unconditionally transcode all source files to UTF-8: this might be somewhat lengthy upon first build.

The man page is not built because OS/400 has no man command. However the text version is stored both in DB2 and IFS, and the cli built-in manual is enabled.

See the commit comments for more info.

Please note we're still far from a working test environment. Mainly because forks and execs.