### PR TITLE
cmake: drop `if(PKG_CONFIG_FOUND)` guard for `pkg_check_modules()`

### DIFF
--- a/CMake/FindNettle.cmake
+++ b/CMake/FindNettle.cmake
@@ -30,9 +30,7 @@
 
 if(UNIX)
   find_package(PkgConfig QUIET)
-  if(PKG_CONFIG_FOUND)
-    pkg_check_modules(NETTLE "nettle")
-  endif()
+  pkg_check_modules(NETTLE "nettle")
 endif()
 
 if(NETTLE_FOUND)


### PR DESCRIPTION
The oldest cmake supported by curl is v3.7.0, which already has such
guard (using `PKG_CONFIG_EXECUTABLE`) inside `pkg_check_modules()`. The
advantage of leaving that guard to CMake is that it will define/reset
all output variables, while the manual guard doesn't do this and also
leaves for example `NETTLE_FOUND` undefined.

Delete the single use of this guard from the recently added `nettle`
detection, where I included it by accident. Then possibly re-introduce
it universally if we find it useful after more evaluation.

Follow-up to 669ce42275635dc1f881dab3dfc9a55c9ab49b21 #14285
Closes #14309
