### PR TITLE
GHA/non-native: bump FreeBSD/arm64 python modules

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -130,13 +130,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            pkgs='autoconf automake libtool pkgconf brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel'
-            if [ '${{ matrix.arch }}' = 'x86_64' ]; then
-              pkgs="${pkgs} py311-openssl py311-impacket py311-cryptography"
-            else
-              pkgs="${pkgs} py39-openssl py39-impacket py39-cryptography"
-            fi
-            sudo pkg install -y ${pkgs}
+            sudo pkg install -y autoconf automake libtool pkgconf brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel py311-openssl py311-impacket py311-cryptography
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
@@ -164,13 +158,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            pkgs='cmake pkgconf brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel'
-            if [ '${{ matrix.arch }}' = 'x86_64' ]; then
-              pkgs="${pkgs} py311-openssl py311-impacket py311-cryptography"
-            else
-              pkgs="${pkgs} py39-openssl py39-impacket py39-cryptography"
-            fi
-            sudo pkg install -y ${pkgs}
+            sudo pkg install -y cmake pkgconf brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel py311-openssl py311-impacket py311-cryptography
             cmake -B bld \
               '-DCMAKE_C_COMPILER=${{ matrix.compiler }}' \
               -DCMAKE_UNITY_BUILD=ON \


### PR DESCRIPTION
FreeBSD seems to upgrade their Python separately for arm64
and Intel. Today, arm64 caught up with the Intel packages.
Update our CI to reflect it.

Closes #14310

---

Fail example:
https://github.com/curl/curl/actions/runs/10159311198/job/28093281279?pr=14309
