### PR TITLE
Ensure all tests pass with rustls backend

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CRLFILE.md
+++ b/docs/libcurl/opts/CURLOPT_CRLFILE.md
@@ -14,6 +14,7 @@ TLS-backend:
   - GnuTLS
   - mbedTLS
   - OpenSSL
+  - rustls
 Added-in: 7.19.0
 ---
 

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -403,22 +403,6 @@ cr_verify_none(void *userdata UNUSED_PARAM,
   return RUSTLS_RESULT_OK;
 }
 
-static bool
-cr_hostname_is_ip(const char *hostname)
-{
-  struct in_addr in;
-#ifdef USE_IPV6
-  struct in6_addr in6;
-  if(Curl_inet_pton(AF_INET6, hostname, &in6) > 0) {
-    return true;
-  }
-#endif /* USE_IPV6 */
-  if(Curl_inet_pton(AF_INET, hostname, &in) > 0) {
-    return true;
-  }
-  return false;
-}
-
 static int
 read_file_into(const char *filename,
                struct dynbuf *out)
@@ -458,7 +442,6 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     /* CURLOPT_CAINFO_BLOB overrides CURLOPT_CAINFO */
     (ca_info_blob ? NULL : conn_config->CAfile);
   const bool verifypeer = conn_config->verifypeer;
-  const char *hostname = connssl->peer.hostname;
   char errorbuf[256];
   size_t errorlen;
   rustls_result result;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -462,14 +462,6 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(!verifypeer) {
     rustls_client_config_builder_dangerous_set_certificate_verifier(
       config_builder, cr_verify_none);
-    /* rustls does not support IP addresses (as of 0.19.0), and will reject
-     * connections created with an IP address, even when certificate
-     * verification is turned off. Set a placeholder hostname and disable
-     * SNI. */
-    if(cr_hostname_is_ip(hostname)) {
-      rustls_client_config_builder_set_enable_sni(config_builder, false);
-      hostname = "example.invalid";
-    }
   }
   else if(ca_info_blob || ssl_cafile) {
     roots_builder = rustls_root_cert_store_builder_new();

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -525,6 +525,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     }
 
     verifier_builder = rustls_web_pki_server_cert_verifier_builder_new(roots);
+    rustls_root_cert_store_free(roots);
 
     if(conn_config->CRLfile) {
       struct dynbuf crl_contents;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -562,6 +562,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
 
     rustls_client_config_builder_set_server_verifier(config_builder,
                                                      server_cert_verifier);
+    rustls_server_cert_verifier_free(server_cert_verifier);
   }
 
   backend->config = rustls_client_config_builder_build(config_builder);

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -85,11 +85,6 @@
 2307
 %endif
 2043
-# The CRL test (313) doesn't work with rustls because rustls doesn't support
-# CRLs.
-%if rustls
-313
-%endif
 # The CRL test doesn't work with wolfSSL
 %if wolfssl
 313

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -87,24 +87,8 @@
 2043
 # The CRL test (313) doesn't work with rustls because rustls doesn't support
 # CRLs.
-# Tests that rely on connecting to an IP address over TLS don't work because
-# rustls doesn't support IP address certificates yet. That's the 400 series of
-# tests listed here, plus 1112 and 1272
 %if rustls
 313
-400
-401
-403
-404
-406
-407
-408
-409
-987
-988
-989
-1112
-1272
 %endif
 # The CRL test doesn't work with wolfSSL
 %if wolfssl


### PR DESCRIPTION
The goal of this PR is to remove the rustls stanza in `tests/data/DISABLED` that skips some tests.

That involves supporting CRLs -- we've had upstream support for a little while, but needs some plumbing in here.

This is my first curl PR, so please shout if I've made any beginner errors: but I have run the tests and run `make checksrc`.
