### PR TITLE
dist: add missing `FindNettle.cmake`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -43,6 +43,7 @@ CMAKE_DIST =                                    \
  CMake/FindNGHTTP2.cmake                        \
  CMake/FindNGHTTP3.cmake                        \
  CMake/FindNGTCP2.cmake                         \
+ CMake/FindNettle.cmake                         \
  CMake/FindQUICHE.cmake                         \
  CMake/FindWolfSSL.cmake                        \
  CMake/FindZstd.cmake                           \


### PR DESCRIPTION
Follow-up to 669ce42275635dc1f881dab3dfc9a55c9ab49b21 #14285
Reported-by: Christoph Reiter
Bug: https://github.com/curl/curl/pull/14285#issuecomment-2259880050
Closes #14320
