### PR TITLE
cmake: distcheck for files in CMake subdir

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -129,3 +129,13 @@ jobs:
           cmake -B build -DCURL_WERROR=ON
           make -C build -j5
         name: 'verify out-of-tree cmake build'
+
+  verify-cmake-test-dist:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: 'cmake test dist'
+        run: |
+          cmake -B build -DENABLE_DIST_TEST=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1609,7 +1609,15 @@ endif()
 # Ugly (but functional) way to include "Makefile.inc" by transforming it
 # (= regenerate it).
 function(transform_makefile_inc INPUT_FILE OUTPUT_FILE)
-  file(READ ${INPUT_FILE} MAKEFILE_INC_TEXT)
+  file(STRINGS "${INPUT_FILE}" _makefile_inc_lines)
+  set(MAKEFILE_INC_TEXT "")
+  foreach(_line IN LISTS _makefile_inc_lines)
+    if(_line MATCHES "### USE SIMPLE LIST ASSIGMENTS ABOVE THIS LINE ###")
+      break()
+    endif()
+    set(MAKEFILE_INC_TEXT "${MAKEFILE_INC_TEXT}${_line}\n")
+  endforeach()
+
   string(REPLACE "$(top_srcdir)"   "\${CURL_SOURCE_DIR}" MAKEFILE_INC_TEXT ${MAKEFILE_INC_TEXT})
   string(REPLACE "$(top_builddir)" "\${CURL_BINARY_DIR}" MAKEFILE_INC_TEXT ${MAKEFILE_INC_TEXT})
 
@@ -1652,6 +1660,23 @@ endif()
 
 if(BUILD_TESTING)
   add_subdirectory(tests)
+endif()
+
+# Verify if all CMake include/input files are listed as distributable
+if(ENABLE_DIST_TEST)
+  # Get 'CMAKE_DIST' variable
+  transform_makefile_inc("Makefile.am" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.am.cmake")
+  include(${CMAKE_CURRENT_BINARY_DIR}/Makefile.am.cmake)
+
+  file(GLOB_RECURSE curl_cmake_files_found RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/CMake/*.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/CMake/*.in")
+
+  foreach(_item IN LISTS curl_cmake_files_found)
+    if(NOT _item IN_LIST CMAKE_DIST)
+      message(FATAL_ERROR "Source file missing from the Makefile.am CMAKE_DIST list: ${_item}")
+    endif()
+  endforeach()
 endif()
 
 if(NOT CURL_DISABLE_INSTALL)

--- a/Makefile.am
+++ b/Makefile.am
@@ -93,6 +93,8 @@ DIST_SUBDIRS = $(SUBDIRS) tests packages scripts include docs
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libcurl.pc
 
+### USE SIMPLE LIST ASSIGMENTS ABOVE THIS LINE ### DO NOT DELETE
+
 # List of files required to generate VC IDE .dsp, .vcproj and .vcxproj files
 include lib/Makefile.inc
 include src/Makefile.inc


### PR DESCRIPTION
- add CMake option to verify if the `CMake/*.cmake`, `CMake/*.in` files
  are listed as distributable in autotools' `EXTRA_DIST`. The check can
  be enabled with `-DENABLE_DIST_TEST=ON` CMake option.

- add CI job to that effect.

Ref: #14320
Closes #14323

---

- [x] rebase on #14320

`IN_LIST` is CMake 3.3: https://cmake.org/cmake/help/latest/command/if.html#in-list
