### PR TITLE
src: fix linking with nghttp2 when USE_EXPLICIT_LIB_DEPS isn't set

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2816,6 +2816,7 @@ if test X"$want_nghttp2" != Xno; then
   LDFLAGS="$LDFLAGS $LD_H2"
   CPPFLAGS="$CPPFLAGS $CPP_H2"
   LIBS="$LIB_H2 $LIBS"
+  AC_SUBST(LIB_H2)
 
   # use nghttp2_session_get_stream_local_window_size to require nghttp2
   # >= 1.15.0

--- a/configure.ac
+++ b/configure.ac
@@ -2816,7 +2816,6 @@ if test X"$want_nghttp2" != Xno; then
   LDFLAGS="$LDFLAGS $LD_H2"
   CPPFLAGS="$CPPFLAGS $CPP_H2"
   LIBS="$LIB_H2 $LIBS"
-  AC_SUBST(LIB_H2)
 
   # use nghttp2_session_get_stream_local_window_size to require nghttp2
   # >= 1.15.0
@@ -2838,7 +2837,9 @@ if test X"$want_nghttp2" != Xno; then
       LDFLAGS=$CLEANLDFLAGS
       CPPFLAGS=$CLEANCPPFLAGS
       LIBS=$CLEANLIBS
+      LIB_H2=
   )
+  AC_SUBST(LIB_H2)
 fi
 
 dnl **********************************************************************

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -70,7 +70,7 @@ LIBS = $(BLANK_AT_MAKETIME)
 if USE_EXPLICIT_LIB_DEPS
 curl_LDADD = $(top_builddir)/lib/libcurl.la @LIBCURL_LIBS@
 else
-curl_LDADD = $(top_builddir)/lib/libcurl.la @SSL_LIBS@ @ZLIB_LIBS@ @CURL_NETWORK_AND_TIME_LIBS@
+curl_LDADD = $(top_builddir)/lib/libcurl.la @LIB_H2@ @SSL_LIBS@ @ZLIB_LIBS@ @CURL_NETWORK_AND_TIME_LIBS@
 endif
 
 # if unit tests are enabled, build a static library to link them with


### PR DESCRIPTION
This PR fixes linking error when attempting to build libcurl with `--with-nghttp2`

While other dependencies are explicitly provided, `LIB_H2` isn't, which causes the build to fail with
```
/opt/toolchains/bin/../lib/gcc/x86_64-unknown-linux-gnu/11.4.0/../../../../x86_64-unknown-linux-gnu/bin/ld.bfd: ../lib/.libs/libcurl.so: undefined reference to `nghttp2_session_consume'
```
and a bunch of other missing symbols from `libnghttp2`

Full disclosure, I'm not 100% sure this is the correct fix. For starters, I'm surprised this was unnoticed given this was introduced many years ago.
I had this issue while attempting to bump a toolchain from a quite old gcc to a more recent one. I suspect the linker behavior changed and it's not defaulting to implicitly linking with the entries in `DT_NEEDED`, but this is rather blurry to me.

Thanks in advance for your review!