### PR TITLE
dist: fix reprodicible builds

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -35,8 +35,8 @@ jobs:
       - run: ./configure --without-ssl --without-libpsl
         name: 'configure'
 
-      - run: make V=1 && make V=1 clean
-        name: 'make and clean'
+      - run: make V=1
+        name: 'make'
 
       - name: 'maketgz'
         run: |
@@ -45,7 +45,7 @@ jobs:
       - name: 'maketgz reproducibility test'
         run: |
           mkdir run1; mv ./curl-99.98.97.* run1/
-          make V=1 && make V=1 clean
+          make V=1 clean && make V=1
           SOURCE_DATE_EPOCH=1711526400 ./maketgz 99.98.97
           mkdir run2; cp -p ./curl-99.98.97.* run2/
           diff run1 run2

--- a/Makefile.am
+++ b/Makefile.am
@@ -101,8 +101,8 @@ include src/Makefile.inc
 
 dist-hook:
 	rm -rf $(top_builddir)/tests/log
-	find $(distdir) -name "*.dist" -exec rm {} \;
-	(distit=`find $(srcdir) -name "*.dist" | grep -v ./ares/`; \
+	find $(distdir) -name "*.dist" -a \! -name Makefile.dist -exec rm {} \;
+	(distit=`find $(srcdir) -name "*.dist"`; \
 	for file in $$distit; do \
 	  strip=`echo $$file | sed -e s/^$(srcdir)// -e s/\.dist//`; \
 	  cp -p $$file $(distdir)$$strip; \

--- a/maketgz
+++ b/maketgz
@@ -87,7 +87,7 @@ datestamp=$(date -d "@$timestamp" +"%F")
 filestamp=$(date -d "@$timestamp" +"%Y%m%d%H%M.%S")
 
 # Replace version number in header file:
-sed -i.bak \
+sed -i \
   -e "s/^#define LIBCURL_VERSION .*/#define LIBCURL_VERSION \"$libversion\"/g" \
   -e "s/^#define LIBCURL_VERSION_NUM .*/#define LIBCURL_VERSION_NUM 0x$numeric/g" \
   -e "s/^#define LIBCURL_VERSION_MAJOR .*/#define LIBCURL_VERSION_MAJOR $major/g" \
@@ -95,11 +95,9 @@ sed -i.bak \
   -e "s/^#define LIBCURL_VERSION_PATCH .*/#define LIBCURL_VERSION_PATCH $patch/g" \
   -e "s/^#define LIBCURL_TIMESTAMP .*/#define LIBCURL_TIMESTAMP \"$datestamp\"/g" \
   "$HEADER"
-rm -f "$HEADER.bak"
 
 # Replace version number in header file:
-sed -i.bak "s/#define CURL_VERSION .*/#define CURL_VERSION \"$curlversion\"/g" "$CHEADER"
-rm -f "$CHEADER.bak"
+sed -i "s/#define CURL_VERSION .*/#define CURL_VERSION \"$curlversion\"/g" "$CHEADER"
 
 if test -n "$only"; then
   # done!
@@ -132,6 +130,11 @@ findprog() {
 
 echo "Re-running config.status"
 ./config.status --recheck >/dev/null
+
+echo "Recreate the built-in manual (with correct version)"
+export CURL_MAKETGZ_VERSION="$version"
+rm -f docs/cmdline-opts/curl.txt
+make -C src
 
 ############################################################################
 #

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -24,7 +24,7 @@
 
 EXTRA_DIST = coverage.sh completion.pl firefox-db2pem.sh checksrc.pl    \
  mk-ca-bundle.pl schemetable.c cd2nroff nroff2cd cdall cd2cd managen \
- dmaketgz
+ dmaketgz release-tools.sh
 
 ZSH_FUNCTIONS_DIR = @ZSH_FUNCTIONS_DIR@
 FISH_FUNCTIONS_DIR = @FISH_FUNCTIONS_DIR@

--- a/scripts/managen
+++ b/scripts/managen
@@ -1205,14 +1205,20 @@ elsif($cmd eq "-c") {
 
 my @files = @ARGV; # the rest are the files
 
-open(INC, "<$include/curl/curlver.h");
-while(<INC>) {
-    if($_ =~ /^#define LIBCURL_VERSION \"([0-9.]*)/) {
-        $version = $1;
-        last;
-    }
+# can be overriden for releases
+if($ENV{'CURL_MAKETGZ_VERSION'}) {
+    $version = $ENV{'CURL_MAKETGZ_VERSION'};
 }
-close(INC);
+else {
+    open(INC, "<$include/curl/curlver.h");
+    while(<INC>) {
+        if($_ =~ /^#define LIBCURL_VERSION \"([0-9.]*)/) {
+            $version = $1;
+            last;
+        }
+    }
+    close(INC);
+}
 
 # learn all existing options
 indexoptions($dir, @files);


### PR DESCRIPTION
Make it possible to rebuild an identical copy from a tarball

- add release-tools.sh to dist
- keep Makefile.dist around to include it in dist
- regenerate tool_huge.c with the new version in dist