### PR TITLE
escape: allow curl_easy_escape to generate 3*input length output

### DIFF
--- a/lib/escape.c
+++ b/lib/escape.c
@@ -63,11 +63,11 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
   if(!string || (inlength < 0))
     return NULL;
 
-  Curl_dyn_init(&d, inlength * 3);
-
   length = (inlength?(size_t)inlength:strlen(string));
   if(!length)
     return strdup("");
+
+  Curl_dyn_init(&d, length * 3);
 
   while(length--) {
     /* treat the characters unsigned */

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -63,7 +63,7 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
   if(!string || (inlength < 0))
     return NULL;
 
-  Curl_dyn_init(&d, CURL_MAX_INPUT_LENGTH * 3);
+  Curl_dyn_init(&d, inlength * 3);
 
   length = (inlength?(size_t)inlength:strlen(string));
   if(!length)

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -67,7 +67,7 @@ char *curl_easy_escape(struct Curl_easy *data, const char *string,
   if(!length)
     return strdup("");
 
-  Curl_dyn_init(&d, length * 3);
+  Curl_dyn_init(&d, length * 3 + 1);
 
   while(length--) {
     /* treat the characters unsigned */


### PR DESCRIPTION
Instead of capping it to the 3 * CURL_MAX_INPUT_LENGTH. To allow users to URL encode larger chunks of data.