### PR TITLE
verify-release is a new script to "verify" a release tarball

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -139,3 +139,21 @@ jobs:
       - name: 'cmake test dist'
         run: |
           cmake -B build -DENABLE_DIST_TEST=ON
+
+  reproducible-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - run: sudo apt-get purge -y curl libcurl4 libcurl4-doc
+        name: 'remove preinstalled curl libcurl4{-doc}'
+
+      - run: ./scripts/dmaketgz 9.10.11
+        name: 'generate release tarballs'
+
+      - name: 'verify release tarballs'
+        run: |
+          mkdir _verify
+          mv curl-9.10.11.tar.gz _verify
+          cd _verify
+          ../scripts/verify-release curl-9.10.11.tar.gz

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -42,14 +42,6 @@ jobs:
         run: |
           SOURCE_DATE_EPOCH=1711526400 ./maketgz 99.98.97
 
-      - name: 'maketgz reproducibility test'
-        run: |
-          mkdir run1; mv ./curl-99.98.97.* run1/
-          make V=1 clean && make V=1
-          SOURCE_DATE_EPOCH=1711526400 ./maketgz 99.98.97
-          mkdir run2; cp -p ./curl-99.98.97.* run2/
-          diff run1 run2
-
       - uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4
         with:
           name: 'release-tgz'

--- a/Makefile.am
+++ b/Makefile.am
@@ -88,7 +88,7 @@ CLEANFILES = $(VC14_LIBVCXPROJ) $(VC14_SRCVCXPROJ) \
 bin_SCRIPTS = curl-config
 
 SUBDIRS = lib docs src scripts
-DIST_SUBDIRS = $(SUBDIRS) tests packages scripts include docs
+DIST_SUBDIRS = $(SUBDIRS) tests packages include docs
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libcurl.pc
@@ -102,7 +102,7 @@ include src/Makefile.inc
 dist-hook:
 	rm -rf $(top_builddir)/tests/log
 	find $(distdir) -name "*.dist" -a \! -name Makefile.dist -exec rm {} \;
-	(distit=`find $(srcdir) -name "*.dist"`; \
+	(distit=`find $(srcdir) -name "*.dist" | grep -v Makefile`; \
 	for file in $$distit; do \
 	  strip=`echo $$file | sed -e s/^$(srcdir)// -e s/\.dist//`; \
 	  cp -p $$file $(distdir)$$strip; \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -24,7 +24,7 @@
 
 EXTRA_DIST = coverage.sh completion.pl firefox-db2pem.sh checksrc.pl    \
  mk-ca-bundle.pl schemetable.c cd2nroff nroff2cd cdall cd2cd managen \
- dmaketgz release-tools.sh
+ dmaketgz release-tools.sh verify-release
 
 ZSH_FUNCTIONS_DIR = @ZSH_FUNCTIONS_DIR@
 FISH_FUNCTIONS_DIR = @FISH_FUNCTIONS_DIR@

--- a/scripts/dmaketgz
+++ b/scripts/dmaketgz
@@ -30,20 +30,22 @@ set -eu
 version="${1:-}"
 
 if [ -z "$version" ]; then
-  echo "Specify a version number!"
-  exit
+    echo "Specify a version number!"
+    exit
 fi
 
 timestamp="${2:-$(date -u +%s)}"
 
-make distclean
+if test -f Makefile; then
+    make distclean
+fi
 docker build \
        --build-arg SOURCE_DATE_EPOCH="$timestamp" \
        --build-arg UID="$(id -u)" \
        --build-arg GID="$(id -g)" \
        -t curl/curl .
 
-docker run --rm -it -u "$(id -u):$(id -g)" \
+docker run --rm -u "$(id -u):$(id -g)" \
        -v "$(pwd):/usr/src" -w /usr/src curl/curl sh -c "
   set -e
   autoreconf -fi

--- a/scripts/verify-release
+++ b/scripts/verify-release
@@ -1,0 +1,80 @@
+#!/bin/sh
+
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# This script remakes a provided curl release and verifies that the newly
+# built version is identical to the original file.
+#
+# It is designed to be invoked in a clean directory with the path to the
+# release tarball as an argument.
+#
+
+set -eu
+
+tarball="${1:-}"
+
+if [ -z "$tarball" ]; then
+    echo "Provide a curl release tarball name as argument"
+    exit
+fi
+
+i="0"
+
+# shellcheck disable=SC2034
+for dl in curl-*; do
+    i=$((i + 1))
+done
+
+if test "$i" -gt 1; then
+    echo "multiple curl-* entries found, disambiguate please"
+    exit
+fi
+
+mkdir -p _tarballs
+rm -rf _tarballs/*
+
+# checksum the original tarball to compare with later
+sha256sum "$tarball" >_tarballs/checksum
+
+# extract the release contents
+tar xf "$tarball"
+
+curlver=$(grep '#define LIBCURL_VERSION ' curl-*/include/curl/curlver.h | sed 's/[^0-9.]//g')
+
+echo "version $curlver"
+
+timestamp=$(grep -Eo 'SOURCE_DATE_EPOCH=[0-9]*' curl-"$curlver"/docs/RELEASE-TOOLS.md | cut -d= -f2)
+
+pwd=$(pwd)
+cd "curl-$curlver"
+./configure --without-ssl
+./scripts/dmaketgz "$curlver" "$timestamp"
+
+mv curl-"$curlver"* ../_tarballs/
+cd "$pwd"
+cd "_tarballs"
+
+# compare the new tarball against the original
+sha256sum -c checksum


### PR DESCRIPTION
Verify in this case means making sure that rebuilding the tarball generates the **exact same** output.

The verify-release script requires 754acd1a9dc6, so it does not work on past curl release tarballs.