### PR TITLE
x509asn1: initialize dynbuf with MAX_X509_CERT

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -71,6 +71,7 @@
 #include "connect.h"
 #include "select.h"
 #include "strdup.h"
+#include "x509asn1.h"
 
 /* The last #include files should be: */
 #include "curl_memory.h"
@@ -887,7 +888,7 @@ CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   struct dynbuf build;
 
-  Curl_dyn_init(&build, 10000);
+  Curl_dyn_init(&build, MAX_X509_CERT);
 
   if(Curl_dyn_add(&build, label) ||
      Curl_dyn_addn(&build, ":", 1) ||

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -99,11 +99,6 @@
 #define CURL_ASN1_CHARACTER_STRING      29
 #define CURL_ASN1_BMP_STRING            30
 
-/* Max sixes */
-
-#define MAX_X509_STR  10000
-#define MAX_X509_CERT 100000
-
 #ifdef WANT_EXTRACT_CERTINFO
 /* ASN.1 OID table entry. */
 struct Curl_OID {

--- a/lib/vtls/x509asn1.h
+++ b/lib/vtls/x509asn1.h
@@ -34,6 +34,11 @@
 #include "cfilters.h"
 #include "urldata.h"
 
+/* Max sixes */
+
+#define MAX_X509_STR  10000
+#define MAX_X509_CERT 100000
+
 /*
  * Types.
  */


### PR DESCRIPTION
Ref.: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1076800

When using GnuTLS we may see certificates whose sizes are bigger than 10000, so use `MAX_X509_CERT` as the maximum `dynbuf` size (instead of `MAX_X509_STR`).

Closes: #14352