### PR TITLE
x509 certificate information, raise limit

### DIFF
--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -118,10 +118,16 @@ static void trc_infof(struct Curl_easy *data, struct curl_trc_feat *feat,
                       const char * const fmt, va_list ap)
 {
   int len = 0;
-  char buffer[MAXINFO + 2];
+  char buffer[MAXINFO + 5];
   if(feat)
-    len = msnprintf(buffer, MAXINFO, "[%s] ", feat->name);
-  len += mvsnprintf(buffer + len, MAXINFO - len, fmt, ap);
+    len = msnprintf(buffer, (MAXINFO + 1), "[%s] ", feat->name);
+  len += mvsnprintf(buffer + len, (MAXINFO + 1) - len, fmt, ap);
+  if(len >= MAXINFO) { /* too long, shorten with '...' */
+    --len;
+    buffer[len++] = '.';
+    buffer[len++] = '.';
+    buffer[len++] = '.';
+  }
   buffer[len++] = '\n';
   buffer[len] = '\0';
   Curl_debug(data, CURLINFO_TEXT, buffer, len);

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -887,7 +887,7 @@ CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   struct dynbuf build;
 
-  Curl_dyn_init(&build, 10000);
+  Curl_dyn_init(&build, CURL_X509_STR_MAX);
 
   if(Curl_dyn_add(&build, label) ||
      Curl_dyn_addn(&build, ":", 1) ||

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -131,6 +131,7 @@ CURLcode Curl_ssl_initsessions(struct Curl_easy *, size_t);
 void Curl_ssl_version(char *buffer, size_t size);
 
 /* Certificate information list handling. */
+#define CURL_X509_STR_MAX  100000
 
 void Curl_ssl_free_certinfo(struct Curl_easy *data);
 CURLcode Curl_ssl_init_certinfo(struct Curl_easy *data, int num);

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -99,10 +99,6 @@
 #define CURL_ASN1_CHARACTER_STRING      29
 #define CURL_ASN1_BMP_STRING            30
 
-/* Max sixes */
-
-#define MAX_X509_STR  10000
-#define MAX_X509_CERT 100000
 
 #ifdef WANT_EXTRACT_CERTINFO
 /* ASN.1 OID table entry. */
@@ -463,7 +459,7 @@ static CURLcode OID2str(struct dynbuf *store,
   if(beg < end) {
     if(symbolic) {
       struct dynbuf buf;
-      Curl_dyn_init(&buf, MAX_X509_STR);
+      Curl_dyn_init(&buf, CURL_X509_STR_MAX);
       result = encodeOID(&buf, beg, end);
 
       if(!result) {
@@ -685,7 +681,7 @@ static CURLcode encodeDN(struct dynbuf *store, struct Curl_asn1Element *dn)
   CURLcode result = CURLE_OK;
   bool added = FALSE;
   struct dynbuf temp;
-  Curl_dyn_init(&temp, MAX_X509_STR);
+  Curl_dyn_init(&temp, CURL_X509_STR_MAX);
 
   for(p1 = dn->beg; p1 < dn->end;) {
     p1 = getASN1Element(&rdn, p1, dn->end);
@@ -949,7 +945,7 @@ static CURLcode do_pubkey_field(struct Curl_easy *data, int certnum,
   CURLcode result;
   struct dynbuf out;
 
-  Curl_dyn_init(&out, MAX_X509_STR);
+  Curl_dyn_init(&out, CURL_X509_STR_MAX);
 
   /* Generate a certificate information record for the public key. */
 
@@ -1093,7 +1089,7 @@ CURLcode Curl_extract_certinfo(struct Curl_easy *data,
     if(certnum)
       return CURLE_OK;
 
-  Curl_dyn_init(&out, MAX_X509_STR);
+  Curl_dyn_init(&out, CURL_X509_STR_MAX);
   /* Prepare the certificate information for curl_easy_getinfo(). */
 
   /* Extract the certificate ASN.1 elements. */

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -119,24 +119,24 @@ fail_unless(verify(result, input) == 0, "No truncation of infof input");
 fail_unless(result[sizeof(result) - 1] == '\0',
             "No truncation of infof input");
 
-/* Just over the limit for truncation without newline */
+/* Just over the limit without newline for truncation via '...' */
 memset(input + 2047, 'A', 4);
 Curl_infof(data, "%s", input);
-fail_unless(strlen(result) == 2048, "Truncation of infof input 1");
+fail_unless(strlen(result) == 2051, "Truncation of infof input 1");
 fail_unless(result[sizeof(result) - 1] == '\0', "Truncation of infof input 1");
 
-/* Just over the limit for truncation with newline */
+/* Just over the limit with newline for truncation via '...' */
 memset(input + 2047, 'A', 4);
 memset(input + 2047 + 4, '\n', 1);
 Curl_infof(data, "%s", input);
-fail_unless(strlen(result) == 2048, "Truncation of infof input 2");
+fail_unless(strlen(result) == 2051, "Truncation of infof input 2");
 fail_unless(result[sizeof(result) - 1] == '\0', "Truncation of infof input 2");
 
-/* Way over the limit for truncation with newline */
+/* Way over the limit for truncation via '...' */
 memset(input, '\0', sizeof(input));
 memset(input, 'A', sizeof(input) - 1);
 Curl_infof(data, "%s", input);
-fail_unless(strlen(result) == 2048, "Truncation of infof input 3");
+fail_unless(strlen(result) == 2051, "Truncation of infof input 3");
 fail_unless(result[sizeof(result) - 1] == '\0', "Truncation of infof input 3");
 
 


### PR DESCRIPTION
Raise the limit for certificate information from 10 thousand to 100 thousand bytes. Certificates can be larger than 10k.

Change the infof() debug output to add '...' at the end when the max limit it can handle is exceeded.

Refs #14352