### PR TITLE
pytest, add tests for HEAD requests in all versions

### DIFF
--- a/tests/http/test_01_basic.py
+++ b/tests/http/test_01_basic.py
@@ -97,3 +97,19 @@ class TestBasic:
         r.check_stats(http_status=200, count=1)
         assert r.stats[0]['time_connect'] > 0, f'{r.stats[0]}'
         assert r.stats[0]['time_appconnect'] > 0, f'{r.stats[0]}'
+
+    # simple https: HEAD
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason=f"curl without SSL")
+    def test_01_07_head(self, env: Env, httpd, nghttpx, repeat, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
+        curl = CurlClient(env=env)
+        url = f'https://{env.authority_for(env.domain1, proto)}/data.json'
+        r = curl.http_download(urls=[url], with_stats=True, with_headers=True,
+                               extra_args=['-I'])
+        r.check_stats(http_status=200, count=1, exitcode=0)
+        # got the Conten-Length: header, but did not download anything
+        assert r.responses[0]['header']['content-length'] == '30', f'{r.responses[0]}'
+        assert r.stats[0]['size_download'] == 0, f'{r.stats[0]}'
+

--- a/tests/http/test_01_basic.py
+++ b/tests/http/test_01_basic.py
@@ -112,4 +112,3 @@ class TestBasic:
         # got the Conten-Length: header, but did not download anything
         assert r.responses[0]['header']['content-length'] == '30', f'{r.responses[0]}'
         assert r.stats[0]['size_download'] == 0, f'{r.stats[0]}'
-


### PR DESCRIPTION
In test_01_07, do a HEAD request, check success, the `Content-Length:` returned and that nothing is downloaded.