### PR TITLE
maketgz: accept option to include latest commit hash

### DIFF
--- a/maketgz
+++ b/maketgz
@@ -32,17 +32,24 @@ export LC_ALL=C
 export TZ=UTC
 
 version="${1:-}"
+cmd="${2:-}"
 
 if [ -z "$version" ]; then
   echo "Specify a version number!"
   exit
 fi
 
-if [ "only" = "${2:-}" ]; then
+echo "$cmd"
+
+only=""
+if [ "only" = "$cmd" ]; then
   echo "Setup version number only!"
   only=1
-else
-  only=
+fi
+
+commit=""
+if [ "commit" = "$cmd" ]; then
+  commit=1
 fi
 
 libversion="$version"
@@ -151,6 +158,11 @@ fi
 
 echo "produce RELEASE-TOOLS.md"
 ./scripts/release-tools.sh "$timestamp" "$version" > docs/RELEASE-TOOLS.md.dist
+
+if test -n "$commit"; then
+  echo "produce docs/tarball-commit.txt"
+  git rev-parse HEAD >docs/tarball-commit.txt.dist
+fi
 
 ############################################################################
 #


### PR DESCRIPTION
If the second argument to the script is "commit", then this will generate a file named `docs/tarball-commit.txt` that contains the latest commit hash (`git rev-parse HEAD`) at the time the script runs.

Doing this breaks the reproducibility so it will not be used for "real" releases but is meant for automated daily snapshots and similar.

Reported-by: Dan Fandrich
Fixes #14363