### PR TITLE
aws_sigv4: Fix ordering for headers with same prefix in the canonical request

### DIFF
--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -232,7 +232,7 @@ test1916 test1917 test1918 test1919 \
 test1933 test1934 test1935 test1936 test1937 test1938 test1939 test1940 \
 test1941 test1942 test1943 test1944 test1945 test1946 test1947 test1948 \
 test1955 test1956 test1957 test1958 test1959 test1960 test1964 \
-test1970 test1971 test1972 test1973 test1974 test1975 \
+test1970 test1971 test1972 test1973 test1974 test1975 test1976 \
 \
 test2000 test2001 test2002 test2003 test2004 \
 \

--- a/tests/data/test1976
+++ b/tests/data/test1976
@@ -1,0 +1,60 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+CURLOPT_AWS_SIGV4
+</keywords>
+</info>
+
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Thu, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 0
+
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+<features>
+SSL
+Debug
+crypto
+</features>
+<name>
+HTTP AWS_SIGV4 canonical request header sorting test
+</name>
+<command>
+-X PUT -H "X-Amz-Meta-Test-Two: test2" -H "x-amz-meta-test: test" --aws-sigv4 "aws:amz:us-east-1:s3" -u "xxx:yyy" http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+^User-Agent:.*
+^Content-Length:.*
+^Accept:.*
+</strip>
+<strippart>
+# Strip the actual signature. We only care about header order in this test
+s/Signature=[a-f0-9]{64}/Signature=stripped/
+</strippart>
+<protocol crlf="yes">
+PUT /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: AWS4-HMAC-SHA256 Credential=xxx/19700101/us-east-1/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date;x-amz-meta-test;x-amz-meta-test-two, Signature=stripped
+X-Amz-Date: 19700101T000000Z
+x-amz-content-sha256: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+X-Amz-Meta-Test-Two: test2
+x-amz-meta-test: test
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
# Problem

AWS SigV4 signing requires headers to be lexicographically ordered by name. The current implementation uses `strcmp` on the full header, leading to incorrect ordering when header names have identical prefixes.

I found two scenarios where curl users could be affected:
1. S3 object uploads with [user-defined metadata](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html) (prefixed by `x-amz-meta-`).
2. [SSE-C](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ServerSideEncryptionCustomerKeys.html#specifying-s3-c-encryption) operations using `x-amz-server-side-encryption-customer-key` and `x-amz-server-side-encryption-customer-key-md5` headers.

Example of the issue:
```bash
curl -X PUT --verbose --silent \
    --aws-sigv4 "aws:amz:us-east-1:s3" --user "$AWS_ACCESS_KEY_ID:$AWS_SECRET_ACCESS_KEY" \
    -H "x-amz-meta-test-two: Test2" \
    -H "x-amz-meta-test: Test" \
    --data-binary @testfile \
    "https://examplebucket.s3.amazonaws.com/testfile"
```

This results in `x-amz-meta-test-two` incorrectly preceding `x-amz-meta-test` in the canonical request, causing S3 to return a `SignatureDoesNotMatch` error.

# Fix

This PR resolves the issue by:
1. Using `strncmp` with the length of the shorter header name for comparison for the canonical request (actual request headers are left in the specified order).
2. If the compared substrings match, the shorter header name is compared as "less than" the longer one.

The fix has been verified with a few real S3 requests, along with the added libcurl test.