### PR TITLE
tests: fixup `tests/data/Makefile.am` references

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -222,7 +222,7 @@ SPDX-License-Identifier: curl
   up. Subsets of tests can now be selected by passing keywords to the
   runtests.pl script via the make `TFLAGS` variable.
 
-  New tests are added by finding a free number in `tests/data/Makefile.inc`.
+  New tests are added by finding a free number in `tests/data/Makefile.am`.
 
 ## Write tests
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -329,8 +329,8 @@ if ($ENV{"NGHTTPX"}) {
 my $disttests = "";
 sub get_disttests {
     # If a non-default $TESTDIR is being used there may not be any
-    # Makefile.inc in which case there's nothing to do.
-    open(my $dh, "<", "$TESTDIR/Makefile.inc") or return;
+    # Makefile.am in which case there's nothing to do.
+    open(my $dh, "<", "$TESTDIR/Makefile.am") or return;
     while(<$dh>) {
         chomp $_;
         if(($_ =~ /^#/) ||($_ !~ /test/)) {
@@ -1034,7 +1034,7 @@ sub singletest_shouldrun {
     my @what;  # what features are needed
 
     if($disttests !~ /test$testnum(\W|\z)/ ) {
-        logmsg "Warning: test$testnum not present in tests/data/Makefile.inc\n";
+        logmsg "Warning: test$testnum not present in tests/data/Makefile.am\n";
     }
     if($disabled{$testnum}) {
         if(!$run_disabled) {

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -37,7 +37,7 @@ source file. The source file should be named `unitNNNN.c` where `NNNN` is a
 previously unused number.
 
 Add your test to `tests/unit/Makefile.inc` (if it is a unit test). Add your
-test data file name to `tests/data/Makefile.inc`
+test data file name to `tests/data/Makefile.am`
 
 You also need a separate file called `tests/data/testNNNN` (using the same
 number) that describes your test case. See the test1300 file for inspiration


### PR DESCRIPTION
Follow-up to f5b826532f2c564ef240df0ba2f3287d521df711 #14357
Reported-by: Stefan Eissing
Fixes #14371
Closes #14372