### PR TITLE
Point out DOH server IP pinning

### DIFF
--- a/docs/cmdline-opts/doh-url.md
+++ b/docs/cmdline-opts/doh-url.md
@@ -11,6 +11,7 @@ See-also:
   - doh-insecure
 Example:
   - --doh-url https://doh.example $URL
+  - --doh-url https://doh.example --resolve doh.example:443:192.0.2.1 $URL
 ---
 
 # `--doh-url`
@@ -22,6 +23,8 @@ Some SSL options that you set for your transfer also applies to DoH since the
 name lookups take place over SSL. However, the certificate verification
 settings are not inherited but are controlled separately via --doh-insecure
 and --doh-cert-status.
+
+By default, DoH is bypassed when initially looking up DNS records of the DoH server. You can specify the IP address(es) of the DoH server with --resolve to avoid this.
 
 This option is unset if an empty string "" is used as the URL.
 (Added in 7.85.0)


### PR DESCRIPTION
The IP address in the example is taken out of [RFC 5737](https://datatracker.ietf.org/doc/html/rfc5737).