### PR TITLE
dist: add missing `docs/examples/CMakeLists.txt`

### DIFF
--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -25,7 +25,7 @@
 AUTOMAKE_OPTIONS = foreign nostdinc
 
 EXTRA_DIST = README.md Makefile.example Makefile.inc Makefile.mk \
-  $(COMPLICATED_EXAMPLES) .checksrc
+  CMakeLists.txt $(COMPLICATED_EXAMPLES) .checksrc
 
 # Specify our include paths here, and do it relative to $(top_srcdir) and
 # $(top_builddir), to ensure that these paths which belong to the library


### PR DESCRIPTION
Follow-up to dfdd978f7c60224dffe2aac25b436dc0a5cd0186 #13491
Closes #14380
