### PR TITLE
revert "tests/http: configure test httpd to honor client cipher order"

### DIFF
--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -176,11 +176,11 @@ class TestSSLUse:
     # test setting cipher suites, the AES 256 ciphers are disabled in the test server
     @pytest.mark.parametrize("ciphers, succeed", [
         [[0x1301], True],
-        [[0x1302], True],
+        [[0x1302], False],
         [[0x1303], True],
         [[0x1302, 0x1303], True],
         [[0xC02B, 0xC02F], True],
-        [[0xC02C, 0xC030], True],
+        [[0xC02C, 0xC030], False],
         [[0xCCA9, 0xCCA8], True],
         [[0xC02C, 0xC030, 0xCCA9, 0xCCA8], True],
     ])

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -257,7 +257,13 @@ class Httpd:
                 f'Listen {self.env.proxys_port}',
                 f'TypesConfig "{self._conf_dir}/mime.types',
                 f'SSLSessionCache "shmcb:ssl_gcache_data(32000)"',
-                f'SSLHonorCipherOrder on',
+                (f'SSLCipherSuite SSL'
+                 f' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256'
+                 f':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305'
+                ),
+                (f'SSLCipherSuite TLSv1.3'
+                 f' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256'
+                ),
             ]
             if 'base' in self._extra_configs:
                 conf.extend(self._extra_configs['base'])


### PR DESCRIPTION
revert f6cb3c63 #14338

Setting SSLHonorCipherOrder to on means it honors the server cipher order. From the documentation: "When choosing a cipher during an SSLv3 or TLSv1 handshake, normally the client's preference is used. If this directive is enabled, the server's preference will be used instead."

Also the commit inhibits test_17_07_ssl_ciphers. The test tries to tests if all the ciphers specified, and only those, are properly set in curl. For that to work we need have cases where some or all ciphers do no intersect with the cipher-set of the server. We need to be able to assert a failed connection based on a cipher set mismatch.

That is why a restricted set of ciphers is used on the server. This set is so chosen that it contains the well known most secure ciphers. Except with the slower aes256 variant intentionally left out, to be able to test above described.

As test_17_07_ssl_ciphers is currently the only test that tests the functioning of the --ciphers and --tls13-ciphers options, it is important that its coverage is as good as possible.