### PR TITLE
cmake: add Linux CI job, fix pytest with cmake

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,8 +57,8 @@ env:
   rustls-version: 0.13.0
 
 jobs:
-  autotools:
-    name: ${{ matrix.build.name }}
+  linux:
+    name: ${{ matrix.build.generate && 'CM' || 'AM' }} ${{ matrix.build.name }}
     runs-on: 'ubuntu-latest'
     container: ${{ matrix.build.container }}
     timeout-minutes: 90
@@ -82,6 +82,12 @@ jobs:
             install_packages: zlib1g-dev valgrind
             install_steps: libressl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --enable-debug
+            singleuse: --unit
+
+          - name: libressl
+            install_packages: zlib1g-dev valgrind
+            install_steps: libressl pytest
+            generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DENABLE_DEBUG=ON
             singleuse: --unit
 
           - name: libressl-clang
@@ -412,29 +418,52 @@ jobs:
           sudo make install
 
       - run: autoreconf -fi
+        if: ${{ matrix.build.configure }}
         name: 'autoreconf'
 
       - run: ./configure --disable-dependency-tracking --enable-warnings --enable-werror ${{ matrix.build.configure }}
-        name: 'configure'
+        if: ${{ matrix.build.configure }}
+        name: 'configure (autotools)'
 
-      - run: make V=1
+      - run: |
+          cmake . \
+            -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \
+            -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON \
+            -DBUILD_EXAMPLES=ON \
+            -DCURL_BROTLI=ON -DCURL_ZSTD=ON \
+            ${{ matrix.build.generate }}
+        if: ${{ matrix.build.generate }}
+        name: 'configure (cmake)'
+
+      - run: make V=1 VERBOSE=1
         name: 'make'
 
       - run: |
           git config --global --add safe.directory "*"
-          ./scripts/singleuse.pl ${{ matrix.build.singleuse }} lib/.libs/libcurl.a
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            libcurla=lib/libcurl.a
+          else
+            libcurla=lib/.libs/libcurl.a
+          fi
+          ./scripts/singleuse.pl ${{ matrix.build.singleuse }} ${libcurla}
         name: single-use function check
 
       - run: ./src/curl -V
         name: 'check curl -V output'
 
       - run: make V=1 examples
+        if: ${{ matrix.build.configure }}
         name: 'make examples'
 
       - run: make V=1 -C tests
-        name: 'make tests'
+        if: ${{ matrix.build.configure }}
+        name: 'make tests (autotools)'
 
-      - run: make V=1 test-ci
+      - run: make VERBOSE=1 testdeps
+        if: ${{ matrix.build.generate }}
+        name: 'make tests (cmake)'
+
+      - run: make V=1 VERBOSE=1 test-ci
         name: 'run tests'
         env:
           TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,7 +87,7 @@ jobs:
           - name: libressl
             install_packages: zlib1g-dev valgrind
             install_steps: libressl pytest
-            generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DENABLE_DEBUG=ON
+            generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DENABLE_DEBUG=ON -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
             singleuse: --unit
 
           - name: libressl-clang

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -435,6 +435,11 @@ jobs:
         if: ${{ matrix.build.generate }}
         name: 'configure (cmake)'
 
+      - name: 'test configs'
+        run: |
+          cat tests/config || true
+          cat tests/http/config.ini || true
+
       - run: make V=1 VERBOSE=1
         name: 'make'
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,10 @@
 ###########################################################################
 set(CMAKE_UNITY_BUILD OFF)
 
+find_program(TEST_NGHTTPX "nghttpx")
+# TEST_NGHTTPX
+configure_file("config.in" "${CMAKE_CURRENT_BINARY_DIR}/config" @ONLY)
+
 add_custom_target(testdeps)
 add_subdirectory(libtest)
 add_subdirectory(server)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_custom_target(testdeps)
 add_subdirectory(libtest)
 add_subdirectory(server)
 add_subdirectory(unit)
+add_subdirectory(http/clients)
 
 function(add_runtests targetname test_flags)
   # Use a special '$TFLAGS' placeholder as last argument which will be

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,7 @@
 set(CMAKE_UNITY_BUILD OFF)
 
 find_program(TEST_NGHTTPX "nghttpx")
-if(NOT TEST_NGHTTPX_FOUND)
+if(NOT TEST_NGHTTPX)
   set(TEST_NGHTTPX "nghttpx")
 endif()
 # TEST_NGHTTPX

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ add_custom_target(testdeps)
 add_subdirectory(libtest)
 add_subdirectory(server)
 add_subdirectory(unit)
+add_subdirectory(http)
 add_subdirectory(http/clients)
 
 function(add_runtests targetname test_flags)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,9 @@
 set(CMAKE_UNITY_BUILD OFF)
 
 find_program(TEST_NGHTTPX "nghttpx")
+if(NOT TEST_NGHTTPX_FOUND)
+  set(TEST_NGHTTPX "nghttpx")
+endif()
 # TEST_NGHTTPX
 configure_file("config.in" "${CMAKE_CURRENT_BINARY_DIR}/config" @ONLY)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,11 +31,11 @@ endif()
 configure_file("config.in" "${CMAKE_CURRENT_BINARY_DIR}/config" @ONLY)
 
 add_custom_target(testdeps)
-add_subdirectory(libtest)
-add_subdirectory(server)
-add_subdirectory(unit)
 add_subdirectory(http)
 add_subdirectory(http/clients)
+add_subdirectory(server)
+add_subdirectory(libtest)
+add_subdirectory(unit)
 
 function(add_runtests targetname test_flags)
   # Use a special '$TFLAGS' placeholder as last argument which will be

--- a/tests/http/CMakeLists.txt
+++ b/tests/http/CMakeLists.txt
@@ -23,28 +23,28 @@
 ###########################################################################
 
 find_program(CADDY "caddy")  # /usr/bin/caddy
-if(NOT CADDY_FOUND)
-  unset(CADDY)
+if(NOT CADDY)
+  set(CADDY "")
 endif()
 find_program(VSFTPD "vsftpd")  # /usr/sbin/vsftpd
-if(NOT VSFTPD_FOUND)
-  unset(VSFTPD)
+if(NOT VSFTPD)
+  set(VSFTPD "")
 endif()
 find_program(HTTPD "apache2")  # /usr/sbin/apache2
-if(NOT HTTPD_FOUND)
-  unset(HTTPD)
+if(NOT HTTPD)
+  set(HTTPD "")
 endif()
 find_program(APACHECTL "apache2ctl")  # /usr/sbin/apache2ctl
-if(NOT APACHECTL_FOUND)
-  unset(APACHECTL)
+if(NOT APACHECTL)
+  set(APACHECTL "")
 endif()
 find_program(APXS "apxs")
-if(NOT APXS_FOUND)
-  unset(APXS)
+if(NOT APXS)
+  set(APXS "")
 endif()
 find_program(HTTPD_NGHTTPX "nghttpx" PATHS "/usr/bin" "/usr/local/bin")
-if(NOT HTTPD_NGHTTPX_FOUND)
-  unset(HTTPD_NGHTTPX)
+if(NOT HTTPD_NGHTTPX)
+  set(HTTPD_NGHTTPX "")
 endif()
 
 # APXS, HTTPD, APACHECTL, HTTPD_NGHTTPX, CADDY, VSFTPD

--- a/tests/http/CMakeLists.txt
+++ b/tests/http/CMakeLists.txt
@@ -23,11 +23,29 @@
 ###########################################################################
 
 find_program(CADDY "caddy")  # /usr/bin/caddy
+if(NOT CADDY_FOUND)
+  unset(CADDY)
+endif()
 find_program(VSFTPD "vsftpd")  # /usr/sbin/vsftpd
+if(NOT VSFTPD_FOUND)
+  unset(VSFTPD)
+endif()
 find_program(HTTPD "apache2")  # /usr/sbin/apache2
+if(NOT HTTPD_FOUND)
+  unset(HTTPD)
+endif()
 find_program(APACHECTL "apache2ctl")  # /usr/sbin/apache2ctl
+if(NOT APACHECTL_FOUND)
+  unset(APACHECTL)
+endif()
 find_program(APXS "apxs")
+if(NOT APXS_FOUND)
+  unset(APXS)
+endif()
 find_program(HTTPD_NGHTTPX "nghttpx" PATHS "/usr/bin" "/usr/local/bin")
+if(NOT HTTPD_NGHTTPX_FOUND)
+  unset(HTTPD_NGHTTPX)
+endif()
 
 # APXS, HTTPD, APACHECTL, HTTPD_NGHTTPX, CADDY, VSFTPD
 configure_file("config.ini.in" "${CMAKE_CURRENT_BINARY_DIR}/config.ini" @ONLY)

--- a/tests/http/CMakeLists.txt
+++ b/tests/http/CMakeLists.txt
@@ -1,0 +1,33 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+find_program(CADDY "caddy")  # /usr/bin/caddy
+find_program(VSFTPD "vsftpd")  # /usr/sbin/vsftpd
+find_program(HTTPD "apache2")  # /usr/sbin/apache2
+find_program(APACHECTL "apache2ctl")  # /usr/sbin/apache2ctl
+find_program(APXS "apxs")
+find_program(HTTPD_NGHTTPX "nghttpx")
+
+# APXS, HTTPD, APACHECTL, HTTPD_NGHTTPX, CADDY, VSFTPD
+configure_file("config.ini.in" "${CMAKE_CURRENT_BINARY_DIR}/config.ini" @ONLY)

--- a/tests/http/CMakeLists.txt
+++ b/tests/http/CMakeLists.txt
@@ -27,7 +27,7 @@ find_program(VSFTPD "vsftpd")  # /usr/sbin/vsftpd
 find_program(HTTPD "apache2")  # /usr/sbin/apache2
 find_program(APACHECTL "apache2ctl")  # /usr/sbin/apache2ctl
 find_program(APXS "apxs")
-find_program(HTTPD_NGHTTPX "nghttpx")
+find_program(HTTPD_NGHTTPX "nghttpx" PATHS "/usr/bin" "/usr/local/bin")
 
 # APXS, HTTPD, APACHECTL, HTTPD_NGHTTPX, CADDY, VSFTPD
 configure_file("config.ini.in" "${CMAKE_CURRENT_BINARY_DIR}/config.ini" @ONLY)

--- a/tests/http/Makefile.am
+++ b/tests/http/Makefile.am
@@ -39,6 +39,7 @@ testenv/vsftpd.py                     \
 testenv/ws_echo_server.py
 
 EXTRA_DIST =           \
+CMakeLists.txt         \
 config.ini.in          \
 conftest.py            \
 requirements.txt       \

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -1,0 +1,44 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# Get 'check_PROGRAMS' variable
+transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
+include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
+
+foreach(_client IN LISTS check_PROGRAMS)
+  set(_client_target "curl-test-client-${_client}")
+  add_executable(${_client_target} "${_client}.c")
+  add_dependencies(testdeps ${_client_target})
+  target_include_directories(${_client_target} PRIVATE
+    "${CURL_SOURCE_DIR}/lib"      # for "curl_setup_once.h"
+    "${CURL_BINARY_DIR}/lib"      # for "curl_config.h"
+    "${CURL_BINARY_DIR}/include"  # for "curl/curl.h"
+  )
+  target_link_libraries(${_client_target} ${LIB_SELECTED} ${CURL_LIBS})
+  target_compile_definitions(${_client_target} PRIVATE "CURL_NO_OLDIES")
+  if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
+    set_property(TARGET ${_client_target} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
+  endif()
+  set_target_properties(${_client_target} PROPERTIES OUTPUT_NAME "${_client}" UNITY_BUILD OFF)
+endforeach()

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -24,6 +24,7 @@
 
 AUTOMAKE_OPTIONS = foreign nostdinc
 
+EXTRA_DIST = CMakeLists.txt
 
 # Specify our include paths here, and do it relative to $(top_srcdir) and
 # $(top_builddir), to ensure that these paths which belong to the library
@@ -59,7 +60,7 @@ endif
 # This might hold -Werror
 CFLAGS += @CURL_CFLAG_EXTRAS@
 
-# Makefile.inc provides the check_PROGRAMS and COMPLICATED_EXAMPLES defines
+# Makefile.inc provides the check_PROGRAMS define
 include Makefile.inc
 
 all: $(check_PROGRAMS)

--- a/tests/http/clients/Makefile.inc
+++ b/tests/http/clients/Makefile.inc
@@ -24,11 +24,11 @@
 
 # These are all libcurl example programs to be test compiled
 check_PROGRAMS = \
-  h2-serverpush \
   h2-download \
-  ws-data \
-  ws-pingpong \
+  h2-pausing \
+  h2-serverpush \
   h2-upgrade-extreme \
   tls-session-reuse \
-  h2-pausing \
-  upload-pausing
+  upload-pausing \
+  ws-data \
+  ws-pingpong

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -35,7 +35,6 @@ int main(void)
 
 /* curl stuff */
 #include <curl/curl.h>
-#include "curl_printf.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -37,7 +37,7 @@
 /* curl stuff */
 #include <curl/curl.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #endif
 

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -85,8 +85,7 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-               xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
     }
     else {
       snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
@@ -185,8 +184,7 @@ static size_t my_write_cb(char *buf, size_t nitems, size_t buflen,
   fprintf(stderr, "[t-%d] RECV %ld bytes, total=%ld, pause_at=%ld\n",
           t->idx, (long)blen, (long)t->recv_size, (long)t->pause_at);
   if(!t->out) {
-    snprintf(t->filename, sizeof(t->filename)-1, "download_%u.data",
-             t->idx);
+    snprintf(t->filename, sizeof(t->filename)-1, "download_%u.data", t->idx);
     t->out = fopen(t->filename, "wb");
     if(!t->out)
       return 0;

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -26,6 +26,13 @@
  * </DESC>
  */
 
+#ifdef _MSC_VER
+int main(void)
+{
+  return 99;
+}
+#else
+
 /* curl stuff */
 #include <curl/curl.h>
 #include <curl/mprintf.h>
@@ -33,6 +40,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* somewhat Unix-specific */
+#include <unistd.h>  /* getopt() */
 
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"
@@ -474,3 +484,4 @@ int main(int argc, char *argv[])
 
   return 0;
 }
+#endif /* _MSC_VER */

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -35,7 +35,7 @@ int main(void)
 
 /* curl stuff */
 #include <curl/curl.h>
-#include <curl/mprintf.h>
+#include "curl_printf.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -25,6 +25,9 @@
  * HTTP/2 server push
  * </DESC>
  */
+/* curl stuff */
+#include <curl/curl.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -33,9 +36,6 @@
 /* somewhat Unix-specific */
 #include <unistd.h>  /* getopt() */
 #endif
-
-/* curl stuff */
-#include <curl/curl.h>
 
 #ifdef _MSC_VER
 #define snprintf _snprintf

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -25,27 +25,27 @@
  * HTTP/2 server push
  * </DESC>
  */
-
-#ifdef _MSC_VER
-int main(void)
-{
-  return 99;
-}
-#else
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef _MSC_VER
 /* somewhat Unix-specific */
 #include <unistd.h>  /* getopt() */
+#endif
 
 /* curl stuff */
 #include <curl/curl.h>
+
+#ifdef _WIN32
+#define snprintf _snprintf
+#endif
 
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"
 #endif
 
+#ifndef _MSC_VER
 static int verbose = 1;
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
@@ -276,12 +276,14 @@ static void usage(const char *msg)
     "  -V http_version (http/1.1, h2, h3) http version to use\n"
   );
 }
+#endif /* !_MSC_VER */
 
 /*
  * Download a file over HTTP/2, take care of server push.
  */
 int main(int argc, char *argv[])
 {
+#ifndef _MSC_VER
   CURLM *multi_handle;
   struct CURLMsg *m;
   const char *url;
@@ -481,5 +483,10 @@ int main(int argc, char *argv[])
   curl_multi_cleanup(multi_handle);
 
   return 0;
+#else
+  (void)argc;
+  (void)argv;
+  fprintf(stderr, "Not supported with this compiler.\n");
+  return 1;
+#endif /* !_MSC_VER */
 }
-#endif /* _MSC_VER */

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -32,16 +32,15 @@ int main(void)
   return 99;
 }
 #else
-
-/* curl stuff */
-#include <curl/curl.h>
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 /* somewhat Unix-specific */
 #include <unistd.h>  /* getopt() */
+
+/* curl stuff */
+#include <curl/curl.h>
 
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -34,10 +34,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* somewhat Unix-specific */
-#include <sys/time.h>
-#include <unistd.h>
-
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"
 #endif

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -85,11 +85,11 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-                     xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
+               xfer_id, conn_id);
     }
     else {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -185,8 +185,8 @@ static size_t my_write_cb(char *buf, size_t nitems, size_t buflen,
   fprintf(stderr, "[t-%d] RECV %ld bytes, total=%ld, pause_at=%ld\n",
           t->idx, (long)blen, (long)t->recv_size, (long)t->pause_at);
   if(!t->out) {
-    curl_msnprintf(t->filename, sizeof(t->filename)-1, "download_%u.data",
-                   t->idx);
+    snprintf(t->filename, sizeof(t->filename)-1, "download_%u.data",
+             t->idx);
     t->out = fopen(t->filename, "wb");
     if(!t->out)
       return 0;

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -83,8 +83,7 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-               xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
     }
     else {
       snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
@@ -273,8 +272,7 @@ int main(int argc, char *argv[])
     exit(1);
   }
   memset(&resolve, 0, sizeof(resolve));
-  snprintf(resolve_buf, sizeof(resolve_buf)-1,
-           "%s:%s:127.0.0.1", host, port);
+  snprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1", host, port);
   resolve = curl_slist_append(resolve, resolve_buf);
 
   for(i = 0; i<HANDLECOUNT; i++) {

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -33,8 +33,6 @@ int main(void)
   return 99;
 }
 #else
-#include <curl/curl.h>
-
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -42,6 +40,8 @@ int main(void)
 
 /* somewhat Unix-specific */
 #include <unistd.h>  /* getopt() */
+
+#include <curl/curl.h>
 
 #define HANDLECOUNT 2
 

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -27,22 +27,23 @@
  */
 /* This is based on the PoC client of issue #11982
  */
-#ifdef _MSC_VER
-int main(void)
-{
-  return 99;
-}
-#else
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 
+#ifndef _MSC_VER
 /* somewhat Unix-specific */
 #include <unistd.h>  /* getopt() */
+#endif
 
 #include <curl/curl.h>
 
+#ifdef _WIN32
+#define snprintf _snprintf
+#endif
+
+#ifndef _MSC_VER
 #define HANDLECOUNT 2
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
@@ -199,9 +200,11 @@ static size_t cb(void *data, size_t size, size_t nmemb, void *clientp)
           handle->idx, (long)realsize);
   return realsize;
 }
+#endif /* !_MSC_VER */
 
 int main(int argc, char *argv[])
 {
+#ifndef _MSC_VER
   struct handle handles[HANDLECOUNT];
   CURLM *multi_handle;
   int i, still_running = 1, msgs_left, numfds;
@@ -402,5 +405,10 @@ out:
   curl_global_cleanup();
 
   return rc;
+#else
+  (void)argc;
+  (void)argv;
+  fprintf(stderr, "Not supported with this compiler.\n");
+  return 1;
+#endif /* !_MSC_VER */
 }
-#endif /* _MSC_VER */

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -347,7 +347,8 @@ int main(int argc, char *argv[])
     if(curl_multi_poll(multi_handle, NULL, 0, 100, &numfds) != CURLM_OK)
       err();
 
-    while((msg = curl_multi_info_read(multi_handle, &msgs_left))) {
+    /* !checksrc! disable EQUALSNULL 1 */
+    while((msg = curl_multi_info_read(multi_handle, &msgs_left)) != NULL) {
       if(msg->msg == CURLMSG_DONE) {
         for(i = 0; i<HANDLECOUNT; i++) {
           if(msg->easy_handle == handles[i].h) {

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -39,7 +39,7 @@
 
 #include <curl/curl.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #endif
 

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -34,7 +34,7 @@ int main(void)
 }
 #else
 #include <curl/curl.h>
-#include <curl/mprintf.h>
+#include "curl_printf.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -82,11 +82,11 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-                     xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
+               xfer_id, conn_id);
     }
     else {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -270,8 +270,8 @@ int main(int argc, char *argv[])
     exit(1);
   }
   memset(&resolve, 0, sizeof(resolve));
-  curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1,
-                 "%s:%s:127.0.0.1", host, port);
+  snprintf(resolve_buf, sizeof(resolve_buf)-1,
+           "%s:%s:127.0.0.1", host, port);
   resolve = curl_slist_append(resolve, resolve_buf);
 
   for(i = 0; i<HANDLECOUNT; i++) {

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -25,16 +25,24 @@
  * HTTP/2 download pausing
  * </DESC>
  */
-/* This is based on the poc client of issue #11982
+/* This is based on the PoC client of issue #11982
  */
+#ifdef _MSC_VER
+int main(void)
+{
+  return 99;
+}
+#else
+#include <curl/curl.h>
+#include <curl/mprintf.h>
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/time.h>
-#include <unistd.h>
 #include <stdlib.h>
-#include <curl/curl.h>
-#include <curl/mprintf.h>
+
+/* somewhat Unix-specific */
+#include <unistd.h>  /* getopt() */
 
 #define HANDLECOUNT 2
 
@@ -395,3 +403,4 @@ out:
 
   return rc;
 }
+#endif /* _MSC_VER */

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -34,7 +34,6 @@ int main(void)
 }
 #else
 #include <curl/curl.h>
-#include "curl_printf.h"
 
 #include <assert.h>
 #include <stdio.h>

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -27,6 +27,8 @@
  */
 /* This is based on the PoC client of issue #11982
  */
+#include <curl/curl.h>
+
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -36,8 +38,6 @@
 /* somewhat Unix-specific */
 #include <unistd.h>  /* getopt() */
 #endif
-
-#include <curl/curl.h>
 
 #ifdef _MSC_VER
 #define snprintf _snprintf

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -36,7 +36,7 @@
 #error "too old libcurl, cannot do HTTP/2 server push!"
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #endif
 

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -166,7 +166,7 @@ static int server_push_callback(CURL *parent,
   int rv;
 
   (void)parent; /* we have no use for this */
-  curl_msnprintf(filename, sizeof(filename)-1, "push%u", count++);
+  snprintf(filename, sizeof(filename)-1, "push%u", count++);
 
   /* here's a new stream, save it in a new file for each new push */
   out = fopen(filename, "wb");

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -25,13 +25,12 @@
  * HTTP/2 server push
  * </DESC>
  */
-
-/* curl stuff */
-#include <curl/curl.h>
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* curl stuff */
+#include <curl/curl.h>
 
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -25,12 +25,12 @@
  * HTTP/2 server push
  * </DESC>
  */
+/* curl stuff */
+#include <curl/curl.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-/* curl stuff */
-#include <curl/curl.h>
 
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -28,7 +28,6 @@
 
 /* curl stuff */
 #include <curl/curl.h>
-#include "curl_printf.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -28,7 +28,7 @@
 
 /* curl stuff */
 #include <curl/curl.h>
-#include <curl/mprintf.h>
+#include "curl_printf.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -34,10 +34,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* somewhat Unix-specific */
-#include <sys/time.h>
-#include <unistd.h>
-
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"
 #endif

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -36,6 +36,10 @@
 #error "too old libcurl, cannot do HTTP/2 server push!"
 #endif
 
+#ifdef _WIN32
+#define snprintf _snprintf
+#endif
+
 static
 void dump(const char *text, unsigned char *ptr, size_t size,
           char nohex)

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -30,7 +30,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 /* #include <error.h> */
 #include <errno.h>
 

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -32,6 +32,10 @@
 
 #include <curl/curl.h>
 
+#ifdef _WIN32
+#define snprintf _snprintf
+#endif
+
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {
   /*

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -26,7 +26,6 @@
  * </DESC>
  */
 #include <curl/curl.h>
-#include "curl_printf.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -209,7 +209,8 @@ int main(int argc, char *argv[])
     }
 
     /* Check for finished handles and remove. */
-    while((msg = curl_multi_info_read(multi, &msgs_in_queue))) {
+    /* !checksrc! disable EQUALSNULL 1 */
+    while((msg = curl_multi_info_read(multi, &msgs_in_queue)) != NULL) {
       if(msg->msg == CURLMSG_DONE) {
         long status = 0;
         curl_off_t xfer_id;

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -25,13 +25,12 @@
  * HTTP/2 Upgrade test
  * </DESC>
  */
-#include <curl/curl.h>
-
 #include <stdio.h>
 #include <stdlib.h>
 /* #include <error.h> */
 #include <errno.h>
 
+#include <curl/curl.h>
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -25,12 +25,12 @@
  * HTTP/2 Upgrade test
  * </DESC>
  */
+#include <curl/curl.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 /* #include <error.h> */
 #include <errno.h>
-
-#include <curl/curl.h>
 
 #ifdef _MSC_VER
 #define snprintf _snprintf

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -26,7 +26,7 @@
  * </DESC>
  */
 #include <curl/curl.h>
-#include <curl/mprintf.h>
+#include "curl_printf.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -32,7 +32,7 @@
 
 #include <curl/curl.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #endif
 

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -73,8 +73,7 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-               xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
     }
     else {
       snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -25,14 +25,14 @@
  * HTTP/2 Upgrade test
  * </DESC>
  */
+#include <curl/curl.h>
+#include <curl/mprintf.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
-#include <inttypes.h>
 /* #include <error.h> */
 #include <errno.h>
-#include <curl/curl.h>
-#include <curl/mprintf.h>
 
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
@@ -181,8 +181,7 @@ int main(int argc, char *argv[])
       curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, write_cb);
       curl_easy_setopt(easy, CURLOPT_WRITEDATA, NULL);
       curl_easy_setopt(easy, CURLOPT_HTTPGET, 1L);
-      curl_msnprintf(range, sizeof(range), "%" PRIu64 "-%" PRIu64,
-                     UINT64_C(0), UINT64_C(16384));
+      curl_msnprintf(range, sizeof(range), "%d-%d", 0, 16384);
       curl_easy_setopt(easy, CURLOPT_RANGE, range);
 
       mc = curl_multi_add_handle(multi, easy);

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -69,11 +69,11 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-                     xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
+               xfer_id, conn_id);
     }
     else {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
       curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, write_cb);
       curl_easy_setopt(easy, CURLOPT_WRITEDATA, NULL);
       curl_easy_setopt(easy, CURLOPT_HTTPGET, 1L);
-      curl_msnprintf(range, sizeof(range), "%d-%d", 0, 16384);
+      snprintf(range, sizeof(range), "%d-%d", 0, 16384);
       curl_easy_setopt(easy, CURLOPT_RANGE, range);
 
       mc = curl_multi_add_handle(multi, easy);

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -25,14 +25,13 @@
  * TLS session reuse
  * </DESC>
  */
-#include <curl/curl.h>
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 /* #include <error.h> */
 #include <errno.h>
 
+#include <curl/curl.h>
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -26,7 +26,6 @@
  * </DESC>
  */
 #include <curl/curl.h>
-#include "curl_printf.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -25,15 +25,15 @@
  * TLS session reuse
  * </DESC>
  */
+#include <curl/curl.h>
+#include <curl/mprintf.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <inttypes.h>
 /* #include <error.h> */
 #include <errno.h>
-#include <curl/curl.h>
-#include <curl/mprintf.h>
 
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -26,7 +26,7 @@
  * </DESC>
  */
 #include <curl/curl.h>
-#include <curl/mprintf.h>
+#include "curl_printf.h"
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -74,8 +74,7 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-               xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
     }
     else {
       snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
@@ -224,8 +223,7 @@ int main(int argc, char *argv[])
   }
 
   memset(&resolve, 0, sizeof(resolve));
-  snprintf(resolve_buf, sizeof(resolve_buf)-1,
-           "%s:%s:127.0.0.1", host, port);
+  snprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1", host, port);
   curl_slist_append(&resolve, resolve_buf);
 
   multi = curl_multi_init();

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -33,6 +33,10 @@
 
 #include <curl/curl.h>
 
+#ifdef _WIN32
+#define snprintf _snprintf
+#endif
+
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {
   /*

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -273,7 +273,8 @@ int main(int argc, char *argv[])
     }
 
     /* Check for finished handles and remove. */
-    while((msg = curl_multi_info_read(multi, &msgs_in_queue))) {
+    /* !checksrc! disable EQUALSNULL 1 */
+    while((msg = curl_multi_info_read(multi, &msgs_in_queue)) != NULL) {
       if(msg->msg == CURLMSG_DONE) {
         long status = 0;
         curl_off_t xfer_id;

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -33,7 +33,7 @@
 
 #include <curl/curl.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #endif
 

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -25,13 +25,13 @@
  * TLS session reuse
  * </DESC>
  */
+#include <curl/curl.h>
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 /* #include <error.h> */
 #include <errno.h>
-
-#include <curl/curl.h>
 
 #ifdef _MSC_VER
 #define snprintf _snprintf

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -30,7 +30,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
 /* #include <error.h> */
 #include <errno.h>

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -70,11 +70,11 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-                     xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
+               xfer_id, conn_id);
     }
     else {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -219,9 +219,9 @@ int main(int argc, char *argv[])
     exit(1);
   }
 
-   memset(&resolve, 0, sizeof(resolve));
-   curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1,
-                  "%s:%s:127.0.0.1", host, port);
+  memset(&resolve, 0, sizeof(resolve));
+  snprintf(resolve_buf, sizeof(resolve_buf)-1,
+           "%s:%s:127.0.0.1", host, port);
   curl_slist_append(&resolve, resolve_buf);
 
   multi = curl_multi_init();

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -27,6 +27,8 @@
  */
 /* This is based on the PoC client of issue #11769
  */
+#include <curl/curl.h>
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -35,8 +37,6 @@
 /* somewhat Unix-specific */
 #include <unistd.h>  /* getopt() */
 #endif
-
-#include <curl/curl.h>
 
 #ifdef _MSC_VER
 #define snprintf _snprintf

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -80,8 +80,7 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-               xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
     }
     else {
       snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
@@ -264,8 +263,7 @@ int main(int argc, char *argv[])
     exit(1);
   }
   memset(&resolve, 0, sizeof(resolve));
-  snprintf(resolve_buf, sizeof(resolve_buf)-1,
-           "%s:%s:127.0.0.1", host, port);
+  snprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1", host, port);
   resolve = curl_slist_append(resolve, resolve_buf);
 
   curl = curl_easy_init();

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -79,11 +79,11 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
-                     xfer_id, conn_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2,
+               xfer_id, conn_id);
     }
     else {
-      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -261,8 +261,8 @@ int main(int argc, char *argv[])
     exit(1);
   }
   memset(&resolve, 0, sizeof(resolve));
-  curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1,
-                 "%s:%s:127.0.0.1", host, port);
+  snprintf(resolve_buf, sizeof(resolve_buf)-1,
+           "%s:%s:127.0.0.1", host, port);
   resolve = curl_slist_append(resolve, resolve_buf);
 
   curl = curl_easy_init();

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -38,7 +38,7 @@
 
 #include <curl/curl.h>
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define snprintf _snprintf
 #endif
 

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -33,14 +33,14 @@ int main(void)
   return 99;
 }
 #else
-#include <curl/curl.h>
-
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 
 /* somewhat Unix-specific */
 #include <unistd.h>  /* getopt() */
+
+#include <curl/curl.h>
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -34,7 +34,6 @@ int main(void)
 }
 #else
 #include <curl/curl.h>
-#include "curl_printf.h"
 
 #include <stdio.h>
 #include <string.h>

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -27,21 +27,22 @@
  */
 /* This is based on the PoC client of issue #11769
  */
-#ifdef _MSC_VER
-int main(void)
-{
-  return 99;
-}
-#else
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 
+#ifndef _MSC_VER
 /* somewhat Unix-specific */
 #include <unistd.h>  /* getopt() */
+#endif
 
 #include <curl/curl.h>
 
+#ifdef _WIN32
+#define snprintf _snprintf
+#endif
+
+#ifndef _MSC_VER
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {
   /*
@@ -199,9 +200,11 @@ static void usage(const char *msg)
     "  -V http_version (http/1.1, h2, h3) http version to use\n"
   );
 }
+#endif /* !_MSC_VER */
 
 int main(int argc, char *argv[])
 {
+#ifndef _MSC_VER
   CURL *curl;
   CURLcode rc = CURLE_OK;
   CURLU *cu;
@@ -313,5 +316,10 @@ int main(int argc, char *argv[])
   curl_global_cleanup();
 
   return (int)rc;
+#else
+  (void)argc;
+  (void)argv;
+  fprintf(stderr, "Not supported with this compiler.\n");
+  return 1;
+#endif /* !_MSC_VER */
 }
-#endif /* _MSC_VER */

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -25,15 +25,19 @@
  * upload pausing
  * </DESC>
  */
-/* This is based on the poc client of issue #11769
+/* This is based on the PoC client of issue #11769
  */
-#include <stdio.h>
-#include <string.h>
-#include <sys/time.h>
-#include <unistd.h>
-#include <stdlib.h>
 #include <curl/curl.h>
 #include <curl/mprintf.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifndef _MSC_VER
+/* somewhat Unix-specific */
+#include <unistd.h>
+#endif
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -27,6 +27,12 @@
  */
 /* This is based on the PoC client of issue #11769
  */
+#ifdef _MSC_VER
+int main(void)
+{
+  return 99;
+}
+#else
 #include <curl/curl.h>
 #include <curl/mprintf.h>
 
@@ -34,10 +40,8 @@
 #include <string.h>
 #include <stdlib.h>
 
-#ifndef _MSC_VER
 /* somewhat Unix-specific */
 #include <unistd.h>
-#endif
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {
@@ -311,3 +315,4 @@ int main(int argc, char *argv[])
 
   return (int)rc;
 }
+#endif /* _MSC_VER */

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -34,14 +34,14 @@ int main(void)
 }
 #else
 #include <curl/curl.h>
-#include <curl/mprintf.h>
+#include "curl_printf.h"
 
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 
 /* somewhat Unix-specific */
-#include <unistd.h>
+#include <unistd.h>  /* getopt() */
 
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -34,10 +34,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* somewhat Unix-specific */
-#include <sys/time.h>
-#include <unistd.h>
-
 #ifdef USE_WEBSOCKETS
 
 static

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -36,6 +36,15 @@
 
 #ifdef USE_WEBSOCKETS
 
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <sys/time.h>
+#endif
+
 static
 void dump(const char *text, unsigned char *ptr, size_t size,
           char nohex)
@@ -108,7 +117,11 @@ static CURLcode recv_binary(CURL *curl, char *exp_data, size_t exp_len)
     result = curl_ws_recv(curl, recvbuf, sizeof(recvbuf), &nread, &frame);
     if(result == CURLE_AGAIN) {
       fprintf(stderr, "EAGAIN, sleep, try again\n");
+#ifdef _WIN32
+      Sleep(100);
+#else
       usleep(100*1000);
+#endif
       continue;
     }
     fprintf(stderr, "ws: curl_ws_recv(offset=%ld, len=%ld) -> %d, %ld\n",

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -25,13 +25,13 @@
  * Websockets data echos
  * </DESC>
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 /* curl stuff */
 #include "curl_setup.h"
 #include <curl/curl.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef USE_WEBSOCKETS
 

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -25,14 +25,13 @@
  * Websockets data echos
  * </DESC>
  */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 /* curl stuff */
 #include "curl_setup.h"
 #include <curl/curl.h>
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #ifdef USE_WEBSOCKETS
 

--- a/tests/http/clients/ws-pingpong.c
+++ b/tests/http/clients/ws-pingpong.c
@@ -34,6 +34,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <sys/time.h>
+#endif
+
 #ifdef USE_WEBSOCKETS
 
 static CURLcode ping(CURL *curl, const char *send_payload)
@@ -98,7 +107,11 @@ static CURLcode pingpong(CURL *curl, const char *payload)
     fprintf(stderr, "Receive pong\n");
     res = recv_pong(curl, payload);
     if(res == CURLE_AGAIN) {
+#ifdef _WIN32
+      Sleep(100);
+#else
       usleep(100*1000);
+#endif
       continue;
     }
     websocket_close(curl);

--- a/tests/http/clients/ws-pingpong.c
+++ b/tests/http/clients/ws-pingpong.c
@@ -25,13 +25,13 @@
  * Websockets pingpong
  * </DESC>
  */
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
 /* curl stuff */
 #include "curl_setup.h"
 #include <curl/curl.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN

--- a/tests/http/clients/ws-pingpong.c
+++ b/tests/http/clients/ws-pingpong.c
@@ -25,14 +25,13 @@
  * Websockets pingpong
  * </DESC>
  */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 /* curl stuff */
 #include "curl_setup.h"
 #include <curl/curl.h>
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN

--- a/tests/http/clients/ws-pingpong.c
+++ b/tests/http/clients/ws-pingpong.c
@@ -34,10 +34,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* somewhat Unix-specific */
-#include <sys/time.h>
-#include <unistd.h>
-
 #ifdef USE_WEBSOCKETS
 
 static CURLcode ping(CURL *curl, const char *send_payload)


### PR DESCRIPTION
- extend existing Linux workflow with CMake support.
  Including running pytest the first time with CMake.

- cmake: generate `tests/config` and `tests/http/config.ini`.
  Required for pytest tests.
  Uses basic detection logic. Feel free to take it from here.
  Also dump config files in a CI step for debugging purposes.

- cmake: build `tests/http/clients` programs.

- fix portability issues with `tests/http/clients` programs.
  Some of them use `getopt()`, which is not supported by MSVC.
  Fix the rest to compile in CI (old-mingw-w64, MSVC, Windows).

- GHA/linux: add CMake job matching an existing autotools one.

- GHA/linux: test `-DCURL_LIBCURL_VERSIONED_SYMBOLS=ON`
  in the new CMake job.

- reorder testdeps to build server, client tests first and then
  libtests and units, to catch errors in the more complex/unique
  sources earlier.

- sort list in `tests/http/clients/Makefile.inc`.

Closes #14382
