### PR TITLE
wolfssl: Add CURLOPT_TLS13_CIPHERS support

### DIFF
--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -215,8 +215,6 @@ class TestSSLUse:
                 pytest.skip('BoringSSL does not support setting TLSv1.3 ciphers')
             elif env.curl_uses_lib('mbedtls') and not env.curl_lib_version_at_least('mbedtls', '3.6.0'):
                 pytest.skip('mbedTLS TLSv1.3 support requires at least 3.6.0')
-            elif env.curl_uses_lib('wolfssl'):
-                extra_args = ['--ciphers', ':'.join(cipher_names)]
             else:
                 extra_args = ['--tls13-ciphers', ':'.join(cipher_names)]
         else:


### PR DESCRIPTION
Bring setting ciphers with WolfSSL in line with other SSL backends, to make the curl interface more consistent across the backends.

Now the tls1.3 ciphers are set with the --tls13-ciphers option, when not set the default tls1.3 ciphers are used. The tls1.2 (1.1, 1.0) ciphers are set with the --ciphers option, when not set the default tls1.2 ciphers are used. The ciphers available for the connection are now a union of the tls1.3 and tls1.2 ciphers.

This changes the behaviour for WolfSSL when --ciphers is set, but --tls13-ciphers is not set. Now the ciphers set with --ciphers are combined with the default tls1.3 ciphers, whereas before solely the ciphers of --ciphers were used.

Thus before when no tls1.3 ciphers were specified in --ciphers, tls1.3 was completely disabled. This might not be what the user expected, especially as this does not happen with OpenSSL.