### PR TITLE
docs: wolfssl and mbedtls add CURLOPT_TLS13_CIPHERS support

### DIFF
--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -12,13 +12,14 @@ and
 [`--ciphers`](https://curl.se/docs/manpage.html#--ciphers)
 users can control which ciphers to consider when negotiating TLS connections.
 
-TLS 1.3 ciphers are supported since curl 7.61 for OpenSSL 1.1.1+, and since
-curl 7.85 for Schannel with options
+TLS 1.3 ciphers are supported since curl 7.61 for OpenSSL 1.1.1+, since curl
+7.85 for Schannel, since curl 8.10.0 for wolfSSL and since curl 8.10.0 for
+mbedTLS 3.6.0+ with options
 [`CURLOPT_TLS13_CIPHERS`](https://curl.se/libcurl/c/CURLOPT_TLS13_CIPHERS.html)
 and
 [`--tls13-ciphers`](https://curl.se/docs/manpage.html#--tls13-ciphers)
-. If you are using a different SSL backend you can try setting TLS 1.3 cipher
-suites by using the respective regular cipher option.
+. Before curl 8.10.0 with mbedTLS or wolfSSL, TLS 1.3 cipher suites where set
+by using the respective regular cipher option.
 
 The names of the known ciphers differ depending on which TLS backend that
 libcurl was built to use. This is an attempt to list known cipher names.

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
@@ -15,6 +15,8 @@ Protocol:
 TLS-backend:
   - OpenSSL
   - Schannel
+  - wolfSSL
+  - mbedTLS
 Added-in: 7.61.0
 ---
 
@@ -42,9 +44,11 @@ Find more details about cipher lists on this URL:
 
  https://curl.se/docs/ssl-ciphers.html
 
-This option is currently used only when curl is built to use OpenSSL 1.1.1 or
-later. If you are using a different SSL backend you can try setting TLS 1.3
-cipher suites by using the CURLOPT_PROXY_SSL_CIPHER_LIST(3) option.
+This option is used when curl is built to use OpenSSL 1.1.1 or later,
+Schannel, wolfSSL, or mbedTLS 3.6.0 or later.
+
+Before curl 8.10.0 with mbedTLS or wolfSSL, TLS 1.3 cipher suites where set
+by using the CURLOPT_PROXY_SSL_CIPHER_LIST(3) option.
 
 The application does not have to keep the string around after setting this
 option.
@@ -71,6 +75,16 @@ int main(void)
   }
 }
 ~~~
+
+# HISTORY
+
+Added in 7.61.0 for OpenSSL. Available when built with OpenSSL \>= 1.1.1.
+
+Added in 7.85.0 for Schannel.
+
+Added in 8.10.0 for wolfSSL.
+
+Added in 8.10.0 for mbedTLS. Available when built with mbedTLS \>= 3.6.0.
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
@@ -16,6 +16,8 @@ Protocol:
 TLS-backend:
   - OpenSSL
   - Schannel
+  - wolfSSL
+  - mbedTLS
 Added-in: 7.61.0
 ---
 
@@ -42,10 +44,11 @@ Find more details about cipher lists on this URL:
 
  https://curl.se/docs/ssl-ciphers.html
 
-This option is currently used only when curl is built to use OpenSSL 1.1.1 or
-later, or Schannel. If you are using a different SSL backend you can try
-setting TLS 1.3 cipher suites by using the CURLOPT_SSL_CIPHER_LIST(3)
-option.
+This option is used when curl is built to use OpenSSL 1.1.1 or later,
+Schannel, wolfSSL, or mbedTLS 3.6.0 or later.
+
+Before curl 8.10.0 with mbedTLS or wolfSSL, TLS 1.3 cipher suites where set
+by using the CURLOPT_SSL_CIPHER_LIST(3) option.
 
 The application does not have to keep the string around after setting this
 option.
@@ -78,6 +81,10 @@ int main(void)
 Added in 7.61.0 for OpenSSL. Available when built with OpenSSL \>= 1.1.1.
 
 Added in 7.85.0 for Schannel.
+
+Added in 8.10.0 for wolfSSL.
+
+Added in 8.10.0 for mbedTLS. Available when built with mbedTLS \>= 3.6.0.
 
 # %AVAILABILITY%
 


### PR DESCRIPTION
Documentation for #14384 and #14385