### PR TITLE
tool_operate: Fix warning potentially uninitialized local variable 'pc' used

### DIFF
--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -182,7 +182,7 @@ fail:
  */
 CURLcode get_url_file_name(char **filename, const char *url)
 {
-  char *pc, *pc2;
+  char *pc = NULL, *pc2 = NULL;
   CURLU *uh = curl_url();
   char *path = NULL;
   CURLUcode uerr;


### PR DESCRIPTION
From changes here:
https://github.com/curl/curl/pull/13988

Fix warning:
c:\projects\curl\src\tool_operhlp.c(215): error C2220: warning treated as error - no 'object' file generated [C:\projects\curl\_bld\src\curl.vcxproj]
c:\projects\curl\src\tool_operhlp.c(215): warning C4701: potentially uninitialized local variable 'pc' used [C:\projects\curl\_bld\src\curl.vcxproj]
https://ci.appveyor.com/project/curlorg/curl/builds/50343057/job/ljcb0k5njpuh7w2v