### PR TITLE
sigpipe: init the struct so that first apply ignores

### DIFF
--- a/lib/sigpipe.h
+++ b/lib/sigpipe.h
@@ -39,6 +39,7 @@ struct sigpipe_ignore {
 static void sigpipe_init(struct sigpipe_ignore *ig)
 {
   memset(ig, 0, sizeof(*ig));
+  ig->no_signal = TRUE;
 }
 
 /*


### PR DESCRIPTION
Initializes 'no_signal' to TRUE, so that a call to sigpipe_apply() after init ignores the signal (unless CURLOPT_NOSIGNAL) is set.

I have read the existing code multiple times now and I think it gets the initial state reversed this missing to ignore.

Regression from 17e6f06ea37136c36d27

Reported-by: Rasmus Thomsen
Fixes #14344