### PR TITLE
tool_help: fix a NULL deref in the --help option code

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -264,7 +264,7 @@ void tool_help(char *category)
         noflagged = TRUE;
       }
       a = findlongopt(lookup);
-      if(noflagged && (ARGTYPE(a->desc) != ARG_BOOL))
+      if(a && noflagged && (ARGTYPE(a->desc) != ARG_BOOL))
         /* a --no- prefix for a non-boolean is not specifying a proper
            option */
         a = NULL;


### PR DESCRIPTION
Follow-up to 9a0cf56471c1a

Pointed out by CodeSonar