### PR TITLE
cmake: fix `GSS_VERSION` for Heimdal found via pkg-config

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -255,7 +255,7 @@ else()
     set(_GSS_VERSION _GSS_PKG_${_MIT_MODNAME}_VERSION)
   else()
     set(GSS_FLAVOUR "Heimdal")
-    set(_GSS_VERSION _GSS_PKG_${_MIT_HEIMDAL}_VERSION)
+    set(_GSS_VERSION _GSS_PKG_${_HEIMDAL_MODNAME}_VERSION)
   endif()
 endif()
 


### PR DESCRIPTION
Previously used source variable was never defined, possibly due
to a copy-paste-edit typo.

Closes #14393