### PR TITLE
Flags to opcodes should ignore CURLWS_CONT flag

### DIFF
--- a/lib/ws.c
+++ b/lib/ws.c
@@ -560,7 +560,7 @@ static ssize_t ws_enc_write_head(struct Curl_easy *data,
     return -1;
   }
 
-  opcode = ws_frame_flags2op((int)flags);
+  opcode = ws_frame_flags2op((int)flags & ~CURLWS_CONT);
   if(!opcode) {
     failf(data, "WS: provided flags not recognized '%x'", flags);
     *err = CURLE_SEND_ERROR;


### PR DESCRIPTION
When converting WebSocket flags such as CURLWS_TEXT | CURLWS_CONT to opcodes for sending fragmented frames, we want to exclude CURLWS_CONT from the lookup so AND it out.

Alternatively, this tweak could be moved into the ws_frame_flags2op() function or the WS_FRAMES table could be re-ordered to test CURLWS_TEXT and CURLWS_BINARY first.

(I'm assuming this is how call to curl_ws_send() is supposed to be used.  My apologies if not.)