### PR TITLE
GHA/windows: ignore test 165 in Schannel MSVC job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -481,6 +481,7 @@ jobs:
         run: |
           export TFLAGS='-j14 !TFTP !MQTT !WebSockets !SMTP !FTP ${{ matrix.tflags }}'
           if [[ '${{ matrix.config }}' = *'-DUSE_WIN32_IDN=ON'* ]]; then
+            TFLAGS+=' ~165'
             if [[ '${{ matrix.config }}' != *'-DENABLE_UNICODE=ON'* ]]; then
               TFLAGS+=' ~1448 ~2046 ~2047'
             fi


### PR DESCRIPTION
Schannel MSVC job: Ignore test 165 when -DUSE_WIN32_IDN=ON

After this ci is fail on Schannel
https://github.com/curl/curl/pull/14387

https://github.com/curl/curl/actions/runs/10251838878/job/28360790340?pr=14383
```
  TESTDONE: 1054 tests out of 1056 reported OK: 99%
  FAIL 165: 'HTTP over proxy with IDN host name' HTTP, HTTP GET, HTTP proxy, IDN
  TESTFAIL: These test cases failed: 165
```

