### PR TITLE
curl: warn on unsupported SSL options including --ciphers, --tls13-ciphers

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -255,15 +255,23 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     /* deprecated */
     break;
   case CURLOPT_SSL_CIPHER_LIST:
-    /* set a list of cipher we want to use in the SSL connection */
-    result = Curl_setstropt(&data->set.str[STRING_SSL_CIPHER_LIST],
-                            va_arg(param, char *));
+    if(Curl_ssl_supports(data, SSLSUPP_CIPHER_LIST)) {
+      /* set a list of cipher we want to use in the SSL connection */
+      result = Curl_setstropt(&data->set.str[STRING_SSL_CIPHER_LIST],
+                              va_arg(param, char *));
+    }
+    else
+      return CURLE_NOT_BUILT_IN;
     break;
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSL_CIPHER_LIST:
-    /* set a list of cipher we want to use in the SSL connection for proxy */
-    result = Curl_setstropt(&data->set.str[STRING_SSL_CIPHER_LIST_PROXY],
-                            va_arg(param, char *));
+    if(Curl_ssl_supports(data, SSLSUPP_CIPHER_LIST)) {
+      /* set a list of cipher we want to use in the SSL connection for proxy */
+      result = Curl_setstropt(&data->set.str[STRING_SSL_CIPHER_LIST_PROXY],
+                              va_arg(param, char *));
+    }
+    else
+      return CURLE_NOT_BUILT_IN;
     break;
 #endif
   case CURLOPT_TLS13_CIPHERS:

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -1113,7 +1113,12 @@ static CURLcode bearssl_sha256sum(const unsigned char *input,
 
 const struct Curl_ssl Curl_ssl_bearssl = {
   { CURLSSLBACKEND_BEARSSL, "bearssl" }, /* info */
-  SSLSUPP_CAINFO_BLOB | SSLSUPP_SSL_CTX | SSLSUPP_HTTPS_PROXY,
+
+  SSLSUPP_CAINFO_BLOB |
+  SSLSUPP_SSL_CTX |
+  SSLSUPP_HTTPS_PROXY |
+  SSLSUPP_CIPHER_LIST,
+
   sizeof(struct bearssl_ssl_backend_data),
 
   Curl_none_init,                  /* init */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1726,7 +1726,8 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
 #ifdef TLS13_SUPPORT
   SSLSUPP_TLS13_CIPHERSUITES |
 #endif
-  SSLSUPP_HTTPS_PROXY,
+  SSLSUPP_HTTPS_PROXY |
+  SSLSUPP_CIPHER_LIST,
 
   sizeof(struct mbed_ssl_backend_data),
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5212,7 +5212,8 @@ const struct Curl_ssl Curl_ssl_openssl = {
   SSLSUPP_ECH |
 #endif
   SSLSUPP_CA_CACHE |
-  SSLSUPP_HTTPS_PROXY,
+  SSLSUPP_HTTPS_PROXY |
+  SSLSUPP_CIPHER_LIST,
 
   sizeof(struct ossl_ctx),
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2969,7 +2969,8 @@ const struct Curl_ssl Curl_ssl_schannel = {
 #endif
   SSLSUPP_TLS13_CIPHERSUITES |
   SSLSUPP_CA_CACHE |
-  SSLSUPP_HTTPS_PROXY,
+  SSLSUPP_HTTPS_PROXY |
+  SSLSUPP_CIPHER_LIST,
 
   sizeof(struct schannel_ssl_backend_data),
 

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2888,7 +2888,8 @@ const struct Curl_ssl Curl_ssl_sectransp = {
 #ifdef SECTRANSP_PINNEDPUBKEY
   SSLSUPP_PINNEDPUBKEY |
 #endif /* SECTRANSP_PINNEDPUBKEY */
-  SSLSUPP_HTTPS_PROXY,
+  SSLSUPP_HTTPS_PROXY |
+  SSLSUPP_CIPHER_LIST,
 
   sizeof(struct st_ssl_backend_data),
 

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -39,6 +39,7 @@ struct Curl_ssl_session;
 #define SSLSUPP_CAINFO_BLOB  (1<<6)
 #define SSLSUPP_ECH          (1<<7)
 #define SSLSUPP_CA_CACHE     (1<<8)
+#define SSLSUPP_CIPHER_LIST  (1<<9) /* supports TLS 1.0-1.2 ciphersuites */
 
 #define ALPN_ACCEPTED "ALPN: server accepted "
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1918,7 +1918,8 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
 #ifdef WOLFSSL_TLS13
   SSLSUPP_TLS13_CIPHERSUITES |
 #endif
-  SSLSUPP_CA_CACHE,
+  SSLSUPP_CA_CACHE |
+  SSLSUPP_CIPHER_LIST,
 
   sizeof(struct wolfssl_ctx),
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -945,6 +945,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         urlnum = state->urlnum;
 
       if(state->up < state->infilenum) {
+        char ssl_ver[80] = "no ssl";
         struct per_transfer *per = NULL;
         struct OutStruct *outs;
         struct OutStruct *heads;
@@ -1654,6 +1655,14 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             my_setopt(curl, CURLOPT_SSH_COMPRESSION, 1L);
         }
 
+        {
+          /* get current SSL backend, chop off multissl */
+          const char *v = curl_version_info(CURLVERSION_NOW)->ssl_version;
+          if(v)
+            msnprintf(ssl_ver, sizeof(ssl_ver),
+                      "%.*s", (int) strcspn(v, " "), v);
+        }
+
         if(config->cacert)
           my_setopt_str(curl, CURLOPT_CAINFO, config->cacert);
         if(config->proxy_cacert)
@@ -1662,9 +1671,10 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->capath) {
           result = res_setopt_str(curl, CURLOPT_CAPATH, config->capath);
           if(result == CURLE_NOT_BUILT_IN) {
-            warnf(global, "ignoring %s, not supported by libcurl",
-                  capath_from_env?
-                  "SSL_CERT_DIR environment variable":"--capath");
+            warnf(global, "ignoring %s, not supported by libcurl with %s",
+                  capath_from_env ?
+                  "SSL_CERT_DIR environment variable" : "--capath",
+                  ssl_ver);
           }
           else if(result)
             break;
@@ -1679,8 +1689,10 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           if((result == CURLE_NOT_BUILT_IN) ||
              (result == CURLE_UNKNOWN_OPTION)) {
             if(config->proxy_capath) {
-              warnf(global,
-                    "ignoring --proxy-capath, not supported by libcurl");
+              warnf(global, "ignoring %s, not supported by libcurl with %s",
+                    config->proxy_capath ?
+                    "--proxy-capath" : "--capath",
+                    ssl_ver);
             }
           }
           else if(result)
@@ -1698,8 +1710,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
                 blob.len);
           result = curl_easy_setopt(curl, CURLOPT_CAINFO_BLOB, &blob);
           if(result == CURLE_NOT_BUILT_IN) {
-            warnf(global,
-                  "ignoring embedded CA bundle, not supported by libcurl");
+            warnf(global, "ignoring %s, not supported by libcurl with %s",
+                  "embedded CA bundle", ssl_ver);
           }
         }
         if(!config->proxy_cacert && !config->proxy_capath) {
@@ -1712,8 +1724,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
                 blob.len);
           result = curl_easy_setopt(curl, CURLOPT_PROXY_CAINFO_BLOB, &blob);
           if(result == CURLE_NOT_BUILT_IN) {
-            warnf(global,
-                  "ignoring embedded CA bundle, not supported by libcurl");
+            warnf(global, "ignoring %s, not supported by libcurl with %s",
+                  "embedded CA bundle", ssl_ver);
           }
         }
 #endif
@@ -1725,8 +1737,13 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         else if(config->crlfile) /* CURLOPT_PROXY_CRLFILE default is crlfile */
           my_setopt_str(curl, CURLOPT_PROXY_CRLFILE, config->crlfile);
 
-        if(config->pinnedpubkey)
-          my_setopt_str(curl, CURLOPT_PINNEDPUBLICKEY, config->pinnedpubkey);
+        if(config->pinnedpubkey) {
+          result = res_setopt_str(curl, CURLOPT_PINNEDPUBLICKEY,
+                                  config->pinnedpubkey);
+          if(result == CURLE_NOT_BUILT_IN)
+            warnf(global, "ignoring %s, not supported by libcurl with %s",
+                  "--pinnedpubkey", ssl_ver);
+        }
 
         if(config->ssl_ec_curves)
           my_setopt_str(curl, CURLOPT_SSL_EC_CURVES, config->ssl_ec_curves);
@@ -2043,19 +2060,34 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if(config->doh_url)
           my_setopt_str(curl, CURLOPT_DOH_URL, config->doh_url);
 
-        if(config->cipher_list)
-          my_setopt_str(curl, CURLOPT_SSL_CIPHER_LIST, config->cipher_list);
-
-        if(config->proxy_cipher_list)
-          my_setopt_str(curl, CURLOPT_PROXY_SSL_CIPHER_LIST,
-                        config->proxy_cipher_list);
-
-        if(config->cipher13_list)
-          my_setopt_str(curl, CURLOPT_TLS13_CIPHERS, config->cipher13_list);
-
-        if(config->proxy_cipher13_list)
-          my_setopt_str(curl, CURLOPT_PROXY_TLS13_CIPHERS,
-                        config->proxy_cipher13_list);
+        if(config->cipher_list) {
+          result = res_setopt_str(curl, CURLOPT_SSL_CIPHER_LIST,
+                                  config->cipher_list);
+          if(result == CURLE_NOT_BUILT_IN)
+            warnf(global, "ignoring %s, not supported by libcurl with %s",
+                  "--ciphers", ssl_ver);
+        }
+        if(config->proxy_cipher_list) {
+          result = res_setopt_str(curl, CURLOPT_PROXY_SSL_CIPHER_LIST,
+                                  config->proxy_cipher_list);
+          if(result == CURLE_NOT_BUILT_IN)
+            warnf(global, "ignoring %s, not supported by libcurl with %s",
+                  "--proxy-ciphers", ssl_ver);
+        }
+        if(config->cipher13_list) {
+          result = res_setopt_str(curl, CURLOPT_TLS13_CIPHERS,
+                                  config->cipher13_list);
+          if(result == CURLE_NOT_BUILT_IN)
+            warnf(global, "ignoring %s, not supported by libcurl with %s",
+                  "--tls13-ciphers", ssl_ver);
+        }
+        if(config->proxy_cipher13_list) {
+          result = res_setopt_str(curl, CURLOPT_PROXY_TLS13_CIPHERS,
+                                  config->proxy_cipher13_list);
+          if(result == CURLE_NOT_BUILT_IN)
+            warnf(global, "ignoring %s, not supported by libcurl with %s",
+                  "--proxy-tls13-ciphers", ssl_ver);
+        }
 
         /* new in libcurl 7.9.2: */
         if(config->disable_epsv)


### PR DESCRIPTION
In curl warn when trying to use an option that is not supported by the SSL backend.

In libcurl added SSLSUPP_CIPHER_LIST flag to be able to differentiate SSL backends that support CURLOPT_SSL_CIPHER_LIST.