### PR TITLE
cmake: use numeric comparison for `HAVE_WIN32_WINNT`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1240,14 +1240,14 @@ if(WIN32)
   unset(HAVE_WIN32_WINNT CACHE)
 
   if(HAVE_WIN32_WINNT)
-    if(HAVE_WIN32_WINNT STRLESS "0x0501")
+    if(HAVE_WIN32_WINNT LESS 0x0501)
       # Windows XP is required for freeaddrinfo, getaddrinfo
       message(FATAL_ERROR "Building for Windows XP or newer is required.")
     endif()
 
     # Pre-fill detection results based on target OS version
     if(MINGW OR MSVC)
-      if(HAVE_WIN32_WINNT STRLESS "0x0600")
+      if(HAVE_WIN32_WINNT LESS 0x0600)
         set(HAVE_INET_NTOP 0)
         set(HAVE_INET_PTON 0)
       else()  # Windows Vista or newer
@@ -1814,7 +1814,7 @@ if(NOT CURL_DISABLE_INSTALL)
   _add_if("Unicode"       ENABLE_UNICODE)
   _add_if("threadsafe"    HAVE_ATOMIC OR
                           (USE_THREADS_POSIX AND HAVE_PTHREAD_H) OR
-                          (WIN32 AND HAVE_WIN32_WINNT GREATER_EQUAL 0x600))
+                          (WIN32 AND HAVE_WIN32_WINNT GREATER_EQUAL 0x0600))
   _add_if("Debug"         ENABLE_DEBUG)
   _add_if("TrackMemory"   ENABLE_CURLDEBUG)
   _add_if("ECH"           SSL_ENABLED AND HAVE_ECH)


### PR DESCRIPTION
Turns out CMake supports numeric comparison with hexadecimal values.
Confirmed in GHA/linux-old with CMake 3.7.2. I could not find
documentation about this, but our CMakeLists.txt already used it before
this patch.

Extend that method to two more comparisons.

Also pad the value in the existing one to 4 digits.

The padding/lowercasing logic when setting `HAVE_WIN32_WINNT` is no
longer required, but keep it anyway for uniform log output.

Follow-up to 2100d9fde267eea68f8097ff0a8ba7b3c9742c7f #12044
Closes #14409
