### PR TITLE
cmake: replace an `MSVC_VERSION` with `MSVC`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1607,7 +1607,7 @@ if(MSVC)
 endif()
 
 if(CURL_WERROR)
-  if(MSVC_VERSION)
+  if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /WX")
   else()
     # This assumes clang or gcc style options


### PR DESCRIPTION
Where the actual version is not relevant.

Follow-up to ce81aeb877c242a173f7eecf02dd2723a0cbce42
Closes #14410
