### PR TITLE
dist: drop buildconf

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -44,6 +44,7 @@ Autoconf
 autoconf
 Automake
 automake
+autoreconf
 Autotools
 autotools
 AVR
@@ -78,7 +79,6 @@ bugfix
 bugfixes
 buildable
 buildbot
-buildconf
 Caddy
 calloc
 CAPA

--- a/.github/workflows/badwords.yml
+++ b/.github/workflows/badwords.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: check
-        run: ./.github/scripts/badwords.pl < .github/scripts/badwords.txt docs/*.md docs/libcurl/*.md docs/libcurl/opts/*.md docs/cmdline-opts/*.md docs/TODO docs/KNOWN_BUGS
+        run: ./.github/scripts/badwords.pl < .github/scripts/badwords.txt docs/*.md docs/libcurl/*.md docs/libcurl/opts/*.md docs/cmdline-opts/*.md docs/TODO docs/KNOWN_BUGS tests/*.md
 
   source:
     runs-on: ubuntu-latest

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,10 +75,9 @@ PLAN9_DIST = plan9/include/mkfile \
  plan9/src/mkfile.inc             \
  plan9/src/mkfile
 
-EXTRA_DIST = CHANGES.md COPYING maketgz Makefile.dist curl-config.in       \
- RELEASE-NOTES buildconf libcurl.pc.in $(CMAKE_DIST) $(VC_DIST)         \
- $(WINBUILD_DIST) $(PLAN9_DIST) lib/libcurl.vers.in buildconf.bat       \
- libcurl.def Dockerfile
+EXTRA_DIST = CHANGES.md COPYING maketgz Makefile.dist curl-config.in    \
+ RELEASE-NOTES libcurl.pc.in $(CMAKE_DIST) $(VC_DIST) $(WINBUILD_DIST)  \
+ $(PLAN9_DIST) lib/libcurl.vers.in buildconf.bat libcurl.def Dockerfile
 
 CLEANFILES = $(VC14_LIBVCXPROJ) $(VC14_SRCVCXPROJ) \
  $(VC14_10_LIBVCXPROJ) $(VC14_10_SRCVCXPROJ)       \

--- a/maketgz
+++ b/maketgz
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Script to build release-archives with. Note that this requires a checkout
-# from git and you should first run ./buildconf and build curl once.
+# from git and you should first run autoreconf -fi and build curl once.
 #
 #***************************************************************************
 #                                  _   _ ____  _

--- a/tests/CI.md
+++ b/tests/CI.md
@@ -6,8 +6,8 @@ SPDX-License-Identifier: curl
 
 # Continuous Integration for curl
 
-Curl runs in many different environments, so every change is run against a large
-number of test suites.
+Curl runs in many different environments, so every change is run against a
+large number of test suites.
 
 Every pull request is verified for each of the following:
 
@@ -22,10 +22,10 @@ Every pull request is verified for each of the following:
  - ... code coverage does not shrink drastically
  - ... different TLS backends still compile and pass tests
 
-If the pull-request fails one of these tests, it will show up as a red X and
-you are expected to fix the problem. If you do not understand when the issue is
-or have other problems to fix the complaint, just ask and other project
-members will likely be able to help out.
+If the pull-request fails one of these tests, it shows up as a red X and you
+are expected to fix the problem. If you do not understand when the issue is or
+have other problems to fix the complaint, just ask and other project members
+can likely help out.
 
 Consider the following table while looking at pull request failures:
 

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -23,9 +23,9 @@ with a `testcase` tag, which encompasses the remainder of the file.
 # Preprocessing
 
 When a test is to be executed, the source file is first preprocessed and
-variables are substituted by their respective contents and the output
-version of the test file is stored as `%LOGDIR/testNUM`. That version is what
-will be read and used by the test servers.
+variables are substituted by their respective contents and the output version
+of the test file is stored as `%LOGDIR/testNUM`. That version is what is read
+and used by the test servers.
 
 ## Base64 Encoding
 
@@ -80,7 +80,7 @@ This instruction allows a test case to include another file. It is helpful to
 remember that the ordinary variables are expanded before the include happens
 so `%LOGDIR` and the others can be used in the include line.
 
-The file name cannot contain `%` as that letter is used to end the name for
+The filename cannot contain `%` as that letter is used to end the name for
 the include instruction:
 
     %include filename%
@@ -89,7 +89,7 @@ the include instruction:
 
 Lines in the test file can be made to appear conditionally on a specific
 feature (see the "features" section below) being set or not set. If the
-specific feature is present, the following lines will be output, otherwise it
+specific feature is present, the following lines are output, otherwise it
 outputs nothing, until a following else or `endif` clause. Like this:
 
     %if brotli
@@ -116,7 +116,7 @@ Nested conditions are supported.
 
 # Variables
 
-When the test is preprocessed, a range of "variables" in the test file will be
+When the test is preprocessed, a range of "variables" in the test file is
 replaced by their content at that time.
 
 Available substitute variables include:
@@ -193,13 +193,13 @@ requests curl sends
 been run ended up correct
 
 Each main section has a number of available subsections that can be specified,
-that will be checked/used if specified.
+that are checked/used if specified.
 
 ## `<info>`
 
 ### `<keywords>`
 A newline-separated list of keywords describing what this test case uses and
-tests. Try to use already used keywords. These keywords will be used for
+tests. Try to use already used keywords. These keywords are used for
 statistical/informational purposes and for choosing or skipping classes of
 tests. Keywords must begin with an alphabetic character, `-`, `[` or `{` and
 may actually consist of multiple words separated by spaces which are treated
@@ -229,24 +229,24 @@ arrived safely. Set `nocheck="yes"` to prevent the test script from verifying
 the arrival of this data.
 
 If the data contains `swsclose` anywhere within the start and end tag, and
-this is an HTTP test, then the connection will be closed by the server after
-this response is sent. If not, the connection will be kept persistent.
+this is an HTTP test, then the connection is closed by the server after this
+response is sent. If not, the connection is kept persistent.
 
 If the data contains `swsbounce` anywhere within the start and end tag, the
-HTTP server will detect if this is a second request using the same test and
-part number and will then increase the part number with one. This is useful
-for auth tests and similar.
+HTTP server detects if this is a second request using the same test and part
+number and then increases the part number with one. This is useful for auth
+tests and similar.
 
-`sendzero=yes` means that the (FTP) server will "send" the data even if the
-size is zero bytes. Used to verify curl's behavior on zero bytes transfers.
+`sendzero=yes` means that the (FTP) server "sends" the data even if the size
+is zero bytes. Used to verify curl's behavior on zero bytes transfers.
 
 `base64=yes` means that the data provided in the test-file is a chunk of data
 encoded with base64. It is the only way a test case can contain binary
-data. (This attribute can in fact be used on any section, but it doesn't make
+data. (This attribute can in fact be used on any section, but it does not make
 much sense for other sections than "data").
 
-`hex=yes` means that the data is a sequence of hex pairs. It will get decoded
-and used as "raw" data.
+`hex=yes` means that the data is a sequence of hex pairs. It gets decoded and
+used as "raw" data.
 
 `nonewline=yes` means that the last byte (the trailing newline character)
 should be cut off from the data before sending or comparing it.
@@ -255,10 +255,10 @@ should be cut off from the data before sending or comparing it.
 the source file. Note that this makes runtests.pl parse and "guess" what is a
 header and what is not in order to apply the CRLF line endings appropriately.
 
-For FTP file listings, the `<data>` section will be used *only* if you make
-sure that there has been a CWD done first to a directory named `test-[NUM]`
-where `NUM` is the test case number. Otherwise the ftp server can't know from
-which test file to load the list content.
+For FTP file listings, the `<data>` section is be used *only* if you make sure
+that there has been a CWD done first to a directory named `test-[NUM]` where
+`NUM` is the test case number. Otherwise the ftp server cannot know from which
+test file to load the list content.
 
 ### `<dataNUM [crlf="yes"]>`
 
@@ -289,8 +289,8 @@ Address type and address details as logged by the SOCKS proxy.
 
 ### `<datacheck [mode="text"] [nonewline="yes"] [crlf="yes"]>`
 if the data is sent but this is what should be checked afterwards. If
-`nonewline=yes` is set, runtests will cut off the trailing newline from the
-data before comparing with the one actually received by the client.
+`nonewline=yes` is set, runtests cuts off the trailing newline from the data
+before comparing with the one actually received by the client.
 
 Use the `mode="text"` attribute if the output is in text mode on platforms
 that have a text/binary difference.
@@ -304,7 +304,7 @@ number to return on a ftp SIZE command (set to -1 to make this command fail)
 
 ### `<mdtm>`
 what to send back if the client sends a (FTP) `MDTM` command, set to -1 to
-have it return that the file doesn't exist
+have it return that the file does not exist
 
 ### `<postcmd>`
 special purpose server-command to control its behavior *after* the
@@ -316,15 +316,15 @@ For HTTP/HTTPS, these are supported:
 ### `<servercmd>`
 Special-commands for the server.
 
-The first line of this file will always be set to `Testnum [number]` by the
-test script, to allow servers to read that to know what test the client is
-about to issue.
+The first line of this file is always set to `Testnum [number]` by the test
+script, to allow servers to read that to know what test the client is about to
+issue.
 
 #### For FTP/SMTP/POP/IMAP
 
 - `REPLY [command] [return value] [response string]` - Changes how the server
   responds to the [command]. [response string] is evaluated as a perl string,
-  so it can contain embedded \r\n, for example. There's a special [command]
+  so it can contain embedded \r\n, for example. There is a special [command]
   named "welcome" (without quotes) which is the string sent immediately on
   connect as a welcome.
 - `REPLYLF` (like above but sends the response terminated with LF-only and not
@@ -335,10 +335,10 @@ about to issue.
   time
 - `RETRWEIRDO` - Enable the "weirdo" RETR case when multiple response lines
    appear at once when a file is transferred
-- `RETRNOSIZE` - Make sure the RETR response doesn't contain the size of the
+- `RETRNOSIZE` - Make sure the RETR response does not contain the size of the
   file
 - `RETRSIZE [size]` - Force RETR response to contain the specified size
-- `NOSAVE` - Don't actually save what is received
+- `NOSAVE` - Do not actually save what is received
 - `SLOWDOWN` - Send FTP responses with 0.01 sec delay between each byte
 - `PASVBADIP` - makes PASV send back an illegal IP in its 227 response
 - `CAPA [capabilities]` - Enables support for and specifies a list of space
@@ -351,7 +351,7 @@ about to issue.
 #### For HTTP/HTTPS
 
 - `auth_required` if this is set and a POST/PUT is made without auth, the
-  server will NOT wait for the full request body to get sent
+  server does NOT wait for the full request body to get sent
 - `delay: [msecs]` - delay this amount after connection
 - `idle` - do nothing after receiving the request, just "sit idle"
 - `stream` - continuously send data to the client, never-ending
@@ -360,12 +360,12 @@ about to issue.
   a PUT or POST request
 - `rtp: part [num] channel [num] size [num]` - stream a fake RTP packet for
   the given part on a chosen channel with the given payload size
-- `connection-monitor` - When used, this will log `[DISCONNECT]` to the
+- `connection-monitor` - When used, this logs `[DISCONNECT]` to the
   `server.input` log when the connection is disconnected.
-- `upgrade` - when an HTTP upgrade header is found, the server will upgrade to
+- `upgrade` - when an HTTP upgrade header is found, the server upgrades to
   http2
 - `swsclose` - instruct server to close connection after response
-- `no-expect` - don't read the request body if Expect: is present
+- `no-expect` - do not read the request body if Expect: is present
 
 #### For TFTP
 `writedelay: [secs]` delay this amount between reply packets (each packet
@@ -411,17 +411,15 @@ What server(s) this test case requires/uses. Available servers:
 
 Give only one per line. This subsection is mandatory (use `none` if no servers
 are required). Servers that require a special server certificate can have the
-PEM certificate file name (found in the `certs` directory) appended to the
+PEM certificate filename (found in the `certs` directory) appended to the
 server name separated by a space.
 
 ### `<features>`
 A list of features that MUST be present in the client/library for this test to
-be able to run. If a required feature is not present then the test will be
-SKIPPED.
+be able to run. If a required feature is not present then the test is SKIPPED.
 
 Alternatively a feature can be prefixed with an exclamation mark to indicate a
-feature is NOT required. If the feature is present then the test will be
-SKIPPED.
+feature is NOT required. If the feature is present then the test is SKIPPED.
 
 Features testable here are:
 
@@ -507,13 +505,12 @@ restart servers.
 ### `<precheck>`
 A command line that if set gets run by the test script before the test. If an
 output is displayed by the command or if the return code is non-zero, the test
-will be skipped and the (single-line) output will be displayed as reason for
-not running the test.
+is skipped and the (single-line) output is displayed as reason for not running
+the test.
 
 ### `<postcheck>`
-A command line that if set gets run by the test script after the test. If
-the command exists with a non-zero status code, the test will be considered
-to have failed.
+A command line that if set gets run by the test script after the test. If the
+command exists with a non-zero status code, the test is considered failed.
 
 ### `<tool>`
 Name of tool to invoke instead of "curl". This tool must be built and exist
@@ -540,21 +537,21 @@ Command line to run.
 
 Note that the URL that gets passed to the server actually controls what data
 that is returned. The last slash in the URL must be followed by a number. That
-number (N) will be used by the test-server to load test case N and return the
-data that is defined within the `<reply><data></data></reply>` section.
+number (N) is used by the test-server to load test case N and return the data
+that is defined within the `<reply><data></data></reply>` section.
 
-If there's no test number found above, the HTTP test server will use the
-number following the last dot in the given hostname (made so that a CONNECT
-can still pass on test number) so that "foo.bar.123" gets treated as test case
+If there is no test number found above, the HTTP test server uses the number
+following the last dot in the given hostname (made so that a CONNECT can still
+pass on test number) so that "foo.bar.123" gets treated as test case
 123. Alternatively, if an IPv6 address is provided to CONNECT, the last
-hexadecimal group in the address will be used as the test number! For example
-the address "[1234::ff]" would be treated as test case 255.
+hexadecimal group in the address is used as the test number! For example the
+address "[1234::ff]" would be treated as test case 255.
 
 Set `type="perl"` to write the test case as a perl script. It implies that
-there's no memory debugging and valgrind gets shut off for this test.
+there is no memory debugging and valgrind gets shut off for this test.
 
 Set `type="shell"` to write the test case as a shell script. It implies that
-there's no memory debugging and valgrind gets shut off for this test.
+there is no memory debugging and valgrind gets shut off for this test.
 
 Set `option="no-output"` to prevent the test script to slap on the `--output`
 argument that directs the output to a file. The `--output` is also not added
@@ -586,12 +583,12 @@ parameter is the not negative integer number of seconds for the delay. This
 'delay' attribute is intended for specific test cases, and normally not
 needed.
 
-### `<file name="%LOGDIR/filename" [nonewline="yes"]>`
+### `<filename="%LOGDIR/filename" [nonewline="yes"]>`
 This creates the named file with this content before the test case is run,
 which is useful if the test case needs a file to act on.
 
-If `nonewline="yes"` is used, the created file will have the final newline
-stripped off.
+If `nonewline="yes"` is used, the created file gets the final newline stripped
+off.
 
 ### `<file1>`
 1 to 4 can be appended to 'file' to create more files.
@@ -605,7 +602,7 @@ stripped off.
 ### `<stdin [nonewline="yes"]>`
 Pass this given data on stdin to the tool.
 
-If `nonewline` is set, we will cut off the trailing newline of this given data
+If `nonewline` is set, we cut off the trailing newline of this given data
 before comparing with the one actually received by the client
 
 ## `<verify>`
@@ -625,8 +622,8 @@ advanced. Example: `s/^EPRT .*/EPRT stripped/`.
 
 ### `<protocol [nonewline="yes"][crlf="yes"]>`
 
-the protocol dump curl should transmit, if `nonewline` is set, we will cut off
-the trailing newline of this given data before comparing with the one actually
+the protocol dump curl should transmit, if `nonewline` is set, we cut off the
+trailing newline of this given data before comparing with the one actually
 sent by the client The `<strip>` and `<strippart>` rules are applied before
 comparisons are made.
 
@@ -636,9 +633,9 @@ test.
 ### `<proxy [nonewline="yes"][crlf="yes"]>`
 
 The protocol dump curl should transmit to an HTTP proxy (when the http-proxy
-server is used), if `nonewline` is set, we will cut off the trailing newline
-of this given data before comparing with the one actually sent by the client
-The `<strip>` and `<strippart>` rules are applied before comparisons are made.
+server is used), if `nonewline` is set, we cut off the trailing newline of
+this given data before comparing with the one actually sent by the client The
+`<strip>` and `<strippart>` rules are applied before comparisons are made.
 
 ### `<stderr [mode="text"] [nonewline="yes"] [crlf="yes"]>`
 This verifies that this data was passed to stderr.
@@ -649,7 +646,7 @@ have a text/binary difference.
 `crlf=yes` forces the newlines to become CRLF even if not written so in the
 test.
 
-If `nonewline` is set, we will cut off the trailing newline of this given data
+If `nonewline` is set, we cut off the trailing newline of this given data
 before comparing with the one actually received by the client
 
 ### `<stdout [mode="text"] [nonewline="yes"] [crlf="yes"] [loadfile="filename"]>`
@@ -658,7 +655,7 @@ This verifies that this data was passed to stdout.
 Use the mode="text" attribute if the output is in text mode on platforms that
 have a text/binary difference.
 
-If `nonewline` is set, we will cut off the trailing newline of this given data
+If `nonewline` is set, we cut off the trailing newline of this given data
 before comparing with the one actually received by the client
 
 `crlf=yes` forces the newlines to become CRLF even if not written so in the
@@ -666,7 +663,7 @@ test.
 
 `loadfile="filename"` makes loading the data from an external file.
 
-### `<file name="%LOGDIR/filename" [mode="text"]>`
+### `<filename="%LOGDIR/filename" [mode="text"]>`
 The file's contents must be identical to this after the test is complete. Use
 the mode="text" attribute if the output is in text mode on platforms that have
 a text/binary difference.

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -300,7 +300,7 @@ The contents of numbered `datacheck` sections are appended to the non-numbered
 one.
 
 ### `<size>`
-number to return on a ftp SIZE command (set to -1 to make this command fail)
+number to return on an ftp SIZE command (set to -1 to make this command fail)
 
 ### `<mdtm>`
 what to send back if the client sends a (FTP) `MDTM` command, set to -1 to
@@ -448,7 +448,7 @@ Features testable here are:
 - `IPv6`
 - `Kerberos`
 - `Largefile`
-- `large-time` (time_t is larger than 32 bit)
+- `large-time` (time_t is larger than 32-bit)
 - `ld_preload`
 - `libssh2`
 - `libssh`

--- a/tests/README.md
+++ b/tests/README.md
@@ -141,13 +141,13 @@ SPDX-License-Identifier: curl
 
 ### Memory test
 
-  The test script will check that all allocated memory is freed properly IF
-  curl has been built with the `CURLDEBUG` define set. The script will
-  automatically detect if that is the case, and it will use the
-  `memanalyze.pl` script to analyze the memory debugging output.
+  The test script checks that all allocated memory is freed properly IF curl
+  has been built with the `CURLDEBUG` define set. The script automatically
+  detects if that is the case, and it uses the `memanalyze.pl` script to
+  analyze the memory debugging output.
 
-  Also, if you run tests on a machine where valgrind is found, the script will
-  use valgrind to run the test with (unless you use `-n`) to further verify
+  Also, if you run tests on a machine where valgrind is found, the script uses
+  valgrind to run the test with (unless you use `-n`) to further verify
   correctness.
 
   The `runtests.pl` `-t` option enables torture testing mode. It runs each
@@ -183,7 +183,7 @@ SPDX-License-Identifier: curl
 
     CURL_DEBUG=ssl curl -v https://curl.se
 
-  will make the `ssl` connection filter log more details. One may do that for
+  makes the `ssl` connection filter log more details. One may do that for
   every filter type and also use a combination of names, separated by `,` or
   space.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -29,7 +29,7 @@ SPDX-License-Identifier: curl
   When you run tests via make, the flags `-a` and `-s` are passed, meaning
   to continue running tests even after one fails, and to emit short output.
 
-  If you'd like to not use those flags, you can run 'runtests.pl' directly.
+  If you would like to not use those flags, you can run 'runtests.pl' directly.
   You must `chdir` into the tests directory, then you can run it like so:
 
     ./runtests.pl 303 410
@@ -201,7 +201,7 @@ SPDX-License-Identifier: curl
 ### Test input files
 
   All test cases are put in the `data/` subdirectory. Each test is stored in
-  the file named according to the test number.
+  the filenamed according to the test number.
 
   See [`FILEFORMAT`](FILEFORMAT.md) for a description of the test case file
   format.
@@ -221,7 +221,7 @@ SPDX-License-Identifier: curl
 
     ggcov -r lib src
 
-  The text mode tool `gcov` may also be used, but it doesn't handle object
+  The text mode tool `gcov` may also be used, but it does not handle object
   files in more than one directory correctly.
 
 ### Remote testing
@@ -272,7 +272,7 @@ SPDX-License-Identifier: curl
 
 ### unit tests
 
-  Unit tests are placed in `tests/unit`. There's a tests/unit/README
+  Unit tests are placed in `tests/unit`. There is a tests/unit/README
   describing the specific set of checks and macros that may be used when
   writing tests that verify behaviors of specific individual functions.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -201,7 +201,7 @@ SPDX-License-Identifier: curl
 ### Test input files
 
   All test cases are put in the `data/` subdirectory. Each test is stored in
-  the filenamed according to the test number.
+  the file named according to the test number.
 
   See [`FILEFORMAT`](FILEFORMAT.md) for a description of the test case file
   format.

--- a/tests/runtests.md
+++ b/tests/runtests.md
@@ -28,8 +28,8 @@ test suite. It is often called from the root Makefile of the curl package with
 Specify which test(s) to run by specifying test numbers or keywords.
 
 If no test number or keyword is given, all existing tests that the script can
-find will be considered for running. You can specify single test cases to run
-by specifying test numbers space-separated, like `1 3 5 7 11`, and you can
+find are considered for running. You can specify single test cases to run by
+specifying test numbers space-separated, like `1 3 5 7 11`, and you can
 specify a range of tests like `45 to 67`.
 
 Specify tests to not run with a leading exclamation point, like `!66`, which
@@ -41,17 +41,17 @@ It is also possible to specify tests based on a keyword describing the test(s)
 to run, like `FTPS`. The keywords are strings used in the individual tests.
 
 You can also specify keywords with a leading exclamation point and the keyword
-or phrase, like "!HTTP NTLM auth" to run all tests **except** those using
-this keyword. Remember that the exclamation marks and spaces will need to be
-quoted somehow when entered at many command shells.
+or phrase, like "!HTTP NTLM auth" to run all tests **except** those using this
+keyword. Remember that the exclamation marks and spaces need to be quoted
+somehow when entered at many command shells.
 
 Prefix a keyword with a tilde (~) to still run it, but ignore the results.
 
 # OUTPUT
 
 When running without `-s` (short output), for instance when running
-runtests.pl directly rather than via make, each test will emits a pair of
-lines like this:
+runtests.pl directly rather than via make, each test emits a pair of lines
+like this:
 
     Test 0045...[simple HTTP Location: without protocol in initial URL]
     --pd---e-v- OK (45  out of 1427, remaining: 16:08, took 6.188s, duration: 00:31)
@@ -99,8 +99,8 @@ curl executable in the build tree.
 ## `-d`
 
 Enable protocol debug: have the servers display protocol output. If used in
-conjunction with parallel testing, it will be difficult to associate the logs
-with the test being run.
+conjunction with parallel testing, it is difficult to associate the logs with
+the specific test being run.
 
 ## `-E \<exclude_file\>`
 
@@ -115,8 +115,8 @@ the reason why matching tests should be skipped. The exclusion types are
 
 ## `-e`
 
-Run the test event-based (if possible). This will make runtests invoke curl
-with --test-event option. This option only works if both curl and libcurl were
+Run the test event-based (if possible). This makes runtests invoke curl with
+--test-event option. This option only works if both curl and libcurl were
 built debug-enabled.
 
 ## `-f`
@@ -222,7 +222,7 @@ the **Sysinternals** `handle[64].exe` to be on PATH)
 ## `--repeat=[num]`
 
 This repeats the given set of test numbers this many times. If no test numbers
-are given, it will repeat ALL tests this many times. It adds the new repeated
+are given, it repeats ALL tests this many times. It adds the new repeated
 sequence at the end of the initially given one.
 
 If **-R** option is also used, the scrambling is done after the repeats have
@@ -234,16 +234,16 @@ Shorter output. Speaks less than default.
 
 ## `--seed=[num]`
 
-When using *--shallow* or *-R* that randomize certain aspects of the
-behavior, this option can set the initial seed. If not set, the random seed
-will be set based on the currently set local year and month and the first line
-of the "curl -V" output.
+When using *--shallow* or *-R* that randomize certain aspects of the behavior,
+this option can set the initial seed. If not set, the random seed is set based
+on the currently set local year and month and the first line of the "curl -V"
+output.
 
 ## `--shallow=[num]`
 
 Used together with **-t**. This limits the number of tests to fail in torture
 mode to no more than **num** per test case. If this reduces the amount, the
-script will randomly discard entries to fail until the amount is **num**.
+script randomly discards entries to fail until the amount is **num**.
 
 The random seed initially set for this is fixed per month and can be set with
 *--seed*.
@@ -264,9 +264,9 @@ Error instead of warning on server unexpectedly alive.
 
 ## `-v`
 
-Enable verbose output. Speaks more than by default. If used in conjunction with
-parallel testing, it will be difficult to associate the logs with the test
-being run.
+Enable verbose output. Speaks more than by default. If used in conjunction
+with parallel testing, it is difficult to associate the logs with the specific
+test being run.
 
 ## `-vc \<curl\>`
 
@@ -283,7 +283,7 @@ use.
 
 The test script checks most of these by itself to determine when it is safe to
 attempt to run each test. Those which cannot be run due to failed requirements
-will simply be skipped and listed at the completion of all test cases. In some
+are simply skipped and listed at the completion of all test cases. In some
 unusual configurations, the test script cannot make the correct determination
 for all tests. In these cases, the problematic tests can be skipped using the
 "!keyword" skip feature documented earlier.

--- a/tests/runtests.md
+++ b/tests/runtests.md
@@ -106,7 +106,7 @@ with the test being run.
 
 Load the **exclude_file** with additional reasons why certain tests should be
 skipped. Useful when testing with external HTTP proxies in which case some of
-the tests aren't appropriate.
+the tests are not appropriate.
 
 The file contains colon-delimited lines. The first field contains the type of
 exclusion, the second field contains a pattern and the final field contains
@@ -183,13 +183,13 @@ etc not able to use this functionality.
 ## `-o \<variablename=value\>`
 
 Overwrite the specified internal **variable** with **value**. Useful to change
-variables that didn't get a dedicated flag to change them. Check the source to
+variables that did not get a dedicated flag to change them. Check the source to
 see which variables are available.
 
 ## `-P \<proxy\>`
 
 Use the specified HTTP proxy when executing tests, even if the tests
-themselves don't specify a proxy. This option allows one to test external
+themselves do not specify a proxy. This option allows one to test external
 proxies using curl's regression test suite.
 
 ## `-p`
@@ -291,5 +291,5 @@ for all tests. In these cases, the problematic tests can be skipped using the
 # WRITING TESTS
 
 The simplest way to write test cases is to start with a similar existing test,
-save it with a new number and then adjust it to fit. There's an attempt to
+save it with a new number and then adjust it to fit. There is an attempt to
 document the test case file format in **tests/FILEFORMAT.md**.

--- a/tests/testcurl.md
+++ b/tests/testcurl.md
@@ -31,10 +31,11 @@ https://curl.se/dev/builds.html
 *options* may be omitted. See *--setup* for what happens then.
 
 *dir* is a curl source dir, possibly a daily snapshot one. Using this will
-make *testcurl* skip the 'buildconf' stage and thus it removes the dependency
-on automake, autoconf, libtool, GNU m4 and possibly a few other things.
+make *testcurl* skip the 'autoreconf -fi' stage and thus it removes the
+dependency on automake, autoconf, libtool, GNU m4 and possibly a few other
+things.
 
-*testcurl* runs `buildconf` (or similar), configure, builds curl and libcurl
+*testcurl* runs `autoreconf -fi` (or similar), configure, builds curl and libcurl
 in a separate build directory and then runs `make test` to test the fresh
 build.
 
@@ -67,10 +68,11 @@ Set name to report as. Displayed in the build summary on the site.
 
 ## `--nobuildconf`
 
-Don't run buildconf. Useful when many builds use the same source tree, as then
-only one need to do this. Also, if multiple processes run tests simultaneously
-on the same source tree (like several hosts on a NFS mounted dir),
-simultaneous buildconf invokes may cause problems. (Added in 7.14.1)
+Don't run autoreconf -fi. Useful when many builds use the same source tree, as
+then only one need to do this. Also, if multiple processes run tests
+simultaneously on the same source tree (like several hosts on a NFS mounted
+dir), simultaneous autoreconf -fi invokes may cause problems. (Added in
+7.14.1)
 
 ## `--nogitpull`
 

--- a/tests/testcurl.md
+++ b/tests/testcurl.md
@@ -25,14 +25,14 @@ from a crontab job or similar at a regular interval. The output is suitable to
 be mailed to **curl-autocompile@haxx.se** to be dealt with automatically (make
 sure the subject includes the word "autobuild" as the mail gets silently
 discarded otherwise). The most current build status (with a reasonable
-backlog) will be published on the curl site, at
-https://curl.se/dev/builds.html
+backlog) is published on the curl site, at https://curl.se/dev/builds.html
 
 *options* may be omitted. See *--setup* for what happens then.
 
-*dir* is a curl source dir, possibly a daily snapshot one. Using this will
-make *testcurl* skip the *autoreconf* stage and thus it removes the dependency
-on automake, autoconf, libtool, GNU m4 and possibly a few other things.
+*dir* is a curl source directory, possibly a daily snapshot one. Using this
+makes *testcurl* skip the *autoreconf* stage and thus it removes the
+dependency on automake, autoconf, libtool, GNU m4 and possibly a few other
+things.
 
 *testcurl* runs `autoreconf` (or similar), configure, builds curl and libcurl
 in a separate build directory and then runs `make test` to test the fresh
@@ -70,7 +70,8 @@ Set name to report as. Displayed in the build summary on the site.
 Do not run autoreconf. Useful when many builds use the same source tree, as
 then only one need to do this. Also, if multiple processes run tests
 simultaneously on the same source tree (like several hosts on a NFS mounted
-dir), simultaneous autoreconf invokes may cause problems. (Added in 7.14.1)
+directory), simultaneous autoreconf invokes may cause problems. (Added in
+7.14.1)
 
 ## `--nogitpull`
 
@@ -84,10 +85,10 @@ by force, and similar.
 
 ## `--setup=[filename]`
 
-filename to read setup from (deprecated). The old style of providing info.
-If info is missing when *testcurl* is started, it will prompt you and then
-store the info in a 'setup' file, which it will look for on each invoke. Use
-*--name*, *--email*, *--configure* and *--desc* instead.
+filename to read setup from (deprecated). The old style of providing info. If
+info is missing when *testcurl* is started, it prompts you and then stores the
+info in a 'setup' file, which it looks for on each invoke. Use *--name*,
+*--email*, *--configure* and *--desc* instead.
 
 ## `--target=[your os]`
 
@@ -110,8 +111,8 @@ now and fill in the answers to the questions it prompts you for:
 
     $ ./curl/tests/testcurl
 
-Now you are ready to go. If you let the script run, it will perform a full
-cycle and spit out lots of output. Mail us that output as described above.
+Now you are ready to go. If you let the script run, it performs a full cycle
+and spit out lots of output. Mail us that output as described above.
 
 # CRONTAB EXAMPLE
 

--- a/tests/testcurl.md
+++ b/tests/testcurl.md
@@ -34,7 +34,7 @@ https://curl.se/dev/builds.html
 make *testcurl* skip the *autoreconf* stage and thus it removes the dependency
 on automake, autoconf, libtool, GNU m4 and possibly a few other things.
 
-*testcurl* runs `autoreconf -fi` (or similar), configure, builds curl and libcurl
+*testcurl* runs `autoreconf` (or similar), configure, builds curl and libcurl
 in a separate build directory and then runs `make test` to test the fresh
 build.
 
@@ -67,24 +67,24 @@ Set name to report as. Displayed in the build summary on the site.
 
 ## `--nobuildconf`
 
-Don't run autoreconf -fi. Useful when many builds use the same source tree, as
+Do not run autoreconf. Useful when many builds use the same source tree, as
 then only one need to do this. Also, if multiple processes run tests
 simultaneously on the same source tree (like several hosts on a NFS mounted
 dir), simultaneous autoreconf invokes may cause problems. (Added in 7.14.1)
 
 ## `--nogitpull`
 
-Don't update from git even though it is a git tree. Useful to still be able to
-test even though your network is down, or similar.
+Do not update from git even though it is a git tree. Useful to still be able
+to test even though your network is down, or similar.
 
 ## `--runtestopts=[options]`
 
 Options that is passed to the runtests script. Useful for disabling valgrind
 by force, and similar.
 
-## `--setup=[file name]`
+## `--setup=[filename]`
 
-File name to read setup from (deprecated). The old style of providing info.
+filename to read setup from (deprecated). The old style of providing info.
 If info is missing when *testcurl* is started, it will prompt you and then
 store the info in a 'setup' file, which it will look for on each invoke. Use
 *--name*, *--email*, *--configure* and *--desc* instead.

--- a/tests/testcurl.md
+++ b/tests/testcurl.md
@@ -31,9 +31,8 @@ https://curl.se/dev/builds.html
 *options* may be omitted. See *--setup* for what happens then.
 
 *dir* is a curl source dir, possibly a daily snapshot one. Using this will
-make *testcurl* skip the 'autoreconf -fi' stage and thus it removes the
-dependency on automake, autoconf, libtool, GNU m4 and possibly a few other
-things.
+make *testcurl* skip the *autoreconf* stage and thus it removes the dependency
+on automake, autoconf, libtool, GNU m4 and possibly a few other things.
 
 *testcurl* runs `autoreconf -fi` (or similar), configure, builds curl and libcurl
 in a separate build directory and then runs `make test` to test the fresh
@@ -71,8 +70,7 @@ Set name to report as. Displayed in the build summary on the site.
 Don't run autoreconf -fi. Useful when many builds use the same source tree, as
 then only one need to do this. Also, if multiple processes run tests
 simultaneously on the same source tree (like several hosts on a NFS mounted
-dir), simultaneous autoreconf -fi invokes may cause problems. (Added in
-7.14.1)
+dir), simultaneous autoreconf invokes may cause problems. (Added in 7.14.1)
 
 ## `--nogitpull`
 

--- a/tests/testcurl.pl
+++ b/tests/testcurl.pl
@@ -51,7 +51,7 @@
 # --notes=[notes]          More human-readable information about this configuration
 # --nocvsup                Don't pull from git even though it is a git tree
 # --nogitpull              Don't pull from git even though it is a git tree
-# --nobuildconf            Don't run buildconf
+# --nobuildconf            Don't run autoreconf -fi
 # --noconfigure            Don't run configure
 # --runtestopts=[options]  Options to pass to runtests.pl
 # --setup=[file name]      File name to read setup from (deprecated)
@@ -460,7 +460,7 @@ if ($git) {
   }
 
   if($nobuildconf) {
-    logit "told to not run buildconf";
+    logit "told to not run autoreconf -fi";
   }
   elsif ($configurebuild) {
     # remove possible left-overs from the past
@@ -479,10 +479,10 @@ if ($git) {
     close($f);
     close($log);
 
-    logit "buildconf was successful";
+    logit "autoreconf -fi was successful";
   }
   else {
-    logit "buildconf was successful (dummy message)";
+    logit "autoreconf -fi was successful (dummy message)";
   }
 }
 


### PR DESCRIPTION
The documented and mandated step has been to not use buildconf but to invoke 'autoreconf -fi' for four years already.

This change only drops buildconf from the release tarball, it remains present in git for now.

Follow-up to 85868537d6d5b8