### PR TITLE
GHA/macos: enable AppleIDN in autotools job

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -80,9 +80,9 @@ jobs:
             compiler: clang
             configure: --enable-debug --without-ssl --enable-websockets
             macos-version-min: '10.9'
-          - name: '!ssl libssh2'
+          - name: '!ssl libssh2 AppleIDN'
             compiler: clang
-            configure: --enable-debug --with-libssh2=$(brew --prefix libssh2) --without-ssl --enable-websockets
+            configure: --enable-debug --with-libssh2=$(brew --prefix libssh2) --without-ssl --with-apple-idn --enable-websockets
             macos-version-min: '10.9'
           - name: 'OpenSSL libssh c-ares'
             compiler: clang

--- a/configure.ac
+++ b/configure.ac
@@ -2776,11 +2776,11 @@ case $host_os in
           AC_CHECK_LIB(icucore, uidna_openUTS46,
           [
             AC_CHECK_HEADERS(unicode/uidna.h,
-               curl_idn_msg="enabled (AppleIDN)"
-               AC_DEFINE(USE_APPLE_IDN, 1, [if AppleIDN])
-               AC_SUBST(USE_APPLE_IDN, [1])
-               AC_SUBST([IDN_ENABLED], [1])
-               LIBS="-licucore $LIBS"
+              curl_idn_msg="enabled (AppleIDN)"
+              AC_DEFINE(USE_APPLE_IDN, 1, [if AppleIDN])
+              AC_SUBST(USE_APPLE_IDN, [1])
+              AC_SUBST([IDN_ENABLED], [1])
+              LIBS="-licucore $LIBS"
             )
           ])
           ;;

--- a/configure.ac
+++ b/configure.ac
@@ -2754,35 +2754,40 @@ dnl **********************************************************************
 dnl Check for the presence of AppleIDN
 dnl **********************************************************************
 
-AC_MSG_CHECKING([whether to build with Apple IDN])
-OPT_IDN="default"
-AC_ARG_WITH(apple-idn,
-AS_HELP_STRING([--with-apple-idn],[Enable AppleIDN])
-AS_HELP_STRING([--without-apple-idn],[Disable AppleIDN]),
-  [OPT_IDN=$withval])
-if test "x$tst_links_winidn" = "xyes" -o "x$want_idn" != "xno"; then
-  want_appleidn="no"
-else
-  case "$OPT_IDN" in
-    no)
-      dnl --without-apple-idn option used
-      AC_MSG_RESULT([no])
-      ;;
-    *)
-      AC_MSG_RESULT([yes, check])
-      AC_CHECK_LIB(icucore, uidna_nameToASCII_UTF8,
-      [
-        AC_CHECK_HEADERS(unicode/uidna.h,
-           curl_idn_msg="enabled (AppleIDN)"
-           AC_DEFINE(USE_APPLE_IDN, 1, [if AppleIDN])
-           AC_SUBST(USE_APPLE_IDN, [1])
-           AC_SUBST([IDN_ENABLED], [1])
-           LIBS="-licucore $LIBS"
-        )
-      ])
-      ;;
-  esac
-fi
+CURL_DARWIN_CFLAGS
+case $host_os in
+  darwin*)
+    AC_MSG_CHECKING([whether to build with Apple IDN])
+    OPT_IDN="default"
+    AC_ARG_WITH(apple-idn,
+    AS_HELP_STRING([--with-apple-idn],[Enable AppleIDN])
+    AS_HELP_STRING([--without-apple-idn],[Disable AppleIDN]),
+      [OPT_IDN=$withval])
+    if test "x$want_idn" != "xno"; then
+      want_appleidn="no"
+    else
+      case "$OPT_IDN" in
+        no)
+          dnl --without-apple-idn option used
+          AC_MSG_RESULT([no])
+          ;;
+        *)
+          AC_MSG_RESULT([yes, check])
+          AC_CHECK_LIB(icucore, uidna_nameToASCII_UTF8,
+          [
+            AC_CHECK_HEADERS(unicode/uidna.h,
+               curl_idn_msg="enabled (AppleIDN)"
+               AC_DEFINE(USE_APPLE_IDN, 1, [if AppleIDN])
+               AC_SUBST(USE_APPLE_IDN, [1])
+               AC_SUBST([IDN_ENABLED], [1])
+               LIBS="-licucore $LIBS"
+            )
+          ])
+          ;;
+      esac
+    fi
+    ;;
+esac
 
 dnl **********************************************************************
 dnl Check for nghttp2

--- a/configure.ac
+++ b/configure.ac
@@ -2773,7 +2773,7 @@ case $host_os in
           ;;
         *)
           AC_MSG_RESULT([yes, check])
-          AC_CHECK_LIB(icucore, uidna_nameToASCII_UTF8,
+          AC_CHECK_LIB(icucore, uidna_openUTS46,
           [
             AC_CHECK_HEADERS(unicode/uidna.h,
                curl_idn_msg="enabled (AppleIDN)"

--- a/configure.ac
+++ b/configure.ac
@@ -2763,7 +2763,7 @@ case $host_os in
     AS_HELP_STRING([--with-apple-idn],[Enable AppleIDN])
     AS_HELP_STRING([--without-apple-idn],[Disable AppleIDN]),
       [OPT_IDN=$withval])
-    if test "x$want_idn" != "xno"; then
+    if test "x$want_idn" != "xno" -a "x$OPT_IDN" != "xyes"; then
       want_appleidn="no"
     else
       case "$OPT_IDN" in


### PR DESCRIPTION
- make `--with-apple-idn` override libidn2, in sync with cmake and
  `lib/curl_setup.h`.

- sync detection function name with cmake.

- limit AppleIDN feature check to Darwin.
  (also drop !WinIDN precondition check.)

Follow-up to 8de8fe8c98309c8b6183b22cc2e209ce4648173b #14401
Closes #14419

---

Without whitespace: https://github.com/curl/curl/pull/14419/files?w=1