### PR TITLE
cmake: drop unused `HAVE_IDNA_STRERROR`

### DIFF
--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -304,9 +304,6 @@
 /* if you have the GNU gssapi libraries */
 #cmakedefine HAVE_GSSGNU 1
 
-/* Define to 1 if you have the `idna_strerror' function. */
-#cmakedefine HAVE_IDNA_STRERROR 1
-
 /* Define to 1 if you have the <ifaddrs.h> header file. */
 #cmakedefine HAVE_IFADDRS_H 1
 


### PR DESCRIPTION
Unused since 9c91ec778104ae3b744b39444d544e82d5ee9ece

Closes #14420