### PR TITLE
Makefile.mk: fixup enabling libidn2

### DIFF
--- a/lib/Makefile.mk
+++ b/lib/Makefile.mk
@@ -239,7 +239,7 @@ endif
 
 ifneq ($(findstring -idn2,$(CFG)),)
   LIBIDN2_PATH ?= $(PROOT)/../libidn2
-  CPPFLAGS += -DUSE_LIBIDN2
+  CPPFLAGS += -DHAVE_LIBIDN2 -DHAVE_IDN2_H
   CPPFLAGS += -I"$(LIBIDN2_PATH)/include"
   LDFLAGS += -L"$(LIBIDN2_PATH)/lib"
   LIBS += -lidn2


### PR DESCRIPTION
Replicate the method used by autotools and cmake to enable libidn2.
This way `lib/curl_setup.h` sets `USE_LIBIDN2` automatically.

Before this patch, `USE_LIBIDN2` was enabled directly, shortcutting
internal logic prioritizing IDN backends.

(This is academic now because `Makefile.mk` no longer supports
other IDN backends. But still useful for clarity.)

Closes #14421