### PR TITLE
tool_help: handle longer lines, exit on too long

### DIFF
--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -213,12 +213,18 @@ bool helpscan(unsigned char *buf, size_t len, struct scan_ctx *ctx)
 
     if(buf[i] == '\n') {
       DEBUGASSERT(ctx->olen < sizeof(ctx->obuf));
+      if(ctx->olen == sizeof(ctx->obuf))
+        return FALSE; /* bail out */
       ctx->obuf[ctx->olen++] = 0;
       ctx->olen = 0;
       puts(ctx->obuf);
     }
-    else
+    else {
+      DEBUGASSERT(ctx->olen < sizeof(ctx->obuf));
+      if(ctx->olen == sizeof(ctx->obuf))
+        return FALSE; /* bail out */
       ctx->obuf[ctx->olen++] = buf[i];
+    }
   }
   return TRUE;
 }

--- a/src/tool_help.h
+++ b/src/tool_help.h
@@ -37,7 +37,7 @@ struct scan_ctx {
   size_t elen;
   size_t olen;
   char rbuf[40];
-  char obuf[80];
+  char obuf[160];
   unsigned char show; /* start as at 0.
                          trigger match moves it to 1
                          arg match moves it to 2


### PR DESCRIPTION
Follow-up to 9a0cf56471c1a

- increase the buffer to handle 160 characters manpage lines
- add another assert
- if the line buffer gets full, abort

Ideally, we add another step in the build process that makes the build fail if this long lines are used.