### PR TITLE
manpage: ensure a maximum width for the text version

### DIFF
--- a/docs/cmdline-opts/Makefile.am
+++ b/docs/cmdline-opts/Makefile.am
@@ -37,6 +37,10 @@ GN_1 =
 GN_ = $(GN_0)
 
 MANAGEN=$(top_srcdir)/scripts/managen
+MAXLINE=$(top_srcdir)/scripts/maxline
+
+# Maximum number of columns accepted in the ASCII version of the manpage
+MAXCOLS=100
 INCDIR=$(top_srcdir)/include
 
 if BUILD_DOCS
@@ -51,7 +55,7 @@ $(MANPAGE): $(DPAGES) $(SUPPORT) mainpage.idx Makefile.inc $(MANAGEN)
 	$(GEN)(rm -f $(MANPAGE) && @PERL@ $(MANAGEN) -d $(srcdir) -I $(INCDIR) mainpage $(DPAGES) > manpage.tmp.$$$$ && mv manpage.tmp.$$$$ $(MANPAGE))
 
 $(ASCIIPAGE): $(DPAGES) $(SUPPORT) mainpage.idx Makefile.inc $(MANAGEN)
-	$(GEN)(rm -f $(ASCIIPAGE) && @PERL@ $(MANAGEN) -d $(srcdir) -I $(INCDIR) ascii $(DPAGES) > asciipage.tmp.$$$$ && mv asciipage.tmp.$$$$ $(ASCIIPAGE))
+	$(GEN)(rm -f $(ASCIIPAGE) && @PERL@ $(MANAGEN) -d $(srcdir) -I $(INCDIR) ascii $(DPAGES) | @PERL@ $(MAXLINE) $(MAXCOLS) > asciipage.tmp.$$$$ && mv asciipage.tmp.$$$$ $(ASCIIPAGE))
 
 listhelp:
 	$(MANAGEN) -d $(srcdir) listhelp $(DPAGES) > $(top_builddir)/src/tool_listhelp.c

--- a/docs/cmdline-opts/ipfs-gateway.md
+++ b/docs/cmdline-opts/ipfs-gateway.md
@@ -24,7 +24,7 @@ if a `~/.ipfs/gateway` file holding the gateway URL exists.
 If you run a local IPFS node, this gateway is by default available under
 `http://localhost:8080`. A full example URL would look like:
 
-    curl --ipfs-gateway http://localhost:8080 ipfs://bafybeigagd5nmnn2iys2f3doro7ydrevyr2mzarwidgadawmamiteydbzi
+    curl --ipfs-gateway http://localhost:8080 ipfs://bafybeigagd5nmnn2iys2f3
 
 There are many public IPFS gateways. See for example:
 https://ipfs.github.io/public-gateway-checker/

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -24,7 +24,7 @@
 
 EXTRA_DIST = coverage.sh completion.pl firefox-db2pem.sh checksrc.pl    \
  mk-ca-bundle.pl schemetable.c cd2nroff nroff2cd cdall cd2cd managen \
- dmaketgz release-tools.sh verify-release
+ dmaketgz release-tools.sh verify-release maxline
 
 ZSH_FUNCTIONS_DIR = @ZSH_FUNCTIONS_DIR@
 FISH_FUNCTIONS_DIR = @FISH_FUNCTIONS_DIR@

--- a/scripts/maxline
+++ b/scripts/maxline
@@ -1,0 +1,40 @@
+#!/usr/bin/env perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# The provided value is the max allowed length.
+my $max = $ARGV[0];
+my $line = 0;
+my $error;
+while(<STDIN>) {
+    my $i = length($_);
+    $line++;
+    if($i > $max) {
+        print STDERR "<STDIN>:$line ERROR line too long, $i > $max\n";
+        print STDERR "<STDIN>:$line $_";
+        $error++;
+    }
+    print $_;
+}
+exit $error;


### PR DESCRIPTION
... using the new script 'maxline' to which we specify the maximum number of columns we allow any single line to be, or it will cause an error.

Bonus: shorten the long line in the --ipfs-gateway section.