### PR TITLE
cmake: delete MSVC warning suppression for tests/server

### DIFF
--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -23,10 +23,6 @@
 ###########################################################################
 set(TARGET_LABEL_PREFIX "Test server ")
 
-if(MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /wd4306")
-endif()
-
 function(setup_executable test_name)  # ARGN are the files in the test
   add_executable(${test_name} EXCLUDE_FROM_ALL ${ARGN})
   add_dependencies(testdeps ${test_name})


### PR DESCRIPTION
Server code no longer produces this warning.

Closes #14428
