### PR TITLE
tests: show snapshot commit in testcurl

### DIFF
--- a/tests/testcurl.pl
+++ b/tests/testcurl.pl
@@ -484,6 +484,16 @@ if ($git) {
   else {
     logit "autoreconf -fi was successful (dummy message)";
   }
+
+} else {
+    # Show snapshot git commit when available
+    if (open (my $f, '<', "docs/tarball-commit.txt")) {
+      my $commit = <$f>;
+      chomp $commit;
+      logit "The most recent curl git commits:";
+      logit "  $commit";
+      close($f);
+    }
 }
 
 # Set timestamp to the one in curlver.h if this isn't a git test build.


### PR DESCRIPTION
This disambiguates the source code being tested. The output format is
the same as when testing out of a git repo, but with no description and
a long hash.

Ref: #14363
Closes #X