### PR TITLE
krb5: fix `-Wcast-align`

### DIFF
--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -336,16 +336,21 @@ krb5_auth(void *app_data, struct Curl_easy *data, struct connectdata *conn)
         }
 
         _gssresp.value = NULL; /* make sure it is initialized */
+        _gssresp.length = 0;
         p += 4; /* over '789 ' */
         p = strstr(p, "ADAT=");
         if(p) {
-          result = Curl_base64_decode(p + 5,
-                                      (unsigned char **)&_gssresp.value,
-                                      &_gssresp.length);
+          unsigned char *outptr;
+          size_t outlen;
+          result = Curl_base64_decode(p + 5, &outptr, &outlen);
           if(result) {
             failf(data, "base64-decoding: %s", curl_easy_strerror(result));
             ret = AUTH_CONTINUE;
             break;
+          }
+          else {
+            _gssresp.value = outptr;
+            _gssresp.length = outlen;
           }
         }
 


### PR DESCRIPTION
```
lib/krb5.c:343:39: warning: cast from 'void **' to 'unsigned char **' increases required alignment from 2 to 8 [-Wcast-align]
                               (unsigned char **)&_gssresp.value,
                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Seen on macOS Intel with Apple clang and brew heimdal 7.8.0_1.

Closes #xxxxx
