### PR TITLE
tracing, allow CURL_DEBUG override

### DIFF
--- a/docs/libcurl/libcurl-env-dbg.md
+++ b/docs/libcurl/libcurl-env-dbg.md
@@ -70,8 +70,8 @@ is needed to make the run emit trace output, but when it does, the contents
 of `CURL_DEBUG` are added and can override existing options.
 
 Example: **CURL_DEBUG=tcp,-http/2 curl -vv url** means trace protocol details,
-triggered by `-vv`, add tracing of tcp in addition and remove tracing of
-http/2.
+triggered by `-vv`, add tracing of TCP in addition and remove tracing of
+HTTP/2.
 
 ## CURL_DEBUG_SIZE
 

--- a/docs/libcurl/libcurl-env-dbg.md
+++ b/docs/libcurl/libcurl-env-dbg.md
@@ -64,6 +64,15 @@ Trace logging behavior as an alternative to calling curl_global_trace(3).
 
 Example: **CURL_DEBUG=http/2** means trace details about HTTP/2 handling.
 
+In the curl command line tool, built with `--enable-debug`, this environment
+variable adds to arguments like `--verbose`, `-vvv`. At least a single `-v`
+is needed to make the run emit trace output, but when it does, the contents
+of `CURL_DEBUG` are added and can override existing options.
+
+Example: **CURL_DEBUG=tcp,-http/2 curl -vv url** means trace protocol details,
+triggered by `-vv`, add tracing of tcp in addition and remove tracing of
+http/2.
+
 ## CURL_DEBUG_SIZE
 
 Fake the size returned by CURLINFO_HEADER_SIZE and CURLINFO_REQUEST_SIZE.

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -314,7 +314,7 @@ static void trc_apply_level_by_category(int category, int lvl)
   }
 }
 
-CURLcode Curl_trc_opt(const char *config)
+static CURLcode trc_opt(const char *config)
 {
   char *token, *tok_buf, *tmp;
   int lvl;
@@ -355,18 +355,29 @@ CURLcode Curl_trc_opt(const char *config)
   return CURLE_OK;
 }
 
+CURLcode Curl_trc_opt(const char *config)
+{
+  CURLcode result = config? trc_opt(config) : CURLE_OK;
+#ifdef DEBUGBUILD
+  /* CURL_DEBUG can override anything */
+  if(!result) {
+    const char *dbg_config = getenv("CURL_DEBUG");
+    if(dbg_config)
+      result = trc_opt(dbg_config);
+  }
+#endif /* DEBUGBUILD */
+  return result;
+}
+
 CURLcode Curl_trc_init(void)
 {
 #ifdef DEBUGBUILD
-  /* WIP: we use the auto-init from an env var only in DEBUG builds for
-   * convenience. */
-  const char *config = getenv("CURL_DEBUG");
-  if(config) {
-    return Curl_trc_opt(config);
-  }
-#endif /* DEBUGBUILD */
+  return Curl_trc_opt(NULL);
+#else
   return CURLE_OK;
+#endif
 }
+
 #else /* defined(CURL_DISABLE_VERBOSE_STRINGS) */
 
 CURLcode Curl_trc_init(void)


### PR DESCRIPTION
On debug builds, allow environment variable CURL_DEBUG to override any setting done via '-v' or '--no-verbose'.