### PR TITLE
curl: fix --proxy-pinnedpubkey

### DIFF
--- a/docs/cmdline-opts/proxy-pinnedpubkey.md
+++ b/docs/cmdline-opts/proxy-pinnedpubkey.md
@@ -27,3 +27,5 @@ When negotiating a TLS or SSL connection, the server sends a certificate
 indicating its identity. A public key is extracted from this certificate and
 if it does not exactly match the public key provided to this option, curl
 aborts the connection before sending or receiving any data.
+
+Before curl 8.10.0 this option did not work due to a bug.

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1750,6 +1750,13 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             warnf(global, "ignoring %s, not supported by libcurl with %s",
                   "--pinnedpubkey", ssl_ver);
         }
+        if(config->proxy_pinnedpubkey) {
+          result = res_setopt_str(curl, CURLOPT_PROXY_PINNEDPUBLICKEY,
+                                  config->proxy_pinnedpubkey);
+          if(result == CURLE_NOT_BUILT_IN)
+            warnf(global, "ignoring %s, not supported by libcurl with %s",
+                  "--proxy-pinnedpubkey", ssl_ver);
+        }
 
         if(config->ssl_ec_curves)
           my_setopt_str(curl, CURLOPT_SSL_EC_CURVES, config->ssl_ec_curves);


### PR DESCRIPTION
This option was added in #2268 but never connected in tool_operate.c.