### PR TITLE
verbose.md: polish, mostly remove back-ticks

### DIFF
--- a/docs/cmdline-opts/verbose.md
+++ b/docs/cmdline-opts/verbose.md
@@ -30,12 +30,12 @@ be more suitable options.
 
 Since curl 8.10, mentioning this option several times in the same argument
 increases the level of the trace output. However, as before, a single
---verbose or --no-verbose reverts any additions by previous -vv again. This
+--verbose or --no-verbose reverts any additions by previous `-vv` again. This
 means that `-vv -v` is equivalent to a single -v. This avoids unwanted
 verbosity when the option is mentioned in the command line *and* curl config
 files.
 
-Using it twice, e.g. -vv, outputs time (--trace-time) and transfer ids
+Using it twice, e.g. `-vv`, outputs time (--trace-time) and transfer ids
 (--trace-ids), as well as enable tracing for all protocols (--trace-config
 protocol).
 

--- a/docs/cmdline-opts/verbose.md
+++ b/docs/cmdline-opts/verbose.md
@@ -29,26 +29,25 @@ If you only want HTTP headers in the output, --include or --dump-header might
 be more suitable options.
 
 Since curl 8.10, mentioning this option several times in the same argument
-increases the level of the trace output. However, as before,
-a single `-v`, `--verbose` or `--no-verbose` reverts any additions by
-previous `-vv` again. This means that `-vv -v` is equivalent to `-v`. This
-avoids unwanted verbosity when the option is mentioned in the command line
-*and* curl config files.
+increases the level of the trace output. However, as before, a single
+--verbose or --no-verbose reverts any additions by previous -vv again. This
+means that `-vv -v` is equivalent to a single -v. This avoids unwanted
+verbosity when the option is mentioned in the command line *and* curl config
+files.
 
-Using it twice, e.g. `-vv`, outputs time (`--trace-time`) and transfer
-ids (`--trace-ids`), as well as enable tracing for all protocols
-(`--trace-config protocol`).
+Using it twice, e.g. -vv, outputs time (--trace-time) and transfer ids
+(--trace-ids), as well as enable tracing for all protocols (--trace-config
+protocol).
 
-Adding a third verbose outputs transfer content (`--trace-ascii %`) and
-enable tracing of more components (`--trace-config read,write,ssl`).
+Adding a third verbose outputs transfer content (--trace-ascii %) and enable
+tracing of more components (--trace-config read,write,ssl).
 
-A forth time adds tracing of all network components.
-(`--trace-config network`).
+A forth time adds tracing of all network components. (--trace-config network).
 
 Any addition of the verbose option after that has no effect.
 
 If you think this option does not give you the right details, consider using
---trace or --trace-ascii instead. Or use it only once and use `--trace-config`
+--trace or --trace-ascii instead. Or use it only once and use --trace-config
 to trace the specific components you wish to see.
 
 Note that verbose output of curl activities and network traffic might contain


### PR DESCRIPTION
To make the page render nicer as manpage and text-only.