### PR TITLE
wolfssl: avoid taking cached x509 store ref if sslctx already using it

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -596,7 +596,10 @@ CURLcode Curl_wssl_setup_x509_store(struct Curl_cfilter *cf,
     !ssl_config->native_ca_store;
 
   cached_store = cache_criteria_met ? get_cached_x509_store(cf, data) : NULL;
-  if(cached_store && wolfSSL_X509_STORE_up_ref(cached_store)) {
+  if(cached_store && wolfSSL_CTX_get_cert_store(wssl->ctx) == cached_store) {
+    /* The cached store is already in use, do nothing. */
+  }
+  else if(cached_store && wolfSSL_X509_STORE_up_ref(cached_store)) {
     wolfSSL_CTX_set_cert_store(wssl->ctx, cached_store);
   }
   else if(cache_criteria_met) {


### PR DESCRIPTION
When using x509 store from cache we first call `wolfSSL_X509_STORE_up_ref` followed by `wolfSSL_CTX_set_cert_store` [here](https://github.com/curl/curl/blob/master/lib/vtls/wolfssl.c#L599), however wolfSSL_CTX_set_cert_store will be a [noop](https://github.com/wolfSSL/wolfssl/blob/632d9653dae5d1f649e12c8dc468d1f9141c05e3/src/ssl.c#L11885) if we're trying to set a store which the sslctx is already using causing us to leak ref -> leak memory.
```
=================================================================
==4992==ERROR: LeakSanitizer: detected memory leaks

Indirect leak of 44768 byte(s) in 108 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x77abda4 in ParseCert third-party/wolfssl/wolfcrypt/src/asn.c:22396:22
    #3 0x76cca59 in AddCA third-party/wolfssl/src/ssl.c:5782:11
    #4 0x76cf3b6 in ProcessBuffer third-party/wolfssl/src/ssl.c:7378:15
    #5 0x76d4a89 in ProcessChainBuffer third-party/wolfssl/src/ssl.c:8070:15
    #6 0x769d03b in ProcessFile third-party/wolfssl/src/ssl.c:8396:19
    #7 0x76d4d45 in wolfSSL_CTX_load_verify_locations_ex third-party/wolfssl/src/ssl.c:8436:15
    #8 0x7492c76 in populate_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:411:7
    #9 0x7491f0a in Curl_wssl_setup_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:597:14
    #10 0x7497db6 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1079:14
    #11 0x7497db6 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #12 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #13 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #14 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #15 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #16 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #17 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #18 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #19 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #20 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #21 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #22 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #23 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #24 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #25 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10 

Indirect leak of 23856 byte(s) in 142 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x77afb0f in MakeSigner third-party/wolfssl/wolfcrypt/src/asn.c:23830:32
    #3 0x76ccc65 in AddCA third-party/wolfssl/src/ssl.c:5900:18
    #4 0x76cf3b6 in ProcessBuffer third-party/wolfssl/src/ssl.c:7378:15
    #5 0x76d4a89 in ProcessChainBuffer third-party/wolfssl/src/ssl.c:8070:15
    #6 0x769d03b in ProcessFile third-party/wolfssl/src/ssl.c:8396:19
    #7 0x76d4d45 in wolfSSL_CTX_load_verify_locations_ex third-party/wolfssl/src/ssl.c:8436:15
    #8 0x7492c76 in populate_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:411:7
    #9 0x7491f0a in Curl_wssl_setup_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:597:14
    #10 0x7497db6 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1079:14
    #11 0x7497db6 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #12 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #13 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #14 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #15 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #16 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #17 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #18 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #19 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #20 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #21 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #22 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #23 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #24 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #25 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10
    #26 0x7bce156 in vrs::ManifoldHttpClient::readObject(std::unique_ptr<vrs::Context, std::default_delete<vrs::Context>>&, 

Indirect leak of 3993 byte(s) in 34 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x77a5861 in StoreEccKey third-party/wolfssl/wolfcrypt/src/asn.c:12310:28
    #3 0x77a5861 in GetCertKey third-party/wolfssl/wolfcrypt/src/asn.c:12532:19
    #4 0x77a5861 in DecodeCertInternal third-party/wolfssl/wolfcrypt/src/asn.c:21944:15
    #5 0x77ac1ed in DecodeCert third-party/wolfssl/wolfcrypt/src/asn.c:21996:12
    #6 0x77ac1ed in ParseCertRelative third-party/wolfssl/wolfcrypt/src/asn.c:23538:19
    #7 0x77abbc8 in ParseCert third-party/wolfssl/wolfcrypt/src/asn.c:22369:11
    #8 0x76cca59 in AddCA third-party/wolfssl/src/ssl.c:5782:11
    #9 0x76cf3b6 in ProcessBuffer third-party/wolfssl/src/ssl.c:7378:15
    #10 0x76d4a89 in ProcessChainBuffer third-party/wolfssl/src/ssl.c:8070:15
    #11 0x769d03b in ProcessFile third-party/wolfssl/src/ssl.c:8396:19
    #12 0x76d4d45 in wolfSSL_CTX_load_verify_locations_ex third-party/wolfssl/src/ssl.c:8436:15
    #13 0x7492c76 in populate_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:411:7
    #14 0x7491f0a in Curl_wssl_setup_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:597:14
    #15 0x7497db6 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1079:14
    #16 0x7497db6 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #17 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #18 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #19 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #20 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #21 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #22 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #23 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #24 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #25 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #26 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #27 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #28 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #29 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #30 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10

Indirect leak of 3661 byte(s) in 135 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x77abc36 in ParseCert third-party/wolfssl/wolfcrypt/src/asn.c:22377:22
    #3 0x76cca59 in AddCA third-party/wolfssl/src/ssl.c:5782:11
    #4 0x76cf3b6 in ProcessBuffer third-party/wolfssl/src/ssl.c:7378:15
    #5 0x76d4a89 in ProcessChainBuffer third-party/wolfssl/src/ssl.c:8070:15
    #6 0x769d03b in ProcessFile third-party/wolfssl/src/ssl.c:8396:19
    #7 0x76d4d45 in wolfSSL_CTX_load_verify_locations_ex third-party/wolfssl/src/ssl.c:8436:15
    #8 0x7492c76 in populate_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:411:7
    #9 0x7491f0a in Curl_wssl_setup_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:597:14
    #10 0x7497db6 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1079:14
    #11 0x7497db6 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #12 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #13 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #14 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #15 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #16 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #17 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #18 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #19 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #20 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #21 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #22 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #23 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #24 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #25 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10

Indirect leak of 336 byte(s) in 1 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x772ff62 in wolfSSL_X509_STORE_new fbsource/src/x509_str.c:768:53
    #3 0x7491eb5 in Curl_wssl_setup_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:590:25
    #4 0x7497db6 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1079:14
    #5 0x7497db6 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #6 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #7 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #8 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #9 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #10 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #11 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #12 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #13 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #14 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #15 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #16 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #17 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #18 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #19 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10

Indirect leak of 270 byte(s) in 1 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x77abda4 in ParseCert third-party/wolfssl/wolfcrypt/src/asn.c:22396:22
    #3 0x76cca59 in AddCA third-party/wolfssl/src/ssl.c:5782:11
    #4 0x762eb60 in ProcessPeerCerts third-party/wolfssl/src/internal.c:14721:35
    #5 0x776824d in DoTls13Certificate third-party/wolfssl/src/tls13.c:9405:15
    #6 0x7765641 in DoTls13HandShakeMsgType third-party/wolfssl/src/tls13.c:12172:15
    #7 0x776b4a4 in DoTls13HandShakeMsg third-party/wolfssl/src/tls13.c:12472:19
    #8 0x764560d in ProcessReplyEx third-party/wolfssl/src/internal.c:21430:31
    #9 0x7643e9a in ProcessReply third-party/wolfssl/src/internal.c:20673:12
    #10 0x776a442 in wolfSSL_connect_TLSv13 third-party/wolfssl/src/tls13.c:12730:35
    #11 0x76c4042 in wolfSSL_connect third-party/wolfssl/src/ssl.c
    #12 0x7497e40 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1085:9
    #13 0x7497e40 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #14 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #15 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #16 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #17 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #18 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #19 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #20 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #21 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #22 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #23 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #24 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #25 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #26 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #27 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10

Indirect leak of 232 byte(s) in 1 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x769a4a6 in wolfSSL_CertManagerNew_ex fbsource/src/ssl_certman.c:103:33
    #3 0x772feb4 in wolfSSL_CertManagerNew fbsource/src/ssl_certman.c:173:12
    #4 0x772feb4 in wolfSSL_X509_STORE_new fbsource/src/x509_str.c:756:22
    #5 0x7491eb5 in Curl_wssl_setup_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:590:25
    #6 0x7497db6 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1079:14
    #7 0x7497db6 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #8 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #9 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #10 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #11 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #12 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #13 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #14 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #15 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #16 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #17 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #18 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #19 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #20 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #21 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10

Indirect leak of 168 byte(s) in 1 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x77afb0f in MakeSigner third-party/wolfssl/wolfcrypt/src/asn.c:23830:32
    #3 0x76ccc65 in AddCA third-party/wolfssl/src/ssl.c:5900:18
    #4 0x762eb60 in ProcessPeerCerts third-party/wolfssl/src/internal.c:14721:35
    #5 0x776824d in DoTls13Certificate third-party/wolfssl/src/tls13.c:9405:15
    #6 0x7765641 in DoTls13HandShakeMsgType third-party/wolfssl/src/tls13.c:12172:15
    #7 0x776b4a4 in DoTls13HandShakeMsg third-party/wolfssl/src/tls13.c:12472:19
    #8 0x764560d in ProcessReplyEx third-party/wolfssl/src/internal.c:21430:31
    #9 0x7643e9a in ProcessReply third-party/wolfssl/src/internal.c:20673:12
    #10 0x776a442 in wolfSSL_connect_TLSv13 third-party/wolfssl/src/tls13.c:12730:35
    #11 0x76c4042 in wolfSSL_connect third-party/wolfssl/src/ssl.c
    #12 0x7497e40 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1085:9
    #13 0x7497e40 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #14 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #15 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #16 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #17 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #18 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #19 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #20 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #21 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #22 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #23 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #24 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #25 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #26 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #27 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10

Indirect leak of 112 byte(s) in 1 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x772fe43 in wolfSSL_X509_STORE_new fbsource/src/x509_str.c:741:39
    #3 0x7491eb5 in Curl_wssl_setup_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:590:25
    #4 0x7497db6 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1079:14
    #5 0x7497db6 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #6 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #7 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #8 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #9 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #10 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #11 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #12 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #13 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #14 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #15 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #16 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #17 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #18 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #19 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x772ffa9 in wolfSSL_X509_STORE_new fbsource/src/x509_str.c:774:48
    #3 0x7491eb5 in Curl_wssl_setup_x509_store arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:590:25
    #4 0x7497db6 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1079:14
    #5 0x7497db6 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #6 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #7 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #8 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #9 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #10 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #11 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #12 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #13 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #14 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #15 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #16 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #17 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #18 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #19 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10

Indirect leak of 39 byte(s) in 1 object(s) allocated from:
    #0 0x6f0d51f in malloc (/data/sandcastle/temp/my_test+0x6f0d51f) (BuildId: 0b8519c8c65373a5)
    #1 0x77ee548 in wolfSSL_Malloc third-party/wolfssl/wolfcrypt/src/memory.c:352:15
    #2 0x77abc36 in ParseCert third-party/wolfssl/wolfcrypt/src/asn.c:22377:22
    #3 0x76cca59 in AddCA third-party/wolfssl/src/ssl.c:5782:11
    #4 0x762eb60 in ProcessPeerCerts third-party/wolfssl/src/internal.c:14721:35
    #5 0x776824d in DoTls13Certificate third-party/wolfssl/src/tls13.c:9405:15
    #6 0x7765641 in DoTls13HandShakeMsgType third-party/wolfssl/src/tls13.c:12172:15
    #7 0x776b4a4 in DoTls13HandShakeMsg third-party/wolfssl/src/tls13.c:12472:19
    #8 0x764560d in ProcessReplyEx third-party/wolfssl/src/internal.c:21430:31
    #9 0x7643e9a in ProcessReply third-party/wolfssl/src/internal.c:20673:12
    #10 0x776a442 in wolfSSL_connect_TLSv13 third-party/wolfssl/src/tls13.c:12730:35
    #11 0x76c4042 in wolfSSL_connect third-party/wolfssl/src/ssl.c
    #12 0x7497e40 in wolfssl_connect_step2 arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1085:9
    #13 0x7497e40 in wolfssl_connect_common arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1671:14
    #14 0x7495390 in wolfssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/wolfssl.c:1700:10
    #15 0x749179f in ssl_connect_nonblocking arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:495:10
    #16 0x748bd5f in ssl_cf_connect arvr/third-party/curl/curl-8.9.1/lib/vtls/vtls.c:1693:14
    #17 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #18 0x7342589 in cf_setup_connect arvr/third-party/curl/curl-8.9.1/lib/connect.c:1307:14
    #19 0x7335c22 in Curl_conn_cf_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:371:12
    #20 0x7356ead in cf_hc_baller_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:136:15
    #21 0x7353528 in cf_hc_connect arvr/third-party/curl/curl-8.9.1/lib/cf-https-connect.c:288:16
    #22 0x733605d in Curl_conn_connect arvr/third-party/curl/curl-8.9.1/lib/cfilters.c:419:14
    #23 0x73f160a in multi_runsingle arvr/third-party/curl/curl-8.9.1/lib/multi.c:2107:16
    #24 0x73efb21 in curl_multi_perform arvr/third-party/curl/curl-8.9.1/lib/multi.c:2739:18
    #25 0x731f4aa in easy_transfer arvr/third-party/curl/curl-8.9.1/lib/easy.c:676:15
    #26 0x731f4aa in easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:771:42
    #27 0x731f4aa in curl_easy_perform arvr/third-party/curl/curl-8.9.1/lib/easy.c:790:10

SUMMARY: AddressSanitizer: 77483 byte(s) leaked in 426 allocation(s).

```