### PR TITLE
cmake: fix version variable references in FindGSS

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -253,12 +253,12 @@ else()
   if(_GSS_MODULE_NAME STREQUAL _MIT_MODNAME OR _GSS_${_MIT_MODNAME}_VERSION)  # _GSS_MODULE_NAME set since CMake 3.16
     set(GSS_FLAVOUR "MIT")
     if(NOT _GSS_VERSION)  # for old CMake versions?
-      set(_GSS_VERSION _GSS_${_MIT_MODNAME}_VERSION)
+      set(_GSS_VERSION ${_GSS_${_MIT_MODNAME}_VERSION})
     endif()
   else()
     set(GSS_FLAVOUR "Heimdal")
     if(NOT _GSS_VERSION)  # for old CMake versions?
-      set(_GSS_VERSION _GSS_${_HEIMDAL_MODNAME}_VERSION)
+      set(_GSS_VERSION ${_GSS_${_HEIMDAL_MODNAME}_VERSION})
     endif()
   endif()
 endif()


### PR DESCRIPTION
Assign the value of the variable instead of the name of the variable
when detecting GSS version via `pkg-config` on old (?) CMake.

(On recent CMake, there is an empty value in these variables.)

Closes #14445