### PR TITLE
krb5: add Linux/macOS CI tests, fix cmake GSS detection

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -441,6 +441,10 @@ jobs:
         if: ${{ matrix.build.generate }}
         name: 'configure (cmake)'
 
+      - name: 'configure log'
+        if: ${{ !cancelled() }}
+        run: cat config.log CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
+
       - name: 'test configs'
         run: |
           cat tests/config || true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -126,10 +126,16 @@ jobs:
             configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: openssl3-clang
-            install_packages: zlib1g-dev clang
+          - name: openssl3-clang krb5
+            install_packages: zlib1g-dev libkrb5-dev clang
             install_steps: openssl3
-            configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
+            configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --with-gssapi --enable-debug --enable-websockets
+            singleuse: --unit
+
+          - name: openssl3-clang krb5
+            install_packages: zlib1g-dev libkrb5-dev clang
+            install_steps: openssl3
+            generate: -DOPENSSL_ROOT_DIR=$HOME/openssl3 -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DENABLE_WEBSOCKETS=ON
             singleuse: --unit
 
           - name: address-sanitizer

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -291,9 +291,9 @@ jobs:
             install: wolfssl
             generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
             macos-version-min: '10.15'
-          - name: 'GnuTLS !ldap'
-            install: gnutls nettle
-            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
+          - name: 'GnuTLS !ldap krb5'
+            install: gnutls nettle krb5
+            generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=$(brew --prefix krb5) -DCURL_DISABLE_LDAP=ON -DCURL_DISABLE_LDAPS=ON
             macos-version-min: '10.15'
         exclude:
           - { compiler: llvm@15, build: { macos-version-min: '10.15' } }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1071,7 +1071,7 @@ if(CURL_USE_GSSAPI)
     message(STATUS "Found ${GSS_FLAVOUR} GSSAPI version: \"${GSS_VERSION}\"")
 
     list(APPEND CMAKE_REQUIRED_INCLUDES ${GSS_INCLUDE_DIR})
-    check_include_file_concat("gssapi/gssapi.h"  HAVE_GSSAPI_GSSAPI_H)
+    check_include_file_concat("gssapi/gssapi.h" HAVE_GSSAPI_GSSAPI_H)
     check_include_file_concat("gssapi/gssapi_generic.h" HAVE_GSSAPI_GSSAPI_GENERIC_H)
     check_include_file_concat("gssapi/gssapi_krb5.h" HAVE_GSSAPI_GSSAPI_KRB5_H)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1071,12 +1071,19 @@ if(CURL_USE_GSSAPI)
     message(STATUS "Found ${GSS_FLAVOUR} GSSAPI version: \"${GSS_VERSION}\"")
 
     list(APPEND CMAKE_REQUIRED_INCLUDES ${GSS_INCLUDE_DIR})
+
+    string(REPLACE ";" " " GSS_COMPILER_FLAGS "${GSS_COMPILER_FLAGS}")
+    string(REPLACE ";" " " GSS_LINKER_FLAGS "${GSS_LINKER_FLAGS}")
+
+    foreach(_dir IN LISTS GSS_LINK_DIRECTORIES)
+      set(GSS_LINKER_FLAGS "${GSS_LINKER_FLAGS} -L\"${_dir}\"")
+    endforeach()
+
     check_include_file_concat("gssapi/gssapi.h" HAVE_GSSAPI_GSSAPI_H)
     check_include_file_concat("gssapi/gssapi_generic.h" HAVE_GSSAPI_GSSAPI_GENERIC_H)
     check_include_file_concat("gssapi/gssapi_krb5.h" HAVE_GSSAPI_GSSAPI_KRB5_H)
 
-    if(NOT GSS_FLAVOUR STREQUAL "Heimdal")
-      # MIT
+    if(GSS_FLAVOUR STREQUAL "MIT")
       set(_include_list "")
       if(HAVE_GSSAPI_GSSAPI_H)
         list(APPEND _include_list "gssapi/gssapi.h")
@@ -1088,15 +1095,8 @@ if(CURL_USE_GSSAPI)
         list(APPEND _include_list "gssapi/gssapi_krb5.h")
       endif()
 
-      string(REPLACE ";" " " _compiler_flags_str "${GSS_COMPILER_FLAGS}")
-      string(REPLACE ";" " " _linker_flags_str "${GSS_LINKER_FLAGS}")
-
-      foreach(_dir IN LISTS GSS_LINK_DIRECTORIES)
-        set(_linker_flags_str "${_linker_flags_str} -L\"${_dir}\"")
-      endforeach()
-
       if(NOT DEFINED HAVE_GSS_C_NT_HOSTBASED_SERVICE)
-        set(CMAKE_REQUIRED_FLAGS "${_compiler_flags_str} ${_linker_flags_str}")
+        set(CMAKE_REQUIRED_FLAGS "${GSS_COMPILER_FLAGS} ${GSS_LINKER_FLAGS}")
         set(CMAKE_REQUIRED_LIBRARIES ${GSS_LIBRARIES})
         check_symbol_exists("GSS_C_NT_HOSTBASED_SERVICE" ${_include_list} HAVE_GSS_C_NT_HOSTBASED_SERVICE)
         unset(CMAKE_REQUIRED_LIBRARIES)
@@ -1109,7 +1109,6 @@ if(CURL_USE_GSSAPI)
     include_directories(${GSS_INCLUDE_DIR})
     link_directories(${GSS_LINK_DIRECTORIES})
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${GSS_COMPILER_FLAGS}")
-    string(REPLACE ";" " " GSS_LINKER_FLAGS "${GSS_LINKER_FLAGS}")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${GSS_LINKER_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GSS_LINKER_FLAGS}")
     list(APPEND CURL_LIBS ${GSS_LIBRARIES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1114,6 +1114,8 @@ if(CURL_USE_GSSAPI)
     list(APPEND CURL_LIBS ${GSS_LIBRARIES})
     if(GSS_FLAVOUR STREQUAL "MIT")
       list(APPEND LIBCURL_PC_REQUIRES_PRIVATE "mit-krb5-gssapi")
+    else()  # Heimdal
+      list(APPEND LIBCURL_PC_REQUIRES_PRIVATE "heimdal-gssapi")
     endif()
   else()
     message(WARNING "GSSAPI support has been requested but no supporting libraries found. Skipping.")


### PR DESCRIPTION
- GHA/macos: enable GSS krb5 in a cmake job.
  Uses CMake-native detection.

- GHA/linux: enable GSS krb5 in autotools job and add a cmake job to match.
  CMake uses `pkg-config`-based detection.

- GHA/linux: add step to dump configure logs.

- fix and simplify logic digesting FindGSS output.

- cmake: add `heimdal-gssapi` to `libcurl.pc`.

Closes #14447
