### PR TITLE
cmake: tidy up more value comparisons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1526,7 +1526,7 @@ set(CMAKE_REQUIRED_FLAGS)
 option(ENABLE_WEBSOCKETS "Set to ON to enable EXPERIMENTAL websockets" OFF)
 
 if(ENABLE_WEBSOCKETS)
-  if(${SIZEOF_CURL_OFF_T} GREATER "4")
+  if(SIZEOF_CURL_OFF_T GREATER 4)
     set(USE_WEBSOCKETS ON)
   else()
     message(WARNING "curl_off_t is too small to enable WebSockets")

--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -38,7 +38,7 @@ function(add_manual_pages _listname)
   set(_eol "_EOL_")
   foreach(_file IN LISTS ${_listname} _eol)
     math(EXPR _file_count "${_file_count} + 1")
-    if(NOT _file_count LESS _files_per_batch OR _file STREQUAL "_EOL_")
+    if(_file_count GREATER_EQUAL _files_per_batch OR _file STREQUAL "_EOL_")
       add_custom_command(OUTPUT ${_rofffiles}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff -k -d "${CMAKE_CURRENT_BINARY_DIR}" ${_mdfiles}

--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -38,7 +38,7 @@ function(add_manual_pages _listname)
   set(_eol "_EOL_")
   foreach(_file IN LISTS ${_listname} _eol)
     math(EXPR _file_count "${_file_count} + 1")
-    if(NOT _file_count LESS ${_files_per_batch} OR _file STREQUAL "_EOL_")
+    if(NOT _file_count LESS _files_per_batch OR _file STREQUAL "_EOL_")
       add_custom_command(OUTPUT ${_rofffiles}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         COMMAND "${PERL_EXECUTABLE}" ${PROJECT_SOURCE_DIR}/scripts/cd2nroff -k -d "${CMAKE_CURRENT_BINARY_DIR}" ${_mdfiles}


### PR DESCRIPTION
- unquote numeric value.

- `NOT LESS` -> `GREATER_EQUAL`.

- replace macro with variable name.
  It also avoids this error when the variable is undefined:
  ```
  CMake Error at CMakeLists.txt:1529 (if):
  if given arguments:
    "GREATER" "4"
  Unknown arguments specified
  ```
  https://github.com/curl/curl/actions/runs/10289921657/job/28478722584#step:30:356

Follow-up to 72ae0d86a42fea83612d8baf59cff2f945aca22a #14409
Follow-up to acbc6b703f6b0ee568d053f6f2565fbc107b5fd3 #14197

Closes #14449
