### PR TITLE
ftp, flush pingpong before response

### DIFF
--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -398,6 +398,7 @@ int Curl_pp_getsock(struct Curl_easy *data,
 bool Curl_pp_needs_flush(struct Curl_easy *data,
                          struct pingpong *pp)
 {
+  (void)data;
   return pp->sendleft > 0;
 }
 

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -395,12 +395,21 @@ int Curl_pp_getsock(struct Curl_easy *data,
   return GETSOCK_READSOCK(0);
 }
 
+bool Curl_pp_needs_flush(struct Curl_easy *data,
+                         struct pingpong *pp)
+{
+  return pp->sendleft > 0;
+}
+
 CURLcode Curl_pp_flushsend(struct Curl_easy *data,
                            struct pingpong *pp)
 {
   /* we have a piece of a command still left to send */
   size_t written;
   CURLcode result;
+
+  if(!Curl_pp_needs_flush(data, pp))
+    return CURLE_OK;
 
   result = Curl_conn_send(data, FIRSTSOCKET,
                           pp->sendthis + pp->sendsize - pp->sendleft,

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -137,6 +137,8 @@ CURLcode Curl_pp_readresp(struct Curl_easy *data,
                           int *code, /* return the server code if done */
                           size_t *size); /* size of the response */
 
+bool Curl_pp_needs_flush(struct Curl_easy *data,
+                         struct pingpong *pp);
 
 CURLcode Curl_pp_flushsend(struct Curl_easy *data,
                            struct pingpong *pp);


### PR DESCRIPTION
Fix FTP protocol to flush the pingpong's send buffer before receiving a response from the server, as it may never come otherwise.

Fixes FTP/FTPS tests with `CURL_DBG_SOCK_WBLOCK=90` set.