### PR TITLE
test556, improve robustness

### DIFF
--- a/tests/libtest/lib556.c
+++ b/tests/libtest/lib556.c
@@ -65,28 +65,35 @@ CURLcode test(char *URL)
     const char *request =
       "GET /556 HTTP/1.1\r\n"
       "Host: ninja\r\n\r\n";
-    size_t iolen = 0;
+    const char *sbuf = request;
+    size_t sblen = strlen(request);
+    size_t nwritten = 0, nread = 0;
 
-    res = curl_easy_send(curl, request, strlen(request), &iolen);
+    do {
+      char buf[1024];
 
-    if(!res) {
-      /* we assume that sending always work */
-
-      do {
-        char buf[1024];
-        /* busy-read like crazy */
-        res = curl_easy_recv(curl, buf, sizeof(buf), &iolen);
-
-        if(iolen) {
-          /* send received stuff to stdout */
-          if(!write(STDOUT_FILENO, buf, iolen))
-            break;
+      if(sblen) {
+        res = curl_easy_send(curl, sbuf, sblen, &nwritten);
+        if(res && res != CURLE_AGAIN)
+          break;
+        if(nwritten > 0) {
+          sbuf += nwritten;
+          sblen -= nwritten;
         }
+      }
 
-      } while((res == CURLE_OK && iolen) || (res == CURLE_AGAIN));
-    }
+      /* busy-read like crazy */
+      res = curl_easy_recv(curl, buf, sizeof(buf), &nread);
 
-    if(iolen)
+      if(nread) {
+        /* send received stuff to stdout */
+        if(!write(STDOUT_FILENO, buf, nread))
+          break;
+      }
+
+    } while((res == CURLE_OK && nread) || (res == CURLE_AGAIN));
+
+    if(res && res != CURLE_AGAIN)
       res = TEST_ERR_FAILURE;
   }
 


### PR DESCRIPTION
Fix handling of partial/blocked sends.

Fixes test with CURL_DBG_SOCK_WBLOCK=90 set.