### PR TITLE
test579, improve robustness

### DIFF
--- a/tests/data/test579
+++ b/tests/data/test579
@@ -76,14 +76,10 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER %LOGDIR/ip%TESTNUMBER
 # Verify data after the test has been "shot"
 <verify>
 <file name="%LOGDIR/ip%TESTNUMBER">
-Progress callback called with UL 0 out of 0
-Progress callback called with UL 5 out of 0
-Progress callback called with UL 0 out of 0
-Progress callback called with UL 8 out of 0
-Progress callback called with UL 16 out of 0
-Progress callback called with UL 26 out of 0
-Progress callback called with UL 61 out of 0
-Progress callback called with UL 66 out of 0
+Progress: start UL 0/0
+Progress: end UL 5/0
+Progress: start UL 0/0
+Progress: end UL 66/0
 </file>
 </verify>
 </testcase>

--- a/tests/libtest/lib579.c
+++ b/tests/libtest/lib579.c
@@ -57,7 +57,7 @@ static int progress_callback(void *clientp, double dltotal, double dlnow,
   (void)dltotal; /* UNUSED */
   (void)dlnow; /* UNUSED */
 
-  if(started && ulnow == 0.0 && last_ul) {
+  if(started && ulnow <= 0.0 && last_ul) {
     progress_final_report();
   }
 

--- a/tests/libtest/lib579.c
+++ b/tests/libtest/lib579.c
@@ -38,31 +38,38 @@ struct WriteThis {
   int counter;
 };
 
+static bool started = FALSE;
+static size_t last_ul = 0;
+static size_t last_ul_total = 0;
+
+static void progress_final_report(void)
+{
+  FILE *moo = fopen(libtest_arg2, "ab");
+  fprintf(moo, "Progress: end UL %zu/%zu\n", last_ul, last_ul_total);
+  started = FALSE;
+  fclose(moo);
+}
+
 static int progress_callback(void *clientp, double dltotal, double dlnow,
                              double ultotal, double ulnow)
 {
-  static int prev_ultotal = -1;
-  static int prev_ulnow = -1;
   (void)clientp; /* UNUSED */
   (void)dltotal; /* UNUSED */
   (void)dlnow; /* UNUSED */
 
-  /* to avoid depending on timing, which will cause this progress function to
-     get called a different number of times depending on circumstances, we
-     only log these lines if the numbers are different from the previous
-     invoke */
-  if((prev_ultotal != (int)ultotal) ||
-     (prev_ulnow != (int)ulnow)) {
-
-    FILE *moo = fopen(libtest_arg2, "ab");
-    if(moo) {
-      fprintf(moo, "Progress callback called with UL %d out of %d\n",
-              (int)ulnow, (int)ultotal);
-      fclose(moo);
-    }
-    prev_ulnow = (int) ulnow;
-    prev_ultotal = (int) ultotal;
+  if(started && ulnow == 0.0 && last_ul) {
+    progress_final_report();
   }
+
+  last_ul = (size_t)ulnow;
+  last_ul_total = (size_t)ultotal;
+  if(!started) {
+    FILE *moo = fopen(libtest_arg2, "ab");
+    fprintf(moo, "Progress: start UL %zu/%zu\n", last_ul, last_ul_total);
+    started = TRUE;
+    fclose(moo);
+  }
+
   return 0;
 }
 
@@ -145,6 +152,8 @@ CURLcode test(char *URL)
 
   /* Perform the request, res will get the return code */
   res = curl_easy_perform(curl);
+
+  progress_final_report();
 
 test_cleanup:
 


### PR DESCRIPTION
Log progress only at start and end of transfer to give normalized output when upload data is only partially sent or temporarily blocked.

Fixes test with CURL_DBG_SOCK_WBLOCK=90 set.