### PR TITLE
test677, improve robustness

### DIFF
--- a/tests/libtest/lib677.c
+++ b/tests/libtest/lib677.c
@@ -75,7 +75,7 @@ CURLcode test(char *URL)
       curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sock);
       waitfd.fd = sock;
     }
-    curl_multi_wait(mcurl, &waitfd, sock == CURL_SOCKET_BAD ? 0 : 1, 500,
+    curl_multi_wait(mcurl, &waitfd, sock == CURL_SOCKET_BAD ? 0 : 1, 50,
                     &mrun);
     if((sock != CURL_SOCKET_BAD) && (waitfd.revents & waitfd.events)) {
       size_t len = 0;
@@ -83,7 +83,10 @@ CURLcode test(char *URL)
       if(!state) {
         CURLcode ec;
         ec = curl_easy_send(curl, cmd + pos, sizeof(cmd) - 1 - pos, &len);
-        if(ec != CURLE_OK) {
+        if(ec == CURLE_AGAIN) {
+          continue;
+        }
+        else if(ec) {
           fprintf(stderr, "curl_easy_send() failed, with code %d (%s)\n",
                   (int)ec, curl_easy_strerror(ec));
           res = ec;
@@ -101,7 +104,10 @@ CURLcode test(char *URL)
       else if(pos < (ssize_t)sizeof(buf)) {
         CURLcode ec;
         ec = curl_easy_recv(curl, buf + pos, sizeof(buf) - pos, &len);
-        if(ec != CURLE_OK) {
+        if(ec == CURLE_AGAIN) {
+          continue;
+        }
+        else if(ec) {
           fprintf(stderr, "curl_easy_recv() failed, with code %d (%s)\n",
                   (int)ec, curl_easy_strerror(ec));
           res = ec;


### PR DESCRIPTION
Do not treat CURLE_AGAIN as error.

Fixes test with CURL_DBG_SOCK_WBLOCK=90 set.