### PR TITLE
runtests: log ignored but passed tests

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3080,8 +3080,10 @@ sub testnumdetails {
 if($total) {
     if($passedign) {
         my $sorted = numsortwords($passedign);
+        logmsg "::group::Passed Ignored Test details\n";
         testnumdetails("PASSED-IGNORED", $sorted);
         logmsg "IGNORED: passed tests: $sorted\n";
+        logmsg "::endgroup::\n";
     }
 
     if($failedign) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -144,6 +144,8 @@ my %disabled;           # disabled test cases
 my %ignored;            # ignored results of test cases
 my %ignoretestcodes;    # if test results are to be ignored
 
+my $passedign;   # tests passed with results ignored
+
 my $timestats;   # time stamping and stats generation
 my $fullstats;   # show time stats for every single test
 my %timeprepini; # timestamp for each test preparation start
@@ -1771,6 +1773,8 @@ sub singletest_success {
     }
 
     if($errorreturncode==2) {
+        # ignored test success
+        $passedign .= "$testnum ";
         logmsg "Warning: test$testnum result is ignored, but passed!\n";
     }
 }
@@ -3074,10 +3078,16 @@ sub testnumdetails {
 }
 
 if($total) {
+    if($passedign) {
+        my $sorted = numsortwords($passedign);
+        testnumdetails("PASSED-IGNORED", $sorted);
+        logmsg "IGNORED: passed tests: $sorted\n";
+    }
+
     if($failedign) {
-        my $failedignsorted = numsortwords($failedign);
-        testnumdetails("FAIL-IGNORED", $failedignsorted);
-        logmsg "IGNORED: failed tests: $failedignsorted\n";
+        my $sorted = numsortwords($failedign);
+        testnumdetails("FAIL-IGNORED", $sorted);
+        logmsg "IGNORED: failed tests: $sorted\n";
     }
     logmsg sprintf("TESTDONE: $ok tests out of $total reported OK: %d%%\n",
                    $ok/$total*100);


### PR DESCRIPTION
List tests explicitly ignored, but passing. It can be useful to catch
ignore rules that are no longer necessary because the tests are not
failing anymore.

To not clutter the default view, hide this information under a GitHub
Actions foldable group.

Closes #14457
