### PR TITLE
websocket, introduce blocking sends

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -481,6 +481,8 @@
 
  - curl_multi_remove_handle for any of the above. See section 2.3.
 
+ - Calling curl_ws_send() from a callback
+
 2.2 Better support for same name resolves
 
  If a name resolve has been initiated for name NN and a second easy handle

--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -109,6 +109,10 @@ Traces reading of upload data from the application in order to send it to the se
 
 Traces writing of download data, received from the server, to the application.
 
+## `ws`
+
+Tracing of WebSocket operations when this protocol is enabled in your build.
+
 # TRACE GROUPS
 
 Besides the specific component names there are the following group names

--- a/docs/libcurl/curl_ws_send.md
+++ b/docs/libcurl/curl_ws_send.md
@@ -53,6 +53,10 @@ If **CURLWS_RAW_MODE** is enabled in CURLOPT_WS_OPTIONS(3), the
 To send a message consisting of multiple frames, set the *CURLWS_CONT* bit
 in all frames except the final one.
 
+Warning: while it is possible to invoke this function from a callback,
+such a call is blocking in this situation, e.g. only returns after all data 
+has been sent or an error is encountered.
+
 # FLAGS
 
 ## CURLWS_TEXT

--- a/docs/libcurl/curl_ws_send.md
+++ b/docs/libcurl/curl_ws_send.md
@@ -54,7 +54,7 @@ To send a message consisting of multiple frames, set the *CURLWS_CONT* bit
 in all frames except the final one.
 
 Warning: while it is possible to invoke this function from a callback,
-such a call is blocking in this situation, e.g. only returns after all data 
+such a call is blocking in this situation, e.g. only returns after all data
 has been sent or an error is encountered.
 
 # FLAGS

--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -91,6 +91,23 @@ static size_t chunk_read(struct buf_chunk *chunk,
   }
 }
 
+static size_t chunk_unwrite(struct buf_chunk *chunk, size_t len)
+{
+  size_t n = chunk->w_offset - chunk->r_offset;
+  DEBUGASSERT(chunk->w_offset >= chunk->r_offset);
+  if(!n) {
+    return 0;
+  }
+  else if(n <= len) {
+    chunk->r_offset = chunk->w_offset = 0;
+    return n;
+  }
+  else {
+    chunk->w_offset -= len;
+    return len;
+  }
+}
+
 static ssize_t chunk_slurpn(struct buf_chunk *chunk, size_t max_len,
                             Curl_bufq_reader *reader,
                             void *reader_ctx, CURLcode *err)
@@ -363,6 +380,49 @@ static void prune_head(struct bufq *q)
   }
 }
 
+static struct buf_chunk *chunk_prev(struct buf_chunk *head,
+                                    struct buf_chunk *chunk)
+{
+  while(head) {
+    if(head == chunk)
+      return NULL;
+    if(head->next == chunk)
+      return head;
+    head = head->next;
+  }
+  return NULL;
+}
+
+static void prune_tail(struct bufq *q)
+{
+  struct buf_chunk *chunk;
+
+  while(q->tail && chunk_is_empty(q->tail)) {
+    chunk = q->tail;
+    q->tail = chunk_prev(q->head, chunk);
+    if(q->tail)
+      q->tail->next = NULL;
+    if(q->head == chunk)
+      q->head = q->tail;
+    if(q->pool) {
+      bufcp_put(q->pool, chunk);
+      --q->chunk_count;
+    }
+    else if((q->chunk_count > q->max_chunks) ||
+       (q->opts & BUFQ_OPT_NO_SPARES)) {
+      /* SOFT_LIMIT allowed us more than max. free spares until
+       * we are at max again. Or free them if we are configured
+       * to not use spares. */
+      free(chunk);
+      --q->chunk_count;
+    }
+    else {
+      chunk->next = q->spare;
+      q->spare = chunk;
+    }
+  }
+}
+
 static struct buf_chunk *get_non_full_tail(struct bufq *q)
 {
   struct buf_chunk *chunk;
@@ -426,6 +486,15 @@ CURLcode Curl_bufq_cwrite(struct bufq *q,
   n = Curl_bufq_write(q, (const unsigned char *)buf, len, &result);
   *pnwritten = (n < 0)? 0 : (size_t)n;
   return result;
+}
+
+CURLcode Curl_bufq_unwrite(struct bufq *q, size_t len)
+{
+  while(len && q->tail) {
+    len -= chunk_unwrite(q->head, len);
+    prune_tail(q);
+  }
+  return len? CURLE_AGAIN : CURLE_OK;
 }
 
 ssize_t Curl_bufq_read(struct bufq *q, unsigned char *buf, size_t len,

--- a/lib/bufq.h
+++ b/lib/bufq.h
@@ -183,6 +183,12 @@ CURLcode Curl_bufq_cwrite(struct bufq *q,
                          size_t *pnwritten);
 
 /**
+ * Remove `len` bytes from the end of the buffer queue again.
+ * Returns CURLE_AGAIN if less than `len` bytes were in the queue.
+ */
+CURLcode Curl_bufq_unwrite(struct bufq *q, size_t len);
+
+/**
  * Read buf from the start of the buffer queue. The buf is copied
  * and the amount of copied bytes is returned.
  * A return code of -1 indicates an error, setting `err` to the

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -221,6 +221,24 @@ void Curl_trc_ftp(struct Curl_easy *data, const char *fmt, ...)
 }
 #endif /* !CURL_DISABLE_FTP */
 
+#if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
+struct curl_trc_feat Curl_trc_feat_ws = {
+  "WS",
+  CURL_LOG_LVL_NONE,
+};
+
+void Curl_trc_ws(struct Curl_easy *data, const char *fmt, ...)
+{
+  DEBUGASSERT(!strchr(fmt, '\n'));
+  if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_ws)) {
+    va_list ap;
+    va_start(ap, fmt);
+    trc_infof(data, &Curl_trc_feat_ws, fmt, ap);
+    va_end(ap);
+  }
+}
+#endif /* USE_WEBSOCKETS && !CURL_DISABLE_HTTP */
+
 #define TRC_CT_NONE        (0)
 #define TRC_CT_PROTOCOL    (1<<(0))
 #define TRC_CT_NETWORK     (1<<(1))
@@ -239,6 +257,9 @@ static struct trc_feat_def trc_feats[] = {
 #endif
 #ifndef CURL_DISABLE_DOH
   { &Curl_doh_trc,            TRC_CT_NETWORK },
+#endif
+#if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
+  { &Curl_trc_feat_ws,        TRC_CT_PROTOCOL },
 #endif
 };
 

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -89,6 +89,11 @@ void Curl_failf(struct Curl_easy *data,
   do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_ftp)) \
          Curl_trc_ftp(data, __VA_ARGS__); } while(0)
 #endif /* !CURL_DISABLE_FTP */
+#if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
+#define CURL_TRC_WS(data, ...) \
+  do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_ws)) \
+         Curl_trc_ws(data, __VA_ARGS__); } while(0)
+#endif /* USE_WEBSOCKETS && !CURL_DISABLE_HTTP */
 
 #else /* CURL_HAVE_C99 */
 
@@ -99,6 +104,9 @@ void Curl_failf(struct Curl_easy *data,
 
 #ifndef CURL_DISABLE_FTP
 #define CURL_TRC_FTP   Curl_trc_ftp
+#endif
+#if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
+#define CURL_TRC_WS    Curl_trc_ws
 #endif
 
 #endif /* !CURL_HAVE_C99 */
@@ -147,6 +155,11 @@ void Curl_trc_read(struct Curl_easy *data,
 extern struct curl_trc_feat Curl_trc_feat_ftp;
 void Curl_trc_ftp(struct Curl_easy *data,
                   const char *fmt, ...) CURL_PRINTF(2, 3);
+#endif
+#if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
+extern struct curl_trc_feat Curl_trc_feat_ws;
+void Curl_trc_ws(struct Curl_easy *data,
+                 const char *fmt, ...) CURL_PRINTF(2, 3);
 #endif
 
 

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1134,7 +1134,7 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *data, const void *buffer,
 {
   struct websocket *ws;
   ssize_t n;
-  size_t space, sblen_before, net_added, payload_added;
+  size_t space, sblen_before, payload_added;
   CURLcode result;
 
   CURL_TRC_WS(data, "curl_ws_send(len=%zu, fragsize=%" CURL_FORMAT_CURL_OFF_T
@@ -1211,9 +1211,6 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *data, const void *buffer,
   if(n < 0)
     goto out;
   payload_added = (size_t)n;
-  DEBUGASSERT(Curl_bufq_len(&ws->sendbuf) >= sblen_before);
-  net_added = Curl_bufq_len(&ws->sendbuf) - sblen_before;
-  DEBUGASSERT(net_added >= payload_added);
 
   while(!result && (buflen || !Curl_bufq_is_empty(&ws->sendbuf))) {
     /* flush, blocking when in callback */
@@ -1252,7 +1249,7 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *data, const void *buffer,
         goto out;
       }
       /* We added the complete data to our sendbuf. Report one byte less as
-       * sent. This parital sucess should make the caller invoke us again
+       * sent. This parital success should make the caller invoke us again
        * with the last byte. */
       *sent = payload_added - 1;
       result = Curl_bufq_unwrite(&ws->sendbuf, 1);

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1022,6 +1022,7 @@ static CURLcode ws_flush(struct Curl_easy *data, struct websocket *ws,
     while(Curl_bufq_peek(&ws->sendbuf, &out, &outlen)) {
       if(blocking) {
         result = ws_send_raw_blocking(data, ws, (char *)out, outlen);
+        n = result? 0 : outlen;
       }
       else if(data->set.connect_only)
         result = Curl_senddata(data, out, outlen, &n);

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1134,7 +1134,7 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *data, const void *buffer,
 {
   struct websocket *ws;
   ssize_t n;
-  size_t space, sblen_before, payload_added;
+  size_t space, payload_added;
   CURLcode result;
 
   CURL_TRC_WS(data, "curl_ws_send(len=%zu, fragsize=%" CURL_FORMAT_CURL_OFF_T
@@ -1174,7 +1174,6 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *data, const void *buffer,
   }
 
   /* Not RAW mode, buf we do the frame encoding */
-  sblen_before = Curl_bufq_len(&ws->sendbuf);
   space = Curl_bufq_space(&ws->sendbuf);
   CURL_TRC_WS(data, "curl_ws_send(len=%zu), sendbuf=%zu space_left=%zu",
               buflen, Curl_bufq_len(&ws->sendbuf), space);


### PR DESCRIPTION
When using `curl_ws_send()`, perform a blocking send of the data if the call is done from within a curl callback. A partial write of the data could subsequently mess up the ws framing, as a callback has a hard time handling waits and repeated calls.

Outside a callback, `curl_ws_send()` is always non-blocking *except* when generating a 0-length frame that could not completely be sent. This is no way to report this partial success.

Document this behaviour in the function and add this as item to the TODO list. Also, add `ws` as protocol trace feature.

Fixes WebSockets tests with CURL_DBG_SOCK_WBLOCK=90 set.