### PR TITLE
lib: fix AIX build issues

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -605,7 +605,7 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
           int act = poll2cselect(fds[i].revents); /* convert */
           infof(multi->easyp,
                 "call curl_multi_socket_action(socket "
-                "%" CURL_FORMAT_SOCKET_T ")", fds[i].fd);
+                "%" CURL_FORMAT_SOCKET_T ")", (curl_socket_t)fds[i].fd);
           mcode = curl_multi_socket_action(multi, fds[i].fd, act,
                                            &ev->running_handles);
         }

--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -216,7 +216,15 @@ if2ip_result_t Curl_if2ip(int af,
   memcpy(req.ifr_name, interf, len + 1);
   req.ifr_addr.sa_family = AF_INET;
 
+#if defined(__GNUC__) && defined(_AIX)
+/* Suppress warning inside system headers */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshift-sign-overflow"
+#endif
   if(ioctl(dummy, SIOCGIFADDR, &req) < 0) {
+#if defined(__GNUC__) && defined(_AIX)
+#pragma GCC diagnostic pop
+#endif
     sclose(dummy);
     /* With SIOCGIFADDR, we cannot tell the difference between an interface
        that does not exist and an interface that has no address of the

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -33,12 +33,10 @@
 #include <curl/curl.h>
 #include "functypes.h"
 
-#if defined(__GNUC__) && __GNUC__ >= 3 && !(defined(_AIX) && defined(malloc))
-/* ibm-clang defines _LINUX_SOURCE_COMPAT which in turn defines a macro named
-  'malloc', which breaks the line below */
-#  define ALLOC_FUNC __attribute__((malloc))
-#  define ALLOC_SIZE(s) __attribute__((alloc_size(s)))
-#  define ALLOC_SIZE2(n, s) __attribute__((alloc_size(n, s)))
+#if defined(__GNUC__) && __GNUC__ >= 3
+#  define ALLOC_FUNC __attribute__((__malloc__))
+#  define ALLOC_SIZE(s) __attribute__((__alloc_size__(s)))
+#  define ALLOC_SIZE2(n, s) __attribute__((__alloc_size__(n, s)))
 #elif defined(_MSC_VER)
 #  define ALLOC_FUNC __declspec(restrict)
 #  define ALLOC_SIZE(s)

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -33,8 +33,9 @@
 #include <curl/curl.h>
 #include "functypes.h"
 
-#if defined(__GNUC__) && __GNUC__ >= 3 && !defined(_AIX)
-/* AIX defines a macro named 'malloc', which breaks the line below */
+#if defined(__GNUC__) && __GNUC__ >= 3 && \
+  !(defined(_AIX) && defined(__clang__))
+/* ibm-clang defines a macro named 'malloc', which breaks the line below */
 #  define ALLOC_FUNC __attribute__((malloc))
 #  define ALLOC_SIZE(s) __attribute__((alloc_size(s)))
 #  define ALLOC_SIZE2(n, s) __attribute__((alloc_size(n, s)))

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -33,7 +33,8 @@
 #include <curl/curl.h>
 #include "functypes.h"
 
-#if defined(__GNUC__) && __GNUC__ >= 3
+#if defined(__GNUC__) && __GNUC__ >= 3 && !defined(_AIX)
+/* AIX defines a macro named 'malloc', which breaks the line below */
 #  define ALLOC_FUNC __attribute__((malloc))
 #  define ALLOC_SIZE(s) __attribute__((alloc_size(s)))
 #  define ALLOC_SIZE2(n, s) __attribute__((alloc_size(n, s)))

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -115,11 +115,17 @@ CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
 /* Set this symbol on the command-line, recompile all lib-sources */
 #undef strdup
 #define strdup(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
+#undef malloc
 #define malloc(size) curl_dbg_malloc(size, __LINE__, __FILE__)
+#undef calloc
 #define calloc(nbelem,size) curl_dbg_calloc(nbelem, size, __LINE__, __FILE__)
+#undef realloc
 #define realloc(ptr,size) curl_dbg_realloc(ptr, size, __LINE__, __FILE__)
+#undef free
 #define free(ptr) curl_dbg_free(ptr, __LINE__, __FILE__)
+#undef send
 #define send(a,b,c,d) curl_dbg_send(a,b,c,d, __LINE__, __FILE__)
+#undef recv
 #define recv(a,b,c,d) curl_dbg_recv(a,b,c,d, __LINE__, __FILE__)
 
 #ifdef _WIN32

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -33,8 +33,7 @@
 #include <curl/curl.h>
 #include "functypes.h"
 
-#if defined(__GNUC__) && __GNUC__ >= 3 && \
-  !(defined(_AIX) && defined(_LINUX_SOURCE_COMPAT))
+#if defined(__GNUC__) && __GNUC__ >= 3 && !(defined(_AIX) && defined(malloc))
 /* ibm-clang defines _LINUX_SOURCE_COMPAT which in turn defines a macro named
   'malloc', which breaks the line below */
 #  define ALLOC_FUNC __attribute__((malloc))

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -34,8 +34,9 @@
 #include "functypes.h"
 
 #if defined(__GNUC__) && __GNUC__ >= 3 && \
-  !(defined(_AIX) && defined(__clang__))
-/* ibm-clang defines a macro named 'malloc', which breaks the line below */
+  !(defined(_AIX) && defined(_LINUX_SOURCE_COMPAT))
+/* ibm-clang defines _LINUX_SOURCE_COMPAT which in turn defines a macro named
+  'malloc', which breaks the line below */
 #  define ALLOC_FUNC __attribute__((malloc))
 #  define ALLOC_SIZE(s) __attribute__((alloc_size(s)))
 #  define ALLOC_SIZE2(n, s) __attribute__((alloc_size(n, s)))


### PR DESCRIPTION
- memdebug: replace keyword `malloc` with `__malloc__` to
  not interfere with envs where `malloc` is redefined. Also apply
  the fix to `alloc_size`.
  Fixes:
  ```
  lib/memdebug.h:107:13: warning: unknown attribute 'vec_malloc' ignored [-Wunknown-attributes]
  CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fdopen(int filedes, const char *mode,
              ^~~~~~~~~~
  lib/memdebug.h:37:37: note: expanded from macro 'ALLOC_FUNC'
  # define ALLOC_FUNC __attribute__((malloc))
                                     ^~~~~~
  /usr/include/stdlib.h:753:16: note: expanded from macro 'malloc'
  #define malloc vec_malloc
                 ^~~~~~~~~~
  ```

- memdebug: always undef before defining.
  Also do this for the rest of functions redefined in the same block.
  Avoids warning on AIX:
  ```
  lib/memdebug.h:117:9: warning: 'malloc' macro redefined [-Wmacro-redefined]
  #define malloc(size) curl_dbg_malloc(size, __LINE__, __FILE__)
          ^
  /usr/include/stdlib.h:753:9: note: previous definition is here
  #define malloc vec_malloc
          ^
  ```

- easy: fix `-Wformat` warning on AIX by adding a cast.
  ```
  lib/easy.c:608:47: warning: format specifies type 'int' but the argument has type 'long' [-Wformat]
  "%" CURL_FORMAT_SOCKET_T ")", fds[i].fd);
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
  ```

- if2ip: silence compiler warning inside AIX system header.

  ```
  /lib/if2ip.c:219:19: warning: signed shift result (0x80000000) sets the sign bit of the shift expression's type ('int') and becomes negative [-Wshift-sign-overflow]
  if(ioctl(dummy, SIOCGIFADDR, &req) < 0) {
                  ^~~~~~~~~~~
  /usr/include/sys/ioctl.h:401:26: note: expanded from macro 'SIOCGIFADDR'
  #define SIOCGIFADDR (int)_IOWR('i',33, struct oifreq) /* get ifnet address */
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /usr/include/sys/ioctl.h:174:23: note: expanded from macro '_IOWR'
  #define _IOWR(x,y,t) (IOC_INOUT|((sizeof(t)&IOCPARM_MASK)<<16)|(x<<8)|y)
                        ^~~~~~~~~
  /usr/include/sys/ioctl.h:168:20: note: expanded from macro 'IOC_INOUT'
  #define IOC_INOUT (IOC_IN|IOC_OUT)
                     ^~~~~~
  /usr/include/sys/ioctl.h:167:28: note: expanded from macro 'IOC_IN'
  #define IOC_IN (0x40000000<<1) /* copy in parameters */
                  ~~~~~~~~~~^ ~
  ```

Ref: https://curl.se/dev/log.cgi?id=20240808180420-3809007
Assisted-by: Dan Fandrich
Closes #14464
