### PR TITLE
mk-ca-bundle.pl: include a link to the caextract webpage

### DIFF
--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -408,6 +408,8 @@ print CRT <<EOT;
 ##
 ## Certificate data from Mozilla ${datesrc}: ${currentdate} GMT
 ##
+## Find the updated versions here: https://curl.se/docs/caextract.html
+##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates
 ## file (certdata.txt).  This file can be found in the mozilla source tree:

--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -408,7 +408,7 @@ print CRT <<EOT;
 ##
 ## Certificate data from Mozilla ${datesrc}: ${currentdate} GMT
 ##
-## Find the updated versions here: https://curl.se/docs/caextract.html
+## Find updated versions here: https://curl.se/docs/caextract.html
 ##
 ## This is a bundle of X.509 certificates of public Certificate Authorities
 ## (CA). These were automatically extracted from Mozilla's root certificates


### PR DESCRIPTION
Makes it easier for users who find the file to find its origin.

Fixes https://github.com/curl/curl-www/issues/374