### PR TITLE
configure: fixup copy-paste mistake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -600,6 +600,7 @@ CURL_CHECK_WIN32_LARGEFILE
 CURL_CHECK_WIN32_CRYPTO
 
 CURL_DARWIN_CFLAGS
+
 case $host_os in
   darwin*)
     CURL_SUPPORTS_BUILTIN_AVAILABLE
@@ -2754,7 +2755,6 @@ dnl **********************************************************************
 dnl Check for the presence of AppleIDN
 dnl **********************************************************************
 
-CURL_DARWIN_CFLAGS
 case $host_os in
   darwin*)
     AC_MSG_CHECKING([whether to build with Apple IDN])


### PR DESCRIPTION
Delete duplicate call to `CURL_DARWIN_CFLAGS`.

Follow-up to ada8ebe18c795cc50a1ee3c56af410f7b8094675 #14419
Closes #14468
