### PR TITLE
configure: Replace nonportable grep -o with awk

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5212,7 +5212,8 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
   Features:         ${SUPPORT_FEATURES}
 ])
 
-non13=`echo "$TLSCHOICE" | $EGREP -io 'bearssl|secure-transport'`;
+# grep -o would simplify this, but is nonportable
+[non13=`echo "$TLSCHOICE" | $AWK '{split("bearssl secure-transport", a); for (i in a) if(match(tolower($0), a[i])) print a[i];}'`]
 if test -n "$non13"; then
  for a in $non13; do
    AC_MSG_WARN([$a is enabled for TLS but it does not support TLS 1.3])


### PR DESCRIPTION
This stops an error shown at the end of configure on systems with POSIX
grep and fixes the warning it's trying to convey.

Closes #14469