### PR TITLE
Introduce transfer multi-id, use for dependency tracking

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -217,6 +217,8 @@ static int doh_done(struct Curl_easy *doh, CURLcode result)
   struct Curl_easy *data;
 
   data = Curl_multi_get_handle(doh->multi, doh->set.dohfor_id);
+  DEBUGF(infof(doh, "doh_done: xfer for %" CURL_FORMAT_CURL_OFF_T
+               " is %p", doh->set.dohfor_id, (void *)data));
   if(data) {
     struct dohdata *dohp = data->req.doh;
     /* one of the DoH request done for the 'data' transfer is now complete! */

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -60,7 +60,7 @@ typedef enum {
 
 /* one of these for each DoH request */
 struct dnsprobe {
-  curl_off_t easy_id; /* id of easy handle doing the lookup */
+  curl_off_t easy_mid; /* multi id of easy handle doing the lookup */
   DNStype dnstype;
   unsigned char dohbuffer[512];
   size_t dohlen;

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -60,7 +60,7 @@ typedef enum {
 
 /* one of these for each DoH request */
 struct dnsprobe {
-  CURL *easy;
+  curl_off_t easy_id; /* id of easy handle doing the lookup */
   DNStype dnstype;
   unsigned char dohbuffer[512];
   size_t dohlen;

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -136,7 +136,7 @@ struct cf_h2_ctx {
   struct bufc_pool stream_bufcp; /* spares for stream buffers */
   struct dynbuf scratch;        /* scratch buffer for temp use */
 
-  struct Curl_hash streams; /* hash of `data->id` to `h2_stream_ctx` */
+  struct Curl_hash streams; /* hash of `data->mid` to `h2_stream_ctx` */
   size_t drain_total; /* sum of all stream's UrlState drain */
   uint32_t max_concurrent_streams;
   uint32_t goaway_error;        /* goaway error code from server */
@@ -212,7 +212,7 @@ struct h2_stream_ctx {
 };
 
 #define H2_STREAM_CTX(ctx,data)   ((struct h2_stream_ctx *)(\
-            data? Curl_hash_offt_get(&(ctx)->streams, (data)->id) : NULL))
+            data? Curl_hash_offt_get(&(ctx)->streams, (data)->mid) : NULL))
 
 static struct h2_stream_ctx *h2_stream_ctx_create(struct cf_h2_ctx *ctx)
 {
@@ -375,7 +375,7 @@ static CURLcode http2_data_setup(struct Curl_cfilter *cf,
   if(!stream)
     return CURLE_OUT_OF_MEMORY;
 
-  if(!Curl_hash_offt_set(&ctx->streams, data->id, stream)) {
+  if(!Curl_hash_offt_set(&ctx->streams, data->mid, stream)) {
     h2_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
@@ -413,7 +413,7 @@ static void http2_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
       nghttp2_session_send(ctx->h2);
   }
 
-  Curl_hash_offt_remove(&ctx->streams, data->id);
+  Curl_hash_offt_remove(&ctx->streams, data->mid);
 }
 
 static int h2_client_new(struct Curl_cfilter *cf,
@@ -2007,9 +2007,8 @@ static ssize_t cf_h2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
      * (unlikely) or the transfer has been done, cleaned up its resources, but
      * a read() is called anyway. It is not clear what the calling sequence
      * is for such a case. */
-    failf(data, "[%zd-%zd], http/2 recv on a transfer never opened "
-          "or already cleared", (ssize_t)data->id,
-          (ssize_t)cf->conn->connection_id);
+    failf(data, "http/2 recv on a transfer never opened "
+          "or already cleared, mid=%" CURL_FORMAT_CURL_OFF_T, data->mid);
     *err = CURLE_HTTP2;
     return -1;
   }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3919,7 +3919,7 @@ struct Curl_easy *Curl_multi_get_handle(struct Curl_multi *multi,
 {
 
   if(id >= 0) {
-    struct Curl_easy *data = multi->easyp;
+    struct Curl_easy *data;
     struct Curl_llist_element *e;
 
     for(data = multi->easyp; data; data = data->next) {

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -807,8 +807,6 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
   struct Curl_llist_element *e;
   CURLMcode rc;
 
-  DEBUGF(infof(data, "curl_multi_remove_handle(xfer=%" CURL_FORMAT_CURL_OFF_T
-               ")", data->id));
   /* First, make some basic checks that the CURLM handle is a good handle */
   if(!GOOD_MULTI_HANDLE(multi))
     return CURLM_BAD_HANDLE;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3931,6 +3931,12 @@ struct Curl_easy *Curl_multi_get_handle(struct Curl_multi *multi,
       if(data->id == id)
         return data;
     }
+    /* may be in pending queue? */
+    for(e = multi->pending.head; e; e = e->next) {
+      data = e->ptr;
+      if(data->id == id)
+        return data;
+    }
   }
   return NULL;
 }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3917,10 +3917,11 @@ static void multi_xfer_bufs_free(struct Curl_multi *multi)
 struct Curl_easy *Curl_multi_get_handle(struct Curl_multi *multi,
                                         curl_off_t id)
 {
-  struct Curl_easy *data = multi->easyp;
-  struct Curl_llist_element *e;
 
   if(id >= 0) {
+    struct Curl_easy *data = multi->easyp;
+    struct Curl_llist_element *e;
+
     for(data = multi->easyp; data; data = data->next) {
       if(data->id == id)
         return data;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -807,6 +807,8 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
   struct Curl_llist_element *e;
   CURLMcode rc;
 
+  DEBUGF(infof(data, "curl_multi_remove_handle(xfer=%" CURL_FORMAT_CURL_OFF_T
+               ")", data->id));
   /* First, make some basic checks that the CURLM handle is a good handle */
   if(!GOOD_MULTI_HANDLE(multi))
     return CURLM_BAD_HANDLE;
@@ -3910,4 +3912,25 @@ static void multi_xfer_bufs_free(struct Curl_multi *multi)
   Curl_safefree(multi->xfer_ulbuf);
   multi->xfer_ulbuf_len = 0;
   multi->xfer_ulbuf_borrowed = FALSE;
+}
+
+struct Curl_easy *Curl_multi_get_handle(struct Curl_multi *multi,
+                                        curl_off_t id)
+{
+  struct Curl_easy *data = multi->easyp;
+  struct Curl_llist_element *e;
+
+  if(id >= 0) {
+    for(data = multi->easyp; data; data = data->next) {
+      if(data->id == id)
+        return data;
+    }
+    /* may be in msgsent queue? */
+    for(e = multi->msgsent.head; e; e = e->next) {
+      data = e->ptr;
+      if(data->id == id)
+        return data;
+    }
+  }
+  return NULL;
 }

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -96,6 +96,7 @@ struct Curl_multi {
   struct Curl_llist process; /* not in PENDING or MSGSENT */
   struct Curl_llist pending; /* in PENDING */
   struct Curl_llist msgsent; /* in MSGSENT */
+  curl_off_t next_easy_mid; /* next multi-id for easy handle added */
 
   /* callback function and user data pointer for the *socket() API */
   curl_socket_callback socket_cb;

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -153,4 +153,10 @@ CURLcode Curl_multi_xfer_ulbuf_borrow(struct Curl_easy *data,
  */
 void Curl_multi_xfer_ulbuf_release(struct Curl_easy *data, char *buf);
 
+/**
+ * Get the transfer handle for the given id. Returns NULL if not found.
+ */
+struct Curl_easy *Curl_multi_get_handle(struct Curl_multi *multi,
+                                        curl_off_t id);
+
 #endif /* HEADER_CURL_MULTIIF_H */

--- a/lib/request.c
+++ b/lib/request.c
@@ -100,6 +100,9 @@ CURLcode Curl_req_done(struct SingleRequest *req,
   if(!aborted)
     (void)req_flush(data);
   Curl_client_reset(data);
+#ifndef CURL_DISABLE_DOH
+  Curl_doh_close(data);
+#endif
   return CURLE_OK;
 }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -537,6 +537,9 @@ CURLcode Curl_open(struct Curl_easy **curl)
     data->state.recent_conn_id = -1;
     /* and not assigned an id yet */
     data->id = -1;
+#ifndef CURL_DISABLE_DOH
+    data->set.dohfor_id = -1;
+#endif
 
     data->progress.flags |= PGRS_HIDE;
     data->state.current_speed = -1; /* init to negative == impossible */
@@ -3580,7 +3583,7 @@ static CURLcode create_conn(struct Curl_easy *data,
         Curl_disconnect(data, conn_candidate, FALSE);
       else
 #ifndef CURL_DISABLE_DOH
-        if(data->set.dohfor)
+        if(data->set.dohfor_id >= 0)
           infof(data, "Allowing DoH to override max connection limit");
         else
 #endif

--- a/lib/url.c
+++ b/lib/url.c
@@ -537,8 +537,9 @@ CURLcode Curl_open(struct Curl_easy **curl)
     data->state.recent_conn_id = -1;
     /* and not assigned an id yet */
     data->id = -1;
+    data->mid = -1;
 #ifndef CURL_DISABLE_DOH
-    data->set.dohfor_id = -1;
+    data->set.dohfor_mid = -1;
 #endif
 
     data->progress.flags |= PGRS_HIDE;
@@ -3583,7 +3584,7 @@ static CURLcode create_conn(struct Curl_easy *data,
         Curl_disconnect(data, conn_candidate, FALSE);
       else
 #ifndef CURL_DISABLE_DOH
-        if(data->set.dohfor_id >= 0)
+        if(data->set.dohfor_mid >= 0)
           infof(data, "Allowing DoH to override max connection limit");
         else
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1751,7 +1751,7 @@ struct UserDefined {
   long upkeep_interval_ms;      /* Time between calls for connection upkeep. */
   multidone_func fmultidone;
 #ifndef CURL_DISABLE_DOH
-  struct Curl_easy *dohfor; /* this is a DoH request for that transfer */
+  curl_off_t dohfor_id; /* this is a DoH request for that transfer */
 #endif
   CURLU *uh; /* URL handle for the current parsed URL */
 #ifndef CURL_DISABLE_HTTP

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1751,7 +1751,7 @@ struct UserDefined {
   long upkeep_interval_ms;      /* Time between calls for connection upkeep. */
   multidone_func fmultidone;
 #ifndef CURL_DISABLE_DOH
-  curl_off_t dohfor_id; /* this is a DoH request for that transfer */
+  curl_off_t dohfor_mid; /* this is a DoH request for that transfer */
 #endif
   CURLU *uh; /* URL handle for the current parsed URL */
 #ifndef CURL_DISABLE_HTTP
@@ -1907,8 +1907,14 @@ struct Curl_easy {
      other using the same cache. For easier tracking
      in log output.
      This may wrap around after LONG_MAX to 0 again, so it
-     has no uniqueness guarantee for very large processings. */
+     has no uniqueness guarantee for very large processings.
+     Note: it has no uniqueness either IFF more than one connection cache
+     is used by the libcurl application. */
   curl_off_t id;
+  /* once an easy handle is added to a multi, either explicitly by the
+   * libcurl application or implicitly during `curl_easy_perform()`,
+   * a unique identifier inside this one multi instance. */
+  curl_off_t mid;
 
   struct connectdata *conn;
   struct Curl_llist_element multi_queue; /* for multihandle list management */

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -119,7 +119,7 @@ struct cf_msh3_ctx {
   struct cf_call_data call_data;
   struct curltime connect_started;   /* time the current attempt started */
   struct curltime handshake_at;      /* time connect handshake finished */
-  struct Curl_hash streams;          /* hash `data->id` to `stream_ctx` */
+  struct Curl_hash streams;          /* hash `data->mid` to `stream_ctx` */
   /* Flags written by msh3/msquic thread */
   bool handshake_complete;
   bool handshake_succeeded;
@@ -158,7 +158,7 @@ struct stream_ctx {
 };
 
 #define H3_STREAM_CTX(ctx,data)   ((struct stream_ctx *)((data && ctx)? \
-                Curl_hash_offt_get(&(ctx)->streams, (data)->id) : NULL))
+                Curl_hash_offt_get(&(ctx)->streams, (data)->mid) : NULL))
 
 static void h3_stream_ctx_free(struct stream_ctx *stream)
 {
@@ -191,7 +191,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
                   H3_STREAM_RECV_CHUNKS, BUFQ_OPT_SOFT_LIMIT);
   CURL_TRC_CF(data, cf, "data setup");
 
-  if(!Curl_hash_offt_set(&ctx->streams, data->id, stream)) {
+  if(!Curl_hash_offt_set(&ctx->streams, data->mid, stream)) {
     h3_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
@@ -207,7 +207,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
   (void)cf;
   if(stream) {
     CURL_TRC_CF(data, cf, "easy handle is done");
-    Curl_hash_offt_remove(&ctx->streams, data->id);
+    Curl_hash_offt_remove(&ctx->streams, data->mid);
   }
 }
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -132,7 +132,7 @@ struct cf_ngtcp2_ctx {
   struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
   struct dynbuf scratch;             /* temp buffer for header construction */
-  struct Curl_hash streams;          /* hash `data->id` to `h3_stream_ctx` */
+  struct Curl_hash streams;          /* hash `data->mid` to `h3_stream_ctx` */
   size_t max_stream_window;          /* max flow window for one stream */
   uint64_t max_idle_ms;              /* max idle time for QUIC connection */
   uint64_t used_bidi_streams;        /* bidi streams we have opened */
@@ -174,7 +174,7 @@ struct h3_stream_ctx {
 };
 
 #define H3_STREAM_CTX(ctx,data)   ((struct h3_stream_ctx *)(\
-            data? Curl_hash_offt_get(&(ctx)->streams, (data)->id) : NULL))
+            data? Curl_hash_offt_get(&(ctx)->streams, (data)->mid) : NULL))
 #define H3_STREAM_CTX_ID(ctx,id)  ((struct h3_stream_ctx *)(\
             Curl_hash_offt_get(&(ctx)->streams, (id))))
 
@@ -216,7 +216,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   stream->sendbuf_len_in_flight = 0;
   Curl_h1_req_parse_init(&stream->h1, H1_PARSE_DEFAULT_MAX_LINE_LEN);
 
-  if(!Curl_hash_offt_set(&ctx->streams, data->id, stream)) {
+  if(!Curl_hash_offt_set(&ctx->streams, data->mid, stream)) {
     h3_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
@@ -255,7 +255,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
     CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] easy handle is done",
                 stream->id);
     cf_ngtcp2_stream_close(cf, data, stream);
-    Curl_hash_offt_remove(&ctx->streams, data->id);
+    Curl_hash_offt_remove(&ctx->streams, data->mid);
   }
 }
 

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -290,7 +290,7 @@ struct cf_osslq_ctx {
   struct curltime first_byte_at;     /* when first byte was recvd */
   struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
-  struct Curl_hash streams;          /* hash `data->id` to `h3_stream_ctx` */
+  struct Curl_hash streams;          /* hash `data->mid` to `h3_stream_ctx` */
   size_t max_stream_window;          /* max flow window for one stream */
   uint64_t max_idle_ms;              /* max idle time for QUIC connection */
   BIT(got_first_byte);               /* if first byte was received */
@@ -573,7 +573,7 @@ struct h3_stream_ctx {
 };
 
 #define H3_STREAM_CTX(ctx,data)   ((struct h3_stream_ctx *)(\
-            data? Curl_hash_offt_get(&(ctx)->streams, (data)->id) : NULL))
+            data? Curl_hash_offt_get(&(ctx)->streams, (data)->mid) : NULL))
 
 static void h3_stream_ctx_free(struct h3_stream_ctx *stream)
 {
@@ -620,7 +620,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   stream->recv_buf_nonflow = 0;
   Curl_h1_req_parse_init(&stream->h1, H1_PARSE_DEFAULT_MAX_LINE_LEN);
 
-  if(!Curl_hash_offt_set(&ctx->streams, data->id, stream)) {
+  if(!Curl_hash_offt_set(&ctx->streams, data->mid, stream)) {
     h3_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
@@ -645,7 +645,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
       stream->closed = TRUE;
     }
 
-    Curl_hash_offt_remove(&ctx->streams, data->id);
+    Curl_hash_offt_remove(&ctx->streams, data->mid);
   }
 }
 

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -98,7 +98,7 @@ struct cf_quiche_ctx {
   struct curltime handshake_at;      /* time connect handshake finished */
   struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
-  struct Curl_hash streams;          /* hash `data->id` to `stream_ctx` */
+  struct Curl_hash streams;          /* hash `data->mid` to `stream_ctx` */
   curl_off_t data_recvd;
   BIT(goaway);                       /* got GOAWAY from server */
   BIT(x509_store_setup);             /* if x509 store has been set up */
@@ -158,7 +158,7 @@ struct stream_ctx {
 };
 
 #define H3_STREAM_CTX(ctx,data)   ((struct stream_ctx *)(\
-            data? Curl_hash_offt_get(&(ctx)->streams, (data)->id) : NULL))
+            data? Curl_hash_offt_get(&(ctx)->streams, (data)->mid) : NULL))
 
 static void h3_stream_ctx_free(struct stream_ctx *stream)
 {
@@ -211,7 +211,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
                   H3_STREAM_RECV_CHUNKS, BUFQ_OPT_SOFT_LIMIT);
   Curl_h1_req_parse_init(&stream->h1, H1_PARSE_DEFAULT_MAX_LINE_LEN);
 
-  if(!Curl_hash_offt_set(&ctx->streams, data->id, stream)) {
+  if(!Curl_hash_offt_set(&ctx->streams, data->mid, stream)) {
     h3_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
@@ -241,7 +241,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
       if(result)
         CURL_TRC_CF(data, cf, "data_done, flush egress -> %d", result);
     }
-    Curl_hash_offt_remove(&ctx->streams, data->id);
+    Curl_hash_offt_remove(&ctx->streams, data->mid);
   }
 }
 


### PR DESCRIPTION
Introduce `data->mid`, a unique identifier inside a multi

`data->id` is unique in *most* situations, but not in all. If a libcurl application uses more than one connection cache, they will overlap. This is a rare situations, but libcurl apps do crazy things.
However, for informative things, like tracing, `data->id` is superior, since it assigns new ids in curl's serial `curl_easy_perform()` use. Also, `data->id` is not cleared when the transfer is removed from the multi handle.

Introduce `data->mid` which is a unique identifer inside one multi instance, assigned on `multi_add_handle()` and cleared on `multi_remove_handle()`.

Use the `mid` in DoH operations and also in h2/h3 stream hashes.
