### PR TITLE
multi: make the "general" list of easy handles a Curl_llist

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -597,14 +597,20 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     }
     else {
       /* here pollrc is > 0 */
+      struct Curl_llist_element *e = multi->process.head;
+      struct Curl_easy *data;
+      DEBUGASSERT(e);
+      data = e->ptr;
+      DEBUGASSERT(data);
 
       /* loop over the monitored sockets to see which ones had activity */
       for(i = 0; i< numfds; i++) {
         if(fds[i].revents) {
           /* socket activity, tell libcurl */
           int act = poll2cselect(fds[i].revents); /* convert */
-          infof(multi->easyp,
-                "call curl_multi_socket_action(socket "
+
+          /* sending infof "randomly" to the first easy handle */
+          infof(data, "call curl_multi_socket_action(socket "
                 "%" CURL_FORMAT_SOCKET_T ")", (curl_socket_t)fds[i].fd);
           mcode = curl_multi_socket_action(multi, fds[i].fd, act,
                                            &ev->running_handles);

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -86,20 +86,16 @@ struct Curl_multi {
      this multi handle with an easy handle. Set this to CURL_MULTI_HANDLE. */
   unsigned int magic;
 
-  /* We have a doubly-linked list with easy handles */
-  struct Curl_easy *easyp;
-  struct Curl_easy *easylp; /* last node */
-
   unsigned int num_easy; /* amount of entries in the linked list above. */
   unsigned int num_alive; /* amount of easy handles that are added but have
                              not yet reached COMPLETE state */
 
   struct Curl_llist msglist; /* a list of messages from completed transfers */
 
-  struct Curl_llist pending; /* Curl_easys that are in the
-                                MSTATE_PENDING state */
-  struct Curl_llist msgsent; /* Curl_easys that are in the
-                                MSTATE_MSGSENT state */
+  /* Each added easy handle is in ONE of these three lists */
+  struct Curl_llist process; /* not in PENDING or MSGSENT */
+  struct Curl_llist pending; /* in PENDING */
+  struct Curl_llist msgsent; /* in MSGSENT */
 
   /* callback function and user data pointer for the *socket() API */
   curl_socket_callback socket_cb;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1910,13 +1910,8 @@ struct Curl_easy {
      has no uniqueness guarantee for very large processings. */
   curl_off_t id;
 
-  /* first, two fields for the linked list of these */
-  struct Curl_easy *next;
-  struct Curl_easy *prev;
-
   struct connectdata *conn;
-  struct Curl_llist_element connect_queue; /* for the pending and msgsent
-                                              lists */
+  struct Curl_llist_element multi_queue; /* for multihandle list management */
   struct Curl_llist_element conn_queue; /* list per connectdata */
 
   CURLMstate mstate;  /* the handle's state */

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -265,7 +265,6 @@ static struct Curl_easy *get_stream_easy(struct Curl_cfilter *cf,
                                          struct h3_stream_ctx **pstream)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
-  struct Curl_easy *sdata;
   struct h3_stream_ctx *stream;
 
   (void)cf;
@@ -275,8 +274,10 @@ static struct Curl_easy *get_stream_easy(struct Curl_cfilter *cf,
     return data;
   }
   else {
+    struct Curl_llist_element *e;
     DEBUGASSERT(data->multi);
-    for(sdata = data->multi->easyp; sdata; sdata = sdata->next) {
+    for(e = data->multi->process.head; e; e = e->next) {
+      struct Curl_easy *sdata = e->ptr;
       if(sdata->conn != data->conn)
         continue;
       stream = H3_STREAM_CTX(ctx, sdata);


### PR DESCRIPTION
Instead of having an especially "unique" linked list handler for the main list of easy handles within the multi handle, this now uses a regular Curl_llist for this as well.

With this change, it is clearer that every easy handle added to a multi handle belongs to one and only one out of three different lists:

 process - the general one for normal transfer processing

 pending - queued up waiting to get a connection (MSTATE_PENDING)

 msgsent - transfer completed (MSTATE_MSGSENT)