### PR TITLE
cmake: exclude tests/http/clients builds by default

### DIFF
--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -28,7 +28,7 @@ include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 foreach(_test_name IN LISTS check_PROGRAMS)
   set(_test_target "curl-test-client-${_test_name}")
-  add_executable(${_test_target} "${_test_name}.c")
+  add_executable(${_test_target} EXCLUDE_FROM_ALL "${_test_name}.c")
   add_dependencies(testdeps ${_test_target})
   target_include_directories(${_test_target} PRIVATE
     "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"


### PR DESCRIPTION
To limit building them with the testdeps target, like it's done with
the rest of test programs.

Follow-up to 232302f88a152a1d1722da9f69c383a766528918 #14382
Closes #14477