### PR TITLE
autotools: add `--with-windows-unicode` option

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,7 +52,7 @@ jobs:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver', name: 'default' }
           - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: 'skipall'                 , config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '', name: 'default R' }
-          - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver --disable-curldebug --enable-static=no', name: 'default' }
+          - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver --disable-curldebug --enable-static=no --with-windows-unicode', name: 'default' }
           # FIXME: WebSockets test results ignored due to frequent failures on native Windows:
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Debug', name: 'schannel U' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }

--- a/configure.ac
+++ b/configure.ac
@@ -4827,12 +4827,9 @@ AC_SUBST(BLANK_AT_MAKETIME)
 
 AM_CONDITIONAL(CROSSCOMPILING, test x$cross_compiling = xyes)
 
-AC_MSG_NOTICE([winuni CPPFLAGS-1: '$CPPFLAGS'])
 if test "x$want_winuni" = "xyes"; then
-  AC_MSG_NOTICE([winuni CPPFLAGS-2: '$CPPFLAGS'])
-  CPPFLAGS=`echo $CPPFLAGS | $SED 's/ -Dmain=wmain//g'`
+  CPPFLAGS=`echo "$CPPFLAGS" | $SED 's/ -Dmain=wmain//g'`
 fi
-AC_MSG_NOTICE([winuni CPPFLAGS-3: '$CPPFLAGS'])
 
 dnl yes or no
 ENABLE_SHARED="$enable_shared"

--- a/configure.ac
+++ b/configure.ac
@@ -2523,29 +2523,31 @@ AC_SUBST([CURL_LT_SHLIB_VERSIONED_FLAVOUR],
 AM_CONDITIONAL([CURL_LT_SHLIB_USE_VERSIONED_SYMBOLS],
   [test "x$versioned_symbols" = 'xyes'])
 
-dnl --------------------
-dnl check Unicode option
-dnl --------------------
+dnl ----------------------------
+dnl check Windows Unicode option
+dnl ----------------------------
 
-AC_MSG_CHECKING([whether to enable Windows native IDN (Windows native builds only)])
-OPT_WINUNI="default"
-AC_ARG_WITH(windows-unicode,
-AS_HELP_STRING([--with-windows-unicode],[enable Windows Unicode])
-AS_HELP_STRING([--without-windows-unicode], [disable Windows Unicode (default)]),
-  OPT_WINUNI=$withval)
-case "$OPT_WINUNI" in
-  yes)
-    CPPFLAGS="${CPPFLAGS} -Dmain=wmain"
-    CPPFLAGS="${CPPFLAGS} -DUNICODE -D_UNICODE"
-    LDFLAGS="${LDFLAGS} -municode"
-    want_winuni="yes"
-    AC_MSG_RESULT([yes])
-    ;;
-  *)
-    want_winuni="no"
-    AC_MSG_RESULT([no])
-    ;;
-esac
+if test "$curl_cv_native_windows" = "yes"; then
+  AC_MSG_CHECKING([whether to enable Windows native IDN (Windows native builds only)])
+  OPT_WINUNI="default"
+  AC_ARG_WITH(windows-unicode,
+  AS_HELP_STRING([--with-windows-unicode],[enable Windows Unicode])
+  AS_HELP_STRING([--without-windows-unicode], [disable Windows Unicode (default)]),
+    OPT_WINUNI=$withval)
+  case "$OPT_WINUNI" in
+    yes)
+      CPPFLAGS="${CPPFLAGS} -Dmain=wmain"
+      CPPFLAGS="${CPPFLAGS} -DUNICODE -D_UNICODE"
+      LDFLAGS="${LDFLAGS} -municode"
+      want_winuni="yes"
+      AC_MSG_RESULT([yes])
+      ;;
+    *)
+      want_winuni="no"
+      AC_MSG_RESULT([no])
+      ;;
+  esac
+fi
 
 dnl -------------------------------------------------
 dnl check winidn option before other IDN libraries

--- a/configure.ac
+++ b/configure.ac
@@ -2529,7 +2529,7 @@ dnl ----------------------------
 
 want_winuni="no"
 if test "$curl_cv_native_windows" = "yes"; then
-  AC_MSG_CHECKING([whether to enable Windows native IDN (Windows native builds only)])
+  AC_MSG_CHECKING([whether to enable Windows Unicode (Windows native builds only)])
   OPT_WINUNI="default"
   AC_ARG_WITH(windows-unicode,
   AS_HELP_STRING([--with-windows-unicode],[enable Windows Unicode])

--- a/configure.ac
+++ b/configure.ac
@@ -2537,7 +2537,6 @@ if test "$curl_cv_native_windows" = "yes"; then
     OPT_WINUNI=$withval)
   case "$OPT_WINUNI" in
     yes)
-      CPPFLAGS="${CPPFLAGS} -Dmain=wmain"
       CPPFLAGS="${CPPFLAGS} -DUNICODE -D_UNICODE"
       want_winuni="yes"
       AC_MSG_RESULT([yes])
@@ -4827,10 +4826,6 @@ BLANK_AT_MAKETIME=
 AC_SUBST(BLANK_AT_MAKETIME)
 
 AM_CONDITIONAL(CROSSCOMPILING, test x$cross_compiling = xyes)
-
-if test "x$want_winuni" = "xyes"; then
-  CPPFLAGS=`echo "$CPPFLAGS" | $SED 's/ -Dmain=wmain//g'`
-fi
 
 dnl yes or no
 ENABLE_SHARED="$enable_shared"

--- a/configure.ac
+++ b/configure.ac
@@ -4827,6 +4827,10 @@ AC_SUBST(BLANK_AT_MAKETIME)
 
 AM_CONDITIONAL(CROSSCOMPILING, test x$cross_compiling = xyes)
 
+if test "x$want_winuni" = "xyes"; then
+  CPPFLAGS=`echo $CPPFLAGS | $SED -e 's/ -Dmain=wmain//'`
+fi
+
 dnl yes or no
 ENABLE_SHARED="$enable_shared"
 AC_SUBST(ENABLE_SHARED)

--- a/configure.ac
+++ b/configure.ac
@@ -4827,9 +4827,12 @@ AC_SUBST(BLANK_AT_MAKETIME)
 
 AM_CONDITIONAL(CROSSCOMPILING, test x$cross_compiling = xyes)
 
+AC_MSG_NOTICE([winuni CPPFLAGS-1: '$CPPFLAGS'])
 if test "x$want_winuni" = "xyes"; then
-  CPPFLAGS=`echo $CPPFLAGS | $SED -e 's/ -Dmain=wmain//'`
+  AC_MSG_NOTICE([winuni CPPFLAGS-2: '$CPPFLAGS'])
+  CPPFLAGS=`echo $CPPFLAGS | $SED 's/ -Dmain=wmain//g'`
 fi
+AC_MSG_NOTICE([winuni CPPFLAGS-3: '$CPPFLAGS'])
 
 dnl yes or no
 ENABLE_SHARED="$enable_shared"

--- a/configure.ac
+++ b/configure.ac
@@ -2539,7 +2539,6 @@ if test "$curl_cv_native_windows" = "yes"; then
     yes)
       CPPFLAGS="${CPPFLAGS} -Dmain=wmain"
       CPPFLAGS="${CPPFLAGS} -DUNICODE -D_UNICODE"
-      LDFLAGS="${LDFLAGS} -municode"
       want_winuni="yes"
       AC_MSG_RESULT([yes])
       ;;
@@ -2548,6 +2547,8 @@ if test "$curl_cv_native_windows" = "yes"; then
       ;;
   esac
 fi
+
+AM_CONDITIONAL([USE_UNICODE], [test "$want_winuni" = "yes"])
 
 dnl -------------------------------------------------
 dnl check winidn option before other IDN libraries

--- a/configure.ac
+++ b/configure.ac
@@ -2527,6 +2527,7 @@ dnl ----------------------------
 dnl check Windows Unicode option
 dnl ----------------------------
 
+want_winuni="no"
 if test "$curl_cv_native_windows" = "yes"; then
   AC_MSG_CHECKING([whether to enable Windows native IDN (Windows native builds only)])
   OPT_WINUNI="default"
@@ -2543,7 +2544,6 @@ if test "$curl_cv_native_windows" = "yes"; then
       AC_MSG_RESULT([yes])
       ;;
     *)
-      want_winuni="no"
       AC_MSG_RESULT([no])
       ;;
   esac
@@ -5015,6 +5015,9 @@ else
   ])
 fi
 
+if test "x$want_winuni" = "xyes"; then
+  SUPPORT_FEATURES="$SUPPORT_FEATURES Unicode"
+fi
 if test "x$want_debug" = "xyes"; then
   SUPPORT_FEATURES="$SUPPORT_FEATURES Debug"
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -2523,6 +2523,30 @@ AC_SUBST([CURL_LT_SHLIB_VERSIONED_FLAVOUR],
 AM_CONDITIONAL([CURL_LT_SHLIB_USE_VERSIONED_SYMBOLS],
   [test "x$versioned_symbols" = 'xyes'])
 
+dnl --------------------
+dnl check Unicode option
+dnl --------------------
+
+AC_MSG_CHECKING([whether to enable Windows native IDN (Windows native builds only)])
+OPT_WINUNI="default"
+AC_ARG_WITH(windows-unicode,
+AS_HELP_STRING([--with-windows-unicode],[enable Windows Unicode])
+AS_HELP_STRING([--without-windows-unicode], [disable Windows Unicode (default)]),
+  OPT_WINUNI=$withval)
+case "$OPT_WINUNI" in
+  yes)
+    CPPFLAGS="${CPPFLAGS} -Dmain=wmain"
+    CPPFLAGS="${CPPFLAGS} -DUNICODE -D_UNICODE"
+    LDFLAGS="${LDFLAGS} -municode"
+    want_winuni="yes"
+    AC_MSG_RESULT([yes])
+    ;;
+  *)
+    want_winuni="no"
+    AC_MSG_RESULT([no])
+    ;;
+esac
+
 dnl -------------------------------------------------
 dnl check winidn option before other IDN libraries
 dnl -------------------------------------------------

--- a/docs/TODO
+++ b/docs/TODO
@@ -178,7 +178,6 @@
  19.3 Do not use GNU libtool on OpenBSD
  19.4 Package curl for Windows in a signed installer
  19.5 make configure use --cache-file more and better
- 19.6 build curl with Windows Unicode support
 
  20. Test suite
  20.1 SSL tunnel
@@ -1306,13 +1305,6 @@
  invokes run much faster.
 
  See https://github.com/curl/curl/issues/7753
-
-19.6 build curl with Windows Unicode support
-
- The user wants an easier way to tell autotools to build curl with Windows
- Unicode support, like ./configure --enable-windows-unicode
-
- See https://github.com/curl/curl/issues/7229
 
 20. Test suite
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -50,6 +50,11 @@ AM_CPPFLAGS += -DCURL_STATICLIB
 endif
 AM_CPPFLAGS += -DBUILDING_CURL
 
+AM_LDFLAGS =
+if USE_UNICODE
+AM_LDFLAGS += -municode
+endif
+
 include Makefile.inc
 
 # CURL_FILES comes from Makefile.inc


### PR DESCRIPTION
- add `--with-windows-unicode` and `--without-windows-unicode` (default)
  options.

- enable it in a CI job.

Fixes #7229
Closes #14478
