### PR TITLE
tidy-up: delete `Makefile.inc` from `EXTRA_DIST`

### DIFF
--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -24,8 +24,8 @@
 
 AUTOMAKE_OPTIONS = foreign nostdinc
 
-EXTRA_DIST = README.md Makefile.example Makefile.inc Makefile.mk \
-  CMakeLists.txt $(COMPLICATED_EXAMPLES) .checksrc
+EXTRA_DIST = README.md Makefile.example Makefile.mk CMakeLists.txt \
+  $(COMPLICATED_EXAMPLES) .checksrc
 
 # Specify our include paths here, and do it relative to $(top_srcdir) and
 # $(top_builddir), to ensure that these paths which belong to the library

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -37,7 +37,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_srcdir)/lib
 
 EXTRA_DIST = test307.pl test610.pl test613.pl test1013.pl test1022.pl   \
-  Makefile.inc notexists.pl CMakeLists.txt mk-lib1521.pl .checksrc
+  notexists.pl CMakeLists.txt mk-lib1521.pl .checksrc
 
 CFLAG_CURL_SYMBOL_HIDING = @CFLAG_CURL_SYMBOL_HIDING@
 

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -49,7 +49,7 @@ endif
 # Makefile.inc provides neat definitions
 include Makefile.inc
 
-EXTRA_DIST = base64.pl Makefile.inc CMakeLists.txt
+EXTRA_DIST = base64.pl CMakeLists.txt
 
 CHECKSRC = $(CS_$(V))
 CS_0 = @echo "  RUN     " $@;

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -38,7 +38,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_srcdir)/src            \
               -I$(top_srcdir)/tests/libtest
 
-EXTRA_DIST = Makefile.inc CMakeLists.txt README.md
+EXTRA_DIST = CMakeLists.txt README.md
 
 CFLAGS += @CURL_CFLAG_EXTRAS@
 


### PR DESCRIPTION
autotools is adding them automatically. Delete the few ones that were
also added manually.

Closes #14496
