### PR TITLE
docs/cmdline: refer to --show-headers instead of --include

### DIFF
--- a/docs/cmdline-opts/location.md
+++ b/docs/cmdline-opts/location.md
@@ -20,7 +20,7 @@ Example:
 If the server reports that the requested page has moved to a different
 location (indicated with a Location: header and a 3XX response code), this
 option makes curl redo the request on the new place. If used together with
---include or --head, headers from all requested pages are shown.
+--show-headers or --head, headers from all requested pages are shown.
 
 When authentication is used, curl only sends its credentials to the initial
 host. If a redirect takes curl to a different host, it does not get the

--- a/docs/cmdline-opts/suppress-connect-headers.md
+++ b/docs/cmdline-opts/suppress-connect-headers.md
@@ -11,12 +11,13 @@ See-also:
   - show-headers
   - proxytunnel
 Example:
-  - --suppress-connect-headers --include -x proxy $URL
+  - --suppress-connect-headers --show-headers -x proxy $URL
 ---
 
 # `--suppress-connect-headers`
 
 When --proxytunnel is used and a CONNECT request is made do not output proxy
-CONNECT response headers. This option is meant to be used with --dump-header or
---include which are used to show protocol headers in the output. It has no
-effect on debug options such as --verbose or --trace, or any statistics.
+CONNECT response headers. This option is meant to be used with --dump-header
+or --show-headers which are used to show protocol headers in the output. It
+has no effect on debug options such as --verbose or --trace, or any
+statistics.

--- a/docs/cmdline-opts/verbose.md
+++ b/docs/cmdline-opts/verbose.md
@@ -25,8 +25,8 @@ what's going on under the hood. A line starting with \> means header data sent
 by curl, \< means header data received by curl that is hidden in normal cases,
 and a line starting with * means additional info provided by curl.
 
-If you only want HTTP headers in the output, --include or --dump-header might
-be more suitable options.
+If you only want HTTP headers in the output, --show-headers or --dump-header
+might be more suitable options.
 
 Since curl 8.10, mentioning this option several times in the same argument
 increases the level of the trace output. However, as before, a single


### PR DESCRIPTION
As it is the new version of the option that is easier to understand what it does by name.