### PR TITLE
unique identifier inside a multi, data->mid

### DIFF
--- a/lib/doh.h
+++ b/lib/doh.h
@@ -60,7 +60,7 @@ typedef enum {
 
 /* one of these for each DoH request */
 struct dnsprobe {
-  CURL *easy;
+  curl_off_t easy_mid; /* multi id of easy handle doing the lookup */
   DNStype dnstype;
   unsigned char dohbuffer[512];
   size_t dohlen;

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3906,22 +3906,22 @@ struct Curl_easy *Curl_multi_get_handle(struct Curl_multi *multi,
 
   if(mid >= 0) {
     struct Curl_easy *data;
-    struct Curl_llist_element *e;
+    struct Curl_llist_node *e;
 
-    for(e = multi->process.head; e; e = e->next) {
-      data = e->ptr;
+    for(e = Curl_llist_head(&multi->process); e; e = Curl_node_next(e)) {
+      data = Curl_node_elem(e);
       if(data->mid == mid)
         return data;
     }
-    /* may be in msgsent queue? */
-    for(e = multi->msgsent.head; e; e = e->next) {
-      data = e->ptr;
+    /* may be in msgsent queue */
+    for(e = Curl_llist_head(&multi->msgsent); e; e = Curl_node_next(e)) {
+      data = Curl_node_elem(e);
       if(data->mid == mid)
         return data;
     }
-    /* may be in pending queue? */
-    for(e = multi->pending.head; e; e = e->next) {
-      data = e->ptr;
+    /* may be in pending queue */
+    for(e = Curl_llist_head(&multi->pending); e; e = Curl_node_next(e)) {
+      data = Curl_node_elem(e);
       if(data->mid == mid)
         return data;
     }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -592,9 +592,16 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
     data->set.server_response_timeout;
   data->state.conn_cache->closure_handle->set.no_signal =
     data->set.no_signal;
+
+  /* the identifier inside the connection cache */
   data->id = data->state.conn_cache->next_easy_id++;
   if(data->state.conn_cache->next_easy_id <= 0)
     data->state.conn_cache->next_easy_id = 0;
+  /* the identifier inside the multi instance */
+  data->mid = multi->next_easy_mid++;
+  if(multi->next_easy_mid <= 0)
+    multi->next_easy_mid = 0;
+
   CONNCACHE_UNLOCK(data);
 
   multi_warn_debug(multi, data);
@@ -904,8 +911,6 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
      since we are not part of that multi handle anymore */
   data->state.conn_cache = NULL;
 
-  data->multi = NULL; /* clear the association to this multi handle */
-
   /* make sure there is no pending message in the queue sent from this easy
      handle */
   for(e = Curl_llist_head(&multi->msglist); e; e = Curl_node_next(e)) {
@@ -917,6 +922,9 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
       break;
     }
   }
+
+  data->multi = NULL; /* clear the association to this multi handle */
+  data->mid = -1;
 
   /* NOTE NOTE NOTE
      We do not touch the easy handle here! */
@@ -3890,4 +3898,33 @@ static void multi_xfer_bufs_free(struct Curl_multi *multi)
   Curl_safefree(multi->xfer_ulbuf);
   multi->xfer_ulbuf_len = 0;
   multi->xfer_ulbuf_borrowed = FALSE;
+}
+
+struct Curl_easy *Curl_multi_get_handle(struct Curl_multi *multi,
+                                        curl_off_t mid)
+{
+
+  if(mid >= 0) {
+    struct Curl_easy *data;
+    struct Curl_llist_element *e;
+
+    for(e = multi->process.head; e; e = e->next) {
+      data = e->ptr;
+      if(data->mid == mid)
+        return data;
+    }
+    /* may be in msgsent queue? */
+    for(e = multi->msgsent.head; e; e = e->next) {
+      data = e->ptr;
+      if(data->mid == mid)
+        return data;
+    }
+    /* may be in pending queue? */
+    for(e = multi->pending.head; e; e = e->next) {
+      data = e->ptr;
+      if(data->mid == mid)
+        return data;
+    }
+  }
+  return NULL;
 }

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -96,6 +96,7 @@ struct Curl_multi {
   struct Curl_llist process; /* not in PENDING or MSGSENT */
   struct Curl_llist pending; /* in PENDING */
   struct Curl_llist msgsent; /* in MSGSENT */
+  curl_off_t next_easy_mid; /* next multi-id for easy handle added */
 
   /* callback function and user data pointer for the *socket() API */
   curl_socket_callback socket_cb;

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -153,4 +153,10 @@ CURLcode Curl_multi_xfer_ulbuf_borrow(struct Curl_easy *data,
  */
 void Curl_multi_xfer_ulbuf_release(struct Curl_easy *data, char *buf);
 
+/**
+ * Get the transfer handle for the given id. Returns NULL if not found.
+ */
+struct Curl_easy *Curl_multi_get_handle(struct Curl_multi *multi,
+                                        curl_off_t id);
+
 #endif /* HEADER_CURL_MULTIIF_H */

--- a/lib/request.c
+++ b/lib/request.c
@@ -100,6 +100,9 @@ CURLcode Curl_req_done(struct SingleRequest *req,
   if(!aborted)
     (void)req_flush(data);
   Curl_client_reset(data);
+#ifndef CURL_DISABLE_DOH
+  Curl_doh_close(data);
+#endif
   return CURLE_OK;
 }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -536,6 +536,10 @@ CURLcode Curl_open(struct Curl_easy **curl)
     data->state.recent_conn_id = -1;
     /* and not assigned an id yet */
     data->id = -1;
+    data->mid = -1;
+#ifndef CURL_DISABLE_DOH
+    data->set.dohfor_mid = -1;
+#endif
 
     data->progress.flags |= PGRS_HIDE;
     data->state.current_speed = -1; /* init to negative == impossible */
@@ -3581,7 +3585,7 @@ static CURLcode create_conn(struct Curl_easy *data,
         Curl_disconnect(data, conn_candidate, FALSE);
       else
 #ifndef CURL_DISABLE_DOH
-        if(data->set.dohfor)
+        if(data->set.dohfor_mid >= 0)
           infof(data, "Allowing DoH to override max connection limit");
         else
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1751,7 +1751,7 @@ struct UserDefined {
   long upkeep_interval_ms;      /* Time between calls for connection upkeep. */
   multidone_func fmultidone;
 #ifndef CURL_DISABLE_DOH
-  struct Curl_easy *dohfor; /* this is a DoH request for that transfer */
+  curl_off_t dohfor_mid; /* this is a DoH request for that transfer */
 #endif
   CURLU *uh; /* URL handle for the current parsed URL */
 #ifndef CURL_DISABLE_HTTP
@@ -1907,8 +1907,14 @@ struct Curl_easy {
      other using the same cache. For easier tracking
      in log output.
      This may wrap around after LONG_MAX to 0 again, so it
-     has no uniqueness guarantee for very large processings. */
+     has no uniqueness guarantee for very large processings.
+     Note: it has no uniqueness either IFF more than one connection cache
+     is used by the libcurl application. */
   curl_off_t id;
+  /* once an easy handle is added to a multi, either explicitly by the
+   * libcurl application or implicitly during `curl_easy_perform()`,
+   * a unique identifier inside this one multi instance. */
+  curl_off_t mid;
 
   struct connectdata *conn;
   struct Curl_llist_node multi_queue; /* for multihandle list management */

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -119,7 +119,7 @@ struct cf_msh3_ctx {
   struct cf_call_data call_data;
   struct curltime connect_started;   /* time the current attempt started */
   struct curltime handshake_at;      /* time connect handshake finished */
-  struct Curl_hash streams;          /* hash `data->id` to `stream_ctx` */
+  struct Curl_hash streams;          /* hash `data->mid` to `stream_ctx` */
   /* Flags written by msh3/msquic thread */
   bool handshake_complete;
   bool handshake_succeeded;
@@ -180,7 +180,7 @@ struct stream_ctx {
 };
 
 #define H3_STREAM_CTX(ctx,data)   ((struct stream_ctx *)((data && ctx)? \
-                Curl_hash_offt_get(&(ctx)->streams, (data)->id) : NULL))
+                Curl_hash_offt_get(&(ctx)->streams, (data)->mid) : NULL))
 
 static void h3_stream_ctx_free(struct stream_ctx *stream)
 {
@@ -213,7 +213,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
                   H3_STREAM_RECV_CHUNKS, BUFQ_OPT_SOFT_LIMIT);
   CURL_TRC_CF(data, cf, "data setup");
 
-  if(!Curl_hash_offt_set(&ctx->streams, data->id, stream)) {
+  if(!Curl_hash_offt_set(&ctx->streams, data->mid, stream)) {
     h3_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
@@ -229,7 +229,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
   (void)cf;
   if(stream) {
     CURL_TRC_CF(data, cf, "easy handle is done");
-    Curl_hash_offt_remove(&ctx->streams, data->id);
+    Curl_hash_offt_remove(&ctx->streams, data->mid);
   }
 }
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -132,7 +132,7 @@ struct cf_ngtcp2_ctx {
   struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
   struct dynbuf scratch;             /* temp buffer for header construction */
-  struct Curl_hash streams;          /* hash `data->id` to `h3_stream_ctx` */
+  struct Curl_hash streams;          /* hash `data->mid` to `h3_stream_ctx` */
   size_t max_stream_window;          /* max flow window for one stream */
   uint64_t max_idle_ms;              /* max idle time for QUIC connection */
   uint64_t used_bidi_streams;        /* bidi streams we have opened */
@@ -203,7 +203,7 @@ struct h3_stream_ctx {
 };
 
 #define H3_STREAM_CTX(ctx,data)   ((struct h3_stream_ctx *)(\
-            data? Curl_hash_offt_get(&(ctx)->streams, (data)->id) : NULL))
+            data? Curl_hash_offt_get(&(ctx)->streams, (data)->mid) : NULL))
 #define H3_STREAM_CTX_ID(ctx,id)  ((struct h3_stream_ctx *)(\
             Curl_hash_offt_get(&(ctx)->streams, (id))))
 
@@ -245,7 +245,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   stream->sendbuf_len_in_flight = 0;
   Curl_h1_req_parse_init(&stream->h1, H1_PARSE_DEFAULT_MAX_LINE_LEN);
 
-  if(!Curl_hash_offt_set(&ctx->streams, data->id, stream)) {
+  if(!Curl_hash_offt_set(&ctx->streams, data->mid, stream)) {
     h3_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
@@ -284,7 +284,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
     CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] easy handle is done",
                 stream->id);
     cf_ngtcp2_stream_close(cf, data, stream);
-    Curl_hash_offt_remove(&ctx->streams, data->id);
+    Curl_hash_offt_remove(&ctx->streams, data->mid);
   }
 }
 

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -290,7 +290,7 @@ struct cf_osslq_ctx {
   struct curltime first_byte_at;     /* when first byte was recvd */
   struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
-  struct Curl_hash streams;          /* hash `data->id` to `h3_stream_ctx` */
+  struct Curl_hash streams;          /* hash `data->mid` to `h3_stream_ctx` */
   size_t max_stream_window;          /* max flow window for one stream */
   uint64_t max_idle_ms;              /* max idle time for QUIC connection */
   BIT(initialized);
@@ -589,7 +589,7 @@ struct h3_stream_ctx {
 };
 
 #define H3_STREAM_CTX(ctx,data)   ((struct h3_stream_ctx *)(\
-            data? Curl_hash_offt_get(&(ctx)->streams, (data)->id) : NULL))
+            data? Curl_hash_offt_get(&(ctx)->streams, (data)->mid) : NULL))
 
 static void h3_stream_ctx_free(struct h3_stream_ctx *stream)
 {
@@ -636,7 +636,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   stream->recv_buf_nonflow = 0;
   Curl_h1_req_parse_init(&stream->h1, H1_PARSE_DEFAULT_MAX_LINE_LEN);
 
-  if(!Curl_hash_offt_set(&ctx->streams, data->id, stream)) {
+  if(!Curl_hash_offt_set(&ctx->streams, data->mid, stream)) {
     h3_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
@@ -661,7 +661,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
       stream->closed = TRUE;
     }
 
-    Curl_hash_offt_remove(&ctx->streams, data->id);
+    Curl_hash_offt_remove(&ctx->streams, data->mid);
   }
 }
 

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -98,7 +98,7 @@ struct cf_quiche_ctx {
   struct curltime handshake_at;      /* time connect handshake finished */
   struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
-  struct Curl_hash streams;          /* hash `data->id` to `stream_ctx` */
+  struct Curl_hash streams;          /* hash `data->mid` to `stream_ctx` */
   curl_off_t data_recvd;
   BIT(initialized);
   BIT(goaway);                       /* got GOAWAY from server */
@@ -182,7 +182,7 @@ struct stream_ctx {
 };
 
 #define H3_STREAM_CTX(ctx,data)   ((struct stream_ctx *)(\
-            data? Curl_hash_offt_get(&(ctx)->streams, (data)->id) : NULL))
+            data? Curl_hash_offt_get(&(ctx)->streams, (data)->mid) : NULL))
 
 static void h3_stream_ctx_free(struct stream_ctx *stream)
 {
@@ -235,7 +235,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
                   H3_STREAM_RECV_CHUNKS, BUFQ_OPT_SOFT_LIMIT);
   Curl_h1_req_parse_init(&stream->h1, H1_PARSE_DEFAULT_MAX_LINE_LEN);
 
-  if(!Curl_hash_offt_set(&ctx->streams, data->id, stream)) {
+  if(!Curl_hash_offt_set(&ctx->streams, data->mid, stream)) {
     h3_stream_ctx_free(stream);
     return CURLE_OUT_OF_MEMORY;
   }
@@ -265,7 +265,7 @@ static void h3_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
       if(result)
         CURL_TRC_CF(data, cf, "data_done, flush egress -> %d", result);
     }
-    Curl_hash_offt_remove(&ctx->streams, data->id);
+    Curl_hash_offt_remove(&ctx->streams, data->mid);
   }
 }
 


### PR DESCRIPTION
`data->id` is unique in *most* situations, but not in all. If a libcurl application uses more than one connection cache, they will overlap. This is an uncommon situation, but some libcurl apps may do crazy things.
For informative purposed, like tracing, `data->id` is good. It assigns new ids in curl's serial curl_easy_perform() use, for example.

Introduce `data->mid` which is a unique identifier inside one multi instance, assigned on multi_add_handle() and cleared on multi_remove_handle(). For tracing, this is not the best, as curl_easy_perform() will give every transfer the multi id 0. However, when associating data *inside the same multi* with a transfer, it gives a unique id for lookups.

Use the `mid` in DoH operations to track relationships between a transfer and its DoH handles. Also, use `mid` to track  h2/h3 streams for transfers.