### PR TITLE
urldata: remove 'scratch' from the UrlState struct

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -266,7 +266,6 @@ CURLcode Curl_close(struct Curl_easy **datap)
   /* Close down all open SSL info and sessions */
   Curl_ssl_close_all(data);
   Curl_safefree(data->state.first_host);
-  Curl_safefree(data->state.scratch);
   Curl_ssl_free_certinfo(data);
 
   if(data->state.referer_alloc) {

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1238,7 +1238,6 @@ struct UrlState {
   struct Curl_ssl_session *session; /* array of 'max_ssl_sessions' size */
   long sessionage;                  /* number of the most recent session */
   int os_errno;  /* filled in with errno whenever an error occurs */
-  char *scratch; /* huge buffer[set.buffer_size*2] for upload CRLF replacing */
   long followlocation; /* redirect counter */
   int requests; /* request counter: redirects + authentication retakes */
 #ifdef HAVE_SIGNAL


### PR DESCRIPTION
It is not used anywhere anymore