### PR TITLE
test httpd, tweak cipher list

### DIFF
--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -291,7 +291,7 @@ class TestProxy:
         x2_args = r1.args[1:]
         x2_args.append('--next')
         x2_args.extend(proxy_args)
-        x2_args.extend(['--proxy-tls13-ciphers', 'TLS_AES_128_GCM_SHA256'])
+        x2_args.extend(['--proxy-tls13-ciphers', 'TLS_AES_256_GCM_SHA384'])
         r2 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
                                extra_args=x2_args)
         r2.check_response(count=2, http_status=200)
@@ -317,7 +317,7 @@ class TestProxy:
         x2_args = r1.args[1:]
         x2_args.append('--next')
         x2_args.extend(proxy_args)
-        x2_args.extend(['--proxy-tls13-ciphers', 'TLS_AES_128_GCM_SHA256'])
+        x2_args.extend(['--proxy-tls13-ciphers', 'TLS_AES_256_GCM_SHA384'])
         r2 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
                                extra_args=x2_args)
         r2.check_response(count=2, http_status=200)
@@ -343,7 +343,7 @@ class TestProxy:
         x2_args = r1.args[1:]
         x2_args.append('--next')
         x2_args.extend(proxy_args)
-        x2_args.extend(['--tls13-ciphers', 'TLS_AES_128_GCM_SHA256'])
+        x2_args.extend(['--tls13-ciphers', 'TLS_AES_256_GCM_SHA384'])
         r2 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
                                extra_args=x2_args)
         r2.check_response(count=2, http_status=200)

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -173,10 +173,10 @@ class TestSSLUse:
         if proto != 'h3':  # we proxy h3
             assert r.json['SSL_TLS_SNI'] == domain, f'{r.json}'
 
-    # test setting cipher suites, the AES 256 ciphers are disabled in the test server
+    # test setting cipher suites, the AES 128 ciphers are disabled in the test server
     @pytest.mark.parametrize("ciphers, succeed", [
-        [[0x1301], True],
-        [[0x1302], False],
+        [[0x1301], False],
+        [[0x1302], True],
         [[0x1303], True],
         [[0x1302, 0x1303], True],
         [[0xC02B, 0xC02F], True],

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -44,7 +44,13 @@ class TestSSLUse:
     def _class_scope(self, env, httpd, nghttpx):
         if env.have_h3():
             nghttpx.start_if_needed()
-        httpd.clear_extra_configs()
+        httpd.set_extra_config('base', [
+            f'SSLCipherSuite SSL'\
+            f' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256'\
+            f':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
+            f'SSLCipherSuite TLSv1.3'\
+            f' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
+        ])
         httpd.reload()
 
     def test_17_01_sslinfo_plain(self, env: Env, httpd, nghttpx, repeat):
@@ -173,10 +179,10 @@ class TestSSLUse:
         if proto != 'h3':  # we proxy h3
             assert r.json['SSL_TLS_SNI'] == domain, f'{r.json}'
 
-    # test setting cipher suites, the AES 128 ciphers are disabled in the test server
+    # test setting cipher suites, the AES 256 ciphers are disabled in the test server
     @pytest.mark.parametrize("ciphers, succeed", [
-        [[0x1301], False],
-        [[0x1302], True],
+        [[0x1301], True],
+        [[0x1302], False],
         [[0x1303], True],
         [[0x1302, 0x1303], True],
         [[0xC02B, 0xC02F], True],

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -257,13 +257,6 @@ class Httpd:
                 f'Listen {self.env.proxys_port}',
                 f'TypesConfig "{self._conf_dir}/mime.types',
                 f'SSLSessionCache "shmcb:ssl_gcache_data(32000)"',
-                (f'SSLCipherSuite SSL'
-                 f' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256'
-                 f':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305'
-                ),
-                (f'SSLCipherSuite TLSv1.3'
-                 f' TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'
-                ),
             ]
             if 'base' in self._extra_configs:
                 conf.extend(self._extra_configs['base'])

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -262,7 +262,7 @@ class Httpd:
                  f':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305'
                 ),
                 (f'SSLCipherSuite TLSv1.3'
-                 f' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256'
+                 f' TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256'
                 ),
             ]
             if 'base' in self._extra_configs:


### PR DESCRIPTION
Configure the AES 256 instead of the AES 128 cipher in the test httpd to make scorecard testing between httpd and caddy more comparable.

Adapt test_17 expectations, now that AES 128 can no longer, but 256 can now be negotiated.