### PR TITLE
http2 and all h3 filters, fix ctx init

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -172,7 +172,7 @@ static void cf_h2_ctx_init(struct cf_h2_ctx *ctx, bool via_h1_upgrade)
 
 static void cf_h2_ctx_free(struct cf_h2_ctx *ctx)
 {
-  if(ctx->initialized) {
+  if(ctx && ctx->initialized) {
     Curl_bufq_free(&ctx->inbufq);
     Curl_bufq_free(&ctx->outbufq);
     Curl_bufcp_free(&ctx->stream_bufcp);

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -142,6 +142,8 @@ struct cf_h2_ctx {
   uint32_t goaway_error;        /* goaway error code from server */
   int32_t remote_max_sid;       /* max id processed by server */
   int32_t local_max_sid;        /* max id processed by us */
+  BIT(initialized);
+  BIT(via_h1_upgrade);
   BIT(conn_closed);
   BIT(rcvd_goaway);
   BIT(sent_goaway);
@@ -154,21 +156,37 @@ struct cf_h2_ctx {
 #define CF_CTX_CALL_DATA(cf)  \
   ((struct cf_h2_ctx *)(cf)->ctx)->call_data
 
+static void h2_stream_hash_free(void *stream);
+
+static void cf_h2_ctx_init(struct cf_h2_ctx *ctx, bool via_h1_upgrade)
+{
+  Curl_bufcp_init(&ctx->stream_bufcp, H2_CHUNK_SIZE, H2_STREAM_POOL_SPARES);
+  Curl_bufq_initp(&ctx->inbufq, &ctx->stream_bufcp, H2_NW_RECV_CHUNKS, 0);
+  Curl_bufq_initp(&ctx->outbufq, &ctx->stream_bufcp, H2_NW_SEND_CHUNKS, 0);
+  Curl_dyn_init(&ctx->scratch, CURL_MAX_HTTP_HEADER);
+  Curl_hash_offt_init(&ctx->streams, 63, h2_stream_hash_free);
+  ctx->remote_max_sid = 2147483647;
+  ctx->via_h1_upgrade = via_h1_upgrade;
+  ctx->initialized = TRUE;
+}
+
 static void cf_h2_ctx_clear(struct cf_h2_ctx *ctx)
 {
-  struct cf_call_data save = ctx->call_data;
-
   if(ctx->h2) {
     nghttp2_session_del(ctx->h2);
   }
-  Curl_bufq_free(&ctx->inbufq);
-  Curl_bufq_free(&ctx->outbufq);
-  Curl_bufcp_free(&ctx->stream_bufcp);
-  Curl_dyn_free(&ctx->scratch);
-  Curl_hash_clean(&ctx->streams);
-  Curl_hash_destroy(&ctx->streams);
-  memset(ctx, 0, sizeof(*ctx));
-  ctx->call_data = save;
+  if(ctx->initialized) {
+    struct cf_call_data save = ctx->call_data;
+
+    Curl_bufq_free(&ctx->inbufq);
+    Curl_bufq_free(&ctx->outbufq);
+    Curl_bufcp_free(&ctx->stream_bufcp);
+    Curl_dyn_free(&ctx->scratch);
+    Curl_hash_clean(&ctx->streams);
+    Curl_hash_destroy(&ctx->streams);
+    memset(ctx, 0, sizeof(*ctx));
+    ctx->call_data = save;
+  }
 }
 
 static void cf_h2_ctx_free(struct cf_h2_ctx *ctx)
@@ -390,7 +408,7 @@ static void http2_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
   struct h2_stream_ctx *stream = H2_STREAM_CTX(ctx, data);
 
   DEBUGASSERT(ctx);
-  if(!stream)
+  if(!stream || !ctx->initialized)
     return;
 
   if(ctx->h2) {
@@ -489,12 +507,8 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
 static int error_callback(nghttp2_session *session, const char *msg,
                           size_t len, void *userp);
 
-/*
- * Initialize the cfilter context
- */
-static CURLcode cf_h2_ctx_init(struct Curl_cfilter *cf,
-                               struct Curl_easy *data,
-                               bool via_h1_upgrade)
+static CURLcode cf_h2_ctx_open(struct Curl_cfilter *cf,
+                               struct Curl_easy *data)
 {
   struct cf_h2_ctx *ctx = cf->ctx;
   struct h2_stream_ctx *stream;
@@ -503,12 +517,7 @@ static CURLcode cf_h2_ctx_init(struct Curl_cfilter *cf,
   nghttp2_session_callbacks *cbs = NULL;
 
   DEBUGASSERT(!ctx->h2);
-  Curl_bufcp_init(&ctx->stream_bufcp, H2_CHUNK_SIZE, H2_STREAM_POOL_SPARES);
-  Curl_bufq_initp(&ctx->inbufq, &ctx->stream_bufcp, H2_NW_RECV_CHUNKS, 0);
-  Curl_bufq_initp(&ctx->outbufq, &ctx->stream_bufcp, H2_NW_SEND_CHUNKS, 0);
-  Curl_dyn_init(&ctx->scratch, CURL_MAX_HTTP_HEADER);
-  Curl_hash_offt_init(&ctx->streams, 63, h2_stream_hash_free);
-  ctx->remote_max_sid = 2147483647;
+  DEBUGASSERT(ctx->initialized);
 
   rc = nghttp2_session_callbacks_new(&cbs);
   if(rc) {
@@ -537,7 +546,7 @@ static CURLcode cf_h2_ctx_init(struct Curl_cfilter *cf,
   }
   ctx->max_concurrent_streams = DEFAULT_MAX_CONCURRENT_STREAMS;
 
-  if(via_h1_upgrade) {
+  if(ctx->via_h1_upgrade) {
     /* HTTP/1.1 Upgrade issued. H2 Settings have already been submitted
      * in the H1 request and we upgrade from there. This stream
      * is opened implicitly as #1. */
@@ -603,7 +612,7 @@ static CURLcode cf_h2_ctx_init(struct Curl_cfilter *cf,
   /* all set, traffic will be send on connect */
   result = CURLE_OK;
   CURL_TRC_CF(data, cf, "[0] created h2 session%s",
-              via_h1_upgrade? " (via h1 upgrade)" : "");
+              ctx->via_h1_upgrade? " (via h1 upgrade)" : "");
 
 out:
   if(cbs)
@@ -2450,8 +2459,9 @@ static CURLcode cf_h2_connect(struct Curl_cfilter *cf,
   *done = FALSE;
 
   CF_DATA_SAVE(save, cf, data);
+  DEBUGASSERT(ctx->initialized);
   if(!ctx->h2) {
-    result = cf_h2_ctx_init(cf, data, FALSE);
+    result = cf_h2_ctx_open(cf, data);
     if(result)
       goto out;
   }
@@ -2735,6 +2745,7 @@ static CURLcode http2_cfilter_add(struct Curl_cfilter **pcf,
   ctx = calloc(1, sizeof(*ctx));
   if(!ctx)
     goto out;
+  cf_h2_ctx_init(ctx, via_h1_upgrade);
 
   result = Curl_cf_create(&cf, &Curl_cft_nghttp2, ctx);
   if(result)
@@ -2742,7 +2753,6 @@ static CURLcode http2_cfilter_add(struct Curl_cfilter **pcf,
 
   ctx = NULL;
   Curl_conn_cf_add(data, conn, sockindex, cf);
-  result = cf_h2_ctx_init(cf, data, via_h1_upgrade);
 
 out:
   if(result)
@@ -2763,6 +2773,7 @@ static CURLcode http2_cfilter_insert_after(struct Curl_cfilter *cf,
   ctx = calloc(1, sizeof(*ctx));
   if(!ctx)
     goto out;
+  cf_h2_ctx_init(ctx, via_h1_upgrade);
 
   result = Curl_cf_create(&cf_h2, &Curl_cft_nghttp2, ctx);
   if(result)
@@ -2770,7 +2781,6 @@ static CURLcode http2_cfilter_insert_after(struct Curl_cfilter *cf,
 
   ctx = NULL;
   Curl_conn_cf_insert_after(cf, cf_h2);
-  result = cf_h2_ctx_init(cf_h2, data, via_h1_upgrade);
 
 out:
   if(result)

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -145,7 +145,7 @@ static void cf_msh3_ctx_init(struct cf_msh3_ctx *ctx,
 
 static void cf_msh3_ctx_free(struct cf_msh3_ctx *ctx)
 {
-  if(ctx->initialized) {
+  if(ctx && ctx->initialized) {
     Curl_hash_destroy(&ctx->streams);
   }
   free(ctx);

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -124,10 +124,32 @@ struct cf_msh3_ctx {
   bool handshake_complete;
   bool handshake_succeeded;
   bool connected;
+  BIT(initialized);
   /* Flags written by curl thread */
   BIT(verbose);
   BIT(active);
 };
+
+static void h3_stream_hash_free(void *stream);
+
+static void cf_msh3_ctx_init(struct cf_msh3_ctx *ctx,
+                             const struct Curl_addrinfo *ai)
+{
+  DEBUGASSERT(!ctx->initialized);
+  Curl_hash_offt_init(&ctx->streams, 63, h3_stream_hash_free);
+  Curl_sock_assign_addr(&ctx->addr, ai, TRNSPRT_QUIC);
+  ctx->sock[SP_LOCAL] = CURL_SOCKET_BAD;
+  ctx->sock[SP_REMOTE] = CURL_SOCKET_BAD;
+  ctx->initialized = TRUE;
+}
+
+static void cf_msh3_ctx_clear(struct cf_msh3_ctx *ctx)
+{
+  if(ctx->initialized) {
+    Curl_hash_destroy(&ctx->streams);
+    memset(ctx, 0, sizeof(*ctx));
+  }
+}
 
 static struct cf_msh3_ctx *h3_get_msh3_ctx(struct Curl_easy *data);
 
@@ -798,7 +820,7 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
   CURLcode result;
   bool verify;
 
-  Curl_hash_offt_init(&ctx->streams, 63, h3_stream_hash_free);
+  DEBUGASSERT(ctx->initialized);
   conn_config = Curl_ssl_cf_get_primary_config(cf);
   if(!conn_config)
     return CURLE_FAILED_INIT;
@@ -925,7 +947,6 @@ static void cf_msh3_close(struct Curl_cfilter *cf, struct Curl_easy *data)
       MsH3ApiClose(ctx->api);
       ctx->api = NULL;
     }
-    Curl_hash_destroy(&ctx->streams);
 
     if(ctx->active) {
       /* We share our socket at cf->conn->sock[cf->sockindex] when active.
@@ -964,6 +985,7 @@ static void cf_msh3_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   CF_DATA_SAVE(save, cf, data);
   cf_msh3_close(cf, data);
+  cf_msh3_ctx_clear(cf->ctx);
   free(cf->ctx);
   cf->ctx = NULL;
   /* no CF_DATA_RESTORE(cf, save); its gone */
@@ -1066,9 +1088,7 @@ CURLcode Curl_cf_msh3_create(struct Curl_cfilter **pcf,
     result = CURLE_OUT_OF_MEMORY;
     goto out;
   }
-  Curl_sock_assign_addr(&ctx->addr, ai, TRNSPRT_QUIC);
-  ctx->sock[SP_LOCAL] = CURL_SOCKET_BAD;
-  ctx->sock[SP_REMOTE] = CURL_SOCKET_BAD;
+  cf_msh3_ctx_init(ctx, ai);
 
   result = Curl_cf_create(&cf, &Curl_cft_http3, ctx);
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -165,7 +165,7 @@ static void cf_ngtcp2_ctx_init(struct cf_ngtcp2_ctx *ctx)
 
 static void cf_ngtcp2_ctx_free(struct cf_ngtcp2_ctx *ctx)
 {
-  if(ctx->initialized) {
+  if(ctx && ctx->initialized) {
     Curl_bufcp_free(&ctx->stream_bufcp);
     Curl_dyn_free(&ctx->scratch);
     Curl_hash_clean(&ctx->streams);

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -147,6 +147,34 @@ struct cf_ngtcp2_ctx {
 #define CF_CTX_CALL_DATA(cf)  \
   ((struct cf_ngtcp2_ctx *)(cf)->ctx)->call_data
 
+static void h3_stream_hash_free(void *stream);
+
+static void cf_ngtcp2_ctx_init(struct cf_ngtcp2_ctx *ctx)
+{
+  DEBUGASSERT(!ctx->initialized);
+  ctx->qlogfd = -1;
+  ctx->version = NGTCP2_PROTO_VER_MAX;
+  ctx->max_stream_window = H3_STREAM_WINDOW_SIZE;
+  ctx->max_idle_ms = CURL_QUIC_MAX_IDLE_MS;
+  Curl_bufcp_init(&ctx->stream_bufcp, H3_STREAM_CHUNK_SIZE,
+                  H3_STREAM_POOL_SPARES);
+  Curl_dyn_init(&ctx->scratch, CURL_MAX_HTTP_HEADER);
+  Curl_hash_offt_init(&ctx->streams, 63, h3_stream_hash_free);
+  ctx->initialized = TRUE;
+}
+
+static void cf_ngtcp2_ctx_free(struct cf_ngtcp2_ctx *ctx)
+{
+  if(ctx->initialized) {
+    Curl_bufcp_free(&ctx->stream_bufcp);
+    Curl_dyn_free(&ctx->scratch);
+    Curl_hash_clean(&ctx->streams);
+    Curl_hash_destroy(&ctx->streams);
+    Curl_ssl_peer_cleanup(&ctx->peer);
+  }
+  free(ctx);
+}
+
 struct pkt_io_ctx;
 static CURLcode cf_progress_ingress(struct Curl_cfilter *cf,
                                     struct Curl_easy *data,
@@ -1964,21 +1992,7 @@ static CURLcode cf_ngtcp2_data_event(struct Curl_cfilter *cf,
   return result;
 }
 
-static void cf_ngtcp2_ctx_init(struct cf_ngtcp2_ctx *ctx)
-{
-  DEBUGASSERT(!ctx->initialized);
-  ctx->qlogfd = -1;
-  ctx->version = NGTCP2_PROTO_VER_MAX;
-  ctx->max_stream_window = H3_STREAM_WINDOW_SIZE;
-  ctx->max_idle_ms = CURL_QUIC_MAX_IDLE_MS;
-  Curl_bufcp_init(&ctx->stream_bufcp, H3_STREAM_CHUNK_SIZE,
-                  H3_STREAM_POOL_SPARES);
-  Curl_dyn_init(&ctx->scratch, CURL_MAX_HTTP_HEADER);
-  Curl_hash_offt_init(&ctx->streams, 63, h3_stream_hash_free);
-  ctx->initialized = TRUE;
-}
-
-static void cf_ngtcp2_ctx_clear(struct cf_ngtcp2_ctx *ctx)
+static void cf_ngtcp2_ctx_close(struct cf_ngtcp2_ctx *ctx)
 {
   struct cf_call_data save = ctx->call_data;
 
@@ -1987,20 +2001,13 @@ static void cf_ngtcp2_ctx_clear(struct cf_ngtcp2_ctx *ctx)
   if(ctx->qlogfd != -1) {
     close(ctx->qlogfd);
   }
+  ctx->qlogfd = -1;
   Curl_vquic_tls_cleanup(&ctx->tls);
   vquic_ctx_free(&ctx->q);
   if(ctx->h3conn)
     nghttp3_conn_del(ctx->h3conn);
   if(ctx->qconn)
     ngtcp2_conn_del(ctx->qconn);
-  Curl_bufcp_free(&ctx->stream_bufcp);
-  Curl_dyn_free(&ctx->scratch);
-  Curl_hash_clean(&ctx->streams);
-  Curl_hash_destroy(&ctx->streams);
-  Curl_ssl_peer_cleanup(&ctx->peer);
-
-  memset(ctx, 0, sizeof(*ctx));
-  ctx->qlogfd = -1;
   ctx->call_data = save;
 }
 
@@ -2105,7 +2112,7 @@ static void cf_ngtcp2_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   CF_DATA_SAVE(save, cf, data);
   if(ctx && ctx->qconn) {
     cf_ngtcp2_conn_close(cf, data);
-    cf_ngtcp2_ctx_clear(ctx);
+    cf_ngtcp2_ctx_close(ctx);
     CURL_TRC_CF(data, cf, "close");
   }
   cf->connected = FALSE;
@@ -2114,18 +2121,11 @@ static void cf_ngtcp2_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
 static void cf_ngtcp2_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
 {
-  struct cf_ngtcp2_ctx *ctx = cf->ctx;
-  struct cf_call_data save;
-
-  CF_DATA_SAVE(save, cf, data);
   CURL_TRC_CF(data, cf, "destroy");
-  if(ctx) {
-    cf_ngtcp2_ctx_clear(ctx);
-    free(ctx);
+  if(cf->ctx) {
+    cf_ngtcp2_ctx_free(cf->ctx);
+    cf->ctx = NULL;
   }
-  cf->ctx = NULL;
-  /* No CF_DATA_RESTORE(cf, save) possible */
-  (void)save;
 }
 
 #ifdef USE_OPENSSL
@@ -2543,7 +2543,7 @@ out:
     if(udp_cf)
       Curl_conn_cf_discard_sub(cf, udp_cf, data, TRUE);
     Curl_safefree(cf);
-    Curl_safefree(ctx);
+    cf_ngtcp2_ctx_free(ctx);
   }
   return result;
 }

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -136,7 +136,7 @@ static void cf_quiche_ctx_init(struct cf_quiche_ctx *ctx)
 
 static void cf_quiche_ctx_free(struct cf_quiche_ctx *ctx)
 {
-  if(ctx->initialized) {
+  if(ctx && ctx->initialized) {
     /* quiche just freed it */
     ctx->tls.ossl.ssl = NULL;
     Curl_vquic_tls_cleanup(&ctx->tls);


### PR DESCRIPTION
Members of the filter context, like stream hash and buffers, need to be initialized early and protected by a flag to also avoid double cleanup.

This allow the context to be used safely before a connect() is started and the other parts of the context are set up.