### PR TITLE
lib: avoid macro collisions between wolfSSL and GnuTLS headers

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -715,6 +715,11 @@
 #define USE_SSL    /* SSL support has been enabled */
 #endif
 
+#if defined(USE_WOLFSSL) && defined(USE_GNUTLS)
+/* Avoid defining unprefixed wolfSSL SHA macros colliding with nettle ones */
+#define NO_OLD_WC_NAMES
+#endif
+
 /* Single point where USE_SPNEGO definition might be defined */
 #if !defined(CURL_DISABLE_NEGOTIATE_AUTH) && \
     (defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI))


### PR DESCRIPTION
Both of these projects define the same `SHA*` macros via headers
included by curl (in MultiSSL builds, possibly only in Unity builds),
causing redefinition compiler warnings.

Fix it by disabling compatibility macros in wolfSSL.

```
Building C object lib/CMakeFiles/libcurl_static.dir/Unity/unity_0_c.c.o
In file included from _bld/lib/CMakeFiles/libcurl_static.dir/Unity/unity_0_c.c:202:
In file included from lib/http_aws_sigv4.c:33:
In file included from lib/curl_sha256.h:40:
In file included from /usr/local/Cellar/wolfssl/5.7.2/include/wolfssl/openssl/sha.h:30:
/usr/local/Cellar/wolfssl/5.7.2/include/wolfssl/wolfcrypt/sha256.h:117:13: warning: 'SHA256_BLOCK_SIZE' macro redefined [-Wmacro-redefined]
    #define SHA256_BLOCK_SIZE  WC_SHA256_BLOCK_SIZE
            ^
/usr/local/Cellar/nettle/3.10/include/nettle/sha2.h:70:9: note: previous definition is here
#define SHA256_BLOCK_SIZE 64
        ^
In file included from _bld/lib/CMakeFiles/libcurl_static.dir/Unity/unity_0_c.c:202:
In file included from lib/http_aws_sigv4.c:33:
In file included from lib/curl_sha256.h:40:
In file included from /usr/local/Cellar/wolfssl/5.7.2/include/wolfssl/openssl/sha.h:30:
[...]
    #define SHA256_DIGEST_SIZE WC_SHA256_DIGEST_SIZE
    #define SHA224_BLOCK_SIZE  WC_SHA224_BLOCK_SIZE
    #define SHA224_DIGEST_SIZE WC_SHA224_DIGEST_SIZE
    #define SHA512_BLOCK_SIZE  WC_SHA512_BLOCK_SIZE
    #define SHA512_DIGEST_SIZE WC_SHA512_DIGEST_SIZE
    #define SHA384_BLOCK_SIZE  WC_SHA384_BLOCK_SIZE
    #define SHA384_DIGEST_SIZE WC_SHA384_DIGEST_SIZE
```

Cherry-picked from #14495
Closes #14511
