### PR TITLE
lib: fix building with wolfSSL without DES support

### DIFF
--- a/lib/curl_des.c
+++ b/lib/curl_des.c
@@ -24,10 +24,10 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_CURL_NTLM_CORE) && !defined(USE_WOLFSSL) &&     \
-  (defined(USE_GNUTLS) ||                                       \
-   defined(USE_SECTRANSP) ||                                    \
-   defined(USE_OS400CRYPTO) ||                                  \
+#if defined(USE_CURL_NTLM_CORE) && \
+  (defined(USE_GNUTLS) ||          \
+   defined(USE_SECTRANSP) ||       \
+   defined(USE_OS400CRYPTO) ||     \
    defined(USE_WIN32_CRYPTO))
 
 #include "curl_des.h"

--- a/lib/curl_des.h
+++ b/lib/curl_des.h
@@ -26,10 +26,10 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_CURL_NTLM_CORE) && !defined(USE_WOLFSSL) &&     \
-  (defined(USE_GNUTLS) ||                                       \
-   defined(USE_SECTRANSP) ||                                    \
-   defined(USE_OS400CRYPTO) ||                                  \
+#if defined(USE_CURL_NTLM_CORE) && \
+  (defined(USE_GNUTLS) ||          \
+   defined(USE_SECTRANSP) ||       \
+   defined(USE_OS400CRYPTO) ||     \
    defined(USE_WIN32_CRYPTO))
 
 /* Applies odd parity to the given byte array */

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -57,9 +57,14 @@
   #if !defined(OPENSSL_NO_DES) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     #define USE_OPENSSL_DES
   #endif
+#elif defined(USE_WOLFSSL)
+  #include <wolfssl/options.h>
+  #if !defined(NO_DES3)
+    #define USE_OPENSSL_DES
+  #endif
 #endif
 
-#if defined(USE_OPENSSL_DES) || defined(USE_WOLFSSL)
+#if defined(USE_OPENSSL_DES)
 
 #if defined(USE_OPENSSL)
 #  include <openssl/des.h>
@@ -67,7 +72,6 @@
 #  include <openssl/ssl.h>
 #  include <openssl/rand.h>
 #else
-#  include <wolfssl/options.h>
 #  include <wolfssl/openssl/des.h>
 #  include <wolfssl/openssl/md5.h>
 #  include <wolfssl/openssl/ssl.h>
@@ -148,7 +152,7 @@ static void extend_key_56_to_64(const unsigned char *key_56, char *key)
 }
 #endif
 
-#if defined(USE_OPENSSL_DES) || defined(USE_WOLFSSL)
+#if defined(USE_OPENSSL_DES)
 /*
  * Turns a 56-bit key into a 64-bit, odd parity key and sets the key. The
  * key schedule ks is also set.
@@ -313,7 +317,7 @@ void Curl_ntlm_core_lm_resp(const unsigned char *keys,
                             const unsigned char *plaintext,
                             unsigned char *results)
 {
-#if defined(USE_OPENSSL_DES) || defined(USE_WOLFSSL)
+#if defined(USE_OPENSSL_DES)
   DES_key_schedule ks;
 
   setup_des_key(keys, DESKEY(ks));
@@ -367,7 +371,7 @@ CURLcode Curl_ntlm_core_mk_lm_hash(const char *password,
   {
     /* Create LanManager hashed password. */
 
-#if defined(USE_OPENSSL_DES) || defined(USE_WOLFSSL)
+#if defined(USE_OPENSSL_DES)
     DES_key_schedule ks;
 
     setup_des_key(pw, DESKEY(ks));


### PR DESCRIPTION
E.g. with Homebrew wolfssl 5.7.2 on macOS:
```
In file included from _bld/lib/CMakeFiles/libcurl_static.dir/Unity/unity_0_c.c:85:
lib/curl_ntlm_core.c:157:27: error: unknown type name 'DES_key_schedule'
                          DES_key_schedule DESKEYARG(ks))
                          ^
lib/curl_ntlm_core.c:159:3: error: use of undeclared identifier 'DES_cblock'
  DES_cblock key;
  ^
[...]
```

Earlier patch addressing this for OpenSSL:
802d8644500f5b18c895b77a23d85e029766d65e #7808

Cherry-picked from #14495
Closes #14512
