### PR TITLE
lib: prefer `CURL_SHA256_DIGEST_LENGTH` over the unprefixed name

### DIFF
--- a/lib/curl_sha256.h
+++ b/lib/curl_sha256.h
@@ -33,13 +33,8 @@
 
 extern const struct HMAC_params Curl_HMAC_SHA256[1];
 
-#ifdef USE_WOLFSSL
-/* SHA256_DIGEST_LENGTH is an enum value in wolfSSL. Need to import it from
- * sha.h */
-#include <wolfssl/options.h>
-#include <wolfssl/openssl/sha.h>
-#else
-#define SHA256_DIGEST_LENGTH 32
+#ifndef CURL_SHA256_DIGEST_LENGTH
+#define CURL_SHA256_DIGEST_LENGTH 32 /* fixed size */
 #endif
 
 CURLcode Curl_sha256it(unsigned char *outbuffer, const unsigned char *input,

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -60,11 +60,11 @@
 #define TIMESTAMP_SIZE 17
 
 /* hex-encoded with trailing null */
-#define SHA256_HEX_LENGTH (2 * SHA256_DIGEST_LENGTH + 1)
+#define SHA256_HEX_LENGTH (2 * CURL_SHA256_DIGEST_LENGTH + 1)
 
 static void sha256_to_hex(char *dst, unsigned char *sha)
 {
-  Curl_hexencode(sha, SHA256_DIGEST_LENGTH,
+  Curl_hexencode(sha, CURL_SHA256_DIGEST_LENGTH,
                  (unsigned char *)dst, SHA256_HEX_LENGTH);
 }
 
@@ -604,7 +604,7 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
   const char *method = NULL;
   char *payload_hash = NULL;
   size_t payload_hash_len = 0;
-  unsigned char sha_hash[SHA256_DIGEST_LENGTH];
+  unsigned char sha_hash[CURL_SHA256_DIGEST_LENGTH];
   char sha_hex[SHA256_HEX_LENGTH];
   char content_sha256_hdr[CONTENT_SHA256_HDR_LEN + 2] = ""; /* add \r\n */
   char *canonical_request = NULL;
@@ -613,8 +613,8 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
   char *str_to_sign = NULL;
   const char *user = data->state.aptr.user ? data->state.aptr.user : "";
   char *secret = NULL;
-  unsigned char sign0[SHA256_DIGEST_LENGTH] = {0};
-  unsigned char sign1[SHA256_DIGEST_LENGTH] = {0};
+  unsigned char sign0[CURL_SHA256_DIGEST_LENGTH] = {0};
+  unsigned char sign1[CURL_SHA256_DIGEST_LENGTH] = {0};
   char *auth_headers = NULL;
 
   DEBUGASSERT(!proxy);

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -247,7 +247,7 @@ static void my_sha256_final(unsigned char *digest, my_sha256_ctx *ctx)
   unsigned long length = 0;
 
   CryptGetHashParam(ctx->hHash, HP_HASHVAL, NULL, &length, 0);
-  if(length == SHA256_DIGEST_LENGTH)
+  if(length == CURL_SHA256_DIGEST_LENGTH)
     CryptGetHashParam(ctx->hHash, HP_HASHVAL, digest, &length, 0);
 
   if(ctx->hHash)

--- a/tests/unit/unit1610.c
+++ b/tests/unit/unit1610.c
@@ -44,7 +44,7 @@ UNITTEST_START
 
   const char string1[] = "1";
   const char string2[] = "hello-you-fool";
-  unsigned char output[SHA256_DIGEST_LENGTH];
+  unsigned char output[CURL_SHA256_DIGEST_LENGTH];
   unsigned char *testp = output;
 
   Curl_sha256it(output, (const unsigned char *) string1, strlen(string1));
@@ -52,14 +52,14 @@ UNITTEST_START
   verify_memory(testp,
                 "\x6b\x86\xb2\x73\xff\x34\xfc\xe1\x9d\x6b\x80\x4e\xff\x5a\x3f"
                 "\x57\x47\xad\xa4\xea\xa2\x2f\x1d\x49\xc0\x1e\x52\xdd\xb7\x87"
-                "\x5b\x4b", SHA256_DIGEST_LENGTH);
+                "\x5b\x4b", CURL_SHA256_DIGEST_LENGTH);
 
   Curl_sha256it(output, (const unsigned char *) string2, strlen(string2));
 
   verify_memory(testp,
                 "\xcb\xb1\x6a\x8a\xb9\xcb\xb9\x35\xa8\xcb\xa0\x2e\x28\xc0\x26"
                 "\x30\xd1\x19\x9c\x1f\x02\x17\xf4\x7c\x96\x20\xf3\xef\xe8\x27"
-                "\x15\xae", SHA256_DIGEST_LENGTH);
+                "\x15\xae", CURL_SHA256_DIGEST_LENGTH);
 #endif
 
 


### PR DESCRIPTION
Already used in `vtls.h`. Prefer this curl-namespaced name over the
unprefixed `SHA256_DIGEST_LENGTH`. The latter is also defined by TLS
backends with a potential to cause issues.

Also stop relying on externel headers setting this constant. It's
already defined in `vtls.h` on curl's behalf, do this also for `lib`.

Cherry-picked from #14495
Closes #14513
