### PR TITLE
curl_sha512_256: fix symbol collisions with nettle library

### DIFF
--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -93,13 +93,13 @@
 /**
  * Size of the SHA-512/256 single processing block in bytes.
  */
-#define SHA512_256_BLOCK_SIZE 128
+#define CURL_SHA512_256_BLOCK_SIZE 128
 
 /**
  * Size of the SHA-512/256 resulting digest in bytes.
  * This is the final digest size, not intermediate hash.
  */
-#define SHA512_256_DIGEST_SIZE SHA512_256_DIGEST_LENGTH
+#define CURL_SHA512_256_DIGEST_SIZE CURL_SHA512_256_DIGEST_LENGTH
 
 /**
  * Context type used for SHA-512/256 calculations
@@ -124,9 +124,9 @@ Curl_sha512_256_init(void *context)
 
   if(EVP_DigestInit_ex(*ctx, EVP_sha512_256(), NULL)) {
     /* Check whether the header and this file use the same numbers */
-    DEBUGASSERT(EVP_MD_CTX_size(*ctx) == SHA512_256_DIGEST_SIZE);
+    DEBUGASSERT(EVP_MD_CTX_size(*ctx) == CURL_SHA512_256_DIGEST_SIZE);
     /* Check whether the block size is correct */
-    DEBUGASSERT(EVP_MD_CTX_block_size(*ctx) == SHA512_256_BLOCK_SIZE);
+    DEBUGASSERT(EVP_MD_CTX_block_size(*ctx) == CURL_SHA512_256_BLOCK_SIZE);
 
     return CURLE_OK; /* Success */
   }
@@ -163,7 +163,8 @@ Curl_sha512_256_update(void *context,
  * Finalise SHA-512/256 calculation, return digest.
  *
  * @param context the calculation context
- * @param[out] digest set to the hash, must be #SHA512_256_DIGEST_SIZE bytes
+ * @param[out] digest set to the hash, must be #CURL_SHA512_256_DIGEST_SIZE
+ #             bytes
  * @return CURLE_OK if succeed,
  *         error code otherwise
  */
@@ -177,11 +178,11 @@ Curl_sha512_256_finish(unsigned char *digest,
 #ifdef NEED_NETBSD_SHA512_256_WORKAROUND
   /* Use a larger buffer to work around a bug in NetBSD:
      https://gnats.netbsd.org/cgi-bin/query-pr-single.pl?number=58039 */
-  unsigned char tmp_digest[SHA512_256_DIGEST_SIZE * 2];
+  unsigned char tmp_digest[CURL_SHA512_256_DIGEST_SIZE * 2];
   ret = EVP_DigestFinal_ex(*ctx,
                            tmp_digest, NULL) ? CURLE_OK : CURLE_SSL_CIPHER;
   if(ret == CURLE_OK)
-    memcpy(digest, tmp_digest, SHA512_256_DIGEST_SIZE);
+    memcpy(digest, tmp_digest, CURL_SHA512_256_DIGEST_SIZE);
   explicit_memset(tmp_digest, 0, sizeof(tmp_digest));
 #else  /* ! NEED_NETBSD_SHA512_256_WORKAROUND */
   ret = EVP_DigestFinal_ex(*ctx, digest, NULL) ? CURLE_OK : CURLE_SSL_CIPHER;
@@ -194,6 +195,9 @@ Curl_sha512_256_finish(unsigned char *digest,
 }
 
 #elif defined(USE_GNUTLS_SHA512_256)
+
+#define CURL_SHA512_256_BLOCK_SIZE  SHA512_256_BLOCK_SIZE
+#define CURL_SHA512_256_DIGEST_SIZE SHA512_256_DIGEST_SIZE
 
 /**
  * Context type used for SHA-512/256 calculations
@@ -212,7 +216,7 @@ Curl_sha512_256_init(void *context)
   Curl_sha512_256_ctx *const ctx = (Curl_sha512_256_ctx *)context;
 
   /* Check whether the header and this file use the same numbers */
-  DEBUGASSERT(SHA512_256_DIGEST_LENGTH == SHA512_256_DIGEST_SIZE);
+  DEBUGASSERT(CURL_SHA512_256_DIGEST_LENGTH == CURL_SHA512_256_DIGEST_SIZE);
 
   sha512_256_init(ctx);
 
@@ -247,7 +251,8 @@ Curl_sha512_256_update(void *context,
  * Finalise SHA-512/256 calculation, return digest.
  *
  * @param context the calculation context
- * @param[out] digest set to the hash, must be #SHA512_256_DIGEST_SIZE bytes
+ * @param[out] digest set to the hash, must be #CURL_SHA512_256_DIGEST_SIZE
+ #             bytes
  * @return always CURLE_OK
  */
 static CURLcode
@@ -256,7 +261,8 @@ Curl_sha512_256_finish(unsigned char *digest,
 {
   Curl_sha512_256_ctx *const ctx = (Curl_sha512_256_ctx *)context;
 
-  sha512_256_digest(ctx, (size_t)SHA512_256_DIGEST_SIZE, (uint8_t *)digest);
+  sha512_256_digest(ctx,
+                    (size_t)CURL_SHA512_256_DIGEST_SIZE, (uint8_t *)digest);
 
   return CURLE_OK;
 }
@@ -360,7 +366,7 @@ MHDx_rotr64(curl_uint64_t value, unsigned int bits)
  * Size of the SHA-512/256 resulting digest in bytes
  * This is the final digest size, not intermediate hash.
  */
-#define SHA512_256_DIGEST_SIZE \
+#define CURL_SHA512_256_DIGEST_SIZE \
   (SHA512_256_DIGEST_SIZE_WORDS * SHA512_256_BYTES_IN_WORD)
 
 /**
@@ -371,7 +377,7 @@ MHDx_rotr64(curl_uint64_t value, unsigned int bits)
 /**
  * Size of the SHA-512/256 single processing block in bytes.
  */
-#define SHA512_256_BLOCK_SIZE (SHA512_256_BLOCK_SIZE_BITS / 8)
+#define CURL_SHA512_256_BLOCK_SIZE (SHA512_256_BLOCK_SIZE_BITS / 8)
 
 /**
  * Size of the SHA-512/256 single processing block in words.
@@ -425,7 +431,7 @@ MHDx_sha512_256_init(void *context)
   struct mhdx_sha512_256ctx *const ctx = (struct mhdx_sha512_256ctx *) context;
 
   /* Check whether the header and this file use the same numbers */
-  DEBUGASSERT(SHA512_256_DIGEST_LENGTH == SHA512_256_DIGEST_SIZE);
+  DEBUGASSERT(CURL_SHA512_256_DIGEST_LENGTH == CURL_SHA512_256_DIGEST_SIZE);
 
   DEBUGASSERT(sizeof(curl_uint64_t) == 8);
 
@@ -453,7 +459,7 @@ MHDx_sha512_256_init(void *context)
  * Base of the SHA-512/256 transformation.
  * Gets a full 128 bytes block of data and updates hash values;
  * @param H     hash values
- * @param data  the data buffer with #SHA512_256_BLOCK_SIZE bytes block
+ * @param data  the data buffer with #CURL_SHA512_256_BLOCK_SIZE bytes block
  */
 static void
 MHDx_sha512_256_transform(curl_uint64_t H[SHA512_256_HASH_SIZE_WORDS],
@@ -636,9 +642,9 @@ MHDx_sha512_256_update(void *context,
   if(0 == length)
     return CURLE_OK; /* Shortcut, do nothing */
 
-  /* Note: (count & (SHA512_256_BLOCK_SIZE-1))
-     equals (count % SHA512_256_BLOCK_SIZE) for this block size. */
-  bytes_have = (unsigned int) (ctx->count & (SHA512_256_BLOCK_SIZE - 1));
+  /* Note: (count & (CURL_SHA512_256_BLOCK_SIZE-1))
+     equals (count % CURL_SHA512_256_BLOCK_SIZE) for this block size. */
+  bytes_have = (unsigned int) (ctx->count & (CURL_SHA512_256_BLOCK_SIZE - 1));
   ctx->count += length;
   if(length > ctx->count)
     ctx->count_bits_hi += 1U << 3; /* Value wrap */
@@ -646,7 +652,7 @@ MHDx_sha512_256_update(void *context,
   ctx->count &= CURL_UINT64_C(0x1FFFFFFFFFFFFFFF);
 
   if(0 != bytes_have) {
-    unsigned int bytes_left = SHA512_256_BLOCK_SIZE - bytes_have;
+    unsigned int bytes_left = CURL_SHA512_256_BLOCK_SIZE - bytes_have;
     if(length >= bytes_left) {
       /* Combine new data with data in the buffer and process the full
          block. */
@@ -660,12 +666,12 @@ MHDx_sha512_256_update(void *context,
     }
   }
 
-  while(SHA512_256_BLOCK_SIZE <= length) {
+  while(CURL_SHA512_256_BLOCK_SIZE <= length) {
     /* Process any full blocks of new data directly,
        without copying to the buffer. */
     MHDx_sha512_256_transform(ctx->H, data);
-    data += SHA512_256_BLOCK_SIZE;
-    length -= SHA512_256_BLOCK_SIZE;
+    data += CURL_SHA512_256_BLOCK_SIZE;
+    length -= CURL_SHA512_256_BLOCK_SIZE;
   }
 
   if(0 != length) {
@@ -694,7 +700,8 @@ MHDx_sha512_256_update(void *context,
  * Finalise SHA-512/256 calculation, return digest.
  *
  * @param context the calculation context
- * @param[out] digest set to the hash, must be #SHA512_256_DIGEST_SIZE bytes
+ * @param[out] digest set to the hash, must be #CURL_SHA512_256_DIGEST_SIZE
+ #             bytes
  * @return always CURLE_OK
  */
 static CURLcode
@@ -712,9 +719,9 @@ MHDx_sha512_256_finish(unsigned char *digest,
      not change the amount of hashed data. */
   num_bits = ctx->count << 3;
 
-  /* Note: (count & (SHA512_256_BLOCK_SIZE-1))
-           equals (count % SHA512_256_BLOCK_SIZE) for this block size. */
-  bytes_have = (unsigned int) (ctx->count & (SHA512_256_BLOCK_SIZE - 1));
+  /* Note: (count & (CURL_SHA512_256_BLOCK_SIZE-1))
+           equals (count % CURL_SHA512_256_BLOCK_SIZE) for this block size. */
+  bytes_have = (unsigned int) (ctx->count & (CURL_SHA512_256_BLOCK_SIZE - 1));
 
   /* Input data must be padded with a single bit "1", then with zeros and
      the finally the length of data in bits must be added as the final bytes
@@ -728,12 +735,12 @@ MHDx_sha512_256_finish(unsigned char *digest,
      processed when formed). */
   ((unsigned char *) ctx_buf)[bytes_have++] = 0x80U;
 
-  if(SHA512_256_BLOCK_SIZE - bytes_have < SHA512_256_SIZE_OF_LEN_ADD) {
+  if(CURL_SHA512_256_BLOCK_SIZE - bytes_have < SHA512_256_SIZE_OF_LEN_ADD) {
     /* No space in the current block to put the total length of message.
        Pad the current block with zeros and process it. */
-    if(bytes_have < SHA512_256_BLOCK_SIZE)
+    if(bytes_have < CURL_SHA512_256_BLOCK_SIZE)
       memset(((unsigned char *) ctx_buf) + bytes_have, 0,
-             SHA512_256_BLOCK_SIZE - bytes_have);
+             CURL_SHA512_256_BLOCK_SIZE - bytes_have);
     /* Process the full block. */
     MHDx_sha512_256_transform(ctx->H, ctx->buffer);
     /* Start the new block. */
@@ -742,17 +749,17 @@ MHDx_sha512_256_finish(unsigned char *digest,
 
   /* Pad the rest of the buffer with zeros. */
   memset(((unsigned char *) ctx_buf) + bytes_have, 0,
-         SHA512_256_BLOCK_SIZE - SHA512_256_SIZE_OF_LEN_ADD - bytes_have);
+         CURL_SHA512_256_BLOCK_SIZE - SHA512_256_SIZE_OF_LEN_ADD - bytes_have);
   /* Put high part of number of bits in processed message and then lower
      part of number of bits as big-endian values.
      See FIPS PUB 180-4 section 5.1.2. */
   /* Note: the target location is predefined and buffer is always aligned */
   MHDX_PUT_64BIT_BE(((unsigned char *) ctx_buf)  \
-                      + SHA512_256_BLOCK_SIZE         \
+                      + CURL_SHA512_256_BLOCK_SIZE    \
                       - SHA512_256_SIZE_OF_LEN_ADD,   \
                       ctx->count_bits_hi);
   MHDX_PUT_64BIT_BE(((unsigned char *) ctx_buf)      \
-                      + SHA512_256_BLOCK_SIZE             \
+                      + CURL_SHA512_256_BLOCK_SIZE        \
                       - SHA512_256_SIZE_OF_LEN_ADD        \
                       + SHA512_256_BYTES_IN_WORD,         \
                       num_bits);
@@ -841,9 +848,9 @@ const struct HMAC_params Curl_HMAC_SHA512_256[] = {
     /* Context structure size. */
     sizeof(Curl_sha512_256_ctx),
     /* Maximum key length (bytes). */
-    SHA512_256_BLOCK_SIZE,
+    CURL_SHA512_256_BLOCK_SIZE,
     /* Result length (bytes). */
-    SHA512_256_DIGEST_SIZE
+    CURL_SHA512_256_DIGEST_SIZE
   }
 };
 

--- a/lib/curl_sha512_256.h
+++ b/lib/curl_sha512_256.h
@@ -33,7 +33,7 @@
 
 extern const struct HMAC_params Curl_HMAC_SHA512_256[1];
 
-#define SHA512_256_DIGEST_LENGTH 32
+#define CURL_SHA512_256_DIGEST_LENGTH 32
 
 CURLcode
 Curl_sha512_256it(unsigned char *output, const unsigned char *input,

--- a/tests/unit/unit1615.c
+++ b/tests/unit/unit1615.c
@@ -41,25 +41,25 @@ UNITTEST_START
 #ifdef CURL_HAVE_SHA512_256
 
   static const char test_str1[] = "1";
-  static const unsigned char precomp_hash1[SHA512_256_DIGEST_LENGTH] = {
+  static const unsigned char precomp_hash1[CURL_SHA512_256_DIGEST_LENGTH] = {
      0x18, 0xd2, 0x75, 0x66, 0xbd, 0x1a, 0xc6, 0x6b, 0x23, 0x32, 0xd8,
      0xc5, 0x4a, 0xd4, 0x3f, 0x7b, 0xb2, 0x20, 0x79, 0xc9, 0x06, 0xd0,
      0x5f, 0x49, 0x1f, 0x3f, 0x07, 0xa2, 0x8d, 0x5c, 0x69, 0x90
   };
   static const char test_str2[] = "hello-you-fool";
-  static const unsigned char precomp_hash2[SHA512_256_DIGEST_LENGTH] = {
+  static const unsigned char precomp_hash2[CURL_SHA512_256_DIGEST_LENGTH] = {
       0xaf, 0x6f, 0xb4, 0xb0, 0x13, 0x9b, 0xee, 0x13, 0xd1, 0x95, 0x3c,
       0xb8, 0xc7, 0xcd, 0x5b, 0x19, 0xf9, 0xcd, 0xcd, 0x21, 0xef, 0xdf,
       0xa7, 0x42, 0x5c, 0x07, 0x13, 0xea, 0xcc, 0x1a, 0x39, 0x76
   };
   static const char test_str3[] = "abc";
-  static const unsigned char precomp_hash3[SHA512_256_DIGEST_LENGTH] = {
+  static const unsigned char precomp_hash3[CURL_SHA512_256_DIGEST_LENGTH] = {
       0x53, 0x04, 0x8E, 0x26, 0x81, 0x94, 0x1E, 0xF9, 0x9B, 0x2E, 0x29,
       0xB7, 0x6B, 0x4C, 0x7D, 0xAB, 0xE4, 0xC2, 0xD0, 0xC6, 0x34, 0xFC,
       0x6D, 0x46, 0xE0, 0xE2, 0xF1, 0x31, 0x07, 0xE7, 0xAF, 0x23
   };
   static const char test_str4[] = ""; /* empty, zero size input */
-  static const unsigned char precomp_hash4[SHA512_256_DIGEST_LENGTH] = {
+  static const unsigned char precomp_hash4[CURL_SHA512_256_DIGEST_LENGTH] = {
       0xc6, 0x72, 0xb8, 0xd1, 0xef, 0x56, 0xed, 0x28, 0xab, 0x87, 0xc3,
       0x62, 0x2c, 0x51, 0x14, 0x06, 0x9b, 0xdd, 0x3a, 0xd7, 0xb8, 0xf9,
       0x73, 0x74, 0x98, 0xd0, 0xc0, 0x1e, 0xce, 0xf0, 0x96, 0x7a
@@ -67,7 +67,7 @@ UNITTEST_START
   static const char test_str5[] =
       "abcdefghijklmnopqrstuvwxyzzyxwvutsrqponMLKJIHGFEDCBA" \
       "abcdefghijklmnopqrstuvwxyzzyxwvutsrqponMLKJIHGFEDCBA";
-  static const unsigned char precomp_hash5[SHA512_256_DIGEST_LENGTH] = {
+  static const unsigned char precomp_hash5[CURL_SHA512_256_DIGEST_LENGTH] = {
       0xad, 0xe9, 0x5d, 0x55, 0x3b, 0x9e, 0x45, 0x69, 0xdb, 0x53, 0xa4,
       0x04, 0x92, 0xe7, 0x87, 0x94, 0xff, 0xc9, 0x98, 0x5f, 0x93, 0x03,
       0x86, 0x45, 0xe1, 0x97, 0x17, 0x72, 0x7c, 0xbc, 0x31, 0x15
@@ -80,13 +80,13 @@ UNITTEST_START
       "/long/long/long/long/long/long/long/long/long/long/long" \
       "/long/long/long/long/long/long/long/long/long/long/long" \
       "/long/long/long/long/path?with%20some=parameters";
-  static const unsigned char precomp_hash6[SHA512_256_DIGEST_LENGTH] = {
+  static const unsigned char precomp_hash6[CURL_SHA512_256_DIGEST_LENGTH] = {
       0xbc, 0xab, 0xc6, 0x2c, 0x0a, 0x22, 0xd5, 0xcb, 0xac, 0xac, 0xe9,
       0x25, 0xcf, 0xce, 0xaa, 0xaf, 0x0e, 0xa1, 0xed, 0x42, 0x46, 0x8a,
       0xe2, 0x01, 0xee, 0x2f, 0xdb, 0x39, 0x75, 0x47, 0x73, 0xf1
   };
   static const char test_str7[] = "Simple string.";
-  static const unsigned char precomp_hash7[SHA512_256_DIGEST_LENGTH] = {
+  static const unsigned char precomp_hash7[CURL_SHA512_256_DIGEST_LENGTH] = {
       0xde, 0xcb, 0x3c, 0x81, 0x65, 0x4b, 0xa0, 0xf5, 0xf0, 0x45, 0x6b,
       0x7e, 0x61, 0xf5, 0x0d, 0xf5, 0x38, 0xa4, 0xfc, 0xb1, 0x8a, 0x95,
       0xff, 0x59, 0xbc, 0x04, 0x82, 0xcf, 0x23, 0xb2, 0x32, 0x56
@@ -109,13 +109,13 @@ UNITTEST_START
       48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31,
       30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13,
       12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1}; /* 255..1 sequence */
-  static const unsigned char precomp_hash8[SHA512_256_DIGEST_LENGTH] = {
+  static const unsigned char precomp_hash8[CURL_SHA512_256_DIGEST_LENGTH] = {
       0x22, 0x31, 0xf2, 0xa1, 0xb4, 0x89, 0xb2, 0x44, 0xf7, 0x66, 0xa0,
       0xb8, 0x31, 0xed, 0xb7, 0x73, 0x8a, 0x34, 0xdc, 0x11, 0xc8, 0x2c,
       0xf2, 0xb5, 0x88, 0x60, 0x39, 0x6b, 0x5c, 0x06, 0x70, 0x37
   };
 
-  unsigned char output_buf[SHA512_256_DIGEST_LENGTH];
+  unsigned char output_buf[CURL_SHA512_256_DIGEST_LENGTH];
   unsigned char *computed_hash; /* Just to mute compiler warning */
 
   /* Mute compiler warnings in 'verify_memory' macros below */
@@ -123,35 +123,35 @@ UNITTEST_START
 
   Curl_sha512_256it(output_buf, (const unsigned char *) test_str1,
                     (sizeof(test_str1) / sizeof(char)) - 1);
-  verify_memory(computed_hash, precomp_hash1, SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash1, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *) test_str2,
                     (sizeof(test_str2) / sizeof(char)) - 1);
-  verify_memory(computed_hash, precomp_hash2, SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash2, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *) test_str3,
                     (sizeof(test_str3) / sizeof(char)) - 1);
-  verify_memory(computed_hash, precomp_hash3, SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash3, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *) test_str4,
                     (sizeof(test_str4) / sizeof(char)) - 1);
-  verify_memory(computed_hash, precomp_hash4, SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash4, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *) test_str5,
                     (sizeof(test_str5) / sizeof(char)) - 1);
-  verify_memory(computed_hash, precomp_hash5, SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash5, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *) test_str6,
                     (sizeof(test_str6) / sizeof(char)) - 1);
-  verify_memory(computed_hash, precomp_hash6, SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash6, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, (const unsigned char *) test_str7,
                     (sizeof(test_str7) / sizeof(char)) - 1);
-  verify_memory(computed_hash, precomp_hash7, SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash7, CURL_SHA512_256_DIGEST_LENGTH);
 
   Curl_sha512_256it(output_buf, test_seq8,
                     sizeof(test_seq8) / sizeof(unsigned char));
-  verify_memory(computed_hash, precomp_hash8, SHA512_256_DIGEST_LENGTH);
+  verify_memory(computed_hash, precomp_hash8, CURL_SHA512_256_DIGEST_LENGTH);
 
 #endif /* CURL_HAVE_SHA512_256 */
 


### PR DESCRIPTION
`SHA512_256_BLOCK_SIZE`, `SHA512_256_DIGEST_SIZE` macros were both
defined within curl and also in the nettle library required by GnuTLS.

Fix it by namespacing the curl macros.

Cherry-picked from #14495
Closes #14514
