### PR TITLE
sha256: fix symbol collision between nettle (GnuTLS) and OpenSSL codepath

### DIFF
--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -100,10 +100,10 @@
 
 #if defined(USE_OPENSSL_SHA256)
 
-struct sha256_ctx {
+struct ossl_sha256_ctx {
   EVP_MD_CTX *openssl_ctx;
 };
-typedef struct sha256_ctx my_sha256_ctx;
+typedef struct ossl_sha256_ctx my_sha256_ctx;
 
 static CURLcode my_sha256_init(my_sha256_ctx *ctx)
 {


### PR DESCRIPTION
Fixes:
```
C:\vcpkg\installed\x64-windows\include\nettle\sha2.h(75,8): error C2011: 'sha256_ctx': 'struct' type redefinition
```
Ref: https://github.com/curl/curl/actions/runs/10341162641/job/28622681573?pr=14484#step:10:30

Cherry-picked from #14495
Closes #14515
