### PR TITLE
vtls: fix static function name collisions between TLS backends

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -350,7 +350,7 @@ static CURLcode handshake(struct Curl_cfilter *cf,
   }
 }
 
-static gnutls_x509_crt_fmt_t do_file_type(const char *type)
+static gnutls_x509_crt_fmt_t gnutls_do_file_type(const char *type)
 {
   if(!type || !type[0])
     return GNUTLS_X509_FMT_PEM;
@@ -939,7 +939,7 @@ static CURLcode gtls_client_init(struct Curl_cfilter *cf,
            gtls->shared_creds->creds,
            config->clientcert,
            ssl_config->key ? ssl_config->key : config->clientcert,
-           do_file_type(ssl_config->cert_type),
+           gnutls_do_file_type(ssl_config->cert_type),
            ssl_config->key_passwd,
            supported_key_encryption_algorithms);
       if(rc != GNUTLS_E_SUCCESS) {
@@ -954,7 +954,7 @@ static CURLcode gtls_client_init(struct Curl_cfilter *cf,
            gtls->shared_creds->creds,
            config->clientcert,
            ssl_config->key ? ssl_config->key : config->clientcert,
-           do_file_type(ssl_config->cert_type) ) !=
+           gnutls_do_file_type(ssl_config->cert_type) ) !=
          GNUTLS_E_SUCCESS) {
         failf(data, "error reading X.509 key or certificate file");
         return CURLE_SSL_CONNECT_ERROR;

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -368,11 +368,11 @@ static gnutls_x509_crt_fmt_t do_file_type(const char *type)
 #define GNUTLS_SRP "+SRP"
 
 static CURLcode
-set_ssl_version_min_max(struct Curl_easy *data,
-                        struct ssl_peer *peer,
-                        struct ssl_primary_config *conn_config,
-                        const char **prioritylist,
-                        const char *tls13support)
+gnutls_set_ssl_version_min_max(struct Curl_easy *data,
+                               struct ssl_peer *peer,
+                               struct ssl_primary_config *conn_config,
+                               const char **prioritylist,
+                               const char *tls13support)
 {
   long ssl_version = conn_config->version;
   long ssl_version_max = conn_config->version_max;
@@ -890,8 +890,8 @@ static CURLcode gtls_client_init(struct Curl_cfilter *cf,
   }
 
   /* At this point we know we have a supported TLS version, so set it */
-  result = set_ssl_version_min_max(data, peer,
-                                   config, &prioritylist, tls13support);
+  result = gnutls_set_ssl_version_min_max(data, peer,
+                                          config, &prioritylist, tls13support);
   if(result)
     return result;
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -314,7 +314,8 @@ static CURLcode mbedtls_version_from_curl(int *mbedver, long version)
 #endif
 
 static CURLcode
-set_ssl_version_min_max(struct Curl_cfilter *cf, struct Curl_easy *data)
+mbedtls_set_ssl_version_min_max(struct Curl_cfilter *cf,
+                                struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
   struct mbed_ssl_backend_data *backend =
@@ -834,7 +835,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   case CURL_SSLVERSION_TLSv1_2:
   case CURL_SSLVERSION_TLSv1_3:
     {
-      CURLcode result = set_ssl_version_min_max(cf, data);
+      CURLcode result = mbedtls_set_ssl_version_min_max(cf, data);
       if(result != CURLE_OK)
         return result;
       break;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1050,7 +1050,7 @@ static CURLcode ossl_seed(struct Curl_easy *data)
 #ifndef SSL_FILETYPE_PKCS12
 #define SSL_FILETYPE_PKCS12 43
 #endif
-static int do_file_type(const char *type)
+static int ossl_do_file_type(const char *type)
 {
   if(!type || !type[0])
     return SSL_FILETYPE_PEM;
@@ -1272,7 +1272,7 @@ int cert_stuff(struct Curl_easy *data,
   char error_buffer[256];
   bool check_privkey = TRUE;
 
-  int file_type = do_file_type(cert_type);
+  int file_type = ossl_do_file_type(cert_type);
 
   if(cert_file || cert_blob || (file_type == SSL_FILETYPE_ENGINE)) {
     SSL *ssl;
@@ -1513,7 +1513,7 @@ fail:
       key_blob = cert_blob;
     }
     else
-      file_type = do_file_type(key_type);
+      file_type = ossl_do_file_type(key_type);
 
     switch(file_type) {
     case SSL_FILETYPE_PEM:

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -748,8 +748,8 @@ static CURLcode sectransp_version_from_curl(SSLProtocol *darwinver,
 }
 #endif
 
-static CURLcode set_ssl_version_min_max(struct Curl_cfilter *cf,
-                                        struct Curl_easy *data)
+static CURLcode sectransp_set_ssl_version_min_max(struct Curl_cfilter *cf,
+                                                  struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
   struct st_ssl_backend_data *backend =
@@ -1156,7 +1156,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
     case CURL_SSLVERSION_TLSv1_1:
     case CURL_SSLVERSION_TLSv1_2:
     case CURL_SSLVERSION_TLSv1_3:
-      result = set_ssl_version_min_max(cf, data);
+      result = sectransp_set_ssl_version_min_max(cf, data);
       if(result != CURLE_OK)
         return result;
       break;
@@ -1191,7 +1191,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
     case CURL_SSLVERSION_TLSv1_1:
     case CURL_SSLVERSION_TLSv1_2:
     case CURL_SSLVERSION_TLSv1_3:
-      result = set_ssl_version_min_max(cf, data);
+      result = sectransp_set_ssl_version_min_max(cf, data);
       if(result != CURLE_OK)
         return result;
       break;

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -205,7 +205,7 @@ wolfssl_log_tls12_secret(SSL *ssl)
 }
 #endif /* OPENSSL_EXTRA */
 
-static int do_file_type(const char *type)
+static int wolfssl_do_file_type(const char *type)
 {
   if(!type || !type[0])
     return SSL_FILETYPE_PEM;
@@ -872,7 +872,7 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     const char *key_file = ssl_config->key;
     const struct curl_blob *cert_blob = ssl_config->primary.cert_blob;
     const struct curl_blob *key_blob = ssl_config->key_blob;
-    int file_type = do_file_type(ssl_config->cert_type);
+    int file_type = wolfssl_do_file_type(ssl_config->cert_type);
     int rc;
 
     switch(file_type) {
@@ -903,7 +903,7 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
       key_file = cert_file;
     }
     else
-      file_type = do_file_type(ssl_config->key_type);
+      file_type = wolfssl_do_file_type(ssl_config->key_type);
 
     rc = key_blob ?
       wolfSSL_CTX_use_PrivateKey_buffer(backend->ctx, key_blob->data,
@@ -918,7 +918,7 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   if(ssl_config->primary.cert_blob) {
     const struct curl_blob *cert_blob = ssl_config->primary.cert_blob;
     const struct curl_blob *key_blob = ssl_config->key_blob;
-    int file_type = do_file_type(ssl_config->cert_type);
+    int file_type = wolfssl_do_file_type(ssl_config->cert_type);
     int rc;
 
     switch(file_type) {
@@ -943,7 +943,7 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     if(!key_blob)
       key_blob = cert_blob;
     else
-      file_type = do_file_type(ssl_config->key_type);
+      file_type = wolfssl_do_file_type(ssl_config->key_type);
 
     if(wolfSSL_CTX_use_PrivateKey_buffer(backend->ctx, key_blob->data,
                                          (long)key_blob->len,


### PR DESCRIPTION
When using CMake Unity build.

- use unique name for `set_ssl_version_min_max()`
  Fixes collision between GnuTLS, mbedTLS and SecureTransport.
  ```
  lib\vtls\mbedtls.c(317,1): error C2084: function 'CURLcode set_ssl_version_min_max(Curl_easy *,ssl_peer *,ssl_primary_config *,const char **,const char *)' already has a body
  lib\vtls\mbedtls.c(837,49): warning C4133: 'function': incompatible types - from 'Curl_cfilter *' to 'Curl_easy *'
  lib\vtls\mbedtls.c(837,53): warning C4133: 'function': incompatible types - from 'Curl_easy *' to 'ssl_peer *'
  lib\vtls\mbedtls.c(837,25): error C2198: 'set_ssl_version_min_max': too few arguments for call
  ```

- use unique name for `do_file_type()`
  Fixes collision between GnuTLS, OpenSSL and wolfSSL.
  ```
  lib\vtls\openssl.c(1053,12): error C2084: function 'gnutls_x509_crt_fmt_t do_file_type(const char *)' already has a body
  ```

Ref: https://github.com/curl/curl/actions/runs/10341162641/job/28622681573?pr=14484#step:10:31
Cherry-picked from #14495
Closes #14516
