### PR TITLE
IDN: fix/extend/migrate test exclusion rules

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -480,12 +480,8 @@ jobs:
         timeout-minutes: 12
         run: |
           export TFLAGS='-j14 !TFTP !MQTT !WebSockets !SMTP !FTP ${{ matrix.tflags }}'
-          if [[ '${{ matrix.config }}' = *'-DUSE_WIN32_IDN=ON'* ]]; then
-            if [[ '${{ matrix.config }}' != *'-DENABLE_UNICODE=ON'* ]]; then
-              TFLAGS+=' ~1448 ~2046 ~2047'
-            fi
-          elif [[ '${{ matrix.config }}' = *'-DUSE_LIBIDN2=ON'* ]]; then
-            TFLAGS+=' ~165 ~1448 ~2046 ~2047'
+          if [[ '${{ matrix.config }}' != *'-DENABLE_UNICODE=ON'* ]]; then
+            TFLAGS+=' ~165 ~1448 ~1560 ~2046 ~2047'  # IDN tests failing without Unicode. 165 is for libidn2, for WinIDN it is disabled globally
           fi
           PATH="$PWD/bld/lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -480,8 +480,5 @@ jobs:
         timeout-minutes: 12
         run: |
           export TFLAGS='-j14 !TFTP !MQTT !WebSockets !SMTP !FTP ${{ matrix.tflags }}'
-          if [[ '${{ matrix.config }}' != *'-DENABLE_UNICODE=ON'* ]]; then
-            TFLAGS+=' ~165 ~1448 ~1560 ~2046 ~2047'  # IDN tests failing without Unicode. 165 is for libidn2, for WinIDN it is disabled globally
-          fi
           PATH="$PWD/bld/lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -396,7 +396,7 @@ jobs:
           #          read its configuration from, making it vulnerable to attacks on
           #          Windows. Do not use this component till there is a fix for these.
           # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
-          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DHTTP_ONLY=ON -DUSE_LIBIDN2=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON'
+          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=ON -DHTTP_ONLY=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON'
         - name: 'wolfssl'
           install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl'
           arch: 'x64'

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -96,3 +96,15 @@
 %if WinIDN
 165
 %endif
+# Windows non-Unicode builds fail to receive Unicode text via the command-line
+%if win32
+%if !Unicode
+%if libidn2
+165
+1560
+%endif
+1448
+2046
+2047
+%endif
+%endif

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -599,6 +599,9 @@ sub checksystemfeatures {
             if ($libcurl =~ /WinIDN/) {
                 $feature{"WinIDN"} = 1;
             }
+            if ($libcurl =~ /libidn2/) {
+                $feature{"libidn2"} = 1;
+            }
             if ($libcurl =~ /libssh2/i) {
                 $feature{"libssh2"} = 1;
             }


### PR DESCRIPTION
- make sure to exclude failing tests when libidn2 is detected by
  default.

- ignore test 1560 results. Seen to fail with libidn2.
  I'm not sure why this test was not executed earlier:
  https://github.com/curl/curl/actions/runs/10354610889/job/28660309355#step:13:3647

- runtests: recognize `libidn2` as a feature.

- move IDN test exclusions from GHA/windows to `tests/data/DISABLED`.

- GHA/windows: drop default `-DUSE_LIBIDN2=ON` cmake config.

Cherry-picked from #14495
Closes #14519
