### PR TITLE
tool_paramhlp: bump maximum post data size in memory to 16GB

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -90,12 +90,11 @@ static size_t memcrlf(char *orig,
   return total; /* no delimiter found */
 }
 
-#define MAX_FILE2STRING (256*1024*1024) /* big enough ? */
+#define MAX_FILE2STRING MAX_FILE2MEMORY
 
 ParameterError file2string(char **bufp, FILE *file)
 {
   struct curlx_dynbuf dyn;
-  DEBUGASSERT(MAX_FILE2STRING < INT_MAX); /* needs to fit in an int later */
   curlx_dyn_init(&dyn, MAX_FILE2STRING);
   if(file) {
     do {
@@ -133,7 +132,6 @@ ParameterError file2memory(char **bufp, size_t *size, FILE *file)
     size_t nread;
     struct curlx_dynbuf dyn;
     /* The size needs to fit in an int later */
-    DEBUGASSERT(MAX_FILE2MEMORY < INT_MAX);
     curlx_dyn_init(&dyn, MAX_FILE2MEMORY);
     do {
       char buffer[4096];

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -33,7 +33,7 @@ ParameterError file2string(char **bufp, FILE *file);
 #if SIZEOF_SIZE_T > 4
 #define MAX_FILE2MEMORY (16LL*1024*1024*1024)
 #else
-#define MAX_FILE2MEMORY (2*1024*1024*1024)
+#define MAX_FILE2MEMORY (INT_MAX)
 #endif
 
 ParameterError file2memory(char **bufp, size_t *size, FILE *file);

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -30,7 +30,11 @@ struct getout *new_getout(struct OperationConfig *config);
 
 ParameterError file2string(char **bufp, FILE *file);
 
-#define MAX_FILE2MEMORY (1024*1024*1024) /* big enough ? */
+#if SIZEOF_SIZE_T > 4
+#define MAX_FILE2MEMORY (16LL*1024*1024*1024)
+#else
+#define MAX_FILE2MEMORY (2*1024*1024*1024)
+#endif
 
 ParameterError file2memory(char **bufp, size_t *size, FILE *file);
 


### PR DESCRIPTION
- stick to 2GB for 32bit systems.

Ref: #14521