### PR TITLE
test587, improve robustness

### DIFF
--- a/tests/data/test587
+++ b/tests/data/test587
@@ -41,21 +41,6 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 #
 # Verify data after the test has been "shot"
 <verify>
-<strippart>
-s/^--------------------------[A-Za-z0-9]*/------------------------------/
-s/boundary=------------------------[A-Za-z0-9]*/boundary=----------------------------/
-</strippart>
-<protocol>
-POST /%TESTNUMBER HTTP/1.1
-Host: %HOSTIP:%HTTPPORT
-Accept: */*
-Content-Length: 780
-Content-Type: multipart/form-data; boundary=----------------------------
-
-------------------------------
-Content-Disposition: form-data; name="sendfile"; filename="postit2.c"
-
-</protocol>
 # CURLE_ABORTED_BY_CALLBACK (42)
 <errorcode>
 42


### PR DESCRIPTION
Remove check of server output as upload may abort before request could fully be sent, so server output may be completely missing.

Test already used a 1 second delay to mitigate timing. This change makes timing no longer an issue.