### PR TITLE
smtp, add tracing feature

### DIFF
--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -105,6 +105,10 @@ Tracing of DNS-over-HTTP operations to resolve hostnames.
 
 Traces reading of upload data from the application in order to send it to the server.
 
+## `smtp`
+
+Tracing of SMTP operations when this protocol is enabled in your build.
+
 ## `write`
 
 Traces writing of download data, received from the server, to the application.

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -221,6 +221,24 @@ void Curl_trc_ftp(struct Curl_easy *data, const char *fmt, ...)
 }
 #endif /* !CURL_DISABLE_FTP */
 
+#ifndef CURL_DISABLE_SMTP
+struct curl_trc_feat Curl_trc_feat_smtp = {
+  "SMTP",
+  CURL_LOG_LVL_NONE,
+};
+
+void Curl_trc_smtp(struct Curl_easy *data, const char *fmt, ...)
+{
+  DEBUGASSERT(!strchr(fmt, '\n'));
+  if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_smtp)) {
+    va_list ap;
+    va_start(ap, fmt);
+    trc_infof(data, &Curl_trc_feat_smtp, fmt, ap);
+    va_end(ap);
+  }
+}
+#endif /* !CURL_DISABLE_SMTP */
+
 #if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
 struct curl_trc_feat Curl_trc_feat_ws = {
   "WS",
@@ -257,6 +275,9 @@ static struct trc_feat_def trc_feats[] = {
 #endif
 #ifndef CURL_DISABLE_DOH
   { &Curl_doh_trc,            TRC_CT_NETWORK },
+#endif
+#ifndef CURL_DISABLE_SMTP
+  { &Curl_trc_feat_smtp,      TRC_CT_PROTOCOL },
 #endif
 #if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
   { &Curl_trc_feat_ws,        TRC_CT_PROTOCOL },

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -89,6 +89,11 @@ void Curl_failf(struct Curl_easy *data,
   do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_ftp)) \
          Curl_trc_ftp(data, __VA_ARGS__); } while(0)
 #endif /* !CURL_DISABLE_FTP */
+#ifndef CURL_DISABLE_SMTP
+#define CURL_TRC_SMTP(data, ...) \
+  do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_smtp)) \
+         Curl_trc_smtp(data, __VA_ARGS__); } while(0)
+#endif /* !CURL_DISABLE_SMTP */
 #if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
 #define CURL_TRC_WS(data, ...) \
   do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_ws)) \
@@ -104,6 +109,9 @@ void Curl_failf(struct Curl_easy *data,
 
 #ifndef CURL_DISABLE_FTP
 #define CURL_TRC_FTP   Curl_trc_ftp
+#endif
+#ifndef CURL_DISABLE_SMTP
+#define CURL_TRC_SMTP  Curl_trc_smtp
 #endif
 #if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
 #define CURL_TRC_WS    Curl_trc_ws
@@ -156,6 +164,11 @@ extern struct curl_trc_feat Curl_trc_feat_ftp;
 void Curl_trc_ftp(struct Curl_easy *data,
                   const char *fmt, ...) CURL_PRINTF(2, 3);
 #endif
+#ifndef CURL_DISABLE_SMTP
+extern struct curl_trc_feat Curl_trc_feat_smtp;
+void Curl_trc_smtp(struct Curl_easy *data,
+                   const char *fmt, ...) CURL_PRINTF(2, 3);
+#endif
 #if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
 extern struct curl_trc_feat Curl_trc_feat_ws;
 void Curl_trc_ws(struct Curl_easy *data,
@@ -203,6 +216,12 @@ static void Curl_trc_read(struct Curl_easy *data, const char *fmt, ...)
 
 #ifndef CURL_DISABLE_FTP
 static void Curl_trc_ftp(struct Curl_easy *data, const char *fmt, ...)
+{
+  (void)data; (void)fmt;
+}
+#endif
+#ifndef CURL_DISABLE_SMTP
+static void Curl_trc_smtp(struct Curl_easy *data, const char *fmt, ...)
 {
   (void)data; (void)fmt;
 }


### PR DESCRIPTION
Add `smtp` as tracing feature, use CURL_TRC_SMTP() in code to trace operations.