### PR TITLE
cmake: show warning if libpsl is not found

### DIFF
--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -114,7 +114,7 @@ jobs:
       - run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install cmake stunnel4
+          sudo apt-get install cmake stunnel4 libpsl-dev
           # ensure we don't pick up openssl in this build
           sudo apt remove --yes libssl-dev
           sudo python3 -m pip install impacket

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: run cmake
         run: |
-          cmake -B build
+          cmake -B build -DCURL_USE_LIBPSL=OFF
 
       - name: compare generated curl_config.h files
         run: ./.github/scripts/cmp-config.pl lib/curl_config.h build/lib/curl_config.h
@@ -62,7 +62,7 @@ jobs:
 
       - name: run cmake
         run: |
-          cmake -B build \
+          cmake -B build -DCURL_USE_LIBPSL=OFF \
             "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
             -DCURL_USE_LIBSSH2=OFF
 

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -118,7 +118,7 @@ jobs:
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
-          cmake -B build -DCURL_WERROR=ON
+          cmake -B build -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF
           make -C build -j5
         name: 'verify out-of-tree cmake build'
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -598,7 +598,7 @@ jobs:
               "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
               -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF \
               -DUSE_NGHTTP2=OFF -DUSE_LIBIDN2=OFF -DUSE_APPLE_IDN=OFF \
-              -DCURL_USE_LIBSSH2=OFF \
+              -DCURL_USE_LIBPSL=OFF -DCURL_USE_LIBSSH2=OFF \
               ${options}
           fi
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -294,6 +294,7 @@ jobs:
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
+            -DCURL_USE_LIBPSL=OFF \
             ${{ matrix.config }}
 
       - name: 'cmake configure log'
@@ -371,7 +372,7 @@ jobs:
           plat: 'uwp'
           type: 'Debug'
           tflags: 'skipall'
-          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON                      -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON'
+          config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBPSL=OFF -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON'
         - name: 'libressl'
           install: 'brotli zlib zstd libpsl nghttp2 libressl libssh2[core,zlib]'
           arch: 'x64'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1042,13 +1042,15 @@ mark_as_advanced(CURL_USE_LIBPSL)
 set(USE_LIBPSL OFF)
 
 if(CURL_USE_LIBPSL)
-  find_package(LibPSL)
+  find_package(LibPSL)  # TODO: add REQUIRED to match autotools
   if(LIBPSL_FOUND)
     list(APPEND CURL_LIBS ${LIBPSL_LIBRARIES})
     list(APPEND LIBCURL_PC_REQUIRES_PRIVATE "libpsl")
     list(APPEND CMAKE_REQUIRED_INCLUDES "${LIBPSL_INCLUDE_DIRS}")
     include_directories(${LIBPSL_INCLUDE_DIRS})
     set(USE_LIBPSL ON)
+  else()
+    message(WARNING "libpsl is enabled, but not found.")
   endif()
 endif()
 

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -60,7 +60,8 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     "-DENABLE_DEBUG=${DEBUG}" \
     "-DENABLE_UNICODE=${ENABLE_UNICODE}" \
     '-DCMAKE_INSTALL_PREFIX=C:/curl' \
-    "-DCMAKE_BUILD_TYPE=${PRJ_CFG}"
+    "-DCMAKE_BUILD_TYPE=${PRJ_CFG}" \
+    '-DCURL_USE_LIBPSL=OFF'
   # shellcheck disable=SC2086
   if ! cmake --build _bld --config "${PRJ_CFG}" --parallel 2 -- ${BUILD_OPT:-}; then
     if [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ]; then


### PR DESCRIPTION
Also:
- explicitly disable libpsl in CI to avoid configure warning, where
  necessary.
- add TODO to make this warning an error (to match autotools.)

Follow-up to 2998874bb61ac6ef3b72d6a61467cd2aaf6e53ea #12661
Closes #14533

---

- [x] rebase on #14545
- [x] rebase on #14546
