### PR TITLE
Curl_sendrecv() improvements

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1121,7 +1121,7 @@ CURLcode curl_easy_pause(struct Curl_easy *data, int action)
                   (data->mstate == MSTATE_PERFORMING ||
                    data->mstate == MSTATE_RATELIMITING));
   /* Unpausing writes is detected on the next run in
-   * transfer.c:Curl_readwrite(). This is because this may result
+   * transfer.c:Curl_sendrecv(). This is because this may result
    * in a transfer error if the application's callbacks fail */
 
   /* Set the new keepon state, so it takes effect no matter what error

--- a/lib/http.c
+++ b/lib/http.c
@@ -4441,7 +4441,8 @@ static CURLcode cr_exp100_read(struct Curl_easy *data,
     }
     /* We are now waiting for a reply from the server or
      * a timeout on our side IFF the request has been fully sent. */
-    DEBUGF(infof(data, "cr_exp100_read, start AWAITING_CONTINUE"));
+    DEBUGF(infof(data, "cr_exp100_read, start AWAITING_CONTINUE, "
+           "timeout %ldms", data->set.expect_100_timeout));
     ctx->state = EXP100_AWAITING_CONTINUE;
     ctx->start = Curl_now();
     Curl_expire(data, data->set.expect_100_timeout, EXPIRE_100_TIMEOUT);

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -32,6 +32,7 @@ CURLcode Curl_updatesocket(struct Curl_easy *data);
 void Curl_expire(struct Curl_easy *data, timediff_t milli, expire_id);
 void Curl_expire_clear(struct Curl_easy *data);
 void Curl_expire_done(struct Curl_easy *data, expire_id id);
+bool Curl_has_expired(struct Curl_easy *data, struct curltime *nowp);
 CURLMcode Curl_update_timer(struct Curl_multi *multi) WARN_UNUSED_RESULT;
 void Curl_attach_connection(struct Curl_easy *data,
                              struct connectdata *conn);

--- a/lib/request.c
+++ b/lib/request.c
@@ -392,21 +392,23 @@ bool Curl_req_sendbuf_empty(struct Curl_easy *data)
   return !data->req.sendbuf_init || Curl_bufq_is_empty(&data->req.sendbuf);
 }
 
-bool Curl_req_want_send(struct Curl_easy *data)
+bool Curl_req_want_send(struct Curl_easy *data, bool timer_expired)
 {
   /* Not done and
    * - KEEP_SEND and not PAUSEd.
    * - or request has buffered data to send
-   * - or transfer connection has pending data to send */
+   * - or transfer connection has pending data to send
+   * - or a timer expired and KEEP_SEND_TIMED is set */
   return !data->req.done &&
          (((data->req.keepon & KEEP_SENDBITS) == KEEP_SEND) ||
            !Curl_req_sendbuf_empty(data) ||
-           Curl_xfer_needs_flush(data));
+           Curl_xfer_needs_flush(data) ||
+           (timer_expired && (data->req.keepon & KEEP_SEND_TIMED)));
 }
 
 bool Curl_req_done_sending(struct Curl_easy *data)
 {
-  return data->req.upload_done && !Curl_req_want_send(data);
+  return data->req.upload_done && !Curl_req_want_send(data, FALSE);
 }
 
 CURLcode Curl_req_send_more(struct Curl_easy *data)

--- a/lib/request.h
+++ b/lib/request.h
@@ -218,7 +218,7 @@ CURLcode Curl_req_send_more(struct Curl_easy *data);
 /**
  * TRUE iff the request wants to send, e.g. has buffered bytes.
  */
-bool Curl_req_want_send(struct Curl_easy *data);
+bool Curl_req_want_send(struct Curl_easy *data, bool timer_expired);
 
 /**
  * TRUE iff the request has no buffered bytes yet to send.

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -196,18 +196,6 @@ CURLcode Curl_xfer_send_shutdown(struct Curl_easy *data, bool *done)
   return Curl_conn_shutdown(data, sockindex, done);
 }
 
-static bool xfer_send_shutdown_started(struct Curl_easy *data)
-{
-  int sockindex;
-
-  if(!data || !data->conn)
-    return CURLE_FAILED_INIT;
-  if(data->conn->writesockfd == CURL_SOCKET_BAD)
-    return CURLE_FAILED_INIT;
-  sockindex = (data->conn->writesockfd == data->conn->sock[SECONDARYSOCKET]);
-  return Curl_shutdown_started(data, sockindex);
-}
-
 /**
  * Receive raw response data for the transfer.
  * @param data         the transfer
@@ -261,7 +249,7 @@ static ssize_t Curl_xfer_recv_resp(struct Curl_easy *data,
         return -1;
       }
     }
-    DEBUGF(infof(data, "readwrite_data: we are done"));
+    DEBUGF(infof(data, "sendrecv_dl: we are done"));
   }
   DEBUGASSERT(nread >= 0);
   return nread;
@@ -272,9 +260,9 @@ static ssize_t Curl_xfer_recv_resp(struct Curl_easy *data,
  * the stream was rewound (in which case we have data in a
  * buffer)
  */
-static CURLcode readwrite_data(struct Curl_easy *data,
-                               struct SingleRequest *k,
-                               int *didwhat)
+static CURLcode sendrecv_dl(struct Curl_easy *data,
+                            struct SingleRequest *k,
+                            int *didwhat)
 {
   struct connectdata *conn = data->conn;
   CURLcode result = CURLE_OK;
@@ -381,14 +369,14 @@ static CURLcode readwrite_data(struct Curl_easy *data,
 out:
   Curl_multi_xfer_buf_release(data, xfer_buf);
   if(result)
-    DEBUGF(infof(data, "readwrite_data() -> %d", result));
+    DEBUGF(infof(data, "sendrecv_dl() -> %d", result));
   return result;
 }
 
 /*
  * Send data to upload to the server, when the socket is writable.
  */
-static CURLcode readwrite_upload(struct Curl_easy *data, int *didwhat)
+static CURLcode sendrecv_ul(struct Curl_easy *data, int *didwhat)
 {
   /* We should not get here when the sending is already done. It
    * probably means that someone set `data-req.keepon |= KEEP_SEND`
@@ -421,61 +409,39 @@ static int select_bits_paused(struct Curl_easy *data, int select_bits)
 }
 
 /*
- * Curl_readwrite() is the low-level function to be called when data is to
+ * Curl_sendrecv() is the low-level function to be called when data is to
  * be read and written to/from the connection.
  */
-CURLcode Curl_readwrite(struct Curl_easy *data)
+CURLcode Curl_sendrecv(struct Curl_easy *data, struct curltime *nowp)
 {
-  struct connectdata *conn = data->conn;
   struct SingleRequest *k = &data->req;
-  CURLcode result;
-  struct curltime now;
+  CURLcode result = CURLE_OK;
   int didwhat = 0;
-  int select_bits;
+  int select_bits = 0;
+  bool expired;
 
-  if(data->state.select_bits) {
+  DEBUGASSERT(nowp);
+  expired = Curl_has_expired(data, nowp);
+  if(expired) {
+    /* A timer for this transfer has expired. Run it. */
+    DEBUGF(infof(data, "sendrecv, timer expired, RUN"));
+    select_bits = (CURL_CSELECT_OUT|CURL_CSELECT_IN);
+  }
+  else if(data->state.select_bits) {
     if(select_bits_paused(data, data->state.select_bits)) {
       /* leave the bits unchanged, so they'll tell us what to do when
        * this transfer gets unpaused. */
-      DEBUGF(infof(data, "readwrite, select_bits, early return on PAUSED"));
+      DEBUGF(infof(data, "sendrecv, select_bits, early return on PAUSED"));
       result = CURLE_OK;
       goto out;
     }
     select_bits = data->state.select_bits;
     data->state.select_bits = 0;
   }
-  else if(((k->keepon & KEEP_RECVBITS) == KEEP_RECV) &&
-          xfer_recv_shutdown_started(data)) {
-    DEBUGF(infof(data, "readwrite, recv for finishing shutdown"));
-    select_bits = CURL_CSELECT_IN;
-  }
-  else if(((k->keepon & KEEP_SENDBITS) == KEEP_SEND) &&
-          xfer_send_shutdown_started(data)) {
-    DEBUGF(infof(data, "readwrite, send for finishing shutdown"));
-    select_bits = CURL_CSELECT_OUT;
-  }
-  else {
-    curl_socket_t fd_read;
-    curl_socket_t fd_write;
-    /* only use the proper socket if the *_HOLD bit is not set simultaneously
-       as then we are in rate limiting state in that transfer direction */
-    if((k->keepon & KEEP_RECVBITS) == KEEP_RECV)
-      fd_read = conn->sockfd;
-    else
-      fd_read = CURL_SOCKET_BAD;
-
-    if(Curl_req_want_send(data))
-      fd_write = conn->writesockfd;
-    else
-      fd_write = CURL_SOCKET_BAD;
-
-    select_bits = Curl_socket_check(fd_read, CURL_SOCKET_BAD, fd_write, 0);
-  }
-
-  if(select_bits == CURL_CSELECT_ERR) {
-    failf(data, "select/poll returned error");
-    result = CURLE_SEND_ERROR;
-    goto out;
+  else if(data->last_poll.num) {
+    /* The transfer wanted something polled. Let's run all available
+     * send/receives. Worst case we EAGAIN on some. */
+    select_bits = (CURL_CSELECT_OUT|CURL_CSELECT_IN);
   }
 
 #ifdef USE_HYPER
@@ -490,17 +456,14 @@ CURLcode Curl_readwrite(struct Curl_easy *data)
      the stream was rewound (in which case we have data in a
      buffer) */
   if((k->keepon & KEEP_RECV) && (select_bits & CURL_CSELECT_IN)) {
-    result = readwrite_data(data, k, &didwhat);
+    result = sendrecv_dl(data, k, &didwhat);
     if(result || data->req.done)
       goto out;
   }
 
   /* If we still have writing to do, we check if we have a writable socket. */
-  if((Curl_req_want_send(data) && (select_bits & CURL_CSELECT_OUT)) ||
-     (k->keepon & KEEP_SEND_TIMED)) {
-    /* write */
-
-    result = readwrite_upload(data, &didwhat);
+  if(Curl_req_want_send(data, expired) && (select_bits & CURL_CSELECT_OUT)) {
+    result = sendrecv_ul(data, &didwhat);
     if(result)
       goto out;
   }
@@ -508,8 +471,8 @@ CURLcode Curl_readwrite(struct Curl_easy *data)
   }
 #endif
 
-  now = Curl_now();
-  if(!didwhat) {
+  if(select_bits && !didwhat) {
+    /* Transfer wanted to send/recv, but nothing was possible. */
     result = Curl_conn_ev_data_idle(data);
     if(result)
       goto out;
@@ -518,23 +481,23 @@ CURLcode Curl_readwrite(struct Curl_easy *data)
   if(Curl_pgrsUpdate(data))
     result = CURLE_ABORTED_BY_CALLBACK;
   else
-    result = Curl_speedcheck(data, now);
+    result = Curl_speedcheck(data, *nowp);
   if(result)
     goto out;
 
   if(k->keepon) {
-    if(0 > Curl_timeleft(data, &now, FALSE)) {
+    if(0 > Curl_timeleft(data, nowp, FALSE)) {
       if(k->size != -1) {
         failf(data, "Operation timed out after %" CURL_FORMAT_TIMEDIFF_T
               " milliseconds with %" CURL_FORMAT_CURL_OFF_T " out of %"
               CURL_FORMAT_CURL_OFF_T " bytes received",
-              Curl_timediff(now, data->progress.t_startsingle),
+              Curl_timediff(*nowp, data->progress.t_startsingle),
               k->bytecount, k->size);
       }
       else {
         failf(data, "Operation timed out after %" CURL_FORMAT_TIMEDIFF_T
               " milliseconds with %" CURL_FORMAT_CURL_OFF_T " bytes received",
-              Curl_timediff(now, data->progress.t_startsingle),
+              Curl_timediff(*nowp, data->progress.t_startsingle),
               k->bytecount);
       }
       result = CURLE_OPERATION_TIMEDOUT;
@@ -573,7 +536,7 @@ CURLcode Curl_readwrite(struct Curl_easy *data)
 
 out:
   if(result)
-    DEBUGF(infof(data, "Curl_readwrite() -> %d", result));
+    DEBUGF(infof(data, "Curl_sendrecv() -> %d", result));
   return result;
 }
 
@@ -1128,7 +1091,7 @@ static void xfer_setup(
 {
   struct SingleRequest *k = &data->req;
   struct connectdata *conn = data->conn;
-  bool want_send = Curl_req_want_send(data);
+  bool want_send = Curl_req_want_send(data, FALSE);
 
   DEBUGASSERT(conn != NULL);
   DEBUGASSERT((sockindex <= 1) && (sockindex >= -1));

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -445,8 +445,8 @@ CURLcode Curl_sendrecv(struct Curl_easy *data, struct curltime *nowp)
   }
 
 #ifdef USE_HYPER
-  if(conn->datastream) {
-    result = conn->datastream(data, conn, &didwhat, select_bits);
+  if(data->conn->datastream) {
+    result = data->conn->datastream(data, data->conn, &didwhat, select_bits);
     if(result || data->req.done)
       goto out;
   }

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -44,7 +44,7 @@ typedef enum {
 
 CURLcode Curl_follow(struct Curl_easy *data, char *newurl,
                      followtype type);
-CURLcode Curl_readwrite(struct Curl_easy *data);
+CURLcode Curl_sendrecv(struct Curl_easy *data, struct curltime *nowp);
 int Curl_single_getsock(struct Curl_easy *data,
                         struct connectdata *conn, curl_socket_t *socks);
 CURLcode Curl_retry_request(struct Curl_easy *data, char **url);

--- a/tests/valgrind.supp
+++ b/tests/valgrind.supp
@@ -14,7 +14,7 @@
    fun:zstd_unencode_write
    fun:Curl_unencode_write
    fun:readwrite_data
-   fun:Curl_readwrite
+   fun:Curl_sendrecv
    fun:multi_runsingle
    fun:curl_multi_perform
    fun:easy_transfer
@@ -31,7 +31,7 @@
    Memcheck:Cond
    fun:ZSTD_decompressStream
    fun:zstd_unencode_write
-   fun:Curl_readwrite
+   fun:Curl_sendrecv
    fun:multi_runsingle
    fun:curl_multi_perform
    fun:curl_easy_perform


### PR DESCRIPTION
Renames Curl_readwrite() to Curl_sendrecv() to reflect that his is mainly about talking to the server, not reads or writes to the client. Add a `nowp` parameter since the single caller already has this.

Add `Curl_has_expired()` that checks if `data->state.expiretime` has been reached. This member carries always the earliest time when expiration timers are added/removed.

When `Curl_sendrecv()` sees the transfer has expired, it always tries to send and/or receive where applicable without checking the socket POLL states.

For non-expired transfers that have also no `data->state.select_bits` set, check if the last poll information of the transfer mentioned any sockets at all. If not, probably as the transfer is paused or otherwise hindered from progressing, do not send/recv.

However if the transfer's poll mentioned any sockets, do try send/recv where applicable. This replaces the former POLL check on the involved sockets.

It seems better to DO send/recv and get an EAGAIN than polling the sockets, because the relationship between the POLL state and the transfer's ability is not clear for all protocols and proxy combinations. It is more robust to just try it.

In order to assess a transfer's last poll information, always use `data->last_poll` when collecting this. The event based handling already did so.