### PR TITLE
cmake: add missing `pkg-config` hints to Find modules

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -598,6 +598,7 @@ jobs:
               "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
               -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF \
               -DUSE_NGHTTP2=OFF -DUSE_LIBIDN2=OFF -DUSE_APPLE_IDN=OFF \
+              -DCURL_USE_LIBSSH2=OFF \
               ${options}
           fi
 

--- a/CMake/FindBrotli.cmake
+++ b/CMake/FindBrotli.cmake
@@ -28,11 +28,33 @@
 # BROTLI_FOUND         System has brotli
 # BROTLI_INCLUDE_DIRS  The brotli include directories
 # BROTLI_LIBRARIES     The brotli library names
+# BROTLI_VERSION       Version of brotli
 
-find_path(BROTLI_INCLUDE_DIR "brotli/decode.h")
+if(CURL_USE_PKGCONFIG)
+  find_package(PkgConfig QUIET)
+  pkg_search_module(PC_BROTLI "libbrotlidec")
+endif()
 
-find_library(BROTLICOMMON_LIBRARY NAMES "brotlicommon")
-find_library(BROTLIDEC_LIBRARY NAMES "brotlidec")
+find_path(BROTLI_INCLUDE_DIR "brotli/decode.h"
+  HINTS
+    ${PC_BROTLI_INCLUDEDIR}
+    ${PC_BROTLI_INCLUDE_DIRS}
+)
+
+find_library(BROTLICOMMON_LIBRARY NAMES "brotlicommon"
+  HINTS
+    ${PC_BROTLI_LIBDIR}
+    ${PC_BROTLI_LIBRARY_DIRS}
+)
+find_library(BROTLIDEC_LIBRARY NAMES "brotlidec"
+  HINTS
+    ${PC_BROTLI_LIBDIR}
+    ${PC_BROTLI_LIBRARY_DIRS}
+)
+
+if(PC_BROTLI_VERSION)
+  set(BROTLI_VERSION ${PC_BROTLI_VERSION})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Brotli
@@ -40,6 +62,8 @@ find_package_handle_standard_args(Brotli
     BROTLI_INCLUDE_DIR
     BROTLIDEC_LIBRARY
     BROTLICOMMON_LIBRARY
+  VERSION_VAR
+    BROTLI_VERSION
 )
 
 if(BROTLI_FOUND)

--- a/CMake/FindCARES.cmake
+++ b/CMake/FindCARES.cmake
@@ -28,16 +28,36 @@
 # CARES_FOUND         System has c-ares
 # CARES_INCLUDE_DIRS  The c-ares include directories
 # CARES_LIBRARIES     The c-ares library names
+# CARES_VERSION       Version of c-ares
 
-find_path(CARES_INCLUDE_DIR "ares.h")
+if(CURL_USE_PKGCONFIG)
+  find_package(PkgConfig QUIET)
+  pkg_search_module(PC_CARES "libcares")
+endif()
 
-find_library(CARES_LIBRARY NAMES ${CARES_NAMES} "cares")
+find_path(CARES_INCLUDE_DIR "ares.h"
+  HINTS
+    ${PC_CARES_INCLUDEDIR}
+    ${PC_CARES_INCLUDE_DIRS}
+)
+
+find_library(CARES_LIBRARY NAMES ${CARES_NAMES} "cares"
+  HINTS
+    ${PC_CARES_LIBDIR}
+    ${PC_CARES_LIBRARY_DIRS}
+)
+
+if(PC_CARES_VERSION)
+  set(CARES_VERSION ${PC_CARES_VERSION})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(CARES
   REQUIRED_VARS
     CARES_INCLUDE_DIR
     CARES_LIBRARY
+  VERSION_VAR
+    CARES_VERSION
 )
 
 if(CARES_FOUND)

--- a/CMake/FindLibPSL.cmake
+++ b/CMake/FindLibPSL.cmake
@@ -30,9 +30,22 @@
 # LIBPSL_LIBRARIES     The libpsl library names
 # LIBPSL_VERSION       Version of libpsl
 
-find_path(LIBPSL_INCLUDE_DIR "libpsl.h")
+if(CURL_USE_PKGCONFIG)
+  find_package(PkgConfig QUIET)
+  pkg_search_module(PC_LIBPSL "libpsl")
+endif()
 
-find_library(LIBPSL_LIBRARY NAMES "psl" "libpsl")
+find_path(LIBPSL_INCLUDE_DIR "libpsl.h"
+  HINTS
+    ${PC_LIBPSL_INCLUDEDIR}
+    ${PC_LIBPSL_INCLUDE_DIRS}
+)
+
+find_library(LIBPSL_LIBRARY NAMES "psl" "libpsl"
+  HINTS
+    ${PC_LIBPSL_LIBDIR}
+    ${PC_LIBPSL_LIBRARY_DIRS}
+)
 
 if(LIBPSL_INCLUDE_DIR)
   file(STRINGS "${LIBPSL_INCLUDE_DIR}/libpsl.h" _libpsl_version_str REGEX "^#define[\t ]+PSL_VERSION[\t ]+\"(.*)\"")

--- a/CMake/FindLibSSH2.cmake
+++ b/CMake/FindLibSSH2.cmake
@@ -30,9 +30,22 @@
 # LIBSSH2_LIBRARIES     The libssh2 library names
 # LIBSSH2_VERSION       Version of libssh2
 
-find_path(LIBSSH2_INCLUDE_DIR "libssh2.h")
+if(CURL_USE_PKGCONFIG)
+  find_package(PkgConfig QUIET)
+  pkg_search_module(PC_LIBSSH2 "libssh2")
+endif()
 
-find_library(LIBSSH2_LIBRARY NAMES "ssh2" "libssh2")
+find_path(LIBSSH2_INCLUDE_DIR "libssh2.h"
+  HINTS
+    ${PC_LIBSSH2_INCLUDEDIR}
+    ${PC_LIBSSH2_INCLUDE_DIRS}
+)
+
+find_library(LIBSSH2_LIBRARY NAMES "ssh2" "libssh2"
+  HINTS
+    ${PC_LIBSSH2_LIBDIR}
+    ${PC_LIBSSH2_LIBRARY_DIRS}
+)
 
 if(LIBSSH2_INCLUDE_DIR)
   file(STRINGS "${LIBSSH2_INCLUDE_DIR}/libssh2.h" _libssh2_version_str REGEX "^#define[\t ]+LIBSSH2_VERSION[\t ]+\"(.*)\"")

--- a/CMake/FindMbedTLS.cmake
+++ b/CMake/FindMbedTLS.cmake
@@ -28,6 +28,7 @@
 # MBEDTLS_FOUND         System has mbedtls
 # MBEDTLS_INCLUDE_DIRS  The mbedtls include directories
 # MBEDTLS_LIBRARIES     The mbedtls library names
+# MBEDTLS_VERSION       Version of mbedtls
 
 # for compatibility. Configuration via MBEDTLS_INCLUDE_DIRS is deprecated, use MBEDTLS_INCLUDE_DIR instead.
 if(DEFINED MBEDTLS_INCLUDE_DIRS AND NOT DEFINED MBEDTLS_INCLUDE_DIR)
@@ -35,11 +36,36 @@ if(DEFINED MBEDTLS_INCLUDE_DIRS AND NOT DEFINED MBEDTLS_INCLUDE_DIR)
   unset(MBEDTLS_INCLUDE_DIRS)
 endif()
 
-find_path(MBEDTLS_INCLUDE_DIR "mbedtls/ssl.h")
+if(CURL_USE_PKGCONFIG)
+  find_package(PkgConfig QUIET)
+  pkg_search_module(PC_MBEDTLS "mbedtls")
+endif()
 
-find_library(MBEDTLS_LIBRARY "mbedtls")
-find_library(MBEDX509_LIBRARY "mbedx509")
-find_library(MBEDCRYPTO_LIBRARY "mbedcrypto")
+find_path(MBEDTLS_INCLUDE_DIR "mbedtls/ssl.h"
+  HINTS
+    ${PC_MBEDTLS_INCLUDEDIR}
+    ${PC_MBEDTLS_INCLUDE_DIRS}
+)
+
+find_library(MBEDTLS_LIBRARY "mbedtls"
+  HINTS
+    ${PC_MBEDTLS_LIBDIR}
+    ${PC_MBEDTLS_LIBRARY_DIRS}
+)
+find_library(MBEDX509_LIBRARY "mbedx509"
+  HINTS
+    ${PC_MBEDTLS_LIBDIR}
+    ${PC_MBEDTLS_LIBRARY_DIRS}
+)
+find_library(MBEDCRYPTO_LIBRARY "mbedcrypto"
+  HINTS
+    ${PC_MBEDTLS_LIBDIR}
+    ${PC_MBEDTLS_LIBRARY_DIRS}
+)
+
+if(PC_MBEDTLS_VERSION)
+  set(MBEDTLS_VERSION ${PC_MBEDTLS_VERSION})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(MbedTLS
@@ -48,6 +74,8 @@ find_package_handle_standard_args(MbedTLS
     MBEDTLS_LIBRARY
     MBEDX509_LIBRARY
     MBEDCRYPTO_LIBRARY
+  VERSION_VAR
+    MBEDTLS_VERSION
 )
 
 if(MBEDTLS_FOUND)

--- a/CMake/Findrustls.cmake
+++ b/CMake/Findrustls.cmake
@@ -28,16 +28,36 @@
 # RUSTLS_FOUND         System has rustls
 # RUSTLS_INCLUDE_DIRS  The rustls include directories
 # RUSTLS_LIBRARIES     The rustls library names
+# RUSTLS_VERSION       Version of rustls
 
-find_path(RUSTLS_INCLUDE_DIR "rustls.h")
+if(CURL_USE_PKGCONFIG)
+  find_package(PkgConfig QUIET)
+  pkg_search_module(PC_RUSTLS "rustls")
+endif()
+
+find_path(RUSTLS_INCLUDE_DIR "rustls.h"
+  HINTS
+    ${PC_RUSTLS_INCLUDEDIR}
+    ${PC_RUSTLS_INCLUDE_DIRS}
+)
 
 find_library(RUSTLS_LIBRARY "rustls")
+  HINTS
+    ${PC_RUSTLS_LIBDIR}
+    ${PC_RUSTLS_LIBRARY_DIRS}
+)
+
+if(PC_RUSTLS_VERSION)
+  set(RUSTLS_VERSION ${PC_RUSTLS_VERSION})
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(rustls
   REQUIRED_VARS
     RUSTLS_INCLUDE_DIR
     RUSTLS_LIBRARY
+  VERSION_VAR
+    RUSTLS_VERSION
 )
 
 if(RUSTLS_FOUND)


### PR DESCRIPTION
- brotli, c-ares, libpsl, libssh2, mbedtls, rustls:
  Use `pkg-config` for path hints and version info. Syncing them up with
  the rest of Find modules.

- GHA/macos: force-disable libssh2 with cmake to sync with autotools.
  After this patch, cmake auto-detects libssh2 in this job.
