### PR TITLE
GHA/configure-vs-cmake: add macOS build, fix issues

### DIFF
--- a/.github/scripts/cmp-config.pl
+++ b/.github/scripts/cmp-config.pl
@@ -51,6 +51,7 @@ my %remove = (
     '#define HAVE_LIBSSH2 1' => 1,
     '#define HAVE_LIBSSL 1' => 1,
     '#define HAVE_LIBZSTD 1' => 1,
+    '#define HAVE_NGHTTP2_NGHTTP2_H 1' => 1,
     '#define HAVE_OPENSSL3 1' => 1,
     '#define HAVE_OPENSSL_CRYPTO_H 1' => 1,
     '#define HAVE_OPENSSL_ERR_H 1' => 1,

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -13,6 +13,7 @@ on:
       - '**/CMakeLists.txt'
       - 'lib/curl_config.h.cmake'
       - '.github/scripts/cmp-config.pl'
+      - '.github/workflows/configure-vs-cmake.yml'
 
   pull_request:
     branches:
@@ -23,6 +24,7 @@ on:
       - '**/CMakeLists.txt'
       - 'lib/curl_config.h.cmake'
       - '.github/scripts/cmp-config.pl'
+      - '.github/workflows/configure-vs-cmake.yml'
 
 permissions: {}
 

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -62,7 +62,9 @@ jobs:
 
       - name: run cmake
         run: |
-          cmake -B build
+          cmake -B build \
+            "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
+            -DCURL_USE_LIBSSH2=OFF
 
       - name: compare generated curl_config.h files
         run: ./.github/scripts/cmp-config.pl lib/curl_config.h build/lib/curl_config.h

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -27,19 +27,40 @@ on:
 permissions: {}
 
 jobs:
-  check:
+  check-linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: run configure --with-openssl
         run: |
-           autoreconf -fi
-           ./configure --with-openssl --without-libpsl
+          autoreconf -fi
+          ./configure --with-openssl --without-libpsl
 
       - name: run cmake
         run: |
-           mkdir build && cd build && cmake ..
+          cmake -B build
+
+      - name: compare generated curl_config.h files
+        run: ./.github/scripts/cmp-config.pl lib/curl_config.h build/lib/curl_config.h
+
+  check-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: install packages
+        run: |
+          while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew install libtool autoconf automake && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
+
+      - name: run configure --with-openssl
+        run: |
+          autoreconf -fi
+          ./configure --with-openssl --without-libpsl
+
+      - name: run cmake
+        run: |
+          cmake -B build
 
       - name: compare generated curl_config.h files
         run: ./.github/scripts/cmp-config.pl lib/curl_config.h build/lib/curl_config.h

--- a/configure.ac
+++ b/configure.ac
@@ -3262,7 +3262,7 @@ if test "x$want_openssl_quic" = "xyes"; then
   if test "$NGTCP2_ENABLED" = 1; then
     AC_MSG_ERROR([--with-openssl-quic and --with-ngtcp2 are mutually exclusive])
   fi
-  if test "$HAVE_OPENSSL_QUIC" != 1; then
+  if test "$have_openssl_quic" != 1; then
     AC_MSG_ERROR([--with-openssl-quic requires quic support and OpenSSL >= 3.3.0])
   fi
   AC_DEFINE(USE_OPENSSL_QUIC, 1, [if openssl QUIC is in use])

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -441,7 +441,7 @@ if test "$OPENSSL_ENABLED" = "1"; then
     ]])
   ],[
     AC_MSG_RESULT([yes])
-    AC_DEFINE(HAVE_OPENSSL_QUIC, 1, [if you have the functions OSSL_QUIC_client_method])
+    have_openssl_quic=1
   ],[
     AC_MSG_RESULT([no])
   ])

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -442,7 +442,6 @@ if test "$OPENSSL_ENABLED" = "1"; then
   ],[
     AC_MSG_RESULT([yes])
     AC_DEFINE(HAVE_OPENSSL_QUIC, 1, [if you have the functions OSSL_QUIC_client_method])
-    AC_SUBST(HAVE_OPENSSL_QUIC, [1])
   ],[
     AC_MSG_RESULT([no])
   ])


### PR DESCRIPTION
- sync cmake macOS `OS` value manually with the autotools one.
- stop exporting/subst-ing `HAVE_OPENSSL_QUIC` from autotools.
  The variable was only used internally.
- exclude a dependency detection symbol.
- allow to run when the workflow itself was updated.
- simplify cmake command.
- fix indentation.
