### PR TITLE
curl: fix the -w urle.* variables

### DIFF
--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -200,7 +200,7 @@ static int urlpart(struct per_transfer *per, writeoutid vid,
     char *part = NULL;
     const char *url = NULL;
 
-    if(vid >= VAR_INPUT_URLEHOST) {
+    if(vid >= VAR_INPUT_URLESCHEME) {
       if(curl_easy_getinfo(per->curl, CURLINFO_EFFECTIVE_URL, &url))
         rc = 5;
     }

--- a/src/tool_writeout.h
+++ b/src/tool_writeout.h
@@ -57,7 +57,7 @@ typedef enum {
   VAR_INPUT_URLFRAGMENT,
   VAR_INPUT_URLZONEID,
   /* the same ones again for url *effective* */
-  VAR_INPUT_URLESCHEME,
+  VAR_INPUT_URLESCHEME, /* keep this the first URLE* variable */
   VAR_INPUT_URLEUSER,
   VAR_INPUT_URLEPASSWORD,
   VAR_INPUT_URLEOPTIONS,

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -77,6 +77,7 @@ test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
 test462 test463 test467 test468 test469 test470 test471 test472 test473 \
+test474 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \

--- a/tests/data/test424
+++ b/tests/data/test424
@@ -59,10 +59,10 @@ http
 # Verify data after the test has been "shot"
 <verify>
 <stdout>
-anotherhost.example+/%TESTNUMBER0002+http+uuuu+pppp+2023+moo.html+
-hello2000+/%TESTNUMBER+h55p+++1+qqqq+ffff
+anotherhost.example+/4240002+http+++2023+moo.html+
+hello2000+/424+h55p+++1+qqqq+ffff
 +++++++
-anotherhost.example+/%TESTNUMBER0002+http+u22u+p22p+2023+moo.html+
+anotherhost.example+/4240002+http+++2023+moo.html+
 </stdout>
 </verify>
 </testcase>

--- a/tests/data/test474
+++ b/tests/data/test474
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+-w
+--write-out
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes" nocheck="yes">
+HTTP/1.1 301 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 0
+Connection: close
+Content-Type: text/html
+Location: https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0002
+
+</data>
+<data2 crlf="yes" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Content-Length: 0
+Connection: close
+
+</data2>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+https
+</server>
+<name>
+-w urle.scheme after HTTP to HTTPS redirect
+</name>
+<command option="no-include">
+-k -L http://%HOSTIP:%HTTPPORT/%TESTNUMBER -w "%{num_redirects} %{url_effective} %{urle.scheme}\n"
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<stdout>
+1 https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0002 https
+</stdout>
+</verify>
+</testcase>


### PR DESCRIPTION
urle.scheme, urle.user, urle.password and urle.options mistakenly operated on the original URL instead of the *effective* (last) URL.

Add test 474 to verify.

Reported-by: Gruber Glass
Fixes #14550