### PR TITLE
cmake: fix find rustls

### DIFF
--- a/CMake/Findrustls.cmake
+++ b/CMake/Findrustls.cmake
@@ -41,7 +41,7 @@ find_path(RUSTLS_INCLUDE_DIR "rustls.h"
     ${PC_RUSTLS_INCLUDE_DIRS}
 )
 
-find_library(RUSTLS_LIBRARY "rustls")
+find_library(RUSTLS_LIBRARY "rustls"
   HINTS
     ${PC_RUSTLS_LIBDIR}
     ${PC_RUSTLS_LIBRARY_DIRS}


### PR DESCRIPTION
Follow-up to 2784801977e81f68c6f87f9509e64f332d74acab #14545