### PR TITLE
cmake: tidy up more in Find modules

### DIFF
--- a/CMake/FindBearSSL.cmake
+++ b/CMake/FindBearSSL.cmake
@@ -35,8 +35,8 @@ if(DEFINED BEARSSL_INCLUDE_DIRS AND NOT DEFINED BEARSSL_INCLUDE_DIR)
   unset(BEARSSL_INCLUDE_DIRS)
 endif()
 
-find_path(BEARSSL_INCLUDE_DIR "bearssl.h")
-find_library(BEARSSL_LIBRARY "bearssl")
+find_path(BEARSSL_INCLUDE_DIR NAMES "bearssl.h")
+find_library(BEARSSL_LIBRARY NAMES "bearssl")
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(BEARSSL

--- a/CMake/FindBearSSL.cmake
+++ b/CMake/FindBearSSL.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the bearssl library
 #
+# Input variables:
+#
+# BEARSSL_INCLUDE_DIR   The bearssl include directory
+# BEARSSL_LIBRARY       Path to bearssl library
+#
 # Result Variables:
 #
 # BEARSSL_FOUND         System has bearssl

--- a/CMake/FindBearSSL.cmake
+++ b/CMake/FindBearSSL.cmake
@@ -28,6 +28,8 @@
 # BEARSSL_INCLUDE_DIR   The bearssl include directory
 # BEARSSL_LIBRARY       Path to bearssl library
 #
+# BEARSSL_INCLUDE_DIRS  The bearssl include directory (deprecated)
+#
 # Result Variables:
 #
 # BEARSSL_FOUND         System has bearssl

--- a/CMake/FindBearSSL.cmake
+++ b/CMake/FindBearSSL.cmake
@@ -29,7 +29,7 @@
 # BEARSSL_INCLUDE_DIRS  The bearssl include directory (deprecated)
 # BEARSSL_LIBRARY       Path to bearssl library
 #
-# Result Variables:
+# Result variables:
 #
 # BEARSSL_FOUND         System has bearssl
 # BEARSSL_INCLUDE_DIRS  The bearssl include directories

--- a/CMake/FindBearSSL.cmake
+++ b/CMake/FindBearSSL.cmake
@@ -26,9 +26,8 @@
 # Input variables:
 #
 # BEARSSL_INCLUDE_DIR   The bearssl include directory
-# BEARSSL_LIBRARY       Path to bearssl library
-#
 # BEARSSL_INCLUDE_DIRS  The bearssl include directory (deprecated)
+# BEARSSL_LIBRARY       Path to bearssl library
 #
 # Result Variables:
 #

--- a/CMake/FindBrotli.cmake
+++ b/CMake/FindBrotli.cmake
@@ -23,6 +23,12 @@
 ###########################################################################
 # Find the brotli library
 #
+# Input variables:
+#
+# BROTLI_INCLUDE_DIR   The brotli include directory
+# BROTLICOMMON_LIBRARY Path to brotlicommon library
+# BROTLIDEC_LIBRARY    Path to brotlidec library
+#
 # Result Variables:
 #
 # BROTLI_FOUND         System has brotli

--- a/CMake/FindBrotli.cmake
+++ b/CMake/FindBrotli.cmake
@@ -29,7 +29,7 @@
 # BROTLICOMMON_LIBRARY Path to brotlicommon library
 # BROTLIDEC_LIBRARY    Path to brotlidec library
 #
-# Result Variables:
+# Result variables:
 #
 # BROTLI_FOUND         System has brotli
 # BROTLI_INCLUDE_DIRS  The brotli include directories

--- a/CMake/FindCARES.cmake
+++ b/CMake/FindCARES.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the c-ares library
 #
+# Input variables:
+#
+# CARES_INCLUDE_DIR   The c-ares include directory
+# CARES_LIBRARY       Path to c-ares library
+#
 # Result Variables:
 #
 # CARES_FOUND         System has c-ares

--- a/CMake/FindCARES.cmake
+++ b/CMake/FindCARES.cmake
@@ -28,7 +28,7 @@
 # CARES_INCLUDE_DIR   The c-ares include directory
 # CARES_LIBRARY       Path to c-ares library
 #
-# Result Variables:
+# Result variables:
 #
 # CARES_FOUND         System has c-ares
 # CARES_INCLUDE_DIRS  The c-ares include directories

--- a/CMake/FindCARES.cmake
+++ b/CMake/FindCARES.cmake
@@ -35,7 +35,7 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_CARES "libcares")
 endif()
 
-find_path(CARES_INCLUDE_DIR "ares.h"
+find_path(CARES_INCLUDE_DIR NAMES "ares.h"
   HINTS
     ${PC_CARES_INCLUDEDIR}
     ${PC_CARES_INCLUDE_DIRS}

--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -27,7 +27,7 @@
 #
 # GSS_ROOT_DIR          Set this variable to the root installation of GSS
 #
-# Result Variables:
+# Result variables:
 #
 # GSS_FOUND             System has the Heimdal library
 # GSS_FLAVOUR           "MIT" or "Heimdal" if anything found

--- a/CMake/FindLibPSL.cmake
+++ b/CMake/FindLibPSL.cmake
@@ -28,7 +28,7 @@
 # LIBPSL_INCLUDE_DIR   The libpsl include directory
 # LIBPSL_LIBRARY       Path to libpsl library
 #
-# Result Variables:
+# Result variables:
 #
 # LIBPSL_FOUND         System has libpsl
 # LIBPSL_INCLUDE_DIRS  The libpsl include directories

--- a/CMake/FindLibPSL.cmake
+++ b/CMake/FindLibPSL.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the libpsl library
 #
+# Input variables:
+#
+# LIBPSL_INCLUDE_DIR   The libpsl include directory
+# LIBPSL_LIBRARY       Path to libpsl library
+#
 # Result Variables:
 #
 # LIBPSL_FOUND         System has libpsl

--- a/CMake/FindLibPSL.cmake
+++ b/CMake/FindLibPSL.cmake
@@ -35,7 +35,7 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_LIBPSL "libpsl")
 endif()
 
-find_path(LIBPSL_INCLUDE_DIR "libpsl.h"
+find_path(LIBPSL_INCLUDE_DIR NAMES "libpsl.h"
   HINTS
     ${PC_LIBPSL_INCLUDEDIR}
     ${PC_LIBPSL_INCLUDE_DIRS}

--- a/CMake/FindLibSSH2.cmake
+++ b/CMake/FindLibSSH2.cmake
@@ -35,7 +35,7 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_LIBSSH2 "libssh2")
 endif()
 
-find_path(LIBSSH2_INCLUDE_DIR "libssh2.h"
+find_path(LIBSSH2_INCLUDE_DIR NAMES "libssh2.h"
   HINTS
     ${PC_LIBSSH2_INCLUDEDIR}
     ${PC_LIBSSH2_INCLUDE_DIRS}

--- a/CMake/FindLibSSH2.cmake
+++ b/CMake/FindLibSSH2.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the libssh2 library
 #
+# Input variables:
+#
+# LIBSSH2_INCLUDE_DIR   The libssh2 include directory
+# LIBSSH2_LIBRARY       Path to libssh2 library
+#
 # Result Variables:
 #
 # LIBSSH2_FOUND         System has libssh2

--- a/CMake/FindLibSSH2.cmake
+++ b/CMake/FindLibSSH2.cmake
@@ -28,7 +28,7 @@
 # LIBSSH2_INCLUDE_DIR   The libssh2 include directory
 # LIBSSH2_LIBRARY       Path to libssh2 library
 #
-# Result Variables:
+# Result variables:
 #
 # LIBSSH2_FOUND         System has libssh2
 # LIBSSH2_INCLUDE_DIRS  The libssh2 include directories

--- a/CMake/FindMSH3.cmake
+++ b/CMake/FindMSH3.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the msh3 library
 #
+# Input variables:
+#
+# MSH3_INCLUDE_DIR   The msh3 include directory
+# MSH3_LIBRARY       Path to msh3 library
+#
 # Result Variables:
 #
 # MSH3_FOUND         System has msh3

--- a/CMake/FindMSH3.cmake
+++ b/CMake/FindMSH3.cmake
@@ -28,7 +28,7 @@
 # MSH3_INCLUDE_DIR   The msh3 include directory
 # MSH3_LIBRARY       Path to msh3 library
 #
-# Result Variables:
+# Result variables:
 #
 # MSH3_FOUND         System has msh3
 # MSH3_INCLUDE_DIRS  The msh3 include directories

--- a/CMake/FindMSH3.cmake
+++ b/CMake/FindMSH3.cmake
@@ -35,7 +35,7 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_MSH3 "libmsh3")
 endif()
 
-find_path(MSH3_INCLUDE_DIR "msh3.h"
+find_path(MSH3_INCLUDE_DIR NAMES "msh3.h"
   HINTS
     ${PC_MSH3_INCLUDEDIR}
     ${PC_MSH3_INCLUDE_DIRS}

--- a/CMake/FindMbedTLS.cmake
+++ b/CMake/FindMbedTLS.cmake
@@ -26,11 +26,10 @@
 # Input variables:
 #
 # MBEDTLS_INCLUDE_DIR   The mbedtls include directory
+# MBEDTLS_INCLUDE_DIRS  The mbedtls include directory (deprecated)
 # MBEDTLS_LIBRARY       Path to mbedtls library
 # MBEDX509_LIBRARY      Path to mbedx509 library
 # MBEDCRYPTO_LIBRARY    Path to mbedcrypto library
-#
-# MBEDTLS_INCLUDE_DIRS  The mbedtls include directory (deprecated)
 #
 # Result Variables:
 #

--- a/CMake/FindMbedTLS.cmake
+++ b/CMake/FindMbedTLS.cmake
@@ -31,7 +31,7 @@
 # MBEDX509_LIBRARY      Path to mbedx509 library
 # MBEDCRYPTO_LIBRARY    Path to mbedcrypto library
 #
-# Result Variables:
+# Result variables:
 #
 # MBEDTLS_FOUND         System has mbedtls
 # MBEDTLS_INCLUDE_DIRS  The mbedtls include directories

--- a/CMake/FindMbedTLS.cmake
+++ b/CMake/FindMbedTLS.cmake
@@ -30,6 +30,8 @@
 # MBEDX509_LIBRARY      Path to mbedx509 library
 # MBEDCRYPTO_LIBRARY    Path to mbedcrypto library
 #
+# MBEDTLS_INCLUDE_DIRS  The mbedtls include directory (deprecated)
+#
 # Result Variables:
 #
 # MBEDTLS_FOUND         System has mbedtls

--- a/CMake/FindMbedTLS.cmake
+++ b/CMake/FindMbedTLS.cmake
@@ -41,23 +41,23 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_MBEDTLS "mbedtls")
 endif()
 
-find_path(MBEDTLS_INCLUDE_DIR "mbedtls/ssl.h"
+find_path(MBEDTLS_INCLUDE_DIR NAMES "mbedtls/ssl.h"
   HINTS
     ${PC_MBEDTLS_INCLUDEDIR}
     ${PC_MBEDTLS_INCLUDE_DIRS}
 )
 
-find_library(MBEDTLS_LIBRARY "mbedtls"
+find_library(MBEDTLS_LIBRARY NAMES "mbedtls"
   HINTS
     ${PC_MBEDTLS_LIBDIR}
     ${PC_MBEDTLS_LIBRARY_DIRS}
 )
-find_library(MBEDX509_LIBRARY "mbedx509"
+find_library(MBEDX509_LIBRARY NAMES "mbedx509"
   HINTS
     ${PC_MBEDTLS_LIBDIR}
     ${PC_MBEDTLS_LIBRARY_DIRS}
 )
-find_library(MBEDCRYPTO_LIBRARY "mbedcrypto"
+find_library(MBEDCRYPTO_LIBRARY NAMES "mbedcrypto"
   HINTS
     ${PC_MBEDTLS_LIBDIR}
     ${PC_MBEDTLS_LIBRARY_DIRS}

--- a/CMake/FindMbedTLS.cmake
+++ b/CMake/FindMbedTLS.cmake
@@ -23,6 +23,13 @@
 ###########################################################################
 # Find the mbedtls library
 #
+# Input variables:
+#
+# MBEDTLS_INCLUDE_DIR   The mbedtls include directory
+# MBEDTLS_LIBRARY       Path to mbedtls library
+# MBEDX509_LIBRARY      Path to mbedx509 library
+# MBEDCRYPTO_LIBRARY    Path to mbedcrypto library
+#
 # Result Variables:
 #
 # MBEDTLS_FOUND         System has mbedtls

--- a/CMake/FindNGHTTP2.cmake
+++ b/CMake/FindNGHTTP2.cmake
@@ -28,7 +28,7 @@
 # NGHTTP2_INCLUDE_DIR   The nghttp2 include directory
 # NGHTTP2_LIBRARY       Path to nghttp2 library
 #
-# Result Variables:
+# Result variables:
 #
 # NGHTTP2_FOUND         System has nghttp2
 # NGHTTP2_INCLUDE_DIRS  The nghttp2 include directories

--- a/CMake/FindNGHTTP2.cmake
+++ b/CMake/FindNGHTTP2.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the nghttp2 library
 #
+# Input variables:
+#
+# NGHTTP2_INCLUDE_DIR   The nghttp2 include directory
+# NGHTTP2_LIBRARY       Path to nghttp2 library
+#
 # Result Variables:
 #
 # NGHTTP2_FOUND         System has nghttp2

--- a/CMake/FindNGHTTP2.cmake
+++ b/CMake/FindNGHTTP2.cmake
@@ -35,7 +35,7 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_NGHTTP2 "libnghttp2")
 endif()
 
-find_path(NGHTTP2_INCLUDE_DIR "nghttp2/nghttp2.h"
+find_path(NGHTTP2_INCLUDE_DIR NAMES "nghttp2/nghttp2.h"
   HINTS
     ${PC_NGHTTP2_INCLUDEDIR}
     ${PC_NGHTTP2_INCLUDE_DIRS}

--- a/CMake/FindNGHTTP3.cmake
+++ b/CMake/FindNGHTTP3.cmake
@@ -28,7 +28,7 @@
 # NGHTTP3_INCLUDE_DIR   The nghttp3 include directory
 # NGHTTP3_LIBRARY       Path to nghttp3 library
 #
-# Result Variables:
+# Result variables:
 #
 # NGHTTP3_FOUND         System has nghttp3
 # NGHTTP3_INCLUDE_DIRS  The nghttp3 include directories

--- a/CMake/FindNGHTTP3.cmake
+++ b/CMake/FindNGHTTP3.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the nghttp3 library
 #
+# Input variables:
+#
+# NGHTTP3_INCLUDE_DIR   The nghttp3 include directory
+# NGHTTP3_LIBRARY       Path to nghttp3 library
+#
 # Result Variables:
 #
 # NGHTTP3_FOUND         System has nghttp3

--- a/CMake/FindNGHTTP3.cmake
+++ b/CMake/FindNGHTTP3.cmake
@@ -35,7 +35,7 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_NGHTTP3 "libnghttp3")
 endif()
 
-find_path(NGHTTP3_INCLUDE_DIR "nghttp3/nghttp3.h"
+find_path(NGHTTP3_INCLUDE_DIR NAMES "nghttp3/nghttp3.h"
   HINTS
     ${PC_NGHTTP3_INCLUDEDIR}
     ${PC_NGHTTP3_INCLUDE_DIRS}

--- a/CMake/FindNGTCP2.cmake
+++ b/CMake/FindNGTCP2.cmake
@@ -43,7 +43,7 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_NGTCP2 "libngtcp2")
 endif()
 
-find_path(NGTCP2_INCLUDE_DIR "ngtcp2/ngtcp2.h"
+find_path(NGTCP2_INCLUDE_DIR NAMES "ngtcp2/ngtcp2.h"
   HINTS
     ${PC_NGTCP2_INCLUDEDIR}
     ${PC_NGTCP2_INCLUDE_DIRS}

--- a/CMake/FindNGTCP2.cmake
+++ b/CMake/FindNGTCP2.cmake
@@ -36,7 +36,7 @@
 # NGTCP2_INCLUDE_DIR   The ngtcp2 include directory
 # NGTCP2_LIBRARY       Path to ngtcp2 library
 #
-# Result Variables:
+# Result variables:
 #
 # NGTCP2_FOUND         System has ngtcp2
 # NGTCP2_INCLUDE_DIRS  The ngtcp2 include directories

--- a/CMake/FindNGTCP2.cmake
+++ b/CMake/FindNGTCP2.cmake
@@ -31,6 +31,11 @@
 # wolfSSL:    Use libngtcp2_crypto_wolfssl
 # GnuTLS:     Use libngtcp2_crypto_gnutls
 #
+# Input variables:
+#
+# NGTCP2_INCLUDE_DIR   The ngtcp2 include directory
+# NGTCP2_LIBRARY       Path to ngtcp2 library
+#
 # Result Variables:
 #
 # NGTCP2_FOUND         System has ngtcp2

--- a/CMake/FindNettle.cmake
+++ b/CMake/FindNettle.cmake
@@ -28,7 +28,7 @@
 # NETTLE_INCLUDE_DIR   The nettle include directory
 # NETTLE_LIBRARY       Path to nettle library
 #
-# Result Variables:
+# Result variables:
 #
 # NETTLE_FOUND         System has nettle
 # NETTLE_INCLUDE_DIRS  The nettle include directories

--- a/CMake/FindNettle.cmake
+++ b/CMake/FindNettle.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the nettle library
 #
+# Input variables (when CURL_USE_PKGCONFIG=OFF):
+#
+# NETTLE_INCLUDE_DIR   The nettle include directory
+# NETTLE_LIBRARY       Path to nettle library
+#
 # Result Variables:
 #
 # NETTLE_FOUND         System has nettle

--- a/CMake/FindQUICHE.cmake
+++ b/CMake/FindQUICHE.cmake
@@ -28,7 +28,7 @@
 # QUICHE_INCLUDE_DIR   The quiche include directory
 # QUICHE_LIBRARY       Path to quiche library
 #
-# Result Variables:
+# Result variables:
 #
 # QUICHE_FOUND         System has quiche
 # QUICHE_INCLUDE_DIRS  The quiche include directories

--- a/CMake/FindQUICHE.cmake
+++ b/CMake/FindQUICHE.cmake
@@ -35,7 +35,7 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_QUICHE "quiche")
 endif()
 
-find_path(QUICHE_INCLUDE_DIR "quiche.h"
+find_path(QUICHE_INCLUDE_DIR NAMES "quiche.h"
   HINTS
     ${PC_QUICHE_INCLUDEDIR}
     ${PC_QUICHE_INCLUDE_DIRS}

--- a/CMake/FindQUICHE.cmake
+++ b/CMake/FindQUICHE.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the quiche library
 #
+# Input variables:
+#
+# QUICHE_INCLUDE_DIR   The quiche include directory
+# QUICHE_LIBRARY       Path to quiche library
+#
 # Result Variables:
 #
 # QUICHE_FOUND         System has quiche

--- a/CMake/FindWolfSSH.cmake
+++ b/CMake/FindWolfSSH.cmake
@@ -30,7 +30,7 @@
 # WOLFSSH_LIBRARIES     The wolfssh library names
 # WOLFSSH_VERSION       Version of wolfssh
 
-find_path(WOLFSSH_INCLUDE_DIR "wolfssh/ssh.h")
+find_path(WOLFSSH_INCLUDE_DIR NAMES "wolfssh/ssh.h")
 find_library(WOLFSSH_LIBRARY NAMES "wolfssh" "libwolfssh")
 
 if(WOLFSSH_INCLUDE_DIR AND EXISTS "${WOLFSSH_INCLUDE_DIR}/wolfssh/version.h")

--- a/CMake/FindWolfSSH.cmake
+++ b/CMake/FindWolfSSH.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the wolfssh library
 #
+# Input variables:
+#
+# WOLFSSH_INCLUDE_DIR   The wolfssh include directory
+# WOLFSSH_LIBRARY       Path to wolfssh library
+#
 # Result Variables:
 #
 # WOLFSSH_FOUND         System has wolfssh

--- a/CMake/FindWolfSSH.cmake
+++ b/CMake/FindWolfSSH.cmake
@@ -28,7 +28,7 @@
 # WOLFSSH_INCLUDE_DIR   The wolfssh include directory
 # WOLFSSH_LIBRARY       Path to wolfssh library
 #
-# Result Variables:
+# Result variables:
 #
 # WOLFSSH_FOUND         System has wolfssh
 # WOLFSSH_INCLUDE_DIRS  The wolfssh include directories

--- a/CMake/FindWolfSSL.cmake
+++ b/CMake/FindWolfSSL.cmake
@@ -30,7 +30,7 @@
 # WOLFSSL_LIBRARY       Path to wolfssl library
 # WolfSSL_LIBRARY       Path to wolfssl library (deprecated)
 #
-# Result Variables:
+# Result variables:
 #
 # WOLFSSL_FOUND         System has wolfssl
 # WOLFSSL_INCLUDE_DIRS  The wolfssl include directories

--- a/CMake/FindWolfSSL.cmake
+++ b/CMake/FindWolfSSL.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the wolfssl library
 #
+# Input variables:
+#
+# WOLFSSL_INCLUDE_DIR   The wolfssl include directory
+# WOLFSSL_LIBRARY       Path to wolfssl library
+#
 # Result Variables:
 #
 # WOLFSSL_FOUND         System has wolfssl

--- a/CMake/FindWolfSSL.cmake
+++ b/CMake/FindWolfSSL.cmake
@@ -28,6 +28,9 @@
 # WOLFSSL_INCLUDE_DIR   The wolfssl include directory
 # WOLFSSL_LIBRARY       Path to wolfssl library
 #
+# WolfSSL_INCLUDE_DIR   The wolfssl include directory (deprecated)
+# WolfSSL_LIBRARY       Path to wolfssl library (deprecated)
+#
 # Result Variables:
 #
 # WOLFSSL_FOUND         System has wolfssl

--- a/CMake/FindWolfSSL.cmake
+++ b/CMake/FindWolfSSL.cmake
@@ -48,7 +48,7 @@ endif()
 
 if(CURL_USE_PKGCONFIG)
   find_package(PkgConfig QUIET)
-  pkg_check_modules(PC_WOLFSSL QUIET "wolfssl")
+  pkg_check_modules(PC_WOLFSSL "wolfssl")
 endif()
 
 find_path(WOLFSSL_INCLUDE_DIR NAMES "wolfssl/ssl.h"

--- a/CMake/FindWolfSSL.cmake
+++ b/CMake/FindWolfSSL.cmake
@@ -26,9 +26,8 @@
 # Input variables:
 #
 # WOLFSSL_INCLUDE_DIR   The wolfssl include directory
-# WOLFSSL_LIBRARY       Path to wolfssl library
-#
 # WolfSSL_INCLUDE_DIR   The wolfssl include directory (deprecated)
+# WOLFSSL_LIBRARY       Path to wolfssl library
 # WolfSSL_LIBRARY       Path to wolfssl library (deprecated)
 #
 # Result Variables:

--- a/CMake/FindZstd.cmake
+++ b/CMake/FindZstd.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the zstd library
 #
+# Input variables:
+#
+# ZSTD_INCLUDE_DIR   The zstd include directory
+# ZSTD_LIBRARY       Path to zstd library
+#
 # Result Variables:
 #
 # ZSTD_FOUND         System has zstd

--- a/CMake/FindZstd.cmake
+++ b/CMake/FindZstd.cmake
@@ -28,6 +28,9 @@
 # ZSTD_INCLUDE_DIR   The zstd include directory
 # ZSTD_LIBRARY       Path to zstd library
 #
+# Zstd_INCLUDE_DIR   The zstd include directory (deprecated)
+# Zstd_LIBRARY       Path to zstd library (deprecated)
+#
 # Result Variables:
 #
 # ZSTD_FOUND         System has zstd

--- a/CMake/FindZstd.cmake
+++ b/CMake/FindZstd.cmake
@@ -44,7 +44,7 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_ZSTD "libzstd")
 endif()
 
-find_path(ZSTD_INCLUDE_DIR "zstd.h"
+find_path(ZSTD_INCLUDE_DIR NAMES "zstd.h"
   HINTS
     ${PC_ZSTD_INCLUDEDIR}
     ${PC_ZSTD_INCLUDE_DIRS}

--- a/CMake/FindZstd.cmake
+++ b/CMake/FindZstd.cmake
@@ -26,9 +26,8 @@
 # Input variables:
 #
 # ZSTD_INCLUDE_DIR   The zstd include directory
-# ZSTD_LIBRARY       Path to zstd library
-#
 # Zstd_INCLUDE_DIR   The zstd include directory (deprecated)
+# ZSTD_LIBRARY       Path to zstd library
 # Zstd_LIBRARY       Path to zstd library (deprecated)
 #
 # Result Variables:

--- a/CMake/FindZstd.cmake
+++ b/CMake/FindZstd.cmake
@@ -30,7 +30,7 @@
 # ZSTD_LIBRARY       Path to zstd library
 # Zstd_LIBRARY       Path to zstd library (deprecated)
 #
-# Result Variables:
+# Result variables:
 #
 # ZSTD_FOUND         System has zstd
 # ZSTD_INCLUDE_DIRS  The zstd include directories

--- a/CMake/Findrustls.cmake
+++ b/CMake/Findrustls.cmake
@@ -35,13 +35,13 @@ if(CURL_USE_PKGCONFIG)
   pkg_check_modules(PC_RUSTLS "rustls")
 endif()
 
-find_path(RUSTLS_INCLUDE_DIR "rustls.h"
+find_path(RUSTLS_INCLUDE_DIR NAMES "rustls.h"
   HINTS
     ${PC_RUSTLS_INCLUDEDIR}
     ${PC_RUSTLS_INCLUDE_DIRS}
 )
 
-find_library(RUSTLS_LIBRARY "rustls"
+find_library(RUSTLS_LIBRARY NAMES "rustls"
   HINTS
     ${PC_RUSTLS_LIBDIR}
     ${PC_RUSTLS_LIBRARY_DIRS}

--- a/CMake/Findrustls.cmake
+++ b/CMake/Findrustls.cmake
@@ -23,6 +23,11 @@
 ###########################################################################
 # Find the rustls library
 #
+# Input variables:
+#
+# RUSTLS_INCLUDE_DIR   The rustls include directory
+# RUSTLS_LIBRARY       Path to rustls library
+#
 # Result Variables:
 #
 # RUSTLS_FOUND         System has rustls

--- a/CMake/Findrustls.cmake
+++ b/CMake/Findrustls.cmake
@@ -28,7 +28,7 @@
 # RUSTLS_INCLUDE_DIR   The rustls include directory
 # RUSTLS_LIBRARY       Path to rustls library
 #
-# Result Variables:
+# Result variables:
 #
 # RUSTLS_FOUND         System has rustls
 # RUSTLS_INCLUDE_DIRS  The rustls include directories


### PR DESCRIPTION
- add `NAMES` where missing.
- document input variables (including deprecated ones.)
- comment cleanups.
- FindWolfSSL: drop stray `QUIET` from `pkg_check_modules()`.
  (`QUIET` may be re-added for all modules in the future.)

---

- [x] move `cmakelint` fixes to separate PR. → #14583
- [ ] move `FindNettle` behaviour updates to separate PR.

w/o whitespace: https://github.com/curl/curl/pull/14579/files?w=1
