### PR TITLE
appveyor: drop uploading artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -211,8 +211,8 @@ skip_commits:
     - 'packages/**/*'
     - 'plan9/**/*'
 
-artifacts:
-  - path: '**/curl.exe'
-    name: curl
-  - path: '**/*curl*.dll'
-    name: libcurl dll
+#artifacts:
+#  - path: '**/curl.exe'
+#    name: curl
+#  - path: '**/*curl*.dll'
+#    name: libcurl dll


### PR DESCRIPTION
Uploading artifacts sometimes results in this error:
```
Uploading artifacts...
[1/1] _bld\src\curl.exe (2,022,912 bytes)...100%
Error uploading artifact to the storage: Remote server returned 503: Service Temporarily Unavailable
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/50424126/job/e4envval6xkicv1i#L123

The artifacts are also probably not very useful to upload for every run.
Let me know if they are or if there is a better solution to the
intermittent failures. Also note that they were missing external DLL
dependencies.

Leave the logic there commented, to make it easy to enable as needed for
debugging or testing artifacts locally.
