### PR TITLE
tests: improve test_17_07_ssl_ciphers

### DIFF
--- a/tests/http/test_18_methods.py
+++ b/tests/http/test_18_methods.py
@@ -44,10 +44,7 @@ class TestMethods:
         if env.have_h3():
             nghttpx.start_if_needed()
         httpd.clear_extra_configs()
-        httpd.reload()
-
-    @pytest.fixture(autouse=True, scope='class')
-    def _class_scope(self, env, httpd):
+        httpd.reload_if_config_changed()
         indir = httpd.docs_dir
         env.make_data_file(indir=indir, fname="data-10k", fsize=10*1024)
         env.make_data_file(indir=indir, fname="data-100k", fsize=100*1024)


### PR DESCRIPTION
Change TLS proto version on the test server to test setting combinations of --tls13-ciphers and --ciphers.

Overloading of autouse fixtures does not seem to work. For the test httpd server to be reloaded with a clean config in test_18_methods, to not be affected by the config changes in test_17_ssl_use, the two class scope fixtures of test_18_methods are now combined.

Added return value to set_extra_config and clear_extra_configs to indicate changes, making it possible to prevent unnecessarily reloading of the test httpd server.