### PR TITLE
CI/azure: disable parallel tests, allow IDN tests

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -244,4 +244,4 @@ stages:
             displayName: 'test'
             env:
               AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-              TFLAGS: "-j0 -ac /usr/bin/curl.exe !IDN !SCP ~612 $(tests)"
+              TFLAGS: "-j0 -ac /usr/bin/curl.exe !SCP ~612 $(tests)"

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -112,7 +112,7 @@ stages:
             displayName: 'test'
             env:
               AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-              TFLAGS: "-ac /usr/bin/curl -r $(tests)"
+              TFLAGS: "-j0 -ac /usr/bin/curl -r $(tests)"
 
   - stage: scanbuild
     dependsOn: []
@@ -244,4 +244,4 @@ stages:
             displayName: 'test'
             env:
               AZURE_ACCESS_TOKEN: "$(System.AccessToken)"
-              TFLAGS: "-ac /usr/bin/curl.exe !IDN !SCP ~612 $(tests)"
+              TFLAGS: "-j0 -ac /usr/bin/curl.exe !IDN !SCP ~612 $(tests)"


### PR DESCRIPTION
They started show the similar flakiness as the GHA ones after enabling
parallel tests (`-j2`) by default.

Example flaky run:
https://dev.azure.com/daniel0244/curl/_build/results?buildId=24763&view=results

Ubuntu:
```
FAIL 137: 'FTP download without size in RETR string' FTP, RETR, --data-binary
FAIL 336: 'FTP range download when SIZE doesn't work' FTP, PASV, TYPE A, RETR
FAIL 975: 'HTTP with auth redirected to FTP allowing auth to continue' HTTP, FTP, --location-trusted
FAIL 1378: 'FTP DL, file without Content-Disposition inside, using -o fname' FTP, RETR
```

MSYS2 mingw32:
```
FAIL 1501: 'FTP with multi interface and slow LIST response' FTP, RETR, multi, LIST, DELAY
```

MSYS2 mingw64:
```
FAIL 1501: 'FTP with multi interface and slow LIST response' FTP, RETR, multi, LIST, DELAY
```

Follow-up to 0324d557e4b4f754ea89636ea9164065f6446560 #11510
