### PR TITLE
cmake: adjust GSSAPI option description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1131,7 +1131,7 @@ if(CURL_USE_GSASL)
   endif()
 endif()
 
-option(CURL_USE_GSSAPI "Use GSSAPI implementation (right now only Heimdal is supported with CMake build)" OFF)
+option(CURL_USE_GSSAPI "Use GSSAPI implementation" OFF)
 mark_as_advanced(CURL_USE_GSSAPI)
 
 if(CURL_USE_GSSAPI)


### PR DESCRIPTION
krb5 also builds with CMake, not only Heimdal.

Ref: 558814e16d84aa202c5ccc0c8108a9d728e77a58