### PR TITLE
build: use -Wno-format-overflow

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -206,7 +206,7 @@ if(PICKY_COMPILER)
         list(APPEND WPICKY_ENABLE
           -Walloc-zero                     #             gcc  7.0
           -Wduplicated-branches            #             gcc  7.0
-          -Wformat-overflow=2              #             gcc  7.0
+          -Wno-format-overflow             #             gcc  7.0
           -Wformat-truncation=2            #             gcc  7.0
           -Wimplicit-fallthrough           # clang  4.0  gcc  7.0
           -Wrestrict                       #             gcc  7.0

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1068,7 +1068,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [duplicated-branches])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [restrict])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [alloc-zero])
-            tmp_CFLAGS="$tmp_CFLAGS -Wformat-overflow=2"
+            tmp_CFLAGS="$tmp_CFLAGS -Wno-format-overflow"
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-truncation=2"
             tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"
           fi


### PR DESCRIPTION
-Wformat-overflow is not a warning that we want enabled as it does not help us. It can only bring us false positives since it warns on bad uses of sprintf and vsprintf ("that might overflow the destination buffer"). Two functions we explicitly ban in curl code.

The only way this flag triggers warnings in curl code is false positives for functions we have marked with the CURL_PRINTF() macro.

Further: it seems -Wformat-trunaction option might in turn also enable -Wformat-overflow, so if this second option is used, we need to explicitly set -Wno-format-overflow - not just skip setting -Wformat-overflow.

Reported-by: Viktor Szakats
Fixes #14168