### PR TITLE
curl: find curlrc in XDG_CONFIG_HOME without leading dot

### DIFF
--- a/src/tool_findfile.c
+++ b/src/tool_findfile.c
@@ -51,7 +51,7 @@ struct finder {
    in the findfile() function */
 static const struct finder conf_list[] = {
   { "CURL_HOME", NULL, FALSE },
-  { "XDG_CONFIG_HOME", NULL, FALSE }, /* index == 1, used in the code */
+  { "XDG_CONFIG_HOME", NULL, TRUE },
   { "HOME", NULL, FALSE },
 #ifdef _WIN32
   { "USERPROFILE", NULL, FALSE },
@@ -102,7 +102,6 @@ static char *checkhome(const char *home, const char *fname, bool dotscore)
 char *findfile(const char *fname, int dotscore)
 {
   int i;
-  bool xdg = FALSE;
   DEBUGASSERT(fname && fname[0]);
   DEBUGASSERT((dotscore != 1) || (fname[0] == '.'));
 
@@ -114,8 +113,6 @@ char *findfile(const char *fname, int dotscore)
     if(home) {
       char *path;
       const char *filename = fname;
-      if(i == 1 /* XDG_CONFIG_HOME */)
-        xdg = TRUE;
       if(!home[0]) {
         curl_free(home);
         continue;
@@ -128,7 +125,7 @@ char *findfile(const char *fname, int dotscore)
         home = c;
       }
       if(conf_list[i].withoutdot) {
-        if(!dotscore || xdg) {
+        if(!dotscore) {
           /* this is not looking for .curlrc, or the XDG_CONFIG_HOME was
              defined so we skip the extended check */
           curl_free(home);

--- a/tests/data/test433
+++ b/tests/data/test433
@@ -20,7 +20,7 @@ Content-Type: text/1
 #
 # Client-side
 <client>
-<file1 name="%LOGDIR/.curlrc">
+<file1 name="%LOGDIR/curlrc">
 --next
 header = "a: a"
 data = "curlrc read"
@@ -34,7 +34,7 @@ HOME=
 CURL_HOME=
 </setenv>
 <name>
-Verify XDG_CONFIG_HOME use to find .curlrc
+Verify XDG_CONFIG_HOME use to find curlrc
 </name>
 <command option="no-q">
 %HOSTIP:%HTTPPORT/%TESTNUMBER


### PR DESCRIPTION
If XDG_CONFIG_HOME is set, look for XDG_CONFIG_HOME/curlrc - without a leading dot in the filename.

Fixes #12129
Reported-by: Jat Satiro