### PR TITLE
ssh: deduplicate SSH backend includes (and fix libssh cmake unity build)

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -31,11 +31,6 @@
 
 #include <limits.h>
 
-/* in 0.10.0 or later, ignore deprecated warnings */
-#define SSH_SUPPRESS_DEPRECATED
-#include <libssh/libssh.h>
-#include <libssh/sftp.h>
-
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -30,9 +30,6 @@
 
 #include <limits.h>
 
-#include <libssh2.h>
-#include <libssh2_sftp.h>
-
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -30,6 +30,8 @@
 #include <libssh2.h>
 #include <libssh2_sftp.h>
 #elif defined(USE_LIBSSH)
+/* in 0.10.0 or later, ignore deprecated warnings */
+#define SSH_SUPPRESS_DEPRECATED
 #include <libssh/libssh.h>
 #include <libssh/sftp.h>
 #elif defined(USE_WOLFSSH)

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -28,8 +28,6 @@
 
 #include <limits.h>
 
-#include <wolfssh/ssh.h>
-#include <wolfssh/wolfsftp.h>
 #include "urldata.h"
 #include "cfilters.h"
 #include "connect.h"


### PR DESCRIPTION
For libssh, it fixes a "unity" build issue where libssh deprecation
warnings were not suppressed before this patch, because the suppression
macro was only set before just one of the two `libssh.h` includes.
If the other was compiled first in unity mode, the warnings appeared.

Seen in local curl-for-win build (`CW_CONFIG=test-x64-libssh-quictls`)
with libssh 0.11.0. (Also in a GHA/macos cmake job upcoming in #14614)

Use this opportunity to drop duplicate SSH header includes from the SSH
modules. It's enough to include them via the common `ssh.h` header.
