### PR TITLE
version: fix shadowing a `libssh.h` symbol

### DIFF
--- a/lib/version.c
+++ b/lib/version.c
@@ -581,7 +581,7 @@ curl_version_info_data *curl_version_info(CURLversion stamp)
   int features = 0;
 
 #if defined(USE_SSH)
-  static char ssh_buffer[80];
+  static char ssh_buf[80];  /* 'ssh_buffer' clashes with libssh/libssh.h */
 #endif
 #ifdef USE_SSL
 #ifdef CURL_WITH_MULTI_SSL
@@ -622,8 +622,8 @@ curl_version_info_data *curl_version_info(CURLversion stamp)
 #endif
 
 #if defined(USE_SSH)
-  Curl_ssh_version(ssh_buffer, sizeof(ssh_buffer));
-  version_info.libssh_version = ssh_buffer;
+  Curl_ssh_version(ssh_buf, sizeof(ssh_buf));
+  version_info.libssh_version = ssh_buf;
 #endif
 
 #ifdef HAVE_BROTLI


### PR DESCRIPTION
```
/Users/runner/work/curl/curl/lib/version.c: In function 'curl_version_info':
/Users/runner/work/curl/curl/lib/version.c:584:15: error: declaration of 'ssh_buffer' shadows a global declaration [-Werror=shadow]
  584 |   static char ssh_buffer[80];
      |               ^~~~~~~~~~
In file included from /Users/runner/work/curl/curl/lib/vssh/ssh.h:35,
                 from /Users/runner/work/curl/curl/lib/urldata.h:185,
                 from /Users/runner/work/curl/curl/lib/altsvc.c:32,
                 from /Users/runner/work/curl/curl/bld/lib/CMakeFiles/libcurl_shared.dir/Unity/unity_0_c.c:4:
/opt/homebrew/include/libssh/libssh.h:99:35: note: shadowed declaration is here
   99 | typedef struct ssh_buffer_struct* ssh_buffer;
      |                                   ^~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/10477958747/job/29020250670#step:9:48

Tested via #14614