### PR TITLE
build: add `iphlpapi` lib for libssh on Windows

### DIFF
--- a/CMake/FindLibssh.cmake
+++ b/CMake/FindLibssh.cmake
@@ -88,6 +88,6 @@ else()
   mark_as_advanced(LIBSSH_INCLUDE_DIR LIBSSH_LIBRARY)
 endif()
 
-if(WIN32)
+if(LIBSSH_FOUND AND WIN32)
   list(APPEND LIBSSH_LIBRARIES "iphlpapi")  # for if_nametoindex
 endif()

--- a/CMake/FindLibssh.cmake
+++ b/CMake/FindLibssh.cmake
@@ -87,3 +87,7 @@ else()
 
   mark_as_advanced(LIBSSH_INCLUDE_DIR LIBSSH_LIBRARY)
 endif()
+
+if(WIN32)
+  list(APPEND LIBSSH_LIBRARIES "iphlpapi")  # for if_nametoindex
+endif()

--- a/configure.ac
+++ b/configure.ac
@@ -2348,6 +2348,10 @@ elif test X"$OPT_LIBSSH" != Xno; then
   fi
 
   if test "$LIBSSH_ENABLED" = "1"; then
+    if test "$curl_cv_native_windows" = "yes"; then
+      dnl for if_nametoindex
+      LIBS="-liphlpapi $LIBS"
+    fi
     if test -n "$DIR_SSH"; then
        dnl when the libssh shared libs were found in a path that the run-time
        dnl linker doesn't search through, we need to add it to CURL_LIBRARY_PATH


### PR DESCRIPTION
vcpkg doesn't need it because it fixes this with a libssh patch.
All other Windows builds need it.

(autotools build not tested.)
