### PR TITLE
buildconf.bat: fix tool_hugehelp.c generation

### DIFF
--- a/src/tool_hugehelp.c.cvs
+++ b/src/tool_hugehelp.c.cvs
@@ -30,8 +30,9 @@ void hugehelp(void)
   puts("built-in manual was disabled at build-time");
 }
 
-void showhelp(const char *arg, const char *endarg)
+void showhelp(const char *trigger, const char *arg, const char *endarg)
 {
+  (void)trigger;
   (void)arg;
   (void)endarg;
   hugehelp();


### PR DESCRIPTION
- Fix showhelp() function prototype in tool_hugehelp.c.cvs.

Follow-up to 9a0cf564 which added the function.

Closes #xxxx