### PR TITLE
http2: fix GOAWAY message sent to server

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -1186,7 +1186,8 @@ static CURLcode cf_h2_proxy_shutdown(struct Curl_cfilter *cf,
   if(!ctx->sent_goaway) {
     rv = nghttp2_submit_goaway(ctx->h2, NGHTTP2_FLAG_NONE,
                                0, 0,
-                               (const uint8_t *)"shutown", sizeof("shutown"));
+                               (const uint8_t *)"shutdown",
+                               sizeof("shutdown"));
     if(rv) {
       failf(data, "nghttp2_submit_goaway() failed: %s(%d)",
             nghttp2_strerror(rv), rv);

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2526,7 +2526,8 @@ static CURLcode cf_h2_shutdown(struct Curl_cfilter *cf,
   if(!ctx->sent_goaway) {
     rv = nghttp2_submit_goaway(ctx->h2, NGHTTP2_FLAG_NONE,
                                ctx->local_max_sid, 0,
-                               (const uint8_t *)"shutown", sizeof("shutown"));
+                               (const uint8_t *)"shutdown",
+                               sizeof("shutdown"));
     if(rv) {
       failf(data, "nghttp2_submit_goaway() failed: %s(%d)",
             nghttp2_strerror(rv), rv);


### PR DESCRIPTION
- fix typo in GOAWAY debug message "shutown" -> "shutdown"

Closes #xxxx

---

![shutown](https://github.com/user-attachments/assets/f3769abb-3ee3-4e0d-9a2f-d26d9d5846ad)
