### PR TITLE
cmake: honor custom `CMAKE_UNITY_BUILD_BATCH_SIZE`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,9 @@ endif()
 
 include_directories("${CURL_SOURCE_DIR}/include")
 
-set(CMAKE_UNITY_BUILD_BATCH_SIZE 0)
+if(NOT DEFINED CMAKE_UNITY_BUILD_BATCH_SIZE)
+  set(CMAKE_UNITY_BUILD_BATCH_SIZE 0)
+endif()
 
 option(CURL_WERROR "Turn compiler warnings into errors" OFF)
 option(PICKY_COMPILER "Enable picky compiler options" ON)


### PR DESCRIPTION
This value tells how many sources files to bundle in a single "unity"
compilation unit.

The CMake default is 8 sources, curl's CMake set this to 0, meaning
to bundle all sources into a single unit.

This patch makes it possible to override the 0 value, and potentially
optimize the build process further by better utilizing multiple cores
in conjunction with `make -jN`.

The number of sources in lib is 172 at the time of writing this. For
a 12-core CPU, this can give a job for them all:
`-DCMAKE_UNITY_BUILD_BATCH_SIZE=15`

(Compile time may be affected by a bunch of other factors.)
