### PR TITLE
setopt: allow CURLOPT_INTERFACE to be set to NULL

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -527,21 +527,21 @@ CURLcode Curl_parse_interface(const char *input,
   if(len > 512)
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
-  if(strncmp(if_prefix, input, strlen(if_prefix)) == 0) {
+  if(!strncmp(if_prefix, input, strlen(if_prefix))) {
     input += strlen(if_prefix);
     if(!*input)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     *iface = Curl_memdup0(input, len - strlen(if_prefix));
     return *iface ? CURLE_OK : CURLE_OUT_OF_MEMORY;
   }
-  if(strncmp(host_prefix, input, strlen(host_prefix)) == 0) {
+  else if(!strncmp(host_prefix, input, strlen(host_prefix))) {
     input += strlen(host_prefix);
     if(!*input)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     *host = Curl_memdup0(input, len - strlen(host_prefix));
     return *host ? CURLE_OK : CURLE_OUT_OF_MEMORY;
   }
-  if(strncmp(if_host_prefix, input, strlen(if_host_prefix)) == 0) {
+  else if(!strncmp(if_host_prefix, input, strlen(if_host_prefix))) {
     const char *host_part;
     input += strlen(if_host_prefix);
     len -= strlen(if_host_prefix);

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -511,16 +511,19 @@ void Curl_sndbuf_init(curl_socket_t sockfd)
  *
  * Returns CURLE_OK on success.
  */
-CURLcode Curl_parse_interface(const char *input, size_t len,
+CURLcode Curl_parse_interface(const char *input,
                               char **dev, char **iface, char **host)
 {
   static const char if_prefix[] = "if!";
   static const char host_prefix[] = "host!";
   static const char if_host_prefix[] = "ifhost!";
+  size_t len;
 
   DEBUGASSERT(dev);
   DEBUGASSERT(iface);
   DEBUGASSERT(host);
+
+  len = strlen(input);
 
   if(strncmp(if_prefix, input, strlen(if_prefix)) == 0) {
     input += strlen(if_prefix);

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -524,6 +524,8 @@ CURLcode Curl_parse_interface(const char *input,
   DEBUGASSERT(host);
 
   len = strlen(input);
+  if(len > 512)
+    return CURLE_BAD_FUNCTION_ARGUMENT;
 
   if(strncmp(if_prefix, input, strlen(if_prefix)) == 0) {
     input += strlen(if_prefix);

--- a/lib/cf-socket.h
+++ b/lib/cf-socket.h
@@ -57,7 +57,7 @@ struct Curl_sockaddr_ex {
 /*
  * Parse interface option, and return the interface name and the host part.
 */
-CURLcode Curl_parse_interface(const char *input, size_t len,
+CURLcode Curl_parse_interface(const char *input,
                               char **dev, char **iface, char **host);
 
 /*

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -139,30 +139,24 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
   return CURLE_OK;
 }
 
-static CURLcode setstropt_interface(
-  char *option, char **devp, char **ifacep, char **hostp)
+static CURLcode setstropt_interface(char *option, char **devp,
+                                    char **ifacep, char **hostp)
 {
   char *dev = NULL;
   char *iface = NULL;
   char *host = NULL;
-  size_t len;
   CURLcode result;
 
   DEBUGASSERT(devp);
   DEBUGASSERT(ifacep);
   DEBUGASSERT(hostp);
 
-  /* Parse the interface details */
-  if(!option || !*option)
-    return CURLE_BAD_FUNCTION_ARGUMENT;
-  len = strlen(option);
-  if(len > 255)
-    return CURLE_BAD_FUNCTION_ARGUMENT;
-
-  result = Curl_parse_interface(option, len, &dev, &iface, &host);
-  if(result)
-    return result;
-
+  if(option) {
+    /* Parse the interface details if set, otherwise clear them all */
+    result = Curl_parse_interface(option, &dev, &iface, &host);
+    if(result)
+      return result;
+  }
   free(*devp);
   *devp = dev;
 

--- a/tests/unit/unit1663.c
+++ b/tests/unit/unit1663.c
@@ -58,8 +58,7 @@ static void test_parse(
   char *dev = NULL;
   char *iface = NULL;
   char *host = NULL;
-  CURLcode rc = Curl_parse_interface(
-    input, strlen(input), &dev, &iface, &host);
+  CURLcode rc = Curl_parse_interface(input, &dev, &iface, &host);
   fail_unless(rc == exp_rc, "Curl_parse_interface() failed");
 
   fail_unless(!!exp_dev == !!dev, "dev expectation failed.");


### PR DESCRIPTION
Ref: https://github.com/curl/curl/discussions/14299#discussioncomment-10393909 Regression from 3060557af702dd591 (shipped in 8.9.0)