### PR TITLE
cmake: simplify version detection regex

### DIFF
--- a/CMake/FindCares.cmake
+++ b/CMake/FindCares.cmake
@@ -55,7 +55,7 @@ find_library(CARES_LIBRARY NAMES ${CARES_NAMES} "cares"
 if(PC_CARES_VERSION)
   set(CARES_VERSION ${PC_CARES_VERSION})
 elseif(CARES_INCLUDE_DIR AND EXISTS "${CARES_INCLUDE_DIR}/ares_version.h")
-  set(_version_regex "#[\t ]*define[\t ]+ARES_VERSION_STR[\t ]+\"([^\"]*)\"")
+  set(_version_regex "#[\t ]*define[\t ]+ARES_VERSION_STR[\t ]+\"([^\"]*)")
   file(STRINGS "${CARES_INCLUDE_DIR}/ares_version.h" _version_str REGEX "${_version_regex}")
   string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
   set(CARES_VERSION "${_version_str}")

--- a/CMake/FindLibgsasl.cmake
+++ b/CMake/FindLibgsasl.cmake
@@ -50,7 +50,7 @@ else()
   find_library(LIBGSASL_LIBRARY NAMES "gsasl" "libgsasl")
 
   if(LIBGSASL_INCLUDE_DIR AND EXISTS "${LIBGSASL_INCLUDE_DIR}/gsasl-version.h")
-    set(_version_regex "#[\t ]*define[\t ]+GSASL_VERSION[\t ]+\"([^\"]*)\"")
+    set(_version_regex "#[\t ]*define[\t ]+GSASL_VERSION[\t ]+\"([^\"]*)")
     file(STRINGS "${LIBGSASL_INCLUDE_DIR}/gsasl-version.h" _version_str REGEX "${_version_regex}")
     string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
     set(LIBGSASL_VERSION "${_version_str}")

--- a/CMake/FindLibidn2.cmake
+++ b/CMake/FindLibidn2.cmake
@@ -50,7 +50,7 @@ else()
   find_library(LIBIDN2_LIBRARY NAMES "idn2" "libidn2")
 
   if(LIBIDN2_INCLUDE_DIR AND EXISTS "${LIBIDN2_INCLUDE_DIR}/idn2.h")
-    set(_version_regex "#[\t ]*define[\t ]+IDN2_VERSION[\t ]+\"([^\"]*)\"")
+    set(_version_regex "#[\t ]*define[\t ]+IDN2_VERSION[\t ]+\"([^\"]*)")
     file(STRINGS "${LIBIDN2_INCLUDE_DIR}/idn2.h" _version_str REGEX "${_version_regex}")
     string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
     set(LIBIDN2_VERSION "${_version_str}")

--- a/CMake/FindLibpsl.cmake
+++ b/CMake/FindLibpsl.cmake
@@ -55,7 +55,7 @@ find_library(LIBPSL_LIBRARY NAMES "psl" "libpsl"
 if(PC_LIBPSL_VERSION)
   set(LIBPSL_VERSION ${PC_LIBPSL_VERSION})
 elseif(LIBPSL_INCLUDE_DIR AND EXISTS "${LIBPSL_INCLUDE_DIR}/libpsl.h")
-  set(_version_regex "#[\t ]*define[\t ]+PSL_VERSION[\t ]+\"([^\"]*)\"")
+  set(_version_regex "#[\t ]*define[\t ]+PSL_VERSION[\t ]+\"([^\"]*)")
   file(STRINGS "${LIBPSL_INCLUDE_DIR}/libpsl.h" _version_str REGEX "${_version_regex}")
   string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
   set(LIBPSL_VERSION "${_version_str}")

--- a/CMake/FindLibssh2.cmake
+++ b/CMake/FindLibssh2.cmake
@@ -55,7 +55,7 @@ find_library(LIBSSH2_LIBRARY NAMES "ssh2" "libssh2"
 if(PC_LIBSSH2_VERSION)
   set(LIBSSH2_VERSION ${PC_LIBSSH2_VERSION})
 elseif(LIBSSH2_INCLUDE_DIR AND EXISTS "${LIBSSH2_INCLUDE_DIR}/libssh2.h")
-  set(_version_regex "#[\t ]*define[\t ]+LIBSSH2_VERSION[\t ]+\"([^\"]*)\"")
+  set(_version_regex "#[\t ]*define[\t ]+LIBSSH2_VERSION[\t ]+\"([^\"]*)")
   file(STRINGS "${LIBSSH2_INCLUDE_DIR}/libssh2.h" _version_str REGEX "${_version_regex}")
   string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
   set(LIBSSH2_VERSION "${_version_str}")

--- a/CMake/FindNGHTTP2.cmake
+++ b/CMake/FindNGHTTP2.cmake
@@ -55,7 +55,7 @@ find_library(NGHTTP2_LIBRARY NAMES "nghttp2" "nghttp2_static"
 if(PC_NGHTTP2_VERSION)
   set(NGHTTP2_VERSION ${PC_NGHTTP2_VERSION})
 elseif(NGHTTP2_INCLUDE_DIR AND EXISTS "${NGHTTP2_INCLUDE_DIR}/nghttp2/nghttp2ver.h")
-  set(_version_regex "#[\t ]*define[\t ]+NGHTTP2_VERSION[\t ]+\"([^\"]*)\"")
+  set(_version_regex "#[\t ]*define[\t ]+NGHTTP2_VERSION[\t ]+\"([^\"]*)")
   file(STRINGS "${NGHTTP2_INCLUDE_DIR}/nghttp2/nghttp2ver.h" _version_str REGEX "${_version_regex}")
   string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
   set(NGHTTP2_VERSION "${_version_str}")

--- a/CMake/FindNGHTTP3.cmake
+++ b/CMake/FindNGHTTP3.cmake
@@ -55,7 +55,7 @@ find_library(NGHTTP3_LIBRARY NAMES "nghttp3"
 if(PC_NGHTTP3_VERSION)
   set(NGHTTP3_VERSION ${PC_NGHTTP3_VERSION})
 elseif(NGHTTP3_INCLUDE_DIR AND EXISTS "${NGHTTP3_INCLUDE_DIR}/nghttp3/version.h")
-  set(_version_regex "#[\t ]*define[\t ]+NGHTTP3_VERSION[\t ]+\"([^\"]*)\"")
+  set(_version_regex "#[\t ]*define[\t ]+NGHTTP3_VERSION[\t ]+\"([^\"]*)")
   file(STRINGS "${NGHTTP3_INCLUDE_DIR}/nghttp3/version.h" _version_str REGEX "${_version_regex}")
   string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
   set(NGHTTP3_VERSION "${_version_str}")

--- a/CMake/FindNGTCP2.cmake
+++ b/CMake/FindNGTCP2.cmake
@@ -63,7 +63,7 @@ find_library(NGTCP2_LIBRARY NAMES "ngtcp2"
 if(PC_NGTCP2_VERSION)
   set(NGTCP2_VERSION ${PC_NGTCP2_VERSION})
 elseif(NGTCP2_INCLUDE_DIR AND EXISTS "${NGTCP2_INCLUDE_DIR}/ngtcp2/version.h")
-  set(_version_regex "#[\t ]*define[\t ]+NGTCP2_VERSION[\t ]+\"([^\"]*)\"")
+  set(_version_regex "#[\t ]*define[\t ]+NGTCP2_VERSION[\t ]+\"([^\"]*)")
   file(STRINGS "${NGTCP2_INCLUDE_DIR}/ngtcp2/version.h" _version_str REGEX "${_version_regex}")
   string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
   set(NGTCP2_VERSION "${_version_str}")

--- a/CMake/FindWolfSSH.cmake
+++ b/CMake/FindWolfSSH.cmake
@@ -39,7 +39,7 @@ find_path(WOLFSSH_INCLUDE_DIR NAMES "wolfssh/ssh.h")
 find_library(WOLFSSH_LIBRARY NAMES "wolfssh" "libwolfssh")
 
 if(WOLFSSH_INCLUDE_DIR AND EXISTS "${WOLFSSH_INCLUDE_DIR}/wolfssh/version.h")
-  set(_version_regex "#[\t ]*define[\t ]+LIBWOLFSSH_VERSION_STRING[\t ]+\"([^\"]*)\"")
+  set(_version_regex "#[\t ]*define[\t ]+LIBWOLFSSH_VERSION_STRING[\t ]+\"([^\"]*)")
   file(STRINGS "${WOLFSSH_INCLUDE_DIR}/wolfssh/version.h" _version_str REGEX "${_version_regex}")
   string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
   set(WOLFSSH_VERSION "${_version_str}")

--- a/CMake/FindWolfSSL.cmake
+++ b/CMake/FindWolfSSL.cmake
@@ -66,7 +66,7 @@ find_library(WOLFSSL_LIBRARY NAMES "wolfssl"
 if(PC_WOLFSSL_VERSION)
   set(WOLFSSL_VERSION ${PC_WOLFSSL_VERSION})
 elseif(WOLFSSL_INCLUDE_DIR AND EXISTS "${WOLFSSL_INCLUDE_DIR}/wolfssl/version.h")
-  set(_version_regex "#[\t ]*define[\t ]+LIBWOLFSSL_VERSION_STRING[\t ]+\"([^\"]*)\"")
+  set(_version_regex "#[\t ]*define[\t ]+LIBWOLFSSL_VERSION_STRING[\t ]+\"([^\"]*)")
   file(STRINGS "${WOLFSSL_INCLUDE_DIR}/wolfssl/version.h" _version_str REGEX "${_version_regex}")
   string(REGEX REPLACE "${_version_regex}" "\\1" _version_str "${_version_str}")
   set(WOLFSSL_VERSION "${_version_str}")


### PR DESCRIPTION
Fixes syntax highlighting in some editors.
Idea taken from CMakeLists.txt's curl version detection.