### PR TITLE
lib: delete stray undefs for `vsnprintf`, `vsprintf`

### DIFF
--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -40,7 +40,6 @@
 # undef msnprintf
 # undef vprintf
 # undef vfprintf
-# undef vsnprintf
 # undef mvsnprintf
 # undef aprintf
 # undef vaprintf

--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -98,7 +98,6 @@
 # undef msnprintf
 # undef vprintf
 # undef vfprintf
-# undef vsprintf
 # undef mvsnprintf
 # undef aprintf
 # undef vaprintf
@@ -112,7 +111,6 @@
 # define mvsnprintf curlx_mvsnprintf
 # define aprintf curlx_maprintf
 # define vaprintf curlx_mvaprintf
-# define vsprintf curlx_mvsprintf
 #endif /* ENABLE_CURLX_PRINTF */
 
 #endif /* HEADER_CURL_CURLX_H */

--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -112,6 +112,7 @@
 # define mvsnprintf curlx_mvsnprintf
 # define aprintf curlx_maprintf
 # define vaprintf curlx_mvaprintf
+# define vsprintf curlx_mvsprintf
 #endif /* ENABLE_CURLX_PRINTF */
 
 #endif /* HEADER_CURL_CURLX_H */


### PR DESCRIPTION
Stop #undefining macros that were not redefined or used in the code.
