### PR TITLE
src: fix potential macro confusion in cmake unity builds

### DIFF
--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -88,10 +88,9 @@
 #define curlx_mvprintf curl_mvprintf
 #define curlx_mvfprintf curl_mvfprintf
 
-#ifdef ENABLE_CURLX_PRINTF
-/* If this define is set, we define all "standard" printf() functions to use
-   the curlx_* version instead. It makes the source code transparent and
-   easier to understand/patch. Undefine them first. */
+/* We define all "standard" printf() functions to use the curlx_* version
+   instead. It makes the source code transparent and easier to
+   understand/patch. Undefine them first. */
 # undef printf
 # undef fprintf
 # undef sprintf
@@ -111,6 +110,5 @@
 # define mvsnprintf curlx_mvsnprintf
 # define aprintf curlx_maprintf
 # define vaprintf curlx_mvaprintf
-#endif /* ENABLE_CURLX_PRINTF */
 
 #endif /* HEADER_CURL_CURLX_H */

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -28,8 +28,6 @@
 #include <unistd.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -27,8 +27,6 @@
 #include <sys/select.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -30,8 +30,6 @@
 
 #include <sys/stat.h>
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -29,8 +29,6 @@
 #  include <direct.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_dirhie.h"

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -27,8 +27,6 @@
 
 #ifndef CURL_DISABLE_LIBCURL_OPTION
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -25,8 +25,6 @@
 
 #include "strcase.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -25,8 +25,6 @@
 
 #include "strcase.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_binmode.h"

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -22,8 +22,7 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
+
 #include "curlx.h"
 
 #include "tool_help.h"

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -25,8 +25,6 @@
 
 #include "strcase.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_ipfs.c
+++ b/src/tool_ipfs.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 #include "dynbuf.h"
 

--- a/src/tool_libinfo.c
+++ b/src/tool_libinfo.c
@@ -25,8 +25,6 @@
 
 #include "strcase.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_libinfo.h"

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -35,8 +35,6 @@
 #include <fcntl.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -60,8 +60,6 @@
 #include <uv.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_binmode.h"

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -26,8 +26,6 @@
 
 #include "strcase.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -25,8 +25,6 @@
 
 #include "strcase.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_progress.c
+++ b/src/tool_progress.c
@@ -26,8 +26,6 @@
 #include "tool_progress.h"
 #include "tool_util.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 /* The point of this function would be to return a string of the input data,

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -25,8 +25,6 @@
 
 #ifndef CURL_DISABLE_LIBCURL_OPTION
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -25,6 +25,8 @@
  ***************************************************************************/
 
 #define CURL_NO_OLDIES
+/* use our own printf() functions from curlx.h */
+#define ENABLE_CURLX_PRINTF
 
 /*
  * curl_setup.h may define preprocessor macros such as _FILE_OFFSET_BITS and

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -25,8 +25,6 @@
  ***************************************************************************/
 
 #define CURL_NO_OLDIES
-/* use our own printf() functions from curlx.h */
-#define ENABLE_CURLX_PRINTF
 
 /*
  * curl_setup.h may define preprocessor macros such as _FILE_OFFSET_BITS and

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 #include "tool_cfgable.h"
 #include "tool_doswin.h"

--- a/src/tool_vms.c
+++ b/src/tool_vms.c
@@ -30,7 +30,6 @@
 #include <unixlib.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
 #include "curlx.h"
 
 #include "curlmsg_vms.h"

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -22,8 +22,7 @@
  *
  ***************************************************************************/
 #include "tool_setup.h"
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
+
 #include "curlx.h"
 #include "tool_cfgable.h"
 #include "tool_writeout.h"

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -23,9 +23,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-
-/* use our own printf() functions */
 #include "curlx.h"
 #include "tool_cfgable.h"
 #include "tool_writeout_json.h"

--- a/src/var.c
+++ b/src/var.c
@@ -23,8 +23,6 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#define ENABLE_CURLX_PRINTF
-/* use our own printf() functions */
 #include "curlx.h"
 
 #include "tool_cfgable.h"

--- a/tests/server/fake_ntlm.c
+++ b/tests/server/fake_ntlm.c
@@ -31,7 +31,6 @@
  * responses with a pre-written string saved in test case test2005.
  */
 
-#define ENABLE_CURLX_PRINTF
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "util.h"

--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -25,9 +25,6 @@
 
 #include "getpart.h"
 
-#define ENABLE_CURLX_PRINTF
-/* make the curlx header define all printf() functions to use the curlx_*
-   versions instead */
 #include "curlx.h" /* from the private lib dir */
 
 /* just to please curl_base64.h we create a fake struct */

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -54,9 +54,6 @@
 #include <netdb.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* make the curlx header define all printf() functions to use the curlx_*
-   versions instead */
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "inet_pton.h"

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -45,9 +45,6 @@
 #include <netdb.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* make the curlx header define all printf() functions to use the curlx_*
-   versions instead */
 #include "curlx.h" /* from the private lib dir */
 #include "util.h"
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -46,9 +46,6 @@
 #include <netinet/tcp.h> /* for TCP_NODELAY */
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* make the curlx header define all printf() functions to use the curlx_*
-   versions instead */
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "util.h"

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -99,9 +99,6 @@
 #include <netdb.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* make the curlx header define all printf() functions to use the curlx_*
-   versions instead */
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "inet_pton.h"

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -71,9 +71,6 @@
 #include <netdb.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* make the curlx header define all printf() functions to use the curlx_*
-   versions instead */
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "inet_pton.h"

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -47,9 +47,6 @@
 #include <netinet/tcp.h> /* for TCP_NODELAY */
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* make the curlx header define all printf() functions to use the curlx_*
-   versions instead */
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "inet_pton.h"

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -81,9 +81,6 @@
 
 #include <ctype.h>
 
-#define ENABLE_CURLX_PRINTF
-/* make the curlx header define all printf() functions to use the curlx_*
-   versions instead */
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "util.h"

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -40,9 +40,6 @@
 #include <sys/poll.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
-/* make the curlx header define all printf() functions to use the curlx_*
-   versions instead */
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "util.h"

--- a/tests/unit/unit1305.c
+++ b/tests/unit/unit1305.c
@@ -33,7 +33,6 @@
 #  include <arpa/inet.h>
 #endif
 
-#define ENABLE_CURLX_PRINTF
 #include "curlx.h"
 
 #include "hash.h"

--- a/tests/unit/unit1602.c
+++ b/tests/unit/unit1602.c
@@ -23,7 +23,6 @@
  ***************************************************************************/
 #include "curlcheck.h"
 
-#define ENABLE_CURLX_PRINTF
 #include "curlx.h"
 
 #include "hash.h"

--- a/tests/unit/unit1603.c
+++ b/tests/unit/unit1603.c
@@ -23,7 +23,6 @@
  ***************************************************************************/
 #include "curlcheck.h"
 
-#define ENABLE_CURLX_PRINTF
 #include "curlx.h"
 
 #include "hash.h"

--- a/tests/unit/unit1616.c
+++ b/tests/unit/unit1616.c
@@ -23,7 +23,6 @@
  ***************************************************************************/
 #include "curlcheck.h"
 
-#define ENABLE_CURLX_PRINTF
 #include "curlx.h"
 
 #include "hash.h"


### PR DESCRIPTION
Sources used `lib/curlx.h` with both `ENABLE_CURLX_PRINTF` set and unset
before including it.

In a cmake "unity" batch where the first included source had it unset,
the next sources did not get the macros requested with
`ENABLE_CURLX_PRINTF` because `lib/curl.x` had already been included
without them.

Fix it by by making the macros enabled permanently and globally for
internal sources, and dropping `ENABLE_CURLX_PRINTF`.

This came up while testing unity builds with smaller batches. The full,
default unity build where all `src` is bundled up in a single unit, was
not affected.

Fixes:
```
$ cmake -B build -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=15
$ make -C build
...
curl/src/tool_getparam.c: In function ‘getparameter’:
curl/src/tool_getparam.c:2409:11: error: implicit declaration of function ‘msnprintf’; did you mean ‘vsnprintf’? [-Wimplicit-function-declaration]
 2409 |           msnprintf(buffer, sizeof(buffer), "%" CURL_FORMAT_CURL_OFF_T "-",
      |           ^~~~~~~~~
      |           vsnprintf
curl/src/tool_getparam.c:2409:11: warning: nested extern declaration of ‘msnprintf’ [-Wnested-externs]
[...]
```

Reported-by: Daniel Stenberg
Bug: https://github.com/curl/curl/pull/14626#issuecomment-2301663491
