### PR TITLE
test1521: verify setting options better

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1250,8 +1250,7 @@ typedef enum {
   /* send linked-list of post-transfer QUOTE commands */
   CURLOPT(CURLOPT_POSTQUOTE, CURLOPTTYPE_SLISTPOINT, 39),
 
-   /* OBSOLETE, do not use! */
-  CURLOPT(CURLOPT_OBSOLETE40, CURLOPTTYPE_OBJECTPOINT, 40),
+  /* 40 is not used */
 
   /* talk a lot */
   CURLOPT(CURLOPT_VERBOSE, CURLOPTTYPE_LONG, 41),
@@ -1352,9 +1351,7 @@ typedef enum {
   /* Max amount of cached alive connections */
   CURLOPT(CURLOPT_MAXCONNECTS, CURLOPTTYPE_LONG, 71),
 
-  /* OBSOLETE, do not use! */
-  CURLOPT(CURLOPT_OBSOLETE72, CURLOPTTYPE_LONG, 72),
-
+  /* 72 = OBSOLETE */
   /* 73 = OBSOLETE */
 
   /* Set to explicitly use a new connection for the upcoming transfer.

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -253,11 +253,13 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
   case CURLINFO_SSL_VERIFYRESULT:
     *param_longp = data->set.ssl.certverifyresult;
     break;
-#ifndef CURL_DISABLE_PROXY
   case CURLINFO_PROXY_SSL_VERIFYRESULT:
+#ifndef CURL_DISABLE_PROXY
     *param_longp = data->set.proxy_ssl.certverifyresult;
-    break;
+#else
+    *param_longp = 0;
 #endif
+    break;
   case CURLINFO_REDIRECT_COUNT:
     *param_longp = data->state.followlocation;
     break;
@@ -314,6 +316,12 @@ static CURLcode getinfo_long(struct Curl_easy *data, CURLINFO info,
     break;
   case CURLINFO_RTSP_CSEQ_RECV:
     *param_longp = data->state.rtsp_CSeq_recv;
+    break;
+#else
+  case CURLINFO_RTSP_CLIENT_CSEQ:
+  case CURLINFO_RTSP_SERVER_CSEQ:
+  case CURLINFO_RTSP_CSEQ_RECV:
+    *param_longp = 0;
     break;
 #endif
   case CURLINFO_HTTP_VERSION:

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -3188,8 +3188,7 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
     argptr = va_arg(param, char *);
     if(!argptr) {
       data->set.tls_ech = CURLECH_DISABLE;
-      result = CURLE_BAD_FUNCTION_ARGUMENT;
-      return result;
+      return CURLE_OK;
     }
     plen = strlen(argptr);
     if(plen > CURL_MAX_INPUT_LENGTH) {

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -425,8 +425,10 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
      * TFTP option that specifies the block size to use for data transmission.
      */
     arg = va_arg(param, long);
-    if(arg > TFTP_BLKSIZE_MAX || arg < TFTP_BLKSIZE_MIN)
-      return CURLE_BAD_FUNCTION_ARGUMENT;
+    if(arg < TFTP_BLKSIZE_MIN)
+      arg = 512;
+    else if(arg > TFTP_BLKSIZE_MAX)
+      arg = TFTP_BLKSIZE_MAX;
     data->set.tftp_blksize = arg;
     break;
 #endif

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2700,17 +2700,27 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
 
   case CURLOPT_PROTOCOLS_STR: {
     argptr = va_arg(param, char *);
-    result = protocol2num(argptr, &data->set.allowed_protocols);
-    if(result)
-      return result;
+    if(argptr) {
+      result = protocol2num(argptr, &data->set.allowed_protocols);
+      if(result)
+        return result;
+    }
+    else
+      /* make a NULL argument reset to default */
+      data->set.allowed_protocols = (curl_prot_t) CURLPROTO_ALL;
     break;
   }
 
   case CURLOPT_REDIR_PROTOCOLS_STR: {
     argptr = va_arg(param, char *);
-    result = protocol2num(argptr, &data->set.redir_protocols);
-    if(result)
-      return result;
+    if(argptr) {
+      result = protocol2num(argptr, &data->set.redir_protocols);
+      if(result)
+        return result;
+    }
+    else
+      /* make a NULL argument reset to default */
+      data->set.redir_protocols = (curl_prot_t) CURLPROTO_REDIR;
     break;
   }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -414,8 +414,7 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 
   set->new_file_perms = 0644;    /* Default permissions */
   set->allowed_protocols = (curl_prot_t) CURLPROTO_ALL;
-  set->redir_protocols = CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP |
-                         CURLPROTO_FTPS;
+  set->redir_protocols = CURLPROTO_REDIR;
 
 #if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
   /*

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -77,6 +77,10 @@ struct curl_trc_featt;
 #define CURLPROTO_WSS 0
 #endif
 
+/* the default protocols accepting a redirect to */
+#define CURLPROTO_REDIR (CURLPROTO_HTTP | CURLPROTO_HTTPS | CURLPROTO_FTP | \
+                         CURLPROTO_FTPS)
+
 /* This should be undefined once we need bit 32 or higher */
 #define PROTO_TYPE_SMALL
 

--- a/tests/data/test1521
+++ b/tests/data/test1521
@@ -26,5 +26,8 @@ unused
 #
 # Verify data after the test has been "shot"
 <verify>
+<stdout>
+ok
+</stdout>
 </verify>
 </testcase>


### PR DESCRIPTION
Previously this test allowed several error values when setting options. This made this test miss #14629.
    
Now, errors are generally not accepted for setopts:
    
 - numerical setopts accept CURLE_BAD_FUNCTION_ARGUMENT for funny input
 - the first setopt to an option accepts CURLE_NOT_BUILT_IN or CURLE_UNKNOWN_OPTION for when they are disabled/not built-in
 - there is an allowlist concept for some return code for some variables, managed at the top of the mk-lib1521.pl script

In curl.h: remove the OBSOLETE named values from the setopt list.
