### PR TITLE
docs: Clarify OpenSSF Best Practices vs Scorecard

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,7 +19,7 @@ We treat security issues with confidentiality until controlled and disclosed res
 
 curl has achieved Gold status on the Open Source Security Foundation (OpenSSF)
 [Best Practices](https://bestpractices.dev/) (formerly Core Infrastructure
-Initiative [CII] Best Practices), reflecting its adherence to rigorous
+Initiative Best Practices), reflecting its adherence to rigorous
 security and best practice standards. This achievement highlights curl's
 comprehensive documentation, secure development processes, effective change
 control mechanisms, and strong maintenance routines. Meeting these criteria

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,13 +15,15 @@ libcurl, report it on [HackerOne](https://hackerone.com/curl).
 
 We treat security issues with confidentiality until controlled and disclosed responsibly.
 
-## OpenSSF Scorecard
+## OpenSSF Best Practices
 
-curl has earned Gold status on the OpenSSF Best Practices, reflecting its adherence to
-rigorous security and best practice standards. This achievement highlights curl's
-comprehensive documentation, secure development processes, effective change control
-mechanisms, and strong maintenance routines. Meeting these criteria demonstrates curl's
-commitment to security and reliability, ensuring the project's sustainability and
-trustworthiness. This recognition by OpenSSF underscores curl's role as a leader in
-open-source software practices. More information can be found on
-their [OpenSSF page](https://www.bestpractices.dev/projects/63).
+curl has achieved Gold status on the Open Source Security Foundation (OpenSSF)
+[Best Practices](https://bestpractices.dev/) (formerly Core Infrastructure
+Initiative [CII] Best Practices), reflecting its adherence to rigorous
+security and best practice standards. This achievement highlights curl's
+comprehensive documentation, secure development processes, effective change
+control mechanisms, and strong maintenance routines. Meeting these criteria
+demonstrates curl's commitment to security and reliability, ensuring the
+project's sustainability and trustworthiness. This underscores curl's role as
+a leader in open-source software practices. More information can be found on
+[curl's OpenSSF Best Practices project page](https://www.bestpractices.dev/projects/63).


### PR DESCRIPTION
#14319 introduced a section to `SECURITY.md` titled **OpenSSF Scorecard** that actually documents OpenSSF Best Practices ([Scorecard](https://scorecard.dev/) is a different OpenSSF project, that incorporates Best Practices, but is distinct in its objectives and how it achieves them).

This change clarifies the terminology, and also removes any implication that Gold Best Practices is an award rather than a self certification programme.

As curl was a leader in implementing Best Practices some folk may be more familiar with the earlier Core Infrastructure Initiative (CII) naming, so a reference to that has been added.

I'll start a discussion on whether curl should be running the Scorecard workflow to generate a score there, which would perhaps go on to justify another section in `SECURITY.md` for that.