### PR TITLE
build: make `CURL_FORMAT_CURL_OFF_T[U]` work with mingw-w64 <=7.0.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -607,6 +607,19 @@ case $host_os in
     ;;
 esac
 
+have_mingw='no'
+case $host_os in
+  mingw*)
+    have_mingw='yes'
+    ;;
+esac
+
+AM_CONDITIONAL([HAVE_MINGW],
+  [test "$have_mingw" = "yes"])
+
+AM_CONDITIONAL([HAVE_WINDOWS],
+  [test "$curl_cv_native_windows" = "yes"])
+
 AM_CONDITIONAL([HAVE_WINDRES],
   [test "$curl_cv_native_windows" = "yes" && test -n "${RC}"])
 

--- a/configure.ac
+++ b/configure.ac
@@ -615,7 +615,7 @@ case $host_os in
 esac
 
 AM_CONDITIONAL([HAVE_MINGW],
-  [test "$curl_cv_native_windows" = "yes" -a "$have_mingw" = "yes"])
+  [test "$curl_cv_native_windows" = 'yes' -a "$have_mingw" = 'yes'])
 
 AM_CONDITIONAL([HAVE_WINDRES],
   [test "$curl_cv_native_windows" = "yes" && test -n "${RC}"])

--- a/configure.ac
+++ b/configure.ac
@@ -615,10 +615,7 @@ case $host_os in
 esac
 
 AM_CONDITIONAL([HAVE_MINGW],
-  [test "$have_mingw" = "yes"])
-
-AM_CONDITIONAL([HAVE_WINDOWS],
-  [test "$curl_cv_native_windows" = "yes"])
+  [test "$curl_cv_native_windows" = "yes" -a "$have_mingw" = "yes"])
 
 AM_CONDITIONAL([HAVE_WINDRES],
   [test "$curl_cv_native_windows" = "yes" && test -n "${RC}"])

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -36,7 +36,7 @@ foreach(_example IN LISTS check_PROGRAMS)
   endif()
   if(MINGW)
     # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-    set_property(TARGET ${_test_target} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
+    set_property(TARGET ${_example_target} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
   endif()
   set_target_properties(${_example_target} PROPERTIES
     OUTPUT_NAME "${_example}" UNITY_BUILD OFF)

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -34,6 +34,10 @@ foreach(_example IN LISTS check_PROGRAMS)
   if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
     set_property(TARGET ${_example_target} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
+  if(MINGW)
+    # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
+    set_property(TARGET ${_test_target} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
+  endif()
   set_target_properties(${_example_target} PROPERTIES
     OUTPUT_NAME "${_example}" UNITY_BUILD OFF)
 endforeach()

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -46,6 +46,11 @@ if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif
 
+if HAVE_MINGW
+# For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
+AM_CPPFLAGS += -D__USE_MINGW_ANSI_STDIO=1
+endif
+
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 

--- a/docs/examples/ftpgetinfo.c
+++ b/docs/examples/ftpgetinfo.c
@@ -75,8 +75,8 @@ int main(void)
       res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                               &filesize);
       if((CURLE_OK == res) && (filesize>0))
-        printf("filesize %s: %" CURL_FORMAT_CURL_OFF_T " bytes\n",
-               filename, filesize);
+        curl_mprintf("filesize %s: %" CURL_FORMAT_CURL_OFF_T " bytes\n",
+                     filename, filesize);
     }
     else {
       /* we failed */

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -39,6 +39,10 @@ foreach(_test_name IN LISTS check_PROGRAMS)
   if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
     set_property(TARGET ${_test_target} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
+  if(MINGW)
+    # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
+    set_property(TARGET ${_test_target} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
+  endif()
   set_target_properties(${_test_target} PROPERTIES
     OUTPUT_NAME "${_test_name}" UNITY_BUILD OFF
     PROJECT_LABEL "Test client ${_test_target}")

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -47,11 +47,9 @@ if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif
 
-if HAVE_WINDOWS
 if HAVE_MINGW
 # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
 AM_CPPFLAGS += -D__USE_MINGW_ANSI_STDIO=1
-endif
 endif
 
 # Prevent LIBS from being used for all link targets

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -47,6 +47,13 @@ if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif
 
+if HAVE_WINDOWS
+if HAVE_MINGW
+# For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
+AM_CPPFLAGS += -D__USE_MINGW_ANSI_STDIO=1
+endif
+endif
+
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 

--- a/tests/http/clients/h2-download.c
+++ b/tests/http/clients/h2-download.c
@@ -37,10 +37,6 @@
 #include <unistd.h>  /* getopt() */
 #endif
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"
 #endif
@@ -84,11 +80,12 @@ static int debug_cb(CURL *handle, curl_infotype type,
 
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
-        conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
+       conn_id >= 0) {
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id,
+                     conn_id);
     }
     else {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -184,7 +181,8 @@ static size_t my_write_cb(char *buf, size_t nitems, size_t buflen,
   fprintf(stderr, "[t-%d] RECV %ld bytes, total=%ld, pause_at=%ld\n",
           t->idx, (long)blen, (long)t->recv_size, (long)t->pause_at);
   if(!t->out) {
-    snprintf(t->filename, sizeof(t->filename)-1, "download_%u.data", t->idx);
+    curl_msnprintf(t->filename, sizeof(t->filename)-1, "download_%u.data",
+                   t->idx);
     t->out = fopen(t->filename, "wb");
     if(!t->out)
       return 0;

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -39,10 +39,6 @@
 #include <unistd.h>  /* getopt() */
 #endif
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
 #ifndef _MSC_VER
 #define HANDLECOUNT 2
 
@@ -83,10 +79,11 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id,
+                     conn_id);
     }
     else {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -272,7 +269,8 @@ int main(int argc, char *argv[])
     exit(1);
   }
   memset(&resolve, 0, sizeof(resolve));
-  snprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1", host, port);
+  curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1",
+                 host, port);
   resolve = curl_slist_append(resolve, resolve_buf);
 
   for(i = 0; i<HANDLECOUNT; i++) {

--- a/tests/http/clients/h2-serverpush.c
+++ b/tests/http/clients/h2-serverpush.c
@@ -36,10 +36,6 @@
 #error "too old libcurl, cannot do HTTP/2 server push!"
 #endif
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
 static
 void dump(const char *text, unsigned char *ptr, size_t size,
           char nohex)
@@ -170,7 +166,7 @@ static int server_push_callback(CURL *parent,
   int rv;
 
   (void)parent; /* we have no use for this */
-  snprintf(filename, sizeof(filename)-1, "push%u", count++);
+  curl_msnprintf(filename, sizeof(filename)-1, "push%u", count++);
 
   /* here's a new stream, save it in a new file for each new push */
   out = fopen(filename, "wb");

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -32,10 +32,6 @@
 /* #include <error.h> */
 #include <errno.h>
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {
   /*
@@ -73,10 +69,11 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id,
+                     conn_id);
     }
     else {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -181,7 +178,7 @@ int main(int argc, char *argv[])
       curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, write_cb);
       curl_easy_setopt(easy, CURLOPT_WRITEDATA, NULL);
       curl_easy_setopt(easy, CURLOPT_HTTPGET, 1L);
-      snprintf(range, sizeof(range), "%d-%d", 0, 16384);
+      curl_msnprintf(range, sizeof(range), "%d-%d", 0, 16384);
       curl_easy_setopt(easy, CURLOPT_RANGE, range);
 
       mc = curl_multi_add_handle(multi, easy);

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -181,8 +181,8 @@ int main(int argc, char *argv[])
       curl_msnprintf(range, sizeof(range),
                      "%" CURL_FORMAT_CURL_OFF_TU "-"
                      "%" CURL_FORMAT_CURL_OFF_TU,
-                     UINT64_C(0),
-                     UINT64_C(16384));
+                     (curl_off_t)0,
+                     (curl_off_t)16384);
       curl_easy_setopt(easy, CURLOPT_RANGE, range);
 
       mc = curl_multi_add_handle(multi, easy);

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -178,7 +178,11 @@ int main(int argc, char *argv[])
       curl_easy_setopt(easy, CURLOPT_WRITEFUNCTION, write_cb);
       curl_easy_setopt(easy, CURLOPT_WRITEDATA, NULL);
       curl_easy_setopt(easy, CURLOPT_HTTPGET, 1L);
-      curl_msnprintf(range, sizeof(range), "%d-%d", 0, 16384);
+      curl_msnprintf(range, sizeof(range),
+                     "%" CURL_FORMAT_CURL_OFF_TU "-"
+                     "%" CURL_FORMAT_CURL_OFF_TU,
+                     UINT64_C(0),
+                     UINT64_C(16384));
       curl_easy_setopt(easy, CURLOPT_RANGE, range);
 
       mc = curl_multi_add_handle(multi, easy);

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -33,10 +33,6 @@
 /* #include <error.h> */
 #include <errno.h>
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {
   /*
@@ -74,10 +70,11 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id,
+                     conn_id);
     }
     else {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -223,7 +220,8 @@ int main(int argc, char *argv[])
   }
 
   memset(&resolve, 0, sizeof(resolve));
-  snprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1", host, port);
+  curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1",
+                 host, port);
   curl_slist_append(&resolve, resolve_buf);
 
   multi = curl_multi_init();

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -38,10 +38,6 @@
 #include <unistd.h>  /* getopt() */
 #endif
 
-#ifdef _MSC_VER
-#define snprintf _snprintf
-#endif
-
 #ifndef _MSC_VER
 static void log_line_start(FILE *log, const char *idsbuf, curl_infotype type)
 {
@@ -80,10 +76,11 @@ static int debug_cb(CURL *handle, curl_infotype type,
   if(!curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id, conn_id);
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_2, xfer_id,
+                     conn_id);
     }
     else {
-      snprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
+      curl_msnprintf(idsbuf, sizeof(idsbuf), TRC_IDS_FORMAT_IDS_1, xfer_id);
     }
   }
   else
@@ -263,7 +260,8 @@ int main(int argc, char *argv[])
     exit(1);
   }
   memset(&resolve, 0, sizeof(resolve));
-  snprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1", host, port);
+  curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1",
+                 host, port);
   resolve = curl_slist_append(resolve, resolve_buf);
 
   curl = curl_easy_init();


### PR DESCRIPTION
Add tweak for mingw-w64 when building tests/http/client programs to
avoid a bogus `-Wformat` warning when using mingw-w64 v7.0.0 or older.
The warning is bogus because these programs use curl's `printf()`
implementation that is guaranteed to support that format spec.

Add this for both CMake and autotools. (But only CMake is CI tested with
an old toolchain.)

Apply the workaround to `docs/examples`, and fix an example to use
curl's `printf()` with `CURL_FORMAT_CURL_OFF_T`.

Reintroduce curl `printf()` calls into `tests/http/client`, via #14625.
Also restore large number masks to a printf, changed earlier in #14382.

Follow-up to 232302f88a152a1d1722da9f69c383a766528918 #14382
Ref: https://github.com/curl/curl/pull/14625#issuecomment-2302361737

---

- [x] add the same for autotools.
- [ ] fix it in `curl/system.h` instead?
