### PR TITLE
printf: fix mingw-w64 format checks, turn C99 format strings into macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -597,16 +597,6 @@ case $host_os in
     ;;
 esac
 
-have_mingw='no'
-case $host_os in
-  mingw*)
-    have_mingw='yes'
-    ;;
-esac
-
-AM_CONDITIONAL([HAVE_MINGW],
-  [test "$curl_cv_native_windows" = 'yes' -a "$have_mingw" = 'yes'])
-
 AM_CONDITIONAL([HAVE_WINDRES],
   [test "$curl_cv_native_windows" = "yes" && test -n "${RC}"])
 

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -34,10 +34,6 @@ foreach(_target IN LISTS check_PROGRAMS)
   if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
     set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
-  if(MINGW)
-    # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-    set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
-  endif()
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}" UNITY_BUILD OFF
     PROJECT_LABEL "Example ${_target}")

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -46,11 +46,6 @@ if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif
 
-if HAVE_MINGW
-# For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-AM_CPPFLAGS += -D__USE_MINGW_ANSI_STDIO=1
-endif
-
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 

--- a/docs/examples/ftpgetinfo.c
+++ b/docs/examples/ftpgetinfo.c
@@ -75,8 +75,8 @@ int main(void)
       res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                               &filesize);
       if((CURLE_OK == res) && (filesize>0))
-        curl_mprintf("filesize %s: %" CURL_FORMAT_CURL_OFF_T " bytes\n",
-                     filename, filesize);
+        printf("filesize %s: %" CURL_FORMAT_CURL_OFF_T " bytes\n",
+               filename, filesize);
     }
     else {
       /* we failed */

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -37,7 +37,7 @@ extern "C" {
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__)
-#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
+#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -39,7 +39,7 @@ extern "C" {
 #if defined(__MINGW32__) && !defined(__clang__)
 #if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
-  __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
+  __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else
 #define CURL_TEMP_PRINTF(fmt, arg)
 #endif

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -36,7 +36,7 @@ extern "C" {
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && !defined(__clang__)
 #if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -36,9 +36,13 @@ extern "C" {
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__) && !defined(__clang__)
+#if defined(__MINGW32__)
+#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
-  __attribute__((format(gnu_printf, fmt, arg)))
+  __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
+#else
+#define CURL_TEMP_PRINTF(fmt, arg)
+#endif
 #else
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((format(printf, fmt, arg)))

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -178,10 +178,16 @@
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 
 #elif defined(__MINGW32__)
+#  include <_mingw.h>
 #  include <inttypes.h>
 #  define CURL_TYPEOF_CURL_OFF_T     long long
+#if defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR <= 7
+#  define CURL_FORMAT_CURL_OFF_T     "lld"
+#  define CURL_FORMAT_CURL_OFF_TU    "llu"
+#else
 #  define CURL_FORMAT_CURL_OFF_T     PRId64
 #  define CURL_FORMAT_CURL_OFF_TU    PRIu64
+#endif
 #  define CURL_SUFFIX_CURL_OFF_T     LL
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -178,16 +178,10 @@
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 
 #elif defined(__MINGW32__)
-#  include <_mingw.h>
 #  include <inttypes.h>
 #  define CURL_TYPEOF_CURL_OFF_T     long long
-#if defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR <= 7
-#  define CURL_FORMAT_CURL_OFF_T     "lld"
-#  define CURL_FORMAT_CURL_OFF_TU    "llu"
-#else
 #  define CURL_FORMAT_CURL_OFF_T     PRId64
 #  define CURL_FORMAT_CURL_OFF_TU    PRIu64
-#endif
 #  define CURL_SUFFIX_CURL_OFF_T     LL
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -86,12 +86,13 @@ size_t Curl_hyper_recv(void *userp, hyper_context *ctx,
   DEBUGASSERT(conn);
   (void)ctx;
 
-  DEBUGF(infof(data, "Curl_hyper_recv(%zu)", buflen));
+  DEBUGF(infof(data, "Curl_hyper_recv(%" CURL_FORMAT_SIZE_T ")", buflen));
   result = Curl_conn_recv(data, io_ctx->sockindex,
                           (char *)buf, buflen, &nread);
   if(result == CURLE_AGAIN) {
     /* would block, register interest */
-    DEBUGF(infof(data, "Curl_hyper_recv(%zu) -> EAGAIN", buflen));
+    DEBUGF(infof(data, "Curl_hyper_recv(%" CURL_FORMAT_SIZE_T ") -> EAGAIN",
+                 buflen));
     if(data->hyp.read_waker)
       hyper_waker_free(data->hyp.read_waker);
     data->hyp.read_waker = hyper_context_waker(ctx);
@@ -105,7 +106,8 @@ size_t Curl_hyper_recv(void *userp, hyper_context *ctx,
     failf(data, "Curl_read failed");
     return HYPER_IO_ERROR;
   }
-  DEBUGF(infof(data, "Curl_hyper_recv(%zu) -> %zd", buflen, nread));
+  DEBUGF(infof(data, "Curl_hyper_recv(%" CURL_FORMAT_SIZE_T ") "
+               "-> %" CURL_FORMAT_SSIZE_T, buflen, nread));
   return (size_t)nread;
 }
 
@@ -117,11 +119,12 @@ size_t Curl_hyper_send(void *userp, hyper_context *ctx,
   CURLcode result;
   size_t nwrote;
 
-  DEBUGF(infof(data, "Curl_hyper_send(%zu)", buflen));
+  DEBUGF(infof(data, "Curl_hyper_send(%" CURL_FORMAT_SIZE_T ")", buflen));
   result = Curl_conn_send(data, io_ctx->sockindex,
                           (void *)buf, buflen, FALSE, &nwrote);
   if(result == CURLE_AGAIN) {
-    DEBUGF(infof(data, "Curl_hyper_send(%zu) -> EAGAIN", buflen));
+    DEBUGF(infof(data, "Curl_hyper_send(%" CURL_FORMAT_SIZE_T ") "
+                 "-> EAGAIN", buflen));
     /* would block, register interest */
     if(data->hyp.write_waker)
       hyper_waker_free(data->hyp.write_waker);
@@ -136,7 +139,8 @@ size_t Curl_hyper_send(void *userp, hyper_context *ctx,
     failf(data, "Curl_write failed");
     return HYPER_IO_ERROR;
   }
-  DEBUGF(infof(data, "Curl_hyper_send(%zu) -> %zd", buflen, nwrote));
+  DEBUGF(infof(data, "Curl_hyper_send(%" CURL_FORMAT_SIZE_T ") "
+               "-> %" CURL_FORMAT_SSIZE_T, buflen, nwrote));
   return (size_t)nwrote;
 }
 

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -450,7 +450,7 @@ static int proxy_h2_process_pending_input(struct Curl_cfilter *cf,
 
     rv = nghttp2_session_mem_recv(ctx->h2, (const uint8_t *)buf, blen);
     CURL_TRC_CF(data, cf, "[0] %" CURL_FORMAT_SIZE_T " bytes to nghttp2 "
-                "-> %" CURL_FORMAT_SSIZE_T "", blen, rv);
+                "-> %" CURL_FORMAT_SSIZE_T, blen, rv);
     if(rv < 0) {
       failf(data,
             "process_pending_input: nghttp2_session_mem_recv() returned "

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1544,7 +1544,7 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     win_update_sndbuf_size(ctx);
 #endif
 
-  CURL_TRC_CF(data, cf, "send(len=%zu) -> %d, err=%d",
+  CURL_TRC_CF(data, cf, "send(len=%" CURL_FORMAT_SIZE_T ") -> %d, err=%d",
               orig_len, (int)nwritten, *err);
   cf->conn->sock[cf->sockindex] = fdsave;
   return nwritten;
@@ -1564,7 +1564,8 @@ static ssize_t cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     unsigned char c = 0;
     Curl_rand(data, &c, 1);
     if(c >= ((100-ctx->rblock_percent)*256/100)) {
-      CURL_TRC_CF(data, cf, "recv(len=%zu) SIMULATE EWOULDBLOCK", len);
+      CURL_TRC_CF(data, cf, "recv(len=%" CURL_FORMAT_SIZE_T ")"
+                  " SIMULATE EWOULDBLOCK", len);
       *err = CURLE_AGAIN;
       return -1;
     }
@@ -1572,7 +1573,8 @@ static ssize_t cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(cf->cft != &Curl_cft_udp && ctx->recv_max && ctx->recv_max < len) {
     size_t orig_len = len;
     len = ctx->recv_max;
-    CURL_TRC_CF(data, cf, "recv(len=%zu) SIMULATE max read of %zu bytes",
+    CURL_TRC_CF(data, cf, "recv(len=%" CURL_FORMAT_SIZE_T ")"
+                " SIMULATE max read of %" CURL_FORMAT_SIZE_T " bytes",
                 orig_len, len);
   }
 #endif
@@ -1607,8 +1609,8 @@ static ssize_t cf_socket_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
     }
   }
 
-  CURL_TRC_CF(data, cf, "recv(len=%zu) -> %d, err=%d", len, (int)nread,
-              *err);
+  CURL_TRC_CF(data, cf, "recv(len=%" CURL_FORMAT_SIZE_T ") "
+              "-> %d, err=%d", len, (int)nread, *err);
   if(nread > 0 && !ctx->got_first_byte) {
     ctx->first_byte_at = Curl_now();
     ctx->got_first_byte = TRUE;

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1483,7 +1483,8 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     unsigned char c = 0;
     Curl_rand_bytes(data, FALSE, &c, 1);
     if(c >= ((100-ctx->wblock_percent)*256/100)) {
-      CURL_TRC_CF(data, cf, "send(len=%zu) SIMULATE EWOULDBLOCK", orig_len);
+      CURL_TRC_CF(data, cf, "send(len=%" CURL_FORMAT_SIZE_T ") "
+                  "SIMULATE EWOULDBLOCK", orig_len);
       *err = CURLE_AGAIN;
       nwritten = -1;
       cf->conn->sock[cf->sockindex] = fdsave;
@@ -1494,7 +1495,8 @@ static ssize_t cf_socket_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     len = len * ctx->wpartial_percent / 100;
     if(!len)
       len = 1;
-    CURL_TRC_CF(data, cf, "send(len=%zu) SIMULATE partial write of %zu bytes",
+    CURL_TRC_CF(data, cf, "send(len=%" CURL_FORMAT_SIZE_T ") "
+                "SIMULATE partial write of %" CURL_FORMAT_SIZE_T " bytes",
                 orig_len, len);
   }
 #endif

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -324,9 +324,10 @@ int Curl_cpool_check_limits(struct Curl_easy *data,
       if(!oldest_idle)
         break;
       /* disconnect the old conn and continue */
-      DEBUGF(infof(data, "Discarding connection #%"
-                   CURL_FORMAT_CURL_OFF_T " from %zu to reach destination "
-                   "limit of %zu", oldest_idle->connection_id,
+      DEBUGF(infof(data, "Discarding connection #"
+                   "%" CURL_FORMAT_CURL_OFF_T " from "
+                   "%" CURL_FORMAT_SIZE_T " to reach destination limit of "
+                   "%" CURL_FORMAT_SIZE_T, oldest_idle->connection_id,
                    Curl_llist_count(&bundle->conns), dest_limit));
       Curl_cpool_disconnect(data, oldest_idle, FALSE);
     }
@@ -342,10 +343,11 @@ int Curl_cpool_check_limits(struct Curl_easy *data,
       if(!oldest_idle)
         break;
       /* disconnect the old conn and continue */
-      DEBUGF(infof(data, "Discarding connection #%"
-                   CURL_FORMAT_CURL_OFF_T " from %zu to reach total "
-                   "limit of %zu",
-                   oldest_idle->connection_id, cpool->num_conn, total_limit));
+      DEBUGF(infof(data, "Discarding connection #"
+                   "%" CURL_FORMAT_CURL_OFF_T " from "
+                   "%" CURL_FORMAT_SIZE_T " to reach total limit of "
+                   "%" CURL_FORMAT_SIZE_T, oldest_idle->connection_id,
+                   cpool->num_conn, total_limit));
       Curl_cpool_disconnect(data, oldest_idle, FALSE);
     }
     if(cpool->num_conn >= total_limit) {
@@ -385,7 +387,7 @@ CURLcode Curl_cpool_add_conn(struct Curl_easy *data,
   conn->connection_id = cpool->next_connection_id++;
   cpool->num_conn++;
   DEBUGF(infof(data, "Added connection %" CURL_FORMAT_CURL_OFF_T ". "
-               "The cache now contains %zu members",
+               "The cache now contains %" CURL_FORMAT_SIZE_T " members",
                conn->connection_id, cpool->num_conn));
 out:
   CPOOL_UNLOCK(cpool);
@@ -720,8 +722,8 @@ static void cpool_discard_conn(struct cpool *cpool,
    */
   if(CONN_INUSE(conn) && !aborted) {
     DEBUGF(infof(data, "[CCACHE] not discarding #%" CURL_FORMAT_CURL_OFF_T
-                       " still in use by %zu transfers", conn->connection_id,
-                       CONN_INUSE(conn)));
+                       " still in use by %" CURL_FORMAT_SIZE_T " transfers",
+                       conn->connection_id, CONN_INUSE(conn)));
     return;
   }
 
@@ -779,7 +781,8 @@ static void cpool_discard_conn(struct cpool *cpool,
 
   Curl_llist_append(&cpool->shutdowns, conn, &conn->cpool_node);
   DEBUGF(infof(data, "[CCACHE] added #%" CURL_FORMAT_CURL_OFF_T
-                     " to shutdown list of length %zu", conn->connection_id,
+                     " to shutdown list of length %" CURL_FORMAT_SIZE_T,
+                     conn->connection_id,
                      Curl_llist_count(&cpool->shutdowns)));
 }
 
@@ -799,7 +802,8 @@ void Curl_cpool_disconnect(struct Curl_easy *data,
    * are other users of it */
   if(CONN_INUSE(conn) && !aborted) {
     DEBUGASSERT(0); /* does this ever happen? */
-    DEBUGF(infof(data, "Curl_disconnect when inuse: %zu", CONN_INUSE(conn)));
+    DEBUGF(infof(data, "Curl_disconnect when inuse: %" CURL_FORMAT_SIZE_T,
+                       CONN_INUSE(conn)));
     return;
   }
 
@@ -983,7 +987,8 @@ static void cpool_perform(struct cpool *cpool)
     return;
 
   DEBUGASSERT(data);
-  DEBUGF(infof(data, "[CCACHE] perform, %zu connections being shutdown",
+  DEBUGF(infof(data, "[CCACHE] perform, "
+               "%" CURL_FORMAT_SIZE_T " connections being shutdown",
                Curl_llist_count(&cpool->shutdowns)));
   while(e) {
     enext = Curl_node_next(e);

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -581,7 +581,8 @@ Curl_cookie_add(struct Curl_easy *data,
         if(nlen >= (MAX_NAME-1) || vlen >= (MAX_NAME-1) ||
            ((nlen + vlen) > MAX_NAME)) {
           freecookie(co);
-          infof(data, "oversized cookie dropped, name/val %zu + %zu bytes",
+          infof(data, "oversized cookie dropped, name/val "
+                "%" CURL_FORMAT_SIZE_T " + %" CURL_FORMAT_SIZE_T " bytes",
                 nlen, vlen);
           return NULL;
         }
@@ -1433,8 +1434,8 @@ struct Cookie *Curl_cookie_getlist(struct Curl_easy *data,
 
             matches++;
             if(matches >= MAX_COOKIE_SEND_AMOUNT) {
-              infof(data, "Included max number of cookies (%zu) in request!",
-                    matches);
+              infof(data, "Included max number of cookies"
+                    " (%" CURL_FORMAT_SIZE_T ") in request!", matches);
               break;
             }
           }

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -514,12 +514,15 @@
 #endif
 
 #if SIZEOF_SIZE_T < 8
+#  define CURL_FORMAT_XSIZE_T "x"
 #  define CURL_FORMAT_SIZE_T  "u"
 #  define CURL_FORMAT_SSIZE_T "d"
 #elif defined(__MINGW32__)
+#  define CURL_FORMAT_XSIZE_T PRIx64
 #  define CURL_FORMAT_SIZE_T  CURL_FORMAT_CURL_OFF_TU
 #  define CURL_FORMAT_SSIZE_T CURL_FORMAT_CURL_OFF_T
 #else
+#  define CURL_FORMAT_XSIZE_T "zx"
 #  define CURL_FORMAT_SIZE_T  "zu"
 #  define CURL_FORMAT_SSIZE_T "zd"
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -412,10 +412,7 @@
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__)
-/* Skip format checks for older mingw-w64 versions. They do not grok
-   the `%zd` `%zu` formats by default, and there is format check CI
-   coverage with newer mingw-w64 versions without them. */
-#if __MINGW64_VERSION_MAJOR >= 8
+#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -317,17 +317,6 @@
 #define CURL_CONC_MACROS_(A,B) A ## B
 #define CURL_CONC_MACROS(A,B) CURL_CONC_MACROS_(A,B)
 
-/* curl uses its own printf() function internally. It understands the GNU
- * format. Use this format, so that is matches the GNU format attribute we
- * use with the MinGW compiler, allowing it to verify them at compile-time.
- */
-#ifdef  __MINGW32__
-#  undef CURL_FORMAT_CURL_OFF_T
-#  undef CURL_FORMAT_CURL_OFF_TU
-#  define CURL_FORMAT_CURL_OFF_T   "lld"
-#  define CURL_FORMAT_CURL_OFF_TU  "llu"
-#endif
-
 /* based on logic in "curl/mprintf.h" */
 
 #if (defined(__GNUC__) || defined(__clang__) ||                         \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -508,7 +508,7 @@
 #if SIZEOF_CURL_SOCKET_T < 8
 #  define CURL_FORMAT_SOCKET_T "d"
 #elif defined(__MINGW32__)
-#  define CURL_FORMAT_SOCKET_T "zd"
+#  define CURL_FORMAT_SOCKET_T CURL_FORMAT_CURL_OFF_T
 #else
 #  define CURL_FORMAT_SOCKET_T "qd"
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -411,7 +411,7 @@
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && !defined(__clang__)
 #if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -513,6 +513,17 @@
 #  define CURL_FORMAT_SOCKET_T "qd"
 #endif
 
+#if SIZEOF_SIZE_T < 8
+#  define CURL_FORMAT_SIZE_T  "u"
+#  define CURL_FORMAT_SSIZE_T "d"
+#elif defined(__MINGW32__)
+#  define CURL_FORMAT_SIZE_T  CURL_FORMAT_CURL_OFF_TU
+#  define CURL_FORMAT_SSIZE_T CURL_FORMAT_CURL_OFF_T
+#else
+#  define CURL_FORMAT_SIZE_T  "zu"
+#  define CURL_FORMAT_SSIZE_T "zd"
+#endif
+
 /*
  * Default sizeof(off_t) in case it has not been defined in config file.
  */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -414,7 +414,7 @@
 #if defined(__MINGW32__) && !defined(__clang__)
 #if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_PRINTF(fmt, arg) \
-  __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
+  __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else
 #define CURL_PRINTF(fmt, arg)
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -412,7 +412,10 @@
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__)
-#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
+/* Skip format checks for older mingw-w64 versions. They do not grok
+   the `%zd` `%zu` formats by default, and there is format check CI
+   coverage with newer mingw-w64 versions without them. */
+#if __MINGW64_VERSION_MAJOR >= 8
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -317,23 +317,6 @@
 #define CURL_CONC_MACROS_(A,B) A ## B
 #define CURL_CONC_MACROS(A,B) CURL_CONC_MACROS_(A,B)
 
-/* based on logic in "curl/mprintf.h" */
-
-#if (defined(__GNUC__) || defined(__clang__) ||                         \
-  defined(__IAR_SYSTEMS_ICC__)) &&                                      \
-  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
-  !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__) && !defined(__clang__)
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(gnu_printf, fmt, arg)))
-#else
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(__printf__, fmt, arg)))
-#endif
-#else
-#define CURL_PRINTF(fmt, arg)
-#endif
-
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro
    expected by macOS SDK v14 / Xcode v15 (2023) and newer.
    gcc (as of v14) is also missing it. */
@@ -421,6 +404,27 @@
 
 #include <stdio.h>
 #include <assert.h>
+
+/* based on logic in "curl/mprintf.h" */
+
+#if (defined(__GNUC__) || defined(__clang__) ||                         \
+  defined(__IAR_SYSTEMS_ICC__)) &&                                      \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
+  !defined(CURL_NO_FMT_CHECKS)
+#if defined(__MINGW32__)
+#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
+#else
+#define CURL_PRINTF(fmt, arg)
+#endif
+#else
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(__printf__, fmt, arg)))
+#endif
+#else
+#define CURL_PRINTF(fmt, arg)
+#endif
 
 #ifdef __TANDEM /* for ns*-tandem-nsk systems */
 # if ! defined __LP64

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -412,7 +412,7 @@
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__)
-#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
+#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else

--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -222,7 +222,8 @@ static CURLcode cw_out_ptr_flush(struct cw_out_ctx *ctx,
     Curl_set_in_callback(data, TRUE);
     nwritten = wcb((char *)buf, 1, wlen, wcb_data);
     Curl_set_in_callback(data, FALSE);
-    CURL_TRC_WRITE(data, "cw_out, wrote %zu %s bytes -> %zu",
+    CURL_TRC_WRITE(data, "cw_out, wrote %" CURL_FORMAT_SIZE_T " %s bytes "
+                   "-> %" CURL_FORMAT_SIZE_T "",
                    wlen, (otype == CW_OUT_BODY)? "body" : "header",
                    nwritten);
     if(CURL_WRITEFUNC_PAUSE == nwritten) {
@@ -240,12 +241,14 @@ static CURLcode cw_out_ptr_flush(struct cw_out_ctx *ctx,
       break;
     }
     else if(CURL_WRITEFUNC_ERROR == nwritten) {
-      failf(data, "client returned ERROR on write of %zu bytes", wlen);
+      failf(data, "client returned ERROR on write "
+            "of %" CURL_FORMAT_SIZE_T " bytes", wlen);
       return CURLE_WRITE_ERROR;
     }
     else if(nwritten != wlen) {
       failf(data, "Failure writing output to destination, "
-            "passed %zu returned %zd", wlen, nwritten);
+            "passed %" CURL_FORMAT_SIZE_T " returned "
+            "%" CURL_FORMAT_SSIZE_T, wlen, nwritten);
       return CURLE_WRITE_ERROR;
     }
     *pconsumed += nwritten;

--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -223,7 +223,7 @@ static CURLcode cw_out_ptr_flush(struct cw_out_ctx *ctx,
     nwritten = wcb((char *)buf, 1, wlen, wcb_data);
     Curl_set_in_callback(data, FALSE);
     CURL_TRC_WRITE(data, "cw_out, wrote %" CURL_FORMAT_SIZE_T " %s bytes "
-                   "-> %" CURL_FORMAT_SIZE_T "",
+                   "-> %" CURL_FORMAT_SIZE_T,
                    wlen, (otype == CW_OUT_BODY)? "body" : "header",
                    nwritten);
     if(CURL_WRITEFUNC_PAUSE == nwritten) {

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -905,7 +905,8 @@ CURLcode Curl_GetFTPResponse(struct Curl_easy *data,
   } /* while there is buffer left and loop is requested */
 
   pp->pending_resp = FALSE;
-  CURL_TRC_FTP(data, "getFTPResponse -> result=%d, nread=%zd, ftpcode=%d",
+  CURL_TRC_FTP(data, "getFTPResponse "
+               "-> result=%d, nread=%" CURL_FORMAT_SSIZE_T ", ftpcode=%d",
                result, *nreadp, *ftpcode);
 
   return result;

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -359,7 +359,8 @@ static CURLcode hds_cw_collect_write(struct Curl_easy *data,
         (type & CLIENTWRITE_TRAILER ? CURLH_TRAILER :
          CURLH_HEADER)));
     CURLcode result = Curl_headers_push(data, buf, htype);
-    CURL_TRC_WRITE(data, "header_collect pushed(type=%x, len=%zu) -> %d",
+    CURL_TRC_WRITE(data, "header_collect "
+                   "pushed(type=%x, len=%" CURL_FORMAT_SIZE_T ") -> %d",
                    htype, blen, result);
     if(result)
       return result;

--- a/lib/http.c
+++ b/lib/http.c
@@ -3117,7 +3117,7 @@ CURLcode Curl_http_header(struct Curl_easy *data,
         infof(data, "Illegal STS header skipped");
 #ifdef DEBUGBUILD
       else
-        infof(data, "Parsed STS header fine (%zu entries)",
+        infof(data, "Parsed STS header fine (%" CURL_FORMAT_SIZE_T " entries)",
               Curl_llist_count(&data->hsts->list));
 #endif
     }
@@ -3345,7 +3345,8 @@ CURLcode Curl_bump_headersize(struct Curl_easy *data,
   else
     bad = data->req.allheadercount + delta;
   if(bad) {
-    failf(data, "Too large response headers: %zu > %u", bad, max);
+    failf(data, "Too large response headers: %" CURL_FORMAT_SIZE_T " > %u",
+          bad, max);
     return CURLE_RECV_ERROR;
   }
   return CURLE_OK;

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -225,8 +225,9 @@ static CURLcode httpchunk_readwrite(struct Curl_easy *data,
       ch->datasize -= piece; /* decrease amount left to expect */
       buf += piece;    /* move read pointer forward */
       blen -= piece;   /* decrease space left in this round */
-      CURL_TRC_WRITE(data, "http_chunked, write %zu body bytes, %"
-                     CURL_FORMAT_CURL_OFF_T " bytes in chunk remain",
+      CURL_TRC_WRITE(data, "http_chunked, write "
+                     "%" CURL_FORMAT_SIZE_T " body bytes, "
+                     "%" CURL_FORMAT_CURL_OFF_T " bytes in chunk remain",
                      piece, ch->datasize);
 
       if(0 == ch->datasize)
@@ -449,7 +450,8 @@ static CURLcode cw_chunked_write(struct Curl_easy *data,
     /* chunks read successfully, download is complete */
     data->req.download_done = TRUE;
     if(blen) {
-      infof(data, "Leftovers after chunking: %zu bytes", blen);
+      infof(data, "Leftovers after chunking: %" CURL_FORMAT_SIZE_T " bytes",
+            blen);
     }
   }
   else if((type & CLIENTWRITE_EOS) && !data->req.no_body) {
@@ -594,8 +596,8 @@ static CURLcode add_chunk(struct Curl_easy *data,
       result = Curl_bufq_cwrite(&ctx->chunkbuf, buf, nread, &n);
     if(!result)
       result = Curl_bufq_cwrite(&ctx->chunkbuf, "\r\n", 2, &n);
-    CURL_TRC_READ(data, "http_chunk, made chunk of %zu bytes -> %d",
-                 nread, result);
+    CURL_TRC_READ(data, "http_chunk, made chunk of "
+                  "%" CURL_FORMAT_SIZE_T " bytes -> %d", nread, result);
     if(result)
       return result;
   }

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -587,7 +587,7 @@ static CURLcode add_chunk(struct Curl_easy *data,
     int hdlen;
     size_t n;
 
-    hdlen = msnprintf(hd, sizeof(hd), "%zx\r\n", nread);
+    hdlen = msnprintf(hd, sizeof(hd), "%" CURL_FORMAT_XSIZE_T "\r\n", nread);
     if(hdlen <= 0)
       return CURLE_READ_ERROR;
     /* On a soft-limited bufq, we do not need to check that all was written */

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1196,8 +1196,9 @@ static CURLcode imap_state_fetch_resp(struct Curl_easy *data,
       if(result)
         return result;
 
-      infof(data, "Written %zu bytes, %" CURL_FORMAT_CURL_OFF_TU
-            " bytes are left for transfer", chunk, size - chunk);
+      infof(data, "Written %" CURL_FORMAT_SIZE_T " bytes"
+            ", %" CURL_FORMAT_CURL_OFF_TU " bytes are left for transfer",
+            chunk, size - chunk);
 
       /* Have we used the entire overflow or just part of it?*/
       if(pp->overflow > chunk) {

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -837,7 +837,7 @@ static CURLcode choose_mech(struct Curl_easy *data, struct connectdata *conn)
 
   tmp_allocation = realloc(conn->app_data, mech->size);
   if(!tmp_allocation) {
-    failf(data, "Failed realloc of size %zu", mech->size);
+    failf(data, "Failed realloc of size %" CURL_FORMAT_SIZE_T, mech->size);
     mech = NULL;
     return CURLE_OUT_OF_MEMORY;
   }

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -954,7 +954,7 @@ static int _ldap_url_parse2(struct Curl_easy *data,
       char *unescaped;
       CURLcode result;
 
-      LDAP_TRACE(("attr[%zu] '%s'\n", i, attributes[i]));
+      LDAP_TRACE(("attr[%" CURL_FORMAT_SIZE_T "] '%s'\n", i, attributes[i]));
 
       /* Unescape the attribute */
       result = Curl_urldecode(attributes[i], 0, &unescaped, NULL,

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -177,7 +177,7 @@ ALLOC_FUNC void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
     mem->size = user_size;
 
   if(source)
-    curl_dbg_log("MEM %s:%d calloc(%" CURL_FORMAT_SIZE_T ","
+    curl_dbg_log("MEM %s:%d calloc(%" CURL_FORMAT_SIZE_T ", "
                  "%" CURL_FORMAT_SIZE_T ") = %p\n",
                  source, line, wanted_elements, wanted_size,
                  mem ? (void *)mem->mem : (void *)0);

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -177,7 +177,7 @@ ALLOC_FUNC void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
     mem->size = user_size;
 
   if(source)
-    curl_dbg_log("MEM %s:%d calloc(%" CURL_FORMAT_SIZE_T ", "
+    curl_dbg_log("MEM %s:%d calloc(%" CURL_FORMAT_SIZE_T ","
                  "%" CURL_FORMAT_SIZE_T ") = %p\n",
                  source, line, wanted_elements, wanted_size,
                  mem ? (void *)mem->mem : (void *)0);

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -149,7 +149,7 @@ ALLOC_FUNC void *curl_dbg_malloc(size_t wantedsize,
   }
 
   if(source)
-    curl_dbg_log("MEM %s:%d malloc(%zu) = %p\n",
+    curl_dbg_log("MEM %s:%d malloc(%" CURL_FORMAT_SIZE_T ") = %p\n",
                  source, line, wantedsize,
                  mem ? (void *)mem->mem : (void *)0);
 
@@ -177,7 +177,8 @@ ALLOC_FUNC void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
     mem->size = user_size;
 
   if(source)
-    curl_dbg_log("MEM %s:%d calloc(%zu,%zu) = %p\n",
+    curl_dbg_log("MEM %s:%d calloc(%" CURL_FORMAT_SIZE_T ","
+                 "%" CURL_FORMAT_SIZE_T ") = %p\n",
                  source, line, wanted_elements, wanted_size,
                  mem ? (void *)mem->mem : (void *)0);
 
@@ -202,7 +203,7 @@ ALLOC_FUNC char *curl_dbg_strdup(const char *str,
     memcpy(mem, str, len);
 
   if(source)
-    curl_dbg_log("MEM %s:%d strdup(%p) (%zu) = %p\n",
+    curl_dbg_log("MEM %s:%d strdup(%p) (%" CURL_FORMAT_SIZE_T ") = %p\n",
                  source, line, (const void *)str, len, (const void *)mem);
 
   return mem;
@@ -228,7 +229,7 @@ ALLOC_FUNC wchar_t *curl_dbg_wcsdup(const wchar_t *str,
     memcpy(mem, str, bsiz);
 
   if(source)
-    curl_dbg_log("MEM %s:%d wcsdup(%p) (%zu) = %p\n",
+    curl_dbg_log("MEM %s:%d wcsdup(%p) (%" CURL_FORMAT_SIZE_T ") = %p\n",
                 source, line, (void *)str, bsiz, (void *)mem);
 
   return mem;
@@ -264,7 +265,7 @@ void *curl_dbg_realloc(void *ptr, size_t wantedsize,
 
   mem = (Curl_crealloc)(mem, size);
   if(source)
-    curl_dbg_log("MEM %s:%d realloc(%p, %zu) = %p\n",
+    curl_dbg_log("MEM %s:%d realloc(%p, %" CURL_FORMAT_SIZE_T ") = %p\n",
                 source, line, (void *)ptr, wantedsize,
                 mem ? (void *)mem->mem : (void *)0);
 

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1949,14 +1949,15 @@ static CURLcode cr_mime_read(struct Curl_easy *data,
 
   /* Once we have errored, we will return the same error forever */
   if(ctx->errored) {
-    CURL_TRC_READ(data, "cr_mime_read(len=%zu) is errored -> %d, eos=0",
-                  blen, ctx->error_result);
+    CURL_TRC_READ(data, "cr_mime_read(len=%" CURL_FORMAT_SIZE_T ") is errored "
+                  "-> %d, eos=0", blen, ctx->error_result);
     *pnread = 0;
     *peos = FALSE;
     return ctx->error_result;
   }
   if(ctx->seen_eos) {
-    CURL_TRC_READ(data, "cr_mime_read(len=%zu) seen eos -> 0, eos=1", blen);
+    CURL_TRC_READ(data, "cr_mime_read(len=%" CURL_FORMAT_SIZE_T ") seen eos "
+                  "-> 0, eos=1", blen);
     *pnread = 0;
     *peos = TRUE;
     return CURLE_OK;
@@ -1975,15 +1976,16 @@ static CURLcode cr_mime_read(struct Curl_easy *data,
      * such small lengths. Returning 0 bytes read is a fix that only works
      * as request upload buffers will get flushed eventually and larger
      * reads will happen again. */
-    CURL_TRC_READ(data, "cr_mime_read(len=%zu), too small, return", blen);
+    CURL_TRC_READ(data, "cr_mime_read(len=%" CURL_FORMAT_SIZE_T ")"
+                  ", too small, return", blen);
     *pnread = 0;
     *peos = FALSE;
     goto out;
   }
 
   nread = Curl_mime_read(buf, 1, blen, ctx->part);
-  CURL_TRC_READ(data, "cr_mime_read(len=%zu), mime_read() -> %zd",
-                blen, nread);
+  CURL_TRC_READ(data, "cr_mime_read(len=%" CURL_FORMAT_SIZE_T ")"
+                ", mime_read() -> %" CURL_FORMAT_SSIZE_T, blen, nread);
 
   switch(nread) {
   case 0:
@@ -2008,7 +2010,8 @@ static CURLcode cr_mime_read(struct Curl_easy *data,
 
   case CURL_READFUNC_PAUSE:
     /* CURL_READFUNC_PAUSE pauses read callbacks that feed socket writes */
-    CURL_TRC_READ(data, "cr_mime_read(len=%zu), paused by callback", blen);
+    CURL_TRC_READ(data, "cr_mime_read(len=%" CURL_FORMAT_SIZE_T ")"
+                  ", paused by callback", blen);
     data->req.keepon |= KEEP_SEND_PAUSE; /* mark socket send as paused */
     *pnread = 0;
     *peos = FALSE;
@@ -2042,8 +2045,10 @@ static CURLcode cr_mime_read(struct Curl_easy *data,
   }
 
 out:
-  CURL_TRC_READ(data, "cr_mime_read(len=%zu, total=%" CURL_FORMAT_CURL_OFF_T
-                ", read=%"CURL_FORMAT_CURL_OFF_T") -> %d, %zu, %d",
+  CURL_TRC_READ(data, "cr_mime_read(len=%" CURL_FORMAT_SIZE_T
+                ", total=%" CURL_FORMAT_CURL_OFF_T
+                ", read=%"CURL_FORMAT_CURL_OFF_T") "
+                "-> %d, %" CURL_FORMAT_SIZE_T ", %d",
                 blen, ctx->total_len, ctx->read_len, CURLE_OK, *pnread, *peos);
   return CURLE_OK;
 }

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -302,7 +302,8 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   /* add client id */
   rc = add_client_id(client_id, strlen(client_id), packet, pos + 1);
   if(rc) {
-    failf(data, "Client ID length mismatched: [%zu]", strlen(client_id));
+    failf(data, "Client ID length mismatched: [%" CURL_FORMAT_SIZE_T "]",
+          strlen(client_id));
     result = CURLE_WEIRD_SERVER_REPLY;
     goto end;
   }
@@ -319,7 +320,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
     rc = add_user(username, ulen,
                   (unsigned char *)packet, start_user, remain_pos);
     if(rc) {
-      failf(data, "Username is too large: [%zu]", ulen);
+      failf(data, "Username is too large: [%" CURL_FORMAT_SIZE_T "]", ulen);
       result = CURLE_WEIRD_SERVER_REPLY;
       goto end;
     }
@@ -329,7 +330,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   if(plen) {
     rc = add_passwd(passwd, plen, packet, start_pwd, remain_pos);
     if(rc) {
-      failf(data, "Password is too large: [%zu]", plen);
+      failf(data, "Password is too large: [%" CURL_FORMAT_SIZE_T "]", plen);
       result = CURLE_WEIRD_SERVER_REPLY;
       goto end;
     }
@@ -660,7 +661,7 @@ MQTT_SUBACK_COMING:
 
     /* -- switched state -- */
     remlen = mq->remaining_length;
-    infof(data, "Remaining length: %zu bytes", remlen);
+    infof(data, "Remaining length: %" CURL_FORMAT_SIZE_T " bytes", remlen);
     if(data->set.max_filesize &&
        (curl_off_t)remlen > data->set.max_filesize) {
       failf(data, "Maximum file size exceeded");

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -607,8 +607,8 @@ static void multi_done_locked(struct connectdata *conn,
 
   if(CONN_INUSE(conn)) {
     /* Stop if still used. */
-    DEBUGF(infof(data, "Connection still in use %zu, "
-                 "no more multi_done now!",
+    DEBUGF(infof(data, "Connection still in use %" CURL_FORMAT_SIZE_T
+                 ", no more multi_done now!",
                  Curl_llist_count(&conn->easyq)));
     return;
   }
@@ -3805,7 +3805,8 @@ CURLcode Curl_multi_xfer_buf_borrow(struct Curl_easy *data,
   if(!data->multi->xfer_buf) {
     data->multi->xfer_buf = malloc((size_t)data->set.buffer_size);
     if(!data->multi->xfer_buf) {
-      failf(data, "could not allocate xfer_buf of %zu bytes",
+      failf(data, "could not allocate xfer_buf of "
+            "%" CURL_FORMAT_SIZE_T " bytes",
             (size_t)data->set.buffer_size);
       return CURLE_OUT_OF_MEMORY;
     }
@@ -3858,7 +3859,8 @@ CURLcode Curl_multi_xfer_ulbuf_borrow(struct Curl_easy *data,
   if(!data->multi->xfer_ulbuf) {
     data->multi->xfer_ulbuf = malloc((size_t)data->set.upload_buffer_size);
     if(!data->multi->xfer_ulbuf) {
-      failf(data, "could not allocate xfer_ulbuf of %zu bytes",
+      failf(data, "could not allocate xfer_ulbuf of "
+            "%" CURL_FORMAT_SIZE_T " bytes",
             (size_t)data->set.upload_buffer_size);
       return CURLE_OUT_OF_MEMORY;
     }

--- a/lib/request.c
+++ b/lib/request.c
@@ -210,7 +210,8 @@ static CURLcode xfer_send(struct Curl_easy *data,
   if(data->req.eos_read &&
     (Curl_bufq_is_empty(&data->req.sendbuf) ||
      Curl_bufq_len(&data->req.sendbuf) == blen)) {
-    DEBUGF(infof(data, "sending last upload chunk of %zu bytes", blen));
+    DEBUGF(infof(data, "sending last upload chunk of "
+           "%" CURL_FORMAT_SIZE_T " bytes", blen));
     eos = TRUE;
   }
   result = Curl_xfer_send(data, buf, blen, eos, pnwritten);
@@ -294,8 +295,8 @@ static CURLcode req_flush(struct Curl_easy *data)
     if(result)
       return result;
     if(!Curl_bufq_is_empty(&data->req.sendbuf)) {
-      DEBUGF(infof(data, "Curl_req_flush(len=%zu) -> EAGAIN",
-             Curl_bufq_len(&data->req.sendbuf)));
+      DEBUGF(infof(data, "Curl_req_flush(len=%" CURL_FORMAT_SIZE_T ") "
+             "-> EAGAIN", Curl_bufq_len(&data->req.sendbuf)));
       return CURLE_AGAIN;
     }
   }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -651,7 +651,8 @@ static CURLcode rtsp_filter_rtp(struct Curl_easy *data,
             /* This could be the next response, no consume and return */
             if(*pconsumed) {
               DEBUGF(infof(data, "RTP rtsp_filter_rtp[SKIP] RTSP/ prefix, "
-                           "skipping %zd bytes of junk", *pconsumed));
+                           "skipping %" CURL_FORMAT_SSIZE_T " bytes of junk",
+                           *pconsumed));
             }
             rtspc->state = RTP_PARSE_SKIP;
             rtspc->in_header = TRUE;
@@ -757,7 +758,7 @@ static CURLcode rtsp_filter_rtp(struct Curl_easy *data,
         buf += needed;
         blen -= needed;
         /* complete RTP message in buffer */
-        DEBUGF(infof(data, "RTP write channel %d rtp_len %zu",
+        DEBUGF(infof(data, "RTP write channel %d rtp_len %" CURL_FORMAT_SIZE_T,
                      rtspc->rtp_channel, rtspc->rtp_len));
         result = rtp_client_write(data, Curl_dyn_ptr(&rtspc->buf),
                                   rtspc->rtp_len);
@@ -804,8 +805,8 @@ static CURLcode rtsp_rtp_write_resp(struct Curl_easy *data,
     goto out;
   }
 
-  DEBUGF(infof(data, "rtsp_rtp_write_resp(len=%zu, in_header=%d, eos=%d)",
-               blen, rtspc->in_header, is_eos));
+  DEBUGF(infof(data, "rtsp_rtp_write_resp(len=%" CURL_FORMAT_SIZE_T
+               ", in_header=%d, eos=%d)", blen, rtspc->in_header, is_eos));
 
   /* If header parsing is not ongoing, extract RTP messages */
   if(!rtspc->in_header) {
@@ -816,8 +817,8 @@ static CURLcode rtsp_rtp_write_resp(struct Curl_easy *data,
     blen -= consumed;
     /* either we consumed all or are at the start of header parsing */
     if(blen && !data->req.header)
-      DEBUGF(infof(data, "RTSP: %zu bytes, possibly excess in response body",
-                   blen));
+      DEBUGF(infof(data, "RTSP: %" CURL_FORMAT_SIZE_T " bytes"
+                   ", possibly excess in response body", blen));
   }
 
   /* we want to parse headers, do so */
@@ -853,7 +854,8 @@ static CURLcode rtsp_rtp_write_resp(struct Curl_easy *data,
   /* we SHOULD have consumed all bytes, unless the response is borked.
    * In which case we write out the left over bytes, letting the client
    * writer deal with it (it will report EXCESS and fail the transfer). */
-  DEBUGF(infof(data, "rtsp_rtp_write_resp(len=%zu, in_header=%d, done=%d "
+  DEBUGF(infof(data, "rtsp_rtp_write_resp(len=%" CURL_FORMAT_SIZE_T
+               ", in_header=%d, done=%d "
                " rtspc->state=%d, req.size=%" CURL_FORMAT_CURL_OFF_T ")",
                blen, rtspc->in_header, data->req.done, rtspc->state,
                data->req.size));

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -89,8 +89,8 @@ CURLcode Curl_client_write(struct Curl_easy *data,
   }
 
   result = Curl_cwriter_write(data, data->req.writer_stack, type, buf, blen);
-  CURL_TRC_WRITE(data, "client_write(type=%x, len=%zu) -> %d",
-                 type, blen, result);
+  CURL_TRC_WRITE(data, "client_write(type=%x, len=%" CURL_FORMAT_SIZE_T ") "
+                 "-> %d", type, blen, result);
   return result;
 }
 
@@ -251,7 +251,8 @@ static CURLcode cw_download_write(struct Curl_easy *data,
     if(is_connect && data->set.suppress_connect_headers)
       return CURLE_OK;
     result = Curl_cwriter_write(data, writer->next, type, buf, nbytes);
-    CURL_TRC_WRITE(data, "download_write header(type=%x, blen=%zu) -> %d",
+    CURL_TRC_WRITE(data, "download_write "
+                   "header(type=%x, blen=%" CURL_FORMAT_SIZE_T ") -> %d",
                    type, nbytes, result);
     return result;
   }
@@ -265,7 +266,8 @@ static CURLcode cw_download_write(struct Curl_easy *data,
   if(data->req.no_body && nbytes > 0) {
     /* BODY arrives although we want none, bail out */
     streamclose(data->conn, "ignoring body");
-    CURL_TRC_WRITE(data, "download_write body(type=%x, blen=%zu), "
+    CURL_TRC_WRITE(data, "download_write "
+                   "body(type=%x, blen=%" CURL_FORMAT_SIZE_T "), "
                    "did not want a BODY", type, nbytes);
     data->req.download_done = TRUE;
     if(data->info.header_size)
@@ -309,7 +311,8 @@ static CURLcode cw_download_write(struct Curl_easy *data,
 
   if(!data->req.ignorebody && (nwrite || (type & CLIENTWRITE_EOS))) {
     result = Curl_cwriter_write(data, writer->next, type, buf, nwrite);
-    CURL_TRC_WRITE(data, "download_write body(type=%x, blen=%zu) -> %d",
+    CURL_TRC_WRITE(data, "download_write "
+                   "body(type=%x, blen=%" CURL_FORMAT_SIZE_T ") -> %d",
                    type, nbytes, result);
     if(result)
       return result;
@@ -327,7 +330,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
     if(!data->req.ignorebody) {
       infof(data,
             "Excess found writing body:"
-            " excess = %zu"
+            " excess = %" CURL_FORMAT_SIZE_T
             ", size = %" CURL_FORMAT_CURL_OFF_T
             ", maxdownload = %" CURL_FORMAT_CURL_OFF_T
             ", bytecount = %" CURL_FORMAT_CURL_OFF_T,
@@ -738,8 +741,10 @@ static CURLcode cr_in_read(struct Curl_easy *data,
     *peos = ctx->seen_eos;
     break;
   }
-  CURL_TRC_READ(data, "cr_in_read(len=%zu, total=%"CURL_FORMAT_CURL_OFF_T
-                ", read=%"CURL_FORMAT_CURL_OFF_T") -> %d, nread=%zu, eos=%d",
+  CURL_TRC_READ(data, "cr_in_read(len=%" CURL_FORMAT_SIZE_T
+                ", total=%"CURL_FORMAT_CURL_OFF_T
+                ", read=%"CURL_FORMAT_CURL_OFF_T") "
+                "-> %d, nread=%" CURL_FORMAT_SIZE_T ", eos=%d",
                 blen, ctx->total_len, ctx->read_len, CURLE_OK,
                 *pnread, *peos);
   return CURLE_OK;
@@ -1043,7 +1048,8 @@ static CURLcode cr_lc_read(struct Curl_easy *data,
   }
 
 out:
-  CURL_TRC_READ(data, "cr_lc_read(len=%zu) -> %d, nread=%zu, eos=%d",
+  CURL_TRC_READ(data, "cr_lc_read(len=%" CURL_FORMAT_SIZE_T ") "
+                "-> %d, nread=%" CURL_FORMAT_SIZE_T ", eos=%d",
                 blen, result, *pnread, *peos);
   return result;
 }
@@ -1190,7 +1196,8 @@ CURLcode Curl_client_read(struct Curl_easy *data, char *buf, size_t blen,
 
   result = Curl_creader_read(data, data->req.reader_stack, buf, blen,
                              nread, eos);
-  CURL_TRC_READ(data, "client_read(len=%zu) -> %d, nread=%zu, eos=%d",
+  CURL_TRC_READ(data, "client_read(len=%" CURL_FORMAT_SIZE_T ") "
+                "-> %d, nread=%" CURL_FORMAT_SIZE_T ", eos=%d",
                 blen, result, *nread, *eos);
   return result;
 }
@@ -1287,7 +1294,8 @@ static CURLcode cr_buf_read(struct Curl_easy *data,
     ctx->index += nread;
     *peos = (ctx->index == ctx->blen);
   }
-  CURL_TRC_READ(data, "cr_buf_read(len=%zu) -> 0, nread=%zu, eos=%d",
+  CURL_TRC_READ(data, "cr_buf_read(len=%" CURL_FORMAT_SIZE_T ") "
+                "-> 0, nread=%" CURL_FORMAT_SIZE_T ", eos=%d",
                 blen, *pnread, *peos);
   return CURLE_OK;
 }
@@ -1364,7 +1372,8 @@ CURLcode Curl_creader_set_buf(struct Curl_easy *data,
   cl_reset_reader(data);
   result = do_init_reader_stack(data, r);
 out:
-  CURL_TRC_READ(data, "add buf reader, len=%zu -> %d", blen, result);
+  CURL_TRC_READ(data, "add buf reader, len=%" CURL_FORMAT_SIZE_T " -> %d",
+                blen, result);
   return result;
 }
 

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1909,8 +1909,8 @@ static CURLcode cr_eob_read(struct Curl_easy *data,
     ctx->eos = TRUE;
   }
   *peos = ctx->eos;
-  DEBUGF(infof(data, "cr_eob_read(%zu) -> %d, %zd, %d",
-         blen, result, *pnread, *peos));
+  DEBUGF(infof(data, "cr_eob_read(%" CURL_FORMAT_SIZE_T ") "
+         "-> %d, %" CURL_FORMAT_SSIZE_T ", %d", blen, result, *pnread, *peos));
   return result;
 }
 

--- a/lib/socks_gssapi.c
+++ b/lib/socks_gssapi.c
@@ -499,8 +499,8 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     gss_release_buffer(&gss_status, &gss_recv_token);
 
     if(gss_w_token.length != 1) {
-      failf(data, "Invalid GSS-API encryption response length (%zu).",
-            gss_w_token.length);
+      failf(data, "Invalid GSS-API encryption response length"
+            " (%" CURL_FORMAT_SIZE_T ").", gss_w_token.length);
       gss_release_buffer(&gss_status, &gss_w_token);
       gss_delete_sec_context(&gss_status, &gss_context, NULL);
       return CURLE_COULDNT_CONNECT;
@@ -511,8 +511,8 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
   }
   else {
     if(gss_recv_token.length != 1) {
-      failf(data, "Invalid GSS-API encryption response length (%zu).",
-            gss_recv_token.length);
+      failf(data, "Invalid GSS-API encryption response length"
+            " (%" CURL_FORMAT_SIZE_T ").", gss_recv_token.length);
       gss_release_buffer(&gss_status, &gss_recv_token);
       gss_delete_sec_context(&gss_status, &gss_context, NULL);
       return CURLE_COULDNT_CONNECT;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1202,8 +1202,8 @@ CURLcode Curl_xfer_write_resp(struct Curl_easy *data,
     data->req.eos_written = TRUE;
     data->req.download_done = TRUE;
   }
-  CURL_TRC_WRITE(data, "xfer_write_resp(len=%zu, eos=%d) -> %d",
-                 blen, is_eos, result);
+  CURL_TRC_WRITE(data, "xfer_write_resp(len=%" CURL_FORMAT_SIZE_T
+                 ", eos=%d) -> %d", blen, is_eos, result);
   return result;
 }
 
@@ -1261,8 +1261,8 @@ CURLcode Curl_xfer_send(struct Curl_easy *data,
   else if(!result && *pnwritten)
     data->info.request_size += *pnwritten;
 
-  DEBUGF(infof(data, "Curl_xfer_send(len=%zu) -> %d, %zu",
-               blen, result, *pnwritten));
+  DEBUGF(infof(data, "Curl_xfer_send(len=%" CURL_FORMAT_SIZE_T ") "
+               "-> %d, %" CURL_FORMAT_SIZE_T, blen, result, *pnwritten));
   return result;
 }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -1160,13 +1160,13 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
     if(CONN_INUSE(conn) >=
             Curl_multi_max_concurrent_streams(data->multi)) {
       infof(data, "client side MAX_CONCURRENT_STREAMS reached"
-            ", skip (%zu)", CONN_INUSE(conn));
+            ", skip (%" CURL_FORMAT_SIZE_T ")", CONN_INUSE(conn));
       return FALSE;
     }
     if(CONN_INUSE(conn) >=
             Curl_conn_get_max_concurrent(data, conn, FIRSTSOCKET)) {
-      infof(data, "MAX_CONCURRENT_STREAMS reached, skip (%zu)",
-            CONN_INUSE(conn));
+      infof(data, "MAX_CONCURRENT_STREAMS reached"
+            ", skip (%" CURL_FORMAT_SIZE_T ")", CONN_INUSE(conn));
       return FALSE;
     }
     /* When not multiplexed, we have a match here! */

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -747,7 +747,8 @@ static bool cf_msh3_data_pending(struct Curl_cfilter *cf,
   (void)cf;
   if(stream && stream->req) {
     msh3_lock_acquire(&stream->recv_lock);
-    CURL_TRC_CF((struct Curl_easy *)data, cf, "data pending = %" CURL_FORMAT_SIZE_T,
+    CURL_TRC_CF((struct Curl_easy *)data, cf,
+                "data pending = %" CURL_FORMAT_SIZE_T,
                 Curl_bufq_len(&stream->recvbuf));
     pending = !Curl_bufq_is_empty(&stream->recvbuf);
     msh3_lock_release(&stream->recv_lock);

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -530,8 +530,8 @@ static ssize_t recv_closed_stream(struct Curl_cfilter *cf,
     goto out;
   }
   else if(stream->error3) {
-    failf(data, "HTTP/3 stream was not closed cleanly: (error %zd)",
-          (ssize_t)stream->error3);
+    failf(data, "HTTP/3 stream was not closed cleanly:"
+          " (error %" CURL_FORMAT_SSIZE_T ")", (ssize_t)stream->error3);
     *err = CURLE_HTTP3;
     CURL_TRC_CF(data, cf, "cf_recv, closed uncleanly -> %d", *err);
     goto out;
@@ -571,7 +571,8 @@ static ssize_t cf_msh3_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   ssize_t nread = -1;
   struct cf_call_data save;
 
-  CURL_TRC_CF(data, cf, "cf_recv(len=%zu), stream=%d", len, !!stream);
+  CURL_TRC_CF(data, cf, "cf_recv(len=%" CURL_FORMAT_SIZE_T "), stream=%d",
+              len, !!stream);
   if(!stream) {
     *err = CURLE_RECV_ERROR;
     return -1;
@@ -591,7 +592,8 @@ static ssize_t cf_msh3_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(!Curl_bufq_is_empty(&stream->recvbuf)) {
     nread = Curl_bufq_read(&stream->recvbuf,
                            (unsigned char *)buf, len, err);
-    CURL_TRC_CF(data, cf, "read recvbuf(len=%zu) -> %zd, %d",
+    CURL_TRC_CF(data, cf, "read recvbuf(len=%" CURL_FORMAT_SIZE_T ") "
+                "-> %" CURL_FORMAT_SSIZE_T ", %d",
                 len, nread, *err);
     if(nread < 0)
       goto out;
@@ -634,7 +636,7 @@ static ssize_t cf_msh3_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
   /* Sizes must match for cast below to work" */
   DEBUGASSERT(stream);
-  CURL_TRC_CF(data, cf, "req: send %zu bytes", len);
+  CURL_TRC_CF(data, cf, "req: send %" CURL_FORMAT_SIZE_T " bytes", len);
 
   if(!stream->req) {
     /* The first send on the request contains the headers and possibly some
@@ -668,7 +670,8 @@ static ssize_t cf_msh3_send(struct Curl_cfilter *cf, struct Curl_easy *data,
       nva[i].ValueLength = e->valuelen;
     }
 
-    CURL_TRC_CF(data, cf, "req: send %zu headers", nheader);
+    CURL_TRC_CF(data, cf, "req: send %" CURL_FORMAT_SIZE_T " headers",
+                nheader);
     stream->req = MsH3RequestOpen(ctx->qconn, &msh3_request_if, data,
                                   nva, nheader,
                                   eos ? MSH3_REQUEST_FLAG_FIN :
@@ -684,7 +687,7 @@ static ssize_t cf_msh3_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
   else {
     /* request is open */
-    CURL_TRC_CF(data, cf, "req: send %zu body bytes", len);
+    CURL_TRC_CF(data, cf, "req: send %" CURL_FORMAT_SIZE_T " body bytes", len);
     if(len > 0xFFFFFFFF) {
       len = 0xFFFFFFFF;
     }
@@ -744,7 +747,7 @@ static bool cf_msh3_data_pending(struct Curl_cfilter *cf,
   (void)cf;
   if(stream && stream->req) {
     msh3_lock_acquire(&stream->recv_lock);
-    CURL_TRC_CF((struct Curl_easy *)data, cf, "data pending = %zu",
+    CURL_TRC_CF((struct Curl_easy *)data, cf, "data pending = %" CURL_FORMAT_SIZE_T,
                 Curl_bufq_len(&stream->recvbuf));
     pending = !Curl_bufq_is_empty(&stream->recvbuf);
     msh3_lock_release(&stream->recv_lock);

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -520,7 +520,7 @@ static int cb_recv_stream_data(ngtcp2_conn *tconn, uint32_t flags,
   if(data)
     CURL_TRC_CF(data, cf, "[%" CURL_PRId64 "] "
                 "read_stream(len=%" CURL_FORMAT_SIZE_T ") "
-                "-> %" CURL_FORMAT_SSIZE_T "", stream_id, buflen, nconsumed);
+                "-> %" CURL_FORMAT_SSIZE_T, stream_id, buflen, nconsumed);
   if(nconsumed < 0) {
     struct h3_stream_ctx *stream = H3_STREAM_CTX_ID(ctx, stream_id);
     if(data && stream) {

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -460,8 +460,8 @@ static CURLcode cf_recv_body(struct Curl_cfilter *cf,
                              stream_resp_read, &cb_ctx, &result);
 
   if(nwritten < 0 && result != CURLE_AGAIN) {
-    CURL_TRC_CF(data, cf, "[%"CURL_PRIu64"] recv_body error %" CURL_FORMAT_SSIZE_T,
-                stream->id, nwritten);
+    CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] "
+                "recv_body error %" CURL_FORMAT_SSIZE_T, stream->id, nwritten);
     failf(data, "Error %d in HTTP/3 response body for stream[%"CURL_PRIu64"]",
           result, stream->id);
     stream->closed = TRUE;
@@ -714,7 +714,8 @@ static ssize_t read_pkt_to_send(void *userp,
   }
 
   if(nwritten < 0) {
-    failf(x->data, "quiche_conn_send returned %" CURL_FORMAT_SSIZE_T, nwritten);
+    failf(x->data, "quiche_conn_send returned %" CURL_FORMAT_SSIZE_T,
+          nwritten);
     *err = CURLE_SEND_ERROR;
     return -1;
   }
@@ -960,7 +961,8 @@ static ssize_t cf_quiche_send_body(struct Curl_cfilter *cf,
   else if(nwritten < 0) {
     CURL_TRC_CF(data, cf, "[%" CURL_PRIu64 "] "
                 "send_body(len=%" CURL_FORMAT_SIZE_T ") "
-                "-> quiche err %" CURL_FORMAT_SSIZE_T, stream->id, len, nwritten);
+                "-> quiche err %" CURL_FORMAT_SSIZE_T,
+                stream->id, len, nwritten);
     *err = CURLE_SEND_ERROR;
     return -1;
   }

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -180,14 +180,15 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
     case EIO:
       if(pktlen > gsolen) {
         /* GSO failure */
-        failf(data, "sendmsg() returned %zd (errno %d); disable GSO", sent,
-              SOCKERRNO);
+        failf(data, "sendmsg() returned %" CURL_FORMAT_SSIZE_T " (errno %d);"
+              " disable GSO", sent, SOCKERRNO);
         qctx->no_gso = TRUE;
         return send_packet_no_gso(cf, data, qctx, pkt, pktlen, gsolen, psent);
       }
       FALLTHROUGH();
     default:
-      failf(data, "sendmsg() returned %zd (errno %d)", sent, SOCKERRNO);
+      failf(data, "sendmsg() returned %" CURL_FORMAT_SSIZE_T " (errno %d)",
+            sent, SOCKERRNO);
       return CURLE_SEND_ERROR;
     }
   }
@@ -210,7 +211,8 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
       return CURLE_AGAIN;
     }
     else {
-      failf(data, "send() returned %zd (errno %d)", sent, SOCKERRNO);
+      failf(data, "send() returned %" CURL_FORMAT_SSIZE_T " (errno %d)",
+            sent, SOCKERRNO);
       if(SOCKERRNO != EMSGSIZE) {
         return CURLE_SEND_ERROR;
       }
@@ -294,7 +296,9 @@ CURLcode vquic_flush(struct Curl_cfilter *cf, struct Curl_easy *data,
     }
 
     result = vquic_send_packets(cf, data, qctx, buf, blen, gsolen, &sent);
-    CURL_TRC_CF(data, cf, "vquic_send(len=%zu, gso=%zu) -> %d, sent=%zu",
+    CURL_TRC_CF(data, cf, "vquic_send(len=%" CURL_FORMAT_SIZE_T
+                          ", gso=%" CURL_FORMAT_SIZE_T ") -> %d"
+                          ", sent=%" CURL_FORMAT_SIZE_T,
                 blen, gsolen, result, sent);
     if(result) {
       if(result == CURLE_AGAIN) {
@@ -326,7 +330,10 @@ CURLcode vquic_send_tail_split(struct Curl_cfilter *cf, struct Curl_easy *data,
   qctx->split_len = Curl_bufq_len(&qctx->sendbuf) - tail_len;
   qctx->split_gsolen = gsolen;
   qctx->gsolen = tail_gsolen;
-  CURL_TRC_CF(data, cf, "vquic_send_tail_split: [%zu gso=%zu][%zu gso=%zu]",
+  CURL_TRC_CF(data, cf, "vquic_send_tail_split: [%" CURL_FORMAT_SIZE_T
+                        " gso=%" CURL_FORMAT_SIZE_T "]"
+                        "[%" CURL_FORMAT_SIZE_T
+                        " gso=%" CURL_FORMAT_SIZE_T "]",
               qctx->split_len, qctx->split_gsolen,
               tail_len, qctx->gsolen);
   return vquic_flush(cf, data, qctx);
@@ -453,7 +460,8 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
 
 out:
   if(total_nread || result)
-    CURL_TRC_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
+    CURL_TRC_CF(data, cf, "recvd %" CURL_FORMAT_SIZE_T " packets with "
+                          "%" CURL_FORMAT_SIZE_T " bytes -> %d",
                 pkts, total_nread, result);
   return result;
 }
@@ -507,7 +515,8 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
         goto out;
       }
       Curl_strerror(SOCKERRNO, errstr, sizeof(errstr));
-      failf(data, "QUIC: recvmsg() unexpectedly returned %zd (errno=%d; %s)",
+      failf(data, "QUIC: recvmsg() unexpectedly returned "
+                  "%" CURL_FORMAT_SSIZE_T " (errno=%d; %s)",
                   nread, SOCKERRNO, errstr);
       result = CURLE_RECV_ERROR;
       goto out;
@@ -540,7 +549,8 @@ static CURLcode recvmsg_packets(struct Curl_cfilter *cf,
 
 out:
   if(total_nread || result)
-    CURL_TRC_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
+    CURL_TRC_CF(data, cf, "recvd %" CURL_FORMAT_SIZE_T " packets with "
+                          "%" CURL_FORMAT_SIZE_T " bytes -> %d",
                 pkts, total_nread, result);
   return result;
 }
@@ -582,7 +592,8 @@ static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
         goto out;
       }
       Curl_strerror(SOCKERRNO, errstr, sizeof(errstr));
-      failf(data, "QUIC: recvfrom() unexpectedly returned %zd (errno=%d; %s)",
+      failf(data, "QUIC: recvfrom() unexpectedly returned "
+                  "%" CURL_FORMAT_SSIZE_T " (errno=%d; %s)",
                   nread, SOCKERRNO, errstr);
       result = CURLE_RECV_ERROR;
       goto out;
@@ -598,7 +609,8 @@ static CURLcode recvfrom_packets(struct Curl_cfilter *cf,
 
 out:
   if(total_nread || result)
-    CURL_TRC_CF(data, cf, "recvd %zu packets with %zu bytes -> %d",
+    CURL_TRC_CF(data, cf, "recvd %" CURL_FORMAT_SIZE_T " packets with "
+                          "%" CURL_FORMAT_SIZE_T " bytes -> %d",
                 pkts, total_nread, result);
   return result;
 }

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -281,7 +281,8 @@ static ssize_t wsftp_send(struct Curl_easy *data, int sockindex,
     return -1;
   }
   DEBUGASSERT(rc == (int)len);
-  infof(data, "sent %zu bytes SFTP from offset %" CURL_FORMAT_CURL_OFF_T,
+  infof(data, "sent %" CURL_FORMAT_SIZE_T " bytes SFTP "
+              "from offset %" CURL_FORMAT_CURL_OFF_T,
         len, sshc->offset);
   sshc->offset += len;
   return (ssize_t)rc;

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -727,7 +727,8 @@ static CURLcode bearssl_run_until(struct Curl_cfilter *cf,
       buf = br_ssl_engine_sendrec_buf(&backend->ctx.eng, &len);
       ret = Curl_conn_cf_send(cf->next, data, (char *)buf, len, FALSE,
                               &result);
-      CURL_TRC_CF(data, cf, "ssl_send(len=%zu) -> %zd, %d", len, ret, result);
+      CURL_TRC_CF(data, cf, "ssl_send(len=%" CURL_FORMAT_SIZE_T ") -> "
+                  "%" CURL_FORMAT_SSIZE_T ", %d", len, ret, result);
       if(ret <= 0) {
         if(result == CURLE_AGAIN)
           connssl->io_need |= CURL_SSL_IO_NEED_SEND;
@@ -738,7 +739,8 @@ static CURLcode bearssl_run_until(struct Curl_cfilter *cf,
     else if(state & BR_SSL_RECVREC) {
       buf = br_ssl_engine_recvrec_buf(&backend->ctx.eng, &len);
       ret = Curl_conn_cf_recv(cf->next, data, (char *)buf, len, &result);
-      CURL_TRC_CF(data, cf, "ssl_recv(len=%zu) -> %zd, %d", len, ret, result);
+      CURL_TRC_CF(data, cf, "ssl_recv(len=%" CURL_FORMAT_SIZE_T ") -> "
+                  "%" CURL_FORMAT_SSIZE_T ", %d", len, ret, result);
       if(ret == 0) {
         failf(data, "SSL: EOF without close notify");
         return CURLE_RECV_ERROR;

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -103,8 +103,8 @@ static ssize_t gtls_push(void *s, const void *buf, size_t blen)
 
   DEBUGASSERT(data);
   nwritten = Curl_conn_cf_send(cf->next, data, buf, blen, FALSE, &result);
-  CURL_TRC_CF(data, cf, "gtls_push(len=%zu) -> %zd, err=%d",
-              blen, nwritten, result);
+  CURL_TRC_CF(data, cf, "gtls_push(len=%" CURL_FORMAT_SIZE_T ") -> "
+              "%" CURL_FORMAT_SSIZE_T ", err=%d", blen, nwritten, result);
   backend->gtls.io_result = result;
   if(nwritten < 0) {
     gnutls_transport_set_errno(backend->gtls.session,
@@ -135,8 +135,8 @@ static ssize_t gtls_pull(void *s, void *buf, size_t blen)
   }
 
   nread = Curl_conn_cf_recv(cf->next, data, buf, blen, &result);
-  CURL_TRC_CF(data, cf, "glts_pull(len=%zu) -> %zd, err=%d",
-              blen, nread, result);
+  CURL_TRC_CF(data, cf, "glts_pull(len=%" CURL_FORMAT_SIZE_T ") -> "
+              "%" CURL_FORMAT_SSIZE_T ", err=%d", blen, nread, result);
   backend->gtls.io_result = result;
   if(nread < 0) {
     gnutls_transport_set_errno(backend->gtls.session,
@@ -745,8 +745,8 @@ static CURLcode gtls_update_session_id(struct Curl_cfilter *cf,
       /* extract session ID to the allocated buffer */
       gnutls_session_get_data(session, connect_sessionid, &connect_idsize);
 
-      CURL_TRC_CF(data, cf, "get session id (len=%zu) and store in cache",
-                  connect_idsize);
+      CURL_TRC_CF(data, cf, "get session id (len=%" CURL_FORMAT_SIZE_T ") "
+                  "and store in cache", connect_idsize);
       Curl_ssl_sessionid_lock(data);
       /* store this session id, takes ownership */
       result = Curl_ssl_set_sessionid(cf, data, &connssl->peer,
@@ -1091,7 +1091,8 @@ CURLcode Curl_gtls_ctx_init(struct gtls_ctx *gctx,
       if(rc < 0)
         infof(data, "SSL failed to set session ID");
       else
-        infof(data, "SSL reusing session ID (size=%zu)", ssl_idsize);
+        infof(data, "SSL reusing session ID (size=%" CURL_FORMAT_SIZE_T ")",
+              ssl_idsize);
     }
     Curl_ssl_sessionid_unlock(data);
   }

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -202,8 +202,9 @@ static int mbedtls_bio_cf_write(void *bio,
 
   nwritten = Curl_conn_cf_send(cf->next, data, (char *)buf, blen, FALSE,
                                &result);
-  CURL_TRC_CF(data, cf, "mbedtls_bio_cf_out_write(len=%zu) -> %zd, err=%d",
-              blen, nwritten, result);
+  CURL_TRC_CF(data, cf, "mbedtls_bio_cf_out_write("
+              "len=%" CURL_FORMAT_SIZE_T ") -> "
+              "%" CURL_FORMAT_SSIZE_T ", err=%d", blen, nwritten, result);
   if(nwritten < 0 && CURLE_AGAIN == result) {
     nwritten = MBEDTLS_ERR_SSL_WANT_WRITE;
   }
@@ -225,8 +226,9 @@ static int mbedtls_bio_cf_read(void *bio, unsigned char *buf, size_t blen)
     return 0;
 
   nread = Curl_conn_cf_recv(cf->next, data, (char *)buf, blen, &result);
-  CURL_TRC_CF(data, cf, "mbedtls_bio_cf_in_read(len=%zu) -> %zd, err=%d",
-              blen, nread, result);
+  CURL_TRC_CF(data, cf, "mbedtls_bio_cf_in_read("
+              "len=%" CURL_FORMAT_SIZE_T ") -> "
+              "%" CURL_FORMAT_SSIZE_T ", err=%d", blen, nread, result);
   if(nread < 0 && CURLE_AGAIN == result) {
     nread = MBEDTLS_ERR_SSL_WANT_READ;
   }
@@ -1180,8 +1182,8 @@ static ssize_t mbed_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   ret = mbedtls_ssl_write(&backend->ssl, (unsigned char *)mem, len);
 
   if(ret < 0) {
-    CURL_TRC_CF(data, cf, "mbedtls_ssl_write(len=%zu) -> -0x%04X",
-                len, -ret);
+    CURL_TRC_CF(data, cf, "mbedtls_ssl_write(len=%" CURL_FORMAT_SIZE_T ") -> "
+                "-0x%04X", len, -ret);
     *curlcode = ((ret == MBEDTLS_ERR_SSL_WANT_WRITE)
 #ifdef TLS13_SUPPORT
       || (ret == MBEDTLS_ERR_SSL_RECEIVED_NEW_SESSION_TICKET)
@@ -1330,8 +1332,8 @@ static ssize_t mbed_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   ret = mbedtls_ssl_read(&backend->ssl, (unsigned char *)buf,
                          buffersize);
   if(ret <= 0) {
-    CURL_TRC_CF(data, cf, "mbedtls_ssl_read(len=%zu) -> -0x%04X",
-                buffersize, -ret);
+    CURL_TRC_CF(data, cf, "mbedtls_ssl_read(len=%" CURL_FORMAT_SIZE_T ") -> "
+                "-0x%04X", buffersize, -ret);
     if(ret == MBEDTLS_ERR_SSL_PEER_CLOSE_NOTIFY)
       return 0;
     *curlcode = ((ret == MBEDTLS_ERR_SSL_WANT_READ)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3901,7 +3901,8 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
 # endif
           else {
             trying_ech_now = 1;
-            infof(data, "ECH: imported ECHConfigList of length %zu", elen);
+            infof(data, "ECH: imported ECHConfigList of "
+                  "length %" CURL_FORMAT_SIZE_T, elen);
           }
         }
         else {

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -271,7 +271,8 @@ static OSStatus sectransp_bio_cf_in_read(SSLConnectionRef connection,
 
   DEBUGASSERT(data);
   nread = Curl_conn_cf_recv(cf->next, data, buf, *dataLength, &result);
-  CURL_TRC_CF(data, cf, "bio_read(len=%zu) -> %zd, result=%d",
+  CURL_TRC_CF(data, cf, "bio_read(len=%" CURL_FORMAT_SIZE_T ") -> "
+                        "%" CURL_FORMAT_SSIZE_T ", result=%d",
               *dataLength, nread, result);
   if(nread < 0) {
     switch(result) {
@@ -312,7 +313,8 @@ static OSStatus sectransp_bio_cf_out_write(SSLConnectionRef connection,
   DEBUGASSERT(data);
   nwritten = Curl_conn_cf_send(cf->next, data, buf, *dataLength, FALSE,
                                &result);
-  CURL_TRC_CF(data, cf, "bio_send(len=%zu) -> %zd, result=%d",
+  CURL_TRC_CF(data, cf, "bio_send(len=%" CURL_FORMAT_SIZE_T ") -> "
+                        "%" CURL_FORMAT_SSIZE_T ", result=%d",
               *dataLength, nwritten, result);
   if(nwritten <= 0) {
     if(result == CURLE_AGAIN) {
@@ -431,7 +433,8 @@ static CURLcode CopyCertSubject(struct Curl_easy *data,
         *certp = cbuf;
     }
     else {
-      failf(data, "SSL: could not allocate %zu bytes of memory", cbuf_size);
+      failf(data, "SSL: could not allocate "
+                  "%" CURL_FORMAT_SIZE_T " bytes of memory", cbuf_size);
       result = CURLE_OUT_OF_MEMORY;
     }
   }
@@ -1558,8 +1561,8 @@ static CURLcode verify_cert_buf(struct Curl_cfilter *cf,
      */
     res = pem_to_der((const char *)certbuf + offset, &der, &derlen);
     if(res < 0) {
-      failf(data, "SSL: invalid CA certificate #%d (offset %zu) in bundle",
-            n, offset);
+      failf(data, "SSL: invalid CA certificate #%d "
+                  "(offset %" CURL_FORMAT_SIZE_T ") in bundle", n, offset);
       result = CURLE_SSL_CACERT_BADFILE;
       goto out;
     }
@@ -1760,7 +1763,8 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
         spkiHeaderLength = 23;
         break;
       default:
-        infof(data, "SSL: unhandled public key length: %zu", pubkeylen);
+        infof(data, "SSL: unhandled public key length: %" CURL_FORMAT_SIZE_T,
+              pubkeylen);
 #elif SECTRANSP_PINNEDPUBKEY_V2
       default:
         /* ecDSA secp256r1 pubkeylen == 91 header already included?
@@ -2468,7 +2472,8 @@ static CURLcode sectransp_shutdown(struct Curl_cfilter *cf,
        * underlying filter and hope it will end. */
       nread = Curl_conn_cf_recv(cf->next, data, buf, sizeof(buf), &result);
     }
-    CURL_TRC_CF(data, cf, "shutdown read -> %zd, %d", nread, result);
+    CURL_TRC_CF(data, cf, "shutdown read -> %" CURL_FORMAT_SSIZE_T ", %d",
+                nread, result);
     if(nread <= 0)
       break;
   }

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1772,8 +1772,8 @@ static ssize_t ssl_cf_recv(struct Curl_cfilter *cf,
     /* eof */
     *err = CURLE_OK;
   }
-  CURL_TRC_CF(data, cf, "cf_recv(len=%zu) -> %zd, %d", len,
-              nread, *err);
+  CURL_TRC_CF(data, cf, "cf_recv(len=%" CURL_FORMAT_SIZE_T ") -> "
+                        "%" CURL_FORMAT_SSIZE_T ", %d", len, nread, *err);
   CF_DATA_RESTORE(cf, save);
   return nread;
 }

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -307,7 +307,7 @@ static int wolfssl_bio_cf_out_write(WOLFSSL_BIO *bio,
   }
   nwritten = Curl_conn_cf_send(cf->next, data, buf, blen, FALSE, &result);
   backend->io_result = result;
-  CURL_TRC_CF(data, cf, "bio_write(len=%d) -> %zd, %d",
+  CURL_TRC_CF(data, cf, "bio_write(len=%d) -> %" CURL_FORMAT_SSIZE_T ", %d",
               blen, nwritten, result);
   wolfSSL_BIO_clear_retry_flags(bio);
   if(nwritten < 0 && CURLE_AGAIN == result) {
@@ -337,7 +337,8 @@ static int wolfssl_bio_cf_in_read(WOLFSSL_BIO *bio, char *buf, int blen)
 
   nread = Curl_conn_cf_recv(cf->next, data, buf, blen, &result);
   backend->io_result = result;
-  CURL_TRC_CF(data, cf, "bio_read(len=%d) -> %zd, %d", blen, nread, result);
+  CURL_TRC_CF(data, cf, "bio_read(len=%d) -> %" CURL_FORMAT_SSIZE_T ", %d",
+              blen, nread, result);
   wolfSSL_BIO_clear_retry_flags(bio);
   if(nread < 0 && CURLE_AGAIN == result)
     BIO_set_retry_read(bio);
@@ -1499,16 +1500,20 @@ static ssize_t wolfssl_send(struct Curl_cfilter *cf,
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:
       /* there is data pending, re-invoke SSL_write() */
-      CURL_TRC_CF(data, cf, "wolfssl_send(len=%zu) -> AGAIN", len);
+      CURL_TRC_CF(data, cf,
+                  "wolfssl_send(len=%" CURL_FORMAT_SIZE_T ") -> AGAIN", len);
       *curlcode = CURLE_AGAIN;
       return -1;
     default:
       if(backend->io_result == CURLE_AGAIN) {
-        CURL_TRC_CF(data, cf, "wolfssl_send(len=%zu) -> AGAIN", len);
+        CURL_TRC_CF(data, cf,
+                    "wolfssl_send(len=%" CURL_FORMAT_SIZE_T ") -> AGAIN", len);
         *curlcode = CURLE_AGAIN;
         return -1;
       }
-      CURL_TRC_CF(data, cf, "wolfssl_send(len=%zu) -> %d, %d", len, rc, err);
+      CURL_TRC_CF(data, cf,
+                  "wolfssl_send(len=%" CURL_FORMAT_SIZE_T ") -> %d, %d",
+                  len, rc, err);
       {
         char error_buffer[256];
         failf(data, "SSL write: %s, errno %d",
@@ -1520,7 +1525,8 @@ static ssize_t wolfssl_send(struct Curl_cfilter *cf,
       return -1;
     }
   }
-  CURL_TRC_CF(data, cf, "wolfssl_send(len=%zu) -> %d", len, rc);
+  CURL_TRC_CF(data, cf, "wolfssl_send(len=%" CURL_FORMAT_SIZE_T ") -> %d",
+              len, rc);
   return rc;
 }
 
@@ -1672,19 +1678,23 @@ static ssize_t wolfssl_recv(struct Curl_cfilter *cf,
 
     switch(err) {
     case SSL_ERROR_ZERO_RETURN: /* no more data */
-      CURL_TRC_CF(data, cf, "wolfssl_recv(len=%zu) -> CLOSED", blen);
+      CURL_TRC_CF(data, cf,
+                  "wolfssl_recv(len=%" CURL_FORMAT_SIZE_T ") -> CLOSED", blen);
       *curlcode = CURLE_OK;
       return 0;
     case SSL_ERROR_NONE:
     case SSL_ERROR_WANT_READ:
     case SSL_ERROR_WANT_WRITE:
       /* there is data pending, re-invoke wolfSSL_read() */
-      CURL_TRC_CF(data, cf, "wolfssl_recv(len=%zu) -> AGAIN", blen);
+      CURL_TRC_CF(data, cf,
+                  "wolfssl_recv(len=%" CURL_FORMAT_SIZE_T ") -> AGAIN", blen);
       *curlcode = CURLE_AGAIN;
       return -1;
     default:
       if(backend->io_result == CURLE_AGAIN) {
-        CURL_TRC_CF(data, cf, "wolfssl_recv(len=%zu) -> AGAIN", blen);
+        CURL_TRC_CF(data, cf,
+                    "wolfssl_recv(len=%" CURL_FORMAT_SIZE_T ") -> AGAIN",
+                    blen);
         *curlcode = CURLE_AGAIN;
         return -1;
       }
@@ -1699,7 +1709,8 @@ static ssize_t wolfssl_recv(struct Curl_cfilter *cf,
       return -1;
     }
   }
-  CURL_TRC_CF(data, cf, "wolfssl_recv(len=%zu) -> %d", blen, nread);
+  CURL_TRC_CF(data, cf, "wolfssl_recv(len=%" CURL_FORMAT_SIZE_T ") -> %d",
+              blen, nread);
   return nread;
 }
 

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -976,10 +976,10 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
      */
     const size_t len = ((pubkey->end - pubkey->beg - 2) * 4);
     if(!certnum)
-      infof(data, "   ECC Public Key (%zu bits)", len);
+      infof(data, "   ECC Public Key (%" CURL_FORMAT_SIZE_T " bits)", len);
     if(data->set.ssl.certinfo) {
       char q[sizeof(len) * 8 / 3 + 1];
-      (void)msnprintf(q, sizeof(q), "%zu", len);
+      (void)msnprintf(q, sizeof(q), "%" CURL_FORMAT_SIZE_T, len);
       if(ssl_push_certinfo(data, certnum, "ECC Public Key", q))
         return 1;
     }
@@ -1011,10 +1011,10 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
     if(len > 32)
       elem.beg = q;     /* Strip leading zero bytes. */
     if(!certnum)
-      infof(data, "   RSA Public Key (%zu bits)", len);
+      infof(data, "   RSA Public Key (%" CURL_FORMAT_SIZE_T " bits)", len);
     if(data->set.ssl.certinfo) {
       char r[sizeof(len) * 8 / 3 + 1];
-      msnprintf(r, sizeof(r), "%zu", len);
+      msnprintf(r, sizeof(r), "%" CURL_FORMAT_SIZE_T, len);
       if(ssl_push_certinfo(data, certnum, "RSA Public Key", r))
         return 1;
     }

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1133,7 +1133,7 @@ static CURLcode ws_send_raw(CURL *data, const void *buffer,
   }
 
   CURL_TRC_WS(data, "ws_send_raw(len=%" CURL_FORMAT_SIZE_T ")"
-                    " -> %d, %" CURL_FORMAT_SIZE_T "",
+                    " -> %d, %" CURL_FORMAT_SIZE_T,
               buflen, result, *pnwritten);
   return result;
 }

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -197,7 +197,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
            ((output != tool_stderr) && (output != stdout))) {
           if(!newl)
             log_line_start(output, timebuf, idsbuf, type);
-          fprintf(output, "[%zu bytes data]\n", size);
+          fprintf(output, "[%" CURL_FORMAT_SIZE_T " bytes data]\n", size);
           newl = FALSE;
           traced_data = TRUE;
         }
@@ -257,8 +257,8 @@ static void dump(const char *timebuf, const char *idsbuf, const char *text,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s%s%s, %zu bytes (0x%zx)\n", timebuf, idsbuf,
-          text, size, size);
+  fprintf(stream, "%s%s%s, %" CURL_FORMAT_SIZE_T " bytes (0x%zx)\n",
+          timebuf, idsbuf, text, size, size);
 
   for(i = 0; i < size; i += width) {
 

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -263,7 +263,7 @@ static void dump(const char *timebuf, const char *idsbuf, const char *text,
 
   for(i = 0; i < size; i += width) {
 
-    fprintf(stream, "%04zx: ", i);
+    fprintf(stream, "%04" CURL_FORMAT_XSIZE_T ": ", i);
 
     if(tracetype == TRACE_BIN) {
       /* hex not disabled, show it */

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -257,7 +257,8 @@ static void dump(const char *timebuf, const char *idsbuf, const char *text,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s%s%s, %" CURL_FORMAT_SIZE_T " bytes (0x%zx)\n",
+  fprintf(stream, "%s%s%s, %" CURL_FORMAT_SIZE_T " bytes"
+          " (0x%" CURL_FORMAT_XSIZE_T ")\n",
           timebuf, idsbuf, text, size, size);
 
   for(i = 0; i < size; i += width) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1709,9 +1709,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           blob.data = (void *)curl_ca_embed;
           blob.len = strlen((const char *)curl_ca_embed);
           blob.flags = CURL_BLOB_NOCOPY;
-          notef(config->global,
-                "Using embedded CA bundle (%zu bytes)",
-                blob.len);
+          notef(config->global, "Using embedded CA bundle"
+                                " (%" CURL_FORMAT_SIZE_T " bytes)", blob.len);
           result = curl_easy_setopt(curl, CURLOPT_CAINFO_BLOB, &blob);
           if(result == CURLE_NOT_BUILT_IN) {
             warnf(global, "ignoring %s, not supported by libcurl with %s",
@@ -1723,9 +1722,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           blob.data = (void *)curl_ca_embed;
           blob.len = strlen((const char *)curl_ca_embed);
           blob.flags = CURL_BLOB_NOCOPY;
-          notef(config->global,
-                "Using embedded CA bundle, for proxies (%zu bytes)",
-                blob.len);
+          notef(config->global, "Using embedded CA bundle, for proxies"
+                                " (%" CURL_FORMAT_SIZE_T " bytes)", blob.len);
           result = curl_easy_setopt(curl, CURLOPT_PROXY_CAINFO_BLOB, &blob);
           if(result == CURLE_NOT_BUILT_IN) {
             warnf(global, "ignoring %s, not supported by libcurl with %s",

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -562,7 +562,8 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
                 kind, *userpwd);
     else
       msnprintf(prompt, sizeof(prompt),
-                "Enter %s password for user '%s' on URL #%zu:",
+                "Enter %s password for user '%s'"
+                " on URL #%" CURL_FORMAT_SIZE_T ":",
                 kind, *userpwd, i + 1);
 
     /* get password */

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -481,7 +481,9 @@ CURLcode glob_url(struct URLGlob **glob, char *url, curl_off_t *urlnum,
       char text[512];
       const char *t;
       if(glob_expand->pos) {
-        msnprintf(text, sizeof(text), "%s in URL position %zu:\n%s\n%*s^",
+        msnprintf(text, sizeof(text), "%s in URL "
+                                      "position %" CURL_FORMAT_SIZE_T ":"
+                                      "\n%s\n%*s^",
                   glob_expand->error,
                   glob_expand->pos, url, (int)glob_expand->pos - 1, " ");
         t = text;

--- a/src/var.c
+++ b/src/var.c
@@ -397,7 +397,8 @@ ParameterError setvariable(struct GlobalConfig *global,
     line++;
   nlen = line - name;
   if(!nlen || (nlen >= MAX_VAR_LEN)) {
-    warnf(global, "Bad variable name length (%zd), skipping", nlen);
+    warnf(global, "Bad variable name length (%" CURL_FORMAT_SSIZE_T ")"
+                  ", skipping", nlen);
     return PARAM_OK;
   }
   if(import) {

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -39,10 +39,6 @@ foreach(_target IN LISTS check_PROGRAMS)
   if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
     set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
-  if(MINGW)
-    # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-    set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
-  endif()
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}" UNITY_BUILD OFF
     PROJECT_LABEL "Test client ${_target}")

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -47,11 +47,6 @@ if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif
 
-if HAVE_MINGW
-# For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-AM_CPPFLAGS += -D__USE_MINGW_ANSI_STDIO=1
-endif
-
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -103,8 +103,9 @@ static int onetest(CURL *curl, const char *url, const struct testparams *p,
   hasbody = 0;
   res = curl_easy_perform(curl);
   if(res != p->result) {
-    printf("%zd: bad error code (%d): resume=%s, fail=%s, http416=%s, "
-           "content-range=%s, expected=%d\n", num, res,
+    printf("%" CURL_FORMAT_SSIZE_T ": bad error code (%d): "
+           "resume=%s, fail=%s, http416=%s, content-range=%s, expected=%d\n",
+           num, res,
            (p->flags & F_RESUME)? "yes": "no",
            (p->flags & F_FAIL)? "yes": "no",
            (p->flags & F_HTTP416)? "yes": "no",
@@ -113,8 +114,8 @@ static int onetest(CURL *curl, const char *url, const struct testparams *p,
     return 1;
   }
   if(hasbody && (p->flags & F_IGNOREBODY)) {
-    printf("body should be ignored and is not: resume=%s, fail=%s, "
-           "http416=%s, content-range=%s\n",
+    printf("body should be ignored and is not: "
+           "resume=%s, fail=%s, http416=%s, content-range=%s\n",
            (p->flags & F_RESUME)? "yes": "no",
            (p->flags & F_FAIL)? "yes": "no",
            (p->flags & F_HTTP416)? "yes": "no",

--- a/tests/libtest/lib1915.c
+++ b/tests/libtest/lib1915.c
@@ -88,7 +88,8 @@ static CURLSTScode hstswrite(CURL *easy, struct curl_hstsentry *e,
 {
   (void)easy;
   (void)userp;
-  printf("[%zu/%zu] %s %s\n", i->index, i->total, e->name, e->expire);
+  printf("[%" CURL_FORMAT_SIZE_T "/%" CURL_FORMAT_SIZE_T "] %s %s\n",
+         i->index, i->total, e->name, e->expire);
   return CURLSTS_OK;
 }
 

--- a/tests/libtest/lib2305.c
+++ b/tests/libtest/lib2305.c
@@ -58,7 +58,7 @@ static void websocket(CURL *curl)
       printf("curl_ws_recv returned %d\n", result);
       return;
     }
-    printf("%d: nread %zu Age %d Flags %x "
+    printf("%d: nread %" CURL_FORMAT_SIZE_T " Age %d Flags %x "
            "Offset %" CURL_FORMAT_CURL_OFF_T " "
            "Bytesleft %" CURL_FORMAT_CURL_OFF_T "\n",
            (int)i,

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -48,8 +48,8 @@ void dump(const char *text,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s, %" CURL_FORMAT_SIZE_T " bytes (0x%zx)\n",
-          text, size, size);
+  fprintf(stream, "%s, %" CURL_FORMAT_SIZE_T " bytes"
+          " (0x%" CURL_FORMAT_XSIZE_T ")\n", text, size, size);
 
   for(i = 0; i<size; i += width) {
 

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -48,7 +48,8 @@ void dump(const char *text,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s, %zu bytes (0x%zx)\n", text, size, size);
+  fprintf(stream, "%s, %" CURL_FORMAT_SIZE_T " bytes (0x%zx)\n",
+          text, size, size);
 
   for(i = 0; i<size; i += width) {
 

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -53,7 +53,7 @@ void dump(const char *text,
 
   for(i = 0; i<size; i += width) {
 
-    fprintf(stream, "%04zx: ", i);
+    fprintf(stream, "%04" CURL_FORMAT_XSIZE_T ": ", i);
 
     if(!nohex) {
       /* hex not disabled, show it */

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -1135,7 +1135,9 @@ static int _strlen_check(int linenumber, char *buf, size_t len)
   size_t buflen = strlen(buf);
   if(len != buflen) {
     /* they shouldn't differ */
-    printf("sprintf strlen:%d failed:\nwe '%zu'\nsystem: '%zu'\n",
+    printf("sprintf strlen:%d failed:\n"
+           "we '%" CURL_FORMAT_SIZE_T "'\n"
+           "system: '%" CURL_FORMAT_SIZE_T "'\n",
            linenumber, buflen, len);
     return 1;
   }

--- a/tests/libtest/lib579.c
+++ b/tests/libtest/lib579.c
@@ -45,7 +45,9 @@ static size_t last_ul_total = 0;
 static void progress_final_report(void)
 {
   FILE *moo = fopen(libtest_arg2, "ab");
-  fprintf(moo, "Progress: end UL %zu/%zu\n", last_ul, last_ul_total);
+  fprintf(moo, "Progress: end UL "
+               "%" CURL_FORMAT_SIZE_T "/%" CURL_FORMAT_SIZE_T "\n",
+          last_ul, last_ul_total);
   started = FALSE;
   fclose(moo);
 }
@@ -65,7 +67,9 @@ static int progress_callback(void *clientp, double dltotal, double dlnow,
   last_ul_total = (size_t)ultotal;
   if(!started) {
     FILE *moo = fopen(libtest_arg2, "ab");
-    fprintf(moo, "Progress: start UL %zu/%zu\n", last_ul, last_ul_total);
+    fprintf(moo, "Progress: start UL "
+                 "%" CURL_FORMAT_SIZE_T "/%" CURL_FORMAT_SIZE_T "\n",
+            last_ul, last_ul_total);
     started = TRUE;
     fclose(moo);
   }

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -45,8 +45,8 @@ void libtest_debug_dump(const char *timebuf, const char *text, FILE *stream,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s%s, %zu bytes (0x%zx)\n", timebuf, text,
-          size, size);
+  fprintf(stream, "%s%s, %" CURL_FORMAT_SIZE_T " bytes (0x%zx)\n",
+          timebuf, text, size, size);
 
   for(i = 0; i < size; i += width) {
 

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -50,7 +50,7 @@ void libtest_debug_dump(const char *timebuf, const char *text, FILE *stream,
 
   for(i = 0; i < size; i += width) {
 
-    fprintf(stream, "%04zx: ", i);
+    fprintf(stream, "%04" CURL_FORMAT_XSIZE_T ": ", i);
 
     if(!nohex) {
       /* hex not disabled, show it */

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -45,8 +45,8 @@ void libtest_debug_dump(const char *timebuf, const char *text, FILE *stream,
     /* without the hex output, we can fit more on screen */
     width = 0x40;
 
-  fprintf(stream, "%s%s, %" CURL_FORMAT_SIZE_T " bytes (0x%zx)\n",
-          timebuf, text, size, size);
+  fprintf(stream, "%s%s, %" CURL_FORMAT_SIZE_T " bytes"
+          " (0x%" CURL_FORMAT_XSIZE_T ")\n", timebuf, text, size, size);
 
   for(i = 0; i < size; i += width) {
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -223,7 +223,7 @@ static void logprotocol(mqttdir dir,
     optr += 2;
     left -= 2;
   }
-  fprintf(output, "%s %s %zx %s\n",
+  fprintf(output, "%s %s %" CURL_FORMAT_XSIZE_T " %s\n",
           dir == FROM_CLIENT? "client": "server",
           prefix, remlen,
           data);
@@ -592,7 +592,9 @@ static curl_socket_t mqttit(curl_socket_t fd)
 
       /* check the length of the payload */
       if((ssize_t)payload_len != (rc - 12)) {
-        logmsg("Payload length mismatch, expected %zx got %zx",
+        logmsg("Payload length mismatch,"
+               " expected %" CURL_FORMAT_XSIZE_T
+               " got %" CURL_FORMAT_XSIZE_T,
                rc - 12, payload_len);
         goto end;
       }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -243,7 +243,7 @@ static int connack(FILE *dump, curl_socket_t fd)
 
   rc = swrite(fd, (char *)packet, sizeof(packet));
   if(rc > 0) {
-    logmsg("WROTE %zd bytes [CONNACK]", rc);
+    logmsg("WROTE %" CURL_FORMAT_SSIZE_T " bytes [CONNACK]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, "CONNACK", 2, dump, packet, sizeof(packet));
   }
@@ -267,7 +267,7 @@ static int suback(FILE *dump, curl_socket_t fd, unsigned short packetid)
 
   rc = swrite(fd, (char *)packet, sizeof(packet));
   if(rc == sizeof(packet)) {
-    logmsg("WROTE %zd bytes [SUBACK]", rc);
+    logmsg("WROTE %" CURL_FORMAT_SSIZE_T " bytes [SUBACK]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, "SUBACK", 3, dump, packet, rc);
     return 0;
@@ -289,7 +289,7 @@ static int puback(FILE *dump, curl_socket_t fd, unsigned short packetid)
 
   rc = swrite(fd, (char *)packet, sizeof(packet));
   if(rc == sizeof(packet)) {
-    logmsg("WROTE %zd bytes [PUBACK]", rc);
+    logmsg("WROTE %" CURL_FORMAT_SSIZE_T " bytes [PUBACK]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, dump, packet, rc);
     return 0;
@@ -307,7 +307,7 @@ static int disconnect(FILE *dump, curl_socket_t fd)
   };
   ssize_t rc = swrite(fd, (char *)packet, sizeof(packet));
   if(rc == sizeof(packet)) {
-    logmsg("WROTE %zd bytes [DISCONNECT]", rc);
+    logmsg("WROTE %" CURL_FORMAT_SSIZE_T " bytes [DISCONNECT]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, "DISCONNECT", 0, dump, packet, rc);
     return 0;
@@ -436,7 +436,7 @@ static int publish(FILE *dump,
 
   rc = swrite(fd, (char *)packet, sendamount);
   if(rc > 0) {
-    logmsg("WROTE %zd bytes [PUBLISH]", rc);
+    logmsg("WROTE %" CURL_FORMAT_SSIZE_T " bytes [PUBLISH]", rc);
     loghex(packet, rc);
     logprotocol(FROM_SERVER, "PUBLISH", remaininglength, dump, packet, rc);
   }
@@ -462,10 +462,10 @@ static int fixedheader(curl_socket_t fd,
   ssize_t rc = sread(fd, (char *)buffer, 2);
   size_t i;
   if(rc < 2) {
-    logmsg("READ %zd bytes [SHORT!]", rc);
+    logmsg("READ %" CURL_FORMAT_SSIZE_T " bytes [SHORT!]", rc);
     return 1; /* fail */
   }
-  logmsg("READ %zd bytes", rc);
+  logmsg("READ %" CURL_FORMAT_SSIZE_T " bytes", rc);
   loghex(buffer, rc);
   *bytep = buffer[0];
 
@@ -480,8 +480,9 @@ static int fixedheader(curl_socket_t fd,
     }
   }
   *remaining_lengthp = decode_length(&buffer[1], i, remaining_length_bytesp);
-  logmsg("Remaining Length: %zu [%zu bytes]", *remaining_lengthp,
-         *remaining_length_bytesp);
+  logmsg("Remaining Length: %" CURL_FORMAT_SIZE_T
+         " [%" CURL_FORMAT_SIZE_T " bytes]",
+         *remaining_lengthp, *remaining_length_bytesp);
   return 0;
 }
 
@@ -543,7 +544,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       buff_size = remaining_length;
       buffer = realloc(buffer, buff_size);
       if(!buffer) {
-        logmsg("Failed realloc of size %zu", buff_size);
+        logmsg("Failed realloc of size %" CURL_FORMAT_SIZE_T, buff_size);
         goto end;
       }
     }
@@ -552,7 +553,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       /* reading variable header and payload into buffer */
       rc = sread(fd, (char *)buffer, remaining_length);
       if(rc > 0) {
-        logmsg("READ %zd bytes", rc);
+        logmsg("READ %" CURL_FORMAT_SSIZE_T " bytes", rc);
         loghex(buffer, rc);
       }
     }
@@ -632,7 +633,8 @@ static curl_socket_t mqttit(curl_socket_t fd)
       /* two bytes topic length */
       topic_len = (size_t)(buffer[2] << 8) | buffer[3];
       if(topic_len != (remaining_length - 5)) {
-        logmsg("Wrong topic length, got %zu expected %zu",
+        logmsg("Wrong topic length, got %" CURL_FORMAT_SIZE_T
+               " expected %" CURL_FORMAT_SIZE_T,
                topic_len, remaining_length - 5);
         goto end;
       }
@@ -676,7 +678,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
                   dump, buffer, rc);
 
       topiclen = (size_t)(buffer[1 + bytes] << 8) | buffer[2 + bytes];
-      logmsg("Got %zu bytes topic", topiclen);
+      logmsg("Got %" CURL_FORMAT_SIZE_T " bytes topic", topiclen);
       /* TODO: verify topiclen */
 
 #ifdef QOS
@@ -687,7 +689,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       /* get the request */
       rc = sread(fd, (char *)&buffer[0], 2);
 
-      logmsg("READ %zd bytes [DISCONNECT]", rc);
+      logmsg("READ %" CURL_FORMAT_SSIZE_T " bytes [DISCONNECT]", rc);
       loghex(buffer, rc);
       logprotocol(FROM_CLIENT, "DISCONNECT", 0, dump, buffer, rc);
       goto end;

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -385,8 +385,8 @@ static int ProcessRequest(struct httprequest *req)
                   req->rtp_buffersize += rtp_size + 4;
                   free(rtp_scratch);
                 }
-                logmsg("rtp_buffersize is %zu, rtp_size is %d.",
-                       req->rtp_buffersize, rtp_size);
+                logmsg("rtp_buffersize is %" CURL_FORMAT_SIZE_T
+                       ", rtp_size is %d.", req->rtp_buffersize, rtp_size);
               }
             }
             else {
@@ -487,7 +487,8 @@ static int ProcessRequest(struct httprequest *req)
 
       logmsg("Found Content-Length: %lu in the request", clen);
       if(req->skip)
-        logmsg("... but will abort after %zu bytes", req->cl);
+        logmsg("... but will abort after %" CURL_FORMAT_SIZE_T " bytes",
+               req->cl);
       break;
     }
     else if(strncasecompare("Transfer-Encoding: chunked", line,
@@ -531,7 +532,7 @@ static int ProcessRequest(struct httprequest *req)
     req->ntlm = TRUE; /* NTLM found */
     logmsg("Received NTLM type-3, sending back data %ld", req->partno);
     if(req->cl) {
-      logmsg("  Expecting %zu POSTed bytes", req->cl);
+      logmsg("  Expecting %" CURL_FORMAT_SIZE_T " POSTed bytes", req->cl);
     }
   }
   else if(!req->ntlm &&
@@ -631,11 +632,13 @@ static void storerequest(char *reqbuf, size_t totalsize)
   } while((writeleft > 0) && ((error = errno) == EINTR));
 
   if(writeleft == 0)
-    logmsg("Wrote request (%zu bytes) input to %s", totalsize, dumpfile);
+    logmsg("Wrote request (%" CURL_FORMAT_SIZE_T " bytes) input to %s",
+           totalsize, dumpfile);
   else if(writeleft > 0) {
     logmsg("Error writing file %s error: %d %s",
            dumpfile, error, strerror(error));
-    logmsg("Wrote only (%zu bytes) of (%zu bytes) request input to %s",
+    logmsg("Wrote only (%" CURL_FORMAT_SIZE_T " bytes) "
+           "of (%" CURL_FORMAT_SIZE_T " bytes) request input to %s",
            totalsize-writeleft, totalsize, dumpfile);
   }
 
@@ -722,7 +725,7 @@ static int get_request(curl_socket_t sock, struct httprequest *req)
       return 1;
     }
 
-    logmsg("Read %zd bytes", got);
+    logmsg("Read %" CURL_FORMAT_SSIZE_T " bytes", got);
 
     req->offset += (size_t)got;
     reqbuf[req->offset] = '\0';
@@ -823,8 +826,8 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
                 CURL_FORMAT_CURL_OFF_T "\r\n", our_getpid());
       msglen = strlen(msgbuf);
       msnprintf(weare, sizeof(weare),
-                "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\n\r\n%s",
-                msglen, msgbuf);
+                "HTTP/1.1 200 OK\r\nContent-Length: %" CURL_FORMAT_SIZE_T
+                "\r\n\r\n%s", msglen, msgbuf);
       buffer = weare;
       break;
     case DOCNUMBER_INTERNAL:
@@ -944,7 +947,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
       break;
     }
     else {
-      logmsg("Sent off %zd bytes", written);
+      logmsg("Sent off %" CURL_FORMAT_SSIZE_T " bytes", written);
     }
     /* write to file as well */
     fwrite(buffer, 1, (size_t)written, dump);
@@ -957,7 +960,8 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
 
   /* Send out any RTP data */
   if(req->rtp_buffer) {
-    logmsg("About to write %zu RTP bytes", req->rtp_buffersize);
+    logmsg("About to write %" CURL_FORMAT_SIZE_T " RTP bytes",
+           req->rtp_buffersize);
     count = req->rtp_buffersize;
     do {
       size_t num = count;
@@ -990,15 +994,15 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
   }
 
   if(sendfailure) {
-    logmsg("Sending response failed. Only (%zu bytes) of "
-           "(%zu bytes) were sent",
+    logmsg("Sending response failed. Only (%" CURL_FORMAT_SIZE_T " bytes) "
+           "of (%" CURL_FORMAT_SIZE_T " bytes) were sent",
            responsesize-count, responsesize);
     free(ptr);
     free(cmd);
     return -1;
   }
 
-  logmsg("Response sent (%zu bytes) and written to %s",
+  logmsg("Response sent (%" CURL_FORMAT_SIZE_T " bytes) and written to %s",
          responsesize, responsedump);
   free(ptr);
 

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1099,7 +1099,8 @@ static bool juggle(curl_socket_t *sockfdp,
          Replies to PORT with "IPv[num]/[port]" */
       msnprintf((char *)buffer, sizeof(buffer), "%s/%hu\n", ipv_inuse, port);
       buffer_len = (ssize_t)strlen((char *)buffer);
-      msnprintf(data, sizeof(data), "PORT\n%04zx\n", buffer_len);
+      msnprintf(data, sizeof(data), "PORT\n%04" CURL_FORMAT_XSIZE_T "\n",
+                buffer_len);
       if(!write_stdout(data, 10))
         return FALSE;
       if(!write_stdout(buffer, buffer_len))
@@ -1176,7 +1177,8 @@ static bool juggle(curl_socket_t *sockfdp,
     nread_socket = sread(sockfd, buffer, sizeof(buffer));
 
     if(nread_socket > 0) {
-      msnprintf(data, sizeof(data), "DATA\n%04zx\n", nread_socket);
+      msnprintf(data, sizeof(data), "DATA\n%04" CURL_FORMAT_XSIZE_T "\n",
+                nread_socket);
       if(!write_stdout(data, 10))
         return FALSE;
       if(!write_stdout(buffer, nread_socket))

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -259,7 +259,7 @@ static ssize_t fullread(int filedes, void *buffer, size_t nbytes)
   } while((size_t)nread < nbytes);
 
   if(verbose)
-    logmsg("read %zd bytes", nread);
+    logmsg("read %" CURL_FORMAT_SSIZE_T " bytes", nread);
 
   return nread;
 }
@@ -305,7 +305,7 @@ static ssize_t fullwrite(int filedes, const void *buffer, size_t nbytes)
   } while((size_t)nwrite < nbytes);
 
   if(verbose)
-    logmsg("wrote %zd bytes", nwrite);
+    logmsg("wrote %" CURL_FORMAT_SSIZE_T " bytes", nwrite);
 
   return nwrite;
 }
@@ -402,11 +402,13 @@ static bool read_data_block(unsigned char *buffer, ssize_t maxlen,
 
   *buffer_len = (ssize_t)strtol((char *)buffer, NULL, 16);
   if(*buffer_len > maxlen) {
-    logmsg("ERROR: Buffer size (%zd bytes) too small for data size "
-           "(%zd bytes)", maxlen, *buffer_len);
+    logmsg("ERROR: Buffer size (%" CURL_FORMAT_SSIZE_T " bytes) too small "
+           "for data size (%" CURL_FORMAT_SSIZE_T " bytes)",
+           maxlen, *buffer_len);
     return FALSE;
   }
-  logmsg("> %zd bytes data, server => client", *buffer_len);
+  logmsg("> %" CURL_FORMAT_SSIZE_T " bytes data, server => client",
+         *buffer_len);
 
   if(!read_stdin(buffer, *buffer_len))
     return FALSE;
@@ -1122,7 +1124,9 @@ static bool juggle(curl_socket_t *sockfdp,
         /* send away on the socket */
         ssize_t bytes_written = swrite(sockfd, buffer, buffer_len);
         if(bytes_written != buffer_len) {
-          logmsg("Not all data was sent. Bytes to send: %zd sent: %zd",
+          logmsg("Not all data was sent."
+                 " Bytes to send: %" CURL_FORMAT_SSIZE_T
+                 " sent: %" CURL_FORMAT_SSIZE_T,
                  buffer_len, bytes_written);
         }
       }
@@ -1178,7 +1182,8 @@ static bool juggle(curl_socket_t *sockfdp,
       if(!write_stdout(buffer, nread_socket))
         return FALSE;
 
-      logmsg("< %zd bytes data, client => server", nread_socket);
+      logmsg("< %" CURL_FORMAT_SSIZE_T " bytes data, client => server",
+             nread_socket);
       lograw(buffer, nread_socket);
     }
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -320,7 +320,7 @@ static curl_socket_t socks4(curl_socket_t fd,
     return CURL_SOCKET_BAD;
   }
   if(rc < 9) {
-    logmsg("SOCKS4 connect message too short: %zd", rc);
+    logmsg("SOCKS4 connect message too short: %" CURL_FORMAT_SSIZE_T, rc);
     return CURL_SOCKET_BAD;
   }
   if(!config.port)
@@ -347,7 +347,7 @@ static curl_socket_t socks4(curl_socket_t fd,
     logmsg("Sending SOCKS4 response failed!");
     return CURL_SOCKET_BAD;
   }
-  logmsg("Sent %zd bytes", rc);
+  logmsg("Sent %" CURL_FORMAT_SSIZE_T " bytes", rc);
   loghex(response, rc);
 
   if(cd == 90)
@@ -377,18 +377,19 @@ static curl_socket_t sockit(curl_socket_t fd)
 
   rc = recv(fd, (char *)buffer, sizeof(buffer), 0);
   if(rc <= 0) {
-    logmsg("SOCKS identifier message missing, recv returned %zd", rc);
+    logmsg("SOCKS identifier message missing, "
+           "recv returned %" CURL_FORMAT_SSIZE_T, rc);
     return CURL_SOCKET_BAD;
   }
 
-  logmsg("READ %zd bytes", rc);
+  logmsg("READ %" CURL_FORMAT_SSIZE_T " bytes", rc);
   loghex(buffer, rc);
 
   if(buffer[SOCKS5_VERSION] == 4)
     return socks4(fd, buffer, rc);
 
   if(rc < 3) {
-    logmsg("SOCKS5 identifier message too short: %zd", rc);
+    logmsg("SOCKS5 identifier message too short: %" CURL_FORMAT_SSIZE_T, rc);
     return CURL_SOCKET_BAD;
   }
 
@@ -405,7 +406,8 @@ static curl_socket_t sockit(curl_socket_t fd)
   /* after NMETHODS follows that many bytes listing the methods the client
      says it supports */
   if(rc != (buffer[SOCKS5_NMETHODS] + 2)) {
-    logmsg("Expected %d bytes, got %zd", buffer[SOCKS5_NMETHODS] + 2, rc);
+    logmsg("Expected %d bytes, got %" CURL_FORMAT_SSIZE_T,
+           buffer[SOCKS5_NMETHODS] + 2, rc);
     return CURL_SOCKET_BAD;
   }
   logmsg("Incoming request deemed fine!");
@@ -418,17 +420,18 @@ static curl_socket_t sockit(curl_socket_t fd)
     logmsg("Sending response failed!");
     return CURL_SOCKET_BAD;
   }
-  logmsg("Sent %zd bytes", rc);
+  logmsg("Sent %" CURL_FORMAT_SSIZE_T " bytes", rc);
   loghex(response, rc);
 
   /* expect the request or auth */
   rc = recv(fd, (char *)buffer, sizeof(buffer), 0);
   if(rc <= 0) {
-    logmsg("SOCKS5 request or auth message missing, recv returned %zd", rc);
+    logmsg("SOCKS5 request or auth message missing, "
+           "recv returned %" CURL_FORMAT_SSIZE_T, rc);
     return CURL_SOCKET_BAD;
   }
 
-  logmsg("READ %zd bytes", rc);
+  logmsg("READ %" CURL_FORMAT_SSIZE_T " bytes", rc);
   loghex(buffer, rc);
 
   if(config.responsemethod == 2) {
@@ -443,7 +446,7 @@ static curl_socket_t sockit(curl_socket_t fd)
     unsigned char plen;
     bool login = TRUE;
     if(rc < 5) {
-      logmsg("Too short auth input: %zd", rc);
+      logmsg("Too short auth input: %" CURL_FORMAT_SSIZE_T, rc);
       return CURL_SOCKET_BAD;
     }
     if(buffer[SOCKS5_VERSION] != 1) {
@@ -452,12 +455,13 @@ static curl_socket_t sockit(curl_socket_t fd)
     }
     ulen = buffer[SOCKS5_ULEN];
     if(rc < 4 + ulen) {
-      logmsg("Too short packet for username: %zd", rc);
+      logmsg("Too short packet for username: %" CURL_FORMAT_SSIZE_T, rc);
       return CURL_SOCKET_BAD;
     }
     plen = buffer[SOCKS5_ULEN + ulen + 1];
     if(rc < 3 + ulen + plen) {
-      logmsg("Too short packet for ulen %d plen %d: %zd", ulen, plen, rc);
+      logmsg("Too short packet for ulen %d plen %d: %" CURL_FORMAT_SSIZE_T,
+             ulen, plen, rc);
       return CURL_SOCKET_BAD;
     }
     if((ulen != strlen(config.user)) ||
@@ -475,7 +479,7 @@ static curl_socket_t sockit(curl_socket_t fd)
       logmsg("Sending auth response failed!");
       return CURL_SOCKET_BAD;
     }
-    logmsg("Sent %zd bytes", rc);
+    logmsg("Sent %" CURL_FORMAT_SSIZE_T " bytes", rc);
     loghex(response, rc);
     if(!login)
       return CURL_SOCKET_BAD;
@@ -483,15 +487,16 @@ static curl_socket_t sockit(curl_socket_t fd)
     /* expect the request */
     rc = recv(fd, (char *)buffer, sizeof(buffer), 0);
     if(rc <= 0) {
-      logmsg("SOCKS5 request message missing, recv returned %zd", rc);
+      logmsg("SOCKS5 request message missing, "
+             "recv returned %" CURL_FORMAT_SSIZE_T, rc);
       return CURL_SOCKET_BAD;
     }
 
-    logmsg("READ %zd bytes", rc);
+    logmsg("READ %" CURL_FORMAT_SSIZE_T " bytes", rc);
     loghex(buffer, rc);
   }
   if(rc < 6) {
-    logmsg("Too short for request: %zd", rc);
+    logmsg("Too short for request: %" CURL_FORMAT_SSIZE_T, rc);
     return CURL_SOCKET_BAD;
   }
 
@@ -536,7 +541,8 @@ static curl_socket_t sockit(curl_socket_t fd)
     return CURL_SOCKET_BAD;
   }
   if(rc < (4 + len + 2)) {
-    logmsg("Request too short: %zd, expected %d", rc, 4 + len + 2);
+    logmsg("Request too short: %" CURL_FORMAT_SSIZE_T
+           ", expected %d", rc, 4 + len + 2);
     return CURL_SOCKET_BAD;
   }
   logmsg("Received ATYP %d", type);
@@ -622,7 +628,7 @@ static curl_socket_t sockit(curl_socket_t fd)
     logmsg("Sending connect response failed!");
     return CURL_SOCKET_BAD;
   }
-  logmsg("Sent %zd bytes", rc);
+  logmsg("Sent %" CURL_FORMAT_SSIZE_T " bytes", rc);
   loghex(response, rc);
 
   if(!rep)
@@ -784,7 +790,8 @@ static bool incoming(curl_socket_t listenfd)
       struct perclient *cp = &c[i];
       if(cp->used) {
         if(tunnel(cp, &fds_read)) {
-          logmsg("SOCKS transfer completed. Bytes: < %zu > %zu",
+          logmsg("SOCKS transfer completed. "
+                 "Bytes: < %" CURL_FORMAT_SIZE_T " > %" CURL_FORMAT_SIZE_T,
                  cp->fromremote, cp->fromclient);
           sclose(cp->clientfd);
           sclose(cp->remotefd);
@@ -1035,8 +1042,8 @@ int main(int argc, char *argv[])
         struct sockaddr_un sau;
         unix_socket = argv[arg];
         if(strlen(unix_socket) >= sizeof(sau.sun_path)) {
-          fprintf(stderr,
-                  "socksd: socket path must be shorter than %zu chars: %s\n",
+          fprintf(stderr, "socksd: socket path must be shorter than "
+                          "%" CURL_FORMAT_SIZE_T " chars: %s\n",
               sizeof(sau.sun_path), unix_socket);
           return 0;
         }

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -1206,7 +1206,7 @@ send_data:
 #endif
       logmsg("read");
       n = sread(peer, &ackbuf.storage[0], sizeof(ackbuf.storage));
-      logmsg("read: %zd", n);
+      logmsg("read: %" CURL_FORMAT_SSIZE_T, n);
 #ifdef HAVE_ALARM
       alarm(0);
 #endif
@@ -1278,7 +1278,7 @@ send_ack:
 #endif
       logmsg("read");
       n = sread(peer, rdp, PKTSIZE);
-      logmsg("read: %zd", n);
+      logmsg("read: %" CURL_FORMAT_SSIZE_T, n);
 #ifdef HAVE_ALARM
       alarm(0);
 #endif

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -99,7 +99,7 @@ UNITTEST_START
     int rem = (i + 7)%NUM_NODES;
     printf("Tree look:\n");
     splayprint(root, 0, 1);
-    printf("remove pointer %d, payload %zu\n", rem,
+    printf("remove pointer %d, payload %" CURL_FORMAT_SIZE_T "\n", rem,
            *(size_t *)Curl_splayget(&nodes[rem]));
     rc = Curl_splayremove(root, &nodes[rem], &root);
     if(rc) {
@@ -132,7 +132,8 @@ UNITTEST_START
     tv_now.tv_usec = i;
     root = Curl_splaygetbest(tv_now, root, &removed);
     while(removed) {
-      printf("removed payload %zu[%zu]\n",
+      printf("removed payload %" CURL_FORMAT_SIZE_T
+             "[%" CURL_FORMAT_SIZE_T "]\n",
              *(size_t *)Curl_splayget(removed) / 10,
              *(size_t *)Curl_splayget(removed) % 10);
       root = Curl_splaygetbest(tv_now, root, &removed);

--- a/tests/unit/unit1650.c
+++ b/tests/unit/unit1650.c
@@ -164,13 +164,16 @@ UNITTEST_START
     DOHcode rc = doh_encode(req[i].name, req[i].type,
                             buffer, sizeof(buffer), &size);
     if(rc != req[i].rc) {
-      fprintf(stderr, "req %zu: Expected return code %d got %d\n", i,
-              req[i].rc, rc);
+      fprintf(stderr, "req %" CURL_FORMAT_SIZE_T ": "
+                      "Expected return code %d got %d\n",
+              i, req[i].rc, rc);
       abort_if(rc != req[i].rc, "return code");
     }
     if(size != req[i].size) {
-      fprintf(stderr, "req %zu: Expected size %zu got %zu\n", i,
-              req[i].size, size);
+      fprintf(stderr, "req %" CURL_FORMAT_SIZE_T ": "
+                      "Expected size %" CURL_FORMAT_SIZE_T
+                      " got %" CURL_FORMAT_SIZE_T "\n",
+              i, req[i].size, size);
       fprintf(stderr, "DNS encode made: %s\n", hexdump(buffer, size));
       abort_if(size != req[i].size, "size");
     }
@@ -193,8 +196,9 @@ UNITTEST_START
     rc = doh_decode((const unsigned char *)resp[i].packet, resp[i].size,
                     resp[i].type, &d);
     if(rc != resp[i].rc) {
-      fprintf(stderr, "resp %zu: Expected return code %d got %d\n", i,
-              resp[i].rc, rc);
+      fprintf(stderr, "resp %" CURL_FORMAT_SIZE_T ": "
+                      "Expected return code %d got %d\n",
+              i, resp[i].rc, rc);
       abort_if(rc != resp[i].rc, "return code");
     }
     len = sizeof(buffer);
@@ -234,8 +238,9 @@ UNITTEST_START
     }
     de_cleanup(&d);
     if(resp[i].out && strcmp((char *)buffer, resp[i].out)) {
-      fprintf(stderr, "resp %zu: Expected %s got %s\n", i,
-              resp[i].out, buffer);
+      fprintf(stderr, "resp %" CURL_FORMAT_SIZE_T ": "
+                      "Expected %s got %s\n",
+              i, resp[i].out, buffer);
       abort_if(resp[i].out && strcmp((char *)buffer, resp[i].out), "content");
     }
   }
@@ -248,7 +253,7 @@ UNITTEST_START
     rc = doh_decode((const unsigned char *)full49, i, DNS_TYPE_A, &d);
     if(!rc) {
       /* none of them should work */
-      fprintf(stderr, "%zu: %d\n", i, rc);
+      fprintf(stderr, "%" CURL_FORMAT_SIZE_T ": %d\n", i, rc);
       abort_if(!rc, "error rc");
     }
   }
@@ -262,7 +267,7 @@ UNITTEST_START
                     DNS_TYPE_A, &d);
     if(!rc) {
       /* none of them should work */
-      fprintf(stderr, "2 %zu: %d\n", i, rc);
+      fprintf(stderr, "2 %" CURL_FORMAT_SIZE_T ": %d\n", i, rc);
       abort_if(!rc, "error rc");
     }
   }

--- a/tests/unit/unit1656.c
+++ b/tests/unit/unit1656.c
@@ -85,12 +85,14 @@ static bool do_test(struct test_spec *spec, size_t i, struct dynbuf *dbuf)
   Curl_dyn_reset(dbuf);
   result = Curl_x509_GTime2str(dbuf, in, in + strlen(in));
   if(result != spec->exp_result) {
-    fprintf(stderr, "test %zu: expect result %d, got %d\n",
+    fprintf(stderr, "test %" CURL_FORMAT_SIZE_T ": "
+                    "expect result %d, got %d\n",
             i, spec->exp_result, result);
     return FALSE;
   }
   else if(!result && strcmp(spec->exp_output, Curl_dyn_ptr(dbuf))) {
-    fprintf(stderr, "test %zu: input '%s', expected output '%s', got '%s'\n",
+    fprintf(stderr, "test %" CURL_FORMAT_SIZE_T ": "
+                    "input '%s', expected output '%s', got '%s'\n",
             i, in, spec->exp_output, Curl_dyn_ptr(dbuf));
     return FALSE;
   }

--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -160,7 +160,8 @@ UNITTEST_START
     showsts(e, chost);
   }
 
-  printf("Number of entries: %zu\n", Curl_llist_count(&h->list));
+  printf("Number of entries: %" CURL_FORMAT_SIZE_T "\n",
+         Curl_llist_count(&h->list));
 
   /* verify that it is exists for 7 seconds */
   chost = "expire.example";

--- a/tests/unit/unit2601.c
+++ b/tests/unit/unit2601.c
@@ -64,12 +64,15 @@ static void dump_bufq(struct bufq *q, const char *msg)
   const char *terr;
   size_t n;
 
-  fprintf(stderr, "bufq[chunk_size=%zu, max_chunks=%zu] %s\n",
+  fprintf(stderr, "bufq[chunk_size=%" CURL_FORMAT_SIZE_T ", "
+                  "max_chunks=%" CURL_FORMAT_SIZE_T "] %s\n",
           q->chunk_size, q->max_chunks, msg);
   fprintf(stderr, "- queue[\n");
   chunk = q->head;
   while(chunk) {
-    fprintf(stderr, "    chunk[len=%zu, roff=%zu, woff=%zu]\n",
+    fprintf(stderr, "    chunk[len=%" CURL_FORMAT_SIZE_T ", "
+                    "roff=%" CURL_FORMAT_SIZE_T ", "
+                    "woff=%" CURL_FORMAT_SIZE_T "]\n",
             chunk->dlen, chunk->r_offset, chunk->w_offset);
     chunk = chunk->next;
   }
@@ -82,8 +85,8 @@ static void dump_bufq(struct bufq *q, const char *msg)
     ++n;
     chunk = chunk->next;
   }
-  fprintf(stderr, "- chunks: %zu\n", q->chunk_count);
-  fprintf(stderr, "- spares: %zu\n", n);
+  fprintf(stderr, "- chunks: %" CURL_FORMAT_SIZE_T "\n", q->chunk_count);
+  fprintf(stderr, "- spares: %" CURL_FORMAT_SIZE_T "\n", n);
 }
 
 static unsigned char test_data[32*1024];
@@ -133,7 +136,8 @@ static void check_bufq(size_t pool_spares,
     }
   }
   if(nwritten != max_len) {
-    fprintf(stderr, "%zu bytes written, but max_len=%zu\n",
+    fprintf(stderr, "%" CURL_FORMAT_SIZE_T " bytes written, "
+                    "but max_len=%" CURL_FORMAT_SIZE_T "\n",
             nwritten, max_len);
     dump_bufq(&q, "after writing full");
     fail_if(TRUE, "write: bufq full but nwritten wrong");
@@ -152,7 +156,8 @@ static void check_bufq(size_t pool_spares,
     }
   }
   if(nread != max_len) {
-    fprintf(stderr, "%zu bytes read, but max_len=%zu\n",
+    fprintf(stderr, "%" CURL_FORMAT_SIZE_T " bytes read, "
+                    "but max_len=%" CURL_FORMAT_SIZE_T "\n",
             nwritten, max_len);
     dump_bufq(&q, "after reading empty");
     fail_if(TRUE, "read: bufq empty but nread wrong");
@@ -188,7 +193,8 @@ static void check_bufq(size_t pool_spares,
     nwritten += (size_t)n;
   }
   if(nwritten < max_len) {
-    fprintf(stderr, "%zu bytes written, but max_len=%zu\n",
+    fprintf(stderr, "%" CURL_FORMAT_SIZE_T " bytes written, "
+                    "but max_len=%" CURL_FORMAT_SIZE_T "\n",
             nwritten, max_len);
     dump_bufq(&q, "after writing full");
     fail_if(TRUE, "write: bufq full but nwritten wrong");

--- a/tests/unit/unit2603.c
+++ b/tests/unit/unit2603.c
@@ -89,7 +89,8 @@ static void parse_success(struct tcase *t)
     in_consumed += (size_t)nread;
     if((size_t)nread != buflen) {
       if(!p.done) {
-        fprintf(stderr, "only %zd/%zu consumed for: '%s'\n",
+        fprintf(stderr, "only %" CURL_FORMAT_SSIZE_T "/"
+                        "%" CURL_FORMAT_SIZE_T " consumed for: '%s'\n",
                 nread, buflen, buf);
         fail("not all consumed");
       }
@@ -99,7 +100,8 @@ static void parse_success(struct tcase *t)
   fail_if(!p.done, "end not detected");
   fail_if(!p.req, "not request created");
   if(t->input_remain != (in_len - in_consumed)) {
-    fprintf(stderr, "expected %zu input bytes to remain, but got %zu\n",
+    fprintf(stderr, "expected %" CURL_FORMAT_SIZE_T " input bytes to remain, "
+                    "but got %" CURL_FORMAT_SIZE_T "\n",
             t->input_remain, in_len - in_consumed);
     fail("unexpected input consumption");
   }
@@ -109,7 +111,8 @@ static void parse_success(struct tcase *t)
     check_eq(p.req->authority, t->authority, "authority");
     check_eq(p.req->path, t->path, "path");
     if(Curl_dynhds_count(&p.req->headers) != t->header_count) {
-      fprintf(stderr, "expected %zu headers but got %zu\n", t->header_count,
+      fprintf(stderr, "expected %" CURL_FORMAT_SIZE_T " headers "
+                      "but got %" CURL_FORMAT_SIZE_T "\n", t->header_count,
              Curl_dynhds_count(&p.req->headers));
       fail("unexpected req header count");
     }

--- a/tests/unit/unit3200.c
+++ b/tests/unit/unit3200.c
@@ -100,7 +100,7 @@ UNITTEST_START
     fp = fopen(arg, "rb");
     abort_unless(fp != NULL, "Cannot open testfile");
 
-    fprintf(stderr, "Test %zd...", i);
+    fprintf(stderr, "Test %" CURL_FORMAT_SSIZE_T "...", i);
     switch(i) {
       case 0:
         rc = Curl_get_line(&buf, fp);


### PR DESCRIPTION
Change mingw-w64 printf format checks to use `__MINGW_PRINTF_FORMAT`
instead of `gnu_printf`, to sync the format checker with the format
string macros published via `curl/system.h`. (Also disable format checks
for mingw-w64 older than 3.0.0 (2013-09-20) and classic-mingw, which
do not support this macro.)

This fixes bogus format checker `-Wformat` warnings in 3rd party code
using curl format strings with the curl printf functions, when using
mingw-w64 7.0.0 (2019-11-10) and older (with GCC, MSVCRT).   
                                                             
It also allows to delete two workaounds for this within curl itself:
- setting `-D__USE_MINGW_ANSI_STDIO=1` for mingw-w64 via cmake and
  configure for `docs/examples` and `tests/http/clients`.
  Ref: c730c8549b5b67e7668ca5d2cd82c3cc183e125d #14640
- overriding `curl/system.h` `CURL_FORMAT_CURL_OFF_T[U]` format strings
  to GNU-style for the curl source code.
  Ref: 3829759bd042c03225ae862062560f568ba1a231 #12489

But, `__MINGW_PRINTF_FORMAT` creates a new problem, where the C99 `%z`
(`size_t`) format string is no longer accepted by the format checker
when using mingw-w64 7.0.0 (2019-11-10) and earlier, which default to
`ms_printf` format string style.

Fix this by adding new, internal, `size_t` format string macros, and
replace `%z` uses across the codebase with them.

The macro adapts to mingw-w64 and other build environments
automatically.

After this patch the `curl/system.h` format string macros, the format
checker style set in `curl/mprintf.h` (and `lib/curl_setup.h`), and the
format strings used across the source code always match.

Also:
- `lib/ws.c`: add missing space to a string.
- fix to use standard printf in the example `ftpgetinfo`.

Verification script:
```bash
: check if format string translations were accurate:
curl -LO https://github.com/curl/curl/pull/14643.diff
grep '^-' 14643.diff > 14643-out.diff
grep '^+' 14643.diff > 14643-in.diff
grep -E -o '%[0-9]*z[xud]' 14643-out.diff > 14643-out-fmt.diff
grep -E -o '%[0-9]*" CURL_FORMAT_[XS]?SIZE_T' 14643-in.diff > 14643-in-fmt.diff
paste 14643-in-fmt.diff 14643-out-fmt.diff | sort | uniq -c > 14643-FORMATS.txt
: check if strings remained intact after reflow:
grep -E '^(\+|@)' 14643.diff | grep -E -o '("[^"]+"|^\+\+\+.+|^@@)' | tr '\n' '\t' | sed -E -e 's/\"\t\"//g' -e 's/\+\+\+ b/--- a/g'       | tr '\t' '\n' > 14643-in.diff
grep -E '^(-|@)'  14643.diff | grep -E -o '("[^"]+"|^---.+|^@@)'    | tr '\n' '\t' | sed -E -e 's/\"\t\"//g' -e 's/(%[0-9]*)z(x|u|d)/\1/g' | tr '\t' '\n' > 14643-out.diff
diff -u 14643-out.diff 14643-in.diff > 14643-STRINGS.diff
```
