### PR TITLE
src: delete `curlx_m*printf()` aliases

### DIFF
--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -77,23 +77,11 @@
 
 */
 
-#define curlx_mvsnprintf curl_mvsnprintf
-#define curlx_msnprintf curl_msnprintf
-#define curlx_maprintf curl_maprintf
-#define curlx_mvaprintf curl_mvaprintf
-#define curlx_msprintf curl_msprintf
-#define curlx_mprintf curl_mprintf
-#define curlx_mfprintf curl_mfprintf
-#define curlx_mvsprintf curl_mvsprintf
-#define curlx_mvprintf curl_mvprintf
-#define curlx_mvfprintf curl_mvfprintf
-
 /* We define all "standard" printf() functions to use the curlx_* version
    instead. It makes the source code transparent and easier to
    understand/patch. Undefine them first. */
 # undef printf
 # undef fprintf
-# undef sprintf
 # undef msnprintf
 # undef vprintf
 # undef vfprintf
@@ -101,14 +89,13 @@
 # undef aprintf
 # undef vaprintf
 
-# define printf curlx_mprintf
-# define fprintf curlx_mfprintf
-# define sprintf curlx_msprintf
-# define msnprintf curlx_msnprintf
-# define vprintf curlx_mvprintf
-# define vfprintf curlx_mvfprintf
-# define mvsnprintf curlx_mvsnprintf
-# define aprintf curlx_maprintf
-# define vaprintf curlx_mvaprintf
+# define printf curl_mprintf
+# define fprintf curl_mfprintf
+# define msnprintf curl_msnprintf
+# define vprintf curl_mvprintf
+# define vfprintf curl_mvfprintf
+# define mvsnprintf curl_mvsnprintf
+# define aprintf curl_maprintf
+# define vaprintf curl_mvaprintf
 
 #endif /* HEADER_CURL_CURLX_H */

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -96,7 +96,7 @@ bool tool_create_output_file(struct OutStruct *outs,
             (errno == EEXIST || errno == EISDIR) &&
             /* because we keep having files that already exist */
             next_num < 100 /* and we have not reached the retry limit */ ) {
-        curlx_msnprintf(newname + len + 1, 12, "%d", next_num);
+        curl_msnprintf(newname + len + 1, 12, "%d", next_num);
         next_num++;
         do {
           fd = open(newname, O_CREAT | O_WRONLY | O_EXCL | O_BINARY, OPENMODE);

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -111,7 +111,7 @@ CURLcode easysrc_addf(struct slist_wc **plist, const char *fmt, ...)
   char *bufp;
   va_list ap;
   va_start(ap, fmt);
-  bufp = curlx_mvaprintf(fmt, ap);
+  bufp = curl_mvaprintf(fmt, ap);
   va_end(ap);
   if(!bufp) {
     ret = CURLE_OUT_OF_MEMORY;

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -53,7 +53,7 @@ static void voutf(struct GlobalConfig *config,
     char *ptr;
     char *print_buffer;
 
-    print_buffer = curlx_mvaprintf(fmt, ap);
+    print_buffer = curl_mvaprintf(fmt, ap);
     if(!print_buffer)
       return;
     len = strlen(print_buffer);

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -557,13 +557,13 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
 
     /* build a nice-looking prompt */
     if(!i && last)
-      curlx_msnprintf(prompt, sizeof(prompt),
-                      "Enter %s password for user '%s':",
-                      kind, *userpwd);
+      curl_msnprintf(prompt, sizeof(prompt),
+                     "Enter %s password for user '%s':",
+                     kind, *userpwd);
     else
-      curlx_msnprintf(prompt, sizeof(prompt),
-                      "Enter %s password for user '%s' on URL #%zu:",
-                      kind, *userpwd, i + 1);
+      curl_msnprintf(prompt, sizeof(prompt),
+                     "Enter %s password for user '%s' on URL #%zu:",
+                     kind, *userpwd, i + 1);
 
     /* get password */
     getpass_r(prompt, passwd, sizeof(passwd));


### PR DESCRIPTION
A couple of seemingly random calls used them.
They were all mapped to `curl_m*printf()`.