### PR TITLE
urlapi: verify URL *decoded* hostname when set

### DIFF
--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -838,6 +838,14 @@ static const struct setgetcase setget_parts_list[] = {
 
 /* !checksrc! disable SPACEBEFORECOMMA 1 */
 static const struct setcase set_parts_list[] = {
+  {"https://example.com/",
+   "host=%43url.se,",
+   "https://%43url.se/",
+   0, 0, CURLUE_OK, CURLUE_OK},
+  {"https://example.com/",
+   "host=%25url.se,",
+   "",
+   0, 0, CURLUE_OK, CURLUE_BAD_HOSTNAME},
   {"https://example.com/?param=value",
    "query=\"\",",
    "https://example.com/",


### PR DESCRIPTION
It was previously wrongly verifying the input in its URL encoded format when setting the hostname component with curl_url_set(), so it wrongly rejected '%'.

Now it URL decodes the name appropriately before the check.

Added tests to lib1560 to verify that a fine %-code is okay and that a bad %-code (that decodes to '%') is rejected.

Regression from 0a0c9b6dfa0de4a4c, shipped in 8.0.0

Fixes #14656
Reported-by: Venkat Krishna R