### PR TITLE
cmake: sync code between test/example targets

### DIFF
--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -39,5 +39,6 @@ foreach(_target IN LISTS check_PROGRAMS)
     set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
   endif()
   set_target_properties(${_target_name} PROPERTIES
-    OUTPUT_NAME "${_target}" UNITY_BUILD OFF)
+    OUTPUT_NAME "${_target}" UNITY_BUILD OFF
+    PROJECT_LABEL "Example ${_target}")
 endforeach()

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -26,18 +26,18 @@
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-foreach(_example IN LISTS check_PROGRAMS)
-  set(_example_target "curl-example-${_example}")
-  add_executable(${_example_target} "${_example}.c")
-  target_link_libraries(${_example_target} ${LIB_SELECTED} ${CURL_LIBS})
-  target_compile_definitions(${_example_target} PRIVATE "CURL_NO_OLDIES")
+foreach(_target IN LISTS check_PROGRAMS)
+  set(_target_name "curl-example-${_target}")
+  add_executable(${_target_name} "${_target}.c")
+  target_link_libraries(${_target_name} ${LIB_SELECTED} ${CURL_LIBS})
+  target_compile_definitions(${_target_name} PRIVATE "CURL_NO_OLDIES")
   if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
-    set_property(TARGET ${_example_target} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
+    set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
   if(MINGW)
     # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-    set_property(TARGET ${_example_target} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
+    set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
   endif()
-  set_target_properties(${_example_target} PROPERTIES
-    OUTPUT_NAME "${_example}" UNITY_BUILD OFF)
+  set_target_properties(${_target_name} PROPERTIES
+    OUTPUT_NAME "${_target}" UNITY_BUILD OFF)
 endforeach()

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -45,5 +45,5 @@ foreach(_target IN LISTS check_PROGRAMS)
   endif()
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}" UNITY_BUILD OFF
-    PROJECT_LABEL "Test client ${_target_name}")
+    PROJECT_LABEL "Test client ${_target}")
 endforeach()

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -26,24 +26,24 @@
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-foreach(_test_name IN LISTS check_PROGRAMS)
-  set(_test_target "curl-test-client-${_test_name}")
-  add_executable(${_test_target} EXCLUDE_FROM_ALL "${_test_name}.c")
-  add_dependencies(testdeps ${_test_target})
-  target_include_directories(${_test_target} PRIVATE
+foreach(_target IN LISTS check_PROGRAMS)
+  set(_target_name "curl-test-client-${_target}")
+  add_executable(${_target_name} EXCLUDE_FROM_ALL "${_target}.c")
+  add_dependencies(testdeps ${_target_name})
+  target_include_directories(${_target_name} PRIVATE
     "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
     "${CURL_SOURCE_DIR}/lib"  # for "curl_setup.h"
   )
-  target_link_libraries(${_test_target} ${LIB_SELECTED} ${CURL_LIBS})
-  target_compile_definitions(${_test_target} PRIVATE "CURL_NO_OLDIES")
+  target_link_libraries(${_target_name} ${LIB_SELECTED} ${CURL_LIBS})
+  target_compile_definitions(${_target_name} PRIVATE "CURL_NO_OLDIES")
   if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
-    set_property(TARGET ${_test_target} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
+    set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
   if(MINGW)
     # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-    set_property(TARGET ${_test_target} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
+    set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
   endif()
-  set_target_properties(${_test_target} PROPERTIES
-    OUTPUT_NAME "${_test_name}" UNITY_BUILD OFF
-    PROJECT_LABEL "Test client ${_test_target}")
+  set_target_properties(${_target_name} PROPERTIES
+    OUTPUT_NAME "${_target}" UNITY_BUILD OFF
+    PROJECT_LABEL "Test client ${_target_name}")
 endforeach()

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -21,29 +21,6 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-function(setup_test _target)  # ARGN are the files in the test
-
-  if(LIB_SELECTED STREQUAL LIB_STATIC)
-    # These are part of the libcurl static lib. Do not compile/link them again.
-    list(REMOVE_ITEM ARGN ${WARNLESS} ${MULTIBYTE} ${TIMEDIFF})
-  endif()
-
-  add_executable(${_target} EXCLUDE_FROM_ALL ${ARGN})
-  add_dependencies(testdeps ${_target})
-  string(TOUPPER ${_target} _upper_target)
-
-  include_directories(
-    "${CURL_BINARY_DIR}/lib"            # for "curl_config.h"
-    "${CURL_SOURCE_DIR}/lib"            # for "curl_setup.h"
-    "${CURL_SOURCE_DIR}/tests/libtest"  # to be able to build generated tests
-  )
-
-  target_link_libraries(${_target} ${LIB_SELECTED} ${CURL_LIBS})
-
-  set_target_properties(${_target} PROPERTIES
-    COMPILE_DEFINITIONS ${_upper_target}
-    PROJECT_LABEL "Test ${_target}")
-endfunction()
 
 # Get 'noinst_PROGRAMS', '*_SOURCES', WARNLESS, MULTIBYTE, TIMEDIFF variables
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
@@ -51,10 +28,30 @@ include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 foreach(_target IN LISTS noinst_PROGRAMS)
   if(DEFINED ${_target}_SOURCES)
-    setup_test(${_target} ${${_target}_SOURCES})
+    set(_sources ${${_target}_SOURCES})
   else()
-    setup_test(${_target} ${nodist_${_target}_SOURCES})
+    set(_sources ${nodist_${_target}_SOURCES})
   endif()
+
+  if(LIB_SELECTED STREQUAL LIB_STATIC)
+    # These are part of the libcurl static lib. Do not compile/link them again.
+    list(REMOVE_ITEM _sources ${WARNLESS} ${MULTIBYTE} ${TIMEDIFF})
+  endif()
+
+  string(TOUPPER ${_target} _upper_target)
+  set(_target_name "curl-test-${_target}")
+  add_executable(${_target_name} EXCLUDE_FROM_ALL ${_sources})
+  add_dependencies(testdeps ${_target_name})
+  target_link_libraries(${_target_name} ${LIB_SELECTED} ${CURL_LIBS})
+  include_directories(
+    "${CURL_BINARY_DIR}/lib"            # for "curl_config.h"
+    "${CURL_SOURCE_DIR}/lib"            # for "curl_setup.h"
+    "${CURL_SOURCE_DIR}/tests/libtest"  # to be able to build generated tests
+  )
+  set_target_properties(${_target_name} PROPERTIES
+    COMPILE_DEFINITIONS ${_upper_target}
+    OUTPUT_NAME "${_target}"
+    PROJECT_LABEL "Test ${_target}")
 endforeach()
 
 # Allows for hostname override to make tests machine independent.

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -21,16 +21,16 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-function(setup_test _test_name)  # ARGN are the files in the test
+function(setup_test _target)  # ARGN are the files in the test
 
   if(LIB_SELECTED STREQUAL LIB_STATIC)
     # These are part of the libcurl static lib. Do not compile/link them again.
     list(REMOVE_ITEM ARGN ${WARNLESS} ${MULTIBYTE} ${TIMEDIFF})
   endif()
 
-  add_executable(${_test_name} EXCLUDE_FROM_ALL ${ARGN})
-  add_dependencies(testdeps ${_test_name})
-  string(TOUPPER ${_test_name} _upper_test_name)
+  add_executable(${_target} EXCLUDE_FROM_ALL ${ARGN})
+  add_dependencies(testdeps ${_target})
+  string(TOUPPER ${_target} _upper_target)
 
   include_directories(
     "${CURL_BINARY_DIR}/lib"            # for "curl_config.h"
@@ -38,22 +38,22 @@ function(setup_test _test_name)  # ARGN are the files in the test
     "${CURL_SOURCE_DIR}/tests/libtest"  # to be able to build generated tests
   )
 
-  target_link_libraries(${_test_name} ${LIB_SELECTED} ${CURL_LIBS})
+  target_link_libraries(${_target} ${LIB_SELECTED} ${CURL_LIBS})
 
-  set_target_properties(${_test_name} PROPERTIES
-    COMPILE_DEFINITIONS ${_upper_test_name}
-    PROJECT_LABEL "Test ${_test_name}")
+  set_target_properties(${_target} PROPERTIES
+    COMPILE_DEFINITIONS ${_upper_target}
+    PROJECT_LABEL "Test ${_target}")
 endfunction()
 
 # Get 'noinst_PROGRAMS', '*_SOURCES', WARNLESS, MULTIBYTE, TIMEDIFF variables
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-foreach(_test_name IN LISTS noinst_PROGRAMS)
-  if(DEFINED ${_test_name}_SOURCES)
-    setup_test(${_test_name} ${${_test_name}_SOURCES})
+foreach(_target IN LISTS noinst_PROGRAMS)
+  if(DEFINED ${_target}_SOURCES)
+    setup_test(${_target} ${${_target}_SOURCES})
   else()
-    setup_test(${_test_name} ${nodist_${_test_name}_SOURCES})
+    setup_test(${_target} ${nodist_${_target}_SOURCES})
   endif()
 endforeach()
 

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -59,6 +59,10 @@ endforeach()
 if(NOT WIN32)
   add_library(hostname MODULE EXCLUDE_FROM_ALL "sethostname.c")
   add_dependencies(testdeps hostname)
+  target_include_directories(${_target_name} PRIVATE
+    "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
+    "${CURL_SOURCE_DIR}/lib"  # for "curl_setup.h"
+  )
   # Output to .libs for compatibility with autotools, the test data expects a
   # library at (tests)/libtest/.libs/libhostname.so
   set_target_properties(hostname PROPERTIES

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -51,7 +51,7 @@ foreach(_target IN LISTS noinst_PROGRAMS)
   set_target_properties(${_target_name} PROPERTIES
     COMPILE_DEFINITIONS ${_upper_target}
     OUTPUT_NAME "${_target}"
-    PROJECT_LABEL "Test ${_target}")
+    PROJECT_LABEL "Test libtest ${_target}")
 endforeach()
 
 # Allows for hostname override to make tests machine independent.

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -59,7 +59,7 @@ endforeach()
 if(NOT WIN32)
   add_library(hostname MODULE EXCLUDE_FROM_ALL "sethostname.c")
   add_dependencies(testdeps hostname)
-  target_include_directories(${_target_name} PRIVATE
+  target_include_directories(hostname PRIVATE
     "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
     "${CURL_SOURCE_DIR}/lib"  # for "curl_setup.h"
   )

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -43,7 +43,7 @@ foreach(_target IN LISTS noinst_PROGRAMS)
   add_executable(${_target_name} EXCLUDE_FROM_ALL ${_sources})
   add_dependencies(testdeps ${_target_name})
   target_link_libraries(${_target_name} ${LIB_SELECTED} ${CURL_LIBS})
-  include_directories(
+  target_include_directories(${_target_name} PRIVATE
     "${CURL_BINARY_DIR}/lib"            # for "curl_config.h"
     "${CURL_SOURCE_DIR}/lib"            # for "curl_setup.h"
     "${CURL_SOURCE_DIR}/tests/libtest"  # to be able to build generated tests

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -42,8 +42,10 @@ foreach(_target IN LISTS noinst_PROGRAMS)
   # to build the servers.  In order to achieve proper linkage of these
   # files on Windows targets it is necessary to build the test servers
   # with CURL_STATICLIB defined, independently of how libcurl is built.
+  if(WIN32)
+    set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
+  endif()
   set_target_properties(${_target_name} PROPERTIES
-    COMPILE_DEFINITIONS "CURL_STATICLIB"
     OUTPUT_NAME "${_target}"
     PROJECT_LABEL "Test server ${_target}")
 endforeach()

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -21,9 +21,9 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-function(setup_executable _test_name)  # ARGN are the files in the test
-  add_executable(${_test_name} EXCLUDE_FROM_ALL ${ARGN})
-  add_dependencies(testdeps ${_test_name})
+function(setup_test_server _target)  # ARGN are the files in the test
+  add_executable(${_target} EXCLUDE_FROM_ALL ${ARGN})
+  add_dependencies(testdeps ${_target})
 
   include_directories(
     "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
@@ -31,7 +31,7 @@ function(setup_executable _test_name)  # ARGN are the files in the test
     "${CURL_SOURCE_DIR}/src"  # for "tool_xattr.h" in disabled_SOURCES
   )
 
-  target_link_libraries(${_test_name} ${CURL_LIBS})
+  target_link_libraries(${_target} ${CURL_LIBS})
 
   # Test servers simply are standalone programs that do not use libcurl
   # library.  For convenience and to ease portability of these servers,
@@ -39,15 +39,15 @@ function(setup_executable _test_name)  # ARGN are the files in the test
   # to build the servers.  In order to achieve proper linkage of these
   # files on Windows targets it is necessary to build the test servers
   # with CURL_STATICLIB defined, independently of how libcurl is built.
-  set_target_properties(${_test_name} PROPERTIES
+  set_target_properties(${_target} PROPERTIES
     COMPILE_DEFINITIONS "CURL_STATICLIB"
-    PROJECT_LABEL "Test server ${_test_name}")
+    PROJECT_LABEL "Test server ${_target}")
 endfunction()
 
 # Get 'noinst_PROGRAMS', '<target>_SOURCES' variables
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-foreach(_executable_name IN LISTS noinst_PROGRAMS)
-  setup_executable(${_executable_name} ${${_executable_name}_SOURCES})
+foreach(_target IN LISTS noinst_PROGRAMS)
+  setup_test_server(${_target} ${${_target}_SOURCES})
 endforeach()

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -21,33 +21,29 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-function(setup_test_server _target)  # ARGN are the files in the test
-  add_executable(${_target} EXCLUDE_FROM_ALL ${ARGN})
-  add_dependencies(testdeps ${_target})
-
-  include_directories(
-    "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
-    "${CURL_SOURCE_DIR}/lib"  # for "curl_setup.h"
-    "${CURL_SOURCE_DIR}/src"  # for "tool_xattr.h" in disabled_SOURCES
-  )
-
-  target_link_libraries(${_target} ${CURL_LIBS})
-
-  # Test servers simply are standalone programs that do not use libcurl
-  # library.  For convenience and to ease portability of these servers,
-  # some source code files from the libcurl subdirectory are also used
-  # to build the servers.  In order to achieve proper linkage of these
-  # files on Windows targets it is necessary to build the test servers
-  # with CURL_STATICLIB defined, independently of how libcurl is built.
-  set_target_properties(${_target} PROPERTIES
-    COMPILE_DEFINITIONS "CURL_STATICLIB"
-    PROJECT_LABEL "Test server ${_target}")
-endfunction()
 
 # Get 'noinst_PROGRAMS', '<target>_SOURCES' variables
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 foreach(_target IN LISTS noinst_PROGRAMS)
-  setup_test_server(${_target} ${${_target}_SOURCES})
+  set(_target_name "curl-test-server-${_target}")
+  add_executable(${_target_name} EXCLUDE_FROM_ALL ${${_target}_SOURCES})
+  add_dependencies(testdeps ${_target_name})
+  include_directories(
+    "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
+    "${CURL_SOURCE_DIR}/lib"  # for "curl_setup.h"
+    "${CURL_SOURCE_DIR}/src"  # for "tool_xattr.h" in disabled_SOURCES
+  )
+  target_link_libraries(${_target_name} ${CURL_LIBS})
+  # Test servers simply are standalone programs that do not use libcurl
+  # library.  For convenience and to ease portability of these servers,
+  # some source code files from the libcurl subdirectory are also used
+  # to build the servers.  In order to achieve proper linkage of these
+  # files on Windows targets it is necessary to build the test servers
+  # with CURL_STATICLIB defined, independently of how libcurl is built.
+  set_target_properties(${_target_name} PROPERTIES
+    COMPILE_DEFINITIONS "CURL_STATICLIB"
+    OUTPUT_NAME "${_target}"
+    PROJECT_LABEL "Test server ${_target}")
 endforeach()

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -30,7 +30,7 @@ foreach(_target IN LISTS noinst_PROGRAMS)
   set(_target_name "curl-test-server-${_target}")
   add_executable(${_target_name} EXCLUDE_FROM_ALL ${${_target}_SOURCES})
   add_dependencies(testdeps ${_target_name})
-  include_directories(
+  target_include_directories(${_target_name} PRIVATE
     "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
     "${CURL_SOURCE_DIR}/lib"  # for "curl_setup.h"
     "${CURL_SOURCE_DIR}/src"  # for "tool_xattr.h" in disabled_SOURCES

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -33,10 +33,10 @@ include_directories(
   "${CURL_SOURCE_DIR}/tests/libtest"
 )
 
-foreach(_test_name IN LISTS UNITPROGS)
-  add_executable(${_test_name} EXCLUDE_FROM_ALL "${_test_name}.c" ${UNITFILES})
-  add_dependencies(testdeps ${_test_name})
-  target_link_libraries(${_test_name} curltool curlu)
-  set_target_properties(${_test_name} PROPERTIES
-    PROJECT_LABEL "Test unit ${_test_name}")
+foreach(_target IN LISTS UNITPROGS)
+  add_executable(${_target} EXCLUDE_FROM_ALL "${_target}.c" ${UNITFILES})
+  add_dependencies(testdeps ${_target})
+  target_link_libraries(${_target} curltool curlu)
+  set_target_properties(${_target} PROPERTIES
+    PROJECT_LABEL "Test unit ${_target}")
 endforeach()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -26,17 +26,18 @@
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-include_directories(
-  "${CURL_BINARY_DIR}/lib"            # for "curl_config.h"
-  "${CURL_SOURCE_DIR}/lib"            # for "curl_setup.h"
-  "${CURL_SOURCE_DIR}/src"
-  "${CURL_SOURCE_DIR}/tests/libtest"
-)
-
 foreach(_target IN LISTS UNITPROGS)
-  add_executable(${_target} EXCLUDE_FROM_ALL "${_target}.c" ${UNITFILES})
-  add_dependencies(testdeps ${_target})
-  target_link_libraries(${_target} curltool curlu)
-  set_target_properties(${_target} PROPERTIES
+  set(_target_name "curl-test-${_target}")
+  add_executable(${_target_name} EXCLUDE_FROM_ALL "${_target}.c" ${UNITFILES})
+  add_dependencies(testdeps ${_target_name})
+  target_link_libraries(${_target_name} curltool curlu)
+  target_include_directories(${_target_name} PRIVATE
+    "${CURL_BINARY_DIR}/lib"            # for "curl_config.h"
+    "${CURL_SOURCE_DIR}/lib"            # for "curl_setup.h"
+    "${CURL_SOURCE_DIR}/src"
+    "${CURL_SOURCE_DIR}/tests/libtest"
+  )
+  set_target_properties(${_target_name} PROPERTIES
+    OUTPUT_NAME "${_target}"
     PROJECT_LABEL "Test unit ${_target}")
 endforeach()


### PR DESCRIPTION
- reuse local variable names.
- sync `PROJECT_LABEL`, add where missing.
- namespace all target names.
- bind header directories to each target.
- tests/server: limit `CURL_STATICLIB` to Windows (as in autotools.)
- drop functions with a single caller.

---

w/o whitespace: https://github.com/curl/curl/pull/14660/files?w=1