### PR TITLE
GHA/windows: add Linux -> mingw-w64 cross-build (cmake, autotools)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -341,8 +341,8 @@ jobs:
           PATH="$PWD/bld/lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
-  linux-cross-mingw64:
-    name: 'linux -> mingw-w64'
+  linux-cross-mingw-w64:
+    name: 'linux-mingw'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -367,6 +367,7 @@ jobs:
         run: |
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --host=${TRIPLET} \
+            --with-schannel \
             --without-libpsl \
             --disable-dependency-tracking
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -341,7 +341,7 @@ jobs:
           PATH="$PWD/bld/lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
-  linux_cross_mingw64:
+  linux-cross-mingw64:
     name: 'linux -> mingw-w64'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -391,6 +391,7 @@ jobs:
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
+            -DCURL_USE_SCHANNEL=ON \
             -DCURL_USE_LIBPSL=OFF
 
       - name: 'cmake configure log'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: 'curl version'
         if: ${{ matrix.build == 'autotools' }}
-        timeout-minutes: 11
+        timeout-minutes: 1
         run: |
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
@@ -525,7 +525,7 @@ jobs:
         run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
-        timeout-minutes: 5
+        timeout-minutes: 1
         run: |
           find . -name '*.exe' -o -name '*.dll' | grep -v '/examples/'
           if [ '${{ matrix.plat }}' != 'uwp' ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -341,6 +341,65 @@ jobs:
           PATH="$PWD/bld/lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
+  linux_cross_mingw64:
+    name: 'linux -> mingw-w64'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [autotools, cmake]
+        compiler: [gcc]
+    env:
+      TRIPLET: 'x86_64-w64-mingw32'
+    steps:
+      - name: 'install packages'
+        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install mingw-w64
+
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: 'autotools autoreconf'
+        if: ${{ matrix.build == 'autotools' }}
+        run: autoreconf -fi
+
+      - name: 'autotools configure'
+        if: ${{ matrix.build == 'autotools' }}
+        run: |
+          mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
+            --host=${TRIPLET} \
+            --without-libpsl \
+            --disable-dependency-tracking
+
+      - name: 'autotools configure log'
+        if: ${{ matrix.build == 'autotools' && !cancelled() }}
+        run: cat bld/config.log 2>/dev/null || true
+
+      - name: 'autotools build'
+        if: ${{ matrix.build == 'autotools' }}
+        run: |
+          make -C bld -j5
+          make -C bld -j5 examples
+
+      - name: 'cmake configure'
+        if: ${{ matrix.build == 'cmake' }}
+        run: |
+          cmake -B bld \
+            -DCMAKE_SYSTEM_NAME=Windows \
+            -DCMAKE_C_COMPILER_TARGET=${TRIPLET} \
+            -DCMAKE_C_COMPILER=${TRIPLET}-gcc \
+            -DCMAKE_UNITY_BUILD=ON \
+            -DCURL_WERROR=ON \
+            -DBUILD_EXAMPLES=ON \
+            -DCURL_USE_LIBPSL=OFF
+
+      - name: 'cmake configure log'
+        if: ${{ matrix.build == 'cmake' && !cancelled() }}
+        run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
+
+      - name: 'cmake build'
+        if: ${{ matrix.build == 'cmake' }}
+        run: cmake --build bld --parallel 5
+
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
     runs-on: windows-latest

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -342,7 +342,7 @@ jobs:
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
   linux-cross-mingw-w64:
-    name: 'linux-mingw'
+    name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,9 @@ endif()
 message(STATUS "CMake platform flags:${_flags}")
 set(_flags)
 
-message(STATUS "Host and target: ${CMAKE_HOST_SYSTEM_NAME}/${CMAKE_HOST_SYSTEM_PROCESSOR} -> ${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR}")
+if(CMAKE_CROSSCOMPILING)
+  message(STATUS "Host and target: '${CMAKE_HOST_SYSTEM_NAME}/${CMAKE_HOST_SYSTEM_PROCESSOR}' -> '${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR}'")
+endif()
 
 function(curl_dumpvars)  # Dump all defined variables with their values
   message("::group::CMake Variable Dump")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ endif()
 message(STATUS "CMake platform flags:${_flags}")
 set(_flags)
 
+message(STATUS "Host and target: ${CMAKE_HOST_SYSTEM_NAME}/${CMAKE_HOST_SYSTEM_PROCESSOR} -> ${CMAKE_SYSTEM_NAME}/${CMAKE_SYSTEM_PROCESSOR}")
+
 function(curl_dumpvars)  # Dump all defined variables with their values
   message("::group::CMake Variable Dump")
   get_cmake_property(_vars VARIABLES)


### PR DESCRIPTION
Also:
- add a line to CMake log output showing the host and target OS and CPU
  when doing cross-builds.
- reduce excessive timeout for `curl -V` steps.
