### PR TITLE
Connection Pools

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -47,202 +47,242 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#define HASHKEY_SIZE 128
 
-static void connc_discard_conn(struct conncache *connc,
-                               struct Curl_easy *last_data,
+#define CPOOL_IS_LOCKED(c)    ((c) && (c)->locked)
+
+#define CPOOL_LOCK(c)                                                   \
+  do {                                                                  \
+    if((c)) {                                                           \
+      if(CURL_SHARE_KEEP_CONNECT((c)->share))                           \
+        Curl_share_lock(((c)->idata), CURL_LOCK_DATA_CONNECT,           \
+                        CURL_LOCK_ACCESS_SINGLE);                       \
+      DEBUGASSERT(!(c)->locked);                                        \
+      (c)->locked = TRUE;                                               \
+    }                                                                   \
+  } while(0)
+
+#define CPOOL_UNLOCK(c)                                                 \
+  do {                                                                  \
+    if((c)) {                                                           \
+      DEBUGASSERT((c)->locked);                                         \
+      (c)->locked = FALSE;                                              \
+      if(CURL_SHARE_KEEP_CONNECT((c)->share))                           \
+        Curl_share_unlock((c)->idata, CURL_LOCK_DATA_CONNECT);          \
+    }                                                                   \
+  } while(0)
+
+
+/* A list of connections to the same destinationn. */
+struct cpool_bundle {
+  struct Curl_llist conns; /* connections in the bundle */
+  size_t dest_len; /* total length of destination, including NUL */
+  char *dest[1]; /* destination of bundle, allocated to keep dest_len bytes */
+};
+
+
+static void cpool_discard_conn(struct cpool *cpool,
+                               struct Curl_easy *data,
                                struct connectdata *conn,
                                bool aborted);
-static void connc_disconnect(struct Curl_easy *data,
-                             struct connectdata *conn,
-                             struct conncache *connc,
-                             bool do_shutdown);
-static void connc_run_conn_shutdown(struct Curl_easy *data,
+static void cpool_close_and_destroy(struct cpool *cpool,
+                                    struct connectdata *conn,
+                                    struct Curl_easy *data,
+                                    bool do_shutdown);
+static void cpool_run_conn_shutdown(struct Curl_easy *data,
                                     struct connectdata *conn,
                                     bool *done);
-static void connc_run_conn_shutdown_handler(struct Curl_easy *data,
+static void cpool_run_conn_shutdown_handler(struct Curl_easy *data,
                                             struct connectdata *conn);
-static CURLMcode connc_update_shutdown_ev(struct Curl_multi *multi,
+static CURLMcode cpool_update_shutdown_ev(struct Curl_multi *multi,
                                           struct Curl_easy *data,
                                           struct connectdata *conn);
-static void connc_shutdown_all(struct conncache *connc, int timeout_ms);
+static void cpool_shutdown_all(struct cpool *cpool,
+                               struct Curl_easy *data, int timeout_ms);
+static void cpool_close_and_destroy_all(struct cpool *cpool);
+static struct connectdata *cpool_get_oldest_idle(struct cpool *cpool);
 
-static CURLcode bundle_create(struct connectbundle **bundlep)
+static struct cpool_bundle *cpool_bundle_create(const char *dest,
+                                                size_t dest_len)
 {
-  DEBUGASSERT(*bundlep == NULL);
-  *bundlep = malloc(sizeof(struct connectbundle));
-  if(!*bundlep)
-    return CURLE_OUT_OF_MEMORY;
-
-  (*bundlep)->num_connections = 0;
-  (*bundlep)->multiuse = BUNDLE_UNKNOWN;
-
-  Curl_llist_init(&(*bundlep)->conn_list, NULL);
-  return CURLE_OK;
+  struct cpool_bundle *bundle;
+  bundle = calloc(1, sizeof(*bundle) + dest_len);
+  if(!bundle)
+    return NULL;
+  Curl_llist_init(&bundle->conns, NULL);
+  bundle->dest_len = dest_len;
+  memcpy(bundle->dest, dest, dest_len);
+  return bundle;
 }
 
-static void bundle_destroy(struct connectbundle *bundle)
+static void cpool_bundle_destroy(struct cpool_bundle *bundle)
 {
+  DEBUGASSERT(!Curl_llist_count(&bundle->conns));
   free(bundle);
 }
 
 /* Add a connection to a bundle */
-static void bundle_add_conn(struct connectbundle *bundle,
-                            struct connectdata *conn)
+static void cpool_bundle_add(struct cpool_bundle *bundle,
+                             struct connectdata *conn)
 {
-  Curl_llist_append(&bundle->conn_list, conn, &conn->bundle_node);
-  conn->bundle = bundle;
-  bundle->num_connections++;
+  DEBUGASSERT(!Curl_node_llist(&conn->cpool_node));
+  Curl_llist_append(&bundle->conns, conn, &conn->cpool_node);
+  conn->bits.in_cpool = TRUE;
 }
 
 /* Remove a connection from a bundle */
-static int bundle_remove_conn(struct connectbundle *bundle,
-                              struct connectdata *conn)
+static void cpool_bundle_remove(struct cpool_bundle *bundle,
+                                struct connectdata *conn)
 {
-  struct Curl_llist_node *curr = Curl_llist_head(&bundle->conn_list);
-  while(curr) {
-    if(Curl_node_elem(curr) == conn) {
-      Curl_node_remove(curr);
-      bundle->num_connections--;
-      conn->bundle = NULL;
-      return 1; /* we removed a handle */
-    }
-    curr = Curl_node_next(curr);
-  }
-  DEBUGASSERT(0);
-  return 0;
+  (void)bundle;
+  DEBUGASSERT(Curl_node_llist(&conn->cpool_node) == &bundle->conns);
+  Curl_node_remove(&conn->cpool_node);
+  conn->bits.in_cpool = FALSE;
 }
 
-static void free_bundle_hash_entry(void *freethis)
+static void cpool_bundle_free_entry(void *freethis)
 {
-  struct connectbundle *b = (struct connectbundle *) freethis;
-
-  bundle_destroy(b);
+  cpool_bundle_destroy((struct cpool_bundle *)freethis);
 }
 
-int Curl_conncache_init(struct conncache *connc,
-                        struct Curl_multi *multi, size_t size)
+int Curl_cpool_init(struct cpool *cpool,
+                        Curl_cpool_disconnect_cb *disconnect_cb,
+                        struct Curl_multi *multi,
+                        struct Curl_share *share,
+                        size_t size)
 {
-  Curl_hash_init(&connc->hash, size, Curl_hash_str,
-                 Curl_str_key_compare, free_bundle_hash_entry);
+  DEBUGASSERT(!!multi != !!share); /* either one */
+  Curl_hash_init(&cpool->dest2bundle, size, Curl_hash_str,
+                 Curl_str_key_compare, cpool_bundle_free_entry);
+  Curl_llist_init(&cpool->shutdowns, NULL);
+
+  DEBUGASSERT(disconnect_cb);
+  if(!disconnect_cb)
+    return 1;
 
   /* allocate a new easy handle to use when closing cached connections */
-  connc->closure_handle = curl_easy_init();
-  if(!connc->closure_handle)
+  cpool->idata = curl_easy_init();
+  if(!cpool->idata)
     return 1; /* bad */
-  connc->closure_handle->state.internal = true;
+  cpool->idata->state.internal = true;
   /* TODO: this is quirky. We need an internal handle for certain
    * operations, but we do not add it to the multi (if there is one).
    * But we give it the multi so that socket event operations can work.
    * Probably better to have an internal handle owned by the multi that
-   * can be used for conncache operations. */
-  connc->closure_handle->multi = multi;
+   * can be used for cpool operations. */
+  cpool->idata->multi = multi;
  #ifdef DEBUGBUILD
   if(getenv("CURL_DEBUG"))
-    connc->closure_handle->set.verbose = true;
+    cpool->idata->set.verbose = true;
 #endif
 
-  connc->closure_handle->state.conn_cache = connc;
-  connc->multi = multi;
-  Curl_llist_init(&connc->shutdowns.conn_list, NULL);
+  cpool->disconnect_cb = disconnect_cb;
+  cpool->idata->multi = cpool->multi = multi;
+  cpool->idata->share = cpool->share = share;
 
   return 0; /* good */
 }
 
-void Curl_conncache_destroy(struct conncache *connc)
+void Curl_cpool_destroy(struct cpool *cpool)
 {
-  if(connc) {
-    if(connc->closure_handle) {
-      connc->closure_handle->multi = NULL;
-      Curl_close(&connc->closure_handle);
+  if(cpool) {
+    if(cpool->idata) {
+      cpool_close_and_destroy_all(cpool);
+      /* The internal closure handle is special and we need to
+       * disconnect it from multi/share before closing it down. */
+      cpool->idata->multi = NULL;
+      cpool->idata->share = NULL;
+      Curl_close(&cpool->idata);
     }
-    Curl_hash_destroy(&connc->hash);
-    connc->multi = NULL;
+    Curl_hash_destroy(&cpool->dest2bundle);
+    cpool->multi = NULL;
   }
 }
 
-/* creates a key to find a bundle for this connection */
-static void hashkey(struct connectdata *conn, char *buf, size_t len)
+static struct cpool *cpool_get_instance(struct Curl_easy *data)
 {
-  const char *hostname;
-  long port = conn->remote_port;
-  DEBUGASSERT(len >= HASHKEY_SIZE);
-#ifndef CURL_DISABLE_PROXY
-  if(conn->bits.httpproxy && !conn->bits.tunnel_proxy) {
-    hostname = conn->http_proxy.host.name;
-    port = conn->primary.remote_port;
+  if(data) {
+    if(CURL_SHARE_KEEP_CONNECT(data->share))
+      return &data->share->cpool;
+    else if(data->multi_easy)
+      return &data->multi_easy->cpool;
+    else if(data->multi)
+      return &data->multi->cpool;
   }
-  else
-#endif
-    if(conn->bits.conn_to_host)
-      hostname = conn->conn_to_host.name;
-  else
-    hostname = conn->host.name;
-
-  /* put the numbers first so that the hostname gets cut off if too long */
-#ifdef USE_IPV6
-  msnprintf(buf, len, "%u/%ld/%s", conn->scope_id, port, hostname);
-#else
-  msnprintf(buf, len, "%ld/%s", port, hostname);
-#endif
-  Curl_strntolower(buf, buf, len);
+  return NULL;
 }
 
-/* Returns number of connections currently held in the connection cache.
-   Locks/unlocks the cache itself!
-*/
-size_t Curl_conncache_size(struct Curl_easy *data)
+void Curl_cpool_xfer_init(struct Curl_easy *data)
 {
-  size_t num;
-  CONNCACHE_LOCK(data);
-  num = data->state.conn_cache->num_conn;
-  CONNCACHE_UNLOCK(data);
-  return num;
+  struct cpool *cpool = cpool_get_instance(data);
+
+  DEBUGASSERT(cpool);
+  if(cpool) {
+    CPOOL_LOCK(cpool);
+    /* the identifier inside the connection cache */
+    data->id = cpool->next_easy_id++;
+    if(cpool->next_easy_id <= 0)
+      cpool->next_easy_id = 0;
+    data->state.lastconnect_id = -1;
+
+    /* The closure handle only ever has default timeouts set. To improve the
+       state somewhat we clone the timeouts from each added handle so that the
+       closure handle always has the same timeouts as the most recently added
+       easy handle. */
+    cpool->idata->set.timeout = data->set.timeout;
+    cpool->idata->set.server_response_timeout =
+      data->set.server_response_timeout;
+    cpool->idata->set.no_signal = data->set.no_signal;
+
+    CPOOL_UNLOCK(cpool);
+  }
+  else {
+    /* We should not get here, but in a non-debug build, do something */
+    data->id = 0;
+    data->state.lastconnect_id = -1;
+  }
 }
 
-/* Look up the bundle with all the connections to the same host this
-   connectdata struct is setup to use.
-
-   **NOTE**: When it returns, it holds the connection cache lock! */
-struct connectbundle *
-Curl_conncache_find_bundle(struct Curl_easy *data,
-                           struct connectdata *conn,
-                           struct conncache *connc)
+static struct cpool_bundle *cpool_find_bundle(struct cpool *cpool,
+                                              struct connectdata *conn)
 {
-  struct connectbundle *bundle = NULL;
-  CONNCACHE_LOCK(data);
-  if(connc) {
-    char key[HASHKEY_SIZE];
-    hashkey(conn, key, sizeof(key));
-    bundle = Curl_hash_pick(&connc->hash, key, strlen(key));
-  }
+  return Curl_hash_pick(&cpool->dest2bundle,
+                        conn->destination, conn->destination_len);
+}
 
+static struct cpool_bundle *
+cpool_add_bundle(struct cpool *cpool, struct connectdata *conn)
+{
+  struct cpool_bundle *bundle;
+
+  bundle = cpool_bundle_create(conn->destination, conn->destination_len);
+  if(!bundle)
+    return NULL;
+
+  if(!Curl_hash_add(&cpool->dest2bundle,
+                    bundle->dest, bundle->dest_len, bundle)) {
+    cpool_bundle_destroy(bundle);
+    return NULL;
+  }
   return bundle;
 }
 
-static void *connc_add_bundle(struct conncache *connc,
-                              char *key, struct connectbundle *bundle)
-{
-  return Curl_hash_add(&connc->hash, key, strlen(key), bundle);
-}
-
-static void connc_remove_bundle(struct conncache *connc,
-                                struct connectbundle *bundle)
+static void cpool_remove_bundle(struct cpool *cpool,
+                                struct cpool_bundle *bundle)
 {
   struct Curl_hash_iterator iter;
   struct Curl_hash_element *he;
 
-  if(!connc)
+  if(!cpool)
     return;
 
-  Curl_hash_start_iterate(&connc->hash, &iter);
+  Curl_hash_start_iterate(&cpool->dest2bundle, &iter);
 
   he = Curl_hash_next_element(&iter);
   while(he) {
     if(he->ptr == bundle) {
       /* The bundle is destroyed by the hash destructor function,
          free_bundle_hash_entry() */
-      Curl_hash_delete(&connc->hash, he->key, he->key_len);
+      Curl_hash_delete(&cpool->dest2bundle, he->key, he->key_len);
       return;
     }
 
@@ -250,120 +290,164 @@ static void connc_remove_bundle(struct conncache *connc,
   }
 }
 
-CURLcode Curl_conncache_add_conn(struct Curl_easy *data)
+static struct connectdata *
+cpool_bundle_get_oldest_idle(struct cpool_bundle *bundle);
+
+int Curl_cpool_check_limits(struct Curl_easy *data,
+                            struct connectdata *conn)
 {
-  CURLcode result = CURLE_OK;
-  struct connectbundle *bundle = NULL;
-  struct connectdata *conn = data->conn;
-  struct conncache *connc = data->state.conn_cache;
-  DEBUGASSERT(conn);
+  struct cpool *cpool = cpool_get_instance(data);
+  struct cpool_bundle *bundle;
+  size_t dest_limit = 0;
+  size_t total_limit = 0;
+  int result = CPOOL_LIMIT_OK;
 
-  /* *find_bundle() locks the connection cache */
-  bundle = Curl_conncache_find_bundle(data, conn, data->state.conn_cache);
-  if(!bundle) {
-    char key[HASHKEY_SIZE];
+  if(!cpool)
+    return CPOOL_LIMIT_OK;
 
-    result = bundle_create(&bundle);
-    if(result) {
-      goto unlock;
+  if(data && data->multi) {
+    dest_limit = data->multi->max_host_connections;
+    total_limit = data->multi->max_total_connections;
+  }
+
+  if(!dest_limit && !total_limit)
+    return CPOOL_LIMIT_OK;
+
+  CPOOL_LOCK(cpool);
+  if(dest_limit) {
+    bundle = cpool_find_bundle(cpool, conn);
+    while(bundle && (Curl_llist_count(&bundle->conns) >= dest_limit)) {
+      struct connectdata *oldest_idle = NULL;
+      /* The bundle is full. Extract the oldest connection that may
+       * be removed now, if there is one. */
+      oldest_idle = cpool_bundle_get_oldest_idle(bundle);
+      if(!oldest_idle)
+        break;
+      /* disconnect the old conn and continue */
+      DEBUGF(infof(data, "Discarding connection #%"
+                   CURL_FORMAT_CURL_OFF_T " from %zu to reach destination "
+                   "limit of %zu", oldest_idle->connection_id,
+                   Curl_llist_count(&bundle->conns), dest_limit));
+      Curl_cpool_disconnect(data, oldest_idle, FALSE);
     }
-
-    hashkey(conn, key, sizeof(key));
-
-    if(!connc_add_bundle(data->state.conn_cache, key, bundle)) {
-      bundle_destroy(bundle);
-      result = CURLE_OUT_OF_MEMORY;
-      goto unlock;
+    if(bundle && (Curl_llist_count(&bundle->conns) >= dest_limit)) {
+      result = CPOOL_LIMIT_DEST;
+      goto out;
     }
   }
 
-  bundle_add_conn(bundle, conn);
-  conn->connection_id = connc->next_connection_id++;
-  connc->num_conn++;
+  if(total_limit) {
+    while(cpool->num_conn >= total_limit) {
+      struct connectdata *oldest_idle = cpool_get_oldest_idle(cpool);
+      if(!oldest_idle)
+        break;
+      /* disconnect the old conn and continue */
+      DEBUGF(infof(data, "Discarding connection #%"
+                   CURL_FORMAT_CURL_OFF_T " from %zu to reach total "
+                   "limit of %zu",
+                   oldest_idle->connection_id, cpool->num_conn, total_limit));
+      Curl_cpool_disconnect(data, oldest_idle, FALSE);
+    }
+    if(cpool->num_conn >= total_limit) {
+      result = CPOOL_LIMIT_TOTAL;
+      goto out;
+    }
+  }
 
+out:
+  CPOOL_UNLOCK(cpool);
+  return result;
+}
+
+CURLcode Curl_cpool_add_conn(struct Curl_easy *data,
+                             struct connectdata *conn)
+{
+  CURLcode result = CURLE_OK;
+  struct cpool_bundle *bundle = NULL;
+  struct cpool *cpool = cpool_get_instance(data);
+  DEBUGASSERT(conn);
+
+  DEBUGASSERT(cpool);
+  if(!cpool)
+    return CURLE_FAILED_INIT;
+
+  CPOOL_LOCK(cpool);
+  bundle = cpool_find_bundle(cpool, conn);
+  if(!bundle) {
+    bundle = cpool_add_bundle(cpool, conn);
+    if(!bundle) {
+      result = CURLE_OUT_OF_MEMORY;
+      goto out;
+    }
+  }
+
+  cpool_bundle_add(bundle, conn);
+  conn->connection_id = cpool->next_connection_id++;
+  cpool->num_conn++;
   DEBUGF(infof(data, "Added connection %" CURL_FORMAT_CURL_OFF_T ". "
                "The cache now contains %zu members",
-               conn->connection_id, connc->num_conn));
-
-unlock:
-  CONNCACHE_UNLOCK(data);
+               conn->connection_id, cpool->num_conn));
+out:
+  CPOOL_UNLOCK(cpool);
 
   return result;
 }
 
-static void connc_remove_conn(struct conncache *connc,
+static void cpool_remove_conn(struct cpool *cpool,
                               struct connectdata *conn)
 {
-  struct connectbundle *bundle = conn->bundle;
-
-  /* The bundle pointer can be NULL, since this function can be called
-     due to a failed connection attempt, before being added to a bundle */
-  if(bundle) {
-    bundle_remove_conn(bundle, conn);
-    if(connc && bundle->num_connections == 0)
-      connc_remove_bundle(connc, bundle);
-    conn->bundle = NULL; /* removed from it */
-    if(connc)
-      connc->num_conn--;
+  struct Curl_llist *list = Curl_node_llist(&conn->cpool_node);
+  DEBUGASSERT(cpool);
+  if(list) {
+    /* The connection is certainly in the pool, but where? */
+    struct cpool_bundle *bundle = cpool_find_bundle(cpool, conn);
+    if(bundle && (list == &bundle->conns)) {
+      cpool_bundle_remove(bundle, conn);
+      if(!Curl_llist_count(&bundle->conns))
+        cpool_remove_bundle(cpool, bundle);
+      conn->bits.in_cpool = FALSE;
+      cpool->num_conn--;
+    }
+    else {
+      /* Not in  a bundle, already in the shutdown list? */
+      DEBUGASSERT(list == &cpool->shutdowns);
+    }
   }
 }
 
-/*
- * Removes the connectdata object from the connection cache, but the transfer
- * still owns this connection.
- *
- * Pass TRUE/FALSE in the 'lock' argument depending on if the parent function
- * already holds the lock or not.
- */
-void Curl_conncache_remove_conn(struct Curl_easy *data,
-                                struct connectdata *conn, bool lock)
-{
-  struct conncache *connc = data->state.conn_cache;
-
-  if(lock)
-    CONNCACHE_LOCK(data);
-  connc_remove_conn(connc, conn);
-  if(lock)
-    CONNCACHE_UNLOCK(data);
-  if(connc)
-    DEBUGF(infof(data, "The cache now contains %zu members",
-                 connc->num_conn));
-}
-
-/* This function iterates the entire connection cache and calls the function
+/* This function iterates the entire connection pool and calls the function
    func() with the connection pointer as the first argument and the supplied
    'param' argument as the other.
 
-   The conncache lock is still held when the callback is called. It needs it,
+   The cpool lock is still held when the callback is called. It needs it,
    so that it can safely continue traversing the lists once the callback
    returns.
 
-   Returns 1 if the loop was aborted due to the callback's return code.
+   Returns TRUE if the loop was aborted due to the callback's return code.
 
    Return 0 from func() to continue the loop, return 1 to abort it.
  */
-bool Curl_conncache_foreach(struct Curl_easy *data,
-                            struct conncache *connc,
-                            void *param,
-                            int (*func)(struct Curl_easy *data,
-                                        struct connectdata *conn, void *param))
+static bool cpool_foreach(struct Curl_easy *data,
+                          struct cpool *cpool,
+                          void *param,
+                          int (*func)(struct Curl_easy *data,
+                                      struct connectdata *conn, void *param))
 {
   struct Curl_hash_iterator iter;
   struct Curl_hash_element *he;
 
-  if(!connc)
+  if(!cpool)
     return FALSE;
 
-  CONNCACHE_LOCK(data);
-  Curl_hash_start_iterate(&connc->hash, &iter);
+  Curl_hash_start_iterate(&cpool->dest2bundle, &iter);
 
   he = Curl_hash_next_element(&iter);
   while(he) {
     struct Curl_llist_node *curr;
-    struct connectbundle *bundle = he->ptr;
+    struct cpool_bundle *bundle = he->ptr;
     he = Curl_hash_next_element(&iter);
 
-    curr = Curl_llist_head(&bundle->conn_list);
+    curr = Curl_llist_head(&bundle->conns);
     while(curr) {
       /* Yes, we need to update curr before calling func(), because func()
          might decide to remove the connection */
@@ -371,104 +455,85 @@ bool Curl_conncache_foreach(struct Curl_easy *data,
       curr = Curl_node_next(curr);
 
       if(1 == func(data, conn, param)) {
-        CONNCACHE_UNLOCK(data);
         return TRUE;
       }
     }
   }
-  CONNCACHE_UNLOCK(data);
   return FALSE;
 }
 
-/* Return the first connection found in the cache. Used when closing all
-   connections.
-
-   NOTE: no locking is done here as this is presumably only done when cleaning
-   up a cache!
-*/
-static struct connectdata *
-connc_find_first_connection(struct conncache *connc)
+/* Return a live connection in the pool or NULL. */
+static struct connectdata *cpool_get_live_conn(struct cpool *cpool)
 {
   struct Curl_hash_iterator iter;
   struct Curl_hash_element *he;
-  struct connectbundle *bundle;
+  struct cpool_bundle *bundle;
+  struct Curl_llist_node *conn_node;
 
-  Curl_hash_start_iterate(&connc->hash, &iter);
-
-  he = Curl_hash_next_element(&iter);
-  while(he) {
-    struct Curl_llist_node *curr;
+  Curl_hash_start_iterate(&cpool->dest2bundle, &iter);
+  for(he = Curl_hash_next_element(&iter); he;
+      he = Curl_hash_next_element(&iter)) {
     bundle = he->ptr;
-
-    curr = Curl_llist_head(&bundle->conn_list);
-    if(curr) {
-      return Curl_node_elem(curr);
-    }
-
-    he = Curl_hash_next_element(&iter);
+    conn_node = Curl_llist_head(&bundle->conns);
+    if(conn_node)
+      return Curl_node_elem(conn_node);
   }
-
   return NULL;
 }
 
 /*
- * Give ownership of a connection back to the connection cache. Might
- * disconnect the oldest existing in there to make space.
+ * A connection (already in the pool) has become idle. Do any
+ * cleanups in regard to the pool's limits.
  *
- * Return TRUE if stored, FALSE if closed.
+ * Return TRUE if idle connection kept in pool, FALSE if closed.
  */
-bool Curl_conncache_return_conn(struct Curl_easy *data,
-                                struct connectdata *conn)
+bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
+                              struct connectdata *conn)
 {
   unsigned int maxconnects = !data->multi->maxconnects ?
     data->multi->num_easy * 4: data->multi->maxconnects;
-  struct connectdata *conn_candidate = NULL;
+  struct connectdata *oldest_idle = NULL;
+  struct cpool *cpool = cpool_get_instance(data);
+  bool kept = TRUE;
 
   conn->lastused = Curl_now(); /* it was used up until now */
-  if(maxconnects && Curl_conncache_size(data) > maxconnects) {
-    infof(data, "Connection cache is full, closing the oldest one");
+  if(cpool && maxconnects) {
+    /* may be called form a callback already under lock */
+    bool do_lock = !CPOOL_IS_LOCKED(cpool);
+    if(do_lock)
+      CPOOL_LOCK(cpool);
+    if(cpool->num_conn > maxconnects) {
+      infof(data, "Connection pool is full, closing the oldest one");
 
-    conn_candidate = Curl_conncache_extract_oldest(data);
-    if(conn_candidate) {
-      /* Use the closure handle for this disconnect so that anything that
-         happens during the disconnect is not stored and associated with the
-         'data' handle which already just finished a transfer and it is
-         important that details from this (unrelated) disconnect does not
-         taint meta-data in the data handle. */
-      struct conncache *connc = data->state.conn_cache;
-      connc_disconnect(NULL, conn_candidate, connc, TRUE);
+      oldest_idle = cpool_get_oldest_idle(cpool);
+      kept = (oldest_idle != conn);
+      if(oldest_idle) {
+        Curl_cpool_disconnect(cpool->idata, oldest_idle, FALSE);
+      }
     }
+    if(do_lock)
+      CPOOL_UNLOCK(cpool);
   }
 
-  return (conn_candidate == conn) ? FALSE : TRUE;
-
+  return kept;
 }
 
 /*
  * This function finds the connection in the connection bundle that has been
  * unused for the longest time.
- *
- * Does not lock the connection cache!
- *
- * Returns the pointer to the oldest idle connection, or NULL if none was
- * found.
  */
-struct connectdata *
-Curl_conncache_extract_bundle(struct Curl_easy *data,
-                              struct connectbundle *bundle)
+static struct connectdata *
+cpool_bundle_get_oldest_idle(struct cpool_bundle *bundle)
 {
   struct Curl_llist_node *curr;
   timediff_t highscore = -1;
   timediff_t score;
   struct curltime now;
-  struct connectdata *conn_candidate = NULL;
+  struct connectdata *oldest_idle = NULL;
   struct connectdata *conn;
 
-  (void)data;
-
   now = Curl_now();
-
-  curr = Curl_llist_head(&bundle->conn_list);
+  curr = Curl_llist_head(&bundle->conns);
   while(curr) {
     conn = Curl_node_elem(curr);
 
@@ -478,130 +543,126 @@ Curl_conncache_extract_bundle(struct Curl_easy *data,
 
       if(score > highscore) {
         highscore = score;
-        conn_candidate = conn;
+        oldest_idle = conn;
       }
     }
     curr = Curl_node_next(curr);
   }
-  if(conn_candidate) {
-    /* remove it to prevent another thread from nicking it */
-    bundle_remove_conn(bundle, conn_candidate);
-    data->state.conn_cache->num_conn--;
-    DEBUGF(infof(data, "The cache now contains %zu members",
-                 data->state.conn_cache->num_conn));
-  }
-
-  return conn_candidate;
+  return oldest_idle;
 }
 
-/*
- * This function finds the connection in the connection cache that has been
- * unused for the longest time and extracts that from the bundle.
- *
- * Returns the pointer to the connection, or NULL if none was found.
- */
-struct connectdata *
-Curl_conncache_extract_oldest(struct Curl_easy *data)
+static struct connectdata *cpool_get_oldest_idle(struct cpool *cpool)
 {
-  struct conncache *connc = data->state.conn_cache;
   struct Curl_hash_iterator iter;
   struct Curl_llist_node *curr;
   struct Curl_hash_element *he;
+  struct connectdata *oldest_idle = NULL;
+  struct cpool_bundle *bundle;
+  struct curltime now;
   timediff_t highscore =- 1;
   timediff_t score;
-  struct curltime now;
-  struct connectdata *conn_candidate = NULL;
-  struct connectbundle *bundle;
-  struct connectbundle *bundle_candidate = NULL;
 
   now = Curl_now();
+  Curl_hash_start_iterate(&cpool->dest2bundle, &iter);
 
-  CONNCACHE_LOCK(data);
-  Curl_hash_start_iterate(&connc->hash, &iter);
-
-  he = Curl_hash_next_element(&iter);
-  while(he) {
+  for(he = Curl_hash_next_element(&iter); he;
+      he = Curl_hash_next_element(&iter)) {
     struct connectdata *conn;
-
     bundle = he->ptr;
 
-    curr = Curl_llist_head(&bundle->conn_list);
-    while(curr) {
+    for(curr = Curl_llist_head(&bundle->conns); curr;
+        curr = Curl_node_next(curr)) {
       conn = Curl_node_elem(curr);
-
-      if(!CONN_INUSE(conn) && !conn->bits.close &&
-         !conn->connect_only) {
-        /* Set higher score for the age passed since the connection was used */
-        score = Curl_timediff(now, conn->lastused);
-
-        if(score > highscore) {
-          highscore = score;
-          conn_candidate = conn;
-          bundle_candidate = bundle;
-        }
+      if(CONN_INUSE(conn) || conn->bits.close || conn->connect_only)
+        continue;
+      /* Set higher score for the age passed since the connection was used */
+      score = Curl_timediff(now, conn->lastused);
+      if(score > highscore) {
+        highscore = score;
+        oldest_idle = conn;
       }
-      curr = Curl_node_next(curr);
     }
-
-    he = Curl_hash_next_element(&iter);
   }
-  if(conn_candidate) {
-    /* remove it to prevent another thread from nicking it */
-    bundle_remove_conn(bundle_candidate, conn_candidate);
-    connc->num_conn--;
-    DEBUGF(infof(data, "The cache now contains %zu members",
-                 connc->num_conn));
-  }
-  CONNCACHE_UNLOCK(data);
-
-  return conn_candidate;
+  return oldest_idle;
 }
 
-static void connc_shutdown_discard_all(struct conncache *connc)
+bool Curl_cpool_find(struct Curl_easy *data,
+                     const char *destination, size_t dest_len,
+                     Curl_cpool_conn_match_cb *conn_cb,
+                     Curl_cpool_done_match_cb *done_cb,
+                     void *userdata)
 {
-  struct Curl_llist_node *e = Curl_llist_head(&connc->shutdowns.conn_list);
+  struct cpool *cpool = cpool_get_instance(data);
+  struct cpool_bundle *bundle;
+  bool result = FALSE;
+
+  DEBUGASSERT(cpool);
+  DEBUGASSERT(conn_cb);
+  if(!cpool)
+    return FALSE;
+
+  CPOOL_LOCK(cpool);
+  bundle = Curl_hash_pick(&cpool->dest2bundle, (void *)destination, dest_len);
+  if(bundle) {
+    struct Curl_llist_node *curr = Curl_llist_head(&bundle->conns);
+    while(curr) {
+      struct connectdata *conn = Curl_node_elem(curr);
+      /* Get next node now. callback might discard current */
+      curr = Curl_node_next(curr);
+
+      if(conn_cb(conn, userdata)) {
+        result = TRUE;
+        break;
+      }
+    }
+  }
+
+  if(done_cb) {
+    result = done_cb(result, userdata);
+  }
+  CPOOL_UNLOCK(cpool);
+  return result;
+}
+
+static void cpool_shutdown_discard_all(struct cpool *cpool)
+{
+  struct Curl_llist_node *e = Curl_llist_head(&cpool->shutdowns);
   struct connectdata *conn;
 
   if(!e)
     return;
 
-  DEBUGF(infof(connc->closure_handle, "conncache_shutdown_discard_all"));
-  DEBUGASSERT(!connc->shutdowns.iter_locked);
-  connc->shutdowns.iter_locked = TRUE;
+  DEBUGF(infof(cpool->idata, "cpool_shutdown_discard_all"));
   while(e) {
     conn = Curl_node_elem(e);
     Curl_node_remove(e);
-    DEBUGF(infof(connc->closure_handle, "discard connection #%"
+    DEBUGF(infof(cpool->idata, "discard connection #%"
                  CURL_FORMAT_CURL_OFF_T, conn->connection_id));
-    connc_disconnect(NULL, conn, connc, FALSE);
-    e = Curl_llist_head(&connc->shutdowns.conn_list);
+    cpool_close_and_destroy(cpool, conn, NULL, FALSE);
+    e = Curl_llist_head(&cpool->shutdowns);
   }
-  connc->shutdowns.iter_locked = FALSE;
 }
 
-static void connc_close_all(struct conncache *connc)
+static void cpool_close_and_destroy_all(struct cpool *cpool)
 {
-  struct Curl_easy *data = connc->closure_handle;
   struct connectdata *conn;
   int timeout_ms = 0;
   SIGPIPE_VARIABLE(pipe_st);
 
-  if(!data)
-    return;
-
+  DEBUGASSERT(cpool);
   /* Move all connections to the shutdown list */
   sigpipe_init(&pipe_st);
-  conn = connc_find_first_connection(connc);
+  CPOOL_LOCK(cpool);
+  conn = cpool_get_live_conn(cpool);
   while(conn) {
-    connc_remove_conn(connc, conn);
-    sigpipe_apply(data, &pipe_st);
-    /* This will remove the connection from the cache */
+    cpool_remove_conn(cpool, conn);
+    sigpipe_apply(cpool->idata, &pipe_st);
     connclose(conn, "kill all");
-    Curl_conncache_remove_conn(connc->closure_handle, conn, TRUE);
-    connc_discard_conn(connc, connc->closure_handle, conn, FALSE);
+    cpool_discard_conn(cpool, cpool->idata, conn, FALSE);
 
-    conn = connc_find_first_connection(connc);
+    conn = cpool_get_live_conn(cpool);
   }
+  CPOOL_UNLOCK(cpool);
 
     /* Just for testing, run graceful shutdown */
 #ifdef DEBUGBUILD
@@ -614,65 +675,44 @@ static void connc_close_all(struct conncache *connc)
     }
   }
 #endif
-  connc_shutdown_all(connc, timeout_ms);
+  sigpipe_apply(cpool->idata, &pipe_st);
+  cpool_shutdown_all(cpool, cpool->idata, timeout_ms);
 
   /* discard all connections in the shutdown list */
-  connc_shutdown_discard_all(connc);
+  cpool_shutdown_discard_all(cpool);
 
-  sigpipe_apply(data, &pipe_st);
-  Curl_hostcache_clean(data, data->dns.hostcache);
-  connc->closure_handle->multi = NULL;
-  Curl_close(&connc->closure_handle);
+  Curl_hostcache_clean(cpool->idata, cpool->idata->dns.hostcache);
   sigpipe_restore(&pipe_st);
 }
 
-void Curl_conncache_close_all_connections(struct conncache *connc)
-{
-  connc_close_all(connc);
-}
 
-static void connc_shutdown_discard_oldest(struct conncache *connc)
+static void cpool_shutdown_destroy_oldest(struct cpool *cpool)
 {
   struct Curl_llist_node *e;
   struct connectdata *conn;
 
-  DEBUGASSERT(!connc->shutdowns.iter_locked);
-  if(connc->shutdowns.iter_locked)
-    return;
-
-  e = Curl_llist_head(&connc->shutdowns.conn_list);
+  e = Curl_llist_head(&cpool->shutdowns);
   if(e) {
     SIGPIPE_VARIABLE(pipe_st);
     conn = Curl_node_elem(e);
     Curl_node_remove(e);
     sigpipe_init(&pipe_st);
-    sigpipe_apply(connc->closure_handle, &pipe_st);
-    connc_disconnect(NULL, conn, connc, FALSE);
+    sigpipe_apply(cpool->idata, &pipe_st);
+    cpool_close_and_destroy(cpool, conn, NULL, FALSE);
     sigpipe_restore(&pipe_st);
   }
 }
 
-static void connc_discard_conn(struct conncache *connc,
-                               struct Curl_easy *last_data,
+static void cpool_discard_conn(struct cpool *cpool,
+                               struct Curl_easy *data,
                                struct connectdata *conn,
                                bool aborted)
 {
-  /* `last_data`, if present, is the transfer that last worked with
-   * the connection. It is present when the connection is being shut down
-   * via `Curl_conncache_discard_conn()`, e.g. when the transfer failed
-   * or does not allow connection reuse.
-   * Using the original handle is necessary for shutting down the protocol
-   * handler belonging to the connection. Protocols like 'file:' rely on
-   * being invoked to clean up their allocations in the easy handle.
-   * When a connection comes from the cache, the transfer is no longer
-   * there and we use the cache is own closure handle.
-   */
-  struct Curl_easy *data = last_data? last_data : connc->closure_handle;
   bool done = FALSE;
 
   DEBUGASSERT(data);
-  DEBUGASSERT(connc);
-  DEBUGASSERT(!conn->bundle);
+  DEBUGASSERT(cpool);
+  DEBUGASSERT(!conn->bits.in_cpool);
 
   /*
    * If this connection is not marked to force-close, leave it open if there
@@ -701,22 +741,14 @@ static void connc_discard_conn(struct conncache *connc,
   if(!done) {
     /* Attempt to shutdown the connection right away. */
     Curl_attach_connection(data, conn);
-    connc_run_conn_shutdown(data, conn, &done);
+    cpool_run_conn_shutdown(data, conn, &done);
     DEBUGF(infof(data, "[CCACHE] shutdown #%" CURL_FORMAT_CURL_OFF_T
                        ", done=%d",conn->connection_id, done));
     Curl_detach_connection(data);
   }
 
   if(done) {
-    connc_disconnect(data, conn, connc, FALSE);
-    return;
-  }
-
-  DEBUGASSERT(!connc->shutdowns.iter_locked);
-  if(connc->shutdowns.iter_locked) {
-    DEBUGF(infof(data, "[CCACHE] discarding #%" CURL_FORMAT_CURL_OFF_T
-                       ", list locked", conn->connection_id));
-    connc_disconnect(data, conn, connc, FALSE);
+    cpool_close_and_destroy(cpool, conn, data, FALSE);
     return;
   }
 
@@ -724,58 +756,85 @@ static void connc_discard_conn(struct conncache *connc,
    * during multi processing. */
   if(data->multi && data->multi->max_shutdown_connections > 0 &&
      (data->multi->max_shutdown_connections >=
-      (long)Curl_llist_count(&connc->shutdowns.conn_list))) {
+      (long)Curl_llist_count(&cpool->shutdowns))) {
     DEBUGF(infof(data, "[CCACHE] discarding oldest shutdown connection "
                        "due to limit of %ld",
                        data->multi->max_shutdown_connections));
-    connc_shutdown_discard_oldest(connc);
+    cpool_shutdown_destroy_oldest(cpool);
   }
 
   if(data->multi && data->multi->socket_cb) {
-    DEBUGASSERT(connc == &data->multi->conn_cache);
+    DEBUGASSERT(cpool == &data->multi->cpool);
     /* Start with an empty shutdown pollset, so out internal closure handle
      * is added to the sockets. */
     memset(&conn->shutdown_poll, 0, sizeof(conn->shutdown_poll));
-    if(connc_update_shutdown_ev(data->multi, connc->closure_handle, conn)) {
+    if(cpool_update_shutdown_ev(data->multi, cpool->idata, conn)) {
       DEBUGF(infof(data, "[CCACHE] update events for shutdown failed, "
                          "discarding #%" CURL_FORMAT_CURL_OFF_T,
                          conn->connection_id));
-      connc_disconnect(data, conn, connc, FALSE);
+      cpool_close_and_destroy(cpool, conn, data, FALSE);
       return;
     }
   }
 
-  Curl_llist_append(&connc->shutdowns.conn_list, conn, &conn->bundle_node);
+  Curl_llist_append(&cpool->shutdowns, conn, &conn->cpool_node);
   DEBUGF(infof(data, "[CCACHE] added #%" CURL_FORMAT_CURL_OFF_T
                      " to shutdown list of length %zu", conn->connection_id,
-                     Curl_llist_count(&connc->shutdowns.conn_list)));
+                     Curl_llist_count(&cpool->shutdowns)));
 }
 
-void Curl_conncache_disconnect(struct Curl_easy *data,
-                               struct connectdata *conn,
-                               bool aborted)
+void Curl_cpool_disconnect(struct Curl_easy *data,
+                           struct connectdata *conn,
+                           bool aborted)
 {
-  DEBUGASSERT(data);
-  /* Connection must no longer be in and connection cache */
-  DEBUGASSERT(!conn->bundle);
+  struct cpool *cpool = cpool_get_instance(data);
+  bool do_lock;
+
+  DEBUGASSERT(cpool);
+  DEBUGASSERT(data && !data->conn);
+  if(!cpool)
+    return;
+
+  /* If this connection is not marked to force-close, leave it open if there
+   * are other users of it */
+  if(CONN_INUSE(conn) && !aborted) {
+    DEBUGASSERT(0); /* does this ever happen? */
+    DEBUGF(infof(data, "Curl_disconnect when inuse: %zu", CONN_INUSE(conn)));
+    return;
+  }
+
+  /* This method may be called while we are under lock, e.g. from a
+   * user callback in find. */
+  do_lock = !CPOOL_IS_LOCKED(cpool);
+  if(do_lock)
+    CPOOL_LOCK(cpool);
+
+  if(conn->bits.in_cpool) {
+    cpool_remove_conn(cpool, conn);
+    DEBUGASSERT(!conn->bits.in_cpool);
+  }
+
+  /* Run the callback to let it clean up anything it wants to. */
+  aborted = cpool->disconnect_cb(data, conn, aborted);
 
   if(data->multi) {
-    /* Add it to the multi's conncache for shutdown handling */
+    /* Add it to the multi's cpool for shutdown handling */
     infof(data, "%s connection #%" CURL_FORMAT_CURL_OFF_T,
           aborted? "closing" : "shutting down", conn->connection_id);
-    connc_discard_conn(&data->multi->conn_cache, data, conn, aborted);
+    cpool_discard_conn(&data->multi->cpool, data, conn, aborted);
   }
   else {
     /* No multi available. Make a best-effort shutdown + close */
     infof(data, "closing connection #%" CURL_FORMAT_CURL_OFF_T,
           conn->connection_id);
-    DEBUGASSERT(!conn->bundle);
-    connc_run_conn_shutdown_handler(data, conn);
-    connc_disconnect(data, conn, NULL, !aborted);
+    cpool_close_and_destroy(NULL, conn, data, !aborted);
   }
+
+  if(do_lock)
+    CPOOL_UNLOCK(cpool);
 }
 
-static void connc_run_conn_shutdown_handler(struct Curl_easy *data,
+static void cpool_run_conn_shutdown_handler(struct Curl_easy *data,
                                             struct connectdata *conn)
 {
   if(!conn->bits.shutdown_handler) {
@@ -793,6 +852,7 @@ static void connc_run_conn_shutdown_handler(struct Curl_easy *data,
       DEBUGF(infof(data, "connection #%" CURL_FORMAT_CURL_OFF_T
                    ", shutdown protocol handler (aborted=%d)",
                    conn->connection_id, conn->bits.aborted));
+
       conn->handler->disconnect(data, conn, conn->bits.aborted);
     }
 
@@ -803,7 +863,7 @@ static void connc_run_conn_shutdown_handler(struct Curl_easy *data,
   }
 }
 
-static void connc_run_conn_shutdown(struct Curl_easy *data,
+static void cpool_run_conn_shutdown(struct Curl_easy *data,
                                     struct connectdata *conn,
                                     bool *done)
 {
@@ -813,7 +873,7 @@ static void connc_run_conn_shutdown(struct Curl_easy *data,
   /* We expect to be attached when called */
   DEBUGASSERT(data->conn == conn);
 
-  connc_run_conn_shutdown_handler(data, conn);
+  cpool_run_conn_shutdown_handler(data, conn);
 
   if(conn->bits.shutdown_filters) {
     *done = TRUE;
@@ -840,25 +900,23 @@ static void connc_run_conn_shutdown(struct Curl_easy *data,
     conn->bits.shutdown_filters = TRUE;
 }
 
-CURLcode Curl_conncache_add_pollfds(struct conncache *connc,
-                                    struct curl_pollfds *cpfds)
+static CURLcode cpool_add_pollfds(struct cpool *cpool,
+                                  struct curl_pollfds *cpfds)
 {
   CURLcode result = CURLE_OK;
 
-  DEBUGASSERT(!connc->shutdowns.iter_locked);
-  connc->shutdowns.iter_locked = TRUE;
-  if(Curl_llist_head(&connc->shutdowns.conn_list)) {
+  if(Curl_llist_head(&cpool->shutdowns)) {
     struct Curl_llist_node *e;
     struct easy_pollset ps;
     struct connectdata *conn;
 
-    for(e = Curl_llist_head(&connc->shutdowns.conn_list); e;
+    for(e = Curl_llist_head(&cpool->shutdowns); e;
         e = Curl_node_next(e)) {
       conn = Curl_node_elem(e);
       memset(&ps, 0, sizeof(ps));
-      Curl_attach_connection(connc->closure_handle, conn);
-      Curl_conn_adjust_pollset(connc->closure_handle, &ps);
-      Curl_detach_connection(connc->closure_handle);
+      Curl_attach_connection(cpool->idata, conn);
+      Curl_conn_adjust_pollset(cpool->idata, &ps);
+      Curl_detach_connection(cpool->idata);
 
       result = Curl_pollfds_add_ps(cpfds, &ps);
       if(result) {
@@ -868,29 +926,37 @@ CURLcode Curl_conncache_add_pollfds(struct conncache *connc,
     }
   }
 out:
-  connc->shutdowns.iter_locked = FALSE;
   return result;
 }
 
-CURLcode Curl_conncache_add_waitfds(struct conncache *connc,
-                                    struct curl_waitfds *cwfds)
+CURLcode Curl_cpool_add_pollfds(struct cpool *cpool,
+                                struct curl_pollfds *cpfds)
+{
+  CURLcode result;
+  CPOOL_LOCK(cpool);
+  result = cpool_add_pollfds(cpool, cpfds);
+  CPOOL_UNLOCK(cpool);
+  return result;
+}
+
+CURLcode Curl_cpool_add_waitfds(struct cpool *cpool,
+                                struct curl_waitfds *cwfds)
 {
   CURLcode result = CURLE_OK;
 
-  DEBUGASSERT(!connc->shutdowns.iter_locked);
-  connc->shutdowns.iter_locked = TRUE;
-  if(Curl_llist_head(&connc->shutdowns.conn_list)) {
+  CPOOL_LOCK(cpool);
+  if(Curl_llist_head(&cpool->shutdowns)) {
     struct Curl_llist_node *e;
     struct easy_pollset ps;
     struct connectdata *conn;
 
-    for(e = Curl_llist_head(&connc->shutdowns.conn_list); e;
+    for(e = Curl_llist_head(&cpool->shutdowns); e;
         e = Curl_node_next(e)) {
       conn = Curl_node_elem(e);
       memset(&ps, 0, sizeof(ps));
-      Curl_attach_connection(connc->closure_handle, conn);
-      Curl_conn_adjust_pollset(connc->closure_handle, &ps);
-      Curl_detach_connection(connc->closure_handle);
+      Curl_attach_connection(cpool->idata, conn);
+      Curl_conn_adjust_pollset(cpool->idata, &ps);
+      Curl_detach_connection(cpool->idata);
 
       result = Curl_waitfds_add_ps(cwfds, &ps);
       if(result)
@@ -898,14 +964,14 @@ CURLcode Curl_conncache_add_waitfds(struct conncache *connc,
     }
   }
 out:
-  connc->shutdowns.iter_locked = FALSE;
+  CPOOL_UNLOCK(cpool);
   return result;
 }
 
-static void connc_perform(struct conncache *connc)
+static void cpool_perform(struct cpool *cpool)
 {
-  struct Curl_easy *data = connc->closure_handle;
-  struct Curl_llist_node *e = Curl_llist_head(&connc->shutdowns.conn_list);
+  struct Curl_easy *data = cpool->idata;
+  struct Curl_llist_node *e = Curl_llist_head(&cpool->shutdowns);
   struct Curl_llist_node *enext;
   struct connectdata *conn;
   struct curltime *nowp = NULL;
@@ -917,21 +983,19 @@ static void connc_perform(struct conncache *connc)
     return;
 
   DEBUGASSERT(data);
-  DEBUGASSERT(!connc->shutdowns.iter_locked);
   DEBUGF(infof(data, "[CCACHE] perform, %zu connections being shutdown",
-               Curl_llist_count(&connc->shutdowns.conn_list)));
-  connc->shutdowns.iter_locked = TRUE;
+               Curl_llist_count(&cpool->shutdowns)));
   while(e) {
     enext = Curl_node_next(e);
     conn = Curl_node_elem(e);
     Curl_attach_connection(data, conn);
-    connc_run_conn_shutdown(data, conn, &done);
+    cpool_run_conn_shutdown(data, conn, &done);
     DEBUGF(infof(data, "[CCACHE] shutdown #%" CURL_FORMAT_CURL_OFF_T
                  ", done=%d", conn->connection_id, done));
     Curl_detach_connection(data);
     if(done) {
       Curl_node_remove(e);
-      connc_disconnect(NULL, conn, connc, FALSE);
+      cpool_close_and_destroy(cpool, conn, NULL, FALSE);
     }
     else {
       /* Not done, when does this connection time out? */
@@ -945,60 +1009,52 @@ static void connc_perform(struct conncache *connc)
     }
     e = enext;
   }
-  connc->shutdowns.iter_locked = FALSE;
 
   if(next_from_now_ms)
     Curl_expire(data, next_from_now_ms, EXPIRE_RUN_NOW);
 }
 
-void Curl_conncache_multi_perform(struct Curl_multi *multi)
+void Curl_cpool_multi_perform(struct Curl_multi *multi)
 {
-  connc_perform(&multi->conn_cache);
+  CPOOL_LOCK(&multi->cpool);
+  cpool_perform(&multi->cpool);
+  CPOOL_UNLOCK(&multi->cpool);
 }
 
 
 /*
- * Disconnects the given connection. Note the connection may not be the
- * primary connection, like when freeing room in the connection cache or
- * killing of a dead old connection.
- *
- * A connection needs an easy handle when closing down. We support this passed
- * in separately since the connection to get closed here is often already
- * disassociated from an easy handle.
- *
- * This function MUST NOT reset state in the Curl_easy struct if that
- * is not strictly bound to the life-time of *this* particular connection.
- *
+ * Close and destroy the connection. Run the shutdown sequence once,
+ * of so requested.
  */
-static void connc_disconnect(struct Curl_easy *data,
-                             struct connectdata *conn,
-                             struct conncache *connc,
-                             bool do_shutdown)
+static void cpool_close_and_destroy(struct cpool *cpool,
+                                    struct connectdata *conn,
+                                    struct Curl_easy *data,
+                                    bool do_shutdown)
 {
   bool done;
 
   /* there must be a connection to close */
   DEBUGASSERT(conn);
-  /* it must be removed from the connection cache */
-  DEBUGASSERT(!conn->bundle);
+  /* it must be removed from the connection pool */
+  DEBUGASSERT(!conn->bits.in_cpool);
   /* there must be an associated transfer */
-  DEBUGASSERT(data || connc);
+  DEBUGASSERT(data || cpool);
   if(!data)
-    data = connc->closure_handle;
+    data = cpool->idata;
 
   /* the transfer must be detached from the connection */
   DEBUGASSERT(data && !data->conn);
 
   Curl_attach_connection(data, conn);
 
-  connc_run_conn_shutdown_handler(data, conn);
+  cpool_run_conn_shutdown_handler(data, conn);
   if(do_shutdown) {
     /* Make a last attempt to shutdown handlers and filters, if
      * not done so already. */
-    connc_run_conn_shutdown(data, conn, &done);
+    cpool_run_conn_shutdown(data, conn, &done);
   }
 
-  if(connc)
+  if(cpool)
     DEBUGF(infof(data, "[CCACHE] closing #%" CURL_FORMAT_CURL_OFF_T,
                  conn->connection_id));
   else
@@ -1012,7 +1068,7 @@ static void connc_disconnect(struct Curl_easy *data,
 }
 
 
-static CURLMcode connc_update_shutdown_ev(struct Curl_multi *multi,
+static CURLMcode cpool_update_shutdown_ev(struct Curl_multi *multi,
                                           struct Curl_easy *data,
                                           struct connectdata *conn)
 {
@@ -1035,49 +1091,41 @@ static CURLMcode connc_update_shutdown_ev(struct Curl_multi *multi,
   return mresult;
 }
 
-void Curl_conncache_multi_socket(struct Curl_multi *multi,
-                                 curl_socket_t s, int ev_bitmask)
+void Curl_cpool_multi_socket(struct Curl_multi *multi,
+                             curl_socket_t s, int ev_bitmask)
 {
-  struct conncache *connc = &multi->conn_cache;
-  struct Curl_easy *data = connc->closure_handle;
-  struct Curl_llist_node *e = Curl_llist_head(&connc->shutdowns.conn_list);
+  struct cpool *cpool = &multi->cpool;
+  struct Curl_easy *data = cpool->idata;
+  struct Curl_llist_node *e;
   struct connectdata *conn;
   bool done;
 
   (void)ev_bitmask;
   DEBUGASSERT(multi->socket_cb);
-  if(!e)
-    return;
-
-  connc->shutdowns.iter_locked = TRUE;
+  CPOOL_LOCK(cpool);
+  e = Curl_llist_head(&cpool->shutdowns);
   while(e) {
     conn = Curl_node_elem(e);
     if(s == conn->sock[FIRSTSOCKET] || s == conn->sock[SECONDARYSOCKET]) {
       Curl_attach_connection(data, conn);
-      connc_run_conn_shutdown(data, conn, &done);
+      cpool_run_conn_shutdown(data, conn, &done);
       DEBUGF(infof(data, "[CCACHE] shutdown #%" CURL_FORMAT_CURL_OFF_T
                    ", done=%d", conn->connection_id, done));
       Curl_detach_connection(data);
-      if(done || connc_update_shutdown_ev(multi, data, conn)) {
+      if(done || cpool_update_shutdown_ev(multi, data, conn)) {
         Curl_node_remove(e);
-        connc_disconnect(NULL, conn, connc, FALSE);
+        cpool_close_and_destroy(cpool, conn, NULL, FALSE);
       }
       break;
     }
     e = Curl_node_next(e);
   }
-  connc->shutdowns.iter_locked = FALSE;
+  CPOOL_UNLOCK(cpool);
 }
-
-void Curl_conncache_multi_close_all(struct Curl_multi *multi)
-{
-  connc_close_all(&multi->conn_cache);
-}
-
 
 #define NUM_POLLS_ON_STACK 10
 
-static CURLcode connc_shutdown_wait(struct conncache *connc, int timeout_ms)
+static CURLcode cpool_shutdown_wait(struct cpool *cpool, int timeout_ms)
 {
   struct pollfd a_few_on_stack[NUM_POLLS_ON_STACK];
   struct curl_pollfds cpfds;
@@ -1085,7 +1133,7 @@ static CURLcode connc_shutdown_wait(struct conncache *connc, int timeout_ms)
 
   Curl_pollfds_init(&cpfds, a_few_on_stack, NUM_POLLS_ON_STACK);
 
-  result = Curl_conncache_add_pollfds(connc, &cpfds);
+  result = cpool_add_pollfds(cpool, &cpfds);
   if(result)
     goto out;
 
@@ -1096,9 +1144,9 @@ out:
   return result;
 }
 
-static void connc_shutdown_all(struct conncache *connc, int timeout_ms)
+static void cpool_shutdown_all(struct cpool *cpool,
+                               struct Curl_easy *data, int timeout_ms)
 {
-  struct Curl_easy *data = connc->closure_handle;
   struct connectdata *conn;
   struct curltime started = Curl_now();
 
@@ -1106,74 +1154,221 @@ static void connc_shutdown_all(struct conncache *connc, int timeout_ms)
     return;
   (void)data;
 
-  DEBUGF(infof(data, "conncache shutdown all"));
+  DEBUGF(infof(data, "cpool shutdown all"));
 
   /* Move all connections into the shutdown queue */
-  conn = connc_find_first_connection(connc);
-  while(conn) {
-    /* This will remove the connection from the cache */
-    DEBUGF(infof(data, "moving connection %" CURL_FORMAT_CURL_OFF_T
+  for(conn = cpool_get_live_conn(cpool); conn;
+      conn = cpool_get_live_conn(cpool)) {
+    /* Move conn from live set to shutdown or destroy right away */
+    DEBUGF(infof(data, "moving connection #%" CURL_FORMAT_CURL_OFF_T
                  " to shutdown queue", conn->connection_id));
-    connc_remove_conn(connc, conn);
-    connc_discard_conn(connc, NULL, conn, FALSE);
-    conn = connc_find_first_connection(connc);
+    cpool_remove_conn(cpool, conn);
+    cpool_discard_conn(cpool, data, conn, FALSE);
   }
 
-  DEBUGASSERT(!connc->shutdowns.iter_locked);
-  while(Curl_llist_head(&connc->shutdowns.conn_list)) {
+  while(Curl_llist_head(&cpool->shutdowns)) {
     timediff_t timespent;
     int remain_ms;
 
-    connc_perform(connc);
+    cpool_perform(cpool);
 
-    if(!Curl_llist_head(&connc->shutdowns.conn_list)) {
-      DEBUGF(infof(data, "conncache shutdown ok"));
+    if(!Curl_llist_head(&cpool->shutdowns)) {
+      DEBUGF(infof(data, "cpool shutdown ok"));
       break;
     }
 
     /* wait for activity, timeout or "nothing" */
     timespent = Curl_timediff(Curl_now(), started);
     if(timespent >= (timediff_t)timeout_ms) {
-      DEBUGF(infof(data, "conncache shutdown %s",
+      DEBUGF(infof(data, "cpool shutdown %s",
                    (timeout_ms > 0)? "timeout" : "best effort done"));
       break;
     }
 
     remain_ms = timeout_ms - (int)timespent;
-    if(connc_shutdown_wait(connc, remain_ms)) {
-      DEBUGF(infof(data, "conncache shutdown all, abort"));
+    if(cpool_shutdown_wait(cpool, remain_ms)) {
+      DEBUGF(infof(data, "cpool shutdown all, abort"));
       break;
     }
   }
 
-  /* Due to errors/timeout, we might come here without being full ydone. */
-  connc_shutdown_discard_all(connc);
+  /* Due to errors/timeout, we might come here without being done. */
+  cpool_shutdown_discard_all(cpool);
+}
+
+struct cpool_reaper_ctx {
+  struct curltime now;
+};
+
+static int cpool_reap_dead_cb(struct Curl_easy *data,
+                              struct connectdata *conn, void *param)
+{
+  struct cpool_reaper_ctx *rctx = param;
+  if(Curl_conn_seems_dead(conn, data, &rctx->now)) {
+    /* stop the iteration here, pass back the connection that was pruned */
+    Curl_cpool_disconnect(data, conn, FALSE);
+    return 1;
+  }
+  return 0; /* continue iteration */
+}
+
+/*
+ * This function scans the data's connection pool for half-open/dead
+ * connections, closes and removes them.
+ * The cleanup is done at most once per second.
+ *
+ * When called, this transfer has no connection attached.
+ */
+void Curl_cpool_prune_dead(struct Curl_easy *data)
+{
+  struct cpool *cpool = cpool_get_instance(data);
+  struct cpool_reaper_ctx rctx;
+  timediff_t elapsed;
+
+  if(!cpool)
+    return;
+
+  rctx.now = Curl_now();
+  CPOOL_LOCK(cpool);
+  elapsed = Curl_timediff(rctx.now, cpool->last_cleanup);
+
+  if(elapsed >= 1000L) {
+    while(cpool_foreach(data, cpool, &rctx, cpool_reap_dead_cb))
+      ;
+    cpool->last_cleanup = rctx.now;
+  }
+  CPOOL_UNLOCK(cpool);
+}
+
+static int conn_upkeep(struct Curl_easy *data,
+                       struct connectdata *conn,
+                       void *param)
+{
+  struct curltime *now = param;
+  /* TODO, shall we reap connections that return an error here? */
+  Curl_conn_upkeep(data, conn, now);
+  return 0; /* continue iteration */
+}
+
+CURLcode Curl_cpool_upkeep(void *data)
+{
+  struct cpool *cpool = cpool_get_instance(data);
+  struct curltime now = Curl_now();
+
+  if(!cpool)
+    return CURLE_OK;
+
+  CPOOL_LOCK(cpool);
+  cpool_foreach(data, cpool, &now, conn_upkeep);
+  CPOOL_UNLOCK(cpool);
+  return CURLE_OK;
+}
+
+struct cpool_find_ctx {
+  curl_off_t id;
+  struct connectdata *conn;
+};
+
+static int cpool_find_conn(struct Curl_easy *data,
+                           struct connectdata *conn, void *param)
+{
+  struct cpool_find_ctx *fctx = param;
+  (void)data;
+  if(conn->connection_id == fctx->id) {
+    fctx->conn = conn;
+    return 1;
+  }
+  return 0;
+}
+
+struct connectdata *Curl_cpool_get_conn(struct Curl_easy *data,
+                                        curl_off_t conn_id)
+{
+  struct cpool *cpool = cpool_get_instance(data);
+  struct cpool_find_ctx fctx;
+
+  if(!cpool)
+    return NULL;
+  fctx.id = conn_id;
+  fctx.conn = NULL;
+  CPOOL_LOCK(cpool);
+  cpool_foreach(cpool->idata, cpool, &fctx, cpool_find_conn);
+  CPOOL_UNLOCK(cpool);
+  return fctx.conn;
+}
+
+struct cpool_do_conn_ctx {
+  curl_off_t id;
+  Curl_cpool_conn_do_cb *cb;
+  void *cbdata;
+};
+
+static int cpool_do_conn(struct Curl_easy *data,
+                         struct connectdata *conn, void *param)
+{
+  struct cpool_do_conn_ctx *dctx = param;
+  (void)data;
+  if(conn->connection_id == dctx->id) {
+    dctx->cb(conn, data, dctx->cbdata);
+    return 1;
+  }
+  return 0;
+}
+
+void Curl_cpool_do_by_id(struct Curl_easy *data, curl_off_t conn_id,
+                         Curl_cpool_conn_do_cb *cb, void *cbdata)
+{
+  struct cpool *cpool = cpool_get_instance(data);
+  struct cpool_do_conn_ctx dctx;
+
+  if(!cpool)
+    return;
+  dctx.id = conn_id;
+  dctx.cb = cb;
+  dctx.cbdata = cbdata;
+  CPOOL_LOCK(cpool);
+  cpool_foreach(data, cpool, &dctx, cpool_do_conn);
+  CPOOL_UNLOCK(cpool);
+}
+
+void Curl_cpool_do_locked(struct Curl_easy *data,
+                          struct connectdata *conn,
+                          Curl_cpool_conn_do_cb *cb, void *cbdata)
+{
+  struct cpool *cpool = cpool_get_instance(data);
+  if(cpool) {
+    CPOOL_LOCK(cpool);
+    cb(conn, data, cbdata);
+    CPOOL_UNLOCK(cpool);
+  }
+  else
+    cb(conn, data, cbdata);
 }
 
 #if 0
-/* Useful for debugging the connection cache */
-void Curl_conncache_print(struct conncache *connc)
+/* Useful for debugging the connection pool */
+void Curl_cpool_print(struct cpool *cpool)
 {
   struct Curl_hash_iterator iter;
   struct Curl_llist_node *curr;
   struct Curl_hash_element *he;
 
-  if(!connc)
+  if(!cpool)
     return;
 
   fprintf(stderr, "=Bundle cache=\n");
 
-  Curl_hash_start_iterate(connc->hash, &iter);
+  Curl_hash_start_iterate(cpool->dest2bundle, &iter);
 
   he = Curl_hash_next_element(&iter);
   while(he) {
-    struct connectbundle *bundle;
+    struct cpool_bundle *bundle;
     struct connectdata *conn;
 
     bundle = he->ptr;
 
     fprintf(stderr, "%s -", he->key);
-    curr = Curl_llist_head(bundle->conn_list);
+    curr = Curl_llist_head(bundle->conns);
     while(curr) {
       conn = Curl_node_elem(curr);
 

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -25,140 +25,177 @@
  *
  ***************************************************************************/
 
-/*
- * All accesses to struct fields and changing of data in the connection cache
- * and connectbundles must be done with the conncache LOCKED. The cache might
- * be shared.
- */
-
 #include <curl/curl.h>
 #include "timeval.h"
 
 struct connectdata;
+struct Curl_easy;
 struct curl_pollfds;
 struct curl_waitfds;
 struct Curl_multi;
+struct Curl_share;
 
-struct connshutdowns {
-  struct Curl_llist conn_list;  /* The connectdata to shut down */
-  BIT(iter_locked);  /* TRUE while iterating the list */
-};
+/**
+ * Callback invoked when disconnecting connections.
+ * @param data    transfer last handling the connection, not attached
+ * @param conn    the connection to discard
+ * @param aborted if the connection is being aborted
+ * @return if the connection is being aborted, e.g. should NOT perform
+ *         a shutdown and just close.
+ **/
+typedef bool Curl_cpool_disconnect_cb(struct Curl_easy *data,
+                                      struct connectdata *conn,
+                                      bool aborted);
 
-struct conncache {
-  struct Curl_hash hash;
+struct cpool {
+   /* the pooled connections, bundled per destination */
+  struct Curl_hash dest2bundle;
   size_t num_conn;
   curl_off_t next_connection_id;
   curl_off_t next_easy_id;
   struct curltime last_cleanup;
-  struct connshutdowns shutdowns;
-  /* handle used for closing cached connections */
-  struct Curl_easy *closure_handle;
-  struct Curl_multi *multi; /* Optional, set if cache belongs to multi */
+  struct Curl_llist shutdowns;  /* The connections being shut down */
+  struct Curl_easy *idata; /* internal handle used for discard */
+  struct Curl_multi *multi; /* != NULL iff pool belongs to multi */
+  struct Curl_share *share; /* != NULL iff pool belongs to share */
+  Curl_cpool_disconnect_cb *disconnect_cb;
+  BIT(locked);
 };
 
-#define BUNDLE_NO_MULTIUSE -1
-#define BUNDLE_UNKNOWN     0  /* initial value */
-#define BUNDLE_MULTIPLEX   2
-
-#ifdef DEBUGBUILD
-/* the debug versions of these macros make extra certain that the lock is
-   never doubly locked or unlocked */
-#define CONNCACHE_LOCK(x)                                               \
-  do {                                                                  \
-    if((x)->share) {                                                    \
-      Curl_share_lock((x), CURL_LOCK_DATA_CONNECT,                      \
-                      CURL_LOCK_ACCESS_SINGLE);                         \
-      DEBUGASSERT(!(x)->state.conncache_lock);                          \
-      (x)->state.conncache_lock = TRUE;                                 \
-    }                                                                   \
-  } while(0)
-
-#define CONNCACHE_UNLOCK(x)                                             \
-  do {                                                                  \
-    if((x)->share) {                                                    \
-      DEBUGASSERT((x)->state.conncache_lock);                           \
-      (x)->state.conncache_lock = FALSE;                                \
-      Curl_share_unlock((x), CURL_LOCK_DATA_CONNECT);                   \
-    }                                                                   \
-  } while(0)
-#else
-#define CONNCACHE_LOCK(x) if((x)->share)                                \
-    Curl_share_lock((x), CURL_LOCK_DATA_CONNECT, CURL_LOCK_ACCESS_SINGLE)
-#define CONNCACHE_UNLOCK(x) if((x)->share)              \
-    Curl_share_unlock((x), CURL_LOCK_DATA_CONNECT)
-#endif
-
-struct connectbundle {
-  int multiuse;                 /* supports multi-use */
-  size_t num_connections;       /* Number of connections in the bundle */
-  struct Curl_llist conn_list;  /* The connectdata members of the bundle */
-};
-
-/* Init the cache, pass multi only if cache is owned by it.
+/* Init the pool, pass multi only if pool is owned by it.
  * returns 1 on error, 0 is fine.
  */
-int Curl_conncache_init(struct conncache *,
-                        struct Curl_multi *multi,
-                        size_t size);
-void Curl_conncache_destroy(struct conncache *connc);
+int Curl_cpool_init(struct cpool *cpool,
+                    Curl_cpool_disconnect_cb *disconnect_cb,
+                    struct Curl_multi *multi,
+                    struct Curl_share *share,
+                    size_t size);
 
-/* return the correct bundle, to a host or a proxy */
-struct connectbundle *Curl_conncache_find_bundle(struct Curl_easy *data,
-                                                 struct connectdata *conn,
-                                                 struct conncache *connc);
-/* returns number of connections currently held in the connection cache */
-size_t Curl_conncache_size(struct Curl_easy *data);
+/* Destroy all connections and free all members */
+void Curl_cpool_destroy(struct cpool *connc);
 
-bool Curl_conncache_return_conn(struct Curl_easy *data,
-                                struct connectdata *conn);
-CURLcode Curl_conncache_add_conn(struct Curl_easy *data) WARN_UNUSED_RESULT;
-void Curl_conncache_remove_conn(struct Curl_easy *data,
-                                struct connectdata *conn,
-                                bool lock);
-bool Curl_conncache_foreach(struct Curl_easy *data,
-                            struct conncache *connc,
-                            void *param,
-                            int (*func)(struct Curl_easy *data,
-                                        struct connectdata *conn,
-                                        void *param));
-
-struct connectdata *
-Curl_conncache_find_first_connection(struct conncache *connc);
-
-struct connectdata *
-Curl_conncache_extract_bundle(struct Curl_easy *data,
-                              struct connectbundle *bundle);
-struct connectdata *
-Curl_conncache_extract_oldest(struct Curl_easy *data);
-void Curl_conncache_close_all_connections(struct conncache *connc);
-void Curl_conncache_print(struct conncache *connc);
+/* Init the transfer to be used within its connection pool.
+ * Assigns `data->id`. */
+void Curl_cpool_xfer_init(struct Curl_easy *data);
 
 /**
- * Tear down the connection. If `aborted` is FALSE, the connection
- * will be shut down first before discarding. If the shutdown
- * is not immediately complete, the connection
- * will be placed into the cache is shutdown queue.
+ * Get the connection with the given id from the transfer's pool.
  */
-void Curl_conncache_disconnect(struct Curl_easy *data,
-                               struct connectdata *conn,
-                               bool aborted);
+struct connectdata *Curl_cpool_get_conn(struct Curl_easy *data,
+                                        curl_off_t conn_id);
+
+CURLcode Curl_cpool_add_conn(struct Curl_easy *data,
+                             struct connectdata *conn) WARN_UNUSED_RESULT;
 
 /**
- * Add sockets and POLLIN/OUT flags for connections handled by the cache.
+ * Return if the pool has reached its configured limits for adding
+ * the given connection. Will try to discard the oldest, idle
+ * connections to make space.
  */
-CURLcode Curl_conncache_add_pollfds(struct conncache *connc,
-                                    struct curl_pollfds *cpfds);
-CURLcode Curl_conncache_add_waitfds(struct conncache *connc,
-                                    struct curl_waitfds *cwfds);
+#define CPOOL_LIMIT_OK     0
+#define CPOOL_LIMIT_DEST   1
+#define CPOOL_LIMIT_TOTAL  2
+int Curl_cpool_check_limits(struct Curl_easy *data,
+                            struct connectdata *conn);
+
+/* Return of conn is suitable. If so, stops iteration. */
+typedef bool Curl_cpool_conn_match_cb(struct connectdata *conn,
+                                      void *userdata);
+
+/* Act on the result of the find, may override it. */
+typedef bool Curl_cpool_done_match_cb(bool result, void *userdata);
 
 /**
- * Perform maintenance on connections in the cache. Specifically,
+ * Find a connection in the pool matching `destination`.
+ * All callbacks are invoked while the pool's lock is held.
+ * @param data        current transfer
+ * @param destination match agaonst `conn->destination` in pool
+ * @param dest_len    destination length, including terminating NUL
+ * @param conn_cb     must be present, called for each connection in the
+ *                    bundle until it returns TRUE
+ * @param result_cb   if not NULL, is called at the end with the result
+ *                    of the `conn_cb` or FALSE if never called.
+ * @return combined result of last conn_db and result_cb or FALSE if no
+                      connections were present.
+ */
+bool Curl_cpool_find(struct Curl_easy *data,
+                     const char *destination, size_t dest_len,
+                     Curl_cpool_conn_match_cb *conn_cb,
+                     Curl_cpool_done_match_cb *done_cb,
+                     void *userdata);
+
+/*
+ * A connection (already in the pool) is now idle. Do any
+ * cleanups in regard to the pool's limits.
+ *
+ * Return TRUE if idle connection kept in pool, FALSE if closed.
+ */
+bool Curl_cpool_conn_now_idle(struct Curl_easy *data,
+                              struct connectdata *conn);
+
+/**
+ * Remove the connection from the pool and tear it down.
+ * If `aborted` is FALSE, the connection will be shut down first
+ * before closing and destroying it.
+ * If the shutdown is not immediately complete, the connection
+ * will be placed into the pool's shutdown queue.
+ */
+void Curl_cpool_disconnect(struct Curl_easy *data,
+                           struct connectdata *conn,
+                           bool aborted);
+
+/**
+ * This function scans the data's connection pool for half-open/dead
+ * connections, closes and removes them.
+ * The cleanup is done at most once per second.
+ *
+ * When called, this transfer has no connection attached.
+ */
+void Curl_cpool_prune_dead(struct Curl_easy *data);
+
+/**
+ * Perform upkeep actions on connections in the transfer's pool.
+ */
+CURLcode Curl_cpool_upkeep(void *data);
+
+typedef void Curl_cpool_conn_do_cb(struct connectdata *conn,
+                                   struct Curl_easy *data,
+                                   void *cbdata);
+
+/**
+ * Invoke the callback on the pool's connection with the
+ * given connection id (if it exists).
+ */
+void Curl_cpool_do_by_id(struct Curl_easy *data,
+                         curl_off_t conn_id,
+                         Curl_cpool_conn_do_cb *cb, void *cbdata);
+
+/**
+ * Invoked the callback for the given data + connection under the
+ * connection pool's lock.
+ * The callback is always invoked, even if the transfer has no connection
+ * pool associated.
+ */
+void Curl_cpool_do_locked(struct Curl_easy *data,
+                          struct connectdata *conn,
+                          Curl_cpool_conn_do_cb *cb, void *cbdata);
+
+/**
+ * Add sockets and POLLIN/OUT flags for connections handled by the pool.
+ */
+CURLcode Curl_cpool_add_pollfds(struct cpool *connc,
+                                struct curl_pollfds *cpfds);
+CURLcode Curl_cpool_add_waitfds(struct cpool *connc,
+                                struct curl_waitfds *cwfds);
+
+/**
+ * Perform maintenance on connections in the pool. Specifically,
  * progress the shutdown of connections in the queue.
  */
-void Curl_conncache_multi_perform(struct Curl_multi *multi);
+void Curl_cpool_multi_perform(struct Curl_multi *multi);
 
-void Curl_conncache_multi_socket(struct Curl_multi *multi,
-                                 curl_socket_t s, int ev_bitmask);
-void Curl_conncache_multi_close_all(struct Curl_multi *multi);
+void Curl_cpool_multi_socket(struct Curl_multi *multi,
+                             curl_socket_t s, int ev_bitmask);
+
 
 #endif /* HEADER_CURL_CONNCACHE_H */

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1449,8 +1449,7 @@ CURLcode Curl_once_resolved(struct Curl_easy *data, bool *protocol_done)
 
   if(result) {
     Curl_detach_connection(data);
-    Curl_conncache_remove_conn(data, conn, TRUE);
-    Curl_disconnect(data, conn, TRUE);
+    Curl_cpool_disconnect(data, conn, TRUE);
   }
   return result;
 }

--- a/lib/http.c
+++ b/lib/http.c
@@ -3241,9 +3241,6 @@ CURLcode Curl_http_statusline(struct Curl_easy *data,
   else if(k->httpversion == 20 ||
           (k->upgr101 == UPGR101_H2 && k->httpcode == 101)) {
     DEBUGF(infof(data, "HTTP/2 found, allow multiplexing"));
-    /* HTTP/2 cannot avoid multiplexing since it is a core functionality
-       of the protocol */
-    conn->bundle->multiuse = BUNDLE_MULTIPLEX;
   }
 
   k->http_bodyless = k->httpcode >= 100 && k->httpcode < 200;
@@ -3392,9 +3389,6 @@ static CURLcode http_on_response(struct Curl_easy *data,
     /* supposedly upgraded to http2 now */
     if(conn->httpversion != 20)
       infof(data, "Lying server, not serving HTTP/2");
-  }
-  if(conn->httpversion < 20) {
-    conn->bundle->multiuse = BUNDLE_NO_MULTIUSE;
   }
 
   if(k->httpcode < 200 && last_hd) {

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2837,7 +2837,6 @@ CURLcode Curl_http2_switch(struct Curl_easy *data,
 
   conn->httpversion = 20; /* we know we are on HTTP/2 now */
   conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
-  conn->bundle->multiuse = BUNDLE_MULTIPLEX;
   Curl_multi_connchanged(data->multi);
 
   if(cf->next) {
@@ -2861,7 +2860,6 @@ CURLcode Curl_http2_switch_at(struct Curl_cfilter *cf, struct Curl_easy *data)
   cf_h2 = cf->next;
   cf->conn->httpversion = 20; /* we know we are on HTTP/2 now */
   cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
-  cf->conn->bundle->multiuse = BUNDLE_MULTIPLEX;
   Curl_multi_connchanged(data->multi);
 
   if(cf_h2->next) {
@@ -2914,7 +2912,6 @@ CURLcode Curl_http2_upgrade(struct Curl_easy *data,
 
   conn->httpversion = 20; /* we know we are on HTTP/2 now */
   conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
-  conn->bundle->multiuse = BUNDLE_MULTIPLEX;
   Curl_multi_connchanged(data->multi);
 
   if(cf->next) {

--- a/lib/llist.c
+++ b/lib/llist.c
@@ -254,3 +254,10 @@ struct Curl_llist_node *Curl_node_prev(struct Curl_llist_node *n)
 }
 
 #endif
+
+struct Curl_llist *Curl_node_llist(struct Curl_llist_node *n)
+{
+  DEBUGASSERT(n);
+  DEBUGASSERT(!n->_list || n->_init == NODEINIT);
+  return n->_list;
+}

--- a/lib/llist.h
+++ b/lib/llist.h
@@ -83,4 +83,7 @@ struct Curl_llist_node *Curl_node_next(struct Curl_llist_node *n);
    Curl_llist_node */
 struct Curl_llist_node *Curl_node_prev(struct Curl_llist_node *n);
 
+/* Curl_node_llist() return the list the node is in or NULL. */
+struct Curl_llist *Curl_node_llist(struct Curl_llist_node *n);
+
 #endif /* HEADER_CURL_LLIST_H */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -411,7 +411,8 @@ struct Curl_multi *Curl_multi_handle(size_t hashsize, /* socket hash */
   Curl_hash_init(&multi->proto_hash, 23,
                  Curl_hash_str, Curl_str_key_compare, ph_freeentry);
 
-  if(Curl_conncache_init(&multi->conn_cache, multi, chashsize))
+  if(Curl_cpool_init(&multi->cpool, Curl_on_disconnect,
+                         multi, NULL, chashsize))
     goto error;
 
   Curl_llist_init(&multi->msglist, NULL);
@@ -443,7 +444,7 @@ error:
   sockhash_destroy(&multi->sockhash);
   Curl_hash_destroy(&multi->proto_hash);
   Curl_hash_destroy(&multi->hostcache);
-  Curl_conncache_destroy(&multi->conn_cache);
+  Curl_cpool_destroy(&multi->cpool);
   free(multi);
   return NULL;
 }
@@ -511,7 +512,7 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
   /*
    * No failure allowed in this function beyond this point. No modification of
    * easy nor multi handle allowed before this except for potential multi's
-   * connection cache growing which will not be undone in this function no
+   * connection pool growing which will not be undone in this function no
    * matter what.
    */
   if(data->set.errorbuffer)
@@ -548,13 +549,6 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
     data->dns.hostcachetype = HCACHE_MULTI;
   }
 
-  /* Point to the shared or multi handle connection cache */
-  if(data->share && (data->share->specifier & (1<< CURL_LOCK_DATA_CONNECT)))
-    data->state.conn_cache = &data->share->conn_cache;
-  else
-    data->state.conn_cache = &multi->conn_cache;
-  data->state.lastconnect_id = -1;
-
 #ifdef USE_LIBPSL
   /* Do the same for PSL. */
   if(data->share && (data->share->specifier & (1 << CURL_LOCK_DATA_PSL)))
@@ -572,28 +566,12 @@ CURLMcode curl_multi_add_handle(struct Curl_multi *multi,
   /* increase the alive-counter */
   multi->num_alive++;
 
-  CONNCACHE_LOCK(data);
-  /* The closure handle only ever has default timeouts set. To improve the
-     state somewhat we clone the timeouts from each added handle so that the
-     closure handle always has the same timeouts as the most recently added
-     easy handle. */
-  data->state.conn_cache->closure_handle->set.timeout = data->set.timeout;
-  data->state.conn_cache->closure_handle->set.server_response_timeout =
-    data->set.server_response_timeout;
-  data->state.conn_cache->closure_handle->set.no_signal =
-    data->set.no_signal;
-
-  /* the identifier inside the connection cache */
-  data->id = data->state.conn_cache->next_easy_id++;
-  if(data->state.conn_cache->next_easy_id <= 0)
-    data->state.conn_cache->next_easy_id = 0;
   /* the identifier inside the multi instance */
   data->mid = multi->next_easy_mid++;
   if(multi->next_easy_mid <= 0)
     multi->next_easy_mid = 0;
 
-  CONNCACHE_UNLOCK(data);
-
+  Curl_cpool_xfer_init(data);
   multi_warn_debug(multi, data);
 
   return CURLM_OK;
@@ -615,6 +593,91 @@ static void debug_print_sock_hash(void *p)
 }
 #endif
 
+struct multi_done_ctx {
+  BIT(premature);
+};
+
+static void multi_done_locked(struct connectdata *conn,
+                              struct Curl_easy *data,
+                              void *userdata)
+{
+  struct multi_done_ctx *mdctx = userdata;
+
+  Curl_detach_connection(data);
+
+  if(CONN_INUSE(conn)) {
+    /* Stop if still used. */
+    DEBUGF(infof(data, "Connection still in use %zu, "
+                 "no more multi_done now!",
+                 Curl_llist_count(&conn->easyq)));
+    return;
+  }
+
+  data->state.done = TRUE; /* called just now! */
+  data->state.recent_conn_id = conn->connection_id;
+
+  if(conn->dns_entry)
+    Curl_resolv_unlink(data, &conn->dns_entry); /* done with this */
+  Curl_hostcache_prune(data);
+
+  /* if data->set.reuse_forbid is TRUE, it means the libcurl client has
+     forced us to close this connection. This is ignored for requests taking
+     place in a NTLM/NEGOTIATE authentication handshake
+
+     if conn->bits.close is TRUE, it means that the connection should be
+     closed in spite of all our efforts to be nice, due to protocol
+     restrictions in our or the server's end
+
+     if premature is TRUE, it means this connection was said to be DONE before
+     the entire request operation is complete and thus we cannot know in what
+     state it is for reusing, so we are forced to close it. In a perfect world
+     we can add code that keep track of if we really must close it here or not,
+     but currently we have no such detail knowledge.
+  */
+
+  if((data->set.reuse_forbid
+#if defined(USE_NTLM)
+      && !(conn->http_ntlm_state == NTLMSTATE_TYPE2 ||
+           conn->proxy_ntlm_state == NTLMSTATE_TYPE2)
+#endif
+#if defined(USE_SPNEGO)
+      && !(conn->http_negotiate_state == GSS_AUTHRECV ||
+           conn->proxy_negotiate_state == GSS_AUTHRECV)
+#endif
+     ) || conn->bits.close
+       || (mdctx->premature && !Curl_conn_is_multiplex(conn, FIRSTSOCKET))) {
+    DEBUGF(infof(data, "multi_done, not reusing connection=%"
+                       CURL_FORMAT_CURL_OFF_T ", forbid=%d"
+                       ", close=%d, premature=%d, conn_multiplex=%d",
+                 conn->connection_id, data->set.reuse_forbid,
+                 conn->bits.close, mdctx->premature,
+                 Curl_conn_is_multiplex(conn, FIRSTSOCKET)));
+    connclose(conn, "disconnecting");
+    Curl_cpool_disconnect(data, conn, mdctx->premature);
+  }
+  else {
+    /* the connection is no longer in use by any transfer */
+    if(Curl_cpool_conn_now_idle(data, conn)) {
+      /* connection kept in the cpool */
+      const char *host =
+#ifndef CURL_DISABLE_PROXY
+        conn->bits.socksproxy ?
+        conn->socks_proxy.host.dispname :
+        conn->bits.httpproxy ? conn->http_proxy.host.dispname :
+#endif
+        conn->bits.conn_to_host ? conn->conn_to_host.dispname :
+        conn->host.dispname;
+      data->state.lastconnect_id = conn->connection_id;
+      infof(data, "Connection #%" CURL_FORMAT_CURL_OFF_T
+            " to host %s left intact", conn->connection_id, host);
+    }
+    else {
+      /* connection was removed from the cpool and destroyed. */
+      data->state.lastconnect_id = -1;
+    }
+  }
+}
+
 static CURLcode multi_done(struct Curl_easy *data,
                            CURLcode status,  /* an error if this is called
                                                 after an error was detected */
@@ -622,6 +685,9 @@ static CURLcode multi_done(struct Curl_easy *data,
 {
   CURLcode result, r2;
   struct connectdata *conn = data->conn;
+  struct multi_done_ctx mdctx;
+
+  memset(&mdctx, 0, sizeof(mdctx));
 
 #if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
   DEBUGF(infof(data, "multi_done[%s]: status: %d prem: %d done: %d",
@@ -684,104 +750,22 @@ static CURLcode multi_done(struct Curl_easy *data,
   if(!result)
     result = Curl_req_done(&data->req, data, premature);
 
-  CONNCACHE_LOCK(data);
-  Curl_detach_connection(data);
-  if(CONN_INUSE(conn)) {
-    /* Stop if still used. */
-    CONNCACHE_UNLOCK(data);
-    DEBUGF(infof(data, "Connection still in use %zu, "
-                 "no more multi_done now!",
-                 Curl_llist_count(&conn->easyq)));
-    return CURLE_OK;
-  }
-
-  data->state.done = TRUE; /* called just now! */
-
-  if(conn->dns_entry)
-    Curl_resolv_unlink(data, &conn->dns_entry); /* done with this */
-  Curl_hostcache_prune(data);
-
-  /* if data->set.reuse_forbid is TRUE, it means the libcurl client has
-     forced us to close this connection. This is ignored for requests taking
-     place in a NTLM/NEGOTIATE authentication handshake
-
-     if conn->bits.close is TRUE, it means that the connection should be
-     closed in spite of all our efforts to be nice, due to protocol
-     restrictions in our or the server's end
-
-     if premature is TRUE, it means this connection was said to be DONE before
-     the entire request operation is complete and thus we cannot know in what
-     state it is for reusing, so we are forced to close it. In a perfect world
-     we can add code that keep track of if we really must close it here or not,
-     but currently we have no such detail knowledge.
-  */
-
-  data->state.recent_conn_id = conn->connection_id;
-  if((data->set.reuse_forbid
-#if defined(USE_NTLM)
-      && !(conn->http_ntlm_state == NTLMSTATE_TYPE2 ||
-           conn->proxy_ntlm_state == NTLMSTATE_TYPE2)
-#endif
-#if defined(USE_SPNEGO)
-      && !(conn->http_negotiate_state == GSS_AUTHRECV ||
-           conn->proxy_negotiate_state == GSS_AUTHRECV)
-#endif
-     ) || conn->bits.close
-       || (premature && !Curl_conn_is_multiplex(conn, FIRSTSOCKET))) {
-    DEBUGF(infof(data, "multi_done, not reusing connection=%"
-                       CURL_FORMAT_CURL_OFF_T ", forbid=%d"
-                       ", close=%d, premature=%d, conn_multiplex=%d",
-                 conn->connection_id,
-                 data->set.reuse_forbid, conn->bits.close, premature,
-                 Curl_conn_is_multiplex(conn, FIRSTSOCKET)));
-    connclose(conn, "disconnecting");
-    Curl_conncache_remove_conn(data, conn, FALSE);
-    CONNCACHE_UNLOCK(data);
-    Curl_disconnect(data, conn, premature);
-  }
-  else {
-    char buffer[256];
-    const char *host =
-#ifndef CURL_DISABLE_PROXY
-      conn->bits.socksproxy ?
-      conn->socks_proxy.host.dispname :
-      conn->bits.httpproxy ? conn->http_proxy.host.dispname :
-#endif
-      conn->bits.conn_to_host ? conn->conn_to_host.dispname :
-      conn->host.dispname;
-    /* create string before returning the connection */
-    curl_off_t connection_id = conn->connection_id;
-    msnprintf(buffer, sizeof(buffer),
-              "Connection #%" CURL_FORMAT_CURL_OFF_T " to host %s left intact",
-              connection_id, host);
-    /* the connection is no longer in use by this transfer */
-    CONNCACHE_UNLOCK(data);
-    if(Curl_conncache_return_conn(data, conn)) {
-      /* remember the most recently used connection */
-      data->state.lastconnect_id = connection_id;
-      data->state.recent_conn_id = connection_id;
-      infof(data, "%s", buffer);
-    }
-    else
-      data->state.lastconnect_id = -1;
-  }
+  /* Under the potential connection pool's share lock, decide what to
+   * do with the transfer's connection. */
+  mdctx.premature = premature;
+  Curl_cpool_do_locked(data, data->conn, multi_done_locked, &mdctx);
 
   return result;
 }
 
-static int close_connect_only(struct Curl_easy *data,
-                              struct connectdata *conn, void *param)
+static void close_connect_only(struct connectdata *conn,
+                               struct Curl_easy *data,
+                               void *userdata)
 {
-  (void)param;
-  if(data->state.lastconnect_id != conn->connection_id)
-    return 0;
-
-  if(!conn->connect_only)
-    return 1;
-
-  connclose(conn, "Removing connect-only easy handle");
-
-  return 1;
+  (void)userdata;
+  (void)data;
+  if(conn->connect_only)
+    connclose(conn, "Removing connect-only easy handle");
 }
 
 CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
@@ -881,15 +865,14 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
     curl_socket_t s;
     s = Curl_getconnectinfo(data, &c);
     if((s != CURL_SOCKET_BAD) && c) {
-      Curl_conncache_remove_conn(data, c, TRUE);
-      Curl_disconnect(data, c, TRUE);
+      Curl_cpool_disconnect(data, c, TRUE);
     }
   }
 
   if(data->state.lastconnect_id != -1) {
     /* Mark any connect-only connection for closure */
-    Curl_conncache_foreach(data, data->state.conn_cache,
-                           NULL, close_connect_only);
+    Curl_cpool_do_by_id(data, data->state.lastconnect_id,
+                            close_connect_only, NULL);
   }
 
 #ifdef USE_LIBPSL
@@ -897,10 +880,6 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
   if(data->psl == &multi->psl)
     data->psl = NULL;
 #endif
-
-  /* as this was using a shared connection cache we clear the pointer to that
-     since we are not part of that multi handle anymore */
-  data->state.conn_cache = NULL;
 
   /* make sure there is no pending message in the queue sent from this easy
      handle */
@@ -920,7 +899,6 @@ CURLMcode curl_multi_remove_handle(struct Curl_multi *multi,
   /* NOTE NOTE NOTE
      We do not touch the easy handle here! */
   multi->num_easy--; /* one less to care about now */
-
   process_pending_handles(multi);
 
   if(removed_timer) {
@@ -1223,7 +1201,7 @@ CURLMcode curl_multi_waitfds(struct Curl_multi *multi,
     }
   }
 
-  if(Curl_conncache_add_waitfds(&multi->conn_cache, &cwfds)) {
+  if(Curl_cpool_add_waitfds(&multi->cpool, &cwfds)) {
     result = CURLM_OUT_OF_MEMORY;
     goto out;
   }
@@ -1300,7 +1278,7 @@ static CURLMcode multi_wait(struct Curl_multi *multi,
     }
   }
 
-  if(Curl_conncache_add_pollfds(&multi->conn_cache, &cpfds)) {
+  if(Curl_cpool_add_pollfds(&multi->cpool, &cpfds)) {
     result = CURLM_OUT_OF_MEMORY;
     goto out;
   }
@@ -1945,8 +1923,14 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
              WAITDO or DO! */
           rc = CURLM_CALL_MULTI_PERFORM;
 
-          if(connected)
+          if(connected) {
+            if(!data->conn->bits.reuse &&
+               Curl_conn_is_multiplex(data->conn, FIRSTSOCKET)) {
+              /* new connection, can multiplex, wake pending handles */
+              process_pending_handles(data->multi);
+            }
             multistate(data, MSTATE_PROTOCONNECT);
+          }
           else {
             multistate(data, MSTATE_CONNECTING);
           }
@@ -2055,6 +2039,11 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       DEBUGASSERT(data->conn);
       result = Curl_conn_connect(data, FIRSTSOCKET, FALSE, &connected);
       if(connected && !result) {
+        if(!data->conn->bits.reuse &&
+           Curl_conn_is_multiplex(data->conn, FIRSTSOCKET)) {
+          /* new connection, can multiplex, wake pending handles */
+          process_pending_handles(data->multi);
+        }
         rc = CURLM_CALL_MULTI_PERFORM;
         multistate(data, MSTATE_PROTOCONNECT);
       }
@@ -2511,10 +2500,6 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
       if(data->conn) {
         CURLcode res;
 
-        if(data->conn->bits.multiplex)
-          /* Check if we can move pending requests to connection */
-          process_pending_handles(multi); /* multiplexing */
-
         /* post-transfer command */
         res = multi_done(data, result, FALSE);
 
@@ -2589,12 +2574,7 @@ statemachine_end:
                We do not have to do this in every case block above where a
                failure is detected */
             Curl_detach_connection(data);
-
-            /* remove connection from cache */
-            Curl_conncache_remove_conn(data, conn, TRUE);
-
-            /* disconnect properly */
-            Curl_disconnect(data, conn, dead_connection);
+            Curl_cpool_disconnect(data, conn, dead_connection);
           }
         }
         else if(data->mstate == MSTATE_CONNECT) {
@@ -2677,8 +2657,8 @@ CURLMcode curl_multi_perform(struct Curl_multi *multi, int *running_handles)
        pointer now */
     n = Curl_node_next(e);
 
-    if(data != multi->conn_cache.closure_handle) {
-      /* connection cache handle is processed below */
+    if(data != multi->cpool.idata) {
+      /* connection pool handle is processed below */
       sigpipe_apply(data, &pipe_st);
       result = multi_runsingle(multi, &now, data);
       if(result)
@@ -2686,8 +2666,8 @@ CURLMcode curl_multi_perform(struct Curl_multi *multi, int *running_handles)
     }
   }
 
-  sigpipe_apply(multi->conn_cache.closure_handle, &pipe_st);
-  Curl_conncache_multi_perform(multi);
+  sigpipe_apply(multi->cpool.idata, &pipe_st);
+  Curl_cpool_multi_perform(multi);
 
   sigpipe_restore(&pipe_st);
 
@@ -2777,8 +2757,6 @@ CURLMcode curl_multi_cleanup(struct Curl_multi *multi)
         data->dns.hostcachetype = HCACHE_NONE;
       }
 
-      /* Clear the pointer to the connection cache */
-      data->state.conn_cache = NULL;
       data->multi = NULL; /* clear the association */
 
 #ifdef USE_LIBPSL
@@ -2787,12 +2765,10 @@ CURLMcode curl_multi_cleanup(struct Curl_multi *multi)
 #endif
     }
 
-    /* Close all the connections in the connection cache */
-    Curl_conncache_multi_close_all(multi);
+    Curl_cpool_destroy(&multi->cpool);
 
     sockhash_destroy(&multi->sockhash);
     Curl_hash_destroy(&multi->proto_hash);
-    Curl_conncache_destroy(&multi->conn_cache);
     Curl_hash_destroy(&multi->hostcache);
     Curl_psl_destroy(&multi->psl);
 
@@ -3143,7 +3119,7 @@ struct multi_run_ctx {
   struct curltime now;
   size_t run_xfers;
   SIGPIPE_MEMBER(pipe_st);
-  bool run_conn_cache;
+  bool run_cpool;
 };
 
 static CURLMcode multi_run_expired(struct multi_run_ctx *mrc)
@@ -3170,8 +3146,8 @@ static CURLMcode multi_run_expired(struct multi_run_ctx *mrc)
       continue;
 
     (void)add_next_timeout(mrc->now, multi, data);
-    if(data == multi->conn_cache.closure_handle) {
-      mrc->run_conn_cache = TRUE;
+    if(data == multi->cpool.idata) {
+      mrc->run_cpool = TRUE;
       continue;
     }
 
@@ -3220,7 +3196,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
         result = singlesocket(multi, Curl_node_elem(e));
       }
     }
-    mrc.run_conn_cache = TRUE;
+    mrc.run_cpool = TRUE;
     goto out;
   }
 
@@ -3234,8 +3210,8 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
          asked to get removed, so thus we better survive stray socket actions
          and just move on. */
       /* The socket might come from a connection that is being shut down
-       * by the multi's conncache. */
-      Curl_conncache_multi_socket(multi, s, ev_bitmask);
+       * by the multi's connection pool. */
+      Curl_cpool_multi_socket(multi, s, ev_bitmask);
     }
     else {
       struct Curl_hash_iterator iter;
@@ -3249,8 +3225,8 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
         DEBUGASSERT(data);
         DEBUGASSERT(data->magic == CURLEASY_MAGIC_NUMBER);
 
-        if(data == multi->conn_cache.closure_handle)
-          mrc.run_conn_cache = TRUE;
+        if(data == multi->cpool.idata)
+          mrc.run_cpool = TRUE;
         else {
           /* Expire with out current now, so we will get it below when
            * asking the splaytree for expired transfers. */
@@ -3275,9 +3251,9 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
   }
 
 out:
-  if(mrc.run_conn_cache) {
-    sigpipe_apply(multi->conn_cache.closure_handle, &mrc.pipe_st);
-    Curl_conncache_multi_perform(multi);
+  if(mrc.run_cpool) {
+    sigpipe_apply(multi->cpool.idata, &mrc.pipe_st);
+    Curl_cpool_multi_perform(multi);
   }
   sigpipe_restore(&mrc.pipe_st);
 
@@ -3731,34 +3707,6 @@ CURLMcode curl_multi_assign(struct Curl_multi *multi, curl_socket_t s,
   there->socketp = hashp;
 
   return CURLM_OK;
-}
-
-size_t Curl_multi_max_host_connections(struct Curl_multi *multi)
-{
-  return multi ? (size_t)multi->max_host_connections : 0;
-}
-
-size_t Curl_multi_max_total_connections(struct Curl_multi *multi)
-{
-  return multi ? (size_t)multi->max_total_connections : 0;
-}
-
-/*
- * When information about a connection has appeared, call this!
- */
-
-void Curl_multiuse_state(struct Curl_easy *data,
-                         int bundlestate) /* use BUNDLE_* defines */
-{
-  struct connectdata *conn;
-  DEBUGASSERT(data);
-  DEBUGASSERT(data->multi);
-  conn = data->conn;
-  DEBUGASSERT(conn);
-  DEBUGASSERT(conn->bundle);
-
-  conn->bundle->multiuse = bundlestate;
-  process_pending_handles(data->multi);
 }
 
 static void move_pending_to_connect(struct Curl_multi *multi,

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -138,7 +138,7 @@ struct Curl_multi {
   struct Curl_hash proto_hash;
 
   /* Shared connection cache (bundles)*/
-  struct conncache conn_cache;
+  struct cpool cpool;
 
   long max_host_connections; /* if >0, a fixed limit of the maximum number
                                 of connections per host */

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -63,15 +63,6 @@ struct Curl_multi *Curl_multi_handle(size_t hashsize,
 /* mask for checking if read and/or write is set for index x */
 #define GETSOCK_MASK_RW(x) (GETSOCK_READSOCK(x)|GETSOCK_WRITESOCK(x))
 
-/* Return the value of the CURLMOPT_MAX_HOST_CONNECTIONS option */
-size_t Curl_multi_max_host_connections(struct Curl_multi *multi);
-
-/* Return the value of the CURLMOPT_MAX_TOTAL_CONNECTIONS option */
-size_t Curl_multi_max_total_connections(struct Curl_multi *multi);
-
-void Curl_multiuse_state(struct Curl_easy *data,
-                         int bundlestate); /* use BUNDLE_* defines */
-
 /*
  * Curl_multi_closed()
  *

--- a/lib/share.c
+++ b/lib/share.c
@@ -31,6 +31,7 @@
 #include "psl.h"
 #include "vtls/vtls.h"
 #include "hsts.h"
+#include "url.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
@@ -120,10 +121,11 @@ curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
       break;
 
     case CURL_LOCK_DATA_CONNECT:
-      if(!share->conn_cache.hash.table) {
-        if(Curl_conncache_init(&share->conn_cache, NULL, 103)) {
+      /* It is safe to set this option several times on a share. */
+      if(!share->cpool.idata) {
+        if(Curl_cpool_init(&share->cpool, Curl_on_disconnect,
+                           NULL, share, 103))
           res = CURLSHE_NOMEM;
-        }
       }
       break;
 
@@ -228,9 +230,7 @@ curl_share_cleanup(struct Curl_share *share)
   }
 
   if(share->specifier & (1 << CURL_LOCK_DATA_CONNECT)) {
-    /* avoid the hash if it was never initialized */
-    Curl_conncache_close_all_connections(&share->conn_cache);
-    Curl_conncache_destroy(&share->conn_cache);
+    Curl_cpool_destroy(&share->cpool);
   }
   Curl_hash_destroy(&share->hostcache);
 

--- a/lib/share.h
+++ b/lib/share.h
@@ -34,6 +34,9 @@
 #define CURL_GOOD_SHARE 0x7e117a1e
 #define GOOD_SHARE_HANDLE(x) ((x) && (x)->magic == CURL_GOOD_SHARE)
 
+#define CURL_SHARE_KEEP_CONNECT(s)    \
+        ((s) && ((s)->specifier & (1<< CURL_LOCK_DATA_CONNECT)))
+
 /* this struct is libcurl-private, do not export details */
 struct Curl_share {
   unsigned int magic; /* CURL_GOOD_SHARE */
@@ -43,7 +46,7 @@ struct Curl_share {
   curl_lock_function lockfunc;
   curl_unlock_function unlockfunc;
   void *clientdata;
-  struct conncache conn_cache;
+  struct cpool cpool;
   struct Curl_hash hostcache;
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)
   struct CookieInfo *cookies;

--- a/lib/url.c
+++ b/lib/url.c
@@ -597,13 +597,14 @@ void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
 #ifdef USE_UNIX_SOCKETS
   Curl_safefree(conn->unix_domain_socket);
 #endif
+  Curl_safefree(conn->destination);
 
   free(conn); /* free all the connection oriented data */
 }
 
 /*
  * Disconnects the given connection. Note the connection may not be the
- * primary connection, like when freeing room in the connection cache or
+ * primary connection, like when freeing room in the connection pool or
  * killing of a dead old connection.
  *
  * A connection needs an easy handle when closing down. We support this passed
@@ -613,14 +614,14 @@ void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
  * This function MUST NOT reset state in the Curl_easy struct if that
  * is not strictly bound to the life-time of *this* particular connection.
  */
-void Curl_disconnect(struct Curl_easy *data,
-                     struct connectdata *conn, bool aborted)
+bool Curl_on_disconnect(struct Curl_easy *data,
+                        struct connectdata *conn, bool aborted)
 {
   /* there must be a connection to close */
   DEBUGASSERT(conn);
 
-  /* it must be removed from the connection cache */
-  DEBUGASSERT(!conn->bundle);
+  /* it must be removed from the connection pool */
+  DEBUGASSERT(!conn->bits.in_cpool);
 
   /* there must be an associated transfer */
   DEBUGASSERT(data);
@@ -631,15 +632,6 @@ void Curl_disconnect(struct Curl_easy *data,
   DEBUGF(infof(data, "Curl_disconnect(conn #%"
          CURL_FORMAT_CURL_OFF_T ", aborted=%d)",
          conn->connection_id, aborted));
-
-  /*
-   * If this connection is not marked to force-close, leave it open if there
-   * are other users of it
-   */
-  if(CONN_INUSE(conn) && !aborted) {
-    DEBUGF(infof(data, "Curl_disconnect when inuse: %zu", CONN_INUSE(conn)));
-    return;
-  }
 
   if(conn->dns_entry)
     Curl_resolv_unlink(data, &conn->dns_entry);
@@ -654,30 +646,28 @@ void Curl_disconnect(struct Curl_easy *data,
     /* treat the connection as aborted in CONNECT_ONLY situations */
     aborted = TRUE;
 
-  Curl_conncache_disconnect(data, conn, aborted);
+  return aborted;
 }
 
 /*
- * IsMultiplexingPossible()
+ * Curl_xfer_may_multiplex()
  *
- * Return a bitmask with the available multiplexing options for the given
- * requested connection.
+ * Return a TRUE, iff the transfer can be done over an (appropriate)
+ * multiplexed connection.
  */
-static int IsMultiplexingPossible(const struct Curl_easy *handle,
-                                  const struct connectdata *conn)
+static bool Curl_xfer_may_multiplex(const struct Curl_easy *data,
+                                    const struct connectdata *conn)
 {
-  int avail = 0;
-
   /* If an HTTP protocol and multiplexing is enabled */
   if((conn->handler->protocol & PROTO_FAMILY_HTTP) &&
      (!conn->bits.protoconnstart || !conn->bits.close)) {
 
-    if(Curl_multiplex_wanted(handle->multi) &&
-       (handle->state.httpwant >= CURL_HTTP_VERSION_2))
-      /* allows HTTP/2 */
-      avail |= CURLPIPE_MULTIPLEX;
+    if(Curl_multiplex_wanted(data->multi) &&
+       (data->state.httpwant >= CURL_HTTP_VERSION_2))
+      /* allows HTTP/2 or newer */
+      return TRUE;
   }
-  return avail;
+  return FALSE;
 }
 
 #ifndef CURL_DISABLE_PROXY
@@ -751,23 +741,24 @@ static bool conn_maxage(struct Curl_easy *data,
 }
 
 /*
- * This function checks if the given connection is dead and prunes it from
- * the connection cache if so.
- *
- * When this is called as a Curl_conncache_foreach() callback, the connection
- * cache lock is held!
- *
- * Returns TRUE if the connection was dead and pruned.
+ * Return TRUE iff the given connection is considered dead.
  */
-static bool prune_if_dead(struct connectdata *conn,
-                          struct Curl_easy *data)
+bool Curl_conn_seems_dead(struct connectdata *conn,
+                          struct Curl_easy *data,
+                          struct curltime *pnow)
 {
+  DEBUGASSERT(!data->conn);
   if(!CONN_INUSE(conn)) {
     /* The check for a dead socket makes sense only if the connection is not in
        use */
     bool dead;
-    struct curltime now = Curl_now();
-    if(conn_maxage(data, conn, now)) {
+    struct curltime now;
+    if(!pnow) {
+      now = Curl_now();
+      pnow = &now;
+    }
+
+    if(conn_maxage(data, conn, *pnow)) {
       /* avoid check if already too old */
       dead = TRUE;
     }
@@ -807,64 +798,40 @@ static bool prune_if_dead(struct connectdata *conn,
     }
 
     if(dead) {
-      /* remove connection from cache */
+      /* remove connection from cpool */
       infof(data, "Connection %" CURL_FORMAT_CURL_OFF_T " seems to be dead",
             conn->connection_id);
-      Curl_conncache_remove_conn(data, conn, FALSE);
       return TRUE;
     }
   }
   return FALSE;
 }
 
-/*
- * Wrapper to use prune_if_dead() function in Curl_conncache_foreach()
- *
- */
-static int call_prune_if_dead(struct Curl_easy *data,
-                              struct connectdata *conn, void *param)
+CURLcode Curl_conn_upkeep(struct Curl_easy *data,
+                          struct connectdata *conn,
+                          struct curltime *now)
 {
-  struct connectdata **pruned = (struct connectdata **)param;
-  if(prune_if_dead(conn, data)) {
-    /* stop the iteration here, pass back the connection that was pruned */
-    *pruned = conn;
-    return 1;
+  CURLcode result = CURLE_OK;
+  if(Curl_timediff(*now, conn->keepalive) <= data->set.upkeep_interval_ms)
+    return result;
+
+  /* briefly attach for action */
+  Curl_attach_connection(data, conn);
+  if(conn->handler->connection_check) {
+    /* Do a protocol-specific keepalive check on the connection. */
+    unsigned int rc;
+    rc = conn->handler->connection_check(data, conn, CONNCHECK_KEEPALIVE);
+    if(rc & CONNRESULT_DEAD)
+      result = CURLE_RECV_ERROR;
   }
-  return 0; /* continue iteration */
-}
-
-/*
- * This function scans the connection cache for half-open/dead connections,
- * closes and removes them. The cleanup is done at most once per second.
- *
- * When called, this transfer has no connection attached.
- */
-static void prune_dead_connections(struct Curl_easy *data)
-{
-  struct curltime now = Curl_now();
-  timediff_t elapsed;
-
-  DEBUGASSERT(!data->conn); /* no connection */
-  CONNCACHE_LOCK(data);
-  elapsed =
-    Curl_timediff(now, data->state.conn_cache->last_cleanup);
-  CONNCACHE_UNLOCK(data);
-
-  if(elapsed >= 1000L) {
-    struct connectdata *pruned = NULL;
-    while(Curl_conncache_foreach(data, data->state.conn_cache, &pruned,
-                                 call_prune_if_dead)) {
-      /* unlocked */
-
-      /* connection previously removed from cache in prune_if_dead() */
-
-      /* disconnect it, do not treat as aborted */
-      Curl_disconnect(data, pruned, FALSE);
-    }
-    CONNCACHE_LOCK(data);
-    data->state.conn_cache->last_cleanup = now;
-    CONNCACHE_UNLOCK(data);
+  else {
+    /* Do the generic action on the FIRSTSOCKET filter chain */
+    result = Curl_conn_keep_alive(data, conn, FIRSTSOCKET);
   }
+  Curl_detach_connection(data);
+
+  conn->keepalive = *now;
+  return result;
 }
 
 #ifdef USE_SSH
@@ -877,6 +844,358 @@ static bool ssh_config_matches(struct connectdata *one,
 #else
 #define ssh_config_matches(x,y) FALSE
 #endif
+
+struct url_conn_match {
+  struct connectdata *found;
+  struct Curl_easy *data;
+  struct connectdata *needle;
+  BIT(may_multiplex);
+  BIT(want_ntlm_http);
+  BIT(want_proxy_ntlm_http);
+
+  BIT(wait_pipe);
+  BIT(force_reuse);
+  BIT(seen_pending_candidate);
+};
+
+static bool url_match_conn(struct connectdata *conn, void *userdata)
+{
+  struct url_conn_match *match = userdata;
+  struct Curl_easy *data = match->data;
+  struct connectdata *needle = match->needle;
+
+  /* Check if `conn` can be used for transfer `data` */
+
+  if(conn->connect_only || conn->bits.close)
+    /* connect-only or to-be-closed connections will not be reused */
+    return FALSE;
+
+  if(data->set.ipver != CURL_IPRESOLVE_WHATEVER
+     && data->set.ipver != conn->ip_version) {
+    /* skip because the connection is not via the requested IP version */
+    return FALSE;
+  }
+
+  if(needle->localdev || needle->localport) {
+    /* If we are bound to a specific local end (IP+port), we must not
+       reuse a random other one, although if we did not ask for a
+       particular one we can reuse one that was bound.
+
+       This comparison is a bit rough and too strict. Since the input
+       parameters can be specified in numerous ways and still end up the
+       same it would take a lot of processing to make it really accurate.
+       Instead, this matching will assume that reuses of bound connections
+       will most likely also reuse the exact same binding parameters and
+       missing out a few edge cases should not hurt anyone very much.
+    */
+    if((conn->localport != needle->localport) ||
+       (conn->localportrange != needle->localportrange) ||
+       (needle->localdev &&
+        (!conn->localdev || strcmp(conn->localdev, needle->localdev))))
+      return FALSE;
+  }
+
+  if(needle->bits.conn_to_host != conn->bits.conn_to_host)
+    /* do not mix connections that use the "connect to host" feature and
+     * connections that do not use this feature */
+    return FALSE;
+
+  if(needle->bits.conn_to_port != conn->bits.conn_to_port)
+    /* do not mix connections that use the "connect to port" feature and
+     * connections that do not use this feature */
+    return FALSE;
+
+  if(!Curl_conn_is_connected(conn, FIRSTSOCKET)) {
+    if(match->may_multiplex) {
+      match->seen_pending_candidate = TRUE;
+      /* Do not pick a connection that has not connected yet */
+      infof(data, "Connection #%" CURL_FORMAT_CURL_OFF_T
+            " is not open enough, cannot reuse", conn->connection_id);
+    }
+    /* Do not pick a connection that has not connected yet */
+    return FALSE;
+  }
+  /* `conn` is connected. If it has transfers, can we add ours to it? */
+
+  if(CONN_INUSE(conn)) {
+    if(!conn->bits.multiplex)
+      /* conn busy and conn cannot take more transfers */
+      return FALSE;
+    if(!match->may_multiplex)
+      /* conn busy and transfer cannot be multiplexed */
+      return FALSE;
+    else {
+      /* transfer and conn multiplex. Are they on the same multi? */
+      struct Curl_llist_node *e = Curl_llist_head(&conn->easyq);
+      struct Curl_easy *entry = Curl_node_elem(e);
+      if(entry->multi != data->multi)
+        return FALSE;
+    }
+  }
+  /* `conn` is connected and we could add the transfer to it, if
+   * all the other criteria do match. */
+
+  /* Does `conn` use the correct protocol? */
+#ifdef USE_UNIX_SOCKETS
+  if(needle->unix_domain_socket) {
+    if(!conn->unix_domain_socket)
+      return FALSE;
+    if(strcmp(needle->unix_domain_socket, conn->unix_domain_socket))
+      return FALSE;
+    if(needle->bits.abstract_unix_socket != conn->bits.abstract_unix_socket)
+      return FALSE;
+  }
+  else if(conn->unix_domain_socket)
+    return FALSE;
+#endif
+
+  if((needle->handler->flags&PROTOPT_SSL) !=
+     (conn->handler->flags&PROTOPT_SSL))
+    /* do not do mixed SSL and non-SSL connections */
+    if(get_protocol_family(conn->handler) !=
+       needle->handler->protocol || !conn->bits.tls_upgraded)
+      /* except protocols that have been upgraded via TLS */
+      return FALSE;
+
+#ifndef CURL_DISABLE_PROXY
+  if(needle->bits.httpproxy != conn->bits.httpproxy ||
+     needle->bits.socksproxy != conn->bits.socksproxy)
+    return FALSE;
+
+  if(needle->bits.socksproxy &&
+    !socks_proxy_info_matches(&needle->socks_proxy,
+                              &conn->socks_proxy))
+    return FALSE;
+
+  if(needle->bits.httpproxy) {
+    if(needle->bits.tunnel_proxy != conn->bits.tunnel_proxy)
+      return FALSE;
+
+    if(!proxy_info_matches(&needle->http_proxy, &conn->http_proxy))
+      return FALSE;
+
+    if(IS_HTTPS_PROXY(needle->http_proxy.proxytype)) {
+      /* https proxies come in different types, http/1.1, h2, ... */
+      if(needle->http_proxy.proxytype != conn->http_proxy.proxytype)
+        return FALSE;
+      /* match SSL config to proxy */
+      if(!Curl_ssl_conn_config_match(data, conn, TRUE)) {
+        DEBUGF(infof(data,
+          "Connection #%" CURL_FORMAT_CURL_OFF_T
+          " has different SSL proxy parameters, cannot reuse",
+          conn->connection_id));
+        return FALSE;
+      }
+      /* the SSL config to the server, which may apply here is checked
+       * further below */
+    }
+  }
+#endif
+
+  if(match->may_multiplex &&
+     (data->state.httpwant == CURL_HTTP_VERSION_2_0) &&
+     (needle->handler->protocol & CURLPROTO_HTTP) &&
+     !conn->httpversion) {
+    if(data->set.pipewait) {
+      infof(data, "Server upgrade does not support multiplex yet, wait");
+      match->found = NULL;
+      match->wait_pipe = TRUE;
+      return TRUE; /* stop searching, we want to wait */
+    }
+    infof(data, "Server upgrade cannot be used");
+    return FALSE;
+  }
+
+  if(!(needle->handler->flags & PROTOPT_CREDSPERREQUEST)) {
+    /* This protocol requires credentials per connection,
+       so verify that we are using the same name and password as well */
+    if(Curl_timestrcmp(needle->user, conn->user) ||
+       Curl_timestrcmp(needle->passwd, conn->passwd) ||
+       Curl_timestrcmp(needle->sasl_authzid, conn->sasl_authzid) ||
+       Curl_timestrcmp(needle->oauth_bearer, conn->oauth_bearer)) {
+      /* one of them was different */
+      return FALSE;
+    }
+  }
+
+  /* GSS delegation differences do not actually affect every connection
+     and auth method, but this check takes precaution before efficiency */
+  if(needle->gssapi_delegation != conn->gssapi_delegation)
+    return FALSE;
+
+  /* If looking for HTTP and the HTTP version we want is less
+   * than the HTTP version of conn, continue looking */
+  if((needle->handler->protocol & PROTO_FAMILY_HTTP) &&
+     (((conn->httpversion >= 20) &&
+       (data->state.httpwant < CURL_HTTP_VERSION_2_0))
+      || ((conn->httpversion >= 30) &&
+          (data->state.httpwant < CURL_HTTP_VERSION_3))))
+    return FALSE;
+#ifdef USE_SSH
+  else if(get_protocol_family(needle->handler) & PROTO_FAMILY_SSH) {
+    if(!ssh_config_matches(needle, conn))
+      return FALSE;
+  }
+#endif
+#ifndef CURL_DISABLE_FTP
+  else if(get_protocol_family(needle->handler) & PROTO_FAMILY_FTP) {
+    /* Also match ACCOUNT, ALTERNATIVE-TO-USER, USE_SSL and CCC options */
+    if(Curl_timestrcmp(needle->proto.ftpc.account,
+                       conn->proto.ftpc.account) ||
+       Curl_timestrcmp(needle->proto.ftpc.alternative_to_user,
+                       conn->proto.ftpc.alternative_to_user) ||
+       (needle->proto.ftpc.use_ssl != conn->proto.ftpc.use_ssl) ||
+       (needle->proto.ftpc.ccc != conn->proto.ftpc.ccc))
+      return FALSE;
+  }
+#endif
+
+  /* Additional match requirements if talking TLS OR
+   * not talking to an HTTP proxy OR using a tunnel through a proxy */
+  if((needle->handler->flags&PROTOPT_SSL)
+#ifndef CURL_DISABLE_PROXY
+     || !needle->bits.httpproxy || needle->bits.tunnel_proxy
+#endif
+    ) {
+    /* Talking the same protocol scheme or a TLS upgraded protocol in the
+     * same protocol family? */
+    if(!strcasecompare(needle->handler->scheme, conn->handler->scheme) &&
+       (get_protocol_family(conn->handler) !=
+        needle->handler->protocol || !conn->bits.tls_upgraded))
+      return FALSE;
+
+    /* If needle has "conn_to_*" set, conn must match this */
+    if((needle->bits.conn_to_host && !strcasecompare(
+        needle->conn_to_host.name, conn->conn_to_host.name)) ||
+       (needle->bits.conn_to_port &&
+         needle->conn_to_port != conn->conn_to_port))
+      return FALSE;
+
+    /* hostname and port must match */
+    if(!strcasecompare(needle->host.name, conn->host.name) ||
+       needle->remote_port != conn->remote_port)
+      return FALSE;
+
+    /* If talking TLS, conn needs to use the same SSL options. */
+    if((needle->handler->flags & PROTOPT_SSL) &&
+       !Curl_ssl_conn_config_match(data, conn, FALSE)) {
+      DEBUGF(infof(data,
+                   "Connection #%" CURL_FORMAT_CURL_OFF_T
+                   " has different SSL parameters, cannot reuse",
+                   conn->connection_id));
+      return FALSE;
+    }
+  }
+
+#if defined(USE_NTLM)
+  /* If we are looking for an HTTP+NTLM connection, check if this is
+     already authenticating with the right credentials. If not, keep
+     looking so that we can reuse NTLM connections if
+     possible. (Especially we must not reuse the same connection if
+     partway through a handshake!) */
+  if(match->want_ntlm_http) {
+    if(Curl_timestrcmp(needle->user, conn->user) ||
+       Curl_timestrcmp(needle->passwd, conn->passwd)) {
+
+      /* we prefer a credential match, but this is at least a connection
+         that can be reused and "upgraded" to NTLM */
+      if(conn->http_ntlm_state == NTLMSTATE_NONE)
+        match->found = conn;
+      return FALSE;
+    }
+  }
+  else if(conn->http_ntlm_state != NTLMSTATE_NONE) {
+    /* Connection is using NTLM auth but we do not want NTLM */
+    return FALSE;
+  }
+
+#ifndef CURL_DISABLE_PROXY
+  /* Same for Proxy NTLM authentication */
+  if(match->want_proxy_ntlm_http) {
+    /* Both conn->http_proxy.user and conn->http_proxy.passwd can be
+     * NULL */
+    if(!conn->http_proxy.user || !conn->http_proxy.passwd)
+      return FALSE;
+
+    if(Curl_timestrcmp(needle->http_proxy.user,
+                       conn->http_proxy.user) ||
+       Curl_timestrcmp(needle->http_proxy.passwd,
+                       conn->http_proxy.passwd))
+      return FALSE;
+  }
+  else if(conn->proxy_ntlm_state != NTLMSTATE_NONE) {
+    /* Proxy connection is using NTLM auth but we do not want NTLM */
+    return FALSE;
+  }
+#endif
+  if(match->want_ntlm_http || match->want_proxy_ntlm_http) {
+    /* Credentials are already checked, we may use this connection.
+     * With NTLM being weird as it is, we MUST use a
+     * connection where it has already been fully negotiated.
+     * If it has not, we keep on looking for a better one. */
+    match->found = conn;
+
+    if((match->want_ntlm_http &&
+       (conn->http_ntlm_state != NTLMSTATE_NONE)) ||
+        (match->want_proxy_ntlm_http &&
+         (conn->proxy_ntlm_state != NTLMSTATE_NONE))) {
+      /* We must use this connection, no other */
+      match->force_reuse = TRUE;
+      return TRUE;
+    }
+    /* Continue look up for a better connection */
+    return FALSE;
+  }
+#endif
+
+  if(CONN_INUSE(conn)) {
+    DEBUGASSERT(match->may_multiplex);
+    DEBUGASSERT(conn->bits.multiplex);
+    /* If multiplexed, make sure we do not go over concurrency limit */
+    if(CONN_INUSE(conn) >=
+            Curl_multi_max_concurrent_streams(data->multi)) {
+      infof(data, "client side MAX_CONCURRENT_STREAMS reached"
+            ", skip (%zu)", CONN_INUSE(conn));
+      return FALSE;
+    }
+    if(CONN_INUSE(conn) >=
+            Curl_conn_get_max_concurrent(data, conn, FIRSTSOCKET)) {
+      infof(data, "MAX_CONCURRENT_STREAMS reached, skip (%zu)",
+            CONN_INUSE(conn));
+      return FALSE;
+    }
+    /* When not multiplexed, we have a match here! */
+    infof(data, "Multiplexed connection found");
+  }
+  else if(Curl_conn_seems_dead(conn, data, NULL)) {
+    /* removed and disconnect. Do not treat as aborted. */
+    Curl_cpool_disconnect(data, conn, FALSE);
+    return FALSE;
+  }
+
+  /* We have found a connection. Let's stop searching. */
+  match->found = conn;
+  return TRUE;
+}
+
+static bool url_match_result(bool result, void *userdata)
+{
+  struct url_conn_match *match = userdata;
+  (void)result;
+  if(match->found) {
+    /* Attach it now while still under lock, so the connection does
+     * no longer appear idle and can be reaped. */
+    Curl_attach_connection(match->data, match->found);
+    return TRUE;
+  }
+  else if(match->seen_pending_candidate && match->data->set.pipewait) {
+    infof(match->data,
+          "Found pending candidate for reuse and CURLOPT_PIPEWAIT is set");
+    match->wait_pipe = TRUE;
+  }
+  match->force_reuse = FALSE;
+  return FALSE;
+}
 
 /*
  * Given one filled in connection struct (named needle), this function should
@@ -896,407 +1215,36 @@ ConnectionExists(struct Curl_easy *data,
                  bool *force_reuse,
                  bool *waitpipe)
 {
-  struct connectdata *chosen = NULL;
-  bool foundPendingCandidate = FALSE;
-  bool canmultiplex = FALSE;
-  struct connectbundle *bundle;
-  struct Curl_llist_node *curr;
+  struct url_conn_match match;
+  bool result;
+
+  memset(&match, 0, sizeof(match));
+  match.data = data;
+  match.needle = needle;
+  match.may_multiplex = Curl_xfer_may_multiplex(data, needle);
 
 #ifdef USE_NTLM
-  bool wantNTLMhttp = ((data->state.authhost.want & CURLAUTH_NTLM) &&
-                       (needle->handler->protocol & PROTO_FAMILY_HTTP));
+  match.want_ntlm_http = ((data->state.authhost.want & CURLAUTH_NTLM) &&
+                          (needle->handler->protocol & PROTO_FAMILY_HTTP));
 #ifndef CURL_DISABLE_PROXY
-  bool wantProxyNTLMhttp = (needle->bits.proxy_user_passwd &&
-                            ((data->state.authproxy.want &
-                              CURLAUTH_NTLM) &&
-                             (needle->handler->protocol & PROTO_FAMILY_HTTP)));
-#else
-  bool wantProxyNTLMhttp = FALSE;
+  match.want_proxy_ntlm_http =
+    (needle->bits.proxy_user_passwd &&
+     (data->state.authproxy.want & CURLAUTH_NTLM) &&
+     (needle->handler->protocol & PROTO_FAMILY_HTTP));
 #endif
 #endif
-  /* plain HTTP with upgrade */
-  bool h2upgrade = (data->state.httpwant == CURL_HTTP_VERSION_2_0) &&
-    (needle->handler->protocol & CURLPROTO_HTTP);
 
-  *usethis = NULL;
-  *force_reuse = FALSE;
-  *waitpipe = FALSE;
+  /* Find a connection in the pool that matches what "data + needle"
+   * requires. If a suitable candidate is found, it is attached to "data". */
+  result = Curl_cpool_find(data, needle->destination, needle->destination_len,
+                           url_match_conn, url_match_result, &match);
 
-  /* Look up the bundle with all the connections to this particular host.
-     Locks the connection cache, beware of early returns! */
-  bundle = Curl_conncache_find_bundle(data, needle, data->state.conn_cache);
-  if(!bundle) {
-    CONNCACHE_UNLOCK(data);
-    return FALSE;
-  }
-  infof(data, "Found bundle for host: %p [%s]",
-        (void *)bundle, (bundle->multiuse == BUNDLE_MULTIPLEX ?
-                         "can multiplex" : "serially"));
-
-  /* We can only multiplex iff the transfer allows it AND we know
-   * that the server we want to talk to supports it as well. */
-  canmultiplex = FALSE;
-  if(IsMultiplexingPossible(data, needle)) {
-    if(bundle->multiuse == BUNDLE_UNKNOWN) {
-      if(data->set.pipewait) {
-        infof(data, "Server does not support multiplex yet, wait");
-        *waitpipe = TRUE;
-        CONNCACHE_UNLOCK(data);
-        return FALSE; /* no reuse */
-      }
-      infof(data, "Server does not support multiplex (yet)");
-    }
-    else if(bundle->multiuse == BUNDLE_MULTIPLEX) {
-      if(Curl_multiplex_wanted(data->multi))
-        canmultiplex = TRUE;
-      else
-        infof(data, "Could multiplex, but not asked to");
-    }
-    else if(bundle->multiuse == BUNDLE_NO_MULTIUSE) {
-      infof(data, "Can not multiplex, even if we wanted to");
-    }
-  }
-
-  curr = Curl_llist_head(&bundle->conn_list);
-  while(curr) {
-    struct connectdata *check = Curl_node_elem(curr);
-    /* Get next node now. We might remove a dead `check` connection which
-     * would invalidate `curr` as well. */
-    curr = Curl_node_next(curr);
-
-    /* Note that if we use an HTTP proxy in normal mode (no tunneling), we
-     * check connections to that proxy and not to the actual remote server.
-     */
-    if(check->connect_only || check->bits.close)
-      /* connect-only or to-be-closed connections will not be reused */
-      continue;
-
-    if(data->set.ipver != CURL_IPRESOLVE_WHATEVER
-       && data->set.ipver != check->ip_version) {
-      /* skip because the connection is not via the requested IP version */
-      continue;
-    }
-
-    if(!canmultiplex) {
-      if(Curl_resolver_asynch() &&
-         /* remote_ip[0] is NUL only if the resolving of the name has not
-            completed yet and until then we do not reuse this connection */
-         !check->primary.remote_ip[0])
-        continue;
-    }
-
-    if(CONN_INUSE(check)) {
-      if(!canmultiplex) {
-        /* transfer cannot be multiplexed and check is in use */
-        continue;
-      }
-      else {
-        /* Could multiplex, but not when check belongs to another multi */
-        struct Curl_llist_node *e = Curl_llist_head(&check->easyq);
-        struct Curl_easy *entry = Curl_node_elem(e);
-        if(entry->multi != data->multi)
-          continue;
-      }
-    }
-
-    if(!Curl_conn_is_connected(check, FIRSTSOCKET)) {
-      foundPendingCandidate = TRUE;
-      /* Do not pick a connection that has not connected yet */
-      infof(data, "Connection #%" CURL_FORMAT_CURL_OFF_T
-            " is not open enough, cannot reuse", check->connection_id);
-      continue;
-    }
-
-    /* `check` is connected. if it is in use and does not support multiplex,
-     * we cannot use it. */
-    if(!check->bits.multiplex && CONN_INUSE(check))
-      continue;
-
-#ifdef USE_UNIX_SOCKETS
-    if(needle->unix_domain_socket) {
-      if(!check->unix_domain_socket)
-        continue;
-      if(strcmp(needle->unix_domain_socket, check->unix_domain_socket))
-        continue;
-      if(needle->bits.abstract_unix_socket !=
-         check->bits.abstract_unix_socket)
-        continue;
-    }
-    else if(check->unix_domain_socket)
-      continue;
-#endif
-
-    if((needle->handler->flags&PROTOPT_SSL) !=
-       (check->handler->flags&PROTOPT_SSL))
-      /* do not do mixed SSL and non-SSL connections */
-      if(get_protocol_family(check->handler) !=
-         needle->handler->protocol || !check->bits.tls_upgraded)
-        /* except protocols that have been upgraded via TLS */
-        continue;
-
-    if(needle->bits.conn_to_host != check->bits.conn_to_host)
-      /* do not mix connections that use the "connect to host" feature and
-       * connections that do not use this feature */
-      continue;
-
-    if(needle->bits.conn_to_port != check->bits.conn_to_port)
-      /* do not mix connections that use the "connect to port" feature and
-       * connections that do not use this feature */
-      continue;
-
-#ifndef CURL_DISABLE_PROXY
-    if(needle->bits.httpproxy != check->bits.httpproxy ||
-       needle->bits.socksproxy != check->bits.socksproxy)
-      continue;
-
-    if(needle->bits.socksproxy &&
-      !socks_proxy_info_matches(&needle->socks_proxy,
-                                &check->socks_proxy))
-      continue;
-
-    if(needle->bits.httpproxy) {
-      if(needle->bits.tunnel_proxy != check->bits.tunnel_proxy)
-        continue;
-
-      if(!proxy_info_matches(&needle->http_proxy, &check->http_proxy))
-        continue;
-
-      if(IS_HTTPS_PROXY(needle->http_proxy.proxytype)) {
-        /* https proxies come in different types, http/1.1, h2, ... */
-        if(needle->http_proxy.proxytype != check->http_proxy.proxytype)
-          continue;
-        /* match SSL config to proxy */
-        if(!Curl_ssl_conn_config_match(data, check, TRUE)) {
-          DEBUGF(infof(data,
-            "Connection #%" CURL_FORMAT_CURL_OFF_T
-            " has different SSL proxy parameters, cannot reuse",
-            check->connection_id));
-          continue;
-        }
-        /* the SSL config to the server, which may apply here is checked
-         * further below */
-      }
-    }
-#endif
-
-    if(h2upgrade && !check->httpversion && canmultiplex) {
-      if(data->set.pipewait) {
-        infof(data, "Server upgrade does not support multiplex yet, wait");
-        *waitpipe = TRUE;
-        CONNCACHE_UNLOCK(data);
-        return FALSE; /* no reuse */
-      }
-      infof(data, "Server upgrade cannot be used");
-      continue; /* cannot be used atm */
-    }
-
-    if(needle->localdev || needle->localport) {
-      /* If we are bound to a specific local end (IP+port), we must not
-         reuse a random other one, although if we did not ask for a
-         particular one we can reuse one that was bound.
-
-         This comparison is a bit rough and too strict. Since the input
-         parameters can be specified in numerous ways and still end up the
-         same it would take a lot of processing to make it really accurate.
-         Instead, this matching will assume that reuses of bound connections
-         will most likely also reuse the exact same binding parameters and
-         missing out a few edge cases should not hurt anyone very much.
-      */
-      if((check->localport != needle->localport) ||
-         (check->localportrange != needle->localportrange) ||
-         (needle->localdev &&
-          (!check->localdev || strcmp(check->localdev, needle->localdev))))
-        continue;
-    }
-
-    if(!(needle->handler->flags & PROTOPT_CREDSPERREQUEST)) {
-      /* This protocol requires credentials per connection,
-         so verify that we are using the same name and password as well */
-      if(Curl_timestrcmp(needle->user, check->user) ||
-         Curl_timestrcmp(needle->passwd, check->passwd) ||
-         Curl_timestrcmp(needle->sasl_authzid, check->sasl_authzid) ||
-         Curl_timestrcmp(needle->oauth_bearer, check->oauth_bearer)) {
-        /* one of them was different */
-        continue;
-      }
-    }
-
-    /* GSS delegation differences do not actually affect every connection
-       and auth method, but this check takes precaution before efficiency */
-    if(needle->gssapi_delegation != check->gssapi_delegation)
-      continue;
-
-    /* If looking for HTTP and the HTTP version  we want is less
-     * than the HTTP version of the check connection, continue looking */
-    if((needle->handler->protocol & PROTO_FAMILY_HTTP) &&
-       (((check->httpversion >= 20) &&
-         (data->state.httpwant < CURL_HTTP_VERSION_2_0))
-        || ((check->httpversion >= 30) &&
-            (data->state.httpwant < CURL_HTTP_VERSION_3))))
-      continue;
-#ifdef USE_SSH
-    else if(get_protocol_family(needle->handler) & PROTO_FAMILY_SSH) {
-      if(!ssh_config_matches(needle, check))
-        continue;
-    }
-#endif
-#ifndef CURL_DISABLE_FTP
-    else if(get_protocol_family(needle->handler) & PROTO_FAMILY_FTP) {
-      /* Also match ACCOUNT, ALTERNATIVE-TO-USER, USE_SSL and CCC options */
-      if(Curl_timestrcmp(needle->proto.ftpc.account,
-                         check->proto.ftpc.account) ||
-         Curl_timestrcmp(needle->proto.ftpc.alternative_to_user,
-                         check->proto.ftpc.alternative_to_user) ||
-         (needle->proto.ftpc.use_ssl != check->proto.ftpc.use_ssl) ||
-         (needle->proto.ftpc.ccc != check->proto.ftpc.ccc))
-        continue;
-    }
-#endif
-
-    /* Additional match requirements if talking TLS OR
-     * not talking to an HTTP proxy OR using a tunnel through a proxy */
-    if((needle->handler->flags&PROTOPT_SSL)
-#ifndef CURL_DISABLE_PROXY
-       || !needle->bits.httpproxy || needle->bits.tunnel_proxy
-#endif
-      ) {
-      /* Talking the same protocol scheme or a TLS upgraded protocol in the
-       * same protocol family? */
-      if(!strcasecompare(needle->handler->scheme, check->handler->scheme) &&
-         (get_protocol_family(check->handler) !=
-          needle->handler->protocol || !check->bits.tls_upgraded))
-        continue;
-
-      /* If needle has "conn_to_*" set, check must match this */
-      if((needle->bits.conn_to_host && !strcasecompare(
-          needle->conn_to_host.name, check->conn_to_host.name)) ||
-         (needle->bits.conn_to_port &&
-           needle->conn_to_port != check->conn_to_port))
-        continue;
-
-      /* hostname and port must match */
-      if(!strcasecompare(needle->host.name, check->host.name) ||
-         needle->remote_port != check->remote_port)
-        continue;
-
-      /* If talking TLS, check needs to use the same SSL options. */
-      if((needle->handler->flags & PROTOPT_SSL) &&
-         !Curl_ssl_conn_config_match(data, check, FALSE)) {
-        DEBUGF(infof(data,
-                     "Connection #%" CURL_FORMAT_CURL_OFF_T
-                     " has different SSL parameters, cannot reuse",
-                     check->connection_id));
-        continue;
-      }
-    }
-
-#if defined(USE_NTLM)
-    /* If we are looking for an HTTP+NTLM connection, check if this is
-       already authenticating with the right credentials. If not, keep
-       looking so that we can reuse NTLM connections if
-       possible. (Especially we must not reuse the same connection if
-       partway through a handshake!) */
-    if(wantNTLMhttp) {
-      if(Curl_timestrcmp(needle->user, check->user) ||
-         Curl_timestrcmp(needle->passwd, check->passwd)) {
-
-        /* we prefer a credential match, but this is at least a connection
-           that can be reused and "upgraded" to NTLM */
-        if(check->http_ntlm_state == NTLMSTATE_NONE)
-          chosen = check;
-        continue;
-      }
-    }
-    else if(check->http_ntlm_state != NTLMSTATE_NONE) {
-      /* Connection is using NTLM auth but we do not want NTLM */
-      continue;
-    }
-
-#ifndef CURL_DISABLE_PROXY
-    /* Same for Proxy NTLM authentication */
-    if(wantProxyNTLMhttp) {
-      /* Both check->http_proxy.user and check->http_proxy.passwd can be
-       * NULL */
-      if(!check->http_proxy.user || !check->http_proxy.passwd)
-        continue;
-
-      if(Curl_timestrcmp(needle->http_proxy.user,
-                         check->http_proxy.user) ||
-         Curl_timestrcmp(needle->http_proxy.passwd,
-                         check->http_proxy.passwd))
-        continue;
-    }
-    else if(check->proxy_ntlm_state != NTLMSTATE_NONE) {
-      /* Proxy connection is using NTLM auth but we do not want NTLM */
-      continue;
-    }
-#endif
-    if(wantNTLMhttp || wantProxyNTLMhttp) {
-      /* Credentials are already checked, we may use this connection.
-       * With NTLM being weird as it is, we MUST use a
-       * connection where it has already been fully negotiated.
-       * If it has not, we keep on looking for a better one. */
-      chosen = check;
-
-      if((wantNTLMhttp &&
-         (check->http_ntlm_state != NTLMSTATE_NONE)) ||
-          (wantProxyNTLMhttp &&
-           (check->proxy_ntlm_state != NTLMSTATE_NONE))) {
-        /* We must use this connection, no other */
-        *force_reuse = TRUE;
-        break;
-      }
-      /* Continue look up for a better connection */
-      continue;
-    }
-#endif
-
-    if(CONN_INUSE(check)) {
-      DEBUGASSERT(canmultiplex);
-      DEBUGASSERT(check->bits.multiplex);
-      /* If multiplexed, make sure we do not go over concurrency limit */
-      if(CONN_INUSE(check) >=
-              Curl_multi_max_concurrent_streams(data->multi)) {
-        infof(data, "client side MAX_CONCURRENT_STREAMS reached"
-              ", skip (%zu)", CONN_INUSE(check));
-        continue;
-      }
-      if(CONN_INUSE(check) >=
-              Curl_conn_get_max_concurrent(data, check, FIRSTSOCKET)) {
-        infof(data, "MAX_CONCURRENT_STREAMS reached, skip (%zu)",
-              CONN_INUSE(check));
-        continue;
-      }
-      /* When not multiplexed, we have a match here! */
-      infof(data, "Multiplexed connection found");
-    }
-    else if(prune_if_dead(check, data)) {
-      /* disconnect it, do not treat as aborted */
-      Curl_disconnect(data, check, FALSE);
-      continue;
-    }
-
-    /* We have found a connection. Let's stop searching. */
-    chosen = check;
-    break;
-  } /* loop over connection bundle */
-
-  if(chosen) {
-    /* mark it as used before releasing the lock */
-    Curl_attach_connection(data, chosen);
-    CONNCACHE_UNLOCK(data);
-    *usethis = chosen;
-    return TRUE; /* yes, we found one to use! */
-  }
-  CONNCACHE_UNLOCK(data);
-
-  if(foundPendingCandidate && data->set.pipewait) {
-    infof(data,
-          "Found pending candidate for reuse and CURLOPT_PIPEWAIT is set");
-    *waitpipe = TRUE;
-  }
-
-  return FALSE; /* no matching connecting exists */
+  /* wait_pipe is TRUE if we encounter a bundle that is undecided. There
+   * is no matching connection then, yet. */
+  *usethis = match.found;
+  *force_reuse = match.force_reuse;
+  *waitpipe = match.wait_pipe;
+  return result;
 }
 
 /*
@@ -2001,6 +1949,8 @@ static CURLcode setup_connection_internals(struct Curl_easy *data,
                                            struct connectdata *conn)
 {
   const struct Curl_handler *p;
+  const char *hostname;
+  int port;
   CURLcode result;
 
   /* Perform setup complement if some. */
@@ -2019,6 +1969,34 @@ static CURLcode setup_connection_internals(struct Curl_easy *data,
     /* we check for -1 here since if proxy was detected already, this
        was very likely already set to the proxy port */
     conn->primary.remote_port = p->defport;
+
+  /* Now create the destination name */
+#ifndef CURL_DISABLE_PROXY
+  if(conn->bits.httpproxy && !conn->bits.tunnel_proxy) {
+    hostname = conn->http_proxy.host.name;
+    port = conn->primary.remote_port;
+  }
+  else
+#endif
+  {
+    port = conn->remote_port;
+    if(conn->bits.conn_to_host)
+      hostname = conn->conn_to_host.name;
+    else
+      hostname = conn->host.name;
+  }
+
+#ifdef USE_IPV6
+  conn->destination = aprintf("%u/%d/%s", conn->scope_id, port, hostname);
+#else
+  conn->destination = aprintf("%d/%s", port, hostname);
+#endif
+  if(!conn->destination)
+    return CURLE_OUT_OF_MEMORY;
+
+  conn->destination_len = strlen(conn->destination) + 1;
+  Curl_strntolower(conn->destination, conn->destination,
+                   conn->destination_len - 1);
 
   return CURLE_OK;
 }
@@ -3219,7 +3197,7 @@ static void reuse_conn(struct Curl_easy *data,
   }
 #endif
 
-  /* Finding a connection for reuse in the cache matches, among other
+  /* Finding a connection for reuse in the cpool matches, among other
    * things on the "remote-relevant" hostname. This is not necessarily
    * the authority of the URL, e.g. conn->host. For example:
    * - we use a proxy (not tunneling). we want to send all requests
@@ -3281,8 +3259,6 @@ static CURLcode create_conn(struct Curl_easy *data,
   bool connections_available = TRUE;
   bool force_reuse = FALSE;
   bool waitpipe = FALSE;
-  size_t max_host_connections = Curl_multi_max_host_connections(data->multi);
-  size_t max_total_connections = Curl_multi_max_total_connections(data->multi);
 
   *async = FALSE;
   *in_connect = NULL;
@@ -3453,7 +3429,7 @@ static CURLcode create_conn(struct Curl_easy *data,
     /* Setup a "faked" transfer that will do nothing */
     if(!result) {
       Curl_attach_connection(data, conn);
-      result = Curl_conncache_add_conn(data);
+      result = Curl_cpool_add_conn(data, conn);
       if(result)
         goto out;
 
@@ -3489,7 +3465,8 @@ static CURLcode create_conn(struct Curl_easy *data,
   if(result)
     goto out;
 
-  prune_dead_connections(data);
+  /* FIXME: do we really want to run this every time we add a transfer? */
+  Curl_cpool_prune_dead(data);
 
   /*************************************************************
    * Check the current list of connections to see if we can
@@ -3548,41 +3525,12 @@ static CURLcode create_conn(struct Curl_easy *data,
          "soon", and we wait for that */
       connections_available = FALSE;
     else {
-      /* this gets a lock on the conncache */
-      struct connectbundle *bundle =
-        Curl_conncache_find_bundle(data, conn, data->state.conn_cache);
-
-      if(max_host_connections > 0 && bundle &&
-         (bundle->num_connections >= max_host_connections)) {
-        struct connectdata *conn_candidate;
-
-        /* The bundle is full. Extract the oldest connection. */
-        conn_candidate = Curl_conncache_extract_bundle(data, bundle);
-        CONNCACHE_UNLOCK(data);
-
-        if(conn_candidate)
-          Curl_disconnect(data, conn_candidate, FALSE);
-        else {
-          infof(data, "No more connections allowed to host: %zu",
-                max_host_connections);
-          connections_available = FALSE;
-        }
-      }
-      else
-        CONNCACHE_UNLOCK(data);
-
-    }
-
-    if(connections_available &&
-       (max_total_connections > 0) &&
-       (Curl_conncache_size(data) >= max_total_connections)) {
-      struct connectdata *conn_candidate;
-
-      /* The cache is full. Let's see if we can kill a connection. */
-      conn_candidate = Curl_conncache_extract_oldest(data);
-      if(conn_candidate)
-        Curl_disconnect(data, conn_candidate, FALSE);
-      else
+      switch(Curl_cpool_check_limits(data, conn)) {
+      case CPOOL_LIMIT_DEST:
+        infof(data, "No more connections allowed to host");
+        connections_available = FALSE;
+        break;
+      case CPOOL_LIMIT_TOTAL:
 #ifndef CURL_DISABLE_DOH
         if(data->set.dohfor_mid >= 0)
           infof(data, "Allowing DoH to override max connection limit");
@@ -3592,6 +3540,10 @@ static CURLcode create_conn(struct Curl_easy *data,
           infof(data, "No connections available in cache");
           connections_available = FALSE;
         }
+        break;
+      default:
+        break;
+      }
     }
 
     if(!connections_available) {
@@ -3615,7 +3567,7 @@ static CURLcode create_conn(struct Curl_easy *data,
       }
 
       Curl_attach_connection(data, conn);
-      result = Curl_conncache_add_conn(data);
+      result = Curl_cpool_add_conn(data, conn);
       if(result)
         goto out;
     }
@@ -3755,8 +3707,7 @@ CURLcode Curl_connect(struct Curl_easy *data,
     /* We are not allowed to return failure with memory left allocated in the
        connectdata struct, free those here */
     Curl_detach_connection(data);
-    Curl_conncache_remove_conn(data, conn, TRUE);
-    Curl_disconnect(data, conn, TRUE);
+    Curl_cpool_disconnect(data, conn, TRUE);
   }
 
   return result;

--- a/lib/url.h
+++ b/lib/url.h
@@ -37,8 +37,8 @@ void Curl_freeset(struct Curl_easy *data);
 CURLcode Curl_uc_to_curlcode(CURLUcode uc);
 CURLcode Curl_close(struct Curl_easy **datap); /* opposite of curl_open() */
 CURLcode Curl_connect(struct Curl_easy *, bool *async, bool *protocol_connect);
-void Curl_disconnect(struct Curl_easy *data,
-                     struct connectdata *, bool aborted);
+bool Curl_on_disconnect(struct Curl_easy *data,
+                        struct connectdata *, bool aborted);
 CURLcode Curl_setup_conn(struct Curl_easy *data,
                          bool *protocol_done);
 void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn);
@@ -64,6 +64,21 @@ const struct Curl_handler *Curl_getn_scheme_handler(const char *scheme,
 void Curl_verboseconnect(struct Curl_easy *data, struct connectdata *conn,
                          int sockindex);
 #endif
+
+/**
+ * Return TRUE iff the given connection is considered dead.
+ * @param nowp      NULL or pointer to time being checked against.
+ */
+bool Curl_conn_seems_dead(struct connectdata *conn,
+                          struct Curl_easy *data,
+                          struct curltime *nowp);
+
+/**
+ * Perform upkeep operations on the connection.
+ */
+CURLcode Curl_conn_upkeep(struct Curl_easy *data,
+                          struct connectdata *conn,
+                          struct curltime *now);
 
 #if defined(USE_HTTP2) || defined(USE_HTTP3)
 void Curl_data_priority_clear_state(struct Curl_easy *data);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -555,6 +555,7 @@ struct ConnectBits {
   BIT(aborted); /* connection was aborted, e.g. in unclean state */
   BIT(shutdown_handler); /* connection shutdown: handler shut down */
   BIT(shutdown_filters); /* connection shutdown: filters shut down */
+  BIT(in_cpool);     /* connection is kept in a connection pool */
 };
 
 struct hostname {
@@ -802,12 +803,12 @@ struct ldapconninfo;
  * unique for an entire connection.
  */
 struct connectdata {
-  struct Curl_llist_node bundle_node; /* conncache */
+  struct Curl_llist_node cpool_node; /* conncache lists */
 
   curl_closesocket_callback fclosesocket; /* function closing the socket(s) */
   void *closesocket_client;
 
-  /* This is used by the connection cache logic. If this returns TRUE, this
+  /* This is used by the connection pool logic. If this returns TRUE, this
      handle is still used by one or more easy handles and can only used by any
      other easy handle without careful consideration (== only for
      multiplexing) and it cannot be used by another multi handle! */
@@ -816,6 +817,8 @@ struct connectdata {
   /**** Fields set when inited and not modified again */
   curl_off_t connection_id; /* Contains a unique number to make it easier to
                                track the connections in the log output */
+  char *destination; /* string carrying normalized hostname+port+scope */
+  size_t destination_len; /* strlen(destination) + 1 */
 
   /* 'dns_entry' is the particular host we use. This points to an entry in the
      DNS cache and it will not get pruned while locked. It gets unlocked in
@@ -851,7 +854,7 @@ struct connectdata {
   char *oauth_bearer; /* OAUTH2 bearer, allocated */
   struct curltime now;     /* "current" time */
   struct curltime created; /* creation time */
-  struct curltime lastused; /* when returned to the connection cache */
+  struct curltime lastused; /* when returned to the connection poolas idle */
   curl_socket_t sock[2]; /* two sockets, the second is used for the data
                             transfer when doing FTP */
   Curl_recv *recv[2];
@@ -971,7 +974,6 @@ struct connectdata {
     unsigned int unused:1; /* avoids empty union */
   } proto;
 
-  struct connectbundle *bundle; /* The bundle we are member of */
 #ifdef USE_UNIX_SOCKETS
   char *unix_domain_socket;
 #endif
@@ -1050,7 +1052,7 @@ struct PureInfo {
      even when the session handle is no longer associated with a connection,
      and also allow curl_easy_reset() to clear this information from the
      session handle without disturbing information which is still alive, and
-     that might be reused, in the connection cache. */
+     that might be reused, in the connection pool. */
   struct ip_quadruple primary;
   int conn_remote_port;  /* this is the "remote port", which is the port
                             number of the used URL, independent of proxy or
@@ -1218,8 +1220,6 @@ struct urlpieces {
 };
 
 struct UrlState {
-  /* Points to the connection cache */
-  struct conncache *conn_cache;
   /* buffers to store authentication data in, as parsed from input options */
   struct curltime keeps_speed; /* for the progress meter really */
 
@@ -1369,9 +1369,6 @@ struct UrlState {
   unsigned char select_bits; /* != 0 -> bitmask of socket events for this
                                  transfer overriding anything the socket may
                                  report */
-#ifdef DEBUGBUILD
-  BIT(conncache_lock);
-#endif
   /* when curl_easy_perform() is called, the multi handle is "owned" by
      the easy handle so curl_easy_cleanup() on such an easy handle will
      also close the multi handle! */
@@ -1907,13 +1904,13 @@ struct Curl_easy {
   /* First a simple identifier to easier detect if a user mix up this easy
      handle with a multi handle. Set this to CURLEASY_MAGIC_NUMBER */
   unsigned int magic;
-  /* once an easy handle is tied to a connection cache
+  /* once an easy handle is tied to a connection pool
      a non-negative number to distinguish this transfer from
-     other using the same cache. For easier tracking
+     other using the same pool. For easier tracking
      in log output.
      This may wrap around after LONG_MAX to 0 again, so it
      has no uniqueness guarantee for very large processings.
-     Note: it has no uniqueness either IFF more than one connection cache
+     Note: it has no uniqueness either IFF more than one connection pool
      is used by the libcurl application. */
   curl_off_t id;
   /* once an easy handle is added to a multi, either explicitly by the

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -911,7 +911,6 @@ static CURLcode cf_msh3_connect(struct Curl_cfilter *cf,
       CURL_TRC_CF(data, cf, "handshake succeeded");
       cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
       cf->conn->httpversion = 30;
-      cf->conn->bundle->multiuse = BUNDLE_MULTIPLEX;
       cf->connected = TRUE;
       cf->conn->alpn = CURL_HTTP_VERSION_3;
       *done = TRUE;

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1630,7 +1630,6 @@ static CURLcode qng_verify_peer(struct Curl_cfilter *cf,
 
   cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
   cf->conn->httpversion = 30;
-  cf->conn->bundle->multiuse = BUNDLE_MULTIPLEX;
 
   return Curl_vquic_tls_verify_peer(&ctx->tls, cf, data, &ctx->peer);
 }

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -562,7 +562,6 @@ static CURLcode cf_osslq_verify_peer(struct Curl_cfilter *cf,
 
   cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
   cf->conn->httpversion = 30;
-  cf->conn->bundle->multiuse = BUNDLE_MULTIPLEX;
 
   return Curl_vquic_tls_verify_peer(&ctx->tls, cf, data, &ctx->peer);
 }

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1380,7 +1380,6 @@ static CURLcode cf_quiche_verify_peer(struct Curl_cfilter *cf,
 
   cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
   cf->conn->httpversion = 30;
-  cf->conn->bundle->multiuse = BUNDLE_MULTIPLEX;
 
   return Curl_vquic_tls_verify_peer(&ctx->tls, cf, data, &ctx->peer);
 }

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2108,9 +2108,6 @@ check_handshake:
         else
           infof(data, VTLS_INFOF_NO_ALPN);
 
-        Curl_multiuse_state(data, cf->conn->alpn == CURL_HTTP_VERSION_2 ?
-                            BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
-
         /* chosenProtocol is a reference to the string within alpnArr
            and does not need to be freed separately */
         if(alpnArr)

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -2222,7 +2222,6 @@ CURLcode Curl_alpn_set_negotiated(struct Curl_cfilter *cf,
                                   const unsigned char *proto,
                                   size_t proto_len)
 {
-  int can_multi = 0;
   unsigned char *palpn =
 #ifndef CURL_DISABLE_PROXY
     (cf->conn->bits.tunnel_proxy && Curl_ssl_cf_is_proxy(cf))?
@@ -2241,14 +2240,12 @@ CURLcode Curl_alpn_set_negotiated(struct Curl_cfilter *cf,
     else if(proto_len == ALPN_H2_LENGTH &&
             !memcmp(ALPN_H2, proto, ALPN_H2_LENGTH)) {
       *palpn = CURL_HTTP_VERSION_2;
-      can_multi = 1;
     }
 #endif
 #ifdef USE_HTTP3
     else if(proto_len == ALPN_H3_LENGTH &&
             !memcmp(ALPN_H3, proto, ALPN_H3_LENGTH)) {
       *palpn = CURL_HTTP_VERSION_3;
-      can_multi = 1;
     }
 #endif
     else {
@@ -2267,9 +2264,6 @@ CURLcode Curl_alpn_set_negotiated(struct Curl_cfilter *cf,
   }
 
 out:
-  if(!Curl_ssl_cf_is_proxy(cf))
-    Curl_multiuse_state(data, can_multi?
-                        BUNDLE_MULTIPLEX : BUNDLE_NO_MULTIUSE);
   return CURLE_OK;
 }
 

--- a/tests/data/test1554
+++ b/tests/data/test1554
@@ -19,67 +19,57 @@ Content-Length: 29
 run 1: foobar and so on fun!
 </data>
 <datacheck>
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
+-> Mutex lock SHARE
+<- Mutex unlock SHARE
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
 run 1: foobar and so on fun!
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock SHARE
+<- Mutex unlock SHARE
+-> Mutex lock SHARE
+<- Mutex unlock SHARE
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
 run 1: foobar and so on fun!
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock SHARE
+<- Mutex unlock SHARE
+-> Mutex lock SHARE
+<- Mutex unlock SHARE
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
 run 1: foobar and so on fun!
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
--> Mutex lock
-<- Mutex unlock
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+-> Mutex lock SHARE
+<- Mutex unlock SHARE
+-> Mutex lock SHARE
+-> Mutex lock CONNECT
+<- Mutex unlock CONNECT
+<- Mutex unlock SHARE
 </datacheck>
 </reply>
 

--- a/tests/libtest/lib1554.c
+++ b/tests/libtest/lib1554.c
@@ -24,6 +24,18 @@
 #include "test.h"
 #include "memdebug.h"
 
+static const char *ldata_names[] = {
+  "NONE",
+  "SHARE",
+  "COOKIE",
+  "DNS",
+  "SESSION",
+  "CONNECT",
+  "PSL",
+  "HSTS",
+  "NULL",
+};
+
 static void my_lock(CURL *handle, curl_lock_data data,
                     curl_lock_access laccess, void *useptr)
 {
@@ -31,7 +43,7 @@ static void my_lock(CURL *handle, curl_lock_data data,
   (void)data;
   (void)laccess;
   (void)useptr;
-  printf("-> Mutex lock\n");
+  printf("-> Mutex lock %s\n", ldata_names[data]);
 }
 
 static void my_unlock(CURL *handle, curl_lock_data data, void *useptr)
@@ -39,7 +51,7 @@ static void my_unlock(CURL *handle, curl_lock_data data, void *useptr)
   (void)handle;
   (void)data;
   (void)useptr;
-  printf("<- Mutex unlock\n");
+  printf("<- Mutex unlock %s\n", ldata_names[data]);
 }
 
 /* test function */


### PR DESCRIPTION
## Connection Pools

Rename "connection cache/conncache" to "Connection Pools/cpool" in source. This is a better match for what they do and the general "cpool" var/function prefix works well.

### Functional Changes

The pool now handles very long hostnames correctly. 

`conn->bundle->multiuse` is no more. It was used to detect if a destination (host+port) supports HTTP/2 and can "multiplex" transfers. With HTTP/3, this is no longer the right thing to do. A destination may talk HTTP/1.1 on port 443 *and* support HTTP/3 there as well.

### Implementation Changes

The following changes have been made:

* 'struct connectdata', e.g. connections, keep new members named `destination` and ' destination_len' that fully specifies interface+port+hostname of where the connection is going to. This is used in the pool for "bundling" of connections with the same destination. There is no limit on the length any more.
* Locking: all locks are done inside conncache.c when calling into the pool and released on return. This eliminates hazards of the callers keeping track.
* 'struct connectbundle' is now internal to the pool. It is no longer referenced by a connection.
* 'bundle->multiuse' no longer exists. HTTP/2 and 3 and TLS filters no longer need to set it. Instead, the multi checks on leaving MSTATE_CONNECT or MSTATE_CONNECTING if the connection is now multiplexed and new, e.g. not conn->bits.reuse. In that case the processing of pending handles is triggered.
* The pool's init is provided with a callback to invoke on all connections being discarded. This allows the cleanups in `Curl_disconnect` to run, wherever it is decided to retire a connection.
* Several pool operations can now be fully done with one call. Pruning dead connections, upkeep and checks on pool limits can now directly discard connections and need no longer return those to the caller for doing that (as we have now the callback described above).
* Finding a connection for reuse is now done via `Curl_cpool_find()` and the caller provides callbacks to evaluate the connection candidates.
* The 'Curl_cpool_check_limits()' now directly uses the max values that may be set in the transfer's multi. No need to pass them around. Curl_multi_max_host_connections() and Curl_multi_max_total_connections() are gone.
* Add method 'Curl_node_llist()' to get the llist a node is in. Used in cpool to verify connection are indeed in the list (or not in any list) as they need to.

### Follow Ups

I left the conncache.[ch] as is for now and also did not touch the documentation. If we update that outside the feature window, we can do this in a separate PR.

Multi-thread safety is not achieved by this PR, but since more details on how pools operate are now "internal" it is a better starting point to go for this in the future. To have safe multi-thread use, one would need to split the INUSE connections from the idle ones, for example. With only the idle in a pool that can be shared. Etc. etc.

**Update**: added support for what formerly `BUNDLE_NO_MULTIUSE` tried to achieve. When the destination search for a reusable connection sees a single-use, busy connection and no multiplexed ones, it seems better to not wait for any pending connection. The server probably will not suddenly negotiate multiplexing on the next one.