### PR TITLE
README: refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: curl
 Curl is a command-line tool for transferring data specified with URL syntax.
 Learn how to use curl by reading [the
 manpage](https://curl.se/docs/manpage.html) or [everything
-curl](https://everything-curl.dev/).
+curl](https://everything.curl.dev/).
 
 Find out how to install curl by reading [the INSTALL
 document](https://curl.se/docs/install.html).

--- a/README.md
+++ b/README.md
@@ -6,26 +6,29 @@ SPDX-License-Identifier: curl
 
 # [![curl logo](https://curl.se/logo/curl-logo.svg)](https://curl.se/)
 
-Curl is a command-line tool for transferring data specified with URL
-syntax. Find out how to use curl by reading [the curl.1 man
-page](https://curl.se/docs/manpage.html) or [the MANUAL
-document](https://curl.se/docs/manual.html). Find out how to install Curl
-by reading [the INSTALL document](https://curl.se/docs/install.html).
+Curl is a command-line tool for transferring data specified with URL syntax.
+Learn how to use curl by reading [the
+manpage](https://curl.se/docs/manpage.html) or [everything
+curl](https://everything-curl.dev/).
+
+Find out how to install curl by reading [the INSTALL
+document](https://curl.se/docs/install.html).
 
 libcurl is the library curl is using to do its job. It is readily available to
-be used by your software. Read [the libcurl.3 man
-page](https://curl.se/libcurl/c/libcurl.html) to learn how.
+be used by your software. Read [the libcurl
+manpage](https://curl.se/libcurl/c/libcurl.html) to learn how.
 
-You can find answers to the most frequent questions we get in [the FAQ
-document](https://curl.se/docs/faq.html).
+## Open Source
 
-Study [the COPYING file](https://curl.se/docs/copyright.html) for
-distribution terms.
+curl is Open Source and distributed under an MIT-like
+[license](https://curl.se/docs/copyright.html).
 
 ## Contact
 
-If you have problems, questions, ideas or suggestions, please contact us by
-posting to a suitable [mailing list](https://curl.se/mail/).
+Contact us on a suitable [mailing list](https://curl.se/mail/) or
+use GitHub [issues](https://github.com/curl/curl/issues)/
+[pull requests](https://github.com/curl/curl/pulls)/
+[discussions](https://github.com/curl/curl/discussions).
 
 All contributors to the project are listed in [the THANKS
 document](https://curl.se/docs/thanks.html).
@@ -37,16 +40,13 @@ applications using (lib)curl visit [the support page](https://curl.se/support.ht
 
 ## Website
 
-Visit the [curl website](https://curl.se/) for the latest news and
-downloads.
+Visit the [curl website](https://curl.se/) for the latest news and downloads.
 
-## Git
+## Source code
 
-To download the latest source from the Git server, do this:
+Download the latest source from the Git server:
 
     git clone https://github.com/curl/curl.git
-
-(you will get a directory named curl created, filled with the source code)
 
 ## Security problems
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ manpage](https://curl.se/libcurl/c/libcurl.html) to learn how.
 
 ## Open Source
 
-curl is Open Source and distributed under an MIT-like
+curl is Open Source and is distributed under an MIT-like
 [license](https://curl.se/docs/copyright.html).
 
 ## Contact


### PR DESCRIPTION
- call them "manpages", not "man pages" and drop the .1 and .3
- replace link to "manual" with a link to everything curl
- remove the link to the FAQ
- add a new "open source "subtitle for the license link, and rephrase
- mention and link GitHub services in the contact section
- rename the "git" subtitle to "source code"
- shorten the source code section somewhat