### PR TITLE
lib, src: delete stray `curl_` prefix from printf calls

### DIFF
--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1680,7 +1680,7 @@ CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...)
   va_list ap;
 
   va_start(ap, fmt);
-  s = curl_mvaprintf(fmt, ap);
+  s = vaprintf(fmt, ap);
   va_end(ap);
 
   if(s) {

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -324,7 +324,7 @@ int Curl_parsenetrc(const char *host, char **loginp, char **passwordp,
       return retcode; /* no home directory found (or possibly out of
                          memory) */
 
-    filealloc = curl_maprintf("%s%s.netrc", home, DIR_CHAR);
+    filealloc = aprintf("%s%s.netrc", home, DIR_CHAR);
     if(!filealloc) {
       free(homea);
       return -1;
@@ -334,7 +334,7 @@ int Curl_parsenetrc(const char *host, char **loginp, char **passwordp,
 #ifdef _WIN32
     if(retcode == NETRC_FILE_MISSING) {
       /* fallback to the old-style "_netrc" file */
-      filealloc = curl_maprintf("%s%s_netrc", home, DIR_CHAR);
+      filealloc = aprintf("%s%s_netrc", home, DIR_CHAR);
       if(!filealloc) {
         free(homea);
         return -1;

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -96,7 +96,7 @@ bool tool_create_output_file(struct OutStruct *outs,
             (errno == EEXIST || errno == EISDIR) &&
             /* because we keep having files that already exist */
             next_num < 100 /* and we have not reached the retry limit */ ) {
-        snprintf(newname + len + 1, 12, "%d", next_num);
+        msnprintf(newname + len + 1, 12, "%d", next_num);
         next_num++;
         do {
           fd = open(newname, O_CREAT | O_WRONLY | O_EXCL | O_BINARY, OPENMODE);

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -96,7 +96,7 @@ bool tool_create_output_file(struct OutStruct *outs,
             (errno == EEXIST || errno == EISDIR) &&
             /* because we keep having files that already exist */
             next_num < 100 /* and we have not reached the retry limit */ ) {
-        curl_msnprintf(newname + len + 1, 12, "%d", next_num);
+        snprintf(newname + len + 1, 12, "%d", next_num);
         next_num++;
         do {
           fd = open(newname, O_CREAT | O_WRONLY | O_EXCL | O_BINARY, OPENMODE);

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -111,7 +111,7 @@ CURLcode easysrc_addf(struct slist_wc **plist, const char *fmt, ...)
   char *bufp;
   va_list ap;
   va_start(ap, fmt);
-  bufp = curl_mvaprintf(fmt, ap);
+  bufp = vaprintf(fmt, ap);
   va_end(ap);
   if(!bufp) {
     ret = CURLE_OUT_OF_MEMORY;

--- a/src/tool_findfile.c
+++ b/src/tool_findfile.c
@@ -35,7 +35,7 @@
 #include <fcntl.h>
 #endif
 
-#include <curl/mprintf.h>
+#include <curlx.h>
 
 #include "tool_findfile.h"
 
@@ -72,9 +72,9 @@ static char *checkhome(const char *home, const char *fname, bool dotscore)
   for(i = 0; i < (dotscore ? 2 : 1); i++) {
     char *c;
     if(dotscore)
-      c = curl_maprintf("%s" DIR_CHAR "%c%s", home, pref[i], &fname[1]);
+      c = aprintf("%s" DIR_CHAR "%c%s", home, pref[i], &fname[1]);
     else
-      c = curl_maprintf("%s" DIR_CHAR "%s", home, fname);
+      c = aprintf("%s" DIR_CHAR "%s", home, fname);
     if(c) {
       int fd = open(c, O_RDONLY);
       if(fd >= 0) {
@@ -118,7 +118,7 @@ char *findfile(const char *fname, int dotscore)
         continue;
       }
       if(conf_list[i].append) {
-        char *c = curl_maprintf("%s%s", home, conf_list[i].append);
+        char *c = aprintf("%s%s", home, conf_list[i].append);
         curl_free(home);
         if(!c)
           return NULL;

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -53,7 +53,7 @@ static void voutf(struct GlobalConfig *config,
     char *ptr;
     char *print_buffer;
 
-    print_buffer = curl_mvaprintf(fmt, ap);
+    print_buffer = vaprintf(fmt, ap);
     if(!print_buffer)
       return;
     len = strlen(print_buffer);

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -557,13 +557,13 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
 
     /* build a nice-looking prompt */
     if(!i && last)
-      curl_msnprintf(prompt, sizeof(prompt),
-                     "Enter %s password for user '%s':",
-                     kind, *userpwd);
+      snprintf(prompt, sizeof(prompt),
+               "Enter %s password for user '%s':",
+               kind, *userpwd);
     else
-      curl_msnprintf(prompt, sizeof(prompt),
-                     "Enter %s password for user '%s' on URL #%zu:",
-                     kind, *userpwd, i + 1);
+      snprintf(prompt, sizeof(prompt),
+               "Enter %s password for user '%s' on URL #%zu:",
+               kind, *userpwd, i + 1);
 
     /* get password */
     getpass_r(prompt, passwd, sizeof(passwd));

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -557,13 +557,13 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
 
     /* build a nice-looking prompt */
     if(!i && last)
-      snprintf(prompt, sizeof(prompt),
-               "Enter %s password for user '%s':",
-               kind, *userpwd);
+      msnprintf(prompt, sizeof(prompt),
+                "Enter %s password for user '%s':",
+                kind, *userpwd);
     else
-      snprintf(prompt, sizeof(prompt),
-               "Enter %s password for user '%s' on URL #%zu:",
-               kind, *userpwd, i + 1);
+      msnprintf(prompt, sizeof(prompt),
+                "Enter %s password for user '%s' on URL #%zu:",
+                kind, *userpwd, i + 1);
 
     /* get password */
     getpass_r(prompt, passwd, sizeof(passwd));

--- a/tests/unit/unit1398.c
+++ b/tests/unit/unit1398.c
@@ -25,8 +25,6 @@
 
 #include "curlcheck.h"
 
-#include "curl/mprintf.h"
-
 static CURLcode unit_setup(void) {return CURLE_OK;}
 static void unit_stop(void) {}
 


### PR DESCRIPTION
Also:
- unit1398: delete redundant `curl/mprintf.h` include.
---

w/o whitespace: https://github.com/curl/curl/pull/14664/files?w=1
