### PR TITLE
GHA/macos: ignore flaky tests 2041 and 2037

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -255,6 +255,7 @@ jobs:
       - name: 'run tests'
         run: |
           export TFLAGS='${{ matrix.tflags }} -j10'
+          TFLAGS+=' ~2037 ~2041'
           if [[ '${{ matrix.compiler }}' = 'gcc'* ]]; then
             TFLAGS+=' ~RTSP'  # 567 568 569 570 571 572 577 689 3100
             TFLAGS+=' ~1156 ~1539'  # HTTP Content-Range, Content-Length
@@ -386,6 +387,7 @@ jobs:
       - name: 'cmake run tests'
         run: |
           export TFLAGS='${{ matrix.build.tflags }} -j10'
+          TFLAGS+=' ~2037 ~2041'
           if [[ '${{ matrix.compiler }}' = 'gcc'* ]]; then
             TFLAGS+=' ~RTSP'  # 567 568 569 570 571 572 577 689 3100
             TFLAGS+=' ~1156 ~1539'  # HTTP Content-Range, Content-Length


### PR DESCRIPTION
- FAIL 2037: 'simple HTTPS GET with PEM public key pinning' HTTPS, HTTP GET, PEM certificate
  https://github.com/curl/curl/actions/runs/10529314166/job/29176801513?pr=14658

- FAIL 2041: 'simple HTTPS GET with base64-sha256 public key pinning' HTTPS, HTTP GET, PEM certificate
  https://github.com/curl/curl/actions/runs/10529181645/job/29176408976#step:16:4363
  https://github.com/curl/curl/actions/runs/10529019749/job/29175882809#step:13:5235
  https://github.com/curl/curl/actions/runs/10528920874/job/29175559070#step:16:4363
  https://github.com/curl/curl/actions/runs/10528759817/job/29175043048#step:16:4274
  https://github.com/curl/curl/actions/runs/10525250422/job/29163662307#step:16:4366
  https://github.com/curl/curl/actions/runs/10525250422/job/29163662602#step:13:3569

  Happened with cmake, autotools, gcc, clang and various TLS backends.

Follow-up to fa461b4eff52b413f88debf543b5350a6cef4724 #14486
