### PR TITLE
tests: tweak use of impacket in smbserver

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -54,31 +54,21 @@ SPDX-License-Identifier: curl
   - nghttpx (for HTTP/2 and HTTP/3 tests)
   - An available `en_US.UTF-8` locale
 
-### Installation of python-impacket
+### Installation of impacket
 
-  The Python-based test servers support both recent Python 2 and 3.
-  You can figure out your default Python interpreter with python -V
+  The Python-based test servers support Python 3.
 
   Please install python-impacket in the correct Python environment.
   You can use pip or your OS' package manager to install 'impacket'.
 
-  On Debian/Ubuntu the package names are:
+  On Debian/Ubuntu the package name is 'python3-impacket'
 
-  -  Python 2: 'python-impacket'
-  -  Python 3: 'python3-impacket'
+  On FreeBSD the package name is 'py311-impacket'
 
-  On FreeBSD the package names are:
-
-  -  Python 2: 'py27-impacket'
-  -  Python 3: 'py37-impacket'
-
-  On any system where pip is available:
-
-  -  Python 2: 'pip2 install impacket'
-  -  Python 3: 'pip3 install impacket'
+  On any system where pip is available: 'python3 -m pip install impacket'
 
   You may also need to manually install the Python package 'six'
-  as that may be a missing requirement for impacket on Python 3.
+  as that may be a missing requirement for impacket.
 
 ## Event-based
 

--- a/tests/data/test1451
+++ b/tests/data/test1451
@@ -28,9 +28,6 @@ Basic SMB request
 <command>
 -u 'curltest:curltest' smb://%HOSTIP:%SMBPORT/TESTS/%TESTNUMBER
 </command>
-<precheck>
-python3 -c "__import__('pkgutil').find_loader('impacket') or (__import__('sys').stdout.write('Test only works if Python package impacket is installed\n'), __import__('sys').exit(1))"
-</precheck>
 </client>
 
 #

--- a/tests/smbserver.py
+++ b/tests/smbserver.py
@@ -46,8 +46,9 @@ else:
 try:
     import impacket
 except ImportError:
-    sys.stderr.write('Python package impacket needs to be installed!\n')
-    sys.stderr.write('Use pip or your package manager to install it.\n')
+    sys.stderr.write(
+        'Warning: Python package impacket is required for smb testing; '
+        'use pip or your package manager to install it\n')
     sys.exit(1)
 from impacket import smb as imp_smb
 from impacket import smbserver as imp_smbserver


### PR DESCRIPTION
The missing message only uses a single line now and has a consistent
prefix making it easier for log parsers to skip. Remove a precheck test
looking for impacket in test1451 because it's incomplete, unnecessary
and in the wrong layer; the test harness will automatically discover
that the smbserver won't start and the test was only checking a single
dependency.  Also update the tests README to no longer mention Python 2.
The servers were switched to Python 3 several years ago and no attempt
is being made to maintain Python 2 compatibility

Closes #14669