### PR TITLE
configure: fix WinIDN builds targeting old Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -367,7 +367,7 @@ jobs:
         run: |
           mkdir bld && cd bld && ../configure --enable-warnings --enable-werror \
             --host=${TRIPLET} \
-            --with-schannel \
+            --with-schannel --with-winidn \
             --without-libpsl \
             --disable-dependency-tracking
 
@@ -391,7 +391,7 @@ jobs:
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
             -DBUILD_EXAMPLES=ON \
-            -DCURL_USE_SCHANNEL=ON \
+            -DCURL_USE_SCHANNEL=ON -DUSE_WIN32_IDN=ON \
             -DCURL_USE_LIBPSL=OFF
 
       - name: 'cmake configure log'

--- a/configure.ac
+++ b/configure.ac
@@ -2617,7 +2617,6 @@ if test "$curl_cv_native_windows" = 'yes'; then
 
   if test "$want_winidn" = "yes"; then
     dnl WinIDN library support has been requested
-    clean_CFLAGS="$CFLAGS"
     clean_CPPFLAGS="$CPPFLAGS"
     clean_LDFLAGS="$LDFLAGS"
     clean_LIBS="$LIBS"
@@ -2629,26 +2628,7 @@ if test "$curl_cv_native_windows" = 'yes'; then
       dnl pkg-config not available or provides no info
       WINIDN_LDFLAGS="-L$want_winidn_path/lib$libsuff"
       WINIDN_CPPFLAGS="-I$want_winidn_path/include"
-      WINIDN_DIR="$want_winidn_path/lib$libsuff"
     fi
-    #
-    dnl WinIDN requires a minimum supported OS version of at least Vista (0x0600)
-    AC_COMPILE_IFELSE([
-      AC_LANG_PROGRAM([[
-        #include <windows.h>
-      ]],[[
-        #if (WINVER < 0x600) && (_WIN32_WINNT < 0x600)
-        #error
-        #endif
-      ]])
-    ],[
-    ],[
-      CFLAGS=`echo $CFLAGS | $SED -e 's/-DWINVER=[[^ ]]*//g'`
-      CFLAGS=`echo $CFLAGS | $SED -e 's/-D_WIN32_WINNT=[[^ ]]*//g'`
-      CPPFLAGS=`echo $CPPFLAGS | $SED -e 's/-DWINVER=[[^ ]]*//g'`
-      CPPFLAGS=`echo $CPPFLAGS | $SED -e 's/-D_WIN32_WINNT=[[^ ]]*//g'`
-      WINIDN_CPPFLAGS="$WINIDN_CPPFLAGS -DWINVER=0x0600"
-    ])
     #
     CPPFLAGS="$CPPFLAGS $WINIDN_CPPFLAGS"
     LDFLAGS="$LDFLAGS $WINIDN_LDFLAGS"
@@ -2675,7 +2655,6 @@ if test "$curl_cv_native_windows" = 'yes'; then
       curl_idn_msg="enabled (Windows-native)"
     else
       AC_MSG_WARN([Cannot find libraries for IDN support: IDN disabled])
-      CFLAGS="$clean_CFLAGS"
       CPPFLAGS="$clean_CPPFLAGS"
       LDFLAGS="$clean_LDFLAGS"
       LIBS="$clean_LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -2639,6 +2639,14 @@ if test "$curl_cv_native_windows" = 'yes'; then
       AC_LANG_PROGRAM([[
         #include <windows.h>
       ]],[[
+        #if (!defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600) && \
+          (!defined(WINVER) || WINVER < 0x600)
+        WINBASEAPI int WINAPI IdnToUnicode(DWORD dwFlags,
+                                           const WCHAR *lpASCIICharStr,
+                                           int cchASCIIChar,
+                                           WCHAR *lpUnicodeCharStr,
+                                           int cchUnicodeChar);
+        #endif
         IdnToUnicode(0, NULL, 0, NULL, 0);
       ]])
     ],[

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -150,7 +150,8 @@ static CURLcode mac_ascii_to_idn(const char *in, char **out)
 #ifdef USE_WIN32_IDN
 /* using Windows kernel32 and normaliz libraries. */
 
-#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
+#if (!defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600) && \
+  (!defined(WINVER) || WINVER < 0x600)
 WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
                                  const WCHAR *lpUnicodeCharStr,
                                  int cchUnicodeChar,

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -150,7 +150,7 @@ static CURLcode mac_ascii_to_idn(const char *in, char **out)
 #ifdef USE_WIN32_IDN
 /* using Windows kernel32 and normaliz libraries. */
 
-#if (!defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600) && !defined(__MINGW32__)
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
 WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
                                  const WCHAR *lpUnicodeCharStr,
                                  int cchUnicodeChar,

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -150,7 +150,7 @@ static CURLcode mac_ascii_to_idn(const char *in, char **out)
 #ifdef USE_WIN32_IDN
 /* using Windows kernel32 and normaliz libraries. */
 
-#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
+#if (!defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600) && !defined(__MINGW32__)
 WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
                                  const WCHAR *lpUnicodeCharStr,
                                  int cchUnicodeChar,


### PR DESCRIPTION
1. GHA/windows: enable WinIDN in Linux cross-builds.
   (to reveal the issue in CI.)

2. fix compiler warning when building with mingw-w64 supporting
   WinIDN, while targeting pre-Vista Windows, with a `WINVER` set to
   target Vista or newer. (Such was Ubuntu's mingw-w64 with the
   classic-mingw-specific trick in point 3 of this PR.)
   ```
   ../../lib/idn.c:154:23: error: redundant redeclaration of ‘IdnToAscii’ [-Werror=redundant-decls]
     154 | WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
         |                       ^~~~~~~~~~
   In file included from /usr/share/mingw-w64/include/windows.h:73,
                    from /usr/share/mingw-w64/include/winsock2.h:23,
                    from ../../lib/setup-win32.h:91,
                    from ../../lib/curl_setup.h:308,
                    from ../../lib/idn.c:29:
   /usr/share/mingw-w64/include/winnls.h:1075:30: note: previous declaration of ‘IdnToAscii’ was here
    1075 |   WINNORMALIZEAPI int WINAPI IdnToAscii (DWORD dwFlags, LPCWSTR lpUnicodeCharStr, int cchUnicodeChar, LPWSTR lpASCIICharStr, int cchASCIIChar);
         |                              ^~~~~~~~~~
   [...same for IdnToUnicode...]
   ```
   Ref: https://github.com/curl/curl/actions/runs/10542832783/job/29210098553#step:7:89

3. drop `WINVER` override for classic-mingw. curl no longer supports
   building with classic-mingw.
   Reverts 37f1c21cb9c809ec870803fc40e1ed2afd9534ac #7581

4. sync `if IdnToUnicode can be linked` detection snippet with the live
   code in `lib/idn.c`. It fixes detection for the scenario in point 2.

5. delete unused `WINIDN_DIR` variable.

Bug: https://github.com/curl/curl/pull/12606#issuecomment-1885381038
Previous abandoned attempt: #12684
