### PR TITLE
pop3: use the protocol handler ->write_resp

### DIFF
--- a/lib/pop3.h
+++ b/lib/pop3.h
@@ -90,9 +90,4 @@ extern const struct Curl_handler Curl_handler_pop3s;
 #define POP3_EOB "\x0d\x0a\x2e\x0d\x0a"
 #define POP3_EOB_LEN 5
 
-/* This function scans the body after the end-of-body and writes everything
- * until the end is found */
-CURLcode Curl_pop3_write(struct Curl_easy *data,
-                         const char *str, size_t nread);
-
 #endif /* HEADER_CURL_POP3_H */

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -1186,15 +1186,7 @@ CURLcode Curl_xfer_write_resp(struct Curl_easy *data,
       int cwtype = CLIENTWRITE_BODY;
       if(is_eos)
         cwtype |= CLIENTWRITE_EOS;
-
-#ifndef CURL_DISABLE_POP3
-      if(blen && data->conn->handler->protocol & PROTO_FAMILY_POP3) {
-        result = data->req.ignorebody? CURLE_OK :
-                 Curl_pop3_write(data, buf, blen);
-      }
-      else
-#endif /* CURL_DISABLE_POP3 */
-        result = Curl_client_write(data, cwtype, buf, blen);
+      result = Curl_client_write(data, cwtype, buf, blen);
     }
   }
 


### PR DESCRIPTION
Remove the "hardcoded" logic for the pop3 transfer handler and instead use the generic protocol handler write_resp function.

Remove the check for 'data->req.ignorebody' because I cannot find a code flow where this is set for POP3.