### PR TITLE
test HTTP/2 Upgrade and prior knowledge

### DIFF
--- a/tests/http/test_01_basic.py
+++ b/tests/http/test_01_basic.py
@@ -112,3 +112,26 @@ class TestBasic:
         # got the Conten-Length: header, but did not download anything
         assert r.responses[0]['header']['content-length'] == '30', f'{r.responses[0]}'
         assert r.stats[0]['size_download'] == 0, f'{r.stats[0]}'
+
+    # http: GET for HTTP/2, see Upgrade:, 101 switch
+    def test_01_08_h2_upgrade(self, env: Env, httpd):
+        curl = CurlClient(env=env)
+        url = f'http://{env.domain1}:{env.http_port}/data.json'
+        r = curl.http_get(url=url, extra_args=['--http2'])
+        r.check_exit_code(0)
+        assert len(r.responses) == 2, f'{r.responses}'
+        assert r.responses[0]['status'] == 101, f'{r.responses[0]}'
+        assert r.responses[1]['status'] == 200, f'{r.responses[1]}'
+        assert r.responses[1]['protocol'] == 'HTTP/2', f'{r.responses[1]}'
+        assert r.json['server'] == env.domain1
+
+    # http: GET for HTTP/2 with prior knowledge
+    def test_01_09_h2_prior_knowledge(self, env: Env, httpd):
+        curl = CurlClient(env=env)
+        url = f'http://{env.domain1}:{env.http_port}/data.json'
+        r = curl.http_get(url=url, extra_args=['--http2-prior-knowledge'])
+        r.check_exit_code(0)
+        assert len(r.responses) == 1, f'{r.responses}'
+        assert r.response['status'] == 200, f'{r.responsw}'
+        assert r.response['protocol'] == 'HTTP/2', f'{r.response}'
+        assert r.json['server'] == env.domain1

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -564,3 +564,28 @@ class TestDownload:
         r.check_exit_code(0)
         srcfile = os.path.join(httpd.docs_dir, docname)
         self.check_downloads(client, srcfile, count)
+
+    # download parallel with prior knowledge
+    def test_02_30_parallel_prior_knowledge(self, env: Env, httpd):
+        count = 3
+        curl = CurlClient(env=env)
+        urln = f'http://{env.domain1}:{env.http_port}/data.json?[0-{count-1}]'
+        r = curl.http_download(urls=[urln], extra_args=[
+            '--parallel', '--http2-prior-knowledge'
+        ])
+        r.check_response(http_status=200, count=count)
+        assert r.total_connects == 1, r.dump_logs()
+
+    # download parallel with h2 "Upgrade:"
+    def test_02_31_parallel_upgrade(self, env: Env, httpd):
+        count = 3
+        curl = CurlClient(env=env)
+        urln = f'http://{env.domain1}:{env.http_port}/data.json?[0-{count-1}]'
+        r = curl.http_download(urls=[urln], extra_args=[
+            '--parallel', '--http2'
+        ])
+        r.check_response(http_status=200, count=count)
+        # we see 3 connections, because Apache only every serves a single
+        # request via Upgrade: and then closed the connection.
+        assert r.total_connects == 3, r.dump_logs()
+

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -588,4 +588,3 @@ class TestDownload:
         # we see 3 connections, because Apache only every serves a single
         # request via Upgrade: and then closed the connection.
         assert r.total_connects == 3, r.dump_logs()
-

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -260,7 +260,6 @@ class Httpd:
                 f'ReadBufferSize 16000',
                 f'H2MinWorkers 16',
                 f'H2MaxWorkers 256',
-                f'H2Direct on',
                 f'Listen {self.env.http_port}',
                 f'Listen {self.env.https_port}',
                 f'Listen {self.env.proxy_port}',
@@ -276,6 +275,7 @@ class Httpd:
                 f'    ServerAlias localhost',
                 f'    DocumentRoot "{self._docs_dir}"',
                 f'    Protocols h2c http/1.1',
+                f'    H2Direct on',
             ])
             conf.extend(self._curltest_conf(domain1))
             conf.extend([


### PR DESCRIPTION
Adds test cases to check that plain http: with HTTP/2 works
via 'Upgrade: h2c' or --http2-prior-knowledge'.

Also added tests to check connection reuse in these situations.