### PR TITLE
share: don't reinitialize conncache

### DIFF
--- a/lib/share.c
+++ b/lib/share.c
@@ -120,8 +120,11 @@ curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
       break;
 
     case CURL_LOCK_DATA_CONNECT:
-      if(Curl_conncache_init(&share->conn_cache, NULL, 103))
-        res = CURLSHE_NOMEM;
+      if(!share->conn_cache.hash.table) {
+        if(Curl_conncache_init(&share->conn_cache, NULL, 103)) {
+          res = CURLSHE_NOMEM;
+        }
+      }
       break;
 
     case CURL_LOCK_DATA_PSL:


### PR DESCRIPTION
Recently I was messing around with the idea of enabling persistent `Curl_share` structs in PHP, i.e. to be able to reuse the same instance of the struct across multiple requests in a single `mod_php` worker.

This worked something like the following (note that this is PHP, not C):

```php
$sh = curl_share_init("some-persistent-id");

curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
curl_share_setopt($sh, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
// ...etc
```

I noticed, however, that `CURL_LOCK_DATA_CONNECT` wasn't working across multiple requests in a `mod_php` worker. It did work if I made sure to only ever call `curl_share_setopt` on the very first request, which led me to look into the definition of `curl_share_setopt`.

I noticed that unlike other options - `CURL_LOCK_DATA_SSL_SESSION`, for example - `CURL_LOCK_DATA_CONNECT` wasn't checking to see if the connection cache had already been initialized.

Regardless of whether I continue to work on the PHP stuff, I figured it would be a simple change to check for this. It wasn't clear to me what the _best_ way was to check if the connection cache was already initialized, so let me know if you have a preference for a better way.