### PR TITLE
configure: remove USE_EXPLICIT_LIB_DEPS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -501,14 +501,6 @@ fi
 AC_SUBST([LIBCURL_PC_CFLAGS])
 
 
-# Determine whether all dependent libraries must be specified when linking
-if test "X$enable_shared" = "Xyes" -a "X$link_all_deplibs" = "Xno"; then
-  require_lib_deps=no
-else
-  require_lib_deps=yes
-fi
-AM_CONDITIONAL(USE_EXPLICIT_LIB_DEPS, test x$require_lib_deps = xyes)
-
 dnl **********************************************************************
 dnl platform/compiler/architecture specific checks/flags
 dnl **********************************************************************

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -55,11 +55,7 @@ endif
 LIBS = $(BLANK_AT_MAKETIME)
 
 # Dependencies
-if USE_EXPLICIT_LIB_DEPS
 LDADD = $(LIBDIR)/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
-else
-LDADD = $(LIBDIR)/libcurl.la
-endif
 
 # This might hold -Werror
 CFLAGS += @CURL_CFLAG_EXTRAS@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,11 +72,7 @@ CFLAGS += @CURL_CFLAG_EXTRAS@
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 
-if USE_EXPLICIT_LIB_DEPS
 curl_LDADD = $(top_builddir)/lib/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
-else
-curl_LDADD = $(top_builddir)/lib/libcurl.la @SSL_LIBS@ @ZLIB_LIBS@ @CURL_NETWORK_AND_TIME_LIBS@
-endif
 
 # if unit tests are enabled, build a static library to link them with
 if BUILD_UNITTESTS

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -56,11 +56,7 @@ endif
 LIBS = $(BLANK_AT_MAKETIME)
 
 # Dependencies
-if USE_EXPLICIT_LIB_DEPS
 LDADD = $(LIBDIR)/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
-else
-LDADD = $(LIBDIR)/libcurl.la
-endif
 
 # This might hold -Werror
 CFLAGS += @CURL_CFLAG_EXTRAS@

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -48,13 +48,8 @@ CLEANFILES = lib1521.c
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 
-if USE_EXPLICIT_LIB_DEPS
 SUPPORTFILES_LIBS = $(top_builddir)/lib/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
 TESTUTIL_LIBS = $(top_builddir)/lib/libcurl.la @LIBCURL_PC_LIBS_PRIVATE@
-else
-SUPPORTFILES_LIBS = $(top_builddir)/lib/libcurl.la @CURL_NETWORK_LIBS@
-TESTUTIL_LIBS = $(top_builddir)/lib/libcurl.la @CURL_NETWORK_AND_TIME_LIBS@
-endif
 
 # Dependencies (may need to be overridden)
 LDADD = $(SUPPORTFILES_LIBS)

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -88,6 +88,7 @@ libntlmconnect_SOURCES = libntlmconnect.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS
 libntlmconnect_LDADD = $(TESTUTIL_LIBS)
 
 libauthretry_SOURCES = libauthretry.c $(SUPPORTFILES)
+libauthretry_LDADD = $(TESTUTIL_LIBS)
 
 libprereq_SOURCES = libprereq.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 libprereq_LDADD = $(TESTUTIL_LIBS)


### PR DESCRIPTION
Added a long time ago for something that libtool should handle for us.