### PR TITLE
printf: fix mingw-w64 format checks, take 2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -597,16 +597,6 @@ case $host_os in
     ;;
 esac
 
-have_mingw='no'
-case $host_os in
-  mingw*)
-    have_mingw='yes'
-    ;;
-esac
-
-AM_CONDITIONAL([HAVE_MINGW],
-  [test "$curl_cv_native_windows" = 'yes' -a "$have_mingw" = 'yes'])
-
 AM_CONDITIONAL([HAVE_WINDRES],
   [test "$curl_cv_native_windows" = "yes" && test -n "${RC}"])
 

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -34,10 +34,6 @@ foreach(_target IN LISTS check_PROGRAMS)
   if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
     set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
-  if(MINGW)
-    # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-    set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
-  endif()
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}" UNITY_BUILD OFF
     PROJECT_LABEL "Example ${_target}")

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -46,11 +46,6 @@ if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif
 
-if HAVE_MINGW
-# For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-AM_CPPFLAGS += -D__USE_MINGW_ANSI_STDIO=1
-endif
-
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 

--- a/docs/examples/ftpgetinfo.c
+++ b/docs/examples/ftpgetinfo.c
@@ -75,8 +75,8 @@ int main(void)
       res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                               &filesize);
       if((CURLE_OK == res) && (filesize>0))
-        curl_mprintf("filesize %s: %" CURL_FORMAT_CURL_OFF_T " bytes\n",
-                     filename, filesize);
+        printf("filesize %s: %" CURL_FORMAT_CURL_OFF_T " bytes\n",
+               filename, filesize);
     }
     else {
       /* we failed */

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -3234,7 +3234,9 @@ CURL_EXTERN CURLcode curl_easy_pause(CURL *handle, int bitmask);
 #include "options.h"
 #include "header.h"
 #include "websockets.h"
+#ifndef CURL_SKIP_INCLUDE_MPRINTF
 #include "mprintf.h"
+#endif
 
 /* the typechecker does not work in C++ (yet) */
 #if defined(__GNUC__) && defined(__GNUC_MINOR__) && \

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -37,7 +37,7 @@ extern "C" {
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__)
-#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
+#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -40,7 +40,7 @@ extern "C" {
 #if defined(__MINGW32__)
 #if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
-  __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
+  __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else
 #define CURL_TEMP_PRINTF(fmt, arg)
 #endif

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -49,6 +49,7 @@ extern "C" {
 #endif
 #else
 #define CURL_TEMP_PRINTF(fmt, arg)
+#error "DISABLING FORMAT CHECKS"
 #endif
 
 CURL_EXTERN int curl_mprintf(const char *format, ...)

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -32,6 +32,7 @@
 extern "C" {
 #endif
 
+#ifndef CURL_TEMP_PRINTF
 #if (defined(__GNUC__) || defined(__clang__) ||                         \
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
@@ -49,6 +50,7 @@ extern "C" {
 #endif
 #else
 #define CURL_TEMP_PRINTF(fmt, arg)
+#endif
 #endif
 
 CURL_EXTERN int curl_mprintf(const char *format, ...)

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -37,7 +37,7 @@ extern "C" {
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && !defined(__clang__)
 #if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -35,7 +35,7 @@ extern "C" {
 #if (defined(__GNUC__) || defined(__clang__) ||                         \
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
-  !defined(CURL_NO_FMT_CHECKS) && !defined(CURL_NO_FMT_CHECK_PUB)
+  !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__) && !defined(__clang__)
 #if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
@@ -49,7 +49,6 @@ extern "C" {
 #endif
 #else
 #define CURL_TEMP_PRINTF(fmt, arg)
-#error "DISABLING FORMAT CHECKS"
 #endif
 
 CURL_EXTERN int curl_mprintf(const char *format, ...)

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -32,11 +32,10 @@
 extern "C" {
 #endif
 
-#ifndef CURL_TEMP_PRINTF
 #if (defined(__GNUC__) || defined(__clang__) ||                         \
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
-  !defined(CURL_NO_FMT_CHECKS)
+  !defined(CURL_NO_FMT_CHECKS) && !defined(CURL_NO_FMT_CHECK_PUB)
 #if defined(__MINGW32__) && !defined(__clang__)
 #if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
@@ -50,7 +49,6 @@ extern "C" {
 #endif
 #else
 #define CURL_TEMP_PRINTF(fmt, arg)
-#endif
 #endif
 
 CURL_EXTERN int curl_mprintf(const char *format, ...)

--- a/include/curl/mprintf.h
+++ b/include/curl/mprintf.h
@@ -36,9 +36,13 @@ extern "C" {
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__) && !defined(__clang__)
+#if defined(__MINGW32__)
+#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
 #define CURL_TEMP_PRINTF(fmt, arg) \
-  __attribute__((format(gnu_printf, fmt, arg)))
+  __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
+#else
+#define CURL_TEMP_PRINTF(fmt, arg)
+#endif
 #else
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((format(printf, fmt, arg)))

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -178,10 +178,16 @@
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 
 #elif defined(__MINGW32__)
+#  include <_mingw.h>
 #  include <inttypes.h>
 #  define CURL_TYPEOF_CURL_OFF_T     long long
+#if defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR <= 7
+#  define CURL_FORMAT_CURL_OFF_T     "lld"
+#  define CURL_FORMAT_CURL_OFF_TU    "llu"
+#else
 #  define CURL_FORMAT_CURL_OFF_T     PRId64
 #  define CURL_FORMAT_CURL_OFF_TU    PRIu64
+#endif
 #  define CURL_SUFFIX_CURL_OFF_T     LL
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -178,16 +178,10 @@
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 
 #elif defined(__MINGW32__)
-#  include <_mingw.h>
 #  include <inttypes.h>
 #  define CURL_TYPEOF_CURL_OFF_T     long long
-#if defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR <= 7
-#  define CURL_FORMAT_CURL_OFF_T     "lld"
-#  define CURL_FORMAT_CURL_OFF_TU    "llu"
-#else
 #  define CURL_FORMAT_CURL_OFF_T     PRId64
 #  define CURL_FORMAT_CURL_OFF_TU    PRIu64
-#endif
 #  define CURL_SUFFIX_CURL_OFF_T     LL
 #  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -29,6 +29,8 @@
  * *rintf() functions.
  */
 
+#include <curl/curl.h>  /* for CURL_EXTERN */
+
 /* based on logic in "curl/mprintf.h" */
 
 CURL_EXTERN int curl_mprintf(const char *format, ...)

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -29,8 +29,12 @@
  * *rintf() functions.
  */
 
-/* override format checks with those defined in curl_setup.h */
-#define CURL_TEMP_PRINTF CURL_PRINTF
+/* Skip format checks for older mingw-w64 versions. They do not grok
+   the `%zd` `%zu` formats by default, and there is format check CI
+   coverage with newer mingw-w64 versions without them. */
+#if defined(__MINGW32__) && !defined(__clang__) && __MINGW64_VERSION_MAJOR <= 7
+#define CURL_NO_FMT_CHECK_PUB
+#endif
 
 #include <curl/mprintf.h>
 

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -31,9 +31,6 @@
 
 /* override format checks with those defined in curl_setup.h */
 #define CURL_TEMP_PRINTF CURL_PRINTF
-#ifndef CURL_PRINTF
-#error "CURL_PRINTF NOT DEFINED!"
-#endif
 
 #include <curl/mprintf.h>
 

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -29,59 +29,30 @@
  * *rintf() functions.
  */
 
-#include <stdarg.h>
-#include <stdio.h> /* needed for FILE */
-#include "curl.h"  /* for CURL_EXTERN */
-
-#ifdef  __cplusplus
-extern "C" {
-#endif
-
 /* based on logic in "curl/mprintf.h" */
 
-#if (defined(__GNUC__) || defined(__clang__) ||                         \
-  defined(__IAR_SYSTEMS_ICC__)) &&                                      \
-  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
-  !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__) && !defined(__clang__)
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(gnu_printf, fmt, arg)))
-#else
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(__printf__, fmt, arg)))
-#endif
-#else
-#define CURL_PRINTF(fmt, arg)
-#endif
-
 CURL_EXTERN int curl_mprintf(const char *format, ...)
-  CURL_TEMP_PRINTF(1, 2);
+  CURL_PRINTF(1, 2);
 CURL_EXTERN int curl_mfprintf(FILE *fd, const char *format, ...)
-  CURL_TEMP_PRINTF(2, 3);
+  CURL_PRINTF(2, 3);
 CURL_EXTERN int curl_msprintf(char *buffer, const char *format, ...)
-  CURL_TEMP_PRINTF(2, 3);
+  CURL_PRINTF(2, 3);
 CURL_EXTERN int curl_msnprintf(char *buffer, size_t maxlength,
                                const char *format, ...)
-  CURL_TEMP_PRINTF(3, 4);
+  CURL_PRINTF(3, 4);
 CURL_EXTERN int curl_mvprintf(const char *format, va_list args)
-  CURL_TEMP_PRINTF(1, 0);
+  CURL_PRINTF(1, 0);
 CURL_EXTERN int curl_mvfprintf(FILE *fd, const char *format, va_list args)
-  CURL_TEMP_PRINTF(2, 0);
+  CURL_PRINTF(2, 0);
 CURL_EXTERN int curl_mvsprintf(char *buffer, const char *format, va_list args)
-  CURL_TEMP_PRINTF(2, 0);
+  CURL_PRINTF(2, 0);
 CURL_EXTERN int curl_mvsnprintf(char *buffer, size_t maxlength,
                                 const char *format, va_list args)
-  CURL_TEMP_PRINTF(3, 0);
+  CURL_PRINTF(3, 0);
 CURL_EXTERN char *curl_maprintf(const char *format, ...)
-  CURL_TEMP_PRINTF(1, 2);
+  CURL_PRINTF(1, 2);
 CURL_EXTERN char *curl_mvaprintf(const char *format, va_list args)
-  CURL_TEMP_PRINTF(1, 0);
-
-#undef CURL_TEMP_PRINTF
-
-#ifdef  __cplusplus
-} /* end of extern "C" */
-#endif
+  CURL_PRINTF(1, 0);
 
 #define MERR_OK        0
 #define MERR_MEM       1

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -29,10 +29,6 @@
  * *rintf() functions.
  */
 
-#include <curl_setup.h>
-#define CURL_TEMP_PRINTF CURL_PRINTF
-#include <curl/mprintf.h>
-
 #define MERR_OK        0
 #define MERR_MEM       1
 #define MERR_TOO_LARGE 2

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -29,32 +29,9 @@
  * *rintf() functions.
  */
 
-#include <curl/curl.h>  /* for CURL_EXTERN */
-
-/* based on logic in "curl/mprintf.h" */
-
-CURL_EXTERN int curl_mprintf(const char *format, ...)
-  CURL_PRINTF(1, 2);
-CURL_EXTERN int curl_mfprintf(FILE *fd, const char *format, ...)
-  CURL_PRINTF(2, 3);
-CURL_EXTERN int curl_msprintf(char *buffer, const char *format, ...)
-  CURL_PRINTF(2, 3);
-CURL_EXTERN int curl_msnprintf(char *buffer, size_t maxlength,
-                               const char *format, ...)
-  CURL_PRINTF(3, 4);
-CURL_EXTERN int curl_mvprintf(const char *format, va_list args)
-  CURL_PRINTF(1, 0);
-CURL_EXTERN int curl_mvfprintf(FILE *fd, const char *format, va_list args)
-  CURL_PRINTF(2, 0);
-CURL_EXTERN int curl_mvsprintf(char *buffer, const char *format, va_list args)
-  CURL_PRINTF(2, 0);
-CURL_EXTERN int curl_mvsnprintf(char *buffer, size_t maxlength,
-                                const char *format, va_list args)
-  CURL_PRINTF(3, 0);
-CURL_EXTERN char *curl_maprintf(const char *format, ...)
-  CURL_PRINTF(1, 2);
-CURL_EXTERN char *curl_mvaprintf(const char *format, va_list args)
-  CURL_PRINTF(1, 0);
+#include <curl_setup.h>
+#define CURL_TEMP_PRINTF CURL_PRINTF
+#include <curl/mprintf.h>
 
 #define MERR_OK        0
 #define MERR_MEM       1

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -31,6 +31,9 @@
 
 /* override format checks with those defined in curl_setup.h */
 #define CURL_TEMP_PRINTF CURL_PRINTF
+#ifndef CURL_PRINTF
+#error "CURL_PRINTF NOT DEFINED!"
+#endif
 
 #include <curl/mprintf.h>
 

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -29,6 +29,9 @@
  * *rintf() functions.
  */
 
+/* override format checks with those defined in curl_setup.h */
+#define CURL_TEMP_PRINTF CURL_PRINTF
+
 #include <curl/mprintf.h>
 
 #define MERR_OK        0

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -29,21 +29,59 @@
  * *rintf() functions.
  */
 
-/* Skip format checks for older mingw-w64 versions. They do not grok
-   the `%zd` `%zu` formats by default, and there is format check CI
-   coverage with newer mingw-w64 versions without them. */
-#ifndef __MINGW64_VERSION_MAJOR
-#error "__MINGW64_VERSION_MAJOR NOT DEFINED"
-#elif __MINGW64_VERSION_MAJOR <= 7
-#error "__MINGW64_VERSION_MAJOR 7 OR LOWER"
+#include <stdarg.h>
+#include <stdio.h> /* needed for FILE */
+#include "curl.h"  /* for CURL_EXTERN */
+
+#ifdef  __cplusplus
+extern "C" {
 #endif
 
-#if defined(__MINGW32__) && !defined(__clang__) && __MINGW64_VERSION_MAJOR <= 7
-#define CURL_NO_FMT_CHECK_PUB
-#error "DISABLING CURL_NO_FMT_CHECK_PUB"
+/* based on logic in "curl/mprintf.h" */
+
+#if (defined(__GNUC__) || defined(__clang__) ||                         \
+  defined(__IAR_SYSTEMS_ICC__)) &&                                      \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
+  !defined(CURL_NO_FMT_CHECKS)
+#if defined(__MINGW32__) && !defined(__clang__)
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(gnu_printf, fmt, arg)))
+#else
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(__printf__, fmt, arg)))
+#endif
+#else
+#define CURL_PRINTF(fmt, arg)
 #endif
 
-#include <curl/mprintf.h>
+CURL_EXTERN int curl_mprintf(const char *format, ...)
+  CURL_TEMP_PRINTF(1, 2);
+CURL_EXTERN int curl_mfprintf(FILE *fd, const char *format, ...)
+  CURL_TEMP_PRINTF(2, 3);
+CURL_EXTERN int curl_msprintf(char *buffer, const char *format, ...)
+  CURL_TEMP_PRINTF(2, 3);
+CURL_EXTERN int curl_msnprintf(char *buffer, size_t maxlength,
+                               const char *format, ...)
+  CURL_TEMP_PRINTF(3, 4);
+CURL_EXTERN int curl_mvprintf(const char *format, va_list args)
+  CURL_TEMP_PRINTF(1, 0);
+CURL_EXTERN int curl_mvfprintf(FILE *fd, const char *format, va_list args)
+  CURL_TEMP_PRINTF(2, 0);
+CURL_EXTERN int curl_mvsprintf(char *buffer, const char *format, va_list args)
+  CURL_TEMP_PRINTF(2, 0);
+CURL_EXTERN int curl_mvsnprintf(char *buffer, size_t maxlength,
+                                const char *format, va_list args)
+  CURL_TEMP_PRINTF(3, 0);
+CURL_EXTERN char *curl_maprintf(const char *format, ...)
+  CURL_TEMP_PRINTF(1, 2);
+CURL_EXTERN char *curl_mvaprintf(const char *format, va_list args)
+  CURL_TEMP_PRINTF(1, 0);
+
+#undef CURL_TEMP_PRINTF
+
+#ifdef  __cplusplus
+} /* end of extern "C" */
+#endif
 
 #define MERR_OK        0
 #define MERR_MEM       1

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -32,8 +32,15 @@
 /* Skip format checks for older mingw-w64 versions. They do not grok
    the `%zd` `%zu` formats by default, and there is format check CI
    coverage with newer mingw-w64 versions without them. */
+#ifndef __MINGW64_VERSION_MAJOR
+#error "__MINGW64_VERSION_MAJOR NOT DEFINED"
+#elif __MINGW64_VERSION_MAJOR <= 7
+#error "__MINGW64_VERSION_MAJOR 7 OR LOWER"
+#endif
+
 #if defined(__MINGW32__) && !defined(__clang__) && __MINGW64_VERSION_MAJOR <= 7
 #define CURL_NO_FMT_CHECK_PUB
+#error "DISABLING CURL_NO_FMT_CHECK_PUB"
 #endif
 
 #include <curl/mprintf.h>

--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -29,6 +29,12 @@
  * *rintf() functions.
  */
 
+#ifndef CURL_TEMP_PRINTF
+#error "CURL_TEMP_PRINTF must be set before including curl/mprintf.h"
+#endif
+
+#include <curl/mprintf.h>
+
 #define MERR_OK        0
 #define MERR_MEM       1
 #define MERR_TOO_LARGE 2

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -335,17 +335,15 @@
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__)
 /* override __MINGW_PRINTF_FORMAT with gnu_printf for internal code */
-#define CURL_TEMP_PRINTF(fmt, arg) \
+#define CURL_PRINTF(fmt, arg) \
   __attribute__((format(gnu_printf, fmt, arg)))
 #else
-#define CURL_TEMP_PRINTF(fmt, arg) \
+#define CURL_PRINTF(fmt, arg) \
   __attribute__((format(printf, fmt, arg)))
 #endif
 #else
-#define CURL_TEMP_PRINTF(fmt, arg)
+#define CURL_PRINTF(fmt, arg)
 #endif
-/* use the same format check for internal functions */
-#define CURL_PRINTF CURL_TEMP_PRINTF
 
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro
    expected by macOS SDK v14 / Xcode v15 (2023) and newer.

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -334,7 +334,7 @@
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__)
+#if defined(__MINGW32__) && !defined(__clang__)
 /* override __MINGW_PRINTF_FORMAT with gnu_printf for internal code */
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((format(gnu_printf, fmt, arg)))

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -348,7 +348,7 @@
 #define CURL_PRINTF(fmt, arg)
 #endif
 
-/* override printf mask check rules in "curl/mprintf.h" */
+/* Override printf mask check rules in "curl/mprintf.h" */
 #define CURL_TEMP_PRINTF CURL_PRINTF
 
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -329,7 +329,6 @@
 #endif
 
 /* based on logic in "curl/mprintf.h" */
-#ifndef CURL_TEMP_PRINTF
 #if (defined(__GNUC__) || defined(__clang__) ||                         \
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
@@ -344,7 +343,6 @@
 #endif
 #else
 #define CURL_TEMP_PRINTF(fmt, arg)
-#endif
 #endif
 /* use the same format check for internal functions */
 #define CURL_PRINTF CURL_TEMP_PRINTF

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -337,7 +337,7 @@
 #if defined(__MINGW32__)
 /* override __MINGW_PRINTF_FORMAT with gnu_printf for internal code */
 #define CURL_TEMP_PRINTF(fmt, arg) \
-  __attribute__((__format__(gnu_printf, fmt, arg)))
+  __attribute__((format(gnu_printf, fmt, arg)))
 #else
 #define CURL_TEMP_PRINTF(fmt, arg) \
   __attribute__((format(printf, fmt, arg)))

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -340,7 +340,7 @@
   __attribute__((format(gnu_printf, fmt, arg)))
 #else
 #define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(printf, fmt, arg)))
+  __attribute__((format(__printf__, fmt, arg)))
 #endif
 #else
 #define CURL_PRINTF(fmt, arg)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -335,9 +335,16 @@
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__) && !defined(__clang__)
+/* Skip format checks for older mingw-w64 versions. They do not grok
+   the `%zd` `%zu` formats by default, and there is format check CI
+   coverage with newer mingw-w64 versions without them. */
+#if __MINGW64_VERSION_MAJOR >= 8
 /* override __MINGW_PRINTF_FORMAT with gnu_printf for internal code */
 #define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(gnu_printf, fmt, arg)))
+  __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
+#else
+#define CURL_PRINTF(fmt, arg)
+#endif
 #else
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((format(__printf__, fmt, arg)))

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -339,9 +339,11 @@
    the `%zd` `%zu` formats by default, and there is format check CI
    coverage with newer mingw-w64 versions without them. */
 #if __MINGW64_VERSION_MAJOR >= 8
-/* override __MINGW_PRINTF_FORMAT with gnu_printf for internal code */
+/* override __MINGW_PRINTF_FORMAT with gnu_printf for internal code
+   to match the CURL_FORMAT_CURL_OFF_T overrides above, regardless
+   of the __USE_MINGW_ANSI_STDIO setting. */
 #define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(__MINGW_PRINTF_FORMAT, fmt, arg)))
+  __attribute__((format(gnu_printf, fmt, arg)))
 #else
 #define CURL_PRINTF(fmt, arg)
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -317,17 +317,6 @@
 #define CURL_CONC_MACROS_(A,B) A ## B
 #define CURL_CONC_MACROS(A,B) CURL_CONC_MACROS_(A,B)
 
-/* curl uses its own printf() function internally. It understands the GNU
- * format. Use this format, so that is matches the GNU format attribute we
- * use with the MinGW compiler, allowing it to verify them at compile-time.
- */
-#ifdef  __MINGW32__
-#  undef CURL_FORMAT_CURL_OFF_T
-#  undef CURL_FORMAT_CURL_OFF_TU
-#  define CURL_FORMAT_CURL_OFF_T   "lld"
-#  define CURL_FORMAT_CURL_OFF_TU  "llu"
-#endif
-
 /* based on logic in "curl/mprintf.h" */
 
 #if (defined(__GNUC__) || defined(__clang__) ||                         \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -317,6 +317,17 @@
 #define CURL_CONC_MACROS_(A,B) A ## B
 #define CURL_CONC_MACROS(A,B) CURL_CONC_MACROS_(A,B)
 
+/* curl uses its own printf() function internally. It understands the GNU
+ * format. Use this format, so that is matches the GNU format attribute we
+ * use with the MinGW compiler, allowing it to verify them at compile-time.
+ */
+#ifdef  __MINGW32__
+#  undef CURL_FORMAT_CURL_OFF_T
+#  undef CURL_FORMAT_CURL_OFF_TU
+#  define CURL_FORMAT_CURL_OFF_T   "lld"
+#  define CURL_FORMAT_CURL_OFF_TU  "llu"
+#endif
+
 /* based on logic in "curl/mprintf.h" */
 #ifndef CURL_TEMP_PRINTF
 #if (defined(__GNUC__) || defined(__clang__) ||                         \
@@ -337,17 +348,6 @@
 #endif
 /* use the same format check for internal functions */
 #define CURL_PRINTF CURL_TEMP_PRINTF
-
-/* curl uses its own printf() function internally. It understands the GNU
- * format. Use this format, so that is matches the GNU format attribute we
- * use with the MinGW compiler, allowing it to verify them at compile-time.
- */
-#ifdef  __MINGW32__
-#  undef CURL_FORMAT_CURL_OFF_T
-#  undef CURL_FORMAT_CURL_OFF_TU
-#  define CURL_FORMAT_CURL_OFF_T   "lld"
-#  define CURL_FORMAT_CURL_OFF_TU  "llu"
-#endif
 
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro
    expected by macOS SDK v14 / Xcode v15 (2023) and newer.

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -328,6 +328,23 @@
 #  define CURL_FORMAT_CURL_OFF_TU  "llu"
 #endif
 
+/* based on logic in "curl/mprintf.h" */
+
+#if (defined(__GNUC__) || defined(__clang__) ||                         \
+  defined(__IAR_SYSTEMS_ICC__)) &&                                      \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
+  !defined(CURL_NO_FMT_CHECKS)
+#if defined(__MINGW32__) && !defined(__clang__)
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(gnu_printf, fmt, arg)))
+#else
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(__printf__, fmt, arg)))
+#endif
+#else
+#define CURL_PRINTF(fmt, arg)
+#endif
+
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro
    expected by macOS SDK v14 / Xcode v15 (2023) and newer.
    gcc (as of v14) is also missing it. */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -328,23 +328,6 @@
 #  define CURL_FORMAT_CURL_OFF_TU  "llu"
 #endif
 
-/* based on logic in "curl/mprintf.h" */
-
-#if (defined(__GNUC__) || defined(__clang__) ||                         \
-  defined(__IAR_SYSTEMS_ICC__)) &&                                      \
-  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
-  !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__) && !defined(__clang__)
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(gnu_printf, fmt, arg)))
-#else
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(__printf__, fmt, arg)))
-#endif
-#else
-#define CURL_PRINTF(fmt, arg)
-#endif
-
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro
    expected by macOS SDK v14 / Xcode v15 (2023) and newer.
    gcc (as of v14) is also missing it. */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -348,7 +348,7 @@
 #define CURL_PRINTF(fmt, arg)
 #endif
 
-/* Override printf mask check rules in "curl/mprintf.h" */
+/* Override default printf mask check rules in "curl/mprintf.h" */
 #define CURL_TEMP_PRINTF CURL_PRINTF
 
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -28,6 +28,7 @@
 #define CURL_NO_OLDIES
 #endif
 
+/* Tell curl/curl.h not to include curl/printf.h */
 #define CURL_SKIP_INCLUDE_MPRINTF
 
 /* FIXME: Delete this once the warnings have been fixed. */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -28,7 +28,7 @@
 #define CURL_NO_OLDIES
 #endif
 
-/* Tell curl/curl.h not to include curl/printf.h */
+/* Tell "curl/curl.h" not to include "curl/mprintf.h" */
 #define CURL_SKIP_INCLUDE_MPRINTF
 
 /* FIXME: Delete this once the warnings have been fixed. */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -329,6 +329,7 @@
 #endif
 
 /* based on logic in "curl/mprintf.h" */
+
 #if (defined(__GNUC__) || defined(__clang__) ||                         \
   defined(__IAR_SYSTEMS_ICC__)) &&                                      \
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -335,18 +335,8 @@
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__) && !defined(__clang__)
-/* Skip format checks for older mingw-w64 versions. They do not grok
-   the `%zd` `%zu` formats by default, and there is format check CI
-   coverage with newer mingw-w64 versions without them. */
-#if __MINGW64_VERSION_MAJOR >= 8
-/* override __MINGW_PRINTF_FORMAT with gnu_printf for internal code
-   to match the CURL_FORMAT_CURL_OFF_T overrides above, regardless
-   of the __USE_MINGW_ANSI_STDIO setting. */
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((format(gnu_printf, fmt, arg)))
-#else
-#define CURL_PRINTF(fmt, arg)
-#endif
 #else
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((format(__printf__, fmt, arg)))

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -28,6 +28,8 @@
 #define CURL_NO_OLDIES
 #endif
 
+#define CURL_SKIP_INCLUDE_MPRINTF
+
 /* FIXME: Delete this once the warnings have been fixed. */
 #if !defined(CURL_WARN_SIGN_CONVERSION)
 #ifdef __GNUC__

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -347,6 +347,8 @@
 #define CURL_PRINTF(fmt, arg)
 #endif
 
+#define CURL_TEMP_PRINTF CURL_PRINTF  /* override "curl/mprintf.h" */
+
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro
    expected by macOS SDK v14 / Xcode v15 (2023) and newer.
    gcc (as of v14) is also missing it. */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -347,7 +347,8 @@
 #define CURL_PRINTF(fmt, arg)
 #endif
 
-#define CURL_TEMP_PRINTF CURL_PRINTF  /* override "curl/mprintf.h" */
+/* override printf mask check rules in "curl/mprintf.h" */
+#define CURL_TEMP_PRINTF CURL_PRINTF
 
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro
    expected by macOS SDK v14 / Xcode v15 (2023) and newer.

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -317,23 +317,6 @@
 #define CURL_CONC_MACROS_(A,B) A ## B
 #define CURL_CONC_MACROS(A,B) CURL_CONC_MACROS_(A,B)
 
-/* based on logic in "curl/mprintf.h" */
-
-#if (defined(__GNUC__) || defined(__clang__) ||                         \
-  defined(__IAR_SYSTEMS_ICC__)) &&                                      \
-  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
-  !defined(CURL_NO_FMT_CHECKS)
-#if defined(__MINGW32__) && !defined(__clang__)
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(gnu_printf, fmt, arg)))
-#else
-#define CURL_PRINTF(fmt, arg) \
-  __attribute__((format(__printf__, fmt, arg)))
-#endif
-#else
-#define CURL_PRINTF(fmt, arg)
-#endif
-
 /* Workaround for mainline llvm v16 and earlier missing a built-in macro
    expected by macOS SDK v14 / Xcode v15 (2023) and newer.
    gcc (as of v14) is also missing it. */
@@ -421,6 +404,27 @@
 
 #include <stdio.h>
 #include <assert.h>
+
+/* based on logic in "curl/mprintf.h" */
+
+#if (defined(__GNUC__) || defined(__clang__) ||                         \
+  defined(__IAR_SYSTEMS_ICC__)) &&                                      \
+  defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
+  !defined(CURL_NO_FMT_CHECKS)
+#if defined(__MINGW32__)
+#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
+#else
+#define CURL_PRINTF(fmt, arg)
+#endif
+#else
+#define CURL_PRINTF(fmt, arg) \
+  __attribute__((format(__printf__, fmt, arg)))
+#endif
+#else
+#define CURL_PRINTF(fmt, arg)
+#endif
 
 #ifdef __TANDEM /* for ns*-tandem-nsk systems */
 # if ! defined __LP64

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -412,7 +412,7 @@
   defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) &&         \
   !defined(CURL_NO_FMT_CHECKS)
 #if defined(__MINGW32__)
-#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 4.0.0+. Needs stdio.h. */
+#if defined(__MINGW_PRINTF_FORMAT)  /* mingw-w64 3.0.0+. Needs stdio.h. */
 #define CURL_PRINTF(fmt, arg) \
   __attribute__((__format__(__MINGW_PRINTF_FORMAT, fmt, arg)))
 #else

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -24,8 +24,7 @@
 
 #include "curl_setup.h"
 #include "dynbuf.h"
-#include "curl_printf.h"  /* must include it before curl/mprintf.h */
-#include <curl/mprintf.h>
+#include "curl_printf.h"
 
 #include "curl_memory.h"
 /* The last #include file should be: */

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 #include "dynbuf.h"
-#include "curl_printf.h"
+#include "curl_printf.h"  /* must include it before curl/mprintf.h */
 #include <curl/mprintf.h>
 
 #include "curl_memory.h"

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -558,7 +558,7 @@ static ssize_t ws_enc_write_head(struct Curl_easy *data,
 
   if(enc->payload_remain > 0) {
     /* trying to write a new frame before the previous one is finished */
-    failf(data, "WS: starting new frame with %zd bytes from last one"
+    failf(data, "WS: starting new frame with %zd bytes from last one "
                 "remaining to be sent", (ssize_t)enc->payload_remain);
     *err = CURLE_SEND_ERROR;
     return -1;

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -39,10 +39,6 @@ foreach(_target IN LISTS check_PROGRAMS)
   if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
     set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
-  if(MINGW)
-    # For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-    set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "__USE_MINGW_ANSI_STDIO=1")
-  endif()
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}" UNITY_BUILD OFF
     PROJECT_LABEL "Test client ${_target}")

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -47,11 +47,6 @@ if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif
 
-if HAVE_MINGW
-# For mingw-w64 7.0.0 and earlier to avoid '-Wformat='
-AM_CPPFLAGS += -D__USE_MINGW_ANSI_STDIO=1
-endif
-
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 


### PR DESCRIPTION
Change mingw-w64 printf format checks in public curl headers to use
`__MINGW_PRINTF_FORMAT` instead of `gnu_printf`. This syncs the format
checker with format string macros published via `curl/system.h`. (Also
disable format checks for mingw-w64 older than 3.0.0 (2013-09-20) and
classic-mingw, which do not support this macro.)

This fixes bogus format checker `-Wformat` warnings in 3rd party code
using curl format strings with the curl printf functions, when using
mingw-w64 7.0.0 (2019-11-10) and older (with GCC, MSVCRT).

It also allows to delete two workaounds for this within curl itself:
- setting `-D__USE_MINGW_ANSI_STDIO=1` for mingw-w64 via cmake and
  configure for `docs/examples` and `tests/http/clients`.
  Ref: c730c8549b5b67e7668ca5d2cd82c3cc183e125d #14640

The format check macro is incompatible (depending on mingw-w64 version
and configuration) with the C99 `%z` (`size_t`) format string used
internally by curl.

To work around this problem, override the format check style in curl
public headers to use `gnu_printf`. This is compatible with `%z` in all
mingw-w64 versions and allows keeping the C99 format strings internally.

Also:
- lib/ws.c: add missing space to an error message.
- docs/examples/ftpgetinfo.c: fix to use standard printf.

Ref: #14643 (take 1)
Follow-up to 3829759bd042c03225ae862062560f568ba1a231 #12489

---

- [ ] give public `CURL_TEMP_PRINTF` a better name? And/or its internal counterpart.