### PR TITLE
test1013.pl: require case match for features, order match for protos, fix issue

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4938,7 +4938,7 @@ if test "x$curl_psl_msg" = "xenabled"; then
 fi
 
 if test "x$curl_gsasl_msg" = "xenabled"; then
-  SUPPORT_FEATURES="$SUPPORT_FEATURES GSASL"
+  SUPPORT_FEATURES="$SUPPORT_FEATURES gsasl"
 fi
 
 if test "x$enable_altsvc" = "xyes"; then

--- a/tests/libtest/test1013.pl
+++ b/tests/libtest/test1013.pl
@@ -38,7 +38,6 @@ open(CURL, "$ARGV[1]") || die "Can't get curl $what list\n";
 while( <CURL> )
 {
     $curl_protocols = $_ if ( /$what:/i );
-    $curl_protocols = uc($curl_protocols) if( $what eq "protocols" );
 }
 close CURL;
 
@@ -53,6 +52,7 @@ open(CURLCONFIG, "sh $ARGV[0] --$what|") || die "Can't get curl-config $what lis
 while( <CURLCONFIG> )
 {
     chomp;
+    $_ = lc($_) if($what eq "protocols");  # accept uppercase protocols in curl-config
     push @curl_config, $_;
 }
 close CURLCONFIG;

--- a/tests/libtest/test1013.pl
+++ b/tests/libtest/test1013.pl
@@ -44,7 +44,6 @@ close CURL;
 $curl_protocols =~ s/\r//;
 $curl_protocols =~ /\w+: (.*)$/;
 @curl = split / /,$1;
-@curl = sort @curl;
 
 # Read the output of curl-config
 my @curl_config;
@@ -57,7 +56,11 @@ while( <CURLCONFIG> )
 }
 close CURLCONFIG;
 
-@curl_config = sort @curl_config;
+# allow order mismatch to handle autotools builds with no 'sort -f' available
+if($what eq "features") {
+    @curl = sort @curl;
+    @curl_config = sort @curl_config;
+}
 
 my $curlproto = join ' ', @curl;
 my $curlconfigproto = join ' ', @curl_config;

--- a/tests/libtest/test1013.pl
+++ b/tests/libtest/test1013.pl
@@ -53,7 +53,6 @@ open(CURLCONFIG, "sh $ARGV[0] --$what|") || die "Can't get curl-config $what lis
 while( <CURLCONFIG> )
 {
     chomp;
-    # ignore curl-config --features not in curl's feature list
     push @curl_config, $_;
 }
 close CURLCONFIG;

--- a/tests/libtest/test1013.pl
+++ b/tests/libtest/test1013.pl
@@ -37,14 +37,14 @@ my $curl_protocols="";
 open(CURL, "$ARGV[1]") || die "Can't get curl $what list\n";
 while( <CURL> )
 {
-    $curl_protocols = lc($_) if ( /$what:/i );
+    $curl_protocols = $_ if ( /$what:/i );
+    $curl_protocols = uc($curl_protocols) if( $what eq "protocols" );
 }
 close CURL;
 
 $curl_protocols =~ s/\r//;
 $curl_protocols =~ /\w+: (.*)$/;
 @curl = split / /,$1;
-@curl = sort @curl;
 
 # Read the output of curl-config
 my @curl_config;
@@ -53,11 +53,9 @@ while( <CURLCONFIG> )
 {
     chomp;
     # ignore curl-config --features not in curl's feature list
-    push @curl_config, lc($_);
+    push @curl_config, $_;
 }
 close CURLCONFIG;
-
-@curl_config = sort @curl_config;
 
 my $curlproto = join ' ', @curl;
 my $curlconfigproto = join ' ', @curl_config;

--- a/tests/libtest/test1013.pl
+++ b/tests/libtest/test1013.pl
@@ -45,6 +45,7 @@ close CURL;
 $curl_protocols =~ s/\r//;
 $curl_protocols =~ /\w+: (.*)$/;
 @curl = split / /,$1;
+@curl = sort @curl;
 
 # Read the output of curl-config
 my @curl_config;
@@ -56,6 +57,8 @@ while( <CURLCONFIG> )
     push @curl_config, $_;
 }
 close CURLCONFIG;
+
+@curl_config = sort @curl_config;
 
 my $curlproto = join ' ', @curl;
 my $curlconfigproto = join ' ', @curl_config;


### PR DESCRIPTION
Update the script for test 1013 and 1014 to require:

- case-sensitive match for the curl feature list.
  (Continue to allow case-difference for protocols. They've always been
  in uppercase within curl config.)

- matching order for the protocol list.
  (Continue to allow any order for features. autotools builds on
  platforms without `sort -f` need it. E.g. Old Linux CI)

Also:

- fix casing of the `gsasl` feature in `configure`, to match `curl -V`
  and cmake.

- delete obsolete comment.
