### PR TITLE
test475: verify a 72K ASCII FTP upload

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1102,11 +1102,7 @@ static CURLcode do_init_reader_stack(struct Curl_easy *data,
   clen = r->crt->total_length(data, r);
   /* if we do not have 0 length init, and crlf conversion is wanted,
    * add the reader for it */
-  if(clen && (data->set.crlf
-#ifdef CURL_DO_LINEEND_CONV
-     || data->state.prefer_ascii
-#endif
-    )) {
+  if(clen && (data->set.crlf || data->state.prefer_ascii)) {
     result = cr_lc_add(data);
     if(result)
       return result;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -105,11 +105,6 @@ typedef unsigned int curl_prot_t;
 #define CURL_DEFAULT_USER "anonymous"
 #define CURL_DEFAULT_PASSWORD "ftp@example.com"
 
-#if !defined(_WIN32) && !defined(MSDOS) && !defined(__EMX__)
-/* do FTP line-end conversions on most platforms */
-#define CURL_DO_LINEEND_CONV
-#endif
-
 /* Convenience defines for checking protocols or their SSL based version. Each
    protocol handler should only ever have a single CURLPROTO_ in its protocol
    field. */

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -692,8 +692,11 @@ content
 
 ### `<stripfile4>`
 
-### `<upload>`
+### `<upload [crlf="yes"]>`
 the contents of the upload data curl should have sent
+
+`crlf=yes` forces *upload* newlines to become CRLF even if not written so in
+the source file.
 
 ### `<valgrind>`
 disable - disables the valgrind log check for this test

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -77,7 +77,7 @@ test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
 test462 test463 test467 test468 test469 test470 test471 test472 test473 \
-test474 test475 \
+test474 test475 test476 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -77,7 +77,7 @@ test435 test436 test437 test438 test439 test440 test441 test442 test443 \
 test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
 test462 test463 test467 test468 test469 test470 test471 test472 test473 \
-test474 \
+test474 test475 \
 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \

--- a/tests/data/test1050
+++ b/tests/data/test1050
@@ -2,6 +2,7 @@
 # Similar to test 253
 <info>
 <keywords>
+FTP
 FTP-ipv6
 IPv6
 EPRT

--- a/tests/data/test475
+++ b/tests/data/test475
@@ -1,0 +1,45 @@
+<testcase>
+<info>
+<keywords>
+FTP
+EPSV
+STOR
+TYPE A
+</keywords>
+</info>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+<name>
+FTP PASV upload ASCII file
+</name>
+<file name="%LOGDIR/test%TESTNUMBER.txt">
+%repeat[1750 x a line of text used for verifying this !%0a]%
+</file>
+<command>
+"ftp://%HOSTIP:%FTPPORT/%TESTNUMBER;type=a" -T %LOGDIR/test%TESTNUMBER.txt
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+QUIT
+</strip>
+<upload crlf="yes">
+%repeat[1750 x a line of text used for verifying this !%0a]%
+</upload>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+EPSV
+TYPE A
+STOR %TESTNUMBER
+QUIT
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test476
+++ b/tests/data/test476
@@ -1,0 +1,45 @@
+<testcase>
+<info>
+<keywords>
+FTP
+EPSV
+STOR
+TYPE A
+</keywords>
+</info>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+<name>
+FTP PASV upload ASCII file already using CRLF
+</name>
+<file name="%LOGDIR/test%TESTNUMBER.txt" crlf="yes">
+%repeat[1750 x a line of text used for verifying this !%0a]%
+</file>
+<command>
+"ftp://%HOSTIP:%FTPPORT/%TESTNUMBER;type=a" -T %LOGDIR/test%TESTNUMBER.txt
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+QUIT
+</strip>
+<upload crlf="yes">
+%repeat[1750 x a line of text used for verifying this !%0a]%
+</upload>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+PWD
+EPSV
+TYPE A
+STOR %TESTNUMBER
+QUIT
+</protocol>
+</verify>
+</testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1195,6 +1195,12 @@ sub singletest_count {
     return 0;
 }
 
+# Make sure all line endings in the array are the same: CRLF
+sub normalize_text {
+    my (@text) = @_;
+    s/\r\n/\n/g for @text;
+    s/\n/\r\n/g for @text;
+}
 
 #######################################################################
 # Verify test succeeded
@@ -1254,10 +1260,8 @@ sub singletest_check {
         # get the mode attribute
         my $filemode=$hash{'mode'};
         if($filemode && ($filemode eq "text")) {
-            s/\r\n/\n/g for @validstdout;
-            s/\n/\r\n/g for @validstdout;
-            s/\r\n/\n/g for @actual;
-            s/\n/\r\n/g for @actual;
+            normalize_text(\@validstdout);
+            normalize_text(\@actual);
         }
 
         if($hash{'nonewline'}) {
@@ -1310,13 +1314,11 @@ sub singletest_check {
             # text mode check in hyper-mode. Sometimes necessary if the stderr
             # data *looks* like HTTP and thus has gotten CRLF newlines
             # mistakenly
-            s/\r\n/\n/g for @validstderr;
+            normalize_text(\@validstderr);
         }
         if($filemode && ($filemode eq "text")) {
-            s/\r\n/\n/g for @validstderr;
-            s/\n/\r\n/g for @validstderr;
-            s/\r\n/\n/g for @actual;
-            s/\n/\r\n/g for @actual;
+            normalize_text(\@validstderr);
+            normalize_text(\@actual);
         }
 
         if($hash{'nonewline'}) {
@@ -1409,8 +1411,7 @@ sub singletest_check {
                 # get the mode attribute
                 my $filemode=$replycheckpartattr{'mode'};
                 if($filemode && ($filemode eq "text")) {
-                    s/\r\n/\n/g for @replycheckpart;
-                    s/\n/\r\n/g for @replycheckpart;
+                    normalize_text(\@replycheckpart);
                 }
                 if($replycheckpartattr{'nonewline'}) {
                     # Yes, we must cut off the final newline from the final line
@@ -1438,8 +1439,7 @@ sub singletest_check {
         # get the mode attribute
         my $filemode=$replyattr{'mode'};
         if($filemode && ($filemode eq "text")) {
-            s/\r\n/\n/g for @reply;
-            s/\n/\r\n/g for @reply;
+            normalize_text(\@reply);
         }
         if($replyattr{'crlf'} ||
            ($feature{"hyper"} && ($keywords{"HTTP"}
@@ -1455,8 +1455,7 @@ sub singletest_check {
         # get the mode attribute
         my $filemode=$replyattr{'mode'};
         if($filemode && ($filemode eq "text")) {
-            s/\r\n/\n/g for @out;
-            s/\n/\r\n/g for @out;
+            normalize_text(\@out);
         }
         $res = compare($runnerid, $testnum, $testname, "data", \@out, \@reply);
         if ($res) {
@@ -1588,10 +1587,8 @@ sub singletest_check {
 
             my $filemode=$hash{'mode'};
             if($filemode && ($filemode eq "text")) {
-                s/\r\n/\n/g for @outfile;
-                s/\n/\r\n/g for @outfile;
-                s/\r\n/\n/g for @generated;
-                s/\n/\r\n/g for @generated;
+                normalize_text(\@outfile);
+                normalize_text(\@generated);
             }
             if($hash{'crlf'} ||
                ($feature{"hyper"} && ($keywords{"HTTP"}

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -132,9 +132,6 @@ my $ftp_ipv6;       # set if FTP server has IPv6 support
 
 my $resolver;       # name of the resolver backend (for human presentation)
 
-my $has_textaware;  # set if running on a system that has a text mode concept
-                    # on files. Windows for example
-
 my %skipped;    # skipped{reason}=counter, reasons for skip
 my @teststat;   # teststat[testnum]=reason, reasons for skip
 my %disabled_keywords;  # key words of tests to skip
@@ -539,7 +536,6 @@ sub checksystemfeatures {
                 # This is a Windows MinGW build or native build, we need to use
                 # Windows-style path.
                 $pwd = sys_native_current_path();
-                $has_textaware = 1;
                 $feature{"win32"} = 1;
                 # set if built with MinGW (as opposed to MinGW-w64)
                 $feature{"MinGW"} = 1 if ($curl =~ /-pc-mingw32/);
@@ -1257,8 +1253,7 @@ sub singletest_check {
 
         # get the mode attribute
         my $filemode=$hash{'mode'};
-        if($filemode && ($filemode eq "text") && $has_textaware) {
-            # text mode when running on Windows: fix line endings
+        if($filemode && ($filemode eq "text")) {
             s/\r\n/\n/g for @validstdout;
             s/\n/\r\n/g for @validstdout;
             s/\r\n/\n/g for @actual;
@@ -1317,10 +1312,11 @@ sub singletest_check {
             # mistakenly
             s/\r\n/\n/g for @validstderr;
         }
-        if($filemode && ($filemode eq "text") && $has_textaware) {
-            # text mode when running on Windows: fix line endings
+        if($filemode && ($filemode eq "text")) {
             s/\r\n/\n/g for @validstderr;
             s/\n/\r\n/g for @validstderr;
+            s/\r\n/\n/g for @actual;
+            s/\n/\r\n/g for @actual;
         }
 
         if($hash{'nonewline'}) {
@@ -1412,8 +1408,7 @@ sub singletest_check {
                 my %replycheckpartattr = getpartattr("reply", "datacheck".$partsuffix);
                 # get the mode attribute
                 my $filemode=$replycheckpartattr{'mode'};
-                if($filemode && ($filemode eq "text") && $has_textaware) {
-                    # text mode when running on Windows: fix line endings
+                if($filemode && ($filemode eq "text")) {
                     s/\r\n/\n/g for @replycheckpart;
                     s/\n/\r\n/g for @replycheckpart;
                 }
@@ -1442,8 +1437,7 @@ sub singletest_check {
         }
         # get the mode attribute
         my $filemode=$replyattr{'mode'};
-        if($filemode && ($filemode eq "text") && $has_textaware) {
-            # text mode when running on Windows: fix line endings
+        if($filemode && ($filemode eq "text")) {
             s/\r\n/\n/g for @reply;
             s/\n/\r\n/g for @reply;
         }
@@ -1457,6 +1451,13 @@ sub singletest_check {
     if(!$replyattr{'nocheck'} && (@reply || $replyattr{'sendzero'})) {
         # verify the received data
         my @out = loadarray($CURLOUT);
+
+        # get the mode attribute
+        my $filemode=$replyattr{'mode'};
+        if($filemode && ($filemode eq "text")) {
+            s/\r\n/\n/g for @out;
+            s/\n/\r\n/g for @out;
+        }
         $res = compare($runnerid, $testnum, $testname, "data", \@out, \@reply);
         if ($res) {
             return -1;
@@ -1586,10 +1587,11 @@ sub singletest_check {
             my @stripfilepar = getpart("verify", "stripfile".$partsuffix);
 
             my $filemode=$hash{'mode'};
-            if($filemode && ($filemode eq "text") && $has_textaware) {
-                # text mode when running on Windows: fix line endings
+            if($filemode && ($filemode eq "text")) {
                 s/\r\n/\n/g for @outfile;
                 s/\n/\r\n/g for @outfile;
+                s/\r\n/\n/g for @generated;
+                s/\n/\r\n/g for @generated;
             }
             if($hash{'crlf'} ||
                ($feature{"hyper"} && ($keywords{"HTTP"}

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1489,6 +1489,9 @@ sub singletest_check {
                 eval $strip;
             }
         }
+        if($hash{'crlf'}) {
+            subnewlines(1, \$_) for @upload;
+        }
 
         $res = compare($runnerid, $testnum, $testname, "upload", \@out, \@upload);
         if ($res) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1197,9 +1197,9 @@ sub singletest_count {
 
 # Make sure all line endings in the array are the same: CRLF
 sub normalize_text {
-    my (@text) = @_;
-    s/\r\n/\n/g for @text;
-    s/\n/\r\n/g for @text;
+    my ($ref) = @_;
+    s/\r\n/\n/g for @$ref;
+    s/\n/\r\n/g for @$ref;
 }
 
 #######################################################################


### PR DESCRIPTION
Extended the test format and runtest.pl so that the verify/upload part can be marked using crlf newlines even when the client/file does not have it.