### PR TITLE
build: drop unused feature-detection code for Apple `poll()`

### DIFF
--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -88,23 +88,6 @@ if(NOT CMAKE_CROSSCOMPILING AND NOT APPLE)
       if(0 != poll(0, 0, 10)) {
         return 1; /* fail */
       }
-      else {
-        /* detect the 10.12 poll() breakage */
-        struct timeval before, after;
-        int rc;
-        size_t us;
-
-        gettimeofday(&before, NULL);
-        rc = poll(NULL, 0, 500);
-        gettimeofday(&after, NULL);
-
-        us = (after.tv_sec - before.tv_sec) * 1000000 +
-          (after.tv_usec - before.tv_usec);
-
-        if(us < 400000) {
-          return 1;
-        }
-      }
       return 0;
     }" HAVE_POLL_FINE)
 endif()

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3477,10 +3477,9 @@ AC_DEFUN([CURL_CHECK_FUNC_POLL], [
       AC_LANG_PROGRAM([[
         $curl_includes_stdlib
         $curl_includes_poll
-        $curl_includes_time
       ]],[[
         /* detect the original poll() breakage */
-        if(0 != poll(0, 0, 10))
+        if(0 != poll(0, 0, 10)) {
           return 1; /* fail */
         }
       ]])

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3481,22 +3481,7 @@ AC_DEFUN([CURL_CHECK_FUNC_POLL], [
       ]],[[
         /* detect the original poll() breakage */
         if(0 != poll(0, 0, 10))
-          exit(1); /* fail */
-        else {
-          /* detect the 10.12 poll() breakage */
-          struct timeval before, after;
-          int rc;
-          size_t us;
-
-          gettimeofday(&before, NULL);
-          rc = poll(NULL, 0, 500);
-          gettimeofday(&after, NULL);
-
-          us = (after.tv_sec - before.tv_sec) * 1000000 +
-            (after.tv_usec - before.tv_usec);
-
-          if(us < 400000)
-            exit(1);
+          return 1; /* fail */
         }
       ]])
     ],[


### PR DESCRIPTION
Drop Apple-specific detection logic for `poll()`. This detection snippet
has been disabled for Apple in both configure and cmake, for `poll()`
being broken on Apple since 10.12 Sierra (2016).

Also replace `exit(1);` with `return 1;` in configure, to make the
snippets match.

Added in 9297ca49f5f3caca938a679b9c1feeb719e61ddb #1057 (2016-10-11).

Disabled for:
configure/darwin in a34c7ce7546f39f24692925d66c2f42324dd94e9 (2016-10-18)
cmake/macOS in 825911be587bbabc3b7e4777ed3bd1bb7c858b58 #7619
cmake/iOS in d14831233df3a15b14db563156614c9ea60fcf06 #8244
cmake/all Apple in a86254b39307af1a53735b065a382567805cd9b8 #12515
