### PR TITLE
openssl quic, fix memory leak

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -434,6 +434,7 @@ static void cf_osslq_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
   CURL_TRC_CF(data, cf, "destroy");
   if(ctx) {
     CURL_TRC_CF(data, cf, "cf_osslq_destroy()");
+    cf_osslq_ctx_close(ctx);
     cf_osslq_ctx_free(ctx);
   }
   cf->ctx = NULL;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -434,7 +434,8 @@ static void cf_osslq_destroy(struct Curl_cfilter *cf, struct Curl_easy *data)
   CURL_TRC_CF(data, cf, "destroy");
   if(ctx) {
     CURL_TRC_CF(data, cf, "cf_osslq_destroy()");
-    cf_osslq_ctx_close(ctx);
+    if(ctx->tls.ossl.ssl)
+      cf_osslq_ctx_close(ctx);
     cf_osslq_ctx_free(ctx);
   }
   cf->ctx = NULL;


### PR DESCRIPTION
When a OpenSSL quic connection filter is aborted early, as the server was not responding, the ssl instances where not closed as they should.

refs #14720