### PR TITLE
configure: catch Apple in more target triplets

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1616,8 +1616,8 @@ dnl
 AC_DEFUN([CURL_DARWIN_CFLAGS], [
 
   tst_cflags="no"
-  case $host_os in
-    darwin*)
+  case $host in
+    *-apple-*)
       tst_cflags="yes"
       ;;
   esac

--- a/configure.ac
+++ b/configure.ac
@@ -591,8 +591,8 @@ CURL_CHECK_WIN32_CRYPTO
 
 CURL_DARWIN_CFLAGS
 
-case $host_os in
-  darwin*)
+case $host in
+  *-apple-*)
     CURL_SUPPORTS_BUILTIN_AVAILABLE
     ;;
 esac
@@ -1943,7 +1943,7 @@ if test x"$want_gss" = xyes; then
     LIBS="-lgss $LIBS"
   elif test -z "$GSSAPI_LIB_DIR"; then
     case $host in
-      *-*-darwin*)
+      *-apple-*)
         LIBS="-lgssapi_krb5 -lresolv $LIBS"
         ;;
       *)
@@ -2667,8 +2667,8 @@ dnl Check for the presence of AppleIDN
 dnl **********************************************************************
 
 tst_links_appleidn='no'
-case $host_os in
-  darwin*)
+case $host in
+  *-apple-*)
     AC_MSG_CHECKING([whether to build with Apple IDN])
     OPT_IDN="default"
     AC_ARG_WITH(apple-idn,

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3409,8 +3409,8 @@ AC_DEFUN([CURL_CHECK_FUNC_POLL], [
   tst_works_poll="unknown"
   tst_allow_poll="unknown"
   #
-  case $host_os in
-    darwin*|interix*)
+  case $host in
+    *-apple-*|*-*-interix*)
       dnl poll() does not work on these platforms
       dnl Interix: "does provide poll(), but the implementing developer must
       dnl have been in a bad mood, because poll() only works on the /proc
@@ -4870,8 +4870,8 @@ dnl CURL_LIBRARY_PATH variable. It keeps the LD_LIBRARY_PATH
 dnl changes contained within this macro.
 
 AC_DEFUN([CURL_RUN_IFELSE], [
-  case $host_os in
-    darwin*)
+  case $host in
+    *-apple-*)
       AC_RUN_IFELSE([AC_LANG_SOURCE([$1])], $2, $3, $4)
       ;;
     *)

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1473,6 +1473,11 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
   #
   if test "$curl_cv_func_getaddrinfo" = "yes"; then
     AC_MSG_CHECKING([if getaddrinfo is threadsafe])
+    case $host in
+      *-apple-*)
+        dnl Darwin 6.0 and macOS 10.2.X and newer
+        tst_tsafe_getaddrinfo="yes"
+    esac
     case $host_os in
       aix[[1234]].* | aix5.[[01]].*)
         dnl AIX 5.1 and older
@@ -1485,10 +1490,6 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
       darwin[[12345]].*)
         dnl Darwin 5.0 and macOS 10.1.X and older
         tst_tsafe_getaddrinfo="no"
-        ;;
-      darwin*)
-        dnl Darwin 6.0 and macOS 10.2.X and newer
-        tst_tsafe_getaddrinfo="yes"
         ;;
       freebsd[[1234]].* | freebsd5.[[1234]]*)
         dnl FreeBSD 5.4 and older

--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -34,8 +34,8 @@ if test "x$OPT_RUSTLS" != xno; then
   CLEANLDFLAGS="$LDFLAGS"
   CLEANCPPFLAGS="$CPPFLAGS"
 
-  case $host_os in
-    darwin*)
+  case $host in
+    *-apple-*)
       LDFLAGS="$LDFLAGS -framework Security"
       ;;
     *)

--- a/m4/curl-sysconfig.m4
+++ b/m4/curl-sysconfig.m4
@@ -24,8 +24,8 @@
 
 AC_DEFUN([CURL_DARWIN_SYSTEMCONFIGURATION], [
 AC_MSG_CHECKING([whether to link macOS CoreFoundation, CoreServices, and SystemConfiguration frameworks])
-case $host_os in
-  darwin*)
+case $host in
+  *-apple-*)
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         #include <sys/types.h>


### PR DESCRIPTION
Before this patch, only these triplets were considered Apple:
`<cpu>-apple-darwin`

After this patch, these are also considered Apple:
`<cpu>-apple-(ios*|tvos*|visionos*|watchos*|<ETC>)`

`$host_os` (the last third of the triplet) still has a valid use
to differentiate between OS flavours, though for now this isn't
used, aligning with CMake.
