### PR TITLE
dump-ca-embed.md: set as "boolean", not "single"

### DIFF
--- a/docs/cmdline-opts/dump-ca-embed.md
+++ b/docs/cmdline-opts/dump-ca-embed.md
@@ -6,7 +6,7 @@ Help: Write the embedded CA bundle to standard output
 Protocols: TLS
 Category: http proxy tls
 Added: 8.10.0
-Multi: single
+Multi: boolean
 See-also:
   - ca-native
   - cacert


### PR DESCRIPTION
Because it is. And it makes the template manpage explanation for it make sense.

Follow-up to 8a3740bc8e558b9a9d4a652b