### PR TITLE
managen: fix superfluous leading blank line in quoted sections

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -374,7 +374,9 @@ sub render {
         elsif($d =~ /^    (.*)/) {
             my $word = $1;
             if(!$quote && $manpage) {
+                push @desc, "\n" if($blankline);
                 push @desc, ".nf\n";
+                $blankline = 0;
             }
             $quote = 1;
             $d = "$word\n";

--- a/tests/data/test1705
+++ b/tests/data/test1705
@@ -222,8 +222,8 @@ sensitive data, including usernames, credentials or secret data content. Be
 aware and be careful when sharing trace logs with others.
 
 End with a quote
-.nf
 
+.nf
 hello
 .fi
 


### PR DESCRIPTION
When a markdown quoted section using 4-space indentation was converted to nroff, managen previously caused a newline to appear after the leading .nf. This fix makes sure that newline is inserted *before* .nf as intended.

This is perhaps most notable in the HTML version of rendered manpages if the quoted sections use different colors or similar.