### PR TITLE
cmake: use host OS to decide about libcurl manpage batch size

### DIFF
--- a/docs/libcurl/CMakeLists.txt
+++ b/docs/libcurl/CMakeLists.txt
@@ -27,7 +27,7 @@ include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 function(add_manual_pages _listname)
   # Maximum number of files per command to stay within shell/OS limits
-  if(UNIX)
+  if(CMAKE_HOST_UNIX)
     set(_files_per_batch 10000)
   else()  # e.g. Windows with cmd.exe and other obsolete/unidentified shells
     set(_files_per_batch 200)


### PR DESCRIPTION
Before this patch the targe OS was used, which prevented building
libcurl manpages in larger batches in cross-builds targeting e.g.
Windows.

Update the condition to use `CMAKE_HOST_UNIX` instead of `UNIX`.

This variable has been available since CMake 2.6.0:
https://github.com/Kitware/CMake/commit/176fe63d151d60e90edd4bd01eaac7d1b74241cd

Follow-up to bb84f82476df2b54c81693616d385e51c490c9e7 #13207
