### PR TITLE
build: add `poll()` detection for cross-builds

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-linux-musl-x64'
+          export CW_CONFIG='-main-werror-linux-musl-r64-x64'
           export CW_REVISION='${{ github.sha }}'
           . ./_versions.sh
           docker trust inspect --pretty "${DOCKER_IMAGE}"

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -45,6 +45,32 @@ env:
   DOCKER_CONTENT_TRUST: '1'
 
 jobs:
+  linux-glibc-llvm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          path: 'curl'
+          fetch-depth: 8
+      - name: 'build'
+        run: |
+          git clone --depth 1 https://github.com/curl/curl-for-win
+          mv curl-for-win/* .
+          export CW_CONFIG='-main-werror-linux-a64-x64'
+          export CW_REVISION='${{ github.sha }}'
+          DOCKER_IMAGE='debian:bookworm-slim'
+          export CW_CCSUFFIX='-15'
+          export CW_GCCSUFFIX='-12'
+          docker trust inspect --pretty "${DOCKER_IMAGE}"
+          time docker pull "${DOCKER_IMAGE}"
+          docker images --digests
+          time docker run --volume "$(pwd):$(pwd)" --workdir "$(pwd)" \
+            --env-file <(env | grep -a -E \
+              '^(CW_|GITHUB_)') \
+            "${DOCKER_IMAGE}" \
+            sh -c ./_ci-linux-debian.sh
+
   linux-musl-llvm:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -77,10 +77,10 @@ check_c_source_compiles("${_source_epilogue}
 unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
 
 if(NOT APPLE)
+  set(_source_epilogue "#undef inline")
+  add_header_include(HAVE_SYS_POLL_H "sys/poll.h")
+  add_header_include(HAVE_POLL_H "poll.h")
   if(NOT CMAKE_CROSSCOMPILING)
-    set(_source_epilogue "#undef inline")
-    add_header_include(HAVE_SYS_POLL_H "sys/poll.h")
-    add_header_include(HAVE_POLL_H "poll.h")
     check_c_source_runs("${_source_epilogue}
       #include <stdlib.h>
       int main(void)
@@ -91,12 +91,12 @@ if(NOT APPLE)
         return 0;
       }" HAVE_POLL_FINE)
   elseif(UNIX)
-    check_c_source_compiles("
+    check_c_source_compiles("${_source_epilogue}
       #include <stdlib.h>
       int main(void)
       {
         #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
-          return 0;
+          (void)poll(0, 0, 0);
         #else
           #error force compilation error
         #endif

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -76,20 +76,32 @@ check_c_source_compiles("${_source_epilogue}
 
 unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
 
-if(NOT CMAKE_CROSSCOMPILING AND NOT APPLE)
-  set(_source_epilogue "#undef inline")
-  add_header_include(HAVE_SYS_POLL_H "sys/poll.h")
-  add_header_include(HAVE_POLL_H "poll.h")
-  check_c_source_runs("${_source_epilogue}
-    #include <stdlib.h>
-    #include <sys/time.h>
-    int main(void)
-    {
-      if(0 != poll(0, 0, 10)) {
-        return 1; /* fail */
-      }
-      return 0;
-    }" HAVE_POLL_FINE)
+if(NOT APPLE)
+  if(NOT CMAKE_CROSSCOMPILING)
+    set(_source_epilogue "#undef inline")
+    add_header_include(HAVE_SYS_POLL_H "sys/poll.h")
+    add_header_include(HAVE_POLL_H "poll.h")
+    check_c_source_runs("${_source_epilogue}
+      #include <stdlib.h>
+      int main(void)
+      {
+        if(0 != poll(0, 0, 10)) {
+          return 1; /* fail */
+        }
+        return 0;
+      }" HAVE_POLL_FINE)
+  elseif(UNIX)
+    check_c_source_compiles("
+      #include <stdlib.h>
+      int main(void)
+      {
+        #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+          return 0;
+        #else
+          #error force compilation error
+        #endif
+      }" HAVE_POLL_FINE)
+  endif()
 endif()
 
 # Detect HAVE_GETADDRINFO_THREADSAFE

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3492,7 +3492,7 @@ AC_DEFUN([CURL_CHECK_FUNC_POLL], [
       ])
     else
       AC_MSG_CHECKING([if native poll seems to be supported])
-      CURL_RUN_IFELSE([
+      AC_COMPILE_IFELSE([
         AC_LANG_PROGRAM([[
           $curl_includes_stdlib
         ]],[[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3470,26 +3470,46 @@ AC_DEFUN([CURL_CHECK_FUNC_POLL], [
   fi
   #
   dnl only do runtime verification when not cross-compiling
-  if test "x$cross_compiling" != "xyes" &&
-    test "$tst_compi_poll" = "yes"; then
-    AC_MSG_CHECKING([if poll seems to work])
-    CURL_RUN_IFELSE([
-      AC_LANG_PROGRAM([[
-        $curl_includes_stdlib
-        $curl_includes_poll
-      ]],[[
-        /* detect the original poll() breakage */
-        if(0 != poll(0, 0, 10)) {
-          return 1; /* fail */
-        }
-      ]])
-    ],[
-      AC_MSG_RESULT([yes])
-      tst_works_poll="yes"
-    ],[
-      AC_MSG_RESULT([no])
-      tst_works_poll="no"
-    ])
+  if test "$tst_compi_poll" = "yes"; then
+    if test "x$cross_compiling" != "xyes"; then
+      AC_MSG_CHECKING([if poll seems to work])
+      CURL_RUN_IFELSE([
+        AC_LANG_PROGRAM([[
+          $curl_includes_stdlib
+          $curl_includes_poll
+        ]],[[
+          /* detect the original poll() breakage */
+          if(0 != poll(0, 0, 10)) {
+            return 1; /* fail */
+          }
+        ]])
+      ],[
+        AC_MSG_RESULT([yes])
+        tst_works_poll="yes"
+      ],[
+        AC_MSG_RESULT([no])
+        tst_works_poll="no"
+      ])
+    else
+      AC_MSG_CHECKING([if native poll seems to be supported])
+      CURL_RUN_IFELSE([
+        AC_LANG_PROGRAM([[
+          $curl_includes_stdlib
+        ]],[[
+          #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+            return 0;
+          #else
+            #error force compilation error
+          #endif
+        ]])
+      ],[
+        AC_MSG_RESULT([yes])
+        tst_works_poll="yes"
+      ],[
+        AC_MSG_RESULT([no])
+        tst_works_poll="no"
+      ])
+    fi
   fi
   #
   if test "$tst_compi_poll" = "yes" &&


### PR DESCRIPTION
For cross-builds rely on `_POSIX_C_SOURCE` to decide if `poll()` is
supported, rather than just assuming it isn't.

This may still miss to detect `poll()` support, as seen for example with
Linux MUSL cross-builds.

Also:

- GHA/curl-for-win: enable RISC-V 64 cross-target for Linux MUSL.
  (to test this case with cmake, with a false-negative.)
  The first RISC-V 64 build in curl's CI.

- GHA/curl-for-win: add arm64/intel64 job for Linux glibc.
  (to test this case with cmake, and succeed.)

- cmake: delete unnecessary `#include <sys/time.h>` from non-cross-build
  `poll()` detection snippet.
  Follow-up tp cc8b8137659e1733fdd3810c19ff5ec8db438509 #14718

Fixes #14714

---

w/o whitespace: https://github.com/curl/curl/pull/14734/files?w=1