### PR TITLE
managen: in man output, remove the leading space from examples

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -803,7 +803,7 @@ sub single {
                 $e =~ s!\$URL!https://example.com!g;
                 # convert single backslahes to doubles
                 $e =~ s/\\/\\\\/g;
-                print " curl $e\n";
+                print "curl $e\n";
             }
             print ".fi\n";
         }

--- a/tests/data/test1705
+++ b/tests/data/test1705
@@ -234,7 +234,7 @@ Disable it again with \-\-no-fakeitreal.
 
 Example:
 .nf
- curl --verbose https://example.com
+curl --verbose https://example.com
 .fi
 
 This option is mutually exclusive with \fI\-\-trace\fP and \fI\-\-trace\-ascii\fP.
@@ -272,7 +272,7 @@ If --proto is provided several times, the last set value is used.
 
 Example:
 .nf
- curl --proto =http,https,sftp https://example.com
+curl --proto =http,https,sftp https://example.com
 .fi
 
 See also \fI-v, \-\-fakeitreal\fP and \fI\-\-proto\-default\fP.


### PR DESCRIPTION
Leave that rendering decision to the display tool.