### PR TITLE
cmdline-opts: language fix for expect100-timeout.md and max-time.md

### DIFF
--- a/docs/cmdline-opts/expect100-timeout.md
+++ b/docs/cmdline-opts/expect100-timeout.md
@@ -21,5 +21,5 @@ response when curl emits an Expects: 100-continue header in its request. By
 default curl waits one second. This option accepts decimal values. When curl
 stops waiting, it continues as if a response was received.
 
-The decimal value needs to provided using a dot (`.`) as decimal separator -
+The decimal value needs to be provided using a dot (`.`) as decimal separator -
 not the local version even if it might be using another separator.

--- a/docs/cmdline-opts/http3.md
+++ b/docs/cmdline-opts/http3.md
@@ -30,6 +30,6 @@ host and port.
 When asked to use HTTP/3, curl issues a separate attempt to use older HTTP
 versions with a slight delay, so if the HTTP/3 transfer fails or is slow, curl
 still tries to proceed with an older HTTP version. The fallback performs the
-regular negoatiaion between HTTP/1 and HTTP/2.
+regular negotiation between HTTP/1 and HTTP/2.
 
 Use --http3-only for similar functionality *without* a fallback.

--- a/docs/cmdline-opts/max-time.md
+++ b/docs/cmdline-opts/max-time.md
@@ -26,5 +26,5 @@ If you enable retrying the transfer (--retry) then the maximum time counter is
 reset each time the transfer is retried. You can use --retry-max-time to limit
 the retry time.
 
-The decimal value needs to provided using a dot (.) as decimal separator - not
-the local version even if it might be using another separator.
+The decimal value needs to be provided using a dot (.) as decimal separator -
+not the local version even if it might be using another separator.


### PR DESCRIPTION
needs to **be** provided