### PR TITLE
llist: clear the list pointer when a node is removed

### DIFF
--- a/lib/llist.c
+++ b/lib/llist.c
@@ -170,6 +170,7 @@ Curl_node_uremove(struct Curl_llist_node *e, void *user)
 
   ptr = e->_ptr;
 
+  e->_list = NULL;
   e->_ptr  = NULL;
   e->_prev = NULL;
   e->_next = NULL;


### PR DESCRIPTION
When removing a node from its list, clear its internal `_list` pointer to indicate that it is now orphaned.