### PR TITLE
configure: fix to detect `RANDOM_FILE` in more builds

### DIFF
--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -69,6 +69,30 @@ jobs:
       - name: compare generated curl_config.h files
         run: ./.github/scripts/cmp-config.pl lib/curl_config.h build/lib/curl_config.h
 
+  check-macos-securetransport:
+    runs-on: macos-latest
+    steps:
+      - name: install packages
+        run: |
+          while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew install libtool autoconf automake && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
+
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: run configure --with-secure-transport
+        run: |
+          autoreconf -fi
+          ./configure --with-secure-transport --without-libpsl
+
+      - name: run cmake
+        run: |
+          cmake -B build -DCURL_USE_LIBPSL=OFF \
+            "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
+            -DCURL_USE_SECTRANSP=ON -DCURL_USE_OPENSSL=OFF \
+            -DCURL_USE_LIBSSH2=OFF
+
+      - name: compare generated curl_config.h files
+        run: ./.github/scripts/cmp-config.pl lib/curl_config.h build/lib/curl_config.h
+
   check-windows:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -46,6 +46,23 @@ jobs:
       - name: compare generated curl_config.h files
         run: ./.github/scripts/cmp-config.pl lib/curl_config.h build/lib/curl_config.h
 
+  check-linux-nossl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+
+      - name: run configure --without-ssl
+        run: |
+          autoreconf -fi
+          ./configure --without-ssl --without-libpsl
+
+      - name: run cmake
+        run: |
+          cmake -B build -DCURL_USE_OPENSSL=OFF -DCURL_USE_LIBPSL=OFF
+
+      - name: compare generated curl_config.h files
+        run: ./.github/scripts/cmp-config.pl lib/curl_config.h build/lib/curl_config.h
+
   check-macos:
     runs-on: macos-latest
     steps:
@@ -64,30 +81,6 @@ jobs:
         run: |
           cmake -B build -DCURL_USE_LIBPSL=OFF \
             "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
-            -DCURL_USE_LIBSSH2=OFF
-
-      - name: compare generated curl_config.h files
-        run: ./.github/scripts/cmp-config.pl lib/curl_config.h build/lib/curl_config.h
-
-  check-macos-securetransport:
-    runs-on: macos-latest
-    steps:
-      - name: install packages
-        run: |
-          while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew install libtool autoconf automake && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
-
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-
-      - name: run configure --with-secure-transport
-        run: |
-          autoreconf -fi
-          ./configure --with-secure-transport --without-libpsl
-
-      - name: run cmake
-        run: |
-          cmake -B build -DCURL_USE_LIBPSL=OFF \
-            "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
-            -DCURL_USE_SECTRANSP=ON -DCURL_USE_OPENSSL=OFF \
             -DCURL_USE_LIBSSH2=OFF
 
       - name: compare generated curl_config.h files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1444,10 +1444,6 @@ if(NOT WIN32 AND NOT CMAKE_CROSSCOMPILING AND
   mark_as_advanced(RANDOM_FILE)
 endif()
 
-if(USE_RUSTLS AND NOT HAVE_ARC4RANDOM)
-  message(FATAL_ERROR "Rustls requires arc4random.")
-endif()
-
 # Check for some functions that are used
 if(WIN32)
   set(CMAKE_REQUIRED_LIBRARIES "ws2_32")
@@ -1537,6 +1533,10 @@ if(WIN32)
   check_type_size("ADDRESS_FAMILY" SIZEOF_ADDRESS_FAMILY)
   set(HAVE_ADDRESS_FAMILY ${HAVE_SIZEOF_ADDRESS_FAMILY})
   set(CMAKE_EXTRA_INCLUDE_FILES "")
+endif()
+
+if(USE_RUSTLS AND NOT HAVE_ARC4RANDOM)
+  message(FATAL_ERROR "Rustls requires arc4random.")
 endif()
 
 # Do curl specific tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1444,6 +1444,10 @@ if(NOT WIN32 AND NOT CMAKE_CROSSCOMPILING AND
   mark_as_advanced(RANDOM_FILE)
 endif()
 
+if(USE_RUSTLS AND NOT HAVE_ARC4RANDOM)
+  message(FATAL_ERROR "Rustls requires arc4random.")
+endif()
+
 # Check for some functions that are used
 if(WIN32)
   set(CMAKE_REQUIRED_LIBRARIES "ws2_32")

--- a/configure.ac
+++ b/configure.ac
@@ -2112,8 +2112,8 @@ dnl **********************************************************************
 dnl Check for the random seed preferences
 dnl **********************************************************************
 
-dnl Check for user-specified random device
 if test "$curl_cv_native_windows" != 'yes'; then
+  dnl Check for user-specified random device
   AC_ARG_WITH(random,
   AS_HELP_STRING([--with-random=FILE],
                  [read randomness from FILE (default=/dev/urandom)]),

--- a/configure.ac
+++ b/configure.ac
@@ -2109,6 +2109,32 @@ elif test yes = "$VALID_DEFAULT_SSL_BACKEND"; then
 fi
 
 dnl **********************************************************************
+dnl Check for the random seed preferences
+dnl **********************************************************************
+
+dnl Check for user-specified random device
+if test "$curl_cv_native_windows" != 'yes'; then
+  AC_ARG_WITH(random,
+  AS_HELP_STRING([--with-random=FILE],
+                 [read randomness from FILE (default=/dev/urandom)]),
+    [ RANDOM_FILE="$withval" ],
+    [
+      if test x$cross_compiling != xyes; then
+        dnl Check for random device
+        AC_CHECK_FILE("/dev/urandom", [ RANDOM_FILE="/dev/urandom"] )
+      else
+        AC_MSG_WARN([skipped the /dev/urandom detection when cross-compiling])
+      fi
+    ]
+  )
+  if test -n "$RANDOM_FILE" && test X"$RANDOM_FILE" != Xno; then
+    AC_SUBST(RANDOM_FILE)
+    AC_DEFINE_UNQUOTED(RANDOM_FILE, "$RANDOM_FILE",
+    [a suitable file to read random data from])
+  fi
+fi
+
+dnl **********************************************************************
 dnl Check for the CA bundle
 dnl **********************************************************************
 

--- a/configure.ac
+++ b/configure.ac
@@ -4028,6 +4028,10 @@ AC_CHECK_FUNCS([\
   utimes \
 ])
 
+if test "$RUSTLS_ENABLED" = '1' -a "$HAVE_ARC4RANDOM" != '1'; then
+  AC_MSG_ERROR([Rustls requires arc4random.])
+fi
+
 if test "$curl_cv_native_windows" != 'yes'; then
   AC_CHECK_FUNCS([fseeko])
 

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -147,7 +147,8 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,
   }
 #endif
 
-#if defined(HAVE_ARC4RANDOM) && !defined(USE_OPENSSL)
+#if defined(HAVE_ARC4RANDOM) && \
+  !(defined(USE_OPENSSL) && defined(LIBRESSL_VERSION_NUMBER))
   if(!seeded) {
     *rnd = (unsigned int)arc4random();
     return CURLE_OK;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -43,6 +43,10 @@
 #include "connect.h" /* for the connect timeout */
 #include "cipher_suite.h"
 
+#if !defined(HAVE_ARC4RANDOM)
+#error "Rustls requires arc4random"
+#endif
+
 struct rustls_ssl_backend_data
 {
   const struct rustls_client_config *config;

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -359,32 +359,6 @@ if test X"$OPT_OPENSSL" != Xno &&
   AC_MSG_ERROR([--with-openssl was given but OpenSSL could not be detected])
 fi
 
-dnl **********************************************************************
-dnl Check for the random seed preferences
-dnl **********************************************************************
-
-if test X"$OPENSSL_ENABLED" = X"1"; then
-  dnl Check for user-specified random device
-  AC_ARG_WITH(random,
-  AS_HELP_STRING([--with-random=FILE],
-                 [read randomness from FILE (default=/dev/urandom)]),
-    [ RANDOM_FILE="$withval" ],
-    [
-      if test x$cross_compiling != xyes; then
-        dnl Check for random device
-        AC_CHECK_FILE("/dev/urandom", [ RANDOM_FILE="/dev/urandom"] )
-      else
-        AC_MSG_WARN([skipped the /dev/urandom detection when cross-compiling])
-      fi
-    ]
-  )
-  if test -n "$RANDOM_FILE" && test X"$RANDOM_FILE" != Xno; then
-    AC_SUBST(RANDOM_FILE)
-    AC_DEFINE_UNQUOTED(RANDOM_FILE, "$RANDOM_FILE",
-    [a suitable file to read random data from])
-  fi
-fi
-
 dnl ---
 dnl We require OpenSSL with SRP support.
 dnl ---


### PR DESCRIPTION
Before this patch, `./configure` detected `RANDOM_FILE` only for builds
with the OpenSSL backend enabled. It was initially detected regardless
of backend, then [1] made it OpenSSL-specific because `RANDOM_FILE` was
solely used with OpenSSL. Many years later it got [2] a new use in
a generic random function though, and this use only expanded since.

Make `RANDOM_FILE` detected again regardless of TLS-backend, also
syncing behaviour with cmake.

In most builds the TLS backend provides the random source, so affected
builds were limited to those without one, specifically:
- mbedTLS, when using a build without built-in random support.
- Rustls.

(It's also an option to limit detection to OpenSSL/mbedTLS/Rustls, but
it risks making the codebase  fragile.)

Also:
- exclude detection for Windows. Windows builds don't use the
  `RANDOM_FILE` macro.
- GHA/configure-vs-cmake: add Linux job to test this.

Example log demonstrating the difference between autotools and cmake:
https://github.com/curl/curl/actions/runs/10636096088/job/29487155759#step:5:31

[1] df3ca59116bff161c0fa44b1af7915dc8c1da20e
[2] 365c5ba39591fab2e60bf4f0e67d9dcf79ecc506

---

- [x] move cmake fixes (one revealed by the CI job added here) to separate PR. → #14745
- [x] rebase on #14745 to fix CI.
- [ ] move `rand: exclude arc4random for LibreSSL only` to separate PR.
- [ ] move Rustls to require arc4random to separate PR? (makes Linux rustls CI fail)
