### PR TITLE
cmake: sync `CURL_DISABLE_*` behaviour with autotools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,10 +331,6 @@ option(CURL_DISABLE_VERBOSE_STRINGS "Disable verbose strings" OFF)
 mark_as_advanced(CURL_DISABLE_VERBOSE_STRINGS)
 
 if(CURL_DISABLE_HTTP)
-  if(NOT CURL_DISABLE_FTP OR
-     NOT CURL_DISABLE_RTSP)
-    message(WARNING "Disable HTTP disables FTP over proxy and RTSP")
-  endif()
   set(CURL_DISABLE_RTSP ON)
   set(CURL_DISABLE_ALTSVC ON)
   set(CURL_DISABLE_HSTS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,7 +331,6 @@ option(CURL_DISABLE_VERBOSE_STRINGS "Disable verbose strings" OFF)
 mark_as_advanced(CURL_DISABLE_VERBOSE_STRINGS)
 
 if(CURL_DISABLE_HTTP)
-  message(WARNING "Disable HTTP disables FTP over proxy and RTSP")
   set(CURL_DISABLE_RTSP ON)
   set(CURL_DISABLE_ALTSVC ON)
   set(CURL_DISABLE_HSTS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,10 @@ option(CURL_DISABLE_VERBOSE_STRINGS "Disable verbose strings" OFF)
 mark_as_advanced(CURL_DISABLE_VERBOSE_STRINGS)
 
 if(CURL_DISABLE_HTTP)
+  if(NOT CURL_DISABLE_FTP OR
+     NOT CURL_DISABLE_RTSP)
+    message(WARNING "Disable HTTP disables FTP over proxy and RTSP")
+  endif()
   set(CURL_DISABLE_RTSP ON)
   set(CURL_DISABLE_ALTSVC ON)
   set(CURL_DISABLE_HSTS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,8 @@ count_true(_enabled_ssl_options_count
 )
 if(_enabled_ssl_options_count GREATER 1)
   set(CURL_WITH_MULTI_SSL ON)
+elseif(_enabled_ssl_options_count EQUAL 0)
+  set(CURL_DISABLE_HSTS ON)
 endif()
 
 if(CURL_USE_SCHANNEL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,13 @@ mark_as_advanced(CURL_DISABLE_TFTP)
 option(CURL_DISABLE_VERBOSE_STRINGS "Disable verbose strings" OFF)
 mark_as_advanced(CURL_DISABLE_VERBOSE_STRINGS)
 
+if(CURL_DISABLE_HTTP)
+  message(WARNING "Disable HTTP disables FTP over proxy and RTSP")
+  set(CURL_DISABLE_RTSP ON)
+  set(CURL_DISABLE_ALTSVC ON)
+  set(CURL_DISABLE_HSTS ON)
+endif()
+
 # Corresponds to HTTP_ONLY in lib/curl_setup.h
 option(HTTP_ONLY "Disable all protocols except HTTP (This overrides all CURL_DISABLE_* options)" OFF)
 mark_as_advanced(HTTP_ONLY)


### PR DESCRIPTION
- disable RTSP, ALTSVC, HSTS when HTTP is disabled.
  (`./configure` warning deemed unnecessary and not replicated with
  cmake.)

- disable HSTS when there is no TLS backend.

Tested via #14744
