### PR TITLE
autotools: settle with option name: `--enable-windows-unicode`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,7 +53,7 @@ jobs:
           - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '', name: 'default R' }
           - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver --disable-curldebug --enable-static=no', name: 'default' }
-          - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: '~472 ~1299 ~1613'        , config: '--enable-debug --with-windows-unicode --enable-ares', name: 'c-ares U' }
+          - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: '~472 ~1299 ~1613'        , config: '--enable-debug --enable-windows-unicode --enable-ares', name: 'c-ares U' }
           # FIXME: WebSockets test results ignored due to frequent failures on native Windows:
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_ARES=ON', type: 'Debug', name: 'schannel c-ares U' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }

--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -8,7 +8,7 @@ curl and libcurl 8.10.0
 
 This release includes the following changes:
 
- o autotools: add `--with-windows-unicode` option [103]
+ o autotools: add `--enable-windows-unicode` option [103]
  o curl: --help [option] displays documentation for given cmdline option [19]
  o curl: add --skip-existing [54]
  o curl: for -O, use "default" as filename when the URL has none [34]

--- a/configure.ac
+++ b/configure.ac
@@ -2556,12 +2556,10 @@ dnl ----------------------------
 want_winuni="no"
 if test "$curl_cv_native_windows" = "yes"; then
   AC_MSG_CHECKING([whether to enable Windows Unicode (Windows native builds only)])
-  OPT_WINUNI="default"
-  AC_ARG_WITH(windows-unicode,
-AS_HELP_STRING([--with-windows-unicode],[enable Windows Unicode])
-AS_HELP_STRING([--without-windows-unicode], [disable Windows Unicode (default)]),
-    OPT_WINUNI=$withval)
-  case "$OPT_WINUNI" in
+  AC_ARG_ENABLE(windows-unicode,
+AS_HELP_STRING([--enable-windows-unicode],[Enable Windows Unicode])
+AS_HELP_STRING([--disable-windows-unicode],[Disable Windows Unicode (default)]),
+  [ case "$enableval" in
     yes)
       CPPFLAGS="${CPPFLAGS} -DUNICODE -D_UNICODE"
       want_winuni="yes"
@@ -2570,7 +2568,9 @@ AS_HELP_STRING([--without-windows-unicode], [disable Windows Unicode (default)])
     *)
       AC_MSG_RESULT([no])
       ;;
-  esac
+    esac ],
+      AC_MSG_RESULT([no])
+  )
 fi
 
 AM_CONDITIONAL([USE_UNICODE], [test "$want_winuni" = "yes"])


### PR DESCRIPTION
Bring the option name style in sync with cmake and with other configure
options aiming to enable something unrelated to an optional package.

(I initially named this new option `--with-windows-unicode` within this
release cycle.)

Follow-up to 9e4a2187e763dd80a1296b07fd3e073f46c4dc8f #14478
