### PR TITLE
lib: remove use of RANDOM_FILE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1440,12 +1440,6 @@ if(SIZEOF_SUSECONDS_T)
   set(HAVE_SUSECONDS_T 1)
 endif()
 
-if(NOT WIN32 AND NOT CMAKE_CROSSCOMPILING AND
-   (NOT DEFINED RANDOM_FILE OR RANDOM_FILE))
-  find_file(RANDOM_FILE "urandom" "/dev")
-  mark_as_advanced(RANDOM_FILE)
-endif()
-
 # Check for some functions that are used
 if(WIN32)
   set(CMAKE_REQUIRED_LIBRARIES "ws2_32")

--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -65,9 +65,6 @@
 /* Define this to 'int' if ssize_t is not an available typedefed type */
 #undef ssize_t
 
-/* Define this as a suitable file to read random data from */
-#undef RANDOM_FILE
-
 /* Define to 1 if you have the alarm function. */
 #define HAVE_ALARM 1
 

--- a/lib/config-plan9.h
+++ b/lib/config-plan9.h
@@ -41,7 +41,6 @@
 #define PACKAGE_STRING "curl -"
 #define PACKAGE_TARNAME "curl"
 #define PACKAGE_VERSION "-"
-#define RANDOM_FILE "/dev/random"
 #define VERSION "0.0.0" /* TODO */
 
 #define STDC_HEADERS 1

--- a/lib/config-riscos.h
+++ b/lib/config-riscos.h
@@ -63,9 +63,6 @@
 /* Define this to 'int' if ssize_t is not an available typedefed type */
 #undef ssize_t
 
-/* Define this as a suitable file to read random data from */
-#undef RANDOM_FILE
-
 /* Define if you have the alarm function. */
 #define HAVE_ALARM
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -638,9 +638,6 @@
 /* Define to the version of this package. */
 #cmakedefine PACKAGE_VERSION ${PACKAGE_VERSION}
 
-/* a suitable file to read random data from */
-#cmakedefine RANDOM_FILE "${RANDOM_FILE}"
-
 /*
  Note: SIZEOF_* variables are fetched with CMake through check_type_size().
  As per CMake documentation on CheckTypeSize, C preprocessor code is

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -100,17 +100,70 @@ CURLcode Curl_win32_random(unsigned char *entropy, size_t length)
 }
 #endif
 
+#if !defined(USE_SSL) || defined(USE_RUSTLS)
+/* ---- possibly non-cryptographic version following ---- */
+CURLcode Curl_weak_random(struct Curl_easy *data,
+                          unsigned char *entropy,
+                          size_t length) /* always 4, size of int */
+{
+  unsigned int r;
+  DEBUGASSERT(length == sizeof(int));
+
+  /* Trying cryptographically secure functions first */
+#ifdef _WIN32
+  (void)data;
+  {
+    CURLcode result = Curl_win32_random(entropy, length);
+    if(result != CURLE_NOT_BUILT_IN)
+      return result;
+  }
+#endif
+
+#if defined(HAVE_ARC4RANDOM)
+  (void)data;
+  r = (unsigned int)arc4random();
+  memcpy(entropy, &r, length);
+#else
+  infof(data, "WARNING: using weak random seed");
+  {
+    static unsigned int randseed;
+    static bool seeded = FALSE;
+    unsigned int rnd;
+    if(!seeded) {
+      struct curltime now = Curl_now();
+      randseed += (unsigned int)now.tv_usec + (unsigned int)now.tv_sec;
+      randseed = randseed * 1103515245 + 12345;
+      randseed = randseed * 1103515245 + 12345;
+      randseed = randseed * 1103515245 + 12345;
+      seeded = TRUE;
+    }
+
+    /* Return an unsigned 32-bit pseudo-random number. */
+    r = randseed = randseed * 1103515245 + 12345;
+    rnd = (r << 16) | ((r >> 16) & 0xFFFF);
+    memcpy(entropy, &rnd, length);
+  }
+#endif
+  return CURLE_OK;
+}
+#endif
+
+#ifdef USE_SSL
+#define _random(x,y,z) Curl_ssl_random(x,y,z)
+#else
+#define _random(x,y,z) Curl_weak_random(x,y,z)
+#endif
+
 static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,
                        bool env_override)
 {
-  CURLcode result = CURLE_OK;
-  static unsigned int randseed;
-  static bool seeded = FALSE;
-
 #ifdef DEBUGBUILD
   if(env_override) {
     char *force_entropy = getenv("CURL_ENTROPY");
     if(force_entropy) {
+      static unsigned int randseed;
+      static bool seeded = FALSE;
+
       if(!seeded) {
         unsigned int seed = 0;
         size_t elen = strlen(force_entropy);
@@ -131,46 +184,7 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,
 #endif
 
   /* data may be NULL! */
-  result = Curl_ssl_random(data, (unsigned char *)rnd, sizeof(*rnd));
-  if(result != CURLE_NOT_BUILT_IN)
-    /* only if there is no random function in the TLS backend do the non crypto
-       version, otherwise return result */
-    return result;
-
-  /* ---- non-cryptographic version following ---- */
-
-#ifdef _WIN32
-  if(!seeded) {
-    result = Curl_win32_random((unsigned char *)rnd, sizeof(*rnd));
-    if(result != CURLE_NOT_BUILT_IN)
-      return result;
-  }
-#endif
-
-#if defined(HAVE_ARC4RANDOM) && !defined(USE_OPENSSL)
-  if(!seeded) {
-    *rnd = (unsigned int)arc4random();
-    return CURLE_OK;
-  }
-#endif
-
-  if(!seeded) {
-    struct curltime now = Curl_now();
-    infof(data, "WARNING: using weak random seed");
-    randseed += (unsigned int)now.tv_usec + (unsigned int)now.tv_sec;
-    randseed = randseed * 1103515245 + 12345;
-    randseed = randseed * 1103515245 + 12345;
-    randseed = randseed * 1103515245 + 12345;
-    seeded = TRUE;
-  }
-
-  {
-    unsigned int r;
-    /* Return an unsigned 32-bit pseudo-random number. */
-    r = randseed = randseed * 1103515245 + 12345;
-    *rnd = (r << 16) | ((r >> 16) & 0xFFFF);
-  }
-  return CURLE_OK;
+  return _random(data, (unsigned char *)rnd, sizeof(*rnd));
 }
 
 /*

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -154,20 +154,6 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,
   }
 #endif
 
-#if defined(RANDOM_FILE) && !defined(_WIN32)
-  if(!seeded) {
-    /* if there is a random file to read a seed from, use it */
-    int fd = open(RANDOM_FILE, O_RDONLY);
-    if(fd > -1) {
-      /* read random data into the randseed variable */
-      ssize_t nread = read(fd, &randseed, sizeof(randseed));
-      if(nread == sizeof(randseed))
-        seeded = TRUE;
-      close(fd);
-    }
-  }
-#endif
-
   if(!seeded) {
     struct curltime now = Curl_now();
     infof(data, "WARNING: using weak random seed");

--- a/lib/rand.h
+++ b/lib/rand.h
@@ -36,6 +36,11 @@ CURLcode Curl_rand_bytes(struct Curl_easy *data,
 #define Curl_rand(a,b,c)   Curl_rand_bytes((a), (b), (c))
 #endif
 
+/* ---- non-cryptographic version following ---- */
+CURLcode Curl_weak_random(struct Curl_easy *data,
+                          unsigned char *rnd,
+                          size_t length);
+
 /*
  * Curl_rand_hex() fills the 'rnd' buffer with a given 'num' size with random
  * hexadecimal digits PLUS a null-terminating byte. It must be an odd number

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -998,12 +998,6 @@ static CURLcode ossl_seed(struct Curl_easy *data)
   return CURLE_SSL_CONNECT_ERROR;
 #else
 
-#ifdef RANDOM_FILE
-  RAND_load_file(RANDOM_FILE, RAND_LOAD_LENGTH);
-  if(rand_enough())
-    return CURLE_OK;
-#endif
-
   /* fallback to a custom seeding of the PRNG using a hash based on a current
      time */
   do {

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -42,6 +42,7 @@
 #include "multiif.h"
 #include "connect.h" /* for the connect timeout */
 #include "cipher_suite.h"
+#include "rand.h"
 
 struct rustls_ssl_backend_data
 {
@@ -1037,7 +1038,7 @@ const struct Curl_ssl Curl_ssl_rustls = {
   Curl_none_check_cxn,             /* check_cxn */
   cr_shutdown,                     /* shutdown */
   cr_data_pending,                 /* data_pending */
-  Curl_none_random,                /* random */
+  Curl_weak_random,                /* random */
   Curl_none_cert_status_request,   /* cert_status_request */
   cr_connect_blocking,             /* connect */
   cr_connect_nonblocking,          /* connect_nonblocking */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -71,6 +71,7 @@
 #include "connect.h"
 #include "select.h"
 #include "strdup.h"
+#include "rand.h"
 
 /* The last #include files should be: */
 #include "curl_memory.h"
@@ -923,7 +924,10 @@ CURLcode Curl_ssl_random(struct Curl_easy *data,
                          unsigned char *entropy,
                          size_t length)
 {
-  return Curl_ssl->random(data, entropy, length);
+  if(Curl_ssl->random)
+    return Curl_ssl->random(data, entropy, length);
+  else
+    return CURLE_NOT_BUILT_IN;
 }
 
 /*
@@ -1193,16 +1197,6 @@ int Curl_none_check_cxn(struct Curl_cfilter *cf, struct Curl_easy *data)
   return -1;
 }
 
-CURLcode Curl_none_random(struct Curl_easy *data UNUSED_PARAM,
-                          unsigned char *entropy UNUSED_PARAM,
-                          size_t length UNUSED_PARAM)
-{
-  (void)data;
-  (void)entropy;
-  (void)length;
-  return CURLE_NOT_BUILT_IN;
-}
-
 void Curl_none_close_all(struct Curl_easy *data UNUSED_PARAM)
 {
   (void)data;
@@ -1329,7 +1323,7 @@ static const struct Curl_ssl Curl_ssl_multi = {
   Curl_none_check_cxn,               /* check_cxn */
   Curl_none_shutdown,                /* shutdown */
   Curl_none_data_pending,            /* data_pending */
-  Curl_none_random,                  /* random */
+  NULL,                              /* random */
   Curl_none_cert_status_request,     /* cert_status_request */
   multissl_connect,                  /* connect */
   multissl_connect_nonblocking,      /* connect_nonblocking */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -920,10 +920,12 @@ CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data,
   return result;
 }
 
+/* get 32bits of random */
 CURLcode Curl_ssl_random(struct Curl_easy *data,
                          unsigned char *entropy,
                          size_t length)
 {
+  DEBUGASSERT(length == sizeof(int));
   if(Curl_ssl->random)
     return Curl_ssl->random(data, entropy, length);
   else

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -920,7 +920,7 @@ CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data,
   return result;
 }
 
-/* get 32bits of random */
+/* get 32 bits of random */
 CURLcode Curl_ssl_random(struct Curl_easy *data,
                          unsigned char *entropy,
                          size_t length)

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -171,8 +171,6 @@ void Curl_none_cleanup(void);
 CURLcode Curl_none_shutdown(struct Curl_cfilter *cf, struct Curl_easy *data,
                             bool send_shutdown, bool *done);
 int Curl_none_check_cxn(struct Curl_cfilter *cf, struct Curl_easy *data);
-CURLcode Curl_none_random(struct Curl_easy *data, unsigned char *entropy,
-                          size_t length);
 void Curl_none_close_all(struct Curl_easy *data);
 void Curl_none_session_free(void *ptr);
 bool Curl_none_data_pending(struct Curl_cfilter *cf,

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -359,32 +359,6 @@ if test X"$OPT_OPENSSL" != Xno &&
   AC_MSG_ERROR([--with-openssl was given but OpenSSL could not be detected])
 fi
 
-dnl **********************************************************************
-dnl Check for the random seed preferences
-dnl **********************************************************************
-
-if test X"$OPENSSL_ENABLED" = X"1"; then
-  dnl Check for user-specified random device
-  AC_ARG_WITH(random,
-  AS_HELP_STRING([--with-random=FILE],
-                 [read randomness from FILE (default=/dev/urandom)]),
-    [ RANDOM_FILE="$withval" ],
-    [
-      if test x$cross_compiling != xyes; then
-        dnl Check for random device
-        AC_CHECK_FILE("/dev/urandom", [ RANDOM_FILE="/dev/urandom"] )
-      else
-        AC_MSG_WARN([skipped the /dev/urandom detection when cross-compiling])
-      fi
-    ]
-  )
-  if test -n "$RANDOM_FILE" && test X"$RANDOM_FILE" != Xno; then
-    AC_SUBST(RANDOM_FILE)
-    AC_DEFINE_UNQUOTED(RANDOM_FILE, "$RANDOM_FILE",
-    [a suitable file to read random data from])
-  fi
-fi
-
 dnl ---
 dnl We require OpenSSL with SRP support.
 dnl ---


### PR DESCRIPTION
It could previously be set with configure/cmake and used in rare cases for reading randomness: with ancient mbedTLS or rustls without arc4random.

We now get randomness in this order:

1. The TLS library's way to provide random
2. On Windows: Curl_win32_random
3. if arc4random exists, use that
4. weak non-crytographically strong pseudo-random