### PR TITLE
rand: exclude arc4random for LibreSSL (3.8.x and earlier) only

### DIFF
--- a/lib/rand.c
+++ b/lib/rand.c
@@ -147,7 +147,8 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,
   }
 #endif
 
-#if defined(HAVE_ARC4RANDOM) && !defined(USE_OPENSSL)
+#if defined(HAVE_ARC4RANDOM) && \
+  !(defined(USE_OPENSSL) && defined(LIBRESSL_VERSION_NUMBER))
   if(!seeded) {
     *rnd = (unsigned int)arc4random();
     return CURLE_OK;

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -148,7 +148,9 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,
 #endif
 
 #if defined(HAVE_ARC4RANDOM) && \
-  !(defined(USE_OPENSSL) && defined(LIBRESSL_VERSION_NUMBER))
+  !(defined(USE_OPENSSL) && \
+    defined(LIBRESSL_VERSION_NUMBER) && \
+    LIBRESSL_VERSION_NUMBER < 0x3090000fL)
   if(!seeded) {
     *rnd = (unsigned int)arc4random();
     return CURLE_OK;


### PR DESCRIPTION
Use `arc4random` with OpenSSL-family again, except with LibreSSL, the
only fork that's incompatible with it.

LibreSSL 3.9.0 fixed the issue that required this workaround, so also
unlock `arc4random` for builds using that or newer.

Follow-up to 7925ba431b9a099daee1fa21d36c21887f787ad5 #12274

---

- [ ] rebase on #14749.
