### PR TITLE
test1165: check if `curl_config.h.cmake` lists all `DISABLED` options

### DIFF
--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -131,6 +131,9 @@
 /* disables RTSP */
 #cmakedefine CURL_DISABLE_RTSP 1
 
+/* disabled shuffle DNS feature */
+#cmakedefine CURL_DISABLE_SHUFFLE_DNS 1
+
 /* disables SMB */
 #cmakedefine CURL_DISABLE_SMB 1
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -89,6 +89,9 @@
 /* disables HTTP */
 #cmakedefine CURL_DISABLE_HTTP 1
 
+/* disabled all HTTP authentication methods */
+#cmakedefine CURL_DISABLE_HTTP_AUTH 1
+
 /* disables IMAP */
 #cmakedefine CURL_DISABLE_IMAP 1
 

--- a/tests/test1165.pl
+++ b/tests/test1165.pl
@@ -31,6 +31,8 @@ use warnings;
 my %disable;
 # the DISABLE options that can be set by CMakeLists.txt
 my %disable_cmake;
+# the DISABLE options propagated via curl_config.h.cmake
+my %disable_cmake_config_h;
 # the DISABLE options that are used in C files
 my %file;
 # the DISABLE options that are documented
@@ -64,13 +66,13 @@ sub scan_configure {
 }
 
 sub scanconf_cmake {
-    my ($f)=@_;
+    my ($hashr, $f)=@_;
     open S, "<$f";
     while(<S>) {
         if(/(CURL_DISABLE_[A-Z0-9_]+)/g) {
             my ($sym)=($1);
             if(not $sym =~ /^(CURL_DISABLE_INSTALL|CURL_DISABLE_TESTS|CURL_DISABLE_SRP)$/) {
-                $disable_cmake{$sym} = 1;
+                $hashr->{$sym} = 1;
             }
         }
     }
@@ -78,7 +80,11 @@ sub scanconf_cmake {
 }
 
 sub scan_cmake {
-    scanconf_cmake("$root/CMakeLists.txt");
+    scanconf_cmake(\%disable_cmake, "$root/CMakeLists.txt");
+}
+
+sub scan_cmake_config_h {
+    scanconf_cmake(\%disable_cmake_config_h, "$root/lib/curl_config.h.cmake");
 }
 
 sub scan_file {
@@ -127,6 +133,7 @@ sub scan_docs {
 
 scan_configure();
 scan_cmake();
+scan_cmake_config_h();
 scan_sources();
 scan_docs();
 
@@ -152,6 +159,14 @@ for my $s (sort keys %disable_cmake) {
     }
     if(!$docs{$s}) {
         printf "Present in CMakeLists.txt, not documented in $DOCS: %s\n", $s;
+        $error++;
+    }
+}
+
+# Check the CMakeLists.txt symbols for use in curl_config.h.cmake
+for my $s (sort keys %disable_cmake) {
+    if(!$disable_cmake_config_h{$s}) {
+        printf "Present in CMakeLists.txt, not propagated via curl_config.h.cmake: %s\n", $s;
         $error++;
     }
 }


### PR DESCRIPTION
Also fix issues:
- cmake: fix `CURL_DISABLE_HTTP_AUTH` option
- cmake: fix `CURL_DISABLE_SHUFFLE_DNS` option

Fixes:
```
Present in CMakeLists.txt, not propagated via curl_config.h.cmake: CURL_DISABLE_HTTP_AUTH
Present in CMakeLists.txt, not propagated via curl_config.h.cmake: CURL_DISABLE_SHUFFLE_DNS
```
Ref: https://github.com/curl/curl/actions/runs/10655027540/job/29532054141?pr=14754#step:11:2090
