### PR TITLE
schannel: avoid malloc for CAinfo_blob_digest

### DIFF
--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -165,7 +165,7 @@ struct schannel_ssl_backend_data {
 #define MPROTO_SCHANNEL_CERT_SHARE_KEY   "tls:schannel:cert:share"
 
 struct schannel_cert_share {
-  unsigned char *CAinfo_blob_digest; /* CA info blob digest */
+  unsigned char CAinfo_blob_digest[CURL_SHA256_DIGEST_LENGTH];
   size_t CAinfo_blob_size;           /* CA info blob size */
   char *CAfile;                      /* CAfile path used to generate
                                         certificate store */


### PR DESCRIPTION
...it can just as well be part of the struct always.