### PR TITLE
openssl: certinfo errors now fail correctly

### DIFF
--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -74,18 +74,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
 #define SSL_get1_peer_certificate SSL_get_peer_certificate
 #endif
 
-CURLcode Curl_ossl_verifyhost(struct Curl_easy *data, struct connectdata *conn,
-                              struct ssl_peer *peer, X509 *server_cert);
 extern const struct Curl_ssl Curl_ssl_openssl;
-
-CURLcode Curl_ossl_set_client_cert(struct Curl_easy *data,
-                                   SSL_CTX *ctx, char *cert_file,
-                                   const struct curl_blob *cert_blob,
-                                   const char *cert_type, char *key_file,
-                                   const struct curl_blob *key_blob,
-                                   const char *key_type, char *key_passwd);
-
-CURLcode Curl_ossl_certchain(struct Curl_easy *data, SSL *ssl);
 
 /**
  * Setup the OpenSSL X509_STORE in `ssl_ctx` for the cfilter `cf` and

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -901,6 +901,8 @@ CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   struct dynbuf build;
 
+  DEBUGASSERT(certnum < ci->num_of_certs);
+
   Curl_dyn_init(&build, CURL_X509_STR_MAX);
 
   if(Curl_dyn_add(&build, label) ||


### PR DESCRIPTION
If there is a (memory) error when creating the certinfo data, the code would previously continue which could lead to a partial/broken response. Now, the first error aborts and cleans up the entire thing.

A certinfo "collection" error is however still not considered an error big enough to stop the handshake.

Bonus: made two functions static (and removed the Curl_ prefix) that were not used outside of openssl.c

Bonus 2: removed the unused function `Curl_ossl_set_client_cert`