### PR TITLE
GHA/distcheck: keep upload artifacts for one day only

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           name: 'release-tgz'
           path: 'curl-99.98.97.tar.gz'
+          retention-days: 1
 
       - run: |
           echo "::stop-commands::$(uuidgen)"


### PR DESCRIPTION
The uploads are only used as a cache mechanism between jobs to save them from having to re-run maketgz multiple times, so there is no need to save the artifact longer than this.