### PR TITLE
CURLMOPT_SOCKETFUNCTION.md: expand on the easy argument

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -50,6 +50,9 @@ libcurl by calling curl_multi_socket_action(3).
 # CALLBACK ARGUMENTS
 
 *easy* identifies the specific transfer for which this update is related.
+Since this callback manages a whole multi handle, an application should not
+make assumptions about which particular handle that is passed here. It might
+even be an internal easy handle that the application did not add itself.
 
 *s* is the specific socket this function invocation concerns. If the
 **what** argument is not CURL_POLL_REMOVE then it holds information about


### PR DESCRIPTION
Since recent changes makes it more likely to be an internal handle that shows up and some users have been surprised by this.

Ref: #14792