### PR TITLE
firefox-db2pem: mention what "certutil" the script uses

### DIFF
--- a/scripts/firefox-db2pem.sh
+++ b/scripts/firefox-db2pem.sh
@@ -26,6 +26,9 @@
 # It extracts all ca certs it finds in the local Firefox database and converts
 # them all into PEM format.
 #
+# It uses the "certutil" command line tool from the NSS project to perform the
+# conversion. On Debian it comes in the "libnss3-tools" package.
+#
 
 set -eu
 


### PR DESCRIPTION
... and the Debian package that provides it.