### PR TITLE
.dcignore: remove

### DIFF
--- a/.dcignore
+++ b/.dcignore
@@ -1,7 +1,0 @@
-# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
-#
-# SPDX-License-Identifier: curl
-
-tests/**
-docs/**
-docs/examples/**


### PR DESCRIPTION
This was a config file for deepcode.ai, a static code analyzer that we have not used for ages.