### PR TITLE
build: use `configurehelp.pm.in` with autotools and cmake

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1527,11 +1527,11 @@ dnl harness needs information on how to run the C preprocessor.
 
 AC_DEFUN([CURL_GENERATE_CONFIGUREHELP_PM], [
   AC_REQUIRE([AC_PROG_CPP])dnl
-  CURL_CPP=`eval echo "$ac_cpp" 2>/dev/null`
-  if test -z "$CURL_CPP"; then
-    CURL_CPP='cpp'
+  tmp_cpp=`eval echo "$ac_cpp" 2>/dev/null`
+  if test -z "$tmp_cpp"; then
+    tmp_cpp='cpp'
   fi
-  AC_SUBST(CURL_CPP)
+  AC_SUBST(CURL_CPP, $tmp_cpp)
 ])
 
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1527,35 +1527,11 @@ dnl harness needs information on how to run the C preprocessor.
 
 AC_DEFUN([CURL_GENERATE_CONFIGUREHELP_PM], [
   AC_REQUIRE([AC_PROG_CPP])dnl
-  tmp_cpp=`eval echo "$ac_cpp" 2>/dev/null`
-  if test -z "$tmp_cpp"; then
-    tmp_cpp='cpp'
+  CURL_CPP=`eval echo "$ac_cpp" 2>/dev/null`
+  if test -z "$CURL_CPP"; then
+    CURL_CPP='cpp'
   fi
-  cat >./tests/configurehelp.pm <<_EOF
-[@%:@] This is a generated file.  Do not edit.
-
-package configurehelp;
-
-use strict;
-use warnings;
-use Exporter;
-
-use vars qw(
-    @ISA
-    @EXPORT_OK
-    \$Cpreprocessor
-    );
-
-@ISA = qw(Exporter);
-
-@EXPORT_OK = qw(
-    \$Cpreprocessor
-    );
-
-\$Cpreprocessor = '$tmp_cpp';
-
-1;
-_EOF
+  AC_SUBST(CURL_CPP)
 ])
 
 

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1518,14 +1518,14 @@ AC_DEFUN([CURL_CHECK_PKGCONFIG], [
 ])
 
 
-dnl CURL_GENERATE_CONFIGUREHELP_PM
+dnl CURL_PREPARE_CONFIGUREHELP_PM
 dnl -------------------------------------------------
-dnl Generate test harness configurehelp.pm module, defining and
+dnl Prepare test harness configurehelp.pm module, defining and
 dnl initializing some perl variables with values which are known
 dnl when the configure script runs. For portability reasons, test
 dnl harness needs information on how to run the C preprocessor.
 
-AC_DEFUN([CURL_GENERATE_CONFIGUREHELP_PM], [
+AC_DEFUN([CURL_PREPARE_CONFIGUREHELP_PM], [
   AC_REQUIRE([AC_PROG_CPP])dnl
   tmp_cpp=`eval echo "$ac_cpp" 2>/dev/null`
   if test -z "$tmp_cpp"; then

--- a/configure.ac
+++ b/configure.ac
@@ -5218,6 +5218,8 @@ if test "x$want_curldebug_assumed" = "xyes" &&
   ac_configure_args="$ac_configure_args --enable-curldebug"
 fi
 
+CURL_GENERATE_CONFIGUREHELP_PM
+
 AC_CONFIG_FILES([\
   Makefile \
   docs/Makefile \
@@ -5249,8 +5251,6 @@ AC_CONFIG_FILES([\
   libcurl.pc
 ])
 AC_OUTPUT
-
-CURL_GENERATE_CONFIGUREHELP_PM
 
 SUPPORT_PROTOCOLS_LOWER=`echo "$SUPPORT_PROTOCOLS" | tr A-Z a-z`
 

--- a/configure.ac
+++ b/configure.ac
@@ -5233,6 +5233,7 @@ AC_CONFIG_FILES([\
   lib/libcurl.vers \
   tests/Makefile \
   tests/config \
+  tests/configurehelp.pm \
   tests/certs/Makefile \
   tests/certs/scripts/Makefile \
   tests/data/Makefile \

--- a/configure.ac
+++ b/configure.ac
@@ -5218,7 +5218,7 @@ if test "x$want_curldebug_assumed" = "xyes" &&
   ac_configure_args="$ac_configure_args --enable-curldebug"
 fi
 
-CURL_GENERATE_CONFIGUREHELP_PM
+CURL_PREPARE_CONFIGUREHELP_PM
 
 AC_CONFIG_FILES([\
   Makefile \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,42 +57,24 @@ endfunction()
 
 # Create configurehelp.pm, used by tests needing to run the C preprocessor.
 if(MSVC OR CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-  set(_cpp_cmd "\"${CMAKE_C_COMPILER}\" -E")
+  set(CURL_CPP "\"${CMAKE_C_COMPILER}\" -E")
   if(APPLE AND CMAKE_OSX_SYSROOT)
-    set(_cpp_cmd "${_cpp_cmd} -isysroot ${CMAKE_OSX_SYSROOT}")
+    set(CURL_CPP "${CURL_CPP} -isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
   # Add header directories, like autotools builds do.
   get_property(_include_dirs TARGET ${LIB_SELECTED} PROPERTY INCLUDE_DIRECTORIES)
   foreach(_include_dir IN LISTS _include_dirs)
-    set(_cpp_cmd "${_cpp_cmd} -I${_include_dir}")
+    set(CURL_CPP "${CURL_CPP} -I${_include_dir}")
   endforeach()
 else()
-  set(_cpp_cmd "cpp")
+  set(CURL_CPP "cpp")
 endif()
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/configurehelp.pm" "# This is a generated file.  Do not edit.
-
-package configurehelp;
-
-use strict;
-use warnings;
-use Exporter;
-
-use vars qw(
-    @ISA
-    @EXPORT_OK
-    \$Cpreprocessor
-    );
-
-@ISA = qw(Exporter);
-
-@EXPORT_OK = qw(
-    \$Cpreprocessor
-    );
-
-\$Cpreprocessor = '${_cpp_cmd}';
-
-1;
-")
+# Generate version script for the linker, for versioned symbols.
+# Consumed variable:
+#   CURL_CPP
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/configurehelp.pm.in"
+  "${CMAKE_CURRENT_BINARY_DIR}/configurehelp.pm" @ONLY)
 
 add_runtests(test-quiet     "-a -s")
 add_runtests(test-am        "-a -am")

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -95,7 +95,7 @@ EXTRA_DIST =        \
  $(TESTSCRIPTS)     \
  $(CURLPAGES)
 
-DISTCLEANFILES = configurehelp.pm
+DISTCLEANFILES =
 
 # we have two variables here to make sure DIST_SUBDIRS won't get 'unit'
 # added twice as then targets such as 'distclean' misbehave and try to

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -95,8 +95,6 @@ EXTRA_DIST =        \
  $(TESTSCRIPTS)     \
  $(CURLPAGES)
 
-DISTCLEANFILES =
-
 # we have two variables here to make sure DIST_SUBDIRS won't get 'unit'
 # added twice as then targets such as 'distclean' misbehave and try to
 # do things twice in that subdir at times (and thus fails).

--- a/tests/configurehelp.pm.in
+++ b/tests/configurehelp.pm.in
@@ -31,15 +31,15 @@ use Exporter;
 use vars qw(
     @ISA
     @EXPORT_OK
-    \$Cpreprocessor
+    $Cpreprocessor
     );
 
 @ISA = qw(Exporter);
 
 @EXPORT_OK = qw(
-    \$Cpreprocessor
+    $Cpreprocessor
     );
 
-\$Cpreprocessor = '@CURL_CPP@';
+$Cpreprocessor = '@CURL_CPP@';
 
 1;

--- a/tests/configurehelp.pm.in
+++ b/tests/configurehelp.pm.in
@@ -1,0 +1,23 @@
+# This is a generated file.  Do not edit.
+
+package configurehelp;
+
+use strict;
+use warnings;
+use Exporter;
+
+use vars qw(
+    @ISA
+    @EXPORT_OK
+    \$Cpreprocessor
+    );
+
+@ISA = qw(Exporter);
+
+@EXPORT_OK = qw(
+    \$Cpreprocessor
+    );
+
+\$Cpreprocessor = '@CURL_CPP@';
+
+1;

--- a/tests/configurehelp.pm.in
+++ b/tests/configurehelp.pm.in
@@ -1,4 +1,26 @@
-# This is a generated file.  Do not edit.
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
 
 package configurehelp;
 


### PR DESCRIPTION
Before this patch, each build tool generated `tests/configurehelp.pm`
manually.

Ref: https://github.com/curl/curl/pull/14802#issuecomment-2332734326