### PR TITLE
maketgz: fix RELEASE-TOOLS.md for daily tarballs

### DIFF
--- a/scripts/maketgz
+++ b/scripts/maketgz
@@ -156,13 +156,13 @@ else
   automake --include-deps Makefile >/dev/null
 fi
 
-echo "produce RELEASE-TOOLS.md"
-./scripts/release-tools.sh "$timestamp" "$version" > docs/RELEASE-TOOLS.md.dist
-
 if test -n "$commit"; then
   echo "produce docs/tarball-commit.txt"
   git rev-parse HEAD >docs/tarball-commit.txt.dist
 fi
+
+echo "produce RELEASE-TOOLS.md"
+./scripts/release-tools.sh "$timestamp" "$version" "$commit" > docs/RELEASE-TOOLS.md.dist
 
 ############################################################################
 #

--- a/scripts/release-tools.sh
+++ b/scripts/release-tools.sh
@@ -29,6 +29,11 @@ set -eu
 timestamp=${1:-unknown}
 version=${2:-unknown}
 tag=$(echo "curl-$version" | tr '.' '_')
+commit=${3}
+if [ -n "$commit" ] && [ -r "docs/tarball-commit.txt.dist" ]; then
+  # If commit is given, then the tag likely doesn't actually exist
+  tag="$(cat docs/tarball-commit.txt.dist)"
+fi
 
 cat <<MOO
 # Release tools used for curl $version
@@ -38,10 +43,9 @@ produce this release tarball.
 
 MOO
 
-exists=$(command -v dpkg 2>/dev/null)
-if test ! -e "$exists"; then
-  echo "(unknown, could not find dpkg)"
-  exit
+if ! command -v dpkg >/dev/null; then
+  echo "Error: could not find dpkg" >&2
+  exit 1
 fi
 
 debian() {
@@ -58,7 +62,7 @@ cat <<MOO
 
 # Reproduce the tarball
 
-- Clone the repo and checkout the tag: $tag
+- Clone the repo and checkout the tag/commit: $tag
 - Install the same set of tools + versions as listed above
 
 ## Do a standard build


### PR DESCRIPTION
The daily snapshots have no associated git tag, so provide a commit has
instead in these cases. Fix the dpkg detection since the shell would
exit immediately without showing an error message if it weren't found.
Also, use "which" instead of "command" since the latter is bash-specific
and this script specifies a plain Bourne shell.

Closes #14820