### PR TITLE
dist: drop `.in` files from `EXTRA_DIST`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -82,9 +82,9 @@ PLAN9_DIST = plan9/include/mkfile \
  plan9/src/mkfile.inc             \
  plan9/src/mkfile
 
-EXTRA_DIST = CHANGES.md COPYING Makefile.dist curl-config.in    \
- RELEASE-NOTES libcurl.pc.in $(CMAKE_DIST) $(VC_DIST) $(WINBUILD_DIST)  \
- $(PLAN9_DIST) lib/libcurl.vers.in buildconf.bat Dockerfile
+EXTRA_DIST = CHANGES.md COPYING Makefile.dist             \
+ RELEASE-NOTES $(CMAKE_DIST) $(VC_DIST) $(WINBUILD_DIST)  \
+ $(PLAN9_DIST) buildconf.bat Dockerfile
 
 CLEANFILES = $(VC14_LIBVCXPROJ) $(VC14_SRCVCXPROJ) \
  $(VC14_10_LIBVCXPROJ) $(VC14_10_SRCVCXPROJ)       \

--- a/tests/http/Makefile.am
+++ b/tests/http/Makefile.am
@@ -40,7 +40,6 @@ testenv/ws_echo_server.py
 
 EXTRA_DIST =           \
 CMakeLists.txt         \
-config.ini.in          \
 conftest.py            \
 requirements.txt       \
 scorecard.py           \


### PR DESCRIPTION
Some of the `.in` files were listed in `EXTRA_DIST`. Delete them.

`.in` files (passed to `AC_CONFIG_FILES`) are added automatically
to the distro by autotools.
