### PR TITLE
lib: remove the final strncpy() calls

### DIFF
--- a/lib/.checksrc
+++ b/lib/.checksrc
@@ -1,1 +1,2 @@
 enable STRERROR
+enable STRNCPY

--- a/lib/curl_gethostname.c
+++ b/lib/curl_gethostname.c
@@ -59,7 +59,10 @@ int Curl_gethostname(char * const name, GETHOSTNAME_TYPE_ARG2 namelen)
   /* Override hostname when environment variable CURL_GETHOSTNAME is set */
   const char *force_hostname = getenv("CURL_GETHOSTNAME");
   if(force_hostname) {
-    strncpy(name, force_hostname, namelen - 1);
+    if(strlen(force_hostname) < (size_t)namelen)
+      strcpy(name, force_hostname);
+    else
+      return 1; /* can't do it */
     err = 0;
   }
   else {

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1176,15 +1176,15 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
 static char *wolfssl_strerror(unsigned long error, char *buf,
                               unsigned long size)
 {
-  DEBUGASSERT(size);
+  DEBUGASSERT(size > 40);
   *buf = '\0';
 
   wolfSSL_ERR_error_string_n(error, buf, size);
 
   if(!*buf) {
     const char *msg = error ? "Unknown error" : "No error";
-    strncpy(buf, msg, size - 1);
-    buf[size - 1] = '\0';
+    /* the string fits because the assert above assures this */
+    strcpy(buf, msg);
   }
 
   return buf;

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -50,6 +50,7 @@ my @ignore_line;
 my %warnings_extended = (
     'COPYRIGHTYEAR'    => 'copyright year incorrect',
     'STRERROR',        => 'strerror() detected',
+    'STRNCPY',         => 'strncpy() detected',
     'STDERR',          => 'stderr detected',
     );
 
@@ -746,6 +747,18 @@ sub scanfile {
                 if($1 !~ /^ *\#/) {
                     # skip preprocessor lines
                     checkwarn("STRERROR",
+                              $line, length($1), $file, $ol,
+                              "use of $2 is banned");
+                }
+            }
+        }
+        if($warnings{"STRNCPY"}) {
+            # scan for use of banned strncpy. This is not a BANNEDFUNC to
+            # allow for individual enable/disable of this warning.
+            if($l =~ /^(.*\W)(strncpy)\s*\(/x) {
+                if($1 !~ /^ *\#/) {
+                    # skip preprocessor lines
+                    checkwarn("STRNCPY",
                               $line, length($1), $file, $ol,
                               "use of $2 is banned");
                 }


### PR DESCRIPTION
wolfssl: use strcpy() as the target buffer is > 40 bytes

gethostname: return failure if the buffer is too small instead