### PR TITLE
CURLOPT_COOKIE.md: this cookie gets appended to the others

### DIFF
--- a/docs/libcurl/opts/CURLOPT_COOKIE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.md
@@ -35,8 +35,8 @@ NAME=CONTENTS, where NAME is the cookie name and CONTENTS is what the cookie
 should contain.
 
 To set multiple cookies, set them all using a single option concatenated like
-this: "name1=content1; name2=content2;" etc. libcurl will not syntax check the
-data but assumes the applications gives it what it wants to send.
+this: "name1=content1; name2=content2;" etc. libcurl does not syntax check the
+data but assumes the applications gives it what it needs to send.
 
 This option sets the cookie header explicitly in the outgoing request(s). If
 multiple requests are done due to authentication, followed redirections or

--- a/docs/libcurl/opts/CURLOPT_COOKIE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.md
@@ -35,7 +35,8 @@ NAME=CONTENTS, where NAME is the cookie name and CONTENTS is what the cookie
 should contain.
 
 To set multiple cookies, set them all using a single option concatenated like
-this: "name1=content1; name2=content2;" etc.
+this: "name1=content1; name2=content2;" etc. libcurl will not syntax check the
+data but assumes the applications gives it what it wants to send.
 
 This option sets the cookie header explicitly in the outgoing request(s). If
 multiple requests are done due to authentication, followed redirections or
@@ -43,28 +44,24 @@ similar, they all get this cookie passed on.
 
 The cookies set by this option are separate from the internal cookie storage
 held by the cookie engine and they are not be modified by it. If you enable
-the cookie engine and either you have imported a cookie of the same name
-(e.g. 'foo') or the server has set one, it has no effect on the cookies you
-set here. A request to the server sends both the 'foo' held by the cookie
-engine and the 'foo' held by this option. To set a cookie that is instead held
-by the cookie engine and can be modified by the server use
-CURLOPT_COOKIELIST(3).
+the cookie engine and either you have imported a cookie of the same name (e.g.
+'foo') or the server has set one, it has no effect on the cookies you set
+here. A request to the server sends both the 'foo' held by the cookie engine
+and the 'foo' held by this option. To set a cookie that is instead held by the
+cookie engine and can be modified by the server use CURLOPT_COOKIELIST(3).
+
+Since this custom cookie is appended to the Cookie: header in addition to any
+cookies set by the cookie engine, there is a risk that the header ends up too
+long and thereby getting the entire request rejected by the server.
 
 Using this option multiple times makes the last set string override the
 previous ones.
 
-This option does not enable the cookie engine. Use CURLOPT_COOKIEFILE(3)
-or CURLOPT_COOKIEJAR(3) to enable parsing and sending cookies
-automatically.
+This option does not enable the cookie engine. Use CURLOPT_COOKIEFILE(3) or
+CURLOPT_COOKIEJAR(3) to enable parsing and sending cookies automatically.
 
 The application does not have to keep the string around after setting this
 option.
-
-If libcurl is built with PSL (*Public Suffix List*) support, it detects and
-discards cookies that are specified for such suffix domains that should not be
-allowed to have cookies. If libcurl is *not* built with PSL support, it has no
-ability to stop super cookies. PSL support is identified by the
-**CURL_VERSION_PSL** feature bit returned by curl_version_info(3).
 
 # DEFAULT
 


### PR DESCRIPTION
... so it adds the risk of making the header too long. Clarify this better.

Also: remove the PSL mention from here since it is not really relevant for this option as this option is for specific *outgoing* cookies only.

Reported-by: Hiroki Kurosawa