### PR TITLE
src: tidy-up conditions for CA bundle search

### DIFF
--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -624,25 +624,21 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
   (void)config;
   (void)bundle_file;
 #else
-  /* Search and set cert file only if libcurl supports SSL. */
-  if(feature_ssl) {
+  DWORD res_len;
+  TCHAR buf[PATH_MAX];
+  TCHAR *ptr = NULL;
 
-    DWORD res_len;
-    TCHAR buf[PATH_MAX];
-    TCHAR *ptr = NULL;
+  buf[0] = TEXT('\0');
 
-    buf[0] = TEXT('\0');
-
-    res_len = SearchPath(NULL, bundle_file, NULL, PATH_MAX, buf, &ptr);
-    if(res_len > 0) {
-      char *mstr = curlx_convert_tchar_to_UTF8(buf);
-      Curl_safefree(config->cacert);
-      if(mstr)
-        config->cacert = strdup(mstr);
-      curlx_unicodefree(mstr);
-      if(!config->cacert)
-        result = CURLE_OUT_OF_MEMORY;
-    }
+  res_len = SearchPath(NULL, bundle_file, NULL, PATH_MAX, buf, &ptr);
+  if(res_len > 0) {
+    char *mstr = curlx_convert_tchar_to_UTF8(buf);
+    Curl_safefree(config->cacert);
+    if(mstr)
+      config->cacert = strdup(mstr);
+    curlx_unicodefree(mstr);
+    if(!config->cacert)
+      result = CURLE_OUT_OF_MEMORY;
   }
 #endif
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -616,23 +616,16 @@ char **__crt0_glob_function(char *arg)
  */
 
 CURLcode FindWin32CACert(struct OperationConfig *config,
-                         curl_sslbackend backend,
                          const TCHAR *bundle_file)
 {
   CURLcode result = CURLE_OK;
 
 #ifdef CURL_WINDOWS_UWP
   (void)config;
-  (void)backend;
   (void)bundle_file;
 #else
-  /* Search and set cert file only if libcurl supports SSL.
-   *
-   * If Schannel is the selected SSL backend then these locations are
-   * ignored. We allow setting CA location for schannel only when explicitly
-   * specified by the user via CURLOPT_CAINFO / --cacert.
-   */
-  if(feature_ssl && backend != CURLSSLBACKEND_SCHANNEL) {
+  /* Search and set cert file only if libcurl supports SSL. */
+  if(feature_ssl) {
 
     DWORD res_len;
     TCHAR buf[PATH_MAX];

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -600,7 +600,12 @@ char **__crt0_glob_function(char *arg)
 
 #ifdef _WIN32
 
-/*
+/* Search and set the CA cert file for Windows.
+ *
+ * Do not call this function if Schannel is the selected SSL backend. We allow
+ * setting CA location for Schannel only when explicitly specified by the user
+ * via CURLOPT_CAINFO / --cacert.
+ *
  * Function to find CACert bundle on a Win32 platform using SearchPath.
  * (SearchPath is already declared via inclusions done in setup header file)
  * (Use the ASCII version instead of the Unicode one!)
@@ -614,7 +619,6 @@ char **__crt0_glob_function(char *arg)
  * For WinXP and later search order actually depends on registry value:
  * HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\SafeProcessSearchMode
  */
-
 CURLcode FindWin32CACert(struct OperationConfig *config,
                          const TCHAR *bundle_file)
 {

--- a/src/tool_doswin.h
+++ b/src/tool_doswin.h
@@ -60,7 +60,6 @@ char **__crt0_glob_function(char *arg);
 #ifdef _WIN32
 
 CURLcode FindWin32CACert(struct OperationConfig *config,
-                         curl_sslbackend backend,
                          const TCHAR *bundle_file);
 struct curl_slist *GetLoadedModulePaths(void);
 CURLcode win32_init(void);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -3014,7 +3014,8 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
    * too. Just for the sake of it.
    */
   capath_from_env = false;
-  if(!config->cacert &&
+  if(feature_ssl &&
+     !config->cacert &&
      !config->capath &&
      (!config->insecure_ok || (config->doh_url && !config->doh_insecure_ok))) {
     CURL *curltls = curl_easy_init();
@@ -3078,8 +3079,7 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
       }
 
 #ifdef _WIN32
-       /* Search and set cert file only if libcurl supports SSL. */
-      if(!env && feature_ssl)
+      if(!env)
         result = FindWin32CACert(config, TEXT("curl-ca-bundle.crt"));
 #endif
     }

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -3079,8 +3079,7 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
 
 #ifdef _WIN32
       if(!env)
-        result = FindWin32CACert(config, tls_backend_info->backend,
-                                 TEXT("curl-ca-bundle.crt"));
+        result = FindWin32CACert(config, TEXT("curl-ca-bundle.crt"));
 #endif
     }
     curl_easy_cleanup(curltls);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -3078,7 +3078,8 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
       }
 
 #ifdef _WIN32
-      if(!env)
+       /* Search and set cert file only if libcurl supports SSL. */
+      if(!env && feature_ssl)
         result = FindWin32CACert(config, TEXT("curl-ca-bundle.crt"));
 #endif
     }

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -3036,11 +3036,13 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
      * no environment-specified filename is found then check for CA bundle
      * default filename curl-ca-bundle.crt in the user's PATH.
      *
-     * If Schannel is the selected SSL backend then these locations are
-     * ignored. We allow setting CA location for schannel only when explicitly
-     * specified by the user via CURLOPT_CAINFO / --cacert.
+     * If Schannel or SecureTransport is the selected SSL backend then these
+     * locations are ignored. We allow setting CA location for Schannel and
+     * SecureTransport when explicitly specified by the user via
+     *  CURLOPT_CAINFO / --cacert.
      */
-    if(tls_backend_info->backend != CURLSSLBACKEND_SCHANNEL) {
+    if(tls_backend_info->backend != CURLSSLBACKEND_SCHANNEL &&
+       tls_backend_info->backend != CURLSSLBACKEND_SECURETRANSPORT) {
       char *env;
       env = curl_getenv("CURL_CA_BUNDLE");
       if(env) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -3036,13 +3036,11 @@ static CURLcode transfer_per_config(struct GlobalConfig *global,
      * no environment-specified filename is found then check for CA bundle
      * default filename curl-ca-bundle.crt in the user's PATH.
      *
-     * If Schannel or SecureTransport is the selected SSL backend then these
-     * locations are ignored. We allow setting CA location for Schannel and
-     * SecureTransport when explicitly specified by the user via
-     *  CURLOPT_CAINFO / --cacert.
+     * If Schannel is the selected SSL backend then these locations are
+     * ignored. We allow setting CA location for schannel only when explicitly
+     * specified by the user via CURLOPT_CAINFO / --cacert.
      */
-    if(tls_backend_info->backend != CURLSSLBACKEND_SCHANNEL &&
-       tls_backend_info->backend != CURLSSLBACKEND_SECURETRANSPORT) {
+    if(tls_backend_info->backend != CURLSSLBACKEND_SCHANNEL) {
       char *env;
       env = curl_getenv("CURL_CA_BUNDLE");
       if(env) {


### PR DESCRIPTION
- delete redundant Schannel check.

- move `feature_ssl` check one level up from `FindWin32CACert()`.

- check `feature_ssl` early to skip a bunch of CA bundle search logic
  for no-ssl configurations.

---

w/o whitespace: https://github.com/curl/curl/pull/14841/files?w=1
