### PR TITLE
cd2nroff: only require "added-in" for source "libcurl"

### DIFF
--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -304,7 +304,7 @@ sub single {
                 print STDERR "$f:$line:1:ERROR: no 'Source:' in $f\n";
                 return 2;
             }
-            if(!$addedin) {
+            if(($source eq "libcurl") && !$addedin) {
                 print STDERR "$f:$line:1:ERROR: no 'Added-in:' in $f\n";
                 return 2;
             }


### PR DESCRIPTION
To allow this script to be used by trurl easier.