### PR TITLE
runtests: accept 'quictls' as OpenSSL compatible

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -576,6 +576,11 @@ sub checksystemfeatures {
                $feature{"OpenSSL"} = 1;
                $feature{"SSLpinning"} = 1;
            }
+           elsif ($libcurl =~ /\squictls\b/i) {
+               # OpenSSL compatible API
+               $feature{"OpenSSL"} = 1;
+               $feature{"SSLpinning"} = 1;
+           }
            elsif ($libcurl =~ /\smbedTLS\b/i) {
                $feature{"mbedtls"} = 1;
                $feature{"SSLpinning"} = 1;


### PR DESCRIPTION
And set the "OpenSSL" feature.

Follow-up to 86d4a4124e275f355320d