### PR TITLE
libcurl-docs: CURLINFO_LOCAL_* work for QUIC as well as TCP

### DIFF
--- a/docs/libcurl/opts/CURLINFO_LOCAL_IP.md
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_IP.md
@@ -10,7 +10,8 @@ See-also:
   - curl_easy_getinfo (3)
   - curl_easy_setopt (3)
 Protocol:
-  - All
+  - TCP
+  - QUIC
 Added-in: 7.21.0
 ---
 
@@ -30,13 +31,13 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_LOCAL_IP, char **ip);
 
 Pass a pointer to a char pointer to receive the pointer to a null-terminated
 string holding the IP address of the local end of most recent connection done
-with this **curl** handle. This string may be IPv6 when that is
-enabled. Note that you get a pointer to a memory area that is reused at next
-request so you need to copy the string if you want to keep the information.
+with this **curl** handle. This string may be IPv6 when that is enabled. Note
+that you get a pointer to a memory area that is reused at next request so you
+need to copy the string if you want to keep the information.
 
-The **ip** pointer is NULL or points to private memory. You MUST NOT free -
-it gets freed when you call curl_easy_cleanup(3) on the corresponding
-CURL handle.
+The **ip** pointer is NULL or points to private memory. You MUST NOT free - it
+gets freed when you call curl_easy_cleanup(3) on the corresponding CURL
+handle.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/opts/CURLINFO_LOCAL_PORT.md
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_PORT.md
@@ -6,6 +6,7 @@ Section: 3
 Source: libcurl
 Protocol:
   - TCP
+  - QUIC
 See-also:
   - CURLINFO_LOCAL_IP (3)
   - CURLINFO_PRIMARY_PORT (3)
@@ -30,6 +31,9 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_LOCAL_PORT, long *portp);
 
 Pass a pointer to a long to receive the local port number of the most recent
 connection done with this **curl** handle.
+
+If the connection was done using QUIC, the port number is a UDP port number,
+otherwise it is a TCP port number.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.md
@@ -7,7 +7,7 @@ Source: libcurl
 See-also:
   - CURLOPT_SSL_FALSESTART (3)
 Protocol:
-  - All
+  - TCP
 Added-in: 7.49.0
 ---
 

--- a/scripts/cd2nroff
+++ b/scripts/cd2nroff
@@ -178,6 +178,7 @@ my %knownprotos = (
     'WSS' => 1,
     'TLS' => 1,
     'TCP' => 1,
+    'QUIC' => 1,
     'All' => 1
     );
 


### PR DESCRIPTION
Also, CURLOPT_TCP_FASTOPEN is for TCP only.