### PR TITLE
GHA: add `valgrind` to the job titles using it, and tidy-ups

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,73 +66,73 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: BearSSL valgrind
+          - name: bearssl valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: bearssl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
             singleuse: --unit
 
-          - name: BearSSL clang
+          - name: bearssl clang
             install_packages: zlib1g-dev clang
             install_steps: bearssl
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
             singleuse: --unit
 
-          - name: LibreSSL heimdal valgrind
+          - name: libressl heimdal valgrind
             install_packages: zlib1g-dev heimdal-dev valgrind
             install_steps: libressl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --with-gssapi --enable-debug
             singleuse: --unit
 
-          - name: LibreSSL heimdal valgrind
+          - name: libressl heimdal valgrind
             install_packages: zlib1g-dev heimdal-dev valgrind
             install_steps: libressl pytest
             generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
             singleuse: --unit
 
-          - name: LibreSSL clang
+          - name: libressl clang
             install_packages: zlib1g-dev clang
             install_steps: libressl
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --enable-debug
             singleuse: --unit
 
-          - name: mbedTLS valgrind
+          - name: mbedtls valgrind
             install_packages: libnghttp2-dev valgrind
             install_steps: mbedtls pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
             singleuse: --unit
 
-          - name: mbedTLS clang
+          - name: mbedtls clang
             install_packages: libnghttp2-dev clang
             install_steps: mbedtls
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
             singleuse: --unit
 
-          - name: MSH3 valgrind
+          - name: msh3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: quictls msh3
             configure: LDFLAGS="-Wl,-rpath,$HOME/msh3/lib -Wl,-rpath,$HOME/quictls/lib" --with-msh3=$HOME/msh3 --with-openssl=$HOME/quictls --enable-debug
             singleuse: --unit
 
-          - name: OpenSSL3 valgrind
+          - name: openssl3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11 openssl3 pytest
             configure: CFLAGS=-std=gnu89 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: OpenSSL3 O3 valgrind
+          - name: openssl3-O3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11 openssl3
             configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: OpenSSL3 clang krb5
+          - name: openssl3 clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang
             install_steps: openssl3
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --with-gssapi --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: OpenSSL3 clang krb5
+          - name: openssl3 clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang
             install_steps: openssl3
             generate: -DOPENSSL_ROOT_DIR=$HOME/openssl3 -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DENABLE_WEBSOCKETS=ON
@@ -181,7 +181,7 @@ jobs:
             configure: LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" --with-openssl --with-hyper=$HOME/hyper --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: Rustls valgrind
+          - name: rustls valgrind
             install_steps: rust rustls pytest valgrind libpsl-dev
             configure: --with-rustls=$HOME/rustls --enable-debug
             singleuse: --unit
@@ -192,13 +192,13 @@ jobs:
             configure: CC=icc --enable-debug --without-ssl
             singleuse: --unit
 
-          - name: IntelC OpenSSL valgrind
+          - name: IntelC openssl valgrind
             install_packages: zlib1g-dev libssl-dev valgrind
             install_steps: intel
             configure: CC=icc --enable-debug --with-openssl
             singleuse: --unit
 
-          - name: Slackware OpenSSL gssapi gcc
+          - name: Slackware openssl gssapi gcc
             # These are essentially the same flags used to build the curl Slackware package
             # https://ftpmirror.infania.net/slackware/slackware64-current/source/n/curl/curl.SlackBuild
             configure: --with-openssl --with-libssh2 --with-gssapi --enable-ares --enable-static=no --without-ca-bundle --with-ca-path=/etc/ssl/certs

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: bearssl v
+          - name: bearssl valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: bearssl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
@@ -78,13 +78,13 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
             singleuse: --unit
 
-          - name: libressl heimdal v
+          - name: libressl heimdal valgrind
             install_packages: zlib1g-dev heimdal-dev valgrind
             install_steps: libressl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --with-gssapi --enable-debug
             singleuse: --unit
 
-          - name: libressl heimdal v
+          - name: libressl heimdal valgrind
             install_packages: zlib1g-dev heimdal-dev valgrind
             install_steps: libressl pytest
             generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
@@ -96,7 +96,7 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --enable-debug
             singleuse: --unit
 
-          - name: mbedtls v
+          - name: mbedtls valgrind
             install_packages: libnghttp2-dev valgrind
             install_steps: mbedtls pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
@@ -108,19 +108,19 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
             singleuse: --unit
 
-          - name: msh3 v
+          - name: msh3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: quictls msh3
             configure: LDFLAGS="-Wl,-rpath,$HOME/msh3/lib -Wl,-rpath,$HOME/quictls/lib" --with-msh3=$HOME/msh3 --with-openssl=$HOME/quictls --enable-debug
             singleuse: --unit
 
-          - name: openssl3 v
+          - name: openssl3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11 openssl3 pytest
             configure: CFLAGS=-std=gnu89 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: openssl3-O3 v
+          - name: openssl3-O3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11 openssl3
             configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
@@ -170,29 +170,29 @@ jobs:
               --without-ssl --without-zlib --without-brotli --without-zstd --without-libpsl --without-nghttp2 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: event-based v
+          - name: event-based valgrind
             install_packages: libssh-dev valgrind
             configure: --enable-debug --disable-shared --disable-threaded-resolver --with-libssh --with-openssl
             tflags: -n -e '!TLS-SRP'
             singleuse: --unit
 
-          - name: hyper v
+          - name: hyper valgrind
             install_steps: rust hyper valgrind
             configure: LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" --with-openssl --with-hyper=$HOME/hyper --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: rustls v
+          - name: rustls valgrind
             install_steps: rust rustls pytest valgrind libpsl-dev
             configure: --with-rustls=$HOME/rustls --enable-debug
             singleuse: --unit
 
-          - name: Intel compiler - without SSL v
+          - name: IntelC !SSL valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: intel
             configure: CC=icc --enable-debug --without-ssl
             singleuse: --unit
 
-          - name: Intel compiler - OpenSSL v
+          - name: IntelC OpenSSL valgrind
             install_packages: zlib1g-dev libssl-dev valgrind
             install_steps: intel
             configure: CC=icc --enable-debug --with-openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: bearssl
+          - name: bearssl v
             install_packages: zlib1g-dev valgrind
             install_steps: bearssl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
@@ -78,13 +78,13 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
             singleuse: --unit
 
-          - name: libressl heimdal
+          - name: libressl heimdal v
             install_packages: zlib1g-dev heimdal-dev valgrind
             install_steps: libressl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --with-gssapi --enable-debug
             singleuse: --unit
 
-          - name: libressl heimdal
+          - name: libressl heimdal v
             install_packages: zlib1g-dev heimdal-dev valgrind
             install_steps: libressl pytest
             generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
@@ -96,7 +96,7 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --enable-debug
             singleuse: --unit
 
-          - name: mbedtls
+          - name: mbedtls v
             install_packages: libnghttp2-dev valgrind
             install_steps: mbedtls pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
@@ -108,19 +108,19 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
             singleuse: --unit
 
-          - name: msh3
+          - name: msh3 v
             install_packages: zlib1g-dev valgrind
             install_steps: quictls msh3
             configure: LDFLAGS="-Wl,-rpath,$HOME/msh3/lib -Wl,-rpath,$HOME/quictls/lib" --with-msh3=$HOME/msh3 --with-openssl=$HOME/quictls --enable-debug
             singleuse: --unit
 
-          - name: openssl3
+          - name: openssl3 v
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11 openssl3 pytest
             configure: CFLAGS=-std=gnu89 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: openssl3-O3
+          - name: openssl3-O3 v
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11 openssl3
             configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
@@ -170,29 +170,29 @@ jobs:
               --without-ssl --without-zlib --without-brotli --without-zstd --without-libpsl --without-nghttp2 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: event-based
+          - name: event-based v
             install_packages: libssh-dev valgrind
             configure: --enable-debug --disable-shared --disable-threaded-resolver --with-libssh --with-openssl
             tflags: -n -e '!TLS-SRP'
             singleuse: --unit
 
-          - name: hyper
+          - name: hyper v
             install_steps: rust hyper valgrind
             configure: LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" --with-openssl --with-hyper=$HOME/hyper --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: rustls
+          - name: rustls v
             install_steps: rust rustls pytest valgrind libpsl-dev
             configure: --with-rustls=$HOME/rustls --enable-debug
             singleuse: --unit
 
-          - name: Intel compiler - without SSL
+          - name: Intel compiler - without SSL v
             install_packages: zlib1g-dev valgrind
             install_steps: intel
             configure: CC=icc --enable-debug --without-ssl
             singleuse: --unit
 
-          - name: Intel compiler - OpenSSL
+          - name: Intel compiler - OpenSSL v
             install_packages: zlib1g-dev libssl-dev valgrind
             install_steps: intel
             configure: CC=icc --enable-debug --with-openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,73 +66,73 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: bearssl valgrind
+          - name: BearSSL valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: bearssl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
             singleuse: --unit
 
-          - name: bearssl-clang
+          - name: BearSSL clang
             install_packages: zlib1g-dev clang
             install_steps: bearssl
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
             singleuse: --unit
 
-          - name: libressl heimdal valgrind
+          - name: LibreSSL heimdal valgrind
             install_packages: zlib1g-dev heimdal-dev valgrind
             install_steps: libressl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --with-gssapi --enable-debug
             singleuse: --unit
 
-          - name: libressl heimdal valgrind
+          - name: LibreSSL heimdal valgrind
             install_packages: zlib1g-dev heimdal-dev valgrind
             install_steps: libressl pytest
             generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
             singleuse: --unit
 
-          - name: libressl-clang
+          - name: LibreSSL clang
             install_packages: zlib1g-dev clang
             install_steps: libressl
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --enable-debug
             singleuse: --unit
 
-          - name: mbedtls valgrind
+          - name: mbedTLS valgrind
             install_packages: libnghttp2-dev valgrind
             install_steps: mbedtls pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
             singleuse: --unit
 
-          - name: mbedtls-clang
+          - name: mbedTLS clang
             install_packages: libnghttp2-dev clang
             install_steps: mbedtls
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
             singleuse: --unit
 
-          - name: msh3 valgrind
+          - name: MSH3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: quictls msh3
             configure: LDFLAGS="-Wl,-rpath,$HOME/msh3/lib -Wl,-rpath,$HOME/quictls/lib" --with-msh3=$HOME/msh3 --with-openssl=$HOME/quictls --enable-debug
             singleuse: --unit
 
-          - name: openssl3 valgrind
+          - name: OpenSSL3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11 openssl3 pytest
             configure: CFLAGS=-std=gnu89 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: openssl3-O3 valgrind
+          - name: OpenSSL3 O3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11 openssl3
             configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: openssl3-clang krb5
+          - name: OpenSSL3 clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang
             install_steps: openssl3
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --with-gssapi --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: openssl3-clang krb5
+          - name: OpenSSL3 clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang
             install_steps: openssl3
             generate: -DOPENSSL_ROOT_DIR=$HOME/openssl3 -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DENABLE_WEBSOCKETS=ON
@@ -181,7 +181,7 @@ jobs:
             configure: LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" --with-openssl --with-hyper=$HOME/hyper --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: rustls valgrind
+          - name: Rustls valgrind
             install_steps: rust rustls pytest valgrind libpsl-dev
             configure: --with-rustls=$HOME/rustls --enable-debug
             singleuse: --unit
@@ -198,7 +198,7 @@ jobs:
             configure: CC=icc --enable-debug --with-openssl
             singleuse: --unit
 
-          - name: Slackware-openssl-with-gssapi-gcc
+          - name: Slackware OpenSSL gssapi gcc
             # These are essentially the same flags used to build the curl Slackware package
             # https://ftpmirror.infania.net/slackware/slackware64-current/source/n/curl/curl.SlackBuild
             configure: --with-openssl --with-libssh2 --with-gssapi --enable-ares --enable-static=no --without-ca-bundle --with-ca-path=/etc/ssl/certs

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -54,11 +54,11 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: wolfssl (with --enable-all)
+          - name: wolfSSL (with --enable-all)
             install:
             configure: LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" --with-wolfssl=$HOME/wssl --enable-debug
             wolfssl-configure: --enable-all
-          - name: wolfssl (with --enable-opensslextra) valgrind
+          - name: wolfSSL (with --enable-opensslextra) valgrind
             install: valgrind
             configure: LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" --with-wolfssl=$HOME/wssl --enable-debug
             wolfssl-configure: --enable-opensslextra

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -58,7 +58,7 @@ jobs:
             install:
             configure: LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" --with-wolfssl=$HOME/wssl --enable-debug
             wolfssl-configure: --enable-all
-          - name: wolfssl (configured with --enable-opensslextra)
+          - name: wolfssl (configured with --enable-opensslextra) v
             install: valgrind
             configure: LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" --with-wolfssl=$HOME/wssl --enable-debug
             wolfssl-configure: --enable-opensslextra

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -54,11 +54,11 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: wolfSSL (with --enable-all)
+          - name: wolfssl (with --enable-all)
             install:
             configure: LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" --with-wolfssl=$HOME/wssl --enable-debug
             wolfssl-configure: --enable-all
-          - name: wolfSSL (with --enable-opensslextra) valgrind
+          - name: wolfssl (with --enable-opensslextra) valgrind
             install: valgrind
             configure: LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" --with-wolfssl=$HOME/wssl --enable-debug
             wolfssl-configure: --enable-opensslextra

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -54,11 +54,11 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: wolfssl (configured with --enable-all)
+          - name: wolfssl (with --enable-all)
             install:
             configure: LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" --with-wolfssl=$HOME/wssl --enable-debug
             wolfssl-configure: --enable-all
-          - name: wolfssl (configured with --enable-opensslextra) v
+          - name: wolfssl (with --enable-opensslextra) valgrind
             install: valgrind
             configure: LDFLAGS="-Wl,-rpath,$HOME/wssl/lib" --with-wolfssl=$HOME/wssl --enable-debug
             wolfssl-configure: --enable-opensslextra


### PR DESCRIPTION
There is a 4-5x difference in test run times. Make the reason more
obvious by adding valgrind to the job names.

Also:
- tidy up job names.
