### PR TITLE
Fix AF_INET6 use outside of USE_IPV6

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1749,7 +1749,11 @@ static CURLcode cf_socket_query(struct Curl_cfilter *cf,
     return CURLE_OK;
   }
   case CF_QUERY_IP_INFO:
+#ifdef USE_IPV6
     *pres1 = (ctx->addr.family == AF_INET6)? TRUE : FALSE;
+#else
+    *pres1 = FALSE;
+#endif
     *(struct ip_quadruple *)pres2 = ctx->ip;
     return CURLE_OK;
   default:

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -800,8 +800,10 @@ static CURLcode start_connect(struct Curl_cfilter *cf,
   }
   else {
     /* no user preference, we try ipv6 always first when available */
+#ifdef USE_IPV6
     ai_family0 = AF_INET6;
     addr0 = addr_first_match(remotehost->addr, ai_family0);
+#endif
     /* next candidate is ipv4 */
     ai_family1 = AF_INET;
     addr1 = addr_first_match(remotehost->addr, ai_family1);


### PR DESCRIPTION
This fixes the build for systems where AF_INET6 doesn't exist.