### PR TITLE
multi: do not call the socket callback when cleanup is called

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2723,6 +2723,7 @@ CURLMcode curl_multi_cleanup(struct Curl_multi *multi)
       return CURLM_RECURSIVE_API_CALL;
 
     multi->magic = 0; /* not good anymore */
+    multi->socket_cb = NULL; /* no callbacks when shutting down */
 
     /* move the pending and msgsent entries back to process
        so that there is just one list to iterate over */


### PR DESCRIPTION
There is no point since the handle is getting killed.