### PR TITLE
keep trying to connect to draining QUIC servers

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -547,9 +547,11 @@ static CURLcode baller_start_next(struct Curl_cfilter *cf,
 {
   if(cf->sockindex == FIRSTSOCKET) {
     baller_next_addr(baller);
-    /* If we get inconclusive answers from the server(s), we make
-     * a second iteration over the address list */
-    if(!baller->addr && baller->inconclusive && !baller->rewinded)
+    /* If we get inconclusive answers from the server(s), we start
+     * again until this whole thing times out. This allows us to
+     * connect to servers that are gracefully restarting and the
+     * packet routing to the new instance has not happened yet (e.g. QUIC). */
+    if(!baller->addr && baller->inconclusive)
       baller_rewind(baller);
     baller_start(cf, data, baller, timeoutms);
   }

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -129,7 +129,6 @@ struct cf_ngtcp2_ctx {
   nghttp3_settings h3settings;
   struct curltime started_at;        /* time the current attempt started */
   struct curltime handshake_at;      /* time connect handshake finished */
-  struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
   struct dynbuf scratch;             /* temp buffer for header construction */
   struct Curl_hash streams;          /* hash `data->mid` to `h3_stream_ctx` */
@@ -2310,12 +2309,6 @@ static CURLcode cf_ngtcp2_connect(struct Curl_cfilter *cf,
   pktx_init(&pktx, cf, data);
 
   CF_DATA_SAVE(save, cf, data);
-
-  if(ctx->reconnect_at.tv_sec && Curl_timediff(now, ctx->reconnect_at) < 0) {
-    /* Not time yet to attempt the next connect */
-    CURL_TRC_CF(data, cf, "waiting for reconnect time");
-    goto out;
-  }
 
   if(!ctx->qconn) {
     ctx->started_at = now;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -288,7 +288,6 @@ struct cf_osslq_ctx {
   struct curltime started_at;        /* time the current attempt started */
   struct curltime handshake_at;      /* time connect handshake finished */
   struct curltime first_byte_at;     /* when first byte was recvd */
-  struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
   struct Curl_hash streams;          /* hash `data->mid` to `h3_stream_ctx` */
   size_t max_stream_window;          /* max flow window for one stream */
@@ -1685,12 +1684,6 @@ static CURLcode cf_osslq_connect(struct Curl_cfilter *cf,
   *done = FALSE;
   now = Curl_now();
   CF_DATA_SAVE(save, cf, data);
-
-  if(ctx->reconnect_at.tv_sec && Curl_timediff(now, ctx->reconnect_at) < 0) {
-    /* Not time yet to attempt the next connect */
-    CURL_TRC_CF(data, cf, "waiting for reconnect time");
-    goto out;
-  }
 
   if(!ctx->tls.ossl.ssl) {
     ctx->started_at = now;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -96,7 +96,6 @@ struct cf_quiche_ctx {
   uint8_t scid[QUICHE_MAX_CONN_ID_LEN];
   struct curltime started_at;        /* time the current attempt started */
   struct curltime handshake_at;      /* time connect handshake finished */
-  struct curltime reconnect_at;      /* time the next attempt should start */
   struct bufc_pool stream_bufcp;     /* chunk pool for streams */
   struct Curl_hash streams;          /* hash `data->mid` to `stream_ctx` */
   curl_off_t data_recvd;
@@ -1405,13 +1404,6 @@ static CURLcode cf_quiche_connect(struct Curl_cfilter *cf,
 
   *done = FALSE;
   vquic_ctx_update_time(&ctx->q);
-
-  if(ctx->reconnect_at.tv_sec &&
-     Curl_timediff(ctx->q.last_op, ctx->reconnect_at) < 0) {
-    /* Not time yet to attempt the next connect */
-    CURL_TRC_CF(data, cf, "waiting for reconnect time");
-    goto out;
-  }
 
   if(!ctx->qconn) {
     result = cf_quiche_ctx_open(cf, data);

--- a/tests/http/test_03_goaway.py
+++ b/tests/http/test_03_goaway.py
@@ -36,7 +36,6 @@ from testenv import Env, CurlClient, ExecResult
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
 class TestGoAway:
 
     @pytest.fixture(autouse=True, scope='class')
@@ -83,8 +82,6 @@ class TestGoAway:
         proto = 'h3'
         if proto == 'h3' and env.curl_uses_lib('msh3'):
             pytest.skip("msh3 stalls here")
-        if proto == 'h3' and env.curl_uses_lib('quiche'):
-            pytest.skip("does not work in CI, but locally for some reason")
         if proto == 'h3' and env.curl_uses_ossl_quic():
             pytest.skip('OpenSSL QUIC fails here')
         count = 3


### PR DESCRIPTION
We once established a connect retry logic in our IP Eyeballing that made a second attempt when the filter returned a WEIRD_SERVER_REPLY. QUIC filters use that when the server is responding with a "draining" connect. This happens when the server shuts down or gracefully restarts. The problem for QUIC is that UDP packets can not be routed atomically to a new process like for TCP. Such "draining" responses seem hard to avoid.

The previous approach of just retrying once leads to timing problems. When curl is faster than the server, the second attempt will also fail and abort the connect. With this PR, the happy eyeballing will continue retrying the available addresses that report draining - until success or the overall connect timeout. This is far more reliable.

Remove the old `reconnect_at` variables in the QUIC filters that are no longer used. 

Enable test_03 for restarting servers in CI. Hopefully those work there reliable now.