### PR TITLE
FTP: (mostly) revert eeb7c1280742f5c8fa48a4340fc1e1a1a2c7075a

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -327,7 +327,7 @@ static void freedirs(struct ftp_conn *ftpc)
   Curl_safefree(ftpc->newhost);
 }
 
-#ifdef CURL_DO_LINEEND_CONV
+#ifdef CURL_PREFER_LF_LINEENDS
 /***********************************************************************
  *
  * Lineend Conversions
@@ -416,7 +416,7 @@ static const struct Curl_cwtype ftp_cw_lc = {
   sizeof(struct ftp_cw_lc_ctx)
 };
 
-#endif /* CURL_DO_LINEEND_CONV */
+#endif /* CURL_PREFER_LF_LINEENDS */
 /***********************************************************************
  *
  * AcceptServerConnect()
@@ -4144,7 +4144,7 @@ static CURLcode ftp_do(struct Curl_easy *data, bool *done)
   *done = FALSE; /* default to false */
   ftpc->wait_data_conn = FALSE; /* default to no such wait */
 
-#ifdef CURL_DO_LINEEND_CONV
+#ifdef CURL_PREFER_LF_LINEENDS
   {
     /* FTP data may need conversion. */
     struct Curl_cwriter *ftp_lc_writer;
@@ -4160,7 +4160,7 @@ static CURLcode ftp_do(struct Curl_easy *data, bool *done)
       return result;
     }
   }
-#endif /* CURL_DO_LINEEND_CONV */
+#endif /* CURL_PREFER_LF_LINEENDS */
 
   if(data->state.wildcardmatch) {
     result = wc_statemach(data);

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -327,6 +327,7 @@ static void freedirs(struct ftp_conn *ftpc)
   Curl_safefree(ftpc->newhost);
 }
 
+#ifdef CURL_DO_LINEEND_CONV
 /***********************************************************************
  *
  * Lineend Conversions
@@ -415,6 +416,7 @@ static const struct Curl_cwtype ftp_cw_lc = {
   sizeof(struct ftp_cw_lc_ctx)
 };
 
+#endif /* CURL_DO_LINEEND_CONV */
 /***********************************************************************
  *
  * AcceptServerConnect()
@@ -4138,22 +4140,27 @@ static CURLcode ftp_do(struct Curl_easy *data, bool *done)
   CURLcode result = CURLE_OK;
   struct connectdata *conn = data->conn;
   struct ftp_conn *ftpc = &conn->proto.ftpc;
-  /* FTP data may need conversion. */
-  struct Curl_cwriter *ftp_lc_writer;
 
   *done = FALSE; /* default to false */
   ftpc->wait_data_conn = FALSE; /* default to no such wait */
 
-  result = Curl_cwriter_create(&ftp_lc_writer, data, &ftp_cw_lc,
-                               CURL_CW_CONTENT_DECODE);
-  if(result)
-    return result;
+#ifdef CURL_DO_LINEEND_CONV
+  {
+    /* FTP data may need conversion. */
+    struct Curl_cwriter *ftp_lc_writer;
 
-  result = Curl_cwriter_add(data, ftp_lc_writer);
-  if(result) {
-    Curl_cwriter_free(data, ftp_lc_writer);
-    return result;
+    result = Curl_cwriter_create(&ftp_lc_writer, data, &ftp_cw_lc,
+                                 CURL_CW_CONTENT_DECODE);
+    if(result)
+      return result;
+
+    result = Curl_cwriter_add(data, ftp_lc_writer);
+    if(result) {
+      Curl_cwriter_free(data, ftp_lc_writer);
+      return result;
+    }
   }
+#endif /* CURL_DO_LINEEND_CONV */
 
   if(data->state.wildcardmatch) {
     result = wc_statemach(data);

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1101,7 +1101,11 @@ static CURLcode do_init_reader_stack(struct Curl_easy *data,
   clen = r->crt->total_length(data, r);
   /* if we do not have 0 length init, and crlf conversion is wanted,
    * add the reader for it */
-  if(clen && (data->set.crlf || data->state.prefer_ascii)) {
+  if(clen && (data->set.crlf
+#ifdef CURL_DO_LINEEND_CONV
+     || data->state.prefer_ascii
+#endif
+    )) {
     result = cr_lc_add(data);
     if(result)
       return result;

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1005,9 +1005,11 @@ static CURLcode cr_lc_read(struct Curl_easy *data,
       goto out;
     }
 
-    /* at least one \n needs conversion to '\r\n', place into ctx->buf */
+    /* at least one \n might need conversion to '\r\n', place into ctx->buf */
     for(i = start = 0; i < nread; ++i) {
-      if(buf[i] != '\n')
+      /* if this byte is not an LF character, or if the preceeding character
+         is a CR (meaning this already is a CRLF pair), go to next */
+      if((buf[i] != '\n') || (i && (buf[i -1] == '\r')))
         continue;
       /* on a soft limit bufq, we do not need to check length */
       result = Curl_bufq_cwrite(&ctx->buf, buf + start, i - start, &n);

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1102,7 +1102,7 @@ static CURLcode do_init_reader_stack(struct Curl_easy *data,
   /* if we do not have 0 length init, and crlf conversion is wanted,
    * add the reader for it */
   if(clen && (data->set.crlf
-#ifdef CURL_DO_LINEEND_CONV
+#ifdef CURL_PREFER_LF_LINEENDS
      || data->state.prefer_ascii
 #endif
     )) {

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -1008,8 +1008,8 @@ static CURLcode cr_lc_read(struct Curl_easy *data,
 
     /* at least one \n might need conversion to '\r\n', place into ctx->buf */
     for(i = start = 0; i < nread; ++i) {
-      /* if this byte is not an LF character, or if the preceeding character
-         is a CR (meaning this already is a CRLF pair), go to next */
+      /* if this byte is not an LF character, or if the preceding character is
+         a CR (meaning this already is a CRLF pair), go to next */
       if((buf[i] != '\n') || ctx->prev_cr) {
         ctx->prev_cr = (buf[i] == '\r');
         continue;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -108,7 +108,7 @@ typedef unsigned int curl_prot_t;
 #if !defined(_WIN32) && !defined(MSDOS) && !defined(__EMX__)
 /* do FTP line-end CRLF => LF conversions on platforms that prefer LF-only. It
    also means: keep CRLF line endings on the CRLF platforms */
-#define CURL_DO_LINEEND_CONV
+#define CURL_PREFER_LF_LINEENDS
 #endif
 
 /* Convenience defines for checking protocols or their SSL based version. Each

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -105,6 +105,12 @@ typedef unsigned int curl_prot_t;
 #define CURL_DEFAULT_USER "anonymous"
 #define CURL_DEFAULT_PASSWORD "ftp@example.com"
 
+#if !defined(_WIN32) && !defined(MSDOS) && !defined(__EMX__)
+/* do FTP line-end CRLF => LF conversions on platforms that prefer LF-only. It
+   also means: keep CRLF line endings on the CRLF platforms */
+#define CURL_DO_LINEEND_CONV
+#endif
+
 /* Convenience defines for checking protocols or their SSL based version. Each
    protocol handler should only ever have a single CURLPROTO_ in its protocol
    field. */

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -694,11 +694,14 @@ content
 
 ### `<stripfile4>`
 
-### `<upload [crlf="yes"]>`
+### `<upload [crlf="yes"] [nonewline="yes"]>`
 the contents of the upload data curl should have sent
 
 `crlf=yes` forces *upload* newlines to become CRLF even if not written so in
 the source file.
+
+`nonewline=yes` means that the last byte (the trailing newline character)
+should be cut off from the upload data before comparing it.
 
 ### `<valgrind>`
 disable - disables the valgrind log check for this test

--- a/tests/data/test475
+++ b/tests/data/test475
@@ -16,7 +16,7 @@ ftp
 <name>
 FTP PASV upload ASCII file
 </name>
-<file name="%LOGDIR/test%TESTNUMBER.txt">
+<file name="%LOGDIR/test%TESTNUMBER.txt" nonewline="yes">
 %if win32
 %repeat[1750 x a line of text used for verifying this !%0d%0a]%
 %else
@@ -33,7 +33,7 @@ FTP PASV upload ASCII file
 <strip>
 QUIT
 </strip>
-<upload crlf="yes">
+<upload crlf="yes" nonewline="yes">
 %repeat[1750 x a line of text used for verifying this !%0a]%
 </upload>
 <protocol>

--- a/tests/data/test475
+++ b/tests/data/test475
@@ -17,7 +17,11 @@ ftp
 FTP PASV upload ASCII file
 </name>
 <file name="%LOGDIR/test%TESTNUMBER.txt">
+%if win32
+%repeat[1750 x a line of text used for verifying this !%0d%0a]%
+%else
 %repeat[1750 x a line of text used for verifying this !%0a]%
+%endif
 </file>
 <command>
 "ftp://%HOSTIP:%FTPPORT/%TESTNUMBER;type=a" -T %LOGDIR/test%TESTNUMBER.txt

--- a/tests/data/test476
+++ b/tests/data/test476
@@ -16,8 +16,8 @@ ftp
 <name>
 FTP PASV upload ASCII file already using CRLF
 </name>
-<file name="%LOGDIR/test%TESTNUMBER.txt" crlf="yes">
-%repeat[1750 x a line of text used for verifying this !%0a]%
+<file name="%LOGDIR/test%TESTNUMBER.txt">
+%repeat[1750 x a line of text used for verifying this !%0d%0a]%
 </file>
 <command>
 "ftp://%HOSTIP:%FTPPORT/%TESTNUMBER;type=a" -T %LOGDIR/test%TESTNUMBER.txt

--- a/tests/data/test476
+++ b/tests/data/test476
@@ -16,7 +16,7 @@ ftp
 <name>
 FTP PASV upload ASCII file already using CRLF
 </name>
-<file name="%LOGDIR/test%TESTNUMBER.txt">
+<file name="%LOGDIR/test%TESTNUMBER.txt" nonewline="yes">
 %repeat[1750 x a line of text used for verifying this !%0d%0a]%
 </file>
 <command>
@@ -29,7 +29,7 @@ FTP PASV upload ASCII file already using CRLF
 <strip>
 QUIT
 </strip>
-<upload crlf="yes">
+<upload crlf="yes" nonewline="yes">
 %repeat[1750 x a line of text used for verifying this !%0a]%
 </upload>
 <protocol>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1497,6 +1497,11 @@ sub singletest_check {
         if($hash{'crlf'}) {
             subnewlines(1, \$_) for @upload;
         }
+        if($hash{'nonewline'}) {
+            # Yes, we must cut off the final newline from the final line
+            # of the upload data
+            chomp($upload[-1]);
+        }
 
         $res = compare($runnerid, $testnum, $testname, "upload", \@out, \@upload);
         if ($res) {


### PR DESCRIPTION
Since ASCII transfers on FTP means sending CRLF line endings, we should still keep converting them to LF *only on platforms where text files typically do not use CRLF*.

Regression from eeb7c1280742f5c8 shipped in 8.10.0

Reported-by: finkjsc on github
Fixes #14873