### PR TITLE
GHA/macOS: add an -e test

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -132,6 +132,11 @@ jobs:
             compiler: clang
             configure: --enable-debug --with-openssl=$(brew --prefix openssl) --enable-websockets
             macos-version-min: '10.9'
+          - name: 'OpenSSL event-based'
+            compiler: clang
+            configure: --enable-debug --with-openssl=$(brew --prefix openssl) --enable-websockets
+            macos-version-min: '10.9'
+            tflags: -e
           - name: 'OpenSSL torture !FTP'
             compiler: clang
             configure: --enable-debug --disable-shared --disable-threaded-resolver --with-openssl=$(brew --prefix openssl) --enable-websockets


### PR DESCRIPTION
Adds -e to runtests for using the event-based API in the tool.