### PR TITLE
tidy-up: rename `CURL_WINDOWS_APP` to `CURL_WINDOWS_UWP`

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -286,7 +286,7 @@ static CURLcode getaddrinfo_complete(struct Curl_easy *data)
  * and wait on it.
  */
 static
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
 DWORD
 #else
 unsigned int
@@ -354,7 +354,7 @@ CURL_STDCALL getaddrinfo_thread(void *arg)
  * gethostbyname_thread() resolves a name and then exits.
  */
 static
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
 DWORD
 #else
 unsigned int

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -475,7 +475,7 @@ Vista
 #endif
 
 /* Define to use the Windows crypto library. */
-#if !defined(CURL_WINDOWS_APP)
+#if !defined(CURL_WINDOWS_UWP)
 #define USE_WIN32_CRYPTO
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -109,7 +109,7 @@
 #  include <winapifamily.h>
 #  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) &&  \
      !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#    define CURL_WINDOWS_APP
+#    define CURL_WINDOWS_UWP
 #  endif
 # endif
 #endif

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -103,7 +103,7 @@ int Curl_thread_join(curl_thread_t *hnd)
 #elif defined(USE_THREADS_WIN32)
 
 curl_thread_t Curl_thread_create(
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
                                  DWORD
 #else
                                  unsigned int
@@ -111,14 +111,14 @@ curl_thread_t Curl_thread_create(
                                  (CURL_STDCALL *func) (void *),
                                  void *arg)
 {
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
   typedef HANDLE curl_win_thread_handle_t;
 #else
   typedef uintptr_t curl_win_thread_handle_t;
 #endif
   curl_thread_t t;
   curl_win_thread_handle_t thread_handle;
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
   thread_handle = CreateThread(NULL, 0, func, arg, 0, NULL);
 #else
   thread_handle = _beginthreadex(NULL, 0, func, arg, 0, NULL);

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -53,7 +53,7 @@
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
 
 curl_thread_t Curl_thread_create(
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
                                  DWORD
 #else
                                  unsigned int

--- a/lib/getenv.c
+++ b/lib/getenv.c
@@ -31,7 +31,7 @@
 
 static char *GetEnv(const char *variable)
 {
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP) || \
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP) || \
   defined(__ORBIS__) || defined(__PROSPERO__) /* PlayStation 4 and 5 */
   (void)variable;
   return NULL;

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -49,7 +49,7 @@
 #ifdef _WIN32
 
 #if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600 && \
-  !defined(CURL_WINDOWS_APP)
+  !defined(CURL_WINDOWS_UWP)
 #  define HAVE_WIN_BCRYPTGENRANDOM
 #  include <bcrypt.h>
 #  ifdef _MSC_VER

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -175,7 +175,7 @@ typedef HMODULE (APIENTRY *LOADLIBRARYEX_FN)(LPCTSTR, HANDLE, DWORD);
  */
 HMODULE Curl_load_library(LPCTSTR filename)
 {
-#ifndef CURL_WINDOWS_APP
+#ifndef CURL_WINDOWS_UWP
   HMODULE hModule = NULL;
   LOADLIBRARYEX_FN pLoadLibraryEx = NULL;
 

--- a/lib/version_win32.c
+++ b/lib/version_win32.c
@@ -79,7 +79,7 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
 {
   bool matched = FALSE;
 
-#if defined(CURL_WINDOWS_APP)
+#if defined(CURL_WINDOWS_UWP)
   /* We have no way to determine the Windows version from Windows apps,
      so let's assume we are running on the target Windows version. */
   const WORD fullVersion = MAKEWORD(minorVersion, majorVersion);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2732,7 +2732,7 @@ static void schannel_checksum(const unsigned char *input,
                               DWORD provType,
                               const unsigned int algId)
 {
-#ifdef CURL_WINDOWS_APP
+#ifdef CURL_WINDOWS_UWP
   (void)input;
   (void)inputlen;
   (void)provType;
@@ -2952,7 +2952,7 @@ const struct Curl_ssl Curl_ssl_schannel = {
 #ifdef HAS_MANUAL_VERIFY_API
   SSLSUPP_CAINFO_BLOB |
 #endif
-#ifndef CURL_WINDOWS_APP
+#ifndef CURL_WINDOWS_UWP
   SSLSUPP_PINNEDPUBKEY |
 #endif
   SSLSUPP_TLS13_CIPHERSUITES |

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -31,7 +31,7 @@
 #include "vtls.h"
 
 #if (defined(__MINGW32__) || defined(CERT_CHAIN_REVOCATION_CHECK_CHAIN)) \
-  && !defined(CURL_WINDOWS_APP)
+  && !defined(CURL_WINDOWS_UWP)
 #define HAS_MANUAL_VERIFY_API
 #endif
 

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -346,7 +346,7 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
                                   DWORD length)
 {
   DWORD actual_length = 0;
-#if defined(CURL_WINDOWS_APP)
+#if defined(CURL_WINDOWS_UWP)
   (void)data;
   (void)cert_context;
   (void)host_names;

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -66,7 +66,7 @@ unsigned int get_terminal_columns(void)
     struct winsize ts;
     if(!ioctl(STDIN_FILENO, TIOCGWINSZ, &ts))
       cols = (int)ts.ws_col;
-#elif defined(_WIN32) && !defined(CURL_WINDOWS_APP)
+#elif defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
     {
       HANDLE  stderr_hnd = GetStdHandle(STD_ERROR_HANDLE);
       CONSOLE_SCREEN_BUFFER_INFO console_info;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -621,7 +621,7 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
 {
   CURLcode result = CURLE_OK;
 
-#ifdef CURL_WINDOWS_APP
+#ifdef CURL_WINDOWS_UWP
   (void)config;
   (void)backend;
   (void)bundle_file;
@@ -712,7 +712,7 @@ cleanup:
 
 bool tool_term_has_bold;
 
-#ifndef CURL_WINDOWS_APP
+#ifndef CURL_WINDOWS_UWP
 /* The terminal settings to restore on exit */
 static struct TerminalSettings {
   HANDLE hStdOut;
@@ -795,7 +795,7 @@ CURLcode win32_init(void)
 
   QueryPerformanceFrequency(&tool_freq);
 
-#ifndef CURL_WINDOWS_APP
+#ifndef CURL_WINDOWS_UWP
   init_terminal();
 #endif
 

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -41,7 +41,7 @@ int getfiletime(const char *filename, struct GlobalConfig *global,
 /* Windows stat() may attempt to adjust the Unix GMT file time by a daylight
    saving time offset and since it is GMT that is bad behavior. When we have
    access to a 64-bit type we can bypass stat and get the times directly. */
-#if defined(_WIN32) && !defined(CURL_WINDOWS_APP)
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
   HANDLE hfile;
   TCHAR *tchar_filename = curlx_convert_UTF8_to_tchar((char *)filename);
 
@@ -95,7 +95,7 @@ void setfiletime(curl_off_t filetime, const char *filename,
 /* Windows utime() may attempt to adjust the Unix GMT file time by a daylight
    saving time offset and since it is GMT that is bad behavior. When we have
    access to a 64-bit type we can bypass utime and set the times directly. */
-#if defined(_WIN32) && !defined(CURL_WINDOWS_APP)
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
     HANDLE hfile;
     TCHAR *tchar_filename = curlx_convert_UTF8_to_tchar((char *)filename);
 

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -29,7 +29,7 @@
 #define NUM_THREADS 100
 
 #ifdef _WIN32
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
 static DWORD WINAPI run_thread(LPVOID ptr)
 #else
 #include <process.h>
@@ -47,7 +47,7 @@ static unsigned int WINAPI run_thread(void *ptr)
 
 CURLcode test(char *URL)
 {
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
   typedef HANDLE curl_win_thread_handle_t;
 #else
   typedef uintptr_t curl_win_thread_handle_t;
@@ -78,7 +78,7 @@ CURLcode test(char *URL)
   for(i = 0; i < tid_count; i++) {
     curl_win_thread_handle_t th;
     results[i] = CURL_LAST; /* initialize with invalid value */
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
     th = CreateThread(NULL, 0, run_thread, &results[i], 0, NULL);
 #else
     th = _beginthreadex(NULL, 0, run_thread, &results[i], 0, NULL);

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -74,7 +74,7 @@ static size_t write_memory_callback(void *contents, size_t size,
 
 static
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
-#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_APP)
+#if defined(_WIN32_WCE) || defined(CURL_WINDOWS_UWP)
 DWORD
 #else
 unsigned int

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -133,7 +133,7 @@ double tutil_tvdiff_secs(struct timeval newer, struct timeval older)
 #ifdef _WIN32
 HMODULE win32_load_system_library(const TCHAR *filename)
 {
-#ifdef CURL_WINDOWS_APP
+#ifdef CURL_WINDOWS_UWP
   (void)filename;
   return NULL;
 #else

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -149,7 +149,7 @@ enum sockmode {
   ACTIVE_DISCONNECT  /* as a client, disconnected from server */
 };
 
-#if defined(_WIN32) && !defined(CURL_WINDOWS_APP)
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
 /*
  * read-wrapper to support reading from stdin on Windows.
  */
@@ -417,7 +417,7 @@ static bool read_data_block(unsigned char *buffer, ssize_t maxlen,
 }
 
 
-#if defined(USE_WINSOCK) && !defined(CURL_WINDOWS_APP)
+#if defined(USE_WINSOCK) && !defined(CURL_WINDOWS_UWP)
 /*
  * Winsock select() does not support standard file descriptors,
  * it can only check SOCKETs. The following function is an attempt

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -497,7 +497,7 @@ static SIGHANDLER_T old_sigterm_handler = SIG_ERR;
 static SIGHANDLER_T old_sigbreak_handler = SIG_ERR;
 #endif
 
-#if defined(_WIN32) && !defined(CURL_WINDOWS_APP)
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
 #ifdef _WIN32_WCE
 static DWORD thread_main_id = 0;
 #else
@@ -580,7 +580,7 @@ static BOOL WINAPI ctrl_event_handler(DWORD dwCtrlType)
 }
 #endif
 
-#if defined(_WIN32) && !defined(CURL_WINDOWS_APP)
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP)
 /* Window message handler for Windows applications to add support
  * for graceful process termination via taskkill (without /f) which
  * sends WM_CLOSE to all Windows of a process (even hidden ones).
@@ -743,7 +743,7 @@ void install_signal_handlers(bool keep_sigalrm)
   if(!SetConsoleCtrlHandler(ctrl_event_handler, TRUE))
     logmsg("cannot install CTRL event handler");
 
-#ifndef CURL_WINDOWS_APP
+#ifndef CURL_WINDOWS_UWP
   {
 #ifdef _WIN32_WCE
     typedef HANDLE curl_win_thread_handle_t;
@@ -798,7 +798,7 @@ void restore_signal_handlers(bool keep_sigalrm)
 #endif
 #ifdef _WIN32
   (void)SetConsoleCtrlHandler(ctrl_event_handler, FALSE);
-#ifndef CURL_WINDOWS_APP
+#ifndef CURL_WINDOWS_UWP
   if(thread_main_window && thread_main_id) {
     if(PostThreadMessage(thread_main_id, WM_APP, 0, 0)) {
       if(WaitForSingleObjectEx(thread_main_window, INFINITE, TRUE)) {


### PR DESCRIPTION
Rename internal macro to make its purpose more obvious.

After this patch `grep -i uwp` shows all the code related to UWP.

Ref: https://curl.se/mail/lib-2024-09/0014.html
