### PR TITLE
cmake: fix broken dependency chain for cmdline-opts, tidy-ups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1797,6 +1797,8 @@ cmake_dependent_option(BUILD_TESTING "Build tests"
   OFF)
 
 if(HAVE_MANUAL_TOOLS)
+  set(MANPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1")
+  set(ASCIIPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt")
   add_subdirectory(docs)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1797,8 +1797,8 @@ cmake_dependent_option(BUILD_TESTING "Build tests"
   OFF)
 
 if(HAVE_MANUAL_TOOLS)
-  set(MANPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1")
-  set(ASCIIPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt")
+  set(CURL_MANPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1")
+  set(CURL_ASCIIPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt")
   add_subdirectory(docs)
 endif()
 

--- a/docs/cmdline-opts/CMakeLists.txt
+++ b/docs/cmdline-opts/CMakeLists.txt
@@ -35,7 +35,7 @@ add_custom_command(OUTPUT "${CURL_MANPAGE}"
   VERBATIM
 )
 
-add_custom_target("generate-curl.1" ALL DEPENDS "${CURL_MANPAGE}")
+add_custom_target(generate-curl.1 ALL DEPENDS "${CURL_MANPAGE}")
 
 if(NOT CURL_DISABLE_INSTALL)
   install(FILES "${CURL_MANPAGE}" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")

--- a/docs/cmdline-opts/CMakeLists.txt
+++ b/docs/cmdline-opts/CMakeLists.txt
@@ -25,7 +25,7 @@
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-add_custom_command(OUTPUT "${CURL_MANPAGE}"
+add_custom_command(OUTPUT "${CURL_MANPAGE}" "${CURL_ASCIIPAGE}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" mainpage ${DPAGES} > "${CURL_MANPAGE}"
   COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" ascii ${DPAGES} > "${CURL_ASCIIPAGE}"

--- a/docs/cmdline-opts/CMakeLists.txt
+++ b/docs/cmdline-opts/CMakeLists.txt
@@ -25,18 +25,18 @@
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-add_custom_command(OUTPUT "${MANPAGE}"
+add_custom_command(OUTPUT "${CURL_MANPAGE}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" mainpage ${DPAGES} > "${MANPAGE}"
-  COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" ascii ${DPAGES} > "${ASCIIPAGE}"
+  COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" mainpage ${DPAGES} > "${CURL_MANPAGE}"
+  COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" ascii ${DPAGES} > "${CURL_ASCIIPAGE}"
   DEPENDS
     "${PROJECT_SOURCE_DIR}/scripts/managen"
     ${DPAGES}
   VERBATIM
 )
 
-add_custom_target("generate-curl.1" ALL DEPENDS "${MANPAGE}")
+add_custom_target("generate-curl.1" ALL DEPENDS "${CURL_MANPAGE}")
 
 if(NOT CURL_DISABLE_INSTALL)
-  install(FILES "${MANPAGE}" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
+  install(FILES "${CURL_MANPAGE}" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
 endif()

--- a/docs/cmdline-opts/CMakeLists.txt
+++ b/docs/cmdline-opts/CMakeLists.txt
@@ -21,9 +21,6 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-set(MANPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1")
-set(ASCIIPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt")
-
 # Get 'DPAGES' variable
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")

--- a/docs/cmdline-opts/CMakeLists.txt
+++ b/docs/cmdline-opts/CMakeLists.txt
@@ -32,9 +32,14 @@ add_custom_command(OUTPUT "${MANPAGE}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" mainpage ${DPAGES} > "${MANPAGE}"
   COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" ascii ${DPAGES} > "${ASCIIPAGE}"
+  DEPENDS
+    "${PROJECT_SOURCE_DIR}/scripts/managen"
+    ${DPAGES}
   VERBATIM
 )
+
 add_custom_target("generate-curl.1" ALL DEPENDS "${MANPAGE}")
+
 if(NOT CURL_DISABLE_INSTALL)
   install(FILES "${MANPAGE}" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,17 +30,15 @@ if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
     OUTPUT "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#include \"tool_setup.h\"" > "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#ifndef HAVE_LIBZ" >> "tool_hugehelp.c"
-    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
-      < "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt" >> "tool_hugehelp.c"
+    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"    < "${ASCIIPAGE}" >> "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#else" >> "tool_hugehelp.c"
-    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c
-      < "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt" >> "tool_hugehelp.c"
+    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c < "${ASCIIPAGE}" >> "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#endif /* HAVE_LIBZ */" >> "tool_hugehelp.c"
     DEPENDS
       "generate-curl.1"
       "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
-      "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt"
+      "${ASCIIPAGE}"
     VERBATIM)
 else()
   add_custom_command(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
       "generate-curl.1"
       "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
-      "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1"
+      "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt"
     VERBATIM)
 else()
   add_custom_command(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,16 +32,15 @@ if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
     COMMAND ${CMAKE_COMMAND} -E echo "#ifndef HAVE_LIBZ" >> "tool_hugehelp.c"
     COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
       < "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt" >> "tool_hugehelp.c"
-
     COMMAND ${CMAKE_COMMAND} -E echo "#else" >> "tool_hugehelp.c"
     COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c
       < "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt" >> "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#endif /* HAVE_LIBZ */" >> "tool_hugehelp.c"
     DEPENDS
       "generate-curl.1"
-      "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1"
       "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
+      "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1"
     VERBATIM)
 else()
   add_custom_command(
@@ -64,8 +63,8 @@ if(CURL_CA_EMBED_SET)
       COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mk-file-embed.pl" --var curl_ca_embed
         < "${CURL_CA_EMBED}" > "tool_ca_embed.c"
       DEPENDS
-        "${CURL_CA_EMBED}"
         "${CMAKE_CURRENT_SOURCE_DIR}/mk-file-embed.pl"
+        "${CURL_CA_EMBED}"
       VERBATIM)
     list(APPEND CURL_CFILES "tool_ca_embed.c")
   else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,7 @@ if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
     COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c < "${CURL_ASCIIPAGE}" >> "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#endif /* HAVE_LIBZ */" >> "tool_hugehelp.c"
     DEPENDS
-      "generate-curl.1"
+      generate-curl.1
       "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
       "${CURL_ASCIIPAGE}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,6 @@ if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
     COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c < "${CURL_ASCIIPAGE}" >> "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#endif /* HAVE_LIBZ */" >> "tool_hugehelp.c"
     DEPENDS
-      generate-curl.1
       "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
       "${CURL_ASCIIPAGE}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,15 +30,15 @@ if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
     OUTPUT "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#include \"tool_setup.h\"" > "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#ifndef HAVE_LIBZ" >> "tool_hugehelp.c"
-    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"    < "${ASCIIPAGE}" >> "tool_hugehelp.c"
+    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"    < "${CURL_ASCIIPAGE}" >> "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#else" >> "tool_hugehelp.c"
-    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c < "${ASCIIPAGE}" >> "tool_hugehelp.c"
+    COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c < "${CURL_ASCIIPAGE}" >> "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#endif /* HAVE_LIBZ */" >> "tool_hugehelp.c"
     DEPENDS
       "generate-curl.1"
       "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
-      "${ASCIIPAGE}"
+      "${CURL_ASCIIPAGE}"
     VERBATIM)
 else()
   add_custom_command(


### PR DESCRIPTION
- make `curl.1` and `curl.txt` depend on `DPAGES`.
  To trigger a rebuild when an individual manpage is updated.

- tell CMake that the cmdline-opts command also creates `curl.txt`.

- make `tool_hugehelp.c` depend on `curl.txt` (was: `curl.1`), to match
  what it actually uses for input.

- stop using `generate-curl.1` as an indirect way to create `curl.txt`
  in time for `tool_hugehelp.c`. After the fixes above there is a direct
  depedency chain between them.

- move `ASCIIPAGE` and `MANPAGE` variables to top-level, re-use them in
  `src` and prefix them with `CURL_` to avoid clashing with other
  projects.                                                           
                                                                      
- drop double quotes from `generate-curl.1` as a hint that it is not  
  a filename, but a target name.                                      
                                                                      
- src: tidy up order of dependency lists.                             

---

- [ ] maybe add back `generate-curl.1` to `DEPENDS` just in case?