### PR TITLE
vtls/rustls: 0.14.0 update and assoc. improvements

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,7 +54,7 @@ env:
   # unhandled
   quictls-version: 3.1.4+quic
   # renovate: datasource=github-tags depName=rustls/rustls-ffi versioning=semver registryUrl=https://github.com
-  rustls-version: 0.13.0
+  rustls-version: 0.14.0
 
 jobs:
   linux:

--- a/docs/EXPERIMENTAL.md
+++ b/docs/EXPERIMENTAL.md
@@ -56,7 +56,6 @@ Graduation requirements:
 Graduation requirements:
 
 - a reasonable expectation of a stable API going forward.
-- a sufficient approach to avoid using weak random numbers
 
 ### WebSocket
 

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: curl
 [Rustls is a TLS backend written in Rust](https://docs.rs/rustls/). Curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
 the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
-version of curl depends on version v0.13.0 of rustls-ffi.
+version of curl depends on version v0.14.0 of rustls-ffi.
 
 # Building with Rustls
 
@@ -17,7 +17,7 @@ First, [install Rust](https://rustup.rs/).
 
 Next, check out, build, and install the appropriate version of rustls-ffi:
 
-    % git clone https://github.com/rustls/rustls-ffi -b v0.13.0
+    % git clone https://github.com/rustls/rustls-ffi -b v0.14.0
     % cd rustls-ffi
     % make
     % make DESTDIR=${HOME}/rustls-ffi-built/ install
@@ -29,6 +29,11 @@ Now configure and build curl with Rustls:
     % autoreconf -fi
     % ./configure --with-rustls=${HOME}/rustls-ffi-built
     % make
+
+See the [rustls-ffi README] for more information on cryptography providers and
+their build/platform requirements.
+
+[rustls-ffi README]: https://github.com/rustls/rustls-ffi/blob/main/README.md#cryptography-provide
 
 ## Randomness
 

--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -34,18 +34,3 @@ See the [rustls-ffi README] for more information on cryptography providers and
 their build/platform requirements.
 
 [rustls-ffi README]: https://github.com/rustls/rustls-ffi/blob/main/README.md#cryptography-provide
-
-## Randomness
-
-Every TLS libcurl curl supports - *except* Rustls - provides a function for
-curl to extract cryptographically safe random numbers with.
-
-When you build curl with Rustls, curl uses its own internal attempts to get a
-decent random value:
-
-1. Windows specific APIs
-2. arc4random
-
-If neither of those are present, then curl using Rustls falls back to **weak
-pseudo-random values**, and thus weakening several curl authentication
-implementations.

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -100,9 +100,9 @@ CURLcode Curl_win32_random(unsigned char *entropy, size_t length)
 }
 #endif
 
-#if !defined(USE_SSL) || defined(USE_RUSTLS)
+#if !defined(USE_SSL)
 /* ---- possibly non-cryptographic version following ---- */
-CURLcode Curl_weak_random(struct Curl_easy *data,
+static CURLcode weak_random(struct Curl_easy *data,
                           unsigned char *entropy,
                           size_t length) /* always 4, size of int */
 {
@@ -151,7 +151,7 @@ CURLcode Curl_weak_random(struct Curl_easy *data,
 #ifdef USE_SSL
 #define _random(x,y,z) Curl_ssl_random(x,y,z)
 #else
-#define _random(x,y,z) Curl_weak_random(x,y,z)
+#define _random(x,y,z) weak_random(x,y,z)
 #endif
 
 static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,

--- a/lib/rand.h
+++ b/lib/rand.h
@@ -36,11 +36,6 @@ CURLcode Curl_rand_bytes(struct Curl_easy *data,
 #define Curl_rand(a,b,c)   Curl_rand_bytes((a), (b), (c))
 #endif
 
-/* ---- non-cryptographic version following ---- */
-CURLcode Curl_weak_random(struct Curl_easy *data,
-                          unsigned char *rnd,
-                          size_t length);
-
 /*
  * Curl_rand_hex() fills the 'rnd' buffer with a given 'num' size with random
  * hexadecimal digits PLUS a null-terminating byte. It must be an odd number

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -436,7 +436,7 @@ cr_get_selected_ciphers(struct Curl_easy *data,
                         size_t *selected_size)
 {
   size_t supported_len = *selected_size;
-  size_t default_len = rustls_default_ciphersuites_len();
+  size_t default_len = rustls_default_crypto_provider_ciphersuites_len();
   const struct rustls_supported_ciphersuite *entry;
   const char *ciphers = ciphers12;
   size_t count = 0, default13_count = 0, i, j;
@@ -448,7 +448,7 @@ cr_get_selected_ciphers(struct Curl_easy *data,
     /* Add default TLSv1.3 ciphers to selection */
     for(j = 0; j < default_len; j++) {
       struct rustls_str s;
-      entry = rustls_default_ciphersuites_get_entry(j);
+      entry = rustls_default_crypto_provider_ciphersuites_get(j);
       s = rustls_supported_ciphersuite_get_name(entry);
       if(s.len < 5 || strncmp(s.data, "TLS13", 5) != 0)
         continue;
@@ -471,7 +471,7 @@ add_ciphers:
     /* Check if cipher is supported */
     if(id) {
       for(i = 0; i < supported_len; i++) {
-        entry = rustls_all_ciphersuites_get_entry(i);
+        entry = rustls_default_crypto_provider_ciphersuites_get(i);
         if(rustls_supported_ciphersuite_get_suite(entry) == id)
           break;
       }
@@ -506,7 +506,7 @@ add_ciphers:
     /* Add default TLSv1.2 ciphers to selection */
     for(j = 0; j < default_len; j++) {
       struct rustls_str s;
-      entry = rustls_default_ciphersuites_get_entry(j);
+      entry = rustls_default_crypto_provider_ciphersuites_get(j);
       s = rustls_supported_ciphersuite_get_name(entry);
       if(s.len >= 5 && strncmp(s.data, "TLS13", 5) == 0)
         continue;
@@ -529,6 +529,8 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
 {
   struct ssl_connect_data *connssl = cf->ctx;
   struct ssl_primary_config *conn_config = Curl_ssl_cf_get_primary_config(cf);
+  struct rustls_crypto_provider_builder *custom_provider_builder = NULL;
+  const struct rustls_crypto_provider *custom_provider = NULL;
   struct rustls_connection *rconn = NULL;
   struct rustls_client_config_builder *config_builder = NULL;
   const struct rustls_root_cert_store *roots = NULL;
@@ -554,7 +556,8 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     };
     size_t tls_versions_len = 2;
     const struct rustls_supported_ciphersuite **cipher_suites;
-    size_t cipher_suites_len = rustls_default_ciphersuites_len();
+    size_t cipher_suites_len =
+      rustls_default_crypto_provider_ciphersuites_len();
 
     switch(conn_config->version) {
     case CURL_SSLVERSION_DEFAULT:
@@ -604,17 +607,47 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
       return CURLE_SSL_CIPHER;
     }
 
-    result = rustls_client_config_builder_new_custom(cipher_suites,
-                                                     cipher_suites_len,
-                                                     tls_versions,
-                                                     tls_versions_len,
-                                                     &config_builder);
+    result = rustls_crypto_provider_builder_new_from_default(
+                      &custom_provider_builder);
+    if(result != RUSTLS_RESULT_OK) {
+      failf(data,
+        "rustls: failed to create crypto provider builder from default");
+      return CURLE_SSL_ENGINE_INITFAILED;
+    }
+
+    result =
+      rustls_crypto_provider_builder_set_cipher_suites(
+        custom_provider_builder,
+        cipher_suites,
+        cipher_suites_len);
+    if(result != RUSTLS_RESULT_OK) {
+      failf(data,
+        "rustls: failed to set ciphersuites for crypto provider builder");
+        rustls_crypto_provider_builder_free(custom_provider_builder);
+        return CURLE_SSL_ENGINE_INITFAILED;
+    }
+
+    result = rustls_crypto_provider_builder_build(
+      custom_provider_builder, &custom_provider);
+    if(result != RUSTLS_RESULT_OK) {
+      failf(data, "rustls: failed to build custom crypto provider");
+      rustls_crypto_provider_builder_free(custom_provider_builder);
+      return CURLE_SSL_ENGINE_INITFAILED;
+    }
+
+    result = rustls_client_config_builder_new_custom(custom_provider,
+                                                      tls_versions,
+                                                      tls_versions_len,
+                                                      &config_builder);
     free(cipher_suites);
     if(result != RUSTLS_RESULT_OK) {
       failf(data, "rustls: failed to create client config");
       return CURLE_SSL_ENGINE_INITFAILED;
     }
   }
+
+  rustls_crypto_provider_builder_free(custom_provider_builder);
+  rustls_crypto_provider_free(custom_provider);
 
   if(connssl->alpn) {
     struct alpn_proto_buf proto;
@@ -710,7 +743,15 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     rustls_server_cert_verifier_free(server_cert_verifier);
   }
 
-  backend->config = rustls_client_config_builder_build(config_builder);
+  result = rustls_client_config_builder_build(
+    config_builder,
+    &backend->config);
+  if(result != RUSTLS_RESULT_OK) {
+    failf(data, "rustls: failed to build client config");
+    rustls_client_config_free(backend->config);
+    return CURLE_SSL_ENGINE_INITFAILED;
+  }
+
   DEBUGASSERT(rconn == NULL);
   result = rustls_client_connection_new(backend->config,
                                         connssl->peer.hostname, &rconn);
@@ -806,10 +847,7 @@ cr_connect_common(struct Curl_cfilter *cf,
       /* REALLY Done with the handshake. */
       {
         uint16_t proto = rustls_connection_get_protocol_version(rconn);
-        const rustls_supported_ciphersuite *rcipher =
-            rustls_connection_get_negotiated_ciphersuite(rconn);
-        uint16_t cipher = rcipher ?
-                          rustls_supported_ciphersuite_get_suite(rcipher) : 0;
+        uint16_t cipher = rustls_connection_get_negotiated_ciphersuite(rconn);
         char buf[64] = "";
         const char *ver = "TLS version unknown";
         if(proto == RUSTLS_TLS_VERSION_TLSV1_3)

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -447,10 +447,9 @@ cr_get_selected_ciphers(struct Curl_easy *data,
   if(!ciphers13) {
     /* Add default TLSv1.3 ciphers to selection */
     for(j = 0; j < default_len; j++) {
-      struct rustls_str s;
       entry = rustls_default_crypto_provider_ciphersuites_get(j);
-      s = rustls_supported_ciphersuite_get_name(entry);
-      if(s.len < 5 || strncmp(s.data, "TLS13", 5) != 0)
+      if(rustls_supported_ciphersuite_protocol_version(entry) !=
+        RUSTLS_TLS_VERSION_TLSV1_3)
         continue;
 
       selected[count++] = entry;
@@ -505,10 +504,9 @@ add_ciphers:
   if(!ciphers12) {
     /* Add default TLSv1.2 ciphers to selection */
     for(j = 0; j < default_len; j++) {
-      struct rustls_str s;
       entry = rustls_default_crypto_provider_ciphersuites_get(j);
-      s = rustls_supported_ciphersuite_get_name(entry);
-      if(s.len >= 5 && strncmp(s.data, "TLS13", 5) == 0)
+      if(rustls_supported_ciphersuite_protocol_version(entry) ==
+          RUSTLS_TLS_VERSION_TLSV1_3)
         continue;
 
       /* No duplicates allowed (so selected cannot overflow) */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -646,8 +646,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
       if(result != RUSTLS_RESULT_OK) {
         failf(data, "rustls: failed to parse trusted certificates from blob");
         rustls_root_cert_store_builder_free(roots_builder);
-        rustls_client_config_free(
-          rustls_client_config_builder_build(config_builder));
+        rustls_client_config_builder_free(config_builder);
         return CURLE_SSL_CACERT_BADFILE;
       }
     }
@@ -658,8 +657,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
       if(result != RUSTLS_RESULT_OK) {
         failf(data, "rustls: failed to load trusted certificates");
         rustls_root_cert_store_builder_free(roots_builder);
-        rustls_client_config_free(
-          rustls_client_config_builder_build(config_builder));
+        rustls_client_config_builder_free(config_builder);
         return CURLE_SSL_CACERT_BADFILE;
       }
     }
@@ -668,8 +666,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     rustls_root_cert_store_builder_free(roots_builder);
     if(result != RUSTLS_RESULT_OK) {
       failf(data, "rustls: failed to load trusted certificates");
-      rustls_client_config_free(
-        rustls_client_config_builder_build(config_builder));
+      rustls_client_config_builder_free(config_builder);
       return CURLE_SSL_CACERT_BADFILE;
     }
 
@@ -704,8 +701,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     if(result != RUSTLS_RESULT_OK) {
       failf(data, "rustls: failed to load trusted certificates");
       rustls_server_cert_verifier_free(server_cert_verifier);
-      rustls_client_config_free(
-        rustls_client_config_builder_build(config_builder));
+      rustls_client_config_builder_free(config_builder);
       return CURLE_SSL_CACERT_BADFILE;
     }
 

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -665,7 +665,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     result = rustls_root_cert_store_builder_build(roots_builder, &roots);
     rustls_root_cert_store_builder_free(roots_builder);
     if(result != RUSTLS_RESULT_OK) {
-      failf(data, "rustls: failed to load trusted certificates");
+      failf(data, "rustls: failed to build trusted root certificate store");
       rustls_client_config_builder_free(config_builder);
       return CURLE_SSL_CACERT_BADFILE;
     }
@@ -699,7 +699,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
       verifier_builder, &server_cert_verifier);
     rustls_web_pki_server_cert_verifier_builder_free(verifier_builder);
     if(result != RUSTLS_RESULT_OK) {
-      failf(data, "rustls: failed to load trusted certificates");
+      failf(data, "rustls: failed to build certificate verifier");
       rustls_server_cert_verifier_free(server_cert_verifier);
       rustls_client_config_builder_free(config_builder);
       return CURLE_SSL_CACERT_BADFILE;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1056,6 +1056,16 @@ static size_t cr_version(char *buffer, size_t size)
   return msnprintf(buffer, size, "%.*s", (int)ver.len, ver.data);
 }
 
+static CURLcode
+cr_random(struct Curl_easy *data, unsigned char *entropy, size_t length)
+{
+  rustls_result rresult = 0;
+  (void)data;
+  rresult =
+    rustls_default_crypto_provider_random(entropy, length);
+  return map_error(rresult);
+}
+
 const struct Curl_ssl Curl_ssl_rustls = {
   { CURLSSLBACKEND_RUSTLS, "rustls" },
   SSLSUPP_CAINFO_BLOB |            /* supports */
@@ -1070,7 +1080,7 @@ const struct Curl_ssl Curl_ssl_rustls = {
   Curl_none_check_cxn,             /* check_cxn */
   cr_shutdown,                     /* shutdown */
   cr_data_pending,                 /* data_pending */
-  Curl_weak_random,                /* random */
+  cr_random,                       /* random */
   Curl_none_cert_status_request,   /* cert_status_request */
   cr_connect_blocking,             /* connect */
   cr_connect_nonblocking,          /* connect_nonblocking */


### PR DESCRIPTION
:wave: This branch updates the experimental `rustls` vtls backend for `curl` to use the just-released [rustls-ffi 0.14.0](https://github.com/rustls/rustls-ffi/releases/tag/v0.14.0), and the latest release of the main rust crate, [rustls 0.23.13](https://github.com/rustls/rustls/releases/tag/v%2F0.23.13).

Along the way I made a handful of other small improvements and so I recommend reviewing commit-by-commit. My goal was to have each commit build independent of the others, and to avoid introducing new functionality at the same time as updating breaking API changes. I've done my best to match local style but I'm still quite green at contributing to `curl`: feedback very welcome.

In addition to the 0.14.0 update, this branch resolves the "weak RNG" situation described in https://github.com/curl/curl/pull/14770 and replaces the ciphersuite name string comparison logic from https://github.com/curl/curl/pull/14840 with a more robust solution based on protocol version constants.