### PR TITLE
connect info when really done

### DIFF
--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -189,7 +189,6 @@ static CURLcode baller_connected(struct Curl_cfilter *cf,
 
   switch(cf->conn->alpn) {
   case CURL_HTTP_VERSION_3:
-    infof(data, "using HTTP/3");
     break;
   case CURL_HTTP_VERSION_2:
 #ifdef USE_NGHTTP2
@@ -202,10 +201,8 @@ static CURLcode baller_connected(struct Curl_cfilter *cf,
       return result;
     }
 #endif
-    infof(data, "using HTTP/2");
     break;
   default:
-    infof(data, "using HTTP/1.x");
     break;
   }
   ctx->state = CF_HC_SUCCESS;

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -437,6 +437,7 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
       cf_cntrl_update_info(data, data->conn);
       conn_report_connect_stats(data, data->conn);
       data->conn->keepalive = Curl_now();
+      Curl_verboseconnect(data, data->conn, sockindex);
     }
     else if(result) {
       conn_report_connect_stats(data, data->conn);

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -969,7 +969,17 @@ static CURLcode cf_he_connect(struct Curl_cfilter *cf,
 
         if(cf->conn->handler->protocol & PROTO_FAMILY_SSH)
           Curl_pgrsTime(data, TIMER_APPCONNECT); /* we are connected already */
-        Curl_verboseconnect(data, cf->conn, cf->sockindex);
+        if(Curl_trc_cf_is_verbose(cf, data)) {
+          struct ip_quadruple ipquad;
+          int is_ipv6;
+          if(!Curl_conn_cf_get_ip_info(cf->next, data, &is_ipv6, &ipquad)) {
+            const char *host, *disphost;
+            int port;
+            cf->next->cft->get_host(cf->next, data, &host, &disphost, &port);
+            CURL_TRC_CF(data, cf, "Connected to %s (%s) port %u",
+                        disphost, ipquad.remote_ip, ipquad.remote_port);
+          }
+        }
         data->info.numconnects++; /* to track the # of connections made */
       }
       break;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1274,6 +1274,21 @@ void Curl_verboseconnect(struct Curl_easy *data,
     infof(data, "Connected to %s (%s) port %u",
           CURL_CONN_HOST_DISPNAME(conn), conn->primary.remote_ip,
           conn->primary.remote_port);
+#if !defined(CURL_DISABLE_HTTP)
+    if(conn->handler->protocol & PROTO_FAMILY_HTTP) {
+      switch(conn->alpn) {
+      case CURL_HTTP_VERSION_3:
+        infof(data, "using HTTP/3");
+        break;
+      case CURL_HTTP_VERSION_2:
+        infof(data, "using HTTP/2");
+        break;
+      default:
+        infof(data, "using HTTP/1.x");
+        break;
+      }
+    }
+#endif
 }
 #endif
 


### PR DESCRIPTION
Output the 'Connected to...' info message when the connection has been fully established and all information is available.

Due to our happy eyeballing, we should not emit info messages in filters, because they may be part of an eyeballing attempt and may be discarded later for another chain.

refs #14894