### PR TITLE
cmake/FindNGTCP2: use library path as hint for finding the crypto module

### DIFF
--- a/CMake/FindNGTCP2.cmake
+++ b/CMake/FindNGTCP2.cmake
@@ -83,12 +83,15 @@ if(NGTCP2_FIND_COMPONENTS)
   endforeach()
 
   if(_ngtcp2_crypto_backend)
+    get_filename_component(_ngtcp2_library_dir "${NGTCP2_LIBRARY}" DIRECTORY)
+
     string(TOLOWER "ngtcp2_crypto_${_ngtcp2_crypto_backend}" _crypto_library)
     if(CURL_USE_PKGCONFIG)
       pkg_check_modules(PC_${_crypto_library} "lib${_crypto_library}")
     endif()
     find_library(${_crypto_library}_LIBRARY NAMES ${_crypto_library}
       HINTS
+        ${_ngtcp2_library_dir}
         ${PC_${_crypto_library}_LIBDIR}
         ${PC_${_crypto_library}_LIBRARY_DIRS}
     )

--- a/CMake/FindNGTCP2.cmake
+++ b/CMake/FindNGTCP2.cmake
@@ -83,18 +83,20 @@ if(NGTCP2_FIND_COMPONENTS)
   endforeach()
 
   if(_ngtcp2_crypto_backend)
-    get_filename_component(_ngtcp2_library_dir "${NGTCP2_LIBRARY}" DIRECTORY)
-
     string(TOLOWER "ngtcp2_crypto_${_ngtcp2_crypto_backend}" _crypto_library)
+
     if(CURL_USE_PKGCONFIG)
       pkg_check_modules(PC_${_crypto_library} "lib${_crypto_library}")
     endif()
+
+    get_filename_component(_ngtcp2_library_dir "${NGTCP2_LIBRARY}" DIRECTORY)
     find_library(${_crypto_library}_LIBRARY NAMES ${_crypto_library}
       HINTS
         ${_ngtcp2_library_dir}
         ${PC_${_crypto_library}_LIBDIR}
         ${PC_${_crypto_library}_LIBRARY_DIRS}
     )
+
     if(${_crypto_library}_LIBRARY)
       set(NGTCP2_${_ngtcp2_crypto_backend}_FOUND TRUE)
       set(NGTCP2_CRYPTO_LIBRARY ${${_crypto_library}_LIBRARY})


### PR DESCRIPTION
It allows finding the ngtcp2 crypto interface library automatically when
using a custom `NGTCP2_LIBRARY`.

Before this patch the library location had to be added via
`CMAKE_LIBRARY_PATH` or by other means.

Also add empty lines for readability / uniformity.

Fixes https://github.com/curl/curl-for-win/blob/8b8909e1206de1dcca356a8dd33eb1e4ffeea7fd/curl.sh#L289

---

TODO:
- [x] test it with curl-for-win after deleting `CMAKE_LIBRARY_PATH` option from curl.sh. (tested OK locally with non-curl-for-win, but a custom native build.)
- [x] test when this directory is empty or undefined.
