### PR TITLE
cmake: separate target for examples, optimize CI, fix fallouts

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -113,11 +113,6 @@ jobs:
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 
-      - name: 'autotools build examples'
-        if: ${{ matrix.build == 'automake' }}
-        timeout-minutes: 5
-        run: make -C bld -j5 V=1 examples
-
       - name: 'autotools build tests'
         if: ${{ matrix.build == 'automake' && matrix.tflags != 'skipall' }}
         timeout-minutes: 15
@@ -133,6 +128,11 @@ jobs:
           fi
           make -C bld -j5 V=1 test-ci
 
+      - name: 'autotools build examples'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 5
+        run: make -C bld -j5 V=1 examples
+
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 5
@@ -141,7 +141,6 @@ jobs:
           cmake -B bld -G Ninja ${options} \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
-            -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
             -DCURL_BROTLI=ON \
             ${{ matrix.config }}
@@ -186,3 +185,8 @@ jobs:
           fi
           PATH="$PWD/bld/lib:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
+
+      - name: 'cmake build examples'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 5
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -504,7 +504,6 @@ jobs:
           cmake . \
             -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \
             -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON \
-            -DBUILD_EXAMPLES=ON \
             -DCURL_BROTLI=ON -DCURL_ZSTD=ON \
             ${{ matrix.build.generate }}
         if: ${{ matrix.build.generate }}
@@ -535,10 +534,6 @@ jobs:
       - run: ./src/curl -V
         name: 'check curl -V output'
 
-      - run: ${{ matrix.build.make-prefix }} make V=1 examples
-        if: ${{ matrix.build.configure }}
-        name: 'make examples'
-
       - run: make V=1 -C tests
         if: ${{ matrix.build.configure && matrix.build.install_steps != 'skipall' }}
         name: 'make tests (autotools)'
@@ -566,3 +561,11 @@ jobs:
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
           CURL_CI: github
+
+      - run: ${{ matrix.build.make-prefix }} make V=1 examples
+        if: ${{ matrix.build.configure }}
+        name: 'make examples (autotools)'
+
+      - run: ${{ matrix.build.make-prefix }} make VERBOSE=1 curl-examples
+        if: ${{ matrix.build.generate }}
+        name: 'make examples (cmake)'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -121,7 +121,7 @@ jobs:
             compiler: gcc-12
             configure: --enable-debug --with-secure-transport --enable-websockets --with-libssh2=$(brew --prefix libssh2)
             macos-version-min: '10.8'
-          - name: 'LibreSSL'
+          - name: 'LibreSSL +examples'
             compiler: clang
             install: libressl
             configure: --enable-debug --with-openssl=$(brew --prefix libressl) --enable-websockets
@@ -229,9 +229,6 @@ jobs:
       - name: 'curl version'
         run: bld/src/curl --disable --version
 
-      - name: 'make examples'
-        run: make -C bld V=1 examples
-
       - name: 'make tests'
         run: make -C bld V=1 -C tests
 
@@ -264,6 +261,10 @@ jobs:
           rm -f $HOME/.curlrc
           make -C bld V=1 test-ci
 
+      - name: 'make examples'
+        if: ${{ contains(matrix.build.name, '+examples') }}
+        run: make -C bld V=1 examples
+
   cmake:
     name: 'CM ${{ matrix.compiler }} ${{ matrix.build.name }}'
     runs-on: 'macos-latest'
@@ -287,9 +288,9 @@ jobs:
           - name: 'SecureTransport ws debug+'
             generate: -DCURL_USE_SECTRANSP=ON -DENABLE_WEBSOCKETS=ON -DENABLE_DEBUG=ON -DENABLE_CURLDEBUG=ON
             macos-version-min: '10.8'
-          - name: 'LibreSSL !ldap heimdal c-ares'
+          - name: 'LibreSSL !ldap heimdal c-ares +examples'
             install: libressl heimdal
-            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix libressl) -DENABLE_ARES=ON -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=$(brew --prefix heimdal) -DCURL_DISABLE_LDAP=ON -DBUILD_EXAMPLES=ON
+            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix libressl) -DENABLE_ARES=ON -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=$(brew --prefix heimdal) -DCURL_DISABLE_LDAP=ON
             macos-version-min: '10.15'
           - name: 'wolfSSL !ldap brotli zstd'
             install: brotli wolfssl zstd
@@ -398,6 +399,10 @@ jobs:
           PATH="$HOME/venv/bin:$PATH"
           rm -f $HOME/.curlrc
           ninja -C bld test-ci
+
+      - name: 'cmake build examples'
+        if: ${{ contains(matrix.name, '+examples') }}
+        run: make -C bld VERBOSE=1
 
   combinations:  # Test buildability with host OS, Xcode / SDK, compiler, target-OS, SecureTransport/not, built tool, combinations
     if: true  # Set to `true` to enable this test matrix. It runs quickly.

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -69,7 +69,9 @@ jobs:
               export TFLAGS='-j0'  # flakies: ~389 ~392 ~TFTP and more
               cmake --build bld --config Debug --target test-ci
             fi
+            echo '::group::build examples'
             cmake --build bld --config Debug --parallel 3 --target curl-examples
+            echo '::endgroup::'
 
   openbsd:
     name: 'OpenBSD (cmake, libressl, clang)'
@@ -104,7 +106,9 @@ jobs:
               export TFLAGS='-j8 ~3017 ~TFTP ~FTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
               cmake --build bld --config Debug --target test-ci
             fi
+            echo '::group::build examples'
             cmake --build bld --config Debug --parallel 3 --target curl-examples
+            echo '::endgroup::'
 
   freebsd:
     name: 'FreeBSD (${{ matrix.build }}, openssl, ${{ matrix.compiler }}, ${{ matrix.arch }})'
@@ -144,7 +148,9 @@ jobs:
               make -j3 -C tests
               make test-ci V=1 TFLAGS='-j8 ~FTP'
             fi
+            echo '::group::build examples'
             make -j3 examples
+            echo '::endgroup::'
 
       - name: 'cmake'
         if: ${{ matrix.build == 'cmake' }}
@@ -173,7 +179,9 @@ jobs:
               export TFLAGS='-j8 ~FTP'
               cmake --build bld --config Debug --target test-ci
             fi
+            echo '::group::build examples'
             cmake --build bld --config Debug --parallel 3 --target curl-examples
+            echo '::endgroup::'
 
   omnios:
     name: 'OmniOS (autotools, openssl, gcc, amd64)'
@@ -199,4 +207,6 @@ jobs:
             src/curl --disable --version
             gmake -j3 -C tests
             gmake test-ci V=1 TFLAGS='-j12 ~MQTT ~FTP'
+            echo '::group::build examples'
             gmake -j3 examples
+            echo '::endgroup::'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -64,12 +64,12 @@ jobs:
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
-            cmake --build bld --config Debug --parallel 3 --target curl-examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j0'  # flakies: ~389 ~392 ~TFTP and more
               cmake --build bld --config Debug --target test-ci
             fi
+            cmake --build bld --config Debug --parallel 3 --target curl-examples
 
   openbsd:
     name: 'OpenBSD (cmake, libressl, clang)'
@@ -99,12 +99,12 @@ jobs:
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
-            cmake --build bld --config Debug --parallel 3 --target curl-examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j8 ~3017 ~TFTP ~FTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
               cmake --build bld --config Debug --target test-ci
             fi
+            cmake --build bld --config Debug --parallel 3 --target curl-examples
 
   freebsd:
     name: 'FreeBSD (${{ matrix.build }}, openssl, ${{ matrix.compiler }}, ${{ matrix.arch }})'
@@ -140,11 +140,11 @@ jobs:
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             make -j3 install
             src/curl --disable --version
-            make -j3 examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               make -j3 -C tests
               make test-ci V=1 TFLAGS='-j8 ~FTP'
             fi
+            make -j3 examples
 
       - name: 'cmake'
         if: ${{ matrix.build == 'cmake' }}
@@ -168,12 +168,12 @@ jobs:
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
-            cmake --build bld --config Debug --parallel 3 --target curl-examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j8 ~FTP'
               cmake --build bld --config Debug --target test-ci
             fi
+            cmake --build bld --config Debug --parallel 3 --target curl-examples
 
   omnios:
     name: 'OmniOS (autotools, openssl, gcc, amd64)'
@@ -197,6 +197,6 @@ jobs:
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
             gmake -j3 install
             src/curl --disable --version
-            gmake -j3 examples
             gmake -j3 -C tests
             gmake test-ci V=1 TFLAGS='-j12 ~MQTT ~FTP'
+            gmake -j3 examples

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -58,13 +58,13 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=ON \
               -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DCURL_USE_GSSAPI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
+            cmake --build bld --config Debug --parallel 3 --target curl-examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j0'  # flakies: ~389 ~392 ~TFTP and more
@@ -93,13 +93,13 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=ON \
               -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
+            cmake --build bld --config Debug --parallel 3 --target curl-examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j8 ~3017 ~TFTP ~FTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
@@ -162,13 +162,13 @@ jobs:
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-              -DBUILD_EXAMPLES=ON \
               -DENABLE_WEBSOCKETS=ON \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DCURL_USE_GSSAPI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             cmake --build bld --config Debug --parallel 3
             bld/src/curl --disable --version
+            cmake --build bld --config Debug --parallel 3 --target curl-examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
               export TFLAGS='-j8 ~FTP'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -427,9 +427,11 @@ jobs:
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' }}
-        run: |
-          make -C bld -j5
-          make -C bld -j5 examples
+        run: make -C bld -j5
+
+      - name: 'autotools build examples'
+        if: ${{ matrix.build == 'autotools' }}
+        run: make -C bld -j5 examples
 
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
@@ -449,9 +451,11 @@ jobs:
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
-        run: |
-          cmake --build bld --parallel 5
-          cmake --build bld --parallel 5 --target curl-examples
+        run: cmake --build bld --parallel 5
+
+      - name: 'cmake build examples'
+        if: ${{ matrix.build == 'cmake' }}
+        run: cmake --build bld --parallel 5 --target curl-examples
 
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -56,8 +56,8 @@ jobs:
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_ARES=ON', type: 'Debug', name: 'schannel c-ares U' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }
           - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release', name: 'openssl' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DBUILD_EXAMPLES=OFF', type: 'Release', test: 'uwp', name: 'schannel R' }
-          - { build: 'cmake'    , sys: 'mingw32', env: 'i686'        , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DBUILD_EXAMPLES=OFF', type: 'Release', name: 'schannel R' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', test: 'uwp', name: 'schannel R' }
+          - { build: 'cmake'    , sys: 'mingw32', env: 'i686'        , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', name: 'schannel R' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
@@ -135,11 +135,6 @@ jobs:
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 
-      - name: 'autotools build examples'
-        if: ${{ matrix.build == 'autotools' }}
-        timeout-minutes: 5
-        run: make -C bld -j5 V=1 examples
-
       - name: 'autotools build tests'
         if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' }}
         timeout-minutes: 10
@@ -168,6 +163,11 @@ jobs:
           fi
           PATH="$PATH:/c/Program Files (x86)/stunnel/bin"
           make -C bld -j5 V=1 test-ci
+
+      - name: 'autotools build examples'
+        if: ${{ matrix.build == 'autotools' }}
+        timeout-minutes: 5
+        run: make -C bld -j5 V=1 examples
 
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
@@ -198,7 +198,6 @@ jobs:
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
-            -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
             -DCURL_BROTLI=ON \
             ${{ matrix.config }}
@@ -224,7 +223,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 1
         run: |
-          find . -name '*.exe' -o -name '*.dll' | grep -v '/examples/'
+          find . -name '*.exe' -o -name '*.dll'
           if [ '${{ matrix.test }}' != 'uwp' ]; then  # UWP missing 'msvcr120_app.dll', fails with exit code 0xc0000135
             PATH="$PWD/bld/lib:$PATH"
             bld/src/curl.exe --disable --version
@@ -258,6 +257,11 @@ jobs:
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
+
+      - name: 'cmake build examples'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 5
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
 
   old-mingw-w64:
     name: 'old-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
@@ -327,7 +331,6 @@ jobs:
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
-            -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
             -DCURL_USE_LIBPSL=OFF \
             ${{ matrix.config }}
@@ -343,7 +346,7 @@ jobs:
         run: cat bld/lib/curl_config.h || true
 
       - name: 'cmake build'
-        timeout-minutes: 10
+        timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
@@ -351,7 +354,7 @@ jobs:
       - name: 'curl version'
         timeout-minutes: 1
         run: |
-          find . -name '*.exe' -o -name '*.dll' | grep -v '/examples/'
+          find . -name '*.exe' -o -name '*.dll'
           PATH="$PWD/bld/lib:$PATH"
           bld/src/curl.exe --disable --version
 
@@ -381,6 +384,12 @@ jobs:
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
+
+      - name: 'cmake build examples'
+        timeout-minutes: 5
+        run: |
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
 
   linux-cross-mingw-w64:
     name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
@@ -431,7 +440,6 @@ jobs:
             -DCMAKE_C_COMPILER=${TRIPLET}-gcc \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
-            -DBUILD_EXAMPLES=ON \
             -DCURL_USE_SCHANNEL=ON -DUSE_WIN32_IDN=ON \
             -DCURL_USE_LIBPSL=OFF
 
@@ -441,7 +449,9 @@ jobs:
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
-        run: cmake --build bld --parallel 5
+        run: |
+          cmake --build bld --parallel 5
+          cmake --build bld --parallel 5 --target curl-examples
 
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
@@ -553,7 +563,6 @@ jobs:
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \
-            -DBUILD_EXAMPLES=ON \
             -DENABLE_WEBSOCKETS=ON \
             -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
             -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE= \
@@ -576,7 +585,7 @@ jobs:
       - name: 'curl version'
         timeout-minutes: 1
         run: |
-          find . -name '*.exe' -o -name '*.dll' | grep -v '/examples/'
+          find . -name '*.exe' -o -name '*.dll'
           if [ '${{ matrix.plat }}' != 'uwp' ]; then
             PATH="$PWD/bld/lib:$PATH"
             bld/src/curl.exe --disable --version
@@ -611,3 +620,7 @@ jobs:
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
+
+      - name: 'cmake build examples'
+        timeout-minutes: 5
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1784,7 +1784,7 @@ endif()
 
 option(BUILD_EXAMPLES "Build libcurl examples" ON)
 if(BUILD_EXAMPLES)
-  add_subdirectory(docs/examples EXCLUDE_FROM_ALL)
+  add_subdirectory(docs/examples)
 endif()
 
 if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1782,9 +1782,9 @@ if(BUILD_CURL_EXE)
   add_subdirectory(src)
 endif()
 
-option(BUILD_EXAMPLES "Build libcurl examples" OFF)
+option(BUILD_EXAMPLES "Build libcurl examples" ON)
 if(BUILD_EXAMPLES)
-  add_subdirectory(docs/examples)
+  add_subdirectory(docs/examples EXCLUDE_FROM_ALL)
 endif()
 
 if(BUILD_TESTING)

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -149,3 +149,10 @@ if [[ "${TFLAGS}" != 'skipall' ]] && \
     )
   fi
 fi
+
+# build examples
+
+if [[ "${EXAMPLES}" = 'ON' ]] && \
+   [ "${BUILD_SYSTEM}" = 'CMake' ]; then
+  cmake --build _bld --config "${PRJ_CFG}" --parallel 2 --target curl-examples
+fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,7 @@ environment:
   DEBUG: 'ON'
   SHARED: 'OFF'
   TFLAGS: 'skipall'
+  EXAMPLES: 'OFF'
   matrix:
 
     # generated CMake-based Visual Studio builds
@@ -50,7 +51,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
       SHARED: 'ON'
-    - job_name: 'CMake, VS2008, Debug, x86, Schannel, Build-tests'
+    - job_name: 'CMake, VS2008, Debug, x86, Schannel, Build-tests & examples'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 9 2008'
@@ -60,6 +61,7 @@ environment:
       HTTP_ONLY: 'OFF'
       SHARED: 'ON'
       TFLAGS: 'skiprun'
+      EXAMPLES: 'ON'
     - job_name: 'CMake, VS2022, Release, x64, OpenSSL 3.2, WebSockets, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -84,7 +86,7 @@ environment:
       DEBUG: 'OFF'
       CURLDEBUG: 'ON'
       TFLAGS: 'skiprun'
-    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-tests'
+    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-tests & examples'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 10 2010 Win64'
@@ -93,6 +95,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       HTTP_ONLY: 'OFF'
       TFLAGS: 'skiprun'
+      EXAMPLES: 'ON'
     - job_name: 'CMake, VS2022, Debug, x64, Schannel, Static, Unicode, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -30,7 +30,7 @@ include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 foreach(_target IN LISTS check_PROGRAMS)
   set(_target_name "curl-example-${_target}")
-  add_executable(${_target_name} "${_target}.c")
+  add_executable(${_target_name} EXCLUDE_FROM_ALL "${_target}.c")
   add_dependencies(curl-examples ${_target_name})
   target_link_libraries(${_target_name} ${LIB_SELECTED} ${CURL_LIBS})
   target_compile_definitions(${_target_name} PRIVATE "CURL_NO_OLDIES")

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -22,14 +22,16 @@
 #
 ###########################################################################
 
+add_custom_target(curl-examples)
+
 # Get 'check_PROGRAMS' variable
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-set(_all_targets)
 foreach(_target IN LISTS check_PROGRAMS)
   set(_target_name "curl-example-${_target}")
   add_executable(${_target_name} "${_target}.c")
+  add_dependencies(curl-examples ${_target_name})
   target_link_libraries(${_target_name} ${LIB_SELECTED} ${CURL_LIBS})
   target_compile_definitions(${_target_name} PRIVATE "CURL_NO_OLDIES")
   if(LIB_SELECTED STREQUAL LIB_STATIC AND WIN32)
@@ -38,7 +40,4 @@ foreach(_target IN LISTS check_PROGRAMS)
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}" UNITY_BUILD OFF
     PROJECT_LABEL "Example ${_target}")
-  list(APPEND _all_targets ${_target_name})
 endforeach()
-
-add_custom_target("curl-examples" DEPENDS ${_all_targets})

--- a/docs/examples/CMakeLists.txt
+++ b/docs/examples/CMakeLists.txt
@@ -26,6 +26,7 @@
 transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
+set(_all_targets)
 foreach(_target IN LISTS check_PROGRAMS)
   set(_target_name "curl-example-${_target}")
   add_executable(${_target_name} "${_target}.c")
@@ -37,4 +38,7 @@ foreach(_target IN LISTS check_PROGRAMS)
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}" UNITY_BUILD OFF
     PROJECT_LABEL "Example ${_target}")
+  list(APPEND _all_targets ${_target_name})
 endforeach()
+
+add_custom_target("curl-examples" DEPENDS ${_all_targets})

--- a/docs/examples/cookie_interface.c
+++ b/docs/examples/cookie_interface.c
@@ -32,6 +32,7 @@
 #include <time.h>
 
 #include <curl/curl.h>
+#include <curl/mprintf.h>
 
 static void
 print_cookies(CURL *curl)
@@ -90,14 +91,11 @@ main(void)
 
     printf("-----------------------------------------------\n"
            "Setting a cookie \"PREF\" via cookie interface:\n");
-#ifdef _WIN32
-#define snprintf _snprintf
-#endif
     /* Netscape format cookie */
-    snprintf(nline, sizeof(nline), "%s\t%s\t%s\t%s\t%.0f\t%s\t%s",
-             ".example.com", "TRUE", "/", "FALSE",
-             difftime(time(NULL) + 31337, (time_t)0),
-             "PREF", "hello example, i like you!");
+    curl_msnprintf(nline, sizeof(nline), "%s\t%s\t%s\t%s\t%.0f\t%s\t%s",
+                   ".example.com", "TRUE", "/", "FALSE",
+                   difftime(time(NULL) + 31337, (time_t)0),
+                   "PREF", "hello example, i like you!");
     res = curl_easy_setopt(curl, CURLOPT_COOKIELIST, nline);
     if(res != CURLE_OK) {
       fprintf(stderr, "Curl curl_easy_setopt failed: %s\n",
@@ -110,7 +108,7 @@ main(void)
        modified, likely not what you intended. For more information refer to
        the CURLOPT_COOKIELIST documentation.
     */
-    snprintf(nline, sizeof(nline),
+    curl_msnprintf(nline, sizeof(nline),
       "Set-Cookie: OLD_PREF=3d141414bf4209321; "
       "expires=Sun, 17-Jan-2038 19:14:07 GMT; path=/; domain=.example.com");
     res = curl_easy_setopt(curl, CURLOPT_COOKIELIST, nline);

--- a/docs/examples/http2-serverpush.c
+++ b/docs/examples/http2-serverpush.c
@@ -31,6 +31,7 @@
 
 /* curl stuff */
 #include <curl/curl.h>
+#include <curl/mprintf.h>
 
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"
@@ -172,7 +173,7 @@ static int server_push_callback(CURL *parent,
 
   (void)parent; /* we have no use for this */
 
-  snprintf(filename, 128, "push%u", count++);
+  curl_msnprintf(filename, 128, "push%u", count++);
 
   /* here's a new stream, save it in a new file for each new push */
   out = fopen(filename, "wb");

--- a/docs/examples/sendrecv.c
+++ b/docs/examples/sendrecv.c
@@ -51,6 +51,9 @@ static int wait_on_socket(curl_socket_t sockfd, int for_recv, long timeout_ms)
 #if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-conversion"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable:4127)  /* conditional expression is constant */
 #endif
   FD_SET(sockfd, &errfd); /* always check for error */
 
@@ -62,6 +65,8 @@ static int wait_on_socket(curl_socket_t sockfd, int for_recv, long timeout_ms)
   }
 #if defined(__GNUC__)
 #pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
 #endif
 
   /* select() returns the number of signalled sockets or -1 */

--- a/docs/examples/simplessl.c
+++ b/docs/examples/simplessl.c
@@ -83,6 +83,10 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "HTTPS://your.favourite.ssl.site");
     curl_easy_setopt(curl, CURLOPT_HEADERDATA, headerfile);
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4127)  /* conditional expression is constant */
+#endif
     do { /* dummy loop, just to break out from */
       if(pEngine) {
         /* use crypto engine */
@@ -133,6 +137,9 @@ int main(void)
 
       /* we are done... */
     } while(0);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
     /* always cleanup */
     curl_easy_cleanup(curl);
   }


### PR DESCRIPTION
- Move `docs/examples` builds under a separate target.

- Make `BUILD_EXAMPLES` default to `ON`. It means to generate the rules
  for `docs/examples` by default, but not build them. To build them,
  an explicit `make curl-examples` (or ninja, etc) command is necessary.
  This syncs behaviour with autotools, and also how both cmake and
  autotools are building tests.

- GHA: update cmake jobs to use the new way of building examples.

- GHA: move examples build step at the end of the job, after building
  and running tests. This allows to have build and test run results
  faster, and leave the seldom-changing examples build to the end.
  Building examples is the slowest build step with no practical way to
  make them fast.

- appveyor: enable building examples in two old-MSVC jobs.

- examples: fix examples to build cleanly with old MSVC versions.

- GHA/non-native: move example build log under a GHA foldable section.

- GHA/windows: move building examples into separate step for Linux cross
  jobs.

Follow-up to dfdd978f7c60224dffe2aac25b436dc0a5cd0186 #13491
