### PR TITLE
build: limit `arc4random` detection to no-SSL configs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1487,7 +1487,6 @@ check_symbol_exists("stricmp"         "${CURL_INCLUDES};string.h" HAVE_STRICMP)
 check_symbol_exists("strcmpi"         "${CURL_INCLUDES};string.h" HAVE_STRCMPI)
 check_symbol_exists("memrchr"         "${CURL_INCLUDES};string.h" HAVE_MEMRCHR)
 check_symbol_exists("alarm"           "${CURL_INCLUDES}" HAVE_ALARM)
-check_symbol_exists("arc4random"      "${CURL_INCLUDES};stdlib.h" HAVE_ARC4RANDOM)
 check_symbol_exists("fcntl"           "${CURL_INCLUDES}" HAVE_FCNTL)
 check_symbol_exists("getppid"         "${CURL_INCLUDES}" HAVE_GETPPID)
 check_symbol_exists("utimes"          "${CURL_INCLUDES}" HAVE_UTIMES)
@@ -1523,6 +1522,10 @@ check_symbol_exists("getrlimit"       "${CURL_INCLUDES}" HAVE_GETRLIMIT)
 check_symbol_exists("setlocale"       "${CURL_INCLUDES}" HAVE_SETLOCALE)
 check_symbol_exists("setmode"         "${CURL_INCLUDES}" HAVE_SETMODE)
 check_symbol_exists("setrlimit"       "${CURL_INCLUDES}" HAVE_SETRLIMIT)
+
+if(NOT _ssl_enabled)
+  check_symbol_exists("arc4random" "${CURL_INCLUDES};stdlib.h" HAVE_ARC4RANDOM)
+endif()
 
 if(NOT MSVC OR (MSVC_VERSION GREATER_EQUAL 1900))
   # Earlier MSVC compilers had faulty snprintf implementations

--- a/configure.ac
+++ b/configure.ac
@@ -3969,7 +3969,6 @@ AC_CHECK_DECLS([getpwuid_r], [], [AC_DEFINE(HAVE_DECL_GETPWUID_R_MISSING, 1, "Se
 
 AC_CHECK_FUNCS([\
   _fseeki64 \
-  arc4random \
   eventfd \
   fnmatch \
   geteuid \
@@ -3991,6 +3990,10 @@ AC_CHECK_FUNCS([\
   utime \
   utimes \
 ])
+
+if test -z "$ssl_backends"; then
+  AC_CHECK_FUNCS([arc4random])
+fi
 
 if test "$curl_cv_native_windows" != 'yes'; then
   AC_CHECK_FUNCS([fseeko])


### PR DESCRIPTION
`arc4random()` is no longer used if any TLS backend is active.
Limit feature detection to builds with no TLS backend.
