### PR TITLE
lib, src, tests: added space around ternary expressions

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -311,7 +311,7 @@ CURL_STDCALL getaddrinfo_thread(void *arg)
   rc = Curl_getaddrinfo_ex(tsd->hostname, service, &tsd->hints, &tsd->res);
 
   if(rc) {
-    tsd->sock_error = SOCKERRNO?SOCKERRNO:rc;
+    tsd->sock_error = SOCKERRNO ? SOCKERRNO : rc;
     if(tsd->sock_error == 0)
       tsd->sock_error = RESOLVER_ENOMEM;
   }

--- a/lib/c-hyper.c
+++ b/lib/c-hyper.c
@@ -1035,7 +1035,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
   }
 
   p_accept = Curl_checkheaders(data,
-                               STRCONST("Accept"))?NULL:"Accept: */*\r\n";
+                               STRCONST("Accept")) ? NULL : "Accept: */*\r\n";
   if(p_accept) {
     result = Curl_hyper_header(data, headers, p_accept);
     if(result)

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -231,7 +231,7 @@ static CURLcode cf_haproxy_create(struct Curl_cfilter **pcf,
 
 out:
   cf_haproxy_ctx_free(ctx);
-  *pcf = result? NULL : cf;
+  *pcf = result ? NULL : cf;
   return result;
 }
 

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -553,7 +553,7 @@ static CURLcode cf_hc_create(struct Curl_cfilter **pcf,
   cf_hc_reset(cf, data);
 
 out:
-  *pcf = result? NULL : cf;
+  *pcf = result ? NULL : cf;
   free(ctx);
   return result;
 }

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1417,7 +1417,7 @@ static CURLcode cf_setup_create(struct Curl_cfilter **pcf,
   ctx = NULL;
 
 out:
-  *pcf = result? NULL : cf;
+  *pcf = result ? NULL : cf;
   free(ctx);
   return result;
 }

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -904,7 +904,7 @@ Curl_cookie_add(struct Curl_easy *data,
          * domain can access the variable. Set TRUE when the cookie says
          * .domain.com and to false when the domain is complete www.domain.com
          */
-        co->tailmatch = strcasecompare(ptr, "TRUE")?TRUE:FALSE;
+        co->tailmatch = strcasecompare(ptr, "TRUE") ? TRUE : FALSE;
         break;
       case 2:
         /* The file format allows the path field to remain not filled in */
@@ -1400,7 +1400,7 @@ struct Cookie *Curl_cookie_getlist(struct Curl_easy *data,
 
   while(co) {
     /* if the cookie requires we are secure we must only continue if we are! */
-    if(co->secure?secure:TRUE) {
+    if(co->secure ? secure : TRUE) {
 
       /* now check if the domain is correct */
       if(!co->domain ||

--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -404,7 +404,7 @@ static CURLcode cw_out_write(struct Curl_easy *data,
   CURLcode result;
   bool flush_all;
 
-  flush_all = (type & CLIENTWRITE_EOS)? TRUE:FALSE;
+  flush_all = (type & CLIENTWRITE_EOS) ? TRUE : FALSE;
   if((type & CLIENTWRITE_BODY) ||
      ((type & CLIENTWRITE_HEADER) && data->set.include_header)) {
     result = cw_out_do_write(ctx, data, CW_OUT_BODY, flush_all, buf, blen);

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -128,7 +128,7 @@ CURLcode Curl_urldecode(const char *string, size_t length,
   DEBUGASSERT(string);
   DEBUGASSERT(ctrl >= REJECT_NADA); /* crash on TRUE/FALSE */
 
-  alloc = (length?length:strlen(string));
+  alloc = (length ? length : strlen(string));
   ns = malloc(alloc + 1);
 
   if(!ns)

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2218,7 +2218,7 @@ static CURLcode client_write_header(struct Curl_easy *data,
   int save = data->set.include_header;
   data->set.include_header = TRUE;
   result = Curl_client_write(data, CLIENTWRITE_HEADER, buf, blen);
-  data->set.include_header = save? TRUE:FALSE;
+  data->set.include_header = save ? TRUE : FALSE;
   return result;
 }
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -630,7 +630,7 @@ bool Curl_ipv6works(struct Curl_easy *data)
       ipv6_works = 1;
       sclose(s);
     }
-    return (ipv6_works>0)?TRUE:FALSE;
+    return (ipv6_works>0) ? TRUE : FALSE;
   }
 }
 #endif /* USE_IPV6 */

--- a/lib/http.c
+++ b/lib/http.c
@@ -2582,7 +2582,7 @@ CURLcode Curl_http(struct Curl_easy *data, bool *done)
     goto fail;
 
   p_accept = Curl_checkheaders(data,
-                               STRCONST("Accept"))?NULL:"Accept: */*\r\n";
+                               STRCONST("Accept")) ? NULL : "Accept: */*\r\n";
 
   result = Curl_http_range(data, httpreq);
   if(result)
@@ -3042,8 +3042,8 @@ CURLcode Curl_http_header(struct Curl_easy *data,
         char *persistentauth = Curl_copy_header_value(hd);
         if(!persistentauth)
           return CURLE_OUT_OF_MEMORY;
-        negdata->noauthpersist = checkprefix("false", persistentauth)?
-          TRUE:FALSE;
+        negdata->noauthpersist = checkprefix("false", persistentauth) ?
+          TRUE : FALSE;
         negdata->havenoauthpersist = TRUE;
         infof(data, "Negotiate: noauthpersist -> %d, header part: %s",
               negdata->noauthpersist, persistentauth);
@@ -4093,7 +4093,7 @@ CURLcode Curl_http_req_make(struct httpreq **preq,
 out:
   if(result && req)
     Curl_http_req_free(req);
-  *preq = result? NULL : req;
+  *preq = result ? NULL : req;
   return result;
 }
 
@@ -4251,7 +4251,7 @@ CURLcode Curl_http_req_make2(struct httpreq **preq,
 out:
   if(result && req)
     Curl_http_req_free(req);
-  *preq = result? NULL : req;
+  *preq = result ? NULL : req;
   return result;
 }
 
@@ -4382,7 +4382,7 @@ CURLcode Curl_http_resp_make(struct http_resp **presp,
 out:
   if(result && resp)
     Curl_http_resp_free(resp);
-  *presp = result? NULL : resp;
+  *presp = result ? NULL : resp;
   return result;
 }
 
@@ -4543,7 +4543,7 @@ static void http_exp100_send_anyway(struct Curl_easy *data)
 bool Curl_http_exp100_is_selected(struct Curl_easy *data)
 {
   struct Curl_creader *r = Curl_creader_get_by_type(data, &cr_exp100);
-  return r? TRUE : FALSE;
+  return r ? TRUE : FALSE;
 }
 
 #endif /* CURL_DISABLE_HTTP */

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2751,7 +2751,7 @@ static CURLcode http2_cfilter_add(struct Curl_cfilter **pcf,
 out:
   if(result)
     cf_h2_ctx_free(ctx);
-  *pcf = result? NULL : cf;
+  *pcf = result ? NULL : cf;
   return result;
 }
 

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -623,7 +623,7 @@ static void do_sec_send(struct Curl_easy *data, struct connectdata *conn,
   size_t cmd_size = 0;
   CURLcode error;
   enum protection_level prot_level = conn->data_prot;
-  bool iscmd = (prot_level == PROT_CMD)?TRUE:FALSE;
+  bool iscmd = (prot_level == PROT_CMD) ? TRUE : FALSE;
 
   DEBUGASSERT(prot_level > PROT_NONE && prot_level < PROT_LAST);
 
@@ -655,7 +655,7 @@ static void do_sec_send(struct Curl_easy *data, struct connectdata *conn,
 
       socket_write(data, fd, cmd_buffer, cmd_size);
       socket_write(data, fd, "\r\n", 2);
-      infof(data, "Send: %s%s", prot_level == PROT_PRIVATE?enc:mic,
+      infof(data, "Send: %s%s", prot_level == PROT_PRIVATE ? enc : mic,
             cmd_buffer);
       free(cmd_buffer);
     }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2374,7 +2374,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
          */
         CURLcode ret = Curl_retry_request(data, &newurl);
         if(!ret)
-          retry = (newurl)?TRUE:FALSE;
+          retry = (newurl) ? TRUE : FALSE;
         else if(!result)
           result = ret;
 

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -113,9 +113,9 @@ CURLcode Curl_pp_statemach(struct Curl_easy *data,
     /* We are receiving and there is data ready in the SSL library */
     rc = 1;
   else
-    rc = Curl_socket_check(pp->sendleft?CURL_SOCKET_BAD:sock, /* reading */
+    rc = Curl_socket_check(pp->sendleft ? CURL_SOCKET_BAD : sock, /* reading */
                            CURL_SOCKET_BAD,
-                           pp->sendleft?sock:CURL_SOCKET_BAD, /* writing */
+                           pp->sendleft ? sock : CURL_SOCKET_BAD, /* writing */
                            interval_ms);
 
   if(block) {

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -398,7 +398,7 @@ CURLcode Curl_cwriter_create(struct Curl_cwriter **pwriter,
   result = cwt->do_init(data, writer);
 
 out:
-  *pwriter = result? NULL : writer;
+  *pwriter = result ? NULL : writer;
   if(result)
     free(writer);
   return result;
@@ -930,7 +930,7 @@ CURLcode Curl_creader_create(struct Curl_creader **preader,
   result = crt->do_init(data, reader);
 
 out:
-  *preader = result? NULL : reader;
+  *preader = result ? NULL : reader;
   if(result)
     free(reader);
   return result;

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2476,7 +2476,7 @@ static bool cf_ngtcp2_conn_is_alive(struct Curl_cfilter *cf,
     *input_pending = FALSE;
     result = cf_progress_ingress(cf, data, NULL);
     CURL_TRC_CF(data, cf, "is_alive, progress ingress -> %d", result);
-    alive = result? FALSE : TRUE;
+    alive = result ? FALSE : TRUE;
   }
 
 out:

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -2207,7 +2207,7 @@ static bool cf_osslq_conn_is_alive(struct Curl_cfilter *cf,
     *input_pending = FALSE;
     result = cf_progress_ingress(cf, data);
     CURL_TRC_CF(data, cf, "is_alive, progress ingress -> %d", result);
-    alive = result? FALSE : TRUE;
+    alive = result ? FALSE : TRUE;
   }
 
 out:

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2609,7 +2609,7 @@ static ssize_t sftp_recv(struct Curl_easy *data, int sockindex,
                               mem, (uint32_t)len,
                               (uint32_t)conn->proto.sshc.sftp_file_index);
 
-      myssh_block2waitfor(conn, (nread == SSH_AGAIN)?TRUE:FALSE);
+      myssh_block2waitfor(conn, (nread == SSH_AGAIN) ? TRUE : FALSE);
 
       if(nread == SSH_AGAIN) {
         *err = CURLE_AGAIN;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2269,7 +2269,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
            (sftperr != LIBSSH2_FX_PERMISSION_DENIED)) {
           result = sftp_libssh2_error_to_CURLE(sftperr);
           state(data, SSH_SFTP_CLOSE);
-          sshc->actualcode = result?result:CURLE_SSH;
+          sshc->actualcode = result ? result : CURLE_SSH;
           break;
         }
         rc = 0; /* clear rc and continue */
@@ -2304,7 +2304,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
               sftp_libssh2_strerror(sftperr));
         state(data, SSH_SFTP_CLOSE);
         result = sftp_libssh2_error_to_CURLE(sftperr);
-        sshc->actualcode = result?result:CURLE_SSH;
+        sshc->actualcode = result ? result : CURLE_SSH;
         break;
       }
       sshp->readdir_filename = malloc(PATH_MAX + 1);
@@ -2384,7 +2384,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
       else if(rc < 0) {
         sftperr = libssh2_sftp_last_error(sshc->sftp_session);
         result = sftp_libssh2_error_to_CURLE(sftperr);
-        sshc->actualcode = result?result:CURLE_SSH;
+        sshc->actualcode = result ? result : CURLE_SSH;
         failf(data, "Could not open remote file for reading: %s :: %d",
               sftp_libssh2_strerror(sftperr),
               libssh2_session_last_errno(sshc->ssh_session));
@@ -2474,7 +2474,7 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
               sftp_libssh2_strerror(sftperr));
         state(data, SSH_SFTP_CLOSE);
         result = sftp_libssh2_error_to_CURLE(sftperr);
-        sshc->actualcode = result?result:CURLE_SSH;
+        sshc->actualcode = result ? result : CURLE_SSH;
         break;
       }
       state(data, SSH_SFTP_DOWNLOAD_STAT);
@@ -3545,7 +3545,7 @@ static ssize_t scp_send(struct Curl_easy *data, int sockindex,
   /* libssh2_channel_write() returns int! */
   nwrite = (ssize_t) libssh2_channel_write(sshc->ssh_channel, mem, len);
 
-  ssh_block2waitfor(data, (nwrite == LIBSSH2_ERROR_EAGAIN)?TRUE:FALSE);
+  ssh_block2waitfor(data, (nwrite == LIBSSH2_ERROR_EAGAIN) ? TRUE : FALSE);
 
   if(nwrite == LIBSSH2_ERROR_EAGAIN) {
     *err = CURLE_AGAIN;
@@ -3570,7 +3570,7 @@ static ssize_t scp_recv(struct Curl_easy *data, int sockindex,
   /* libssh2_channel_read() returns int */
   nread = (ssize_t) libssh2_channel_read(sshc->ssh_channel, mem, len);
 
-  ssh_block2waitfor(data, (nread == LIBSSH2_ERROR_EAGAIN)?TRUE:FALSE);
+  ssh_block2waitfor(data, (nread == LIBSSH2_ERROR_EAGAIN) ? TRUE : FALSE);
   if(nread == LIBSSH2_ERROR_EAGAIN) {
     *err = CURLE_AGAIN;
     nread = -1;
@@ -3683,7 +3683,7 @@ static ssize_t sftp_send(struct Curl_easy *data, int sockindex,
 
   nwrite = libssh2_sftp_write(sshc->sftp_handle, mem, len);
 
-  ssh_block2waitfor(data, (nwrite == LIBSSH2_ERROR_EAGAIN)?TRUE:FALSE);
+  ssh_block2waitfor(data, (nwrite == LIBSSH2_ERROR_EAGAIN) ? TRUE : FALSE);
 
   if(nwrite == LIBSSH2_ERROR_EAGAIN) {
     *err = CURLE_AGAIN;
@@ -3711,7 +3711,7 @@ static ssize_t sftp_recv(struct Curl_easy *data, int sockindex,
 
   nread = libssh2_sftp_read(sshc->sftp_handle, mem, len);
 
-  ssh_block2waitfor(data, (nread == LIBSSH2_ERROR_EAGAIN)?TRUE:FALSE);
+  ssh_block2waitfor(data, (nread == LIBSSH2_ERROR_EAGAIN) ? TRUE : FALSE);
 
   if(nread == LIBSSH2_ERROR_EAGAIN) {
     *err = CURLE_AGAIN;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4356,9 +4356,9 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
         infof(data, "ECH: unexpected status %d",rv);
       }
       infof(data, "ECH: result: status is %s, inner is %s, outer is %s",
-             (status?status:"NULL"),
-             (inner?inner:"NULL"),
-             (outer?outer:"NULL"));
+             (status ? status : "NULL"),
+             (inner ? inner : "NULL"),
+             (outer ? outer : "NULL"));
       OPENSSL_free(inner);
       OPENSSL_free(outer);
       if(rv == SSL_ECH_STATUS_GREASE_ECH) {

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -866,8 +866,8 @@ cr_connect_common(struct Curl_cfilter *cf,
     wants_write = rustls_connection_wants_write(rconn) ||
                   backend->plain_out_buffered;
     DEBUGASSERT(wants_read || wants_write);
-    writefd = wants_write?sockfd:CURL_SOCKET_BAD;
-    readfd = wants_read?sockfd:CURL_SOCKET_BAD;
+    writefd = wants_write ? sockfd : CURL_SOCKET_BAD;
+    readfd = wants_read ? sockfd : CURL_SOCKET_BAD;
 
     /* check allowed time left */
     timeout_ms = Curl_timeleft(data, NULL, TRUE);

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1254,7 +1254,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
   else {
 #if CURL_SUPPORT_MAC_10_8
     err = SSLSetEnableCertVerify(backend->ssl_ctx,
-                                 conn_config->verifypeer?true:false);
+                                 conn_config->verifypeer ? true : false);
     if(err != noErr) {
       failf(data, "SSL: SSLSetEnableCertVerify() failed: OSStatus %d", err);
       return CURLE_SSL_CONNECT_ERROR;
@@ -1263,7 +1263,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
   }
 #else
   err = SSLSetEnableCertVerify(backend->ssl_ctx,
-                               conn_config->verifypeer?true:false);
+                               conn_config->verifypeer ? true : false);
   if(err != noErr) {
     failf(data, "SSL: SSLSetEnableCertVerify() failed: OSStatus %d", err);
     return CURLE_SSL_CONNECT_ERROR;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1950,7 +1950,7 @@ static CURLcode cf_ssl_create(struct Curl_cfilter **pcf,
 out:
   if(result)
     cf_ctx_free(ctx);
-  *pcf = result? NULL : cf;
+  *pcf = result ? NULL : cf;
   return result;
 }
 
@@ -2008,7 +2008,7 @@ static CURLcode cf_ssl_proxy_create(struct Curl_cfilter **pcf,
 out:
   if(result)
     cf_ctx_free(ctx);
-  *pcf = result? NULL : cf;
+  *pcf = result ? NULL : cf;
   return result;
 }
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1216,7 +1216,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       config->disallow_username_in_url = toggle;
       break;
     case C_EPSV: /* --epsv */
-      config->disable_epsv = (!toggle)?TRUE:FALSE;
+      config->disable_epsv = (!toggle) ? TRUE : FALSE;
       break;
     case C_DNS_SERVERS: /* --dns-servers */
       if(!curlinfo->ares_num) /* c-ares is needed for this */
@@ -1246,7 +1246,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       break;
     case C_ALPN: /* --alpn */
-      config->noalpn = (!toggle)?TRUE:FALSE;
+      config->noalpn = (!toggle) ? TRUE : FALSE;
       break;
     case C_LIMIT_RATE: /* --limit-rate */
       err = GetSizeParameter(global, nextarg, "rate", &value);
@@ -1367,7 +1367,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       config->disable_eprt = toggle;
       break;
     case C_EPRT: /* --eprt */
-      config->disable_eprt = (!toggle)?TRUE:FALSE;
+      config->disable_eprt = (!toggle) ? TRUE : FALSE;
       break;
     case C_XATTR: /* --xattr */
       config->xattr = toggle;
@@ -1548,7 +1548,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       config->ftp_ssl_reqd = toggle;
       break;
     case C_SESSIONID: /* --sessionid */
-      config->disable_sessionid = (!toggle)?TRUE:FALSE;
+      config->disable_sessionid = (!toggle) ? TRUE : FALSE;
       break;
     case C_FTP_SSL_CONTROL: /* --ftp-ssl-control */
       if(toggle && !feature_ssl)
@@ -1578,7 +1578,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       config->raw = toggle;
       break;
     case C_KEEPALIVE: /* --keepalive */
-      config->nokeepalive = (!toggle)?TRUE:FALSE;
+      config->nokeepalive = (!toggle) ? TRUE : FALSE;
       break;
     case C_KEEPALIVE_TIME: /* --keepalive-time */
       err = str2unum(&config->alivetime, nextarg);
@@ -2163,7 +2163,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
                    nextarg,
                    &config->mimeroot,
                    &config->mimecurrent,
-                   (cmd == C_FORM_STRING)?TRUE:FALSE)) /* literal string */
+                   (cmd == C_FORM_STRING) ? TRUE : FALSE)) /* literal string */
         err = PARAM_BAD_USE;
       else if(SetHTTPrequest(config, TOOL_HTTPREQ_MIMEPOST, &config->httpreq))
         err = PARAM_BAD_USE;
@@ -2198,7 +2198,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         char *string;
         size_t len;
         bool use_stdin = !strcmp(&nextarg[1], "-");
-        FILE *file = use_stdin?stdin:fopen(&nextarg[1], FOPEN_READTEXT);
+        FILE *file = use_stdin ? stdin : fopen(&nextarg[1], FOPEN_READTEXT);
         if(!file) {
           errorf(global, "Failed to open %s", &nextarg[1]);
           err = PARAM_READ_ERROR;

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -122,7 +122,7 @@ CURLcode add_file_name_to_url(CURL *curl, char **inurlp, const char *filename)
       /* We only want the part of the local path that is on the right
          side of the rightmost slash and backslash. */
       const char *filep = strrchr(filename, '/');
-      char *file2 = strrchr(filep?filep:filename, '\\');
+      char *file2 = strrchr(filep ? filep : filename, '\\');
       char *encfile;
 
       if(file2)

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -156,7 +156,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       option = line;
 
       /* the option starts with a dash? */
-      dashed_option = option[0]=='-'?TRUE:FALSE;
+      dashed_option = (option[0] == '-') ? TRUE : FALSE;
 
       while(*line && !ISSPACE(*line) && !ISSEP(*line, dashed_option))
         line++;

--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -252,7 +252,7 @@ static int curltest_echo_handler(request_rec *r)
   apr_table_setn(r->subprocess_env, "no-gzip", "1");
 
   ct = apr_table_get(r->headers_in, "content-type");
-  ap_set_content_type(r, ct? ct : "application/octet-stream");
+  ap_set_content_type(r, ct ? ct : "application/octet-stream");
 
   bb = apr_brigade_create(r->pool, c->bucket_alloc);
   /* copy any request body into the response */
@@ -593,7 +593,7 @@ static int curltest_put_handler(request_rec *r)
   apr_table_setn(r->subprocess_env, "no-gzip", "1");
 
   ct = apr_table_get(r->headers_in, "content-type");
-  ap_set_content_type(r, ct? ct : "text/plain");
+  ap_set_content_type(r, ct ? ct : "text/plain");
 
   if(read_delay) {
     apr_sleep(read_delay);
@@ -675,7 +675,7 @@ static int curltest_1_1_required(request_rec *r)
   apr_table_setn(r->subprocess_env, "no-gzip", "1");
 
   ct = apr_table_get(r->headers_in, "content-type");
-  ap_set_content_type(r, ct? ct : "text/plain");
+  ap_set_content_type(r, ct ? ct : "text/plain");
 
   bb = apr_brigade_create(r->pool, c->bucket_alloc);
   /* flush response */

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1270,7 +1270,7 @@ retry:
     } while(ptr && *ptr);
   }
   free(cmd);
-  req->open = use_gopher?FALSE:persistent;
+  req->open = use_gopher ? FALSE : persistent;
 
   prevtestno = req->testno;
   prevpartno = req->partno;

--- a/tests/unit/unit2601.c
+++ b/tests/unit/unit2601.c
@@ -75,7 +75,7 @@ static void dump_bufq(struct bufq *q, const char *msg)
   }
   fprintf(stderr, "  ]\n");
   terr = tail_err(q);
-  fprintf(stderr, "- tail: %s\n", terr? terr : "ok");
+  fprintf(stderr, "- tail: %s\n", terr ? terr : "ok");
   n = 0;
   chunk = q->spare;
   while(chunk) {


### PR DESCRIPTION
Added space around ternary expressions to be in accordance with code style