### PR TITLE
GHA/non-native: replace make with ninja in cmake jobs

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -55,8 +55,8 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/
-            sudo pkgin -y install cmake pkg-config perl brotli heimdal openldap-client libssh2 libidn2 libpsl nghttp2  # python311 py311-impacket
-            cmake -B bld \
+            sudo pkgin -y install cmake ninja-build pkg-config perl brotli heimdal openldap-client libssh2 libidn2 libpsl nghttp2  # python311 py311-impacket
+            cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
@@ -90,8 +90,8 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake perl brotli openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
-            cmake -B bld \
+            sudo pkg_add cmake ninja perl brotli openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
+            cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
@@ -130,7 +130,8 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y autoconf automake libtool pkgconf brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel py311-openssl py311-impacket py311-cryptography
+            sudo pkg install -y autoconf automake libtool \
+              pkgconf brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel py311-openssl py311-impacket py311-cryptography
             autoreconf -fi
             export CC='${{ matrix.compiler }}'
             mkdir bld && cd bld && ../configure --enable-debug --enable-warnings --enable-werror \
@@ -158,8 +159,9 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://ports.freebsd.org/
-            sudo pkg install -y cmake pkgconf brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel py311-openssl py311-impacket py311-cryptography
-            cmake -B bld \
+            sudo pkg install -y cmake ninja \
+              pkgconf brotli openldap26-client libidn2 libnghttp2 nghttp2 stunnel py311-openssl py311-impacket py311-cryptography
+            cmake -B bld -G Ninja \
               '-DCMAKE_C_COMPILER=${{ matrix.compiler }}' \
               -DCMAKE_UNITY_BUILD=ON \
               -DCURL_WERROR=ON \
@@ -175,7 +177,8 @@ jobs:
               cmake --build bld --config Debug --parallel 3 --target testdeps
               # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
               # therefore the SFTP and SCP tests are disabled right away from the beginning.
-              make test-ci V=1 TFLAGS='-j8 !SFTP !SCP ~FTP'
+              export TFLAGS='-j8 !SFTP !SCP ~FTP'
+              cmake --build bld --config Debug --target test-ci
             fi
 
   omnios:


### PR DESCRIPTION
Comparing job times for non-native runners is unreliable, but
a speed-up is expected nonetheless.

Full job times:
- NetBSD amd64: 14m1 → 13m15
- OpenBSD amd64: 6m14 → 5m33
- FreeBSD arm64: 6m10 → 5m32 

Example runs:
before: https://github.com/curl/curl/actions/runs/10866939368
after: https://github.com/curl/curl/actions/runs/10870425491?pr=14917
