### PR TITLE
cmake: drop redundant zlib var, rename function (internals)

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -64,7 +64,7 @@ macro(curl_internal_test _curl_test)
   endif()
 endmacro()
 
-macro(optional_dependency _dependency)
+macro(curl_dependency_option _dependency)
   set(CURL_${_dependency} "AUTO" CACHE STRING "Build curl with ${_dependency} support (AUTO, ON or OFF)")
   set_property(CACHE CURL_${_dependency} PROPERTY STRINGS "AUTO" "ON" "OFF")
 

--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -35,7 +35,7 @@ include(CMakeFindDependencyMacro)
 if(@USE_OPENSSL@)
   find_dependency(OpenSSL @OPENSSL_VERSION_MAJOR@)
 endif()
-if(@USE_ZLIB@)
+if(@HAVE_LIBZ@)
   find_dependency(ZLIB @ZLIB_VERSION_MAJOR@)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,11 +703,9 @@ endif()
 # and before calling openssl_check_symbol_exists().
 
 set(HAVE_LIBZ OFF)
-set(USE_ZLIB OFF)
 optional_dependency(ZLIB)
 if(ZLIB_FOUND)
   set(HAVE_LIBZ ON)
-  set(USE_ZLIB ON)
 
   # Depend on ZLIB via imported targets. This allows our dependents to
   # get our dependencies transitively.
@@ -2144,7 +2142,7 @@ if(NOT CURL_DISABLE_INSTALL)
   #   LIB_SELECTED
   #   TARGETS_EXPORT_NAME
   #   USE_OPENSSL
-  #   USE_ZLIB
+  #   HAVE_LIBZ
   configure_package_config_file("CMake/curl-config.cmake.in"
     "${_project_config}"
     INSTALL_DESTINATION ${CURL_INSTALL_CMAKE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -703,7 +703,7 @@ endif()
 # and before calling openssl_check_symbol_exists().
 
 set(HAVE_LIBZ OFF)
-optional_dependency(ZLIB)
+curl_dependency_option(ZLIB)
 if(ZLIB_FOUND)
   set(HAVE_LIBZ ON)
 


### PR DESCRIPTION
- drop redundant internal variable `USE_ZLIB`, rely on `HAVE_LIBZ`.

- rename `optional_dependency()` → `curl_dependency_option()`
  Make `grep 'option('` hit this option. Namespaced.
  It has a single use with `ZLIB`.
