### PR TITLE
singleuse: drop `Curl_memrchr()` for no-HTTP builds

### DIFF
--- a/lib/curl_memrchr.c
+++ b/lib/curl_memrchr.c
@@ -33,6 +33,9 @@
 #include "memdebug.h"
 
 #ifndef HAVE_MEMRCHR
+#if (!defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)) || \
+  defined(USE_OPENSSL) || \
+  defined(USE_SCHANNEL)
 
 /*
  * Curl_memrchr()
@@ -61,4 +64,5 @@ Curl_memrchr(const void *s, int c, size_t n)
   return NULL;
 }
 
+#endif
 #endif /* HAVE_MEMRCHR */

--- a/lib/curl_memrchr.h
+++ b/lib/curl_memrchr.h
@@ -34,11 +34,15 @@
 #endif
 
 #else /* HAVE_MEMRCHR */
+#if (!defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)) || \
+  defined(USE_OPENSSL) || \
+  defined(USE_SCHANNEL)
 
 void *Curl_memrchr(const void *s, int c, size_t n);
 
 #define memrchr(x,y,z) Curl_memrchr((x),(y),(z))
 
+#endif
 #endif /* HAVE_MEMRCHR */
 
 #endif /* HEADER_CURL_MEMRCHR_H */


### PR DESCRIPTION
Make single-use function check CI test pass by dropping the global
`Curl_memrchr()` function from the build when it has no caller.

Fixes:
```
Curl_memrchr in curl_memrchr
```
https://github.com/curl/curl/actions/runs/10816280747/job/30007145114

Seen while migrating affected job from Azure to GHA.
Ref: #14859
