### PR TITLE
GHA/non-native: enable SFTP/SCP tests on FreeBSD

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -145,9 +145,7 @@ jobs:
             make -j3 examples
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               make -j3 -C tests
-              # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
-              # therefore the SFTP and SCP tests are disabled right away from the beginning.
-              make test-ci V=1 TFLAGS='-j8 !SFTP !SCP ~FTP'
+              make test-ci V=1 TFLAGS='-j8 ~FTP'
             fi
 
       - name: 'cmake'
@@ -175,9 +173,7 @@ jobs:
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               cmake --build bld --config Debug --parallel 3 --target testdeps
-              # The OpenSSH server instance for the testsuite cannot be started on FreeBSD,
-              # therefore the SFTP and SCP tests are disabled right away from the beginning.
-              export TFLAGS='-j8 !SFTP !SCP ~FTP'
+              export TFLAGS='-j8 ~FTP'
               cmake --build bld --config Debug --target test-ci
             fi
 


### PR DESCRIPTION
It's working now. Possibly fixed in the runner env?

---

I'm not sure why it works now and did not work before.
This PR uses #14859 (yet to be merged) as a base, which
contains SSH tests related fixes, though it's also possible
the env brought fixes. Planning to merge this after #14859.
→ [TESTED OK without #14859]
