### PR TITLE
test, https server check

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -125,7 +125,7 @@ TEST = srcdir=$(srcdir) $(PERL) $(PERLFLAGS) $(srcdir)/runtests.pl
 TEST_Q = -a -s
 TEST_AM = -a -am
 TEST_F = -a -p -r
-TEST_T = -a -t
+TEST_T = -a -t -j4
 TEST_E = -a -e
 
 # ~<keyword> means that it will run all tests matching the keyword, but will
@@ -133,7 +133,7 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r -rm -j2
+TEST_CI = $(TEST_NF) -r -rm -j16
 endif
 
 CD2NROFF = $(top_srcdir)/scripts/cd2nroff $< >$@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -134,8 +134,7 @@ TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
 # we used to default to 2 runners, is that the hanging problem?
-# TEST_CI = $(TEST_NF) -r -rm -j2
-TEST_CI = $(TEST_NF) -r -rm
+TEST_CI = $(TEST_NF) -r -rm -j2
 endif
 
 CD2NROFF = $(top_srcdir)/scripts/cd2nroff $< >$@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -125,7 +125,7 @@ TEST = srcdir=$(srcdir) $(PERL) $(PERLFLAGS) $(srcdir)/runtests.pl
 TEST_Q = -a -s
 TEST_AM = -a -am
 TEST_F = -a -p -r
-TEST_T = -a -t -j4
+TEST_T = -a -t -j2
 TEST_E = -a -e
 
 # ~<keyword> means that it will run all tests matching the keyword, but will
@@ -133,7 +133,7 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r -rm -j16
+TEST_CI = $(TEST_NF) -r -rm -j8
 endif
 
 CD2NROFF = $(top_srcdir)/scripts/cd2nroff $< >$@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -133,7 +133,9 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r -rm -j2
+# we used to default to 2 runners, is that the hanging problem?
+# TEST_CI = $(TEST_NF) -r -rm -j2
+TEST_CI = $(TEST_NF) -r -rm
 endif
 
 CD2NROFF = $(top_srcdir)/scripts/cd2nroff $< >$@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -133,7 +133,6 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-# we used to default to 2 runners, is that the hanging problem?
 TEST_CI = $(TEST_NF) -r -rm -j2
 endif
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -133,7 +133,7 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r -rm -j8
+TEST_CI = $(TEST_NF) -r -rm -j2
 endif
 
 CD2NROFF = $(top_srcdir)/scripts/cd2nroff $< >$@

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2886,6 +2886,7 @@ createrunners($numrunners);
 #   - if a runner has a response for us, process the response
 
 # run through each candidate test and execute it
+my $runner_wait_cnt = 0;
 while () {
     # check the abort flag
     if($globalabort) {
@@ -3000,14 +3001,22 @@ while () {
         }
     }
     if(!$ridready && scalar(%runnersrunning)) {
-        logmsg "waiting for " . scalar(%runnersrunning) . " test results\n";
-        my $msg = "tests: ";
-        my $sep = "";
+        my $msg = "waiting for " . scalar(%runnersrunning) . " results:";
+        my $sep = " ";
         foreach my $rid (keys %runnersrunning) {
             $msg .= $sep . $runnersrunning{$rid} . "[$rid]";
             $sep = ", "
         }
-        logmsg $msg;
+        logmsg "$msg\n";
+        $runner_wait_cnt++;
+        if($runner_wait_cnt > 10) {
+            $runner_wait_cnt = 0;
+            foreach my $rid (keys %runnersrunning) {
+                my $testnum = $runnersrunning{$rid};
+                logmsg "current state of test $testnum in [$rid]:\n";
+                displaylogs($rid, $testnum);
+            }
+        }
     }
     if($riderror) {
         logmsg "ERROR: runner $riderror is dead! aborting test run\n";

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2965,6 +2965,7 @@ while () {
             $runnersrunning{$ridready} = $testnum;
         } else {
             # Test is complete
+            $runner_wait_cnt = 0;
             runnerready($ridready);
 
             if($error < 0) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1169,7 +1169,7 @@ sub singletest_shouldrun {
 #######################################################################
 # Print the test name and count tests
 sub singletest_count {
-    my ($testnum, $why) = @_;
+    my ($testnum, $why , $runnerid) = @_;
 
     if($why && !$listonly) {
         # there's a problem, count it as "skipped"
@@ -1188,7 +1188,7 @@ sub singletest_count {
     }
 
     # At this point we've committed to run this test
-    logmsg sprintf("test %04d...", $testnum) if(!$automakestyle);
+    logmsg sprintf("[$runnerid] test %04d...", $testnum) if(!$automakestyle);
 
     # name of the test
     my $testname= (getpart("client", "name"))[0];
@@ -1584,7 +1584,7 @@ sub singletest_check {
                     if(!$rid) {
                         logmsg "ERROR: runner $runnerid seems to have died\n";
                     } else {
-                        logmsg $logs;
+                        logmsg "[$runnerid]: $logs";
                     }
                 }
                 # timestamp test result verification end
@@ -1759,7 +1759,7 @@ sub singletest_check {
     # add 'E' for event-based
     $ok .= $run_event_based ? "E" : "-";
 
-    logmsg "$ok " if(!$short);
+    logmsg "[$runnerid] $ok " if(!$short);
 
     # timestamp test result verification end
     $timevrfyend{$testnum} = Time::HiRes::time();
@@ -1900,7 +1900,7 @@ sub singletest {
 
         #######################################################################
         # Print the test name and count tests
-        $error = singletest_count($testnum, $why);
+        $error = singletest_count($testnum, $why, $runnerid);
         if($error) {
             # Submit the test case result with the CI environment
             citest_finishtest($testnum, $error);
@@ -2854,7 +2854,7 @@ foreach my $testnum (@at) {
     my ($why, $errorreturncode) = singletest_shouldrun($testnum);
     if($why || $listonly) {
         # Display test name now--test will be completely skipped later
-        my $error = singletest_count($testnum, $why);
+        my $error = singletest_count($testnum, $why, 0);
         next;
     }
     $ignoretestcodes{$testnum} = $errorreturncode;
@@ -2998,6 +2998,16 @@ while () {
                 $ok++; # successful test counter
             }
         }
+    }
+    if(!$ridready && scalar(%runnersrunning)) {
+        logmsg "waiting for " . scalar(%runnersrunning) . " test results\n";
+        my $msg = "tests: ";
+        my $sep = "";
+        foreach my $rid (keys %runnersrunning) {
+            $msg .= $sep . $runnersrunning{$rid} . "[$rid]";
+            $sep = ", "
+        }
+        logmsg $msg;
     }
     if($riderror) {
         logmsg "ERROR: runner $riderror is dead! aborting test run\n";

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3000,7 +3000,7 @@ while () {
             }
         }
     }
-    if(!$ridready && scalar(%runnersrunning)) {
+    if(!$ridready && $runnerwait && scalar(%runnersrunning)) {
         my $msg = "waiting for " . scalar(%runnersrunning) . " results:";
         my $sep = " ";
         foreach my $rid (keys %runnersrunning) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3001,7 +3001,7 @@ while () {
             }
         }
     }
-    if(!$ridready && $runnerwait && scalar(%runnersrunning)) {
+    if(!$ridready && $runnerwait && !$torture && scalar(%runnersrunning)) {
         $runner_wait_cnt++;
         if($runner_wait_cnt >= 5) {
             my $msg = "waiting for " . scalar(%runnersrunning) . " results:";

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3002,15 +3002,17 @@ while () {
         }
     }
     if(!$ridready && $runnerwait && scalar(%runnersrunning)) {
-        my $msg = "waiting for " . scalar(%runnersrunning) . " results:";
-        my $sep = " ";
-        foreach my $rid (keys %runnersrunning) {
-            $msg .= $sep . $runnersrunning{$rid} . "[$rid]";
-            $sep = ", "
-        }
-        logmsg "$msg\n";
         $runner_wait_cnt++;
-        if($runner_wait_cnt > 10) {
+        if($runner_wait_cnt >= 5) {
+            my $msg = "waiting for " . scalar(%runnersrunning) . " results:";
+            my $sep = " ";
+            foreach my $rid (keys %runnersrunning) {
+                $msg .= $sep . $runnersrunning{$rid} . "[$rid]";
+                $sep = ", "
+            }
+            logmsg "$msg\n";
+        }
+        if($runner_wait_cnt >= 10) {
             $runner_wait_cnt = 0;
             foreach my $rid (keys %runnersrunning) {
                 my $testnum = $runnersrunning{$rid};

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1169,7 +1169,7 @@ sub singletest_shouldrun {
 #######################################################################
 # Print the test name and count tests
 sub singletest_count {
-    my ($testnum, $why , $runnerid) = @_;
+    my ($testnum, $why) = @_;
 
     if($why && !$listonly) {
         # there's a problem, count it as "skipped"
@@ -1188,7 +1188,7 @@ sub singletest_count {
     }
 
     # At this point we've committed to run this test
-    logmsg sprintf("[$runnerid] test %04d...", $testnum) if(!$automakestyle);
+    logmsg sprintf("test %04d...", $testnum) if(!$automakestyle);
 
     # name of the test
     my $testname= (getpart("client", "name"))[0];
@@ -1584,7 +1584,7 @@ sub singletest_check {
                     if(!$rid) {
                         logmsg "ERROR: runner $runnerid seems to have died\n";
                     } else {
-                        logmsg "[$runnerid]: $logs";
+                        logmsg $logs;
                     }
                 }
                 # timestamp test result verification end
@@ -1759,7 +1759,7 @@ sub singletest_check {
     # add 'E' for event-based
     $ok .= $run_event_based ? "E" : "-";
 
-    logmsg "[$runnerid] $ok " if(!$short);
+    logmsg "$ok " if(!$short);
 
     # timestamp test result verification end
     $timevrfyend{$testnum} = Time::HiRes::time();
@@ -1900,7 +1900,7 @@ sub singletest {
 
         #######################################################################
         # Print the test name and count tests
-        $error = singletest_count($testnum, $why, $runnerid);
+        $error = singletest_count($testnum, $why);
         if($error) {
             # Submit the test case result with the CI environment
             citest_finishtest($testnum, $error);
@@ -2854,7 +2854,7 @@ foreach my $testnum (@at) {
     my ($why, $errorreturncode) = singletest_shouldrun($testnum);
     if($why || $listonly) {
         # Display test name now--test will be completely skipped later
-        my $error = singletest_count($testnum, $why, 0);
+        my $error = singletest_count($testnum, $why);
         next;
     }
     $ignoretestcodes{$testnum} = $errorreturncode;

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2587,15 +2587,24 @@ sub startservers {
                 if(stopserver('https')) {
                     return ("failed stopping HTTPS server with different cert", 3);
                 }
+                # also stop http server, we do not know which state it is in
+                if($run{'http'} && stopserver('http')) {
+                    return ("failed stopping HTTP server", 3);
+                }
             }
             if($run{'https'} &&
                !responsive_http_server("https", $verbose, 0,
                                        protoport('https'))) {
-               if(stopserver('https')) {
-                   return ("failed stopping unresponsive HTTPS server", 3);
-               }
+                if(stopserver('https')) {
+                    return ("failed stopping unresponsive HTTPS server", 3);
+                }
+                # also stop http server, we do not know which state it is in
+                if($run{'http'} && stopserver('http')) {
+                    return ("failed stopping unresponsive HTTP server", 3);
+                }
             }
-            if($run{'http'} &&
+            # check a running http server if we not already checked https
+            if($run{'http'} && !$run{'https'} &&
                !responsive_http_server("http", $verbose, 0,
                                        protoport('http'))) {
                 if(stopserver('http')) {


### PR DESCRIPTION
When a https test server is responsive, we do not need to check the stunnel-proxied http server. It already took part in the first check.

When we tear down a https stunnel server, also tear down the http server behind it. We do not know in which state this is when the stunnel does not properly respond.