### PR TITLE
curl_url_set.md: document HOST handling when URL is parsed

### DIFF
--- a/docs/libcurl/curl_url_set.md
+++ b/docs/libcurl/curl_url_set.md
@@ -91,6 +91,8 @@ it does not recognize.
 Unless *CURLU_NO_AUTHORITY* is set, a blank hostname is not allowed in
 the URL.
 
+When a full URL is set (parsed), the hostname component is stored URL decoded.
+
 ## CURLUPART_SCHEME
 
 Scheme cannot be URL decoded on set. libcurl only accepts setting schemes up


### PR DESCRIPTION
When a full URL is set (parsed), the hostname component is stored URL decoded (with default zero flags).

While perhaps surprising and inconsistent, the API has done this for quite some time already and changigtn this now would break existing behaviour.

Fixes #14942
Reported-by: Venkat Krishna R