### PR TITLE
negotiate: skip GSSAPI channel binding if not building with TLS

### DIFF
--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -108,7 +108,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
   neg_ctx->sslContext = conn->sslContext;
 #endif
   /* Check if the connection is using SSL and get the channel binding data */
-#ifdef HAVE_GSSAPI
+#if defined(HAVE_GSSAPI) && defined(USE_SSL)
   if(conn->handler->flags & PROTOPT_SSL) {
     Curl_dyn_init(&neg_ctx->channel_binding_data, SSL_CB_MAX_SIZE);
     result = Curl_ssl_get_channel_binding(
@@ -124,7 +124,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
   result = Curl_auth_decode_spnego_message(data, userp, passwdp, service,
                                            host, header, neg_ctx);
 
-#ifdef HAVE_GSSAPI
+#if defined(HAVE_GSSAPI) && defined(USE_SSL)
   Curl_dyn_free(&neg_ctx->channel_binding_data);
 #endif
 


### PR DESCRIPTION
Proposed-by: Jon Rumsey
Reported-by: lomberd2 on github
Fixes #14938
Fixes #14952