### PR TITLE
sendf: add condition to max-filesize check

### DIFF
--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -300,7 +300,7 @@ static CURLcode cw_download_write(struct Curl_easy *data,
 
   /* Error on too large filesize is handled below, after writing
    * the permitted bytes */
-  if(data->set.max_filesize) {
+  if(data->set.max_filesize && !data->req.ignorebody) {
     size_t wmax = get_max_body_write_len(data, data->set.max_filesize);
     if(nwrite > wmax) {
       nwrite = wmax;


### PR DESCRIPTION
Since the max filesize check should not be performed while the body is ignored.

Follow-up to aef384a7df23c5f52940112593f