### PR TITLE
processhelp.pm: improve `taskkill` calls (Windows)

### DIFF
--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -168,7 +168,7 @@ sub pidterm {
             $pid -= 65536;
             if($^O ne 'MSWin32') {
                 # https://ss64.com/nt/taskkill.html
-                my $cmd = "taskkill -pid $pid >nul 2>&1";
+                my $cmd = "taskkill -t -pid $pid >nul 2>&1";
                 logmsg "Executing: '$cmd'\n";
                 system($cmd);
                 return;

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -169,7 +169,9 @@ sub pidterm {
             if($^O ne 'MSWin32') {
                 my $filter = "PID eq $pid";
                 # https://ss64.com/nt/taskkill.html
-                system("taskkill -fi \"$filter\" >nul 2>&1");
+                my $cmd = "taskkill -fi \"$filter\" >nul 2>&1";
+                logmsg "Executing: '$cmd'\n";
+                system($cmd);
                 return;
             }
         }

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -168,12 +168,8 @@ sub pidterm {
             $pid -= 65536;
             if($^O ne 'MSWin32') {
                 my $filter = "PID eq $pid";
-                # https://ss64.com/nt/tasklist.html
-                my $result = `tasklist -fi \"$filter\" 2>nul`;
-                if(index($result, "$pid") != -1) {
-                    # https://ss64.com/nt/taskkill.html
-                    system("taskkill -fi \"$filter\" >nul 2>&1");
-                }
+                # https://ss64.com/nt/taskkill.html
+                system("taskkill -fi \"$filter\" >nul 2>&1");
                 return;
             }
         }
@@ -196,16 +192,10 @@ sub pidkill {
             $pid -= 65536;
             if($^O ne 'MSWin32') {
                 my $filter = "PID eq $pid";
-                # https://ss64.com/nt/tasklist.html
-                my $cmd = "tasklist -fi \"$filter\" 2>nul";
+                # https://ss64.com/nt/taskkill.html
+                my $cmd = "taskkill -f -t -fi \"$filter\" >nul 2>&1";
                 logmsg "Executing: '$cmd'\n";
-                my $result = `$cmd`;
-                if(index($result, "$pid") != -1) {
-                    # https://ss64.com/nt/taskkill.html
-                    my $cmd = "taskkill -f -t -fi \"$filter\" >nul 2>&1";
-                    logmsg "Executing: '$cmd'\n";
-                    system($cmd);
-                }
+                system($cmd);
                 return;
             }
         }

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -167,9 +167,8 @@ sub pidterm {
         if ($pid > 65536 && os_is_win()) {
             $pid -= 65536;
             if($^O ne 'MSWin32') {
-                my $filter = "PID eq $pid";
                 # https://ss64.com/nt/taskkill.html
-                my $cmd = "taskkill -fi \"$filter\" >nul 2>&1";
+                my $cmd = "taskkill -pid $pid >nul 2>&1";
                 logmsg "Executing: '$cmd'\n";
                 system($cmd);
                 return;
@@ -193,9 +192,8 @@ sub pidkill {
         if ($pid > 65536 && os_is_win()) {
             $pid -= 65536;
             if($^O ne 'MSWin32') {
-                my $filter = "PID eq $pid";
                 # https://ss64.com/nt/taskkill.html
-                my $cmd = "taskkill -f -t -fi \"$filter\" >nul 2>&1";
+                my $cmd = "taskkill -f -t -pid $pid >nul 2>&1";
                 logmsg "Executing: '$cmd'\n";
                 system($cmd);
                 return;


### PR DESCRIPTION
- drop `tasklist` call before `taskkill`.
  `taskkill` offers two ways to kill a `pid`:
  1. `-pid <pid>`
     If `<pid>` is missing it returns 128 and outputs:
     ```
     ERROR: The process "<pid>" not found.
     ```
  2. `-fi "PID eq <pid>"`
     If `<pid>` is missing, it returns 0 and outputs:
     ```
     INFO: No tasks running with the specified criteria.
     ```
  The curl runner script doesn't check the result of the call and both
  stdout and stderr are redirected to NUL.
  Meaning the `tasklist` calls pre-verifying if the PID exists are not
  necessary and we can drop them to put less strain on the runner
  environment.

- log a `taskkill` call missed earlier.
  Follow-up to e53523fef07894991c69d907a7c7794c7ada4ff4 #14859

- streamline `taskkill` calls by using the `-pid` option
  (was `-fi <filter-expression>`).

- make `taskkill` in `pidterm()` use `-t` to kill the process tree.

Ref: #11009

---

w/o whitespace: https://github.com/curl/curl/pull/14959/files?w=1
