### PR TITLE
CURLMOPT_PIPELINING.md: clarify that CURLPIPE_NOTHING is not default

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_PIPELINING.md
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING.md
@@ -38,7 +38,7 @@ same connection when doing parallel transfers to the same hosts.
 
 ## CURLPIPE_NOTHING (0)
 
-Default, which means doing no attempts at multiplexing.
+Make no attempts at multiplexing.
 
 ## CURLPIPE_HTTP1 (1)
 


### PR DESCRIPTION
Fixes #14961
Reported-by: Pavel Kropachev