### PR TITLE
connection reuse on h3 connections

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -64,6 +64,8 @@ static enum alpnid alpn2alpnid(char *name)
     return ALPN_h2;
   if(strcasecompare(name, H3VERSION))
     return ALPN_h3;
+  if(strcasecompare(name, "http/1.1"))
+    return ALPN_h1;
   return ALPN_none; /* unknown, probably rubbish input */
 }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -1031,13 +1031,25 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
     return FALSE;
 
   /* If looking for HTTP and the HTTP version we want is less
-   * than the HTTP version of conn, continue looking */
+   * than the HTTP version of conn, continue looking.
+   * CURL_HTTP_VERSION_2TLS is default which indicates no preference,
+   * so we take any existing connection. */
   if((needle->handler->protocol & PROTO_FAMILY_HTTP) &&
-     (((conn->httpversion >= 20) &&
-       (data->state.httpwant < CURL_HTTP_VERSION_2_0))
-      || ((conn->httpversion >= 30) &&
-          (data->state.httpwant < CURL_HTTP_VERSION_3))))
-    return FALSE;
+     (data->state.httpwant != CURL_HTTP_VERSION_2TLS)) {
+    if((conn->httpversion >= 20) &&
+       (data->state.httpwant < CURL_HTTP_VERSION_2_0)) {
+      DEBUGF(infof(data, "nor reusing conn #%" CURL_FORMAT_CURL_OFF_T
+             " with httpversion=%d, we want a version less than h2",
+             conn->connection_id, conn->httpversion));
+    }
+    if((conn->httpversion >= 30) &&
+       (data->state.httpwant < CURL_HTTP_VERSION_3)) {
+      DEBUGF(infof(data, "nor reusing conn #%" CURL_FORMAT_CURL_OFF_T
+             " with httpversion=%d, we want a version less than h3",
+             conn->connection_id, conn->httpversion));
+      return FALSE;
+    }
+  }
 #ifdef USE_SSH
   else if(get_protocol_family(needle->handler) & PROTO_FAMILY_SSH) {
     if(!ssh_config_matches(needle, conn))
@@ -3016,7 +3028,7 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
        )) {
     /* no connect_to match, try alt-svc! */
     enum alpnid srcalpnid;
-    bool hit;
+    bool hit = FALSE;
     struct altsvc *as;
     const int allowed_versions = ( ALPN_h1
 #ifdef USE_HTTP2
@@ -3026,24 +3038,27 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
                                    | ALPN_h3
 #endif
       ) & data->asi->flags;
+    static int alpn_ids[] = {
+#ifdef USE_HTTP3
+      ALPN_h3,
+#endif
+#ifdef USE_HTTP2
+      ALPN_h2,
+#endif
+      ALPN_h1,
+    };
+    size_t i;
 
     host = conn->host.rawalloc;
-#ifdef USE_HTTP2
-    /* with h2 support, check that first */
-    srcalpnid = ALPN_h2;
-    hit = Curl_altsvc_lookup(data->asi,
-                             srcalpnid, host, conn->remote_port, /* from */
-                             &as /* to */,
-                             allowed_versions);
-    if(!hit)
-#endif
-    {
-      srcalpnid = ALPN_h1;
+    DEBUGF(infof(data, "check Alt-Svc for host %s", host));
+    for(i = 0; !hit && (i < ARRAYSIZE(alpn_ids)); ++i) {
+      srcalpnid = alpn_ids[i];
       hit = Curl_altsvc_lookup(data->asi,
                                srcalpnid, host, conn->remote_port, /* from */
                                &as /* to */,
                                allowed_versions);
     }
+
     if(hit) {
       char *hostd = strdup((char *)as->dst.host);
       if(!hostd)

--- a/lib/url.c
+++ b/lib/url.c
@@ -3039,7 +3039,7 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
                                    | ALPN_h3
 #endif
       ) & data->asi->flags;
-    static int alpn_ids[] = {
+    static enum alpnid alpn_ids[] = {
 #ifdef USE_HTTP3
       ALPN_h3,
 #endif

--- a/lib/url.c
+++ b/lib/url.c
@@ -3027,9 +3027,10 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
 #endif
        )) {
     /* no connect_to match, try alt-svc! */
-    enum alpnid srcalpnid;
+    enum alpnid srcalpnid = ALPN_none;
+    bool use_alt_svc = FALSE;
     bool hit = FALSE;
-    struct altsvc *as;
+    struct altsvc *as = NULL;
     const int allowed_versions = ( ALPN_h1
 #ifdef USE_HTTP2
                                    | ALPN_h2
@@ -3049,15 +3050,53 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
     };
     size_t i;
 
+    switch(data->state.httpwant) {
+    case CURL_HTTP_VERSION_1_0:
+      break;
+    case CURL_HTTP_VERSION_1_1:
+      use_alt_svc = TRUE;
+      srcalpnid = ALPN_h1; /* only regard alt-svc advice for http/1.1 */
+      break;
+    case CURL_HTTP_VERSION_2_0:
+      use_alt_svc = TRUE;
+      srcalpnid = ALPN_h2; /* only regard alt-svc advice for h2 */
+      break;
+    case CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE:
+      break;
+    case CURL_HTTP_VERSION_3:
+      use_alt_svc = TRUE;
+      srcalpnid = ALPN_h3; /* only regard alt-svc advice for h3 */
+      break;
+    case CURL_HTTP_VERSION_3ONLY:
+      break;
+    default: /* no specific HTTP version wanted, look at all of alt-svc */
+      use_alt_svc = TRUE;
+      srcalpnid = ALPN_none;
+      break;
+    }
+    if(!use_alt_svc)
+      return CURLE_OK;
+
     host = conn->host.rawalloc;
     DEBUGF(infof(data, "check Alt-Svc for host %s", host));
-    for(i = 0; !hit && (i < ARRAYSIZE(alpn_ids)); ++i) {
-      srcalpnid = alpn_ids[i];
+    if(srcalpnid == ALPN_none) {
+      /* scan all alt-svc protocol ids in order or relevance */
+      for(i = 0; !hit && (i < ARRAYSIZE(alpn_ids)); ++i) {
+        srcalpnid = alpn_ids[i];
+        hit = Curl_altsvc_lookup(data->asi,
+                                 srcalpnid, host, conn->remote_port, /* from */
+                                 &as /* to */,
+                                 allowed_versions);
+      }
+    }
+    else {
+      /* look for a specific alt-svc protocol id */
       hit = Curl_altsvc_lookup(data->asi,
                                srcalpnid, host, conn->remote_port, /* from */
                                &as /* to */,
                                allowed_versions);
     }
+
 
     if(hit) {
       char *hostd = strdup((char *)as->dst.host);


### PR DESCRIPTION
- When searching for existing connections, interpret the default CURL_HTTP_VERSION_2TLS as "anything goes". This will allow us to reuse HTTP/3 connections better
- add 'http/1.1' as allowed protocol identifier in Alt-Svc files
- add test_02_0[345] for testing protocol selection on provided alt-svc files

refs #14890

Update:

alt-svc lookups: honor `data->state.httpwant`

When a transfer is set for a specific HTTP version, only lookup that protocol in the alt-svc mappings. When no specific version is requested, scan all entries as before.