### PR TITLE
testrunner fairness

### DIFF
--- a/tests/http2-server.pl
+++ b/tests/http2-server.pl
@@ -108,6 +108,7 @@ $certfile = abs_path($certfile);
 $keyfile = abs_path($keyfile);
 
 my $cmdline="$nghttpx --backend=$connect ".
+    "--backend-keep-alive-timeout=500ms ".
     "--frontend=\"*,$listenport;no-tls\" ".
     "--frontend=\"*,$listenport2\" ".
     "--log-level=INFO ".

--- a/tests/http3-server.pl
+++ b/tests/http3-server.pl
@@ -108,6 +108,7 @@ $certfile = abs_path($certfile);
 $keyfile = abs_path($keyfile);
 
 my $cmdline="$nghttpx --http2-proxy --backend=$connect ".
+    "--backend-keep-alive-timeout=500ms ".
     "--frontend=\"*,$listenport\" ".
     "--frontend=\"*,$listenport;quic\" ".
     "--log-level=INFO ".

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1361,6 +1361,7 @@ sub runnerar_ready {
     my $rin = "";
     my %idbyfileno;
     my $maxfileno=0;
+    my @ready_runners = ();
     foreach my $p (keys(%controllerr)) {
         my $fd = fileno($controllerr{$p});
         vec($rin, $fd, 1) = 1;
@@ -1383,10 +1384,11 @@ sub runnerar_ready {
                 return (undef, $idbyfileno{$fd});
             }
             if(vec($rout, $fd, 1)) {
-                return ($idbyfileno{$fd}, undef);
+                push(@ready_runners, $idbyfileno{$fd});
             }
         }
-        die "Internal pipe readiness inconsistency\n";
+        die "Internal pipe readiness inconsistency\n" if(!@ready_runners);
+        return (@ready_runners, undef);
     }
     return (undef, undef);
 }


### PR DESCRIPTION
Collect all ready runners from select() and process in a loop. This assures fairness in processing among all runners.

Formerly, only the first ready runner in the list of all was processed, leading to later runners being delayed in processing and reporting overly long test durations.

Also, reduce the backend idle timeout for the h2/h3 test servers so that process shutdowns take less time.