### PR TITLE
unit1660: fix unreachable code warning in no-SSL builds

### DIFF
--- a/tests/unit/unit1660.c
+++ b/tests/unit/unit1660.c
@@ -41,7 +41,7 @@ unit_stop(void)
 #if defined(CURL_DISABLE_HTTP) || defined(CURL_DISABLE_HSTS)
 UNITTEST_START
 {
-  return CURLE_OK; /* nothing to do when HTTP or HSTS are disabled */
+  puts("nothing to do when HTTP or HSTS are disabled");
 }
 UNITTEST_STOP
 #else


### PR DESCRIPTION
Or no-HTTP, no-HSTS builds, also MSH3 builds.

CMake, VS2022, Debug, x64, no SSL, Static, Build-only:
```
C:\projects\curl\tests\unit\unit1660.c(46,1): error C2220: the following warning is treated as an error
C:\projects\curl\tests\unit\unit1660.c(46,1): warning C4702: unreachable code
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/50531210/job/cjewvo9agavthr3o#L216

Required-by: #14922
Cherry-picked from #14772
