### PR TITLE
GHA: keep default pkgconf, do not replace with pkg-config on Linux

### DIFF
--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -52,7 +52,7 @@ jobs:
       - run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install --yes libtool autoconf automake pkg-config stunnel4 libpsl-dev
+          sudo apt-get install --yes libtool autoconf automake pkgconf stunnel4 libpsl-dev
           # ensure we don't pick up openssl in this build
           sudo apt remove --yes libssl-dev
           sudo python3 -m pip install impacket

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -162,7 +162,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install libtool autoconf automake pkg-config stunnel4 \
+          sudo apt-get install libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \
@@ -298,7 +298,7 @@ jobs:
       - run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install libtool autoconf automake pkg-config stunnel4 \
+          sudo apt-get install libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -252,7 +252,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install libtool autoconf automake pkg-config stunnel4 libpsl-dev libbrotli-dev libzstd-dev ${{ matrix.build.install_packages }}
+          sudo apt-get install libtool autoconf automake pkgconf stunnel4 libpsl-dev libbrotli-dev libzstd-dev ${{ matrix.build.install_packages }}
           sudo python3 -m pip install impacket
         name: 'install prereqs and impacket'
 

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -60,7 +60,7 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-suggests --no-install-recommends libtool autoconf automake pkg-config stunnel4 ${{ matrix.build.install_packages }}
+          sudo apt-get install -y --no-install-suggests --no-install-recommends libtool autoconf automake pkgconf stunnel4 ${{ matrix.build.install_packages }}
           sudo python3 -m pip install impacket
         name: 'install prereqs'
 

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -65,7 +65,7 @@ jobs:
       - run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install libtool autoconf automake pkg-config stunnel4 ${{ matrix.build.install }}
+          sudo apt-get install libtool autoconf automake pkgconf stunnel4 ${{ matrix.build.install }}
           sudo python3 -m pip install impacket
         name: 'install prereqs and impacket'
 

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -65,7 +65,7 @@ jobs:
       - run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install libtool autoconf automake pkg-config stunnel4 libpsl-dev ${{ matrix.build.install }}
+          sudo apt-get install libtool autoconf automake pkgconf stunnel4 libpsl-dev ${{ matrix.build.install }}
           sudo python3 -m pip install impacket
         name: 'install prereqs and impacket'
 


### PR DESCRIPTION
Ubuntu has the `pkgconf` package installed by default that implements
the `pkg-config` command. Switch CI `apt` commands over to `pkgconf`
to avoid replacing it in every job run.

Avoids:
```
The following packages will be REMOVED:
  pkgconf r-base-dev
The following NEW packages will be installed:
  [...] pkg-config [...]
```
https://github.com/curl/curl/actions/runs/10949915766/job/30404126342?pr=14972#step:2:20
