### PR TITLE
tests/valgrind.pm: fix warnings when no valgrind report to show

### DIFF
--- a/tests/valgrind.pm
+++ b/tests/valgrind.pm
@@ -41,7 +41,8 @@ use File::Basename;
 sub valgrindparse {
     my ($file) = @_;
     my @o;
-    open(my $val, "<", "$file");
+    open(my $val, "<", "$file") ||
+        return;
     @o = <$val>;
     close($val);
     return @o;


### PR DESCRIPTION
`readline() on closed filehandle $val at valgrind.pm line 45.`