### PR TITLE
GHA/linux: fix installing valgrind, libpsl for rustls job, other cleanups

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -206,8 +206,8 @@ jobs:
               --without-ssl --without-zlib --without-brotli --without-zstd --without-libpsl --without-nghttp2 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: event-based valgrind
-            install_packages: libssh-dev valgrind
+          - name: event-based
+            install_packages: libssh-dev
             configure: --enable-debug --disable-shared --disable-threaded-resolver --with-libssh --with-openssl
             tflags: -n -e '!TLS-SRP'
             singleuse: --unit

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -212,8 +212,7 @@ jobs:
             tflags: -n -e '!TLS-SRP'
             singleuse: --unit
 
-          - name: hyper valgrind
-            install_packages: valgrind
+          - name: hyper
             install_steps: rust hyper
             configure: LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" --with-openssl --with-hyper=$HOME/hyper --enable-debug --enable-websockets
             singleuse: --unit

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -198,7 +198,6 @@ jobs:
 
           - name: memory-sanitizer
             install_packages: clang
-            install_steps:
             configure: >
               CC=clang
               CFLAGS="-fsanitize=memory -Wformat -Werror=format-security -Werror=array-bounds -g"
@@ -214,12 +213,14 @@ jobs:
             singleuse: --unit
 
           - name: hyper valgrind
-            install_steps: rust hyper valgrind
+            install_packages: valgrind
+            install_steps: rust hyper
             configure: LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" --with-openssl --with-hyper=$HOME/hyper --enable-debug --enable-websockets
             singleuse: --unit
 
           - name: rustls valgrind
-            install_steps: rust rustls pytest valgrind libpsl-dev
+            install_packages: libpsl-dev valgrind
+            install_steps: rust rustls pytest
             configure: --with-rustls=$HOME/rustls --enable-debug
             singleuse: --unit
 


### PR DESCRIPTION
Move them from `install_steps` to `install_packages`.

Also:
- stop installing valgrind for the event-based job where valgrind is
  explicitly disabled with tflags `-n`.
- stop installing valgrind for the hyper job. It wasn't enabled (by
  accident) before, and when actually enabled, it fails to pass tests:
  ```
  TESTFAIL: These test cases failed: 11 25 28 30 36 37 43 45 69 78 88
    90 94 129 153 154 155 158 160 170 176 178 187 193 207 217 233 234
    243 257 262 276 287 302 309 317 318 330 376 379 388 394 395 398
    415 427 440 441 493 497 498 547 548 551 552 555 590 599 644 650
    1031 1067 1071 1079 1089 1090 1104 1127 1128 1141 1142 1168 1172
    1174 1197 1239 1244 1261 1297 1314 1412 1416 1424 1430 1431 1432
    1433 1434 1473 1479 1480 1511 1531 1909 2081 2306 3015 3102
  ```
  Ref: https://github.com/curl/curl/actions/runs/10957987291/job/30427294361?pr=14979#step:41:50381
  Hyper is also scheduled for removal in February 2025.
