### PR TITLE
multi.c: make stronger check for paused transfer before asserting

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1126,6 +1126,7 @@ static void multi_getsock(struct Curl_easy *data,
 
   if(expect_sockets && !ps->num &&
      !(data->req.keepon & (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) &&
+     !Curl_cwriter_is_paused(data) && !Curl_creader_is_paused(data) &&
      Curl_conn_is_ip_connected(data, FIRSTSOCKET)) {
     infof(data, "WARNING: no socket in pollset, transfer may stall!");
     DEBUGASSERT(0);


### PR DESCRIPTION
With higher parallelism in CI, the ASSERT triggered on pause tests. Strengthen the check. We might want to think about removing KEEP_RECV_PAUSE|KEEP_SEND_PAUSE altogether.