### PR TITLE
GHA/linux: disable unity build for fix scanbuild job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -170,7 +170,7 @@ jobs:
           - name: scanbuild
             install_packages: clang-tools clang libssl-dev libssh2-1-dev
             install_steps: skipall
-            configure: --with-openssl --enable-debug --with-libssh2
+            configure: --with-openssl --enable-debug --with-libssh2 --disable-unity
             configure-prefix: CC=clang scan-build
             make-prefix: scan-build --status-bugs
             singleuse: --unit


### PR DESCRIPTION
Unity mode seems to defeat the scanner and miss issues.

before, miss: https://github.com/curl/curl/actions/runs/10967056702/job/30456136390
after, OK: https://github.com/curl/curl/actions/runs/10967128744/job/30456330732#step:35:1232

Tested with PR commit:
https://github.com/curl/curl/pull/14880/commits/32854bb30861e757d4f8d61d303c1b1f0e55bd26

Follow-up to 60c3d0446546332e1645541f2dc2c072cd019fe9 #14815