### PR TITLE
checksrc: Added checks for colon operator in ternary expressions

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -1471,7 +1471,7 @@ static CURLcode ftp_state_prepare_transfer(struct Curl_easy *data)
       struct ftp_conn *ftpc = &conn->proto.ftpc;
       if(!conn->proto.ftpc.file)
         result = Curl_pp_sendf(data, &ftpc->pp, "PRET %s",
-                               data->set.str[STRING_CUSTOMREQUEST]?
+                               data->set.str[STRING_CUSTOMREQUEST] ?
                                data->set.str[STRING_CUSTOMREQUEST] :
                                (data->state.list_only ? "NLST" : "LIST"));
       else if(data->state.upload)
@@ -1578,7 +1578,7 @@ static CURLcode ftp_state_list(struct Curl_easy *data)
   }
 
   cmd = aprintf("%s%s%s",
-                data->set.str[STRING_CUSTOMREQUEST]?
+                data->set.str[STRING_CUSTOMREQUEST] ?
                 data->set.str[STRING_CUSTOMREQUEST] :
                 (data->state.list_only ? "NLST" : "LIST"),
                 lstArg ? " " : "",

--- a/lib/http.c
+++ b/lib/http.c
@@ -1837,7 +1837,7 @@ CURLcode Curl_http_target(struct Curl_easy *data,
     curl_url_cleanup(h);
 
     /* target or URL */
-    result = Curl_dyn_add(r, data->set.str[STRING_TARGET]?
+    result = Curl_dyn_add(r, data->set.str[STRING_TARGET] ?
       data->set.str[STRING_TARGET] : url);
     free(url);
     if(result)

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -984,7 +984,7 @@ number:
         *fptr++ = 'l';
 
       if(flags & FLAGS_FLOATE)
-        *fptr++ = (char)((flags & FLAGS_UPPER) ? 'E':'e');
+        *fptr++ = (char)((flags & FLAGS_UPPER) ? 'E' : 'e');
       else if(flags & FLAGS_FLOATG)
         *fptr++ = (char)((flags & FLAGS_UPPER) ? 'G' : 'g');
       else

--- a/packages/OS400/ccsidcurl.c
+++ b/packages/OS400/ccsidcurl.c
@@ -127,8 +127,8 @@ convert(char *d, size_t dlen, int dccsid,
     dccsid = ASCII_CCSID;
 
   if(sccsid == dccsid) {
-    lslen = slen >= 0 ? slen: strlen(s) + 1;
-    i = lslen < dlen ? lslen: dlen;
+    lslen = slen >= 0 ? slen : strlen(s) + 1;
+    i = lslen < dlen ? lslen : dlen;
 
     if(s != d && i > 0)
       memcpy(d, s, i);
@@ -170,7 +170,7 @@ static char *dynconvert(int dccsid, const char *s, int slen, int sccsid)
 
   /* Like convert, but the destination is allocated and returned. */
 
-  dlen = (size_t) (slen < 0 ? strlen(s): slen) + 1;
+  dlen = (size_t) (slen < 0 ? strlen(s) : slen) + 1;
   dlen *= MAX_CONV_EXPANSION;           /* Allow some expansion. */
   d = malloc(dlen);
 
@@ -294,7 +294,7 @@ curl_easy_escape_ccsid(CURL *handle, const char *string, int length,
     return (char *) NULL;
     }
 
-  s = dynconvert(ASCII_CCSID, string, length ? length: -1, sccsid);
+  s = dynconvert(ASCII_CCSID, string, length ? length : -1, sccsid);
 
   if(!s)
     return (char *) NULL;
@@ -324,7 +324,7 @@ curl_easy_unescape_ccsid(CURL *handle, const char *string, int length,
     return (char *) NULL;
     }
 
-  s = dynconvert(ASCII_CCSID, string, length ? length: -1, sccsid);
+  s = dynconvert(ASCII_CCSID, string, length ? length : -1, sccsid);
 
   if(!s)
     return (char *) NULL;
@@ -1046,7 +1046,7 @@ Curl_formget_callback_ccsid(void *arg, const char *buf, size_t len)
 
   ret = (*p->append)(p->arg, b, l);
   free(b);
-  return ret == l ? len: -1;
+  return ret == l ? len : -1;
 }
 
 

--- a/packages/OS400/os400sys.c
+++ b/packages/OS400/os400sys.c
@@ -640,8 +640,8 @@ Curl_ldap_search_s_a(void *ld, char *base, int scope, char *filter,
   }
 
   if(status == LDAP_SUCCESS)
-    status = ldap_search_s(ld, ebase ? ebase: "", scope,
-                           efilter ? efilter: "(objectclass=*)",
+    status = ldap_search_s(ld, ebase ? ebase : "", scope,
+                           efilter ? efilter : "(objectclass=*)",
                            eattrs, attrsonly, res);
 
   if(eattrs) {

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -56,51 +56,52 @@ my %warnings_extended = (
 
 my %warnings = (
     'ASSIGNWITHINCONDITION' => 'assignment within conditional expression',
-    'ASTERISKNOSPACE'  => 'pointer declared without space before asterisk',
-    'ASTERISKSPACE'    => 'pointer declared with space after asterisk',
-    'BADCOMMAND'       => 'bad !checksrc! instruction',
-    'BANNEDFUNC'       => 'a banned function was used',
-    'BANNEDPREPROC'    => 'a banned symbol was used on a preprocessor line',
-    'BRACEELSE'        => '} else on the same line',
-    'BRACEPOS'         => 'wrong position for an open brace',
-    'BRACEWHILE'       => 'A single space between open brace and while',
-    'COMMANOSPACE'     => 'comma without following space',
-    'COMMENTNOSPACEEND' => 'no space before */',
-    'COMMENTNOSPACESTART' => 'no space following /*',
-    'COPYRIGHT'        => 'file missing a copyright statement',
-    'CPPCOMMENTS'      => '// comment detected',
-    'DOBRACE'          => 'A single space between do and open brace',
-    'EMPTYLINEBRACE'   => 'Empty line before the open brace',
-    'EQUALSNOSPACE'    => 'equals sign without following space',
-    'EQUALSNULL'       => 'if/while comparison with == NULL',
-    'EXCLAMATIONSPACE' => 'Whitespace after exclamation mark in expression',
-    'FOPENMODE'        => 'fopen needs a macro for the mode string',
-    'INCLUDEDUP',      => 'same file is included again',
-    'INDENTATION'      => 'wrong start column for code',
-    'LONGLINE'         => "Line longer than $max_column",
-    'SPACEBEFORELABEL' => 'labels not at the start of the line',
-    'MULTISPACE'       => 'multiple spaces used when not suitable',
-    'NOSPACEEQUALS'    => 'equals sign without preceding space',
-    'NOSPACEQ'         => 'missing space around ternary question mark operator',
-    'NOSPACETHAN'      => 'missing space around less or greater than',
-    'NOTEQUALSZERO',   => 'if/while comparison with != 0',
-    'ONELINECONDITION' => 'conditional block on the same line as the if()',
-    'OPENCOMMENT'      => 'file ended with a /* comment still "open"',
-    'PARENBRACE'       => '){ without sufficient space',
-    'RETURNNOSPACE'    => 'return without space',
-    'SEMINOSPACE'      => 'semicolon without following space',
-    'SIZEOFNOPAREN'    => 'use of sizeof without parentheses',
-    'SNPRINTF'         => 'use of snprintf',
-    'SPACEAFTERPAREN'  => 'space after open parenthesis',
-    'SPACEBEFORECLOSE' => 'space before a close parenthesis',
-    'SPACEBEFORECOMMA' => 'space before a comma',
-    'SPACEBEFOREPAREN' => 'space before an open parenthesis',
-    'SPACESEMICOLON'   => 'space before semicolon',
-    'SPACESWITCHCOLON' => 'space before colon of switch label',
-    'TABS'             => 'TAB characters not allowed',
-    'TRAILINGSPACE'    => 'Trailing whitespace on the line',
-    'TYPEDEFSTRUCT'    => 'typedefed struct',
-    'UNUSEDIGNORE'     => 'a warning ignore was not used',
+    'ASTERISKNOSPACE'       => 'pointer declared without space before asterisk',
+    'ASTERISKSPACE'         => 'pointer declared with space after asterisk',
+    'BADCOMMAND'            => 'bad !checksrc! instruction',
+    'BANNEDFUNC'            => 'a banned function was used',
+    'BANNEDPREPROC'         => 'a banned symbol was used on a preprocessor line',
+    'BRACEELSE'             => '} else on the same line',
+    'BRACEPOS'              => 'wrong position for an open brace',
+    'BRACEWHILE'            => 'A single space between open brace and while',
+    'COMMANOSPACE'          => 'comma without following space',
+    'COMMENTNOSPACEEND'     => 'no space before */',
+    'COMMENTNOSPACESTART'   => 'no space following /*',
+    'COPYRIGHT'             => 'file missing a copyright statement',
+    'CPPCOMMENTS'           => '// comment detected',
+    'DOBRACE'               => 'A single space between do and open brace',
+    'EMPTYLINEBRACE'        => 'Empty line before the open brace',
+    'EQUALSNOSPACE'         => 'equals sign without following space',
+    'EQUALSNULL'            => 'if/while comparison with == NULL',
+    'EXCLAMATIONSPACE'      => 'Whitespace after exclamation mark in expression',
+    'FOPENMODE'             => 'fopen needs a macro for the mode string',
+    'INCLUDEDUP',           => 'same file is included again',
+    'INDENTATION'           => 'wrong start column for code',
+    'LONGLINE'              => "Line longer than $max_column",
+    'SPACEBEFORELABEL'      => 'labels not at the start of the line',
+    'MULTISPACE'            => 'multiple spaces used when not suitable',
+    'NOSPACEC'              => 'missing space around ternary colon operator',
+    'NOSPACEEQUALS'         => 'equals sign without preceding space',
+    'NOSPACEQ'              => 'missing space around ternary question mark operator',
+    'NOSPACETHAN'           => 'missing space around less or greater than',
+    'NOTEQUALSZERO',        => 'if/while comparison with != 0',
+    'ONELINECONDITION'      => 'conditional block on the same line as the if()',
+    'OPENCOMMENT'           => 'file ended with a /* comment still "open"',
+    'PARENBRACE'            => '){ without sufficient space',
+    'RETURNNOSPACE'         => 'return without space',
+    'SEMINOSPACE'           => 'semicolon without following space',
+    'SIZEOFNOPAREN'         => 'use of sizeof without parentheses',
+    'SNPRINTF'              => 'use of snprintf',
+    'SPACEAFTERPAREN'       => 'space after open parenthesis',
+    'SPACEBEFORECLOSE'      => 'space before a close parenthesis',
+    'SPACEBEFORECOMMA'      => 'space before a comma',
+    'SPACEBEFOREPAREN'      => 'space before an open parenthesis',
+    'SPACESEMICOLON'        => 'space before semicolon',
+    'SPACESWITCHCOLON'      => 'space before colon of switch label',
+    'TABS'                  => 'TAB characters not allowed',
+    'TRAILINGSPACE'         => 'Trailing whitespace on the line',
+    'TYPEDEFSTRUCT'         => 'typedefed struct',
+    'UNUSEDIGNORE'          => 'a warning ignore was not used',
     );
 
 sub readskiplist {
@@ -625,12 +626,37 @@ sub scanfile {
                       "space after open parenthesis");
         }
 
+        # check spaces before colon
+        if($nostr =~ /^(.*[^']\?[^'].*)(\w|\)|\]|')\:/i) {
+            my $m = $1;
+            my $e = $nostr;
+            $e =~ s/'(.)':'(.)'/$1:$2/g; # eliminate chars quotes that suround colon
+            $e =~ s/':'//g;              # ignore these
+            if($e =~ /^(.*[^']\?[^'].*)(\w|\)|\]|')\:/i) {
+                checkwarn("NOSPACEC",
+                          $line, length($m)+1, $file, $l,
+                          "missing space before colon");
+            }
+        }
+        # check spaces after colon
+        if($nostr =~ /^(.*[^'"]\?[^'"].*)\:(\w|\)|\]|')/i) {
+            my $m = $1;
+            my $e = $nostr;
+            $e =~ s/'(.)':'(.)'/$1:$2/g; # eliminate chars quotes that suround colon
+            $e =~ s/':'//g;              # ignore these
+            if($e =~ /^(.*[^'"]\?[^'"].*)\:(\w|\)|\]|')/i) {
+                checkwarn("NOSPACEC",
+                          $line, length($m)+1, $file, $l,
+                          "missing space after colon");
+            }
+        }
+
         # check spaces before question mark
         if($nostr =~ /^(.*)(\w|\)|\]|')\?/i) {
             my $m = $1;
             my $e = $nostr;
             $e =~ s/'?'//g; # ignore these
-            if($e =~ /^(.*)(\w|\)|')\?/i) {
+            if($e =~ /^(.*)(\w|\)|\]|')\?/i) {
                 checkwarn("NOSPACEQ",
                           $line, length($m)+1, $file, $l,
                           "missing space before question mark");

--- a/tests/data/test1185
+++ b/tests/data/test1185
@@ -165,6 +165,12 @@ void startfunc(int a, int b) {
 ./%LOGDIR/code1185.c:53:10: warning: use of snprintf is banned (SNPRINTF)
   int a = snprintf(buffer, sizeof(buffer), "%d", 99);
           ^
+./%LOGDIR/code1185.c:54:21: warning: missing space before colon (NOSPACEC)
+  int moo = hej?wrong:a>b;
+                     ^
+./%LOGDIR/code1185.c:54:22: warning: missing space after colon (NOSPACEC)
+  int moo = hej?wrong:a>b;
+                      ^
 ./%LOGDIR/code1185.c:54:15: warning: missing space before question mark (NOSPACEQ)
   int moo = hej?wrong:a>b;
                ^
@@ -195,7 +201,7 @@ void startfunc(int a, int b) {
 ./%LOGDIR/code1185.c:1:1: error: Missing closing comment (OPENCOMMENT)
  
  ^
-checksrc: 0 errors and 36 warnings
+checksrc: 0 errors and 38 warnings
 </stdout>
 <errorcode>
 5

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -90,16 +90,16 @@ static int onetest(CURL *curl, const char *url, const struct testparams *p,
   unsigned int replyselector;
   char urlbuf[256];
 
-  replyselector = (p->flags & F_CONTENTRANGE) ? 1: 0;
+  replyselector = (p->flags & F_CONTENTRANGE) ? 1 : 0;
   if(p->flags & F_HTTP416)
     replyselector += 2;
   msnprintf(urlbuf, sizeof(urlbuf), "%s%04u", url, replyselector);
   test_setopt(curl, CURLOPT_URL, urlbuf);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_RESUME_FROM, (p->flags & F_RESUME) ? 3: 0);
+  test_setopt(curl, CURLOPT_RESUME_FROM, (p->flags & F_RESUME) ? 3 : 0);
   test_setopt(curl, CURLOPT_RANGE, !(p->flags & F_RESUME) ?
                                    "3-1000000": (char *) NULL);
-  test_setopt(curl, CURLOPT_FAILONERROR, (p->flags & F_FAIL) ? 1: 0);
+  test_setopt(curl, CURLOPT_FAILONERROR, (p->flags & F_FAIL) ? 1 : 0);
   hasbody = 0;
   res = curl_easy_perform(curl);
   if(res != p->result) {

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -56,7 +56,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userp)
     return CURL_READFUNC_PAUSE;
   case 2:
     delta = time(NULL) - pooh->origin;
-    *ptr = delta >= PAUSE_TIME ? '\x42': '\x41'; /* ASCII A or B. */
+    *ptr = delta >= PAUSE_TIME ? '\x42' : '\x41'; /* ASCII A or B. */
     return 1;
   case 3:
     return 0;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1021,7 +1021,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req)
   char responsedump[256];
 
   msnprintf(responsedump, sizeof(responsedump), "%s/%s",
-            logdir, is_proxy ? RESPONSE_PROXY_DUMP:RESPONSE_DUMP);
+            logdir, is_proxy ? RESPONSE_PROXY_DUMP : RESPONSE_DUMP);
 
   switch(req->rcmd) {
   default:


### PR DESCRIPTION
This is an attempt to provide a check for colon operators in ternary expressions.
Sadly, the current version does work  only for ternary expressions that are written in one line.