### PR TITLE
GHA: use more ninja, build examples in the last step, and more

### DIFF
--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -50,8 +50,6 @@ jobs:
 
     steps:
       - run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
           sudo apt-get install --yes libtool autoconf automake pkgconf stunnel4 libpsl-dev
           # ensure we don't pick up openssl in this build
           sudo apt remove --yes libssl-dev
@@ -111,8 +109,6 @@ jobs:
 
     steps:
       - run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
           sudo apt-get install cmake ninja-build stunnel4 libpsl-dev
           # ensure we don't pick up openssl in this build
           sudo apt remove --yes libssl-dev

--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -113,7 +113,7 @@ jobs:
       - run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install cmake stunnel4 libpsl-dev
+          sudo apt-get install cmake ninja-build stunnel4 libpsl-dev
           # ensure we don't pick up openssl in this build
           sudo apt remove --yes libssl-dev
           sudo python3 -m pip install impacket
@@ -136,14 +136,14 @@ jobs:
           tar xzf v${{ env.awslc-version }}.tar.gz
           mkdir aws-lc-${{ env.awslc-version }}-build
           cd aws-lc-${{ env.awslc-version }}-build
-          cmake -DCMAKE_INSTALL_PREFIX=$HOME/awslc ../aws-lc-${{ env.awslc-version }}
+          cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/awslc ../aws-lc-${{ env.awslc-version }}
           cmake --build . --parallel
           cmake --install .
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - run: |
-          cmake -B build -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
+          cmake -B build -G Ninja -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
             -DOPENSSL_ROOT_DIR=$HOME/awslc -DBUILD_SHARED_LIBS=ON
         name: 'cmake generate out-of-tree'
 

--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -92,15 +92,15 @@ jobs:
       - run: make -C build V=1
         name: 'make'
 
-      - run: make -C build V=1 examples
-        name: 'make examples'
-
       - run: make -C build V=1 -C tests
         name: 'make tests'
 
       - run: make -C build V=1 test-ci
         name: 'run tests'
         timeout-minutes: 15
+
+      - run: make -C build V=1 examples
+        name: 'make examples'
 
   cmake:
     name: awslc (cmake)

--- a/.github/workflows/awslc.yml
+++ b/.github/workflows/awslc.yml
@@ -151,3 +151,6 @@ jobs:
 
       - run: cmake --build build --parallel --target testdeps
         name: 'cmake build tests'
+
+      - run: cmake --build build --parallel --target curl-examples
+        name: 'cmake build examples'

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -49,8 +49,6 @@ jobs:
 
       - name: install
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
           sudo apt-get install codespell python3-pip
           python3 -m pip install cmakelint==1.4.3
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -160,8 +160,6 @@ jobs:
       - name: install build prerequisites
         if: steps.settings.outputs.needs-build == 'true'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
           sudo apt-get install libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
@@ -296,8 +294,6 @@ jobs:
 
     steps:
       - run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
           sudo apt-get install libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -457,9 +457,6 @@ jobs:
       - run: make V=1
         name: 'make'
 
-      - run: make V=1 examples
-        name: 'make examples'
-
       - run: make V=1 -C tests
         name: 'make tests'
 
@@ -473,3 +470,6 @@ jobs:
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
           CURL_CI: github
+
+      - run: make V=1 examples
+        name: 'make examples'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -551,7 +551,7 @@ jobs:
         run: |
           export TFLAGS='${{ matrix.build.tflags }}'
           if [[ '${{ matrix.build.install_packages }}' = *'valgrind'* ]]; then
-            TFLAGS+=' -j4'
+            TFLAGS+=' -j8'
           fi
           if [[ '${{ matrix.build.install_packages }}' = *'heimdal-dev'* ]]; then
             TFLAGS+=' ~2077 ~2078'  # valgrind errors

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -551,7 +551,7 @@ jobs:
         run: |
           export TFLAGS='${{ matrix.build.tflags }}'
           if [[ '${{ matrix.build.install_packages }}' = *'valgrind'* ]]; then
-            TFLAGS+=' -j8'
+            TFLAGS+=' -j6'
           fi
           if [[ '${{ matrix.build.install_packages }}' = *'heimdal-dev'* ]]; then
             TFLAGS+=' ~2077 ~2078'  # valgrind errors

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -250,8 +250,6 @@ jobs:
     steps:
       - if: matrix.build.container == null
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
           sudo apt-get install libtool autoconf automake pkgconf stunnel4 libpsl-dev libbrotli-dev libzstd-dev ${{ matrix.build.install_packages }}
           sudo python3 -m pip install impacket
         name: 'install prereqs and impacket'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -551,7 +551,7 @@ jobs:
         run: |
           export TFLAGS='${{ matrix.build.tflags }}'
           if [[ '${{ matrix.build.install_packages }}' = *'valgrind'* ]]; then
-            TFLAGS+=' -j6'
+            TFLAGS+=' -j4'
           fi
           if [[ '${{ matrix.build.install_packages }}' = *'heimdal-dev'* ]]; then
             TFLAGS+=' ~2077 ~2078'  # valgrind errors

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -550,6 +550,9 @@ jobs:
         timeout-minutes: ${{ contains(matrix.build.install_packages, 'valgrind') && 30 || 15 }}
         run: |
           export TFLAGS='${{ matrix.build.tflags }}'
+          if [[ '${{ matrix.build.install_packages }}' = *'valgrind'* ]]; then
+            TFLAGS+=' -j4'
+          fi
           if [[ '${{ matrix.build.install_packages }}' = *'heimdal-dev'* ]]; then
             TFLAGS+=' ~2077 ~2078'  # valgrind errors
           fi

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -80,9 +80,6 @@ jobs:
       - run: ./src/curl -V
         name: 'check curl -V output'
 
-      - run: make V=1 examples
-        name: 'make examples'
-
       - run: make V=1 -C tests
         name: 'make tests'
 
@@ -90,3 +87,6 @@ jobs:
         name: 'run tests'
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
+
+      - run: make V=1 examples
+        name: 'make examples'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -325,8 +325,7 @@ jobs:
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
-          cmake -B bld ${options} \
-            '-GMSYS Makefiles' \
+          cmake -B bld ${options} -G 'MSYS Makefiles' \
             -DCMAKE_C_COMPILER=gcc \
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -63,8 +63,6 @@ jobs:
 
     steps:
       - run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
           sudo apt-get install libtool autoconf automake pkgconf stunnel4 libpsl-dev ${{ matrix.build.install }}
           sudo python3 -m pip install impacket
         name: 'install prereqs and impacket'

--- a/.github/workflows/wolfssl.yml
+++ b/.github/workflows/wolfssl.yml
@@ -90,9 +90,6 @@ jobs:
       - run: make V=1
         name: 'make'
 
-      - run: make V=1 examples
-        name: 'make examples'
-
       - run: make V=1 -C tests
         name: 'make tests'
 
@@ -101,3 +98,6 @@ jobs:
         timeout-minutes: ${{ contains(matrix.build.install, 'valgrind') && 30 || 15 }}
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
+
+      - run: make V=1 examples
+        name: 'make examples'


### PR DESCRIPTION
- linux: bump up test parallelism for valgrind tests to `-j4`
  (from `-j2`). (EXPERIMENTAL)
- linux: drop `apt-get update` for the default architecture on the GHA
  native runner. It makes prereq install steps complete faster.
  The runner image gets weekly updates, and that should be enough to
  guarantee fresh packages in most cases:
  https://github.com/actions/runner-images/commits/main/images/ubuntu/Ubuntu2204-Readme.md
- aws-lc: use ninja with cmake.
- aws-lc: build examples with cmake.
- aws-lc: drop `apt update`.
- aws-lc, wolfssl, linux32, http3-linux: move building examples to
  the last step.
  Follow-up to 45202cbba4bb3d12b4469063864b57d2f8765d9c #14906
- windows: formatting.
