### PR TITLE
GHA/windows: do not disable TrackFileAccess

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -622,7 +622,7 @@ jobs:
             TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
-          cmake --build bld --config '${{ matrix.type }}' --target test-ci
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target test-ci
 
       - name: 'cmake build examples'
         timeout-minutes: 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -563,7 +563,6 @@ jobs:
             "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
             "-DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed" \
             '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
-            -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON \
             -DCURL_WERROR=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2216,13 +2216,9 @@ endif()
 # Post-build events are always executed in MSBuild, even if the build is up to date.
 # Apply the workaround from https://gitlab.kitware.com/cmake/cmake/-/issues/18530
 if(CMAKE_GENERATOR MATCHES "Visual Studio")
-    file(CONFIGURE OUTPUT Directory.Build.props CONTENT [[
-      <Project>
-        <Target Name="DisablePostBuildEvent" AfterTargets="Link" BeforeTargets="PostBuildEvent">
-            <PropertyGroup>
-              <PostBuildEventUseInBuild Condition="'$(LinkSkippedExecution)' == 'True'">false</PostBuildEventUseInBuild>
-            </PropertyGroup>
-          </Target>
-      </Project>
-    ]] @ONLY)
+  configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Directory.Build.props.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Directory.Build.props
+    @ONLY
+  )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2212,3 +2212,17 @@ file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/buildinfo.txt" "# This is a generated fi
 if(NOT "$ENV{CURL_BUILDINFO}$ENV{CURL_CI}$ENV{CI}" STREQUAL "")
   message(STATUS "\n${_buildinfo}")
 endif()
+
+# Post-build events are always executed in MSBuild, even if the build is up to date.
+# Apply the workaround from https://gitlab.kitware.com/cmake/cmake/-/issues/18530
+if(CMAKE_GENERATOR MATCHES "Visual Studio")
+    file(CONFIGURE OUTPUT Directory.Build.props CONTENT [[
+      <Project>
+        <Target Name="DisablePostBuildEvent" AfterTargets="Link" BeforeTargets="PostBuildEvent">
+            <PropertyGroup>
+              <PostBuildEventUseInBuild Condition="'$(LinkSkippedExecution)' == 'True'">false</PostBuildEventUseInBuild>
+            </PropertyGroup>
+          </Target>
+      </Project>
+    ]] @ONLY)
+endif()

--- a/Directory.Build.props.in
+++ b/Directory.Build.props.in
@@ -1,0 +1,7 @@
+<Project>
+<Target Name="DisablePostBuildEvent" AfterTargets="Link" BeforeTargets="PostBuildEvent">
+    <PropertyGroup>
+        <PostBuildEventUseInBuild Condition="'$(LinkSkippedExecution)' == 'True'">false</PostBuildEventUseInBuild>
+    </PropertyGroup>
+    </Target>
+</Project>


### PR DESCRIPTION
To support incremental build, it is necessary to track file access patterns.