### PR TITLE
GHA/windows: mark 3023, 3024 flaky for mingw-w64 7.3.0

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -286,7 +286,7 @@ jobs:
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON'
             type: 'Release'
-            tflags: '~2301 ~2302 ~3027 ~1451'
+            tflags: '~2301 ~2302 ~3027 ~3023 ~3024 ~1451'
           - name: 'schannel !unity'
             env: '6.4.0-i686'
             dir: 'mingw32'


### PR DESCRIPTION
They became flaky recently as reported by Testclutch and firsthand
observations. It's curious because it only seems to happen in 7.3.0,
but not in the very similar (except non-Unicode) 9.5.0 job.

We've found no explanation or reason for them so far.

```
test 3023...[HTTPS GET to localhost, first subject alt name matches, CN does not match (Schannel variant)]

 3023: protocol FAILED!
 There was no content at all in the file log/14/server.input.
 Server glitch? Total curl failure? Returned: 7
```
Ref: https://github.com/curl/curl/actions/runs/10871191391/job/30164710777?pr=14918#step:13:4849

```
test 3024...[HTTPS GET to localhost, last subject alt name matches, CN does not match (Schannel variant)]

 3024: protocol FAILED!
 There was no content at all in the file log/8/server.input.
 Server glitch? Total curl failure? Returned: 7
```
Ref: https://github.com/curl/curl/actions/runs/10871191391/job/30164710777?pr=14918#step:13:4713

```
FAIL 3023: 'HTTPS GET to localhost, first subject alt name matches, CN does not match (Schannel variant)' HTTPS, HTTP GET, PEM certificate
FAIL 3024: 'HTTPS GET to localhost, last subject alt name matches, CN does not match (Schannel variant)' HTTPS, HTTP GET, PEM certificate
```
https://github.com/curl/curl/actions/runs/10982991876/job/30491895264?pr=14930#step:14:4914
https://github.com/curl/curl/actions/runs/10871191391/job/30164710777?pr=14918
https://github.com/curl/curl/actions/runs/10841065505/job/30084573629?pr=14859#step:13:5484
https://github.com/curl/curl/actions/runs/10858001821/job/30135376138?pr=14906#step:13:4841

Reported-by: Testclutch
Fixes https://github.com/curl/curl/pull/14905#issuecomment-2350772804
Ref: https://github.com/curl/curl/discussions/14854#discussioncomment-10652044
