### PR TITLE
tests: libtests and unit tests need explicit #include memdebug

### DIFF
--- a/tests/libtest/lib2305.c
+++ b/tests/libtest/lib2305.c
@@ -24,6 +24,7 @@
 
 #include "test.h"
 #include "testtrace.h"
+#include "memdebug.h"
 
 #ifdef USE_WEBSOCKETS
 

--- a/tests/unit/unit1661.c
+++ b/tests/unit/unit1661.c
@@ -22,8 +22,8 @@
  *
  ***************************************************************************/
 #include "curlcheck.h"
-
 #include "bufref.h"
+#include "memdebug.h"
 
 static struct bufref bufref;
 

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -49,7 +49,7 @@
 #include "multiif.h"
 #include "select.h"
 #include "curl_trc.h"
-
+#include "memdebug.h"
 
 static CURL *easy;
 

--- a/tests/unit/unit2604.c
+++ b/tests/unit/unit2604.c
@@ -23,6 +23,7 @@
  ***************************************************************************/
 #include "curlcheck.h"
 #include "curl_path.h"
+#include "memdebug.h"
 
 static CURLcode unit_setup(void)
 {

--- a/tests/unit/unit3200.c
+++ b/tests/unit/unit3200.c
@@ -23,6 +23,7 @@
  ***************************************************************************/
 #include "curlcheck.h"
 #include "curl_get_line.h"
+#include "memdebug.h"
 
 #if !defined(CURL_DISABLE_COOKIES) || !defined(CURL_DISABLE_ALTSVC) ||  \
   !defined(CURL_DISABLE_HSTS) || !defined(CURL_DISABLE_NETRC)


### PR DESCRIPTION
... as otherwise they do not monitor the resource use within the test files - until they are unity built.