### PR TITLE
CI: add missed updates to the `configure-libssh` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ commands:
       - run:
           command: |
             autoreconf -fi
-            ./configure --enable-warnings --enable-werror --with-openssl --with-libssh \
+            ./configure --disable-dependency-tracking --enable-unity --enable-test-bundles --enable-warnings --enable-werror --with-openssl --with-libssh \
               || { tail -1000 config.log; false; }
 
   install-wolfssl:


### PR DESCRIPTION
Disable dependency tracking and enable unity + test bundles for
the `configure-libssh` job that was missed in earlier commits.

Follow-up to 71cf0d1fca9e1f53524e1545ef0c08d174458d80 #14772
Follow-up to dff66196d0bc52b53a91f59d3972769412f9639b #14975
