### PR TITLE
build: fix possible `-Wformat-overflow` in lib557 with test bundle builds

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -206,7 +206,6 @@ if(PICKY_COMPILER)
         list(APPEND WPICKY_ENABLE
           -Walloc-zero                     #             gcc  7.0
           -Wduplicated-branches            #             gcc  7.0
-          -Wno-format-overflow             #             gcc  7.0
           -Wformat-truncation=2            #             gcc  7.0
           -Wimplicit-fallthrough           # clang  4.0  gcc  7.0
           -Wrestrict                       #             gcc  7.0

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1076,7 +1076,6 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [duplicated-branches])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [restrict])
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [alloc-zero])
-            tmp_CFLAGS="$tmp_CFLAGS -Wno-format-overflow"
             tmp_CFLAGS="$tmp_CFLAGS -Wformat-truncation=2"
             tmp_CFLAGS="$tmp_CFLAGS -Wimplicit-fallthrough"
           fi

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -41,7 +41,9 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat"
 #pragma GCC diagnostic ignored "-Wformat-extra-args"
+#if !defined(__clang__) && __GNUC__ >= 7
 #pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif
 #endif
 
 #if (SIZEOF_CURL_OFF_T > SIZEOF_LONG)

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -41,6 +41,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat"
 #pragma GCC diagnostic ignored "-Wformat-extra-args"
+#pragma GCC diagnostic ignored "-Wformat-overflow"
 #endif
 
 #if (SIZEOF_CURL_OFF_T > SIZEOF_LONG)

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -29,8 +29,10 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat"
-#pragma GCC diagnostic ignored "-Wformat-overflow"
 #pragma GCC diagnostic ignored "-Wformat-zero-length"
+#if !defined(__clang__) && __GNUC__ >= 7
+#pragma GCC diagnostic ignored "-Wformat-overflow"
+#endif
 #endif
 
 /*

--- a/tests/unit/unit1652.c
+++ b/tests/unit/unit1652.c
@@ -29,6 +29,7 @@
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat"
+#pragma GCC diagnostic ignored "-Wformat-overflow"
 #pragma GCC diagnostic ignored "-Wformat-zero-length"
 #endif
 


### PR DESCRIPTION
- lib557: suppress `-Wformat-overflow` warning in source.
  Fixes:
  ```
  lib557.c: In function ‘test_float_formatting’:
  lib557.c:1408:37: error: ‘%*f’ directive output of 2147483648 bytes exceeds ‘INT_MAX’ [-Werror=format-overflow=]
   1408 |   curl_msnprintf(buf, sizeof(buf), "%*f", INT_MIN, 9.1);
        |                                     ^~~
  lib557.c:1408:3: note: ‘curl_msnprintf’ output 2147483649 bytes
   1408 |   curl_msnprintf(buf, sizeof(buf), "%*f", INT_MIN, 9.1);
        |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  ```
  Ref: https://app.circleci.com/pipelines/github/curl/curl/10226/workflows/87642ee9-cda6-4916-8206-c82aac5f595e/jobs/107669?invite=true#step-106-40996_46

  The root cause of why this option gets enabled remains undiscovered.

  Reported-by: Daniel Stenberg
  Fixes #15008
  Follow-up to 71cf0d1fca9e1f53524e1545ef0c08d174458d80 #14772

- build: drop `-Wno-format-overflow` from picky warning list.
  These options only get used with picky warnings enabled.
  Follow-up to 145f87b9e89f3a5e287233fe7d3cf57aca23dd8c #14598

- unit1652: suppress in source (and not rely on picky warnings anymore.)
