### PR TITLE
GHA/linux: review and prune valgrind use

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -123,8 +123,8 @@ jobs:
             configure: --with-openssl --enable-debug --disable-threaded-resolver --with-libssh2
             singleuse: --unit
 
-          - name: openssl3 valgrind
-            install_packages: zlib1g-dev valgrind
+          - name: openssl3
+            install_packages: zlib1g-dev
             install_steps: gcc-11 openssl3 pytest
             configure: CFLAGS=-std=gnu89 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
             singleuse: --unit

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -129,7 +129,7 @@ jobs:
             configure: CFLAGS=-std=gnu89 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets
             singleuse: --unit
 
-          - name: openssl3-O3 valgrind
+          - name: openssl3 -O3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11 openssl3
             configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --enable-websockets

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -64,8 +64,8 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: bearssl valgrind
-            install_packages: zlib1g-dev valgrind
+          - name: bearssl
+            install_packages: zlib1g-dev
             install_steps: bearssl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
             singleuse: --unit
@@ -76,8 +76,8 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
             singleuse: --unit
 
-          - name: libressl heimdal valgrind
-            install_packages: zlib1g-dev heimdal-dev valgrind
+          - name: libressl heimdal
+            install_packages: zlib1g-dev heimdal-dev
             install_steps: libressl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --with-gssapi --enable-debug
             singleuse: --unit
@@ -106,8 +106,8 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
             singleuse: --unit
 
-          - name: msh3 valgrind
-            install_packages: zlib1g-dev valgrind
+          - name: msh3
+            install_packages: zlib1g-dev
             install_steps: quictls msh3
             configure: LDFLAGS="-Wl,-rpath,$HOME/msh3/lib -Wl,-rpath,$HOME/quictls/lib" --with-msh3=$HOME/msh3 --with-openssl=$HOME/quictls --enable-debug
             singleuse: --unit
@@ -223,8 +223,8 @@ jobs:
             configure: --with-rustls=$HOME/rustls --enable-debug
             singleuse: --unit
 
-          - name: IntelC !SSL valgrind
-            install_packages: zlib1g-dev valgrind
+          - name: IntelC !SSL
+            install_packages: zlib1g-dev
             install_steps: intel
             configure: CC=icc --enable-debug --without-ssl
             singleuse: --unit


### PR DESCRIPTION
Valgrind jobs are slow, drop it from jobs where its use is redundant
and/or has limited impact:

- BearSSL: deprecated.
- LibreSSL heimdal with autotools.
  Keep valgrind for the same job with cmake.
- msh3.
- IntelC no-SSL.
  Keep valgrind for IntelC OpenSSL.
- OpenSSL 3.
  All OpenSSL jobs are v3 now, keep valgrind for the `-O3`, and
  libssh2 + sync-resolver variants.
