### PR TITLE
GHA/linux: enable test bundles for cmake jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -504,7 +504,7 @@ jobs:
       - run: |
           cmake . \
             -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \
-            -DCMAKE_UNITY_BUILD=ON -DCURL_WERROR=ON \
+            -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
             -DCURL_BROTLI=ON -DCURL_ZSTD=ON \
             ${{ matrix.build.generate }}
         if: ${{ matrix.build.generate }}


### PR DESCRIPTION
Test build step speed-up (3x): 18s → 6s

Follow-up to 71cf0d1fca9e1f53524e1545ef0c08d174458d80 #14772
