### PR TITLE
curl_trc: fix build with verbose messages disabled

### DIFF
--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -226,6 +226,12 @@ static void Curl_trc_smtp(struct Curl_easy *data, const char *fmt, ...)
   (void)data; (void)fmt;
 }
 #endif
+#if defined(USE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
+static void Curl_trc_ws(struct Curl_easy *data, const char *fmt, ...)
+{
+  (void)data; (void)fmt;
+}
+#endif
 
 #endif /* !defined(CURL_DISABLE_VERBOSE_STRINGS) */
 


### PR DESCRIPTION
Add empty definition of Curl_trc_ws() to fix this following build error:

In file included from sendf.h:29,
                 from ws.c:35:
ws.c: In function 'Curl_ws_accept':
curl_trc.h:100:10: error: implicit declaration of function 'Curl_trc_ws'; did you mean 'Curl_trc_ftp'? [-Wimplicit-function-declaration]
  100 |          Curl_trc_ws(data, __VA_ARGS__); } while(0)
      |          ^~~~~~~~~~~
ws.c:779:5: note: in expansion of macro 'CURL_TRC_WS'
  779 |     CURL_TRC_WS(data, "WS, using chunk size %zu", chunk_size);
      |     ^~~~~~~~~~~