### PR TITLE
multi.c: warn/assert on stall only without timer

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1125,10 +1125,14 @@ static void multi_getsock(struct Curl_easy *data,
   }
 
   if(expect_sockets && !ps->num &&
-     !(data->req.keepon & (KEEP_RECV_PAUSE|KEEP_SEND_PAUSE)) &&
+     !Curl_llist_count(&data->state.timeoutlist) &&
      !Curl_cwriter_is_paused(data) && !Curl_creader_is_paused(data) &&
      Curl_conn_is_ip_connected(data, FIRSTSOCKET)) {
-    infof(data, "WARNING: no socket in pollset, transfer may stall!");
+    /* We expected sockets for POLL monitoring, but none are set.
+     * We are not waiting on any timer.
+     * None of the READ/WRITE directions are paused.
+     * We are connected to the server on IP level, at least. */
+    infof(data, "WARNING: no socket in pollset or timer, transfer may stall!");
     DEBUGASSERT(0);
   }
 }


### PR DESCRIPTION
Warn/assert about a possibly stalling transfer only when it has no timeout set.

The assertion triggered in test 1540 on loaded CI sometimes.