### PR TITLE
GHA/Windows: looking for 7-zip

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -558,7 +558,7 @@ jobs:
           echo '----------------------'
           PATH="/c/Program Files/7-Zip:$PATH"
           export VCPKG_FORCE_SYSTEM_BINARIES=1
-          vcpkg x-set-installed ${{ matrix.install }} --debug '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
+          vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
 
       - name: 'cmake configure'
         timeout-minutes: 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -552,7 +552,14 @@ jobs:
 
       - name: 'vcpkg build'
         timeout-minutes: 35
-        run: vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
+          echo '----------------------'
+          ls -lA '/c/Program Files/'
+          echo '----------------------'
+          ls -lA '/c/Program Files (x86)/'
+          echo '----------------------'
+          PATH="$PATH:/c/Program Files/7-Zip"
+          echo "${PATH}"
+          vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
 
       - name: 'cmake configure'
         timeout-minutes: 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -552,6 +552,7 @@ jobs:
 
       - name: 'vcpkg build'
         timeout-minutes: 35
+        run: |
           echo '----------------------'
           ls -lA '/c/Program Files/'
           echo '----------------------'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -554,13 +554,11 @@ jobs:
         timeout-minutes: 35
         run: |
           echo '----------------------'
-          ls -lA '/c/Program Files/'
+          find '/c/Program Files/7-Zip'
           echo '----------------------'
-          ls -lA '/c/Program Files (x86)/'
-          echo '----------------------'
-          PATH="$PATH:/c/Program Files/7-Zip"
-          echo "${PATH}"
-          vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
+          PATH="/c/Program Files/7-Zip:$PATH"
+          export VCPKG_FORCE_SYSTEM_BINARIES=1
+          vcpkg x-set-installed ${{ matrix.install }} --debug '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
 
       - name: 'cmake configure'
         timeout-minutes: 5


### PR DESCRIPTION
It's 10 wasted seconds and bandwidth in each vcpkg job.
edit: according to the debug log, that 10 seconds is spent on querying the cache too.

Still a waste because the GHA Windows runner machine comes with the exact same 7-zip version preinstalled. Adding it to path doesn't help. Apparently and open issue since 2022.

https://github.com/microsoft/vcpkg/issues/26844
https://github.com/microsoft/vcpkg/issues/39921
https://github.com/microsoft/vcpkg/issues/40408

```
Tue, 24 Sep 2024 13:03:31 GMT Additional packages (*) will be modified to complete this operation.
Tue, 24 Sep 2024 13:03:31 GMT A suitable version of 7zip was not found (required v24.8.0).
Tue, 24 Sep 2024 13:03:31 GMT Downloading https://github.com/ip7z/7zip/releases/download/24.08/7z2408-extra.7z
Tue, 24 Sep 2024 13:03:31 GMT Extracting 7zip...
Tue, 24 Sep 2024 13:03:39 GMT Restored 30 package(s) from GitHub Actions Cache in 7.4 s. Use --debug to see more details.
```
https://github.com/curl/curl/actions/runs/11014344980/job/30584761547#step:5:43

with `--debug`:
```
Tue, 24 Sep 2024 16:37:00 GMT Additional packages (*) will be modified to complete this operation.
Tue, 24 Sep 2024 16:37:00 GMT [DEBUG] Default binary cache path is: C:\Users\runneradmin\AppData\Local\vcpkg\archives
Tue, 24 Sep 2024 16:37:00 GMT A suitable version of 7zip was not found (required v24.8.0).
Tue, 24 Sep 2024 16:37:01 GMT [DEBUG] Trying to hash C:\vcpkg\downloads\7z2408-extra.7z.2848.part
Tue, 24 Sep 2024 16:37:01 GMT [DEBUG] C:\vcpkg\downloads\7z2408-extra.7z.2848.part has hash 35f55236fccfb576ca014e29d0c35f4a213e53f06683bd2e82f869ed02506e230c8dd623c01d0207244d6a997031f737903456b7ad4a44db1717f0a17a78602e
Tue, 24 Sep 2024 16:37:01 GMT Downloading https://github.com/ip7z/7zip/releases/download/24.08/7z2408-extra.7z
Tue, 24 Sep 2024 16:37:01 GMT Extracting 7zip...
Tue, 24 Sep 2024 16:37:01 GMT [DEBUG] 1007: CreateProcessW("C:\Program Files\CMake\bin\cmake.exe" -E tar xzf "C:\vcpkg\downloads\7z2408-extra.7z")
Tue, 24 Sep 2024 16:37:01 GMT [DEBUG] 1007: cmd_execute() returned 0 after 381718 us
Tue, 24 Sep 2024 16:37:01 GMT [DEBUG] 1008: CreateProcessW(curl -s -L -H "User-Agent: vcpkg/2024-08-01-fd884a0d390d12783076341bd43d77c3a6a15658 (curl)" -H "Content-Type: application/json" -H "Authorization: ***" -H "Accept: application/json;api-version=6.0-preview.1" -X GET "https://acghubeus2.actions.githubusercontent.com/LBtO2h2PnCINU7gm3jjmEjodUj2g1Be2AKcmGQDkydACxmcFgb/_apis/artifactcache/cache?keys=vcpkg-cmake-751d986d83d7625af22141204ac9aa43a8b8bfdd3a67b1a10053c71661f3c970&version=751d986d83d7625af22141204ac9aa43a8b8bfdd3a67b1a10053c71661f3c970")
[...]
Tue, 24 Sep 2024 16:37:09 GMT [DEBUG] 1039: CreateProcessW("C:\vcpkg\downloads\tools\7zip-24.08-windows\7za.exe" x "C:\vcpkg\buildtrees\vcpkg-cmake\x64-windows.zip" "-oC:\vcpkg\packages\vcpkg-cmake_x64-windows" -y)
Tue, 24 Sep 2024 16:37:09 GMT [DEBUG] 1040: CreateProcessW("C:\vcpkg\downloads\tools\7zip-24.08-windows\7za.exe" x "C:\vcpkg\buildtrees\vcpkg-cmake-config\x64-windows.zip" "-oC:\vcpkg\packages\vcpkg-cmake-config_x64-windows" -y)
Tue, 24 Sep 2024 16:37:09 GMT [DEBUG] 1040: cmd_execute_and_stream_data() returned 0 after    30090 us
Tue, 24 Sep 2024 16:37:09 GMT [DEBUG] 1039: cmd_execute_and_stream_data() returned 0 after    31108 us
```
https://github.com/curl/curl/actions/runs/11018088046/job/30597580863#step:5:1547