### PR TITLE
build: clarify CA embed is for curl tool, mark default, improve summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1274,7 +1274,7 @@ if(_curl_ca_bundle_supported)
   set(CURL_CA_PATH "auto" CACHE
     STRING "Location of default CA path. Set 'none' to disable or 'auto' for auto-detection. Defaults to 'auto'.")
   set(CURL_CA_EMBED "" CACHE
-    STRING "Path to the CA bundle to embed into the curl tool.")
+    STRING "Path to the CA bundle to embed in the curl tool.")
 
   if(CURL_CA_BUNDLE STREQUAL "")
     message(FATAL_ERROR "Invalid value of CURL_CA_BUNDLE. Use 'none', 'auto' or file path.")

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1344,12 +1344,12 @@ dnl Check if a ca-bundle should be embedded
 
 AC_DEFUN([CURL_CHECK_CA_EMBED], [
 
-  AC_MSG_CHECKING([CA cert bundle path to embed])
+  AC_MSG_CHECKING([CA cert bundle path to embed in the curl tool])
 
   AC_ARG_WITH(ca-embed,
 AS_HELP_STRING([--with-ca-embed=FILE],
-  [Absolute path to a file containing CA certificates (example: /etc/ca-bundle.crt)])
-AS_HELP_STRING([--without-ca-embed], [Don't embed a default CA bundle]),
+  [Absolute path to a file containing CA certificates to embed in the curl tool (example: /etc/ca-bundle.crt)])
+AS_HELP_STRING([--without-ca-embed], [Don't embed a default CA bundle in the curl tool]),
   [
     want_ca_embed="$withval"
     if test "x$want_ca_embed" = "xyes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -5208,6 +5208,9 @@ if test "x$want_curldebug" = "xyes"; then
 fi
 if test "x$CURL_CA_EMBED" != "x"; then
   SUPPORT_FEATURES="$SUPPORT_FEATURES CAcert"
+  CURL_CA_EMBED_msg="$CURL_CA_EMBED"
+else
+  CURL_CA_EMBED_msg='no'
 fi
 
 dnl replace spaces with newlines
@@ -5410,7 +5413,7 @@ AC_MSG_NOTICE([Configured to build curl/libcurl:
   SSPI:             ${curl_sspi_msg}
   ca cert bundle:   ${ca}${ca_warning}
   ca cert path:     ${capath}${capath_warning}
-  ca cert embed:    ${CURL_CA_EMBED}
+  ca cert embed:    ${CURL_CA_EMBED_msg}
   ca fallback:      ${with_ca_fallback}
   LDAP:             ${curl_ldap_msg}
   LDAPS:            ${curl_ldaps_msg}


### PR DESCRIPTION
- say that CA embed is for the curl tool.
- show "no" in summary when there is no CA embed.
- cmake: sync wording.
