### PR TITLE
build: fix cross-compile check for poll with bionic

### DIFF
--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -95,7 +95,8 @@ if(NOT APPLE)
       #include <stdlib.h>
       int main(void)
       {
-        #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+        #if defined(__BIONIC__) || \
+          defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
           (void)poll(0, 0, 0);
         #else
           #error force compilation error

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3497,7 +3497,8 @@ AC_DEFUN([CURL_CHECK_FUNC_POLL], [
         AC_LANG_PROGRAM([[
           $curl_includes_stdlib
         ]],[[
-          #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
+          #if defined(__BIONIC__) || \
+            (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L)
             return 0;
           #else
             #error force compilation error


### PR DESCRIPTION
Since it seems the _POSIX_C_SOURCE "trick" does not work there, the check does not find poll().

Fixes #15013
Reported-by: vvb2060 on github