### PR TITLE
curl-config.in: Don't surround CA path with quotes

### DIFF
--- a/curl-config.in
+++ b/curl-config.in
@@ -71,7 +71,7 @@ while test "$#" -gt 0; do
     ;;
 
   --ca)
-    echo '@CURL_CA_BUNDLE@'
+    echo @CURL_CA_BUNDLE@
     ;;
 
   --cc)


### PR DESCRIPTION
Closes #15041