### PR TITLE
lib/cw-out: initialize 'flush_all' directly

### DIFF
--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -402,9 +402,8 @@ static CURLcode cw_out_write(struct Curl_easy *data,
 {
   struct cw_out_ctx *ctx = writer->ctx;
   CURLcode result;
-  bool flush_all;
+  bool flush_all = !!(type & CLIENTWRITE_EOS);
 
-  flush_all = (type & CLIENTWRITE_EOS) ? TRUE : FALSE;
   if((type & CLIENTWRITE_BODY) ||
      ((type & CLIENTWRITE_HEADER) && data->set.include_header)) {
     result = cw_out_do_write(ctx, data, CW_OUT_BODY, flush_all, buf, blen);


### PR DESCRIPTION
Similar to:
https://github.com/curl/curl/blob/da94b0237260f2fbc149f880c00c24a90fb7c5af/lib/sendf.c#L243