### PR TITLE
test504, fix handling on pending connect

### DIFF
--- a/tests/libtest/lib504.c
+++ b/tests/libtest/lib504.c
@@ -72,6 +72,21 @@ CURLcode test(char *URL)
 
     multi_perform(m, &running);
 
+    while(running) {
+      CURLMcode mres;
+      int num;
+      mres = curl_multi_wait(m, NULL, 0, TEST_HANG_TIMEOUT, &num);
+      if(mres != CURLM_OK) {
+        printf("curl_multi_wait() returned %d\n", mres);
+        res = TEST_ERR_MAJOR_BAD;
+        goto test_cleanup;
+      }
+
+      abort_on_test_timeout();
+      multi_perform(m, &running);
+      abort_on_test_timeout();
+    }
+
     abort_on_test_timeout();
 
     if(!running) {


### PR DESCRIPTION
Test expected a connect to a port no one is listening to immediately fail. But Windows has its internal retry logic that may fail this.

As fix, multi_perform()/multi_wait() until transfer is done.