### PR TITLE
test190: replace %FTPTIME2 with a fixed value

### DIFF
--- a/tests/data/test190
+++ b/tests/data/test190
@@ -27,7 +27,7 @@ ftp
 FTP download with strict timeout and slow CWD
 </name>
 <command>
-ftp://%HOSTIP:%FTPPORT/path/to/file/%TESTNUMBER -m %FTPTIME2
+ftp://%HOSTIP:%FTPPORT/path/to/file/%TESTNUMBER -m 10
 </command>
 </client>
 


### PR DESCRIPTION
The variable FTPTIME2 may, on a loaded test server, become so large that the timeout does not happen before the fixed 60 seconds the server waits.