### PR TITLE
testrunner: http/2 and http/3 server

### DIFF
--- a/tests/data/test1700
+++ b/tests/data/test1700
@@ -42,7 +42,6 @@ Content-Type: text/html
 h2c
 </features>
 <server>
-http
 http/2
 </server>
 <name>

--- a/tests/data/test1701
+++ b/tests/data/test1701
@@ -33,7 +33,6 @@ Funny-head: yesyes
 h2c
 </features>
 <server>
-http
 http/2
 </server>
 <name>

--- a/tests/data/test1702
+++ b/tests/data/test1702
@@ -32,7 +32,6 @@ Funny-head: yesyes
 h2c
 </features>
 <server>
-http
 http/2
 </server>
 <name>

--- a/tests/data/test2401
+++ b/tests/data/test2401
@@ -30,7 +30,6 @@ h2c
 SSL
 </features>
 <server>
-http
 http/2
 </server>
 <name>

--- a/tests/data/test2402
+++ b/tests/data/test2402
@@ -51,7 +51,6 @@ h2c
 SSL
 </features>
 <server>
-http
 http/2
 </server>
 <tool>

--- a/tests/data/test2403
+++ b/tests/data/test2403
@@ -34,7 +34,6 @@ SSL
 headers-api
 </features>
 <server>
-http
 http/2
 </server>
 <name>

--- a/tests/data/test2404
+++ b/tests/data/test2404
@@ -51,7 +51,6 @@ h2c
 SSL
 </features>
 <server>
-http
 http/2
 </server>
 <tool>

--- a/tests/data/test2405
+++ b/tests/data/test2405
@@ -29,7 +29,6 @@ Funny-head: yesyes
 # Client-side
 <client>
 <server>
-http
 http/2
 </server>
 <tool>

--- a/tests/data/test2406
+++ b/tests/data/test2406
@@ -32,7 +32,6 @@ h2c
 SSL
 </features>
 <server>
-http
 http/2
 </server>
 <name>

--- a/tests/data/test2500
+++ b/tests/data/test2500
@@ -33,7 +33,6 @@ http/3
 nghttpx-h3
 </features>
 <server>
-http
 http/3
 </server>
 <name>

--- a/tests/data/test2501
+++ b/tests/data/test2501
@@ -30,7 +30,6 @@ http
 http/3
 </features>
 <server>
-http
 http/3
 </server>
 <name>

--- a/tests/data/test2502
+++ b/tests/data/test2502
@@ -50,7 +50,6 @@ file contents should appear once for each file
 http/3
 </features>
 <server>
-http
 http/3
 </server>
 <tool>

--- a/tests/data/test2503
+++ b/tests/data/test2503
@@ -33,7 +33,6 @@ nghttpx-h3
 headers-api
 </features>
 <server>
-http
 http/3
 </server>
 <name>


### PR DESCRIPTION
Check responsiveness of http/3 server when running.

Also, a test case with http/2 or http/3 server requirement now implicitly drags in a 'http' server and we need no longer mention that in testdata.