### PR TITLE
tests: use '-4' where needed

### DIFF
--- a/tests/data/test2033
+++ b/tests/data/test2033
@@ -40,7 +40,7 @@ simple HTTPS GET with DER public key pinning (Schannel variant)
 CURL_SSL_BACKEND=schannel
  </setenv>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.der --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.der --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2034
+++ b/tests/data/test2034
@@ -36,7 +36,7 @@ https Server-localhost-sv.pem
 simple HTTPS GET with DER public key pinning
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.der https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.der https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2035
+++ b/tests/data/test2035
@@ -27,7 +27,7 @@ https Server-localhost-sv.pem
 HTTPS wrong DER pinnedpubkey but right CN
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.der https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.der https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2037
+++ b/tests/data/test2037
@@ -36,7 +36,7 @@ https Server-localhost-sv.pem
 simple HTTPS GET with PEM public key pinning
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.pem https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.pem https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2038
+++ b/tests/data/test2038
@@ -27,7 +27,7 @@ https Server-localhost-sv.pem
 HTTPS wrong PEM pinnedpubkey but right CN
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pem https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pem https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2041
+++ b/tests/data/test2041
@@ -36,7 +36,7 @@ https Server-localhost-sv.pem
 simple HTTPS GET with base64-sha256 public key pinning
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey sha256//%sha256b64file[%SRCDIR/certs/Server-localhost-sv.pub.der]sha256b64file% https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey sha256//%sha256b64file[%SRCDIR/certs/Server-localhost-sv.pub.der]sha256b64file% https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2042
+++ b/tests/data/test2042
@@ -27,7 +27,7 @@ https Server-localhost-sv.pem
 HTTPS wrong base64-sha256 pinnedpubkey but right CN
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey sha256//bSIggTf+ikMG0CtmDlpMVBd7yi7H1md4URogRPqerso= https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey sha256//bSIggTf+ikMG0CtmDlpMVBd7yi7H1md4URogRPqerso= https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2048
+++ b/tests/data/test2048
@@ -26,7 +26,7 @@ https Server-localhost-sv.pem
 pinnedpubkey no-match must fail even when insecure
 </name>
 <command>
---insecure --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost.nn-sv.pub.der https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --insecure --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost.nn-sv.pub.der https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2070
+++ b/tests/data/test2070
@@ -39,7 +39,7 @@ Ignore certificate revocation "best effort" strategy
 CURL_SSL_BACKEND=schannel
  </setenv>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2079
+++ b/tests/data/test2079
@@ -40,7 +40,7 @@ simple HTTPS GET with PEM public key pinning (Schannel variant)
 CURL_SSL_BACKEND=schannel
  </setenv>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.pem --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey %SRCDIR/certs/Server-localhost-sv.pub.pem --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test2087
+++ b/tests/data/test2087
@@ -40,7 +40,7 @@ simple HTTPS GET with base64-sha256 public key pinning (Schannel variant)
 CURL_SSL_BACKEND=schannel
  </setenv>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey sha256//%sha256b64file[%SRCDIR/certs/Server-localhost-sv.pub.der]sha256b64file% --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --pinnedpubkey sha256//%sha256b64file[%SRCDIR/certs/Server-localhost-sv.pub.der]sha256b64file% --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test3000
+++ b/tests/data/test3000
@@ -35,7 +35,7 @@ https Server-localhost-firstSAN-sv.pem
 HTTPS GET to localhost, first subject alt name matches, CN does not match
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test3001
+++ b/tests/data/test3001
@@ -35,7 +35,7 @@ https Server-localhost-lastSAN-sv.pem
 HTTPS GET to localhost, last subject alt name matches, CN does not match
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test3023
+++ b/tests/data/test3023
@@ -39,7 +39,7 @@ HTTPS GET to localhost, first subject alt name matches, CN does not match (Schan
 CURL_SSL_BACKEND=schannel
 </setenv>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test3024
+++ b/tests/data/test3024
@@ -39,7 +39,7 @@ HTTPS GET to localhost, last subject alt name matches, CN does not match (Schann
 CURL_SSL_BACKEND=schannel
 </setenv>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --ssl-revoke-best-effort https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test310
+++ b/tests/data/test310
@@ -35,7 +35,7 @@ https Server-localhost-sv.pem
 simple HTTPS GET
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test311
+++ b/tests/data/test311
@@ -26,7 +26,7 @@ https Server-localhost0h-sv.pem
 HTTPS wrong subjectAltName but right CN
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test312
+++ b/tests/data/test312
@@ -26,7 +26,7 @@ https Server-localhost.nn-sv.pem
 HTTPS GET to localhost and null-prefixed CN cert
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test313
+++ b/tests/data/test313
@@ -22,7 +22,7 @@ https Server-localhost-sv.pem
 CRL test
 </name>
 <command>
---cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --crlfile %SRCDIR/certs/Server-localhost-sv.crl https://localhost:%HTTPSPORT/%TESTNUMBER
+-4 --cacert %SRCDIR/certs/EdelCurlRoot-ca.crt --crlfile %SRCDIR/certs/Server-localhost-sv.crl https://localhost:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test389
+++ b/tests/data/test389
@@ -38,7 +38,7 @@ local-http
 *.localhost is a local host
 </name>
 <command>
-http://curlmachine.localhost:%HTTPPORT/%TESTNUMBER
+-4 http://curlmachine.localhost:%HTTPPORT/%TESTNUMBER
 </command>
 # Ensure that we're running on localhost
 </client>

--- a/tests/data/test392
+++ b/tests/data/test392
@@ -35,7 +35,7 @@ HTTP secure cookies over localhost
 TZ=GMT
 </setenv>
 <command>
-http://localhost:%HTTPPORT/%TESTNUMBER -b none http://localhost:%HTTPPORT/%TESTNUMBER
+-4 http://localhost:%HTTPPORT/%TESTNUMBER -b none http://localhost:%HTTPPORT/%TESTNUMBER
 </command>
 <features>
 cookies


### PR DESCRIPTION
Our test servers run either on ipv4 *or* on ipv6, as requested. A test case using 'localhost' or '*.local' in the url needs to run with the specific version of the server started.

Otherwise, curl's "happy eyeball"ing will connect to another server that may be running due to parallel testing or for some other reasons.

Note that port reuse here depends on the OS strategy and it seems netbsd is especially likely to hit this.