### PR TITLE
test518: restore valgrind disable

### DIFF
--- a/tests/data/test518
+++ b/tests/data/test518
@@ -60,5 +60,8 @@ Host: %HOSTIP:%HTTPPORT
 Accept: */*
 
 </protocol>
+<valgrind>
+disable
+</valgrind>
 </verify>
 </testcase>


### PR DESCRIPTION
The test does not work well when run with valgrind