### PR TITLE
CI: update 32-bit CI to Ubuntu 24.04 and enable more

### DIFF
--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -45,15 +45,15 @@ env:
 jobs:
   linux-i686:
     name: ${{ matrix.build.name }}
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-24.04'
     timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         build:
           - name: Linux i686
-            install_packages: gcc-11-i686-linux-gnu libssl-dev:i386 zlib1g-dev:i386 libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386
-            configure: --enable-debug --enable-websockets --with-openssl --host=i686-linux-gnu CC=i686-linux-gnu-gcc-11 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig CPPFLAGS=-I/usr/include/i386-linux-gnu LDFLAGS=-L/usr/lib/i386-linux-gnu
+            install_packages: gcc-14-i686-linux-gnu libssl-dev:i386 librtmp-dev:i386 libssh2-1-dev:i386 libidn2-0-dev:i386 libc-ares-dev:i386 zlib1g-dev:i386 libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386
+            configure: --enable-debug --enable-websockets --with-openssl --with-librtmp --with-libssh2 --with-libidn2 --enable-ares --host=i686-linux-gnu CC=i686-linux-gnu-gcc-14 PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig CPPFLAGS=-I/usr/include/i386-linux-gnu LDFLAGS=-L/usr/lib/i386-linux-gnu
 
     steps:
       - run: |
@@ -61,7 +61,7 @@ jobs:
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends libtool autoconf automake pkgconf stunnel4 ${{ matrix.build.install_packages }}
-          sudo python3 -m pip install impacket
+          sudo python3 -m pip install --break-system-packages impacket
         name: 'install prereqs'
 
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4


### PR DESCRIPTION
Enable librtmp, libssh, libidn2 and c-ares support for broader test
coverage. Bump the gcc version to 14.

Closes #15068