### PR TITLE
singleuse: make run faster, add Apple `nm` support

### DIFF
--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -152,7 +152,7 @@ my %api = (
 
 sub doublecheck {
     my ($f, $used) = @_;
-    open(F, "git grep -le '$f\\W' -- lib ${unittests}packages|");
+    open(F, "git grep -Fwle '$f' -- lib ${unittests}packages|");
     my @also;
     while(<F>) {
         my $e = $_;

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -180,13 +180,17 @@ while (<N>) {
     if($l =~ /^([0-9a-z_-]+)\.o:/) {
         $file = $1;
     }
-    if($l =~ /^([0-9a-f]+) T (.*)/) {
+    # libcurl.a(unity_0_c.c.o):
+    elsif($l =~ /\(([0-9a-z_.-]+)\.o\):/) {  # Apple nm
+        $file = $1;
+    }
+    if($l =~ /^([0-9a-f]+) T _?(.*)/) {
         my ($name)=($2);
         #print "Define $name in $file\n";
         $file =~ s/^libcurl_la-//;
         $exist{$name} = $file;
     }
-    elsif($l =~ /^                 U (.*)/) {
+    elsif($l =~ /^                 U _?(.*)/) {
         my ($name)=($1);
         #print "Uses $name in $file\n";
         $uses{$name} .= "$file, ";


### PR DESCRIPTION
- avoid regexp in grep to make it run faster.
- add support for parsing Apple `nm` output.
  - skip leading underscore from function names.
  - pick object name correctly.
