### PR TITLE
cmake: websockets tidy-ups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1608,8 +1608,6 @@ endif()
 
 unset(CMAKE_REQUIRED_FLAGS)
 
-option(ENABLE_WEBSOCKETS "Enable WebSockets (experimental)" OFF)
-
 curl_internal_test(HAVE_GLIBC_STRERROR_R)
 curl_internal_test(HAVE_POSIX_STRERROR_R)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1610,12 +1610,8 @@ unset(CMAKE_REQUIRED_FLAGS)
 
 option(ENABLE_WEBSOCKETS "Enable WebSockets (experimental)" OFF)
 
-foreach(_curl_test IN ITEMS
-    HAVE_GLIBC_STRERROR_R
-    HAVE_POSIX_STRERROR_R
-    )
-  curl_internal_test(${_curl_test})
-endforeach()
+curl_internal_test(HAVE_GLIBC_STRERROR_R)
+curl_internal_test(HAVE_POSIX_STRERROR_R)
 
 # Check for reentrant
 foreach(_curl_test IN ITEMS


### PR DESCRIPTION
- restore change lost after websockets-default update.
  Ref: 6a1dcdc5d2f1b450de4d10739660b32d081c51a1 #14998
- delete unused line after websockets is on by default.
  Follow-up to d78e129d50b2d190f1c1bde2ad1f62f02f152db0 #14936
