### PR TITLE
ci: tidy-ups

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -95,4 +95,4 @@ jobs:
       - name: badwords
         run: |
           grep -Ev '(\\bwill| url | dir )' .github/scripts/badwords.txt | \
-          .github/scripts/badwords.pl `git ls-files -- src lib include`
+          .github/scripts/badwords.pl $(git ls-files -- src lib include)

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -93,6 +93,6 @@ jobs:
 
       # we allow some extra in source code
       - name: badwords
-        run: >
-          grep -Ev '(\\bwill| url | dir )' .github/scripts/badwords.txt |
+        run: |
+          grep -Ev '(\\bwill| url | dir )' .github/scripts/badwords.txt | \
           .github/scripts/badwords.pl `git ls-files -- src lib include`

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -166,7 +166,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 1
         run: |
-          find . -name '*.exe' -o -name '*.dll' | grep -v '/examples/'
+          find . -name '*.exe' -o -name '*.dll'
           PATH="$PWD/bld/lib:$PATH"
           bld/src/curl.exe --disable --version
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -469,7 +469,7 @@ jobs:
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
 
-      - run: pytest -v tests/http
+      - run: make pytest-ci
         name: 'run pytest'
         env:
           TFLAGS: "${{ matrix.build.tflags }}"

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -266,18 +266,21 @@ jobs:
               --with-ngtcp2=$HOME/ngtcp2/build --enable-warnings --enable-werror --enable-debug --disable-ntlm
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-openssl=$HOME/quictls/build
+
           - name: gnutls
             configure: >-
               PKG_CONFIG_PATH="$HOME/gnutls/build/lib/pkgconfig:$HOME/nghttp3/build/lib/pkgconfig:$HOME/ngtcp2/build/lib/pkgconfig:$HOME/nghttp2/build/lib/pkgconfig" LDFLAGS="-Wl,-rpath,$HOME/gnutls/build/lib"
               --with-ngtcp2=$HOME/ngtcp2/build --enable-warnings --enable-werror --enable-debug
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-gnutls=$HOME/gnutls/build
+
           - name: wolfssl
             configure: >-
               PKG_CONFIG_PATH="$HOME/wolfssl/build/lib/pkgconfig:$HOME/nghttp3/build/lib/pkgconfig:$HOME/ngtcp2/build/lib/pkgconfig:$HOME/nghttp2/build/lib/pkgconfig" LDFLAGS="-Wl,-rpath,$HOME/wolfssl/build/lib"
               --with-ngtcp2=$HOME/ngtcp2/build --enable-warnings --enable-werror --enable-debug
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-wolfssl=$HOME/wolfssl/build
+
           - name: openssl-quic
             configure: >-
               PKG_CONFIG_PATH="$HOME/openssl3/build/lib64/pkgconfig" LDFLAGS="-Wl,-rpath,$HOME/openssl3/build/lib64"
@@ -285,6 +288,7 @@ jobs:
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-openssl=$HOME/openssl3/build --with-openssl-quic
               --with-nghttp3=$HOME/nghttp3/build
+
           - name: quiche
             configure: >-
               LDFLAGS="-Wl,-rpath,/home/runner/quiche/target/release"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -161,7 +161,7 @@ jobs:
 
           - name: openssl3 https-only
             install_steps: gcc-11 openssl3
-            configure: >
+            configure: >-
               LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --disable-unity
               --disable-dict --disable-gopher --disable-ldap --disable-telnet
               --disable-imap --disable-pop3 --disable-smtp
@@ -182,7 +182,7 @@ jobs:
           - name: address-sanitizer
             install_packages: zlib1g-dev libssh2-1-dev clang libssl-dev libubsan1 libasan8 libtsan2
             install_steps: pytest
-            configure: >
+            configure: >-
               CC=clang
               CFLAGS="-fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g"
               LDFLAGS="-fsanitize=address,undefined -fno-sanitize-recover=undefined,integer"
@@ -192,7 +192,7 @@ jobs:
           - name: thread-sanitizer
             install_packages: zlib1g-dev clang libtsan2
             install_steps: pytest openssltsan3
-            configure: >
+            configure: >-
               CC=clang
               CFLAGS="-fsanitize=thread -g"
               LDFLAGS="-fsanitize=thread -Wl,-rpath,$HOME/openssl3/lib"
@@ -200,7 +200,7 @@ jobs:
 
           - name: memory-sanitizer
             install_packages: clang
-            configure: >
+            configure: >-
               CC=clang
               CFLAGS="-fsanitize=memory -Wformat -Werror=format-security -Werror=array-bounds -g"
               LDFLAGS="-fsanitize=memory"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -479,7 +479,7 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >
+            config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
               -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
@@ -490,7 +490,7 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >
+            config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
               -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
@@ -501,7 +501,7 @@ jobs:
             plat: 'uwp'
             type: 'Debug'
             tflags: 'skiprun'
-            config: >
+            config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
               -DCURL_USE_LIBPSL=OFF
@@ -512,7 +512,7 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >
+            config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
               -DCURL_CA_SEARCH_SAFE=ON
@@ -523,7 +523,7 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >
+            config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
               -DUSE_HTTPSRR=ON -DUSE_ECH=ON
@@ -534,7 +534,7 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516'
-            config: >
+            config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
               -DCURL_USE_GSASL=ON
@@ -549,7 +549,7 @@ jobs:
             #          read its configuration from, making it vulnerable to attacks on
             #          Windows. Do not use this component till there is a fix for these.
             # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
-            config: >
+            config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_GNUTLS=ON -DUSE_NGTCP2=ON
               -DCURL_USE_GSASL=ON
@@ -560,7 +560,7 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             tflags: 'skipall'
-            config: >
+            config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DUSE_MSH3=ON
               -DCURL_USE_GSASL=ON


### PR DESCRIPTION
- http3-linux: add newlines for readability.
- http3-linux: use `make pytest` to run pytest.
- checksrc: use `|` multiline to sync with other uses.
- checksrc: prefer `$()`.
- prefer `>-` over `>` for folded option lists.
- cygwin: drop a `grep` no longer necessary.
