### PR TITLE
GHA linux: restore `apt-get update`

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -160,6 +160,8 @@ jobs:
       - name: install build prerequisites
         if: steps.settings.outputs.needs-build == 'true'
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update -y
           sudo apt-get install libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
@@ -294,6 +296,8 @@ jobs:
 
     steps:
       - run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update -y
           sudo apt-get install libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -245,6 +245,8 @@ jobs:
     steps:
       - if: matrix.build.container == null
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update -y
           sudo apt-get install libtool autoconf automake ninja-build pkgconf stunnel4 libpsl-dev libbrotli-dev libzstd-dev \
             ${{ matrix.build.install_packages }}
           sudo python3 -m pip install impacket
@@ -267,6 +269,7 @@ jobs:
 
       - if: contains(matrix.build.install_steps, 'gcc-11')
         run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
           sudo apt-get update
           sudo apt-get install gcc-11


### PR DESCRIPTION
It seems like the Ubuntu apt mirror list or other preloaded data on the
Linux runner can go stale (?) throughout a single week causing failures
like this, in some of the jobs:
```
Ign:16 http://security.ubuntu.com/ubuntu jammy-updates/main amd64 libapr1-dev amd64 1.7.0-8ubuntu0.22.04.1
Err:16 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/main amd64 libapr1-dev amd64 1.7.0-8ubuntu0.22.04.1
  404  Not Found [IP: 40.81.13.82 80]
Get:24 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 libnghttp2-dev amd64 1.43.0-1ubuntu0.2 [117 kB]
Get:25 http://azure.archive.ubuntu.com/ubuntu jammy-updates/main amd64 vsftpd amd64 3.0.5-0ubuntu1.1 [123 kB]
Fetched 4029 kB in 2s (1682 kB/s)
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/a/apr/libapr1-dev_1.7.0-8ubuntu0.22.04.1_amd64.deb  404  Not Found [IP: 40.81.13.82 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```
https://github.com/curl/curl/actions/runs/11074211380/job/30772496037#step:32:63

Restore `apt update` to fix it.

Follow-up to 1b8449674adb57ee0f60e761d654c69b20ee8fcf #14992
