### PR TITLE
GHA/cygwin, msys: move tests to cmake jobs, to finish faster

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -128,11 +128,6 @@ jobs:
           fi
           make -C bld -j5 V=1 test-ci
 
-      - name: 'autotools build examples'
-        if: ${{ matrix.build == 'automake' }}
-        timeout-minutes: 5
-        run: make -C bld -j5 V=1 examples
-
       - name: 'cmake configure'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 5

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -48,8 +48,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'automake', platform: 'x86_64', tflags: ''       , config: '--enable-debug --disable-threaded-resolver', name: 'openssl' }
-          - { build: 'cmake'   , platform: 'x86_64', tflags: 'skiprun', config: '-DCURL_USE_OPENSSL=ON', name: 'openssl R' }
+          - { build: 'automake', platform: 'x86_64', tflags: 'skiprun', config: '', name: 'openssl R' }
+          - { build: 'cmake'   , platform: 'x86_64', tflags: ''       , config: '-DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'openssl' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -165,7 +165,7 @@ jobs:
           make -C bld -j5 V=1 test-ci
 
       - name: 'autotools build examples'
-        if: ${{ matrix.build == 'autotools' }}
+        if: ${{ matrix.build == 'autotools' && (matrix.tflags == 'skipall' || matrix.tflags == 'skiprun') }}
         timeout-minutes: 5
         run: make -C bld -j5 V=1 examples
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -47,8 +47,8 @@ jobs:
       matrix:
         include:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy', name: '!proxy' }
-          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver', name: 'default' }
-          - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver', name: 'default' }
+          - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '', name: 'default R' }
           - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver --disable-curldebug --enable-static=no --without-zlib', name: 'default' }
           - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: '~472 ~1299 ~1613'        , config: '--enable-debug --enable-windows-unicode --enable-ares', name: 'c-ares U' }


### PR DESCRIPTION
Move test runs from autotools jobs to cmake ones for Cygwin and MSYS.
This makes producing test results and finishing the workflows faster,
because the cmake build steps are much faster than autotools in these
envs.

Also:
- drop building examples with Cygwin autotools. It takes almost
  4 minutes. Keep building them with cmake, taking 20 seconds.
- drop building examples in MSYS autotools jobs that run tests.
  Keep building them in autotools jobs without tests. It makes
  the longest running job 2 minutes shorter.

After this patch Cygwin job times are on par with or lower than Windows
ones. It means Cygwin doesn't cause extra delay to finish the whole
workflow, allowing to re-merge these jobs into the Windows workflow.
