### PR TITLE
cmake: readd `generate-curl.1` dependency for `src` just in case

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
     COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl" -c < "${CURL_ASCIIPAGE}" >> "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#endif /* HAVE_LIBZ */" >> "tool_hugehelp.c"
     DEPENDS
+      generate-curl.1
       "${CMAKE_CURRENT_SOURCE_DIR}/mkhelp.pl"
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
       "${CURL_ASCIIPAGE}"


### PR DESCRIPTION
Trying to fix intermittent build failures with MSVC 2008:
```
unity_0.obj : error LNK2019: unresolved external symbol _showhelp referenced in function _tool_help
unity_0.obj : error LNK2019: unresolved external symbol _hugehelp referenced in function _operate
```
https://ci.appveyor.com/project/curlorg/curl/builds/50700212/job/h3ekljnbccosej5k#L154 https://ci.appveyor.com/project/curlorg/curl/builds/50701615/job/61mkg9og1eooqli8#L155

Follow-up to 496da69aa0eb988ac92eb815742eb89b975ad83e #14883