### PR TITLE
tests: add and use `%PERL` variable to refer to the Perl binary

### DIFF
--- a/tests/data/test1026
+++ b/tests/data/test1026
@@ -33,7 +33,7 @@ curl --manual
 # Search for these two sentinel lines in the manual output; if they are found,
 # then chances are good the entire manual is there.
 <postcheck>
-perl -e 'open(IN,$ARGV[0]); my $lines=grep(/(curl\s*-\s*transfer\sa\s*URL)|(AUTHORS)/, <IN>); exit ($lines != 2); # Let this file pass an XML syntax check: </IN>' %LOGDIR/stdout%TESTNUMBER
+%PERL -e 'open(IN,$ARGV[0]); my $lines=grep(/(curl\s*-\s*transfer\sa\s*URL)|(AUTHORS)/, <IN>); exit ($lines != 2); # Let this file pass an XML syntax check: </IN>' %LOGDIR/stdout%TESTNUMBER
 </postcheck>
 <errorcode>
 0

--- a/tests/data/test1027
+++ b/tests/data/test1027
@@ -33,7 +33,7 @@ curl --help
 # Search for these two sentinel lines in the help output; if they are found,
 # then chances are good the entire help is there.
 <postcheck>
-perl -e 'open(IN,$ARGV[0]); my $lines=grep(/(Usage: curl )|(--version\s*Show version)/, <IN>); exit ($lines != 2); # Let this file pass an XML syntax check: </IN>' %LOGDIR/stdout%TESTNUMBER
+%PERL -e 'open(IN,$ARGV[0]); my $lines=grep(/(Usage: curl )|(--version\s*Show version)/, <IN>); exit ($lines != 2); # Let this file pass an XML syntax check: </IN>' %LOGDIR/stdout%TESTNUMBER
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test1056
+++ b/tests/data/test1056
@@ -62,7 +62,7 @@ HTTP follow redirect from IPv4 to IPv6 with scope
 http://%HOSTIP:%HTTPPORT/we/are/all/twits/%TESTNUMBER -L
 </command>
 <precheck>
-perl -e "print 'Test is not supported on the Windows kernel' if ($^O eq 'MSWin32' || $^O eq 'msys' || $^O eq 'cygwin');"
+%PERL -e "print 'Test is not supported on the Windows kernel' if ($^O eq 'MSWin32' || $^O eq 'msys' || $^O eq 'cygwin');"
 </precheck>
 </client>
 

--- a/tests/data/test1082
+++ b/tests/data/test1082
@@ -35,7 +35,7 @@ HTTP GET with localhost --interface
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -4 --interface 127.0.0.1
 </command>
 <precheck>
-perl -e "print 'Test requires default test client host address' if ( '%CLIENTIP' ne '127.0.0.1' );"
+%PERL -e "print 'Test requires default test client host address' if ( '%CLIENTIP' ne '127.0.0.1' );"
 </precheck>
 </client>
 

--- a/tests/data/test1083
+++ b/tests/data/test1083
@@ -39,7 +39,7 @@ HTTP-IPv6 GET with ip6-localhost --interface
 -g "http://%HOST6IP:%HTTP6PORT/%TESTNUMBER" --interface ip6-localhost
 </command>
 <precheck>
-perl -e "if ('%CLIENT6IP' ne '[::1]') {print 'Test requires default test client host address';} else {exec './server/resolve --ipv6 ip6-localhost'; print 'Cannot run precheck resolve';}"
+%PERL -e "if ('%CLIENT6IP' ne '[::1]') {print 'Test requires default test client host address';} else {exec './server/resolve --ipv6 ip6-localhost'; print 'Cannot run precheck resolve';}"
 </precheck>
 </client>
 

--- a/tests/data/test1158
+++ b/tests/data/test1158
@@ -32,7 +32,7 @@ HTTP RFC1867-type formposting with filename containing '"'
 http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F "file=@\"%LOGDIR/test%TESTNUMBER\\\".txt\";type=mo/foo;filename=\"test%TESTNUMBER\\\".txt\"" -F 'file2=@"%LOGDIR/test%TESTNUMBER\".txt"' -F 'file3=@"%LOGDIR/test%TESTNUMBER\".txt";type=m/f,"%LOGDIR/test%TESTNUMBER\".txt"'
 </command>
 <precheck>
-perl -e "print 'Test requires a system supporting double quotes in file names' if ($^O eq 'msys');"
+%PERL -e "print 'Test requires a system supporting double quotes in file names' if ($^O eq 'msys');"
 </precheck>
 # We create this file before the command is invoked!
 <file name=%LOGDIR/test%TESTNUMBER".txt>

--- a/tests/data/test1186
+++ b/tests/data/test1186
@@ -32,7 +32,7 @@ Multipart formposting with backslash-escaping filename containing '"'
 http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER --form-escape -F "file=@\"%LOGDIR/test%TESTNUMBER\\\".txt\";type=mo/foo;filename=\"test%TESTNUMBER\\\".txt\"" -F 'file2=@"%LOGDIR/test%TESTNUMBER\".txt"' -F 'file3=@"%LOGDIR/test%TESTNUMBER\".txt";type=m/f,"%LOGDIR/test%TESTNUMBER\".txt"'
 </command>
 <precheck>
-perl -e "print 'Test requires a system supporting double quotes in file names' if ($^O eq 'msys');"
+%PERL -e "print 'Test requires a system supporting double quotes in file names' if ($^O eq 'msys');"
 </precheck>
 # We create this file before the command is invoked!
 <file name=%LOGDIR/test%TESTNUMBER".txt>

--- a/tests/data/test1291
+++ b/tests/data/test1291
@@ -31,7 +31,7 @@ XXXXXXXx
 </file>
 # generate the config file
 <precheck>
-perl -e 'for(1 .. 1000) { printf("upload-file=%LOGDIR/upload-this\nurl=htttttp://non-existing-host.haxx.se/upload/%TESTNUMBER\n", $_);}' > %LOGDIR/cmd%TESTNUMBER;
+%PERL -e 'for(1 .. 1000) { printf("upload-file=%LOGDIR/upload-this\nurl=htttttp://non-existing-host.haxx.se/upload/%TESTNUMBER\n", $_);}' > %LOGDIR/cmd%TESTNUMBER;
 </precheck>
 </client>
 

--- a/tests/data/test1443
+++ b/tests/data/test1443
@@ -60,7 +60,7 @@ Accept: */*
 12345
 </file>
 <postcheck>
-perl -e 'exit((stat("%LOGDIR/%TESTNUMBER"))[9] != 960898200)'
+%PERL -e 'exit((stat("%LOGDIR/%TESTNUMBER"))[9] != 960898200)'
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test1444
+++ b/tests/data/test1444
@@ -49,7 +49,7 @@ QUIT
 # Verify the mtime of the file. The mtime is specifically chosen to be an even
 # number so that it can be represented exactly on a FAT filesystem.
 <postcheck>
-perl -e 'exit((stat("%LOGDIR/curl%TESTNUMBER.out"))[9] != 1234567890)'
+%PERL -e 'exit((stat("%LOGDIR/curl%TESTNUMBER.out"))[9] != 1234567890)'
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test1445
+++ b/tests/data/test1445
@@ -15,7 +15,7 @@ FILE
 file
 </server>
 <precheck>
-perl %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
 </precheck>
 <name>
 file:// with --remote-time
@@ -28,8 +28,8 @@ file://localhost%FILE_PWD/%LOGDIR/test%TESTNUMBER.dir/plainfile.txt --remote-tim
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-perl %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir && \
-perl -e 'exit((stat("%LOGDIR/curl%TESTNUMBER.out"))[9] != 946728000)'
+%PERL %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir && \
+%PERL -e 'exit((stat("%LOGDIR/curl%TESTNUMBER.out"))[9] != 946728000)'
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test1446
+++ b/tests/data/test1446
@@ -18,7 +18,7 @@ SFTP
 sftp
 </server>
 <precheck>
-perl %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
 </precheck>
 <name>
 SFTP with --remote-time
@@ -32,8 +32,8 @@ SFTP with --remote-time
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-perl %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir && \
-perl -e 'exit((stat("%LOGDIR/curl%TESTNUMBER.out"))[9] != 978264000)'
+%PERL %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir && \
+%PERL -e 'exit((stat("%LOGDIR/curl%TESTNUMBER.out"))[9] != 978264000)'
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test1683
+++ b/tests/data/test1683
@@ -39,7 +39,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER -o %LOGDIR/exist%TESTNUMBER --no-clobber
 to stay the same
 </file>
 <precheck>
-perl -e 'for my $i ((1..100)) { my $filename = "%LOGDIR/exist%TESTNUMBER.$i"; open(FH, ">", $filename) or die $!; print FH "to stay the same" ; close(FH) }'
+%PERL -e 'for my $i ((1..100)) { my $filename = "%LOGDIR/exist%TESTNUMBER.$i"; open(FH, ">", $filename) or die $!; print FH "to stay the same" ; close(FH) }'
 </precheck>
 </client>
 
@@ -53,7 +53,7 @@ perl -e 'for my $i ((1..100)) { my $filename = "%LOGDIR/exist%TESTNUMBER.$i"; op
 to stay the same
 </file>
 <postcheck>
-perl -e 'for my $i ((1..100)) { my $filename = "%LOGDIR/exist%TESTNUMBER.$i"; open(FH, "<", $filename) or die $!; (<FH> eq "to stay the same" and <FH> eq "") or die "incorrect $filename" ; close(FH) }'
+%PERL -e 'for my $i ((1..100)) { my $filename = "%LOGDIR/exist%TESTNUMBER.$i"; open(FH, "<", $filename) or die $!; (<FH> eq "to stay the same" and <FH> eq "") or die "incorrect $filename" ; close(FH) }'
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test2072
+++ b/tests/data/test2072
@@ -27,7 +27,7 @@ file:// with Unix path resolution behavior for the case of extra slashes
 file:////%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt
 </command>
 <precheck>
-perl -e "print 'Test requires a Unix system' if ( $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'dos' || $^O eq 'msys');"
+%PERL -e "print 'Test requires a Unix system' if ( $^O eq 'MSWin32' || $^O eq 'cygwin' || $^O eq 'dos' || $^O eq 'msys');"
 </precheck>
 <file name="%LOGDIR/test%TESTNUMBER.txt">
 foo

--- a/tests/data/test307
+++ b/tests/data/test307
@@ -29,7 +29,7 @@ OpenSSL
 https
 </server>
 <precheck>
-perl %SRCDIR/libtest/test%TESTNUMBER.pl %CURL
+%PERL %SRCDIR/libtest/test%TESTNUMBER.pl %CURL
 </precheck>
 
 <name>

--- a/tests/data/test608
+++ b/tests/data/test608
@@ -40,7 +40,7 @@ Test file for rename test
 Test file for rename test
 </file>
 <postcheck>
-perl %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/file%TESTNUMBER.txt move %PWD/%LOGDIR/file%TESTNUMBER-renamed.txt %PWD/%LOGDIR/file%TESTNUMBER.txt
+%PERL %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/file%TESTNUMBER.txt move %PWD/%LOGDIR/file%TESTNUMBER-renamed.txt %PWD/%LOGDIR/file%TESTNUMBER.txt
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test610
+++ b/tests/data/test610
@@ -21,7 +21,7 @@ Dummy test file for rmdir test
 sftp
 </server>
 <precheck>
-perl %SRCDIR/libtest/test%TESTNUMBER.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test%TESTNUMBER.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 </precheck>
 <name>
 SFTP post-quote rmdir
@@ -38,7 +38,7 @@ Dummy test file for rmdir test
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-perl %SRCDIR/libtest/test%TESTNUMBER.pl gone %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test%TESTNUMBER.pl gone %PWD/%LOGDIR/test%TESTNUMBER.dir
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test611
+++ b/tests/data/test611
@@ -21,7 +21,7 @@ Dummy test file for rename test
 sftp
 </server>
 <precheck>
-perl %SRCDIR/libtest/test610.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test610.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 </precheck>
 <name>
 SFTP post-quote rename
@@ -38,7 +38,7 @@ Dummy test file for rename test
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-perl %SRCDIR/libtest/test610.pl rmdir %PWD/%LOGDIR/test%TESTNUMBER.new
+%PERL %SRCDIR/libtest/test610.pl rmdir %PWD/%LOGDIR/test%TESTNUMBER.new
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test612
+++ b/tests/data/test612
@@ -38,7 +38,7 @@ Dummy test file for remove test
 Dummy test file for remove test
 </upload>
 <postcheck>
-perl %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/test%TESTNUMBER.txt
+%PERL %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/test%TESTNUMBER.txt
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test613
+++ b/tests/data/test613
@@ -23,7 +23,7 @@ d?????????    N U         U               N ???  N NN:NN asubdir
 sftp
 </server>
 <precheck>
-perl %SRCDIR/libtest/test%TESTNUMBER.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test%TESTNUMBER.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
 </precheck>
 <name>
 SFTP directory retrieval
@@ -37,7 +37,7 @@ SFTP directory retrieval
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-perl %SRCDIR/libtest/test%TESTNUMBER.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/curl%TESTNUMBER.out
+%PERL %SRCDIR/libtest/test%TESTNUMBER.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/curl%TESTNUMBER.out
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test614
+++ b/tests/data/test614
@@ -24,7 +24,7 @@ d?????????    N U         U               N ???  N NN:NN asubdir
 sftp
 </server>
 <precheck>
-perl %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
 </precheck>
 <name>
 SFTP pre-quote chmod
@@ -38,7 +38,7 @@ SFTP pre-quote chmod
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-perl %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/curl%TESTNUMBER.out
+%PERL %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/curl%TESTNUMBER.out
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test615
+++ b/tests/data/test615
@@ -14,7 +14,7 @@ FAILURE
 sftp
 </server>
 <precheck>
-perl %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test613.pl prepare %PWD/%LOGDIR/test%TESTNUMBER.dir
 </precheck>
 <name>
 SFTP put remote failure
@@ -35,7 +35,7 @@ for ssh upload test
 9
 </errorcode>
 <postcheck>
-perl %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test624
+++ b/tests/data/test624
@@ -38,7 +38,7 @@ Test data
 for ssh upload test
 </upload>
 <postcheck>
-perl %SRCDIR/libtest/test610.pl move %PWD/%LOGDIR/test%TESTNUMBER.dir/upload.%TESTNUMBER %PWD/%LOGDIR/upload.%TESTNUMBER rmdir %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test610.pl move %PWD/%LOGDIR/test%TESTNUMBER.dir/upload.%TESTNUMBER %PWD/%LOGDIR/upload.%TESTNUMBER rmdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test625
+++ b/tests/data/test625
@@ -38,7 +38,7 @@ Test data
 for ssh upload test
 </upload>
 <postcheck>
-perl %SRCDIR/libtest/test610.pl move %PWD/%LOGDIR/test%TESTNUMBER.a/upload.%TESTNUMBER %PWD/%LOGDIR/upload.%TESTNUMBER rmdir %PWD/%LOGDIR/test%TESTNUMBER.a rm %PWD/%LOGDIR/test%TESTNUMBER.b/upload.%TESTNUMBER rmdir %PWD/%LOGDIR/test%TESTNUMBER.b
+%PERL %SRCDIR/libtest/test610.pl move %PWD/%LOGDIR/test%TESTNUMBER.a/upload.%TESTNUMBER %PWD/%LOGDIR/upload.%TESTNUMBER rmdir %PWD/%LOGDIR/test%TESTNUMBER.a rm %PWD/%LOGDIR/test%TESTNUMBER.b/upload.%TESTNUMBER rmdir %PWD/%LOGDIR/test%TESTNUMBER.b
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test627
+++ b/tests/data/test627
@@ -37,7 +37,7 @@ Dummy test file for remove test
 <protocol>
 </protocol>
 <postcheck>
-perl %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/test%TESTNUMBER.txt
+%PERL %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/test%TESTNUMBER.txt
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test638
+++ b/tests/data/test638
@@ -23,7 +23,7 @@ Dummy test file for rename test
 sftp
 </server>
 <precheck>
-perl %SRCDIR/libtest/test610.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test610.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 </precheck>
 <name>
 SFTP post-quote rename * asterisk accept-fail
@@ -40,7 +40,7 @@ Dummy test file for rename test
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-perl %SRCDIR/libtest/test610.pl rmdir %PWD/%LOGDIR/test%TESTNUMBER.new
+%PERL %SRCDIR/libtest/test610.pl rmdir %PWD/%LOGDIR/test%TESTNUMBER.new
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test639
+++ b/tests/data/test639
@@ -23,7 +23,7 @@ Dummy test file for rename test
 sftp
 </server>
 <precheck>
-perl %SRCDIR/libtest/test610.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test610.pl mkdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 </precheck>
 <name>
 SFTP post-quote rename * asterisk accept-fail
@@ -40,7 +40,7 @@ Dummy test file for rename test
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-perl %SRCDIR/libtest/test610.pl rmdir %PWD/%LOGDIR/test%TESTNUMBER.dir
+%PERL %SRCDIR/libtest/test610.pl rmdir %PWD/%LOGDIR/test%TESTNUMBER.dir
 </postcheck>
 </verify>
 </testcase>

--- a/tests/data/test8
+++ b/tests/data/test8
@@ -79,7 +79,7 @@ Set-Cookie: cookie31=%hex[%7f-junk]hex%
 
 </file>
 <precheck>
-perl -e 'if ("%HOSTIP" !~ /\.0\.0\.1$/) {print "Test only works for HOSTIPs ending with .0.0.1"; exit(1)}'
+%PERL -e 'if ("%HOSTIP" !~ /\.0\.0\.1$/) {print "Test only works for HOSTIPs ending with .0.0.1"; exit(1)}'
 </precheck>
 <features>
 cookies

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -47,6 +47,7 @@ BEGIN {
         $LOGDIR
         $memanalyze
         $MEMDUMP
+        $perlcmd
         $perl
         $PIDDIR
         $proxy_address
@@ -91,7 +92,8 @@ our $randseed = 0;    # random number seed
 # paths
 our $pwd = getcwd();  # current working directory
 our $srcdir = $ENV{'srcdir'} || '.';  # root of the test source code
-our $perl="perl -I. -I$srcdir"; # invoke perl like this
+our $perlcmd="$^X";
+our $perl="$perlcmd -I. -I$srcdir"; # invoke perl like this
 our $LOGDIR="log";  # root of the log directory; this will be different for
                     # each runner in multiprocess mode
 our $LIBDIR="./libtest";

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -3095,6 +3095,7 @@ sub subvariables {
     $$thing =~ s/${prefix}HOSTIP/$HOSTIP/g;
 
     # misc
+    $$thing =~ s/${prefix}PERL/$perlcmd/g;
     $$thing =~ s/${prefix}CURL/$CURL/g;
     $$thing =~ s/${prefix}LOGDIR/$LOGDIR/g;
     $$thing =~ s/${prefix}PWD/$pwd/g;


### PR DESCRIPTION
To ensure Perl invocations within tests call the same Perl binary used
for running the tests, as specified or auto-detected via `PERL` env
(autotools) or `PERL_EXECUTABLE` setting (cmake). Instead of the first
`perl` executable found in `PATH`.)

Cherry-picked from #14949
