### PR TITLE
tests: replace hard-coded `/dev/null` with variable

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -126,7 +126,7 @@ Available substitute variables include:
 - `%CLIENTIP` - IPv4 address of the client running curl
 - `%CURL` - Path to the curl executable
 - `%DATE` - current YYYY-MM-DD date
-- `%DEV_NULL` - Null device (/dev/null or NUL)
+- `%DEV_NULL` - Null device (e.g. /dev/null)
 - `%FILE_PWD` - Current directory, on Windows prefixed with a slash
 - `%FTP6PORT` - IPv6 port number of the FTP server
 - `%FTPPORT` - Port number of the FTP server

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -126,7 +126,7 @@ Available substitute variables include:
 - `%CLIENTIP` - IPv4 address of the client running curl
 - `%CURL` - Path to the curl executable
 - `%DATE` - current YYYY-MM-DD date
-- `%DEVNULL` - Null device (/dev/null or NUL)
+- `%DEV_NULL` - Null device (/dev/null or NUL)
 - `%FILE_PWD` - Current directory, on Windows prefixed with a slash
 - `%FTP6PORT` - IPv6 port number of the FTP server
 - `%FTPPORT` - Port number of the FTP server

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -126,6 +126,7 @@ Available substitute variables include:
 - `%CLIENTIP` - IPv4 address of the client running curl
 - `%CURL` - Path to the curl executable
 - `%DATE` - current YYYY-MM-DD date
+- `%DEVNULL` - Null device (/dev/null or NUL)
 - `%FILE_PWD` - Current directory, on Windows prefixed with a slash
 - `%FTP6PORT` - IPv6 port number of the FTP server
 - `%FTPPORT` - Port number of the FTP server

--- a/tests/data/test173
+++ b/tests/data/test173
@@ -31,7 +31,7 @@ http
 HTTP RFC1867-formpost a file from stdin with "faked" filename
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F field1=contents1 -F "fileupload=@-;filename=/dev/null;type=text/x-null;format=x-curl"
+http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F field1=contents1 -F "fileupload=@-;filename=%DEVNULL;type=text/x-null;format=x-curl"
 </command>
 
 <stdin>
@@ -64,7 +64,7 @@ Content-Disposition: form-data; name="field1"
 
 contents1
 ------------------------------5dbea401cd8c
-Content-Disposition: form-data; name="fileupload"; filename="/dev/null"
+Content-Disposition: form-data; name="fileupload"; filename="%DEVNULL"
 Content-Type: text/x-null;format=x-curl
 
 line1

--- a/tests/data/test173
+++ b/tests/data/test173
@@ -31,7 +31,7 @@ http
 HTTP RFC1867-formpost a file from stdin with "faked" filename
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F field1=contents1 -F "fileupload=@-;filename=%DEVNULL;type=text/x-null;format=x-curl"
+http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F field1=contents1 -F "fileupload=@-;filename=%DEV_NULL;type=text/x-null;format=x-curl"
 </command>
 
 <stdin>
@@ -64,7 +64,7 @@ Content-Disposition: form-data; name="field1"
 
 contents1
 ------------------------------5dbea401cd8c
-Content-Disposition: form-data; name="fileupload"; filename="%DEVNULL"
+Content-Disposition: form-data; name="fileupload"; filename="%DEV_NULL"
 Content-Type: text/x-null;format=x-curl
 
 line1

--- a/tests/data/test3015
+++ b/tests/data/test3015
@@ -50,7 +50,7 @@ http
 HTTP GET -w num_headers with redirected fetch (2 connects)
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -w "%{num_headers}\n" -L -o%DEVNULL
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -w "%{num_headers}\n" -L -o%DEV_NULL
 </command>
 </client>
 

--- a/tests/data/test3015
+++ b/tests/data/test3015
@@ -50,7 +50,7 @@ http
 HTTP GET -w num_headers with redirected fetch (2 connects)
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -w "%{num_headers}\n" -L -o/dev/null
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -w "%{num_headers}\n" -L -o%DEVNULL
 </command>
 </client>
 

--- a/tests/devtest.pl
+++ b/tests/devtest.pl
@@ -110,7 +110,7 @@ sub parseprotocols {
 # Initialize @protocols from the curl binary under test
 #
 sub init_protocols {
-    for (`$CURL -V 2>$devnull`) {
+    for (`$CURL -V 2>$dev_null`) {
         if(m/^Protocols: (.*)$/) {
             parseprotocols($1);
         }

--- a/tests/devtest.pl
+++ b/tests/devtest.pl
@@ -110,7 +110,7 @@ sub parseprotocols {
 # Initialize @protocols from the curl binary under test
 #
 sub init_protocols {
-    for (`$CURL -V 2>/dev/null`) {
+    for (`$CURL -V 2>$devnull`) {
         if(m/^Protocols: (.*)$/) {
             parseprotocols($1);
         }

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -66,7 +66,7 @@ BEGIN {
         %keywords
         @protocols
         $bundle
-        $devnull
+        $dev_null
     );
 }
 use pathhelp qw(exe_ext);
@@ -105,7 +105,7 @@ our $VCURL=$CURL;  # what curl binary to use to verify the servers with
 our $memanalyze="$perl $srcdir/memanalyze.pl";
 our $valgrind;     # path to valgrind, or empty if disabled
 our $bundle = 0;   # use bundled server, libtest, unit binaries
-our $devnull = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
+our $dev_null = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
 
 # paths in $LOGDIR
 our $LOCKDIR = "lock";          # root of the server directory with lock files

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -66,6 +66,7 @@ BEGIN {
         %keywords
         @protocols
         $bundle
+        $devnull
     );
 }
 use pathhelp qw(exe_ext);
@@ -104,6 +105,7 @@ our $VCURL=$CURL;  # what curl binary to use to verify the servers with
 our $memanalyze="$perl $srcdir/memanalyze.pl";
 our $valgrind;     # path to valgrind, or empty if disabled
 our $bundle = 0;   # use bundled server, libtest, unit binaries
+our $devnull = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
 
 # paths in $LOGDIR
 our $LOCKDIR = "lock";          # root of the server directory with lock files

--- a/tests/http2-server.pl
+++ b/tests/http2-server.pl
@@ -38,7 +38,7 @@ my $listenport2 = 9016;
 my $connect = "127.0.0.1,8990";
 my $conf = "nghttpx.conf";
 my $cert = "Server-localhost-sv";
-my $devnull = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
+my $dev_null = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
 
 #***************************************************************************
 # Process command line options
@@ -118,4 +118,4 @@ my $cmdline="$nghttpx --backend=$connect ".
     "--errorlog-file=$logfile ".
     "$keyfile $certfile";
 print "RUN: $cmdline\n" if($verbose);
-exec("exec $cmdline 2>$devnull");
+exec("exec $cmdline 2>$dev_null");

--- a/tests/http2-server.pl
+++ b/tests/http2-server.pl
@@ -38,6 +38,7 @@ my $listenport2 = 9016;
 my $connect = "127.0.0.1,8990";
 my $conf = "nghttpx.conf";
 my $cert = "Server-localhost-sv";
+my $devnull = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
 
 #***************************************************************************
 # Process command line options
@@ -117,4 +118,4 @@ my $cmdline="$nghttpx --backend=$connect ".
     "--errorlog-file=$logfile ".
     "$keyfile $certfile";
 print "RUN: $cmdline\n" if($verbose);
-exec("exec $cmdline 2>/dev/null");
+exec("exec $cmdline 2>$devnull");

--- a/tests/http3-server.pl
+++ b/tests/http3-server.pl
@@ -38,6 +38,7 @@ my $listenport = 9017;
 my $connect = "127.0.0.1,8990";
 my $cert = "Server-localhost-sv";
 my $conf = "nghttpx.conf";
+my $devnull = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
 
 #***************************************************************************
 # Process command line options
@@ -117,4 +118,4 @@ my $cmdline="$nghttpx --http2-proxy --backend=$connect ".
     "--conf=$conf ".
     "$keyfile $certfile";
 print "RUN: $cmdline\n" if($verbose);
-exec("exec $cmdline 2>/dev/null");
+exec("exec $cmdline 2>$devnull");

--- a/tests/http3-server.pl
+++ b/tests/http3-server.pl
@@ -38,7 +38,7 @@ my $listenport = 9017;
 my $connect = "127.0.0.1,8990";
 my $cert = "Server-localhost-sv";
 my $conf = "nghttpx.conf";
-my $devnull = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
+my $dev_null = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
 
 #***************************************************************************
 # Process command line options
@@ -118,4 +118,4 @@ my $cmdline="$nghttpx --http2-proxy --backend=$connect ".
     "--conf=$conf ".
     "$keyfile $certfile";
 print "RUN: $cmdline\n" if($verbose);
-exec("exec $cmdline 2>$devnull");
+exec("exec $cmdline 2>$dev_null");

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -97,6 +97,8 @@ BEGIN {
     }
 }
 
+my $devnull = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
+
 my $use_cygpath;     # Only for Windows:
                      #  undef - autodetect
                      #      0 - do not use cygpath
@@ -106,7 +108,7 @@ my $use_cygpath;     # Only for Windows:
 sub should_use_cygpath {
     return $use_cygpath if defined $use_cygpath;
     if(os_is_win()) {
-        $use_cygpath = (qx{cygpath -u '.\\' 2>/dev/null} eq "./\n" && $? == 0);
+        $use_cygpath = (qx{cygpath -u '.\\' 2>$devnull} eq "./\n" && $? == 0);
     } else {
         $use_cygpath = 0;
     }
@@ -714,7 +716,7 @@ sub do_dumb_guessed_transform {
     while(1) {
         if(-d $check_path) {
             my $res =
-                `(cd "$check_path" && cmd /c "echo %__CD__%") 2>/dev/null`;
+                `(cd "$check_path" && cmd /c "echo %__CD__%") 2>$devnull`;
             if($? == 0 && substr($path, 0, 1) ne '%') {
                 # Remove both '\r' and '\n'.
                 $res =~ s{\n|\r}{}g;

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -97,7 +97,7 @@ BEGIN {
     }
 }
 
-my $devnull = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
+my $dev_null = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
 
 my $use_cygpath;     # Only for Windows:
                      #  undef - autodetect
@@ -108,7 +108,7 @@ my $use_cygpath;     # Only for Windows:
 sub should_use_cygpath {
     return $use_cygpath if defined $use_cygpath;
     if(os_is_win()) {
-        $use_cygpath = (qx{cygpath -u '.\\' 2>$devnull} eq "./\n" && $? == 0);
+        $use_cygpath = (qx{cygpath -u '.\\' 2>$dev_null} eq "./\n" && $? == 0);
     } else {
         $use_cygpath = 0;
     }
@@ -716,7 +716,7 @@ sub do_dumb_guessed_transform {
     while(1) {
         if(-d $check_path) {
             my $res =
-                `(cd "$check_path" && cmd /c "echo %__CD__%") 2>$devnull`;
+                `(cd "$check_path" && cmd /c "echo %__CD__%") 2>$dev_null`;
             if($? == 0 && substr($path, 0, 1) ne '%') {
                 # Remove both '\r' and '\n'.
                 $res =~ s{\n|\r}{}g;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -318,7 +318,7 @@ if (!$ENV{"NGHTTPX"}) {
     $ENV{"NGHTTPX"} = checktestcmd("nghttpx");
 }
 if ($ENV{"NGHTTPX"}) {
-    my $nghttpx_version=join(' ', `"$ENV{'NGHTTPX'}" -v 2>/dev/null`);
+    my $nghttpx_version=join(' ', `"$ENV{'NGHTTPX'}" -v 2>$devnull`);
     $nghttpx_h3 = $nghttpx_version =~ /nghttp3\//;
     chomp $nghttpx_h3;
 }
@@ -410,10 +410,10 @@ sub showdiff {
         print $temp "\n";
     }
     close($temp) || die "Failure writing diff file";
-    my @out = `diff -u $file2 $file1 2>/dev/null`;
+    my @out = `diff -u $file2 $file1 2>$devnull`;
 
     if(!$out[0]) {
-        @out = `diff -c $file2 $file1 2>/dev/null`;
+        @out = `diff -c $file2 $file1 2>$devnull`;
     }
 
     return @out;
@@ -2529,7 +2529,7 @@ if(!$randseed) {
     # seed of the month. December 2019 becomes 201912
     $randseed = ($year+1900)*100 + $mon+1;
     print "Using curl: $CURL\n";
-    open(my $curlvh, "-|", shell_quote($CURL) . " --version 2>/dev/null") ||
+    open(my $curlvh, "-|", shell_quote($CURL) . " --version 2>$devnull") ||
         die "could not get curl version!";
     my @c = <$curlvh>;
     close($curlvh) || die "could not get curl version!";
@@ -2547,7 +2547,7 @@ if($valgrind) {
     # we have found valgrind on the host, use it
 
     # verify that we can invoke it fine
-    my $code = runclient("valgrind >/dev/null 2>&1");
+    my $code = runclient("valgrind >$devnull 2>&1");
 
     if(($code>>8) != 1) {
         #logmsg "Valgrind failure, disable it\n";
@@ -2558,7 +2558,7 @@ if($valgrind) {
         # use it, if it is supported by the version installed on the system
         # (this happened in 2003, so we could probably don't need to care about
         # that old version any longer and just delete this check)
-        runclient("valgrind --help 2>&1 | grep -- --tool > /dev/null 2>&1");
+        runclient("valgrind --help 2>&1 | grep -- --tool >$devnull 2>&1");
         if (($? >> 8)) {
             $valgrind_tool="";
         }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -318,7 +318,8 @@ if (!$ENV{"NGHTTPX"}) {
     $ENV{"NGHTTPX"} = checktestcmd("nghttpx");
 }
 if ($ENV{"NGHTTPX"}) {
-    my $nghttpx_version=join(' ', `"$ENV{'NGHTTPX'}" -v 2>$dev_null`);
+    my $cmd = "\"$ENV{'NGHTTPX'}\" -v 2>$dev_null";
+    my $nghttpx_version=join(' ', `$cmd`);
     $nghttpx_h3 = $nghttpx_version =~ /nghttp3\//;
     chomp $nghttpx_h3;
 }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -318,7 +318,7 @@ if (!$ENV{"NGHTTPX"}) {
     $ENV{"NGHTTPX"} = checktestcmd("nghttpx");
 }
 if ($ENV{"NGHTTPX"}) {
-    my $nghttpx_version=join(' ', `"$ENV{'NGHTTPX'}" -v 2>$devnull`);
+    my $nghttpx_version=join(' ', `"$ENV{'NGHTTPX'}" -v 2>$dev_null`);
     $nghttpx_h3 = $nghttpx_version =~ /nghttp3\//;
     chomp $nghttpx_h3;
 }
@@ -410,10 +410,10 @@ sub showdiff {
         print $temp "\n";
     }
     close($temp) || die "Failure writing diff file";
-    my @out = `diff -u $file2 $file1 2>$devnull`;
+    my @out = `diff -u $file2 $file1 2>$dev_null`;
 
     if(!$out[0]) {
-        @out = `diff -c $file2 $file1 2>$devnull`;
+        @out = `diff -c $file2 $file1 2>$dev_null`;
     }
 
     return @out;
@@ -2529,7 +2529,7 @@ if(!$randseed) {
     # seed of the month. December 2019 becomes 201912
     $randseed = ($year+1900)*100 + $mon+1;
     print "Using curl: $CURL\n";
-    open(my $curlvh, "-|", shell_quote($CURL) . " --version 2>$devnull") ||
+    open(my $curlvh, "-|", shell_quote($CURL) . " --version 2>$dev_null") ||
         die "could not get curl version!";
     my @c = <$curlvh>;
     close($curlvh) || die "could not get curl version!";
@@ -2547,7 +2547,7 @@ if($valgrind) {
     # we have found valgrind on the host, use it
 
     # verify that we can invoke it fine
-    my $code = runclient("valgrind >$devnull 2>&1");
+    my $code = runclient("valgrind >$dev_null 2>&1");
 
     if(($code>>8) != 1) {
         #logmsg "Valgrind failure, disable it\n";
@@ -2558,7 +2558,7 @@ if($valgrind) {
         # use it, if it is supported by the version installed on the system
         # (this happened in 2003, so we could probably don't need to care about
         # that old version any longer and just delete this check)
-        runclient("valgrind --help 2>&1 | grep -- --tool >$devnull 2>&1");
+        runclient("valgrind --help 2>&1 | grep -- --tool >$dev_null 2>&1");
         if (($? >> 8)) {
             $valgrind_tool="";
         }

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -3122,7 +3122,7 @@ sub subvariables {
     $$thing =~ s/${prefix}SSH_PWD/$ssh_pwd/g;
     $$thing =~ s/${prefix}SRCDIR/$srcdir/g;
     $$thing =~ s/${prefix}USER/$USER/g;
-    $$thing =~ s/${prefix}DEV_NULL/$devnull/g;
+    $$thing =~ s/${prefix}DEV_NULL/$dev_null/g;
 
     $$thing =~ s/${prefix}SSHSRVMD5/$SSHSRVMD5/g;
     $$thing =~ s/${prefix}SSHSRVSHA256/$SSHSRVSHA256/g;

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -3122,7 +3122,7 @@ sub subvariables {
     $$thing =~ s/${prefix}SSH_PWD/$ssh_pwd/g;
     $$thing =~ s/${prefix}SRCDIR/$srcdir/g;
     $$thing =~ s/${prefix}USER/$USER/g;
-    $$thing =~ s/${prefix}DEVNULL/$devnull/g;
+    $$thing =~ s/${prefix}DEV_NULL/$devnull/g;
 
     $$thing =~ s/${prefix}SSHSRVMD5/$SSHSRVMD5/g;
     $$thing =~ s/${prefix}SSHSRVSHA256/$SSHSRVSHA256/g;

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -3122,6 +3122,7 @@ sub subvariables {
     $$thing =~ s/${prefix}SSH_PWD/$ssh_pwd/g;
     $$thing =~ s/${prefix}SRCDIR/$srcdir/g;
     $$thing =~ s/${prefix}USER/$USER/g;
+    $$thing =~ s/${prefix}DEVNULL/$devnull/g;
 
     $$thing =~ s/${prefix}SSHSRVMD5/$SSHSRVMD5/g;
     $$thing =~ s/${prefix}SSHSRVSHA256/$SSHSRVSHA256/g;

--- a/tests/testutil.pm
+++ b/tests/testutil.pm
@@ -56,7 +56,7 @@ use MIME::Base64;
 use globalconfig qw(
     $torture
     $verbose
-    $devnull
+    $dev_null
 );
 
 my $logfunc;      # optional reference to function for logging
@@ -196,7 +196,7 @@ sub runclient {
 #
 sub runclientoutput {
     my ($cmd)=@_;
-    return `$cmd 2>$devnull`;
+    return `$cmd 2>$dev_null`;
 
 # This is one way to test curl on a remote machine
 #    my @out = `ssh $CLIENTIP cd \'$pwd\' \\; \'$cmd\'`;

--- a/tests/testutil.pm
+++ b/tests/testutil.pm
@@ -56,6 +56,7 @@ use MIME::Base64;
 use globalconfig qw(
     $torture
     $verbose
+    $devnull
 );
 
 my $logfunc;      # optional reference to function for logging
@@ -195,7 +196,7 @@ sub runclient {
 #
 sub runclientoutput {
     my ($cmd)=@_;
-    return `$cmd 2>/dev/null`;
+    return `$cmd 2>$devnull`;
 
 # This is one way to test curl on a remote machine
 #    my @out = `ssh $CLIENTIP cd \'$pwd\' \\; \'$cmd\'`;


### PR DESCRIPTION
- add variable for the null device filename and use that in Perl code.
- initialize this variable with `NUL` on native Windows.
- add `%DEV_NULL` variable and use it in tests.

Fixes `The system cannot find the path specified.` messages seen when
running `runtests.pl` with native Windows Perl.

Also adjust code to not break mcedit syntax highlighting.

Cherry-picked from #14949