### PR TITLE
tests: fixup `checkcmd` `PATH` on non-unixy platforms

### DIFF
--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -154,13 +154,15 @@ our $stunnel;        # path to stunnel command
 #
 sub checkcmd {
     my ($cmd, @extrapaths)=@_;
-    my $sep = '[:]';
+    my @paths;
     if ($^O eq 'MSWin32' || $^O eq 'dos' || $^O eq 'os2') {
         # PATH separator is different
-        $sep = '[;]';
+        @paths=(split(';', $ENV{'PATH'}), @extrapaths);
     }
-    my @paths=(split(m/$sep/, $ENV{'PATH'}), "/usr/sbin", "/usr/local/sbin",
-               "/sbin", "/usr/bin", "/usr/local/bin", @extrapaths);
+    else {
+        @paths=(split(':', $ENV{'PATH'}), "/usr/sbin", "/usr/local/sbin",
+                "/sbin", "/usr/bin", "/usr/local/bin", @extrapaths);
+    }
     for(@paths) {
         if( -x "$_/$cmd" . exe_ext('SYS') && ! -d "$_/$cmd" . exe_ext('SYS')) {
             # executable bit but not a directory!


### PR DESCRIPTION
Do not add unixy system directories to `PATH` when looking up commands
on Windows, MS-DOS or OS/2.

Cherry-picked from #14949
