### PR TITLE
docs/libcurl: expand multi documentation

### DIFF
--- a/docs/libcurl/curl_multi_cleanup.md
+++ b/docs/libcurl/curl_multi_cleanup.md
@@ -42,7 +42,7 @@ handle is no longer connected to the multi handle
 removed
 
 When this function is called, remaining entries in the connection pool held by
-the multi handle will be shut down, which might trigger calls to the
+the multi handle are shut down, which might trigger calls to the
 CURLMOPT_SOCKETFUNCTION(3) callback.
 
 Passing in a NULL pointer in *multi_handle* makes this function return

--- a/docs/libcurl/curl_multi_cleanup.md
+++ b/docs/libcurl/curl_multi_cleanup.md
@@ -41,6 +41,10 @@ handle is no longer connected to the multi handle
 3 - curl_multi_cleanup(3) should be called when all easy handles are
 removed
 
+When this function is called, remaining entries in the connection pool held by
+the multi handle will be shut down, which might trigger calls to the
+CURLMOPT_SOCKETFUNCTION(3) callback.
+
 Passing in a NULL pointer in *multi_handle* makes this function return
 CURLM_BAD_HANDLE immediately with no other action.
 

--- a/docs/libcurl/curl_multi_init.md
+++ b/docs/libcurl/curl_multi_init.md
@@ -35,7 +35,7 @@ places in the documentation. This init call MUST have a corresponding call to
 curl_multi_cleanup(3) when the operation is complete.
 
 By default, several caches are stored in and held by the multi handle: DNS
-cache, connection pool, TLS sessiond ID cache and the TLS CA cert cache. All
+cache, connection pool, TLS session ID cache and the TLS CA cert cache. All
 transfers using the same multi handle share these caches.
 
 # %PROTOCOLS%

--- a/docs/libcurl/curl_multi_init.md
+++ b/docs/libcurl/curl_multi_init.md
@@ -34,6 +34,10 @@ all the other multi-functions, sometimes referred to as a multi handle in some
 places in the documentation. This init call MUST have a corresponding call to
 curl_multi_cleanup(3) when the operation is complete.
 
+By default, several caches are stored in and held by the multi handle: DNS
+cache, connection pool, TLS sessiond ID cache and the TLS CA cert cache. All
+transfers using the same multi handle share these caches.
+
 # %PROTOCOLS%
 
 # EXAMPLE


### PR DESCRIPTION
curl_multi_init - mention the caches held by the handle

curl_multi_cleanup - mention that the socket callback might be invoked by this function