### PR TITLE
tests: simplify `pathhelp.pm`, avoid using external tools

### DIFF
--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -132,38 +132,11 @@ sub sys_native_current_path {
     return Cwd::getcwd() if !os_is_win();
 
     my $cur_dir;
-    if($^O eq 'msys') {
-        # MSYS shell has built-in command.
-        chomp($cur_dir = `bash -c 'pwd -W'`);
-        if($? != 0) {
-            warn "Can't determine Windows current directory.\n";
-            return undef;
-        }
-        # Add final slash if required.
-        $cur_dir .= '/' if length($cur_dir) > 3;
+    if($^O eq 'MSWin32') {
+        $cur_dir = Cwd::getcwd();
     }
     else {
-        my $cmd = 'cmd "/c;" echo %__CD__%';
-        print "sys_native_current_path: $^O: Executing: '$cmd'\n";
-        # Do not use 'cygpath' - it falsely succeeds on paths like '/cygdrive'.
-        $cur_dir = `$cmd`;
-        if($^O eq 'MSWin32') {
-          my $cur_dirnative = Cwd::getcwd();
-          print "sys_native_current_path: $^O: Result: '$cur_dir' TEST: '$cur_dirnative'\n";
-        }
-        else {
-          my $cur_dirnative = Cygwin::posix_to_win_path("", 1);
-          print "sys_native_current_path: $^O: Result: '$cur_dir' TEST: '$cur_dirnative'\n";
-        }
-        if($? != 0 || substr($cur_dir, 0, 1) eq '%') {
-            warn "Can't determine Windows current directory.\n";
-            return undef;
-        }
-        # Remove both '\r' and '\n'.
-        $cur_dir =~ s{\n|\r}{}g;
-
-        # Replace back slashes with forward slashes.
-        $cur_dir =~ s{\\}{/}g;
+        $cur_dir = Cygwin::posix_to_win_path(Cwd::getcwd());
     }
     print "sys_native_current_path: $^O: Return: '$cur_dir'\n";
     return $cur_dir;

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -143,8 +143,11 @@ sub sys_native_current_path {
         $cur_dir .= '/' if length($cur_dir) > 3;
     }
     else {
-        # Do not use 'cygpath' - it falsely succeed on paths like '/cygdrive'.
-        $cur_dir = `cmd "/c;" echo %__CD__%`;
+        my $cmd = 'cmd "/c;" echo %__CD__%';
+        print "sys_native_current_path: $^O: Executing: '$cmd'\n";
+        # Do not use 'cygpath' - it falsely succeeds on paths like '/cygdrive'.
+        $cur_dir = `$cmd`;
+        print "sys_native_current_path: $^O: Result: '$cur_dir'\n";
         if($? != 0 || substr($cur_dir, 0, 1) eq '%') {
             warn "Can't determine Windows current directory.\n";
             return undef;
@@ -164,7 +167,10 @@ sub sys_native_current_path {
 sub get_win32_current_drive {
     # Notice parameter "/c;" - it's required to turn off MSYS's
     # transformation of '/c' and compatible with Cygwin.
-    my $drive_letter = `cmd "/c;" echo %__CD__:~0,2%`;
+    my $cmd = 'cmd "/c;" echo %__CD__:~0,2%';
+    print "get_win32_current_drive: $^O: Executing: '$cmd'\n";
+    my $drive_letter = `$cmd`;
+    print "get_win32_current_drive: $^O: Result: '$drive_letter'\n";
     if($? != 0 || substr($drive_letter, 1, 1) ne ':') {
         warn "Can't determine current Windows drive letter.\n";
         return undef;
@@ -241,7 +247,10 @@ sub sys_native_path {
         my $has_final_slash = ($path =~ m{[/\\]$});
 
         # Use 'cygpath', '-m' means Windows path with forward slashes.
-        chomp($path = `cygpath -m '$path'`);
+        my $cmd = "cygpath -m '$path'";
+        print "sys_native_path: $^O: Executing: '$cmd'\n";
+        chomp($path = `$cmd`);
+        print "sys_native_path: $^O: Result: $? '$path'\n";
         if ($? != 0) {
             warn "Can't convert path by \"cygpath\".\n";
             return undef;
@@ -332,7 +341,10 @@ sub sys_native_abs_path {
         # print "Inter result: \"$path\"\n";
         # Use 'cygpath', '-m' means Windows path with forward slashes,
         # '-a' means absolute path
-        chomp($path = `cygpath -m -a '$path'`);
+        my $cmd = "cygpath -m -a '$path'";
+        print "sys_native_abs_path: $^O: Executing: '$cmd'\n";
+        chomp($path = `$cmd`);
+        print "sys_native_abs_path: $^O: Result: $? '$path'\n";
         if($? != 0) {
             warn "Can't resolve path by usung \"cygpath\".\n";
             return undef;
@@ -377,7 +389,10 @@ sub sys_native_abs_path {
             $cur_dir = `bash -c 'pwd -L'`;
         }
         else {
-            $cur_dir = `pwd -L`;
+            my $cmd = 'pwd -L';
+            print "sys_native_abs_path: $^O: Executing: '$cmd'\n";
+            $cur_dir = `$cmd`;
+            print "sys_native_abs_path: $^O: Result: $? '$cur_dir'\n";
         }
         if($? != 0) {
             warn "Can't determine current working directory.\n";
@@ -451,7 +466,10 @@ sub build_sys_abs_path {
             chomp($path = `bash -c 'pwd -L'`);
         }
         else {
-            chomp($path = `pwd -L`);
+            my $cmd = 'pwd -L';
+            print "build_sys_abs_path: $^O: Executing: '$cmd'\n";
+            chomp($path = `$cmd`);
+            print "build_sys_abs_path: $^O: Result: $? '$path'\n";
         }
         if($? != 0) {
             warn "Can't determine Unix-style current working directory.\n";
@@ -475,7 +493,10 @@ sub build_sys_abs_path {
 
         # Use 'cygpath', '-u' means Unix-stile path,
         # '-a' means absolute path
-        chomp($path = `cygpath -u -a '$path'`);
+        my $cmd = "cygpath -u -a '$path'";
+        print "build_sys_abs_path: $^O: Executing: '$cmd'\n";
+        chomp($path = `$cmd`);
+        print "build_sys_abs_path: $^O: Result: $? '$path'\n";
         if($? != 0) {
             warn "Can't resolve path by usung \"cygpath\".\n";
             return undef;
@@ -529,7 +550,10 @@ sub build_sys_abs_path {
             $cur_dir = `bash -c 'pwd -L'`;
         }
         else {
-            $cur_dir = `pwd -L`;
+            my $cmd = 'pwd -L';
+            print "build_sys_abs_path: $^O: Executing: '$cmd'\n";
+            $cur_dir = `$cmd`;
+            print "build_sys_abs_path: $^O: Result: $? '$cur_dir'\n";
         }
         if($? != 0) {
             warn "Can't determine current working directory.\n";
@@ -629,7 +653,10 @@ sub do_msys_transform {
     # MSYS transforms automatically path to Windows native form in staring
     # program parameters if program is not MSYS-based.
     # Note: already checked that $path is non-empty.
-    $path = `cmd //c echo '$path'`;
+    my $cmd = "cmd //c echo '$path'";
+    print "do_msys_transform: $^O: Executing: '$cmd'\n";
+    $path = `$cmd`;
+    print "do_msys_transform: $^O: Result: $? '$path'\n";
     if($? != 0) {
         warn "Can't transform path into Windows form by using MSYS" .
              "internal transformation.\n";
@@ -652,7 +679,10 @@ sub get_abs_path_on_win32_drive {
 
     # Get current directory on specified drive.
     # "/c;" is compatible with both MSYS and Cygwin.
-    my $cur_dir_on_drv = `cmd "/c;" echo %=$drv:%`;
+    my $cmd = 'cmd "/c;" echo %=$drv:%';
+    print "get_abs_path_on_win32_drive: $^O: Executing: '$cmd'\n";
+    my $cur_dir_on_drv = `$cmd`;
+    print "get_abs_path_on_win32_drive: $^O: Result: $? '$cur_dir_on_drv'\n";
     if($? != 0) {
         warn "Can't determine Windows current directory on drive $drv:.\n";
         return undef;
@@ -715,8 +745,10 @@ sub do_dumb_guessed_transform {
     my $path_tail = '';
     while(1) {
         if(-d $check_path) {
-            my $res =
-                `(cd "$check_path" && cmd /c "echo %__CD__%") 2>$dev_null`;
+            my $cmd = "(cd \"$check_path\" && cmd /c \"echo %__CD__%\") 2>$dev_null";
+            print "do_dumb_guessed_transform: $^O: Executing: '$cmd'\n";
+            my $res = `$cmd`;
+            print "do_dumb_guessed_transform: $^O: Result: $? '$res'\n";
             if($? == 0 && substr($path, 0, 1) ne '%') {
                 # Remove both '\r' and '\n'.
                 $res =~ s{\n|\r}{}g;
@@ -754,7 +786,10 @@ sub simple_transform_win32_to_unix {
     if(should_use_cygpath()) {
         # 'cygpath' gives precise result.
         my $res;
-        chomp($res = `cygpath -a -u '$path'`);
+        my $cmd = "cygpath -a -u '$path'";
+        print "simple_transform_win32_to_unix: $^O: Executing: '$cmd'\n";
+        chomp($res = `$cmd`);
+        print "simple_transform_win32_to_unix: $^O: Result: $? '$res'\n";
         if($? != 0) {
             warn "Can't determine Unix-style directory for Windows " .
                  "directory \"$path\".\n";

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -137,14 +137,19 @@ sub sys_native_path {
     # Do not process empty path.
     return $path if ($path eq '');
 
+    my $new;
     if($^O eq 'msys' || $^O eq 'cygwin') {
-        return Cygwin::posix_to_win_path($path);
+        $new = Cygwin::posix_to_win_path($path);
     }
     elsif($path =~ m{^/(cygdrive/)?([a-z])/(.*)}) {
-        return uc($2) . ":/" . $3;
+        $new = uc($2) . ":/" . $3;
+    }
+    else {
+        $new = $path;
     }
 
-    return $path;
+    print "sys_native_path: $^O: Return: '$path' -> '$new'\n";
+    return $new;
 }
 
 #######################################################################
@@ -161,14 +166,19 @@ sub sys_native_abs_path {
     # Do not process empty path.
     return $path if ($path eq '');
 
+    my $new;
     if($^O eq 'msys' || $^O eq 'cygwin') {
-        return Cygwin::posix_to_win_path(Cwd::abs_path($path));
+        $new = Cygwin::posix_to_win_path(Cwd::abs_path($path));
     }
     elsif($path =~ m{^/(cygdrive/)?([a-z])/(.*)}) {
-        return uc($2) . ":/" . $3;
+        $new = uc($2) . ":/" . $3;
+    }
+    else {
+        $new = Cwd::abs_path($path);
     }
 
-    return Cwd::abs_path($path);
+    print "sys_native_abs_path: $^O: Return: '$path' -> '$new'\n";
+    return $new;
 }
 
 #######################################################################
@@ -188,12 +198,17 @@ sub build_sys_abs_path {
 
     $path = normalize_path(Cwd::abs_path($path));
 
+    my $new;
     if($path =~ m{^([A-Za-z]):(.*)}) {
-        $path = "/" . lc($1) . $2;
-        $path = '/cygdrive' . $path if(drives_mounted_on_cygdrive());
+        $new = "/" . lc($1) . $2;
+        $new = '/cygdrive' . $new if(drives_mounted_on_cygdrive());
+    }
+    else {
+        $new = $path;
     }
 
-    return $path;
+    print "build_sys_abs_path: $^O: Return: '$path' -> '$new'\n";
+    return $new;
 }
 
 #######################################################################

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -23,11 +23,9 @@
 ###########################################################################
 
 # This Perl package helps with path transforming when running curl tests on
-# Windows platform with MSYS or Cygwin.
-# Three main functions 'sys_native_abs_path' and
-# 'build_sys_abs_path' autodetect format of given pathnames. Following formats
-# are supported:
-#  (1) /some/path   - absolute path in Unix-style
+# native Windows and MSYS/Cygwin.
+# Following input formats are supported (via built-in Perl functions):
+#  (1) /some/path   - absolute path in POSIX-style
 #  (2) D:/some/path - absolute path in Windows-style
 #  (3) some/path    - relative path
 #  (4) D:some/path  - path relative to current directory on Windows drive
@@ -141,7 +139,7 @@ sub sys_native_abs_path {
 
 #######################################################################
 # Converts given path to build system format absolute path, i.e. to
-# MSYS/Cygwin Unix-style absolute format on Windows platform. Both
+# MSYS/Cygwin POSIX-style absolute format on Windows platform. Both
 # relative and absolute formats are supported for input.
 #
 sub build_sys_abs_path {

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -160,7 +160,7 @@ sub build_sys_abs_path {
     my ($path) = @_;
 
     # Return untouched on non-Windows platforms.
-    return Cwd::abs_path($path) if (!os_is_win());
+    return Cwd::abs_path($path) if !os_is_win();
 
     if($^O eq 'msys' || $^O eq 'cygwin') {
         new = Cygwin::win_to_posix_path($path, 1);

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -147,7 +147,14 @@ sub sys_native_current_path {
         print "sys_native_current_path: $^O: Executing: '$cmd'\n";
         # Do not use 'cygpath' - it falsely succeeds on paths like '/cygdrive'.
         $cur_dir = `$cmd`;
-        print "sys_native_current_path: $^O: Result: '$cur_dir'\n";
+        if($^O eq 'MSWin32') {
+          my $cur_dirnative = Cwd::getcwd();
+          print "sys_native_current_path: $^O: Result: '$cur_dir' TEST: '$cur_dirnative'\n";
+        }
+        else {
+          my $cur_dirnative = Cygwin::posix_to_win_path("", 1);
+          print "sys_native_current_path: $^O: Result: '$cur_dir' TEST: '$cur_dirnative'\n";
+        }
         if($? != 0 || substr($cur_dir, 0, 1) eq '%') {
             warn "Can't determine Windows current directory.\n";
             return undef;
@@ -158,6 +165,7 @@ sub sys_native_current_path {
         # Replace back slashes with forward slashes.
         $cur_dir =~ s{\\}{/}g;
     }
+    print "sys_native_current_path: $^O: Return: '$cur_dir'\n";
     return $cur_dir;
 }
 

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -430,31 +430,9 @@ sub normalize_path {
 # transformation.
 sub do_msys_transform {
     my ($path) = @_;
-    return undef if $^O ne 'msys';
+    return undef if $^O ne 'msys' || $^O ne 'cygwin';
     return $path if $path eq '';
-
-    # Remove leading double forward slashes, as they turn off MSYS
-    # transforming.
-    $path =~ s{^/[/\\]+}{/};
-
-    # MSYS transforms automatically path to Windows native form in staring
-    # program parameters if program is not MSYS-based.
-    # Note: already checked that $path is non-empty.
-    my $cmd = "cmd //c echo '$path'";
-    print "do_msys_transform: $^O: Executing: '$cmd'\n";
-    $path = `$cmd`;
-    print "do_msys_transform: $^O: Result: $? '$path'\n";
-    if($? != 0) {
-        warn "Can't transform path into Windows form by using MSYS" .
-             "internal transformation.\n";
-        return undef;
-    }
-
-    # Remove double quotes, they are added for paths with spaces,
-    # remove both '\r' and '\n'.
-    $path =~ s{^\"|\"$|\"\r|\n|\r}{}g;
-
-    return $path;
+    return Cygwin::posix_to_win_path($path);
 }
 
 # Internal function. Gets two parameters: first parameter must be single

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -163,7 +163,7 @@ sub build_sys_abs_path {
 
     return $res;
 }
-#
+
 #***************************************************************************
 # Return file extension for executable files on this operating system
 #

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -162,11 +162,12 @@ sub build_sys_abs_path {
     # Return untouched on non-Windows platforms.
     return Cwd::abs_path($path) if !os_is_win();
 
+    my $new;
     if($^O eq 'msys' || $^O eq 'cygwin') {
-        new = Cygwin::win_to_posix_path($path, 1);
+        $new = Cygwin::win_to_posix_path($path, 1);
     }
     else {
-        my $new = normalize_path(Cwd::abs_path($path));
+        $new = normalize_path(Cwd::abs_path($path));
 
         if($new =~ m{^([A-Za-z]):(.*)}) {
             $new = "/" . lc($1) . $2;

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -146,18 +146,7 @@ sub sys_native_current_path {
 # Returns Windows current drive letter with colon.
 #
 sub get_win32_current_drive {
-    # Notice parameter "/c;" - it's required to turn off MSYS's
-    # transformation of '/c' and compatible with Cygwin.
-    my $cmd = 'cmd "/c;" echo %__CD__:~0,2%';
-    print "get_win32_current_drive: $^O: Executing: '$cmd'\n";
-    my $drive_letter = `$cmd`;
-    print "get_win32_current_drive: $^O: Result: '$drive_letter'\n";
-    if($? != 0 || substr($drive_letter, 1, 1) ne ':') {
-        warn "Can't determine current Windows drive letter.\n";
-        return undef;
-    }
-
-    return substr($drive_letter, 0, 2);
+    return substr(Cwd::getcwd(), 0, 2);
 }
 
 # Internal function. Converts path by using MSYS's built-in transformation.

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -119,7 +119,6 @@ sub sys_native_current_path {
         $cur_dir = Cygwin::posix_to_win_path(Cwd::getcwd());
     }
     $cur_dir =~ s{[/\\]+}{/}g;
-    print "sys_native_current_path: $^O: Return: '$cur_dir'\n";
     return $cur_dir;
 }
 
@@ -149,7 +148,6 @@ sub sys_native_abs_path {
     }
 
     $new =~ s{[/\\]+}{/}g;
-    print "sys_native_abs_path: $^O: Return: '$path' -> '$new'\n";
     return $new;
 }
 
@@ -177,7 +175,6 @@ sub build_sys_abs_path {
         }
     }
 
-    print "build_sys_abs_path: $^O: Return: '$path' -> '$new'\n";
     return $new;
 }
 

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -66,7 +66,6 @@ BEGIN {
         sys_native_current_path
         build_sys_abs_path
         normalize_path
-        should_use_cygpath
         drives_mounted_on_cygdrive
     );
 }
@@ -95,24 +94,6 @@ BEGIN {
         $cygdrive_present = ((-e '/cygdrive/') && (-d '/cygdrive/')) ? 1 : 0;
         return $cygdrive_present;
     }
-}
-
-my $dev_null = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
-
-my $use_cygpath;     # Only for Windows:
-                     #  undef - autodetect
-                     #      0 - do not use cygpath
-                     #      1 - use cygpath
-
-# Returns boolean true if 'cygpath' utility should be used for path conversion.
-sub should_use_cygpath {
-    return $use_cygpath if defined $use_cygpath;
-    if(os_is_win()) {
-        $use_cygpath = (qx{cygpath -u '.\\' 2>$dev_null} eq "./\n" && $? == 0);
-    } else {
-        $use_cygpath = 0;
-    }
-    return $use_cygpath;
 }
 
 #######################################################################

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -24,7 +24,7 @@
 
 # This Perl package helps with path transforming when running curl tests on
 # Windows platform with MSYS or Cygwin.
-# Three main functions 'sys_native_abs_path', 'sys_native_path' and
+# Three main functions 'sys_native_abs_path' and
 # 'build_sys_abs_path' autodetect format of given pathnames. Following formats
 # are supported:
 #  (1) /some/path   - absolute path in Unix-style
@@ -37,8 +37,7 @@
 # slash in forms (1) and (5).
 # Forward slashes are simpler processed in Perl, do not require extra escaping
 # for shell (unlike back slashes) and accepted by Windows native programs, so
-# all functions return paths with only forward slashes except
-# 'sys_native_path' which returns paths with first forward slash for form (5).
+# all functions return paths with only forward slashes.
 # All returned paths don't contain any duplicated slashes, only single slashes
 # are used as directory separators on output.
 # On non-Windows platforms functions acts as transparent wrappers for similar
@@ -121,35 +120,6 @@ sub sys_native_current_path {
     }
     print "sys_native_current_path: $^O: Return: '$cur_dir'\n";
     return $cur_dir;
-}
-
-#######################################################################
-# Converts given path to system native format, i.e. to Windows format on
-# Windows platform. Relative paths converted to relative, absolute
-# paths converted to absolute.
-#
-sub sys_native_path {
-    my ($path) = @_;
-
-    # Return untouched on non-Windows platforms.
-    return $path if (!os_is_win());
-
-    # Do not process empty path.
-    return $path if ($path eq '');
-
-    my $new;
-    if($^O eq 'msys' || $^O eq 'cygwin') {
-        $new = Cygwin::posix_to_win_path($path);
-    }
-    elsif($path =~ m{^/(cygdrive/)?([a-z])/(.*)}) {
-        $new = uc($2) . ":/" . $3;
-    }
-    else {
-        $new = $path;
-    }
-
-    print "sys_native_path: $^O: Return: '$path' -> '$new'\n";
-    return $new;
 }
 
 #######################################################################

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -122,19 +122,19 @@ sub sys_native_abs_path {
     # Do not process empty path.
     return $path if ($path eq '');
 
-    my $new;
+    my $res;
     if($^O eq 'msys' || $^O eq 'cygwin') {
-        $new = Cygwin::posix_to_win_path(Cwd::abs_path($path));
+        $res = Cygwin::posix_to_win_path(Cwd::abs_path($path));
     }
     elsif($path =~ m{^/(cygdrive/)?([a-z])/(.*)}) {
-        $new = uc($2) . ":/" . $3;
+        $res = uc($2) . ":/" . $3;
     }
     else {
-        $new = Cwd::abs_path($path);
+        $res = Cwd::abs_path($path);
     }
 
-    $new =~ s{[/\\]+}{/}g;
-    return $new;
+    $res =~ s{[/\\]+}{/}g;
+    return $res;
 }
 
 #######################################################################
@@ -148,20 +148,20 @@ sub build_sys_abs_path {
     # Return untouched on non-Windows platforms.
     return Cwd::abs_path($path) if !os_is_win();
 
-    my $new;
+    my $res;
     if($^O eq 'msys' || $^O eq 'cygwin') {
-        $new = Cygwin::win_to_posix_path($path, 1);
+        $res = Cygwin::win_to_posix_path($path, 1);
     }
     else {
-        $new = Cwd::abs_path($path);
+        $res = Cwd::abs_path($path);
 
-        if($new =~ m{^([A-Za-z]):(.*)}) {
-            $new = "/" . lc($1) . $2;
-            $new = '/cygdrive' . $new if(drives_mounted_on_cygdrive());
+        if($res =~ m{^([A-Za-z]):(.*)}) {
+            $res = "/" . lc($1) . $2;
+            $res = '/cygdrive' . $res if(drives_mounted_on_cygdrive());
         }
     }
 
-    return $new;
+    return $res;
 }
 #
 #***************************************************************************

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -142,10 +142,6 @@ sub sys_native_current_path {
     return $cur_dir;
 }
 
-# Internal function. Converts path by using MSYS's built-in transformation.
-# Returned path may contain duplicated and back slashes.
-sub do_msys_transform;
-
 #######################################################################
 # Converts given path to system native format, i.e. to Windows format on
 # Windows platform. Relative paths converted to relative, absolute
@@ -161,9 +157,7 @@ sub sys_native_path {
     return $path if ($path eq '');
 
     if($^O eq 'msys' || $^O eq 'cygwin') {
-        # MSYS transforms automatically path to Windows native form in staring
-        # program parameters if program is not MSYS-based.
-        return do_msys_transform($path);
+        return Cygwin::posix_to_win_path($path);
     }
     elsif($path =~ m{^/(cygdrive/)?([a-z])/(.*)}) {
         return uc($2) . ":/" . $3;
@@ -187,9 +181,7 @@ sub sys_native_abs_path {
     return $path if ($path eq '');
 
     if($^O eq 'msys' || $^O eq 'cygwin') {
-        # MSYS transforms automatically path to Windows native form in staring
-        # program parameters if program is not MSYS-based.
-        return do_msys_transform(Cwd::abs_path($path));
+        return Cygwin::posix_to_win_path(Cwd::abs_path($path));
     }
     elsif($path =~ m{^/(cygdrive/)?([a-z])/(.*)}) {
         return uc($2) . ":/" . $3;
@@ -293,15 +285,6 @@ sub normalize_path {
     $ret .= '/' if($path =~ m{\\$|/$} && scalar @res > 0);
 
     return $ret;
-}
-
-# Internal function. Converts path by using MSYS's built-in
-# transformation.
-sub do_msys_transform {
-    my ($path) = @_;
-    return undef if $^O ne 'msys' || $^O ne 'cygwin';
-    return $path if $path eq '';
-    return Cygwin::posix_to_win_path($path);
 }
 #
 #***************************************************************************

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -64,8 +64,6 @@ BEGIN {
         sys_native_abs_path
         sys_native_current_path
         build_sys_abs_path
-        normalize_path
-        drives_mounted_on_cygdrive
     );
 }
 

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -118,6 +118,7 @@ sub sys_native_current_path {
     else {
         $cur_dir = Cygwin::posix_to_win_path(Cwd::getcwd());
     }
+    $cur_dir =~ s{[/\\]+}{/}g;
     print "sys_native_current_path: $^O: Return: '$cur_dir'\n";
     return $cur_dir;
 }
@@ -147,6 +148,7 @@ sub sys_native_abs_path {
         $new = Cwd::abs_path($path);
     }
 
+    $new =~ s{[/\\]+}{/}g;
     print "sys_native_abs_path: $^O: Return: '$path' -> '$new'\n";
     return $new;
 }

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -193,18 +193,15 @@ sub build_sys_abs_path {
     return Cwd::abs_path($path) if (!os_is_win());
 
     if($^O eq 'msys' || $^O eq 'cygwin') {
-        return Cygwin::win_to_posix_path($path, 1);
-    }
-
-    $path = normalize_path(Cwd::abs_path($path));
-
-    my $new;
-    if($path =~ m{^([A-Za-z]):(.*)}) {
-        $new = "/" . lc($1) . $2;
-        $new = '/cygdrive' . $new if(drives_mounted_on_cygdrive());
+        new = Cygwin::win_to_posix_path($path, 1);
     }
     else {
-        $new = $path;
+        my $new = normalize_path(Cwd::abs_path($path));
+
+        if($new =~ m{^([A-Za-z]):(.*)}) {
+            $new = "/" . lc($1) . $2;
+            $new = '/cygdrive' . $new if(drives_mounted_on_cygdrive());
+        }
     }
 
     print "build_sys_abs_path: $^O: Return: '$path' -> '$new'\n";

--- a/tests/pathhelp.pm
+++ b/tests/pathhelp.pm
@@ -131,7 +131,7 @@ sub sys_native_abs_path {
     my ($path) = @_;
 
     # Return untouched on non-Windows platforms.
-    return Cwd::abs_path($path) if (!os_is_win());
+    return Cwd::abs_path($path) if !os_is_win();
 
     # Do not process empty path.
     return $path if ($path eq '');


### PR DESCRIPTION
Instead of calling the shell and external tools, rely on Perl functions
like `Cwd::getcwd()`, `Cwd::abs_path()`, `Cygwin::posix_to_win_path()`,
`Cygwin::win_to_posix_path()` to retrieve the current directory and
convert between POSIX and Windows formats.

This adds native Windows Perl support, avoids most failure modes and
makes format guessing and other internal functions unnecessary.

Also:
- delete unused `sys_native_path()`.
- delete redundant `normalize_path()` because Perl `abs_path()` already
  does it.

Cherry-picked from #14949
