### PR TITLE
tests: remove debug requirement on 38 tests

### DIFF
--- a/tests/data/test1210
+++ b/tests/data/test1210
@@ -24,22 +24,14 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -J without Content-Disposition
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER?junk -J -O
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER?junk -J -O --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1311
+++ b/tests/data/test1311
@@ -25,22 +25,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -J output in
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -J and Content-Disposition
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1312
+++ b/tests/data/test1312
@@ -25,22 +25,14 @@ Content-Disposition: inline; filename="name%TESTNUMBER;weird"
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -J output in
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -J, Content-Disposition and ; in filename
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O
+%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1313
+++ b/tests/data/test1313
@@ -25,22 +25,14 @@ Content-Disposition: inline; filename='name%TESTNUMBER
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -J output in
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -J, Content-Disposition, uneven quotes
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1334
+++ b/tests/data/test1334
@@ -23,22 +23,14 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O without Content-Disposition, -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D %LOGDIR/heads%TESTNUMBER
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1335
+++ b/tests/data/test1335
@@ -23,22 +23,14 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O without Content-Disposition, -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D -
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1336
+++ b/tests/data/test1336
@@ -24,22 +24,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O and Content-Disposition, -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D %LOGDIR/heads%TESTNUMBER
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1337
+++ b/tests/data/test1337
@@ -24,22 +24,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O and Content-Disposition, -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D -
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1338
+++ b/tests/data/test1338
@@ -24,22 +24,14 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O and -J output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -J without Content-Disposition, -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O -D %LOGDIR/heads%TESTNUMBER
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1339
+++ b/tests/data/test1339
@@ -24,22 +24,14 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O and -J output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -J without Content-Disposition, -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O -D -
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1340
+++ b/tests/data/test1340
@@ -63,7 +63,7 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 </file2>
 
 <file3 name="%LOGDIR/stdout%TESTNUMBER" mode="text">
-curl saved to filename %PWD/%LOGDIR/name%TESTNUMBER
+curl saved to filename %LOGDIR/name%TESTNUMBER
 </file3>
 
 </verify>

--- a/tests/data/test1340
+++ b/tests/data/test1340
@@ -25,22 +25,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O and -J output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -J and Content-Disposition, -D file
 </name>
-<setenv>
-CURL_TESTDIR=%PWD/%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O -D %LOGDIR/heads%TESTNUMBER -w "curl saved to filename %{filename_effective}\n"
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O -D %LOGDIR/heads%TESTNUMBER -w "curl saved to filename %{filename_effective}\n" --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1341
+++ b/tests/data/test1341
@@ -25,22 +25,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O and -J output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -J and Content-Disposition, -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%PWD/%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O -D - -w "curl saved to filename %{filename_effective}\n"
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O -D - -w "curl saved to filename %{filename_effective}\n" --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1341
+++ b/tests/data/test1341
@@ -60,7 +60,7 @@ Connection: close
 Content-Type: text/html
 Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 
-curl saved to filename %PWD/%LOGDIR/name%TESTNUMBER
+curl saved to filename %LOGDIR/name%TESTNUMBER
 </file2>
 
 </verify>

--- a/tests/data/test1342
+++ b/tests/data/test1342
@@ -23,22 +23,14 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -i without Content-Disposition, -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O -D %LOGDIR/heads%TESTNUMBER
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1343
+++ b/tests/data/test1343
@@ -23,22 +23,14 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -i without Content-Disposition, -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O -D -
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1344
+++ b/tests/data/test1344
@@ -24,22 +24,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -i and Content-Disposition, -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O -D %LOGDIR/heads%TESTNUMBER
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1345
+++ b/tests/data/test1345
@@ -24,22 +24,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -i and Content-Disposition, -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O -D -
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1346
+++ b/tests/data/test1346
@@ -23,22 +23,14 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -i without Content-Disposition, without -D
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1347
+++ b/tests/data/test1347
@@ -24,22 +24,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O -i and Content-Disposition, without -D
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -i -O --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1348
+++ b/tests/data/test1348
@@ -16,22 +16,14 @@ mooo
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file without Content-Disposition inside, using -O
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1349
+++ b/tests/data/test1349
@@ -16,22 +16,14 @@ mooo
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file without C-D inside, using -O -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -D %LOGDIR/heads%TESTNUMBER
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1350
+++ b/tests/data/test1350
@@ -16,22 +16,14 @@ mooo
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file without C-D inside, using -O -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -D -
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1351
+++ b/tests/data/test1351
@@ -17,22 +17,14 @@ mooo
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file without C-D inside, using -O -J -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -J -D %LOGDIR/heads%TESTNUMBER
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -J -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1352
+++ b/tests/data/test1352
@@ -17,22 +17,14 @@ mooo
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file without C-D inside, using -O -J -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -J -D -
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -J -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1353
+++ b/tests/data/test1353
@@ -16,22 +16,14 @@ mooo
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file without C-D inside, using -O -i -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i -D %LOGDIR/heads%TESTNUMBER
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1354
+++ b/tests/data/test1354
@@ -16,22 +16,14 @@ mooo
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file without C-D inside, using -O -i -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i -D -
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1355
+++ b/tests/data/test1355
@@ -16,22 +16,14 @@ mooo
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file without C-D inside, using -O -i, without -D
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1356
+++ b/tests/data/test1356
@@ -24,22 +24,14 @@ MOOOO
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file with Content-Disposition inside, using -O
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1357
+++ b/tests/data/test1357
@@ -24,22 +24,14 @@ MOOOO
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file with C-D inside, using -O -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -D %LOGDIR/heads%TESTNUMBER
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1358
+++ b/tests/data/test1358
@@ -24,22 +24,14 @@ MOOOO
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file with C-D inside, using -O -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -D -
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1359
+++ b/tests/data/test1359
@@ -25,22 +25,14 @@ MOOOO
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file with C-D inside, using -O -J -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -J -D %LOGDIR/heads%TESTNUMBER
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -J -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1360
+++ b/tests/data/test1360
@@ -25,22 +25,14 @@ MOOOO
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file with C-D inside, using -O -J -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -J -D -
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -J -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1361
+++ b/tests/data/test1361
@@ -24,22 +24,14 @@ MOOOO
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file with C-D inside, using -O -i -D file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i -D %LOGDIR/heads%TESTNUMBER
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i -D %LOGDIR/heads%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1362
+++ b/tests/data/test1362
@@ -24,22 +24,14 @@ MOOOO
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file with C-D inside, using -O -i -D stdout
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i -D -
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i -D - --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1363
+++ b/tests/data/test1363
@@ -24,22 +24,14 @@ MOOOO
 
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O output in, using the CURL_TESTDIR variable
-<features>
-Debug
-</features>
 <server>
 ftp
 </server>
 <name>
 FTP download, file with C-D inside, using -O -i, without -D
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i
+ftp://%HOSTIP:%FTPPORT/path/file%TESTNUMBER -O -i --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1422
+++ b/tests/data/test1422
@@ -24,10 +24,7 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=str//nge
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -O and -J output in, using the CURL_TESTDIR variable
 <features>
-Debug
 file
 </features>
 <server>
@@ -36,11 +33,8 @@ http
 <name>
 HTTP GET with -O -J and Content-Disposition (empty file)
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O file://%FILE_PWD/%LOGDIR/name%TESTNUMBER
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O file://%FILE_PWD/%LOGDIR/name%TESTNUMBER --output-dir %LOGDIR
 </command>
 </client>
 

--- a/tests/data/test1443
+++ b/tests/data/test1443
@@ -25,22 +25,14 @@ Connection: close
 #
 # Client-side
 <client>
-# This relies on the debug feature to allow us to set a directory
-# in which to store the -O output
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -O and --remote-time
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O --remote-time
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O --remote-time --output-dir %LOGDIR
 </command>
 # Verify the mtime of the file. The mtime is specifically chosen to be an even
 # number so that it can be represented exactly on a FAT filesystem.

--- a/tests/data/test1460
+++ b/tests/data/test1460
@@ -22,22 +22,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -J output in
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -Ji and Content-Disposition with existing file
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -Ji -O
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -Ji -O --output-dir %LOGDIR
 </command>
 <file name="%LOGDIR/name%TESTNUMBER">
 initial content

--- a/tests/data/test1487
+++ b/tests/data/test1487
@@ -25,22 +25,14 @@ Content-Disposition: filename=name%TESTNUMBER; charset=funny; option=strange
 #
 # Client-side
 <client>
-# this relies on the debug feature to allow us to set directory to store the
-# -J output in
-<features>
-Debug
-</features>
 <server>
 http
 </server>
 <name>
 HTTP GET with -J and Content-Disposition on 301
 </name>
-<setenv>
-CURL_TESTDIR=%LOGDIR
-</setenv>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -J -O --output-dir %LOGDIR
 </command>
 </client>
 


### PR DESCRIPTION
For all tests using -O that were previously relying on a debug build and the CURL_TESTDIR environment variable, use the plain --output-dir option instead so that they can run proper in non-debug builds.