### PR TITLE
lib: use bool/TRUE/FALSE properly

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -355,11 +355,11 @@ static CURLcode socket_open(struct Curl_easy *data,
     * might have been changed and this 'new' address will actually be used
     * here to connect.
     */
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     *sockfd = data->set.fopensocket(data->set.opensocket_client,
                                     CURLSOCKTYPE_IPCXN,
                                     (struct curl_sockaddr *)addr);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
   }
   else {
     /* opensocket callback not set, so simply create the socket now */
@@ -413,9 +413,9 @@ static int socket_close(struct Curl_easy *data, struct connectdata *conn,
   if(use_callback && conn && conn->fclosesocket) {
     int rc;
     Curl_multi_closed(data, sock);
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     rc = conn->fclosesocket(conn->closesocket_client, sock);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
     return rc;
   }
 
@@ -1164,11 +1164,11 @@ static CURLcode cf_socket_open(struct Curl_cfilter *cf,
 
   if(data->set.fsockopt) {
     /* activate callback for setting socket options */
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     error = data->set.fsockopt(data->set.sockopt_client,
                                ctx->sock,
                                CURLSOCKTYPE_IPCXN);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
 
     if(error == CURL_SOCKOPT_ALREADY_CONNECTED)
       isconnected = TRUE;

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -523,10 +523,10 @@ bool Curl_conn_cf_needs_flush(struct Curl_cfilter *cf,
                               struct Curl_easy *data)
 {
   CURLcode result;
-  int pending = FALSE;
+  int pending = 0;
   result = cf ? cf->cft->query(cf, data, CF_QUERY_NEED_FLUSH,
                                &pending, NULL) : CURLE_UNKNOWN_OPTION;
-  return (result || pending == FALSE) ? FALSE : TRUE;
+  return (result || !pending) ? FALSE : TRUE;
 }
 
 bool Curl_conn_needs_flush(struct Curl_easy *data, int sockindex)

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -163,7 +163,7 @@ int Curl_cpool_init(struct cpool *cpool,
   cpool->idata = curl_easy_init();
   if(!cpool->idata)
     return 1; /* bad */
-  cpool->idata->state.internal = true;
+  cpool->idata->state.internal = TRUE;
   /* TODO: this is quirky. We need an internal handle for certain
    * operations, but we do not add it to the multi (if there is one).
    * But we give it the multi so that socket event operations can work.
@@ -172,7 +172,7 @@ int Curl_cpool_init(struct cpool *cpool,
   cpool->idata->multi = multi;
  #ifdef DEBUGBUILD
   if(getenv("CURL_DEBUG"))
-    cpool->idata->set.verbose = true;
+    cpool->idata->set.verbose = TRUE;
 #endif
 
   cpool->disconnect_cb = disconnect_cb;

--- a/lib/curl_fnmatch.c
+++ b/lib/curl_fnmatch.c
@@ -161,7 +161,7 @@ static void setcharorrange(unsigned char **pp, unsigned char *charset)
   }
 }
 
-/* returns 1 (true) if pattern is OK, 0 if is bad ("p" is pattern pointer) */
+/* returns 1 (TRUE) if pattern is OK, 0 if is bad ("p" is pattern pointer) */
 static int setcharset(unsigned char **p, unsigned char *charset)
 {
   setcharset_state state = CURLFNM_SCHS_DEFAULT;
@@ -303,7 +303,7 @@ static int loop(const unsigned char *pattern, const unsigned char *string,
     case '[':
       pp = p + 1; /* Copy in case of syntax error in set. */
       if(setcharset(&pp, charset)) {
-        int found = FALSE;
+        bool found = FALSE;
         if(!*s)
           return CURL_FNMATCH_NOMATCH;
         if(charset[(unsigned int)*s])

--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -255,7 +255,7 @@ static CURLcode rtmp_connect(struct Curl_easy *data, bool *done)
     return CURLE_FAILED_INIT;
 
   /* Clients must send a periodic BytesReceived report to the server */
-  r->m_bSendCounter = true;
+  r->m_bSendCounter = TRUE;
 
   *done = TRUE;
   conn->recv[FIRSTSOCKET] = rtmp_recv;

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -65,7 +65,7 @@ void Curl_debug(struct Curl_easy *data, curl_infotype type,
       "* ", "< ", "> ", "{ ", "} ", "{ ", "} " };
     if(data->set.fdebug) {
       bool inCallback = Curl_is_in_callback(data);
-      Curl_set_in_callback(data, true);
+      Curl_set_in_callback(data, TRUE);
       (void)(*data->set.fdebug)(data, type, ptr, size, data->set.debugdata);
       Curl_set_in_callback(data, inCallback);
     }

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -198,10 +198,10 @@ static void doh_print_buf(struct Curl_easy *data,
 {
   unsigned char hexstr[LOCAL_PB_HEXMAX];
   size_t hlen = LOCAL_PB_HEXMAX;
-  bool truncated = false;
+  bool truncated = FALSE;
 
   if(len > (LOCAL_PB_HEXMAX / 2))
-    truncated = true;
+    truncated = TRUE;
   Curl_hexencode(buf, len, hexstr, hlen);
   if(!truncated)
     infof(data, "%s: len=%d, val=%s", prefix, (int)len, hexstr);
@@ -278,7 +278,7 @@ static CURLcode doh_run_probe(struct Curl_easy *data,
 
   /* pass in the struct pointer via a local variable to please coverity and
      the gcc typecheck helpers */
-  doh->state.internal = true;
+  doh->state.internal = TRUE;
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
   doh->state.feat = &Curl_doh_trc;
 #endif

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -465,11 +465,11 @@ static CURLcode AcceptServerConnect(struct Curl_easy *data)
     int error = 0;
 
     /* activate callback for setting socket options */
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     error = data->set.fsockopt(data->set.sockopt_client,
                                s,
                                CURLSOCKTYPE_ACCEPT);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
 
     if(error) {
       close_secondarysocket(data);
@@ -1704,10 +1704,10 @@ static CURLcode ftp_state_ul_setup(struct Curl_easy *data,
 
     /* Let's read off the proper amount of bytes from the input. */
     if(data->set.seek_func) {
-      Curl_set_in_callback(data, true);
+      Curl_set_in_callback(data, TRUE);
       seekerr = data->set.seek_func(data->set.seek_client,
                                     data->state.resume_from, SEEK_SET);
-      Curl_set_in_callback(data, false);
+      Curl_set_in_callback(data, FALSE);
     }
 
     if(seekerr != CURL_SEEKFUNC_OK) {
@@ -3406,9 +3406,9 @@ static CURLcode ftp_done(struct Curl_easy *data, CURLcode status,
 
   if(data->state.wildcardmatch) {
     if(data->set.chunk_end && ftpc->file) {
-      Curl_set_in_callback(data, true);
+      Curl_set_in_callback(data, TRUE);
       data->set.chunk_end(data->set.wildcardptr);
-      Curl_set_in_callback(data, false);
+      Curl_set_in_callback(data, FALSE);
     }
     ftpc->known_filesize = -1;
   }
@@ -4052,11 +4052,11 @@ static CURLcode wc_statemach(struct Curl_easy *data)
       infof(data, "Wildcard - START of \"%s\"", finfo->filename);
       if(data->set.chunk_bgn) {
         long userresponse;
-        Curl_set_in_callback(data, true);
+        Curl_set_in_callback(data, TRUE);
         userresponse = data->set.chunk_bgn(
           finfo, data->set.wildcardptr,
           (int)Curl_llist_count(&wildcard->filelist));
-        Curl_set_in_callback(data, false);
+        Curl_set_in_callback(data, FALSE);
         switch(userresponse) {
         case CURL_CHUNK_BGN_FUNC_SKIP:
           infof(data, "Wildcard - \"%s\" skipped by user",
@@ -4095,9 +4095,9 @@ static CURLcode wc_statemach(struct Curl_easy *data)
 
     case CURLWC_SKIP: {
       if(data->set.chunk_end) {
-        Curl_set_in_callback(data, true);
+        Curl_set_in_callback(data, TRUE);
         data->set.chunk_end(data->set.wildcardptr);
-        Curl_set_in_callback(data, false);
+        Curl_set_in_callback(data, FALSE);
       }
       Curl_node_remove(Curl_llist_head(&wildcard->filelist));
       wildcard->state = (Curl_llist_count(&wildcard->filelist) == 0) ?

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -334,7 +334,7 @@ static CURLcode ftp_pl_insert_finfo(struct Curl_easy *data,
     compare = Curl_fnmatch;
 
   /* filter pattern-corresponding filenames */
-  Curl_set_in_callback(data, true);
+  Curl_set_in_callback(data, TRUE);
   if(compare(data->set.fnmatch_data, wc->pattern,
              finfo->filename) == 0) {
     /* discard symlink which is containing multiple " -> " */
@@ -346,7 +346,7 @@ static CURLcode ftp_pl_insert_finfo(struct Curl_easy *data,
   else {
     add = FALSE;
   }
-  Curl_set_in_callback(data, false);
+  Curl_set_in_callback(data, FALSE);
 
   if(add) {
     Curl_llist_append(llist, finfo, &infop->list);

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -57,7 +57,7 @@ CURLcode Curl_initinfo(struct Curl_easy *data)
   pro->t_starttransfer = 0;
   pro->timespent = 0;
   pro->t_redirect = 0;
-  pro->is_t_startransfer_set = false;
+  pro->is_t_startransfer_set = FALSE;
 
   info->httpcode = 0;
   info->httpproxycode = 0;

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -313,7 +313,7 @@ static struct Curl_dns_entry *fetch_addr(struct Curl_easy *data,
   /* See if the returned entry matches the required resolve mode */
   if(dns && data->conn->ip_version != CURL_IPRESOLVE_WHATEVER) {
     int pf = PF_INET;
-    bool found = false;
+    bool found = FALSE;
     struct Curl_addrinfo *addr = dns->addr;
 
 #ifdef PF_INET6
@@ -323,7 +323,7 @@ static struct Curl_dns_entry *fetch_addr(struct Curl_easy *data,
 
     while(addr) {
       if(addr->ai_family == pf) {
-        found = true;
+        found = TRUE;
         break;
       }
       addr = addr->ai_next;
@@ -739,7 +739,7 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
     /* notify the resolver start callback */
     if(data->set.resolver_start) {
       int st;
-      Curl_set_in_callback(data, true);
+      Curl_set_in_callback(data, TRUE);
       st = data->set.resolver_start(
 #ifdef USE_CURL_ASYNC
         data->state.async.resolver,
@@ -748,7 +748,7 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
 #endif
         NULL,
         data->set.resolver_start_client);
-      Curl_set_in_callback(data, false);
+      Curl_set_in_callback(data, FALSE);
       if(st)
         return CURLRESOLV_ERROR;
     }
@@ -1129,7 +1129,7 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
   char *host_end;
 
   /* Default is no wildcard found */
-  data->state.wildcard_resolve = false;
+  data->state.wildcard_resolve = FALSE;
 
   for(hostp = data->state.resolve; hostp; hostp = hostp->next) {
     char entry_id[MAX_HOSTCACHE_LEN];
@@ -1179,7 +1179,7 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
       char *end_ptr;
       bool permanent = TRUE;
       unsigned long tmp_port;
-      bool error = true;
+      bool error = TRUE;
       char *host_begin = hostp->data;
       size_t hlen = 0;
 
@@ -1256,7 +1256,7 @@ CURLcode Curl_loadhostpairs(struct Curl_easy *data)
       if(!head)
         goto err;
 
-      error = false;
+      error = FALSE;
 err:
       if(error) {
         failf(data, "Couldn't parse CURLOPT_RESOLVE entry '%s'",
@@ -1316,7 +1316,7 @@ err:
       /* Wildcard hostname */
       if((hlen == 1) && (host_begin[0] == '*')) {
         infof(data, "RESOLVE *:%d using wildcard", port);
-        data->state.wildcard_resolve = true;
+        data->state.wildcard_resolve = TRUE;
       }
     }
   }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -993,11 +993,11 @@ static int push_promise(struct Curl_cfilter *cf,
     }
     DEBUGASSERT(stream);
 
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     rv = data->multi->push_cb(data, newhandle,
                               stream->push_headers_used, &heads,
                               data->multi->push_userp);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
 
     /* free the headers again */
     free_push_headers(stream);

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -176,7 +176,7 @@ static CURLcode make_headers(struct Curl_easy *data,
   struct curl_slist *tmp_head = NULL;
   CURLcode ret = CURLE_OUT_OF_MEMORY;
   struct curl_slist *l;
-  int again = 1;
+  bool again = TRUE;
 
   /* provider1 mid */
   Curl_strntolower(provider1, provider1, strlen(provider1));
@@ -300,7 +300,7 @@ static CURLcode make_headers(struct Curl_easy *data,
 
   /* alpha-sort by header name in a case sensitive manner */
   do {
-    again = 0;
+    again = FALSE;
     for(l = head; l; l = l->next) {
       struct curl_slist *next = l->next;
 
@@ -309,7 +309,7 @@ static CURLcode make_headers(struct Curl_easy *data,
 
         l->data = next->data;
         next->data = tmp;
-        again = 1;
+        again = TRUE;
       }
     }
   } while(again);
@@ -507,7 +507,7 @@ static CURLcode canon_string(const char *q, size_t len,
           /* allowed as-is */
           if(*q == '=') {
             result = Curl_dyn_addn(dq, q, 1);
-            *found_equals = true;
+            *found_equals = TRUE;
             break;
           }
         }
@@ -562,7 +562,7 @@ static CURLcode canon_query(struct Curl_easy *data,
   ap = &array[0];
   for(i = 0; !result && (i < entry); i++, ap++) {
     const char *q = ap->p;
-    bool found_equals = false;
+    bool found_equals = FALSE;
     if(!ap->len)
       continue;
     result = canon_string(q, ap->len, dq, &found_equals);
@@ -589,7 +589,7 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
   char provider1[MAX_SIGV4_LEN + 1]="";
   char region[MAX_SIGV4_LEN + 1]="";
   char service[MAX_SIGV4_LEN + 1]="";
-  bool sign_as_s3 = false;
+  bool sign_as_s3 = FALSE;
   const char *hostname = conn->host.name;
   time_t clock;
   struct tm tm;

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -516,9 +516,9 @@ static CURLcode add_last_chunk(struct Curl_easy *data,
   if(result)
     goto out;
 
-  Curl_set_in_callback(data, true);
+  Curl_set_in_callback(data, TRUE);
   rc = data->set.trailer_callback(&trailers, data->set.trailer_data);
-  Curl_set_in_callback(data, false);
+  Curl_set_in_callback(data, FALSE);
 
   if(rc != CURL_TRAILERFUNC_OK) {
     failf(data, "operation aborted by trailing headers callback");

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -520,8 +520,8 @@ static CURLcode imap_perform_login(struct Curl_easy *data,
   }
 
   /* Make sure the username and password are in the correct atom format */
-  user = imap_atom(conn->user, false);
-  passwd = imap_atom(conn->passwd, false);
+  user = imap_atom(conn->user, FALSE);
+  passwd = imap_atom(conn->passwd, FALSE);
 
   /* Send the LOGIN command */
   result = imap_sendf(data, "LOGIN %s %s", user ? user : "",
@@ -655,7 +655,7 @@ static CURLcode imap_perform_list(struct Curl_easy *data)
                         imap->custom_params ? imap->custom_params : "");
   else {
     /* Make sure the mailbox is in the correct atom format if necessary */
-    char *mailbox = imap->mailbox ? imap_atom(imap->mailbox, true)
+    char *mailbox = imap->mailbox ? imap_atom(imap->mailbox, TRUE)
                                   : strdup("");
     if(!mailbox)
       return CURLE_OUT_OF_MEMORY;
@@ -697,7 +697,7 @@ static CURLcode imap_perform_select(struct Curl_easy *data)
   }
 
   /* Make sure the mailbox is in the correct atom format */
-  mailbox = imap_atom(imap->mailbox, false);
+  mailbox = imap_atom(imap->mailbox, FALSE);
   if(!mailbox)
     return CURLE_OUT_OF_MEMORY;
 
@@ -809,7 +809,7 @@ static CURLcode imap_perform_append(struct Curl_easy *data)
   }
 
   /* Make sure the mailbox is in the correct atom format */
-  mailbox = imap_atom(imap->mailbox, false);
+  mailbox = imap_atom(imap->mailbox, FALSE);
   if(!mailbox)
     return CURLE_OUT_OF_MEMORY;
 
@@ -1859,7 +1859,7 @@ static bool imap_is_bchar(char ch)
   /* Performing the alnum check with this macro is faster because of ASCII
      arithmetic */
   if(ISALNUM(ch))
-    return true;
+    return TRUE;
 
   switch(ch) {
     /* bchar */
@@ -1873,10 +1873,10 @@ static bool imap_is_bchar(char ch)
     case '+': case ',':
     /* bchar -> achar -> uchar -> pct-encoded */
     case '%': /* HEXDIG chars are already included above */
-      return true;
+      return TRUE;
 
     default:
-      return false;
+      return FALSE;
   }
 }
 
@@ -1891,7 +1891,7 @@ static CURLcode imap_parse_url_options(struct connectdata *conn)
   CURLcode result = CURLE_OK;
   struct imap_conn *imapc = &conn->proto.imapc;
   const char *ptr = conn->options;
-  bool prefer_login = false;
+  bool prefer_login = FALSE;
 
   while(!result && ptr && *ptr) {
     const char *key = ptr;
@@ -1907,16 +1907,16 @@ static CURLcode imap_parse_url_options(struct connectdata *conn)
 
     if(strncasecompare(key, "AUTH=+LOGIN", 11)) {
       /* User prefers plaintext LOGIN over any SASL, including SASL LOGIN */
-      prefer_login = true;
+      prefer_login = TRUE;
       imapc->sasl.prefmech = SASL_AUTH_NONE;
     }
     else if(strncasecompare(key, "AUTH=", 5)) {
-      prefer_login = false;
+      prefer_login = FALSE;
       result = Curl_sasl_parse_url_auth_option(&imapc->sasl,
                                                value, ptr - value);
     }
     else {
-      prefer_login = false;
+      prefer_login = FALSE;
       result = CURLE_URL_MALFORMAT;
     }
 

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -668,7 +668,7 @@ static int formatf(
   char work[BUFFSIZE];
 
   /* 'workend' points to the final buffer byte position, but with an extra
-     byte as margin to avoid the (false?) warning Coverity gives us
+     byte as margin to avoid the (FALSE?) warning Coverity gives us
      otherwise */
   char *workend = &work[sizeof(work) - 2];
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -464,7 +464,7 @@ static void multi_warn_debug(struct Curl_multi *multi, struct Curl_easy *data)
     infof(data, "!!! WARNING !!!");
     infof(data, "This is a debug build of libcurl, "
           "do not use in production.");
-    multi->warned = true;
+    multi->warned = TRUE;
   }
 }
 #else
@@ -2102,13 +2102,13 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
         int prereq_rc;
 
         /* call the prerequest callback function */
-        Curl_set_in_callback(data, true);
+        Curl_set_in_callback(data, TRUE);
         prereq_rc = data->set.fprereq(data->set.prereq_userp,
                                       data->info.primary.remote_ip,
                                       data->info.primary.local_ip,
                                       data->info.primary.remote_port,
                                       data->info.primary.local_port);
-        Curl_set_in_callback(data, false);
+        Curl_set_in_callback(data, FALSE);
         if(prereq_rc != CURL_PREREQFUNC_OK) {
           failf(data, "operation aborted by pre-request callback");
           /* failure in pre-request callback - do not do any other
@@ -2535,7 +2535,7 @@ static CURLMcode multi_runsingle(struct Curl_multi *multi,
     if(data->mstate >= MSTATE_CONNECT &&
        data->mstate < MSTATE_DO &&
        rc != CURLM_CALL_MULTI_PERFORM &&
-       !multi_ischanged(multi, false)) {
+       !multi_ischanged(multi, FALSE)) {
       /* We now handle stream timeouts if and only if this will be the last
        * loop iteration. We only check this on the last iteration to ensure
        * that if we know we have additional work to do immediately

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -74,8 +74,8 @@ static int parsenetrc(const char *host,
 
   char state_login = 0;      /* Found a login keyword */
   char state_password = 0;   /* Found a password keyword */
-  int state_our_login = TRUE;  /* With specific_login, found *our* login
-                                  name (or login-less line) */
+  bool state_our_login = TRUE;  /* With specific_login, found *our* login
+                                   name (or login-less line) */
 
   DEBUGASSERT(netrcfile);
 

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -471,9 +471,8 @@ static CURLcode oldap_ssl_connect(struct Curl_easy *data, ldapstate newstate)
 {
   struct connectdata *conn = data->conn;
   struct ldapconninfo *li = conn->proto.ldapc;
-  bool ssldone = 0;
-  CURLcode result =
-    Curl_conn_connect(data, FIRSTSOCKET, FALSE, &ssldone);
+  bool ssldone = FALSE;
+  CURLcode result = Curl_conn_connect(data, FIRSTSOCKET, FALSE, &ssldone);
   if(!result) {
     oldap_state(data, newstate);
 
@@ -973,7 +972,7 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
   BerElement *ber = NULL;
   struct timeval tv = {0, 0};
   struct berval bv, *bvals;
-  int binary = 0;
+  bool binary = FALSE;
   CURLcode result = CURLE_AGAIN;
   int code;
   char *info = NULL;
@@ -1056,10 +1055,10 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
       }
 
       binary = bv.bv_len > 7 &&
-               !strncmp(bv.bv_val + bv.bv_len - 7, ";binary", 7);
+        !strncmp(bv.bv_val + bv.bv_len - 7, ";binary", 7);
 
       for(i = 0; bvals[i].bv_val != NULL; i++) {
-        int binval = 0;
+        bool binval = FALSE;
 
         result = client_write(data, STRCONST("\t"), bv.bv_val, bv.bv_len,
                               STRCONST(":"));
@@ -1070,13 +1069,13 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
           /* check for leading or trailing whitespace */
           if(ISBLANK(bvals[i].bv_val[0]) ||
              ISBLANK(bvals[i].bv_val[bvals[i].bv_len - 1]))
-            binval = 1;
+            binval = TRUE;
           else {
             /* check for unprintable characters */
             unsigned int j;
             for(j = 0; j < bvals[i].bv_len; j++)
               if(!ISPRINT(bvals[i].bv_val[j])) {
-                binval = 1;
+                binval = TRUE;
                 break;
               }
           }

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -174,7 +174,7 @@ void Curl_pgrsTimeWas(struct Curl_easy *data, timerid timer,
   case TIMER_STARTSINGLE:
     /* This is set at the start of each single transfer */
     data->progress.t_startsingle = timestamp;
-    data->progress.is_t_startransfer_set = false;
+    data->progress.is_t_startransfer_set = FALSE;
     break;
   case TIMER_POSTQUEUE:
     /* Set when the transfer starts (after potentially having been brought
@@ -211,7 +211,7 @@ void Curl_pgrsTimeWas(struct Curl_easy *data, timerid timer,
       return;
     }
     else {
-      data->progress.is_t_startransfer_set = true;
+      data->progress.is_t_startransfer_set = TRUE;
       break;
     }
   case TIMER_POSTRANSFER:
@@ -249,7 +249,7 @@ void Curl_pgrsStartNow(struct Curl_easy *data)
 {
   data->progress.speeder_c = 0; /* reset the progress meter display */
   data->progress.start = Curl_now();
-  data->progress.is_t_startransfer_set = false;
+  data->progress.is_t_startransfer_set = FALSE;
   data->progress.ul.limit.start = data->progress.start;
   data->progress.dl.limit.start = data->progress.start;
   data->progress.ul.limit.start_size = 0;
@@ -583,13 +583,13 @@ static int pgrsupdate(struct Curl_easy *data, bool showprogress)
     if(data->set.fxferinfo) {
       int result;
       /* There is a callback set, call that */
-      Curl_set_in_callback(data, true);
+      Curl_set_in_callback(data, TRUE);
       result = data->set.fxferinfo(data->set.progress_client,
                                    data->progress.dl.total_size,
                                    data->progress.dl.cur_size,
                                    data->progress.ul.total_size,
                                    data->progress.ul.cur_size);
-      Curl_set_in_callback(data, false);
+      Curl_set_in_callback(data, FALSE);
       if(result != CURL_PROGRESSFUNC_CONTINUE) {
         if(result)
           failf(data, "Callback aborted");
@@ -599,13 +599,13 @@ static int pgrsupdate(struct Curl_easy *data, bool showprogress)
     else if(data->set.fprogress) {
       int result;
       /* The older deprecated callback is set, call that */
-      Curl_set_in_callback(data, true);
+      Curl_set_in_callback(data, TRUE);
       result = data->set.fprogress(data->set.progress_client,
                                    (double)data->progress.dl.total_size,
                                    (double)data->progress.dl.cur_size,
                                    (double)data->progress.ul.total_size,
                                    (double)data->progress.ul.cur_size);
-      Curl_set_in_callback(data, false);
+      Curl_set_in_callback(data, FALSE);
       if(result != CURL_PROGRESSFUNC_CONTINUE) {
         if(result)
           failf(data, "Callback aborted");

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -898,9 +898,9 @@ CURLcode rtp_client_write(struct Curl_easy *data, const char *ptr, size_t len)
     user_ptr = data->set.out;
   }
 
-  Curl_set_in_callback(data, true);
+  Curl_set_in_callback(data, TRUE);
   wrote = writeit((char *)ptr, 1, len, user_ptr);
-  Curl_set_in_callback(data, false);
+  Curl_set_in_callback(data, FALSE);
 
   if(CURL_WRITEFUNC_PAUSE == wrote) {
     failf(data, "Cannot pause RTP");

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -677,9 +677,9 @@ static CURLcode cr_in_read(struct Curl_easy *data,
   }
   nread = 0;
   if(ctx->read_cb && blen) {
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     nread = ctx->read_cb(buf, 1, blen, ctx->cb_user_data);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
     ctx->has_used_cb = TRUE;
   }
 
@@ -773,9 +773,9 @@ static CURLcode cr_in_resume_from(struct Curl_easy *data,
     return CURLE_READ_ERROR;
 
   if(data->set.seek_func) {
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     seekerr = data->set.seek_func(data->set.seek_client, offset, SEEK_SET);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
   }
 
   if(seekerr != CURL_SEEKFUNC_OK) {
@@ -794,10 +794,10 @@ static CURLcode cr_in_resume_from(struct Curl_easy *data,
         curlx_sotouz(offset - passed);
       size_t actuallyread;
 
-      Curl_set_in_callback(data, true);
+      Curl_set_in_callback(data, TRUE);
       actuallyread = ctx->read_cb(scratch, 1, readthisamountnow,
                                   ctx->cb_user_data);
-      Curl_set_in_callback(data, false);
+      Curl_set_in_callback(data, FALSE);
 
       passed += actuallyread;
       if((actuallyread == 0) || (actuallyread > readthisamountnow)) {
@@ -835,9 +835,9 @@ static CURLcode cr_in_rewind(struct Curl_easy *data,
   if(data->set.seek_func) {
     int err;
 
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     err = (data->set.seek_func)(data->set.seek_client, 0, SEEK_SET);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
     CURL_TRC_READ(data, "cr_in, rewind via set.seek_func -> %d", err);
     if(err) {
       failf(data, "seek callback returned error %d", (int)err);
@@ -847,10 +847,10 @@ static CURLcode cr_in_rewind(struct Curl_easy *data,
   else if(data->set.ioctl_func) {
     curlioerr err;
 
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     err = (data->set.ioctl_func)(data, CURLIOCMD_RESTARTREAD,
                                  data->set.ioctl_client);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
     CURL_TRC_READ(data, "cr_in, rewind via set.ioctl_func -> %d", (int)err);
     if(err) {
       failf(data, "ioctl callback returned error %d", (int)err);
@@ -1014,7 +1014,7 @@ static CURLcode cr_lc_read(struct Curl_easy *data,
         ctx->prev_cr = (buf[i] == '\r');
         continue;
       }
-      ctx->prev_cr = false;
+      ctx->prev_cr = FALSE;
       /* on a soft limit bufq, we do not need to check length */
       result = Curl_bufq_cwrite(&ctx->buf, buf + start, i - start, &n);
       if(!result)

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -908,7 +908,7 @@ static CURLcode smb_connection_state(struct Curl_easy *data, bool *done)
     }
     smbc->uid = smb_swap16(h->uid);
     conn_state(data, SMB_CONNECTED);
-    *done = true;
+    *done = TRUE;
     break;
 
   default:
@@ -1108,7 +1108,7 @@ static CURLcode smb_request_state(struct Curl_easy *data, bool *done)
 
   case SMB_DONE:
     result = req->result;
-    *done = true;
+    *done = TRUE;
     break;
 
   default:

--- a/lib/url.c
+++ b/lib/url.c
@@ -2913,8 +2913,8 @@ static CURLcode parse_connect_to_string(struct Curl_easy *data,
 {
   CURLcode result = CURLE_OK;
   const char *ptr = conn_to_host;
-  int host_match = FALSE;
-  int port_match = FALSE;
+  bool host_match = FALSE;
+  bool port_match = FALSE;
 
   *host_result = NULL;
   *port_result = -1;

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -329,7 +329,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
   /* We had an input token before so if there is another one now that means we
      provided bad credentials in the previous request or it is stale. */
   if(digest->input_token) {
-    bool stale = false;
+    bool stale = FALSE;
     const char *p = chlg;
 
     /* Check for the 'stale' directive */
@@ -345,7 +345,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 
       if(strcasecompare(value, "stale") &&
          strcasecompare(content, "true")) {
-        stale = true;
+        stale = TRUE;
         break;
       }
 

--- a/lib/vauth/gsasl.c
+++ b/lib/vauth/gsasl.c
@@ -59,7 +59,7 @@ bool Curl_auth_gsasl_is_supported(struct Curl_easy *data,
     return FALSE;
   }
 
-  return true;
+  return TRUE;
 }
 
 CURLcode Curl_auth_gsasl_start(struct Curl_easy *data,

--- a/lib/version_win32.c
+++ b/lib/version_win32.c
@@ -209,12 +209,12 @@ bool curlx_verify_windows_version(const unsigned int majorVersion,
   typedef LONG (APIENTRY *RTLVERIFYVERSIONINFO_FN)
     (struct OUR_OSVERSIONINFOEXW *, ULONG, ULONGLONG);
   static RTLVERIFYVERSIONINFO_FN pRtlVerifyVersionInfo;
-  static bool onetime = true; /* safe because first call is during init */
+  static bool onetime = TRUE; /* safe because first call is during init */
 
   if(onetime) {
     pRtlVerifyVersionInfo = CURLX_FUNCTION_CAST(RTLVERIFYVERSIONINFO_FN,
       (GetProcAddress(GetModuleHandleA("ntdll"), "RtlVerifyVersionInfo")));
-    onetime = false;
+    onetime = FALSE;
   }
 
   switch(condition) {

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -280,9 +280,9 @@ static void MSH3_CALL msh3_conn_connected(MSH3_CONNECTION *Connection,
   (void)Connection;
 
   CURL_TRC_CF(data, cf, "[MSH3] connected");
-  ctx->handshake_succeeded = true;
-  ctx->connected = true;
-  ctx->handshake_complete = true;
+  ctx->handshake_succeeded = TRUE;
+  ctx->connected = TRUE;
+  ctx->handshake_complete = TRUE;
 }
 
 static void MSH3_CALL msh3_conn_shutdown_complete(MSH3_CONNECTION *Connection,
@@ -294,8 +294,8 @@ static void MSH3_CALL msh3_conn_shutdown_complete(MSH3_CONNECTION *Connection,
 
   (void)Connection;
   CURL_TRC_CF(data, cf, "[MSH3] shutdown complete");
-  ctx->connected = false;
-  ctx->handshake_complete = true;
+  ctx->connected = FALSE;
+  ctx->handshake_complete = TRUE;
 }
 
 static void MSH3_CALL msh3_conn_new_request(MSH3_CONNECTION *Connection,
@@ -450,7 +450,7 @@ static bool MSH3_CALL msh3_data_received(MSH3_REQUEST *Request,
       stream->recv_error = result;
       goto out;
     }
-    stream->recv_header_complete = true;
+    stream->recv_header_complete = TRUE;
   }
 
   result = write_resp_raw(data, buf, *buflen);
@@ -476,7 +476,7 @@ static void MSH3_CALL msh3_complete(MSH3_REQUEST *Request, void *IfContext,
     return;
   msh3_lock_acquire(&stream->recv_lock);
   stream->closed = TRUE;
-  stream->recv_header_complete = true;
+  stream->recv_header_complete = TRUE;
   if(error)
     stream->error3 = error;
   if(aborted)

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1309,7 +1309,7 @@ static CURLcode cf_osslq_stream_recv(struct cf_osslq_stream *s,
   CURLcode result = CURLE_OK;
   ssize_t nread;
   struct h3_quic_recv_ctx x;
-  int rv, eagain = FALSE;
+  bool eagain = FALSE;
   size_t total_recv_len = 0;
 
   DEBUGASSERT(s);
@@ -1359,6 +1359,7 @@ static CURLcode cf_osslq_stream_recv(struct cf_osslq_stream *s,
 
     /* When we forwarded everything, handle RESET/EOS */
     if(Curl_bufq_is_empty(&s->recvbuf) && !s->closed) {
+      int rv;
       result = CURLE_OK;
       if(s->reset) {
         uint64_t app_error;
@@ -1632,11 +1633,11 @@ static CURLcode check_and_set_expiry(struct Curl_cfilter *cf,
   CURLcode result = CURLE_OK;
   struct timeval tv;
   timediff_t timeoutms;
-  int is_infinite = TRUE;
+  int is_infinite = 1;
 
   if(ctx->tls.ossl.ssl &&
-    SSL_get_event_timeout(ctx->tls.ossl.ssl, &tv, &is_infinite) &&
-    !is_infinite) {
+     SSL_get_event_timeout(ctx->tls.ossl.ssl, &tv, &is_infinite) &&
+     !is_infinite) {
     timeoutms = curlx_tvtoms(&tv);
     /* QUIC want to be called again latest at the returned timeout */
     if(timeoutms <= 0) {

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1287,7 +1287,7 @@ static CURLcode cf_quiche_ctx_open(struct Curl_cfilter *cf,
     failf(data, "cannot create quiche config");
     return CURLE_FAILED_INIT;
   }
-  quiche_config_enable_pacing(ctx->cfg, false);
+  quiche_config_enable_pacing(ctx->cfg, FALSE);
   quiche_config_set_max_idle_timeout(ctx->cfg, CURL_QUIC_MAX_IDLE_MS);
   quiche_config_set_initial_max_data(ctx->cfg, (1 * 1024 * 1024)
     /* (QUIC_MAX_STREAMS/2) * H3_STREAM_WINDOW_SIZE */);
@@ -1334,7 +1334,7 @@ static CURLcode cf_quiche_ctx_open(struct Curl_cfilter *cf,
                                         ctx->q.local_addrlen,
                                         &sockaddr->curl_sa_addr,
                                         sockaddr->addrlen,
-                                        ctx->cfg, ctx->tls.ossl.ssl, false);
+                                        ctx->cfg, ctx->tls.ossl.ssl, FALSE);
   if(!ctx->qconn) {
     failf(data, "cannot create quiche connection");
     return CURLE_OUT_OF_MEMORY;

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -173,10 +173,10 @@ static CURLcode Curl_wssl_init_ctx(struct curl_tls_ctx *ctx,
 
   /* give application a chance to interfere with SSL set up. */
   if(data->set.ssl.fsslctx) {
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     result = (*data->set.ssl.fsslctx)(data, ctx->wssl.ctx,
                                       data->set.ssl.fsslctxp);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
     if(result) {
       failf(data, "error signaled by ssl ctx callback");
       goto out;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -496,11 +496,11 @@ static int myssh_is_known(struct Curl_easy *data)
         goto cleanup;
       }
 
-      Curl_set_in_callback(data, true);
+      Curl_set_in_callback(data, TRUE);
       rc = func(data, knownkeyp, /* from the knownhosts file */
                 &foundkey, /* from the remote host */
                 keymatch, data->set.ssh_keyfunc_userp);
-      Curl_set_in_callback(data, false);
+      Curl_set_in_callback(data, FALSE);
 
       switch(rc) {
       case CURLKHSTAT_FINE_ADD_TO_FILE:
@@ -1294,10 +1294,10 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       if(data->state.resume_from > 0) {
         /* Let's read off the proper amount of bytes from the input. */
         if(data->set.seek_func) {
-          Curl_set_in_callback(data, true);
+          Curl_set_in_callback(data, TRUE);
           seekerr = data->set.seek_func(data->set.seek_client,
                                         data->state.resume_from, SEEK_SET);
-          Curl_set_in_callback(data, false);
+          Curl_set_in_callback(data, FALSE);
         }
 
         if(seekerr != CURL_SEEKFUNC_OK) {
@@ -2317,7 +2317,7 @@ CURLcode scp_perform(struct Curl_easy *data,
 static CURLcode myssh_do_it(struct Curl_easy *data, bool *done)
 {
   CURLcode result;
-  bool connected = 0;
+  bool connected = FALSE;
   struct connectdata *conn = data->conn;
   struct ssh_conn *sshc = &conn->proto.sshc;
 

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -580,11 +580,11 @@ static CURLcode ssh_knownhost(struct Curl_easy *data)
         keymatch = (enum curl_khmatch)keycheck;
 
         /* Ask the callback how to behave */
-        Curl_set_in_callback(data, true);
+        Curl_set_in_callback(data, TRUE);
         rc = func(data, knownkeyp, /* from the knownhosts file */
                   &foundkey, /* from the remote host */
                   keymatch, data->set.ssh_keyfunc_userp);
-        Curl_set_in_callback(data, false);
+        Curl_set_in_callback(data, FALSE);
       }
     }
     else
@@ -782,10 +782,10 @@ static CURLcode ssh_check_fingerprint(struct Curl_easy *data)
                                                       &keylen, &sshkeytype);
       if(remotekey) {
         enum curl_khtype keytype = convert_ssh2_keytype(sshkeytype);
-        Curl_set_in_callback(data, true);
+        Curl_set_in_callback(data, TRUE);
         rc = data->set.ssh_hostkeyfunc(data->set.ssh_hostkeyfunc_userp,
                                        (int)keytype, remotekey, keylen);
-        Curl_set_in_callback(data, false);
+        Curl_set_in_callback(data, FALSE);
         if(rc!= CURLKHMATCH_OK) {
           state(data, SSH_SESSION_FREE);
           sshc->actualcode = CURLE_PEER_FAILED_VERIFICATION;
@@ -849,7 +849,7 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data)
   const char *kh_name_end = NULL;
   size_t kh_name_size = 0;
   int port = 0;
-  bool found = false;
+  bool found = FALSE;
 
   if(sshc->kh && !data->set.str[STRING_SSH_HOST_PUBLIC_KEY_MD5]) {
     /* lets try to find our host in the known hosts file */
@@ -870,18 +870,18 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data)
               kh_name_size = strlen(store->name) - 1 - strlen(kh_name_end);
               if(strncmp(store->name + 1,
                  conn->host.name, kh_name_size) == 0) {
-                found = true;
+                found = TRUE;
                 break;
               }
             }
           }
           else if(strcmp(store->name, conn->host.name) == 0) {
-            found = true;
+            found = TRUE;
             break;
           }
         }
         else {
-          found = true;
+          found = TRUE;
           break;
         }
       }
@@ -2148,10 +2148,10 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
       if(data->state.resume_from > 0) {
         /* Let's read off the proper amount of bytes from the input. */
         if(data->set.seek_func) {
-          Curl_set_in_callback(data, true);
+          Curl_set_in_callback(data, TRUE);
           seekerr = data->set.seek_func(data->set.seek_client,
                                         data->state.resume_from, SEEK_SET);
-          Curl_set_in_callback(data, false);
+          Curl_set_in_callback(data, FALSE);
         }
 
         if(seekerr != CURL_SEEKFUNC_OK) {
@@ -2170,11 +2170,11 @@ static CURLcode ssh_statemach_act(struct Curl_easy *data, bool *block)
               sizeof(scratch) : curlx_sotouz(data->state.resume_from - passed);
 
             size_t actuallyread;
-            Curl_set_in_callback(data, true);
+            Curl_set_in_callback(data, TRUE);
             actuallyread = data->state.fread_func(scratch, 1,
                                                   readthisamountnow,
                                                   data->state.in);
-            Curl_set_in_callback(data, false);
+            Curl_set_in_callback(data, FALSE);
 
             passed += actuallyread;
             if((actuallyread == 0) || (actuallyread > readthisamountnow)) {
@@ -3453,7 +3453,7 @@ static CURLcode scp_doing(struct Curl_easy *data,
 static CURLcode ssh_do(struct Curl_easy *data, bool *done)
 {
   CURLcode result;
-  bool connected = 0;
+  bool connected = FALSE;
   struct connectdata *conn = data->conn;
   struct ssh_conn *sshc = &conn->proto.sshc;
 

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -629,10 +629,10 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
         /* Let's read off the proper amount of bytes from the input. */
         int seekerr = CURL_SEEKFUNC_OK;
         if(data->set.seek_func) {
-          Curl_set_in_callback(data, true);
+          Curl_set_in_callback(data, TRUE);
           seekerr = data->set.seek_func(data->set.seek_client,
                                         data->state.resume_from, SEEK_SET);
-          Curl_set_in_callback(data, false);
+          Curl_set_in_callback(data, FALSE);
         }
 
         if(seekerr != CURL_SEEKFUNC_OK) {
@@ -651,11 +651,11 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
               sizeof(scratch) : curlx_sotouz(data->state.resume_from - passed);
 
             size_t actuallyread;
-            Curl_set_in_callback(data, true);
+            Curl_set_in_callback(data, TRUE);
             actuallyread = data->state.fread_func(scratch, 1,
                                                   readthisamountnow,
                                                   data->state.in);
-            Curl_set_in_callback(data, false);
+            Curl_set_in_callback(data, FALSE);
 
             passed += actuallyread;
             if((actuallyread == 0) || (actuallyread > readthisamountnow)) {
@@ -962,7 +962,7 @@ CURLcode wsftp_perform(struct Curl_easy *data,
 static CURLcode wssh_do(struct Curl_easy *data, bool *done)
 {
   CURLcode result;
-  bool connected = 0;
+  bool connected = FALSE;
   struct connectdata *conn = data->conn;
   struct ssh_conn *sshc = &conn->proto.sshc;
 

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -653,10 +653,10 @@ static CURLcode bearssl_connect_step1(struct Curl_cfilter *cf,
 
   /* give application a chance to interfere with SSL set up. */
   if(data->set.ssl.fsslctx) {
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     ret = (*data->set.ssl.fsslctx)(data, &backend->ctx,
                                    data->set.ssl.fsslctxp);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
     if(ret) {
       failf(data, "BearSSL: error signaled by ssl ctx callback");
       return ret;
@@ -791,7 +791,7 @@ static CURLcode bearssl_connect_step2(struct Curl_cfilter *cf,
     }
     br_ssl_engine_get_session_parameters(&backend->ctx.eng, &session);
     Curl_cipher_suite_get_str(session.cipher_suite, cipher_str,
-                              sizeof(cipher_str), true);
+                              sizeof(cipher_str), TRUE);
     infof(data, "BearSSL: %s connection using %s", ver_str, cipher_str);
   }
   return ret;

--- a/lib/vtls/cipher_suite.c
+++ b/lib/vtls/cipher_suite.c
@@ -844,10 +844,10 @@ static bool cs_is_separator(char c)
     case ':':
     case ',':
     case ';':
-      return true;
+      return TRUE;
     default:;
   }
-  return false;
+  return FALSE;
 }
 
 uint16_t Curl_cipher_suite_walk_str(const char **str, const char **end)

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -509,7 +509,7 @@ static CURLcode gtls_populate_creds(struct Curl_cfilter *cf,
   int rc;
 
   if(config->verifypeer) {
-    bool imported_native_ca = false;
+    bool imported_native_ca = FALSE;
 
     if(ssl_config->native_ca_store) {
       rc = gnutls_certificate_set_x509_system_trust(creds);
@@ -519,7 +519,7 @@ static CURLcode gtls_populate_creds(struct Curl_cfilter *cf,
       else {
         infof(data, "found %d certificates in native ca store", rc);
         if(rc > 0)
-          imported_native_ca = true;
+          imported_native_ca = TRUE;
       }
     }
 
@@ -590,7 +590,7 @@ static bool gtls_shared_creds_expired(const struct Curl_easy *data,
   timediff_t timeout_ms = cfg->ca_cache_timeout * (timediff_t)1000;
 
   if(timeout_ms < 0)
-    return false;
+    return FALSE;
 
   return elapsed_ms >= timeout_ms;
 }

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -99,13 +99,13 @@ Curl_tls_keylog_write_line(const char *line)
   char buf[256];
 
   if(!keylog_file_fp || !line) {
-    return false;
+    return FALSE;
   }
 
   linelen = strlen(line);
   if(linelen == 0 || linelen > sizeof(buf) - 2) {
     /* Empty line or too big to fit in a LF and NUL. */
-    return false;
+    return FALSE;
   }
 
   memcpy(buf, line, linelen);
@@ -117,7 +117,7 @@ Curl_tls_keylog_write_line(const char *line)
   /* Using fputs here instead of fprintf since libcurl's fprintf replacement
      may not be thread-safe. */
   fputs(buf, keylog_file_fp);
-  return true;
+  return TRUE;
 }
 
 bool
@@ -131,13 +131,13 @@ Curl_tls_keylog_write(const char *label,
             2 * SECRET_MAXLEN + 1 + 1];
 
   if(!keylog_file_fp) {
-    return false;
+    return FALSE;
   }
 
   pos = strlen(label);
   if(pos > KEYLOG_LABEL_MAXLEN || !secretlen || secretlen > SECRET_MAXLEN) {
     /* Should never happen - sanity check anyway. */
-    return false;
+    return FALSE;
   }
 
   memcpy(line, label, pos);
@@ -161,7 +161,7 @@ Curl_tls_keylog_write(const char *label,
   /* Using fputs here instead of fprintf since libcurl's fprintf replacement
      may not be thread-safe. */
   fputs(line, keylog_file_fp);
-  return true;
+  return TRUE;
 }
 
 #endif  /* TLS or QUIC backend */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1005,7 +1005,7 @@ mbed_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
     uint16_t cipher_id;
     cipher_id = (uint16_t)
                 mbedtls_ssl_get_ciphersuite_id_from_ssl(&backend->ssl);
-    mbed_cipher_suite_get_str(cipher_id, cipher_str, sizeof(cipher_str), true);
+    mbed_cipher_suite_get_str(cipher_id, cipher_str, sizeof(cipher_str), TRUE);
     infof(data, "mbedTLS: %s Handshake complete, cipher is %s",
           mbedtls_ssl_get_version(&backend->ssl), cipher_str);
   }

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -916,7 +916,7 @@ ossl_log_tls12_secret(const SSL *ssl, bool *keylog_done)
   if(master_key_length <= 0)
     return;
 
-  *keylog_done = true;
+  *keylog_done = TRUE;
   Curl_tls_keylog_write("CLIENT_RANDOM", client_random,
                         master_key, master_key_length);
 }
@@ -3004,7 +3004,7 @@ static CURLcode import_windows_cert_store(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   HCERTSTORE hStore;
 
-  *imported = false;
+  *imported = FALSE;
 
   hStore = CertOpenSystemStoreA(0, name);
   if(hStore) {
@@ -3091,12 +3091,12 @@ static CURLcode import_windows_cert_store(struct Curl_easy *data,
           }
           else {
             DWORD i;
-            bool found = false;
+            bool found = FALSE;
 
             for(i = 0; i < enhkey_usage->cUsageIdentifier; ++i) {
               if(!strcmp("1.3.6.1.5.5.7.3.1" /* OID server auth */,
                          enhkey_usage->rgpszUsageIdentifier[i])) {
-                found = true;
+                found = TRUE;
                 break;
               }
             }
@@ -3122,7 +3122,7 @@ static CURLcode import_windows_cert_store(struct Curl_easy *data,
 #if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
         infof(data, "SSL: Imported cert");
 #endif
-        *imported = true;
+        *imported = TRUE;
       }
       X509_free(x509);
     }
@@ -3154,8 +3154,8 @@ static CURLcode populate_x509_store(struct Curl_cfilter *cf,
   const char * const ssl_capath = conn_config->CApath;
   const char * const ssl_crlfile = ssl_config->primary.CRLfile;
   const bool verifypeer = conn_config->verifypeer;
-  bool imported_native_ca = false;
-  bool imported_ca_info_blob = false;
+  bool imported_native_ca = FALSE;
+  bool imported_ca_info_blob = FALSE;
 
   CURL_TRC_CF(data, cf, "populate_x509_store, path=%s, blob=%d",
               ssl_cafile ? ssl_cafile : "none", !!ca_info_blob);
@@ -3176,14 +3176,14 @@ static CURLcode populate_x509_store(struct Curl_cfilter *cf,
       };
       size_t i;
       for(i = 0; i < ARRAYSIZE(storeNames); ++i) {
-        bool imported = false;
+        bool imported = FALSE;
         result = import_windows_cert_store(data, storeNames[i], store,
                                            &imported);
         if(result)
           return result;
         if(imported) {
           infof(data, "successfully imported Windows %s store", storeNames[i]);
-          imported_native_ca = true;
+          imported_native_ca = TRUE;
         }
         else
           infof(data, "error importing Windows %s store, continuing anyway",
@@ -3198,7 +3198,7 @@ static CURLcode populate_x509_store(struct Curl_cfilter *cf,
         return result;
       }
       else {
-        imported_ca_info_blob = true;
+        imported_ca_info_blob = TRUE;
         infof(data, "successfully imported CA certificate blob");
       }
     }
@@ -3795,10 +3795,10 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
         return result;
       octx->x509_store_setup = TRUE;
     }
-    Curl_set_in_callback(data, true);
+    Curl_set_in_callback(data, TRUE);
     result = (*data->set.ssl.fsslctx)(data, octx->ssl_ctx,
                                       data->set.ssl.fsslctxp);
-    Curl_set_in_callback(data, false);
+    Curl_set_in_callback(data, FALSE);
     if(result) {
       failf(data, "error signaled by ssl ctx callback");
       return result;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -852,7 +852,7 @@ cr_connect_common(struct Curl_cfilter *cf,
           ver = "TLSv1.3";
         if(proto == RUSTLS_TLS_VERSION_TLSV1_2)
           ver = "TLSv1.2";
-        Curl_cipher_suite_get_str(cipher, buf, sizeof(buf), true);
+        Curl_cipher_suite_get_str(cipher, buf, sizeof(buf), TRUE);
         infof(data, "rustls: handshake complete, %s, cipher: %s",
               ver, buf);
       }
@@ -935,7 +935,7 @@ cr_connect_common(struct Curl_cfilter *cf,
 
   /* We should never fall through the loop. We should return either because
      the handshake is done or because we cannot read/write without blocking. */
-  DEBUGASSERT(false);
+  DEBUGASSERT(FALSE);
 }
 
 static CURLcode

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1090,14 +1090,14 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     curlx_verify_windows_version(6, 3, 0, PLATFORM_WINNT,
                                  VERSION_GREATER_THAN_EQUAL);
 #else
-  backend->use_alpn = false;
+  backend->use_alpn = FALSE;
 #endif
 
 #ifdef _WIN32_WCE
 #ifdef HAS_MANUAL_VERIFY_API
   /* certificate validation on CE does not seem to work right; we will
    * do it following a more manual process. */
-  backend->use_manual_cred_validation = true;
+  backend->use_manual_cred_validation = TRUE;
 #else
 #error "compiler too old to support Windows CE requisite manual cert verify"
 #endif
@@ -1106,7 +1106,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   if(conn_config->CAfile || conn_config->ca_info_blob) {
     if(curlx_verify_windows_version(6, 1, 0, PLATFORM_WINNT,
                                     VERSION_GREATER_THAN_EQUAL)) {
-      backend->use_manual_cred_validation = true;
+      backend->use_manual_cred_validation = TRUE;
     }
     else {
       failf(data, "schannel: this version of Windows is too old to support "
@@ -1115,7 +1115,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     }
   }
   else
-    backend->use_manual_cred_validation = false;
+    backend->use_manual_cred_validation = FALSE;
 #else
   if(conn_config->CAfile || conn_config->ca_info_blob) {
     failf(data, "schannel: CA cert support not built in");
@@ -1300,10 +1300,10 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
                "sent %zd bytes", written));
 
   backend->recv_unrecoverable_err = CURLE_OK;
-  backend->recv_sspi_close_notify = false;
-  backend->recv_connection_closed = false;
-  backend->recv_renegotiating = false;
-  backend->encdata_is_incomplete = false;
+  backend->recv_sspi_close_notify = FALSE;
+  backend->recv_connection_closed = FALSE;
+  backend->recv_renegotiating = FALSE;
+  backend->encdata_is_incomplete = FALSE;
 
   /* continue to second handshake step */
   connssl->connecting_state = ssl_connect_2;
@@ -1355,7 +1355,7 @@ schannel_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
 
   /* buffer to store previously received and encrypted data */
   if(!backend->encdata_buffer) {
-    backend->encdata_is_incomplete = false;
+    backend->encdata_is_incomplete = FALSE;
     backend->encdata_offset = 0;
     backend->encdata_length = CURL_SCHANNEL_BUFFER_INIT_SIZE;
     backend->encdata_buffer = malloc(backend->encdata_length);
@@ -1407,7 +1407,7 @@ schannel_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
 
       /* increase encrypted data buffer offset */
       backend->encdata_offset += nread;
-      backend->encdata_is_incomplete = false;
+      backend->encdata_is_incomplete = FALSE;
       DEBUGF(infof(data, "schannel: encrypted data got %zd", nread));
     }
 
@@ -1447,7 +1447,7 @@ schannel_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
 
     /* check if the handshake was incomplete */
     if(sspi_status == SEC_E_INCOMPLETE_MESSAGE) {
-      backend->encdata_is_incomplete = true;
+      backend->encdata_is_incomplete = TRUE;
       connssl->io_need = CURL_SSL_IO_NEED_RECV;
       DEBUGF(infof(data,
                    "schannel: received incomplete message, need more data"));
@@ -1617,9 +1617,9 @@ traverse_cert_store(const CERT_CONTEXT *context, Read_crt_func func,
                     void *arg)
 {
   const CERT_CONTEXT *current_context = NULL;
-  bool should_continue = true;
-  bool first = true;
-  bool reverse_order = false;
+  bool should_continue = TRUE;
+  bool first = TRUE;
+  bool reverse_order = FALSE;
   while(should_continue &&
         (current_context = CertEnumCertificatesInStore(
           context->hCertStore,
@@ -1630,9 +1630,9 @@ traverse_cert_store(const CERT_CONTEXT *context, Read_crt_func func,
        by comparing SECPKG_ATTR_REMOTE_CERT_CONTEXT's pbCertContext with the
        first certificate's pbCertContext. */
     if(first && context->pbCertEncoded != current_context->pbCertEncoded)
-      reverse_order = true;
+      reverse_order = TRUE;
     should_continue = func(current_context, reverse_order, arg);
-    first = false;
+    first = FALSE;
   }
 
   if(current_context)
@@ -1646,7 +1646,7 @@ cert_counter_callback(const CERT_CONTEXT *ccert_context, bool reverse_order,
   (void)reverse_order; /* unused */
   if(valid_cert_encoding(ccert_context))
     (*(int *)certs_count)++;
-  return true;
+  return TRUE;
 }
 
 struct Adder_args
@@ -2181,12 +2181,12 @@ schannel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
         infof(data, "schannel: recv returned error %d", *err);
     }
     else if(nread == 0) {
-      backend->recv_connection_closed = true;
+      backend->recv_connection_closed = TRUE;
       DEBUGF(infof(data, "schannel: server closed the connection"));
     }
     else if(nread > 0) {
       backend->encdata_offset += (size_t)nread;
-      backend->encdata_is_incomplete = false;
+      backend->encdata_is_incomplete = FALSE;
       DEBUGF(infof(data, "schannel: encrypted data got %zd", nread));
     }
   }
@@ -2299,9 +2299,9 @@ schannel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
         connssl->state = ssl_connection_negotiating;
         connssl->connecting_state = ssl_connect_2;
         connssl->io_need = CURL_SSL_IO_NEED_SEND;
-        backend->recv_renegotiating = true;
+        backend->recv_renegotiating = TRUE;
         *err = schannel_connect_common(cf, data, FALSE, &done);
-        backend->recv_renegotiating = false;
+        backend->recv_renegotiating = FALSE;
         if(*err) {
           infof(data, "schannel: renegotiation failed");
           goto cleanup;
@@ -2315,16 +2315,16 @@ schannel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
       else if(sspi_status == SEC_I_CONTEXT_EXPIRED) {
         /* In Windows 2000 SEC_I_CONTEXT_EXPIRED (close_notify) is not
            returned so we have to work around that in cleanup. */
-        backend->recv_sspi_close_notify = true;
+        backend->recv_sspi_close_notify = TRUE;
         if(!backend->recv_connection_closed)
-          backend->recv_connection_closed = true;
+          backend->recv_connection_closed = TRUE;
         infof(data,
               "schannel: server close notification received (close_notify)");
         goto cleanup;
       }
     }
     else if(sspi_status == SEC_E_INCOMPLETE_MESSAGE) {
-      backend->encdata_is_incomplete = true;
+      backend->encdata_is_incomplete = TRUE;
       if(!*err)
         *err = CURLE_AGAIN;
       infof(data, "schannel: failed to decrypt data, need more data");
@@ -2370,7 +2370,7 @@ cleanup:
                                                 VERSION_EQUAL);
 
     if(isWin2k && sspi_status == SEC_E_OK)
-      backend->recv_sspi_close_notify = true;
+      backend->recv_sspi_close_notify = TRUE;
     else {
       *err = CURLE_RECV_ERROR;
       infof(data, "schannel: server closed abruptly (missing close_notify)");
@@ -2622,7 +2622,7 @@ static void schannel_close(struct Curl_cfilter *cf, struct Curl_easy *data)
     Curl_safefree(backend->encdata_buffer);
     backend->encdata_length = 0;
     backend->encdata_offset = 0;
-    backend->encdata_is_incomplete = false;
+    backend->encdata_is_incomplete = FALSE;
   }
 
   /* free internal buffer for received decrypted data */
@@ -2896,7 +2896,7 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
   DEBUGASSERT(multi);
 
   if(!multi) {
-    return false;
+    return FALSE;
   }
 
   share = Curl_hash_pick(&multi->proto_hash,
@@ -2905,14 +2905,14 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
   if(!share) {
     share = calloc(1, sizeof(*share));
     if(!share) {
-      return false;
+      return FALSE;
     }
     if(!Curl_hash_add2(&multi->proto_hash,
                        (void *)MPROTO_SCHANNEL_CERT_SHARE_KEY,
                        sizeof(MPROTO_SCHANNEL_CERT_SHARE_KEY)-1,
                        share, schannel_cert_share_free)) {
       free(share);
-      return false;
+      return FALSE;
     }
   }
 
@@ -2927,7 +2927,7 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
     if(conn_config->CAfile) {
       CAfile = strdup(conn_config->CAfile);
       if(!CAfile) {
-        return false;
+        return FALSE;
       }
     }
   }
@@ -2942,7 +2942,7 @@ bool Curl_schannel_set_cached_cert_store(struct Curl_cfilter *cf,
   share->cert_store = cert_store;
   share->CAinfo_blob_size = CAinfo_blob_size;
   share->CAfile = CAfile;
-  return true;
+  return TRUE;
 }
 
 const struct Curl_ssl Curl_ssl_schannel = {

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -278,7 +278,7 @@ static OSStatus sectransp_bio_cf_in_read(SSLConnectionRef connection,
       case CURLE_OK:
       case CURLE_AGAIN:
         rtn = errSSLWouldBlock;
-        backend->ssl_direction = false;
+        backend->ssl_direction = FALSE;
         break;
       default:
         rtn = ioErr;
@@ -317,7 +317,7 @@ static OSStatus sectransp_bio_cf_out_write(SSLConnectionRef connection,
   if(nwritten <= 0) {
     if(result == CURLE_AGAIN) {
       rtn = errSSLWouldBlock;
-      backend->ssl_direction = true;
+      backend->ssl_direction = TRUE;
     }
     else {
       rtn = ioErr;
@@ -512,7 +512,7 @@ static OSStatus CopyIdentityWithLabel(char *label,
                                     * label matching below worked correctly */
     keys[2] = kSecMatchLimit;
     /* identity searches need a SecPolicyRef in order to work */
-    values[3] = SecPolicyCreateSSL(false, NULL);
+    values[3] = SecPolicyCreateSSL(FALSE, NULL);
     keys[3] = kSecMatchPolicy;
     /* match the name of the certificate (does not work in macOS 10.12.1) */
     values[4] = label_cf;
@@ -609,7 +609,7 @@ static OSStatus CopyIdentityFromPKCS12File(const char *cPath,
     pkcs_url =
       CFURLCreateFromFileSystemRepresentation(NULL,
                                               (const UInt8 *)cPath,
-                                              (CFIndex)strlen(cPath), false);
+                                              (CFIndex)strlen(cPath), FALSE);
     resource_imported =
       CFURLCreateDataAndPropertiesFromResource(NULL,
                                                pkcs_url, &pkcs_data,
@@ -711,11 +711,11 @@ CF_INLINE bool is_file(const char *filename)
   struct_stat st;
 
   if(!filename)
-    return false;
+    return FALSE;
 
   if(stat(filename, &st) == 0)
     return S_ISREG(st.st_mode);
-  return false;
+  return FALSE;
 }
 
 static CURLcode
@@ -796,8 +796,8 @@ legacy:
   }
 
   /* only TLS 1.0 is supported, disable SSL 3.0 and SSL 2.0 */
-  SSLSetProtocolVersionEnabled(backend->ssl_ctx, kSSLProtocolAll, false);
-  SSLSetProtocolVersionEnabled(backend->ssl_ctx, kTLSProtocol1, true);
+  SSLSetProtocolVersionEnabled(backend->ssl_ctx, kSSLProtocolAll, FALSE);
+  SSLSetProtocolVersionEnabled(backend->ssl_ctx, kTLSProtocol1, TRUE);
 
   return CURLE_OK;
 #endif
@@ -1069,7 +1069,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
 #if CURL_SUPPORT_MAC_10_8
     if(backend->ssl_ctx)
       (void)SSLDisposeContext(backend->ssl_ctx);
-    err = SSLNewContext(false, &(backend->ssl_ctx));
+    err = SSLNewContext(FALSE, &(backend->ssl_ctx));
     if(err != noErr) {
       failf(data, "SSL: could not create a context: OSStatus %d", err);
       return CURLE_OUT_OF_MEMORY;
@@ -1079,7 +1079,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
 #else
   if(backend->ssl_ctx)
     (void)SSLDisposeContext(backend->ssl_ctx);
-  err = SSLNewContext(false, &(backend->ssl_ctx));
+  err = SSLNewContext(FALSE, &(backend->ssl_ctx));
   if(err != noErr) {
     failf(data, "SSL: could not create a context: OSStatus %d", err);
     return CURLE_OUT_OF_MEMORY;
@@ -1253,7 +1253,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
   else {
 #if CURL_SUPPORT_MAC_10_8
     err = SSLSetEnableCertVerify(backend->ssl_ctx,
-                                 conn_config->verifypeer ? true : false);
+                                 conn_config->verifypeer ? true : FALSE);
     if(err != noErr) {
       failf(data, "SSL: SSLSetEnableCertVerify() failed: OSStatus %d", err);
       return CURLE_SSL_CONNECT_ERROR;
@@ -1262,7 +1262,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
   }
 #else
   err = SSLSetEnableCertVerify(backend->ssl_ctx,
-                               conn_config->verifypeer ? true : false);
+                               conn_config->verifypeer ? true : FALSE);
   if(err != noErr) {
     failf(data, "SSL: SSLSetEnableCertVerify() failed: OSStatus %d", err);
     return CURLE_SSL_CONNECT_ERROR;
@@ -1604,7 +1604,7 @@ static CURLcode verify_cert_buf(struct Curl_cfilter *cf,
     failf(data, "SecTrustSetAnchorCertificates() returned error %d", ret);
     goto out;
   }
-  ret = SecTrustSetAnchorCertificatesOnly(trust, true);
+  ret = SecTrustSetAnchorCertificatesOnly(trust, TRUE);
   if(ret != noErr) {
     failf(data, "SecTrustSetAnchorCertificatesOnly() returned error %d", ret);
     goto out;
@@ -2053,7 +2053,7 @@ check_handshake:
     (void)SSLGetNegotiatedProtocolVersion(backend->ssl_ctx, &protocol);
 
     sectransp_cipher_suite_get_str((uint16_t) cipher, cipher_str,
-                                   sizeof(cipher_str), true);
+                                   sizeof(cipher_str), TRUE);
     switch(protocol) {
       case kSSLProtocol2:
         infof(data, "SSL 2.0 connection using %s", cipher_str);
@@ -2168,7 +2168,7 @@ static CURLcode collect_server_cert(struct Curl_cfilter *cf,
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
   const bool show_verbose_server_cert = data->set.verbose;
 #else
-  const bool show_verbose_server_cert = false;
+  const bool show_verbose_server_cert = FALSE;
 #endif
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
   CURLcode result = ssl_config->certinfo ?
@@ -2543,10 +2543,10 @@ static bool sectransp_data_pending(struct Curl_cfilter *cf,
     err = SSLGetBufferedReadSize(backend->ssl_ctx, &buffer);
     if(err == noErr)
       return buffer > 0UL;
-    return false;
+    return FALSE;
   }
   else
-    return false;
+    return FALSE;
 }
 
 static CURLcode sectransp_random(struct Curl_easy *data UNUSED_PARAM,

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -382,7 +382,7 @@ static CURLcode populate_x509_store(struct Curl_cfilter *cf,
     (ca_info_blob ? NULL : conn_config->CAfile);
   const char * const ssl_capath = conn_config->CApath;
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
-  bool imported_native_ca = false;
+  bool imported_native_ca = FALSE;
 
 #if !defined(NO_FILESYSTEM) && defined(WOLFSSL_SYS_CA_CERTS)
   /* load native CA certificates */
@@ -391,7 +391,7 @@ static CURLcode populate_x509_store(struct Curl_cfilter *cf,
       infof(data, "error importing native CA store, continuing anyway");
     }
     else {
-      imported_native_ca = true;
+      imported_native_ca = TRUE;
       infof(data, "successfully imported native CA store");
       wssl->x509_store_setup = TRUE;
     }
@@ -493,7 +493,7 @@ cached_x509_store_expired(const struct Curl_easy *data,
   timediff_t timeout_ms = cfg->ca_cache_timeout * (timediff_t)1000;
 
   if(timeout_ms < 0)
-    return false;
+    return FALSE;
 
   return elapsed_ms >= timeout_ms;
 }


### PR DESCRIPTION
booleans should use the type 'bool' and set the value to TRUE/FALSE

non-booleans should not be 'bool' and should not set the value to TRUE/FALSE