### PR TITLE
Adding support for connection event

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -506,6 +506,31 @@ typedef int (*curl_prereq_callback)(void *clientp,
    request */
 #define CURL_PREREQFUNC_ABORT 1
 
+typedef enum {
+   CURL_CONNEVT_GOAWAY = 1, /* GOAWAY frame in HTTP/2 */
+} curl_connevt_type;
+
+struct curl_connevt_goaway {
+   unsigned int error_code; /* An error code explaining why
+                               the GOAWAY is being sent */
+   struct {
+      const void *buffer;
+      size_t size;
+   } opaque; /* Diagnostic information */
+};
+
+struct curl_connevt_msg {
+   curl_connevt_type type; /* The connection event type */
+   union {
+      struct curl_connevt_goaway goaway; /* GOAWAY event data */
+   } data;
+};
+
+/* This is the CURLOPT_CONNEVTFUNCTION callback prototype. */
+typedef void (*curl_connevt_callback)(CURL *handle,
+                                      const struct curl_connevt_msg *msg,
+                                      void *userp);
+
 /* All possible error codes from all sorts of curl functions. Future versions
    may return other values, stay prepared.
 
@@ -2223,6 +2248,12 @@ typedef enum {
 
   /* maximum number of keepalive probes (Linux, *BSD, macOS, etc.) */
   CURLOPT(CURLOPT_TCP_KEEPCNT, CURLOPTTYPE_LONG, 326),
+
+  /* Function that will be called when receiving connection events */
+  CURLOPT(CURLOPT_CONNEVTFUNCTION, CURLOPTTYPE_FUNCTIONPOINT, 327),
+
+  /* Data passed to the CURLOPT_CONNEVTFUNCTION callback */
+  CURLOPT(CURLOPT_CONNEVTDATA, CURLOPTTYPE_CBPOINT, 328),
 
   CURLOPT_LASTENTRY /* the last unused */
 } CURLoption;

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -3238,6 +3238,12 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
   case CURLOPT_QUICK_EXIT:
     data->set.quick_exit = (0 != va_arg(param, long)) ? 1L : 0L;
     break;
+  case CURLOPT_CONNEVTFUNCTION:
+    data->set.connevt_func = va_arg(param, curl_connevt_callback);
+    break;
+  case CURLOPT_CONNEVTDATA:
+    data->set.connevt_data = va_arg(param, void *);
+    break;
   default:
     /* unknown tag and its companion, just ignore: */
     result = CURLE_UNKNOWN_OPTION;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1626,6 +1626,8 @@ struct UserDefined {
 #if !defined(CURL_DISABLE_MIME) || !defined(CURL_DISABLE_FORM_API)
   curl_mimepart mimepost;  /* MIME/POST data. */
 #endif
+  curl_connevt_callback connevt_func; /* callback of connection events */
+  void *connevt_data; /* pointer to pass to connevt_func */
 #ifndef CURL_DISABLE_TELNET
   struct curl_slist *telnet_options; /* linked list of telnet options */
 #endif


### PR DESCRIPTION
This is initial implementation for connection events (mainly HTTP/2 GOAWAY) as discussed [here](https://github.com/curl/curl/discussions/15014). I'll add documentation once this is reviewed.