### PR TITLE
GHA/windows: disable vcpkg jobs, all fail with runner 20240929.1

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,158 +36,10 @@ concurrency:
 permissions: {}
 
 jobs:
-  cygwin:
-    name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
-    runs-on: windows-latest
-    timeout-minutes: 45
-    defaults:
-      run:
-        shell: C:\cygwin\bin\bash.exe '{0}'
-    env:
-      SHELLOPTS: 'igncr'
-    strategy:
-      matrix:
-        include:
-          - { build: 'automake', platform: 'x86_64', tflags: 'skiprun', config: '', name: 'openssl R' }
-          - { build: 'cmake'   , platform: 'x86_64', tflags: ''       , config: '-DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'openssl' }
-      fail-fast: false
-    steps:
-      - run: git config --global core.autocrlf input
-        shell: pwsh
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
-      - uses: cygwin/cygwin-install-action@006ad0b0946ca6d0a3ea2d4437677fa767392401 # v4
-        with:
-          platform: ${{ matrix.platform }}
-          site: https://mirrors.kernel.org/sourceware/cygwin/
-          # https://cygwin.com/cgi-bin2/package-grep.cgi
-          packages: >-
-            autoconf libtool gcc-core gcc-g++ binutils
-            ${{ matrix.build }} make ninja
-            openssh
-            libssl-devel
-            libssh2-devel
-            libpsl-devel
-            zlib-devel
-            libbrotli-devel
-            libnghttp2-devel
-
-      - name: 'autotools autoreconf'
-        if: ${{ matrix.build == 'automake' }}
-        timeout-minutes: 2
-        run: autoreconf -fi
-
-      - name: 'autotools configure'
-        if: ${{ matrix.build == 'automake' }}
-        timeout-minutes: 5
-        run: |
-          PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
-          mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
-            --prefix="${HOME}"/install \
-            --with-openssl \
-            --with-libssh2 \
-            --disable-dependency-tracking \
-            ${{ matrix.config }}
-
-      - name: 'autotools configure log'
-        if: ${{ matrix.build == 'automake' && !cancelled() }}
-        run: cat bld/config.log 2>/dev/null || true
-
-      - name: 'curl_config.h'
-        if: ${{ matrix.build == 'automake' }}
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        if: ${{ matrix.build == 'automake' }}
-        run: cat bld/lib/curl_config.h || true
-
-      - name: 'autotools build'
-        if: ${{ matrix.build == 'automake' }}
-        timeout-minutes: 10
-        run: make -C bld -j5 V=1 install
-
-      - name: 'curl version'
-        if: ${{ matrix.build == 'automake' }}
-        timeout-minutes: 1
-        run: |
-          find . -name '*.exe' -o -name '*.dll'
-          bld/src/curl.exe --disable --version
-
-      - name: 'autotools build tests'
-        if: ${{ matrix.build == 'automake' && matrix.tflags != 'skipall' }}
-        timeout-minutes: 15
-        run: make -C bld -j5 V=1 -C tests
-
-      - name: 'autotools run tests'
-        if: ${{ matrix.build == 'automake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 15
-        run: |
-          export TFLAGS='-j20 ${{ matrix.tflags }} ~615'
-          if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
-            TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
-          fi
-          make -C bld -j5 V=1 test-ci
-
-      - name: 'cmake configure'
-        if: ${{ matrix.build == 'cmake' }}
-        timeout-minutes: 5
-        run: |
-          PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
-          cmake -B bld -G Ninja ${options} \
-            -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
-            -DCURL_WERROR=ON \
-            -DCURL_BROTLI=ON \
-            ${{ matrix.config }}
-
-      - name: 'cmake configure log'
-        if: ${{ matrix.build == 'cmake' && !cancelled() }}
-        run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
-
-      - name: 'curl_config.h'
-        if: ${{ matrix.build == 'cmake' }}
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        if: ${{ matrix.build == 'cmake' }}
-        run: cat bld/lib/curl_config.h || true
-
-      - name: 'cmake build'
-        if: ${{ matrix.build == 'cmake' }}
-        timeout-minutes: 10
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
-
-      - name: 'curl version'
-        if: ${{ matrix.build == 'cmake' }}
-        timeout-minutes: 1
-        run: |
-          find . -name '*.exe' -o -name '*.dll'
-          PATH="$PWD/bld/lib:$PATH"
-          bld/src/curl.exe --disable --version
-
-      - name: 'cmake build tests'
-        if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' }}
-        timeout-minutes: 15
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
-
-      - name: 'cmake run tests'
-        if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 15
-        run: |
-          export TFLAGS='-j8 ${{ matrix.tflags }} ~615'
-          if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
-            TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
-          fi
-          PATH="$PWD/bld/lib:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --target test-ci
-
-      - name: 'cmake build examples'
-        if: ${{ matrix.build == 'cmake' }}
-        timeout-minutes: 5
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
-
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     defaults:
       run:
         shell: msys2 {0}
@@ -195,23 +47,23 @@ jobs:
       matrix:
         include:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy', name: '!proxy' }
-          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver', name: 'default' }
-          - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver', name: 'default' }
+          - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '', name: 'default R' }
           - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver --disable-curldebug --enable-static=no --without-zlib', name: 'default' }
           - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: '~472 ~1299 ~1613'        , config: '--enable-debug --enable-windows-unicode --enable-ares', name: 'c-ares U' }
           # FIXME: WebSockets test results ignored due to frequent failures on native Windows:
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_ARES=ON', type: 'Debug', name: 'schannel c-ares U' }
-          - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }
-          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON  -DENABLE_UNICODE=OFF', type: 'Release', name: 'openssl' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', test: 'uwp', name: 'schannel R' }
-          - { build: 'cmake'    , sys: 'mingw32', env: 'i686'        , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', name: 'schannel R' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_ARES=ON', type: 'Debug', name: 'schannel c-ares U' }
+          - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }
+          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release', name: 'openssl' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', test: 'uwp', name: 'schannel R' }
+          - { build: 'cmake'    , sys: 'mingw32', env: 'i686'        , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', name: 'schannel R' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
         shell: pwsh
 
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - uses: msys2/setup-msys2@ddf331adaebd714795f1042345e6ca57bd66cea8 # v2
         if: ${{ matrix.sys == 'msys' }}
@@ -253,6 +105,7 @@ jobs:
         run: |
           mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
             --prefix="${HOME}"/install \
+            --enable-websockets \
             --with-openssl \
             --with-libssh2 \
             --disable-dependency-tracking \
@@ -296,11 +149,11 @@ jobs:
 
       - name: 'autotools run tests'
         if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 10
+        timeout-minutes: 14
         run: |
-          export TFLAGS='-j8 ${{ matrix.tflags }} ~SCP'
+          export TFLAGS='-j14 ${{ matrix.tflags }} ~SCP'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
-            TFLAGS+=' ~2301 ~2302'  # WebSockets'
+            TFLAGS+=' ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP'
             TFLAGS+=' ~612 ~613 ~616 ~618'  # SFTP
           else
             TFLAGS+=' ~SFTP'
@@ -312,7 +165,7 @@ jobs:
           make -C bld -j5 V=1 test-ci
 
       - name: 'autotools build examples'
-        if: ${{ matrix.build == 'autotools' && (matrix.tflags == 'skipall' || matrix.tflags == 'skiprun') }}
+        if: ${{ matrix.build == 'autotools' }}
         timeout-minutes: 5
         run: make -C bld -j5 V=1 examples
 
@@ -345,6 +198,7 @@ jobs:
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
             -DCURL_WERROR=ON \
+            -DENABLE_WEBSOCKETS=ON \
             -DCURL_BROTLI=ON \
             ${{ matrix.config }}
 
@@ -389,11 +243,11 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 10
+        timeout-minutes: 14
         run: |
-          export TFLAGS='-j8 ${{ matrix.tflags }} ~SCP'
+          export TFLAGS='-j14 ${{ matrix.tflags }} ~SCP'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
-            TFLAGS+=' ~WebSockets'
+            TFLAGS+=' ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP'
             TFLAGS+=' ~612 ~613 ~616 ~618'  # SFTP
           else
             TFLAGS+=' ~SFTP'
@@ -412,7 +266,7 @@ jobs:
   old-mingw-w64:
     name: 'old-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     defaults:
       run:
         shell: C:\msys64\usr\bin\bash.exe {0}
@@ -463,7 +317,7 @@ jobs:
           ls -l
 
       - run: git config --global core.autocrlf input
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: 'cmake configure'
         timeout-minutes: 5
@@ -476,6 +330,7 @@ jobs:
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
             -DCURL_WERROR=ON \
+            -DENABLE_WEBSOCKETS=ON \
             -DCURL_USE_LIBPSL=OFF \
             ${{ matrix.config }}
 
@@ -498,7 +353,7 @@ jobs:
       - name: 'curl version'
         timeout-minutes: 1
         run: |
-          PATH=/usr/bin find . -name '*.exe' -o -name '*.dll'
+          find . -name '*.exe' -o -name '*.dll'
           PATH="$PWD/bld/lib:$PATH"
           bld/src/curl.exe --disable --version
 
@@ -519,10 +374,10 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 10
+        timeout-minutes: 14
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          export TFLAGS='-j4 ~WebSockets ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ~TFTP ~MQTT ~WebSockets ~FTP ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -550,7 +405,7 @@ jobs:
       - name: 'install packages'
         run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}
@@ -624,66 +479,42 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
-              -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
-
+            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=ON  -DCURL_USE_SCHANNEL=ON  -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON'
           - name: 'openssl'
             install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
-
+            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON'
           - name: 'openssl'
             install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'
             arch: 'x64'
             plat: 'uwp'
             type: 'Debug'
             tflags: 'skiprun'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-              -DCURL_USE_LIBPSL=OFF
-
+            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON -DCURL_USE_LIBPSL=OFF'
           - name: 'libressl'
             install: 'brotli zlib zstd libpsl nghttp2 libressl libssh2[core,zlib]'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
-              -DCURL_CA_SEARCH_SAFE=ON
-
+            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DCURL_CA_SEARCH_SAFE=ON'
           - name: 'boringssl-ECH'
             install: 'brotli zlib zstd libpsl nghttp2 boringssl libssh2[core,zlib]'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
-              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
-
+            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_HTTPSRR=ON -DUSE_ECH=ON'
           - name: 'wolfssl'
             install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl ngtcp2[wolfssl] nghttp3'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
-              -DCURL_USE_GSASL=ON
-
+            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON -DCURL_USE_GSASL=ON'
           - name: 'gnutls'
             install: 'brotli zlib zstd libpsl nghttp2 shiftmedia-libgnutls libssh pkgconf gsasl ngtcp2[gnutls] nghttp3'
             arch: 'x64'
@@ -694,25 +525,17 @@ jobs:
             #          read its configuration from, making it vulnerable to attacks on
             #          Windows. Do not use this component till there is a fix for these.
             # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_GNUTLS=ON -DUSE_NGTCP2=ON
-              -DCURL_USE_GSASL=ON
-
+            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_GSASL=ON -DUSE_NGTCP2=ON'
           - name: 'msh3'
             install: 'brotli zlib zstd libpsl nghttp2 msh3 libssh2 pkgconf gsasl'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: 'skipall'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DUSE_MSH3=ON
-              -DCURL_USE_GSASL=ON
-
+            tflags: '~1516'
+            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DUSE_MSH3=ON -DCURL_USE_GSASL=ON'
       fail-fast: false
     steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
 
       - name: 'vcpkg cache setup'
         uses: actions/github-script@v7
@@ -747,8 +570,7 @@ jobs:
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
             -DCURL_WERROR=ON \
-            -DBUILD_SHARED_LIBS=OFF \
-            -DENABLE_DEBUG=ON \
+            -DENABLE_WEBSOCKETS=ON \
             -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
             -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE= \
             ${{ matrix.config }}
@@ -795,9 +617,9 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 10
+        timeout-minutes: 16
         run: |
-          export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
+          export TFLAGS='-j14 ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP ~SCP ~612 ${{ matrix.tflags }}'
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SFTP'
           elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -605,207 +605,209 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: cmake --build bld --parallel 5 --target curl-examples
 
-#  msvc:
-#    name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
-#    runs-on: windows-latest
-#    timeout-minutes: 55
-#    defaults:
-#      run:
-#        shell: bash
-#    env:
-#      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
-#      VCPKG_DISABLE_METRICS: '1'
-#    strategy:
-#      matrix:
-#        include:
-#          - name: 'schannel MultiSSL U'
-#            install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl openssl mbedtls shiftmedia-libgnutls'
-#            arch: 'x64'
-#            plat: 'windows'
-#            type: 'Debug'
-#            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-#            config: >-
-#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-#              -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
-#              -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
-#
-#          - name: 'openssl'
-#            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv'
-#            arch: 'x64'
-#            plat: 'windows'
-#            type: 'Debug'
-#            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-#            config: >-
-#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-#              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
-#
-#          - name: 'openssl'
-#            install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'
-#            arch: 'x64'
-#            plat: 'uwp'
-#            type: 'Debug'
-#            tflags: 'skiprun'
-#            config: >-
-#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-#              -DCURL_USE_LIBPSL=OFF
-#
-#          - name: 'libressl'
-#            install: 'brotli zlib zstd libpsl nghttp2 libressl libssh2[core,zlib]'
-#            arch: 'x64'
-#            plat: 'windows'
-#            type: 'Debug'
-#            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-#            config: >-
-#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
-#              -DCURL_CA_SEARCH_SAFE=ON
-#
-#          - name: 'boringssl-ECH'
-#            install: 'brotli zlib zstd libpsl nghttp2 boringssl libssh2[core,zlib]'
-#            arch: 'x64'
-#            plat: 'windows'
-#            type: 'Debug'
-#            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-#            config: >-
-#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
-#              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
-#
-#          - name: 'wolfssl'
-#            install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl ngtcp2[wolfssl] nghttp3'
-#            arch: 'x64'
-#            plat: 'windows'
-#            type: 'Debug'
-#            tflags: '~1516'
-#            config: >-
-#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
-#              -DCURL_USE_GSASL=ON
-#
-#          - name: 'gnutls'
-#            install: 'brotli zlib zstd libpsl nghttp2 shiftmedia-libgnutls libssh pkgconf gsasl ngtcp2[gnutls] nghttp3'
-#            arch: 'x64'
-#            plat: 'windows'
-#            type: 'Debug'
-#            tflags: '~1516'
-#            # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
-#            #          read its configuration from, making it vulnerable to attacks on
-#            #          Windows. Do not use this component till there is a fix for these.
-#            # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
-#            config: >-
-#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
-#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_GNUTLS=ON -DUSE_NGTCP2=ON
-#              -DCURL_USE_GSASL=ON
-#
-#          - name: 'msh3'
-#            install: 'brotli zlib zstd libpsl nghttp2 msh3 libssh2 pkgconf gsasl'
-#            arch: 'x64'
-#            plat: 'windows'
-#            type: 'Debug'
-#            tflags: 'skipall'
-#            config: >-
-#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-#              -DCURL_USE_SCHANNEL=OFF -DUSE_MSH3=ON
-#              -DCURL_USE_GSASL=ON
-#
-#      fail-fast: false
-#    steps:
-#      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
-#
-#      - name: 'vcpkg cache setup'
-#        uses: actions/github-script@v7
-#        with:
-#          script: |
-#            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-#            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-#
-#      - name: 'vcpkg versions'
-#        timeout-minutes: 1
-#        run: |
-#          git -C "$VCPKG_INSTALLATION_ROOT" show --no-patch --format='%H %ai'
-#          vcpkg version
-#
-#      - name: 'vcpkg build'
-#        timeout-minutes: 35
-#        run: vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
-#
-#      - name: 'cmake configure'
-#        timeout-minutes: 5
-#        run: |
-#          if [[ '${{ matrix.install }}' = *'libressl'* ]]; then
-#            # without this, CMake gets confused by the non-vcpkg OpenSSL
-#            # installed on the runner and fails when linking.
-#            options+=" -DOPENSSL_ROOT_DIR=$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
-#          fi
-#          cmake -B bld ${options} \
-#            "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
-#            "-DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed" \
-#            '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
-#            -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
-#            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
-#            -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
-#            -DCURL_WERROR=ON \
-#            -DBUILD_SHARED_LIBS=OFF \
-#            -DENABLE_DEBUG=ON \
-#            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-#            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE= \
-#            ${{ matrix.config }}
-#
-#      - name: 'cmake configure log'
-#        if: ${{ !cancelled() }}
-#        run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
-#
-#      - name: 'curl_config.h'
-#        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-#
-#      - name: 'curl_config.h (full)'
-#        run: cat bld/lib/curl_config.h || true
-#
-#      - name: 'cmake build'
-#        timeout-minutes: 5
-#        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
-#
-#      - name: 'curl version'
-#        timeout-minutes: 1
-#        run: |
-#          find . -name '*.exe' -o -name '*.dll'
-#          if [ '${{ matrix.plat }}' != 'uwp' ]; then
-#            PATH="$PWD/bld/lib:$PATH"
-#            bld/src/curl.exe --disable --version
-#          fi
-#
-#      - name: 'cmake build tests'
-#        if: ${{ matrix.tflags != 'skipall' }}
-#        timeout-minutes: 10
-#        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
-#
-#      - name: 'install test tools'
-#        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-#        timeout-minutes: 5
-#        run: |
-#          # GnuTLS is not fully functional on Windows, so skip the tests
-#          # https://github.com/ShiftMediaProject/gnutls/issues/23
-#          if [[ '${{ matrix.name }}' != *'gnutls'* ]]; then
-#            /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel openssh || true
-#          fi
-#          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 https://live.sysinternals.com/handle64.exe --output /bin/handle64.exe
-#          python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
-#
-#      - name: 'cmake run tests'
-#        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-#        timeout-minutes: 10
-#        run: |
-#          export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
-#          if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
-#            TFLAGS+=' ~SFTP'
-#          elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then
-#            TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
-#          fi
-#          PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
-#          cmake --build bld --config '${{ matrix.type }}' --target test-ci
-#
-#      - name: 'cmake build examples'
-#        timeout-minutes: 5
-#        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
+  msvc:
+    name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
+    runs-on: windows-latest
+    timeout-minutes: 55
+    defaults:
+      run:
+        shell: bash
+    env:
+      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+      VCPKG_DISABLE_METRICS: '1'
+    strategy:
+      matrix:
+        include:
+          - name: 'schannel MultiSSL U'
+            install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl openssl mbedtls shiftmedia-libgnutls'
+            arch: 'x64'
+            plat: 'windows'
+            type: 'Debug'
+            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
+              -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
+
+          - name: 'openssl'
+            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv'
+            arch: 'x64'
+            plat: 'windows'
+            type: 'Debug'
+            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
+              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
+
+          - name: 'openssl'
+            install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'
+            arch: 'x64'
+            plat: 'uwp'
+            type: 'Debug'
+            tflags: 'skiprun'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
+              -DCURL_USE_LIBPSL=OFF
+
+          - name: 'libressl'
+            install: 'brotli zlib zstd libpsl nghttp2 libressl libssh2[core,zlib]'
+            arch: 'x64'
+            plat: 'windows'
+            type: 'Debug'
+            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
+              -DCURL_CA_SEARCH_SAFE=ON
+
+          - name: 'boringssl-ECH'
+            install: 'brotli zlib zstd libpsl nghttp2 boringssl libssh2[core,zlib]'
+            arch: 'x64'
+            plat: 'windows'
+            type: 'Debug'
+            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
+              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
+
+          - name: 'wolfssl'
+            install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl ngtcp2[wolfssl] nghttp3'
+            arch: 'x64'
+            plat: 'windows'
+            type: 'Debug'
+            tflags: '~1516'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
+              -DCURL_USE_GSASL=ON
+
+          - name: 'gnutls'
+            install: 'brotli zlib zstd libpsl nghttp2 shiftmedia-libgnutls libssh pkgconf gsasl ngtcp2[gnutls] nghttp3'
+            arch: 'x64'
+            plat: 'windows'
+            type: 'Debug'
+            tflags: '~1516'
+            # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
+            #          read its configuration from, making it vulnerable to attacks on
+            #          Windows. Do not use this component till there is a fix for these.
+            # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_GNUTLS=ON -DUSE_NGTCP2=ON
+              -DCURL_USE_GSASL=ON
+
+          - name: 'msh3'
+            install: 'brotli zlib zstd libpsl nghttp2 msh3 libssh2 pkgconf gsasl'
+            arch: 'x64'
+            plat: 'windows'
+            type: 'Debug'
+            tflags: 'skipall'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DUSE_MSH3=ON
+              -DCURL_USE_GSASL=ON
+
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
+
+      - name: 'vcpkg cache setup'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+
+      - name: 'vcpkg versions'
+        timeout-minutes: 1
+        run: |
+          git -C "$VCPKG_INSTALLATION_ROOT" show --no-patch --format='%H %ai'
+          vcpkg version
+
+      - name: 'vcpkg build'
+        timeout-minutes: 35
+        run: vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
+
+      - name: 'cmake configure'
+        timeout-minutes: 5
+        run: |
+          if [[ '${{ matrix.install }}' = *'libressl'* ]]; then
+            # without this, CMake gets confused by the non-vcpkg OpenSSL
+            # installed on the runner and fails when linking.
+            options+=" -DOPENSSL_ROOT_DIR=$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
+          fi
+          cmake -B bld ${options} \
+            "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
+            "-DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed" \
+            '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
+            -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
+            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
+            -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
+            -DCURL_WERROR=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DENABLE_DEBUG=ON \
+            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE= \
+            ${{ matrix.config }}
+
+      - name: 'cmake configure log'
+        if: ${{ !cancelled() }}
+        run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
+
+      - name: 'curl_config.h'
+        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+
+      - name: 'curl_config.h (full)'
+        run: cat bld/lib/curl_config.h || true
+
+      - name: 'cmake build'
+        timeout-minutes: 5
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
+
+      - name: 'curl version'
+        timeout-minutes: 1
+        run: |
+          find . -name '*.exe' -o -name '*.dll'
+          if [ '${{ matrix.plat }}' != 'uwp' ]; then
+            PATH="$PWD/bld/lib:$PATH"
+            bld/src/curl.exe --disable --version
+          fi
+
+      - name: 'cmake build tests'
+        if: ${{ matrix.tflags != 'skipall' }}
+        timeout-minutes: 10
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
+
+      - name: 'install test tools'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        timeout-minutes: 5
+        run: |
+          # GnuTLS is not fully functional on Windows, so skip the tests
+          # https://github.com/ShiftMediaProject/gnutls/issues/23
+          if [[ '${{ matrix.name }}' != *'gnutls'* ]]; then
+            /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel openssh || true
+          fi
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 https://live.sysinternals.com/handle64.exe --output /bin/handle64.exe
+          python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
+
+      - name: 'cmake run tests'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        timeout-minutes: 10
+        run: |
+          export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
+          if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
+            TFLAGS+=' ~SFTP'
+          elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then
+            TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
+          fi
+          PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
+          cmake --build bld --config '${{ matrix.type }}' --target test-ci
+
+      - name: 'cmake build examples'
+        timeout-minutes: 5
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
+
+# test1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -605,209 +605,207 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: cmake --build bld --parallel 5 --target curl-examples
 
-  msvc:
-    name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
-    runs-on: windows-latest
-    timeout-minutes: 55
-    defaults:
-      run:
-        shell: bash
-    env:
-      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
-      VCPKG_DISABLE_METRICS: '1'
-    strategy:
-      matrix:
-        include:
-          - name: 'schannel MultiSSL U'
-            install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl openssl mbedtls shiftmedia-libgnutls'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
-              -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
-
-          - name: 'openssl'
-            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
-
-          - name: 'openssl'
-            install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'
-            arch: 'x64'
-            plat: 'uwp'
-            type: 'Debug'
-            tflags: 'skiprun'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-              -DCURL_USE_LIBPSL=OFF
-
-          - name: 'libressl'
-            install: 'brotli zlib zstd libpsl nghttp2 libressl libssh2[core,zlib]'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
-              -DCURL_CA_SEARCH_SAFE=ON
-
-          - name: 'boringssl-ECH'
-            install: 'brotli zlib zstd libpsl nghttp2 boringssl libssh2[core,zlib]'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
-              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
-
-          - name: 'wolfssl'
-            install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl ngtcp2[wolfssl] nghttp3'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            tflags: '~1516'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
-              -DCURL_USE_GSASL=ON
-
-          - name: 'gnutls'
-            install: 'brotli zlib zstd libpsl nghttp2 shiftmedia-libgnutls libssh pkgconf gsasl ngtcp2[gnutls] nghttp3'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            tflags: '~1516'
-            # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
-            #          read its configuration from, making it vulnerable to attacks on
-            #          Windows. Do not use this component till there is a fix for these.
-            # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_GNUTLS=ON -DUSE_NGTCP2=ON
-              -DCURL_USE_GSASL=ON
-
-          - name: 'msh3'
-            install: 'brotli zlib zstd libpsl nghttp2 msh3 libssh2 pkgconf gsasl'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            tflags: 'skipall'
-            config: >-
-              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DUSE_MSH3=ON
-              -DCURL_USE_GSASL=ON
-
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
-
-      - name: 'vcpkg cache setup'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-
-      - name: 'vcpkg versions'
-        timeout-minutes: 1
-        run: |
-          git -C "$VCPKG_INSTALLATION_ROOT" show --no-patch --format='%H %ai'
-          vcpkg version
-
-      - name: 'vcpkg build'
-        timeout-minutes: 35
-        run: vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
-
-      - name: 'cmake configure'
-        timeout-minutes: 5
-        run: |
-          if [[ '${{ matrix.install }}' = *'libressl'* ]]; then
-            # without this, CMake gets confused by the non-vcpkg OpenSSL
-            # installed on the runner and fails when linking.
-            options+=" -DOPENSSL_ROOT_DIR=$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
-          fi
-          cmake -B bld ${options} \
-            "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
-            "-DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed" \
-            '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
-            -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
-            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
-            -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
-            -DCURL_WERROR=ON \
-            -DBUILD_SHARED_LIBS=OFF \
-            -DENABLE_DEBUG=ON \
-            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
-            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE= \
-            ${{ matrix.config }}
-
-      - name: 'cmake configure log'
-        if: ${{ !cancelled() }}
-        run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
-
-      - name: 'curl_config.h'
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        run: cat bld/lib/curl_config.h || true
-
-      - name: 'cmake build'
-        timeout-minutes: 5
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
-
-      - name: 'curl version'
-        timeout-minutes: 1
-        run: |
-          find . -name '*.exe' -o -name '*.dll'
-          if [ '${{ matrix.plat }}' != 'uwp' ]; then
-            PATH="$PWD/bld/lib:$PATH"
-            bld/src/curl.exe --disable --version
-          fi
-
-      - name: 'cmake build tests'
-        if: ${{ matrix.tflags != 'skipall' }}
-        timeout-minutes: 10
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
-
-      - name: 'install test tools'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 5
-        run: |
-          # GnuTLS is not fully functional on Windows, so skip the tests
-          # https://github.com/ShiftMediaProject/gnutls/issues/23
-          if [[ '${{ matrix.name }}' != *'gnutls'* ]]; then
-            /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel openssh || true
-          fi
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 https://live.sysinternals.com/handle64.exe --output /bin/handle64.exe
-          python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
-
-      - name: 'cmake run tests'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 10
-        run: |
-          export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
-          if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
-            TFLAGS+=' ~SFTP'
-          elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then
-            TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
-          fi
-          PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
-          cmake --build bld --config '${{ matrix.type }}' --target test-ci
-
-      - name: 'cmake build examples'
-        timeout-minutes: 5
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
-
-# test1
+#  msvc:
+#    name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
+#    runs-on: windows-latest
+#    timeout-minutes: 55
+#    defaults:
+#      run:
+#        shell: bash
+#    env:
+#      VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
+#      VCPKG_DISABLE_METRICS: '1'
+#    strategy:
+#      matrix:
+#        include:
+#          - name: 'schannel MultiSSL U'
+#            install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl openssl mbedtls shiftmedia-libgnutls'
+#            arch: 'x64'
+#            plat: 'windows'
+#            type: 'Debug'
+#            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+#            config: >-
+#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+#              -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
+#              -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
+#
+#          - name: 'openssl'
+#            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv'
+#            arch: 'x64'
+#            plat: 'windows'
+#            type: 'Debug'
+#            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+#            config: >-
+#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
+#              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
+#
+#          - name: 'openssl'
+#            install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'
+#            arch: 'x64'
+#            plat: 'uwp'
+#            type: 'Debug'
+#            tflags: 'skiprun'
+#            config: >-
+#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
+#              -DCURL_USE_LIBPSL=OFF
+#
+#          - name: 'libressl'
+#            install: 'brotli zlib zstd libpsl nghttp2 libressl libssh2[core,zlib]'
+#            arch: 'x64'
+#            plat: 'windows'
+#            type: 'Debug'
+#            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+#            config: >-
+#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
+#              -DCURL_CA_SEARCH_SAFE=ON
+#
+#          - name: 'boringssl-ECH'
+#            install: 'brotli zlib zstd libpsl nghttp2 boringssl libssh2[core,zlib]'
+#            arch: 'x64'
+#            plat: 'windows'
+#            type: 'Debug'
+#            tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
+#            config: >-
+#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
+#              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
+#
+#          - name: 'wolfssl'
+#            install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl ngtcp2[wolfssl] nghttp3'
+#            arch: 'x64'
+#            plat: 'windows'
+#            type: 'Debug'
+#            tflags: '~1516'
+#            config: >-
+#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
+#              -DCURL_USE_GSASL=ON
+#
+#          - name: 'gnutls'
+#            install: 'brotli zlib zstd libpsl nghttp2 shiftmedia-libgnutls libssh pkgconf gsasl ngtcp2[gnutls] nghttp3'
+#            arch: 'x64'
+#            plat: 'windows'
+#            type: 'Debug'
+#            tflags: '~1516'
+#            # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
+#            #          read its configuration from, making it vulnerable to attacks on
+#            #          Windows. Do not use this component till there is a fix for these.
+#            # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
+#            config: >-
+#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
+#              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_GNUTLS=ON -DUSE_NGTCP2=ON
+#              -DCURL_USE_GSASL=ON
+#
+#          - name: 'msh3'
+#            install: 'brotli zlib zstd libpsl nghttp2 msh3 libssh2 pkgconf gsasl'
+#            arch: 'x64'
+#            plat: 'windows'
+#            type: 'Debug'
+#            tflags: 'skipall'
+#            config: >-
+#              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+#              -DCURL_USE_SCHANNEL=OFF -DUSE_MSH3=ON
+#              -DCURL_USE_GSASL=ON
+#
+#      fail-fast: false
+#    steps:
+#      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
+#
+#      - name: 'vcpkg cache setup'
+#        uses: actions/github-script@v7
+#        with:
+#          script: |
+#            core.exportVariable('ACTIONS_CACHE_URL', process.env.ACTIONS_CACHE_URL || '');
+#            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+#
+#      - name: 'vcpkg versions'
+#        timeout-minutes: 1
+#        run: |
+#          git -C "$VCPKG_INSTALLATION_ROOT" show --no-patch --format='%H %ai'
+#          vcpkg version
+#
+#      - name: 'vcpkg build'
+#        timeout-minutes: 35
+#        run: vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
+#
+#      - name: 'cmake configure'
+#        timeout-minutes: 5
+#        run: |
+#          if [[ '${{ matrix.install }}' = *'libressl'* ]]; then
+#            # without this, CMake gets confused by the non-vcpkg OpenSSL
+#            # installed on the runner and fails when linking.
+#            options+=" -DOPENSSL_ROOT_DIR=$VCPKG_INSTALLATION_ROOT/installed/${{ matrix.arch }}-${{ matrix.plat }}"
+#          fi
+#          cmake -B bld ${options} \
+#            "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
+#            "-DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed" \
+#            '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
+#            -DCMAKE_VS_GLOBALS=TrackFileAccess=false \
+#            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
+#            -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
+#            -DCURL_WERROR=ON \
+#            -DBUILD_SHARED_LIBS=OFF \
+#            -DENABLE_DEBUG=ON \
+#            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+#            -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE= \
+#            ${{ matrix.config }}
+#
+#      - name: 'cmake configure log'
+#        if: ${{ !cancelled() }}
+#        run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
+#
+#      - name: 'curl_config.h'
+#        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+#
+#      - name: 'curl_config.h (full)'
+#        run: cat bld/lib/curl_config.h || true
+#
+#      - name: 'cmake build'
+#        timeout-minutes: 5
+#        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
+#
+#      - name: 'curl version'
+#        timeout-minutes: 1
+#        run: |
+#          find . -name '*.exe' -o -name '*.dll'
+#          if [ '${{ matrix.plat }}' != 'uwp' ]; then
+#            PATH="$PWD/bld/lib:$PATH"
+#            bld/src/curl.exe --disable --version
+#          fi
+#
+#      - name: 'cmake build tests'
+#        if: ${{ matrix.tflags != 'skipall' }}
+#        timeout-minutes: 10
+#        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
+#
+#      - name: 'install test tools'
+#        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+#        timeout-minutes: 5
+#        run: |
+#          # GnuTLS is not fully functional on Windows, so skip the tests
+#          # https://github.com/ShiftMediaProject/gnutls/issues/23
+#          if [[ '${{ matrix.name }}' != *'gnutls'* ]]; then
+#            /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel openssh || true
+#          fi
+#          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 https://live.sysinternals.com/handle64.exe --output /bin/handle64.exe
+#          python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
+#
+#      - name: 'cmake run tests'
+#        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+#        timeout-minutes: 10
+#        run: |
+#          export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
+#          if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
+#            TFLAGS+=' ~SFTP'
+#          elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then
+#            TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
+#          fi
+#          PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
+#          cmake --build bld --config '${{ matrix.type }}' --target test-ci
+#
+#      - name: 'cmake build examples'
+#        timeout-minutes: 5
+#        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -809,3 +809,5 @@ jobs:
       - name: 'cmake build examples'
         timeout-minutes: 5
         run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
+
+# test1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,10 +36,158 @@ concurrency:
 permissions: {}
 
 jobs:
+  cygwin:
+    name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
+    runs-on: windows-latest
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: C:\cygwin\bin\bash.exe '{0}'
+    env:
+      SHELLOPTS: 'igncr'
+    strategy:
+      matrix:
+        include:
+          - { build: 'automake', platform: 'x86_64', tflags: 'skiprun', config: '', name: 'openssl R' }
+          - { build: 'cmake'   , platform: 'x86_64', tflags: ''       , config: '-DENABLE_DEBUG=ON -DCURL_USE_OPENSSL=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'openssl' }
+      fail-fast: false
+    steps:
+      - run: git config --global core.autocrlf input
+        shell: pwsh
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
+      - uses: cygwin/cygwin-install-action@006ad0b0946ca6d0a3ea2d4437677fa767392401 # v4
+        with:
+          platform: ${{ matrix.platform }}
+          site: https://mirrors.kernel.org/sourceware/cygwin/
+          # https://cygwin.com/cgi-bin2/package-grep.cgi
+          packages: >-
+            autoconf libtool gcc-core gcc-g++ binutils
+            ${{ matrix.build }} make ninja
+            openssh
+            libssl-devel
+            libssh2-devel
+            libpsl-devel
+            zlib-devel
+            libbrotli-devel
+            libnghttp2-devel
+
+      - name: 'autotools autoreconf'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 2
+        run: autoreconf -fi
+
+      - name: 'autotools configure'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 5
+        run: |
+          PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
+          mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
+            --prefix="${HOME}"/install \
+            --with-openssl \
+            --with-libssh2 \
+            --disable-dependency-tracking \
+            ${{ matrix.config }}
+
+      - name: 'autotools configure log'
+        if: ${{ matrix.build == 'automake' && !cancelled() }}
+        run: cat bld/config.log 2>/dev/null || true
+
+      - name: 'curl_config.h'
+        if: ${{ matrix.build == 'automake' }}
+        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+
+      - name: 'curl_config.h (full)'
+        if: ${{ matrix.build == 'automake' }}
+        run: cat bld/lib/curl_config.h || true
+
+      - name: 'autotools build'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 10
+        run: make -C bld -j5 V=1 install
+
+      - name: 'curl version'
+        if: ${{ matrix.build == 'automake' }}
+        timeout-minutes: 1
+        run: |
+          find . -name '*.exe' -o -name '*.dll'
+          bld/src/curl.exe --disable --version
+
+      - name: 'autotools build tests'
+        if: ${{ matrix.build == 'automake' && matrix.tflags != 'skipall' }}
+        timeout-minutes: 15
+        run: make -C bld -j5 V=1 -C tests
+
+      - name: 'autotools run tests'
+        if: ${{ matrix.build == 'automake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        timeout-minutes: 15
+        run: |
+          export TFLAGS='-j20 ${{ matrix.tflags }} ~615'
+          if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
+            TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
+          fi
+          make -C bld -j5 V=1 test-ci
+
+      - name: 'cmake configure'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 5
+        run: |
+          PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
+          cmake -B bld -G Ninja ${options} \
+            -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
+            -DCURL_WERROR=ON \
+            -DCURL_BROTLI=ON \
+            ${{ matrix.config }}
+
+      - name: 'cmake configure log'
+        if: ${{ matrix.build == 'cmake' && !cancelled() }}
+        run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
+
+      - name: 'curl_config.h'
+        if: ${{ matrix.build == 'cmake' }}
+        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+
+      - name: 'curl_config.h (full)'
+        if: ${{ matrix.build == 'cmake' }}
+        run: cat bld/lib/curl_config.h || true
+
+      - name: 'cmake build'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 10
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
+
+      - name: 'curl version'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 1
+        run: |
+          find . -name '*.exe' -o -name '*.dll'
+          PATH="$PWD/bld/lib:$PATH"
+          bld/src/curl.exe --disable --version
+
+      - name: 'cmake build tests'
+        if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' }}
+        timeout-minutes: 15
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
+
+      - name: 'cmake run tests'
+        if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        timeout-minutes: 15
+        run: |
+          export TFLAGS='-j8 ${{ matrix.tflags }} ~615'
+          if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
+            TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
+          fi
+          PATH="$PWD/bld/lib:$PATH"
+          cmake --build bld --config '${{ matrix.type }}' --target test-ci
+
+      - name: 'cmake build examples'
+        if: ${{ matrix.build == 'cmake' }}
+        timeout-minutes: 5
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
+
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     defaults:
       run:
         shell: msys2 {0}
@@ -47,23 +195,23 @@ jobs:
       matrix:
         include:
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19                !1233', config: '--enable-debug --disable-threaded-resolver --disable-proxy', name: '!proxy' }
-          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '--enable-debug --disable-threaded-resolver', name: 'default' }
-          - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
+          - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver', name: 'default' }
+          - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '', name: 'default R' }
           - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver --disable-curldebug --enable-static=no --without-zlib', name: 'default' }
           - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: '~472 ~1299 ~1613'        , config: '--enable-debug --enable-windows-unicode --enable-ares', name: 'c-ares U' }
           # FIXME: WebSockets test results ignored due to frequent failures on native Windows:
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_ARES=ON', type: 'Debug', name: 'schannel c-ares U' }
-          - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }
-          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON -DENABLE_UNICODE=OFF', type: 'Release', name: 'openssl' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', test: 'uwp', name: 'schannel R' }
-          - { build: 'cmake'    , sys: 'mingw32', env: 'i686'        , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', name: 'schannel R' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: '~2301 ~2302'             , config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_ARES=ON', type: 'Debug', name: 'schannel c-ares U' }
+          - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }
+          - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON  -DENABLE_UNICODE=OFF', type: 'Release', name: 'openssl' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', test: 'uwp', name: 'schannel R' }
+          - { build: 'cmake'    , sys: 'mingw32', env: 'i686'        , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', name: 'schannel R' }
       fail-fast: false
     steps:
       - run: git config --global core.autocrlf input
         shell: pwsh
 
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
 
       - uses: msys2/setup-msys2@ddf331adaebd714795f1042345e6ca57bd66cea8 # v2
         if: ${{ matrix.sys == 'msys' }}
@@ -105,7 +253,6 @@ jobs:
         run: |
           mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
             --prefix="${HOME}"/install \
-            --enable-websockets \
             --with-openssl \
             --with-libssh2 \
             --disable-dependency-tracking \
@@ -149,11 +296,11 @@ jobs:
 
       - name: 'autotools run tests'
         if: ${{ matrix.build == 'autotools' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 14
+        timeout-minutes: 10
         run: |
-          export TFLAGS='-j14 ${{ matrix.tflags }} ~SCP'
+          export TFLAGS='-j8 ${{ matrix.tflags }} ~SCP'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
-            TFLAGS+=' ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP'
+            TFLAGS+=' ~2301 ~2302'  # WebSockets'
             TFLAGS+=' ~612 ~613 ~616 ~618'  # SFTP
           else
             TFLAGS+=' ~SFTP'
@@ -165,7 +312,7 @@ jobs:
           make -C bld -j5 V=1 test-ci
 
       - name: 'autotools build examples'
-        if: ${{ matrix.build == 'autotools' }}
+        if: ${{ matrix.build == 'autotools' && (matrix.tflags == 'skipall' || matrix.tflags == 'skiprun') }}
         timeout-minutes: 5
         run: make -C bld -j5 V=1 examples
 
@@ -198,7 +345,6 @@ jobs:
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
             -DCURL_WERROR=ON \
-            -DENABLE_WEBSOCKETS=ON \
             -DCURL_BROTLI=ON \
             ${{ matrix.config }}
 
@@ -243,11 +389,11 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 14
+        timeout-minutes: 10
         run: |
-          export TFLAGS='-j14 ${{ matrix.tflags }} ~SCP'
+          export TFLAGS='-j8 ${{ matrix.tflags }} ~SCP'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
-            TFLAGS+=' ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP'
+            TFLAGS+=' ~WebSockets'
             TFLAGS+=' ~612 ~613 ~616 ~618'  # SFTP
           else
             TFLAGS+=' ~SFTP'
@@ -266,7 +412,7 @@ jobs:
   old-mingw-w64:
     name: 'old-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
     defaults:
       run:
         shell: C:\msys64\usr\bin\bash.exe {0}
@@ -317,7 +463,7 @@ jobs:
           ls -l
 
       - run: git config --global core.autocrlf input
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
 
       - name: 'cmake configure'
         timeout-minutes: 5
@@ -330,7 +476,6 @@ jobs:
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
             -DCURL_WERROR=ON \
-            -DENABLE_WEBSOCKETS=ON \
             -DCURL_USE_LIBPSL=OFF \
             ${{ matrix.config }}
 
@@ -353,7 +498,7 @@ jobs:
       - name: 'curl version'
         timeout-minutes: 1
         run: |
-          find . -name '*.exe' -o -name '*.dll'
+          PATH=/usr/bin find . -name '*.exe' -o -name '*.dll'
           PATH="$PWD/bld/lib:$PATH"
           bld/src/curl.exe --disable --version
 
@@ -374,10 +519,10 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 14
+        timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          export TFLAGS='-j14 ~TFTP ~MQTT ~WebSockets ~FTP ${{ matrix.tflags }}'
+          export TFLAGS='-j4 ~WebSockets ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -405,7 +550,7 @@ jobs:
       - name: 'install packages'
         run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
 
       - name: 'autotools autoreconf'
         if: ${{ matrix.build == 'autotools' }}
@@ -479,42 +624,66 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=ON  -DCURL_USE_SCHANNEL=ON  -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
+              -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
+
           - name: 'openssl'
             install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
+              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
+
           - name: 'openssl'
             install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'
             arch: 'x64'
             plat: 'uwp'
             type: 'Debug'
             tflags: 'skiprun'
-            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON -DCURL_USE_LIBPSL=OFF'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
+              -DCURL_USE_LIBPSL=OFF
+
           - name: 'libressl'
             install: 'brotli zlib zstd libpsl nghttp2 libressl libssh2[core,zlib]'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DCURL_CA_SEARCH_SAFE=ON'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
+              -DCURL_CA_SEARCH_SAFE=ON
+
           - name: 'boringssl-ECH'
             install: 'brotli zlib zstd libpsl nghttp2 boringssl libssh2[core,zlib]'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
-            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_OPENSSL=ON -DUSE_HTTPSRR=ON -DUSE_ECH=ON'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
+              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
+
           - name: 'wolfssl'
             install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl ngtcp2[wolfssl] nghttp3'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516'
-            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON -DCURL_USE_GSASL=ON'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
+              -DCURL_USE_GSASL=ON
+
           - name: 'gnutls'
             install: 'brotli zlib zstd libpsl nghttp2 shiftmedia-libgnutls libssh pkgconf gsasl ngtcp2[gnutls] nghttp3'
             arch: 'x64'
@@ -525,17 +694,25 @@ jobs:
             #          read its configuration from, making it vulnerable to attacks on
             #          Windows. Do not use this component till there is a fix for these.
             # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
-            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_GSASL=ON -DUSE_NGTCP2=ON'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_GNUTLS=ON -DUSE_NGTCP2=ON
+              -DCURL_USE_GSASL=ON
+
           - name: 'msh3'
             install: 'brotli zlib zstd libpsl nghttp2 msh3 libssh2 pkgconf gsasl'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: '~1516'
-            config: '-DENABLE_DEBUG=ON -DENABLE_UNICODE=OFF -DCURL_USE_SCHANNEL=OFF -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_LIBSSH2=ON -DUSE_MSH3=ON -DCURL_USE_GSASL=ON'
+            tflags: 'skipall'
+            config: >-
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DUSE_MSH3=ON
+              -DCURL_USE_GSASL=ON
+
       fail-fast: false
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
 
       - name: 'vcpkg cache setup'
         uses: actions/github-script@v7
@@ -570,7 +747,8 @@ jobs:
             '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
             -DCURL_WERROR=ON \
-            -DENABLE_WEBSOCKETS=ON \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DENABLE_DEBUG=ON \
             -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
             -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE= \
             ${{ matrix.config }}
@@ -617,9 +795,9 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 16
+        timeout-minutes: 10
         run: |
-          export TFLAGS='-j14 ~TFTP ~MQTT ~WebSockets ~SMTP ~FTP ~SCP ~612 ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SFTP'
           elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then


### PR DESCRIPTION
vcpkg jobs started failing at the 'vcpkg build' step before actually
building anything or restoring from cache.

There was no relevant local change to trigger this.

Failures appeared with Windows runner update 20240929.1:
https://github.com/actions/runner-images/pull/10704
https://github.com/actions/runner-images/releases/tag/win22%2F20240929.1
vcpkg: build from commit 98aa63962 → 76d153790 (other packages changed too)

- Good run from last week, previous runner image only:
  https://github.com/curl/curl/actions/runs/11054863335
- New images fail, old images pass:
  https://github.com/curl/curl/actions/runs/11144016115
- All fail with new image only:
  https://github.com/curl/curl/actions/runs/11151074919

---

uwp:
```
Detecting compiler hash for triplet x64-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.41.34120/bin/Hostx64/x64/cl.exe
Detecting compiler hash for triplet x64-uwp...
error: vcpkg was unable to detect the active compiler's information. See above for the CMake failure output.
error: while detecting compiler information:
The log file content at "C:\vcpkg\buildtrees\detect_compiler\stdout-x64-uwp.log" is:
-- Found external ninja('1.11.0').
-- Configuring x64-uwp
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:127 (message):
    Command failed: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/Common7/IDE/CommonExtensions/Microsoft/CMake/Ninja/ninja.exe" -v
    Working Directory: C:/vcpkg/buildtrees/detect_compiler/x64-uwp-rel/vcpkg-parallel-configure
    Error code: 1
    See logs for more information:
      C:\vcpkg\buildtrees\detect_compiler\config-x64-uwp-rel-CMakeCache.txt.log
      C:\vcpkg\buildtrees\detect_compiler\config-x64-uwp-out.log

Call Stack (most recent call first):
  scripts/cmake/vcpkg_configure_cmake.cmake:314 (vcpkg_execute_required_process)
  scripts/detect_compiler/portfile.cmake:18 (vcpkg_configure_cmake)
  scripts/ports.cmake:192 (include)
```
https://github.com/curl/curl/actions/runs/11151074919/job/30994494622#step:5:10

others:
```
Detecting compiler hash for triplet x64-windows...
Compiler found: C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Tools/MSVC/14.41.34120/bin/Hostx64/x64/cl.exe
The following packages will be built and installed:
    brotli:x64-windows@1.1.0#1
  * getopt:x64-windows@0#3
  * getopt-win32:x64-windows@1.1.0.20220925
  * gettext:x64-windows@0.22.5#1
  * gettext-libintl:x64-windows@0.22.5#2
  * gettimeofday:x64-windows@2017-10-14#6
  * gmp:x64-windows@6.3.0
    gsasl:x64-windows@2.2.1
  * icu[core,tools]:x64-windows@74.2#4
  * libiconv:x64-windows@1.17#4
  * libidn2:x64-windows@2.3.7#1
    libpsl[core,libicu]:x64-windows@0.21.5#1
    libssh2[core,zlib]:x64-windows@1.11.0#2
  * libtasn1:x64-windows@4.19.0#1
  * libunistring:x64-windows@1.2
    mbedtls:x64-windows@3.6.1
  * nettle:x64-windows@3.10
    nghttp2:x64-windows@1.62.1
    openssl:x64-windows@3.3.2#1
    pkgconf:x64-windows@2.3.0
    shiftmedia-libgnutls:x64-windows@3.8.4#3
  * vcpkg-cmake:x64-windows@2024-04-23
  * vcpkg-cmake-config:x64-windows@2024-05-23
  * vcpkg-cmake-get-vars:x64-windows@2023-12-31
  * vcpkg-tool-meson:x64-windows@1.5.2
  * vs-yasm:x64-windows@0.5.0#2
  * yasm[core,tools]:x64-windows@1.3.0#5
  * yasm-tool-helper:x64-windows@2020-03-11#1
    zlib:x64-windows@1.3.1
    zstd:x64-windows@1.5.6
Additional packages (*) will be modified to complete this operation.
A suitable version of 7zip was not found (required v24.8.0).
Downloading https://github.com/ip7z/7zip/releases/download/24.08/7z2408-extra.7z
Extracting 7zip...
A suitable version of 7zr was not found (required v24.8.0).
Downloading https://github.com/ip7z/7zip/releases/download/24.08/7zr.exe
Restored 2 package(s) from GitHub Actions Cache in 9.8 s. Use --debug to see more details.
Installing 1/30 vcpkg-cmake:x64-windows@2024-04-23...
Elapsed time to handle vcpkg-cmake:x64-windows: 18.7 ms
vcpkg-cmake:x64-windows package ABI: eba2a29e23565c1127388386a46b3919463c346e5ba81740a57aa18015c7dad9
Installing 2/30 vcpkg-cmake-config:x64-windows@2024-05-23...
Elapsed time to handle vcpkg-cmake-config:x64-windows: 4.68 ms
vcpkg-cmake-config:x64-windows package ABI: bd808a43c2dfd433c1f7747aad957f51a5f820ba97c22788bf3395da5a24d309
Installing 3/30 brotli:x64-windows@1.1.0#1...
Building brotli:x64-windows@1.1.0#1...
-- Downloading https://github.com/google/brotli/archive/v1.1.0.tar.gz -> google-brotli-v1.1.0.tar.gz...
[DEBUG] To include the environment variables in debug output, pass --debug-env
[DEBUG] Trying to load bundleconfig from C:\vcpkg\vcpkg-bundle.json
[DEBUG] Failed to open: C:\vcpkg\vcpkg-bundle.json
[DEBUG] Bundle config: readonly=false, usegitregistry=false, embeddedsha=nullopt, deployment=Git, vsversion=nullopt
[DEBUG] Force disabling metrics with --disable-metrics
[DEBUG] Feature flag 'binarycaching' unset
[DEBUG] Feature flag 'compilertracking' unset
[DEBUG] Feature flag 'registries' unset
[DEBUG] Feature flag 'versions' unset
[DEBUG] Feature flag 'dependencygraph' unset
warning: Download failed -- retrying after 1000ms
warning: Download failed -- retrying after 2000ms
warning: Download failed -- retrying after 4000ms
error: Missing google-brotli-v1.1.0.tar.gz and downloads are blocked by x-block-origin.
error: https://github.com/google/brotli/archive/v1.1.0.tar.gz: WinHttpSendRequest failed with exit code 10106
error: https://github.com/google/brotli/archive/v1.1.0.tar.gz: WinHttpSendRequest failed with exit code 10106
error: https://github.com/google/brotli/archive/v1.1.0.tar.gz: WinHttpSendRequest failed with exit code 10106
error: https://github.com/google/brotli/archive/v1.1.0.tar.gz: WinHttpSendRequest failed with exit code 10106
[DEBUG] D:\a\_work\1\s\src\vcpkg\base\downloads.cpp(1030): 
[DEBUG] Time in subprocesses: 0us
[DEBUG] Time in parsing JSON: 5us
[DEBUG] Time in JSON reader: 0us
[DEBUG] Time in filesystem: 166us
[DEBUG] Time in loading ports: 0us
[DEBUG] Exiting after 7 s (7039020us)

CMake Error at scripts/cmake/vcpkg_download_distfile.cmake:32 (message):
      
      Failed to download file with error: 1
      If you are using a proxy, please check your proxy setting. Possible causes are:
      
      1. You are actually using an HTTP proxy, but setting HTTPS_PROXY variable
         to `https://address:port`. This is not correct, because `https://` prefix
         claims the proxy is an HTTPS proxy, while your proxy (v2ray, shadowsocksr
         , etc..) is an HTTP proxy. Try setting `http://address:port` to both
         HTTP_PROXY and HTTPS_PROXY instead.
      
      2. If you are using Windows, vcpkg will automatically use your Windows IE Proxy Settings
         set by your proxy software. See https://github.com/microsoft/vcpkg-tool/pull/77
         The value set by your proxy might be wrong, or have same `https://` prefix issue.
      
      3. Your proxy's remote server is out of service.
      
      If you've tried directly download the link, and believe this is not a temporary
      download server failure, please submit an issue at https://github.com/Microsoft/vcpkg/issues
      to report this upstream download server failure.
      

Call Stack (most recent call first):
  scripts/cmake/vcpkg_download_distfile.cmake:270 (z_vcpkg_download_distfile_show_proxy_and_fail)
  scripts/cmake/vcpkg_from_github.cmake:106 (vcpkg_download_distfile)
  ports/brotli/portfile.cmake:1 (vcpkg_from_github)
  scripts/ports.cmake:192 (include)


error: building brotli:x64-windows failed with: BUILD_FAILED
See https://learn.microsoft.com/vcpkg/troubleshoot/build-failures?WT.mc_id=vcpkg_inproduct_cli for more information.
Elapsed time to handle brotli:x64-windows: 7.1 s
Please ensure you're using the latest port files with `git pull` and `vcpkg update`.
Then check for known issues at:
  https://github.com/microsoft/vcpkg/issues?q=is%3Aissue+is%3Aopen+in%3Atitle+brotli
You can submit a new issue at:
  https://github.com/microsoft/vcpkg/issues/new?title=[brotli]+Build+error+on+x64-windows&body=Copy+issue+body+from+C%3A%2Fvcpkg%2Finstalled%2Fvcpkg%2Fissue_body.md
You can also submit an issue by running (GitHub CLI must be installed):
  gh issue create -R microsoft/vcpkg --title "[brotli] Build failure on x64-windows" --body-file C:/vcpkg/installed/vcpkg/issue_body.md
Error: Process completed with exit code 1.
```
https://github.com/curl/curl/actions/runs/11151074919/job/30994493214#step:5:10
