### PR TITLE
tests: let openssl generate random cert serials

### DIFF
--- a/tests/certs/scripts/genroot.sh
+++ b/tests/certs/scripts/genroot.sh
@@ -60,9 +60,7 @@ if [ -n "$NOTOK" ]; then
   exit
 fi
 
-SERIAL="$(date +'%s')${RANDOM:(-4)}"
-
-echo "SERIAL=$SERIAL PREFIX=$PREFIX DURATION=$DURATION KEYSIZE=$KEYSIZE"
+echo "PREFIX=$PREFIX DURATION=$DURATION KEYSIZE=$KEYSIZE"
 
 set -x
 
@@ -72,8 +70,8 @@ EOF
 "$OPENSSL" req -config "$PREFIX-ca.prm" -new -key "$PREFIX-ca.key" -out "$PREFIX-ca.csr" -passin fd:0 <<EOF
 pass:secret
 EOF
-"$OPENSSL" x509 -set_serial "$SERIAL" -extfile "$PREFIX-ca.prm" -days "$DURATION" -req -signkey "$PREFIX-ca.key" -in "$PREFIX-ca.csr" -out "$PREFIX-$SERIAL-ca.cacert" "$DIGESTALGO"
-"$OPENSSL" x509 -text -in "$PREFIX-$SERIAL-ca.cacert" -nameopt multiline > "$PREFIX-ca.cacert"
+"$OPENSSL" x509 -extfile "$PREFIX-ca.prm" -days "$DURATION" -req -signkey "$PREFIX-ca.key" -in "$PREFIX-ca.csr" -out "$PREFIX-raw-ca.cacert" "$DIGESTALGO"
+"$OPENSSL" x509 -text -in "$PREFIX-raw-ca.cacert" -nameopt multiline > "$PREFIX-ca.cacert"
 "$OPENSSL" x509 -in "$PREFIX-ca.cacert" -outform der -out "$PREFIX-ca.der"
 "$OPENSSL" x509 -in "$PREFIX-ca.cacert" -text -nameopt multiline > "$PREFIX-ca.crt"
 "$OPENSSL" x509 -noout -text -in "$PREFIX-ca.cacert" -nameopt multiline

--- a/tests/certs/scripts/genserv.sh
+++ b/tests/certs/scripts/genserv.sh
@@ -79,11 +79,7 @@ if [ -n "$NOTOK" ]; then
   exit
 fi
 
-if [ -z "${SERIAL:-}" ]; then
-  SERIAL="$(date +'%s')${RANDOM:(-4)}"
-fi
-
-echo "SERIAL=$SERIAL PREFIX=$PREFIX CAPREFIX=$CAPREFIX DURATION=$DURATION KEYSIZE=$KEYSIZE"
+echo "PREFIX=$PREFIX CAPREFIX=$CAPREFIX DURATION=$DURATION KEYSIZE=$KEYSIZE"
 
 set -x
 
@@ -104,7 +100,7 @@ echo 'pseudo secrets generated'
 
 "$OPENSSL" rsa -in "$PREFIX-sv.key" -pubout -outform DER -out "$PREFIX-sv.pub.der"
 "$OPENSSL" rsa -in "$PREFIX-sv.key" -pubout -outform PEM -out "$PREFIX-sv.pub.pem"
-"$OPENSSL" x509 -set_serial "$SERIAL" -extfile "$PREFIX-sv.prm" -days "$DURATION" -CA "$CAPREFIX-ca.cacert" -CAkey "$CAPREFIX-ca.key" -in "$PREFIX-sv.csr" -req -text -nameopt multiline "$DIGESTALGO" > "$PREFIX-sv.crt"
+"$OPENSSL" x509 -extfile "$PREFIX-sv.prm" -days "$DURATION" -CA "$CAPREFIX-ca.cacert" -CAkey "$CAPREFIX-ca.key" -in "$PREFIX-sv.csr" -req -text -nameopt multiline "$DIGESTALGO" > "$PREFIX-sv.crt"
 
 if [ "$P12" = YES ]; then
   "$OPENSSL" pkcs12 -export -des3 -out "$PREFIX-sv.p12" -caname "$CAPREFIX" -name "$PREFIX" -inkey "$PREFIX-sv.key" -in "$PREFIX-sv.crt" -certfile "$CAPREFIX-ca.crt"


### PR DESCRIPTION
Generate the certificate serial numbers automatically instead of doing
from shell (or Perl earlier).

Fixes intermittent CI failures due to the shell-based random generator
generating the same serial number twice:
```
$ openssl ca -config EdelCurlRoot-ca.cnf -revoke Server-localhost0h-sv.crt
Using configuration from EdelCurlRoot-ca.cnf
ERROR:Already revoked, serial number 66FDB23A
make: *** [../../../tests/certs/Server-localhost0h-sv.pem] Error 1
```
https://github.com/curl/curl/actions/runs/11151401083/job/30994755798?pr=15128#step:10:498

Follow-up to fa461b4eff52b413f88debf543b5350a6cef4724 #14486
Follow-up to fa69b41c7790fab86fd363242c81d8ef2e89e183 #13307
