### PR TITLE
GHA/linux: fix wolfSSL version in cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,8 @@ commands:
     steps:
       - run:
           command: |
-            source .github/scripts/VERSIONS
+            # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
+            WOLFSSL_VER=5.6.0
             echo "Installing wolfSSL $WOLFSSL_VER"
             curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VER-stable.tar.gz
             tar -xzf v$WOLFSSL_VER-stable.tar.gz
@@ -64,7 +65,8 @@ commands:
     steps:
       - run:
           command: |
-            source .github/scripts/VERSIONS
+            # renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
+            WOLFSSH_VER=1.4.12
             echo "Installing wolfSSH $WOLFSSH_VER"
             curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssh/archive/v$WOLFSSH_VER-stable.tar.gz
             tar -xzf v$WOLFSSH_VER-stable.tar.gz

--- a/.github/scripts/VERSIONS
+++ b/.github/scripts/VERSIONS
@@ -1,9 +1,0 @@
-# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
-#
-# SPDX-License-Identifier: curl
-
-# renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
-WOLFSSL_VER=5.7.2
-
-# renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
-WOLFSSH_VER=1.4.17

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,6 +41,8 @@ env:
   bearssl-version: 0.6
   # renovate: datasource=github-tags depName=libressl-portable/portable versioning=semver registryUrl=https://github.com
   libressl-version: 3.9.2
+  # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
+  wolfssl-version: 5.7.2
   # renovate: datasource=github-tags depName=ARMmbed/mbedtls versioning=semver registryUrl=https://github.com
   mbedtls-version: 3.6.0
   # renovate: datasource=github-tags depName=icing/mod_h2 versioning=semver registryUrl=https://github.com
@@ -326,15 +328,14 @@ jobs:
           cache-name: cache-wolfssl-all
         with:
           path: /home/runner/wolfssl-all
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.libressl-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
 
       - name: 'build wolfssl (all)'
         if: contains(matrix.build.install_steps, 'wolfssl-all') && steps.cache-wolfssl-all.outputs.cache-hit != 'true'
         run: |
-          source .github/scripts/VERSIONS
-          curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VER-stable.tar.gz
-          tar -xzf v$WOLFSSL_VER-stable.tar.gz
-          cd wolfssl-$WOLFSSL_VER-stable
+          curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v${{ env.wolfssl-version }}-stable.tar.gz
+          tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
+          cd wolfssl-${{ env.wolfssl-version }}-stable
           ./autogen.sh
           ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-all --enable-all
           make install
@@ -347,15 +348,14 @@ jobs:
           cache-name: cache-wolfssl-opensslextra
         with:
           path: /home/runner/wolfssl-opensslextra
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.libressl-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
 
       - name: 'build wolfssl (opensslextra)'
         if: contains(matrix.build.install_steps, 'wolfssl-opensslextra') && steps.cache-wolfssl-opensslextra.outputs.cache-hit != 'true'
         run: |
-          source .github/scripts/VERSIONS
-          curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VER-stable.tar.gz
-          tar -xzf v$WOLFSSL_VER-stable.tar.gz
-          cd wolfssl-$WOLFSSL_VER-stable
+          curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v${{ env.wolfssl-version }}-stable.tar.gz
+          tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
+          cd wolfssl-${{ env.wolfssl-version }}-stable
           ./autogen.sh
           ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-opensslextra --enable-opensslextra
           make install

--- a/renovate.json
+++ b/renovate.json
@@ -49,7 +49,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^.github/scripts/VERSIONS$"
+        ".circleci/config.yml"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?( extractVersion=(?<extractVersion>.+?))?( registryUrl=(?<registryUrl>.*?))?\\s.*?_VER=(?<currentValue>.*)\\s"


### PR DESCRIPTION
This needs the version in the GHA context, so move those back
from external file `VERSIONS`.

Also move back `VERSIONS` content in it previous place to
`.circleci/config.yml`. Update renovate config.

Renovate bot should keep updating the wolfSSL version, but from now on
not in one, but two files.

Follow-up to 820afa2b7cb33a0daaca5b61e8755546b46136d5 #15030
Follow-up to 73a36021207284ad2b4340ffde34a51b0ba4d47a
