### PR TITLE
GHA/windows: add vcpkg workaround

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -729,7 +729,11 @@ jobs:
 
       - name: 'vcpkg build'
         timeout-minutes: 35
-        run: vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
+        run: |
+          export SystemDrive="$SYSTEMDRIVE"
+          export SystemRoot="$SYSTEMROOT"
+          export windir="$WINDIR"
+          vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
 
       - name: 'cmake configure'
         timeout-minutes: 5


### PR DESCRIPTION
Dealing with this error:
```
error: https://github.com/google/brotli/archive/v1.1.0.tar.gz: WinHttpSendRequest failed with exit code 10106
error: https://github.com/google/brotli/archive/v1.1.0.tar.gz: WinHttpSendRequest failed with exit code 10106
error: https://github.com/google/brotli/archive/v1.1.0.tar.gz: WinHttpSendRequest failed with exit code 10106
error: https://github.com/google/brotli/archive/v1.1.0.tar.gz: WinHttpSendRequest failed with exit code 10106
```

add vcpkg workaround:
https://github.com/microsoft/vcpkg/issues/41199#issuecomment-2378255699

