### PR TITLE
wolfssl: add colon separator

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -807,7 +807,7 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     }
   }
 #else
-#define MAX_CIPHER_LEN 1024
+#define MAX_CIPHER_LEN 4096
   if(conn_config->cipher_list || conn_config->cipher_list13) {
     const char *ciphers12 = conn_config->cipher_list;
     const char *ciphers13 = conn_config->cipher_list13;

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -814,7 +814,10 @@ wolfssl_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
       result = wssl_add_default_ciphers(TRUE, &c);
 
     if(!result) {
-      if(ciphers12)
+      result = Curl_dyn_addn(&c, ":", 1);
+      if(result)
+        ;
+      else if(ciphers12)
         result = Curl_dyn_add(&c, ciphers12);
       else
         result = wssl_add_default_ciphers(FALSE, &c);


### PR DESCRIPTION
Ref: #15132 - although this code is not used for QUIC, only old style TLS.

Follow-up to 6fd5a9777acb720e1ac872478151e8b1