### PR TITLE
DEPRECATE: remove hyper in January 2025

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -51,7 +51,7 @@ The only way to keep hyper support in curl is to give it a good polish by
 someone with time, skill and energy to spend on this task.
 
 Unless a significant overhaul has proven to be in progress, hyper support is
-removed from curl after February 2025.
+removed from curl in January 2025.
 
 ## Past removals
 


### PR DESCRIPTION
Previously this document stated we would do it after February, but now it will be done already for the first January 2025 release.

The reason being that since we decided to deprecate hyper, the degradation speed has increased as now no one bothers to fix issues in the hyper side of things. Also: not a single soul has yet spoken up in favor of keeping the support.