### PR TITLE
bufq unwrite fix

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -889,6 +889,7 @@ unsanitized
 Unshare
 unsharing
 untrusted
+unwrite
 UPN
 upstreaming
 URI

--- a/docs/internals/BUFQ.md
+++ b/docs/internals/BUFQ.md
@@ -76,6 +76,17 @@ void Curl_bufq_skip(struct bufq *q, size_t amount);
 
 This removes `amount` number of bytes from the `bufq`.
 
+## unwrite
+
+It is possible to undo writes by calling:
+
+```
+CURLcode Curl_bufq_unwrite(struct bufq *q, size_t len);
+```
+
+This will remove `len` bytes from the end of the bufq again. When removing
+more bytes than are present, CURLE_AGAIN is returned and the bufq will be
+empty.
 
 ## lifetime
 

--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -491,7 +491,7 @@ CURLcode Curl_bufq_cwrite(struct bufq *q,
 CURLcode Curl_bufq_unwrite(struct bufq *q, size_t len)
 {
   while(len && q->tail) {
-    len -= chunk_unwrite(q->head, len);
+    len -= chunk_unwrite(q->tail, len);
     prune_tail(q);
   }
   return len ? CURLE_AGAIN : CURLE_OK;

--- a/tests/unit/unit2601.c
+++ b/tests/unit/unit2601.c
@@ -209,6 +209,37 @@ static void check_bufq(size_t pool_spares,
   }
   fail_unless(nread == nwritten, "did not get the same out as put in");
 
+  /* CHECK bufq_unwrite: write a string repeatedly into the second chunk.
+   * bufq_unwrite() 1 byte. Read strings again and check for content.
+   * We had a bug that unwrite used the head chunk instead of tail, which
+   * did corrupt the read values. */
+  if(TRUE) {
+    const unsigned char buf[] = "0123456789--";
+    size_t roffset;
+    Curl_bufq_reset(&q);
+    while(Curl_bufq_len(&q) < chunk_size) {
+      n = Curl_bufq_write(&q, buf, sizeof(buf), &result);
+      fail_unless(n > 0 && (size_t)n == sizeof(buf), "write should be complete");
+    }
+    result = Curl_bufq_unwrite(&q, 1);
+    roffset = 0;
+    while(!Curl_bufq_is_empty(&q)) {
+      unsigned char rbuf[sizeof(buf)];
+      n = Curl_bufq_read(&q, rbuf, sizeof(rbuf), &result);
+      fail_unless(n > 0, "read should work");
+      if(n != sizeof(rbuf)) {
+        fail_unless(Curl_bufq_is_empty(&q), "should be last read");
+      }
+      if(memcmp(buf, rbuf, n)) {
+        fprintf(stderr, "at offset %zu expected '%.*s', got '%.*s'\n",
+                roffset, (int)n, buf, (int)n, rbuf);
+        fail("read buf content wrong");
+      }
+      roffset += n;
+    }
+    Curl_bufq_reset(&q);
+  }
+
   dump_bufq(&q, "at end of test");
   Curl_bufq_free(&q);
   if(pool_spares > 0)

--- a/tests/unit/unit2601.c
+++ b/tests/unit/unit2601.c
@@ -219,7 +219,7 @@ static void check_bufq(size_t pool_spares,
     Curl_bufq_reset(&q);
     while(Curl_bufq_len(&q) < chunk_size) {
       n = Curl_bufq_write(&q, buf, sizeof(buf), &result);
-      fail_unless(n > 0 && (size_t)n == sizeof(buf), "write should be complete");
+      fail_unless(n > 0 && (size_t)n == sizeof(buf), "write incomplete");
     }
     result = Curl_bufq_unwrite(&q, 1);
     roffset = 0;

--- a/tests/unit/unit2601.c
+++ b/tests/unit/unit2601.c
@@ -220,6 +220,8 @@ static void check_bufq(size_t pool_spares,
     while(Curl_bufq_len(&q) < chunk_size) {
       n = Curl_bufq_write(&q, buf, sizeof(buf), &result);
       fail_unless(n > 0 && (size_t)n == sizeof(buf), "write incomplete");
+      if(result)
+        break;
     }
     result = Curl_bufq_unwrite(&q, 1);
     roffset = 0;
@@ -227,6 +229,8 @@ static void check_bufq(size_t pool_spares,
       unsigned char rbuf[sizeof(buf)];
       n = Curl_bufq_read(&q, rbuf, sizeof(rbuf), &result);
       fail_unless(n > 0, "read should work");
+      if(result)
+        break;
       if(n != sizeof(rbuf)) {
         fail_unless(Curl_bufq_is_empty(&q), "should be last read");
       }


### PR DESCRIPTION
`Curl_bufq_unwrite()` used the head instead of the tail chunk to shrink the bufq's content. Fix this and add test case that checks correct behaviour.

Affects only the WebSocket protocol, not used anywhere else.