### PR TITLE
urlapi: normalize the IPv6 address

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -610,19 +610,14 @@ static CURLUcode ipv6_parse(struct Curl_URL *u, char *hostname,
     /* hostname is fine */
   }
 
-  /* Check the IPv6 address. */
+  /* Normalize the IPv6 address */
   {
     char dest[16]; /* fits a binary IPv6 address */
-    char norm[MAX_IPADR_LEN];
     hostname[hlen] = 0; /* end the address there */
     if(1 != Curl_inet_pton(AF_INET6, hostname, dest))
       return CURLUE_BAD_IPV6;
-
-    /* check if it can be done shorter */
-    if(Curl_inet_ntop(AF_INET6, dest, norm, sizeof(norm)) &&
-       (strlen(norm) < hlen)) {
-      strcpy(hostname, norm);
-      hlen = strlen(norm);
+    if(Curl_inet_ntop(AF_INET6, dest, hostname, hlen)) {
+      hlen = strlen(hostname); /* might be shorter now */
       hostname[hlen + 1] = 0;
     }
     hostname[hlen] = ']'; /* restore ending bracket */

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -565,6 +565,10 @@ static const struct urltestcase get_url_list[] = {
   {"https://[fe80:0:0:0:409b::]:80/moo",
    "https://[fe80::409b:0:0:0]:80/moo",
    0, 0, CURLUE_OK},
+  /* normalize to lower case */
+  {"https://[FE80:0:A:0:409B:0:0:0]:80/moo",
+   "https://[fe80:0:a:0:409b::]:80/moo",
+   0, 0, CURLUE_OK},
   {"https://[::%25fakeit];80/moo",
    "",
    0, 0, CURLUE_BAD_PORT_NUMBER},


### PR DESCRIPTION
As the parsing and address "regeneration" are done anyway, we might as well use the updated version in the result and thereby A) get a normalized (and lower cased) version of the address and B) avoid a strcpy().

Updated test 1560 to verify.