### PR TITLE
warnless: remove curlx_sktosi and curlx_sitosk

### DIFF
--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -345,28 +345,6 @@ size_t curlx_sitouz(int sinum)
 #endif
 }
 
-#ifdef USE_WINSOCK
-
-/*
-** curl_socket_t to signed int
-*/
-
-int curlx_sktosi(curl_socket_t s)
-{
-  return (int)((ssize_t) s);
-}
-
-/*
-** signed int to curl_socket_t
-*/
-
-curl_socket_t curlx_sitosk(int i)
-{
-  return (curl_socket_t)((ssize_t) i);
-}
-
-#endif /* USE_WINSOCK */
-
 #if defined(_WIN32)
 
 ssize_t curlx_read(int fd, void *buf, size_t count)

--- a/lib/warnless.h
+++ b/lib/warnless.h
@@ -61,14 +61,6 @@ unsigned short curlx_uitous(unsigned int uinum);
 
 size_t curlx_sitouz(int sinum);
 
-#ifdef USE_WINSOCK
-
-int curlx_sktosi(curl_socket_t s);
-
-curl_socket_t curlx_sitosk(int i);
-
-#endif /* USE_WINSOCK */
-
 #if defined(_WIN32)
 
 ssize_t curlx_read(int fd, void *buf, size_t count);

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -691,7 +691,7 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
   nth = 0; /* number of internal waiting threads */
   nws = 0; /* number of handled Winsock sockets */
   for(fd = 0; fd < nfds; fd++) {
-    wsasock = curlx_sitosk(fd);
+    wsasock = (curl_socket_t)fd;
     wsaevents.lNetworkEvents = 0;
     handles[nfd] = 0;
 
@@ -818,7 +818,7 @@ static int select_ws(int nfds, fd_set *readfds, fd_set *writefds,
   for(i = 0; i < nfd; i++) {
     fd = data[i].fd;
     handle = handles[i];
-    wsasock = curlx_sitosk(fd);
+    wsasock = (curl_socket_t)fd;
 
     /* check if the current internal handle was triggered */
     if(wait != WAIT_FAILED && (wait - WAIT_OBJECT_0) <= i &&


### PR DESCRIPTION
They were only used by test server code. Use plain old typecasts there.