### PR TITLE
multi: Make curl_multi_waitfds consistent with the documentation.

### DIFF
--- a/docs/libcurl/curl_multi_waitfds.md
+++ b/docs/libcurl/curl_multi_waitfds.md
@@ -45,12 +45,13 @@ If a number of descriptors used by the multi_handle is greater than the
 *size* parameter then libcurl returns CURLM_OUT_OF_MEMORY error.
 
 If the *fd_count* argument is not a null pointer, it points to a variable
-that on returns specifies the number of descriptors used by the multi_handle to
+that on return specifies the number of descriptors used by the multi_handle to
 be checked for being ready to read or write.
 
 The client code can pass *size* equal to zero just to get the number of the
 descriptors and allocate appropriate storage for them to be used in a
-subsequent function call.
+subsequent function call. In this case, *fd_count* receives a number greater
+than or equal to the number of descriptors.
 
 # %PROTOCOLS%
 
@@ -89,7 +90,7 @@ int main(void)
     ufds = (struct curl_waitfd*)malloc(fd_count * sizeof(struct curl_waitfd));
 
     /* get wait descriptors from the transfers and put them into array. */
-    mc = curl_multi_waitfds(multi, ufds, fd_count, NULL);
+    mc = curl_multi_waitfds(multi, ufds, fd_count, &fd_count);
 
     if(mc != CURLM_OK) {
       fprintf(stderr, "curl_multi_waitfds() failed, code %d.\n", mc);

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -926,10 +926,10 @@ CURLcode Curl_cpool_add_pollfds(struct cpool *cpool,
   return result;
 }
 
-CURLcode Curl_cpool_add_waitfds(struct cpool *cpool,
-                                struct curl_waitfds *cwfds)
+unsigned int Curl_cpool_add_waitfds(struct cpool *cpool,
+                                    struct curl_waitfds *cwfds)
 {
-  CURLcode result = CURLE_OK;
+  unsigned int need = 0;
 
   CPOOL_LOCK(cpool);
   if(Curl_llist_head(&cpool->shutdowns)) {
@@ -945,14 +945,11 @@ CURLcode Curl_cpool_add_waitfds(struct cpool *cpool,
       Curl_conn_adjust_pollset(cpool->idata, &ps);
       Curl_detach_connection(cpool->idata);
 
-      result = Curl_waitfds_add_ps(cwfds, &ps);
-      if(result)
-        goto out;
+      need += Curl_waitfds_add_ps(cwfds, &ps);
     }
   }
-out:
   CPOOL_UNLOCK(cpool);
-  return result;
+  return need;
 }
 
 static void cpool_perform(struct cpool *cpool)

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -183,8 +183,8 @@ void Curl_cpool_do_locked(struct Curl_easy *data,
  */
 CURLcode Curl_cpool_add_pollfds(struct cpool *connc,
                                 struct curl_pollfds *cpfds);
-CURLcode Curl_cpool_add_waitfds(struct cpool *connc,
-                                struct curl_waitfds *cwfds);
+unsigned int Curl_cpool_add_waitfds(struct cpool *connc,
+                                    struct curl_waitfds *cwfds);
 
 /**
  * Perform maintenance on connections in the pool. Specifically,

--- a/lib/select.h
+++ b/lib/select.h
@@ -140,8 +140,7 @@ void Curl_waitfds_init(struct curl_waitfds *cwfds,
                        struct curl_waitfd *static_wfds,
                        unsigned int static_count);
 
-CURLcode Curl_waitfds_add_ps(struct curl_waitfds *cwfds,
-                             struct easy_pollset *ps);
-
+unsigned int Curl_waitfds_add_ps(struct curl_waitfds *cwfds,
+                                 struct easy_pollset *ps);
 
 #endif /* HEADER_CURL_SELECT_H */

--- a/tests/libtest/lib2405.c
+++ b/tests/libtest/lib2405.c
@@ -28,6 +28,10 @@
  *  empty multi handle (expected zero descriptors),
  *  HTTP1 amd HTTP2 (no multiplexing) two transfers (expected two descriptors),
  *  HTTP2 with multiplexing (expected one descriptors)
+ *  Improper inputs to the API result in CURLM_BAD_FUNCTION_ARGUMENT.
+ *  Sending a empty ufds, and size = 0 will return the number of fds needed.
+ *  Sending a non-empty ufds, but smaller than the fds needed will result in a
+ *    CURLM_OUT_OF_MEMORY, and a number of fds that is >= to the number needed.
  *
  *  It is also expected that all transfers run by multi-handle should complete
  *  successfully.
@@ -158,10 +162,39 @@ static CURLcode test_run(char *URL, long option, unsigned int *max_fd_count)
   while(!mc) {
     /* get the count of file descriptors from the transfers */
     unsigned int fd_count = 0;
+    unsigned int fd_count_chk = 0;
 
     mc = curl_multi_perform(multi, &still_running);
     if(!still_running || mc != CURLM_OK)
       break;
+
+    /* verify improper inputs are treated correctly. */
+    mc = curl_multi_waitfds(multi, NULL, 0, NULL);
+
+    if(mc != CURLM_BAD_FUNCTION_ARGUMENT) {
+      fprintf(stderr, "curl_multi_waitfds() return code %d instead of "
+        "CURLM_BAD_FUNCTION_ARGUMENT.\n", mc);
+      res = TEST_ERR_FAILURE;
+      break;
+    }
+
+    mc = curl_multi_waitfds(multi, NULL, 1, NULL);
+
+    if(mc != CURLM_BAD_FUNCTION_ARGUMENT) {
+      fprintf(stderr, "curl_multi_waitfds() return code %d instead of "
+        "CURLM_BAD_FUNCTION_ARGUMENT.\n", mc);
+      res = TEST_ERR_FAILURE;
+      break;
+    }
+
+    mc = curl_multi_waitfds(multi, NULL, 1, &fd_count);
+
+    if(mc != CURLM_BAD_FUNCTION_ARGUMENT) {
+      fprintf(stderr, "curl_multi_waitfds() return code %d instead of "
+        "CURLM_BAD_FUNCTION_ARGUMENT.\n", mc);
+      res = TEST_ERR_FAILURE;
+      break;
+    }
 
     mc = curl_multi_waitfds(multi, ufds, 10, &fd_count);
 
@@ -174,12 +207,62 @@ static CURLcode test_run(char *URL, long option, unsigned int *max_fd_count)
     if(!fd_count)
       continue; /* no descriptors yet */
 
+    /* verify that sending nothing but the fd_count results in at least the
+     * same number of fds */
+    mc = curl_multi_waitfds(multi, NULL, 0, &fd_count_chk);
+
+    if(mc != CURLM_OK) {
+      fprintf(stderr, "curl_multi_waitfds() failed, code %d.\n", mc);
+      res = TEST_ERR_FAILURE;
+      break;
+    }
+
+    if(fd_count_chk < fd_count) {
+      fprintf(stderr, "curl_multi_waitfds() should return at least the number "
+        "of fds needed\n");
+      res = TEST_ERR_FAILURE;
+      break;
+    }
+
     /* checking case when we don't have enough space for waitfds */
-    mc = curl_multi_waitfds(multi, ufds1, fd_count - 1, NULL);
+    mc = curl_multi_waitfds(multi, ufds1, fd_count - 1, &fd_count_chk);
 
     if(mc != CURLM_OUT_OF_MEMORY) {
       fprintf(stderr, "curl_multi_waitfds() return code %d instead of "
         "CURLM_OUT_OF_MEMORY.\n", mc);
+      res = TEST_ERR_FAILURE;
+      break;
+    }
+
+    if(fd_count_chk < fd_count) {
+      fprintf(stderr, "curl_multi_waitfds() sould return the amount of fds "
+        "needed if enough isn't passed in.\n");
+      res = TEST_ERR_FAILURE;
+      break;
+    }
+
+    /* sending ufds with zero size, is valid */
+    mc = curl_multi_waitfds(multi, ufds, 0, NULL);
+
+    if(mc != CURLM_OUT_OF_MEMORY) {
+      fprintf(stderr, "curl_multi_waitfds() return code %d instead of "
+        "CURLM_OUT_OF_MEMORY.\n", mc);
+      res = TEST_ERR_FAILURE;
+      break;
+    }
+
+    mc = curl_multi_waitfds(multi, ufds, 0, &fd_count_chk);
+
+    if(mc != CURLM_OUT_OF_MEMORY) {
+      fprintf(stderr, "curl_multi_waitfds() return code %d instead of "
+        "CURLM_OUT_OF_MEMORY.\n", mc);
+      res = TEST_ERR_FAILURE;
+      break;
+    }
+
+    if(fd_count_chk < fd_count) {
+      fprintf(stderr, "curl_multi_waitfds() sould return the amount of fds "
+        "needed if enough isn't passed in.\n");
       res = TEST_ERR_FAILURE;
       break;
     }


### PR DESCRIPTION
Issue Addressed:

 - The documentation of curl_multi_waitfds indicates that users should be able to call curl_multi_waitfds with a NULL ufds. However, before this change, the function would return CURLM_BAD_FUNCTION_ARGUMENT.
 - Additionally, the documentation suggests that users can use this function to determine the number of file descriptors (fds) needed. However, the function would stop counting fds if the supplied fds were exhausted.

Changes Made:

 - NULL ufds Handling: curl_multi_waitfds can now accept a NULL ufds if size is also zero.
 - Counting File Descriptors: If curl_multi_waitfds is passed a NULL ufds, or the size of ufds is insufficient, the output parameter fd_count will return the number of fds needed. This value may be higher than actually needed but never lower.

Testing:

 - Test 2405 has been updated to cover the usage scenarios described above.

Ref: #15146