### PR TITLE
GHA/non-native: fix OmniOS job to fail on tests

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -191,6 +191,7 @@ jobs:
           # https://pkg.omnios.org/r151050/core/en/index.shtml
           prepare: pkg install build-essential libtool
           run: |
+            set -e
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
             autoreconf -fi
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-debug --enable-warnings --enable-werror \

--- a/tests/data/test1
+++ b/tests/data/test1
@@ -45,7 +45,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 <protocol crlf="yes">
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-User-Agent: curl/%VERSION
+User-Agent-TESTING: curl/%VERSION
 Accept: */*
 
 </protocol>

--- a/tests/data/test1
+++ b/tests/data/test1
@@ -45,7 +45,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 <protocol crlf="yes">
 GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-User-Agent-TESTING: curl/%VERSION
+User-Agent: curl/%VERSION
 Accept: */*
 
 </protocol>


### PR DESCRIPTION
Before this patch a failed test did not result in a failed CI job.