### PR TITLE
configure: drop unused bare `socket.h` detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3884,7 +3884,6 @@ AC_CHECK_HEADERS(
   sys/utime.h \
   sys/poll.h \
   poll.h \
-  socket.h \
   sys/resource.h \
   libgen.h \
   locale.h \

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -212,27 +212,6 @@ curl_includes_signal="\
 ])
 
 
-dnl CURL_INCLUDES_SOCKET
-dnl -------------------------------------------------
-dnl Set up variable with list of headers that must be
-dnl included when socket.h is to be included.
-
-AC_DEFUN([CURL_INCLUDES_SOCKET], [
-curl_includes_socket="\
-/* includes start */
-#ifdef HAVE_SYS_TYPES_H
-#  include <sys/types.h>
-#endif
-#ifdef HAVE_SOCKET_H
-#  include <socket.h>
-#endif
-/* includes end */"
-  AC_CHECK_HEADERS(
-    sys/types.h socket.h,
-    [], [], [$curl_includes_socket])
-])
-
-
 dnl CURL_INCLUDES_STDLIB
 dnl -------------------------------------------------
 dnl Set up variable with list of headers that must be
@@ -694,7 +673,6 @@ dnl HAVE_CLOSESOCKET will be defined.
 
 AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
   AC_REQUIRE([CURL_INCLUDES_WINSOCK2])dnl
-  AC_REQUIRE([CURL_INCLUDES_SOCKET])dnl
   #
   tst_links_closesocket="unknown"
   tst_proto_closesocket="unknown"
@@ -705,7 +683,6 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_winsock2
-      $curl_includes_socket
     ]],[[
       if(0 != closesocket(0))
         return 1;
@@ -722,7 +699,6 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
     AC_MSG_CHECKING([if closesocket is prototyped])
     AC_EGREP_CPP([closesocket],[
       $curl_includes_winsock2
-      $curl_includes_socket
     ],[
       AC_MSG_RESULT([yes])
       tst_proto_closesocket="yes"
@@ -737,7 +713,6 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_winsock2
-        $curl_includes_socket
       ]],[[
         if(0 != closesocket(0))
           return 1;
@@ -3836,7 +3811,6 @@ dnl HAVE_SOCKET will be defined.
 AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
   AC_REQUIRE([CURL_INCLUDES_WINSOCK2])dnl
   AC_REQUIRE([CURL_INCLUDES_SYS_SOCKET])dnl
-  AC_REQUIRE([CURL_INCLUDES_SOCKET])dnl
   #
   tst_links_socket="unknown"
   tst_proto_socket="unknown"
@@ -3849,7 +3823,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
       $curl_includes_winsock2
       $curl_includes_bsdsocket
       $curl_includes_sys_socket
-      $curl_includes_socket
     ]],[[
       if(0 != socket(0, 0, 0))
         return 1;
@@ -3868,7 +3841,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
       $curl_includes_winsock2
       $curl_includes_bsdsocket
       $curl_includes_sys_socket
-      $curl_includes_socket
     ],[
       AC_MSG_RESULT([yes])
       tst_proto_socket="yes"
@@ -3885,7 +3857,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
         $curl_includes_winsock2
         $curl_includes_bsdsocket
         $curl_includes_sys_socket
-        $curl_includes_socket
       ]],[[
         if(0 != socket(0, 0, 0))
           return 1;
@@ -3936,7 +3907,6 @@ dnl HAVE_SOCKETPAIR will be defined.
 
 AC_DEFUN([CURL_CHECK_FUNC_SOCKETPAIR], [
   AC_REQUIRE([CURL_INCLUDES_SYS_SOCKET])dnl
-  AC_REQUIRE([CURL_INCLUDES_SOCKET])dnl
   #
   tst_links_socketpair="unknown"
   tst_proto_socketpair="unknown"
@@ -3958,7 +3928,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKETPAIR], [
     AC_MSG_CHECKING([if socketpair is prototyped])
     AC_EGREP_CPP([socketpair],[
       $curl_includes_sys_socket
-      $curl_includes_socket
     ],[
       AC_MSG_RESULT([yes])
       tst_proto_socketpair="yes"
@@ -3973,7 +3942,6 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKETPAIR], [
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
         $curl_includes_sys_socket
-        $curl_includes_socket
       ]],[[
         int sv[2];
         if(0 != socketpair(0, 0, 0, sv))


### PR DESCRIPTION
Added in 37eba37019388f767f5de67b4071641044d7b026 (2009-06-17) to help
detecting socket functions.

But, this `socket.h` isn't used in the source code since
90dd1fc66401d5bb7814f4edeb16a06c925b1f1e #8288 (2022-01-16).
