### PR TITLE
doc: cli-option `--json` is an alias of `--data-binary`

### DIFF
--- a/docs/cmdline-opts/json.md
+++ b/docs/cmdline-opts/json.md
@@ -24,7 +24,7 @@ Example:
 Sends the specified JSON data in a POST request to the HTTP server. --json
 works as a shortcut for passing on these three options:
 
-    --data [arg]
+    --data-binary [arg]
     --header "Content-Type: application/json"
     --header "Accept: application/json"
 


### PR DESCRIPTION
Due to https://github.com/curl/curl/blob/master/src/tool_getparam.c#L879-L880, `--json` is actually an alias for `--data-binary`, not `--data`. Assuming the code is as intended, the documentation should reflect that. 

I encountered this by switching from `-h 'Content-Type: application/json' -d @invalid.json` to `--json @invalid.json` in a test, that expected parsing-error, which contains some information about the line and column. However, due to effectively switching to `--data-binary`, the information about line and column were changed as well and the test failed.

This PR does not change the behaviour of this test, but correctly informs the user about the actual behaviour of `--json`.