### PR TITLE
GHA/windows: drop vcpkg shiftmedia-gnutls, replace with mbedtls

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -619,14 +619,14 @@ jobs:
       matrix:
         include:
           - name: 'schannel MultiSSL U'
-            install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl openssl mbedtls shiftmedia-libgnutls'
+            install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl openssl mbedtls'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             tflags: '~1516 ~2301 ~2302 ~2303 ~2307'
             config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_GNUTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
+              -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
               -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
 
           - name: 'openssl'
@@ -684,8 +684,8 @@ jobs:
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
               -DCURL_USE_GSASL=ON
 
-          - name: 'gnutls'
-            install: 'brotli zlib zstd libpsl nghttp2 shiftmedia-libgnutls libssh pkgconf gsasl ngtcp2[gnutls] nghttp3'
+          - name: 'mbedtls'
+            install: 'brotli zlib zstd libpsl nghttp2 mbedtls libssh pkgconf gsasl'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
@@ -696,7 +696,7 @@ jobs:
             # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
             config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_GNUTLS=ON -DUSE_NGTCP2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_MBEDTLS=ON
               -DCURL_USE_GSASL=ON
 
           - name: 'msh3'


### PR DESCRIPTION
GnuTLS vcpkg package broken again with the latest runner image update:
https://github.com/curl/curl/actions/runs/11240011311/job/31248406051?pr=15203#step:5:137
    
Previous breakage: 09b21e4755b4cc8ff31e9126aa9caf464988551e #14864

---

```
Building shiftmedia-libgnutls:x64-windows@3.8.4#3...
-- Downloading https://github.com/ShiftMediaProject/gnutls/archive/3.8.4.tar.gz -> ShiftMediaProject-gnutls-3.8.4.tar.gz...
-- Extracting source C:/vcpkg/downloads/ShiftMediaProject-gnutls-3.8.4.tar.gz
-- Applying patch external-libtasn1.patch
-- Applying patch pkgconfig.patch
-- Applying patch ssize_t_already_define.patch
-- Applying patch fix-warnings.patch
-- Applying patch mkdir.patch
-- Using source at C:/vcpkg/buildtrees/shiftmedia-libgnutls/src/3.8.4-7d5d4b8442.clean
-- Downloading https://git.savannah.gnu.org/gitweb/?p=gnulib.git\;a=snapshot\;h=3639c57\;sf=tgz -> gnulib-3639c57.tar.gz...
-- Extracting source C:/vcpkg/downloads/gnulib-3639c57.tar.gz
-- Using source at C:/vcpkg/buildtrees/shiftmedia-libgnutls/src/3639c57-6c17dd416b.clean
-- Building SMP/libgnutls.sln for Release
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:127 (message):
    Command failed: msbuild C:/vcpkg/buildtrees/shiftmedia-libgnutls/x64-windows-rel/3.8.4-7d5d4b8442.clean/SMP/libgnutls.sln /p:Configuration=ReleaseDLL /p:YasmPath="C:\\vcpkg\\installed\\x64-windows\\tools\\yasm\\yasm.exe" /p:OutDir=..\\msvc /t:Rebuild /p:Platform=x64 /p:PlatformToolset=v143 /p:VCPkgLocalAppDataDisabled=true /p:UseIntelMKL=No /p:WindowsTargetPlatformVersion=10.0.22621.0 /p:VcpkgTriplet=x64-windows /p:VcpkgInstalledDir=C:/vcpkg/installed /p:VcpkgManifestInstall=false /p:UseMultiToolTask=true /p:MultiProcMaxCount=5 /p:EnforceProcessCountAcrossBuilds=true /m:5 /p:ForceImportBeforeCppTargets=C:/vcpkg/scripts/buildsystems/msbuild/vcpkg.targets /p:VcpkgApplocalDeps=false /p:RuntimeLibrary=MultiThreadedDLL
    Working Directory: C:/vcpkg/buildtrees/shiftmedia-libgnutls/x64-windows-rel/3.8.4-7d5d4b8442.clean
    Error code: 1
    See logs for more information:
      C:\vcpkg\buildtrees\shiftmedia-libgnutls\build-x64-windows-rel-out.log

Call Stack (most recent call first):
  scripts/cmake/vcpkg_install_msbuild.cmake:79 (vcpkg_execute_required_process)
  ports/shiftmedia-libgnutls/portfile.cmake:138 (vcpkg_install_msbuild)
  scripts/ports.cmake:192 (include)

error: building shiftmedia-libgnutls:x64-windows failed with: BUILD_FAILED
See https://learn.microsoft.com/vcpkg/troubleshoot/build-failures?WT.mc_id=vcpkg_inproduct_cli for more information.
Elapsed time to handle shiftmedia-libgnutls:x64-windows: 1.3 min
```