### PR TITLE
GHA: add Linux and macOS mbedTLS jobs, fix issue

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,7 +44,7 @@ env:
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   wolfssl-version: 5.7.2
   # renovate: datasource=github-tags depName=Mbed-TLS/mbedtls versioning=semver registryUrl=https://github.com
-  mbedtls-version: 3.6.0
+  mbedtls-version: 3.6.1
   # renovate: datasource=github-tags depName=icing/mod_h2 versioning=semver registryUrl=https://github.com
   mod_h2-version: 2.0.29
   # renovate: datasource=github-tags depName=nibanks/msh3 versioning=semver registryUrl=https://github.com

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -572,9 +572,6 @@ jobs:
         run: |
           [[ '${{ matrix.build.install_steps }}' = *'awslc'* ]] && sudo apt remove --yes libssl-dev
           if [ -n '${{ matrix.build.generate }}' ]; then
-            if [[ '${{ matrix.build.install_steps }}' = *'mbedtls'* ]]; then
-              export PKG_CONFIG_PATH="$HOME/mbedtls/lib/pkgconfig"
-            fi
             cmake -B . -G Ninja \
               -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -566,7 +566,7 @@ jobs:
         run: |
           [[ '${{ matrix.build.install_steps }}' = *'awslc'* ]] && sudo apt remove --yes libssl-dev
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake -G Ninja \
+            cmake -B . -G Ninja \
               -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,12 +120,7 @@ jobs:
 
           - name: mbedtls-pkg
             install_packages: libnghttp2-dev libmbedtls-dev
-            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
-
-          - name: mbedtls-pkg !pc
-            install_packages: libnghttp2-dev libmbedtls-dev
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCURL_USE_PKGCONFIG=OFF
-            install_steps: skipall
 
           - name: msh3
             install_packages: zlib1g-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,7 +116,7 @@ jobs:
           - name: mbedtls
             install_packages: libnghttp2-dev
             install_steps: mbedtls
-            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCMAKE_C_FLAGS=-fPIC
+            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
 
           - name: mbedtls-packaged
             install_packages: libnghttp2-dev libmbedtls-dev
@@ -390,7 +390,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls
           git submodule update --init
-          cmake -B . -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls
+          cmake -B . -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -385,8 +385,9 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls
           git submodule update --init
-          cmake -B . -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
-          make DESTDIR=$HOME/mbedtls install
+          cmake -B . -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls
+          cmake --build .
+          cmake --install .
 
       - name: cache openssl3
         if: contains(matrix.build.install_steps, 'openssl3')

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -43,7 +43,7 @@ env:
   libressl-version: 3.9.2
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   wolfssl-version: 5.7.2
-  # renovate: datasource=github-tags depName=ARMmbed/mbedtls versioning=semver registryUrl=https://github.com
+  # renovate: datasource=github-tags depName=Mbed-TLS/mbedtls versioning=semver registryUrl=https://github.com
   mbedtls-version: 3.6.0
   # renovate: datasource=github-tags depName=icing/mod_h2 versioning=semver registryUrl=https://github.com
   mod_h2-version: 2.0.29
@@ -378,7 +378,7 @@ jobs:
       - name: 'build mbedtls'
         if: contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtls.outputs.cache-hit != 'true'
         run: |
-          git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/ARMmbed/mbedtls
+          git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls
           git submodule update --init
           make DESTDIR=$HOME/mbedtls install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,6 +113,11 @@ jobs:
             install_steps: mbedtls
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
 
+          - name: mbedtls
+            install_packages: libnghttp2-dev
+            install_steps: mbedtls
+            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
+
           - name: msh3
             install_packages: zlib1g-dev
             install_steps: quictls msh3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,6 +118,10 @@ jobs:
             install_steps: mbedtls
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
 
+          - name: mbedtls-packaged
+            install_packages: libnghttp2-dev libmbedtls-dev
+            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
+
           - name: msh3
             install_packages: zlib1g-dev
             install_steps: quictls msh3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,11 +116,16 @@ jobs:
           - name: mbedtls
             install_packages: libnghttp2-dev
             install_steps: mbedtls
-            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
+            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCMAKE_C_FLAGS=-fPIC
 
           - name: mbedtls-packaged
             install_packages: libnghttp2-dev libmbedtls-dev
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
+
+          - name: mbedtls-packaged !pkg-config
+            install_packages: libnghttp2-dev libmbedtls-dev
+            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCURL_USE_PKGCONFIG=OFF
+            install_steps: skipall
 
           - name: msh3
             install_packages: zlib1g-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -569,6 +569,8 @@ jobs:
             if [[ '${{ matrix.build.install_steps }}' = *'mbedtls'* ]]; then
               export PKG_CONFIG_PATH="$HOME/mbedtls/lib/pkgconfig"
               echo '-------------'
+              find "$HOME/mbedtls"
+              echo '-------------'
               ls -l $HOME/mbedtls/lib/pkgconfig
               echo '-------------'
             fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -381,6 +381,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls
           git submodule update --init
+          cmake -B . -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
           make DESTDIR=$HOME/mbedtls install
 
       - name: cache openssl3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -390,7 +390,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls
           git submodule update --init
-          cmake -B . -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls
+          cmake -B . -G Ninja -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,11 +118,11 @@ jobs:
             install_steps: mbedtls
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
 
-          - name: mbedtls-packaged
+          - name: mbedtls-pkg
             install_packages: libnghttp2-dev libmbedtls-dev
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
 
-          - name: mbedtls-packaged !pkg-config
+          - name: mbedtls-pkg !pc
             install_packages: libnghttp2-dev libmbedtls-dev
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCURL_USE_PKGCONFIG=OFF
             install_steps: skipall

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -568,6 +568,9 @@ jobs:
           if [ -n '${{ matrix.build.generate }}' ]; then
             if [[ '${{ matrix.build.install_steps }}' = *'mbedtls'* ]]; then
               export PKG_CONFIG_PATH="$HOME/mbedtls/lib/pkgconfig"
+              echo '-------------'
+              ls -l $HOME/mbedtls/lib/pkgconfig
+              echo '-------------'
             fi
             cmake -B . -G Ninja \
               -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -113,11 +113,6 @@ jobs:
             install_steps: mbedtls
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
 
-          - name: mbedtls
-            install_packages: libnghttp2-dev
-            install_steps: mbedtls
-            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
-
           - name: mbedtls-pkg
             install_packages: libnghttp2-dev libmbedtls-dev
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCURL_USE_PKGCONFIG=OFF

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -566,6 +566,9 @@ jobs:
         run: |
           [[ '${{ matrix.build.install_steps }}' = *'awslc'* ]] && sudo apt remove --yes libssl-dev
           if [ -n '${{ matrix.build.generate }}' ]; then
+            if [[ '${{ matrix.build.install_steps }}' = *'mbedtls'* ]]; then
+              export PKG_CONFIG_PATH="$HOME/mbedtls/lib/pkgconfig"
+            fi
             cmake -B . -G Ninja \
               -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,7 +44,7 @@ env:
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   wolfssl-version: 5.7.2
   # renovate: datasource=github-tags depName=Mbed-TLS/mbedtls versioning=semver registryUrl=https://github.com
-  mbedtls-version: 3.6.1
+  mbedtls-version: 3.6.0
   # renovate: datasource=github-tags depName=icing/mod_h2 versioning=semver registryUrl=https://github.com
   mod_h2-version: 2.0.29
   # renovate: datasource=github-tags depName=nibanks/msh3 versioning=semver registryUrl=https://github.com

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -574,11 +574,6 @@ jobs:
           if [ -n '${{ matrix.build.generate }}' ]; then
             if [[ '${{ matrix.build.install_steps }}' = *'mbedtls'* ]]; then
               export PKG_CONFIG_PATH="$HOME/mbedtls/lib/pkgconfig"
-              echo '-------------'
-              find "$HOME/mbedtls"
-              echo '-------------'
-              ls -l $HOME/mbedtls/lib/pkgconfig
-              echo '-------------'
             fi
             cmake -B . -G Ninja \
               -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -287,6 +287,10 @@ jobs:
             install: brotli wolfssl zstd
             generate: -DCURL_USE_WOLFSSL=ON -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_DISABLE_LDAP=ON
             macos-version-min: '10.15'
+          - name: 'mbedTLS !ldap brotli zstd'
+            install: brotli mbedtls zstd
+            generate: -DCURL_USE_MBEDTLS=ON -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_DISABLE_LDAP=ON
+            macos-version-min: '10.15'
           - name: 'GnuTLS !ldap krb5'
             install: gnutls nettle krb5
             generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=$(brew --prefix krb5) -DCURL_DISABLE_LDAP=ON

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1048,7 +1048,7 @@ mbed_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
 
     /* Make a copy of our const peercert because mbedtls_pk_write_pubkey_der
        needs a non-const key, for now.
-       https://github.com/ARMmbed/mbedtls/issues/396 */
+       https://github.com/Mbed-TLS/mbedtls/issues/396 */
 #if MBEDTLS_VERSION_NUMBER == 0x03000000
     if(mbedtls_x509_crt_parse_der(p,
                         peercert->MBEDTLS_PRIVATE(raw).MBEDTLS_PRIVATE(p),

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -340,6 +340,7 @@ mbed_set_ssl_version_min_max(struct Curl_easy *data,
    cipher suite present in other SSL implementations. Provide
    provisional support for specifying the cipher suite here. */
 #ifdef MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8
+#if MBEDTLS_VERSION_NUMBER >= 0x03020000
 static int
 mbed_cipher_suite_get_str(uint16_t id, char *buf, size_t buf_size,
                           bool prefer_rfc)
@@ -350,6 +351,7 @@ mbed_cipher_suite_get_str(uint16_t id, char *buf, size_t buf_size,
     return Curl_cipher_suite_get_str(id, buf, buf_size, prefer_rfc);
   return 0;
 }
+#endif
 
 static uint16_t
 mbed_cipher_suite_walk_str(const char **str, const char **end)


### PR DESCRIPTION
- update mbedTLS repo URL.
- switch local mbedTLS build to use CMake, and Ninja.
  CMake build is required to create and install mbedTLS `pkg-config`
  files. (as of v3.6.1)
  `-DCMAKE_POSITION_INDEPENDENT_CODE=ON` required to avoid this error
  when linking mbedtls to `libcurl.so`:
  ```
  /usr/bin/ld: /home/runner/mbedtls/lib/libmbedcrypto.a(cipher.c.o): warning: relocation against `mbedtls_cipher_base_lookup_table' in read-only section `.text'
  /usr/bin/ld: /home/runner/mbedtls/lib/libmbedtls.a(ssl_tls.c.o): relocation R_X86_64_PC32 against symbol `mbedtls_x509_crt_profile_suiteb' can not be used when making a shared object; recompile with -fPIC
  /usr/bin/ld: final link failed: bad value
  ```
  Ref: https://github.com/curl/curl/actions/runs/11245069259/job/31264386723#step:40:43
- make local mbedTLS build 10x smaller by omitting programs and tests.
- GHA/linux: fix cmake warning by adding `-B .` option.
- GHA/linux: add build-only cmake job for packaged mbedTLS (2.x).
- fix compiler warning when building with mbedTLS 2.x:
  ```
  /home/runner/work/curl/curl/lib/vtls/mbedtls.c:344:1: error: ‘mbed_cipher_suite_get_str’ defined but not used [-Werror=unused-function]
    344 | mbed_cipher_suite_get_str(uint16_t id, char *buf, size_t buf_size,
        | ^~~~~~~~~~~~~~~~~~~~~~~~~
  ```
  Ref: https://github.com/curl/curl/actions/runs/11244999065/job/31264168295#step:40:50

Also in preparation for #15193
