### PR TITLE
tool_xattr: create the user.creator xattr attribute

### DIFF
--- a/docs/cmdline-opts/xattr.md
+++ b/docs/cmdline-opts/xattr.md
@@ -17,7 +17,7 @@ Example:
 # `--xattr`
 
 When saving output to a file, tell curl to store file metadata in extended
-file attributes. Currently, the URL is stored in the `xdg.origin.url`
-attribute and, for HTTP, the content type is stored in the `mime_type`
-attribute. If the file system does not support extended attributes, a warning
-is issued.
+file attributes. Currently, `curl` is stored in the `user.creator` attribute,
+the URL is stored in the `xdg.origin.url` attribute and, for HTTP, the content
+type is stored in the `mime_type` attribute. If the file system does not
+support extended attributes, a warning is issued.

--- a/src/tool_xattr.c
+++ b/src/tool_xattr.c
@@ -114,7 +114,7 @@ static int xattr(int fd,
 int fwrite_xattr(CURL *curl, const char *url, int fd)
 {
   int i = 0;
-  int err = 0;
+  int err = xattr(fd, "user.creator", "curl");
 
   /* loop through all xattr-curlinfo pairs and abort on a set error */
   while(!err && mappings[i].attr) {

--- a/tests/data/test644
+++ b/tests/data/test644
@@ -78,6 +78,7 @@ Accept: */*
 
 </protocol>
 <stdout mode="text">
+user.creator => curl
 user.mime_type => text/html
 user.xdg.origin.url => http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 </stdout>

--- a/tests/data/test687
+++ b/tests/data/test687
@@ -55,6 +55,7 @@ Accept: */*
 
 </protocol>
 <stdout mode="text">
+user.creator => curl
 user.mime_type => fake/data
 user.xdg.origin.url => http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 </stdout>

--- a/tests/data/test688
+++ b/tests/data/test688
@@ -55,6 +55,7 @@ Accept: */*
 
 </protocol>
 <stdout mode="text">
+user.creator => curl
 user.mime_type => fake/data
 user.xdg.origin.url => http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 </stdout>


### PR DESCRIPTION
This indicates that the file was created by curl which can help a user
determine the origin of a file. Like the other attributes, this is only
enabled with the --xattr option.

Closes #15237