### PR TITLE
GHA/linux: fix mbedTLS cmake build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -367,15 +367,15 @@ jobs:
       - name: cache mbedtls
         if: contains(matrix.build.install_steps, 'mbedtls')
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
-        id: cache-mbedtls
+        id: cache-mbedtlsRwD
         env:
-          cache-name: cache-mbedtls
+          cache-name: cache-mbedtlsRwD
         with:
           path: /home/runner/mbedtls
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.mbedtls-version }}
 
       - name: 'build mbedtls'
-        if: contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtls.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtlsRwD.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -367,15 +367,15 @@ jobs:
       - name: cache mbedtls
         if: contains(matrix.build.install_steps, 'mbedtls')
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
-        id: cache-mbedtlsRwD
+        id: cache-mbedtls
         env:
-          cache-name: cache-mbedtlsRwD
+          cache-name: cache-mbedtls
         with:
           path: /home/runner/mbedtls
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.mbedtls-version }}
 
       - name: 'build mbedtls'
-        if: contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtlsRwD.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtls.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -380,7 +380,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls
           git submodule update --init
-          cmake -B . -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls \
+          cmake -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls \
             -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
           cmake --build .
           cmake --install .

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -380,7 +380,8 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls
           git submodule update --init
-          cmake -B . -G Ninja -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls
+          cmake -B . -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls \
+            -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
           cmake --build .
           cmake --install .
 


### PR DESCRIPTION
CMake builds mbedTLS in Debug mode by default, which was the reason
for these consistent test failures:
```
FAIL 1631: 'FTP through HTTPS-proxy' FTP, HTTPS-proxy
FAIL 1632: 'FTP through HTTPS-proxy, with connection reuse' FTP, HTTPS-proxy
```
Sometimes also:
```
FAIL 303: 'HTTPS with 8 secs timeout' HTTPS, HTTP GET, timeout, FAILURE
```
https://github.com/curl/curl/actions/runs/11260616621/job/31313234198

Fix it by building in `RelWithDebInfo` mode, matching the bare
`Makefile` builds used earlier. (`Release` mode also works.)

Cache sizes:
- Makefile: 10MB
- CMake Release: 1MB
- CMake RelWithDebInfo: 2.5MB

Ref: #15215
Follow-up to e377c917664241d8cccf67316b96d59a280ad8e4 #15208