### PR TITLE
GHA/linux, http3-linux: add CMake support, sync steps, other improvements

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -255,7 +255,7 @@ jobs:
       - setup
       - build-cache
     runs-on: 'ubuntu-latest'
-    timeout-minutes: 60
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -323,6 +323,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: cache gnutls
+        if: matrix.build.name == 'gnutls'
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         id: cache-gnutls
         env:
@@ -333,6 +334,7 @@ jobs:
           fail-on-cache-miss: true
 
       - name: cache wolfssl
+        if: matrix.build.name == 'wolfssl'
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
         id: cache-wolfssl
         env:

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -431,7 +431,8 @@ jobs:
           path: /home/runner/mod_h2
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.mod_h2-version }}
 
-      - if: steps.cache-mod_h2.outputs.cache-hit != 'true'
+      - name: 'build mod_h2'
+        if: steps.cache-mod_h2.outputs.cache-hit != 'true'
         run: |
           cd $HOME
           git clone --quiet --depth=1 -b v${{ env.mod_h2-version }} https://github.com/icing/mod_h2
@@ -439,12 +440,11 @@ jobs:
           autoreconf -fi
           ./configure
           make
-        name: 'build mod_h2'
 
-      - run: |
+      - name: 'install mod_h2'
+        run: |
           cd $HOME/mod_h2
           sudo make install
-        name: 'install mod_h2'
 
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4
 
@@ -455,25 +455,25 @@ jobs:
       - run: autoreconf -fi
         name: 'autoreconf'
 
-      - run: ./configure --disable-dependency-tracking --enable-unity --enable-test-bundles ${{ matrix.build.configure }}
-        name: 'configure'
+      - name: 'configure'
+        run: ./configure --disable-dependency-tracking --enable-unity --enable-test-bundles ${{ matrix.build.configure }}
 
-      - run: make V=1
-        name: 'make'
+      - name: 'make'
+        run: make V=1
 
-      - run: make V=1 -C tests
-        name: 'make tests'
+      - name: 'make tests'
+        run: make V=1 -C tests
 
-      - run: make V=1 test-ci
-        name: 'run tests'
+      - name: 'run tests'
+        run: make V=1 test-ci
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
 
-      - run: make pytest-ci
-        name: 'run pytest'
+      - name: 'run pytest'
+        run: make pytest-ci
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
           CURL_CI: github
 
-      - run: make V=1 examples
-        name: 'make examples'
+      - name: 'make examples'
+        run: make V=1 examples

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -249,8 +249,8 @@ jobs:
           make install
         name: 'build nghttp2'
 
-  autotools:
-    name: ${{ matrix.build.name }}
+  linux:
+    name: ${{ matrix.build.generate && 'CM' || 'AM' }} ${{ matrix.build.name }}
     needs:
       - setup
       - build-cache
@@ -302,7 +302,7 @@ jobs:
       - run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
-          sudo apt-get install libtool autoconf automake pkgconf stunnel4 \
+          sudo apt-get install libtool autoconf automake ninja-build pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \
@@ -453,27 +453,63 @@ jobs:
         name: 'install python test prereqs'
 
       - run: autoreconf -fi
+        if: ${{ matrix.build.configure }}
         name: 'autoreconf'
 
       - name: 'configure'
-        run: ./configure --disable-dependency-tracking --enable-unity --enable-test-bundles ${{ matrix.build.configure }}
+        run: |
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            cmake -B . -G Ninja \
+              -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \
+              -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
+              -DCURL_BROTLI=ON -DCURL_ZSTD=ON \
+              ${{ matrix.build.generate }}
+          else
+            ./configure --disable-dependency-tracking --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
+              ${{ matrix.build.configure }}
+          fi
 
-      - name: 'make'
-        run: make V=1
+      - name: 'build'
+        run: |
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            cmake --build . --parallel 5 --verbose
+          else
+            make V=1
+          fi
 
-      - name: 'make tests'
-        run: make V=1 -C tests
+      - name: 'build tests'
+        run: |
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            cmake --build . --parallel 5 --verbose --target testdeps
+          else
+            make V=1 -C tests
+          fi
 
       - name: 'run tests'
-        run: make V=1 test-ci
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
+        run: |
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            cmake --build . --verbose --target test-ci
+          else
+            make V=1 test-ci
+          fi
 
       - name: 'run pytest'
-        run: make pytest-ci
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
           CURL_CI: github
+        run: |
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            cmake --build . --verbose --target curl-pytest-ci
+          else
+            make V=1 pytest-ci
+          fi
 
-      - name: 'make examples'
-        run: make V=1 examples
+      - name: 'build examples'
+        run: |
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            cmake --build . --parallel 5 --verbose --target curl-examples
+          else
+            make V=1 examples
+          fi

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -291,10 +291,10 @@ jobs:
 
           - name: quiche
             configure: >-
-              LDFLAGS="-Wl,-rpath,/home/runner/quiche/target/release"
-              --with-openssl=/home/runner/quiche/quiche/deps/boringssl/src
+              LDFLAGS="-Wl,-rpath,$HOME/quiche/target/release"
+              --with-openssl=$HOME/quiche/quiche/deps/boringssl/src
               --enable-warnings --enable-werror --enable-debug
-              --with-quiche=/home/runner/quiche/target/release
+              --with-quiche=$HOME/quiche/target/release
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-ca-fallback
 
@@ -417,9 +417,9 @@ jobs:
           ln -vnf $(find target/release -name libcrypto.a -o -name libssl.a) quiche/deps/boringssl/src/lib/
 
           # include dir
-          # /home/runner/quiche/quiche/deps/boringssl/src/include
+          # $HOME/quiche/quiche/deps/boringssl/src/include
           # lib dir
-          # /home/runner/quiche/quiche/deps/boringssl/src/lib
+          # $HOME/quiche/quiche/deps/boringssl/src/lib
         name: 'build quiche and boringssl'
 
       - name: cache mod_h2

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -475,6 +475,11 @@ jobs:
         if: ${{ !cancelled() }}
         run: cat config.log CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
 
+      - name: 'curl_config.h'
+        run: |
+          echo '::group::raw'; cat lib/curl_config.h || true; echo '::endgroup::'
+          cat lib/curl_config.h | grep -F '#define' | sort || true
+
       - name: 'test configs'
         run: |
           cat tests/config || true

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -217,7 +217,7 @@ jobs:
           cd $HOME
           git clone --quiet --depth=1 -b v${{ env.nghttp3-version }} https://github.com/ngtcp2/nghttp3
           cd nghttp3
-          git submodule update --init
+          git submodule update --init --depth=1
           autoreconf -fi
           ./configure --disable-dependency-tracking --prefix=$PWD/build PKG_CONFIG_PATH="$PWD/build/lib/pkgconfig" --enable-lib-only
           make

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -469,6 +469,15 @@ jobs:
               ${{ matrix.build.configure }}
           fi
 
+      - name: 'configure log'
+        if: ${{ !cancelled() }}
+        run: cat config.log CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
+
+      - name: 'test configs'
+        run: |
+          cat tests/config || true
+          cat tests/http/config.ini || true
+
       - name: 'build'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
@@ -476,6 +485,9 @@ jobs:
           else
             make V=1
           fi
+
+      - run: ./src/curl -V
+        name: 'check curl -V output'
 
       - name: 'build tests'
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -583,6 +583,11 @@ jobs:
         if: ${{ !cancelled() }}
         run: cat config.log CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
 
+      - name: 'curl_config.h'
+        run: |
+          echo '::group::raw'; cat lib/curl_config.h || true; echo '::endgroup::'
+          cat lib/curl_config.h | grep -F '#define' | sort || true
+
       - name: 'test configs'
         run: |
           cat tests/config || true

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -63,7 +63,7 @@ jobs:
     name: ${{ matrix.build.generate && 'CM' || 'AM' }} ${{ matrix.build.name }}
     runs-on: 'ubuntu-latest'
     container: ${{ matrix.build.container }}
-    timeout-minutes: 90
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -379,7 +379,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b v${{ env.mbedtls-version }} https://github.com/Mbed-TLS/mbedtls
           cd mbedtls
-          git submodule update --init
+          git submodule update --init --depth=1
           cmake -B . -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_INSTALL_PREFIX=$HOME/mbedtls \
             -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
           cmake --build .

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -260,7 +260,10 @@ jobs:
 
       - if: startsWith(matrix.build.container, 'alpine')
         run: |
-          apk add --no-cache build-base autoconf automake libtool perl openssl-dev libssh2-dev zlib-dev brotli-dev zstd-dev libidn2-dev openldap-dev heimdal-dev libpsl-dev py3-impacket py3-asn1 py3-six py3-pycryptodomex perl-time-hires openssh stunnel sudo git
+          apk add --no-cache build-base autoconf automake libtool perl openssl-dev libssh2-dev \
+            zlib-dev brotli-dev zstd-dev libidn2-dev openldap-dev heimdal-dev libpsl-dev \
+            py3-impacket py3-asn1 py3-six py3-pycryptodomex \
+            perl-time-hires openssh stunnel sudo git
         name: 'install dependencies'
 
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4


### PR DESCRIPTION
- use shallow clone for submodules.
- reduce total job timeout from 90/60 → 45 minutes.
- use `$HOME` instead of literal.
- http3-linux: sync step yaml order with linux.yml.
- http3-linux: add cmake + ninja support like in linux.yml.
- http3-linux: dump confgure log, test config, curl -V like in linux.yml.
- http3-linux: skip restoring gnutls and wolfssl when not used.
- dump `curl_config.h`.
- fold a long line.
