### PR TITLE
GHA/linux: skip installing rust if rustls is in cache

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -487,14 +487,6 @@ jobs:
           cmake --build . --parallel 5
           cmake --install .
 
-      - if: contains(matrix.build.install_steps, 'rust')
-        run: |
-          cd $HOME
-          curl -sSf --compressed https://sh.rustup.rs/ | sh -s -- -y
-          source $HOME/.cargo/env
-          rustup toolchain install nightly
-        name: 'install rust'
-
       - name: cache rustls
         if: contains(matrix.build.install_steps, 'rustls')
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4
@@ -504,6 +496,14 @@ jobs:
         with:
           path: /home/runner/rustls
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.rustls-version }}
+
+      - name: 'install rust'
+        if: contains(matrix.build.install_steps, 'rust') && steps.cache-rustls.outputs.cache-hit != 'true'
+        run: |
+          cd $HOME
+          curl -sSf --compressed https://sh.rustup.rs/ | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup toolchain install nightly
 
       - name: 'build rustls'
         if: contains(matrix.build.install_steps, 'rustls') && steps.cache-rustls.outputs.cache-hit != 'true'


### PR DESCRIPTION
Rust remains installed for the Hyper job, because the rustls cache flag
is always false in that case.
