### PR TITLE
GHA: drop `--parallel` option for CMake + Ninja jobs

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -511,7 +511,7 @@ jobs:
       - name: 'build'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --parallel 5 --verbose
+            cmake --build . --verbose
           else
             make V=1
           fi
@@ -522,7 +522,7 @@ jobs:
       - name: 'build tests'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --parallel 5 --verbose --target testdeps
+            cmake --build . --verbose --target testdeps
           else
             make V=1 -C tests
           fi
@@ -551,7 +551,7 @@ jobs:
       - name: 'build examples'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --parallel 5 --verbose --target curl-examples
+            cmake --build . --verbose --target curl-examples
           else
             make V=1 examples
           fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -502,7 +502,7 @@ jobs:
           mkdir aws-lc-${{ env.awslc-version }}-build
           cd aws-lc-${{ env.awslc-version }}-build
           cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/awslc ../aws-lc-${{ env.awslc-version }}
-          cmake --build . --parallel 5
+          cmake --build .
           cmake --install .
 
       - name: cache rustls
@@ -620,7 +620,7 @@ jobs:
       - name: 'build'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            ${{ matrix.build.make-prefix }} cmake --build . --parallel 5 --verbose
+            ${{ matrix.build.make-prefix }} cmake --build . --verbose
           else
             ${{ matrix.build.make-prefix }} make V=1
           fi
@@ -647,7 +647,7 @@ jobs:
         if: ${{ matrix.build.install_steps != 'skipall' }}
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --parallel 5 --verbose --target testdeps
+            cmake --build . --verbose --target testdeps
           else
             make V=1 -C tests
           fi
@@ -684,7 +684,7 @@ jobs:
       - name: 'build examples'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            ${{ matrix.build.make-prefix }} cmake --build . --parallel 5 --verbose --target curl-examples
+            ${{ matrix.build.make-prefix }} cmake --build . --verbose --target curl-examples
           else
             ${{ matrix.build.make-prefix }} make V=1 examples
           fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -61,15 +61,15 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DCURL_USE_GSSAPI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            cmake --build bld --config Debug --parallel 3
+            cmake --build bld --config Debug
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              cmake --build bld --config Debug --parallel 3 --target testdeps
+              cmake --build bld --config Debug --target testdeps
               export TFLAGS='-j4'
               cmake --build bld --config Debug --target test-ci
             fi
             echo '::group::build examples'
-            cmake --build bld --config Debug --parallel 3 --target curl-examples
+            cmake --build bld --config Debug --target curl-examples
             echo '::endgroup::'
 
   openbsd:
@@ -97,15 +97,15 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            cmake --build bld --config Debug --parallel 3
+            cmake --build bld --config Debug
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              cmake --build bld --config Debug --parallel 3 --target testdeps
+              cmake --build bld --config Debug --target testdeps
               export TFLAGS='-j8 ~3017 ~TFTP ~FTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
               cmake --build bld --config Debug --target test-ci
             fi
             echo '::group::build examples'
-            cmake --build bld --config Debug --parallel 3 --target curl-examples
+            cmake --build bld --config Debug --target curl-examples
             echo '::endgroup::'
 
   freebsd:
@@ -168,14 +168,14 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DCURL_USE_GSSAPI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            cmake --build bld --config Debug --parallel 3
+            cmake --build bld --config Debug
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              cmake --build bld --config Debug --parallel 3 --target testdeps
+              cmake --build bld --config Debug --target testdeps
               cmake --build bld --config Debug --target test-ci
             fi
             echo '::group::build examples'
-            cmake --build bld --config Debug --parallel 3 --target curl-examples
+            cmake --build bld --config Debug --target curl-examples
             echo '::endgroup::'
 
   omnios:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -153,7 +153,7 @@ jobs:
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 10
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
+        run: cmake --build bld --config '${{ matrix.type }}'
 
       - name: 'curl version'
         if: ${{ matrix.build == 'cmake' }}
@@ -166,7 +166,7 @@ jobs:
       - name: 'cmake build tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' }}
         timeout-minutes: 15
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
+        run: cmake --build bld --config '${{ matrix.type }}' --target testdeps
 
       - name: 'cmake run tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -182,7 +182,7 @@ jobs:
       - name: 'cmake build examples'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 5
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
+        run: cmake --build bld --config '${{ matrix.type }}' --target curl-examples
 
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
@@ -363,7 +363,7 @@ jobs:
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 10
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
+        run: cmake --build bld --config '${{ matrix.type }}'
 
       - name: 'curl version'
         if: ${{ matrix.build == 'cmake' }}
@@ -378,7 +378,7 @@ jobs:
       - name: 'cmake build tests'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' }}
         timeout-minutes: 10
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
+        run: cmake --build bld --config '${{ matrix.type }}' --target testdeps
 
       - name: 'install test tools'
         if: ${{ matrix.build == 'cmake' && matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -407,7 +407,7 @@ jobs:
       - name: 'cmake build examples'
         if: ${{ matrix.build == 'cmake' }}
         timeout-minutes: 5
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
+        run: cmake --build bld --config '${{ matrix.type }}' --target curl-examples
 
   old-mingw-w64:
     name: 'old-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
@@ -595,15 +595,15 @@ jobs:
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
-        run: cmake --build bld --parallel 5
+        run: cmake --build bld
 
       - name: 'cmake build tests'
         if: ${{ matrix.build == 'cmake' }}
-        run: cmake --build bld --parallel 5 --target testdeps
+        run: cmake --build bld --target testdeps
 
       - name: 'cmake build examples'
         if: ${{ matrix.build == 'cmake' }}
-        run: cmake --build bld --parallel 5 --target curl-examples
+        run: cmake --build bld --target curl-examples
 
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'


### PR DESCRIPTION
It's managed by Ninja automatically.