### PR TITLE
tests: allow pytests to run out of tree

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -72,7 +72,6 @@ function(add_pytest _targetname _test_flags)
   endif()
   string(REPLACE " " ";" _test_flags_list "${_test_flags}")
   add_custom_target(${_targetname}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND pytest ${_test_flags_list} "${CMAKE_CURRENT_SOURCE_DIR}/http"
     DEPENDS "${_depends}"
     VERBATIM USES_TERMINAL

--- a/tests/http/testenv/client.py
+++ b/tests/http/testenv/client.py
@@ -44,7 +44,7 @@ class LocalClient:
                  timeout: Optional[float] = None,
                  run_env: Optional[Dict[str,str]] = None):
         self.name = name
-        self.path = os.path.join(env.project_dir, f'tests/http/clients/{name}')
+        self.path = os.path.join(env.build_dir, f'tests/http/clients/{name}')
         self.env = env
         self._run_env = run_env
         self._timeout = timeout if timeout else env.test_timeout

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -49,10 +49,9 @@ def init_config_from(conf_path):
 
 
 TESTS_HTTPD_PATH = os.path.dirname(os.path.dirname(__file__))
-DEF_CONFIG = init_config_from(os.path.join(TESTS_HTTPD_PATH, 'config.ini'))
-
-TOP_PATH = os.path.dirname(os.path.dirname(TESTS_HTTPD_PATH))
-CURL = os.path.join(TOP_PATH, 'src/curl')
+TOP_PATH = os.path.join(os.getcwd(), os.path.pardir)
+DEF_CONFIG = init_config_from(os.path.join(TOP_PATH, 'tests', 'http', 'config.ini'))
+CURL = os.path.join(TOP_PATH, 'src', 'curl')
 
 
 class EnvConfig:
@@ -61,6 +60,7 @@ class EnvConfig:
         self.tests_dir = TESTS_HTTPD_PATH
         self.gen_dir = os.path.join(self.tests_dir, 'gen')
         self.project_dir = os.path.dirname(os.path.dirname(self.tests_dir))
+        self.build_dir = TOP_PATH
         self.config = DEF_CONFIG
         # check cur and its features
         self.curl = CURL
@@ -435,6 +435,10 @@ class Env:
     @property
     def project_dir(self) -> str:
         return self.CONFIG.project_dir
+
+    @property
+    def build_dir(self) -> str:
+        return self.CONFIG.build_dir
 
     @property
     def ca(self):


### PR DESCRIPTION
Some of the files it needs are in the build directory but the code did
not make a distinction.

Closes #15257