### PR TITLE
smb: do not redefine `getpid` on Windows

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -27,10 +27,6 @@
 
 #if !defined(CURL_DISABLE_SMB) && defined(USE_CURL_NTLM_CORE)
 
-#ifdef _WIN32
-#define getpid GetCurrentProcessId
-#endif
-
 #include "smb.h"
 #include "urldata.h"
 #include "sendf.h"
@@ -546,7 +542,11 @@ static void smb_format_message(struct Curl_easy *data, struct smb_header *h,
   h->flags2 = smb_swap16(SMB_FLAGS2_IS_LONG_NAME | SMB_FLAGS2_KNOWS_LONG_NAME);
   h->uid = smb_swap16(smbc->uid);
   h->tid = smb_swap16(req->tid);
+#ifdef _WIN32
+  pid = (unsigned int)GetCurrentProcessId();
+#else
   pid = (unsigned int)getpid();
+#endif
   h->pid_high = smb_swap16((unsigned short)(pid >> 16));
   h->pid = smb_swap16((unsigned short) pid);
 }

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -27,6 +27,12 @@
 
 #if !defined(CURL_DISABLE_SMB) && defined(USE_CURL_NTLM_CORE)
 
+#ifdef _WIN32
+#define Curl_getpid() GetCurrentProcessId()
+#else
+#define Curl_getpid() getpid()
+#endif
+
 #include "smb.h"
 #include "urldata.h"
 #include "sendf.h"
@@ -542,11 +548,7 @@ static void smb_format_message(struct Curl_easy *data, struct smb_header *h,
   h->flags2 = smb_swap16(SMB_FLAGS2_IS_LONG_NAME | SMB_FLAGS2_KNOWS_LONG_NAME);
   h->uid = smb_swap16(smbc->uid);
   h->tid = smb_swap16(req->tid);
-#ifdef _WIN32
-  pid = (unsigned int)GetCurrentProcessId();
-#else
-  pid = (unsigned int)getpid();
-#endif
+  pid = (unsigned int)Curl_getpid();
   h->pid_high = smb_swap16((unsigned short)(pid >> 16));
   h->pid = smb_swap16((unsigned short) pid);
 }

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -28,9 +28,9 @@
 #if !defined(CURL_DISABLE_SMB) && defined(USE_CURL_NTLM_CORE)
 
 #ifdef _WIN32
-#define Curl_getpid() GetCurrentProcessId()
+#define Curl_getpid() ((unsigned int)GetCurrentProcessId())
 #else
-#define Curl_getpid() getpid()
+#define Curl_getpid() ((unsigned int)getpid())
 #endif
 
 #include "smb.h"
@@ -548,7 +548,7 @@ static void smb_format_message(struct Curl_easy *data, struct smb_header *h,
   h->flags2 = smb_swap16(SMB_FLAGS2_IS_LONG_NAME | SMB_FLAGS2_KNOWS_LONG_NAME);
   h->uid = smb_swap16(smbc->uid);
   h->tid = smb_swap16(req->tid);
-  pid = (unsigned int)Curl_getpid();
+  pid = Curl_getpid();
   h->pid_high = smb_swap16((unsigned short)(pid >> 16));
   h->pid = smb_swap16((unsigned short) pid);
 }


### PR DESCRIPTION
Replace with namespaced local macro `Curl_getpid()`.

Redefining symbols can backfire if that symbol is used in system
headers, especially with unity build. We haven't seen a fallout in CI
or supported envs, but do it anyway for good measure.

Bug report: https://datagirl.xyz/posts/wolfssl_curl_w2k.html
