### PR TITLE
gnutls, use session cache for QUIC

### DIFF
--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -240,7 +240,7 @@ CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
 #elif defined(USE_GNUTLS)
   (void)result;
   return Curl_gtls_ctx_init(&ctx->gtls, cf, data, peer,
-                            (const unsigned char *)alpn, alpn_len,
+                            (const unsigned char *)alpn, alpn_len, NULL,
                             cb_setup, cb_user_data, ssl_user_data);
 #elif defined(USE_WOLFSSL)
   result = Curl_wssl_init_ctx(ctx, cf, data, cb_setup, cb_user_data);

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -45,6 +45,7 @@ struct Curl_cfilter;
 struct ssl_primary_config;
 struct ssl_config_data;
 struct ssl_peer;
+struct ssl_connect_data;
 
 struct gtls_shared_creds {
   gnutls_certificate_credentials_t creds;
@@ -78,6 +79,7 @@ CURLcode Curl_gtls_ctx_init(struct gtls_ctx *gctx,
                             struct Curl_easy *data,
                             struct ssl_peer *peer,
                             const unsigned char *alpn, size_t alpn_len,
+                            struct ssl_connect_data *connssl,
                             Curl_gtls_ctx_setup_cb *cb_setup,
                             void *cb_user_data,
                             void *ssl_user_data);
@@ -92,6 +94,13 @@ CURLcode Curl_gtls_verifyserver(struct Curl_easy *data,
                                 struct ssl_config_data *ssl_config,
                                 struct ssl_peer *peer,
                                 const char *pinned_key);
+
+/* Extract TLS session and place in cache, if configured. */
+CURLcode Curl_gtls_update_session_id(struct Curl_cfilter *cf,
+                                     struct Curl_easy *data,
+                                     gnutls_session_t session,
+                                     struct ssl_peer *peer,
+                                     const char *alpn);
 
 extern const struct Curl_ssl Curl_ssl_gnutls;
 

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -625,10 +625,16 @@ class TestDownload:
         self.check_downloads(client, srcfile, count)
         # check that TLS earlydata worked as expected
         earlydata = {}
+        reused_session = False
         for line in r.trace_lines:
             m = re.match(r'^\[t-(\d+)] EarlyData: (\d+)', line)
             if m:
                 earlydata[int(m.group(1))] = int(m.group(2))
+                continue
+            m = re.match(r'\[1-1] \* SSL reusing session.*', line)
+            if m:
+                reused_session = True
+        assert reused_session, f'session was not reused for 2nd transfer'
         assert earlydata[0] == 0, f'{earlydata}'
         if proto == 'http/1.1':
             assert earlydata[1] == 69, f'{earlydata}'

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -634,7 +634,7 @@ class TestDownload:
             m = re.match(r'\[1-1] \* SSL reusing session.*', line)
             if m:
                 reused_session = True
-        assert reused_session, f'session was not reused for 2nd transfer'
+        assert reused_session, 'session was not reused for 2nd transfer'
         assert earlydata[0] == 0, f'{earlydata}'
         if proto == 'http/1.1':
             assert earlydata[1] == 69, f'{earlydata}'


### PR DESCRIPTION
Add session reuse for QUIC transfers using GnuTLS. This does not include support for TLS early data, yet.

Fix check of early data support in common GnuTLS init code to not access the filter context, as the struct varies between TCP and QUIC connections.