### PR TITLE
ci: dump `curl_config.h` to log in all jobs

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -501,7 +501,7 @@ jobs:
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat lib/curl_config.h || true; echo '::endgroup::'
-          cat lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' lib/curl_config.h | sort || true
 
       - name: 'test configs'
         run: |

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -87,7 +87,7 @@ jobs:
       - name: 'cmake build-only curl_config.h'
         run: |
           echo '::group::raw'; cat bld-1/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld-1/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld-1/lib/curl_config.h | sort || true
 
       - name: 'cmake generate (out-of-tree, c-ares, libssh, zstd, gssapi)'
         run: |
@@ -100,7 +100,7 @@ jobs:
       - name: 'cmake curl_config.h'
         run: |
           echo '::group::raw'; cat bld-cares/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld-cares/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld-cares/lib/curl_config.h | sort || true
 
       - name: 'cmake build'
         run: |
@@ -130,7 +130,7 @@ jobs:
       - name: 'autoconf curl_config.h'
         run: |
           echo '::group::raw'; cat bld-am/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld-am/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld-am/lib/curl_config.h | sort || true
 
       - name: 'autoconf build'
         run: |

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -84,6 +84,11 @@ jobs:
           make install
           src/curl --disable --version
 
+      - name: 'cmake build-only curl_config.h'
+        run: |
+          echo '::group::raw'; cat bld-1/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld-1/lib/curl_config.h | grep -F '#define' | sort || true
+
       - name: 'cmake generate (out-of-tree, c-ares, libssh, zstd, gssapi)'
         run: |
           mkdir bld-cares
@@ -91,6 +96,11 @@ jobs:
           cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON \
             -DENABLE_ARES=ON -DCURL_ZSTD=ON -DCURL_USE_GSSAPI=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DUSE_LIBRTMP=ON \
             -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
+
+      - name: 'cmake curl_config.h'
+        run: |
+          echo '::group::raw'; cat bld-cares/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld-cares/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'cmake build'
         run: |
@@ -116,6 +126,11 @@ jobs:
           ../configure --disable-dependency-tracking --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
             --with-openssl --enable-ares --with-libssh --with-zstd --with-gssapi --with-librtmp \
             --prefix="$PWD"/../install-am
+
+      - name: 'autoconf curl_config.h'
+        run: |
+          echo '::group::raw'; cat bld-am/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld-am/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'autoconf build'
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -610,7 +610,7 @@ jobs:
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat lib/curl_config.h || true; echo '::endgroup::'
-          cat lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' lib/curl_config.h | sort || true
 
       - name: 'test configs'
         run: |

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -74,6 +74,11 @@ jobs:
             ${{ matrix.build.configure }}
         name: 'configure'
 
+      - name: 'curl_config.h'
+        run: |
+          echo '::group::raw'; cat lib/curl_config.h || true; echo '::endgroup::'
+          cat lib/curl_config.h | grep -F '#define' | sort || true
+
       - run: make V=1
         name: 'make'
 

--- a/.github/workflows/linux32.yml
+++ b/.github/workflows/linux32.yml
@@ -77,7 +77,7 @@ jobs:
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat lib/curl_config.h || true; echo '::endgroup::'
-          cat lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' lib/curl_config.h | sort || true
 
       - run: make V=1
         name: 'make'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -205,7 +205,7 @@ jobs:
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'build-cert'
         if: contains(matrix.configure, '--with-secure-transport')
@@ -363,7 +363,7 @@ jobs:
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'build-cert'
         if: contains(matrix.build.generate, '-DCURL_USE_SECTRANSP=ON')
@@ -643,7 +643,7 @@ jobs:
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'build / ${{ matrix.build }}'
         run: make -C bld V=1 VERBOSE=1

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -61,7 +61,8 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DCURL_USE_GSSAPI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h'; cat bld/lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
+            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
             cmake --build bld --config Debug
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -98,7 +99,8 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h'; cat bld/lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
+            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
             cmake --build bld --config Debug
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -141,7 +143,8 @@ jobs:
               --with-openssl \
               --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 --with-gssapi \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
-            echo '::group::curl_config.h'; cat lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
+            echo '::group::curl_config.h (raw)'; cat lib/curl_config.h || true; echo '::endgroup::'
+            echo '::group::curl_config.h'; grep -F '#define' lib/curl_config.h | sort || true; echo '::endgroup::'
             make -j3 install
             src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -171,7 +174,8 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DCURL_USE_GSSAPI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            echo '::group::curl_config.h'; cat bld/lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
+            echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+            echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
             cmake --build bld --config Debug
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -202,7 +206,8 @@ jobs:
               --prefix="${HOME}"/install \
               --with-openssl \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
-            echo '::group::curl_config.h'; cat lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
+            echo '::group::curl_config.h (raw)'; cat lib/curl_config.h || true; echo '::endgroup::'
+            echo '::group::curl_config.h'; grep -F '#define' lib/curl_config.h | sort || true; echo '::endgroup::'
             gmake -j3 install
             src/curl --disable --version
             gmake -j3 -C tests

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -61,6 +61,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DCURL_USE_GSSAPI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
+            echo '::group::curl_config.h'; cat bld/lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
             cmake --build bld --config Debug
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -97,6 +98,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
+            echo '::group::curl_config.h'; cat bld/lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
             cmake --build bld --config Debug
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -139,6 +141,7 @@ jobs:
               --with-openssl \
               --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 --with-gssapi \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
+            echo '::group::curl_config.h'; cat lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
             make -j3 install
             src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -168,6 +171,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON -DCURL_USE_GSSAPI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
+            echo '::group::curl_config.h'; cat bld/lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
             cmake --build bld --config Debug
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
@@ -198,6 +202,7 @@ jobs:
               --prefix="${HOME}"/install \
               --with-openssl \
               --disable-dependency-tracking || { tail -n 1000 config.log; false; }
+            echo '::group::curl_config.h'; cat lib/curl_config.h | grep -F '#define' | sort || true; echo '::endgroup::'
             gmake -j3 install
             src/curl --disable --version
             gmake -j3 -C tests

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -72,6 +72,11 @@ jobs:
             ${{ matrix.build.generate }}
         name: 'cmake configure'
 
+      - name: 'cmake curl_config.h'
+        run: |
+          echo '::group::raw'; cat lib/curl_config.h || true; echo '::endgroup::'
+          cat lib/curl_config.h | grep -F '#define' | sort || true
+
       - run: cmake --build . --verbose
         name: 'cmake build'
 

--- a/.github/workflows/torture.yml
+++ b/.github/workflows/torture.yml
@@ -75,7 +75,7 @@ jobs:
       - name: 'cmake curl_config.h'
         run: |
           echo '::group::raw'; cat lib/curl_config.h || true; echo '::endgroup::'
-          cat lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' lib/curl_config.h | sort || true
 
       - run: cmake --build . --verbose
         name: 'cmake build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -569,6 +569,14 @@ jobs:
         if: ${{ matrix.build == 'autotools' && !cancelled() }}
         run: cat bld/config.log 2>/dev/null || true
 
+      - name: 'curl_config.h'
+        if: ${{ matrix.build == 'autotools' }}
+        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+
+      - name: 'curl_config.h (full)'
+        if: ${{ matrix.build == 'cmake' }}
+        run: cat bld/lib/curl_config.h || true
+
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' }}
         run: make -C bld -j5
@@ -592,6 +600,14 @@ jobs:
       - name: 'cmake configure log'
         if: ${{ matrix.build == 'cmake' && !cancelled() }}
         run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
+
+      - name: 'curl_config.h'
+        if: ${{ matrix.build == 'cmake' }}
+        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+
+      - name: 'curl_config.h (full)'
+        if: ${{ matrix.build == 'cmake' }}
+        run: cat bld/lib/curl_config.h || true
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -94,11 +94,9 @@ jobs:
 
       - name: 'curl_config.h'
         if: ${{ matrix.build == 'automake' }}
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        if: ${{ matrix.build == 'automake' }}
-        run: cat bld/lib/curl_config.h || true
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'automake' }}
@@ -144,11 +142,9 @@ jobs:
 
       - name: 'curl_config.h'
         if: ${{ matrix.build == 'cmake' }}
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        if: ${{ matrix.build == 'cmake' }}
-        run: cat bld/lib/curl_config.h || true
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -264,11 +260,9 @@ jobs:
 
       - name: 'curl_config.h'
         if: ${{ matrix.build == 'autotools' }}
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        if: ${{ matrix.build == 'autotools' }}
-        run: cat bld/lib/curl_config.h || true
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' }}
@@ -354,11 +348,9 @@ jobs:
 
       - name: 'curl_config.h'
         if: ${{ matrix.build == 'cmake' }}
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        if: ${{ matrix.build == 'cmake' }}
-        run: cat bld/lib/curl_config.h || true
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -484,10 +476,9 @@ jobs:
         run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
 
       - name: 'curl_config.h'
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        run: cat bld/lib/curl_config.h || true
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'cmake build'
         timeout-minutes: 5
@@ -571,11 +562,9 @@ jobs:
 
       - name: 'curl_config.h'
         if: ${{ matrix.build == 'autotools' }}
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        if: ${{ matrix.build == 'cmake' }}
-        run: cat bld/lib/curl_config.h || true
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' }}
@@ -603,11 +592,9 @@ jobs:
 
       - name: 'curl_config.h'
         if: ${{ matrix.build == 'cmake' }}
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        if: ${{ matrix.build == 'cmake' }}
-        run: cat bld/lib/curl_config.h || true
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -779,10 +766,9 @@ jobs:
         run: cat bld/CMakeFiles/CMake*.yaml 2>/dev/null || true
 
       - name: 'curl_config.h'
-        run: cat bld/lib/curl_config.h | grep -F '#define' | sort || true
-
-      - name: 'curl_config.h (full)'
-        run: cat bld/lib/curl_config.h || true
+        run: |
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
 
       - name: 'cmake build'
         timeout-minutes: 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,7 +96,7 @@ jobs:
         if: ${{ matrix.build == 'automake' }}
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'automake' }}
@@ -144,7 +144,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -262,7 +262,7 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' }}
@@ -350,7 +350,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -478,7 +478,7 @@ jobs:
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'cmake build'
         timeout-minutes: 5
@@ -564,7 +564,7 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'autotools build'
         if: ${{ matrix.build == 'autotools' }}
@@ -594,7 +594,7 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'cmake build'
         if: ${{ matrix.build == 'cmake' }}
@@ -768,7 +768,7 @@ jobs:
       - name: 'curl_config.h'
         run: |
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
-          cat bld/lib/curl_config.h | grep -F '#define' | sort || true
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'cmake build'
         timeout-minutes: 5

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -62,6 +62,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     '-DCMAKE_INSTALL_PREFIX=C:/curl' \
     "-DCMAKE_BUILD_TYPE=${PRJ_CFG}" \
     '-DCURL_USE_LIBPSL=OFF'
+  echo 'curl_config.h'; cat _bld/lib/curl_config.h | grep -F '#define' | sort || true
   # shellcheck disable=SC2086
   if ! cmake --build _bld --config "${PRJ_CFG}" --parallel 2 -- ${BUILD_OPT:-}; then
     if [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ]; then

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -62,7 +62,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     '-DCMAKE_INSTALL_PREFIX=C:/curl' \
     "-DCMAKE_BUILD_TYPE=${PRJ_CFG}" \
     '-DCURL_USE_LIBPSL=OFF'
-  echo 'curl_config.h'; cat _bld/lib/curl_config.h | grep -F '#define' | sort || true
+  echo 'curl_config.h'; grep -F '#define' _bld/lib/curl_config.h | sort || true
   # shellcheck disable=SC2086
   if ! cmake --build _bld --config "${PRJ_CFG}" --parallel 2 -- ${BUILD_OPT:-}; then
     if [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ]; then


### PR DESCRIPTION
Also:
- GHA/windows: merge full and brief dump into a single job step.
- fix shellcheck warning 'useless cat'.
