### PR TITLE
pytest: include `buildinfo.txt` in the output

### DIFF
--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -53,7 +53,15 @@ def pytest_report_header(config):
         report.extend([
             f'  VsFTPD: {env.vsftpd_version()}, ftp:{env.ftp_port}, ftps:{env.ftps_port}'
         ])
-    return '\n'.join(report)
+    out = '\n'.join(report)
+    buildinfo_fn = os.path.join(env.build_dir, 'buildinfo.txt')
+    if os.path.exists(buildinfo_fn):
+        with open(buildinfo_fn, 'r') as file_in:
+            for line in file_in:
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    out += '\n' + line
+    return out
 
 # TODO: remove this and repeat argument everywhere, pytest-repeat can be used to repeat tests
 def pytest_generate_tests(metafunc):

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -53,15 +53,14 @@ def pytest_report_header(config):
         report.extend([
             f'  VsFTPD: {env.vsftpd_version()}, ftp:{env.ftp_port}, ftps:{env.ftps_port}'
         ])
-    out = '\n'.join(report)
     buildinfo_fn = os.path.join(env.build_dir, 'buildinfo.txt')
     if os.path.exists(buildinfo_fn):
         with open(buildinfo_fn, 'r') as file_in:
             for line in file_in:
                 line = line.strip()
                 if line and not line.startswith('#'):
-                    out += '\n' + line
-    return out
+                    report.extend([line])
+    return '\n'.join(report)
 
 # TODO: remove this and repeat argument everywhere, pytest-repeat can be used to repeat tests
 def pytest_generate_tests(metafunc):


### PR DESCRIPTION
If present.

It aims to provide TextClutch the same build information that
`runtests.pl` already is providing.

Ref: https://testclutch.curl.se/static/reports/feature-matrix.html
Ref: #15256
Follow-up to 1fdea1684602a1ae2870c67b5f3e8fd34f63da95 #14802

---

Example:
```
============================= test session starts ==============================
platform linux -- Python 3.10.12, pytest-8.3.3, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
Testing curl 8.11.0-DEV
  httpd: 2.4.52, http:54909 https:58605
  httpd-proxy: 2.4.52, http:33255 https:47459
  VsFTPD: unknown, ftp:48291, ftps:43843
buildinfo.configure.tool: configure
buildinfo.configure.args:  '--disable-dependency-tracking' '--enable-unity' '--enable-test-bundles' '--enable-warnings' '--enable-werror' 'LDFLAGS=-Wl,-rpath,/home/runner/bearssl/lib' '--with-bearssl=/home/runner/bearssl' '--enable-debug'
buildinfo.host: x86_64-pc-linux-gnu
buildinfo.host.cpu: x86_64
buildinfo.host.os: linux-gnu
buildinfo.target: x86_64-pc-linux-gnu
buildinfo.target.cpu: x86_64
buildinfo.target.os: linux-gnu
buildinfo.target.flags: UNIX GCC
buildinfo.compiler: GNU_C
buildinfo.compiler.version: 11
buildinfo.sysroot:
rootdir: /home/runner/work/curl/curl/tests
collecting ... collected 640 items
```
https://github.com/curl/curl/actions/runs/11309061752/job/31452535187?pr=15279#step:47:64
