### PR TITLE
GHA/linux: add cmake job for system mbedTLS with pkg-config

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,7 @@ env:
 jobs:
   linux:
     name: ${{ matrix.build.generate && 'CM' || 'AM' }} ${{ matrix.build.name }}
-    runs-on: 'ubuntu-latest'
+    runs-on: 'ubuntu-24.04'
     container: ${{ matrix.build.container }}
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -116,10 +116,14 @@ jobs:
           - name: mbedtls
             install_packages: libnghttp2-dev
             install_steps: mbedtls
-            PKG_CONFIG_PATH: '$HOME/mbedtls/lib/pkgconfig'  # Requires v3.6.0 or upper
+            PKG_CONFIG_PATH: '$HOME/mbedtls/lib/pkgconfig'  # Requires v3.6.0 or v2.28.8
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
 
           - name: mbedtls-pkg
+            install_packages: libnghttp2-dev libmbedtls-dev
+            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
+
+          - name: mbedtls-pkg !pc
             install_packages: libnghttp2-dev libmbedtls-dev
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCURL_USE_PKGCONFIG=OFF
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -125,6 +125,7 @@ jobs:
 
           - name: mbedtls-pkg !pc
             install_packages: libnghttp2-dev libmbedtls-dev
+            install_steps: skipall
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCURL_USE_PKGCONFIG=OFF
 
           - name: msh3

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,7 +61,7 @@ env:
 jobs:
   linux:
     name: ${{ matrix.build.generate && 'CM' || 'AM' }} ${{ matrix.build.name }}
-    runs-on: 'ubuntu-24.04'
+    runs-on: 'ubuntu-latest'
     container: ${{ matrix.build.container }}
     timeout-minutes: 45
     strategy:


### PR DESCRIPTION
Add a build-only cmake job with system mbedTLS package and `pkg-config`
enabled. Ubuntu 24.04 comes with mbedTLS 2.28.8 which supports
`pkg-config`.

Follow-up to 7bab201abe3915a0167c002f9308950cb8a06e4b #15193