### PR TITLE
GHA/linux: fixup pip for Ubuntu 24.04

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -501,7 +501,7 @@ jobs:
 
       - name: 'install test prereqs'
         run: |
-          sudo python3 -m pip install -r tests/requirements.txt
+          sudo python3 -m pip install --break-system-packages -r tests/requirements.txt
 
       - name: 'run tests'
         env:
@@ -515,7 +515,7 @@ jobs:
 
       - name: 'install pytest prereqs'
         run: |
-          sudo python3 -m pip install -r tests/http/requirements.txt
+          sudo python3 -m pip install --break-system-packages -r tests/http/requirements.txt
 
       - name: cache mod_h2
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -627,7 +627,7 @@ jobs:
       - name: 'install test prereqs'
         if: ${{ matrix.build.install_steps != 'skipall' && !startsWith(matrix.build.container, 'alpine') && matrix.build.container == null }}
         run: |
-          sudo python3 -m pip install -r tests/requirements.txt
+          sudo python3 -m pip install --break-system-packages -r tests/requirements.txt
 
       - name: 'run tests'
         if: ${{ matrix.build.install_steps != 'skipall' && matrix.build.install_steps != 'skiprun' }}
@@ -649,7 +649,7 @@ jobs:
       - name: 'install pytest prereqs'
         if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          sudo python3 -m pip install -r tests/http/requirements.txt
+          sudo python3 -m pip install --break-system-packages -r tests/http/requirements.txt
 
       - name: cache mod_h2
         if: contains(matrix.build.install_steps, 'pytest')


### PR DESCRIPTION
`ubuntu-latest` became `ubuntu-24.04` today.