### PR TITLE
lib: fix function pointers to please UndefinedBehaviorSanitizer

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -30,7 +30,7 @@
  */
 
 #ifdef CURL_NO_OLDIES
-#define CURL_STRICTER
+#define CURL_STRICTER /* not used since 8.11.0 */
 #endif
 
 /* Compile-time deprecation macros. */
@@ -114,13 +114,8 @@
 extern "C" {
 #endif
 
-#if defined(BUILDING_LIBCURL) || defined(CURL_STRICTER)
-typedef struct Curl_easy CURL;
-typedef struct Curl_share CURLSH;
-#else
 typedef void CURL;
 typedef void CURLSH;
-#endif
 
 /*
  * libcurl external API function linkage decorations.

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -54,11 +54,7 @@
 extern "C" {
 #endif
 
-#if defined(BUILDING_LIBCURL) || defined(CURL_STRICTER)
-typedef struct Curl_multi CURLM;
-#else
 typedef void CURLM;
-#endif
 
 typedef enum {
   CURLM_CALL_MULTI_PERFORM = -1, /* please call curl_multi_perform() or

--- a/lib/curl_hmac.h
+++ b/lib/curl_hmac.h
@@ -32,30 +32,28 @@
 
 #define HMAC_MD5_LENGTH 16
 
-typedef CURLcode (* HMAC_hinit_func)(void *context);
-typedef void    (* HMAC_hupdate_func)(void *context,
-                                      const unsigned char *data,
-                                      unsigned int len);
-typedef void    (* HMAC_hfinal_func)(unsigned char *result, void *context);
-
+typedef CURLcode (*HMAC_hinit)(void *context);
+typedef void    (*HMAC_hupdate)(void *context,
+                                const unsigned char *data,
+                                unsigned int len);
+typedef void    (*HMAC_hfinal)(unsigned char *result, void *context);
 
 /* Per-hash function HMAC parameters. */
 struct HMAC_params {
-  HMAC_hinit_func
-  hmac_hinit;     /* Initialize context procedure. */
-  HMAC_hupdate_func     hmac_hupdate;   /* Update context with data. */
-  HMAC_hfinal_func      hmac_hfinal;    /* Get final result procedure. */
-  unsigned int          hmac_ctxtsize;  /* Context structure size. */
-  unsigned int          hmac_maxkeylen; /* Maximum key length (bytes). */
-  unsigned int          hmac_resultlen; /* Result length (bytes). */
+  HMAC_hinit       hinit;     /* Initialize context procedure. */
+  HMAC_hupdate     hupdate;   /* Update context with data. */
+  HMAC_hfinal      hfinal;    /* Get final result procedure. */
+  unsigned int     ctxtsize;  /* Context structure size. */
+  unsigned int     maxkeylen; /* Maximum key length (bytes). */
+  unsigned int     resultlen; /* Result length (bytes). */
 };
 
 
 /* HMAC computation context. */
 struct HMAC_context {
-  const struct HMAC_params *hmac_hash; /* Hash function definition. */
-  void *hmac_hashctxt1;         /* Hash function context 1. */
-  void *hmac_hashctxt2;         /* Hash function context 2. */
+  const struct HMAC_params *hash; /* Hash function definition. */
+  void *hashctxt1;         /* Hash function context 1. */
+  void *hashctxt2;         /* Hash function context 2. */
 };
 
 

--- a/lib/curl_md5.h
+++ b/lib/curl_md5.h
@@ -31,11 +31,11 @@
 
 #define MD5_DIGEST_LEN  16
 
-typedef CURLcode (* Curl_MD5_init_func)(void *context);
-typedef void (* Curl_MD5_update_func)(void *context,
-                                      const unsigned char *data,
-                                      unsigned int len);
-typedef void (* Curl_MD5_final_func)(unsigned char *result, void *context);
+typedef CURLcode (*Curl_MD5_init_func)(void *context);
+typedef void (*Curl_MD5_update_func)(void *context,
+                                     const unsigned char *data,
+                                     unsigned int len);
+typedef void (*Curl_MD5_final_func)(unsigned char *result, void *context);
 
 struct MD5_params {
   Curl_MD5_init_func     md5_init_func;   /* Initialize context procedure */
@@ -50,8 +50,8 @@ struct MD5_context {
   void                  *md5_hashctx;   /* Hash function context */
 };
 
-extern const struct MD5_params Curl_DIGEST_MD5[1];
-extern const struct HMAC_params Curl_HMAC_MD5[1];
+extern const struct MD5_params Curl_DIGEST_MD5;
+extern const struct HMAC_params Curl_HMAC_MD5;
 
 CURLcode Curl_md5it(unsigned char *output, const unsigned char *input,
                     const size_t len);

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -528,7 +528,7 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_hash(const char *user, size_t userlen,
   ascii_uppercase_to_unicode_le(identity, user, userlen);
   ascii_to_unicode_le(identity + (userlen << 1), domain, domlen);
 
-  result = Curl_hmacit(Curl_HMAC_MD5, ntlmhash, 16, identity, identity_len,
+  result = Curl_hmacit(&Curl_HMAC_MD5, ntlmhash, 16, identity, identity_len,
                        ntlmv2hash);
   free(identity);
 
@@ -613,7 +613,7 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
 
   /* Concatenate the Type 2 challenge with the BLOB and do HMAC MD5 */
   memcpy(ptr + 8, &ntlm->nonce[0], 8);
-  result = Curl_hmacit(Curl_HMAC_MD5, ntlmv2hash, HMAC_MD5_LENGTH, ptr + 8,
+  result = Curl_hmacit(&Curl_HMAC_MD5, ntlmv2hash, HMAC_MD5_LENGTH, ptr + 8,
                     NTLMv2_BLOB_LEN + 8, hmac_output);
   if(result) {
     free(ptr);
@@ -656,7 +656,7 @@ CURLcode  Curl_ntlm_core_mk_lmv2_resp(unsigned char *ntlmv2hash,
   memcpy(&data[0], challenge_server, 8);
   memcpy(&data[8], challenge_client, 8);
 
-  result = Curl_hmacit(Curl_HMAC_MD5, ntlmv2hash, 16, &data[0], 16,
+  result = Curl_hmacit(&Curl_HMAC_MD5, ntlmv2hash, 16, &data[0], 16,
                        hmac_output);
   if(result)
     return result;

--- a/lib/curl_sha256.h
+++ b/lib/curl_sha256.h
@@ -31,7 +31,7 @@
 #include <curl/curl.h>
 #include "curl_hmac.h"
 
-extern const struct HMAC_params Curl_HMAC_SHA256[1];
+extern const struct HMAC_params Curl_HMAC_SHA256;
 
 #ifndef CURL_SHA256_DIGEST_LENGTH
 #define CURL_SHA256_DIGEST_LENGTH 32 /* fixed size */

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -180,7 +180,7 @@ UNITTEST DOHcode doh_req_encode(const char *host,
 }
 
 static size_t
-doh_write_cb(const void *contents, size_t size, size_t nmemb, void *userp)
+doh_write_cb(char *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
   struct dynbuf *mem = (struct dynbuf *)userp;

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -238,14 +238,14 @@ static int doh_done(struct Curl_easy *doh, CURLcode result)
   return 0;
 }
 
-#define ERROR_CHECK_SETOPT(x,y) \
-do {                                          \
-  result = curl_easy_setopt(doh, x, y);       \
-  if(result &&                                \
-     result != CURLE_NOT_BUILT_IN &&          \
-     result != CURLE_UNKNOWN_OPTION)          \
-    goto error;                               \
-} while(0)
+#define ERROR_CHECK_SETOPT(x,y)                         \
+  do {                                                  \
+    result = curl_easy_setopt((CURL *)doh, x, y);       \
+    if(result &&                                        \
+       result != CURLE_NOT_BUILT_IN &&                  \
+       result != CURLE_UNKNOWN_OPTION)                  \
+      goto error;                                       \
+  } while(0)
 
 static CURLcode doh_run_probe(struct Curl_easy *data,
                               struct doh_probe *p, DNStype dnstype,
@@ -301,7 +301,7 @@ static CURLcode doh_run_probe(struct Curl_easy *data,
   ERROR_CHECK_SETOPT(CURLOPT_PROTOCOLS, CURLPROTO_HTTP|CURLPROTO_HTTPS);
 #endif
   ERROR_CHECK_SETOPT(CURLOPT_TIMEOUT_MS, (long)timeout_ms);
-  ERROR_CHECK_SETOPT(CURLOPT_SHARE, data->share);
+  ERROR_CHECK_SETOPT(CURLOPT_SHARE, (CURLSH *)data->share);
   if(data->set.err && data->set.err != stderr)
     ERROR_CHECK_SETOPT(CURLOPT_STDERR, data->set.err);
   if(Curl_trc_ft_is_verbose(data, &Curl_doh_trc))

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -29,6 +29,8 @@
 
 #include <curl/curl.h>
 
+struct Curl_easy;
+
 #include "urldata.h"
 #include "warnless.h"
 #include "escape.h"
@@ -53,7 +55,7 @@ char *curl_unescape(const char *string, int length)
 /* Escapes for URL the given unescaped string of given length.
  * 'data' is ignored since 7.82.0.
  */
-char *curl_easy_escape(struct Curl_easy *data, const char *string,
+char *curl_easy_escape(CURL *data, const char *string,
                        int inlength)
 {
   size_t length;
@@ -176,7 +178,7 @@ CURLcode Curl_urldecode(const char *string, size_t length,
  * If olen == NULL, no output length is stored.
  * 'data' is ignored since 7.82.0.
  */
-char *curl_easy_unescape(struct Curl_easy *data, const char *string,
+char *curl_easy_unescape(CURL *data, const char *string,
                          int length, int *olen)
 {
   char *str = NULL;

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -26,6 +26,8 @@
 
 #include <curl/curl.h>
 
+struct Curl_easy;
+
 #include "formdata.h"
 #if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_FORM_API)
 
@@ -812,7 +814,7 @@ static int fseeko_wrapper(void *stream, curl_off_t offset, int whence)
  * a NULL pointer in the 'data' argument.
  */
 
-CURLcode Curl_getformdata(struct Curl_easy *data,
+CURLcode Curl_getformdata(CURL *data,
                           curl_mimepart *finalform,
                           struct curl_httppost *post,
                           curl_read_callback fread_func)

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -49,7 +49,7 @@ struct FormInfo {
   bool showfilename_alloc;
 };
 
-CURLcode Curl_getformdata(struct Curl_easy *data,
+CURLcode Curl_getformdata(CURL *data,
                           curl_mimepart *,
                           struct curl_httppost *post,
                           curl_read_callback fread_func);

--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -49,8 +49,6 @@
 static const unsigned char hmac_ipad = 0x36;
 static const unsigned char hmac_opad = 0x5C;
 
-
-
 struct HMAC_context *
 Curl_HMAC_init(const struct HMAC_params *hashparams,
                const unsigned char *key,
@@ -62,42 +60,40 @@ Curl_HMAC_init(const struct HMAC_params *hashparams,
   unsigned char b;
 
   /* Create HMAC context. */
-  i = sizeof(*ctxt) + 2 * hashparams->hmac_ctxtsize +
-    hashparams->hmac_resultlen;
+  i = sizeof(*ctxt) + 2 * hashparams->ctxtsize + hashparams->resultlen;
   ctxt = malloc(i);
 
   if(!ctxt)
     return ctxt;
 
-  ctxt->hmac_hash = hashparams;
-  ctxt->hmac_hashctxt1 = (void *) (ctxt + 1);
-  ctxt->hmac_hashctxt2 = (void *) ((char *) ctxt->hmac_hashctxt1 +
-      hashparams->hmac_ctxtsize);
+  ctxt->hash = hashparams;
+  ctxt->hashctxt1 = (void *) (ctxt + 1);
+  ctxt->hashctxt2 = (void *) ((char *) ctxt->hashctxt1 + hashparams->ctxtsize);
 
   /* If the key is too long, replace it by its hash digest. */
-  if(keylen > hashparams->hmac_maxkeylen) {
-    (*hashparams->hmac_hinit)(ctxt->hmac_hashctxt1);
-    (*hashparams->hmac_hupdate)(ctxt->hmac_hashctxt1, key, keylen);
-    hkey = (unsigned char *) ctxt->hmac_hashctxt2 + hashparams->hmac_ctxtsize;
-    (*hashparams->hmac_hfinal)(hkey, ctxt->hmac_hashctxt1);
+  if(keylen > hashparams->maxkeylen) {
+    hashparams->hinit(ctxt->hashctxt1);
+    hashparams->hupdate(ctxt->hashctxt1, key, keylen);
+    hkey = (unsigned char *) ctxt->hashctxt2 + hashparams->ctxtsize;
+    hashparams->hfinal(hkey, ctxt->hashctxt1);
     key = hkey;
-    keylen = hashparams->hmac_resultlen;
+    keylen = hashparams->resultlen;
   }
 
   /* Prime the two hash contexts with the modified key. */
-  (*hashparams->hmac_hinit)(ctxt->hmac_hashctxt1);
-  (*hashparams->hmac_hinit)(ctxt->hmac_hashctxt2);
+  hashparams->hinit(ctxt->hashctxt1);
+  hashparams->hinit(ctxt->hashctxt2);
 
   for(i = 0; i < keylen; i++) {
     b = (unsigned char)(*key ^ hmac_ipad);
-    (*hashparams->hmac_hupdate)(ctxt->hmac_hashctxt1, &b, 1);
+    hashparams->hupdate(ctxt->hashctxt1, &b, 1);
     b = (unsigned char)(*key++ ^ hmac_opad);
-    (*hashparams->hmac_hupdate)(ctxt->hmac_hashctxt2, &b, 1);
+    hashparams->hupdate(ctxt->hashctxt2, &b, 1);
   }
 
-  for(; i < hashparams->hmac_maxkeylen; i++) {
-    (*hashparams->hmac_hupdate)(ctxt->hmac_hashctxt1, &hmac_ipad, 1);
-    (*hashparams->hmac_hupdate)(ctxt->hmac_hashctxt2, &hmac_opad, 1);
+  for(; i < hashparams->maxkeylen; i++) {
+    hashparams->hupdate(ctxt->hashctxt1, &hmac_ipad, 1);
+    hashparams->hupdate(ctxt->hashctxt2, &hmac_opad, 1);
   }
 
   /* Done, return pointer to HMAC context. */
@@ -105,31 +101,29 @@ Curl_HMAC_init(const struct HMAC_params *hashparams,
 }
 
 int Curl_HMAC_update(struct HMAC_context *ctxt,
-                     const unsigned char *data,
+                     const unsigned char *ptr,
                      unsigned int len)
 {
   /* Update first hash calculation. */
-  (*ctxt->hmac_hash->hmac_hupdate)(ctxt->hmac_hashctxt1, data, len);
+  ctxt->hash->hupdate(ctxt->hashctxt1, ptr, len);
   return 0;
 }
 
 
-int Curl_HMAC_final(struct HMAC_context *ctxt, unsigned char *result)
+int Curl_HMAC_final(struct HMAC_context *ctxt, unsigned char *output)
 {
-  const struct HMAC_params *hashparams = ctxt->hmac_hash;
+  const struct HMAC_params *hashparams = ctxt->hash;
 
-  /* Do not get result if called with a null parameter: only release
+  /* Do not get output if called with a null parameter: only release
      storage. */
 
-  if(!result)
-    result = (unsigned char *) ctxt->hmac_hashctxt2 +
-     ctxt->hmac_hash->hmac_ctxtsize;
+  if(!output)
+    output = (unsigned char *) ctxt->hashctxt2 + ctxt->hash->ctxtsize;
 
-  (*hashparams->hmac_hfinal)(result, ctxt->hmac_hashctxt1);
-  (*hashparams->hmac_hupdate)(ctxt->hmac_hashctxt2,
-   result, hashparams->hmac_resultlen);
-  (*hashparams->hmac_hfinal)(result, ctxt->hmac_hashctxt2);
-  free((char *) ctxt);
+  hashparams->hfinal(output, ctxt->hashctxt1);
+  hashparams->hupdate(ctxt->hashctxt2, output, hashparams->resultlen);
+  hashparams->hfinal(output, ctxt->hashctxt2);
+  free(ctxt);
   return 0;
 }
 
@@ -144,15 +138,15 @@ int Curl_HMAC_final(struct HMAC_context *ctxt, unsigned char *result)
  * hashparams [in]     - The hash function (Curl_HMAC_MD5).
  * key        [in]     - The key to use.
  * keylen     [in]     - The length of the key.
- * data       [in]     - The data to encrypt.
- * datalen    [in]     - The length of the data.
+ * buf        [in]     - The data to encrypt.
+ * buflen     [in]     - The length of the data.
  * output     [in/out] - The output buffer.
  *
  * Returns CURLE_OK on success.
  */
 CURLcode Curl_hmacit(const struct HMAC_params *hashparams,
                      const unsigned char *key, const size_t keylen,
-                     const unsigned char *data, const size_t datalen,
+                     const unsigned char *buf, const size_t buflen,
                      unsigned char *output)
 {
   struct HMAC_context *ctxt =
@@ -162,7 +156,7 @@ CURLcode Curl_hmacit(const struct HMAC_params *hashparams,
     return CURLE_OUT_OF_MEMORY;
 
   /* Update the digest with the given challenge */
-  Curl_HMAC_update(ctxt, data, curlx_uztoui(datalen));
+  Curl_HMAC_update(ctxt, buf, curlx_uztoui(buflen));
 
   /* Finalise the digest */
   Curl_HMAC_final(ctxt, output);

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -47,7 +47,7 @@
 
 #define HMAC_SHA256(k, kl, d, dl, o)           \
   do {                                         \
-    result = Curl_hmacit(Curl_HMAC_SHA256,     \
+    result = Curl_hmacit(&Curl_HMAC_SHA256,    \
                          (unsigned char *)k,   \
                          kl,                   \
                          (unsigned char *)d,   \

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -88,20 +88,20 @@
 
 typedef struct md5_ctx my_md5_ctx;
 
-static CURLcode my_md5_init(my_md5_ctx *ctx)
+static CURLcode my_md5_init(void *ctx)
 {
   md5_init(ctx);
   return CURLE_OK;
 }
 
-static void my_md5_update(my_md5_ctx *ctx,
+static void my_md5_update(void *ctx,
                           const unsigned char *input,
                           unsigned int inputLen)
 {
   md5_update(ctx, inputLen, input);
 }
 
-static void my_md5_final(unsigned char *digest, my_md5_ctx *ctx)
+static void my_md5_final(unsigned char *digest, void *ctx)
 {
   md5_digest(ctx, 16, digest);
 }
@@ -110,7 +110,7 @@ static void my_md5_final(unsigned char *digest, my_md5_ctx *ctx)
 
 typedef MD5_CTX my_md5_ctx;
 
-static CURLcode my_md5_init(my_md5_ctx *ctx)
+static CURLcode my_md5_init(void *ctx)
 {
   if(!MD5_Init(ctx))
     return CURLE_OUT_OF_MEMORY;
@@ -118,14 +118,14 @@ static CURLcode my_md5_init(my_md5_ctx *ctx)
   return CURLE_OK;
 }
 
-static void my_md5_update(my_md5_ctx *ctx,
+static void my_md5_update(void *ctx,
                           const unsigned char *input,
                           unsigned int len)
 {
   (void)MD5_Update(ctx, input, len);
 }
 
-static void my_md5_final(unsigned char *digest, my_md5_ctx *ctx)
+static void my_md5_final(unsigned char *digest, void *ctx)
 {
   (void)MD5_Final(digest, ctx);
 }
@@ -134,7 +134,7 @@ static void my_md5_final(unsigned char *digest, my_md5_ctx *ctx)
 
 typedef mbedtls_md5_context my_md5_ctx;
 
-static CURLcode my_md5_init(my_md5_ctx *ctx)
+static CURLcode my_md5_init(void *ctx)
 {
 #if (MBEDTLS_VERSION_NUMBER >= 0x03000000)
   if(mbedtls_md5_starts(ctx))
@@ -148,7 +148,7 @@ static CURLcode my_md5_init(my_md5_ctx *ctx)
   return CURLE_OK;
 }
 
-static void my_md5_update(my_md5_ctx *ctx,
+static void my_md5_update(void *ctx,
                           const unsigned char *data,
                           unsigned int length)
 {
@@ -159,7 +159,7 @@ static void my_md5_update(my_md5_ctx *ctx,
 #endif
 }
 
-static void my_md5_final(unsigned char *digest, my_md5_ctx *ctx)
+static void my_md5_final(unsigned char *digest, void *ctx)
 {
 #if !defined(HAS_MBEDTLS_RESULT_CODE_BASED_FUNCTIONS)
   (void) mbedtls_md5_finish(ctx, digest);
@@ -178,7 +178,7 @@ static void my_md5_final(unsigned char *digest, my_md5_ctx *ctx)
    reliable than defining COMMON_DIGEST_FOR_OPENSSL on older cats. */
 #  define my_md5_ctx CC_MD5_CTX
 
-static CURLcode my_md5_init(my_md5_ctx *ctx)
+static CURLcode my_md5_init(void *ctx)
 {
   if(!CC_MD5_Init(ctx))
     return CURLE_OUT_OF_MEMORY;
@@ -186,14 +186,14 @@ static CURLcode my_md5_init(my_md5_ctx *ctx)
   return CURLE_OK;
 }
 
-static void my_md5_update(my_md5_ctx *ctx,
+static void my_md5_update(void *ctx,
                           const unsigned char *input,
                           unsigned int inputLen)
 {
   CC_MD5_Update(ctx, input, inputLen);
 }
 
-static void my_md5_final(unsigned char *digest, my_md5_ctx *ctx)
+static void my_md5_final(unsigned char *digest, void *ctx)
 {
   CC_MD5_Final(digest, ctx);
 }
@@ -206,8 +206,9 @@ struct md5_ctx {
 };
 typedef struct md5_ctx my_md5_ctx;
 
-static CURLcode my_md5_init(my_md5_ctx *ctx)
+static CURLcode my_md5_init(void *in)
 {
+  my_md5_ctx *ctx = (my_md5_ctx *)in;
   if(!CryptAcquireContext(&ctx->hCryptProv, NULL, NULL, PROV_RSA_FULL,
                           CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
     return CURLE_OUT_OF_MEMORY;
@@ -221,15 +222,17 @@ static CURLcode my_md5_init(my_md5_ctx *ctx)
   return CURLE_OK;
 }
 
-static void my_md5_update(my_md5_ctx *ctx,
+static void my_md5_update(void *in,
                           const unsigned char *input,
                           unsigned int inputLen)
 {
+  my_md5_ctx *ctx = in;
   CryptHashData(ctx->hHash, (unsigned char *)input, inputLen, 0);
 }
 
-static void my_md5_final(unsigned char *digest, my_md5_ctx *ctx)
+static void my_md5_final(unsigned char *digest, void *in)
 {
+  my_md5_ctx *ctx = (my_md5_ctx *)in;
   unsigned long length = 0;
   CryptGetHashParam(ctx->hHash, HP_HASHVAL, NULL, &length, 0);
   if(length == 16)
@@ -292,10 +295,10 @@ struct md5_ctx {
 };
 typedef struct md5_ctx my_md5_ctx;
 
-static CURLcode my_md5_init(my_md5_ctx *ctx);
-static void my_md5_update(my_md5_ctx *ctx, const void *data,
-                          unsigned long size);
-static void my_md5_final(unsigned char *result, my_md5_ctx *ctx);
+static CURLcode my_md5_init(void *ctx);
+static void my_md5_update(void *ctx, const unsigned char *data,
+                          unsigned int size);
+static void my_md5_final(unsigned char *result, void *ctx);
 
 /*
  * The basic MD5 functions.
@@ -455,8 +458,9 @@ static const void *my_md5_body(my_md5_ctx *ctx,
   return ptr;
 }
 
-static CURLcode my_md5_init(my_md5_ctx *ctx)
+static CURLcode my_md5_init(void *in)
 {
+  my_md5_ctx *ctx = (my_md5_ctx *)in;
   ctx->a = 0x67452301;
   ctx->b = 0xefcdab89;
   ctx->c = 0x98badcfe;
@@ -468,11 +472,12 @@ static CURLcode my_md5_init(my_md5_ctx *ctx)
   return CURLE_OK;
 }
 
-static void my_md5_update(my_md5_ctx *ctx, const void *data,
-                          unsigned long size)
+static void my_md5_update(void *in, const unsigned char *data,
+                          unsigned int size)
 {
   MD5_u32plus saved_lo;
-  unsigned long used;
+  unsigned int used;
+  my_md5_ctx *ctx = (my_md5_ctx *)in;
 
   saved_lo = ctx->lo;
   ctx->lo = (saved_lo + size) & 0x1fffffff;
@@ -483,7 +488,7 @@ static void my_md5_update(my_md5_ctx *ctx, const void *data,
   used = saved_lo & 0x3f;
 
   if(used) {
-    unsigned long available = 64 - used;
+    unsigned int available = 64 - used;
 
     if(size < available) {
       memcpy(&ctx->buffer[used], data, size);
@@ -504,9 +509,10 @@ static void my_md5_update(my_md5_ctx *ctx, const void *data,
   memcpy(ctx->buffer, data, size);
 }
 
-static void my_md5_final(unsigned char *result, my_md5_ctx *ctx)
+static void my_md5_final(unsigned char *result, void *in)
 {
-  unsigned long used, available;
+  unsigned int used, available;
+  my_md5_ctx *ctx = (my_md5_ctx *)in;
 
   used = ctx->lo & 0x3f;
 
@@ -557,36 +563,21 @@ static void my_md5_final(unsigned char *result, my_md5_ctx *ctx)
 
 #endif /* CRYPTO LIBS */
 
-const struct HMAC_params Curl_HMAC_MD5[] = {
-  {
-    /* Hash initialization function. */
-    CURLX_FUNCTION_CAST(HMAC_hinit_func, my_md5_init),
-    /* Hash update function. */
-    CURLX_FUNCTION_CAST(HMAC_hupdate_func, my_md5_update),
-    /* Hash computation end function. */
-    CURLX_FUNCTION_CAST(HMAC_hfinal_func, my_md5_final),
-    /* Size of hash context structure. */
-    sizeof(my_md5_ctx),
-    /* Maximum key length. */
-    64,
-    /* Result size. */
-    16
-  }
+const struct HMAC_params Curl_HMAC_MD5 = {
+  my_md5_init,        /* Hash initialization function. */
+  my_md5_update,      /* Hash update function. */
+  my_md5_final,       /* Hash computation end function. */
+  sizeof(my_md5_ctx), /* Size of hash context structure. */
+  64,                 /* Maximum key length. */
+  16                  /* Result size. */
 };
 
-const struct MD5_params Curl_DIGEST_MD5[] = {
-  {
-    /* Digest initialization function */
-    CURLX_FUNCTION_CAST(Curl_MD5_init_func, my_md5_init),
-    /* Digest update function */
-    CURLX_FUNCTION_CAST(Curl_MD5_update_func, my_md5_update),
-    /* Digest computation end function */
-    CURLX_FUNCTION_CAST(Curl_MD5_final_func, my_md5_final),
-    /* Size of digest context struct */
-    sizeof(my_md5_ctx),
-    /* Result size */
-    16
-  }
+const struct MD5_params Curl_DIGEST_MD5 = {
+  my_md5_init,        /* Digest initialization function */
+  my_md5_update,      /* Digest update function */
+  my_md5_final,       /* Digest computation end function */
+  sizeof(my_md5_ctx), /* Size of digest context struct */
+  16                  /* Result size */
 };
 
 /*

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -26,6 +26,8 @@
 
 #include <curl/curl.h>
 
+struct Curl_easy;
+
 #include "mime.h"
 #include "warnless.h"
 #include "urldata.h"
@@ -1279,7 +1281,7 @@ CURLcode Curl_mime_duppart(struct Curl_easy *data,
  */
 
 /* Create a mime handle. */
-curl_mime *curl_mime_init(struct Curl_easy *easy)
+curl_mime *curl_mime_init(void *easy)
 {
   curl_mime *mime;
 

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -504,7 +504,7 @@ static CURLcode pop3_perform_apop(struct Curl_easy *data,
   }
 
   /* Create the digest */
-  ctxt = Curl_MD5_init(Curl_DIGEST_MD5);
+  ctxt = Curl_MD5_init(&Curl_DIGEST_MD5);
   if(!ctxt)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/psl.h
+++ b/lib/psl.h
@@ -27,6 +27,8 @@
 #ifdef USE_LIBPSL
 #include <libpsl.h>
 
+struct Curl_easy;
+
 #define PSL_TTL (72 * 3600)     /* PSL time to live before a refresh. */
 
 struct PslCache {

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -3213,10 +3213,11 @@ CURLcode Curl_vsetopt(struct Curl_easy *data, CURLoption option, va_list param)
  */
 
 #undef curl_easy_setopt
-CURLcode curl_easy_setopt(struct Curl_easy *data, CURLoption tag, ...)
+CURLcode curl_easy_setopt(CURL *d, CURLoption tag, ...)
 {
   va_list arg;
   CURLcode result;
+  struct Curl_easy *data = d;
 
   if(!data)
     return CURLE_BAD_FUNCTION_ARGUMENT;

--- a/lib/share.c
+++ b/lib/share.c
@@ -38,7 +38,7 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-struct Curl_share *
+CURLSH *
 curl_share_init(void)
 {
   struct Curl_share *share = calloc(1, sizeof(struct Curl_share));
@@ -53,7 +53,7 @@ curl_share_init(void)
 
 #undef curl_share_setopt
 CURLSHcode
-curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
+curl_share_setopt(CURLSH *sh, CURLSHoption option, ...)
 {
   va_list param;
   int type;
@@ -61,6 +61,7 @@ curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
   curl_unlock_function unlockfunc;
   void *ptr;
   CURLSHcode res = CURLSHE_OK;
+  struct Curl_share *share = sh;
 
   if(!GOOD_SHARE_HANDLE(share))
     return CURLSHE_INVALID;
@@ -214,8 +215,9 @@ curl_share_setopt(struct Curl_share *share, CURLSHoption option, ...)
 }
 
 CURLSHcode
-curl_share_cleanup(struct Curl_share *share)
+curl_share_cleanup(CURLSH *sh)
 {
+  struct Curl_share *share = sh;
   if(!GOOD_SHARE_HANDLE(share))
     return CURLSHE_INVALID;
 

--- a/lib/speedcheck.h
+++ b/lib/speedcheck.h
@@ -27,7 +27,7 @@
 #include "curl_setup.h"
 
 #include "timeval.h"
-
+struct Curl_easy;
 void Curl_speedinit(struct Curl_easy *data);
 CURLcode Curl_speedcheck(struct Curl_easy *data,
                          struct curltime now);

--- a/lib/vauth/cram.c
+++ b/lib/vauth/cram.c
@@ -67,7 +67,7 @@ CURLcode Curl_auth_create_cram_md5_message(const struct bufref *chlg,
   char *response;
 
   /* Compute the digest using the password as the key */
-  ctxt = Curl_HMAC_init(Curl_HMAC_MD5,
+  ctxt = Curl_HMAC_init(&Curl_HMAC_MD5,
                         (const unsigned char *) passwdp,
                         curlx_uztoui(strlen(passwdp)));
   if(!ctxt)

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -388,7 +388,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     return result;
 
   /* So far so good, now calculate A1 and H(A1) according to RFC 2831 */
-  ctxt = Curl_MD5_init(Curl_DIGEST_MD5);
+  ctxt = Curl_MD5_init(&Curl_DIGEST_MD5);
   if(!ctxt)
     return CURLE_OUT_OF_MEMORY;
 
@@ -402,7 +402,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
                   curlx_uztoui(strlen(passwdp)));
   Curl_MD5_final(ctxt, digest);
 
-  ctxt = Curl_MD5_init(Curl_DIGEST_MD5);
+  ctxt = Curl_MD5_init(&Curl_DIGEST_MD5);
   if(!ctxt)
     return CURLE_OUT_OF_MEMORY;
 
@@ -425,7 +425,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
 
   /* Calculate H(A2) */
-  ctxt = Curl_MD5_init(Curl_DIGEST_MD5);
+  ctxt = Curl_MD5_init(&Curl_DIGEST_MD5);
   if(!ctxt) {
     free(spn);
 
@@ -443,7 +443,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     msnprintf(&HA2_hex[2 * i], 3, "%02x", digest[i]);
 
   /* Now calculate the response hash */
-  ctxt = Curl_MD5_init(Curl_DIGEST_MD5);
+  ctxt = Curl_MD5_init(&Curl_DIGEST_MD5);
   if(!ctxt) {
     free(spn);
 

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -389,7 +389,7 @@ static void state(struct Curl_easy *data, sshstate nowstate)
 
 
 #ifdef HAVE_LIBSSH2_KNOWNHOST_API
-static int sshkeycallback(struct Curl_easy *easy,
+static int sshkeycallback(CURL *easy,
                           const struct curl_khkey *knownkey, /* known */
                           const struct curl_khkey *foundkey, /* found */
                           enum curl_khmatch match,

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -924,10 +924,11 @@ static ssize_t nw_in_recv(void *reader_ctx,
   return (ssize_t)nread;
 }
 
-CURL_EXTERN CURLcode curl_ws_recv(struct Curl_easy *data, void *buffer,
+CURL_EXTERN CURLcode curl_ws_recv(CURL *d, void *buffer,
                                   size_t buflen, size_t *nread,
                                   const struct curl_ws_frame **metap)
 {
+  struct Curl_easy *data = d;
   struct connectdata *conn = data->conn;
   struct websocket *ws;
   struct ws_collect ctx;
@@ -1047,11 +1048,12 @@ static CURLcode ws_flush(struct Curl_easy *data, struct websocket *ws,
   return CURLE_OK;
 }
 
-static CURLcode ws_send_raw_blocking(CURL *data, struct websocket *ws,
+static CURLcode ws_send_raw_blocking(CURL *d, struct websocket *ws,
                                      const char *buffer, size_t buflen)
 {
   CURLcode result = CURLE_OK;
   size_t nwritten;
+  struct Curl_easy *data = d;
 
   (void)ws;
   while(buflen) {
@@ -1088,7 +1090,7 @@ static CURLcode ws_send_raw_blocking(CURL *data, struct websocket *ws,
   return result;
 }
 
-static CURLcode ws_send_raw(CURL *data, const void *buffer,
+static CURLcode ws_send_raw(struct Curl_easy *data, const void *buffer,
                             size_t buflen, size_t *pnwritten)
 {
   struct websocket *ws = data->conn->proto.ws;
@@ -1124,7 +1126,7 @@ static CURLcode ws_send_raw(CURL *data, const void *buffer,
   return result;
 }
 
-CURL_EXTERN CURLcode curl_ws_send(CURL *data, const void *buffer,
+CURL_EXTERN CURLcode curl_ws_send(CURL *d, const void *buffer,
                                   size_t buflen, size_t *sent,
                                   curl_off_t fragsize,
                                   unsigned int flags)
@@ -1133,6 +1135,7 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *data, const void *buffer,
   ssize_t n;
   size_t space, payload_added;
   CURLcode result;
+  struct Curl_easy *data = d;
 
   CURL_TRC_WS(data, "curl_ws_send(len=%zu, fragsize=%" FMT_OFF_T
               ", flags=%x), raw=%d",
@@ -1289,10 +1292,11 @@ static CURLcode ws_disconnect(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-CURL_EXTERN const struct curl_ws_frame *curl_ws_meta(struct Curl_easy *data)
+CURL_EXTERN const struct curl_ws_frame *curl_ws_meta(CURL *d)
 {
   /* we only return something for websocket, called from within the callback
      when not using raw mode */
+  struct Curl_easy *data = d;
   if(GOOD_EASY_HANDLE(data) && Curl_is_in_callback(data) && data->conn &&
      data->conn->proto.ws && !data->set.ws_raw_mode)
     return &data->conn->proto.ws->frame;
@@ -1380,7 +1384,7 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *curl, const void *buffer,
   return CURLE_NOT_BUILT_IN;
 }
 
-CURL_EXTERN const struct curl_ws_frame *curl_ws_meta(struct Curl_easy *data)
+CURL_EXTERN const struct curl_ws_frame *curl_ws_meta(CURL *data)
 {
   (void)data;
   return NULL;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -98,7 +98,8 @@
 #include "tool_ipfs.h"
 #include "dynbuf.h"
 #ifdef DEBUGBUILD
-#include "easyif.h"  /* for libcurl's debug-only curl_easy_perform_ev() */
+/* libcurl's debug-only curl_easy_perform_ev() */
+CURL_EXTERN CURLcode curl_easy_perform_ev(CURL *easy);
 #endif
 
 #include "memdebug.h" /* keep this as LAST include */

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -167,7 +167,7 @@ struct handle
   CURL *h;
 };
 
-static size_t cb(void *data, size_t size, size_t nmemb, void *clientp)
+static size_t cb(char *data, size_t size, size_t nmemb, void *clientp)
 {
   size_t realsize = size * nmemb;
   struct handle *handle = (struct handle *) clientp;

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -159,10 +159,10 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb,
 }
 
 static int progress_callback(void *clientp,
-                             double dltotal,
-                             double dlnow,
-                             double ultotal,
-                             double ulnow)
+                             curl_off_t dltotal,
+                             curl_off_t dlnow,
+                             curl_off_t ultotal,
+                             curl_off_t ulnow)
 {
   (void)dltotal;
   (void)dlnow;

--- a/tests/libtest/lib1485.c
+++ b/tests/libtest/lib1485.c
@@ -35,7 +35,7 @@ struct transfer_status {
   int http_status;
 };
 
-static size_t header_callback(void *ptr, size_t size, size_t nmemb,
+static size_t header_callback(char *ptr, size_t size, size_t nmemb,
                               void *userp)
 {
   struct transfer_status *st = (struct transfer_status *)userp;
@@ -77,7 +77,7 @@ static size_t header_callback(void *ptr, size_t size, size_t nmemb,
   return len;
 }
 
-static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct transfer_status *st = (struct transfer_status *)userp;
   size_t len = size * nmemb;

--- a/tests/libtest/lib1509.c
+++ b/tests/libtest/lib1509.c
@@ -27,8 +27,8 @@
 #include "warnless.h"
 #include "memdebug.h"
 
-size_t WriteOutput(void *ptr, size_t size, size_t nmemb, void *stream);
-size_t WriteHeader(void *ptr, size_t size, size_t nmemb, void *stream);
+size_t WriteOutput(char *ptr, size_t size, size_t nmemb, void *stream);
+size_t WriteHeader(char *ptr, size_t size, size_t nmemb, void *stream);
 
 static unsigned long realHeaderSize = 0;
 
@@ -82,13 +82,13 @@ test_cleanup:
   return res;
 }
 
-size_t WriteOutput(void *ptr, size_t size, size_t nmemb, void *stream)
+size_t WriteOutput(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   fwrite(ptr, size, nmemb, stream);
   return nmemb * size;
 }
 
-size_t WriteHeader(void *ptr, size_t size, size_t nmemb, void *stream)
+size_t WriteHeader(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   (void)ptr;
   (void)stream;

--- a/tests/libtest/lib1540.c
+++ b/tests/libtest/lib1540.c
@@ -57,7 +57,7 @@ static int please_continue(void *userp,
   return 0; /* go on */
 }
 
-static size_t header_callback(void *ptr, size_t size, size_t nmemb,
+static size_t header_callback(char *ptr, size_t size, size_t nmemb,
                               void *userp)
 {
   size_t len = size * nmemb;
@@ -66,7 +66,7 @@ static size_t header_callback(void *ptr, size_t size, size_t nmemb,
   return len;
 }
 
-static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct transfer_status *st = (struct transfer_status *)userp;
   size_t len = size * nmemb;

--- a/tests/libtest/lib1541.c
+++ b/tests/libtest/lib1541.c
@@ -77,7 +77,7 @@ static void check_time0(CURL *easy, int key, const char *name,
     report_time(name, where, tval, !tval);
 }
 
-static size_t header_callback(void *ptr, size_t size, size_t nmemb,
+static size_t header_callback(char *ptr, size_t size, size_t nmemb,
                               void *userp)
 {
   struct transfer_status *st = (struct transfer_status *)userp;
@@ -100,7 +100,7 @@ static size_t header_callback(void *ptr, size_t size, size_t nmemb,
   return len;
 }
 
-static size_t write_callback(void *ptr, size_t size, size_t nmemb, void *userp)
+static size_t write_callback(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   struct transfer_status *st = (struct transfer_status *)userp;
 

--- a/tests/libtest/lib1556.c
+++ b/tests/libtest/lib1556.c
@@ -31,7 +31,7 @@ struct headerinfo {
   size_t largest;
 };
 
-static size_t header(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t header(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t headersize = size * nmemb;
   struct headerinfo *info = (struct headerinfo *)stream;

--- a/tests/libtest/lib2308.c
+++ b/tests/libtest/lib2308.c
@@ -27,7 +27,7 @@
 
 #include <curl/curl.h>
 
-static size_t cb_curl(void *buffer, size_t size, size_t nmemb, void *userp)
+static size_t cb_curl(char *buffer, size_t size, size_t nmemb, void *userp)
 {
   (void)buffer;
   (void)size;

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -46,29 +46,30 @@ struct Ctx {
   struct curl_slist *contents;
 };
 
-static size_t write_memory_callback(void *contents, size_t size,
-  size_t nmemb, void *userp) {
-    /* append the data to contents */
-    size_t realsize = size * nmemb;
-    struct Ctx *mem = (struct Ctx *)userp;
-    char *data = (char *)malloc(realsize + 1);
-    struct curl_slist *item_append = NULL;
-    if(!data) {
-      printf("not enough memory (malloc returned NULL)\n");
-      return 0;
-    }
-    memcpy(data, contents, realsize);
-    data[realsize] = '\0';
-    item_append = curl_slist_append(mem->contents, data);
-    free(data);
-    if(item_append) {
-      mem->contents = item_append;
-    }
-    else {
-      printf("not enough memory (curl_slist_append returned NULL)\n");
-      return 0;
-    }
-    return realsize;
+static size_t write_memory_callback(char *contents, size_t size,
+                                    size_t nmemb, void *userp)
+{
+  /* append the data to contents */
+  size_t realsize = size * nmemb;
+  struct Ctx *mem = (struct Ctx *)userp;
+  char *data = (char *)malloc(realsize + 1);
+  struct curl_slist *item_append = NULL;
+  if(!data) {
+    printf("not enough memory (malloc returned NULL)\n");
+    return 0;
+  }
+  memcpy(data, contents, realsize);
+  data[realsize] = '\0';
+  item_append = curl_slist_append(mem->contents, data);
+  free(data);
+  if(item_append) {
+    mem->contents = item_append;
+  }
+  else {
+    printf("not enough memory (curl_slist_append returned NULL)\n");
+    return 0;
+  }
+  return realsize;
 }
 
 static

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -141,7 +141,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 }
 
 
-static size_t write_callback(void *ptr, size_t size, size_t nmemb,
+static size_t write_callback(char *ptr, size_t size, size_t nmemb,
                              void *stream)
 {
   int amount = curlx_uztosi(size * nmemb);

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -52,7 +52,7 @@ static const char *RTP_DATA = "$_1234\n\0Rsdf";
 
 static int rtp_packet_count = 0;
 
-static size_t rtp_write(void *ptr, size_t size, size_t nmemb, void *stream)
+static size_t rtp_write(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   char *data = (char *)ptr;
   int channel = RTP_PKT_CHANNEL(data);

--- a/tests/libtest/lib576.c
+++ b/tests/libtest/lib576.c
@@ -32,8 +32,9 @@ struct chunk_data {
 };
 
 static
-long chunk_bgn(const struct curl_fileinfo *finfo, void *ptr, int remains)
+long chunk_bgn(const void *f, void *ptr, int remains)
 {
+  const struct curl_fileinfo *finfo = f;
   struct chunk_data *ch_d = ptr;
   ch_d->remains = remains;
 

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -85,10 +85,8 @@ void libtest_debug_dump(const char *timebuf, const char *text, FILE *stream,
 }
 
 int libtest_debug_cb(CURL *handle, curl_infotype type,
-                     unsigned char *data, size_t size,
-                     void *userp)
+                     char *data, size_t size, void *userp)
 {
-
   struct libtest_trace_cfg *trace_cfg = userp;
   const char *text;
   struct timeval tv;
@@ -140,6 +138,7 @@ int libtest_debug_cb(CURL *handle, curl_infotype type,
     return 0;
   }
 
-  libtest_debug_dump(timebuf, text, stderr, data, size, trace_cfg->nohex);
+  libtest_debug_dump(timebuf, text, stderr, (unsigned char *)data, size,
+                     trace_cfg->nohex);
   return 0;
 }

--- a/tests/libtest/testtrace.h
+++ b/tests/libtest/testtrace.h
@@ -32,7 +32,6 @@ struct libtest_trace_cfg {
 extern struct libtest_trace_cfg libtest_debug_config;
 
 int libtest_debug_cb(CURL *handle, curl_infotype type,
-                     unsigned char *data, size_t size,
-                     void *userp);
+                     char *data, size_t size, void *userp);
 
 #endif /* HEADER_LIBTEST_TESTTRACE_H */

--- a/tests/unit/unit1612.c
+++ b/tests/unit/unit1612.c
@@ -47,7 +47,7 @@ UNITTEST_START
   unsigned char output[HMAC_MD5_LENGTH];
   unsigned char *testp = output;
 
-  Curl_hmacit(Curl_HMAC_MD5,
+  Curl_hmacit(&Curl_HMAC_MD5,
               (const unsigned char *) password, strlen(password),
               (const unsigned char *) string1, strlen(string1),
               output);
@@ -56,7 +56,7 @@ UNITTEST_START
                 "\xd1\x29\x75\x43\x58\xdc\xab\x78\xdf\xcd\x7f\x2b\x29\x31\x13"
                 "\x37", HMAC_MD5_LENGTH);
 
-  Curl_hmacit(Curl_HMAC_MD5,
+  Curl_hmacit(&Curl_HMAC_MD5,
               (const unsigned char *) password, strlen(password),
               (const unsigned char *) string2, strlen(string2),
               output);


### PR DESCRIPTION
Use plain typecasts instead to make it more obvious what the code does.

The UndefinedBehaviorSanitizer (ubsan) now errors if a callback pointer is used to a call a function with ever so slight difference in signature. This is annoying because it means that we can no longer use our long established practice of using a different typedef for several handles when building the library vs when using it. We used to have a plain struct pointer for libcurl builds and a `void *` for that name when the header is used for applications.