### PR TITLE
GHA: silence proselint warnings and an error

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,4 +26,4 @@ Send your suggestions using one of these methods:
 
  3. as an [issue](https://github.com/curl/curl/issues)
 
-/ The curl team!
+/ The curl team

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -62,7 +62,7 @@ jobs:
         run: git ls-files -z '*.md' | xargs -0 -n1 .github/scripts/trimmarkdownheader.pl
 
       - name: check prose
-        run: git ls-files -z '*.md' | grep -Evz 'CHECKSRC.md|DISTROS.md|CURLOPT_INTERFACE.md|interface.md' | xargs -0 proselint README
+        run: git ls-files -z '*.md' | grep -Evz 'CHECKSRC.md|DISTROS.md|curl_mprintf.md|CURLOPT_INTERFACE.md|interface.md' | xargs -0 proselint README
 
       # This is for CHECKSRC and files with aggressive exclamation mark needs
       - name: create second proselint config
@@ -73,13 +73,14 @@ jobs:
               "typography.diacritical_marks": false,
               "typography.symbols": false,
               "typography.exclamation": false,
+              "lexical_illusions.misc": false,
               "annotations.misc": false
             }
           }
           JSON
 
       - name: check special prose
-        run: proselint docs/CHECKSRC.md docs/libcurl/opts/CURLOPT_INTERFACE.md docs/cmdline-opts/interface.md
+        run: proselint docs/CHECKSRC.md docs/libcurl/curl_mprintf.md docs/libcurl/opts/CURLOPT_INTERFACE.md docs/cmdline-opts/interface.md
 
   # Docs: https://github.com/marketplace/actions/markdown-link-check
   linkcheck:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -80,7 +80,12 @@ jobs:
           JSON
 
       - name: check special prose
-        run: proselint docs/CHECKSRC.md docs/libcurl/curl_mprintf.md docs/libcurl/opts/CURLOPT_INTERFACE.md docs/cmdline-opts/interface.md
+        run: >-
+          proselint
+            docs/internals/CHECKSRC.md
+            docs/libcurl/curl_mprintf.md
+            docs/libcurl/opts/CURLOPT_INTERFACE.md
+            docs/cmdline-opts/interface.md
 
   # Docs: https://github.com/marketplace/actions/markdown-link-check
   linkcheck:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -47,7 +47,7 @@ jobs:
       # config file help: https://github.com/amperser/proselint/
       - name: create proselint config
         run: |
-          cat <<JSON > $HOME/.proselintrc
+          cat <<JSON > $HOME/.proselintrc.json
           {
             "checks": {
               "typography.diacritical_marks": false,
@@ -67,7 +67,7 @@ jobs:
       # This is for CHECKSRC and files with aggressive exclamation mark needs
       - name: create second proselint config
         run: |
-          cat <<JSON > $HOME/.proselintrc
+          cat <<JSON > $HOME/.proselintrc.json
           {
             "checks": {
               "typography.diacritical_marks": false,

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -80,12 +80,7 @@ jobs:
           JSON
 
       - name: check special prose
-        run: >-
-          proselint
-            docs/internals/CHECKSRC.md
-            docs/libcurl/curl_mprintf.md
-            docs/libcurl/opts/CURLOPT_INTERFACE.md
-            docs/cmdline-opts/interface.md
+        run: proselint docs/internals/CHECKSRC.md docs/libcurl/curl_mprintf.md docs/libcurl/opts/CURLOPT_INTERFACE.md docs/cmdline-opts/interface.md
 
   # Docs: https://github.com/marketplace/actions/markdown-link-check
   linkcheck:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ distribution terms.
 
 ## Backers
 
-Thank you to all our backers! 🙏 [Become a backer](https://opencollective.com/curl#section-contribute).
+Thank you to all our backers 🙏 [Become a backer](https://opencollective.com/curl#section-contribute).
 
 ## Sponsors
 

--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -59,7 +59,7 @@ TLS_AES_128_CCM_8_SHA256
 In addition to above list the following cipher suites can be used:
 `TLS_SM4_GCM_SM3` `TLS_SM4_CCM_SM3` `TLS_SHA256_SHA256` `TLS_SHA384_SHA384`.
 Usage of these cipher suites is not recommended. (The last two cipher suites
-are NULL ciphers!)
+are NULL ciphers, offering no encryption whatsoever.)
 
 ### Schannel notes
 

--- a/docs/ECH.md
+++ b/docs/ECH.md
@@ -330,7 +330,7 @@ Then:
     autoreconf -fi
     LDFLAGS="-Wl,-rpath,$HOME/code/boringssl/inst/lib" ./configure --with-ssl=$HOME/code/boringssl/inst --enable-ech --enable-httpsrr
     ...lots of output...
-    WARNING: ECH HTTPSRR enabled but marked EXPERIMENTAL. Use with caution!
+    WARNING: ECH HTTPSRR enabled but marked EXPERIMENTAL. Use with caution.
     make
 ```
 

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -245,9 +245,9 @@ You can build curl with cmake:
      % cd ..
      % git clone https://github.com/curl/curl
      % cd curl
-     % cmake . -B build -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-     % cmake --build build
-     % cmake --install build
+     % cmake . -B bld -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
+     % cmake --build bld
+     % cmake --install bld
 
  If `make install` results in `Permission denied` error, you need to prepend
  it with `sudo`.
@@ -404,7 +404,7 @@ Get, build and install nghttp2:
      % git clone https://github.com/nghttp2/nghttp2.git
      % cd nghttp2
      % autoreconf -fi
-     % PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/home/daniel/build-quictls/lib/pkgconfig:/home/daniel/build-nghttp3/lib/pkgconfig:/home/daniel/build-ngtcp2/lib/pkgconfig  LDFLAGS=-L/home/daniel/build-quictls/lib CFLAGS=-I/home/daniel/build-quictls/include ./configure --enable-maintainer-mode --prefix=/home/daniel/build-nghttp2 --disable-shared --enable-app --enable-http3 --without-jemalloc --without-libxml2 --without-systemd
+     % PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/home/daniel/build-quictls/lib/pkgconfig:/home/daniel/build-nghttp3/lib/pkgconfig:/home/daniel/build-ngtcp2/lib/pkgconfig LDFLAGS=-L/home/daniel/build-quictls/lib CFLAGS=-I/home/daniel/build-quictls/include ./configure --enable-maintainer-mode --prefix=/home/daniel/build-nghttp2 --disable-shared --enable-app --enable-http3 --without-jemalloc --without-libxml2 --without-systemd
      % make && make install
 
 Run the local h3 server on port 9443, make it proxy all traffic through to

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -570,7 +570,7 @@ that are not automatically detected:
 
 This is a probably incomplete list of known CPU architectures and operating
 systems that curl has been compiled for. If you know a system curl compiles
-and runs on, that is not listed, please let us know!
+and runs on, that is not listed, please let us know.
 
 ## 101 Operating Systems
 

--- a/docs/MAIL-ETIQUETTE.md
+++ b/docs/MAIL-ETIQUETTE.md
@@ -232,7 +232,7 @@ We allow subscribers to subscribe to the "digest" version of the mailing
 lists. A digest is a collection of mails lumped together in one single mail.
 
 Should you decide to reply to a mail sent out as a digest, there are two
-things you MUST consider if you really really cannot subscribe normally
+things you MUST consider if you really, really cannot subscribe normally
 instead:
 
 Cut off all mails and chatter that is not related to the mail you want to

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -274,7 +274,7 @@ To get even more details and information on what curl does, try using the
 `--trace` or `--trace-ascii` options with a given filename to log to, like
 this:
 
-    curl --trace trace-output.txt www.haxx.se
+    curl --trace my-trace.txt www.haxx.se
 
 
 ## Detailed Information

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -274,7 +274,7 @@ To get even more details and information on what curl does, try using the
 `--trace` or `--trace-ascii` options with a given filename to log to, like
 this:
 
-    curl --trace trace.txt www.haxx.se
+    curl --trace trace-output.txt www.haxx.se
 
 
 ## Detailed Information

--- a/docs/SPONSORS.md
+++ b/docs/SPONSORS.md
@@ -44,4 +44,4 @@ gambling, pornography, social media manipulation etc.
 ## Past Sponsors
 
 Sponsors that stop paying are considered *Past Sponsors* and are not displayed
-on the sponsor page anymore. We thank you for your contributions!
+on the sponsor page anymore. We thank you for your contributions.

--- a/docs/SSL-PROBLEMS.md
+++ b/docs/SSL-PROBLEMS.md
@@ -44,7 +44,7 @@ SPDX-License-Identifier: curl
   when connecting to make the connection succeed.
 
   An additional complication can be that modern SSL libraries sometimes are
-  built with support for older SSL and TLS versions disabled!
+  built with support for older SSL and TLS versions disabled.
 
   All versions of SSL and the TLS versions before 1.2 are considered insecure
   and should be avoided. Use TLS 1.2 or later.

--- a/docs/TheArtOfHttpScripting.md
+++ b/docs/TheArtOfHttpScripting.md
@@ -571,7 +571,7 @@ SPDX-License-Identifier: curl
 
  Curl supports encrypted fetches when built to use a TLS library and it can be
  built to use one out of a fairly large set of libraries - `curl -V` shows
- which one your curl was built to use (if any!). To get a page from an HTTPS
+ which one your curl was built to use (if any). To get a page from an HTTPS
  server, simply run curl like:
 
     curl https://secure.example.com

--- a/docs/URL-SYNTAX.md
+++ b/docs/URL-SYNTAX.md
@@ -32,7 +32,7 @@ unlikely that multiple parsers treat URLs the same way.
 
 Due to the inherent differences between URL parser implementations, it is
 considered a security risk to mix different implementations and assume the
-same behavior!
+same behavior.
 
 For example, if you use one parser to check if a URL uses a good hostname or
 the correct auth field, and then pass on that same URL to a *second* parser,

--- a/docs/cmdline-opts/_EXITCODES.md
+++ b/docs/cmdline-opts/_EXITCODES.md
@@ -105,7 +105,7 @@ Too many redirects. When following redirects, curl hit the maximum amount.
 ## 48
 Unknown option specified to libcurl. This indicates that you passed a weird
 option to curl that was passed on to libcurl and rejected. Read up in the
-manual!
+manual.
 ## 49
 Malformed telnet option.
 ## 52

--- a/docs/cmdline-opts/_OPTIONS.md
+++ b/docs/cmdline-opts/_OPTIONS.md
@@ -1,6 +1,7 @@
 <!-- Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al. -->
 <!-- SPDX-License-Identifier: curl -->
 # OPTIONS
+
 Options start with one or two dashes. Many of the options require an
 additional value next to them. If provided text does not start with a dash, it
 is presumed to be and treated as a URL.

--- a/docs/cmdline-opts/data-urlencode.md
+++ b/docs/cmdline-opts/data-urlencode.md
@@ -30,7 +30,7 @@ curl using one of the following syntaxes:
 ## content
 URL-encode the content and pass that on. Just be careful so that the content
 does not contain any `=` or `@` symbols, as that makes the syntax match one of
-the other cases below!
+the other cases below.
 
 ## =content
 URL-encode the content and pass that on. The preceding `=` symbol is not

--- a/docs/cmdline-opts/head.md
+++ b/docs/cmdline-opts/head.md
@@ -18,6 +18,6 @@ Example:
 
 # `--head`
 
-Fetch the headers only! HTTP-servers feature the command HEAD which this uses
+Fetch the headers only. HTTP-servers feature the command HEAD which this uses
 to get nothing but the header of a document. When used on an FTP or FILE URL,
 curl displays the file size and last modification time only.

--- a/docs/cmdline-opts/head.md
+++ b/docs/cmdline-opts/head.md
@@ -19,5 +19,5 @@ Example:
 # `--head`
 
 Fetch the headers only! HTTP-servers feature the command HEAD which this uses
-to get nothing but the header of a document. When used on an FTP or FILE file,
+to get nothing but the header of a document. When used on an FTP or FILE URL,
 curl displays the file size and last modification time only.

--- a/docs/cmdline-opts/libcurl.md
+++ b/docs/cmdline-opts/libcurl.md
@@ -18,4 +18,4 @@ Example:
 
 Append this option to any ordinary curl command line, and you get
 libcurl-using C source code written to the file that does the equivalent of
-what your command-line operation does!
+what your command-line operation does.

--- a/docs/cmdline-opts/range.md
+++ b/docs/cmdline-opts/range.md
@@ -42,7 +42,7 @@ specifies two separate 100-byte ranges(*) (HTTP)
 ##
 
 (*) = NOTE that these make the server reply with a multipart response, which
-is returned as-is by curl! Parsing or otherwise transforming this response is
+is returned as-is by curl. Parsing or otherwise transforming this response is
 the responsibility of the caller.
 
 Only digit characters (0-9) are valid in the 'start' and 'stop' fields of the

--- a/docs/cmdline-opts/url.md
+++ b/docs/cmdline-opts/url.md
@@ -29,4 +29,4 @@ To control where this URL is written, use the --output or the --remote-name
 options.
 
 **WARNING**: On Windows, particular `file://` accesses can be converted to
-network accesses by the operating system. Beware!
+network accesses by the operating system. Beware.

--- a/docs/cmdline-opts/version.md
+++ b/docs/cmdline-opts/version.md
@@ -44,7 +44,7 @@ curl was built with support for character set conversions (like EBCDIC)
 
 ## `Debug`
 This curl uses a libcurl built with Debug. This enables more error-tracking
-and memory debugging etc. For curl-developers only!
+and memory debugging etc. For curl-developers only.
 
 ## `ECH`
 ECH support is present.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -21,12 +21,12 @@ first.
 
 Most examples should build fine using a command line like this:
 
-    `curl-config --cc --cflags --libs` -o example example.c
+    `curl-config --cc --cflags --libs` -o my-example example.c
 
 Some compilers do not like having the arguments in this order but instead
 want you do reorganize them like:
 
-    `curl-config --cc` -o example example.c `curl-config --cflags --libs`
+    `curl-config --cc` -o my-example example.c `curl-config --cflags --libs`
 
 **Please** do not use the `curl.se` site as a test target for your libcurl
 applications/experiments. Even if some of the examples use that site as a URL

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -21,12 +21,12 @@ first.
 
 Most examples should build fine using a command line like this:
 
-    `curl-config --cc --cflags --libs` -o my-example example.c
+    `curl-config --cc --cflags --libs` -o example-my example.c
 
 Some compilers do not like having the arguments in this order but instead
 want you do reorganize them like:
 
-    `curl-config --cc` -o my-example example.c `curl-config --cflags --libs`
+    `curl-config --cc` -o example-my example.c `curl-config --cflags --libs`
 
 **Please** do not use the `curl.se` site as a test target for your libcurl
 applications/experiments. Even if some of the examples use that site as a URL

--- a/docs/internals/HYPER.md
+++ b/docs/internals/HYPER.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: curl
 Hyper is a separate HTTP library written in Rust. curl can be told to use this
 library as a backend to deal with HTTP.
 
-## Experimental!
+## EXPERIMENTAL
 
 Hyper support in curl is considered **EXPERIMENTAL** until further notice. It
 needs to be explicitly enabled at build-time.

--- a/docs/internals/NEW-PROTOCOL.md
+++ b/docs/internals/NEW-PROTOCOL.md
@@ -101,7 +101,7 @@ peculiarities of the protocol. It needs documentation.
 
 Maybe it even needs some internal documentation so that the developers who try
 to debug something five years from now can figure out functionality a little
-easier!
+easier.
 
 The protocol specification itself should be freely available without requiring
 a non-disclosure agreement or similar.

--- a/docs/libcurl/curl_easy_getinfo.md
+++ b/docs/libcurl/curl_easy_getinfo.md
@@ -351,7 +351,7 @@ In microseconds. See CURLINFO_STARTTRANSFER_TIME_T(3)
 ## CURLINFO_TLS_SESSION
 
 (**Deprecated**) TLS session info that can be used for further processing. See
-CURLINFO_TLS_SESSION(3). Use CURLINFO_TLS_SSL_PTR(3) instead!
+CURLINFO_TLS_SESSION(3). Use CURLINFO_TLS_SSL_PTR(3) instead.
 
 ## CURLINFO_TLS_SSL_PTR
 

--- a/docs/libcurl/curl_easy_setopt.md
+++ b/docs/libcurl/curl_easy_setopt.md
@@ -37,7 +37,7 @@ appropriate options, the application can change libcurl's behavior. All
 options are set with an *option* followed by a *parameter*. That parameter can
 be a **long**, a **function pointer**, an **object pointer** or a
 **curl_off_t**, depending on what the specific option expects. Read this
-manual carefully as bad input values may cause libcurl to behave badly! You
+manual carefully as bad input values may cause libcurl to behave badly. You
 can only set one option in each function call. A typical application uses many
 curl_easy_setopt(3) calls in the setup phase.
 

--- a/docs/libcurl/curl_easy_unescape.md
+++ b/docs/libcurl/curl_easy_unescape.md
@@ -59,7 +59,7 @@ int main(void)
     int decodelen;
     char *decoded = curl_easy_unescape(curl, "%63%75%72%6c", 12, &decodelen);
     if(decoded) {
-      /* do not assume printf() works on the decoded data! */
+      /* do not assume printf() works on the decoded data */
       printf("Decoded: ");
       /* ... */
       curl_free(decoded);

--- a/docs/libcurl/curl_escape.md
+++ b/docs/libcurl/curl_escape.md
@@ -26,7 +26,7 @@ char *curl_escape(const char *string, int length);
 
 # DESCRIPTION
 
-Obsolete function. Use curl_easy_escape(3) instead!
+Obsolete function. Use curl_easy_escape(3) instead.
 
 This function converts the given input **string** to a URL encoded string
 and return that as a new allocated string. All input characters that are not

--- a/docs/libcurl/curl_formadd.md
+++ b/docs/libcurl/curl_formadd.md
@@ -105,7 +105,7 @@ you must make sure strlen() on the data pointer returns zero.
 
 ## CURLFORM_CONTENTSLENGTH
 
-(This option is deprecated. Use *CURLFORM_CONTENTLEN* instead!)
+(This option is deprecated. Use *CURLFORM_CONTENTLEN* instead.)
 
 followed by a long giving the length of the contents. Note that for
 *CURLFORM_STREAM* contents, this option is mandatory.

--- a/docs/libcurl/curl_formfree.md
+++ b/docs/libcurl/curl_formfree.md
@@ -27,7 +27,7 @@ void curl_formfree(struct curl_httppost *form);
 
 # DESCRIPTION
 
-This function is deprecated. Do not use. See curl_mime_init(3) instead!
+This function is deprecated. Do not use. See curl_mime_init(3) instead.
 
 curl_formfree() is used to clean up data previously built/appended with
 curl_formadd(3). This must be called when the data has been used, which

--- a/docs/libcurl/curl_formget.md
+++ b/docs/libcurl/curl_formget.md
@@ -44,7 +44,7 @@ return the buffer length passed to it on success.
 
 If the **CURLFORM_STREAM** option is used in the formpost, it prevents
 curl_formget(3) from working until you have performed the actual HTTP request.
-This, because first then does libcurl known which actual read callback to use!
+This, because first then does libcurl known which actual read callback to use.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/curl_free.md
+++ b/docs/libcurl/curl_free.md
@@ -42,7 +42,7 @@ int main(void)
 {
   char *width = curl_getenv("COLUMNS");
   if(width) {
-    /* it was set! */
+    /* it was set */
     curl_free(width);
   }
 }

--- a/docs/libcurl/curl_getenv.md
+++ b/docs/libcurl/curl_getenv.md
@@ -40,7 +40,7 @@ int main(void)
 {
   char *width = curl_getenv("COLUMNS");
   if(width) {
-    /* it was set! */
+    /* it was set */
     curl_free(width);
   }
 }

--- a/docs/libcurl/curl_global_init_mem.md
+++ b/docs/libcurl/curl_global_init_mem.md
@@ -69,7 +69,7 @@ to that man page for documentation.
 # CAUTION
 
 Manipulating these gives considerable powers to the application to severely
-screw things up for libcurl. Take care!
+screw things up for libcurl. Take care.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/curl_mprintf.md
+++ b/docs/libcurl/curl_mprintf.md
@@ -183,9 +183,9 @@ pointer to a long argument
 
 ## ll
 
-(ell-ell). A following integer conversion corresponds to a `long long` or
-`unsigned long long` argument, or a following n conversion corresponds to
-a pointer to a `long long` argument.
+(ell-ell). A following integer conversion corresponds to a *long long* or
+*unsigned long long* argument, or a following n conversion corresponds to
+a pointer to a *long long* argument.
 
 ## q
 

--- a/docs/libcurl/curl_mprintf.md
+++ b/docs/libcurl/curl_mprintf.md
@@ -183,9 +183,9 @@ pointer to a long argument
 
 ## ll
 
-(ell-ell). A following integer conversion corresponds to a *long long* or
-*unsigned long long* argument, or a following n conversion corresponds to
-a pointer to a long long argument.
+(ell-ell). A following integer conversion corresponds to a `long long` or
+`unsigned long long` argument, or a following n conversion corresponds to
+a pointer to a `long long` argument.
 
 ## q
 

--- a/docs/libcurl/curl_multi_perform.md
+++ b/docs/libcurl/curl_multi_perform.md
@@ -85,7 +85,7 @@ int main(void)
         break;
       }
 
-    /* if there are still transfers, loop! */
+    /* if there are still transfers, loop */
     } while(still_running);
   }
 }

--- a/docs/libcurl/curl_multi_socket.md
+++ b/docs/libcurl/curl_multi_socket.md
@@ -76,7 +76,7 @@ int main(void)
 
 # DEPRECATED
 
-curl_multi_socket(3) is deprecated, use curl_multi_socket_action(3) instead!
+curl_multi_socket(3) is deprecated, use curl_multi_socket_action(3) instead.
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/curl_url_cleanup.md
+++ b/docs/libcurl/curl_url_cleanup.md
@@ -29,7 +29,7 @@ void curl_url_cleanup(CURLU *handle);
 
 # DESCRIPTION
 
-Frees all the resources associated with the given *CURLU* handle!
+Frees all the resources associated with the given *CURLU* handle.
 
 Passing in a NULL pointer in *handle* makes this function return
 immediately with no action.

--- a/docs/libcurl/curl_url_dup.md
+++ b/docs/libcurl/curl_url_dup.md
@@ -45,7 +45,7 @@ int main(void)
   CURLU *url2;
   rc = curl_url_set(url, CURLUPART_URL, "https://example.com", 0);
   if(!rc) {
-    url2 = curl_url_dup(url); /* clone it! */
+    url2 = curl_url_dup(url); /* clone it */
     curl_url_cleanup(url2);
   }
   curl_url_cleanup(url);

--- a/docs/libcurl/curl_version.md
+++ b/docs/libcurl/curl_version.md
@@ -28,7 +28,7 @@ char *curl_version();
 Returns a human readable string with the version number of libcurl and some of
 its important components (like OpenSSL version).
 
-We recommend using curl_version_info(3) instead!
+We recommend using curl_version_info(3) instead.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/libcurl-errors.md
+++ b/docs/libcurl/libcurl-errors.md
@@ -525,7 +525,7 @@ You are doomed.
 
 ## CURLM_INTERNAL_ERROR (4)
 
-This can only be returned if libcurl bugs. Please report it to us!
+This can only be returned if libcurl bugs. Please report it to us.
 
 ## CURLM_BAD_SOCKET (5)
 

--- a/docs/libcurl/libcurl-errors.md
+++ b/docs/libcurl/libcurl-errors.md
@@ -60,7 +60,7 @@ The URL was not properly formatted.
 
 ## CURLE_NOT_BUILT_IN (4)
 
-A requested feature, protocol or option was not found built-in in this libcurl
+A requested feature, protocol or option was not found built into this libcurl
 due to a build-time decision. This means that a feature or option was not
 enabled or explicitly disabled when libcurl was built and in order to get it
 to function you have to get a rebuilt libcurl.

--- a/docs/libcurl/libcurl-security.md
+++ b/docs/libcurl/libcurl-security.md
@@ -460,7 +460,7 @@ created.
 libcurl itself uses *fork()* and *execl()* if told to use the
 **CURLAUTH_NTLM_WB** authentication method which then invokes the helper
 command in a child process with file descriptors duplicated. Make sure that
-only the trusted and reliable helper program is invoked!
+only the trusted and reliable helper program is invoked.
 
 This feature was removed from curl in 8.8.0.
 

--- a/docs/libcurl/libcurl-share.md
+++ b/docs/libcurl/libcurl-share.md
@@ -36,7 +36,7 @@ The share interface was added to enable sharing of data between curl handles.
 
 You can have multiple easy handles share data between them. Have them update
 and use the **same** cookie database, DNS cache, TLS session cache and/or
-connection cache! This way, each single transfer takes advantage from data
+connection cache. This way, each single transfer takes advantage from data
 updates made by the other transfer(s).
 
 # SHARE OBJECT

--- a/docs/libcurl/libcurl-url.md
+++ b/docs/libcurl/libcurl-url.md
@@ -104,7 +104,7 @@ Extracted parts are not URL decoded unless the user also asks for it with the
 *CURLU_URLDECODE* flag set in the fourth bitmask argument.
 
 Remember to free the returned string with curl_free(3) when you are done
-with it!
+with it.
 
 # SET PARTS
 

--- a/docs/libcurl/libcurl.md
+++ b/docs/libcurl/libcurl.md
@@ -119,7 +119,7 @@ a lowercase c). You can find other functions in the library source code, but
 other prefixes indicate that the functions are private and may change without
 further notice in the next release.
 
-Only use documented functions and functionality!
+Only use documented functions and functionality.
 
 # PORTABILITY
 

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
@@ -51,7 +51,7 @@ int main(void)
   CURL *curl = curl_easy_init();
   if(curl) {
     CURLcode res;
-    long sockfd; /* does not work on win64! */
+    long sockfd; /* does not work on win64 */
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* Do not do the transfer - only connect to host */

--- a/docs/libcurl/opts/CURLINFO_PROTOCOL.md
+++ b/docs/libcurl/opts/CURLINFO_PROTOCOL.md
@@ -29,7 +29,7 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_PROTOCOL, long *p);
 
 This option is deprecated. We strongly recommend using
 CURLINFO_SCHEME(3) instead, because this option cannot return all
-possible protocols!
+possible protocols.
 
 Pass a pointer to a long to receive the version used in the last http
 connection. The returned value is set to one of the CURLPROTO_* values:

--- a/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.md
@@ -31,7 +31,7 @@ CURLcode curl_easy_getinfo(CURL *handle, CURLINFO_RTSP_SERVER_CSEQ,
 Pass a pointer to a long to receive the next CSeq that is expected to be used
 by the application.
 
-Listening for server initiated requests is not implemented!
+Listening for server initiated requests is not implemented.
 
 Applications wishing to resume an RTSP session on another connection should
 retrieve this info before closing the active connection.

--- a/docs/libcurl/opts/CURLOPT_CHUNK_BGN_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_BGN_FUNCTION.md
@@ -24,7 +24,7 @@ CURLOPT_CHUNK_BGN_FUNCTION - callback before a transfer with FTP wildcard match
 struct curl_fileinfo {
   char *filename;
   curlfiletype filetype;
-  time_t time;   /* always zero! */
+  time_t time;   /* always zero */
   unsigned int perm;
   int uid;
   int gid;

--- a/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
@@ -69,7 +69,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);
     ret = curl_easy_perform(curl);
     if(ret == CURLE_OK) {
-      /* only connected! */
+      /* only connected */
     }
   }
 }

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
@@ -73,7 +73,7 @@ int main(void)
 
     res = curl_easy_perform(curl);
 
-    /* close the handle, write the cookies! */
+    /* close the handle, write the cookies */
     curl_easy_cleanup(curl);
   }
 }

--- a/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.md
@@ -27,7 +27,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_DNS_USE_GLOBAL_CACHE,
 
 # DESCRIPTION
 
-Has no function since 7.62.0. Do not use!
+Has no function since 7.62.0. Do not use.
 
 Pass a long. If the *enable* value is 1, it tells curl to use a global DNS
 cache that survives between easy handle creations and deletions. This is not

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
@@ -51,7 +51,7 @@ for consistency with the other *VERIFYHOST* options we suggest use 2 and
 not 1.
 
 When the *verify* value is set to 0L, the connection succeeds regardless of
-the names used in the certificate. Use that ability with caution!
+the names used in the certificate. Use that ability with caution.
 
 See also CURLOPT_DOH_SSL_VERIFYPEER(3) to verify the digital signature
 of the DoH server certificate.

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
@@ -50,7 +50,7 @@ retry the CWD command again if the subsequent **MKD** command fails. This is
 especially useful if you are doing many simultaneous connections against the
 same server and they all have this option enabled, as then CWD may first fail
 but then another connection does **MKD** before this connection and thus
-**MKD** fails but trying CWD works!
+**MKD** fails but trying CWD works.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.md
@@ -48,7 +48,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL,
                      "ftp://example.com/old-server/file.txt");
 
-    /* a drftpd server, do it! */
+    /* a drftpd server, do it */
     curl_easy_setopt(curl, CURLOPT_FTP_USE_PRET, 1L);
 
     res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_HEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HEADER.md
@@ -48,7 +48,7 @@ It is often better to use CURLOPT_HEADERFUNCTION(3) to get the header
 data separately.
 
 While named confusingly similar, CURLOPT_HTTPHEADER(3) is used to set
-custom HTTP headers!
+custom HTTP headers.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
@@ -45,7 +45,7 @@ header data. The header callback is called once for each header and only
 complete header lines are passed on to the callback. Parsing headers is easy
 to do using this callback. *buffer* points to the delivered data, and the size
 of that data is *nitems*; *size* is always 1. The provided header line is not
-null-terminated! Do not modify the passed in buffer.
+null-terminated. Do not modify the passed in buffer.
 
 The pointer named *userdata* is the one you set with the CURLOPT_HEADERDATA(3)
 option.

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -64,7 +64,7 @@ int main(void)
 
     /* HTTPS over a proxy makes a separate CONNECT to the proxy, so tell
        libcurl to not send the custom headers to the proxy. Keep them
-       separate! */
+       separate. */
     curl_easy_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
     ret = curl_easy_perform(curl);
     curl_slist_free_all(list);

--- a/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.md
@@ -30,7 +30,7 @@ Pass the long argument *allowed* set to 1L to allow HTTP/0.9 responses.
 
 An HTTP/0.9 response is a server response entirely without headers and only a
 body. You can connect to lots of random TCP services and still get a response
-that curl might consider to be HTTP/0.9!
+that curl might consider to be HTTP/0.9.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
@@ -35,7 +35,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_HTTPHEADER,
 
 Pass a pointer to a linked list of HTTP headers to pass to the server and/or
 proxy in your HTTP request. The same list can be used for both host and proxy
-requests!
+requests.
 
 When used within an IMAP or SMTP request to upload a MIME mail, the given
 header list establishes the document-level MIME headers to prepend to the

--- a/docs/libcurl/opts/CURLOPT_IOCTLFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_IOCTLFUNCTION.md
@@ -57,7 +57,7 @@ The *clientp* argument to the callback is set with the
 CURLOPT_IOCTLDATA(3) option.
 
 **This option is deprecated**. Do not use it. Use CURLOPT_SEEKFUNCTION(3)
-instead to provide seeking! If CURLOPT_SEEKFUNCTION(3) is set, this
+instead to provide seeking. If CURLOPT_SEEKFUNCTION(3) is set, this
 parameter is ignored when seeking.
 
 # DEFAULT

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.md
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.md
@@ -54,7 +54,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 30L);
     res = curl_easy_perform(curl);
     if(CURLE_OPERATION_TIMEDOUT == res) {
-      printf("Timeout!\n");
+      printf("Timeout.\n");
     }
     /* always cleanup */
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.md
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.md
@@ -51,7 +51,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_LOW_SPEED_LIMIT, 30L);
     res = curl_easy_perform(curl);
     if(CURLE_OPERATION_TIMEDOUT == res) {
-      printf("Timeout!\n");
+      printf("Timeout.\n");
     }
     /* always cleanup */
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
@@ -56,7 +56,7 @@ int main(void)
   if(curl) {
     CURLcode ret;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
-    /* refuse to download if larger than 1000 bytes! */
+    /* refuse to download if larger than 1000 bytes */
     curl_easy_setopt(curl, CURLOPT_MAXFILESIZE, 1000L);
     ret = curl_easy_perform(curl);
   }

--- a/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.md
@@ -58,7 +58,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     /* cap the upload speed to 1000 bytes/sec */
     curl_easy_setopt(curl, CURLOPT_MAX_SEND_SPEED_LARGE, (curl_off_t)1000);
-    /* (set some upload options as well!) */
+    /* (set some upload options as well) */
     ret = curl_easy_perform(curl);
   }
 }

--- a/docs/libcurl/opts/CURLOPT_MIMEPOST.md
+++ b/docs/libcurl/opts/CURLOPT_MIMEPOST.md
@@ -68,7 +68,7 @@ int main(void)
       /* Set the form info */
       curl_easy_setopt(curl, CURLOPT_MIMEPOST, multipart);
 
-      curl_easy_perform(curl); /* post away! */
+      curl_easy_perform(curl); /* post away */
       curl_mime_free(multipart); /* free the post data */
     }
   }

--- a/docs/libcurl/opts/CURLOPT_NOBODY.md
+++ b/docs/libcurl/opts/CURLOPT_NOBODY.md
@@ -61,7 +61,7 @@ int main(void)
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
-    /* get us the resource without a body - use HEAD! */
+    /* get us the resource without a body - use HEAD */
     curl_easy_setopt(curl, CURLOPT_NOBODY, 1L);
 
     /* Perform the request */

--- a/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
+++ b/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
@@ -16,7 +16,7 @@ Added-in: 7.42.0
 
 # NAME
 
-CURLOPT_PATH_AS_IS - do not handle dot dot sequences
+CURLOPT_PATH_AS_IS - do not handle dot-dot sequences
 
 # SYNOPSIS
 
@@ -35,7 +35,7 @@ This instructs libcurl to NOT squash sequences of "/../" or "/./" that may
 exist in the URL's path part and that is supposed to be removed according to
 RFC 3986 section 5.2.4.
 
-Some server implementations are known to (erroneously) require the dot dot
+Some server implementations are known to (erroneously) require the dot-dot
 sequences to remain in the path and some clients want to pass these on in
 order to try out server implementations.
 

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
@@ -29,7 +29,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_PROTOCOLS, long bitmask);
 
 This option is deprecated. We strongly recommend using
 CURLOPT_PROTOCOLS_STR(3) instead because this option cannot control all
-available protocols!
+available protocols.
 
 Pass a long that holds a bitmask of CURLPROTO_* defines. If used, this bitmask
 limits what protocols libcurl may use in the transfer. This allows you to have

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
@@ -56,7 +56,7 @@ an error and leaving the flag untouched.
 From 7.66.0: treats 1 and 2 the same.
 
 When the *verify* value is 0L, the connection succeeds regardless of the
-names used in the certificate. Use that ability with caution!
+names used in the certificate. Use that ability with caution.
 
 See also CURLOPT_PROXY_SSL_VERIFYPEER(3) to verify the digital signature
 of the proxy certificate.

--- a/docs/libcurl/opts/CURLOPT_READFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_READFUNCTION.md
@@ -86,7 +86,7 @@ size_t read_callback(char *ptr, size_t size, size_t nmemb, void *userdata)
   curl_off_t nread;
 
   /* copy as much data as possible into the 'ptr' buffer, but no more than
-     'size' * 'nmemb' bytes! */
+     'size' * 'nmemb' bytes. */
   size_t retcode = fread(ptr, size, nmemb, readhere);
 
   nread = (curl_off_t)retcode;

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
@@ -30,7 +30,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_REDIR_PROTOCOLS, long bitmask);
 
 This option is deprecated. We strongly recommend using
 CURLOPT_REDIR_PROTOCOLS_STR(3) instead because this option cannot
-control all available protocols!
+control all available protocols.
 
 Pass a long that holds a bitmask of CURLPROTO_* defines. If used, this bitmask
 limits what protocols libcurl may use in a transfer that it follows to in a

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
@@ -123,7 +123,7 @@ int main(void)
   if(curl) {
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "rtsp://example.com/");
-    /* ask for options! */
+    /* ask for options */
     curl_easy_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_OPTIONS);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.md
@@ -60,7 +60,7 @@ done by instead reading from the input or similar.
 
 If you forward the input arguments directly to fseek(3) or lseek(3), note that
 the data type for *offset* is not the same as defined for curl_off_t on
-many systems!
+many systems.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.md
@@ -34,7 +34,7 @@ enum curl_khstat {
 
 enum curl_khmatch {
   CURLKHMATCH_OK,       /* match */
-  CURLKHMATCH_MISMATCH, /* host found, key mismatch! */
+  CURLKHMATCH_MISMATCH, /* host found, key mismatch */
   CURLKHMATCH_MISSING,  /* no matching host/key found */
 };
 

--- a/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
@@ -52,7 +52,7 @@ int main(void)
   if(curl) {
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
-    /* switch off session-id use! */
+    /* switch off session-id use */
     curl_easy_setopt(curl, CURLOPT_SSL_SESSIONID_CACHE, 0L);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.md
@@ -53,7 +53,7 @@ int main(void)
   if(curl) {
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
-    /* ask for OCSP stapling! */
+    /* ask for OCSP stapling */
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYSTATUS, 1L);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.md
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.md
@@ -64,7 +64,7 @@ int main(void)
     curl_easy_setopt(curl2, CURLOPT_URL, "https://example.com/two");
     curl_easy_setopt(curl2, CURLOPT_STREAM_DEPENDS, curl);
 
-    /* then add both to a multi handle and transfer them! */
+    /* then add both to a multi handle and transfer them */
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.md
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.md
@@ -67,7 +67,7 @@ int main(void)
     curl_easy_setopt(curl2, CURLOPT_URL, "https://example.com/two");
     curl_easy_setopt(curl2, CURLOPT_STREAM_DEPENDS_E, curl);
 
-    /* then add both to a multi handle and transfer them! */
+    /* then add both to a multi handle and transfer them */
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.md
+++ b/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.md
@@ -67,7 +67,7 @@ int main(void)
     curl_easy_setopt(curl2, CURLOPT_URL, "https://example.com/two");
     curl_easy_setopt(curl2, CURLOPT_STREAM_WEIGHT, 20L);
 
-    /* then add both to a multi handle and transfer them! */
+    /* then add both to a multi handle and transfer them */
   }
 }
 ~~~

--- a/docs/libcurl/opts/CURLOPT_UPLOAD.md
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD.md
@@ -83,7 +83,7 @@ int main(void)
     /* Set the size of the file to upload */
     curl_easy_setopt(curl, CURLOPT_INFILESIZE_LARGE, (curl_off_t)fsize);
 
-    /* Now run off and do what you have been told! */
+    /* Now run off and do what you have been told */
     curl_easy_perform(curl);
   }
 }

--- a/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_WRITEFUNCTION.md
@@ -95,7 +95,7 @@ static size_t cb(char *data, size_t size, size_t nmemb, void *clientp)
 
   char *ptr = realloc(mem->response, mem->size + realsize + 1);
   if(!ptr)
-    return 0;  /* out of memory! */
+    return 0;  /* out of memory */
 
   mem->response = ptr;
   memcpy(&(mem->response[mem->size]), data, realsize);

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -545,7 +545,7 @@ If there is no test number found above, the HTTP test server uses the number
 following the last dot in the given hostname (made so that a CONNECT can still
 pass on test number) so that "foo.bar.123" gets treated as test case
 123. Alternatively, if an IPv6 address is provided to CONNECT, the last
-hexadecimal group in the address is used as the test number! For example the
+hexadecimal group in the address is used as the test number. For example the
 address "[1234::ff]" would be treated as test case 255.
 
 Set `type="perl"` to write the test case as a perl script. It implies that

--- a/tests/http/README.md
+++ b/tests/http/README.md
@@ -85,7 +85,7 @@ There is a lot of [`pytest` documentation](https://docs.pytest.org/) with exampl
 
 In `conftest.py` 3 "fixtures" are defined that are used by all test cases:
 
-1. `env`: the test environment. It is an instance of class `testenv/env.py:Env`. It holds all information about paths, availability of features (HTTP/3!), port numbers to use, domains and SSL certificates for those.
+1. `env`: the test environment. It is an instance of class `testenv/env.py:Env`. It holds all information about paths, availability of features (HTTP/3), port numbers to use, domains and SSL certificates for those.
 2. `httpd`: the Apache httpd instance, configured and started, then stopped at the end of the test suite. It has sites configured for the domains from `env`. It also loads a local module `mod_curltest?` and makes it available in certain locations. (more on mod_curltest below).
 3. `nghttpx`: an instance of nghttpx that provides HTTP/3 support. `nghttpx` proxies those requests to the `httpd` server. In a direct mapping, so you may access all the resources under the same path as with HTTP/2. Only the port number used for HTTP/3 requests will be different.
 


### PR DESCRIPTION
Fix new issues found by `proselint`.

Also:
- silence this technical warning:
  ```
  :0: DeprecationWarning: /home/runner/.proselintrc was found instead of a JSON file. Rename to /home/runner/.proselintrc.json.
  ```
- fix an input filename.
  `proselints` fails now if an input file is missing.

Reported-by: Jay Satiro
Bug: https://github.com/curl/curl/pull/15291#issuecomment-2410505100
