### PR TITLE
GHA/windows: mark tests 1632, 2042 flaky for vcpkg jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -800,6 +800,8 @@ jobs:
         timeout-minutes: 10
         run: |
           export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
+          TFLAGS+=' ~1632'  # flaky
+          TFLAGS+=' ~2042'  # flaky
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SFTP'
           elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then


### PR DESCRIPTION
```
curl returned 35, when expecting 90
[...]
curl : (35) SSL_connect failed with error -308: error state on socket
[...]
FAIL 2042: 'HTTPS wrong base64-sha256 pinnedpubkey but right CN' HTTPS, HTTP GET, PEM certificate
```
https://github.com/curl/curl/actions/runs/11329312660/job/31504598717?pr=15293#step:13:3813 (wolfssl)

```
FAIL 1632: 'FTP through HTTPS-proxy, with connection reuse' FTP, HTTPS-proxy
```
https://github.com/curl/curl/actions/runs/11290725487/job/31403189512#step:14:3513 (libressl) https://github.com/curl/curl/actions/runs/11295457751/job/31418226057#check-step-13 (openssl) https://github.com/curl/curl/actions/runs/11295496471/job/31418357192#step:13:5477 (mbedtls) https://github.com/curl/curl/actions/runs/11317797587/job/31471654291#step:13:6583 (openssl)