### PR TITLE
vquic: fix compiler warning with gcc + MUSL

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -328,13 +328,13 @@ static size_t msghdr_get_udp_gro(struct msghdr *msg)
   struct cmsghdr *cmsg;
 
   /* Workaround musl CMSG_NXTHDR issue */
-#ifndef __GLIBC__
+#if defined(__clang__) && !defined(__GLIBC__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsign-compare"
 #pragma clang diagnostic ignored "-Wcast-align"
 #endif
   for(cmsg = CMSG_FIRSTHDR(msg); cmsg; cmsg = CMSG_NXTHDR(msg, cmsg)) {
-#ifndef __GLIBC__
+#if defined(__clang__) && !defined(__GLIBC__)
 #pragma clang diagnostic pop
 #endif
     if(cmsg->cmsg_level == SOL_UDP && cmsg->cmsg_type == UDP_GRO) {


### PR DESCRIPTION
```
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/vquic/vquic.c: In function 'msghdr_get_udp_gro':
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/vquic/vquic.c:344: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
  344 | #pragma clang diagnostic push
      |
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/vquic/vquic.c:345: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
  345 | #pragma clang diagnostic ignored "-Wsign-compare"
      |
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/vquic/vquic.c:346: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
  346 | #pragma clang diagnostic ignored "-Wcast-align"
      |
/Users/runner/work/curl-for-win/curl-for-win/curl/lib/vquic/vquic.c:350: warning: ignoring #pragma clang diagnostic [-Wunknown-pragmas]
  350 | #pragma clang diagnostic pop
      |
```
https://github.com/curl/curl-for-win/actions/runs/11356281008/job/31587180874#step:3:9534

Follow-up to a571afc02e11c1ab9a9f59c2150e11acca423fcc #14012