### PR TITLE
KNOWN_BUGS: LDFLAGS passed too late

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -36,6 +36,7 @@ problems may have been fixed or changed somewhat since this was written.
  5. Build and portability issues
  5.1 OS400 port requires deprecated IBM library
  5.2 curl-config --libs contains private details
+ 5.3 LDFLAGS passed too late making libs linked incorrectly
  5.6 Cygwin: make install installs curl-config.1 twice
  5.11 configure --with-gssapi with Heimdal is ignored on macOS
  5.12 flaky CI builds
@@ -224,6 +225,14 @@ problems may have been fixed or changed somewhat since this was written.
  "curl-config --libs" include details set in LDFLAGS when configure is run
  that might be needed only for building libcurl. Further, curl-config --cflags
  suffers from the same effects with CFLAGS/CPPFLAGS.
+
+5.3 LDFLAGS passed too late making libs linked incorrectly
+
+ Compiling latest curl on HP-UX and linking against a custom OpenSSL (which is
+ on the default loader/linker path), fails because the generated Makefile has
+ LDFLAGS passed on after LIBS.
+
+ See https://github.com/curl/curl/issues/14893
 
 5.6 Cygwin: make install installs curl-config.1 twice
 


### PR DESCRIPTION
Makes linking fail on some (ancient) platforms.

Closes #14893