### PR TITLE
src: guard for double declaration of `curl_ca_embed` in unity builds

### DIFF
--- a/src/mk-file-embed.pl
+++ b/src/mk-file-embed.pl
@@ -29,7 +29,7 @@ if($ARGV[0] eq "--var") {
     $varname = shift @ARGV;
 }
 
-my $varname_upper = uc($varnam);
+my $varname_upper = uc($varname);
 
 print <<HEAD
 /*

--- a/src/mk-file-embed.pl
+++ b/src/mk-file-embed.pl
@@ -29,11 +29,16 @@ if($ARGV[0] eq "--var") {
     $varname = shift @ARGV;
 }
 
+my $varname_upper = uc($varnam);
+
 print <<HEAD
 /*
  * NEVER EVER edit this manually, fix the mk-file-embed.pl script instead!
  */
+#ifndef CURL_DECLARED_${varname_upper}
+#define CURL_DECLARED_${varname_upper}
 extern const unsigned char ${varname}[];
+#endif
 const unsigned char ${varname}[] = {
 HEAD
     ;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -105,7 +105,10 @@ CURL_EXTERN CURLcode curl_easy_perform_ev(CURL *easy);
 #include "memdebug.h" /* keep this as LAST include */
 
 #ifdef CURL_CA_EMBED
+#ifndef CURL_DECLARED_CURL_CA_EMBED
+#define CURL_DECLARED_CURL_CA_EMBED
 extern const unsigned char curl_ca_embed[];
+#endif
 #endif
 
 #ifndef O_BINARY


### PR DESCRIPTION
Seen with curl-for-win linux-musl-from-mac build with gcc 9.2.0.

```
n file included from /Users/runner/work/curl-for-win/curl-for-win/curl/_x64-linux-musl-bld/src/CMakeFiles/curl.dir/Unity/unity_0_c.c:136:
/Users/runner/work/curl-for-win/curl-for-win/curl/_x64-linux-musl-bld/src/tool_ca_embed.c:4:28: warning: redundant redeclaration of 'curl_ca_embed' [-Wredundant-decls]
    4 | extern const unsigned char curl_ca_embed[];
      |                            ^~~~~~~~~~~~~
In file included from /Users/runner/work/curl-for-win/curl-for-win/curl/_x64-linux-musl-bld/src/CMakeFiles/curl.dir/Unity/unity_0_c.c:88:
/Users/runner/work/curl-for-win/curl-for-win/curl/src/tool_operate.c:107:28: note: previous declaration of 'curl_ca_embed' was here
  107 | extern const unsigned char curl_ca_embed[];
      |                            ^~~~~~~~~~~~~
```
https://github.com/curl/curl-for-win/actions/runs/11192203640/job/31116070669#step:3:4894

Follow-up to 8a3740bc8e558b9a9d4a652b74cf27a0961d7010 #14059
