### PR TITLE
winbuild/README: consolidate command prompt section

### DIFF
--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -46,24 +46,19 @@ SPDX-License-Identifier: curl
 
 Open a Visual Studio Command prompt:
 
- Using the **'Developer Command Prompt for VS [version]'** menu entry: where
- [version} is the Visual Studio version. The developer prompt at default uses
- the x86 mode. It is required to call `Vcvarsall.bat` to setup the prompt for
- the machine type you want. This type of command prompt may not exist in all
- Visual Studio versions.
-
- See also: [Developer Command Prompt for Visual
- Studio](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs)
- and [How to: Enable a 64-Bit, x64 hosted MSVC toolset on the command
- line](https://docs.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line)
-
  Using the **'VS [version] [platform] [type] Command Prompt'** menu entry:
  where [version] is the Visual Studio version, [platform] is e.g. x64 and
- [type] Native of Cross platform build. This type of command prompt may not
+ [type] Native or Cross platform build. This type of command prompt may not
  exist in all Visual Studio versions. For example, to build a 64-bit curl open
  the x64 Native Tools prompt.
 
- See also: [Set the Path and Environment Variables for Command-Line Builds](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line)
+ See also:
+
+ [How to: Enable a 64-Bit, x64 hosted MSVC toolset on the command line](https://docs.microsoft.com/en-us/cpp/build/how-to-enable-a-64-bit-visual-cpp-toolset-on-the-command-line)
+
+ [Set the Path and Environment Variables for Command-Line Builds](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line)
+
+ [Developer Command Prompt for Visual Studio](https://docs.microsoft.com/en-us/dotnet/framework/tools/developer-command-prompt-for-vs)
 
 ## Build in the console
 


### PR DESCRIPTION
- Remove reference to 'Developer Command Prompt for Visual Studio' shortcut since it opens in x86 mode.

That prompt may confuse users since it is not easily switched to x64. Our instruction says vcvarsall can be used to change the platform but it is not in the path in any version that I checked (VS 2010, 2013, 2022) and if it is invoked manually it appends to the path.

Instead users will now only see the remaining instruction to use a platform specific command prompt to build curl, like "x64 Native Tools".

There's several links as well to Microsoft documentation for users that have more complicated requirements, such as using vcvarsall.

Closes #xxxx

/cc @kdekker