### PR TITLE
GHA: switch off proselint

### DIFF
--- a/.github/scripts/badwords.txt
+++ b/.github/scripts/badwords.txt
@@ -65,3 +65,4 @@ couldn't:could not
 64 bit\b=64-bit
 64-bits:64 bits or 64-bit
 32-bits:32 bits or 32-bit
+\bvery\b:rephrase using an alternative word

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -33,55 +33,55 @@ concurrency:
 permissions: {}
 
 jobs:
-#  proselint:
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
-#        name: checkout
-#
-#      - name: install prereqs
-#        run: |
-#          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-#          sudo apt-get install python3-proselint
-#
-#      # config file help: https://github.com/amperser/proselint/
-#      - name: create proselint config
-#        run: |
-#          cat <<JSON > $HOME/.proselintrc.json
-#          {
-#            "checks": {
-#              "typography.diacritical_marks": false,
-#              "typography.symbols": false,
-#              "annotations.misc": false,
-#              "security.password": false,
-#              "misc.annotations": false
-#            }
-#          }
-#          JSON
-#
-#      - name: trim headers off all *.md files
-#        run: git ls-files -z '*.md' | xargs -0 -n1 .github/scripts/trimmarkdownheader.pl
-#
-#      - name: check prose
-#        run: git ls-files -z '*.md' | grep -Evz 'CHECKSRC.md|DISTROS.md|curl_mprintf.md|CURLOPT_INTERFACE.md|interface.md' | xargs -0 proselint README
-#
-#      # This is for CHECKSRC and files with aggressive exclamation mark needs
-#      - name: create second proselint config
-#        run: |
-#          cat <<JSON > $HOME/.proselintrc.json
-#          {
-#            "checks": {
-#              "typography.diacritical_marks": false,
-#              "typography.symbols": false,
-#              "typography.exclamation": false,
-#              "lexical_illusions.misc": false,
-#              "annotations.misc": false
-#            }
-#          }
-#          JSON
-#
-#      - name: check special prose
-#        run: proselint docs/internals/CHECKSRC.md docs/libcurl/curl_mprintf.md docs/libcurl/opts/CURLOPT_INTERFACE.md docs/cmdline-opts/interface.md
+  #  proselint:
+  #    runs-on: ubuntu-latest
+  #    steps:
+  #      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+  #        name: checkout
+  #
+  #      - name: install prereqs
+  #        run: |
+  #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+  #          sudo apt-get install python3-proselint
+  #
+  #      # config file help: https://github.com/amperser/proselint/
+  #      - name: create proselint config
+  #        run: |
+  #          cat <<JSON > $HOME/.proselintrc.json
+  #          {
+  #            "checks": {
+  #              "typography.diacritical_marks": false,
+  #              "typography.symbols": false,
+  #              "annotations.misc": false,
+  #              "security.password": false,
+  #              "misc.annotations": false
+  #            }
+  #          }
+  #          JSON
+  #
+  #      - name: trim headers off all *.md files
+  #        run: git ls-files -z '*.md' | xargs -0 -n1 .github/scripts/trimmarkdownheader.pl
+  #
+  #      - name: check prose
+  #        run: git ls-files -z '*.md' | grep -Evz 'CHECKSRC.md|DISTROS.md|curl_mprintf.md|CURLOPT_INTERFACE.md|interface.md' | xargs -0 proselint README
+  #
+  #      # This is for CHECKSRC and files with aggressive exclamation mark needs
+  #      - name: create second proselint config
+  #        run: |
+  #          cat <<JSON > $HOME/.proselintrc.json
+  #          {
+  #            "checks": {
+  #              "typography.diacritical_marks": false,
+  #              "typography.symbols": false,
+  #              "typography.exclamation": false,
+  #              "lexical_illusions.misc": false,
+  #              "annotations.misc": false
+  #            }
+  #          }
+  #          JSON
+  #
+  #      - name: check special prose
+  #        run: proselint docs/internals/CHECKSRC.md docs/libcurl/curl_mprintf.md docs/libcurl/opts/CURLOPT_INTERFACE.md docs/cmdline-opts/interface.md
 
   # Docs: https://github.com/marketplace/actions/markdown-link-check
   linkcheck:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -33,59 +33,55 @@ concurrency:
 permissions: {}
 
 jobs:
-  proselint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
-        name: checkout
-
-      - name: install prereqs
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get install python3-proselint
-
-      # config file help: https://github.com/amperser/proselint/
-      - name: create proselint config
-        run: |
-          cat <<JSON > $HOME/.proselintrc.json
-          {
-            "checks": {
-              "typography.symbols.multiplication_symbol": false,
-              "typography.symbols.copyright": false,
-              "typography.symbols.ellipsis": false,
-              "typography.symbols.curly_quotes": false,
-              "typography.diacritical_marks": false,
-              "typography.symbols": false,
-              "annotations.misc": false,
-              "security.password": false,
-              "misc.annotations": false
-            }
-          }
-          JSON
-
-      - name: trim headers off all *.md files
-        run: git ls-files -z '*.md' | xargs -0 -n1 .github/scripts/trimmarkdownheader.pl
-
-      - name: check prose
-        run: git ls-files -z '*.md' | grep -Evz 'CHECKSRC.md|DISTROS.md|curl_mprintf.md|CURLOPT_INTERFACE.md|interface.md' | xargs -0 proselint README
-
-      # This is for CHECKSRC and files with aggressive exclamation mark needs
-      - name: create second proselint config
-        run: |
-          cat <<JSON > $HOME/.proselintrc.json
-          {
-            "checks": {
-              "typography.diacritical_marks": false,
-              "typography.symbols": false,
-              "typography.exclamation": false,
-              "lexical_illusions.misc": false,
-              "annotations.misc": false
-            }
-          }
-          JSON
-
-      - name: check special prose
-        run: proselint docs/internals/CHECKSRC.md docs/libcurl/curl_mprintf.md docs/libcurl/opts/CURLOPT_INTERFACE.md docs/cmdline-opts/interface.md
+#  proselint:
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+#        name: checkout
+#
+#      - name: install prereqs
+#        run: |
+#          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+#          sudo apt-get install python3-proselint
+#
+#      # config file help: https://github.com/amperser/proselint/
+#      - name: create proselint config
+#        run: |
+#          cat <<JSON > $HOME/.proselintrc.json
+#          {
+#            "checks": {
+#              "typography.diacritical_marks": false,
+#              "typography.symbols": false,
+#              "annotations.misc": false,
+#              "security.password": false,
+#              "misc.annotations": false
+#            }
+#          }
+#          JSON
+#
+#      - name: trim headers off all *.md files
+#        run: git ls-files -z '*.md' | xargs -0 -n1 .github/scripts/trimmarkdownheader.pl
+#
+#      - name: check prose
+#        run: git ls-files -z '*.md' | grep -Evz 'CHECKSRC.md|DISTROS.md|curl_mprintf.md|CURLOPT_INTERFACE.md|interface.md' | xargs -0 proselint README
+#
+#      # This is for CHECKSRC and files with aggressive exclamation mark needs
+#      - name: create second proselint config
+#        run: |
+#          cat <<JSON > $HOME/.proselintrc.json
+#          {
+#            "checks": {
+#              "typography.diacritical_marks": false,
+#              "typography.symbols": false,
+#              "typography.exclamation": false,
+#              "lexical_illusions.misc": false,
+#              "annotations.misc": false
+#            }
+#          }
+#          JSON
+#
+#      - name: check special prose
+#        run: proselint docs/internals/CHECKSRC.md docs/libcurl/curl_mprintf.md docs/libcurl/opts/CURLOPT_INTERFACE.md docs/cmdline-opts/interface.md
 
   # Docs: https://github.com/marketplace/actions/markdown-link-check
   linkcheck:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -50,10 +50,15 @@ jobs:
           cat <<JSON > $HOME/.proselintrc.json
           {
             "checks": {
+              "typography.symbols.multiplication_symbol": false,
+              "typography.symbols.copyright": false,
+              "typography.symbols.ellipsis": false,
+              "typography.symbols.curly_quotes": false,
               "typography.diacritical_marks": false,
               "typography.symbols": false,
               "annotations.misc": false,
-              "security.password": false
+              "security.password": false,
+              "misc.annotations": false
             }
           }
           JSON

--- a/docs/DISTROS.md
+++ b/docs/DISTROS.md
@@ -144,7 +144,7 @@ Issues and patches for this are managed in the main curl project.
 - curl: https://formulae.brew.sh/formula/curl
 
 Homebrew's policy is that all patches and issues should be submitted upstream
-unless it is very specific to Homebrew's way of packaging software.
+unless it is specific to Homebrew's way of packaging software.
 
 ## MacPorts
 

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -249,12 +249,12 @@ typedef int (*curl_xferinfo_callback)(void *clientp,
 #endif
 
 #ifndef CURL_MAX_WRITE_SIZE
-  /* Tests have proven that 20K is a very bad buffer size for uploads on
-     Windows, while 16K for some odd reason performed a lot better.
-     We do the ifndef check to allow this value to easier be changed at build
-     time for those who feel adventurous. The practical minimum is about
-     400 bytes since libcurl uses a buffer of this size as a scratch area
-     (unrelated to network send operations). */
+  /* Tests have proven that 20K is a bad buffer size for uploads on Windows,
+     while 16K for some odd reason performed a lot better. We do the ifndef
+     check to allow this value to easier be changed at build time for those
+     who feel adventurous. The practical minimum is about 400 bytes since
+     libcurl uses a buffer of this size as a scratch area (unrelated to
+     network send operations). */
 #define CURL_MAX_WRITE_SIZE 16384
 #endif
 

--- a/include/curl/multi.h
+++ b/include/curl/multi.h
@@ -244,13 +244,13 @@ CURL_EXTERN CURLMcode curl_multi_cleanup(CURLM *multi_handle);
  *          The data the returned pointer points to will not survive calling
  *          curl_multi_cleanup().
  *
- *          The 'CURLMsg' struct is meant to be very simple and only contain
- *          very basic information. If more involved information is wanted,
- *          we will provide the particular "transfer handle" in that struct
- *          and that should/could/would be used in subsequent
- *          curl_easy_getinfo() calls (or similar). The point being that we
- *          must never expose complex structs to applications, as then we will
- *          undoubtably get backwards compatibility problems in the future.
+ *          The 'CURLMsg' struct is meant to be simple and only contain basic
+ *          information. If more involved information is wanted, we will
+ *          provide the particular "transfer handle" in that struct and that
+ *          should/could/would be used in subsequent curl_easy_getinfo() calls
+ *          (or similar). The point being that we must never expose complex
+ *          structs to applications, as then we will undoubtably get backwards
+ *          compatibility problems in the future.
  *
  * Returns: A pointer to a filled-in struct, or NULL if it failed or ran out
  *          of structs. It also writes the number of messages left in the

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1310,7 +1310,7 @@ static CURLcode cf_tcp_connect(struct Curl_cfilter *cf,
   if(blocking)
     return CURLE_UNSUPPORTED_PROTOCOL;
 
-  *done = FALSE; /* a very negative world view is best */
+  *done = FALSE; /* a negative world view is best */
   if(ctx->sock == CURL_SOCKET_BAD) {
     int error;
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -619,7 +619,7 @@ static CURLcode is_connected(struct Curl_cfilter *cf,
    * If transport is QUIC, we need to shutdown the ongoing 'other'
    * cot ballers in a QUIC appropriate way. */
 evaluate:
-  *connected = FALSE; /* a very negative world view is best */
+  *connected = FALSE; /* a negative world view is best */
   now = Curl_now();
   ongoing = not_started = 0;
   for(i = 0; i < ARRAYSIZE(ctx->baller); i++) {

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -302,10 +302,10 @@ static void close_secondarysocket(struct Curl_easy *data)
  * requests on files respond with headers passed to the client/stdout that
  * looked like HTTP ones.
  *
- * This approach is not very elegant, it causes confusion and is error-prone.
- * It is subject for removal at the next (or at least a future) soname bump.
- * Until then you can test the effects of the removal by undefining the
- * following define named CURL_FTP_HTTPSTYLE_HEAD.
+ * This approach is not elegant, it causes confusion and is error-prone. It is
+ * subject for removal at the next (or at least a future) soname bump. Until
+ * then you can test the effects of the removal by undefining the following
+ * define named CURL_FTP_HTTPSTYLE_HEAD.
  */
 #define CURL_FTP_HTTPSTYLE_HEAD 1
 
@@ -2454,10 +2454,10 @@ static CURLcode ftp_state_get_resp(struct Curl_easy *data,
        !data->set.ignorecl &&
        (ftp->downloadsize < 1)) {
       /*
-       * It seems directory listings either do not show the size or very
-       * often uses size 0 anyway. ASCII transfers may very well turn out
-       * that the transferred amount of data is not the same as this line
-       * tells, why using this number in those cases only confuses us.
+       * It seems directory listings either do not show the size or often uses
+       * size 0 anyway. ASCII transfers may cause that the transferred amount
+       * of data is not the same as this line tells, why using this number in
+       * those cases only confuses us.
        *
        * Example D above makes this parsing a little tricky */
       char *bytes;

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -49,9 +49,9 @@ struct memdebug {
 };
 
 /*
- * Note that these debug functions are very simple and they are meant to
- * remain so. For advanced analysis, record a log file and write perl scripts
- * to analyze them!
+ * Note that these debug functions are simple and they are meant to remain so.
+ * For advanced analysis, record a log file and write perl scripts to analyze
+ * them!
  *
  * Do not use these with multithreaded test programs!
  */

--- a/lib/splay.c
+++ b/lib/splay.c
@@ -113,9 +113,9 @@ struct Curl_tree *Curl_splayinsert(struct curltime i,
     t = Curl_splay(i, t);
     DEBUGASSERT(t);
     if(compare(i, t->key) == 0) {
-      /* There already exists a node in the tree with the very same key. Build
-         a doubly-linked circular list of nodes. We add the new 'node' struct
-         to the end of this list. */
+      /* There already exists a node in the tree with the same key. Build a
+         doubly-linked circular list of nodes. We add the new 'node' struct to
+         the end of this list. */
 
       node->key = KEY_NOTUSED; /* we set the key in the sub node to NOTUSED
                                   to quickly identify this node as a subnode */
@@ -199,7 +199,7 @@ struct Curl_tree *Curl_splaygetbest(struct curltime i,
 }
 
 
-/* Deletes the very node we point out from the tree if it is there. Stores a
+/* Deletes the node we point out from the tree if it is there. Stores a
  * pointer to the new resulting tree in 'newroot'.
  *
  * Returns zero on success and non-zero on errors!

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -348,9 +348,9 @@ curl_easy_strerror(CURLcode error)
    * By using gcc -Wall -Werror, you cannot forget.
    *
    * A table would not have the same benefit. Most compilers will generate
-   * code very similar to a table in any case, so there is little performance
-   * gain from a table. Something is broken for the user's application,
-   * anyways, so does it matter how fast it _does not_ work?
+   * code similar to a table in any case, so there is little performance gain
+   * from a table. Something is broken for the user's application, anyways, so
+   * does it matter how fast it _does not_ work?
    *
    * The line number for the error will be near this comment, which is why it
    * is here, and not at the start of the switch.

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -998,7 +998,7 @@ static CURLcode tftp_connect(struct Curl_easy *data, bool *done)
       return CURLE_OUT_OF_MEMORY;
   }
 
-  /* we do not keep TFTP connections up basically because there is none or very
+  /* we do not keep TFTP connections up basically because there is none or
    * little gain for UDP */
   connclose(conn, "TFTP");
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -777,8 +777,8 @@ static void xfer_setup(
   int sockindex,            /* socket index to read from or -1 */
   curl_off_t size,          /* -1 if unknown at this point */
   bool getheader,           /* TRUE if header parsing is wanted */
-  int writesockindex,       /* socket index to write to, it may very well be
-                               the same we read from. -1 disables */
+  int writesockindex,       /* socket index to write to, it may be the same we
+                               read from. -1 disables */
   bool shutdown,            /* shutdown connection at transfer end. Only
                              * supported when sending OR receiving. */
   bool shutdown_err_ignore  /* errors during shutdown do not fail the
@@ -801,7 +801,7 @@ static void xfer_setup(
       conn->sock[sockindex];
     conn->writesockfd = conn->sockfd;
     if(want_send)
-      /* special and very HTTP-specific */
+      /* special and HTTP-specific */
       writesockindex = FIRSTSOCKET;
   }
   else {

--- a/lib/url.c
+++ b/lib/url.c
@@ -506,10 +506,10 @@ CURLcode Curl_open(struct Curl_easy **curl)
   CURLcode result;
   struct Curl_easy *data;
 
-  /* Very simple start-up: alloc the struct, init it with zeroes and return */
+  /* simple start-up: alloc the struct, init it with zeroes and return */
   data = calloc(1, sizeof(struct Curl_easy));
   if(!data) {
-    /* this is a very serious error */
+    /* this is a serious error */
     DEBUGF(fprintf(stderr, "Error: calloc of Curl_easy failed\n"));
     return CURLE_OUT_OF_MEMORY;
   }
@@ -880,16 +880,16 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
   }
 
   if(needle->localdev || needle->localport) {
-    /* If we are bound to a specific local end (IP+port), we must not
-       reuse a random other one, although if we did not ask for a
-       particular one we can reuse one that was bound.
+    /* If we are bound to a specific local end (IP+port), we must not reuse a
+       random other one, although if we did not ask for a particular one we
+       can reuse one that was bound.
 
        This comparison is a bit rough and too strict. Since the input
-       parameters can be specified in numerous ways and still end up the
-       same it would take a lot of processing to make it really accurate.
-       Instead, this matching will assume that reuses of bound connections
-       will most likely also reuse the exact same binding parameters and
-       missing out a few edge cases should not hurt anyone very much.
+       parameters can be specified in numerous ways and still end up the same
+       it would take a lot of processing to make it really accurate. Instead,
+       this matching will assume that reuses of bound connections will most
+       likely also reuse the exact same binding parameters and missing out a
+       few edge cases should not hurt anyone much.
     */
     if((conn->localport != needle->localport) ||
        (conn->localportrange != needle->localportrange) ||
@@ -2006,8 +2006,8 @@ static CURLcode setup_connection_internals(struct Curl_easy *data,
   }
 
   if(conn->primary.remote_port < 0)
-    /* we check for -1 here since if proxy was detected already, this
-       was very likely already set to the proxy port */
+    /* we check for -1 here since if proxy was detected already, this was
+       likely already set to the proxy port */
     conn->primary.remote_port = p->defport;
 
   /* Now create the destination name */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -871,9 +871,8 @@ struct connectdata {
   /**** curl_get() phase fields */
 
   curl_socket_t sockfd;   /* socket to read from or CURL_SOCKET_BAD */
-  curl_socket_t writesockfd; /* socket to write to, it may very
-                                well be the same we read from.
-                                CURL_SOCKET_BAD disables */
+  curl_socket_t writesockfd; /* socket to write to, it may be the same we read
+                                from. CURL_SOCKET_BAD disables */
 
 #ifdef HAVE_GSSAPI
   BIT(sec_complete); /* if Kerberos is enabled for this connection */
@@ -1896,14 +1895,12 @@ struct Curl_easy {
   /* First a simple identifier to easier detect if a user mix up this easy
      handle with a multi handle. Set this to CURLEASY_MAGIC_NUMBER */
   unsigned int magic;
-  /* once an easy handle is tied to a connection pool
-     a non-negative number to distinguish this transfer from
-     other using the same pool. For easier tracking
-     in log output.
-     This may wrap around after LONG_MAX to 0 again, so it
-     has no uniqueness guarantee for very large processings.
-     Note: it has no uniqueness either IFF more than one connection pool
-     is used by the libcurl application. */
+  /* once an easy handle is tied to a connection pool a non-negative number to
+     distinguish this transfer from other using the same pool. For easier
+     tracking in log output. This may wrap around after LONG_MAX to 0 again,
+     so it has no uniqueness guarantee for large processings. Note: it has no
+     uniqueness either IFF more than one connection pool is used by the
+     libcurl application. */
   curl_off_t id;
   /* once an easy handle is added to a multi, either explicitly by the
    * libcurl application or implicitly during `curl_easy_perform()`,

--- a/lib/vquic/vquic-tls.h
+++ b/lib/vquic/vquic-tls.h
@@ -64,7 +64,7 @@ typedef CURLcode Curl_vquic_tls_ctx_setup(struct Curl_cfilter *cf,
  * @param alpn        the ALPN string in protocol format ((len+bytes+)+),
  *                    may be NULL
  * @param alpn_len    the overall number of bytes in `alpn`
- * @param cb_setup    optional callback for very early TLS config
+ * @param cb_setup    optional callback for early TLS config
  ± @param cb_user_data user_data param for callback
  * @param ssl_user_data  optional pointer to set in TLS application context
  */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1138,9 +1138,9 @@ CURLcode Curl_gtls_ctx_init(struct gtls_ctx *gctx,
     Curl_ssl_sessionid_unlock(data);
   }
 
-  /* convert the ALPN string from our arguments to a list of strings
-   * that gnutls wants and will convert internally back to this very
-   * string for sending to the server. nice. */
+  /* convert the ALPN string from our arguments to a list of strings that
+   * gnutls wants and will convert internally back to this string for sending
+   * to the server. nice. */
   if(!gtls_alpns_count && alpn && alpn_len) {
     size_t i, alen = alpn_len;
     unsigned char *s = (unsigned char *)alpn;

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -234,7 +234,7 @@ bool Curl_ssl_getsessionid(struct Curl_cfilter *cf,
                            char **palpn);
 
 /* Set a TLS session ID for `peer`. Replaces an existing session ID if
- * not already the very same.
+ * not already the same.
  * Sessionid mutex must be locked (see Curl_ssl_sessionid_lock).
  * Call takes ownership of `ssl_sessionid`, using `sessionid_free_cb`
  * to deallocate it. Is called in all outcomes, either right away or

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -39,7 +39,7 @@
 
 /*
  * get_terminal_columns() returns the number of columns in the current
- * terminal. It will return 79 on failure. Also, the number can be very big.
+ * terminal. It will return 79 on failure. Also, the number can be big.
  */
 
 unsigned int get_terminal_columns(void)
@@ -87,5 +87,5 @@ unsigned int get_terminal_columns(void)
   }
   if(!width)
     width = 79;
-  return width; /* 79 for unknown, might also be very small or very big */
+  return width; /* 79 for unknown, might also be tiny or enormous */
 }


### PR DESCRIPTION
- typography.symbols.curly_quotes Use curly quotes “”, not straight quotes "". Found once elsewhere.

- typography.symbols.ellipsis '...' is an approximation, use the ellipsis symbol '…'.a

- typography.symbols.copyright (c) is a goofy alphabetic approximation, use the symbol ©.

- typography.symbols.multiplication_symbol Use the multiplication symbol ×, not the letter x.