### PR TITLE
tests: update some HTTP/2 over HTTPS tests

### DIFF
--- a/tests/data/test2400
+++ b/tests/data/test2400
@@ -28,7 +28,7 @@ Funny-head: yesyes
 <client>
 <features>
 Debug
-h2c
+http/2
 SSL
 </features>
 <server>
@@ -36,7 +36,7 @@ http
 http/2
 </server>
 <name>
-HTTP/2 GET
+HTTP/2 GET over HTTPS
 </name>
 <setenv>
 </setenv>

--- a/tests/data/test2401
+++ b/tests/data/test2401
@@ -26,14 +26,14 @@ Funny-head: yesyes
 <client>
 <features>
 Debug
-h2c
+http/2
 SSL
 </features>
 <server>
 http/2
 </server>
 <name>
-HTTP/2 GET
+HTTP/2 POST over HTTPS
 </name>
 <setenv>
 </setenv>
@@ -56,7 +56,7 @@ via: 1.1 nghttpx
 
 </stdout>
 <protocol nonewline="yes">
-POST /2401 HTTP/1.1
+POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTP2TLSPORT
 User-Agent: curl/%VERSION
 Accept: */*

--- a/tests/data/test2402
+++ b/tests/data/test2402
@@ -47,7 +47,7 @@ file contents should appear once for each file
 # Client-side
 <client>
 <features>
-h2c
+http/2
 SSL
 </features>
 <server>
@@ -57,7 +57,7 @@ http/2
 lib%TESTNUMBER
 </tool>
 <name>
-HTTP GET multiple over HTTP/2
+HTTP GET multiple files over HTTP/2 using HTTPS
 </name>
 <command>
 https://%HOSTIP:%HTTP2TLSPORT/path/%TESTNUMBER %HOSTIP %HTTP2TLSPORT

--- a/tests/data/test2403
+++ b/tests/data/test2403
@@ -29,7 +29,7 @@ Funny-head: yesyes
 # Client-side
 <client>
 <features>
-h2c
+http/2
 SSL
 headers-api
 </features>
@@ -37,7 +37,7 @@ headers-api
 http/2
 </server>
 <name>
-HTTP/2 GET
+HTTP/2 GET using %{header_json}
 </name>
 <setenv>
 </setenv>

--- a/tests/data/test2404
+++ b/tests/data/test2404
@@ -47,7 +47,7 @@ file contents should appear once for each file
 # Client-side
 <client>
 <features>
-h2c
+http/2
 SSL
 </features>
 <server>

--- a/tests/data/test2406
+++ b/tests/data/test2406
@@ -28,14 +28,14 @@ Funny-head: yesyes
 <client>
 <features>
 Debug
-h2c
+http/2
 SSL
 </features>
 <server>
 http/2
 </server>
 <name>
-HTTP/2 with -f
+HTTP/2 over HTTPS with -f
 </name>
 <setenv>
 </setenv>


### PR DESCRIPTION
- improve descriptions
- require http/2, not h2c, since they are done over HTTPS