### PR TITLE
tool_operate: break out of loop on error

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2994,6 +2994,7 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
         if(result) {
           returncode = result;
           bailout = TRUE;
+          break;
         }
       } while(skipped);
     }


### PR DESCRIPTION
Follow-up to 69bf530dfd2a

The loop could get stuck there in torture tests/OOM.