### PR TITLE
libcurl/opts: improve phrasing for connection cap related options

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.md
@@ -26,17 +26,16 @@ CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAXCONNECTS, long max);
 
 # DESCRIPTION
 
-Pass a long indicating the **max**. The set number is used as the maximum
-amount of simultaneously open connections that libcurl may keep in its
-connection cache after completed use. By default libcurl enlarges the size for
-each added easy handle to make it fit 4 times the number of added easy
-handles.
+Pass a long indicating the **max**, the maximum amount of connections that
+libcurl may keep alive in its connection cache after use. By default libcurl
+enlarges the size for each added easy handle to make it fit 4 times the number
+of added easy handles.
 
-By setting this option, you can prevent the cache size from growing beyond the
+By setting this option, you prevent the cache size from growing beyond the
 limit set by you.
 
-When the cache is full, curl closes the oldest one in the cache to prevent the
-number of open connections from increasing.
+When the cache is full, curl closes the oldest connection present in the cache
+to prevent the number of connections from increasing.
 
 This option is for the multi handle's use only, when using the easy interface
 you should instead use the CURLOPT_MAXCONNECTS(3) option.
@@ -46,8 +45,8 @@ connections.
 
 Changing this value when there are transfers in progress is possible, and the
 new value is then used the next time checks are performed. Lowering the value
-does however not close down any active transfers, it simply does not allow new
-ones to get made.
+does not close down any active transfers, it simply does not allow new ones to
+get made.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.md
@@ -27,30 +27,31 @@ CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAX_HOST_CONNECTIONS,
 
 # DESCRIPTION
 
-Pass a long to indicate **max**. The set number is used as the maximum amount
-of simultaneously open connections to a single host (a host being the same as
-a hostname + port number pair). For each new session to a host, libcurl might
-open a new connection up to the limit set by CURLMOPT_MAX_HOST_CONNECTIONS(3).
-When the limit is reached, new sessions are kept pending until a connection
-becomes available.
+Pass a long to indicate **max**, the maximum amount of simultaneously open
+connections libcurl may hold a single host (a host being the same as a
+hostname + port number pair). For each new transfer to the same host, libcurl
+might open a new connection up to the limit set by
+CURLMOPT_MAX_HOST_CONNECTIONS(3). When the limit is reached, new sessions are
+kept pending until a connection becomes available.
 
 The default **max** value is 0, unlimited. This set limit is also used for
 proxy connections, and then the proxy is considered to be the host for which
 this limit counts.
 
 When more transfers are added to the multi handle than what can be performed
-due to the set limit, they are queued up waiting for their chance. When that
-happens, the CURLOPT_TIMEOUT_MS(3) timeout is inclusive of the waiting time,
-meaning that if you set a too narrow timeout in such a case the transfer might
-never even start before it times out.
+due to the set limit, they are queued up waiting for their chance.
 
-Even in the queued up situation, the CURLOPT_CONNECTTIMEOUT_MS(3) timeout is
-however treated as a per-connect timeout.
+While a transfer is queued up internally waiting for a connection, the
+CURLOPT_TIMEOUT_MS(3) timeout is counted inclusive of the waiting time,
+meaning that if you set a too narrow timeout the transfer might never even
+start before it times out. The CURLOPT_CONNECTTIMEOUT_MS(3) time is also
+similarly still treated as a per-connect timeout and might expire even before
+making a new connection is permitted.
 
-Changing this value when there are transfers in progress is possible, and the
-new value is then used the next time checks are performed. Lowering the value
-does however not close down any active transfers, it simply does not allow new
-ones to get made.
+Changing this value while there are transfers in progress is possible. The new
+value is then used the next time checks are performed. Lowering the value does
+not close down any active transfers, it simply does not allow new ones to get
+made.
 
 # DEFAULT
 

--- a/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.md
@@ -30,24 +30,29 @@ CURLMcode curl_multi_setopt(CURLM *handle, CURLMOPT_MAX_TOTAL_CONNECTIONS,
 Pass a long for the **amount**. The set number is used as the maximum number
 of simultaneously open connections in total using this multi handle. For each
 new session, libcurl might open a new connection up to the limit set by
-CURLMOPT_MAX_TOTAL_CONNECTIONS(3). When the limit is reached, new
-sessions are held pending until there are available connections. If
-CURLMOPT_PIPELINING(3) is enabled, libcurl can try multiplexing if the
-host is capable of it.
+CURLMOPT_MAX_TOTAL_CONNECTIONS(3). If CURLMOPT_PIPELINING(3) is enabled,
+libcurl can try multiplexing if the host is capable of it.
 
 When more transfers are added to the multi handle than what can be performed
-due to the set limit, they get queued up waiting for their chance. When that
-happens, the CURLOPT_TIMEOUT_MS(3) timeout is counted inclusive of the
-waiting time, meaning that if you set a too narrow timeout in such a case the
-transfer might never even start before it times out.
+due to the set limit, they get queued up waiting for their chance.
 
-Even in the queued up situation, the CURLOPT_CONNECTTIMEOUT_MS(3)
-timeout is however treated as a per-connect timeout.
+While a transfer is queued up internally waiting for a connection, the
+CURLOPT_TIMEOUT_MS(3) timeout is counted inclusive of the waiting time,
+meaning that if you set a too narrow timeout the transfer might never even
+start before it times out. The CURLOPT_CONNECTTIMEOUT_MS(3) time is also
+similarly still treated as a per-connect timeout and might expire even before
+making a new connection is permitted.
+
+Changing this value while there are transfers in progress is possible. The new
+value is then used the next time checks are performed. Lowering the value does
+not close down any active transfers, it simply does not allow new ones to get
+made.
 
 # DEFAULT
 
 0, which means that there is no limit. It is then simply controlled by the
-number of easy handles added.
+number of easy handles added concurrently and how much multiplexing is being
+done.
 
 # %PROTOCOLS%
 

--- a/docs/libcurl/opts/CURLOPT_MAXCONNECTS.md
+++ b/docs/libcurl/opts/CURLOPT_MAXCONNECTS.md
@@ -28,18 +28,18 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_MAXCONNECTS, long amount);
 
 # DESCRIPTION
 
-Pass a long. The set *amount* is the maximum number of simultaneously open
-persistent connections that libcurl may cache in the pool associated with this
-handle. The default is 5, and there is not much point in changing this value
-unless you are perfectly aware of how this works. This concerns connections
-using any of the protocols that support persistent connections.
+Pass a long. The set *amount* is the maximum number of connections that
+libcurl may keep alive in its connection cache after use. The default is 5,
+and there is not much point in changing this value unless you are perfectly
+aware of how this works. This concerns connections using any of the protocols
+that support persistent connections.
 
-When reaching the maximum limit, curl closes the oldest one in the cache to
-prevent increasing the number of open connections.
+When reaching the maximum limit, curl closes the oldest connection present in
+the cache to prevent the number of connections from increasing.
 
 If you already have performed transfers with this curl handle, setting a
-smaller CURLOPT_MAXCONNECTS(3) than before may cause open connections to
-get closed unnecessarily.
+smaller CURLOPT_MAXCONNECTS(3) than before may cause open connections to get
+closed unnecessarily.
 
 If you add this easy handle to a multi handle, this setting is not
 acknowledged, and you must instead use curl_multi_setopt(3) and the


### PR DESCRIPTION
Unify, clarify.