### PR TITLE
GHA: drop the hyper job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -235,10 +235,6 @@ jobs:
             configure: --enable-debug --disable-shared --disable-threaded-resolver --with-libssh --with-openssl
             tflags: -n -e '!TLS-SRP'
 
-          - name: hyper
-            install_steps: rust hyper
-            configure: LDFLAGS="-Wl,-rpath,$HOME/hyper/target/debug" --with-openssl --with-hyper=$HOME/hyper --enable-debug
-
           - name: rustls valgrind
             install_packages: libpsl-dev valgrind
             install_steps: rust rustls pytest
@@ -538,15 +534,6 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.rustls-version }} --recursive https://github.com/rustls/rustls-ffi.git
           cd rustls-ffi
           make DESTDIR=$HOME/rustls install
-
-      - if: contains(matrix.build.install_steps, 'hyper')
-        run: |
-          cd $HOME
-          git clone --quiet --depth=1 https://github.com/hyperium/hyper.git
-          cd $HOME/hyper
-          RUSTFLAGS="--cfg hyper_unstable_ffi" cargo +nightly rustc --features client,http1,http2,ffi -Z unstable-options --crate-type cdylib
-          echo "LD_LIBRARY_PATH=$HOME/hyper/target/debug:/usr/local/lib" >> $GITHUB_ENV
-        name: 'install hyper'
 
       - if: contains(matrix.build.install_steps, 'intel')
         run: |


### PR DESCRIPTION
Hyper support is being removed in 2025. No one works on it. Getting flaky test runs with this job adds nothing to the project.