### PR TITLE
cmake: replace `CURL_*_DIR` with `{PROJECT,CMAKE_CURRENT}_*_DIR`

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -46,7 +46,7 @@ macro(curl_internal_test _curl_test)
 
     message(STATUS "Performing Test ${_curl_test}")
     try_compile(${_curl_test}
-      ${CMAKE_BINARY_DIR}
+      ${PROJECT_BINARY_DIR}
       "${CMAKE_CURRENT_SOURCE_DIR}/CMake/CurlTests.c"
       CMAKE_FLAGS
         "-DCOMPILE_DEFINITIONS:STRING=-D${_curl_test} ${CURL_TEST_DEFINES} ${_cmake_required_definitions}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ else()
   set(OS "\"${CMAKE_SYSTEM_NAME}\"")
 endif()
 
-include_directories("${CURL_SOURCE_DIR}/include")
+include_directories("${PROJECT_SOURCE_DIR}/include")
 
 if(NOT DEFINED CMAKE_UNITY_BUILD_BATCH_SIZE)
   set(CMAKE_UNITY_BUILD_BATCH_SIZE 0)
@@ -1676,7 +1676,7 @@ endif()
 
 # Include this header to get the type
 cmake_push_check_state()
-set(CMAKE_REQUIRED_INCLUDES "${CURL_SOURCE_DIR}/include")
+set(CMAKE_REQUIRED_INCLUDES "${PROJECT_SOURCE_DIR}/include")
 set(CMAKE_EXTRA_INCLUDE_FILES "curl/system.h")
 check_type_size("curl_off_t" SIZEOF_CURL_OFF_T)
 set(CMAKE_EXTRA_INCLUDE_FILES "curl/curl.h")
@@ -1831,8 +1831,8 @@ endif()
 # (= regenerate it).
 function(transform_makefile_inc _input_file _output_file)
   file(READ ${_input_file} _makefile_inc_text)
-  string(REPLACE "$(top_srcdir)"   "\${CURL_SOURCE_DIR}" _makefile_inc_text ${_makefile_inc_text})
-  string(REPLACE "$(top_builddir)" "\${CURL_BINARY_DIR}" _makefile_inc_text ${_makefile_inc_text})
+  string(REPLACE "$(top_srcdir)"   "\${PROJECT_SOURCE_DIR}" _makefile_inc_text ${_makefile_inc_text})
+  string(REPLACE "$(top_builddir)" "\${PROJECT_BINARY_DIR}" _makefile_inc_text ${_makefile_inc_text})
 
   string(REGEX REPLACE "\\\\\n" "!π!α!" _makefile_inc_text ${_makefile_inc_text})
   string(REGEX REPLACE "([a-zA-Z_][a-zA-Z0-9_]*)[\t ]*=[\t ]*([^\n]*)" "set(\\1 \\2)" _makefile_inc_text ${_makefile_inc_text})
@@ -1860,8 +1860,8 @@ cmake_dependent_option(BUILD_TESTING "Build tests"
   OFF)
 
 if(HAVE_MANUAL_TOOLS)
-  set(CURL_MANPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.1")
-  set(CURL_ASCIIPAGE "${CURL_BINARY_DIR}/docs/cmdline-opts/curl.txt")
+  set(CURL_MANPAGE "${PROJECT_BINARY_DIR}/docs/cmdline-opts/curl.1")
+  set(CURL_ASCIIPAGE "${PROJECT_BINARY_DIR}/docs/cmdline-opts/curl.txt")
   add_subdirectory(docs)
 endif()
 
@@ -2169,9 +2169,9 @@ if(NOT CURL_DISABLE_INSTALL)
   #   SUPPORT_PROTOCOLS
   #   VERSIONNUM
   configure_file(
-    "${CURL_SOURCE_DIR}/curl-config.in"
-    "${CURL_BINARY_DIR}/curl-config" @ONLY)
-  install(FILES "${CURL_BINARY_DIR}/curl-config"
+    "${PROJECT_SOURCE_DIR}/curl-config.in"
+    "${PROJECT_BINARY_DIR}/curl-config" @ONLY)
+  install(FILES "${PROJECT_BINARY_DIR}/curl-config"
     DESTINATION ${CMAKE_INSTALL_BINDIR}
     PERMISSIONS
       OWNER_READ OWNER_WRITE OWNER_EXECUTE
@@ -2200,9 +2200,9 @@ if(NOT CURL_DISABLE_INSTALL)
   #   https://manpages.debian.org/unstable/pkg-config/pkg-config.1.en.html
   #   https://www.msys2.org/docs/pkgconfig/
   configure_file(
-    "${CURL_SOURCE_DIR}/libcurl.pc.in"
-    "${CURL_BINARY_DIR}/libcurl.pc" @ONLY)
-  install(FILES "${CURL_BINARY_DIR}/libcurl.pc"
+    "${PROJECT_SOURCE_DIR}/libcurl.pc.in"
+    "${PROJECT_BINARY_DIR}/libcurl.pc" @ONLY)
+  install(FILES "${PROJECT_BINARY_DIR}/libcurl.pc"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
   # Install headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2206,7 +2206,7 @@ if(NOT CURL_DISABLE_INSTALL)
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
 
   # Install headers
-  install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/include/curl"
+  install(DIRECTORY "${PROJECT_SOURCE_DIR}/include/curl"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     FILES_MATCHING PATTERN "*.h")
 
@@ -2297,7 +2297,7 @@ buildinfo.compiler: ${CMAKE_C_COMPILER_ID}
 buildinfo.compiler.version: ${CMAKE_C_COMPILER_VERSION}
 buildinfo.sysroot: ${_cmake_sysroot}
 ")
-file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/buildinfo.txt" "# This is a generated file.  Do not edit.\n${_buildinfo}")
+file(WRITE "${PROJECT_BINARY_DIR}/buildinfo.txt" "# This is a generated file.  Do not edit.\n${_buildinfo}")
 if(NOT "$ENV{CURL_BUILDINFO}$ENV{CURL_CI}$ENV{CI}" STREQUAL "")
   message(STATUS "\n${_buildinfo}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,7 @@ include(CheckCSourceCompiles)
 
 # Preload settings on Windows
 if(WIN32)
-  include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/Platforms/WindowsCache.cmake)
+  include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/Platforms/WindowsCache.cmake")
 endif()
 
 if(ENABLE_THREADED_RESOLVER)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 
 if(BUILD_MISC_DOCS)
   foreach(_man_misc IN ITEMS "curl-config" "mk-ca-bundle")
-    set(_man_target "${CURL_BINARY_DIR}/docs/${_man_misc}.1")
+    set(_man_target "${CMAKE_CURRENT_BINARY_DIR}/${_man_misc}.1")
     add_custom_command(OUTPUT "${_man_target}"
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/cd2nroff" "${_man_misc}.md" > "${_man_target}"

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -39,8 +39,8 @@ list(APPEND HHEADERS "${CMAKE_CURRENT_BINARY_DIR}/curl_config.h")
 # The rest of the build
 
 include_directories(
-  "${CMAKE_CURRENT_BINARY_DIR}"
-  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${PROJECT_BINARY_DIR}/lib"  # for "curl_config.h"
+  "${PROJECT_SOURCE_DIR}/lib"  # for "curl_setup.h"
 )
 if(USE_ARES)
   include_directories(SYSTEM ${CARES_INCLUDE_DIRS})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -112,7 +112,7 @@ if(SHARE_LIB_OBJECT)
 
   target_include_directories(${LIB_OBJECT} INTERFACE
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-    "$<BUILD_INTERFACE:${CURL_SOURCE_DIR}/include>")
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
   set(LIB_SOURCE $<TARGET_OBJECTS:${LIB_OBJECT}>)
 else()
@@ -145,7 +145,7 @@ if(BUILD_STATIC_LIBS)
 
   target_include_directories(${LIB_STATIC} INTERFACE
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-    "$<BUILD_INTERFACE:${CURL_SOURCE_DIR}/include>")
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 endif()
 
 if(BUILD_SHARED_LIBS)
@@ -163,7 +163,7 @@ if(BUILD_SHARED_LIBS)
   if(WIN32)
     set_property(TARGET ${LIB_SHARED} APPEND PROPERTY SOURCES "libcurl.rc")
     if(CURL_HIDES_PRIVATE_SYMBOLS)
-      set_property(TARGET ${LIB_SHARED} APPEND PROPERTY SOURCES "${CURL_SOURCE_DIR}/lib/libcurl.def")
+      set_property(TARGET ${LIB_SHARED} APPEND PROPERTY SOURCES "${PROJECT_SOURCE_DIR}/lib/libcurl.def")
     endif()
   endif()
   target_link_libraries(${LIB_SHARED} PRIVATE ${CURL_LIBS})
@@ -184,7 +184,7 @@ if(BUILD_SHARED_LIBS)
 
   target_include_directories(${LIB_SHARED} INTERFACE
     "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
-    "$<BUILD_INTERFACE:${CURL_SOURCE_DIR}/include>")
+    "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>")
 
   if(CMAKE_DLL_NAME_WITH_SOVERSION OR
     CYGWIN OR

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,10 +118,10 @@ source_group("curl source files" FILES ${CURL_CFILES})
 source_group("curl header files" FILES ${CURL_HFILES})
 
 include_directories(
-  "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
-  "${CURL_SOURCE_DIR}/lib"  # for "curl_setup.h"
+  "${PROJECT_BINARY_DIR}/lib"  # for "curl_config.h"
+  "${PROJECT_SOURCE_DIR}/lib"  # for "curl_setup.h"
   # This is needed as tool_hugehelp.c is generated in the binary dir
-  "${CURL_SOURCE_DIR}/src"  # for "tool_hugehelp.h"
+  "${PROJECT_SOURCE_DIR}/src"  # for "tool_hugehelp.h"
 )
 
 # Build curl executable

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -34,8 +34,8 @@ foreach(_target IN LISTS check_PROGRAMS)
   add_dependencies(testdeps ${_target_name})
   add_dependencies(test-http-clients ${_target_name})
   target_include_directories(${_target_name} PRIVATE
-    "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
-    "${CURL_SOURCE_DIR}/lib"  # for "curl_setup.h"
+    "${PROJECT_BINARY_DIR}/lib"  # for "curl_config.h"
+    "${PROJECT_SOURCE_DIR}/lib"  # for "curl_setup.h"
   )
   target_link_libraries(${_target_name} ${LIB_SELECTED} ${CURL_LIBS})
   target_compile_definitions(${_target_name} PRIVATE "CURL_NO_OLDIES")

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -30,18 +30,18 @@ set_source_files_properties("../../lib/curl_multibyte.c" PROPERTIES SKIP_UNITY_B
 
 add_custom_command(
   OUTPUT "lib1521.c"
-  COMMAND ${PERL_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/mk-lib1521.pl" < "${CURL_SOURCE_DIR}/include/curl/curl.h" "lib1521.c"
+  COMMAND ${PERL_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/mk-lib1521.pl" < "${PROJECT_SOURCE_DIR}/include/curl/curl.h" "lib1521.c"
   DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/mk-lib1521.pl"
-    "${CURL_SOURCE_DIR}/include/curl/curl.h"
+    "${PROJECT_SOURCE_DIR}/include/curl/curl.h"
   VERBATIM)
 
 if(CURL_TEST_BUNDLES)
   add_custom_command(
     OUTPUT "libtest_bundle.c"
-    COMMAND ${PERL_EXECUTABLE} "${CURL_SOURCE_DIR}/tests/mk-bundle.pl" "${CMAKE_CURRENT_SOURCE_DIR}" > "libtest_bundle.c"
+    COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/tests/mk-bundle.pl" "${CMAKE_CURRENT_SOURCE_DIR}" > "libtest_bundle.c"
     DEPENDS
-      "${CURL_SOURCE_DIR}/tests/mk-bundle.pl" ${FIRSTFILES} "lib1521.c"
+      "${PROJECT_SOURCE_DIR}/tests/mk-bundle.pl" ${FIRSTFILES} "lib1521.c"
       "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc"
     VERBATIM)
 
@@ -72,9 +72,9 @@ foreach(_target IN LISTS LIBTESTPROGS)
   add_dependencies(testdeps ${_target_name})
   target_link_libraries(${_target_name} ${LIB_SELECTED} ${CURL_LIBS})
   target_include_directories(${_target_name} PRIVATE
-    "${CURL_BINARY_DIR}/lib"            # for "curl_config.h"
-    "${CURL_SOURCE_DIR}/lib"            # for "curl_setup.h"
-    "${CURL_SOURCE_DIR}/tests/libtest"  # to be able to build generated tests
+    "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
+    "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
+    "${PROJECT_SOURCE_DIR}/tests/libtest"  # to be able to build generated tests
   )
   if(NOT CURL_TEST_BUNDLES)
     set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS ${_upper_target})

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -33,9 +33,9 @@ foreach(_target IN LISTS noinst_PROGRAMS)
   add_executable(${_target_name} EXCLUDE_FROM_ALL ${${_target}_SOURCES})
   add_dependencies(testdeps ${_target_name})
   target_include_directories(${_target_name} PRIVATE
-    "${CURL_BINARY_DIR}/lib"  # for "curl_config.h"
-    "${CURL_SOURCE_DIR}/lib"  # for "curl_setup.h"
-    "${CURL_SOURCE_DIR}/src"  # for "tool_xattr.h" in disabled_SOURCES
+    "${PROJECT_BINARY_DIR}/lib"  # for "curl_config.h"
+    "${PROJECT_SOURCE_DIR}/lib"  # for "curl_setup.h"
+    "${PROJECT_SOURCE_DIR}/src"  # for "tool_xattr.h" in disabled_SOURCES
   )
   target_link_libraries(${_target_name} ${CURL_LIBS})
   # Test servers simply are standalone programs that do not use libcurl

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -29,9 +29,9 @@ include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 if(CURL_TEST_BUNDLES)
   add_custom_command(
     OUTPUT "unit_bundle.c"
-    COMMAND ${PERL_EXECUTABLE} "${CURL_SOURCE_DIR}/tests/mk-bundle.pl" "${CMAKE_CURRENT_SOURCE_DIR}" > "unit_bundle.c"
+    COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/tests/mk-bundle.pl" "${CMAKE_CURRENT_SOURCE_DIR}" > "unit_bundle.c"
     DEPENDS
-      "${CURL_SOURCE_DIR}/tests/mk-bundle.pl" ${FIRSTFILES}
+      "${PROJECT_SOURCE_DIR}/tests/mk-bundle.pl" ${FIRSTFILES}
       "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc"
     VERBATIM)
 
@@ -45,13 +45,13 @@ foreach(_target IN LISTS UNITPROGS)
   add_dependencies(testdeps ${_target_name})
   target_link_libraries(${_target_name} curltool curlu)
   target_include_directories(${_target_name} PRIVATE
-    "${CURL_BINARY_DIR}/lib"            # for "curl_config.h"
-    "${CURL_SOURCE_DIR}/lib"            # for "curl_setup.h"
-    "${CURL_SOURCE_DIR}/src"
-    "${CURL_SOURCE_DIR}/tests/libtest"
+    "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
+    "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
+    "${PROJECT_SOURCE_DIR}/src"
+    "${PROJECT_SOURCE_DIR}/tests/libtest"
   )
   if(CURL_TEST_BUNDLES)
-    target_include_directories(${_target_name} PRIVATE "${CURL_SOURCE_DIR}/tests/unit")
+    target_include_directories(${_target_name} PRIVATE "${PROJECT_SOURCE_DIR}/tests/unit")
   endif()
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}"


### PR DESCRIPTION
It reduces the number of synonym variables in the code.
Makes it easier to grok and grep.

- replace `CURL_SOURCE_DIR`
  with `PROJECT_SOURCE_DIR`.

- replace `CURL_BINARY_DIR`
  with `PROJECT_BINARY_DIR` or `CMAKE_CURRENT_BINARY_DIR`.

- replace a single use of `CMAKE_BINARY_DIR`
  with `PROJECT_BINARY_DIR`.

- replace `CMAKE_CURRENT_*_DIR`
  with `PROJECT_*_DIR` where it makes the code more uniform.

- quote an argument (formatting).

---

- [x] check `CMAKE_SOURCE_DIR` and `CMAKE_BINARY_DIR` as an alternative for `PROJECT_*`.