### PR TITLE
version: say quictls in MSH3 builds

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -247,7 +247,7 @@
 #elif defined(OPENSSL_IS_AWSLC)
 #define OSSL_PACKAGE "AWS-LC"
 #else
-# if defined(USE_NGHTTP3) && (defined(USE_NGTCP2) || defined(USE_MSH3))
+# if (defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || defined(USE_MSH3)
 #   define OSSL_PACKAGE "quictls"
 # else
 #   define OSSL_PACKAGE "OpenSSL"

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -247,7 +247,7 @@
 #elif defined(OPENSSL_IS_AWSLC)
 #define OSSL_PACKAGE "AWS-LC"
 #else
-# if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
+# if defined(USE_NGHTTP3) && (defined(USE_NGTCP2) || defined(USE_MSH3))
 #   define OSSL_PACKAGE "quictls"
 # else
 #   define OSSL_PACKAGE "OpenSSL"


### PR DESCRIPTION
Before: `curl 8.11.0-DEV (x86_64-pc-linux-gnu) libcurl/8.11.0-DEV OpenSSL/3.3.0 zlib/1.3 brotli/1.1.0 zstd/1.5.5 libpsl/0.21.2 msh3/0.6.0.0`
After:  `curl 8.11.0-DEV (x86_64-pc-linux-gnu) libcurl/8.11.0-DEV quictls/3.3.0 zlib/1.3 brotli/1.1.0 zstd/1.5.5 libpsl/0.21.2 msh3/0.6.0.0`
