### PR TITLE
cmake: fix compile warnings for clang-cl

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -30,17 +30,17 @@ if(CURL_WERROR AND
      NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0 AND
      NOT CMAKE_VERSION VERSION_LESS 3.23.0) OR  # to avoid check_symbol_exists() conflicting with GCC -pedantic-errors
    CMAKE_C_COMPILER_ID MATCHES "Clang"))
-  set(WPICKY "${WPICKY} -pedantic-errors")
+  list(APPEND WPICKY "-pedantic-errors")
 endif()
 
 if(APPLE AND
    (CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
    (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
-  set(WPICKY "${WPICKY} -Werror=partial-availability")  # clang 3.6  appleclang 6.3
+  list(APPEND WPICKY "-Werror=partial-availability")  # clang 3.6  appleclang 6.3
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-  set(WPICKY "${WPICKY} -Werror-implicit-function-declaration")  # clang 1.0  gcc 2.95
+  list(APPEND WPICKY "-Werror-implicit-function-declaration")  # clang 1.0  gcc 2.95
 endif()
 
 if(PICKY_COMPILER)
@@ -221,7 +221,7 @@ if(PICKY_COMPILER)
     #
 
     foreach(_ccopt IN LISTS WPICKY_ENABLE)
-      set(WPICKY "${WPICKY} ${_ccopt}")
+      list(APPEND WPICKY "${_ccopt}")
     endforeach()
 
     foreach(_ccopt IN LISTS WPICKY_DETECT)
@@ -233,13 +233,14 @@ if(PICKY_COMPILER)
       string(REPLACE "-Wno-" "-W" _ccopt_on "${_ccopt}")
       check_c_compiler_flag(${_ccopt_on} ${_optvarname})
       if(${_optvarname})
-        set(WPICKY "${WPICKY} ${_ccopt}")
+        list(APPEND WPICKY "${_ccopt}")
       endif()
     endforeach()
   endif()
 endif()
 
 if(WPICKY)
+  string(REPLACE ";" " " WPICKY "${WPICKY}")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WPICKY}")
   message(STATUS "Picky compiler options:${WPICKY}")
 endif()

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -239,6 +239,16 @@ if(PICKY_COMPILER)
   endif()
 endif()
 
+# clang-cl
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND MSVC)
+  # list(TRANSFORM WPICKY PREPEND "/clang:") # since CMake 3.12
+  set(_wpicky "")
+  foreach(_ccopt IN LISTS WPICKY)
+    list(APPEND _wpicky "/clang:${_ccopt}")
+  endforeach()
+  set(WPICKY ${_wpicky})
+endif()
+
 if(WPICKY)
   string(REPLACE ";" " " WPICKY "${WPICKY}")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WPICKY}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1796,7 +1796,7 @@ if(MSVC)
   endif()
 
   # Use multithreaded compilation on VS 2008+
-  if(MSVC_VERSION GREATER_EQUAL 1500)
+  if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND MSVC_VERSION GREATER_EQUAL 1500)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
   endif()
 endif()


### PR DESCRIPTION
[clang-cl is an alternative command-line interface to Clang, designed for compatibility with the Visual C++ compiler, cl.exe.](https://clang.llvm.org/docs/UsersManual.html#clang-cl)

The way to test clang-cl in CMake:
- `CMAKE_<LANGUAGE>_COMPILER_ID`: "Clang"
- `CMAKE_<LANGUAGE>_COMPILER_FRONTEND_VARIANT`: "MSVC"

Note: [CMAKE_\<LANGUAGE\>_COMPILER_FRONTEND_VARIANT](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_FRONTEND_VARIANT.html)) was introduced since CMake 3.14, but the variable [MSVC](https://cmake.org/cmake/help/latest/variable/MSVC.html) works fine here.

---

To pass the GNU style compile options to cl frontend, prefix `/clang:` or `-Xclang` is required to be prepended.

`COMPILE_OPTIONS` here is easier to be transformed, because it is a list, not like `CMAKE_<LANG>_FLAGS` is just a string.