### PR TITLE
GHA/linux: tidy up and performance

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -158,12 +158,12 @@ jobs:
             install_steps: pytest
             configure: --with-openssl --enable-debug --disable-threaded-resolver --with-libssh2
 
-          - name: openssl
+          - name: openssl gcc-11
             install_packages: zlib1g-dev
             install_steps: gcc-11 pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
-          - name: openssl -O3 valgrind
+          - name: openssl gcc-11 -O3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11
             configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 --with-openssl --enable-debug
@@ -176,11 +176,11 @@ jobs:
             install_packages: zlib1g-dev libkrb5-dev clang
             generate: -DCURL_USE_OPENSSL=ON -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON
 
-          - name: openssl !ipv6
+          - name: openssl gcc-11 !ipv6
             install_steps: gcc-11
             configure: --with-openssl --disable-ipv6 --enable-debug --disable-unity
 
-          - name: openssl https-only
+          - name: openssl gcc-11 https-only
             install_steps: gcc-11
             configure: >-
               --with-openssl --enable-debug --disable-unity
@@ -189,7 +189,7 @@ jobs:
               --disable-rtmp --disable-rtsp
               --disable-scp --disable-sftp --disable-tftp --disable-ftp --disable-file --disable-smb
 
-          - name: '!ssl !http !smtp !imap'
+          - name: 'gcc-11 !ssl !http !smtp !imap'
             install_steps: gcc-11
             configure: --without-ssl --enable-debug --disable-http --disable-smtp --disable-imap --disable-unity
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -419,6 +419,7 @@ jobs:
         if: contains(matrix.build.install_steps, 'openssltsan3') && steps.cache-openssltsan3.outputs.cache-hit != 'true'
         # There are global data race in openssl:
         # Cherry-Pick the fix for testing https://github.com/openssl/openssl/pull/24782
+        # Drop this when bumping to OpenSSL 3.4.0 or upper.
         run: |
           git clone --quiet --depth=1 -b ${{ env.openssl3-version }} https://github.com/openssl/openssl
           cd openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -174,6 +174,7 @@ jobs:
 
           - name: openssl clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang
+            install_steps: skipall
             generate: -DCURL_USE_OPENSSL=ON -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON
 
           - name: openssl gcc-11 !ipv6

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,7 +52,7 @@ env:
   # renovate: datasource=github-tags depName=awslabs/aws-lc versioning=semver registryUrl=https://github.com
   awslc-version: 1.37.0
   # handled in renovate.json
-  openssl3-version: openssl-3.1.3
+  openssl3-version: openssl-3.3.2
   # unhandled
   quictls-version: 3.3.0-quic1
   # renovate: datasource=github-tags depName=rustls/rustls-ffi versioning=semver registryUrl=https://github.com

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -249,8 +249,8 @@ jobs:
             install_steps: intel
             configure: CC=icc --enable-debug --without-ssl
 
-          - name: IntelC openssl valgrind
-            install_packages: zlib1g-dev libssl-dev valgrind
+          - name: IntelC openssl
+            install_packages: zlib1g-dev libssl-dev
             install_steps: intel
             configure: CC=icc --enable-debug --with-openssl
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -244,11 +244,6 @@ jobs:
             PKG_CONFIG_PATH: '$HOME/rustls/lib/pkgconfig'  # Not built as of v0.14.0
             generate: -DCURL_USE_RUSTLS=ON -DRUSTLS_INCLUDE_DIR=$HOME/rustls/include -DRUSTLS_LIBRARY=$HOME/rustls/lib/librustls.a -DENABLE_DEBUG=ON
 
-          - name: IntelC !SSL
-            install_packages: zlib1g-dev
-            install_steps: intel
-            configure: CC=icc --enable-debug --without-ssl
-
           - name: IntelC openssl
             install_packages: zlib1g-dev libssl-dev
             install_steps: intel

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -158,14 +158,13 @@ jobs:
             install_steps: pytest
             configure: --with-openssl --enable-debug --disable-threaded-resolver --with-libssh2
 
-          - name: openssl gcc-11
+          - name: openssl
             install_packages: zlib1g-dev
-            install_steps: gcc-11 pytest
+            install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
-          - name: openssl gcc-11 -O3 valgrind
+          - name: openssl -O3 valgrind
             install_packages: zlib1g-dev valgrind
-            install_steps: gcc-11
             configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 --with-openssl --enable-debug
 
           - name: openssl clang krb5
@@ -177,12 +176,10 @@ jobs:
             install_steps: skipall
             generate: -DCURL_USE_OPENSSL=ON -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON
 
-          - name: openssl gcc-11 !ipv6
-            install_steps: gcc-11
+          - name: openssl !ipv6
             configure: --with-openssl --disable-ipv6 --enable-debug --disable-unity
 
-          - name: openssl gcc-11 https-only
-            install_steps: gcc-11
+          - name: openssl https-only
             configure: >-
               --with-openssl --enable-debug --disable-unity
               --disable-dict --disable-gopher --disable-ldap --disable-telnet
@@ -190,8 +187,7 @@ jobs:
               --disable-rtmp --disable-rtsp
               --disable-scp --disable-sftp --disable-tftp --disable-ftp --disable-file --disable-smb
 
-          - name: 'gcc-11 !ssl !http !smtp !imap'
-            install_steps: gcc-11
+          - name: '!ssl !http !smtp !imap'
             configure: --without-ssl --enable-debug --disable-http --disable-smtp --disable-imap --disable-unity
 
           - name: scanbuild
@@ -292,17 +288,6 @@ jobs:
         # See https://github.com/actions/runner-images/issues/9491
         continue-on-error: true
         run: sudo sysctl vm.mmap_rnd_bits=28
-
-      - if: contains(matrix.build.install_steps, 'gcc-11')
-        run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
-          sudo apt-get update
-          sudo apt-get install gcc-11
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
-          sudo update-alternatives --set gcc /usr/bin/gcc-11
-          gcc --version
-        name: 'install gcc-11'
 
       - name: cache bearssl
         if: contains(matrix.build.install_steps, 'bearssl')

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -160,32 +160,30 @@ jobs:
 
           - name: openssl3
             install_packages: zlib1g-dev
-            install_steps: gcc-11 openssl3 pytest
-            configure: CFLAGS=-std=gnu89 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug
+            install_steps: gcc-11 pytest
+            configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
           - name: openssl3 -O3 valgrind
             install_packages: zlib1g-dev valgrind
-            install_steps: gcc-11 openssl3
-            configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug
+            install_steps: gcc-11
+            configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 --with-openssl --enable-debug
 
           - name: openssl3 clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang
-            install_steps: openssl3
-            configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --with-gssapi --enable-debug
+            configure: CC=clang --with-openssl --with-gssapi --enable-debug
 
           - name: openssl3 clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang
-            install_steps: openssl3
-            generate: -DOPENSSL_ROOT_DIR=$HOME/openssl3 -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON
+            generate: -DCURL_USE_OPENSSL=ON -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON
 
           - name: openssl3 !ipv6
-            install_steps: gcc-11 openssl3
-            configure: LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --disable-ipv6 --disable-unity
+            install_steps: gcc-11
+            configure: --with-openssl --disable-ipv6 --enable-debug --disable-unity
 
           - name: openssl3 https-only
-            install_steps: gcc-11 openssl3
+            install_steps: gcc-11
             configure: >-
-              LDFLAGS="-Wl,-rpath,$HOME/openssl3/lib" --with-openssl=$HOME/openssl3 --enable-debug --disable-unity
+              --with-openssl --enable-debug --disable-unity
               --disable-dict --disable-gopher --disable-ldap --disable-telnet
               --disable-imap --disable-pop3 --disable-smtp
               --disable-rtmp --disable-rtsp
@@ -410,24 +408,6 @@ jobs:
             -DENABLE_PROGRAMS=OFF -DENABLE_TESTING=OFF
           cmake --build .
           cmake --install .
-
-      - name: cache openssl3
-        if: contains(matrix.build.install_steps, 'openssl3')
-        uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
-        id: cache-openssl3
-        env:
-          cache-name: cache-openssl3
-        with:
-          path: /home/runner/openssl3
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl3-version }}
-
-      - name: 'install openssl3'
-        if: contains(matrix.build.install_steps, 'openssl3') && steps.cache-openssl3.outputs.cache-hit != 'true'
-        run: |
-          git clone --quiet --depth=1 -b ${{ env.openssl3-version }} https://github.com/openssl/openssl
-          cd openssl
-          ./config --prefix=$HOME/openssl3 --libdir=lib
-          make -j1 install_sw
 
       - name: cache openssltsan3
         if: contains(matrix.build.install_steps, 'openssltsan3')

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -158,29 +158,29 @@ jobs:
             install_steps: pytest
             configure: --with-openssl --enable-debug --disable-threaded-resolver --with-libssh2
 
-          - name: openssl3
+          - name: openssl
             install_packages: zlib1g-dev
             install_steps: gcc-11 pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
-          - name: openssl3 -O3 valgrind
+          - name: openssl -O3 valgrind
             install_packages: zlib1g-dev valgrind
             install_steps: gcc-11
             configure: CPPFLAGS=-DCURL_WARN_SIGN_CONVERSION CFLAGS=-O3 --with-openssl --enable-debug
 
-          - name: openssl3 clang krb5
+          - name: openssl clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang
             configure: CC=clang --with-openssl --with-gssapi --enable-debug
 
-          - name: openssl3 clang krb5
+          - name: openssl clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang
             generate: -DCURL_USE_OPENSSL=ON -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON
 
-          - name: openssl3 !ipv6
+          - name: openssl !ipv6
             install_steps: gcc-11
             configure: --with-openssl --disable-ipv6 --enable-debug --disable-unity
 
-          - name: openssl3 https-only
+          - name: openssl https-only
             install_steps: gcc-11
             configure: >-
               --with-openssl --enable-debug --disable-unity


### PR DESCRIPTION
- replace openssl3 default local build with packaged one.
- drop valgrind from IntelC job.
- drop IntelC no-ssl job.
- bump local openssl to 3.3.2.
- disable tests in the cmake variant of a job.
- add comment to the remaining local openssl3 build.
  We can drop the patch after upgrading to upcoming 3.4.0.
- drop gcc-11 from jobs. packaged gcc is now newer at 13.2.0.
  (saves more than 1m install time for each of the 5 jobs.)
  Follow-up to 9cc9a6472c5d2e13a117ca02f432443db2d1be57 #9454