### PR TITLE
cmake: avoid setting `BUILD_TESTING`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1855,9 +1855,7 @@ set(_generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
 set(_project_config "${_generated_dir}/${PROJECT_NAME}Config.cmake")
 set(_version_config "${_generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
 
-cmake_dependent_option(BUILD_TESTING "Build tests"
-  ON "PERL_FOUND;NOT CURL_DISABLE_TESTS"
-  OFF)
+option(BUILD_TESTING "Build tests" ON)
 
 if(HAVE_MANUAL_TOOLS)
   set(CURL_MANPAGE "${PROJECT_BINARY_DIR}/docs/cmdline-opts/curl.1")
@@ -1876,7 +1874,7 @@ if(BUILD_EXAMPLES)
   add_subdirectory(docs/examples)
 endif()
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND PERL_FOUND AND NOT CURL_DISABLE_TESTS)
   add_subdirectory(tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1856,6 +1856,11 @@ set(_project_config "${_generated_dir}/${PROJECT_NAME}Config.cmake")
 set(_version_config "${_generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
 
 option(BUILD_TESTING "Build tests" ON)
+if(BUILD_TESTING AND PERL_FOUND AND NOT CURL_DISABLE_TESTS)
+  set(CURL_BUILD_TESTING ON)
+else()
+  set(CURL_BUILD_TESTING OFF)
+endif()
 
 if(HAVE_MANUAL_TOOLS)
   set(CURL_MANPAGE "${PROJECT_BINARY_DIR}/docs/cmdline-opts/curl.1")
@@ -1874,7 +1879,7 @@ if(BUILD_EXAMPLES)
   add_subdirectory(docs/examples)
 endif()
 
-if(BUILD_TESTING AND PERL_FOUND AND NOT CURL_DISABLE_TESTS)
+if(CURL_BUILD_TESTING)
   add_subdirectory(tests)
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,7 +46,7 @@ if(USE_ARES)
   include_directories(SYSTEM ${CARES_INCLUDE_DIRS})
 endif()
 
-if(BUILD_TESTING AND PERL_FOUND AND NOT CURL_DISABLE_TESTS)
+if(CURL_BUILD_TESTING)
   add_library(
     curlu  # special libcurlu library just for unittests
     STATIC

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,7 +46,7 @@ if(USE_ARES)
   include_directories(SYSTEM ${CARES_INCLUDE_DIRS})
 endif()
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND PERL_FOUND AND NOT CURL_DISABLE_TESTS)
   add_library(
     curlu  # special libcurlu library just for unittests
     STATIC


### PR DESCRIPTION
`BUILD_TESTING` variable is used by other projects and CMake internally.
Replace `cmake_dependent_option()` with `option()` and introduce an
internal variable to track if want and can do testing.

Reported-by: Robert Maynard
Fixes #15351
Follow-up to #6036
Follow-up to 3a1e798009799be1e9fad30666351b66f250befb #6072
