### PR TITLE
GHA/windows: ignore results for test 987

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -800,6 +800,7 @@ jobs:
         timeout-minutes: 10
         run: |
           export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
+          TFLAGS+=' ~987'  # 'SMTPS with redundant explicit SSL request'
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SFTP'
           elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then


### PR DESCRIPTION
987 is `SMTPS with redundant explicit SSL request`.

Root cause undiscovered.

Started failing after GHA bumping the windows image to `20241015.1.0`:
https://github.com/actions/runner-images/commit/fcc4cdb1d095af1317859c4809364538953b3497
https://github.com/actions/runner-images/pull/10803

vcpkg packages also got bumped as a result. They seem unrelated:
c-ares  1.33.1 -> 1.34.1
nghttp2 1.62.1 -> 1.63.0
nghttp3 1.5.0  -> 1.6.0
(there may be more)

Ref: https://github.com/curl/curl/pull/15335#issuecomment-2423759953
