### PR TITLE
ci: fix renovate's matching for OpenSSL

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -43,9 +43,9 @@ permissions: {}
 env:
   MAKEFLAGS: -j 5
   # handled in renovate.json
-  openssl3-version: openssl-3.3.0
-  # unhandled
-  quictls-version: 3.3.0-quic1
+  openssl3-version: 3.3.0
+  # handled in renovate.json
+  quictls-version: 3.3.0
   # renovate: datasource=github-tags depName=gnutls/gnutls versioning=semver registryUrl=https://github.com
   gnutls-version: 3.8.7
   wolfssl-version: master
@@ -98,7 +98,7 @@ jobs:
           cache-name: cache-quictls-no-deprecated
         with:
           path: /home/runner/quictls/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
 
       - name: cache gnutls
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
@@ -174,7 +174,7 @@ jobs:
       - if: steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true'
         run: |
           cd $HOME
-          git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }} https://github.com/quictls/openssl quictls
+          git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
           ./config no-deprecated --prefix=$PWD/build --libdir=lib
           make
@@ -408,7 +408,7 @@ jobs:
       - name: 'install openssl3'
         if: matrix.build.name == 'openssl-quic' && steps.cache-openssl3.outputs.cache-hit != 'true'
         run: |
-          git clone --quiet --depth=1 -b ${{ env.openssl3-version }} https://github.com/openssl/openssl
+          git clone --quiet --depth=1 -b openssl-${{ env.openssl3-version }} https://github.com/openssl/openssl
           cd openssl
           ./config --prefix=$HOME/openssl3/build
           make -j1 install_sw

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,9 +52,9 @@ env:
   # renovate: datasource=github-tags depName=awslabs/aws-lc versioning=semver registryUrl=https://github.com
   awslc-version: 1.37.0
   # handled in renovate.json
-  openssl3-version: openssl-3.3.2
-  # unhandled
-  quictls-version: 3.3.0-quic1
+  openssl3-version: 3.3.2
+  # handled in renovate.json
+  quictls-version: 3.3.0
   # renovate: datasource=github-tags depName=rustls/rustls-ffi versioning=semver registryUrl=https://github.com
   rustls-version: 0.14.0
 
@@ -406,7 +406,7 @@ jobs:
         # Cherry-Pick the fix for testing https://github.com/openssl/openssl/pull/24782
         # Drop this when bumping to OpenSSL 3.4.0 or upper.
         run: |
-          git clone --quiet --depth=1 -b ${{ env.openssl3-version }} https://github.com/openssl/openssl
+          git clone --quiet --depth=1 -b openssl-${{ env.openssl3-version }} https://github.com/openssl/openssl
           cd openssl
           git fetch --quiet --depth=2 origin d8def79838cd0d5e7c21d217aa26edb5229f0ab4
           git cherry-pick -n d8def79838cd0d5e7c21d217aa26edb5229f0ab4
@@ -421,12 +421,12 @@ jobs:
           cache-name: cache-quictls
         with:
           path: /home/runner/quictls
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.quictls-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
 
       - name: 'build quictls'
         if: contains(matrix.build.install_steps, 'quictls') && steps.cache-quictls.outputs.cache-hit != 'true'
         run: |
-          git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }} https://github.com/quictls/openssl
+          git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl
           ./config --prefix=$HOME/quictls --libdir=lib
           make -j1 install_sw

--- a/renovate.json
+++ b/renovate.json
@@ -80,8 +80,21 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "openssl/openssl",
       "versioningTemplate": "semver",
-      "extractVersionTemplate": "^openssl-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "registryUrlTemplate": "https://github.com"
+      "extractVersionTemplate": "^openssl-(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^.github/workflows/linux.yml$",
+        "^.github/workflows/http3-linux.yml$"
+      ],
+      "matchStrings": [
+        "quictls-version: (?<currentValue>.*)\\s"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "quictls/openssl",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^openssl-(?<version>.*)-quic1$"
     }
   ]
 }


### PR DESCRIPTION
Renovate only matches on the raw version numbers of a package, but OpenSSL includes `openssl-` as a prefix in the version number. This change means that the match string now expects the `openssl-` prefix and will just update the version portion.