### PR TITLE
GHA/windows: increase timeout for vcpkg jobs due to slowness

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -792,7 +792,7 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 15
+        timeout-minutes: 12
         run: |
           export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
           TFLAGS+=' ~987'  # 'SMTPS with redundant explicit SSL request'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -727,6 +727,9 @@ jobs:
       - name: 'vcpkg versions'
         timeout-minutes: 1
         run: |
+          uname -a
+          cygpath -w ~ || true
+          cygpath -w / || true
           git -C "$VCPKG_INSTALLATION_ROOT" show --no-patch --format='%H %ai'
           vcpkg version
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -633,7 +633,7 @@ jobs:
               -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
 
           - name: 'openssl'
-            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv'
+            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
@@ -641,7 +641,7 @@ jobs:
             config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
+              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON
 
           - name: 'openssl'
             install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -727,9 +727,6 @@ jobs:
       - name: 'vcpkg versions'
         timeout-minutes: 1
         run: |
-          uname -a
-          cygpath -w ~ || true
-          cygpath -w / || true
           git -C "$VCPKG_INSTALLATION_ROOT" show --no-patch --format='%H %ai'
           vcpkg version
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -792,7 +792,7 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 10
+        timeout-minutes: 15
         run: |
           export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
           TFLAGS+=' ~987'  # 'SMTPS with redundant explicit SSL request'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -641,7 +641,7 @@ jobs:
             config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-              -DCURL_USE_GSASL=ON -DENABLE_ARES=OFF -DCURL_USE_LIBUV=ON
+              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
 
           - name: 'openssl'
             install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -633,7 +633,7 @@ jobs:
               -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON
 
           - name: 'openssl'
-            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares'
+            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
@@ -641,7 +641,7 @@ jobs:
             config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON
+              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
 
           - name: 'openssl'
             install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -641,7 +641,7 @@ jobs:
             config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON
+              -DCURL_USE_GSASL=ON -DENABLE_ARES=OFF -DCURL_USE_LIBUV=ON
 
           - name: 'openssl'
             install: 'brotli zlib zstd        nghttp2 nghttp3 openssl libssh2'


### PR DESCRIPTION
The openssl job no longer fits into 10 minutes since the 20241015.1.0
GHA windows-latest image update. This caused all runs to fail.

The `run tests` step takes ~10 minutes now, up from ~4. This is
6 minutes more than before these updates. It's seen with other vcpkg
jobs too, tests run slower than half speed since.

Bump the timeout to make it, though the headroom is now less than it
was.

Before:
https://github.com/curl/curl/actions/runs/11386748199/job/31679733295
https://github.com/curl/curl/actions/runs/11347976608/job/31560690219

After:
https://github.com/curl/curl/actions/runs/11462332743/job/31893491625?pr=15364

Ref: https://github.com/actions/runner-images/commit/fcc4cdb1d095af1317859c4809364538953b3497
Ref: https://github.com/curl/curl/pull/15335#issuecomment-2423759953
Follow-up to 1e0305973c22b1d84036fe0c4eee34aea5cd40cc #15356
