### PR TITLE
mk-lib1521.pl: fix the long return code check

### DIFF
--- a/tests/libtest/mk-lib1521.pl
+++ b/tests/libtest/mk-lib1521.pl
@@ -441,7 +441,7 @@ MOO
 MOO
             ;
         my $flongcheckzero = <<MOO
-    if(first && present(first) && !bad_long(res,
+    if(first && present(first) && !bad_long(first,
        $name))
       errlongzero("$name", first, __LINE__);
 MOO
@@ -594,7 +594,6 @@ MOO
 
 print $fh <<FOOTER
   )
-
   curl_easy_setopt(curl, (CURLoption)1, 0);
   res = CURLE_OK;
 test_cleanup:


### PR DESCRIPTION
It worked mostly by accident since it checked the variable from the *previous* setopt invoke.

Bonus: this disables deprecation differently. Using the CURL_IGNORE_DEPRECATION() style works, but it makes the code infuriatingly annoying to work with when single-stepping in a debugger. 