### PR TITLE
GHA: use `--no-install-suggests --no-install-recommends` where missing

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -42,7 +42,8 @@ jobs:
   #      - name: install prereqs
   #        run: |
   #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-  #          sudo apt-get install python3-proselint
+  #          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+  #            python3-proselint
   #
   #      # config file help: https://github.com/amperser/proselint/
   #      - name: create proselint config

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -41,7 +41,7 @@ jobs:
   #
   #      - name: install prereqs
   #        run: |
-  #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
+  #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
   #          sudo apt-get install -y --no-install-suggests --no-install-recommends \
   #            python3-proselint
   #

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -41,7 +41,7 @@ jobs:
   #
   #      - name: install prereqs
   #        run: |
-  #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+  #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
   #          sudo apt-get install -y --no-install-suggests --no-install-recommends \
   #            python3-proselint
   #

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -160,7 +160,8 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
-          sudo apt-get install libtool autoconf automake pkgconf stunnel4 \
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+            libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \
@@ -320,7 +321,8 @@ jobs:
       - run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
-          sudo apt-get install libtool autoconf automake ninja-build pkgconf stunnel4 \
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+            libtool autoconf automake ninja-build pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -158,7 +158,7 @@ jobs:
       - name: install build prereqs
         if: steps.settings.outputs.needs-build == 'true'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
             libtool autoconf automake pkgconf stunnel4 \
@@ -319,7 +319,7 @@ jobs:
 
     steps:
       - run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
             libtool autoconf automake ninja-build pkgconf stunnel4 \

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -158,7 +158,7 @@ jobs:
       - name: install build prereqs
         if: steps.settings.outputs.needs-build == 'true'
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
             libtool autoconf automake pkgconf stunnel4 \
@@ -319,7 +319,7 @@ jobs:
 
     steps:
       - run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
             libtool autoconf automake ninja-build pkgconf stunnel4 \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -281,7 +281,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
-          sudo apt-get install -y \
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
             libtool autoconf automake pkgconf ninja-build stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev \
             ${{ matrix.build.install_packages }}
@@ -300,7 +300,8 @@ jobs:
 
       - if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          sudo apt-get install apache2 apache2-dev libnghttp2-dev vsftpd
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+            apache2 apache2-dev libnghttp2-dev vsftpd
         name: 'install prereqs for pytest'
 
       - if: startsWith(matrix.build.container, 'alpine')

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -279,7 +279,8 @@ jobs:
     steps:
       - if: matrix.build.container == null && !contains(matrix.build.name, 'i686')
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
+          find . /etc/apt/
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
             libtool autoconf automake pkgconf ninja-build stunnel4 \
@@ -289,7 +290,7 @@ jobs:
 
       - if: contains(matrix.build.name, 'i686')
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -279,8 +279,7 @@ jobs:
     steps:
       - if: matrix.build.container == null && !contains(matrix.build.name, 'i686')
         run: |
-          find . /etc/apt/
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
             libtool autoconf automake pkgconf ninja-build stunnel4 \
@@ -290,7 +289,7 @@ jobs:
 
       - if: contains(matrix.build.name, 'i686')
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list /etc/apt/sources.list.d/azure-cli.sources
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -279,6 +279,7 @@ jobs:
     steps:
       - if: matrix.build.container == null && !contains(matrix.build.name, 'i686')
         run: |
+          find . /etc/apt/
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -279,7 +279,6 @@ jobs:
     steps:
       - if: matrix.build.container == null && !contains(matrix.build.name, 'i686')
         run: |
-          find . /etc/apt/
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \


### PR DESCRIPTION
It prevents `apt-get install` commands installing unnecessary packages.

Makes the 8 HTTP/3 jobs around 30 seconds faster each.

before: https://github.com/curl/curl/actions/runs/11466168597
after: https://github.com/curl/curl/actions/runs/11469013245?pr=15373
