### PR TITLE
runtests: use deterministic sort for `TESTINFO` lines

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3147,7 +3147,7 @@ if(%skipped && !$short) {
         $log_line .= ")\n";
         $restraints{$log_line} = $skip_count;
     }
-    foreach my $log_line (sort {$restraints{$b} <=> $restraints{$a} || $a cmp $b} keys %restraints) {
+    foreach my $log_line (sort {$restraints{$b} <=> $restraints{$a} || uc($a) cmp uc($b)} keys %restraints) {
         logmsg $log_line;
     }
 }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3147,7 +3147,7 @@ if(%skipped && !$short) {
         $log_line .= ")\n";
         $restraints{$log_line} = $skip_count;
     }
-    foreach my $log_line (sort {$restraints{$b} <=> $restraints{$a} || $b cmp $a} keys %restraints) {
+    foreach my $log_line (sort {$restraints{$b} <=> $restraints{$a} || $a cmp $b} keys %restraints) {
         logmsg $log_line;
     }
 }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3147,7 +3147,7 @@ if(%skipped && !$short) {
         $log_line .= ")\n";
         $restraints{$log_line} = $skip_count;
     }
-    foreach my $log_line (sort {$restraints{$b} <=> $restraints{$a}} keys %restraints) {
+    foreach my $log_line (sort {$restraints{$b} <=> $restraints{$a} || $b cmp $a} keys %restraints) {
         logmsg $log_line;
     }
 }


### PR DESCRIPTION
Sort TESTINFO lines by description within the number of skipped test.
It makes the list of skipped test groups easier to diff/compare between
jobs and runs.
