### PR TITLE
GHA/linux: drop patch from openssl3 thread sanitizer

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -229,7 +229,7 @@ jobs:
 
           - name: thread-sanitizer
             install_packages: zlib1g-dev clang libtsan2
-            install_steps: pytest openssltsan3
+            install_steps: pytest openssl3-tsan
             configure: >-
               CC=clang
               CFLAGS="-fsanitize=thread -g"
@@ -423,26 +423,21 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: cache openssltsan3
-        if: contains(matrix.build.install_steps, 'openssltsan3')
+      - name: cache openssl3-tsan
+        if: contains(matrix.build.install_steps, 'openssl3-tsan')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
-        id: cache-openssltsan3
+        id: cache-openssl3-tsan
         env:
-          cache-name: cache-openssltsan3
+          cache-name: cache-openssl3-tsan
         with:
           path: /home/runner/openssl3
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl3-version }}-d8def798
 
-      - name: 'install openssltsan3'
-        if: contains(matrix.build.install_steps, 'openssltsan3') && steps.cache-openssltsan3.outputs.cache-hit != 'true'
-        # There are global data race in openssl:
-        # Cherry-Pick the fix for testing https://github.com/openssl/openssl/pull/24782
-        # Drop this when bumping to OpenSSL 3.4.0 or upper.
+      - name: 'build openssl3 (thread sanitizer)'
+        if: contains(matrix.build.install_steps, 'openssl3-tsan') && steps.cache-openssl3-tsan.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl3-version }} https://github.com/openssl/openssl
           cd openssl
-          git fetch --quiet --depth=2 origin d8def79838cd0d5e7c21d217aa26edb5229f0ab4
-          git cherry-pick -n d8def79838cd0d5e7c21d217aa26edb5229f0ab4
           CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl3 --libdir=lib
           make -j1 install_sw
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -314,7 +314,7 @@ jobs:
 
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
 
-      - name: Fix kernel mmap rnd bits
+      - name: 'Fix kernel mmap rnd bits'
         # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
         # high-entropy ASLR in much newer kernels that GitHub runners are
         # using leading to random crashes: https://reviews.llvm.org/D148280
@@ -322,7 +322,7 @@ jobs:
         continue-on-error: true
         run: sudo sysctl vm.mmap_rnd_bits=28
 
-      - name: cache bearssl
+      - name: 'cache bearssl'
         if: contains(matrix.build.install_steps, 'bearssl')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-bearssl
@@ -343,7 +343,7 @@ jobs:
           cp inc/*.h $HOME/bearssl/include
           cp build/libbearssl.* $HOME/bearssl/lib
 
-      - name: cache libressl
+      - name: 'cache libressl'
         if: contains(matrix.build.install_steps, 'libressl')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-libressl
@@ -362,7 +362,7 @@ jobs:
           ./configure --disable-dependency-tracking --prefix=$HOME/libressl
           make install
 
-      - name: cache wolfssl (all)
+      - name: 'cache wolfssl (all)'
         if: contains(matrix.build.install_steps, 'wolfssl-all')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-wolfssl-all
@@ -382,7 +382,7 @@ jobs:
           ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-all --enable-all
           make install
 
-      - name: cache wolfssl (opensslextra)
+      - name: 'cache wolfssl (opensslextra)'
         if: contains(matrix.build.install_steps, 'wolfssl-opensslextra')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-wolfssl-opensslextra
@@ -402,7 +402,7 @@ jobs:
           ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-opensslextra --enable-opensslextra
           make install
 
-      - name: cache mbedtls
+      - name: 'cache mbedtls'
         if: contains(matrix.build.install_steps, 'mbedtls')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-mbedtls
@@ -423,7 +423,7 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: cache openssl (thread sanitizer)
+      - name: 'cache openssl (thread sanitizer)'
         if: contains(matrix.build.install_steps, 'openssl-tsan')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-openssl-tsan
@@ -441,7 +441,7 @@ jobs:
           CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl3 --libdir=lib
           make -j1 install_sw
 
-      - name: cache quictls
+      - name: 'cache quictls'
         if: contains(matrix.build.install_steps, 'quictls')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-quictls
@@ -459,7 +459,7 @@ jobs:
           ./config --prefix=$HOME/quictls --libdir=lib
           make -j1 install_sw
 
-      - name: cache msh3
+      - name: 'cache msh3'
         if: contains(matrix.build.install_steps, 'msh3')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-msh3
@@ -478,7 +478,7 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: cache awslc
+      - name: 'cache awslc'
         if: contains(matrix.build.install_steps, 'awslc')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-awslc
@@ -488,7 +488,7 @@ jobs:
           path: /home/runner/awslc
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.awslc-version }}
 
-      - name: build awslc
+      - name: 'build awslc'
         if: contains(matrix.build.install_steps, 'awslc') && steps.cache-awslc.outputs.cache-hit != 'true'
         run: |
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 \
@@ -500,7 +500,7 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: cache rustls
+      - name: 'cache rustls'
         if: contains(matrix.build.install_steps, 'rustls')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-rustls
@@ -579,7 +579,7 @@ jobs:
             ${{ matrix.build.make-prefix }} make V=1
           fi
 
-      - name: single-use function check
+      - name: 'single-use function check'
         if: ${{ contains(matrix.build.configure, '--disable-unity') || contains(matrix.build.generate, '-DCMAKE_UNITY_BUILD=OFF') }}
         run: |
           git config --global --add safe.directory "*"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -229,7 +229,7 @@ jobs:
 
           - name: thread-sanitizer
             install_packages: zlib1g-dev clang libtsan2
-            install_steps: pytest openssl3-tsan
+            install_steps: pytest openssl-tsan
             configure: >-
               CC=clang
               CFLAGS="-fsanitize=thread -g"
@@ -423,18 +423,18 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: cache openssl3-tsan
-        if: contains(matrix.build.install_steps, 'openssl3-tsan')
+      - name: cache openssl-tsan
+        if: contains(matrix.build.install_steps, 'openssl-tsan')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
-        id: cache-openssl3-tsan
+        id: cache-openssl-tsan
         env:
-          cache-name: cache-openssl3-tsan
+          cache-name: cache-openssl-tsan
         with:
           path: /home/runner/openssl3
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl3-version }}-d8def798
 
-      - name: 'build openssl3 (thread sanitizer)'
-        if: contains(matrix.build.install_steps, 'openssl3-tsan') && steps.cache-openssl3-tsan.outputs.cache-hit != 'true'
+      - name: 'build openssl (thread sanitizer)'
+        if: contains(matrix.build.install_steps, 'openssl-tsan') && steps.cache-openssl-tsan.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl3-version }} https://github.com/openssl/openssl
           cd openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -423,7 +423,7 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: cache openssl-tsan
+      - name: cache openssl (thread sanitizer)
         if: contains(matrix.build.install_steps, 'openssl-tsan')
         uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4
         id: cache-openssl-tsan


### PR DESCRIPTION
The patch is now part of the 3.4.0 stable release.
(Turns out it was part of 3.3.2 already.)

Also:
- rename this local build to match the scheme used with wolfssl.
- drop '3' from local openssl build name.
- sync job name with others.
- quote step names where missing.

Follow-up to a2bcec0ee0895c23b98aea8e72ad4e9278fa67c8 #14751
