### PR TITLE
GHA/windows: work around Git for Windows perf regression

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -614,7 +614,7 @@ jobs:
     timeout-minutes: 55
     defaults:
       run:
-        shell: bash
+        shell: C:\msys64\usr\bin\bash.exe {0}
     env:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
       VCPKG_DISABLE_METRICS: '1'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -797,7 +797,7 @@ jobs:
 
       - name: 'cmake run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
-        timeout-minutes: 12
+        timeout-minutes: 10
         run: |
           export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
           TFLAGS+=' ~987'  # 'SMTPS with redundant explicit SSL request'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -737,6 +737,7 @@ jobs:
       - name: 'cmake configure'
         timeout-minutes: 5
         run: |
+          PATH="/c/msys64/usr/bin:$PATH"
           cmake -B bld ${options} \
             "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
             "-DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed" \
@@ -762,7 +763,9 @@ jobs:
 
       - name: 'cmake build'
         timeout-minutes: 5
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
+        run: |
+          PATH="/c/msys64/usr/bin:$PATH"
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
         timeout-minutes: 1
@@ -776,7 +779,9 @@ jobs:
       - name: 'cmake build tests'
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
+        run: |
+          PATH="/c/msys64/usr/bin:$PATH"
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -802,8 +807,11 @@ jobs:
             TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
+          PATH="/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'cmake build examples'
         timeout-minutes: 5
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
+        run: |
+          PATH="/c/msys64/usr/bin:$PATH"
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -800,7 +800,6 @@ jobs:
         timeout-minutes: 10
         run: |
           export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
-          TFLAGS+=' ~987'  # 'SMTPS with redundant explicit SSL request'
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SFTP'
           elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then


### PR DESCRIPTION
Fix the significant perf regression for vcpkg jobs by switching to the
MSYS2 shell environment from Git for Windows. This env is already used
for old-mingw-w64 job that remained unaffected by this issue.

The issue began with the windows-runner update 20241015.1.0. It bumped
Git for Windows from Git 2.46.2.windows.1 to Git 2.47.0.windows.1. GfW
bumped its MSYS2 components, including `msys-2.0.dll`. That's Cygwin
code, which may have contributed to this. Pipes were involved and
`runtests.pl` relies on pipes heavily in parallel mode. (The issue was
not seen with parallel tests disabled, in retrospect.)

This is useful as a permanent solution too. It drop GfW as a dependency
and makes Windows jobs use one less shell/env flavour.

Long term it might help to use native Windows Perl to avoid the MSYS
layer completely, if there is a way to make that work.

Assortment of possibly related links:
https://cygwin.com/pipermail/cygwin/2024-August/256398.html
https://github.com/cygwin/cygwin/commit/f78009cb1ccf84cc343cf2441c76196461d87532
https://github.com/cygwin/cygwin/commit/7f3c22532577ae0a926e8eb8ad63787c9841abbf

https://github.com/actions/runner-images/issues/10843
https://github.com/git-for-windows/git/issues/5199
https://github.com/git-for-windows/msys2-runtime/pull/75
https://github.com/git-for-windows/msys2-runtime/commit/7913a41703dbc476ad3cf1b85e6939ebbe524251
https://github.com/git-for-windows/msys2-runtime/commit/555afcb2f3a6638084912ce1011bd6acef59ea79
https://github.com/cygwin/cygwin/commit/1c5f4dcdc5ec3344e3fd741c43fa359d0e1323c0

Follow-up to c33174d42fc8a4a0625b46f1d09f5e79eb2abbf1 #15364
Follow-up to 1e0305973c22b1d84036fe0c4eee34aea5cd40cc #15356
