### PR TITLE
libssh2: delete duplicate `break`

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2492,7 +2492,6 @@ static CURLcode ssh_statemachine(struct Curl_easy *data, bool *block)
         state(data, SSH_SFTP_CLOSE);
       }
       break;
-      break;
 
     case SSH_SFTP_READDIR_LINK:
       rc =


### PR DESCRIPTION
```
lib/vssh/libssh2.c:2495:7: warning: 'break' will never be executed [-Wunreachable-code-break]
      break;
      ^~~~~
```

CI did not catch it due to llvm skipping this check for all #included
files. It's designed this way to avoid performance issues and false
positive when checking headers:                
https://github.com/llvm/llvm-project/issues/71046
