### PR TITLE
[ngtcp2] set max window size to 10x of initial (128KB), as the quiche backend does

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -429,7 +429,7 @@ static void quic_settings(struct cf_ngtcp2_ctx *ctx,
   s->initial_ts = pktx->ts;
   s->handshake_timeout = QUIC_HANDSHAKE_TIMEOUT;
   s->max_window = 100 * ctx->max_stream_window;
-  s->max_stream_window = ctx->max_stream_window;
+  s->max_stream_window = 10 * ctx->max_stream_window;
 
   t->initial_max_data = 10 * ctx->max_stream_window;
   t->initial_max_stream_data_bidi_local = ctx->max_stream_window;


### PR DESCRIPTION
QUIC backends use flow control windows initially set to 128KB. In #14880, the maximum size used by the quiche backend was increased to 1280KB, but that of the ngtcp2 backend remained at 128KB.

With a window size of 128KB, the sustained maximum throughput with the ngtcp2 backend has been equivalent to TCP without the window scaling option (note: ngtcp2 sends MAX_STREAM_DATA when 1/2 the window is consumed, while TCP updates the window size with each ACK).

This PR changes the ngtcp2 backend to use the same maximum (1280KB) as the quiche backend does.