### PR TITLE
version: minor cleanups

### DIFF
--- a/lib/version.c
+++ b/lib/version.c
@@ -93,20 +93,52 @@ static void brotli_version(char *buf, size_t bufsz)
   unsigned int major = brotli_version >> 24;
   unsigned int minor = (brotli_version & 0x00FFFFFF) >> 12;
   unsigned int patch = brotli_version & 0x00000FFF;
-  (void)msnprintf(buf, bufsz, "%u.%u.%u", major, minor, patch);
+  (void)msnprintf(buf, bufsz, "brotli/%u.%u.%u", major, minor, patch);
 }
 #endif
 
 #ifdef HAVE_ZSTD
 static void zstd_version(char *buf, size_t bufsz)
 {
-  unsigned long zstd_version = (unsigned long)ZSTD_versionNumber();
-  unsigned int major = (unsigned int)(zstd_version / (100 * 100));
-  unsigned int minor = (unsigned int)((zstd_version -
-                                       (major * 100 * 100)) / 100);
-  unsigned int patch = (unsigned int)(zstd_version -
-                                      (major * 100 * 100) - (minor * 100));
-  (void)msnprintf(buf, bufsz, "%u.%u.%u", major, minor, patch);
+  unsigned int version = ZSTD_versionNumber();
+  unsigned int major = (version / (100 * 100));
+  unsigned int minor = ((version - (major * 100 * 100)) / 100);
+  unsigned int patch = (version - (major * 100 * 100) - (minor * 100));
+  (void)msnprintf(buf, bufsz, "zstd/%u.%u.%u", major, minor, patch);
+}
+#endif
+
+#ifdef USE_OPENLDAP
+static void oldap_version(char *buf, size_t bufsz)
+{
+  LDAPAPIInfo api;
+  api.ldapai_info_version = LDAP_API_INFO_VERSION;
+
+  if(ldap_get_option(NULL, LDAP_OPT_API_INFO, &api) == LDAP_OPT_SUCCESS) {
+    unsigned int patch = (unsigned int)(api.ldapai_vendor_version % 100);
+    unsigned int major = (unsigned int)(api.ldapai_vendor_version / 10000);
+    unsigned int minor =
+      (((unsigned int)api.ldapai_vendor_version - major * 10000)
+       - patch) / 100;
+    msnprintf(buf, bufsz, "%s/%u.%u.%u",
+              api.ldapai_vendor_name, major, minor, patch);
+    ldap_memfree(api.ldapai_vendor_name);
+    ber_memvfree((void **)api.ldapai_extensions);
+  }
+}
+#endif
+
+#ifdef USE_LIBPSL
+static void psl_version(char *buf, size_t bufsz)
+{
+#if defined(PSL_VERSION_MAJOR) && (PSL_VERSION_MAJOR > 0 ||     \
+                                   PSL_VERSION_MINOR >= 11)
+  int num = psl_check_version_number(0);
+  msnprintf(buf, bufsz, "libpsl/%d.%d.%d",
+            num >> 16, (num >> 8) & 0xff, num & 0xff);
+#else
+  msnprintf(buf, bufsz, "libpsl/%s", psl_get_version());
+#endif
 }
 #endif
 
@@ -130,34 +162,34 @@ char *curl_version(void)
   char ssl_version[200];
 #endif
 #ifdef HAVE_LIBZ
-  char z_version[40];
+  char z_version[30];
 #endif
 #ifdef HAVE_BROTLI
-  char br_version[40] = "brotli/";
+  char br_version[30];
 #endif
 #ifdef HAVE_ZSTD
-  char zst_version[40] = "zstd/";
+  char zstd_ver[30];
 #endif
 #ifdef USE_ARES
-  char cares_version[40];
+  char cares_version[30];
 #endif
-#if defined(USE_LIBIDN2)
-  char idn_version[40];
+#ifdef USE_LIBIDN2
+  char idn_version[30];
 #endif
 #ifdef USE_LIBPSL
-  char psl_version[40];
+  char psl_ver[30];
 #endif
 #ifdef USE_SSH
-  char ssh_version[40];
+  char ssh_version[30];
 #endif
 #ifdef USE_NGHTTP2
-  char h2_version[40];
+  char h2_version[30];
 #endif
 #ifdef USE_HTTP3
-  char h3_version[40];
+  char h3_version[30];
 #endif
 #ifdef USE_LIBRTMP
-  char rtmp_version[40];
+  char rtmp_version[30];
 #endif
 #ifdef USE_HYPER
   char hyper_buf[30];
@@ -190,12 +222,12 @@ char *curl_version(void)
   src[i++] = z_version;
 #endif
 #ifdef HAVE_BROTLI
-  brotli_version(&br_version[7], sizeof(br_version) - 7);
+  brotli_version(br_version, sizeof(br_version));
   src[i++] = br_version;
 #endif
 #ifdef HAVE_ZSTD
-  zstd_version(&zst_version[5], sizeof(zst_version) - 5);
-  src[i++] = zst_version;
+  zstd_version(zstd_ver, sizeof(zstd_ver));
+  src[i++] = zstd_ver;
 #endif
 #ifdef USE_ARES
   msnprintf(cares_version, sizeof(cares_version),
@@ -211,22 +243,10 @@ char *curl_version(void)
 #elif defined(USE_APPLE_IDN)
   src[i++] = (char *)"AppleIDN";
 #endif
-
 #ifdef USE_LIBPSL
-  {
-#if defined(PSL_VERSION_MAJOR) && (PSL_VERSION_MAJOR > 0 ||     \
-                                   PSL_VERSION_MINOR >= 11)
-    int num = psl_check_version_number(0);
-    msnprintf(psl_version, sizeof(psl_version), "libpsl/%d.%d.%d",
-              num >> 16, (num >> 8) & 0xff, num & 0xff);
-#else
-    msnprintf(psl_version, sizeof(psl_version), "libpsl/%s",
-              psl_get_version());
+  psl_version(psl_ver, sizeof(psl_ver));
+  src[i++] = psl_ver;
 #endif
-    src[i++] = psl_version;
-  }
-#endif
-
 #ifdef USE_SSH
   Curl_ssh_version(ssh_version, sizeof(ssh_version));
   src[i++] = ssh_version;
@@ -253,23 +273,8 @@ char *curl_version(void)
   src[i++] = gsasl_buf;
 #endif
 #ifdef USE_OPENLDAP
-  {
-    LDAPAPIInfo api;
-    api.ldapai_info_version = LDAP_API_INFO_VERSION;
-
-    if(ldap_get_option(NULL, LDAP_OPT_API_INFO, &api) == LDAP_OPT_SUCCESS) {
-      unsigned int patch = (unsigned int)(api.ldapai_vendor_version % 100);
-      unsigned int major = (unsigned int)(api.ldapai_vendor_version / 10000);
-      unsigned int minor =
-        (((unsigned int)api.ldapai_vendor_version - major * 10000)
-          - patch) / 100;
-      msnprintf(ldap_buf, sizeof(ldap_buf), "%s/%u.%u.%u",
-                api.ldapai_vendor_name, major, minor, patch);
-      src[i++] = ldap_buf;
-      ldap_memfree(api.ldapai_vendor_name);
-      ber_memvfree((void **)api.ldapai_extensions);
-    }
-  }
+  oldap_version(ldap_buf, sizeof(ldap_buf));
+  src[i++] = ldap_buf;
 #endif
 
   DEBUGASSERT(i <= VERSION_PARTS);


### PR DESCRIPTION
- remove typecasts in zstd_version()
- create and use oldap_version() for OpenLDAP
- create and use psl_version() for libpsl
- reduce the size of the 40 byte buffers to 30 bytes
- use the brotil/zstd like the others (add the lib name in the functions)