### PR TITLE
bearssl, session handling, test exceptions

### DIFF
--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -474,12 +474,6 @@ class TestDownload:
     # make extreme parallel h2 upgrades, check invalid conn reuse
     # before protocol switch has happened
     def test_02_25_h2_upgrade_x(self, env: Env, httpd, repeat):
-        # not locally reproducible timeouts with certain SSL libs
-        # Since this test is about connection reuse handling, we skip
-        # it on these builds. Although we would certainly like to understand
-        # why this happens.
-        if env.curl_uses_lib('bearssl'):
-            pytest.skip('CI workflows timeout on bearssl build')
         url = f'http://localhost:{env.http_port}/data-100k'
         client = LocalClient(name='h2-upgrade-extreme', env=env, timeout=15)
         if not client.exists():

--- a/tests/http/test_12_reuse.py
+++ b/tests/http/test_12_reuse.py
@@ -35,7 +35,6 @@ from testenv import Env, CurlClient
 log = logging.getLogger(__name__)
 
 
-@pytest.mark.skipif(condition=Env.curl_uses_lib('bearssl'), reason='BearSSL too slow')
 @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")
 class TestReuse:
 


### PR DESCRIPTION
Add length to session saves, making it clear that we are storing a byte blob and allowing memcmp() on sameness check.

Remove some pytest skips for bearssl to see if they now work properly in CI.