### PR TITLE
cmake: use `list(APPEND)` on `CURL_INCLUDES`

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -30,7 +30,7 @@
 macro(check_include_file_concat _file _variable)
   check_include_files("${CURL_INCLUDES};${_file}" ${_variable})
   if(${_variable})
-    set(CURL_INCLUDES ${CURL_INCLUDES} ${_file})
+    list(APPEND CURL_INCLUDES ${_file})
   endif()
 endmacro()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1414,8 +1414,8 @@ endif()
 
 # Check for header files
 if(WIN32)
-  set(CURL_INCLUDES ${CURL_INCLUDES} "winsock2.h")
-  set(CURL_INCLUDES ${CURL_INCLUDES} "ws2tcpip.h")
+  list(APPEND CURL_INCLUDES "winsock2.h")
+  list(APPEND CURL_INCLUDES "ws2tcpip.h")
 
   if(HAVE_WIN32_WINNT)
     if(HAVE_WIN32_WINNT LESS 0x0501)


### PR DESCRIPTION
It does the same as the `set()` used before this patch.
Makes the code easier to read.
