### PR TITLE
cmake: tidy up picky warning initialization

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -242,11 +242,11 @@ endif()
 # clang-cl
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND MSVC)
   # list(TRANSFORM WPICKY PREPEND "/clang:") # since CMake 3.12
-  set(_wpicky "")
+  set(_wpicky_tmp "")
   foreach(_ccopt IN LISTS WPICKY)
-    list(APPEND _wpicky "/clang:${_ccopt}")
+    list(APPEND _wpicky_tmp "/clang:${_ccopt}")
   endforeach()
-  set(WPICKY ${_wpicky})
+  set(WPICKY ${_wpicky_tmp})
 endif()
 
 if(WPICKY)

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -225,14 +225,12 @@ if(PICKY_COMPILER)
     endforeach()
 
     foreach(_ccopt IN LISTS _picky_detect)
-      # Surprisingly, check_c_compiler_flag() needs a new variable to store each new
-      # test result in.
-      string(MAKE_C_IDENTIFIER "OPT${_ccopt}" _optvarname)
       # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,
       # so test for the positive form instead
       string(REPLACE "-Wno-" "-W" _ccopt_on "${_ccopt}")
-      check_c_compiler_flag(${_ccopt_on} ${_optvarname})
-      if(${_optvarname})
+      unset(_have_ccopt CACHE)
+      check_c_compiler_flag(${_ccopt_on} _have_ccopt)
+      if(_have_ccopt)
         list(APPEND _picky "${_ccopt}")
       endif()
     endforeach()

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -241,12 +241,15 @@ endif()
 
 # clang-cl
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND MSVC)
-  # list(TRANSFORM _picky PREPEND "/clang:") # since CMake 3.12
-  set(_picky_tmp "")
-  foreach(_ccopt IN LISTS _picky)
-    list(APPEND _picky_tmp "/clang:${_ccopt}")
-  endforeach()
-  set(_picky ${_picky_tmp})
+  if(CMAKE_VERSION VERSION_LESS 3.12)
+    set(_picky_tmp "")
+    foreach(_ccopt IN LISTS _picky)
+      list(APPEND _picky_tmp "/clang:${_ccopt}")
+    endforeach()
+    set(_picky ${_picky_tmp})
+  else()
+    list(TRANSFORM _picky PREPEND "/clang:")
+  endif()
 endif()
 
 if(_picky)

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -226,7 +226,7 @@ if(PICKY_COMPILER)
 
     foreach(_ccopt IN LISTS _picky_detect)
       # Use a unique variable name 1. for meaningful log output 2. to have a fresh, undefined variable for each detection
-      string(MAKE_C_IDENTIFIER "OPT${_ccopt}" _optvarname)
+      string(MAKE_C_IDENTIFIER "HAVE${_ccopt}" _optvarname)
       # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,
       # so test for the positive form instead
       string(REPLACE "-Wno-" "-W" _ccopt_on "${_ccopt}")

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -226,7 +226,7 @@ if(PICKY_COMPILER)
 
     foreach(_ccopt IN LISTS _picky_detect)
       # Use a unique variable name 1. for meaningful log output 2. to have a fresh, undefined variable for each detection
-      string(MAKE_C_IDENTIFIER "HAVE${_ccopt}" _optvarname)
+      string(MAKE_C_IDENTIFIER "OPT${_ccopt}" _optvarname)
       # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,
       # so test for the positive form instead
       string(REPLACE "-Wno-" "-W" _ccopt_on "${_ccopt}")

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -23,24 +23,24 @@
 ###########################################################################
 include(CheckCCompilerFlag)
 
-unset(_wpicky)
+unset(_picky)
 
 if(CURL_WERROR AND
    ((CMAKE_COMPILER_IS_GNUCC AND
      NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0 AND
      NOT CMAKE_VERSION VERSION_LESS 3.23.0) OR  # to avoid check_symbol_exists() conflicting with GCC -pedantic-errors
    CMAKE_C_COMPILER_ID MATCHES "Clang"))
-  list(APPEND _wpicky "-pedantic-errors")
+  list(APPEND _picky "-pedantic-errors")
 endif()
 
 if(APPLE AND
    (CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
    (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
-  list(APPEND _wpicky "-Werror=partial-availability")  # clang 3.6  appleclang 6.3
+  list(APPEND _picky "-Werror=partial-availability")  # clang 3.6  appleclang 6.3
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-  list(APPEND _wpicky "-Werror-implicit-function-declaration")  # clang 1.0  gcc 2.95
+  list(APPEND _picky "-Werror-implicit-function-declaration")  # clang 1.0  gcc 2.95
 endif()
 
 if(PICKY_COMPILER)
@@ -49,29 +49,29 @@ if(PICKY_COMPILER)
     # https://clang.llvm.org/docs/DiagnosticsReference.html
     # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
 
-    # _wpicky_enable = Options we want to enable as-is.
-    # _wpicky_detect = Options we want to test first and enable if available.
+    # _picky_enable = Options we want to enable as-is.
+    # _picky_detect = Options we want to test first and enable if available.
 
     # Prefer the -Wextra alias with clang.
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      set(_wpicky_enable "-Wextra")
+      set(_picky_enable "-Wextra")
     else()
-      set(_wpicky_enable "-W")
+      set(_picky_enable "-W")
     endif()
 
-    list(APPEND _wpicky_enable
+    list(APPEND _picky_enable
       -Wall -pedantic
     )
 
     # ----------------------------------
     # Add new options here, if in doubt:
     # ----------------------------------
-    set(_wpicky_detect
+    set(_picky_detect
     )
 
     # Assume these options always exist with both clang and gcc.
     # Require clang 3.0 / gcc 2.95 or later.
-    list(APPEND _wpicky_enable
+    list(APPEND _picky_enable
       -Wbad-function-cast                  # clang  2.7  gcc  2.95
       -Wconversion                         # clang  2.7  gcc  2.95
       -Winline                             # clang  1.0  gcc  1.0
@@ -89,7 +89,7 @@ if(PICKY_COMPILER)
     )
 
     # Always enable with clang, version dependent with gcc
-    set(_wpicky_common_old
+    set(_picky_common_old
       -Waddress                            # clang  2.7  gcc  4.3
       -Wattributes                         # clang  2.7  gcc  4.1
       -Wcast-align                         # clang  1.0  gcc  4.2
@@ -118,7 +118,7 @@ if(PICKY_COMPILER)
       -Wvla                                # clang  2.8  gcc  4.3
     )
 
-    set(_wpicky_common
+    set(_picky_common
       -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
       -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
       -Wpragmas                            # clang  3.5  gcc  4.1  appleclang  6.0
@@ -126,8 +126,8 @@ if(PICKY_COMPILER)
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      list(APPEND _wpicky_enable
-        ${_wpicky_common_old}
+      list(APPEND _picky_enable
+        ${_picky_common_old}
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
         -Wlanguage-extension-token         # clang  3.0
@@ -136,8 +136,8 @@ if(PICKY_COMPILER)
       # Enable based on compiler version
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
-        list(APPEND _wpicky_enable
-          ${_wpicky_common}
+        list(APPEND _picky_enable
+          ${_picky_common}
           -Wunreachable-code-break         # clang  3.5            appleclang  6.0
           -Wheader-guard                   # clang  3.4            appleclang  5.1
           -Wsometimes-uninitialized        # clang  3.2            appleclang  4.6
@@ -145,32 +145,32 @@ if(PICKY_COMPILER)
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.3))
-        list(APPEND _wpicky_enable
+        list(APPEND _picky_enable
           -Wcomma                          # clang  3.9            appleclang  8.3
           -Wmissing-variable-declarations  # clang  3.2            appleclang  4.6
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.3))
-        list(APPEND _wpicky_enable
+        list(APPEND _picky_enable
           -Wassign-enum                    # clang  7.0            appleclang 10.3
           -Wextra-semi-stmt                # clang  7.0            appleclang 10.3
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 12.4))
-        list(APPEND _wpicky_enable
+        list(APPEND _picky_enable
           -Wimplicit-fallthrough           # clang  4.0  gcc  7.0  appleclang 12.4  # We do silencing for clang 10.0 and above only
         )
       endif()
     else()  # gcc
-      list(APPEND _wpicky_detect
-        ${_wpicky_common}
+      list(APPEND _picky_detect
+        ${_picky_common}
       )
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
-        list(APPEND _wpicky_enable
-          ${_wpicky_common_old}
+        list(APPEND _picky_enable
+          ${_picky_common_old}
           -Wclobbered                      #             gcc  4.3
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
@@ -179,22 +179,22 @@ if(PICKY_COMPILER)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.5 AND MINGW)
-        list(APPEND _wpicky_enable
+        list(APPEND _picky_enable
           -Wno-pedantic-ms-format          #             gcc  4.5 (MinGW-only)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8)
-        list(APPEND _wpicky_enable
+        list(APPEND _picky_enable
           -Wformat=2                       # clang  3.0  gcc  4.8
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
-        list(APPEND _wpicky_enable
+        list(APPEND _picky_enable
           -Warray-bounds=2 -ftree-vrp      # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
-        list(APPEND _wpicky_enable
+        list(APPEND _picky_enable
           -Wduplicated-cond                #             gcc  6.0
           -Wnull-dereference               # clang  3.0  gcc  6.0 (clang default)
             -fdelete-null-pointer-checks
@@ -203,7 +203,7 @@ if(PICKY_COMPILER)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0)
-        list(APPEND _wpicky_enable
+        list(APPEND _picky_enable
           -Walloc-zero                     #             gcc  7.0
           -Wduplicated-branches            #             gcc  7.0
           -Wformat-truncation=2            #             gcc  7.0
@@ -212,7 +212,7 @@ if(PICKY_COMPILER)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0)
-        list(APPEND _wpicky_enable
+        list(APPEND _picky_enable
           -Warith-conversion               #             gcc 10.0
         )
       endif()
@@ -220,11 +220,11 @@ if(PICKY_COMPILER)
 
     #
 
-    foreach(_ccopt IN LISTS _wpicky_enable)
-      list(APPEND _wpicky "${_ccopt}")
+    foreach(_ccopt IN LISTS _picky_enable)
+      list(APPEND _picky "${_ccopt}")
     endforeach()
 
-    foreach(_ccopt IN LISTS _wpicky_detect)
+    foreach(_ccopt IN LISTS _picky_detect)
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
       # test result in.
       string(MAKE_C_IDENTIFIER "OPT${_ccopt}" _optvarname)
@@ -233,7 +233,7 @@ if(PICKY_COMPILER)
       string(REPLACE "-Wno-" "-W" _ccopt_on "${_ccopt}")
       check_c_compiler_flag(${_ccopt_on} ${_optvarname})
       if(${_optvarname})
-        list(APPEND _wpicky "${_ccopt}")
+        list(APPEND _picky "${_ccopt}")
       endif()
     endforeach()
   endif()
@@ -241,16 +241,16 @@ endif()
 
 # clang-cl
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND MSVC)
-  # list(TRANSFORM _wpicky PREPEND "/clang:") # since CMake 3.12
-  set(_wpicky_tmp "")
-  foreach(_ccopt IN LISTS _wpicky)
-    list(APPEND _wpicky_tmp "/clang:${_ccopt}")
+  # list(TRANSFORM _picky PREPEND "/clang:") # since CMake 3.12
+  set(_picky_tmp "")
+  foreach(_ccopt IN LISTS _picky)
+    list(APPEND _picky_tmp "/clang:${_ccopt}")
   endforeach()
-  set(_wpicky ${_wpicky_tmp})
+  set(_picky ${_picky_tmp})
 endif()
 
-if(_wpicky)
-  string(REPLACE ";" " " _wpicky "${_wpicky}")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_wpicky}")
-  message(STATUS "Picky compiler options:${_wpicky}")
+if(_picky)
+  string(REPLACE ";" " " _picky "${_picky}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_picky}")
+  message(STATUS "Picky compiler options:${_picky}")
 endif()

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -225,8 +225,7 @@ if(PICKY_COMPILER)
     endforeach()
 
     foreach(_ccopt IN LISTS _picky_detect)
-      # Surprisingly, check_c_compiler_flag() needs a new variable to store each new
-      # test result in.
+      # Use a unique variable name 1. for meaningful log output 2. to have a fresh, undefined variable for each detection
       string(MAKE_C_IDENTIFIER "OPT${_ccopt}" _optvarname)
       # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,
       # so test for the positive form instead

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -23,24 +23,24 @@
 ###########################################################################
 include(CheckCCompilerFlag)
 
-unset(WPICKY)
+unset(_wpicky)
 
 if(CURL_WERROR AND
    ((CMAKE_COMPILER_IS_GNUCC AND
      NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0 AND
      NOT CMAKE_VERSION VERSION_LESS 3.23.0) OR  # to avoid check_symbol_exists() conflicting with GCC -pedantic-errors
    CMAKE_C_COMPILER_ID MATCHES "Clang"))
-  list(APPEND WPICKY "-pedantic-errors")
+  list(APPEND _wpicky "-pedantic-errors")
 endif()
 
 if(APPLE AND
    (CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
    (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
-  list(APPEND WPICKY "-Werror=partial-availability")  # clang 3.6  appleclang 6.3
+  list(APPEND _wpicky "-Werror=partial-availability")  # clang 3.6  appleclang 6.3
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-  list(APPEND WPICKY "-Werror-implicit-function-declaration")  # clang 1.0  gcc 2.95
+  list(APPEND _wpicky "-Werror-implicit-function-declaration")  # clang 1.0  gcc 2.95
 endif()
 
 if(PICKY_COMPILER)
@@ -49,29 +49,29 @@ if(PICKY_COMPILER)
     # https://clang.llvm.org/docs/DiagnosticsReference.html
     # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
 
-    # WPICKY_ENABLE = Options we want to enable as-is.
-    # WPICKY_DETECT = Options we want to test first and enable if available.
+    # _wpicky_enable = Options we want to enable as-is.
+    # _wpicky_detect = Options we want to test first and enable if available.
 
     # Prefer the -Wextra alias with clang.
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      set(WPICKY_ENABLE "-Wextra")
+      set(_wpicky_enable "-Wextra")
     else()
-      set(WPICKY_ENABLE "-W")
+      set(_wpicky_enable "-W")
     endif()
 
-    list(APPEND WPICKY_ENABLE
+    list(APPEND _wpicky_enable
       -Wall -pedantic
     )
 
     # ----------------------------------
     # Add new options here, if in doubt:
     # ----------------------------------
-    set(WPICKY_DETECT
+    set(_wpicky_detect
     )
 
     # Assume these options always exist with both clang and gcc.
     # Require clang 3.0 / gcc 2.95 or later.
-    list(APPEND WPICKY_ENABLE
+    list(APPEND _wpicky_enable
       -Wbad-function-cast                  # clang  2.7  gcc  2.95
       -Wconversion                         # clang  2.7  gcc  2.95
       -Winline                             # clang  1.0  gcc  1.0
@@ -89,7 +89,7 @@ if(PICKY_COMPILER)
     )
 
     # Always enable with clang, version dependent with gcc
-    set(WPICKY_COMMON_OLD
+    set(_wpicky_common_old
       -Waddress                            # clang  2.7  gcc  4.3
       -Wattributes                         # clang  2.7  gcc  4.1
       -Wcast-align                         # clang  1.0  gcc  4.2
@@ -118,7 +118,7 @@ if(PICKY_COMPILER)
       -Wvla                                # clang  2.8  gcc  4.3
     )
 
-    set(WPICKY_COMMON
+    set(_wpicky_common
       -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
       -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
       -Wpragmas                            # clang  3.5  gcc  4.1  appleclang  6.0
@@ -126,8 +126,8 @@ if(PICKY_COMPILER)
     )
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-      list(APPEND WPICKY_ENABLE
-        ${WPICKY_COMMON_OLD}
+      list(APPEND _wpicky_enable
+        ${_wpicky_common_old}
         -Wshift-sign-overflow              # clang  2.9
         -Wshorten-64-to-32                 # clang  1.0
         -Wlanguage-extension-token         # clang  3.0
@@ -136,8 +136,8 @@ if(PICKY_COMPILER)
       # Enable based on compiler version
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
-        list(APPEND WPICKY_ENABLE
-          ${WPICKY_COMMON}
+        list(APPEND _wpicky_enable
+          ${_wpicky_common}
           -Wunreachable-code-break         # clang  3.5            appleclang  6.0
           -Wheader-guard                   # clang  3.4            appleclang  5.1
           -Wsometimes-uninitialized        # clang  3.2            appleclang  4.6
@@ -145,32 +145,32 @@ if(PICKY_COMPILER)
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 8.3))
-        list(APPEND WPICKY_ENABLE
+        list(APPEND _wpicky_enable
           -Wcomma                          # clang  3.9            appleclang  8.3
           -Wmissing-variable-declarations  # clang  3.2            appleclang  4.6
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.3))
-        list(APPEND WPICKY_ENABLE
+        list(APPEND _wpicky_enable
           -Wassign-enum                    # clang  7.0            appleclang 10.3
           -Wextra-semi-stmt                # clang  7.0            appleclang 10.3
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 12.4))
-        list(APPEND WPICKY_ENABLE
+        list(APPEND _wpicky_enable
           -Wimplicit-fallthrough           # clang  4.0  gcc  7.0  appleclang 12.4  # We do silencing for clang 10.0 and above only
         )
       endif()
     else()  # gcc
-      list(APPEND WPICKY_DETECT
-        ${WPICKY_COMMON}
+      list(APPEND _wpicky_detect
+        ${_wpicky_common}
       )
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
-        list(APPEND WPICKY_ENABLE
-          ${WPICKY_COMMON_OLD}
+        list(APPEND _wpicky_enable
+          ${_wpicky_common_old}
           -Wclobbered                      #             gcc  4.3
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
@@ -179,22 +179,22 @@ if(PICKY_COMPILER)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.5 AND MINGW)
-        list(APPEND WPICKY_ENABLE
+        list(APPEND _wpicky_enable
           -Wno-pedantic-ms-format          #             gcc  4.5 (MinGW-only)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8)
-        list(APPEND WPICKY_ENABLE
+        list(APPEND _wpicky_enable
           -Wformat=2                       # clang  3.0  gcc  4.8
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.0)
-        list(APPEND WPICKY_ENABLE
+        list(APPEND _wpicky_enable
           -Warray-bounds=2 -ftree-vrp      # clang  3.0  gcc  5.0 (clang default: -Warray-bounds)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.0)
-        list(APPEND WPICKY_ENABLE
+        list(APPEND _wpicky_enable
           -Wduplicated-cond                #             gcc  6.0
           -Wnull-dereference               # clang  3.0  gcc  6.0 (clang default)
             -fdelete-null-pointer-checks
@@ -203,7 +203,7 @@ if(PICKY_COMPILER)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0)
-        list(APPEND WPICKY_ENABLE
+        list(APPEND _wpicky_enable
           -Walloc-zero                     #             gcc  7.0
           -Wduplicated-branches            #             gcc  7.0
           -Wformat-truncation=2            #             gcc  7.0
@@ -212,7 +212,7 @@ if(PICKY_COMPILER)
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0)
-        list(APPEND WPICKY_ENABLE
+        list(APPEND _wpicky_enable
           -Warith-conversion               #             gcc 10.0
         )
       endif()
@@ -220,11 +220,11 @@ if(PICKY_COMPILER)
 
     #
 
-    foreach(_ccopt IN LISTS WPICKY_ENABLE)
-      list(APPEND WPICKY "${_ccopt}")
+    foreach(_ccopt IN LISTS _wpicky_enable)
+      list(APPEND _wpicky "${_ccopt}")
     endforeach()
 
-    foreach(_ccopt IN LISTS WPICKY_DETECT)
+    foreach(_ccopt IN LISTS _wpicky_detect)
       # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
       # test result in.
       string(MAKE_C_IDENTIFIER "OPT${_ccopt}" _optvarname)
@@ -233,7 +233,7 @@ if(PICKY_COMPILER)
       string(REPLACE "-Wno-" "-W" _ccopt_on "${_ccopt}")
       check_c_compiler_flag(${_ccopt_on} ${_optvarname})
       if(${_optvarname})
-        list(APPEND WPICKY "${_ccopt}")
+        list(APPEND _wpicky "${_ccopt}")
       endif()
     endforeach()
   endif()
@@ -241,16 +241,16 @@ endif()
 
 # clang-cl
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND MSVC)
-  # list(TRANSFORM WPICKY PREPEND "/clang:") # since CMake 3.12
+  # list(TRANSFORM _wpicky PREPEND "/clang:") # since CMake 3.12
   set(_wpicky_tmp "")
-  foreach(_ccopt IN LISTS WPICKY)
+  foreach(_ccopt IN LISTS _wpicky)
     list(APPEND _wpicky_tmp "/clang:${_ccopt}")
   endforeach()
-  set(WPICKY ${_wpicky_tmp})
+  set(_wpicky ${_wpicky_tmp})
 endif()
 
-if(WPICKY)
-  string(REPLACE ";" " " WPICKY "${WPICKY}")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WPICKY}")
-  message(STATUS "Picky compiler options:${WPICKY}")
+if(_wpicky)
+  string(REPLACE ";" " " _wpicky "${_wpicky}")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_wpicky}")
+  message(STATUS "Picky compiler options:${_wpicky}")
 endif()

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -225,12 +225,14 @@ if(PICKY_COMPILER)
     endforeach()
 
     foreach(_ccopt IN LISTS _picky_detect)
+      # Surprisingly, check_c_compiler_flag() needs a new variable to store each new
+      # test result in.
+      string(MAKE_C_IDENTIFIER "OPT${_ccopt}" _optvarname)
       # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,
       # so test for the positive form instead
       string(REPLACE "-Wno-" "-W" _ccopt_on "${_ccopt}")
-      unset(_have_ccopt CACHE)
-      check_c_compiler_flag(${_ccopt_on} _have_ccopt)
-      if(_have_ccopt)
+      check_c_compiler_flag(${_ccopt_on} ${_optvarname})
+      if(${_optvarname})
         list(APPEND _picky "${_ccopt}")
       endif()
     endforeach()

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -225,7 +225,7 @@ if(PICKY_COMPILER)
     endforeach()
 
     foreach(_ccopt IN LISTS _picky_detect)
-      # surprisingly, CHECK_C_COMPILER_FLAG needs a new variable to store each new
+      # Surprisingly, check_c_compiler_flag() needs a new variable to store each new
       # test result in.
       string(MAKE_C_IDENTIFIER "OPT${_ccopt}" _optvarname)
       # GCC only warns about unknown -Wno- options if there are also other diagnostic messages,


### PR DESCRIPTION
- use CMake 3.12 syntax when available, in clang-cl branch.
  Follow-up to e89491e1f015bab8b4050ed73d1cedc17419336f #15337

- rename internal variables to underscore-lowercase.
  Follow-up to d8de4806e1463f589a1b54de1da7d6396de94d11 #14571

- update comment.

---

w/o whitespace: https://github.com/curl/curl/pull/15404/files?w=1