### PR TITLE
cmake: drop obsolete items from `TODO` and `INSTALL-CMAKE`

### DIFF
--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -16,23 +16,6 @@ instructions below for the platform you are building on.
 CMake builds can be configured either from the command line, or from one of
 CMake's GUIs.
 
-# Current flaws in the curl CMake build
-
-Missing features in the CMake build:
-
- - Builds libcurl without large file support
- - Does not support all SSL libraries (only OpenSSL, Schannel, Secure
-   Transport, and mbedTLS, wolfSSL)
- - Does not allow different resolver backends (no c-ares build support)
- - No RTMP support built
- - Does not allow build curl and libcurl debug enabled
- - Does not allow a custom CA bundle path
- - Does not allow you to disable specific protocols from the build
- - Does not find or use krb4 or GSS
- - Rebuilds test files too eagerly, but still cannot run the tests
- - Does not detect the correct `strerror_r` flavor when cross-compiling
-   (issue #1123)
-
 # Configuring
 
 A CMake configuration of curl is similar to the autotools build of curl.

--- a/docs/TODO
+++ b/docs/TODO
@@ -59,7 +59,6 @@
 
  3. Documentation
  3.1 Improve documentation about fork safety
- 3.2 Provide cmake config-file
 
  4. FTP
  4.1 HOST
@@ -545,12 +544,6 @@
 3.1 Improve documentation about fork safety
 
  See https://github.com/curl/curl/issues/6968
-
-3.2 Provide cmake config-file
-
- A config-file package is a set of files provided by us to allow applications
- to write cmake scripts to find and use libcurl easier. See
- https://github.com/curl/curl/issues/885
 
 4. FTP
 


### PR DESCRIPTION
- INSTALL-CMAKE: delete `Current flaws in the curl CMake build` section.
  #1123 was fixed in 7e93637acd9f5741ac4c09bbca353ac8da42bb17 #2443

- TODO: delete item 3.2.
  Follow-up to 1cb4f5d6e8e470638759a48ba99fda230089712f #1879
