### PR TITLE
openssl: do not break HTTP proxy due to missing TLS channel binding

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5134,9 +5134,8 @@ static CURLcode ossl_get_channel_binding(struct Curl_easy *data, int sockindex,
   } while(cf->next);
 
   if(!octx) {
-    failf(data,
-          "Failed to find SSL backend for endpoint");
-    return CURLE_SSL_ENGINE_INITFAILED;
+      /* No SSL backend, don't do channel binding */
+      return CURLE_OK;
   }
 
   cert = SSL_get1_peer_certificate(octx->ssl);


### PR DESCRIPTION
Fixes https://github.com/curl/curl/issues/14973

I want to avoid breaking past working functionality, so I have made a proposed PR which - similar to if a peer certificate isn't presented - soft-fails and continues establishing the connection without SecureChannelBinding even if an SSL backend isn't found (such as when using a HTTP proxy).

This makes the **_behaviour_** of CURL the same as before then SCB feature was integrated.

And then if someone very specifically needs SecureChannelBinding over HTTP proxy (if that is even technically possible!?) it could be implemented in a future request.