### PR TITLE
build: disable warning `-Wunreachable-code-break`

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -138,7 +138,7 @@ if(PICKY_COMPILER)
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
         list(APPEND _picky_enable
           ${_picky_common}
-          -Wunreachable-code-break         # clang  3.5            appleclang  6.0
+        # -Wunreachable-code-break         # clang  3.5            appleclang  6.0  # Not used: Silent in "unity" builds
           -Wheader-guard                   # clang  3.4            appleclang  5.1
           -Wsometimes-uninitialized        # clang  3.2            appleclang  4.6
         )

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -879,7 +879,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           dnl Only clang 3.5 or later
           if test "$compiler_num" -ge "305"; then
             CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [pragmas])
-            CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unreachable-code-break])
+          # CURL_ADD_COMPILER_WARNINGS([tmp_CFLAGS], [unreachable-code-break])  # Not used: Silent in "unity" builds
           fi
           #
           dnl Only clang 3.6 or later


### PR DESCRIPTION
This warning remains silent in unity builds. Since we're using unity
in CI for most jobs, warnings remain undetected there.
Disable them for all builds to avoid a surprise warning outside our CI.

The issue caught by the warning is useful for a tidy codebase, but
doesn't affect executed code. It was enabled in
84338c4de2d7c798e3c270c9610d51a4ad18a90b #12331 (2023-11-15).

llvm source: https://github.com/llvm/llvm-project/blob/fee2953f23bd8a8a71e574e6a8db08033778d3a4/clang/lib/Sema/AnalysisBasedWarnings.cpp#L125-L134
llvm issue: https://github.com/llvm/llvm-project/issues/71046

Follow-up to 7c023c3f6e2c454fbac7277d8dc038854c192d72 #15384
