### PR TITLE
lib: remove Curl_ prefix from static functions

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2810,8 +2810,8 @@ out:
   return result;
 }
 
-static bool Curl_cf_is_http2(struct Curl_cfilter *cf,
-                             const struct Curl_easy *data)
+static bool cf_is_http2(struct Curl_cfilter *cf,
+                        const struct Curl_easy *data)
 {
   (void)data;
   for(; cf; cf = cf->next) {
@@ -2827,7 +2827,7 @@ bool Curl_conn_is_http2(const struct Curl_easy *data,
                         const struct connectdata *conn,
                         int sockindex)
 {
-  return conn ? Curl_cf_is_http2(conn->cfilter[sockindex], data) : FALSE;
+  return conn ? cf_is_http2(conn->cfilter[sockindex], data) : FALSE;
 }
 
 bool Curl_http2_may_switch(struct Curl_easy *data,
@@ -2879,7 +2879,7 @@ CURLcode Curl_http2_switch_at(struct Curl_cfilter *cf, struct Curl_easy *data)
   struct Curl_cfilter *cf_h2;
   CURLcode result;
 
-  DEBUGASSERT(!Curl_cf_is_http2(cf, data));
+  DEBUGASSERT(!cf_is_http2(cf, data));
 
   result = http2_cfilter_insert_after(cf, data, FALSE);
   if(result)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -204,10 +204,10 @@ CURLcode Curl_xfer_send_shutdown(struct Curl_easy *data, bool *done)
  * @param err error    code in case of -1 return
  * @return number of bytes read or -1 for error
  */
-static ssize_t Curl_xfer_recv_resp(struct Curl_easy *data,
-                                   char *buf, size_t blen,
-                                   bool eos_reliable,
-                                   CURLcode *err)
+static ssize_t xfer_recv_resp(struct Curl_easy *data,
+                              char *buf, size_t blen,
+                              bool eos_reliable,
+                              CURLcode *err)
 {
   ssize_t nread;
 
@@ -302,8 +302,7 @@ static CURLcode sendrecv_dl(struct Curl_easy *data,
         bytestoread = (size_t)data->set.max_recv_speed;
     }
 
-    nread = Curl_xfer_recv_resp(data, buf, bytestoread,
-                                is_multiplex, &result);
+    nread = xfer_recv_resp(data, buf, bytestoread, is_multiplex, &result);
     if(nread < 0) {
       if(CURLE_AGAIN != result)
         goto out; /* real error */

--- a/lib/url.c
+++ b/lib/url.c
@@ -651,13 +651,13 @@ bool Curl_on_disconnect(struct Curl_easy *data,
 }
 
 /*
- * Curl_xfer_may_multiplex()
+ * xfer_may_multiplex()
  *
  * Return a TRUE, iff the transfer can be done over an (appropriate)
  * multiplexed connection.
  */
-static bool Curl_xfer_may_multiplex(const struct Curl_easy *data,
-                                    const struct connectdata *conn)
+static bool xfer_may_multiplex(const struct Curl_easy *data,
+                               const struct connectdata *conn)
 {
   /* If an HTTP protocol and multiplexing is enabled */
   if((conn->handler->protocol & PROTO_FAMILY_HTTP) &&
@@ -1248,7 +1248,7 @@ ConnectionExists(struct Curl_easy *data,
   memset(&match, 0, sizeof(match));
   match.data = data;
   match.needle = needle;
-  match.may_multiplex = Curl_xfer_may_multiplex(data, needle);
+  match.may_multiplex = xfer_may_multiplex(data, needle);
 
 #ifdef USE_NTLM
   match.want_ntlm_http = ((data->state.authhost.want & CURLAUTH_NTLM) &&

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -76,11 +76,11 @@ static void keylog_callback(const WOLFSSL *ssl, const char *line)
 }
 #endif
 
-static CURLcode Curl_wssl_init_ctx(struct curl_tls_ctx *ctx,
-                                   struct Curl_cfilter *cf,
-                                   struct Curl_easy *data,
-                                   Curl_vquic_tls_ctx_setup *cb_setup,
-                                   void *cb_user_data)
+static CURLcode wssl_init_ctx(struct curl_tls_ctx *ctx,
+                              struct Curl_cfilter *cf,
+                              struct Curl_easy *data,
+                              Curl_vquic_tls_ctx_setup *cb_setup,
+                              void *cb_user_data)
 {
   struct ssl_primary_config *conn_config;
   CURLcode result = CURLE_FAILED_INIT;
@@ -194,12 +194,12 @@ out:
 
 /** SSL callbacks ***/
 
-static CURLcode Curl_wssl_init_ssl(struct curl_tls_ctx *ctx,
-                                   struct Curl_cfilter *cf,
-                                   struct Curl_easy *data,
-                                   struct ssl_peer *peer,
-                                   const char *alpn, size_t alpn_len,
-                                   void *user_data)
+static CURLcode wssl_init_ssl(struct curl_tls_ctx *ctx,
+                              struct Curl_cfilter *cf,
+                              struct Curl_easy *data,
+                              struct ssl_peer *peer,
+                              const char *alpn, size_t alpn_len,
+                              void *user_data)
 {
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
 
@@ -249,12 +249,11 @@ CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
                             (const unsigned char *)alpn, alpn_len, NULL,
                             cb_setup, cb_user_data, ssl_user_data);
 #elif defined(USE_WOLFSSL)
-  result = Curl_wssl_init_ctx(ctx, cf, data, cb_setup, cb_user_data);
+  result = wssl_init_ctx(ctx, cf, data, cb_setup, cb_user_data);
   if(result)
     return result;
 
-  return Curl_wssl_init_ssl(ctx, cf, data, peer, alpn, alpn_len,
-                            ssl_user_data);
+  return wssl_init_ssl(ctx, cf, data, peer, alpn, alpn_len, ssl_user_data);
 #else
 #error "no TLS lib in used, should not happen"
   return CURLE_FAILED_INIT;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -259,7 +259,7 @@ static bool clone_ssl_primary_config(struct ssl_primary_config *source,
   return TRUE;
 }
 
-static void Curl_free_primary_ssl_config(struct ssl_primary_config *sslc)
+static void free_primary_ssl_config(struct ssl_primary_config *sslc)
 {
   Curl_safefree(sslc->CApath);
   Curl_safefree(sslc->CAfile);
@@ -359,9 +359,9 @@ CURLcode Curl_ssl_conn_config_init(struct Curl_easy *data,
 
 void Curl_ssl_conn_config_cleanup(struct connectdata *conn)
 {
-  Curl_free_primary_ssl_config(&conn->ssl_config);
+  free_primary_ssl_config(&conn->ssl_config);
 #ifndef CURL_DISABLE_PROXY
-  Curl_free_primary_ssl_config(&conn->proxy_ssl_config);
+  free_primary_ssl_config(&conn->proxy_ssl_config);
 #endif
 }
 
@@ -609,7 +609,7 @@ void Curl_ssl_kill_session(struct Curl_ssl_session *session)
     session->sessionid_free = NULL;
     session->age = 0; /* fresh */
 
-    Curl_free_primary_ssl_config(&session->ssl_config);
+    free_primary_ssl_config(&session->ssl_config);
 
     Curl_safefree(session->name);
     Curl_safefree(session->conn_to_host);
@@ -726,7 +726,7 @@ CURLcode Curl_ssl_set_sessionid(struct Curl_cfilter *cf,
 
   /* now init the session struct wisely */
   if(!clone_ssl_primary_config(conn_config, &store->ssl_config)) {
-    Curl_free_primary_ssl_config(&store->ssl_config);
+    free_primary_ssl_config(&store->ssl_config);
     store->sessionid = NULL; /* let caller free sessionid */
     goto out;
   }


### PR DESCRIPTION
'Curl_' is a prefix used for library global functions (cross-files). Static functions should thus not use it.