### PR TITLE
tls, test --insecure

### DIFF
--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -341,3 +341,29 @@ class TestSSLUse:
             if m:
                 reused_session = True
         assert reused_session, f'{r}\n{r.dump_logs()}'
+
+    # use host name with trailing dot, verify handshake
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    def test_17_11_wrong_host(self, env: Env, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
+        curl = CurlClient(env=env)
+        domain = f'insecure.{env.tld}'
+        url = f'https://{domain}:{env.port_for(proto)}/curltest/sslinfo'
+        r = curl.http_get(url=url, alpn_proto=proto)
+        assert r.exit_code == 60, f'{r}'
+
+    # use host name with trailing dot, verify handshake
+    @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
+    def test_17_12_insecure(self, env: Env, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
+        curl = CurlClient(env=env)
+        domain = f'insecure.{env.tld}'
+        url = f'https://{domain}:{env.port_for(proto)}/curltest/sslinfo'
+        r = curl.http_get(url=url, alpn_proto=proto, extra_args=[
+            '--insecure'
+        ])
+        assert r.exit_code == 0, f'{r}'
+        assert r.json, f'{r}'
+

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -366,4 +366,3 @@ class TestSSLUse:
         ])
         assert r.exit_code == 0, f'{r}'
         assert r.json, f'{r}'
-

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -342,7 +342,7 @@ class TestSSLUse:
                 reused_session = True
         assert reused_session, f'{r}\n{r.dump_logs()}'
 
-    # use host name with trailing dot, verify handshake
+    # use host name server has no certificate for
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_11_wrong_host(self, env: Env, proto):
         if proto == 'h3' and not env.have_h3():
@@ -353,7 +353,7 @@ class TestSSLUse:
         r = curl.http_get(url=url, alpn_proto=proto)
         assert r.exit_code == 60, f'{r}'
 
-    # use host name with trailing dot, verify handshake
+    # use host name server has no cert for with --insecure
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_17_12_insecure(self, env: Env, proto):
         if proto == 'h3' and not env.have_h3():

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -461,6 +461,10 @@ class Env:
         return self.CONFIG.htdocs_dir
 
     @property
+    def tld(self) -> str:
+        return self.CONFIG.tld
+
+    @property
     def domain1(self) -> str:
         return self.CONFIG.domain1
 


### PR DESCRIPTION
Add two test cases that connection using a hostname the server has no certificate for. First, verify that the peer verification fail, as expected. Second, provide '--insecure' to test that the connection succeeded and returned some data.