### PR TITLE
tls: avoid abusing CURLE_SSL_ENGINE_INITFAILED

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5134,9 +5134,8 @@ static CURLcode ossl_get_channel_binding(struct Curl_easy *data, int sockindex,
   } while(cf->next);
 
   if(!octx) {
-    failf(data,
-          "Failed to find SSL backend for endpoint");
-    return CURLE_SSL_ENGINE_INITFAILED;
+    failf(data, "Failed to find the SSL filter");
+    return CURLE_BAD_FUNCTION_ARGUMENT;
   }
 
   cert = SSL_get1_peer_certificate(octx->ssl);

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -570,7 +570,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
       break;
     default:
       failf(data, "rustls: unsupported minimum TLS version value");
-      return CURLE_SSL_ENGINE_INITFAILED;
+      return CURLE_BAD_FUNCTION_ARGUMENT;
     }
 
     switch(conn_config->version_max) {
@@ -588,7 +588,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     case CURL_SSLVERSION_MAX_TLSv1_0:
     default:
       failf(data, "rustls: unsupported maximum TLS version value");
-      return CURLE_SSL_ENGINE_INITFAILED;
+      return CURLE_BAD_FUNCTION_ARGUMENT;
     }
 
     cipher_suites = malloc(sizeof(cipher_suites) * (cipher_suites_len));
@@ -610,7 +610,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     if(result != RUSTLS_RESULT_OK) {
       failf(data,
             "rustls: failed to create crypto provider builder from default");
-      return CURLE_SSL_ENGINE_INITFAILED;
+      return CURLE_SSL_CIPHER;
     }
 
     result =
@@ -622,7 +622,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
       failf(data,
             "rustls: failed to set ciphersuites for crypto provider builder");
       rustls_crypto_provider_builder_free(custom_provider_builder);
-      return CURLE_SSL_ENGINE_INITFAILED;
+      return CURLE_SSL_CIPHER;
     }
 
     result = rustls_crypto_provider_builder_build(
@@ -630,7 +630,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     if(result != RUSTLS_RESULT_OK) {
       failf(data, "rustls: failed to build custom crypto provider");
       rustls_crypto_provider_builder_free(custom_provider_builder);
-      return CURLE_SSL_ENGINE_INITFAILED;
+      return CURLE_SSL_CIPHER;
     }
 
     result = rustls_client_config_builder_new_custom(custom_provider,
@@ -640,7 +640,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
     free(cipher_suites);
     if(result != RUSTLS_RESULT_OK) {
       failf(data, "rustls: failed to create client config");
-      return CURLE_SSL_ENGINE_INITFAILED;
+      return CURLE_SSL_CIPHER;
     }
   }
 
@@ -747,7 +747,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
   if(result != RUSTLS_RESULT_OK) {
     failf(data, "rustls: failed to build client config");
     rustls_client_config_free(backend->config);
-    return CURLE_SSL_ENGINE_INITFAILED;
+    return CURLE_SSL_CONNECT_ERROR;
   }
 
   DEBUGASSERT(rconn == NULL);


### PR DESCRIPTION
That error code was introduced and has been used for OpenSSL ENGINE things and not others, so switch the other use cases over to other TLS related error codes.