### PR TITLE
lib: msprintf tidy-ups

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -847,11 +847,9 @@ static void doh_show(struct Curl_easy *data,
     }
     else if(a->type == DNS_TYPE_AAAA) {
       int j;
-      char buffer[128];
-      char *ptr;
-      size_t len;
-      len = msnprintf(buffer, 128, "[DoH] AAAA: ");
-      ptr = &buffer[len];
+      char buffer[128] = "[DoH] AAAA: ";
+      size_t len = strlen(buffer);
+      char *ptr = &buffer[len];
       len = sizeof(buffer) - len;
       for(j = 0; j < 16; j += 2) {
         size_t l;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2683,9 +2683,7 @@ static void ossl_trace(int direction, int ssl_ver, int content_type,
                         "%s (%s), %s, %s (%d):\n",
                         verstr, direction ? "OUT" : "IN",
                         tls_rt_name, msg_name, msg_type);
-    if(0 <= txt_len && (unsigned)txt_len < sizeof(ssl_buf)) {
-      Curl_debug(data, CURLINFO_TEXT, ssl_buf, (size_t)txt_len);
-    }
+    Curl_debug(data, CURLINFO_TEXT, ssl_buf, (size_t)txt_len);
   }
 
   Curl_debug(data, (direction == 1) ? CURLINFO_SSL_DATA_OUT :


### PR DESCRIPTION
doh: avoid an msnprintf()

openssl: skip a superfluous return code check