### PR TITLE
runtests: pass single backslashes with Windows Perl

### DIFF
--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -192,7 +192,7 @@ sub runner_init {
             $SIG{INT} = 'IGNORE';
             $SIG{TERM} = 'IGNORE';
             eval {
-                # some msys2 perl versions don't define SIGUSR1
+                # some msys2 perl versions don't define SIGUSR1, also missing from Win32 Perl
                 $SIG{USR1} = 'IGNORE';
             };
 

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -272,7 +272,12 @@ sub clearlocks {
 
     if(os_is_win()) {
         $dir = sys_native_abs_path($dir);
-        $dir =~ s/\//\\\\/g;
+        if ($^O eq 'MSWin32') {
+            $dir =~ s/\//\\/g;
+        }
+        else {
+            $dir =~ s/\//\\\\/g;
+        }
         my $handle = "handle";
         if($ENV{"PROCESSOR_ARCHITECTURE"} =~ /64$/) {
             $handle = "handle64";

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -297,7 +297,8 @@ sub clearlocks {
                         # https://ss64.com/nt/taskkill.html
                         my $cmd = "taskkill.exe -f -t -fi \"IMAGENAME eq $1\" -fi \"PID eq $2\" >nul 2>&1";
                         logmsg "clearlocks: Executing kill: '$cmd'\n";
-                        system($cmd);
+                        my $result = system($cmd);
+                        print "clearlocks: taskkill.exe result: $result\n";
                         $done = 1;
                     }
                 }

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -285,18 +285,18 @@ sub clearlocks {
         if(checkcmd($handle)) {
             # https://learn.microsoft.com/sysinternals/downloads/handle#usage
             my $cmd = "$handle $dir -accepteula -nobanner";
-            logmsg "Executing: '$cmd'\n";
+            logmsg "clearlocks: Executing query: '$cmd'\n";
             my @handles = `$cmd`;
             for my $tryhandle (@handles) {
                 # Skip the "No matching handles found." warning when returned
                 if($tryhandle =~ /^(\S+)\s+pid:\s+(\d+)\s+type:\s+(\w+)\s+([0-9A-F]+):\s+(.+)\r\r/) {
-                    logmsg "Found $3 lock of '$5' ($4) by $1 ($2)\n";
+                    logmsg "clearlocks: Found $3 lock of '$5' ($4) by $1 ($2)\n";
                     # Ignore stunnel since we cannot do anything about its locks
                     if("$3" eq "File" && "$1" ne "tstunnel.exe") {
-                        logmsg "Killing IMAGENAME eq $1 and PID eq $2\n";
+                        logmsg "clearlocks: Killing IMAGENAME eq $1 and PID eq $2\n";
                         # https://ss64.com/nt/taskkill.html
                         my $cmd = "taskkill.exe -f -t -fi \"IMAGENAME eq $1\" -fi \"PID eq $2\" >nul 2>&1";
-                        logmsg "Executing: '$cmd'\n";
+                        logmsg "clearlocks: Executing kill: '$cmd'\n";
                         system($cmd);
                         $done = 1;
                     }

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -297,8 +297,7 @@ sub clearlocks {
                         # https://ss64.com/nt/taskkill.html
                         my $cmd = "taskkill.exe -f -t -fi \"IMAGENAME eq $1\" -fi \"PID eq $2\" >nul 2>&1";
                         logmsg "clearlocks: Executing kill: '$cmd'\n";
-                        my $result = system($cmd);
-                        print "clearlocks: taskkill.exe result: $result\n";
+                        system($cmd);
                         $done = 1;
                     }
                 }


### PR DESCRIPTION
handle/handle64 requires a literal match with the filenames it's
listing.

Also:
- make handle64 log messages more unique to help text searches.
- update a comment with Windows Perl info.

Cherry-picked from #14949

---

w/o whitespace: https://github.com/curl/curl/pull/15436/files?w=1