### PR TITLE
GHA/windows: avoid curl.exe libtool wrapper

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -274,8 +274,9 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         timeout-minutes: 1
         run: |
+          # avoid the libtool wrapper
           mv bld/src/.libs/curl.exe bld/src/curl.exe
-          mv bld/lib/.libs/libcurl*.dll bld/src
+          mv bld/lib/.libs/libcurl*.dll bld/src || true
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -274,6 +274,7 @@ jobs:
         if: ${{ matrix.build == 'autotools' }}
         timeout-minutes: 1
         run: |
+          mv bld/src/.libs/curl.exe bld/src/curl.exe
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -276,7 +276,7 @@ jobs:
         run: |
           # avoid the libtool wrapper
           mv bld/src/.libs/curl.exe bld/src/curl.exe
-          mv bld/lib/.libs/libcurl*.dll bld/src || true
+          mv bld/lib/.libs/*.dll bld/src || true
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -275,6 +275,7 @@ jobs:
         timeout-minutes: 1
         run: |
           mv bld/src/.libs/curl.exe bld/src/curl.exe
+          mv bld/lib/.libs/libcurl*.dll bld/src
           find . -name '*.exe' -o -name '*.dll'
           bld/src/curl.exe --disable --version
 


### PR DESCRIPTION
Avoid the `curl.exe` wrapper binary created by libtool, and run the real
`curl.exe` directly for tests and version information.

This solution was used in Azure jobs. I missed it when migrating jobs
to GHA.

Applies to tests run in the `mingw, AM x86_64 c-ares U` job, which has
seen unexplained flakiness.

Ref: 354afc891df4b60b8017fc5d35a05daedb2cd812 #6049
Follow-up to e53523fef07894991c69d907a7c7794c7ada4ff4 #14859

---

Example failure: (not necessarily related to this update)
https://github.com/curl/curl/actions/runs/11564763508/job/32190603526?pr=15436#step:14:7208