### PR TITLE
setopt: return error for bad input to CURLOPT_RTSP_REQUEST

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1261,7 +1261,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
       rtspreq = RTSPREQ_RECEIVE;
       break;
     default:
-      rtspreq = RTSPREQ_NONE;
+      return CURLE_BAD_FUNCTION_ARGUMENT;
     }
 
     data->set.rtspreq = rtspreq;


### PR DESCRIPTION
And leave the value untouched. Previously, an unrecognized argument would reset it to RTSPREQ_NONE (and still return OK).