### PR TITLE
multi: fix "Useless Assignment"

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2303,7 +2303,6 @@ static CURLMcode state_do(struct Curl_easy *data,
     /* keep connection open for application to use the socket */
     connkeep(data->conn, "CONNECT_ONLY");
     multistate(data, MSTATE_DONE);
-    result = CURLE_OK;
     rc = CURLM_CALL_MULTI_PERFORM;
   }
   else {


### PR DESCRIPTION
CodeSonar pointed out "This code assigns the variable the same value it already had"

Follow-up to e77326403d3d27e7e