### PR TITLE
pytest, fix run against multissl curl

### DIFF
--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -102,7 +102,7 @@ def httpd(env) -> Generator[Httpd, None, None]:
 @pytest.fixture(scope='package')
 def nghttpx(env, httpd) -> Generator[Nghttpx, None, None]:
     nghttpx = NghttpxQuic(env=env)
-    if env.have_h3() or nghttpx.https_port > 0:
+    if nghttpx.exists() and (env.have_h3() or nghttpx.https_port > 0):
         nghttpx.clear_logs()
         assert nghttpx.start()
     yield nghttpx
@@ -111,7 +111,7 @@ def nghttpx(env, httpd) -> Generator[Nghttpx, None, None]:
 @pytest.fixture(scope='package')
 def nghttpx_fwd(env, httpd) -> Generator[Nghttpx, None, None]:
     nghttpx = NghttpxFwd(env=env)
-    if env.have_h3() or nghttpx.https_port > 0:
+    if nghttpx.exists() and (env.have_h3() or nghttpx.https_port > 0):
         nghttpx.clear_logs()
         assert nghttpx.start()
     yield nghttpx

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -102,7 +102,7 @@ def httpd(env) -> Generator[Httpd, None, None]:
 @pytest.fixture(scope='package')
 def nghttpx(env, httpd) -> Generator[Nghttpx, None, None]:
     nghttpx = NghttpxQuic(env=env)
-    if env.have_h3():
+    if env.have_h3() or nghttpx.https_port > 0:
         nghttpx.clear_logs()
         assert nghttpx.start()
     yield nghttpx
@@ -111,7 +111,7 @@ def nghttpx(env, httpd) -> Generator[Nghttpx, None, None]:
 @pytest.fixture(scope='package')
 def nghttpx_fwd(env, httpd) -> Generator[Nghttpx, None, None]:
     nghttpx = NghttpxFwd(env=env)
-    if env.have_h3():
+    if env.have_h3() or nghttpx.https_port > 0:
         nghttpx.clear_logs()
         assert nghttpx.start()
     yield nghttpx

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -27,7 +27,6 @@
 import difflib
 import filecmp
 import logging
-import time
 import math
 import os
 import re

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -27,6 +27,7 @@
 import difflib
 import filecmp
 import logging
+import time
 import math
 import os
 import re
@@ -572,7 +573,7 @@ class TestDownload:
         assert r.total_connects == 1, r.dump_logs()
 
     # download parallel with h2 "Upgrade:"
-    def test_02_31_parallel_upgrade(self, env: Env, httpd):
+    def test_02_31_parallel_upgrade(self, env: Env, httpd, nghttpx):
         count = 3
         curl = CurlClient(env=env)
         urln = f'http://{env.domain1}:{env.http_port}/data.json?[0-{count-1}]'
@@ -599,7 +600,6 @@ class TestDownload:
         port = env.port_for(proto)
         if proto != 'h3':
             port = env.nghttpx_https_port
-        # url = f'https://{env.domain1}:{env.port_for(proto)}/{docname}'
         url = f'https://{env.domain1}:{port}/{docname}'
         client = LocalClient(name='hx-download', env=env)
         if not client.exists():

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -95,7 +95,7 @@ class EnvConfig:
                         lib.lower() for lib in m.group('libs').split(' ')
                     ]
                     self.curl_props['libs'] = [
-                        re.sub(r'/.*', '', lib) for lib in self.curl_props['lib_versions']
+                        re.sub(r'/[a-z0-9.-]*', '', lib) for lib in self.curl_props['lib_versions']
                     ]
             if line.startswith('Features: '):
                 self.curl_props['features'] = [
@@ -303,7 +303,7 @@ class Env:
 
     @staticmethod
     def have_ssl_curl() -> bool:
-        return 'ssl' in Env.CONFIG.curl_props['features']
+        return Env.curl_has_feature('ssl') or Env.curl_has_feature('multissl')
 
     @staticmethod
     def have_h2_curl() -> bool:

--- a/tests/http/testenv/nghttpx.py
+++ b/tests/http/testenv/nghttpx.py
@@ -41,10 +41,11 @@ log = logging.getLogger(__name__)
 
 class Nghttpx:
 
-    def __init__(self, env: Env, port: int, name: str):
+    def __init__(self, env: Env, port: int, https_port: int, name: str):
         self.env = env
         self._name = name
         self._port = port
+        self._https_port = https_port
         self._cmd = env.nghttpx
         self._run_dir = os.path.join(env.gen_dir, name)
         self._pid_file = os.path.join(self._run_dir, 'nghttpx.pid')
@@ -57,6 +58,10 @@ class Nghttpx:
         self._rmf(self._error_log)
         self._mkpath(self._run_dir)
         self._write_config()
+
+    @property
+    def https_port(self):
+        return self._https_port
 
     def exists(self):
         return os.path.exists(self._cmd)
@@ -127,10 +132,18 @@ class Nghttpx:
         curl = CurlClient(env=self.env, run_dir=self._tmp_dir)
         try_until = datetime.now() + timeout
         while datetime.now() < try_until:
-            check_url = f'https://{self.env.domain1}:{self._port}/'
-            r = curl.http_get(url=check_url, extra_args=[
-                '--http3-only', '--connect-timeout', '1'
-            ])
+            if self._https_port > 0:
+                check_url = f'https://{self.env.domain1}:{self._https_port}/'
+                r = curl.http_get(url=check_url, extra_args=[
+                    '--trace', 'curl.trace', '--trace-time',
+                    '--connect-timeout', '1'
+                ])
+            else:
+                check_url = f'https://{self.env.domain1}:{self._port}/'
+                r = curl.http_get(url=check_url, extra_args=[
+                    '--trace', 'curl.trace', '--trace-time',
+                    '--http3-only', '--connect-timeout', '1'
+                ])
             if r.exit_code != 0:
                 return True
             log.debug(f'waiting for nghttpx to stop responding: {r}')
@@ -142,11 +155,18 @@ class Nghttpx:
         curl = CurlClient(env=self.env, run_dir=self._tmp_dir)
         try_until = datetime.now() + timeout
         while datetime.now() < try_until:
-            check_url = f'https://{self.env.domain1}:{self._port}/'
-            r = curl.http_get(url=check_url, extra_args=[
-                '--http3-only', '--trace', 'curl.trace', '--trace-time',
-                '--connect-timeout', '1'
-            ])
+            if self._https_port > 0:
+                check_url = f'https://{self.env.domain1}:{self._https_port}/'
+                r = curl.http_get(url=check_url, extra_args=[
+                    '--trace', 'curl.trace', '--trace-time',
+                    '--connect-timeout', '1'
+                ])
+            else:
+                check_url = f'https://{self.env.domain1}:{self._port}/'
+                r = curl.http_get(url=check_url, extra_args=[
+                    '--http3-only', '--trace', 'curl.trace', '--trace-time',
+                    '--connect-timeout', '1'
+                ])
             if r.exit_code == 0:
                 return True
             log.debug(f'waiting for nghttpx to become responsive: {r}')
@@ -173,7 +193,8 @@ class Nghttpx:
 class NghttpxQuic(Nghttpx):
 
     def __init__(self, env: Env):
-        super().__init__(env=env, name='nghttpx-quic', port=env.h3_port)
+        super().__init__(env=env, name='nghttpx-quic', port=env.h3_port,
+                         https_port=env.nghttpx_https_port)
 
     def start(self, wait_live=True):
         self._mkpath(self._tmp_dir)
@@ -210,7 +231,8 @@ class NghttpxQuic(Nghttpx):
 class NghttpxFwd(Nghttpx):
 
     def __init__(self, env: Env):
-        super().__init__(env=env, name='nghttpx-fwd', port=env.h2proxys_port)
+        super().__init__(env=env, name='nghttpx-fwd', port=env.h2proxys_port,
+                         https_port=0)
 
     def start(self, wait_live=True):
         self._mkpath(self._tmp_dir)

--- a/tests/http/testenv/nghttpx.py
+++ b/tests/http/testenv/nghttpx.py
@@ -64,7 +64,7 @@ class Nghttpx:
         return self._https_port
 
     def exists(self):
-        return os.path.exists(self._cmd)
+        return self._cmd and os.path.exists(self._cmd)
 
     def clear_logs(self):
         self._rmf(self._error_log)


### PR DESCRIPTION
Changes to make a curl built with OpenSSL + GnuTLS to run successfully in our pytests. Run

CURL_SSL_BACKEND=openssl pytest

to test a TLS backend other than the default.