### PR TITLE
mqtt: Fixed mqtt.md wording and added clearer explanation.

### DIFF
--- a/docs/internals/MQTT.md
+++ b/docs/internals/MQTT.md
@@ -9,19 +9,35 @@ SPDX-License-Identifier: curl
 ## Usage
 
 A plain "GET" subscribes to the topic and prints all published messages.
+
 Doing a "POST" publishes the post data to the topic and exits.
+
+
+### Subscribing
+Command usage:
+    
+    curl mqtt://host/topic
 
 Example subscribe:
 
     curl mqtt://host.home/bedroom/temp
 
+This will send an MQTT SUBSCRIBE packet for the topic `bedroom/temp` and listen in for incoming PUBLISH packets.
+
+### Publishing
+Command usage:
+
+    curl -d payload mqtt://host/topic
+
 Example publish:
 
     curl -d 75 mqtt://host.home/bedroom/dimmer
 
+This will send an MQTT PUBLISH packet to the topic `bedroom/dimmer` with the payload `75`.
+
 ## What does curl deliver as a response to a subscribe
 
-It outputs two bytes topic length (MSB | LSB), the topic followed by the
+Whenever a PUBLISH packet is received, curl outputs two bytes topic length (MSB | LSB), the topic followed by the
 payload.
 
 ## Caveats


### PR DESCRIPTION
Some of the wording in the `MQTT.md` file was confusing in terms of how the commands were used and what they did, so
I cleared up some of the wording to better explain the use case of each command.