### PR TITLE
unit1307: tidy up Apple OS detection

### DIFF
--- a/tests/unit/unit1307.c
+++ b/tests/unit/unit1307.c
@@ -280,11 +280,11 @@ UNITTEST_START
   enum system machine;
 
 #ifdef HAVE_FNMATCH
-  if(strstr(CURL_OS, "apple") || strstr(CURL_OS, "darwin")) {
-    machine = SYSTEM_MACOS;
-  }
-  else
-    machine = SYSTEM_LINUX;
+#ifdef __APPLE__
+  machine = SYSTEM_MACOS;
+#else
+  machine = SYSTEM_LINUX;
+#endif
   printf("Tested with system fnmatch(), %s-style\n",
          machine == SYSTEM_LINUX ? "linux" : "mac");
 #else


### PR DESCRIPTION
Use `__APPLE__` macro to detect Apple OS instead of relying on
the string in `CURL_OS`.

This also fixes detection with default CMake builds where `CURL_OS` is
`Darwin`. The code before this patch was expecting this substring in
lowercase.
