### PR TITLE
cmake: make libpsl required by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1124,15 +1124,11 @@ mark_as_advanced(CURL_USE_LIBPSL)
 set(USE_LIBPSL OFF)
 
 if(CURL_USE_LIBPSL)
-  find_package(Libpsl)  # TODO: add REQUIRED to match autotools
-  if(LIBPSL_FOUND)
-    list(APPEND CURL_LIBS ${LIBPSL_LIBRARIES})
-    list(APPEND LIBCURL_PC_REQUIRES_PRIVATE "libpsl")
-    include_directories(SYSTEM ${LIBPSL_INCLUDE_DIRS})
-    set(USE_LIBPSL ON)
-  else()
-    message(WARNING "libpsl is enabled, but not found.")
-  endif()
+  find_package(Libpsl REQUIRED)
+  list(APPEND CURL_LIBS ${LIBPSL_LIBRARIES})
+  list(APPEND LIBCURL_PC_REQUIRES_PRIVATE "libpsl")
+  include_directories(SYSTEM ${LIBPSL_INCLUDE_DIRS})
+  set(USE_LIBPSL ON)
 endif()
 
 # libssh2


### PR DESCRIPTION
As done earlier in `./configure`:

To force users to explictily disable it if they really don't want it
used and make it harder to accidentally miss it.

`-DCURL_USE_LIBPSL=OFF` is the option to use if PSL is not wanted.

Follow-up to 2998874bb61ac6ef3b72d6a61467cd2aaf6e53ea #12661
