### PR TITLE
pytest: include curl version string and python platform in log

### DIFF
--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -25,6 +25,7 @@
 import logging
 import os
 import sys
+import platform
 from typing import Generator
 
 import pytest
@@ -38,6 +39,7 @@ def pytest_report_header(config):
     env = Env()
     report = [
         f'Testing curl {env.curl_version()}',
+        f'  platform: {platform.platform()}',
         f'  curl: Version: {env.curl_version_string()}',
         f'  curl: Features: {env.curl_features_string()}',
         f'  curl: Protocols: {env.curl_protocols_string()}',

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -38,6 +38,7 @@ def pytest_report_header(config):
     env = Env()
     report = [
         f'Testing curl {env.curl_version()}',
+        f'  curl: Version: {env.curl_version_string()}',
         f'  curl: Features: {env.curl_features_string()}',
         f'  curl: Protocols: {env.curl_protocols_string()}',
         f'  httpd: {env.httpd_version()}, http:{env.http_port} https:{env.https_port}',

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -68,6 +68,7 @@ class EnvConfig:
         if 'CURL' in os.environ:
             self.curl = os.environ['CURL']
         self.curl_props = {
+            'version_string': '',
             'version': '',
             'os': '',
             'fullname': '',
@@ -88,6 +89,7 @@ class EnvConfig:
             self.curl_is_debug = True
         for line in p.stdout.splitlines(keepends=False):
             if line.startswith('curl '):
+                self.curl_props['version_string'] = line
                 m = re.match(r'^curl (?P<version>\S+) (?P<os>\S+) (?P<libs>.*)$', line)
                 if m:
                     self.curl_props['fullname'] = m.group(0)
@@ -326,6 +328,10 @@ class Env:
         if Env.have_h3_curl():
             return not Env.curl_uses_lib('ngtcp2') and Env.curl_uses_lib('nghttp3')
         return False
+
+    @staticmethod
+    def curl_version_string() -> str:
+        return Env.CONFIG.curl_props['version_string']
 
     @staticmethod
     def curl_features_string() -> str:


### PR DESCRIPTION
For the Test Clutch matrix.

https://testclutch.curl.se/static/reports/feature-matrix.html