### PR TITLE
wolfssl: no more use of the OpenSSL API

### DIFF
--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -34,9 +34,6 @@
 
 #ifdef USE_WOLFSSL
 #include <wolfssl/options.h>
-#ifndef NO_SHA256
-#define USE_OPENSSL_SHA256
-#endif
 #endif
 
 #if defined(USE_OPENSSL)


### PR DESCRIPTION
This allows curl to build with a wolfSSL built without the OpenSSL API

It should allow curl to (soon?) build with *both* wolfSSL and OpenSSL

This change makes curl use its own sha256 implementaion when built with wolfSSL: room for improvement.