### PR TITLE
GHA/non-native: fix installing OpenLDAP on OpenBSD

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -100,6 +100,7 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
+            cat bld/CMakeFiles/CMake*.yaml || true
             echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
             echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
             cmake --build bld --config Debug

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -91,7 +91,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake ninja perl brotli openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
+            sudo pkg_add cmake ninja brotli openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
             cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -91,6 +91,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
+            # https://www.openbsd.org/faq/faq15.html
             sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
             cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -100,7 +100,6 @@ jobs:
               -DCURL_USE_OPENSSL=ON \
               -DCURL_BROTLI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
-            cat bld/CMakeFiles/CMake*.yaml || true
             echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
             echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
             cmake --build bld --config Debug

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -91,7 +91,7 @@ jobs:
           architecture: ${{ matrix.arch }}
           run: |
             # https://openbsd.app/
-            sudo pkg_add cmake ninja brotli openldap-client libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
+            sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
             cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \


### PR DESCRIPTION
Also:
- drop failing manual install of perl. It's there by default now.
- add link to OpenBSD package management FAQ page.
