### PR TITLE
pytest, add test for use of CURLMOPT_MAX_HOST_CONNECTIONS

### DIFF
--- a/tests/http/clients/hx-download.c
+++ b/tests/http/clients/hx-download.c
@@ -534,6 +534,7 @@ int main(int argc, char *argv[])
   free(transfers);
 
   curl_share_cleanup(share);
+  curl_slist_free_all(host);
   free(resolve);
 
   return 0;

--- a/tests/http/clients/hx-download.c
+++ b/tests/http/clients/hx-download.c
@@ -306,7 +306,7 @@ int main(int argc, char *argv[])
   int http_version = CURL_HTTP_VERSION_2_0;
   int ch;
   struct curl_slist *host = NULL;
-  const char *resolve = NULL;
+  char *resolve = NULL;
   size_t max_host_conns = 0;
   int fresh_connect = 0;
 
@@ -346,7 +346,7 @@ int main(int argc, char *argv[])
       pause_offset = (size_t)strtol(optarg, NULL, 10);
       break;
     case 'r':
-      resolve = optarg;
+      resolve = strdup(optarg);
       break;
     case 'V': {
       if(!strcmp("http/1.1", optarg))
@@ -534,6 +534,7 @@ int main(int argc, char *argv[])
   free(transfers);
 
   curl_share_cleanup(share);
+  free(resolve);
 
   return 0;
 #else

--- a/tests/http/clients/hx-download.c
+++ b/tests/http/clients/hx-download.c
@@ -229,7 +229,7 @@ static int my_progress_cb(void *userdata,
 
 static int setup(CURL *hnd, const char *url, struct transfer *t,
                  int http_version, struct curl_slist *host,
-                 CURLSH *share, int use_earlydata)
+                 CURLSH *share, int use_earlydata, int fresh_connect)
 {
   curl_easy_setopt(hnd, CURLOPT_SHARE, share);
   curl_easy_setopt(hnd, CURLOPT_URL, url);
@@ -248,6 +248,8 @@ static int setup(CURL *hnd, const char *url, struct transfer *t,
     curl_easy_setopt(hnd, CURLOPT_FORBID_REUSE, 1L);
   if(host)
     curl_easy_setopt(hnd, CURLOPT_RESOLVE, host);
+  if(fresh_connect)
+    curl_easy_setopt(hnd, CURLOPT_FRESH_CONNECT, 1L);
 
   /* please be verbose */
   if(verbose) {
@@ -305,8 +307,10 @@ int main(int argc, char *argv[])
   int ch;
   struct curl_slist *host = NULL;
   const char *resolve = NULL;
+  size_t max_host_conns = 0;
+  int fresh_connect = 0;
 
-  while((ch = getopt(argc, argv, "aefhm:n:A:F:P:r:V:")) != -1) {
+  while((ch = getopt(argc, argv, "aefhm:n:xA:F:M:P:r:V:")) != -1) {
     switch(ch) {
     case 'h':
       usage(NULL);
@@ -326,11 +330,17 @@ int main(int argc, char *argv[])
     case 'n':
       transfer_count = (size_t)strtol(optarg, NULL, 10);
       break;
+    case 'x':
+      fresh_connect = 1;
+      break;
     case 'A':
       abort_offset = (size_t)strtol(optarg, NULL, 10);
       break;
     case 'F':
       fail_offset = (size_t)strtol(optarg, NULL, 10);
+      break;
+    case 'M':
+      max_host_conns = (size_t)strtol(optarg, NULL, 10);
       break;
     case 'P':
       pause_offset = (size_t)strtol(optarg, NULL, 10);
@@ -379,7 +389,7 @@ int main(int argc, char *argv[])
   curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_COOKIE);
   curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_DNS);
   curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
-  curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT);
+  /* curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_CONNECT); */
   curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_PSL);
   curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_HSTS);
 
@@ -391,6 +401,8 @@ int main(int argc, char *argv[])
 
   multi_handle = curl_multi_init();
   curl_multi_setopt(multi_handle, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
+  curl_multi_setopt(multi_handle, CURLMOPT_MAX_HOST_CONNECTIONS,
+                    (long)max_host_conns);
 
   active_transfers = 0;
   for(i = 0; i < transfer_count; ++i) {
@@ -406,7 +418,8 @@ int main(int argc, char *argv[])
     t = &transfers[i];
     t->easy = curl_easy_init();
     if(!t->easy ||
-       setup(t->easy, url, t, http_version, host, share, use_earlydata)) {
+       setup(t->easy, url, t, http_version, host, share, use_earlydata,
+             fresh_connect)) {
       fprintf(stderr, "[t-%d] FAILED setup\n", (int)i);
       return 1;
     }
@@ -486,7 +499,7 @@ int main(int argc, char *argv[])
             t->easy = curl_easy_init();
             if(!t->easy ||
                setup(t->easy, url, t, http_version, host, share,
-                     use_earlydata)) {
+                     use_earlydata, fresh_connect)) {
               fprintf(stderr, "[t-%d] FAILED setup\n", (int)i);
               return 1;
             }


### PR DESCRIPTION
Add test_02_33 to run with various values for the multi option CURLMOPT_MAX_HOST_CONNECTIONS and CURLOPT_FRESH_CONNECT to trigger connection pool limit handling code.

refs  #15127 where spurious crashes in this code are reported. Test is unable to reproduce but good for executing this code parts.