### PR TITLE
cmake: drop cmake args list from `buildinfo.txt`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,23 +46,6 @@
 cmake_minimum_required(VERSION 3.7...3.16 FATAL_ERROR)
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
-# Collect command-line arguments for buildinfo.txt.
-# Must reside at the top of the script to work as expected.
-get_cmake_property(_cache_vars CACHE_VARIABLES)
-unset(_cmake_args)
-foreach(_cache_var ${_cache_vars})
-  get_property(_cache_var_helpstring CACHE ${_cache_var} PROPERTY HELPSTRING)
-  if(_cache_var_helpstring STREQUAL "No help, variable specified on the command line.")
-    get_property(_cache_var_type CACHE ${_cache_var} PROPERTY TYPE)
-    if(_cache_var_type STREQUAL "UNINITIALIZED")
-      set(_cache_var_type)
-    else()
-      set(_cache_var_type ":${_cache_var_type}")
-    endif()
-    set(_cmake_args "${_cmake_args} -D${_cache_var}${_cache_var_type}=\"${${_cache_var}}\"")
-  endif()
-endforeach()
-
 function(curl_dumpvars)  # Dump all defined variables with their values
   message("::group::CMake Variable Dump")
   get_cmake_property(_vars VARIABLES)
@@ -2295,7 +2278,6 @@ set(_buildinfo "\
 buildinfo.configure.tool: cmake
 buildinfo.configure.command: ${CMAKE_COMMAND}
 buildinfo.configure.version: ${CMAKE_VERSION}
-buildinfo.configure.args:${_cmake_args}
 buildinfo.configure.generator: ${CMAKE_GENERATOR}
 buildinfo.configure.make: ${CMAKE_MAKE_PROGRAM}
 buildinfo.host.cpu: ${CMAKE_HOST_SYSTEM_PROCESSOR}


### PR DESCRIPTION
Collecting the args list has the undesired side-effect of silencing
CMake warnings about unused variables passed via the command-line.

Drop it till a better method is found to retrieve them.

Reported-by: Kai Pastor
Ref: https://github.com/curl/curl/pull/14936#issuecomment-2460350977
Follow-up to 1fdea1684602a1ae2870c67b5f3e8fd34f63da95 #14802
