### PR TITLE
macos: disable gcc `availability` workaround as needed

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -56,15 +56,17 @@
    fail.
    Fixed upstream in 14.2.0_1. Disable the workaround if the fix is detected.
  */
-#if defined(__APPLE__) &&                            \
-  !defined(__clang__) &&                             \
-  !defined(CURL_NO_APPLE_AVAILABILITY_WORKAROUND) && \
-  defined(__GNUC__) &&                               \
-  defined(__has_attribute) &&                        \
-  (defined(CURL_APPLE_AVAILABILITY_WORKAROUND) ||    \
-   !defined(__has_feature) ||                        \
-   !__has_feature(attribute_availability))
+#if defined(__APPLE__) &&                          \
+  !defined(__clang__) &&                           \
+  defined(__GNUC__) &&                             \
+  defined(__has_attribute) &&                      \
+  !defined(CURL_NO_APPLE_AVAILABILITY_WORKAROUND)
+/* Separate #if to make it compile with some non-Apple gcc compilers */
+#if defined(CURL_APPLE_AVAILABILITY_WORKAROUND) || \
+  !defined(__has_feature) ||                       \
+  !__has_feature(attribute_availability)
 #define availability curl_pp_attribute_disabled
+#endif
 #endif
 
 #if defined(__APPLE__)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -43,7 +43,7 @@
 #include <_mingw.h>
 #endif
 
-/* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0 (initial rev)
+/* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0 (initial build)
    that started advertising the `availability` attribute, which then gets used
    by Apple SDK, but, in a way incompatible with gcc, resulting in misc errors
    inside SDK headers, e.g.:

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -43,7 +43,10 @@
 #include <_mingw.h>
 #endif
 
-/* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0 and newer (as of 14.1.0)
+/* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0.
+   Fixed it 14.2.0_1. We also omit the workaround for 14.2.0 because there
+   is now way to tall 14.2.0_1 and 14.2.0 apart, and the workaround breaks
+   the fixed 14.2.0_1 version.
    that started advertising the `availability` attribute, which then gets used
    by Apple SDK, but, in a way incompatible with gcc, resulting in misc errors
    inside SDK headers, e.g.:
@@ -53,9 +56,13 @@
    Followed by missing declarations.
    Fix it by overriding the built-in feature-check macro used by the headers
    to enable the problematic attributes. This makes the feature check fail. */
-#if defined(__APPLE__) &&                \
-  !defined(__clang__) &&                 \
-  defined(__GNUC__) && __GNUC__ >= 12 && \
+#if defined(__APPLE__) &&                                 \
+  !defined(__clang__) &&                                  \
+  defined(__GNUC__) &&                                    \
+  (__GNUC__ == 12 ||                                      \
+   __GNUC__ == 13 ||                                      \
+  (__GNUC__ == 14 &&                                      \
+    defined(__GNUC_MINOR__) && (__GNUC_MINOR__ <= 1))) && \
   defined(__has_attribute)
 #define availability curl_pp_attribute_disabled
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -53,18 +53,15 @@
    Followed by missing declarations.
    Work it around by overriding the built-in feature-check macro used by the
    headers to enable the problematic attributes. This makes the feature check
-   fail.
-   Fixed upstream in 14.2.0_1. Disable the workaround if the fix is detected.
+   fail. Fixed in 14.2.0_1. Disable the workaround if the fix is detected.
  */
-#if defined(__APPLE__) &&                 \
-  !defined(__clang__) &&                  \
-  defined(__GNUC__) &&                    \
+#if defined(__APPLE__) && !defined(__clang__) && defined(__GNUC__) && \
   defined(__has_attribute)
-/* Separate #if to make it compile with some non-Apple gcc compilers */
-#if !defined(__has_feature) ||            \
-  !__has_feature(attribute_availability)
-#define availability curl_pp_attribute_disabled
-#endif
+#  if !defined(__has_feature)
+#    define availability curl_pp_attribute_disabled
+#  elif !__has_feature(attribute_availability)
+#    define availability curl_pp_attribute_disabled
+#  endif
 #endif
 
 #if defined(__APPLE__)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -56,14 +56,12 @@
    fail.
    Fixed upstream in 14.2.0_1. Disable the workaround if the fix is detected.
  */
-#if defined(__APPLE__) &&                          \
-  !defined(__clang__) &&                           \
-  defined(__GNUC__) &&                             \
-  defined(__has_attribute) &&                      \
-  !defined(CURL_NO_APPLE_AVAILABILITY_WORKAROUND)
+#if defined(__APPLE__) &&                 \
+  !defined(__clang__) &&                  \
+  defined(__GNUC__) &&                    \
+  defined(__has_attribute)
 /* Separate #if to make it compile with some non-Apple gcc compilers */
-#if defined(CURL_APPLE_AVAILABILITY_WORKAROUND) || \
-  !defined(__has_feature) ||                       \
+#if !defined(__has_feature) ||            \
   !__has_feature(attribute_availability)
 #define availability curl_pp_attribute_disabled
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -54,19 +54,16 @@
    Work it around by overriding the built-in feature-check macro used by the
    headers to enable the problematic attributes. This makes the feature check
    fail.
-   Fixed upstream in 14.2.0_1. We also omit the workaround for 14.2.0 because
-   there is no macro to tell 14.2.0_1 and 14.2.0 apart, and the workaround
-   breaks the fixed 14.2.0_1 version. */
-#if defined(__APPLE__) &&                                 \
-  !defined(__clang__) &&                                  \
-  !defined(CURL_NO_APPLE_AVAILABILITY_WORKAROUND) &&      \
-  defined(__GNUC__) &&                                    \
-  (defined(CURL_APPLE_AVAILABILITY_WORKAROUND) ||         \
-   __GNUC__ == 12 ||                                      \
-   __GNUC__ == 13 ||                                      \
-  (__GNUC__ == 14 &&                                      \
-    defined(__GNUC_MINOR__) && (__GNUC_MINOR__ <= 1))) && \
-  defined(__has_attribute)
+   Fixed upstream in 14.2.0_1. Disable the workaround if the fix is detected.
+ */
+#if defined(__APPLE__) &&                            \
+  !defined(__clang__) &&                             \
+  !defined(CURL_NO_APPLE_AVAILABILITY_WORKAROUND) && \
+  defined(__GNUC__) &&                               \
+  defined(__has_attribute) &&                        \
+  (defined(CURL_APPLE_AVAILABILITY_WORKAROUND) ||    \
+   !defined(__has_feature) ||                        \
+   !__has_feature(attribute_availability))
 #define availability curl_pp_attribute_disabled
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -53,8 +53,7 @@
    Followed by missing declarations.
    Work it around by overriding the built-in feature-check macro used by the
    headers to enable the problematic attributes. This makes the feature check
-   fail. Fixed in 14.2.0_1. Disable the workaround if the fix is detected.
- */
+   fail. Fixed in 14.2.0_1. Disable the workaround if the fix is detected. */
 #if defined(__APPLE__) && !defined(__clang__) && defined(__GNUC__) && \
   defined(__has_attribute)
 #  if !defined(__has_feature)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -45,7 +45,7 @@
 
 /* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0.
    Fixed it 14.2.0_1. We also omit the workaround for 14.2.0 because there
-   is now way to tall 14.2.0_1 and 14.2.0 apart, and the workaround breaks
+   is no macro to tell 14.2.0_1 and 14.2.0 apart, and the workaround breaks
    the fixed 14.2.0_1 version.
    that started advertising the `availability` attribute, which then gets used
    by Apple SDK, but, in a way incompatible with gcc, resulting in misc errors

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -58,8 +58,10 @@
    to enable the problematic attributes. This makes the feature check fail. */
 #if defined(__APPLE__) &&                                 \
   !defined(__clang__) &&                                  \
+  !defined(CURL_NO_APPLE_AVAILABILITY_WORKAROUND) &&      \
   defined(__GNUC__) &&                                    \
-  (__GNUC__ == 12 ||                                      \
+  (defined(CURL_APPLE_AVAILABILITY_WORKAROUND) ||         \
+   __GNUC__ == 12 ||                                      \
    __GNUC__ == 13 ||                                      \
   (__GNUC__ == 14 &&                                      \
     defined(__GNUC_MINOR__) && (__GNUC_MINOR__ <= 1))) && \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -43,10 +43,7 @@
 #include <_mingw.h>
 #endif
 
-/* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0.
-   Fixed it 14.2.0_1. We also omit the workaround for 14.2.0 because there
-   is no macro to tell 14.2.0_1 and 14.2.0 apart, and the workaround breaks
-   the fixed 14.2.0_1 version.
+/* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0 (initial rev)
    that started advertising the `availability` attribute, which then gets used
    by Apple SDK, but, in a way incompatible with gcc, resulting in misc errors
    inside SDK headers, e.g.:
@@ -54,8 +51,12 @@
             definition
      error: expected ',' or '}' before
    Followed by missing declarations.
-   Fix it by overriding the built-in feature-check macro used by the headers
-   to enable the problematic attributes. This makes the feature check fail. */
+   Work it around by overriding the built-in feature-check macro used by the
+   headers to enable the problematic attributes. This makes the feature check
+   fail.
+   Fixed upstream in 14.2.0_1. We also omit the workaround for 14.2.0 because
+   there is no macro to tell 14.2.0_1 and 14.2.0 apart, and the workaround
+   breaks the fixed 14.2.0_1 version. */
 #if defined(__APPLE__) &&                                 \
   !defined(__clang__) &&                                  \
   !defined(CURL_NO_APPLE_AVAILABILITY_WORKAROUND) &&      \


### PR DESCRIPTION
Homebrew gcc 14.2.0_1 fixed the issue, and the workaround is no longer
needed. Not only not needed, but the workaround is breaking builds with
the fixed gcc.

Auto-detect the upstream fix and stop applying the local workaround if
detected.

Assisted-by: Bo Anderson
Ref: https://github.com/Homebrew/homebrew-core/issues/194778#issuecomment-2462764619
Follow-up to e91fcbac7d86292858718a0bfebad57978761af4 #14155
