### PR TITLE
Fixing HTTP content decoding enabled (broken in commit 30da1f5)

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1146,7 +1146,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     /*
      * raw data passed to the application when content encoding is used
      */
-    data->set.http_ce_skip = enabled;
+    data->set.http_ce_skip = !enabled; /* reversed */
     break;
 
 #if !defined(CURL_DISABLE_FTP) || defined(USE_SSH)


### PR DESCRIPTION
Hi
I found the logic handling CURLOPT_HTTP_CONTENT_DECODING was broken in [setopt: split Curl_vsetopt() into several sub functions](https://github.com/curl/curl/commit/30da1f5974d34841b30c4fac3fa5837386f15589).
This PR should fix it