### PR TITLE
GHA: add `apt update` where missing

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -42,6 +42,7 @@ jobs:
   #      - name: install prereqs
   #        run: |
   #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+  #          sudo apt-get update -y
   #          sudo apt-get install -y --no-install-suggests --no-install-recommends \
   #            python3-proselint
   #

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -50,12 +50,14 @@ jobs:
       - name: install
         env:
           DEBIAN_FRONTEND: noninteractive
-        run: >-
-          sudo apt-get install -y --no-install-suggests --no-install-recommends
-          codespell python3-pip python3-networkx python3-pydot python3-yaml
-          python3-toml python3-markupsafe python3-jinja2 python3-tabulate
-          python3-typing-extensions python3-libcst python3-impacket
-          python3-websockets python3-pytest &&
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+            codespell python3-pip python3-networkx python3-pydot python3-yaml \
+            python3-toml python3-markupsafe python3-jinja2 python3-tabulate \
+            python3-typing-extensions python3-libcst python3-impacket \
+            python3-websockets python3-pytest
           python3 -m pip install --break-system-packages cmakelint==1.4.3 pytype==2024.9.13 ruff==0.6.8
 
       - name: spellcheck


### PR DESCRIPTION
To mitigate this kind of error:
```
Err:14 http://azure.archive.ubuntu.com/ubuntu noble-updates/main amd64 python3-werkzeug all 3.0.1-3ubuntu0.1
  404  Not Found [IP: 40.81.13.82 80]
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/p/python-werkzeug/python3-werkzeug_3.0.1-3ubuntu0.1_all.deb  404  Not Found [IP: 40.81.13.82 80]
Fetched 10.4 MB in 4s (2593 kB/s)
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```
https://github.com/curl/curl/actions/runs/11732257460/job/32684111508#step:3:74

Follow-up to 842f88434f627c0330e263a3881b2d9438786b32 #15082