### PR TITLE
lib: replace `inline` redefine with `CURL_INLINE` macro

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -981,25 +981,25 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #endif
 
 #if defined(inline)
-  /* 'inline' is defined as macro and assumed to be correct */
-  /* No need for 'inline' replacement */
+/* 'inline' is defined as macro and assumed to be correct */
+#  define CURL_INLINE inline /* No need for 'inline' replacement */
 #elif defined(__cplusplus)
-  /* The code is compiled with C++ compiler.
-     C++ always supports 'inline'. */
-  /* No need for 'inline' replacement */
+/* The code is compiled with C++ compiler.
+   C++ always supports 'inline'. */
+#  define CURL_INLINE inline /* No need for 'inline' replacement */
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901
-  /* C99 (and later) supports 'inline' keyword */
-  /* No need for 'inline' replacement */
+/* C99 (and later) supports 'inline' keyword */
+#  define CURL_INLINE inline /* No need for 'inline' replacement */
 #elif defined(__GNUC__) && __GNUC__ >= 3
-  /* GCC supports '__inline__' as an extension */
-#  define inline __inline__
+/* GCC supports '__inline__' as an extension */
+#  define CURL_INLINE __inline__
 #elif defined(_MSC_VER) && _MSC_VER >= 1400
-  /* MSC supports '__inline' from VS 2005 (or even earlier) */
-#  define inline __inline
+/* MSC supports '__inline' from VS 2005 (or even earlier) */
+#  define CURL_INLINE __inline
 #else
-  /* Probably 'inline' is not supported by compiler.
-     Define to the empty string to be on the safe side. */
-#  define inline /* empty */
+/* Probably 'inline' is not supported by compiler.
+   Define to the empty string to be on the safe side. */
+#  define CURL_INLINE /* empty */
 #endif
 
 #endif /* HEADER_CURL_SETUP_H */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -980,16 +980,17 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #define OPENSSL_SUPPRESS_DEPRECATED
 #endif
 
-#if defined(inline)
-/* 'inline' is defined as macro and assumed to be correct */
-#  define CURL_INLINE inline /* No need for 'inline' replacement */
+#if defined(CURL_INLINE)
+/* 'CURL_INLINE' defined, use as-is */
+#elif defined(inline)
+#  define CURL_INLINE inline /* 'inline' defined, assumed correct */
 #elif defined(__cplusplus)
 /* The code is compiled with C++ compiler.
    C++ always supports 'inline'. */
-#  define CURL_INLINE inline /* No need for 'inline' replacement */
+#  define CURL_INLINE inline /* 'inline' keyword supported */
 #elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901
 /* C99 (and later) supports 'inline' keyword */
-#  define CURL_INLINE inline /* No need for 'inline' replacement */
+#  define CURL_INLINE inline /* 'inline' keyword supported */
 #elif defined(__GNUC__) && __GNUC__ >= 3
 /* GCC supports '__inline__' as an extension */
 #  define CURL_INLINE __inline__

--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -283,7 +283,7 @@ Curl_sha512_256_finish(unsigned char *digest,
 #ifdef __GNUC__
 #  if defined(__has_attribute) && defined(__STDC_VERSION__)
 #    if __has_attribute(always_inline) && __STDC_VERSION__ >= 199901
-#      define MHDX_INLINE inline __attribute__((always_inline))
+#      define MHDX_INLINE CURL_INLINE __attribute__((always_inline))
 #    endif
 #  endif
 #endif
@@ -296,9 +296,9 @@ Curl_sha512_256_finish(unsigned char *digest,
 #endif
 
 #if !defined(MHDX_INLINE)
-   /* Assume that 'inline' keyword works or the
+   /* Assume that 'CURL_INLINE' keyword works or the
     * macro was already defined correctly. */
-#  define MHDX_INLINE inline
+#  define MHDX_INLINE CURL_INLINE
 #endif
 
 /* Bits manipulation macros and functions.

--- a/lib/easy_lock.h
+++ b/lib/easy_lock.h
@@ -69,7 +69,7 @@
 
 #endif
 
-static inline void curl_simple_lock_lock(curl_simple_lock *lock)
+static CURL_INLINE void curl_simple_lock_lock(curl_simple_lock *lock)
 {
   for(;;) {
     if(!atomic_exchange_explicit(lock, true, memory_order_acquire))
@@ -88,7 +88,7 @@ static inline void curl_simple_lock_lock(curl_simple_lock *lock)
   }
 }
 
-static inline void curl_simple_lock_unlock(curl_simple_lock *lock)
+static CURL_INLINE void curl_simple_lock_unlock(curl_simple_lock *lock)
 {
   atomic_store_explicit(lock, false, memory_order_release);
 }


### PR DESCRIPTION
Instead of redefining the `inline` keyword, introduce curl's own
`CURL_INLINE` macro and set it depending on the compiler's capabilities,
or use its value set via custom C flags.

Also keep honoring a custom `inline` macro, if set.

---

w/o whitespace: https://github.com/curl/curl/pull/15523/files?w=1
