### PR TITLE
build: use `_fseeki64()` on Windows, drop detections

### DIFF
--- a/CMake/Platforms/WindowsCache.cmake
+++ b/CMake/Platforms/WindowsCache.cmake
@@ -148,7 +148,6 @@ set(HAVE_TERMIO_H 0)
 set(HAVE_LINUX_TCP_H 0)
 
 set(HAVE_FSEEKO 0)  # mingw-w64 2.0.0 and newer has it
-set(HAVE__FSEEKI64 1)
 set(HAVE_SOCKET 1)
 set(HAVE_SELECT 1)
 set(HAVE_STRDUP 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1570,7 +1570,6 @@ check_symbol_exists("freeaddrinfo"    "${CURL_INCLUDES}" HAVE_FREEADDRINFO)  # w
 check_function_exists("pipe"          HAVE_PIPE)
 check_function_exists("eventfd"       HAVE_EVENTFD)
 check_symbol_exists("ftruncate"       "unistd.h" HAVE_FTRUNCATE)
-check_function_exists("_fseeki64"     HAVE__FSEEKI64)
 check_symbol_exists("getpeername"     "${CURL_INCLUDES}" HAVE_GETPEERNAME)  # winsock2.h unistd.h proto/bsdsocket.h
 check_symbol_exists("getsockname"     "${CURL_INCLUDES}" HAVE_GETSOCKNAME)  # winsock2.h unistd.h proto/bsdsocket.h
 check_function_exists("if_nametoindex"  HAVE_IF_NAMETOINDEX)  # winsock2.h net/if.h

--- a/configure.ac
+++ b/configure.ac
@@ -4100,7 +4100,6 @@ AC_CHECK_DECLS([getpwuid_r], [], [AC_DEFINE(HAVE_DECL_GETPWUID_R_MISSING, 1, "Se
           #include <sys/types.h>]])
 
 AC_CHECK_FUNCS([\
-  _fseeki64 \
   eventfd \
   fnmatch \
   geteuid \

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -427,10 +427,6 @@ Vista
 #  endif
 #endif
 
-#ifdef USE_WIN32_LARGE_FILES
-#define HAVE__FSEEKI64
-#endif
-
 /* Define to the size of `off_t', as computed by sizeof. */
 #if defined(__MINGW32__) && \
   defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -246,9 +246,6 @@
 /* Define to 1 if you have the fseeko declaration. */
 #cmakedefine HAVE_DECL_FSEEKO 1
 
-/* Define to 1 if you have the _fseeki64 function. */
-#cmakedefine HAVE__FSEEKI64 1
-
 /* Define to 1 if you have the ftruncate function. */
 #cmakedefine HAVE_FTRUNCATE 1
 

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -793,7 +793,7 @@ static CURLcode setname(curl_mimepart *part, const char *name, size_t len)
 /* wrap call to fseeko so it matches the calling convention of callback */
 static int fseeko_wrapper(void *stream, curl_off_t offset, int whence)
 {
-#if defined(HAVE__FSEEKI64)
+#if defined(_WIN32) && defined(USE_WIN32_LARGE_FILES)
   return _fseeki64(stream, (__int64)offset, whence);
 #elif defined(HAVE_FSEEKO) && defined(HAVE_DECL_FSEEKO)
   return fseeko(stream, (off_t)offset, whence);


### PR DESCRIPTION
A recent update caused CMake builds to mis-detect this symbol on iOS.
Auto-detection also seems redundant given that it's a Windows-only
function and most Windows builds were already opted-in.

Drop detections and use it in all Windows builds with large file support
enabled.

Feature history:
- pririotizing for Windows: aaacd02466f77d03b8fdc19e91a0a3ec72f4c38a #14678
- Windows opt-in cmake: 8e74c0729d0cace00a202fc6c33c1b35703e220a #11950
- Windows opt-in: aa6c94c5bf4f5caa31c0213d9cd7058c29a9b30b #11944
- use in libcurl: 9c7165e96a3a9a2d0b7059c87c699b5ca8cdae93 #11918
- use in example: 817d1c01064ac81e9609819b15738ee540ef056c

Regression from 8e345057761a8f796403923a96f2c8fd3edca647 #15164

Reported-by: Maarten Billemont
Fixes #15525
