### PR TITLE
Docs: result checking in line with coding style rules.

### DIFF
--- a/docs/examples/certinfo.c
+++ b/docs/examples/certinfo.c
@@ -57,12 +57,12 @@ int main(void)
 
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       struct curl_certinfo *certinfo;
 
       res = curl_easy_getinfo(curl, CURLINFO_CERTINFO, &certinfo);
 
-      if(!res && certinfo) {
+      if(CURLE_OK == res && certinfo) {
         int i;
 
         printf("%d certs!\n", certinfo->num_of_certs);

--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -165,7 +165,7 @@ int main(void)
 
     close(sockfd);
 
-    if(res) {
+    if(res != CURLE_OK) {
       printf("libcurl error: %d\n", res);
       return 4;
     }

--- a/docs/examples/sessioninfo.c
+++ b/docs/examples/sessioninfo.c
@@ -49,7 +49,7 @@ static size_t wrfu(void *ptr, size_t size, size_t nmemb, void *stream)
 
   res = curl_easy_getinfo(curl, CURLINFO_TLS_SESSION, &info);
 
-  if(!res) {
+  if(CURLE_OK == res) {
     switch(info->backend) {
     case CURLSSLBACKEND_GNUTLS:
       /* info->internals is now the gnutls_session_t */

--- a/docs/examples/sftpuploadresume.c
+++ b/docs/examples/sftpuploadresume.c
@@ -66,7 +66,7 @@ static curl_off_t sftpGetRemoteFileSize(const char *i_remoteFile)
     result = curl_easy_getinfo(curlHandlePtr,
                                CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                                &remoteFileSizeByte);
-    if(result)
+    if(result != CURLE_OK)
       return -1;
     printf("filesize: %lu\n", (unsigned long)remoteFileSizeByte);
   }

--- a/docs/examples/websocket.c
+++ b/docs/examples/websocket.c
@@ -51,7 +51,7 @@ static int recv_pong(CURL *curl, const char *expected_payload)
   const struct curl_ws_frame *meta;
   char buffer[256];
   CURLcode result = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
-  if(!result) {
+  if(CURLE_OK == result) {
     if(meta->flags & CURLWS_PONG) {
       int same = 0;
       fprintf(stderr, "ws: got PONG back\n");

--- a/docs/libcurl/curl_easy_cleanup.md
+++ b/docs/libcurl/curl_easy_cleanup.md
@@ -65,7 +65,7 @@ int main(void)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     res = curl_easy_perform(curl);
-    if(res)
+    if(res != CURLE_OK)
       printf("error: %s\n", curl_easy_strerror(res));
     curl_easy_cleanup(curl);
   }

--- a/docs/libcurl/curl_ws_recv.md
+++ b/docs/libcurl/curl_ws_recv.md
@@ -59,7 +59,7 @@ int main(void)
   CURL *curl = curl_easy_init();
   if(curl) {
     CURLcode res = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
-    if(res)
+    if(res != CURLE_OK)
       printf("error: %s\n", curl_easy_strerror(res));
   }
 }

--- a/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
@@ -65,7 +65,7 @@ int main(void)
 
     /* Extract the socket from the curl handle */
     res = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);
-    if(!res && sockfd != CURL_SOCKET_BAD) {
+    if(CURLE_OK == res && sockfd != CURL_SOCKET_BAD) {
       /* operate on sockfd */
     }
 

--- a/docs/libcurl/opts/CURLINFO_CERTINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.md
@@ -71,12 +71,12 @@ int main(void)
 
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       int i;
       struct curl_certinfo *ci;
       res = curl_easy_getinfo(curl, CURLINFO_CERTINFO, &ci);
 
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("%d certs!\n", ci->num_of_certs);
 
         for(i = 0; i < ci->num_of_certs; i++) {

--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
@@ -60,11 +60,11 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* check the time condition */
       long unmet;
       res = curl_easy_getinfo(curl, CURLINFO_CONDITION_UNMET, &unmet);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("The time condition was %sfulfilled\n", unmet?"NOT":"");
       }
     }

--- a/docs/libcurl/opts/CURLINFO_CONN_ID.md
+++ b/docs/libcurl/opts/CURLINFO_CONN_ID.md
@@ -51,10 +51,10 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       curl_off_t conn_id;
       res = curl_easy_getinfo(curl, CURLINFO_CONN_ID, &conn_id);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Connection used: %" CURL_FORMAT_CURL_OFF_T "\n", conn_id);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
@@ -50,11 +50,11 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* check the size */
       double cl;
       res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD, &cl);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Size: %.0f\n", cl);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.md
@@ -47,11 +47,11 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* check the size */
       curl_off_t cl;
       res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Download size: %" CURL_FORMAT_CURL_OFF_T "\n", cl);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.md
@@ -49,11 +49,11 @@ int main(void)
     /* Perform the upload */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* check the size */
       double cl;
       res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_UPLOAD, &cl);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Size: %.0f\n", cl);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.md
@@ -46,11 +46,11 @@ int main(void)
     /* Perform the upload */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* check the size */
       curl_off_t cl;
       res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_UPLOAD_T, &cl);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Upload size: %" CURL_FORMAT_CURL_OFF_T "\n", cl);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.md
@@ -54,11 +54,11 @@ int main(void)
 
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* extract the content-type */
       char *ct = NULL;
       res = curl_easy_getinfo(curl, CURLINFO_CONTENT_TYPE, &ct);
-      if(!res && ct) {
+      if(CURLE_OK == res && ct) {
         printf("Content-Type: %s\n", ct);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_COOKIELIST.md
+++ b/docs/libcurl/opts/CURLINFO_COOKIELIST.md
@@ -54,11 +54,11 @@ int main(void)
 
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* extract all known cookies */
       struct curl_slist *cookies = NULL;
       res = curl_easy_getinfo(curl, CURLINFO_COOKIELIST, &cookies);
-      if(!res && cookies) {
+      if(CURLE_OK == res && cookies) {
         /* a linked list of cookies in cookie file format */
         struct curl_slist *each = cookies;
         while(each) {

--- a/docs/libcurl/opts/CURLINFO_EARLYDATA_SENT_T.md
+++ b/docs/libcurl/opts/CURLINFO_EARLYDATA_SENT_T.md
@@ -57,10 +57,10 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       curl_off_t amount;
       res = curl_easy_getinfo(curl, CURLINFO_EARLYDATA_SENT_T, &amount);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("TLS earlydata: %" CURL_FORMAT_CURL_OFF_T " bytes\n", amount);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.md
+++ b/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.md
@@ -49,11 +49,11 @@ int main(void)
 
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* extract the entry path */
       char *ep = NULL;
       res = curl_easy_getinfo(curl, CURLINFO_FTP_ENTRY_PATH, &ep);
-      if(!res && ep) {
+      if(CURLE_OK == res && ep) {
         printf("Entry path was: %s\n", ep);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
@@ -49,7 +49,7 @@ int main(void)
     if(res == CURLE_OK) {
       long size;
       res = curl_easy_getinfo(curl, CURLINFO_HEADER_SIZE, &size);
-      if(!res)
+      if(CURLE_OK == res)
         printf("Header size: %ld bytes\n", size);
     }
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.md
+++ b/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.md
@@ -46,11 +46,11 @@ int main(void)
 
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* extract the available authentication types */
       long auth;
       res = curl_easy_getinfo(curl, CURLINFO_HTTPAUTH_AVAIL, &auth);
-      if(!res) {
+      if(CURLE_OK == res) {
         if(!auth)
           printf("No auth available, perhaps no 401?\n");
         else {

--- a/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.md
+++ b/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.md
@@ -46,10 +46,10 @@ int main(void)
     /* typically CONNECT is used to do HTTPS over HTTP proxies */
     curl_easy_setopt(curl, CURLOPT_PROXY, "http://127.0.0.1");
     res = curl_easy_perform(curl);
-    if(res == CURLE_OK) {
+    if(CURLE_OK == res) {
       long code;
       res = curl_easy_getinfo(curl, CURLINFO_HTTP_CONNECTCODE, &code);
-      if(!res && code)
+      if(CURLE_OK == res && code)
         printf("The CONNECT response code: %03ld\n", code);
     }
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
@@ -65,7 +65,7 @@ int main(void)
 
     /* Extract the socket from the curl handle */
     res = curl_easy_getinfo(curl, CURLINFO_LASTSOCKET, &sockfd);
-    if(!res && sockfd != -1) {
+    if(CURLE_OK == res && sockfd != -1) {
       /* operate on sockfd */
     }
 

--- a/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
+++ b/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
@@ -46,10 +46,10 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     res = curl_easy_perform(curl);
-    if(res == CURLE_OK) {
+    if(CURLE_OK == res) {
       long connects;
       res = curl_easy_getinfo(curl, CURLINFO_NUM_CONNECTS, &connects);
-      if(!res)
+      if(CURLE_OK == res)
         printf("It needed %ld connects\n", connects);
     }
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
@@ -53,7 +53,7 @@ int main(void)
     if(res != CURLE_OK) {
       long error;
       res = curl_easy_getinfo(curl, CURLINFO_OS_ERRNO, &error);
-      if(!res && error) {
+      if(CURLE_OK == res && error) {
         printf("Errno: %ld\n", error);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.md
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.md
@@ -48,10 +48,10 @@ int main(void)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     res = curl_easy_perform(curl);
-    if(res == CURLE_OK) {
+    if(CURLE_OK == res) {
       long port;
       res = curl_easy_getinfo(curl, CURLINFO_PRIMARY_PORT, &port);
-      if(!res)
+      if(CURLE_OK == res)
         printf("Connected to remote port: %ld\n", port);
     }
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLINFO_PRIVATE.md
+++ b/docs/libcurl/opts/CURLINFO_PRIVATE.md
@@ -52,7 +52,7 @@ int main(void)
     /* extract the private pointer again */
     res = curl_easy_getinfo(curl, CURLINFO_PRIVATE, &pointer);
 
-    if(res)
+    if(res != CURLE_OK)
       printf("error: %s\n", curl_easy_strerror(res));
 
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.md
+++ b/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.md
@@ -47,11 +47,11 @@ int main(void)
 
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* extract the available proxy authentication types */
       long auth;
       res = curl_easy_getinfo(curl, CURLINFO_PROXYAUTH_AVAIL, &auth);
-      if(!res) {
+      if(CURLE_OK == res) {
         if(!auth)
           printf("No proxy auth available, perhaps no 407?\n");
         else {

--- a/docs/libcurl/opts/CURLINFO_PROXY_ERROR.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_ERROR.md
@@ -86,10 +86,10 @@ int main(void)
 
     curl_easy_setopt(curl, CURLOPT_PROXY, "socks5://127.0.0.1");
     res = curl_easy_perform(curl);
-    if(res == CURLE_PROXY) {
+    if(CURLE_PROXY == res) {
       long proxycode;
       res = curl_easy_getinfo(curl, CURLINFO_PROXY_ERROR, &proxycode);
-      if(!res && proxycode)
+      if(CURLE_OK == res && proxycode)
         printf("The detailed proxy error: %ld\n", proxycode);
     }
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
@@ -53,7 +53,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_PROXY, "https://proxy:443");
 
     res = curl_easy_perform(curl);
-    if(res) {
+    if(res != CURLE_OK) {
       printf("error: %s\n", curl_easy_strerror(res));
       curl_easy_cleanup(curl);
       return 1;
@@ -61,7 +61,7 @@ int main(void)
 
     res = curl_easy_getinfo(curl, CURLINFO_PROXY_SSL_VERIFYRESULT,
                             &verifyresult);
-    if(!res) {
+    if(CURLE_OK == res) {
       printf("The peer verification said %s\n",
              (verifyresult ? "bad" : "fine"));
     }

--- a/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.md
@@ -44,10 +44,10 @@ int main(void)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     res = curl_easy_perform(curl);
-    if(res == CURLE_OK) {
+    if(CURLE_OK == res) {
       long req;
       res = curl_easy_getinfo(curl, CURLINFO_REQUEST_SIZE, &req);
-      if(!res)
+      if(CURLE_OK == res)
         printf("Request size: %ld bytes\n", req);
     }
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.md
@@ -53,11 +53,11 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* check the size */
       double dl;
       res = curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD, &dl);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Downloaded %.0f bytes\n", dl);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.md
@@ -50,11 +50,11 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* check the size */
       curl_off_t dl;
       res = curl_easy_getinfo(curl, CURLINFO_SIZE_DOWNLOAD_T, &dl);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Downloaded %" CURL_FORMAT_CURL_OFF_T " bytes\n", dl);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.md
@@ -50,10 +50,10 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       double ul;
       res = curl_easy_getinfo(curl, CURLINFO_SIZE_UPLOAD, &ul);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Uploaded %.0f bytes\n", ul);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.md
@@ -47,10 +47,10 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       curl_off_t ul;
       res = curl_easy_getinfo(curl, CURLINFO_SIZE_UPLOAD_T, &ul);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Uploaded %" CURL_FORMAT_CURL_OFF_T " bytes\n", ul);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.md
@@ -50,10 +50,10 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       double speed;
       res = curl_easy_getinfo(curl, CURLINFO_SPEED_DOWNLOAD, &speed);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Download speed %.0f bytes/sec\n", speed);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.md
@@ -47,10 +47,10 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       curl_off_t speed;
       res = curl_easy_getinfo(curl, CURLINFO_SPEED_DOWNLOAD_T, &speed);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Download speed %" CURL_FORMAT_CURL_OFF_T " bytes/sec\n",
                speed);
       }

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.md
@@ -48,10 +48,10 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       double speed;
       res = curl_easy_getinfo(curl, CURLINFO_SPEED_UPLOAD, &speed);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Upload speed %.0f bytes/sec\n", speed);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.md
@@ -46,10 +46,10 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       curl_off_t speed;
       res = curl_easy_getinfo(curl, CURLINFO_SPEED_UPLOAD_T, &speed);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Upload speed %" CURL_FORMAT_CURL_OFF_T " bytes/sec\n", speed);
       }
     }

--- a/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
@@ -52,7 +52,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     res = curl_easy_perform(curl);
-    if(res) {
+    if(res != CURLE_OK) {
       printf("error: %s\n", curl_easy_strerror(res));
       curl_easy_cleanup(curl);
       return 1;
@@ -60,7 +60,7 @@ int main(void)
 
     res = curl_easy_getinfo(curl, CURLINFO_SSL_VERIFYRESULT,
                             &verifyresult);
-    if(!res) {
+    if(CURLE_OK == res) {
       printf("The peer verification said %s\n",
              (verifyresult ? "bad" : "fine"));
     }

--- a/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
@@ -61,7 +61,7 @@ int main(void)
     struct curl_tlssessioninfo *tls;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     res = curl_easy_perform(curl);
-    if(res)
+    if(res != CURLE_OK)
       printf("error: %s\n", curl_easy_strerror(res));
     curl_easy_getinfo(curl, CURLINFO_TLS_SESSION, &tls);
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
@@ -147,7 +147,7 @@ static size_t wf(void *ptr, size_t size, size_t nmemb, void *stream)
 {
   const struct curl_tlssessioninfo *info = NULL;
   CURLcode res = curl_easy_getinfo(curl, CURLINFO_TLS_SSL_PTR, &info);
-  if(info && !res) {
+  if(info && CURLE_OK == res) {
     if(CURLSSLBACKEND_OPENSSL == info->backend) {
       printf("OpenSSL ver. %s\n", SSL_get_version((SSL*)info->internals));
     }

--- a/docs/libcurl/opts/CURLINFO_USED_PROXY.md
+++ b/docs/libcurl/opts/CURLINFO_USED_PROXY.md
@@ -48,11 +48,11 @@ int main(int argc, char *argv[])
 
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       /* extract the available proxy authentication types */
       long used;
       res = curl_easy_getinfo(curl, CURLINFO_USED_PROXY, &used);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("The proxy was %sused\n", used ? "": "NOT ");
       }
     }

--- a/docs/libcurl/opts/CURLINFO_XFER_ID.md
+++ b/docs/libcurl/opts/CURLINFO_XFER_ID.md
@@ -51,10 +51,10 @@ int main(void)
     /* Perform the request */
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       curl_off_t xfer_id;
       res = curl_easy_getinfo(curl, CURLINFO_XFER_ID, &xfer_id);
-      if(!res) {
+      if(CURLE_OK == res) {
         printf("Transfer ID: %" CURL_FORMAT_CURL_OFF_T "\n", xfer_id);
       }
     }

--- a/docs/libcurl/opts/CURLOPT_CERTINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CERTINFO.md
@@ -64,11 +64,11 @@ int main(void)
 
     res = curl_easy_perform(curl);
 
-    if(!res) {
+    if(CURLE_OK == res) {
       struct curl_certinfo *ci;
       res = curl_easy_getinfo(curl, CURLINFO_CERTINFO, &ci);
 
-      if(!res) {
+      if(CURLE_OK == res) {
         int i;
         printf("%d certs!\n", ci->num_of_certs);
 


### PR DESCRIPTION
This patch replaces `!res` with `CURLE_OK == res` in examples. I believe that's closer to https://github.com/curl/curl/blob/b723f6a445b4d5757db915fe9946158e4158def4/docs/internals/CODE_STYLE.md#use-boolean-conditions which clearly states `!result` means error condition.

A few occurrences of `res == CURLE_OK` are replaced with `CURLE_OK == res` for consistency. Although assignment mistakes are detected by modern  compilers, and such a style is not among my personal preferences elther, I believe most C coders still would place constant first.

And a few `if (res)` are made more verbose `if (res != CURLE_OK)` for clarity and consistency. At a glance `if (res)` looks checking for success. If it was `if (err)` that would be okay, but `CURLstatus` is a status which can hold success, not errors only.