### PR TITLE
curl.h: mark two error codes as obsolete

### DIFF
--- a/docs/libcurl/libcurl-errors.md
+++ b/docs/libcurl/libcurl-errors.md
@@ -203,9 +203,9 @@ Not used in modern versions.
 
 The server does not support or accept range requests.
 
-## CURLE_HTTP_POST_ERROR (34)
+## Obsolete error (34)
 
-This is an odd error that mainly occurs due to internal confusion.
+Not used since 7.56.0.
 
 ## CURLE_SSL_CONNECT_ERROR (35)
 
@@ -236,9 +236,9 @@ LDAP search failed.
 
 Not used in modern versions.
 
-## CURLE_FUNCTION_NOT_FOUND (41)
+## Obsolete error (41)
 
-Function not found. A required zlib function was not found.
+Not used since 7.53.0.
 
 ## CURLE_ABORTED_BY_CALLBACK (42)
 

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -551,14 +551,14 @@ typedef enum {
   CURLE_FTP_COULDNT_USE_REST,    /* 31 - the REST command failed */
   CURLE_OBSOLETE32,              /* 32 - NOT USED */
   CURLE_RANGE_ERROR,             /* 33 - RANGE "command" did not work */
-  CURLE_HTTP_POST_ERROR,         /* 34 */
+  CURLE_OBSOLETE34,              /* 34 */
   CURLE_SSL_CONNECT_ERROR,       /* 35 - wrong when connecting with SSL */
   CURLE_BAD_DOWNLOAD_RESUME,     /* 36 - could not resume download */
   CURLE_FILE_COULDNT_READ_FILE,  /* 37 */
   CURLE_LDAP_CANNOT_BIND,        /* 38 */
   CURLE_LDAP_SEARCH_FAILED,      /* 39 */
   CURLE_OBSOLETE40,              /* 40 - NOT USED */
-  CURLE_FUNCTION_NOT_FOUND,      /* 41 - NOT USED starting with 7.53.0 */
+  CURLE_OBSOLETE41,              /* 41 - NOT USED starting with 7.53.0 */
   CURLE_ABORTED_BY_CALLBACK,     /* 42 */
   CURLE_BAD_FUNCTION_ARGUMENT,   /* 43 */
   CURLE_OBSOLETE44,              /* 44 - NOT USED */
@@ -642,6 +642,12 @@ typedef enum {
 
 #ifndef CURL_NO_OLDIES /* define this to test if your app builds with all
                           the obsolete stuff removed! */
+
+/* removed in 7.53.0 */
+#define CURLE_FUNCTION_NOT_FOUND CURLE_OBSOLETE41
+
+/* removed in 7.56.0 */
+#define CURLE_HTTP_POST_ERROR CURLE_OBSOLETE34
 
 /* Previously obsolete error code reused in 7.38.0 */
 #define CURLE_OBSOLETE16 CURLE_HTTP2

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -151,9 +151,6 @@ curl_easy_strerror(CURLcode error)
   case CURLE_RANGE_ERROR:
     return "Requested range was not delivered by the server";
 
-  case CURLE_HTTP_POST_ERROR:
-    return "Internal problem setting up the POST";
-
   case CURLE_SSL_CONNECT_ERROR:
     return "SSL connect error";
 
@@ -168,9 +165,6 @@ curl_easy_strerror(CURLcode error)
 
   case CURLE_LDAP_SEARCH_FAILED:
     return "LDAP: search failed";
-
-  case CURLE_FUNCTION_NOT_FOUND:
-    return "A required function in the library was not found";
 
   case CURLE_ABORTED_BY_CALLBACK:
     return "Operation was aborted by an application callback";
@@ -330,7 +324,9 @@ curl_easy_strerror(CURLcode error)
   case CURLE_OBSOLETE24:
   case CURLE_OBSOLETE29:
   case CURLE_OBSOLETE32:
+  case CURLE_OBSOLETE34:
   case CURLE_OBSOLETE40:
+  case CURLE_OBSOLETE41:
   case CURLE_OBSOLETE44:
   case CURLE_OBSOLETE46:
   case CURLE_OBSOLETE50:

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -145,7 +145,6 @@ static bool is_fatal_error(CURLcode code)
   case CURLE_FAILED_INIT:
   case CURLE_OUT_OF_MEMORY:
   case CURLE_UNKNOWN_OPTION:
-  case CURLE_FUNCTION_NOT_FOUND:
   case CURLE_BAD_FUNCTION_ARGUMENT:
     /* critical error */
     return TRUE;

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -66,14 +66,14 @@ e30: FTP: command PORT failed
 e31: FTP: command REST failed
 e32: Unknown error
 e33: Requested range was not delivered by the server
-e34: Internal problem setting up the POST
+e34: Unknown error
 e35: SSL connect error
 e36: Could not resume download
 e37: Could not read a file:// file
 e38: LDAP: cannot bind
 e39: LDAP: search failed
 e40: Unknown error
-e41: A required function in the library was not found
+e41: Unknown error
 e42: Operation was aborted by an application callback
 e43: A libcurl function was given a bad argument
 e44: Unknown error


### PR DESCRIPTION
Not used by libcurl since many years