### PR TITLE
Docs: Add result code on prereqfunction failure

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
@@ -51,7 +51,8 @@ This function may be called multiple times if redirections are enabled and are
 being followed (see CURLOPT_FOLLOWLOCATION(3)).
 
 The callback function must return *CURL_PREREQFUNC_OK* on success, or
-*CURL_PREREQFUNC_ABORT* to cause the transfer to fail.
+*CURL_PREREQFUNC_ABORT* to cause the transfer to fail with result
+*CURLE_ABORTED_BY_CALLBACK*.
 
 This function is passed the following arguments:
 


### PR DESCRIPTION
Pretty trivial change, but I had to search the code (or just try it out) to find the answer to this, so I figure someone else will have to at some point, too.

Most (all?) other callbacks that can abort a transfer document the result code if/when that occurs.