### PR TITLE
curl-rustls.m4: keep existing `CPPFLAGS`/`LDFLAGS` when detected

### DIFF
--- a/m4/curl-rustls.m4
+++ b/m4/curl-rustls.m4
@@ -155,8 +155,8 @@ if test "x$OPT_RUSTLS" != xno; then
   fi
 
   dnl finally, set flags to use this TLS backend
-  CPPFLAGS="$CLEAN_CPPFLAGS $SSL_CPPFLAGS"
-  LDFLAGS="$CLAN_LDFLAGS $SSL_LDFLAGS"
+  CPPFLAGS="$CLEANCPPFLAGS $SSL_CPPFLAGS"
+  LDFLAGS="$CLEANLDFLAGS $SSL_LDFLAGS"
 
   if test "x$USE_RUSTLS" = "xyes"; then
     AC_MSG_NOTICE([detected Rustls])


### PR DESCRIPTION
Different variable names were used in flag save and restore operations,
which could cause existing `CPPFLAGS` and `LDFLAGS` be accidentally lost
when detecting Rustls.

Follow-up to 647e86a3efe1eea7a2a456c009cfe1eb55fe48eb #13179
