### PR TITLE
mk-ca-bundle: remove CKA_NSS_SERVER_DISTRUST_AFTER conditions

### DIFF
--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -553,48 +553,6 @@ while (<TXT>) {
       }
       next;
     }
-    elsif (/^CKA_NSS_SERVER_DISTRUST_AFTER (CK_BBOOL CK_FALSE|MULTILINE_OCTAL)/) {
-      # Example:
-      # CKA_NSS_SERVER_DISTRUST_AFTER MULTILINE_OCTAL
-      # \062\060\060\066\061\067\060\060\060\060\060\060\132
-      # END
-      if($1 eq "MULTILINE_OCTAL") {
-        my @timestamp;
-        while (<TXT>) {
-          last if (/^END/);
-          chomp;
-          my @octets = split(/\\/);
-          shift @octets;
-          for (@octets) {
-            push @timestamp, chr(oct);
-          }
-        }
-        scalar(@timestamp) == 13 or die "Failed parsing timestamp";
-        # A trailing Z in the timestamp signifies UTC
-        if($timestamp[12] ne "Z") {
-          report "distrust date stamp is not using UTC";
-        }
-        # Example date: 200617000000Z
-        # Means 2020-06-17 00:00:00 UTC
-        my $distrustat =
-          timegm($timestamp[10] . $timestamp[11], # second
-                 $timestamp[8] . $timestamp[9],   # minute
-                 $timestamp[6] . $timestamp[7],   # hour
-                 $timestamp[4] . $timestamp[5],   # day
-                 ($timestamp[2] . $timestamp[3]) - 1, # month
-                 "20" . $timestamp[0] . $timestamp[1]); # year
-        if(time >= $distrustat) {
-          # not trusted anymore
-          $skipnum++;
-          report "Skipping: $main_block_name is not trusted anymore" if ($opt_v);
-          $valid = 0;
-        }
-        else {
-          # still trusted
-        }
-      }
-      next;
-    }
     else {
       next;
     }


### PR DESCRIPTION
The script's previous treatment of this meta-data was a misunderstanding. (Added in 1ebc53df25181908) The mistrust is not for the root cert at this date (it would simply be removed from the bundle then instead) but for created server certificates:

    If a builtin certificate has a CKA_NSS_SERVER_DISTRUST_AFTER
    timestamp before the SCT or NotBefore date of a certificate that
    builtin issued, then clients can elect not to trust it.

That is however information that cannot be provided in the generated PEM output.

Fixes #15547
Reported-by: Andrew Ayer