### PR TITLE
cmake: work around `ios.toolchain.cmake` breaking feature-detections

### DIFF
--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -76,6 +76,7 @@ check_c_source_compiles("${_source_epilogue}
   }" HAVE_STRUCT_TIMEVAL)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE ${_cmake_try_compile_target_type_save})
+unset(_cmake_try_compile_target_type_save)
 
 # Detect HAVE_GETADDRINFO_THREADSAFE
 
@@ -151,3 +152,5 @@ if(NOT WIN32 AND NOT DEFINED HAVE_CLOCK_GETTIME_MONOTONIC_RAW)
       return 0;
     }" HAVE_CLOCK_GETTIME_MONOTONIC_RAW)
 endif()
+
+unset(_source_epilogue)

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -32,6 +32,7 @@ macro(add_header_include _check _header)
   endif()
 endmacro()
 
+set(_cmake_try_compile_target_type_save ${CMAKE_TRY_COMPILE_TARGET_TYPE})
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
 if(NOT DEFINED HAVE_STRUCT_SOCKADDR_STORAGE)
@@ -74,7 +75,7 @@ check_c_source_compiles("${_source_epilogue}
     return 0;
   }" HAVE_STRUCT_TIMEVAL)
 
-unset(CMAKE_TRY_COMPILE_TARGET_TYPE)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE ${_cmake_try_compile_target_type_save})
 
 # Detect HAVE_GETADDRINFO_THREADSAFE
 

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -33,7 +33,7 @@ macro(add_header_include _check _header)
 endmacro()
 
 set(_cmake_try_compile_target_type_save ${CMAKE_TRY_COMPILE_TARGET_TYPE})
-set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+set(CMAKE_TRY_COMPILE_TARGET_TYPE "STATIC_LIBRARY")
 
 if(NOT DEFINED HAVE_STRUCT_SOCKADDR_STORAGE)
   cmake_push_check_state()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,8 @@ endif()
 # non-existing features. This happens by default when using 'ios.toolchain.cmake'.
 # Work it around by setting this value to `EXECUTABLE`.
 if(CMAKE_TRY_COMPILE_TARGET_TYPE STREQUAL "STATIC_LIBRARY")
-  message(STATUS "CMAKE_TRY_COMPILE_TARGET_TYPE was found set to STATIC_LIBRARY. Overriding with EXECUTABLE for feature detections to work.")
+  message(STATUS "CMAKE_TRY_COMPILE_TARGET_TYPE was found set to STATIC_LIBRARY. "
+    "Overriding with EXECUTABLE for feature detections to work.")
   set(_cmake_try_compile_target_type_save ${CMAKE_TRY_COMPILE_TARGET_TYPE})
   set(CMAKE_TRY_COMPILE_TARGET_TYPE "EXECUTABLE")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,6 @@ if(CMAKE_CROSSCOMPILING)
 endif()
 message(STATUS "CMake platform flags:${_target_flags}")
 
-if(CMAKE_TRY_COMPILE_TARGET_TYPE STREQUAL "STATIC_LIBRARY")
-  message(WARNING "CMAKE_TRY_COMPILE_TARGET_TYPE is set to STATIC_LIBRARY. Features may be falsely detected.")
-endif()
-
 if(CMAKE_CROSSCOMPILING)
   message(STATUS "Cross-compiling: "
     "${CMAKE_HOST_SYSTEM_NAME}/${CMAKE_HOST_SYSTEM_PROCESSOR} -> "
@@ -131,6 +127,16 @@ include_directories("${PROJECT_SOURCE_DIR}/include")
 
 if(NOT DEFINED CMAKE_UNITY_BUILD_BATCH_SIZE)
   set(CMAKE_UNITY_BUILD_BATCH_SIZE 0)
+endif()
+
+# Having CMAKE_TRY_COMPILE_TARGET_TYPE set to STATIC_LIBRARY breaks certain
+# 'check_function_exists()' detections (possibly more), by detecting
+# non-existing features. This happens by default when using 'ios.toolchain.cmake'.
+# Work it around by setting this value to `EXECUTABLE`.
+if(CMAKE_TRY_COMPILE_TARGET_TYPE STREQUAL "STATIC_LIBRARY")
+  message(STATUS "CMAKE_TRY_COMPILE_TARGET_TYPE was found set to STATIC_LIBRARY. Overriding with EXECUTABLE for feature detections to work.")
+  set(_cmake_try_compile_target_type_save ${CMAKE_TRY_COMPILE_TARGET_TYPE})
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE "EXECUTABLE")
 endif()
 
 option(CURL_WERROR "Turn compiler warnings into errors" OFF)
@@ -461,9 +467,7 @@ include(CheckCSourceCompiles)
 if(WIN32)
   include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/Platforms/WindowsCache.cmake")
 elseif(APPLE)
-  # Fast-track feature detections to avoid them being mis-detected when
-  # CMAKE_TRY_COMPILE_TARGET_TYPE is set to STATIC_LIBRARY.
-  # This happens by default when using 'ios.toolchain.cmake'.
+  # Fast-track predicable feature detections
   set(HAVE_EVENTFD 0)
   set(HAVE_GETPASS_R 0)
   set(HAVE_SENDMMSG 0)
@@ -1760,6 +1764,11 @@ if(CMAKE_COMPILER_IS_GNUCC AND APPLE)
     set_source_files_properties("mprintf.c" PROPERTIES
       COMPILE_FLAGS ${_mprintf_compile_flags})
   endif()
+endif()
+
+if(_cmake_try_compile_target_type_save)
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE ${_cmake_try_compile_target_type_save})
+  unset(_cmake_try_compile_target_type_save)
 endif()
 
 include(CMake/OtherTests.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,6 +456,8 @@ include(CheckCSourceCompiles)
 # Preload settings on Windows
 if(WIN32)
   include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/Platforms/WindowsCache.cmake")
+elseif(APPLE)
+  set(HAVE_GETPASS_R 0)
 endif()
 
 if(ENABLE_THREADED_RESOLVER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -462,8 +462,8 @@ if(WIN32)
   include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/Platforms/WindowsCache.cmake")
 elseif(APPLE)
   # Fast-track feature detections to avoid them being mis-detected when
-  # CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY is set. This happens by
-  # default when using `ios.toolchain.cmake`.
+  # CMAKE_TRY_COMPILE_TARGET_TYPE is set to STATIC_LIBRARY.
+  # This happens by default when using 'ios.toolchain.cmake'.
   set(HAVE_EVENTFD 0)
   set(HAVE_GETPASS_R 0)
   set(HAVE_SENDMMSG 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,9 @@ include(CheckCSourceCompiles)
 if(WIN32)
   include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/Platforms/WindowsCache.cmake")
 elseif(APPLE)
+  # Fast-track feature detections to avoid them being mis-detected when
+  # CMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY is set. This happens by
+  # default when using `ios.toolchain.cmake`.
   set(HAVE_EVENTFD 0)
   set(HAVE_GETPASS_R 0)
   set(HAVE_SENDMMSG 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -459,6 +459,7 @@ if(WIN32)
 elseif(APPLE)
   set(HAVE_EVENTFD 0)
   set(HAVE_GETPASS_R 0)
+  set(HAVE_SENDMMSG 0)
 endif()
 
 if(ENABLE_THREADED_RESOLVER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -457,6 +457,7 @@ include(CheckCSourceCompiles)
 if(WIN32)
   include("${CMAKE_CURRENT_SOURCE_DIR}/CMake/Platforms/WindowsCache.cmake")
 elseif(APPLE)
+  set(HAVE_EVENTFD 0)
   set(HAVE_GETPASS_R 0)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ if(CMAKE_CROSSCOMPILING)
 endif()
 message(STATUS "CMake platform flags:${_target_flags}")
 
+if(CMAKE_TRY_COMPILE_TARGET_TYPE STREQUAL "STATIC_LIBRARY")
+  message(WARNING "CMAKE_TRY_COMPILE_TARGET_TYPE is set to STATIC_LIBRARY. Features may be falsely detected.")
+endif()
+
 if(CMAKE_CROSSCOMPILING)
   message(STATUS "Cross-compiling: "
     "${CMAKE_HOST_SYSTEM_NAME}/${CMAKE_HOST_SYSTEM_PROCESSOR} -> "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,7 +472,7 @@ if(ENABLE_THREADED_RESOLVER)
 endif()
 
 # Check for all needed libraries
-if(NOT WIN32)
+if(NOT WIN32 AND NOT APPLE)
   check_library_exists("socket" "connect" "" HAVE_LIBSOCKET)
   if(HAVE_LIBSOCKET)
     set(CURL_LIBS "socket;${CURL_LIBS}")


### PR DESCRIPTION
Fix builds with CMake configured to falsely return successful detection
when using `check_function_exists()` (and `check_library_exists()`, and
anything based on `try_compile()` that's relying on the linker). After
such mis-detection the build fails when trying to use the feature that
doesn't in fact exist.

The mis-detection is caused by this CMake setting:
```
set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
```
It is set by default (or on conditions) when using 3rd-party toolchain:
https://github.com/leetal/ios-cmake/blob/master/ios.toolchain.cmake

After this patch the curl build overrides this setting for the duration
of feature tests, and logs a message about it.

Also preset and skip feature tests for known mis-detections:
- `connect()` in `libsocket`
- `getpass_r()`
- `eventfd()` (did not cause an issue due to a separate bug)
- `sendmmsg()` (did not cause an issue because it's Linux-only)

If mis-detections are still seen, the workaround is to force-set the
specific feature by passing `-DHAVE_*=OFF` to cmake.
Also consider passing `-DENABLE_STRICT_TRY_COMPILE=ON` for
`ios.toolchain.cmake` to fix the root cause.

Interestingly curl itself uses this setting to speed up compile-only
detections: be17f298ff508d62d493d4a8d43e56a1e2861a50 #3744

Also:
- OtherTests.cmake: restore original value of
  `CMAKE_TRY_COMPILE_TARGET_TYPE`. Before this patch it reset it
  to empty.
- OtherTests.cmake: unset a local variable after use, quote a string.

Follow-up to 8e345057761a8f796403923a96f2c8fd3edca647 #15164
Follow-up to 8b76a8aeb21c8ae2261147af1bddd0d4637c252c #15525
Ref: https://github.com/leetal/ios-cmake/issues/47
Ref: https://gitlab.kitware.com/cmake/cmake/-/issues/18121
Ref: https://cmake.org/cmake/help/latest/variable/CMAKE_TRY_COMPILE_TARGET_TYPE.html
Reported-by: Dan Rosser
Fixes #15557
