### PR TITLE
strtok: use namespaced `strtok_r` macro instead of redefining it

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -833,14 +833,16 @@ parse_netscape(struct Cookie *co,
   if(ptr)
     *ptr = 0; /* clear it */
 
-  firstptr = strtok_r((char *)lineptr, "\t", &tok_buf); /* tokenize on TAB */
+  /* tokenize on TAB */
+  firstptr = Curl_strtok_r((char *)lineptr, "\t", &tok_buf);
 
   /*
    * Now loop through the fields and init the struct we already have
    * allocated
    */
   fields = 0;
-  for(ptr = firstptr; ptr; ptr = strtok_r(NULL, "\t", &tok_buf), fields++) {
+  for(ptr = firstptr; ptr;
+      ptr = Curl_strtok_r(NULL, "\t", &tok_buf), fields++) {
     switch(fields) {
     case 0:
       if(ptr[0]=='.') /* skip preceding dots */

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -365,7 +365,7 @@ static CURLcode trc_opt(const char *config)
   if(!tmp)
     return CURLE_OUT_OF_MEMORY;
 
-  token = strtok_r(tmp, ", ", &tok_buf);
+  token = Curl_strtok_r(tmp, ", ", &tok_buf);
   while(token) {
     switch(*token) {
       case '-':
@@ -391,7 +391,7 @@ static CURLcode trc_opt(const char *config)
     else
       trc_apply_level_by_name(token, lvl);
 
-    token = strtok_r(NULL, ", ", &tok_buf);
+    token = Curl_strtok_r(NULL, ", ", &tok_buf);
   }
   free(tmp);
   return CURLE_OK;

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -825,8 +825,8 @@ static bool split_str(char *str, char ***out, size_t *count)
   if(!res)
     return FALSE;
 
-  for(i = 0, s = strtok_r(str, ",", &lasts); s && i < items;
-      s = strtok_r(NULL, ",", &lasts), i++)
+  for(i = 0, s = Curl_strtok_r(str, ",", &lasts); s && i < items;
+      s = Curl_strtok_r(NULL, ",", &lasts), i++)
     res[i] = s;
 
   *out = res;

--- a/lib/strtok.h
+++ b/lib/strtok.h
@@ -26,11 +26,11 @@
 #include "curl_setup.h"
 #include <stddef.h>
 
-#ifndef HAVE_STRTOK_R
-char *Curl_strtok_r(char *s, const char *delim, char **last);
-#define strtok_r Curl_strtok_r
-#else
+#ifdef HAVE_STRTOK_R
 #include <string.h>
+#define Curl_strtok_r strtok_r
+#else
+char *Curl_strtok_r(char *s, const char *delim, char **last);
 #endif
 
 #endif /* HEADER_CURL_STRTOK_H */

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -227,12 +227,12 @@ static CURLcode auth_digest_get_qop_values(const char *options, int *value)
   *value = 0;
 
   /* Tokenise the list of qop values. Use a temporary clone of the buffer since
-     strtok_r() ruins it. */
+     Curl_strtok_r() ruins it. */
   tmp = strdup(options);
   if(!tmp)
     return CURLE_OUT_OF_MEMORY;
 
-  token = strtok_r(tmp, ",", &tok_buf);
+  token = Curl_strtok_r(tmp, ",", &tok_buf);
   while(token) {
     if(strcasecompare(token, DIGEST_QOP_VALUE_STRING_AUTH))
       *value |= DIGEST_QOP_VALUE_AUTH;
@@ -241,7 +241,7 @@ static CURLcode auth_digest_get_qop_values(const char *options, int *value)
     else if(strcasecompare(token, DIGEST_QOP_VALUE_STRING_AUTH_CONF))
       *value |= DIGEST_QOP_VALUE_AUTH_CONF;
 
-    token = strtok_r(NULL, ",", &tok_buf);
+    token = Curl_strtok_r(NULL, ",", &tok_buf);
   }
 
   free(tmp);
@@ -553,12 +553,12 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
       else if(strcasecompare(value, "qop")) {
         char *tok_buf = NULL;
         /* Tokenize the list and choose auth if possible, use a temporary
-           clone of the buffer since strtok_r() ruins it */
+           clone of the buffer since Curl_strtok_r() ruins it */
         tmp = strdup(content);
         if(!tmp)
           return CURLE_OUT_OF_MEMORY;
 
-        token = strtok_r(tmp, ",", &tok_buf);
+        token = Curl_strtok_r(tmp, ",", &tok_buf);
         while(token) {
           /* Pass additional spaces here */
           while(*token && ISBLANK(*token))
@@ -569,7 +569,7 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
           else if(strcasecompare(token, DIGEST_QOP_VALUE_STRING_AUTH_INT)) {
             foundAuthInt = TRUE;
           }
-          token = strtok_r(NULL, ",", &tok_buf);
+          token = Curl_strtok_r(NULL, ",", &tok_buf);
         }
 
         free(tmp);

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -354,8 +354,8 @@ CF_INLINE void GetDarwinVersionNumber(int *major, int *minor)
   }
 
   /* Parse the version: */
-  os_version_major = strtok_r(os_version, ".", &tok_buf);
-  os_version_minor = strtok_r(NULL, ".", &tok_buf);
+  os_version_major = Curl_strtok_r(os_version, ".", &tok_buf);
+  os_version_minor = Curl_strtok_r(NULL, ".", &tok_buf);
   *major = atoi(os_version_major);
   *minor = atoi(os_version_minor);
   free(os_version);


### PR DESCRIPTION
krb5 defines `strtok_r` for Windows unconditionally in its public
header:
https://github.com/krb5/krb5/blob/dc5554394e5a4363b3e109623edbeb9ad6c18a62/src/include/win-mac.h#L214-L215
resulting in warning:
```
lib\strtok.h(31,9): warning C4005: 'strtok_r': macro redefinition
      C:\vcpkg\installed\x64-windows\include\win-mac.h(215,9):
      see previous definition of 'strtok_r'
```

This collides with curl's own definition, when `strtok_r` is 
undetected and falling back to the local replacement.

Reported-by: Tal Regev
Bug: https://github.com/curl/curl/pull/15549#issuecomment-2468251761

---

Perhaps worth noting that `win-mac.h` unconditionally mapping
`strtok_r` to `strtok_s` is wrong. At least mingw-w64 3.2.0 and
older versions don't support the latter symbol. Doing it in a public
header is possibly worse.
