### PR TITLE
Fixing IBMi EBCDIC conversion of arguments

### DIFF
--- a/packages/OS400/curlmain.c
+++ b/packages/OS400/curlmain.c
@@ -61,8 +61,10 @@ int main(int argc, char **argv)
   size_t inbytesleft;
   size_t outbytesleft;
   char dummybuf[128];
-  const char *tocode = "IBMCCSID01208"; /* Use UTF-8. */
-  const char *fromcode = "IBMCCSID000000000010";
+  /* To/From codes are 32 byte long strings with
+     reserved fields initialized to ZEROs */
+  const char tocode[32]   = {"IBMCCSID01208"}; /* Use UTF-8. */
+  const char fromcode[32] = {"IBMCCSID000000000010"};
 
   ebcdic_argc = argc;
   ebcdic_argv = argv;


### PR DESCRIPTION
Fixing issue #15570, where IBMi EBCDIC conversion of command line arguments got broken.