### PR TITLE
GHA/macos: follow Homebrew and switch to `pkgconf`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -198,7 +198,7 @@ jobs:
         # https://github.com/curl/curl/runs/4095721123?check_suite_focus=true
         run: |
           echo ${{ matrix.build.generate && 'ninja' || 'automake libtool' }} \
-            pkg-config libpsl libssh2 nghttp2 stunnel ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
+            pkgconf libpsl libssh2 nghttp2 stunnel ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
           while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
 
       - name: 'brew unlink openssl'


### PR DESCRIPTION
Homebrew switched to `pkgconf`, and now pkg-config installs an extra
package. Update package list to avoid that.

The side-effect of `pkgconf` is that this former log message:
```
--   Package 'libcrypto', required by 'libssh2', not found
```
https://github.com/curl/curl/actions/runs/11779568834/job/32808325442#step:7:84

is replaced by this, and repeated 10 times:
```
Package libcrypto was not found in the pkg-config search path.
Perhaps you should add the directory containing `libcrypto.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libcrypto', required by 'libssh2', not found
```
https://github.com/curl/curl/actions/runs/11792711391/job/32846858320#step:7:85
