### PR TITLE
GHA/linux: fix `pip3 install impacket` breakage

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -501,6 +501,7 @@ jobs:
 
       - name: 'install test prereqs'
         run: |
+          sudo apt-get remove python3-blinker
           sudo python3 -m pip install --break-system-packages -r tests/requirements.txt
 
       - name: 'run tests'

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -328,6 +328,7 @@ jobs:
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \
             texinfo texlive texlive-extra-utils autopoint libev-dev \
             apache2 apache2-dev libnghttp2-dev vsftpd
+          python3 -m venv $HOME/venv
           echo 'CC=gcc-12' >> $GITHUB_ENV
           echo 'CXX=g++-12' >> $GITHUB_ENV
         name: 'install prereqs'
@@ -501,12 +502,14 @@ jobs:
 
       - name: 'install test prereqs'
         run: |
-          sudo python3 -m pip install --break-system-packages --ignore-installed -r tests/requirements.txt
+          source $HOME/venv/bin/activate
+          python3 -m pip install -r tests/requirements.txt
 
       - name: 'run tests'
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
         run: |
+          source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target test-ci
           else
@@ -515,13 +518,15 @@ jobs:
 
       - name: 'install pytest prereqs'
         run: |
-          sudo python3 -m pip install --break-system-packages -r tests/http/requirements.txt
+          source $HOME/venv/bin/activate
+          python3 -m pip install -r tests/http/requirements.txt
 
       - name: 'run pytest'
         env:
           TFLAGS: "${{ matrix.build.tflags }}"
           CURL_CI: github
         run: |
+          source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target curl-pytest-ci
           else

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -501,8 +501,7 @@ jobs:
 
       - name: 'install test prereqs'
         run: |
-          sudo apt-get remove python3-blinker
-          sudo python3 -m pip install --break-system-packages -r tests/requirements.txt
+          sudo python3 -m pip install --break-system-packages --ignore-installed -r tests/requirements.txt
 
       - name: 'run tests'
         env:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -618,7 +618,7 @@ jobs:
       - name: 'install test prereqs'
         if: ${{ matrix.build.install_steps != 'skipall' && matrix.build.container == null }}
         run: |
-          [ -z '${{ matrix.build.container }}' ] && source $HOME/venv/bin/activate
+          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
           python3 -m pip install -r tests/requirements.txt
 
       - name: 'run tests'
@@ -634,7 +634,7 @@ jobs:
               TFLAGS+=' ~2077 ~2078'  # valgrind errors
             fi
           fi
-          [ -z '${{ matrix.build.container }}' ] && source $HOME/venv/bin/activate
+          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target ${{ matrix.build.torture && 'test-torture' || 'test-ci' }}
           else
@@ -644,7 +644,7 @@ jobs:
       - name: 'install pytest prereqs'
         if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          [ -z '${{ matrix.build.container }}' ] && source $HOME/venv/bin/activate
+          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
           python3 -m pip install -r tests/http/requirements.txt
 
       - name: 'run pytest'
@@ -653,7 +653,7 @@ jobs:
           TFLAGS: "${{ matrix.build.tflags }}"
           CURL_CI: github
         run: |
-          [ -z '${{ matrix.build.container }}' ] && source $HOME/venv/bin/activate
+          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target curl-pytest-ci
           else

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -293,7 +293,7 @@ jobs:
           python3 -m venv $HOME/venv
         name: 'install prereqs'
 
-      - if: contains(matrix.build.name, 'i686')
+      - if: matrix.build.container == null && contains(matrix.build.name, 'i686')
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -618,7 +618,7 @@ jobs:
       - name: 'install test prereqs'
         if: ${{ matrix.build.install_steps != 'skipall' && matrix.build.container == null }}
         run: |
-          source $HOME/venv/bin/activate
+          [ -z '${{ matrix.build.container }}' ] && source $HOME/venv/bin/activate
           python3 -m pip install -r tests/requirements.txt
 
       - name: 'run tests'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -616,8 +616,7 @@ jobs:
       - name: 'install test prereqs'
         if: ${{ matrix.build.install_steps != 'skipall' && matrix.build.container == null }}
         run: |
-          sudo apt-get remove python3-blinker
-          sudo python3 -m pip install --break-system-packages -r tests/requirements.txt
+          sudo python3 -m pip install --break-system-packages --ignore-installed -r tests/requirements.txt
 
       - name: 'run tests'
         if: ${{ matrix.build.install_steps != 'skipall' && matrix.build.install_steps != 'skiprun' }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -293,7 +293,7 @@ jobs:
           python3 -m venv $HOME/venv
         name: 'install prereqs'
 
-      - if: matrix.build.container == null && contains(matrix.build.name, 'i686')
+      - if: contains(matrix.build.name, 'i686')
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -634,7 +634,7 @@ jobs:
               TFLAGS+=' ~2077 ~2078'  # valgrind errors
             fi
           fi
-          source $HOME/venv/bin/activate
+          [ -z '${{ matrix.build.container }}' ] && source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target ${{ matrix.build.torture && 'test-torture' || 'test-ci' }}
           else
@@ -644,7 +644,7 @@ jobs:
       - name: 'install pytest prereqs'
         if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          source $HOME/venv/bin/activate
+          [ -z '${{ matrix.build.container }}' ] && source $HOME/venv/bin/activate
           python3 -m pip install -r tests/http/requirements.txt
 
       - name: 'run pytest'
@@ -653,7 +653,7 @@ jobs:
           TFLAGS: "${{ matrix.build.tflags }}"
           CURL_CI: github
         run: |
-          source $HOME/venv/bin/activate
+          [ -z '${{ matrix.build.container }}' ] && source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target curl-pytest-ci
           else

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -290,6 +290,7 @@ jobs:
             libtool autoconf automake pkgconf ninja-build stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev \
             ${{ matrix.build.install_packages }}
+          python3 -m venv $HOME/venv
         name: 'install prereqs'
 
       - if: contains(matrix.build.name, 'i686')
@@ -301,6 +302,7 @@ jobs:
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386 \
             ${{ matrix.build.install_packages }}
+          python3 -m venv $HOME/venv
         name: 'install prereqs'
 
       - if: contains(matrix.build.install_steps, 'pytest')
@@ -616,7 +618,8 @@ jobs:
       - name: 'install test prereqs'
         if: ${{ matrix.build.install_steps != 'skipall' && matrix.build.container == null }}
         run: |
-          sudo python3 -m pip install --break-system-packages --ignore-installed -r tests/requirements.txt
+          source $HOME/venv/bin/activate
+          python3 -m pip install -r tests/requirements.txt
 
       - name: 'run tests'
         if: ${{ matrix.build.install_steps != 'skipall' && matrix.build.install_steps != 'skiprun' }}
@@ -631,6 +634,7 @@ jobs:
               TFLAGS+=' ~2077 ~2078'  # valgrind errors
             fi
           fi
+          source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target ${{ matrix.build.torture && 'test-torture' || 'test-ci' }}
           else
@@ -640,7 +644,8 @@ jobs:
       - name: 'install pytest prereqs'
         if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          sudo python3 -m pip install --break-system-packages -r tests/http/requirements.txt
+          source $HOME/venv/bin/activate
+          python3 -m pip install -r tests/http/requirements.txt
 
       - name: 'run pytest'
         if: contains(matrix.build.install_steps, 'pytest')
@@ -648,6 +653,7 @@ jobs:
           TFLAGS: "${{ matrix.build.tflags }}"
           CURL_CI: github
         run: |
+          source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target curl-pytest-ci
           else

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -616,6 +616,7 @@ jobs:
       - name: 'install test prereqs'
         if: ${{ matrix.build.install_steps != 'skipall' && matrix.build.container == null }}
         run: |
+          sudo apt-get remove python3-blinker
           sudo python3 -m pip install --break-system-packages -r tests/requirements.txt
 
       - name: 'run tests'


### PR DESCRIPTION
An upstream update `impacket` pip package started requiring `blinker`.
An older version is shipping with Ubuntu, causing this on install:
```
  Attempting uninstall: blinker
    Found existing installation: blinker 1.7.0
ERROR: Cannot uninstall blinker 1.7.0, RECORD file not found. Hint: The package was installed by debian.
```

Fix it by switching to venv and install everything separate from the
system.

The overhead is the same as using `pip --ignore-installed`, which also
installs everything from scratch.

The 3rd option is to uninstall the system `python3-blinker` package, but
it was the slowest.
