### PR TITLE
configure: replace `$#` shell syntax

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5084,13 +5084,13 @@ dnl
 LIBCURL_PC_LDFLAGS_PRIVATE=''
 dnl Do not quote $INITIAL_LDFLAGS
 set -- $INITIAL_LDFLAGS
-while [ "$#" -gt 0 ]; do
+while test -n "$1"; do
   case "$1" in
     -L* | --library-path=* | -F*)
       LIBCURL_PC_LDFLAGS_PRIVATE="$LIBCURL_PC_LDFLAGS_PRIVATE $1"
       ;;
     -framework)
-      if [ "$#" -gt 1 ]; then
+      if test -n "$2"; then
         LIBCURL_PC_LDFLAGS_PRIVATE="$LIBCURL_PC_LDFLAGS_PRIVATE $1 $2"
         shift
       fi


### PR DESCRIPTION
With a more portable alternative.

Fixes (seen on macOS):
```
../configure: line 47131: 1: command not found
```
Ref: https://github.com/curl/curl/actions/runs/11846071276/job/33012894013#step:7:635

Follow-up to e244d50064a56723c2ba4f0df8c847d6b70de0cb #15550
