### PR TITLE
GHA/linux: enable ECH in wolfSSL jobs

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -282,6 +282,7 @@ jobs:
               --with-ngtcp2=$HOME/ngtcp2/build --enable-warnings --enable-werror --enable-debug
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-wolfssl=$HOME/wolfssl/build
+              --enable-httpsrr --enable-ech
 
           - name: wolfssl
             PKG_CONFIG_PATH: '$HOME/wolfssl/build/lib/pkgconfig:$HOME/nghttp3/build/lib/pkgconfig:$HOME/ngtcp2/build/lib/pkgconfig:$HOME/nghttp2/build/lib/pkgconfig'
@@ -289,6 +290,7 @@ jobs:
               -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON -DENABLE_DEBUG=ON
               -DTEST_NGHTTPX="$HOME/nghttp2/build/bin/nghttpx"
               -DHTTPD_NGHTTPX="$HOME/nghttp2/build/bin/nghttpx"
+              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
 
           - name: openssl-quic
             PKG_CONFIG_PATH: '$HOME/openssl/build/lib64/pkgconfig'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -94,7 +94,7 @@ jobs:
           - name: wolfssl-all
             install_packages: zlib1g-dev
             install_steps: wolfssl-all
-            configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-all/lib" --with-wolfssl=$HOME/wolfssl-all --enable-debug
+            configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-all/lib" --with-wolfssl=$HOME/wolfssl-all --enable-httpsrr --enable-ech --enable-debug
 
           - name: wolfssl-opensslextra valgrind
             install_packages: zlib1g-dev valgrind

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -669,7 +669,7 @@ jobs:
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
               -DCURL_CA_SEARCH_SAFE=ON
 
-          - name: 'boringssl-ECH'
+          - name: 'boringssl'
             install: 'brotli zlib zstd libpsl nghttp2 boringssl libssh2[core,zlib]'
             arch: 'x64'
             plat: 'windows'


### PR DESCRIPTION
wolfSSL `--enable-all` builds support ECH. Enable it for 3 jobs using
such builds.

Also:
- GHA/windows: drop ECH from the job name.
