### PR TITLE
netrc: fix pointer to bool conversion

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -104,7 +104,7 @@ static int parsenetrc(struct store_netrc *store,
   int retcode = NETRC_FILE_MISSING;
   char *login = *loginp;
   char *password = NULL;
-  bool specific_login = login; /* points to something */
+  bool specific_login = !!login; /* points to something */
   enum host_lookup_state state = NOTHING;
   enum found_state keyword = NONE;
   unsigned char found = 0; /* login + password found bits, as they can come in


### PR DESCRIPTION
with MSVC 2008 and 2010:
```
lib/netrc.c(107): error C2440: 'initializing' : cannot convert from 'char *' to 'bool'
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/51002792/job/jtoxd4mk984oi6fd#L164
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/51002792/job/0wxlw9a8g04e56vt#L177

Follow-up to e9b9bbac22c26cf67316fa8e6c6b9e831af31949 #15586
