### PR TITLE
Crosscompile for AmigaOS3 - Changes to Configure.ac and Nonblock.c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1338,6 +1338,9 @@ if test "$HAVE_GETHOSTBYNAME" != "1" -o "${with_amissl+set}" = set; then
     AC_MSG_RESULT([yes])
     HAVE_GETHOSTBYNAME="1"
     HAVE_PROTO_BSDSOCKET_H="1"
+    HAVE_IOCTLSOCKET_CAMEL_FIONBIO="1"
+    AC_DEFINE(HAVE_IOCTLSOCKET_CAMEL_FIONBIO, 1, [Amiga NonBlock Method])
+    AC_SUBST(HAVE_IOCTLSOCKET_CAMEL_FIONBIO, 1)
     AC_DEFINE(HAVE_PROTO_BSDSOCKET_H, 1, [if Amiga bsdsocket.library is in use])
     AC_SUBST(HAVE_PROTO_BSDSOCKET_H, [1])
   ],[

--- a/lib/nonblock.c
+++ b/lib/nonblock.c
@@ -68,7 +68,7 @@ int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
   /* Amiga */
   long flags = nonblock ? 1L : 0L;
   return IoctlSocket(sockfd, FIONBIO, (char *)&flags);
-  
+
 #elif defined(HAVE_IOCTL_FIONBIO)
 
   /* older Unix versions */

--- a/lib/nonblock.c
+++ b/lib/nonblock.c
@@ -63,6 +63,12 @@ int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
     flags &= ~O_NONBLOCK;
   return sfcntl(sockfd, F_SETFL, flags);
 
+#elif defined(HAVE_IOCTLSOCKET_CAMEL_FIONBIO)
+
+  /* Amiga */
+  long flags = nonblock ? 1L : 0L;
+  return IoctlSocket(sockfd, FIONBIO, (char *)&flags);
+  
 #elif defined(HAVE_IOCTL_FIONBIO)
 
   /* older Unix versions */
@@ -74,12 +80,6 @@ int curlx_nonblock(curl_socket_t sockfd,    /* operate on this */
   /* Windows */
   unsigned long flags = nonblock ? 1UL : 0UL;
   return ioctlsocket(sockfd, (long)FIONBIO, &flags);
-
-#elif defined(HAVE_IOCTLSOCKET_CAMEL_FIONBIO)
-
-  /* Amiga */
-  long flags = nonblock ? 1L : 0L;
-  return IoctlSocket(sockfd, FIONBIO, (char *)&flags);
 
 #elif defined(HAVE_SETSOCKOPT_SO_NONBLOCK)
 


### PR DESCRIPTION
Changes to Configure.ac and nonblock.c to allow the AmigaOS3 cross compile to run correctly.
Without these changes the AmigaOS3 cannot be built using configure.

However the configure.ac defines will only go in if AmiSSL is selected via this method.
so if you don't select AmiSSL I would assume the compilation would fail

With these changes, the AmigaOS 3 Cross Compile works with the following build statement

./buildconf && PKG_CONFIG=true ./configure --host=m68k-amigaos --build=$(uname -m)-pc-linux-gnu CC=m68k-amigaos-gcc AR=m68k-amigaos-ar --disable-shared --disable-ipv6 --prefix=/opt/amiga13 --disable-ntlm-wb --disable-netrc --without-libpsl --with-amissl --disable-threaded-resolver CFLAGS="-m68000 -O0 -msoft-float -Werror-implicit-function-declaration -Wno-system-headers -mcrt=clib2" CPPFLAGS="-D__AMIGA__" LIBS="-lnet -lm -lc -lz -lunix -latomic"

Tested with AmigaOS 3.2.2.1