### PR TITLE
GHA/macos: enable ECH in wolfSSL jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -159,7 +159,7 @@ jobs:
             macos-version-min: '10.15'
           - name: 'wolfSSL !ldap brotli zstd'
             install: brotli wolfssl zstd
-            generate: -DCURL_USE_WOLFSSL=ON -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_DISABLE_LDAP=ON
+            generate: -DCURL_USE_WOLFSSL=ON -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_DISABLE_LDAP=ON -DUSE_HTTPSRR=ON -DUSE_ECH=ON
             macos-version-min: '10.15'
           - name: 'mbedTLS !ldap brotli zstd'
             install: brotli mbedtls zstd


### PR DESCRIPTION
Homebrew wolfSSL builds recently enabled all features.
It allows to enable ECH in curl for these jobs.

https://github.com/Homebrew/homebrew-core/commit/97d1ed6e6db63071853f0d0c5b3b02cb22983be9
https://github.com/Homebrew/homebrew-core/pull/191561
