### PR TITLE
Document default `User-Agent`

### DIFF
--- a/docs/TheArtOfHttpScripting.md
+++ b/docs/TheArtOfHttpScripting.md
@@ -456,6 +456,8 @@ SPDX-License-Identifier: curl
  it is time to set the User Agent field to fool the server into thinking you
  are one of those browsers.
 
+ By default, curl uses curl/VERSION, such as User-Agent: curl/`%VERSION`.
+
  To make curl look like Internet Explorer 5 on a Windows 2000 box:
 
     curl --user-agent "Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0)" [URL]

--- a/docs/TheArtOfHttpScripting.md
+++ b/docs/TheArtOfHttpScripting.md
@@ -456,7 +456,7 @@ SPDX-License-Identifier: curl
  it is time to set the User Agent field to fool the server into thinking you
  are one of those browsers.
 
- By default, curl uses curl/VERSION, such as User-Agent: curl/`%VERSION`.
+ By default, curl uses curl/VERSION, such as User-Agent: curl/8.11.0.
 
  To make curl look like Internet Explorer 5 on a Windows 2000 box:
 

--- a/docs/cmdline-opts/user-agent.md
+++ b/docs/cmdline-opts/user-agent.md
@@ -25,3 +25,5 @@ be set with the --header or the --proxy-header options.
 If you give an empty argument to --user-agent (""), it removes the header
 completely from the request. If you prefer a blank header, you can set it to a
 single space (" ").
+
+By default, curl uses curl/VERSION, such as User-Agent: curl/`%VERSION`.


### PR DESCRIPTION
## Description

curl offers a `--user-agent` option for modifying the `User-Agent` header supplied in its requests.

The man page section for this option explains how to use the `--user-agent` option, but does not explain which `User-Agent` curl uses by default.

By default, curl uses curl/VERSION, such as `User-Agent: curl/8.11.0`.

https://github.com/curl/curl/blob/ca6d3d2e9b5814d126445b1d0667c140037327a0/src/tool_paramhlp.c#L638-L644
https://github.com/curl/curl/blob/ca6d3d2e9b5814d126445b1d0667c140037327a0/scripts/mk-ca-bundle.pl#L357

Note that this appears to be different from the libcurl default (no header).

https://github.com/curl/curl/blob/ca6d3d2e9b5814d126445b1d0667c140037327a0/docs/libcurl/opts/CURLOPT_USERAGENT.md?plain=1#L41-L43

## Changes

This pull request will document the default `User-Agent` in the man page section for the `--user-agent` option, as well as on the "Art of Scripting" page.

The `%VERSION` placeholder will be used to insert the current version as described in the man page generator docs.

https://github.com/curl/curl/blob/ca6d3d2e9b5814d126445b1d0667c140037327a0/docs/cmdline-opts/MANPAGE.md?plain=1#L98-L102

## Related

- "[The Art Of Scripting HTTP Requests Using Curl](https://curl.se/docs/httpscripting.html)"
- [curl man page](https://curl.se/docs/manpage.html)
- [MDN: User-Agent](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent)
