### PR TITLE
cmake: bump minimum version to 3.10 (was: 3.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1832,12 +1832,6 @@ if(CURL_WERROR)
 endif()
 
 if(CURL_LTO)
-  if(CMAKE_VERSION VERSION_LESS 3.9)
-    message(FATAL_ERROR "LTO has been requested, but your cmake version ${CMAKE_VERSION} is to old. You need at least 3.9")
-  endif()
-
-  cmake_policy(SET CMP0069 NEW)
-
   include(CheckIPOSupported)
   check_ipo_supported(RESULT CURL_HAS_LTO OUTPUT _lto_error LANGUAGES C)
   if(CURL_HAS_LTO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@
 # to ON or OFF), the symbol detection is skipped.  If the variable is
 # NOT DEFINED, the symbol detection is performed.
 
-cmake_minimum_required(VERSION 3.7...3.16 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10...3.16 FATAL_ERROR)
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 # Collect command-line arguments for buildinfo.txt.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,11 @@
 # to ON or OFF), the symbol detection is skipped.  If the variable is
 # NOT DEFINED, the symbol detection is performed.
 
-cmake_minimum_required(VERSION 3.10...3.16 FATAL_ERROR)
+if(CMAKE_VERSION VERSION_LESS 3.10)
+  cmake_minimum_required(VERSION 3.7...3.16 FATAL_ERROR)
+else()
+  cmake_minimum_required(VERSION 3.10...3.16 FATAL_ERROR)
+endif()
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
 # Collect command-line arguments for buildinfo.txt.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if(CMAKE_VERSION VERSION_LESS 3.10)
 else()
   cmake_minimum_required(VERSION 3.10...3.16 FATAL_ERROR)
 endif()
-message(STATUS "Using CMake version ${CMAKE_VERSION}")
+message(STATUS "Using CMake version ${CMAKE_VERSION} (minimum required: ${CMAKE_MINIMUM_REQUIRED_VERSION})")
 
 # Collect command-line arguments for buildinfo.txt.
 # Must reside at the top of the script to work as expected.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1832,6 +1832,12 @@ if(CURL_WERROR)
 endif()
 
 if(CURL_LTO)
+  if(CMAKE_VERSION VERSION_LESS 3.9)
+    message(FATAL_ERROR "LTO has been requested, but your cmake version ${CMAKE_VERSION} is to old. You need at least 3.9")
+  endif()
+
+  cmake_policy(SET CMP0069 NEW)
+
   include(CheckIPOSupported)
   check_ipo_supported(RESULT CURL_HAS_LTO OUTPUT _lto_error LANGUAGES C)
   if(CURL_HAS_LTO)


### PR DESCRIPTION
The problem is that old-linux offers a CMake older than the minimum now
required by the latest CMake version.

To fix these warnings (43 of them per run!) by CMake 3.31 or upper:
```
CMake Deprecation Warning at C:/vcpkg/scripts/buildsystems/vcpkg.cmake:40 (cmake_policy):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
Call Stack (most recent call first):
  C:/Program Files/CMake/share/cmake-3.31/Modules/CMakeDetermineSystem.cmake:146 (include)
  CMakeLists.txt:94 (project)
```
Ref: https://github.com/curl/curl/actions/runs/11922701519/job/33229551423#step:6:26
