### PR TITLE
windows: clear sensitive command-line options from process list

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1030,11 +1030,11 @@ const struct LongShort *findlongopt(const char *opt)
 
 ParameterError getparameter(const char *flag, /* f or -long-flag */
                             char *nextarg,    /* NULL if unset */
+                            bool *toclear,    /* arg is to be cleared */
                             bool *usedarg,    /* set to TRUE if the arg
                                                  has been used */
                             struct GlobalConfig *global,
-                            struct OperationConfig *config,
-                            bool *toclear)
+                            struct OperationConfig *config)
 {
   int rc;
   const char *parse = NULL;
@@ -2740,8 +2740,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
           }
         }
 
-        result = getparameter(orig_opt, nextarg, &passarg, global, config,
-                              &toclear);
+        result = getparameter(orig_opt, nextarg, &toclear, &passarg,
+                              global, config);
 
 #ifdef HAVE_WIN32_ACMDLN
         if(tcmdln) {
@@ -2802,8 +2802,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
       bool used;
 
       /* Just add the URL please */
-      result = getparameter("--url", orig_opt, &used, global, config,
-                            &toclear);
+      result = getparameter("--url", orig_opt, &toclear, &used, global,
+                            config);
 
 #ifdef HAVE_WIN32_ACMDLN
       if(tcmdln) {

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2815,17 +2815,13 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
 #ifdef HAVE_WIN32_ACMDLN
   if(tcmdln) {
 #ifdef UNICODE
-    if(_wcmdln)
-      memcpy(_wcmdln, tcmdln, wcmdln_siz);
-    if(_acmdln)
-      (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1,
-                                _acmdln, (int)acmdln_siz, NULL, NULL);
+    memcpy(_wcmdln, tcmdln, wcmdln_siz);
+    (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1,
+                              _acmdln, (int)acmdln_siz, NULL, NULL);
 #else
-    if(_acmdln)
-      memcpy(_acmdln, tcmdln, acmdln_siz);
-    if(_wcmdln)
-      (void)MultiByteToWideChar(CP_ACP, 0, tcmdln, -1,
-                                _wcmdln, (int)wcmdln_siz);
+    memcpy(_acmdln, tcmdln, acmdln_siz);
+    (void)MultiByteToWideChar(CP_ACP, 0, tcmdln, -1,
+                              _wcmdln, (int)wcmdln_siz);
 #endif
   }
 #endif

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2810,14 +2810,12 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
 
 #ifdef HAVE_WIN32_ACMDLN
   if(tcmdln) {
-    size_t acmdln_siz = acmdln_len * sizeof(char);
-    size_t wcmdln_siz = wcmdln_len * sizeof(wchar_t);
 #ifdef UNICODE
-    memcpy(_wcmdln, tcmdln, wcmdln_siz);
+    memcpy(_wcmdln, tcmdln, wcmdln_len * sizeof(wchar_t));
     (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1, _acmdln, (int)acmdln_len,
                               NULL, NULL);
 #else
-    memcpy(_acmdln, tcmdln, acmdln_siz);
+    memcpy(_acmdln, tcmdln, acmdln_len * sizeof(char));
     (void)MultiByteToWideChar(CP_ACP, 0, tcmdln, -1, _wcmdln, (int)wcmdln_len);
 #endif
     free(tcmdln);

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2712,7 +2712,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
   size_t wcmdln_len = wcslen(_wcmdln) + 1;
   size_t acmdln_siz = acmdln_len * sizeof(char);
   size_t wcmdln_siz = wcmdln_len * sizeof(wchar_t);
-  TCHAR *tcmdln = calloc(wcmdln_len, sizeof(TCHAR));
+  TCHAR *tcmdln = calloc(CURLMAX(wcmdln_len, acmdln_len), sizeof(TCHAR));
   _tcscat(tcmdln, TEXT("\""));
   _tcscat(tcmdln, argv[0]);
   _tcscat(tcmdln, TEXT("\""));

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2692,8 +2692,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
   struct OperationConfig *config = global->first;
 
 #ifdef HAVE_WIN32_ACMDLN
-  size_t acmdln_len, acmdln_siz;
-  size_t wcmdln_len, wcmdln_siz;
+  size_t acmdln_len, acmdln_siz = 0;
+  size_t wcmdln_len, wcmdln_siz = 0;
   TCHAR *tcmdln = NULL;
   if(_acmdln && _wcmdln) {
     acmdln_len = strlen(_acmdln) + 1;

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2743,12 +2743,10 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
           _tcscat(tcmdln, argv[i]);
           if(passarg) {
             _tcscat(tcmdln, TEXT(" "));
-            if(toclear) {
+            if(toclear)
               _tcscat(tcmdln, TEXT("\"\""));
-            }
-            else {
+            else
               _tcscat(tcmdln, argv[i + 1]);
-            }
           }
         }
 #elif defined(HAVE_WRITABLE_ARGV)

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2814,11 +2814,11 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
     size_t wcmdln_siz = wcmdln_len * sizeof(wchar_t);
 #ifdef UNICODE
     memcpy(_wcmdln, tcmdln, wcmdln_siz);
-    (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1, _acmdln, (int)acmdln_siz,
+    (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1, _acmdln, (int)acmdln_len,
                               NULL, NULL);
 #else
     memcpy(_acmdln, tcmdln, acmdln_siz);
-    (void)MultiByteToWideChar(CP_ACP, 0, tcmdln, -1, _wcmdln, (int)wcmdln_siz);
+    (void)MultiByteToWideChar(CP_ACP, 0, tcmdln, -1, _wcmdln, (int)wcmdln_len);
 #endif
     free(tcmdln);
   }

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2811,7 +2811,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
   }
 
 #ifdef HAVE_WIN32_ACMDLN
-  if(tcmdln) {
+  if(tcmdln && _acmdln && _wcmdln) {
 #ifdef UNICODE
     memcpy(_wcmdln, tcmdln, wcmdln_siz);
     (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1,

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2700,7 +2700,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
     wcmdln_len = wcslen(_wcmdln) + 1;
     acmdln_siz = acmdln_len * sizeof(char);
     wcmdln_siz = wcmdln_len * sizeof(wchar_t);
-    tcmdln = calloc(CURLMAX(wcmdln_len, acmdln_len), sizeof(TCHAR));
+    tcmdln = calloc(CURLMAX(wcmdln_len, acmdln_len) + 2, sizeof(TCHAR));
     if(tcmdln) {
       /* !checksrc! disable BANNEDFUNC 3 */
       _tcscat(tcmdln, TEXT("\""));
@@ -2744,7 +2744,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
           if(passarg) {
             _tcscat(tcmdln, TEXT(" "));
             if(toclear)
-              _tcscat(tcmdln, TEXT("\"\""));
+              _tcscat(tcmdln, TEXT("*"));
             else
               _tcscat(tcmdln, argv[i + 1]);
           }

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -53,9 +53,6 @@
   defined(__MINGW64_VERSION_MAJOR) && __MINGW64_VERSION_MAJOR >= 6) || \
   (defined(_MSC_VER) && _MSC_VER >= 1900))
 #define HAVE_WIN32_ACMDLN
-#endif
-
-#ifdef HAVE_WIN32_ACMDLN
 #include <process.h> /* for _acmdln and _wcmdln */
 #endif
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -49,6 +49,10 @@
 #  define USE_WATT32
 #endif
 
+#ifdef _WIN32
+#include <process.h> /* for _acmdln and _wcmdln */
+#endif
+
 #define ALLOW_BLANK TRUE
 #define DENY_BLANK FALSE
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2713,6 +2713,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
   size_t acmdln_siz = acmdln_len * sizeof(char);
   size_t wcmdln_siz = wcmdln_len * sizeof(wchar_t);
   TCHAR *tcmdln = calloc(CURLMAX(wcmdln_len, acmdln_len), sizeof(TCHAR));
+  /* !checksrc! disable BANNEDFUNC 3 */
   _tcscat(tcmdln, TEXT("\""));
   _tcscat(tcmdln, argv[0]);
   _tcscat(tcmdln, TEXT("\""));
@@ -2745,6 +2746,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
                               global, config, &toclear);
 
 #ifdef _WIN32
+        /* !checksrc! disable BANNEDFUNC 5 */
         _tcscat(tcmdln, TEXT(" "));
         _tcscat(tcmdln, argv[i]);
         if(passarg) {
@@ -2802,6 +2804,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
                             &toclear);
 
 #ifdef _WIN32
+      /* !checksrc! disable BANNEDFUNC 2 */
       _tcscat(tcmdln, TEXT(" "));
       _tcscat(tcmdln, argv[i]);
 #endif

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2755,7 +2755,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
           }
         }
 #elif defined(HAVE_WRITABLE_ARGV)
-        cleanarg(argv[i + 1]);
+        if(toclear)
+          cleanarg(argv[i + 1]);
 #endif
 
         curlx_unicodefree(nextarg);

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1141,7 +1141,6 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         break;
       }
       else {
-        *toclear = TRUE;
         *usedarg = TRUE; /* mark it as used */
       }
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2814,12 +2814,11 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
   if(tcmdln) {
 #ifdef UNICODE
     memcpy(_wcmdln, tcmdln, wcmdln_siz);
-    (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1,
-                              _acmdln, (int)acmdln_siz, NULL, NULL);
+    (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1, _acmdln, (int)acmdln_siz,
+                              NULL, NULL);
 #else
     memcpy(_acmdln, tcmdln, acmdln_siz);
-    (void)MultiByteToWideChar(CP_ACP, 0, tcmdln, -1,
-                              _wcmdln, (int)wcmdln_siz);
+    (void)MultiByteToWideChar(CP_ACP, 0, tcmdln, -1, _wcmdln, (int)wcmdln_siz);
 #endif
   }
 #endif

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2811,7 +2811,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
   }
 
 #ifdef HAVE_WIN32_ACMDLN
-  if(tcmdln && _acmdln && _wcmdln) {
+  if(tcmdln) {
 #ifdef UNICODE
     memcpy(_wcmdln, tcmdln, wcmdln_siz);
     (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1,

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2712,17 +2712,10 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
   size_t wcmdln_len = wcslen(_wcmdln) + 1;
   size_t acmdln_siz = acmdln_len * sizeof(char);
   size_t wcmdln_siz = wcmdln_len * sizeof(wchar_t);
-  char *acmdln = calloc(acmdln_len, sizeof(char));
-  wchar_t *wcmdln = calloc(wcmdln_len, sizeof(wchar_t));
-#ifdef UNICODE
-  wcscat(wcmdln, L"\"");
-  wcscat(wcmdln, argv[0]);
-  wcscat(wcmdln, L"\"");
-#else
-  strcat(acmdln, "\"");
-  strcat(acmdln, argv[0]);
-  strcat(acmdln, "\"");
-#endif
+  TCHAR *tcmdln = calloc(wcmdln_len, sizeof(TCHAR));
+  _tcscat(tcmdln, TEXT("\""));
+  _tcscat(tcmdln, argv[0]);
+  _tcscat(tcmdln, TEXT("\""));
 #endif
 
   for(i = 1, stillflags = TRUE; i < argc && !result; i++) {
@@ -2752,29 +2745,17 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
                               global, config, &toclear);
 
 #ifdef _WIN32
-#ifdef UNICODE
-        wcscat(wcmdln, L" ");
-        wcscat(wcmdln, orig_opt);
+        _tcscat(tcmdln, TEXT(" "));
+        _tcscat(tcmdln, argv[i]);
         if(passarg) {
-          wcscat(wcmdln, L" ");
+          _tcscat(tcmdln, TEXT(" "));
           if(toclear) {
-            wcscat(wcmdln, L"\"\"");
-          } else {
-            wcscat(wcmdln, argv[i + 1]);
+            _tcscat(tcmdln, TEXT("\"\""));
+          }
+          else {
+            _tcscat(tcmdln, argv[i + 1]);
           }
         }
-#else
-        strcat(acmdln, " ");
-        strcat(acmdln, orig_opt);
-        if(passarg) {
-          strcat(acmdln, " ");
-          if(toclear) {
-            strcat(acmdln, "\"\"");
-          } else {
-            strcat(acmdln, argv[i + 1]);
-          }
-        }
-#endif
 #endif
 
         curlx_unicodefree(nextarg);
@@ -2821,13 +2802,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
                             &toclear);
 
 #ifdef _WIN32
-#ifdef UNICODE
-      wcscat(wcmdln, L" ");
-      wcscat(wcmdln, orig_opt);
-#else
-      strcat(acmdln, " ");
-      strcat(acmdln, orig_opt);
-#endif
+      _tcscat(tcmdln, TEXT(" "));
+      _tcscat(tcmdln, argv[i]);
 #endif
     }
 
@@ -2837,16 +2813,16 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
 
 #ifdef _WIN32
 #ifdef UNICODE
-  memcpy(_wcmdln, wcmdln, wcmdln_siz);
-  if(!WideCharToMultiByte(CP_ACP, 0, wcmdln, -1,
+  memcpy(_wcmdln, tcmdln, wcmdln_siz);
+  if(!WideCharToMultiByte(CP_ACP, 0, _wcmdln, -1,
                           _acmdln, (int)acmdln_siz, NULL, NULL)) {
     memset(_acmdln, 0, acmdln_siz);
   }
 #else
-  memcpy(_acmdln, acmdln, acmdln_siz);
-  if(!MultiByteToWideChar(CP_ACP, 0, acmdln, -1,
+  memcpy(_acmdln, tcmdln, acmdln_siz);
+  if(!MultiByteToWideChar(CP_ACP, 0, _acmdln, -1,
                           _wcmdln, (int)wcmdln_siz)) {
-    memcpy(_wcmdln, wcmdln, wcmdln_siz);
+    memset(_wcmdln, 0, wcmdln_siz);
   }
 #endif
 #endif

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2692,14 +2692,12 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
   struct OperationConfig *config = global->first;
 
 #ifdef HAVE_WIN32_ACMDLN
-  size_t acmdln_len, acmdln_siz = 0;
-  size_t wcmdln_len, wcmdln_siz = 0;
+  size_t acmdln_len = 0;
+  size_t wcmdln_len = 0;
   TCHAR *tcmdln = NULL;
   if(_acmdln && _wcmdln) {
     acmdln_len = strlen(_acmdln) + 1;
     wcmdln_len = wcslen(_wcmdln) + 1;
-    acmdln_siz = acmdln_len * sizeof(char);
-    wcmdln_siz = wcmdln_len * sizeof(wchar_t);
     tcmdln = calloc(CURLMAX(wcmdln_len, acmdln_len) + 2, sizeof(TCHAR));
     if(tcmdln) {
       /* !checksrc! disable BANNEDFUNC 3 */
@@ -2812,6 +2810,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
 
 #ifdef HAVE_WIN32_ACMDLN
   if(tcmdln) {
+    size_t acmdln_siz = acmdln_len * sizeof(char);
+    size_t wcmdln_siz = wcmdln_len * sizeof(wchar_t);
 #ifdef UNICODE
     memcpy(_wcmdln, tcmdln, wcmdln_siz);
     (void)WideCharToMultiByte(CP_ACP, 0, tcmdln, -1, _acmdln, (int)acmdln_siz,

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2758,7 +2758,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
         if(passarg) {
           wcscat(wcmdln, L" ");
           if(toclear) {
-            wcscat(wcmdln, L"***");
+            wcscat(wcmdln, L"\"\"");
           } else {
             wcscat(wcmdln, argv[i + 1]);
           }
@@ -2769,7 +2769,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
         if(passarg) {
           strcat(acmdln, " ");
           if(toclear) {
-            strcat(acmdln, "***");
+            strcat(acmdln, "\"\"");
           } else {
             strcat(acmdln, argv[i + 1]);
           }

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2820,6 +2820,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
     memcpy(_acmdln, tcmdln, acmdln_siz);
     (void)MultiByteToWideChar(CP_ACP, 0, tcmdln, -1, _wcmdln, (int)wcmdln_siz);
 #endif
+    free(tcmdln);
   }
 #endif
 

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -358,10 +358,10 @@ const struct LongShort *findlongopt(const char *opt);
 const struct LongShort *findshortopt(char letter);
 
 ParameterError getparameter(const char *flag, char *nextarg,
+                            bool *toclear,
                             bool *usedarg,
                             struct GlobalConfig *global,
-                            struct OperationConfig *operation,
-                            bool *toclear);
+                            struct OperationConfig *operation);
 
 #ifdef UNITTESTS
 void parse_cert_parameter(const char *cert_parameter,

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -361,7 +361,8 @@ ParameterError getparameter(const char *flag, char *nextarg,
                             argv_item_t cleararg,
                             bool *usedarg,
                             struct GlobalConfig *global,
-                            struct OperationConfig *operation);
+                            struct OperationConfig *operation,
+                            bool *toclear);
 
 #ifdef UNITTESTS
 void parse_cert_parameter(const char *cert_parameter,

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -358,7 +358,6 @@ const struct LongShort *findlongopt(const char *opt);
 const struct LongShort *findshortopt(char letter);
 
 ParameterError getparameter(const char *flag, char *nextarg,
-                            argv_item_t cleararg,
                             bool *usedarg,
                             struct GlobalConfig *global,
                             struct OperationConfig *operation,

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -193,7 +193,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
 #ifdef DEBUG_CONFIG
       fprintf(tool_stderr, "PARAM: \"%s\"\n",(param ? param : "(null)"));
 #endif
-      res = getparameter(option, param, NULL, &usedarg, global, operation,
+      res = getparameter(option, param, &usedarg, global, operation,
                          &toclear);
       operation = global->last;
 

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -100,6 +100,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
     while(!rc && my_get_line(file, &buf, &fileerror)) {
       ParameterError res;
       bool alloced_param = FALSE;
+      bool toclear;
       lineno++;
       line = curlx_dyn_ptr(&buf);
       if(!line) {
@@ -192,7 +193,8 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
 #ifdef DEBUG_CONFIG
       fprintf(tool_stderr, "PARAM: \"%s\"\n",(param ? param : "(null)"));
 #endif
-      res = getparameter(option, param, NULL, &usedarg, global, operation);
+      res = getparameter(option, param, NULL, &usedarg, global, operation,
+                         &toclear);
       operation = global->last;
 
       if(!res && param && *param && !usedarg)

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -193,7 +193,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
 #ifdef DEBUG_CONFIG
       fprintf(tool_stderr, "PARAM: \"%s\"\n",(param ? param : "(null)"));
 #endif
-      res = getparameter(option, param, &usedarg, global, operation, &toclear);
+      res = getparameter(option, param, &toclear, &usedarg, global, operation);
       operation = global->last;
 
       if(!res && param && *param && !usedarg)

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -193,8 +193,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
 #ifdef DEBUG_CONFIG
       fprintf(tool_stderr, "PARAM: \"%s\"\n",(param ? param : "(null)"));
 #endif
-      res = getparameter(option, param, &usedarg, global, operation,
-                         &toclear);
+      res = getparameter(option, param, &usedarg, global, operation, &toclear);
       operation = global->last;
 
       if(!res && param && *param && !usedarg)


### PR DESCRIPTION
Writing to `argv` is not effective on Windows, but there is an alternate
method to modify the command-line as seen here:
https://github.com/lordmulder/cURL-build-win32/blob/2e9d3818baf8f7b1183331750b7b33152dd6ee82/patch/curl_tool_doswin.diff

Try a patch that's re-creating the full command-line string from each
argument except sensitive ones and writing it back to the command-line
buffer.

![Screen Shot 2024-11-21 non-unicode](https://github.com/user-attachments/assets/dd5574fb-5fb3-4908-83e2-3ef74a16753b)
![Screen Shot 2024-11-21 unicode](https://github.com/user-attachments/assets/bc7856bf-a810-45e5-b6b7-03d66126d457)

The known issue is the use of banned func `_tcscat()`.

---

- [ ] replace `cat`s.
- [x] look into suspect GHA/windows Unicode job issues. Timing out with "too large log" or similar.
  https://github.com/curl/curl/actions/runs/11953800552/job/33325198409?pr=15620
  https://github.com/curl/curl/actions/runs/11953800552/job/33325199361?pr=15620
  Seems to be mingw-w64 + c-ares builds (Unicode and non-Unicode):
  https://github.com/curl/curl/actions/runs/11964350233/job/33356658887
  Doh, I missed `free()`.
- [x] figure out which Windows targets support it. (MSVS 2008, 2010, 2013, mingw-w64 6.4.0, do not)
- [x] mingw-64 32-bit: `1264 Segmentation fault      bld/src/curl.exe --disable --version`: https://github.com/curl/curl/actions/runs/11945298830/job/33297864984?pr=15620#step:20:14