### PR TITLE
GHA: disable building tests, apps, docs in dependencies

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -175,7 +175,7 @@ jobs:
           cd $HOME
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
-          ./config no-deprecated --prefix=$PWD/build --libdir=lib
+          ./config no-deprecated --prefix=$PWD/build --libdir=lib no-makedepend no-apps no-docs no-tests
           make
           make -j1 install_sw
         name: 'build quictls'
@@ -206,7 +206,8 @@ jobs:
           git fetch origin --depth=1 ${{ env.wolfssl-version }}
           git checkout ${{ env.wolfssl-version }}
           ./autogen.sh
-          ./configure --disable-dependency-tracking --enable-all --enable-quic --prefix=$PWD/build
+          ./configure --disable-dependency-tracking --enable-all --enable-quic \
+            --disable-benchmark --disable-crypttests --disable-examples --prefix=$PWD/build
           make
           make install
         name: 'build wolfssl'
@@ -413,7 +414,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
-          ./config --prefix=$HOME/openssl/build
+          ./config --prefix=$HOME/openssl/build no-makedepend no-apps no-docs no-tests
           make -j1 install_sw
           cat exporters/openssl.pc
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -89,15 +89,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: cache quictls
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-quictls-no-deprecated
-        env:
-          cache-name: cache-quictls-no-deprecated
-        with:
-          path: /home/runner/quictls/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
-
       - name: cache gnutls
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
         id: cache-gnutls
@@ -106,16 +97,6 @@ jobs:
         with:
           path: /home/runner/gnutls/build
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.gnutls-version }}
-
-      - name: cache wolfssl
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-wolfssl
-        env:
-          cache-name: cache-wolfssl
-          wolfssl-version: ${{ needs.setup.outputs.wolfssl-version }}
-        with:
-          path: /home/runner/wolfssl/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
 
       - name: cache nghttp3
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
@@ -170,8 +151,7 @@ jobs:
           echo 'CC=gcc-12' >> $GITHUB_ENV
           echo 'CXX=g++-12' >> $GITHUB_ENV
 
-      - if: steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true'
-        run: |
+      - run: |
           cd $HOME
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
@@ -194,8 +174,7 @@ jobs:
           make install
         name: 'build gnutls'
 
-      - if: steps.cache-wolfssl.outputs.cache-hit != 'true'
-        env:
+      - env:
           wolfssl-version: ${{ needs.setup.outputs.wolfssl-version }}
         run: |
           cd $HOME
@@ -336,16 +315,6 @@ jobs:
           echo 'CXX=g++-12' >> $GITHUB_ENV
         name: 'install prereqs'
 
-      - name: cache quictls
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-quictls-no-deprecated
-        env:
-          cache-name: cache-quictls-no-deprecated
-        with:
-          path: /home/runner/quictls/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}
-          fail-on-cache-miss: true
-
       - name: cache gnutls
         if: matrix.build.name == 'gnutls'
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
@@ -355,18 +324,6 @@ jobs:
         with:
           path: /home/runner/gnutls/build
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.gnutls-version }}
-          fail-on-cache-miss: true
-
-      - name: cache wolfssl
-        if: matrix.build.name == 'wolfssl'
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-wolfssl
-        env:
-          cache-name: cache-wolfssl
-          wolfssl-version: ${{ needs.setup.outputs.wolfssl-version }}
-        with:
-          path: /home/runner/wolfssl/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
           fail-on-cache-miss: true
 
       - name: cache nghttp3
@@ -399,18 +356,8 @@ jobs:
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.nghttp2-version }}
           fail-on-cache-miss: true
 
-      - name: cache openssl
-        if: matrix.build.name == 'openssl-quic'
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-openssl
-        env:
-          cache-name: cache-openssl
-        with:
-          path: /home/runner/openssl/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.openssl-version }}
-
       - name: 'install openssl'
-        if: matrix.build.name == 'openssl-quic' && steps.cache-openssl.outputs.cache-hit != 'true'
+        if: matrix.build.name == 'openssl-quic'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -89,6 +89,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: cache quictls
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-quictls-no-deprecated
+        env:
+          cache-name: cache-quictls-no-deprecated
+        with:
+          path: /home/runner/quictls/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
+
       - name: cache gnutls
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
         id: cache-gnutls
@@ -97,6 +106,16 @@ jobs:
         with:
           path: /home/runner/gnutls/build
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.gnutls-version }}
+
+      - name: cache wolfssl
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-wolfssl
+        env:
+          cache-name: cache-wolfssl
+          wolfssl-version: ${{ needs.setup.outputs.wolfssl-version }}
+        with:
+          path: /home/runner/wolfssl/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
 
       - name: cache nghttp3
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
@@ -151,7 +170,8 @@ jobs:
           echo 'CC=gcc-12' >> $GITHUB_ENV
           echo 'CXX=g++-12' >> $GITHUB_ENV
 
-      - run: |
+      - if: steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true'
+        run: |
           cd $HOME
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
@@ -174,7 +194,8 @@ jobs:
           make install
         name: 'build gnutls'
 
-      - env:
+      - if: steps.cache-wolfssl.outputs.cache-hit != 'true'
+        env:
           wolfssl-version: ${{ needs.setup.outputs.wolfssl-version }}
         run: |
           cd $HOME
@@ -315,6 +336,16 @@ jobs:
           echo 'CXX=g++-12' >> $GITHUB_ENV
         name: 'install prereqs'
 
+      - name: cache quictls
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-quictls-no-deprecated
+        env:
+          cache-name: cache-quictls-no-deprecated
+        with:
+          path: /home/runner/quictls/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}
+          fail-on-cache-miss: true
+
       - name: cache gnutls
         if: matrix.build.name == 'gnutls'
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
@@ -324,6 +355,18 @@ jobs:
         with:
           path: /home/runner/gnutls/build
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.gnutls-version }}
+          fail-on-cache-miss: true
+
+      - name: cache wolfssl
+        if: matrix.build.name == 'wolfssl'
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-wolfssl
+        env:
+          cache-name: cache-wolfssl
+          wolfssl-version: ${{ needs.setup.outputs.wolfssl-version }}
+        with:
+          path: /home/runner/wolfssl/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
           fail-on-cache-miss: true
 
       - name: cache nghttp3
@@ -356,8 +399,18 @@ jobs:
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.nghttp2-version }}
           fail-on-cache-miss: true
 
-      - name: 'install openssl'
+      - name: cache openssl
         if: matrix.build.name == 'openssl-quic'
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-openssl
+        env:
+          cache-name: cache-openssl
+        with:
+          path: /home/runner/openssl/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.openssl-version }}
+
+      - name: 'install openssl'
+        if: matrix.build.name == 'openssl-quic' && steps.cache-openssl.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -155,7 +155,7 @@ jobs:
           cd $HOME
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
-          ./config no-deprecated --prefix=$PWD/build --libdir=lib no-makedepend no-apps no-docs no-tests
+          ./config no-deprecated --prefix=$PWD/build --libdir=lib
           make
           make -j1 install_sw
         name: 'build quictls'
@@ -185,8 +185,7 @@ jobs:
           git fetch origin --depth=1 ${{ env.wolfssl-version }}
           git checkout ${{ env.wolfssl-version }}
           ./autogen.sh
-          ./configure --disable-dependency-tracking --enable-all --enable-quic \
-            --disable-benchmark --disable-crypttests --disable-examples --prefix=$PWD/build
+          ./configure --disable-dependency-tracking --enable-all --enable-quic --prefix=$PWD/build
           make
           make install
         name: 'build wolfssl'
@@ -361,7 +360,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
-          ./config --prefix=$HOME/openssl/build no-makedepend no-apps no-docs no-tests
+          ./config --prefix=$HOME/openssl/build
           make -j1 install_sw
           cat exporters/openssl.pc
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -155,7 +155,7 @@ jobs:
           cd $HOME
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
-          ./config no-deprecated --prefix=$PWD/build --libdir=lib
+          ./config no-deprecated --prefix=$PWD/build --libdir=lib no-makedepend no-apps no-docs no-tests
           make
           make -j1 install_sw
         name: 'build quictls'
@@ -185,7 +185,8 @@ jobs:
           git fetch origin --depth=1 ${{ env.wolfssl-version }}
           git checkout ${{ env.wolfssl-version }}
           ./autogen.sh
-          ./configure --disable-dependency-tracking --enable-all --enable-quic --prefix=$PWD/build
+          ./configure --disable-dependency-tracking --enable-all --enable-quic \
+            --disable-benchmark --disable-crypttests --disable-examples --prefix=$PWD/build
           make
           make install
         name: 'build wolfssl'
@@ -360,7 +361,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
-          ./config --prefix=$HOME/openssl/build
+          ./config --prefix=$HOME/openssl/build no-makedepend no-apps no-docs no-tests
           make -j1 install_sw
           cat exporters/openssl.pc
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -366,7 +366,7 @@ jobs:
           git clone --quiet --depth=1 -b v${{ env.libressl-version }} https://github.com/libressl-portable/portable.git libressl-git
           cd libressl-git
           ./autogen.sh
-          ./configure --disable-dependency-tracking --prefix=$HOME/libressl
+          ./configure --disable-dependency-tracking --prefix=$HOME/libressl --disable-tests
           make install
 
       - name: 'cache wolfssl (all)'
@@ -386,7 +386,8 @@ jobs:
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
           cd wolfssl-${{ env.wolfssl-version }}-stable
           ./autogen.sh
-          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-all --enable-all
+          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --enable-all \
+            --disable-benchmark --disable-crypttests --disable-examples --prefix=$HOME/wolfssl-all
           make install
 
       - name: 'cache wolfssl (opensslextra)'
@@ -406,7 +407,8 @@ jobs:
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
           cd wolfssl-${{ env.wolfssl-version }}-stable
           ./autogen.sh
-          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-opensslextra --enable-opensslextra
+          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --enable-opensslextra \
+            --disable-benchmark --disable-crypttests --disable-examples --prefix=$HOME/wolfssl-opensslextra
           make install
 
       - name: 'cache mbedtls'
@@ -447,7 +449,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
-          CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib
+          CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib no-makedepend no-apps no-docs no-tests
           make -j1 install_sw
 
       - name: 'cache quictls'
@@ -465,7 +467,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl
-          ./config --prefix=$HOME/quictls --libdir=lib
+          ./config --prefix=$HOME/quictls --libdir=lib no-makedepend no-apps no-docs no-tests
           make -j1 install_sw
 
       - name: 'cache msh3'
@@ -505,7 +507,7 @@ jobs:
           tar xzf v${{ env.awslc-version }}.tar.gz
           mkdir aws-lc-${{ env.awslc-version }}-build
           cd aws-lc-${{ env.awslc-version }}-build
-          cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/awslc ../aws-lc-${{ env.awslc-version }}
+          cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/awslc ../aws-lc-${{ env.awslc-version }} -DBUILD_TOOL=OFF -DBUILD_TESTING=OFF
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -356,7 +356,7 @@ jobs:
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/libressl/portable/releases/download/v${{ env.libressl-version }}/libressl-${{ env.libressl-version }}.tar.gz
           tar -xzf libressl-${{ env.libressl-version }}.tar.gz
           cd libressl-${{ env.libressl-version }}
-          ./configure --disable-dependency-tracking --prefix=$HOME/libressl --disable-tests
+          ./configure --disable-dependency-tracking --prefix=$HOME/libressl
           make install
 
       - name: 'build wolfssl (all)'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -350,8 +350,18 @@ jobs:
           cp inc/*.h $HOME/bearssl/include
           cp build/libbearssl.* $HOME/bearssl/lib
 
-      - name: 'build libressl'
+      - name: 'cache libressl'
         if: contains(matrix.build.install_steps, 'libressl')
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-libressl
+        env:
+          cache-name: cache-libressl
+        with:
+          path: /home/runner/libressl
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.libressl-version }}
+
+      - name: 'build libressl'
+        if: contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true'
         run: |
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/libressl/portable/releases/download/v${{ env.libressl-version }}/libressl-${{ env.libressl-version }}.tar.gz
           tar -xzf libressl-${{ env.libressl-version }}.tar.gz
@@ -359,8 +369,18 @@ jobs:
           ./configure --disable-dependency-tracking --prefix=$HOME/libressl
           make install
 
-      - name: 'build wolfssl (all)'
+      - name: 'cache wolfssl (all)'
         if: contains(matrix.build.install_steps, 'wolfssl-all')
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-wolfssl-all
+        env:
+          cache-name: cache-wolfssl-all
+        with:
+          path: /home/runner/wolfssl-all
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
+
+      - name: 'build wolfssl (all)'
+        if: contains(matrix.build.install_steps, 'wolfssl-all') && steps.cache-wolfssl-all.outputs.cache-hit != 'true'
         run: |
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v${{ env.wolfssl-version }}-stable.tar.gz
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
@@ -370,8 +390,18 @@ jobs:
             --disable-benchmark --disable-crypttests --disable-examples --prefix=$HOME/wolfssl-all
           make install
 
-      - name: 'build wolfssl (opensslextra)'
+      - name: 'cache wolfssl (opensslextra)'
         if: contains(matrix.build.install_steps, 'wolfssl-opensslextra')
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-wolfssl-opensslextra
+        env:
+          cache-name: cache-wolfssl-opensslextra
+        with:
+          path: /home/runner/wolfssl-opensslextra
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
+
+      - name: 'build wolfssl (opensslextra)'
+        if: contains(matrix.build.install_steps, 'wolfssl-opensslextra') && steps.cache-wolfssl-opensslextra.outputs.cache-hit != 'true'
         run: |
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v${{ env.wolfssl-version }}-stable.tar.gz
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
@@ -404,16 +434,36 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: 'build openssl (thread sanitizer)'
+      - name: 'cache openssl (thread sanitizer)'
         if: contains(matrix.build.install_steps, 'openssl-tsan')
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-openssl-tsan
+        env:
+          cache-name: cache-openssl-tsan
+        with:
+          path: /home/runner/openssl
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl-version }}
+
+      - name: 'build openssl (thread sanitizer)'
+        if: contains(matrix.build.install_steps, 'openssl-tsan') && steps.cache-openssl-tsan.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
           CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib no-makedepend no-apps no-docs no-tests
           make -j1 install_sw
 
-      - name: 'build quictls'
+      - name: 'cache quictls'
         if: contains(matrix.build.install_steps, 'quictls')
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-quictls
+        env:
+          cache-name: cache-quictls
+        with:
+          path: /home/runner/quictls
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
+
+      - name: 'build quictls'
+        if: contains(matrix.build.install_steps, 'quictls') && steps.cache-quictls.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl
@@ -439,8 +489,18 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: 'build awslc'
+      - name: 'cache awslc'
         if: contains(matrix.build.install_steps, 'awslc')
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-awslc
+        env:
+          cache-name: cache-awslc
+        with:
+          path: /home/runner/awslc
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.awslc-version }}
+
+      - name: 'build awslc'
+        if: contains(matrix.build.install_steps, 'awslc') && steps.cache-awslc.outputs.cache-hit != 'true'
         run: |
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 \
             https://github.com/awslabs/aws-lc/archive/refs/tags/v${{ env.awslc-version }}.tar.gz

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -356,7 +356,7 @@ jobs:
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/libressl/portable/releases/download/v${{ env.libressl-version }}/libressl-${{ env.libressl-version }}.tar.gz
           tar -xzf libressl-${{ env.libressl-version }}.tar.gz
           cd libressl-${{ env.libressl-version }}
-          ./configure --disable-dependency-tracking --prefix=$HOME/libressl --disable-tests
+          ./configure --disable-dependency-tracking --prefix=$HOME/libressl
           make install
 
       - name: 'build wolfssl (all)'
@@ -366,8 +366,7 @@ jobs:
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
           cd wolfssl-${{ env.wolfssl-version }}-stable
           ./autogen.sh
-          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --enable-all \
-            --disable-benchmark --disable-crypttests --disable-examples --prefix=$HOME/wolfssl-all
+          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-all --enable-all
           make install
 
       - name: 'build wolfssl (opensslextra)'
@@ -377,8 +376,7 @@ jobs:
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
           cd wolfssl-${{ env.wolfssl-version }}-stable
           ./autogen.sh
-          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --enable-opensslextra \
-            --disable-benchmark --disable-crypttests --disable-examples --prefix=$HOME/wolfssl-opensslextra
+          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-opensslextra --enable-opensslextra
           make install
 
       - name: 'cache mbedtls'
@@ -409,7 +407,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
-          CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib no-makedepend no-apps no-docs no-tests
+          CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib
           make -j1 install_sw
 
       - name: 'build quictls'
@@ -417,7 +415,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl
-          ./config --prefix=$HOME/quictls --libdir=lib no-makedepend no-apps no-docs no-tests
+          ./config --prefix=$HOME/quictls --libdir=lib
           make -j1 install_sw
 
       - name: 'cache msh3'
@@ -447,7 +445,7 @@ jobs:
           tar xzf v${{ env.awslc-version }}.tar.gz
           mkdir aws-lc-${{ env.awslc-version }}-build
           cd aws-lc-${{ env.awslc-version }}-build
-          cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/awslc ../aws-lc-${{ env.awslc-version }} -DBUILD_TOOL=OFF -DBUILD_TESTING=OFF
+          cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/awslc ../aws-lc-${{ env.awslc-version }}
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -353,9 +353,9 @@ jobs:
       - name: 'build libressl'
         if: contains(matrix.build.install_steps, 'libressl')
         run: |
-          git clone --quiet --depth=1 -b v${{ env.libressl-version }} https://github.com/libressl-portable/portable.git libressl-git
-          cd libressl-git
-          ./autogen.sh
+          curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/libressl/portable/releases/download/v${{ env.libressl-version }}/libressl-${{ env.libressl-version }}.tar.gz
+          tar -xzf libressl-${{ env.libressl-version }}.tar.gz
+          cd libressl-${{ env.libressl-version }}
           ./configure --disable-dependency-tracking --prefix=$HOME/libressl --disable-tests
           make install
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -356,7 +356,7 @@ jobs:
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/libressl/portable/releases/download/v${{ env.libressl-version }}/libressl-${{ env.libressl-version }}.tar.gz
           tar -xzf libressl-${{ env.libressl-version }}.tar.gz
           cd libressl-${{ env.libressl-version }}
-          ./configure --disable-dependency-tracking --prefix=$HOME/libressl
+          ./configure --disable-dependency-tracking --prefix=$HOME/libressl --disable-tests
           make install
 
       - name: 'build wolfssl (all)'
@@ -366,7 +366,8 @@ jobs:
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
           cd wolfssl-${{ env.wolfssl-version }}-stable
           ./autogen.sh
-          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-all --enable-all
+          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --enable-all \
+            --disable-benchmark --disable-crypttests --disable-examples --prefix=$HOME/wolfssl-all
           make install
 
       - name: 'build wolfssl (opensslextra)'
@@ -376,7 +377,8 @@ jobs:
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
           cd wolfssl-${{ env.wolfssl-version }}-stable
           ./autogen.sh
-          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --prefix=$HOME/wolfssl-opensslextra --enable-opensslextra
+          ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --enable-opensslextra \
+            --disable-benchmark --disable-crypttests --disable-examples --prefix=$HOME/wolfssl-opensslextra
           make install
 
       - name: 'cache mbedtls'
@@ -407,7 +409,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
-          CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib
+          CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib no-makedepend no-apps no-docs no-tests
           make -j1 install_sw
 
       - name: 'build quictls'
@@ -415,7 +417,7 @@ jobs:
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl
-          ./config --prefix=$HOME/quictls --libdir=lib
+          ./config --prefix=$HOME/quictls --libdir=lib no-makedepend no-apps no-docs no-tests
           make -j1 install_sw
 
       - name: 'cache msh3'
@@ -445,7 +447,7 @@ jobs:
           tar xzf v${{ env.awslc-version }}.tar.gz
           mkdir aws-lc-${{ env.awslc-version }}-build
           cd aws-lc-${{ env.awslc-version }}-build
-          cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/awslc ../aws-lc-${{ env.awslc-version }}
+          cmake -G Ninja -DCMAKE_INSTALL_PREFIX=$HOME/awslc ../aws-lc-${{ env.awslc-version }} -DBUILD_TOOL=OFF -DBUILD_TESTING=OFF
           cmake --build .
           cmake --install .
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -350,18 +350,8 @@ jobs:
           cp inc/*.h $HOME/bearssl/include
           cp build/libbearssl.* $HOME/bearssl/lib
 
-      - name: 'cache libressl'
-        if: contains(matrix.build.install_steps, 'libressl')
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-libressl
-        env:
-          cache-name: cache-libressl
-        with:
-          path: /home/runner/libressl
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.libressl-version }}
-
       - name: 'build libressl'
-        if: contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'libressl')
         run: |
           git clone --quiet --depth=1 -b v${{ env.libressl-version }} https://github.com/libressl-portable/portable.git libressl-git
           cd libressl-git
@@ -369,18 +359,8 @@ jobs:
           ./configure --disable-dependency-tracking --prefix=$HOME/libressl --disable-tests
           make install
 
-      - name: 'cache wolfssl (all)'
-        if: contains(matrix.build.install_steps, 'wolfssl-all')
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-wolfssl-all
-        env:
-          cache-name: cache-wolfssl-all
-        with:
-          path: /home/runner/wolfssl-all
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
-
       - name: 'build wolfssl (all)'
-        if: contains(matrix.build.install_steps, 'wolfssl-all') && steps.cache-wolfssl-all.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'wolfssl-all')
         run: |
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v${{ env.wolfssl-version }}-stable.tar.gz
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
@@ -390,18 +370,8 @@ jobs:
             --disable-benchmark --disable-crypttests --disable-examples --prefix=$HOME/wolfssl-all
           make install
 
-      - name: 'cache wolfssl (opensslextra)'
-        if: contains(matrix.build.install_steps, 'wolfssl-opensslextra')
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-wolfssl-opensslextra
-        env:
-          cache-name: cache-wolfssl-opensslextra
-        with:
-          path: /home/runner/wolfssl-opensslextra
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.wolfssl-version }}
-
       - name: 'build wolfssl (opensslextra)'
-        if: contains(matrix.build.install_steps, 'wolfssl-opensslextra') && steps.cache-wolfssl-opensslextra.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'wolfssl-opensslextra')
         run: |
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v${{ env.wolfssl-version }}-stable.tar.gz
           tar -xzf v${{ env.wolfssl-version }}-stable.tar.gz
@@ -434,36 +404,16 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: 'cache openssl (thread sanitizer)'
-        if: contains(matrix.build.install_steps, 'openssl-tsan')
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-openssl-tsan
-        env:
-          cache-name: cache-openssl-tsan
-        with:
-          path: /home/runner/openssl
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl-version }}
-
       - name: 'build openssl (thread sanitizer)'
-        if: contains(matrix.build.install_steps, 'openssl-tsan') && steps.cache-openssl-tsan.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'openssl-tsan')
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
           CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib no-makedepend no-apps no-docs no-tests
           make -j1 install_sw
 
-      - name: 'cache quictls'
-        if: contains(matrix.build.install_steps, 'quictls')
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-quictls
-        env:
-          cache-name: cache-quictls
-        with:
-          path: /home/runner/quictls
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
-
       - name: 'build quictls'
-        if: contains(matrix.build.install_steps, 'quictls') && steps.cache-quictls.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'quictls')
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl
@@ -489,18 +439,8 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: 'cache awslc'
-        if: contains(matrix.build.install_steps, 'awslc')
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-awslc
-        env:
-          cache-name: cache-awslc
-        with:
-          path: /home/runner/awslc
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.awslc-version }}
-
       - name: 'build awslc'
-        if: contains(matrix.build.install_steps, 'awslc') && steps.cache-awslc.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'awslc')
         run: |
           curl -LOsSf --retry 6 --retry-connrefused --max-time 999 \
             https://github.com/awslabs/aws-lc/archive/refs/tags/v${{ env.awslc-version }}.tar.gz


### PR DESCRIPTION
Also:
- for LibreSSL download the official source tarball instead of
  using the tagged Git repo and running the build script which
  merged the OpenBSD libressl repo into it. The latter method
  was also broken at the time of this commit.

Build times:
```
                       before   after
aws-lc:                 1m55s    ~40s
libressl:               1m16s  ~1m20s
openssl-tsan:           5m47s   3m43s
openssl:                6m38s   4m49s
quictls-no-deprecated:  2m28s   1m51s
quictls:               ~6m08s   4m16s
wolfssl-all:            1m36s     52s
wolfssl-master:         1m34s     53s
wolfssl-opensslextra:     50s     32s
```

LibreSSL build options are unchanged, but by using the tarball now
instead of two repos and a generator script, it also should be faster,
and more stable.
