### PR TITLE
cmake: include `wolfssl/options.h` first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -850,9 +850,9 @@ macro(openssl_check_quic)
 endmacro()
 
 if(USE_WOLFSSL)
-  openssl_check_symbol_exists("wolfSSL_DES_ecb_encrypt" "wolfssl/openssl/des.h" HAVE_WOLFSSL_DES_ECB_ENCRYPT "")
-  openssl_check_symbol_exists("wolfSSL_BIO_new" "wolfssl/ssl.h" HAVE_WOLFSSL_BIO "")
-  openssl_check_symbol_exists("wolfSSL_BIO_set_shutdown" "wolfssl/ssl.h" HAVE_WOLFSSL_FULL_BIO "")
+  openssl_check_symbol_exists("wolfSSL_DES_ecb_encrypt" "wolfssl/options.h;wolfssl/openssl/des.h" HAVE_WOLFSSL_DES_ECB_ENCRYPT "")
+  openssl_check_symbol_exists("wolfSSL_BIO_new" "wolfssl/options.h;wolfssl/ssl.h" HAVE_WOLFSSL_BIO "")
+  openssl_check_symbol_exists("wolfSSL_BIO_set_shutdown" "wolfssl/options.h;wolfssl/ssl.h" HAVE_WOLFSSL_FULL_BIO "")
 endif()
 
 if(USE_OPENSSL OR USE_WOLFSSL)

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -33,8 +33,8 @@
 #ifdef USE_WOLFSSL
 
 #define WOLFSSL_OPTIONS_IGNORE_SYS
-#include <wolfssl/version.h>
 #include <wolfssl/options.h>
+#include <wolfssl/version.h>
 
 #if LIBWOLFSSL_VERSION_HEX < 0x03004006 /* wolfSSL 3.4.6 (2015) */
 #error "wolfSSL version should be at least 3.4.6"


### PR DESCRIPTION
It was missing while detecting `wolfSSL_DES_ecb_encrypt`,
`wolfSSL_BIO_new` and `wolfSSL_BIO_set_shutdown`.

We have not seen it causing issues in stable wolfSSL releases as of
v5.7.4, until a recent commit in wolfSSL master, which broke detections:
```
curl/CMakeFiles/CMakeScratch//CheckSymbolExists.c:8:19: error: ‘wolfSSL_BIO_new’ undeclared (first use in this function); did you mean ‘wolfSSL_CTX_new’?
curl/CMakeFiles/CMakeScratch//CheckSymbolExists.c:8:19: error: ‘wolfSSL_BIO_set_shutdown’ undeclared (first use in this function); did you mean ‘wolfSSL_set_shutdown’?
```
This in turn disabled `HTTPS-proxy` and failed related pytests:
https://github.com/curl/curl/actions/runs/11953800545/job/33324250039?pr=15620

wolfSSL source diff causing the regression:
https://github.com/wolfSSL/wolfSSL/compare/be70bea687526a51e3d751d425bbaaa412b451ee..c06f65a8ace311667d9b9d7fd320b6b25f8b1bf8

The wolfSSL build says:
```
Note: Make sure your application includes "wolfssl/options.h" before any other wolfSSL headers.
      You can define "WOLFSSL_USE_OPTIONS_H" in your application to include this automatically.
```

This patch makes sure to follow this rule across the curl codebase.

Also:
- include `wolfssl/options.h` first in `lib/vtls/wolfssl.c`.
  It was preceded by `wolfssl/version.h`, which did not cause issues.
  Background for the pre-existing include order:
  Ref: deb9462ff2de8e955c67ed441f5f48619a31198d #3903
  Ref: https://curl.se/mail/lib-2015-04/0069.html

Bug: https://github.com/curl/curl/pull/15620#issuecomment-2491872463
Follow-up to d68a121266671c806b5065c2fdce52d292bf7830 #14064
