### PR TITLE
rtsp: Check eos in the rtsp receive and return an error code

### DIFF
--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -215,7 +215,7 @@ static CURLcode rtsp_done(struct Curl_easy *data,
     }
     if(data->set.rtspreq == RTSPREQ_RECEIVE &&
        data->req.eos_written) {
-      failf(data, "End of stream.");
+      failf(data, "Server prematurely closed the RTSP connection.");
       return CURLE_RECV_ERROR;
     }
   }

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -213,6 +213,11 @@ static CURLcode rtsp_done(struct Curl_easy *data,
        (data->conn->proto.rtspc.rtp_channel == -1)) {
       infof(data, "Got an RTP Receive with a CSeq of %ld", CSeq_recv);
     }
+    if(data->set.rtspreq == RTSPREQ_RECEIVE &&
+       data->req.eos_written) {
+      failf(data, "End of stream.");
+      return CURLE_RECV_ERROR;
+    }
   }
 
   return httpStatus;


### PR DESCRIPTION
This helps the caller detect disconnection events.

fix #15624 