### PR TITLE
GHA: speed up 3 openssl/quictls builds 3x

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -166,8 +166,7 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
           ./config no-deprecated --prefix=$PWD/build --libdir=lib no-makedepend no-apps no-docs no-tests
-          make
-          make -j1 install_sw
+          make install_sw
         name: 'build quictls'
 
       - if: steps.cache-gnutls.outputs.cache-hit != 'true'
@@ -385,8 +384,7 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
           ./config --prefix=$HOME/openssl/build no-makedepend no-apps no-docs no-tests
-          make
-          make -j1 install_sw
+          make install_sw
           cat exporters/openssl.pc
 
       - name: cache quiche

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -89,15 +89,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: cache quictls
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-quictls-no-deprecated
-        env:
-          cache-name: cache-quictls-no-deprecated
-        with:
-          path: /home/runner/quictls/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
-
       - name: cache gnutls
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
         id: cache-gnutls
@@ -170,8 +161,7 @@ jobs:
           echo 'CC=gcc-12' >> $GITHUB_ENV
           echo 'CXX=g++-12' >> $GITHUB_ENV
 
-      - if: steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true'
-        run: |
+      - run: |
           cd $HOME
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
@@ -336,16 +326,6 @@ jobs:
           echo 'CXX=g++-12' >> $GITHUB_ENV
         name: 'install prereqs'
 
-      - name: cache quictls
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-quictls-no-deprecated
-        env:
-          cache-name: cache-quictls-no-deprecated
-        with:
-          path: /home/runner/quictls/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}
-          fail-on-cache-miss: true
-
       - name: cache gnutls
         if: matrix.build.name == 'gnutls'
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
@@ -399,18 +379,8 @@ jobs:
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.nghttp2-version }}
           fail-on-cache-miss: true
 
-      - name: cache openssl
-        if: matrix.build.name == 'openssl-quic'
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-openssl
-        env:
-          cache-name: cache-openssl
-        with:
-          path: /home/runner/openssl/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.openssl-version }}
-
       - name: 'install openssl'
-        if: matrix.build.name == 'openssl-quic' && steps.cache-openssl.outputs.cache-hit != 'true'
+        if: matrix.build.name == 'openssl-quic'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -385,6 +385,7 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
           ./config --prefix=$HOME/openssl/build no-makedepend no-apps no-docs no-tests
+          make
           make -j1 install_sw
           cat exporters/openssl.pc
 

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -166,7 +166,8 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
           ./config no-deprecated --prefix=$PWD/build --libdir=lib no-makedepend no-apps no-docs no-tests
-          make install_sw
+          make
+          make -j1 install_sw
         name: 'build quictls'
 
       - if: steps.cache-gnutls.outputs.cache-hit != 'true'
@@ -384,7 +385,8 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
           ./config --prefix=$HOME/openssl/build no-makedepend no-apps no-docs no-tests
-          make install_sw
+          make
+          make -j1 install_sw
           cat exporters/openssl.pc
 
       - name: cache quiche

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -89,6 +89,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: cache quictls
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-quictls-no-deprecated
+        env:
+          cache-name: cache-quictls-no-deprecated
+        with:
+          path: /home/runner/quictls/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
+
       - name: cache gnutls
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
         id: cache-gnutls
@@ -161,7 +170,8 @@ jobs:
           echo 'CC=gcc-12' >> $GITHUB_ENV
           echo 'CXX=g++-12' >> $GITHUB_ENV
 
-      - run: |
+      - if: steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true'
+        run: |
           cd $HOME
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
           cd quictls
@@ -326,6 +336,16 @@ jobs:
           echo 'CXX=g++-12' >> $GITHUB_ENV
         name: 'install prereqs'
 
+      - name: cache quictls
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-quictls-no-deprecated
+        env:
+          cache-name: cache-quictls-no-deprecated
+        with:
+          path: /home/runner/quictls/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}
+          fail-on-cache-miss: true
+
       - name: cache gnutls
         if: matrix.build.name == 'gnutls'
         uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
@@ -379,8 +399,18 @@ jobs:
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.nghttp2-version }}
           fail-on-cache-miss: true
 
-      - name: 'install openssl'
+      - name: cache openssl
         if: matrix.build.name == 'openssl-quic'
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-openssl
+        env:
+          cache-name: cache-openssl
+        with:
+          path: /home/runner/openssl/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.openssl-version }}
+
+      - name: 'install openssl'
+        if: matrix.build.name == 'openssl-quic' && steps.cache-openssl.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -434,8 +434,18 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: 'build openssl (thread sanitizer)'
+      - name: 'cache openssl (thread sanitizer)'
         if: contains(matrix.build.install_steps, 'openssl-tsan')
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-openssl-tsan
+        env:
+          cache-name: cache-openssl-tsan
+        with:
+          path: /home/runner/openssl
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl-version }}
+
+      - name: 'build openssl (thread sanitizer)'
+        if: contains(matrix.build.install_steps, 'openssl-tsan') && steps.cache-openssl-tsan.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
@@ -443,8 +453,18 @@ jobs:
           make
           make -j1 install_sw
 
-      - name: 'build quictls'
+      - name: 'cache quictls'
         if: contains(matrix.build.install_steps, 'quictls')
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
+        id: cache-quictls
+        env:
+          cache-name: cache-quictls
+        with:
+          path: /home/runner/quictls
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
+
+      - name: 'build quictls'
+        if: contains(matrix.build.install_steps, 'quictls') && steps.cache-quictls.outputs.cache-hit != 'true'
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -440,7 +440,8 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
           CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib no-makedepend no-apps no-docs no-tests
-          make install_sw
+          make
+          make -j1 install_sw
 
       - name: 'build quictls'
         if: contains(matrix.build.install_steps, 'quictls')
@@ -448,7 +449,8 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl
           ./config --prefix=$HOME/quictls --libdir=lib no-makedepend no-apps no-docs no-tests
-          make install_sw
+          make
+          make -j1 install_sw
 
       - name: 'cache msh3'
         if: contains(matrix.build.install_steps, 'msh3')

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -440,8 +440,7 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
           CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib no-makedepend no-apps no-docs no-tests
-          make
-          make -j1 install_sw
+          make install_sw
 
       - name: 'build quictls'
         if: contains(matrix.build.install_steps, 'quictls')
@@ -449,8 +448,7 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl
           ./config --prefix=$HOME/quictls --libdir=lib no-makedepend no-apps no-docs no-tests
-          make
-          make -j1 install_sw
+          make install_sw
 
       - name: 'cache msh3'
         if: contains(matrix.build.install_steps, 'msh3')

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -434,36 +434,16 @@ jobs:
           cmake --build .
           cmake --install .
 
-      - name: 'cache openssl (thread sanitizer)'
-        if: contains(matrix.build.install_steps, 'openssl-tsan')
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-openssl-tsan
-        env:
-          cache-name: cache-openssl-tsan
-        with:
-          path: /home/runner/openssl
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.openssl-version }}
-
       - name: 'build openssl (thread sanitizer)'
-        if: contains(matrix.build.install_steps, 'openssl-tsan') && steps.cache-openssl-tsan.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'openssl-tsan')
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
           CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib no-makedepend no-apps no-docs no-tests
           make -j1 install_sw
 
-      - name: 'cache quictls'
-        if: contains(matrix.build.install_steps, 'quictls')
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
-        id: cache-quictls
-        env:
-          cache-name: cache-quictls
-        with:
-          path: /home/runner/quictls
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
-
       - name: 'build quictls'
-        if: contains(matrix.build.install_steps, 'quictls') && steps.cache-quictls.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'quictls')
         run: |
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -440,6 +440,7 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.openssl-version }} https://github.com/openssl/openssl
           cd openssl
           CC="clang" CFLAGS="-fsanitize=thread" LDFLAGS="-fsanitize=thread" ./config --prefix=$HOME/openssl --libdir=lib no-makedepend no-apps no-docs no-tests
+          make
           make -j1 install_sw
 
       - name: 'build quictls'
@@ -448,6 +449,7 @@ jobs:
           git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
           cd openssl
           ./config --prefix=$HOME/quictls --libdir=lib no-makedepend no-apps no-docs no-tests
+          make
           make -j1 install_sw
 
       - name: 'cache msh3'


### PR DESCRIPTION
Build in parallel first, then install with `-j1`. This makes the build
part 3x quicker, while avoiding parallellism issues at the install
phase.

```
                       before   after  after
                              1da198d   this
aws-lc:                 1m55s    ~40s
libressl:               1m16s  ~1m20s
openssl-tsan:           5m47s   3m43s  1m48s (clang)
openssl:                6m38s   4m49s  2m13s (quic)
quictls-no-deprecated:  2m28s   1m51s
quictls:               ~6m08s   4m16s  1m55s
wolfssl-all:            1m36s     52s
wolfssl-master:         1m34s     53s
wolfssl-opensslextra:     50s     32s
```                                                      

Follow-up to 1da198d18e495c08adb5691459da0b5fcfc7f160 #15622
