### PR TITLE
tool_getpass: make local `getpass_r()` a dummy for UWP

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -210,7 +210,7 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - uses: msys2/setup-msys2@ddf331adaebd714795f1042345e6ca57bd66cea8 # v2
+      - uses: msys2/setup-msys2@c52d1fa9c7492275e60fe763540fb601f5f232a1 # v2
         if: ${{ matrix.sys == 'msys' }}
         with:
           msystem: ${{ matrix.sys }}
@@ -226,7 +226,7 @@ jobs:
             libpsl-devel
             libssh2-devel
 
-      - uses: msys2/setup-msys2@ddf331adaebd714795f1042345e6ca57bd66cea8 # v2
+      - uses: msys2/setup-msys2@c52d1fa9c7492275e60fe763540fb601f5f232a1 # v2
         if: ${{ matrix.sys != 'msys' }}
         with:
           msystem: ${{ matrix.sys }}

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -102,7 +102,7 @@ char *getpass_r(const char *prompt, char *buffer, size_t buflen)
   fputs(prompt, tool_stderr);
 
   for(i = 0; i < buflen; i++) {
-    buffer[i] = (char)getch();
+    buffer[i] = (char)_getch();
     if(buffer[i] == '\r' || buffer[i] == '\n') {
       buffer[i] = '\0';
       break;

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -98,27 +98,34 @@ char *getpass_r(const char *prompt, char *buffer, size_t buflen)
 
 char *getpass_r(const char *prompt, char *buffer, size_t buflen)
 {
-  size_t i;
   fputs(prompt, tool_stderr);
-
-  for(i = 0; i < buflen; i++) {
-    buffer[i] = (char)getch();
-    if(buffer[i] == '\r' || buffer[i] == '\n') {
-      buffer[i] = '\0';
-      break;
-    }
-    else
-      if(buffer[i] == '\b')
-        /* remove this letter and if this is not the first key, remove the
-           previous one as well */
-        i = i - (i >= 1 ? 2 : 1);
-  }
-  /* since echo is disabled, print a newline */
+#ifdef CURL_WINDOWS_UWP
   fputs("\n", tool_stderr);
-  /* if user did not hit ENTER, terminate buffer */
-  if(i == buflen)
-    buffer[buflen-1] = '\0';
+  if(buflen > 0)
+    buffer[0] = '\0';
+#else
+  {
+    size_t i;
 
+    for(i = 0; i < buflen; i++) {
+      buffer[i] = (char)getch();
+      if(buffer[i] == '\r' || buffer[i] == '\n') {
+        buffer[i] = '\0';
+        break;
+      }
+      else
+        if(buffer[i] == '\b')
+          /* remove this letter and if this is not the first key, remove the
+             previous one as well */
+          i = i - (i >= 1 ? 2 : 1);
+    }
+    /* since echo is disabled, print a newline */
+    fputs("\n", tool_stderr);
+    /* if user did not hit ENTER, terminate buffer */
+    if(i == buflen)
+      buffer[buflen-1] = '\0';
+    }
+#endif
   return buffer; /* we always return success */
 }
 #define DONE

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -102,7 +102,7 @@ char *getpass_r(const char *prompt, char *buffer, size_t buflen)
   fputs(prompt, tool_stderr);
 
   for(i = 0; i < buflen; i++) {
-    buffer[i] = (char)_getch();
+    buffer[i] = (char)getch();
     if(buffer[i] == '\r' || buffer[i] == '\n') {
       buffer[i] = '\0';
       break;


### PR DESCRIPTION
The CRT call `getch()` isn't supported on Windows UWP. This function is
used to implement `getpass_r()` for reading a password from the console,
for platforms not supporting it natively. This patch makes this function
a dummy, so password entry from the command-line is no longer supported
for UWP apps. Though it probably did not work before this patch, due to:

CRT headers do declare `getch()`, but it's missing from the CRT DLL.

MSDN documents it as unsupported for UWP:
https://learn.microsoft.com/cpp/c-runtime-library/reference/getch
https://learn.microsoft.com/cpp/c-runtime-library/reference/getch-getwch

Same is true for the non-deprecated `_getch()` function.

After mingw-w64 synced its implib with `msvcr120_app.dll`, the CI job
`mingw, CM x86_64 schannel R uwp` broke with:
```
[16/16] Linking C executable src\curl.exe
FAILED: src/curl.exe 
[...]
D:/a/_temp/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe:
  src/CMakeFiles/curl.dir/Unity/unity_0_c.c.obj:unity_0_c.c:(.text+0x4d05): undefined reference to `getch'
```
Ref: https://github.com/curl/curl/actions/runs/11873795410/job/33089008727?pr=15597#step:19:25

Also:
- GHA/windows: bump `msys2/setup-msys2` action to
  https://github.com/msys2/setup-msys2/commit/c52d1fa
  This triggered the build failure above.
  Closes #15597

Ref: https://sourceforge.net/p/mingw-w64/mingw-w64/ci/d408f51e5a3e9a4eb3739efea1fb2daf50dbb058/tree/mingw-w64-crt/def-include/crt-aliases.def.in?diff=9e27bb062a46d20aa9a372559956451d4565c22b

---

w/o whitespace: https://github.com/curl/curl/pull/15637/files?w=1
