### PR TITLE
setopt: fix missing options for builds without HTTP & MQTT

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1768,6 +1768,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     Curl_safefree(data->set.str[STRING_COPYPOSTFIELDS]);
     data->set.method = HTTPREQ_POST;
     break;
+#endif /* ! CURL_DISABLE_HTTP || ! CURL_DISABLE_MQTT */
 
 #ifndef CURL_DISABLE_HTTP
   case CURLOPT_ACCEPT_ENCODING:
@@ -2186,7 +2187,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * proxy exception list
      */
     return Curl_setstropt(&data->set.str[STRING_NOPROXY], ptr);
-#endif
+#endif /* ! CURL_DISABLE_PROXY */
 
   case CURLOPT_RANGE:
     /*
@@ -2194,7 +2195,6 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      */
     return Curl_setstropt(&data->set.str[STRING_SET_RANGE], ptr);
 
-#endif /* ! CURL_DISABLE_PROXY */
   case CURLOPT_CURLU:
     /*
      * pass CURLU to set URL


### PR DESCRIPTION
- Restore some necessary options for builds without HTTP and MQTT.

The logic to turn off a segment of options in builds without HTTP and MQTT was too expansive. Those builds (such as FTP-only builds) could not use options such as CURLOPT_URL or CURLOPT_USERNAME etc.

Prior to this change 30da1f59 (precedes 8.11.0) refactored the options parsing and caused this issue.

Reported-by: Yoshimasa Ohno

Fixes https://github.com/curl/curl/issues/15634
Closes #xxxx