### PR TITLE
tool_getpass: replace `getch()` call with `_getch()` on Windows

### DIFF
--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -102,7 +102,7 @@ char *getpass_r(const char *prompt, char *buffer, size_t buflen)
   fputs(prompt, tool_stderr);
 
   for(i = 0; i < buflen; i++) {
-    buffer[i] = (char)getch();
+    buffer[i] = (char)_getch();
     if(buffer[i] == '\r' || buffer[i] == '\n') {
       buffer[i] = '\0';
       break;


### PR DESCRIPTION
`getch()` is deprecated according to MSDN:
https://learn.microsoft.com/cpp/c-runtime-library/reference/getch
"The Microsoft-specific function name `getch` is a deprecated alias
for the `_getch` function."

Ref: https://learn.microsoft.com/cpp/c-runtime-library/reference/getch-getwch

Follow-up to 72edb22b8a0e1e62216b59a045147d1a863ad59b #15638