### PR TITLE
tests: re-enable 2086, and 472, 1299, 1613 for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -173,7 +173,7 @@ jobs:
           - { build: 'cmake'    , sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '-DENABLE_DEBUG=ON -DENABLE_THREADED_RESOLVER=OFF', name: 'default' }
           - { build: 'autotools', sys: 'msys'   , env: 'x86_64'      , tflags: '!19 !504 !704 !705 !1233', config: '', name: 'default R' }
           - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '--enable-debug --disable-threaded-resolver --disable-curldebug --enable-static=no --without-zlib', name: 'default' }
-          - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: '~472 ~1299 ~1613'        , config: '--enable-debug --enable-windows-unicode --enable-ares', name: 'c-ares U' }
+          - { build: 'autotools', sys: 'mingw64', env: 'x86_64'      , tflags: ''                        , config: '--enable-debug --enable-windows-unicode --enable-ares', name: 'c-ares U' }
           # FIXME: WebSockets test results ignored due to frequent failures on native Windows:
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: ''                        , config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_ARES=ON', type: 'Debug', name: 'schannel c-ares U' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -40,7 +40,7 @@
 # some of the directories.
 1182
 # test 1184 causes flakiness in CI builds, mostly visible on macOS
-1184
+####1184
 1209
 1211
 # fnmatch differences are just too common to make testing them sensible
@@ -48,13 +48,13 @@
 1316
 # test 1510 causes problems on the CI on GitHub
 # example: https://travis-ci.org/curl/curl/builds/81633600
-1510
+####1510
 1512
 # test 1801 causes problems on macOS and GitHub
 # https://github.com/curl/curl/issues/380
-1801
+####1801
 # test 2086 causes issues on Windows only
-2086
+####2086
 #
 #
 # Tests that are disabled here for Hyper are SUPPOSED to work but

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -46,6 +46,9 @@
 # fnmatch differences are just too common to make testing them sensible
 1307
 1316
+# test 1510 causes problems on the CI on GitHub
+# example: https://travis-ci.org/curl/curl/builds/81633600
+1510
 1512
 # test 1801 causes problems in CI builds
 # https://github.com/curl/curl/issues/380

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -46,15 +46,10 @@
 # fnmatch differences are just too common to make testing them sensible
 1307
 1316
-# test 1510 causes problems on the CI on GitHub
-# example: https://travis-ci.org/curl/curl/builds/81633600
-####1510
 1512
 # test 1801 causes problems in CI builds
 # https://github.com/curl/curl/issues/380
 1801
-# test 2086 causes issues on Windows only
-####2086
 #
 #
 # Tests that are disabled here for Hyper are SUPPOSED to work but

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -39,8 +39,8 @@
 # of running runtests.pl as a child of itself sharing
 # some of the directories.
 1182
-# test 1184 causes flakiness in CI builds, mostly visible on macOS
-####1184
+# test 1184 causes flakiness in CI builds
+1184
 1209
 1211
 # fnmatch differences are just too common to make testing them sensible
@@ -50,9 +50,9 @@
 # example: https://travis-ci.org/curl/curl/builds/81633600
 ####1510
 1512
-# test 1801 causes problems on macOS and GitHub
+# test 1801 causes problems in CI builds
 # https://github.com/curl/curl/issues/380
-####1801
+1801
 # test 2086 causes issues on Windows only
 ####2086
 #


### PR DESCRIPTION
- GHA/windows: un-ignore tests 472 1299 1613.
  They were ignored for the mingw-w64 c-ares U job.
  They do run fine now:
  https://github.com/curl/curl/actions/runs/12032875421/job/33547724780?pr=15644

- globally re-enable test 2086.
  Comment says it only affected Windows.
  Seems to be running fine now. Example:
  Windows:
  https://github.com/curl/curl/actions/runs/12032875421/job/33547718309?pr=15644#step:13:3856
  Linux:
  https://github.com/curl/curl/actions/runs/12032875397/job/33545739712#step:41:3650

- update comments for disabled tests 1184, 1801.
  They affect all operating systems, likely all CIs.

  FAIL 1801: 'HTTP/2 upgrade with lying server' HTTP, HTTP/2
  https://github.com/curl/curl/actions/runs/12032362497/job/33544053001#step:14:4265
  FAIL 1184: 'HTTP 1.1 CONNECT with redirect and set -H user-agent' HTTP, HTTP CONNECT, HTTP proxy, proxytunnel
  https://github.com/curl/curl/actions/runs/12032362497/job/33544051415#step:14:5252
