### PR TITLE
build: fix ECH to always enable HTTPS RR

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -283,7 +283,7 @@ jobs:
               --with-ngtcp2=$HOME/ngtcp2/build --enable-warnings --enable-werror --enable-debug
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-wolfssl=$HOME/wolfssl/build
-              --enable-httpsrr --enable-ech
+              --enable-ech
 
           - name: wolfssl
             PKG_CONFIG_PATH: '$HOME/wolfssl/build/lib/pkgconfig:$HOME/nghttp3/build/lib/pkgconfig:$HOME/ngtcp2/build/lib/pkgconfig:$HOME/nghttp2/build/lib/pkgconfig'
@@ -291,7 +291,7 @@ jobs:
               -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON -DENABLE_DEBUG=ON
               -DTEST_NGHTTPX="$HOME/nghttp2/build/bin/nghttpx"
               -DHTTPD_NGHTTPX="$HOME/nghttp2/build/bin/nghttpx"
-              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
+              -DUSE_ECH=ON
 
           - name: openssl-quic
             PKG_CONFIG_PATH: '$HOME/openssl/build/lib64/pkgconfig'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -94,7 +94,7 @@ jobs:
           - name: wolfssl-all
             install_packages: zlib1g-dev
             install_steps: wolfssl-all
-            configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-all/lib" --with-wolfssl=$HOME/wolfssl-all --enable-httpsrr --enable-ech --enable-debug
+            configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-all/lib" --with-wolfssl=$HOME/wolfssl-all --enable-ech --enable-debug
 
           - name: wolfssl-opensslextra valgrind
             install_packages: zlib1g-dev valgrind
@@ -140,12 +140,12 @@ jobs:
           - name: awslc
             install_packages: zlib1g-dev
             install_steps: awslc
-            configure: LDFLAGS="-Wl,-rpath,$HOME/awslc/lib" --with-openssl=$HOME/awslc --enable-httpsrr --enable-ech
+            configure: LDFLAGS="-Wl,-rpath,$HOME/awslc/lib" --with-openssl=$HOME/awslc --enable-ech
 
           - name: awslc
             install_packages: zlib1g-dev
             install_steps: awslc
-            generate: -DOPENSSL_ROOT_DIR=$HOME/awslc -DUSE_HTTPSRR=ON -DUSE_ECH=ON -DCMAKE_UNITY_BUILD=OFF
+            generate: -DOPENSSL_ROOT_DIR=$HOME/awslc -DUSE_ECH=ON -DCMAKE_UNITY_BUILD=OFF
 
           - name: openssl default
             install_steps: pytest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -159,7 +159,7 @@ jobs:
             macos-version-min: '10.15'
           - name: 'wolfSSL !ldap brotli zstd'
             install: brotli wolfssl zstd
-            generate: -DCURL_USE_WOLFSSL=ON -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_DISABLE_LDAP=ON -DUSE_HTTPSRR=ON -DUSE_ECH=ON
+            generate: -DCURL_USE_WOLFSSL=ON -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON
             macos-version-min: '10.15'
           - name: 'mbedTLS !ldap brotli zstd'
             install: brotli mbedtls zstd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -623,7 +623,7 @@ jobs:
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
               -DCURL_USE_GSASL=ON
-              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
+              -DUSE_ECH=ON
 
           - name: 'mbedtls'
             install: 'brotli zlib zstd libpsl nghttp2 mbedtls libssh pkgconf gsasl'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -611,7 +611,7 @@ jobs:
             config: >-
               -DCURL_BROTLI=ON -DCURL_ZSTD=ON -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
-              -DUSE_HTTPSRR=ON -DUSE_ECH=ON
+              -DUSE_ECH=ON
 
           - name: 'wolfssl'
             install: 'brotli zlib zstd libpsl nghttp2 wolfssl libssh2 pkgconf gsasl ngtcp2[wolfssl] nghttp3'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -864,7 +864,7 @@ if(USE_OPENSSL OR USE_WOLFSSL)
   endif()
 endif()
 
-option(USE_HTTPSRR "Enable HTTPS RR support for ECH (experimental)" OFF)
+option(USE_HTTPSRR "Enable HTTPS RR support" OFF)
 option(USE_ECH "Enable ECH support" OFF)
 if(USE_ECH)
   if(USE_OPENSSL OR USE_WOLFSSL)

--- a/configure.ac
+++ b/configure.ac
@@ -5022,8 +5022,6 @@ if test "x$want_ech" != "xno"; then
 
   dnl now deal with whatever we found
   if test "x$ECH_ENABLED" = "x1"; then
-    dnl force pre-requisites for ECH
-    AC_DEFINE(USE_HTTPSRR, 1, [force HTTPS RR support for ECH])
     AC_DEFINE(USE_ECH, 1, [if ECH support is available])
     AC_MSG_RESULT($ECH_SUPPORT)
     experimental="$experimental ECH"

--- a/docs/ECH.md
+++ b/docs/ECH.md
@@ -39,7 +39,7 @@ To build curl ECH-enabled, making use of the above:
     git clone https://github.com/curl/curl
     cd curl
     autoreconf -fi
-    LDFLAGS="-Wl,-rpath,$HOME/code/openssl-local-inst/lib/" ./configure --with-ssl=$HOME/code/openssl-local-inst --enable-ech --enable-httpsrr
+    LDFLAGS="-Wl,-rpath,$HOME/code/openssl-local-inst/lib/" ./configure --with-ssl=$HOME/code/openssl-local-inst --enable-ech
     ...lots of output...
     WARNING: ECH HTTPSRR enabled but marked EXPERIMENTAL...
     make
@@ -210,7 +210,7 @@ Code changes are ``#ifdef`` protected via ``USE_ECH`` or ``USE_HTTPSRR``:
 
 - ``USE_HTTPSRR`` is used for HTTPS RR retrieval code that could be generically
   used should non-ECH uses for HTTPS RRs be identified, e.g. use of ALPN values
-or IP address hints.
+  or IP address hints.
 
 - ``USE_ECH`` protects ECH specific code.
 
@@ -296,7 +296,7 @@ To build with cmake, assuming our ECH-enabled OpenSSL is as before:
     cd curl
     mkdir build
     cd build
-    cmake -DOPENSSL_ROOT_DIR=$HOME/code/openssl -DUSE_ECH=1 -DUSE_HTTPSRR=1 ..
+    cmake -DOPENSSL_ROOT_DIR=$HOME/code/openssl -DUSE_ECH=1 ..
     ...
     make
     ...
@@ -328,7 +328,7 @@ Then:
     git clone https://github.com/curl/curl
     cd curl
     autoreconf -fi
-    LDFLAGS="-Wl,-rpath,$HOME/code/boringssl/inst/lib" ./configure --with-ssl=$HOME/code/boringssl/inst --enable-ech --enable-httpsrr
+    LDFLAGS="-Wl,-rpath,$HOME/code/boringssl/inst/lib" ./configure --with-ssl=$HOME/code/boringssl/inst --enable-ech
     ...lots of output...
     WARNING: ECH HTTPSRR enabled but marked EXPERIMENTAL. Use with caution.
     make
@@ -365,7 +365,7 @@ important or else we get build problems with curl below.
     git clone https://github.com/curl/curl
     cd curl
     autoreconf -fi
-    ./configure --with-wolfssl=$HOME/code/wolfssl/inst --enable-ech --enable-httpsrr
+    ./configure --with-wolfssl=$HOME/code/wolfssl/inst --enable-ech
     make
 ```
 

--- a/docs/ECH.md
+++ b/docs/ECH.md
@@ -219,9 +219,9 @@ arguments which are not described here, but should be fairly clear.
 
 As shown in the ``configure`` usage above, there are ``configure.ac`` changes
 that allow separately dis/enabling ``USE_HTTPSRR`` and ``USE_ECH``. If ``USE_ECH``
-is enabled, then ``USE_HTTPSRR`` is forced. In both cases ``USE_DOH``
-is required. (There may be some configuration conflicts available for the
-determined:-)
+is enabled, then ``USE_HTTPSRR`` is forced. In both cases ``CURL_DISABLE_DOH``
+must not be enabled. (There may be some configuration conflicts available for the
+determined :-)
 
 The main functional change, as you would expect, is in ``lib/vtls/openssl.c``
 where an ECHConfig, if available from command line or DNS cache, is fed into

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -187,7 +187,7 @@ assumes that CMake generates `Makefile`:
 - `ENABLE_UNICODE`:                         Use the Unicode version of the Windows API functions. Default: `OFF`
 - `ENABLE_UNIX_SOCKETS`:                    Enable Unix domain sockets support. Default: `ON`
 - `USE_ECH`:                                Enable ECH support. Default: `OFF`
-- `USE_HTTPSRR`:                            Enable HTTPS RR support for ECH (experimental). Default: `OFF`
+- `USE_HTTPSRR`:                            Enable HTTPS RR support. Default: `OFF`
 - `USE_OPENSSL_QUIC`:                       Use OpenSSL and nghttp3 libraries for HTTP/3 support. Default: `OFF`
 
 ## Disabling features

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -290,6 +290,14 @@
 #  define CURL_DISABLE_HTTP_AUTH 1
 #endif
 
+/*
+ * ECH requires HTTPSRR.
+ */
+
+#if defined(USE_ECH) && !defined(USE_HTTPSRR)
+#  define USE_HTTPSRR
+#endif
+
 /* ================================================================ */
 /* No system header file shall be included in this file before this */
 /* point.                                                           */


### PR DESCRIPTION
The ECH feature cannot be built without HTTPS RR.

ECH automatically implied HTTPS RR in `./configure` but not in CMake,
winbuild, documentation.

Also update documentation and CI configs.

Follow-up to a362962b7289ec02b412890c9515657cf0ed50ac #11922