### PR TITLE
20241126-wolf-opensslcoexist-expansion

### DIFF
--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -71,13 +71,6 @@
 #  include <openssl/md5.h>
 #  include <openssl/ssl.h>
 #  include <openssl/rand.h>
-#else
-#  include <wolfssl/openssl/des.h>
-#  include <wolfssl/openssl/md5.h>
-#  include <wolfssl/openssl/ssl.h>
-#  include <wolfssl/openssl/rand.h>
-#endif
-
 #  if (defined(OPENSSL_VERSION_NUMBER) && \
        (OPENSSL_VERSION_NUMBER < 0x00907001L)) && !defined(USE_WOLFSSL)
 #    define DES_key_schedule des_key_schedule
@@ -95,6 +88,25 @@
 #    define DESKEYARG(x) *x
 #    define DESKEY(x) &x
 #  endif
+#else
+#  include <wolfssl/openssl/des.h>
+#  include <wolfssl/openssl/md5.h>
+#  include <wolfssl/openssl/ssl.h>
+#  include <wolfssl/openssl/rand.h>
+#  if defined(OPENSSL_COEXIST)
+#    define DES_key_schedule WOLFSSL_DES_key_schedule
+#    define DES_cblock WOLFSSL_DES_cblock
+#    define DES_set_odd_parity wolfSSL_DES_set_odd_parity
+#    define DES_set_key wolfSSL_DES_set_key
+#    define DES_set_key_unchecked wolfSSL_DES_set_key_unchecked
+#    define DES_ecb_encrypt wolfSSL_DES_ecb_encrypt
+#    define DESKEY(x) ((WOLFSSL_DES_key_schedule *)(x))
+#    define DESKEYARG(x) *x
+#  else
+#    define DESKEYARG(x) *x
+#    define DESKEY(x) &x
+#  endif
+#endif
 
 #elif defined(USE_GNUTLS)
 

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -115,6 +115,13 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
 #elif defined(USE_WOLFSSL) && !defined(WOLFSSL_NO_MD4)
 
+#ifdef OPENSSL_COEXIST
+  #define MD4_CTX WOLFSSL_MD4_CTX
+  #define MD4_Init wolfSSL_MD4_Init
+  #define MD4_Update wolfSSL_MD4_Update
+  #define MD4_Final wolfSSL_MD4_Final
+#endif
+
 #elif defined(USE_OPENSSL) && !defined(OPENSSL_NO_MD4)
 
 #elif defined(AN_APPLE_OS)

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -106,7 +106,8 @@ static void my_md5_final(unsigned char *digest, void *ctx)
   md5_digest(ctx, 16, digest);
 }
 
-#elif defined(USE_OPENSSL_MD5) || defined(USE_WOLFSSL_MD5)
+#elif defined(USE_OPENSSL_MD5) || \
+  (defined(USE_WOLFSSL_MD5) && !defined(OPENSSL_COEXIST))
 
 typedef MD5_CTX my_md5_ctx;
 
@@ -128,6 +129,30 @@ static void my_md5_update(void *ctx,
 static void my_md5_final(unsigned char *digest, void *ctx)
 {
   (void)MD5_Final(digest, ctx);
+}
+
+#elif defined(USE_WOLFSSL_MD5)
+
+typedef WOLFSSL_MD5_CTX my_md5_ctx;
+
+static CURLcode my_md5_init(void *ctx)
+{
+  if(!wolfSSL_MD5_Init(ctx))
+    return CURLE_OUT_OF_MEMORY;
+
+  return CURLE_OK;
+}
+
+static void my_md5_update(void *ctx,
+                          const unsigned char *input,
+                          unsigned int len)
+{
+  (void)wolfSSL_MD5_Update(ctx, input, len);
+}
+
+static void my_md5_final(unsigned char *digest, void *ctx)
+{
+  (void)wolfSSL_MD5_Final(digest, ctx);
 }
 
 #elif defined(USE_MBEDTLS)


### PR DESCRIPTION
Fixes for wolfSSL `OPENSSL_COEXIST` expansion for MD4, MD5, and DES.

The wolf-native APIs and types used in the changes are all old/preexisting -- there wasn't any need for version gating on any of this.

Tested with `wolfssl-multi-test.sh ... curl-master-with-wolfssl-coexist`

wolfSSL: `./configure --enable-curl --enable-opensslcoexist --prefix="/tmp/installed-for-curl" CFLAGS=-DTEST_OPENSSL_COEXIST`

curl: `./configure --with-wolfssl="/tmp/installed-for-curl" --with-ca-bundle="/etc/ssl/certs/ca-certificates.crt" CFLAGS=-DTEST_OPENSSL_COEXIST`
