### PR TITLE
build: improve building without deprecated Windows CRT symbols

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -228,6 +228,9 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
+          if [ '${{ matrix.sys }}' != 'msys' ]; then
+            export CFLAGS=-DNO_OLDNAMES
+          fi
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             if [[ '${{ matrix.env }}' = 'clang'* ]]; then
               options='-DCMAKE_C_COMPILER=clang'
@@ -417,6 +420,7 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
+          export CFLAGS=-DNO_OLDNAMES
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
@@ -508,6 +512,7 @@ jobs:
 
       - name: 'configure'
         run: |
+          export CFLAGS=-DNO_OLDNAMES
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake -B bld -G Ninja \
               -DCMAKE_SYSTEM_NAME=Windows \
@@ -702,7 +707,7 @@ jobs:
             "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
             "-DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed" \
             '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
-            "-DCMAKE_C_FLAGS=${cflags}" \
+            "-DCMAKE_C_FLAGS=-D_CRT_DECLARE_NONSTDC_NAMES=0 ${cflags}" \
             "-DCMAKE_EXE_LINKER_FLAGS=/INCREMENTAL:NO ${ldflags}" \
             "-DCMAKE_SHARED_LINKER_FLAGS=/INCREMENTAL:NO ${ldflags}" \
             "-DCMAKE_VS_GLOBALS=TrackFileAccess=false${vsglobals}" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -261,6 +261,7 @@ jobs:
               -DCURL_WERROR=ON \
               ${{ matrix.config }}
           else
+            CFLAGS+=' -DFTYPE=_off64_t -D_FILE_OFFSET_BITS=64'
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
               --with-openssl \
@@ -523,6 +524,7 @@ jobs:
               -DCURL_USE_SCHANNEL=ON -DUSE_WIN32_IDN=ON \
               -DCURL_USE_LIBPSL=OFF
           else
+            CFLAGS+=' -DFTYPE=_off64_t -D_FILE_OFFSET_BITS=64'
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
               --host=${TRIPLET} \
               --with-schannel --with-winidn \

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -150,11 +150,16 @@ int main(void) { return 0; }
 #undef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
 #include <sys/types.h>
+#if defined(__MINGW32__) && defined(NO_OLDNAMES)
+#define CURLTEST_OFF_T _off64_t
+#else
+#define CURLTEST_OFF_T off_t
+#endif
 /* Check that off_t can represent 2**63 - 1 correctly.
    We cannot simply define LARGE_OFF_T to be 9223372036854775807,
    since some C++ compilers masquerading as C compilers
    incorrectly reject 9223372036854775807. */
-#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+#define LARGE_OFF_T (((CURLTEST_OFF_T)1 << 62) - 1 + ((CURLTEST_OFF_T)1 << 62))
 int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
                      && LARGE_OFF_T % 2147483647 == 1)
                     ? 1 : -1];

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -150,7 +150,7 @@ int main(void) { return 0; }
 #undef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
 #include <sys/types.h>
-#if defined(__MINGW32__) && defined(NO_OLDNAMES)
+#if defined(__MINGW32__) && defined(NO_OLDNAMES) && !defined(_POSIX)
 #define CURLTEST_OFF_T _off64_t
 #else
 #define CURLTEST_OFF_T off_t

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -150,10 +150,15 @@ int main(void) { return 0; }
 #undef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
 #include <sys/types.h>
-#if defined(__MINGW32__) && defined(NO_OLDNAMES) && !defined(_POSIX)
-#define CURLTEST_OFF_T _off64_t
-#else
 #define CURLTEST_OFF_T off_t
+#ifdef __MINGW32__
+#  include <_mingw.h>
+#  if defined(__MINGW64_VERSION_MAJOR) && (__MINGW64_VERSION_MAJOR >= 3) && \
+      defined(NO_OLDNAMES) && !defined(_POSIX)
+#    undef CURLTEST_OFF_T
+#    define CURLTEST_OFF_T _off64_t
+#  else
+#  endif
 #endif
 /* Check that off_t can represent 2**63 - 1 correctly.
    We cannot simply define LARGE_OFF_T to be 9223372036854775807,

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -51,6 +51,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   fi
   # shellcheck disable=SC2086
   cmake -B _bld "-G${PRJ_GEN}" ${TARGET:-} ${options} \
+    '-DCMAKE_C_FLAGS=-D_CRT_DECLARE_NONSTDC_NAMES=0' \
     "-DCURL_USE_OPENSSL=${OPENSSL}" \
     "-DCURL_USE_SCHANNEL=${SCHANNEL}" \
     "-DHTTP_ONLY=${HTTP_ONLY}" \

--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -69,8 +69,13 @@ typedef union {
 
 #else
 
+#ifdef _WIN32
+#define curlx_convert_UTF8_to_tchar(ptr) (_strdup)(ptr)
+#define curlx_convert_tchar_to_UTF8(ptr) (_strdup)(ptr)
+#else
 #define curlx_convert_UTF8_to_tchar(ptr) (strdup)(ptr)
 #define curlx_convert_tchar_to_UTF8(ptr) (strdup)(ptr)
+#endif
 
 typedef union {
   char                *tchar_ptr;

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -183,7 +183,7 @@
 #  define sys_errlist _sys_errlist
 #  define strcmpi _strcmpi
 #  /* Workaround for dependency headers requiring deprecated symbols */
-#  if defined(HAVE_LIBZ) || defined(USE_OPENSSL)
+#  if defined(_MSC_VER) && (defined(HAVE_LIBZ) || defined(USE_OPENSSL))
 #    define off_t _off_t
 #  endif
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -43,28 +43,10 @@
 #include <_mingw.h>
 #endif
 
+/* TESTING */
 #ifdef _WIN32
 #define _CRT_DECLARE_NONSTDC_NAMES 0
 #define NO_OLDNAMES
-#define strdup _strdup
-#define fdopen _fdopen
-#define unlink _unlink
-#define close _close
-#define isatty _isatty
-#define fileno _fileno
-#define O_CREAT _O_CREAT
-#define O_RDONLY _O_RDONLY
-#define O_WRONLY _O_WRONLY
-#define O_RDWR _O_RDWR
-#define O_BINARY _O_BINARY
-#define O_APPEND _O_APPEND
-#define O_TRUNC _O_TRUNC
-#define O_EXCL _O_EXCL
-#define S_IREAD _S_IREAD
-#define S_IWRITE _S_IWRITE
-#define sys_nerr _sys_nerr
-#define sys_errlist _sys_errlist
-#define strcmpi _strcmpi
 #endif
 
 /* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0 (initial build)
@@ -182,6 +164,35 @@
 #endif
 
 #endif /* HAVE_CONFIG_H */
+
+/* Allow building with deprecated CRT symbols disabled */
+#if defined(_WIN32) && \
+  (defined(NO_OLDNAMES) || \
+   (defined(_CRT_DECLARE_NONSTDC_NAMES) && !_CRT_DECLARE_NONSTDC_NAMES))
+#  define strdup _strdup
+#  define fdopen _fdopen
+#  define unlink _unlink
+#  define close _close
+#  define isatty _isatty
+#  define fileno _fileno
+#  define O_CREAT _O_CREAT
+#  define O_RDONLY _O_RDONLY
+#  define O_WRONLY _O_WRONLY
+#  define O_RDWR _O_RDWR
+#  define O_BINARY _O_BINARY
+#  define O_APPEND _O_APPEND
+#  define O_TRUNC _O_TRUNC
+#  define O_EXCL _O_EXCL
+#  define S_IREAD _S_IREAD
+#  define S_IWRITE _S_IWRITE
+#  define sys_nerr _sys_nerr
+#  define sys_errlist _sys_errlist
+#  define strcmpi _strcmpi
+#  /* Workaround for dependency headers requiring deprecated symbols */
+#  if defined(HAVE_LIBZ) || defined(USE_OPENSSL)
+#    define off_t _off_t
+#  endif
+#endif
 
 /* ================================================================ */
 /* Definition of preprocessor macros/symbols which modify compiler  */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -862,7 +862,8 @@
 #  if defined(HAVE_LIBZ) || defined(USE_OPENSSL)
 #    ifdef _MSC_VER
 #      define off_t _off_t
-#    elif defined(__MINGW32__) && !defined(_POSIX)
+#    elif defined(__MINGW32__) && !defined(_POSIX) && \
+          defined(__MINGW64_VERSION_MAJOR) && (__MINGW64_VERSION_MAJOR >= 3)
 #      if defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
 #        define off_t _off64_t
 #      else

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -167,7 +167,7 @@
 
 /* Allow building with deprecated CRT symbols disabled */
 #if defined(_WIN32) && \
-  (defined(NO_OLDNAMES) || \
+  ((defined(__MINGW32__) && defined(NO_OLDNAMES)) || \
    (defined(_CRT_DECLARE_NONSTDC_NAMES) && !_CRT_DECLARE_NONSTDC_NAMES))
 #  define strdup _strdup
 #  define fdopen _fdopen

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -49,6 +49,8 @@
 #define strdup _strdup
 #define fdopen _fdopen
 #define unlink _unlink
+#define close _close
+#define isatty _isatty
 #define O_CREAT _O_CREAT
 #define O_RDONLY _O_RDONLY
 #define O_WRONLY _O_WRONLY
@@ -57,10 +59,11 @@
 #define O_APPEND _O_APPEND
 #define O_TRUNC _O_TRUNC
 #define O_EXCL _O_EXCL
+#define S_IREAD _S_IREAD
+#define S_IWRITE _S_IWRITE
 #define sys_nerr _sys_nerr
 #define sys_errlist _sys_errlist
-#define read(a,b,c) _read(a,b,c)
-#define write(a,b,c) _write(a,b,c)
+#define strcmpi _strcmpi
 #endif
 
 /* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0 (initial build)
@@ -890,13 +893,13 @@
 #endif
 
 /* Define S_ISREG if not defined by system headers, e.g. MSVC */
-#if !defined(S_ISREG) && defined(S_IFMT) && defined(S_IFREG)
-#define S_ISREG(m) (((m) & S_IFMT) == S_IFREG)
+#if !defined(S_ISREG) && defined(_S_IFMT) && defined(_S_IFREG)
+#define S_ISREG(m) (((m) & _S_IFMT) == _S_IFREG)
 #endif
 
 /* Define S_ISDIR if not defined by system headers, e.g. MSVC */
-#if !defined(S_ISDIR) && defined(S_IFMT) && defined(S_IFDIR)
-#define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
+#if !defined(S_ISDIR) && defined(_S_IFMT) && defined(_S_IFDIR)
+#define S_ISDIR(m) (((m) & _S_IFMT) == _S_IFDIR)
 #endif
 
 /* In Windows the default file mode is text but an application can override it.

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -43,8 +43,25 @@
 #include <_mingw.h>
 #endif
 
+#ifdef _WIN32
 #define _CRT_DECLARE_NONSTDC_NAMES 0
 #define NO_OLDNAMES
+#define strdup _strdup
+#define fdopen _fdopen
+#define unlink _unlink
+#define O_CREAT _O_CREAT
+#define O_RDONLY _O_RDONLY
+#define O_WRONLY _O_WRONLY
+#define O_RDWR _O_RDWR
+#define O_BINARY _O_BINARY
+#define O_APPEND _O_APPEND
+#define O_TRUNC _O_TRUNC
+#define O_EXCL _O_EXCL
+#define sys_nerr _sys_nerr
+#define sys_errlist _sys_errlist
+#define read(a,b,c) _read(a,b,c)
+#define write(a,b,c) _write(a,b,c)
+#endif
 
 /* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0 (initial build)
    that started advertising the `availability` attribute, which then gets used

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -159,35 +159,6 @@
 
 #endif /* HAVE_CONFIG_H */
 
-/* Allow building with deprecated CRT symbols disabled */
-#if defined(_WIN32) && \
-  ((defined(__MINGW32__) && defined(NO_OLDNAMES)) || \
-   (defined(_CRT_DECLARE_NONSTDC_NAMES) && !_CRT_DECLARE_NONSTDC_NAMES))
-#  define strdup _strdup
-#  define fdopen _fdopen
-#  define unlink _unlink
-#  define close _close
-#  define isatty _isatty
-#  define fileno _fileno
-#  define O_CREAT _O_CREAT
-#  define O_RDONLY _O_RDONLY
-#  define O_WRONLY _O_WRONLY
-#  define O_RDWR _O_RDWR
-#  define O_BINARY _O_BINARY
-#  define O_APPEND _O_APPEND
-#  define O_TRUNC _O_TRUNC
-#  define O_EXCL _O_EXCL
-#  define S_IREAD _S_IREAD
-#  define S_IWRITE _S_IWRITE
-#  define sys_nerr _sys_nerr
-#  define sys_errlist _sys_errlist
-#  define strcmpi _strcmpi
-#  /* Workaround for dependency headers requiring deprecated symbols */
-#  if defined(_MSC_VER) && (defined(HAVE_LIBZ) || defined(USE_OPENSSL))
-#    define off_t _off_t
-#  endif
-#endif
-
 /* ================================================================ */
 /* Definition of preprocessor macros/symbols which modify compiler  */
 /* behavior or generated code characteristics must be done here,   */
@@ -862,6 +833,35 @@
 
 #ifndef HEADER_CURL_SETUP_ONCE_H
 #include "curl_setup_once.h"
+#endif
+
+/* Allow building with deprecated CRT symbols disabled */
+#if defined(_WIN32) && \
+  ((defined(__MINGW32__) && defined(NO_OLDNAMES)) || \
+   (defined(_CRT_DECLARE_NONSTDC_NAMES) && !_CRT_DECLARE_NONSTDC_NAMES))
+#  define strdup _strdup
+#  define fdopen _fdopen
+#  define unlink _unlink
+#  define close _close
+#  define isatty _isatty
+#  define fileno _fileno
+#  define O_CREAT _O_CREAT
+#  define O_RDONLY _O_RDONLY
+#  define O_WRONLY _O_WRONLY
+#  define O_RDWR _O_RDWR
+#  define O_BINARY _O_BINARY
+#  define O_APPEND _O_APPEND
+#  define O_TRUNC _O_TRUNC
+#  define O_EXCL _O_EXCL
+#  define S_IREAD _S_IREAD
+#  define S_IWRITE _S_IWRITE
+#  define sys_nerr _sys_nerr
+#  define sys_errlist _sys_errlist
+#  define strcmpi _strcmpi
+#  /* Workaround for dependency headers requiring deprecated symbols */
+#  if defined(_MSC_VER) && (defined(HAVE_LIBZ) || defined(USE_OPENSSL))
+#    define off_t _off_t
+#  endif
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -43,12 +43,6 @@
 #include <_mingw.h>
 #endif
 
-/* TESTING */
-#ifdef _WIN32
-#define _CRT_DECLARE_NONSTDC_NAMES 0
-#define NO_OLDNAMES
-#endif
-
 /* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0 (initial build)
    that started advertising the `availability` attribute, which then gets used
    by Apple SDK, but, in a way incompatible with gcc, resulting in misc errors

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -51,6 +51,7 @@
 #define unlink _unlink
 #define close _close
 #define isatty _isatty
+#define fileno _fileno
 #define O_CREAT _O_CREAT
 #define O_RDONLY _O_RDONLY
 #define O_WRONLY _O_WRONLY

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -43,6 +43,9 @@
 #include <_mingw.h>
 #endif
 
+#define _CRT_DECLARE_NONSTDC_NAMES 0
+#define NO_OLDNAMES
+
 /* Workaround for Homebrew gcc 12.4.0, 13.3.0, 14.1.0, 14.2.0 (initial build)
    that started advertising the `availability` attribute, which then gets used
    by Apple SDK, but, in a way incompatible with gcc, resulting in misc errors

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -859,8 +859,16 @@
 #  define sys_errlist _sys_errlist
 #  define strcmpi _strcmpi
 #  /* Workaround for dependency headers requiring deprecated symbols */
-#  if defined(_MSC_VER) && (defined(HAVE_LIBZ) || defined(USE_OPENSSL))
-#    define off_t _off_t
+#  if defined(HAVE_LIBZ) || defined(USE_OPENSSL)
+#    ifdef _MSC_VER
+#      define off_t _off_t
+#    elif defined(__MINGW32__) && !defined(_POSIX)
+#      if defined(_FILE_OFFSET_BITS) && (_FILE_OFFSET_BITS == 64)
+#        define off_t _off64_t
+#      else
+#        define off_t long
+#      endif
+#    endif
 #  endif
 #endif
 

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -104,7 +104,7 @@ static curl_simple_lock s_lock = CURL_SIMPLE_LOCK_INIT;
  * ways, but at this point it must be defined as the system-supplied strdup
  * so the callback pointer is initialized correctly.
  */
-#if defined(_WIN32_WCE)
+#if defined(_WIN32) || defined(_WIN32_WCE)
 #define system_strdup _strdup
 #elif !defined(HAVE_STRDUP)
 #define system_strdup Curl_strdup

--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -327,12 +327,12 @@ size_t curlx_sitouz(int sinum)
 
 ssize_t curlx_read(int fd, void *buf, size_t count)
 {
-  return (ssize_t)read(fd, buf, curlx_uztoui(count));
+  return (ssize_t)_read(fd, buf, curlx_uztoui(count));
 }
 
 ssize_t curlx_write(int fd, const void *buf, size_t count)
 {
-  return (ssize_t)write(fd, buf, curlx_uztoui(count));
+  return (ssize_t)_write(fd, buf, curlx_uztoui(count));
 }
 
 #endif /* _WIN32 */

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -4507,7 +4507,12 @@ AC_DEFUN([CURL_SIZEOF], [
   dnl The #define name to make autoheader put the name in curl_config.h.in
   define(TYPE, translit(sizeof_$1, [a-z *], [A-Z_P]))dnl
 
-  AC_MSG_CHECKING(size of $1)
+  _type="$1"
+  if test "$curl_cv_native_windows" = 'yes' -a "$_type" = 'off_t'; then
+    _type='_off_t'
+  fi
+
+  AC_MSG_CHECKING(size of $_type)
   r=0
   dnl Check the sizes in a reasonable order
   for typesize in 8 4 2 16 1; do
@@ -4517,7 +4522,7 @@ $2
 ]],
     [switch(0) {
       case 0:
-      case (sizeof($1) == $typesize):;
+      case (sizeof($_type) == $typesize):;
     }
     ]) ],
       [
@@ -4530,7 +4535,7 @@ $2
     fi
   done
   if test $r -eq 0; then
-    AC_MSG_ERROR([Failed to find size of $1])
+    AC_MSG_ERROR([Failed to find size of $_type])
   fi
   AC_MSG_RESULT($r)
   dnl lowercase and underscore instead of space

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -37,7 +37,11 @@
 #include "memdebug.h" /* keep this as LAST include */
 
 #if defined(_WIN32) || (defined(MSDOS) && !defined(__DJGPP__))
-#  define mkdir(x,y) (mkdir)((x))
+#  ifdef _WIN32
+#    define mkdir(x,y) (_mkdir)((x))
+#  else
+#    define mkdir(x,y) (mkdir)((x))
+#  endif
 #  ifndef F_OK
 #    define F_OK 0
 #  endif

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -142,10 +142,18 @@ void setfiletime(curl_off_t filetime, const char *filename,
     }
 
 #elif defined(HAVE_UTIME)
+#ifdef _WIN32
+    struct _utimbuf times;
+#else
     struct utimbuf times;
+#endif
     times.actime = (time_t)filetime;
     times.modtime = (time_t)filetime;
+#ifdef _WIN32
+    if(_utime(filename, &times)) {
+#else
     if(utime(filename, &times)) {
+#endif
       warnf(global, "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
             " on '%s': %s", filetime, filename, strerror(errno));
     }

--- a/src/tool_strdup.c
+++ b/src/tool_strdup.c
@@ -23,7 +23,7 @@
  ***************************************************************************/
 #include "tool_strdup.h"
 
-#ifndef HAVE_STRDUP
+#if !defined(HAVE_STRDUP) && !defined(_WIN32)
 char *strdup(const char *str)
 {
   size_t len;

--- a/src/tool_strdup.h
+++ b/src/tool_strdup.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-#ifndef HAVE_STRDUP
+#if !defined(HAVE_STRDUP) && !defined(_WIN32)
 extern char *strdup(const char *str);
 #endif
 

--- a/tests/libtest/lib509.c
+++ b/tests/libtest/lib509.c
@@ -53,7 +53,11 @@ static void *custom_malloc(size_t size)
 static char *custom_strdup(const char *ptr)
 {
   seen++;
+#ifdef _WIN32
+  return (_strdup)(ptr);
+#else
   return (strdup)(ptr);
+#endif
 }
 
 static void *custom_realloc(void *ptr, size_t size)

--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -51,7 +51,11 @@
 curl_malloc_callback Curl_cmalloc = (curl_malloc_callback)malloc;
 curl_free_callback Curl_cfree = (curl_free_callback)free;
 curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
+#ifdef _WIN32
+curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)_strdup;
+#else
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)strdup;
+#endif
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
 #if defined(_WIN32) && defined(UNICODE)
 curl_wcsdup_callback Curl_cwcsdup = (curl_wcsdup_callback)_wcsdup;


### PR DESCRIPTION
Build curl with deprecate Windows CRT symbols disabled.

Fix inconsistencies and fallouts found.

Most issues are due to `off_t` and `strdup()`:
- mingw-w64 as of 12.0.0 would map `off_t` to either a 64-bit or
  32-bit type, but always keeps `_off_t` `long`. This becomes an
  issue when `off_t` is disabled via `NO_OLDNAMES`.
  MS SDK maps both names to `long`.
  Pending issue:
  - how to make autotools detect it as 64-bit.
    → CFLAGS trick.
  - the trick employed for mingw-w64 in cmake requires mingw-w64
    v3 that supports large files, but doesn't check for this condition.  
    (addressed).
- `strdup()` is redefined within `lib`, so mapping it to `_strdup`
  via a define isn't working. There probably should be a global
  `Curl_strdup()` introduced and called directly to fix it, but
  that seems overkill.
  strdup is messy:
  - two pre-existing redefinitions (debug and memory-track)
  - a file-specific 3rd mapping it to a lib/strdup.c implementation
     if missing.
  - curl-tool specific local implementation without namespace
    in src/tool_strdup.c.
  - feature-detected, but used unconditionally across the code.
     In lib, the local implementation is declared but never used?
     (outside easy.c which does its own mapping)
- `off_t` is used in OpenSSL 3 and zlib public headers. They
  should probably be addressed upstream.
- libtool's stub source code breaks without deprecated symbols:
  ```
  ./.libs/lt-units.c:63:10: warning: "stat" redefined
     63 | # define stat    _stat
        |          ^~~~
  In file included from ./.libs/lt-units.c:35:
  D:/a/_temp/msys64/mingw64/include/sys/stat.h:279:9: note: this is the location of the previous definition
    279 | #define stat _stat64
        |         ^~~~
  ./.libs/lt-units.c: In function 'check_executable':
  ./.libs/lt-units.c:376:25: error: 'S_IXUSR' undeclared (first use in this function)
    376 |       && (st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)))
        |                         ^~~~~~~
  ./.libs/lt-units.c:376:25: note: each undeclared identifier is reported only once for each function it appears in
  ./.libs/lt-units.c: In function 'make_executable':
  ./.libs/lt-units.c:395:60: error: 'S_IXUSR' undeclared (first use in this function)
    395 |       rval = chmod (path, st.st_mode | S_IXOTH | S_IXGRP | S_IXUSR);
        |                                                            ^~~~~~~
  ./.libs/lt-units.c: In function 'check_executable':
  ./.libs/lt-units.c:380:1: warning: control reaches end of non-void function [-Wreturn-type]
    380 | }
        | ^
  ```
  https://github.com/curl/curl/actions/runs/12075769317/job/33676106320#step:14:516

---

- [ ] rework the `./configure` `CURL_SIZEOF` hack for `off_t`. In master it fails with
  `NO_OLDNAMES` when the type is missing. Insteat of it should somehow come up
  with 8 like cmake does:
  ```
  -#define SIZEOF_OFF_T 4
  +#define SIZEOF_OFF_T 8
  ```
  https://github.com/curl/curl/actions/runs/12075769308/job/33676093576?pr=15652#step:8:41
- [x] fix unguarded `_setmode()` use in tests. Either make a `curl_set_binmode()`
  and use that consistently, or delete `HAVE__SETMODE` and guard uses
  with `WIN32 || CYGWIN`.
- [x] verify that all mapped symbols exist back to mingw-w64 1.0.
- [x] move test/enable logic to CI.
- [ ] pick and migrate useful parts into ~5 separate PRs/commits.
  Drop enabling this in tests, drop most/part of the logic from `lib/curl_setup.h`.
  - setmode → #15787
  - stricmp → #15788
  - examples & client test to work with no-oldnames → #15789
  - tidy-ups → #15799
  - misc lib/src changes to improve no-oldnames compatibility (maybe)
