### PR TITLE
Add defines to support NonStop builds as of OpenSSL 3.3/3.4+, as of 8.11.0

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -117,6 +117,12 @@
 # endif
 #endif
 
+/* Required build defines for the HPE NonStop platforms. */
+#if defined (__TANDEM)
+# define _XOPEN_SOURCE_EXTENDED 1
+# define __NSK_OPTIONAL_TYPES__
+#endif
+
 /* Compatibility */
 #if defined(ENABLE_IPV6)
 #  define USE_IPV6 1


### PR DESCRIPTION
This change is compatible with older versions of OpenSSL and curl.
This specifically adds required defines only for the NonStop platform.

Fixes: #15655