### PR TITLE
docs: suggest --ssl-reqd instead of --ftp-ssl

### DIFF
--- a/docs/FAQ
+++ b/docs/FAQ
@@ -999,7 +999,7 @@ FAQ
   the control connection and will therefore immediately connect and try to
   speak SSL. FTPS:// connections default to port 990.
 
-  To use explicit FTPS, you use an FTP:// URL and the --ftp-ssl option (or one
+  To use explicit FTPS, you use an FTP:// URL and the --ssl-reqd option (or one
   of its related flavors). This is the most common method, and the one
   mandated by RFC 4217. This kind of connection will then of course use the
   standard FTP port 21 by default.

--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -42,7 +42,7 @@ Get a file off an FTPS server:
 
 or use the more appropriate FTPS way to get the same file:
 
-    curl --ftp-ssl ftp://files.are.example.com/secrets.txt
+    curl --ssl-reqd ftp://files.are.example.com/secrets.txt
 
 Get a file from an SSH server using SFTP:
 


### PR DESCRIPTION
Reported-by: SuperStormer on github
Fixes #15658