### PR TITLE
GHA/windows: avoid libtool wrapper for test and server executables

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -316,7 +316,6 @@ jobs:
             cp bld/lib/.libs/*.dll bld/tests/libtest || true
             cp bld/lib/.libs/*.dll bld/tests/server || true
             cp bld/lib/.libs/*.dll bld/tests/unit || true
-            find . -name '*.exe' -o -name '*.dll'
           fi
 
       - name: 'install test prereqs'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -307,10 +307,16 @@ jobs:
             make -C bld -j5 V=1 -C tests
           fi
           if [ '${{ matrix.build }}' != 'cmake' ]; then
-            find . -name '*.exe' -o -name '*.dll'
             # avoid libtool's .exe wrappers
-            mv bld/src/.libs/curl.exe bld/src/curl.exe
-            cp bld/lib/.libs/*.dll bld/src || true
+            mv bld/tests/http/clients/.libs/*.exe bld/tests/http/clients
+            mv bld/tests/libtest/.libs/*.exe bld/tests/libtest
+            mv bld/tests/server/.libs/*.exe bld/tests/server
+            mv bld/tests/unit/.libs/*.exe bld/tests/unit
+            cp bld/lib/.libs/*.dll bld/tests/http/clients || true
+            cp bld/lib/.libs/*.dll bld/tests/libtest || true
+            cp bld/lib/.libs/*.dll bld/tests/server || true
+            cp bld/lib/.libs/*.dll bld/tests/unit || true
+            find . -name '*.exe' -o -name '*.dll'
           fi
 
       - name: 'install test prereqs'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -311,7 +311,7 @@ jobs:
             mv bld/tests/http/clients/.libs/*.exe bld/tests/http/clients
             mv bld/tests/libtest/.libs/*.exe bld/tests/libtest
             mv bld/tests/server/.libs/*.exe bld/tests/server
-            mv bld/tests/unit/.libs/*.exe bld/tests/unit
+            mv bld/tests/unit/.libs/*.exe bld/tests/unit || true
             cp bld/lib/.libs/*.dll bld/tests/http/clients || true
             cp bld/lib/.libs/*.dll bld/tests/libtest || true
             cp bld/lib/.libs/*.dll bld/tests/server || true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -290,7 +290,7 @@ jobs:
           else
             # avoid libtool's curl.exe wrapper
             mv bld/src/.libs/curl.exe bld/src/curl.exe
-            mv bld/lib/.libs/*.dll bld/src || true
+            cp bld/lib/.libs/*.dll bld/src || true
           fi
           find . -name '*.exe' -o -name '*.dll'
           if [ '${{ matrix.test }}' != 'uwp' ]; then  # curl: error initializing curl library
@@ -305,6 +305,12 @@ jobs:
             cmake --build bld --config '${{ matrix.type }}' --target testdeps
           else
             make -C bld -j5 V=1 -C tests
+          fi
+          if [ '${{ matrix.build }}' != 'cmake' ]; then
+            find . -name '*.exe' -o -name '*.dll'
+            # avoid libtool's .exe wrappers
+            mv bld/src/.libs/curl.exe bld/src/curl.exe
+            cp bld/lib/.libs/*.dll bld/src || true
           fi
 
       - name: 'install test prereqs'


### PR DESCRIPTION
This makes `runtests.pl` run the final executables directly.
Before this patch it called the autotools/libtool wrapper tool, which
then called the final executables.

This solution was already used for `curl.exe`.

Applies to tests run in the `mingw, AM x86_64 c-ares U` job, which still
shows unexplained flakiness.

Also makes tests finish 45 seconds faster.

Ref: #14854
Follow-up to 1a2d38c47c7825ad4d993d10664a45be3e3bbb58 #15437

---

https://github.com/curl/curl/actions/runs/11963010431/job/33352609235 5:24
https://github.com/curl/curl/actions/runs/11965487753/job/33359588646 5:14
https://github.com/curl/curl/actions/runs/11992530431/job/33432468396 5:10
https://github.com/curl/curl/actions/runs/11997965852/job/33444203138 5:15
https://github.com/curl/curl/actions/runs/12015637687/job/33494151585 5:10
https://github.com/curl/curl/actions/runs/12020291178/job/33508622184 5:12
https://github.com/curl/curl/actions/runs/12030148596/job/33536977450 5:10
https://github.com/curl/curl/actions/runs/12032300108/job/33543838109 5:31
https://github.com/curl/curl/actions/runs/12048253216/job/33592517602 5:03
https://github.com/curl/curl/actions/runs/12067501114/job/33650619330 5:16
https://github.com/curl/curl/actions/runs/12069776268/job/33657802143 5:12
→
https://github.com/curl/curl/actions/runs/12076821946/job/33678825955 4:33
https://github.com/curl/curl/actions/runs/12076914854/job/33679013498 4:28
https://github.com/curl/curl/actions/runs/12077764102/job/33681137111 4:36
