### PR TITLE
digest: change cnonce length from 32 to 16

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -352,7 +352,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   char algorithm[64];
   char qop_options[64];
   int qop_values;
-  char cnonce[33];
+  char cnonce[17];
   char nonceCount[] = "00000001";
   char method[]     = "AUTHENTICATE";
   char qop[]        = DIGEST_QOP_VALUE_STRING_AUTH;
@@ -709,7 +709,7 @@ static CURLcode auth_create_digest_http_message(
     digest->nc = 1;
 
   if(!digest->cnonce) {
-    char cnoncebuf[33];
+    char cnoncebuf[17];
     result = Curl_rand_hex(data, (unsigned char *)cnoncebuf,
                            sizeof(cnoncebuf));
     if(result)


### PR DESCRIPTION
The 'cnonce' length is not specified. Other programs (Postname, Chrome, Python request) does use the small 'cnonce' length. In order to be consistent with the other programs, the value is therefore also set at 16.

The reason for the change was, that silly implementation cannot handle 'cnonce' values greater than '16'. A connection via 'digest' auth could not be established with this system, because curl is using the 'cnonce' value '32'. So that these faulty implementation also work with 'curl' and not only with the other mentioned programs, the 'cnonce' value must be changed to '16'.

Closes: 15653