### PR TITLE
curl: --continue-at is mutually exclusive with --range

### DIFF
--- a/docs/cmdline-opts/continue-at.md
+++ b/docs/cmdline-opts/continue-at.md
@@ -24,3 +24,6 @@ the FTP server command SIZE is not used by curl.
 
 Use "-C -" to instruct curl to automatically find out where/how to resume the
 transfer. It then uses the given output/input files to figure that out.
+
+This command line option is mutually exclusive with --range: you can only use
+one of them for a single transfer.

--- a/docs/cmdline-opts/range.md
+++ b/docs/cmdline-opts/range.md
@@ -55,3 +55,6 @@ attempt to get a range, curl instead gets the whole document.
 FTP and SFTP range downloads only support the simple 'start-stop' syntax
 (optionally with one of the numbers omitted). FTP use depends on the extended
 FTP command SIZE.
+
+This command line option is mutually exclusive with --continue-at: you can only
+use one of them for a single transfer.

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1845,6 +1845,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       err = getstr(&config->cookiejar, nextarg, DENY_BLANK);
       break;
     case C_CONTINUE_AT: /* --continue-at */
+      if(config->range) {
+        errorf(global, "--continue-at is mutually exclusive with --range");
+        return PARAM_BAD_USE;
+      }
       /* This makes us continue an ftp transfer at given position */
       if(strcmp(nextarg, "-")) {
         err = str2offset(&config->resume_from, nextarg);
@@ -2397,6 +2401,10 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       break;
     case C_RANGE: /* --range */
+      if(config->use_resume) {
+        errorf(global, "--continue-at is mutually exclusive with --range");
+        return PARAM_BAD_USE;
+      }
       /* Specifying a range WITHOUT A DASH will create an illegal HTTP range
          (and will not actually be range by definition). The manpage
          previously claimed that to be a good way, why this code is added to


### PR DESCRIPTION
Allowing both just creates a transfer with behaviors no user can properly anticipate so better just deny the combo.

Fixes #15646
Reported-by: Harry Sintonen