### PR TITLE
QUIC, 0RTT for gnutls

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -66,6 +66,7 @@
 #include "vquic-tls.h"
 #include "vtls/keylog.h"
 #include "vtls/vtls.h"
+#include "vtls/vtls_scache.h"
 #include "curl_ngtcp2.h"
 
 #include "warnless.h"
@@ -137,8 +138,16 @@ struct cf_ngtcp2_ctx {
   uint64_t max_idle_ms;              /* max idle time for QUIC connection */
   uint64_t used_bidi_streams;        /* bidi streams we have opened */
   uint64_t max_bidi_streams;         /* max bidi streams we can open */
+  size_t earlydata_max;              /* max amount of early data supported by
+                                        server on session reuse */
+  size_t earlydata_skip;            /* sending bytes to skip when earlydata
+                                     * is accepted by peer */
+  CURLcode tls_vrfy_result;          /* result of TLS peer verification */
   int qlogfd;
   BIT(initialized);
+  BIT(tls_handshake_complete);       /* TLS handshake is done */
+  BIT(use_earlydata);                /* Using 0RTT data */
+  BIT(earlydata_accepted);           /* 0RTT was acceptd by server */
   BIT(shutdown_started);             /* queued shutdown packets */
 };
 
@@ -442,12 +451,42 @@ static void quic_settings(struct cf_ngtcp2_ctx *ctx,
   }
 }
 
-static CURLcode init_ngh3_conn(struct Curl_cfilter *cf);
+static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,
+                               struct Curl_easy *data);
 
-static int cb_handshake_completed(ngtcp2_conn *tconn, void *user_data)
+static int cf_ngtcp2_handshake_completed(ngtcp2_conn *tconn, void *user_data)
 {
-  (void)user_data;
+  struct Curl_cfilter *cf = user_data;
+  struct cf_ngtcp2_ctx *ctx = cf ? cf->ctx : NULL;
+  struct Curl_easy *data;
+
   (void)tconn;
+  DEBUGASSERT(ctx);
+  data = CF_DATA_CURRENT(cf);
+  DEBUGASSERT(data);
+  if(!ctx || !data)
+    return NGHTTP3_ERR_CALLBACK_FAILURE;
+
+  ctx->handshake_at = Curl_now();
+  ctx->tls_handshake_complete = TRUE;
+  cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
+  cf->conn->httpversion = 30;
+
+  ctx->tls_vrfy_result = Curl_vquic_tls_verify_peer(&ctx->tls, cf,
+                                                    data, &ctx->peer);
+  CURL_TRC_CF(data, cf, "handshake complete after %dms",
+             (int)Curl_timediff(ctx->handshake_at, ctx->started_at));
+#ifdef USE_GNUTLS
+  if(ctx->use_earlydata) {
+    int flags = gnutls_session_get_flags(ctx->tls.gtls.session);
+    ctx->earlydata_accepted = !!(flags & GNUTLS_SFLAGS_EARLY_DATA);
+    CURL_TRC_CF(data, cf, "server did%s accept %zu bytes of early data",
+                ctx->earlydata_accepted ? "" : " not", ctx->earlydata_skip);
+    Curl_pgrsEarlyData(data, ctx->earlydata_accepted ?
+                              (curl_off_t)ctx->earlydata_skip :
+                             -(curl_off_t)ctx->earlydata_skip);
+  }
+#endif
   return 0;
 }
 
@@ -717,16 +756,19 @@ static int cb_recv_rx_key(ngtcp2_conn *tconn, ngtcp2_encryption_level level,
                           void *user_data)
 {
   struct Curl_cfilter *cf = user_data;
+  struct cf_ngtcp2_ctx *ctx = cf ? cf->ctx : NULL;
+  struct Curl_easy *data = CF_DATA_CURRENT(cf);
   (void)tconn;
 
-  if(level != NGTCP2_ENCRYPTION_LEVEL_1RTT) {
+  if(level != NGTCP2_ENCRYPTION_LEVEL_1RTT)
     return 0;
-  }
 
-  if(init_ngh3_conn(cf) != CURLE_OK) {
-    return NGTCP2_ERR_CALLBACK_FAILURE;
+  DEBUGASSERT(ctx);
+  DEBUGASSERT(data);
+  if(ctx && data && !ctx->h3conn) {
+    if(init_ngh3_conn(cf, data))
+      return NGTCP2_ERR_CALLBACK_FAILURE;
   }
-
   return 0;
 }
 
@@ -739,7 +781,7 @@ static ngtcp2_callbacks ng_callbacks = {
   ngtcp2_crypto_client_initial_cb,
   NULL, /* recv_client_initial */
   ngtcp2_crypto_recv_crypto_data_cb,
-  cb_handshake_completed,
+  cf_ngtcp2_handshake_completed,
   NULL, /* recv_version_negotiation */
   ngtcp2_crypto_encrypt_cb,
   ngtcp2_crypto_decrypt_cb,
@@ -1128,14 +1170,15 @@ static nghttp3_callbacks ngh3_callbacks = {
   NULL /* recv_settings */
 };
 
-static CURLcode init_ngh3_conn(struct Curl_cfilter *cf)
+static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,
+                               struct Curl_easy *data)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
-  CURLcode result;
-  int rc;
   int64_t ctrl_stream_id, qpack_enc_stream_id, qpack_dec_stream_id;
+  int rc;
 
   if(ngtcp2_conn_get_streams_uni_left(ctx->qconn) < 3) {
+    failf(data, "QUIC connection lacks 3 uni streams to run HTTP/3");
     return CURLE_QUIC_CONNECT_ERROR;
   }
 
@@ -1147,45 +1190,47 @@ static CURLcode init_ngh3_conn(struct Curl_cfilter *cf)
                                nghttp3_mem_default(),
                                cf);
   if(rc) {
-    result = CURLE_OUT_OF_MEMORY;
-    goto fail;
+    failf(data, "error creating nghttp3 connection instance");
+    return CURLE_OUT_OF_MEMORY;
   }
 
   rc = ngtcp2_conn_open_uni_stream(ctx->qconn, &ctrl_stream_id, NULL);
   if(rc) {
-    result = CURLE_QUIC_CONNECT_ERROR;
-    goto fail;
+    failf(data, "error creating HTTP/3 control stream: %s",
+          ngtcp2_strerror(rc));
+    return CURLE_QUIC_CONNECT_ERROR;
   }
 
   rc = nghttp3_conn_bind_control_stream(ctx->h3conn, ctrl_stream_id);
   if(rc) {
-    result = CURLE_QUIC_CONNECT_ERROR;
-    goto fail;
+    failf(data, "error binding HTTP/3 control stream: %s",
+          ngtcp2_strerror(rc));
+    return CURLE_QUIC_CONNECT_ERROR;
   }
 
   rc = ngtcp2_conn_open_uni_stream(ctx->qconn, &qpack_enc_stream_id, NULL);
   if(rc) {
-    result = CURLE_QUIC_CONNECT_ERROR;
-    goto fail;
+    failf(data, "error creating HTTP/3 qpack encoding stream: %s",
+          ngtcp2_strerror(rc));
+    return CURLE_QUIC_CONNECT_ERROR;
   }
 
   rc = ngtcp2_conn_open_uni_stream(ctx->qconn, &qpack_dec_stream_id, NULL);
   if(rc) {
-    result = CURLE_QUIC_CONNECT_ERROR;
-    goto fail;
+    failf(data, "error creating HTTP/3 qpack decoding stream: %s",
+          ngtcp2_strerror(rc));
+    return CURLE_QUIC_CONNECT_ERROR;
   }
 
   rc = nghttp3_conn_bind_qpack_streams(ctx->h3conn, qpack_enc_stream_id,
                                        qpack_dec_stream_id);
   if(rc) {
-    result = CURLE_QUIC_CONNECT_ERROR;
-    goto fail;
+    failf(data, "error binding HTTP/3 qpack streams: %s",
+          ngtcp2_strerror(rc));
+    return CURLE_QUIC_CONNECT_ERROR;
   }
 
   return CURLE_OK;
-fail:
-
-  return result;
 }
 
 static ssize_t recv_closed_stream(struct Curl_cfilter *cf,
@@ -1235,6 +1280,10 @@ static ssize_t cf_ngtcp2_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   DEBUGASSERT(ctx->qconn);
   DEBUGASSERT(ctx->h3conn);
   *err = CURLE_OK;
+
+  /* handshake verification failed in callback, do not recv anything */
+  if(ctx->tls_vrfy_result)
+    return ctx->tls_vrfy_result;
 
   pktx_init(&pktx, cf, data);
 
@@ -1533,6 +1582,10 @@ static ssize_t cf_ngtcp2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   pktx_init(&pktx, cf, data);
   *err = CURLE_OK;
 
+  /* handshake verification failed in callback, do not send anything */
+  if(ctx->tls_vrfy_result)
+    return ctx->tls_vrfy_result;
+
   (void)eos; /* TODO: use for stream EOF and block handling */
   result = cf_progress_ingress(cf, data, &pktx);
   if(result) {
@@ -1598,6 +1651,9 @@ static ssize_t cf_ngtcp2_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     (void)nghttp3_conn_resume_stream(ctx->h3conn, stream->id);
   }
 
+  if(sent > 0 && !ctx->tls_handshake_complete && ctx->use_earlydata)
+    ctx->earlydata_skip += sent;
+
   result = cf_progress_egress(cf, data, &pktx);
   if(result) {
     *err = result;
@@ -1614,17 +1670,6 @@ out:
               stream ? stream->id : -1, len, sent, *err);
   CF_DATA_RESTORE(cf, save);
   return sent;
-}
-
-static CURLcode qng_verify_peer(struct Curl_cfilter *cf,
-                                struct Curl_easy *data)
-{
-  struct cf_ngtcp2_ctx *ctx = cf->ctx;
-
-  cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
-  cf->conn->httpversion = 30;
-
-  return Curl_vquic_tls_verify_peer(&ctx->tls, cf, data, &ctx->peer);
 }
 
 static CURLcode recv_pkt(const unsigned char *pkt, size_t pktlen,
@@ -2140,6 +2185,24 @@ static int quic_ossl_new_session_cb(SSL *ssl, SSL_SESSION *ssl_sessionid)
 #endif /* USE_OPENSSL */
 
 #ifdef USE_GNUTLS
+
+static const char *gtls_hs_msg_name(int mtype)
+{
+  switch(mtype) {
+    case 1: return "ClientHello";
+    case 2: return "ServerHello";
+    case 4: return "SessionTicket";
+    case 8: return "EncryptedExtensions";
+    case 11: return "Certificate";
+    case 13: return "CertificateRequest";
+    case 15: return "CertificateVerify";
+    case 20: return "Finished";
+    case 24: return "KeyUpdate";
+    case 254: return "MessageHash";
+  }
+  return "Unknown";
+}
+
 static int quic_gtls_handshake_cb(gnutls_session_t session, unsigned int htype,
                                   unsigned when, unsigned int incoming,
                                   const gnutls_datum_t *msg)
@@ -2153,14 +2216,28 @@ static int quic_gtls_handshake_cb(gnutls_session_t session, unsigned int htype,
   if(when && cf && ctx) { /* after message has been processed */
     struct Curl_easy *data = CF_DATA_CURRENT(cf);
     DEBUGASSERT(data);
-    if(data) {
-      CURL_TRC_CF(data, cf, "handshake: %s message type %d",
-                  incoming ? "incoming" : "outgoing", htype);
-    }
+    if(!data)
+      return 0;
+    CURL_TRC_CF(data, cf, "SSL message: %s %s [%d]",
+                incoming ? "<-" : "->", gtls_hs_msg_name(htype), htype);
     switch(htype) {
     case GNUTLS_HANDSHAKE_NEW_SESSION_TICKET: {
+      ngtcp2_ssize tplen;
+      uint8_t tpbuf[256];
+      unsigned char *quic_tp = NULL;
+      size_t quic_tp_len = 0;
+
+      tplen = ngtcp2_conn_encode_0rtt_transport_params(ctx->qconn, tpbuf,
+                                                       sizeof(tpbuf));
+      if(tplen < 0)
+        CURL_TRC_CF(data, cf, "error encoding 0RTT transport data: %s",
+                    ngtcp2_strerror((int)tplen));
+      else {
+        quic_tp = (unsigned char *)tpbuf;
+        quic_tp_len = (size_t)tplen;
+      }
       (void)Curl_gtls_cache_session(cf, data, ctx->peer.scache_key,
-                                    session, -1, "h3");
+                                    session, -1, "h3", quic_tp, quic_tp_len);
       break;
     }
     default:
@@ -2191,9 +2268,9 @@ static int wssl_quic_new_session_cb(WOLFSSL *ssl, WOLFSSL_SESSION *session)
 }
 #endif /* USE_WOLFSSL */
 
-static CURLcode tls_ctx_setup(struct Curl_cfilter *cf,
-                              struct Curl_easy *data,
-                              void *user_data)
+static CURLcode cf_ngtcp2_tls_ctx_setup(struct Curl_cfilter *cf,
+                                        struct Curl_easy *data,
+                                        void *user_data)
 {
   struct curl_tls_ctx *ctx = user_data;
   struct ssl_config_data *ssl_config = Curl_ssl_cf_get_config(cf, data);
@@ -2246,6 +2323,53 @@ static CURLcode tls_ctx_setup(struct Curl_cfilter *cf,
   return CURLE_OK;
 }
 
+static CURLcode cf_ngtcp2_on_session_reuse(struct Curl_cfilter *cf,
+                                           struct Curl_easy *data,
+                                           struct Curl_ssl_session *scs,
+                                           bool *do_early_data)
+{
+  struct cf_ngtcp2_ctx *ctx = cf->ctx;
+  CURLcode result = CURLE_OK;
+
+  *do_early_data = FALSE;
+#ifdef USE_GNUTLS
+  ctx->earlydata_max =
+    gnutls_record_get_max_early_data_size(ctx->tls.gtls.session);
+  if((!ctx->earlydata_max)) {
+    CURL_TRC_CF(data, cf, "SSL session does not allow earlydata");
+  }
+  else if(strcmp("h3", scs->alpn)) {
+    CURL_TRC_CF(data, cf, "SSL session from different ALPN, no early data");
+  }
+  else if(!scs->quic_tp || !scs->quic_tp_len) {
+    CURL_TRC_CF(data, cf, "no 0RTT transport parameters, no early data, ");
+  }
+  else {
+    int rv;
+    rv = ngtcp2_conn_decode_and_set_0rtt_transport_params(
+      ctx->qconn, (uint8_t *)scs->quic_tp, scs->quic_tp_len);
+    if(rv)
+      CURL_TRC_CF(data, cf, "no early data, failed to set 0RTT transport "
+                  "parameters: %s", ngtcp2_strerror(rv));
+    else {
+      infof(data, "SSL session allows %zu bytes of early data, "
+            "reusing ALPN '%s'", ctx->earlydata_max, scs->alpn);
+      result = init_ngh3_conn(cf, data);
+      if(!result) {
+        ctx->use_earlydata = TRUE;
+        cf->connected = TRUE;
+        *do_early_data = TRUE;
+      }
+    }
+  }
+#else /* USE_GNUTLS */
+  (void)data;
+  (void)ctx;
+  (void)scs;
+#endif
+  return result;
+}
+
 /*
  * Might be called twice for happy eyeballs.
  */
@@ -2261,17 +2385,6 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
   int qfd;
 
   DEBUGASSERT(ctx->initialized);
-#define H3_ALPN "\x2h3\x5h3-29"
-  result = Curl_vquic_tls_init(&ctx->tls, cf, data, &ctx->peer,
-                               H3_ALPN, sizeof(H3_ALPN) - 1,
-                               tls_ctx_setup, &ctx->tls, &ctx->conn_ref);
-  if(result)
-    return result;
-
-#ifdef USE_OPENSSL
-  SSL_set_quic_use_legacy_codepoint(ctx->tls.ossl.ssl, 0);
-#endif
-
   ctx->dcid.datalen = NGTCP2_MAX_CIDLEN;
   result = Curl_rand(data, ctx->dcid.data, NGTCP2_MAX_CIDLEN);
   if(result)
@@ -2313,7 +2426,17 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
   if(rc)
     return CURLE_QUIC_CONNECT_ERROR;
 
+#define H3_ALPN "\x2h3\x5h3-29"
+  result = Curl_vquic_tls_init(&ctx->tls, cf, data, &ctx->peer,
+                               H3_ALPN, sizeof(H3_ALPN) - 1,
+                               cf_ngtcp2_tls_ctx_setup, &ctx->tls,
+                               &ctx->conn_ref,
+                               cf_ngtcp2_on_session_reuse);
+  if(result)
+    return result;
+
 #ifdef USE_OPENSSL
+  SSL_set_quic_use_legacy_codepoint(ctx->tls.ossl.ssl, 0);
   ngtcp2_conn_set_tls_native_handle(ctx->qconn, ctx->tls.ossl.ssl);
 #elif defined(USE_GNUTLS)
   ngtcp2_conn_set_tls_native_handle(ctx->qconn, ctx->tls.gtls.session);
@@ -2364,6 +2487,11 @@ static CURLcode cf_ngtcp2_connect(struct Curl_cfilter *cf,
     result = cf_connect_start(cf, data, &pktx);
     if(result)
       goto out;
+    if(cf->connected) {
+      cf->conn->alpn = CURL_HTTP_VERSION_3;
+      *done = TRUE;
+      goto out;
+    }
     result = cf_progress_egress(cf, data, &pktx);
     /* we do not expect to be able to recv anything yet */
     goto out;
@@ -2378,10 +2506,7 @@ static CURLcode cf_ngtcp2_connect(struct Curl_cfilter *cf,
     goto out;
 
   if(ngtcp2_conn_get_handshake_completed(ctx->qconn)) {
-    ctx->handshake_at = now;
-    CURL_TRC_CF(data, cf, "handshake complete after %dms",
-               (int)Curl_timediff(now, ctx->started_at));
-    result = qng_verify_peer(cf, data);
+    result = ctx->tls_vrfy_result;
     if(!result) {
       CURL_TRC_CF(data, cf, "peer verified");
       cf->connected = TRUE;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1166,7 +1166,7 @@ static CURLcode cf_osslq_ctx_start(struct Curl_cfilter *cf,
 #define H3_ALPN "\x2h3"
   result = Curl_vquic_tls_init(&ctx->tls, cf, data, &ctx->peer,
                                H3_ALPN, sizeof(H3_ALPN) - 1,
-                               NULL, NULL, NULL);
+                               NULL, NULL, NULL, NULL);
   if(result)
     goto out;
 

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1309,7 +1309,7 @@ static CURLcode cf_quiche_ctx_open(struct Curl_cfilter *cf,
   result = Curl_vquic_tls_init(&ctx->tls, cf, data, &ctx->peer,
                                QUICHE_H3_APPLICATION_PROTOCOL,
                                sizeof(QUICHE_H3_APPLICATION_PROTOCOL) - 1,
-                               NULL, NULL, cf);
+                               NULL, NULL, cf, NULL);
   if(result)
     return result;
 

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -235,7 +235,8 @@ CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
                              struct ssl_peer *peer,
                              const char *alpn, size_t alpn_len,
                              Curl_vquic_tls_ctx_setup *cb_setup,
-                             void *cb_user_data, void *ssl_user_data)
+                             void *cb_user_data, void *ssl_user_data,
+                             Curl_vquic_session_reuse_cb *session_reuse_cb)
 {
   char tls_id[80];
   CURLcode result;
@@ -250,6 +251,7 @@ CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
 #error "no TLS lib in used, should not happen"
   return CURLE_FAILED_INIT;
 #endif
+  (void)session_reuse_cb;
   result = Curl_ssl_peer_init(peer, cf, tls_id, TRNSPRT_QUIC);
   if(result)
     return result;
@@ -260,15 +262,16 @@ CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
                             (const unsigned char *)alpn, alpn_len,
                             cb_setup, cb_user_data, NULL, ssl_user_data);
 #elif defined(USE_GNUTLS)
-  (void)result;
   return Curl_gtls_ctx_init(&ctx->gtls, cf, data, peer,
-                            (const unsigned char *)alpn, alpn_len, NULL,
-                            cb_setup, cb_user_data, ssl_user_data);
+                            (const unsigned char *)alpn, alpn_len,
+                            cb_setup, cb_user_data, ssl_user_data,
+                            session_reuse_cb);
 #elif defined(USE_WOLFSSL)
-  result = wssl_init_ctx(ctx, cf, data, cb_setup, cb_user_data);
+  CURLcode result = wssl_init_ctx(ctx, cf, data, cb_setup, cb_user_data);
   if(result)
     return result;
 
+  (void)session_reuse_cb;
   return wssl_init_ssl(ctx, cf, data, peer, alpn, alpn_len, ssl_user_data);
 #else
 #error "no TLS lib in used, should not happen"

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -267,7 +267,7 @@ CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
                             cb_setup, cb_user_data, ssl_user_data,
                             session_reuse_cb);
 #elif defined(USE_WOLFSSL)
-  CURLcode result = wssl_init_ctx(ctx, cf, data, cb_setup, cb_user_data);
+  result = wssl_init_ctx(ctx, cf, data, cb_setup, cb_user_data);
   if(result)
     return result;
 

--- a/lib/vquic/vquic-tls.h
+++ b/lib/vquic/vquic-tls.h
@@ -35,6 +35,7 @@
 #include "vtls/wolfssl.h"
 
 struct ssl_peer;
+struct Curl_ssl_session;
 
 struct curl_tls_ctx {
 #ifdef USE_OPENSSL
@@ -57,6 +58,11 @@ typedef CURLcode Curl_vquic_tls_ctx_setup(struct Curl_cfilter *cf,
                                           struct Curl_easy *data,
                                           void *cb_user_data);
 
+typedef CURLcode Curl_vquic_session_reuse_cb(struct Curl_cfilter *cf,
+                                             struct Curl_easy *data,
+                                             struct Curl_ssl_session *scs,
+                                             bool *do_early_data);
+
 /**
  * Initialize the QUIC TLS instances based of the SSL configurations
  * for the connection filter, transfer and peer.
@@ -68,8 +74,9 @@ typedef CURLcode Curl_vquic_tls_ctx_setup(struct Curl_cfilter *cf,
  *                    may be NULL
  * @param alpn_len    the overall number of bytes in `alpn`
  * @param cb_setup    optional callback for early TLS config
- ± @param cb_user_data user_data param for callback
+ * @param cb_user_data user_data param for callback
  * @param ssl_user_data  optional pointer to set in TLS application context
+ * @param session_reuse_cb callback to handle session reuse, signal early data
  */
 CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
                              struct Curl_cfilter *cf,
@@ -78,7 +85,8 @@ CURLcode Curl_vquic_tls_init(struct curl_tls_ctx *ctx,
                              const char *alpn, size_t alpn_len,
                              Curl_vquic_tls_ctx_setup *cb_setup,
                              void *cb_user_data,
-                             void *ssl_user_data);
+                             void *ssl_user_data,
+                             Curl_vquic_session_reuse_cb *session_reuse_cb);
 
 /**
  * Cleanup all data that has been initialized.

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -836,7 +836,7 @@ static CURLcode bearssl_connect_step3(struct Curl_cfilter *cf,
     ret = Curl_ssl_session_create((unsigned char *)session, sizeof(*session),
                                   (int)session->version,
                                   connssl->negotiated.alpn,
-                                  0, -1, &sc_session);
+                                  0, -1, 0, &sc_session);
     if(!ret) {
       ret = Curl_ssl_scache_put(cf, data, connssl->peer.scache_key,
                                 sc_session);

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -46,6 +46,7 @@ struct ssl_primary_config;
 struct ssl_config_data;
 struct ssl_peer;
 struct ssl_connect_data;
+struct Curl_ssl_session;
 
 int Curl_glts_get_ietf_proto(gnutls_session_t session);
 
@@ -78,15 +79,20 @@ typedef CURLcode Curl_gtls_ctx_setup_cb(struct Curl_cfilter *cf,
                                         struct Curl_easy *data,
                                         void *user_data);
 
+typedef CURLcode Curl_gtls_init_session_reuse_cb(struct Curl_cfilter *cf,
+                                                 struct Curl_easy *data,
+                                                 struct Curl_ssl_session *scs,
+                                                 bool *do_early_data);
+
 CURLcode Curl_gtls_ctx_init(struct gtls_ctx *gctx,
                             struct Curl_cfilter *cf,
                             struct Curl_easy *data,
                             struct ssl_peer *peer,
                             const unsigned char *alpn, size_t alpn_len,
-                            struct ssl_connect_data *connssl,
                             Curl_gtls_ctx_setup_cb *cb_setup,
                             void *cb_user_data,
-                            void *ssl_user_data);
+                            void *ssl_user_data,
+                            Curl_gtls_init_session_reuse_cb *sess_reuse_cb);
 
 CURLcode Curl_gtls_client_trust_setup(struct Curl_cfilter *cf,
                                       struct Curl_easy *data,
@@ -105,7 +111,9 @@ CURLcode Curl_gtls_cache_session(struct Curl_cfilter *cf,
                                  const char *ssl_peer_key,
                                  gnutls_session_t session,
                                  int lifetime_secs,
-                                 const char *alpn);
+                                 const char *alpn,
+                                 unsigned char *quic_tp,
+                                 size_t quic_tp_len);
 
 extern const struct Curl_ssl Curl_ssl_gnutls;
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1171,7 +1171,7 @@ mbed_new_session(struct Curl_cfilter *cf, struct Curl_easy *data)
 #endif
   result = Curl_ssl_session_create(sdata, slen,
                                    ietf_tls_id,
-                                   connssl->negotiated.alpn, 0, -1,
+                                   connssl->negotiated.alpn, 0, -1, 0,
                                    &sc_session);
   sdata = NULL;  /* call took ownership */
   if(!result)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2903,7 +2903,7 @@ CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
 
     result = Curl_ssl_session_create(der_session_buf, der_session_size,
                                      ietf_tls_id, alpn, 0,
-                                     SSL_SESSION_get_timeout(session),
+                                     SSL_SESSION_get_timeout(session), 0,
                                      &sc_session);
     der_session_buf = NULL;  /* took ownership of sdata */
     if(!result) {

--- a/lib/vtls/vtls_scache.h
+++ b/lib/vtls/vtls_scache.h
@@ -122,6 +122,9 @@ struct Curl_ssl_session {
   int lifetime_secs;           /* ticket lifetime (-1 unknown) */
   int ietf_tls_id;             /* TLS protocol identifier negotiated */
   char *alpn;                  /* APLN TLS negotiated protocol string */
+  size_t earlydata_max;        /* max 0-RTT data supported by peer */
+  const unsigned char *quic_tp; /* Optional QUIC transport param bytes */
+  size_t quic_tp_len;          /* number of bytes in quic_tp */
   struct Curl_llist_node list; /*  internal storage handling */
 };
 
@@ -142,7 +145,18 @@ CURLcode
 Curl_ssl_session_create(unsigned char *sdata, size_t sdata_len,
                         int ietf_tls_id, const char *alpn,
                         curl_off_t time_received, long lifetime_secs,
+                        size_t earlydata_max,
                         struct Curl_ssl_session **psession);
+
+/* Variation of session creation with quic transport parameter bytes,
+ * Takes ownership of `quic_tp` regardless of return code. */
+CURLcode
+Curl_ssl_session_create2(unsigned char *sdata, size_t sdata_len,
+                         int ietf_tls_id, const char *alpn,
+                         curl_off_t time_received, long lifetime_secs,
+                         size_t earlydata_max,
+                         unsigned char *quic_tp, size_t quic_tp_len,
+                         struct Curl_ssl_session **psession);
 
 /* Destroy a `session` instance. Can be called with NULL.
  * Does NOT need locking. */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -432,7 +432,7 @@ CURLcode Curl_wssl_cache_session(struct Curl_cfilter *cf,
 
   result = Curl_ssl_session_create(sdata, sdata_len,
                                    ietf_tls_id, alpn, 0,
-                                   wolfSSL_SESSION_get_timeout(session),
+                                   wolfSSL_SESSION_get_timeout(session), 0,
                                    &sc_session);
   sdata = NULL;  /* took ownership of sdata */
   if(!result) {

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -631,8 +631,7 @@ class TestDownload:
         elif proto == 'h2':
             assert earlydata[1] == 107, f'{earlydata}'
         elif proto == 'h3':
-            # not implemented
-            assert earlydata[1] == 0, f'{earlydata}'
+            assert earlydata[1] == 67, f'{earlydata}'
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     @pytest.mark.parametrize("max_host_conns", [0, 1, 5])

--- a/tests/http/testenv/nghttpx.py
+++ b/tests/http/testenv/nghttpx.py
@@ -205,6 +205,7 @@ class NghttpxQuic(Nghttpx):
         args = [
             self._cmd,
             f'--frontend=*,{self.env.h3_port};quic',
+            '--frontend-quic-early-data',
             f'--frontend=*,{self.env.nghttpx_https_port};tls',
             f'--backend=127.0.0.1,{self.env.https_port};{self.env.domain1};sni={self.env.domain1};proto=h2;tls',
             f'--backend=127.0.0.1,{self.env.http_port}',


### PR DESCRIPTION
When a QUIC TLS session announced early data support and 'CURLSSLOPT_EARLYDATA' is set for the transfer, send initial request and body (up to the 128k we buffer) as 0RTT when curl is built with ngtcp2+gnutls.

QUIC 0RTT needs not only the TLS session but the QUIC transport paramters as well. Store those and the earlydata max value together with the session in the cache.

Add test case for h3 use of this. Enable quic early data in nghttpx for testing.

**Update**: it's probably easiest to merge #15774 first and then rebase this one on top.