### PR TITLE
digest: produce a shorter cnonce in Digest headers

### DIFF
--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -709,13 +709,17 @@ static CURLcode auth_create_digest_http_message(
     digest->nc = 1;
 
   if(!digest->cnonce) {
-    char cnoncebuf[33];
-    result = Curl_rand_hex(data, (unsigned char *)cnoncebuf,
-                           sizeof(cnoncebuf));
+    char cnoncebuf[12];
+    result = Curl_rand_bytes(data,
+#ifdef DEBUGBUILD
+                             TRUE,
+#endif
+                             (unsigned char *)cnoncebuf,
+                             sizeof(cnoncebuf));
     if(result)
       return result;
 
-    result = Curl_base64_encode(cnoncebuf, strlen(cnoncebuf),
+    result = Curl_base64_encode(cnoncebuf, sizeof(cnoncebuf),
                                 &cnonce, &cnonce_sz);
     if(result)
       return result;


### PR DESCRIPTION
Other programs (Postman, Chrome, Python request) use a 16 byte cnonce and there are instances of server-side implementations that don't support the larger lengths curl used previously.

Fixes #15653
Reported-by: Florian Eckert

(This is an alternative to #15665)