### PR TITLE
KNOWN_BUGS: setting a disabled option should return CURLE_NOT_BUILT_IN

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -78,6 +78,7 @@ problems may have been fixed or changed somewhat since this was written.
  11.6 test cases sometimes timeout
  11.7 CURLOPT_CONNECT_TO does not work for HTTPS proxy
  11.8 WinIDN test failures
+ 11.9 setting a disabled option should return CURLE_NOT_BUILT_IN
 
  12. LDAP
  12.1 OpenLDAP hangs after returning results
@@ -494,6 +495,15 @@ problems may have been fixed or changed somewhat since this was written.
 11.8 WinIDN test failures
 
  Test 165 disabled when built with WinIDN.
+
+11.9 setting a disabled option should return CURLE_NOT_BUILT_IN
+
+ When curl has been built with specific features or protocols disabled,
+ setting such options with curl_easy_setopt() should rather return
+ CURLE_NOT_BUILT_IN instead of CURLE_UNKNOWN_OPTION to signal the difference
+ to the application
+
+ See https://github.com/curl/curl/issues/15472
 
 12. LDAP
 


### PR DESCRIPTION
Closes #15472