### PR TITLE
hostip: don't use the resolver for FQDN localhost

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -798,7 +798,9 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
         return CURLRESOLV_ERROR;
 
       if(strcasecompare(hostname, "localhost") ||
-         tailmatch(hostname, ".localhost"))
+         strcasecompare(hostname, "localhost.") ||
+         tailmatch(hostname, ".localhost") ||
+         tailmatch(hostname, ".localhost."))
         addr = get_localhost(port, hostname);
 #ifndef CURL_DISABLE_DOH
       else if(allowDOH && data->set.doh && !ipnum)


### PR DESCRIPTION
- Treat `[<any>.]localhost.` as fixed value 127.0.0.1 and ::1 instead of querying the resolver.

Prior to this change, b5c0fe20 (precedes 7.85.0) did the same for non-FQDN `<any>.localhost`.

Prior to this change, 1a0ebf66 (precedes 7.78.0) did the same for non-FQDN `localhost`.

Ref: https://github.com/curl/curl/issues/15628

Closes #xxxxx