### PR TITLE
test2086: disable MSYS2's POSIX path conversion

### DIFF
--- a/tests/data/test2086
+++ b/tests/data/test2086
@@ -34,6 +34,10 @@ libprereq
 <command>
 %HOST6IP:%HTTP6PORT/%TESTNUMBER#ipv6
 </command>
+<setenv>
+# Needed for MSYS2 to not treat the URL as a path list
+MSYS2_ARG_CONV_EXCL=*
+</setenv>
 </client>
 
 # Verify data after the test has been "shot"


### PR DESCRIPTION
Older MSYS2 versions treat the URL as paths list and convert them from UNIX to Windows format. There's no path here that needs to be converted, so disable path conversion for this test as done for others.

Fixes https://github.com/curl/curl/pull/15644#issuecomment-2511313206
Closes https://github.com/curl/curl/pull/15677