### PR TITLE
openssl: remove three "Useless Assignments"

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1203,14 +1203,12 @@ static int use_privatekey_blob(SSL_CTX *ctx, const struct curl_blob *blob,
                                    (void *)key_passwd);
   else if(type == SSL_FILETYPE_ASN1)
     pkey = d2i_PrivateKey_bio(in, NULL);
-  else {
-    ret = 0;
+  else
     goto end;
-  }
-  if(!pkey) {
-    ret = 0;
+
+  if(!pkey)
     goto end;
-  }
+
   ret = SSL_CTX_use_PrivateKey(ctx, pkey);
   EVP_PKEY_free(pkey);
 end:
@@ -1237,11 +1235,8 @@ use_certificate_chain_blob(SSL_CTX *ctx, const struct curl_blob *blob,
 
   x = PEM_read_bio_X509_AUX(in, NULL,
                             passwd_callback, (void *)key_passwd);
-
-  if(!x) {
-    ret = 0;
+  if(!x)
     goto end;
-  }
 
   ret = SSL_CTX_use_certificate(ctx, x);
 


### PR DESCRIPTION
Pointed out by CodeSonar