### PR TITLE
tool_formparse: remove use of sscanf()

### DIFF
--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -469,8 +469,6 @@ static int get_param_part(struct OperationConfig *config, char endchar,
   char *endpos;
   char *tp;
   char sep;
-  char type_major[128] = "";
-  char type_minor[128] = "";
   char *endct = NULL;
   struct curl_slist *headers = NULL;
 
@@ -502,18 +500,10 @@ static int get_param_part(struct OperationConfig *config, char endchar,
       /* set type pointer */
       type = p;
 
-      /* verify that this is a fine type specifier */
-      if(2 != sscanf(type, "%127[^/ ]/%127[^;, \n]", type_major, type_minor)) {
-        warnf(config->global, "Illegally formatted content-type field");
-        curl_slist_free_all(headers);
-        return -1; /* illegal content-type syntax! */
-      }
-
-      /* now point beyond the content-type specifier */
-      p = type + strlen(type_major) + strlen(type_minor) + 1;
-      for(endct = p; *p && *p != ';' && *p != endchar; p++)
-        if(!ISSPACE(*p))
-          endct = p + 1;
+      /* find end of content-type */
+      while(*p && (ISALPHA(*p) || (*p == '/') || (*p == '-')))
+        p++;
+      endct = p;
       sep = *p;
     }
     else if(checkprefix("filename=", p)) {


### PR DESCRIPTION
In the function for handling 'type=' in the -F command line arguments, we make the code more lax to accept more strings and thereby also avoid the use of sscanf().