### PR TITLE
checksrc: ban use of sscanf()

### DIFF
--- a/docs/examples/.checksrc
+++ b/docs/examples/.checksrc
@@ -1,3 +1,4 @@
 disable TYPEDEFSTRUCT
 disable SNPRINTF
 disable BANNEDFUNC
+disable SSCANF

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -99,6 +99,7 @@ my %warnings = (
     'SPACEBEFOREPAREN'      => 'space before an open parenthesis',
     'SPACESEMICOLON'        => 'space before semicolon',
     'SPACESWITCHCOLON'      => 'space before colon of switch label',
+    "SSCANF"                => 'use of sscanf',
     'TABS'                  => 'TAB characters not allowed',
     'TRAILINGSPACE'         => 'Trailing whitespace on the line',
     'TYPEDEFSTRUCT'         => 'typedefed struct',
@@ -813,6 +814,16 @@ sub scanfile {
             checkwarn("BANNEDFUNC",
                       $line, length($1), $file, $ol,
                       "use of $2 is banned");
+        }
+        # scan for use of sscanf. This is not a BANNEDFUNC to allow for
+        # individual enable/disable of this warning.
+        if($l =~ /^(.*\W)(sscanf)\s*\(/x) {
+            if($1 !~ /^ *\#/) {
+                # skip preprocessor lines
+                checkwarn("SSCANF",
+                          $line, length($1), $file, $ol,
+                          "use of $2 is banned");
+            }
         }
         if($warnings{"STRERROR"}) {
             # scan for use of banned strerror. This is not a BANNEDFUNC to

--- a/tests/libtest/.checksrc
+++ b/tests/libtest/.checksrc
@@ -1,2 +1,3 @@
 disable TYPEDEFSTRUCT
 disable BANNEDFUNC
+disable SSCANF

--- a/tests/server/.checksrc
+++ b/tests/server/.checksrc
@@ -1,1 +1,2 @@
 enable STRNCPY
+disable SSCANF


### PR DESCRIPTION
Using sscanf() is not a (security) problem in itself, but we strongly discourage using it for parsing input since it is hard to use right, easy to mess up and often makes for sloppy error checking.

- [X] fix src/ - gone!
- [X] fix lib/ (waits for #15692)
- [X] fix docs/examples/ - accepted in there
- [X] fix tests/ - short term at least we need to accept them in test code