### PR TITLE
Use --no-cache when building docker image

### DIFF
--- a/scripts/dmaketgz
+++ b/scripts/dmaketgz
@@ -40,6 +40,7 @@ if test -f Makefile; then
     make distclean
 fi
 docker build \
+       --no-cache \
        --build-arg SOURCE_DATE_EPOCH="$timestamp" \
        --build-arg UID="$(id -u)" \
        --build-arg GID="$(id -g)" \


### PR DESCRIPTION
This fixes #15689.

Adding `--no-cache` option guarantees docker image is rebuilt and correct release date is set.