### PR TITLE
CMake: Correctly set CURL_STATICLIB when building static lib.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -125,7 +125,7 @@ if(BUILD_STATIC_LIBS)
   add_library(${LIB_STATIC} STATIC ${LIB_SOURCE})
   add_library(${PROJECT_NAME}::${LIB_STATIC} ALIAS ${LIB_STATIC})
   if(WIN32)
-    set_property(TARGET ${LIB_OBJECT} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
+    set_property(TARGET ${LIB_STATIC} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
   target_link_libraries(${LIB_STATIC} PRIVATE ${CURL_LIBS})
   # Remove the "lib" prefix since the library is already named "libcurl".


### PR DESCRIPTION
CMake: when compiled with BUILD_STATIC_LIBS=ON and SHARE_LIB_OBJECT=OFF compile definition CURL_STATICLIB was not set for static library. It seems to be copy-paste error in the lib/CMakeLists.txt.

This pull request fixes it.