### PR TITLE
tool_getparam: remove Redundant Condition

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1064,7 +1064,7 @@ static ParameterError parse_localport(struct OperationConfig *config,
   if(*p) {
     pp = p;
     /* check for ' - [end]' */
-    if(*pp && ISSPACE(*pp))
+    if(ISSPACE(*pp))
       pp++;
     if(*pp != '-')
       return PARAM_BAD_USE;


### PR DESCRIPTION
Pointed out by CodeSonar