### PR TITLE
mprintf: fix the integer overflow checks

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -321,10 +321,10 @@ static int parsefmt(const char *format,
               fmt++;
             }
             while(ISDIGIT(*fmt)) {
-              if(precision > INT_MAX/10)
+              int n = *fmt - '0';
+              if(precision > (INT_MAX - n)/10)
                 return PFMT_PREC;
-              precision *= 10;
-              precision += *fmt - '0';
+              precision = precision * 10 + n;
               fmt++;
             }
             if(is_neg)
@@ -397,10 +397,10 @@ static int parsefmt(const char *format,
           width = 0;
           fmt--;
           do {
-            if(width > INT_MAX/10)
+            int n = *fmt - '0';
+            if(width > (INT_MAX-n)/10)
               return PFMT_WIDTH;
-            width *= 10;
-            width += *fmt - '0';
+            width = width * 10 + n;
             fmt++;
           } while(ISDIGIT(*fmt));
           break;


### PR DESCRIPTION
When a floating point precision or string width are provided as a base-10 number, the code could miss to detect integer overflows if the provided value was exactly 2147483648 or 2147483649 (2147483647 being the maxium value a signed integer can hold).

The chance that such values would actually ever be used is slim.

This change fixes the detection to also cover those edge cases.