### PR TITLE
async-thread: avoid closing eventfd twice

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -195,9 +195,11 @@ void destroy_thread_sync_data(struct thread_sync_data *tsd)
    * close one end of the socket pair (may be done in resolver thread);
    * the other end (for reading) is always closed in the parent thread.
    */
+#ifndef USE_EVENTFD
   if(tsd->sock_pair[1] != CURL_SOCKET_BAD) {
     wakeup_close(tsd->sock_pair[1]);
   }
+#endif
 #endif
   memset(tsd, 0, sizeof(*tsd));
 }


### PR DESCRIPTION
When employing eventfd for socketpair, there is only one file descriptor. Closing that fd twice might result in fd corruption. Thus, we should avoid closing the eventfd twice, following the pattern in lib/multi.c.

Fixes #15725