### PR TITLE
curl: return error if etag options are used with multiple URLs

### DIFF
--- a/docs/cmdline-opts/etag-compare.md
+++ b/docs/cmdline-opts/etag-compare.md
@@ -25,3 +25,5 @@ line with the desired ETag. An empty file is parsed as an empty ETag.
 
 Use the option --etag-save to first save the ETag from a response, and then
 use this option to compare against the saved ETag in a subsequent request.
+
+Use this option with a single URL only.

--- a/docs/cmdline-opts/etag-save.md
+++ b/docs/cmdline-opts/etag-save.md
@@ -17,6 +17,6 @@ Example:
 # `--etag-save`
 
 Save an HTTP ETag to the specified file. An ETag is a caching related header,
-usually returned in a response.
+usually returned in a response. Use this option with a single URL only.
 
 If no ETag is sent by the server, an empty file is created.

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -130,6 +130,7 @@ struct OperationConfig {
   struct getout *url_get;   /* point to the node to fill in URL */
   struct getout *url_out;   /* point to the node to fill in outfile */
   struct getout *url_ul;    /* point to the node to fill in upload */
+  size_t num_urls;          /* number of URLs added to the list */
 #ifndef CURL_DISABLE_IPFS
   char *ipfs_gateway;
 #endif /* !CURL_DISABLE_IPFS */

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -78,7 +78,7 @@ test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
 test462 test463 test467 test468 test469 test470 test471 test472 test473 \
 test474 test475 test476 test477 test478 test479 test480 test481 test482 \
-test483 \
+test483 test484 test485 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \
 test508 test509 test510 test511 test512 test513 test514 test515 test516 \

--- a/tests/data/test484
+++ b/tests/data/test484
@@ -34,7 +34,11 @@ http://example.com/%TESTNUMBER --etag-compare %LOGDIR/etag%TESTNUMBER --etag-sav
 <stderr mode="text">
 curl: The etag options only work on a single URL
 curl: option --url: is badly used here
+%if manual
 curl: try 'curl --help' or 'curl --manual' for more information
+%else
+curl: try 'curl --help' for more information
+%endif
 </stderr>
 </verify>
 </testcase>

--- a/tests/data/test484
+++ b/tests/data/test484
@@ -1,0 +1,40 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+etags
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<name>
+Use --etag-compare and -save with more than one URL
+</name>
+<command>
+http://example.com/%TESTNUMBER --etag-compare %LOGDIR/etag%TESTNUMBER --etag-save %LOGDIR/etag%TESTNUMBER --url http://example.net/fooo
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+2
+</errorcode>
+<stderr mode="text">
+curl: The etag options only work on a single URL
+curl: option --url: is badly used here
+curl: try 'curl --help' or 'curl --manual' for more information
+</stderr>
+</verify>
+</testcase>

--- a/tests/data/test485
+++ b/tests/data/test485
@@ -34,7 +34,11 @@ http://example.com/%TESTNUMBER http://example.net/fooo --etag-save %LOGDIR/etag%
 <stderr mode="text">
 curl: The etag options only work on a single URL
 curl: option --etag-save: is badly used here
+%if manual
 curl: try 'curl --help' or 'curl --manual' for more information
+%else
+curl: try 'curl --help' for more information
+%endif
 </stderr>
 </verify>
 </testcase>

--- a/tests/data/test485
+++ b/tests/data/test485
@@ -1,0 +1,40 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+etags
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<name>
+Use --etag-compare and -save with more than one URL, URLs specified first
+</name>
+<command>
+http://example.com/%TESTNUMBER http://example.net/fooo --etag-save %LOGDIR/etag%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+2
+</errorcode>
+<stderr mode="text">
+curl: The etag options only work on a single URL
+curl: option --etag-save: is badly used here
+curl: try 'curl --help' or 'curl --manual' for more information
+</stderr>
+</verify>
+</testcase>


### PR DESCRIPTION
And document it.

Add tests 484 and 485

Fixes #15729
Reported-by: Tamir Duberstein
Closes #