### PR TITLE
tool_operate: make --etag-compare always accept a non-existing file

### DIFF
--- a/docs/cmdline-opts/etag-compare.md
+++ b/docs/cmdline-opts/etag-compare.md
@@ -21,7 +21,8 @@ Make a conditional HTTP request for the specific ETag read from the given file
 by sending a custom If-None-Match header using the stored ETag.
 
 For correct results, make sure that the specified file contains only a single
-line with the desired ETag. An empty file is parsed as an empty ETag.
+line with the desired ETag. A non-existing or empty file is treated as an
+empty ETag.
 
 Use the option --etag-save to first save the ETag from a response, and then
 use this option to compare against the saved ETag in a subsequent request.

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1940,12 +1940,9 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
         /* open file for reading: */
         FILE *file = fopen(config->etag_compare_file, FOPEN_READTEXT);
-        if(!file && !config->etag_save_file) {
-          errorf(global,
-                 "Failed to open %s", config->etag_compare_file);
-          result = CURLE_READ_ERROR;
-          break;
-        }
+        if(!file)
+          warnf(global, "Failed to open %s: %s", config->etag_compare_file,
+                strerror(errno));
 
         if((PARAM_OK == file2string(&etag_from_file, file)) &&
            etag_from_file) {

--- a/tests/data/test341
+++ b/tests/data/test341
@@ -36,7 +36,7 @@ chunky-trailer: header data
 http
 </server>
 <name>
-Try to open a non existing file with --etag-compare should return an error
+A non existing file with --etag-compare is just a blank
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER --etag-compare %LOGDIR/etag%TESTNUMBER
@@ -46,9 +46,14 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER --etag-compare %LOGDIR/etag%TESTNUMBER
 #
 # Verify data after the test has been "shot"
 <verify>
-<errorcode>
-26
-</errorcode>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+If-None-Match: ""
+
+</protocol>
 </verify>
 
 </testcase>


### PR DESCRIPTION
Consider it a blank etag. It allows for more use cases when the file just might not have been created yet.