### PR TITLE
tool_getparam: fix the ECH parser

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1135,11 +1135,13 @@ static ParameterError parse_ech(struct GlobalConfig *global,
     err = PARAM_LIBCURL_DOESNT_SUPPORT;
   else if(strlen(nextarg) > 4 && strncasecompare("pn:", nextarg, 3)) {
     /* a public_name */
+    nextarg += 3;
     err = getstr(&config->ech_public, nextarg, DENY_BLANK);
   }
   else if(strlen(nextarg) > 5 && strncasecompare("ecl:", nextarg, 4)) {
     /* an ECHConfigList */
-    if('@' != *(nextarg + 4)) {
+    nextarg += 4;
+    if('@' != *nextarg) {
       err = getstr(&config->ech_config, nextarg, DENY_BLANK);
     }
     else {


### PR DESCRIPTION
The pn: and ecl: prefixes were not handled correctly.

CodeSonar helped me realize as it poined out an "Unreachable Data Flow"