### PR TITLE
ws-docs: remove the outdated texts saying ws support is experimental

### DIFF
--- a/docs/libcurl/curl_ws_meta.md
+++ b/docs/libcurl/curl_ws_meta.md
@@ -29,8 +29,6 @@ const struct curl_ws_frame *curl_ws_meta(CURL *curl);
 
 # DESCRIPTION
 
-This function call is EXPERIMENTAL.
-
 When the write callback (CURLOPT_WRITEFUNCTION(3)) is invoked on
 received WebSocket traffic, curl_ws_meta(3) can be called from within
 the callback to provide additional information about the current frame.

--- a/docs/libcurl/curl_ws_recv.md
+++ b/docs/libcurl/curl_ws_recv.md
@@ -30,8 +30,6 @@ CURLcode curl_ws_recv(CURL *curl, void *buffer, size_t buflen,
 
 # DESCRIPTION
 
-This function call is EXPERIMENTAL.
-
 Retrieves as much as possible of a received WebSocket data fragment into the
 **buffer**, but not more than **buflen** bytes. *recv* is set to the
 number of bytes actually stored.

--- a/docs/libcurl/curl_ws_send.md
+++ b/docs/libcurl/curl_ws_send.md
@@ -31,8 +31,6 @@ CURLcode curl_ws_send(CURL *curl, const void *buffer, size_t buflen,
 
 # DESCRIPTION
 
-This function call is EXPERIMENTAL.
-
 Send the specific message fragment over an established WebSocket
 connection. The *buffer* holds the data to send and it is *buflen*
 number of payload bytes in that memory area.

--- a/docs/libcurl/libcurl-ws.md
+++ b/docs/libcurl/libcurl-ws.md
@@ -115,12 +115,3 @@ back to the application.
 Once such a setup has been successfully performed, the application can proceed
 and use curl_ws_recv(3) and curl_ws_send(3) freely to exchange
 WebSocket messages with the server.
-
-# EXPERIMENTAL
-
-The WebSocket API was introduced as experimental in 7.86.0 and is still
-experimental today.
-
-It is only built-in if explicitly opted in at build time. We discourage use of
-the WebSocket API in production because of its experimental state. We might
-change API, ABI and behavior before this "goes live".


### PR DESCRIPTION
It went out of experimental in 8.10.0

Fixes #15749
Reported-by: Mohammed Sadiq