### PR TITLE
tool_getparam: fix memory leak in parse_ech

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1169,9 +1169,9 @@ static ParameterError parse_ech(struct GlobalConfig *global,
       if(err)
         return err;
       config->ech_config = aprintf("ecl:%s",tmpcfg);
+      free(tmpcfg);
       if(!config->ech_config)
         return PARAM_NO_MEM;
-      free(tmpcfg);
     } /* file done */
   }
   else {


### PR DESCRIPTION
tmpcfg from file2string should be freed before return

Change-Id: I8f8508b224706f002d56eaf7801abaa22f082e76