### PR TITLE
GHA/codeql-analysis: install libpsl

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -46,6 +46,13 @@ jobs:
     permissions:
       security-events: write
     steps:
+      - name: 'install prereqs'
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+            libpsl-dev
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
Stay with the default CMake build. It requires libpsl now, but
the latest Ubuntu runner no longer seems to provide it. Install it
manually.

Bug: https://github.com/curl/curl/pull/15464#issuecomment-2546602052
Follow-up to 7afbc39173f1dc00b99ebe3b08837d6d051672d6 #15464
