### PR TITLE
tool_formparse: accept digits in --form type= strings

### DIFF
--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -501,7 +501,7 @@ static int get_param_part(struct OperationConfig *config, char endchar,
       type = p;
 
       /* find end of content-type */
-      while(*p && (ISALPHA(*p) || (*p == '/') || (*p == '-')))
+      while(*p && (ISALNUM(*p) || (*p == '/') || (*p == '-')))
         p++;
       endct = p;
       sep = *p;

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -495,14 +495,15 @@ static int get_param_part(struct OperationConfig *config, char endchar,
       ;
 
     if(!endct && checkprefix("type=", p)) {
+      size_t tlen;
       for(p += 5; ISSPACE(*p); p++)
         ;
       /* set type pointer */
       type = p;
 
       /* find end of content-type */
-      while(*p && (ISALNUM(*p) || (*p == '/') || (*p == '-')))
-        p++;
+      tlen = strcspn(p, "()<>@,;:\\\"[]?=\r\n ");
+      p += tlen;
       endct = p;
       sep = *p;
     }

--- a/tests/data/test186
+++ b/tests/data/test186
@@ -31,7 +31,7 @@ http
 HTTP RFC1867-type formposting with types on text fields
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F "name=daniel;type=moo/foo" -F "html= <body>hello</body>;type=text/html;charset=verymoo"
+http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F "name=daniel;type=moo/foo4" -F "html= <body>hello</body>;type=text/html;charset=verymoo"
 </command>
 # We create this file before the command is invoked!
 </client>
@@ -46,12 +46,12 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 338
+Content-Length: 339
 Content-Type: multipart/form-data; boundary=----------------------------212d9006ceb5
 
 ------------------------------212d9006ceb5
 Content-Disposition: form-data; name="name"
-Content-Type: moo/foo
+Content-Type: moo/foo4
 
 daniel
 ------------------------------212d9006ceb5

--- a/tests/data/test186
+++ b/tests/data/test186
@@ -31,7 +31,7 @@ http
 HTTP RFC1867-type formposting with types on text fields
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F "name=daniel;type=moo/foo4" -F "html= <body>hello</body>;type=text/html;charset=verymoo"
+http://%HOSTIP:%HTTPPORT/we/want/%TESTNUMBER -F "name=daniel;type=moo/foo-.4" -F "html= <body>hello</body>;type=text/html;charset=verymoo"
 </command>
 # We create this file before the command is invoked!
 </client>
@@ -46,12 +46,12 @@ POST /we/want/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Content-Length: 339
+Content-Length: 341
 Content-Type: multipart/form-data; boundary=----------------------------212d9006ceb5
 
 ------------------------------212d9006ceb5
 Content-Disposition: form-data; name="name"
-Content-Type: moo/foo4
+Content-Type: moo/foo-.4
 
 daniel
 ------------------------------212d9006ceb5


### PR DESCRIPTION
Adjusted test 186 to verify.

Regression in 9664d5a5475fdc66, shipped in 8.11.1

Reported-by: IcedCoffeee on github
Fixes #15761