### PR TITLE
apple builds, supress deprecation warnings

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -45,9 +45,6 @@ permissions: {}
 #
 # For Secure Transport, curl implements features that require a target
 # newer than the 10.8 required by `CFURLCreateDataAndPropertiesFromResource`.
-# In this case `-Wno-deprecated-declarations` still comes handy to pacify
-# deprecation warnings, though the real solution would be to avoid calling
-# that function.
 
 env:
   LDFLAGS: -w  # suppress 'object file was built for newer macOS version than being linked' warnings
@@ -118,7 +115,6 @@ jobs:
             compiler: clang
             configure: --enable-debug --with-secure-transport --with-libssh2=$(brew --prefix libssh2)
             macos-version-min: '10.12'  # for monotonic timers
-            cflags: '-Wno-deprecated-declarations'
           - name: 'SecureTransport libssh2'
             compiler: gcc-12
             configure: --enable-debug --with-secure-transport --with-libssh2=$(brew --prefix libssh2)

--- a/lib/curl_gssapi.c
+++ b/lib/curl_gssapi.c
@@ -40,6 +40,11 @@
 #define CURL_ALIGN8
 #endif
 
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 gss_OID_desc Curl_spnego_mech_oid CURL_ALIGN8 = {
   6, (char *)"\x2b\x06\x01\x05\x05\x02"
 };
@@ -148,5 +153,9 @@ void Curl_gss_log_error(struct Curl_easy *data, const char *prefix,
   (void)prefix;
 #endif
 }
+
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* HAVE_GSSAPI */

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -63,6 +63,11 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 static CURLcode ftpsend(struct Curl_easy *data, struct connectdata *conn,
                         const char *cmd)
 {
@@ -923,5 +928,9 @@ Curl_sec_end(struct connectdata *conn)
   conn->data_prot = PROT_CLEAR;
   conn->mech = NULL;
 }
+
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* HAVE_GSSAPI && !CURL_DISABLE_FTP */

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -26,6 +26,11 @@
 
 #if !defined(CURL_DISABLE_LDAP) && !defined(USE_OPENLDAP)
 
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 /*
  * Notice that USE_OPENLDAP is only a source code selection switch. When
  * libcurl is built with USE_OPENLDAP defined the libcurl source code that
@@ -1113,4 +1118,9 @@ static void _ldap_free_urldesc(LDAPURLDesc *ludp)
   free(ludp);
 }
 #endif  /* !HAVE_LDAP_URL_PARSE */
+
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic pop
+#endif
+
 #endif  /* !CURL_DISABLE_LDAP && !USE_OPENLDAP */

--- a/lib/socks_gssapi.c
+++ b/lib/socks_gssapi.c
@@ -42,6 +42,11 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #define MAX_GSS_LEN 1024
 
 static gss_ctx_id_t gss_context = GSS_C_NO_CONTEXT;
@@ -536,5 +541,9 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
 
   return CURLE_OK;
 }
+
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* HAVE_GSSAPI && !CURL_DISABLE_PROXY */

--- a/lib/vauth/krb5_gssapi.c
+++ b/lib/vauth/krb5_gssapi.c
@@ -42,6 +42,11 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 /*
  * Curl_auth_is_gssapi_supported()
  *
@@ -320,5 +325,9 @@ void Curl_auth_cleanup_gssapi(struct kerberos5data *krb5)
     krb5->spn = GSS_C_NO_NAME;
   }
 }
+
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* HAVE_GSSAPI && USE_KERBEROS5 */

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -42,6 +42,11 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 /*
  * Curl_auth_is_spnego_supported()
  *
@@ -287,5 +292,9 @@ void Curl_auth_cleanup_spnego(struct negotiatedata *nego)
   nego->havenegdata = FALSE;
   nego->havemultiplerequests = FALSE;
 }
+
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic pop
+#endif
 
 #endif /* HAVE_GSSAPI && USE_SPNEGO */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -51,6 +51,11 @@
 #pragma GCC diagnostic ignored "-Waddress"
 #endif
 
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
 #include <limits.h>
 
 #include <Security/Security.h>
@@ -2769,6 +2774,10 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   sectransp_send,                     /* send data to encrypt */
   NULL,                               /* get_channel_binding */
 };
+
+#if defined(__GNUC__) && defined(__APPLE__)
+#pragma GCC diagnostic pop
+#endif
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop


### PR DESCRIPTION
On apple builds, the gssapi/ldap/securetransport headers deprecate almost everything which leads to a wall of compiler warnings on use in code.

Suppress those warning that may hide other warnings/errors.