### PR TITLE
checksrc: fix the return() checker

### DIFF
--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -714,7 +714,7 @@ sub scanfile {
         }
 
         # check for "return(" without space
-        if($l =~ /^(.*)return\(/) {
+        if($l =~ /^(.*\W)return\(/) {
             if($1 =~ / *\#/) {
                 # this is a #if, treat it differently
             }

--- a/tests/data/test1185
+++ b/tests/data/test1185
@@ -46,7 +46,7 @@ if(a == 2){ /* followed by comment */
   ;
 }
 
-func() ;
+func_return() ;
 
 a = sprintf(buffer, "%s", moo);
 
@@ -120,9 +120,9 @@ void startfunc(int a, int b) {
 ./%LOGDIR/code1185.c:24:11: warning: missing space after close paren (PARENBRACE)
  if(a == 2){  
            ^
-./%LOGDIR/code1185.c:28:7: warning: no space before semicolon (SPACESEMICOLON)
- func() ;
-       ^
+./%LOGDIR/code1185.c:28:14: warning: no space before semicolon (SPACESEMICOLON)
+ func_return() ;
+              ^
 ./%LOGDIR/code1185.c:30:5: warning: use of sprintf is banned (BANNEDFUNC)
  a = sprintf(buffer, "%s", moo);
      ^


### PR DESCRIPTION
It would previously wrongly also catch function calls to function names ending with 'return'

Amended test1185.

Reported-by: Stefan Eissing