### PR TITLE
multissl: auto-enable `OPENSSL_COEXIST` for wolfSSL + OpenSSL

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -743,6 +743,17 @@
 #define USE_SSL    /* SSL support has been enabled */
 #endif
 
+#if defined(USE_OPENSSL) && defined(USE_WOLFSSL)
+#  include <wolfssl/version.h>
+#  if LIBWOLFSSL_VERSION_HEX >= 0x05007004 /* >= 5.7.5 FIXME FIXME FIXME */
+#    ifndef OPENSSL_COEXIST
+#    define OPENSSL_COEXIST
+#    endif
+#  else
+#    error "OpenSSL can only coexist with wolfSSL v5.7.5 or upper"
+#  endif
+#endif
+
 #if defined(USE_WOLFSSL) && defined(USE_GNUTLS)
 /* Avoid defining unprefixed wolfSSL SHA macros colliding with nettle ones */
 #define NO_OLD_WC_NAMES

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -745,12 +745,12 @@
 
 #if defined(USE_OPENSSL) && defined(USE_WOLFSSL)
 #  include <wolfssl/version.h>
-#  if LIBWOLFSSL_VERSION_HEX >= 0x05007004 /* >= 5.7.5 FIXME FIXME FIXME */
+#  if LIBWOLFSSL_VERSION_HEX >= 0x05007006
 #    ifndef OPENSSL_COEXIST
 #    define OPENSSL_COEXIST
 #    endif
 #  else
-#    error "OpenSSL can only coexist with wolfSSL v5.7.5 or upper"
+#    error "OpenSSL can only coexist with wolfSSL v5.7.6 or upper"
 #  endif
 #endif
 


### PR DESCRIPTION
When building with both OpenSSL and wolfSSL set this necessary option.
Otherwise fail with an error.

Requires wolfSSL v5.7.6 or upper.

---

- [x] finalize cutoff version for wolfSSL's `OPENSSL_COEXIST`.
- [x] wait for wolfSSL release with coexist support.
- [ ] wait for vcpkg supporting that version.
- [ ] enable wolfSSL in the vcpkg MultiSSL job.
