### PR TITLE
netrc: fix password-only entries

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -267,7 +267,8 @@ static int parsenetrc(struct store_netrc *store,
             retcode = NETRC_FAILED; /* allocation failed */
             goto out;
           }
-          found |= FOUND_PASSWORD;
+          if(!specific_login || our_login)
+            found |= FOUND_PASSWORD;
           keyword = NONE;
         }
         else if(strcasecompare("login", tok))
@@ -276,6 +277,10 @@ static int parsenetrc(struct store_netrc *store,
           keyword = PASSWORD;
         else if(strcasecompare("machine", tok)) {
           /* a new machine here */
+          if(found & FOUND_PASSWORD) {
+            done = TRUE;
+            break;
+          }
           state = HOSTFOUND;
           keyword = NONE;
           found = 0;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -238,7 +238,7 @@ test1941 test1942 test1943 test1944 test1945 test1946 test1947 test1948 \
 test1955 test1956 test1957 test1958 test1959 test1960 test1964 \
 test1970 test1971 test1972 test1973 test1974 test1975 test1976 \
 \
-test2000 test2001 test2002 test2003 test2004 \
+test2000 test2001 test2002 test2003 test2004 test2005 \
 \
                                                                test2023 \
 test2024 test2025 test2026 test2027 test2028 test2029 test2030 test2031 \

--- a/tests/data/test2005
+++ b/tests/data/test2005
@@ -1,0 +1,55 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+netrc
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Fri, 05 Aug 2022 10:09:00 GMT
+Server: test-server/fake
+Content-Type: text/plain
+Content-Length: 6
+Connection: close
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+netrc match with password only in file, no username. machine follows
+</name>
+<command>
+--netrc-optional --netrc-file %LOGDIR/netrc%TESTNUMBER http://%HOSTIP:%HTTPPORT/
+</command>
+<file name="%LOGDIR/netrc%TESTNUMBER" >
+machine %HOSTIP
+password 5up3r53cr37
+
+machine example.com
+</file>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET / HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: Basic %b64[:5up3r53cr37]b64%
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
When a specific hostname matched, and only a password is set before another machine is specified in the netrc file, the parser would not be happy and stop there and return the password-only state. It instead continued and did not return a match.

Added test 2005 to verify this case

Reported-by: Ben Zanin
Fixes #15767