### PR TITLE
docs(resolve): asterisk not ampersand

### DIFF
--- a/docs/libcurl/opts/CURLOPT_RESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.md
@@ -47,7 +47,7 @@ numerical IP addresses. If you specify multiple IP addresses they need to be
 separated by comma. If libcurl is built to support IPv6, each of the ADDRESS
 entries can of course be either IPv4 or IPv6 style addressing.
 
-Specify the host as a single ampersand (`*`) to match all names. This wildcard
+Specify the host as a single asterisk (`*`) to match all names. This wildcard
 is resolved last so any resolve with a specific host and port number is given
 priority.
 


### PR DESCRIPTION
It's an asterisk, not an ampersand