### PR TITLE
vtls: replace "none"-functions with NULL pointers

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -991,7 +991,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     /*
      * Enable TLS false start.
      */
-    if(!Curl_ssl_false_start(data))
+    if(!Curl_ssl_false_start())
       return CURLE_NOT_BUILT_IN;
 
     data->set.ssl.falsestart = enabled;

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -1154,24 +1154,24 @@ const struct Curl_ssl Curl_ssl_bearssl = {
 
   sizeof(struct bearssl_ssl_backend_data),
 
-  Curl_none_init,                  /* init */
-  Curl_none_cleanup,               /* cleanup */
+  NULL,                            /* init */
+  NULL,                            /* cleanup */
   bearssl_version,                 /* version */
-  Curl_none_check_cxn,             /* check_cxn */
+  NULL,                            /* check_cxn */
   bearssl_shutdown,                /* shutdown */
   bearssl_data_pending,            /* data_pending */
   bearssl_random,                  /* random */
-  Curl_none_cert_status_request,   /* cert_status_request */
+  NULL,                            /* cert_status_request */
   bearssl_connect,                 /* connect */
   bearssl_connect_nonblocking,     /* connect_nonblocking */
   Curl_ssl_adjust_pollset,         /* adjust_pollset */
   bearssl_get_internals,           /* get_internals */
   bearssl_close,                   /* close_one */
-  Curl_none_close_all,             /* close_all */
-  Curl_none_set_engine,            /* set_engine */
-  Curl_none_set_engine_default,    /* set_engine_default */
-  Curl_none_engines_list,          /* engines_list */
-  Curl_none_false_start,           /* false_start */
+  NULL,                            /* close_all */
+  NULL,                            /* set_engine */
+  NULL,                            /* set_engine_default */
+  NULL,                            /* engines_list */
+  NULL,                            /* false_start */
   bearssl_sha256sum,               /* sha256sum */
   NULL,                            /* associate_connection */
   NULL,                            /* disassociate_connection */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -2269,7 +2269,7 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   gtls_init,                     /* init */
   gtls_cleanup,                  /* cleanup */
   gtls_version,                  /* version */
-  Curl_none_check_cxn,           /* check_cxn */
+  NULL,                          /* check_cxn */
   gtls_shutdown,                 /* shutdown */
   gtls_data_pending,             /* data_pending */
   gtls_random,                   /* random */
@@ -2279,11 +2279,11 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   Curl_ssl_adjust_pollset,       /* adjust_pollset */
   gtls_get_internals,            /* get_internals */
   gtls_close,                    /* close_one */
-  Curl_none_close_all,           /* close_all */
-  Curl_none_set_engine,          /* set_engine */
-  Curl_none_set_engine_default,  /* set_engine_default */
-  Curl_none_engines_list,        /* engines_list */
-  Curl_none_false_start,         /* false_start */
+  NULL,                          /* close_all */
+  NULL,                          /* set_engine */
+  NULL,                          /* set_engine_default */
+  NULL,                          /* engines_list */
+  NULL,                          /* false_start */
   gtls_sha256sum,                /* sha256sum */
   NULL,                          /* associate_connection */
   NULL,                          /* disassociate_connection */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1200,11 +1200,6 @@ static ssize_t mbed_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   return ret;
 }
 
-static void mbedtls_close_all(struct Curl_easy *data)
-{
-  (void)data;
-}
-
 static CURLcode mbedtls_shutdown(struct Curl_cfilter *cf,
                                  struct Curl_easy *data,
                                  bool send_shutdown, bool *done)
@@ -1648,21 +1643,21 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   mbedtls_init,                     /* init */
   mbedtls_cleanup,                  /* cleanup */
   mbedtls_version,                  /* version */
-  Curl_none_check_cxn,              /* check_cxn */
+  NULL,                             /* check_cxn */
   mbedtls_shutdown,                 /* shutdown */
   mbedtls_data_pending,             /* data_pending */
   mbedtls_random,                   /* random */
-  Curl_none_cert_status_request,    /* cert_status_request */
+  NULL,                             /* cert_status_request */
   mbedtls_connect,                  /* connect */
   mbedtls_connect_nonblocking,      /* connect_nonblocking */
   Curl_ssl_adjust_pollset,          /* adjust_pollset */
   mbedtls_get_internals,            /* get_internals */
   mbedtls_close,                    /* close_one */
-  mbedtls_close_all,                /* close_all */
-  Curl_none_set_engine,             /* set_engine */
-  Curl_none_set_engine_default,     /* set_engine_default */
-  Curl_none_engines_list,           /* engines_list */
-  Curl_none_false_start,            /* false_start */
+  NULL,                             /* close_all */
+  NULL,                             /* set_engine */
+  NULL,                             /* set_engine_default */
+  NULL,                             /* engines_list */
+  NULL,                             /* false_start */
   mbedtls_sha256sum,                /* sha256sum */
   NULL,                             /* associate_connection */
   NULL,                             /* disassociate_connection */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5337,7 +5337,7 @@ const struct Curl_ssl Curl_ssl_openssl = {
   ossl_init,                /* init */
   ossl_cleanup,             /* cleanup */
   ossl_version,             /* version */
-  Curl_none_check_cxn,      /* check_cxn */
+  NULL,                     /* check_cxn */
   ossl_shutdown,            /* shutdown */
   ossl_data_pending,        /* data_pending */
   ossl_random,              /* random */
@@ -5351,7 +5351,7 @@ const struct Curl_ssl Curl_ssl_openssl = {
   ossl_set_engine,          /* set_engine */
   ossl_set_engine_default,  /* set_engine_default */
   ossl_engines_list,        /* engines_list */
-  Curl_none_false_start,    /* false_start */
+  NULL,                     /* false_start */
 #if (OPENSSL_VERSION_NUMBER >= 0x0090800fL) && !defined(OPENSSL_NO_SHA256)
   ossl_sha256sum,           /* sha256sum */
 #else

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1076,24 +1076,24 @@ const struct Curl_ssl Curl_ssl_rustls = {
   SSLSUPP_TLS13_CIPHERSUITES,
   sizeof(struct rustls_ssl_backend_data),
 
-  Curl_none_init,                  /* init */
-  Curl_none_cleanup,               /* cleanup */
+  NULL,                            /* init */
+  NULL,                            /* cleanup */
   cr_version,                      /* version */
-  Curl_none_check_cxn,             /* check_cxn */
+  NULL,                            /* check_cxn */
   cr_shutdown,                     /* shutdown */
   cr_data_pending,                 /* data_pending */
   cr_random,                       /* random */
-  Curl_none_cert_status_request,   /* cert_status_request */
+  NULL,                            /* cert_status_request */
   cr_connect_blocking,             /* connect */
   cr_connect_nonblocking,          /* connect_nonblocking */
   Curl_ssl_adjust_pollset,         /* adjust_pollset */
   cr_get_internals,                /* get_internals */
   cr_close,                        /* close_one */
-  Curl_none_close_all,             /* close_all */
-  Curl_none_set_engine,            /* set_engine */
-  Curl_none_set_engine_default,    /* set_engine_default */
-  Curl_none_engines_list,          /* engines_list */
-  Curl_none_false_start,           /* false_start */
+  NULL,                            /* close_all */
+  NULL,                            /* set_engine */
+  NULL,                            /* set_engine_default */
+  NULL,                            /* engines_list */
+  NULL,                            /* false_start */
   NULL,                            /* sha256sum */
   NULL,                            /* associate_connection */
   NULL,                            /* disassociate_connection */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2798,21 +2798,21 @@ const struct Curl_ssl Curl_ssl_schannel = {
   schannel_init,                     /* init */
   schannel_cleanup,                  /* cleanup */
   schannel_version,                  /* version */
-  Curl_none_check_cxn,               /* check_cxn */
+  NULL,                              /* check_cxn */
   schannel_shutdown,                 /* shutdown */
   schannel_data_pending,             /* data_pending */
   schannel_random,                   /* random */
-  Curl_none_cert_status_request,     /* cert_status_request */
+  NULL,                              /* cert_status_request */
   schannel_connect,                  /* connect */
   schannel_connect_nonblocking,      /* connect_nonblocking */
   Curl_ssl_adjust_pollset,           /* adjust_pollset */
   schannel_get_internals,            /* get_internals */
   schannel_close,                    /* close_one */
-  Curl_none_close_all,               /* close_all */
-  Curl_none_set_engine,              /* set_engine */
-  Curl_none_set_engine_default,      /* set_engine_default */
-  Curl_none_engines_list,            /* engines_list */
-  Curl_none_false_start,             /* false_start */
+  NULL,                              /* close_all */
+  NULL,                              /* set_engine */
+  NULL,                              /* set_engine_default */
+  NULL,                              /* engines_list */
+  NULL,                              /* false_start */
   schannel_sha256sum,                /* sha256sum */
   NULL,                              /* associate_connection */
   NULL,                              /* disassociate_connection */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2749,23 +2749,23 @@ const struct Curl_ssl Curl_ssl_sectransp = {
 
   sizeof(struct st_ssl_backend_data),
 
-  Curl_none_init,                     /* init */
-  Curl_none_cleanup,                  /* cleanup */
+  NULLL,                              /* init */
+  NULL,                               /* cleanup */
   sectransp_version,                  /* version */
-  Curl_none_check_cxn,                /* check_cxn */
+  NULL,                               /* check_cxn */
   sectransp_shutdown,                 /* shutdown */
   sectransp_data_pending,             /* data_pending */
   sectransp_random,                   /* random */
-  Curl_none_cert_status_request,      /* cert_status_request */
+  NULL,                               /* cert_status_request */
   sectransp_connect,                  /* connect */
   sectransp_connect_nonblocking,      /* connect_nonblocking */
   Curl_ssl_adjust_pollset,            /* adjust_pollset */
   sectransp_get_internals,            /* get_internals */
   sectransp_close,                    /* close_one */
-  Curl_none_close_all,                /* close_all */
-  Curl_none_set_engine,               /* set_engine */
-  Curl_none_set_engine_default,       /* set_engine_default */
-  Curl_none_engines_list,             /* engines_list */
+  NULL,                               /* close_all */
+  NULL,                               /* set_engine */
+  NULL,                               /* set_engine_default */
+  NULL,                               /* engines_list */
   sectransp_false_start,              /* false_start */
   sectransp_sha256sum,                /* sha256sum */
   NULL,                               /* associate_connection */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2749,7 +2749,7 @@ const struct Curl_ssl Curl_ssl_sectransp = {
 
   sizeof(struct st_ssl_backend_data),
 
-  NULLL,                              /* init */
+  NULL,                               /* init */
   NULL,                               /* cleanup */
   sectransp_version,                  /* version */
   NULL,                               /* check_cxn */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -832,7 +832,7 @@ void Curl_ssl_adjust_pollset(struct Curl_cfilter *cf, struct Curl_easy *data,
 CURLcode Curl_ssl_set_engine(struct Curl_easy *data, const char *engine)
 {
   if(Curl_ssl->set_engine)
-    Curl_ssl->set_engine(data, engine);
+    return Curl_ssl->set_engine(data, engine);
   return CURLE_NOT_BUILT_IN;
 }
 

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -426,7 +426,9 @@ int Curl_ssl_init(void)
     return 1;
   init_ssl = TRUE; /* never again */
 
-  return Curl_ssl->init();
+  if(Curl_ssl->init)
+    return Curl_ssl->init();
+  return 1;
 }
 
 static bool ssl_prefs_check(struct Curl_easy *data)
@@ -799,7 +801,8 @@ void Curl_ssl_close_all(struct Curl_easy *data)
     Curl_safefree(data->state.session);
   }
 
-  Curl_ssl->close_all(data);
+  if(Curl_ssl->close_all)
+    Curl_ssl->close_all(data);
 }
 
 void Curl_ssl_adjust_pollset(struct Curl_cfilter *cf, struct Curl_easy *data,
@@ -828,20 +831,26 @@ void Curl_ssl_adjust_pollset(struct Curl_cfilter *cf, struct Curl_easy *data,
  */
 CURLcode Curl_ssl_set_engine(struct Curl_easy *data, const char *engine)
 {
-  return Curl_ssl->set_engine(data, engine);
+  if(Curl_ssl->set_engine)
+    Curl_ssl->set_engine(data, engine);
+  return CURLE_NOT_BUILT_IN;
 }
 
 /* Selects the default SSL crypto engine
  */
 CURLcode Curl_ssl_set_engine_default(struct Curl_easy *data)
 {
-  return Curl_ssl->set_engine_default(data);
+  if(Curl_ssl->set_engine_default)
+    return Curl_ssl->set_engine_default(data);
+  return CURLE_NOT_BUILT_IN;
 }
 
 /* Return list of OpenSSL crypto engine names. */
 struct curl_slist *Curl_ssl_engines_list(struct Curl_easy *data)
 {
-  return Curl_ssl->engines_list(data);
+  if(Curl_ssl->engines_list)
+    return Curl_ssl->engines_list(data);
+  return NULL;
 }
 
 /*
@@ -1185,96 +1194,18 @@ end:
  */
 bool Curl_ssl_cert_status_request(void)
 {
-  return Curl_ssl->cert_status_request();
+  if(Curl_ssl->cert_status_request)
+    return Curl_ssl->cert_status_request();
+  return FALSE;
 }
 
 /*
  * Check whether the SSL backend supports false start.
  */
-bool Curl_ssl_false_start(struct Curl_easy *data)
+bool Curl_ssl_false_start(void)
 {
-  (void)data;
-  return Curl_ssl->false_start();
-}
-
-/*
- * Default implementations for unsupported functions.
- */
-
-int Curl_none_init(void)
-{
-  return 1;
-}
-
-void Curl_none_cleanup(void)
-{ }
-
-CURLcode Curl_none_shutdown(struct Curl_cfilter *cf UNUSED_PARAM,
-                            struct Curl_easy *data UNUSED_PARAM,
-                            bool send_shutdown UNUSED_PARAM,
-                            bool *done)
-{
-  (void)data;
-  (void)cf;
-  (void)send_shutdown;
-  /* Every SSL backend should have a shutdown implementation. Until we
-   * have implemented that, we put this fake in place. */
-  *done = TRUE;
-  return CURLE_OK;
-}
-
-int Curl_none_check_cxn(struct Curl_cfilter *cf, struct Curl_easy *data)
-{
-  (void)cf;
-  (void)data;
-  return -1;
-}
-
-void Curl_none_close_all(struct Curl_easy *data UNUSED_PARAM)
-{
-  (void)data;
-}
-
-void Curl_none_session_free(void *ptr UNUSED_PARAM)
-{
-  (void)ptr;
-}
-
-bool Curl_none_data_pending(struct Curl_cfilter *cf UNUSED_PARAM,
-                            const struct Curl_easy *data UNUSED_PARAM)
-{
-  (void)cf;
-  (void)data;
-  return 0;
-}
-
-bool Curl_none_cert_status_request(void)
-{
-  return FALSE;
-}
-
-CURLcode Curl_none_set_engine(struct Curl_easy *data UNUSED_PARAM,
-                              const char *engine UNUSED_PARAM)
-{
-  (void)data;
-  (void)engine;
-  return CURLE_NOT_BUILT_IN;
-}
-
-CURLcode Curl_none_set_engine_default(struct Curl_easy *data UNUSED_PARAM)
-{
-  (void)data;
-  return CURLE_NOT_BUILT_IN;
-}
-
-struct curl_slist *Curl_none_engines_list(struct Curl_easy *data UNUSED_PARAM)
-{
-  (void)data;
-  return (struct curl_slist *)NULL;
-}
-
-bool Curl_none_false_start(void)
-{
+  if(Curl_ssl->false_start)
+    return Curl_ssl->false_start();
   return FALSE;
 }
 
@@ -1351,23 +1282,23 @@ static const struct Curl_ssl Curl_ssl_multi = {
   (size_t)-1, /* something insanely large to be on the safe side */
 
   multissl_init,                     /* init */
-  Curl_none_cleanup,                 /* cleanup */
+  NULL,                              /* cleanup */
   multissl_version,                  /* version */
-  Curl_none_check_cxn,               /* check_cxn */
-  Curl_none_shutdown,                /* shutdown */
-  Curl_none_data_pending,            /* data_pending */
+  NULL,                              /* check_cxn */
+  NULL,                              /* shutdown */
+  NULL,                              /* data_pending */
   NULL,                              /* random */
-  Curl_none_cert_status_request,     /* cert_status_request */
+  NULL,                              /* cert_status_request */
   multissl_connect,                  /* connect */
   multissl_connect_nonblocking,      /* connect_nonblocking */
-  multissl_adjust_pollset,          /* adjust_pollset */
+  multissl_adjust_pollset,           /* adjust_pollset */
   multissl_get_internals,            /* get_internals */
   multissl_close,                    /* close_one */
-  Curl_none_close_all,               /* close_all */
-  Curl_none_set_engine,              /* set_engine */
-  Curl_none_set_engine_default,      /* set_engine_default */
-  Curl_none_engines_list,            /* engines_list */
-  Curl_none_false_start,             /* false_start */
+  NULL,                              /* close_all */
+  NULL,                              /* set_engine */
+  NULL,                              /* set_engine_default */
+  NULL,                              /* engines_list */
+  NULL,                              /* false_start */
   NULL,                              /* sha256sum */
   NULL,                              /* associate_connection */
   NULL,                              /* disassociate_connection */
@@ -1432,7 +1363,8 @@ void Curl_ssl_cleanup(void)
 {
   if(init_ssl) {
     /* only cleanup if we did a previous init */
-    Curl_ssl->cleanup();
+    if(Curl_ssl->cleanup)
+      Curl_ssl->cleanup();
 #if defined(CURL_WITH_MULTI_SSL)
     Curl_ssl = &Curl_ssl_multi;
 #endif
@@ -1761,7 +1693,7 @@ static bool ssl_cf_data_pending(struct Curl_cfilter *cf,
   bool result;
 
   CF_DATA_SAVE(save, cf, data);
-  if(Curl_ssl->data_pending(cf, data))
+  if(Curl_ssl->data_pending && Curl_ssl->data_pending(cf, data))
     result = TRUE;
   else
     result = cf->next->cft->has_data_pending(cf->next, data);
@@ -1817,7 +1749,7 @@ static CURLcode ssl_cf_shutdown(struct Curl_cfilter *cf,
   CURLcode result = CURLE_OK;
 
   *done = TRUE;
-  if(!cf->shutdown) {
+  if(!cf->shutdown && Curl_ssl->shut_down) {
     struct cf_call_data save;
 
     CF_DATA_SAVE(save, cf, data);
@@ -1893,8 +1825,7 @@ static CURLcode ssl_cf_query(struct Curl_cfilter *cf,
 static bool cf_ssl_is_alive(struct Curl_cfilter *cf, struct Curl_easy *data,
                             bool *input_pending)
 {
-  struct cf_call_data save;
-  int result;
+  int result = -1;
   /*
    * This function tries to determine connection status.
    *
@@ -1903,9 +1834,12 @@ static bool cf_ssl_is_alive(struct Curl_cfilter *cf, struct Curl_easy *data,
    *     0 means the connection has been closed
    *    -1 means the connection status is unknown
    */
-  CF_DATA_SAVE(save, cf, data);
-  result = Curl_ssl->check_cxn(cf, data);
-  CF_DATA_RESTORE(cf, save);
+  if(Curl_ssl->check_cxn) {
+    struct cf_call_data save;
+    CF_DATA_SAVE(save, cf, data);
+    result = Curl_ssl->check_cxn(cf, data);
+    CF_DATA_RESTORE(cf, save);
+  }
   if(result > 0) {
     *input_pending = TRUE;
     return TRUE;

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -192,7 +192,7 @@ CURLcode Curl_pin_peer_pubkey(struct Curl_easy *data,
 
 bool Curl_ssl_cert_status_request(void);
 
-bool Curl_ssl_false_start(struct Curl_easy *data);
+bool Curl_ssl_false_start(void);
 
 /* The maximum size of the SSL channel binding is 85 bytes, as defined in
  * RFC 5929, Section 4.1. The 'tls-server-end-point:' prefix is 21 bytes long,

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -278,7 +278,7 @@ extern struct Curl_cftype Curl_cft_ssl_proxy;
 #define Curl_ssl_kill_session(x) Curl_nop_stmt
 #define Curl_ssl_random(x,y,z) ((void)x, CURLE_NOT_BUILT_IN)
 #define Curl_ssl_cert_status_request() FALSE
-#define Curl_ssl_false_start(a) FALSE
+#define Curl_ssl_false_start() FALSE
 #define Curl_ssl_get_internals(a,b,c,d) NULL
 #define Curl_ssl_supports(a,b) FALSE
 #define Curl_ssl_cfilter_add(a,b,c) CURLE_NOT_BUILT_IN

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -190,23 +190,8 @@ struct Curl_ssl {
 
 extern const struct Curl_ssl *Curl_ssl;
 
-
-int Curl_none_init(void);
-void Curl_none_cleanup(void);
-CURLcode Curl_none_shutdown(struct Curl_cfilter *cf, struct Curl_easy *data,
-                            bool send_shutdown, bool *done);
-int Curl_none_check_cxn(struct Curl_cfilter *cf, struct Curl_easy *data);
-void Curl_none_close_all(struct Curl_easy *data);
-void Curl_none_session_free(void *ptr);
-bool Curl_none_data_pending(struct Curl_cfilter *cf,
-                            const struct Curl_easy *data);
-bool Curl_none_cert_status_request(void);
-CURLcode Curl_none_set_engine(struct Curl_easy *data, const char *engine);
-CURLcode Curl_none_set_engine_default(struct Curl_easy *data);
-struct curl_slist *Curl_none_engines_list(struct Curl_easy *data);
-bool Curl_none_false_start(void);
 void Curl_ssl_adjust_pollset(struct Curl_cfilter *cf, struct Curl_easy *data,
-                              struct easy_pollset *ps);
+                             struct easy_pollset *ps);
 
 /**
  * Get the SSL filter below the given one or NULL if there is none.

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2031,21 +2031,21 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   wolfssl_init,                    /* init */
   wolfssl_cleanup,                 /* cleanup */
   wolfssl_version,                 /* version */
-  Curl_none_check_cxn,             /* check_cxn */
+  NULL,                            /* check_cxn */
   wolfssl_shutdown,                /* shutdown */
   wolfssl_data_pending,            /* data_pending */
   wolfssl_random,                  /* random */
-  Curl_none_cert_status_request,   /* cert_status_request */
+  NULL,                            /* cert_status_request */
   wolfssl_connect,                 /* connect */
   wolfssl_connect_nonblocking,     /* connect_nonblocking */
   Curl_ssl_adjust_pollset,         /* adjust_pollset */
   wolfssl_get_internals,           /* get_internals */
   wolfssl_close,                   /* close_one */
-  Curl_none_close_all,             /* close_all */
-  Curl_none_set_engine,            /* set_engine */
-  Curl_none_set_engine_default,    /* set_engine_default */
-  Curl_none_engines_list,          /* engines_list */
-  Curl_none_false_start,           /* false_start */
+  NULL,                            /* close_all */
+  NULL,                            /* set_engine */
+  NULL,                            /* set_engine_default */
+  NULL,                            /* engines_list */
+  NULL,                            /* false_start */
   wolfssl_sha256sum,               /* sha256sum */
   NULL,                            /* associate_connection */
   NULL,                            /* disassociate_connection */


### PR DESCRIPTION
For TLS backends that don't need these functions, they now use plain NULL pointers instead of setting a function that does nothing.

Helps making it clearer that a specific TLS handler does not provide anything specific for that action.