### PR TITLE
cmake: drop redundant opening/closing `.*` from `MATCH` expressions

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -99,7 +99,7 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
       string(REGEX REPLACE " +-([^I][^ \\t;]*)" ";-\\1" _GSS_CFLAGS "${_GSS_CFLAGS}")
 
       foreach(_flag IN LISTS _GSS_CFLAGS)
-        if(_flag MATCHES "^-I.*")
+        if(_flag MATCHES "^-I")
           string(REGEX REPLACE "^-I" "" _val "${_flag}")
           list(APPEND _GSS_INCLUDE_DIRS "${_val}")
         else()
@@ -123,10 +123,10 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
       string(REGEX REPLACE " +-([^Ll][^ \\t;]*)" ";-\\1" _gss_lib_flags "${_gss_lib_flags}")
 
       foreach(_flag IN LISTS _gss_lib_flags)
-        if(_flag MATCHES "^-l.*")
+        if(_flag MATCHES "^-l")
           string(REGEX REPLACE "^-l" "" _val "${_flag}")
           list(APPEND _GSS_LIBRARIES "${_val}")
-        elseif(_flag MATCHES "^-L.*")
+        elseif(_flag MATCHES "^-L")
           string(REGEX REPLACE "^-L" "" _val "${_flag}")
           list(APPEND _GSS_LIBRARY_DIRS "${_val}")
         endif()
@@ -156,7 +156,7 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
     if(_gss_configure_failed)
       set(GSS_FLAVOUR "Heimdal")  # most probably, should not really matter
     else()
-      if(_gss_vendor MATCHES ".*H|heimdal.*")
+      if(_gss_vendor MATCHES "H|heimdal")
         set(GSS_FLAVOUR "Heimdal")
       else()
         set(GSS_FLAVOUR "MIT")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,8 +199,8 @@ if(WIN32)
   # Detect actual value of _WIN32_WINNT and store as HAVE_WIN32_WINNT
   curl_internal_test(HAVE_WIN32_WINNT)
   if(HAVE_WIN32_WINNT)
-    string(REGEX MATCH ".*_WIN32_WINNT=0x[0-9a-fA-F]+" CURL_TEST_OUTPUT "${CURL_TEST_OUTPUT}")
-    string(REGEX REPLACE ".*_WIN32_WINNT=" "" CURL_TEST_OUTPUT "${CURL_TEST_OUTPUT}")
+    string(REGEX MATCH "_WIN32_WINNT=0x[0-9a-fA-F]+" CURL_TEST_OUTPUT "${CURL_TEST_OUTPUT}")
+    string(REGEX REPLACE "_WIN32_WINNT=" "" CURL_TEST_OUTPUT "${CURL_TEST_OUTPUT}")
     string(REGEX REPLACE "0x([0-9a-f][0-9a-f][0-9a-f])$" "0x0\\1" CURL_TEST_OUTPUT "${CURL_TEST_OUTPUT}")  # pad to 4 digits
     string(TOLOWER "${CURL_TEST_OUTPUT}" HAVE_WIN32_WINNT)
     message(STATUS "Found _WIN32_WINNT=${HAVE_WIN32_WINNT}")
@@ -2198,7 +2198,7 @@ if(NOT CURL_DISABLE_INSTALL)
     endif()
     if(_lib MATCHES "^-")  # '-framework <name>'
       list(APPEND _ldflags "${_lib}")
-    elseif(_lib MATCHES ".*/.*")
+    elseif(_lib MATCHES "/")
       # This gets a bit more complex, because we want to specify the
       # directory separately, and only once per directory
       get_filename_component(_libdir ${_lib} DIRECTORY)


### PR DESCRIPTION
Also from a corresponding `REPLACE` expression.

CMake matches expressions anywhere within the value without an explicit
`.*`.

https://cmake.org/cmake/help/latest/command/if.html#matches
https://cmake.org/cmake/help/latest/command/string.html#regex-match