### PR TITLE
vtls: remove unusued 'check_cxn' from TLS handler struct

### DIFF
--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -1157,7 +1157,6 @@ const struct Curl_ssl Curl_ssl_bearssl = {
   NULL,                            /* init */
   NULL,                            /* cleanup */
   bearssl_version,                 /* version */
-  NULL,                            /* check_cxn */
   bearssl_shutdown,                /* shutdown */
   bearssl_data_pending,            /* data_pending */
   bearssl_random,                  /* random */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -2269,7 +2269,6 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   gtls_init,                     /* init */
   gtls_cleanup,                  /* cleanup */
   gtls_version,                  /* version */
-  NULL,                          /* check_cxn */
   gtls_shutdown,                 /* shutdown */
   gtls_data_pending,             /* data_pending */
   gtls_random,                   /* random */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1643,7 +1643,6 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   mbedtls_init,                     /* init */
   mbedtls_cleanup,                  /* cleanup */
   mbedtls_version,                  /* version */
-  NULL,                             /* check_cxn */
   mbedtls_shutdown,                 /* shutdown */
   mbedtls_data_pending,             /* data_pending */
   mbedtls_random,                   /* random */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5337,7 +5337,6 @@ const struct Curl_ssl Curl_ssl_openssl = {
   ossl_init,                /* init */
   ossl_cleanup,             /* cleanup */
   ossl_version,             /* version */
-  NULL,                     /* check_cxn */
   ossl_shutdown,            /* shutdown */
   ossl_data_pending,        /* data_pending */
   ossl_random,              /* random */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1079,7 +1079,6 @@ const struct Curl_ssl Curl_ssl_rustls = {
   NULL,                            /* init */
   NULL,                            /* cleanup */
   cr_version,                      /* version */
-  NULL,                            /* check_cxn */
   cr_shutdown,                     /* shutdown */
   cr_data_pending,                 /* data_pending */
   cr_random,                       /* random */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2798,7 +2798,6 @@ const struct Curl_ssl Curl_ssl_schannel = {
   schannel_init,                     /* init */
   schannel_cleanup,                  /* cleanup */
   schannel_version,                  /* version */
-  NULL,                              /* check_cxn */
   schannel_shutdown,                 /* shutdown */
   schannel_data_pending,             /* data_pending */
   schannel_random,                   /* random */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2752,7 +2752,6 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   NULL,                               /* init */
   NULL,                               /* cleanup */
   sectransp_version,                  /* version */
-  NULL,                               /* check_cxn */
   sectransp_shutdown,                 /* shutdown */
   sectransp_data_pending,             /* data_pending */
   sectransp_random,                   /* random */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1284,7 +1284,6 @@ static const struct Curl_ssl Curl_ssl_multi = {
   multissl_init,                     /* init */
   NULL,                              /* cleanup */
   multissl_version,                  /* version */
-  NULL,                              /* check_cxn */
   NULL,                              /* shutdown */
   NULL,                              /* data_pending */
   NULL,                              /* random */
@@ -1825,30 +1824,9 @@ static CURLcode ssl_cf_query(struct Curl_cfilter *cf,
 static bool cf_ssl_is_alive(struct Curl_cfilter *cf, struct Curl_easy *data,
                             bool *input_pending)
 {
-  int result = -1;
   /*
    * This function tries to determine connection status.
-   *
-   * Return codes:
-   *     1 means the connection is still in place
-   *     0 means the connection has been closed
-   *    -1 means the connection status is unknown
    */
-  if(Curl_ssl->check_cxn) {
-    struct cf_call_data save;
-    CF_DATA_SAVE(save, cf, data);
-    result = Curl_ssl->check_cxn(cf, data);
-    CF_DATA_RESTORE(cf, save);
-  }
-  if(result > 0) {
-    *input_pending = TRUE;
-    return TRUE;
-  }
-  if(result == 0) {
-    *input_pending = FALSE;
-    return FALSE;
-  }
-  /* ssl backend does not know */
   return cf->next ?
     cf->next->cft->is_alive(cf->next, data, input_pending) :
     FALSE; /* pessimistic in absence of data */

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -142,7 +142,6 @@ struct Curl_ssl {
   void (*cleanup)(void);
 
   size_t (*version)(char *buffer, size_t size);
-  int (*check_cxn)(struct Curl_cfilter *cf, struct Curl_easy *data);
   CURLcode (*shut_down)(struct Curl_cfilter *cf, struct Curl_easy *data,
                         bool send_shutdown, bool *done);
   bool (*data_pending)(struct Curl_cfilter *cf,

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2031,7 +2031,6 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   wolfssl_init,                    /* init */
   wolfssl_cleanup,                 /* cleanup */
   wolfssl_version,                 /* version */
-  NULL,                            /* check_cxn */
   wolfssl_shutdown,                /* shutdown */
   wolfssl_data_pending,            /* data_pending */
   wolfssl_random,                  /* random */


### PR DESCRIPTION
The last use was removed in 7c5637b8b4