### PR TITLE
vtls: remove 'detach/attach' functions from TLS handler struct

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -644,7 +644,8 @@ CURLcode Curl_conn_cf_cntrl(struct Curl_cfilter *cf,
   for(; cf; cf = cf->next) {
     if(Curl_cf_def_cntrl == cf->cft->cntrl)
       continue;
-    result = cf->cft->cntrl(cf, data, event, arg1, arg2);
+    if(cf->cft->cntrl)
+      result = cf->cft->cntrl(cf, data, event, arg1, arg2);
     if(!ignore_result && result)
       break;
   }

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -644,8 +644,7 @@ CURLcode Curl_conn_cf_cntrl(struct Curl_cfilter *cf,
   for(; cf; cf = cf->next) {
     if(Curl_cf_def_cntrl == cf->cft->cntrl)
       continue;
-    if(cf->cft->cntrl)
-      result = cf->cft->cntrl(cf, data, event, arg1, arg2);
+    result = cf->cft->cntrl(cf, data, event, arg1, arg2);
     if(!ignore_result && result)
       break;
   }

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -1172,8 +1172,6 @@ const struct Curl_ssl Curl_ssl_bearssl = {
   NULL,                            /* engines_list */
   NULL,                            /* false_start */
   bearssl_sha256sum,               /* sha256sum */
-  NULL,                            /* associate_connection */
-  NULL,                            /* disassociate_connection */
   bearssl_recv,                    /* recv decrypted data */
   bearssl_send,                    /* send data to encrypt */
   NULL,                            /* get_channel_binding */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -2284,8 +2284,6 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   NULL,                          /* engines_list */
   NULL,                          /* false_start */
   gtls_sha256sum,                /* sha256sum */
-  NULL,                          /* associate_connection */
-  NULL,                          /* disassociate_connection */
   gtls_recv,                     /* recv decrypted data */
   gtls_send,                     /* send data to encrypt */
   NULL,                          /* get_channel_binding */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1658,8 +1658,6 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   NULL,                             /* engines_list */
   NULL,                             /* false_start */
   mbedtls_sha256sum,                /* sha256sum */
-  NULL,                             /* associate_connection */
-  NULL,                             /* disassociate_connection */
   mbed_recv,                        /* recv decrypted data */
   mbed_send,                        /* send data to encrypt */
   NULL,                             /* get_channel_binding */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5356,8 +5356,6 @@ const struct Curl_ssl Curl_ssl_openssl = {
 #else
   NULL,                     /* sha256sum */
 #endif
-  NULL,                     /* use of data in this connection */
-  NULL,                     /* remote of data from this connection */
   ossl_recv,                /* recv decrypted data */
   ossl_send,                /* send data to encrypt */
   ossl_get_channel_binding  /* get_channel_binding */

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1094,8 +1094,6 @@ const struct Curl_ssl Curl_ssl_rustls = {
   NULL,                            /* engines_list */
   NULL,                            /* false_start */
   NULL,                            /* sha256sum */
-  NULL,                            /* associate_connection */
-  NULL,                            /* disassociate_connection */
   cr_recv,                         /* recv decrypted data */
   cr_send,                         /* send data to encrypt */
   NULL,                            /* get_channel_binding */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2813,8 +2813,6 @@ const struct Curl_ssl Curl_ssl_schannel = {
   NULL,                              /* engines_list */
   NULL,                              /* false_start */
   schannel_sha256sum,                /* sha256sum */
-  NULL,                              /* associate_connection */
-  NULL,                              /* disassociate_connection */
   schannel_recv,                     /* recv decrypted data */
   schannel_send,                     /* send data to encrypt */
   NULL,                              /* get_channel_binding */

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -2767,8 +2767,6 @@ const struct Curl_ssl Curl_ssl_sectransp = {
   NULL,                               /* engines_list */
   sectransp_false_start,              /* false_start */
   sectransp_sha256sum,                /* sha256sum */
-  NULL,                               /* associate_connection */
-  NULL,                               /* disassociate_connection */
   sectransp_recv,                     /* recv decrypted data */
   sectransp_send,                     /* send data to encrypt */
   NULL,                               /* get_channel_binding */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1847,7 +1847,7 @@ struct Curl_cftype Curl_cft_ssl_proxy = {
   ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,
-  NULL,
+  ssl_cf_cntrl,
   cf_ssl_is_alive,
   Curl_cf_def_conn_keep_alive,
   Curl_cf_def_query,

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1299,8 +1299,6 @@ static const struct Curl_ssl Curl_ssl_multi = {
   NULL,                              /* engines_list */
   NULL,                              /* false_start */
   NULL,                              /* sha256sum */
-  NULL,                              /* associate_connection */
-  NULL,                              /* disassociate_connection */
   multissl_recv_plain,               /* recv decrypted data */
   multissl_send_plain,               /* send data to encrypt */
   NULL,                              /* get_channel_binding */
@@ -1771,35 +1769,6 @@ static void ssl_cf_adjust_pollset(struct Curl_cfilter *cf,
   CF_DATA_RESTORE(cf, save);
 }
 
-static CURLcode ssl_cf_cntrl(struct Curl_cfilter *cf,
-                             struct Curl_easy *data,
-                             int event, int arg1, void *arg2)
-{
-  struct cf_call_data save;
-
-  (void)arg1;
-  (void)arg2;
-  switch(event) {
-  case CF_CTRL_DATA_ATTACH:
-    if(Curl_ssl->attach_data) {
-      CF_DATA_SAVE(save, cf, data);
-      Curl_ssl->attach_data(cf, data);
-      CF_DATA_RESTORE(cf, save);
-    }
-    break;
-  case CF_CTRL_DATA_DETACH:
-    if(Curl_ssl->detach_data) {
-      CF_DATA_SAVE(save, cf, data);
-      Curl_ssl->detach_data(cf, data);
-      CF_DATA_RESTORE(cf, save);
-    }
-    break;
-  default:
-    break;
-  }
-  return CURLE_OK;
-}
-
 static CURLcode ssl_cf_query(struct Curl_cfilter *cf,
                              struct Curl_easy *data,
                              int query, int *pres1, void *pres2)
@@ -1845,7 +1814,7 @@ struct Curl_cftype Curl_cft_ssl = {
   ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,
-  ssl_cf_cntrl,
+  NULL,
   cf_ssl_is_alive,
   Curl_cf_def_conn_keep_alive,
   ssl_cf_query,
@@ -1866,7 +1835,7 @@ struct Curl_cftype Curl_cft_ssl_proxy = {
   ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,
-  ssl_cf_cntrl,
+  NULL,
   cf_ssl_is_alive,
   Curl_cf_def_conn_keep_alive,
   Curl_cf_def_query,

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1801,6 +1801,19 @@ static bool cf_ssl_is_alive(struct Curl_cfilter *cf, struct Curl_easy *data,
     FALSE; /* pessimistic in absence of data */
 }
 
+/* do nothing */
+static CURLcode ssl_cf_cntrl(struct Curl_cfilter *cf, struct Curl_easy *data,
+                             int event, int arg1, void *arg2)
+{
+  (void)cf;
+  (void)data;
+  (void)event;
+  (void)arg1;
+  (void)arg2;
+  return CURLE_OK;
+}
+
+
 struct Curl_cftype Curl_cft_ssl = {
   "SSL",
   CF_TYPE_SSL,
@@ -1814,7 +1827,7 @@ struct Curl_cftype Curl_cft_ssl = {
   ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,
-  NULL,
+  ssl_cf_cntrl,
   cf_ssl_is_alive,
   Curl_cf_def_conn_keep_alive,
   ssl_cf_query,

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1769,6 +1769,18 @@ static void ssl_cf_adjust_pollset(struct Curl_cfilter *cf,
   CF_DATA_RESTORE(cf, save);
 }
 
+static CURLcode ssl_cf_cntrl(struct Curl_cfilter *cf,
+                             struct Curl_easy *data,
+                             int event, int arg1, void *arg2)
+{
+  (void)cf;
+  (void)data;
+  (void)event;
+  (void)arg1;
+  (void)arg2;
+  return CURLE_OK;
+}
+
 static CURLcode ssl_cf_query(struct Curl_cfilter *cf,
                              struct Curl_easy *data,
                              int query, int *pres1, void *pres2)
@@ -1800,19 +1812,6 @@ static bool cf_ssl_is_alive(struct Curl_cfilter *cf, struct Curl_easy *data,
     cf->next->cft->is_alive(cf->next, data, input_pending) :
     FALSE; /* pessimistic in absence of data */
 }
-
-/* do nothing */
-static CURLcode ssl_cf_cntrl(struct Curl_cfilter *cf, struct Curl_easy *data,
-                             int event, int arg1, void *arg2)
-{
-  (void)cf;
-  (void)data;
-  (void)event;
-  (void)arg1;
-  (void)arg2;
-  return CURLE_OK;
-}
-
 
 struct Curl_cftype Curl_cft_ssl = {
   "SSL",

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1769,18 +1769,6 @@ static void ssl_cf_adjust_pollset(struct Curl_cfilter *cf,
   CF_DATA_RESTORE(cf, save);
 }
 
-static CURLcode ssl_cf_cntrl(struct Curl_cfilter *cf,
-                             struct Curl_easy *data,
-                             int event, int arg1, void *arg2)
-{
-  (void)cf;
-  (void)data;
-  (void)event;
-  (void)arg1;
-  (void)arg2;
-  return CURLE_OK;
-}
-
 static CURLcode ssl_cf_query(struct Curl_cfilter *cf,
                              struct Curl_easy *data,
                              int query, int *pres1, void *pres2)
@@ -1826,7 +1814,7 @@ struct Curl_cftype Curl_cft_ssl = {
   ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,
-  ssl_cf_cntrl,
+  Curl_cf_def_cntrl,
   cf_ssl_is_alive,
   Curl_cf_def_conn_keep_alive,
   ssl_cf_query,
@@ -1847,7 +1835,7 @@ struct Curl_cftype Curl_cft_ssl_proxy = {
   ssl_cf_data_pending,
   ssl_cf_send,
   ssl_cf_recv,
-  ssl_cf_cntrl,
+  Curl_cf_def_cntrl,
   cf_ssl_is_alive,
   Curl_cf_def_conn_keep_alive,
   Curl_cf_def_query,

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -173,10 +173,6 @@ struct Curl_ssl {
   bool (*false_start)(void);
   CURLcode (*sha256sum)(const unsigned char *input, size_t inputlen,
                     unsigned char *sha256sum, size_t sha256sumlen);
-
-  bool (*attach_data)(struct Curl_cfilter *cf, struct Curl_easy *data);
-  void (*detach_data)(struct Curl_cfilter *cf, struct Curl_easy *data);
-
   ssize_t (*recv_plain)(struct Curl_cfilter *cf, struct Curl_easy *data,
                         char *buf, size_t len, CURLcode *code);
   ssize_t (*send_plain)(struct Curl_cfilter *cf, struct Curl_easy *data,

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2046,8 +2046,6 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   NULL,                            /* engines_list */
   NULL,                            /* false_start */
   wolfssl_sha256sum,               /* sha256sum */
-  NULL,                            /* associate_connection */
-  NULL,                            /* disassociate_connection */
   wolfssl_recv,                    /* recv decrypted data */
   wolfssl_send,                    /* send data to encrypt */
   NULL,                            /* get_channel_binding */


### PR DESCRIPTION
Unused since 7c8bae0d9c9b2dfeeb