### PR TITLE
config-mac: drop `MACOS_SSL_SUPPORT` macro

### DIFF
--- a/lib/config-mac.h
+++ b/lib/config-mac.h
@@ -65,10 +65,6 @@
 
 #define HAVE_SIGACTION          1
 
-#ifdef MACOS_SSL_SUPPORT
-#  define USE_OPENSSL           1
-#endif
-
 #define CURL_DISABLE_LDAP       1
 
 #define HAVE_IOCTL_FIONBIO      1


### PR DESCRIPTION
It has been a synonym for `USE_OPENSSL` since
709cf76f6bb7dbaca14e3e8df160ccfac04dcecb (2015).

The few uses of this on GitHub also set `USE_OPENSSL` and
should be fine. Those which don't, please replace
`-DMACOS_SSL_SUPPORT` with `-DUSE_OPENSSL`.
