### PR TITLE
http_aws_sigv4: Fix invalid compare function handling zero-length pairs

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -435,6 +435,8 @@ static int compare_func(const void *a, const void *b)
   const struct pair *aa = a;
   const struct pair *bb = b;
   /* If one element is empty, the other is always sorted higher */
+  if(aa->len == 0 && bb->len == 0)
+    return 0;
   if(aa->len == 0)
     return -1;
   if(bb->len == 0)


### PR DESCRIPTION
The compare_func() can violate the antisymmetric property required by qsort. Specifically, when both aa->len == 0 and bb->len == 0, the function returns conflicting results (-1 for compare_func(a, b) and -1 for compare_func(b, a)).

This violates the rules of qsort and may lead to undefined behavior, including incorrect sorting or memory corruption in glibc [1].

Add a check to return 0 when both lengths are zero, ensuring proper behavior and preventing undefined behavior in the sorting process.

Ref: https://www.qualys.com/2024/01/30/qsort.txt [1]