### PR TITLE
gitignore: ignore output files created by mk-ca-bundle.pl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ aclocal.m4
 aclocal.m4.bak
 autom4te.cache
 buildinfo.txt
+ca-bundle.crt
+certdata.txt
 compile
 config.cache
 config.guess


### PR DESCRIPTION
- Ignore mk-ca-bundle.pl's default output files scripts/ca-bundle.crt and scripts/certdata.txt.

Closes #xxxx