### PR TITLE
examples: make them compile with compatibility functions disabled (Windows)

### DIFF
--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -34,11 +34,9 @@
 #include <curl/curl.h>
 
 #ifdef _WIN32
-#  define stat _stat
-#  define fstat _fstat
-#  define FILENO(fp) _fileno(fp)
-#else
-#  define FILENO(fp) fileno(fp)
+#define stat _stat
+#define fstat _fstat
+#define fileno _fileno
 #endif
 
 #if LIBCURL_VERSION_NUM < 0x070c03
@@ -100,7 +98,7 @@ int main(int argc, char **argv)
 
   /* get the file size of the local file */
   fp = fopen(file, "rb");
-  fstat(FILENO(fp), &file_info);
+  fstat(fileno(fp), &file_info);
 
   /* In Windows, this inits the Winsock stuff */
   curl_global_init(CURL_GLOBAL_ALL);

--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -34,6 +34,7 @@
 #include <curl/curl.h>
 
 #ifdef _WIN32
+#  define stat _stat
 #  define FILENO(fp) _fileno(fp)
 #else
 #  define FILENO(fp) fileno(fp)

--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -35,6 +35,7 @@
 
 #ifdef _WIN32
 #  define stat _stat
+#  define fstat _fstat
 #  define FILENO(fp) _fileno(fp)
 #else
 #  define FILENO(fp) fileno(fp)

--- a/docs/examples/anyauthput.c
+++ b/docs/examples/anyauthput.c
@@ -34,7 +34,9 @@
 #include <curl/curl.h>
 
 #ifdef _WIN32
+#undef stat
 #define stat _stat
+#undef fstat
 #define fstat _fstat
 #define fileno _fileno
 #endif

--- a/docs/examples/fileupload.c
+++ b/docs/examples/fileupload.c
@@ -33,6 +33,7 @@
 #ifdef _WIN32
 #define stat _stat
 #define fstat _fstat
+#define fileno _fileno
 #endif
 
 int main(void)

--- a/docs/examples/fileupload.c
+++ b/docs/examples/fileupload.c
@@ -31,7 +31,9 @@
 #include <fcntl.h>
 
 #ifdef _WIN32
+#undef stat
 #define stat _stat
+#undef fstat
 #define fstat _fstat
 #define fileno _fileno
 #endif

--- a/docs/examples/fileupload.c
+++ b/docs/examples/fileupload.c
@@ -32,6 +32,7 @@
 
 #ifdef _WIN32
 #define stat _stat
+#define fstat _fstat
 #endif
 
 int main(void)

--- a/docs/examples/fileupload.c
+++ b/docs/examples/fileupload.c
@@ -30,6 +30,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#ifdef _WIN32
+#define stat _stat
+#endif
+
 int main(void)
 {
   CURL *curl;

--- a/docs/examples/ftpupload.c
+++ b/docs/examples/ftpupload.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #ifdef _WIN32
 #include <io.h>
+#undef stat
 #define stat _stat
 #else
 #include <unistd.h>

--- a/docs/examples/ftpupload.c
+++ b/docs/examples/ftpupload.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #ifdef _WIN32
 #include <io.h>
+#define stat _stat
 #else
 #include <unistd.h>
 #endif

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -38,6 +38,10 @@
 #include <unistd.h>
 #endif
 
+#ifdef _WIN32
+#define stat _stat
+#endif
+
 /* curl stuff */
 #include <curl/curl.h>
 #include <curl/mprintf.h>

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -39,6 +39,7 @@
 #endif
 
 #ifdef _WIN32
+#undef stat
 #define stat _stat
 #endif
 

--- a/docs/examples/httpput.c
+++ b/docs/examples/httpput.c
@@ -31,6 +31,7 @@
 #include <curl/curl.h>
 
 #ifdef _WIN32
+#undef stat
 #define stat _stat
 #endif
 

--- a/docs/examples/httpput.c
+++ b/docs/examples/httpput.c
@@ -30,6 +30,10 @@
 #include <sys/stat.h>
 #include <curl/curl.h>
 
+#ifdef _WIN32
+#define stat _stat
+#endif
+
 /*
  * This example shows an HTTP PUT operation. PUTs a file given as a command
  * line argument to the URL also given on the command line.

--- a/tests/http/clients/hx-download.c
+++ b/tests/http/clients/hx-download.c
@@ -37,6 +37,10 @@
 #include <unistd.h>  /* getopt() */
 #endif
 
+#ifdef _WIN32
+#define strdup _strdup
+#endif
+
 #ifndef CURLPIPE_MULTIPLEX
 #error "too old libcurl, cannot do HTTP/2 server push!"
 #endif


### PR DESCRIPTION
For MinGW this is `-DNO_OLDNAMES`, with MSVC it is
`-D_CRT_DECLARE_NONSTDC_NAMES=0`.

There have been some support for this before this patch.
After this patch this is extended to all examples.

(And also the standalone http/client programs, if here.)

Cherry-picked from #15652
