### PR TITLE
tidy-up: misc

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -147,19 +147,17 @@ int main(void) { return 0; }
 #endif
 
 #ifdef HAVE_FILE_OFFSET_BITS
-#ifdef _FILE_OFFSET_BITS
 #undef _FILE_OFFSET_BITS
-#endif
 #define _FILE_OFFSET_BITS 64
 #include <sys/types.h>
- /* Check that off_t can represent 2**63 - 1 correctly.
-    We cannot simply define LARGE_OFF_T to be 9223372036854775807,
-    since some C++ compilers masquerading as C compilers
-    incorrectly reject 9223372036854775807.  */
+/* Check that off_t can represent 2**63 - 1 correctly.
+   We cannot simply define LARGE_OFF_T to be 9223372036854775807,
+   since some C++ compilers masquerading as C compilers
+   incorrectly reject 9223372036854775807.  */
 #define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
-  int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
-                       && LARGE_OFF_T % 2147483647 == 1)
-                      ? 1 : -1];
+int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
+                     && LARGE_OFF_T % 2147483647 == 1)
+                    ? 1 : -1];
 int main(void) { return 0; }
 #endif
 

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -153,7 +153,7 @@ int main(void) { return 0; }
 /* Check that off_t can represent 2**63 - 1 correctly.
    We cannot simply define LARGE_OFF_T to be 9223372036854775807,
    since some C++ compilers masquerading as C compilers
-   incorrectly reject 9223372036854775807.  */
+   incorrectly reject 9223372036854775807. */
 #define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
 int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
                      && LARGE_OFF_T % 2147483647 == 1)

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -342,7 +342,7 @@ April: added the cyassl backend (later renamed to wolfSSL)
 
  July: OSS-Fuzz started fuzzing libcurl
 
- September: Added Multi-SSL support
+ September: Added MultiSSL support
 
  The website serves 3100 GB/month
 

--- a/docs/examples/httpput-postfields.c
+++ b/docs/examples/httpput-postfields.c
@@ -27,7 +27,6 @@
  */
 #include <stdio.h>
 #include <fcntl.h>
-#include <sys/stat.h>
 #include <curl/curl.h>
 
 static const char olivertwist[]=

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -948,7 +948,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
     defined(USE_QUICHE) || defined(USE_MSH3)
 
 #ifdef CURL_WITH_MULTI_SSL
-#error "Multi-SSL combined with QUIC is not supported"
+#error "MultiSSL combined with QUIC is not supported"
 #endif
 
 #define USE_HTTP3

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -53,7 +53,7 @@ int Curl_pipe(curl_socket_t socks[2], bool nonblocking)
     return -1;
 #ifdef HAVE_FCNTL
   if(fcntl(socks[0], F_SETFD, FD_CLOEXEC) ||
-     fcntl(socks[1], F_SETFD, FD_CLOEXEC) ) {
+     fcntl(socks[1], F_SETFD, FD_CLOEXEC)) {
     close(socks[0]);
     close(socks[1]);
     socks[0] = socks[1] = CURL_SOCKET_BAD;

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -39,11 +39,6 @@
 
 #include "memdebug.h" /* keep this as LAST include */
 
-#ifdef O_BINARY
-#define CURL_O_BINARY O_BINARY
-#else
-#define CURL_O_BINARY 0
-#endif
 #ifdef _WIN32
 #define OPENMODE S_IREAD | S_IWRITE
 #else

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -46,11 +46,11 @@
 #  undef  PATH_MAX
 #  define PATH_MAX MAX_PATH
 
-#  define _use_lfn(f) (1)   /* long filenames always available */
+#  define _use_lfn(f) (1)  /* long filenames always available */
 #elif !defined(__DJGPP__) || (__DJGPP__ < 2)  /* DJGPP 2.0 has _use_lfn() */
 #  define _use_lfn(f) (0)  /* long filenames never available */
 #elif defined(__DJGPP__)
-#  include <fcntl.h>                /* _use_lfn(f) prototype */
+#  include <fcntl.h>       /* _use_lfn(f) prototype */
 #endif
 
 #ifdef MSDOS

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -45,7 +45,15 @@
 #ifdef _WIN32
 #  undef  PATH_MAX
 #  define PATH_MAX MAX_PATH
+
+#  define _use_lfn(f) (1)   /* long filenames always available */
+#elif !defined(__DJGPP__) || (__DJGPP__ < 2)  /* DJGPP 2.0 has _use_lfn() */
+#  define _use_lfn(f) (0)  /* long filenames never available */
+#elif defined(__DJGPP__)
+#  include <fcntl.h>                /* _use_lfn(f) prototype */
 #endif
+
+#ifdef MSDOS
 
 #ifndef S_ISCHR
 #  ifdef S_IFCHR
@@ -55,15 +63,6 @@
 #  endif
 #endif
 
-#ifdef _WIN32
-#  define _use_lfn(f) (1)   /* long filenames always available */
-#elif !defined(__DJGPP__) || (__DJGPP__ < 2)  /* DJGPP 2.0 has _use_lfn() */
-#  define _use_lfn(f) (0)  /* long filenames never available */
-#elif defined(__DJGPP__)
-#  include <fcntl.h>                /* _use_lfn(f) prototype */
-#endif
-
-#ifdef MSDOS
 /* only used by msdosify() */
 static SANITIZEcode truncate_dryrun(const char *path,
                                     const size_t truncate_pos);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -111,14 +111,6 @@ extern const unsigned char curl_ca_embed[];
 #endif
 #endif
 
-/* since O_BINARY is used in bitmasks, setting it to zero makes it usable in
-   source code but yet it does not ruin anything */
-#ifdef O_BINARY
-#define CURL_O_BINARY O_BINARY
-#else
-#define CURL_O_BINARY 0
-#endif
-
 #ifndef SOL_IP
 #  define SOL_IP IPPROTO_IP
 #endif

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -66,6 +66,14 @@ extern FILE *tool_stderr;
 #  include "tool_strdup.h"
 #endif
 
+/* since O_BINARY is used in bitmasks, setting it to zero makes it usable in
+   source code but yet it does not ruin anything */
+#ifdef O_BINARY
+#define CURL_O_BINARY O_BINARY
+#else
+#define CURL_O_BINARY 0
+#endif
+
 #if defined(_WIN32)
 #  define CURL_STRICMP(p1, p2)  _stricmp(p1, p2)
 #elif defined(HAVE_STRCASECMP)

--- a/tests/libtest/lib1531.c
+++ b/tests/libtest/lib1531.c
@@ -31,7 +31,7 @@
 #define TEST_HANG_TIMEOUT 60 * 1000
 
 static char const testData[] = ".abc\0xyz";
-static off_t const testDataSize = sizeof(testData) - 1;
+static curl_off_t const testDataSize = sizeof(testData) - 1;
 
 CURLcode test(char *URL)
 {
@@ -57,8 +57,7 @@ CURLcode test(char *URL)
 
   /* set the options (I left out a few, you'll get the point anyway) */
   curl_easy_setopt(easy, CURLOPT_URL, URL);
-  curl_easy_setopt(easy, CURLOPT_POSTFIELDSIZE_LARGE,
-                   (curl_off_t)testDataSize);
+  curl_easy_setopt(easy, CURLOPT_POSTFIELDSIZE_LARGE, testDataSize);
   curl_easy_setopt(easy, CURLOPT_POSTFIELDS, testData);
 
   /* we start some action by calling perform right away */

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -45,7 +45,7 @@
 #include "curl_printf.h"
 
 #ifdef _WIN32
-#define sleep(sec) Sleep ((sec)*1000)
+#define sleep(sec) Sleep((sec)*1000)
 #endif
 
 #define test_setopt(A,B,C)                                      \


### PR DESCRIPTION
- lib1531: fix to use `curl_off_t`.
- src/tool_doswin: merge `_WIN32` guards.
- src/tool_doswin: limit `S_ISCHR()` to MS-DOS.
- src: dedupe `CURL_O_BINARY` macro into `tool_setup.h`.
- CMake/CurlTests.c: cleanup/formatting `HAVE_FILE_OFFSET_BITS` test.
- examples/httpput-postfields: delete unused include.
- spelling: MultiSSL.
- whitespace.

Ref: #15652
