### PR TITLE
Rustls: Support sslkeylogfile

### DIFF
--- a/docs/cmdline-opts/_ENVIRONMENT.md
+++ b/docs/cmdline-opts/_ENVIRONMENT.md
@@ -102,7 +102,7 @@ If you set this environment variable to a filename, curl stores TLS secrets
 from its connections in that file when invoked to enable you to analyze the
 TLS traffic in real time using network analyzing tools such as Wireshark. This
 works with the following TLS backends: OpenSSL, LibreSSL (TLS 1.2 max),
-BoringSSL, GnuTLS and wolfSSL.
+BoringSSL, GnuTLS, wolfSSL and Rustls.
 
 ## `USERPROFILE` <dir>
 On Windows, this variable is used when trying to find the home directory. If

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -27,7 +27,8 @@
   defined(USE_GNUTLS) || \
   defined(USE_WOLFSSL) || \
   (defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || \
-  defined(USE_QUICHE)
+  defined(USE_QUICHE) || \
+  defined(USE_RUSTLS)
 
 #include "keylog.h"
 #include <curl/curl.h>

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -36,18 +36,6 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#define KEYLOG_LABEL_MAXLEN (sizeof("CLIENT_HANDSHAKE_TRAFFIC_SECRET") - 1)
-
-#define CLIENT_RANDOM_SIZE  32
-
-/*
- * The master secret in TLS 1.2 and before is always 48 bytes. In TLS 1.3, the
- * secret size depends on the cipher suite's hash function which is 32 bytes
- * for SHA-256 and 48 bytes for SHA-384.
- */
-#define SECRET_MAXLEN       48
-
-
 /* The fp for the open SSLKEYLOGFILE, or NULL if not open */
 static FILE *keylog_file_fp;
 

--- a/lib/vtls/keylog.h
+++ b/lib/vtls/keylog.h
@@ -25,6 +25,17 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
+#define KEYLOG_LABEL_MAXLEN (sizeof("CLIENT_HANDSHAKE_TRAFFIC_SECRET") - 1)
+
+#define CLIENT_RANDOM_SIZE  32
+
+/*
+ * The master secret in TLS 1.2 and before is always 48 bytes. In TLS 1.3, the
+ * secret size depends on the cipher suite's hash function which is 32 bytes
+ * for SHA-256 and 48 bytes for SHA-384.
+ */
+#define SECRET_MAXLEN       48
+
 /*
  * Opens the TLS key log file if requested by the user. The SSLKEYLOGFILE
  * environment variable specifies the output file.


### PR DESCRIPTION
This uses functions that aren't released yet in rustls-ffi, so I'll keep this as a draft until it's actually released, or close it for now if you prefer :)