### PR TITLE
http2: fix value stored to 'result' is never read

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2496,9 +2496,7 @@ static CURLcode cf_h2_connect(struct Curl_cfilter *cf,
   /* Send out our SETTINGS and ACKs and such. If that blocks, we
    * have it buffered and  can count this filter as being connected */
   result = h2_progress_egress(cf, data);
-  if(result == CURLE_AGAIN)
-    result = CURLE_OK;
-  else if(result)
+  if(result != CURLE_AGAIN)
     goto out;
 
   *done = TRUE;

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2496,7 +2496,7 @@ static CURLcode cf_h2_connect(struct Curl_cfilter *cf,
   /* Send out our SETTINGS and ACKs and such. If that blocks, we
    * have it buffered and  can count this filter as being connected */
   result = h2_progress_egress(cf, data);
-  if(result != CURLE_AGAIN)
+  if(result && (result != CURLE_AGAIN))
     goto out;
 
   *done = TRUE;


### PR DESCRIPTION
Detected by clang-tidy