### PR TITLE
vquic: make vquic_send_packets not return without setting psent

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -248,6 +248,7 @@ static CURLcode vquic_send_packets(struct Curl_cfilter *cf,
   /* simulate network blocking/partial writes */
   if(qctx->wblock_percent > 0) {
     unsigned char c;
+    *psent = 0;
     Curl_rand(data, &c, 1);
     if(c >= ((100-qctx->wblock_percent)*256/100)) {
       CURL_TRC_CF(data, cf, "vquic_flush() simulate EWOULDBLOCK");


### PR DESCRIPTION
This is debug code, but since the caller might use the value even when this function returns error, it needs to be cleared properly here.

Spotted by Clang-tidy