### PR TITLE
curl-config: tidy up, optimize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2265,7 +2265,6 @@ if(NOT CURL_DISABLE_INSTALL)
   #   exec_prefix
   #   includedir
   #   LIBCURL_PC_CFLAGS
-  #   LIBCURL_PC_CFLAGS_PRIVATE
   #   LIBCURL_PC_LDFLAGS_PRIVATE
   #   LIBCURL_PC_LIBS_PRIVATE
   #   libdir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2265,6 +2265,7 @@ if(NOT CURL_DISABLE_INSTALL)
   #   exec_prefix
   #   includedir
   #   LIBCURL_PC_CFLAGS
+  #   LIBCURL_PC_CFLAGS_PRIVATE
   #   LIBCURL_PC_LDFLAGS_PRIVATE
   #   LIBCURL_PC_LIBS_PRIVATE
   #   libdir

--- a/curl-config.in
+++ b/curl-config.in
@@ -31,7 +31,6 @@ prefix='@prefix@'
 exec_prefix="@exec_prefix@"
 # shellcheck disable=SC2034
 includedir="@includedir@"
-cppflag_curl_staticlib='@LIBCURL_PC_CFLAGS@'
 
 usage()
 {
@@ -142,7 +141,7 @@ while test "$#" -gt 0; do
     ;;
 
   --cflags)
-    if test "X$cppflag_curl_staticlib" = 'X-DCURL_STATICLIB'; then
+    if test 'X@LIBCURL_PC_CFLAGS@' = 'X-DCURL_STATICLIB'; then
       CPPFLAG_CURL_STATICLIB='-DCURL_STATICLIB '
     else
       CPPFLAG_CURL_STATICLIB=''

--- a/curl-config.in
+++ b/curl-config.in
@@ -141,15 +141,10 @@ while test "$#" -gt 0; do
     ;;
 
   --cflags)
-    if test 'X@LIBCURL_PC_CFLAGS@' = 'X@LIBCURL_PC_CFLAGS_PRIVATE@'; then
-      cppflag_curl_staticlib='@LIBCURL_PC_CFLAGS_PRIVATE@ '
-    else
-      cppflag_curl_staticlib=''
-    fi
     if test "X@includedir@" = 'X/usr/include'; then
-      echo "${cppflag_curl_staticlib}"
+      echo '@LIBCURL_PC_CFLAGS@'
     else
-      echo "${cppflag_curl_staticlib}-I@includedir@"
+      echo "@LIBCURL_PC_CFLAGS@ -I@includedir@"
     fi
     ;;
 

--- a/curl-config.in
+++ b/curl-config.in
@@ -141,8 +141,8 @@ while test "$#" -gt 0; do
     ;;
 
   --cflags)
-    if test 'X@LIBCURL_PC_CFLAGS@' = 'X-DCURL_STATICLIB'; then
-      CPPFLAG_CURL_STATICLIB='-DCURL_STATICLIB '
+    if test 'X@LIBCURL_PC_CFLAGS@' = 'X@LIBCURL_PC_CFLAGS_PRIVATE@'; then
+      CPPFLAG_CURL_STATICLIB='@LIBCURL_PC_CFLAGS_PRIVATE@ '
     else
       CPPFLAG_CURL_STATICLIB=''
     fi

--- a/curl-config.in
+++ b/curl-config.in
@@ -142,27 +142,27 @@ while test "$#" -gt 0; do
 
   --cflags)
     if test 'X@LIBCURL_PC_CFLAGS@' = 'X@LIBCURL_PC_CFLAGS_PRIVATE@'; then
-      CPPFLAG_CURL_STATICLIB='@LIBCURL_PC_CFLAGS_PRIVATE@ '
+      cppflag_curl_staticlib='@LIBCURL_PC_CFLAGS_PRIVATE@ '
     else
-      CPPFLAG_CURL_STATICLIB=''
+      cppflag_curl_staticlib=''
     fi
     if test "X@includedir@" = 'X/usr/include'; then
-      echo "${CPPFLAG_CURL_STATICLIB}"
+      echo "${cppflag_curl_staticlib}"
     else
-      echo "${CPPFLAG_CURL_STATICLIB}-I@includedir@"
+      echo "${cppflag_curl_staticlib}-I@includedir@"
     fi
     ;;
 
   --libs)
     if test "X@libdir@" != 'X/usr/lib' -a "X@libdir@" != 'X/usr/lib64'; then
-      CURLLIBDIR="-L@libdir@ "
+      curllibdir="-L@libdir@ "
     else
-      CURLLIBDIR=''
+      curllibdir=''
     fi
     if test 'X@ENABLE_SHARED@' = 'Xno'; then
-      echo "${CURLLIBDIR}-lcurl @LIBCURL_PC_LIBS_PRIVATE@"
+      echo "${curllibdir}-lcurl @LIBCURL_PC_LIBS_PRIVATE@"
     else
-      echo "${CURLLIBDIR}-lcurl"
+      echo "${curllibdir}-lcurl"
     fi
     ;;
 


### PR DESCRIPTION
- optimize out `cppflag_curl_staticlib` variable.
- optimize out `CPPFLAG_CURL_STATICLIB` variable and simplify logic.
- lowercase local variable name `CURLLIBDIR`.
