### PR TITLE
build: fix the tidy targets for autotools

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -155,7 +155,7 @@ all-local: checksrc
 endif
 
 # disable the tests that are mostly causing false positives
-TIDYFLAGS=-checks=-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-optin.performance.Padding,-clang-analyzer-valist.Uninitialized,-clang-analyzer-core.NonNullParamChecker,-clang-analyzer-core.NullDereference -quiet
+TIDYFLAGS=-checks=-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-optin.performance.Padding,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling -quiet
 
 TIDY:=clang-tidy
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -190,12 +190,12 @@ all-local: checksrc
 endif
 
 # disable the tests that are mostly causing false positives
-TIDYFLAGS=-checks=-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-optin.performance.Padding,-clang-analyzer-valist.Uninitialized,-clang-analyzer-core.NonNullParamChecker,-clang-analyzer-core.NullDereference
+TIDYFLAGS=-checks=-clang-analyzer-security.insecureAPI.strcpy,-clang-analyzer-optin.performance.Padding,-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling -quiet
 
 TIDY:=clang-tidy
 
 tidy:
-	$(TIDY) $(CURL_CFILES) $(TIDYFLAGS) -- $(curl_CPPFLAGS) $(CPPFLAGS) -DHAVE_CONFIG_H
+	$(TIDY) $(CURL_CFILES) $(TIDYFLAGS) -- $(curl_CPPFLAGS) $(CPPFLAGS) $(AM_CPPFLAGS) -DHAVE_CONFIG_H
 
 listhelp:
 	(cd $(top_srcdir)/docs/cmdline-opts && make listhelp)


### PR DESCRIPTION
To make them run clang-tidy correctly. clang-tidy occasionally finds mistakes none of the other static code analyzers we use finds.

Also added the
-clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling flag, to make it not complain about memcpy()

"make tidy" in the build root works fine now. The previous clang-tidy CI job was removed in e43c3b3e3e6c2d580. It is probably time to bring it back.