### PR TITLE
cookie: fix crash in netscape cookie parsing

### DIFF
--- a/docs/libcurl/opts/CURLOPT_COOKIELIST.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIELIST.md
@@ -81,7 +81,7 @@ NULL
 
 int main(void)
 {
-  char *my_cookie =
+  const char *my_cookie =
     "example.com"    /* Hostname */
     SEP "FALSE"      /* Include subdomains */
     SEP "/"          /* Path */


### PR DESCRIPTION
- Tokenize a copy of the input string instead of the original.

Prior to this change a segfault could occur if the input string was const because the tokenizer modified the input string. For example if the user set CURLOPT_COOKIELIST to a const string then libcurl would likely cause a crash when modifying that string. Even if the string was not const or a crash did not occur there was still the incorrect and unexpected modification of the user's input string.

This issue was caused by 30da1f59 (precedes 8.11.0) which refactored some options parsing and eliminated the copy of the input string. Also, an earlier commit f88cc654 incorrectly cast the input pointer when passing it to strtok.

Closes #xxxx