### PR TITLE
cmake/FindLibpsl: protect against `pkg-config` "half-detection"

### DIFF
--- a/CMake/FindLibpsl.cmake
+++ b/CMake/FindLibpsl.cmake
@@ -44,7 +44,7 @@ if(CURL_USE_PKGCONFIG AND
   pkg_check_modules(LIBPSL "libpsl")
 endif()
 
-if(LIBPSL_FOUND)
+if(LIBPSL_FOUND AND LIBPSL_INCLUDE_DIRS)
   string(REPLACE ";" " " LIBPSL_CFLAGS "${LIBPSL_CFLAGS}")
   message(STATUS "Found Libpsl (via pkg-config): ${LIBPSL_INCLUDE_DIRS} (found version \"${LIBPSL_VERSION}\")")
 else()


### PR DESCRIPTION
Same issue as seen before with libssh2: `libpsl`'s pkg-config module
depends on another module, but that's not found. CMake ends up reporting
`LIBPSL_FOUND=YES`, while leaving `LIBPSL_INCLUDE_DIRS` empty. Then
the build fails to find `psl.h`.

The missing dependency in this case is `icu4c`, which is "keg-only",
meaning it's not exposed in the default Homebrew header, pkg-config,
lib, etc locations. It must be added to the `PKG_CONFIG_PATH` env, as
suggested by the warnings messages of `pkgconf`.

To avoid this fallout, let's ensure that `LIBPSL_INCLUDE_DIRS` is
non-empty when detecting via `pkg-config` and fall back to the CMake
detection method otherwise.

This was an issue till Homebrew libpsl 0.21.5_1, fixed in 0.21.5_2, that
no longer depends on `icu4c`.

Example log:
```
-- Checking for module 'libpsl'
--   Found libpsl, version 0.21.5
Package icu-uc was not found in the pkg-config search path.
Perhaps you should add the directory containing `icu-uc.pc'
to the PKG_CONFIG_PATH environment variable
Package 'icu-uc', required by 'libpsl', not found
[...]
-- Found Libpsl (via pkg-config):  (found version "0.21.5")
[...]
In file included from curl/_bld/lib/CMakeFiles/libcurl_static.dir/Unity/unity_0_c.c:4:
In file included from curl/lib/altsvc.c:32:
In file included from curl/lib/urldata.h:145:
curl/lib/psl.h:28:10: fatal error: 'libpsl.h' file not found
         ^~~~~~~~~~
1 error generated.
```

Follow-up to 39c741b7b008b5959980b29ac721357ff75de3f5 #15408
