### PR TITLE
mbedtls, fix handling of blocked sends

### DIFF
--- a/docs/KNOWN_BUGS
+++ b/docs/KNOWN_BUGS
@@ -21,6 +21,7 @@ problems may have been fixed or changed somewhat since this was written.
  2.7 Client cert (MTLS) issues with Schannel
  2.11 Schannel TLS 1.2 handshake bug in old Windows versions
  2.13 CURLOPT_CERTINFO results in CURLE_OUT_OF_MEMORY with Schannel
+ 2.14 mbedTLS and CURLE_AGAIN handling
 
  3. Email protocols
  3.1 IMAP SEARCH ALL truncated response
@@ -158,6 +159,10 @@ problems may have been fixed or changed somewhat since this was written.
 2.13 CURLOPT_CERTINFO results in CURLE_OUT_OF_MEMORY with Schannel
 
  https://github.com/curl/curl/issues/8741
+
+2.14 mbedTLS and CURLE_AGAIN handling
+
+ https://github.com/curl/curl/issues/15801
 
 3. Email protocols
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1220,7 +1220,7 @@ static ssize_t mbed_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 #endif
       ) ? CURLE_AGAIN : CURLE_SEND_ERROR;
     ret = -1;
-    if((*curlcode == CURLE_AGAIN) && !backend->send_blocked_len) {
+    if((*curlcode == CURLE_AGAIN) && !backend->send_blocked) {
       backend->send_blocked = TRUE;
       backend->send_blocked_len = len;
     }

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -212,6 +212,8 @@ class TestCaddy:
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_08_08_earlydata(self, env: Env, httpd, caddy, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
         count = 2
         docname = 'data10k.data'
         url = f'https://{env.domain1}:{caddy.port}/{docname}'


### PR DESCRIPTION
mbedtls is picky when a mbedtls_ssl_write) was previously blocked. It requires to be called with the same amount of bytes again, or it will lose bytes, e.g. reporting all was sent but they were not. Remember the blocked length and use that when set.

refs #15801