### PR TITLE
urlapi: fix redirect to a new fragment or query (only)

### DIFF
--- a/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
+++ b/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
@@ -41,6 +41,9 @@ order to try out server implementations.
 
 By default libcurl normalizes such sequences before using the path.
 
+This is a request for the *first* request libcurl issues. When following
+redirects, it may no longer apply.
+
 The corresponding flag for the curl_url_set(3) function is called
 **CURLU_PATH_AS_IS**.
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -258,7 +258,6 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
    problems in the future...
   */
   struct dynbuf newest;
-  char *pathsep;
   bool host_changed = FALSE;
   const char *useurl = relurl;
   CURLcode result = CURLE_OK;
@@ -275,7 +274,7 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
   if(('/' != relurl[0]) && ('#' != relurl[0])) {
     /* First we need to find out if there is a ?-letter in the original URL,
        and cut it and the right-side of that off */
-    pathsep = strchr(protsep, '?');
+    char *pathsep = strchr(protsep, '?');
     if(pathsep)
       *pathsep = 0;
     else {
@@ -345,7 +344,7 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
     else {
       /* cut off the original URL from the first slash, or deal with URLs
          without slash */
-      pathsep = strchr(protsep, '/');
+      char *pathsep = strchr(protsep, '/');
       if(pathsep) {
         /* When people use badly formatted URLs, such as
            "http://www.example.com?dir=/home/daniel" we must not use the first
@@ -370,7 +369,7 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
     /* the relative piece starts with '#' */
 
     /* If there is a fragment in the original URL, cut it off */
-    pathsep = strchr(protsep, '#');
+    char *pathsep = strchr(protsep, '#');
     if(pathsep)
       *pathsep = 0;
     skip_slash = TRUE;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -342,27 +342,13 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
       host_changed = TRUE;
     }
     else {
-      /* cut off the original URL from the first slash, or deal with URLs
-         without slash */
-      char *pathsep = strchr(protsep, '/');
-      if(pathsep) {
-        /* When people use badly formatted URLs, such as
-           "http://www.example.com?dir=/home/daniel" we must not use the first
-           slash, if there is a ?-letter before it! */
-        char *sep = strchr(protsep, '?');
-        if(sep && (sep < pathsep))
-          pathsep = sep;
+      /* cut the original URL at question mark then first slash */
+      char *pathsep = strchr(protsep, '?');
+      if(pathsep)
         *pathsep = 0;
-      }
-      else {
-        /* There was no slash. Now, since we might be operating on a badly
-           formatted URL, such as "http://www.example.com?id=2380" which does
-           not use a slash separator as it is supposed to, we need to check
-           for a ?-letter as well! */
-        pathsep = strchr(protsep, '?');
-        if(pathsep)
-          *pathsep = 0;
-      }
+      pathsep = strchr(protsep, '/');
+      if(pathsep)
+        *pathsep = 0;
     }
   }
   else {

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -258,25 +258,21 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
    problems in the future...
   */
   struct dynbuf newest;
-  char *protsep;
   char *pathsep;
   bool host_changed = FALSE;
   const char *useurl = relurl;
   CURLcode result = CURLE_OK;
   CURLUcode uc;
   bool skip_slash = FALSE;
-  *newurl = NULL;
-
   /* protsep points to the start of the hostname */
-  protsep = strstr(base, "//");
+  char *protsep = strstr(base, "//");
   if(!protsep)
     protsep = base;
   else
     protsep += 2; /* pass the slashes */
 
+  *newurl = NULL;
   if(('/' != relurl[0]) && ('#' != relurl[0])) {
-    int level = 0;
-
     /* First we need to find out if there is a ?-letter in the original URL,
        and cut it and the right-side of that off */
     pathsep = strchr(protsep, '?');
@@ -293,6 +289,7 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
        available, or the new URL is just a query string (starts with a '?') we
        append the new one at the end of the current URL */
     if(useurl[0] != '?') {
+      int level = 0;
       pathsep = strrchr(protsep, '/');
       if(pathsep)
         *pathsep = 0;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -288,7 +288,6 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
        available, or the new URL is just a query string (starts with a '?') we
        append the new one at the end of the current URL */
     if(useurl[0] != '?') {
-      int level = 0;
       pathsep = strrchr(protsep, '/');
       if(pathsep)
         *pathsep = 0;
@@ -300,32 +299,6 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
         protsep = pathsep + 1;
       else
         protsep = NULL;
-
-      /* now deal with one "./" or any amount of "../" in the newurl
-         and act accordingly */
-
-      if((useurl[0] == '.') && (useurl[1] == '/'))
-        useurl += 2; /* just skip the "./" */
-
-      while((useurl[0] == '.') &&
-            (useurl[1] == '.') &&
-            (useurl[2] == '/')) {
-        level++;
-        useurl += 3; /* pass the "../" */
-      }
-
-      if(protsep) {
-        while(level--) {
-          /* cut off one more level from the right of the original URL */
-          pathsep = strrchr(protsep, '/');
-          if(pathsep)
-            *pathsep = 0;
-          else {
-            *protsep = 0;
-            break;
-          }
-        }
-      }
     }
     else
       skip_slash = TRUE;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -315,11 +315,8 @@ static CURLcode concat_url(char *base, const char *relurl, char **newurl)
       host_changed = TRUE;
     }
     else {
-      /* cut the original URL at question mark then first slash */
-      char *pathsep = strchr(protsep, '?');
-      if(pathsep)
-        *pathsep = 0;
-      pathsep = strchr(protsep, '/');
+      /* cut the original URL at first slash */
+      char *pathsep = strchr(protsep, '/');
       if(pathsep)
         *pathsep = 0;
     }

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1827,7 +1827,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
     if(result)
       return cc2cu(result);
 
-    uc = parseurl_and_replace(redired_url, u, flags);
+    uc = parseurl_and_replace(redired_url, u, flags&~CURLU_PATH_AS_IS);
     free(redired_url);
     return uc;
   }

--- a/tests/data/test391
+++ b/tests/data/test391
@@ -62,7 +62,7 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 
-GET /../%TESTNUMBER0002 HTTP/1.1
+GET /%TESTNUMBER0002 HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1143,6 +1143,8 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
 }
 
 static const struct redircase set_url_list[] = {
+  {"http://example.org?bar/moo", "?weird",
+   "http://example.org/?weird", 0, 0, CURLUE_OK},
   {"http://example.org/foo?bar", "?weird",
    "http://example.org/foo?weird", 0, 0, CURLUE_OK},
   {"http://example.org/foo", "?weird",
@@ -1152,6 +1154,8 @@ static const struct redircase set_url_list[] = {
   {"http://example.org/#original", "?weird#moo",
    "http://example.org/?weird#moo", 0, 0, CURLUE_OK},
 
+  {"http://example.org?bar/moo#yes/path", "#new/slash",
+   "http://example.org/?bar/moo#new/slash", 0, 0, CURLUE_OK},
   {"http://example.org/foo?bar", "#weird",
    "http://example.org/foo?bar#weird", 0, 0, CURLUE_OK},
   {"http://example.org/foo?bar#original", "#weird",

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1143,6 +1143,27 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
 }
 
 static const struct redircase set_url_list[] = {
+  {"http://example.org/foo?bar", "?weird",
+   "http://example.org/foo?weird", 0, 0, CURLUE_OK},
+  {"http://example.org/foo", "?weird",
+   "http://example.org/foo?weird", 0, 0, CURLUE_OK},
+  {"http://example.org", "?weird",
+   "http://example.org/?weird", 0, 0, CURLUE_OK},
+  {"http://example.org/#original", "?weird#moo",
+   "http://example.org/?weird#moo", 0, 0, CURLUE_OK},
+
+  {"http://example.org/foo?bar", "#weird",
+   "http://example.org/foo?bar#weird", 0, 0, CURLUE_OK},
+  {"http://example.org/foo?bar#original", "#weird",
+   "http://example.org/foo?bar#weird", 0, 0, CURLUE_OK},
+  {"http://example.org/foo#original", "#weird",
+   "http://example.org/foo#weird", 0, 0, CURLUE_OK},
+  {"http://example.org/#original", "#weird",
+   "http://example.org/#weird", 0, 0, CURLUE_OK},
+  {"http://example.org#original", "#weird",
+   "http://example.org/#weird", 0, 0, CURLUE_OK},
+  {"http://example.org/foo?bar", "moo?hey#weird",
+   "http://example.org/moo?hey#weird", 0, 0, CURLUE_OK},
   {"http://example.org/",
    "../path/././../../moo",
    "http://example.org/moo",

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1143,6 +1143,10 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
 }
 
 static const struct redircase set_url_list[] = {
+  {"http://example.org/", "../path/././../././../moo",
+   "http://example.org/moo",
+   0, 0, CURLUE_OK},
+
   {"http://example.org?bar/moo", "?weird",
    "http://example.org/?weird", 0, 0, CURLUE_OK},
   {"http://example.org/foo?bar", "?weird",

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -1143,6 +1143,9 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
 }
 
 static const struct redircase set_url_list[] = {
+  {"http://example.org#withs/ash", "/moo#frag",
+   "http://example.org/moo#frag",
+   0, 0, CURLUE_OK},
   {"http://example.org/", "../path/././../././../moo",
    "http://example.org/moo",
    0, 0, CURLUE_OK},


### PR DESCRIPTION
The redirect logic was broken when the redirect-to URL was a relative URL as a fragment only (starting with '#').

Extended test 1560 to reproduce, then verify.

Reported-by: Jeroen Ooms
Fixes #15836
Closes #