### PR TITLE
cmake: optimize out 4 picky warning option detections with gcc

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -118,13 +118,6 @@ if(PICKY_COMPILER)
       -Wvla                                # clang  2.8  gcc  4.3
     )
 
-    set(_picky_common
-      -Wdouble-promotion                   # clang  3.6  gcc  4.6  appleclang  6.3
-      -Wenum-conversion                    # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
-      -Wpragmas                            # clang  3.5  gcc  4.1  appleclang  6.0
-      -Wunused-const-variable              # clang  3.4  gcc  6.0  appleclang  5.1
-    )
-
     if(CMAKE_C_COMPILER_ID MATCHES "Clang")
       list(APPEND _picky_enable
         ${_picky_common_old}
@@ -141,10 +134,13 @@ if(PICKY_COMPILER)
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6) OR
          (CMAKE_C_COMPILER_ID STREQUAL "AppleClang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 6.3))
         list(APPEND _picky_enable
-          ${_picky_common}
-        # -Wunreachable-code-break         # clang  3.5            appleclang  6.0  # Not used: Silent in "unity" builds
+          -Wdouble-promotion               # clang  3.6  gcc  4.6  appleclang  6.3
+          -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
           -Wheader-guard                   # clang  3.4            appleclang  5.1
+          -Wpragmas                        # clang  3.5  gcc  4.1  appleclang  6.0
           -Wsometimes-uninitialized        # clang  3.2            appleclang  4.6
+        # -Wunreachable-code-break         # clang  3.5            appleclang  6.0  # Not used: Silent in "unity" builds
+          -Wunused-const-variable          # clang  3.4  gcc  6.0  appleclang  5.1
         )
       endif()
       if((CMAKE_C_COMPILER_ID STREQUAL "Clang"      AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.9) OR
@@ -168,9 +164,6 @@ if(PICKY_COMPILER)
         )
       endif()
     else()  # gcc
-      list(APPEND _picky_detect
-        ${_picky_common}
-      )
       # Enable based on compiler version
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3)
         list(APPEND _picky_enable
@@ -178,6 +171,7 @@ if(PICKY_COMPILER)
           -Wclobbered                      #             gcc  4.3
           -Wmissing-parameter-type         #             gcc  4.3
           -Wold-style-declaration          #             gcc  4.3
+          -Wpragmas                        # clang  3.5  gcc  4.1  appleclang  6.0
           -Wstrict-aliasing=3              #             gcc  4.0
           -Wtrampolines                    #             gcc  4.3
         )
@@ -189,6 +183,7 @@ if(PICKY_COMPILER)
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8)
         list(APPEND _picky_enable
+          -Wdouble-promotion               # clang  3.6  gcc  4.6  appleclang  6.3
           -Wformat=2                       # clang  3.0  gcc  4.8
         )
       endif()
@@ -204,6 +199,7 @@ if(PICKY_COMPILER)
             -fdelete-null-pointer-checks
           -Wshift-negative-value           # clang  3.7  gcc  6.0 (clang default)
           -Wshift-overflow=2               # clang  3.0  gcc  6.0 (clang default: -Wshift-overflow)
+          -Wunused-const-variable          # clang  3.4  gcc  6.0  appleclang  5.1
         )
       endif()
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 7.0)
@@ -218,6 +214,7 @@ if(PICKY_COMPILER)
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 10.0)
         list(APPEND _picky_enable
           -Warith-conversion               #             gcc 10.0
+          -Wenum-conversion                # clang  3.2  gcc 10.0  appleclang  4.6  g++ 11.0
         )
       endif()
     endif()


### PR DESCRIPTION
Follow-up to 9c543de0ecf14880c3324d3d24591fb695dd1917 #10973