### PR TITLE
GHA/windows: shorten job timeouts

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
   cygwin:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 25
     defaults:
       run:
         shell: C:\cygwin\bin\bash.exe '{0}'
@@ -162,7 +162,7 @@ jobs:
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     defaults:
       run:
         shell: msys2 {0}
@@ -359,7 +359,7 @@ jobs:
   old-mingw-w64:
     name: 'old-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     defaults:
       run:
         shell: C:\msys64\usr\bin\bash.exe {0}


### PR DESCRIPTION
To reduce the wait for re-running stuck jobs.

Sometimes jobs hang/get stuck while running tests, ignoring the step
timeout.
