### PR TITLE
multi: fix return code for an already-removed easy handle

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -787,7 +787,7 @@ CURLMcode curl_multi_remove_handle(CURLM *m, CURL *d)
     return CURLM_BAD_HANDLE;
 
   /* Verify that we got a somewhat good easy handle too */
-  if(!GOOD_EASY_HANDLE(data) || !multi->num_easy)
+  if(!GOOD_EASY_HANDLE(data))
     return CURLM_BAD_EASY_HANDLE;
 
   /* Prevent users from trying to remove same easy handle more than once */
@@ -797,6 +797,11 @@ CURLMcode curl_multi_remove_handle(CURLM *m, CURL *d)
   /* Prevent users from trying to remove an easy handle from the wrong multi */
   if(data->multi != multi)
     return CURLM_BAD_EASY_HANDLE;
+
+  if(!multi->num_easy) {
+    DEBUGASSERT(0);
+    return CURLM_INTERNAL_ERROR;
+  }
 
   if(multi->in_callback)
     return CURLM_RECURSIVE_API_CALL;


### PR DESCRIPTION
- Ensure that CURLM_OK is returned when curl_multi_remove_handle is called with an already removed easy handle.

Prior to this change and since ba235ab2 which precedes 8.10.0, if curl_multi_remove_handle was called with an already-removed easy handle then the return code would be CURLM_OK or CURLM_BAD_EASY_HANDLE depending respectively on whether the multi did or did not contain other easy handles.

This change restores the old behavior of returning CURLM_OK in both cases.

Reported-by: seragh@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/15844
Closes #xxxxxx