### PR TITLE
configure: drop unused detections and macros

### DIFF
--- a/.github/scripts/cmp-config.pl
+++ b/.github/scripts/cmp-config.pl
@@ -70,7 +70,6 @@ my %remove = (
     '#define HAVE_OPENSSL_SSL_H 1' => 1,
     '#define HAVE_OPENSSL_X509_H 1' => 1,
     '#define HAVE_QUICHE_H 1' => 1,
-    '#define HAVE_SETJMP_H 1' => 1,
     '#define HAVE_SSL_ECH_SET1_ECHCONFIG 1' => 1,
     '#define HAVE_SSL_SET1_ECH_CONFIG_LIST 1' => 1,
     '#define HAVE_SSL_SET_QUIC_USE_LEGACY_CODEPOINT 1' => 1,

--- a/.github/scripts/cmp-config.pl
+++ b/.github/scripts/cmp-config.pl
@@ -47,7 +47,6 @@ my %remove = (
     '#define HAVE_DLFCN_H 1' => 1,
     '#define HAVE_GSSAPI_GSSAPI_KRB5_H 1' => 1,
     '#define HAVE_INTTYPES_H 1' => 1,
-    '#define HAVE_IOCTL 1' => 1,
     '#define HAVE_LDAP_H 1' => 1,
     '#define HAVE_LDAP_SSL 1' => 1,
     '#define HAVE_LIBBROTLIDEC 1' => 1,

--- a/configure.ac
+++ b/configure.ac
@@ -3842,8 +3842,7 @@ AC_CHECK_HEADERS(
   locale.h \
   stdbool.h \
   sys/filio.h \
-  sys/eventfd.h \
-  setjmp.h,
+  sys/eventfd.h,
 dnl to do if not found
 [],
 dnl to do if found

--- a/configure.ac
+++ b/configure.ac
@@ -3815,7 +3815,6 @@ AC_CHECK_HEADERS(
   sys/socket.h \
   sys/ioctl.h \
   unistd.h \
-  stdlib.h \
   arpa/inet.h \
   net/if.h \
   netinet/in.h \
@@ -3849,6 +3848,7 @@ dnl to do if found
 [],
 dnl default includes
 [
+#include <stdlib.h>
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -2501,7 +2501,7 @@ dnl Verify if ioctl is available, prototyped, and
 dnl can be compiled. If all of these are true, and
 dnl usage has not been previously disallowed with
 dnl shell variable curl_disallow_ioctl, then
-dnl HAVE_IOCTL will be defined.
+dnl curl_cv_func_ioctl is set to "yes".
 
 AC_DEFUN([CURL_CHECK_FUNC_IOCTL], [
   AC_REQUIRE([CURL_INCLUDES_STROPTS])dnl
@@ -2570,8 +2570,6 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTL], [
      test "$tst_compi_ioctl" = "yes" &&
      test "$tst_allow_ioctl" = "yes"; then
     AC_MSG_RESULT([yes])
-    AC_DEFINE_UNQUOTED(HAVE_IOCTL, 1,
-      [Define to 1 if you have the ioctl function.])
     curl_cv_func_ioctl="yes"
     CURL_CHECK_FUNC_IOCTL_FIONBIO
     CURL_CHECK_FUNC_IOCTL_SIOCGIFADDR


### PR DESCRIPTION
- drop `HAVE_IOCTL` macro, drop exception.
- drop unused `setjmp.h` detection, drop exception.
  It's a C89 header and result also not used in detections.
- use C89 `stdlib.h` without detection.
  (It's still being detected by autotools anyway.)
