### PR TITLE
connection pool, count shutdowns against conn limits

### DIFF
--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -148,8 +148,6 @@ struct Curl_multi {
 
   long max_total_connections; /* if >0, a fixed limit of the maximum number
                                  of connections in total */
-  long max_shutdown_connections; /* if >0, a fixed limit of the maximum number
-                                 of connections in shutdown handling */
 
   /* timer callback and user data pointer for the *socket() API */
   curl_multi_timer_callback timer_cb;

--- a/tests/http/clients/hx-download.c
+++ b/tests/http/clients/hx-download.c
@@ -312,10 +312,11 @@ int main(int argc, char *argv[])
   struct curl_slist *host = NULL;
   char *resolve = NULL;
   size_t max_host_conns = 0;
+  size_t max_total_conns = 0;
   int fresh_connect = 0;
   int result = 0;
 
-  while((ch = getopt(argc, argv, "aefhm:n:xA:F:M:P:r:V:")) != -1) {
+  while((ch = getopt(argc, argv, "aefhm:n:xA:F:M:P:r:T:V:")) != -1) {
     switch(ch) {
     case 'h':
       usage(NULL);
@@ -354,6 +355,9 @@ int main(int argc, char *argv[])
     case 'r':
       free(resolve);
       resolve = strdup(optarg);
+      break;
+    case 'T':
+      max_total_conns = (size_t)strtol(optarg, NULL, 10);
       break;
     case 'V': {
       if(!strcmp("http/1.1", optarg))
@@ -413,6 +417,8 @@ int main(int argc, char *argv[])
 
   multi_handle = curl_multi_init();
   curl_multi_setopt(multi_handle, CURLMOPT_PIPELINING, CURLPIPE_MULTIPLEX);
+  curl_multi_setopt(multi_handle, CURLMOPT_MAX_TOTAL_CONNECTIONS,
+                    (long)max_total_conns);
   curl_multi_setopt(multi_handle, CURLMOPT_MAX_HOST_CONNECTIONS,
                     (long)max_host_conns);
 


### PR DESCRIPTION
Include connections being shut down for checks against `CURLMOPT_MAX_TOTAL_CONNECTIONS` and `CURLMOPT_MAX_HOST_CONNECTIONS`.

* add test_02_34 to verify total limit
* add checks to test_02_33/34 that limit is kept
* eliminate separate, internal `max_shutdown` limit as the total limit now also applies to shutdowns
* add reaction to `Curl_multi_connchanged()` in `multi.c` after calls to `Curl_cpool_multi_perform()`, so that released shutdowns can trigger pending transfer processing.