### PR TITLE
select: avoid a NULL deref in cwfds_add_sock

### DIFF
--- a/lib/select.c
+++ b/lib/select.c
@@ -503,7 +503,10 @@ static unsigned int cwfds_add_sock(struct curl_waitfds *cwfds,
                                    curl_socket_t sock, short events)
 {
   int i;
-
+  DEBUGASSERT(cwfds->wfds);
+  if(!cwfds->wfds)
+    /* if there is no array, count this */
+    return 1;
   if(cwfds->n <= INT_MAX) {
     for(i = (int)cwfds->n - 1; i >= 0; --i) {
       if(sock == cwfds->wfds[i].fd) {

--- a/lib/select.c
+++ b/lib/select.c
@@ -503,10 +503,10 @@ static unsigned int cwfds_add_sock(struct curl_waitfds *cwfds,
                                    curl_socket_t sock, short events)
 {
   int i;
-  DEBUGASSERT(cwfds->wfds);
-  if(!cwfds->wfds)
-    /* if there is no array, count this */
+  if(!cwfds->wfds) {
+    DEBUGASSERT(!cwfds->count && !cwfds->n);
     return 1;
+  }
   if(cwfds->n <= INT_MAX) {
     for(i = (int)cwfds->n - 1; i >= 0; --i) {
       if(sock == cwfds->wfds[i].fd) {


### PR DESCRIPTION
curl_multi_waitfds(m, NULL, ...);

=> Curl_waitfds_init(&cwfds, ufds, size);

=> Curl_waitfds_add_ps(&cwfds);

=>   cwfds_add_sock(cwfds, ...);

Would then try to use the ->wfds array while set to NULL previously. This should not happen, why this is protected with an assert to trigger debug builds if it happens.

Caught by CodeSonar

![Screenshot 2025-01-01 at 12-20-53 Null Pointer Dereference daily CodeSonar](https://github.com/user-attachments/assets/2c0d92e4-7e5a-44f9-ae78-f5532a346154)
