### PR TITLE
lib: remove `__EMX__` guards

### DIFF
--- a/lib/file.c
+++ b/lib/file.c
@@ -78,7 +78,7 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#if defined(_WIN32) || defined(MSDOS) || defined(__EMX__)
+#if defined(_WIN32) || defined(MSDOS)
 #define DOS_FILESYSTEM 1
 #elif defined(__amigaos4__)
 #define AMIGA_FILESYSTEM 1

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -53,7 +53,7 @@
 #ifdef _WIN32
 #define PATHSEP "\\"
 #define IS_SEP(x) (((x) == '/') || ((x) == '\\'))
-#elif defined(MSDOS) || defined(__EMX__) || defined(OS2)
+#elif defined(MSDOS) || defined(OS2)
 #define PATHSEP "\\"
 #define IS_SEP(x) ((x) == '\\')
 #else

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -105,7 +105,7 @@ typedef unsigned int curl_prot_t;
 #define CURL_DEFAULT_USER "anonymous"
 #define CURL_DEFAULT_PASSWORD "ftp@example.com"
 
-#if !defined(_WIN32) && !defined(MSDOS) && !defined(__EMX__)
+#if !defined(_WIN32) && !defined(MSDOS)
 /* do FTP line-end CRLF => LF conversions on platforms that prefer LF-only. It
    also means: keep CRLF line endings on the CRLF platforms */
 #define CURL_PREFER_LF_LINEENDS


### PR DESCRIPTION
Follow-up to 179ee78e8672ec44c50aa36279c48b28e008ea29 #2166