### PR TITLE
hash: add asserts in hash_element_dtor()

### DIFF
--- a/lib/hash.c
+++ b/lib/hash.c
@@ -42,6 +42,8 @@ hash_element_dtor(void *user, void *element)
 {
   struct Curl_hash *h = (struct Curl_hash *) user;
   struct Curl_hash_element *e = (struct Curl_hash_element *) element;
+  DEBUGASSERT(h);
+  DEBUGASSERT(e);
 
   if(e->ptr) {
     if(e->dtor)


### PR DESCRIPTION
This just adds a precaution and shows a clear intention in the code. Added because CodeSonar is reporting a false positive Use After Free on this function.