### PR TITLE
src: drop support for `CURL_TESTDIR` debug env

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -392,26 +392,6 @@ static char *parse_filename(const char *ptr, size_t len)
   }
 #endif /* _WIN32 || MSDOS */
 
-  /* in case we built debug enabled, we allow an environment variable
-   * named CURL_TESTDIR to prefix the given filename to put it into a
-   * specific directory
-   */
-#ifdef DEBUGBUILD
-  {
-    char *tdir = curl_getenv("CURL_TESTDIR");
-    if(tdir) {
-      char buffer[512]; /* suitably large */
-      msnprintf(buffer, sizeof(buffer), "%s/%s", tdir, copy);
-      Curl_safefree(copy);
-      copy = strdup(buffer); /* clone the buffer, we do not use the libcurl
-                                aprintf() or similar since we want to use the
-                                same memory code as the "real" parse_filename
-                                function */
-      curl_free(tdir);
-    }
-  }
-#endif
-
   return copy;
 }
 

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -238,23 +238,6 @@ CURLcode get_url_file_name(struct GlobalConfig *global,
       }
 #endif /* _WIN32 || MSDOS */
 
-      /* in case we built debug enabled, we allow an environment variable
-       * named CURL_TESTDIR to prefix the given filename to put it into a
-       * specific directory
-       */
-#ifdef DEBUGBUILD
-      {
-        char *tdir = curl_getenv("CURL_TESTDIR");
-        if(tdir) {
-          char *alt = aprintf("%s/%s", tdir, *filename);
-          Curl_safefree(*filename);
-          *filename = alt;
-          curl_free(tdir);
-          if(!*filename)
-            return CURLE_OUT_OF_MEMORY;
-        }
-      }
-#endif
       return CURLE_OK;
     }
   }


### PR DESCRIPTION
No longer used by curl tests.

`--output-dir` option can be used as an alternative in all builds.

Follow-up to 39697dead3e7e3366941fe740226d56f30e6fc9e #15114
