### PR TITLE
cmake/FindLDAP: avoid framework locations for libs too (Apple)

### DIFF
--- a/CMake/FindLDAP.cmake
+++ b/CMake/FindLDAP.cmake
@@ -63,13 +63,14 @@ else()
   # On Apple the SDK LDAP gets picked up from
   # 'MacOSX.sdk/System/Library/Frameworks/LDAP.framework/Headers', which contains
   # ldap.h and lber.h both being stubs to include <ldap.h> and <lber.h>.
-  # This causes an infinite inclusion loop in compile.
+  # This causes an infinite inclusion loop in compile. Also do this for libraries
+  # to avoid picking up the 'ldap.framework' with a full path.
   set(_save_cmake_system_framework_path ${CMAKE_SYSTEM_FRAMEWORK_PATH})
   set(CMAKE_SYSTEM_FRAMEWORK_PATH "")
   find_path(LDAP_INCLUDE_DIR NAMES "ldap.h")
-  set(CMAKE_SYSTEM_FRAMEWORK_PATH ${_save_cmake_system_framework_path})
   find_library(LDAP_LIBRARY NAMES "ldap")
   find_library(LDAP_LBER_LIBRARY NAMES "lber")
+  set(CMAKE_SYSTEM_FRAMEWORK_PATH ${_save_cmake_system_framework_path})
 
   unset(LDAP_VERSION CACHE)
   if(LDAP_INCLUDE_DIR AND EXISTS "${LDAP_INCLUDE_DIR}/ldap_features.h")


### PR DESCRIPTION
We already avoid system framework paths while looking for LDAP headers
to avoid issues.

Do the same while looking for LDAP libraries. This makes sure to find
the regular ldap library (`libldap.tbd`) instead of picking up
`ldap.framework` and let that seep into `libcurl.pc` with a full path.

This makes LDAP detection work on Apple as before introducing FindLDAP.

Follow-up to 49f2a23d509645d534cbb2e2ffbd6347fac6e59e #15273
