### PR TITLE
docs/libcurl/opts: clarify the return values

### DIFF
--- a/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_ACTIVESOCKET.md
@@ -78,4 +78,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_APPCONNECT_TIME_T.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CAINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CAINFO.md
@@ -64,4 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CAPATH.md
+++ b/docs/libcurl/opts/CURLINFO_CAPATH.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CERTINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.md
@@ -103,4 +103,7 @@ Transport support added in 7.79.0. mbedTLS support added in 8.9.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME.md
@@ -63,4 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONNECT_TIME_T.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CONN_ID.md
+++ b/docs/libcurl/opts/CURLINFO_CONN_ID.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD.md
@@ -70,4 +70,7 @@ Deprecated since 7.55.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_DOWNLOAD_T.md
@@ -63,4 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD.md
@@ -69,4 +69,7 @@ Deprecated since 7.55.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_LENGTH_UPLOAD_T.md
@@ -62,4 +62,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.md
+++ b/docs/libcurl/opts/CURLINFO_CONTENT_TYPE.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_COOKIELIST.md
+++ b/docs/libcurl/opts/CURLINFO_COOKIELIST.md
@@ -78,4 +78,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_EARLYDATA_SENT_T.md
+++ b/docs/libcurl/opts/CURLINFO_EARLYDATA_SENT_T.md
@@ -72,4 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.md
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_METHOD.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.md
+++ b/docs/libcurl/opts/CURLINFO_EFFECTIVE_URL.md
@@ -64,4 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_FILETIME.md
+++ b/docs/libcurl/opts/CURLINFO_FILETIME.md
@@ -73,4 +73,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_FILETIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_FILETIME_T.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.md
+++ b/docs/libcurl/opts/CURLINFO_FTP_ENTRY_PATH.md
@@ -70,4 +70,7 @@ Works for SFTP since 7.21.4
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_HEADER_SIZE.md
@@ -61,4 +61,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.md
+++ b/docs/libcurl/opts/CURLINFO_HTTPAUTH_AVAIL.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_HTTPAUTH_USED.md
+++ b/docs/libcurl/opts/CURLINFO_HTTPAUTH_USED.md
@@ -73,4 +73,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.md
+++ b/docs/libcurl/opts/CURLINFO_HTTP_CONNECTCODE.md
@@ -61,4 +61,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLINFO_HTTP_VERSION.md
@@ -57,4 +57,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
+++ b/docs/libcurl/opts/CURLINFO_LASTSOCKET.md
@@ -78,4 +78,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_LOCAL_IP.md
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_IP.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_LOCAL_PORT.md
+++ b/docs/libcurl/opts/CURLINFO_LOCAL_PORT.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME.md
@@ -64,4 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_NAMELOOKUP_TIME_T.md
@@ -65,4 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
+++ b/docs/libcurl/opts/CURLINFO_NUM_CONNECTS.md
@@ -61,4 +61,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
+++ b/docs/libcurl/opts/CURLINFO_OS_ERRNO.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_POSTTRANSFER_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_POSTTRANSFER_TIME_T.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_PRETRANSFER_TIME_T.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_IP.md
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_IP.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.md
+++ b/docs/libcurl/opts/CURLINFO_PRIMARY_PORT.md
@@ -63,4 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PRIVATE.md
+++ b/docs/libcurl/opts/CURLINFO_PRIVATE.md
@@ -64,4 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PROTOCOL.md
+++ b/docs/libcurl/opts/CURLINFO_PROTOCOL.md
@@ -73,4 +73,7 @@ Deprecated since 7.85.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.md
+++ b/docs/libcurl/opts/CURLINFO_PROXYAUTH_AVAIL.md
@@ -72,4 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PROXYAUTH_USED.md
+++ b/docs/libcurl/opts/CURLINFO_PROXYAUTH_USED.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PROXY_ERROR.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_ERROR.md
@@ -101,4 +101,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_PROXY_SSL_VERIFYRESULT.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_QUEUE_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_QUEUE_TIME_T.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_COUNT.md
@@ -58,4 +58,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_TIME_T.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_REDIRECT_URL.md
+++ b/docs/libcurl/opts/CURLINFO_REDIRECT_URL.md
@@ -65,4 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_REFERER.md
+++ b/docs/libcurl/opts/CURLINFO_REFERER.md
@@ -63,4 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.md
+++ b/docs/libcurl/opts/CURLINFO_REQUEST_SIZE.md
@@ -59,4 +59,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.md
+++ b/docs/libcurl/opts/CURLINFO_RESPONSE_CODE.md
@@ -68,4 +68,7 @@ responses added in 7.25.0, for OpenLDAP in 7.81.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_RETRY_AFTER.md
+++ b/docs/libcurl/opts/CURLINFO_RETRY_AFTER.md
@@ -72,4 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CLIENT_CSEQ.md
@@ -57,4 +57,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_CSEQ_RECV.md
@@ -57,4 +57,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SERVER_CSEQ.md
@@ -61,4 +61,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.md
+++ b/docs/libcurl/opts/CURLINFO_RTSP_SESSION_ID.md
@@ -62,4 +62,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SCHEME.md
+++ b/docs/libcurl/opts/CURLINFO_SCHEME.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD.md
@@ -73,4 +73,7 @@ Deprecated since 7.55.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_DOWNLOAD_T.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD.md
@@ -69,4 +69,7 @@ Deprecated since 7.55.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SIZE_UPLOAD_T.md
@@ -62,4 +62,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD.md
@@ -69,4 +69,7 @@ Deprecated since 7.55.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_DOWNLOAD_T.md
@@ -63,4 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD.md
@@ -67,4 +67,7 @@ Deprecated since 7.55.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.md
+++ b/docs/libcurl/opts/CURLINFO_SPEED_UPLOAD_T.md
@@ -61,4 +61,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SSL_ENGINES.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_ENGINES.md
@@ -63,4 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
+++ b/docs/libcurl/opts/CURLINFO_SSL_VERIFYRESULT.md
@@ -73,4 +73,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_STARTTRANSFER_TIME_T.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
@@ -77,4 +77,7 @@ Deprecated since 7.48.0
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SSL_PTR.md
@@ -178,4 +178,7 @@ This option is exactly the same as that option except in the case of OpenSSL.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME.md
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME.md
@@ -65,4 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_TOTAL_TIME_T.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_USED_PROXY.md
+++ b/docs/libcurl/opts/CURLINFO_USED_PROXY.md
@@ -65,4 +65,7 @@ int main(int argc, char *argv[])
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLINFO_XFER_ID.md
+++ b/docs/libcurl/opts/CURLINFO_XFER_ID.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_getinfo(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE.md
+++ b/docs/libcurl/opts/CURLMOPT_CHUNK_LENGTH_PENALTY_SIZE.md
@@ -57,4 +57,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE.md
+++ b/docs/libcurl/opts/CURLMOPT_CONTENT_LENGTH_PENALTY_SIZE.md
@@ -56,4 +56,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAXCONNECTS.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_MAX_CONCURRENT_STREAMS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_CONCURRENT_STREAMS.md
@@ -55,4 +55,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_HOST_CONNECTIONS.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_MAX_PIPELINE_LENGTH.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_PIPELINE_LENGTH.md
@@ -60,4 +60,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.md
+++ b/docs/libcurl/opts/CURLMOPT_MAX_TOTAL_CONNECTIONS.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING.md
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING.md
@@ -79,4 +79,7 @@ Before that, default was **CURLPIPE_NOTHING**.
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING_SERVER_BL.md
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING_SERVER_BL.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_PIPELINING_SITE_BL.md
+++ b/docs/libcurl/opts/CURLMOPT_PIPELINING_SITE_BL.md
@@ -62,4 +62,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_PUSHDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_PUSHDATA.md
@@ -83,4 +83,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_PUSHFUNCTION.md
@@ -144,4 +144,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.md
@@ -103,4 +103,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLM_OK if the option is supported, and CURLM_UNKNOWN_OPTION if not.
+curl_multi_setopt(3) returns a CURLMcode indicating success or error.
+
+CURLM_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.md
+++ b/docs/libcurl/opts/CURLOPT_ABSTRACT_UNIX_SOCKET.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_ACCEPTTIMEOUT_MS.md
@@ -57,4 +57,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.md
+++ b/docs/libcurl/opts/CURLOPT_ACCEPT_ENCODING.md
@@ -114,5 +114,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.md
+++ b/docs/libcurl/opts/CURLOPT_ADDRESS_SCOPE.md
@@ -58,5 +58,8 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).
 Returns CURLE_BAD_FUNCTION_ARGUMENT if set to a negative value.

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -113,4 +113,7 @@ Integer priority value (not currently used)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -95,4 +95,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_APPEND.md
+++ b/docs/libcurl/opts/CURLOPT_APPEND.md
@@ -62,4 +62,7 @@ This option was known as CURLOPT_FTPAPPEND up to 7.16.4
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_AUTOREFERER.md
+++ b/docs/libcurl/opts/CURLOPT_AUTOREFERER.md
@@ -73,4 +73,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_AWS_SIGV4.md
+++ b/docs/libcurl/opts/CURLOPT_AWS_SIGV4.md
@@ -123,4 +123,7 @@ the special value "UNSIGNED-PAYLOAD".
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_BUFFERSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_BUFFERSIZE.md
@@ -80,4 +80,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CAINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CAINFO.md
@@ -89,5 +89,7 @@ Schannel support added in libcurl 7.60.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_CAINFO_BLOB.md
@@ -89,5 +89,7 @@ Transport and Schannel backends.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_CA_CACHE_TIMEOUT.md
@@ -86,4 +86,7 @@ This option is supported by OpenSSL and its forks (since 7.87.0), Schannel
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CERTINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CERTINFO.md
@@ -94,4 +94,7 @@ mbedTLS support added in 8.9.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CHUNK_BGN_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_BGN_FUNCTION.md
@@ -148,4 +148,7 @@ int main()
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CHUNK_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_DATA.md
@@ -98,4 +98,7 @@ int main()
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CHUNK_END_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_END_FUNCTION.md
@@ -78,4 +78,7 @@ int main()
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -82,4 +82,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT.md
@@ -83,5 +83,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK. Returns CURLE_BAD_FUNCTION_ARGUMENT if set to a negative
-value or a value that when converted to milliseconds is too large.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECTTIMEOUT_MS.md
@@ -84,4 +84,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
@@ -83,4 +83,7 @@ WS and WSS support added in 7.86.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CONNECT_TO.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_TO.md
@@ -113,4 +113,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CONV_FROM_NETWORK_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CONV_FROM_NETWORK_FUNCTION.md
@@ -114,4 +114,7 @@ built.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CONV_FROM_UTF8_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CONV_FROM_UTF8_FUNCTION.md
@@ -107,4 +107,7 @@ built.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CONV_TO_NETWORK_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CONV_TO_NETWORK_FUNCTION.md
@@ -110,4 +110,7 @@ built.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_COOKIE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIE.md
@@ -89,5 +89,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
@@ -97,4 +97,7 @@ online here: https://curl.se/docs/http-cookies.html
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
@@ -83,5 +83,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_COOKIELIST.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIELIST.md
@@ -135,5 +135,7 @@ online here: https://curl.se/docs/http-cookies.html
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_COOKIESESSION.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIESESSION.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.md
+++ b/docs/libcurl/opts/CURLOPT_COPYPOSTFIELDS.md
@@ -78,5 +78,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CRLF.md
+++ b/docs/libcurl/opts/CURLOPT_CRLF.md
@@ -58,4 +58,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CRLFILE.md
+++ b/docs/libcurl/opts/CURLOPT_CRLFILE.md
@@ -85,5 +85,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CURLU.md
+++ b/docs/libcurl/opts/CURLOPT_CURLU.md
@@ -75,4 +75,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_CUSTOMREQUEST.md
@@ -130,5 +130,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DEBUGDATA.md
+++ b/docs/libcurl/opts/CURLOPT_DEBUGDATA.md
@@ -82,4 +82,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
@@ -214,4 +214,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DIRLISTONLY.md
+++ b/docs/libcurl/opts/CURLOPT_DIRLISTONLY.md
@@ -85,4 +85,7 @@ since 7.21.5.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
+++ b/docs/libcurl/opts/CURLOPT_DISALLOW_USERNAME_IN_URL.md
@@ -61,7 +61,10 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).
 
 curl_easy_perform(3) returns CURLE_LOGIN_DENIED if this option is
 enabled and a URL containing a username is specified.

--- a/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_CACHE_TIMEOUT.md
@@ -85,4 +85,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_INTERFACE.md
@@ -70,5 +70,7 @@ supports this operation. The c-ares backend is the only such one.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not,
-or CURLE_NOT_BUILT_IN if support was disabled at compile-time.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP4.md
@@ -69,6 +69,7 @@ supports this operation. The c-ares backend is the only such one.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not,
-CURLE_NOT_BUILT_IN if support was disabled at compile-time, or
-CURLE_BAD_FUNCTION_ARGUMENT when given a bad address.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_LOCAL_IP6.md
@@ -69,6 +69,7 @@ supports this operation. The c-ares backend is the only such one.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not,
-CURLE_NOT_BUILT_IN if support was disabled at compile-time, or
-CURLE_BAD_FUNCTION_ARGUMENT when given a bad address.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DNS_SERVERS.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_SERVERS.md
@@ -74,7 +74,7 @@ supports this operation. The c-ares backend is the only such one.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not,
-CURLE_NOT_BUILT_IN if support was disabled at compile-time,
-CURLE_BAD_FUNCTION_ARGUMENT when given an invalid server list, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.md
+++ b/docs/libcurl/opts/CURLOPT_DNS_USE_GLOBAL_CACHE.md
@@ -68,4 +68,7 @@ Deprecated since 7.11.1. Functionality removed in 7.62.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYHOST.md
@@ -86,4 +86,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYPEER.md
@@ -98,4 +98,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_SSL_VERIFYSTATUS.md
@@ -73,5 +73,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if OCSP stapling is supported by the SSL backend, otherwise
-returns CURLE_NOT_BUILT_IN.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_DOH_URL.md
+++ b/docs/libcurl/opts/CURLOPT_DOH_URL.md
@@ -90,9 +90,11 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK on success or CURLE_OUT_OF_MEMORY if there was insufficient
-heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
 
-Note that curl_easy_setopt(3) does immediately parse the given string so
-when given a bad DoH URL, libcurl might not detect the problem until it later
-tries to resolve a name with it.
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).
+
+Note that curl_easy_setopt(3) does immediately parse the given string so when
+given a bad DoH URL, libcurl might not detect the problem until it later tries
+to resolve a name with it.

--- a/docs/libcurl/opts/CURLOPT_ECH.md
+++ b/docs/libcurl/opts/CURLOPT_ECH.md
@@ -104,5 +104,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK on success or CURLE_OUT_OF_MEMORY if there was insufficient
-heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_EGDSOCKET.md
+++ b/docs/libcurl/opts/CURLOPT_EGDSOCKET.md
@@ -41,4 +41,7 @@ This option was deprecated in 7.84.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_ERRORBUFFER.md
+++ b/docs/libcurl/opts/CURLOPT_ERRORBUFFER.md
@@ -100,4 +100,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_EXPECT_100_TIMEOUT_MS.md
@@ -60,4 +60,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FAILONERROR.md
+++ b/docs/libcurl/opts/CURLOPT_FAILONERROR.md
@@ -70,4 +70,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is enabled, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FILETIME.md
+++ b/docs/libcurl/opts/CURLOPT_FILETIME.md
@@ -72,4 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FNMATCH_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_FNMATCH_DATA.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_FNMATCH_FUNCTION.md
@@ -84,4 +84,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.md
+++ b/docs/libcurl/opts/CURLOPT_FOLLOWLOCATION.md
@@ -99,4 +99,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
+++ b/docs/libcurl/opts/CURLOPT_FORBID_REUSE.md
@@ -65,4 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.md
+++ b/docs/libcurl/opts/CURLOPT_FRESH_CONNECT.md
@@ -64,4 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTPPORT.md
+++ b/docs/libcurl/opts/CURLOPT_FTPPORT.md
@@ -93,5 +93,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
@@ -72,4 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_ACCOUNT.md
@@ -65,5 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTP_ALTERNATIVE_TO_USER.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_ALTERNATIVE_TO_USER.md
@@ -65,5 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
@@ -82,5 +82,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if the
-create value is not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
@@ -82,4 +82,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTP_SKIP_PASV_IP.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SKIP_PASV_IP.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_EPRT.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_EPSV.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_EPSV.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if FTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_USE_PRET.md
@@ -62,4 +62,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.md
+++ b/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.md
@@ -61,4 +61,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.md
+++ b/docs/libcurl/opts/CURLOPT_HAPROXYPROTOCOL.md
@@ -60,4 +60,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is enabled, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HAPROXY_CLIENT_IP.md
+++ b/docs/libcurl/opts/CURLOPT_HAPROXY_CLIENT_IP.md
@@ -65,4 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is enabled, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HEADER.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HEADERDATA.md
+++ b/docs/libcurl/opts/CURLOPT_HEADERDATA.md
@@ -85,4 +85,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_HEADERFUNCTION.md
@@ -131,4 +131,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -77,4 +77,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HSTS.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS.md
@@ -80,4 +80,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HSTS_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS_CTRL.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP09_ALLOWED.md
@@ -64,4 +64,7 @@ responses.
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP200ALIASES.md
@@ -77,4 +77,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -161,6 +161,7 @@ CURLAUTH_AWS_SIGV4 was added in 7.74.0
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_NOT_BUILT_IN if the bitmask specified no supported authentication
-methods.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTPGET.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPGET.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPHEADER.md
@@ -184,4 +184,7 @@ Use for MIME mail added in 7.56.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTPPOST.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPPOST.md
@@ -100,4 +100,7 @@ Deprecated in 7.56.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is enabled, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPPROXYTUNNEL.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTP_CONTENT_DECODING.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_CONTENT_DECODING.md
@@ -58,4 +58,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTP_TRANSFER_DECODING.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_TRANSFER_DECODING.md
@@ -56,4 +56,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -119,4 +119,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.md
+++ b/docs/libcurl/opts/CURLOPT_IGNORE_CONTENT_LENGTH.md
@@ -73,4 +73,7 @@ Support for FTP added in 7.46.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_INFILESIZE.md
+++ b/docs/libcurl/opts/CURLOPT_INFILESIZE.md
@@ -85,4 +85,7 @@ SMTP support added in 7.23.0
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_INFILESIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_INFILESIZE_LARGE.md
@@ -81,4 +81,7 @@ SMTP support added in 7.23.0
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_INTERFACE.md
+++ b/docs/libcurl/opts/CURLOPT_INTERFACE.md
@@ -89,5 +89,7 @@ The `ifhost!` syntax was added in 8.9.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK on success or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.md
+++ b/docs/libcurl/opts/CURLOPT_INTERLEAVEDATA.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_INTERLEAVEFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_INTERLEAVEFUNCTION.md
@@ -98,4 +98,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_IOCTLDATA.md
+++ b/docs/libcurl/opts/CURLOPT_IOCTLDATA.md
@@ -72,4 +72,7 @@ Deprecated since 7.18.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_IOCTLFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_IOCTLFUNCTION.md
@@ -103,4 +103,7 @@ Deprecated since 7.18.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -79,4 +79,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT.md
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT.md
@@ -78,5 +78,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_ISSUERCERT_BLOB.md
@@ -89,5 +89,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_KEEP_SENDING_ON_ERROR.md
+++ b/docs/libcurl/opts/CURLOPT_KEEP_SENDING_ON_ERROR.md
@@ -64,4 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is enabled, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_KEYPASSWD.md
+++ b/docs/libcurl/opts/CURLOPT_KEYPASSWD.md
@@ -75,5 +75,7 @@ CURLOPT_SSLCERTPASSWD up to 7.9.2.
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_KRBLEVEL.md
+++ b/docs/libcurl/opts/CURLOPT_KRBLEVEL.md
@@ -68,5 +68,7 @@ This option was known as CURLOPT_KRB4LEVEL up to 7.16.3
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_LOCALPORT.md
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORT.md
@@ -60,4 +60,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.md
+++ b/docs/libcurl/opts/CURLOPT_LOCALPORTRANGE.md
@@ -63,4 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_LOGIN_OPTIONS.md
@@ -81,5 +81,7 @@ Support for OpenLDAP added in 7.82.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.md
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_LIMIT.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.md
+++ b/docs/libcurl/opts/CURLOPT_LOW_SPEED_TIME.md
@@ -63,4 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAIL_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_AUTH.md
@@ -74,5 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAIL_FROM.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_FROM.md
@@ -67,5 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAIL_RCPT.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_RCPT.md
@@ -81,4 +81,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAIL_RCPT_ALLOWFAILS.md
+++ b/docs/libcurl/opts/CURLOPT_MAIL_RCPT_ALLOWFAILS.md
@@ -80,4 +80,7 @@ two letter L) before 8.2.0
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.md
+++ b/docs/libcurl/opts/CURLOPT_MAXAGE_CONN.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAXCONNECTS.md
+++ b/docs/libcurl/opts/CURLOPT_MAXCONNECTS.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE.md
@@ -67,5 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the size passed is valid or CURLE_BAD_FUNCTION_ARGUMENT if
-not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_MAXFILESIZE_LARGE.md
@@ -69,5 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_BAD_FUNCTION_ARGUMENT if the size passed is invalid.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.md
+++ b/docs/libcurl/opts/CURLOPT_MAXLIFETIME_CONN.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAXREDIRS.md
+++ b/docs/libcurl/opts/CURLOPT_MAXREDIRS.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_MAX_RECV_SPEED_LARGE.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_MAX_SEND_SPEED_LARGE.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
@@ -95,4 +95,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -139,4 +139,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
@@ -64,5 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_NEW_DIRECTORY_PERMS.md
+++ b/docs/libcurl/opts/CURLOPT_NEW_DIRECTORY_PERMS.md
@@ -62,4 +62,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_NEW_FILE_PERMS.md
+++ b/docs/libcurl/opts/CURLOPT_NEW_FILE_PERMS.md
@@ -58,4 +58,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_NOBODY.md
+++ b/docs/libcurl/opts/CURLOPT_NOBODY.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_NOPROGRESS.md
+++ b/docs/libcurl/opts/CURLOPT_NOPROGRESS.md
@@ -61,4 +61,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_NOPROXY.md
+++ b/docs/libcurl/opts/CURLOPT_NOPROXY.md
@@ -88,5 +88,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_NOSIGNAL.md
+++ b/docs/libcurl/opts/CURLOPT_NOSIGNAL.md
@@ -72,4 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.md
+++ b/docs/libcurl/opts/CURLOPT_OPENSOCKETDATA.md
@@ -88,4 +88,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_OPENSOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_OPENSOCKETFUNCTION.md
@@ -135,4 +135,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_PASSWORD.md
@@ -69,5 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
+++ b/docs/libcurl/opts/CURLOPT_PATH_AS_IS.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PINNEDPUBLICKEY.md
@@ -149,5 +149,7 @@ Other SSL backends not supported.
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PIPEWAIT.md
+++ b/docs/libcurl/opts/CURLOPT_PIPEWAIT.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PORT.md
+++ b/docs/libcurl/opts/CURLOPT_PORT.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_POST.md
+++ b/docs/libcurl/opts/CURLOPT_POST.md
@@ -98,4 +98,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDS.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDS.md
@@ -124,4 +124,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE_LARGE.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_POSTQUOTE.md
+++ b/docs/libcurl/opts/CURLOPT_POSTQUOTE.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -81,4 +81,7 @@ This option was known as CURLOPT_POST301 up to 7.19.0 as it only supported the
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PREQUOTE.md
+++ b/docs/libcurl/opts/CURLOPT_PREQUOTE.md
@@ -78,4 +78,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PREREQDATA.md
+++ b/docs/libcurl/opts/CURLOPT_PREREQDATA.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_PREREQFUNCTION.md
@@ -122,4 +122,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PRE_PROXY.md
+++ b/docs/libcurl/opts/CURLOPT_PRE_PROXY.md
@@ -82,5 +82,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if proxies are supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PRIVATE.md
+++ b/docs/libcurl/opts/CURLOPT_PRIVATE.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROGRESSDATA.md
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSDATA.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.md
@@ -126,4 +126,7 @@ Deprecated since 7.32.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
@@ -104,4 +104,7 @@ Deprecated since 7.85.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY.md
@@ -158,5 +158,7 @@ error.
 
 # RETURN VALUE
 
-Returns CURLE_OK if proxies are supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -71,6 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_NOT_BUILT_IN if the bitmask specified no supported authentication
-methods.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXYHEADER.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYHEADER.md
@@ -80,4 +80,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYPASSWORD.md
@@ -68,5 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXYPORT.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYPORT.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -97,4 +97,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERNAME.md
@@ -68,5 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYUSERPWD.md
@@ -69,5 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if proxies are supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO.md
@@ -96,5 +96,7 @@ https://curl.se/docs/ssl-compared.html
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CAINFO_BLOB.md
@@ -89,5 +89,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_CRLFILE.md
@@ -85,5 +85,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT.md
@@ -82,5 +82,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_ISSUERCERT_BLOB.md
@@ -92,5 +92,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_KEYPASSWD.md
@@ -73,5 +73,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_PINNEDPUBLICKEY.md
@@ -131,5 +131,7 @@ Other SSL backends not supported.
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SERVICE_NAME.md
@@ -63,5 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT.md
@@ -84,5 +84,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERTTYPE.md
@@ -78,5 +78,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLCERT_BLOB.md
@@ -83,5 +83,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY.md
@@ -78,5 +78,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEYTYPE.md
@@ -69,5 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLKEY_BLOB.md
@@ -83,5 +83,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
@@ -128,4 +128,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_CIPHER_LIST.md
@@ -102,4 +102,7 @@ Since curl 8.10.0 returns CURLE_NOT_BUILT_IN when not supported.
 
 # RETURN VALUE
 
-Returns CURLE_OK if supported, CURLE_NOT_BUILT_IN otherwise.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -117,4 +117,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYHOST.md
@@ -88,6 +88,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
 
-If 1 is set as argument, *CURLE_BAD_FUNCTION_ARGUMENT* is returned.
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_VERIFYPEER.md
@@ -90,4 +90,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLS13_CIPHERS.md
@@ -95,4 +95,7 @@ by using the CURLOPT_PROXY_SSL_CIPHER_LIST(3) option.
 
 # RETURN VALUE
 
-Returns CURLE_OK if supported, CURLE_NOT_BUILT_IN otherwise.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_PASSWORD.md
@@ -72,5 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_TYPE.md
@@ -79,4 +79,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TLSAUTH_USERNAME.md
@@ -72,5 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PROXY_TRANSFER_MODE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_TRANSFER_MODE.md
@@ -64,5 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if the
-enabled value is not supported.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_PUT.md
+++ b/docs/libcurl/opts/CURLOPT_PUT.md
@@ -89,4 +89,7 @@ Deprecated since 7.12.1.
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_QUICK_EXIT.md
+++ b/docs/libcurl/opts/CURLOPT_QUICK_EXIT.md
@@ -58,4 +58,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_QUOTE.md
+++ b/docs/libcurl/opts/CURLOPT_QUOTE.md
@@ -166,4 +166,7 @@ SFTP support added in 7.16.3. *-prefix for SFTP added in 7.24.0
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RANDOM_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_RANDOM_FILE.md
@@ -41,4 +41,7 @@ Deprecated since 7.84.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RANGE.md
+++ b/docs/libcurl/opts/CURLOPT_RANGE.md
@@ -88,5 +88,7 @@ FILE since 7.18.0, RTSP since 7.20.0
 
 # RETURN VALUE
 
-Returns CURLE_OK on success or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
@@ -114,4 +114,7 @@ Deprecated since 7.85.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_REFERER.md
+++ b/docs/libcurl/opts/CURLOPT_REFERER.md
@@ -65,5 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP support is enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.md
+++ b/docs/libcurl/opts/CURLOPT_REQUEST_TARGET.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.md
@@ -121,4 +121,7 @@ Support for adding non-permanent entries by using the "+" prefix was added in
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_DATA.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVER_START_FUNCTION.md
@@ -84,4 +84,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RESUME_FROM.md
+++ b/docs/libcurl/opts/CURLOPT_RESUME_FROM.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RESUME_FROM_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_RESUME_FROM_LARGE.md
@@ -75,4 +75,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RTSP_CLIENT_CSEQ.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_CLIENT_CSEQ.md
@@ -58,4 +58,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
@@ -135,4 +135,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RTSP_SERVER_CSEQ.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SERVER_CSEQ.md
@@ -57,4 +57,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_SESSION_ID.md
@@ -66,5 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_STREAM_URI.md
@@ -70,5 +70,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
@@ -63,5 +63,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.md
+++ b/docs/libcurl/opts/CURLOPT_SASL_AUTHZID.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SASL_IR.md
+++ b/docs/libcurl/opts/CURLOPT_SASL_IR.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.md
@@ -98,4 +98,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT.md
@@ -71,6 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if supported, and CURLE_UNKNOWN_OPTION if not. Returns
-CURLE_BAD_FUNCTION_ARGUMENT if set to a negative value or a value that when
-converted to milliseconds is too large.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_SERVER_RESPONSE_TIMEOUT_MS.md
@@ -73,6 +73,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if supported, and CURLE_UNKNOWN_OPTION if not. Returns
-CURLE_BAD_FUNCTION_ARGUMENT if set to a negative value or a value that when
-converted to milliseconds is too large.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SERVICE_NAME.md
+++ b/docs/libcurl/opts/CURLOPT_SERVICE_NAME.md
@@ -68,5 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLOPT_SHARE.md
@@ -84,4 +84,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKOPTFUNCTION.md
@@ -127,4 +127,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -64,5 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_NOT_BUILT_IN if the bitmask contains unsupported flags.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_NEC.md
@@ -59,4 +59,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_GSSAPI_SERVICE.md
@@ -67,5 +67,7 @@ Deprecated since 7.49.0
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
@@ -64,4 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_COMPRESSION.md
@@ -60,5 +60,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYDATA.md
@@ -74,4 +74,7 @@ Works only with the libssh2 backend.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOSTKEYFUNCTION.md
@@ -99,4 +99,7 @@ Work only with the libssh2 backend.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_MD5.md
@@ -70,5 +70,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256.md
@@ -70,5 +70,7 @@ Requires the libssh2 backend.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYDATA.md
@@ -72,4 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KEYFUNCTION.md
@@ -149,4 +149,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.md
@@ -67,5 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_PRIVATE_KEYFILE.md
@@ -72,5 +72,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_PUBLIC_KEYFILE.md
@@ -71,5 +71,7 @@ The "" trick was added in 7.26.0
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSLCERT.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT.md
@@ -92,5 +92,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERTTYPE.md
@@ -76,5 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_SSLCERT_BLOB.md
@@ -83,5 +83,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSLKEY.md
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY.md
@@ -74,5 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_SSLKEYTYPE.md
@@ -80,5 +80,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.md
+++ b/docs/libcurl/opts/CURLOPT_SSLKEY_BLOB.md
@@ -85,5 +85,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS enabled, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.md
@@ -154,4 +154,7 @@ Rustls support added in 8.10.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_CIPHER_LIST.md
@@ -103,4 +103,7 @@ Since curl 8.10.0 returns CURLE_NOT_BUILT_IN when not supported.
 
 # RETURN VALUE
 
-Returns CURLE_OK if supported, CURLE_NOT_BUILT_IN otherwise.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_EC_CURVES.md
@@ -66,4 +66,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_ALPN.md
@@ -58,4 +58,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
@@ -64,4 +64,7 @@ Deprecated since 7.86.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_FALSESTART.md
@@ -58,5 +58,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if false start is supported by the SSL backend, otherwise
-returns CURLE_NOT_BUILT_IN.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -123,4 +123,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_SESSIONID_CACHE.md
@@ -64,4 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYHOST.md
@@ -118,4 +118,7 @@ From 7.66.0: libcurl treats 1 and 2 to this option the same.
 
 # RETURN VALUE
 
-Returns CURLE_OK if TLS is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYPEER.md
@@ -96,4 +96,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_VERIFYSTATUS.md
@@ -65,5 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if OCSP stapling is supported by the SSL backend, otherwise
-returns CURLE_NOT_BUILT_IN.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_STDERR.md
+++ b/docs/libcurl/opts/CURLOPT_STDERR.md
@@ -61,4 +61,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.md
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS.md
@@ -73,4 +73,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.md
+++ b/docs/libcurl/opts/CURLOPT_STREAM_DEPENDS_E.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.md
+++ b/docs/libcurl/opts/CURLOPT_STREAM_WEIGHT.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_FASTOPEN.md
@@ -62,5 +62,7 @@ This option is only supported on Linux and macOS 10.11 or later.
 
 # RETURN VALUE
 
-Returns CURLE_OK if fast open is supported by the operating system, otherwise
-returns CURLE_NOT_BUILT_IN.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPALIVE.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPCNT.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPCNT.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPIDLE.md
@@ -70,4 +70,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_KEEPINTVL.md
@@ -69,4 +69,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
@@ -71,4 +71,7 @@ The default was changed to 1 from 0 in 7.50.2.
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TELNETOPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_TELNETOPTIONS.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if TELNET is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TFTP_BLKSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_TFTP_BLKSIZE.md
@@ -59,4 +59,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_TFTP_NO_OPTIONS.md
@@ -74,4 +74,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
@@ -68,4 +68,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT.md
@@ -85,5 +85,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK. Returns CURLE_BAD_FUNCTION_ARGUMENT if set to a negative
-value or a value that when converted to milliseconds is too large.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEOUT_MS.md
@@ -60,4 +60,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
@@ -65,4 +65,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
+++ b/docs/libcurl/opts/CURLOPT_TLS13_CIPHERS.md
@@ -95,4 +95,7 @@ by using the CURLOPT_SSL_CIPHER_LIST(3) option.
 
 # RETURN VALUE
 
-Returns CURLE_OK if supported, CURLE_NOT_BUILT_IN otherwise.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_PASSWORD.md
@@ -71,5 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_TYPE.md
@@ -75,4 +75,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_TLSAUTH_USERNAME.md
@@ -70,5 +70,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TRAILERDATA.md
+++ b/docs/libcurl/opts/CURLOPT_TRAILERDATA.md
@@ -55,4 +55,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.md
@@ -107,4 +107,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TRANSFERTEXT.md
+++ b/docs/libcurl/opts/CURLOPT_TRANSFERTEXT.md
@@ -61,4 +61,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if FTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.md
+++ b/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.md
@@ -64,4 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.md
+++ b/docs/libcurl/opts/CURLOPT_UNIX_SOCKET_PATH.md
@@ -85,4 +85,7 @@ you can use the proc filesystem to bypass the limitation:
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_UNRESTRICTED_AUTH.md
@@ -81,4 +81,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.md
+++ b/docs/libcurl/opts/CURLOPT_UPKEEP_INTERVAL_MS.md
@@ -78,4 +78,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_UPLOAD.md
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD.md
@@ -93,4 +93,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_UPLOAD_BUFFERSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_UPLOAD_BUFFERSIZE.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_URL.md
+++ b/docs/libcurl/opts/CURLOPT_URL.md
@@ -139,9 +139,10 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK on success or CURLE_OUT_OF_MEMORY if there was insufficient
-heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
 
-Note that curl_easy_setopt(3) does not parse the given string so given a
-bad URL, it is not detected until curl_easy_perform(3) or similar is
-called.
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).
+
+Note that curl_easy_setopt(3) does not parse the given string so given a bad
+URL, it is not detected until curl_easy_perform(3) or similar is called.

--- a/docs/libcurl/opts/CURLOPT_USERAGENT.md
+++ b/docs/libcurl/opts/CURLOPT_USERAGENT.md
@@ -64,5 +64,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if HTTP is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_USERNAME.md
+++ b/docs/libcurl/opts/CURLOPT_USERNAME.md
@@ -86,5 +86,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_USERPWD.md
+++ b/docs/libcurl/opts/CURLOPT_USERPWD.md
@@ -95,5 +95,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK on success or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -89,4 +89,7 @@ OpenLDAP backend only.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_VERBOSE.md
+++ b/docs/libcurl/opts/CURLOPT_VERBOSE.md
@@ -67,4 +67,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.md
+++ b/docs/libcurl/opts/CURLOPT_WILDCARDMATCH.md
@@ -107,4 +107,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_WS_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_WS_OPTIONS.md
@@ -71,4 +71,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, and CURLE_UNKNOWN_OPTION if not.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_XFERINFODATA.md
+++ b/docs/libcurl/opts/CURLOPT_XFERINFODATA.md
@@ -76,4 +76,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.md
@@ -120,4 +120,7 @@ int main(void)
 
 # RETURN VALUE
 
-Returns CURLE_OK.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).

--- a/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.md
+++ b/docs/libcurl/opts/CURLOPT_XOAUTH2_BEARER.md
@@ -73,5 +73,7 @@ Support for OpenLDAP added in 7.82.0.
 
 # RETURN VALUE
 
-Returns CURLE_OK if the option is supported, CURLE_UNKNOWN_OPTION if not, or
-CURLE_OUT_OF_MEMORY if there was insufficient heap space.
+curl_easy_setopt(3) returns a CURLcode indicating success or error.
+
+CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
+libcurl-errors(3).


### PR DESCRIPTION
Expand a little.

- mention the type name of the return code
- avoid stating which exact return codes that might be returned, as that varies over time, builds and conditions
- avoid stating some always return OK
- refer to the manpage documenting all the return codes