### PR TITLE
websocket, fix EAGAIN handling, improve testing

### DIFF
--- a/docs/libcurl/libcurl-env-dbg.md
+++ b/docs/libcurl/libcurl-env-dbg.md
@@ -130,6 +130,11 @@ greater. There is a number of debug levels, refer to *openldap.c* comments.
 Used to influence the buffer chunk size used for WebSocket encoding and
 decoding.
 
+## CURL_WS_CHUNK_EAGAIN
+
+Used to simulate blocking sends after this chunk size for WebSocket
+connections.
+
 ## CURL_FORBID_REUSE
 
 Used to set the CURLOPT_FORBID_REUSE flag on each transfer initiated

--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -45,11 +45,6 @@ static size_t chunk_len(const struct buf_chunk *chunk)
   return chunk->w_offset - chunk->r_offset;
 }
 
-static size_t chunk_space(const struct buf_chunk *chunk)
-{
-  return chunk->dlen - chunk->w_offset;
-}
-
 static void chunk_reset(struct buf_chunk *chunk)
 {
   chunk->next = NULL;
@@ -285,24 +280,6 @@ size_t Curl_bufq_len(const struct bufq *q)
     chunk = chunk->next;
   }
   return len;
-}
-
-size_t Curl_bufq_space(const struct bufq *q)
-{
-  size_t space = 0;
-  if(q->tail)
-    space += chunk_space(q->tail);
-  if(q->spare) {
-    struct buf_chunk *chunk = q->spare;
-    while(chunk) {
-      space += chunk->dlen;
-      chunk = chunk->next;
-    }
-  }
-  if(q->chunk_count < q->max_chunks) {
-    space += (q->max_chunks - q->chunk_count) * q->chunk_size;
-  }
-  return space;
 }
 
 bool Curl_bufq_is_empty(const struct bufq *q)

--- a/lib/bufq.h
+++ b/lib/bufq.h
@@ -151,14 +151,6 @@ void Curl_bufq_free(struct bufq *q);
 size_t Curl_bufq_len(const struct bufq *q);
 
 /**
- * Return the total amount of free space in the queue.
- * The returned length is the number of bytes that can
- * be expected to be written successfully to the bufq,
- * providing no memory allocations fail.
- */
-size_t Curl_bufq_space(const struct bufq *q);
-
-/**
  * Returns TRUE iff there is no data in the buffer queue.
  */
 bool Curl_bufq_is_empty(const struct bufq *q);

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1147,7 +1147,7 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *d, const void *buffer_arg,
   struct websocket *ws;
   const unsigned char *buffer = buffer_arg;
   ssize_t n;
-  CURLcode result;
+  CURLcode result = CURLE_OK;
   struct Curl_easy *data = d;
 
   CURL_TRC_WS(data, "curl_ws_send(len=%zu, fragsize=%" FMT_OFF_T

--- a/lib/ws.h
+++ b/lib/ws.h
@@ -65,7 +65,8 @@ struct websocket {
   struct bufq recvbuf;    /* raw data from the server */
   struct bufq sendbuf;    /* raw data to be sent to the server */
   struct curl_ws_frame frame;  /* the current WS FRAME received */
-  BIT(eagain_encoded); /* EAGAIN on already encoded frame */
+  size_t sendbuf_payload; /* number of payload bytes in sendbuf */
+  BIT(enc_ack_pending);   /* sending was EGAINed, need OK after flush */
 };
 
 CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req);

--- a/lib/ws.h
+++ b/lib/ws.h
@@ -66,7 +66,6 @@ struct websocket {
   struct bufq sendbuf;    /* raw data to be sent to the server */
   struct curl_ws_frame frame;  /* the current WS FRAME received */
   size_t sendbuf_payload; /* number of payload bytes in sendbuf */
-  BIT(enc_ack_pending);   /* sending was EGAINed, need OK after flush */
 };
 
 CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req);

--- a/lib/ws.h
+++ b/lib/ws.h
@@ -53,7 +53,7 @@ struct ws_encoder {
   unsigned int xori; /* xor index */
   unsigned char mask[4]; /* 32-bit mask for this connection */
   unsigned char firstbyte; /* first byte of frame we encode */
-  bool contfragment; /* set TRUE if the previous fragment sent was not final */
+  BIT(contfragment); /* set TRUE if the previous fragment sent was not final */
 };
 
 /* A websocket connection with en- and decoder that treat frames
@@ -65,6 +65,7 @@ struct websocket {
   struct bufq recvbuf;    /* raw data from the server */
   struct bufq sendbuf;    /* raw data to be sent to the server */
   struct curl_ws_frame frame;  /* the current WS FRAME received */
+  BIT(eagain_encoded); /* EAGAIN on already encoded frame */
 };
 
 CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req);

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -42,7 +42,6 @@ if($ARGV[0] eq "--unit") {
 my $file = $ARGV[0];
 
 my %wl = (
-    'Curl_bufq_space' => 'internal api',
     'Curl_xfer_write_resp' => 'internal api',
     'Curl_creader_def_init' => 'internal api',
     'Curl_creader_def_close' => 'internal api',

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -42,6 +42,7 @@ if($ARGV[0] eq "--unit") {
 my $file = $ARGV[0];
 
 my %wl = (
+    'Curl_bufq_space' => 'internal api',
     'Curl_xfer_write_resp' => 'internal api',
     'Curl_creader_def_init' => 'internal api',
     'Curl_creader_def_close' => 'internal api',

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -167,8 +167,9 @@ static CURLcode data_echo(CURL *curl, size_t count,
         r = curl_ws_send(curl, sbuf, slen, &nwritten, 0, CURLWS_BINARY);
         sblock = (r == CURLE_AGAIN);
         if(!r || (r == CURLE_AGAIN)) {
-          fprintf(stderr, "curl_ws_send(len=%ld) -> %d, %zu (%zu/%zu)\n",
-                  (long)slen, r, nwritten, len - slen, len);
+          fprintf(stderr, "curl_ws_send(len=%ld) -> %d, %ld (%ld/%ld)\n",
+                  (long)slen, r, (long)nwritten,
+                  (long)(len - slen), (long)len);
           sbuf += nwritten;
           slen -= nwritten;
         }
@@ -187,8 +188,8 @@ static CURLcode data_echo(CURL *curl, size_t count,
                          &nread, &frame);
         if(!r || (r == CURLE_AGAIN)) {
           rblock = (r == CURLE_AGAIN);
-          fprintf(stderr, "curl_ws_recv(len=%ld) -> %d, %zu (%zu/%zu) \n",
-                  (long)rlen, r, nread, len - rlen, len);
+          fprintf(stderr, "curl_ws_recv(len=%ld) -> %d, %ld (%ld/%ld) \n",
+                  (long)rlen, r, (long)nread, (long)(len - rlen), (long)len);
           if(!r) {
             r = check_recv(frame, len - rlen, nread, len);
             if(r)

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -241,8 +241,6 @@ out:
   return r;
 }
 
-#endif
-
 static void usage(const char *msg)
 {
   if(msg)
@@ -253,6 +251,8 @@ static void usage(const char *msg)
     "  -M number  maximum frame size\n"
   );
 }
+
+#endif
 
 int main(int argc, char *argv[])
 {

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -267,7 +267,7 @@ int main(int argc, char *argv[])
     switch(ch) {
     case 'h':
       usage(NULL);
-      res = 2;
+      res = CURLE_BAD_FUNCTION_ARGUMENT;
       goto cleanup;
     case 'c':
       count = (size_t)strtol(optarg, NULL, 10);
@@ -280,7 +280,7 @@ int main(int argc, char *argv[])
       break;
     default:
       usage("invalid option");
-      res = 1;
+      res = CURLE_BAD_FUNCTION_ARGUMENT;
       goto cleanup;
     }
   }
@@ -293,13 +293,13 @@ int main(int argc, char *argv[])
   if(plen_max < plen_min) {
     fprintf(stderr, "maxlen must be >= minlen, got %ld-%ld\n",
             (long)plen_min, (long)plen_max);
-    res = 2;
+    res = CURLE_BAD_FUNCTION_ARGUMENT;
     goto cleanup;
   }
 
   if(argc != 1) {
     usage(NULL);
-    res = 2;
+    res = CURLE_BAD_FUNCTION_ARGUMENT;
     goto cleanup;
   }
   url = argv[0];

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -104,9 +104,16 @@ static CURLcode check_recv(const struct curl_ws_frame *frame,
   if(!frame)
     return CURLE_OK;
 
+  if(frame->flags & CURLWS_CLOSE) {
+    fprintf(stderr, "recv_data: unexpected CLOSE frame from server, "
+            "got %ld bytes, offset=%ld, rflags %x\n",
+            (long)nread, (long)r_offset, frame->flags);
+    return CURLE_RECV_ERROR;
+  }
   if(!r_offset && !(frame->flags & CURLWS_BINARY)) {
-    fprintf(stderr, "recv_data: wrong frame, got %ld bytes rflags %x\n",
-            (long)r_offset, frame->flags);
+    fprintf(stderr, "recv_data: wrong frame, got %ld bytes, offset=%ld, "
+            "rflags %x\n",
+            (long)nread, (long)r_offset, frame->flags);
     return CURLE_RECV_ERROR;
   }
   if(frame->offset != (curl_off_t)r_offset) {

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -93,86 +93,38 @@ void dump(const char *text, unsigned char *ptr, size_t size,
   }
 }
 
-static CURLcode send_binary(CURL *curl, char *buf, size_t buflen)
+static CURLcode check_recv(const struct curl_ws_frame *frame,
+                           size_t r_offset, size_t nread, size_t exp_len)
 {
-  size_t nwritten;
-  CURLcode result =
-    curl_ws_send(curl, buf, buflen, &nwritten, 0, CURLWS_BINARY);
-  fprintf(stderr, "ws: send_binary(len=%ld) -> %d, %ld\n",
-          (long)buflen, result, (long)nwritten);
-  return result;
+  if(!frame)
+    return CURLE_OK;
+
+  if(!r_offset && !(frame->flags & CURLWS_BINARY)) {
+    fprintf(stderr, "recv_data: wrong frame, got %ld bytes rflags %x\n",
+            (long)r_offset, frame->flags);
+    return CURLE_RECV_ERROR;
+  }
+  if(frame->offset != (curl_off_t)r_offset) {
+    fprintf(stderr, "recv_data: frame offset, expected %ld, got %ld\n",
+            (long)r_offset, (long)frame->offset);
+    return CURLE_RECV_ERROR;
+  }
+  if(frame->bytesleft != (curl_off_t)(exp_len - r_offset - nread)) {
+    fprintf(stderr, "recv_data: frame bytesleft, expected %ld, got %ld\n",
+            (long)(exp_len - r_offset - nread), (long)frame->bytesleft);
+    return CURLE_RECV_ERROR;
+  }
+  if(r_offset + nread > exp_len) {
+    fprintf(stderr, "recv_data: data length, expected %ld, now at %ld\n",
+            (long)exp_len, (long)(r_offset + nread));
+    return CURLE_RECV_ERROR;
+  }
+  return CURLE_OK;
 }
 
 #if defined(__TANDEM)
 # include <cextdecs.h(PROCESS_DELAY_)>
 #endif
-static CURLcode recv_binary(CURL *curl, char *exp_data, size_t exp_len)
-{
-  const struct curl_ws_frame *frame;
-  char recvbuf[256];
-  size_t r_offset, nread;
-  CURLcode result;
-
-  fprintf(stderr, "recv_binary: expected payload %ld bytes\n", (long)exp_len);
-  r_offset = 0;
-  while(1) {
-    result = curl_ws_recv(curl, recvbuf, sizeof(recvbuf), &nread, &frame);
-    if(result == CURLE_AGAIN) {
-      fprintf(stderr, "EAGAIN, sleep, try again\n");
-#ifdef _WIN32
-      Sleep(100);
-#elif defined(__TANDEM)
-      /* NonStop only defines usleep when building for a threading model */
-# if defined(_PUT_MODEL_) || defined(_KLT_MODEL_)
-      usleep(100*1000);
-# else
-      PROCESS_DELAY_(100*1000);
-# endif
-#else
-      usleep(100*1000);
-#endif
-      continue;
-    }
-    fprintf(stderr, "ws: curl_ws_recv(offset=%ld, len=%ld) -> %d, %ld\n",
-            (long)r_offset, (long)sizeof(recvbuf), result, (long)nread);
-    if(result) {
-      return result;
-    }
-    if(!(frame->flags & CURLWS_BINARY)) {
-      fprintf(stderr, "recv_data: wrong frame, got %ld bytes rflags %x\n",
-              (long)nread, frame->flags);
-      return CURLE_RECV_ERROR;
-    }
-    if(frame->offset != (curl_off_t)r_offset) {
-      fprintf(stderr, "recv_data: frame offset, expected %ld, got %ld\n",
-              (long)r_offset, (long)frame->offset);
-      return CURLE_RECV_ERROR;
-    }
-    if(frame->bytesleft != (curl_off_t)(exp_len - r_offset - nread)) {
-      fprintf(stderr, "recv_data: frame bytesleft, expected %ld, got %ld\n",
-              (long)(exp_len - r_offset - nread), (long)frame->bytesleft);
-      return CURLE_RECV_ERROR;
-    }
-    if(r_offset + nread > exp_len) {
-      fprintf(stderr, "recv_data: data length, expected %ld, now at %ld\n",
-              (long)exp_len, (long)(r_offset + nread));
-      return CURLE_RECV_ERROR;
-    }
-    if(memcmp(exp_data + r_offset, recvbuf, nread)) {
-      fprintf(stderr, "recv_data: data differs, offset=%ld, len=%ld\n",
-              (long)r_offset, (long)nread);
-      dump("expected:", (unsigned char *)exp_data + r_offset, nread, 0);
-      dump("received:", (unsigned char *)recvbuf, nread, 0);
-      return CURLE_RECV_ERROR;
-    }
-    r_offset += nread;
-    if(r_offset >= exp_len) {
-      fprintf(stderr, "recv_data: frame complete\n");
-      break;
-    }
-  }
-  return CURLE_OK;
-}
 
 /* just close the connection */
 static void websocket_close(CURL *curl)
@@ -184,12 +136,15 @@ static void websocket_close(CURL *curl)
           "ws: curl_ws_send returned %u, sent %u\n", (int)result, (int)sent);
 }
 
-static CURLcode data_echo(CURL *curl, size_t plen_min, size_t plen_max)
+static CURLcode data_echo(CURL *curl, size_t count,
+                          size_t plen_min, size_t plen_max)
 {
-  CURLcode res = CURLE_OK;
+  CURLcode r = CURLE_OK;
+  const struct curl_ws_frame *frame;
   size_t len;
-  char *send_buf;
-  size_t i;
+  char *send_buf, *recv_buf;
+  size_t i, scount = count, rcount = count;
+  int rblock, sblock;
 
   send_buf = calloc(1, plen_max);
   if(!send_buf)
@@ -197,26 +152,106 @@ static CURLcode data_echo(CURL *curl, size_t plen_min, size_t plen_max)
   for(i = 0; i < plen_max; ++i) {
     send_buf[i] = (char)('0' + ((int)i % 10));
   }
+  recv_buf = calloc(1, plen_max);
+  if(!recv_buf)
+    return CURLE_OUT_OF_MEMORY;
 
   for(len = plen_min; len <= plen_max; ++len) {
-    res = send_binary(curl, send_buf, len);
-    if(res)
-      goto out;
-    res = recv_binary(curl, send_buf, len);
-    if(res) {
-      fprintf(stderr, "recv_data(len=%ld) -> %d\n", (long)len, res);
+    size_t nwritten, nread, slen = len, rlen = len;
+    char *sbuf = send_buf, *rbuf = recv_buf;
+
+    memset(recv_buf, 0, plen_max);
+    while(slen || rlen || scount || rcount) {
+      sblock = rblock = 1;
+      if(slen) {
+        r = curl_ws_send(curl, sbuf, slen, &nwritten, 0, CURLWS_BINARY);
+        sblock = (r == CURLE_AGAIN);
+        if(!r || (r == CURLE_AGAIN)) {
+          fprintf(stderr, "curl_ws_send(len=%ld) -> %d, %zu (%zu/%zu)\n",
+                  (long)slen, r, nwritten, len - slen, len);
+          sbuf += nwritten;
+          slen -= nwritten;
+        }
+        else
+          goto out;
+      }
+      if(!slen && scount) { /* go again? */
+        scount--;
+        sbuf = send_buf;
+        slen = len;
+      }
+
+      if(rlen) {
+        size_t max_recv = (64 * 1024);
+        r = curl_ws_recv(curl, rbuf, (rlen > max_recv) ? max_recv : rlen,
+                         &nread, &frame);
+        if(!r || (r == CURLE_AGAIN)) {
+          rblock = (r == CURLE_AGAIN);
+          fprintf(stderr, "curl_ws_recv(len=%ld) -> %d, %zu (%zu/%zu) \n",
+                  (long)rlen, r, nread, len - rlen, len);
+          if(!r) {
+            r = check_recv(frame, len - rlen, nread, len);
+            if(r)
+              goto out;
+          }
+          rbuf += nread;
+          rlen -= nread;
+        }
+        else
+          goto out;
+      }
+      if(!rlen && rcount) { /* go again? */
+        rcount--;
+        rbuf = recv_buf;
+        rlen = len;
+      }
+
+      if(rblock && sblock) {
+        fprintf(stderr, "EAGAIN, sleep, try again\n");
+  #ifdef _WIN32
+        Sleep(100);
+  #elif defined(__TANDEM)
+        /* NonStop only defines usleep when building for a threading model */
+  # if defined(_PUT_MODEL_) || defined(_KLT_MODEL_)
+        usleep(100*1000);
+  # else
+        PROCESS_DELAY_(100*1000);
+  # endif
+  #else
+        usleep(100*1000);
+  #endif
+      }
+    }
+
+    if(memcmp(send_buf, recv_buf, len)) {
+      fprintf(stderr, "recv_data: data differs\n");
+      dump("expected:", (unsigned char *)send_buf, len, 0);
+      dump("received:", (unsigned char *)recv_buf, len, 0);
+      r = CURLE_RECV_ERROR;
       goto out;
     }
   }
 
 out:
-  if(!res)
+  if(!r)
     websocket_close(curl);
   free(send_buf);
-  return res;
+  free(recv_buf);
+  return r;
 }
 
 #endif
+
+static void usage(const char *msg)
+{
+  if(msg)
+    fprintf(stderr, "%s\n", msg);
+  fprintf(stderr,
+    "usage: [options] url\n"
+    "  -m number  minimum frame size\n"
+    "  -M number  maximum frame size\n"
+  );
+}
 
 int main(int argc, char *argv[])
 {
@@ -224,32 +259,49 @@ int main(int argc, char *argv[])
   CURL *curl;
   CURLcode res = CURLE_OK;
   const char *url;
-  long l1, l2;
-  size_t plen_min, plen_max;
+  size_t plen_min = 0, plen_max = 0, count = 1;
+  int ch;
 
+  while((ch = getopt(argc, argv, "c:hm:M:")) != -1) {
+    switch(ch) {
+    case 'h':
+      usage(NULL);
+      res = 2;
+      goto cleanup;
+    case 'c':
+      count = (size_t)strtol(optarg, NULL, 10);
+      break;
+    case 'm':
+      plen_min = (size_t)strtol(optarg, NULL, 10);
+      break;
+    case 'M':
+      plen_max = (size_t)strtol(optarg, NULL, 10);
+      break;
+    default:
+      usage("invalid option");
+      res = 1;
+      goto cleanup;
+    }
+  }
+  argc -= optind;
+  argv += optind;
 
-  if(argc != 4) {
-    fprintf(stderr, "usage: ws-data url minlen maxlen\n");
-    return 2;
-  }
-  url = argv[1];
-  l1 = strtol(argv[2], NULL, 10);
-  if(l1 < 0) {
-    fprintf(stderr, "minlen must be >= 0, got %ld\n", l1);
-    return 2;
-  }
-  l2 = strtol(argv[3], NULL, 10);
-  if(l2 < 0) {
-    fprintf(stderr, "maxlen must be >= 0, got %ld\n", l2);
-    return 2;
-  }
-  plen_min = l1;
-  plen_max = l2;
+  if(!plen_max)
+    plen_max = plen_min;
+
   if(plen_max < plen_min) {
     fprintf(stderr, "maxlen must be >= minlen, got %ld-%ld\n",
             (long)plen_min, (long)plen_max);
-    return 2;
+    res = 2;
+    goto cleanup;
   }
+
+  if(argc != 1) {
+    usage(NULL);
+    res = 2;
+    goto cleanup;
+  }
+  url = argv[0];
 
   curl_global_init(CURL_GLOBAL_ALL);
 
@@ -264,11 +316,13 @@ int main(int argc, char *argv[])
     res = curl_easy_perform(curl);
     fprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
     if(res == CURLE_OK)
-      res = data_echo(curl, plen_min, plen_max);
+      res = data_echo(curl, count, plen_min, plen_max);
 
     /* always cleanup */
     curl_easy_cleanup(curl);
   }
+
+cleanup:
   curl_global_cleanup();
   return (int)res;
 

--- a/tests/http/clients/ws-data.c
+++ b/tests/http/clients/ws-data.c
@@ -44,6 +44,11 @@
 #include <sys/time.h>
 #endif
 
+#ifndef _MSC_VER
+/* somewhat Unix-specific */
+#include <unistd.h>  /* getopt() */
+#endif
+
 static
 void dump(const char *text, unsigned char *ptr, size_t size,
           char nohex)

--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -103,34 +103,30 @@ class TestWebsockets:
         r = client.run(args=[url, payload])
         r.check_exit_code(56)
 
-    # the python websocket server does not like 'large' control frames
     def test_20_04_data_small(self, env: Env, ws_echo, repeat):
         client = LocalClient(env=env, name='ws-data')
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         url = f'ws://localhost:{env.ws_port}/'
-        r = client.run(args=[url, str(0), str(10)])
+        r = client.run(args=['-m', str(0), '-M', str(10), url])
         r.check_exit_code(0)
 
-    # the python websocket server does not like 'large' control frames
     def test_20_05_data_med(self, env: Env, ws_echo, repeat):
         client = LocalClient(env=env, name='ws-data')
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         url = f'ws://localhost:{env.ws_port}/'
-        r = client.run(args=[url, str(120), str(130)])
+        r = client.run(args=['-m', str(120), '-M', str(130), url])
         r.check_exit_code(0)
 
-    # the python websocket server does not like 'large' control frames
     def test_20_06_data_large(self, env: Env, ws_echo, repeat):
         client = LocalClient(env=env, name='ws-data')
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         url = f'ws://localhost:{env.ws_port}/'
-        r = client.run(args=[url, str(65535 - 5), str(65535 + 5)])
+        r = client.run(args=['-m', str(65535 - 5), '-M', str(65535 + 5), url])
         r.check_exit_code(0)
 
-    # the python websocket server does not like 'large' control frames
     def test_20_07_data_large_small_recv(self, env: Env, ws_echo, repeat):
         client = LocalClient(env=env, name='ws-data', run_env={
             'CURL_WS_CHUNK_SIZE': '1024',
@@ -138,5 +134,17 @@ class TestWebsockets:
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         url = f'ws://localhost:{env.ws_port}/'
-        r = client.run(args=[url, str(65535 - 5), str(65535 + 5)])
+        r = client.run(args=['-m', str(65535 - 5), '-M', str(65535 + 5), url])
         r.check_exit_code(0)
+
+    # the python websocket server does not like too 'large' binary frames
+    def test_20_08_data_very_large(self, env: Env, ws_echo, repeat):
+        client = LocalClient(env=env, name='ws-data')
+        if not client.exists():
+            pytest.skip(f'example client not built: {client.name}')
+        url = f'ws://localhost:{env.ws_port}/'
+        count = 10
+        large = 512 * 1024
+        r = client.run(args=['-c', str(count), '-m', str(large), url])
+        r.check_exit_code(0)
+

--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -128,22 +128,26 @@ class TestWebsockets:
         r.check_exit_code(0)
 
     def test_20_07_data_large_small_recv(self, env: Env, ws_echo, repeat):
-        client = LocalClient(env=env, name='ws-data', run_env={
-            'CURL_WS_CHUNK_SIZE': '1024',
-        })
+        run_env = os.environ.copy()
+        run_env['CURL_WS_CHUNK_SIZE'] = '1024'
+        client = LocalClient(env=env, name='ws-data', run_env=run_env)
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         url = f'ws://localhost:{env.ws_port}/'
         r = client.run(args=['-m', str(65535 - 5), '-M', str(65535 + 5), url])
         r.check_exit_code(0)
 
-    # the python websocket server does not like too 'large' binary frames
+    # Send large frames and simulate send blocking on 8192 bytes chunks
+    # Simlates error reported in #15865
     def test_20_08_data_very_large(self, env: Env, ws_echo, repeat):
-        client = LocalClient(env=env, name='ws-data')
+        run_env = os.environ.copy()
+        run_env['CURL_WS_CHUNK_EAGAIN'] = '8192'
+        client = LocalClient(env=env, name='ws-data', run_env=run_env)
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         url = f'ws://localhost:{env.ws_port}/'
         count = 10
         large = 512 * 1024
+        large = 20000
         r = client.run(args=['-c', str(count), '-m', str(large), url])
         r.check_exit_code(0)

--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -147,4 +147,3 @@ class TestWebsockets:
         large = 512 * 1024
         r = client.run(args=['-c', str(count), '-m', str(large), url])
         r.check_exit_code(0)
-


### PR DESCRIPTION
Fixed a bug in EAGAIN handling when sending frames that led to a corrupted last byte of the frame sent. Added test case to simulate conditions as reporting in #15901.

- change 'ws-data' test client to allow concurrent send/recv operations. Give command line option to vary frame sizes and repeat count
- add test_20_08 with simulated EAGAIN

**Update**: restored sanity to `curl_ws_send()` behaviour. `CURLE_AGAIN` is only returned when non of the payload bytes (or for 0-length frames, not all of the frame header bytes) could be sent.
