### PR TITLE
Fix compiler warning in smb.c

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -915,7 +915,7 @@ static CURLcode smb_connection_state(struct Curl_easy *data, bool *done)
  */
 static void get_posix_time(time_t *out, curl_off_t timestamp)
 {
-  timestamp -= 116444736000000000LL;
+  timestamp -= CURL_OFF_T_C(116444736000000000);
   timestamp /= 10000000;
 #if SIZEOF_TIME_T < SIZEOF_CURL_OFF_T
   if(timestamp > TIME_T_MAX)

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -915,7 +915,7 @@ static CURLcode smb_connection_state(struct Curl_easy *data, bool *done)
  */
 static void get_posix_time(time_t *out, curl_off_t timestamp)
 {
-  timestamp -= 116444736000000000;
+  timestamp -= 116444736000000000LL;
   timestamp /= 10000000;
 #if SIZEOF_TIME_T < SIZEOF_CURL_OFF_T
   if(timestamp > TIME_T_MAX)


### PR DESCRIPTION
An old version of GCC (which is not updatable on the target system) moans about the constant being too big to fit in a long.