### PR TITLE
CURLOPT_SEEKFUNCTION.md: used for FTP, HTTP and SFTP (only)

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SEEKDATA.md
+++ b/docs/libcurl/opts/CURLOPT_SEEKDATA.md
@@ -10,7 +10,9 @@ See-also:
   - CURLOPT_SEEKFUNCTION (3)
   - CURLOPT_STDERR (3)
 Protocol:
-  - All
+  - FTP
+  - HTTP
+  - SFTP
 Added-in: 7.18.0
 ---
 

--- a/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_SEEKFUNCTION.md
@@ -10,7 +10,9 @@ See-also:
   - CURLOPT_SEEKDATA (3)
   - CURLOPT_STDERR (3)
 Protocol:
-  - All
+  - FTP
+  - HTTP
+  - SFTP
 Added-in: 7.18.0
 ---
 


### PR DESCRIPTION
The same goes for *SEEKDATA.