### PR TITLE
Use SSL_poll to determine writeability of QUIC streams

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1461,23 +1461,65 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
 {
   struct cf_osslq_ctx *ctx = cf->ctx;
   struct h3_stream_ctx *stream;
+  SSL_POLL_ITEM *poll_items = NULL;
+  struct Curl_easy **curl_items = NULL;
+  size_t poll_count = 0;
+  size_t result_count = 0;
+  size_t idx_count = 0;
+  CURLcode res = CURLE_OK;
+  struct timeval timeout;
 
   if(ctx->h3.conn) {
     struct Curl_llist_node *e;
+
+    res = CURLE_OUT_OF_MEMORY;
+
+    poll_items = calloc(Curl_llist_count(&data->multi->process),
+                        sizeof(SSL_POLL_ITEM));
+    if (!poll_items)
+        goto out;
+
+    curl_items = calloc(Curl_llist_count(&data->multi->process),
+                        sizeof(struct Curl_easy *));
+    if (!curl_items)
+        goto out;
+
     for(e = Curl_llist_head(&data->multi->process); e; e = Curl_node_next(e)) {
       struct Curl_easy *sdata = Curl_node_elem(e);
-      if(sdata->conn == data->conn) {
+      if (sdata->conn == data->conn) {
         stream = H3_STREAM_CTX(ctx, sdata);
-        if(stream && stream->s.ssl && stream->s.send_blocked &&
-           !SSL_want_write(stream->s.ssl)) {
-          nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
-          stream->s.send_blocked = FALSE;
-          h3_drain_stream(cf, sdata);
-          CURL_TRC_CF(sdata, cf, "unblocked");
+        if (stream && stream->s.ssl && stream->s.send_blocked) {
+          poll_items[poll_count].desc = SSL_as_poll_descriptor(stream->s.ssl);
+          poll_items[poll_count].events = SSL_POLL_EVENT_W;
+          curl_items[poll_count] = sdata;
+          poll_count++;
         }
       }
     }
+
+    memset(&timeout, 0, sizeof(struct timeval));
+    res = CURLE_UNRECOVERABLE_POLL;
+    if (!SSL_poll(poll_items, poll_count, sizeof(SSL_POLL_ITEM), &timeout,
+                  0, &result_count))
+        goto out;
+
+    res = CURLE_OK;
+
+    for (idx_count = 0; idx_count < poll_count && result_count > 0; idx_count++) {
+      if (poll_items[idx_count].revents && SSL_POLL_EVENT_W) {
+          stream = H3_STREAM_CTX(ctx, curl_items[idx_count]);
+          nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
+          stream->s.send_blocked = FALSE;
+          h3_drain_stream(cf, curl_items[idx_count]);
+          CURL_TRC_CF(curl_items[idx_count], cf, "unblocked");
+          result_count--;
+      }
+    }
   }
+
+out:
+  free(poll_items);
+  free(curl_items);
   return CURLE_OK;
 }
 

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1530,7 +1530,7 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
 
     for(idx_count = 0; idx_count < poll_count && result_count > 0;
         idx_count++) {
-      if(ctx->poll_items[idx_count].revents && SSL_POLL_EVENT_W) {
+      if(ctx->poll_items[idx_count].revents & SSL_POLL_EVENT_W) {
         stream = H3_STREAM_CTX(ctx, ctx->curl_items[idx_count]);
         nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
         stream->s.send_blocked = FALSE;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1476,19 +1476,19 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
 
     poll_items = calloc(Curl_llist_count(&data->multi->process),
                         sizeof(SSL_POLL_ITEM));
-    if (!poll_items)
-        goto out;
+    if(!poll_items)
+      goto out;
 
     curl_items = calloc(Curl_llist_count(&data->multi->process),
                         sizeof(struct Curl_easy *));
-    if (!curl_items)
-        goto out;
+    if(!curl_items)
+      goto out;
 
     for(e = Curl_llist_head(&data->multi->process); e; e = Curl_node_next(e)) {
       struct Curl_easy *sdata = Curl_node_elem(e);
-      if (sdata->conn == data->conn) {
+      if(sdata->conn == data->conn) {
         stream = H3_STREAM_CTX(ctx, sdata);
-        if (stream && stream->s.ssl && stream->s.send_blocked) {
+        if(stream && stream->s.ssl && stream->s.send_blocked) {
           poll_items[poll_count].desc = SSL_as_poll_descriptor(stream->s.ssl);
           poll_items[poll_count].events = SSL_POLL_EVENT_W;
           curl_items[poll_count] = sdata;
@@ -1499,20 +1499,21 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
 
     memset(&timeout, 0, sizeof(struct timeval));
     res = CURLE_UNRECOVERABLE_POLL;
-    if (!SSL_poll(poll_items, poll_count, sizeof(SSL_POLL_ITEM), &timeout,
+    if(!SSL_poll(poll_items, poll_count, sizeof(SSL_POLL_ITEM), &timeout,
                   0, &result_count))
         goto out;
 
     res = CURLE_OK;
 
-    for (idx_count = 0; idx_count < poll_count && result_count > 0; idx_count++) {
-      if (poll_items[idx_count].revents && SSL_POLL_EVENT_W) {
-          stream = H3_STREAM_CTX(ctx, curl_items[idx_count]);
-          nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
-          stream->s.send_blocked = FALSE;
-          h3_drain_stream(cf, curl_items[idx_count]);
-          CURL_TRC_CF(curl_items[idx_count], cf, "unblocked");
-          result_count--;
+    for(idx_count = 0; idx_count < poll_count && result_count > 0;
+        idx_count++) {
+      if(poll_items[idx_count].revents && SSL_POLL_EVENT_W) {
+        stream = H3_STREAM_CTX(ctx, curl_items[idx_count]);
+        nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
+        stream->s.send_blocked = FALSE;
+        h3_drain_stream(cf, curl_items[idx_count]);
+        CURL_TRC_CF(curl_items[idx_count], cf, "unblocked");
+        result_count--;
       }
     }
   }

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1474,6 +1474,7 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
   size_t idx_count = 0;
   CURLcode res = CURLE_OK;
   struct timeval timeout;
+  void *tmpptr;
 
   if(ctx->h3.conn) {
     struct Curl_llist_node *e;
@@ -1482,17 +1483,25 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
 
     if(ctx->item_count < Curl_llist_count(&data->multi->process)) {
       ctx->item_count = 0;
-      ctx->poll_items = realloc(ctx->poll_items,
-                                Curl_llist_count(&data->multi->process) *
-                                sizeof(SSL_POLL_ITEM));
-      if(!ctx->poll_items)
+      tmpptr = realloc(ctx->poll_items,
+                       Curl_llist_count(&data->multi->process) *
+                       sizeof(SSL_POLL_ITEM));
+      if(!tmpptr) {
+        free(ctx->poll_items);
+        ctx->poll_items = NULL;
         goto out;
+      }
+      ctx->poll_items = tmpptr;
 
-      ctx->curl_items = realloc(ctx->curl_items,
-                                Curl_llist_count(&data->multi->process) *
-                                sizeof(struct Curl_easy *));
-      if(!ctx->curl_items)
+      tmpptr = realloc(ctx->curl_items,
+                       Curl_llist_count(&data->multi->process) *
+                       sizeof(struct Curl_easy *));
+      if(!tmpptr) {
+        free(ctx->curl_items);
+        ctx->curl_items = NULL;
         goto out;
+      }
+      ctx->curl_items = tmpptr;
 
       ctx->item_count = Curl_llist_count(&data->multi->process);
     }

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1521,7 +1521,7 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
 out:
   free(poll_items);
   free(curl_items);
-  return CURLE_OK;
+  return res;
 }
 
 static CURLcode h3_send_streams(struct Curl_cfilter *cf,


### PR DESCRIPTION
This discussion:
https://github.com/openssl/openssl/discussions/23339#discussion-6094341

Specifically item number 2 (Send Blocking) was raised by the curl team, noting that SSL_want_write returning false was not a good indicator of when a stream is writeable.  The suggestion in that discussion was to use SSL_poll with an SSL_POLL_EVENT_W flag instead, as that is a proper indication of when an SSL_object will allow writing without blocking.

While ssl_want_write updates its state based on the last error encountered (implying a need to retry an operation to update the last_error state again), SSL_poll checks stream buffer status during the call, giving it more up to date information on request.  This is the method used by our guide demos (quic-hq-interop specifically), and it works well.

This change has been run through the curl test suite, and shown to pass all tests.  However, given  the initial problem description I'm not sure if there is a test case that explicitly checks for blocking and unblocking of streams.  As such some additional testing may be warranted.