### PR TITLE
Fixed the SIGPIPE signal leak in version 8.9.1

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -640,6 +640,7 @@ static void cpool_close_and_destroy_all(struct cpool *cpool)
   DEBUGASSERT(cpool);
   /* Move all connections to the shutdown list */
   sigpipe_init(&pipe_st);
+  sigpipe_save(&pipe_st);
   CPOOL_LOCK(cpool);
   conn = cpool_get_live_conn(cpool);
   while(conn) {
@@ -685,6 +686,7 @@ static void cpool_shutdown_destroy_oldest(struct cpool *cpool)
     conn = Curl_node_elem(e);
     Curl_node_remove(e);
     sigpipe_init(&pipe_st);
+    sigpipe_save(&pipe_st);
     sigpipe_apply(cpool->idata, &pipe_st);
     cpool_close_and_destroy(cpool, conn, NULL, FALSE);
     sigpipe_restore(&pipe_st);

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -790,6 +790,7 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
   data->multi_easy = multi;
 
   sigpipe_init(&pipe_st);
+  sigpipe_save(&pipe_st);
   sigpipe_apply(data, &pipe_st);
 
   /* run the transfer */

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3010,6 +3010,7 @@ CURLMcode curl_multi_perform(CURLM *m, int *running_handles)
     return CURLM_RECURSIVE_API_CALL;
 
   sigpipe_init(&pipe_st);
+  sigpipe_save(&pipe_st);
   for(e = Curl_llist_head(&multi->process); e; e = n) {
     struct Curl_easy *data = Curl_node_elem(e);
     CURLMcode result;
@@ -3546,6 +3547,7 @@ static CURLMcode multi_socket(struct Curl_multi *multi,
   mrc.multi = multi;
   mrc.now = Curl_now();
   sigpipe_init(&mrc.pipe_st);
+  sigpipe_save(&mrc.pipe_st);
 
   if(checkall) {
     struct Curl_llist_node *e;

--- a/lib/sigpipe.h
+++ b/lib/sigpipe.h
@@ -40,7 +40,6 @@ struct sigpipe_ignore {
 static void sigpipe_init(struct sigpipe_ignore *ig)
 {
   memset(ig, 0, sizeof(*ig));
-  ig->no_signal = TRUE;
 }
 
 /*
@@ -77,6 +76,14 @@ static void sigpipe_restore(struct sigpipe_ignore *ig)
     sigaction(SIGPIPE, &ig->old_pipe_act, NULL);
 }
 
+static void sigpipe_save(struct sigpipe_ignore *ig)
+{
+  if(!ig->no_signal) {
+    /* save the outside state */
+    sigaction(SIGPIPE, NULL, &ig->old_pipe_act);
+  }
+}
+
 static void sigpipe_apply(struct Curl_easy *data,
                           struct sigpipe_ignore *ig)
 {
@@ -91,6 +98,7 @@ static void sigpipe_apply(struct Curl_easy *data,
 #define sigpipe_ignore(x,y) Curl_nop_stmt
 #define sigpipe_apply(x,y) Curl_nop_stmt
 #define sigpipe_init(x)  Curl_nop_stmt
+#define sigpipe_save(x)  Curl_nop_stmt
 #define sigpipe_restore(x)  Curl_nop_stmt
 #define SIGPIPE_VARIABLE(x)
 #define SIGPIPE_MEMBER(x)   bool x


### PR DESCRIPTION
**Background:**
After version 8.9.1, after performing the following operations on the SIGPIPE signal: `sigpipe_init`, `sigpipe_apply`, `sigpipe_restore`, the SIGPIPE signal processing will be abnormal.
Issue link: [#14344](https://github.com/curl/curl/issues/14344)
**Reason:**
The specific reason is that after calling `sigpipe_init`, `old_pipe_act` is null, which causes problems in setting `old_pipe_act` during the subsequent `sigpipe_restore`.
**Solution:**
After calling `sigpipe_init`, immediately save the old pipe action to `old_pipe_act` through calling `sigpipe_save` function.