### PR TITLE
autotools: silence gcc warnings in libtool code

### DIFF
--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1046,7 +1046,7 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             fi
             case $host_os in
               cygwin*)
-                dnl Silence bogus warnings in 'lt_fatal' libtool function
+                dnl Silence warnings in 'lt_fatal' libtool function
                 tmp_CFLAGS="$tmp_CFLAGS -Wno-suggest-attribute=noreturn"
                 ;;
             esac

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1044,6 +1044,12 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
             if test "$curl_cv_native_windows" = "yes"; then
               tmp_CFLAGS="$tmp_CFLAGS -Wno-pedantic-ms-format"
             fi
+            case $host_os in
+              cygwin*)
+                dnl Silence bogus warnings in 'lt_fatal' libtool function
+                tmp_CFLAGS="$tmp_CFLAGS -Wno-suggest-attribute=noreturn"
+                ;;
+            esac
           fi
           #
           dnl Only gcc 4.6 or later


### PR DESCRIPTION
Seen on Cygwin with gcc 12:
```
./.libs/lt-upload-pausing.c: In function 'lt_fatal':
./.libs/lt-upload-pausing.c:593:1: warning: function might be candidate for attribute 'noreturn' [-Wsuggest-attribute=noreturn]
  593 | lt_fatal (const char *file, int line, const char *message, ...)
      | ^~~~~~~~
```
https://github.com/curl/curl/actions/runs/12611924141/job/35148104431?pr=15911#step:11:264

Ref: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wsuggest-attribute_003d
