### PR TITLE
checksrc: Don't allow snprintf specifically

### DIFF
--- a/docs/examples/.checksrc
+++ b/docs/examples/.checksrc
@@ -1,3 +1,2 @@
 disable TYPEDEFSTRUCT
-disable SNPRINTF
 disable BANNEDFUNC


### PR DESCRIPTION
This isn't needed anymore after https://github.com/curl/curl/pull/15835, since banned functions are just allowed in general in `docs/examples/.checksrc`, and emits a warning when running make checksrc:
`invalid warning specified in .checksrc: "SNPRINTF"`