### PR TITLE
cookie: small variable type cleanups

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -438,7 +438,7 @@ static bool bad_domain(const char *domain, size_t len)
   fine. The prime reason for filtering out control bytes is that some HTTP
   servers return 400 for requests that contain such.
 */
-static int invalid_octets(const char *p)
+static bool invalid_octets(const char *p)
 {
   /* Reject all bytes \x01 - \x1f (*except* \x09, TAB) + \x7f */
   static const char badoctets[] = {

--- a/lib/cookie.h
+++ b/lib/cookie.h
@@ -38,7 +38,7 @@ struct Cookie {
   char *spath;        /* sanitized cookie path */
   char *domain;       /* domain = <this> */
   curl_off_t expires; /* expires = <this> */
-  int creationtime;   /* time when the cookie was written */
+  unsigned int creationtime; /* time when the cookie was written */
   BIT(tailmatch);     /* tail-match the domain name */
   BIT(secure);        /* the 'secure' keyword was used */
   BIT(livecookie);    /* updated from a server, not a stored file */
@@ -60,10 +60,10 @@ struct CookieInfo {
   /* linked lists of cookies we know of */
   struct Curl_llist cookielist[COOKIE_HASH_SIZE];
   curl_off_t next_expiration; /* the next time at which expiration happens */
-  int numcookies;  /* number of cookies in the "jar" */
-  int lastct;      /* last creation-time used in the jar */
-  bool running;    /* state info, for cookie adding information */
-  bool newsession; /* new session, discard session cookies on load */
+  unsigned int numcookies;  /* number of cookies in the "jar" */
+  unsigned int lastct;      /* last creation-time used in the jar */
+  BIT(running);    /* state info, for cookie adding information */
+  BIT(newsession); /* new session, discard session cookies on load */
 };
 
 /* The maximum sizes we accept for cookies. RFC 6265 section 6.1 says


### PR DESCRIPTION
- bump cookie counter and "creation time" to use 'unsigned int'
- use BIT() for single-bit struct field
- make invalid_octets() return bool properly