### PR TITLE
msvc: fix building with `HAVE_INET_NTOP` and MSVC <=1900

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1703,8 +1703,8 @@ if(APPLE)
   check_function_exists("mach_absolute_time" HAVE_MACH_ABSOLUTE_TIME)
 endif()
 check_symbol_exists("inet_ntop" "${CURL_INCLUDES};stdlib.h;string.h" HAVE_INET_NTOP)  # arpa/inet.h
-if(MSVC AND (MSVC_VERSION LESS_EQUAL 1600))
-  set(HAVE_INET_NTOP OFF)
+if(MSVC AND (MSVC_VERSION LESS_EQUAL 1900))
+  set(HAVE_INET_NTOP 0)
 endif()
 check_symbol_exists("inet_pton" "${CURL_INCLUDES};stdlib.h;string.h" HAVE_INET_PTON)  # arpa/inet.h
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1703,9 +1703,6 @@ if(APPLE)
   check_function_exists("mach_absolute_time" HAVE_MACH_ABSOLUTE_TIME)
 endif()
 check_symbol_exists("inet_ntop" "${CURL_INCLUDES};stdlib.h;string.h" HAVE_INET_NTOP)  # arpa/inet.h
-if(MSVC AND (MSVC_VERSION LESS_EQUAL 1900))
-  set(HAVE_INET_NTOP 0)
-endif()
 check_symbol_exists("inet_pton" "${CURL_INCLUDES};stdlib.h;string.h" HAVE_INET_PTON)  # arpa/inet.h
 
 check_symbol_exists("fsetxattr" "sys/xattr.h" HAVE_FSETXATTR)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,26 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       EXAMPLES: 'ON'
+    - job_name: 'CMake, VS2010, Debug, x64, OpenSSL 1.1.1, Build-only'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 10 2010'
+      TARGET: '-A x64'
+      PRJ_CFG: Debug
+      OPENSSL: 'ON'
+      SCHANNEL: 'OFF'
+      ENABLE_UNICODE: 'OFF'
+      SHARED: 'ON'
+    - job_name: 'CMake, VS2012, Debug, x64, OpenSSL 1.1.1, Build-only'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 11 2012'
+      TARGET: '-A x64'
+      PRJ_CFG: Debug
+      OPENSSL: 'ON'
+      SCHANNEL: 'OFF'
+      ENABLE_UNICODE: 'OFF'
+      SHARED: 'ON'
     - job_name: 'CMake, VS2013, Debug, x64, OpenSSL 1.1.1, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,6 +70,7 @@ environment:
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
+      TFLAGS: 'skipall'
     - job_name: 'CMake, VS2015, Debug, x64, OpenSSL 1.1.1, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
@@ -79,6 +80,7 @@ environment:
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
+      TFLAGS: 'skipall'
     - job_name: 'CMake, VS2017, Debug, x64, OpenSSL 3.3, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
@@ -88,6 +90,7 @@ environment:
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
+      TFLAGS: 'skipall'
     - job_name: 'CMake, VS2022, Release, x64, OpenSSL 3.3, Shared, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,6 +61,23 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       EXAMPLES: 'ON'
+    - job_name: 'CMake, VS2015, Debug, x64, OpenSSL 1.1.1, Build-only'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 14 2015 Win64'
+      PRJ_CFG: Debug
+      SCHANNEL: 'OFF'
+      ENABLE_UNICODE: 'OFF'
+      SHARED: 'ON'
+    - job_name: 'CMake, VS2017, Debug, x64, OpenSSL 3.3, Build-only'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 15 2017'
+      TARGET: '-A x64'
+      PRJ_CFG: Debug
+      SCHANNEL: 'OFF'
+      ENABLE_UNICODE: 'OFF'
+      SHARED: 'ON'
     - job_name: 'CMake, VS2022, Release, x64, OpenSSL 3.3, Shared, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,6 +67,7 @@ environment:
       PRJ_GEN: 'Visual Studio 12 2013'
       TARGET: '-A x64'
       PRJ_CFG: Debug
+      OPENSSL: 'ON'
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
@@ -77,6 +78,7 @@ environment:
       PRJ_GEN: 'Visual Studio 14 2015'
       TARGET: '-A x64'
       PRJ_CFG: Debug
+      OPENSSL: 'ON'
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
@@ -87,6 +89,7 @@ environment:
       PRJ_GEN: 'Visual Studio 15 2017'
       TARGET: '-A x64'
       PRJ_CFG: Debug
+      OPENSSL: 'ON'
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,16 +61,6 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       EXAMPLES: 'ON'
-    - job_name: 'CMake, VS2012, Debug, x64, OpenSSL 1.1.1, Build-only'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
-      BUILD_SYSTEM: CMake
-      PRJ_GEN: 'Visual Studio 11 2012'
-      TARGET: '-A x64'
-      PRJ_CFG: Debug
-      OPENSSL: 'ON'
-      SCHANNEL: 'OFF'
-      ENABLE_UNICODE: 'OFF'
-      SHARED: 'ON'
     - job_name: 'CMake, VS2013, Debug, x64, OpenSSL 1.1.1, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,7 +83,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       TFLAGS: 'skipall'
-    - job_name: 'CMake, VS2017, Debug, x64, OpenSSL 3.3, Build-only'
+    - job_name: 'CMake, VS2017, Debug, x64, OpenSSL 1.1.1, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 15 2017'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,16 +61,6 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       EXAMPLES: 'ON'
-    - job_name: 'CMake, VS2010, Debug, x64, OpenSSL 1.1.1, Build-only'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
-      BUILD_SYSTEM: CMake
-      PRJ_GEN: 'Visual Studio 10 2010'
-      TARGET: '-A x64'
-      PRJ_CFG: Debug
-      OPENSSL: 'ON'
-      SCHANNEL: 'OFF'
-      ENABLE_UNICODE: 'OFF'
-      SHARED: 'ON'
     - job_name: 'CMake, VS2012, Debug, x64, OpenSSL 1.1.1, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -80,7 +80,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
     - job_name: 'CMake, VS2017, Debug, x64, OpenSSL 3.3, Build-only'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 15 2017'
       TARGET: '-A x64'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,10 +61,20 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       EXAMPLES: 'ON'
+    - job_name: 'CMake, VS2013, Debug, x64, OpenSSL 1.1.1, Build-only'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 12 2013'
+      TARGET: '-A x64'
+      PRJ_CFG: Debug
+      SCHANNEL: 'OFF'
+      ENABLE_UNICODE: 'OFF'
+      SHARED: 'ON'
     - job_name: 'CMake, VS2015, Debug, x64, OpenSSL 1.1.1, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: 'Visual Studio 14 2015 Win64'
+      PRJ_GEN: 'Visual Studio 14 2015'
+      TARGET: '-A x64'
       PRJ_CFG: Debug
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'

--- a/lib/inet_ntop.h
+++ b/lib/inet_ntop.h
@@ -33,8 +33,11 @@ char *Curl_inet_ntop(int af, const void *addr, char *buf, size_t size);
 #include <arpa/inet.h>
 #endif
 #ifdef _WIN32
-#define Curl_inet_ntop(af,addr,buf,size) \
-        inet_ntop(af, addr, buf, size)
+#if defined(_MSC_VER) && (_MSC_VER <= 1900)
+#define Curl_inet_ntop(af,addr,buf,size) inet_ntop(af, (void *)addr, buf, size)
+#else
+#define Curl_inet_ntop(af,addr,buf,size) inet_ntop(af, addr, buf, size)
+#endif
 #elif defined(__AMIGA__)
 #define Curl_inet_ntop(af,addr,buf,size) \
         (char *)inet_ntop(af, (void *)addr, (unsigned char *)buf, \


### PR DESCRIPTION
MSVC 1900 and older is missing a `const` specifier in the `inet_ntop()`
declaration for the second argument. A workaround was in place for it
in cmake, but it didn't cover all necessary versions.

Replace the workaround with a different one, move it to `lib/inet_ntop.c`
and extend to all necessary MSVC versions.

Also add CI jobs for the older MSVC versions: 2013, 2015, 2017.
