### PR TITLE
GHA/windows: drop MSH3 job (broken after 0.7.0 bump)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -654,17 +654,6 @@ jobs:
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_MBEDTLS=ON
               -DCURL_USE_GSASL=ON
 
-          - name: 'msh3'
-            install: 'brotli zlib zstd libpsl nghttp2 msh3 libssh2 pkgconf gsasl'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            tflags: 'skipall'
-            config: >-
-              -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DUSE_MSH3=ON
-              -DCURL_USE_GSASL=ON
-
       fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Starting GHA runner image 20250105.1.0.

As seen on Linux with 0.7.0:
```
/home/runner/msh3/include/msh3.h:377:18: error: width of ‘RESERVED’ exceeds its type
  377 |             bool RESERVED                 : 5;
      |                  ^~~~~~~~
/home/runner/msh3/include/msh3.h:490:18: error: width of ‘RESERVED’ exceeds its type
  490 |             bool RESERVED            : 7;
      |                  ^~~~~~~~
```
https://github.com/curl/curl/actions/runs/12655717818/job/35266716846#step:35:195

Bug: https://github.com/curl/curl/pull/15924#issuecomment-2575106711
Bug: https://github.com/curl/curl/pull/15930#issuecomment-2575842486
