### PR TITLE
content_encoding: namespace GZIP flag constants

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -79,10 +79,12 @@
 #define GZIP_MAGIC_1 0x8b
 
 /* gzip flag byte */
-#define CURL_GZIPFLAG_ASCII        0x01 /* bit 0 set: file probably ASCII text */
+#define CURL_GZIPFLAG_ASCII        0x01 /* bit 0 set: file probably ASCII
+                                           text */
 #define CURL_GZIPFLAG_HEAD_CRC     0x02 /* bit 1 set: header CRC present */
 #define CURL_GZIPFLAG_EXTRA_FIELD  0x04 /* bit 2 set: extra field present */
-#define CURL_GZIPFLAG_ORIG_NAME    0x08 /* bit 3 set: original filename present */
+#define CURL_GZIPFLAG_ORIG_NAME    0x08 /* bit 3 set: original filename
+                                           present */
 #define CURL_GZIPFLAG_COMMENT      0x10 /* bit 4 set: file comment present */
 #define CURL_GZIPFLAG_RESERVED     0xE0 /* bits 5..7: reserved */
 

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -79,12 +79,12 @@
 #define GZIP_MAGIC_1 0x8b
 
 /* gzip flag byte */
-#define ASCII_FLAG   0x01 /* bit 0 set: file probably ASCII text */
-#define HEAD_CRC     0x02 /* bit 1 set: header CRC present */
-#define EXTRA_FIELD  0x04 /* bit 2 set: extra field present */
-#define ORIG_NAME    0x08 /* bit 3 set: original filename present */
-#define COMMENT      0x10 /* bit 4 set: file comment present */
-#define RESERVED     0xE0 /* bits 5..7: reserved */
+#define CURL_GZIPFLAG_ASCII        0x01 /* bit 0 set: file probably ASCII text */
+#define CURL_GZIPFLAG_HEAD_CRC     0x02 /* bit 1 set: header CRC present */
+#define CURL_GZIPFLAG_EXTRA_FIELD  0x04 /* bit 2 set: extra field present */
+#define CURL_GZIPFLAG_ORIG_NAME    0x08 /* bit 3 set: original filename present */
+#define CURL_GZIPFLAG_COMMENT      0x10 /* bit 4 set: file comment present */
+#define CURL_GZIPFLAG_RESERVED     0xE0 /* bits 5..7: reserved */
 
 typedef enum {
   ZLIB_UNINIT,               /* uninitialized */
@@ -387,7 +387,7 @@ static gzip_status check_gzip_header(unsigned char const *data, ssize_t len,
   method = data[2];
   flags = data[3];
 
-  if(method != Z_DEFLATED || (flags & RESERVED) != 0) {
+  if(method != Z_DEFLATED || (flags & CURL_GZIPFLAG_RESERVED) != 0) {
     /* cannot handle this compression method or unknown flag */
     return GZIP_BAD;
   }
@@ -396,7 +396,7 @@ static gzip_status check_gzip_header(unsigned char const *data, ssize_t len,
   len -= 10;
   data += 10;
 
-  if(flags & EXTRA_FIELD) {
+  if(flags & CURL_GZIPFLAG_EXTRA_FIELD) {
     ssize_t extra_len;
 
     if(len < 2)
@@ -411,7 +411,7 @@ static gzip_status check_gzip_header(unsigned char const *data, ssize_t len,
     data += (extra_len + 2);
   }
 
-  if(flags & ORIG_NAME) {
+  if(flags & CURL_GZIPFLAG_ORIG_NAME) {
     /* Skip over NUL-terminated filename */
     while(len && *data) {
       --len;
@@ -425,7 +425,7 @@ static gzip_status check_gzip_header(unsigned char const *data, ssize_t len,
     ++data;
   }
 
-  if(flags & COMMENT) {
+  if(flags & CURL_GZIPFLAG_COMMENT) {
     /* Skip over NUL-terminated comment */
     while(len && *data) {
       --len;
@@ -438,7 +438,7 @@ static gzip_status check_gzip_header(unsigned char const *data, ssize_t len,
     --len;
   }
 
-  if(flags & HEAD_CRC) {
+  if(flags & CURL_GZIPFLAG_HEAD_CRC) {
     if(len < 2)
       return GZIP_UNDERFLOW;
 


### PR DESCRIPTION
To avoid collision with a 3rd-party `RESERVED` symbols.

This symbol is used in the public header of MSH3 0.7.0.
