### PR TITLE
appveyor: bump VS2008 jobs to VS2010

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -44,11 +44,6 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   [ "${PRJ_CFG}" = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
   [ "${PRJ_CFG}" = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
   [[ "${PRJ_GEN}" = *'Visual Studio'* ]] && options+=' -DCMAKE_VS_GLOBALS=TrackFileAccess=false'
-  if [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ]; then
-    [ "${DEBUG}" = 'ON' ] && [ "${SHARED}" = 'ON' ] && SKIP_RUN='Crash on startup in ENABLE_DEBUG=ON shared builds'
-    # Fails to run without this due to missing MSVCR90.dll / MSVCR90D.dll
-    options+=' -DCURL_STATIC_CRT=ON'
-  fi
   # shellcheck disable=SC2086
   cmake -B _bld "-G${PRJ_GEN}" ${TARGET:-} ${options} \
     "-DCURL_USE_OPENSSL=${OPENSSL}" \
@@ -69,10 +64,6 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   echo 'curl_config.h'; grep -F '#define' _bld/lib/curl_config.h | sort || true
   # shellcheck disable=SC2086
   if ! cmake --build _bld --config "${PRJ_CFG}" --parallel 2 -- ${BUILD_OPT:-}; then
-    if [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ]; then
-      find . -name BuildLog.htm -exec dos2unix '{}' +
-      find . -name BuildLog.htm -exec cat '{}' +
-    fi
     false
   fi
   if [ "${SHARED}" = 'ON' ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,12 +63,12 @@ environment:
       ENABLE_UNICODE: 'OFF'
       DEBUG: 'OFF'
       CURLDEBUG: 'ON'
-    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-tests'
+    - job_name: 'CMake, VS2010, Release, x64, Schannel, Static, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 10 2010'
       TARGET: '-A x64'
-      PRJ_CFG: Debug
+      PRJ_CFG: Release
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,24 +43,6 @@ environment:
 
     # generated CMake-based Visual Studio builds
 
-    - job_name: 'CMake, VS2008, Release, x86, Schannel, Shared, Build-tests'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
-      BUILD_SYSTEM: CMake
-      PRJ_GEN: 'Visual Studio 9 2008'
-      PRJ_CFG: Release
-      DEBUG: 'OFF'
-      SCHANNEL: 'ON'
-      ENABLE_UNICODE: 'OFF'
-      SHARED: 'ON'
-    - job_name: 'CMake, VS2008, Debug, x86, Schannel, Shared, Build-tests & examples'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
-      BUILD_SYSTEM: CMake
-      PRJ_GEN: 'Visual Studio 9 2008'
-      PRJ_CFG: Debug
-      SCHANNEL: 'ON'
-      ENABLE_UNICODE: 'OFF'
-      SHARED: 'ON'
-      EXAMPLES: 'ON'
     - job_name: 'CMake, VS2022, Release, x64, OpenSSL 3.3, Shared, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake
@@ -81,6 +63,15 @@ environment:
       ENABLE_UNICODE: 'OFF'
       DEBUG: 'OFF'
       CURLDEBUG: 'ON'
+    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-tests'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 10 2010'
+      TARGET: '-A x64'
+      PRJ_CFG: Debug
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'OFF'
+      SHARED: 'ON'
     - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-tests & examples'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
@@ -89,6 +80,7 @@ environment:
       PRJ_CFG: Debug
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
+      SHARED: 'ON'
       EXAMPLES: 'ON'
     - job_name: 'CMake, VS2012, Debug, x64, OpenSSL 1.1.1, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -159,6 +159,8 @@
 
 #endif /* HAVE_CONFIG_H */
 
+#include <stdint.h>
+
 /* ================================================================ */
 /* Definition of preprocessor macros/symbols which modify compiler  */
 /* behavior or generated code characteristics must be done here,   */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -159,8 +159,6 @@
 
 #endif /* HAVE_CONFIG_H */
 
-#include <stdint.h>
-
 /* ================================================================ */
 /* Definition of preprocessor macros/symbols which modify compiler  */
 /* behavior or generated code characteristics must be done here,   */


### PR DESCRIPTION
VS2008 has been partly broken for a while with its shared-debug builds
crashing on startup. Its compiler output (UTF-16 HTML) was also barely
readable even after conversion. It's also the only platform in CI
missing `stdint.h`.

This patch migrates a VS2008 job to VS2010 and drops another that
already had a VS2010 equivalent.

We recommend switching to VS2010 or newer when using MSVC to build curl.

Ref: #15907
