### PR TITLE
appveyor: always use cmake `-A` option to select x64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -84,7 +84,8 @@ environment:
     - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-tests & examples'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
-      PRJ_GEN: 'Visual Studio 10 2010 Win64'
+      PRJ_GEN: 'Visual Studio 10 2010'
+      TARGET: '-A x64'
       PRJ_CFG: Debug
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'


### PR DESCRIPTION
The `Win64` generator suffix alternative was required by old CMake
versions (<3.1) only:
https://cmake.org/cmake/help/v3.22/generator/Visual%20Studio%2010%202010.html
