### PR TITLE
HTTP/2, strip TE request header

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -4121,7 +4121,9 @@ struct name_const {
   size_t namelen;
 };
 
+/* keep them sorted by length! */
 static struct name_const H2_NON_FIELD[] = {
+  { STRCONST("TE") },
   { STRCONST("Host") },
   { STRCONST("Upgrade") },
   { STRCONST("Connection") },

--- a/tests/http/test_01_basic.py
+++ b/tests/http/test_01_basic.py
@@ -149,4 +149,3 @@ class TestBasic:
         assert len(r.responses) == 1, f'{r.responses}'
         assert r.responses[0]['status'] == 200, f'{r.responses[1]}'
         assert r.responses[0]['protocol'] == 'HTTP/2', f'{r.responses[1]}'
-

--- a/tests/http/test_01_basic.py
+++ b/tests/http/test_01_basic.py
@@ -139,3 +139,14 @@ class TestBasic:
         assert r.response['status'] == 200, f'{r.responsw}'
         assert r.response['protocol'] == 'HTTP/2', f'{r.response}'
         assert r.json['server'] == env.domain1
+
+    # http: strip TE header in HTTP/2 requests
+    def test_01_10_te_strip(self, env: Env, httpd):
+        curl = CurlClient(env=env)
+        url = f'https://{env.authority_for(env.domain1, "h2")}/data.json'
+        r = curl.http_get(url=url, extra_args=['--http2', '-H', 'TE: gzip'])
+        r.check_exit_code(0)
+        assert len(r.responses) == 1, f'{r.responses}'
+        assert r.responses[0]['status'] == 200, f'{r.responses[1]}'
+        assert r.responses[0]['protocol'] == 'HTTP/2', f'{r.responses[1]}'
+


### PR DESCRIPTION
The TE request header field is invalid in HTTP/2. Since clients may not know in advance if a connection negotiates HTTP/2, automatically strip such a header when h2 is in play.

Add test_01_10 to verify.

refs #15941

