### PR TITLE
msvc: drop checks for ancient versions

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -820,7 +820,7 @@
 #if (defined(__GNUC__) && (__GNUC__ >= 3)) || defined(__clang__) || \
   defined(__IAR_SYSTEMS_ICC__)
 #  define CURL_NORETURN  __attribute__((__noreturn__))
-#elif defined(_MSC_VER) && (_MSC_VER >= 1200)
+#elif defined(_MSC_VER)
 #  define CURL_NORETURN  __declspec(noreturn)
 #else
 #  define CURL_NORETURN
@@ -1007,8 +1007,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #elif defined(__GNUC__) && __GNUC__ >= 3
 /* GCC supports '__inline__' as an extension */
 #  define CURL_INLINE __inline__
-#elif defined(_MSC_VER) && _MSC_VER >= 1400
-/* MSC supports '__inline' from VS 2005 (or even earlier) */
+#elif defined(_MSC_VER)
 #  define CURL_INLINE __inline
 #else
 /* Probably 'inline' is not supported by compiler.

--- a/lib/curl_sha512_256.c
+++ b/lib/curl_sha512_256.c
@@ -290,9 +290,7 @@ Curl_sha512_256_finish(unsigned char *digest,
 
 #if !defined(CURL_FORCEINLINE) && \
   defined(_MSC_VER) && !defined(__GNUC__) && !defined(__clang__)
-#  if _MSC_VER >= 1400
-#    define CURL_FORCEINLINE __forceinline
-#  endif
+#  define CURL_FORCEINLINE __forceinline
 #endif
 
 #if !defined(CURL_FORCEINLINE)


### PR DESCRIPTION
- drop version guard for `__inline`.
  Supported since `_MSC_VER` 1000.
  Visual C++, 32-bit, version 4.0 (1996)

- drop version guard for `__declspec(noreturn)` and `__forceinline`.
  Supported since `_MSC_VER` 1200.
  Visual C++, 32-bit, version 6.0 (1998)

For ancient versions, it's possible to override the default behaviour
by setting these macros via `CPPFLAGS`: `CURL_NORETURN`, `CURL_INLINE`,
`CURL_FORCEINLINE`

---

Potential candidates:
`_INTEGRAL_MAX_BITS`: It's always 64 since `_MSC_VER` 1400,
(year 2005) possibly earlier, since 1300 (year 2002).
Though the oldest MSVC supported by curl build tools is 1200.
Also checks for version 900. Tackle this in another PR.
