### PR TITLE
tool_ssls: fix "ignored return value" warning

### DIFF
--- a/src/tool_ssls.c
+++ b/src/tool_ssls.c
@@ -48,7 +48,7 @@ static CURLcode tool_ssls_easy(struct GlobalConfig *global,
     return CURLE_OUT_OF_MEMORY;
 
   result = curl_easy_setopt(*peasy, CURLOPT_SHARE, share);
-  if(global->tracetype != TRACE_NONE) {
+  if(!result && (global->tracetype != TRACE_NONE)) {
     my_setopt(*peasy, CURLOPT_DEBUGFUNCTION, tool_debug_cb);
     my_setopt(*peasy, CURLOPT_DEBUGDATA, config);
     my_setopt(*peasy, CURLOPT_VERBOSE, 1L);


### PR DESCRIPTION
Pointed out by CodeSonar. While harmless, we might as well address it.