### PR TITLE
msvc: drop checks for `_MSC_VER >= 900`

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -360,7 +360,7 @@
 #    define CURL_FORMAT_CURL_OFF_TU    PRIu64
 #    define CURL_SUFFIX_CURL_OFF_T     i64
 #    define CURL_SUFFIX_CURL_OFF_TU    ui64
-#  elif (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64)
+#  elif (_INTEGRAL_MAX_BITS >= 64)
 #    define CURL_TYPEOF_CURL_OFF_T     __int64
 #    define CURL_FORMAT_CURL_OFF_T     "I64d"
 #    define CURL_FORMAT_CURL_OFF_TU    "I64u"

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -360,7 +360,7 @@
 #    define CURL_FORMAT_CURL_OFF_TU    PRIu64
 #    define CURL_SUFFIX_CURL_OFF_T     i64
 #    define CURL_SUFFIX_CURL_OFF_TU    ui64
-#  elif (_INTEGRAL_MAX_BITS >= 64)
+#  elif (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64)
 #    define CURL_TYPEOF_CURL_OFF_T     __int64
 #    define CURL_FORMAT_CURL_OFF_T     "I64d"
 #    define CURL_FORMAT_CURL_OFF_TU    "I64u"

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -394,7 +394,7 @@ Vista
 /* ---------------------------------------------------------------- */
 
 #if defined(_MSC_VER) && !defined(_WIN32_WCE)
-#  if (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64)
+#  if (_INTEGRAL_MAX_BITS >= 64)
 #    define USE_WIN32_LARGE_FILES
 #  else
 #    define USE_WIN32_SMALL_FILES

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -239,7 +239,7 @@
 /* ---------------------------------------------------------------- */
 
 #if defined(_MSC_VER) && !defined(_WIN32_WCE)
-#  if (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64)
+#  if (_INTEGRAL_MAX_BITS >= 64)
 #    define USE_WIN32_LARGE_FILES
 #  else
 #    define USE_WIN32_SMALL_FILES

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -37,14 +37,12 @@
 #ifdef HAVE_LONGLONG
 #  define LONG_LONG_TYPE long long
 #  define HAVE_LONG_LONG_TYPE
+#elif defined(_MSC_VER) && (_INTEGRAL_MAX_BITS >= 64)
+#  define LONG_LONG_TYPE __int64
+#  define HAVE_LONG_LONG_TYPE
 #else
-#  if defined(_MSC_VER) && (_INTEGRAL_MAX_BITS >= 64)
-#    define LONG_LONG_TYPE __int64
-#    define HAVE_LONG_LONG_TYPE
-#  else
-#    undef LONG_LONG_TYPE
-#    undef HAVE_LONG_LONG_TYPE
-#  endif
+#  undef LONG_LONG_TYPE
+#  undef HAVE_LONG_LONG_TYPE
 #endif
 
 /*

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -38,7 +38,7 @@
 #  define LONG_LONG_TYPE long long
 #  define HAVE_LONG_LONG_TYPE
 #else
-#  if defined(_MSC_VER) && (_MSC_VER >= 900) && (_INTEGRAL_MAX_BITS >= 64)
+#  if defined(_MSC_VER) && (_INTEGRAL_MAX_BITS >= 64)
 #    define LONG_LONG_TYPE __int64
 #    define HAVE_LONG_LONG_TYPE
 #  else


### PR DESCRIPTION
It's Visual C++, 32-bit, version 2.0, released in 1993. Used to verify
if `_INTEGRAL_MAX_BITS` is available.

After this patch we assume `_INTEGRAL_MAX_BITS` is always available in
MSVC.
