### PR TITLE
change session cache dimensions

### DIFF
--- a/lib/share.c
+++ b/lib/share.c
@@ -110,7 +110,12 @@ curl_share_setopt(CURLSH *sh, CURLSHoption option, ...)
     case CURL_LOCK_DATA_SSL_SESSION:
 #ifdef USE_SSL
       if(!share->ssl_scache) {
-        if(Curl_ssl_scache_create(8, 2, &share->ssl_scache))
+        /* There is no way (yet) for the application to configure the
+         * session cache size, shared between many transfers. As for curl
+         * itself, a high session count will impact startup time. Also, the
+         * scache is not optimized for several hundreds of peers. So,
+         * keep it at a reasonable level. */
+        if(Curl_ssl_scache_create(25, 2, &share->ssl_scache))
           res = CURLSHE_NOMEM;
       }
 #else

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -568,8 +568,10 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
 
 #ifdef USE_SSL
   if(!data->state.ssl_scache) {
-    result = Curl_ssl_scache_create(data->set.general_ssl.max_ssl_sessions,
-                                    2, &data->state.ssl_scache);
+    /* There was no ssl session cache set via a share, so we create
+     * one just for this transfer alone. Most transfers talk to just
+     * one host, but redirects may involve several occasionally. */
+    result = Curl_ssl_scache_create(3, 2, &data->state.ssl_scache);
     if(result)
       return result;
   }

--- a/lib/url.c
+++ b/lib/url.c
@@ -382,8 +382,6 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
 #endif
   set->dns_cache_timeout = 60; /* Timeout every 60 seconds by default */
 
-  /* Set the default size of the SSL session ID cache */
-  set->general_ssl.max_ssl_sessions = 5;
   /* Timeout every 24 hours by default */
   set->general_ssl.ca_cache_timeout = 24 * 60 * 60;
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -315,7 +315,6 @@ struct ssl_config_data {
 };
 
 struct ssl_general_config {
-  size_t max_ssl_sessions; /* SSL session id cache size */
   int ca_cache_timeout;  /* Certificate store cache timeout (seconds) */
 };
 


### PR DESCRIPTION
Now that we can (experimentally) import/export sessions, let's adjust the session cache somewhat:

- for non-share transfers, 3 peers with 2 tickets each should be enough
- share session caches get reused, so we want something larger. 25 peers with 2 tickets each seems better than 8 we had before. That means 50 tickets max and in my tests, we import those in ~3ms on my machine. Obviously this is a made up number up for debate.