### PR TITLE
GnuTLS: fix 'time_appconnect' for early data

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1969,6 +1969,9 @@ gtls_connect_common(struct Curl_cfilter *cf,
       goto out;
 
     if(connssl->earlydata_state == ssl_earlydata_sent) {
+      /* report the true time the handshake was done */
+      connssl->handshake_done = Curl_now();
+      Curl_pgrsTimeWas(data, TIMER_APPCONNECT, connssl->handshake_done);
       if(gnutls_session_get_flags(backend->gtls.session) &
          GNUTLS_SFLAGS_EARLY_DATA) {
         connssl->earlydata_state = ssl_earlydata_accepted;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1386,7 +1386,8 @@ static CURLcode ssl_cf_connect(struct Curl_cfilter *cf,
 
   if(!result && *done) {
     cf->connected = TRUE;
-    connssl->handshake_done = Curl_now();
+    if(connssl->state == ssl_connection_complete)
+      connssl->handshake_done = Curl_now();
     /* Connection can be deferred when sending early data */
     DEBUGASSERT(connssl->state == ssl_connection_complete ||
                 connssl->state == ssl_connection_deferred);


### PR DESCRIPTION
When using early data with GnuTLS, the the timer `appconnect` had the value from the "pretended" connect, not when the actual TLS handshake was done.