### PR TITLE
msvc: assume `_INTEGRAL_MAX_BITS >= 64`

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -355,24 +355,15 @@
 #elif defined(_MSC_VER)
 #  if (_MSC_VER >= 1800)
 #    include <inttypes.h>
-#    define CURL_TYPEOF_CURL_OFF_T     __int64
 #    define CURL_FORMAT_CURL_OFF_T     PRId64
 #    define CURL_FORMAT_CURL_OFF_TU    PRIu64
-#    define CURL_SUFFIX_CURL_OFF_T     i64
-#    define CURL_SUFFIX_CURL_OFF_TU    ui64
-#  elif (_INTEGRAL_MAX_BITS >= 64)
-#    define CURL_TYPEOF_CURL_OFF_T     __int64
+#  else
 #    define CURL_FORMAT_CURL_OFF_T     "I64d"
 #    define CURL_FORMAT_CURL_OFF_TU    "I64u"
-#    define CURL_SUFFIX_CURL_OFF_T     i64
-#    define CURL_SUFFIX_CURL_OFF_TU    ui64
-#  else
-#    define CURL_TYPEOF_CURL_OFF_T     long
-#    define CURL_FORMAT_CURL_OFF_T     "ld"
-#    define CURL_FORMAT_CURL_OFF_TU    "lu"
-#    define CURL_SUFFIX_CURL_OFF_T     L
-#    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  endif
+#  define CURL_TYPEOF_CURL_OFF_T     __int64
+#  define CURL_SUFFIX_CURL_OFF_T     i64
+#  define CURL_SUFFIX_CURL_OFF_TU    ui64
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 
 /* ===================================== */

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -394,11 +394,7 @@ Vista
 /* ---------------------------------------------------------------- */
 
 #if defined(_MSC_VER) && !defined(_WIN32_WCE)
-#  if (_INTEGRAL_MAX_BITS >= 64)
-#    define USE_WIN32_LARGE_FILES
-#  else
-#    define USE_WIN32_SMALL_FILES
-#  endif
+#  define USE_WIN32_LARGE_FILES
 #endif
 
 #if defined(__MINGW32__) && !defined(USE_WIN32_LARGE_FILES)

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -239,11 +239,7 @@
 /* ---------------------------------------------------------------- */
 
 #if defined(_MSC_VER) && !defined(_WIN32_WCE)
-#  if (_INTEGRAL_MAX_BITS >= 64)
-#    define USE_WIN32_LARGE_FILES
-#  else
-#    define USE_WIN32_SMALL_FILES
-#  endif
+#  define USE_WIN32_LARGE_FILES
 #endif
 
 #if !defined(USE_WIN32_LARGE_FILES) && !defined(USE_WIN32_SMALL_FILES)

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -37,7 +37,7 @@
 #ifdef HAVE_LONGLONG
 #  define LONG_LONG_TYPE long long
 #  define HAVE_LONG_LONG_TYPE
-#elif defined(_MSC_VER) && (_INTEGRAL_MAX_BITS >= 64)
+#elif defined(_MSC_VER)
 #  define LONG_LONG_TYPE __int64
 #  define HAVE_LONG_LONG_TYPE
 #else

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -39,7 +39,7 @@
 #  ifdef HAVE_STRTOLL
 #    define strtooff strtoll
 #  else
-#    if defined(_MSC_VER) && (_MSC_VER >= 1300) && (_INTEGRAL_MAX_BITS >= 64)
+#    if defined(_MSC_VER) && (_MSC_VER >= 1300)
 #      if defined(_SAL_VERSION)
          _Check_return_ _CRTIMP __int64 __cdecl _strtoi64(
              _In_z_ const char *_String,


### PR DESCRIPTION
curl requires C compilers supporting 64-bit `curl_off_t` type since
835682661c7a36b0e860c978204e8cd9b033be45 #10597 (v8.0.0).

Assume the MSVC compiler offers the necessary support.

It makes curl require Visual Studio .NET 2003, v7.1 (`_MSC_VER = 1310`).
With the possibility that 1300 (Visual Studio .NET, v7.0, 2002), or 1200
(Visual C++, 32-bit, v6.0, 1998) may also work.

Follow-up to ca18198dd4d6517bd2d8b34a99fcd9d4f780d219 #15952
