### PR TITLE
system.h: drop compilers lacking 64-bit integer type (Windows/MS-DOS)

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -52,62 +52,24 @@
  *
  */
 
-#if defined(__DJGPP__) || defined(__GO32__)
-#  if defined(__DJGPP__) && (__DJGPP__ > 1)
-#    define CURL_TYPEOF_CURL_OFF_T     long long
-#    define CURL_FORMAT_CURL_OFF_T     "lld"
-#    define CURL_FORMAT_CURL_OFF_TU    "llu"
-#    define CURL_SUFFIX_CURL_OFF_T     LL
-#    define CURL_SUFFIX_CURL_OFF_TU    ULL
-#  else
-#    define CURL_TYPEOF_CURL_OFF_T     long
-#    define CURL_FORMAT_CURL_OFF_T     "ld"
-#    define CURL_FORMAT_CURL_OFF_TU    "lu"
-#    define CURL_SUFFIX_CURL_OFF_T     L
-#    define CURL_SUFFIX_CURL_OFF_TU    UL
-#  endif
-#  define CURL_TYPEOF_CURL_SOCKLEN_T int
-
-#elif defined(__SALFORDC__)
-#  define CURL_TYPEOF_CURL_OFF_T     long
-#  define CURL_FORMAT_CURL_OFF_T     "ld"
-#  define CURL_FORMAT_CURL_OFF_TU    "lu"
-#  define CURL_SUFFIX_CURL_OFF_T     L
-#  define CURL_SUFFIX_CURL_OFF_TU    UL
+#if defined(__DJGPP__)
+#  define CURL_TYPEOF_CURL_OFF_T     long long
+#  define CURL_FORMAT_CURL_OFF_T     "lld"
+#  define CURL_FORMAT_CURL_OFF_TU    "llu"
+#  define CURL_SUFFIX_CURL_OFF_T     LL
+#  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 
 #elif defined(__BORLANDC__)
-#  if (__BORLANDC__ < 0x520)
-#    define CURL_TYPEOF_CURL_OFF_T     long
-#    define CURL_FORMAT_CURL_OFF_T     "ld"
-#    define CURL_FORMAT_CURL_OFF_TU    "lu"
-#    define CURL_SUFFIX_CURL_OFF_T     L
-#    define CURL_SUFFIX_CURL_OFF_TU    UL
-#  else
-#    define CURL_TYPEOF_CURL_OFF_T     __int64
-#    define CURL_FORMAT_CURL_OFF_T     "I64d"
-#    define CURL_FORMAT_CURL_OFF_TU    "I64u"
-#    define CURL_SUFFIX_CURL_OFF_T     i64
-#    define CURL_SUFFIX_CURL_OFF_TU    ui64
-#  endif
-#  define CURL_TYPEOF_CURL_SOCKLEN_T int
-
-#elif defined(__TURBOC__)
-#  define CURL_TYPEOF_CURL_OFF_T     long
-#  define CURL_FORMAT_CURL_OFF_T     "ld"
-#  define CURL_FORMAT_CURL_OFF_TU    "lu"
-#  define CURL_SUFFIX_CURL_OFF_T     L
-#  define CURL_SUFFIX_CURL_OFF_TU    UL
+#  define CURL_TYPEOF_CURL_OFF_T     __int64
+#  define CURL_FORMAT_CURL_OFF_T     "I64d"
+#  define CURL_FORMAT_CURL_OFF_TU    "I64u"
+#  define CURL_SUFFIX_CURL_OFF_T     i64
+#  define CURL_SUFFIX_CURL_OFF_TU    ui64
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 
 #elif defined(__POCC__)
-#  if (__POCC__ < 280)
-#    define CURL_TYPEOF_CURL_OFF_T     long
-#    define CURL_FORMAT_CURL_OFF_T     "ld"
-#    define CURL_FORMAT_CURL_OFF_TU    "lu"
-#    define CURL_SUFFIX_CURL_OFF_T     L
-#    define CURL_SUFFIX_CURL_OFF_TU    UL
-#  elif defined(_MSC_VER)
+#  if defined(_MSC_VER)
 #    define CURL_TYPEOF_CURL_OFF_T     __int64
 #    define CURL_FORMAT_CURL_OFF_T     "I64d"
 #    define CURL_FORMAT_CURL_OFF_TU    "I64u"
@@ -226,12 +188,6 @@
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
-#  elif defined(_LP64)
-#    define CURL_TYPEOF_CURL_OFF_T     long
-#    define CURL_FORMAT_CURL_OFF_T     "ld"
-#    define CURL_FORMAT_CURL_OFF_TU    "lu"
-#    define CURL_SUFFIX_CURL_OFF_T     L
-#    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  else
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -188,6 +188,12 @@
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
+#  elif defined(_LP64)
+#    define CURL_TYPEOF_CURL_OFF_T     long
+#    define CURL_FORMAT_CURL_OFF_T     "ld"
+#    define CURL_FORMAT_CURL_OFF_TU    "lu"
+#    define CURL_SUFFIX_CURL_OFF_T     L
+#    define CURL_SUFFIX_CURL_OFF_TU    UL
 #  else
 #    define CURL_TYPEOF_CURL_OFF_T     long
 #    define CURL_FORMAT_CURL_OFF_T     "ld"

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -415,7 +415,7 @@
 
 #if defined(__STDC__) || defined(_MSC_VER) || defined(__cplusplus) || \
   defined(__HP_aCC) || defined(__BORLANDC__) || defined(__LCC__) || \
-  defined(__POCC__) || \
+  defined(__POCC__) || defined(__HIGHC__) || \
   defined(__ILEC400__)
   /* This compiler is believed to have an ISO compatible preprocessor */
 #define CURL_ISOCPP

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -415,7 +415,7 @@
 
 #if defined(__STDC__) || defined(_MSC_VER) || defined(__cplusplus) || \
   defined(__HP_aCC) || defined(__BORLANDC__) || defined(__LCC__) || \
-  defined(__POCC__) || defined(__HIGHC__) || \
+  defined(__POCC__) || \
   defined(__ILEC400__)
   /* This compiler is believed to have an ISO compatible preprocessor */
 #define CURL_ISOCPP

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -415,7 +415,7 @@
 
 #if defined(__STDC__) || defined(_MSC_VER) || defined(__cplusplus) || \
   defined(__HP_aCC) || defined(__BORLANDC__) || defined(__LCC__) || \
-  defined(__POCC__) || defined(__SALFORDC__) || defined(__HIGHC__) || \
+  defined(__POCC__) || defined(__HIGHC__) || \
   defined(__ILEC400__)
   /* This compiler is believed to have an ISO compatible preprocessor */
 #define CURL_ISOCPP

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -550,8 +550,7 @@ static SANITIZEcode rename_if_reserved_dos(char **const sanitized,
   return (*sanitized ? SANITIZE_ERR_OK : SANITIZE_ERR_OUT_OF_MEMORY);
 }
 
-#if defined(MSDOS) && defined(__DJGPP__)
-
+#ifdef __DJGPP__
 /*
  * Disable program default argument globbing. We do it on our own.
  */
@@ -560,8 +559,7 @@ char **__crt0_glob_function(char *arg)
   (void)arg;
   return (char **)0;
 }
-
-#endif /* MSDOS && __DJGPP__ */
+#endif
 
 #ifdef _WIN32
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -550,7 +550,7 @@ static SANITIZEcode rename_if_reserved_dos(char **const sanitized,
   return (*sanitized ? SANITIZE_ERR_OK : SANITIZE_ERR_OUT_OF_MEMORY);
 }
 
-#if defined(MSDOS) && (defined(__DJGPP__) || defined(__GO32__))
+#if defined(MSDOS) && defined(__DJGPP__)
 
 /*
  * Disable program default argument globbing. We do it on our own.
@@ -561,7 +561,7 @@ char **__crt0_glob_function(char *arg)
   return (char **)0;
 }
 
-#endif /* MSDOS && (__DJGPP__ || __GO32__) */
+#endif /* MSDOS && __DJGPP__ */
 
 #ifdef _WIN32
 

--- a/src/tool_doswin.h
+++ b/src/tool_doswin.h
@@ -41,11 +41,11 @@ typedef enum {
 SANITIZEcode sanitize_file_name(char **const sanitized, const char *file_name,
                                 int flags);
 
-#if defined(MSDOS) && (defined(__DJGPP__) || defined(__GO32__))
+#if defined(MSDOS) && defined(__DJGPP__)
 
 char **__crt0_glob_function(char *arg);
 
-#endif /* MSDOS && (__DJGPP__ || __GO32__) */
+#endif /* MSDOS && __DJGPP__ */
 
 #ifdef _WIN32
 

--- a/src/tool_doswin.h
+++ b/src/tool_doswin.h
@@ -41,11 +41,9 @@ typedef enum {
 SANITIZEcode sanitize_file_name(char **const sanitized, const char *file_name,
                                 int flags);
 
-#if defined(MSDOS) && defined(__DJGPP__)
-
+#ifdef __DJGPP__
 char **__crt0_glob_function(char *arg);
-
-#endif /* MSDOS && __DJGPP__ */
+#endif
 
 #ifdef _WIN32
 

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -151,7 +151,7 @@ static CURLcode main_init(struct GlobalConfig *config)
 {
   CURLcode result = CURLE_OK;
 
-#if defined(__DJGPP__) || defined(__GO32__)
+#if defined(__DJGPP__)
   /* stop stat() wasting time */
   _djstat_flags |= _STAT_INODE | _STAT_EXEC_MAGIC | _STAT_DIRSIZE;
 #endif

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -151,7 +151,7 @@ static CURLcode main_init(struct GlobalConfig *config)
 {
   CURLcode result = CURLE_OK;
 
-#if defined(__DJGPP__)
+#ifdef __DJGPP__
   /* stop stat() wasting time */
   _djstat_flags |= _STAT_INODE | _STAT_EXEC_MAGIC | _STAT_DIRSIZE;
 #endif


### PR DESCRIPTION
- DJGPP 1.x (including `__GO32__`) (MS-DOS)
  DJGPP 2.x support remains unchanged.
- Salford C (Windows)
- Turbo C (Windows 16-bit)
- Borland C++ < 5.2 (Windows 16-bit?)
- Pelles C < 2.8 (Windows)

These targets mapped `curl_off_t` to `long`. On Windows and MS-DOS
`long` is always 32-bit.

curl requires C compilers supporting 64-bit `curl_off_t` type since
835682661c7a36b0e860c978204e8cd9b033be45 #10597 (v8.0.0).

Also: drop remaining `__GO32__` and Salford C guards.

---

w/o whitespace: https://github.com/curl/curl/pull/15957/files?w=1
