### PR TITLE
msvc: require VS2005 for large file support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1900,7 +1900,7 @@ if(MSVC)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4")
   endif()
 
-  # Use multithreaded compilation on VS 2008+
+  # Use multithreaded compilation on VS2008+
   if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND MSVC_VERSION GREATER_EQUAL 1500)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1870,9 +1870,9 @@ include(CMake/OtherTests.cmake)
 
 add_definitions("-DHAVE_CONFIG_H")
 
-# For Windows, all compilers used by CMake should support large files
 if(WIN32)
-  if(NOT MSVC OR (MSVC_VERSION GREATER_EQUAL 1400))  # _fseeki64() requires VS2005
+  # _fseeki64() requires VS2005
+  if(NOT MSVC OR (MSVC_VERSION GREATER_EQUAL 1400))
     set(USE_WIN32_LARGE_FILES ON)
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1872,7 +1872,9 @@ add_definitions("-DHAVE_CONFIG_H")
 
 # For Windows, all compilers used by CMake should support large files
 if(WIN32)
-  set(USE_WIN32_LARGE_FILES ON)
+  if(NOT MSVC OR (MSVC_VERSION GREATER_EQUAL 1400))  # _fseeki64() requires VS2005
+    set(USE_WIN32_LARGE_FILES ON)
+  endif()
 
   # Use the manifest embedded in the Windows Resource
   set(CMAKE_RC_FLAGS "${CMAKE_RC_FLAGS} -DCURL_EMBED_MANIFEST")

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -387,7 +387,8 @@ Vista
 /*                        LARGE FILE SUPPORT                        */
 /* ---------------------------------------------------------------- */
 
-#if defined(_MSC_VER) || defined(__MINGW32__)
+/* _fseeki64() requires VS2005 */
+#if (defined(_MSC_VER) && (_MSC_VER >= 1400)) || defined(__MINGW32__)
 #  define USE_WIN32_LARGE_FILES
 /* Number of bits in a file offset, on hosts where this is settable. */
 #  ifdef __MINGW32__

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -493,11 +493,6 @@
 #  define LSEEK_ERROR                (offset_t)-1
 #endif
 
-#if defined(_MSC_VER) && (_MSC_VER == 1310)
-/* VS2003 misses the declaration in stdio.h, but the CRT has it */
-extern int __cdecl _fseeki64(FILE *stream, __int64 offset, int whence);
-#endif
-
 /*
  * Small file (<2Gb) support using Win32 functions.
  */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -493,6 +493,11 @@
 #  define LSEEK_ERROR                (offset_t)-1
 #endif
 
+#if defined(_MSC_VER) && (_MSC_VER == 1310)
+/* VS2003 misses the declaration in stdio.h, but the CRT has it */
+extern int __cdecl _fseeki64(FILE *stream, __int64 offset, int whence);
+#endif
+
 /*
  * Small file (<2Gb) support using Win32 functions.
  */


### PR DESCRIPTION
Large file support requires `_fseeki64()`. This function is offered in
VS2005 and upper.

VS2003 has it in the static CRT only, with declaration missing from 
headers, so it's not usable.

Ref: https://archive.org/details/X10-38445 (MS Visual Studio .NET 2003)
Ref: 8b76a8aeb21c8ae2261147af1bddd0d4637c252c #15526
