### PR TITLE
 msvc: move `_CRT_*` macros to `curl_setup.h`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1893,7 +1893,6 @@ if(MSVC)
   # Disable default manifest added by CMake
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")
 
-  add_definitions("-D_CRT_SECURE_NO_DEPRECATE" "-D_CRT_NONSTDC_NO_DEPRECATE")
   if(CMAKE_C_FLAGS MATCHES "/W[0-4]")
     string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
   else()

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -293,12 +293,6 @@
 #define HAVE_LONGLONG 1
 #endif
 
-/* Define to avoid VS2005 complaining about portable C functions. */
-#if defined(_MSC_VER) && (_MSC_VER >= 1400)
-#define _CRT_SECURE_NO_DEPRECATE 1
-#define _CRT_NONSTDC_NO_DEPRECATE 1
-#endif
-
 /* mingw-w64 and visual studio >= 2005 (MSVCR80)
    all default to 64-bit time_t unless _USE_32BIT_TIME_T is defined */
 #if (defined(_MSC_VER) && (_MSC_VER >= 1400)) || defined(__MINGW32__)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -107,14 +107,14 @@
 #  endif
 /* Detect Windows App environment which has a restricted access
  * to the Win32 APIs. */
-# if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
-  defined(WINAPI_FAMILY)
-#  include <winapifamily.h>
-#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) &&  \
-     !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#    define CURL_WINDOWS_UWP
+#  if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
+     defined(WINAPI_FAMILY)
+#    include <winapifamily.h>
+#    if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) &&  \
+       !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#      define CURL_WINDOWS_UWP
+#    endif
 #  endif
-# endif
 #endif
 
 /* Compatibility */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -85,13 +85,21 @@
 #endif
 #endif
 
+#ifdef _MSC_VER
 /*
  * Disable Visual Studio warnings:
  * 4127 "conditional expression is constant"
  */
-#ifdef _MSC_VER
-#pragma warning(disable:4127)
-#endif
+#  pragma warning(disable:4127)
+
+/* Define to avoid VS2005 and upper complaining about portable C functions. */
+#  ifndef _CRT_NONSTDC_NO_DEPRECATE
+#  define _CRT_NONSTDC_NO_DEPRECATE  /* for strdup(), write(), etc. */
+#  endif
+#  ifndef _CRT_SECURE_NO_DEPRECATE
+#  define _CRT_SECURE_NO_DEPRECATE
+#  endif
+#endif /* _MSC_VER */
 
 #ifdef _WIN32
 /*


### PR DESCRIPTION
From CMake and `lib/config-win32.h`.

Also:
- make sure not to redefine them.
- drop the unnecessary version guard. For older versions they
  should be a no-op.
- fix indentation.

---

- [ ] see what happens with sources not using `curl-config.h` (CMake)
