### PR TITLE
tidy-up: `curl_setup.h`, `curl_setup_once.h`, `config-win32ce.h`

### DIFF
--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -270,11 +270,11 @@
 /* ---------------------------------------------------------------- */
 
 #ifndef UNICODE
-#  define UNICODE
+#define UNICODE
 #endif
 
 #ifndef _UNICODE
-#  define _UNICODE
+#define _UNICODE
 #endif
 
 #define CURL_DISABLE_FILE 1

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -690,9 +690,9 @@
 /*
  * MSVC threads support requires a multi-threaded runtime library.
  * _beginthreadex() is not available in single-threaded ones.
+ * Single-threaded option was last available in VS2005: _MSC_VER <= 1400
  */
-
-#if defined(_MSC_VER) && !defined(_MT)
+#if defined(_MSC_VER) && !defined(_MT)  /* available in _MSC_VER <= 1400 */
 #  undef USE_THREADS_POSIX
 #  undef USE_THREADS_WIN32
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -735,8 +735,6 @@
 #error "libidn2 cannot be enabled with WinIDN or AppleIDN, choose one."
 #endif
 
-#define LIBIDN_REQUIRED_VERSION "0.4.1"
-
 #if defined(USE_GNUTLS) || defined(USE_OPENSSL) || defined(USE_MBEDTLS) || \
   defined(USE_WOLFSSL) || defined(USE_SCHANNEL) || defined(USE_SECTRANSP) || \
   defined(USE_BEARSSL) || defined(USE_RUSTLS)

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -135,10 +135,8 @@
 
 #ifdef _WIN32_WCE
 #  include "config-win32ce.h"
-#else
-#  ifdef _WIN32
-#    include "config-win32.h"
-#  endif
+#elif defined(_WIN32)
+#  include "config-win32.h"
 #endif
 
 #ifdef macintosh

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -943,7 +943,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #define UNITTEST static
 #endif
 
-#if defined(USE_NGHTTP2)
+#ifdef USE_NGHTTP2
 #define USE_HTTP2
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -118,8 +118,8 @@
 #endif
 
 /* Compatibility */
-#if defined(ENABLE_IPV6)
-#  define USE_IPV6 1
+#ifdef ENABLE_IPV6
+#define USE_IPV6 1
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -782,10 +782,6 @@
 #  endif
 #endif
 
-#ifdef CURL_WANTS_CA_BUNDLE_ENV
-#error "No longer supported. Set CURLOPT_CAINFO at runtime instead."
-#endif
-
 #if defined(USE_LIBSSH2) || defined(USE_LIBSSH) || defined(USE_WOLFSSH)
 #define USE_SSH
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -100,10 +100,10 @@
  * Make sure to define this macro before including any Windows headers.
  */
 #  ifndef WIN32_LEAN_AND_MEAN
-#    define WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
 #  endif
 #  ifndef NOGDI
-#    define NOGDI
+#  define NOGDI
 #  endif
 /* Detect Windows App environment which has a restricted access
  * to the Win32 APIs. */
@@ -173,7 +173,7 @@
 
 #ifdef NEED_THREAD_SAFE
 #  ifndef _THREAD_SAFE
-#    define _THREAD_SAFE
+#  define _THREAD_SAFE
 #  endif
 #endif
 
@@ -185,14 +185,14 @@
 
 #ifdef NEED_REENTRANT
 #  ifndef _REENTRANT
-#    define _REENTRANT
+#  define _REENTRANT
 #  endif
 #endif
 
 /* Solaris needs this to get a POSIX-conformant getpwuid_r */
 #if defined(sun) || defined(__sun)
 #  ifndef _POSIX_PTHREAD_SEMANTICS
-#    define _POSIX_PTHREAD_SEMANTICS 1
+#  define _POSIX_PTHREAD_SEMANTICS 1
 #  endif
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -107,14 +107,14 @@
 #  endif
 /* Detect Windows App environment which has a restricted access
  * to the Win32 APIs. */
-# if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
-  defined(WINAPI_FAMILY)
-#  include <winapifamily.h>
-#  if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) &&  \
-     !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#    define CURL_WINDOWS_UWP
+#  if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
+     defined(WINAPI_FAMILY)
+#    include <winapifamily.h>
+#    if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) &&  \
+       !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#      define CURL_WINDOWS_UWP
+#    endif
 #  endif
-# endif
 #endif
 
 /* Compatibility */
@@ -443,9 +443,9 @@
 #include <assert.h>
 
 #ifdef __TANDEM /* for ns*-tandem-nsk systems */
-# if ! defined __LP64
-#  include <floss.h> /* FLOSS is only used for 32-bit builds. */
-# endif
+#  if ! defined __LP64
+#    include <floss.h> /* FLOSS is only used for 32-bit builds. */
+#  endif
 #endif
 
 #ifndef STDC_HEADERS /* no standard C headers! */
@@ -513,11 +513,11 @@
 #endif
 
 #ifndef struct_stat
-#  define struct_stat struct stat
+#define struct_stat struct stat
 #endif
 
 #ifndef LSEEK_ERROR
-#  define LSEEK_ERROR (off_t)-1
+#define LSEEK_ERROR (off_t)-1
 #endif
 
 #ifndef SIZEOF_TIME_T
@@ -588,8 +588,8 @@
 #  endif
 #  define CURL_UINT64_SUFFIX  CURL_SUFFIX_CURL_OFF_TU
 #  define CURL_UINT64_C(val)  CURL_CONC_MACROS(val,CURL_UINT64_SUFFIX)
-# define FMT_PRId64  CURL_FORMAT_CURL_OFF_T
-# define FMT_PRIu64  CURL_FORMAT_CURL_OFF_TU
+#  define FMT_PRId64  CURL_FORMAT_CURL_OFF_T
+#  define FMT_PRIu64  CURL_FORMAT_CURL_OFF_TU
 #endif
 
 #define FMT_OFF_T CURL_FORMAT_CURL_OFF_T
@@ -843,7 +843,7 @@
  */
 
 #ifndef Curl_nop_stmt
-#  define Curl_nop_stmt do { } while(0)
+#define Curl_nop_stmt do { } while(0)
 #endif
 
 /*

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -24,7 +24,6 @@
  *
  ***************************************************************************/
 
-
 /*
  * Inclusion of common header files.
  */
@@ -106,8 +105,8 @@
 
 #ifndef HAVE_STRUCT_TIMEVAL
 struct timeval {
- long tv_sec;
- long tv_usec;
+  long tv_sec;
+  long tv_usec;
 };
 #endif
 
@@ -228,8 +227,8 @@ struct timeval {
 
 #ifndef HAVE_BOOL_T
   typedef enum {
-      bool_false = 0,
-      bool_true  = 1
+    bool_false = 0,
+    bool_true  = 1
   } bool;
 
 /*
@@ -392,7 +391,7 @@ typedef unsigned int bit;
 #ifdef __VMS
 #define argv_item_t  __char_ptr32
 #elif defined(_UNICODE)
-#define argv_item_t wchar_t *
+#define argv_item_t  wchar_t *
 #else
 #define argv_item_t  char *
 #endif


### PR DESCRIPTION
- drop unused `LIBIDN_REQUIRED_VERSION` macro.
  Unused since 9c91ec778104ae3b744b39444d544e82d5ee9ece

- drop compatibility error for `CURL_WANTS_CA_BUNDLE_ENV`.
  This macro was once set by `Makefile.mk` and Watcom makefiles.
  They are no longer supported, making the compatibility message moot.

  Follow-up to 7d7346519d8bff513f9ed9f0c5e709782b159e5a #1542 (2017)
  Follow-up to c2aeb1b3ba09af8b2e555eafa94dd9c534426bfb #1538 (2017)

- document last MSVC supporting the `!_MT` condition
  Ref: https://stackoverflow.com/questions/2278919/are-the-time-functions-of-msvc-thread-safe

- flatten an `#if` tree, prefer `#ifdef`.

- fix/adjust indentation, whitespace.

---

w/o whitespace: https://github.com/curl/curl/pull/15967/files?w=1