### PR TITLE
windows: drop redundant `USE_WIN32_SMALL_FILES` macro

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1407,8 +1407,6 @@ AC_DEFUN([CURL_CHECK_WIN32_LARGEFILE], [
       ;;
     win32_small_files)
       AC_MSG_RESULT([yes (large file disabled)])
-      AC_DEFINE_UNQUOTED(USE_WIN32_SMALL_FILES, 1,
-        [Define to 1 if you are building a Windows target without large file support.])
       ;;
     *)
       AC_MSG_RESULT([no])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1385,7 +1385,7 @@ AC_DEFUN([CURL_CHECK_WIN32_LARGEFILE], [
       AC_COMPILE_IFELSE([
         AC_LANG_PROGRAM([[
         ]],[[
-          #if !defined(_WIN32_WCE) && (defined(__MINGW32__) || defined(_MSC_VER))
+          #if !defined(_WIN32_WCE) && defined(__MINGW32__)
             int dummy=1;
           #else
             #error Win32 large file API not supported.

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1396,18 +1396,7 @@ AC_DEFUN([CURL_CHECK_WIN32_LARGEFILE], [
       ])
     fi
     if test "$curl_win32_file_api" = "no"; then
-      AC_COMPILE_IFELSE([
-        AC_LANG_PROGRAM([[
-        ]],[[
-          #if defined(_WIN32_WCE) || defined(__MINGW32__) || defined(_MSC_VER)
-            int dummy=1;
-          #else
-            #error Win32 small file API not supported.
-          #endif
-        ]])
-      ],[
-        curl_win32_file_api="win32_small_files"
-      ])
+      curl_win32_file_api="win32_small_files"
     fi
   fi
   case "$curl_win32_file_api" in

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -401,10 +401,6 @@ Vista
 #  define USE_WIN32_LARGE_FILES
 #endif
 
-#if !defined(USE_WIN32_LARGE_FILES) && !defined(USE_WIN32_SMALL_FILES)
-#  define USE_WIN32_SMALL_FILES
-#endif
-
 /* Number of bits in a file offset, on hosts where this is settable. */
 #if defined(USE_WIN32_LARGE_FILES) && defined(__MINGW32__)
 #  ifndef _FILE_OFFSET_BITS

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -395,12 +395,11 @@ Vista
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #  define USE_WIN32_LARGE_FILES
-#endif
-
 /* Number of bits in a file offset, on hosts where this is settable. */
-#if defined(USE_WIN32_LARGE_FILES) && defined(__MINGW32__)
-#  ifndef _FILE_OFFSET_BITS
-#  define _FILE_OFFSET_BITS 64
+#  ifdef __MINGW32__
+#    ifndef _FILE_OFFSET_BITS
+#    define _FILE_OFFSET_BITS 64
+#    endif
 #  endif
 #endif
 

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -393,11 +393,7 @@ Vista
 /*                        LARGE FILE SUPPORT                        */
 /* ---------------------------------------------------------------- */
 
-#if defined(_MSC_VER)
-#  define USE_WIN32_LARGE_FILES
-#endif
-
-#if defined(__MINGW32__) && !defined(USE_WIN32_LARGE_FILES)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #  define USE_WIN32_LARGE_FILES
 #endif
 

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -393,7 +393,7 @@ Vista
 /*                        LARGE FILE SUPPORT                        */
 /* ---------------------------------------------------------------- */
 
-#if defined(_MSC_VER) && !defined(_WIN32_WCE)
+#if defined(_MSC_VER)
 #  define USE_WIN32_LARGE_FILES
 #endif
 

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -242,10 +242,6 @@
 #  define USE_WIN32_LARGE_FILES
 #endif
 
-#if !defined(USE_WIN32_LARGE_FILES) && !defined(USE_WIN32_SMALL_FILES)
-#  define USE_WIN32_SMALL_FILES
-#endif
-
 /* ---------------------------------------------------------------- */
 /*                           LDAP SUPPORT                           */
 /* ---------------------------------------------------------------- */

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -238,9 +238,7 @@
 /*                        LARGE FILE SUPPORT                        */
 /* ---------------------------------------------------------------- */
 
-#if defined(_MSC_VER) && !defined(_WIN32_WCE)
-#  define USE_WIN32_LARGE_FILES
-#endif
+/* No large file support on Windows CE */
 
 /* ---------------------------------------------------------------- */
 /*                           LDAP SUPPORT                           */

--- a/lib/config-win32ce.h
+++ b/lib/config-win32ce.h
@@ -238,7 +238,7 @@
 /*                        LARGE FILE SUPPORT                        */
 /* ---------------------------------------------------------------- */
 
-/* No large file support on Windows CE */
+/* Windows CE does not support large files */
 
 /* ---------------------------------------------------------------- */
 /*                           LDAP SUPPORT                           */

--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -84,10 +84,6 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w)
   return str_utf8;
 }
 
-#endif /* _WIN32 */
-
-#if defined(USE_WIN32_LARGE_FILES) || defined(USE_WIN32_SMALL_FILES)
-
 /* declare GetFullPathNameW for mingw-w64 UWP builds targeting old windows */
 #if defined(CURL_WINDOWS_UWP) && defined(__MINGW32__) && \
   (_WIN32_WINNT < _WIN32_WINNT_WIN10)
@@ -329,10 +325,10 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
       target = fixed;
     else
       target = path_w;
-#if defined(USE_WIN32_SMALL_FILES)
-    result = _wstat(target, buffer);
-#else
+#if defined(USE_WIN32_LARGE_FILES)
     result = _wstati64(target, buffer);
+#else
+    result = _wstat(target, buffer);
 #endif
     curlx_unicodefree(path_w);
   }
@@ -343,10 +339,10 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
     target = fixed;
   else
     target = path;
-#if defined(USE_WIN32_SMALL_FILES)
-  result = _stat(target, buffer);
-#else
+#if defined(USE_WIN32_LARGE_FILES)
   result = _stati64(target, buffer);
+#else
+  result = _stat(target, buffer);
 #endif
 #endif
 
@@ -354,4 +350,4 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
   return result;
 }
 
-#endif /* USE_WIN32_LARGE_FILES || USE_WIN32_SMALL_FILES */
+#endif /* _WIN32 */

--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -32,7 +32,7 @@
 
 #include "curl_setup.h"
 
-#if defined(_WIN32)
+#ifdef _WIN32
 
 #include "curl_multibyte.h"
 
@@ -325,7 +325,7 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
       target = fixed;
     else
       target = path_w;
-#if defined(USE_WIN32_LARGE_FILES)
+#ifdef USE_WIN32_LARGE_FILES
     result = _wstati64(target, buffer);
 #else
     result = _wstat(target, buffer);
@@ -339,7 +339,7 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
     target = fixed;
   else
     target = path;
-#if defined(USE_WIN32_LARGE_FILES)
+#ifdef USE_WIN32_LARGE_FILES
   result = _stati64(target, buffer);
 #else
   result = _stat(target, buffer);

--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -325,10 +325,10 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
       target = fixed;
     else
       target = path_w;
-#ifdef USE_WIN32_LARGE_FILES
-    result = _wstati64(target, buffer);
-#else
+#ifndef USE_WIN32_LARGE_FILES
     result = _wstat(target, buffer);
+#else
+    result = _wstati64(target, buffer);
 #endif
     curlx_unicodefree(path_w);
   }
@@ -339,10 +339,10 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
     target = fixed;
   else
     target = path;
-#ifdef USE_WIN32_LARGE_FILES
-  result = _stati64(target, buffer);
-#else
+#ifndef USE_WIN32_LARGE_FILES
   result = _stat(target, buffer);
+#else
+  result = _stati64(target, buffer);
 #endif
 #endif
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -495,7 +495,7 @@
  * Small file (<2Gb) support using Win32 functions.
  */
 
-#ifdef USE_WIN32_SMALL_FILES
+#if defined(_WIN32) && !defined(USE_WIN32_LARGE_FILES)
 #  include <io.h>
 #  include <sys/types.h>
 #  include <sys/stat.h>

--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -49,7 +49,7 @@ int tool_seek_cb(void *userdata, curl_off_t offset, int whence)
 {
   struct per_transfer *per = userdata;
 
-#if(SIZEOF_CURL_OFF_T > SIZEOF_OFF_T) && !defined(USE_WIN32_LARGE_FILES)
+#if (SIZEOF_CURL_OFF_T > SIZEOF_OFF_T) && !defined(USE_WIN32_LARGE_FILES)
 
   /* The offset check following here is only interesting if curl_off_t is
      larger than off_t and we are not using the Win32 large file support


### PR DESCRIPTION
In effect it meant `_WIN32 && !USE_WIN32_LARGE_FILES`.
Replace it with these macros.

Also:
- configure: delete tautological check for small file support.
- configure: delete stray `_MSC_VER` reference. autotools does not
  support MSVC.
- drop tautological checks for WinCE in `config-win32*.h` when setting
  `USE_WIN32_LARGE_FILES`.
- merge related PP logic.
- prefer `#ifdef`, fix whitespace.

Suggested-by: Marcel Raad
Report: https://github.com/curl/curl/pull/15952#issuecomment-2580092328

---

w/o whitespace: https://github.com/curl/curl/pull/15968/files?w=1
