### PR TITLE
curl_setup: fix missing `ADDRESS_FAMILY` type in rare build cases

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -980,7 +980,11 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #    define UNIX_PATH_MAX 108
      /* !checksrc! disable TYPEDEFSTRUCT 1 */
      typedef struct sockaddr_un {
+#    if defined(HAVE_ADDRESS_FAMILY)
        ADDRESS_FAMILY sun_family;
+#    else
+       CURL_SA_FAMILY_T sun_family;
+#    endif
        char sun_path[UNIX_PATH_MAX];
      } SOCKADDR_UN, *PSOCKADDR_UN;
 #    define WIN32_SOCKADDR_UN

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -980,11 +980,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #    define UNIX_PATH_MAX 108
      /* !checksrc! disable TYPEDEFSTRUCT 1 */
      typedef struct sockaddr_un {
-#    if defined(HAVE_ADDRESS_FAMILY)
-       ADDRESS_FAMILY sun_family;
-#    else
        CURL_SA_FAMILY_T sun_family;
-#    endif
        char sun_path[UNIX_PATH_MAX];
      } SOCKADDR_UN, *PSOCKADDR_UN;
 #    define WIN32_SOCKADDR_UN


### PR DESCRIPTION
Build failed when both `ADDRESS_FAMILY` and `sockaddr_un` stuct were
missing from the Windows SDK, with UnixSockets enabled.

Seen with GNU 4.4.0 in CeGCC 0.59.1:
```
lib/curl_setup.h:983: error: expected specifier-qualifier-list before 'ADDRESS_FAMILY'
lib/curl_setup.h:985: warning: struct has no members
```

Also reported with VS2003:
https://datagirl.xyz/posts/wolfssl_curl_w2k.html
