### PR TITLE
cmake: drop VS2010 "Dialog Hell" workaround added in 2013

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2380,7 +2380,7 @@ if(NOT CURL_DISABLE_INSTALL)
     DESTINATION ${_install_cmake_dir})
 
   # Workaround for VS2010 to avoid the Dialog Hell
-  # FIXME: This could be removed with future version of CMake.
+  # FIXME: This could be removed with future version of CMake (as of v2.8.10).
   if(MSVC_VERSION EQUAL 1600)
     set(_curl_sln_filename "${CMAKE_CURRENT_BINARY_DIR}/CURL.sln")
     if(EXISTS "${_curl_sln_filename}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2379,7 +2379,7 @@ if(NOT CURL_DISABLE_INSTALL)
   install(FILES ${_version_config} ${_project_config}
     DESTINATION ${_install_cmake_dir})
 
-  # Workaround for MSVS10 to avoid the Dialog Hell
+  # Workaround for VS2010 to avoid the Dialog Hell
   # FIXME: This could be removed with future version of CMake.
   if(MSVC_VERSION EQUAL 1600)
     set(_curl_sln_filename "${CMAKE_CURRENT_BINARY_DIR}/CURL.sln")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2379,15 +2379,6 @@ if(NOT CURL_DISABLE_INSTALL)
   install(FILES ${_version_config} ${_project_config}
     DESTINATION ${_install_cmake_dir})
 
-  # Workaround for VS2010 to avoid the Dialog Hell
-  # FIXME: This could be removed with future version of CMake (as of v2.8.10).
-  if(MSVC_VERSION EQUAL 1600)
-    set(_curl_sln_filename "${CMAKE_CURRENT_BINARY_DIR}/CURL.sln")
-    if(EXISTS "${_curl_sln_filename}")
-      file(APPEND "${_curl_sln_filename}" "\n# This should be regenerated!\n")
-    endif()
-  endif()
-
   if(NOT TARGET curl_uninstall)
     configure_file(
       "${CMAKE_CURRENT_SOURCE_DIR}/CMake/cmake_uninstall.cmake.in"

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -460,7 +460,7 @@ Vista
 #ifndef CURL_OS
 #if defined(_M_IX86) || defined(__i386__) /* x86 (MSVC or gcc) */
 #define CURL_OS "i386-pc-win32"
-#elif defined(_M_X64) || defined(__x86_64__) /* x86_64 (MSVC >=2005 or gcc) */
+#elif defined(_M_X64) || defined(__x86_64__) /* x86_64 (VS2005+ or gcc) */
 #define CURL_OS "x86_64-pc-win32"
 #elif defined(_M_IA64) || defined(__ia64__) /* Itanium */
 #define CURL_OS "ia64-pc-win32"


### PR DESCRIPTION
Delete the workaround added via a94a68a3c1d04ccb53e46baa69753bbf6354ee14
(2013-02-04). The commit message has no details. The comment mentions
"Dialog Hell", and seems to fix CMake missing to regenerate `CURL.sln`
with VS2010. It also added a FIXME saying the workaround can be deleted
with future versions of CMake.

At the time CMake's latest version was v2.8.10.

curl now requires v3.7 (2018) minimum, and v3.24 (2022) was the
latest CMake natively supporting VS2010. Assume this has since been
fixed.

Also: format an MSVC version reference in comment.
