### PR TITLE
multihandle: add an ssl_scache here

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -48,7 +48,6 @@
 #include <curl/curl.h>
 #include "transfer.h"
 #include "vtls/vtls.h"
-#include "vtls/vtls_scache.h"
 #include "url.h"
 #include "getinfo.h"
 #include "hostip.h"
@@ -765,9 +764,9 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
   if(data->multi_easy)
     multi = data->multi_easy;
   else {
-    /* this multi handle will only ever have a single easy handled attached
-       to it, so make it use minimal hashes */
-    multi = Curl_multi_handle(1, 3, 7);
+    /* this multi handle will only ever have a single easy handle attached to
+       it, so make it use minimal hash sizes */
+    multi = Curl_multi_handle(1, 3, 7, 3);
     if(!multi)
       return CURLE_OUT_OF_MEMORY;
   }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -46,6 +46,7 @@
 #include "multihandle.h"
 #include "sigpipe.h"
 #include "vtls/vtls.h"
+#include "vtls/vtls_scache.h"
 #include "http_proxy.h"
 #include "http2.h"
 #include "socketpair.h"
@@ -71,6 +72,10 @@
 
 #ifndef CURL_DNS_HASH_SIZE
 #define CURL_DNS_HASH_SIZE 71
+#endif
+
+#ifndef CURL_TLS_SESSION_SIZE
+#define CURL_TLS_SESSION_SIZE 25
 #endif
 
 #define CURL_MULTI_HANDLE 0x000bab1e
@@ -395,9 +400,10 @@ static void multi_addmsg(struct Curl_multi *multi, struct Curl_message *msg)
   Curl_llist_append(&multi->msglist, msg, &msg->list);
 }
 
-struct Curl_multi *Curl_multi_handle(size_t hashsize, /* socket hash */
+struct Curl_multi *Curl_multi_handle(size_t hashsize,  /* socket hash */
                                      size_t chashsize, /* connection hash */
-                                     size_t dnssize) /* dns hash */
+                                     size_t dnssize,   /* dns hash */
+                                     size_t sesssize)  /* TLS session cache */
 {
   struct Curl_multi *multi = calloc(1, sizeof(struct Curl_multi));
 
@@ -414,7 +420,10 @@ struct Curl_multi *Curl_multi_handle(size_t hashsize, /* socket hash */
                  Curl_hash_str, Curl_str_key_compare, ph_freeentry);
 
   if(Curl_cpool_init(&multi->cpool, Curl_on_disconnect,
-                         multi, NULL, chashsize))
+                     multi, NULL, chashsize))
+    goto error;
+
+  if(Curl_ssl_scache_create(sesssize, 2, &multi->ssl_scache))
     goto error;
 
   Curl_llist_init(&multi->msglist, NULL);
@@ -447,6 +456,7 @@ error:
   Curl_hash_destroy(&multi->proto_hash);
   Curl_hash_destroy(&multi->hostcache);
   Curl_cpool_destroy(&multi->cpool);
+  Curl_ssl_scache_destroy(multi->ssl_scache);
   free(multi);
   return NULL;
 }
@@ -455,7 +465,8 @@ CURLM *curl_multi_init(void)
 {
   return Curl_multi_handle(CURL_SOCKET_HASH_TABLE_SIZE,
                            CURL_CONNECTION_HASH_SIZE,
-                           CURL_DNS_HASH_SIZE);
+                           CURL_DNS_HASH_SIZE,
+                           CURL_TLS_SESSION_SIZE);
 }
 
 #if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
@@ -3136,6 +3147,7 @@ CURLMcode curl_multi_cleanup(CURLM *m)
     Curl_hash_destroy(&multi->proto_hash);
     Curl_hash_destroy(&multi->hostcache);
     Curl_psl_destroy(&multi->psl);
+    Curl_ssl_scache_destroy(multi->ssl_scache);
 
 #ifdef USE_WINSOCK
     WSACloseEvent(multi->wsa_event);

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -106,8 +106,8 @@ struct Curl_multi {
   curl_push_callback push_cb;
   void *push_userp;
 
-  /* Hostname cache */
-  struct Curl_hash hostcache;
+  struct Curl_hash hostcache; /* Hostname cache */
+  struct Curl_ssl_scache *ssl_scache; /* TLS session pool */
 
 #ifdef USE_LIBPSL
   /* PSL cache. */

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -47,7 +47,8 @@ void Curl_multi_connchanged(struct Curl_multi *multi);
    socket, connection and dns hashes */
 struct Curl_multi *Curl_multi_handle(size_t hashsize,
                                      size_t chashsize,
-                                     size_t dnssize);
+                                     size_t dnssize,
+                                     size_t sesssize);
 
 /* the write bits start at bit 16 for the *getsock() bitmap */
 #define GETSOCK_WRITEBITSTART 16

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1583,7 +1583,7 @@ static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
 #endif
 #ifdef USE_SSL
       if(data->share->ssl_scache == data->state.ssl_scache)
-        data->state.ssl_scache = NULL;
+        data->state.ssl_scache = data->multi ? data->multi->ssl_scache : NULL;
 #endif
 #ifdef USE_LIBPSL
       if(data->psl == &data->share->psl)

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -72,7 +72,6 @@
 #include "url.h"
 #include "getinfo.h"
 #include "vtls/vtls.h"
-#include "vtls/vtls_scache.h"
 #include "vquic/vquic.h"
 #include "select.h"
 #include "multiif.h"
@@ -567,14 +566,9 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
   data->state.url = data->set.str[STRING_SET_URL];
 
 #ifdef USE_SSL
-  if(!data->state.ssl_scache) {
-    /* There was no ssl session cache set via a share, so we create
-     * one just for this transfer alone. Most transfers talk to just
-     * one host, but redirects may involve several occasionally. */
-    result = Curl_ssl_scache_create(3, 2, &data->state.ssl_scache);
-    if(result)
-      return result;
-  }
+  if(!data->state.ssl_scache)
+    /* There was no ssl session cache set via a share, use the multi one */
+    data->state.ssl_scache = data->multi->ssl_scache;
 #endif
 
   data->state.requests = 0;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -526,12 +526,6 @@ CURLcode Curl_ssl_get_channel_binding(struct Curl_easy *data, int sockindex,
 
 void Curl_ssl_close_all(struct Curl_easy *data)
 {
-  /* kill the session ID cache if not shared */
-  if(data->state.ssl_scache && !CURL_SHARE_ssl_scache(data)) {
-    Curl_ssl_scache_destroy(data->state.ssl_scache);
-    data->state.ssl_scache = NULL;
-  }
-
   if(Curl_ssl->close_all)
     Curl_ssl->close_all(data);
 }

--- a/lib/vtls/vtls_scache.h
+++ b/lib/vtls/vtls_scache.h
@@ -210,8 +210,8 @@ CURLcode Curl_ssl_session_export(struct Curl_easy *data,
 
 #else /* USE_SSL */
 
-#define Curl_ssl_scache_create(x,y) CURLE_OK
-#define Curl_ssl_scache_destroy(x) CURLE_OK
+#define Curl_ssl_scache_create(x,y,z) ((void)x, CURLE_OK)
+#define Curl_ssl_scache_destroy(x) do {} while(0)
 
 #endif /* USE_SSL (else) */
 


### PR DESCRIPTION
The TLS session cache is now held by the multi handle unless it is shared, so that all easy handles within a multi handle get the benefit of sharing the same, larger, cache.

The multi handle session cache size is set to 25, unless it is the internal one used for the easy interface - which still uses only 3.