### PR TITLE
altsvc: return error on dot-only name

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -108,19 +108,20 @@ static struct altsvc *altsvc_createid(const char *srchost,
     return NULL;
   DEBUGASSERT(hlen);
   DEBUGASSERT(dlen);
-  if(!hlen || !dlen) {
+  if(!hlen || !dlen)
     /* bad input */
-    free(as);
-    return NULL;
-  }
+    goto error;
   if((hlen > 2) && srchost[0] == '[') {
     /* IPv6 address, strip off brackets */
     srchost++;
     hlen -= 2;
   }
-  else if(srchost[hlen - 1] == '.')
+  else if(srchost[hlen - 1] == '.') {
     /* strip off trailing dot */
     hlen--;
+    if(!hlen)
+      goto error;
+  }
   if((dlen > 2) && dsthost[0] == '[') {
     /* IPv6 address, strip off brackets */
     dsthost++;


### PR DESCRIPTION
Because it is a trailing dot that otherwise leads to a zero length name.

Coverity CID 1638755.