### PR TITLE
telnet: handle single-byte input option

### DIFF
--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -695,7 +695,10 @@ static void printsub(struct Curl_easy *data,
           infof(data, ", not IAC SE) ");
         }
       }
-      length -= 2;
+      if(length >= 2)
+        length -= 2;
+      else /* bad input */
+        return;
     }
     if(length < 1) {
       infof(data, "(Empty suboption?)");


### PR DESCRIPTION
Coverity CID 1638753 correctly identies this code misbehaved if the passed in suboption is exactly one byte long by substracting two from the unsigned size_t variable.