### PR TITLE
curl_easy_ssls_export/import.md: made for TLS protocols

### DIFF
--- a/docs/libcurl/curl_easy_ssls_export.md
+++ b/docs/libcurl/curl_easy_ssls_export.md
@@ -9,7 +9,7 @@ See-also:
   - curl_share_setopt (3)
   - curl_easy_ssls_import (3)
 Protocol:
-  - All
+  - TLS
 TLS-backend:
   - GnuTLS
   - OpenSSL

--- a/docs/libcurl/curl_easy_ssls_import.md
+++ b/docs/libcurl/curl_easy_ssls_import.md
@@ -9,7 +9,13 @@ See-also:
   - curl_share_setopt (3)
   - curl_easy_ssls_export (3)
 Protocol:
-  - All
+  - TLS
+TLS-backend:
+  - GnuTLS
+  - OpenSSL
+  - BearSSL
+  - wolfSSL
+  - mbedTLS
 Added-in: 8.12.0
 ---
 


### PR DESCRIPTION
Which then makes the generated man page also include details about the specific backends that support this feature.

Follow-up to 515a21f350b89f0676e5df7f904c62c8f67be377