### PR TITLE
sha256: use this with TLS builds now

### DIFF
--- a/lib/curl_hmac.h
+++ b/lib/curl_hmac.h
@@ -24,9 +24,9 @@
  *
  ***************************************************************************/
 
-#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI))         \
-  || !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH)   \
-  || defined(USE_LIBSSH2)
+#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI)) ||      \
+  !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH) ||   \
+  defined(USE_SSL)
 
 #include <curl/curl.h>
 

--- a/lib/curl_sha256.h
+++ b/lib/curl_sha256.h
@@ -26,7 +26,7 @@
  ***************************************************************************/
 
 #if !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH) \
-    || defined(USE_LIBSSH2)
+    || defined(USE_LIBSSH2) || defined(USE_SSL)
 
 #include <curl/curl.h>
 #include "curl_hmac.h"

--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -26,8 +26,9 @@
 
 #include "curl_setup.h"
 
-#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI))         \
-  || !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH)
+#if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI)) ||      \
+  !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH) ||   \
+  defined(USE_SSL)
 
 #include <curl/curl.h>
 

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -26,7 +26,7 @@
 #include "curl_setup.h"
 
 #if !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH) \
-    || defined(USE_LIBSSH2)
+  || defined(USE_LIBSSH2) || defined(USE_SSL)
 
 #include "warnless.h"
 #include "curl_sha256.h"


### PR DESCRIPTION
Used by the SSL session cache code.

Bug: https://curl.se/mail/lib-2025-01/0041.html
Reported-by: Aleksander Mazur