### PR TITLE
mprintf: terminate snprintf output on windows

### DIFF
--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -1015,6 +1015,11 @@ number:
          output characters */
 #ifdef HAVE_SNPRINTF
       (snprintf)(work, BUFFSIZE, formatbuf, iptr->val.dnum); /* NOLINT */
+#ifdef _WIN32
+      /* Old versions of the Windows CRT do not terminate the snprintf output
+         buffer if it reaches the max size so we do that here. */
+      work[BUFFSIZE - 1] = 0;
+#endif
 #else
       (sprintf)(work, formatbuf, iptr->val.dnum);
 #endif
@@ -1022,11 +1027,6 @@ number:
 #pragma clang diagnostic pop
 #endif
       DEBUGASSERT(strlen(work) < BUFFSIZE);
-#ifdef __MINGW32__
-      /* Work-around for a nasty bug seen with old-mingw and gcc 7.3.0 when it
-         writes one byte more than permitted. */
-      work[BUFFSIZE - 1] = 0;
-#endif
       for(fptr = work; *fptr; fptr++)
         OUTCHAR(*fptr);
       break;


### PR DESCRIPTION
- Null terminate the end of the snprintf output buffer on Windows.

Old versions of the Windows CRT (which are often found on later versions of Windows) do not terminate the snprintf output buffer if the output reaches the max size.

This is a follow-up to 7e32f656 which made the same change but limited it to mingw, however it is a CRT version issue irrespective of compiler.

Ref: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/snprintf-snprintf-snprintf-l-snwprintf-snwprintf-l?view=msvc-170#remarks

Closes #xxxx