### PR TITLE
pytest, use httpd/apache2 directly, no apachectl

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -324,17 +324,16 @@ AS_HELP_STRING([--with-test-vsftpd=PATH],[where to find vsftpd for testing]),
 )
 AC_SUBST(VSFTPD)
 
-dnl we'd like a httpd+apachectl as test server
+dnl we'd like a httpd as test server
 dnl
 HTTPD_ENABLED="maybe"
 AC_ARG_WITH(test-httpd, [AS_HELP_STRING([--with-test-httpd=PATH],
                          [where to find httpd/apache2 for testing])],
   [request_httpd=$withval], [request_httpd=check])
 if test x"$request_httpd" = "xcheck" -o x"$request_httpd" = "xyes"; then
-  if test -x "/usr/sbin/apache2" -a -x "/usr/sbin/apache2ctl"; then
+  if test -x "/usr/sbin/apache2"; then
     # common location on distros (debian/ubuntu)
     HTTPD="/usr/sbin/apache2"
-    APACHECTL="/usr/sbin/apache2ctl"
     AC_PATH_PROG([APXS], [apxs])
     if test "x$APXS" = "x"; then
       AC_MSG_NOTICE([apache2-dev not installed, httpd tests disabled])
@@ -345,9 +344,8 @@ if test x"$request_httpd" = "xcheck" -o x"$request_httpd" = "xyes"; then
     if test "x$HTTPD" = "x"; then
       AC_PATH_PROG([HTTPD], [apache2])
     fi
-    AC_PATH_PROG([APACHECTL], [apachectl])
     AC_PATH_PROG([APXS], [apxs])
-    if test "x$HTTPD" = "x" -o "x$APACHECTL" = "x"; then
+    if test "x$HTTPD" = "x"; then
       AC_MSG_NOTICE([httpd/apache2 not in PATH, http tests disabled])
       HTTPD_ENABLED="no"
     fi
@@ -358,13 +356,9 @@ if test x"$request_httpd" = "xcheck" -o x"$request_httpd" = "xyes"; then
   fi
 elif test x"$request_httpd" != "xno"; then
   HTTPD="${request_httpd}/bin/httpd"
-  APACHECTL="${request_httpd}/bin/apachectl"
   APXS="${request_httpd}/bin/apxs"
   if test ! -x "${HTTPD}"; then
     AC_MSG_NOTICE([httpd not found as ${HTTPD}, http tests disabled])
-    HTTPD_ENABLED="no"
-  elif test ! -x "${APACHECTL}"; then
-    AC_MSG_NOTICE([apachectl not found as ${APACHECTL}, http tests disabled])
     HTTPD_ENABLED="no"
   elif test ! -x "${APXS}"; then
     AC_MSG_NOTICE([apxs not found as ${APXS}, http tests disabled])
@@ -375,11 +369,9 @@ elif test x"$request_httpd" != "xno"; then
 fi
 if test x"$HTTPD_ENABLED" = "xno"; then
   HTTPD=""
-  APACHECTL=""
   APXS=""
 fi
 AC_SUBST(HTTPD)
-AC_SUBST(APACHECTL)
 AC_SUBST(APXS)
 
 dnl the nghttpx we might use in httpd testing

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -368,7 +368,6 @@ Details via CMake
 
 ## Test tools
 
-- `APACHECTL`:                              Default: `apache2ctl`
 - `APXS`:                                   Default: `apxs`
 - `CADDY`:                                  Default: `caddy`
 - `HTTPD_NGHTTPX`:                          Default: `nghttpx`

--- a/tests/http/CMakeLists.txt
+++ b/tests/http/CMakeLists.txt
@@ -40,12 +40,6 @@ if(NOT HTTPD)
 endif()
 mark_as_advanced(HTTPD)
 
-find_program(APACHECTL "apache2ctl")  # /usr/sbin/apache2ctl
-if(NOT APACHECTL)
-  set(APACHECTL "")
-endif()
-mark_as_advanced(APACHECTL)
-
 find_program(APXS "apxs")
 if(NOT APXS)
   set(APXS "")
@@ -58,5 +52,5 @@ if(NOT HTTPD_NGHTTPX)
 endif()
 mark_as_advanced(HTTPD_NGHTTPX)
 
-# Consumed variables: APACHECTL, APXS, CADDY, HTTPD, HTTPD_NGHTTPX, VSFTPD
+# Consumed variables: APXS, CADDY, HTTPD, HTTPD_NGHTTPX, VSFTPD
 configure_file("config.ini.in" "${CMAKE_CURRENT_BINARY_DIR}/config.ini" @ONLY)

--- a/tests/http/config.ini.in
+++ b/tests/http/config.ini.in
@@ -28,7 +28,6 @@
 [httpd]
 apxs = @APXS@
 httpd = @HTTPD@
-apachectl = @APACHECTL@
 
 [nghttpx]
 nghttpx = @HTTPD_NGHTTPX@

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -127,7 +127,6 @@ class EnvConfig:
             'ws': socket.SOCK_STREAM,
         })
         self.httpd = self.config['httpd']['httpd']
-        self.apachectl = self.config['httpd']['apachectl']
         self.apxs = self.config['httpd']['apxs']
         if len(self.apxs) == 0:
             self.apxs = None
@@ -257,7 +256,6 @@ class EnvConfig:
 
     def is_complete(self) -> bool:
         return os.path.isfile(self.httpd) and \
-               os.path.isfile(self.apachectl) and \
                self.apxs is not None and \
                os.path.isfile(self.apxs)
 
@@ -266,8 +264,6 @@ class EnvConfig:
             return 'httpd not configured, see `--with-test-httpd=<path>`'
         if not os.path.isfile(self.httpd):
             return f'httpd ({self.httpd}) not found'
-        if not os.path.isfile(self.apachectl):
-            return f'apachectl ({self.apachectl}) not found'
         if self.apxs is None:
             return "command apxs not found (commonly provided in apache2-dev)"
         if not os.path.isfile(self.apxs):
@@ -577,10 +573,6 @@ class Env:
     @property
     def httpd(self) -> str:
         return self.CONFIG.httpd
-
-    @property
-    def apachectl(self) -> str:
-        return self.CONFIG.apachectl
 
     @property
     def apxs(self) -> str:

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -63,7 +63,6 @@ class Httpd:
 
     def __init__(self, env: Env, proxy_auth: bool = False):
         self.env = env
-        self._cmd = env.apachectl
         self._apache_dir = os.path.join(env.gen_dir, 'apache')
         self._run_dir = os.path.join(self._apache_dir, 'run')
         self._lock_dir = os.path.join(self._apache_dir, 'locks')
@@ -102,7 +101,7 @@ class Httpd:
         self._rmf(self._error_log)
 
     def exists(self):
-        return os.path.exists(self._cmd)
+        return os.path.exists(self.env.httpd)
 
     def set_extra_config(self, domain: str, lines: Optional[Union[str, List[str]]]):
         if lines is None:
@@ -132,8 +131,8 @@ class Httpd:
                           stderr=p.stderr.decode().splitlines(),
                           duration=datetime.now() - start)
 
-    def _apachectl(self, cmd: str):
-        args = [self.env.apachectl,
+    def _cmd_httpd(self, cmd: str):
+        args = [self.env.httpd,
                 "-d", self._apache_dir,
                 "-f", self._conf_file,
                 "-k", cmd]
@@ -147,7 +146,7 @@ class Httpd:
             fd.write('start of server\n')
         with open(os.path.join(self._apache_dir, 'xxx'), 'a') as fd:
             fd.write('start of server\n')
-        r = self._apachectl('start')
+        r = self._cmd_httpd('start')
         if r.exit_code != 0:
             log.error(f'failed to start httpd: {r}')
             return False
@@ -155,7 +154,7 @@ class Httpd:
         return self.wait_live(timeout=timedelta(seconds=5))
 
     def stop(self):
-        r = self._apachectl('stop')
+        r = self._cmd_httpd('stop')
         self._loaded_extra_configs = None
         if r.exit_code == 0:
             return self.wait_dead(timeout=timedelta(seconds=5))
@@ -168,7 +167,7 @@ class Httpd:
 
     def reload(self):
         self._write_config()
-        r = self._apachectl("graceful")
+        r = self._cmd_httpd("graceful")
         self._loaded_extra_configs = None
         if r.exit_code != 0:
             log.error(f'failed to reload httpd: {r}')


### PR DESCRIPTION
Since the script 'apachectl' from the httpd project is severly mutilated on several distros, use the executable httpd/apache2 directly in pytest runs.

Remove detection of apachectl form autoconf and cmake.