### PR TITLE
CI: add/extend curl binary info, VS2010 32-bit, misc improvements

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -299,6 +299,10 @@ jobs:
             make -j5 -C bld
           fi
 
+      - name: 'curl info'
+        run: |
+          find . -type f \( -name curl -o -name '*.a' \) -exec file '{}' \;
+
       - name: 'build tests'
         if: ${{ matrix.build == 'cmake' }}  # skip for autotools to save time
         run: |
@@ -401,6 +405,10 @@ jobs:
           else
             make -j5 -C bld
           fi
+
+      - name: 'curl info'
+        run: |
+          find . \( -name '*.exe' -o -name '*.a' \) -exec file '{}' \;
 
       - name: 'build tests'
         if: ${{ matrix.build == 'cmake' }}  # skip for autotools to save time

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -357,7 +357,7 @@ jobs:
           fi
 
   mingw-w64-standalone-downloads:
-    name: 'mingw-dl, CM ${{ matrix.env }} ${{ matrix.name }}'
+    name: 'dl-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
     timeout-minutes: 20
     defaults:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -356,8 +356,8 @@ jobs:
             make -C bld -j5 V=1 examples
           fi
 
-  old-mingw-w64:
-    name: 'old-mingw64, CM ${{ matrix.env }} ${{ matrix.name }}'
+  mingw-w64-standalone:
+    name: 'mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
     timeout-minutes: 20
     defaults:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -356,8 +356,8 @@ jobs:
             make -C bld -j5 V=1 examples
           fi
 
-  mingw-w64-standalone:
-    name: 'mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
+  mingw-w64-standalone-downloads:
+    name: 'mingw-dl, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
     timeout-minutes: 20
     defaults:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -357,7 +357,7 @@ jobs:
           fi
 
   old-mingw-w64:
-    name: 'old-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
+    name: 'old-mingw64, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
     timeout-minutes: 20
     defaults:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -118,7 +118,7 @@ jobs:
       - name: 'curl version'
         timeout-minutes: 1
         run: |
-          find . -name '*.exe' -o -name '*.dll'
+          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -exec file '{}' \;
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             PATH="$PWD/bld/lib:$PATH"
           fi
@@ -294,7 +294,7 @@ jobs:
             # avoid libtool's curl.exe wrapper
             mv bld/src/.libs/curl.exe bld/src/curl.exe
           fi
-          find . -name '*.exe' -o -name '*.dll'
+          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -exec file '{}' \;
           if [ '${{ matrix.test }}' != 'uwp' ]; then  # curl: error initializing curl library
             bld/src/curl.exe --disable --version
           fi
@@ -446,7 +446,7 @@ jobs:
       - name: 'curl version'
         timeout-minutes: 1
         run: |
-          PATH=/usr/bin find . -name '*.exe' -o -name '*.dll'
+          PATH=/usr/bin find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -exec file '{}' \;
           PATH="$PWD/bld/lib:$PATH"
           bld/src/curl.exe --disable --version
 
@@ -541,6 +541,10 @@ jobs:
           else
             make -C bld -j5
           fi
+
+      - name: 'curl info'
+        run: |
+          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -exec file '{}' \;
 
       - name: 'build tests'
         if: ${{ matrix.build == 'cmake' }}  # Save time by skipping this for autotools
@@ -722,7 +726,7 @@ jobs:
       - name: 'curl version'
         timeout-minutes: 1
         run: |
-          PATH=/usr/bin find . -name '*.exe' -o -name '*.dll'
+          PATH=/usr/bin find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' \) -exec file '{}' \;
           if [ '${{ matrix.plat }}' != 'uwp' ]; then  # Missing: ucrtbased.dll, VCRUNTIME140D.dll, VCRUNTIME140D_APP.dll
             PATH="$PWD/bld/lib:$PATH"
             bld/src/curl.exe --disable --version

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -101,7 +101,7 @@ EOF
   curl="builds/libcurl-vc14.10-x64-${PATHPART}-dll-ssl-dll-ipv6-sspi/bin/curl.exe"
 fi
 
-find . -name '*.exe' -o -name '*.dll'
+find . \( -name '*.exe' -o -name '*.dll' -o -name '*.lib' \) -exec file '{}' \;
 if [ -z "${SKIP_RUN:-}" ]; then
   "${curl}" --disable --version
 else

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,11 +63,11 @@ environment:
       ENABLE_UNICODE: 'OFF'
       DEBUG: 'OFF'
       CURLDEBUG: 'ON'
-    - job_name: 'CMake, VS2010, Release, x64, Schannel, Static, Build-tests'
+    - job_name: 'CMake, VS2010, Release, x86, Schannel, Static, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 10 2010'
-      TARGET: '-A x64'
+      TARGET: '-A Win32'
       PRJ_CFG: Release
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'


### PR DESCRIPTION
- fix `find` commands to not miss items.

- call `file` on the built files in `curl -V` steps.
  To give more feedback on what was built.

- add `curl info` step for cross-jobs that can't do a `curl -V`.
  It lists the files built and calls `file` on them.

- appveyor: make a VS2010 32-bit to match the VS2008 job it replaced.
  Follow-up to d34aeecb08cdbb98cb81420605a78b83e4aee3c2 #15934

- GHA/windows: drop the word "old" from standalone mingw-w64 jobs to not
  conflate it with "old mingw" we no longer support (while also keeping
  it short).

Cherry-picked from #15975
