### PR TITLE
easy: make curl_easy_perform() return error if connection still there

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -751,6 +751,11 @@ static CURLcode easy_perform(struct Curl_easy *data, bool events)
   if(!data)
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
+  if(data->conn) {
+    failf(data, "cannot use again while associated with a connection");
+    return CURLE_BAD_FUNCTION_ARGUMENT;
+  }
+
   if(data->set.errorbuffer)
     /* clear this as early as possible */
     data->set.errorbuffer[0] = 0;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -101,7 +101,7 @@ test652 test653 test654 test655 test656 test658 test659 test660 test661 \
 test662 test663 test664 test665 test666 test667 test668 test669 test670 \
 test671 test672 test673 test674 test675 test676 test677 test678 test679 \
 test680 test681 test682 test683 test684 test685 test686 test687 test688 \
-test689 test690 test691 test692 test693 test694 test695 \
+test689 test690 test691 test692 test693 test694 test695 test696 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/test696
+++ b/tests/data/test696
@@ -1,0 +1,52 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+<reply>
+<data>
+HTTP/1.1 200 OK swsclose
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+Content-Length: 6
+Connection: close
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<tool>
+lib%TESTNUMBER
+</tool>
+<name>
+CONNECT_ONLY and doing a second curl_easy_perform
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /556 HTTP/1.1
+Host: ninja
+
+</protocol>
+
+# 43 == CURLE_BAD_FUNCTION_ARGUMENT
+<errorcode>
+43
+</errorcode>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -49,6 +49,7 @@ LIBTESTPROGS = libauthretry libntlmconnect libprereq                     \
  lib643        lib645 lib650 lib651 lib652 lib653 lib654 lib655 lib658   \
  lib659 lib661 lib666 lib667 lib668 \
  lib670 lib671 lib672 lib673 lib674 lib676 lib677 lib678 lib694 lib695   \
+ lib696 \
  lib1156 \
  lib1301 \
  lib1485 \
@@ -341,6 +342,9 @@ lib678_LDADD = $(TESTUTIL_LIBS)
 lib694_SOURCES = lib694.c $(SUPPORTFILES)
 
 lib695_SOURCES = lib695.c $(SUPPORTFILES)
+
+lib696_SOURCES = lib556.c $(SUPPORTFILES)
+lib696_CPPFLAGS = $(AM_CPPFLAGS) -DLIB696
 
 lib1301_SOURCES = lib1301.c $(SUPPORTFILES) $(TESTUTIL)
 lib1301_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib556.c
+++ b/tests/libtest/lib556.c
@@ -97,6 +97,15 @@ CURLcode test(char *URL)
       res = TEST_ERR_FAILURE;
   }
 
+#ifdef LIB696
+  /* attempt to use it the handle again */
+  test_setopt(curl, CURLOPT_URL, URL);
+  test_setopt(curl, CURLOPT_CONNECT_ONLY, 1L);
+  test_setopt(curl, CURLOPT_VERBOSE, 1L);
+
+  res = curl_easy_perform(curl);
+#endif
+
 test_cleanup:
 
   curl_easy_cleanup(curl);


### PR DESCRIPTION
This typically happens if CURL_CONNECT_ONLY is used and a second curl_easy_perform() is attempted.

A connection "taken over" with CURL_CONNECT_ONLY cannot be ended any other way than a curl_easy_cleanup() on the easy handle that holds it.

Add test 696 to verify.