### PR TITLE
msvc: drop support for VS2005 and older

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1935,10 +1935,7 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS "HAVE_CONFIG_H")
 if(WIN32)
   list(APPEND CURL_LIBS "ws2_32" "bcrypt")
 
-  # _fseeki64() requires VS2005
-  if(NOT MSVC OR (MSVC_VERSION GREATER_EQUAL 1400))
-    set(USE_WIN32_LARGE_FILES ON)
-  endif()
+  set(USE_WIN32_LARGE_FILES ON)
 
   # Use the manifest embedded in the Windows Resource
   string(APPEND CMAKE_RC_FLAGS " -DCURL_EMBED_MANIFEST")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1955,10 +1955,7 @@ if(MSVC)
   # Disable default manifest added by CMake
   string(APPEND CMAKE_EXE_LINKER_FLAGS " -MANIFEST:NO")
 
-  # Use multithreaded compilation on VS2008+
-  if(CMAKE_C_COMPILER_ID STREQUAL "MSVC" AND MSVC_VERSION GREATER_EQUAL 1500)
-    string(APPEND CMAKE_C_FLAGS " -MP")
-  endif()
+  string(APPEND CMAKE_C_FLAGS " -MP")  # Parallel compilation
 endif()
 
 if(CURL_WERROR)

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -330,7 +330,7 @@
 #endif
 
 /* VS2008 default target settings and minimum build target check. */
-#if defined(_MSC_VER) && (_MSC_VER >= 1500) && (_MSC_VER <= 1600)
+#if defined(_MSC_VER) && (_MSC_VER <= 1600)
 #  ifndef _WIN32_WINNT
 #  define _WIN32_WINNT VS2008_DEF_TARGET
 #  endif

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -389,8 +389,7 @@ Vista
 
 #ifndef UNDER_CE
 
-/* _fseeki64() requires VS2005 */
-#if (defined(_MSC_VER) && (_MSC_VER >= 1400)) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #  define USE_WIN32_LARGE_FILES
 /* Number of bits in a file offset, on hosts where this is settable. */
 #  ifdef __MINGW32__

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -283,7 +283,7 @@
 /* #undef HAVE_GMTIME_R */
 
 /* Define if the compiler supports the 'long long' data type. */
-#if (defined(_MSC_VER) && (_MSC_VER >= 1310)) || defined(__MINGW32__)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #define HAVE_LONGLONG 1
 #endif
 

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -287,9 +287,8 @@
 #define HAVE_LONGLONG 1
 #endif
 
-/* mingw-w64 and visual studio >= 2005 (MSVCR80)
-   all default to 64-bit time_t unless _USE_32BIT_TIME_T is defined */
-#if (defined(_MSC_VER) && (_MSC_VER >= 1400)) || defined(__MINGW32__)
+/* Default to 64-bit time_t unless _USE_32BIT_TIME_T is defined */
+#if defined(_MSC_VER) || defined(__MINGW32__)
 #  ifndef _USE_32BIT_TIME_T
 #    define SIZEOF_TIME_T 8
 #  else

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -681,16 +681,6 @@
 /* ---------------------------------------------------------------- */
 
 /*
- * MSVC threads support requires a multi-threaded runtime library.
- * _beginthreadex() is not available in single-threaded ones.
- * Single-threaded option was last available in VS2005: _MSC_VER <= 1400
- */
-#if defined(_MSC_VER) && !defined(_MT)  /* available in _MSC_VER <= 1400 */
-#  undef USE_THREADS_POSIX
-#  undef USE_THREADS_WIN32
-#endif
-
-/*
  * Mutually exclusive CURLRES_* definitions.
  */
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -78,6 +78,12 @@
 #endif
 #endif
 
+/* Visual Studio 2008 is the minimum Visual Studio version we support.
+   Workarounds for older versions of Visual Studio have been removed. */
+#if defined(_MSC_VER) && (_MSC_VER < 1500)
+#error "Ancient versions of Visual Studio are no longer supported due to bugs."
+#endif
+
 #ifdef _MSC_VER
 /* Disable Visual Studio warnings: 4127 "conditional expression is constant" */
 #pragma warning(disable:4127)

--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -8,8 +8,8 @@ SPDX-License-Identifier: curl
 
  This document describes how to compile, build and install curl and libcurl
  from sources using the Visual C++ build tool. To build with VC++, you have to
- first install VC++. The minimum required version of VC is 6 (part of Visual
- Studio 6). However using a more recent version is strongly recommended.
+ first install VC++. The minimum required version of VC is 9 (part of Visual
+ Studio 2008). However using a more recent version is strongly recommended.
 
  VC++ is also part of the Windows Platform SDK. You do not have to install the
  full Visual Studio or Visual C++ if all you want is to build curl.


### PR DESCRIPTION
- cmake: assume large file support (VS2005+ / `_fseeki64()`)
- config-win32.h: assume large file support (VS2005+ / `_fseeki64()`)
- config-win32.h: assume `HAVE_LONGLONG` (VS2003+)
- config-win32.h: assume 64-bit `time_t` (VS2005+)
- config-win32.h: assume VS2008+
- cmake: use multi-threaded/parallel compilation (VS2008+)
- curl_setup.h: require multi-threading MSVC CRT (~VS2005+)
- curl_setup.h: hard fail for unsupported MSVC versions.
  Authored-by: Jay Satiro
- winbuild: bump minimum version

Follow-up to 308437ac53a142be2c3470330e7de3737915bb23 #15992
Ref: #15972

---

w/o whitespace: https://github.com/curl/curl/pull/16004/files?w=1
