### PR TITLE
tidy-up: extend `CURL_O_BINARY` to lib and tests

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -886,6 +886,14 @@
 #define S_ISDIR(m) (((m) & S_IFMT) == S_IFDIR)
 #endif
 
+/* Since O_BINARY is used in bitmasks, setting it to zero makes it usable in
+   source code but yet it does not ruin anything */
+#ifdef O_BINARY
+#define CURL_O_BINARY O_BINARY
+#else
+#define CURL_O_BINARY 0
+#endif
+
 /* In Windows the default file mode is text but an application can override it.
 Therefore we specify it explicitly. https://github.com/curl/curl/pull/258
 */

--- a/lib/file.c
+++ b/lib/file.c
@@ -203,7 +203,7 @@ static CURLcode file_connect(struct Curl_easy *data, bool *done)
       return CURLE_URL_MALFORMAT;
     }
 
-  fd = open(actual_path, O_RDONLY|O_BINARY);
+  fd = open(actual_path, O_RDONLY|CURL_O_BINARY);
   file->path = actual_path;
 #else
   if(memchr(real_path, 0, real_path_len)) {
@@ -312,16 +312,11 @@ static CURLcode file_upload(struct Curl_easy *data)
   if(!dir[1])
     return CURLE_FILE_COULDNT_READ_FILE; /* fix: better error code */
 
-#ifdef O_BINARY
-#define MODE_DEFAULT O_WRONLY|O_CREAT|O_BINARY
-#else
-#define MODE_DEFAULT O_WRONLY|O_CREAT
-#endif
-
+  mode = O_WRONLY|O_CREAT|CURL_O_BINARY;
   if(data->state.resume_from)
-    mode = MODE_DEFAULT|O_APPEND;
+    mode |= O_APPEND;
   else
-    mode = MODE_DEFAULT|O_TRUNC;
+    mode |= O_TRUNC;
 
 #if (defined(ANDROID) || defined(__ANDROID__)) && \
     (defined(__i386__) || defined(__arm__))

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -53,12 +53,6 @@
 
 #ifdef USE_HTTP3
 
-#ifdef O_BINARY
-#define QLOGMODE O_WRONLY|O_CREAT|O_BINARY
-#else
-#define QLOGMODE O_WRONLY|O_CREAT
-#endif
-
 #define NW_CHUNK_SIZE     (64 * 1024)
 #define NW_SEND_CHUNKS    2
 
@@ -657,7 +651,7 @@ CURLcode Curl_qlogdir(struct Curl_easy *data,
       result = Curl_dyn_add(&fname, ".sqlog");
 
     if(!result) {
-      int qlogfd = open(Curl_dyn_ptr(&fname), QLOGMODE,
+      int qlogfd = open(Curl_dyn_ptr(&fname), O_WRONLY|O_CREAT|CURL_O_BINARY,
                         data->set.new_file_perms);
       if(qlogfd != -1)
         *qlogfdp = qlogfd;

--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -66,14 +66,6 @@ extern FILE *tool_stderr;
 #  include "tool_strdup.h"
 #endif
 
-/* since O_BINARY is used in bitmasks, setting it to zero makes it usable in
-   source code but yet it does not ruin anything */
-#ifdef O_BINARY
-#define CURL_O_BINARY O_BINARY
-#else
-#define CURL_O_BINARY 0
-#endif
-
 #if defined(_WIN32)
 #  define CURL_STRICMP(p1, p2)  _stricmp(p1, p2)
 #elif defined(HAVE_STRCASECMP)

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -454,11 +454,7 @@ static ssize_t write_behind(struct testcase *test, int convert)
   if(!test->ofile) {
     char outfile[256];
     msnprintf(outfile, sizeof(outfile), "%s/upload.%ld", logdir, test->testno);
-#ifdef _WIN32
-    test->ofile = open(outfile, O_CREAT|O_RDWR|O_BINARY, 0777);
-#else
-    test->ofile = open(outfile, O_CREAT|O_RDWR, 0777);
-#endif
+    test->ofile = open(outfile, O_CREAT|O_RDWR|CURL_O_BINARY, 0777);
     if(test->ofile == -1) {
       logmsg("Couldn't create and/or open file %s for upload!", outfile);
       return -1; /* failure! */


### PR DESCRIPTION
Move `CURL_O_BINARY` definition from src to lib and use it from lib and
tests code.
