### PR TITLE
cmake: move mingw UWP workaround from GHA to `CMakeLists.txt`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -228,6 +228,9 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
+          if [ '${{ matrix.test }}' = 'uwp' ]; then
+            CPPFLAGS='-DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP'
+          fi
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             if [[ '${{ matrix.env }}' = 'clang'* ]]; then
               options='-DCMAKE_C_COMPILER=clang'
@@ -239,18 +242,19 @@ jobs:
               if [[ '${{ matrix.env }}' != 'clang'* ]]; then
                 specs="$(realpath gcc-specs-uwp)"
                 gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp/' -e 's/-lmsvcrt/-lucrtapp/' > "${specs}"
-                cflags="-specs=$(cygpath -w "${specs}")"
+                CPPFLAGS+=" -specs=$(cygpath -w "${specs}")"
               fi
             fi
             [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
             [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
             cmake -B bld -G Ninja ${options} \
-              "-DCMAKE_C_FLAGS=${{ matrix.cflags }} ${cflags}" \
+              "-DCMAKE_C_FLAGS=${{ matrix.cflags }} ${CPPFLAGS}" \
               '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               ${{ matrix.config }}
           else
+            export CPPFLAGS
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
               --with-openssl \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -228,7 +228,6 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
-          [ '${{ matrix.test }}' = 'uwp' ] && cflags='-DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP'
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             if [[ '${{ matrix.env }}' = 'clang'* ]]; then
               options='-DCMAKE_C_COMPILER=clang'
@@ -237,6 +236,7 @@ jobs:
             fi
             if [ '${{ matrix.test }}' = 'uwp' ]; then
               options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
+              cflags='-DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP'
               if [[ '${{ matrix.env }}' != 'clang'* ]]; then
                 specs="$(realpath gcc-specs-uwp)"
                 gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp/' -e 's/-lmsvcrt/-lucrtapp/' > "${specs}"
@@ -252,7 +252,6 @@ jobs:
               -DCURL_WERROR=ON \
               ${{ matrix.config }}
           else
-            export CPPFLAGS="${cflags}"
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
               --with-openssl \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -229,7 +229,7 @@ jobs:
         timeout-minutes: 5
         run: |
           if [ '${{ matrix.test }}' = 'uwp' ]; then
-            CPPFLAGS='-DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP'
+            cflags='-DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP'
           fi
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             if [[ '${{ matrix.env }}' = 'clang'* ]]; then
@@ -242,19 +242,19 @@ jobs:
               if [[ '${{ matrix.env }}' != 'clang'* ]]; then
                 specs="$(realpath gcc-specs-uwp)"
                 gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp/' -e 's/-lmsvcrt/-lucrtapp/' > "${specs}"
-                CPPFLAGS+=" -specs=$(cygpath -w "${specs}")"
+                cflags+=" -specs=$(cygpath -w "${specs}")"
               fi
             fi
             [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
             [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
             cmake -B bld -G Ninja ${options} \
-              "-DCMAKE_C_FLAGS=${{ matrix.cflags }} ${CPPFLAGS}" \
+              "-DCMAKE_C_FLAGS=${{ matrix.cflags }} ${cflags}" \
               '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               ${{ matrix.config }}
           else
-            export CPPFLAGS
+            export CPPFLAGS="${cflags}"
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
               --with-openssl \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -228,9 +228,7 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
-          if [ '${{ matrix.test }}' = 'uwp' ]; then
-            cflags='-DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP'
-          fi
+          [ '${{ matrix.test }}' = 'uwp' ] && cflags='-DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP'
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             if [[ '${{ matrix.env }}' = 'clang'* ]]; then
               options='-DCMAKE_C_COMPILER=clang'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -236,23 +236,16 @@ jobs:
             fi
             if [ '${{ matrix.test }}' = 'uwp' ]; then
               options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
-              cflags='-DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP'
               if [[ '${{ matrix.env }}' != 'clang'* ]]; then
                 specs="$(realpath gcc-specs-uwp)"
                 gcc -dumpspecs | sed -e 's/-lmingwex/-lwindowsapp -lmingwex -lwindowsapp/' -e 's/-lmsvcrt/-lucrtapp/' > "${specs}"
-                cflags+=" -specs=$(cygpath -w "${specs}")"
+                cflags="-specs=$(cygpath -w "${specs}")"
               fi
-              # CMake (as of v3.31.0) gets confused and applies the MSVC rc.exe command-line
-              # template to windres. Reset it to the windres template manually:
-              rcopts='<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>'
-            else
-              rcopts=''
             fi
             [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
             [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
             cmake -B bld -G Ninja ${options} \
               "-DCMAKE_C_FLAGS=${{ matrix.cflags }} ${cflags}" \
-              "-DCMAKE_RC_COMPILE_OBJECT=${rcopts}" \
               '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,16 @@ project(CURL
   VERSION "${_curl_version_sem}"
   LANGUAGES C)
 
+# CMake (as of 3.30.3) does not recognize some targets accurately.
+# Touch up the configuration manually as a workaround.
+if(WINDOWS_STORE AND MINGW)  # mingw UWP build
+  add_definitions("-DWINSTORECOMPAT" "-DWINAPI_FAMILY=WINAPI_FAMILY_APP")
+  list(APPEND CMAKE_REQUIRED_DEFINITIONS "-DWINSTORECOMPAT" "-DWINAPI_FAMILY=WINAPI_FAMILY_APP")  # Apply to all feature checks
+  # CMake (as of v3.31.0) gets confused and applies the MSVC rc.exe command-line
+  # template to windres. Reset it to the windres template via 'Modules/Platform/Windows-windres.cmake':
+  set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>")
+endif()
+
 set(_target_flags "")
 if(APPLE)
   set(_target_flags "${_target_flags} APPLE")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,11 @@ if(WINDOWS_STORE AND MINGW)  # mingw UWP build
   # CMake (as of v3.31.0) gets confused and applies the MSVC rc.exe command-line
   # template to windres. Reset it to the windres template via 'Modules/Platform/Windows-windres.cmake':
   set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>")
+elseif(DOS AND CMAKE_COMPILER_IS_GNUCC)  # DJGPP
+  set(CMAKE_STATIC_LIBRARY_PREFIX "lib")
+  set(CMAKE_STATIC_LIBRARY_SUFFIX ".a")
+  set(CMAKE_FIND_LIBRARY_PREFIXES "lib")
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
 endif()
 
 set(_target_flags "")
@@ -220,12 +225,6 @@ if(WIN32)
 elseif(DOS OR AMIGA)
   set(BUILD_SHARED_LIBS OFF)
   set(BUILD_STATIC_LIBS ON)
-  if(DOS AND CMAKE_COMPILER_IS_GNUCC)
-    set(CMAKE_STATIC_LIBRARY_PREFIX "lib")
-    set(CMAKE_STATIC_LIBRARY_SUFFIX ".a")
-    set(CMAKE_FIND_LIBRARY_PREFIXES "lib")
-    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-  endif()
 endif()
 option(CURL_LTO "Enable compiler Link Time Optimizations" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,7 @@ project(CURL
   VERSION "${_curl_version_sem}"
   LANGUAGES C)
 
-# CMake (as of 3.31.2) does not recognize some targets accurately.
-# Touch up the configuration manually as a workaround.
+# CMake does not recognize some targets accurately. Touch up configuration manually as a workaround.
 if(WINDOWS_STORE AND MINGW)  # mingw UWP build
   # CMake (as of v3.31.2) gets confused and applies the MSVC rc.exe command-line
   # template to windres. Reset it to the windres template via 'Modules/Platform/Windows-windres.cmake':

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,12 +86,10 @@ project(CURL
   VERSION "${_curl_version_sem}"
   LANGUAGES C)
 
-# CMake (as of 3.30.3) does not recognize some targets accurately.
+# CMake (as of 3.31.2) does not recognize some targets accurately.
 # Touch up the configuration manually as a workaround.
 if(WINDOWS_STORE AND MINGW)  # mingw UWP build
-  add_definitions("-DWINSTORECOMPAT" "-DWINAPI_FAMILY=WINAPI_FAMILY_APP")
-  list(APPEND CMAKE_REQUIRED_DEFINITIONS "-DWINSTORECOMPAT" "-DWINAPI_FAMILY=WINAPI_FAMILY_APP")  # Apply to all feature checks
-  # CMake (as of v3.31.0) gets confused and applies the MSVC rc.exe command-line
+  # CMake (as of v3.31.2) gets confused and applies the MSVC rc.exe command-line
   # template to windres. Reset it to the windres template via 'Modules/Platform/Windows-windres.cmake':
   set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>")
 elseif(DOS AND CMAKE_COMPILER_IS_GNUCC)  # DJGPP


### PR DESCRIPTION
CMake (as of 3.31.2) doesn't fully recognize mingw-w64 with
`CMAKE_SYSTEM_NAME=WindowsStore`.
The manual logic works around it.

Also move existing DJGPP workaround to the same block.

---

Failure example without the workaround:
```
[2/16] Building RC object lib/CMakeFiles/libcurl_shared.dir/libcurl.rc.obj
FAILED: lib/CMakeFiles/libcurl_shared.dir/libcurl.rc.obj 
D:\a\_temp\msys64\ucrt64\bin\windres.exe -DBUILDING_LIBCURL -DCURL_HIDDEN_SYMBOLS -DHAVE_CONFIG_H -DUNICODE -D_UNICODE -Dlibcurl_shared_EXPORTS -I D:/a/curl/curl/include -I D:/a/curl/curl/bld/lib -I D:/a/curl/curl/lib -I D:/a/_temp/msys64/ucrt64/include -DCURL_EMBED_MANIFEST /fo lib/CMakeFiles/libcurl_shared.dir/libcurl.rc.obj D:/a/curl/curl/lib/libcurl.rc
Usage: D:\a\_temp\msys64\ucrt64\bin\windres.exe [option(s)] [input-file] [output-file]
 The options are:
  -i --input=<file>            Name input file
  -o --output=<file>           Name output file
  -J --input-format=<format>   Specify input format
  -O --output-format=<format>  Specify output format
  -F --target=<target>         Specify COFF target
     --preprocessor=<program>  Program to use to preprocess rc file
     --preprocessor-arg=<arg>  Additional preprocessor argument
  -I --include-dir=<dir>       Include directory when preprocessing rc file
  -D --define <sym>[=<val>]    Define SYM when preprocessing rc file
  -U --undefine <sym>          Undefine SYM when preprocessing rc file
  -v --verbose                 Verbose - tells you what it's doing
  -c --codepage=<codepage>     Specify default codepage
  -l --language=<val>          Set language when reading rc file
     --use-temp-file           Use a temporary file instead of popen to read
                               the preprocessor output
     --no-use-temp-file        Use popen (default)
  -r                           Ignored for compatibility with rc
  @<file>                      Read options from <file>
  -h --help                    Print this help message
  -V --version                 Print version information
FORMAT is one of rc, res, or coff, and is deduced from the file name
extension if not specified.  A single file name is an input file.
No input-file is stdin, default rc.  No output-file is stdout, default rc.
D:\a\_temp\msys64\ucrt64\bin\windres.exe: supported targets: pe-x86-64 pei-x86-64 pe-bigobj-x86-64 elf64-x86-64 pe-i386 pei-i386 elf32-i386 elf32-iamcu pdb elf64-little elf64-big elf32-little elf32-big srec symbolsrec verilog tekhex binary ihex plugin
```
https://github.com/curl/curl/actions/runs/12808644523/job/35711843082?pr=16019#step:10:13
