### PR TITLE
GHA/labeler: fix `INSTALL-CMAKE.md` references

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -66,7 +66,7 @@ build:
               **/*.m4,\
               **/*.mk,\
               *.m4,\
-              docs/INSTALL.cmake,\
+              docs/INSTALL-CMAKE.md,\
               lib/curl_config.h.cmake,\
               lib/libcurl*.in,\
               CMake/**,\
@@ -99,7 +99,7 @@ cmake:
           - any-glob-to-all-files: "{\
               **/CMakeLists.txt,\
               CMake/**,\
-              docs/INSTALL.cmake,\
+              docs/INSTALL-CMAKE.md,\
               lib/curl_config.h.cmake\
               }"
 


### PR DESCRIPTION
Follow-up to 0f4c19b66ad5c646ebc3c4268a0f3ad9c15bf57c #12772