### PR TITLE
GHA: start using ARM Linux runners

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -160,7 +160,7 @@ jobs:
         run: .github/scripts/verify-examples.pl docs/libcurl/curl*.3 docs/libcurl/opts/*.3
 
   miscchecks:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -44,6 +44,29 @@ jobs:
         run: git ls-files -z "*.[ch]" | xargs -0 -n1 ./scripts/checksrc.pl
 
   codespell-cmakelint-pytype-ruff:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+        name: checkout
+
+      - name: install
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          echo "|$PATH|"
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
+          sudo apt-get update -y
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+            codespell python3-pip python3-networkx python3-pydot python3-yaml \
+            python3-toml python3-markupsafe python3-jinja2 python3-tabulate \
+            python3-typing-extensions python3-libcst python3-impacket \
+            python3-websockets python3-pytest
+          python3 -m pip install --break-system-packages cmakelint==1.4.3 pytype==2024.9.13 ruff==0.6.8
+          echo "|$PATH|"
+
+  codespell-cmakelint-pytype-ruff:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -55,6 +55,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          echo "|$PATH|"
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
@@ -63,6 +64,7 @@ jobs:
             python3-typing-extensions python3-libcst python3-impacket \
             python3-websockets python3-pytest
           python3 -m pip install --break-system-packages cmakelint==1.4.3 pytype==2024.9.13 ruff==0.6.8
+          echo "|$PATH|"
 
       - name: spellcheck
         run: |

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -44,7 +44,7 @@ jobs:
         run: git ls-files -z "*.[ch]" | xargs -0 -n1 ./scripts/checksrc.pl
 
   codespell-cmakelint-pytype-ruff:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -55,6 +55,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          echo "|$HOME|"
           echo "|$PATH|"
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
@@ -78,6 +79,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
+          echo "|$HOME|"
           echo "|$PATH|"
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -43,7 +43,7 @@ jobs:
       - name: check
         run: git ls-files -z "*.[ch]" | xargs -0 -n1 ./scripts/checksrc.pl
 
-  codespell-cmakelint-pytype-ruff:
+  codespell-cmakelint-pytype-ruff-intel:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -43,7 +43,7 @@ jobs:
       - name: check
         run: git ls-files -z "*.[ch]" | xargs -0 -n1 ./scripts/checksrc.pl
 
-  codespell-cmakelint-pytype-ruff-intel:
+  codespell-cmakelint-pytype-ruff:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -55,8 +55,6 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
-          echo "|$HOME|"
-          echo "|$PATH|"
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
@@ -65,31 +63,6 @@ jobs:
             python3-typing-extensions python3-libcst python3-impacket \
             python3-websockets python3-pytest
           python3 -m pip install --break-system-packages cmakelint==1.4.3 pytype==2024.9.13 ruff==0.6.8
-          echo "|$PATH|"
-
-  codespell-cmakelint-pytype-ruff:
-    runs-on: ubuntu-24.04-arm
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-        name: checkout
-
-      - name: install
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        run: |
-          echo "|$HOME|"
-          echo "|$PATH|"
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update -y
-          sudo apt-get install -y --no-install-suggests --no-install-recommends \
-            codespell python3-pip python3-networkx python3-pydot python3-yaml \
-            python3-toml python3-markupsafe python3-jinja2 python3-tabulate \
-            python3-typing-extensions python3-libcst python3-impacket \
-            python3-websockets python3-pytest
-          python3 -m pip install --break-system-packages cmakelint==1.4.3 pytype==2024.9.13 ruff==0.6.8
-          echo "|$PATH|"
 
       - name: spellcheck
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,7 +62,7 @@ env:
 jobs:
   linux:
     name: ${{ matrix.build.generate && 'CM' || 'AM' }} ${{ matrix.build.name }}
-    runs-on: 'ubuntu-24.04'
+    runs-on: ${{ matrix.build.image || 'ubuntu-24.04' }}
     container: ${{ matrix.build.container }}
     timeout-minutes: 45
     strategy:
@@ -163,6 +163,12 @@ jobs:
             install_packages: zlib1g-dev
             install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
+
+          - name: openssl
+            install_packages: zlib1g-dev
+            install_steps: pytest
+            configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
+            image: 'ubuntu-24.04-arm'
 
           - name: openssl -O3 valgrind
             install_packages: zlib1g-dev valgrind

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -706,6 +706,7 @@ jobs:
           CURL_CI: github
           PYTEST_ADDOPTS: "--color=yes"
         run: |
+          echo "CANARY:|${HOME}|${PATH}|"
           PATH="${PATH//\/home\/runneradmin/${HOME}}"  # workaround for PATH issue on ubuntu-24.04-arm
           [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -706,6 +706,7 @@ jobs:
           CURL_CI: github
           PYTEST_ADDOPTS: "--color=yes"
         run: |
+          PATH="${PATH//\/home\/runneradmin/${HOME}}"  # workaround for PATH issue on ubuntu-24.04-arm
           [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target curl-pytest-ci

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -164,7 +164,7 @@ jobs:
             install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
-          - name: openssl
+          - name: openssl arm
             install_packages: zlib1g-dev
             install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -37,7 +37,7 @@ permissions: {}
 
 jobs:
   netbsd:
-    name: 'NetBSD (CM, openssl, clang)'
+    name: 'NetBSD (CM, openssl, clang, ${{ matrix.arch }})'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -77,7 +77,7 @@ jobs:
             echo '::endgroup::'
 
   openbsd:
-    name: 'OpenBSD (CM, libressl, clang)'
+    name: 'OpenBSD (CM, libressl, clang, ${{ matrix.arch }})'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -37,13 +37,12 @@ permissions: {}
 
 jobs:
   netbsd:
-    name: 'NetBSD (CM, openssl, clang, ${{ matrix.arch }})'
-    runs-on: ${{ matrix.image }}
+    name: 'NetBSD (CM, openssl, clang)'
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
-        include:
-          - { image: 'ubuntu-latest', arch: 'x86_64' }
+        arch: ['x86_64']
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -78,13 +77,12 @@ jobs:
             echo '::endgroup::'
 
   openbsd:
-    name: 'OpenBSD (CM, libressl, clang, ${{ matrix.arch }})'
-    runs-on: ${{ matrix.image }}
+    name: 'OpenBSD (CM, libressl, clang)'
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
-        include:
-          - { image: 'ubuntu-latest', arch: 'x86_64' }
+        arch: ['x86_64']
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -120,14 +118,14 @@ jobs:
 
   freebsd:
     name: "FreeBSD (${{ matrix.build == 'cmake' && 'CM' || 'AM' }}, openssl, ${{ matrix.compiler }}, ${{ matrix.arch }})"
-    runs-on: ${{ matrix.image }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
       matrix:
         include:
-          - { build: 'autotools', image: 'ubuntu-latest', arch: 'x86_64', compiler: 'clang' }
-          - { build: 'autotools', image: 'ubuntu-latest', arch: 'arm64', compiler: 'clang' }
-          - { build: 'cmake'    , image: 'ubuntu-latest', arch: 'arm64', compiler: 'clang' }
+          - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
+          - { build: 'autotools', arch: 'arm64', compiler: 'clang' }
+          - { build: 'cmake'    , arch: 'arm64', compiler: 'clang' }
       fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -126,8 +126,8 @@ jobs:
       matrix:
         include:
           - { build: 'autotools', image: 'ubuntu-latest', arch: 'x86_64', compiler: 'clang' }
-          - { build: 'autotools', image: 'ubuntu-latest', arch: 'arm64', compiler: 'clang' }
-          - { build: 'cmake'    , image: 'ubuntu-latest', arch: 'arm64', compiler: 'clang' }
+          - { build: 'autotools', image: 'ubuntu-24.04-arm', arch: 'arm64', compiler: 'clang' }
+          - { build: 'cmake'    , image: 'ubuntu-24.04-arm', arch: 'arm64', compiler: 'clang' }
       fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -126,8 +126,8 @@ jobs:
       matrix:
         include:
           - { build: 'autotools', image: 'ubuntu-latest', arch: 'x86_64', compiler: 'clang' }
-          - { build: 'autotools', image: 'ubuntu-24.04-arm', arch: 'arm64', compiler: 'clang' }
-          - { build: 'cmake'    , image: 'ubuntu-24.04-arm', arch: 'arm64', compiler: 'clang' }
+          - { build: 'autotools', image: 'ubuntu-latest', arch: 'arm64', compiler: 'clang' }
+          - { build: 'cmake'    , image: 'ubuntu-latest', arch: 'arm64', compiler: 'clang' }
       fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -37,12 +37,13 @@ permissions: {}
 
 jobs:
   netbsd:
-    name: 'NetBSD (CM, openssl, clang)'
-    runs-on: ubuntu-latest
+    name: 'NetBSD (CM, openssl, clang, ${{ matrix.arch }})'
+    runs-on: ${{ matrix.image }}
     timeout-minutes: 10
     strategy:
       matrix:
-        arch: ['x86_64']
+        include:
+          - { image: 'ubuntu-latest', arch: 'x86_64' }
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -77,12 +78,13 @@ jobs:
             echo '::endgroup::'
 
   openbsd:
-    name: 'OpenBSD (CM, libressl, clang)'
-    runs-on: ubuntu-latest
+    name: 'OpenBSD (CM, libressl, clang, ${{ matrix.arch }})'
+    runs-on: ${{ matrix.image }}
     timeout-minutes: 10
     strategy:
       matrix:
-        arch: ['x86_64']
+        include:
+          - { image: 'ubuntu-latest', arch: 'x86_64' }
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -118,14 +120,14 @@ jobs:
 
   freebsd:
     name: "FreeBSD (${{ matrix.build == 'cmake' && 'CM' || 'AM' }}, openssl, ${{ matrix.compiler }}, ${{ matrix.arch }})"
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.image }}
     timeout-minutes: 20
     strategy:
       matrix:
         include:
-          - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
-          - { build: 'autotools', arch: 'arm64', compiler: 'clang' }
-          - { build: 'cmake'    , arch: 'arm64', compiler: 'clang' }
+          - { build: 'autotools', image: 'ubuntu-latest', arch: 'x86_64', compiler: 'clang' }
+          - { build: 'autotools', image: 'ubuntu-latest', arch: 'arm64', compiler: 'clang' }
+          - { build: 'cmake'    , image: 'ubuntu-latest', arch: 'arm64', compiler: 'clang' }
       fail-fast: false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
- GHA/linux: allow per-job runner image override.
- GHA/linux: add an arm version of an existing job.
  Add workaround for broken `PATH` in the arm runner image.
- GHA/non-native: add CPU arch to job name where missing.
- GHA/checkdocs: switch a linter job to arm.

Performance looks a little bit better than Intel
(presumably with lower power consumption).

Test jobs, with openssl, tests, pytests, examples:
- arm:
  - https://github.com/curl/curl/actions/runs/12816430794/job/35737374521 4m7s
  - https://github.com/curl/curl/actions/runs/12816201136/job/35736615144 4m5s
- Intel:
  - https://github.com/curl/curl/actions/runs/12816430794/job/35737374118 4m32s
  - https://github.com/curl/curl/actions/runs/12816201136/job/35736614764 4m13s

Ref: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/
