### PR TITLE
GHA/linux: enable wolfSSH in a wolfSSL job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
             tar -xzf v$WOLFSSH_VER-stable.tar.gz
             cd wolfssh-$WOLFSSH_VER-stable
             ./autogen.sh
-            ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wssl --prefix=$HOME/wssh --enable-scp --enable-sftp --disable-examples
+            ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wssl --prefix=$HOME/wssh --enable-sftp --disable-scp --disable-term --disable-examples
             make install
 
   configure:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ commands:
             tar -xzf v$WOLFSSH_VER-stable.tar.gz
             cd wolfssh-$WOLFSSH_VER-stable
             ./autogen.sh
-            ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wssl --prefix=$HOME/wssh --enable-sftp --disable-scp --disable-term --disable-examples
+            ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wssl --prefix=$HOME/wssh --enable-scp --enable-sftp --disable-term --disable-examples
             make install
 
   configure:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -445,7 +445,7 @@ jobs:
           tar -xzf v${{ env.wolfssh-version }}-stable.tar.gz
           cd wolfssh-${{ env.wolfssh-version }}-stable
           ./autogen.sh
-          ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wolfssl-all --enable-scp --enable-sftp \
+          ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wolfssl-all --enable-sftp --disable-scp --disable-term \
             --disable-examples --prefix=$HOME/wolfssh
           make install
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -670,6 +670,9 @@ jobs:
         run: |
           export TFLAGS='${{ matrix.build.tflags }}'
           if [ -z '${{ matrix.build.torture }}' ]; then
+            if [[ '${{ matrix.build.install_packages }}' = *'wolfssh'* ]]; then
+              TFLAGS+=' ~SFTP'
+            fi
             if [[ '${{ matrix.build.install_packages }}' = *'valgrind'* ]]; then
               TFLAGS+=' -j6'
             fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -670,7 +670,7 @@ jobs:
         run: |
           export TFLAGS='${{ matrix.build.tflags }}'
           if [ -z '${{ matrix.build.torture }}' ]; then
-            if [[ '${{ matrix.build.install_packages }}' = *'wolfssh'* ]]; then
+            if [[ '${{ matrix.build.install_steps }}' = *'wolfssh'* ]]; then
               TFLAGS+=' ~SFTP'
             fi
             if [[ '${{ matrix.build.install_packages }}' = *'valgrind'* ]]; then

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -97,7 +97,7 @@ jobs:
           - name: wolfssl-all
             install_packages: zlib1g-dev
             install_steps: wolfssl-all wolfssh
-            configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-all/lib" --with-wolfssl=$HOME/wolfssl-all --with-wolfssh=$HOME/wolfssh-all --enable-ech --enable-debug
+            configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-all/lib" --with-wolfssl=$HOME/wolfssl-all --with-wolfssh=$HOME/wolfssh --enable-ech --enable-debug
 
           - name: wolfssl-opensslextra valgrind
             install_packages: zlib1g-dev valgrind

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -44,6 +44,8 @@ env:
   libressl-version: 4.0.0
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
   wolfssl-version: 5.7.6
+  # renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
+  wolfssh-version: 1.4.19
   # renovate: datasource=github-tags depName=Mbed-TLS/mbedtls versioning=semver registryUrl=https://github.com
   mbedtls-version: 3.6.2
   # renovate: datasource=github-tags depName=nibanks/msh3 versioning=semver registryUrl=https://github.com
@@ -94,8 +96,8 @@ jobs:
 
           - name: wolfssl-all
             install_packages: zlib1g-dev
-            install_steps: wolfssl-all
-            configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-all/lib" --with-wolfssl=$HOME/wolfssl-all --enable-ech --enable-debug
+            install_steps: wolfssl-all wolfssh
+            configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-all/lib" --with-wolfssl=$HOME/wolfssl-all --with-wolfssh=$HOME/wolfssh-all --enable-ech --enable-debug
 
           - name: wolfssl-opensslextra valgrind
             install_packages: zlib1g-dev valgrind
@@ -423,6 +425,28 @@ jobs:
           ./autogen.sh
           ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --enable-opensslextra \
             --disable-benchmark --disable-crypttests --disable-examples --prefix=$HOME/wolfssl-opensslextra
+          make install
+
+      - name: 'cache wolfssh'
+        if: contains(matrix.build.install_steps, 'wolfssl')
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        id: cache-wolfssh
+        env:
+          cache-name: cache-wolfssh
+        with:
+          path: /home/runner/wolfssh
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.wolfssl-version }}-${{ env.wolfssh-version }}
+
+      - name: 'build wolfssh'
+        if: contains(matrix.build.install_steps, 'wolfssh') && steps.cache-wolfssh.outputs.cache-hit != 'true'
+        run: |
+          curl -LOsSf --retry 6 --retry-connrefused --max-time 999 \
+            https://github.com/wolfSSL/wolfssh/archive/v${{ env.wolfssh-version }}-stable.tar.gz
+          tar -xzf v${{ env.wolfssh-version }}-stable.tar.gz
+          cd wolfssh-${{ env.wolfssh-version }}-stable
+          ./autogen.sh
+          ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wolfssl-all --enable-scp --enable-sftp \
+            --disable-examples --prefix=$HOME/wolfssh
           make install
 
       - name: 'cache mbedtls'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -445,7 +445,7 @@ jobs:
           tar -xzf v${{ env.wolfssh-version }}-stable.tar.gz
           cd wolfssh-${{ env.wolfssh-version }}-stable
           ./autogen.sh
-          ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wolfssl-all --enable-sftp --disable-scp --disable-term \
+          ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wolfssl-all --enable-scp --enable-sftp --disable-term \
             --disable-examples --prefix=$HOME/wolfssh
           make install
 

--- a/tests/data/test642
+++ b/tests/data/test642
@@ -21,7 +21,7 @@ for ssh test
 sftp
 </server>
 <name>
-SFTP retrieval
+SFTP retrieval (compressed)
 </name>
 <command>
 --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: --compressed-ssh sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/file%TESTNUMBER.txt --insecure


### PR DESCRIPTION
With tests. (Most SFTP tests fail with wolfSSH.)

Also:
- disable pseudo-terminal in wolfSSH builds (also in CircleCI).
  Not needed for curl.
- test642: add "compressed" to the description.
  To avoid being the same as test600.
  Follow-up to b7b4dc0d49543175ab0d9bb1cdc257a2d7f7cf0a #1735
