### PR TITLE
configure: UWP and Android follow-up fixes

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -180,7 +180,7 @@ jobs:
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DENABLE_CURLDEBUG=ON', type: 'Release', name: 'schannel R TrackMemory' }
           - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON  -DENABLE_UNICODE=OFF', type: 'Release', name: 'openssl' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON', type: 'Release', test: 'uwp', name: 'schannel' }
-          # { build: 'autotools', sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '--without-debug --with-schannel --enable-shared', type: 'Release', test: 'uwp', name: 'schannel' }
+          - { build: 'autotools', sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun'                 , config: '--without-debug --with-schannel --enable-shared', type: 'Release', test: 'uwp', name: 'schannel' }
           - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCMAKE_VERBOSE_MAKEFILE=ON', type: 'Debug', cflags: '-DCURL_SCHANNEL_DEV_DEBUG', name: 'schannel dev debug' }
           - { build: 'cmake'    , sys: 'mingw32', env: 'i686'        , tflags: 'skiprun'                 , config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', type: 'Release', name: 'schannel R' }
       fail-fast: false

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1524,21 +1524,14 @@ AC_DEFUN([CURL_PREPARE_BUILDINFO], [
   case $host in
     *-apple-*) curl_pflags="${curl_pflags} APPLE";;
   esac
-  if test "$curl_cv_native_windows" = 'yes'; then
-    curl_pflags="${curl_pflags} WIN32"
-  else
-    case $host in
-      *-*-*bsd*|*-*-aix*|*-*-hpux*|*-*-interix*|*-*-irix*|*-*-linux*|*-*-solaris*|*-*-sunos*|*-apple-*|*-*-cygwin*|*-*-msys*)
-        curl_pflags="${curl_pflags} UNIX";;
-    esac
-    case $host in
-      *-*-*bsd*)
-        curl_pflags="${curl_pflags} BSD";;
-    esac
-  fi
-  if test "$curl_cv_winuwp" = 'yes'; then
-    curl_pflags="${curl_pflags} UWP"
-  fi
+  case $host in
+    *-*-*bsd*|*-*-aix*|*-*-hpux*|*-*-interix*|*-*-irix*|*-*-linux*|*-*-solaris*|*-*-sunos*|*-apple-*|*-*-cygwin*|*-*-msys*)
+      curl_pflags="${curl_pflags} UNIX";;
+  esac
+  case $host in
+    *-*-*bsd*)
+      curl_pflags="${curl_pflags} BSD";;
+  esac
   case $host in
     *-*-android*)
       curl_pflags="${curl_pflags} ANDROID"
@@ -1548,6 +1541,12 @@ AC_DEFUN([CURL_PREPARE_BUILDINFO], [
       fi
       ;;
   esac
+  if test "$curl_cv_native_windows" = 'yes'; then
+    curl_pflags="${curl_pflags} WIN32"
+  fi
+  if test "$curl_cv_winuwp" = 'yes'; then
+    curl_pflags="${curl_pflags} UWP"
+  fi
   if test "$curl_cv_cygwin" = 'yes'; then
     curl_pflags="${curl_pflags} CYGWIN"
   fi

--- a/configure.ac
+++ b/configure.ac
@@ -494,9 +494,11 @@ CURL_CHECK_COMPILER
 CURL_CHECK_NATIVE_WINDOWS
 
 curl_cv_winuwp='no'
-case $CPPFLAGS in
-  *-DWINSTORECOMPAT*) curl_cv_winuwp='yes';;
-esac
+if test "$curl_cv_native_windows" = "yes"; then
+  case "$CPPFLAGS" in
+    *-DWINSTORECOMPAT*) curl_cv_winuwp='yes';;
+  esac
+fi
 
 CURL_SET_COMPILER_BASIC_OPTS
 CURL_SET_COMPILER_DEBUG_OPTS


### PR DESCRIPTION
- limit UWP detection to native Windows.
- add missing double-quotes to variable.
- drop interlock and sync order in buildinfo flags.

Follow-up to 56a74fac47a27cfbfe2f49976938dab7a1b9b4f2 #16014
Follow-up to f7bb6c1f64049dcdaee970de6759db6f8597879e #16020

---

w/o whitespace: https://github.com/curl/curl/pull/16027/files?w=1
