### PR TITLE
libzstd: use custom memory functions

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -764,7 +764,7 @@ static CURLcode zstd_do_init(struct Curl_easy *data,
   (void)data;
 
 #ifdef ZSTD_STATIC_LINKING_ONLY
-  zp->zds = ZSTD_createDStream_advanced((ZSTD_customMem){
+  zp->zds = ZSTD_createDStream_advanced((ZSTD_customMem) {
     .customAlloc = Curl_zstd_alloc,
     .customFree  = Curl_zstd_free,
     .opaque      = NULL

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -742,6 +742,20 @@ struct zstd_writer {
   void *decomp;
 };
 
+#ifdef ZSTD_STATIC_LINKING_ONLY
+static void *Curl_zstd_alloc(void *opaque, size_t size)
+{
+  (void)opaque;
+  return Curl_cmalloc(size);
+}
+
+static void Curl_zstd_free(void *opaque, void *address)
+{
+  (void)opaque;
+  Curl_cfree(address);
+}
+#endif
+
 static CURLcode zstd_do_init(struct Curl_easy *data,
                                  struct Curl_cwriter *writer)
 {
@@ -749,7 +763,16 @@ static CURLcode zstd_do_init(struct Curl_easy *data,
 
   (void)data;
 
+#ifdef ZSTD_STATIC_LINKING_ONLY
+  zp->zds = ZSTD_createDStream_advanced((ZSTD_customMem){
+    .customAlloc = Curl_zstd_alloc,
+    .customFree  = Curl_zstd_free,
+    .opaque      = NULL
+  });
+#else
   zp->zds = ZSTD_createDStream();
+#endif
+
   zp->decomp = NULL;
   return zp->zds ? CURLE_OK : CURLE_OUT_OF_MEMORY;
 }


### PR DESCRIPTION
# Problem

When using automatic zstd decoding from libcurl, libcurl's custom allocators are not passed through to libzstd.

# Solution

To configure libzstd's custom allocators, we must pass them through "advanced" APIs:
```
typedef void* (*ZSTD_allocFunction) (void* opaque, size_t size);
typedef void  (*ZSTD_freeFunction) (void* opaque, void* address);
typedef struct { ZSTD_allocFunction customAlloc; ZSTD_freeFunction customFree; void* opaque; } ZSTD_customMem;
static
#ifdef __GNUC__
__attribute__((__unused__))
#endif
ZSTD_customMem const ZSTD_defaultCMem = { NULL, NULL, NULL };  /**< this constant defers to stdlib's functions */
  These prototypes make it possible to pass your own allocation/free functions.
  ZSTD_customMem is provided at creation time, using ZSTD_create*_advanced() variants listed below.
  All allocation/free operations will be completed using these custom variants instead of regular  ones.
```

These APIs don't are not usable without static linking (as they're considered experimental and unstable, avoiding dynamic linking against a breaking change):
```
  Advanced experimental functions can be accessed using
  `#define ZSTD_STATIC_LINKING_ONLY` before including zstd.h.

  Advanced experimental APIs should never be used with a dynamically-linked
  library. They are not "stable"; their definitions or signatures may change in
  the future. Only static linking is allowed.
``` 

So for curl users who are using zstd, if they want to set custom allocators they should pass in a compiler flag `ZSTD_STATIC_LINKING_ONLY`, example:

```
target_compile_definitions(libcurl_static
        PRIVATE $<$<BOOL:${CURL_ZSTD}>:ZSTD_STATIC_LINKING_ONLY>
)
```

This function was introduced in v0.8.1 in 2016 here: https://github.com/facebook/zstd/commit/be6180c1422f6272f56a3b0264073432f3ec0fce (signature hasn't changed since then afaict).