### PR TITLE
checksrc.bat: remove explicit SNPRINTF bypass

### DIFF
--- a/projects/checksrc.bat
+++ b/projects/checksrc.bat
@@ -175,7 +175,7 @@ rem ***************************************************************************
   if "%CHECK_EXAMPLES%" == "TRUE" (
     rem Check the docs\examples directory
     if exist %SRC_DIR%\docs\examples (
-      for /f "delims=" %%i in ('dir "%SRC_DIR%\docs\examples\*.c.*" /b 2^>NUL') do @perl "%SRC_DIR%\scripts\checksrc.pl" "-D%SRC_DIR%\docs\examples" -ASNPRINTF "%%i"
+      for /f "delims=" %%i in ('dir "%SRC_DIR%\docs\examples\*.c.*" /b 2^>NUL') do @perl "%SRC_DIR%\scripts\checksrc.pl" "-D%SRC_DIR%\docs\examples" "%%i"
     )
   )
 


### PR DESCRIPTION
- Remove the command line argument that accepts SNPRINTF violations in docs/examples.

This is a follow-up to c445b742 which introduced a different management of banned functions and removed the SNPRINTF rule in favor of banning snprintf in lib. There's no longer a SNPRINTF warning to suppress.

Closes #xxxxx