### PR TITLE
cpool: make sure that all sockets get CURL_POLL_REMOVE

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -957,6 +957,17 @@ void Curl_pollset_change(struct Curl_easy *data,
   }
 }
 
+void Curl_pollset_merge(struct Curl_easy *data,
+                        struct easy_pollset *dest,
+                        struct easy_pollset *src)
+{
+  unsigned int i;
+
+  for(i = 0; i < src->num; ++i) {
+    Curl_pollset_change(data, dest, src->sockets[i], src->actions[i], 0);
+  }
+}
+
 void Curl_pollset_set(struct Curl_easy *data,
                       struct easy_pollset *ps, curl_socket_t sock,
                       bool do_in, bool do_out)

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -594,6 +594,10 @@ void Curl_pollset_change(struct Curl_easy *data,
                          struct easy_pollset *ps, curl_socket_t sock,
                          int add_flags, int remove_flags);
 
+void Curl_pollset_merge(struct Curl_easy *data,
+                        struct easy_pollset *dest,
+                        struct easy_pollset *src);
+
 void Curl_pollset_set(struct Curl_easy *data,
                       struct easy_pollset *ps, curl_socket_t sock,
                       bool do_in, bool do_out);


### PR DESCRIPTION
When finally discarding a connection (for whatever reason), triffer CURL_POLL_REMOVE on all sockets still in the original transfers's for connection's shutdown_poll.

These sockets have not been removed yet, most likely due to an incomplete shutdown.

refs #16026