### PR TITLE
cmake: pre-fill `HAVE_STDATOMIC_H`, `HAVE_ATOMIC` for mingw-w64

### DIFF
--- a/CMake/win32-cache.cmake
+++ b/CMake/win32-cache.cmake
@@ -45,8 +45,14 @@ if(MINGW)
   set(HAVE_UTIME_H 1)  # wrapper to sys/utime.h
   set(HAVE_DIRENT_H 1)
   set(HAVE_OPENDIR 1)
-# set(HAVE_STDATOMIC_H 0)  # gcc 4.9.0 and newer has it
-# set(HAVE_ATOMIC 0)  # gcc 4.9.0 and newer has it
+  if((CMAKE_COMPILER_IS_GNUCC              AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.9) OR
+     (CMAKE_C_COMPILER_ID STREQUAL "Clang" AND NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 3.6))
+    set(HAVE_STDATOMIC_H 1)
+    set(HAVE_ATOMIC 1)
+  else()
+    set(HAVE_STDATOMIC_H 0)
+    set(HAVE_ATOMIC 0)
+  endif()
 else()
   set(HAVE_LIBGEN_H 0)
   set(HAVE_FTRUNCATE 0)

--- a/CMake/win32-cache.cmake
+++ b/CMake/win32-cache.cmake
@@ -45,6 +45,8 @@ if(MINGW)
   set(HAVE_UTIME_H 1)  # wrapper to sys/utime.h
   set(HAVE_DIRENT_H 1)
   set(HAVE_OPENDIR 1)
+# set(HAVE_STDATOMIC_H 0)  # gcc 4.9.0 and newer has it
+# set(HAVE_ATOMIC 0)  # gcc 4.9.0 and newer has it
 else()
   set(HAVE_LIBGEN_H 0)
   set(HAVE_FTRUNCATE 0)


### PR DESCRIPTION
`stdatomic.h` and `_Atomic` were first available in gcc 4.9.0 and
llvm/clang 3.6. Set detection values accordingly and save these two
detections on configure runs.
