### PR TITLE
cmake: drop `fseeko()` pre-fill and check for Windows

### DIFF
--- a/CMake/win32-cache.cmake
+++ b/CMake/win32-cache.cmake
@@ -161,7 +161,6 @@ set(HAVE_TERMIOS_H 0)
 set(HAVE_TERMIO_H 0)
 set(HAVE_LINUX_TCP_H 0)
 
-set(HAVE_FSEEKO 0)  # mingw-w64 2.0.0 and newer has it
 set(HAVE_SOCKET 1)
 set(HAVE_SELECT 1)
 set(HAVE_STRDUP 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1788,13 +1788,15 @@ if(HAVE_FILE_OFFSET_BITS)
 endif()
 check_type_size("off_t" SIZEOF_OFF_T)
 
-# fseeko may not exist with _FILE_OFFSET_BITS=64 but can exist with
-# _FILE_OFFSET_BITS unset or 32 (e.g. Android ARMv7 with NDK 26b and API level < 24)
-# so we need to test fseeko after testing for _FILE_OFFSET_BITS
-check_symbol_exists("fseeko" "${CURL_INCLUDES};stdio.h" HAVE_FSEEKO)
+if(NOT WIN32)
+  # fseeko may not exist with _FILE_OFFSET_BITS=64 but can exist with
+  # _FILE_OFFSET_BITS unset or 32 (e.g. Android ARMv7 with NDK 26b and API level < 24)
+  # so we need to test fseeko after testing for _FILE_OFFSET_BITS
+  check_symbol_exists("fseeko" "${CURL_INCLUDES};stdio.h" HAVE_FSEEKO)
 
-if(HAVE_FSEEKO)
-  set(HAVE_DECL_FSEEKO 1)
+  if(HAVE_FSEEKO)
+    set(HAVE_DECL_FSEEKO 1)
+  endif()
 endif()
 
 # Include this header to get the type

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -941,7 +941,7 @@ endings either CRLF or LF so 't' is appropriate.
    as their argument */
 #define STRCONST(x) x,sizeof(x)-1
 
-/* Some versions of the Android SDK is missing the declaration */
+/* Some versions of the Android NDK is missing the declaration */
 #if defined(HAVE_GETPWUID_R) && \
   defined(__ANDROID_API__) && (__ANDROID_API__ < 21)
 struct passwd;


### PR DESCRIPTION
To sync detection code with autotools.

---

w/o whitespace: https://github.com/curl/curl/pull/16041/files?w=1
