### PR TITLE
GHA: tidy up quotes, checkout order, silence Android/CMake warnings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: 'github-actions'
+    directory: '/'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -87,7 +87,7 @@ jobs:
       - name: run cmake
         run: |
           cmake -B bld-cm -DCURL_USE_LIBPSL=OFF -DCURL_DISABLE_LDAP=ON \
-            "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
+            -DCMAKE_C_COMPILER_TARGET="$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
             -DCURL_BROTLI=OFF \
             -DCURL_USE_LIBSSH2=OFF
 
@@ -122,14 +122,14 @@ jobs:
         run: |
           autoreconf -fi
           export PKG_CONFIG_DEBUG_SPEW=1
-          mkdir bld-am && cd bld-am && ../configure --enable-static=no --with-schannel --without-libpsl --host=${TRIPLET}
+          mkdir bld-am && cd bld-am && ../configure --enable-static=no --with-schannel --without-libpsl --host="${TRIPLET}"
 
       - name: run cmake
         run: |
           cmake -B bld-cm -DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBPSL=OFF \
             -DCMAKE_SYSTEM_NAME=Windows \
-            -DCMAKE_C_COMPILER_TARGET=${TRIPLET} \
-            -DCMAKE_C_COMPILER=${TRIPLET}-gcc
+            -DCMAKE_C_COMPILER_TARGET="${TRIPLET}" \
+            -DCMAKE_C_COMPILER="${TRIPLET}-gcc"
 
       - name: 'configure log'
         run: cat bld-am/config.log 2>/dev/null || true

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -476,7 +476,7 @@ jobs:
 
       - name: 'run tests'
         env:
-          TFLAGS: "${{ matrix.build.tflags }}"
+          TFLAGS: '${{ matrix.build.tflags }}'
         run: |
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
@@ -492,9 +492,9 @@ jobs:
 
       - name: 'run pytest'
         env:
-          TFLAGS: "${{ matrix.build.tflags }}"
+          TFLAGS: '${{ matrix.build.tflags }}'
           CURL_CI: github
-          PYTEST_ADDOPTS: "--color=yes"
+          PYTEST_ADDOPTS: '--color=yes'
         run: |
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -23,4 +23,4 @@ jobs:
     steps:
       - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -702,9 +702,9 @@ jobs:
       - name: 'run pytest'
         if: contains(matrix.build.install_steps, 'pytest')
         env:
-          TFLAGS: "${{ matrix.build.tflags }}"
+          TFLAGS: '${{ matrix.build.tflags }}'
           CURL_CI: github
-          PYTEST_ADDOPTS: "--color=yes"
+          PYTEST_ADDOPTS: '--color=yes'
         run: |
           echo "CANARY:|${HOME}|${PATH}|"
           PATH="${PATH//\/home\/runneradmin/${HOME}}"  # workaround for PATH issue on ubuntu-24.04-arm

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -335,10 +335,6 @@ jobs:
             perl-time-hires openssh stunnel sudo git
         name: 'install dependencies'
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
       - name: 'Fix kernel mmap rnd bits'
         # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
         # high-entropy ASLR in much newer kernels that GitHub runners are
@@ -592,6 +588,10 @@ jobs:
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
         name: 'install Intel compilers'
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - run: autoreconf -fi
         if: ${{ matrix.build.configure }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -706,8 +706,6 @@ jobs:
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
         run: |
-          echo "CANARY:|${HOME}|${PATH}|"
-          PATH="${PATH//\/home\/runneradmin/${HOME}}"  # workaround for PATH issue on ubuntu-24.04-arm
           [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target curl-pytest-ci

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -193,10 +193,6 @@ jobs:
             brew unlink openssl
           fi
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
       - name: 'toolchain versions'
         run: |
           [[ '${{ matrix.compiler }}' = 'llvm'* ]] && CC="$(brew --prefix ${{ matrix.compiler }})/bin/clang"
@@ -208,6 +204,10 @@ jobs:
           ls -l /Library/Developer/CommandLineTools/SDKs || true
           echo '::group::macros predefined'; "${CC}" -dM -E - < /dev/null | sort || true; echo '::endgroup::'
           echo '::group::brew packages installed'; ls -l "$(brew --prefix)/opt"; echo '::endgroup::'
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - name: 'autoreconf'
         if: ${{ matrix.build.configure }}
@@ -404,10 +404,6 @@ jobs:
           echo automake libtool | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
           while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
       - name: 'toolchain versions'
         run: |
           [[ '${{ matrix.compiler }}' = 'llvm'* ]] && CC="$(brew --prefix ${{ matrix.compiler }})/bin/clang"
@@ -419,6 +415,10 @@ jobs:
           ls -l /Library/Developer/CommandLineTools/SDKs || true
           echo '::group::macros predefined'; "${CC}" -dM -E - < /dev/null | sort || true; echo '::endgroup::'
           echo '::group::brew packages preinstalled'; ls -l "$(brew --prefix)/opt"; echo '::endgroup::'
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - name: 'autoreconf'
         if: ${{ matrix.build == 'autotools' }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -244,8 +244,8 @@ jobs:
           else
             [ -n '${{ matrix.build.macos-version-min }}' ] && options+=' -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.build.macos-version-min }}'
             cmake -B bld -G Ninja -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
-              "-DCMAKE_OSX_SYSROOT=${sysroot}" \
-              "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
+              -DCMAKE_OSX_SYSROOT="${sysroot}" \
+              -DCMAKE_C_COMPILER_TARGET="$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
               ${{ matrix.build.generate }} ${options}
           fi
 
@@ -463,9 +463,9 @@ jobs:
             [ -n '${{ matrix.macos-version-min }}' ] && options+=' -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.macos-version-min }}'
             # would pick up nghttp2, libidn2, and libssh2
             cmake -B bld -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
-              "-DCMAKE_OSX_SYSROOT=${sysroot}" \
-              "-DCMAKE_C_COMPILER_TARGET=$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
-              "-DCMAKE_IGNORE_PREFIX_PATH=$(brew --prefix)" \
+              -DCMAKE_OSX_SYSROOT="${sysroot}" \
+              -DCMAKE_C_COMPILER_TARGET="$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
+              -DCMAKE_IGNORE_PREFIX_PATH="$(brew --prefix)" \
               -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF \
               -DUSE_NGHTTP2=OFF -DUSE_LIBIDN2=OFF \
               -DCURL_USE_LIBPSL=OFF -DCURL_USE_LIBSSH2=OFF \

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -277,8 +277,7 @@ jobs:
           fi
 
       - name: 'curl info'
-        run: |
-          find . -type f \( -name curl -o -name '*.so' -o -name '*.a' \) -exec file '{}' \;
+        run: find . -type f \( -name curl -o -name '*.so' -o -name '*.a' \) -exec file '{}' \;
 
       - name: 'build tests'
         if: ${{ matrix.build == 'cmake' }}  # skip for autotools to save time
@@ -374,8 +373,7 @@ jobs:
           fi
 
       - name: 'curl info'
-        run: |
-          find . -type f \( -name curl -o -name '*.a' \) -exec file '{}' \;
+        run: find . -type f \( -name curl -o -name '*.a' \) -exec file '{}' \;
 
       - name: 'build tests'
         if: ${{ matrix.build == 'cmake' }}  # skip for autotools to save time
@@ -481,8 +479,7 @@ jobs:
           fi
 
       - name: 'curl info'
-        run: |
-          find . \( -name '*.exe' -o -name '*.a' \) -exec file '{}' \;
+        run: find . \( -name '*.exe' -o -name '*.a' \) -exec file '{}' \;
 
       - name: 'build tests'
         if: ${{ matrix.build == 'cmake' }}  # skip for autotools to save time

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -173,7 +173,7 @@ jobs:
             time sudo pkg install -y cmake-core ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2 stunnel py311-impacket
             time cmake -B bld -G Ninja \
-              '-DCMAKE_C_COMPILER=${{ matrix.compiler }}' \
+              -DCMAKE_C_COMPILER='${{ matrix.compiler }}' \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
@@ -241,7 +241,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake -B bld \
               -DANDROID_ABI=arm64-v8a \
-              -DANDROID_PLATFORM=android-${{ matrix.platform }} \
+              -DANDROID_PLATFORM='android-${{ matrix.platform }}' \
               -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
@@ -254,7 +254,7 @@ jobs:
               CC="$TOOLCHAIN/bin/aarch64-linux-android${{ matrix.platform }}-clang" \
               AR="$TOOLCHAIN/bin/llvm-ar" \
               RANLIB="$TOOLCHAIN/bin/llvm-ranlib" \
-              --host=aarch64-linux-android${{ matrix.platform }} \
+              --host='aarch64-linux-android${{ matrix.platform }}' \
               --without-ssl \
               --without-libpsl
           fi
@@ -437,26 +437,26 @@ jobs:
               -DCMAKE_SYSTEM_NAME=DOS \
               -DCMAKE_SYSTEM_PROCESSOR=x86 \
               -DCMAKE_C_COMPILER_TARGET=i586-pc-msdosdjgpp \
-              -DCMAKE_C_COMPILER=$HOME/djgpp/bin/i586-pc-msdosdjgpp-gcc \
+              -DCMAKE_C_COMPILER="$HOME/djgpp/bin/i586-pc-msdosdjgpp-gcc" \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               -DCURL_USE_LIBPSL=OFF \
-              -DOPENSSL_INCLUDE_DIR=$HOME/djgpp/include \
-              -DOPENSSL_SSL_LIBRARY=$HOME/djgpp/lib/libssl.a \
-              -DOPENSSL_CRYPTO_LIBRARY=$HOME/djgpp/lib/libcrypto.a \
-              -DZLIB_INCLUDE_DIR=$HOME/djgpp/include" \
-              -DZLIB_LIBRARY=$HOME/djgpp/lib/libz.a" \
-              -DWATT_ROOT=$HOME/djgpp/net/watt
+              -DOPENSSL_INCLUDE_DIR="$HOME/djgpp/include" \
+              -DOPENSSL_SSL_LIBRARY="$HOME/djgpp/lib/libssl.a" \
+              -DOPENSSL_CRYPTO_LIBRARY="$HOME/djgpp/lib/libcrypto.a" \
+              -DZLIB_INCLUDE_DIR="$HOME/djgpp/include" \
+              -DZLIB_LIBRARY="$HOME/djgpp/lib/libz.a" \
+              -DWATT_ROOT="$HOME/djgpp/net/watt"
           else
             autoreconf -fi
             mkdir bld && cd bld && ../configure --disable-dependency-tracking --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
-              CC=$HOME/djgpp/bin/i586-pc-msdosdjgpp-gcc \
-              AR=$HOME/djgpp/bin/i586-pc-msdosdjgpp-ar \
-              RANLIB=$HOME/djgpp/bin/i586-pc-msdosdjgpp-ranlib \
-              WATT_ROOT=$HOME/djgpp/net/watt \
+              CC="$HOME/djgpp/bin/i586-pc-msdosdjgpp-gcc" \
+              AR="$HOME/djgpp/bin/i586-pc-msdosdjgpp-ar" \
+              RANLIB="$HOME/djgpp/bin/i586-pc-msdosdjgpp-ranlib" \
+              WATT_ROOT="$HOME/djgpp/net/watt" \
               --host=i586-pc-msdosdjgpp \
-              --with-openssl=$HOME/djgpp \
-              --with-zlib=$HOME/djgpp \
+              --with-openssl="$HOME/djgpp" \
+              --with-zlib="$HOME/djgpp" \
               --without-libpsl \
               --disable-shared
           fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -242,7 +242,7 @@ jobs:
             cmake -B bld \
               -DANDROID_ABI=arm64-v8a \
               -DANDROID_PLATFORM='android-${{ matrix.platform }}' \
-              -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" \
+              -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake" -DCMAKE_WARN_DEPRECATED=OFF \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               -DCURL_ENABLE_SSL=OFF \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,9 +54,11 @@ jobs:
     steps:
       - run: git config --global core.autocrlf input
         shell: pwsh
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
+
       - uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
         with:
           platform: ${{ matrix.platform }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,10 +55,6 @@ jobs:
       - run: git config --global core.autocrlf input
         shell: pwsh
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
       - uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
         with:
           platform: ${{ matrix.platform }}
@@ -74,6 +70,10 @@ jobs:
             zlib-devel
             libbrotli-devel
             libnghttp2-devel
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - name: 'autoreconf'
         if: ${{ matrix.build == 'automake' }}
@@ -190,10 +190,6 @@ jobs:
       - run: git config --global core.autocrlf input
         shell: pwsh
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
       - uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2
         if: ${{ matrix.sys == 'msys' }}
         with:
@@ -222,6 +218,10 @@ jobs:
             mingw-w64-${{ matrix.env }}-libssh2
             mingw-w64-${{ matrix.env }}-libpsl
             mingw-w64-${{ matrix.env }}-c-ares
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - name: 'autoreconf'
         if: ${{ matrix.build == 'autotools' }}
@@ -658,10 +658,6 @@ jobs:
 
       fail-fast: false
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
       - name: 'vcpkg cache setup'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
@@ -678,6 +674,10 @@ jobs:
       - name: 'vcpkg build'
         timeout-minutes: 35
         run: vcpkg x-set-installed ${{ matrix.install }} '--triplet=${{ matrix.arch }}-${{ matrix.plat }}'
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
 
       - name: 'configure'
         timeout-minutes: 5

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -250,8 +250,8 @@ jobs:
             [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
             [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
             cmake -B bld -G Ninja ${options} \
-              "-DCMAKE_C_FLAGS=${{ matrix.cflags }} ${CFLAGS_CMAKE} ${CPPFLAGS}" \
-              '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
+              -DCMAKE_C_FLAGS="${{ matrix.cflags }} ${CFLAGS_CMAKE} ${CPPFLAGS}" \
+              -DCMAKE_BUILD_TYPE='${{ matrix.type }}' \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               ${{ matrix.config }}
@@ -421,7 +421,7 @@ jobs:
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
           cmake -B bld -G 'MSYS Makefiles' ${options} \
             -DCMAKE_C_COMPILER=gcc \
-            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
+            -DCMAKE_BUILD_TYPE='${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
             -DCURL_WERROR=ON \
             -DCURL_USE_LIBPSL=OFF \
@@ -510,15 +510,15 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake -B bld -G Ninja \
               -DCMAKE_SYSTEM_NAME=Windows \
-              -DCMAKE_C_COMPILER_TARGET=${TRIPLET} \
-              -DCMAKE_C_COMPILER=${TRIPLET}-gcc \
+              -DCMAKE_C_COMPILER_TARGET="${TRIPLET}" \
+              -DCMAKE_C_COMPILER="${TRIPLET}-gcc" \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               -DCURL_USE_SCHANNEL=ON -DUSE_WIN32_IDN=ON \
               -DCURL_USE_LIBPSL=OFF
           else
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
-              --host=${TRIPLET} \
+              --host="${TRIPLET}" \
               --with-schannel --with-winidn \
               --without-libpsl \
               --disable-dependency-tracking
@@ -690,14 +690,14 @@ jobs:
             vsglobals=';AppxPackage=false;WindowsAppContainer=false'
           fi
           cmake -B bld ${options} \
-            "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
-            "-DVCPKG_INSTALLED_DIR=$VCPKG_INSTALLATION_ROOT/installed" \
-            '-DVCPKG_TARGET_TRIPLET=${{ matrix.arch }}-${{ matrix.plat }}' \
-            "-DCMAKE_C_FLAGS=${cflags}" \
-            "-DCMAKE_EXE_LINKER_FLAGS=/INCREMENTAL:NO ${ldflags}" \
-            "-DCMAKE_SHARED_LINKER_FLAGS=/INCREMENTAL:NO ${ldflags}" \
-            "-DCMAKE_VS_GLOBALS=TrackFileAccess=false${vsglobals}" \
-            '-DCMAKE_BUILD_TYPE=${{ matrix.type }}' \
+            -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLATION_ROOT/installed" \
+            -DVCPKG_TARGET_TRIPLET='${{ matrix.arch }}-${{ matrix.plat }}' \
+            -DCMAKE_C_FLAGS="${cflags}" \
+            -DCMAKE_EXE_LINKER_FLAGS="/INCREMENTAL:NO ${ldflags}" \
+            -DCMAKE_SHARED_LINKER_FLAGS="/INCREMENTAL:NO ${ldflags}" \
+            -DCMAKE_VS_GLOBALS="TrackFileAccess=false${vsglobals}" \
+            -DCMAKE_BUILD_TYPE='${{ matrix.type }}' \
             -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
             -DCURL_WERROR=ON \
             -DBUILD_SHARED_LIBS=OFF \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -539,8 +539,7 @@ jobs:
           fi
 
       - name: 'curl info'
-        run: |
-          find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -exec file '{}' \;
+        run: find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -exec file '{}' \;
 
       - name: 'build tests'
         if: ${{ matrix.build == 'cmake' }}  # Save time by skipping this for autotools

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -408,6 +408,7 @@ jobs:
           ls -l
 
       - run: git config --global core.autocrlf input
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false


### PR DESCRIPTION
- move checkout step right before use.
- quotes in yaml and bash.
- unfold single-line run commands.
- set `CMAKE_WARN_DEPRECATED=OFF` for CMake with Android NDK to avoid
  a wall of useless deprecation warnings hiding useful output.
  These warnings happen in 3rd-party scripts, and unfixable in curl.
