### PR TITLE
Fix build with mbedtls v3.6 PSA but without TLS 1.3 or session tickets

### DIFF
--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -117,6 +117,11 @@ struct mbed_ssl_backend_data {
 #define mbedtls_strerror(a,b,c) b[0] = 0
 #endif
 
+/* PSA can be used independently of TLS 1.3 */
+#if defined(MBEDTLS_USE_PSA_CRYPTO) && MBEDTLS_VERSION_NUMBER >= 0x03060000
+#define HAS_PSA_SUPPORT
+#endif
+
 #if defined(MBEDTLS_SSL_PROTO_TLS1_3) && MBEDTLS_VERSION_NUMBER >= 0x03060000
 #define HAS_TLS13_SUPPORT
 #endif
@@ -1589,7 +1594,7 @@ static int mbedtls_init(void)
 #ifdef HAS_THREADING_SUPPORT
   entropy_init_mutex(&ts_entropy);
 #endif
-#ifdef HAS_TLS13_SUPPORT
+#ifdef HAS_PSA_SUPPORT
   {
     int ret;
 #ifdef HAS_THREADING_SUPPORT
@@ -1602,7 +1607,7 @@ static int mbedtls_init(void)
     if(ret != PSA_SUCCESS)
       return 0;
   }
-#endif /* HAS_TLS13_SUPPORT */
+#endif /* HAS_PSA_SUPPORT */
   return 1;
 }
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -805,7 +805,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-#ifdef MBEDTLS_SSL_TLS1_3_SIGNAL_NEW_SESSION_TICKETS_ENABLED
+#ifdef HAS_SESSION_TICKETS
   /* New in mbedTLS 3.6.1, need to enable, default is now disabled */
   mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets(&backend->config,
     MBEDTLS_SSL_TLS1_3_SIGNAL_NEW_SESSION_TICKETS_ENABLED);

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -810,7 +810,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-#ifdef HAS_SESSION_TICKETS
+#if defined(HAS_SESSION_TICKETS) && MBEDTLS_VERSION_NUMBER >= 0x03060100
   /* New in mbedTLS 3.6.1, need to enable, default is now disabled */
   mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets(&backend->config,
     MBEDTLS_SSL_TLS1_3_SIGNAL_NEW_SESSION_TICKETS_ENABLED);


### PR DESCRIPTION
# Problems
1. Build fails when support for session tickets is disabled (thus `HAS_SESSION_TICKETS` undefined in `lib/vtls/mbedtls.c`).
2. Runtime error for all TLS connections when built with `MBEDTLS_USE_PSA_CRYPTO` but without TLS 1.3 support:
```
$ ./build/bin/curl --insecure --verbose --head https://curl.se
* ssl_handshake returned: (-0x3E80) PK - Bad input parameters to function
curl: (35) ssl_handshake returned: (-0x3E80) PK - Bad input parameters to function
```

# Solutions
1. `mbedtls_ssl_conf_tls13_enable_signal_new_session_tickets` requires the conditionals that are already covered by `HAS_SESSION_TICKETS`, see [include/mbedtls/ssl.h](https://github.com/Mbed-TLS/mbedtls/blob/v3.6.2/include/mbedtls/ssl.h#L4513-L4517) (and the lines above). 
`MBEDTLS_SSL_TLS1_3_SIGNAL_NEW_SESSION_TICKETS_ENABLED` always resolves to `1` because it is only meant as a boolean parameter for the function.

2. When Mbed TLS is built with PSA, it must always be initialized regardless of the TLS 1.3 support.