### PR TITLE
easy_lock: use Sleep(1) for thread yield on old Windows

### DIFF
--- a/lib/easy_lock.h
+++ b/lib/easy_lock.h
@@ -81,6 +81,8 @@ static CURL_INLINE void curl_simple_lock_lock(curl_simple_lock *lock)
       __builtin_ia32_pause();
 #elif defined(__aarch64__)
       __asm__ volatile("yield" ::: "memory");
+#elif defined(_WIN32)
+      Sleep(1);
 #elif defined(HAVE_SCHED_YIELD)
       sched_yield();
 #endif


### PR DESCRIPTION
- Prefer Sleep(1) over sched_yield() for pre-Vista thread yield.

On Windows sched_yield is often implemented as Sleep(0) which only yields to threads of highest priority to current priority. However, during libcurl initialization if there is thread contention then it's possible that there is a wait for a different library or OS thread of a lesser priority and then the yield is not effective during that time. On the other hand Sleep(1) will wait the minimum time slice which is usually like 15ms or more.

Prior to this change 2c4bfef removed sched_yield detection on Windows, which effectively removed the yield in the spin lock, and therefore this change restores the yield but in a different way.

For Windows Vista and later we use SRW locks and do not have this issue.

Ref: https://github.com/curl/curl/pull/16037#issuecomment-2600161764
Ref: https://devblogs.microsoft.com/oldnewthing/20051004-09/?p=33923

Closes #xxxx