### PR TITLE
curl_multi_fdset: include the shutdown connections in the set

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -1011,7 +1011,8 @@ void Curl_cpool_setfds(struct cpool *cpool,
 #if defined(__DJGPP__)
 #pragma GCC diagnostic pop
 #endif
-        if((int)ps.sockets[i] > *maxfd)
+        if((ps.actions[i] & (CURL_POLL_OUT | CURL_POLL_IN)) &&
+           ((int)ps.sockets[i] > *maxfd))
           *maxfd = (int)ps.sockets[i];
       }
     }

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -1001,10 +1001,17 @@ void Curl_cpool_setfds(struct cpool *cpool,
       Curl_detach_connection(cpool->idata);
 
       for(i = 0; i < ps.num; i++) {
+#if defined(__DJGPP__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warith-conversion"
+#endif
         if(ps.actions[i] & CURL_POLL_IN)
           FD_SET(ps.sockets[i], read_fd_set);
         if(ps.actions[i] & CURL_POLL_OUT)
           FD_SET(ps.sockets[i], write_fd_set);
+#if defined(__DJGPP__)
+#pragma GCC diagnostic pop
+#endif
         if((int)ps.sockets[i] > *maxfd)
           *maxfd = (int)ps.sockets[i];
       }

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -988,13 +988,12 @@ void Curl_cpool_setfds(struct cpool *cpool,
   CPOOL_LOCK(cpool);
   if(Curl_llist_head(&cpool->shutdowns)) {
     struct Curl_llist_node *e;
-    struct easy_pollset ps;
-    struct connectdata *conn;
 
     for(e = Curl_llist_head(&cpool->shutdowns); e;
         e = Curl_node_next(e)) {
+      struct easy_pollset ps;
       unsigned int i;
-      conn = Curl_node_elem(e);
+      struct connectdata *conn = Curl_node_elem(e);
       memset(&ps, 0, sizeof(ps));
       Curl_attach_connection(cpool->idata, conn);
       Curl_conn_adjust_pollset(cpool->idata, &ps);

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -953,8 +953,9 @@ CURLcode Curl_cpool_add_pollfds(struct cpool *cpool,
   return result;
 }
 
+/* return information about the shutdown connections */
 unsigned int Curl_cpool_add_waitfds(struct cpool *cpool,
-                                    struct curl_waitfds *cwfds)
+                                    struct Curl_waitfds *cwfds)
 {
   unsigned int need = 0;
 

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -1010,6 +1010,7 @@ void Curl_cpool_setfds(struct cpool *cpool,
       }
     }
   }
+  CPOOL_UNLOCK(cpool);
 }
 
 static void cpool_perform(struct cpool *cpool)

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -186,6 +186,10 @@ CURLcode Curl_cpool_add_pollfds(struct cpool *connc,
 unsigned int Curl_cpool_add_waitfds(struct cpool *connc,
                                     struct Curl_waitfds *cwfds);
 
+void Curl_cpool_setfds(struct cpool *cpool,
+                       fd_set *read_fd_set, fd_set *write_fd_set,
+                       curl_socket_t *maxfd);
+
 /**
  * Perform maintenance on connections in the pool. Specifically,
  * progress the shutdown of connections in the queue.

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -31,7 +31,7 @@
 struct connectdata;
 struct Curl_easy;
 struct curl_pollfds;
-struct curl_waitfds;
+struct Curl_waitfds;
 struct Curl_multi;
 struct Curl_share;
 
@@ -184,7 +184,7 @@ void Curl_cpool_do_locked(struct Curl_easy *data,
 CURLcode Curl_cpool_add_pollfds(struct cpool *connc,
                                 struct curl_pollfds *cpfds);
 unsigned int Curl_cpool_add_waitfds(struct cpool *connc,
-                                    struct curl_waitfds *cwfds);
+                                    struct Curl_waitfds *cwfds);
 
 /**
  * Perform maintenance on connections in the pool. Specifically,

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -188,7 +188,7 @@ unsigned int Curl_cpool_add_waitfds(struct cpool *connc,
 
 void Curl_cpool_setfds(struct cpool *cpool,
                        fd_set *read_fd_set, fd_set *write_fd_set,
-                       curl_socket_t *maxfd);
+                       int *maxfd);
 
 /**
  * Perform maintenance on connections in the pool. Specifically,

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1158,8 +1158,6 @@ static void multi_getsock(struct Curl_easy *data,
   }
 }
 
-#define NUM_STACK_FDS 5
-
 CURLMcode curl_multi_fdset(CURLM *m,
                            fd_set *read_fd_set, fd_set *write_fd_set,
                            fd_set *exc_fd_set, int *max_fd)

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1168,6 +1168,8 @@ CURLMcode curl_multi_fdset(CURLM *m,
   int this_max_fd = -1;
   struct Curl_llist_node *e;
   struct Curl_multi *multi = m;
+  struct Curl_waitfds cwfds = { 0 };
+  unsigned int i;
   (void)exc_fd_set; /* not used */
 
   if(!GOOD_MULTI_HANDLE(multi))
@@ -1178,7 +1180,6 @@ CURLMcode curl_multi_fdset(CURLM *m,
 
   for(e = Curl_llist_head(&multi->process); e; e = Curl_node_next(e)) {
     struct Curl_easy *data = Curl_node_elem(e);
-    unsigned int i;
 
     multi_getsock(data, &data->last_poll);
 
@@ -1202,6 +1203,16 @@ CURLMcode curl_multi_fdset(CURLM *m,
     }
   }
 
+  (void)Curl_cpool_add_waitfds(&multi->cpool, &cwfds);
+  for(i = 0; i < cwfds.n; i++) {
+    if(cwfds.wfds[i].events & CURL_WAIT_POLLIN)
+      FD_SET(cwfds.wfds[i].fd, read_fd_set);
+    if(cwfds.wfds[i].events & CURL_WAIT_POLLOUT)
+      FD_SET(cwfds.wfds[i].fd, write_fd_set);
+    if((int)cwfds.wfds[i].fd > this_max_fd)
+      this_max_fd = (int)cwfds.wfds[i].fd;
+  }
+
   *max_fd = this_max_fd;
 
   return CURLM_OK;
@@ -1212,7 +1223,7 @@ CURLMcode curl_multi_waitfds(CURLM *m,
                              unsigned int size,
                              unsigned int *fd_count)
 {
-  struct curl_waitfds cwfds;
+  struct Curl_waitfds cwfds;
   CURLMcode result = CURLM_OK;
   struct Curl_llist_node *e;
   struct Curl_multi *multi = m;

--- a/lib/select.c
+++ b/lib/select.c
@@ -488,7 +488,7 @@ CURLcode Curl_pollfds_add_ps(struct curl_pollfds *cpfds,
   return CURLE_OK;
 }
 
-void Curl_waitfds_init(struct curl_waitfds *cwfds,
+void Curl_waitfds_init(struct Curl_waitfds *cwfds,
                        struct curl_waitfd *static_wfds,
                        unsigned int static_count)
 {
@@ -499,7 +499,7 @@ void Curl_waitfds_init(struct curl_waitfds *cwfds,
   cwfds->count = static_count;
 }
 
-static unsigned int cwfds_add_sock(struct curl_waitfds *cwfds,
+static unsigned int cwfds_add_sock(struct Curl_waitfds *cwfds,
                                    curl_socket_t sock, short events)
 {
   int i;
@@ -524,7 +524,7 @@ static unsigned int cwfds_add_sock(struct curl_waitfds *cwfds,
   return 1;
 }
 
-unsigned int Curl_waitfds_add_ps(struct curl_waitfds *cwfds,
+unsigned int Curl_waitfds_add_ps(struct Curl_waitfds *cwfds,
                                  struct easy_pollset *ps)
 {
   size_t i;

--- a/lib/select.h
+++ b/lib/select.h
@@ -130,17 +130,17 @@ CURLcode Curl_pollfds_add_ps(struct curl_pollfds *cpfds,
 CURLcode Curl_pollfds_add_sock(struct curl_pollfds *cpfds,
                                curl_socket_t sock, short events);
 
-struct curl_waitfds {
+struct Curl_waitfds {
   struct curl_waitfd *wfds;
   unsigned int n;
   unsigned int count;
 };
 
-void Curl_waitfds_init(struct curl_waitfds *cwfds,
+void Curl_waitfds_init(struct Curl_waitfds *cwfds,
                        struct curl_waitfd *static_wfds,
                        unsigned int static_count);
 
-unsigned int Curl_waitfds_add_ps(struct curl_waitfds *cwfds,
+unsigned int Curl_waitfds_add_ps(struct Curl_waitfds *cwfds,
                                  struct easy_pollset *ps);
 
 #endif /* HEADER_CURL_SELECT_H */


### PR DESCRIPTION
They were previously missing.

Follow-up from c9b95c0bb30f88bf00e1ac7e706c

Fixes #15156
Reported-by: Christopher Dannemiller