### PR TITLE
libcurl/opts: do not save files in dirs where attackers have access

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -41,6 +41,12 @@ option.
 Using this option multiple times makes the last set string override the
 previous ones. Set it to NULL to disable its use again.
 
+# SECURITY CONCERNS
+
+libcurl cannot fully protect against attacks where an attacker has write
+access to the same directory where it is directed to save files. This is
+particularly sensitive if you save files using elevated privileges.
+
 # DEFAULT
 
 NULL. The alt-svc cache is not read nor written to file.

--- a/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEFILE.md
@@ -55,7 +55,7 @@ If you use this option multiple times, you add more files to read cookies
 from. Setting this option to NULL disables the cookie engine and clears the
 list of files to read cookies from.
 
-# SECURITY
+# SECURITY CONCERNS
 
 This document previously mentioned how specifying a non-existing file can also
 enable the cookie engine. While true, we strongly advise against using that

--- a/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
+++ b/docs/libcurl/opts/CURLOPT_COOKIEJAR.md
@@ -52,6 +52,12 @@ option.
 Using this option multiple times makes the last set string override the
 previous ones. Set it to NULL to disable its use again.
 
+# SECURITY CONCERNS
+
+libcurl cannot fully protect against attacks where an attacker has write
+access to the same directory where it is directed to save files. This is
+particularly sensitive if you save files using elevated privileges.
+
 # DEFAULT
 
 NULL

--- a/docs/libcurl/opts/CURLOPT_HSTS.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS.md
@@ -61,6 +61,12 @@ currently no length or size limit.
 
 NULL, no filename
 
+# SECURITY CONCERNS
+
+libcurl cannot fully protect against attacks where an attacker has write
+access to the same directory where it is directed to save files. This is
+particularly sensitive if you save files using elevated privileges.
+
 # %PROTOCOLS%
 
 # EXAMPLE


### PR DESCRIPTION
libcurl cannot fully protect against attacks where an attacker has write access to the same directory where it is directed to save files. This is particularly sensitive if you save files using elevated privileges.

Previously only mentioned in VULN-DISCLOSURE-POLICY.md.

Highlighted-by: Donguk Kim