### PR TITLE
src: omit hugehelp and ca-embed from libcurltool

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -95,10 +95,10 @@ add_executable(
 )
 
 set(_curl_files "${CURL_CFILES}" "${CURL_HFILES}")
-if(CMAKE_GENERATOR STREQUAL "Xcode")
-  # Workaround for 'The custom command generating tool_hugehelp.c is attached to multiple targets [...] curl curltool'
-  list(REMOVE_ITEM _curl_files "tool_hugehelp.c" "tool_hugehelp.h" "tool_ca_embed.c")
-endif()
+# Avoid 'The custom command generating tool_hugehelp.c is attached to multiple targets [...] curl curltool'
+# by excluding the generated sources from curltool library. The UNITTESTS macro disables them in source.
+list(REMOVE_ITEM _curl_files "tool_hugehelp.c" "tool_hugehelp.h" "tool_ca_embed.c")
+
 add_library(
   curltool  # special libcurltool library just for unittests
   STATIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,9 +24,8 @@
 set(EXE_NAME curl)
 add_definitions("-DBUILDING_CURL")
 
-# Get 'CURL_CFILES', 'CURLX_CFILES', 'CURL_HFILES', 'CURLTOOL_LIBCURL_CFILES' variables
-curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
-include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
+set(_curl_cfiles_gen "")
+set(_curl_hfiles_gen "")
 
 if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
   add_definitions("-DUSE_MANUAL")
@@ -44,8 +43,8 @@ if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
       "${CURL_ASCIIPAGE}"
     VERBATIM)
-    list(APPEND CURL_CFILES "tool_hugehelp.c")
-    list(APPEND CURL_HFILES "tool_hugehelp.h")
+    list(APPEND _curl_cfiles_gen "tool_hugehelp.c")
+    list(APPEND _curl_hfiles_gen "tool_hugehelp.h")
 else()
   add_custom_command(
     OUTPUT "tool_hugehelp.c"
@@ -66,11 +65,15 @@ if(CURL_CA_EMBED_SET)
         "${CMAKE_CURRENT_SOURCE_DIR}/mk-file-embed.pl"
         "${CURL_CA_EMBED}"
       VERBATIM)
-    list(APPEND CURL_CFILES "tool_ca_embed.c")
+    list(APPEND _curl_cfiles_gen "tool_ca_embed.c")
   else()
     message(WARNING "Perl not found. Will not embed the CA bundle.")
   endif()
 endif()
+
+# Get 'CURL_CFILES', 'CURLX_CFILES', 'CURL_HFILES', 'CURLTOOL_LIBCURL_CFILES' variables
+curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
+include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 if(WIN32)
   list(APPEND CURL_CFILES "curl.rc")
@@ -88,7 +91,7 @@ endif()
 
 add_executable(
   ${EXE_NAME}
-  ${CURL_CFILES} ${CURLX_CFILES} ${CURL_HFILES}
+  ${CURL_CFILES} ${_curl_cfiles_gen} ${CURLX_CFILES} ${CURL_HFILES} ${_curl_hfiles_gen}
 )
 
 add_executable(
@@ -114,8 +117,8 @@ if(ENABLE_UNICODE AND MINGW)
 endif()
 
 source_group("curlX source files" FILES ${CURLX_CFILES})
-source_group("curl source files" FILES ${CURL_CFILES})
-source_group("curl header files" FILES ${CURL_HFILES})
+source_group("curl source files" FILES ${CURL_CFILES} ${_curl_cfiles_gen})
+source_group("curl header files" FILES ${CURL_HFILES} ${_curl_hfiles_gen})
 
 include_directories(
   "${PROJECT_BINARY_DIR}/lib"  # for "curl_config.h"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,10 @@
 set(EXE_NAME curl)
 add_definitions("-DBUILDING_CURL")
 
+# Get 'CURL_CFILES', 'CURLX_CFILES', 'CURL_HFILES', 'CURLTOOL_LIBCURL_CFILES' variables
+curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
+include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
+
 if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
   add_definitions("-DUSE_MANUAL")
   add_custom_command(
@@ -40,6 +44,8 @@ if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
       "${CURL_ASCIIPAGE}"
     VERBATIM)
+    list(APPEND CURL_CFILES "tool_hugehelp.c")
+    list(APPEND CURL_HFILES "tool_hugehelp.h")
 else()
   add_custom_command(
     OUTPUT "tool_hugehelp.c"
@@ -48,10 +54,6 @@ else()
       "${CMAKE_CURRENT_SOURCE_DIR}/tool_hugehelp.h"
     VERBATIM)
 endif()
-
-# Get 'CURL_CFILES', 'CURLX_CFILES', 'CURL_HFILES', 'CURLTOOL_LIBCURL_CFILES' variables
-curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
-include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
 if(CURL_CA_EMBED_SET)
   if(PERL_FOUND)
@@ -94,16 +96,11 @@ add_executable(
   ALIAS ${EXE_NAME}
 )
 
-set(_curl_files "${CURL_CFILES}" "${CURL_HFILES}")
-# Avoid 'The custom command generating tool_hugehelp.c is attached to multiple targets [...] curl curltool'
-# by excluding the generated sources from curltool library. The UNITTESTS macro disables them in source.
-list(REMOVE_ITEM _curl_files "tool_hugehelp.c" "tool_hugehelp.h" "tool_ca_embed.c")
-
 add_library(
   curltool  # special libcurltool library just for unittests
   STATIC
   EXCLUDE_FROM_ALL
-  ${_curl_files} ${CURLTOOL_LIBCURL_CFILES}
+  ${CURL_CFILES} ${CURLTOOL_LIBCURL_CFILES} ${CURL_HFILES}
 )
 target_compile_definitions(curltool PUBLIC "UNITTESTS" "CURL_STATICLIB")
 target_link_libraries(curltool PRIVATE ${CURL_LIBS})

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,6 +61,7 @@ endif
 include Makefile.inc
 
 curl_cfiles_gen =
+curl_hfiles_gen =
 CLEANFILES =
 
 if USE_UNITY
@@ -83,7 +84,7 @@ curl_SOURCES = $(curl_EXCLUDE)
 CLEANFILES += curltool_unity.c
 else
 # CURL_FILES comes from Makefile.inc
-curl_SOURCES = $(CURL_FILES) $(curl_cfiles_gen)
+curl_SOURCES = $(CURL_FILES) $(curl_cfiles_gen) $(curl_hfiles_gen)
 endif
 if HAVE_WINDRES
 curl_SOURCES += $(CURL_RCFILES)
@@ -159,6 +160,7 @@ $(HUGE):
 endif
 
 curl_cfiles_gen += $(HUGE)
+curl_hfiles_gen += tool_hugehelp.h
 CLEANFILES += $(HUGE)
 
 CA_EMBED_CSOURCE = tool_ca_embed.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -61,7 +61,6 @@ endif
 include Makefile.inc
 
 curl_cfiles_gen =
-curl_hfiles_gen =
 CLEANFILES =
 
 if USE_UNITY
@@ -160,7 +159,6 @@ $(HUGE):
 endif
 
 curl_cfiles_gen += $(HUGE)
-curl_hfiles_gen += tool_hugehelp.h
 CLEANFILES += $(HUGE)
 
 CA_EMBED_CSOURCE = tool_ca_embed.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,8 +76,8 @@ curl_CURLX = $(CURLTOOL_LIBCURL_CFILES)
 else
 curl_CURLX = $(CURLX_CFILES)
 endif
-curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curl_CURLX)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl $(srcdir) $(CURL_CFILES) $(curl_CURLX) --exclude $(curl_EXCLUDE) > curltool_unity.c
+curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curl_cfiles_gen) $(curl_CURLX)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl $(srcdir) $(CURL_CFILES) $(curl_cfiles_gen) $(curl_CURLX) --exclude $(curl_EXCLUDE) > curltool_unity.c
 
 nodist_curl_SOURCES = curltool_unity.c
 curl_SOURCES = $(curl_EXCLUDE)
@@ -202,7 +202,7 @@ endif
 TIDY := clang-tidy
 
 tidy: $(HUGE) $(CA_EMBED_CSOURCE)
-	$(TIDY) $(CURL_CFILES) $(TIDYFLAGS) $(CURL_CLANG_TIDYFLAGS) -- $(curl_CPPFLAGS) $(CPPFLAGS) $(AM_CPPFLAGS) -DHAVE_CONFIG_H
+	$(TIDY) $(CURL_CFILES) $(curl_cfiles_gen) $(TIDYFLAGS) $(CURL_CLANG_TIDYFLAGS) -- $(curl_CPPFLAGS) $(CPPFLAGS) $(AM_CPPFLAGS) -DHAVE_CONFIG_H
 
 listhelp:
 	(cd $(top_srcdir)/docs/cmdline-opts && make listhelp)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -60,6 +60,8 @@ endif
 
 include Makefile.inc
 
+curl_cfiles_gen =
+curl_hfiles_gen =
 CLEANFILES =
 
 if USE_UNITY
@@ -157,12 +159,12 @@ $(HUGE):
 	echo '#include "tool_hugehelp.h"' >> $(HUGE)
 endif
 
-CURL_CFILES += $(HUGE)
-CURL_HFILES += tool_hugehelp.h
+curl_cfiles_gen += $(HUGE)
+curl_hfiles_gen += tool_hugehelp.h
 CLEANFILES += $(HUGE)
 
 CA_EMBED_CSOURCE = tool_ca_embed.c
-CURL_CFILES += $(CA_EMBED_CSOURCE)
+curl_cfiles_gen += $(CA_EMBED_CSOURCE)
 CLEANFILES += $(CA_EMBED_CSOURCE)
 if CURL_CA_EMBED_SET
 AM_CPPFLAGS += -DCURL_CA_EMBED

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -75,7 +75,7 @@ else
 curl_CURLX = $(CURLX_CFILES)
 endif
 curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curl_CURLX)
-	@PERL@  $(top_srcdir)/scripts/mk-unity.pl $(srcdir) $(CURL_CFILES) $(curl_CURLX) --exclude $(curl_EXCLUDE) > curltool_unity.c
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl $(srcdir) $(CURL_CFILES) $(curl_CURLX) --exclude $(curl_EXCLUDE) > curltool_unity.c
 
 nodist_curl_SOURCES = curltool_unity.c
 curl_SOURCES = $(curl_EXCLUDE)
@@ -157,6 +157,8 @@ $(HUGE):
 	echo '#include "tool_hugehelp.h"' >> $(HUGE)
 endif
 
+CURL_CFILES += $(HUGE)
+CURL_HFILES += tool_hugehelp.h
 CLEANFILES += $(HUGE)
 
 CA_EMBED_CSOURCE = tool_ca_embed.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,7 +83,7 @@ curl_SOURCES = $(curl_EXCLUDE)
 CLEANFILES += curltool_unity.c
 else
 # CURL_FILES comes from Makefile.inc
-curl_SOURCES = $(CURL_FILES)
+curl_SOURCES = $(CURL_FILES) $(curl_cfiles_gen)
 endif
 if HAVE_WINDRES
 curl_SOURCES += $(CURL_RCFILES)

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -82,7 +82,6 @@ CURL_CFILES = \
   tool_getpass.c \
   tool_help.c \
   tool_helpers.c \
-  tool_hugehelp.c \
   tool_ipfs.c \
   tool_libinfo.c \
   tool_listhelp.c \
@@ -129,7 +128,6 @@ CURL_HFILES = \
   tool_getpass.h \
   tool_help.h \
   tool_helpers.h \
-  tool_hugehelp.h \
   tool_ipfs.h \
   tool_libinfo.h \
   tool_main.h \

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -30,7 +30,9 @@
 #include "tool_util.h"
 #include "tool_version.h"
 #include "tool_cb_prg.h"
+#ifndef UNITTESTS
 #include "tool_hugehelp.h"
+#endif
 #include "tool_getparam.h"
 #include "terminal.h"
 
@@ -284,11 +286,13 @@ void tool_help(char *category)
         msnprintf(cmdbuf, sizeof(cmdbuf), "\n    --no-%s", a->lname);
       else
         msnprintf(cmdbuf, sizeof(cmdbuf), "\n    %s", category);
+#ifndef UNITTESTS
       if(a->cmd == C_XATTR)
         /* this is the last option, which then ends when FILES starts */
         showhelp("\nALL OPTIONS\n", cmdbuf, "\nFILES");
       else
         showhelp("\nALL OPTIONS\n", cmdbuf, "\n    -");
+#endif
     }
 #else
     fprintf(tool_stderr, "Cannot comply. "

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -3190,10 +3190,11 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
       if(res == PARAM_HELP_REQUESTED)
         tool_help(global->help_category);
       /* Check if we were asked for the manual */
-      else if(res == PARAM_MANUAL_REQUESTED)
+      else if(res == PARAM_MANUAL_REQUESTED) {
 #ifndef UNITTESTS
         hugehelp();
 #endif
+      }
       /* Check if we were asked for the version information */
       else if(res == PARAM_VERSION_INFO_REQUESTED)
         tool_version_info();

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -94,7 +94,9 @@
 #include "tool_xattr.h"
 #include "tool_vms.h"
 #include "tool_help.h"
+#ifndef UNITTESTS
 #include "tool_hugehelp.h"
+#endif
 #include "tool_progress.h"
 #include "tool_ipfs.h"
 #include "dynbuf.h"
@@ -104,6 +106,10 @@ CURL_EXTERN CURLcode curl_easy_perform_ev(CURL *easy);
 #endif
 
 #include "memdebug.h" /* keep this as LAST include */
+
+#ifdef UNITTESTS
+#undef CURL_CA_EMBED
+#endif
 
 #ifdef CURL_CA_EMBED
 #ifndef CURL_DECLARED_CURL_CA_EMBED
@@ -3185,7 +3191,9 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
         tool_help(global->help_category);
       /* Check if we were asked for the manual */
       else if(res == PARAM_MANUAL_REQUESTED)
+#ifndef UNITTESTS
         hugehelp();
+#endif
       /* Check if we were asked for the version information */
       else if(res == PARAM_VERSION_INFO_REQUESTED)
         tool_version_info();


### PR DESCRIPTION
CMake builds using the Xcode generator broke with an error saying it
doesn't support multiple targets depending on the same custom commands.
These custom commands are generating `tool_hugehelp.c` and
`tool_c_embed.c` for the curl tool and libcurltool.

`unit1394` and `unit1604` tests use libcurltool to test tool-specific
functions. They don't need hugehelp and ca-embed. It's thus safe to
disable and exclude them when compiling the sources for libcurltool.
Use the `UNITTESTS` macro to detect a libcurltool build within C.

After this patch these sources are solely used for building the curl
tool. Making the build compatible with the CMake Xcode generator.

Apply the change to autotools too to keep build systems synchronized.

Follow-up to 12a6de2f660dd692cce93cb65ce6e3ec126bb531 #16043

---

Clean fix for:
```
CMake Error in src/CMakeLists.txt:
-- Generating done (0.2s)
  The custom command generating

    /Users/runner/work/curl/curl/bld/src/tool_hugehelp.c

  is attached to multiple targets:

    curl
    curltool

  but none of these is a common dependency of the other(s).  This is not
  allowed by the Xcode "new build system".

CMake Generate step failed.  Build files cannot be regenerated correctly.
Error: Process completed with exit code 1.
```
https://github.com/curl/curl/actions/runs/12840127495/job/35808354148?pr=16043#step:5:1797
