### PR TITLE
tests: change the behavior of swsbounce

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -237,10 +237,14 @@ If the data contains `swsclose` anywhere within the start and end tag, and
 this is an HTTP test, then the connection is closed by the server after this
 response is sent. If not, the connection is kept persistent.
 
-If the data contains `swsbounce` anywhere within the start and end tag, the
-HTTP server detects if this is a second request using the same test and part
-number and then increases the part number with one. This is useful for auth
-tests and similar.
+If the data contains `swsbounce` anywhere within the start and end tag, then
+the HTTP server will override the part number response returned for a
+subsequent request made by the same test to `previous part number + 1`. For
+example, if a test makes a request which causes the server to return `<data>`
+that contains keyword `swsbounce` then for the next response it will ignore
+the requested part number and instead return `<data1>`. And if `<data1>`
+contains keyword `swsbounce` then the next response is `<data2>` and so on.
+This is useful for auth tests and similar.
 
 `sendzero=yes` means that the (FTP) server "sends" the data even if the size
 is zero bytes. Used to verify curl's behavior on zero bytes transfers.

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -238,13 +238,13 @@ this is an HTTP test, then the connection is closed by the server after this
 response is sent. If not, the connection is kept persistent.
 
 If the data contains `swsbounce` anywhere within the start and end tag, then
-the HTTP server will override the part number response returned for a
-subsequent request made by the same test to `previous part number + 1`. For
-example, if a test makes a request which causes the server to return `<data>`
-that contains keyword `swsbounce` then for the next response it will ignore
-the requested part number and instead return `<data1>`. And if `<data1>`
-contains keyword `swsbounce` then the next response is `<data2>` and so on.
-This is useful for auth tests and similar.
+the HTTP server overrides the part number response returned for a subsequent
+request made by the same test to `previous part number + 1`. For example, if a
+test makes a request which causes the server to return `<data>` that contains
+keyword `swsbounce` then for the next response it ignores the requested part
+number and instead returns `<data1>`. And if `<data1>` contains keyword
+`swsbounce` then the next response is `<data2>` and so on. This is useful for
+auth tests and similar.
 
 `sendzero=yes` means that the (FTP) server "sends" the data even if the size
 is zero bytes. Used to verify curl's behavior on zero bytes transfers.

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -268,6 +268,7 @@ test3000 test3001 test3002 test3003 test3004 test3005 test3006 test3007 \
 test3008 test3009 test3010 test3011 test3012 test3013 test3014 test3015 \
 test3016 test3017 test3018 test3019 test3020 test3021 test3022 test3023 \
 test3024 test3025 test3026 test3027 test3028 test3029 test3030 test3031 \
+test3032 \
 \
 test3100 test3101 test3102 test3103 test3104 test3105 \
 test3200 \

--- a/tests/data/test1001
+++ b/tests/data/test1001
@@ -19,7 +19,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1
@@ -41,7 +41,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test1002
+++ b/tests/data/test1002
@@ -18,7 +18,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1
@@ -40,7 +40,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test1060
+++ b/tests/data/test1060
@@ -836,7 +836,7 @@ daniel
 
 # then this is returned when we get proxy-auth
 <connect1000>
-HTTP/1.1 200 OK swsbounce
+HTTP/1.1 200 OK
 Server: no
 
 </connect1000>
@@ -847,7 +847,7 @@ Proxy-Authenticate: Digest realm="weirdorealm", nonce="12345"
 Content-Length: 40000
 X-tra-long-header: %repeat[16080 x a]%
 
-HTTP/1.1 200 OK swsbounce
+HTTP/1.1 200 OK
 Server: no
 
 HTTP/1.1 200 OK

--- a/tests/data/test1061
+++ b/tests/data/test1061
@@ -841,7 +841,7 @@ daniel
 
 # then this is returned when we get proxy-auth
 <connect1000>
-HTTP/1.1 200 OK swsbounce
+HTTP/1.1 200 OK
 Server: no
 
 </connect1000>
@@ -852,7 +852,7 @@ Proxy-Authenticate: Digest realm="weirdorealm", nonce="12345"
 Transfer-Encoding: chunked
 X-tra-long-header: %repeat[16080 x a]%
 
-HTTP/1.1 200 OK swsbounce
+HTTP/1.1 200 OK
 Server: no
 
 HTTP/1.1 200 OK

--- a/tests/data/test1284
+++ b/tests/data/test1284
@@ -10,7 +10,7 @@ HTTP Digest auth
 # Server-side
 <reply>
 <data>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1
@@ -27,7 +27,7 @@ ok
 </data1000>
 
 <datacheck>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test1285
+++ b/tests/data/test1285
@@ -10,7 +10,7 @@ HTTP Digest auth
 # Server-side
 <reply>
 <data>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1
@@ -27,7 +27,7 @@ ok
 </data1000>
 
 <datacheck>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test1286
+++ b/tests/data/test1286
@@ -11,7 +11,7 @@ followlocation
 # Server-side
 <reply>
 <data>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", qop="auth"
 Content-Type: text/html; charset=iso-8859-1
@@ -35,7 +35,7 @@ Content-Length: 0
 </data1001>
 
 <datacheck>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", qop="auth"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test176
+++ b/tests/data/test176
@@ -11,7 +11,7 @@ HTTP NTLM auth
 <reply>
 # the first request has NTLM type-1 included, and then the 1001 is returned
 <data1001>
-HTTP/1.1 200 beng swsclose swsbounce
+HTTP/1.1 200 beng swsclose
 Server: Microsoft-IIS/6.0
 Authentication-Info: Passport1.4 tname=MSPAuth,tname=MSPProf,tname=MSPConsent,tname=MSPSecAuth
 Content-Type: text/html; charset=iso-8859-1
@@ -29,7 +29,7 @@ content for you
 </data>
 
 <datacheck>
-HTTP/1.1 200 beng swsclose swsbounce
+HTTP/1.1 200 beng swsclose
 Server: Microsoft-IIS/6.0
 Authentication-Info: Passport1.4 tname=MSPAuth,tname=MSPProf,tname=MSPConsent,tname=MSPSecAuth
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test2058
+++ b/tests/data/test2058
@@ -19,7 +19,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-256", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1
@@ -41,7 +41,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-256", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test2059
+++ b/tests/data/test2059
@@ -19,7 +19,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-256", nonce="1053604144", userhash=true
 Content-Type: text/html; charset=iso-8859-1
@@ -41,7 +41,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-256", nonce="1053604144", userhash=true
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test206
+++ b/tests/data/test206
@@ -41,7 +41,7 @@ daniel
 
 # then this is returned when we get proxy-auth
 <connect1000>
-HTTP/1.1 200 OK swsbounce
+HTTP/1.1 200 OK
 Server: no
 
 </connect1000>
@@ -51,7 +51,7 @@ HTTP/1.1 407 Authorization Required to proxy me my dear
 Proxy-Authenticate: Digest realm="weirdorealm", nonce="12345"
 Content-Length: 33
 
-HTTP/1.1 200 OK swsbounce
+HTTP/1.1 200 OK
 Server: no
 
 HTTP/1.1 200 OK

--- a/tests/data/test2060
+++ b/tests/data/test2060
@@ -19,7 +19,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-512-256", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1
@@ -41,7 +41,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", algorithm="SHA-512-256", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test2067
+++ b/tests/data/test2067
@@ -10,7 +10,7 @@ HTTP Digest auth
 # Server-side
 <reply>
 <data>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-256"
 Content-Type: text/html; charset=iso-8859-1
@@ -27,7 +27,7 @@ ok
 </data1000>
 
 <datacheck>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-256"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test2068
+++ b/tests/data/test2068
@@ -10,7 +10,7 @@ HTTP Digest auth
 # Server-side
 <reply>
 <data>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-512-256"
 Content-Type: text/html; charset=iso-8859-1
@@ -27,7 +27,7 @@ ok
 </data1000>
 
 <datacheck>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-512-256"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test2069
+++ b/tests/data/test2069
@@ -10,7 +10,7 @@ HTTP Digest auth
 # Server-side
 <reply>
 <data>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-256", userhash=true
 Content-Type: text/html; charset=iso-8859-1
@@ -27,7 +27,7 @@ ok
 </data1000>
 
 <datacheck>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144", algorithm="SHA-256", userhash=true
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test245
+++ b/tests/data/test245
@@ -10,7 +10,7 @@ HTTP Digest auth
 # Server-side
 <reply>
 <data>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1
@@ -27,7 +27,7 @@ ok
 </data1000>
 
 <datacheck>
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test246
+++ b/tests/data/test246
@@ -15,7 +15,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1
@@ -37,7 +37,7 @@ Server: Microsoft-IIS/5.0
 Date: Sun, 03 Apr 2005 14:57:45 GMT
 X-Powered-By: ASP.NET
 
-HTTP/1.1 401 authentication please swsbounce
+HTTP/1.1 401 authentication please
 Server: Microsoft-IIS/6.0
 WWW-Authenticate: Digest realm="testrealm", nonce="1053604144"
 Content-Type: text/html; charset=iso-8859-1

--- a/tests/data/test3032
+++ b/tests/data/test3032
@@ -1,0 +1,112 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+--location
+</keywords>
+</info>
+
+# Server-side
+<reply>
+
+<data>
+HTTP/1.1 301 redirect swsbounce
+Content-Length: 0
+Location: http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+Part: data
+
+</data>
+
+<data1>
+HTTP/1.1 301 redirect swsbounce
+Content-Length: 0
+Location: http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+Part: data1
+
+</data1>
+
+<data2>
+HTTP/1.1 301 redirect swsbounce
+Content-Length: 0
+Location: http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+Part: data2
+
+</data2>
+
+<data3>
+HTTP/1.1 200 OK
+Content-Type: text/html
+Content-Length: 30
+Part: data3
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+</data3>
+
+<datacheck>
+HTTP/1.1 301 redirect swsbounce
+Content-Length: 0
+Location: http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+Part: data
+
+HTTP/1.1 301 redirect swsbounce
+Content-Length: 0
+Location: http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+Part: data1
+
+HTTP/1.1 301 redirect swsbounce
+Content-Length: 0
+Location: http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+Part: data2
+
+HTTP/1.1 200 OK
+Content-Type: text/html
+Content-Length: 30
+Part: data3
+
+XXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<server>
+http
+</server>
+# This is a test of the swsbounce keyword which is used during tests to
+# override the data response number for the next request to the previous
+# data response number + 1. eg data, data1, data2 etc.
+<name>
+HTTP redirect loop 3x swsbounce test
+</name>
+<command>
+--location http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -72,9 +72,9 @@ static int serverlogslocked = 0;
 
 static long prevtestno = -1;    /* previous test number we served */
 static long prevpartno = -1;    /* previous part number we served */
-static bool prevbounce = FALSE; /* instructs the server to increase the part
-                                   number for a test in case the identical
-                                   testno+partno request shows up again */
+static bool prevbounce = FALSE; /* instructs the server to override the
+                                   requested part number to prevpartno + 1 when
+                                   prevtestno and current test are the same */
 
 #define RCMD_NORMALREQ 0 /* default request, use the tests file normally */
 #define RCMD_IDLE      1 /* told to sit idle */
@@ -1319,9 +1319,8 @@ int main(int argc, char *argv[])
 
       if(prevbounce) {
         /* bounce treatment requested */
-        if((req.testno == prevtestno) &&
-           (req.partno == prevpartno)) {
-          req.partno++;
+        if(req.testno == prevtestno) {
+          req.partno = prevpartno + 1;
           logmsg("BOUNCE part number to %ld", req.partno);
         }
         else {

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -84,9 +84,9 @@ static bool is_proxy = FALSE;
 
 static long prevtestno = -1;    /* previous test number we served */
 static long prevpartno = -1;    /* previous part number we served */
-static bool prevbounce = FALSE; /* instructs the server to increase the part
-                                   number for a test in case the identical
-                                   testno+partno request shows up again */
+static bool prevbounce = FALSE; /* instructs the server to override the
+                                   requested part number to prevpartno + 1 when
+                                   prevtestno and current test are the same */
 
 #define RCMD_NORMALREQ 0 /* default request, use the tests file normally */
 #define RCMD_IDLE      1 /* told to sit idle */
@@ -1982,9 +1982,8 @@ static int service_connection(curl_socket_t msgsock, struct httprequest *req,
 
   if(prevbounce) {
     /* bounce treatment requested */
-    if((req->testno == prevtestno) &&
-       (req->partno == prevpartno)) {
-      req->partno++;
+    if(req->testno == prevtestno) {
+      req->partno = prevpartno + 1;
       logmsg("BOUNCE part number to %ld", req->partno);
     }
     else {


### PR DESCRIPTION
- Change the swsbounce keyword to override the part number on a subsequent request to the previous part number + 1.

Note the previous part number in this case is the part number that was returned as a response to the previous request and contained the swsbounce keyword.

Prior to this change swsbounce incremented the part number of the subsequent request instead of overriding it, and did so in a more limited fashion that prevented chaining swsbounce in multiple responses.

For example, if the test makes a request that causes the sws server to return `<data>` as a response and that response contains `swsbounce` then for the next response the sws server returns `<data1>`. If `<data1>` also contains `swsbounce` then for the next response the sws server now returns `<data2>` instead of the requested part.

Fixes https://github.com/curl/curl/discussions/16074
Closes #xxxx

---

I removed `swsbounce` from a bunch of tests where it was not actually used but now that the behavior has changed it would be used incorrectly.
