### PR TITLE
VULN-DISCLOSURE-POLICY: on legacy dependencies

### DIFF
--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -330,10 +330,10 @@ security problems.
 
 A *legacy dependency* is here defined as:
 
-- the legacy version was released over ten years ago
+- the legacy version was released over ten years ago AND
 
 - the legacy version is not shipped by any existing supported operating system
-  or distribution
+  or distribution AND
 
 - there are modern versions of equivalent or better functionality offered and
   in common use

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -322,3 +322,18 @@ that being the end of the world.
 
 There need to be more and special circumstances to treat such problems as
 security issues.
+
+## Legacy dependencies
+
+Problems that only trigger using *legacy* dependencies are not considered
+security problems.
+
+A *legacy dependency* is here defined as:
+
+- the legacy version was released over ten years ago
+
+- the legacy version is not shipped by any existing supported operating system
+  or distribution
+
+- there are modern versions of equivalent or better functionality offered and
+  in common use

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -332,8 +332,8 @@ A *legacy dependency* is here defined as:
 
 - the legacy version was released over ten years ago AND
 
-- the legacy version is not shipped by any existing supported operating system
-  or distribution AND
+- the legacy version is no longer in use by any existing supported operating
+  system or distribution AND
 
 - there are modern versions of equivalent or better functionality offered and
   in common use

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -325,8 +325,8 @@ security issues.
 
 ## Legacy dependencies
 
-Problems that only trigger using *legacy* dependencies are not considered
-security problems.
+Problems that can be triggered only by the use of a *legacy dependency* are
+not considered security problems.
 
 A *legacy dependency* is here defined as:
 

--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -332,8 +332,8 @@ A *legacy dependency* is here defined as:
 
 - the legacy version was released over ten years ago AND
 
-- the legacy version is no longer in use by any existing supported operating
-  system or distribution AND
+- the legacy version is no longer in use by any existing still supported
+  operating system or distribution AND
 
 - there are modern versions of equivalent or better functionality offered and
   in common use


### PR DESCRIPTION
Problems that only trigger using *legacy* dependencies are not considered security problems.