### PR TITLE
cmake: drop `CURL_USE_PKGCONFIG` from `curl-config.cmake.in`

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -23,16 +23,6 @@
 ###########################################################################
 @PACKAGE_INIT@
 
-# Keep condition in sync with CMake/curl-config.cmake.in
-if((UNIX AND NOT ANDROID AND (NOT APPLE OR CMAKE_SYSTEM_NAME MATCHES "Darwin")) OR
-   VCPKG_TOOLCHAIN OR
-   (MINGW AND NOT CMAKE_CROSSCOMPILING))
-  set(_curl_use_pkgconfig_default ON)
-else()
-  set(_curl_use_pkgconfig_default OFF)
-endif()
-option(CURL_USE_PKGCONFIG "Enable pkg-config to detect @PROJECT_NAME@ dependencies" ${_curl_use_pkgconfig_default})
-
 include(CMakeFindDependencyMacro)
 if("@USE_OPENSSL@")
   find_dependency(OpenSSL "@OPENSSL_VERSION_MAJOR@")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,7 +322,6 @@ else()
 endif()
 
 # Override to force-disable or force-enable the use of pkg-config.
-# Keep condition in sync with CMake/curl-config.cmake.in
 if((UNIX AND NOT ANDROID AND (NOT APPLE OR CMAKE_SYSTEM_NAME MATCHES "Darwin")) OR
    VCPKG_TOOLCHAIN OR
    (MINGW AND NOT CMAKE_CROSSCOMPILING))
@@ -2397,8 +2396,8 @@ if(NOT CURL_DISABLE_INSTALL)
   #   CURLVERSION
   #   LIB_SELECTED
   #   TARGETS_EXPORT_NAME
-  #   USE_OPENSSL
-  #   HAVE_LIBZ
+  #   USE_OPENSSL OPENSSL_VERSION_MAJOR
+  #   HAVE_LIBZ ZLIB_VERSION_MAJOR
   #   CURL_SUPPORTED_FEATURES_LIST
   #   CURL_SUPPORTED_PROTOCOLS_LIST
   configure_package_config_file("CMake/curl-config.cmake.in"


### PR DESCRIPTION
This variable was meant to be used by curl Find modules, but it turns
out it makes no sense to use those from `curl-config.cmake.in`. It means
this variable was not used before and will not be used in the future,
and therefore safe to delete.

Also add missing macros passed to `curl-config.cmake` to comment.

Ref: https://github.com/curl/curl/pull/14930#discussion_r1929537797
