### PR TITLE
GHA/non-native: bump to NetBSD 10.1

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -51,7 +51,7 @@ jobs:
         uses: cross-platform-actions/action@fe0167d8082ac584754ef3ffb567fded22642c7d # v0.27.0
         with:
           operating_system: 'netbsd'
-          version: '10.0'
+          version: '10.1'
           architecture: ${{ matrix.arch }}
           run: |
             # https://pkgsrc.se/


### PR DESCRIPTION
---

before: https://github.com/curl/curl/actions/runs/12968556355/job/36171836644 5m27s
after: https://github.com/curl/curl/actions/runs/12968728336/job/36172028232?pr=16088 8m17s
