### PR TITLE
version: rename the c-ares-rr feature to asyn-rr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2107,7 +2107,7 @@ curl_add_if("brotli"        HAVE_BROTLI)
 curl_add_if("gsasl"         USE_GSASL)
 curl_add_if("zstd"          HAVE_ZSTD)
 curl_add_if("AsynchDNS"     USE_ARES OR USE_THREADS_POSIX OR USE_THREADS_WIN32)
-curl_add_if("c-ares-rr"     USE_ARES AND ENABLE_THREADED_RESOLVER)
+curl_add_if("asyn-rr"       USE_ARES AND ENABLE_THREADED_RESOLVER)
 curl_add_if("IDN"           (HAVE_LIBIDN2 AND HAVE_IDN2_H) OR
                             USE_WIN32_IDN OR
                             USE_APPLE_IDN)

--- a/configure.ac
+++ b/configure.ac
@@ -5018,7 +5018,7 @@ if test "x$USE_ARES" = "x1" -o "x$USE_THREADS_POSIX" = "x1" \
   SUPPORT_FEATURES="$SUPPORT_FEATURES AsynchDNS"
 fi
 if test "x$USE_ARES" = "x1" -a "$want_threaded_resolver" = "yes"; then
-  SUPPORT_FEATURES="$SUPPORT_FEATURES c-ares-rr"
+  SUPPORT_FEATURES="$SUPPORT_FEATURES asyn-rr"
 fi
 if test "x$IDN_ENABLED" = "x1"; then
   SUPPORT_FEATURES="$SUPPORT_FEATURES IDN"

--- a/docs/HTTPSRR.md
+++ b/docs/HTTPSRR.md
@@ -25,9 +25,9 @@ curl features **experimental** support for HTTPS RR.
 HTTPS RR support. If c-ares is not included in the build, the HTTPS RR support
 is limited to DoH.
 
-`c-ares-rr` is listed as a feature in the `curl -V` output if c-ares is used
-for additional resolves in addition to a "normal" resolve done with the
-threaded resolver.
+`asyn-rr` is listed as a feature in the `curl -V` output if c-ares is used for
+additional resolves in addition to a "normal" resolve done with the threaded
+resolver.
 
 The data extracted from the HTTPS RR is stored in the in-memory DNS cache to
 be reused on subsequent uses of the same hostnames.

--- a/docs/libcurl/curl_version_info.md
+++ b/docs/libcurl/curl_version_info.md
@@ -171,7 +171,7 @@ interface. (added in 7.10.7)
 
 supports HTTP Brotli content encoding using libbrotlidec (Added in 7.57.0)
 
-## `c-ares-rr`
+## `asyn-rr`
 
 *features* mask bit: non-existent
 

--- a/lib/version.c
+++ b/lib/version.c
@@ -464,11 +464,11 @@ static const struct feat features_table[] = {
 #ifdef CURLRES_ASYNCH
   FEATURE("AsynchDNS",   NULL,                CURL_VERSION_ASYNCHDNS),
 #endif
+#if defined(USE_ARES) && defined(CURLRES_THREADED) && defined(USE_HTTPSRR)
+  FEATURE("asyn-rr", NULL,             0),
+#endif
 #ifdef HAVE_BROTLI
   FEATURE("brotli",      NULL,                CURL_VERSION_BROTLI),
-#endif
-#if defined(USE_ARES) && defined(CURLRES_THREADED) && defined(USE_HTTPSRR)
-  FEATURE("c-ares-rr", NULL,             0),
 #endif
 #ifdef DEBUGBUILD
   FEATURE("Debug",       NULL,                CURL_VERSION_DEBUG),

--- a/lib/version.c
+++ b/lib/version.c
@@ -467,7 +467,7 @@ static const struct feat features_table[] = {
 #ifdef HAVE_BROTLI
   FEATURE("brotli",      NULL,                CURL_VERSION_BROTLI),
 #endif
-#if defined(CURLRES_ARES) && defined(CURLRES_THREADED)
+#if defined(USE_ARES) && defined(CURLRES_THREADED)
   FEATURE("c-ares-rr", NULL,             0),
 #endif
 #ifdef DEBUGBUILD

--- a/lib/version.c
+++ b/lib/version.c
@@ -467,7 +467,7 @@ static const struct feat features_table[] = {
 #ifdef HAVE_BROTLI
   FEATURE("brotli",      NULL,                CURL_VERSION_BROTLI),
 #endif
-#if defined(USE_ARES) && defined(CURLRES_THREADED)
+#if defined(USE_ARES) && defined(CURLRES_THREADED) && defined(USE_HTTPSRR)
   FEATURE("c-ares-rr", NULL,             0),
 #endif
 #ifdef DEBUGBUILD

--- a/lib/version.c
+++ b/lib/version.c
@@ -461,11 +461,11 @@ static const struct feat features_table[] = {
 #ifndef CURL_DISABLE_ALTSVC
   FEATURE("alt-svc",     NULL,                CURL_VERSION_ALTSVC),
 #endif
-#ifdef CURLRES_ASYNCH
-  FEATURE("AsynchDNS",   NULL,                CURL_VERSION_ASYNCHDNS),
-#endif
 #if defined(USE_ARES) && defined(CURLRES_THREADED) && defined(USE_HTTPSRR)
   FEATURE("asyn-rr", NULL,             0),
+#endif
+#ifdef CURLRES_ASYNCH
+  FEATURE("AsynchDNS",   NULL,                CURL_VERSION_ASYNCHDNS),
 #endif
 #ifdef HAVE_BROTLI
   FEATURE("brotli",      NULL,                CURL_VERSION_BROTLI),

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -436,10 +436,10 @@ Features testable here are:
 
 - `alt-svc`
 - `AppleIDN`
+- `asyn-rr` - c-ares is used for additional records only
 - `bearssl`
 - `brotli`
 - `c-ares` - c-ares is used for (all) name resolves
-- `c-ares-rr` - c-ares is used for additional records only
 - `CharConv`
 - `codeset-utf8`. If the running codeset is UTF-8 capable.
 - `cookies`

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -699,7 +699,7 @@ sub checksystemfeatures {
             # Thread-safe init
             $feature{"threadsafe"} = $feat =~ /threadsafe/i;
             $feature{"HTTPSRR"} = $feat =~ /HTTPSRR/;
-            $feature{"c-ares-rr"} = $feat =~ /c-ares-rr/;
+            $feature{"asyn-rr"} = $feat =~ /asyn-rr/;
         }
         #
         # Test harness currently uses a non-stunnel server in order to


### PR DESCRIPTION
Needs c-ares use but threaded-resolver resolving.

Follow-up to 0d4fdbf15d8eec908b3