### PR TITLE
msvc: add missing push/pop for warning pragmas

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4107,11 +4107,6 @@ static CURLcode ftp_disconnect(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4706)  /* assignment within conditional expression */
-#endif
-
 /***********************************************************************
  *
  * ftp_parse_url_path()
@@ -4201,6 +4196,10 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
           return CURLE_OUT_OF_MEMORY;
         }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4706) /* assignment within conditional expression */
+#endif
         /* parse the URL path into separate path components */
         while((slashPos = strchr(curPos, '/'))) {
           size_t compLen = slashPos - curPos;
@@ -4222,6 +4221,9 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
           }
           curPos = slashPos + 1;
         }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
       }
       DEBUGASSERT((size_t)ftpc->dirdepth <= dirAlloc);
       fileName = curPos; /* the rest is the filename (or empty) */
@@ -4265,10 +4267,6 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
   free(rawPath);
   return CURLE_OK;
 }
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 /* call this when the DO phase has completed */
 static CURLcode ftp_dophase_done(struct Curl_easy *data, bool connected)

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4107,6 +4107,11 @@ static CURLcode ftp_disconnect(struct Curl_easy *data,
   return CURLE_OK;
 }
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4706) /* assignment within conditional expression */
+#endif
+
 /***********************************************************************
  *
  * ftp_parse_url_path()
@@ -4196,10 +4201,6 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
           return CURLE_OUT_OF_MEMORY;
         }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4706) /* assignment within conditional expression */
-#endif
         /* parse the URL path into separate path components */
         while((slashPos = strchr(curPos, '/'))) {
           size_t compLen = slashPos - curPos;
@@ -4221,9 +4222,6 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
           }
           curPos = slashPos + 1;
         }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
       }
       DEBUGASSERT((size_t)ftpc->dirdepth <= dirAlloc);
       fileName = curPos; /* the rest is the filename (or empty) */
@@ -4267,6 +4265,10 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
   free(rawPath);
   return CURLE_OK;
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 /* call this when the DO phase has completed */
 static CURLcode ftp_dophase_done(struct Curl_easy *data, bool connected)

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4108,8 +4108,8 @@ static CURLcode ftp_disconnect(struct Curl_easy *data,
 }
 
 #ifdef _MSC_VER
-/* warning C4706: assignment within conditional expression */
-#pragma warning(disable:4706)
+#pragma warning(push)
+#pragma warning(disable:4706)  /* assignment within conditional expression */
 #endif
 
 /***********************************************************************
@@ -4265,6 +4265,10 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
   free(rawPath);
   return CURLE_OK;
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 /* call this when the DO phase has completed */
 static CURLcode ftp_dophase_done(struct Curl_easy *data, bool connected)

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -57,7 +57,7 @@
 #ifdef USE_WIN32_LDAP           /* Use Windows LDAP implementation. */
 # ifdef _MSC_VER
 #  pragma warning(push)
-#  pragma warning(disable: 4201)
+#  pragma warning(disable:4201)
 # endif
 # include <subauth.h>  /* for [P]UNICODE_STRING */
 # ifdef _MSC_VER

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -779,8 +779,7 @@ static void printsub(struct Curl_easy *data,
 
 #ifdef _MSC_VER
 #pragma warning(push)
-/* warning C4706: assignment within conditional expression */
-#pragma warning(disable:4706)
+#pragma warning(disable:4706)  /* assignment within conditional expression */
 #endif
 static bool str_is_nonascii(const char *str)
 {

--- a/lib/vtls/schannel.h
+++ b/lib/vtls/schannel.h
@@ -30,7 +30,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable: 4201)
+#pragma warning(disable:4201)
 #endif
 #include <subauth.h>
 #ifdef _MSC_VER

--- a/lib/warnless.c
+++ b/lib/warnless.c
@@ -126,8 +126,8 @@ int curlx_uztosi(size_t uznum)
 unsigned long curlx_uztoul(size_t uznum)
 {
 #ifdef __INTEL_COMPILER
-# pragma warning(push)
-# pragma warning(disable:810) /* conversion may lose significant bits */
+#  pragma warning(push)
+#  pragma warning(disable:810) /* conversion may lose significant bits */
 #endif
 
 #if ULONG_MAX < SIZE_T_MAX
@@ -136,7 +136,7 @@ unsigned long curlx_uztoul(size_t uznum)
   return (unsigned long)(uznum & (size_t) CURL_MASK_ULONG);
 
 #ifdef __INTEL_COMPILER
-# pragma warning(pop)
+#  pragma warning(pop)
 #endif
 }
 
@@ -147,8 +147,8 @@ unsigned long curlx_uztoul(size_t uznum)
 unsigned int curlx_uztoui(size_t uznum)
 {
 #ifdef __INTEL_COMPILER
-# pragma warning(push)
-# pragma warning(disable:810) /* conversion may lose significant bits */
+#  pragma warning(push)
+#  pragma warning(disable:810) /* conversion may lose significant bits */
 #endif
 
 #if UINT_MAX < SIZE_T_MAX
@@ -157,7 +157,7 @@ unsigned int curlx_uztoui(size_t uznum)
   return (unsigned int)(uznum & (size_t) CURL_MASK_UINT);
 
 #ifdef __INTEL_COMPILER
-# pragma warning(pop)
+#  pragma warning(pop)
 #endif
 }
 

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -119,8 +119,8 @@ void ourWriteOutJSON(FILE *stream, const struct writeoutvar mappings[],
 }
 
 #ifdef _MSC_VER
-/* warning C4706: assignment within conditional expression */
-#pragma warning(disable:4706)
+#pragma warning(push)
+#pragma warning(disable:4706) /* assignment within conditional expression */
 #endif
 
 void headerJSON(FILE *stream, struct per_transfer *per)
@@ -169,3 +169,7 @@ void headerJSON(FILE *stream, struct per_transfer *per)
   }
   fputs("\n}", stream);
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif

--- a/tests/libtest/lib1945.c
+++ b/tests/libtest/lib1945.c
@@ -27,8 +27,8 @@
 #include "memdebug.h"
 
 #ifdef _MSC_VER
-/* warning C4706: assignment within conditional expression */
-#pragma warning(disable:4706)
+#pragma warning(push)
+#pragma warning(disable:4706) /* assignment within conditional expression */
 #endif
 static void showem(CURL *easy, unsigned int type)
 {
@@ -41,6 +41,9 @@ static void showem(CURL *easy, unsigned int type)
     prev = header;
   }
 }
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 static size_t write_cb(char *data, size_t n, size_t l, void *userp)
 {


### PR DESCRIPTION
Also fix indentation/formatting around similar pragmas.
