### PR TITLE
openssl: drop support for old OpenSSL/LibreSSL versions

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -25,6 +25,7 @@ versions of libs and build tools.
  We aim to support these or later versions.
 
  - OpenSSL      0.9.7
+ - LibreSSL     2.5.3
  - GnuTLS       3.1.10
  - zlib         1.2.0.4
  - libssh2      1.2.8

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -24,7 +24,7 @@ versions of libs and build tools.
 
  We aim to support these or later versions.
 
- - OpenSSL      0.9.7
+ - OpenSSL      1.0.2
  - LibreSSL     2.9.1
  - GnuTLS       3.1.10
  - zlib         1.2.0.4

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -24,7 +24,7 @@ versions of libs and build tools.
 
  We aim to support these or later versions.
 
- - OpenSSL      1.0.2
+ - OpenSSL      1.0.2a
  - LibreSSL     2.9.1
  - GnuTLS       3.1.10
  - zlib         1.2.0.4

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -25,7 +25,7 @@ versions of libs and build tools.
  We aim to support these or later versions.
 
  - OpenSSL      0.9.7
- - LibreSSL     2.5.3
+ - LibreSSL     2.7.1
  - GnuTLS       3.1.10
  - zlib         1.2.0.4
  - libssh2      1.2.8

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -25,7 +25,7 @@ versions of libs and build tools.
  We aim to support these or later versions.
 
  - OpenSSL      0.9.7
- - LibreSSL     2.7.1
+ - LibreSSL     2.9.1
  - GnuTLS       3.1.10
  - zlib         1.2.0.4
  - libssh2      1.2.8

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -71,8 +71,7 @@
 #  include <openssl/md5.h>
 #  include <openssl/ssl.h>
 #  include <openssl/rand.h>
-#  if (defined(OPENSSL_VERSION_NUMBER) && \
-       (OPENSSL_VERSION_NUMBER < 0x00907001L)) && !defined(USE_WOLFSSL)
+#  ifndef USE_WOLFSSL
 #    define DES_key_schedule des_key_schedule
 #    define DES_cblock des_cblock
 #    define DES_set_odd_parity des_set_odd_parity

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -71,15 +71,7 @@
 #  include <openssl/md5.h>
 #  include <openssl/ssl.h>
 #  include <openssl/rand.h>
-#  ifndef USE_WOLFSSL
-#    define DES_key_schedule des_key_schedule
-#    define DES_cblock des_cblock
-#    define DES_set_odd_parity des_set_odd_parity
-#    define DES_set_key des_set_key
-#    define DES_ecb_encrypt des_ecb_encrypt
-#    define DESKEY(x) x
-#    define DESKEYARG(x) x
-#  elif defined(OPENSSL_IS_AWSLC)
+#  if defined(OPENSSL_IS_AWSLC)
 #    define DES_set_key_unchecked (void)DES_set_key
 #    define DESKEYARG(x) *x
 #    define DESKEY(x) &x

--- a/lib/setup-vms.h
+++ b/lib/setup-vms.h
@@ -399,14 +399,6 @@ static struct passwd *vms_getpwuid(uid_t uid)
 #       define OpenSSL_add_all_algorithms OPENSSL_ADD_ALL_ALGORITHMS
         void OPENSSL_ADD_ALL_ALGORITHMS(void);
 #   endif
-
-/* Need this to stop a macro redefinition error */
-#if OPENSSL_VERSION_NUMBER < 0x00907000L
-#   ifdef X509_STORE_set_flags
-#       undef X509_STORE_set_flags
-#       define X509_STORE_set_flags(x,y) Curl_nop_stmt
-#   endif
-#endif
 #endif
 
 #endif /* HEADER_CURL_SETUP_VMS_H */

--- a/lib/setup-vms.h
+++ b/lib/setup-vms.h
@@ -394,44 +394,12 @@ static struct passwd *vms_getpwuid(uid_t uid)
 /* that way a newer port will also work if some one has one */
 #ifdef __VAX
 
-#   if (OPENSSL_VERSION_NUMBER < 0x00907001L)
-#       define des_set_odd_parity DES_SET_ODD_PARITY
-#       define des_set_key DES_SET_KEY
-#       define des_ecb_encrypt DES_ECB_ENCRYPT
-
-#   endif
 #   include <openssl/evp.h>
 #   ifndef OpenSSL_add_all_algorithms
 #       define OpenSSL_add_all_algorithms OPENSSL_ADD_ALL_ALGORITHMS
         void OPENSSL_ADD_ALL_ALGORITHMS(void);
 #   endif
 
-    /* Curl defines these to lower case and VAX needs them in upper case */
-    /* So we need static routines */
-#   if (OPENSSL_VERSION_NUMBER < 0x00907001L)
-
-#       undef des_set_odd_parity
-#       undef DES_set_odd_parity
-#       undef des_set_key
-#       undef DES_set_key
-#       undef des_ecb_encrypt
-#       undef DES_ecb_encrypt
-
-        static void des_set_odd_parity(des_cblock *key) {
-            DES_SET_ODD_PARITY(key);
-        }
-
-        static int des_set_key(const_des_cblock *key,
-                               des_key_schedule schedule) {
-            return DES_SET_KEY(key, schedule);
-        }
-
-        static void des_ecb_encrypt(const_des_cblock *input,
-                                    des_cblock *output,
-                                    des_key_schedule ks, int enc) {
-            DES_ECB_ENCRYPT(input, output, ks, enc);
-        }
-#endif
 /* Need this to stop a macro redefinition error */
 #if OPENSSL_VERSION_NUMBER < 0x00907000L
 #   ifdef X509_STORE_set_flags

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -32,10 +32,6 @@
 #include "curl_sha256.h"
 #include "curl_hmac.h"
 
-#ifdef USE_OPENSSL
-#define USE_OPENSSL_SHA256
-#endif /* USE_OPENSSL */
-
 #ifdef USE_MBEDTLS
 #include <mbedtls/version.h>
 
@@ -45,7 +41,7 @@
 #endif
 #endif /* USE_MBEDTLS */
 
-#if defined(USE_OPENSSL_SHA256)
+#ifdef USE_OPENSSL
 
 /* When OpenSSL or wolfSSL is available we use their SHA256-functions. */
 #if defined(USE_OPENSSL)
@@ -83,7 +79,7 @@
  * file even if multiple backends are enabled at the same time.
  */
 
-#if defined(USE_OPENSSL_SHA256)
+#ifdef USE_OPENSSL
 
 struct ossl_sha256_ctx {
   EVP_MD_CTX *openssl_ctx;

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -42,12 +42,7 @@
 #endif /* USE_MBEDTLS */
 
 #ifdef USE_OPENSSL
-
-/* When OpenSSL or wolfSSL is available we use their SHA256-functions. */
-#if defined(USE_OPENSSL)
 #include <openssl/evp.h>
-#endif
-
 #elif defined(USE_GNUTLS)
 #include <nettle/sha.h>
 #elif defined(USE_MBEDTLS)

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -32,20 +32,16 @@
 #include "curl_sha256.h"
 #include "curl_hmac.h"
 
-#ifdef USE_MBEDTLS
-#include <mbedtls/version.h>
-
-#if(MBEDTLS_VERSION_NUMBER >= 0x02070000) && \
-   (MBEDTLS_VERSION_NUMBER < 0x03000000)
-  #define HAS_MBEDTLS_RESULT_CODE_BASED_FUNCTIONS
-#endif
-#endif /* USE_MBEDTLS */
-
 #ifdef USE_OPENSSL
 #include <openssl/evp.h>
 #elif defined(USE_GNUTLS)
 #include <nettle/sha.h>
 #elif defined(USE_MBEDTLS)
+#include <mbedtls/version.h>
+#if(MBEDTLS_VERSION_NUMBER >= 0x02070000) && \
+   (MBEDTLS_VERSION_NUMBER < 0x03000000)
+  #define HAS_MBEDTLS_RESULT_CODE_BASED_FUNCTIONS
+#endif
 #include <mbedtls/sha256.h>
 #elif (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && \
               (__MAC_OS_X_VERSION_MAX_ALLOWED >= 1040)) || \
@@ -511,6 +507,5 @@ const struct HMAC_params Curl_HMAC_SHA256 = {
   64,                    /* Maximum key length. */
   32                     /* Result size. */
 };
-
 
 #endif /* AWS, DIGEST, or libssh2 */

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -50,8 +50,6 @@
 /* When OpenSSL or wolfSSL is available we use their SHA256-functions. */
 #if defined(USE_OPENSSL)
 #include <openssl/evp.h>
-#elif defined(USE_WOLFSSL)
-#include <wolfssl/openssl/evp.h>
 #endif
 
 #elif defined(USE_GNUTLS)

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -32,10 +32,6 @@
 #include "curl_sha256.h"
 #include "curl_hmac.h"
 
-#ifdef USE_WOLFSSL
-#include <wolfssl/options.h>
-#endif
-
 #ifdef USE_OPENSSL
 #define USE_OPENSSL_SHA256
 #endif /* USE_OPENSSL */

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -36,14 +36,8 @@
 #include <wolfssl/options.h>
 #endif
 
-#if defined(USE_OPENSSL)
-
-#include <openssl/opensslv.h>
-
-#if (OPENSSL_VERSION_NUMBER >= 0x0090800fL)
+#ifdef USE_OPENSSL
 #define USE_OPENSSL_SHA256
-#endif
-
 #endif /* USE_OPENSSL */
 
 #ifdef USE_MBEDTLS

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -208,7 +208,7 @@
 #   define OSSL_PACKAGE "quictls"
 # else
 #   define OSSL_PACKAGE "OpenSSL"
-#endif
+# endif
 #endif
 
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -103,6 +103,7 @@
 #endif
 
 #ifdef LIBRESSL_VERSION_NUMBER
+# /* As of LibreSSL 2.0.0-4.0.0: OPENSSL_VERSION_NUMBER == 0x20000000L */
 # if LIBRESSL_VERSION_NUMBER < 0x2090100fL /* 2019-04-13 */
 #  error "LibreSSL 2.9.1 or later required"
 # endif
@@ -262,7 +263,7 @@ typedef unsigned long sslerr_t;
 #endif
 
 /* What API version do we use? */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define HAVE_PRE_1_1_API
 #endif
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -203,12 +203,10 @@
 #define OSSL_PACKAGE "BoringSSL"
 #elif defined(OPENSSL_IS_AWSLC)
 #define OSSL_PACKAGE "AWS-LC"
+#elif (defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || defined(USE_MSH3)
+#define OSSL_PACKAGE "quictls"
 #else
-# if (defined(USE_NGTCP2) && defined(USE_NGHTTP3)) || defined(USE_MSH3)
-#   define OSSL_PACKAGE "quictls"
-# else
-#   define OSSL_PACKAGE "OpenSSL"
-# endif
+#define OSSL_PACKAGE "OpenSSL"
 #endif
 
 #if defined(OPENSSL_IS_BORINGSSL) || defined(OPENSSL_IS_AWSLC)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5226,7 +5226,6 @@ static CURLcode ossl_get_channel_binding(struct Curl_easy *data, int sockindex,
 size_t Curl_ossl_version(char *buffer, size_t size)
 {
 #ifdef LIBRESSL_VERSION_NUMBER
-#ifdef HAVE_OPENSSL_VERSION
   char *p;
   size_t count;
   const char *ver = OpenSSL_version(OPENSSL_VERSION);
@@ -5240,13 +5239,6 @@ size_t Curl_ossl_version(char *buffer, size_t size)
       *p = '_';
   }
   return count;
-#else
-  return msnprintf(buffer, size, "%s/%lx.%lx.%lx",
-                   OSSL_PACKAGE,
-                   (LIBRESSL_VERSION_NUMBER >> 28) & 0xf,
-                   (LIBRESSL_VERSION_NUMBER >> 20) & 0xff,
-                   (LIBRESSL_VERSION_NUMBER >> 12) & 0xff);
-#endif
 #elif defined(OPENSSL_IS_BORINGSSL)
 #ifdef CURL_BORINGSSL_VERSION
   return msnprintf(buffer, size, "%s/%s",

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -196,18 +196,6 @@
   #endif
 #endif
 
-/*
- * Whether SSL_CTX_set1_curves_list is available.
- * OpenSSL: supported since 1.0.2, see
- *   https://docs.openssl.org/master/man3/SSL_CTX_set1_curves/
- * BoringSSL: supported since 5fd1807d95f7 (committed 2016-09-30)
- * LibreSSL: since 2.5.3 (April 12, 2017)
- */
-#if (OPENSSL_VERSION_NUMBER >= 0x10002000L) ||  \
-  defined(OPENSSL_IS_BORINGSSL)
-#define HAVE_SSL_CTX_SET_EC_CURVES
-#endif
-
 #if defined(LIBRESSL_VERSION_NUMBER)
 #define OSSL_PACKAGE "LibreSSL"
 #elif defined(OPENSSL_IS_BORINGSSL)
@@ -3799,7 +3787,6 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   SSL_CTX_set_post_handshake_auth(octx->ssl_ctx, 1);
 #endif
 
-#ifdef HAVE_SSL_CTX_SET_EC_CURVES
   {
     const char *curves = conn_config->curves;
     if(curves) {
@@ -3809,7 +3796,6 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
       }
     }
   }
-#endif
 
 #ifdef USE_OPENSSL_SRP
   if(ssl_config->primary.username && Curl_auth_allowed_to_host(data)) {

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -260,11 +260,6 @@ typedef unsigned long sslerr_t;
 #define HAVE_SSL_X509_STORE_SHARE
 #endif
 
-/* What API version do we use? */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#define HAVE_PRE_1_1_API
-#endif
-
 static CURLcode ossl_certchain(struct Curl_easy *data, SSL *ssl);
 
 static CURLcode push_certinfo(struct Curl_easy *data,
@@ -637,7 +632,7 @@ static CURLcode ossl_certchain(struct Curl_easy *data, SSL *ssl)
 
 #ifdef USE_OPENSSL
 
-#ifdef HAVE_PRE_1_1_API
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 #define BIO_set_init(x,v)          ((x)->init=(v))
 #define BIO_get_data(x)            ((x)->ptr)
 #define BIO_set_data(x,v)          ((x)->ptr=(v))
@@ -649,7 +644,7 @@ static int ossl_bio_cf_create(BIO *bio)
 {
   BIO_set_shutdown(bio, 1);
   BIO_set_init(bio, 1);
-#ifdef HAVE_PRE_1_1_API
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   bio->num = -1;
 #endif
   BIO_set_data(bio, NULL);
@@ -766,7 +761,7 @@ static int ossl_bio_cf_in_read(BIO *bio, char *buf, int blen)
   return (int)nread;
 }
 
-#ifdef HAVE_PRE_1_1_API
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 
 static BIO_METHOD ossl_bio_cf_meth_1_0 = {
   BIO_TYPE_MEM,

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -34,7 +34,7 @@
 #include <limits.h>
 
 /* Wincrypt must be included before anything that could include OpenSSL. */
-#if defined(USE_WIN32_CRYPTO)
+#ifdef USE_WIN32_CRYPTO
 #include <wincrypt.h>
 /* Undefine wincrypt conflicting symbols for BoringSSL. */
 #undef X509_NAME
@@ -83,7 +83,7 @@
 #include <openssl/tls1.h>
 #include <openssl/evp.h>
 
-#if defined(HAVE_SSL_SET1_ECH_CONFIG_LIST)
+#ifdef HAVE_SSL_SET1_ECH_CONFIG_LIST
 #define USE_ECH_OPENSSL
 #endif
 
@@ -191,12 +191,12 @@
       LIBRESSL_VERSION_NUMBER >= 0x3040100fL)) && \
     !defined(OPENSSL_IS_BORINGSSL)
   #define HAVE_SSL_CTX_SET_CIPHERSUITES
-  #if !defined(OPENSSL_IS_AWSLC)
+  #ifndef OPENSSL_IS_AWSLC
     #define HAVE_SSL_CTX_SET_POST_HANDSHAKE_AUTH
   #endif
 #endif
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#ifdef LIBRESSL_VERSION_NUMBER
 #define OSSL_PACKAGE "LibreSSL"
 #elif defined(OPENSSL_IS_BORINGSSL)
 #define OSSL_PACKAGE "BoringSSL"
@@ -891,15 +891,15 @@ static const char *SSL_ERROR_to_str(int err)
     return "SSL_ERROR_WANT_CONNECT";
   case SSL_ERROR_WANT_ACCEPT:
     return "SSL_ERROR_WANT_ACCEPT";
-#if defined(SSL_ERROR_WANT_ASYNC)
+#ifdef SSL_ERROR_WANT_ASYNC
   case SSL_ERROR_WANT_ASYNC:
     return "SSL_ERROR_WANT_ASYNC";
 #endif
-#if defined(SSL_ERROR_WANT_ASYNC_JOB)
+#ifdef SSL_ERROR_WANT_ASYNC_JOB
   case SSL_ERROR_WANT_ASYNC_JOB:
     return "SSL_ERROR_WANT_ASYNC_JOB";
 #endif
-#if defined(SSL_ERROR_WANT_EARLY)
+#ifdef SSL_ERROR_WANT_EARLY
   case SSL_ERROR_WANT_EARLY:
     return "SSL_ERROR_WANT_EARLY";
 #endif
@@ -2145,7 +2145,7 @@ static void ossl_close_all(struct Curl_easy *data)
 #else
   (void)data;
 #endif
-#if !defined(HAVE_ERR_REMOVE_THREAD_STATE_DEPRECATED)
+#ifndef HAVE_ERR_REMOVE_THREAD_STATE_DEPRECATED
   /* OpenSSL 1.0.1 and 1.0.2 build an error queue that is stored per-thread
      so we need to clean it here in case the thread will be killed. All OpenSSL
      code should extract the error in association with the error so clearing
@@ -2409,7 +2409,7 @@ static CURLcode verifystatus(struct Curl_cfilter *cf,
                              struct ossl_ctx *octx)
 {
   int i, ocsp_status;
-#if defined(OPENSSL_IS_AWSLC)
+#ifdef OPENSSL_IS_AWSLC
   const uint8_t *status;
 #else
   unsigned char *status;
@@ -3061,7 +3061,7 @@ static CURLcode load_cacert_from_memory(X509_STORE *store,
   return (count > 0) ? CURLE_OK : CURLE_SSL_CACERT_BADFILE;
 }
 
-#if defined(USE_WIN32_CRYPTO)
+#ifdef USE_WIN32_CRYPTO
 static CURLcode import_windows_cert_store(struct Curl_easy *data,
                                           const char *name,
                                           X509_STORE *store,
@@ -3229,7 +3229,7 @@ static CURLcode ossl_populate_x509_store(struct Curl_cfilter *cf,
     return CURLE_OUT_OF_MEMORY;
 
   if(verifypeer) {
-#if defined(USE_WIN32_CRYPTO)
+#ifdef USE_WIN32_CRYPTO
     /* Import certificates from the Windows root certificate store if
        requested.
        https://stackoverflow.com/questions/9507184/
@@ -3347,7 +3347,7 @@ static CURLcode ossl_populate_x509_store(struct Curl_cfilter *cf,
        https://web.archive.org/web/20190422050538/
        rt.openssl.org/Ticket/Display.html?id=3621
     */
-#if defined(X509_V_FLAG_TRUSTED_FIRST)
+#ifdef X509_V_FLAG_TRUSTED_FIRST
     X509_STORE_set_flags(store, X509_V_FLAG_TRUSTED_FIRST);
 #endif
 #ifdef X509_V_FLAG_PARTIAL_CHAIN
@@ -3368,7 +3368,7 @@ static CURLcode ossl_populate_x509_store(struct Curl_cfilter *cf,
   return result;
 }
 
-#if defined(HAVE_SSL_X509_STORE_SHARE)
+#ifdef HAVE_SSL_X509_STORE_SHARE
 
 /* key to use at `multi->proto_hash` */
 #define MPROTO_OSSL_X509_KEY   "tls:ossl:x509:share"
@@ -4281,7 +4281,7 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
         else
           failf(data, "%s", "SSL certificate verification failed");
       }
-#if defined(SSL_R_TLSV13_ALERT_CERTIFICATE_REQUIRED)
+#ifdef SSL_R_TLSV13_ALERT_CERTIFICATE_REQUIRED
       /* SSL_R_TLSV13_ALERT_CERTIFICATE_REQUIRED is only available on
          OpenSSL version above v1.1.1, not LibreSSL, BoringSSL, or AWS-LC */
       else if((lib == ERR_LIB_SSL) &&

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -103,10 +103,10 @@
 #endif
 
 #if defined(LIBRESSL_VERSION_NUMBER)
-# if (LIBRESSL_VERSION_NUMBER < 0x2090100fL)
+# if LIBRESSL_VERSION_NUMBER < 0x2090100fL /* 2019-04-13 */
 #  error "LibreSSL 2.9.1 or later required"
 # endif
-#elif OPENSSL_VERSION_NUMBER < 0x1000200fL
+#elif OPENSSL_VERSION_NUMBER < 0x1000200fL /* 2015-01-22 */
 # error "OpenSSL 1.0.2 or later required"
 #endif
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -133,7 +133,6 @@
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && /* OpenSSL 1.1.0+ */ \
     !(defined(LIBRESSL_VERSION_NUMBER) && \
       LIBRESSL_VERSION_NUMBER < 0x20700000L)
-#define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER
 #define HAVE_X509_GET0_EXTENSIONS 1 /* added in 1.1.0 -pre1 */
 #define HAVE_OPAQUE_EVP_PKEY 1 /* since 1.1.0 -pre3 */
 #define HAVE_OPAQUE_RSA_DSA_DH 1 /* since 1.1.0 -pre5 */
@@ -5330,25 +5329,19 @@ size_t Curl_ossl_version(char *buffer, size_t size)
   sub[2]='\0';
   sub[1]='\0';
   ssleay_value = OpenSSL_version_num();
-  if(ssleay_value < 0x906000) {
-    ssleay_value = SSLEAY_VERSION_NUMBER;
-    sub[0]='\0';
-  }
-  else {
-    if(ssleay_value&0xff0) {
-      int minor_ver = (ssleay_value >> 4) & 0xff;
-      if(minor_ver > 26) {
-        /* handle extended version introduced for 0.9.8za */
-        sub[1] = (char) ((minor_ver - 1) % 26 + 'a' + 1);
-        sub[0] = 'z';
-      }
-      else {
-        sub[0] = (char) (minor_ver + 'a' - 1);
-      }
+  if(ssleay_value&0xff0) {
+    int minor_ver = (ssleay_value >> 4) & 0xff;
+    if(minor_ver > 26) {
+      /* handle extended version introduced for 0.9.8za */
+      sub[1] = (char) ((minor_ver - 1) % 26 + 'a' + 1);
+      sub[0] = 'z';
     }
-    else
-      sub[0]='\0';
+    else {
+      sub[0] = (char) (minor_ver + 'a' - 1);
+    }
   }
+  else
+    sub[0]='\0';
 
   return msnprintf(buffer, size, "%s/%lx.%lx.%lx%s"
 #ifdef OPENSSL_FIPS

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -262,7 +262,9 @@ typedef unsigned long sslerr_t;
 #endif
 
 /* What API version do we use? */
-#ifndef LIBRESSL_VERSION_NUMBER
+#ifdef LIBRESSL_VERSION_NUMBER
+#define USE_PRE_1_1_API 0
+#else
 #define USE_PRE_1_1_API (OPENSSL_VERSION_NUMBER < 0x10100000L)
 #endif /* !LIBRESSL_VERSION_NUMBER */
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -102,7 +102,7 @@
 #include <openssl/engine.h>
 #endif
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#ifdef LIBRESSL_VERSION_NUMBER
 # if LIBRESSL_VERSION_NUMBER < 0x2090100fL /* 2019-04-13 */
 #  error "LibreSSL 2.9.1 or later required"
 # endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -111,7 +111,7 @@
 # error "OpenSSL 1.0.2a or later required"
 #endif
 
-#if OPENSSL_VERSION_NUMBER >= 0x03000000fL && !defined(OPENSSL_NO_UI_CONSOLE)
+#if OPENSSL_VERSION_NUMBER >= 0x3000000fL && !defined(OPENSSL_NO_UI_CONSOLE)
 #include <openssl/provider.h>
 #include <openssl/store.h>
 /* this is used in the following conditions to make them easier to read */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -102,6 +102,14 @@
 #include <openssl/engine.h>
 #endif
 
+#if defined(LIBRESSL_VERSION_NUMBER)
+# if (LIBRESSL_VERSION_NUMBER < 0x20503000L)
+#  error "LibreSSL 2.5.3 or later required"
+# endif
+#elif OPENSSL_VERSION_NUMBER < 0x1000200fL
+# error "OpenSSL 1.0.2 or later required"
+#endif
+
 #if OPENSSL_VERSION_NUMBER >= 0x03000000fL && !defined(OPENSSL_NO_UI_CONSOLE)
 #include <openssl/provider.h>
 #include <openssl/store.h>

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -262,11 +262,9 @@ typedef unsigned long sslerr_t;
 #endif
 
 /* What API version do we use? */
-#ifdef LIBRESSL_VERSION_NUMBER
-#define USE_PRE_1_1_API 0
-#else
-#define USE_PRE_1_1_API (OPENSSL_VERSION_NUMBER < 0x10100000L)
-#endif /* !LIBRESSL_VERSION_NUMBER */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
+#define HAVE_PRE_1_1_API
+#endif
 
 static CURLcode ossl_certchain(struct Curl_easy *data, SSL *ssl);
 
@@ -640,19 +638,19 @@ static CURLcode ossl_certchain(struct Curl_easy *data, SSL *ssl)
 
 #ifdef USE_OPENSSL
 
-#if USE_PRE_1_1_API
+#ifdef HAVE_PRE_1_1_API
 #define BIO_set_init(x,v)          ((x)->init=(v))
 #define BIO_get_data(x)            ((x)->ptr)
 #define BIO_set_data(x,v)          ((x)->ptr=(v))
 #define BIO_get_shutdown(x)        ((x)->shutdown)
 #define BIO_set_shutdown(x,v)      ((x)->shutdown=(v))
-#endif /* USE_PRE_1_1_API */
+#endif /* HAVE_PRE_1_1_API */
 
 static int ossl_bio_cf_create(BIO *bio)
 {
   BIO_set_shutdown(bio, 1);
   BIO_set_init(bio, 1);
-#if USE_PRE_1_1_API
+#ifdef HAVE_PRE_1_1_API
   bio->num = -1;
 #endif
   BIO_set_data(bio, NULL);
@@ -769,7 +767,7 @@ static int ossl_bio_cf_in_read(BIO *bio, char *buf, int blen)
   return (int)nread;
 }
 
-#if USE_PRE_1_1_API
+#ifdef HAVE_PRE_1_1_API
 
 static BIO_METHOD ossl_bio_cf_meth_1_0 = {
   BIO_TYPE_MEM,

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -106,8 +106,8 @@
 # if LIBRESSL_VERSION_NUMBER < 0x2090100fL /* 2019-04-13 */
 #  error "LibreSSL 2.9.1 or later required"
 # endif
-#elif OPENSSL_VERSION_NUMBER < 0x1000200fL /* 2015-01-22 */
-# error "OpenSSL 1.0.2 or later required"
+#elif OPENSSL_VERSION_NUMBER < 0x1000201fL /* 2015-03-19 */
+# error "OpenSSL 1.0.2a or later required"
 #endif
 
 #if OPENSSL_VERSION_NUMBER >= 0x03000000fL && !defined(OPENSSL_NO_UI_CONSOLE)

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -139,7 +139,7 @@
 #include <openssl/ui.h>
 #endif
 
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) /* OpenSSL 1.1.0+ and LibreSSL */
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L /* OpenSSL 1.1.0+ and LibreSSL */
 #define HAVE_X509_GET0_EXTENSIONS 1 /* added in 1.1.0 -pre1 */
 #define HAVE_OPAQUE_EVP_PKEY 1 /* since 1.1.0 -pre3 */
 #define HAVE_OPAQUE_RSA_DSA_DH 1 /* since 1.1.0 -pre5 */
@@ -1803,7 +1803,7 @@ static CURLcode x509_name_oneline(X509_NAME *a, struct dynbuf *d)
  */
 static int ossl_init(void)
 {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
   const uint64_t flags =
 #ifdef OPENSSL_INIT_ENGINE_ALL_BUILTIN
     /* not present in BoringSSL */
@@ -1853,7 +1853,7 @@ static int ossl_init(void)
 /* Global cleanup */
 static void ossl_cleanup(void)
 {
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
   /* OpenSSL 1.1 deprecates all these cleanup functions and
      turns them into no-ops in OpenSSL 1.0 compatibility mode */
 #else

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -103,8 +103,8 @@
 #endif
 
 #if defined(LIBRESSL_VERSION_NUMBER)
-# if (LIBRESSL_VERSION_NUMBER < 0x2070100fL)
-#  error "LibreSSL 2.7.1 or later required"
+# if (LIBRESSL_VERSION_NUMBER < 0x2090100fL)
+#  error "LibreSSL 2.9.1 or later required"
 # endif
 #elif OPENSSL_VERSION_NUMBER < 0x1000200fL
 # error "OpenSSL 1.0.2 or later required"
@@ -1187,8 +1187,6 @@ static int
 use_certificate_chain_blob(SSL_CTX *ctx, const struct curl_blob *blob,
                            const char *key_passwd)
 {
-#if !(defined(LIBRESSL_VERSION_NUMBER) && \
-  (LIBRESSL_VERSION_NUMBER < 0x2090100fL)) /* LibreSSL 2.9.1 or later */
   int ret = 0;
   X509 *x = NULL;
   void *passwd_callback_userdata = (void *)key_passwd;
@@ -1240,12 +1238,6 @@ end:
   X509_free(x);
   BIO_free(in);
   return ret;
-#else
-  (void)ctx; /* unused */
-  (void)blob; /* unused */
-  (void)key_passwd; /* unused */
-  return 0;
-#endif
 }
 
 static


### PR DESCRIPTION
Require OpenSSL 1.0.2a (2015-03-19) or LibreSSL 2.9.1 (2019-04-13).

---

w/o whitespace: https://github.com/curl/curl/pull/16104/files?w=1
