### PR TITLE
openssl: define `HAVE_KEYLOG_CALLBACK` before use

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -207,18 +207,6 @@
 #define FREE_PKEY_PARAM_BIGNUM(name)
 #endif
 
-/*
- * Whether SSL_CTX_set_keylog_callback is available.
- * OpenSSL: supported since 1.1.1 https://github.com/openssl/openssl/pull/2287
- * BoringSSL: supported since d28f59c27bac (committed 2015-11-19)
- * LibreSSL: not supported. 3.5.0+ has a stub function that does nothing.
- */
-#if (OPENSSL_VERSION_NUMBER >= 0x10101000L && \
-     !defined(LIBRESSL_VERSION_NUMBER)) || \
-    defined(OPENSSL_IS_BORINGSSL)
-#define HAVE_KEYLOG_CALLBACK
-#endif
-
 /* Whether SSL_CTX_set_ciphersuites is available.
  * OpenSSL: supported since 1.1.1 (commit a53b5be6a05)
  * BoringSSL: no

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -31,10 +31,23 @@
  * This header should only be needed to get included by vtls.c, openssl.c
  * and ngtcp2.c
  */
+#include <openssl/opensslv.h>
 #include <openssl/ossl_typ.h>
 #include <openssl/ssl.h>
 
 #include "urldata.h"
+
+/*
+ * Whether SSL_CTX_set_keylog_callback is available.
+ * OpenSSL: supported since 1.1.1 https://github.com/openssl/openssl/pull/2287
+ * BoringSSL: supported since d28f59c27bac (committed 2015-11-19)
+ * LibreSSL: not supported. 3.5.0+ has a stub function that does nothing.
+ */
+#if (OPENSSL_VERSION_NUMBER >= 0x10101000L && \
+     !defined(LIBRESSL_VERSION_NUMBER)) || \
+    defined(OPENSSL_IS_BORINGSSL)
+#define HAVE_KEYLOG_CALLBACK
+#endif
 
 struct ssl_peer;
 


### PR DESCRIPTION
Before this patch this macro was used in `vtls/openssl.h` without
setting it first, causing the `keylog_done` member be present in
struct `ossl_ctx` while the code did not use it.

Follow-up to 3210101088dfa3d6a125d213226b092f2f866722 #13172