### PR TITLE
Fix asyn-thread HTTPS resolution and a memory leak in asyn-ares

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -435,8 +435,9 @@ CURLcode Curl_resolver_is_resolved(struct Curl_easy *data,
         struct Curl_https_rrinfo *lhrr =
           Curl_memdup(&res->hinfo, sizeof(struct Curl_https_rrinfo));
         if(!lhrr)
-          return CURLE_OUT_OF_MEMORY;
-        (*dns)->hinfo = lhrr;
+          result = CURLE_OUT_OF_MEMORY;
+        else
+          (*dns)->hinfo = lhrr;
       }
 #endif
     }

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -64,6 +64,7 @@
 #include "inet_ntop.h"
 #include "curl_threads.h"
 #include "connect.h"
+#include "strdup.h"
 
 #ifdef USE_ARES
 #include <ares.h>
@@ -619,6 +620,17 @@ CURLcode Curl_resolver_is_resolved(struct Curl_easy *data,
       destroy_async_data(&data->state.async);
       return result;
     }
+#ifdef USE_HTTPSRR_ARES
+    {
+      struct Curl_https_rrinfo *lhrr =
+        Curl_memdup(&td->hinfo, sizeof(struct Curl_https_rrinfo));
+      if(!lhrr) {
+        destroy_async_data(&data->state.async);
+        return CURLE_OUT_OF_MEMORY;
+      }
+      data->state.async.dns->hinfo = lhrr;
+    }
+#endif
     destroy_async_data(&data->state.async);
     *entry = data->state.async.dns;
   }


### PR DESCRIPTION
asyn-thread was forgetting to copy the actual HTTPS info into the result and asyn-ares had a minor memory leak that only existed in another OOM path.