### PR TITLE
gitignore, use fnmatch patterns

### DIFF
--- a/tests/http/clients/.gitignore
+++ b/tests/http/clients/.gitignore
@@ -2,4 +2,12 @@
 #
 # SPDX-License-Identifier: curl
 
-/[0-9a-z_-]+
+h2-serverpush
+hx-download
+hx-upload
+ws-data
+ws-pingpong
+h2-upgrade-extreme
+tls-session-reuse
+h2-pausing
+upload-pausing

--- a/tests/libtest/.gitignore
+++ b/tests/libtest/.gitignore
@@ -2,6 +2,6 @@
 #
 # SPDX-License-Identifier: curl
 
-/lib[0-9a-z_-]+
+/lib[0-9a-z_-]*
 lib1521.c
 libtest_bundle.c

--- a/tests/server/.gitignore
+++ b/tests/server/.gitignore
@@ -2,4 +2,12 @@
 #
 # SPDX-License-Identifier: curl
 
-[0-9a-z_-]+
+getpart
+resolve
+rtspd
+sockfilt
+sws
+tftpd
+socksd
+disabled
+mqttd


### PR DESCRIPTION
replace the new regular expressions, which are not supported in .gitignore with the previous fnmatch patterns.

refs #16112