### PR TITLE
ws-docs: Extend WebSocket documentation

### DIFF
--- a/docs/libcurl/curl_ws_recv.md
+++ b/docs/libcurl/curl_ws_recv.md
@@ -30,19 +30,31 @@ CURLcode curl_ws_recv(CURL *curl, void *buffer, size_t buflen,
 
 # DESCRIPTION
 
-Retrieves as much as possible of a received WebSocket data fragment into the
-**buffer**, but not more than **buflen** bytes. *recv* is set to the
+Retrieves as much as possible of a received WebSocket frame into the
+*buffer*, but not more than *buflen* bytes. *recv* is set to the
 number of bytes actually stored.
-
-If there is more fragment data to deliver than what fits in the provided
-*buffer*, libcurl returns a full buffer and the application needs to call this
-function again to continue draining the buffer.
 
 If the function call is successful, the *meta* pointer gets set to point to a
 *const struct curl_ws_frame* that contains information about the received
 data. That struct must not be freed and its contents must not be relied upon
-anymore once another WebSocket function is called. See the curl_ws_meta(3) for
+anymore once another WebSocket function is called. See curl_ws_meta(3) for more
 details on that struct.
+
+The application must check `meta->bytesleft` to determine whether the complete
+frame has been received. If more payload is pending, the application must call
+this function again with an updated *buffer* and *buflen* to resume receiving.
+This may for example happen when the data does not fit into the provided buffer
+or when not all frame data has been delivered over the network yet.
+
+If the application wants to read the metadata without consuming any payload,
+it may call this function with a *buflen* of zero. Setting *buffer* to a NULL
+pointer is permitted in this case. Note that frames without payload are consumed
+by this action.
+
+If the received message consists of multiple fragments, the *CURLWS_CONT* bit
+is set in all frames except the final one. The application is responsible for
+reassembling fragmented messages. See curl_ws_meta(3) for more details on
+*CURLWS_CONT*.
 
 # %PROTOCOLS%
 
@@ -51,15 +63,34 @@ details on that struct.
 ~~~c
 int main(void)
 {
-  size_t rlen;
+  size_t recv;
+  size_t recv_total = 0;
   const struct curl_ws_frame *meta;
   char buffer[256];
+  CURLcode res;
   CURL *curl = curl_easy_init();
-  if(curl) {
-    CURLcode res = curl_ws_recv(curl, buffer, sizeof(buffer), &rlen, &meta);
-    if(res)
-      printf("error: %s\n", curl_easy_strerror(res));
-  }
+
+  curl_easy_setopt(curl, CURLOPT_URL, "wss://example.com/");
+  curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L);
+  curl_easy_perform(curl);
+
+  /* Note: This example neglects fragmented messages. (CURLWS_CONT bit)
+           A real application must handle them appropriately. */
+
+  do {
+    res = curl_ws_recv(curl, buffer + recv_total, sizeof(buffer) - recv_total,
+                       &recv, &meta);
+    recv_total += recv;
+    if(meta->bytesleft > sizeof(buffer) - recv_total)
+      res = CURLE_TOO_LARGE;
+    if(res == CURLE_AGAIN) {
+      /* .. wait for socket here ... */
+      res = CURLE_OK;
+    }
+  } while(res && meta->bytesleft > 0);
+
+  curl_easy_cleanup(curl);
+  return (int)res;
 }
 ~~~
 
@@ -79,3 +110,8 @@ Returns **CURLE_GOT_NOTHING** if the associated connection is closed.
 Instead of blocking, the function returns **CURLE_AGAIN**. The correct
 behavior is then to wait for the socket to signal readability before calling
 this function again.
+
+Any other non-zero return value indicates an error. See the libcurl-errors(3)
+man page for the full list with descriptions.
+
+Returns **CURLE_GOT_NOTHING** if the associated connection is closed.

--- a/docs/libcurl/curl_ws_send.md
+++ b/docs/libcurl/curl_ws_send.md
@@ -31,25 +31,30 @@ CURLcode curl_ws_send(CURL *curl, const void *buffer, size_t buflen,
 
 # DESCRIPTION
 
-Send the specific message fragment over an established WebSocket
-connection. The *buffer* holds the data to send and it is *buflen*
-number of payload bytes in that memory area.
+Send the specific message chunk over an established WebSocket
+connection. *buffer* must point to a valid memory location containing
+(at least) *buflen* bytes of payload memory.
 
-*sent* is returned as the number of payload bytes actually sent.
+*sent* is set to the number of payload bytes actually sent. If the return value
+is **CURLE_OK** but *sent* is less than the given *buflen*, libcurl was unable
+to consume the complete payload in a single call. In this case the application
+must call this function again until all payload is processed. *buffer* and
+*buflen* must be updated on every following invocation to only point to the
+remaining piece of the payload.
 
-To send a (huge) fragment using multiple calls with partial content per
-invoke, set the *CURLWS_OFFSET* bit and the *fragsize* argument as the
-total expected size for the first part, then set the *CURLWS_OFFSET* with
-a zero *fragsize* for the following parts.
+*fragsize* should always be set to zero unless a (huge) frame shall be sent
+using multiple calls with partial content per call explicitly. In that
+case you must set the *CURLWS_OFFSET* bit and set the *fragsize* as documented
+in the section on *CURLWS_OFFSET* below.
 
-If not sending a partial fragment or if this is raw mode, *fragsize*
-should be set to zero.
+*flags* must contain at least one flag indicating the type of the message.
+To send a fragmented message consisting of multiple frames, additionally set
+the *CURLWS_CONT* bit in all frames except the final one.
 
-If **CURLWS_RAW_MODE** is enabled in CURLOPT_WS_OPTIONS(3), the
-**flags** argument should be set to 0.
+For more details on the supported flags see below and in curl_ws_meta(3).
 
-To send a message consisting of multiple frames, set the *CURLWS_CONT* bit
-in all frames except the final one.
+If *CURLWS_RAW_MODE* is enabled in CURLOPT_WS_OPTIONS(3), the
+*flags* argument should be set to 0.
 
 Warning: while it is possible to invoke this function from a callback,
 such a call is blocking in this situation, e.g. only returns after all data
@@ -57,39 +62,15 @@ has been sent or an error is encountered.
 
 # FLAGS
 
-## CURLWS_TEXT
-
-The buffer contains text data. Note that this makes a difference to WebSocket
-but libcurl itself does not make any verification of the content or
-precautions that you actually send valid UTF-8 content.
-
-## CURLWS_BINARY
-
-This is binary data.
-
-## CURLWS_CONT
-
-This is not the final fragment of the message, which implies that there is
-another fragment coming as part of the same message where this bit is not set.
-
-## CURLWS_CLOSE
-
-Close this transfer.
-
-## CURLWS_PING
-
-This is a ping.
-
-## CURLWS_PONG
-
-This is a pong.
+Supports all flags documented in curl_ws_meta(3) and additionally the following
+flags.
 
 ## CURLWS_OFFSET
 
-The provided data is only a partial fragment and there is more coming in a
+The provided data is only a partial frame and there is more coming in a
 following call to *curl_ws_send()*. When sending only a piece of the
-fragment like this, the *fragsize* must be provided with the total
-expected fragment size in the first call and it needs to be zero in subsequent
+frame like this, the *fragsize* must be provided with the total
+expected frame size in the first call and must be zero in all subsequent
 calls.
 
 # %PROTOCOLS%
@@ -99,18 +80,29 @@ calls.
 ~~~c
 #include <string.h> /* for strlen */
 
-const char *send_payload = "magic";
+const char *buffer = "magic";
 
 int main(void)
 {
   size_t sent;
+  size_t sent_total = 0;
   CURLcode res;
   CURL *curl = curl_easy_init();
+
   curl_easy_setopt(curl, CURLOPT_URL, "wss://example.com/");
   curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L);
   curl_easy_perform(curl);
-  res = curl_ws_send(curl, send_payload, strlen(send_payload), &sent, 0,
-                     CURLWS_PING);
+
+  while (res && buflen > 0) {
+    res = curl_ws_send(curl, buffer + sent_total, strlen(buffer) - sent_total,
+                       &sent, 0, CURLWS_PING);
+    sent_total += sent;
+    if(res == CURLE_AGAIN) {
+      /* .. wait for socket here ... */
+      res = CURLE_OK;
+    }
+  }
+
   curl_easy_cleanup(curl);
   return (int)res;
 }
@@ -126,3 +118,10 @@ CURLE_OK (0) means everything was OK, non-zero means an error occurred, see
 libcurl-errors(3). If CURLOPT_ERRORBUFFER(3) was set with curl_easy_setopt(3)
 there can be an error message stored in the error buffer when non-zero is
 returned.
+
+Instead of blocking, the function returns **CURLE_AGAIN**. The correct
+behavior is then to wait for the socket to signal readability before calling
+this function again.
+
+Any other non-zero return value indicates an error. See the libcurl-errors(3)
+man page for the full list with descriptions.


### PR DESCRIPTION
Tried to clean up and extend the documentation on the WebSocket-API a little.

There are some other information missing from the docs in my opinion, but since they are not relevant for my use case I wasn't able to investigate further. So see this as a suggestion for an TODO list of doc improvements if you will:
* How does CURLWS_RAW_MODE affect curl_ws_meta/curl_ws_recv/curl_ws_send?
* Can curl_ws_send be used if CURLOPT_WRITEFUNCTION was set instead of CURLOPT_CONNECT_ONLY?