### PR TITLE
test1960: don't close the socket too early

### DIFF
--- a/tests/libtest/lib1960.c
+++ b/tests/libtest/lib1960.c
@@ -121,9 +121,9 @@ CURLcode test(char *URL)
   res = curl_easy_perform(curl);
 
 test_cleanup:
+  curl_easy_cleanup(curl);
   if(client_fd != CURL_SOCKET_BAD)
     sclose(client_fd);
-  curl_easy_cleanup(curl);
   curl_global_cleanup();
 
   return res;


### PR DESCRIPTION
The socket was closed while the handle was still in use, so
curl_easy_cleanup ended up setting nonblocking mode on a closed handle.

Closes #16123