### PR TITLE
GHA: tidy up `apt` commands

### DIFF
--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -47,7 +47,7 @@ jobs:
   #        run: |
   #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
   #          sudo apt-get update
-  #          sudo apt-get install -y \
+  #          sudo apt-get install \
   #            python3-proselint
   #
   #      # config file help: https://github.com/amperser/proselint/

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -47,7 +47,7 @@ jobs:
   #        run: |
   #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
   #          sudo apt-get update -y
-  #          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+  #          sudo apt-get install -y \
   #            python3-proselint
   #
   #      # config file help: https://github.com/amperser/proselint/

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -46,8 +46,8 @@ jobs:
   #      - name: install prereqs
   #        run: |
   #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-  #          sudo apt-get --option Dpkg::Use-Pty=0 update
-  #          sudo apt-get --option Dpkg::Use-Pty=0 install python3-proselint
+  #          sudo apt-get -o Dpkg::Use-Pty=0 update
+  #          sudo apt-get -o Dpkg::Use-Pty=0 install python3-proselint
   #
   #      # config file help: https://github.com/amperser/proselint/
   #      - name: create proselint config

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -47,8 +47,7 @@ jobs:
   #        run: |
   #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
   #          sudo apt-get --option Dpkg::Use-Pty=0 update
-  #          sudo apt-get --option Dpkg::Use-Pty=0 install \
-  #            python3-proselint
+  #          sudo apt-get --option Dpkg::Use-Pty=0 install python3-proselint
   #
   #      # config file help: https://github.com/amperser/proselint/
   #      - name: create proselint config

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -46,7 +46,7 @@ jobs:
   #      - name: install prereqs
   #        run: |
   #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-  #          sudo apt-get update -y
+  #          sudo apt-get update
   #          sudo apt-get install -y \
   #            python3-proselint
   #

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -46,8 +46,8 @@ jobs:
   #      - name: install prereqs
   #        run: |
   #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-  #          sudo apt-get update
-  #          sudo apt-get install \
+  #          sudo apt-get --option Dpkg::Use-Pty=0 update
+  #          sudo apt-get --option Dpkg::Use-Pty=0 install \
   #            python3-proselint
   #
   #      # config file help: https://github.com/amperser/proselint/

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install \
             codespell python3-pip python3-networkx python3-pydot python3-yaml \
             python3-toml python3-markupsafe python3-jinja2 python3-tabulate \
             python3-typing-extensions python3-libcst python3-impacket \

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -56,8 +56,8 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get --option Dpkg::Use-Pty=0 update
-          sudo apt-get --option Dpkg::Use-Pty=0 install \
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install \
             codespell python3-pip python3-networkx python3-pydot python3-yaml \
             python3-toml python3-markupsafe python3-jinja2 python3-tabulate \
             python3-typing-extensions python3-libcst python3-impacket \

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -56,7 +56,7 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update -y
+          sudo apt-get update
           sudo apt-get install -y \
             codespell python3-pip python3-networkx python3-pydot python3-yaml \
             python3-toml python3-markupsafe python3-jinja2 python3-tabulate \

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -56,8 +56,8 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install \
+          sudo apt-get --option Dpkg::Use-Pty=0 update
+          sudo apt-get --option Dpkg::Use-Pty=0 install \
             codespell python3-pip python3-networkx python3-pydot python3-yaml \
             python3-toml python3-markupsafe python3-jinja2 python3-tabulate \
             python3-typing-extensions python3-libcst python3-impacket \

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+          sudo apt-get install -y \
             codespell python3-pip python3-networkx python3-pydot python3-yaml \
             python3-toml python3-markupsafe python3-jinja2 python3-tabulate \
             python3-typing-extensions python3-libcst python3-impacket \

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -112,7 +112,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --option Dpkg::Use-Pty=0 install mingw-w64
+        run: sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -112,7 +112,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --quiet 1 --option Dpkg::Use-Pty=0 install mingw-w64
+        run: sudo apt-get --option Dpkg::Use-Pty=0 install mingw-w64
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -112,7 +112,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --option Dpkg::Use-Pty=0 install mingw-w64
+        run: sudo apt-get --quiet --option Dpkg::Use-Pty=0 install mingw-w64
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -112,7 +112,9 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install mingw-w64
+        run: |
+          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+            mingw-w64
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -112,7 +112,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --quiet --option Dpkg::Use-Pty=0 install mingw-w64
+        run: sudo apt-get --quiet 1 --option Dpkg::Use-Pty=0 install mingw-w64
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -112,7 +112,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends mingw-w64
+        run: sudo apt-get install -y --no-install-suggests --no-install-recommends mingw-w64
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -112,9 +112,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: |
-          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
-            mingw-w64
+        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends mingw-w64
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -112,7 +112,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get install -y --no-install-suggests --no-install-recommends mingw-w64
+        run: sudo apt-get --option Dpkg::Use-Pty=0 install mingw-w64
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -41,8 +41,7 @@ jobs:
         name: 'make'
 
       - name: 'maketgz'
-        run: |
-          SOURCE_DATE_EPOCH=1711526400 ./scripts/maketgz 99.98.97
+        run: SOURCE_DATE_EPOCH=1711526400 ./scripts/maketgz 99.98.97
 
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
         with:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: 'remove preinstalled curl libcurl4{-doc}'
-        run: sudo apt-get purge curl libcurl4 libcurl4-doc
+        run: sudo apt-get --option Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
 
       - name: 'autoreconf'
         run: autoreconf -fi
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
 
       - name: 'remove preinstalled curl libcurl4{-doc}'
-        run: sudo apt-get purge curl libcurl4 libcurl4-doc
+        run: sudo apt-get --option Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
 
       - name: 'generate release tarballs'
         run: ./scripts/dmaketgz 9.10.11

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: 'remove preinstalled curl libcurl4{-doc}'
-        run: sudo apt-get --option Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
+        run: sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
 
       - name: 'autoreconf'
         run: autoreconf -fi
@@ -148,7 +148,7 @@ jobs:
           persist-credentials: false
 
       - name: 'remove preinstalled curl libcurl4{-doc}'
-        run: sudo apt-get --option Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
+        run: sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
 
       - name: 'generate release tarballs'
         run: ./scripts/dmaketgz 9.10.11

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -28,17 +28,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: sudo apt-get purge curl libcurl4 libcurl4-doc
-        name: 'remove preinstalled curl libcurl4{-doc}'
+      - name: 'remove preinstalled curl libcurl4{-doc}'
+        run: sudo apt-get purge curl libcurl4 libcurl4-doc
 
-      - run: autoreconf -fi
-        name: 'autoreconf'
+      - name: 'autoreconf'
+        run: autoreconf -fi
 
-      - run: ./configure --without-ssl --without-libpsl
-        name: 'configure'
+      - name: 'configure'
+        run: ./configure --without-ssl --without-libpsl
 
-      - run: make V=1
-        name: 'make'
+      - name: 'make'
+        run: make V=1
 
       - name: 'maketgz'
         run: SOURCE_DATE_EPOCH=1711526400 ./scripts/maketgz 99.98.97
@@ -49,7 +49,8 @@ jobs:
           path: 'curl-99.98.97.tar.gz'
           retention-days: 1
 
-      - run: |
+      - name: 'verify in-tree configure build including install'
+        run: |
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
@@ -61,7 +62,6 @@ jobs:
           # basic check of the installed files
           bash scripts/installcheck.sh $HOME/temp
           rm -rf curl-99.98.97
-        name: 'verify in-tree configure build including install'
 
   verify-out-of-tree-docs:
     runs-on: ubuntu-latest
@@ -72,7 +72,8 @@ jobs:
         with:
           name: 'release-tgz'
 
-      - run: |
+      - name: 'verify out-of-tree configure build including docs'
+        run: |
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           touch curl-99.98.97/docs/{cmdline-opts,libcurl}/Makefile.inc
@@ -84,7 +85,6 @@ jobs:
           popd
           rm -rf build
           rm -rf curl-99.98.97
-        name: 'verify out-of-tree configure build including docs'
 
   verify-out-of-tree-autotools-debug:
     runs-on: ubuntu-latest
@@ -95,7 +95,8 @@ jobs:
         with:
           name: 'release-tgz'
 
-      - run: |
+      - name: 'verify out-of-tree autotools debug build'
+        run: |
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
@@ -105,7 +106,6 @@ jobs:
           make -j5
           make -j5 test-ci
           make -j5 install
-        name: 'verify out-of-tree autotools debug build'
 
   verify-out-of-tree-cmake:
     runs-on: ubuntu-latest
@@ -116,13 +116,13 @@ jobs:
         with:
           name: 'release-tgz'
 
-      - run: |
+      - name: 'verify out-of-tree cmake build'
+        run: |
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
           cmake -B build -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF
           make -C build -j5
-        name: 'verify out-of-tree cmake build'
 
   missing-files:
     runs-on: ubuntu-latest
@@ -147,11 +147,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: sudo apt-get purge curl libcurl4 libcurl4-doc
-        name: 'remove preinstalled curl libcurl4{-doc}'
+      - name: 'remove preinstalled curl libcurl4{-doc}'
+        run: sudo apt-get purge curl libcurl4 libcurl4-doc
 
-      - run: ./scripts/dmaketgz 9.10.11
-        name: 'generate release tarballs'
+      - name: 'generate release tarballs'
+        run: ./scripts/dmaketgz 9.10.11
 
       - name: 'verify release tarballs'
         run: |

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: sudo apt-get purge -y curl libcurl4 libcurl4-doc
+      - run: sudo apt-get purge curl libcurl4 libcurl4-doc
         name: 'remove preinstalled curl libcurl4{-doc}'
 
       - run: autoreconf -fi
@@ -148,7 +148,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - run: sudo apt-get purge -y curl libcurl4 libcurl4-doc
+      - run: sudo apt-get purge curl libcurl4 libcurl4-doc
         name: 'remove preinstalled curl libcurl4{-doc}'
 
       - run: ./scripts/dmaketgz 9.10.11

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -129,8 +129,8 @@ jobs:
         if: steps.settings.outputs.needs-build == 'true'
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install \
+          sudo apt-get --option Dpkg::Use-Pty=0 update
+          sudo apt-get --option Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
@@ -289,8 +289,8 @@ jobs:
       - name: 'install prereqs'
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install \
+          sudo apt-get --option Dpkg::Use-Pty=0 update
+          sudo apt-get --option Dpkg::Use-Pty=0 install \
             libtool autoconf automake ninja-build pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -129,8 +129,8 @@ jobs:
         if: steps.settings.outputs.needs-build == 'true'
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get --option Dpkg::Use-Pty=0 update
-          sudo apt-get --option Dpkg::Use-Pty=0 install \
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
@@ -289,8 +289,8 @@ jobs:
       - name: 'install prereqs'
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get --option Dpkg::Use-Pty=0 update
-          sudo apt-get --option Dpkg::Use-Pty=0 install \
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install \
             libtool autoconf automake ninja-build pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -129,7 +129,7 @@ jobs:
         if: steps.settings.outputs.needs-build == 'true'
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update -y
+          sudo apt-get update
           sudo apt-get install -y \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
@@ -289,7 +289,7 @@ jobs:
       - name: 'install prereqs'
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update -y
+          sudo apt-get update
           sudo apt-get install -y \
             libtool autoconf automake ninja-build pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
@@ -290,7 +290,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install \
             libtool autoconf automake ninja-build pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+          sudo apt-get install -y \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
@@ -290,7 +290,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+          sudo apt-get install -y \
             libtool autoconf automake ninja-build pkgconf stunnel4 \
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -60,14 +60,14 @@ jobs:
         # Remember, this shell is dash, not bash
         run: |
           sed -E -i -e s@[a-z]+\.debian\.org/@archive.debian.org/debian-archive/@ -e '/ stretch-updates /d' /etc/apt/sources.list
-          apt-get --option Dpkg::Use-Pty=0 update
+          apt-get -o Dpkg::Use-Pty=0 update
           # See comment above if this fails after 2025-05-20
-          apt-get --option Dpkg::Use-Pty=0 install -y --no-install-suggests --no-install-recommends httrack
+          apt-get -o Dpkg::Use-Pty=0 install -y --no-install-suggests --no-install-recommends httrack
           httrack --get https://deb.freexian.com/extended-lts/pool/main/f/freexian-archive-keyring/freexian-archive-keyring_2022.06.08_all.deb
           dpkg -i freexian-archive-keyring_2022.06.08_all.deb
           echo 'deb http://deb.freexian.com/extended-lts stretch-lts main contrib non-free' | tee /etc/apt/sources.list.d/extended-lts.list
-          apt-get --option Dpkg::Use-Pty=0 update
-          apt-get --option Dpkg::Use-Pty=0 install -y --no-install-suggests --no-install-recommends cmake make automake autoconf libtool gcc pkg-config libpsl-dev libzstd-dev zlib1g-dev libssl1.0-dev libssh-dev libssh2-1-dev libc-ares-dev heimdal-dev libldap2-dev librtmp-dev stunnel4 groff
+          apt-get -o Dpkg::Use-Pty=0 update
+          apt-get -o Dpkg::Use-Pty=0 install -y --no-install-suggests --no-install-recommends cmake make automake autoconf libtool gcc pkg-config libpsl-dev libzstd-dev zlib1g-dev libssl1.0-dev libssh-dev libssh2-1-dev libc-ares-dev heimdal-dev libldap2-dev librtmp-dev stunnel4 groff
           # GitHub's actions/checkout needs a newer glibc. This one is the
           # latest available for buster, the next stable release after stretch.
           httrack --get https://security.debian.org/debian-security/pool/updates/main/g/glibc/libc6_2.28-10+deb10u4_amd64.deb

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -60,14 +60,14 @@ jobs:
         # Remember, this shell is dash, not bash
         run: |
           sed -E -i -e s@[a-z]+\.debian\.org/@archive.debian.org/debian-archive/@ -e '/ stretch-updates /d' /etc/apt/sources.list
-          apt-get update
+          apt-get --option Dpkg::Use-Pty=0 update
           # See comment above if this fails after 2025-05-20
-          apt-get install -y --no-install-suggests --no-install-recommends httrack
+          apt-get --option Dpkg::Use-Pty=0 install -y --no-install-suggests --no-install-recommends httrack
           httrack --get https://deb.freexian.com/extended-lts/pool/main/f/freexian-archive-keyring/freexian-archive-keyring_2022.06.08_all.deb
           dpkg -i freexian-archive-keyring_2022.06.08_all.deb
           echo 'deb http://deb.freexian.com/extended-lts stretch-lts main contrib non-free' | tee /etc/apt/sources.list.d/extended-lts.list
-          apt-get update
-          apt-get install -y --no-install-suggests --no-install-recommends cmake make automake autoconf libtool gcc pkg-config libpsl-dev libzstd-dev zlib1g-dev libssl1.0-dev libssh-dev libssh2-1-dev libc-ares-dev heimdal-dev libldap2-dev librtmp-dev stunnel4 groff
+          apt-get --option Dpkg::Use-Pty=0 update
+          apt-get --option Dpkg::Use-Pty=0 install -y --no-install-suggests --no-install-recommends cmake make automake autoconf libtool gcc pkg-config libpsl-dev libzstd-dev zlib1g-dev libssl1.0-dev libssh-dev libssh2-1-dev libc-ares-dev heimdal-dev libldap2-dev librtmp-dev stunnel4 groff
           # GitHub's actions/checkout needs a newer glibc. This one is the
           # latest available for buster, the next stable release after stretch.
           httrack --get https://security.debian.org/debian-security/pool/updates/main/g/glibc/libc6_2.28-10+deb10u4_amd64.deb

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -302,7 +302,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+          sudo apt-get install -y \
             libtool autoconf automake pkgconf ninja-build \
             ${{ matrix.build.install_steps != 'skipall' && matrix.build.install_steps != 'skiprun' && 'stunnel4' || '' }} \
             libpsl-dev libbrotli-dev libzstd-dev \
@@ -315,7 +315,7 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+          sudo apt-get install -y \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386 \
             ${{ matrix.build.install_packages }}
@@ -324,7 +324,7 @@ jobs:
       - name: 'install prereqs for pytest'
         if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+          sudo apt-get install -y \
             apache2 apache2-dev libnghttp2-dev vsftpd
 
       - name: 'install dependencies'
@@ -584,7 +584,7 @@ jobs:
         run: |
           curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt-get install -y --no-install-suggests --no-install-recommends intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -583,7 +583,7 @@ jobs:
         if: contains(matrix.build.install_steps, 'intel')
         run: |
           cd /tmp
-          curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo apt-key add -
+          curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
             intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -585,7 +585,8 @@ jobs:
           cd /tmp
           curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo apt-key add -
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt-get install -y --no-install-recommends intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y --no-install-suggests --no-install-recommends \
+            intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -301,7 +301,7 @@ jobs:
         if: matrix.build.container == null && !contains(matrix.build.name, 'i686')
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update -y
+          sudo apt-get update
           sudo apt-get install -y \
             libtool autoconf automake pkgconf ninja-build \
             ${{ matrix.build.install_steps != 'skipall' && matrix.build.install_steps != 'skiprun' && 'stunnel4' || '' }} \
@@ -314,7 +314,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386
-          sudo apt-get update -y
+          sudo apt-get update
           sudo apt-get install -y \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386 \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -582,7 +582,7 @@ jobs:
       - name: 'install Intel compilers'
         if: contains(matrix.build.install_steps, 'intel')
         run: |
-          curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc
+          curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get install -y --no-install-suggests --no-install-recommends \
             intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -301,8 +301,8 @@ jobs:
         if: matrix.build.container == null && !contains(matrix.build.name, 'i686')
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install \
+          sudo apt-get --option Dpkg::Use-Pty=0 update
+          sudo apt-get --option Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf ninja-build \
             ${{ matrix.build.install_steps != 'skipall' && matrix.build.install_steps != 'skiprun' && 'stunnel4' || '' }} \
             libpsl-dev libbrotli-dev libzstd-dev \
@@ -314,8 +314,8 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386
-          sudo apt-get update
-          sudo apt-get install \
+          sudo apt-get --option Dpkg::Use-Pty=0 update
+          sudo apt-get --option Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386 \
             ${{ matrix.build.install_packages }}
@@ -324,7 +324,7 @@ jobs:
       - name: 'install prereqs for pytest'
         if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          sudo apt-get install \
+          sudo apt-get --option Dpkg::Use-Pty=0 install \
             apache2 apache2-dev libnghttp2-dev vsftpd
 
       - name: 'install dependencies'
@@ -584,7 +584,7 @@ jobs:
         run: |
           curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get --option Dpkg::Use-Pty=0 install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -301,8 +301,8 @@ jobs:
         if: matrix.build.container == null && !contains(matrix.build.name, 'i686')
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get --option Dpkg::Use-Pty=0 update
-          sudo apt-get --option Dpkg::Use-Pty=0 install \
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf ninja-build \
             ${{ matrix.build.install_steps != 'skipall' && matrix.build.install_steps != 'skiprun' && 'stunnel4' || '' }} \
             libpsl-dev libbrotli-dev libzstd-dev \
@@ -314,8 +314,8 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386
-          sudo apt-get --option Dpkg::Use-Pty=0 update
-          sudo apt-get --option Dpkg::Use-Pty=0 install \
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386 \
             ${{ matrix.build.install_packages }}
@@ -324,7 +324,7 @@ jobs:
       - name: 'install prereqs for pytest'
         if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          sudo apt-get --option Dpkg::Use-Pty=0 install apache2 apache2-dev libnghttp2-dev vsftpd
+          sudo apt-get -o Dpkg::Use-Pty=0 install apache2 apache2-dev libnghttp2-dev vsftpd
 
       - name: 'install dependencies'
         if: startsWith(matrix.build.container, 'alpine')
@@ -583,7 +583,7 @@ jobs:
         run: |
           curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt-get --option Dpkg::Use-Pty=0 install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get -o Dpkg::Use-Pty=0 install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -437,7 +437,7 @@ jobs:
           cache-name: cache-wolfssh
         with:
           path: ~/wolfssh
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.wolfssl-version }}-${{ env.wolfssh-version }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.wolfssh-version }}-${{ env.wolfssl-version }}
 
       - name: 'build wolfssh'
         if: contains(matrix.build.install_steps, 'wolfssh') && steps.cache-wolfssh.outputs.cache-hit != 'true'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -584,8 +584,7 @@ jobs:
         run: |
           curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt-get install -y --no-install-suggests --no-install-recommends \
-            intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y --no-install-suggests --no-install-recommends intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -582,7 +582,6 @@ jobs:
       - name: 'install Intel compilers'
         if: contains(matrix.build.install_steps, 'intel')
         run: |
-          cd /tmp
           curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get install -y --no-install-suggests --no-install-recommends \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -302,7 +302,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install \
             libtool autoconf automake pkgconf ninja-build \
             ${{ matrix.build.install_steps != 'skipall' && matrix.build.install_steps != 'skiprun' && 'stunnel4' || '' }} \
             libpsl-dev libbrotli-dev libzstd-dev \
@@ -315,7 +315,7 @@ jobs:
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo dpkg --add-architecture i386
           sudo apt-get update
-          sudo apt-get install -y \
+          sudo apt-get install \
             libtool autoconf automake pkgconf stunnel4 \
             libpsl-dev:i386 libbrotli-dev:i386 libzstd-dev:i386 \
             ${{ matrix.build.install_packages }}
@@ -324,7 +324,7 @@ jobs:
       - name: 'install prereqs for pytest'
         if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          sudo apt-get install -y \
+          sudo apt-get install \
             apache2 apache2-dev libnghttp2-dev vsftpd
 
       - name: 'install dependencies'
@@ -584,7 +584,7 @@ jobs:
         run: |
           curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt-get install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -585,7 +585,7 @@ jobs:
           cd /tmp
           curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo apt-key add -
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
-          sudo apt install --no-install-recommends intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+          sudo apt-get install -y --no-install-recommends intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh
           printenv >> $GITHUB_ENV
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -324,8 +324,7 @@ jobs:
       - name: 'install prereqs for pytest'
         if: contains(matrix.build.install_steps, 'pytest')
         run: |
-          sudo apt-get --option Dpkg::Use-Pty=0 install \
-            apache2 apache2-dev libnghttp2-dev vsftpd
+          sudo apt-get --option Dpkg::Use-Pty=0 install apache2 apache2-dev libnghttp2-dev vsftpd
 
       - name: 'install dependencies'
         if: startsWith(matrix.build.container, 'alpine')

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -606,9 +606,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 'install packages'
-        run: |
-          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
-            libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - name: 'cache compiler (djgpp)'
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -420,8 +420,8 @@ jobs:
         timeout-minutes: 5
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get --option Dpkg::Use-Pty=0 update
-          sudo apt-get --option Dpkg::Use-Pty=0 install nasm
+          sudo apt-get -o Dpkg::Use-Pty=0 update
+          sudo apt-get -o Dpkg::Use-Pty=0 install nasm
 
       - name: 'vcpkg build'
         if: ${{ matrix.install }}
@@ -606,7 +606,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 'install packages'
-        run: sudo apt-get --option Dpkg::Use-Pty=0 install libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get -o Dpkg::Use-Pty=0 install libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - name: 'cache compiler (djgpp)'
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -420,8 +420,8 @@ jobs:
         timeout-minutes: 5
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update
-          sudo apt-get install nasm
+          sudo apt-get --option Dpkg::Use-Pty=0 update
+          sudo apt-get --option Dpkg::Use-Pty=0 install nasm
 
       - name: 'vcpkg build'
         if: ${{ matrix.install }}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -421,7 +421,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update -y
-          sudo apt-get install -y --no-install-suggests --no-install-recommends nasm
+          sudo apt-get install -y nasm
 
       - name: 'vcpkg build'
         if: ${{ matrix.install }}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -606,7 +606,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 'install packages'
-        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get install -y --no-install-suggests --no-install-recommends libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - name: 'cache compiler (djgpp)'
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -606,7 +606,9 @@ jobs:
       fail-fast: false
     steps:
       - name: 'install packages'
-        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: |
+          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+            libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - name: 'cache compiler (djgpp)'
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -421,7 +421,7 @@ jobs:
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get update
-          sudo apt-get install -y nasm
+          sudo apt-get install nasm
 
       - name: 'vcpkg build'
         if: ${{ matrix.install }}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -606,7 +606,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 'install packages'
-        run: sudo apt-get install -y --no-install-suggests --no-install-recommends libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get --option Dpkg::Use-Pty=0 install libfl2 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - name: 'cache compiler (djgpp)'
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -420,7 +420,7 @@ jobs:
         timeout-minutes: 5
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get update -y
+          sudo apt-get update
           sudo apt-get install -y nasm
 
       - name: 'vcpkg build'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -495,7 +495,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get install -y --no-install-suggests --no-install-recommends mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -495,7 +495,9 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: |
+          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
+            mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -495,7 +495,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get install -y --no-install-suggests --no-install-recommends mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get --option Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -495,7 +495,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: sudo apt-get --option Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -495,9 +495,7 @@ jobs:
       TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
-        run: |
-          sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends \
-            mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: sudo apt-get --quiet 2 --option Dpkg::Use-Pty=0 install --no-install-suggests --no-install-recommends mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/scripts/cijobs.pl
+++ b/scripts/cijobs.pl
@@ -85,7 +85,7 @@ sub githubactions {
                 $m = 0;
                 $j = 0;
             }
-            elsif($_ =~ /^    - run: .* apt-get install (.*)/) {
+            elsif($_ =~ /^    - run: .* apt-get .* install (.*)/) {
                 $job{'install'} = $1;
             }
             elsif($m >= 0) {


### PR DESCRIPTION
- drop `--quiet 2` option where used, to have uniform output.
- replace `apt` with `apt-get` in one job. sync options with rest.
- replace deprecated `apt-key` command with the alternative recommended
  by `apt-key(8)`.
- drop stray `cd /tmp`, no longer needed after migrating to GHA.
- shorten `--option Dpkg::Use-Pty=0` to `-o Dpkg::Use-Pty=0`.
- add `-o Dpkg::Use-Pty=0` to hide `apt-get` progress bars taking
  vertical log space, where missing.
- drop `-y --no-install-suggests --no-install-recommends` `apt-get`
  options. They are the default in the ubuntu-24.04 image.
- GHA/distcheck: move `name:` to top in steps where not there.
- scripts/cijobs.pl: catch `apt-get` lines with the `-o` option.
