### PR TITLE
fix precedence issue in runtests.pl

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1673,7 +1673,7 @@ sub singletest_check {
             my %cmdhash = getpartattr("client", "command");
             my $cmdtype = $cmdhash{'type'} || "default";
             logmsg "\n** ALERT! memory tracking with no output file?\n"
-                if(!$cmdtype eq "perl");
+                if($cmdtype ne "perl");
             $ok .= "-"; # problem with memory checking
         }
         else {


### PR DESCRIPTION
The condition `!$cmdtype eq "perl"` (introduced in a4765b0551) is always false. It checks whether a logical negation (giving true/false) is equal to the string `"perl"`. This is impossible, so the logging never worked.

The intent was probably to negate the result of the string comparison:`!($cmdtype eq "perl")` or simply `$cmdtype ne "perl"`.

Fixes #16128.