### PR TITLE
c-ares: fix/tidy-up macro initializations, avoid a deprecated function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,7 +352,6 @@ if(ENABLE_ARES)
   if(CARES_CFLAGS)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CARES_CFLAGS}")
   endif()
-  add_definitions("-DCARES_NO_DEPRECATED")  # Ignore c-ares deprecation warnings
 endif()
 
 include(CurlSymbolHiding)

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -62,10 +62,6 @@
 #include "httpsrr.h"
 #include "strdup.h"
 
-#if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) &&   \
-  defined(_WIN32)
-#  define CARES_STATICLIB
-#endif
 #include <ares.h>
 #include <ares_version.h> /* really old c-ares did not include this by
                              itself */

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -429,7 +429,7 @@ static void destroy_async_data(struct Curl_async *async)
 static CURLcode resolve_httpsrr(struct Curl_easy *data,
                                 struct Curl_async *asp)
 {
-  int status = ares_init(&asp->tdata->channel);
+  int status = ares_init_options(&asp->tdata->channel, NULL, 0);
   if(status != ARES_SUCCESS)
     return CURLE_FAILED_INIT;
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -378,6 +378,9 @@
 #endif
 
 #ifdef USE_ARES
+#  ifndef CARES_NO_DEPRECATED
+#  define CARES_NO_DEPRECATED  /* for ares_getsock() */
+#  endif
 #  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) && defined(_WIN32)
 #    define CARES_STATICLIB  /* define it before including ares.h */
 #  endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -377,6 +377,12 @@
 #  endif
 #endif
 
+#ifdef USE_ARES
+#  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) && defined(_WIN32)
+#    define CARES_STATICLIB  /* define it before including ares.h */
+#  endif
+#endif
+
 #ifdef USE_LWIPSOCK
 #  include <lwip/init.h>
 #  include <lwip/sockets.h>

--- a/lib/version.c
+++ b/lib/version.c
@@ -38,10 +38,6 @@
 #include "easy_lock.h"
 
 #ifdef USE_ARES
-#  if defined(CURL_STATICLIB) && !defined(CARES_STATICLIB) &&   \
-  defined(_WIN32)
-#    define CARES_STATICLIB
-#  endif
 #  include <ares.h>
 #endif
 

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -532,7 +532,6 @@ AC_DEFUN([CURL_CHECK_LIB_ARES], [
     if test "$want_ares" = "yes"; then
       dnl finally c-ares will be used
       AC_DEFINE(USE_ARES, 1, [Define to enable c-ares support])
-      AC_DEFINE(CARES_NO_DEPRECATED, 1, [Ignore c-ares deprecation warnings])
       USE_ARES=1
       LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE libcares"
       curl_res_msg="c-ares"


### PR DESCRIPTION
- replace deprecated `ares_init()` call with `ares_init_options()`.
  Follow-up to 0d4fdbf15d8eec908b3e63b606f112b18a63015e #16054

- dedupe `CARES_STATICLIB` initalizations into `curl_setup.h`, to
  ensure it's defined before the first (and every) `ares.h` include and
  avoid a potential confusion.

- move `CARES_NO_DEPRECATED` from build level to `curl_setup.h`.
  To work regardless of build system.
  It is necessary because curl calls `ares_getsock()` from two places,
  of which one feeds a chain of wrappers: `Curl_ares_getsock()`,
  `Curl_resolver_getsock()`, `Curl_resolv_getsock()`.
