### PR TITLE
pytest: test negotiate with http proxy

### DIFF
--- a/tests/http/test_13_proxy_auth.py
+++ b/tests/http/test_13_proxy_auth.py
@@ -25,6 +25,7 @@
 ###########################################################################
 #
 import logging
+import os
 import re
 import pytest
 
@@ -152,3 +153,14 @@ class TestProxyAuth:
                          protocol='HTTP/2' if proto == 'h2' else 'HTTP/1.1')
         assert self.get_tunnel_proto_used(r) == 'HTTP/2' \
             if tunnel == 'h2' else 'HTTP/1.1'
+
+    def test_13_09_negotiate_http(self, env: Env, httpd):
+        run_env = os.environ.copy()
+        run_env['https_proxy'] = f'http://127.0.0.1:{env.proxy_port}'
+        curl = CurlClient(env=env, run_env=run_env)
+        url = f'https://localhost:{env.https_port}/data.json'
+        r1 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True, extra_args=[
+            '--negotiate', '--proxy-user', 'proxy:proxy'
+        ])
+        r1.check_response(count=1, http_status=200)
+

--- a/tests/http/test_13_proxy_auth.py
+++ b/tests/http/test_13_proxy_auth.py
@@ -154,6 +154,8 @@ class TestProxyAuth:
         assert self.get_tunnel_proto_used(r) == 'HTTP/2' \
             if tunnel == 'h2' else 'HTTP/1.1'
 
+    @pytest.mark.skipif(condition=not Env.curl_has_feature('SPNEGO'),
+                        reason='curl lacks SPNEGO support')
     def test_13_09_negotiate_http(self, env: Env, httpd):
         run_env = os.environ.copy()
         run_env['https_proxy'] = f'http://127.0.0.1:{env.proxy_port}'

--- a/tests/http/test_13_proxy_auth.py
+++ b/tests/http/test_13_proxy_auth.py
@@ -163,4 +163,3 @@ class TestProxyAuth:
             '--negotiate', '--proxy-user', 'proxy:proxy'
         ])
         r1.check_response(count=1, http_status=200)
-


### PR DESCRIPTION
refs #14973

When curl negotiated with a http: proxy for a https: request, it wrongly believed there must be an SSL filter present, which during CONNECT, there is not.

25b445e fixed this. This PR adds a pytest case for the setup.