### PR TITLE
symbols-in-versions: update version for LIBCURL_VERSION and LIBCURL_VERSION_NUM symbols

### DIFF
--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -1152,8 +1152,8 @@ CURLWS_RAW_MODE                 7.86.0
 CURLWS_TEXT                     7.86.0
 LIBCURL_COPYRIGHT               7.18.0
 LIBCURL_TIMESTAMP               7.16.2
-LIBCURL_VERSION                 7.11.0
+LIBCURL_VERSION                 7.1.1
 LIBCURL_VERSION_MAJOR           7.11.0
 LIBCURL_VERSION_MINOR           7.11.0
-LIBCURL_VERSION_NUM             7.11.0
+LIBCURL_VERSION_NUM             7.1.1
 LIBCURL_VERSION_PATCH           7.11.0


### PR DESCRIPTION
Those 2 symbols were available since the first 7.1.1 release