### PR TITLE
cmake: drop `LDAP_DEPRECATED=1` macro, to sync with autotools

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -147,9 +147,9 @@ jobs:
           - name: 'wolfSSL !ldap brotli zstd'
             install: brotli wolfssl zstd
             generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON
-          - name: 'mbedTLS !ldap brotli zstd'
-            install: brotli mbedtls zstd
-            generate: -DCURL_USE_MBEDTLS=ON -DCURL_DISABLE_LDAP=ON
+          - name: 'mbedTLS openldap brotli zstd'
+            install: brotli mbedtls zstd openldap
+            generate: -DCURL_USE_MBEDTLS=ON -DLDAP_INCLUDE_DIR="$(brew --prefix openldap)/include" -DLDAP_LIBRARY="$(brew --prefix openldap)/lib/libldap.dylib" -DLDAP_LBER_LIBRARY="$(brew --prefix openldap)/lib/liblber.dylib"
           - name: 'GnuTLS !ldap krb5'
             install: gnutls nettle krb5
             generate: -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=$(brew --prefix krb5) -DCURL_DISABLE_LDAP=ON -DUSE_SSLS_EXPORT=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1216,7 +1216,6 @@ if(NOT CURL_DISABLE_LDAP)
 
       if(HAVE_LDAP_INIT_FD)
         set(USE_OPENLDAP ON)
-        add_definitions("-DLDAP_DEPRECATED=1")
       endif()
       if(NOT CURL_DISABLE_LDAPS)
         set(HAVE_LDAP_SSL ON)

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -38,6 +38,10 @@
  * OpenLDAP library versions, USE_OPENLDAP shall not be defined.
  */
 
+#ifndef LDAP_DEPRECATED
+#define LDAP_DEPRECATED 0
+#endif
+
 #include <ldap.h>
 
 #include "urldata.h"

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -38,10 +38,6 @@
  * OpenLDAP library versions, USE_OPENLDAP shall not be defined.
  */
 
-#ifndef LDAP_DEPRECATED
-#define LDAP_DEPRECATED 0
-#endif
-
 #include <ldap.h>
 
 #include "urldata.h"


### PR DESCRIPTION
We set this macro to silence a warning inside `openldap.h`. With this
warning now silenced by using `-isystem`, we can drop it. Also it never
had to be set to `1`.

Also enable OpenLDAP in a CMake GHA/macos job.

Follow-up to 445fb81237342ff1ec177a61241a53778570526f #14763
Follow-up to 751e168d93b4a58f3fbbe2908c0041ae2f934329 #12024
