### PR TITLE
tool_getparam: warn on a request for multiple byte ranges

### DIFF
--- a/docs/libcurl/opts/CURLOPT_RANGE.md
+++ b/docs/libcurl/opts/CURLOPT_RANGE.md
@@ -39,9 +39,12 @@ left out and X and Y are byte indexes.
 HTTP transfers also support several intervals, separated with commas as in
 *"X-Y,N-M"*. Using this kind of multiple intervals causes the HTTP server
 to send the response document in pieces (using standard MIME separation
-techniques). Unfortunately, the HTTP standard (RFC 7233 section 3.1) allows
-servers to ignore range requests so even when you set CURLOPT_RANGE(3)
-for a request, you may end up getting the full response sent back.
+techniques). Parsing or otherwise transforming the multiple part response is
+the responsibility of the caller.
+
+Unfortunately, the HTTP standard (RFC 7233 section 3.1) allows servers to
+ignore range requests so even when you set CURLOPT_RANGE(3) for a request, you
+may end up getting the full response sent back.
 
 For RTSP, the formatting of a range should follow RFC 2326 Section 12.29. For
 RTSP, byte ranges are **not** permitted. Instead, ranges should be given in


### PR DESCRIPTION
- Warn during --range parsing that curl does not support decoding a server response containing multiple byte ranges.

- Warn in CURLOPT_RANGE doc that multipart range responses are not decoded by libcurl.

If a user requests multiple byte ranges (eg --range 1-2,3-4) and the server supports that then it replies with a multipart/byteranges response that is not decoded by curl. There is already a doc warning for --range about this, however prior to this change there was no usage warning for the tool and a less explicit doc warning for CURLOPT_RANGE.

Reported-by: Ralf A. Timmermann

Fixes https://github.com/curl/curl/issues/16139
Closes #xxxxx