### PR TITLE
Fix compiler pragma warning on GCC <= 4.2

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -33,7 +33,7 @@
 
 /* Make these warnings visible with an option. */
 #if !defined(CURL_WARN_SIGN_CONVERSION)
-#if (defined(__GNUC__) && (__GNUC__ > 4 || \
+#if (defined(__GNUC__) && defined(__GNUC_MINOR__) && (__GNUC__ > 4 || \
   (__GNUC__ == 4 && __GNUC__MINOR__ > 2))) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -33,7 +33,7 @@
 
 /* Make these warnings visible with an option. */
 #if !defined(CURL_WARN_SIGN_CONVERSION)
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) && (__GNUC__ > 4)) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -33,7 +33,7 @@
 
 /* Make these warnings visible with an option. */
 #if !defined(CURL_WARN_SIGN_CONVERSION)
-#if (defined(__GNUC__) && (__GNUC__ > 4)) || defined(__clang__)
+#if (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC__MINOR__ > 2))) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -33,7 +33,8 @@
 
 /* Make these warnings visible with an option. */
 #if !defined(CURL_WARN_SIGN_CONVERSION)
-#if (defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC__MINOR__ > 2))) || defined(__clang__)
+#if (defined(__GNUC__) && (__GNUC__ > 4 || \
+  (__GNUC__ == 4 && __GNUC__MINOR__ > 2))) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -34,7 +34,7 @@
 /* Make these warnings visible with an option. */
 #if !defined(CURL_WARN_SIGN_CONVERSION)
 #if (defined(__GNUC__) && defined(__GNUC_MINOR__) && (__GNUC__ > 4 || \
-  (__GNUC__ == 4 && __GNUC__MINOR__ > 2))) || defined(__clang__)
+  (__GNUC__ == 4 && __GNUC_MINOR__ > 2))) || defined(__clang__)
 #pragma GCC diagnostic ignored "-Wsign-conversion"
 #endif
 #endif


### PR DESCRIPTION
I get this error on GCC 4.5.2:
curl_setup.h:37: warning: unknown option after '#pragma GCC diagnostic' kind

I don't known which version implemented this, possibly 4.6, but just rule out any 4.x version, which is probably good enough.
