### PR TITLE
transfer: fix returning init failures from `xfer_recv_shutdown_started()`

### DIFF
--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -176,9 +176,9 @@ static bool xfer_recv_shutdown_started(struct Curl_easy *data)
   int sockindex;
 
   if(!data || !data->conn)
-    return CURLE_FAILED_INIT;
+    return false;
   if(data->conn->sockfd == CURL_SOCKET_BAD)
-    return CURLE_FAILED_INIT;
+    return false;
   sockindex = (data->conn->sockfd == data->conn->sock[SECONDARYSOCKET]);
   return Curl_shutdown_started(data, sockindex);
 }


### PR DESCRIPTION
Before this patch it returned `CURLE_FAILED_INIT` on init failures, with
the value of 2. Fix it to return `false`.

Seen with clang 18.1.8:
```
../lib/transfer.c(181,12): warning: integer constant not in range of enumerated type 'bool' [-Wassign-enum]
  181 |     return CURLE_FAILED_INIT;
      |            ^
../lib/transfer.c(181,12): warning: implicit conversion from enumeration type 'CURLcode' to different enumeration type 'bool' [-Wenum-conversion]
  181 |     return CURLE_FAILED_INIT;
      |     ~~~~~~ ^~~~~~~~~~~~~~~~~
../lib/transfer.c(183,12): warning: integer constant not in range of enumerated type 'bool' [-Wassign-enum]
  183 |     return CURLE_FAILED_INIT;
      |            ^
../lib/transfer.c(183,12): warning: implicit conversion from enumeration type 'CURLcode' to different enumeration type 'bool' [-Wenum-conversion]
  183 |     return CURLE_FAILED_INIT;
      |     ~~~~~~ ^~~~~~~~~~~~~~~~~
```

Follow-up to 35bf766280a77cde3055e0f4e249ab02a0dcd275 #14253