### PR TITLE
cfilters: silence compiler warning

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -520,7 +520,7 @@ unsigned char Curl_conn_http_version(struct Curl_easy *data)
     if(cf->cft->flags & (CF_TYPE_IP_CONNECT|CF_TYPE_SSL))
       break;
   }
-  return result ? 0 : v;
+  return (unsigned char)(result ? 0 : v);
 }
 
 bool Curl_conn_data_pending(struct Curl_easy *data, int sockindex)


### PR DESCRIPTION
seen with gcc 4.4.0:
```
../../lib/cfilters.c: In function 'Curl_conn_http_version':
../../lib/cfilters.c:523: error: conversion to 'unsigned char' from 'int' may alter its value
```
Ref: https://github.com/curl/curl/actions/runs/13124120573/job/36616761121?pr=15975#step:9:20

Follow-up to e83818cae1da495939aee5def1172ca1d20cc1e4 #16073