### PR TITLE
pop3, revert connection ssl check

### DIFF
--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1112,7 +1112,10 @@ static CURLcode pop3_multi_statemach(struct Curl_easy *data, bool *done)
   struct connectdata *conn = data->conn;
   struct pop3_conn *pop3c = &conn->proto.pop3c;
 
-  if(Curl_conn_is_ssl(conn, FIRSTSOCKET) && !pop3c->ssldone) {
+  /* Issue #16166, STLS seems to stall and time out. Revert to previous
+   * check, but it remains to find out why this is wrong. */
+  /* if(Curl_conn_is_ssl(conn, FIRSTSOCKET) && !pop3c->ssldone) { */
+  if((conn->handler->flags & PROTOPT_SSL) && !pop3c->ssldone) {
     bool ssldone = FALSE;
     result = Curl_conn_connect(data, FIRSTSOCKET, FALSE, &ssldone);
     pop3c->ssldone = ssldone;


### PR DESCRIPTION
As reported in #16166, the STLS hangs with the check for SSL connection filters, but is working with the old protocol handler way. Revert the change, although it is unclear why it was no good here.