### PR TITLE
ldap: drop support for legacy Novell LDAP SDK

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -448,11 +448,7 @@ Vista
 /*                           LDAP SUPPORT                           */
 /* ---------------------------------------------------------------- */
 
-#ifdef CURL_HAS_NOVELL_LDAPSDK
-#undef USE_WIN32_LDAP
-#define HAVE_LDAP_SSL_H 1
-#define HAVE_LDAP_URL_PARSE 1
-#elif defined(CURL_HAS_OPENLDAP_LDAPSDK)
+#ifdef CURL_HAS_OPENLDAP_LDAPSDK
 #undef USE_WIN32_LDAP
 #define HAVE_LDAP_URL_PARSE 1
 #elif !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)


### PR DESCRIPTION
The latest copy I could find at:
https://beta.novell.com/developer/ndk/ldap_libraries_for_c.html
is from 2016-Feb-03, available for Linux and Windows.

I built curl against the Windows package with CMake:
https://sdk.suse.com/ndk/cldap/builds/2016/openldapsdk-devel-windows64-2016-01-28.zip
(It comes with OpenSSL 1.0.1q-fips (2015-Dec-03) binaries.)
CMake identified it as OpenLDAP and built with it as expected:
```
curl 8.12.0-DEV (x86_64-w64-mingw32) libcurl/8.12.0-DEV Schannel OpenLDAP/2.4.37
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp ws wss
Features: alt-svc AsynchDNS HSTS HTTPS-proxy IPv6 Kerberos Largefile NTLM SPNEGO SSL SSPI threadsafe UnixSockets
```

Since it identified it as OpenLDAP (`lib/openldap.c`), the branch
deleted in this PR (`lib/ldap.c`) wasn't reached. Thus, defining
the `CURL_HAS_NOVELL_LDAPSDK` also made no difference in the build.
This suggests the code guarded by it is now orphan and unnecessary.

Novell NetWare builds were another user, but we dropped support for them
in 2022: 3b16575ae938dec2a29454631a12aa52b6ab9c67 #8358

---

Let me know if I missed something and there might still be use for this.
