### PR TITLE
asyn-thread: fix build with `CURL_DISABLE_SOCKETPAIR`

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -668,9 +668,11 @@ int Curl_resolver_getsock(struct Curl_easy *data, curl_socket_t *socks)
   timediff_t milli;
   timediff_t ms;
   struct resdata *reslv = (struct resdata *)data->state.async.resolver;
-  int socketi = 0;
 #ifndef CURL_DISABLE_SOCKETPAIR
   struct thread_data *td = data->state.async.tdata;
+#endif
+#if !defined(CURL_DISABLE_SOCKETPAIR) || defined(USE_HTTPSRR_ARES)
+  int socketi = 0;
 #else
   (void)socks;
 #endif


### PR DESCRIPTION
With `CURL_DISABLE_SOCKETPAIR` defined and `USE_HTTPSRR_ARES` undefined, the local variable `socketi` was unused.

This fixes a regression from commit 0d4fdbf15d8.

Closes https://github.com/curl/curl/pull/16179