### PR TITLE
curl: add build option to use CA native store by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1472,6 +1472,8 @@ endif()
 #
 # CA handling
 #
+option(CURL_CA_NATIVE_BY_DEFAULT "Use native CA store by default in the curl tool" OFF)
+
 if(_curl_ca_bundle_supported)
   set(CURL_CA_BUNDLE "auto" CACHE
     STRING "Path to the CA bundle. Set 'none' to disable or 'auto' for auto-detection. Defaults to 'auto'.")

--- a/configure.ac
+++ b/configure.ac
@@ -2119,6 +2119,26 @@ fi
 
 AM_CONDITIONAL(CURL_CA_EMBED_SET, test "x$CURL_CA_EMBED" != "x")
 
+dnl --------------------------------
+dnl check native CA store by default
+dnl --------------------------------
+
+AC_MSG_CHECKING([whether to use native CA store by default in the curl tool])
+AC_ARG_ENABLE(ca-native,
+AS_HELP_STRING([--enable-ca-native-by-default],[Enable native CA store by default in the curl tool])
+AS_HELP_STRING([--disable-ca-native-by-default],[Disable native CA store by default in the curl tool (default)]),
+[ case "$enableval" in
+  yes)
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(CURL_CA_NATIVE_BY_DEFAULT, 1, [If native CA store by default in the curl tool is enabled])
+    ;;
+  *)
+    AC_MSG_RESULT([no])
+    ;;
+  esac ],
+    AC_MSG_RESULT([no])
+)
+
 dnl ----------------------
 dnl check unsafe CA search
 dnl ----------------------

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -177,6 +177,8 @@ assumes that CMake generates `Makefile`:
 - `CURL_CA_BUNDLE`:                         Path to the CA bundle. Set `none` to disable or `auto` for auto-detection. Default: `auto`
 - `CURL_CA_EMBED`:                          Path to the CA bundle to embed in the curl tool. Default: (disabled)
 - `CURL_CA_FALLBACK`:                       Use built-in CA store of TLS backend. Default: `OFF`
+- `CURL_CA_NATIVE_BY_DEFAULT`:              Use native CA store by default in the curl tool. Default: `OFF`
+                                            Supported by GnuTLS, OpenSSL (including forks) on Windows, wolfSSL.
 - `CURL_CA_PATH`:                           Location of default CA path. Set `none` to disable or `auto` for auto-detection. Default: `auto`
 - `CURL_CA_SEARCH_SAFE`:                    Enable safe CA bundle search (within the curl tool directory) on Windows. Default: `OFF`
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -34,6 +34,9 @@
 /* Default SSL backend */
 #cmakedefine CURL_DEFAULT_SSL_BACKEND "${CURL_DEFAULT_SSL_BACKEND}"
 
+/* Use native CA store by default in curl tool */
+#cmakedefine CURL_CA_NATIVE_BY_DEFAULT 1
+
 /* disables alt-svc */
 #cmakedefine CURL_DISABLE_ALTSVC 1
 

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -46,6 +46,11 @@ void config_init(struct OperationConfig *config)
   config->ftp_skip_ip = TRUE;
   config->file_clobber_mode = CLOBBER_DEFAULT;
   curlx_dyn_init(&config->postdata, MAX_FILE2MEMORY);
+
+#ifdef CURL_CA_NATIVE_BY_DEFAULT
+  config->native_ca_store = TRUE;
+  config->proxy_native_ca_store = TRUE;
+#endif
 }
 
 static void free_config_fields(struct OperationConfig *config)


### PR DESCRIPTION
Usage:
- cmake: `-DCURL_CA_NATIVE_BY_DEFAULT=ON`
- autotools: `--enable-ca-native-by-default`
- CPPFLAGS: `-DCURL_CA_NATIVE_BY_DEFAULT`

When running curl, you can disable the native CA store with
the `--no-ca-native` command-line option.

---

- [ ] add a feature flag to `disabled` or `--version-all`: #16133