### PR TITLE
smb: silence `-Warray-bounds` with gcc 13+

### DIFF
--- a/lib/smb.c
+++ b/lib/smb.c
@@ -881,14 +881,14 @@ static CURLcode smb_connection_state(struct Curl_easy *data, bool *done)
       return CURLE_COULDNT_CONNECT;
     }
     nrsp = msg;
-#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 1300
+#if defined(__GNUC__) && __GNUC__ >= 13
 #pragma GCC diagnostic push
 /* error: 'memcpy' offset [74, 80] from the object at '<unknown>' is out of
    the bounds of referenced subobject 'bytes' with type 'char[1]' */
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
     memcpy(smbc->challenge, nrsp->bytes, sizeof(smbc->challenge));
-#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 1300
+#if defined(__GNUC__) && __GNUC__ >= 13
 #pragma GCC diagnostic pop
 #endif
     smbc->session_key = smb_swap32(nrsp->session_key);

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -881,7 +881,16 @@ static CURLcode smb_connection_state(struct Curl_easy *data, bool *done)
       return CURLE_COULDNT_CONNECT;
     }
     nrsp = msg;
+#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 1300
+#pragma GCC diagnostic push
+/* error: 'memcpy' offset [74, 80] from the object at '<unknown>' is out of
+   the bounds of referenced subobject 'bytes' with type 'char[1]' */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
     memcpy(smbc->challenge, nrsp->bytes, sizeof(smbc->challenge));
+#if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 1300
+#pragma GCC diagnostic pop
+#endif
     smbc->session_key = smb_swap32(nrsp->session_key);
     result = smb_send_setup(data);
     if(result) {


### PR DESCRIPTION
The code look correct. The compiler gets confused by the `byte[1]`
struct member mapped into a memory buffer with a variable-sized
payload starting at this member. Perhaps there is a cleaner way
to silence this by changing the code.

First seen with gcc 13.2.0 in curl-for-win builds. Then with 13.2.1 and
the latest 14.2.0.

```
curl/lib/smb.c: In function 'smb_connection_state':
curl/lib/smb.c:895:5: warning: 'memcpy' offset [74, 80] from the object at 'buf' is out of the bounds of referenced subobject 'bytes' with type 'char[1]' at offset 73 [-Warray-bounds=]
  895 |     memcpy(smbc->challenge, nrsp->bytes, sizeof(smbc->challenge));
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
curl/lib/smb.c:130:8: note: subobject 'bytes' declared here
  130 |   char bytes[1];
      |        ^~~~~
```

gcc 14.2.0 debian:testing musl riscv64: https://github.com/curl/curl/actions/runs/13157579253/job/36718140035?pr=16182#step:3:5576
gcc 13.2.1 alpine amd64: https://github.com/curl/curl-for-win/actions/runs/9370491111/job/25797582549#step:3:4869
gcc 13.2.0 debian:testing glibc aarch64: https://github.com/curl/curl-for-win/actions/runs/9370491111/job/25797581315#step:3:6054
gcc 13.2.0 debian:testing glibc amd64: https://github.com/curl/curl-for-win/actions/runs/9370491111/job/25797581315#step:3:10959
gcc 13.2.0 debian:sid glibc riscv64: https://github.com/curl/curl-for-win/actions/runs/9370491111/job/25797580697#step:3:6122
gcc 13.2.0 debian:sid musl riscv64: https://github.com/curl/curl-for-win/actions/runs/9370491111/job/25797583450#step:3:6227
