### PR TITLE
libssh: silence `-Wconversion` with a cast (Windows 32-bit)

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1848,7 +1848,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
       }
 
       rc = ssh_scp_push_file(sshc->scp_session, protop->path,
-                             data->state.infilesize,
+                             (size_t)data->state.infilesize,
                              (int)data->set.new_file_perms);
       if(rc != SSH_OK) {
         err_msg = ssh_get_error(sshc->ssh_session);


### PR DESCRIPTION
Seen with GCC 13 with Windows x86:
```
lib/vssh/libssh.c: In function 'myssh_statemach_act':
lib/vssh/libssh.c:1851:41: error: conversion from 'curl_off_t' {aka 'long long int'} to 'size_t' {aka 'unsigned int'} may change value [-Werror=conversion]
 1851 |                              data->state.infilesize,
      |                              ~~~~~~~~~~~^~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/13161422041/job/36737994642?pr=16182#step:3:5111