### PR TITLE
GHA/non-native: skip examples in non-unity job

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -124,7 +124,7 @@ jobs:
       matrix:
         include:
           - { build: 'autotools', arch: 'x86_64', compiler: 'clang' }
-          - { build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF -DCURL_TEST_BUNDLES=OFF', tflags: 'skiprun', desc: ' !unity !bundle !testrun' }
+          - { build: 'cmake'    , arch: 'x86_64', compiler: 'clang', options: '-DCMAKE_UNITY_BUILD=OFF -DCURL_TEST_BUNDLES=OFF', desc: ' !unity !bundle !runtests !examples' }
           - { build: 'autotools', arch: 'arm64', compiler: 'clang' }
           - { build: 'cmake'    , arch: 'arm64', compiler: 'clang' }
       fail-fast: false
@@ -158,13 +158,15 @@ jobs:
             src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               time make -j3 -C tests
-              if [ '${{ matrix.tflags }}' != 'skiprun' ]; then
+              if [[ '${{ matrix.desc }}' != *'!runtests'* ]]; then
                 time make test-ci V=1 TFLAGS='-j4'
               fi
             fi
-            echo '::group::build examples'
-            time make -j3 examples
-            echo '::endgroup::'
+            if [[ '${{ matrix.desc }}' != *'!examples'* ]]; then
+              echo '::group::build examples'
+              time make -j3 examples
+              echo '::endgroup::'
+            fi
 
       - name: 'cmake'
         if: ${{ matrix.build == 'cmake' }}
@@ -192,13 +194,15 @@ jobs:
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               time cmake --build bld --config Debug --target testdeps
-              if [ '${{ matrix.tflags }}' != 'skiprun' ]; then
+              if [[ '${{ matrix.desc }}' != *'!runtests'* ]]; then
                 time cmake --build bld --config Debug --target test-ci
               fi
             fi
-            echo '::group::build examples'
-            time cmake --build bld --config Debug --target curl-examples
-            echo '::endgroup::'
+            if [[ '${{ matrix.desc }}' != *'!examples'* ]]; then
+              echo '::group::build examples'
+              time cmake --build bld --config Debug --target curl-examples
+              echo '::endgroup::'
+            fi
 
   omnios:
     name: 'OmniOS, AM gcc openssl amd64'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -156,13 +156,14 @@ jobs:
             echo '::group::curl_config.h'; grep -F '#define' lib/curl_config.h | sort || true; echo '::endgroup::'
             time make -j3 install
             src/curl --disable --version
+            desc='${{ matrix.desc }}'
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               time make -j3 -C tests
-              if [[ '${{ matrix.desc }}' != *'!runtests'* ]]; then
+              if [ "${desc#*!runtests*}" = "${desc}" ]; then
                 time make test-ci V=1 TFLAGS='-j4'
               fi
             fi
-            if [[ '${{ matrix.desc }}' != *'!examples'* ]]; then
+            if [ "${desc#*!examples*}" = "${desc}" ]; then
               echo '::group::build examples'
               time make -j3 examples
               echo '::endgroup::'
@@ -192,13 +193,14 @@ jobs:
             echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
             time cmake --build bld --config Debug
             bld/src/curl --disable --version
+            desc='${{ matrix.desc }}'
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
               time cmake --build bld --config Debug --target testdeps
-              if [[ '${{ matrix.desc }}' != *'!runtests'* ]]; then
+              if [ "${desc#*!runtests*}" = "${desc}" ]; then
                 time cmake --build bld --config Debug --target test-ci
               fi
             fi
-            if [[ '${{ matrix.desc }}' != *'!examples'* ]]; then
+            if [ "${desc#*!examples*}" = "${desc}" ]; then
               echo '::group::build examples'
               time cmake --build bld --config Debug --target curl-examples
               echo '::endgroup::'


### PR DESCRIPTION
To save time. They are built the same way in the other jobs.

Follow-up to 6fc703904b2ed5e320abd66c9ef1efc894578fe9 #16188