### PR TITLE
cmake: initialize variables where missing

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -34,6 +34,8 @@ macro(check_include_file_concat_curl _file _variable)
   endif()
 endmacro()
 
+set(CURL_TEST_DEFINES "")  # Initialize variable
+
 # For other curl specific tests, use this macro.
 # Return result in variable: CURL_TEST_OUTPUT
 macro(curl_internal_test _curl_test)

--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -39,6 +39,7 @@ endmacro()
 macro(curl_internal_test _curl_test)
   if(NOT DEFINED "${_curl_test}")
     string(REPLACE ";" " " _cmake_required_definitions "${CMAKE_REQUIRED_DEFINITIONS}")
+    set(_curl_test_add_libraries "")
     if(CMAKE_REQUIRED_LIBRARIES)
       set(_curl_test_add_libraries
         "-DLINK_LIBRARIES:STRING=${CMAKE_REQUIRED_LIBRARIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1640,6 +1640,7 @@ endif()
 
 # Pass these detection results to curl_internal_test() for use in CurlTests.c
 # Add here all feature flags referenced from CurlTests.c
+set(CURL_TEST_DEFINES "")
 foreach(_variable IN ITEMS
     HAVE_STDATOMIC_H
     HAVE_STDBOOL_H
@@ -2464,6 +2465,7 @@ if(NOT CURL_DISABLE_INSTALL)
 endif()
 
 # Save build info for test runner to pick up and log
+set(_cmake_sysroot "")
 if(CMAKE_OSX_SYSROOT)
   set(_cmake_sysroot ${CMAKE_OSX_SYSROOT})
 elseif(CMAKE_SYSROOT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1640,7 +1640,6 @@ endif()
 
 # Pass these detection results to curl_internal_test() for use in CurlTests.c
 # Add here all feature flags referenced from CurlTests.c
-set(CURL_TEST_DEFINES "")
 foreach(_variable IN ITEMS
     HAVE_STDATOMIC_H
     HAVE_STDBOOL_H

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -65,6 +65,13 @@ endif()
 
 ## Library definition
 
+if(NOT DEFINED IMPORT_LIB_SUFFIX)
+  set(IMPORT_LIB_SUFFIX "")
+endif()
+if(NOT DEFINED STATIC_LIB_SUFFIX)
+  set(STATIC_LIB_SUFFIX "")
+endif()
+
 # Add "_imp" as a suffix before the extension to avoid conflicting with
 # the statically linked "libcurl.lib" (typically with MSVC)
 if(WIN32 AND


### PR DESCRIPTION
As detected using `cmake --warn-uninitialized`.

It also lists:
- variables inherited from `Makefile.inc`, which this PR does not fix.

- a documented CMake global variable, which is unexpected:
  `CMAKE_MODULE_PATH`.
  I'd expect CMake to initialize its namespace.

- envs: `CI`, `CURL_CI` and `CURL_BUILDINFO`. Unexpected, as the manual
  mentions variables only. As of August 2024, there is no solution to
  silence them:
  https://discourse.cmake.org/t/how-to-test-for-set-env-variables-without-getting-warnings/11401

https://cmake.org/cmake/help/latest/manual/cmake.1.html#cmdoption-cmake-warn-uninitialized
