### PR TITLE
libssh: drop support for libssh older than 0.9.0

### DIFF
--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -91,12 +91,14 @@ jobs:
           echo '::group::raw'; cat bld-1/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld-1/lib/curl_config.h | sort || true
 
-      - name: 'cmake generate (out-of-tree, c-ares, libssh, zstd, gssapi)'
+      # when this job can get a libssh version 0.9.0 or later, this should get
+      # that enabled again
+      - name: 'cmake generate (out-of-tree, c-ares, zstd, gssapi)'
         run: |
           mkdir bld-cares
           cd bld-cares
           cmake .. -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON -DBUILD_SHARED_LIBS=ON \
-            -DENABLE_ARES=ON -DCURL_USE_GSSAPI=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DUSE_LIBRTMP=ON \
+            -DENABLE_ARES=ON -DCURL_USE_GSSAPI=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=OFF -DUSE_LIBRTMP=ON \
             -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
 
       - name: 'cmake curl_config.h'

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -123,12 +123,12 @@ jobs:
       - name: 'autoreconf'
         run: autoreconf -if
 
-      - name: 'configure (out-of-tree, c-ares, libssh, zstd, gssapi)'
+      - name: 'configure (out-of-tree, c-ares, libssh2, zstd, gssapi)'
         run: |
           mkdir bld-am
           cd bld-am
           ../configure --disable-dependency-tracking --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
-            --with-openssl --enable-ares --with-libssh --with-zstd --with-gssapi --with-librtmp \
+            --with-openssl --enable-ares --with-libssh2 --with-zstd --with-gssapi --with-librtmp \
             --prefix="$PWD"/../install-am
 
       - name: 'autoconf curl_config.h'

--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -28,6 +28,7 @@ versions of libs and build tools.
  - GnuTLS       3.1.10
  - zlib         1.2.0.4
  - libssh2      1.2.8
+ - libssh       0.9.0
  - c-ares       1.16.0
  - libidn2      2.0.0
  - wolfSSL      3.4.6

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -214,6 +214,12 @@ struct ssh_conn {
 #endif /* USE_LIBSSH */
 };
 
+#ifdef USE_LIBSSH
+#if LIBSSH_VERSION_INT < SSH_VERSION_INT(0, 9, 0)
+#  error "SCP/SFTP protocols require libssh 0.9.0 or later"
+#endif
+#endif
+
 #if defined(USE_LIBSSH2)
 
 /* Feature detection based on version numbers to better work with


### PR DESCRIPTION
libssh 0.9.0 was shipped on June 28 2019 and is the first version featuring the knownhosts API