### PR TITLE
CURLOPT_SSH_KNOWNHOSTS.md: strongly recommend using this

### DIFF
--- a/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_KNOWNHOSTS.md
@@ -7,6 +7,7 @@ Source: libcurl
 See-also:
   - CURLOPT_SSH_AUTH_TYPES (3)
   - CURLOPT_SSH_HOST_PUBLIC_KEY_MD5 (3)
+  - CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256 (3)
 Protocol:
   - SFTP
   - SCP
@@ -29,10 +30,14 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSH_KNOWNHOSTS, char *fname);
 
 Pass a pointer to a null-terminated string holding the filename of the
 known_host file to use. The known_hosts file should use the OpenSSH file
-format as supported by libssh2. If this file is specified, libcurl only
-accepts connections with hosts that are known and present in that file, with a
-matching public key. Use CURLOPT_SSH_KEYFUNCTION(3) to alter the default
-behavior on host and key matches and mismatches.
+format. If this file is specified, libcurl only accepts connections with hosts
+that are known and present in that file, with a matching public key. Use
+CURLOPT_SSH_KEYFUNCTION(3) to alter the default behavior on host and key
+matches and mismatches.
+
+We strongly suggest users doing SCP or SFTP transfers to set this option to
+make sure that the network communication is done with the intended server and
+not an impostor.
 
 The application does not have to keep the string around after setting this
 option.

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2425,6 +2425,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      */
     return Curl_setstropt(&data->set.str[STRING_SSH_PRIVATE_KEY], ptr);
 
+#if defined(USE_LIBSSH2) || defined(USE_LIBSSH)
   case CURLOPT_SSH_HOST_PUBLIC_KEY_MD5:
     /*
      * Option to allow for the MD5 of the host public key to be checked
@@ -2437,7 +2438,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Store the filename to read known hosts from.
      */
     return Curl_setstropt(&data->set.str[STRING_SSH_KNOWNHOSTS], ptr);
-
+#endif
   case CURLOPT_SSH_KEYDATA:
     /*
      * Custom client data to pass to the SSH keyfunc callback


### PR DESCRIPTION
Make setopt fail for SSH backends not supporting knownhosts or pub md5