### PR TITLE
tool_operate: fail SSH transfers without server auth

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -324,6 +324,8 @@ struct GlobalConfig {
   char *libcurl;                  /* Output libcurl code to this filename */
   char *ssl_sessions;             /* file to load/save SSL session tickets */
   char *help_category;            /* The help category, if set */
+  char *knownhosts;               /* known host path, if set. curl_free()
+                                     this */
   struct tool_var *variables;
   struct OperationConfig *first;
   struct OperationConfig *current;

--- a/tests/data/test445
+++ b/tests/data/test445
@@ -46,7 +46,7 @@ http-proxy
 Refuse tunneling protocols through HTTP proxy
 </name>
 <command>
--x http://%HOSTIP:%PROXYPORT/%TESTNUMBER -p gopher://127.0.0.1 dict://127.0.0.1 http://moo https://example telnet://another ftp://yes ftps://again imap://more ldap://perhaps mqtt://yes pop3://mail rtsp://harder scp://copy sftp://files smb://wird smtp://send
+-x http://%HOSTIP:%PROXYPORT/%TESTNUMBER -p gopher://127.0.0.1 dict://127.0.0.1 http://moo https://example telnet://another ftp://yes ftps://again imap://more ldap://perhaps mqtt://yes pop3://mail rtsp://harder scp://copy sftp://files smb://wird smtp://send -k
 </command>
 </client>
 


### PR DESCRIPTION
This now insists on using a server auth option unless --insecure is provided. As an added bonus, it now also only checks for the knownhosts file once (if found).

Ref: #16197