### PR TITLE
GHA/windows: always pass `-A <arch>` to cmake in vcpkg jobs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -689,6 +689,9 @@ jobs:
             ldflags='-OPT:NOREF -OPT:NOICF -APPCONTAINER:NO'
             vsglobals=';AppxPackage=false;WindowsAppContainer=false'
           fi
+          [ '${{ matrix.arch }}' = 'arm64' ] && options+=' -A ARM64'
+          [ '${{ matrix.arch }}' = 'x64' ] && options+=' -A x64'
+          [ '${{ matrix.arch }}' = 'x86' ] && options+=' -A Win32'
           cmake -B bld ${options} \
             -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
             -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLATION_ROOT/installed" \


### PR DESCRIPTION
Instead of relying on the default `-A x64` on `windows-latest` runners,
tell cmake the arch explicitly, to be in sync with `matrix.arch`. Also
add support for arm64 and x86.

`-DVCPKG_TARGET_TRIPLET=` isn't enough to select the platform, ref:
https://github.com/curl/curl/actions/runs/13179082565/job/36785363766?pr=16210
