### PR TITLE
curl: reorder structs, switch to bitfields for booleans

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -45,48 +45,27 @@ struct State {
 };
 
 struct OperationConfig {
-  bool remote_time;
+  struct State state;             /* for create_transfer() */
+  struct curlx_dynbuf postdata;
   char *useragent;
   struct curl_slist *cookies;  /* cookies to serialize into a single line */
   char *cookiejar;          /* write to this file */
   struct curl_slist *cookiefiles;  /* file(s) to load cookies from */
   char *altsvc;             /* alt-svc cache filename */
   char *hsts;               /* HSTS cache filename */
-  bool cookiesession;       /* new session? */
-  bool encoding;            /* Accept-Encoding please */
-  bool tr_encoding;         /* Transfer-Encoding please */
-  unsigned long authtype;   /* auth bitmask */
-  bool use_resume;
-  bool resume_from_current;
-  bool disable_epsv;
-  bool disable_eprt;
-  bool ftp_pret;
   char *proto_str;
-  bool proto_present;
   char *proto_redir_str;
-  bool proto_redir_present;
   char *proto_default;
   curl_off_t resume_from;
   char *postfields;
-  struct curlx_dynbuf postdata;
   char *referer;
   char *query;
-  long timeout_ms;
-  long connecttimeout_ms;
-  long maxredirs;
   curl_off_t max_filesize;
   char *output_dir;
   char *headerfile;
   char *ftpport;
   char *iface;
-  long localport;
-  long localportrange;
-  unsigned short porttouse;
   char *range;
-  long low_speed_limit;
-  long low_speed_time;
-  long ip_tos;         /* IP Type of Service */
-  long vlan_priority;  /* VLAN priority */
   char *dns_servers;   /* dot notation: 1.1.1.1;2.2.2.2 */
   char *dns_interface; /* interface name */
   char *dns_ipv4_addr; /* dot notation */
@@ -101,29 +80,11 @@ struct OperationConfig {
   char *proxy_tls_authtype;
   char *proxyuserpwd;
   char *proxy;
-  int proxyver;             /* set to CURLPROXY_HTTP* define */
   char *noproxy;
   char *mail_from;
   struct curl_slist *mail_rcpt;
   char *mail_auth;
-  bool mail_rcpt_allowfails; /* --mail-rcpt-allowfails */
   char *sasl_authzid;       /* Authorization identity (identity to use) */
-  bool sasl_ir;             /* Enable/disable SASL initial response */
-  bool proxytunnel;
-  bool ftp_append;          /* APPE on ftp */
-  bool use_ascii;           /* select ASCII or text transfer */
-  bool autoreferer;         /* automatically set referer */
-  bool failonerror;         /* fail on (HTTP) errors */
-  bool failwithbody;        /* fail on (HTTP) errors but still store body */
-  bool show_headers;        /* show headers to data output */
-  bool no_body;             /* do not get the body */
-  bool dirlistonly;         /* only get the FTP dir list */
-  bool followlocation;      /* follow http redirects */
-  bool unrestricted_auth;   /* Continue to send authentication (user+password)
-                               when following redirects, even when hostname
-                               changed */
-  bool netrc_opt;
-  bool netrc;
   char *netrc_file;
   struct getout *url_list;  /* point to the first node */
   struct getout *url_last;  /* point to the last/current node */
@@ -163,12 +124,119 @@ struct OperationConfig {
   char *engine;
   char *etag_save_file;
   char *etag_compare_file;
-  bool crlf;
   char *customrequest;
   char *ssl_ec_curves;
   char *krblevel;
   char *request_target;
+  char *writeout;           /* %-styled format string to output */
+  struct curl_slist *quote;
+  struct curl_slist *postquote;
+  struct curl_slist *prequote;
+  struct curl_slist *headers;
+  struct curl_slist *proxyheaders;
+  struct tool_mime *mimeroot;
+  struct tool_mime *mimecurrent;
+  curl_mime *mimepost;
+  struct curl_slist *telnet_options;
+  struct curl_slist *resolve;
+  struct curl_slist *connect_to;
+  char *preproxy;
+  char *proxy_service_name; /* set authentication service name for HTTP and
+                               SOCKS5 proxies */
+  char *service_name;       /* set authentication service name for DIGEST-MD5,
+                               Kerberos 5 and SPNEGO */
+  char *ftp_account;        /* for ACCT */
+  char *ftp_alternative_to_user;  /* send command if USER/PASS fails */
+  char *oauth_bearer;             /* OAuth 2.0 bearer token */
+  char *unix_socket_path;         /* path to Unix domain socket */
+  char *haproxy_clientip;         /* client IP for HAProxy protocol */
+  char *aws_sigv4;
+  char *ech;                      /* Config set by --ech keywords */
+  char *ech_config;               /* Config set by "--ech esl:" option */
+  char *ech_public;               /* Config set by "--ech pn:" option */
+  struct GlobalConfig *global;
+  struct OperationConfig *prev;
+  struct OperationConfig *next;   /* Always last in the struct */
+  curl_off_t condtime;
+  /* for bandwidth limiting features: */
+  curl_off_t sendpersecond; /* send to peer */
+  curl_off_t recvpersecond; /* receive from peer */
+
+  long ssl_version;
+  long ssl_version_max;
+  long proxy_ssl_version;
+  long ip_version;
+  long create_file_mode; /* CURLOPT_NEW_FILE_PERMS */
+  long low_speed_limit;
+  long low_speed_time;
+  long ip_tos;         /* IP Type of Service */
+  long vlan_priority;  /* VLAN priority */
+  long localport;
+  long localportrange;
+  unsigned long authtype;   /* auth bitmask */
+  long timeout_ms;
+  long connecttimeout_ms;
+  long maxredirs;
   long httpversion;
+  unsigned long socks5_auth;/* auth bitmask for socks5 proxies */
+  long req_retry;           /* number of retries */
+  long retry_delay;         /* delay between retries (in seconds) */
+  long retry_maxtime;       /* maximum time to keep retrying */
+
+  long mime_options;        /* Mime option flags. */
+  long tftp_blksize;        /* TFTP BLKSIZE option */
+  long alivetime;           /* keepalive-time */
+  long alivecnt;            /* keepalive-cnt */
+  long gssapi_delegation;
+  long expect100timeout_ms;
+  long happy_eyeballs_timeout_ms; /* happy eyeballs timeout in milliseconds.
+                                     0 is valid. default: CURL_HET_DEFAULT. */
+  curl_TimeCond timecond;
+  HttpReq httpreq;
+  int proxyver;             /* set to CURLPROXY_HTTP* define */
+  int ftp_ssl_ccc_mode;
+  int ftp_filemethod;
+  int default_node_flags;   /* default flags to search for each 'node', which
+                               is basically each given URL to transfer */
+  enum {
+    CLOBBER_DEFAULT, /* Provides compatibility with previous versions of curl,
+                        by using the default behavior for -o, -O, and -J.
+                        If those options would have overwritten files, like
+                        -o and -O would, then overwrite them. In the case of
+                        -J, this will not overwrite any files. */
+    CLOBBER_NEVER, /* If the file exists, always fail */
+    CLOBBER_ALWAYS /* If the file exists, always overwrite it */
+  } file_clobber_mode;
+  unsigned short porttouse;
+  bool remote_time;
+  bool cookiesession;       /* new session? */
+  bool encoding;            /* Accept-Encoding please */
+  bool tr_encoding;         /* Transfer-Encoding please */
+  bool use_resume;
+  bool resume_from_current;
+  bool disable_epsv;
+  bool disable_eprt;
+  bool ftp_pret;
+  bool proto_present;
+  bool proto_redir_present;
+  bool mail_rcpt_allowfails; /* --mail-rcpt-allowfails */
+  bool sasl_ir;             /* Enable/disable SASL initial response */
+  bool proxytunnel;
+  bool ftp_append;          /* APPE on ftp */
+  bool use_ascii;           /* select ASCII or text transfer */
+  bool autoreferer;         /* automatically set referer */
+  bool failonerror;         /* fail on (HTTP) errors */
+  bool failwithbody;        /* fail on (HTTP) errors but still store body */
+  bool show_headers;        /* show headers to data output */
+  bool no_body;             /* do not get the body */
+  bool dirlistonly;         /* only get the FTP dir list */
+  bool followlocation;      /* follow http redirects */
+  bool unrestricted_auth;   /* Continue to send authentication (user+password)
+                               when following redirects, even when hostname
+                               changed */
+  bool netrc_opt;
+  bool netrc;
+  bool crlf;
   bool http09_allowed;
   bool nobuffer;
   bool readbusy;            /* set when reading input returns EAGAIN */
@@ -191,58 +259,16 @@ struct OperationConfig {
   bool proxybasic;
   bool proxyanyauth;
   bool jsoned; /* added json content-type */
-  char *writeout;           /* %-styled format string to output */
-  struct curl_slist *quote;
-  struct curl_slist *postquote;
-  struct curl_slist *prequote;
-  long ssl_version;
-  long ssl_version_max;
-  long proxy_ssl_version;
-  long ip_version;
-  long create_file_mode; /* CURLOPT_NEW_FILE_PERMS */
-  curl_TimeCond timecond;
-  curl_off_t condtime;
-  struct curl_slist *headers;
-  struct curl_slist *proxyheaders;
-  struct tool_mime *mimeroot;
-  struct tool_mime *mimecurrent;
-  curl_mime *mimepost;
-  struct curl_slist *telnet_options;
-  struct curl_slist *resolve;
-  struct curl_slist *connect_to;
-  HttpReq httpreq;
-
-  /* for bandwidth limiting features: */
-  curl_off_t sendpersecond; /* send to peer */
-  curl_off_t recvpersecond; /* receive from peer */
-
   bool ftp_ssl;
   bool ftp_ssl_reqd;
   bool ftp_ssl_control;
   bool ftp_ssl_ccc;
-  int ftp_ssl_ccc_mode;
-  char *preproxy;
   bool socks5_gssapi_nec;   /* The NEC reference server does not protect the
                                encryption type exchange */
-  unsigned long socks5_auth;/* auth bitmask for socks5 proxies */
-  char *proxy_service_name; /* set authentication service name for HTTP and
-                               SOCKS5 proxies */
-  char *service_name;       /* set authentication service name for DIGEST-MD5,
-                               Kerberos 5 and SPNEGO */
-
   bool tcp_nodelay;
   bool tcp_fastopen;
-  long req_retry;           /* number of retries */
   bool retry_all_errors;    /* retry on any error */
   bool retry_connrefused;   /* set connection refused as a transient error */
-  long retry_delay;         /* delay between retries (in seconds) */
-  long retry_maxtime;       /* maximum time to keep retrying */
-
-  char *ftp_account;        /* for ACCT */
-  char *ftp_alternative_to_user;  /* send command if USER/PASS fails */
-  int ftp_filemethod;
-  long mime_options;        /* Mime option flags. */
-  long tftp_blksize;        /* TFTP BLKSIZE option */
   bool tftp_no_options;     /* do not send TFTP options requests */
   bool ignorecl;            /* --ignore-content-length */
   bool disable_sessionid;
@@ -252,15 +278,9 @@ struct OperationConfig {
   bool post302;
   bool post303;
   bool nokeepalive;         /* for keepalive needs */
-  long alivetime;           /* keepalive-time */
-  long alivecnt;            /* keepalive-cnt */
   bool content_disposition; /* use Content-disposition filename */
 
-  int default_node_flags;   /* default flags to search for each 'node', which
-                               is basically each given URL to transfer */
-
   bool xattr;               /* store metadata in extended attributes */
-  long gssapi_delegation;
   bool ssl_allow_beast;     /* allow this SSL vulnerability */
   bool ssl_allow_earlydata; /* allow use of TLSv1.3 early data */
   bool proxy_ssl_allow_beast; /* allow this SSL vulnerability for proxy */
@@ -273,76 +293,53 @@ struct OperationConfig {
   bool ssl_auto_client_cert;   /* automatically locate and use a client
                                   certificate for authentication (Schannel) */
   bool proxy_ssl_auto_client_cert; /* proxy version of ssl_auto_client_cert */
-  char *oauth_bearer;             /* OAuth 2.0 bearer token */
   bool noalpn;                    /* enable/disable TLS ALPN extension */
-  char *unix_socket_path;         /* path to Unix domain socket */
   bool abstract_unix_socket;      /* path to an abstract Unix domain socket */
   bool falsestart;
   bool path_as_is;
-  long expect100timeout_ms;
   bool suppress_connect_headers;  /* suppress proxy CONNECT response headers
                                      from user callbacks */
   bool synthetic_error;           /* if TRUE, this is tool-internal error */
   bool ssh_compression;           /* enable/disable SSH compression */
-  long happy_eyeballs_timeout_ms; /* happy eyeballs timeout in milliseconds.
-                                     0 is valid. default: CURL_HET_DEFAULT. */
   bool haproxy_protocol;          /* whether to send HAProxy protocol v1 */
-  char *haproxy_clientip;         /* client IP for HAProxy protocol */
   bool disallow_username_in_url;  /* disallow usernames in URLs */
-  char *aws_sigv4;
-  enum {
-    CLOBBER_DEFAULT, /* Provides compatibility with previous versions of curl,
-                        by using the default behavior for -o, -O, and -J.
-                        If those options would have overwritten files, like
-                        -o and -O would, then overwrite them. In the case of
-                        -J, this will not overwrite any files. */
-    CLOBBER_NEVER, /* If the file exists, always fail */
-    CLOBBER_ALWAYS /* If the file exists, always overwrite it */
-  } file_clobber_mode;
   bool mptcp;                     /* enable MPTCP support */
-  struct GlobalConfig *global;
-  struct OperationConfig *prev;
-  struct OperationConfig *next;   /* Always last in the struct */
-  struct State state;             /* for create_transfer() */
   bool rm_partial;                /* on error, remove partially written output
                                      files */
   bool skip_existing;
-  char *ech;                      /* Config set by --ech keywords */
-  char *ech_config;               /* Config set by "--ech esl:" option */
-  char *ech_public;               /* Config set by "--ech pn:" option */
 };
 
 struct GlobalConfig {
-  bool showerror;                 /* show errors when silent */
-  bool silent;                    /* do not show messages, --silent given */
-  bool noprogress;                /* do not show progress bar */
-  bool isatty;                    /* Updated internally if output is a tty */
-  unsigned char verbosity;        /* How verbose we should be */
   char *trace_dump;               /* file to dump the network trace to */
   FILE *trace_stream;
-  bool trace_fopened;
-  trace tracetype;
-  bool tracetime;                 /* include timestamp? */
-  bool traceids;                  /* include xfer-/conn-id? */
-  int progressmode;               /* CURL_PROGRESS_BAR / CURL_PROGRESS_STATS */
   char *libcurl;                  /* Output libcurl code to this filename */
-  bool fail_early;                /* exit on first transfer error */
-  bool styled_output;             /* enable fancy output style detection */
+  char *ssl_sessions;             /* file to load/save SSL session tickets */
+  char *help_category;            /* The help category, if set */
+  struct tool_var *variables;
+  struct OperationConfig *first;
+  struct OperationConfig *current;
+  struct OperationConfig *last;
   long ms_per_transfer;           /* start next transfer after (at least) this
                                      many milliseconds */
-  char *ssl_sessions;             /* file to load/save SSL session tickets */
+  trace tracetype;
+  int progressmode;               /* CURL_PROGRESS_BAR / CURL_PROGRESS_STATS */
+  unsigned short parallel_max; /* MAX_PARALLEL is the maximum */
+  unsigned char verbosity;        /* How verbose we should be */
 #ifdef DEBUGBUILD
   bool test_duphandle;
   bool test_event_based;
 #endif
   bool parallel;
-  unsigned short parallel_max; /* MAX_PARALLEL is the maximum */
   bool parallel_connect;
-  char *help_category;            /* The help category, if set */
-  struct tool_var *variables;
-  struct OperationConfig *first;
-  struct OperationConfig *current;
-  struct OperationConfig *last;   /* Always last in the struct */
+  bool fail_early;                /* exit on first transfer error */
+  bool styled_output;             /* enable fancy output style detection */
+  bool trace_fopened;
+  bool tracetime;                 /* include timestamp? */
+  bool traceids;                  /* include xfer-/conn-id? */
+  bool showerror;                 /* show errors when silent */
+  bool silent;                    /* do not show messages, --silent given */
+  bool noprogress;                /* do not show progress bar */
+  bool isatty;                    /* Updated internally if output is a tty */
 };
 
 void config_init(struct OperationConfig *config);

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -28,6 +28,14 @@
 #include "tool_urlglob.h"
 #include "var.h"
 
+/* the type we use for storing a single boolean bit */
+#ifdef _MSC_VER
+#define BIT(x) bool x
+#else
+typedef unsigned int bit;
+#define BIT(x) bit x:1
+#endif
+
 struct GlobalConfig;
 
 struct State {
@@ -208,105 +216,105 @@ struct OperationConfig {
     CLOBBER_ALWAYS /* If the file exists, always overwrite it */
   } file_clobber_mode;
   unsigned short porttouse;
-  bool remote_time;
-  bool cookiesession;       /* new session? */
-  bool encoding;            /* Accept-Encoding please */
-  bool tr_encoding;         /* Transfer-Encoding please */
-  bool use_resume;
-  bool resume_from_current;
-  bool disable_epsv;
-  bool disable_eprt;
-  bool ftp_pret;
-  bool proto_present;
-  bool proto_redir_present;
-  bool mail_rcpt_allowfails; /* --mail-rcpt-allowfails */
-  bool sasl_ir;             /* Enable/disable SASL initial response */
-  bool proxytunnel;
-  bool ftp_append;          /* APPE on ftp */
-  bool use_ascii;           /* select ASCII or text transfer */
-  bool autoreferer;         /* automatically set referer */
-  bool failonerror;         /* fail on (HTTP) errors */
-  bool failwithbody;        /* fail on (HTTP) errors but still store body */
-  bool show_headers;        /* show headers to data output */
-  bool no_body;             /* do not get the body */
-  bool dirlistonly;         /* only get the FTP dir list */
-  bool followlocation;      /* follow http redirects */
-  bool unrestricted_auth;   /* Continue to send authentication (user+password)
+  BIT(remote_time);
+  BIT(cookiesession);       /* new session? */
+  BIT(encoding);            /* Accept-Encoding please */
+  BIT(tr_encoding);         /* Transfer-Encoding please */
+  BIT(use_resume);
+  BIT(resume_from_current);
+  BIT(disable_epsv);
+  BIT(disable_eprt);
+  BIT(ftp_pret);
+  BIT(proto_present);
+  BIT(proto_redir_present);
+  BIT(mail_rcpt_allowfails); /* --mail-rcpt-allowfails */
+  BIT(sasl_ir);             /* Enable/disable SASL initial response */
+  BIT(proxytunnel);
+  BIT(ftp_append);          /* APPE on ftp */
+  BIT(use_ascii);           /* select ASCII or text transfer */
+  BIT(autoreferer);         /* automatically set referer */
+  BIT(failonerror);         /* fail on (HTTP) errors */
+  BIT(failwithbody);        /* fail on (HTTP) errors but still store body */
+  BIT(show_headers);        /* show headers to data output */
+  BIT(no_body);             /* do not get the body */
+  BIT(dirlistonly);         /* only get the FTP dir list */
+  BIT(followlocation);      /* follow http redirects */
+  BIT(unrestricted_auth);   /* Continue to send authentication (user+password)
                                when following redirects, even when hostname
                                changed */
-  bool netrc_opt;
-  bool netrc;
-  bool crlf;
-  bool http09_allowed;
-  bool nobuffer;
-  bool readbusy;            /* set when reading input returns EAGAIN */
-  bool globoff;
-  bool use_httpget;
-  bool insecure_ok;         /* set TRUE to allow insecure SSL connects */
-  bool doh_insecure_ok;     /* set TRUE to allow insecure SSL connects
+  BIT(netrc_opt);
+  BIT(netrc);
+  BIT(crlf);
+  BIT(http09_allowed);
+  BIT(nobuffer);
+  BIT(readbusy);            /* set when reading input returns EAGAIN */
+  BIT(globoff);
+  BIT(use_httpget);
+  BIT(insecure_ok);         /* set TRUE to allow insecure SSL connects */
+  BIT(doh_insecure_ok);     /* set TRUE to allow insecure SSL connects
                                for DoH */
-  bool proxy_insecure_ok;   /* set TRUE to allow insecure SSL connects
+  BIT(proxy_insecure_ok);   /* set TRUE to allow insecure SSL connects
                                for proxy */
-  bool terminal_binary_ok;
-  bool verifystatus;
-  bool doh_verifystatus;
-  bool create_dirs;
-  bool ftp_create_dirs;
-  bool ftp_skip_ip;
-  bool proxynegotiate;
-  bool proxyntlm;
-  bool proxydigest;
-  bool proxybasic;
-  bool proxyanyauth;
-  bool jsoned; /* added json content-type */
-  bool ftp_ssl;
-  bool ftp_ssl_reqd;
-  bool ftp_ssl_control;
-  bool ftp_ssl_ccc;
-  bool socks5_gssapi_nec;   /* The NEC reference server does not protect the
+  BIT(terminal_binary_ok);
+  BIT(verifystatus);
+  BIT(doh_verifystatus);
+  BIT(create_dirs);
+  BIT(ftp_create_dirs);
+  BIT(ftp_skip_ip);
+  BIT(proxynegotiate);
+  BIT(proxyntlm);
+  BIT(proxydigest);
+  BIT(proxybasic);
+  BIT(proxyanyauth);
+  BIT(jsoned); /* added json content-type */
+  BIT(ftp_ssl);
+  BIT(ftp_ssl_reqd);
+  BIT(ftp_ssl_control);
+  BIT(ftp_ssl_ccc);
+  BIT(socks5_gssapi_nec);   /* The NEC reference server does not protect the
                                encryption type exchange */
-  bool tcp_nodelay;
-  bool tcp_fastopen;
-  bool retry_all_errors;    /* retry on any error */
-  bool retry_connrefused;   /* set connection refused as a transient error */
-  bool tftp_no_options;     /* do not send TFTP options requests */
-  bool ignorecl;            /* --ignore-content-length */
-  bool disable_sessionid;
+  BIT(tcp_nodelay);
+  BIT(tcp_fastopen);
+  BIT(retry_all_errors);    /* retry on any error */
+  BIT(retry_connrefused);   /* set connection refused as a transient error */
+  BIT(tftp_no_options);     /* do not send TFTP options requests */
+  BIT(ignorecl);            /* --ignore-content-length */
+  BIT(disable_sessionid);
 
-  bool raw;
-  bool post301;
-  bool post302;
-  bool post303;
-  bool nokeepalive;         /* for keepalive needs */
-  bool content_disposition; /* use Content-disposition filename */
+  BIT(raw);
+  BIT(post301);
+  BIT(post302);
+  BIT(post303);
+  BIT(nokeepalive);         /* for keepalive needs */
+  BIT(content_disposition); /* use Content-disposition filename */
 
-  bool xattr;               /* store metadata in extended attributes */
-  bool ssl_allow_beast;     /* allow this SSL vulnerability */
-  bool ssl_allow_earlydata; /* allow use of TLSv1.3 early data */
-  bool proxy_ssl_allow_beast; /* allow this SSL vulnerability for proxy */
-  bool ssl_no_revoke;       /* disable SSL certificate revocation checks */
-  bool ssl_revoke_best_effort; /* ignore SSL revocation offline/missing
+  BIT(xattr);               /* store metadata in extended attributes */
+  BIT(ssl_allow_beast);     /* allow this SSL vulnerability */
+  BIT(ssl_allow_earlydata); /* allow use of TLSv1.3 early data */
+  BIT(proxy_ssl_allow_beast); /* allow this SSL vulnerability for proxy */
+  BIT(ssl_no_revoke);       /* disable SSL certificate revocation checks */
+  BIT(ssl_revoke_best_effort); /* ignore SSL revocation offline/missing
                                   revocation list errors */
 
-  bool native_ca_store;        /* use the native OS CA store */
-  bool proxy_native_ca_store;  /* use the native OS CA store for proxy */
-  bool ssl_auto_client_cert;   /* automatically locate and use a client
+  BIT(native_ca_store);        /* use the native OS CA store */
+  BIT(proxy_native_ca_store);  /* use the native OS CA store for proxy */
+  BIT(ssl_auto_client_cert);   /* automatically locate and use a client
                                   certificate for authentication (Schannel) */
-  bool proxy_ssl_auto_client_cert; /* proxy version of ssl_auto_client_cert */
-  bool noalpn;                    /* enable/disable TLS ALPN extension */
-  bool abstract_unix_socket;      /* path to an abstract Unix domain socket */
-  bool falsestart;
-  bool path_as_is;
-  bool suppress_connect_headers;  /* suppress proxy CONNECT response headers
+  BIT(proxy_ssl_auto_client_cert); /* proxy version of ssl_auto_client_cert */
+  BIT(noalpn);                    /* enable/disable TLS ALPN extension */
+  BIT(abstract_unix_socket);      /* path to an abstract Unix domain socket */
+  BIT(falsestart);
+  BIT(path_as_is);
+  BIT(suppress_connect_headers);  /* suppress proxy CONNECT response headers
                                      from user callbacks */
-  bool synthetic_error;           /* if TRUE, this is tool-internal error */
-  bool ssh_compression;           /* enable/disable SSH compression */
-  bool haproxy_protocol;          /* whether to send HAProxy protocol v1 */
-  bool disallow_username_in_url;  /* disallow usernames in URLs */
-  bool mptcp;                     /* enable MPTCP support */
-  bool rm_partial;                /* on error, remove partially written output
+  BIT(synthetic_error);           /* if TRUE, this is tool-internal error */
+  BIT(ssh_compression);           /* enable/disable SSH compression */
+  BIT(haproxy_protocol);          /* whether to send HAProxy protocol v1 */
+  BIT(disallow_username_in_url);  /* disallow usernames in URLs */
+  BIT(mptcp);                     /* enable MPTCP support */
+  BIT(rm_partial);                /* on error, remove partially written output
                                      files */
-  bool skip_existing;
+  BIT(skip_existing);
 };
 
 struct GlobalConfig {
@@ -326,20 +334,20 @@ struct GlobalConfig {
   unsigned short parallel_max; /* MAX_PARALLEL is the maximum */
   unsigned char verbosity;        /* How verbose we should be */
 #ifdef DEBUGBUILD
-  bool test_duphandle;
-  bool test_event_based;
+  BIT(test_duphandle);
+  BIT(test_event_based);
 #endif
-  bool parallel;
-  bool parallel_connect;
-  bool fail_early;                /* exit on first transfer error */
-  bool styled_output;             /* enable fancy output style detection */
-  bool trace_fopened;
-  bool tracetime;                 /* include timestamp? */
-  bool traceids;                  /* include xfer-/conn-id? */
-  bool showerror;                 /* show errors when silent */
-  bool silent;                    /* do not show messages, --silent given */
-  bool noprogress;                /* do not show progress bar */
-  bool isatty;                    /* Updated internally if output is a tty */
+  BIT(parallel);
+  BIT(parallel_connect);
+  BIT(fail_early);                /* exit on first transfer error */
+  BIT(styled_output);             /* enable fancy output style detection */
+  BIT(trace_fopened);
+  BIT(tracetime);                 /* include timestamp? */
+  BIT(traceids);                  /* include xfer-/conn-id? */
+  BIT(showerror);                 /* show errors when silent */
+  BIT(silent);                    /* do not show messages, --silent given */
+  BIT(noprogress);                /* do not show progress bar */
+  BIT(isatty);                    /* Updated internally if output is a tty */
 };
 
 void config_init(struct OperationConfig *config);

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -29,11 +29,12 @@
 #include "var.h"
 
 /* the type we use for storing a single boolean bit */
+#ifndef BIT
 #ifdef _MSC_VER
 #define BIT(x) bool x
 #else
-typedef unsigned int bit;
-#define BIT(x) bit x:1
+#define BIT(x) unsigned int x:1
+#endif
 #endif
 
 struct GlobalConfig;

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -61,22 +61,22 @@ struct per_transfer {
   curl_off_t ulnow;
   curl_off_t uploadfilesize; /* expected total amount */
   curl_off_t uploadedsofar; /* amount delivered from the callback */
-  bool dltotal_added; /* if the total has been added from this */
-  bool ultotal_added;
+  BIT(dltotal_added); /* if the total has been added from this */
+  BIT(ultotal_added);
 
   /* NULL or malloced */
   char *uploadfile;
   char *errorbuffer; /* allocated and assigned while this is used for a
                         transfer */
-  bool infdopen; /* TRUE if infd needs closing */
-  bool noprogress;
-  bool was_last_header_empty;
+  BIT(infdopen); /* TRUE if infd needs closing */
+  BIT(noprogress);
+  BIT(was_last_header_empty);
 
-  bool added; /* set TRUE when added to the multi handle */
-  bool abort; /* when doing parallel transfers and this is TRUE then a critical
+  BIT(added); /* set TRUE when added to the multi handle */
+  BIT(abort); /* when doing parallel transfers and this is TRUE then a critical
                  error (eg --fail-early) has occurred in another transfer and
                  this transfer will be aborted in the progress callback */
-  bool skip;  /* considered already done */
+  BIT(skip);  /* considered already done */
 };
 
 CURLcode operate(struct GlobalConfig *config, int argc, argv_item_t argv[]);

--- a/src/tool_sdecls.h
+++ b/src/tool_sdecls.h
@@ -64,10 +64,10 @@
 
 struct OutStruct {
   char *filename;
-  bool alloc_filename;
-  bool is_cd_filename;
-  bool s_isreg;
-  bool fopened;
+  BIT(alloc_filename);
+  BIT(is_cd_filename);
+  BIT(s_isreg);
+  BIT(fopened);
   FILE *stream;
   curl_off_t bytes;
   curl_off_t init;


### PR DESCRIPTION
Saves several hundred bytes with no functionality change or loss.