### PR TITLE
runtests: quote commands to support paths with spaces

### DIFF
--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -99,7 +99,7 @@ our $randseed = 0;    # random number seed
 our $pwd = getcwd();  # current working directory
 our $srcdir = $ENV{'srcdir'} || '.';  # root of the test source code
 our $perlcmd=shell_quote($^X);
-our $perl="$perlcmd -I. -I$srcdir"; # invoke perl like this
+our $perl="$perlcmd -I. " . shell_quote("-I$srcdir"); # invoke perl like this
 our $LOGDIR="log";  # root of the log directory; this will be different for
                     # each runner in multiprocess mode
 our $LIBDIR="./libtest";
@@ -109,7 +109,7 @@ our $VCURL=$CURL;  # what curl binary to use to verify the servers with
                    # VCURL is handy to set to the system one when the one you
                    # just built hangs or crashes and thus prevent verification
 # the path to the script that analyzes the memory debug output file
-our $memanalyze="$perl $srcdir/memanalyze.pl";
+our $memanalyze="$perl " . shell_quote("$srcdir/memanalyze.pl");
 our $valgrind;     # path to valgrind, or empty if disabled
 our $bundle = 0;   # use bundled server, libtest, unit binaries
 our $dev_null = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -73,6 +73,9 @@ BEGIN {
 }
 use pathhelp qw(exe_ext);
 use Cwd qw(getcwd);
+use testutil qw(
+    shell_quote
+);
 
 
 #######################################################################
@@ -95,7 +98,7 @@ our $randseed = 0;    # random number seed
 # paths
 our $pwd = getcwd();  # current working directory
 our $srcdir = $ENV{'srcdir'} || '.';  # root of the test source code
-our $perlcmd="$^X";
+our $perlcmd=shell_quote($^X);
 our $perl="$perlcmd -I. -I$srcdir"; # invoke perl like this
 our $LOGDIR="log";  # root of the log directory; this will be different for
                     # each runner in multiprocess mode

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -507,7 +507,7 @@ sub torture {
         if($valgrind && !$gdbthis) {
             my @valgrindoption = getpart("verify", "valgrind");
             if((!@valgrindoption) || ($valgrindoption[0] !~ /disable/)) {
-                my $valgrindcmd = "$valgrind ";
+                my $valgrindcmd = shell_quote($valgrind) . " ";
                 $valgrindcmd .= "$valgrind_tool " if($valgrind_tool);
                 $valgrindcmd .= "--quiet --leak-check=yes ";
                 $valgrindcmd .= "--suppressions=$srcdir/valgrind.supp ";

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -112,6 +112,7 @@ use testutil qw(
     logmsg
     runclient
     runclientoutput
+    shell_quote
     );
 
 
@@ -1153,7 +1154,7 @@ sub runhttpserver {
     my $ip = $HOSTIP;
     my $ipvnum = 4;
     my $idnum = 1;
-    my $exe = "$perl $srcdir/http-server.pl";
+    my $exe = "$perl " . shell_quote("$srcdir/http-server.pl");
     my $verbose_flag = "--verbose ";
     my $keepalive_secs = 30; # forwarded to sws, was 5 by default which
                              # led to pukes in CI jobs
@@ -1253,7 +1254,7 @@ sub runhttp2server {
     my $proto="http/2";
     my $ipvnum = 4;
     my $idnum = 0;
-    my $exe = "$perl $srcdir/http2-server.pl";
+    my $exe = "$perl " . shell_quote("$srcdir/http2-server.pl");
     my $verbose_flag = "--verbose ";
 
     my $server = servername_id($proto, $ipvnum, $idnum);
@@ -1314,7 +1315,7 @@ sub runhttp3server {
     my $proto="http/3";
     my $ipvnum = 4;
     my $idnum = 0;
-    my $exe = "$perl $srcdir/http3-server.pl";
+    my $exe = "$perl " . shell_quote("$srcdir/http3-server.pl");
     my $verbose_flag = "--verbose ";
 
     my $server = servername_id($proto, $ipvnum, $idnum);
@@ -1423,7 +1424,7 @@ sub runhttpsserver {
 
     my $port = getfreeport($ipvnum);
     my $options = "$flags --accept $port";
-    my $cmd = "$perl $srcdir/secureserver.pl $options";
+    my $cmd = "$perl " . shell_quote("$srcdir/secureserver.pl") . " " . $options;
     my ($httpspid, $pid2) = startnew($cmd, $pidfile, 15, 0);
 
     if($httpspid <= 0 || !pidexists($httpspid)) {
@@ -1551,7 +1552,7 @@ sub runpingpongserver {
     $flags .= "--id $idnum " if($idnum > 1);
     $flags .= "--ipv$ipvnum --port 0 --addr \"$ip\"";
 
-    my $cmd = "$perl $srcdir/ftpserver.pl $flags";
+    my $cmd = "$perl " . shell_quote("$srcdir/ftpserver.pl") . " " . $flags;
     my ($ftppid, $pid2) = startnew($cmd, $pidfile, 15, 0);
 
     if($ftppid <= 0 || !pidexists($ftppid)) {
@@ -1631,7 +1632,7 @@ sub runsecureserver {
     my $port = getfreeport($ipvnum);
     my $options = "$flags --accept $port";
 
-    my $cmd = "$perl $srcdir/secureserver.pl $options";
+    my $cmd = "$perl " . shell_quote("$srcdir/secureserver.pl") . " " . $options;
     my ($protospid, $pid2) = startnew($cmd, $pidfile, 15, 0);
 
     if($protospid <= 0 || !pidexists($protospid)) {
@@ -1698,7 +1699,7 @@ sub runtftpserver {
     $flags .= "--id $idnum " if($idnum > 1);
     $flags .= "--ipv$ipvnum --port 0 --srcdir \"$srcdir\"";
 
-    my $cmd = "$perl $srcdir/tftpserver.pl $flags";
+    my $cmd = "$perl " . shell_quote("$srcdir/tftpserver.pl") . " " . $flags;
     my ($tftppid, $pid2) = startnew($cmd, $pidfile, 15, 0);
 
     if($tftppid <= 0 || !pidexists($tftppid)) {
@@ -1774,7 +1775,7 @@ sub runrtspserver {
     $flags .= "--id $idnum " if($idnum > 1);
     $flags .= "--ipv$ipvnum --port 0 --srcdir \"$srcdir\"";
 
-    my $cmd = "$perl $srcdir/rtspserver.pl $flags";
+    my $cmd = "$perl " . shell_quote("$srcdir/rtspserver.pl") . " " . $flags;
     my ($rtsppid, $pid2) = startnew($cmd, $pidfile, 15, 0);
 
     if($rtsppid <= 0 || !pidexists($rtsppid)) {
@@ -1861,7 +1862,7 @@ sub runsshserver {
 
     my $options = "$flags --sshport $port";
 
-    my $cmd = "$perl $srcdir/sshserver.pl $options";
+    my $cmd = "$perl " . shell_quote("$srcdir/sshserver.pl") . " " . $options;
     my ($sshpid, $pid2) = startnew($cmd, $pidfile, 60, 0);
 
     # on loaded systems sshserver start up can take longer than the


### PR DESCRIPTION
In certain Windows configurations, Perl resides under `C:/Program Files`
causing tests to fail when executing Perl. Fix by quoting the command.

Seen in `dl-mingw` jobs when switching to the default `bash` shell
offered by the `windows-latest` runner on GHA.

Also:
- apply the same fix for `valgrind` for consistency.
- make more use of `shell_quote()` when passing the `srcdir` directory
  over the command-line. This doesn't come up in CI, but seems like
  good practice. There are lots more unquoted arguments and possibly
  also commands.

```
-------e--- OK (940 out of 1537, remaining: 00:32, took 0.217s, duration: 00:50)
test 1167...[Verify curl prefix of public symbols in header files]
/C/Program Files/Git/usr/bin/perl -I. -ID:/a/curl/curl/tests  returned 127, when expecting 0
 1167: exit FAILED
[...]
=== Start of file stderr1167
 sh: line 1: /C/Program: No such file or directory
```
Ref: https://github.com/curl/curl/actions/runs/13181757313/job/36794072190?pr=16217#step:13:2107
