### PR TITLE
INTERNALS: fix c-ares, as we actually support 1.6.0 or later

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -28,7 +28,7 @@ versions of libs and build tools.
  - GnuTLS       3.1.10
  - zlib         1.2.0.4
  - libssh2      1.2.8
- - c-ares       1.16.0
+ - c-ares       1.6.0
  - libidn2      2.0.0
  - wolfSSL      3.4.6
  - OpenLDAP     2.0


### PR DESCRIPTION
It was wrongly bumped to 1.16.0 in db50fc6e95816ec. While we strongly recommend using 1.16.0 or later, we still allow builds using older versions.

It would make sense to raise the requirement to at least 1.11.0 (Feb 19 2016) but that's not done right now.