### PR TITLE
runtest.pl, stop protocol server

### DIFF
--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -887,8 +887,8 @@ sub singletest_run {
         else {
             $cmdargs .= "--trace-ascii $LOGDIR/trace$testnum ";
         }
-        $cmdargs .= "--trace-config all ";
-        $cmdargs .= "--trace-time ";
+        # $cmdargs .= "--trace-config all ";
+        # $cmdargs .= "--trace-time ";
         if($run_event_based) {
             $cmdargs .= "--test-event ";
             $fail_due_event_based--;

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -669,6 +669,7 @@ sub verifyftp {
     }
     $flags .= "\"$proto://$ip:$port/verifiedserver\"";
 
+    logmsg "RUN: curl $flags for server $proto\n";
     my $cmd = "$VCURL $flags 2>$verifylog";
 
     # check if this is our server running on this port:
@@ -2566,7 +2567,7 @@ sub startservers {
             }
             if($run{$cproto} &&
                !responsive_pingpong_server($cproto, "", $verbose)) {
-                if(stopserver($cproto)) {
+                if(stopserver($what)) {
                     return ("failed stopping unresponsive $cproto server", 3);
                 }
             }


### PR DESCRIPTION
When the pingpong server is unresponsive (imaps/pop3s/smtps), stop all server, not only the pingpong server for restarting it.

Let's try if this makes things more reliable or not.