### PR TITLE
test1516: avoid failure due to spaces in path

### DIFF
--- a/tests/data/test1516
+++ b/tests/data/test1516
@@ -45,7 +45,7 @@ lib1515
 caching of manual libcurl DNS entries after dead connection
 </name>
 <command>
-/path/%TESTNUMBER %HOSTIP %HTTPPORT
+path/%TESTNUMBER %HOSTIP %HTTPPORT
 </command>
 </client>
 


### PR DESCRIPTION
Sync the test path with test1515. If fixes the test when the perl tool
resides on a path with spaces in it. E.g. when using the perl from Git
for Windows. This is a workaround, there may be a better fix this
type of issue.

Similar fix for test1515: 38b055446ae46e4568328fa90e96a87fe71c56a7

Failure:
```
test 1516...[caching of manual libcurl DNS entries after dead connection]
lib1515.exe returned 3, when expecting 0
 1516: exit FAILED
=== Start of file stderr1516
 Test: lib1515
[...]
 17:59:32.390000 == Info: Expire cleared
 request http://testserver.example.com:63621/C:/Program Files/Git/path/15160001 failed with 3
 Test ended with result 3
=== End of file stderr1516
```
Ref: https://github.com/curl/curl/actions/runs/13184790755/job/36804217128?pr=16217#step:13:2805
