### PR TITLE
runtests: fix the disabling of the memory tracking

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -670,11 +670,15 @@ sub checksystemfeatures {
             $feature{"alt-svc"} = $feat =~ /alt-svc/i;
             # HSTS support
             $feature{"HSTS"} = $feat =~ /HSTS/i;
+            $feature{"asyn-rr"} = $feat =~ /asyn-rr/;
             if($feat =~ /AsynchDNS/i) {
-                if(!$feature{"c-ares"}) {
+                if(!$feature{"c-ares"} || $feature{"asyn-rr"}) {
                     # this means threaded resolver
                     $feature{"threaded-resolver"} = 1;
                     $resolver="threaded";
+
+                    # does not count as "real" c-ares
+                    $feature{"c-ares"} = 0;
                 }
             }
             # http2 enabled
@@ -698,7 +702,6 @@ sub checksystemfeatures {
             # Thread-safe init
             $feature{"threadsafe"} = $feat =~ /threadsafe/i;
             $feature{"HTTPSRR"} = $feat =~ /HTTPSRR/;
-            $feature{"asyn-rr"} = $feat =~ /asyn-rr/;
         }
         #
         # Test harness currently uses a non-stunnel server in order to


### PR DESCRIPTION
It should be done if "threaded-resolver" is enabled, but the detection was slightly broken for builds that add c-ares for the asyn-rr feature.