### PR TITLE
asyn-thread: fix the returned bitmask from Curl_resolver_getsock

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -688,7 +688,7 @@ int Curl_resolver_getsock(struct Curl_easy *data, curl_socket_t *socks)
   if(td) {
     /* return read fd to client for polling the DNS resolution status */
     socks[socketi] = td->tsd.sock_pair[0];
-    ret_val = GETSOCK_READSOCK(socketi);
+    ret_val |= GETSOCK_READSOCK(socketi);
   }
   else {
 #endif


### PR DESCRIPTION
It should use a bitwise OR, not an assignment so that it does not override the c-ares bits.