### PR TITLE
add custom hostname support for ntlm via login options

### DIFF
--- a/docs/cmdline-opts/login-options.md
+++ b/docs/cmdline-opts/login-options.md
@@ -18,10 +18,10 @@ Example:
 
 Specify the login options to use during server authentication.
 
-You can use login options to specify protocol specific options that may be
-used during authentication. At present only IMAP, POP3 and SMTP support login
-options. For more information about login options please see RFC 2384,
-RFC 5092 and the IETF draft
+You can use login options to specify protocol specific options that may be used
+during authentication. At present only IMAP, NTLM, POP3 and SMTP support login
+options. For more information about login options please see RFC 2384, RFC 5092
+and the IETF draft
 https://datatracker.ietf.org/doc/html/draft-earhart-url-smtp-00
 
 Since 8.2.0, IMAP supports the login option `AUTH=+LOGIN`. With this option,
@@ -30,3 +30,9 @@ advertises SASL authentication. Care should be taken in using this option, as
 it sends your password over the network in plain text. This does not work if
 the IMAP server disables the plain `LOGIN` (e.g. to prevent password
 snooping).
+
+Since x.x.x, NTLM supports the login option `LOCALHOSTNAME=<workstation>`. With
+this option, curl explicitly sets the workstation name in the 3rd step of the
+NTLM handshake to the specified value. Old versions of curl transmitted the
+client's hostname as workstation name, whereas newer versions hardcode it to
+`WORKSTATION`.

--- a/docs/cmdline-opts/ntlm.md
+++ b/docs/cmdline-opts/ntlm.md
@@ -11,6 +11,7 @@ Added: 7.10.6
 Multi: mutex
 See-also:
   - proxy-ntlm
+  - login-options
 Example:
   - --ntlm -u user:password $URL
 ---

--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -631,8 +631,9 @@ CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
                                                    &conn->ntlm);
     if(!result)
       result = Curl_auth_create_ntlm_type3_message(data, conn->user,
-                                                   conn->passwd, &conn->ntlm,
-                                                   &resp);
+                                                   conn->passwd,
+                                                   conn->options,
+                                                   &conn->ntlm, &resp);
     break;
 #endif
 

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -132,6 +132,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
   const char *passwdp;
   const char *service = NULL;
   const char *hostname = NULL;
+  const char *options = NULL;
   const char *localhostname = NULL;
 
   /* point to the correct struct with this */
@@ -151,6 +152,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
     service = data->set.str[STRING_PROXY_SERVICE_NAME] ?
       data->set.str[STRING_PROXY_SERVICE_NAME] : "HTTP";
     hostname = conn->http_proxy.host.name;
+    options = conn->options;
     ntlm = &conn->proxyntlm;
     state = &conn->proxy_ntlm_state;
     authp = &data->state.authproxy;
@@ -165,7 +167,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
     service = data->set.str[STRING_SERVICE_NAME] ?
       data->set.str[STRING_SERVICE_NAME] : "HTTP";
     hostname = conn->host.name;
-    localhostname = conn->options;
+    options = conn->options;
     ntlm = &conn->ntlm;
     state = &conn->http_ntlm_state;
     authp = &data->state.authhost;
@@ -181,7 +183,11 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
 
   /* The fixed hostname we provide, in order to not leak our real local host
      name. Copy the name used by Firefox. Make it configurable. */
-  if(!localhostname)
+  if(options && strncasecompare(options, "LOCALHOSTNAME=", 14)) {
+    localhostname = strchr(options, '=');
+    localhostname++;
+  }
+  else
     localhostname = "WORKSTATION";
 
 #ifdef USE_WINDOWS_SSPI

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -235,7 +235,8 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
   case NTLMSTATE_TYPE2:
     /* We already received the type-2 message, create a type-3 message */
     result = Curl_auth_create_ntlm_type3_message(data, userp, passwdp,
-                                                 localhostname, ntlm, &ntlmmsg);
+                                                 localhostname, ntlm,
+                                                 &ntlmmsg);
     if(!result && Curl_bufref_len(&ntlmmsg)) {
       result = Curl_base64_encode((const char *) Curl_bufref_ptr(&ntlmmsg),
                                   Curl_bufref_len(&ntlmmsg), &base64, &len);

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -132,7 +132,7 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
   const char *passwdp;
   const char *service = NULL;
   const char *hostname = NULL;
-  const char *localhostname;
+  const char *localhostname = NULL;
 
   /* point to the correct struct with this */
   struct ntlmdata *ntlm;

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -558,6 +558,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
 CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              const char *userp,
                                              const char *passwdp,
+                                             const char *localhostname,
                                              struct ntlmdata *ntlm,
                                              struct bufref *out)
 {
@@ -590,9 +591,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
   unsigned char *ptr_ntresp = &ntresp[0];
   unsigned char *ntlmv2resp = NULL;
   bool unicode = (ntlm->flags & NTLMFLAG_NEGOTIATE_UNICODE);
-  /* The fixed hostname we provide, in order to not leak our real local host
-     name. Copy the name used by Firefox. */
-  static const char host[] = "WORKSTATION";
+  const char *host;
   const char *user;
   const char *domain = "";
   size_t hostoff = 0;
@@ -617,7 +616,9 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
     user = userp;
 
   userlen = strlen(user);
-  hostlen = sizeof(host) - 1;
+
+  host = localhostname;
+  hostlen = strlen(host);
 
   if(ntlm->flags & NTLMFLAG_NEGOTIATE_NTLM2_KEY) {
     unsigned char ntbuffer[0x18];

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -550,6 +550,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
  * data    [in]     - The session handle.
  * userp   [in]     - The username in the format User or Domain\User.
  * passwdp [in]     - The user's password.
+ * options [in]     - Login options holding localhostname
  * ntlm    [in/out] - The NTLM data struct being used and modified.
  * out     [out]    - The result storage.
  *
@@ -558,7 +559,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
 CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              const char *userp,
                                              const char *passwdp,
-                                             const char *localhostname,
+                                             const char *options,
                                              struct ntlmdata *ntlm,
                                              struct bufref *out)
 {
@@ -618,7 +619,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 
   userlen = strlen(user);
 
-  host = localhostname;
+  host = options;
   hostlen = strlen(host);
 
   if(ntlm->flags & NTLMFLAG_NEGOTIATE_NTLM2_KEY) {

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -237,6 +237,7 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
  * data    [in]     - The session handle.
  * userp   [in]     - The username in the format User or Domain\User.
  * passwdp [in]     - The user's password.
+ * options [in]     - Login options - unused
  * ntlm    [in/out] - The NTLM data struct being used and modified.
  * out     [out]    - The result storage.
  *
@@ -245,6 +246,7 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
 CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              const char *userp,
                                              const char *passwdp,
+                                             const char *options,
                                              struct ntlmdata *ntlm,
                                              struct bufref *out)
 {
@@ -262,6 +264,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 #endif
   (void) passwdp;
   (void) userp;
+  (void) options;
 
   /* Setup the type-2 "input" security buffer */
   type_2_desc.ulVersion     = SECBUFFER_VERSION;

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -162,6 +162,7 @@ CURLcode Curl_auth_decode_ntlm_type2_message(struct Curl_easy *data,
 CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              const char *userp,
                                              const char *passwdp,
+                                             const char *localhostname,
                                              struct ntlmdata *ntlm,
                                              struct bufref *out);
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -196,7 +196,7 @@ test1460 test1461 test1462 test1463 test1464 test1465 test1466 test1467 \
 test1468 test1469 test1470 test1471 test1472 test1473 test1474 test1475 \
 test1476 test1477 test1478 test1479 test1480 test1481 test1482 test1483 \
 test1484 test1485 test1486 test1487 test1488 test1489 test1490 test1491 \
-test1492 test1493 test1494 test1495 test1496 \
+test1492 test1493 test1494 test1495 test1496 test1497 \
 \
 test1500 test1501 test1502 test1503 test1504 test1505 test1506 test1507 \
 test1508 test1509 test1510 test1511 test1512 test1513 test1514 test1515 \

--- a/tests/data/test1497
+++ b/tests/data/test1497
@@ -1,0 +1,91 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+HTTP NTLM auth
+NTLM
+</keywords>
+</info>
+# Server-side
+<reply>
+
+<!-- no <data> in this test since we have NTLM from the start
+
+This is supposed to be returned when the server gets a first
+Authorization: NTLM line passed-in from the client -->
+
+<data1001>
+HTTP/1.1 401 Now gimme that second request of crap
+Server: Microsoft-IIS/5.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 34
+WWW-Authenticate: NTLM TlRMTVNTUAACAAAAAgACADAAAACGggEAc51AYVDgyNcAAAAAAAAAAG4AbgAyAAAAQ0MCAAQAQwBDAAEAEgBFAEwASQBTAEEAQgBFAFQASAAEABgAYwBjAC4AaQBjAGUAZABlAHYALgBuAHUAAwAsAGUAbABpAHMAYQBiAGUAdABoAC4AYwBjAC4AaQBjAGUAZABlAHYALgBuAHUAAAAAAA==
+
+This is not the real page either!
+</data1001>
+
+# This is supposed to be returned when the server gets the second
+# Authorization: NTLM line passed-in from the client
+<data1002>
+HTTP/1.1 200 Things are fine in server land swsclose
+Server: Microsoft-IIS/5.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</data1002>
+
+<datacheck>
+HTTP/1.1 401 Now gimme that second request of crap
+Server: Microsoft-IIS/5.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 34
+WWW-Authenticate: NTLM TlRMTVNTUAACAAAAAgACADAAAACGggEAc51AYVDgyNcAAAAAAAAAAG4AbgAyAAAAQ0MCAAQAQwBDAAEAEgBFAEwASQBTAEEAQgBFAFQASAAEABgAYwBjAC4AaQBjAGUAZABlAHYALgBuAHUAAwAsAGUAbABpAHMAYQBiAGUAdABoAC4AYwBjAC4AaQBjAGUAZABlAHYALgBuAHUAAAAAAA==
+
+HTTP/1.1 200 Things are fine in server land swsclose
+Server: Microsoft-IIS/5.0
+Content-Type: text/html; charset=iso-8859-1
+Content-Length: 32
+
+Finally, this is the real page!
+</datacheck>
+
+</reply>
+
+# Client-side
+<client>
+<features>
+NTLM
+SSL
+!SSPI
+</features>
+<server>
+http
+</server>
+<name>
+HTTP with NTLM authorization and custom workstation
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u testuser:testpass --ntlm --login-options LOCALHOSTNAME=TESTSTATION
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: NTLM TlRMTVNTUAABAAAABoIIAAAAAAAAAAAAAAAAAAAAAAA=
+User-Agent: curl/%VERSION
+Accept: */*
+
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+Authorization: NTLM TlRMTVNTUAADAAAAGAAYAEAAAAAYABgAWAAAAAAAAABwAAAACAAIAHAAAAALAAsAeAAAAAAAAAAAAAAAhoIBAFpkQwKRCZFMhjj0tw47wEjKHRHlvzfxQamFcheMuv8v+xeqphEO5V41xRd7R9deOXRlc3R1c2VyVEVTVFNUQVRJT04=
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Adds the ability to define the hostname sent during NTLM authentication. Users have therefore the option to go with the old computer name, the newer fixed WORKSTATION or define a custom one via `--login-options`.