### PR TITLE
wolfssl: silence compiler warning (MSVC 2019), simplify existing

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4107,11 +4107,6 @@ static CURLcode ftp_disconnect(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4706) /* assignment within conditional expression */
-#endif
-
 /***********************************************************************
  *
  * ftp_parse_url_path()
@@ -4202,7 +4197,8 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
         }
 
         /* parse the URL path into separate path components */
-        while((slashPos = strchr(curPos, '/'))) {
+        /* !checksrc! disable EQUALSNULL 1 */
+        while((slashPos = strchr(curPos, '/')) != NULL) {
           size_t compLen = slashPos - curPos;
 
           /* path starts with a slash: add that as a directory */
@@ -4265,10 +4261,6 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
   free(rawPath);
   return CURLE_OK;
 }
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 /* call this when the DO phase has completed */
 static CURLcode ftp_dophase_done(struct Curl_easy *data, bool connected)

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4198,7 +4198,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
 
         /* parse the URL path into separate path components */
         /* !checksrc! disable EQUALSNULL 1 */
-        while((slashPos = strchr(curPos, '/'))) {
+        while((slashPos = strchr(curPos, '/')) != NULL) {
           size_t compLen = slashPos - curPos;
 
           /* path starts with a slash: add that as a directory */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -4198,7 +4198,7 @@ CURLcode ftp_parse_url_path(struct Curl_easy *data)
 
         /* parse the URL path into separate path components */
         /* !checksrc! disable EQUALSNULL 1 */
-        while((slashPos = strchr(curPos, '/')) != NULL) {
+        while((slashPos = strchr(curPos, '/'))) {
           size_t compLen = slashPos - curPos;
 
           /* path starts with a slash: add that as a directory */

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -777,22 +777,15 @@ static void printsub(struct Curl_easy *data,
   }
 }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4706) /* assignment within conditional expression */
-#endif
 static bool str_is_nonascii(const char *str)
 {
   char c;
-  while((c = *str++))
+  while((c = *str++) != 0)
     if(c & 0x80)
       return TRUE;
 
   return FALSE;
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 static CURLcode check_telnet_options(struct Curl_easy *data)
 {

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -770,7 +770,7 @@ wssl_add_default_ciphers(bool tls13, struct dynbuf *buf)
   int i;
   char *str;
 
-  for(i = 0; (str = wolfSSL_get_cipher_list(i)); i++) {
+  for(i = 0; (str = wolfSSL_get_cipher_list(i)) != NULL; i++) {
     size_t n;
     if((strncmp(str, "TLS13", 5) == 0) != tls13)
       continue;

--- a/src/tool_writeout_json.c
+++ b/src/tool_writeout_json.c
@@ -118,11 +118,6 @@ void ourWriteOutJSON(FILE *stream, const struct writeoutvar mappings[],
   fprintf(stream, "}");
 }
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4706) /* assignment within conditional expression */
-#endif
-
 void headerJSON(FILE *stream, struct per_transfer *per)
 {
   struct curl_header *header;
@@ -130,7 +125,7 @@ void headerJSON(FILE *stream, struct per_transfer *per)
 
   fputc('{', stream);
   while((header = curl_easy_nextheader(per->curl, CURLH_HEADER, -1,
-                                       prev))) {
+                                       prev)) != NULL) {
     if(header->amount > 1) {
       if(!header->index) {
         /* act on the 0-index entry and pull the others in, then output in a
@@ -169,7 +164,3 @@ void headerJSON(FILE *stream, struct per_transfer *per)
   }
   fputs("\n}", stream);
 }
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif

--- a/tests/libtest/lib1945.c
+++ b/tests/libtest/lib1945.c
@@ -26,24 +26,18 @@
 
 #include "memdebug.h"
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4706) /* assignment within conditional expression */
-#endif
 static void showem(CURL *easy, unsigned int type)
 {
   struct curl_header *header = NULL;
   struct curl_header *prev = NULL;
 
-  while((header = curl_easy_nextheader(easy, type, 0, prev))) {
+  /* !checksrc! disable EQUALSNULL 1 */
+  while((header = curl_easy_nextheader(easy, type, 0, prev)) != NULL) {
     printf(" %s == %s (%u/%u)\n", header->name, header->value,
            (int)header->index, (int)header->amount);
     prev = header;
   }
 }
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 static size_t write_cb(char *data, size_t n, size_t l, void *userp)
 {


### PR DESCRIPTION
Seen with VS2019 and older versions:
```
lib\vtls\wolfssl.c(773): warning C4706: assignment within conditional expression
```
Ref: https://github.com/curl/curl/actions/runs/13190321645/job/36821938202?pr=16217#step:9:30

Also replace pragma suppression with this simpler method, and silence
`checksrc` where it complains about the extra ` != NULL` this needs.
