### PR TITLE
GHA/appveyor: add VS2019 job, merge two others, fix build fallout

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -28,18 +28,23 @@ set -eux; [ -n "${BASH:-}${ZSH_NAME:-}" ] && set -o pipefail
 
 # build
 
+case "${TARGET}" in
+  x64)   openssl_suffix='-Win64';;
+  Win32) openssl_suffix='-Win32';;
+esac
+
 if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
-  openssl_root_win='C:/OpenSSL-v34-Win64'
+  openssl_root_win="C:/OpenSSL-v34${openssl_suffix:-}"
 elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2019' ]; then
-  openssl_root_win='C:/OpenSSL-Win64'
+  openssl_root_win="C:/OpenSSL${openssl_suffix:-}"
 else
-  openssl_root_win='C:/OpenSSL-v111-Win64'
+  openssl_root_win="C:/OpenSSL-v111${openssl_suffix:-}"
 fi
 openssl_root="$(cygpath "${openssl_root_win}")"
 
 if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   options=''
-  [[ "${TARGET:-}" = *'ARM64'* ]] && SKIP_RUN='ARM64 architecture'
+  [[ "${TARGET}" = *'ARM64'* ]] && SKIP_RUN='ARM64 architecture'
   [ -n "${TOOLSET:-}" ] && options+=" -T ${TOOLSET}"
   [ "${OPENSSL}" = 'ON' ] && options+=" -DOPENSSL_ROOT_DIR=${openssl_root_win}"
   [ -n "${CURLDEBUG:-}" ] && options+=" -DENABLE_CURLDEBUG=${CURLDEBUG}"
@@ -47,7 +52,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
   [ "${PRJ_CFG}" = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
   [[ "${PRJ_GEN}" = *'Visual Studio'* ]] && options+=' -DCMAKE_VS_GLOBALS=TrackFileAccess=false'
   # shellcheck disable=SC2086
-  cmake -B _bld "-G${PRJ_GEN}" ${TARGET:-} ${options} \
+  cmake -B _bld "-G${PRJ_GEN}" ${TARGET} ${options} \
     "-DCURL_USE_OPENSSL=${OPENSSL}" \
     "-DCURL_USE_SCHANNEL=${SCHANNEL}" \
     "-DHTTP_ONLY=${HTTP_ONLY}" \

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -28,17 +28,17 @@ set -eux; [ -n "${BASH:-}${ZSH_NAME:-}" ] && set -o pipefail
 
 # build
 
-case "${TARGET}" in
-  *x64)   openssl_suffix='-Win64';;
+case "${TARGET:-}" in
   *Win32) openssl_suffix='-Win32';;
+  *)      openssl_suffix='-Win64';;
 esac
 
 if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
-  openssl_root_win="C:/OpenSSL-v34${openssl_suffix:-}"
+  openssl_root_win="C:/OpenSSL-v34${openssl_suffix}"
 elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2019' ]; then
-  openssl_root_win="C:/OpenSSL${openssl_suffix:-}"
+  openssl_root_win="C:/OpenSSL${openssl_suffix}"
 else
-  openssl_root_win="C:/OpenSSL-v111${openssl_suffix:-}"
+  openssl_root_win="C:/OpenSSL-v111${openssl_suffix}"
 fi
 openssl_root="$(cygpath "${openssl_root_win}")"
 

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -30,6 +30,8 @@ set -eux; [ -n "${BASH:-}${ZSH_NAME:-}" ] && set -o pipefail
 
 if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
   openssl_root_win='C:/OpenSSL-v34-Win64'
+elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2019' ]; then
+  openssl_root_win='C:/OpenSSL-Win64'
 else
   openssl_root_win='C:/OpenSSL-v111-Win64'
 fi

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -29,8 +29,8 @@ set -eux; [ -n "${BASH:-}${ZSH_NAME:-}" ] && set -o pipefail
 # build
 
 case "${TARGET}" in
-  x64)   openssl_suffix='-Win64';;
-  Win32) openssl_suffix='-Win32';;
+  *x64)   openssl_suffix='-Win64';;
+  *Win32) openssl_suffix='-Win32';;
 esac
 
 if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -73,7 +73,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       EXAMPLES: 'ON'
-    - job_name: 'CMake, VS2012, Release, x86, OpenSSL 1.1.1 + Schannel, Build-tests'
+    - job_name: 'CMake, VS2012, Release, x86, OpenSSL 1.1.1 + Schannel, Shared, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 11 2012'
@@ -83,7 +83,7 @@ environment:
       SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
-    - job_name: 'CMake, VS2013, Debug, x64, OpenSSL 1.1.1, Build-only'
+    - job_name: 'CMake, VS2013, Debug, x64, OpenSSL 1.1.1, Shared, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 12 2013'
@@ -94,7 +94,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       TFLAGS: 'skipall'
-    - job_name: 'CMake, VS2015, Debug, x64, OpenSSL 1.1.1, Build-only'
+    - job_name: 'CMake, VS2015, Debug, x64, OpenSSL 1.1.1, Shared, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 14 2015'
@@ -105,7 +105,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       TFLAGS: 'skipall'
-    - job_name: 'CMake, VS2017, Debug, x64, OpenSSL 1.1.1, Build-only'
+    - job_name: 'CMake, VS2017, Debug, x64, OpenSSL 1.1.1, Shared, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 15 2017'
@@ -116,7 +116,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       TFLAGS: 'skipall'
-    - job_name: 'CMake, VS2019, Debug, x64, OpenSSL 1.0.2 + Schannel, Build-tests'
+    - job_name: 'CMake, VS2019, Debug, x64, OpenSSL 1.0.2 + Schannel, Shared, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2019'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 16 2019'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -125,6 +125,16 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       TFLAGS: 'skipall'
+    - job_name: 'CMake, VS2019, Debug, x64, OpenSSL 1.0.2 + Schannel, Build-tests'
+      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2019'
+      BUILD_SYSTEM: CMake
+      PRJ_GEN: 'Visual Studio 16 2019'
+      TARGET: '-A x64'
+      PRJ_CFG: Debug
+      OPENSSL: 'ON'
+      SCHANNEL: 'ON'
+      ENABLE_UNICODE: 'OFF'
+      SHARED: 'ON'
     - job_name: 'CMake, VS2022, Debug, x64, Schannel, Static, Unicode, Build-tests & examples, clang-cl'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2022'
       BUILD_SYSTEM: CMake

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -94,7 +94,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       TFLAGS: 'skipall'
-    - job_name: 'CMake, VS2015, Debug, x64, OpenSSL 1.1.1, Shared, Build-only'
+    - job_name: 'CMake, VS2015, Debug, x64, OpenSSL 1.1.1, Static, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 14 2015'
@@ -103,7 +103,6 @@ environment:
       OPENSSL: 'ON'
       SCHANNEL: 'OFF'
       ENABLE_UNICODE: 'OFF'
-      SHARED: 'ON'
       TFLAGS: 'skipall'
     - job_name: 'CMake, VS2017, Debug, x64, OpenSSL 1.1.1, Shared, Build-only'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2017'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,15 +63,6 @@ environment:
       ENABLE_UNICODE: 'OFF'
       DEBUG: 'OFF'
       CURLDEBUG: 'ON'
-    - job_name: 'CMake, VS2010, Release, x86, Schannel, Static, Build-tests'
-      APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
-      BUILD_SYSTEM: CMake
-      PRJ_GEN: 'Visual Studio 10 2010'
-      TARGET: '-A Win32'
-      PRJ_CFG: Release
-      SCHANNEL: 'ON'
-      ENABLE_UNICODE: 'OFF'
-      SHARED: 'ON'
     - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-tests & examples'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
@@ -82,14 +73,14 @@ environment:
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
       EXAMPLES: 'ON'
-    - job_name: 'CMake, VS2012, Debug, x64, OpenSSL 1.1.1, Build-tests'
+    - job_name: 'CMake, VS2012, Release, x86, OpenSSL 1.1.1 + Schannel, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 11 2012'
-      TARGET: '-A x64'
-      PRJ_CFG: Debug
+      TARGET: '-A Win32'
+      PRJ_CFG: Release
       OPENSSL: 'ON'
-      SCHANNEL: 'OFF'
+      SCHANNEL: 'ON'
       ENABLE_UNICODE: 'OFF'
       SHARED: 'ON'
     - job_name: 'CMake, VS2013, Debug, x64, OpenSSL 1.1.1, Build-only'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ environment:
       ENABLE_UNICODE: 'OFF'
       DEBUG: 'OFF'
       CURLDEBUG: 'ON'
-    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Static, Build-tests & examples'
+    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Shared, Build-tests & examples'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       BUILD_SYSTEM: CMake
       PRJ_GEN: 'Visual Studio 10 2010'

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -79,9 +79,8 @@
 #include "memdebug.h"
 
 /* ALPN for http2 */
-#undef HAS_ALPN
 #if defined(USE_HTTP2) && defined(MBEDTLS_SSL_ALPN)
-#  define HAS_ALPN
+#  define HAS_ALPN_MBEDTLS
 #endif
 
 struct mbed_ssl_backend_data {
@@ -95,7 +94,7 @@ struct mbed_ssl_backend_data {
 #endif
   mbedtls_pk_context pk;
   mbedtls_ssl_config config;
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_MBEDTLS
   const char *protocols[3];
 #endif
   int *ciphersuites;
@@ -929,7 +928,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_MBEDTLS
   if(connssl->alpn) {
     struct alpn_proto_buf proto;
     size_t i;
@@ -1107,7 +1106,7 @@ pinnedpubkey_error:
     }
   }
 
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_MBEDTLS
   if(connssl->alpn) {
     const char *proto = mbedtls_ssl_get_alpn_protocol(&backend->ssl);
 

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -79,11 +79,9 @@
 #include "memdebug.h"
 
 /* ALPN for http2 */
-#ifdef USE_HTTP2
-#  undef HAS_ALPN
-#  ifdef MBEDTLS_SSL_ALPN
-#    define HAS_ALPN
-#  endif
+#undef HAS_ALPN
+#if defined(USE_HTTP2) && defined(MBEDTLS_SSL_ALPN)
+#  define HAS_ALPN
 #endif
 
 struct mbed_ssl_backend_data {

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2871,10 +2871,9 @@ static void ossl_trace(int direction, int ssl_ver, int content_type,
 /* ====================================================== */
 
 /* Check for OpenSSL 1.0.2 which has ALPN support. */
-#undef HAS_ALPN
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L       \
   && !defined(OPENSSL_NO_TLSEXT)
-#  define HAS_ALPN 1
+#  define HAS_ALPN_OPENSSL
 #endif
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) /* 1.1.0 */
@@ -3854,7 +3853,7 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
 #endif
 
   if(alpn && alpn_len) {
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_OPENSSL
     if(SSL_CTX_set_alpn_protos(octx->ssl_ctx, alpn, (int)alpn_len)) {
       failf(data, "Error setting ALPN");
       return CURLE_SSL_CONNECT_ERROR;
@@ -4192,7 +4191,7 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
   DEBUGASSERT(ssl_connect_1 == connssl->connecting_state);
   DEBUGASSERT(octx);
   memset(&proto, 0, sizeof(proto));
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_OPENSSL
   if(connssl->alpn) {
     result = Curl_alpn_to_proto_buf(&proto, connssl->alpn);
     if(result) {
@@ -4229,7 +4228,7 @@ static CURLcode ossl_connect_step1(struct Curl_cfilter *cf,
   SSL_set_bio(octx->ssl, bio, bio);
 #endif
 
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_OPENSSL
   if(connssl->alpn) {
     Curl_alpn_to_proto_str(&proto, connssl->alpn);
     infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
@@ -4541,7 +4540,7 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
 # endif  /* !OPENSSL_IS_BORINGSSL && !OPENSSL_IS_AWSLC */
 #endif  /* USE_ECH_OPENSSL */
 
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_OPENSSL
     /* Sets data and len to negotiated protocol, len is 0 if no protocol was
      * negotiated
      */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -76,6 +76,7 @@
 
    https://technet.microsoft.com/en-us/library/hh831771%28v=ws.11%29.aspx
 */
+#undef HAS_ALPN
 #if defined(_MSC_VER) && (_MSC_VER >= 1800) && !defined(_USING_V110_SDK71_)
 #  define HAS_ALPN 1
 #endif

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -76,9 +76,8 @@
 
    https://technet.microsoft.com/en-us/library/hh831771%28v=ws.11%29.aspx
 */
-#undef HAS_ALPN
 #if defined(_MSC_VER) && (_MSC_VER >= 1800) && !defined(_USING_V110_SDK71_)
-#  define HAS_ALPN 1
+#  define HAS_ALPN_SCHANNEL
 #endif
 
 #ifndef BCRYPT_CHACHA20_POLY1305_ALGORITHM
@@ -889,7 +888,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   SecBufferDesc outbuf_desc;
   SecBuffer inbuf;
   SecBufferDesc inbuf_desc;
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_SCHANNEL
   unsigned char alpn_buffer[128];
 #endif
   SECURITY_STATUS sspi_status = SEC_E_OK;
@@ -909,7 +908,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
           "connect to some servers due to lack of SNI, algorithms, etc.");
   }
 
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_SCHANNEL
   /* ALPN is only supported on Windows 8.1 / Server 2012 R2 and above.
      Also it does not seem to be supported for WINE, see curl bug #983. */
   backend->use_alpn = connssl->alpn &&
@@ -992,7 +991,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     infof(data, "schannel: using IP address, SNI is not supported by OS.");
   }
 
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_SCHANNEL
   if(backend->use_alpn) {
     int cur = 0;
     int list_start_index = 0;
@@ -1040,7 +1039,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
     InitSecBuffer(&inbuf, SECBUFFER_EMPTY, NULL, 0);
     InitSecBufferDesc(&inbuf_desc, &inbuf, 1);
   }
-#else /* HAS_ALPN */
+#else /* HAS_ALPN_SCHANNEL */
   InitSecBuffer(&inbuf, SECBUFFER_EMPTY, NULL, 0);
   InitSecBufferDesc(&inbuf_desc, &inbuf, 1);
 #endif
@@ -1534,7 +1533,7 @@ schannel_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
   CURLcode result = CURLE_OK;
   SECURITY_STATUS sspi_status = SEC_E_OK;
   CERT_CONTEXT *ccert_context = NULL;
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_SCHANNEL
   SecPkgContext_ApplicationProtocol alpn_result;
 #endif
 
@@ -1563,7 +1562,7 @@ schannel_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
     return CURLE_SSL_CONNECT_ERROR;
   }
 
-#ifdef HAS_ALPN
+#ifdef HAS_ALPN_SCHANNEL
   if(backend->use_alpn) {
     sspi_status =
       Curl_pSecFn->QueryContextAttributes(&backend->ctxt->ctxt_handle,


### PR DESCRIPTION
- add VS2019 job, with Schannel + OpenSSL 1.0.2.
  First MultiSSL job here and add the last missing modern VS version.

- fix builds with mixed ALPN capabilities in MultiSSL unity builds.
  Caused by reusing `HAS_ALPN` between TLS modules without
  resetting it. Fix it by using unique names for each backend.

- merge a VS2010 job into a VS2012. With MultiSSL and x86 OpenSSL.

- make a job static.

- fix `Shared`/`Static` in a job name.

- add `Shared` to job names.
