### PR TITLE
Avoid unnecessary -L for implicit link dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2252,6 +2252,7 @@ if(NOT CURL_DISABLE_INSTALL)
       endif()
     endif()
   endforeach()
+  list(APPEND _sys_libdirs ${CMAKE_C_IMPLICIT_LINK_DIRECTORIES})
 
   foreach(_libdir IN LISTS _custom_libdirs CURL_LIBDIRS)
     if(NOT CMAKE_VERSION VERSION_LESS 3.20)


### PR DESCRIPTION
The unnecessary `-L` may unexpectedly change the toolchain's chosen search order in implicit link directories.

Causing this error noticed by a vcpkg user, and reproduced, in the context of Android NDK r22b, API level 16, static library and CRT linkage:
~~~
configure:23635: checking whether libcurl is usable
configure:23669: armv7a-linux-androideabi16-clang -o conftest --sysroot=/home/runner/work/boinc/boinc/3rdParty/android/android-ndk-r22b/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DANDROID -DDECLARE_TIMEZONE -Wall -I/home/runner/work/boinc/boinc/3rdParty/buildCache/android/android-tc/arm/arm-linux-androideabi/include -O3 -fomit-frame-pointer -fPIE -march=armv7-a -mfloat-abi=softfp -mfpu=vfpv3-d16 -D__ANDROID_API__=16 -Wall  -I/home/runner/work/boinc/boinc/3rdParty/android/vcpkg/installed/arm-android/include -I/home/runner/work/boinc/boinc/3rdParty/android/vcpkg/installed/arm-android/lib/pkgconfig/../../include -DCURL_STATICLIB  -L/home/runner/work/boinc/boinc/3rdParty/android/vcpkg/installed/arm-android/lib -llog -fPIE -pie -latomic -static-libstdc++ -march=armv7-a -Wl,--fix-cortex-a8 -L/home/runner/work/boinc/boinc/3rdParty/android/vcpkg/installed/arm-android/lib conftest.c  -L/home/runner/work/boinc/boinc/3rdParty/android/vcpkg/installed/arm-android/lib/pkgconfig/../../lib -lcurl -L/home/runner/work/boinc/boinc/3rdParty/android/android-ndk-r22b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi -lssl -lcrypto -ldl -pthread -lz  >&5
clang: warning: argument unused during compilation: '-static-libstdc++' [-Wunused-command-line-argument]
ld: error: undefined symbol: bsd_signal
>>> referenced by legacy_signal_inlines.h:116 (/home/runner/work/boinc/boinc/3rdParty/android/android-ndk-r22b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/android/legacy_signal_inlines.h:116)
>>>               libcrypto-lib-ui_openssl.o:(read_string_inner) in archive /home/runner/work/boinc/boinc/3rdParty/android/vcpkg/installed/arm-android/lib/libcrypto.a

ld: error: undefined symbol: pthread_atfork
>>> referenced by libc_init_common.cpp:129 (bionic/libc/bionic/libc_init_common.cpp:129)
>>>               libc_init_common.o:(__libc_init_fork_handler()) in archive /home/runner/work/boinc/boinc/3rdParty/android/android-ndk-r22b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc.a
>>> referenced by guarded_pool_allocator_posix.cpp:109 (external/gwp_asan/gwp_asan/platform_specific/guarded_pool_allocator_posix.cpp:109)
>>>               guarded_pool_allocator_posix.o:(gwp_asan::GuardedPoolAllocator::installAtFork()) in archive /home/runner/work/boinc/boinc/3rdParty/android/android-ndk-r22b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc.a
>>> referenced by android_je_iterate.c:91 (external/jemalloc_new/src/android_je_iterate.c:91)
>>>               jemalloc.o:(je_malloc_disable_init) in archive /home/runner/work/boinc/boinc/3rdParty/android/android-ndk-r22b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi/libc.a
>>> referenced 1 more times
clang: error: linker command failed with exit code 1 (use -v to see invocation)
~~~
with the unnecessary option
~~~
-L/home/runner/work/boinc/boinc/3rdParty/android/android-ndk-r22b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/arm-linux-androideabi 
~~~
Reference: https://github.com/microsoft/vcpkg/pull/43463#issuecomment-2638611717