### PR TITLE
ignore test 987 on ci-windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -756,7 +756,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 10
         run: |
-          export TFLAGS='-j4 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
+          export TFLAGS='-j4 ~WebSockets ~SCP ~612 ~987 ${{ matrix.tflags }}'
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SFTP'
           elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then


### PR DESCRIPTION
This test is consistently failing everywhere without a known cause. CI Logs show that curl is unable to connect o smtps test server.