### PR TITLE
asyn-thread: do not allocate thread_data separately

### DIFF
--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -49,7 +49,6 @@ struct thread_sync_data {
 #ifdef HAVE_GETADDRINFO
   struct addrinfo hints;
 #endif
-  struct thread_data *td; /* for thread-self cleanup */
   int port;
   int sock_error;
   bool done;
@@ -64,6 +63,7 @@ struct thread_data {
   struct Curl_https_rrinfo hinfo;
   ares_channel channel;
 #endif
+  bool init;
 };
 
 #elif defined(CURLRES_ARES) /* CURLRES_THREADED */
@@ -79,7 +79,7 @@ struct thread_data {
 #ifdef USE_HTTPSRR
   struct Curl_https_rrinfo hinfo;
 #endif
-  char hostname[1];
+  char *hostname;
 };
 
 #endif /* CURLRES_ARES */

--- a/lib/httpsrr.c
+++ b/lib/httpsrr.c
@@ -100,7 +100,7 @@ static void httpsrr_opt(struct Curl_easy *data,
   size_t len = 0;
   const unsigned char *val = NULL;
   unsigned short code;
-  struct thread_data *res = data->state.async.tdata;
+  struct thread_data *res = &data->state.async.thdata;
   struct Curl_https_rrinfo *hi = &res->hinfo;
   code  = ares_dns_rr_get_opt(rr, key, idx, &val, &len);
 
@@ -138,7 +138,7 @@ void Curl_dnsrec_done_cb(void *arg, ares_status_t status,
   struct Curl_easy *data = arg;
   size_t i;
 #ifdef CURLRES_ARES
-  struct thread_data *res = data->state.async.tdata;
+  struct thread_data *res = &data->state.async.thdata;
 
   res->num_pending--;
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -568,7 +568,9 @@ struct hostname {
 struct Curl_async {
   char *hostname;
   struct Curl_dns_entry *dns;
-  struct thread_data *tdata;
+#ifdef CURLRES_ASYNCH
+  struct thread_data thdata;
+#endif
   void *resolver; /* resolver state, if it is used in the URL state -
                      ares_channel e.g. */
   int port;


### PR DESCRIPTION
Put the full struct into Curl_async since it will be used for every name resolve anyway.

cherry-picked from  #16219