### PR TITLE
asyn-thread: survive a c-ares channel set to NULL

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -109,6 +109,9 @@ int Curl_ares_perform(ares_channel channel,
   int i;
   int num = 0;
 
+  if(!channel)
+    return 0;
+
   bitmask = ares_getsock(channel, socks, ARES_GETSOCK_MAXNUM);
 
   for(i = 0; i < ARES_GETSOCK_MAXNUM; i++) {

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -383,7 +383,8 @@ static void destroy_async_data(struct Curl_easy *data)
 #endif
 
 #ifdef USE_HTTPSRR_ARES
-    ares_destroy(data->state.async.tdata->channel);
+    if(data->state.async.tdata->channel)
+      ares_destroy(data->state.async.tdata->channel);
 #endif
     /*
      * if the thread is still blocking in the resolve syscall, detach it and
@@ -490,7 +491,7 @@ static bool init_resolve_thread(struct Curl_easy *data,
   }
 #ifdef USE_HTTPSRR_ARES
   if(resolve_httpsrr(data, asp))
-    goto err_exit;
+    infof(data, "Failed HTTPS RR operation");
 #endif
   return TRUE;
 
@@ -670,7 +671,7 @@ int Curl_resolver_getsock(struct Curl_easy *data, curl_socket_t *socks)
 #endif
 
 #ifdef USE_HTTPSRR_ARES
-  if(data->state.async.tdata) {
+  if(data->state.async.tdata && data->state.async.tdata->channel) {
     ret_val = Curl_ares_getsock(data, data->state.async.tdata->channel, socks);
     for(socketi = 0; socketi < (MAX_SOCKSPEREASYHANDLE - 1); socketi++)
       if(!ARES_GETSOCK_READABLE(ret_val, socketi) &&


### PR DESCRIPTION
When the c-ares setup fails and we get a NULL channel, the resolve still continues and we just need to survive it and just not get any HTTPS RR.

Reported-by: nono303 on github
Fixes #16216