### PR TITLE
CURLSHOPT_SHARE.md: Adjust for the new SSL session cache

### DIFF
--- a/docs/libcurl/opts/CURLSHOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLSHOPT_SHARE.md
@@ -47,17 +47,17 @@ It is not supported to share cookies between multiple concurrent threads.
 
 Cached DNS hosts are shared across the easy handles using this shared
 object. Note that when you use the multi interface, all easy handles added to
-the same multi handle share DNS cache by default without using this option.
+the same multi handle share the DNS cache by default without using this option.
 
 ## CURL_LOCK_DATA_SSL_SESSION
 
-SSL session IDs are shared across the easy handles using this shared
+SSL sessions are shared across the easy handles using this shared
 object. This reduces the time spent in the SSL handshake when reconnecting to
-the same server. Note SSL session IDs are reused within the same easy handle
-by default. Note this symbol was added in 7.10.3 but was not implemented until
+the same server. This symbol was added in 7.10.3 but was not implemented until
 7.23.0.
 
-It is not supported to share SSL sessions between multiple concurrent threads.
+Note that when you use the multi interface, all easy handles added to the same
+multi handle share the SSL session cache by default without using this option.
 
 ## CURL_LOCK_DATA_CONNECT
 
@@ -75,7 +75,7 @@ Support for **CURL_LOCK_DATA_CONNECT** was added in 7.57.0, but the symbol
 existed before this.
 
 Note that when you use the multi interface, all easy handles added to the same
-multi handle shares connection cache by default without using this option.
+multi handle share the connection cache by default without using this option.
 
 ## CURL_LOCK_DATA_PSL
 
@@ -86,7 +86,7 @@ refreshed, this avoids updates in too many different contexts.
 Added in 7.61.0.
 
 Note that when you use the multi interface, all easy handles added to the same
-multi handle shares PSL cache by default without using this option.
+multi handle share the PSL cache by default without using this option.
 
 ## CURL_LOCK_DATA_HSTS
 


### PR DESCRIPTION
curl 8.12.0 introduced an improved SSL session cache. All easy handles that are added to the same multi handle automatically use the multi handle's SSL session cache.