### PR TITLE
Fix undeterministic zsh completion script output

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -47,7 +47,7 @@ if CROSSCOMPILING
 	@echo "NOTICE: we can't generate zsh completion when cross-compiling!"
 else # if not cross-compiling:
 	if test -z "$(PERL)"; then echo "No perl: can't install completion script"; else \
-	$(PERL) $(srcdir)/completion.pl --curl $(top_builddir)/src/curl$(EXEEXT) --shell zsh > $@ ; fi
+	$(PERL) $(srcdir)/completion.pl --shell zsh > $@ ; fi
 endif
 endif
 
@@ -57,7 +57,7 @@ if CROSSCOMPILING
 	@echo "NOTICE: we can't generate fish completion when cross-compiling!"
 else # if not cross-compiling:
 	if test -z "$(PERL)"; then echo "No perl: can't install completion script"; else \
-	$(PERL) $(srcdir)/completion.pl --curl $(top_builddir)/src/curl$(EXEEXT) --shell fish > $@ ; fi
+	$(PERL) $(srcdir)/completion.pl --shell fish > $@ ; fi
 endif
 endif
 


### PR DESCRIPTION
Related to #16072

Modify the zsh completion script to use source code as input instead of dynamic `--help` output.

* **scripts/completion.pl**
  - Change `parse_main_opts` to read source code files instead of calling `curl --help all`.
  - Update the regex pattern to match option definitions in the source code files.
  - Add a function `read_source_files` to read and parse source code files for options and descriptions.

* **scripts/Makefile.am**
  - Update the `completion.pl` target to use the new source code parsing function.

