### PR TITLE
generate.bat: remove curl_get_line.c from the curlx file list

### DIFF
--- a/projects/generate.bat
+++ b/projects/generate.bat
@@ -155,7 +155,6 @@ rem
       call :element %1 lib "timediff.c" %3
       call :element %1 lib "nonblock.c" %3
       call :element %1 lib "warnless.c" %3
-      call :element %1 lib "curl_get_line.c" %3
       call :element %1 lib "curl_multibyte.c" %3
       call :element %1 lib "version_win32.c" %3
       call :element %1 lib "dynbuf.c" %3
@@ -168,7 +167,6 @@ rem
       call :element %1 lib "nonblock.h" %3
       call :element %1 lib "warnless.h" %3
       call :element %1 lib "curl_ctype.h" %3
-      call :element %1 lib "curl_get_line.h" %3
       call :element %1 lib "curl_multibyte.h" %3
       call :element %1 lib "version_win32.h" %3
       call :element %1 lib "dynbuf.h" %3


### PR DESCRIPTION
Follow-up to d8618f4d which did the same for the other build systems.

Closes #xxxxx