### PR TITLE
openssl: fix out of scope variables in goto

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1296,7 +1296,9 @@ int cert_stuff(struct Curl_easy *data,
   if(cert_file || cert_blob || (file_type == SSL_FILETYPE_ENGINE) ||
      (file_type == SSL_FILETYPE_PROVIDER)) {
     SSL *ssl;
-    X509 *x509;
+    X509 *x509 = NULL;
+    EVP_PKEY *pri = NULL;
+    STACK_OF(X509) *ca = NULL;
     int cert_done = 0;
     int cert_use_result;
 
@@ -1485,8 +1487,6 @@ int cert_stuff(struct Curl_easy *data,
     {
       BIO *cert_bio = NULL;
       PKCS12 *p12 = NULL;
-      EVP_PKEY *pri;
-      STACK_OF(X509) *ca = NULL;
       if(cert_blob) {
         cert_bio = BIO_new_mem_buf(cert_blob->data, (int)(cert_blob->len));
         if(!cert_bio) {
@@ -1527,8 +1527,7 @@ int cert_stuff(struct Curl_easy *data,
 
       PKCS12_PBE_add();
 
-      if(!PKCS12_parse(p12, key_passwd, &pri, &x509,
-                       &ca)) {
+      if(!PKCS12_parse(p12, key_passwd, &pri, &x509, &ca)) {
         failf(data,
               "could not parse PKCS12 file, check password, " OSSL_PACKAGE
               " error %s",


### PR DESCRIPTION
Some of the 'goto fail' situations could happen without having initialized the local variables referenced in the error code flow.

Reported-by: Marcel Raad
Fixes #16246