### PR TITLE
curl_global_sslset.md: Add SSL backend names

### DIFF
--- a/docs/libcurl/curl_global_sslset.md
+++ b/docs/libcurl/curl_global_sslset.md
@@ -64,16 +64,17 @@ If this is not thread-safe, you must not call this function when any other
 thread in the program (i.e. a thread sharing the same memory) is running.
 This does not just mean no other thread that is using libcurl.
 
-# OpenSSL
+# Names
+
+SSL backend names (case-insensitive): BearSSL, GnuTLS, mbedTLS, OpenSSL,
+Rustls, Schannel, Secure-Transport, wolfSSL
 
 The name "OpenSSL" is used for all versions of OpenSSL and its associated
 forks/flavors in this function. OpenSSL, BoringSSL, LibreSSL, quictls and
 AmiSSL are all supported by libcurl, but in the eyes of
 curl_global_sslset(3) they are all just "OpenSSL". They all mostly
-provide the same API.
-
-curl_version_info(3) can return more specific info about the exact
-OpenSSL flavor and version number is use.
+provide the same API. curl_version_info(3) can return more specific info about
+the exact OpenSSL flavor and version number in use.
 
 # struct
 

--- a/docs/libcurl/libcurl-env.md
+++ b/docs/libcurl/libcurl-env.md
@@ -51,8 +51,8 @@ backend at first use. If no selection is done by the program using libcurl,
 this variable's selection is used. Setting a name that is not a built-in
 alternative makes libcurl stay with the default.
 
-SSL backend names (case-insensitive): BearSSL, GnuTLS, mbedTLS,
-nss, OpenSSL, Rustls, Schannel, Secure-Transport, wolfSSL
+SSL backend names (case-insensitive): BearSSL, GnuTLS, mbedTLS, OpenSSL,
+Rustls, Schannel, Secure-Transport, wolfSSL
 
 ## `HOME`
 


### PR DESCRIPTION
- Add the names that can be used to select an SSL backend by name.

This change syncs the names in 3 places: curl_global_sslset documentation, the curl tool environment variable documentation for CURL_SSL_BACKEND and the libcurl environment variable documentation for CURL_SSL_BACKEND.

Closes #xxxx