### PR TITLE
vtls: fix multissl-init

### DIFF
--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -915,7 +915,9 @@ static int multissl_init(void)
 {
   if(multissl_setup(NULL))
     return 1;
-  return Curl_ssl->init();
+  if(Curl_ssl->init)
+    return Curl_ssl->init();
+  return 1;
 }
 
 static CURLcode multissl_connect(struct Curl_cfilter *cf,


### PR DESCRIPTION
Regression since and follow-up to 2bf48b48b3e564bcbf3249.

Don't call init functions that are set to NULL.

Fixes #16253
Reported-by: thisisgk on github