### PR TITLE
eliminate 'data->state.ssl_scache'

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1584,10 +1584,6 @@ static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
       if(data->share->hsts == data->hsts)
         data->hsts = NULL;
 #endif
-#ifdef USE_SSL
-      if(data->share->ssl_scache == data->state.ssl_scache)
-        data->state.ssl_scache = data->multi ? data->multi->ssl_scache : NULL;
-#endif
 #ifdef USE_LIBPSL
       if(data->psl == &data->share->psl)
         data->psl = data->multi ? &data->multi->psl : NULL;
@@ -1627,10 +1623,6 @@ static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
         Curl_hsts_cleanup(&data->hsts);
         data->hsts = data->share->hsts;
       }
-#endif
-#ifdef USE_SSL
-      if(data->share->ssl_scache)
-        data->state.ssl_scache = data->share->ssl_scache;
 #endif
 #ifdef USE_LIBPSL
       if(data->share->specifier & (1 << CURL_LOCK_DATA_PSL))

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -567,12 +567,6 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
 #endif
   data->state.httpreq = data->set.method;
 
-#ifdef USE_SSL
-  if(!data->state.ssl_scache)
-    /* There was no ssl session cache set via a share, use the multi one */
-    data->state.ssl_scache = data->multi->ssl_scache;
-#endif
-
   data->state.requests = 0;
   data->state.followlocation = 0; /* reset the location-follow counter */
   data->state.this_is_a_follow = FALSE; /* reset this */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1199,7 +1199,6 @@ struct UrlState {
   curl_prot_t first_remote_protocol;
 
   int retrycount; /* number of retries on a new connection */
-  struct Curl_ssl_scache *ssl_scache; /* TLS session pool */
   int os_errno;  /* filled in with errno whenever an error occurs */
   long followlocation; /* redirect counter */
   int requests; /* request counter: redirects + authentication retakes */

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -272,6 +272,6 @@ test3032 \
 \
 test3100 test3101 test3102 test3103 test3104 test3105 \
 test3200 \
-test3201 test3202 test3203 test3204 test3205 test3207
+test3201 test3202 test3203 test3204 test3205 test3207 test3208
 
 EXTRA_DIST = $(TESTCASES) DISABLED

--- a/tests/data/test3208
+++ b/tests/data/test3208
@@ -1,0 +1,60 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+libtest
+</keywords>
+</info>
+#
+# Server-side
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+# Client-side
+<client>
+<server>
+https
+</server>
+# tool is what to use instead of 'curl'
+<tool>
+lib%TESTNUMBER
+</tool>
+
+<name>
+curl_easy_perform then curl_multi_perform the same handle
+</name>
+<command>
+https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPSPORT
+Accept: */*
+
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPSPORT
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -76,7 +76,7 @@ LIBTESTPROGS = libauthretry libntlmconnect libprereq                     \
  lib2402 lib2404 lib2405 \
  lib2502 \
  lib3010 lib3025 lib3026 lib3027 \
- lib3100 lib3101 lib3102 lib3103 lib3104 lib3105 lib3207
+ lib3100 lib3101 lib3102 lib3103 lib3104 lib3105 lib3207 lib3208
 
 libntlmconnect_SOURCES = libntlmconnect.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 libntlmconnect_LDADD = $(TESTUTIL_LIBS)
@@ -736,3 +736,6 @@ lib3105_SOURCES = lib3105.c $(SUPPORTFILES)
 
 lib3207_SOURCES = lib3207.c $(SUPPORTFILES) $(TESTUTIL) $(THREADS) $(WARNLESS) $(MULTIBYTE)
 lib3207_LDADD = $(TESTUTIL_LIBS)
+
+lib3208_SOURCES = lib3208.c $(SUPPORTFILES) $(TESTUTIL)
+lib3208_LDADD = $(TESTUTIL_LIBS)

--- a/tests/libtest/lib3208.c
+++ b/tests/libtest/lib3208.c
@@ -1,0 +1,100 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+#include "test.h"
+
+#include "testutil.h"
+#include "warnless.h"
+#include "memdebug.h"
+
+#define TEST_HANG_TIMEOUT 60 * 1000
+
+CURLcode test(char *URL)
+{
+  CURL *curl = NULL;
+  CURLM *multi = NULL;
+  int still_running;
+  CURLcode i = TEST_ERR_FAILURE;
+  CURLcode res = CURLE_OK;
+  CURLMsg *msg;
+
+  start_test_timing();
+
+  global_init(CURL_GLOBAL_ALL);
+
+  multi_init(multi);
+
+  easy_init(curl);
+
+  easy_setopt(curl, CURLOPT_URL, URL);
+  easy_setopt(curl, CURLOPT_HEADER, 1L);
+  /* no peer verify */
+  easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 0L);
+  easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 0L);
+
+  /* first, make an easy perform with the handle */
+  curl_easy_perform(curl);
+
+  /* then proceed and use it for a multi perform */
+  multi_add_handle(multi, curl);
+
+  multi_perform(multi, &still_running);
+
+  abort_on_test_timeout();
+
+  while(still_running) {
+    CURLMcode mres;
+    int num;
+    mres = curl_multi_wait(multi, NULL, 0, TEST_HANG_TIMEOUT, &num);
+    if(mres != CURLM_OK) {
+      printf("curl_multi_wait() returned %d\n", mres);
+      res = TEST_ERR_MAJOR_BAD;
+      goto test_cleanup;
+    }
+
+    abort_on_test_timeout();
+
+    multi_perform(multi, &still_running);
+
+    abort_on_test_timeout();
+  }
+
+  msg = curl_multi_info_read(multi, &still_running);
+  if(msg)
+    /* this should now contain a result code from the easy handle,
+       get it */
+    i = msg->data.result;
+
+test_cleanup:
+
+  /* undocumented cleanup sequence - type UA */
+
+  curl_multi_cleanup(multi);
+  curl_easy_cleanup(curl);
+  curl_global_cleanup();
+
+  if(res)
+    i = res;
+
+  return i; /* return the final return code */
+}


### PR DESCRIPTION
Keeping the relevant 'ssl_scache' in 'data->state' leads to problems when the owner of the cache is cleaned up and this reference is left dangling.

Remove the ref entirely and always find the ssl_scache at the curren share or multi.

Folded in #16260 to verify this fixes the bug with a dangling reference when an easy handle is used with easy_perform first and in a multi_perform after.

refs #16236