### PR TITLE
GHA/windows: restore runtests perf with last known good Git for Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,6 +36,33 @@ concurrency:
 permissions: {}
 
 jobs:
+  build-cache:
+    runs-on: windows-latest
+    steps:
+      - name: 'cache Git for Windows'
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        id: cache-git-for-windows
+        env:
+          cache-name: cache-git-for-windows
+        with:
+          path: ~/_gfw
+          key: ${{ runner.os }}-${{ env.cache-name }}-v2.46.2.windows.1
+
+      - name: 'install Git for Windows'
+        if: steps.cache-git-for-windows.outputs.cache-hit != 'true'
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          mkdir "$HOME/_gfw"
+          cd "$HOME/_gfw" || exit 1
+          # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
+          # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
+          #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 \
+            --location https://github.com/git-for-windows/git/releases/download/v2.46.2.windows.1/PortableGit-2.46.2-64-bit.7z.exe --output bin.7z
+          7z x -bd -y bin.7z
+          rm -f bin.7z
+
   cygwin:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
     runs-on: windows-latest
@@ -358,6 +385,8 @@ jobs:
     name: 'dl-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
     timeout-minutes: 20
+    needs:
+      - build-cache
     defaults:
       run:
         shell: C:\_gfw\usr\bin\bash.exe {0}
@@ -387,19 +416,15 @@ jobs:
             tflags: 'skiprun'
       fail-fast: false
     steps:
-      - name: 'install known good Git for Windows'
-        shell: bash
-        timeout-minutes: 5
-        run: |
-          mkdir /c/_gfw
-          cd /c/_gfw || exit 1
-          # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
-          # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
-          #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 \
-            --location https://github.com/git-for-windows/git/releases/download/v2.46.2.windows.1/PortableGit-2.46.2-64-bit.7z.exe --output bin.7z
-          7z x -bd -y bin.7z
-          rm -f bin.7z
+      - name: 'cache Git for Windows'
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        id: cache-git-for-windows
+        env:
+          cache-name: cache-git-for-windows
+        with:
+          path: ~/_gfw
+          key: ${{ runner.os }}-${{ env.cache-name }}-v2.46.2.windows.1
+          fail-on-cache-miss: true
 
       - name: 'cache compiler (gcc ${{ matrix.env }})'
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
@@ -584,6 +609,8 @@ jobs:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
     runs-on: windows-latest
     timeout-minutes: 55
+    needs:
+      - build-cache
     defaults:
       run:
         shell: C:\_gfw\usr\bin\bash.exe {0}
@@ -677,19 +704,15 @@ jobs:
 
       fail-fast: false
     steps:
-      - name: 'install known good Git for Windows'
-        shell: bash
-        timeout-minutes: 5
-        run: |
-          mkdir /c/_gfw
-          cd /c/_gfw || exit 1
-          # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
-          # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
-          #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 \
-            --location https://github.com/git-for-windows/git/releases/download/v2.46.2.windows.1/PortableGit-2.46.2-64-bit.7z.exe --output bin.7z
-          7z x -bd -y bin.7z
-          rm -f bin.7z
+      - name: 'cache Git for Windows'
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
+        id: cache-git-for-windows
+        env:
+          cache-name: cache-git-for-windows
+        with:
+          path: ~/_gfw
+          key: ${{ runner.os }}-{{ env.cache-name }}-v2.46.2.windows.1
+          fail-on-cache-miss: true
 
       - name: 'vcpkg cache setup'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -360,7 +360,7 @@ jobs:
     timeout-minutes: 20
     defaults:
       run:
-        shell: C:\msys64\usr\bin\bash.exe {0}
+        shell: C:\_gfw\usr\bin\bash.exe {0}
     strategy:
       matrix:
         include:
@@ -387,6 +387,20 @@ jobs:
             tflags: 'skiprun'
       fail-fast: false
     steps:
+      - name: 'install known good Git for Windows'
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          mkdir /c/_gfw
+          cd /c/_gfw || exit 1
+          # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
+          # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
+          #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 \
+            --location https://github.com/git-for-windows/git/releases/download/v2.46.2.windows.1/PortableGit-2.46.2-64-bit.7z.exe --output bin.7z
+          7z x -bd -y bin.7z
+          rm -f bin.7z
+
       - name: 'cache compiler (gcc ${{ matrix.env }})'
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
         id: cache-compiler
@@ -417,6 +431,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
           cmake -B bld -G 'MSYS Makefiles' ${options} \
@@ -440,6 +455,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -454,6 +470,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -469,17 +486,19 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          export TFLAGS='-j4 ~WebSockets ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ~WebSockets ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
 
   linux-cross-mingw-w64:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -487,7 +487,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          export TFLAGS='-j8 ~WebSockets ${{ matrix.tflags }}'
+          export TFLAGS='-j4 ~WebSockets ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -567,7 +567,7 @@ jobs:
     timeout-minutes: 55
     defaults:
       run:
-        shell: C:\msys64\usr\bin\bash.exe {0}
+        shell: C:\_gfw\usr\bin\bash.exe {0}
     env:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
       VCPKG_DISABLE_METRICS: '1'
@@ -658,6 +658,20 @@ jobs:
 
       fail-fast: false
     steps:
+      - name: 'install known good Git for Windows'
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          mkdir /c/_gfw
+          cd /c/_gfw || exit 1
+          # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
+          # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
+          #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 \
+            --location https://github.com/git-for-windows/git/releases/download/v2.46.2.windows.1/PortableGit-2.46.2-64-bit.7z.exe --output bin.7z
+          7z x -bd -y bin.7z
+          rm -f bin.7z
+
       - name: 'vcpkg cache setup'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         with:
@@ -682,7 +696,7 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
-          PATH="/c/msys64/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           if [ '${{ matrix.plat }}' = 'uwp' ]; then
             options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             cflags='-DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP'
@@ -721,7 +735,7 @@ jobs:
       - name: 'build'
         timeout-minutes: 5
         run: |
-          PATH="/c/msys64/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -737,7 +751,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
         run: |
-          PATH="/c/msys64/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -756,18 +770,18 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 10
         run: |
-          export TFLAGS='-j4 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SFTP'
           elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then
             TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
-          PATH="/c/msys64/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
-          PATH="/c/msys64/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -360,7 +360,7 @@ jobs:
     timeout-minutes: 20
     defaults:
       run:
-        shell: C:\_gfw\usr\bin\bash.exe {0}
+        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && 'C:\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
     strategy:
       matrix:
         include:
@@ -388,6 +388,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 'install known good Git for Windows'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         shell: bash
         timeout-minutes: 5
         run: |
@@ -431,7 +432,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
           cmake -B bld -G 'MSYS Makefiles' ${options} \
@@ -455,7 +456,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -470,7 +471,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -491,14 +492,14 @@ jobs:
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
 
   linux-cross-mingw-w64:
@@ -586,7 +587,7 @@ jobs:
     timeout-minutes: 55
     defaults:
       run:
-        shell: C:\_gfw\usr\bin\bash.exe {0}
+        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && 'C:\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
     env:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
       VCPKG_DISABLE_METRICS: '1'
@@ -678,6 +679,7 @@ jobs:
       fail-fast: false
     steps:
       - name: 'install known good Git for Windows'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         shell: bash
         timeout-minutes: 5
         run: |
@@ -715,7 +717,7 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           if [ '${{ matrix.plat }}' = 'uwp' ]; then
             options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             cflags='-DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP'
@@ -754,7 +756,7 @@ jobs:
       - name: 'build'
         timeout-minutes: 5
         run: |
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -770,7 +772,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
         run: |
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -796,11 +798,11 @@ jobs:
             TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
-          PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,33 +36,6 @@ concurrency:
 permissions: {}
 
 jobs:
-  build-cache:
-    runs-on: windows-latest
-    steps:
-      - name: 'cache Git for Windows'
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        id: cache-git-for-windows
-        env:
-          cache-name: cache-git-for-windows
-        with:
-          path: ~/_gfw
-          key: ${{ runner.os }}-${{ env.cache-name }}-v2.46.2.windows.1
-
-      - name: 'install Git for Windows'
-        if: steps.cache-git-for-windows.outputs.cache-hit != 'true'
-        shell: bash
-        timeout-minutes: 5
-        run: |
-          mkdir "$HOME/_gfw"
-          cd "$HOME/_gfw" || exit 1
-          # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
-          # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
-          #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 \
-            --location https://github.com/git-for-windows/git/releases/download/v2.46.2.windows.1/PortableGit-2.46.2-64-bit.7z.exe --output bin.7z
-          7z x -bd -y bin.7z
-          rm -f bin.7z
-
   cygwin:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
     runs-on: windows-latest
@@ -385,8 +358,6 @@ jobs:
     name: 'dl-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
     timeout-minutes: 20
-    needs:
-      - build-cache
     defaults:
       run:
         shell: C:\_gfw\usr\bin\bash.exe {0}
@@ -416,15 +387,19 @@ jobs:
             tflags: 'skiprun'
       fail-fast: false
     steps:
-      - name: 'cache Git for Windows'
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        id: cache-git-for-windows
-        env:
-          cache-name: cache-git-for-windows
-        with:
-          path: ~/_gfw
-          key: ${{ runner.os }}-${{ env.cache-name }}-v2.46.2.windows.1
-          fail-on-cache-miss: true
+      - name: 'install known good Git for Windows'
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          mkdir /c/_gfw
+          cd /c/_gfw || exit 1
+          # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
+          # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
+          #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 \
+            --location https://github.com/git-for-windows/git/releases/download/v2.46.2.windows.1/PortableGit-2.46.2-64-bit.7z.exe --output bin.7z
+          7z x -bd -y bin.7z
+          rm -f bin.7z
 
       - name: 'cache compiler (gcc ${{ matrix.env }})'
         uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
@@ -609,8 +584,6 @@ jobs:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
     runs-on: windows-latest
     timeout-minutes: 55
-    needs:
-      - build-cache
     defaults:
       run:
         shell: C:\_gfw\usr\bin\bash.exe {0}
@@ -704,15 +677,19 @@ jobs:
 
       fail-fast: false
     steps:
-      - name: 'cache Git for Windows'
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4
-        id: cache-git-for-windows
-        env:
-          cache-name: cache-git-for-windows
-        with:
-          path: ~/_gfw
-          key: ${{ runner.os }}-{{ env.cache-name }}-v2.46.2.windows.1
-          fail-on-cache-miss: true
+      - name: 'install known good Git for Windows'
+        shell: bash
+        timeout-minutes: 5
+        run: |
+          mkdir /c/_gfw
+          cd /c/_gfw || exit 1
+          # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
+          # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
+          #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 \
+            --location https://github.com/git-for-windows/git/releases/download/v2.46.2.windows.1/PortableGit-2.46.2-64-bit.7z.exe --output bin.7z
+          7z x -bd -y bin.7z
+          rm -f bin.7z
 
       - name: 'vcpkg cache setup'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -391,8 +391,8 @@ jobs:
         shell: bash
         timeout-minutes: 5
         run: |
-          mkdir /c/_gfw
-          cd /c/_gfw || exit 1
+          mkdir "$HOME/_gfw"
+          cd "$HOME/_gfw" || exit 1
           # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
           # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
           #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
@@ -431,7 +431,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
           cmake -B bld -G 'MSYS Makefiles' ${options} \
@@ -455,7 +455,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -470,7 +470,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -491,14 +491,14 @@ jobs:
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
 
   linux-cross-mingw-w64:
@@ -681,8 +681,8 @@ jobs:
         shell: bash
         timeout-minutes: 5
         run: |
-          mkdir /c/_gfw
-          cd /c/_gfw || exit 1
+          mkdir "$HOME/_gfw"
+          cd "$HOME/_gfw" || exit 1
           # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
           # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
           #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
@@ -715,7 +715,7 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           if [ '${{ matrix.plat }}' = 'uwp' ]; then
             options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             cflags='-DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP'
@@ -754,7 +754,7 @@ jobs:
       - name: 'build'
         timeout-minutes: 5
         run: |
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -770,7 +770,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
         run: |
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -796,11 +796,11 @@ jobs:
             TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
-          PATH="/c/_gfw/usr/bin:$PATH"
+          PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -391,8 +391,8 @@ jobs:
         shell: bash
         timeout-minutes: 5
         run: |
-          mkdir "$HOME/_gfw"
-          cd "$HOME/_gfw" || exit 1
+          mkdir /c/_gfw
+          cd /c/_gfw || exit 1
           # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
           # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
           #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
@@ -431,7 +431,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
           cmake -B bld -G 'MSYS Makefiles' ${options} \
@@ -455,7 +455,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -470,7 +470,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -491,14 +491,14 @@ jobs:
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
 
   linux-cross-mingw-w64:
@@ -681,8 +681,8 @@ jobs:
         shell: bash
         timeout-minutes: 5
         run: |
-          mkdir "$HOME/_gfw"
-          cd "$HOME/_gfw" || exit 1
+          mkdir /c/_gfw
+          cd /c/_gfw || exit 1
           # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
           # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
           #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
@@ -715,7 +715,7 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           if [ '${{ matrix.plat }}' = 'uwp' ]; then
             options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             cflags='-DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP'
@@ -754,7 +754,7 @@ jobs:
       - name: 'build'
         timeout-minutes: 5
         run: |
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -770,7 +770,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
         run: |
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -796,11 +796,11 @@ jobs:
             TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
-          PATH="$HOME/_gfw/usr/bin:$PATH"
+          PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -360,7 +360,7 @@ jobs:
     timeout-minutes: 20
     defaults:
       run:
-        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && '~\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
+        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && 'C:\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
     strategy:
       matrix:
         include:
@@ -392,8 +392,8 @@ jobs:
         shell: bash
         timeout-minutes: 5
         run: |
-          mkdir "$HOME/_gfw"
-          cd "$HOME/_gfw" || exit 1
+          mkdir /c/_gfw
+          cd /c/_gfw || exit 1
           # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
           # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
           #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
@@ -432,7 +432,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
           cmake -B bld -G 'MSYS Makefiles' ${options} \
@@ -456,7 +456,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -471,7 +471,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -492,14 +492,14 @@ jobs:
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
 
   linux-cross-mingw-w64:
@@ -587,7 +587,7 @@ jobs:
     timeout-minutes: 55
     defaults:
       run:
-        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && '~\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
+        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && 'C:\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
     env:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
       VCPKG_DISABLE_METRICS: '1'
@@ -683,8 +683,8 @@ jobs:
         shell: bash
         timeout-minutes: 5
         run: |
-          mkdir "$HOME/_gfw"
-          cd "$HOME/_gfw" || exit 1
+          mkdir /c/_gfw
+          cd /c/_gfw || exit 1
           # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
           # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
           #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
@@ -717,7 +717,7 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           if [ '${{ matrix.plat }}' = 'uwp' ]; then
             options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             cflags='-DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP'
@@ -756,7 +756,7 @@ jobs:
       - name: 'build'
         timeout-minutes: 5
         run: |
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -772,7 +772,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
         run: |
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -798,11 +798,11 @@ jobs:
             TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
-          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
+          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -360,7 +360,7 @@ jobs:
     timeout-minutes: 20
     defaults:
       run:
-        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && 'C:\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
+        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && '~\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
     strategy:
       matrix:
         include:
@@ -392,8 +392,8 @@ jobs:
         shell: bash
         timeout-minutes: 5
         run: |
-          mkdir /c/_gfw
-          cd /c/_gfw || exit 1
+          mkdir "$HOME/_gfw"
+          cd "$HOME/_gfw" || exit 1
           # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
           # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
           #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
@@ -432,7 +432,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
           [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
           cmake -B bld -G 'MSYS Makefiles' ${options} \
@@ -456,7 +456,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -471,7 +471,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -492,14 +492,14 @@ jobs:
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
 
   linux-cross-mingw-w64:
@@ -587,7 +587,7 @@ jobs:
     timeout-minutes: 55
     defaults:
       run:
-        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && 'C:\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
+        shell: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && '~\_gfw\usr\bin\bash.exe {0}' || 'C:\msys64\usr\bin\bash.exe {0}' }}
     env:
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
       VCPKG_DISABLE_METRICS: '1'
@@ -683,8 +683,8 @@ jobs:
         shell: bash
         timeout-minutes: 5
         run: |
-          mkdir /c/_gfw
-          cd /c/_gfw || exit 1
+          mkdir "$HOME/_gfw"
+          cd "$HOME/_gfw" || exit 1
           # The last known good Perl version (as of v2.47.1.windows.2) without pipe/signal MSYS2
           # runtime (?) regressions that cause runtests.pl to run at 2.5x reduced speed, is this:
           #   https://github.com/git-for-windows/git/releases/tag/v2.46.2.windows.1
@@ -717,7 +717,7 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           if [ '${{ matrix.plat }}' = 'uwp' ]; then
             options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
             cflags='-DWINAPI_FAMILY=WINAPI_FAMILY_PC_APP'
@@ -756,7 +756,7 @@ jobs:
       - name: 'build'
         timeout-minutes: 5
         run: |
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
@@ -772,7 +772,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
         run: |
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
@@ -798,11 +798,11 @@ jobs:
             TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
-          [ -d /c/_gfw ] && PATH="/c/_gfw/usr/bin:$PATH"
+          [ -d "$HOME/_gfw" ] && PATH="$HOME/_gfw/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -387,7 +387,7 @@ jobs:
             tflags: 'skiprun'
       fail-fast: false
     steps:
-      - name: 'install known good Git for Windows'
+      - name: 'install Git for Windows'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         shell: bash
         timeout-minutes: 5
@@ -678,7 +678,7 @@ jobs:
 
       fail-fast: false
     steps:
-      - name: 'install known good Git for Windows'
+      - name: 'install Git for Windows'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         shell: bash
         timeout-minutes: 5


### PR DESCRIPTION
Use the last known good release of Git for Windows by installing it
manually. It restores `runtests.pl` performance to the levels before
the October 2024 and this week's fallouts which gradually deployed
MSYS2 runtimes with pipe/signal/concurrency issues.

Also:
- restore vcpkg job's test parallelism to `-j8` (from `-j4`).
- keep using the default shell for jobs not running tests.
  To avoid the unnecessary Git for Windows install overhead.

Upsides:
- good performance again.
- easy to experiment with any version.

Downsides:
- installing the Git for Windows package takes 15-30 seconds.
- we're pinned to an old package version.
- no canary to tell when the issue is fixed on the runner images.

Unknown:
- stability. (no MSYS2 runtimes were ever stable and it's difficult
  to quantify if a version improves or worsens stability/flakiness, and
  intermittent env failures.

Follow-up to 1bf774df57e873d08f0c6e525e6ec3a0f6e62bce #16217
Follow-up to 5f9411f953f35ca84645b5a6824fb9fef20887ed #15380
