### PR TITLE
Use correct example domains

### DIFF
--- a/docs/MANUAL.md
+++ b/docs/MANUAL.md
@@ -582,7 +582,7 @@ Example, set default time out and proxy in a config file:
     # We want a 30 minute timeout:
     -m 1800
     # ... and we use a proxy for all accesses:
-    proxy = proxy.our.domain.com:8080
+    proxy = proxy.our.domain.example.com:8080
 
 Whitespaces ARE significant at the end of lines, but all whitespace leading
 up to the first characters of each line are ignored.

--- a/docs/cmdline-opts/netrc.md
+++ b/docs/cmdline-opts/netrc.md
@@ -30,9 +30,9 @@ On Windows two filenames in the home directory are checked: *.netrc* and
 only.
 
 A quick and simple example of how to setup a *.netrc* to allow curl to FTP to
-the machine host.domain.com with username 'myself' and password 'secret' could
+the machine host.example.com with username 'myself' and password 'secret' could
 look similar to:
 
-    machine host.domain.com
+    machine host.example.com
     login myself
     password secret

--- a/docs/examples/simplessl.c
+++ b/docs/examples/simplessl.c
@@ -82,7 +82,7 @@ int main(void)
   curl = curl_easy_init();
   if(curl) {
     /* what call to write: */
-    curl_easy_setopt(curl, CURLOPT_URL, "HTTPS://your.favourite.ssl.site");
+    curl_easy_setopt(curl, CURLOPT_URL, "HTTPS://secure.site.example");
     curl_easy_setopt(curl, CURLOPT_HEADERDATA, headerfile);
 
 #ifdef _MSC_VER

--- a/docs/libcurl/libcurl-tutorial.md
+++ b/docs/libcurl/libcurl-tutorial.md
@@ -194,7 +194,7 @@ One of the most basic properties to set in the handle is the URL. You set your
 preferred URL to transfer with CURLOPT_URL(3) in a manner similar to:
 
 ~~~c
- curl_easy_setopt(handle, CURLOPT_URL, "http://domain.com/");
+ curl_easy_setopt(handle, CURLOPT_URL, "http://example.com/");
 ~~~
 
 Let's assume for a while that you want to receive data as the URL identifies a

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -879,7 +879,7 @@ parse_netscape(struct Cookie *co,
       /*
        * flag: A TRUE/FALSE value indicating if all machines within a given
        * domain can access the variable. Set TRUE when the cookie says
-       * .domain.com and to false when the domain is complete www.domain.com
+       * .example.com and to false when the domain is complete www.example.com
        */
       co->tailmatch = !!strncasecompare(ptr, "TRUE", len);
       break;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -395,7 +395,7 @@ static CURLUcode parse_hostname_login(struct Curl_URL *u,
 
   /* We will now try to extract the
    * possible login information in a string like:
-   * ftp://user:password@ftp.my.site:8021/README */
+   * ftp://user:password@ftp.site.example:8021/README */
   ptr++;
 
   /* if this is a known scheme, get some details */


### PR DESCRIPTION
Fixes #16269 - replaces .site domains and domain.com with valid example domains.

There may be other invalid examples, but these were the obvious ones I could find.

Please let me know if there are any changes needed.