### PR TITLE
GHA/windows: bump dl-mingw tests to `-j8`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -487,7 +487,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          export TFLAGS='-j4 ~WebSockets ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ~WebSockets ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi


### PR DESCRIPTION
To match the rest of Windows jobs.

dl-mingw, CM 9.5.0-x86_64 schannel: 4m24s → 2m56s
dl-mingw, CM 7.3.0-x86_64 schannel U: 4m37s → 3m10s
(based on a few runs.)
