### PR TITLE
lib: silence LibreSSL collision warning on non-MSVC Windows

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -990,7 +990,7 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
    replacements (yet) so tell the compiler to not warn for them. */
 #  define OPENSSL_SUPPRESS_DEPRECATED
 #  ifdef _WIN32
-/* Silence warnings about symbol collisions. Available in LibreSSL 3.8.2+ */
+/* Silence LibreSSL warnings about wincrypt.h collision. Works in 3.8.2+ */
 #    ifndef LIBRESSL_DISABLE_OVERRIDE_WINCRYPT_DEFINES_WARNING
 #    define LIBRESSL_DISABLE_OVERRIDE_WINCRYPT_DEFINES_WARNING
 #    endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -985,10 +985,16 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #  endif
 #endif
 
+#ifdef USE_OPENSSL
 /* OpenSSLv3 marks DES, MD5 and ENGINE functions deprecated but we have no
    replacements (yet) so tell the compiler to not warn for them. */
-#ifdef USE_OPENSSL
-#define OPENSSL_SUPPRESS_DEPRECATED
+#  define OPENSSL_SUPPRESS_DEPRECATED
+#  ifdef _WIN32
+/* Silence warnings about symbol collisions. Available in LibreSSL 3.8.2+ */
+#    ifndef LIBRESSL_DISABLE_OVERRIDE_WINCRYPT_DEFINES_WARNING
+#    define LIBRESSL_DISABLE_OVERRIDE_WINCRYPT_DEFINES_WARNING
+#    endif
+#  endif
 #endif
 
 #if defined(CURL_INLINE)


### PR DESCRIPTION
LibreSSL headers emit this warning because we included `wincrypt.h`
before them. We have to include `wincrypt.h` before OpenSSL headers
to avoid symbol collisions when using other forks. LibreSSL 3.8.2+
offers a macro to silence its warnings to avoid this issue. This patch
sets it.

This allows to stop setting this macro in curl-for-win builds.

Warnings seen with MinGW with cmake non-unity (also unity batch=30):
```
[156/219] Building C object lib/CMakeFiles/libcurl_object.dir/vtls/openssl.c.obj
In file included from lib/vtls/openssl.h:35,
                 from lib/vtls/openssl.c:53:
dep/libressl-win-x64/include/openssl/ossl_typ.h:90:2: warning: #warning overriding WinCrypt defines [-Wcpp]
   90 | #warning overriding WinCrypt defines
      |  ^~~~~~~
In file included from dep/libressl-win-x64/include/openssl/pem.h:71,
                 from dep/libressl-win-x64/include/openssl/ssl.h:151,
                 from lib/vtls/openssl.h:36:
dep/libressl-win-x64/include/openssl/x509.h:108:2: warning: #warning overriding WinCrypt defines [-Wcpp]
  108 | #warning overriding WinCrypt defines
      |  ^~~~~~~
In file included from dep/libressl-win-x64/include/openssl/x509.h:319:
dep/libressl-win-x64/include/openssl/pkcs7.h:77:2: warning: #warning overriding WinCrypt defines [-Wcpp]
   77 | #warning overriding WinCrypt defines
      |  ^~~~~~~
```

Ref: https://github.com/libressl/portable/issues/910
Ref: https://github.com/libressl/portable/pull/924
Ref: https://github.com/libressl/portable/commit/e7fe6caab2869a043514c297ce04e6995a65d79f
Ref: https://github.com/curl/curl-for-win/commit/760ccfcc9114dbb6d79710a5582323be0f152c9e

---

w/o whitespace: https://github.com/curl/curl/pull/16273/files?w=1
