### PR TITLE
addrinfo: add curl macro to avoid redefining foreign symbols

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,7 +86,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             PATH="/usr/bin:$(cygpath "${SYSTEMROOT}")/System32"
             cmake -B bld -G Ninja ${options} \
-              -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=32 -DCURL_TEST_BUNDLES=ON \
+              -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=30 -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               ${{ matrix.config }}
           else
@@ -252,7 +252,7 @@ jobs:
             cmake -B bld -G Ninja ${options} \
               -DCMAKE_C_FLAGS="${{ matrix.cflags }} ${CFLAGS_CMAKE} ${CPPFLAGS}" \
               -DCMAKE_BUILD_TYPE='${{ matrix.type }}' \
-              -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=32 -DCURL_TEST_BUNDLES=ON \
+              -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=30 -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               ${{ matrix.config }}
           else

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -118,7 +118,7 @@ Curl_getaddrinfo_ex(const char *nodename,
 
   *result = NULL; /* assume failure */
 
-  error = getaddrinfo(nodename, servname, hints, &aihead);
+  error = CURL_GETADDRINFO(nodename, servname, hints, &aihead);
   if(error)
     return error;
 
@@ -184,7 +184,7 @@ Curl_getaddrinfo_ex(const char *nodename,
 
   /* destroy the addrinfo list */
   if(aihead)
-    freeaddrinfo(aihead);
+    CURL_FREEADDRINFO(aihead);
 
   /* if we failed, also destroy the Curl_addrinfo list */
   if(error) {
@@ -509,7 +509,7 @@ curl_dbg_freeaddrinfo(struct addrinfo *freethis,
 #ifdef USE_LWIPSOCK
   lwip_freeaddrinfo(freethis);
 #else
-  (freeaddrinfo)(freethis);
+  freeaddrinfo(freethis);
 #endif
 }
 #endif /* defined(CURLDEBUG) && defined(HAVE_FREEADDRINFO) */
@@ -534,7 +534,7 @@ curl_dbg_getaddrinfo(const char *hostname,
 #ifdef USE_LWIPSOCK
   int res = lwip_getaddrinfo(hostname, service, hints, result);
 #else
-  int res = (getaddrinfo)(hostname, service, hints, result);
+  int res = getaddrinfo(hostname, service, hints, result);
 #endif
   if(0 == res)
     /* success */

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -84,19 +84,15 @@
 #undef socketpair
 #endif
 
-#ifndef CURL_NO_GETADDRINFO_OVERRIDE
 #ifdef HAVE_GETADDRINFO
-#if defined(getaddrinfo) && defined(__osf__)
-#undef ogetaddrinfo
-#else
-#undef getaddrinfo
-#endif
+#undef CURL_GETADDRINFO
+#define CURL_GETADDRINFO getaddrinfo
 #endif /* HAVE_GETADDRINFO */
 
 #ifdef HAVE_FREEADDRINFO
-#undef freeaddrinfo
+#undef CURL_FREEADDRINFO
+#define CURL_FREEADDRINFO freeaddrinfo
 #endif /* HAVE_FREEADDRINFO */
-#endif /* !CURL_NO_GETADDRINFO_OVERRIDE */
 
 /* sclose is probably already defined, redefine it! */
 #undef sclose

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -84,16 +84,6 @@
 #undef socketpair
 #endif
 
-#ifdef HAVE_GETADDRINFO
-#undef CURL_GETADDRINFO
-#define CURL_GETADDRINFO getaddrinfo
-#endif /* HAVE_GETADDRINFO */
-
-#ifdef HAVE_FREEADDRINFO
-#undef CURL_FREEADDRINFO
-#define CURL_FREEADDRINFO freeaddrinfo
-#endif /* HAVE_FREEADDRINFO */
-
 /* sclose is probably already defined, redefine it! */
 #undef sclose
 #undef fopen

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -935,10 +935,15 @@ endings either CRLF or LF so 't' is appropriate.
 
 #define CURL_ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
 
-#undef CURL_GETADDRINFO
+#ifdef CURLDEBUG
+#define CURL_GETADDRINFO(host,serv,hint,res) \
+  curl_dbg_getaddrinfo(host, serv, hint, res, __LINE__, __FILE__)
+#define CURL_FREEADDRINFO(data) \
+  curl_dbg_freeaddrinfo(data, __LINE__, __FILE__)
+#else
 #define CURL_GETADDRINFO getaddrinfo
-#undef CURL_FREEADDRINFO
 #define CURL_FREEADDRINFO freeaddrinfo
+#endif
 
 /* Some versions of the Android NDK is missing the declaration */
 #if defined(HAVE_GETPWUID_R) && \

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -935,6 +935,11 @@ endings either CRLF or LF so 't' is appropriate.
 
 #define CURL_ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
 
+#undef CURL_GETADDRINFO
+#define CURL_GETADDRINFO getaddrinfo
+#undef CURL_FREEADDRINFO
+#define CURL_FREEADDRINFO freeaddrinfo
+
 /* Some versions of the Android NDK is missing the declaration */
 #if defined(HAVE_GETPWUID_R) && \
   defined(__ANDROID_API__) && (__ANDROID_API__ < 21)

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -153,27 +153,17 @@ CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
                      __LINE__, __FILE__)
 #endif
 
-#ifndef CURL_NO_GETADDRINFO_OVERRIDE
 #ifdef HAVE_GETADDRINFO
-#if defined(getaddrinfo) && defined(__osf__)
-/* OSF/1 and Tru64 have getaddrinfo as a define already, so we cannot define
-   our macro as for other platforms. Instead, we redefine the new name they
-   define getaddrinfo to become! */
-#define ogetaddrinfo(host,serv,hint,res) \
+#undef CURL_GETADDRINFO
+#define CURL_GETADDRINFO(host,serv,hint,res) \
   curl_dbg_getaddrinfo(host, serv, hint, res, __LINE__, __FILE__)
-#else
-#undef getaddrinfo
-#define getaddrinfo(host,serv,hint,res) \
-  curl_dbg_getaddrinfo(host, serv, hint, res, __LINE__, __FILE__)
-#endif
 #endif /* HAVE_GETADDRINFO */
 
 #ifdef HAVE_FREEADDRINFO
-#undef freeaddrinfo
-#define freeaddrinfo(data) \
+#undef CURL_FREEADDRINFO
+#define CURL_FREEADDRINFO(data) \
   curl_dbg_freeaddrinfo(data, __LINE__, __FILE__)
 #endif /* HAVE_FREEADDRINFO */
-#endif /* !CURL_NO_GETADDRINFO_OVERRIDE */
 
 /* sclose is probably already defined, redefine it! */
 #undef sclose

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -153,18 +153,6 @@ CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
                      __LINE__, __FILE__)
 #endif
 
-#ifdef HAVE_GETADDRINFO
-#undef CURL_GETADDRINFO
-#define CURL_GETADDRINFO(host,serv,hint,res) \
-  curl_dbg_getaddrinfo(host, serv, hint, res, __LINE__, __FILE__)
-#endif /* HAVE_GETADDRINFO */
-
-#ifdef HAVE_FREEADDRINFO
-#undef CURL_FREEADDRINFO
-#define CURL_FREEADDRINFO(data) \
-  curl_dbg_freeaddrinfo(data, __LINE__, __FILE__)
-#endif /* HAVE_FREEADDRINFO */
-
 /* sclose is probably already defined, redefine it! */
 #undef sclose
 #define sclose(sockfd) curl_dbg_sclose(sockfd,__LINE__,__FILE__)

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -50,12 +50,6 @@
 #endif
 
 #ifdef HAVE_UV_H
-/* Hack for Unity mode */
-#ifdef HEADER_CURL_MEMDEBUG_H
-#undef HEADER_CURL_MEMDEBUG_H
-#undef freeaddrinfo
-#undef getaddrinfo
-#endif
 /* this is for libuv-enabled debug builds only */
 #include <uv.h>
 #endif

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -81,7 +81,6 @@ foreach(_target IN LISTS LIBTESTPROGS)
   if(NOT CURL_TEST_BUNDLES)
     set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS ${_upper_target})
   endif()
-  set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_GETADDRINFO_OVERRIDE")
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}"
     PROJECT_LABEL "Test libtest ${_target}")

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -90,8 +90,6 @@ libstubgss_la_DEPENDENCIES =
 endif
 
 if USE_TEST_BUNDLES
-AM_CPPFLAGS += -DCURL_NO_GETADDRINFO_OVERRIDE
-
 libtest_bundle.c: $(top_srcdir)/tests/mk-bundle.pl lib1521.c
 	@PERL@ $(top_srcdir)/tests/mk-bundle.pl $(srcdir) > libtest_bundle.c
 

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -47,10 +47,6 @@ foreach(_target IN LISTS noinst_PROGRAMS)
   if(WIN32)
     set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_STATICLIB")
   endif()
-  # getaddrinfo/freeaddrinfo overrides break UNITY build by overriding them
-  # before including system headers. Server code doesn't need these overrides,
-  # so it's safe to disable them globally.
-  set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_GETADDRINFO_OVERRIDE")
   set_target_properties(${_target_name} PROPERTIES
     OUTPUT_NAME "${_target}"
     PROJECT_LABEL "Test server ${_target}")

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -43,7 +43,6 @@ LIBS = $(BLANK_AT_MAKETIME)
 if DOING_NATIVE_WINDOWS
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif
-AM_CPPFLAGS += -DCURL_NO_GETADDRINFO_OVERRIDE
 
 # Makefile.inc provides neat definitions
 include Makefile.inc

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -21,10 +21,6 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#ifndef CURL_NO_GETADDRINFO_OVERRIDE
-#define CURL_NO_GETADDRINFO_OVERRIDE
-#endif
-
 #include "server_setup.h"
 
 /* Purpose


### PR DESCRIPTION
Before this patch curl code was redefining `getaddrinfo` and
`freeaddrinfo` system symbols to plug in its debug wrappers. This was
causing pains to avoid applying the redefinitions to system headers
defining these functions, and to the local debug wrappers. Especially
in unity builds. It also required workarounds for systems where these
symbols are already macros.

Introduce curl-namespaced macros for these functions and use them.
This allows to drop all workarounds and makes it work in all envs,
local targets and unity/bundle combinations.

Also drop GHA/windows workaround and use the same unity batch across
all jobs. Follow-up to 29e4eda631f46368c2adf833ba3065b1b46c2a7d #16272

Ref: #16272
Ref: 71cf0d1fca9e1f53524e1545ef0c08d174458d80 #14772
Ref: 3efba94f773db5d8ae19e33aa749ab7914cafeea #14765
Ref: f7d5f47059c381502824ef9c1c9a2ca484930c91 #14399

---

- [x] once merged, revisit or tweak #16272 to use batch=30 (instead of the batch=32, used as a workaround to avoid this issue)
