### PR TITLE
eventfd: allow for all CPUs

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -178,7 +178,7 @@ void destroy_thread_sync_data(struct thread_sync_data *tsd)
    * close one end of the socket pair (may be done in resolver thread);
    * the other end (for reading) is always closed in the parent thread.
    */
-#ifndef USE_EVENTFD
+#ifndef HAVE_EVENTFD
   if(tsd->sock_pair[1] != CURL_SOCKET_BAD) {
     wakeup_close(tsd->sock_pair[1]);
   }
@@ -306,7 +306,7 @@ CURL_STDCALL getaddrinfo_thread(void *arg)
   else {
 #ifndef CURL_DISABLE_SOCKETPAIR
     if(tsd->sock_pair[1] != CURL_SOCKET_BAD) {
-#ifdef USE_EVENTFD
+#ifdef HAVE_EVENTFD
       const uint64_t buf[1] = { 1 };
 #else
       const char buf[1] = { 1 };

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1552,7 +1552,7 @@ CURLMcode curl_multi_wakeup(CURLM *m)
      and before cleanup */
   if(multi->wakeup_pair[1] != CURL_SOCKET_BAD) {
     while(1) {
-#ifdef USE_EVENTFD
+#ifdef HAVE_EVENTFD
       /* eventfd has a stringent rule of requiring the 8-byte buffer when
          calling write(2) on it */
       const uint64_t buf[1] = { 1 };
@@ -2870,7 +2870,7 @@ CURLMcode curl_multi_cleanup(CURLM *m)
 #else
 #ifdef ENABLE_WAKEUP
     wakeup_close(multi->wakeup_pair[0]);
-#ifndef USE_EVENTFD
+#ifndef HAVE_EVENTFD
     wakeup_close(multi->wakeup_pair[1]);
 #endif
 #endif

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -27,7 +27,7 @@
 #include "urldata.h"
 #include "rand.h"
 
-#ifdef USE_EVENTFD
+#ifdef HAVE_EVENTFD
 #ifdef HAVE_SYS_EVENTFD_H
 #include <sys/eventfd.h>
 #endif

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -27,7 +27,7 @@
 #include "urldata.h"
 #include "rand.h"
 
-#if defined(USE_EVENTFD)
+#ifdef USE_EVENTFD
 #ifdef HAVE_SYS_EVENTFD_H
 #include <sys/eventfd.h>
 #endif

--- a/lib/socketpair.h
+++ b/lib/socketpair.h
@@ -26,23 +26,7 @@
 
 #include "curl_setup.h"
 
-#if defined(HAVE_EVENTFD) && \
-    (defined(__x86_64__) || \
-     defined(__aarch64__) || \
-     defined(__ia64__) || \
-     defined(__ppc64__) || \
-     defined(__mips64) || \
-     defined(__sparc64__) || \
-     defined(__riscv_64e) || \
-     defined(__s390x__))
-
-/* Use eventfd only with 64-bit CPU architectures because eventfd has a
- * stringent rule of requiring the 8-byte buffer when calling read(2) and
- * write(2) on it. In some rare cases, the C standard library implementation
- * on a 32-bit system might choose to define uint64_t as a 32-bit type for
- * various reasons (memory limitations, compatibility with older code),
- * which makes eventfd broken.
- */
+#ifdef HAVE_EVENTFD
 #define USE_EVENTFD 1
 
 #define wakeup_write  write

--- a/lib/socketpair.h
+++ b/lib/socketpair.h
@@ -27,7 +27,6 @@
 #include "curl_setup.h"
 
 #ifdef HAVE_EVENTFD
-#define USE_EVENTFD
 
 #define wakeup_write  write
 #define wakeup_read   read
@@ -47,7 +46,7 @@ int Curl_eventfd(curl_socket_t socks[2], bool nonblocking);
 #include <curl/curl.h>
 int Curl_pipe(curl_socket_t socks[2], bool nonblocking);
 
-#else /* !USE_EVENTFD && !HAVE_PIPE */
+#else /* !HAVE_EVENTFD && !HAVE_PIPE */
 
 #define wakeup_write     swrite
 #define wakeup_read      sread
@@ -70,7 +69,7 @@ int Curl_pipe(curl_socket_t socks[2], bool nonblocking);
 #define wakeup_create(p,nb)\
 Curl_socketpair(SOCKETPAIR_FAMILY, SOCKETPAIR_TYPE, 0, p, nb)
 
-#endif /* USE_EVENTFD */
+#endif /* HAVE_EVENTFD */
 
 #ifndef CURL_DISABLE_SOCKETPAIR
 #include <curl/curl.h>

--- a/lib/socketpair.h
+++ b/lib/socketpair.h
@@ -27,7 +27,7 @@
 #include "curl_setup.h"
 
 #ifdef HAVE_EVENTFD
-#define USE_EVENTFD 1
+#define USE_EVENTFD
 
 #define wakeup_write  write
 #define wakeup_read   read


### PR DESCRIPTION
After fixing support for x32, unlock eventfd support for all CPUs.
Before this patch, it was explicitly limited to 64-bit ones.

You can disable eventfs manually on systems where it's auto-detected:
- cmake: `-DHAVE_EVENTFD=0`
- configure: `export ac_cv_func_eventfd=0`

Ref: c2aa504ab9148b5c284b090c5043d9f0c3fbd903 #16239
