### PR TITLE
GHA/linux: hide progress bar in `apt remove`

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -589,7 +589,7 @@ jobs:
 
       - name: 'configure'
         run: |
-          [[ '${{ matrix.build.install_steps }}' = *'awslc'* ]] && sudo apt remove --yes libssl-dev
+          [[ '${{ matrix.build.install_steps }}' = *'awslc'* ]] && sudo apt-get -o Dpkg::Use-Pty=0 purge libssl-dev
           if [ -n '${{ matrix.build.PKG_CONFIG_PATH }}' ]; then
             export PKG_CONFIG_PATH="${{ matrix.build.PKG_CONFIG_PATH }}"
           fi


### PR DESCRIPTION
Also switch to `apt-get` and drop redundant `--yes` for conistency with
other GHA scripts.

Follow-up to b13e9066b3dfd65ba8aadc336232ae7832ac687a #16127
