### PR TITLE
cmake: fix `HAVE_GETHOSTBYNAME_R_*` detections with `CURL_WERROR=ON`

### DIFF
--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: 'run cmake'
         run: |
-          cmake -B bld-cm -DCURL_USE_LIBPSL=OFF -DCURL_BROTLI=OFF
+          cmake -B bld-cm -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DCURL_BROTLI=OFF
 
       - name: 'configure log'
         run: cat bld-am/config.log 2>/dev/null || true
@@ -88,7 +88,7 @@ jobs:
 
       - name: 'run cmake'
         run: |
-          cmake -B bld-cm -DCURL_USE_LIBPSL=OFF -DCURL_DISABLE_LDAP=ON \
+          cmake -B bld-cm -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DCURL_DISABLE_LDAP=ON \
             -DCMAKE_C_COMPILER_TARGET="$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
             -DCURL_BROTLI=OFF \
             -DCURL_USE_LIBSSH2=OFF
@@ -128,7 +128,7 @@ jobs:
 
       - name: 'run cmake'
         run: |
-          cmake -B bld-cm -DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBPSL=OFF \
+          cmake -B bld-cm -DCURL_WERROR=ON -DCURL_USE_SCHANNEL=ON -DCURL_USE_LIBPSL=OFF \
             -DCMAKE_SYSTEM_NAME=Windows \
             -DCMAKE_C_COMPILER_TARGET="${TRIPLET}" \
             -DCMAKE_C_COMPILER="${TRIPLET}-gcc"

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -70,7 +70,7 @@ int main(void)
 #include <netdb.h>
 int main(void)
 {
-  char *address = "example.com";
+  const char *address = "example.com";
   int length = 0;
   int type = 0;
   struct hostent h;


### PR DESCRIPTION
Fix `HAVE_GETHOSTBYNAME_R_*` feature detections always failing with
`CURL_WERROR=ON` due to stripping a const.

Also fix the GHA/cmake-vs-configure to enable `CURL_WERROR=ON` to sync
this setting with `./configure` which enables it by default. With that,
CI detects this issue.

```
CMake/CurlTests.c:73:19: error: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
   73 |   char *address = "example.com";
      |                   ^~~~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/13225827821/job/36916564107#step:33:4198
