### PR TITLE
tool_progress: fix percent output of large transfers

### DIFF
--- a/src/tool_progress.c
+++ b/src/tool_progress.c
@@ -216,13 +216,16 @@ bool progress_meter(struct GlobalConfig *global,
         all_running++;
     }
     if(dlknown && all_dltotal)
-      /* TODO: handle integer overflow */
       msnprintf(dlpercen, sizeof(dlpercen), "%3" CURL_FORMAT_CURL_OFF_T,
-                all_dlnow * 100 / all_dltotal);
+                all_dlnow < (CURL_OFF_T_MAX/100) ?
+                (all_dlnow * 100 / all_dltotal) :
+                (all_dltotal / (all_dltotal/100)));
+
     if(ulknown && all_ultotal)
-      /* TODO: handle integer overflow */
       msnprintf(ulpercen, sizeof(ulpercen), "%3" CURL_FORMAT_CURL_OFF_T,
-                all_ulnow * 100 / all_ultotal);
+                all_ulnow < (CURL_OFF_T_MAX/100) ?
+                (all_ulnow * 100 / all_ultotal) :
+                (all_ulnow / (all_ultotal/100)));
 
     /* get the transfer speed, the higher of the two */
 

--- a/src/tool_progress.c
+++ b/src/tool_progress.c
@@ -219,7 +219,7 @@ bool progress_meter(struct GlobalConfig *global,
       msnprintf(dlpercen, sizeof(dlpercen), "%3" CURL_FORMAT_CURL_OFF_T,
                 all_dlnow < (CURL_OFF_T_MAX/100) ?
                 (all_dlnow * 100 / all_dltotal) :
-                (all_dltotal / (all_dltotal/100)));
+                (all_dlnow / (all_dltotal/100)));
 
     if(ulknown && all_ultotal)
       msnprintf(ulpercen, sizeof(ulpercen), "%3" CURL_FORMAT_CURL_OFF_T,


### PR DESCRIPTION
When the transfered amount (upload or download) was larger than 2^63/100 bytes (81 petabytes) the progress percent counter would show wrong.