### PR TITLE
build: fix compiler warnings in feature detections

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -323,6 +323,7 @@ int main(void)
 {
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
+  (void)ts;
   return 0;
 }
 #endif

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -322,7 +322,7 @@ int main(void)
 int main(void)
 {
   struct timespec ts = {0, 0};
-  clock_gettime(CLOCK_MONOTONIC, &ts);
+  (void)clock_gettime(CLOCK_MONOTONIC, &ts);
   (void)ts;
   return 0;
 }

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -85,8 +85,8 @@ int main(void)
       defined(HAVE_GETHOSTBYNAME_R_6) || \
       defined(HAVE_GETHOSTBYNAME_R_6_REENTRANT)
   char buffer[8192];
-  int h_errnop;
   struct hostent *hp;
+  int h_errnop;
 #endif
 
 #if   defined(HAVE_GETHOSTBYNAME_R_3) || \
@@ -97,9 +97,12 @@ int main(void)
       defined(HAVE_GETHOSTBYNAME_R_5_REENTRANT)
   rc = gethostbyname_r(address, &h, buffer, 8192, &h_errnop);
   (void)hp; /* not used for test */
+  (void)h_errnop;
 #elif defined(HAVE_GETHOSTBYNAME_R_6) || \
       defined(HAVE_GETHOSTBYNAME_R_6_REENTRANT)
   rc = gethostbyname_r(address, &h, buffer, 8192, &hp, &h_errnop);
+  (void)hp;
+  (void)h_errnop;
 #endif
 
   (void)length;

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -58,11 +58,11 @@ int main(void)
 #if defined(HAVE_GETHOSTBYNAME_R_3_REENTRANT) || \
     defined(HAVE_GETHOSTBYNAME_R_5_REENTRANT) || \
     defined(HAVE_GETHOSTBYNAME_R_6_REENTRANT)
-#   ifndef _REENTRANT
-#   define _REENTRANT
-#   endif
-    /* no idea whether _REENTRANT is always set, just invent a new flag */
-#   define TEST_GETHOSTBYFOO_REENTRANT
+#ifndef _REENTRANT
+#define _REENTRANT
+#endif
+/* no idea whether _REENTRANT is always set, just invent a new flag */
+#define TEST_GETHOSTBYFOO_REENTRANT
 #endif
 #if defined(HAVE_GETHOSTBYNAME_R_3) || \
     defined(HAVE_GETHOSTBYNAME_R_5) || \

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -321,7 +321,7 @@ int main(void)
 #include <time.h>
 int main(void)
 {
-  struct timespec ts = {0, 0};
+  struct timespec ts;
   (void)clock_gettime(CLOCK_MONOTONIC, &ts);
   (void)ts;
   return 0;

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -141,7 +141,11 @@ int main(void) { return 0; }
 static int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721 &&
                            LARGE_OFF_T % 2147483647 == 1)
                           ? 1 : -1];
-int main(void) { return 0; }
+int main(void)
+{
+  (void)off_t_is_large;
+  return 0;
+}
 #endif
 
 #ifdef HAVE_IOCTLSOCKET

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -321,7 +321,7 @@ int main(void)
 #include <time.h>
 int main(void)
 {
-  struct timespec ts;
+  struct timespec ts = {0, 0};
   clock_gettime(CLOCK_MONOTONIC, &ts);
   (void)ts;
   return 0;

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -55,19 +55,12 @@ int main(void)
 #endif
 
 /* tests for gethostbyname_r */
-#if defined(HAVE_GETHOSTBYNAME_R_3_REENTRANT) || \
-    defined(HAVE_GETHOSTBYNAME_R_5_REENTRANT) || \
-    defined(HAVE_GETHOSTBYNAME_R_6_REENTRANT)
-#ifndef _REENTRANT
-#define _REENTRANT
-#endif
-/* no idea whether _REENTRANT is always set, just invent a new flag */
-#define TEST_GETHOSTBYFOO_REENTRANT
-#endif
 #if defined(HAVE_GETHOSTBYNAME_R_3) || \
+    defined(HAVE_GETHOSTBYNAME_R_3_REENTRANT) || \
     defined(HAVE_GETHOSTBYNAME_R_5) || \
+    defined(HAVE_GETHOSTBYNAME_R_5_REENTRANT) || \
     defined(HAVE_GETHOSTBYNAME_R_6) || \
-    defined(TEST_GETHOSTBYFOO_REENTRANT)
+    defined(HAVE_GETHOSTBYNAME_R_6_REENTRANT)
 #include <sys/types.h>
 #include <netdb.h>
 int main(void)
@@ -130,8 +123,6 @@ int main(void) { return 0; }
 #endif
 
 #ifdef HAVE_FILE_OFFSET_BITS
-#undef _FILE_OFFSET_BITS
-#define _FILE_OFFSET_BITS 64
 #include <sys/types.h>
 /* Check that off_t can represent 2**63 - 1 correctly.
    We cannot simply define LARGE_OFF_T to be 9223372036854775807,

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -102,6 +102,7 @@ int main(void)
   (void)hp;
   (void)h_errnop;
 #endif
+  (void)h;
   (void)rc;
   return 0;
 }

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -30,14 +30,14 @@
 /* */
 #if defined(sun) || defined(__sun__) || \
     defined(__SUNPRO_C) || defined(__SUNPRO_CC)
-# if defined(__SVR4) || defined(__srv4__)
-#  define PLATFORM_SOLARIS
-# else
-#  define PLATFORM_SUNOS4
-# endif
+#  if defined(__SVR4) || defined(__srv4__)
+#    define PLATFORM_SOLARIS
+#  else
+#    define PLATFORM_SUNOS4
+#  endif
 #endif
 #if (defined(_AIX) || defined(__xlC__)) && !defined(_AIX41)
-# define PLATFORM_AIX_V3
+#  define PLATFORM_AIX_V3
 #endif
 /* */
 #if defined(PLATFORM_SUNOS4) || defined(PLATFORM_AIX_V3)

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -58,7 +58,9 @@ int main(void)
 #if defined(HAVE_GETHOSTBYNAME_R_3_REENTRANT) || \
     defined(HAVE_GETHOSTBYNAME_R_5_REENTRANT) || \
     defined(HAVE_GETHOSTBYNAME_R_6_REENTRANT)
+#   ifndef _REENTRANT
 #   define _REENTRANT
+#   endif
     /* no idea whether _REENTRANT is always set, just invent a new flag */
 #   define TEST_GETHOSTBYFOO_REENTRANT
 #endif

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -321,7 +321,7 @@ int main(void)
 #include <time.h>
 int main(void)
 {
-  struct timespec ts = {0, 0};
+  struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
   return 0;
 }

--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -73,8 +73,6 @@ int main(void)
 int main(void)
 {
   const char *address = "example.com";
-  int length = 0;
-  int type = 0;
   struct hostent h;
   int rc = 0;
 #if   defined(HAVE_GETHOSTBYNAME_R_3) || \
@@ -104,9 +102,6 @@ int main(void)
   (void)hp;
   (void)h_errnop;
 #endif
-
-  (void)length;
-  (void)type;
   (void)rc;
   return 0;
 }

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -107,11 +107,10 @@ if(NOT DEFINED HAVE_GETADDRINFO_THREADSAFE)
   check_c_source_compiles("${_source_epilogue}
     int main(void)
     {
-    #ifdef h_errno
-      return 0;
-    #else
+    #ifndef h_errno
       #error force compilation error
     #endif
+      return 0;
     }" HAVE_H_ERRNO)
 
   if(NOT HAVE_H_ERRNO)

--- a/CMake/OtherTests.cmake
+++ b/CMake/OtherTests.cmake
@@ -127,12 +127,11 @@ if(NOT DEFINED HAVE_GETADDRINFO_THREADSAFE)
         int main(void)
         {
         #if defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200809L)
-          return 0;
         #elif defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 700)
-          return 0;
         #else
           #error force compilation error
         #endif
+          return 0;
         }" HAVE_H_ERRNO_SBS_ISSUE_7)
     endif()
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,8 @@ include(CheckSymbolExists)
 include(CheckTypeSize)
 include(CheckCSourceCompiles)
 
+set(_CURL_PREFILL OFF)
+
 option(_CURL_PREFILL "Fast-track known feature detection results (Windows, some Apple)" "${WIN32}")
 if(_CURL_PREFILL)
   if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1971,8 +1971,8 @@ endif()
 if(CURL_WERROR)
   if(MSVC)
     string(APPEND CMAKE_C_FLAGS " -WX")
-  elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-    string(APPEND CMAKE_C_FLAGS " -Werror")
+  else()
+    string(APPEND CMAKE_C_FLAGS " -Werror")  # This assumes clang or gcc style options
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,8 +534,6 @@ include(CheckSymbolExists)
 include(CheckTypeSize)
 include(CheckCSourceCompiles)
 
-set(_CURL_PREFILL OFF)
-
 option(_CURL_PREFILL "Fast-track known feature detection results (Windows, some Apple)" "${WIN32}")
 if(_CURL_PREFILL)
   if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1808,16 +1808,43 @@ foreach(_curl_test IN ITEMS
     HAVE_GETHOSTBYNAME_R_3
     HAVE_GETHOSTBYNAME_R_5
     HAVE_GETHOSTBYNAME_R_6
-    HAVE_GETHOSTBYNAME_R_3_REENTRANT
-    HAVE_GETHOSTBYNAME_R_5_REENTRANT
-    HAVE_GETHOSTBYNAME_R_6_REENTRANT
     HAVE_BOOL_T
     STDC_HEADERS
-    HAVE_FILE_OFFSET_BITS
     HAVE_ATOMIC
     )
   curl_internal_test(${_curl_test})
 endforeach()
+
+# Check for reentrant
+cmake_push_check_state()
+list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_REENTRANT")
+foreach(_curl_test IN ITEMS
+    HAVE_GETHOSTBYNAME_R_3
+    HAVE_GETHOSTBYNAME_R_5
+    HAVE_GETHOSTBYNAME_R_6)
+  curl_internal_test(${_curl_test}_REENTRANT)
+  if(NOT ${_curl_test} AND ${_curl_test}_REENTRANT)
+    set(NEED_REENTRANT 1)
+  endif()
+endforeach()
+cmake_pop_check_state()
+
+if(NEED_REENTRANT)
+  foreach(_curl_test IN ITEMS
+      HAVE_GETHOSTBYNAME_R_3
+      HAVE_GETHOSTBYNAME_R_5
+      HAVE_GETHOSTBYNAME_R_6)
+    set(${_curl_test} 0)
+    if(${_curl_test}_REENTRANT)
+      set(${_curl_test} 1)
+    endif()
+  endforeach()
+endif()
+
+cmake_push_check_state()
+list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_FILE_OFFSET_BITS=64")
+curl_internal_test(HAVE_FILE_OFFSET_BITS)
+cmake_pop_check_state()
 
 cmake_push_check_state()
 if(HAVE_FILE_OFFSET_BITS)
@@ -1871,30 +1898,6 @@ endif()
 
 curl_internal_test(HAVE_GLIBC_STRERROR_R)
 curl_internal_test(HAVE_POSIX_STRERROR_R)
-
-# Check for reentrant
-foreach(_curl_test IN ITEMS
-    HAVE_GETHOSTBYNAME_R_3
-    HAVE_GETHOSTBYNAME_R_5
-    HAVE_GETHOSTBYNAME_R_6)
-  if(NOT ${_curl_test})
-    if(${_curl_test}_REENTRANT)
-      set(NEED_REENTRANT 1)
-    endif()
-  endif()
-endforeach()
-
-if(NEED_REENTRANT)
-  foreach(_curl_test IN ITEMS
-      HAVE_GETHOSTBYNAME_R_3
-      HAVE_GETHOSTBYNAME_R_5
-      HAVE_GETHOSTBYNAME_R_6)
-    set(${_curl_test} 0)
-    if(${_curl_test}_REENTRANT)
-      set(${_curl_test} 1)
-    endif()
-  endforeach()
-endif()
 
 if(NOT WIN32)
   curl_internal_test(HAVE_CLOCK_GETTIME_MONOTONIC)  # Check clock_gettime(CLOCK_MONOTONIC, x) support

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -178,7 +178,7 @@ AC_DEFUN([CURL_CHECK_NATIVE_WINDOWS], [
       AC_LANG_PROGRAM([[
       ]],[[
         #ifdef _WIN32
-          int dummy=1;
+          int dummy = 1;
           (void)dummy;
         #else
           #error Not a native Windows build target.

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -48,7 +48,7 @@ AC_DEFUN([CURL_CHECK_DEF], [
   tmp_exp=""
   AC_PREPROC_IFELSE([
     AC_LANG_SOURCE(
-ifelse($2,,,[$2])[[
+    ifelse($2,,,[$2])[[
       #ifdef $1
       CURL_DEF_TOKEN $1
       #endif
@@ -88,7 +88,7 @@ AC_DEFUN([CURL_CHECK_DEF_CC], [
   ifelse($3,,[AC_MSG_CHECKING([for compiler definition of $1])])
   AC_COMPILE_IFELSE([
     AC_LANG_SOURCE(
-ifelse($2,,,[$2])[[
+    ifelse($2,,,[$2])[[
       int main(void)
       {
       #ifndef $1

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -855,6 +855,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOCK_GETTIME_MONOTONIC_RAW], [
       ]],[[
         struct timespec ts;
         (void)clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+        (void)ts;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -901,6 +902,7 @@ AC_DEFUN([CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC], [
           ]],[[
             struct timespec ts;
             (void)clock_gettime(CLOCK_MONOTONIC, &ts);
+            (void)ts;
           ]])
         ],[
           curl_cv_gclk_LIBS="$x_xlibs"
@@ -947,10 +949,10 @@ AC_DEFUN([CURL_CHECK_LIBS_CLOCK_GETTIME_MONOTONIC], [
           #include <time.h>
         ]],[[
           struct timespec ts;
-          if (0 == clock_gettime(CLOCK_MONOTONIC, &ts))
-            exit(0);
-          else
-            exit(1);
+          if(0 == clock_gettime(CLOCK_MONOTONIC, &ts))
+            return 0;
+          (void)ts;
+          return 1;
         ]])
       ],[
         AC_MSG_RESULT([yes])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -689,7 +689,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
       #endif
       #endif
     ]],[[
-      send(0, "", 0, 0);
+      send(0, 0, 0, 0);
     ]])
   ],[
     AC_MSG_RESULT([yes])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -91,11 +91,10 @@ AC_DEFUN([CURL_CHECK_DEF_CC], [
 ifelse($2,,,[$2])[[
       int main(void)
       {
-      #ifdef $1
-        return 0;
-      #else
+      #ifndef $1
         #error force compilation error
       #endif
+        return 0;
       }
     ]])
   ],[
@@ -126,12 +125,11 @@ AC_DEFUN([CURL_CHECK_LIB_XNET], [
       int main(void)
       {
       #if defined(__hpux) && defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE >= 600)
-        return 0;
       #elif defined(__hpux) && defined(_XOPEN_SOURCE_EXTENDED)
-        return 0;
       #else
         #error force compilation error
       #endif
+        return 0;
       }
     ]])
   ],[

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -306,6 +306,7 @@ AC_DEFUN([CURL_CHECK_HEADER_LDAP], [
       ]],[[
         LDAP *ldp = ldap_init("0.0.0.0", LDAP_PORT);
         int res = ldap_unbind(ldp);
+        (void)res;
       ]])
     ],[
       curl_cv_header_ldap_h="yes"
@@ -354,6 +355,7 @@ AC_DEFUN([CURL_CHECK_HEADER_LDAP_SSL], [
         #include <ldap_ssl.h>
       ]],[[
         LDAP *ldp = ldapssl_init("0.0.0.0", LDAPS_PORT, 1);
+        (void)ldp;
       ]])
     ],[
       curl_cv_header_ldap_ssl_h="yes"
@@ -433,6 +435,7 @@ AC_DEFUN([CURL_CHECK_LIBS_WINLDAP], [
           LDAP *ldp = ldap_init("0.0.0.0", LDAP_PORT);
           ULONG res = ldap_unbind(ldp);
           ber_free(bep, 1);
+          (void)res;
         ]])
       ],[
         curl_cv_ldap_LIBS="$x_nlibs"
@@ -543,6 +546,7 @@ AC_DEFUN([CURL_CHECK_LIBS_LDAP], [
           LDAP *ldp = ldap_init("0.0.0.0", LDAP_PORT);
           int res = ldap_unbind(ldp);
           ber_free(bep, 1);
+          (void)res;
         ]])
       ],[
         curl_cv_ldap_LIBS="$x_nlibs"
@@ -730,6 +734,7 @@ AC_DEFUN([CURL_CHECK_MSG_NOSIGNAL], [
         #endif
       ]],[[
         int flag=MSG_NOSIGNAL;
+        (void)flag;
       ]])
     ],[
       curl_cv_msg_nosignal="yes"
@@ -777,6 +782,7 @@ AC_DEFUN([CURL_CHECK_STRUCT_TIMEVAL], [
         struct timeval ts;
         ts.tv_sec  = 0;
         ts.tv_usec = 0;
+        (void)ts;
       ]])
     ],[
       curl_cv_struct_timeval="yes"
@@ -814,6 +820,7 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOCK_GETTIME_MONOTONIC], [
       ]],[[
         struct timespec ts;
         (void)clock_gettime(CLOCK_MONOTONIC, &ts);
+        (void)ts;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -1090,7 +1097,7 @@ AC_DEFUN([CURL_VERIFY_RUNTIMELIBS], [
     dnl point also is available run-time!
     AC_MSG_CHECKING([run-time libs availability])
     CURL_RUN_IFELSE([
-      int main()
+      int main(void)
       {
         return 0;
       }

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -689,7 +689,7 @@ AC_DEFUN([CURL_CHECK_FUNC_SEND], [
       #endif
       #endif
     ]],[[
-      send(0, 0, 0, 0);
+      send(0, "", 0, 0);
     ]])
   ],[
     AC_MSG_RESULT([yes])

--- a/acinclude.m4
+++ b/acinclude.m4
@@ -181,6 +181,7 @@ AC_DEFUN([CURL_CHECK_NATIVE_WINDOWS], [
       ]],[[
         #ifdef _WIN32
           int dummy=1;
+          (void)dummy;
         #else
           #error Not a native Windows build target.
         #endif
@@ -733,7 +734,7 @@ AC_DEFUN([CURL_CHECK_MSG_NOSIGNAL], [
         #endif
         #endif
       ]],[[
-        int flag=MSG_NOSIGNAL;
+        int flag = MSG_NOSIGNAL;
         (void)flag;
       ]])
     ],[

--- a/configure.ac
+++ b/configure.ac
@@ -1243,7 +1243,8 @@ if test "$HAVE_GETHOSTBYNAME" != "1" -o "${with_amissl+set}" = set; then
   struct Library *SocketBase = NULL;
   #endif
     ]],[[
-      gethostbyname("localhost");
+      char host[] = "localhost";
+      gethostbyname(host);
     ]])
   ],[
     AC_MSG_RESULT([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -1243,7 +1243,7 @@ if test "$HAVE_GETHOSTBYNAME" != "1" -o "${with_amissl+set}" = set; then
   struct Library *SocketBase = NULL;
   #endif
     ]],[[
-      char host[] = "localhost";
+      unsigned char host[] = "localhost";
       gethostbyname(host);
     ]])
   ],[

--- a/configure.ac
+++ b/configure.ac
@@ -1720,7 +1720,6 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       int main(void)
       {
         struct sockaddr_in6 s;
-        (void)s;
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }
     ]])

--- a/configure.ac
+++ b/configure.ac
@@ -1720,7 +1720,7 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       #endif
       int main(void)
       {
-        struct sockaddr_in6 *s = 0;
+        struct sockaddr_in6 s;
         (void)s;
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }

--- a/configure.ac
+++ b/configure.ac
@@ -1719,7 +1719,8 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       #endif
       int main(void)
       {
-        struct sockaddr_in6 s;
+        struct sockaddr_in6 s = { 0 };
+        (void)s;
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }
     ]])

--- a/configure.ac
+++ b/configure.ac
@@ -1719,8 +1719,8 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       #endif
       int main(void)
       {
-        struct sockaddr_in6 s;
-        memset(&s, 0, sizeof(s));
+        struct sockaddr_in6 *s = 0;
+        (void)s;
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }
     ]])

--- a/configure.ac
+++ b/configure.ac
@@ -1720,8 +1720,7 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       int main(void)
       {
         struct sockaddr_in6 s;
-        memset(&s, 0, sizeof(sockaddr_in6));
-        (void)s;
+        memset(&s, 0, sizeof(s));
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }
     ]])

--- a/configure.ac
+++ b/configure.ac
@@ -1719,7 +1719,7 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       #endif
       int main(void)
       {
-        struct sockaddr_in6 s = { 0 };
+        struct sockaddr_in6 s;
         (void)s;
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }

--- a/configure.ac
+++ b/configure.ac
@@ -1754,6 +1754,7 @@ if test "$ipv6" = yes; then
     ]], [[
       struct sockaddr_in6 s;
       s.sin6_scope_id = 0;
+      (void)s;
     ]])
   ],[
     AC_MSG_RESULT([yes])

--- a/configure.ac
+++ b/configure.ac
@@ -1717,10 +1717,9 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       #include <netinet/in6.h>
       #endif
       #endif
-
       int main(void)
       {
-        struct sockaddr_in6 s;
+        struct sockaddr_in6 s = { 0 };
         (void)s;
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }

--- a/configure.ac
+++ b/configure.ac
@@ -1720,7 +1720,7 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       #endif
       int main(void)
       {
-        struct sockaddr_in6 s;
+        int s = (int)sizeof(struct sockaddr_in6);
         (void)s;
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }

--- a/configure.ac
+++ b/configure.ac
@@ -1719,7 +1719,8 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       #endif
       int main(void)
       {
-        struct sockaddr_in6 s = { 0 };
+        struct sockaddr_in6 s;
+        memset(&s, 0, sizeof(sockaddr_in6));
         (void)s;
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }

--- a/configure.ac
+++ b/configure.ac
@@ -1720,6 +1720,7 @@ AS_HELP_STRING([--disable-ipv6],[Disable IPv6 support]),
       int main(void)
       {
         struct sockaddr_in6 s;
+        (void)s;
         return socket(AF_INET6, SOCK_STREAM, 0) < 0;
       }
     ]])

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1468,7 +1468,10 @@ AC_DEFUN([CURL_CHECK_COMPILER_SYMBOL_HIDING], [
         }
       ]],[[
         char b[16];
-        char *r = dummy(&b[0]);
+        char *r;
+        b[0] = ' ';
+        b[1] = ' ';
+        r = dummy(&b[0]);
         if(r)
           return (int)*r;
         (void)b;

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1310,7 +1310,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_ARRAY_SIZE_NEGATIVE], [
   AC_MSG_CHECKING([if compiler halts on negative sized arrays])
   AC_COMPILE_IFELSE([
     AC_LANG_PROGRAM([[
-      typedef char bad_t[sizeof(char) == sizeof(int) ? -1 : -1 ];
+      typedef char bad_t[sizeof(char) == sizeof(int) ? -1 : -1];
     ]],[[
       bad_t dummy;
       (void)dummy;
@@ -1343,8 +1343,8 @@ AC_DEFUN([CURL_CHECK_COMPILER_STRUCT_MEMBER_SIZE], [
         struct mystruct *next;
       };
       struct mystruct myfunc();
-      typedef char good_t1[sizeof(myfunc().mi) == sizeof(int)  ? 1 : -1 ];
-      typedef char good_t2[sizeof(myfunc().mc) == sizeof(char) ? 1 : -1 ];
+      typedef char good_t1[sizeof(myfunc().mi) == sizeof(int)  ? 1 : -1];
+      typedef char good_t2[sizeof(myfunc().mc) == sizeof(char) ? 1 : -1];
     ]],[[
       good_t1 dummy1;
       good_t2 dummy2;
@@ -1367,8 +1367,8 @@ AC_DEFUN([CURL_CHECK_COMPILER_STRUCT_MEMBER_SIZE], [
         struct mystruct *next;
       };
       struct mystruct myfunc();
-      typedef char bad_t1[sizeof(myfunc().mi) != sizeof(int)  ? 1 : -1 ];
-      typedef char bad_t2[sizeof(myfunc().mc) != sizeof(char) ? 1 : -1 ];
+      typedef char bad_t1[sizeof(myfunc().mi) != sizeof(int)  ? 1 : -1];
+      typedef char bad_t2[sizeof(myfunc().mc) != sizeof(char) ? 1 : -1];
     ]],[[
       bad_t1 dummy1;
       bad_t2 dummy2;

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1458,8 +1458,8 @@ AC_DEFUN([CURL_CHECK_COMPILER_SYMBOL_HIDING], [
     squeeze CFLAGS
     AC_COMPILE_IFELSE([
       AC_LANG_PROGRAM([[
-        $tmp_EXTERN char *dummy(char *buff);
-        char *dummy(char *buff)
+        $tmp_EXTERN const char *dummy(const char *buff);
+        const char *dummy(const char *buff)
         {
           if(buff)
             return ++buff;
@@ -1467,14 +1467,10 @@ AC_DEFUN([CURL_CHECK_COMPILER_SYMBOL_HIDING], [
             return buff;
         }
       ]],[[
-        char b[16];
-        char *r;
-        b[0] = ' ';
-        b[1] = ' ';
-        r = dummy(&b[0]);
+        const char *b = "example";
+        const char *r = dummy(&b[0]);
         if(r)
           return (int)*r;
-        (void)b;
       ]])
     ],[
       supports_symbol_hiding="yes"

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1313,6 +1313,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_ARRAY_SIZE_NEGATIVE], [
       typedef char bad_t[sizeof(char) == sizeof(int) ? -1 : -1 ];
     ]],[[
       bad_t dummy;
+      (void)dummy;
     ]])
   ],[
     AC_MSG_RESULT([no])
@@ -1347,6 +1348,8 @@ AC_DEFUN([CURL_CHECK_COMPILER_STRUCT_MEMBER_SIZE], [
     ]],[[
       good_t1 dummy1;
       good_t2 dummy2;
+      (void)dummy1;
+      (void)dummy2;
     ]])
   ],[
     tst_compiler_check_one_works="yes"
@@ -1369,6 +1372,8 @@ AC_DEFUN([CURL_CHECK_COMPILER_STRUCT_MEMBER_SIZE], [
     ]],[[
       bad_t1 dummy1;
       bad_t2 dummy2;
+      (void)dummy1;
+      (void)dummy2;
     ]])
   ],[
     tst_compiler_check_two_works="no"
@@ -1465,6 +1470,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_SYMBOL_HIDING], [
         char *r = dummy(&b[0]);
         if(r)
           return (int)*r;
+        (void)b;
       ]])
     ],[
       supports_symbol_hiding="yes"

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1288,7 +1288,6 @@ AC_DEFUN([CURL_CHECK_COMPILER_HALT_ON_ERROR], [
     AC_LANG_PROGRAM([[
     ]],[[
       #error force compilation error
-      return 0;
     ]])
   ],[
     AC_MSG_RESULT([no])

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1288,6 +1288,7 @@ AC_DEFUN([CURL_CHECK_COMPILER_HALT_ON_ERROR], [
     AC_LANG_PROGRAM([[
     ]],[[
       #error force compilation error
+      return 0;
     ]])
   ],[
     AC_MSG_RESULT([no])

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -504,11 +504,11 @@ AC_DEFUN([CURL_CHECK_LIB_ARES], [
       AC_LANG_PROGRAM([[
         #include <ares.h>
         /* set of dummy functions in case c-ares was built with debug */
-        void curl_dofree() { }
-        void curl_sclose() { }
-        void curl_domalloc() { }
-        void curl_docalloc() { }
-        void curl_socket() { }
+        void curl_dofree(void) {}
+        void curl_sclose(void) {}
+        void curl_domalloc(void) {}
+        void curl_docalloc(void) {}
+        void curl_socket(void) {}
       ]],[[
         ares_channel channel;
         ares_cancel(channel); /* added in 1.2.0 */

--- a/m4/curl-confopts.m4
+++ b/m4/curl-confopts.m4
@@ -504,11 +504,11 @@ AC_DEFUN([CURL_CHECK_LIB_ARES], [
       AC_LANG_PROGRAM([[
         #include <ares.h>
         /* set of dummy functions in case c-ares was built with debug */
-        void curl_dofree(void) {}
-        void curl_sclose(void) {}
-        void curl_domalloc(void) {}
-        void curl_docalloc(void) {}
-        void curl_socket(void) {}
+        void curl_dofree(void);   void curl_dofree(void) {}
+        void curl_sclose(void);   void curl_sclose(void) {}
+        void curl_domalloc(void); void curl_domalloc(void) {}
+        void curl_docalloc(void); void curl_docalloc(void) {}
+        void curl_socket(void);   void curl_socket(void) {}
       ]],[[
         ares_channel channel;
         ares_cancel(channel); /* added in 1.2.0 */

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3037,7 +3037,7 @@ AC_DEFUN([CURL_CHECK_FUNC_MEMRCHR], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != memrchr("", 0, 0))
+        if(0 != memrchr(0, 0, 0))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -2392,7 +2392,7 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
       AC_LANG_PROGRAM([[
         $curl_includes_arpa_inet
       ]],[[
-        if(0 != inet_pton(0, 0, 0))
+        if(0 != inet_pton(0, 1, 1))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3944,10 +3944,8 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        char s[1];
-        if(0 != strerror_r(0, s, 0))
+        if(0 != strerror_r(0, 0, 0))
           return 1;
-        (void)s;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -4031,8 +4029,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
             $curl_includes_string
             int strerror_r(int errnum, char *resultbuf, $arg3 bufsize);
           ]],[[
-            if(0 != strerror_r(0, 0, 0))
+            char s[1];
+            if(0 != strerror_r(0, s, 0))
               return 1;
+            (void)s;
           ]])
         ],[
           tst_posix_strerror_r_type_arg3="$arg3"

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3010,7 +3010,7 @@ AC_DEFUN([CURL_CHECK_FUNC_MEMRCHR], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != memrchr(0, 0, 0))
+        if(0 != memrchr("", 0, 0))
           return 1;
       ]])
     ],[
@@ -4276,7 +4276,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRTOK_R], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != strtok_r(0, 0, 0))
+        if(0 != strtok_r(0, "", 0))
           return 1;
       ]])
     ],[
@@ -4361,7 +4361,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRTOLL], [
       AC_LANG_PROGRAM([[
         $curl_includes_stdlib
       ]],[[
-        if(0 != strtoll(0, 0, 0))
+        if(0 != strtoll("", 0, 0))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -2392,7 +2392,7 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
       AC_LANG_PROGRAM([[
         $curl_includes_arpa_inet
       ]],[[
-        if(0 != inet_pton(0, 1, 1))
+        if(0 != inet_pton(0, 0, 0))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3037,7 +3037,7 @@ AC_DEFUN([CURL_CHECK_FUNC_MEMRCHR], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != memrchr(0, 0, 0))
+        if(0 != memrchr("", 0, 0))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3667,7 +3667,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRCASECMP], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != strcasecmp(0, 0))
+        if(0 != strcasecmp("", ""))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1652,8 +1652,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
       $curl_includes_unistd
       $curl_includes_bsdsocket
     ]],[[
-      if(0 != gethostname(0, 0))
+      char s[1];
+      if(0 != gethostname((void *)s, 0))
         return 1;
+      (void)s;
     ]])
   ],[
     AC_MSG_RESULT([yes])
@@ -1686,8 +1688,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
         $curl_includes_unistd
         $curl_includes_bsdsocket
       ]],[[
-        if(0 != gethostname(0, 0))
+        char s[1];
+        if(0 != gethostname((void *)s, 0))
           return 1;
+        (void)s;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -1712,8 +1716,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
               $curl_preprocess_callconv
               extern int FUNCALLCONV gethostname($tst_arg1, $tst_arg2);
             ]],[[
-              if(0 != gethostname(0, 0))
+              char s[1];
+              if(0 != gethostname((tst_arg1)s, 0))
                 return 1;
+              (void)s;
             ]])
           ],[
             tst_gethostname_type_arg2="$tst_arg2"
@@ -3005,7 +3011,7 @@ AC_DEFUN([CURL_CHECK_FUNC_MEMRCHR], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != memrchr(0, 0, 0))
+        if(0 != memrchr("", 0, 0))
           return 1;
       ]])
     ],[
@@ -3944,8 +3950,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != strerror_r(0, 0, 0))
+        char s[1];
+        if(0 != strerror_r(0, s, 0))
           return 1;
+        (void)s;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -3966,8 +3974,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
             $curl_includes_string
             char *strerror_r(int errnum, char *workbuf, $arg3 bufsize);
           ]],[[
-            if(0 != strerror_r(0, 0, 0))
+            char s[1];
+            if(0 != strerror_r(0, s, 0))
               return 1;
+            (void)s;
           ]])
         ],[
           tst_glibc_strerror_r_type_arg3="$arg3"
@@ -4267,8 +4277,10 @@ AC_DEFUN([CURL_CHECK_FUNC_STRTOK_R], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != strtok_r(0, 0, 0))
+        char *s;
+        if(0 != strtok_r(0, "", &s))
           return 1;
+        (void)s;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -4352,7 +4364,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRTOLL], [
       AC_LANG_PROGRAM([[
         $curl_includes_stdlib
       ]],[[
-        if(0 != strtoll(0, 0, 0))
+        if(0 != strtoll("", 0, 0))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -2140,6 +2140,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GMTIME_R], [
         struct tm *gmt = 0;
         struct tm result;
         gmt = gmtime_r(&local, &result);
+        (void)result;
         if(gmt)
           exit(0);
         else
@@ -3993,7 +3994,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
       AC_LANG_PROGRAM([[
         $curl_includes_stdlib
         $curl_includes_string
-#       include <errno.h>
+        #include <errno.h>
       ]],[[
         char buffer[1024];
         char *string = 0;
@@ -4054,7 +4055,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
       AC_LANG_PROGRAM([[
         $curl_includes_stdlib
         $curl_includes_string
-#       include <errno.h>
+        #include <errno.h>
       ]],[[
         char buffer[1024];
         int error = 1;
@@ -4463,6 +4464,7 @@ AC_DEFUN([CURL_ATOMIC],[
       ]],[[
         _Atomic int i = 0;
         i = 4;  // Force an atomic-write operation.
+        (void)i;
       ]])
     ],[
       AC_MSG_RESULT([yes])

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3836,7 +3836,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRDUP], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != strdup(0))
+        if(0 != strdup(""))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3005,7 +3005,7 @@ AC_DEFUN([CURL_CHECK_FUNC_MEMRCHR], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != memrchr("", 0, 0))
+        if(0 != memrchr(0, 0, 0))
           return 1;
       ]])
     ],[
@@ -3667,7 +3667,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRCASECMP], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != strcasecmp("", ""))
+        if(0 != strcasecmp(0, 0))
           return 1;
       ]])
     ],[
@@ -4271,10 +4271,8 @@ AC_DEFUN([CURL_CHECK_FUNC_STRTOK_R], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        char *s;
-        if(0 != strtok_r(0, "", &s))
+        if(0 != strtok_r(0, 0, 0))
           return 1;
-        (void)s;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -4358,7 +4356,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRTOLL], [
       AC_LANG_PROGRAM([[
         $curl_includes_stdlib
       ]],[[
-        if(0 != strtoll("", 0, 0))
+        if(0 != strtoll(0, 0, 0))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1099,7 +1099,7 @@ AC_DEFUN([CURL_CHECK_FUNC_FSETXATTR], [
         AC_LANG_PROGRAM([[
           $curl_includes_sys_xattr
         ]],[[
-          if(0 != fsetxattr(0, "", 0, 0, 0))
+          if(0 != fsetxattr(0, 0, 0, 0, 0))
             return 1;
         ]])
       ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3836,7 +3836,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRDUP], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != strdup(""))
+        if(0 != strdup(0))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1099,7 +1099,7 @@ AC_DEFUN([CURL_CHECK_FUNC_FSETXATTR], [
         AC_LANG_PROGRAM([[
           $curl_includes_sys_xattr
         ]],[[
-          if(0 != fsetxattr(0, 0, 0, 0, 0))
+          if(0 != fsetxattr(0, "", 0, 0, 0))
             return 1;
         ]])
       ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -2265,8 +2265,8 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOP], [
         char ipv4res[sizeof "255.255.255.255"];
         unsigned char ipv6a[26];
         unsigned char ipv4a[5];
-        char *ipv6ptr = 0;
-        char *ipv4ptr = 0;
+        const char *ipv6ptr = 0;
+        const char *ipv4ptr = 0;
         /* - */
         ipv4res[0] = '\0';
         ipv4a[0] = 0xc0;

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1652,10 +1652,8 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
       $curl_includes_unistd
       $curl_includes_bsdsocket
     ]],[[
-      char s[1];
-      if(0 != gethostname((void *)s, 0))
+      if(0 != gethostname(1, 0))
         return 1;
-      (void)s;
     ]])
   ],[
     AC_MSG_RESULT([yes])
@@ -1688,10 +1686,8 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
         $curl_includes_unistd
         $curl_includes_bsdsocket
       ]],[[
-        char s[1];
-        if(0 != gethostname((void *)s, 0))
+        if(0 != gethostname(1, 0))
           return 1;
-        (void)s;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -1716,10 +1712,8 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
               $curl_preprocess_callconv
               extern int FUNCALLCONV gethostname($tst_arg1, $tst_arg2);
             ]],[[
-              char s[1];
-              if(0 != gethostname((tst_arg1)s, 0))
+              if(0 != gethostname(1, 0))
                 return 1;
-              (void)s;
             ]])
           ],[
             tst_gethostname_type_arg2="$tst_arg2"

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -3672,7 +3672,7 @@ AC_DEFUN([CURL_CHECK_FUNC_STRCASECMP], [
       AC_LANG_PROGRAM([[
         $curl_includes_string
       ]],[[
-        if(0 != strcasecmp(0, 0))
+        if(0 != strcasecmp("", ""))
           return 1;
       ]])
     ],[

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1710,7 +1710,12 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
               $curl_includes_unistd
               $curl_includes_bsdsocket
               $curl_preprocess_callconv
-              extern int FUNCALLCONV gethostname($tst_arg1, $tst_arg2);
+              #if defined(_WIN32) && defined(WINSOCK_API_LINKAGE)
+              WINSOCK_API_LINKAGE
+              #else
+              extern
+              #endif
+              int FUNCALLCONV gethostname($tst_arg1, $tst_arg2);
             ]],[[
               if(0 != gethostname(0, 0))
                 return 1;

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1652,7 +1652,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
       $curl_includes_unistd
       $curl_includes_bsdsocket
     ]],[[
-      if(0 != gethostname(1, 0))
+      if(0 != gethostname(0, 0))
         return 1;
     ]])
   ],[
@@ -1686,7 +1686,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
         $curl_includes_unistd
         $curl_includes_bsdsocket
       ]],[[
-        if(0 != gethostname(1, 0))
+        if(0 != gethostname(0, 0))
           return 1;
       ]])
     ],[
@@ -1712,7 +1712,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
               $curl_preprocess_callconv
               extern int FUNCALLCONV gethostname($tst_arg1, $tst_arg2);
             ]],[[
-              if(0 != gethostname(1, 0))
+              if(0 != gethostname(0, 0))
                 return 1;
             ]])
           ],[

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -284,6 +284,7 @@ if test "x$OPT_OPENSSL" != xno; then
         #include <openssl/opensslv.h>
       ]],[[
         int dummy = LIBRESSL_VERSION_NUMBER;
+        (void)dummy;
       ]])
     ],[
       AC_MSG_RESULT([yes])

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -46,6 +46,9 @@ if test "x$OPT_OPENSSL" != xno; then
       my_ac_save_LIBS=$LIBS
       LIBS="-lgdi32 $LIBS"
       AC_LINK_IFELSE([ AC_LANG_PROGRAM([[
+        #ifndef WIN32_LEAN_AND_MEAN
+        #define WIN32_LEAN_AND_MEAN
+        #endif
         #include <windef.h>
         #include <wingdi.h>
         ]],

--- a/m4/curl-openssl.m4
+++ b/m4/curl-openssl.m4
@@ -352,10 +352,13 @@ if test "$OPENSSL_ENABLED" = "1"; then
   AC_MSG_CHECKING([for SRP support in OpenSSL])
   AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
+      #ifndef OPENSSL_SUPPRESS_DEPRECATED
+      #define OPENSSL_SUPPRESS_DEPRECATED
+      #endif
       #include <openssl/ssl.h>
     ]],[[
-      SSL_CTX_set_srp_username(NULL, "");
-      SSL_CTX_set_srp_password(NULL, "");
+      SSL_CTX_set_srp_username(NULL, NULL);
+      SSL_CTX_set_srp_password(NULL, NULL);
     ]])
   ],[
     AC_MSG_RESULT([yes])

--- a/m4/curl-override.m4
+++ b/m4/curl-override.m4
@@ -51,8 +51,7 @@ m4_define([AC_LANG_PROGRAM(C)],
 int main(void)
 {
 $2
- ;
- return 0;
+  return 0;
 }])
 
 dnl Override Autoconf's AC_LANG_CALL (C)

--- a/m4/curl-reentrant.m4
+++ b/m4/curl-reentrant.m4
@@ -57,6 +57,7 @@ AC_DEFUN([CURL_CHECK_NEED_REENTRANT_ERRNO], [
       ]],[[
         #ifdef errno
           int dummy = 1;
+          (void)dummy;
         #else
           #error force compilation error
         #endif
@@ -71,6 +72,7 @@ AC_DEFUN([CURL_CHECK_NEED_REENTRANT_ERRNO], [
         ]],[[
           #ifdef errno
             int dummy = 1;
+            (void)dummy;
           #else
             #error force compilation error
           #endif
@@ -412,6 +414,7 @@ AC_DEFUN([CURL_CONFIGURE_REENTRANT], [
     ]],[[
       #ifdef _REENTRANT
         int dummy = 1;
+        (void)dummy;
       #else
         #error force compilation error
       #endif

--- a/m4/curl-reentrant.m4
+++ b/m4/curl-reentrant.m4
@@ -472,6 +472,7 @@ AC_DEFUN([CURL_CONFIGURE_THREAD_SAFE], [
     ]],[[
       #ifdef _THREAD_SAFE
         int dummy=1;
+        (void)dummy;
       #else
         #error force compilation error
       #endif

--- a/m4/curl-reentrant.m4
+++ b/m4/curl-reentrant.m4
@@ -56,7 +56,7 @@ AC_DEFUN([CURL_CHECK_NEED_REENTRANT_ERRNO], [
         #include <errno.h>
       ]],[[
         #ifdef errno
-          int dummy=1;
+          int dummy = 1;
         #else
           #error force compilation error
         #endif
@@ -70,7 +70,7 @@ AC_DEFUN([CURL_CHECK_NEED_REENTRANT_ERRNO], [
           #include <errno.h>
         ]],[[
           #ifdef errno
-            int dummy=1;
+            int dummy = 1;
           #else
             #error force compilation error
           #endif
@@ -411,7 +411,7 @@ AC_DEFUN([CURL_CONFIGURE_REENTRANT], [
     AC_LANG_PROGRAM([[
     ]],[[
       #ifdef _REENTRANT
-        int dummy=1;
+        int dummy = 1;
       #else
         #error force compilation error
       #endif
@@ -471,7 +471,7 @@ AC_DEFUN([CURL_CONFIGURE_THREAD_SAFE], [
     AC_LANG_PROGRAM([[
     ]],[[
       #ifdef _THREAD_SAFE
-        int dummy=1;
+        int dummy = 1;
         (void)dummy;
       #else
         #error force compilation error


### PR DESCRIPTION
Fix or silence compiler warnings happening in feature detections
to reduce log noise. Warnings may also get promoted to errors in certain
cases, causing missed detections.

It reduces the number of warnings by 4500+ across the linux, linux-old,
macos, non-native and windows GHA workflows (~142 jobs).

Also move picky warning logic for MSVC/Borland to
`CMake/PickyWarnings.cmake. To make them listed in the picky-warnings
log output, and to also apply to feature detections to make them compile
under the same conditions as source code. The hope is to help catching
issues faster. It also improves code quality of feature tests.

Fixed/silenced:
```
warning #177: variable "dummy" was declared but never referenced
warning #177: variable "flag" was declared but never referenced
warning #177: variable "res" was declared but never referenced
warning #592: variable "s" is used before its value is set
warning #1011: missing return statement at end of non-void function "main"
warning #1786: function "SSL_CTX_set_srp_password" (declared at line 1888 of "/usr/include/openssl/ssl.h") was declared deprecated ("Since OpenSSL 3.0")
warning #1786: function "SSL_CTX_set_srp_username" (declared at line 1887 of "/usr/include/openssl/ssl.h") was declared deprecated ("Since OpenSSL 3.0")
warning #2332: a value of type "const char *" cannot be assigned to an entity of type "char *" (dropping qualifiers)
warning: 'SSL_CTX_set_srp_password' is deprecated [-Wdeprecated-declarations]
warning: 'SSL_CTX_set_srp_password' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
warning: 'SSL_CTX_set_srp_username' is deprecated [-Wdeprecated-declarations]
warning: 'SSL_CTX_set_srp_username' is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
warning: 'b' is used uninitialized [-Wuninitialized]
warning: 'gethostname' redeclared without dllimport attribute: previous dllimport ignored [-Wattributes]
warning: Undefined or garbage value returned to caller [core.uninitialized.UndefReturn]
warning: Value stored to 'i' is never read [deadcode.DeadStores]
warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
warning: control reaches end of non-void function [-Wreturn-type]
warning: empty expression statement has no effect; remove unnecessary ';' to silence this warning [-Wextra-semi-stmt]
warning: excess elements in struct initializer
warning: initialization discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
warning: macro "_FILE_OFFSET_BITS" is not used [-Wunused-macros]
warning: macro "_REENTRANT" is not used [-Wunused-macros]
warning: missing braces around initializer [-Wmissing-braces]
warning: no previous extern declaration for non-static variable 'off_t_is_large' [-Wmissing-variable-declarations]
warning: no previous prototype for 'check' [-Wmissing-prototypes]
warning: no previous prototype for function 'check' [-Wmissing-prototypes]
warning: null argument where non-null required (argument 2) [-Wnonnull]
warning: passing 'const char[1]' to parameter of type 'char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
warning: passing argument 2 of 'SSL_CTX_set_srp_password' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
warning: passing argument 2 of 'SSL_CTX_set_srp_username' discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
warning: unused parameter 'c' [-Wunused-parameter]
warning: unused parameter 'f' [-Wunused-parameter]
warning: unused variable 'data' [-Wunused-variable]
warning: unused variable 'dummy' [-Wunused-variable]
warning: unused variable 'flag' [-Wunused-variable]
warning: unused variable 'res' [-Wunused-variable]
warning: unused variable 's' [-Wunused-variable]
warning: variable 's' set but not used [-Wunused-but-set-variable]
warning: variable 'ts' set but not used [-Wunused-but-set-variable]
```

---

w/o whitespace: https://github.com/curl/curl/pull/16287/files?w=1

- [x] rebase on #16278.
- [x] disable Windows pre-fill for double checking results.

Warnings possibly fixable, but not fixed in this PR:
```
ld: warning: ignoring duplicate libraries: '-lcrypto'
ld: warning: ignoring duplicate libraries: '-lcrypto', '-lnghttp2', '-lssl'
ld: warning: ignoring duplicate libraries: '-lcrypto', '-lrtmp', '-lssl'
ld: warning: ignoring duplicate libraries: '-lcrypto', '-lssl'

warning #1786: function "siginterrupt" (declared at line 324 of "/usr/include/signal.h") was declared deprecated ("Use sigaction with SA_RESTART instead")
warning: 'siginterrupt' is deprecated: Use sigaction with SA_RESTART instead [-Wdeprecated-declarations]

warning #2193: null argument provided for parameter marked with attribute "nonnull"
warning: Null pointer passed to 1st parameter expecting 'nonnull' [core.NonNullParamChecker]
warning: Null pointer passed to 2nd parameter expecting 'nonnull' [core.NonNullParamChecker]
warning: Null pointer passed to 3rd parameter expecting 'nonnull' [core.NonNullParamChecker]
warning: argument 1 null where non-null expected [-Wnonnull]
warning: argument 2 null where non-null expected [-Wnonnull]
warning: argument 3 null where non-null expected [-Wnonnull]
warning: null argument where non-null required (argument 1) [-Wnonnull]
warning: null passed to a callee that requires a non-null argument [-Wnonnull]

warning: 'ber_free' is deprecated: first deprecated in macOS 10.11 - use OpenDirectory Framework [-Wdeprecated-declarations]
warning: 'ber_init' is deprecated: first deprecated in macOS 10.11 - use OpenDirectory Framework [-Wdeprecated-declarations]
warning: 'ldap_init' is deprecated: first deprecated in macOS 10.10 - use ldap_initialize [-Wdeprecated-declarations]
warning: 'ldap_unbind' is deprecated: first deprecated in macOS 10.10 - use ldap_unbind_ext [-Wdeprecated-declarations]

warning: unused variable 'hdata' [-Wunused-variable]
warning: unused variable 'ts' [-Wunused-variable]
```
