### PR TITLE
tests: fix test 558, 1330 for MSVC, allow TrackMemory with MSVC in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2196,7 +2196,6 @@ if(NOT CURL_DISABLE_INSTALL)
 
   # curl-config needs the following options to be set.
   set(CC                      "${CMAKE_C_COMPILER}")
-  # TODO: probably put a -D... options here?
   set(CONFIGURE_OPTIONS       "")
   set(CURLVERSION             "${_curl_version}")
   set(VERSIONNUM              "${_curl_version_num}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ endif()
 option(ENABLE_CURLDEBUG "Enable TrackMemory debug feature" ${ENABLE_DEBUG})
 
 if(MSVC)
-  set(ENABLE_CURLDEBUG OFF)  # FIXME: TrackMemory + MSVC fails test 558 and 1330. Tested with static build, Debug mode.
+#  set(ENABLE_CURLDEBUG OFF)  # FIXME: TrackMemory + MSVC fails test 558 and 1330. Tested with static build, Debug mode.
 endif()
 
 if(ENABLE_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,10 +265,6 @@ if(ENABLE_DEBUG)
 endif()
 option(ENABLE_CURLDEBUG "Enable TrackMemory debug feature" ${ENABLE_DEBUG})
 
-if(MSVC)
-#  set(ENABLE_CURLDEBUG OFF)  # FIXME: TrackMemory + MSVC fails test 558 and 1330. Tested with static build, Debug mode.
-endif()
-
 if(ENABLE_DEBUG)
   set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS "DEBUGBUILD")
 endif()

--- a/tests/data/test1330
+++ b/tests/data/test1330
@@ -39,7 +39,7 @@ MEM unit%TESTNUMBER.c: free()
 s/ =.*//
 s/\(.*\)/()/
 s/:\d+/:/
-s:^(MEM )(.*/)(.*):$1$3:
+s:^(MEM )(.*[/\\])(.*):$1$3:
 s/\r\n/\n/
 s/^MEM getenv.c: realloc\(\)[\n]$//
 s/^MEM getenv.c: free\(\)[\n]$//

--- a/tests/data/test558
+++ b/tests/data/test558
@@ -49,7 +49,7 @@ s/^MEM escape.c:\d+ free\(\(nil\)\)[\n]$//
 s/ =.*//
 s/\(.*\)/()/
 s/:\d+/:/
-s:^(MEM |FD )(.*/)(.*):$1$3:
+s:^(MEM |FD )(.*[/\\])(.*):$1$3:
 s/\r\n/\n/
 s/^MEM getenv.c: realloc\(\)[\n]$//
 s/^MEM getenv.c: free\(\)[\n]$//

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -866,7 +866,7 @@ sub checksystemfeatures {
     }
     if($feature{"TrackMemory"} && $feature{"threaded-resolver"}) {
         logmsg("*\n",
-               "*** DISABLES memory tracking when using threaded resolver\n",
+               "*** DISABLES TrackMemory (memory tracking) when using threaded resolver\n",
                "*\n");
     }
 


### PR DESCRIPTION
Extend output filter to pick up backslashes. This makes them pass in CI
when run in the vcpkg MSVC job, for example.

Also:
- cmake: allow TrackMemory, aka `ENABLE_CURLDEBUG` again. Drop FIXME.
- cmake: drop stale TODO.
- runtests: include the word 'TrackMemory' in the message disabling it.

Follow-up to 9f23c8f201f55f1a148b41b16a5e71f3385faa5e #14541
Follow-up to 94c596bbc588ff5f37390754be778c47cd70cc91 #16283
