### PR TITLE
libssh2: fix to use non-deprecated `libssh2_scp_send64()`

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -414,7 +414,8 @@ static int sshkeycallback(CURL *easy,
  * Earlier libssh2 versions did not do SCP properly beyond 32-bit sizes on
  * 32-bit architectures so we check of the necessary function is present.
  */
-#define SCP_SEND(a,b,c,d) libssh2_scp_send_ex(a, b, (int)(c), (size_t)d, 0, 0)
+#define SCP_SEND(a,b,c,d) libssh2_scp_send64(a, b, (int)(c),            \
+                                             (libssh2_int64_t)d, 0, 0)
 
 /*
  * libssh2 1.2.8 fixed the problem with 32-bit ints used for sockets on win64.


### PR DESCRIPTION
Seen in curl-for-win daily, building against libssh2 1.11.2_DEV:
```
curl-for-win/curl/lib/vssh/libssh2.c:2644:9: warning: 'libssh2_scp_send_ex' is deprecated:
  since libssh2 1.2.6. Use libssh2_scp_send64() [-Wdeprecated-declarations]
 2644 |         SCP_SEND(sshc->ssh_session, sshp->path, data->set.new_file_perms,
```
Ref: https://github.com/curl/curl-for-win/actions/runs/13229370277/job/36924363438#step:3:5805

Follow-up to 553248f501762735c6aa5531f5748e88aefb5314 #16199
