### PR TITLE
cmake: fix to detect `HAVE_OPENSSL_SRP` in MSVC UWP builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -942,6 +942,7 @@ macro(curl_openssl_check_symbol_exists _symbol _files _variable)
   cmake_push_check_state()
   if(USE_OPENSSL)
     list(APPEND CMAKE_REQUIRED_LIBRARIES OpenSSL::SSL OpenSSL::Crypto)
+    list(APPEND CMAKE_REQUIRED_DEFINITIONS "-DOPENSSL_SUPPRESS_DEPRECATED")  # for SSL_CTX_set_srp_username deprecated since 3.0.0
     if(HAVE_LIBZ)
       list(APPEND CMAKE_REQUIRED_LIBRARIES ZLIB::ZLIB)
     endif()


### PR DESCRIPTION
A deprecation error prevented correct detection in MSVC UWP builds:
```
curl\\bld\\CMakeFiles\\CMakeScratch\\TryCompile-ks2aa4\\CheckSymbolExists.c(8,19):
  error C4996: 'SSL_CTX_set_srp_username': Since OpenSSL 3.0
```
Ref: https://github.com/curl/curl/actions/runs/13242285473/job/36960223663#step:8:898

It seems to be caused by different default warning levels used by
the toolchain (or CMake?): `/W3` for UWP and `/W1` for Windows desktop.

https://github.com/curl/curl/actions/runs/13242285473/job/36960223663#step:8:893 UWP
https://github.com/curl/curl/actions/runs/13242285473/job/36960223262#step:8:445 desktop

Fix by passing the OpenSSL macro suppressing its deprecation warnings.

Cherry-picked from #16287
