### PR TITLE
tracing for multi

### DIFF
--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -101,9 +101,15 @@ trace.
 
 Tracing of DNS-over-HTTP operations to resolve hostnames.
 
+## `multi`
+
+Traces multi operations managing transfers' state changes and sockets poll
+states.
+
 ## `read`
 
-Traces reading of upload data from the application in order to send it to the server.
+Traces reading of upload data from the application in order to send it to the
+server.
 
 ## `ssls`
 

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -82,6 +82,9 @@ void Curl_infof(struct Curl_easy *data,
  */
 void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
                        const char *fmt, ...) CURL_PRINTF(3, 4);
+void Curl_trc_multi(struct Curl_easy *data,
+                    const char *fmt, ...) CURL_PRINTF(2, 3);
+const char *Curl_trc_mstate_name(int state);
 void Curl_trc_write(struct Curl_easy *data,
                     const char *fmt, ...) CURL_PRINTF(2, 3);
 void Curl_trc_read(struct Curl_easy *data,
@@ -112,6 +115,10 @@ void Curl_trc_ws(struct Curl_easy *data,
 #define infof(data, ...) \
   do { if(Curl_trc_is_verbose(data)) \
          Curl_infof(data, __VA_ARGS__); } while(0)
+#define CURL_TRC_M(data, ...) \
+  do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_multi)) \
+         Curl_trc_multi(data, __VA_ARGS__); } while(0)
+#define CURL_MSTATE_NAME(s)  Curl_trc_mstate_name((int)(s))
 #define CURL_TRC_CF(data, cf, ...) \
   do { if(Curl_trc_cf_is_verbose(cf, data)) \
          Curl_trc_cf_infof(data, cf, __VA_ARGS__); } while(0)
@@ -146,6 +153,7 @@ void Curl_trc_ws(struct Curl_easy *data,
 #else /* CURL_HAVE_C99 */
 
 #define infof Curl_infof
+#define CURL_TRC_M  Curl_trc_multi
 #define CURL_TRC_CF Curl_trc_cf_infof
 #define CURL_TRC_WRITE Curl_trc_write
 #define CURL_TRC_READ  Curl_trc_read
@@ -172,6 +180,7 @@ struct curl_trc_feat {
   const char *name;
   int log_level;
 };
+extern struct curl_trc_feat Curl_trc_feat_multi;
 extern struct curl_trc_feat Curl_trc_feat_read;
 extern struct curl_trc_feat Curl_trc_feat_write;
 
@@ -192,6 +201,7 @@ extern struct curl_trc_feat Curl_trc_feat_write;
 #define Curl_trc_is_verbose(d)        (FALSE)
 #define Curl_trc_cf_is_verbose(x,y)   (FALSE)
 #define Curl_trc_ft_is_verbose(x,y)   (FALSE)
+#define CURL_MSTATE_NAME(x)           ((void)(x), "-")
 
 #endif /* !defined(CURL_DISABLE_VERBOSE_STRINGS) */
 

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -38,9 +38,9 @@ struct Curl_message {
   struct CURLMsg extmsg;
 };
 
-/* NOTE: if you add a state here, add the name to the statename[] array as
-   well!
-*/
+/* NOTE: if you add a state here, add the name to the statenames[] array
+ * in curl_trc.c as well!
+ */
 typedef enum {
   MSTATE_INIT,         /* 0 - start in this state */
   MSTATE_PENDING,      /* 1 - no connections, waiting for one */


### PR DESCRIPTION
add CURL_TRC_M() to trace multi related things, auto-add multi state name to traces. Add tracing to event callback handling. Use CURL_TRC_M() also in connection cache.

Example:

```
15:16:28.633188 [0-x] * [MULTI] [SETUP] -> [CONNECT] (line 2376)
15:16:28.633596 [0-0] * [MULTI] [CONNECT] -> [CONNECTING] (line 2291)
15:16:28.634274 [0-0] * [MULTI] [CONNECTING] pollset sockets=1, ip_connected=0, timeouts=0, paused 0/0 (r/w)
...
15:16:28.634636 [0-0] * [MULTI] [CONNECTING] socket_callback(s=9, POLLOUT)
...
15:16:28.638251 [0-0] * [MULTI] [CONNECTING] socket_callback(s=9, POLLIN)
15:16:28.645336 [0-0] * [MULTI] [CONNECTING] -> [PROTOCONNECT] (line 2414)
...
15:16:28.649635 [1-0] * [MULTI] [PERFORMING] socket=9 adding transfer, action=0x1, users=2, readers=2, writers=0
...
15:16:28.654309 [1-0] * [MULTI] [COMPLETED] Expire cleared
15:16:28.654374 [1-0] * [MULTI] [COMPLETED] -> [MSGSENT] (line 2675)
15:16:28.654442 [1-0] * [MULTI] [MSGSENT] socket_callback(s=9, REMOVE)
```

