### PR TITLE
GHA/non-native: drop cmake Xcode generator iOS job for poor performance

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -266,17 +266,6 @@ jobs:
               -DOPENSSL_CRYPTO_LIBRARY="$HOME/libressl/lib/libcrypto.a"
               -DCURL_USE_LIBPSL=OFF
 
-          - name: 'libressl'
-            install_steps: libressl
-            generator: Xcode
-            generate: >-
-              -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=OFF
-              -DMACOSX_BUNDLE_GUI_IDENTIFIER=se.curl
-              -DOPENSSL_INCLUDE_DIR="$HOME/libressl/include"
-              -DOPENSSL_SSL_LIBRARY="$HOME/libressl/lib/libssl.a"
-              -DOPENSSL_CRYPTO_LIBRARY="$HOME/libressl/lib/libcrypto.a"
-              -DCURL_USE_LIBPSL=OFF
-
     steps:
       - name: 'brew install'
         if: ${{ matrix.build.configure }}
@@ -334,7 +323,6 @@ jobs:
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
             # https://cmake.org/cmake/help/latest/manual/cmake-toolchains.7.html#cross-compiling-for-ios-tvos-visionos-or-watchos
-            [ -n '${{ matrix.build.generator }}' ] && options='-G ${{ matrix.build.generator }}'
             cmake -B bld -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
               -DCMAKE_SYSTEM_NAME=iOS \
               -DUSE_APPLE_IDN=ON \


### PR DESCRIPTION
The Xcode configure phase is slow. In most cases it's >10x slower than
the GNU Makefile configuration. This is after days of attempts to make
it faster. With GNU Makefile it takes 20-30 seconds, while Xcode can
take 3 to 10 minutes, which sometimes makes the job run out of its time
limit and fail.

CMake recommends this generator, but with such poor, and inconsistent
performance, it isn't practical. It helped detecting an Xcode-specific
CMake script issue, but aside from that it's not adding much value.

9m33s: https://github.com/curl/curl/actions/runs/13280738423/job/37078441164
8m18s: https://github.com/curl/curl/actions/runs/13281140850/job/37079589779
2m50s: https://github.com/curl/curl/actions/runs/13280725335/job/37078375179

Follow-up to 12a6de2f660dd692cce93cb65ce6e3ec126bb531 #16043

---

That said if you know how to make it perform reasonably well, or at least
consistently, let us know.
