### PR TITLE
GHA/linux: drop Linux arm job for runner image flakiness with stunnel4

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -164,12 +164,6 @@ jobs:
             install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
-          - name: openssl arm
-            install_packages: zlib1g-dev
-            install_steps: pytest
-            configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
-            image: 'ubuntu-24.04-arm'
-
           - name: openssl -O3 valgrind
             install_packages: zlib1g-dev valgrind
             configure: CFLAGS=-O3 --with-openssl --enable-debug


### PR DESCRIPTION
Since last week the Ubuntu arm runner became flaky while installing `stunnel`.

```
08:07:26 Setting up stunnel4 (3:5.72-1build2) ...
08:07:26 Failed to check if group stunnel4 already exists: Connection refused
08:07:26 Group stunnel4 not found.
08:07:28 Reload daemon failed: Failed to activate service 'org.freedesktop.systemd1': timed out (service_start_timeout=25000ms)
08:07:28 Created symlink /etc/systemd/system/multi-user.target.wants/stunnel.target -> /usr/lib/systemd/system/stunnel.target.
08:08:18 Failed to get unit file state for stunnel.target: Connection timed out
08:08:43 Failed to retrieve unit state: Connection timed out
08:08:43 stunnel.target is a disabled or a static unit, not starting it.
08:08:43 /bin/chown: invalid user: ‘stunnel4:stunnel4’
08:08:43 dpkg: error processing package stunnel4 (--configure):
08:08:43  installed stunnel4 package post-installation script subprocess returned error exit status 1
08:08:43 [...]
08:08:47 Errors were encountered while processing:
08:08:47 stunnel4
08:08:54 Error: Timeout was reached
08:08:55 E: Sub-process /usr/bin/dpkg returned an error code (1)
08:08:55 Error: Process completed with exit code 100.
```
Ref: https://github.com/curl/curl/actions/runs/13280736653/job/37078440398?pr=16300#step:2:94