### PR TITLE
cookie: simplify invalid_octets()

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -461,15 +461,12 @@ static bool bad_domain(const char *domain, size_t len)
 static bool invalid_octets(const char *p)
 {
   /* Reject all bytes \x01 - \x1f (*except* \x09, TAB) + \x7f */
-  static const char badoctets[] = {
-    "\x01\x02\x03\x04\x05\x06\x07\x08\x0a"
-    "\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14"
-    "\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\x7f"
-  };
-  size_t len;
-  /* scan for all the octets that are *not* in cookie-octet */
-  len = strcspn(p, badoctets);
-  return p[len] != '\0';
+  while(*p) {
+    if(((*p != 9) && (*p < 0x20)) || (*p == 0x7f))
+      return TRUE;
+    p++;
+  }
+  return FALSE;
 }
 
 #define CERR_OK            0


### PR DESCRIPTION
should also make it marginally faster and smaller.