### PR TITLE
multi events rework

### DIFF
--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -52,6 +52,7 @@ INTERNALDOCS =                                  \
  internals/HASH.md                              \
  internals/LLIST.md                             \
  internals/MQTT.md                              \
+ internals/MULTI-EV.md                          \
  internals/NEW-PROTOCOL.md                      \
  internals/README.md                            \
  internals/SPLAY.md                             \

--- a/docs/internals/MULTI-EV.md
+++ b/docs/internals/MULTI-EV.md
@@ -1,0 +1,127 @@
+<!--
+Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+
+SPDX-License-Identifier: curl
+-->
+
+# Multi Event Based
+
+A libcurl multi is operating "event based" when the application uses
+and event library like `libuv` to monitor the sockets and file descriptors
+libcurl uses to trigger transfer operations. How that works from the
+applications point of view is described in libcurl-multi(3).
+
+This documents is about the internal handling.
+
+## Source Locations
+
+All code related to event based handling is found in `lib/multi_ev.c`
+and `lib/multi_ev.h`. The header defines a set of internal functions
+and `struct curl_multi_ev` that is embedded in each multi handle.
+
+There is `Curl_multi_ev_init()` and `Curl_multi_ev_cleanup()` to manage
+the overall life cycle, call on creation and destruction of the multi
+handle.
+
+## Tracking Events
+
+First, the various functions in `lib/multi_ev.h` only ever really do
+something when the libcurl application has registered its callback
+in `multi->socket_cb`.
+
+This is important as this callback gets informed about *changes* to sockets.
+When a new socket is added, an existing is removed, or the `POLLIN/OUT`
+flags change, `multi->socket_cb` needs to be invoked. `multi_ev` has to
+track what it already reported to detect changes.
+
+Most applications are expected to go "event based" right from the start,
+but the libcurl API does not prohibit an application to start another
+way and then go for events later on, even in the middle of a transfer.
+
+### Transfer Events
+
+Most event that happen are in connection with a transfer. A transfer
+opens a connection, which opens a socket, and waits for this socket
+to become writable (`POLLOUT`) when using TCP, for example.
+
+The multi then calls `Curl_multi_ev_assess_xfer(multi, data)` to
+let the multi event code detect what sockets the transfer is interested in.
+If indeed a `multi->socket_cb` is set, the *current* transfer pollset is
+retrieved via `Curl_multi_getsock()`. This current pollset is then
+compared to the *previous* pollset. If relevant changes are detected,
+`multi->socket_cb` gets informed about those. These can be:
+
+ * a socket is in the current set, but not the previous one
+ * a socket was also in the previous one, but IN/OUT flags changed
+ * a socket in the previous one is no longer part of the current
+
+`multi_ev.c` keeps a `struct mev_sh_entry` for each sockets in a hash
+with the socket as key. It tracks in each entry which transfers are
+interested in this particular socket. How many transfer want to read
+and/or write and what the summarized `POLLIN/POLLOUT` action, that
+had been reported to `multi->socket_cb` was.
+
+This is necessary as a socket may be in use by several transfers
+at the same time (think HTTP/2 on the same connection). When a transfer
+is done and gets removed from the socket entry, it decrements
+the reader and/or writer count (depending on what it was last
+interested in). This *may* result in the entry's summarized action
+to change, or not.
+
+### Connection Events
+
+There are also events not connected to any transfer that need to be tracked.
+The multi connection cache, concerned with clean shutdowns of connections,
+is interested in socket events during the shutdown.
+
+To allow use of the libcurl infrastructure, the connection cache operates
+using an *internal* easy handle that is not a transfer as such. The
+internal handle is used for all connection shutdown operations, being tied
+to a particular connection only for a short time. This means tracking
+the last pollset for an internal handle is useless.
+
+Instead, the connection cache uses `Curl_multi_ev_assess_conn()` to have
+multi event handling check the connection and track a "last pollset"
+for the connection alone.
+
+## Event Processing
+
+When the libcurl application is informed by the event library that
+a particular socket has an event, it calls `curl_multi_socket_action()`
+to make libcurl react to it. This internally invokes
+`Curl_multi_ev_expire_xfers()` which expires all transfers that
+are interested in the given socket, so the multi handle runs them.
+
+In addition `Curl_multi_ev_expire_xfers()` returns a `bool` to let
+the multi know that connections are also interested in the socket, so
+the connection pool should be informed as well.
+
+## All Things Pass
+
+When a transfer is done, e.g. removed from its multi handle, the
+multi calls `Curl_multi_ev_xfer_done()`. This cleans up the pollset
+tracking for the transfer.
+
+When a connection is done, and before it is destroyed,
+`Curl_multi_ev_conn_done()` is called. This cleans up the pollset
+tracking for this connection.
+
+When a socket is about to be closed, `Curl_multi_ev_socket_done()`
+is called to cleanup the socket entry and all information kept there.
+
+These calls do not have to happen in any particular order. A transfer's
+socket may be around while the transfer is ongoing. Or it might disappear
+in the middle of things. Also, a transfer might be interested in several
+sockets at the same time (resolving, eye balling, ftp are all examples of
+those).
+
+### And Come Again
+
+While transfer and connection identifier are practically unique in a
+libcurl application, sockets are not. Operating systems are keen on reusing
+their resources, and the next socket may get the same identifier as
+one just having been closed with high likelihood.
+
+This means that multi event handling needs to be informed *before* a close,
+clean up all its tracking and be ready to see that same socket identifier
+again right after.

--- a/docs/libcurl/curl_global_trace.md
+++ b/docs/libcurl/curl_global_trace.md
@@ -101,13 +101,34 @@ trace.
 
 Tracing of DNS operations to resolve hostnames and HTTPS records.
 
+## `lib-ids`
+
+Adds transfer and connection identifiers as prefix to every call to
+CURLOPT_DEBUGFUNCTION(3). The format is `[n-m]` where `n` is the identifier
+of the transfer and `m` is the identifier of the connection. A literal `x`
+is used for internal transfers or when no connection is assigned.
+
+For example, `[5-x]` is the prefix for transfer 5 that has no
+connection. The command line tool `curl`uses the same format for its
+`--trace-ids` option.
+
+`lib-ids` is intended for libcurl applications that handle multiple
+transfers but have no own way to identify in trace output which transfer
+a trace event is connected to.
+
 ## `doh`
 
 Former name for DNS-over-HTTP operations. Now an alias for `dns`.
 
+## `multi`
+
+Traces multi operations managing transfers' state changes and sockets poll
+states.
+
 ## `read`
 
-Traces reading of upload data from the application in order to send it to the server.
+Traces reading of upload data from the application in order to send it to the
+server.
 
 ## `ssls`
 

--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -198,6 +198,7 @@ LIB_CFILES =         \
   mprintf.c          \
   mqtt.c             \
   multi.c            \
+  multi_ev.c         \
   netrc.c            \
   nonblock.c         \
   noproxy.c          \
@@ -335,6 +336,7 @@ LIB_HFILES =         \
   mime.h             \
   mqtt.h             \
   multihandle.h      \
+  multi_ev.h         \
   multiif.h          \
   netrc.h            \
   nonblock.h         \

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -245,7 +245,7 @@ static void sock_state_cb(void *data, ares_socket_t socket_fd,
   struct Curl_easy *easy = data;
   if(!readable && !writable) {
     DEBUGASSERT(easy);
-    Curl_multi_closed(easy, socket_fd);
+    Curl_multi_will_close(easy, socket_fd);
   }
 }
 

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -394,7 +394,7 @@ static void destroy_async_data(struct Curl_easy *data)
      * ensure CURLMOPT_SOCKETFUNCTION fires CURL_POLL_REMOVE
      * before the FD is invalidated to avoid EBADF on EPOLL_CTL_DEL
      */
-    Curl_multi_closed(data, sock_rd);
+    Curl_multi_will_close(data, sock_rd);
     wakeup_close(sock_rd);
 #endif
 

--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -177,7 +177,7 @@ void Curl_resolver_kill(struct Curl_easy *data);
 
 /* Curl_resolver_getsock()
  *
- * This function is called from the multi_getsock() function.  'sock' is a
+ * This function is called from the Curl_multi_getsock() function.  'sock' is a
  * pointer to an array to hold the file descriptors, with 'numsock' being the
  * size of that array (in number of entries). This function is supposed to
  * return bitmask indicating what file descriptors (referring to array indexes

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -422,7 +422,7 @@ static int socket_close(struct Curl_easy *data, struct connectdata *conn,
 
   if(use_callback && conn && conn->fclosesocket) {
     int rc;
-    Curl_multi_closed(data, sock);
+    Curl_multi_will_close(data, sock);
     Curl_set_in_callback(data, TRUE);
     rc = conn->fclosesocket(conn->closesocket_client, sock);
     Curl_set_in_callback(data, FALSE);
@@ -431,7 +431,7 @@ static int socket_close(struct Curl_easy *data, struct connectdata *conn,
 
   if(conn)
     /* tell the multi-socket code about this */
-    Curl_multi_closed(data, sock);
+    Curl_multi_will_close(data, sock);
 
   sclose(sock);
 
@@ -997,7 +997,7 @@ static void cf_socket_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   struct cf_socket_ctx *ctx = cf->ctx;
 
   if(ctx && CURL_SOCKET_BAD != ctx->sock) {
-    CURL_TRC_CF(data, cf, "cf_socket_close(%" FMT_SOCKET_T ")", ctx->sock);
+    CURL_TRC_CF(data, cf, "cf_socket_close, fd=%" FMT_SOCKET_T, ctx->sock);
     if(ctx->sock == cf->conn->sock[cf->sockindex])
       cf->conn->sock[cf->sockindex] = CURL_SOCKET_BAD;
     socket_close(data, cf->conn, !ctx->accepted, ctx->sock);
@@ -1019,7 +1019,7 @@ static CURLcode cf_socket_shutdown(struct Curl_cfilter *cf,
   if(cf->connected) {
     struct cf_socket_ctx *ctx = cf->ctx;
 
-    CURL_TRC_CF(data, cf, "cf_socket_shutdown(%" FMT_SOCKET_T ")", ctx->sock);
+    CURL_TRC_CF(data, cf, "cf_socket_shutdown, fd=%" FMT_SOCKET_T, ctx->sock);
     /* On TCP, and when the socket looks well and non-blocking mode
      * can be enabled, receive dangling bytes before close to avoid
      * entering RST states unnecessarily. */

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -200,8 +200,8 @@ CURLcode Curl_conn_shutdown(struct Curl_easy *data, int sockindex, bool *done)
   *done = FALSE;
   now = Curl_now();
   if(!Curl_shutdown_started(data, sockindex)) {
-    DEBUGF(infof(data, "shutdown start on%s connection",
-           sockindex ? " secondary" : ""));
+    CURL_TRC_M(data, "shutdown start on%s connection",
+               sockindex ? " secondary" : "");
     Curl_shutdown_start(data, sockindex, &now);
   }
   else {
@@ -476,7 +476,7 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
       /* In general, we want to send after connect, wait on that. */
       if(sockfd != CURL_SOCKET_BAD)
         Curl_pollset_set_out_only(data, &ps, sockfd);
-      Curl_conn_adjust_pollset(data, &ps);
+      Curl_conn_adjust_pollset(data, data->conn, &ps);
       result = Curl_pollfds_add_ps(&cpfds, &ps);
       if(result)
         goto out;
@@ -626,14 +626,15 @@ void Curl_conn_cf_adjust_pollset(struct Curl_cfilter *cf,
 }
 
 void Curl_conn_adjust_pollset(struct Curl_easy *data,
-                               struct easy_pollset *ps)
+                              struct connectdata *conn,
+                              struct easy_pollset *ps)
 {
   int i;
 
   DEBUGASSERT(data);
-  DEBUGASSERT(data->conn);
+  DEBUGASSERT(conn);
   for(i = 0; i < 2; ++i) {
-    Curl_conn_cf_adjust_pollset(data->conn->cfilter[i], data, ps);
+    Curl_conn_cf_adjust_pollset(conn->cfilter[i], data, ps);
   }
 }
 

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -455,7 +455,8 @@ void Curl_conn_cf_adjust_pollset(struct Curl_cfilter *cf,
  * Adjust pollset from filters installed at transfer's connection.
  */
 void Curl_conn_adjust_pollset(struct Curl_easy *data,
-                               struct easy_pollset *ps);
+                              struct connectdata *conn,
+                              struct easy_pollset *ps);
 
 /**
  * Curl_poll() the filter chain at `cf` with timeout `timeout_ms`.

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -191,13 +191,9 @@ void Curl_cpool_setfds(struct cpool *cpool,
                        int *maxfd);
 
 /**
- * Perform maintenance on connections in the pool. Specifically,
- * progress the shutdown of connections in the queue.
+ * Run connections on socket. If socket is CURL_SOCKET_TIMEOUT, run
+ * maintenance on all connections.
  */
-void Curl_cpool_multi_perform(struct Curl_multi *multi);
-
-void Curl_cpool_multi_socket(struct Curl_multi *multi,
-                             curl_socket_t s, int ev_bitmask);
-
+void Curl_cpool_multi_perform(struct Curl_multi *multi, curl_socket_t s);
 
 #endif /* HEADER_CURL_CONNCACHE_H */

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -53,12 +53,10 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-void Curl_debug(struct Curl_easy *data, curl_infotype type,
-                char *ptr, size_t size)
+static void trc_write(struct Curl_easy *data, curl_infotype type,
+                      char *ptr, size_t size)
 {
   if(data->set.verbose) {
-    static const char s_infotype[CURLINFO_END][3] = {
-      "* ", "< ", "> ", "{ ", "} ", "{ ", "} " };
     if(data->set.fdebug) {
       bool inCallback = Curl_is_in_callback(data);
       Curl_set_in_callback(data, TRUE);
@@ -66,6 +64,8 @@ void Curl_debug(struct Curl_easy *data, curl_infotype type,
       Curl_set_in_callback(data, inCallback);
     }
     else {
+      static const char s_infotype[CURLINFO_END][3] = {
+        "* ", "< ", "> ", "{ ", "} ", "{ ", "} " };
       switch(type) {
       case CURLINFO_TEXT:
       case CURLINFO_HEADER_OUT:
@@ -80,6 +80,100 @@ void Curl_debug(struct Curl_easy *data, curl_infotype type,
   }
 }
 
+/* max length we trace before ending in '...' */
+#define TRC_LINE_MAX 2048
+
+#define CURL_TRC_FMT_IDSC   "[x-%" CURL_FORMAT_CURL_OFF_T "] "
+#define CURL_TRC_FMT_IDSD   "[%" CURL_FORMAT_CURL_OFF_T "-x] "
+#define CURL_TRC_FMT_IDSDC  "[%" CURL_FORMAT_CURL_OFF_T "-%" \
+                            CURL_FORMAT_CURL_OFF_T "] "
+
+static struct curl_trc_feat Curl_trc_feat_ids = {
+  "LIB-IDS",
+  CURL_LOG_LVL_NONE,
+};
+#define CURL_TRC_IDS(data) \
+             (Curl_trc_is_verbose(data) && \
+             Curl_trc_feat_ids.log_level >= CURL_LOG_LVL_INFO)
+
+static size_t trc_print_ids(struct Curl_easy *data, char *buf, size_t maxlen)
+{
+  curl_off_t cid = data->conn ?
+                   data->conn->connection_id : data->state.recent_conn_id;
+  if(data->id >= 0) {
+    if(cid >= 0)
+      return msnprintf(buf, maxlen, CURL_TRC_FMT_IDSDC, data->id, cid);
+    else
+      return msnprintf(buf, maxlen, CURL_TRC_FMT_IDSD, data->id);
+  }
+  else if(cid >= 0)
+    return msnprintf(buf, maxlen, CURL_TRC_FMT_IDSC, cid);
+  else {
+    return msnprintf(buf, maxlen, "[x-x] ");
+  }
+}
+
+static size_t trc_end_buf(char *buf, size_t len, size_t maxlen, bool addnl)
+{
+  /* make sure we end the trace line in `buf` properly. It needs
+   * to end with a terminating '\0' or '\n\0' */
+  if(len >= (maxlen - (addnl ? 2 : 1))) {
+    len = maxlen - 5;
+    buf[len++] = '.';
+    buf[len++] = '.';
+    buf[len++] = '.';
+    buf[len++] = '\n';
+  }
+  else if(addnl)
+    buf[len++] = '\n';
+  buf[len] = '\0';
+  return len;
+}
+
+void Curl_debug(struct Curl_easy *data, curl_infotype type,
+                char *ptr, size_t size)
+{
+  if(data->set.verbose) {
+    static const char s_infotype[CURLINFO_END][3] = {
+      "* ", "< ", "> ", "{ ", "} ", "{ ", "} " };
+    char buf[TRC_LINE_MAX];
+    size_t len;
+    if(data->set.fdebug) {
+      bool inCallback = Curl_is_in_callback(data);
+
+      if(CURL_TRC_IDS(data) && (size < TRC_LINE_MAX)) {
+        len = trc_print_ids(data, buf, TRC_LINE_MAX);
+        len += msnprintf(buf + len, TRC_LINE_MAX - len, "%.*s",
+                         (int)size, ptr);
+        len = trc_end_buf(buf, len, TRC_LINE_MAX, FALSE);
+        Curl_set_in_callback(data, TRUE);
+        (void)(*data->set.fdebug)(data, type, buf, len, data->set.debugdata);
+        Curl_set_in_callback(data, inCallback);
+      }
+      else {
+        Curl_set_in_callback(data, TRUE);
+        (void)(*data->set.fdebug)(data, type, ptr, size, data->set.debugdata);
+        Curl_set_in_callback(data, inCallback);
+      }
+    }
+    else {
+      switch(type) {
+      case CURLINFO_TEXT:
+      case CURLINFO_HEADER_OUT:
+      case CURLINFO_HEADER_IN:
+        if(CURL_TRC_IDS(data)) {
+          len = trc_print_ids(data, buf, TRC_LINE_MAX);
+          fwrite(buf, len, 1, data->set.err);
+        }
+        fwrite(s_infotype[type], 2, 1, data->set.err);
+        fwrite(ptr, size, 1, data->set.err);
+        break;
+      default: /* nada */
+        break;
+      }
+    }
+  }
+}
 
 /* Curl_failf() is for messages stating why we failed.
  * The message SHALL NOT include any LF or CR.
@@ -89,7 +183,7 @@ void Curl_failf(struct Curl_easy *data, const char *fmt, ...)
   DEBUGASSERT(!strchr(fmt, '\n'));
   if(data->set.verbose || data->set.errorbuffer) {
     va_list ap;
-    int len;
+    size_t len;
     char error[CURL_ERROR_SIZE + 2];
     va_start(ap, fmt);
     len = mvsnprintf(error, CURL_ERROR_SIZE, fmt, ap);
@@ -100,36 +194,41 @@ void Curl_failf(struct Curl_easy *data, const char *fmt, ...)
     }
     error[len++] = '\n';
     error[len] = '\0';
-    Curl_debug(data, CURLINFO_TEXT, error, len);
+    trc_write(data, CURLINFO_TEXT, error, len);
     va_end(ap);
   }
 }
 
 #if !defined(CURL_DISABLE_VERBOSE_STRINGS)
 
-/* Curl_infof() is for info message along the way */
-#define MAXINFO 2048
 
-static void trc_infof(struct Curl_easy *data, struct curl_trc_feat *feat,
-                      const char * const fmt, va_list ap)  CURL_PRINTF(3, 0);
+static void trc_infof(struct Curl_easy *data,
+                      struct curl_trc_feat *feat,
+                      const char *opt_id, int opt_id_idx,
+                      const char * const fmt, va_list ap)  CURL_PRINTF(5, 0);
 
-static void trc_infof(struct Curl_easy *data, struct curl_trc_feat *feat,
+static void trc_infof(struct Curl_easy *data,
+                      struct curl_trc_feat *feat,
+                      const char *opt_id, int opt_id_idx,
                       const char * const fmt, va_list ap)
 {
-  int len = 0;
-  char buffer[MAXINFO + 5];
+  size_t len = 0;
+  char buf[TRC_LINE_MAX];
+
+  if(CURL_TRC_IDS(data))
+    len += trc_print_ids(data, buf + len, TRC_LINE_MAX - len);
   if(feat)
-    len = msnprintf(buffer, (MAXINFO + 1), "[%s] ", feat->name);
-  len += mvsnprintf(buffer + len, (MAXINFO + 1) - len, fmt, ap);
-  if(len >= MAXINFO) { /* too long, shorten with '...' */
-    --len;
-    buffer[len++] = '.';
-    buffer[len++] = '.';
-    buffer[len++] = '.';
+    len += msnprintf(buf + len, TRC_LINE_MAX - len, "[%s] ", feat->name);
+  if(opt_id) {
+    if(opt_id_idx > 0)
+      len += msnprintf(buf + len, TRC_LINE_MAX - len, "[%s-%d] ",
+                       opt_id, opt_id_idx);
+    else
+      len += msnprintf(buf + len, TRC_LINE_MAX - len, "[%s] ", opt_id);
   }
-  buffer[len++] = '\n';
-  buffer[len] = '\0';
-  Curl_debug(data, CURLINFO_TEXT, buffer, len);
+  len += mvsnprintf(buf + len, TRC_LINE_MAX - len, fmt, ap);
+  len = trc_end_buf(buf, len, TRC_LINE_MAX, TRUE);
+  trc_write(data, CURLINFO_TEXT, buf, len);
 }
 
 void Curl_infof(struct Curl_easy *data, const char *fmt, ...)
@@ -138,7 +237,7 @@ void Curl_infof(struct Curl_easy *data, const char *fmt, ...)
   if(Curl_trc_is_verbose(data)) {
     va_list ap;
     va_start(ap, fmt);
-    trc_infof(data, data->state.feat, fmt, ap);
+    trc_infof(data, data->state.feat, NULL, 0, fmt, ap);
     va_end(ap);
   }
 }
@@ -149,25 +248,16 @@ void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
   DEBUGASSERT(cf);
   if(Curl_trc_cf_is_verbose(cf, data)) {
     va_list ap;
-    int len = 0;
-    char buffer[MAXINFO + 2];
-    if(data->state.feat)
-      len += msnprintf(buffer + len, MAXINFO - len, "[%s] ",
-                       data->state.feat->name);
-    if(cf->sockindex)
-      len += msnprintf(buffer + len, MAXINFO - len, "[%s-%d] ",
-                      cf->cft->name, cf->sockindex);
-    else
-      len += msnprintf(buffer + len, MAXINFO - len, "[%s] ", cf->cft->name);
     va_start(ap, fmt);
-    len += mvsnprintf(buffer + len, MAXINFO - len, fmt, ap);
+    trc_infof(data, data->state.feat, cf->cft->name, cf->sockindex, fmt, ap);
     va_end(ap);
-    buffer[len++] = '\n';
-    buffer[len] = '\0';
-    Curl_debug(data, CURLINFO_TEXT, buffer, len);
   }
 }
 
+struct curl_trc_feat Curl_trc_feat_multi = {
+  "MULTI",
+  CURL_LOG_LVL_NONE,
+};
 struct curl_trc_feat Curl_trc_feat_read = {
   "READ",
   CURL_LOG_LVL_NONE,
@@ -182,13 +272,54 @@ struct curl_trc_feat Curl_trc_feat_dns = {
 };
 
 
+static const char * const Curl_trc_mstate_names[]={
+  "INIT",
+  "PENDING",
+  "SETUP",
+  "CONNECT",
+  "RESOLVING",
+  "CONNECTING",
+  "TUNNELING",
+  "PROTOCONNECT",
+  "PROTOCONNECTING",
+  "DO",
+  "DOING",
+  "DOING_MORE",
+  "DID",
+  "PERFORMING",
+  "RATELIMITING",
+  "DONE",
+  "COMPLETED",
+  "MSGSENT",
+};
+
+const char *Curl_trc_mstate_name(int state)
+{
+  if((state >= 0) && ((size_t)state < CURL_ARRAYSIZE(Curl_trc_mstate_names)))
+    return Curl_trc_mstate_names[(size_t)state];
+  return "?";
+}
+
+void Curl_trc_multi(struct Curl_easy *data, const char *fmt, ...)
+{
+  DEBUGASSERT(!strchr(fmt, '\n'));
+  if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_multi)) {
+    const char *sname = (data->id >= 0) ?
+                        Curl_trc_mstate_name(data->mstate) : NULL;
+    va_list ap;
+    va_start(ap, fmt);
+    trc_infof(data, &Curl_trc_feat_multi, sname, 0, fmt, ap);
+    va_end(ap);
+  }
+}
+
 void Curl_trc_read(struct Curl_easy *data, const char *fmt, ...)
 {
   DEBUGASSERT(!strchr(fmt, '\n'));
   if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_read)) {
     va_list ap;
     va_start(ap, fmt);
-    trc_infof(data, &Curl_trc_feat_read, fmt, ap);
+    trc_infof(data, &Curl_trc_feat_read, NULL, 0, fmt, ap);
     va_end(ap);
   }
 }
@@ -199,7 +330,7 @@ void Curl_trc_write(struct Curl_easy *data, const char *fmt, ...)
   if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_write)) {
     va_list ap;
     va_start(ap, fmt);
-    trc_infof(data, &Curl_trc_feat_write, fmt, ap);
+    trc_infof(data, &Curl_trc_feat_write, NULL, 0, fmt, ap);
     va_end(ap);
   }
 }
@@ -210,7 +341,7 @@ void Curl_trc_dns(struct Curl_easy *data, const char *fmt, ...)
   if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_dns)) {
     va_list ap;
     va_start(ap, fmt);
-    trc_infof(data, &Curl_trc_feat_dns, fmt, ap);
+    trc_infof(data, &Curl_trc_feat_dns, NULL, 0, fmt, ap);
     va_end(ap);
   }
 }
@@ -227,7 +358,7 @@ void Curl_trc_ftp(struct Curl_easy *data, const char *fmt, ...)
   if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_ftp)) {
     va_list ap;
     va_start(ap, fmt);
-    trc_infof(data, &Curl_trc_feat_ftp, fmt, ap);
+    trc_infof(data, &Curl_trc_feat_ftp, NULL, 0, fmt, ap);
     va_end(ap);
   }
 }
@@ -245,7 +376,7 @@ void Curl_trc_smtp(struct Curl_easy *data, const char *fmt, ...)
   if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_smtp)) {
     va_list ap;
     va_start(ap, fmt);
-    trc_infof(data, &Curl_trc_feat_smtp, fmt, ap);
+    trc_infof(data, &Curl_trc_feat_smtp, NULL, 0, fmt, ap);
     va_end(ap);
   }
 }
@@ -263,7 +394,7 @@ void Curl_trc_ssls(struct Curl_easy *data, const char *fmt, ...)
   if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_ssls)) {
     va_list ap;
     va_start(ap, fmt);
-    trc_infof(data, &Curl_trc_feat_ssls, fmt, ap);
+    trc_infof(data, &Curl_trc_feat_ssls, NULL, 0, fmt, ap);
     va_end(ap);
   }
 }
@@ -281,7 +412,7 @@ void Curl_trc_ws(struct Curl_easy *data, const char *fmt, ...)
   if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_ws)) {
     va_list ap;
     va_start(ap, fmt);
-    trc_infof(data, &Curl_trc_feat_ws, fmt, ap);
+    trc_infof(data, &Curl_trc_feat_ws, NULL, 0, fmt, ap);
     va_end(ap);
   }
 }
@@ -291,6 +422,7 @@ void Curl_trc_ws(struct Curl_easy *data, const char *fmt, ...)
 #define TRC_CT_PROTOCOL    (1<<(0))
 #define TRC_CT_NETWORK     (1<<(1))
 #define TRC_CT_PROXY       (1<<(2))
+#define TRC_CT_INTERNALS   (1<<(3))
 
 struct trc_feat_def {
   struct curl_trc_feat *feat;
@@ -298,6 +430,8 @@ struct trc_feat_def {
 };
 
 static struct trc_feat_def trc_feats[] = {
+  { &Curl_trc_feat_ids,       TRC_CT_INTERNALS },
+  { &Curl_trc_feat_multi,     TRC_CT_NETWORK },
   { &Curl_trc_feat_read,      TRC_CT_NONE },
   { &Curl_trc_feat_write,     TRC_CT_NONE },
   { &Curl_trc_feat_dns,       TRC_CT_NETWORK },
@@ -467,6 +601,11 @@ void Curl_trc_cf_infof(struct Curl_easy *data,
 }
 
 struct curl_trc_feat;
+
+void Curl_trc_multi(struct Curl_easy *data, const char *fmt, ...)
+{
+  (void)data; (void)fmt;
+}
 
 void Curl_trc_write(struct Curl_easy *data, const char *fmt, ...)
 {

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -82,6 +82,10 @@ void Curl_infof(struct Curl_easy *data,
  */
 void Curl_trc_cf_infof(struct Curl_easy *data, struct Curl_cfilter *cf,
                        const char *fmt, ...) CURL_PRINTF(3, 4);
+void Curl_trc_multi(struct Curl_easy *data,
+                    const char *fmt, ...) CURL_PRINTF(2, 3);
+const char *Curl_trc_mstate_name(int state);
+#define CURL_MSTATE_NAME(s)  Curl_trc_mstate_name((int)(s))
 void Curl_trc_write(struct Curl_easy *data,
                     const char *fmt, ...) CURL_PRINTF(2, 3);
 void Curl_trc_read(struct Curl_easy *data,
@@ -114,6 +118,9 @@ void Curl_trc_ws(struct Curl_easy *data,
 #define infof(data, ...) \
   do { if(Curl_trc_is_verbose(data)) \
          Curl_infof(data, __VA_ARGS__); } while(0)
+#define CURL_TRC_M(data, ...) \
+  do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_multi)) \
+         Curl_trc_multi(data, __VA_ARGS__); } while(0)
 #define CURL_TRC_CF(data, cf, ...) \
   do { if(Curl_trc_cf_is_verbose(cf, data)) \
          Curl_trc_cf_infof(data, cf, __VA_ARGS__); } while(0)
@@ -151,6 +158,7 @@ void Curl_trc_ws(struct Curl_easy *data,
 #else /* CURL_HAVE_C99 */
 
 #define infof Curl_infof
+#define CURL_TRC_M  Curl_trc_multi
 #define CURL_TRC_CF Curl_trc_cf_infof
 #define CURL_TRC_WRITE Curl_trc_write
 #define CURL_TRC_READ  Curl_trc_read
@@ -178,6 +186,7 @@ struct curl_trc_feat {
   const char *name;
   int log_level;
 };
+extern struct curl_trc_feat Curl_trc_feat_multi;
 extern struct curl_trc_feat Curl_trc_feat_read;
 extern struct curl_trc_feat Curl_trc_feat_write;
 extern struct curl_trc_feat Curl_trc_feat_dns;
@@ -199,6 +208,7 @@ extern struct curl_trc_feat Curl_trc_feat_dns;
 #define Curl_trc_is_verbose(d)        (FALSE)
 #define Curl_trc_cf_is_verbose(x,y)   (FALSE)
 #define Curl_trc_ft_is_verbose(x,y)   (FALSE)
+#define CURL_MSTATE_NAME(x)           ((void)(x), "-")
 
 #endif /* !defined(CURL_DISABLE_VERBOSE_STRINGS) */
 

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1195,10 +1195,10 @@ CURLcode curl_easy_pause(CURL *d, int action)
   }
 
 out:
-  if(!result && !data->state.done && keep_changed)
-    /* This transfer may have been moved in or out of the bundle, update the
-       corresponding socket callback, if used */
-    result = Curl_updatesocket(data);
+  if(!result && !data->state.done && keep_changed && data->multi)
+    /* pause/unpausing may result in multi event changes */
+    if(Curl_multi_ev_assess_xfer(data->multi, data))
+      result = CURLE_ABORTED_BY_CALLBACK;
 
   if(recursive)
     /* this might have called a callback recursively which might have set this

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -1,0 +1,610 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#include <curl/curl.h>
+
+#include "urldata.h"
+#include "cfilters.h"
+#include "curl_trc.h"
+#include "multiif.h"
+#include "timeval.h"
+#include "multi_ev.h"
+#include "select.h"
+#include "warnless.h"
+#include "multihandle.h"
+#include "socks.h"
+/* The last 3 #include files should be in this order */
+#include "curl_printf.h"
+#include "curl_memory.h"
+#include "memdebug.h"
+
+
+static void mev_in_callback(struct Curl_multi *multi, bool value)
+{
+  multi->in_callback = value;
+}
+
+#define CURL_MEV_XFER_HASH_SIZE 13
+#define CURL_MEV_CONN_HASH_SIZE 3
+
+/* Information about a socket for which we inform the libcurl application
+ * what to supervise (CURL_POLL_IN/CURL_POLL_OUT/CURL_POLL_REMOVE)
+ */
+struct mev_sh_entry {
+  struct Curl_hash xfers; /* hash of transfers using this socket */
+  struct Curl_hash conns; /* hash of connections using this socket */
+  void *user_data;      /* libcurl app data via curl_multi_assign() */
+  unsigned int action;  /* CURL_POLL_IN/CURL_POLL_OUT we last told the
+                         * libcurl application to watch out for */
+  unsigned int readers; /* this many transfers want to read */
+  unsigned int writers; /* this many transfers want to write */
+};
+
+static size_t mev_sh_entry_hash(void *key, size_t key_length, size_t slots_num)
+{
+  curl_socket_t fd = *((curl_socket_t *) key);
+  (void) key_length;
+  return (fd % (curl_socket_t)slots_num);
+}
+
+static size_t mev_sh_entry_compare(void *k1, size_t k1_len,
+                                   void *k2, size_t k2_len)
+{
+  (void) k1_len; (void) k2_len;
+  return (*((curl_socket_t *) k1)) == (*((curl_socket_t *) k2));
+}
+
+/* sockhash entry destructor callback */
+static void mev_sh_entry_dtor(void *freethis)
+{
+  struct mev_sh_entry *entry = (struct mev_sh_entry *)freethis;
+  Curl_hash_destroy(&entry->xfers);
+  Curl_hash_destroy(&entry->conns);
+  free(entry);
+}
+
+/* look up a given socket in the socket hash, skip invalid sockets */
+static struct mev_sh_entry *
+mev_sh_entry_get(struct Curl_hash *sh, curl_socket_t s)
+{
+  if(s != CURL_SOCKET_BAD) {
+    /* only look for proper sockets */
+    return Curl_hash_pick(sh, (char *)&s, sizeof(curl_socket_t));
+  }
+  return NULL;
+}
+
+static void mev_nop_dtor(void *e)
+{
+  (void)e; /* does nothing */
+}
+
+/* make sure this socket is present in the hash for this handle */
+static struct mev_sh_entry *
+mev_sh_entry_add(struct Curl_hash *sh, curl_socket_t s)
+{
+  struct mev_sh_entry *there = mev_sh_entry_get(sh, s);
+  struct mev_sh_entry *check;
+
+  if(there) {
+    /* it is present, return fine */
+    return there;
+  }
+
+  /* not present, add it */
+  check = calloc(1, sizeof(struct mev_sh_entry));
+  if(!check)
+    return NULL; /* major failure */
+
+  Curl_hash_offt_init(&check->xfers, CURL_MEV_XFER_HASH_SIZE, mev_nop_dtor);
+  Curl_hash_offt_init(&check->conns, CURL_MEV_CONN_HASH_SIZE, mev_nop_dtor);
+
+  /* make/add new hash entry */
+  if(!Curl_hash_add(sh, (char *)&s, sizeof(curl_socket_t), check)) {
+    mev_sh_entry_dtor(check);
+    return NULL; /* major failure */
+  }
+
+  return check; /* things are good in sockhash land */
+}
+
+/* delete the given socket entry from the hash */
+static void mev_sh_entry_kill(struct Curl_multi *multi, curl_socket_t s)
+{
+  Curl_hash_delete(&multi->ev.sh_entries, (char *)&s, sizeof(curl_socket_t));
+}
+
+static size_t mev_sh_entry_user_count(struct mev_sh_entry *e)
+{
+  return Curl_hash_count(&e->xfers) + Curl_hash_count(&e->conns);
+}
+
+static bool mev_sh_entry_xfer_known(struct mev_sh_entry *e,
+                                    struct Curl_easy *data)
+{
+  return !!Curl_hash_offt_get(&e->xfers, data->id);
+}
+
+static bool mev_sh_entry_conn_known(struct mev_sh_entry *e,
+                                    struct connectdata *conn)
+{
+  return !!Curl_hash_offt_get(&e->conns, conn->connection_id);
+}
+
+static bool mev_sh_entry_xfer_add(struct mev_sh_entry *e,
+                                  struct Curl_easy *data)
+{
+   /* detect weird values */
+  DEBUGASSERT(mev_sh_entry_user_count(e) < 100000);
+  return !!Curl_hash_offt_set(&e->xfers, data->id, data);
+}
+
+static bool mev_sh_entry_conn_add(struct mev_sh_entry *e,
+                                  struct connectdata *conn)
+{
+   /* detect weird values */
+  DEBUGASSERT(mev_sh_entry_user_count(e) < 100000);
+  return !!Curl_hash_offt_set(&e->conns, conn->connection_id, conn);
+}
+
+
+static bool mev_sh_entry_xfer_remove(struct mev_sh_entry *e,
+                                     struct Curl_easy *data)
+{
+  return !Curl_hash_offt_remove(&e->xfers, data->id);
+}
+
+/* Purge any information about socket `s`.
+ * Let the socket callback know as well when necessary */
+static CURLMcode mev_forget_socket(struct Curl_multi *multi,
+                                   struct Curl_easy *data,
+                                   curl_socket_t s,
+                                   const char *cause)
+{
+  struct mev_sh_entry *entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
+  int rc = 0;
+
+  if(!entry) /* we never knew or already forgot about this socket */
+    return CURLM_OK;
+
+  /* We managed this socket before, tell the socket callback to forget it. */
+  if(multi->socket_cb) {
+    CURL_TRC_M(data, "ev %s, call(fd=%" FMT_SOCKET_T ", ev=REMOVE)",
+               cause, s);
+    mev_in_callback(multi, TRUE);
+    rc = multi->socket_cb(data, s, CURL_POLL_REMOVE,
+                          multi->socket_userp, entry->user_data);
+    mev_in_callback(multi, FALSE);
+  }
+
+  mev_sh_entry_kill(multi, s);
+  if(rc == -1) {
+    multi->dead = TRUE;
+    return CURLM_ABORTED_BY_CALLBACK;
+  }
+  return CURLM_OK;
+}
+
+static CURLMcode mev_sh_entry_update(struct Curl_multi *multi,
+                                     struct Curl_easy *data,
+                                     struct mev_sh_entry *entry,
+                                     curl_socket_t s,
+                                     unsigned char last_action,
+                                     unsigned char cur_action)
+{
+  int rc, comboaction;
+
+  /* we should only be called when the callback exists */
+  DEBUGASSERT(multi->socket_cb);
+  if(!multi->socket_cb)
+    return CURLM_OK;
+
+  /* Transfer `data` goes from `last_action` to `cur_action` on socket `s`
+   * with `multi->ev.sh_entries` entry `entry`. Update `entry` and trigger
+   * `multi->socket_cb` on change, if the callback is set. */
+  if(last_action == cur_action)  /* nothing from `data` changed */
+    return CURLM_OK;
+
+  if(last_action & CURL_POLL_IN) {
+    DEBUGASSERT(entry->readers);
+    if(!(cur_action & CURL_POLL_IN))
+      entry->readers--;
+  }
+  else if(cur_action & CURL_POLL_IN)
+    entry->readers++;
+
+  if(last_action & CURL_POLL_OUT) {
+    DEBUGASSERT(entry->writers);
+    if(!(cur_action & CURL_POLL_OUT))
+      entry->writers--;
+  }
+  else if(cur_action & CURL_POLL_OUT)
+    entry->writers++;
+
+  DEBUGASSERT(entry->readers <= mev_sh_entry_user_count(entry));
+  DEBUGASSERT(entry->writers <= mev_sh_entry_user_count(entry));
+  DEBUGASSERT(entry->writers + entry->readers);
+
+  CURL_TRC_M(data, "ev update fd=%" FMT_SOCKET_T ", action '%s%s' -> '%s%s'"
+             " (%d/%d r/w)", s,
+             (last_action & CURL_POLL_IN) ? "IN" : "",
+             (last_action & CURL_POLL_OUT) ? "OUT" : "",
+             (cur_action & CURL_POLL_IN) ? "IN" : "",
+             (cur_action & CURL_POLL_OUT) ? "OUT" : "",
+             entry->readers, entry->writers);
+
+  comboaction = (entry->writers ? CURL_POLL_OUT : 0) |
+                (entry->readers ? CURL_POLL_IN : 0);
+  if(((int)entry->action == comboaction)) /* nothing for socket changed */
+    return CURLM_OK;
+
+  CURL_TRC_M(data, "ev update call(fd=%" FMT_SOCKET_T ", ev=%s%s)",
+             s, (comboaction & CURL_POLL_IN) ? "IN" : "",
+             (comboaction & CURL_POLL_OUT) ? "OUT" : "");
+  mev_in_callback(multi, TRUE);
+  rc = multi->socket_cb(data, s, comboaction, multi->socket_userp,
+                        entry->user_data);
+
+  mev_in_callback(multi, FALSE);
+  if(rc == -1) {
+    multi->dead = TRUE;
+    return CURLM_ABORTED_BY_CALLBACK;
+  }
+  entry->action = (unsigned int)comboaction;
+  return CURLM_OK;
+}
+
+static CURLMcode mev_pollset_diff(struct Curl_multi *multi,
+                                  struct Curl_easy *data,
+                                  struct connectdata *conn,
+                                  struct easy_pollset *ps,
+                                  struct easy_pollset *prev_ps)
+{
+  struct mev_sh_entry *entry;
+  curl_socket_t s;
+  unsigned int i, j;
+  CURLMcode mresult;
+
+  /* The transfer `data` reports in `ps` the sockets it is interested
+   * in and which combinatino of CURL_POLL_IN/CURL_POLL_OUT it wants
+   * to have monitored for events.
+   * There can be more than 1 transfer interested in the same socket
+   * and 1 transfer might be interested in more than 1 socket.
+   * `prev_ps` is the pollset copy from the previous call here. On
+   * the 1st call it will be empty.
+   */
+  DEBUGASSERT(ps);
+  DEBUGASSERT(prev_ps);
+
+  /* Handle changes to sockets the transfer is interested in. */
+  for(i = 0; i < ps->num; i++) {
+    unsigned char last_action;
+    bool first_time = FALSE; /* data/conn appears first time on socket */
+
+    s = ps->sockets[i];
+    /* Have we handled this socket before? */
+    entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
+    if(!entry) {
+      /* new socket, add new entry */
+      first_time = TRUE;
+      entry = mev_sh_entry_add(&multi->ev.sh_entries, s);
+      if(!entry) /* fatal */
+        return CURLM_OUT_OF_MEMORY;
+      CURL_TRC_M(data, "ev new entry fd=%" FMT_SOCKET_T, s);
+    }
+    else if(conn) {
+      first_time = !mev_sh_entry_conn_known(entry, data->conn);
+    }
+    else {
+      first_time = !mev_sh_entry_xfer_known(entry, data);
+    }
+
+    /* What was the previous action the transfer had regarding this socket?
+     * If the transfer is new to the socket, disregard the information
+     * in `last_poll`, because the socket might have been destroyed and
+     * reopened. We'd have cleared the sh_entry for that, but the socket
+     * might still be mentioned in the hashed pollsets. */
+    last_action = 0;
+    if(first_time) {
+      if(conn) {
+        if(!mev_sh_entry_conn_add(entry, data->conn))
+          return CURLM_OUT_OF_MEMORY;
+      }
+      else {
+        if(!mev_sh_entry_xfer_add(entry, data))
+          return CURLM_OUT_OF_MEMORY;
+      }
+      CURL_TRC_M(data, "ev entry fd=%" FMT_SOCKET_T ", added %s #%" FMT_OFF_T
+                 ", total=%zu/%zu (xfer/conn)", s,
+                 conn ? "connection" : "transfer",
+                 conn ? conn->connection_id : data->id,
+                 Curl_hash_count(&entry->xfers),
+                 Curl_hash_count(&entry->conns));
+    }
+    else {
+      for(j = 0; j < prev_ps->num; j++) {
+        if(s == prev_ps->sockets[j]) {
+          last_action = prev_ps->actions[j];
+          break;
+        }
+      }
+    }
+    /* track readers/writers changes and report to socket callback */
+    mresult = mev_sh_entry_update(multi, data, entry, s,
+                                  last_action, ps->actions[i]);
+    if(mresult)
+      return mresult;
+  }
+
+  /* Handle changes to sockets the transfer is NO LONGER interested in. */
+  for(i = 0; i < prev_ps->num; i++) {
+    bool stillused = FALSE;
+
+    s = prev_ps->sockets[i];
+    for(j = 0; j < ps->num; j++) {
+      if(s == ps->sockets[j]) {
+        /* socket is still supervised */
+        stillused = TRUE;
+        break;
+      }
+    }
+    if(stillused)
+      continue;
+
+    entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
+    /* if entry does not exist, we were either never told about it or
+     * have already cleaned up this socket via Curl_multi_ev_socket_done().
+     * In other words: this is perfectly normal */
+    if(!entry)
+      continue;
+
+    if(!mev_sh_entry_xfer_remove(entry, data)) {
+      /* `data` says in `prev_ps` that it had been using a socket,
+       * but `data` has not been registered for it.
+       * This should not happen if our book-keeping is correct? */
+      CURL_TRC_M(data, "ev entry fd=%" FMT_SOCKET_T ", transfer lost "
+                 "interest but is not registered", s);
+      DEBUGASSERT(NULL);
+      continue;
+    }
+
+    if(mev_sh_entry_user_count(entry)) {
+      /* track readers/writers changes and report to socket callback */
+      mresult = mev_sh_entry_update(multi, data, entry, s,
+                                    prev_ps->actions[i], 0);
+      if(mresult)
+        return mresult;
+      CURL_TRC_M(data, "ev entry fd=%" FMT_SOCKET_T ", removed transfer, "
+                 "total=%zu/%zu (xfer/conn)", s,
+                 Curl_hash_count(&entry->xfers),
+                 Curl_hash_count(&entry->conns));
+    }
+    else {
+      mresult = mev_forget_socket(multi, data, s, "last user gone");
+      if(mresult)
+        return mresult;
+    }
+  } /* for loop over num */
+
+  /* Remember for next time */
+  memcpy(prev_ps, ps, sizeof(*prev_ps));
+  return CURLM_OK;
+}
+
+static struct easy_pollset*
+mev_add_new_pollset(struct Curl_hash *h, curl_off_t id)
+{
+  struct easy_pollset *ps;
+
+  ps = calloc(1, sizeof(*ps));
+  if(!ps)
+    return NULL;
+  if(!Curl_hash_offt_set(h, id, ps)) {
+    free(ps);
+    return NULL;
+  }
+  return ps;
+}
+
+static struct easy_pollset *
+mev_get_last_pollset(struct Curl_multi *multi,
+                     struct Curl_easy *data,
+                     struct connectdata *conn)
+{
+  if(data) {
+    if(conn)
+      return Curl_hash_offt_get(&multi->ev.conn_pollsets,
+                                conn->connection_id);
+    else if(data)
+      return Curl_hash_offt_get(&multi->ev.xfer_pollsets, data->id);
+  }
+  return NULL;
+}
+
+static void mev_init_cur_pollset(struct easy_pollset *ps,
+                                 struct Curl_easy *data,
+                                 struct connectdata *conn)
+{
+  memset(ps, 0, sizeof(*ps));
+  if(conn)
+    Curl_conn_adjust_pollset(data, conn, ps);
+  else if(data)
+    Curl_multi_getsock(data, ps, "ev assess");
+}
+
+static CURLMcode mev_assess(struct Curl_multi *multi,
+                            struct Curl_easy *data,
+                            struct connectdata *conn)
+{
+  if(multi && multi->socket_cb) {
+    struct easy_pollset ps, *last_ps;
+
+    mev_init_cur_pollset(&ps, data, conn);
+    last_ps = mev_get_last_pollset(multi, data, conn);
+
+    if(!last_ps && ps.num) {
+      if(conn)
+        last_ps = mev_add_new_pollset(&multi->ev.conn_pollsets,
+                                      data->conn->connection_id);
+      else
+        last_ps = mev_add_new_pollset(&multi->ev.xfer_pollsets, data->id);
+      if(!last_ps)
+        return CURLM_OUT_OF_MEMORY;
+    }
+
+    if(last_ps)
+      return mev_pollset_diff(multi, data, conn, &ps, last_ps);
+    else
+      DEBUGASSERT(!ps.num);
+  }
+  return CURLM_OK;
+}
+
+CURLMcode Curl_multi_ev_assess_xfer(struct Curl_multi *multi,
+                                    struct Curl_easy *data)
+{
+  return mev_assess(multi, data, NULL);
+}
+
+CURLMcode Curl_multi_ev_assess_conn(struct Curl_multi *multi,
+                                    struct Curl_easy *data,
+                                    struct connectdata *conn)
+{
+  return mev_assess(multi, data, conn);
+}
+
+CURLMcode Curl_multi_ev_assess_xfer_list(struct Curl_multi *multi,
+                                         struct Curl_llist *list)
+{
+  struct Curl_llist_node *e;
+  CURLMcode result = CURLM_OK;
+
+  if(multi && multi->socket_cb) {
+    for(e = Curl_llist_head(list); e && !result; e = Curl_node_next(e)) {
+      result = Curl_multi_ev_assess_xfer(multi, Curl_node_elem(e));
+    }
+  }
+  return result;
+}
+
+
+CURLMcode Curl_multi_ev_assign(struct Curl_multi *multi,
+                               curl_socket_t s,
+                               void *user_data)
+{
+  struct mev_sh_entry *e = mev_sh_entry_get(&multi->ev.sh_entries, s);
+  if(!e)
+    return CURLM_BAD_SOCKET;
+  e->user_data = user_data;
+  return CURLM_OK;
+}
+
+
+void Curl_multi_ev_expire_xfers(struct Curl_multi *multi,
+                                curl_socket_t s,
+                                const struct curltime *nowp,
+                                bool *run_cpool)
+{
+  struct mev_sh_entry *entry;
+
+  DEBUGASSERT(s != CURL_SOCKET_TIMEOUT);
+  entry = mev_sh_entry_get(&multi->ev.sh_entries, s);
+
+  /* Unmatched socket, we cannot act on it but we ignore this fact. In
+     real-world tests it has been proved that libevent can in fact give
+     the application actions even though the socket was just previously
+     asked to get removed, so thus we better survive stray socket actions
+     and just move on. */
+  if(entry) {
+    struct Curl_hash_iterator iter;
+    struct Curl_hash_element *he;
+
+    /* the socket can be shared by many transfers, iterate */
+    Curl_hash_start_iterate(&entry->xfers, &iter);
+    for(he = Curl_hash_next_element(&iter); he;
+        he = Curl_hash_next_element(&iter)) {
+      struct Curl_easy *data = (struct Curl_easy *)he->ptr;
+      DEBUGASSERT(data);
+      DEBUGASSERT(data->magic == CURLEASY_MAGIC_NUMBER);
+      DEBUGASSERT(data->id >= 0); /* we should not track internal handles */
+
+      /* Expire with out current now, so we will get it below when
+       * asking the splaytree for expired transfers. */
+      Curl_expire_ex(data, nowp, 0, EXPIRE_RUN_NOW);
+    }
+
+    if(Curl_hash_count(&entry->conns))
+      *run_cpool = TRUE;
+  }
+}
+
+void Curl_multi_ev_socket_done(struct Curl_multi *multi,
+                               struct Curl_easy *data, curl_socket_t s)
+{
+  mev_forget_socket(multi, data, s, "socket done");
+}
+
+void Curl_multi_ev_xfer_done(struct Curl_multi *multi,
+                             struct Curl_easy *data)
+{
+  DEBUGASSERT(!data->conn); /* transfer should have been detached */
+  if(data->id >= 0) {
+    (void)mev_assess(multi, data, NULL);
+    Curl_hash_offt_remove(&multi->ev.xfer_pollsets, data->id);
+  }
+}
+
+void Curl_multi_ev_conn_done(struct Curl_multi *multi,
+                             struct Curl_easy *data,
+                             struct connectdata *conn)
+{
+  (void)mev_assess(multi, data, conn);
+  Curl_hash_offt_remove(&multi->ev.conn_pollsets, conn->connection_id);
+}
+
+#define CURL_MEV_PS_HASH_SLOTS   (991)  /* nice prime */
+
+static void mev_hash_pollset_free(void *entry)
+{
+  free(entry);
+}
+
+void Curl_multi_ev_init(struct Curl_multi *multi, size_t hashsize)
+{
+  Curl_hash_init(&multi->ev.sh_entries, hashsize, mev_sh_entry_hash,
+                 mev_sh_entry_compare, mev_sh_entry_dtor);
+  Curl_hash_offt_init(&multi->ev.xfer_pollsets,
+                      CURL_MEV_PS_HASH_SLOTS, mev_hash_pollset_free);
+  Curl_hash_offt_init(&multi->ev.conn_pollsets,
+                      CURL_MEV_PS_HASH_SLOTS, mev_hash_pollset_free);
+}
+
+void Curl_multi_ev_cleanup(struct Curl_multi *multi)
+{
+  Curl_hash_destroy(&multi->ev.sh_entries);
+  Curl_hash_destroy(&multi->ev.xfer_pollsets);
+  Curl_hash_destroy(&multi->ev.conn_pollsets);
+}

--- a/lib/multi_ev.h
+++ b/lib/multi_ev.h
@@ -1,0 +1,79 @@
+#ifndef HEADER_CURL_MULTI_EV_H
+#define HEADER_CURL_MULTI_EV_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+struct Curl_easy;
+struct Curl_multi;
+struct easy_pollset;
+
+struct curl_multi_ev {
+  struct Curl_hash sh_entries;
+  struct Curl_hash xfer_pollsets;
+  struct Curl_hash conn_pollsets;
+};
+
+/* Setup/teardown of multi event book-keeping. */
+void Curl_multi_ev_init(struct Curl_multi *multi, size_t hashsize);
+void Curl_multi_ev_cleanup(struct Curl_multi *multi);
+
+/* Assign a 'user_data' to be passed to the socket callback when
+ * invoked with the given socket. This will fail if this socket
+ * is not active, e.g. the application has not been told to monitor it. */
+CURLMcode Curl_multi_ev_assign(struct Curl_multi *multi, curl_socket_t s,
+                               void *user_data);
+
+/* Assess the transfer by getting its current pollset, compute
+ * any changes to the last one and inform the application's socket
+ * callback if things have changed. */
+CURLMcode Curl_multi_ev_assess_xfer(struct Curl_multi *multi,
+                                    struct Curl_easy *data);
+/* Assess all easy handles on the list */
+CURLMcode Curl_multi_ev_assess_xfer_list(struct Curl_multi *multi,
+                                         struct Curl_llist *list);
+/* Assess the connection by getting its current pollset */
+CURLMcode Curl_multi_ev_assess_conn(struct Curl_multi *multi,
+                                    struct Curl_easy *data,
+                                    struct connectdata *conn);
+
+/* Expire all transfers tied to the given socket */
+void Curl_multi_ev_expire_xfers(struct Curl_multi *multi,
+                                curl_socket_t s,
+                                const struct curltime *nowp,
+                                bool *run_cpool);
+
+/* Socket will be closed, forget anything we know about it. */
+void Curl_multi_ev_socket_done(struct Curl_multi *multi,
+                               struct Curl_easy *data, curl_socket_t s);
+
+/* Transfer is removed from the multi */
+void Curl_multi_ev_xfer_done(struct Curl_multi *multi,
+                             struct Curl_easy *data);
+
+/* Connection is being destroyed */
+void Curl_multi_ev_conn_done(struct Curl_multi *multi,
+                             struct Curl_easy *data,
+                             struct connectdata *conn);
+
+#endif /* HEADER_CURL_MULTI_EV_H */

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -27,6 +27,7 @@
 #include "llist.h"
 #include "hash.h"
 #include "conncache.h"
+#include "multi_ev.h"
 #include "psl.h"
 #include "socketpair.h"
 
@@ -38,9 +39,9 @@ struct Curl_message {
   struct CURLMsg extmsg;
 };
 
-/* NOTE: if you add a state here, add the name to the statename[] array as
-   well!
-*/
+/* NOTE: if you add a state here, add the name to the statenames[] array
+ * in curl_trc.c as well!
+ */
 typedef enum {
   MSTATE_INIT,         /* 0 - start in this state */
   MSTATE_PENDING,      /* 1 - no connections, waiting for one */
@@ -128,10 +129,9 @@ struct Curl_multi {
   char *xfer_sockbuf; /* the actual buffer */
   size_t xfer_sockbuf_len; /* the allocated length */
 
-  /* 'sockhash' is the lookup hash for socket descriptor => easy handles (note
-     the pluralis form, there can be more than one easy handle waiting on the
-     same actual socket) */
-  struct Curl_hash sockhash;
+  /* multi event related things */
+  struct curl_multi_ev ev;
+
   /* `proto_hash` is a general key-value store for protocol implementations
    * with the lifetime of the multi handle. The number of elements kept here
    * should be in the order of supported protocols (and sub-protocols like

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -815,9 +815,6 @@ struct connectdata {
     struct curltime start[2]; /* when filter shutdown started */
     unsigned int timeout_ms; /* 0 means no timeout */
   } shutdown;
-  /* Last pollset used in connection shutdown. Used to detect changes
-   * for multi_socket API. */
-  struct easy_pollset shutdown_poll;
 
   struct ssl_primary_config ssl_config;
 #ifndef CURL_DISABLE_PROXY
@@ -1884,12 +1881,6 @@ struct Curl_easy {
   CURLcode result;   /* previous result */
 
   struct Curl_message msg; /* A single posted message. */
-
-  /* Array with the plain socket numbers this handle takes care of, in no
-     particular order. Note that all sockets are added to the sockhash, where
-     the state etc are also kept. This array is mostly used to detect when a
-     socket is to be removed from the hash. See singlesocket(). */
-  struct easy_pollset last_poll;
 
   struct Names dns;
   struct Curl_multi *multi;    /* if non-NULL, points to the multi handle

--- a/tests/http/test_15_tracing.py
+++ b/tests/http/test_15_tracing.py
@@ -86,7 +86,7 @@ class TestTracing:
             m = re.match(r'^([0-9:.]+) \[0-[0x]] .+', line)
             if m is None:
                 assert False, f'no match: {line}'
-            m = re.match(r'^([0-9:.]+) \[0-[0x]] . \[TCP].+', line)
+            m = re.match(r'^([0-9:.]+) \[0-[0x]] .+ \[TCP].+', line)
             if m is not None:
                 found_tcp = True
         if not found_tcp:

--- a/tests/http/test_19_shutdown.py
+++ b/tests/http/test_19_shutdown.py
@@ -25,6 +25,7 @@
 ###########################################################################
 #
 import logging
+import os
 import re
 import pytest
 
@@ -56,7 +57,10 @@ class TestShutdown:
     def test_19_01_check_tcp_rst(self, env: Env, httpd, proto):
         if env.ci_run:
             pytest.skip("seems not to work in CI")
-        curl = CurlClient(env=env)
+        run_env = os.environ.copy()
+        if 'CURL_DEBUG' in run_env:
+            del run_env['CURL_DEBUG']
+        curl = CurlClient(env=env, run_env=run_env)
         url = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-1]'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_tcpdump=True, extra_args=[
             '--parallel'
@@ -71,10 +75,12 @@ class TestShutdown:
     def test_19_02_check_shutdown(self, env: Env, httpd, proto):
         if not env.curl_is_debug():
             pytest.skip('only works for curl debug builds')
-        curl = CurlClient(env=env, run_env={
+        run_env = os.environ.copy()
+        run_env.update({
             'CURL_GRACEFUL_SHUTDOWN': '2000',
-            'CURL_DEBUG': 'ssl,tcp'
+            'CURL_DEBUG': 'ssl,tcp,lib-ids,multi'
         })
+        curl = CurlClient(env=env, run_env=run_env)
         url = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-1]'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_tcpdump=True, extra_args=[
             '--parallel'
@@ -91,14 +97,14 @@ class TestShutdown:
         count = 10
         curl = CurlClient(env=env, run_env={
             'CURL_GRACEFUL_SHUTDOWN': '2000',
-            'CURL_DEBUG': 'ssl'
+            'CURL_DEBUG': 'ssl,multi'
         })
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/tweak/?'\
             f'id=[0-{count-1}]&with_cl&close'
         r = curl.http_download(urls=[url], alpn_proto=proto)
         r.check_response(http_status=200, count=count)
         shutdowns = [line for line in r.trace_lines
-                     if re.match(r'.*CCACHE\] shutdown #\d+, done=1', line)]
+                     if re.match(r'.*\[CPOOL\] shutdown, done=1', line)]
         assert len(shutdowns) == count, f'{shutdowns}'
 
     # run downloads with CURLOPT_FORBID_REUSE set, meaning *we* close
@@ -112,7 +118,7 @@ class TestShutdown:
         url = f'https://localhost:{env.https_port}/{docname}'
         client = LocalClient(name='hx-download', env=env, run_env={
             'CURL_GRACEFUL_SHUTDOWN': '2000',
-            'CURL_DEBUG': 'ssl'
+            'CURL_DEBUG': 'ssl,multi'
         })
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
@@ -121,7 +127,7 @@ class TestShutdown:
         ])
         r.check_exit_code(0)
         shutdowns = [line for line in r.trace_lines
-                     if re.match(r'.*CCACHE\] shutdown #\d+, done=1', line)]
+                     if re.match(r'.*CPOOL\] shutdown, done=1', line)]
         assert len(shutdowns) == count, f'{shutdowns}'
 
     # run event-based downloads with CURLOPT_FORBID_REUSE set, meaning *we* close
@@ -131,13 +137,13 @@ class TestShutdown:
         if not env.curl_is_debug():
             pytest.skip('only works for curl debug builds')
         count = 10
-        curl = CurlClient(env=env, run_env={
-            # forbid connection reuse to trigger shutdowns after transfer
-            'CURL_FORBID_REUSE': '1',
-            # make socket receives block 50% of the time to delay shutdown
-            'CURL_DBG_SOCK_RBLOCK': '50',
-            'CURL_DEBUG': 'ssl'
-        })
+        run_env = os.environ.copy()
+        # forbid connection reuse to trigger shutdowns after transfer
+        run_env['CURL_FORBID_REUSE'] = '1'
+        # make socket receives block 50% of the time to delay shutdown
+        run_env['CURL_DBG_SOCK_RBLOCK'] = '50'
+        run_env['CURL_DEBUG'] = 'ssl,multi,lib-ids'
+        curl = CurlClient(env=env, run_env=run_env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/tweak/?'\
             f'id=[0-{count-1}]&with_cl&'
         r = curl.http_download(urls=[url], alpn_proto=proto, extra_args=[
@@ -146,7 +152,7 @@ class TestShutdown:
         r.check_response(http_status=200, count=count)
         # check that we closed all connections
         closings = [line for line in r.trace_lines
-                    if re.match(r'.*CCACHE\] closing #\d+', line)]
+                    if re.match(r'.*CPOOL\] closing', line)]
         assert len(closings) == count, f'{closings}'
         # check that all connection sockets were removed from event
         removes = [line for line in r.trace_lines
@@ -171,5 +177,5 @@ class TestShutdown:
         r.check_response(http_status=200, count=2)
         # check connection cache closings
         shutdowns = [line for line in r.trace_lines
-                     if re.match(r'.*CCACHE\] shutdown #\d+, done=1', line)]
+                     if re.match(r'.*CPOOL\] shutdown, done=1', line)]
         assert len(shutdowns) == 1, f'{shutdowns}'


### PR DESCRIPTION
Rework the event based handling of transfers and connections into a single source file with clearer dependencies.

- add multi_ev.c and multi_ev.h
- add docs/internal/MULTI-EV.md to explain the overall workings
- only do event handling book keeping when the socket callback is set
- add handling for "connection only" event tracking, when internal easy handles are used that are not really tied to a connection. Used in connection pool.
- remove transfer member "last_poll" and connections "shutdown_poll" and keep all that internal to multi_ev.c
- add CURL_TRC_M() for tracing of "multi" related things, including event handling and connection pool operations. Add new trace  feature "multi" for trace config.  multi traces will show exactly what is going on in regard to  event handling.
- multi: trace transfers "mstate" in every CURL_TRC_M() call
- make internal trace buffer 2048 bytes and end the silliness with +n here -m there. Adjust test 1652 expectations of resulting length and input edge cases.
- add trace feature "lib-ids" to perfix libcurl traces with transfer and connection ids. Useful for debugging libcurl applications.
