### PR TITLE
lib: better optimized casecompare() and ncasecompare()

### DIFF
--- a/lib/strcase.c
+++ b/lib/strcase.c
@@ -91,7 +91,7 @@ char Curl_raw_tolower(char in)
 
 static int casecompare(const char *first, const char *second)
 {
-  while(*first && *second) {
+  while(*first) {
     if(Curl_raw_toupper(*first) != Curl_raw_toupper(*second))
       /* get out of the loop as soon as they do not match */
       return 0;
@@ -118,7 +118,7 @@ int curl_strequal(const char *first, const char *second)
 
 static int ncasecompare(const char *first, const char *second, size_t max)
 {
-  while(*first && *second && max) {
+  while(*first && max) {
     if(Curl_raw_toupper(*first) != Curl_raw_toupper(*second))
       return 0;
     max--;


### PR DESCRIPTION
Less 'jne` or `je` CPU instructions.
Compare [CGG 14.2 with -O3](https://godbolt.org/z/665zWv8xs)
```asm
casecompare_old:                                     casecompare_new:
        movzx   edx, BYTE PTR [rdi]                          jmp     .L22
        test    dl, dl                               .L16:
        jne     .L4                                          movzx   edx, BYTE PTR [rsi]
        jmp     .L11                                         movzx   eax, BYTE PTR touppermap[rax]
.L7:                                                         cmp     BYTE PTR touppermap[rdx], al
        movzx   ecx, BYTE PTR touppermap[rdx]                jne     .L17
        cmp     BYTE PTR touppermap[rax], cl                 add     rdi, 1
        jne     .L8                                          add     rsi, 1
        movzx   edx, BYTE PTR [rdi+1]                .L22:
        add     rdi, 1                                       movzx   eax, BYTE PTR [rdi]
        lea     rax, [rsi+1]                                 test    al, al
        test    dl, dl                                       jne     .L16
        je      .L12                                         xor     eax, eax
        mov     rsi, rax                                     cmp     BYTE PTR [rsi], 0
.L4:                                                         sete    al
        movzx   eax, BYTE PTR [rsi]                          ret
        test    al, al                               .L17:
        jne     .L7                                          xor     eax, eax
        mov     edx, 1                                       ret
.L5:
        test    al, al
        sete    al
        xor     eax, edx
        movzx   eax, al
        ret
.L8:
        xor     eax, eax
        ret
.L12:
        movzx   eax, BYTE PTR [rsi+1]
        test    al, al
        sete    al
        xor     eax, edx
        movzx   eax, al
        ret
.L11:
        movzx   eax, BYTE PTR [rsi]
        jmp     .L5
```
```asm
ncasecompare_old:                                     ncasecompare_new:
        jmp     .L37                                          jmp     .L50
.L38:                                                 .L51:
        movzx   ecx, BYTE PTR [rsi]                           test    rdx, rdx
        test    cl, cl                                        je      .L45
        je      .L25                                          movzx   ecx, BYTE PTR [rsi]
        test    rdx, rdx                                      movzx   eax, BYTE PTR touppermap[rax]
        je      .L29                                          cmp     BYTE PTR touppermap[rcx], al
        movzx   eax, BYTE PTR touppermap[rax]                 jne     .L44
        cmp     BYTE PTR touppermap[rcx], al                  sub     rdx, 1
        jne     .L28                                          add     rdi, 1
        sub     rdx, 1                                        add     rsi, 1
        add     rdi, 1                                .L50:
        add     rsi, 1                                        movzx   eax, BYTE PTR [rdi]
.L37:                                                         test    al, al
        movzx   eax, BYTE PTR [rdi]                           jne     .L51
        test    al, al                                        test    rdx, rdx
        jne     .L38                                          je      .L45
.L25:                                                         movzx   eax, BYTE PTR [rsi]
        test    rdx, rdx                                      cmp     BYTE PTR touppermap[rax], 0
        je      .L29                                          sete    al
        movzx   edx, BYTE PTR [rsi]                           movzx   eax, al
        movzx   eax, BYTE PTR touppermap[rax]                 ret
        cmp     BYTE PTR touppermap[rdx], al          .L45:
        sete    al                                            mov     eax, 1
        movzx   eax, al                                       ret
        ret                                           .L44:
.L29:                                                         xor     eax, eax
        mov     eax, 1                                        ret
        ret
.L28:
        xor     eax, eax
        ret
```
