### PR TITLE
tests: fix enum/int confusion (Intel C), fix autotools `CFLAGS` for `servers`

### DIFF
--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -40,6 +40,8 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 # Prevent LIBS from being used for all link targets
 LIBS = $(BLANK_AT_MAKETIME)
 
+CFLAGS += @CURL_CFLAG_EXTRAS@
+
 if DOING_NATIVE_WINDOWS
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -173,15 +173,7 @@ static unsigned short shortval(char *value)
   return num & 0xffff;
 }
 
-static enum {
-  socket_domain_inet = AF_INET
-#ifdef USE_IPV6
-  , socket_domain_inet6 = AF_INET6
-#endif
-#ifdef USE_UNIX_SOCKETS
-  , socket_domain_unix = AF_UNIX
-#endif
-} socket_domain = AF_INET;
+static int socket_domain = AF_INET;
 
 static void getconfig(void)
 {

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -65,15 +65,7 @@
 #define ERANGE  34 /* errno.h value */
 #endif
 
-static enum {
-  socket_domain_inet = AF_INET
-#ifdef USE_IPV6
-  , socket_domain_inet6 = AF_INET6
-#endif
-#ifdef USE_UNIX_SOCKETS
-  , socket_domain_unix = AF_UNIX
-#endif
-} socket_domain = AF_INET;
+static int socket_domain = AF_INET;
 static bool use_gopher = FALSE;
 static int serverlogslocked = 0;
 static bool is_proxy = FALSE;


### PR DESCRIPTION
By dropping the unused enum wrappers for `AF_*` macros.

Also fix `./configure` to apply `--enable-werror` options to
`tests/servers`, to catch this next time.

Seen with Intel C compiler:
```
socksd.c(184): warning #188: enumerated type mixed with another type
socksd.c(881): warning #188: enumerated type mixed with another type
[...]
sws.c(76): warning #188: enumerated type mixed with another type
sws.c(229): warning #188: enumerated type mixed with another type
[...]
```
Ref: https://github.com/curl/curl/actions/runs/13296520425/job/37129676921#step:40:338
