### PR TITLE
manage: correct the warning for un-escaped '<' and '>'

### DIFF
--- a/docs/cmdline-opts/proxy.md
+++ b/docs/cmdline-opts/proxy.md
@@ -22,7 +22,7 @@ Use the specified proxy.
 The proxy string can be specified with a protocol:// prefix. No protocol
 specified or http:// it is treated as an HTTP proxy. Use socks4://,
 socks4a://, socks5:// or socks5h:// to request a specific SOCKS version to be
-used.  (Added in 7.21.7)
+used. (Added in 7.21.7)
 
 Unix domain sockets are supported for socks proxy. Set localhost for the host
 part. e.g. socks5h://localhost/path/to/socket.sock

--- a/scripts/managen
+++ b/scripts/managen
@@ -391,6 +391,23 @@ sub render {
         $d =~ s/`%VERSION`/$version/g;
         $d =~ s/`%GLOBALS`/$globals/g;
 
+        if(!$quote) {
+            if($d =~ /^(.*)  /) {
+                printf STDERR "$f:$line:%d:ERROR: 2 spaces detected\n",
+                    length($1);
+                return 3;
+            }
+            my $back = $d;
+
+            # remove all backticked pieces
+            $back =~ s/\`(.*?)\`//g;
+
+            if($back =~ /[^\\][\<\>]/) {
+                print STDERR "$f:$line:1:WARN: un-escaped < or > used: $back\n";
+                return 3;
+            }
+        }
+
         # convert backticks to double quotes
         $d =~ s/\`/\"/g;
 
@@ -410,17 +427,6 @@ sub render {
             }
         }
 
-        if(!$quote) {
-            if($d =~ /^(.*)  /) {
-                printf STDERR "$f:$line:%d:ERROR: 2 spaces detected\n",
-                    length($1);
-                return 3;
-            }
-            elsif($d =~ /[^\\][\<\>]/) {
-                print STDERR "$f:$line:1:WARN: un-escaped < or > used\n";
-                return 3;
-            }
-        }
         # convert backslash-'<' or '> to just the second character
         $d =~ s/\\([><])/$1/g;
         # convert single backslash to double-backslash


### PR DESCRIPTION
1. make sure the check is done before the backticks are replaced

2. ignore less-than and greater-than used within backticks

(adjust proxy.md that now showed a two-space warning)