### PR TITLE
Update nghttp3 and ngtcp2 versions to match the http3-linux workflow.

### DIFF
--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -43,8 +43,8 @@ To fix before we remove the experimental label:
 
 Building curl with ngtcp2 involves 3 components: `ngtcp2` itself, `nghttp3` and a QUIC supporting TLS library. The supported TLS libraries are covered below.
 
- * `ngtcp2`: v1.2.0
- * `nghttp3`: v1.1.0
+ * `ngtcp2`: v1.10.0
+ * `nghttp3`: v1.7.0
 
 ## Build with quictls
 
@@ -62,7 +62,7 @@ Build quictls:
 Build nghttp3:
 
      % cd ..
-     % git clone -b v1.1.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v1.7.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % git submodule update --init
      % autoreconf -fi
@@ -73,7 +73,7 @@ Build nghttp3:
 Build ngtcp2:
 
      % cd ..
-     % git clone -b v1.2.0 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v1.10.0 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only
@@ -106,7 +106,7 @@ Build GnuTLS:
 Build nghttp3:
 
      % cd ..
-     % git clone -b v1.1.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v1.7.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % git submodule update --init
      % autoreconf -fi
@@ -117,7 +117,7 @@ Build nghttp3:
 Build ngtcp2:
 
      % cd ..
-     % git clone -b v1.2.0 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v1.10.0 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only --with-gnutls
@@ -148,7 +148,7 @@ Build wolfSSL:
 Build nghttp3:
 
      % cd ..
-     % git clone -b v1.1.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v1.7.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % git submodule update --init
      % autoreconf -fi
@@ -159,7 +159,7 @@ Build nghttp3:
 Build ngtcp2:
 
      % cd ..
-     % git clone -b v1.2.0 https://github.com/ngtcp2/ngtcp2
+     % git clone -b v1.10.0 https://github.com/ngtcp2/ngtcp2
      % cd ngtcp2
      % autoreconf -fi
      % ./configure PKG_CONFIG_PATH=<somewhere1>/lib/pkgconfig:<somewhere2>/lib/pkgconfig LDFLAGS="-Wl,-rpath,<somewhere1>/lib" --prefix=<somewhere3> --enable-lib-only --with-wolfssl
@@ -222,7 +222,7 @@ Build OpenSSL 3.3.1:
 Build nghttp3:
 
      % cd ..
-     % git clone -b v1.1.0 https://github.com/ngtcp2/nghttp3
+     % git clone -b v1.7.0 https://github.com/ngtcp2/nghttp3
      % cd nghttp3
      % git submodule update --init
      % autoreconf -fi


### PR DESCRIPTION
Is there a reason why the documented versions are so far behind?
I am seeing a speedup of 13% when measuring single speed performance with newer nghttp3 and ngtcp2 versions.
Further, the http3-linux workflow uses the newer versions too.