### PR TITLE
asyn-thread: avoid the separate 'struct resdata' alloc

### DIFF
--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -58,6 +58,7 @@ struct thread_data {
   curl_thread_t thread_hnd;
   unsigned int poll_interval;
   timediff_t interval_end;
+  struct curltime start;
   struct thread_sync_data tsd;
 #if defined(USE_HTTPSRR) && defined(USE_ARES)
   struct Curl_https_rrinfo hinfo;


### PR DESCRIPTION
Instead move the only struct field (start) into the thread_data struct.

Cherry-picked from #16219