### PR TITLE
asyn-thread: avoid the separate curl_mutex_t alloc

### DIFF
--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -39,9 +39,9 @@ struct Curl_dns_entry;
 
 /* Data for synchronization between resolver thread and its parent */
 struct thread_sync_data {
-  curl_mutex_t *mtx;
   char *hostname;        /* hostname to resolve, Curl_async.hostname
                             duplicate */
+  curl_mutex_t mutx;
 #ifndef CURL_DISABLE_SOCKETPAIR
   curl_socket_t sock_pair[2]; /* eventfd/pipes/socket pair */
 #endif


### PR DESCRIPTION
Just make it a part of the thread_sync_data struct.