### PR TITLE
docs: add FD_ZERO to curl_multi_fdset example

### DIFF
--- a/docs/libcurl/curl_multi_fdset.md
+++ b/docs/libcurl/curl_multi_fdset.md
@@ -100,6 +100,10 @@ int main(void)
 
     /* call curl_multi_perform() */
 
+    FD_ZERO(&fdread);
+    FD_ZERO(&fdwrite);
+    FD_ZERO(&fdexcep);
+
     /* get file descriptors from the transfers */
     mc = curl_multi_fdset(multi, &fdread, &fdwrite, &fdexcep, &maxfd);
 


### PR DESCRIPTION
Minor improvement to the inlined `curl_multi_fdset` example. While the inline code examples aren't supposed to be full apps it might be a good idea to have at least the `FD_ZERO` in place. Of course full  app using the `curl_multi_fdset` would likely also add their own fds to the set(s), too (since this is likely the main reason to use the function to begin with).