### PR TITLE
var: add a '64dec' function that base64 decodes a string

### DIFF
--- a/docs/cmdline-opts/_VARIABLES.md
+++ b/docs/cmdline-opts/_VARIABLES.md
@@ -27,10 +27,10 @@ set:
 When expanding variables, curl supports a set of functions that can make the
 variable contents more convenient to use. It can trim leading and trailing
 white space with `trim`, it can output the contents as a JSON quoted string
-with `json`, URL encode the string with `url` or base64 encode it with `b64`.
-To apply functions to a variable expansion, add them colon separated to the
-right side of the variable. Variable content holding null bytes that are not
-encoded when expanded cause error.
+with `json`, URL encode the string with `url`, base64 encode it with `b64` and
+base64 decode it with `64dec`. To apply functions to a variable expansion, add
+them colon separated to the right side of the variable. Variable content
+holding null bytes that are not encoded when expanded cause error.
 
 Example: get the contents of a file called $HOME/.secret into a variable
 called "fix". Make sure that the content is trimmed and percent-encoded when

--- a/docs/cmdline-opts/variable.md
+++ b/docs/cmdline-opts/variable.md
@@ -66,30 +66,45 @@ error.
 
 Available functions:
 
-## trim
+## `trim`
+
 removes all leading and trailing white space.
 
 Example:
 
     curl --expand-url https://example.com/{{var:trim}}
 
-## json
+## `json`
+
 outputs the content using JSON string quoting rules.
 
 Example:
 
     curl --expand-data {{data:json}} https://example.com
 
-## url
+## `url`
+
 shows the content URL (percent) encoded.
 
 Example:
 
     curl --expand-url https://example.com/{{path:url}}
 
-## b64
+## `b64`
+
 expands the variable base64 encoded
 
 Example:
 
     curl --expand-url https://example.com/{{var:b64}}
+
+## `64dec`
+
+decodes a base64 encoded character sequence. If the sequence is not possible
+to decode, it instead outputs `64dec-fail`
+
+Example:
+
+    curl --expand-url https://example.com/{{var:64dec}}
+
+(Added in 8.13.0)

--- a/src/var.c
+++ b/src/var.c
@@ -91,6 +91,8 @@ static const struct tool_var *varcontent(struct GlobalConfig *global,
 #define FUNC_URL_LEN (sizeof(FUNC_URL) - 1)
 #define FUNC_B64 "b64"
 #define FUNC_B64_LEN (sizeof(FUNC_B64) - 1)
+#define FUNC_64DEC "64dec" /* base64 decode */
+#define FUNC_64DEC_LEN (sizeof(FUNC_64DEC) - 1)
 
 static ParameterError varfunc(struct GlobalConfig *global,
                               char *c, /* content */
@@ -175,6 +177,27 @@ static ParameterError varfunc(struct GlobalConfig *global,
         if(curlx_dyn_addn(out, enc, elen))
           err = PARAM_NO_MEM;
         curl_free(enc);
+        if(err)
+          break;
+      }
+    }
+    else if(FUNCMATCH(f, FUNC_64DEC, FUNC_64DEC_LEN)) {
+      f += FUNC_64DEC_LEN;
+      curlx_dyn_reset(out);
+      if(clen) {
+        unsigned char *enc;
+        size_t elen;
+        CURLcode result = curlx_base64_decode(c, &enc, &elen);
+        /* put it in the output */
+        if(result) {
+          if(curlx_dyn_add(out, "[64dec-fail]"))
+            err = PARAM_NO_MEM;
+        }
+        else {
+          if(curlx_dyn_addn(out, enc, elen))
+            err = PARAM_NO_MEM;
+          curl_free(enc);
+        }
         if(err)
           break;
       }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -78,7 +78,7 @@ test444 test445 test446 test447 test448 test449 test450 test451 test452 \
 test453 test454 test455 test456 test457 test458 test459 test460 test461 \
 test462 test463 test467 test468 test469 test470 test471 test472 test473 \
 test474 test475 test476 test477 test478 test479 test480 test481 test482 \
-test483 test484 test485 test486 \
+test483 test484 test485 test486 test487 \
 test490 test491 test492 test493 test494 test495 test496 test497 test498 \
 test499 test500 test501 test502 test503 test504 test505 test506 test507 \
 test508 test509 test510 test511 test512 test513 test514 test515 test516 \

--- a/tests/data/test487
+++ b/tests/data/test487
@@ -31,10 +31,10 @@ Funny-head: yesyes
 http
 </server>
 <name>
-Variable using base64
+Variable using 64dec with bad base64
 </name>
 <command>
---variable moby="Call me Ishmael" --variable what=%b64[white-whale]b64% --expand-url "http://%HOSTIP:%HTTPPORT/{{moby:b64}}/{{what:64dec}}/%TESTNUMBER"
+--variable what=not-base64-data --expand-url "http://%HOSTIP:%HTTPPORT/{{what:64dec}}/%TESTNUMBER" -g
 </command>
 </client>
 
@@ -42,7 +42,7 @@ Variable using base64
 # Verify data after the test has been "shot"
 <verify>
 <protocol crlf="yes">
-GET /%b64[Call me Ishmael]b64%/white-whale/%TESTNUMBER HTTP/1.1
+GET /[64dec-fail]/%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*


### PR DESCRIPTION
Verified in test 455 and 487.

If the provided string cannot be base64-decoded, it will instead use `[64dec-fail]`.

Ref: #16288

- [X] documented