### PR TITLE
cmake: allow empty custom `IMPORT_LIB_SUFFIX`, add suffix collision detection

### DIFF
--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -167,7 +167,7 @@ assumes that CMake generates `Makefile`:
 - `ENABLE_CURLDEBUG`:                       Enable TrackMemory debug feature. Default: =`ENABLE_DEBUG`
 - `ENABLE_CURL_MANUAL`:                     Build the man page for curl and enable its `-M`/`--manual` option. Default: `ON`
 - `ENABLE_DEBUG`:                           Enable curl debug features (for developing curl itself). Default: `OFF`
-- `IMPORT_LIB_SUFFIX`:                      Import library suffix. Default: `_imp`
+- `IMPORT_LIB_SUFFIX`:                      Import library suffix. Default: `_imp` for MSVC-like toolchains, otherwise empty.
 - `LIBCURL_OUTPUT_NAME`:                    Basename of the curl library. Default: `libcurl`
 - `PICKY_COMPILER`:                         Enable picky compiler options. Default: `ON`
 - `STATIC_LIB_SUFFIX`:                      Static library suffix. Default: (empty)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -68,10 +68,15 @@ endif()
 
 ## Library definition
 
-# Suffix implib name with "_imp" by default, to avoid conflicting with
-# the generated static "libcurl.lib" (typically with MSVC).
 if(NOT DEFINED IMPORT_LIB_SUFFIX)
-  set(IMPORT_LIB_SUFFIX "_imp")
+  # Suffix implib name with "_imp" by default, to avoid conflicting with
+  # the generated static "libcurl.lib" (typically with MSVC).
+  if(WIN32 AND BUILD_SHARED_LIBS AND
+     CMAKE_IMPORT_LIBRARY_SUFFIX STREQUAL CMAKE_STATIC_LIBRARY_SUFFIX)
+    set(IMPORT_LIB_SUFFIX "_imp")
+  else()
+    set(IMPORT_LIB_SUFFIX "")
+  endif()
 endif()
 if(NOT DEFINED STATIC_LIB_SUFFIX)
   set(STATIC_LIB_SUFFIX "")

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -86,10 +86,10 @@ endif()
 if(WIN32 AND BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS AND
    "${IMPORT_LIB_SUFFIX}${CMAKE_IMPORT_LIBRARY_SUFFIX}" STREQUAL
    "${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  message(FATAL_ERROR "Library suffix collision detected for ${LIBCURL_OUTPUT_NAME}. "
-    "It's '${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}' for both import and static library. "
+  message(FATAL_ERROR "Library suffix is the same ('${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}') "
+    "for the import and static ${LIBCURL_OUTPUT_NAME} library. "
     "Set IMPORT_LIB_SUFFIX and/or STATIC_LIB_SUFFIX to different values, "
-    "or disable building either the shared or static library to avoid it.")
+    "or disable building either the shared or static library to avoid the collision.")
 endif()
 
 # Whether to do a single compilation pass for libcurl sources and reuse these

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -87,7 +87,7 @@ if(WIN32 AND BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS AND
    "${IMPORT_LIB_SUFFIX}${CMAKE_IMPORT_LIBRARY_SUFFIX}" STREQUAL
    "${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
   message(FATAL_ERROR "Library suffix is the same ('${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}') "
-    "for the import and static ${LIBCURL_OUTPUT_NAME} library. "
+    "for the import and static '${LIBCURL_OUTPUT_NAME}' library. "
     "Set IMPORT_LIB_SUFFIX and/or STATIC_LIB_SUFFIX to different values, "
     "or disable building either the shared or static library to avoid the collision.")
 endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -89,7 +89,7 @@ if(WIN32 AND BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS AND
   message(FATAL_ERROR "Library suffix is the same ('${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}') "
     "for the import and static '${LIBCURL_OUTPUT_NAME}' library. "
     "Set IMPORT_LIB_SUFFIX and/or STATIC_LIB_SUFFIX to different values, "
-    "or disable building either the shared or static library to avoid the collision.")
+    "or disable building either the shared or static library to avoid the filename collision.")
 endif()
 
 # Whether to do a single compilation pass for libcurl sources and reuse these

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -68,19 +68,24 @@ endif()
 
 ## Library definition
 
+# Suffix implib name with "_imp" by default, to avoid conflicting with
+# the generated static "libcurl.lib" (typically with MSVC).
 if(NOT DEFINED IMPORT_LIB_SUFFIX)
-  set(IMPORT_LIB_SUFFIX "")
+  set(IMPORT_LIB_SUFFIX "_imp")
 endif()
 if(NOT DEFINED STATIC_LIB_SUFFIX)
   set(STATIC_LIB_SUFFIX "")
 endif()
 
-# Add "_imp" as a suffix before the extension to avoid conflicting with
-# the statically linked "libcurl.lib" (typically with MSVC)
-if(WIN32 AND
-   NOT IMPORT_LIB_SUFFIX AND
-   CMAKE_STATIC_LIBRARY_SUFFIX STREQUAL CMAKE_IMPORT_LIBRARY_SUFFIX)
-  set(IMPORT_LIB_SUFFIX "_imp")
+# Detect implib static lib filename collision
+if(WIN32 AND BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS AND
+   "${IMPORT_LIB_SUFFIX}${CMAKE_IMPORT_LIBRARY_SUFFIX}" STREQUAL
+   "${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+  message(FATAL_ERROR "Library suffix collision detected for ${LIBCURL_OUTPUT_NAME} ("
+    "implib: '${IMPORT_LIB_SUFFIX}${CMAKE_IMPORT_LIBRARY_SUFFIX}' vs. "
+    "static: '${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}'). "
+    "Set IMPORT_LIB_SUFFIX and/or STATIC_LIB_SUFFIX to different values, "
+    "or disable building either the shared or static library to avoid it.")
 endif()
 
 # Whether to do a single compilation pass for libcurl sources and reuse these

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -81,9 +81,8 @@ endif()
 if(WIN32 AND BUILD_STATIC_LIBS AND BUILD_SHARED_LIBS AND
    "${IMPORT_LIB_SUFFIX}${CMAKE_IMPORT_LIBRARY_SUFFIX}" STREQUAL
    "${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
-  message(FATAL_ERROR "Library suffix collision detected for ${LIBCURL_OUTPUT_NAME} ("
-    "implib: '${IMPORT_LIB_SUFFIX}${CMAKE_IMPORT_LIBRARY_SUFFIX}' vs. "
-    "static: '${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}'). "
+  message(FATAL_ERROR "Library suffix collision detected for ${LIBCURL_OUTPUT_NAME}. "
+    "It's '${STATIC_LIB_SUFFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}' for both import and static library. "
     "Set IMPORT_LIB_SUFFIX and/or STATIC_LIB_SUFFIX to different values, "
     "or disable building either the shared or static library to avoid it.")
 endif()


### PR DESCRIPTION
Allow overriding the `IMPORT_LIB_SUFFIX` default with an empty value.

Also:
- add a fatal error if the implib and static lib filename are identical.
- clarify `IMPORT_LIB_SUFFIX` default value in the documentation.

Reported-by: RubisetCie on Github
Fixes #16324
Ref: 1199308dbc902c52be67fc805c72dd2582520d30 #11505

---

w/o ws https://github.com/curl/curl/pull/16332/files?w=1
