### PR TITLE
Correct argument names & URL redirection

### DIFF
--- a/docs/CIPHERS.md
+++ b/docs/CIPHERS.md
@@ -137,7 +137,7 @@ for a list of these algorithms. Also, (since curl 7.77.0)
 [documentation for the Windows version in
 use](https://learn.microsoft.com/en-us/windows/win32/secauthn/cipher-suites-in-schannel)
 to see how that affects the cipher suite selection. When not specifying the
-`--chiphers` and `--tl13-ciphers` options curl passes this flag by default.
+`--ciphers` and `--tls13-ciphers` options curl passes this flag by default.
 
 ## Examples
 

--- a/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_ENABLE_NPN.md
@@ -28,7 +28,7 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_SSL_ENABLE_NPN, long npn);
 
 # DESCRIPTION
 
-Deprecated since 7.86.0. Setting this option has no function.
+Deprecated since 7.86.0 Setting this option has no function.
 
 Pass a long as parameter, 0 or 1 where 1 is for enable and 0 for disable. This
 option enables/disables NPN in the SSL handshake (if the SSL backend libcurl
@@ -58,7 +58,7 @@ int main(void)
 
 # DEPRECATED
 
-Deprecated since 7.86.0.
+Deprecated since 7.86.0
 
 # %AVAILABILITY%
 


### PR DESCRIPTION
**Two documentation edits related to the following documentation pages:**

1. [CURLOPT_SSL_ENABLE_NPN](https://curl.se/libcurl/c/CURLOPT_SSL_ENABLE_NPN.html)

Issue:
The use of a full-stop breaks the redirection when rendered on a webpage

Action:
Removed the full-stop

2. [SSL ciphers](https://curl.se/docs/ssl-ciphers.html)

Issue:
The arguments presented are non-existent due to typos resulting in the following errors:
> curl: option --tl13-ciphers: is unknown
> curl: option --chiphers: is unknown

Action:
Fixed the typos to be valid arguments
