### PR TITLE
asyn: remove a superfluous hostname strdup

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -779,7 +779,6 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
   if(!res->hostname)
     return NULL;
 
-  data->state.async.hostname = res->hostname;
   data->state.async.port = port;
   data->state.async.done = FALSE;   /* not done */
   data->state.async.status = 0;     /* clear */

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -400,7 +400,6 @@ static void destroy_async_data(struct Curl_easy *data)
 
     td->init = FALSE;
   }
-  Curl_safefree(async->hostname);
 }
 
 #ifdef USE_HTTPSRR_ARES
@@ -413,7 +412,7 @@ static CURLcode resolve_httpsrr(struct Curl_easy *data,
 
   memset(&async->thdata.hinfo, 0, sizeof(struct Curl_https_rrinfo));
   ares_query_dnsrec(async->thdata.channel,
-                    async->hostname, ARES_CLASS_IN,
+                    async->thdata.tsd.hostname, ARES_CLASS_IN,
                     ARES_REC_TYPE_HTTPS,
                     Curl_dnsrec_done_cb, data, NULL);
 
@@ -446,11 +445,6 @@ static bool init_resolve_thread(struct Curl_easy *data,
     free(td);
     goto errno_exit;
   }
-
-  free(async->hostname);
-  async->hostname = strdup(hostname);
-  if(!async->hostname)
-    goto err_exit;
 
   /* The thread will set this TRUE when complete. */
   td->tsd.done = FALSE;

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -1219,7 +1219,8 @@ CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
 
   if(dohp->probe[DOH_SLOT_IPV4].easy_mid < 0 &&
      dohp->probe[DOH_SLOT_IPV6].easy_mid < 0) {
-    failf(data, "Could not DoH-resolve: %s", data->state.async.hostname);
+    struct connectdata *conn = data->conn;
+    failf(data, "Could not DoH-resolve: %s", conn->host.name);
     return CONN_IS_PROXIED(data->conn) ? CURLE_COULDNT_RESOLVE_PROXY :
       CURLE_COULDNT_RESOLVE_HOST;
   }

--- a/lib/hostasyn.c
+++ b/lib/hostasyn.c
@@ -68,6 +68,7 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
                                 struct Curl_addrinfo *ai)
 {
   struct Curl_dns_entry *dns = NULL;
+  struct connectdata *conn = data->conn;
   CURLcode result = CURLE_OK;
 
   data->state.async.status = status;
@@ -78,8 +79,8 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
         Curl_share_lock(data, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SINGLE);
 
       dns = Curl_cache_addr(data, ai,
-                            data->state.async.hostname, 0,
-                            data->state.async.port, FALSE);
+                            conn->host.name, 0,
+                            conn->primary.remote_port, FALSE);
       if(data->share)
         Curl_share_unlock(data, CURL_LOCK_DATA_DNS);
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1463,9 +1463,9 @@ CURLcode Curl_resolver_error(struct Curl_easy *data)
 {
   const char *host_or_proxy;
   CURLcode result;
+  struct connectdata *conn = data->conn;
 
 #ifndef CURL_DISABLE_PROXY
-  struct connectdata *conn = data->conn;
   if(conn->bits.httpproxy) {
     host_or_proxy = "proxy";
     result = CURLE_COULDNT_RESOLVE_PROXY;
@@ -1478,7 +1478,7 @@ CURLcode Curl_resolver_error(struct Curl_easy *data)
   }
 
   failf(data, "Could not resolve %s: %s", host_or_proxy,
-        data->state.async.hostname);
+        conn->host.name);
 
   return result;
 }

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -566,7 +566,6 @@ struct hostname {
 #if defined(CURLRES_ASYNCH) || !defined(CURL_DISABLE_DOH)
 #define USE_CURL_ASYNC
 struct Curl_async {
-  char *hostname;
   struct Curl_dns_entry *dns;
 #ifdef CURLRES_ASYNCH
   struct thread_data thdata;


### PR DESCRIPTION
Use the name associated with the connection instead.