### PR TITLE
scripts/managen: fix option 'single'

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -1182,8 +1182,8 @@ HEADER
 }
 
 sub showonly {
-    my ($f) = @_;
-    if(single($f, 1)) {
+    my ($dir, $f) = @_;
+    if(single($dir, 1, $f, 1)) {
         print STDERR "$f: failed\n";
     }
 }
@@ -1218,7 +1218,7 @@ sub getargs {
         return;
     }
     elsif($f eq "single") {
-        showonly($s[0]);
+        showonly($dir, $s[0]);
         return;
     }
     elsif($f eq "protos") {


### PR DESCRIPTION
- Fix option 'single' to generate single manpages.

As far as I can tell the option did not work prior to this change.

Example: scripts/managen -d docs/cmdline-opts single variable.md

Closes #xxxx