### PR TITLE
scripts/managen: fix parsing of markdown code sections

### DIFF
--- a/scripts/managen
+++ b/scripts/managen
@@ -302,7 +302,30 @@ sub render {
             # skip leading blank lines
             next;
         }
+
         $start = 1;
+
+        if(/^[ \t]*\n/) {
+            # count and ignore blank lines
+            $blankline++;
+            next;
+        }
+        elsif($d =~ /^    (.*)/) {
+            my $word = $1;
+            if(!$quote && $manpage) {
+                push @desc, "\n" if($blankline);
+                push @desc, ".nf\n";
+                $blankline = 0;
+            }
+            $quote = 1;
+            $d = "$word\n";
+        }
+        elsif($quote) {
+            # end of quote
+            push @desc, ".fi\n" if($manpage);
+            $quote = 0;
+        }
+
         if(/^# (.*)/) {
             $header = 1;
             if($top != 1) {
@@ -365,26 +388,6 @@ sub render {
             my ($cmd) = ($1);
             print STDERR "$f:$line:1:ERROR: $cmd detected, use ##-style\n";
             return 3;
-        }
-        elsif(/^[ \t]*\n/) {
-            # count and ignore blank lines
-            $blankline++;
-            next;
-        }
-        elsif($d =~ /^    (.*)/) {
-            my $word = $1;
-            if(!$quote && $manpage) {
-                push @desc, "\n" if($blankline);
-                push @desc, ".nf\n";
-                $blankline = 0;
-            }
-            $quote = 1;
-            $d = "$word\n";
-        }
-        elsif($quote && ($d !~ /^    (.*)/)) {
-            # end of quote
-            push @desc, ".fi\n" if($manpage);
-            $quote = 0;
         }
 
         $d =~ s/`%DATE`/$date/g;


### PR DESCRIPTION
- Terminate a code section before parsing a heading line.

Prior to this change when a code line (eg `    code`) was followed
by a heading line (eg `## heading`) the code section in the output
was terminated after converting the header instead of before. That led
to some weird formatting outputs depending on the nroff or roffit etc.

With this change:
~~~
.nf
curl \--expand\-url https.//example.com/{{url:trim}}
.fi
.IP json
~~~
Without this change:
~~~
.nf
curl \--expand\-url https.//example.com/{{url:trim}}
.IP json
.fi
~~~

Closes #xxxx

---

There is [bad formatting](https://curl.se/docs/manpage.html#trim) in the curl man page website version

![bad_pre_format](https://github.com/user-attachments/assets/fccd2cea-6689-4064-b370-130bb1b1954c)

I traced at least part of the problem back to managen and fixed it in managen's nroff formatted output but I'm not sure about the webpage generation so more changes may be needed after this.