### PR TITLE
variable.md: clarify 'trim' example

### DIFF
--- a/docs/cmdline-opts/variable.md
+++ b/docs/cmdline-opts/variable.md
@@ -71,7 +71,7 @@ removes all leading and trailing white space.
 
 Example:
 
-    curl --expand-url https.//example.com/{{url:trim}}
+    curl --expand-url https://example.com/{{var:trim}}
 
 ## json
 outputs the content using JSON string quoting rules.


### PR DESCRIPTION
- Use the variable name 'var' instead of 'url' since the latter is also a function name and that may confuse the user.

Closes #xxxx