### PR TITLE
asyn-thread: remove 'status' from struct Curl_async

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -782,7 +782,6 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
   data->state.async.hostname = res->hostname;
   data->state.async.port = port;
   data->state.async.done = FALSE;   /* not done */
-  data->state.async.status = 0;     /* clear */
   data->state.async.dns = NULL;     /* clear */
 
   /* initial status - failed */

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -437,7 +437,6 @@ static bool init_resolve_thread(struct Curl_easy *data,
 
   async->port = port;
   async->done = FALSE;
-  async->status = 0;
   async->dns = NULL;
   td->thread_hnd = curl_thread_t_null;
   td->start = Curl_now();

--- a/lib/hostasyn.c
+++ b/lib/hostasyn.c
@@ -70,8 +70,6 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
   struct Curl_dns_entry *dns = NULL;
   CURLcode result = CURLE_OK;
 
-  data->state.async.status = status;
-
   if(CURL_ASYNC_SUCCESS == status) {
     if(ai) {
       if(data->share)

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -574,7 +574,6 @@ struct Curl_async {
   void *resolver; /* resolver state, if it is used in the URL state -
                      ares_channel e.g. */
   int port;
-  int status; /* if done is TRUE, this is the status from the callback */
   BIT(done);  /* set TRUE when the lookup is complete */
 };
 


### PR DESCRIPTION
While it gets stored, nothing needs nor uses it.