### PR TITLE
cmake: fix ECH detection in custom-patched OpenSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1020,7 +1020,7 @@ if(USE_ECH)
     endif()
     if(HAVE_BORINGSSL OR HAVE_AWSLC)
       curl_openssl_check_symbol_exists("SSL_set1_ech_config_list" "openssl/ssl.h" HAVE_SSL_SET1_ECH_CONFIG_LIST)
-    elseif(HAVE_OPENSSL)
+    elseif(USE_OPENSSL)
       curl_openssl_check_symbol_exists("SSL_set1_ech_config_list" "openssl/ech.h" HAVE_SSL_SET1_ECH_CONFIG_LIST)
     endif()
     if(HAVE_WOLFSSL_CTX_GENERATEECHCONFIG OR


### PR DESCRIPTION
Typo found via #16352
Regression-from fd067bfb5b028ac41660decc5abb87f1cd093b6b #15596
