### PR TITLE
openssl: remove bad `goto`s into other scope

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1452,7 +1452,7 @@ int cert_stuff(struct Curl_easy *data,
           failf(data, "No cert found in the openssl store: %s",
                 ossl_strerror(ERR_get_error(), error_buffer,
                               sizeof(error_buffer)));
-          goto fail;
+          return 0;
         }
 
         if(SSL_CTX_use_certificate(ctx, cert) != 1) {
@@ -1728,7 +1728,7 @@ fail:
           failf(data, "No private key found in the openssl store: %s",
                 ossl_strerror(ERR_get_error(), error_buffer,
                               sizeof(error_buffer)));
-          goto fail;
+          return 0;
         }
 
         if(SSL_CTX_use_PrivateKey(ctx, priv_key) != 1) {

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1289,9 +1289,7 @@ int cert_stuff(struct Curl_easy *data,
   if(cert_file || cert_blob || (file_type == SSL_FILETYPE_ENGINE) ||
      (file_type == SSL_FILETYPE_PROVIDER)) {
     SSL *ssl;
-    X509 *x509 = NULL;
-    EVP_PKEY *pri = NULL;
-    STACK_OF(X509) *ca = NULL;
+    X509 *x509;
     int cert_done = 0;
     int cert_use_result;
 
@@ -1480,6 +1478,8 @@ int cert_stuff(struct Curl_easy *data,
     {
       BIO *cert_bio = NULL;
       PKCS12 *p12 = NULL;
+      EVP_PKEY *pri;
+      STACK_OF(X509) *ca = NULL;
       if(cert_blob) {
         cert_bio = BIO_new_mem_buf(cert_blob->data, (int)(cert_blob->len));
         if(!cert_bio) {


### PR DESCRIPTION
All the `goto` did in these cases was effectively `return 0`, so just
use that explicitly.

This avoids GCC warnings in addition to the MSVC warning.