### PR TITLE
hostip: make CURLOPT_RESOLVE support replacing IPv6 addresses

### DIFF
--- a/docs/cmdline-opts/resolve.md
+++ b/docs/cmdline-opts/resolve.md
@@ -12,6 +12,7 @@ See-also:
   - alt-svc
 Example:
   - --resolve example.com:443:127.0.0.1 $URL
+  - --resolve example.com:443:[2001:db8::252f:efd6] $URL
 ---
 
 # `--resolve`
@@ -20,8 +21,8 @@ Provide a custom address for a specific host and port pair. Using this, you
 can make the curl requests(s) use a specified address and prevent the
 otherwise normally resolved address to be used. Consider it a sort of
 /etc/hosts alternative provided on the command line. The port number should be
-the number used for the specific protocol the host is used for. It means
-you need several entries if you want to provide address for the same host but
+the number used for the specific protocol the host is used for. It means you
+need several entries if you want to provide addresses for the same host but
 different ports.
 
 By specifying `*` as host you can tell curl to resolve any host and specific
@@ -37,9 +38,13 @@ parallel transfers with a lot of files. In such cases, if this option is used
 curl tries to resolve the host as it normally would once the timeout has
 expired.
 
+Provide IPv6 addresses within [brackets].
+
 To redirect connects from a specific hostname or any hostname, independently
 of port number, consider the --connect-to option.
 
 Support for resolving with wildcard was added in 7.64.0.
 
 Support for the '+' prefix was added in 7.75.0.
+
+Support for specifying the host component as an IPv6 address was added in 8.13.0.

--- a/docs/libcurl/opts/CURLOPT_RESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_RESOLVE.md
@@ -73,6 +73,8 @@ resolves, include a string in the linked list that uses the format
 The entry to remove must be prefixed with a dash, and the hostname and port
 number must exactly match what was added previously.
 
+Provide IPv6 addresses within [brackets].
+
 Using this option multiple times makes the last set list override the previous
 ones. Set it to NULL to disable its use again.
 
@@ -90,6 +92,7 @@ int main(void)
   CURL *curl;
   struct curl_slist *host = NULL;
   host = curl_slist_append(NULL, "example.com:443:127.0.0.1");
+  host = curl_slist_append(host, "example.com:443:[2001:db8::252f:efd6]");
 
   curl = curl_easy_init();
   if(curl) {
@@ -116,6 +119,8 @@ Support for providing multiple IP addresses per entry was added in 7.59.0.
 
 Support for adding non-permanent entries by using the "+" prefix was added in
 7.75.0.
+
+Support for specifying the host component as an IPv6 address was added in 8.13.0.
 
 # %AVAILABILITY%
 


### PR DESCRIPTION
This also applies to --resolve of course.

Fixes #16357
Reported-by: rmg-x on github