### PR TITLE
cookie: minor parser simplification

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -519,7 +519,7 @@ parse_cookie_header(struct Curl_easy *data,
     size_t vlen;
     size_t nlen;
 
-    while(*ptr && ISBLANK(*ptr))
+    while(ISBLANK(*ptr))
       ptr++;
 
     /* we have a <name>=<value> pair or a stand-alone word here */
@@ -537,7 +537,12 @@ parse_cookie_header(struct Curl_easy *data,
         nlen--;
 
       if(*ptr == '=') {
-        vlen = strcspn(++ptr, ";\r\n");
+        ptr++;
+        /* Skip spaces and tabs before the value */
+        while(ISBLANK(*ptr))
+          ptr++;
+
+        vlen = strcspn(ptr, ";\r\n");
         valuep = ptr;
         sep = TRUE;
         ptr = &valuep[vlen];
@@ -545,12 +550,6 @@ parse_cookie_header(struct Curl_easy *data,
         /* Strip off trailing whitespace from the value */
         while(vlen && ISBLANK(valuep[vlen-1]))
           vlen--;
-
-        /* Skip leading whitespace from the value */
-        while(vlen && ISBLANK(*valuep)) {
-          valuep++;
-          vlen--;
-        }
 
         /* Reject cookies with a TAB inside the value */
         if(memchr(valuep, '\t', vlen)) {
@@ -770,7 +769,7 @@ parse_cookie_header(struct Curl_easy *data,
       /* this is an "illegal" <what>=<this> pair */
     }
 
-    while(*ptr && ISBLANK(*ptr))
+    while(ISBLANK(*ptr))
       ptr++;
     if(*ptr == ';')
       ptr++;
@@ -1284,7 +1283,7 @@ struct CookieInfo *Curl_cookie_init(struct Curl_easy *data,
           /* This is a cookie line, get it! */
           lineptr += 11;
           headerline = TRUE;
-          while(*lineptr && ISBLANK(*lineptr))
+          while(ISBLANK(*lineptr))
             lineptr++;
         }
 


### PR DESCRIPTION
- parse whitespace before the value is handled
- remove superflous checks from some ISBLANK() loops