### PR TITLE
lib: simplify more white space loops

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -232,7 +232,7 @@ static CURLcode altsvc_load(struct altsvcinfo *asi, const char *file)
     Curl_dyn_init(&buf, MAX_ALTSVC_LINE);
     while(Curl_get_line(&buf, fp)) {
       char *lineptr = Curl_dyn_ptr(&buf);
-      while(*lineptr && ISBLANK(*lineptr))
+      while(ISBLANK(*lineptr))
         lineptr++;
       if(*lineptr == '#')
         /* skip commented lines */
@@ -410,7 +410,7 @@ static CURLcode getalnum(const char **ptr, char *alpnbuf, size_t buflen)
   size_t len;
   const char *protop;
   const char *p = *ptr;
-  while(*p && ISBLANK(*p))
+  while(ISBLANK(*p))
     p++;
   protop = p;
   while(*p && !ISBLANK(*p) && (*p != ';') && (*p != '='))
@@ -593,12 +593,12 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
             /* skip option if name is too long */
             option[0] = '\0';
           }
-          while(*p && ISBLANK(*p))
+          while(ISBLANK(*p))
             p++;
           if(*p != '=')
             return CURLE_OK;
           p++;
-          while(*p && ISBLANK(*p))
+          while(ISBLANK(*p))
             p++;
           if(!*p)
             return CURLE_OK;

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -209,7 +209,7 @@ static CURLcode namevalue(char *header, size_t hlen, unsigned int type,
     return CURLE_BAD_FUNCTION_ARGUMENT;
 
   /* skip all leading space letters */
-  while(*header && ISBLANK(*header))
+  while(ISBLANK(*header))
     header++;
 
   *value = header;

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -154,7 +154,7 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
     return CURLE_OK;
 
   do {
-    while(*p && ISBLANK(*p))
+    while(ISBLANK(*p))
       p++;
     if(strncasecompare("max-age", p, 7)) {
       bool quoted = FALSE;
@@ -164,11 +164,11 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
         return CURLE_BAD_FUNCTION_ARGUMENT;
 
       p += 7;
-      while(*p && ISBLANK(*p))
+      while(ISBLANK(*p))
         p++;
       if(*p++ != '=')
         return CURLE_BAD_FUNCTION_ARGUMENT;
-      while(*p && ISBLANK(*p))
+      while(ISBLANK(*p))
         p++;
 
       if(*p == '\"') {
@@ -202,7 +202,7 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
         p++;
     }
 
-    while(*p && ISBLANK(*p))
+    while(ISBLANK(*p))
       p++;
     if(*p == ';')
       p++;
@@ -534,7 +534,7 @@ static CURLcode hsts_load(struct hsts *h, const char *file)
     Curl_dyn_init(&buf, MAX_HSTS_LINE);
     while(Curl_get_line(&buf, fp)) {
       char *lineptr = Curl_dyn_ptr(&buf);
-      while(*lineptr && ISBLANK(*lineptr))
+      while(ISBLANK(*lineptr))
         lineptr++;
       /*
        * Skip empty or commented lines, since we know the line will have a

--- a/lib/http.c
+++ b/lib/http.c
@@ -257,7 +257,7 @@ char *Curl_copy_header_value(const char *header)
 
   /* Find the first non-space letter */
   start = header;
-  while(*start && ISSPACE(*start))
+  while(ISSPACE(*start))
     start++;
 
   end = strchr(start, '\r');
@@ -1016,7 +1016,7 @@ CURLcode Curl_http_input_auth(struct Curl_easy *data, bool proxy,
       auth++;
     if(*auth == ',') /* if we are on a comma, skip it */
       auth++;
-    while(*auth && ISSPACE(*auth))
+    while(ISSPACE(*auth))
       auth++;
   }
 
@@ -1404,7 +1404,7 @@ Curl_compareheader(const char *headerline, /* line to check */
   start = &headerline[hlen];
 
   /* pass all whitespace */
-  while(*start && ISSPACE(*start))
+  while(ISSPACE(*start))
     start++;
 
   /* find the end of the header line */
@@ -1597,7 +1597,7 @@ CURLcode Curl_add_custom_headers(struct Curl_easy *data,
         if(ptr) {
           optr = ptr;
           ptr++; /* pass the semicolon */
-          while(*ptr && ISSPACE(*ptr))
+          while(ISSPACE(*ptr))
             ptr++;
 
           if(*ptr) {
@@ -1625,7 +1625,7 @@ CURLcode Curl_add_custom_headers(struct Curl_easy *data,
         /* we require a colon for this to be a true header */
 
         ptr++; /* pass the colon */
-        while(*ptr && ISSPACE(*ptr))
+        while(ISSPACE(*ptr))
           ptr++;
 
         if(*ptr || semicolonp) {
@@ -3847,7 +3847,7 @@ static CURLcode http_rw_hd(struct Curl_easy *data,
        */
       const char *p = hd;
 
-      while(*p && ISBLANK(*p))
+      while(ISBLANK(*p))
         p++;
       if(!strncmp(p, "HTTP/", 5)) {
         p += 5;
@@ -3907,7 +3907,7 @@ static CURLcode http_rw_hd(struct Curl_easy *data,
     }
     else if(data->conn->handler->protocol & CURLPROTO_RTSP) {
       const char *p = hd;
-      while(*p && ISBLANK(*p))
+      while(ISBLANK(*p))
         p++;
       if(!strncmp(p, "RTSP/", 5)) {
         p += 5;
@@ -4448,7 +4448,7 @@ CURLcode Curl_http_req_to_h2(struct dynhds *h2_headers,
     scheme = Curl_checkheaders(data, STRCONST(HTTP_PSEUDO_SCHEME));
     if(scheme) {
       scheme += sizeof(HTTP_PSEUDO_SCHEME);
-      while(*scheme && ISBLANK(*scheme))
+      while(ISBLANK(*scheme))
         scheme++;
       infof(data, "set pseudo header %s to %s", HTTP_PSEUDO_SCHEME, scheme);
     }

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -95,12 +95,12 @@ static void trim_headers(struct curl_slist *head)
     store = value;
 
     /* skip leading whitespace */
-    while(*value && ISBLANK(*value))
+    while(ISBLANK(*value))
       value++;
 
     while(*value) {
       int space = 0;
-      while(*value && ISBLANK(*value)) {
+      while(ISBLANK(*value)) {
         value++;
         space++;
       }
@@ -356,7 +356,7 @@ static char *parse_content_sha_hdr(struct Curl_easy *data,
     return NULL;
   ++value;
 
-  while(*value && ISBLANK(*value))
+  while(ISBLANK(*value))
     ++value;
 
   len = strlen(value);

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -62,7 +62,7 @@ CURLcode Curl_input_digest(struct Curl_easy *data,
     return CURLE_BAD_CONTENT_ENCODING;
 
   header += strlen("Digest");
-  while(*header && ISBLANK(*header))
+  while(ISBLANK(*header))
     header++;
 
   return Curl_auth_decode_digest_http_message(header, digest);

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -86,7 +86,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
 
   /* Obtain the input token, if any */
   header += strlen("Negotiate");
-  while(*header && ISBLANK(*header))
+  while(ISBLANK(*header))
     header++;
 
   len = strlen(header);

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -70,7 +70,7 @@ CURLcode Curl_input_ntlm(struct Curl_easy *data,
   if(checkprefix("NTLM", header)) {
     header += strlen("NTLM");
 
-    while(*header && ISSPACE(*header))
+    while(ISSPACE(*header))
       header++;
 
     if(*header) {

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -108,7 +108,7 @@ static CURLcode dynhds_add_custom(struct Curl_easy *data,
         name = headers->data;
         namelen = ptr - headers->data;
         ptr++; /* pass the colon */
-        while(*ptr && ISSPACE(*ptr))
+        while(ISSPACE(*ptr))
           ptr++;
         if(*ptr) {
           value = ptr;
@@ -131,7 +131,7 @@ static CURLcode dynhds_add_custom(struct Curl_easy *data,
         name = headers->data;
         namelen = ptr - headers->data;
         ptr++; /* pass the semicolon */
-        while(*ptr && ISSPACE(*ptr))
+        while(ISSPACE(*ptr))
           ptr++;
         if(!*ptr) {
           /* quirk #2, send an empty header */

--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -177,7 +177,7 @@ bool Curl_check_noproxy(const char *name, const char *no_proxy)
       bool match = FALSE;
 
       /* pass blanks */
-      while(*p && ISBLANK(*p))
+      while(ISBLANK(*p))
         p++;
 
       token = p;

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -944,7 +944,7 @@ CURLcode Curl_rtsp_parseheader(struct Curl_easy *data, const char *header)
 
     /* Find the first non-space letter */
     start = header + 8;
-    while(*start && ISBLANK(*start))
+    while(ISBLANK(*start))
       start++;
 
     if(!*start) {
@@ -1003,7 +1003,7 @@ CURLcode rtsp_parse_transport(struct Curl_easy *data, const char *transport)
   const char *start, *end;
   start = transport;
   while(start && *start) {
-    while(*start && ISBLANK(*start) )
+    while(ISBLANK(*start) )
       start++;
     end = strchr(start, ';');
     if(checkprefix("interleaved=", start)) {

--- a/lib/strtoofft.c
+++ b/lib/strtoofft.c
@@ -39,7 +39,7 @@ CURLofft curlx_strtoofft(const char *str, char **endp, int base,
   *num = 0; /* clear by default */
   DEBUGASSERT((base == 10) || (base == 16));
 
-  while(*str && ISBLANK(*str))
+  while(ISBLANK(*str))
     str++;
 
   rc = base == 10 ?


### PR DESCRIPTION
Since the ISBLANK() and ISSPACE() macros check for specific matches, there is no point in using while(*ptr && ISSPACE(*ptr)) etc, as the '*ptr' check is then superfluous.