### PR TITLE
CI: dump non-prefill configure log on prefill-check fail

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -239,8 +239,9 @@ jobs:
                 -DCMAKE_C_COMPILER_TARGET="$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
                 ${{ matrix.build.generate }} ${options}
             done
-            if [ -d bld_chkprefill ]; then
-              diff -u bld/lib/curl_config.h bld_chkprefill/lib/curl_config.h
+            if [ -d bld_chkprefill ] && ! diff -u bld/lib/curl_config.h bld_chkprefill/lib/curl_config.h; then
+              echo '::group::reference configure log'; cat bld_chkprefill/CMakeFiles/CMake*.yaml 2>/dev/null || true; echo '::endgroup::'
+              false
             fi
           else
             export CFLAGS

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -260,8 +260,9 @@ jobs:
                 -DCURL_WERROR=ON \
                 ${{ matrix.config }}
             done
-            if [ -d bld_chkprefill ]; then
-              diff -u bld/lib/curl_config.h bld_chkprefill/lib/curl_config.h
+            if [ -d bld_chkprefill ] && ! diff -u bld/lib/curl_config.h bld_chkprefill/lib/curl_config.h; then
+              echo '::group::reference configure log'; cat bld_chkprefill/CMakeFiles/CMake*.yaml 2>/dev/null || true; echo '::endgroup::'
+              false
             fi
           else
             export CFLAGS CPPFLAGS
@@ -756,8 +757,9 @@ jobs:
               -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE= \
               ${{ matrix.config }}
           done
-          if [ -d bld_chkprefill ]; then
-            diff -u bld/lib/curl_config.h bld_chkprefill/lib/curl_config.h
+          if [ -d bld_chkprefill ] && ! diff -u bld/lib/curl_config.h bld_chkprefill/lib/curl_config.h; then
+            echo '::group::reference configure log'; cat bld_chkprefill/CMakeFiles/CMake*.yaml 2>/dev/null || true; echo '::endgroup::'
+            false
           fi
 
       - name: 'configure log'

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -70,8 +70,9 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
       -DCMAKE_BUILD_TYPE="${PRJ_CFG}" \
       -DCURL_USE_LIBPSL=OFF ${options}
   done
-  if [ -d _bld_chkprefill ]; then
-    diff -u _bld/lib/curl_config.h _bld_chkprefill/lib/curl_config.h
+  if [ -d _bld_chkprefill ] && ! diff -u _bld/lib/curl_config.h _bld_chkprefill/lib/curl_config.h; then
+    cat _bld_chkprefill/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
+    false
   fi
   if false; then
     cat _bld/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true


### PR DESCRIPTION
To help debugging builds where the actual feature check is broken.

Follow-up to e7adf3e83747c2915c671f2e560cde6f3d4a4905 #15841