### PR TITLE
ca-native.md: sync with CURLSSLOPT_NATIVE_CA

### DIFF
--- a/docs/cmdline-opts/ca-native.md
+++ b/docs/cmdline-opts/ca-native.md
@@ -20,8 +20,9 @@ Example:
 
 Use the operating system's native CA store for certificate verification. If
 you set this option and also set a CA certificate file or directory, or curl
-was built with a default certificate location setting, then during verification
-those certificates are searched in addition to the native CA store.
+was built with a default CA certificate location setting, then during
+verification those certificates are searched in addition to the native CA
+store.
 
 This option works for OpenSSL on Windows (added in 7.71.0).
 
@@ -32,4 +33,4 @@ This option works for GnuTLS (added in 8.5.0).
 
 This option has no effect on Schannel. Schannel is the native TLS library for
 Windows and therefore already uses the native CA store for verification unless
-it is overridden by a certificate location setting.
+it is overridden by a CA certificate location setting.

--- a/docs/cmdline-opts/ca-native.md
+++ b/docs/cmdline-opts/ca-native.md
@@ -18,12 +18,18 @@ Example:
 
 # `--ca-native`
 
-Use the CA store from the native operating system to verify the peer. By
-default, curl otherwise uses a CA store provided in a single file or
-directory, but when using this option it interfaces the operating system's own
-vault.
+Use the operating system's native CA store for certificate verification. If
+you set this option and also set a CA certificate file or directory, or curl
+was built with a default certificate location setting, then during verification
+those certificates are searched in addition to the native CA store.
 
-This option works for curl on Windows when built to use OpenSSL, wolfSSL
-(added in 8.3.0) or GnuTLS (added in 8.5.0). When curl on Windows is built to
-use Schannel, this feature is implied and curl then only uses the native CA
-store.
+This option works for OpenSSL on Windows (added in 7.71.0).
+
+This option works for wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo,
+Fedora, RHEL), macOS, Android and iOS (added in 8.3.0).
+
+This option works for GnuTLS (added in 8.5.0).
+
+This option has no effect on Schannel. Schannel is the native TLS library for
+Windows and therefore already uses the native CA store for verification unless
+it is overridden by a certificate location setting.

--- a/docs/cmdline-opts/ca-native.md
+++ b/docs/cmdline-opts/ca-native.md
@@ -24,13 +24,13 @@ Use the operating system's native CA store for certificate verification.
 This option is independent of other CA certificate locations set at run time or
 build time. Those locations are searched in addition to the native CA store.
 
-This option works for OpenSSL and its forks (LibreSSL, BoringSSL, etc) on
-Windows (added in 7.71.0).
+This option works with OpenSSL and its forks (LibreSSL, BoringSSL, etc) on
+Windows. (Added in 7.71.0)
 
-This option works for wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo,
-Fedora, RHEL), macOS, Android and iOS (added in 8.3.0).
+This option works with wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo,
+Fedora, RHEL), macOS, Android and iOS. (Added in 8.3.0)
 
-This option works for GnuTLS (added in 8.5.0).
+This option works with GnuTLS. (Added in 8.5.0)
 
 This option currently has no effect for Schannel or Secure Transport. Those are
 native TLS libraries from Microsoft and Apple, respectively, that by default

--- a/docs/cmdline-opts/ca-native.md
+++ b/docs/cmdline-opts/ca-native.md
@@ -12,25 +12,27 @@ See-also:
   - capath
   - dump-ca-embed
   - insecure
+  - proxy-ca-native
 Example:
   - --ca-native $URL
 ---
 
 # `--ca-native`
 
-Use the operating system's native CA store for certificate verification. If
-you set this option and also set a CA certificate file or directory, or curl
-was built with a default CA certificate location setting, then during
-verification those certificates are searched in addition to the native CA
-store.
+Use the operating system's native CA store for certificate verification.
 
-This option works for OpenSSL on Windows (added in 7.71.0).
+This option is independent of other CA certificate locations set at run time or
+build time. Those locations are searched in addition to the native CA store.
+
+This option works for OpenSSL and its forks (LibreSSL, BoringSSL, etc) on
+Windows (added in 7.71.0).
 
 This option works for wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo,
 Fedora, RHEL), macOS, Android and iOS (added in 8.3.0).
 
 This option works for GnuTLS (added in 8.5.0).
 
-This option has no effect on Schannel. Schannel is the native TLS library for
-Windows and therefore already uses the native CA store for verification unless
-it is overridden by a CA certificate location setting.
+This option currently has no effect for Schannel or Secure Transport. Those are
+native TLS libraries from Microsoft and Apple, respectively, that by default
+use the native CA store for verification unless overridden by a CA certificate
+location setting.

--- a/docs/cmdline-opts/proxy-ca-native.md
+++ b/docs/cmdline-opts/proxy-ca-native.md
@@ -26,4 +26,5 @@ This option is independent of other HTTPS proxy CA certificate locations set at
 run time or build time. Those locations are searched in addition to the native
 CA store.
 
-Equivalent to --ca-native but used in HTTPS proxy context.
+Equivalent to --ca-native but used in HTTPS proxy context. Refer to --ca-native
+for TLS backend limitations.

--- a/docs/cmdline-opts/proxy-ca-native.md
+++ b/docs/cmdline-opts/proxy-ca-native.md
@@ -8,6 +8,7 @@ Category: tls
 Added: 8.2.0
 Multi: boolean
 See-also:
+  - ca-native
   - cacert
   - capath
   - dump-ca-embed
@@ -18,11 +19,11 @@ Example:
 
 # `--proxy-ca-native`
 
-Use the CA store from the native operating system to verify the HTTPS proxy.
-By default, curl uses a CA store provided in a single file or directory, but
-when using this option it interfaces the operating system's own vault.
+Use the operating system's native CA store for certificate verification of the
+HTTPS proxy.
 
-This option works for curl on Windows when built to use OpenSSL, wolfSSL
-(added in 8.3.0) or GnuTLS (added in 8.5.0). When curl on Windows is built to
-use Schannel, this feature is implied and curl then only uses the native CA
-store.
+This option is independent of other HTTPS proxy CA certificate locations set at
+run time or build time. Those locations are searched in addition to the native
+CA store.
+
+Equivalent to --ca-native but used in HTTPS proxy context.

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -70,13 +70,13 @@ precedence. (Added in 7.70.0)
 ## CURLSSLOPT_NATIVE_CA
 
 Tell libcurl to use the operating system's native CA store for certificate
-verification. If you set this option and also set a CA certificate file or
-directory then during verification those certificates are searched in addition
-to the native CA store.
+verification. This option is independent of other CA certificate locations set
+at run time or build time. Those locations are searched in addition to the
+native CA store.
 
 Works with wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora, RHEL),
-macOS, Android and iOS (added in 8.3.0), with GnuTLS (added in 8.5.0) or on
-Windows when built to use OpenSSL (Added in 7.71.0).
+macOS, Android and iOS (added in 8.3.0); with GnuTLS (added in 8.5.0) and with
+OpenSSL and its forks (LibreSSL, BoringSSL, etc) on Windows (Added in 7.71.0).
 
 ## CURLSSLOPT_AUTO_CLIENT_CERT
 

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -69,8 +69,9 @@ precedence. (Added in 7.70.0)
 
 Tell libcurl to use the operating system's native CA store for certificate
 verification. If you set this option and also set a CA certificate file or
-directory then during verification those certificates are searched in addition
-to the native CA store.
+directory, or libcurl was built with a default certificate location setting,
+then during verification those certificates are searched in addition to the
+native CA store.
 
 Works with wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora, RHEL),
 macOS, Android and iOS (added in 8.3.0), with GnuTLS (added in 8.5.0) or on

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -69,7 +69,7 @@ precedence. (Added in 7.70.0)
 
 Tell libcurl to use the operating system's native CA store for certificate
 verification. If you set this option and also set a CA certificate file or
-directory, or libcurl was built with a default certificate location setting,
+directory, or libcurl was built with a default CA certificate location setting,
 then during verification those certificates are searched in addition to the
 native CA store.
 

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -68,14 +68,13 @@ precedence. (Added in 7.70.0)
 ## CURLSSLOPT_NATIVE_CA
 
 Tell libcurl to use the operating system's native CA store for certificate
-verification. If you set this option and also set a CA certificate file or
-directory, or libcurl was built with a default CA certificate location setting,
-then during verification those certificates are searched in addition to the
+verification. This option is independent of other CA certificate locations set
+at run time or build time. Those locations are searched in addition to the
 native CA store.
 
 Works with wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora, RHEL),
-macOS, Android and iOS (added in 8.3.0), with GnuTLS (added in 8.5.0) or on
-Windows when built to use OpenSSL (Added in 7.71.0).
+macOS, Android and iOS (added in 8.3.0); with GnuTLS (added in 8.5.0) and with
+OpenSSL and its forks (LibreSSL, BoringSSL, etc) on Windows (Added in 7.71.0).
 
 ## CURLSSLOPT_AUTO_CLIENT_CERT
 


### PR DESCRIPTION
- Add that the native CA store is used to verify certs in addition to the other certificate location settings.

Basically clarify that --ca-native does not override --cacert etc.

Prior to this change that behavior was only documented in CURLSSLOPT_NATIVE_CA which is what --ca-native maps to.

Ref: https://github.com/curl/curl/pull/16181#issuecomment-2663998865

Closes #xxxx