### PR TITLE
cmake: `SHARE_LIB_OBJECT=ON` requires CMake 3.12 or newer

### DIFF
--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -170,6 +170,7 @@ assumes that CMake generates `Makefile`:
 - `IMPORT_LIB_SUFFIX`:                      Import library suffix. Default: `_imp` for MSVC-like toolchains, otherwise empty.
 - `LIBCURL_OUTPUT_NAME`:                    Basename of the curl library. Default: `libcurl`
 - `PICKY_COMPILER`:                         Enable picky compiler options. Default: `ON`
+- `SHARE_LIB_OBJECT`:                       Build shared and static libcurl in a single pass (requires CMake 3.12 or newer). Default: `ON` for Windows
 - `STATIC_LIB_SUFFIX`:                      Static library suffix. Default: (empty)
 
 ## CA bundle options

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -106,6 +106,10 @@ if(NOT DEFINED SHARE_LIB_OBJECT)
   endif()
 endif()
 
+if(CMAKE_VERSION VERSION_LESS 3.12)
+  set(SHARE_LIB_OBJECT OFF)
+endif()
+
 if(SHARE_LIB_OBJECT)
   set(LIB_OBJECT "libcurl_object")
   add_library(${LIB_OBJECT} OBJECT ${HHEADERS} ${CSOURCES})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -106,13 +106,9 @@ if(NOT DEFINED SHARE_LIB_OBJECT)
   endif()
 endif()
 
-if(CMAKE_VERSION VERSION_LESS 3.12)
-  set(SHARE_LIB_OBJECT OFF)
-endif()
-
-if(SHARE_LIB_OBJECT)
+if(SHARE_LIB_OBJECT AND NOT CMAKE_VERSION VERSION_LESS 3.12)
   set(LIB_OBJECT "libcurl_object")
-  add_library(${LIB_OBJECT} OBJECT ${HHEADERS} ${CSOURCES})
+  add_library(${LIB_OBJECT} OBJECT ${HHEADERS} ${CSOURCES})  # Requires CMake 3.12
   if(WIN32)
     # Define CURL_STATICLIB always, to disable __declspec(dllexport) for
     # exported libcurl symbols. We handle exports via libcurl.def instead.


### PR DESCRIPTION
This feature requires Object Libraries which is supported by CMake 3.12
or newer: https://cmake.org/cmake/help/latest/release/3.12.html

Keep it permanently disabled for older CMake versions.
Also document it in `docs/INSTALL-CMAKE.md`.

Ref: https://cmake.org/cmake/help/latest/manual/cmake-buildsystem.7.html#object-libraries

Follow-up to fc9bfb14520712672b4784e8b48256fb29204011 #11627
Follow-up to 2ebc74c36a19a1700af394c16855ce144d9878e3 #11546

Reported-by: Mark Phillips
Fixes #16375
