### PR TITLE
schannel: enable ALPN support under WINE 6.0+

### DIFF
--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2466,13 +2466,13 @@ static int schannel_init(void)
   typedef const char *(APIENTRY *WINE_GET_VERSION_FN)(void);
   /* GetModuleHandle() not available for UWP.
      Assume no WINE because WINE has no UWP support. */
-  WINE_GET_VERSION_FN s_p_wine_get_version =
+  WINE_GET_VERSION_FN p_wine_get_version =
     CURLX_FUNCTION_CAST(WINE_GET_VERSION_FN,
                         (GetProcAddress(GetModuleHandle(TEXT("ntdll")),
                                         "wine_get_version")));
-  wine = !!s_p_wine_get_version;
+  wine = !!p_wine_get_version;
   if(wine) {
-    const char *wine_version = s_p_wine_get_version(); /* e.g. "6.0.2" */
+    const char *wine_version = p_wine_get_version(); /* e.g. "6.0.2" */
     /* Assume ALPN support with WINE 6.0.0 or upper */
     wine_has_alpn = wine_version && atoi(wine_version) >= 6;
   }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -154,6 +154,12 @@
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
 
+static bool s_win2000_eq;
+static bool s_winxp_le;
+static bool s_winvista;
+static bool s_win7;
+static bool s_win10_17763;
+static bool s_win10_20384;
 static bool s_win_has_alpn;
 
 static CURLcode schannel_pkp_pin_peer_pubkey(struct Curl_cfilter *cf,
@@ -2461,6 +2467,19 @@ static int schannel_init(void)
 {
   bool wine = FALSE;
   bool wine_has_alpn = FALSE;
+
+  s_win2000_eq  = curlx_verify_windows_version(5, 0, 0, PLATFORM_WINNT,
+                                               VERSION_EQUAL);
+  s_winxp_le    = curlx_verify_windows_version(5, 1, 0, PLATFORM_WINNT,
+                                               VERSION_LESS_THAN_EQUAL);
+  s_winvista    = curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
+                                               VERSION_GREATER_THAN_EQUAL);
+  s_win7        = curlx_verify_windows_version(6, 1, 0, PLATFORM_WINNT,
+                                               VERSION_GREATER_THAN_EQUAL);
+  s_win10_17763 = curlx_verify_windows_version(10, 0, 17763, PLATFORM_WINNT,
+                                               VERSION_GREATER_THAN_EQUAL);
+  s_win10_20384 = curlx_verify_windows_version(10, 0, 20348, PLATFORM_WINNT,
+                                               VERSION_GREATER_THAN_EQUAL);
 
 #ifndef CURL_WINDOWS_UWP
   typedef const char *(APIENTRY *WINE_GET_VERSION_FN)(void);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2459,15 +2459,13 @@ static void schannel_close(struct Curl_cfilter *cf, struct Curl_easy *data)
 
 static int schannel_init(void)
 {
-  bool wine;
-  bool wine_has_alpn;
+  bool wine = FALSE;
+  bool wine_has_alpn = FALSE;
 
-#ifdef CURL_WINDOWS_UWP
+#ifndef CURL_WINDOWS_UWP
+  typedef const char *(APIENTRY *WINE_GET_VERSION_FN)(void);
   /* GetModuleHandle() not available for UWP.
      Assume no WINE because WINE has no UWP support. */
-  wine = FALSE;
-#else
-  typedef const char *(APIENTRY *WINE_GET_VERSION_FN)(void);
   WINE_GET_VERSION_FN s_p_wine_get_version =
     CURLX_FUNCTION_CAST(WINE_GET_VERSION_FN,
                         (GetProcAddress(GetModuleHandle(TEXT("ntdll")),

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -154,7 +154,7 @@
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
 
-static bool s_os_has_alpn;
+static bool s_win_has_alpn;
 
 static CURLcode schannel_pkp_pin_peer_pubkey(struct Curl_cfilter *cf,
                                              struct Curl_easy *data,
@@ -908,7 +908,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   }
 
 #ifdef HAS_ALPN_SCHANNEL
-  backend->use_alpn = connssl->alpn && s_os_has_alpn;
+  backend->use_alpn = connssl->alpn && s_win_has_alpn;
 #else
   backend->use_alpn = FALSE;
 #endif
@@ -2478,11 +2478,11 @@ static int schannel_init(void)
   }
 #endif
   if(wine)
-    s_os_has_alpn = wine_has_alpn;
+    s_win_has_alpn = wine_has_alpn;
   else {
     /* ALPN is supported on Windows 8.1 / Server 2012 R2 and above. */
-    s_os_has_alpn = curlx_verify_windows_version(6, 3, 0, PLATFORM_WINNT,
-                                                 VERSION_GREATER_THAN_EQUAL);
+    s_win_has_alpn = curlx_verify_windows_version(6, 3, 0, PLATFORM_WINNT,
+                                                  VERSION_GREATER_THAN_EQUAL);
   }
 
   return Curl_sspi_global_init() == CURLE_OK ? 1 : 0;

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -927,14 +927,14 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
       s_wine = !!s_p_wine_get_version;
       if(s_wine) {
         const char *wine_version = s_p_wine_get_version(); /* e.g. "6.0.2" */
-        /* Assume ALPN support with WINE 2.0.0 or upper */
-        s_wine_has_alpn = wine_version && atoi(wine_version) >= 2;
+        /* Assume ALPN support with WINE 6.0.0 or upper */
+        s_wine_has_alpn = wine_version && atoi(wine_version) >= 6;
       }
       s_wine_init = TRUE;
     }
 #endif
     /* ALPN is only supported on Windows 8.1 / Server 2012 R2 and above.
-       Under WINE it is reported working in 1.9.0+, see curl bug #983. */
+       It is also supported under WINE 5.6+ with GnuTLS 3.2.0+ */
     if(s_wine)
       os_has_alpn = s_wine_has_alpn;
     else

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -928,7 +928,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
       if(s_wine) {
         const char *wine_version = s_p_wine_get_version(); /* e.g. "6.0.2" */
         /* Assume ALPN support with WINE 2.0.0 or upper */
-        s_wine_has_alpn = atoi(wine_version) >= 2;
+        s_wine_has_alpn = wine_version && atoi(wine_version) >= 2;
       }
       s_wine_init = TRUE;
     }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2472,18 +2472,18 @@ static int schannel_init(void)
                                         "wine_get_version")));
   wine = !!p_wine_get_version;
   if(wine) {
-    const char *wine_version = p_wine_get_version(); /* e.g. "6.0.2" */
+    const char *wine_version = p_wine_get_version();  /* e.g. "6.0.2" */
     /* Assume ALPN support with WINE 6.0.0 or upper */
     wine_has_alpn = wine_version && atoi(wine_version) >= 6;
   }
 #endif
-  /* ALPN is only supported on Windows 8.1 / Server 2012 R2 and above.
-     It is also supported under WINE 5.6+ with GnuTLS 3.2.0+ */
   if(wine)
     s_os_has_alpn = wine_has_alpn;
-  else
+  else {
+    /* ALPN is supported on Windows 8.1 / Server 2012 R2 and above. */
     s_os_has_alpn = curlx_verify_windows_version(6, 3, 0, PLATFORM_WINNT,
                                                  VERSION_GREATER_THAN_EQUAL);
+  }
 
   return Curl_sspi_global_init() == CURLE_OK ? 1 : 0;
 }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -154,12 +154,6 @@
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
 
-static bool s_win2000_eq;
-static bool s_winxp_le;
-static bool s_winvista;
-static bool s_win7;
-static bool s_win10_17763;
-static bool s_win10_20384;
 static bool s_win_has_alpn;
 
 static CURLcode schannel_pkp_pin_peer_pubkey(struct Curl_cfilter *cf,
@@ -2467,19 +2461,6 @@ static int schannel_init(void)
 {
   bool wine = FALSE;
   bool wine_has_alpn = FALSE;
-
-  s_win2000_eq  = curlx_verify_windows_version(5, 0, 0, PLATFORM_WINNT,
-                                               VERSION_EQUAL);
-  s_winxp_le    = curlx_verify_windows_version(5, 1, 0, PLATFORM_WINNT,
-                                               VERSION_LESS_THAN_EQUAL);
-  s_winvista    = curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
-                                               VERSION_GREATER_THAN_EQUAL);
-  s_win7        = curlx_verify_windows_version(6, 1, 0, PLATFORM_WINNT,
-                                               VERSION_GREATER_THAN_EQUAL);
-  s_win10_17763 = curlx_verify_windows_version(10, 0, 17763, PLATFORM_WINNT,
-                                               VERSION_GREATER_THAN_EQUAL);
-  s_win10_20384 = curlx_verify_windows_version(10, 0, 20348, PLATFORM_WINNT,
-                                               VERSION_GREATER_THAN_EQUAL);
 
 #ifndef CURL_WINDOWS_UWP
   typedef const char *(APIENTRY *WINE_GET_VERSION_FN)(void);

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2473,7 +2473,7 @@ static int schannel_init(void)
   wine = !!p_wine_get_version;
   if(wine) {
     const char *wine_version = p_wine_get_version();  /* e.g. "6.0.2" */
-    /* Assume ALPN support with WINE 6.0.0 or upper */
+    /* Assume ALPN support with WINE 6.0 or upper */
     wine_has_alpn = wine_version && atoi(wine_version) >= 6;
   }
 #endif


### PR DESCRIPTION
ALPN support was announced in 5.6 (2020-04-10). It likely needs a WINE
built against GnuTLS 3.2.0 (2013-05-10) or upper (for macOS, GnuTLS was
made default in WINE 6.0.2). I could confirm ALPN working under 6.0.2
(2021-10-26).

https://www.winehq.org/announce/5.6
https://gitlab.winehq.org/wine/wine/-/commit/0527cf89fb907c330bc4fad3b135a1c85208fa9e
https://gitlab.winehq.org/wine/wine/-/blob/wine-5.6/dlls/secur32/schannel_gnutls.c
https://gitlab.winehq.org/wine/wine/-/blob/wine-5.6/dlls/secur32/tests/schannel.c

If you run into problems, open and Issue and disable ALPN manually with
`--no-alpn` or the equivalent for libcurl.

Ref: #983
