### PR TITLE
build: silence bogus `-Wconversion` warnings with gcc 5.1-5.4

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -268,6 +268,9 @@ if(PICKY_COMPILER)
       if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 4.3 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 4.8)
         list(APPEND _picky "-Wno-type-limits")  # Avoid false positives
       endif()
+      if(NOT CMAKE_C_COMPILER_VERSION VERSION_LESS 5.1 AND CMAKE_C_COMPILER_VERSION VERSION_LESS 5.5)
+        list(APPEND _picky "-Wno-conversion")  # Avoid false positives
+      endif()
     endif()
   endif()
 endif()

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -1131,6 +1131,10 @@ AC_DEFUN([CURL_SET_COMPILER_WARNING_OPTS], [
           dnl Avoid false positives
           tmp_CFLAGS="$tmp_CFLAGS -Wno-type-limits"
         fi
+        if test "$compiler_num" -ge "501" -a "$compiler_num" -lt "505"; then
+          dnl Avoid false positives
+          tmp_CFLAGS="$tmp_CFLAGS -Wno-conversion"
+        fi
         ;;
         #
       HP_UX_C)


### PR DESCRIPTION
It's fixed in gcc 5.5.0.

Example: https://godbolt.org/z/x6Th8q844

Seen in gcc 5.1.0, 5.4.0 (both 32/64-bit) with dl-mingw:
```
lib/rtsp.c: In function 'rtsp_parse_transport':
lib/rtsp.c:1025:36: error: conversion to 'unsigned char' from 'int' may alter its value [-Werror=conversion]
           rtp_channel_mask[idx] |= (unsigned char)(1 << off);
                                    ^
lib/mprintf.c: In function 'parsefmt':
lib/mprintf.c:526:31: error: conversion to 'unsigned char' from 'int' may alter its value [-Werror=conversion]
         usedinput[width/8] |= (unsigned char)(1 << (width&7));
                               ^
lib/mprintf.c:544:35: error: conversion to 'unsigned char' from 'int' may alter its value [-Werror=conversion]
         usedinput[precision/8] |= (unsigned char)(1 << (precision&7));
                                   ^
lib/mprintf.c:559:29: error: conversion to 'unsigned char' from 'int' may alter its value [-Werror=conversion]
       usedinput[param/8] |= (unsigned char)(1 << (param&7));
                             ^
lib/cfilters.c: In function 'Curl_pollset_change':
lib/cfilters.c:935:25: error: conversion to 'unsigned char' from 'int' may alter its value [-Werror=conversion]
       ps->actions[i] |= (unsigned char)add_flags;
                         ^
```
gcc 5.1.0: https://github.com/curl/curl/actions/runs/13413103492/job/37467698381#step:9:21
gcc 5.4.0: https://github.com/curl/curl/actions/runs/13413103492/job/37467694479#step:9:19
