### PR TITLE
cf-socket: deduplicate Windows Vista detection

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -82,6 +82,7 @@
 #include "rand.h"
 #include "share.h"
 #include "strdup.h"
+#include "system_win32.h"
 #include "version_win32.h"
 #include "strparse.h"
 
@@ -461,9 +462,6 @@ int Curl_socket_close(struct Curl_easy *data, struct connectdata *conn,
    Windows. Following function trying to detect OS version and skips
    SO_SNDBUF adjustment for Windows Vista and above.
 */
-#define DETECT_OS_NONE 0
-#define DETECT_OS_PREVISTA 1
-#define DETECT_OS_VISTA_OR_LATER 2
 
 void Curl_sndbuf_init(curl_socket_t sockfd)
 {
@@ -471,17 +469,7 @@ void Curl_sndbuf_init(curl_socket_t sockfd)
   int curval = 0;
   int curlen = sizeof(curval);
 
-  static int detectOsState = DETECT_OS_NONE;
-
-  if(detectOsState == DETECT_OS_NONE) {
-    if(curlx_verify_windows_version(6, 0, 0, PLATFORM_WINNT,
-                                    VERSION_GREATER_THAN_EQUAL))
-      detectOsState = DETECT_OS_VISTA_OR_LATER;
-    else
-      detectOsState = DETECT_OS_PREVISTA;
-  }
-
-  if(detectOsState == DETECT_OS_VISTA_OR_LATER)
+  if(Curl_isVistaOrGreater)
     return;
 
   if(getsockopt(sockfd, SOL_SOCKET, SO_SNDBUF, (char *)&curval, &curlen) == 0)


### PR DESCRIPTION
- Remove Vista detection logic from Curl_sndbuf_init and evaluate global init variable Curl_isVistaOrGreater instead.

This way we don't need a separate initialization in Curl_sndbuf_init.

Ref: https://github.com/curl/curl/pull/16393#discussion_r1962377920

Closes #xxxx