### PR TITLE
tool_getparam: clear some sensitive arguments better

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1564,7 +1564,8 @@ static ParameterError parse_time_cond(struct GlobalConfig *global,
 
 ParameterError getparameter(const char *flag, /* f or -long-flag */
                             char *nextarg,    /* NULL if unset */
-                            argv_item_t cleararg,
+                            argv_item_t cleararg1,
+                            argv_item_t cleararg2,
                             bool *usedarg,    /* set to TRUE if the arg
                                                  has been used */
                             struct GlobalConfig *global,
@@ -1669,6 +1670,9 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       if(!longopt && parse[1]) {
         nextarg = (char *)&parse[1]; /* this is the actual extra parameter */
         singleopt = TRUE;   /* do not loop anymore after this */
+#ifdef HAVE_WRITABLE_ARGV
+        clearthis = &cleararg1[parse + 2 - flag];
+#endif
       }
       else if(!nextarg) {
         err = PARAM_REQUIRES_PARAMETER;
@@ -1676,7 +1680,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       }
       else {
 #ifdef HAVE_WRITABLE_ARGV
-        clearthis = cleararg;
+        clearthis = cleararg2;
 #endif
         *usedarg = TRUE; /* mark it as used */
       }
@@ -2889,8 +2893,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
           }
         }
 
-        result = getparameter(orig_opt, nextarg, argv[i + 1], &passarg,
-                              global, config);
+        result = getparameter(orig_opt, nextarg, argv[i], argv[i + 1],
+                              &passarg, global, config);
 
         curlx_unicodefree(nextarg);
         config = global->last;
@@ -2932,7 +2936,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
       bool used;
 
       /* Just add the URL please */
-      result = getparameter("--url", orig_opt, argv[i], &used, global, config);
+      result = getparameter("--url", orig_opt, NULL, NULL,
+                            &used, global, config);
     }
 
     if(!result)

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1591,7 +1591,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
 #ifdef HAVE_WRITABLE_ARGV
   argv_item_t clearthis = NULL;
 #else
-  (void)cleararg;
+  (void)cleararg1;
+  (void)cleararg2;
 #endif
 
   *usedarg = FALSE; /* default is that we do not use the arg */

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -361,7 +361,8 @@ const struct LongShort *findlongopt(const char *opt);
 const struct LongShort *findshortopt(char letter);
 
 ParameterError getparameter(const char *flag, char *nextarg,
-                            argv_item_t cleararg,
+                            argv_item_t cleararg1,
+                            argv_item_t cleararg2,
                             bool *usedarg,
                             struct GlobalConfig *global,
                             struct OperationConfig *operation);

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -190,7 +190,8 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
 #ifdef DEBUG_CONFIG
       fprintf(tool_stderr, "PARAM: \"%s\"\n",(param ? param : "(null)"));
 #endif
-      res = getparameter(option, param, NULL, &usedarg, global, operation);
+      res = getparameter(option, param, NULL, NULL,
+                         &usedarg, global, operation);
       operation = global->last;
 
       if(!res && param && *param && !usedarg)


### PR DESCRIPTION
curl attempts to clear some flags to hide them from snooping neighbors (on platforms where it works). For example the credentials provided with -u. Previously it would only do that if there was a space between the option and the credentials as in "-u joe:s3cr3t" but not when done without a separating space as in "-ujoe:s3cr3t".

This addresses that previous shortcoming.

Reported-by: kayrus on github
Fixes #16396