### PR TITLE
httpsrr: fix port detection

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -843,6 +843,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
   {
     res->num_pending++; /* one more */
     memset(&res->hinfo, 0, sizeof(struct Curl_https_rrinfo));
+    res->hinfo->port = -1;
     ares_query_dnsrec((ares_channel)data->state.async.resolver,
                       hostname, ARES_CLASS_IN,
                       ARES_REC_TYPE_HTTPS,

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -412,6 +412,7 @@ static CURLcode resolve_httpsrr(struct Curl_easy *data,
     return CURLE_FAILED_INIT;
 
   memset(&async->thdata.hinfo, 0, sizeof(struct Curl_https_rrinfo));
+  async->thdata.hinfo.port = -1;
   ares_query_dnsrec(async->thdata.channel,
                     async->hostname, ARES_CLASS_IN,
                     ARES_REC_TYPE_HTTPS,


### PR DESCRIPTION
Initialize port to -1 in the Curl_https_rrinfo struct, else it is set to 0 during memset and makes curl think the HTTPS RR is for port 0.