### PR TITLE
asyn-ares: fix the port assign

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -843,7 +843,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
   {
     res->num_pending++; /* one more */
     memset(&res->hinfo, 0, sizeof(struct Curl_https_rrinfo));
-    res->hinfo->port = -1;
+    res->hinfo.port = -1;
     ares_query_dnsrec((ares_channel)data->state.async.resolver,
                       hostname, ARES_CLASS_IN,
                       ARES_REC_TYPE_HTTPS,


### PR DESCRIPTION
Follow-up to 6bc65a444b2e7f1453b0b4
Fixes #16414