### PR TITLE
http: fix the auth check

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -880,7 +880,7 @@ static bool authcmp(const char *auth, const char *line)
 {
   /* the auth string must not have an alnum following */
   size_t n = strlen(auth);
-  return strncasecompare(auth, line, n) && !ISALNUM(auth[n]);
+  return strncasecompare(auth, line, n) && !ISALNUM(line[n]);
 }
 #endif
 


### PR DESCRIPTION
It used the wrong variable.

Follow-up to d1fc1c4a854d5cc809cc4ae59a9511900228023a Pointed-out-by: qhill on github
Ref: https://github.com/curl/curl/pull/16406#pullrequestreview-2632734134