### PR TITLE
gnutls: fix state check, run GH http3 pytest event based

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -135,7 +135,7 @@ jobs:
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \
-            texinfo texlive texlive-extra-utils autopoint libev-dev libuv1-dev\
+            texinfo texlive texlive-extra-utils autopoint libev-dev \
             apache2 apache2-dev libnghttp2-dev
           echo 'CC=gcc-12' >> $GITHUB_ENV
           echo 'CXX=g++-12' >> $GITHUB_ENV
@@ -302,7 +302,7 @@ jobs:
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \
-            texinfo texlive texlive-extra-utils autopoint libev-dev \
+            texinfo texlive texlive-extra-utils autopoint libev-dev libuv1-dev \
             apache2 apache2-dev libnghttp2-dev vsftpd
           python3 -m venv $HOME/venv
           echo 'CC=gcc-12' >> $GITHUB_ENV

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -510,7 +510,7 @@ jobs:
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
         run: |
-          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
+          source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build . --verbose --target curl-pytest-ci
           else

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -511,7 +511,7 @@ jobs:
           fi
 
       - name: 'run pytest event based'
-        if: ${{ matrix.build.generate }}
+        if: !${{ matrix.build.generate }}
         env:
           TFLAGS: '${{ matrix.build.tflags }}'
           CURL_TEST_EVENT: 1

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -503,6 +503,20 @@ jobs:
             make V=1 pytest-ci
           fi
 
+      - name: 'run pytest event based'
+        env:
+          TFLAGS: '${{ matrix.build.tflags }}'
+          CURL_TEST_EVENT: 1
+          CURL_CI: github
+          PYTEST_ADDOPTS: '--color=yes'
+        run: |
+          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            cmake --build . --verbose --target curl-pytest-ci
+          else
+            make V=1 pytest-ci
+          fi
+
       - name: 'build examples'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -270,7 +270,7 @@ jobs:
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-openssl=$HOME/openssl/build --with-openssl-quic
               --with-nghttp3=$HOME/nghttp3/build
-              -DCURL_USE_LIBUV=ON
+              --with-libuv
 
           - name: quiche
             configure: >-
@@ -280,7 +280,7 @@ jobs:
               --with-quiche=$HOME/quiche/target/release
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-ca-fallback
-              -DCURL_USE_LIBUV=ON
+              --with-libuv
 
           - name: quiche
             PKG_CONFIG_PATH: '$HOME/quiche/target/release'
@@ -511,6 +511,7 @@ jobs:
           fi
 
       - name: 'run pytest event based'
+        if: ${{ matrix.build.generate }}
         env:
           TFLAGS: '${{ matrix.build.tflags }}'
           CURL_TEST_EVENT: 1

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -511,7 +511,7 @@ jobs:
           fi
 
       - name: 'run pytest event based'
-        if: !${{ matrix.build.generate }}
+        if: ${{ !matrix.build.generate }}
         env:
           TFLAGS: '${{ matrix.build.tflags }}'
           CURL_TEST_EVENT: 1

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -135,7 +135,7 @@ jobs:
             libpsl-dev libbrotli-dev libzstd-dev zlib1g-dev libev-dev libc-ares-dev \
             nettle-dev libp11-kit-dev libtspi-dev libunistring-dev guile-2.2-dev libtasn1-bin \
             libtasn1-6-dev libidn2-0-dev gawk gperf libtss2-dev dns-root-data bison gtk-doc-tools \
-            texinfo texlive texlive-extra-utils autopoint libev-dev \
+            texinfo texlive texlive-extra-utils autopoint libev-dev libuv1-dev\
             apache2 apache2-dev libnghttp2-dev
           echo 'CC=gcc-12' >> $GITHUB_ENV
           echo 'CXX=g++-12' >> $GITHUB_ENV
@@ -232,6 +232,7 @@ jobs:
               --with-ngtcp2=$HOME/ngtcp2/build --enable-warnings --enable-werror --enable-debug --disable-ntlm
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-openssl=$HOME/quictls/build --enable-ssls-export
+              --with-libuv
 
           - name: gnutls
             PKG_CONFIG_PATH: '$HOME/gnutls/build/lib/pkgconfig:$HOME/nghttp3/build/lib/pkgconfig:$HOME/ngtcp2/build/lib/pkgconfig:$HOME/nghttp2/build/lib/pkgconfig'
@@ -240,6 +241,7 @@ jobs:
               --with-ngtcp2=$HOME/ngtcp2/build --enable-warnings --enable-werror --enable-debug
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-gnutls=$HOME/gnutls/build --enable-ssls-export
+              --with-libuv
 
           - name: wolfssl
             PKG_CONFIG_PATH: '$HOME/wolfssl/build/lib/pkgconfig:$HOME/nghttp3/build/lib/pkgconfig:$HOME/ngtcp2/build/lib/pkgconfig:$HOME/nghttp2/build/lib/pkgconfig'
@@ -249,6 +251,7 @@ jobs:
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-wolfssl=$HOME/wolfssl/build
               --enable-ech --enable-ssls-export
+              --with-libuv
 
           - name: wolfssl
             PKG_CONFIG_PATH: '$HOME/wolfssl/build/lib/pkgconfig:$HOME/nghttp3/build/lib/pkgconfig:$HOME/ngtcp2/build/lib/pkgconfig:$HOME/nghttp2/build/lib/pkgconfig'
@@ -257,6 +260,7 @@ jobs:
               -DTEST_NGHTTPX="$HOME/nghttp2/build/bin/nghttpx"
               -DHTTPD_NGHTTPX="$HOME/nghttp2/build/bin/nghttpx"
               -DUSE_ECH=ON
+              -DCURL_USE_LIBUV=ON
 
           - name: openssl-quic
             PKG_CONFIG_PATH: '$HOME/openssl/build/lib64/pkgconfig'
@@ -266,6 +270,7 @@ jobs:
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-openssl=$HOME/openssl/build --with-openssl-quic
               --with-nghttp3=$HOME/nghttp3/build
+              -DCURL_USE_LIBUV=ON
 
           - name: quiche
             configure: >-
@@ -275,6 +280,7 @@ jobs:
               --with-quiche=$HOME/quiche/target/release
               --with-test-nghttpx="$HOME/nghttp2/build/bin/nghttpx"
               --with-ca-fallback
+              -DCURL_USE_LIBUV=ON
 
           - name: quiche
             PKG_CONFIG_PATH: '$HOME/quiche/target/release'
@@ -284,6 +290,7 @@ jobs:
               -DTEST_NGHTTPX="$HOME/nghttp2/build/bin/nghttpx"
               -DHTTPD_NGHTTPX="$HOME/nghttp2/build/bin/nghttpx"
               -DCURL_CA_FALLBACK=ON
+              -DCURL_USE_LIBUV=ON
 
     steps:
       - name: 'install prereqs'

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -497,21 +497,7 @@ jobs:
           source $HOME/venv/bin/activate
           python3 -m pip install -r tests/http/requirements.txt
 
-      - name: 'run pytest'
-        env:
-          TFLAGS: '${{ matrix.build.tflags }}'
-          CURL_CI: github
-          PYTEST_ADDOPTS: '--color=yes'
-        run: |
-          source $HOME/venv/bin/activate
-          if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --verbose --target curl-pytest-ci
-          else
-            make V=1 pytest-ci
-          fi
-
       - name: 'run pytest event based'
-        if: ${{ !matrix.build.generate }}
         env:
           TFLAGS: '${{ matrix.build.tflags }}'
           CURL_TEST_EVENT: 1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -698,4 +698,3 @@ jobs:
           else
             make V=1 pytest-ci
           fi
-

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -698,3 +698,12 @@ jobs:
           else
             make V=1 pytest-ci
           fi
+
+      - name: 'build examples'
+        if: ${{ matrix.build.make-custom-target != 'tidy' }}
+        run: |
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            ${{ matrix.build.make-prefix }} cmake --build . --verbose --target curl-examples
+          else
+            ${{ matrix.build.make-prefix }} make V=1 examples
+          fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -106,7 +106,7 @@ jobs:
 
           - name: mbedtls valgrind
             install_packages: libnghttp2-dev valgrind
-            install_steps: mbedtls pytest pytest-event
+            install_steps: mbedtls pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
 
           - name: mbedtls clang
@@ -161,7 +161,7 @@ jobs:
 
           - name: openssl
             install_packages: zlib1g-dev
-            install_steps: pytest pytest-event
+            install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
           - name: openssl -O3 valgrind
@@ -699,26 +699,3 @@ jobs:
             make V=1 pytest-ci
           fi
 
-      - name: 'run pytest event based'
-        if: contains(matrix.build.install_steps, 'pytest-event')
-        env:
-          TFLAGS: '${{ matrix.build.tflags }}'
-          CURL_TEST_EVENT: 1
-          CURL_CI: github
-          PYTEST_ADDOPTS: '--color=yes'
-        run: |
-          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
-          if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --verbose --target curl-pytest-ci
-          else
-            make V=1 pytest-ci
-          fi
-
-      - name: 'build examples'
-        if: ${{ matrix.build.make-custom-target != 'tidy' }}
-        run: |
-          if [ -n '${{ matrix.build.generate }}' ]; then
-            ${{ matrix.build.make-prefix }} cmake --build . --verbose --target curl-examples
-          else
-            ${{ matrix.build.make-prefix }} make V=1 examples
-          fi

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -106,7 +106,7 @@ jobs:
 
           - name: mbedtls valgrind
             install_packages: libnghttp2-dev valgrind
-            install_steps: mbedtls pytest
+            install_steps: mbedtls pytest pytest-event
             configure: LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
 
           - name: mbedtls clang
@@ -161,7 +161,7 @@ jobs:
 
           - name: openssl
             install_packages: zlib1g-dev
-            install_steps: pytest
+            install_steps: pytest pytest-event
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
           - name: openssl -O3 valgrind
@@ -689,6 +689,21 @@ jobs:
         if: contains(matrix.build.install_steps, 'pytest')
         env:
           TFLAGS: '${{ matrix.build.tflags }}'
+          CURL_CI: github
+          PYTEST_ADDOPTS: '--color=yes'
+        run: |
+          [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            cmake --build . --verbose --target curl-pytest-ci
+          else
+            make V=1 pytest-ci
+          fi
+
+      - name: 'run pytest event based'
+        if: contains(matrix.build.install_steps, 'pytest-event')
+        env:
+          TFLAGS: '${{ matrix.build.tflags }}'
+          CURL_TEST_EVENT: 1
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
         run: |

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1951,8 +1951,9 @@ out:
     *done = FALSE;
     return CURLE_OK;
   }
-  *done = ((connssl->connecting_state == ssl_connect_1) ||
+  *done = ((connssl->connecting_state == ssl_connection_complete) ||
            (connssl->state == ssl_connection_deferred));
+  CURL_TRC_CF(data, cf, "gtls_connect_common() -> %d, done=%d", result, *done);
   return result;
 }
 

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1951,7 +1951,7 @@ out:
     *done = FALSE;
     return CURLE_OK;
   }
-  *done = ((connssl->connecting_state == ssl_connection_complete) ||
+  *done = ((connssl->state == ssl_connection_complete) ||
            (connssl->state == ssl_connection_deferred));
   CURL_TRC_CF(data, cf, "gtls_connect_common() -> %d, done=%d", result, *done);
   return result;


### PR DESCRIPTION
When running curl event based, connect attempts stalled as the 'done' check was using the wrong state in gnutls.

Build http3.yml curl with `libuv` and run event based pytest runs to all http3 jobs.