### PR TITLE
cmake: avoid `-Wnonnull` warning in `HAVE_FSETXATTR_5` detection

### DIFF
--- a/CMake/CurlTests.c
+++ b/CMake/CurlTests.c
@@ -312,7 +312,7 @@ int main(void)
 #include <sys/xattr.h> /* header from libc, not from libattr */
 int main(void)
 {
-  fsetxattr(0, 0, 0, 0, 0);
+  fsetxattr(0, "", 0, 0, 0);
   return 0;
 }
 #endif


### PR DESCRIPTION
Seen in Android 21/35 CI jobs:
```
curl/CMake/CurlTests.c:315:16: warning: null passed to a callee that requires a non-null argument [-Wnonnull]
   315 |   fsetxattr(0, 0, 0, 0, 0);
       |                ^
 1 warning generated.
```
Ref: https://github.com/curl/curl/actions/runs/13460225795/job/37613494183#step:9:5978

Follow-up to bd9f9b085aa242a5e93be0b2da96ce498d7813c4 #16377

---

This leaves 10 remaining `-Wnonnull` warnings per Android AM jobs.
