### PR TITLE
GHA/windows: msys/mingw improvements

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -416,6 +416,7 @@ jobs:
           release: false
           update: false
           cache: false
+          path-type: inherit
           install: >-
             mingw-w64-${{ matrix.env }}-libpsl
             ${{ matrix.install }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -391,12 +391,13 @@ jobs:
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/9.5.0-10.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-9.5.0-mingw-w64msvcrt-10.0.0-r1.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
             type: 'Release'
-          - name: 'schannel U'
+          - name: 'schannel openssl U'
             dir: 'mingw64'
             env: 'x86_64'
             ver: '7.3.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON'
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_OPENSSL=ON'
+            install: mingw-w64-x86_64-openssl
             type: 'Release'
             tflags: 'skiprun'
           - name: 'schannel !unity'
@@ -417,7 +418,12 @@ jobs:
           cache: false
           path-type: inherit
           install: >-
+            mingw-w64-${{ matrix.env }}-zlib
+            mingw-w64-${{ matrix.env }}-brotli
+            mingw-w64-${{ matrix.env }}-zstd
+            mingw-w64-${{ matrix.env }}-nghttp2
             mingw-w64-${{ matrix.env }}-libpsl
+            mingw-w64-${{ matrix.env }}-libssh2
             ${{ matrix.install }}
 
       - name: 'cache compiler (gcc ${{ matrix.ver }}-${{ matrix.env }})'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -391,13 +391,13 @@ jobs:
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/9.5.0-10.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-9.5.0-mingw-w64msvcrt-10.0.0-r1.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
             type: 'Release'
-          - name: 'schannel wolfssl U'
+          - name: 'schannel mbedtls U'
             dir: 'mingw64'
             env: 'x86_64'
             ver: '7.3.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_WOLFSSL=ON'
-            install: mingw-w64-x86_64-wolfssl
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_MBEDTLS=ON'
+            install: mingw-w64-x86_64-mbedtls
             type: 'Release'
             tflags: 'skiprun'
           - name: 'schannel !unity'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -439,7 +439,7 @@ jobs:
           for _chkprefill in '' ${{ matrix.chkprefill }}; do
             options=''
             [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
-            cmake -B "bld${_chkprefill}" -G 'MSYS Makefiles' ${options} \
+            cmake -B "bld${_chkprefill}" -G "${{ contains(matrix.url, '/winlibs_mingw/') && 'Ninja' || 'MSYS Makefiles' }}" ${options} \
               -DCMAKE_C_COMPILER=gcc \
               -DCMAKE_BUILD_TYPE='${{ matrix.type }}' \
               -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=30 -DCURL_TEST_BUNDLES=ON \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -416,7 +416,6 @@ jobs:
           release: false
           update: false
           cache: false
-          path-type: inherit
           install: >-
             mingw-w64-${{ matrix.env }}-zlib
             mingw-w64-${{ matrix.env }}-brotli

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -70,6 +70,7 @@ jobs:
             libpsl-devel
             zlib-devel
             libbrotli-devel
+            libzstd-devel
             libnghttp2-devel
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -205,6 +206,7 @@ jobs:
             openssl-devel
             zlib-devel
             brotli-devel
+            libzstd-devel
             libnghttp2-devel
             libpsl-devel
             libssh2-devel

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -378,7 +378,7 @@ jobs:
     timeout-minutes: 20
     defaults:
       run:
-        shell: C:\msys64\usr\bin\bash.exe {0}
+        shell: msys2 {0}
     env:
       MAKEFLAGS: -j 5
     strategy:
@@ -409,6 +409,17 @@ jobs:
             tflags: 'skiprun'
       fail-fast: false
     steps:
+      - uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2
+        with:
+          msystem: ${{ matrix.dir }}
+          release: false
+          update: false
+          cache: false
+          path-type: inherit
+          install: >-
+            mingw-w64-${{ matrix.env }}-libpsl
+            ${{ matrix.install }}
+
       - name: 'cache compiler (gcc ${{ matrix.ver }}-${{ matrix.env }})'
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         id: cache-compiler
@@ -438,7 +449,7 @@ jobs:
       - name: 'configure'
         timeout-minutes: 5
         run: |
-          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:$PATH"
           for _chkprefill in '' ${{ matrix.chkprefill }}; do
             options=''
             [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
@@ -467,7 +478,7 @@ jobs:
       - name: 'build'
         timeout-minutes: 5
         run: |
-          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:$PATH"
           cmake --build bld
 
       - name: 'curl version'
@@ -481,7 +492,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
         run: |
-          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:$PATH"
           cmake --build bld --target testdeps
 
       - name: 'install test prereqs'
@@ -504,7 +515,7 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 10
         run: |
-          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:$PATH"
           export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
@@ -515,7 +526,7 @@ jobs:
       - name: 'build examples'
         timeout-minutes: 5
         run: |
-          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
+          PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:$PATH"
           cmake --build bld --target curl-examples
 
   linux-cross-mingw-w64:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -391,13 +391,13 @@ jobs:
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/9.5.0-10.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-9.5.0-mingw-w64msvcrt-10.0.0-r1.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
             type: 'Release'
-          - name: 'schannel openssl U'
+          - name: 'schannel wolfssl U'
             dir: 'mingw64'
             env: 'x86_64'
             ver: '7.3.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_OPENSSL=ON'
-            install: mingw-w64-x86_64-openssl
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_WOLFSSL=ON'
+            install: mingw-w64-x86_64-wolfssl
             type: 'Release'
             tflags: 'skiprun'
           - name: 'schannel !unity'
@@ -417,12 +417,7 @@ jobs:
           update: false
           cache: false
           install: >-
-            mingw-w64-${{ matrix.env }}-zlib
-            mingw-w64-${{ matrix.env }}-brotli
-            mingw-w64-${{ matrix.env }}-zstd
-            mingw-w64-${{ matrix.env }}-nghttp2
             mingw-w64-${{ matrix.env }}-libpsl
-            mingw-w64-${{ matrix.env }}-libssh2
             ${{ matrix.install }}
 
       - name: 'cache compiler (gcc ${{ matrix.ver }}-${{ matrix.env }})'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -373,7 +373,7 @@ jobs:
           fi
 
   mingw-w64-standalone-downloads:
-    name: 'dl-mingw, CM ${{ matrix.env }} ${{ matrix.name }}'
+    name: 'dl-mingw, CM ${{ matrix.ver }}-${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
     timeout-minutes: 20
     defaults:
@@ -385,35 +385,38 @@ jobs:
       matrix:
         include:
           - name: 'schannel'
-            env: '9.5.0-x86_64'
             dir: 'mingw64'
+            env: 'x86_64'
+            ver: '9.5.0'
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/9.5.0-10.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-9.5.0-mingw-w64msvcrt-10.0.0-r1.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
             type: 'Release'
           - name: 'schannel U'
-            env: '7.3.0-x86_64'
             dir: 'mingw64'
+            env: 'x86_64'
+            ver: '7.3.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON'
             type: 'Release'
             tflags: 'skiprun'
           - name: 'schannel !unity'
-            env: '6.4.0-i686'
             dir: 'mingw32'
+            env: 'i686'
+            ver: '6.4.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF'
             type: 'Debug'
             tflags: 'skiprun'
       fail-fast: false
     steps:
-      - name: 'cache compiler (gcc ${{ matrix.env }})'
+      - name: 'cache compiler (gcc ${{ matrix.ver }}-${{ matrix.env }})'
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
         id: cache-compiler
         with:
           path: ~\my-cache
-          key: ${{ runner.os }}-mingw-w64-${{ matrix.env }}
+          key: ${{ runner.os }}-mingw-w64-${{ matrix.ver }}-${{ matrix.env }}
 
-      - name: 'install compiler (gcc ${{ matrix.env }})'
+      - name: 'install compiler (gcc ${{ matrix.ver }}-${{ matrix.env }})'
         if: ${{ steps.cache-compiler.outputs.cache-hit != 'true' }}
         timeout-minutes: 5
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -458,7 +458,7 @@ jobs:
               -DCMAKE_BUILD_TYPE='${{ matrix.type }}' \
               -DCMAKE_UNITY_BUILD=ON -DCMAKE_UNITY_BUILD_BATCH_SIZE=30 -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
-              -DCURL_USE_LIBPSL=OFF \
+              -DUSE_LIBIDN2=OFF \
               ${{ matrix.config }}
           done
           if [ -d bld_chkprefill ] && ! diff -u bld/lib/curl_config.h bld_chkprefill/lib/curl_config.h; then


### PR DESCRIPTION
- enable zstd in Cygwin and MSYS jobs.
- dl-mingw: use Ninja in the 9.5.0 (winlibs-mingw) job.
  The download package is shipping with it. Saves 15s build time.
  Keep testing GNU Makefiles with the two mingw-builds jobs.
- dl-mingw: split `env` prop to `env` and `ver` to aid integrating with
  MSYS2.
- dl-mingw: install MSYS2 with options to make it quick (<20s).
  It allows to use MSYS2 dependency packages with the downloaded
  toolchains. It also makes configuration cleaner. Install libpsl.
- dl-mingw: enable mbedTLS in the 7.3.0 job.
  (OpenSSL took a long time to install, wolfSSL misses features.)

Assisted-by: Jeremy Drake

---

- [x] rebase on #16614
- [x] perhaps merge dl-mingw jobs into standard msys/mingw ones?
  The difference is that they'd keep using the downloaded toolchain,
  instead of the built-in one. [FUTURE maybe]
- [x] try new msys2 installer by bumping the action pin.
- [x] enable cache again. [Went with OFF, I'm not sure this is okay, but it's fast (below 20s) with the few packages installed on top of the pre-installed MSYS2]
- [x] decide if the extra build/test time is useful for these jobs. → Yes, it's useful to combine these builds with MSYS2 package to improve coverage.
