### PR TITLE
libssh2: Print user with verbose flag

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3167,10 +3167,13 @@ static CURLcode ssh_connect(struct Curl_easy *data, bool *done)
 
   sshc = &conn->proto.sshc;
 
-#ifdef CURL_LIBSSH2_DEBUG
   if(conn->user) {
-    infof(data, "User: %s", conn->user);
+    infof(data, "User: '%s'", conn->user);
   }
+  else {
+    infof(data, "User: NULL");
+  }
+#ifdef CURL_LIBSSH2_DEBUG
   if(conn->passwd) {
     infof(data, "Password: %s", conn->passwd);
   }


### PR DESCRIPTION
Hi! :wave: 

A small quality-of-life improvement, I think.

Do tell if I'm missing something here, and there were any reason not to print out the `conn->user` value that ends-up used for the connection.

* * *

**This change:**

 - Breaks out the existing print out of the LIBSSH2_DEBUG compile-time flag
 - Adds (single) quotation marks around the string to better expose the actual value
 - Adds a NULL print, mirroring other verbose prints in libssh2

**Why was this done?**

I was trying out the `sftp` option in `curl`, and found myself hitting an issue where I was not able to get curl to tell me which username it was using to connect to a host.

With this change, the `User: ` line is printed with `-v`, just like other SSH verbose prints.

Instead of using the pattern used with *SSH MD5 public key*, where a ternary is used to print `NULL` on NULL values, it is using a different branch to add quotes around the string value.

The quotes around the string value are used to better expose to the user an empty string value, compared to "no-value".

* * *

Further thoughts:

 - Should the line be prefixed with `SSH `, to form `SSH User: 'samuel'`?
 - Is there a pattern I could have used to better pretty-print "quoted strings"?
 - Was it truly necessary to add the `NULL` print? Is it even a possibility that `NULL` us present at this location? (I presumed so, from the existing check.)