### PR TITLE
RELEASE-NOTES: fix casing

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -101,7 +101,7 @@ advice from friends like these:
   Anthony Hu, Daniel Stenberg, dependabot[bot], Dexter Gerig, Harry Sintonen,
   John Bampton, Joseph Chen, kayrus on github, kriztalz, lf- on github,
   Marcel Raad, Mark Phillips, Ray Satiro, rmg-x on github,
-  RubisetCie on Github, Sergey, Stefan Eissing, Viktor Szakats,
+  RubisetCie on github, Sergey, Stefan Eissing, Viktor Szakats,
   Zenju on github
   (19 contributors)
 


### PR DESCRIPTION
Follows-up b22f9066a5, which added a new contributor with a different casing for "github" than the others.

Given that there hasn't been a release yet that adds this to the THANKS file, it is still easy to fix.