### PR TITLE
Add advice for socket callback invocation times.

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -47,6 +47,11 @@ libcurl then expects the application to monitor the sockets for the specific
 activities and tell libcurl again when something happens on one of them. Tell
 libcurl by calling curl_multi_socket_action(3).
 
+This callback may get invoked at any time when interacting with libcurl. 
+This may even happen after all transfers are done and is *likely* to
+happen *during* a call to curl_multi_cleanup(3) when cached connections
+are shut down.
+
 # CALLBACK ARGUMENTS
 
 *easy* identifies the specific transfer for which this update is related.

--- a/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_SOCKETFUNCTION.md
@@ -47,7 +47,7 @@ libcurl then expects the application to monitor the sockets for the specific
 activities and tell libcurl again when something happens on one of them. Tell
 libcurl by calling curl_multi_socket_action(3).
 
-This callback may get invoked at any time when interacting with libcurl. 
+This callback may get invoked at any time when interacting with libcurl.
 This may even happen after all transfers are done and is *likely* to
 happen *during* a call to curl_multi_cleanup(3) when cached connections
 are shut down.


### PR DESCRIPTION
Explain when a registered socket callback may get invoked to make user better aware on how to handle it.