### PR TITLE
standalone hash for curl_off_t

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -164,6 +164,7 @@ LIB_CFILES =         \
   getinfo.c          \
   gopher.c           \
   hash.c             \
+  hash_offt.c        \
   headers.c          \
   hmac.c             \
   hostasyn.c         \
@@ -312,6 +313,7 @@ LIB_HFILES =         \
   getinfo.h          \
   gopher.h           \
   hash.h             \
+  hash_offt.h        \
   headers.h          \
   hostip.h           \
   hsts.h             \

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -400,25 +400,3 @@ Curl_hash_next_element(struct Curl_hash_iterator *iter)
 
   return iter->current;
 }
-
-void Curl_hash_offt_init(struct Curl_hash *h,
-                         size_t slots,
-                         Curl_hash_dtor dtor)
-{
-  Curl_hash_init(h, slots, Curl_hash_str, Curl_str_key_compare, dtor);
-}
-
-void *Curl_hash_offt_set(struct Curl_hash *h, curl_off_t id, void *elem)
-{
-  return Curl_hash_add(h, &id, sizeof(id), elem);
-}
-
-int Curl_hash_offt_remove(struct Curl_hash *h, curl_off_t id)
-{
-  return Curl_hash_delete(h, &id, sizeof(id));
-}
-
-void *Curl_hash_offt_get(struct Curl_hash *h, curl_off_t id)
-{
-  return Curl_hash_pick(h, &id, sizeof(id));
-}

--- a/lib/hash.h
+++ b/lib/hash.h
@@ -108,13 +108,4 @@ Curl_hash_next_element(struct Curl_hash_iterator *iter);
 void Curl_hash_print(struct Curl_hash *h,
                      void (*func)(void *));
 
-/* Hash for `curl_off_t` as key */
-void Curl_hash_offt_init(struct Curl_hash *h, size_t slots,
-                         Curl_hash_dtor dtor);
-
-void *Curl_hash_offt_set(struct Curl_hash *h, curl_off_t id, void *elem);
-int Curl_hash_offt_remove(struct Curl_hash *h, curl_off_t id);
-void *Curl_hash_offt_get(struct Curl_hash *h, curl_off_t id);
-
-
 #endif /* HEADER_CURL_HASH_H */

--- a/lib/hash_offt.c
+++ b/lib/hash_offt.c
@@ -69,7 +69,7 @@ hash_offt_mk_entry(curl_off_t id, void *value)
 {
   struct Curl_hash_offt_entry *e;
 
-  /* allocate the struct plus memory after it to store the key */
+  /* allocate the struct for the hash entry */
   e = malloc(sizeof(*e));
   if(e) {
     e->id = id;

--- a/lib/hash_offt.c
+++ b/lib/hash_offt.c
@@ -1,0 +1,242 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#include <curl/curl.h>
+
+#include "hash_offt.h"
+#include "curl_memory.h"
+
+/* The last #include file should be: */
+#include "memdebug.h"
+
+/* random patterns for API verification */
+#ifdef DEBUGBUILD
+#define CURL_HASHOFFTINIT 0x7117e781
+#endif
+
+static size_t hash_offt_hash(curl_off_t id, size_t slots)
+{
+  return (size_t)((id >= 0) ? (id % slots) : (-id % slots));
+}
+
+struct Curl_hash_offt_entry {
+  curl_off_t id;
+  struct Curl_hash_offt_entry *next;
+  void   *value;
+};
+
+void Curl_hash_offt_init(struct Curl_hash_offt *h,
+                         size_t slots,
+                         Curl_hash_offt_dtor *dtor)
+{
+  DEBUGASSERT(h);
+  DEBUGASSERT(slots);
+
+  h->table = NULL;
+  h->dtor = dtor;
+  h->size = 0;
+  h->slots = slots;
+#ifdef DEBUGBUILD
+  h->init = CURL_HASHOFFTINIT;
+#endif
+}
+
+static struct Curl_hash_offt_entry *
+hash_offt_mk_entry(curl_off_t id, void *value)
+{
+  struct Curl_hash_offt_entry *e;
+
+  /* allocate the struct plus memory after it to store the key */
+  e = malloc(sizeof(*e));
+  if(e) {
+    e->id = id;
+    e->next = NULL;
+    e->value = value;
+  }
+  return e;
+}
+
+static void hash_offt_entry_clear(struct Curl_hash_offt *h,
+                                  struct Curl_hash_offt_entry *e)
+{
+  DEBUGASSERT(h);
+  DEBUGASSERT(e);
+  if(e->value) {
+    if(h->dtor)
+      h->dtor(e->id, e->value);
+    e->value = NULL;
+  }
+}
+
+static void hash_offt_entry_destroy(struct Curl_hash_offt *h,
+                                    struct Curl_hash_offt_entry *e)
+{
+  hash_offt_entry_clear(h, e);
+  free(e);
+}
+
+static void hash_offt_entry_unlink(struct Curl_hash_offt *h,
+                                   struct Curl_hash_offt_entry **he_anchor,
+                                   struct Curl_hash_offt_entry *he)
+{
+  *he_anchor = he->next;
+  --h->size;
+}
+
+static void hash_offtr_elem_link(struct Curl_hash_offt *h,
+                                 struct Curl_hash_offt_entry **he_anchor,
+                                 struct Curl_hash_offt_entry *he)
+{
+  he->next = *he_anchor;
+  *he_anchor = he;
+  ++h->size;
+}
+
+#define CURL_HASH_OFFT_SLOT(h,id)  h->table[hash_offt_hash(id, h->slots)]
+#define CURL_HASH_OFFT_SLOT_ADDR(h,id) &CURL_HASH_OFFT_SLOT(h,id)
+
+bool Curl_hash_offt_set(struct Curl_hash_offt *h, curl_off_t id, void *value)
+{
+  struct Curl_hash_offt_entry *he, **slot;
+
+  DEBUGASSERT(h);
+  DEBUGASSERT(h->slots);
+  DEBUGASSERT(h->init == CURL_HASHOFFTINIT);
+  if(!h->table) {
+    h->table = calloc(h->slots, sizeof(*he));
+    if(!h->table)
+      return FALSE; /* OOM */
+  }
+
+  slot = CURL_HASH_OFFT_SLOT_ADDR(h, id);
+  for(he = *slot; he; he = he->next) {
+    if(he->id == id) {
+      /* existing key entry, overwrite by clearing old pointer */
+      hash_offt_entry_clear(h, he);
+      he->value = value;
+      return TRUE;
+    }
+  }
+
+  he = hash_offt_mk_entry(id, value);
+  if(!he)
+    return FALSE; /* OOM */
+
+  hash_offtr_elem_link(h, slot, he);
+  return TRUE;
+}
+
+bool Curl_hash_offt_remove(struct Curl_hash_offt *h, curl_off_t id)
+{
+  DEBUGASSERT(h);
+  DEBUGASSERT(h->slots);
+  DEBUGASSERT(h->init == CURL_HASHOFFTINIT);
+  if(h->table) {
+    struct Curl_hash_offt_entry *he, **he_anchor;
+
+    he_anchor = CURL_HASH_OFFT_SLOT_ADDR(h, id);
+    while(*he_anchor) {
+      he = *he_anchor;
+      if(id == he->id) {
+        hash_offt_entry_unlink(h, he_anchor, he);
+        hash_offt_entry_destroy(h, he);
+        return TRUE;
+      }
+      he_anchor = &he->next;
+    }
+  }
+  return FALSE;
+}
+
+void *Curl_hash_offt_get(struct Curl_hash_offt *h, curl_off_t id)
+{
+  DEBUGASSERT(h);
+  DEBUGASSERT(h->init == CURL_HASHOFFTINIT);
+  if(h->table) {
+    struct Curl_hash_offt_entry *he;
+    DEBUGASSERT(h->slots);
+    he = CURL_HASH_OFFT_SLOT(h, id);
+    while(he) {
+      if(id == he->id) {
+        return he->value;
+      }
+      he = he->next;
+    }
+  }
+  return NULL;
+}
+
+void Curl_hash_offt_clear(struct Curl_hash_offt *h)
+{
+  if(h && h->table) {
+    struct Curl_hash_offt_entry *he, **he_anchor;
+    size_t i;
+    DEBUGASSERT(h->init == CURL_HASHOFFTINIT);
+    for(i = 0; i < h->slots; ++i) {
+      he_anchor = &h->table[i];
+      while(*he_anchor) {
+        he = *he_anchor;
+        hash_offt_entry_unlink(h, he_anchor, he);
+        hash_offt_entry_destroy(h, he);
+      }
+    }
+  }
+}
+
+void
+Curl_hash_offt_destroy(struct Curl_hash_offt *h)
+{
+  DEBUGASSERT(h->init == CURL_HASHOFFTINIT);
+  if(h->table) {
+    Curl_hash_offt_clear(h);
+    Curl_safefree(h->table);
+  }
+  DEBUGASSERT(h->size == 0);
+  h->slots = 0;
+}
+
+size_t Curl_hash_offt_count(struct Curl_hash_offt *h)
+{
+  DEBUGASSERT(h->init == CURL_HASHOFFTINIT);
+  return h->size;
+}
+
+void Curl_hash_offt_visit(struct Curl_hash_offt *h,
+                          Curl_hash_offt_visit_cb *cb,
+                          void *user_data)
+{
+  if(h && h->table && cb) {
+    struct Curl_hash_offt_entry *he;
+    size_t i;
+    DEBUGASSERT(h->init == CURL_HASHOFFTINIT);
+    for(i = 0; i < h->slots; ++i) {
+      for(he = h->table[i]; he; he = he->next) {
+        if(!cb(he->id, he->value, user_data))
+          return;
+      }
+    }
+  }
+}

--- a/lib/hash_offt.h
+++ b/lib/hash_offt.h
@@ -1,0 +1,67 @@
+#ifndef HEADER_CURL_HASH_OFFT_H
+#define HEADER_CURL_HASH_OFFT_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#include <stddef.h>
+
+#include "llist.h"
+
+struct Curl_hash_offt_entry;
+typedef void Curl_hash_offt_dtor(curl_off_t id, void *value);
+
+/* Hash for `curl_off_t` as key */
+struct Curl_hash_offt {
+  struct Curl_hash_offt_entry **table;
+  Curl_hash_offt_dtor *dtor;
+  size_t slots;
+  size_t size;
+#ifdef DEBUGBUILD
+  int init;
+#endif
+};
+
+void Curl_hash_offt_init(struct Curl_hash_offt *h,
+                         size_t slots,
+                         Curl_hash_offt_dtor *dtor);
+void Curl_hash_offt_destroy(struct Curl_hash_offt *h);
+
+bool Curl_hash_offt_set(struct Curl_hash_offt *h, curl_off_t id, void *value);
+bool Curl_hash_offt_remove(struct Curl_hash_offt *h, curl_off_t id);
+void *Curl_hash_offt_get(struct Curl_hash_offt *h, curl_off_t id);
+void Curl_hash_offt_clear(struct Curl_hash_offt *h);
+size_t Curl_hash_offt_count(struct Curl_hash_offt *h);
+
+
+typedef bool Curl_hash_offt_visit_cb(curl_off_t id, void *value,
+                                     void *user_data);
+
+void Curl_hash_offt_visit(struct Curl_hash_offt *h,
+                          Curl_hash_offt_visit_cb *cb,
+                          void *user_data);
+
+
+#endif /* HEADER_CURL_HASH_OFFT_H */

--- a/lib/multi_ev.h
+++ b/lib/multi_ev.h
@@ -24,14 +24,17 @@
  *
  ***************************************************************************/
 
+#include "hash.h"
+#include "hash_offt.h"
+
 struct Curl_easy;
 struct Curl_multi;
 struct easy_pollset;
 
 struct curl_multi_ev {
   struct Curl_hash sh_entries;
-  struct Curl_hash xfer_pollsets;
-  struct Curl_hash conn_pollsets;
+  struct Curl_hash_offt xfer_pollsets;
+  struct Curl_hash_offt conn_pollsets;
 };
 
 /* Setup/teardown of multi event book-keeping. */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -159,6 +159,7 @@ typedef unsigned int curl_prot_t;
 #include "http_chunks.h" /* for the structs and enum stuff */
 #include "hostip.h"
 #include "hash.h"
+#include "hash_offt.h"
 #include "splay.h"
 #include "dynbuf.h"
 #include "dynhds.h"

--- a/tests/unit/unit1616.c
+++ b/tests/unit/unit1616.c
@@ -25,15 +25,16 @@
 
 #include "curlx.h"
 
-#include "hash.h"
+#include "hash_offt.h"
 
 #include "memdebug.h" /* LAST include file */
 
-static struct Curl_hash hash_static;
+static struct Curl_hash_offt hash_static;
 
-static void mydtor(void *elem)
+static void mydtor(curl_off_t id, void *elem)
 {
   int *ptr = (int *)elem;
+  (void)id;
   free(ptr);
 }
 
@@ -45,13 +46,13 @@ static CURLcode unit_setup(void)
 
 static void unit_stop(void)
 {
-  Curl_hash_destroy(&hash_static);
+  Curl_hash_offt_destroy(&hash_static);
 }
 
 UNITTEST_START
   int *value, *v;
   int *value2;
-  int *nodep;
+  bool ok;
 
   curl_off_t key = 20;
   curl_off_t key2 = 25;
@@ -60,24 +61,24 @@ UNITTEST_START
   value = malloc(sizeof(int));
   abort_unless(value != NULL, "Out of memory");
   *value = 199;
-  nodep = Curl_hash_offt_set(&hash_static, key, value);
-  if(!nodep)
+  ok = Curl_hash_offt_set(&hash_static, key, value);
+  if(!ok)
     free(value);
-  abort_unless(nodep, "insertion into hash failed");
+  abort_unless(ok, "insertion into hash failed");
   v = Curl_hash_offt_get(&hash_static, key);
   abort_unless(v == value, "lookup present entry failed");
   v = Curl_hash_offt_get(&hash_static, key2);
   abort_unless(!v, "lookup missing entry failed");
-  Curl_hash_clean(&hash_static);
+  Curl_hash_offt_clear(&hash_static);
 
   /* Attempt to add another key/value pair */
   value2 = malloc(sizeof(int));
   abort_unless(value2 != NULL, "Out of memory");
   *value2 = 204;
-  nodep = Curl_hash_offt_set(&hash_static, key2, value2);
-  if(!nodep)
+  ok = Curl_hash_offt_set(&hash_static, key2, value2);
+  if(!ok)
     free(value2);
-  abort_unless(nodep, "insertion into hash failed");
+  abort_unless(ok, "insertion into hash failed");
   v = Curl_hash_offt_get(&hash_static, key2);
   abort_unless(v == value2, "lookup present entry failed");
   v = Curl_hash_offt_get(&hash_static, key);


### PR DESCRIPTION
Add a standalone hash table for curl_offt_t as key. This allows a smaller memory footprint and faster lookups as we do not need to deal with variable key lengths.

Use in all places we had the standard hash for this purpose.