### PR TITLE
docs: bump `rustls` to 0.14.1

### DIFF
--- a/docs/RUSTLS.md
+++ b/docs/RUSTLS.md
@@ -9,7 +9,7 @@ SPDX-License-Identifier: curl
 [Rustls is a TLS backend written in Rust](https://docs.rs/rustls/). curl can
 be built to use it as an alternative to OpenSSL or other TLS backends. We use
 the [rustls-ffi C bindings](https://github.com/rustls/rustls-ffi/). This
-version of curl depends on version v0.14.0 of rustls-ffi.
+version of curl is compatible with `rustls-ffi` v0.14.x.
 
 # Building with Rustls
 
@@ -17,7 +17,7 @@ First, [install Rust](https://rustup.rs/).
 
 Next, check out, build, and install the appropriate version of rustls-ffi:
 
-    % git clone https://github.com/rustls/rustls-ffi -b v0.14.0
+    % git clone https://github.com/rustls/rustls-ffi -b v0.14.1
     % cd rustls-ffi
     % make
     % make DESTDIR=${HOME}/rustls-ffi-built/ install


### PR DESCRIPTION
Tested this locally, but it's also the version used on CI, so it should be fine.