### PR TITLE
ci: use stable Rust toolchain for `rustls` and skip installing the docs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -560,7 +560,7 @@ jobs:
           cd $HOME
           curl -sSf --compressed https://sh.rustup.rs/ | sh -s -- -y
           source $HOME/.cargo/env
-          rustup toolchain install nightly
+          rustup toolchain install stable --profile minimal
 
       - name: 'build rustls'
         if: contains(matrix.build.install_steps, 'rustls') && steps.cache-rustls.outputs.cache-hit != 'true'


### PR DESCRIPTION
I think it builds on `stable` (or `beta`, at least), so there's no reason to use `nightly`. Also, use the `minimal` profile to skip installing the docs.

It probably won't make a difference (because of caching), but it should be more reliable in the long run.