### PR TITLE
delta: get contributors without changing THANKS

### DIFF
--- a/scripts/contrithanks.sh
+++ b/scripts/contrithanks.sh
@@ -24,8 +24,7 @@
 ###########################################################################
 
 #
-# This script shows all mentioned contributors from <hash> until HEAD and
-# puts them at the end of the THANKS document on stdout
+# This script updates the docs/THANKS document.
 #
 
 set -eu
@@ -35,6 +34,13 @@ start="${1:-}"
 if test "$start" = "-h"; then
   echo "Usage: $0 <since this tag/hash>"
   exit
+fi
+if test "$start" = "stdout"; then
+    # output the names on stdout
+    use_stdout="yes"
+    start=""
+else
+    use_stdout="no";
 fi
 if test -z "$start"; then
   start=$(git tag --sort=taggerdate | grep "^curl-" | tail -1)
@@ -77,8 +83,10 @@ sed -f ./docs/THANKS-filter | \
 sort -fu | \
 grep -aixvFf ./docs/THANKS >> $rand
 
-# output header
-cat <<EOF >./docs/THANKS
+if test "$use_stdout" = "no"; then
+
+  # output header
+  cat <<EOF >./docs/THANKS
  This project has been alive for many years. Countless people have provided
  feedback that have improved curl. Here follows a list of people that have
  contributed (a-z order).
@@ -86,8 +94,12 @@ cat <<EOF >./docs/THANKS
  If you have contributed but are missing here, please let us know!
 
 EOF
-# append all the names, sorted case insensitively
-grep -v "^ " $rand | sort -f $rand >> ./docs/THANKS
+  # append all the names, sorted case insensitively
+  grep -v "^ " $rand | sort -f $rand >> ./docs/THANKS
+else
+  # send all names on stdout
+  grep -v "^ " $rand | sort -f $rand
+fi
 
 # get rid of the temp file
 rm $rand

--- a/scripts/delta
+++ b/scripts/delta
@@ -52,7 +52,7 @@ $acommitters = `git shortlog -s | wc -l`;
 $ncommitters = $acommitters - $bcommitters;
 
 # number of contributors right now
-$acontribs = `./scripts/contrithanks.sh | grep -c '^[^ ]'`;
+$acontribs = `./scripts/contrithanks.sh stdout | wc -l`;
 # number when the tag was set
 $bcontribs = `git show $start:docs/THANKS | grep -c '^[^ ]'`;
 # delta


### PR DESCRIPTION
Give contrithanks.sh the option to send the list of names to stdout so that delta can use it appropriately for counting.