### PR TITLE
urldata: remove 'hostname' from struct Curl_async

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -592,7 +592,7 @@ static void query_completed_cb(void *arg,  /* (struct connectdata *) */
   res->num_pending--;
 
   if(CURL_ASYNC_SUCCESS == status) {
-    struct Curl_addrinfo *ai = Curl_he2ai(hostent, data->state.async.port);
+    struct Curl_addrinfo *ai = Curl_he2ai(hostent, data->conn->localport);
     if(ai) {
       compound_results(res, ai);
     }
@@ -774,8 +774,6 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
   if(!res->hostname)
     return NULL;
 
-  data->state.async.hostname = res->hostname;
-  data->state.async.port = port;
   data->state.async.done = FALSE;   /* not done */
   data->state.async.dns = NULL;     /* clear */
 
@@ -811,6 +809,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
                      service, &hints, addrinfo_cb, data);
   }
 #else
+  (void)port;
 
 #ifdef HAVE_CARES_IPV6
   if((data->conn->ip_version != CURL_IPRESOLVE_V4) && Curl_ipv6works(data)) {

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -400,7 +400,7 @@ static void destroy_async_data(struct Curl_easy *data)
 
     td->init = FALSE;
   }
-  Curl_safefree(async->hostname);
+
 }
 
 #ifdef USE_HTTPSRR_ARES
@@ -414,7 +414,7 @@ static CURLcode resolve_httpsrr(struct Curl_easy *data,
   memset(&async->thdata.hinfo, 0, sizeof(struct Curl_https_rrinfo));
   async->thdata.hinfo.port = -1;
   ares_query_dnsrec(async->thdata.channel,
-                    async->hostname, ARES_CLASS_IN,
+                    data->conn->host.name, ARES_CLASS_IN,
                     ARES_REC_TYPE_HTTPS,
                     Curl_dnsrec_done_cb, data, NULL);
 
@@ -436,7 +436,6 @@ static bool init_resolve_thread(struct Curl_easy *data,
   int err = ENOMEM;
   struct Curl_async *async = &data->state.async;
 
-  async->port = port;
   async->done = FALSE;
   async->dns = NULL;
   td->thread_hnd = curl_thread_t_null;
@@ -446,11 +445,6 @@ static bool init_resolve_thread(struct Curl_easy *data,
     free(td);
     goto errno_exit;
   }
-
-  free(async->hostname);
-  async->hostname = strdup(hostname);
-  if(!async->hostname)
-    goto err_exit;
 
   /* The thread will set this TRUE when complete. */
   td->tsd.done = FALSE;

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -1181,7 +1181,7 @@ CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
 
   if(dohp->probe[DOH_SLOT_IPV4].easy_mid < 0 &&
      dohp->probe[DOH_SLOT_IPV6].easy_mid < 0) {
-    failf(data, "Could not DoH-resolve: %s", data->state.async.hostname);
+    failf(data, "Could not DoH-resolve: %s", dohp->host);
     return CONN_IS_PROXIED(data->conn) ? CURLE_COULDNT_RESOLVE_PROXY :
       CURLE_COULDNT_RESOLVE_HOST;
   }

--- a/lib/hostasyn.c
+++ b/lib/hostasyn.c
@@ -76,8 +76,8 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
         Curl_share_lock(data, CURL_LOCK_DATA_DNS, CURL_LOCK_ACCESS_SINGLE);
 
       dns = Curl_cache_addr(data, ai,
-                            data->state.async.hostname, 0,
-                            data->state.async.port, FALSE);
+                            data->conn->host.dispname, 0,
+                            data->conn->localport, FALSE);
       if(data->share)
         Curl_share_unlock(data, CURL_LOCK_DATA_DNS);
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1480,7 +1480,7 @@ CURLcode Curl_resolver_error(struct Curl_easy *data)
   }
 
   failf(data, "Could not resolve %s: %s", host_or_proxy,
-        data->state.async.hostname);
+        data->conn->host.dispname);
 
   return result;
 }

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -565,14 +565,12 @@ struct hostname {
 #if defined(CURLRES_ASYNCH) || !defined(CURL_DISABLE_DOH)
 #define USE_CURL_ASYNC
 struct Curl_async {
-  char *hostname;
   struct Curl_dns_entry *dns;
 #ifdef CURLRES_ASYNCH
   struct thread_data thdata;
 #endif
   void *resolver; /* resolver state, if it is used in the URL state -
                      ares_channel e.g. */
-  int port;
   BIT(done);  /* set TRUE when the lookup is complete */
 };
 


### PR DESCRIPTION
It is unnecessary duplicated information, as the host name being resolved is already present in conn->host.