### PR TITLE
tls: Make rustls support CURLINFO_CERTINFO

### DIFF
--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -62,7 +62,7 @@ The variables available are:
 
 ## `certs`
 Output the certificate chain with details. Supported only by the OpenSSL,
-GnuTLS, Schannel and Secure Transport backends. (Added in 7.88.0)
+GnuTLS, Schannel, Rustls, and Secure Transport backends. (Added in 7.88.0)
 
 ## `conn_id`
 The connection identifier last used by the transfer. The connection id is
@@ -128,7 +128,7 @@ The http method used in the most recent HTTP request. (Added in 7.72.0)
 
 ## `num_certs`
 Number of server certificates received in the TLS handshake. Supported only by
-the OpenSSL, GnuTLS, Schannel and Secure Transport backends.
+the OpenSSL, GnuTLS, Schannel, Rustls and Secure Transport backends.
 (Added in 7.88.0)
 
 ## `num_connects`

--- a/docs/libcurl/opts/CURLINFO_CERTINFO.md
+++ b/docs/libcurl/opts/CURLINFO_CERTINFO.md
@@ -15,6 +15,7 @@ TLS-backend:
   - GnuTLS
   - Schannel
   - Secure Transport
+  - rustls
 Added-in: 7.19.1
 ---
 

--- a/docs/libcurl/opts/CURLOPT_CERTINFO.md
+++ b/docs/libcurl/opts/CURLOPT_CERTINFO.md
@@ -17,6 +17,7 @@ TLS-backend:
   - GnuTLS
   - Schannel
   - Secure Transport
+  - rustls
 Added-in: 7.19.1
 ---
 

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -26,15 +26,15 @@
 
 #if defined(USE_GNUTLS) || defined(USE_WOLFSSL) ||      \
   defined(USE_SCHANNEL) || defined(USE_SECTRANSP) ||    \
-  defined(USE_MBEDTLS)
+  defined(USE_MBEDTLS) || defined(USE_RUSTLS)
 
 #if defined(USE_GNUTLS) || defined(USE_SCHANNEL) || defined(USE_SECTRANSP) || \
-  defined(USE_MBEDTLS) || defined(USE_WOLFSSL)
+  defined(USE_MBEDTLS) || defined(USE_WOLFSSL) || defined(USE_RUSTLS)
 #define WANT_PARSEX509 /* uses Curl_parseX509() */
 #endif
 
 #if defined(USE_GNUTLS) || defined(USE_SCHANNEL) || defined(USE_SECTRANSP) || \
-  defined(USE_MBEDTLS)
+  defined(USE_MBEDTLS) || defined(USE_RUSTLS)
 #define WANT_EXTRACT_CERTINFO /* uses Curl_extract_certinfo() */
 #endif
 
@@ -1277,4 +1277,5 @@ done:
 
 #endif /* WANT_EXTRACT_CERTINFO */
 
-#endif /* USE_GNUTLS or USE_WOLFSSL or USE_SCHANNEL or USE_SECTRANSP */
+#endif /* USE_GNUTLS or USE_WOLFSSL or USE_SCHANNEL or USE_SECTRANSP
+          or USE_MBEDTLS or USE_RUSTLS */

--- a/lib/vtls/x509asn1.h
+++ b/lib/vtls/x509asn1.h
@@ -29,7 +29,7 @@
 
 #if defined(USE_GNUTLS) || defined(USE_WOLFSSL) || \
   defined(USE_SCHANNEL) || defined(USE_SECTRANSP) || \
-  defined(USE_MBEDTLS)
+  defined(USE_MBEDTLS) || defined(USE_RUSTLS)
 
 #include "cfilters.h"
 #include "urldata.h"
@@ -80,7 +80,7 @@ CURLcode Curl_verifyhost(struct Curl_cfilter *cf, struct Curl_easy *data,
 
 #ifdef UNITTESTS
 #if defined(USE_GNUTLS) || defined(USE_SCHANNEL) || defined(USE_SECTRANSP) || \
-  defined(USE_MBEDTLS)
+  defined(USE_MBEDTLS) || defined(USE_RUSTLS)
 
 /* used by unit1656.c */
 CURLcode Curl_x509_GTime2str(struct dynbuf *store,
@@ -91,5 +91,6 @@ CURLcode Curl_x509_getASN1Element(struct Curl_asn1Element *elem,
 #endif
 #endif
 
-#endif /* USE_GNUTLS or USE_WOLFSSL or USE_SCHANNEL or USE_SECTRANSP */
+#endif /* USE_GNUTLS or USE_WOLFSSL or USE_SCHANNEL or USE_SECTRANSP
+          or USE_MBEDTLS or USE_RUSTLS */
 #endif /* HEADER_CURL_X509ASN1_H */

--- a/tests/data/test3102
+++ b/tests/data/test3102
@@ -20,7 +20,6 @@ HTTP GET
 <features>
 SSL
 !bearssl
-!rustls
 !wolfssl
 </features>
 <server>

--- a/tests/data/test417
+++ b/tests/data/test417
@@ -25,7 +25,6 @@ SSL
 !wolfssl
 !bearssl
 !mbedtls
-!rustls
 </features>
 <server>
 http


### PR DESCRIPTION
This allows you to use the `certs` and `num_certs` writeout variables in the curl tool, and getting information about the server certificates using CURLINFO_CERTINFO.