### PR TITLE
runtests: recognize AWS-LC as OpenSSL

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -569,7 +569,7 @@ sub checksystemfeatures {
                 $feature{"sectransp"} = 1;
                 $feature{"SSLpinning"} = 1;
             }
-            elsif ($libcurl =~ /\sBoringSSL\b/i) {
+            elsif ($libcurl =~ /\s(BoringSSL|AWS-LC)\b/i) {
                 # OpenSSL compatible API
                 $feature{"OpenSSL"} = 1;
                 $feature{"SSLpinning"} = 1;


### PR DESCRIPTION
Fixes (GHA/linux, AWS-LC jobs):
```
test 0307 SKIPPED: curl lacks OpenSSL support
test 0308 SKIPPED: curl lacks OpenSSL support
[...]
```
Ref: https://github.com/curl/curl/actions/runs/13511134270/job/37751473424#step:42:104

Follow-up to 34ef4fab22d93cf7ef1d6c2954a0bad19f323ea9 #10320
