### PR TITLE
runtests: drop recognizing 'winssl' as Schannel

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -950,7 +950,6 @@ winbuild
 WinIDN
 WinLDAP
 winsock
-winssl
 Wireshark
 wolfSSH
 wolfSSL

--- a/tests/CI.md
+++ b/tests/CI.md
@@ -36,7 +36,7 @@ Consider the following table while looking at pull request failures:
  | FreeBSD FreeBSD: ...                | stable | all errors and failures    |
  | LGTM analysis: Python               | stable | new findings               |
  | LGTM analysis:  C/C++               | stable | new findings               |
- | buildbot/curl_winssl_ ...           | stable | all errors and failures    |
+ | buildbot/curl_schannel_ ...         | stable | all errors and failures    |
  | AppVeyor                            | flaky  | all errors and failures    |
  | curl.curl (linux ...)               | stable | all errors and failures    |
  | curl.curl (windows ...)             | flaky  | repetitive errors/failures |

--- a/tests/CI.md
+++ b/tests/CI.md
@@ -36,7 +36,7 @@ Consider the following table while looking at pull request failures:
  | FreeBSD FreeBSD: ...                | stable | all errors and failures    |
  | LGTM analysis: Python               | stable | new findings               |
  | LGTM analysis:  C/C++               | stable | new findings               |
- | buildbot/curl_schannel_ ...         | stable | all errors and failures    |
+ | buildbot/curl_Schannel_ ...         | stable | all errors and failures    |
  | AppVeyor                            | flaky  | all errors and failures    |
  | curl.curl (linux ...)               | stable | all errors and failures    |
  | curl.curl (windows ...)             | flaky  | repetitive errors/failures |

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -543,7 +543,7 @@ sub checksystemfeatures {
                 $pwd = sys_native_current_path();
                 $feature{"win32"} = 1;
             }
-            if ($libcurl =~ /\s(winssl|schannel)\b/i) {
+            if ($libcurl =~ /\sschannel\b/i) {
                 $feature{"Schannel"} = 1;
                 $feature{"SSLpinning"} = 1;
             }


### PR DESCRIPTION
Follow-up to 180501cb0220c8451a38dc8ae04b6c58743025a8 #3504