### PR TITLE
openssl: check return value of X509_get0_pubkey

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4534,7 +4534,7 @@ static void infof_certstack(struct Curl_easy *data, const SSL *ssl)
                                                sizeof(group_name), NULL);
       msnprintf(group_name_final, sizeof(group_name_final), "/%s", group_name);
     }
-    type_name = EVP_PKEY_get0_type_name(current_pkey);
+    type_name = current_pkey ? EVP_PKEY_get0_type_name(current_pkey) : NULL;
 #else
     get_group_name = 0;
     type_name = NULL;


### PR DESCRIPTION
closes #16468 

This PR improves null check to avoid segfault when a certificate doesn't contain a public key.
`infof_certstack` is used for debug/information purposes so this PR doesn't create any functional change to curl.