### PR TITLE
GHA/http3-linux: build out-of-tree, make test2502 support it

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -434,46 +434,47 @@ jobs:
             export PKG_CONFIG_PATH="${{ matrix.build.PKG_CONFIG_PATH }}"
           fi
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake -B . -G Ninja \
+            cmake -B bld -G Ninja \
               -DCMAKE_C_COMPILER_TARGET=$(uname -m)-pc-linux-gnu -DBUILD_STATIC_LIBS=ON \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \
               ${{ matrix.build.generate }}
           else
-            ./configure --disable-dependency-tracking --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
+            mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
+              --disable-dependency-tracking \
               ${{ matrix.build.configure }}
           fi
 
       - name: 'configure log'
         if: ${{ !cancelled() }}
-        run: cat config.log CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
+        run: cat bld/config.log bld/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
 
       - name: 'curl_config.h'
         run: |
-          echo '::group::raw'; cat lib/curl_config.h || true; echo '::endgroup::'
-          grep -F '#define' lib/curl_config.h | sort || true
+          echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
+          grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'test configs'
         run: |
-          cat tests/config || true
-          cat tests/http/config.ini || true
+          cat bld/tests/config || true
+          cat bld/tests/http/config.ini || true
 
       - name: 'build'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --verbose
+            cmake --build bld --verbose
           else
-            make V=1
+            make -C bld V=1
           fi
 
       - name: 'check curl -V output'
-        run: ./src/curl -V
+        run: bld/src/curl -V
 
       - name: 'build tests'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --verbose --target testdeps
+            cmake --build bld --verbose --target testdeps
           else
-            make V=1 -C tests
+            make -C bld V=1 -C tests
           fi
 
       - name: 'install test prereqs'
@@ -487,9 +488,9 @@ jobs:
         run: |
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --verbose --target test-ci
+            cmake --build bld --verbose --target test-ci
           else
-            make V=1 test-ci
+            make -C bld V=1 test-ci
           fi
 
       - name: 'install pytest prereqs'
@@ -506,15 +507,15 @@ jobs:
         run: |
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --verbose --target curl-pytest-ci
+            cmake --build bld --verbose --target curl-pytest-ci
           else
-            make V=1 pytest-ci
+            make -C bld V=1 pytest-ci
           fi
 
       - name: 'build examples'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build . --verbose --target curl-examples
+            cmake --build bld --verbose --target curl-examples
           else
-            make V=1 examples
+            make -C bld V=1 examples
           fi

--- a/tests/data/test2502
+++ b/tests/data/test2502
@@ -59,7 +59,7 @@ lib%TESTNUMBER
 HTTP GET multiple over HTTP/3
 </name>
 <command>
-https://%HOSTIP:%HTTP3PORT/path/%TESTNUMBER %HOSTIP %HTTP3PORT
+https://%HOSTIP:%HTTP3PORT/path/%TESTNUMBER %HOSTIP %HTTP3PORT %SRCDIR/certs/EdelCurlRoot-ca.cacert
 </command>
 </client>
 

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -75,6 +75,7 @@ void wait_ms(int ms)
 
 char *libtest_arg2 = NULL;
 char *libtest_arg3 = NULL;
+char *libtest_arg4 = NULL;
 int test_argc;
 char **test_argv;
 
@@ -200,6 +201,9 @@ int main(int argc, char **argv)
 
   if(argc > (basearg + 2))
     libtest_arg3 = argv[basearg + 2];
+
+  if(argc > (basearg + 2))
+    libtest_arg4 = argv[basearg + 3];
 
   URL = argv[basearg]; /* provide this to the rest */
 

--- a/tests/libtest/lib2502.c
+++ b/tests/libtest/lib2502.c
@@ -77,7 +77,7 @@ CURLcode test(char *URL)
     /* go http2 */
     easy_setopt(curl[i], CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_3ONLY);
     easy_setopt(curl[i], CURLOPT_CONNECTTIMEOUT_MS, (long)5000);
-    easy_setopt(curl[i], CURLOPT_CAINFO, "./certs/EdelCurlRoot-ca.cacert");
+    easy_setopt(curl[i], CURLOPT_CAINFO, libtest_arg4);
     /* wait for first connection established to see if we can share it */
     easy_setopt(curl[i], CURLOPT_PIPEWAIT, 1L);
     /* go verbose */

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -65,7 +65,7 @@
 
 extern char *libtest_arg2; /* set by first.c to the argv[2] or NULL */
 extern char *libtest_arg3; /* set by first.c to the argv[3] or NULL */
-extern char *libtest_arg4; /* set by first.c to the argv[3] or NULL */
+extern char *libtest_arg4; /* set by first.c to the argv[4] or NULL */
 
 /* argc and argv as passed in to the main() function */
 extern int test_argc;

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -65,6 +65,7 @@
 
 extern char *libtest_arg2; /* set by first.c to the argv[2] or NULL */
 extern char *libtest_arg3; /* set by first.c to the argv[3] or NULL */
+extern char *libtest_arg4; /* set by first.c to the argv[3] or NULL */
 
 /* argc and argv as passed in to the main() function */
 extern int test_argc;


### PR DESCRIPTION
To sync with the rest of core workflows.

Also fixup test2502 failing for out-of-tree builds due to:
```
== Info: error reading ca cert file ./certs/EdelCurlRoot-ca.cacert (Error while reading file.)
```
Ref: https://github.com/curl/curl/actions/runs/13525575035/job/37795171282?pr=16480#step:23:3608

Cherry-picked from #16480
