### PR TITLE
runtests: drop logic calling the `handle` tool (Windows)

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -158,7 +158,7 @@ if [ "${TFLAGS}" != 'skipall' ] && \
     time cmake --build _bld --config "${PRJ_CFG}" --target test-ci
   else
     (
-      TFLAGS="-a -p !flaky -r -rm ${TFLAGS}"
+      TFLAGS="-a -p !flaky -r ${TFLAGS}"
       cd _bld/tests
       time ./runtests.pl
     )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -107,7 +107,7 @@ curl_add_runtests(test-am        "-a -am")
 curl_add_runtests(test-full      "-a -p -r")
 # ~flaky means that it ignores results of tests using the flaky keyword
 curl_add_runtests(test-nonflaky  "-a -p ~flaky ~timing-dependent")
-curl_add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r -rm -j20")
+curl_add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r -j20")
 curl_add_runtests(test-torture   "-a -t -j20")
 curl_add_runtests(test-event     "-a -e")
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -144,7 +144,7 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r -rm -j20
+TEST_CI = $(TEST_NF) -r -j20
 
 PYTEST = pytest
 endif

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -88,7 +88,6 @@ use processhelp qw(
     );
 use servers qw(
     checkcmd
-    clearlocks
     initserverconfig
     serverfortest
     stopserver
@@ -1519,7 +1518,6 @@ sub runner_clearlocks {
     if(clearlogs()) {
         logmsg "Warning: log messages were lost\n";
     }
-    clearlocks($lockdir);
     return clearlogs();
 }
 

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1467,10 +1467,7 @@ sub ipcrecv {
     # print "ipcrecv $funcname\n";
     # Synchronously call the desired function
     my @res;
-    if($funcname eq "runner_clearlocks") {
-        @res = runner_clearlocks(@$argsarrayref);
-    }
-    elsif($funcname eq "runner_shutdown") {
+    if($funcname eq "runner_shutdown") {
         runner_shutdown(@$argsarrayref);
         # Special case: no response will be forthcoming
         return 1;
@@ -1503,16 +1500,6 @@ sub ipcrecv {
 
     return 0;
 }
-
-###################################################################
-# Kill the server processes that still have lock files in a directory
-sub runner_clearlocks {
-    if(clearlogs()) {
-        logmsg "Warning: log messages were lost\n";
-    }
-    return clearlogs();
-}
-
 
 ###################################################################
 # Kill all server processes

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -47,7 +47,6 @@ BEGIN {
         readtestkeywords
         restore_test_env
         runner_init
-        runnerac_clearlocks
         runnerac_shutdown
         runnerac_stopservers
         runnerac_test_preprocess
@@ -1275,12 +1274,6 @@ sub runner_test_run {
     return (0, clearlogs(), \%testtimings, $cmdres, $CURLOUT, $tool, $usedvalgrind);
 }
 
-# Async call runner_clearlocks
-# Called by controller
-sub runnerac_clearlocks {
-    return controlleripccall(\&runner_clearlocks, @_);
-}
-
 # Async call runner_shutdown
 # This call does NOT generate an IPC response and must be the last IPC call
 # received.
@@ -1474,10 +1467,7 @@ sub ipcrecv {
     # print "ipcrecv $funcname\n";
     # Synchronously call the desired function
     my @res;
-    if($funcname eq "runner_clearlocks") {
-        @res = runner_clearlocks(@$argsarrayref);
-    }
-    elsif($funcname eq "runner_shutdown") {
+    if($funcname eq "runner_shutdown") {
         runner_shutdown(@$argsarrayref);
         # Special case: no response will be forthcoming
         return 1;
@@ -1509,16 +1499,6 @@ sub ipcrecv {
     }
 
     return 0;
-}
-
-###################################################################
-# Kill the server processes that still have lock files in a directory
-sub runner_clearlocks {
-    my ($lockdir)=@_;
-    if(clearlogs()) {
-        logmsg "Warning: log messages were lost\n";
-    }
-    return clearlogs();
 }
 
 

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -47,6 +47,7 @@ BEGIN {
         readtestkeywords
         restore_test_env
         runner_init
+        runnerac_clearlocks
         runnerac_shutdown
         runnerac_stopservers
         runnerac_test_preprocess
@@ -1274,6 +1275,12 @@ sub runner_test_run {
     return (0, clearlogs(), \%testtimings, $cmdres, $CURLOUT, $tool, $usedvalgrind);
 }
 
+# Async call runner_clearlocks
+# Called by controller
+sub runnerac_clearlocks {
+    return controlleripccall(\&runner_clearlocks, @_);
+}
+
 # Async call runner_shutdown
 # This call does NOT generate an IPC response and must be the last IPC call
 # received.
@@ -1467,7 +1474,10 @@ sub ipcrecv {
     # print "ipcrecv $funcname\n";
     # Synchronously call the desired function
     my @res;
-    if($funcname eq "runner_shutdown") {
+    if($funcname eq "runner_clearlocks") {
+        @res = runner_clearlocks(@$argsarrayref);
+    }
+    elsif($funcname eq "runner_shutdown") {
         runner_shutdown(@$argsarrayref);
         # Special case: no response will be forthcoming
         return 1;
@@ -1499,6 +1509,16 @@ sub ipcrecv {
     }
 
     return 0;
+}
+
+###################################################################
+# Kill the server processes that still have lock files in a directory
+sub runner_clearlocks {
+    my ($lockdir)=@_;
+    if(clearlogs()) {
+        logmsg "Warning: log messages were lost\n";
+    }
+    return clearlogs();
 }
 
 

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -47,7 +47,6 @@ BEGIN {
         readtestkeywords
         restore_test_env
         runner_init
-        runnerac_clearlocks
         runnerac_shutdown
         runnerac_stopservers
         runnerac_test_preprocess
@@ -1273,12 +1272,6 @@ sub runner_test_run {
     restore_test_env(0);
 
     return (0, clearlogs(), \%testtimings, $cmdres, $CURLOUT, $tool, $usedvalgrind);
-}
-
-# Async call runner_clearlocks
-# Called by controller
-sub runnerac_clearlocks {
-    return controlleripccall(\&runner_clearlocks);
 }
 
 # Async call runner_shutdown

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1278,7 +1278,7 @@ sub runner_test_run {
 # Async call runner_clearlocks
 # Called by controller
 sub runnerac_clearlocks {
-    return controlleripccall(\&runner_clearlocks, @_);
+    return controlleripccall(\&runner_clearlocks);
 }
 
 # Async call runner_shutdown
@@ -1514,7 +1514,6 @@ sub ipcrecv {
 ###################################################################
 # Kill the server processes that still have lock files in a directory
 sub runner_clearlocks {
-    my ($lockdir)=@_;
     if(clearlogs()) {
         logmsg "Warning: log messages were lost\n";
     }

--- a/tests/runtests.md
+++ b/tests/runtests.md
@@ -219,11 +219,6 @@ Display run time statistics. (Requires the `Perl Time::HiRes` module)
 
 Display full run time statistics. (Requires the `Perl Time::HiRes` module)
 
-## `-rm`
-
-Force removal of files by killing locking processes. (Windows only, requires
-the **Sysinternals** `handle[64].exe` to be on PATH)
-
 ## `--repeat=[num]`
 
 This repeats the given set of test numbers this many times. If no test numbers

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1852,6 +1852,13 @@ sub singletest {
         # first, remove all lingering log & lock files
         if((!cleardir($logdir) || !cleardir("$logdir/$LOCKDIR"))
             && $clearlocks) {
+            # On Windows, lock files can't be deleted when the process still
+            # has them open, so kill those processes first
+            if(runnerac_clearlocks($runnerid, "$logdir/$LOCKDIR")) {
+                logmsg "ERROR: runner $runnerid seems to have died\n";
+                $singletest_state{$runnerid} = ST_INIT;
+                return (-1, 0);
+            }
             $singletest_state{$runnerid} = ST_CLEARLOCKS;
         } else {
             $singletest_state{$runnerid} = ST_INITED;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1852,13 +1852,6 @@ sub singletest {
         # first, remove all lingering log & lock files
         if((!cleardir($logdir) || !cleardir("$logdir/$LOCKDIR"))
             && $clearlocks) {
-            # On Windows, lock files can't be deleted when the process still
-            # has them open, so kill those processes first
-            if(runnerac_clearlocks($runnerid, "$logdir/$LOCKDIR")) {
-                logmsg "ERROR: runner $runnerid seems to have died\n";
-                $singletest_state{$runnerid} = ST_INIT;
-                return (-1, 0);
-            }
             $singletest_state{$runnerid} = ST_CLEARLOCKS;
         } else {
             $singletest_state{$runnerid} = ST_INITED;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1854,7 +1854,7 @@ sub singletest {
             && $clearlocks) {
             # On Windows, lock files can't be deleted when the process still
             # has them open, so kill those processes first
-            if(runnerac_clearlocks($runnerid, "$logdir/$LOCKDIR")) {
+            if(runnerac_clearlocks($runnerid)) {
                 logmsg "ERROR: runner $runnerid seems to have died\n";
                 $singletest_state{$runnerid} = ST_INIT;
                 return (-1, 0);

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1849,10 +1849,10 @@ sub singletest {
         my $logdir = getrunnerlogdir($runnerid);
         # first, remove all lingering log & lock files
         if(!cleardir($logdir)) {
-            logmsg "ERROR: $runnerid: cleardir($logdir) failed\n";
+            logmsg "Warning: $runnerid: cleardir($logdir) failed\n";
         }
         if(!cleardir("$logdir/$LOCKDIR")) {
-            logmsg "ERROR: $runnerid: cleardir($logdir/$LOCKDIR) failed\n";
+            logmsg "Warning: $runnerid: cleardir($logdir/$LOCKDIR) failed\n";
         }
 
         $singletest_state{$runnerid} = ST_INITED;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2435,10 +2435,6 @@ while(@ARGV) {
             $fullstats=1;
         }
     }
-    elsif($ARGV[0] eq "-rm") {
-        # force removal of files by killing locking processes
-        $clearlocks=1;
-    }
     elsif($ARGV[0] eq "-u") {
         # error instead of warning on server unexpectedly alive
         $err_unexpected=1;
@@ -2472,7 +2468,6 @@ Usage: runtests.pl [options] [test selection(s)]
   -R       scrambled order (uses the random seed, see --seed)
   -r       run time statistics
   -rf      full run time statistics
-  -rm      force removal of files by killing locking processes (Windows only)
   --repeat=[num] run the given tests this many times
   -s       short output
   --seed=[num] set the random seed to a fixed number

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -160,7 +160,6 @@ my $globalabort; # flag signalling program abort
 # values for $singletest_state
 use constant {
     ST_INIT => 0,
-    ST_CLEARLOCKS => 1,
     ST_INITED => 2,
     ST_PREPROCESS => 3,
     ST_RUN => 4,
@@ -1856,21 +1855,6 @@ sub singletest {
             logmsg "ERROR: $runnerid: cleardir($logdir/$LOCKDIR) failed\n";
         }
 
-        $singletest_state{$runnerid} = ST_INITED;
-        # Recursively call the state machine again because there is no
-        # event expected that would otherwise trigger a new call.
-        return singletest(@_);
-
-    } elsif($singletest_state{$runnerid} == ST_CLEARLOCKS) {
-        my ($rid, $logs) = runnerar($runnerid);
-        if(!$rid) {
-            logmsg "ERROR: runner $runnerid seems to have died\n";
-            $singletest_state{$runnerid} = ST_INIT;
-            return (-1, 0);
-        }
-        logmsg $logs;
-        my $logdir = getrunnerlogdir($runnerid);
-        cleardir($logdir);
         $singletest_state{$runnerid} = ST_INITED;
         # Recursively call the state machine again because there is no
         # event expected that would otherwise trigger a new call.


### PR DESCRIPTION
In the cases observed throughout the last year, `handle64` run once per
test run, but with no action (match or task kill). It did not help with
flakiness and seems redundant.

runtests launched it (if present) in Cygwin/MSYS jobs too, where it
probably shouldn't have, because we have seen no flakiness there. In CI
the tool was present and launched in MSYS2 jobs, but not in Cygwin.

After this patch the "clearlocks" warning remain in the log. They are
consistently appearing once in every MSVC CI log, early in the tests:
```
  test 3207 SKIPPED: curl lacks OpenSSL support
[...START-OF-TESTS...]
  test 0003...[HTTP POST with auth and contents but with content-length set to 0]
  --pd---e--- OK (3   out of 1596, remaining: 17:50, took 1.423s, duration: 00:02)
  test 0007...[HTTP with cookie parser and header recording]
  --pd--oe--- OK (7   out of 1596, remaining: 07:51, took 1.485s, duration: 00:02)
  test 0006...[HTTP with simple cookie send]
  --pd---e--- OK (6   out of 1596, remaining: 09:11, took 1.488s, duration: 00:02)
  test 0005...[HTTP over proxy]
  --pd---e--- OK (5   out of 1596, remaining: 11:03, took 1.491s, duration: 00:02)
CUSTOMBUILD : error : 169: cleardir(log/8/lock) failed [D:\a\curl\curl\bld\tests\test-ci.vcxproj]
  test 0001...[HTTP GET]
  --pd---e--- OK (1   out of 1596, remaining: 55:34, took 1.466s, duration: 00:02)
  test 0004...[Replaced internal and added custom HTTP headers]
```
Ref: https://github.com/curl/curl/actions/runs/13546192228/job/37858323380?pr=16484#step:14:167

Ref: e53523fef07894991c69d907a7c7794c7ada4ff4 #14859
Ref: 311c31ec8e721b11ba77adf7a3865cf0cd30aa42 #6179
Follow-up to 3a8920e5edaead8304a818594f54485a5564f976 #16600
