### PR TITLE
libtest/libprereq.c: set CURLOPT_FOLLOWLOCATION with a long

### DIFF
--- a/tests/libtest/libprereq.c
+++ b/tests/libtest/libprereq.c
@@ -80,7 +80,7 @@ CURLcode test(char *URL)
 
     if(strstr(URL, "#redir")) {
       /* Enable follow-location */
-      curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1);
+      curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
     }
 
     ret = curl_easy_perform(curl);


### PR DESCRIPTION
Previously this used '1', which as an int. The option needs a long.