### PR TITLE
test1167: catch #defines with extra whitespace

### DIFF
--- a/tests/test1167.pl
+++ b/tests/test1167.pl
@@ -124,7 +124,7 @@ sub scanheader {
     open H, "<$f";
     while(<H>) {
         my ($line, $linenum) = ($_, $.);
-        if (/^#define +([^ \n]*)/) {
+        if (/^ *# *define +([^ \n]*)/) {
             if($verbose) {
                 print "Source: $f\n";
                 print "Symbol: $1\n";


### PR DESCRIPTION
Before this patch, it missed this in `curl/curl.h`:
```c
#  define __has_declspec_attribute(x) 0
```
After this patch:
```
test 1167...[Verify curl prefix of public symbols in header files]
/usr/bin/perl -I. -I.  returned 1, when expecting 0
 1167: exit FAILED
== Contents of files in the log/14/ dir after test 1167
=== Start of file server.cmd
 Testnum 1167
=== End of file server.cmd
=== Start of file stdout1167
 Bad symbols in public header files:
   __has_declspec_attribute(x)
=== End of file stdout1167
FAIL 1167: 'Verify curl prefix of public symbols in header files' source analysis
TESTFAIL: These test cases failed: 1167
```

Ref: #16491

---

- [x] rebase on #16491 to fix the new catch.
