### PR TITLE
GHA: tidy up parallel options, improve performance for some jobs

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -19,12 +19,13 @@ concurrency:
 
 permissions: {}
 
+env:
+  MAKEFLAGS: -j 5
+
 jobs:
   maketgz-and-verify-in-tree:
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      MAKEFLAGS: -j 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -23,6 +23,8 @@ jobs:
   maketgz-and-verify-in-tree:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      MAKEFLAGS: -j 5
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -55,9 +57,9 @@ jobs:
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
           ./configure --prefix=$HOME/temp --without-ssl --without-libpsl
-          make -j5
-          make -j5 test-ci
-          make -j5 install
+          make
+          make test-ci
+          make install
           popd
           # basic check of the installed files
           bash scripts/installcheck.sh $HOME/temp
@@ -80,8 +82,8 @@ jobs:
           mkdir build
           pushd build
           ../curl-99.98.97/configure --without-ssl --without-libpsl
-          make -j5
-          make -j5 test-ci
+          make
+          make test-ci
           popd
           rm -rf build
           rm -rf curl-99.98.97
@@ -103,9 +105,9 @@ jobs:
           mkdir build
           pushd build
           ../configure --without-ssl --enable-debug "--prefix=${PWD}/pkg" --without-libpsl
-          make -j5
-          make -j5 test-ci
-          make -j5 install
+          make
+          make test-ci
+          make install
 
   verify-out-of-tree-cmake:
     runs-on: ubuntu-latest
@@ -122,7 +124,7 @@ jobs:
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
           cmake -B build -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF
-          make -C build -j5
+          make -C build
 
   missing-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,8 +47,8 @@ permissions: {}
 # newer than the 10.8 required by `CFURLCreateDataAndPropertiesFromResource`.
 
 env:
-  LDFLAGS: -w  # suppress 'object file was built for newer macOS version than being linked' warnings
   MAKEFLAGS: -j 4
+  LDFLAGS: -w  # suppress 'object file was built for newer macOS version than being linked' warnings
 
 jobs:
   macos:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -263,7 +263,7 @@ jobs:
             install_steps: libressl
             # FIXME: Could not make OPENSSL_ROOT_DIR work. CMake seems to prepend sysroot to it.
             generate: >-
-              -DCMAKE_BUILD_TYPE=Debug
+              -DCMAKE_BUILD_TYPE=Release
               -DOPENSSL_INCLUDE_DIR="$HOME/libressl/include"
               -DOPENSSL_SSL_LIBRARY="$HOME/libressl/lib/libssl.a"
               -DOPENSSL_CRYPTO_LIBRARY="$HOME/libressl/lib/libcrypto.a"

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -244,9 +244,9 @@ jobs:
     runs-on: 'macos-latest'
     timeout-minutes: 10
     env:
+      MAKEFLAGS: -j 4
       DEVELOPER_DIR: "/Applications/Xcode${{ matrix.build.xcode && format('_{0}', matrix.build.xcode) || '' }}.app/Contents/Developer"
       CC: ${{ matrix.build.compiler || 'clang' }}
-      MAKEFLAGS: -j 4
       # renovate: datasource=github-tags depName=libressl-portable/portable versioning=semver registryUrl=https://github.com
       libressl-version: 4.0.0
     strategy:
@@ -390,9 +390,9 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 25
     env:
+      MAKEFLAGS: -j 5
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
       VCPKG_DISABLE_METRICS: '1'
-      MAKEFLAGS: -j 5
     strategy:
       matrix:
         include:
@@ -517,8 +517,8 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     env:
-      amissl-version: 5.18
       MAKEFLAGS: -j 5
+      amissl-version: 5.18
     strategy:
       matrix:
         build: [autotools, cmake]
@@ -616,8 +616,8 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 5
     env:
-      toolchain-version: '3.4'
       MAKEFLAGS: -j 5
+      toolchain-version: '3.4'
     strategy:
       matrix:
         build: [autotools, cmake]

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -140,6 +140,7 @@ jobs:
           version: '14.1'
           architecture: ${{ matrix.arch }}
           run: |
+            export MAKEFLAGS=-j3
             # https://ports.freebsd.org/
             time sudo pkg install -y autoconf automake libtool \
               pkgconf brotli openldap26-client libidn2 libnghttp2 stunnel py311-impacket
@@ -154,18 +155,18 @@ jobs:
               || { tail -n 1000 config.log; false; }
             echo '::group::curl_config.h (raw)'; cat lib/curl_config.h || true; echo '::endgroup::'
             echo '::group::curl_config.h'; grep -F '#define' lib/curl_config.h | sort || true; echo '::endgroup::'
-            time make -j3 install
+            time make install
             src/curl --disable --version
             desc='${{ matrix.desc }}'
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              time make -j3 -C tests
+              time make -C tests
               if [ "${desc#*!runtests*}" = "${desc}" ]; then
                 time make test-ci V=1 TFLAGS='-j4'
               fi
             fi
             if [ "${desc#*!examples*}" = "${desc}" ]; then
               echo '::group::build examples'
-              time make -j3 examples
+              time make examples
               echo '::endgroup::'
             fi
 
@@ -223,6 +224,7 @@ jobs:
           run: |
             set -e
             ln -s /usr/bin/gcpp /usr/bin/cpp  # Some tests expect `cpp`, which is named `gcpp` in this env.
+            export MAKEFLAGS=-j3
             time autoreconf -fi
             mkdir bld && cd bld && time ../configure --enable-unity --enable-test-bundles --enable-debug --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
@@ -231,12 +233,12 @@ jobs:
               || { tail -n 1000 config.log; false; }
             echo '::group::curl_config.h (raw)'; cat lib/curl_config.h || true; echo '::endgroup::'
             echo '::group::curl_config.h'; grep -F '#define' lib/curl_config.h | sort || true; echo '::endgroup::'
-            time gmake -j3 install
+            time gmake install
             src/curl --disable --version
-            time gmake -j3 -C tests
+            time gmake -C tests
             time gmake test-ci V=1
             echo '::group::build examples'
-            time gmake -j3 examples
+            time gmake examples
             echo '::endgroup::'
 
   ios:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -59,21 +59,21 @@ jobs:
             time cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_USE_GSSAPI=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
             echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld --config Debug
+            time cmake --build bld
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              time cmake --build bld --config Debug --target testdeps
+              time cmake --build bld --target testdeps
               export TFLAGS='-j4'
-              time cmake --build bld --config Debug --target test-ci
+              time cmake --build bld --target test-ci
             fi
             echo '::group::build examples'
-            time cmake --build bld --config Debug --target curl-examples
+            time cmake --build bld --target curl-examples
             echo '::endgroup::'
 
   openbsd:
@@ -100,20 +100,20 @@ jobs:
             time cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
               -DCURL_USE_OPENSSL=ON \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
             echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld --config Debug
+            time cmake --build bld
             bld/src/curl --disable --version
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              time cmake --build bld --config Debug --target testdeps
+              time cmake --build bld --target testdeps
               export TFLAGS='-j8 ~3017 ~TFTP ~FTP'  # FIXME: TFTP requests executed twice? Related: `curl: (69) TFTP: Access Violation`?
-              time cmake --build bld --config Debug --target test-ci
+              time cmake --build bld --target test-ci
             fi
             echo '::group::build examples'
-            time cmake --build bld --config Debug --target curl-examples
+            time cmake --build bld --target curl-examples
             echo '::endgroup::'
 
   freebsd:
@@ -185,25 +185,25 @@ jobs:
               -DCMAKE_C_COMPILER='${{ matrix.compiler }}' \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
-              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG= \
+              -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_USE_GSSAPI=ON \
               ${{ matrix.options }} \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
             echo '::group::curl_config.h'; grep -F '#define' bld/lib/curl_config.h | sort || true; echo '::endgroup::'
-            time cmake --build bld --config Debug
+            time cmake --build bld
             bld/src/curl --disable --version
             desc='${{ matrix.desc }}'
             if [ '${{ matrix.arch }}' = 'x86_64' ]; then  # Slow on emulated CPU
-              time cmake --build bld --config Debug --target testdeps
+              time cmake --build bld --target testdeps
               if [ "${desc#*!runtests*}" = "${desc}" ]; then
-                time cmake --build bld --config Debug --target test-ci
+                time cmake --build bld --target test-ci
               fi
             fi
             if [ "${desc#*!examples*}" = "${desc}" ]; then
               echo '::group::build examples'
-              time cmake --build bld --config Debug --target curl-examples
+              time cmake --build bld --target curl-examples
               echo '::endgroup::'
             fi
 

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -263,6 +263,7 @@ jobs:
             install_steps: libressl
             # FIXME: Could not make OPENSSL_ROOT_DIR work. CMake seems to prepend sysroot to it.
             generate: >-
+              -DCMAKE_BUILD_TYPE=Debug
               -DOPENSSL_INCLUDE_DIR="$HOME/libressl/include"
               -DOPENSSL_SSL_LIBRARY="$HOME/libressl/lib/libssl.a"
               -DOPENSSL_CRYPTO_LIBRARY="$HOME/libressl/lib/libcrypto.a"
@@ -271,6 +272,7 @@ jobs:
           - name: 'libressl'
             install_steps: libressl
             generator: Xcode
+            options: --config Debug
             generate: >-
               -DCMAKE_XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED=OFF
               -DMACOSX_BUNDLE_GUI_IDENTIFIER=se.curl
@@ -363,7 +365,7 @@ jobs:
       - name: 'build'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build bld --parallel 4 --verbose
+            cmake --build bld ${{ matrix.build.options }} --parallel 4 --verbose
           else
             make -C bld V=1
           fi
@@ -374,7 +376,7 @@ jobs:
       - name: 'build tests'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build bld --parallel 4 --target testdeps --verbose
+            cmake --build bld ${{ matrix.build.options }} --parallel 4 --target testdeps --verbose
           else
             make -C bld V=1 -C tests
           fi
@@ -382,7 +384,7 @@ jobs:
       - name: 'build examples'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build bld --parallel 4 --target curl-examples --verbose
+            cmake --build bld ${{ matrix.build.options }} --parallel 4 --target curl-examples --verbose
           else
             make -C bld examples V=1
           fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -361,7 +361,7 @@ jobs:
       - name: 'build'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build bld --verbose
+            cmake --build bld --parallel 4 --verbose
           else
             make -C bld V=1
           fi
@@ -372,7 +372,7 @@ jobs:
       - name: 'build tests'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build bld --target testdeps --verbose
+            cmake --build bld --parallel 4 --target testdeps --verbose
           else
             make -C bld V=1 -C tests
           fi
@@ -380,7 +380,7 @@ jobs:
       - name: 'build examples'
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build bld --target curl-examples --verbose
+            cmake --build bld --parallel 4 --target curl-examples --verbose
           else
             make -C bld examples V=1
           fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -490,7 +490,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --verbose
           else
-            make -j5 -C bld V=1
+            make -C bld V=1
           fi
 
       - name: 'curl info'
@@ -501,7 +501,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target testdeps
           else
-            make -j5 -C bld -C tests
+            make -C bld -C tests
           fi
 
       - name: 'build examples'
@@ -509,7 +509,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target curl-examples
           else
-            make -j5 -C bld examples
+            make -C bld examples
           fi
 
   amiga:
@@ -518,6 +518,7 @@ jobs:
     timeout-minutes: 5
     env:
       amissl-version: 5.18
+      MAKEFLAGS: -j 5
     strategy:
       matrix:
         build: [autotools, cmake]
@@ -584,9 +585,9 @@ jobs:
       - name: 'build'
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld --parallel 5
+            cmake --build bld
           else
-            make -j5 -C bld
+            make -C bld
           fi
 
       - name: 'curl info'
@@ -596,18 +597,18 @@ jobs:
         if: ${{ matrix.build == 'cmake' }}  # skip for autotools to save time
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld --parallel 5 --target testdeps
+            cmake --build bld --target testdeps
           else
-            make -j5 -C bld -C tests
+            make -C bld -C tests
           fi
 
       - name: 'build examples'
         if: ${{ matrix.build == 'cmake' }}  # skip for autotools to save time
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld --parallel 5 --target curl-examples
+            cmake --build bld --target curl-examples
           else
-            make -j5 -C bld examples
+            make -C bld examples
           fi
 
   msdos:
@@ -616,6 +617,7 @@ jobs:
     timeout-minutes: 5
     env:
       toolchain-version: '3.4'
+      MAKEFLAGS: -j 5
     strategy:
       matrix:
         build: [autotools, cmake]
@@ -694,7 +696,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld
           else
-            make -j5 -C bld
+            make -C bld
           fi
 
       - name: 'curl info'
@@ -706,7 +708,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target testdeps
           else
-            make -j5 -C bld -C tests
+            make -C bld -C tests
           fi
 
       - name: 'build examples'
@@ -715,5 +717,5 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target curl-examples
           else
-            make -j5 -C bld examples
+            make -C bld examples
           fi

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -264,6 +264,7 @@ jobs:
             # FIXME: Could not make OPENSSL_ROOT_DIR work. CMake seems to prepend sysroot to it.
             generate: >-
               -DCMAKE_BUILD_TYPE=Release
+              -DCMAKE_UNITY_BUILD_BATCH_SIZE=50
               -DOPENSSL_INCLUDE_DIR="$HOME/libressl/include"
               -DOPENSSL_SSL_LIBRARY="$HOME/libressl/lib/libssl.a"
               -DOPENSSL_CRYPTO_LIBRARY="$HOME/libressl/lib/libcrypto.a"

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -263,8 +263,7 @@ jobs:
             install_steps: libressl
             # FIXME: Could not make OPENSSL_ROOT_DIR work. CMake seems to prepend sysroot to it.
             generate: >-
-              -DCMAKE_BUILD_TYPE=Release
-              -DCMAKE_UNITY_BUILD_BATCH_SIZE=50
+              -DCMAKE_BUILD_TYPE=Release -DCMAKE_UNITY_BUILD_BATCH_SIZE=50
               -DOPENSSL_INCLUDE_DIR="$HOME/libressl/include"
               -DOPENSSL_SSL_LIBRARY="$HOME/libressl/lib/libssl.a"
               -DOPENSSL_CRYPTO_LIBRARY="$HOME/libressl/lib/libcrypto.a"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -112,7 +112,7 @@ jobs:
         timeout-minutes: 10
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld --config '${{ matrix.type }}'
+            cmake --build bld
           else
             make -C bld V=1 install
           fi
@@ -131,7 +131,7 @@ jobs:
         timeout-minutes: 15
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld --config '${{ matrix.type }}' --target testdeps
+            cmake --build bld --target testdeps
           else
             make -C bld V=1 -C tests
           fi
@@ -146,7 +146,7 @@ jobs:
           fi
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             PATH="$PWD/bld/lib:$PATH"
-            cmake --build bld --config '${{ matrix.type }}' --target test-ci
+            cmake --build bld --target test-ci
           else
             make -C bld V=1 test-ci
           fi
@@ -156,7 +156,7 @@ jobs:
         timeout-minutes: 5
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld --config '${{ matrix.type }}' --target curl-examples
+            cmake --build bld --target curl-examples
           else
             make -C bld V=1 examples
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -523,6 +523,7 @@ jobs:
         compiler: [gcc]
     steps:
       - name: 'install packages'
+        timeout-minutes: 5
         run: sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -603,6 +604,7 @@ jobs:
     steps:
       - name: 'install packages'
         if: ${{ matrix.build == 'autotools' }}
+        timeout-minutes: 5
         run: |
           echo automake libtool | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
           while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
@@ -616,6 +618,7 @@ jobs:
 
       - name: 'install compiler (mingw32ce)'
         if: ${{ steps.cache-compiler.outputs.cache-hit != 'true' }}
+        timeout-minutes: 5
         run: |
           cd "${HOME}" || exit 1
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 --retry-connrefused --proto-redir =https \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -44,8 +44,8 @@ jobs:
       run:
         shell: C:\cygwin\bin\bash.exe '{0}'
     env:
-      SHELLOPTS: 'igncr'
       MAKEFLAGS: -j 5
+      SHELLOPTS: 'igncr'
     strategy:
       matrix:
         include:
@@ -518,8 +518,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
-      TRIPLET: 'x86_64-w64-mingw32'
       MAKEFLAGS: -j 5
+      TRIPLET: 'x86_64-w64-mingw32'
     strategy:
       fail-fast: false
       matrix:
@@ -598,8 +598,8 @@ jobs:
     runs-on: 'macos-latest'
     timeout-minutes: 10
     env:
-      toolchain-version: '0.59.1'
       MAKEFLAGS: -j 4
+      toolchain-version: '0.59.1'
     strategy:
       matrix:
         build: [autotools, cmake]

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -45,6 +45,7 @@ jobs:
         shell: C:\cygwin\bin\bash.exe '{0}'
     env:
       SHELLOPTS: 'igncr'
+      MAKEFLAGS: -j 5
     strategy:
       matrix:
         include:
@@ -113,7 +114,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --config '${{ matrix.type }}'
           else
-            make -C bld -j5 V=1 install
+            make -C bld V=1 install
           fi
 
       - name: 'curl version'
@@ -132,7 +133,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --config '${{ matrix.type }}' --target testdeps
           else
-            make -C bld -j5 V=1 -C tests
+            make -C bld V=1 -C tests
           fi
 
       - name: 'run tests'
@@ -147,7 +148,7 @@ jobs:
             PATH="$PWD/bld/lib:$PATH"
             cmake --build bld --config '${{ matrix.type }}' --target test-ci
           else
-            make -C bld -j5 V=1 test-ci
+            make -C bld V=1 test-ci
           fi
 
       - name: 'build examples'
@@ -157,7 +158,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --config '${{ matrix.type }}' --target curl-examples
           else
-            make -C bld -j5 V=1 examples
+            make -C bld V=1 examples
           fi
 
   msys2:  # both msys and mingw-w64
@@ -167,6 +168,8 @@ jobs:
     defaults:
       run:
         shell: msys2 {0}
+    env:
+      MAKEFLAGS: -j 5
     strategy:
       matrix:
         include:
@@ -288,7 +291,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --config '${{ matrix.type }}'
           else
-            make -C bld -j5 V=1 install
+            make -C bld V=1 install
           fi
 
       - name: 'curl version'
@@ -313,7 +316,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --config '${{ matrix.type }}' --target testdeps
           else
-            make -C bld -j5 V=1 -C tests
+            make -C bld V=1 -C tests
           fi
           if [ '${{ matrix.build }}' != 'cmake' ]; then
             # avoid libtool's .exe wrappers
@@ -350,7 +353,7 @@ jobs:
             cmake --build bld --config '${{ matrix.type }}' --target test-ci
           else
             PATH="$PWD/bld/lib/.libs:$PATH"
-            make -C bld -j5 V=1 test-ci
+            make -C bld V=1 test-ci
           fi
 
       - name: 'build examples'
@@ -360,7 +363,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --config '${{ matrix.type }}' --target curl-examples
           else
-            make -C bld -j5 V=1 examples
+            make -C bld V=1 examples
           fi
 
   mingw-w64-standalone-downloads:
@@ -370,6 +373,8 @@ jobs:
     defaults:
       run:
         shell: C:\msys64\usr\bin\bash.exe {0}
+    env:
+      MAKEFLAGS: -j 5
     strategy:
       matrix:
         include:
@@ -457,7 +462,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --parallel 5
+          cmake --build bld --config '${{ matrix.type }}'
 
       - name: 'curl version'
         timeout-minutes: 1
@@ -471,7 +476,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
+          cmake --build bld --config '${{ matrix.type }}' --target testdeps
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -506,19 +511,20 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
+          cmake --build bld --config '${{ matrix.type }}' --target curl-examples
 
   linux-cross-mingw-w64:
     name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      TRIPLET: 'x86_64-w64-mingw32'
+      MAKEFLAGS: -j 5
     strategy:
       fail-fast: false
       matrix:
         build: [autotools, cmake]
         compiler: [gcc]
-    env:
-      TRIPLET: 'x86_64-w64-mingw32'
     steps:
       - name: 'install packages'
         run: sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
@@ -564,7 +570,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld
           else
-            make -C bld -j5
+            make -C bld
           fi
 
       - name: 'curl info'
@@ -576,7 +582,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target testdeps
           else
-            make -C bld -j5 -C tests
+            make -C bld -C tests
           fi
 
       - name: 'build examples'
@@ -584,7 +590,7 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target curl-examples
           else
-            make -C bld -j5 examples
+            make -C bld examples
           fi
 
   wince:
@@ -859,7 +865,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --parallel 5
+          cmake --build bld --config '${{ matrix.type }}'
 
       - name: 'curl version'
         timeout-minutes: 1
@@ -875,7 +881,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
+          cmake --build bld --config '${{ matrix.type }}' --target testdeps
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -917,4 +923,4 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples
+          cmake --build bld --config '${{ matrix.type }}' --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -431,8 +431,6 @@ jobs:
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
           for _chkprefill in '' ${{ matrix.chkprefill }}; do
             options=''
-            [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
-            [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
             [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
             cmake -B "bld${_chkprefill}" -G 'MSYS Makefiles' ${options} \
               -DCMAKE_C_COMPILER=gcc \
@@ -460,7 +458,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}'
+          cmake --build bld
 
       - name: 'curl version'
         timeout-minutes: 1
@@ -474,7 +472,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --target testdeps
+          cmake --build bld --target testdeps
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -503,13 +501,13 @@ jobs:
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
           PATH="$PWD/bld/lib:$PATH:/c/Program Files (x86)/stunnel/bin"
-          cmake --build bld --config '${{ matrix.type }}' --target test-ci
+          cmake --build bld --target test-ci
 
       - name: 'build examples'
         timeout-minutes: 5
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --target curl-examples
+          cmake --build bld --target curl-examples
 
   linux-cross-mingw-w64:
     name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -865,7 +865,7 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}'
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5
 
       - name: 'curl version'
         timeout-minutes: 1
@@ -881,7 +881,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --target testdeps
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target testdeps
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -923,4 +923,4 @@ jobs:
         timeout-minutes: 5
         run: |
           PATH="/c/msys64/usr/bin:$PATH"
-          cmake --build bld --config '${{ matrix.type }}' --target curl-examples
+          cmake --build bld --config '${{ matrix.type }}' --parallel 5 --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -253,8 +253,6 @@ jobs:
               fi
               [ '${{ matrix.sys }}' = 'msys' ] && options+=' -D_CURL_PREFILL=ON'
               [ '${{ matrix.test }}' = 'uwp' ] && options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
-              [ '${{ matrix.type }}' = 'Debug' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_DEBUG='
-              [ '${{ matrix.type }}' = 'Release' ] && options+=' -DCMAKE_RUNTIME_OUTPUT_DIRECTORY_RELEASE='
               [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
               cmake -B "bld${_chkprefill}" -G Ninja ${options} \
                 -DCMAKE_C_FLAGS="${{ matrix.cflags }} ${CFLAGS_CMAKE} ${CPPFLAGS}" \
@@ -289,7 +287,7 @@ jobs:
         timeout-minutes: 10
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld --config '${{ matrix.type }}'
+            cmake --build bld
           else
             make -C bld V=1 install
           fi
@@ -314,7 +312,7 @@ jobs:
         timeout-minutes: 10
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld --config '${{ matrix.type }}' --target testdeps
+            cmake --build bld --target testdeps
           else
             make -C bld V=1 -C tests
           fi
@@ -350,7 +348,7 @@ jobs:
           PATH="$PATH:/c/Program Files (x86)/stunnel/bin"
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             PATH="$PWD/bld/lib:$PATH"
-            cmake --build bld --config '${{ matrix.type }}' --target test-ci
+            cmake --build bld --target test-ci
           else
             PATH="$PWD/bld/lib/.libs:$PATH"
             make -C bld V=1 test-ci
@@ -361,7 +359,7 @@ jobs:
         timeout-minutes: 5
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            cmake --build bld --config '${{ matrix.type }}' --target curl-examples
+            cmake --build bld --target curl-examples
           else
             make -C bld V=1 examples
           fi


### PR DESCRIPTION
- replace `--parallel <n>` and `-j<n>` for individual commands with
  `MAKEFLAGS`, for jobs not yet doing it.
  This enables parallel builds in distcheck / maketgz-and-verify-in-tree,
  where `-j` option was missing.
- add `--parallel` for iOS Xcode job for improved performance.
- drop redundant `-j5` for Android jobs.
- drop stray `cmake --config` options from single-target jobs (cygwin,
  msys/mingw, dl-mingw, non-native). Drop redundant
  `CMAKE_RUNTIME_OUTPUT_DIRECTORY_*` settings too.
- GHA/windows: add timeout for package install steps where missing.
- GHA/non-native: specify target type explicitly for iOS cmake jobs.
  Xcode default was already Debug, single-target default was generic,
  now it's Release, with unity batch to keep it fast.

`MAKEFLAGS` is necessary for autotools jobs and CMake jobs using
the default (GNU Make) generator. It's ignored by Ninja and other tools.
`cmake --parallel` is still necessary for jobs with Visual Studio or
Xcode generators. Parallelism is 5 for GHA Linux and Windows runners,
4 for macOS, 3 for VMs, 2 for AppVeyor.
