### PR TITLE
Expose FIN bit via curl_ws_meta

### DIFF
--- a/docs/libcurl/curl_ws_meta.md
+++ b/docs/libcurl/curl_ws_meta.md
@@ -124,6 +124,13 @@ reassemble the fragments to receive the complete message.
 Only a single fragmented message can be transmitted at a time, but it may
 be interrupted by CURLWS_CLOSE, CURLWS_PING or CURLWS_PONG frames.
 
+## CURLWS_FIN
+
+This flag is set when the FIN bit is present in the received WebSocket frame.
+In WebSocket protocol, the FIN bit indicates that this frame is the final
+frame of the message. When CURLWS_FIN is set, it means no further frames
+follow for this message.
+
 # %PROTOCOLS%
 
 # EXAMPLE

--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -1146,6 +1146,7 @@ CURLWARNING                     7.66.0
 CURLWS_BINARY                   7.86.0
 CURLWS_CLOSE                    7.86.0
 CURLWS_CONT                     7.86.0
+CURLWS_FIN                      8.13.0
 CURLWS_OFFSET                   7.86.0
 CURLWS_PING                     7.86.0
 CURLWS_PONG                     7.86.0

--- a/include/curl/websockets.h
+++ b/include/curl/websockets.h
@@ -43,6 +43,7 @@ struct curl_ws_frame {
 #define CURLWS_CLOSE      (1<<3)
 #define CURLWS_PING       (1<<4)
 #define CURLWS_OFFSET     (1<<5)
+#define CURLWS_FIN        (1<<6)
 
 /*
  * NAME curl_ws_recv()

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -195,6 +195,8 @@ static CURLcode ws_dec_read_head(struct ws_decoder *dec,
       }
 
       dec->frame_flags = ws_frame_op2flags(dec->head[0]);
+      dec->frame_flags = dec->frame_flags |
+        ((dec->head[0] & WSBIT_FIN) ? CURLWS_FIN : 0);
       if(!dec->frame_flags) {
         failf(data, "WS: unknown opcode: %x",
               dec->head[0] & WSBIT_OPCODE_MASK);

--- a/tests/data/test2302
+++ b/tests/data/test2302
@@ -64,7 +64,7 @@ Sec-WebSocket-Key: NDMyMTUzMjE2MzIxNzMyMQ==
 </protocol>
 <stdout mode="text">
 68 65 6c 6c 6f 
-RECFLAGS: 1
+RECFLAGS: 41
 </stdout>
 </verify>
 </testcase>


### PR DESCRIPTION
This pull request aims to expose the websocket FIN bit from the frame headers in the websocket protocol. This bit is required in order to handle messages that take up multiple frames. CURLWS_CONT does not do what is required. Consider the following example:

| Frame No.   |      OpCode      |  FIN bit |
|----------|:-------------:|------:|
| 1 |  TEXT | 0 |
| 2 |    CONT   |   0 |
| 3 | CONT |    1 |

In the first message, OpCode gives no indication that I should be expecting further frames. I need to know if I should be expecting other fragments so I know if I should return the websocket message to the user or continue receiving for the rest of it. The FIN bit being zero tells me that I have not received the full message.

In the case of the last example, the OpCode is CONT. This gives no indication that I have received the full message and can return it to the user. On the contrary, seeing that the FIN bit is 1 would indicate I have received the full message and should return it to the user. 

According to the websocket protocol, the CONT opcode is not set on the first frame. It is set from the second frame onward, including the last frame. That is what makes it unsatisfactory in handling frames that consist of multiple messages.

I have attempted to add some basic code to expose this bit in the flags living in curl_ws_meta. I am unsure if this is the correct approach, and would be more than happy to make whatever changes deemed necessary. Let me know if I have failed to follow any rules or best practices.