### PR TITLE
tidy-up: prefer `return` over `exit()`, fix fallouts

### DIFF
--- a/docs/examples/block_ip.c
+++ b/docs/examples/block_ip.c
@@ -300,12 +300,17 @@ int main(void)
   if(!filter)
     return 1;
 
-  if(curl_global_init(CURL_GLOBAL_DEFAULT))
+  if(curl_global_init(CURL_GLOBAL_DEFAULT)) {
+    free(filter);
     return 1;
+  }
 
   curl = curl_easy_init();
-  if(!curl)
+  if(!curl) {
+    curl_global_cleanup();
+    free(filter);
     return 1;
+  }
 
   /* Set the target URL */
   curl_easy_setopt(curl, CURLOPT_URL, "http://localhost");

--- a/docs/examples/block_ip.c
+++ b/docs/examples/block_ip.c
@@ -298,14 +298,14 @@ int main(void)
 
   filter = (struct connection_filter *)calloc(1, sizeof(*filter));
   if(!filter)
-    exit(1);
+    return 1;
 
   if(curl_global_init(CURL_GLOBAL_DEFAULT))
-    exit(1);
+    return 1;
 
   curl = curl_easy_init();
   if(!curl)
-    exit(1);
+    return 1;
 
   /* Set the target URL */
   curl_easy_setopt(curl, CURLOPT_URL, "http://localhost");

--- a/docs/examples/chkspeed.c
+++ b/docs/examples/chkspeed.c
@@ -79,12 +79,12 @@ int main(int argc, char *argv[])
           fprintf(stderr,
                   "\rUsage: %s [-m=1|2|5|10|20|50|100] [-t] [-x] [url]\n",
                   appname);
-          exit(1);
+          return 1;
         case 'v':
         case 'V':
           fprintf(stderr, "\r%s %s - %s\n",
                   appname, CHKSPEED_VERSION, curl_version());
-          exit(1);
+          return 1;
         case 'a':
         case 'A':
           prtall = 1;

--- a/docs/examples/cookie_interface.c
+++ b/docs/examples/cookie_interface.c
@@ -34,8 +34,7 @@
 #include <curl/curl.h>
 #include <curl/mprintf.h>
 
-static void
-print_cookies(CURL *curl)
+static int print_cookies(CURL *curl)
 {
   CURLcode res;
   struct curl_slist *cookies;
@@ -47,7 +46,7 @@ print_cookies(CURL *curl)
   if(res != CURLE_OK) {
     fprintf(stderr, "Curl curl_easy_getinfo failed: %s\n",
             curl_easy_strerror(res));
-    exit(1);
+    return 1;
   }
   nc = cookies;
   i = 1;
@@ -60,6 +59,8 @@ print_cookies(CURL *curl)
     printf("(none)\n");
   }
   curl_slist_free_all(cookies);
+
+  return 0;
 }
 
 int

--- a/docs/examples/htmltitle.cpp
+++ b/docs/examples/htmltitle.cpp
@@ -94,7 +94,7 @@ static bool init(CURL *&conn, const char *url)
 
   if(conn == NULL) {
     fprintf(stderr, "Failed to create CURL connection\n");
-    exit(EXIT_FAILURE);
+    return false;
   }
 
   code = curl_easy_setopt(conn, CURLOPT_ERRORBUFFER, errorBuffer);
@@ -270,7 +270,7 @@ int main(int argc, char *argv[])
 
   if(argc != 2) {
     fprintf(stderr, "Usage: %s <url>\n", argv[0]);
-    exit(EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
 
   curl_global_init(CURL_GLOBAL_DEFAULT);
@@ -279,7 +279,7 @@ int main(int argc, char *argv[])
 
   if(!init(conn, argv[1])) {
     fprintf(stderr, "Connection initialization failed\n");
-    exit(EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
 
   // Retrieve content for the URL
@@ -289,7 +289,7 @@ int main(int argc, char *argv[])
 
   if(code != CURLE_OK) {
     fprintf(stderr, "Failed to get '%s' [%s]\n", argv[1], errorBuffer);
-    exit(EXIT_FAILURE);
+    return EXIT_FAILURE;
   }
 
   // Parse the (assumed) HTML code

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -142,7 +142,7 @@ int my_trace(CURL *handle, curl_infotype type,
   return 0;
 }
 
-static void setup(struct transfer *t, int num)
+static int setup(struct transfer *t, int num)
 {
   char filename[128];
   CURL *hnd;
@@ -155,7 +155,7 @@ static void setup(struct transfer *t, int num)
   if(!t->out) {
     fprintf(stderr, "error: could not open file %s for writing: %s\n",
             filename, strerror(errno));
-    exit(1);
+    return 1;
   }
 
   /* write to this file */
@@ -179,6 +179,7 @@ static void setup(struct transfer *t, int num)
   /* wait for pipe connection to confirm */
   curl_easy_setopt(hnd, CURLOPT_PIPEWAIT, 1L);
 #endif
+  return 0;
 }
 
 /*
@@ -204,7 +205,8 @@ int main(int argc, char **argv)
   multi_handle = curl_multi_init();
 
   for(i = 0; i < num_transfers; i++) {
-    setup(&trans[i], i);
+    if(setup(&trans[i], i))
+      break;
 
     /* add the individual transfer */
     curl_multi_add_handle(multi_handle, trans[i].easy);

--- a/docs/examples/http2-download.c
+++ b/docs/examples/http2-download.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 
   for(i = 0; i < num_transfers; i++) {
     if(setup(&trans[i], i))
-      break;
+      return 1;
 
     /* add the individual transfer */
     curl_multi_add_handle(multi_handle, trans[i].easy);

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -209,7 +209,8 @@ static int setup(struct input *i, int num, const char *upload)
   curl_off_t uploadsize;
   CURL *hnd;
 
-  hnd = i->hnd = curl_easy_init();
+  hnd = i->hnd = NULL;
+
   i->num = num;
   curl_msnprintf(filename, 128, "dl-%d", num);
   out = fopen(filename, "wb");
@@ -225,6 +226,7 @@ static int setup(struct input *i, int num, const char *upload)
   if(stat(upload, &file_info)) {
     fprintf(stderr, "error: could not stat file %s: %s\n", upload,
             strerror(errno));
+    fclose(out);
     return 1;
   }
 
@@ -234,8 +236,11 @@ static int setup(struct input *i, int num, const char *upload)
   if(!i->in) {
     fprintf(stderr, "error: could not open file %s for reading: %s\n", upload,
             strerror(errno));
+    fclose(out);
     return 1;
   }
+
+  hnd = i->hnd = curl_easy_init();
 
   /* write to this file */
   curl_easy_setopt(hnd, CURLOPT_WRITEDATA, out);

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
 
   for(i = 0; i < num_transfers; i++) {
     if(setup(&trans[i], i, filename))
-      break;
+      return 1;
 
     /* add the individual transfer */
     curl_multi_add_handle(multi_handle, trans[i].hnd);

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -482,7 +482,7 @@ AC_DEFUN([CURL_COMPILER_WORKS_IFELSE], [
         #endif
       ]],[[
         int i = 0;
-        exit(i);
+        return i;
       ]])
     ],[
       tmp_compiler_works="yes"

--- a/m4/curl-compilers.m4
+++ b/m4/curl-compilers.m4
@@ -482,7 +482,7 @@ AC_DEFUN([CURL_COMPILER_WORKS_IFELSE], [
         #endif
       ]],[[
         int i = 0;
-        return i;
+        exit(i);
       ]])
     ],[
       tmp_compiler_works="yes"

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1884,8 +1884,10 @@ AC_DEFUN([CURL_CHECK_FUNC_GETIFADDRS], [
         error = getifaddrs(&ifa);
         if(error || !ifa)
           return 1; /* fail */
-        else
+        else {
+          freeifaddrs(ifa);
           return 0;
+        }
       ]])
     ],[
       AC_MSG_RESULT([yes])

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1274,7 +1274,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
         #ifdef _WIN32
         WSADATA wsa;
         if(WSAStartup(MAKEWORD(2, 2), &wsa))
-          return 2;
+          exit(2);
         #endif
 
         memset(&hints, 0, sizeof(hints));
@@ -1283,9 +1283,9 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
         hints.ai_socktype = SOCK_STREAM;
         error = getaddrinfo("127.0.0.1", 0, &hints, &ai);
         if(error || !ai)
-          return 1; /* fail */
+          exit(1); /* fail */
         else
-          return 0;
+          exit(0);
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -1883,9 +1883,9 @@ AC_DEFUN([CURL_CHECK_FUNC_GETIFADDRS], [
 
         error = getifaddrs(&ifa);
         if(error || !ifa)
-          return 1; /* fail */
+          exit(1); /* fail */
         else
-          return 0;
+          exit(0);
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -2003,9 +2003,9 @@ AC_DEFUN([CURL_CHECK_FUNC_GMTIME_R], [
         gmt = gmtime_r(&local, &result);
         (void)result;
         if(gmt)
-          return 0;
+          exit(0);
         else
-          return 1;
+          exit(1);
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -2134,13 +2134,13 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOP], [
         /* - */
         ipv4ptr = inet_ntop(AF_INET, ipv4a, ipv4res, sizeof(ipv4res));
         if(!ipv4ptr)
-          return 1; /* fail */
+          exit(1); /* fail */
         if(ipv4ptr != ipv4res)
-          return 1; /* fail */
+          exit(1); /* fail */
         if(!ipv4ptr[0])
-          return 1; /* fail */
+          exit(1); /* fail */
         if(memcmp(ipv4res, "192.168.100.1", 13) != 0)
-          return 1; /* fail */
+          exit(1); /* fail */
         /* - */
         ipv6res[0] = '\0';
         memset(ipv6a, 0, sizeof(ipv6a));
@@ -2158,15 +2158,15 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOP], [
         /* - */
         ipv6ptr = inet_ntop(AF_INET6, ipv6a, ipv6res, sizeof(ipv6res));
         if(!ipv6ptr)
-          return 1; /* fail */
+          exit(1); /* fail */
         if(ipv6ptr != ipv6res)
-          return 1; /* fail */
+          exit(1); /* fail */
         if(!ipv6ptr[0])
-          return 1; /* fail */
+          exit(1); /* fail */
         if(memcmp(ipv6res, "fe80::214:4fff:fe0b:76c8", 24) != 0)
-          return 1; /* fail */
+          exit(1); /* fail */
         /* - */
-        return 0;
+        exit(0);
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -2286,18 +2286,18 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
         /* - */
         memset(ipv4a, 1, sizeof(ipv4a));
         if(1 != inet_pton(AF_INET, ipv4src, ipv4a))
-          return 1; /* fail */
+          exit(1); /* fail */
         /* - */
         if( (ipv4a[0] != 0xc0) ||
             (ipv4a[1] != 0xa8) ||
             (ipv4a[2] != 0x64) ||
             (ipv4a[3] != 0x01) ||
             (ipv4a[4] != 0x01) )
-          return 1; /* fail */
+          exit(1); /* fail */
         /* - */
         memset(ipv6a, 1, sizeof(ipv6a));
         if(1 != inet_pton(AF_INET6, ipv6src, ipv6a))
-          return 1; /* fail */
+          exit(1); /* fail */
         /* - */
         if( (ipv6a[0]  != 0xfe) ||
             (ipv6a[1]  != 0x80) ||
@@ -2310,7 +2310,7 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
             (ipv6a[14] != 0x76) ||
             (ipv6a[15] != 0xc8) ||
             (ipv6a[16] != 0x01) )
-          return 1; /* fail */
+          exit(1); /* fail */
         /* - */
         if( (ipv6a[2]  != 0x0) ||
             (ipv6a[3]  != 0x0) ||
@@ -2318,9 +2318,9 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
             (ipv6a[5]  != 0x0) ||
             (ipv6a[6]  != 0x0) ||
             (ipv6a[7]  != 0x0) )
-          return 1; /* fail */
+          exit(1); /* fail */
         /* - */
-        return 0;
+        exit(0);
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -3809,11 +3809,11 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
         buffer[0] = '\0';
         string = strerror_r(EACCES, buffer, sizeof(buffer));
         if(!string)
-          return 1; /* fail */
+          exit(1); /* fail */
         if(!string[0])
-          return 1; /* fail */
+          exit(1); /* fail */
         else
-          return 0;
+          exit(0);
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -3872,11 +3872,11 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
         buffer[0] = '\0';
         error = strerror_r(EACCES, buffer, sizeof(buffer));
         if(error)
-          return 1; /* fail */
+          exit(1); /* fail */
         if(buffer[0] == '\0')
-          return 1; /* fail */
+          exit(1); /* fail */
         else
-          return 0;
+          exit(0);
       ]])
     ],[
       AC_MSG_RESULT([yes])

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1270,6 +1270,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
         struct addrinfo hints;
         struct addrinfo *ai = 0;
         int error;
+        int exitcode;
 
         #ifdef _WIN32
         WSADATA wsa;
@@ -1283,9 +1284,15 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
         hints.ai_socktype = SOCK_STREAM;
         error = getaddrinfo("127.0.0.1", 0, &hints, &ai);
         if(error || !ai)
-          return 1; /* fail */
-        else
-          return 0;
+          exitcode = 1; /* fail */
+        else {
+          freeaddrinfo(ai);
+          exitcode = 0;
+        }
+        #ifdef _WIN32
+        WSACleanup();
+        #endif
+        return exitcode;
       ]])
     ],[
       AC_MSG_RESULT([yes])

--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -1274,7 +1274,7 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
         #ifdef _WIN32
         WSADATA wsa;
         if(WSAStartup(MAKEWORD(2, 2), &wsa))
-          exit(2);
+          return 2;
         #endif
 
         memset(&hints, 0, sizeof(hints));
@@ -1283,9 +1283,9 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
         hints.ai_socktype = SOCK_STREAM;
         error = getaddrinfo("127.0.0.1", 0, &hints, &ai);
         if(error || !ai)
-          exit(1); /* fail */
+          return 1; /* fail */
         else
-          exit(0);
+          return 0;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -1883,9 +1883,9 @@ AC_DEFUN([CURL_CHECK_FUNC_GETIFADDRS], [
 
         error = getifaddrs(&ifa);
         if(error || !ifa)
-          exit(1); /* fail */
+          return 1; /* fail */
         else
-          exit(0);
+          return 0;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -2003,9 +2003,9 @@ AC_DEFUN([CURL_CHECK_FUNC_GMTIME_R], [
         gmt = gmtime_r(&local, &result);
         (void)result;
         if(gmt)
-          exit(0);
+          return 0;
         else
-          exit(1);
+          return 1;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -2134,13 +2134,13 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOP], [
         /* - */
         ipv4ptr = inet_ntop(AF_INET, ipv4a, ipv4res, sizeof(ipv4res));
         if(!ipv4ptr)
-          exit(1); /* fail */
+          return 1; /* fail */
         if(ipv4ptr != ipv4res)
-          exit(1); /* fail */
+          return 1; /* fail */
         if(!ipv4ptr[0])
-          exit(1); /* fail */
+          return 1; /* fail */
         if(memcmp(ipv4res, "192.168.100.1", 13) != 0)
-          exit(1); /* fail */
+          return 1; /* fail */
         /* - */
         ipv6res[0] = '\0';
         memset(ipv6a, 0, sizeof(ipv6a));
@@ -2158,15 +2158,15 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_NTOP], [
         /* - */
         ipv6ptr = inet_ntop(AF_INET6, ipv6a, ipv6res, sizeof(ipv6res));
         if(!ipv6ptr)
-          exit(1); /* fail */
+          return 1; /* fail */
         if(ipv6ptr != ipv6res)
-          exit(1); /* fail */
+          return 1; /* fail */
         if(!ipv6ptr[0])
-          exit(1); /* fail */
+          return 1; /* fail */
         if(memcmp(ipv6res, "fe80::214:4fff:fe0b:76c8", 24) != 0)
-          exit(1); /* fail */
+          return 1; /* fail */
         /* - */
-        exit(0);
+        return 0;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -2286,18 +2286,18 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
         /* - */
         memset(ipv4a, 1, sizeof(ipv4a));
         if(1 != inet_pton(AF_INET, ipv4src, ipv4a))
-          exit(1); /* fail */
+          return 1; /* fail */
         /* - */
         if( (ipv4a[0] != 0xc0) ||
             (ipv4a[1] != 0xa8) ||
             (ipv4a[2] != 0x64) ||
             (ipv4a[3] != 0x01) ||
             (ipv4a[4] != 0x01) )
-          exit(1); /* fail */
+          return 1; /* fail */
         /* - */
         memset(ipv6a, 1, sizeof(ipv6a));
         if(1 != inet_pton(AF_INET6, ipv6src, ipv6a))
-          exit(1); /* fail */
+          return 1; /* fail */
         /* - */
         if( (ipv6a[0]  != 0xfe) ||
             (ipv6a[1]  != 0x80) ||
@@ -2310,7 +2310,7 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
             (ipv6a[14] != 0x76) ||
             (ipv6a[15] != 0xc8) ||
             (ipv6a[16] != 0x01) )
-          exit(1); /* fail */
+          return 1; /* fail */
         /* - */
         if( (ipv6a[2]  != 0x0) ||
             (ipv6a[3]  != 0x0) ||
@@ -2318,9 +2318,9 @@ AC_DEFUN([CURL_CHECK_FUNC_INET_PTON], [
             (ipv6a[5]  != 0x0) ||
             (ipv6a[6]  != 0x0) ||
             (ipv6a[7]  != 0x0) )
-          exit(1); /* fail */
+          return 1; /* fail */
         /* - */
-        exit(0);
+        return 0;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -3809,11 +3809,11 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
         buffer[0] = '\0';
         string = strerror_r(EACCES, buffer, sizeof(buffer));
         if(!string)
-          exit(1); /* fail */
+          return 1; /* fail */
         if(!string[0])
-          exit(1); /* fail */
+          return 1; /* fail */
         else
-          exit(0);
+          return 0;
       ]])
     ],[
       AC_MSG_RESULT([yes])
@@ -3872,11 +3872,11 @@ AC_DEFUN([CURL_CHECK_FUNC_STRERROR_R], [
         buffer[0] = '\0';
         error = strerror_r(EACCES, buffer, sizeof(buffer));
         if(error)
-          exit(1); /* fail */
+          return 1; /* fail */
         if(buffer[0] == '\0')
-          exit(1); /* fail */
+          return 1; /* fail */
         else
-          exit(0);
+          return 0;
       ]])
     ],[
       AC_MSG_RESULT([yes])

--- a/packages/vms/report_openssl_version.c
+++ b/packages/vms/report_openssl_version.c
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
 
   if(argc < 1) {
     puts("report_openssl_version filename");
-    exit(1);
+    return 1;
   }
 
   libptr = dlopen(argv[1], 0);
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
 
   if(!ssl_version) {
     puts("Unable to lookup version of OpenSSL");
-    exit(1);
+    return 1;
   }
 
   version = ssl_version(SSLEAY_VERSION);
@@ -91,9 +91,9 @@ int main(int argc, char **argv)
 
     status = LIB$SET_SYMBOL(&symbol_dsc, &value_dsc, &table_type);
     if(!$VMS_STATUS_SUCCESS(status)) {
-      exit(status);
+      return status;
     }
   }
 
-  exit(0);
+  return 0;
 }

--- a/tests/http/clients/h2-pausing.c
+++ b/tests/http/clients/h2-pausing.c
@@ -140,12 +140,6 @@ static int debug_cb(CURL *handle, curl_infotype type,
   return 0;
 }
 
-#define ERR()                                                             \
-  do {                                                                    \
-    fprintf(stderr, "something unexpected went wrong - bailing out!\n");  \
-    exit(2);                                                              \
-  } while(0)
-
 static void usage(const char *msg)
 {
   if(msg)
@@ -196,6 +190,13 @@ static size_t cb(char *data, size_t size, size_t nmemb, void *clientp)
           handle->idx, (long)realsize);
   return realsize;
 }
+
+#define ERR()                                                             \
+  do {                                                                    \
+    fprintf(stderr, "something unexpected went wrong - bailing out!\n");  \
+    return 2;                                                             \
+  } while(0)
+
 #endif /* !_MSC_VER */
 
 int main(int argc, char *argv[])
@@ -254,19 +255,19 @@ int main(int argc, char *argv[])
   cu = curl_url();
   if(!cu) {
     fprintf(stderr, "out of memory\n");
-    exit(1);
+    return 1;
   }
   if(curl_url_set(cu, CURLUPART_URL, url, 0)) {
     fprintf(stderr, "not a URL: '%s'\n", url);
-    exit(1);
+    return 1;
   }
   if(curl_url_get(cu, CURLUPART_HOST, &host, 0)) {
     fprintf(stderr, "could not get host of '%s'\n", url);
-    exit(1);
+    return 1;
   }
   if(curl_url_get(cu, CURLUPART_PORT, &port, 0)) {
     fprintf(stderr, "could not get port of '%s'\n", url);
-    exit(1);
+    return 1;
   }
   memset(&resolve, 0, sizeof(resolve));
   curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1",

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -188,6 +188,7 @@ int main(int argc, char *argv[])
       if(mc != CURLM_OK) {
         fprintf(stderr, "curl_multi_add_handle: %s\n",
                 curl_multi_strerror(mc));
+        curl_easy_cleanup(easy);
         goto cleanup;
       }
       --start_count;

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -138,13 +138,14 @@ static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *opaque)
 int main(int argc, char *argv[])
 {
   const char *url;
-  CURLM *multi;
+  CURLM *multi = NULL;
   CURL *easy;
   CURLMcode mc;
   int running_handles = 0, start_count, numfds;
   CURLMsg *msg;
   int msgs_in_queue;
   char range[128];
+  int exitcode = 1;
 
   if(argc != 2) {
     fprintf(stderr, "%s URL\n", argv[0]);
@@ -155,7 +156,7 @@ int main(int argc, char *argv[])
   multi = curl_multi_init();
   if(!multi) {
     fprintf(stderr, "curl_multi_init failed\n");
-    return 1;
+    goto cleanup;
   }
 
   start_count = 200;
@@ -164,7 +165,7 @@ int main(int argc, char *argv[])
       easy = curl_easy_init();
       if(!easy) {
         fprintf(stderr, "curl_easy_init failed\n");
-        return 1;
+        goto cleanup;
       }
       curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
       curl_easy_setopt(easy, CURLOPT_DEBUGFUNCTION, debug_cb);
@@ -186,8 +187,8 @@ int main(int argc, char *argv[])
       mc = curl_multi_add_handle(multi, easy);
       if(mc != CURLM_OK) {
         fprintf(stderr, "curl_multi_add_handle: %s\n",
-               curl_multi_strerror(mc));
-        return 1;
+                curl_multi_strerror(mc));
+        goto cleanup;
       }
       --start_count;
     }
@@ -195,16 +196,16 @@ int main(int argc, char *argv[])
     mc = curl_multi_perform(multi, &running_handles);
     if(mc != CURLM_OK) {
       fprintf(stderr, "curl_multi_perform: %s\n",
-             curl_multi_strerror(mc));
-      return 1;
+              curl_multi_strerror(mc));
+      goto cleanup;
     }
 
     if(running_handles) {
       mc = curl_multi_poll(multi, NULL, 0, 1000000, &numfds);
       if(mc != CURLM_OK) {
         fprintf(stderr, "curl_multi_poll: %s\n",
-               curl_multi_strerror(mc));
-        return 1;
+                curl_multi_strerror(mc));
+        goto cleanup;
       }
     }
 
@@ -224,12 +225,12 @@ int main(int argc, char *argv[])
         else if(msg->data.result) {
           fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
                   ": failed with %d\n", xfer_id, msg->data.result);
-          return 1;
+          goto cleanup;
         }
         else if(status != 206) {
           fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
                   ": wrong http status %ld (expected 206)\n", xfer_id, status);
-          return 1;
+          goto cleanup;
         }
         curl_multi_remove_handle(multi, msg->easy_handle);
         curl_easy_cleanup(msg->easy_handle);
@@ -244,5 +245,22 @@ int main(int argc, char *argv[])
   } while(running_handles > 0 || start_count);
 
   fprintf(stderr, "exiting\n");
-  return EXIT_SUCCESS;
+  exitcode = EXIT_SUCCESS;
+
+cleanup:
+
+  if(multi) {
+    CURL **list = curl_multi_get_handles(multi);
+    if(list) {
+      int i;
+      for(i = 0; list[i]; i++) {
+        curl_multi_remove_handle(multi, list[i]);
+        curl_easy_cleanup(list[i]);
+      }
+      curl_free(list);
+    }
+    curl_multi_cleanup(multi);
+  }
+
+  return exitcode;
 }

--- a/tests/http/clients/h2-upgrade-extreme.c
+++ b/tests/http/clients/h2-upgrade-extreme.c
@@ -148,14 +148,14 @@ int main(int argc, char *argv[])
 
   if(argc != 2) {
     fprintf(stderr, "%s URL\n", argv[0]);
-    exit(2);
+    return 2;
   }
 
   url = argv[1];
   multi = curl_multi_init();
   if(!multi) {
     fprintf(stderr, "curl_multi_init failed\n");
-    exit(1);
+    return 1;
   }
 
   start_count = 200;
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
       easy = curl_easy_init();
       if(!easy) {
         fprintf(stderr, "curl_easy_init failed\n");
-        exit(1);
+        return 1;
       }
       curl_easy_setopt(easy, CURLOPT_VERBOSE, 1L);
       curl_easy_setopt(easy, CURLOPT_DEBUGFUNCTION, debug_cb);
@@ -187,7 +187,7 @@ int main(int argc, char *argv[])
       if(mc != CURLM_OK) {
         fprintf(stderr, "curl_multi_add_handle: %s\n",
                curl_multi_strerror(mc));
-        exit(1);
+        return 1;
       }
       --start_count;
     }
@@ -196,7 +196,7 @@ int main(int argc, char *argv[])
     if(mc != CURLM_OK) {
       fprintf(stderr, "curl_multi_perform: %s\n",
              curl_multi_strerror(mc));
-      exit(1);
+      return 1;
     }
 
     if(running_handles) {
@@ -204,7 +204,7 @@ int main(int argc, char *argv[])
       if(mc != CURLM_OK) {
         fprintf(stderr, "curl_multi_poll: %s\n",
                curl_multi_strerror(mc));
-        exit(1);
+        return 1;
       }
     }
 
@@ -224,12 +224,12 @@ int main(int argc, char *argv[])
         else if(msg->data.result) {
           fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
                   ": failed with %d\n", xfer_id, msg->data.result);
-          exit(1);
+          return 1;
         }
         else if(status != 206) {
           fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
                   ": wrong http status %ld (expected 206)\n", xfer_id, status);
-          exit(1);
+          return 1;
         }
         curl_multi_remove_handle(multi, msg->easy_handle);
         curl_easy_cleanup(msg->easy_handle);
@@ -244,5 +244,5 @@ int main(int argc, char *argv[])
   } while(running_handles > 0 || start_count);
 
   fprintf(stderr, "exiting\n");
-  exit(EXIT_SUCCESS);
+  return EXIT_SUCCESS;
 }

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -168,6 +168,7 @@ static int add_transfer(CURLM *multi, CURLSH *share,
   if(mc != CURLM_OK) {
     fprintf(stderr, "curl_multi_add_handle: %s\n",
             curl_multi_strerror(mc));
+    curl_easy_cleanup(easy);
     return 1;
   }
   return 0;

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -176,7 +176,7 @@ static int add_transfer(CURLM *multi, CURLSH *share,
 int main(int argc, char *argv[])
 {
   const char *url;
-  CURLM *multi;
+  CURLM *multi = NULL;
   CURLMcode mc;
   int running_handles = 0, numfds;
   CURLMsg *msg;
@@ -188,6 +188,7 @@ int main(int argc, char *argv[])
   int add_more, waits, ongoing = 0;
   char *host, *port;
   int http_version = CURL_HTTP_VERSION_1_1;
+  int exitcode = 1;
 
   if(argc != 3) {
     fprintf(stderr, "%s proto URL\n", argv[0]);
@@ -207,15 +208,15 @@ int main(int argc, char *argv[])
   }
   if(curl_url_set(cu, CURLUPART_URL, url, 0)) {
     fprintf(stderr, "not a URL: '%s'\n", url);
-    return 1;
+    goto cleanup;
   }
   if(curl_url_get(cu, CURLUPART_HOST, &host, 0)) {
     fprintf(stderr, "could not get host of '%s'\n", url);
-    return 1;
+    goto cleanup;
   }
   if(curl_url_get(cu, CURLUPART_PORT, &port, 0)) {
     fprintf(stderr, "could not get port of '%s'\n", url);
-    return 1;
+    goto cleanup;
   }
 
   memset(&resolve, 0, sizeof(resolve));
@@ -226,19 +227,19 @@ int main(int argc, char *argv[])
   multi = curl_multi_init();
   if(!multi) {
     fprintf(stderr, "curl_multi_init failed\n");
-    return 1;
+    goto cleanup;
   }
 
   share = curl_share_init();
   if(!share) {
     fprintf(stderr, "curl_share_init failed\n");
-    return 1;
+    goto cleanup;
   }
   curl_share_setopt(share, CURLSHOPT_SHARE, CURL_LOCK_DATA_SSL_SESSION);
 
 
   if(add_transfer(multi, share, &resolve, url, http_version))
-    return 1;
+    goto cleanup;
   ++ongoing;
   add_more = 6;
   waits = 3;
@@ -246,16 +247,16 @@ int main(int argc, char *argv[])
     mc = curl_multi_perform(multi, &running_handles);
     if(mc != CURLM_OK) {
       fprintf(stderr, "curl_multi_perform: %s\n",
-             curl_multi_strerror(mc));
-      return 1;
+              curl_multi_strerror(mc));
+      goto cleanup;
     }
 
     if(running_handles) {
       mc = curl_multi_poll(multi, NULL, 0, 1000000, &numfds);
       if(mc != CURLM_OK) {
         fprintf(stderr, "curl_multi_poll: %s\n",
-               curl_multi_strerror(mc));
-        return 1;
+                curl_multi_strerror(mc));
+        goto cleanup;
       }
     }
 
@@ -265,7 +266,7 @@ int main(int argc, char *argv[])
     else {
       while(add_more) {
         if(add_transfer(multi, share, &resolve, url, http_version))
-          return 1;
+          goto cleanup;
         ++ongoing;
         --add_more;
       }
@@ -287,12 +288,12 @@ int main(int argc, char *argv[])
         else if(msg->data.result) {
           fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
                   ": failed with %d\n", xfer_id, msg->data.result);
-          return 1;
+          goto cleanup;
         }
         else if(status != 200) {
           fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
                   ": wrong http status %ld (expected 200)\n", xfer_id, status);
-          return 1;
+          goto cleanup;
         }
         curl_multi_remove_handle(multi, msg->easy_handle);
         curl_easy_cleanup(msg->easy_handle);
@@ -308,5 +309,23 @@ int main(int argc, char *argv[])
   } while(ongoing || add_more);
 
   fprintf(stderr, "exiting\n");
-  return EXIT_SUCCESS;
+  exitcode = EXIT_SUCCESS;
+
+cleanup:
+
+  if(multi) {
+    CURL **list = curl_multi_get_handles(multi);
+    if(list) {
+      int i;
+      for(i = 0; list[i]; i++) {
+        curl_multi_remove_handle(multi, list[i]);
+        curl_easy_cleanup(list[i]);
+      }
+      curl_free(list);
+    }
+    curl_multi_cleanup(multi);
+  }
+  curl_url_cleanup(cu);
+
+  return exitcode;
 }

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
   CURLMcode mc;
   int running_handles = 0, numfds;
   CURLMsg *msg;
-  CURLSH *share;
+  CURLSH *share = NULL;
   CURLU *cu;
   struct curl_slist resolve;
   char resolve_buf[1024];
@@ -325,6 +325,7 @@ cleanup:
     }
     curl_multi_cleanup(multi);
   }
+  curl_share_cleanup(share);
   curl_url_cleanup(cu);
 
   return exitcode;

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -180,12 +180,6 @@ static int progress_callback(void *clientp,
   return 0;
 }
 
-#define ERR()                                                             \
-  do {                                                                    \
-    fprintf(stderr, "something unexpected went wrong - bailing out!\n");  \
-    exit(2);                                                              \
-  } while(0)
-
 static void usage(const char *msg)
 {
   if(msg)
@@ -196,6 +190,13 @@ static void usage(const char *msg)
     "  -V http_version (http/1.1, h2, h3) http version to use\n"
   );
 }
+
+#define ERR()                                                             \
+  do {                                                                    \
+    fprintf(stderr, "something unexpected went wrong - bailing out!\n");  \
+    return 2;                                                             \
+  } while(0)
+
 #endif /* !_MSC_VER */
 
 int main(int argc, char *argv[])
@@ -245,19 +246,19 @@ int main(int argc, char *argv[])
   cu = curl_url();
   if(!cu) {
     fprintf(stderr, "out of memory\n");
-    exit(1);
+    return 1;
   }
   if(curl_url_set(cu, CURLUPART_URL, url, 0)) {
     fprintf(stderr, "not a URL: '%s'\n", url);
-    exit(1);
+    return 1;
   }
   if(curl_url_get(cu, CURLUPART_HOST, &host, 0)) {
     fprintf(stderr, "could not get host of '%s'\n", url);
-    exit(1);
+    return 1;
   }
   if(curl_url_get(cu, CURLUPART_PORT, &port, 0)) {
     fprintf(stderr, "could not get port of '%s'\n", url);
-    exit(1);
+    return 1;
   }
   memset(&resolve, 0, sizeof(resolve));
   curl_msnprintf(resolve_buf, sizeof(resolve_buf)-1, "%s:%s:127.0.0.1",
@@ -267,7 +268,7 @@ int main(int argc, char *argv[])
   curl = curl_easy_init();
   if(!curl) {
     fprintf(stderr, "out of memory\n");
-    exit(1);
+    return 1;
   }
   /* We want to use our own read function. */
   curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_callback);

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -1018,7 +1018,8 @@ int main(int argc, char *argv[])
             logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
 #ifdef _WIN32
-  win32_init();
+  if(win32_init())
+    return 2;
   atexit(win32_cleanup);
 #endif
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -1020,7 +1020,6 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
   if(win32_init())
     return 2;
-  atexit(win32_cleanup);
 #endif
 
   CURL_SET_BINMODE(stdin);

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -99,7 +99,8 @@ int main(int argc, char *argv[])
   }
 
 #ifdef _WIN32
-  win32_init();
+  if(win32_init())
+    return 2;
   atexit(win32_cleanup);
 #endif
 

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -101,7 +101,6 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
   if(win32_init())
     return 2;
-  atexit(win32_cleanup);
 #endif
 
 #if defined(CURLRES_IPV6)

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1145,7 +1145,8 @@ int main(int argc, char *argv[])
             logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
 #ifdef _WIN32
-  win32_init();
+  if(win32_init())
+    return 2;
   atexit(win32_cleanup);
 #endif
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1147,7 +1147,6 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
   if(win32_init())
     return 2;
-  atexit(win32_cleanup);
 #endif
 
   install_signal_handlers(false);

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1507,7 +1507,8 @@ int main(int argc, char *argv[])
   }
 
 #ifdef _WIN32
-  win32_init();
+  if(win32_init())
+    return 2;
   atexit(win32_cleanup);
 #endif
 

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1509,7 +1509,6 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
   if(win32_init())
     return 2;
-  atexit(win32_cleanup);
 #endif
 
   CURL_SET_BINMODE(stdin);

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -1086,7 +1086,8 @@ int main(int argc, char *argv[])
   }
 
 #ifdef _WIN32
-  win32_init();
+  if(win32_init())
+    return 2;
   atexit(win32_cleanup);
 #endif
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -1088,7 +1088,6 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
   if(win32_init())
     return 2;
-  atexit(win32_cleanup);
 #endif
 
   CURL_SET_BINMODE(stdin);

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2209,7 +2209,6 @@ int main(int argc, char *argv[])
 #ifdef _WIN32
   if(win32_init())
     return 2;
-  atexit(win32_cleanup);
 #endif
 
   install_signal_handlers(false);

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1611,7 +1611,7 @@ static void http_connect(curl_socket_t *infdp,
           if(!req2) {
             req2 = malloc(sizeof(*req2));
             if(!req2)
-              exit(1);
+              goto http_connect_cleanup;  /* fail */
           }
           memset(req2, 0, sizeof(*req2));
           logmsg("====> Client connect DATA");

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2207,7 +2207,8 @@ int main(int argc, char *argv[])
             is_proxy ? "-proxy" : "", socket_type);
 
 #ifdef _WIN32
-  win32_init();
+  if(win32_init())
+    return 2;
   atexit(win32_cleanup);
 #endif
 

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -646,7 +646,6 @@ int main(int argc, char **argv)
 #ifdef _WIN32
   if(win32_init())
     return 2;
-  atexit(win32_cleanup);
 #endif
 
   install_signal_handlers(true);

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -644,7 +644,8 @@ int main(int argc, char **argv)
             logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
 #ifdef _WIN32
-  win32_init();
+  if(win32_init())
+    return 2;
   atexit(win32_cleanup);
 #endif
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -153,7 +153,7 @@ void win32_perror(const char *msg)
   fprintf(stderr, "%s\n", buf);
 }
 
-void win32_init(void)
+int win32_init(void)
 {
 #ifdef USE_WINSOCK
   WORD wVersionRequested;
@@ -166,7 +166,7 @@ void win32_init(void)
   if(err) {
     perror("Winsock init failed");
     logmsg("Error initialising Winsock -- aborting");
-    exit(1);
+    return 1;
   }
 
   if(LOBYTE(wsaData.wVersion) != LOBYTE(wVersionRequested) ||
@@ -174,9 +174,10 @@ void win32_init(void)
     WSACleanup();
     perror("Winsock init failed");
     logmsg("No suitable winsock.dll found -- aborting");
-    exit(1);
+    return 1;
   }
 #endif  /* USE_WINSOCK */
+  return 0;
 }
 
 void win32_cleanup(void)

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -153,6 +153,16 @@ void win32_perror(const char *msg)
   fprintf(stderr, "%s\n", buf);
 }
 
+static void win32_cleanup(void)
+{
+#ifdef USE_WINSOCK
+  WSACleanup();
+#endif  /* USE_WINSOCK */
+
+  /* flush buffers of all streams regardless of their mode */
+  _flushall();
+}
+
 int win32_init(void)
 {
 #ifdef USE_WINSOCK
@@ -177,17 +187,8 @@ int win32_init(void)
     return 1;
   }
 #endif  /* USE_WINSOCK */
+  atexit(win32_cleanup);
   return 0;
-}
-
-void win32_cleanup(void)
-{
-#ifdef USE_WINSOCK
-  WSACleanup();
-#endif  /* USE_WINSOCK */
-
-  /* flush buffers of all streams regardless of their mode */
-  _flushall();
 }
 
 /* socket-safe strerror (works on Winsock errors, too) */

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -51,7 +51,7 @@ extern const char *cmdfile;
 #define perror(m) win32_perror(m)
 void win32_perror(const char *msg);
 
-void win32_init(void);
+int win32_init(void);
 void win32_cleanup(void);
 const char *sstrerror(int err);
 #else   /* _WIN32 */

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -52,7 +52,6 @@ extern const char *cmdfile;
 void win32_perror(const char *msg);
 
 int win32_init(void);
-void win32_cleanup(void);
 const char *sstrerror(int err);
 #else   /* _WIN32 */
 


### PR DESCRIPTION
To avoid breaking the control flow and align to majority of code 
already using `return`.

`exit()` has the side-effect of suppressing leak detection in cases.
Fix fallouts detected after switching to `return`.

- configure:
  - fix `getaddrinfo` run test to call `freeaddrinfo()` to pacify ASAN,
    and call `WSACleanup()` to deinit winsock2.
  - fix `getifaddrs` run test to call `freeifaddrs()` to pacify ASAN.
- tests/server:
  - setup `atexit(win32_cleanup)` via `win32_init()`.
  - return 2 instead of 1 on winsock2 init failures.
  - sws: goto cleanup instead of `exit()` in `http_connect()`.
    Follow-up to 02dfe7193704817184b522888ffa926e6b73f648 #7235
- tests/client/http:
  - cleanup memory to pacify ASAN in `h2-upgrade-extreme`,
    `tls-session-reuse`.
- examples:
  - block_ip: fix memory leak reported by CI.
  - http2-upload: avoid handle leaks.

Untouched `exit()` calls, made from callbacks:
- docs/examples: ephiperfifo.c, ghiper.c, hiperfifo.c
- tests/libtest: lib582.c, lib655.c, lib670.c
- tests/server: tftpd.c
