### PR TITLE
cmake: drop `HAVE_C_FLAG_Wno_long_double` logic for ancient Apple gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1954,22 +1954,6 @@ endif()
 
 # Some other minor tests
 
-if(CMAKE_COMPILER_IS_GNUCC AND APPLE)
-  include(CheckCCompilerFlag)
-  check_c_compiler_flag("-Wno-long-double" HAVE_C_FLAG_Wno_long_double)
-  if(HAVE_C_FLAG_Wno_long_double)
-    # The Mac version of GCC warns about use of long double. Disable it.
-    get_source_file_property(_mprintf_compile_flags "mprintf.c" COMPILE_FLAGS)
-    if(_mprintf_compile_flags)
-      string(APPEND _mprintf_compile_flags " -Wno-long-double")
-    else()
-      set(_mprintf_compile_flags "-Wno-long-double")
-    endif()
-    set_source_files_properties("mprintf.c" PROPERTIES
-      COMPILE_FLAGS ${_mprintf_compile_flags})
-  endif()
-endif()
-
 if(_cmake_try_compile_target_type_save)
   set(CMAKE_TRY_COMPILE_TARGET_TYPE ${_cmake_try_compile_target_type_save})
   unset(_cmake_try_compile_target_type_save)

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -66,6 +66,11 @@
 # undef FORMAT_INT
 #endif
 
+#if defined(__APPLE__) && !defined(__clang__) && defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wlong-double"
+#endif
+
 /* Lower-case digits.  */
 static const char lower_digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
@@ -1221,3 +1226,7 @@ int curl_mvfprintf(FILE *whereto, const char *format, va_list ap_save)
 {
   return formatf(whereto, fputc_wrapper, format, ap_save);
 }
+
+#if defined(__APPLE__) && !defined(__clang__) && defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -66,11 +66,6 @@
 # undef FORMAT_INT
 #endif
 
-#if defined(__APPLE__) && !defined(__clang__) && defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wlong-double"
-#endif
-
 /* Lower-case digits.  */
 static const char lower_digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
 
@@ -1226,7 +1221,3 @@ int curl_mvfprintf(FILE *whereto, const char *format, va_list ap_save)
 {
   return formatf(whereto, fputc_wrapper, format, ap_save);
 }
-
-#if defined(__APPLE__) && !defined(__clang__) && defined(__GNUC__)
-#pragma GCC diagnostic pop
-#endif


### PR DESCRIPTION
The initial curl CMake commit introduced it in 2009-04-02 via
4c5307b45655ba75ab066564afdc0c111a8b9291. Suppressing a stray
`-Wlong-double` warning in `mprintf.c`. This was before Apple switched
to clang, and likely affected the Apple distributed GCC, version 4.2.1
at the time. It applied the workaround to CMake builds only, though
the issue seems build-tool agnostic. Yet, it was not suppressed or
reported for autotools builds.

For these reasons this logic seems obsolete and this patch drops it with
no replacement. It saves a feature detection for GCC builds for macOS.

In PR sub-commits I added (and reverted) in-source suppression. In case
it becomes necessary, that should fix it for all build tools.
