### PR TITLE
GHA/linux: improve 'test configs' step, don't set `TFLAGS` for pytest

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -498,7 +498,6 @@ jobs:
 
       - name: 'run pytest event based'
         env:
-          TFLAGS: '${{ matrix.build.tflags }}'
           CURL_TEST_EVENT: 1
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -454,9 +454,7 @@ jobs:
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'test configs'
-        run: |
-          cat bld/tests/config || true
-          cat bld/tests/http/config.ini || true
+        run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true
 
       - name: 'build'
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -612,9 +612,7 @@ jobs:
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
       - name: 'test configs'
-        run: |
-          cat bld/tests/config || true
-          cat bld/tests/http/config.ini || true
+        run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true
 
       - name: 'build'
         run: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -688,7 +688,6 @@ jobs:
       - name: 'run pytest'
         if: contains(matrix.build.install_steps, 'pytest')
         env:
-          TFLAGS: '${{ matrix.build.tflags }}'
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
         run: |


### PR DESCRIPTION
- omit comments from th config dump, show filenames for each line.
- `TFLAGS` is not used by pytest, don't set it.
