### PR TITLE
 cmake: improve httpd detection for pytest

### DIFF
--- a/tests/http/CMakeLists.txt
+++ b/tests/http/CMakeLists.txt
@@ -36,7 +36,10 @@ mark_as_advanced(VSFTPD)
 
 find_program(HTTPD "apache2")  # /usr/sbin/apache2
 if(NOT HTTPD)
-  set(HTTPD "")
+  find_program(HTTPD "httpd")
+  if(NOT HTTPD)
+    set(HTTPD "")
+  endif()
 endif()
 mark_as_advanced(HTTPD)
 

--- a/tests/http/CMakeLists.txt
+++ b/tests/http/CMakeLists.txt
@@ -34,12 +34,9 @@ if(NOT VSFTPD)
 endif()
 mark_as_advanced(VSFTPD)
 
-find_program(HTTPD "apache2")  # /usr/sbin/apache2
+find_program(HTTPD NAMES "/usr/sbin/apache2" "httpd" "apache2")
 if(NOT HTTPD)
-  find_program(HTTPD "httpd")
-  if(NOT HTTPD)
-    set(HTTPD "")
-  endif()
+  set(HTTPD "")
 endif()
 mark_as_advanced(HTTPD)
 


### PR DESCRIPTION
Look for `httpd` in addition to `apache2`, like `./configure` does.
It fixes detection with macOS Homebrew for example.
