### PR TITLE
GHA/macos: use quictls in some jobs, other small improvements

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -189,6 +189,7 @@ jobs:
           while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
 
       - name: 'brew unlink openssl'
+        if: ${{ contains(matrix.build.install, 'libressl') }}
         run: |
           if test -d $(brew --prefix)/include/openssl; then
             brew unlink openssl

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -123,9 +123,10 @@ jobs:
             compiler: clang
             configure: --enable-debug --with-openssl=$(brew --prefix openssl)
             tflags: --test-event
-          - name: 'OpenSSL libssh2 !ldap 10.15'
+          - name: 'quictls libssh2 !ldap 10.15'
             compiler: clang
-            configure: --enable-debug --disable-ldap --with-openssl=$(brew --prefix openssl)
+            install: quictls
+            configure: --enable-debug --disable-ldap --with-openssl=$(brew --prefix quictls)
             macos-version-min: '10.15'
           # cmake
           - name: 'OpenSSL gsasl rtmp AppleIDN'
@@ -145,6 +146,9 @@ jobs:
           - name: 'LibreSSL !ldap heimdal c-ares +examples'
             install: libressl heimdal
             generate: -DOPENSSL_ROOT_DIR=$(brew --prefix libressl) -DENABLE_ARES=ON -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=$(brew --prefix heimdal) -DCURL_DISABLE_LDAP=ON
+          - name: 'quictls brotli zstd'
+            install: brotli quictls zstd
+            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix quictls)
           - name: 'wolfSSL !ldap brotli zstd'
             install: brotli wolfssl zstd
             generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON
@@ -189,7 +193,7 @@ jobs:
           while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
 
       - name: 'brew unlink openssl'
-        if: ${{ contains(matrix.build.install, 'libressl') }}
+        if: ${{ contains(matrix.build.install, 'libressl') || contains(matrix.build.install, 'quictls') }}
         run: |
           if test -d $(brew --prefix)/include/openssl; then
             brew unlink openssl

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -344,7 +344,7 @@ jobs:
         if: ${{ contains(matrix.build.name, '+examples') }}
         run: |
           if [ -n '${{ matrix.build.generate }}' ]; then
-            cmake --build bld --target curl-examples --verbose
+            cmake --build bld --verbose --target curl-examples
           else
             make -C bld examples V=1
           fi

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -184,7 +184,7 @@ jobs:
         run: |
           echo ${{ matrix.build.generate && 'ninja' || 'automake libtool' }} \
             pkgconf libpsl libssh2 \
-            ${{ !matrix.build.clang-tidy && 'nghttp2 stunnel' || '' }} \
+            ${{ !matrix.build.clang-tidy && 'libnghttp2 stunnel' || '' }} \
             ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
           while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --no-lock --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -137,18 +137,15 @@ jobs:
             generate: -DOPENSSL_ROOT_DIR=$(brew --prefix openssl) -DUSE_APPLE_IDN=ON -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=$(brew --prefix llvm)/bin/clang-tidy
             clang-tidy: true
             chkprefill: _chkprefill
-          - name: 'OpenSSL +static libssh +examples'
-            install: libssh
-            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix openssl) -DBUILD_STATIC_LIBS=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
+          - name: 'quictls +static libssh +examples'
+            install: quictls libssh
+            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix quictls) -DBUILD_STATIC_LIBS=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
           - name: 'SecureTransport debug'
             generate: -DCURL_USE_SECTRANSP=ON -DENABLE_DEBUG=ON
             macos-version-min: '10.8'
           - name: 'LibreSSL !ldap heimdal c-ares +examples'
             install: libressl heimdal
             generate: -DOPENSSL_ROOT_DIR=$(brew --prefix libressl) -DENABLE_ARES=ON -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=$(brew --prefix heimdal) -DCURL_DISABLE_LDAP=ON
-          - name: 'quictls brotli zstd'
-            install: brotli quictls zstd
-            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix quictls)
           - name: 'wolfSSL !ldap brotli zstd'
             install: brotli wolfssl zstd
             generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -126,7 +126,7 @@ jobs:
           - name: 'quictls libssh2 !ldap 10.15'
             compiler: clang
             install: quictls
-            configure: --enable-debug --disable-ldap --with-openssl=$(brew --prefix quictls) LDFLAGS="${LDFLAGS} $(brew --prefix quictls)/lib"
+            configure: --enable-debug --disable-ldap --with-openssl=$(brew --prefix quictls) LDFLAGS="${LDFLAGS} -L$(brew --prefix quictls)/lib"
             macos-version-min: '10.15'
           # cmake
           - name: 'OpenSSL gsasl rtmp AppleIDN'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -126,7 +126,7 @@ jobs:
           - name: 'quictls libssh2 !ldap 10.15'
             compiler: clang
             install: quictls
-            configure: --enable-debug --disable-ldap --with-openssl=$(brew --prefix quictls)
+            configure: --enable-debug --disable-ldap --with-openssl=$(brew --prefix quictls) LDFLAGS="${LDFLAGS} $(brew --prefix quictls)/lib"
             macos-version-min: '10.15'
           # cmake
           - name: 'OpenSSL gsasl rtmp AppleIDN'


### PR DESCRIPTION
- enable quictls in autotools and cmake jobs. autotools requires
  a workaround due to wrong libpath in the quictls pkg-config.
  nghttp3 is offered by Homebrew, but not ngtcp2, to enable H3.

- install `libnghttp2` rather than `nghttp2`.
  `libnghttp2` is preinstalled and smaller. It also avoids detecting
  `nghttpx`, which confuses `pytest`.

- limit `brew unlink openssl` to libressl/quictls jobs.

---

- [x] add quictls to the mix.
