### PR TITLE
GHA/macos: add initial pytest support

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -139,6 +139,7 @@ jobs:
             chkprefill: _chkprefill
           - name: 'quictls +static libssh +examples'
             install: quictls libssh
+            install_steps: pytest
             generate: -DOPENSSL_ROOT_DIR=$(brew --prefix quictls) -DBUILD_STATIC_LIBS=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
           - name: 'SecureTransport debug'
             generate: -DCURL_USE_SECTRANSP=ON -DENABLE_DEBUG=ON
@@ -186,6 +187,7 @@ jobs:
           echo ${{ matrix.build.generate && 'ninja' || 'automake libtool' }} \
             pkgconf libpsl libssh2 \
             ${{ !matrix.build.clang-tidy && 'nghttp2 stunnel' || '' }} \
+            ${{ contains(matrix.build.install_steps, 'pytest') && 'caddy httpd vsftpd' || '' }} \
             ${{ matrix.build.install }} | xargs -Ix -n1 echo brew '"x"' > /tmp/Brewfile
           while [[ $? == 0 ]]; do for i in 1 2 3; do brew update && brew bundle install --file /tmp/Brewfile && break 2 || { echo Error: wait to try again; sleep 10; } done; false Too many retries; done
 
@@ -270,6 +272,9 @@ jobs:
           echo '::group::raw'; cat bld/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld/lib/curl_config.h | sort || true
 
+      - name: 'test configs'
+        run: grep -H -v '^#' bld/tests/config bld/tests/http/config.ini || true
+
       - name: 'build-cert'
         if: contains(matrix.build.generate, '-DCURL_USE_SECTRANSP=ON') || contains(matrix.build.configure, '--with-secure-transport')
         run: |
@@ -325,6 +330,28 @@ jobs:
             cmake --build bld --target ${{ matrix.build.torture && 'test-torture' || 'test-ci' }}
           else
             make -C bld V=1 ${{ matrix.build.torture && 'test-torture' || 'test-ci' }}
+          fi
+
+      - name: 'install pytest prereqs'
+        if: ${{ !matrix.build.clang-tidy && contains(matrix.build.install_steps, 'pytest') }}
+        run: |
+          source $HOME/venv/bin/activate
+          python3 -m pip install -r tests/http/requirements.txt
+
+      - name: 'run pytest'
+        if: ${{ !matrix.build.clang-tidy && contains(matrix.build.install_steps, 'pytest') }}
+        env:
+          CURL_CI: github
+          PYTEST_ADDOPTS: '--color=yes --verbose'
+        run: |
+          brew services start caddy
+          brew services start httpd
+          brew services start vsftpd
+          source $HOME/venv/bin/activate
+          if [ -n '${{ matrix.build.generate }}' ]; then
+            cmake --build bld --verbose --target curl-pytest-ci
+          else
+            make -C bld V=1 pytest-ci
           fi
 
       - name: 'build examples'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -139,7 +139,6 @@ jobs:
             chkprefill: _chkprefill
           - name: 'quictls +static libssh +examples'
             install: quictls libssh
-            install_steps: pytest
             generate: -DOPENSSL_ROOT_DIR=$(brew --prefix quictls) -DBUILD_STATIC_LIBS=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
           - name: 'SecureTransport debug'
             generate: -DCURL_USE_SECTRANSP=ON -DENABLE_DEBUG=ON

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -118,7 +118,6 @@ jobs:
             configure: --enable-debug --with-openssl=$(brew --prefix libressl)
           - name: 'OpenSSL'
             compiler: clang
-            install_steps: pytest
             configure: --enable-debug --with-openssl=$(brew --prefix openssl)
           - name: 'OpenSSL event-based'
             compiler: clang

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -346,6 +346,7 @@ jobs:
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
         run: |
+          brew services start httpd
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build bld --verbose --target curl-pytest-ci

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -342,11 +342,9 @@ jobs:
         if: ${{ !matrix.build.clang-tidy && contains(matrix.build.install_steps, 'pytest') }}
         env:
           CURL_CI: github
-          PYTEST_ADDOPTS: '--color=yes --verbose'
+          PYTEST_ADDOPTS: '--color=yes'
         run: |
-          brew services start caddy
           brew services start httpd
-          brew services start vsftpd
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build bld --verbose --target curl-pytest-ci

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -140,7 +140,7 @@ jobs:
           - name: 'quictls +static libssh +examples'
             install: quictls libssh
             install_steps: pytest
-            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix quictls) -DBUILD_STATIC_LIBS=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DTEST_NGHTTPX= -DHTTPD_NGHTTPX=
+            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix quictls) -DBUILD_STATIC_LIBS=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
           - name: 'SecureTransport debug'
             generate: -DCURL_USE_SECTRANSP=ON -DENABLE_DEBUG=ON
             macos-version-min: '10.8'
@@ -236,6 +236,7 @@ jobs:
             for _chkprefill in '' ${{ matrix.build.chkprefill }}; do
               options=''
               [ -n '${{ matrix.build.macos-version-min }}' ] && options+=' -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ matrix.build.macos-version-min }}'
+              [[ '${{ matrix.build.install_steps }}' = *'pytest'* ]] && options+=' -DTEST_NGHTTPX= -DHTTPD_NGHTTPX='
               [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
               cmake -B "bld${_chkprefill}" -G Ninja -D_CURL_PREFILL=ON \
                 -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON -DCURL_WERROR=ON \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -346,7 +346,6 @@ jobs:
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
         run: |
-          brew services start httpd
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build bld --verbose --target curl-pytest-ci

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -344,7 +344,6 @@ jobs:
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
         run: |
-          brew services start httpd
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then
             cmake --build bld --verbose --target curl-pytest-ci

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -118,6 +118,7 @@ jobs:
             configure: --enable-debug --with-openssl=$(brew --prefix libressl)
           - name: 'OpenSSL'
             compiler: clang
+            install_steps: pytest
             configure: --enable-debug --with-openssl=$(brew --prefix openssl)
           - name: 'OpenSSL event-based'
             compiler: clang

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -258,6 +258,7 @@ jobs:
               CFLAGS+=" --sysroot=${sysroot}"
             fi
             [ -n '${{ matrix.build.macos-version-min }}' ] && CFLAGS+=' -mmacosx-version-min=${{ matrix.build.macos-version-min }}'
+            [[ '${{ matrix.build.install_steps }}' = *'pytest'* ]] && options+=' --with-test-nghttpx= ac_cv_path_HTTPD_NGHTTPX='
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
               --disable-dependency-tracking \
               --with-libpsl=$(brew --prefix libpsl) \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -140,7 +140,7 @@ jobs:
           - name: 'quictls +static libssh +examples'
             install: quictls libssh
             install_steps: pytest
-            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix quictls) -DBUILD_STATIC_LIBS=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
+            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix quictls) -DBUILD_STATIC_LIBS=ON -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON -DTEST_NGHTTPX= -DHTTPD_NGHTTPX=
           - name: 'SecureTransport debug'
             generate: -DCURL_USE_SECTRANSP=ON -DENABLE_DEBUG=ON
             macos-version-min: '10.8'


### PR DESCRIPTION
Add support for running pytest in GHA/macos jobs.

Experimental, with caveats:
- slow.
- `httpd` often fails to start.
- 10-15 tests (depending on C compiler) fail consistently:
  02_20, 02_33, 02_34, 03_01, 03_03, 05_04, 07_42.
- Homebrew build of vsftpd misses TLS support.
- `nghttpx` temporarily disabled for pytest.

You can test pytest by adding `install_steps: pytest` to a job.

---

- [x] rebase on #16517.

Failing with all compilers consistently:
```
FAILED tests/http/test_02_download.py::TestDownload::test_02_33_max_host_conns[1-http/1.1] - assert 0 > 0
FAILED tests/http/test_02_download.py::TestDownload::test_02_33_max_host_conns[1-h2] - assert 0 > 0
FAILED tests/http/test_02_download.py::TestDownload::test_02_33_max_host_conns[5-http/1.1] - assert 0 > 0
FAILED tests/http/test_02_download.py::TestDownload::test_02_33_max_host_conns[5-h2] - assert 0 > 0
FAILED tests/http/test_02_download.py::TestDownload::test_02_34_max_total_conns[1-http/1.1] - assert 0 > 0
FAILED tests/http/test_02_download.py::TestDownload::test_02_34_max_total_conns[1-h2] - assert 0 > 0
FAILED tests/http/test_02_download.py::TestDownload::test_02_34_max_total_conns[5-http/1.1] - assert 0 > 0
FAILED tests/http/test_02_download.py::TestDownload::test_02_34_max_total_conns[5-h2] - assert 0 > 0
FAILED tests/http/test_03_goaway.py::TestGoAway::test_03_01_h2_goaway - assert 1 == 2
FAILED tests/http/test_03_goaway.py::TestGoAway::test_03_03_h1_goaway - AssertionError: expected 2, but 1 were made
```                                                           
                                                              
with llvm@15 (may be flakyness):                                              
```                                                                           
FAILED tests/http/test_02_download.py::TestDownload::test_02_20_h2_small_frames - assert False
```                                                                           
                                                                              
with gcc-12:                                                                  
```                                                                           
FAILED tests/http/test_07_upload.py::TestUpload::test_07_42a_upload_disconnect[http/1.1] - AssertionError: expected exit code 18, got 92
FAILED tests/http/test_07_upload.py::TestUpload::test_07_42b_upload_disconnect[http/1.1] - AssertionError: expected exit code 52, got 0
FAILED tests/http/test_07_upload.py::TestUpload::test_07_42c_upload_disconnect[http/1.1] - AssertionError: expected exit code 52, got 0
```
 
Seen with clang and gcc (may be flakiness):
```
FAILED tests/http/test_05_errors.py::TestErrors::test_05_04_unclean_tls_shutdown[http/1.0] - AssertionError: expected exit code 0, got 56
```

/cc @icing if you're interested, or may have suggestions for the failing tests?
