### PR TITLE
test488: set --output-dir

### DIFF
--- a/tests/data/test488
+++ b/tests/data/test488
@@ -36,7 +36,7 @@ http
 Download two URLs provided on stdin
 </name>
 <command>
---output-dir log --url @-
+--output-dir %LOGDIR --url @-
 </command>
 <stdin>
 http://%HOSTIP:%HTTPPORT/a

--- a/tests/data/test488
+++ b/tests/data/test488
@@ -36,7 +36,7 @@ http
 Download two URLs provided on stdin
 </name>
 <command>
---url @-
+--output-dir log --url @-
 </command>
 <stdin>
 http://%HOSTIP:%HTTPPORT/a


### PR DESCRIPTION
Otherwise the downloaded files land in the `tests` directory and show up in git status.