### PR TITLE
lib533.c: Comment fixed

### DIFF
--- a/tests/libtest/lib533.c
+++ b/tests/libtest/lib533.c
@@ -21,7 +21,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-/* used for test case 533, 534 and 535 */
+/* used for test case 533, 534, 535 and 546 */
 
 #include "test.h"
 


### PR DESCRIPTION
This PR fixes the comment issue in lib533. Test 546 also depends on lib533.

https://github.com/curl/curl/blob/049352dd80e1ab73945c49a3bac2e4a08db32f98/tests/data/test546#L34-L36