### PR TITLE
examples: prefer `return` over `exit()` (cont.)

### DIFF
--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -418,7 +418,7 @@ static int init_fifo(GlobalInfo *g)
   struct epoll_event epev;
 
   fprintf(MSG_OUT, "Creating named pipe \"%s\"\n", fifo);
-  if(lstat (fifo, &st) == 0) {
+  if(lstat(fifo, &st) == 0) {
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");
@@ -426,7 +426,7 @@ static int init_fifo(GlobalInfo *g)
     }
   }
   unlink(fifo);
-  if(mkfifo (fifo, 0600) == -1) {
+  if(mkfifo(fifo, 0600) == -1) {
     perror("mkfifo");
     return 1;
   }

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -449,9 +449,9 @@ static int init_fifo(GlobalInfo *g)
 
 static void clean_fifo(GlobalInfo *g)
 {
-    epoll_ctl(g->epfd, EPOLL_CTL_DEL, g->fifofd, NULL);
-    fclose(g->input);
-    unlink(fifo);
+  epoll_ctl(g->epfd, EPOLL_CTL_DEL, g->fifofd, NULL);
+  fclose(g->input);
+  unlink(fifo);
 }
 
 

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -406,18 +406,18 @@ static int init_fifo(GlobalInfo *g)
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");
-      exit(1);
+      return 1;
     }
   }
   unlink(fifo);
   if(mkfifo (fifo, 0600) == -1) {
     perror("mkfifo");
-    exit(1);
+    return 1;
   }
   sockfd = open(fifo, O_RDWR | O_NONBLOCK, 0);
   if(sockfd == -1) {
     perror("open");
-    exit(1);
+    return 1;
   }
   g->input = fdopen(sockfd, "r");
 
@@ -436,7 +436,8 @@ int main(int argc, char **argv)
   memset(&g, 0, sizeof(GlobalInfo));
   g.loop = ev_default_loop(0);
 
-  init_fifo(&g);
+  if(init_fifo(&g))
+    return 1;
   g.multi = curl_multi_init();
 
   ev_timer_init(&g.timer_event, timer_cb, 0., 0.);

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -402,7 +402,7 @@ static int init_fifo(GlobalInfo *g)
   curl_socket_t sockfd;
 
   fprintf(MSG_OUT, "Creating named pipe \"%s\"\n", fifo);
-  if(lstat (fifo, &st) == 0) {
+  if(lstat(fifo, &st) == 0) {
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");
@@ -410,7 +410,7 @@ static int init_fifo(GlobalInfo *g)
     }
   }
   unlink(fifo);
-  if(mkfifo (fifo, 0600) == -1) {
+  if(mkfifo(fifo, 0600) == -1) {
     perror("mkfifo");
     return 1;
   }

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -397,7 +397,7 @@ int init_fifo(void)
   }
 
   unlink(fifo);
-  if(mkfifo (fifo, 0600) == -1) {
+  if(mkfifo(fifo, 0600) == -1) {
     perror("mkfifo");
     return CURL_SOCKET_BAD;
   }

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -392,21 +392,21 @@ int init_fifo(void)
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");
-      exit(1);
+      return CURL_SOCKET_BAD;
     }
   }
 
   unlink(fifo);
   if(mkfifo (fifo, 0600) == -1) {
     perror("mkfifo");
-    exit(1);
+    return CURL_SOCKET_BAD;
   }
 
   socket = open(fifo, O_RDWR | O_NONBLOCK, 0);
 
-  if(socket == -1) {
+  if(socket == CURL_SOCKET_BAD) {
     perror("open");
-    exit(1);
+    return socket;
   }
   MSG_OUT("Now, pipe some URL's into > %s\n", fifo);
 
@@ -421,6 +421,8 @@ int main(void)
   GIOChannel* ch;
 
   fd = init_fifo();
+  if(fd == CURL_SOCKET_BAD)
+    return 1;
   ch = g_io_channel_unix_new(fd);
   g_io_add_watch(ch, G_IO_IN, fifo_cb, g);
   gmain = g_main_loop_new(NULL, FALSE);

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -399,7 +399,7 @@ static int init_fifo(GlobalInfo *g)
   curl_socket_t sockfd;
 
   fprintf(MSG_OUT, "Creating named pipe \"%s\"\n", fifo);
-  if(lstat (fifo, &st) == 0) {
+  if(lstat(fifo, &st) == 0) {
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -403,18 +403,18 @@ static int init_fifo(GlobalInfo *g)
     if((st.st_mode & S_IFMT) == S_IFREG) {
       errno = EEXIST;
       perror("lstat");
-      exit(1);
+      return 1;
     }
   }
   unlink(fifo);
   if(mkfifo (fifo, 0600) == -1) {
     perror("mkfifo");
-    exit(1);
+    return 1;
   }
   sockfd = open(fifo, O_RDWR | O_NONBLOCK, 0);
   if(sockfd == -1) {
     perror("open");
-    exit(1);
+    return 1;
   }
   g->input = fdopen(sockfd, "r");
 
@@ -440,7 +440,8 @@ int main(int argc, char **argv)
 
   memset(&g, 0, sizeof(GlobalInfo));
   g.evbase = event_base_new();
-  init_fifo(&g);
+  if(init_fifo(&g))
+    return 1;
   g.multi = curl_multi_init();
   evtimer_assign(&g.timer_event, g.evbase, timer_cb, &g);
 


### PR DESCRIPTION
Some of these calls were not in callbacks. These examples may leak
handles.

Also fix some whitespace.

Follow-up to 08c7c937dc0dbd1f92f73360e5d8b2bb2ee6afa8 #16507