### PR TITLE
tests/server: round of tidy-ups

### DIFF
--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -102,7 +102,6 @@ struct configurable {
 
 static struct configurable config;
 
-const char *serverlogfile = DEFAULT_LOGFILE;
 static const char *configfile = DEFAULT_CONFIG;
 static const char *logdir = "log";
 static char loglockfile[256];

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -927,6 +927,8 @@ int main(int argc, char *argv[])
   int error;
   int arg = 1;
 
+  serverlogfile = DEFAULT_LOGFILE;
+
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {
       printf("mqttd IPv4%s\n",

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -66,10 +66,6 @@
 
 #define DEFAULT_PORT 1883 /* MQTT default port */
 
-#ifndef DEFAULT_LOGFILE
-#define DEFAULT_LOGFILE "log/mqttd.log"
-#endif
-
 #ifndef DEFAULT_CONFIG
 #define DEFAULT_CONFIG "mqttd.config"
 #endif
@@ -927,7 +923,7 @@ int main(int argc, char *argv[])
   int error;
   int arg = 1;
 
-  serverlogfile = DEFAULT_LOGFILE;
+  serverlogfile = "log/mqttd.log";
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -64,11 +64,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#ifdef USE_WINSOCK
-#undef  EINTR
-#define EINTR    4 /* errno.h value */
-#endif
-
 #define DEFAULT_PORT 1883 /* MQTT default port */
 
 #ifndef DEFAULT_LOGFILE

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -53,8 +53,6 @@
 static bool use_ipv6 = FALSE;
 static const char *ipv_inuse = "IPv4";
 
-const char *serverlogfile = ""; /* for a util.c function we don't use */
-
 int main(int argc, char *argv[])
 {
   int arg = 1;

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -117,10 +117,6 @@ static void storerequest(char *reqbuf, size_t totalsize);
 
 #define DEFAULT_PORT 8999
 
-#ifndef DEFAULT_LOGFILE
-#define DEFAULT_LOGFILE "log/rtspd.log"
-#endif
-
 static const char *logdir = "log";
 static char loglockfile[256];
 
@@ -1045,7 +1041,7 @@ int main(int argc, char *argv[])
 
   memset(&req, 0, sizeof(req));
 
-  serverlogfile = DEFAULT_LOGFILE;
+  serverlogfile = "log/rtspd.log";
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -128,7 +128,6 @@ static void storerequest(char *reqbuf, size_t totalsize);
 #define DEFAULT_LOGFILE "log/rtspd.log"
 #endif
 
-const char *serverlogfile = DEFAULT_LOGFILE;
 static const char *logdir = "log";
 static char loglockfile[256];
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1045,6 +1045,8 @@ int main(int argc, char *argv[])
 
   memset(&req, 0, sizeof(req));
 
+  serverlogfile = DEFAULT_LOGFILE;
+
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {
       printf("rtspd IPv4%s"

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -56,13 +56,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#ifdef USE_WINSOCK
-#undef  EINTR
-#define EINTR    4 /* errno.h value */
-#undef  ERANGE
-#define ERANGE  34 /* errno.h value */
-#endif
-
 #ifdef USE_IPV6
 static bool use_ipv6 = FALSE;
 #endif

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -154,16 +154,6 @@ static char loglockfile[256];
 
 #define END_OF_HEADERS "\r\n\r\n"
 
-enum {
-  DOCNUMBER_NOTHING = -7,
-  DOCNUMBER_QUIT    = -6,
-  DOCNUMBER_BADCONNECT = -5,
-  DOCNUMBER_INTERNAL = -4,
-  DOCNUMBER_CONNECT = -3,
-  DOCNUMBER_WERULEZ = -2,
-  DOCNUMBER_404     = -1
-};
-
 
 /* sent as reply to a QUIT */
 static const char *docquit =

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1393,6 +1393,8 @@ int main(int argc, char *argv[])
   enum sockmode mode = PASSIVE_LISTEN; /* default */
   const char *addr = NULL;
 
+  serverlogfile = DEFAULT_LOGFILE;
+
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {
       printf("sockfilt IPv4%s\n",

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -116,10 +116,6 @@
 
 #define DEFAULT_PORT 8999
 
-#ifndef DEFAULT_LOGFILE
-#define DEFAULT_LOGFILE "log/sockfilt.log"
-#endif
-
 /* buffer is this excessively large only to be able to support things like
   test 1003 which tests exceedingly large server response lines */
 #define BUFFER_SIZE 17010
@@ -1393,7 +1389,7 @@ int main(int argc, char *argv[])
   enum sockmode mode = PASSIVE_LISTEN; /* default */
   const char *addr = NULL;
 
-  serverlogfile = DEFAULT_LOGFILE;
+  serverlogfile = "log/sockfilt.log";
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -135,8 +135,6 @@
   test 1003 which tests exceedingly large server response lines */
 #define BUFFER_SIZE 17010
 
-const char *serverlogfile = DEFAULT_LOGFILE;
-
 static bool verbose = FALSE;
 static bool bind_only = FALSE;
 #ifdef USE_IPV6

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -114,17 +114,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#ifdef USE_WINSOCK
-#undef  EINTR
-#define EINTR    4 /* errno.h value */
-#undef  EAGAIN
-#define EAGAIN  11 /* errno.h value */
-#undef  ENOMEM
-#define ENOMEM  12 /* errno.h value */
-#undef  EINVAL
-#define EINVAL  22 /* errno.h value */
-#endif
-
 #define DEFAULT_PORT 8999
 
 #ifndef DEFAULT_LOGFILE

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -87,10 +87,6 @@
 
 #define DEFAULT_PORT 8905
 
-#ifndef DEFAULT_LOGFILE
-#define DEFAULT_LOGFILE "log/socksd.log"
-#endif
-
 #ifndef DEFAULT_REQFILE
 #define DEFAULT_REQFILE "log/socksd-request.log"
 #endif
@@ -973,7 +969,7 @@ int main(int argc, char *argv[])
   bool unlink_socket = false;
 #endif
 
-  serverlogfile = DEFAULT_LOGFILE;
+  serverlogfile = "log/socksd.log";
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -85,11 +85,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#ifdef USE_WINSOCK
-#undef  EINTR
-#define EINTR    4 /* errno.h value */
-#endif
-
 #define DEFAULT_PORT 8905
 
 #ifndef DEFAULT_LOGFILE

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -973,6 +973,8 @@ int main(int argc, char *argv[])
   bool unlink_socket = false;
 #endif
 
+  serverlogfile = DEFAULT_LOGFILE;
+
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {
       printf("socksd IPv4%s\n",

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -134,7 +134,6 @@ struct configurable {
 
 static struct configurable config;
 
-const char *serverlogfile = DEFAULT_LOGFILE;
 static const char *reqlogfile = DEFAULT_REQFILE;
 static const char *configfile = DEFAULT_CONFIG;
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -135,7 +135,6 @@ static void storerequest(const char *reqbuf, size_t totalsize);
 #define DEFAULT_LOGFILE "log/sws.log"
 #endif
 
-const char *serverlogfile = DEFAULT_LOGFILE;
 static const char *logdir = "log";
 static char loglockfile[256];
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -150,7 +150,7 @@ static char loglockfile[256];
 
 /* file in which additional instructions may be found */
 #define DEFAULT_CMDFILE "log/server.cmd"
-const char *cmdfile = DEFAULT_CMDFILE;
+static const char *cmdfile = DEFAULT_CMDFILE;
 
 /* very-big-path support */
 #define MAXDOCNAMELEN 140000

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -58,15 +58,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#ifdef USE_WINSOCK
-#undef  EINTR
-#define EINTR    4 /* errno.h value */
-#undef  EAGAIN
-#define EAGAIN  11 /* errno.h value */
-#undef  ERANGE
-#define ERANGE  34 /* errno.h value */
-#endif
-
 static int socket_domain = AF_INET;
 static bool use_gopher = FALSE;
 static int serverlogslocked = 0;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2043,6 +2043,8 @@ int main(int argc, char *argv[])
   /* a default CONNECT port is basically pointless but still ... */
   size_t socket_idx;
 
+  serverlogfile = DEFAULT_LOGFILE;
+
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {
       puts("sws IPv4"

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -122,10 +122,6 @@ static void storerequest(const char *reqbuf, size_t totalsize);
 
 #define DEFAULT_PORT 8999
 
-#ifndef DEFAULT_LOGFILE
-#define DEFAULT_LOGFILE "log/sws.log"
-#endif
-
 static const char *logdir = "log";
 static char loglockfile[256];
 
@@ -2043,7 +2039,7 @@ int main(int argc, char *argv[])
   /* a default CONNECT port is basically pointless but still ... */
   size_t socket_idx;
 
-  serverlogfile = DEFAULT_LOGFILE;
+  serverlogfile = "log/sws.log";
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -184,13 +184,6 @@ const char *cmdfile = DEFAULT_CMDFILE;
 
 #define END_OF_HEADERS "\r\n\r\n"
 
-enum {
-  DOCNUMBER_NOTHING = -4,
-  DOCNUMBER_QUIT    = -3,
-  DOCNUMBER_WERULEZ = -2,
-  DOCNUMBER_404     = -1
-};
-
 static const char *end_of_headers = END_OF_HEADERS;
 
 /* sent as reply to a QUIT */

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -563,6 +563,8 @@ int main(int argc, char **argv)
 
   memset(&test, 0, sizeof(test));
 
+  serverlogfile = DEFAULT_LOGFILE;
+
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {
       printf("tftpd IPv4%s\n",

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -559,7 +559,7 @@ int main(int argc, char **argv)
 
   memset(&test, 0, sizeof(test));
 
-  serverlogfile = "log/tftpd.log"
+  serverlogfile = "log/tftpd.log";
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -205,7 +205,6 @@ static bool use_ipv6 = FALSE;
 #endif
 static const char *ipv_inuse = "IPv4";
 
-const char *serverlogfile = DEFAULT_LOGFILE;
 static const char *logdir = "log";
 static char loglockfile[256];
 static const char *pidname = ".tftpd.pid";

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -150,10 +150,6 @@ struct bf {
 #undef MIN
 #define MIN(x,y) ((x)<(y)?(x):(y))
 
-#ifndef DEFAULT_LOGFILE
-#define DEFAULT_LOGFILE "log/tftpd.log"
-#endif
-
 #define REQUEST_DUMP  "server.input"
 
 #define DEFAULT_PORT 8999 /* UDP */
@@ -563,7 +559,7 @@ int main(int argc, char **argv)
 
   memset(&test, 0, sizeof(test));
 
-  serverlogfile = DEFAULT_LOGFILE;
+  serverlogfile = "log/tftpd.log"
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -56,7 +56,7 @@
 #include "timeval.h"
 #include "timediff.h"
 
-const char *serverlogfile = DEFAULT_LOGFILE;
+const char *serverlogfile = NULL;  /* needs init from main() */
 
 static struct timeval tvnow(void);
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -56,13 +56,6 @@
 #include "timeval.h"
 #include "timediff.h"
 
-#ifdef USE_WINSOCK
-#undef  EINTR
-#define EINTR    4 /* errno.h value */
-#undef  EINVAL
-#define EINVAL  22 /* errno.h value */
-#endif
-
 const char *serverlogfile = DEFAULT_LOGFILE;
 
 static struct timeval tvnow(void);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -209,13 +209,13 @@ FILE *test2fopen(long testno, const char *logdir2)
   FILE *stream;
   char filename[256];
   /* first try the alternative, preprocessed, file */
-  msnprintf(filename, sizeof(filename), ALTTEST_DATA_PATH, logdir2, testno);
+  msnprintf(filename, sizeof(filename), "%s/test%ld", logdir2, testno);
   stream = fopen(filename, "rb");
   if(stream)
     return stream;
 
   /* then try the source version */
-  msnprintf(filename, sizeof(filename), TEST_DATA_PATH, path, testno);
+  msnprintf(filename, sizeof(filename), "%s/data/test%ld", path, testno);
   stream = fopen(filename, "rb");
 
   return stream;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -145,7 +145,7 @@ void logmsg(const char *msg, ...)
 
 #ifdef _WIN32
 /* use instead of perror() on generic Windows */
-void win32_perror(const char *msg)
+static void win32_perror(const char *msg)
 {
   char buf[512];
   int err = SOCKERRNO;
@@ -176,7 +176,7 @@ int win32_init(void)
   err = WSAStartup(wVersionRequested, &wsaData);
 
   if(err) {
-    perror("Winsock init failed");
+    win32_perror("Winsock init failed");
     logmsg("Error initialising Winsock -- aborting");
     return 1;
   }
@@ -184,7 +184,7 @@ int win32_init(void)
   if(LOBYTE(wsaData.wVersion) != LOBYTE(wVersionRequested) ||
      HIBYTE(wsaData.wVersion) != HIBYTE(wVersionRequested) ) {
     WSACleanup();
-    perror("Winsock init failed");
+    win32_perror("Winsock init failed");
     logmsg("No suitable winsock.dll found -- aborting");
     return 1;
   }
@@ -635,7 +635,7 @@ static unsigned int WINAPI main_window_loop(void *lpParameter)
   wc.hInstance = (HINSTANCE)lpParameter;
   wc.lpszClassName = TEXT("MainWClass");
   if(!RegisterClass(&wc)) {
-    perror("RegisterClass failed");
+    win32_perror("RegisterClass failed");
     return (DWORD)-1;
   }
 
@@ -647,14 +647,14 @@ static unsigned int WINAPI main_window_loop(void *lpParameter)
                                       (HWND)NULL, (HMENU)NULL,
                                       wc.hInstance, (LPVOID)NULL);
   if(!hidden_main_window) {
-    perror("CreateWindowEx failed");
+    win32_perror("CreateWindowEx failed");
     return (DWORD)-1;
   }
 
   do {
     ret = GetMessage(&msg, NULL, 0, 0);
     if(ret == -1) {
-      perror("GetMessage failed");
+      win32_perror("GetMessage failed");
       return (DWORD)-1;
     }
     else if(ret) {

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -62,6 +62,8 @@
 #define EINVAL  22 /* errno.h value */
 #endif
 
+const char *serverlogfile = DEFAULT_LOGFILE;
+
 static struct timeval tvnow(void);
 
 /* This function returns a pointer to STATIC memory. It converts the given

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -204,12 +204,12 @@ const char *sstrerror(int err)
 /* set by the main code to point to where the test dir is */
 const char *path = ".";
 
-FILE *test2fopen(long testno, const char *logdir)
+FILE *test2fopen(long testno, const char *logdir2)
 {
   FILE *stream;
   char filename[256];
   /* first try the alternative, preprocessed, file */
-  msnprintf(filename, sizeof(filename), ALTTEST_DATA_PATH, logdir, testno);
+  msnprintf(filename, sizeof(filename), ALTTEST_DATA_PATH, logdir2, testno);
   stream = fopen(filename, "rb");
   if(stream)
     return stream;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -54,6 +54,7 @@
 #include "getpart.h"
 #include "util.h"
 #include "timeval.h"
+#include "timediff.h"
 
 #ifdef USE_WINSOCK
 #undef  EINTR
@@ -220,6 +221,19 @@ FILE *test2fopen(long testno, const char *logdir2)
 
   return stream;
 }
+
+#if !defined(MSDOS) && !defined(USE_WINSOCK)
+static long timediff(struct timeval newer, struct timeval older)
+{
+  timediff_t diff = newer.tv_sec-older.tv_sec;
+  if(diff >= (LONG_MAX/1000))
+    return LONG_MAX;
+  else if(diff <= (LONG_MIN/1000))
+    return LONG_MIN;
+  return (long)(newer.tv_sec-older.tv_sec)*1000+
+    (long)(newer.tv_usec-older.tv_usec)/1000;
+}
+#endif
 
 /*
  * Portable function used for waiting a specific amount of ms.
@@ -456,17 +470,6 @@ static struct timeval tvnow(void)
 }
 
 #endif
-
-long timediff(struct timeval newer, struct timeval older)
-{
-  timediff_t diff = newer.tv_sec-older.tv_sec;
-  if(diff >= (LONG_MAX/1000))
-    return LONG_MAX;
-  else if(diff <= (LONG_MIN/1000))
-    return LONG_MIN;
-  return (long)(newer.tv_sec-older.tv_sec)*1000+
-    (long)(newer.tv_usec-older.tv_usec)/1000;
-}
 
 /* vars used to keep around previous signal handlers */
 

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -25,6 +25,16 @@
  ***************************************************************************/
 #include "server_setup.h"
 
+enum {
+  DOCNUMBER_NOTHING = -7,
+  DOCNUMBER_QUIT    = -6,
+  DOCNUMBER_BADCONNECT = -5,
+  DOCNUMBER_INTERNAL = -4,
+  DOCNUMBER_CONNECT = -3,
+  DOCNUMBER_WERULEZ = -2,
+  DOCNUMBER_404     = -1
+};
+
 char *data_to_hex(char *data, size_t len);
 void logmsg(const char *msg, ...) CURL_PRINTF(1, 2);
 long timediff(struct timeval newer, struct timeval older);

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -47,13 +47,11 @@ extern const char *path;
 extern const char *serverlogfile;
 
 #ifdef _WIN32
-#include <process.h>
 int win32_init(void);
 const char *sstrerror(int err);
-#else   /* _WIN32 */
-
+#else
 #define sstrerror(e) strerror(e)
-#endif  /* _WIN32 */
+#endif
 
 /* fopens the test case file */
 FILE *test2fopen(long testno, const char *logdir);

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -25,6 +25,20 @@
  ***************************************************************************/
 #include "server_setup.h"
 
+#ifdef USE_WINSOCK
+/* errno.h values */
+#undef  EINTR
+#define EINTR    4
+#undef  EAGAIN
+#define EAGAIN  11
+#undef  ENOMEM
+#define ENOMEM  12
+#undef  EINVAL
+#define EINVAL  22
+#undef  ERANGE
+#define ERANGE  34
+#endif
+
 enum {
   DOCNUMBER_NOTHING    = -7,
   DOCNUMBER_QUIT       = -6,

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -46,8 +46,6 @@ extern const char *path;
 /* global variable, log file name */
 extern const char *serverlogfile;
 
-extern const char *cmdfile;
-
 #ifdef _WIN32
 #include <process.h>
 #include <fcntl.h>

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -48,7 +48,6 @@ extern const char *serverlogfile;
 
 #ifdef _WIN32
 #include <process.h>
-#include <fcntl.h>
 int win32_init(void);
 const char *sstrerror(int err);
 #else   /* _WIN32 */

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -26,13 +26,13 @@
 #include "server_setup.h"
 
 enum {
-  DOCNUMBER_NOTHING = -7,
-  DOCNUMBER_QUIT    = -6,
+  DOCNUMBER_NOTHING    = -7,
+  DOCNUMBER_QUIT       = -6,
   DOCNUMBER_BADCONNECT = -5,
-  DOCNUMBER_INTERNAL = -4,
-  DOCNUMBER_CONNECT = -3,
-  DOCNUMBER_WERULEZ = -2,
-  DOCNUMBER_404     = -1
+  DOCNUMBER_INTERNAL   = -4,
+  DOCNUMBER_CONNECT    = -3,
+  DOCNUMBER_WERULEZ    = -2,
+  DOCNUMBER_404        = -1
 };
 
 char *data_to_hex(char *data, size_t len);

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -37,7 +37,6 @@ enum {
 
 char *data_to_hex(char *data, size_t len);
 void logmsg(const char *msg, ...) CURL_PRINTF(1, 2);
-long timediff(struct timeval newer, struct timeval older);
 
 #define SERVERLOGS_LOCKDIR "lock"  /* within logdir */
 

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -39,8 +39,6 @@ char *data_to_hex(char *data, size_t len);
 void logmsg(const char *msg, ...) CURL_PRINTF(1, 2);
 long timediff(struct timeval newer, struct timeval older);
 
-#define TEST_DATA_PATH "%s/data/test%ld"
-#define ALTTEST_DATA_PATH "%s/test%ld"
 #define SERVERLOGS_LOCKDIR "lock"  /* within logdir */
 
 /* global variable, where to find the 'data' dir */

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -55,8 +55,6 @@ extern const char *cmdfile;
 #include <process.h>
 #include <fcntl.h>
 
-#define sleep(sec) Sleep ((sec)*1000)
-
 #undef perror
 #define perror(m) win32_perror(m)
 void win32_perror(const char *msg);

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -54,11 +54,6 @@ extern const char *cmdfile;
 #ifdef _WIN32
 #include <process.h>
 #include <fcntl.h>
-
-#undef perror
-#define perror(m) win32_perror(m)
-void win32_perror(const char *msg);
-
 int win32_init(void);
 const char *sstrerror(int err);
 #else   /* _WIN32 */

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -78,16 +78,13 @@ void install_signal_handlers(bool keep_sigalrm);
 void restore_signal_handlers(bool keep_sigalrm);
 
 #ifdef USE_UNIX_SOCKETS
-
 #include <curl/curl.h> /* for curl_socket_t */
-
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h> /* for sockaddr_un */
-#endif /* HAVE_SYS_UN_H */
-
+#endif
 int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
-        struct sockaddr_un *sau);
-#endif  /* USE_UNIX_SOCKETS */
+                     struct sockaddr_un *sau);
+#endif /* USE_UNIX_SOCKETS */
 
 unsigned short util_ultous(unsigned long ulnum);
 


### PR DESCRIPTION
Dedupe, merge macros, globals, make symbols local where possible. Drop
unused macros and headers. Drop `DEFAULT_LOGFILE` macro in favour of
`--logfile` command-line option.

Ref: #15000
