### PR TITLE
asyn: bring back port to the Curl_async struct

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -592,7 +592,7 @@ static void query_completed_cb(void *arg,  /* (struct connectdata *) */
   res->num_pending--;
 
   if(CURL_ASYNC_SUCCESS == status) {
-    struct Curl_addrinfo *ai = Curl_he2ai(hostent, data->conn->remote_port);
+    struct Curl_addrinfo *ai = Curl_he2ai(hostent, data->state.async.port);
     if(ai) {
       compound_results(res, ai);
     }
@@ -774,6 +774,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
   if(!res->hostname)
     return NULL;
 
+  data->state.async.port = port;
   data->state.async.done = FALSE;   /* not done */
   data->state.async.dns = NULL;     /* clear */
 
@@ -809,7 +810,6 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
                      service, &hints, addrinfo_cb, data);
   }
 #else
-  (void)port;
 
 #ifdef HAVE_CARES_IPV6
   if((data->conn->ip_version != CURL_IPRESOLVE_V4) && Curl_ipv6works(data)) {

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -436,6 +436,7 @@ static bool init_resolve_thread(struct Curl_easy *data,
   int err = ENOMEM;
   struct Curl_async *async = &data->state.async;
 
+  async->port = port;
   async->done = FALSE;
   async->dns = NULL;
   td->thread_hnd = curl_thread_t_null;

--- a/lib/hostasyn.c
+++ b/lib/hostasyn.c
@@ -77,7 +77,7 @@ CURLcode Curl_addrinfo_callback(struct Curl_easy *data,
 
       dns = Curl_cache_addr(data, ai,
                             data->conn->host.dispname, 0,
-                            data->conn->localport, FALSE);
+                            data->state.async.port, FALSE);
       if(data->share)
         Curl_share_unlock(data, CURL_LOCK_DATA_DNS);
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -571,6 +571,7 @@ struct Curl_async {
 #endif
   void *resolver; /* resolver state, if it is used in the URL state -
                      ares_channel e.g. */
+  int port;
   BIT(done);  /* set TRUE when the lookup is complete */
 };
 


### PR DESCRIPTION
To make sure we store and use the correct port used for this particular lookup.

Partial revert of 8ded8e5f3f

Fixes #16531
Reported-by: Jay Satiro