### PR TITLE
Added retry-after messaging for cURL

### DIFF
--- a/docs/TODO
+++ b/docs/TODO
@@ -69,7 +69,6 @@
 
  5. HTTP
  5.1 Provide the error body from a CONNECT response
- 5.2 Obey Retry-After in redirects
  5.3 Rearrange request header order
  5.4 Allow SAN names in HTTP/2 server push
  5.5 auth= in URLs
@@ -597,14 +596,6 @@
  new callback? Through some other means?
 
  See https://github.com/curl/curl/issues/9513
-
-5.2 Obey Retry-After in redirects
-
- The Retry-After is said to dicate "the minimum time that the user agent is
- asked to wait before issuing the redirected request" and libcurl does not
- obey this.
-
- See https://github.com/curl/curl/issues/11447
 
 5.3 Rearrange request header order
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2886,9 +2886,21 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
       }
       if(global->test_event_based)
         result = curl_easy_perform_ev(per->curl);
-      else
+      else{
 #endif
         result = curl_easy_perform(per->curl);
+        /* Check if server returns retry after message */
+        if(result == CURLE_OK) {
+          curl_off_t wait = 0;
+          curl_easy_getinfo(per->curl,
+                            CURLINFO_RETRY_AFTER,
+                            &wait);
+          if(wait)
+            printf("Wait for %" CURL_FORMAT_CURL_OFF_T " seconds\n", wait);
+        }
+      #ifdef DEBUGBUILD
+      }
+      #endif
     }
 
     returncode = post_per_transfer(global, per, result, &retry, &delay_ms);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2907,9 +2907,9 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
       else{
 #endif
         result = curl_easy_perform(per->curl);
+        curl_off_t wait = 0;
         /* Check if server returns retry after message */
         if(result == CURLE_OK) {
-          curl_off_t wait = 0;
           curl_easy_getinfo(per->curl,
                             CURLINFO_RETRY_AFTER,
                             &wait);


### PR DESCRIPTION
Changed curl source code to make output regarding retry-after error message for [this issue](https://github.com/curl/curl/issues/11447)