### PR TITLE
ftp: fix comment

### DIFF
--- a/lib/ftp.h
+++ b/lib/ftp.h
@@ -125,7 +125,8 @@ struct ftp_conn {
   char *entrypath; /* the PWD reply when we logged on */
   char *file;    /* url-decoded filename (or path) */
   char **dirs;   /* realloc()ed array for path components */
-  char *newhost;
+  char *newhost; /* the (allocated) IP addr or hostname to connect the data
+                    connection to */
   char *prevpath;   /* url-decoded conn->path from the previous transfer */
   char transfertype; /* set by ftp_transfertype for use by Curl_client_write()a
                         and others (A/I or zero) */
@@ -139,9 +140,8 @@ struct ftp_conn {
   int count1; /* general purpose counter for the state machine */
   int count2; /* general purpose counter for the state machine */
   int count3; /* general purpose counter for the state machine */
-  /* newhost is the (allocated) IP addr or hostname to connect the data
-     connection to */
-  unsigned short newport;
+  unsigned short newport;  /* the port of 'newhost' to connect the data
+                              connection to */
   ftpstate state; /* always use ftp.c:state() to change state! */
   ftpstate state_saved; /* transfer type saved to be reloaded after data
                            connection is established */


### PR DESCRIPTION
- Explain ftp_conn's newhost and newport in the struct definition.

Follow-up to 1485e892 which changed the order of some struct members to reduce struct size.

Closes #xxxx