### PR TITLE
http2: reset stream on response header error

### DIFF
--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -549,7 +549,7 @@ class TestUpload:
         if r.exit_code == 18: # PARTIAL_FILE is always ok
             pass
         elif proto == 'h2':
-            r.check_exit_code(92)  # CURLE_HTTP2_STREAM also ok
+            r.check_exit_code(16)  # CURLE_HTTP2 also ok
         elif proto == 'h3':
             r.check_exit_code(95)  # CURLE_HTTP3 also ok
         else:


### PR DESCRIPTION
refs #16535

We send a GOAWAY, but some servers ignore that and happily continue sending the stream response. RST the stream when response header errors are encountered.