### PR TITLE
http_chunks: replace a strofft call with curl_str_hex

### DIFF
--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -34,7 +34,7 @@
 #include "content_encoding.h"
 #include "http.h"
 #include "multiif.h"
-#include "strtoofft.h"
+#include "strparse.h"
 #include "warnless.h"
 
 /* The last #include files should be: */
@@ -158,6 +158,7 @@ static CURLcode httpchunk_readwrite(struct Curl_easy *data,
         (*pconsumed)++;
       }
       else {
+        const char *p;
         if(0 == ch->hexindex) {
           /* This is illegal data, we received junk where we expected
              a hexadecimal digit. */
@@ -166,11 +167,11 @@ static CURLcode httpchunk_readwrite(struct Curl_easy *data,
           ch->last_code = CHUNKE_ILLEGAL_HEX;
           return CURLE_RECV_ERROR;
         }
-
         /* blen and buf are unmodified */
         ch->hexbuffer[ch->hexindex] = 0;
-        if(curlx_strtoofft(ch->hexbuffer, NULL, 16, &ch->datasize)) {
-          failf(data, "chunk hex-length not valid: '%s'", ch->hexbuffer);
+        p = &ch->hexbuffer[0];
+        if(Curl_str_hex(&p, &ch->datasize, CURL_OFF_T_MAX)) {
+          failf(data, "invalid chunk size: '%s'", ch->hexbuffer);
           ch->state = CHUNK_FAILED;
           ch->last_code = CHUNKE_ILLEGAL_HEX;
           return CURLE_RECV_ERROR;


### PR DESCRIPTION
Make it not skip leading blanks. There should not be any.