### PR TITLE
lib: fix two curlx_strtoofft invokes

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -315,8 +315,11 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
             k->httpcode);
     }
     else {
-      (void)curlx_strtoofft(header + strlen("Content-Length:"),
-                            NULL, 10, &ts->cl);
+      if(curlx_strtoofft(header + strlen("Content-Length:"),
+                         NULL, 10, &ts->cl)) {
+        failf(data, "Unsupported Content-Length value");
+        return CURLE_WEIRD_SERVER_REPLY;
+      }
     }
   }
   else if(Curl_compareheader(header,


### PR DESCRIPTION
- cf-h1-proxy: check return code and return error if the parser fails

- http: make the Retry-After parser check for a date string first then number to avoid mis-parsing the begining of a date as a number