### PR TITLE
cmake: exclude `-MP` for `clang-cl` again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1986,7 +1986,7 @@ if(WIN32)
   endif()
 endif()
 
-if(MSVC)
+if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")  # MSVC but exclude clang-cl
   string(APPEND CMAKE_C_FLAGS " -MP")  # Parallel compilation
 endif()
 


### PR DESCRIPTION
To avoid this warning/error (seen with Ninja generator):
```
clang-cl: warning: argument unused during compilation: '-MP' [-Wunused-command-line-argument]
```

Curious why CI missed it. Maybe due to using a Visual Studio generator.

Regression from e0fd5790d94feb239f7d2457578f2a34c85cdd65 #16004
