### PR TITLE
tests/server: replace `errno` with `SOCKERRNO` in sockfilt, socksd, sws

### DIFF
--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1081,11 +1081,11 @@ static bool juggle(curl_socket_t *sockfdp,
       return FALSE;
     }
 
-  } while((rc == -1) && ((error = errno) == EINTR));
+  } while((rc == -1) && ((error = SOCKERRNO) == EINTR));
 
   if(rc < 0) {
     logmsg("select() failed with error: (%d) %s",
-           error, strerror(error));
+           error, sstrerror(error));
     return FALSE;
   }
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -740,7 +740,7 @@ static bool incoming(curl_socket_t listenfd)
         logmsg("signalled to die, exiting...");
         return FALSE;
       }
-    } while((rc == -1) && ((error = errno) == EINTR));
+    } while((rc == -1) && ((error = SOCKERRNO) == EINTR));
 
     if(rc < 0) {
       logmsg("select() failed with error: (%d) %s",

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -869,7 +869,8 @@ static int get_request(curl_socket_t sock, struct httprequest *req)
           logmsg("Got %zu bytes from client", got);
         }
 
-        if((got == -1) && ((EAGAIN == errno) || (EWOULDBLOCK == errno))) {
+        if((got == -1) && ((SOCKERRNO == EAGAIN) ||
+                           (SOCKERRNO == EWOULDBLOCK))) {
           int rc;
           fd_set input;
           fd_set output;
@@ -891,7 +892,7 @@ static int get_request(curl_socket_t sock, struct httprequest *req)
           do {
             logmsg("Wait until readable");
             rc = select((int)sock + 1, &input, &output, NULL, &timeout);
-          } while(rc < 0 && errno == EINTR && !got_exit_signal);
+          } while(rc < 0 && SOCKERRNO == EINTR && !got_exit_signal);
           logmsg("readable %d", rc);
           if(rc)
             got = 1;
@@ -1567,7 +1568,7 @@ static void http_connect(curl_socket_t *infdp,
 
     do {
       rc = select((int)maxfd + 1, &input, &output, NULL, &timeout);
-    } while(rc < 0 && errno == EINTR && !got_exit_signal);
+    } while(rc < 0 && SOCKERRNO == EINTR && !got_exit_signal);
 
     if(got_exit_signal)
       break;
@@ -2387,7 +2388,7 @@ int main(int argc, char *argv[])
 
     do {
       rc = select((int)maxfd + 1, &input, &output, NULL, &timeout);
-    } while(rc < 0 && errno == EINTR && !got_exit_signal);
+    } while(rc < 0 && SOCKERRNO == EINTR && !got_exit_signal);
 
     if(got_exit_signal)
       goto sws_cleanup;


### PR DESCRIPTION
To correctly read the winsock2 result code on Windows.

Follow-up to de2126b1821fecbc1f66715714cb34c5c2d14ec4 #5241
Ref: https://github.com/curl/curl/commit/5e855bbd18f84a02c951be7cac6188276818cdac#r38507132
Ref: #14854
