### PR TITLE
tool_getparam: avoid strdup on platforms not doing UTF8 conversions

### DIFF
--- a/lib/curl_multibyte.h
+++ b/lib/curl_multibyte.h
@@ -84,7 +84,7 @@ typedef union {
 #define curlx_unicodefree(ptr)                          \
   do {                                                  \
     if(ptr) {                                           \
-      (free)(ptr);                                      \
+      (free)((char *)ptr);                              \
       (ptr) = NULL;                                     \
     }                                                   \
   } while(0)

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -361,7 +361,7 @@ struct OperationConfig;
 const struct LongShort *findlongopt(const char *opt);
 const struct LongShort *findshortopt(char letter);
 
-ParameterError getparameter(const char *flag, char *nextarg,
+ParameterError getparameter(const char *flag, const char *nextarg,
                             argv_item_t cleararg1,
                             argv_item_t cleararg2,
                             bool *usedarg,
@@ -376,5 +376,19 @@ void parse_cert_parameter(const char *cert_parameter,
 
 ParameterError parse_args(struct GlobalConfig *config, int argc,
                           argv_item_t argv[]);
+
+#if defined(UNICODE) && defined(_WIN32) && !defined(UNDER_CE)
+
+#define convert_UTF8_to_tchar(ptr) curlx_convert_UTF8_to_wchar((ptr))
+#define convert_tchar_to_UTF8(ptr) curlx_convert_wchar_to_UTF8((ptr))
+#define unicodefree(ptr) curlx_unicodefree(ptr)
+
+#else
+
+#define convert_UTF8_to_tchar(ptr) (const char *)(ptr)
+#define convert_tchar_to_UTF8(ptr) (const char *)(ptr)
+#define unicodefree(ptr) do {} while(0)
+
+#endif
 
 #endif /* HEADER_CURL_TOOL_GETPARAM_H */

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -381,7 +381,7 @@ ParameterError parse_args(struct GlobalConfig *config, int argc,
 
 #define convert_UTF8_to_tchar(ptr) curlx_convert_UTF8_to_wchar((ptr))
 #define convert_tchar_to_UTF8(ptr) curlx_convert_wchar_to_UTF8((ptr))
-#define unicodefree(ptr) curlx_unicodefree(ptr)
+#define unicodefree(ptr) curlx_unicodefree((char *)ptr)
 
 #else
 

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -381,7 +381,7 @@ ParameterError parse_args(struct GlobalConfig *config, int argc,
 
 #define convert_UTF8_to_tchar(ptr) curlx_convert_UTF8_to_wchar((ptr))
 #define convert_tchar_to_UTF8(ptr) curlx_convert_wchar_to_UTF8((ptr))
-#define unicodefree(ptr) curlx_unicodefree((char *)ptr)
+#define unicodefree(ptr) curlx_unicodefree(ptr)
 
 #else
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -3161,11 +3161,11 @@ static CURLcode run_all_transfers(struct GlobalConfig *global,
 CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
 {
   CURLcode result = CURLE_OK;
-  char *first_arg;
+  const char *first_arg;
 #ifdef UNDER_CE
   first_arg = argc > 1 ? strdup(argv[1]) : NULL;
 #else
-  first_arg = argc > 1 ? curlx_convert_tchar_to_UTF8(argv[1]) : NULL;
+  first_arg = argc > 1 ? convert_tchar_to_UTF8(argv[1]) : NULL;
 #endif
 
 #ifdef HAVE_SETLOCALE
@@ -3187,7 +3187,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
     }
   }
 
-  curlx_unicodefree(first_arg);
+  unicodefree(first_arg);
 
   if(!result) {
     /* Parse the command line arguments */

--- a/src/tool_stderr.c
+++ b/src/tool_stderr.c
@@ -36,7 +36,7 @@ void tool_init_stderr(void)
   tool_stderr = stderr;
 }
 
-void tool_set_stderr_file(struct GlobalConfig *global, char *filename)
+void tool_set_stderr_file(struct GlobalConfig *global, const char *filename)
 {
   FILE *fp;
 

--- a/src/tool_stderr.h
+++ b/src/tool_stderr.h
@@ -27,6 +27,6 @@
 #include "tool_cfgable.h"
 
 void tool_init_stderr(void);
-void tool_set_stderr_file(struct GlobalConfig *global, char *filename);
+void tool_set_stderr_file(struct GlobalConfig *global, const char *filename);
 
 #endif /* HEADER_CURL_TOOL_STDERR_H */


### PR DESCRIPTION
... which is all except Windows UNICODE builds.

Which required a switch to more const strings.