### PR TITLE
build: tidy-ups around `inet_pton`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1625,7 +1625,7 @@ if(WIN32)
 
     # Pre-fill detection results based on target OS version
     if(MINGW OR MSVC OR WINCE)
-      if(HAVE_WIN32_WINNT LESS 0x0600)
+      if(WINCE OR HAVE_WIN32_WINNT LESS 0x0600)
         set(HAVE_INET_NTOP 0)
         set(HAVE_INET_PTON 0)
       else()  # Windows Vista or newer

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -92,8 +92,7 @@ socksd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 socksd_CFLAGS = $(AM_CFLAGS)
 
 mqttd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
- server_sockaddr.h mqttd.c \
- ../../lib/inet_pton.c
+ server_sockaddr.h mqttd.c
 mqttd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 mqttd_CFLAGS = $(AM_CFLAGS)
 

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -61,6 +61,9 @@ USEFUL = \
  ../../lib/memdebug.c \
  ../../lib/memdebug.h
 
+INET_PTON = \
+ ../../lib/inet_pton.c
+
 UTIL = \
  util.c \
  util.h \
@@ -78,16 +81,14 @@ rtspd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
 rtspd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 rtspd_CFLAGS = $(AM_CFLAGS)
 
-sockfilt_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
+sockfilt_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) $(INET_PTON) \
  server_sockaddr.h \
  sockfilt.c \
- ../../lib/inet_pton.c
 sockfilt_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 sockfilt_CFLAGS = $(AM_CFLAGS)
 
-socksd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
+socksd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) $(INET_PTON) \
  server_sockaddr.h socksd.c \
- ../../lib/inet_pton.c
 socksd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 socksd_CFLAGS = $(AM_CFLAGS)
 
@@ -96,10 +97,9 @@ mqttd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
 mqttd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 mqttd_CFLAGS = $(AM_CFLAGS)
 
-sws_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
+sws_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) $(INET_PTON) \
  server_sockaddr.h \
  sws.c \
- ../../lib/inet_pton.c
 sws_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 sws_CFLAGS = $(AM_CFLAGS)
 

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -83,12 +83,12 @@ rtspd_CFLAGS = $(AM_CFLAGS)
 
 sockfilt_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) $(INET_PTON) \
  server_sockaddr.h \
- sockfilt.c \
+ sockfilt.c
 sockfilt_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 sockfilt_CFLAGS = $(AM_CFLAGS)
 
 socksd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) $(INET_PTON) \
- server_sockaddr.h socksd.c \
+ server_sockaddr.h socksd.c
 socksd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 socksd_CFLAGS = $(AM_CFLAGS)
 
@@ -99,7 +99,7 @@ mqttd_CFLAGS = $(AM_CFLAGS)
 
 sws_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) $(INET_PTON) \
  server_sockaddr.h \
- sws.c \
+ sws.c
 sws_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 sws_CFLAGS = $(AM_CFLAGS)
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -55,7 +55,6 @@
 
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
-#include "inet_pton.h"
 #include "server_sockaddr.h"
 #include "warnless.h"
 


### PR DESCRIPTION
- cmake: make the `inet_pton`/`inet_ntop` detection codepath explicit
  for WinCE. To not rely on an empty `HAVE_WIN32_WINNT`.

- tests/server/mqttd: drop `inet_pton` header and lib source.

- tests/server: move `inet_pton` lib source to a variable.
