### PR TITLE
GHA/windows: drop running tests with dl-mingw 7.3.0 due to flakiness

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -389,7 +389,7 @@ jobs:
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON'
             type: 'Release'
-            tflags: '~2301 ~2302 ~2310 ~3027 ~3023 ~3024 ~1451'
+            tflags: 'skiprun'
           - name: 'schannel !unity'
             env: '6.4.0-i686'
             dir: 'mingw32'


### PR DESCRIPTION
This job was never stable. Bumping to -j8 (from -j4) possibly made it
flakier: 032447e6249bf87958b16eb0c97874490b711ec7 #16271

Keep this job for build tests and drop running tests to improve the CI
experience and save CI time.

It's also a simple build with no dependencies. CI continues to build
a similar job with 9.5.0, which is more stable.

It remains a puzzle why builds with this toolchain (7.3.0 win32 threads
mingw-builds) is flakier and requires more test exceptions than the
indentical build with a slightly different build/version of
the toolchain (9.5.0 posix threads winlibs_mingw).

Ref: #14854