### PR TITLE
http_aws_sigv4: cannot be used for proxy

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -634,9 +634,10 @@ output_auth_headers(struct Curl_easy *data,
   (void)path;
 #endif
 #ifndef CURL_DISABLE_AWS
-  if(authstatus->picked == CURLAUTH_AWS_SIGV4) {
+  if((authstatus->picked == CURLAUTH_AWS_SIGV4) && !proxy) {
+    /* this method is never for proxy */
     auth = "AWS_SIGV4";
-    result = Curl_output_aws_sigv4(data, proxy);
+    result = Curl_output_aws_sigv4(data);
     if(result)
       return result;
   }

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -569,7 +569,7 @@ static CURLcode canon_query(struct Curl_easy *data,
 }
 
 
-CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
+CURLcode Curl_output_aws_sigv4(struct Curl_easy *data)
 {
   CURLcode result = CURLE_OUT_OF_MEMORY;
   struct connectdata *conn = data->conn;
@@ -604,9 +604,6 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy)
   unsigned char sign0[CURL_SHA256_DIGEST_LENGTH] = {0};
   unsigned char sign1[CURL_SHA256_DIGEST_LENGTH] = {0};
   char *auth_headers = NULL;
-
-  DEBUGASSERT(!proxy);
-  (void)proxy;
 
   if(Curl_checkheaders(data, STRCONST("Authorization"))) {
     /* Authorization already present, Bailing out */

--- a/lib/http_aws_sigv4.h
+++ b/lib/http_aws_sigv4.h
@@ -26,6 +26,6 @@
 #include "curl_setup.h"
 
 /* this is for creating aws_sigv4 header output */
-CURLcode Curl_output_aws_sigv4(struct Curl_easy *data, bool proxy);
+CURLcode Curl_output_aws_sigv4(struct Curl_easy *data);
 
 #endif /* HEADER_CURL_HTTP_AWS_SIGV4_H */


### PR DESCRIPTION
Make sure it is never attempted.

Reported-by: Philippe Antoine