### PR TITLE
GHA/windows: stop ignoring most ignored test results

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -380,7 +380,6 @@ jobs:
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/9.5.0-10.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-9.5.0-mingw-w64msvcrt-10.0.0-r1.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
             type: 'Release'
-            tflags: ''
           - name: 'schannel U'
             env: '7.3.0-x86_64'
             dir: 'mingw64'
@@ -724,7 +723,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
@@ -735,7 +733,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_WOLFSSL=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
@@ -746,7 +743,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
@@ -757,7 +753,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
@@ -768,7 +763,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
@@ -780,7 +774,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: ''
             chkprefill: '_chkprefill'
             # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
             #          read its configuration from, making it vulnerable to attacks on

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -335,12 +335,10 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 10
         run: |
-          export TFLAGS='-j8 ${{ matrix.tflags }} ~SCP'
+          export TFLAGS='-j8 ${{ matrix.tflags }}'
+          TFLAGS+=' ~613'  # SFTP
           if [ '${{ matrix.sys }}' != 'msys' ]; then
-            TFLAGS+=' ~2301 ~2302 ~2310'  # WebSockets'
-            TFLAGS+=' ~612 ~613 ~616 ~618'  # SFTP
-          else
-            TFLAGS+=' ~SFTP'
+            TFLAGS+=' ~612'  # SFTP
           fi
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
@@ -382,7 +380,7 @@ jobs:
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/9.5.0-10.0.0-msvcrt-r1/winlibs-x86_64-posix-seh-gcc-9.5.0-mingw-w64msvcrt-10.0.0-r1.7z'
             config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
             type: 'Release'
-            tflags: '~2301 ~2302 ~2310 ~3027'
+            tflags: ''
           - name: 'schannel U'
             env: '7.3.0-x86_64'
             dir: 'mingw64'
@@ -496,7 +494,7 @@ jobs:
         timeout-minutes: 10
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:/c/msys64/usr/bin:$PATH"
-          export TFLAGS='-j8 ~WebSockets ${{ matrix.tflags }}'
+          export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -726,7 +724,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: '~1516 ~2301 ~2302 ~2303 ~2307 ~2310'
+            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
@@ -737,7 +735,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: '~1516 ~2301 ~2302 ~2303 ~2307 ~2310'
+            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=ON  -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_WOLFSSL=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
@@ -748,7 +746,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: '~1516 ~2301 ~2302 ~2303 ~2307 ~2310'
+            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
@@ -759,7 +757,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: '~1516 ~2301 ~2302 ~2303 ~2307 ~2310'
+            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON
@@ -770,7 +768,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: '~1516'
+            tflags: ''
             config: >-
               -DCURL_USE_LIBSSH2=ON
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON
@@ -782,7 +780,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            tflags: '~1516'
+            tflags: ''
             chkprefill: '_chkprefill'
             # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
             #          read its configuration from, making it vulnerable to attacks on
@@ -908,12 +906,7 @@ jobs:
         timeout-minutes: 10
         run: |
           export CURL_DIRSUFFIX='${{ matrix.type }}'
-          export TFLAGS='-j8 ~WebSockets ~SCP ~612 ${{ matrix.tflags }}'
-          if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
-            TFLAGS+=' ~SFTP'
-          elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then
-            TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
-          fi
+          export TFLAGS='-j8 ${{ matrix.tflags }} ~2302 ~2303 ~2307'
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
           PATH="/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci


### PR DESCRIPTION
These tests seem to be running no less stable now than others.
Stop ignoring their results to catch real issues.

These are consistently failing and remain on the ignore list:

in MSVC / vcpkg jobs:
```
FAIL-IGNORED 2302: 'WebSockets via callback (frame mode) + curl_ws_send()' WebSockets
FAIL-IGNORED 2303: 'WebSockets but gets a 200 back' WebSockets
FAIL-IGNORED 2307: 'WebSockets, overlong PING payload' WebSockets
```
https://github.com/curl/curl/actions/runs/13674664461/job/38233949942?pr=16570#step:14:4089
- Likely curl issues either in tests, server, or in WebSockets support.

in tests running under MSYS, affecting native mingw Windows builds only:
```
FAIL-IGNORED 612: 'SFTP post-quote remove file' SFTP, post-quote
[...]
 curl: (21) rm command failed: Operation failed
```
https://github.com/curl/curl/actions/runs/13674664461/job/38233952699?pr=16570#step:14:1378

in tests running under MSYS, affecting both MSYS and native mingw Windows builds:
```diff
FAIL-IGNORED 613: 'SFTP directory retrieval' SFTP, directory
[...]
 --- log/7/check-expected	2025-03-05 11:19:54.119658000 +0000
 +++ log/7/check-generated	2025-03-05 11:19:54.119658000 +0000
@@ -1,3 +1,3 @@
 d?????????    N U         U               N ???  N NN:NN asubdir[LF]
--rw?rw?rw?    1 U         U              37 Jan  1  2000 plainfile.txt[LF]
+-rw?r-?r-?    1 U         U              37 Jan  1  2000 plainfile.txt[LF]
 -r-?r-?r-?    1 U         U              47 Dec 31  2000 rofile.txt[LF]
```
https://github.com/curl/curl/actions/runs/13674664461/job/38233950866?pr=16570#step:14:1316
- Possibly a curl test portabibility, Perl or MSYS issue.

in Cygwin tests:
```
FAIL-IGNORED 615: 'SFTP put remote failure' SFTP, SFTP put, FAILURE
```
https://github.com/curl/curl/actions/runs/13674664461/job/38233949428?pr=16570#step:12:3817

Follow-up to adcfd4fb3e9be1de0e506728066bea2aaa53c394 #16553
Ref: #14854
