### PR TITLE
runtests: check and report if `diff` tool is missing

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -200,7 +200,6 @@ jobs:
           install: >-
             gcc
             ${{ matrix.build }} ${{ matrix.build == 'autotools' && 'make' || 'ninja' }}
-            diffutils
             openssh
             openssl-devel
             zlib-devel
@@ -208,6 +207,7 @@ jobs:
             libnghttp2-devel
             libpsl-devel
             libssh2-devel
+            ${{ matrix.chkprefill == '_chkprefill' && 'diffutils' || '' }}
 
       - uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2
         if: ${{ matrix.sys != 'msys' }}
@@ -216,12 +216,12 @@ jobs:
           install: >-
             mingw-w64-${{ matrix.env }}-cc
             mingw-w64-${{ matrix.env }}-${{ matrix.build }} ${{ matrix.build == 'autotools' && 'make' || '' }}
-            mingw-w64-${{ matrix.env }}-diffutils
             openssh
             mingw-w64-${{ matrix.env }}-openssl
             mingw-w64-${{ matrix.env }}-libssh2
             mingw-w64-${{ matrix.env }}-libpsl
             mingw-w64-${{ matrix.env }}-c-ares
+            ${{ matrix.chkprefill == '_chkprefill' && format('mingw-w64-{0}-diffutils', matrix.env) || '' }}
 
       - name: 'downgrade msys2-runtime'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && matrix.sys != 'msys' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -200,6 +200,7 @@ jobs:
           install: >-
             gcc
             ${{ matrix.build }} ${{ matrix.build == 'autotools' && 'make' || 'ninja' }}
+            diffutils
             openssh
             openssl-devel
             zlib-devel
@@ -207,7 +208,6 @@ jobs:
             libnghttp2-devel
             libpsl-devel
             libssh2-devel
-            ${{ matrix.chkprefill == '_chkprefill' && 'diffutils' || '' }}
 
       - uses: msys2/setup-msys2@61f9e5e925871ba6c9e3e8da24ede83ea27fa91f # v2
         if: ${{ matrix.sys != 'msys' }}
@@ -216,12 +216,12 @@ jobs:
           install: >-
             mingw-w64-${{ matrix.env }}-cc
             mingw-w64-${{ matrix.env }}-${{ matrix.build }} ${{ matrix.build == 'autotools' && 'make' || '' }}
+            mingw-w64-${{ matrix.env }}-diffutils
             openssh
             mingw-w64-${{ matrix.env }}-openssl
             mingw-w64-${{ matrix.env }}-libssh2
             mingw-w64-${{ matrix.env }}-libpsl
             mingw-w64-${{ matrix.env }}-c-ares
-            ${{ matrix.chkprefill == '_chkprefill' && format('mingw-w64-{0}-diffutils', matrix.env) || '' }}
 
       - name: 'downgrade msys2-runtime'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && matrix.sys != 'msys' }}

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -856,7 +856,7 @@ sub checksystemfeatures {
     my $hostos=$^O;
 
     my $havediff;
-    if(system('diff') == 0) {
+    if(system("diff $TESTDIR/DISABLED $TESTDIR/DISABLED 2>$dev_null") == 0) {
       $havediff = 'available';
     }
     else {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -855,6 +855,14 @@ sub checksystemfeatures {
     chomp $hosttype;
     my $hostos=$^O;
 
+    my $havediff;
+    if(system('diff') == 0) {
+      $havediff = 'available';
+    }
+    else {
+      $havediff = 'missing';
+    }
+
     # display summary information about curl and the test host
     logmsg ("********* System characteristics ******** \n",
             "* $curl\n",
@@ -866,6 +874,7 @@ sub checksystemfeatures {
             "* System: $hosttype\n",
             "* OS: $hostos\n",
             "* Perl: $^V ($^X)\n",
+            "* diff: $havediff\n",
             "* Args: $args\n");
 
     if($jobs) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -856,7 +856,6 @@ sub checksystemfeatures {
     my $hostos=$^O;
 
     my $havediff;
-    logmsg "TEST-1: |$TESTDIR/DISABLED|\n";
     if(system("diff $TESTDIR/DISABLED $TESTDIR/DISABLED 2>$dev_null") == 0) {
       $havediff = 'available';
     }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -856,6 +856,7 @@ sub checksystemfeatures {
     my $hostos=$^O;
 
     my $havediff;
+    logmsg "TEST-1: |$TESTDIR/DISABLED|\n";
     if(system("diff $TESTDIR/DISABLED $TESTDIR/DISABLED 2>$dev_null") == 0) {
       $havediff = 'available';
     }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -416,6 +416,9 @@ sub showdiff {
 
     if(!$out[0]) {
         @out = `diff -c $file2 $file1 2>$dev_null`;
+        if(!$out[0]) {
+            logmsg "FAIL to show diff. The diff tool may be missing\n";
+        }
     }
 
     return @out;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -417,7 +417,7 @@ sub showdiff {
     if(!$out[0]) {
         @out = `diff -c $file2 $file1 2>$dev_null`;
         if(!$out[0]) {
-            logmsg "FAIL to show diff. The diff tool may be missing\n";
+            logmsg "Failed to show diff. The diff tool may be missing.\n";
         }
     }
 


### PR DESCRIPTION
To make it apparent which CI jobs are missing this tool, so we can
install it to improve the runtests log.

Correction to the followed-up commit: `diff` is not installed via the
`gcc` package but via `automake`. Meaning it needs be installed manually
for MSYS cmake jobs.

Follow-up to e6c78e18dac1da2027eac6dd3829a0fdbfa55501 #16571
