### PR TITLE
lib1156: pass longs to `curl_easy_setopt()`

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -315,7 +315,6 @@ jobs:
           if [ -z '${{ matrix.build.torture }}' ]; then
             TFLAGS+=' ~2037 ~2041'  # flaky
             if [[ '${{ matrix.compiler }}' = 'gcc'* ]]; then
-              TFLAGS+=' ~1156'  # HTTP Content-Range
               if [[ -n '${{ matrix.build.configure }}' || \
                     '${{ matrix.build.generate }}' = *'-DCURL_USE_SECTRANSP=ON'* ]]; then
                 TFLAGS+=' ~2100'  # 2100:'HTTP GET using DoH' https://github.com/curl/curl/actions/runs/9942146678/job/27462937524#step:15:5059

--- a/tests/libtest/lib1156.c
+++ b/tests/libtest/lib1156.c
@@ -96,10 +96,10 @@ static int onetest(CURL *curl, const char *url, const struct testparams *p,
   msnprintf(urlbuf, sizeof(urlbuf), "%s%04u", url, replyselector);
   test_setopt(curl, CURLOPT_URL, urlbuf);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_RESUME_FROM, (p->flags & F_RESUME) ? 3 : 0);
+  test_setopt(curl, CURLOPT_RESUME_FROM, (p->flags & F_RESUME) ? 3L : 0L);
   test_setopt(curl, CURLOPT_RANGE, !(p->flags & F_RESUME) ?
                                    "3-1000000": (char *) NULL);
-  test_setopt(curl, CURLOPT_FAILONERROR, (p->flags & F_FAIL) ? 1 : 0);
+  test_setopt(curl, CURLOPT_FAILONERROR, (p->flags & F_FAIL) ? 1L : 0L);
   hasbody = 0;
   res = curl_easy_perform(curl);
   if(res != p->result) {


### PR DESCRIPTION
To fix this test on macOS with the gcc compiler.

Also unignore test 1156 in GHA/macos.

Ref: c349bd668c91f2484ae21c0f361ddf497143093c #14097 (issue 15.)
Ref: 7b0240c07799c28dc84272f9e38e1092ce4cc498 #16539
Ref: 2ec00372a1fc7f27cd3a6c43e29007400acfe2b6 #16482
