### PR TITLE
sectransp: add support for HTTP/2 in gcc builds

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -314,12 +314,6 @@ jobs:
           export TFLAGS='-j20 ${{ matrix.build.tflags }}'
           if [ -z '${{ matrix.build.torture }}' ]; then
             TFLAGS+=' ~2037 ~2041'  # flaky
-            if [[ '${{ matrix.compiler }}' = 'gcc'* ]]; then
-              if [[ '${{ matrix.build.configure }}' = *'--with-secure-transport'* || \
-                    '${{ matrix.build.generate }}' = *'-DCURL_USE_SECTRANSP=ON'* ]]; then
-                TFLAGS+=' ~HTTP/2'  # 2400 2401 2402 2403 2404 2406, Secure Transport + nghttp2
-              fi
-            fi
             if [[ '${{ matrix.build.configure }}' = *'--with-secure-transport'* || \
                   '${{ matrix.build.generate }}' = *'-DCURL_USE_SECTRANSP=ON'* ]]; then
               TFLAGS+=' ~313'  # Secure Transport does not support crl file

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1091,9 +1091,9 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
   if(result != CURLE_OK)
     return result;
 
-#if CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11
   if(connssl->alpn) {
-#ifdef HAVE_BUILTIN_AVAILABLE
+#if (CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11) && \
+    defined(HAVE_BUILTIN_AVAILABLE)
     if(__builtin_available(macOS 10.13.4, iOS 11, tvOS 11, *)) {
 #else
     if(&SSLSetALPNProtocols && &SSLCopyALPNProtocols) {
@@ -1120,7 +1120,6 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
       infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
     }
   }
-#endif
 
   if(ssl_config->key) {
     infof(data, "WARNING: SSL: CURLOPT_SSLKEY is ignored by Secure "
@@ -2091,9 +2090,9 @@ check_handshake:
         break;
     }
 
-#if CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11
     if(connssl->alpn) {
-#ifdef HAVE_BUILTIN_AVAILABLE
+#if (CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11) && \
+    defined(HAVE_BUILTIN_AVAILABLE)
       if(__builtin_available(macOS 10.13.4, iOS 11, tvOS 11, *)) {
 #else
       if(&SSLSetALPNProtocols && &SSLCopyALPNProtocols) {
@@ -2125,7 +2124,6 @@ check_handshake:
           CFRelease(alpnArr);
       }
     }
-#endif
 
     return CURLE_OK;
   }

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1091,10 +1091,11 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
   if(result != CURLE_OK)
     return result;
 
-#if (CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11) && \
-    defined(HAVE_BUILTIN_AVAILABLE)
+#if CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11
   if(connssl->alpn) {
+#ifdef HAVE_BUILTIN_AVAILABLE
     if(__builtin_available(macOS 10.13.4, iOS 11, tvOS 11, *)) {
+#endif
       struct alpn_proto_buf proto;
       size_t i;
       CFStringRef cstr;
@@ -1115,7 +1116,9 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
       CFRelease(alpnArr);
       Curl_alpn_to_proto_str(&proto, connssl->alpn);
       infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
+#ifdef HAVE_BUILTIN_AVAILABLE
     }
+#endif
   }
 #endif
 
@@ -2088,10 +2091,11 @@ check_handshake:
         break;
     }
 
-#if (CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11) && \
-    defined(HAVE_BUILTIN_AVAILABLE)
+#if CURL_BUILD_MAC_10_13 || CURL_BUILD_IOS_11
     if(connssl->alpn) {
+#ifdef HAVE_BUILTIN_AVAILABLE
       if(__builtin_available(macOS 10.13.4, iOS 11, tvOS 11, *)) {
+#endif
         CFArrayRef alpnArr = NULL;
         CFStringRef chosenProtocol = NULL;
         err = SSLCopyALPNProtocols(backend->ssl_ctx, &alpnArr);
@@ -2117,7 +2121,9 @@ check_handshake:
            and does not need to be freed separately */
         if(alpnArr)
           CFRelease(alpnArr);
+#ifdef HAVE_BUILTIN_AVAILABLE
       }
+#endif
     }
 #endif
 

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -1095,6 +1095,8 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
   if(connssl->alpn) {
 #ifdef HAVE_BUILTIN_AVAILABLE
     if(__builtin_available(macOS 10.13.4, iOS 11, tvOS 11, *)) {
+#else
+    if(&SSLSetALPNProtocols && &SSLCopyALPNProtocols) {
 #endif
       struct alpn_proto_buf proto;
       size_t i;
@@ -1116,9 +1118,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
       CFRelease(alpnArr);
       Curl_alpn_to_proto_str(&proto, connssl->alpn);
       infof(data, VTLS_INFOF_ALPN_OFFER_1STR, proto.data);
-#ifdef HAVE_BUILTIN_AVAILABLE
     }
-#endif
   }
 #endif
 
@@ -2095,6 +2095,8 @@ check_handshake:
     if(connssl->alpn) {
 #ifdef HAVE_BUILTIN_AVAILABLE
       if(__builtin_available(macOS 10.13.4, iOS 11, tvOS 11, *)) {
+#else
+      if(&SSLSetALPNProtocols && &SSLCopyALPNProtocols) {
 #endif
         CFArrayRef alpnArr = NULL;
         CFStringRef chosenProtocol = NULL;
@@ -2121,9 +2123,7 @@ check_handshake:
            and does not need to be freed separately */
         if(alpnArr)
           CFRelease(alpnArr);
-#ifdef HAVE_BUILTIN_AVAILABLE
       }
-#endif
     }
 #endif
 


### PR DESCRIPTION
Before this patch `--http2` did not work in gcc builds with Secure
Transport, because ALPN relied on a compiler supporting the
`HAVE_BUILTIN_AVAILABLE` aka `__builtin_available()` feature. This
is clang-specific and missing from gcc (as of gcc v14).

Add support for ALPN and HTTP/2 when this compiler feature is missing.

Also drop test exceptions from GHA/macos in CI.

Follow-up to 092f6815c808489f1cea3df8449e16dff2c35e6b
Ref: c349bd668c91f2484ae21c0f361ddf497143093c #14097 (issue 15.)
Ref: #4314

---

- [x] rebase on #16580 to fix tests 2402, 2404
  https://github.com/curl/curl/actions/runs/13687990672/job/38275638630?pr=16581
