### PR TITLE
tests: mark tests 1631, 1632 flaky

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -327,7 +327,6 @@ jobs:
             if [[ '${{ matrix.build.configure }}' = *'--with-secure-transport'* || \
                   '${{ matrix.build.generate }}' = *'-DCURL_USE_SECTRANSP=ON'* ]]; then
               TFLAGS+=' ~313'  # Secure Transport does not support crl file
-              TFLAGS+=' ~1631 ~1632'  # Secure Transport is not able to shutdown ftp over https gracefully yet
             fi
           fi
           source $HOME/venv/bin/activate

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -909,6 +909,7 @@ jobs:
         run: |
           export CURL_DIRSUFFIX='${{ matrix.type }}'
           export TFLAGS='-j8 ${{ matrix.tflags }} ~2302 ~2303 ~2307'
+          TFLAGS+=' ~1631 ~1632'  # Flaky: FTP through HTTPS-proxy
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
           PATH="/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -909,7 +909,6 @@ jobs:
         run: |
           export CURL_DIRSUFFIX='${{ matrix.type }}'
           export TFLAGS='-j8 ${{ matrix.tflags }} ~2302 ~2303 ~2307'
-          TFLAGS+=' ~1631 ~1632'  # Flaky: FTP through HTTPS-proxy
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
           PATH="/c/msys64/usr/bin:$PATH"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/tests/data/test1631
+++ b/tests/data/test1631
@@ -3,6 +3,7 @@
 <keywords>
 FTP
 HTTPS-proxy
+flaky
 </keywords>
 </info>
 

--- a/tests/data/test1632
+++ b/tests/data/test1632
@@ -3,6 +3,7 @@
 <keywords>
 FTP
 HTTPS-proxy
+flaky
 </keywords>
 </info>
 


### PR DESCRIPTION
We already marked them flaky in GHA/macos CI. They are also flaky in
other CI jobs, in other OSes, with multiple TLS backends:
- MSVC/LibreSSL: https://github.com/curl/curl/actions/runs/13683996410/job/38262956317
- MSVC/wolfSSL: https://github.com/curl/curl/actions/runs/13680682695/job/38252047077
- FreeBSD/OpenSSL3: https://github.com/curl/curl/actions/runs/13690910863/job/38283867721#step:3:1

Ref: fa461b4eff52b413f88debf543b5350a6cef4724 #14486

---

- [x] extend globally? It's also seen on FreeBSD. https://github.com/curl/curl/actions/runs/13690910863/job/38283867721#step:3:1