### PR TITLE
tool_parsecfg: make my_get_line skip comments and newlines

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1113,29 +1113,9 @@ static ParameterError parse_url(struct GlobalConfig *global,
     if(f) {
       curlx_dyn_init(&line, 8092);
       while(my_get_line(f, &line, &error)) {
-        /* every line has a newline that we strip off */
-        size_t len = curlx_dyn_len(&line);
-        const char *ptr;
-        if(len)
-          curlx_dyn_setlen(&line, len - 1);
-        ptr = curlx_dyn_ptr(&line);
-        /* line with # in the first non-blank column is a comment! */
-        while(*ptr && ISSPACE(*ptr))
-          ptr++;
+        const char *ptr = curlx_dyn_ptr(&line);
 
-        switch(*ptr) {
-        case '#':
-        case '/':
-        case '\r':
-        case '\n':
-        case '*':
-        case '\0':
-          /* comment or weird line, skip it */
-          break;
-        default:
-          err = add_url(global, config, ptr, GETOUT_USEREMOTE | GETOUT_NOGLOB);
-          break;
-        }
+        err = add_url(global, config, ptr, GETOUT_USEREMOTE | GETOUT_NOGLOB);
         if(err)
           break;
         curlx_dyn_reset(&line);
@@ -1295,18 +1275,12 @@ static ParameterError parse_header(struct GlobalConfig *global,
       bool error = FALSE;
       curlx_dyn_init(&line, 1024*100);
       while(my_get_line(file, &line, &error)) {
-        /* every line has a newline that we strip off */
-        size_t len = curlx_dyn_len(&line);
-        if(len) {
-          const char *ptr;
-          curlx_dyn_setlen(&line, len - 1);
-          ptr = curlx_dyn_ptr(&line);
-          err = add2list(cmd == C_PROXY_HEADER ? /* --proxy-header? */
-                         &config->proxyheaders :
-                         &config->headers, ptr);
-          if(err)
-            break;
-        }
+        const char *ptr = curlx_dyn_ptr(&line);
+        err = add2list(cmd == C_PROXY_HEADER ? /* --proxy-header? */
+                       &config->proxyheaders :
+                       &config->headers, ptr);
+        if(err)
+          break;
       }
       if(error)
         err = PARAM_READ_ERROR;

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -303,7 +303,8 @@ static bool get_line(FILE *input, struct dynbuf *buf, bool *error)
 
       else if(b[rlen-1] == '\n') {
         /* end of the line, drop the newline */
-        curlx_dyn_setlen(buf, rlen - 1);
+        curl_off_t len = curlx_dyn_len(buf);
+        curlx_dyn_setlen(buf, len - 1);
         return TRUE; /* all good */
       }
 

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -105,21 +105,6 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
         break;
       }
 
-      /* line with # in the first non-blank column is a comment! */
-      while(*line && ISSPACE(*line))
-        line++;
-
-      switch(*line) {
-      case '#':
-      case '/':
-      case '\r':
-      case '\n':
-      case '*':
-      case '\0':
-        curlx_dyn_reset(&buf);
-        continue;
-      }
-
       /* the option keywords starts here */
       option = line;
 
@@ -295,11 +280,7 @@ static const char *unslashquote(const char *line, char *param)
   return line;
 }
 
-/*
- * Reads a line from the given file, ensuring is NUL terminated.
- */
-
-bool my_get_line(FILE *input, struct dynbuf *buf, bool *error)
+static bool get_line(FILE *input, struct dynbuf *buf, bool *error)
 {
   CURLcode result;
   char buffer[128];
@@ -320,23 +301,42 @@ bool my_get_line(FILE *input, struct dynbuf *buf, bool *error)
         return FALSE; /* error */
       }
 
-      else if(b[rlen-1] == '\n')
-        /* end of the line */
-        return TRUE; /* all good */
-
-      else if(feof(input)) {
-        /* append a newline */
-        result = curlx_dyn_addn(buf, "\n", 1);
-        if(result) {
-          /* too long line or out of memory */
-          *error = TRUE;
-          return FALSE; /* error */
-        }
+      else if(b[rlen-1] == '\n') {
+        /* end of the line, drop the newline */
+        curlx_dyn_setlen(buf, rlen - 1);
         return TRUE; /* all good */
       }
+
+      else if(feof(input))
+        return TRUE; /* all good */
     }
     else
       break;
   }
   return FALSE;
+}
+
+/*
+ * Returns a line from the given file. Every line is NULL terminated (no
+ * newline). Skips #-commented and space/tabs-only lines automatically.
+ */
+bool my_get_line(FILE *input, struct dynbuf *buf, bool *error)
+{
+  bool retcode;
+  do {
+    retcode = get_line(input, buf, error);
+    if(!*error && retcode) {
+      const char *line = curlx_dyn_ptr(buf);
+      if(line) {
+        while(ISBLANK(*line))
+          line++;
+
+        /* a line with # in the first non-blank column is a comment! */
+        if((*line == '#') || (*line == '\n'))
+          continue;
+      }
+    }
+    break;
+  } while(retcode);
+  return retcode;
 }

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -303,7 +303,7 @@ static bool get_line(FILE *input, struct dynbuf *buf, bool *error)
 
       else if(b[rlen-1] == '\n') {
         /* end of the line, drop the newline */
-        curl_off_t len = curlx_dyn_len(buf);
+        size_t len = curlx_dyn_len(buf);
         curlx_dyn_setlen(buf, len - 1);
         return TRUE; /* all good */
       }

--- a/src/tool_ssls.c
+++ b/src/tool_ssls.c
@@ -87,11 +87,6 @@ CURLcode tool_ssls_load(struct GlobalConfig *global,
     curl_free(shmac);
     curl_free(sdata);
     line = Curl_dyn_ptr(&buf);
-    while(*line && ISBLANK(*line))
-      line++;
-    if(*line == '#')
-      /* skip commented lines */
-      continue;
 
     c = memchr(line, ':', strlen(line));
     if(!c) {


### PR DESCRIPTION
- then brings this functionality to all users of this function automatically and consistently

- now consistently returns every line without trailing \n