### PR TITLE
Fix pkcs11 uri checking for key files.

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1612,9 +1612,9 @@ fail:
     case SSL_FILETYPE_PROVIDER:
     {
       /* Implicitly use pkcs11 provider if none was provided and the
-       * cert_file is a PKCS#11 URI */
+       * key_file is a PKCS#11 URI */
       if(!data->state.provider) {
-        if(is_pkcs11_uri(cert_file)) {
+        if(is_pkcs11_uri(key_file)) {
           if(ossl_set_provider(data, "pkcs11") != CURLE_OK) {
             return 0;
           }


### PR DESCRIPTION
I have found this issue when trying to use the new PKCS#11 provider support in curl.

I was getting the following error when trying to use a pkcs11 uri as a key, in curl 8.12.1:

```
* crypto provider not set, cannot load private key
* closing connection #0
curl: (58) crypto provider not set, cannot load private key
```
After checking the code that prints the error, I have found out that it is incorrectly checking if cert_file is a pkcs11 uri, instead of checking key_file:

https://github.com/curl/curl/blob/curl-8_12_1/lib/vtls/openssl.c#L1678

Probably a copy-paste error.
