### PR TITLE
options: fixes memory leak on API misuse

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2140,12 +2140,12 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * user:password needed to use the proxy
      */
+    char *u = NULL;
+    char *p = NULL;
     if(data->set.str[STRING_PROXYUSERNAME] ||
        data->set.str[STRING_PROXYPASSWORD]) {
       return CURLE_BAD_FUNCTION_ARGUMENT;
     }
-    char *u = NULL;
-    char *p = NULL;
     result = setstropt_userpwd(ptr, &u, &p);
 
     /* URL decode the components */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2140,6 +2140,10 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * user:password needed to use the proxy
      */
+    if(data->set.str[STRING_PROXYUSERNAME] ||
+       data->set.str[STRING_PROXYPASSWORD]) {
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     char *u = NULL;
     char *p = NULL;
     result = setstropt_userpwd(ptr, &u, &p);
@@ -2159,12 +2163,18 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * authentication username to use in the operation
      */
+    if(data->set.str[STRING_PROXYUSERNAME]) {
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return Curl_setstropt(&data->set.str[STRING_PROXYUSERNAME], ptr);
 
   case CURLOPT_PROXYPASSWORD:
     /*
      * authentication password to use in the operation
      */
+    if(data->set.str[STRING_PROXYPASSWORD]) {
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    }
     return Curl_setstropt(&data->set.str[STRING_PROXYPASSWORD], ptr);
 
   case CURLOPT_NOPROXY:


### PR DESCRIPTION
CURLOPT_PROXYUSERPWD should not be used if
CURLOPT_PROXYUSERNAME and/or CURLOPT_PROXYPASSWORD get used and vice versa

Will allow fuzzers to go past that with https://github.com/curl/curl-fuzzer/pull/124 cc @cmeister2 