### PR TITLE
setopt: setting PROXYUSERPWD after PROXYUSERNAME/PASSWORD is fine

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -2145,12 +2145,16 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     result = setstropt_userpwd(ptr, &u, &p);
 
     /* URL decode the components */
-    if(!result && u)
+    if(!result && u) {
+      Curl_safefree(data->set.str[STRING_PROXYUSERNAME]);
       result = Curl_urldecode(u, 0, &data->set.str[STRING_PROXYUSERNAME], NULL,
                               REJECT_ZERO);
-    if(!result && p)
+    }
+    if(!result && p) {
+      Curl_safefree(data->set.str[STRING_PROXYPASSWORD]);
       result = Curl_urldecode(p, 0, &data->set.str[STRING_PROXYPASSWORD], NULL,
                               REJECT_ZERO);
+    }
     free(u);
     free(p);
   }

--- a/tests/libtest/lib590.c
+++ b/tests/libtest/lib590.c
@@ -61,6 +61,10 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_PROXYAUTH,
               (long) (CURLAUTH_BASIC | CURLAUTH_DIGEST | CURLAUTH_NTLM));
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2); /* set in first.c */
+
+  /* set the name + password twice to test that the API is fine with it */
+  test_setopt(curl, CURLOPT_PROXYUSERNAME, "me");
+  test_setopt(curl, CURLOPT_PROXYPASSWORD, "password");
   test_setopt(curl, CURLOPT_PROXYUSERPWD, "me:password");
 
   res = curl_easy_perform(curl);


### PR DESCRIPTION
Prevent the previous memory leak. Adjusted test 590 to reproduce the problem then verify the fix.

Fixes #16599
Reported-by: Catena cyber