### PR TITLE
url: call protocol handler's disconnect in Curl_conn_free

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -590,6 +590,9 @@ void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
 #endif
   Curl_safefree(conn->destination);
 
+  if(conn->handler && conn->handler->disconnect &&
+     !conn->bits.shutdown_handler)
+    conn->handler->disconnect(data, conn, TRUE);
   free(conn); /* free all the connection oriented data */
 }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -557,6 +557,10 @@ void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
 
   DEBUGASSERT(conn);
 
+  if(conn->handler && conn->handler->disconnect &&
+     !conn->bits.shutdown_handler)
+    conn->handler->disconnect(data, conn, TRUE);
+
   for(i = 0; i < CURL_ARRAYSIZE(conn->cfilter); ++i) {
     Curl_conn_cf_discard_all(data, conn, (int)i);
   }
@@ -590,9 +594,6 @@ void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
 #endif
   Curl_safefree(conn->destination);
 
-  if(conn->handler && conn->handler->disconnect &&
-     !conn->bits.shutdown_handler)
-    conn->handler->disconnect(data, conn, TRUE);
   free(conn); /* free all the connection oriented data */
 }
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -101,7 +101,7 @@ test654 test655 test656 test658 test659 test660 test661 test662 test663 \
 test664 test665 test666 test667 test668 test669 test670 test671 test672 \
 test673 test674 test675 test676 test677 test678 test679 test680 test681 \
 test682 test683 test684 test685 test686 test687 test688 test689 test690 \
-test691 test692 test693 test694 test695 test696 test697 \
+test691 test692 test693 test694 test695 test696 test697 test698 \
 \
 test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \

--- a/tests/data/test698
+++ b/tests/data/test698
@@ -1,0 +1,58 @@
+<testcase>
+<info>
+<keywords>
+FTP
+ACCT
+</keywords>
+</info>
+# Server-side
+<reply>
+<data>
+data
+    to
+      see
+that FTP
+works
+  so does it?
+</data>
+<servercmd>
+REPLY PASS 332 please provide account name
+REPLY ACCT 230 thank you
+</servercmd>
+</reply>
+
+# Client-side
+<client>
+<server>
+ftp
+</server>
+<name>
+FTP with ACCT and connection reuse
+</name>
+<command>
+ftp://%HOSTIP:%FTPPORT/%TESTNUMBER --ftp-account "one count" ftp://%HOSTIP:%FTPPORT/%TESTNUMBER
+</command>
+</client>
+
+
+# Verify data after the test has been "shot"
+<verify>
+<strip>
+QUIT
+</strip>
+<protocol>
+USER anonymous
+PASS ftp@example.com
+ACCT one count
+PWD
+EPSV
+TYPE I
+SIZE %TESTNUMBER
+RETR %TESTNUMBER
+EPSV
+SIZE %TESTNUMBER
+RETR %TESTNUMBER
+QUIT
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
For the case when the connection struct is all setup, the protocol handler allocates data in its setup_connection function, but the connection struct is discarded again before used further because a connection reuse is prefered. Then the handler's disconnect function was not previously called, which then would lead to a memory leak.

I added test case 698 that reproduces the leak and the fix.

Reported-by: Philippe Antoine