### PR TITLE
wolfssl: fix unused variable warning

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1531,7 +1531,6 @@ static CURLcode wssl_verify_pinned(struct Curl_cfilter *cf,
                                    struct Curl_easy *data)
 {
   struct ssl_connect_data *connssl = cf->ctx;
-  struct wssl_ctx *wssl = (struct wssl_ctx *)connssl->backend;
 #ifndef CURL_DISABLE_PROXY
   const char * const pinnedpubkey = Curl_ssl_cf_is_proxy(cf) ?
     data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY] :
@@ -1542,6 +1541,7 @@ static CURLcode wssl_verify_pinned(struct Curl_cfilter *cf,
 
   if(pinnedpubkey) {
 #ifdef KEEP_PEER_CERT
+    struct wssl_ctx *wssl = (struct wssl_ctx *)connssl->backend;
     WOLFSSL_X509 *x509;
     const char *x509_der;
     int x509_der_len;


### PR DESCRIPTION
E.g. when building against msys2-mingw wolfssl:
https://packages.msys2.org/base/mingw-w64-wolfssl

```
lib/vtls/wolfssl.c: In function 'wssl_verify_pinned':
lib/vtls/wolfssl.c:1534:20: error: unused variable 'wssl' [-Werror=unused-variable]
   struct wssl_ctx *wssl = (struct wssl_ctx *)connssl->backend;
                    ^~~~
```
Ref: https://github.com/curl/curl/actions/runs/13713131802/job/38353245932#step:10:78

Building with the MSYS2 wolfssl is broken due to further issues.
