### PR TITLE
tests/server: round of tidy-ups (part 2)

### DIFF
--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -63,12 +63,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#define DEFAULT_PORT 1883 /* MQTT default port */
-
-#ifndef DEFAULT_CONFIG
-#define DEFAULT_CONFIG "mqttd.config"
-#endif
-
 #define MQTT_MSG_CONNECT    0x10
 #define MQTT_MSG_CONNACK    0x20
 #define MQTT_MSG_PUBLISH    0x30
@@ -91,16 +85,6 @@ struct configurable {
 #define CONFIG_VERSION 5
 
 static struct configurable config;
-
-static const char *configfile = DEFAULT_CONFIG;
-static const char *logdir = "log";
-static char loglockfile[256];
-
-#ifdef USE_IPV6
-static bool use_ipv6 = FALSE;
-#endif
-static const char *ipv_inuse = "IPv4";
-static unsigned short server_port = DEFAULT_PORT;
 
 static void resetdefaults(void)
 {
@@ -923,6 +907,8 @@ int main(int argc, char *argv[])
   int arg = 1;
 
   serverlogfile = "log/mqttd.log";
+  configfile = "mqttd.config";
+  server_port = 1883; /* MQTT default port */
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -735,8 +735,8 @@ static bool mqttd_incoming(curl_socket_t listenfd)
   return TRUE;
 }
 
-static curl_socket_t sockdaemon(curl_socket_t sock,
-                                unsigned short *listenport)
+static curl_socket_t mqttd_sockdaemon(curl_socket_t sock,
+                                      unsigned short *listenport)
 {
   /* passive daemon style */
   srvr_sockaddr_union_t listener;
@@ -997,7 +997,7 @@ int main(int argc, char *argv[])
 
   {
     /* passive daemon style */
-    sock = sockdaemon(sock, &server_port);
+    sock = mqttd_sockdaemon(sock, &server_port);
     if(CURL_SOCKET_BAD == sock) {
       goto mqttd_cleanup;
     }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -900,12 +900,12 @@ int main(int argc, char *argv[])
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
   int wroteportfile = 0;
-  const char *portname = ".mqttd.port";
   bool juggle_again;
   int error;
   int arg = 1;
 
   pidname = ".mqttd.pid";
+  portname = ".mqttd.port";
   serverlogfile = "log/mqttd.log";
   configfile = "mqttd.config";
   server_port = 1883; /* MQTT default port */

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -97,7 +97,7 @@ static void resetdefaults(void)
   config.testnum = 0;
 }
 
-static void getconfig(void)
+static void mqttd_getconfig(void)
 {
   FILE *fp = fopen(configfile, FOPEN_READTEXT);
   resetdefaults();
@@ -452,7 +452,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
   if(!dump)
     goto end;
 
-  getconfig();
+  mqttd_getconfig();
 
   testno = config.testnum;
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -657,7 +657,7 @@ end:
   if sockfd is CURL_SOCKET_BAD, listendfd is a listening socket we must
   accept()
 */
-static bool incoming(curl_socket_t listenfd)
+static bool mqttd_incoming(curl_socket_t listenfd)
 {
   fd_set fds_read;
   fd_set fds_write;
@@ -1018,7 +1018,7 @@ int main(int argc, char *argv[])
   }
 
   do {
-    juggle_again = incoming(sock);
+    juggle_again = mqttd_incoming(sock);
   } while(juggle_again);
 
 mqttd_cleanup:

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -761,7 +761,9 @@ static curl_socket_t mqttd_sockdaemon(curl_socket_t sock,
         rc = wait_ms(delay);
         if(rc) {
           /* should not happen */
-          logmsg("wait_ms() failed with error (%d)", rc);
+          error = errno;
+          logmsg("wait_ms() failed with error (%d) %s",
+                 error, strerror(error));
           sclose(sock);
           return CURL_SOCKET_BAD;
         }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -100,7 +100,7 @@ static char loglockfile[256];
 static bool use_ipv6 = FALSE;
 #endif
 static const char *ipv_inuse = "IPv4";
-static unsigned short port = DEFAULT_PORT;
+static unsigned short server_port = DEFAULT_PORT;
 
 static void resetdefaults(void)
 {
@@ -986,7 +986,7 @@ int main(int argc, char *argv[])
                   argv[arg]);
           return 0;
         }
-        port = util_ultous(ulnum);
+        server_port = util_ultous(ulnum);
         arg++;
       }
     }
@@ -1036,7 +1036,7 @@ int main(int argc, char *argv[])
 
   {
     /* passive daemon style */
-    sock = sockdaemon(sock, &port);
+    sock = sockdaemon(sock, &server_port);
     if(CURL_SOCKET_BAD == sock) {
       goto mqttd_cleanup;
     }
@@ -1044,14 +1044,14 @@ int main(int argc, char *argv[])
   }
 
   logmsg("Running %s version", ipv_inuse);
-  logmsg("Listening on port %hu", port);
+  logmsg("Listening on port %hu", server_port);
 
   wrotepidfile = write_pidfile(pidname);
   if(!wrotepidfile) {
     goto mqttd_cleanup;
   }
 
-  wroteportfile = write_portfile(portname, port);
+  wroteportfile = write_portfile(portname, server_port);
   if(!wroteportfile) {
     goto mqttd_cleanup;
   }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -736,7 +736,8 @@ static bool mqttd_incoming(curl_socket_t listenfd)
 }
 
 static curl_socket_t mqttd_sockdaemon(curl_socket_t sock,
-                                      unsigned short *listenport)
+                                      unsigned short *listenport,
+                                      bool bind_only)
 {
   /* passive daemon style */
   srvr_sockaddr_union_t listener;
@@ -855,6 +856,12 @@ static curl_socket_t mqttd_sockdaemon(curl_socket_t sock,
       sclose(sock);
       return CURL_SOCKET_BAD;
     }
+  }
+
+  /* bindonly option forces no listening */
+  if(bind_only) {
+    logmsg("instructed to bind port without listening");
+    return sock;
   }
 
   /* start accepting connections */
@@ -999,7 +1006,7 @@ int main(int argc, char *argv[])
 
   {
     /* passive daemon style */
-    sock = mqttd_sockdaemon(sock, &server_port);
+    sock = mqttd_sockdaemon(sock, &server_port, FALSE);
     if(CURL_SOCKET_BAD == sock) {
       goto mqttd_cleanup;
     }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -900,12 +900,12 @@ int main(int argc, char *argv[])
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
   int wroteportfile = 0;
-  const char *pidname = ".mqttd.pid";
   const char *portname = ".mqttd.port";
   bool juggle_again;
   int error;
   int arg = 1;
 
+  pidname = ".mqttd.pid";
   serverlogfile = "log/mqttd.log";
   configfile = "mqttd.config";
   server_port = 1883; /* MQTT default port */

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -86,7 +86,7 @@ struct configurable {
 
 static struct configurable config;
 
-static void resetdefaults(void)
+static void mqttd_resetdefaults(void)
 {
   logmsg("Reset to defaults");
   config.version = CONFIG_VERSION;
@@ -100,7 +100,7 @@ static void resetdefaults(void)
 static void mqttd_getconfig(void)
 {
   FILE *fp = fopen(configfile, FOPEN_READTEXT);
-  resetdefaults();
+  mqttd_resetdefaults();
   if(fp) {
     char buffer[512];
     logmsg("parse config file");

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -97,12 +97,6 @@ static void resetdefaults(void)
   config.testnum = 0;
 }
 
-static unsigned char byteval(char *value)
-{
-  unsigned long num = strtoul(value, NULL, 10);
-  return num & 0xff;
-}
-
 static void getconfig(void)
 {
   FILE *fp = fopen(configfile, FOPEN_READTEXT);

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -84,17 +84,17 @@ struct mqttd_configurable {
 #define REQUEST_DUMP  "server.input"
 #define CONFIG_VERSION 5
 
-static struct mqttd_configurable config;
+static struct mqttd_configurable m_config;
 
 static void mqttd_resetdefaults(void)
 {
   logmsg("Reset to defaults");
-  config.version = CONFIG_VERSION;
-  config.publish_before_suback = FALSE;
-  config.short_publish = FALSE;
-  config.excessive_remaining = FALSE;
-  config.error_connack = 0;
-  config.testnum = 0;
+  m_config.version = CONFIG_VERSION;
+  m_config.publish_before_suback = FALSE;
+  m_config.short_publish = FALSE;
+  m_config.excessive_remaining = FALSE;
+  m_config.error_connack = 0;
+  m_config.testnum = 0;
 }
 
 static void mqttd_getconfig(void)
@@ -109,28 +109,28 @@ static void mqttd_getconfig(void)
       char value[32];
       if(2 == sscanf(buffer, "%31s %31s", key, value)) {
         if(!strcmp(key, "version")) {
-          config.version = byteval(value);
-          logmsg("version [%d] set", config.version);
+          m_config.version = byteval(value);
+          logmsg("version [%d] set", m_config.version);
         }
         else if(!strcmp(key, "PUBLISH-before-SUBACK")) {
           logmsg("PUBLISH-before-SUBACK set");
-          config.publish_before_suback = TRUE;
+          m_config.publish_before_suback = TRUE;
         }
         else if(!strcmp(key, "short-PUBLISH")) {
           logmsg("short-PUBLISH set");
-          config.short_publish = TRUE;
+          m_config.short_publish = TRUE;
         }
         else if(!strcmp(key, "error-CONNACK")) {
-          config.error_connack = byteval(value);
-          logmsg("error-CONNACK = %d", config.error_connack);
+          m_config.error_connack = byteval(value);
+          logmsg("error-CONNACK = %d", m_config.error_connack);
         }
         else if(!strcmp(key, "Testnum")) {
-          config.testnum = atoi(value);
-          logmsg("testnum = %d", config.testnum);
+          m_config.testnum = atoi(value);
+          logmsg("testnum = %d", m_config.testnum);
         }
         else if(!strcmp(key, "excessive-remaining")) {
           logmsg("excessive-remaining set");
-          config.excessive_remaining = TRUE;
+          m_config.excessive_remaining = TRUE;
         }
       }
     }
@@ -177,7 +177,7 @@ static int connack(FILE *dump, curl_socket_t fd)
   };
   ssize_t rc;
 
-  packet[3] = config.error_connack;
+  packet[3] = m_config.error_connack;
 
   rc = swrite(fd, (char *)packet, sizeof(packet));
   if(rc > 0) {
@@ -338,7 +338,7 @@ static int publish(FILE *dump,
   unsigned char rembuffer[4];
   size_t encodedlen;
 
-  if(config.excessive_remaining) {
+  if(m_config.excessive_remaining) {
     /* manually set illegal remaining length */
     rembuffer[0] = 0xff;
     rembuffer[1] = 0xff;
@@ -369,7 +369,7 @@ static int publish(FILE *dump,
   memcpy(&packet[payloadindex], payload, payloadlen);
 
   sendamount = packetlen;
-  if(config.short_publish)
+  if(m_config.short_publish)
     sendamount -= 2;
 
   rc = swrite(fd, (char *)packet, sendamount);
@@ -454,7 +454,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
 
   mqttd_getconfig();
 
-  testno = config.testnum;
+  testno = m_config.testnum;
 
   if(testno)
     logmsg("Found test number %ld", testno);
@@ -586,7 +586,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
       stream = test2fopen(testno, logdir);
       error = getpart(&data, &datalen, "reply", "data", stream);
       if(!error) {
-        if(!config.publish_before_suback) {
+        if(!m_config.publish_before_suback) {
           if(suback(dump, fd, packet_id)) {
             logmsg("failed sending SUBACK");
             free(data);
@@ -599,7 +599,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
           goto end;
         }
         free(data);
-        if(config.publish_before_suback) {
+        if(m_config.publish_before_suback) {
           if(suback(dump, fd, packet_id)) {
             logmsg("failed sending SUBACK");
             goto end;

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -327,7 +327,7 @@ static size_t encode_length(size_t packetlen,
 }
 
 
-static size_t decode_length(unsigned char *buf,
+static size_t decode_length(unsigned char *buffer,
                             size_t buflen, size_t *lenbytes)
 {
   size_t len = 0;
@@ -336,7 +336,7 @@ static size_t decode_length(unsigned char *buf,
   unsigned char encoded = 0x80;
 
   for(i = 0; (i < buflen) && (encoded & 0x80); i++) {
-    encoded = buf[i];
+    encoded = buffer[i];
     len += (encoded & 0x7f) * mult;
     mult *= 0x80;
   }

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -147,25 +147,6 @@ static void getconfig(void)
   }
 }
 
-static void loghex(unsigned char *buffer, ssize_t len)
-{
-  char data[12000];
-  ssize_t i;
-  unsigned char *ptr = buffer;
-  char *optr = data;
-  ssize_t width = 0;
-  int left = sizeof(data);
-
-  for(i = 0; i < len && (left >= 0); i++) {
-    msnprintf(optr, left, "%02x", ptr[i]);
-    width += 2;
-    optr += 2;
-    left -= 2;
-  }
-  if(width)
-    logmsg("'%s'", data);
-}
-
 typedef enum {
   FROM_CLIENT,
   FROM_SERVER

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -71,7 +71,7 @@
 #define MQTT_MSG_SUBACK     0x90
 #define MQTT_MSG_DISCONNECT 0xe0
 
-struct configurable {
+struct mqttd_configurable {
   unsigned char version; /* initial version byte in the request must match
                             this */
   bool publish_before_suback;
@@ -84,7 +84,7 @@ struct configurable {
 #define REQUEST_DUMP  "server.input"
 #define CONFIG_VERSION 5
 
-static struct configurable config;
+static struct mqttd_configurable config;
 
 static void mqttd_resetdefaults(void)
 {

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -71,11 +71,11 @@ int main(int argc, char *argv[])
 #if defined(CURLRES_IPV6)
       ipv_inuse = "IPv6";
       use_ipv6 = TRUE;
+      arg++;
 #else
       puts("IPv6 support has been disabled in this program");
       return 1;
 #endif
-      arg++;
     }
     else if(!strcmp("--ipv4", argv[arg])) {
       /* for completeness, we support this option as well */

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -68,14 +68,21 @@ int main(int argc, char *argv[])
       return 0;
     }
     else if(!strcmp("--ipv6", argv[arg])) {
+#if defined(CURLRES_IPV6)
       ipv_inuse = "IPv6";
       use_ipv6 = TRUE;
+#else
+      puts("IPv6 support has been disabled in this program");
+      return 1;
+#endif
       arg++;
     }
     else if(!strcmp("--ipv4", argv[arg])) {
       /* for completeness, we support this option as well */
       ipv_inuse = "IPv4";
+#if defined(CURLRES_IPV6)
       use_ipv6 = FALSE;
+#endif
       arg++;
     }
     else {
@@ -124,13 +131,8 @@ int main(int argc, char *argv[])
       freeaddrinfo(ai);
   }
 #else
-  if(use_ipv6) {
-    puts("IPv6 support has been disabled in this program");
-    return 1;
-  }
-  else {
-    /* gethostbyname() resolve */
-    struct hostent *he;
+  {
+    struct hostent *he;  /* gethostbyname() resolve */
 
 #ifdef __AMIGA__
     he = gethostbyname((unsigned char *)host);

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -50,9 +50,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-static bool use_ipv6 = FALSE;
-static const char *ipv_inuse = "IPv4";
-
 int main(int argc, char *argv[])
 {
   int arg = 1;

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -560,7 +560,7 @@ static int rtspd_ProcessRequest(struct httprequest *req)
 }
 
 /* store the entire request in a file */
-static void storerequest(char *reqbuf, size_t totalsize)
+static void rtspd_storerequest(char *reqbuf, size_t totalsize)
 {
   int res;
   int error = 0;
@@ -682,7 +682,7 @@ static int rtspd_get_request(curl_socket_t sock, struct httprequest *req)
     if(fail) {
       /* dump the request received so far to the external file */
       reqbuf[req->offset] = '\0';
-      storerequest(reqbuf, req->offset);
+      rtspd_storerequest(reqbuf, req->offset);
       return 1;
     }
 
@@ -717,7 +717,7 @@ static int rtspd_get_request(curl_socket_t sock, struct httprequest *req)
     reqbuf[req->offset] = '\0';
 
   /* dump the request to an external file */
-  storerequest(reqbuf, req->pipelining ? req->checkindex : req->offset);
+  rtspd_storerequest(reqbuf, req->pipelining ? req->checkindex : req->offset);
   if(got_exit_signal)
     return 1;
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -59,11 +59,12 @@
 #undef REQBUFSIZ
 #define REQBUFSIZ 150000
 
-static long prevtestno = -1;    /* previous test number we served */
-static long prevpartno = -1;    /* previous part number we served */
-static bool prevbounce = FALSE; /* instructs the server to override the
-                                   requested part number to prevpartno + 1 when
-                                   prevtestno and current test are the same */
+static long rtspd_prevtestno = -1;    /* previous test number we served */
+static long rtspd_prevpartno = -1;    /* previous part number we served */
+static bool rtspd_prevbounce = FALSE; /* instructs the server to override the
+                                         requested part number to
+                                         prevpartno + 1 when prevtestno and
+                                         current test are the same */
 
 #define RCMD_NORMALREQ 0 /* default request, use the tests file normally */
 #define RCMD_IDLE      1 /* told to sit idle */
@@ -877,11 +878,11 @@ static int rtspd_send_doc(curl_socket_t sock, struct httprequest *req)
     logmsg("connection close instruction \"swsclose\" found in response");
   }
   if(strstr(buffer, "swsbounce")) {
-    prevbounce = TRUE;
+    rtspd_prevbounce = TRUE;
     logmsg("enable \"swsbounce\" in the next request");
   }
   else
-    prevbounce = FALSE;
+    rtspd_prevbounce = FALSE;
 
   dump = fopen(responsedump, "ab");
   if(!dump) {
@@ -1003,8 +1004,8 @@ static int rtspd_send_doc(curl_socket_t sock, struct httprequest *req)
   free(cmd);
   req->open = persistent;
 
-  prevtestno = req->testno;
-  prevpartno = req->partno;
+  rtspd_prevtestno = req->testno;
+  rtspd_prevpartno = req->partno;
 
   return 0;
 }
@@ -1285,16 +1286,16 @@ int main(int argc, char *argv[])
         /* non-zero means error, break out of loop */
         break;
 
-      if(prevbounce) {
+      if(rtspd_prevbounce) {
         /* bounce treatment requested */
-        if(req.testno == prevtestno) {
-          req.partno = prevpartno + 1;
+        if(req.testno == rtspd_prevtestno) {
+          req.partno = rtspd_prevpartno + 1;
           logmsg("BOUNCE part number to %ld", req.partno);
         }
         else {
-          prevbounce = FALSE;
-          prevtestno = -1;
-          prevpartno = -1;
+          rtspd_prevbounce = FALSE;
+          rtspd_prevtestno = -1;
+          rtspd_prevpartno = -1;
         }
       }
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -725,7 +725,7 @@ static int rtspd_get_request(curl_socket_t sock, struct httprequest *req)
 }
 
 /* returns -1 on failure */
-static int send_doc(curl_socket_t sock, struct httprequest *req)
+static int rtspd_send_doc(curl_socket_t sock, struct httprequest *req)
 {
   ssize_t written;
   size_t count;
@@ -1298,7 +1298,7 @@ int main(int argc, char *argv[])
         }
       }
 
-      send_doc(msgsock, &req);
+      rtspd_send_doc(msgsock, &req);
       if(got_exit_signal)
         break;
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -132,7 +132,7 @@ struct httprequest {
 
 
 /* sent as reply to a QUIT */
-static const char *docquit =
+static const char *docquit_rtsp =
 "HTTP/1.1 200 Goodbye" END_OF_HEADERS;
 
 /* sent as reply to a CONNECT */
@@ -778,7 +778,7 @@ static int rtspd_send_doc(curl_socket_t sock, struct httprequest *req)
     switch(req->testno) {
     case DOCNUMBER_QUIT:
       logmsg("Replying to QUIT");
-      buffer = docquit;
+      buffer = docquit_rtsp;
       break;
     case DOCNUMBER_WERULEZ:
       /* we got a "friends?" question, reply back that we sure are */

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -56,8 +56,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-static int serverlogslocked = 0;
-
 #undef REQBUFSIZ
 #define REQBUFSIZ 150000
 
@@ -1030,6 +1028,7 @@ int main(int argc, char *argv[])
 
   pidname = ".rtsp.pid";
   serverlogfile = "log/rtspd.log";
+  serverlogslocked = 0;
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -614,7 +614,7 @@ storerequest_cleanup:
 }
 
 /* return 0 on success, non-zero on failure */
-static int get_request(curl_socket_t sock, struct httprequest *req)
+static int rtspd_get_request(curl_socket_t sock, struct httprequest *req)
 {
   int error;
   int fail = 0;
@@ -1271,9 +1271,9 @@ int main(int argc, char *argv[])
     }
 #endif
 
-    /* initialization of httprequest struct is done in get_request(), but due
-       to pipelining treatment the pipelining struct field must be initialized
-       previously to FALSE every time a new connection arrives. */
+    /* initialization of httprequest struct is done in rtspd_get_request(),
+       but due to pipelining treatment the pipelining struct field must be
+       initialized previously to FALSE every time a new connection arrives. */
 
     req.pipelining = FALSE;
 
@@ -1281,7 +1281,7 @@ int main(int argc, char *argv[])
       if(got_exit_signal)
         break;
 
-      if(get_request(msgsock, &req))
+      if(rtspd_get_request(msgsock, &req))
         /* non-zero means error, break out of loop */
         break;
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -56,10 +56,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#ifdef USE_IPV6
-static bool use_ipv6 = FALSE;
-#endif
-static const char *ipv_inuse = "IPv4";
 static int serverlogslocked = 0;
 
 #define REQBUFSIZ 150000
@@ -114,11 +110,6 @@ struct httprequest {
 
 static int ProcessRequest(struct httprequest *req);
 static void storerequest(char *reqbuf, size_t totalsize);
-
-#define DEFAULT_PORT 8999
-
-static const char *logdir = "log";
-static char loglockfile[256];
 
 #define RTSPDVERSION "curl test suite RTSP server/0.1"
 
@@ -1031,7 +1022,7 @@ int main(int argc, char *argv[])
   int wrotepidfile = 0;
   int wroteportfile = 0;
   int flag;
-  unsigned short port = DEFAULT_PORT;
+  unsigned short port = 8999;
   const char *pidname = ".rtsp.pid";
   const char *portname = NULL; /* none by default */
   struct httprequest req;

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -58,6 +58,7 @@
 
 static int serverlogslocked = 0;
 
+#undef REQBUFSIZ
 #define REQBUFSIZ 150000
 
 static long prevtestno = -1;    /* previous test number we served */

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1023,7 +1023,6 @@ int main(int argc, char *argv[])
   int wroteportfile = 0;
   int flag;
   unsigned short port = 8999;
-  const char *portname = NULL; /* none by default */
   struct httprequest req;
   int rc;
   int error;

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -166,7 +166,7 @@ static const char *doc404_RTSP = "RTSP/1.0 404 Not Found\r\n"
 #define RTP_DATA_SIZE 12
 static const char *RTP_DATA = "$_1234\n\0Rsdf";
 
-static int ProcessRequest(struct httprequest *req)
+static int rtspd_ProcessRequest(struct httprequest *req)
 {
   char *line = &req->reqbuf[req->checkindex];
   bool chunked = FALSE;
@@ -176,7 +176,7 @@ static int ProcessRequest(struct httprequest *req)
   int prot_major, prot_minor;
   char *end = strstr(line, END_OF_HEADERS);
 
-  logmsg("ProcessRequest() called with testno %ld and line [%s]",
+  logmsg("rtspd_ProcessRequest() called with testno %ld and line [%s]",
          req->testno, line);
 
   /* try to figure out the request characteristics as soon as possible, but
@@ -405,10 +405,10 @@ static int ProcessRequest(struct httprequest *req)
 
   if(!end) {
     /* we don't have a complete request yet! */
-    logmsg("ProcessRequest returned without a complete request");
+    logmsg("rtspd_ProcessRequest returned without a complete request");
     return 0; /* not complete yet */
   }
-  logmsg("ProcessRequest found a complete request");
+  logmsg("rtspd_ProcessRequest found a complete request");
 
   if(req->pipe)
     /* we do have a full set, advance the checkindex to after the end of the
@@ -691,7 +691,7 @@ static int get_request(curl_socket_t sock, struct httprequest *req)
     req->offset += (size_t)got;
     reqbuf[req->offset] = '\0';
 
-    done_processing = ProcessRequest(req);
+    done_processing = rtspd_ProcessRequest(req);
     if(got_exit_signal)
       return 1;
     if(done_processing && req->pipe) {

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1023,7 +1023,6 @@ int main(int argc, char *argv[])
   int wroteportfile = 0;
   int flag;
   unsigned short port = 8999;
-  const char *pidname = ".rtsp.pid";
   const char *portname = NULL; /* none by default */
   struct httprequest req;
   int rc;
@@ -1032,6 +1031,7 @@ int main(int argc, char *argv[])
 
   memset(&req, 0, sizeof(req));
 
+  pidname = ".rtsp.pid";
   serverlogfile = "log/rtspd.log";
 
   while(argc > arg) {

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -81,7 +81,7 @@ typedef enum {
 #define SET_RTP_PKT_LEN(p,l) (((p)[2] = (char)(((l) >> 8) & 0xFF)), \
                               ((p)[3] = (char)((l) & 0xFF)))
 
-struct httprequest {
+struct rtspd_httprequest {
   char reqbuf[REQBUFSIZ]; /* buffer area for the incoming request */
   size_t checkindex; /* where to start checking of the request */
   size_t offset;     /* size of the incoming request */
@@ -167,7 +167,7 @@ static const char *doc404_RTSP = "RTSP/1.0 404 Not Found\r\n"
 #define RTP_DATA_SIZE 12
 static const char *RTP_DATA = "$_1234\n\0Rsdf";
 
-static int rtspd_ProcessRequest(struct httprequest *req)
+static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
 {
   char *line = &req->reqbuf[req->checkindex];
   bool chunked = FALSE;
@@ -615,7 +615,7 @@ storerequest_cleanup:
 }
 
 /* return 0 on success, non-zero on failure */
-static int rtspd_get_request(curl_socket_t sock, struct httprequest *req)
+static int rtspd_get_request(curl_socket_t sock, struct rtspd_httprequest *req)
 {
   int error;
   int fail = 0;
@@ -726,7 +726,7 @@ static int rtspd_get_request(curl_socket_t sock, struct httprequest *req)
 }
 
 /* returns -1 on failure */
-static int rtspd_send_doc(curl_socket_t sock, struct httprequest *req)
+static int rtspd_send_doc(curl_socket_t sock, struct rtspd_httprequest *req)
 {
   ssize_t written;
   size_t count;
@@ -1020,7 +1020,7 @@ int main(int argc, char *argv[])
   int wroteportfile = 0;
   int flag;
   unsigned short port = 8999;
-  struct httprequest req;
+  struct rtspd_httprequest req;
   int rc;
   int error;
   int arg = 1;

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -109,9 +109,6 @@ struct httprequest {
   size_t rtp_buffersize;
 };
 
-static int ProcessRequest(struct httprequest *req);
-static void storerequest(char *reqbuf, size_t totalsize);
-
 #define RTSPDVERSION "curl test suite RTSP server/0.1"
 
 #define REQUEST_DUMP  "server.input"

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1375,7 +1375,6 @@ int main(int argc, char *argv[])
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
   int wroteportfile = 0;
-  const char *portname = NULL; /* none by default */
   bool juggle_again;
   int rc;
   int error;

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -127,7 +127,8 @@ static bool use_ipv6 = FALSE;
 #endif
 static const char *ipv_inuse = "IPv4";
 static unsigned short server_port = DEFAULT_PORT;
-static unsigned short connectport = 0; /* if non-zero, we activate this mode */
+static unsigned short server_connectport = 0; /* if non-zero,
+                                                 we activate this mode */
 
 enum sockmode {
   PASSIVE_LISTEN,    /* as a server waiting for connections */
@@ -1463,7 +1464,7 @@ int main(int argc, char *argv[])
                   argv[arg]);
           return 0;
         }
-        connectport = util_ultous(ulnum);
+        server_connectport = util_ultous(ulnum);
         arg++;
       }
     }
@@ -1519,7 +1520,7 @@ int main(int argc, char *argv[])
     goto sockfilt_cleanup;
   }
 
-  if(connectport) {
+  if(server_connectport) {
     /* Active mode, we should connect to the given port number */
     mode = ACTIVE;
 #ifdef USE_IPV6
@@ -1527,7 +1528,7 @@ int main(int argc, char *argv[])
 #endif
       memset(&me.sa4, 0, sizeof(me.sa4));
       me.sa4.sin_family = AF_INET;
-      me.sa4.sin_port = htons(connectport);
+      me.sa4.sin_port = htons(server_connectport);
       me.sa4.sin_addr.s_addr = INADDR_ANY;
       if(!addr)
         addr = "127.0.0.1";
@@ -1539,7 +1540,7 @@ int main(int argc, char *argv[])
     else {
       memset(&me.sa6, 0, sizeof(me.sa6));
       me.sa6.sin6_family = AF_INET6;
-      me.sa6.sin6_port = htons(connectport);
+      me.sa6.sin6_port = htons(server_connectport);
       if(!addr)
         addr = "::1";
       Curl_inet_pton(AF_INET6, addr, &me.sa6.sin6_addr);
@@ -1550,7 +1551,7 @@ int main(int argc, char *argv[])
     if(rc) {
       error = SOCKERRNO;
       logmsg("Error connecting to port %hu (%d) %s",
-             connectport, error, sstrerror(error));
+             server_connectport, error, sstrerror(error));
       write_stdout("FAIL\n", 5);
       goto sockfilt_cleanup;
     }
@@ -1569,8 +1570,8 @@ int main(int argc, char *argv[])
 
   logmsg("Running %s version", ipv_inuse);
 
-  if(connectport)
-    logmsg("Connected to port %hu", connectport);
+  if(server_connectport)
+    logmsg("Connected to port %hu", server_connectport);
   else if(bind_only)
     logmsg("Bound without listening on port %hu", server_port);
   else

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -126,7 +126,7 @@ static bool bind_only = FALSE;
 static bool use_ipv6 = FALSE;
 #endif
 static const char *ipv_inuse = "IPv4";
-static unsigned short port = DEFAULT_PORT;
+static unsigned short server_port = DEFAULT_PORT;
 static unsigned short connectport = 0; /* if non-zero, we activate this mode */
 
 enum sockmode {
@@ -1126,7 +1126,8 @@ static bool juggle(curl_socket_t *sockfdp,
     else if(!memcmp("PORT", buffer, 4)) {
       /* Question asking us what PORT number we are listening to.
          Replies to PORT with "IPv[num]/[port]" */
-      msnprintf((char *)buffer, sizeof(buffer), "%s/%hu\n", ipv_inuse, port);
+      msnprintf((char *)buffer, sizeof(buffer), "%s/%hu\n",
+                ipv_inuse, server_port);
       buffer_len = (ssize_t)strlen((char *)buffer);
       msnprintf(data, sizeof(data), "PORT\n%04zx\n", buffer_len);
       if(!write_stdout(data, 10))
@@ -1445,7 +1446,7 @@ int main(int argc, char *argv[])
       if(argc > arg) {
         char *endptr;
         unsigned long ulnum = strtoul(argv[arg], &endptr, 10);
-        port = util_ultous(ulnum);
+        server_port = util_ultous(ulnum);
         arg++;
       }
     }
@@ -1558,7 +1559,7 @@ int main(int argc, char *argv[])
   }
   else {
     /* passive daemon style */
-    sock = sockdaemon(sock, &port);
+    sock = sockdaemon(sock, &server_port);
     if(CURL_SOCKET_BAD == sock) {
       write_stdout("FAIL\n", 5);
       goto sockfilt_cleanup;
@@ -1571,9 +1572,9 @@ int main(int argc, char *argv[])
   if(connectport)
     logmsg("Connected to port %hu", connectport);
   else if(bind_only)
-    logmsg("Bound without listening on port %hu", port);
+    logmsg("Bound without listening on port %hu", server_port);
   else
-    logmsg("Listening on port %hu", port);
+    logmsg("Listening on port %hu", server_port);
 
   wrotepidfile = write_pidfile(pidname);
   if(!wrotepidfile) {
@@ -1581,7 +1582,7 @@ int main(int argc, char *argv[])
     goto sockfilt_cleanup;
   }
   if(portname) {
-    wroteportfile = write_portfile(portname, port);
+    wroteportfile = write_portfile(portname, server_port);
     if(!wroteportfile) {
       write_stdout("FAIL\n", 5);
       goto sockfilt_cleanup;

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1375,7 +1375,6 @@ int main(int argc, char *argv[])
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
   int wroteportfile = 0;
-  const char *pidname = ".sockfilt.pid";
   const char *portname = NULL; /* none by default */
   bool juggle_again;
   int rc;
@@ -1384,6 +1383,7 @@ int main(int argc, char *argv[])
   enum sockmode mode = PASSIVE_LISTEN; /* default */
   const char *addr = NULL;
 
+  pidname = ".sockfilt.pid";
   serverlogfile = "log/sockfilt.log";
   server_port = 8999;
 

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -114,19 +114,12 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#define DEFAULT_PORT 8999
-
 /* buffer is this excessively large only to be able to support things like
   test 1003 which tests exceedingly large server response lines */
 #define BUFFER_SIZE 17010
 
 static bool verbose = FALSE;
 static bool bind_only = FALSE;
-#ifdef USE_IPV6
-static bool use_ipv6 = FALSE;
-#endif
-static const char *ipv_inuse = "IPv4";
-static unsigned short server_port = DEFAULT_PORT;
 static unsigned short server_connectport = 0; /* if non-zero,
                                                  we activate this mode */
 
@@ -1392,6 +1385,7 @@ int main(int argc, char *argv[])
   const char *addr = NULL;
 
   serverlogfile = "log/sockfilt.log";
+  server_port = 8999;
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1226,8 +1226,8 @@ static bool juggle(curl_socket_t *sockfdp,
 #endif
 }
 
-static curl_socket_t sockdaemon(curl_socket_t sock,
-                                unsigned short *listenport)
+static curl_socket_t sockfilt_sockdaemon(curl_socket_t sock,
+                                         unsigned short *listenport)
 {
   /* passive daemon style */
   srvr_sockaddr_union_t listener;
@@ -1553,7 +1553,7 @@ int main(int argc, char *argv[])
   }
   else {
     /* passive daemon style */
-    sock = sockdaemon(sock, &server_port);
+    sock = sockfilt_sockdaemon(sock, &server_port);
     if(CURL_SOCKET_BAD == sock) {
       write_stdout("FAIL\n", 5);
       goto sockfilt_cleanup;

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -119,7 +119,7 @@
 #define BUFFER_SIZE 17010
 
 static bool verbose = FALSE;
-static bool bind_only = FALSE;
+static bool s_bind_only = FALSE;
 static unsigned short server_connectport = 0; /* if non-zero,
                                                  we activate this mode */
 
@@ -1227,7 +1227,8 @@ static bool juggle(curl_socket_t *sockfdp,
 }
 
 static curl_socket_t sockfilt_sockdaemon(curl_socket_t sock,
-                                         unsigned short *listenport)
+                                         unsigned short *listenport,
+                                         bool bind_only)
 {
   /* passive daemon style */
   srvr_sockaddr_union_t listener;
@@ -1432,7 +1433,7 @@ int main(int argc, char *argv[])
       arg++;
     }
     else if(!strcmp("--bindonly", argv[arg])) {
-      bind_only = TRUE;
+      s_bind_only = TRUE;
       arg++;
     }
     else if(!strcmp("--port", argv[arg])) {
@@ -1553,7 +1554,7 @@ int main(int argc, char *argv[])
   }
   else {
     /* passive daemon style */
-    sock = sockfilt_sockdaemon(sock, &server_port);
+    sock = sockfilt_sockdaemon(sock, &server_port, s_bind_only);
     if(CURL_SOCKET_BAD == sock) {
       write_stdout("FAIL\n", 5);
       goto sockfilt_cleanup;
@@ -1565,7 +1566,7 @@ int main(int argc, char *argv[])
 
   if(server_connectport)
     logmsg("Connected to port %hu", server_connectport);
-  else if(bind_only)
+  else if(s_bind_only)
     logmsg("Bound without listening on port %hu", server_port);
   else
     logmsg("Listening on port %hu", server_port);

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -129,7 +129,7 @@ static const char *reqlogfile = DEFAULT_REQFILE;
 static const char *configfile = DEFAULT_CONFIG;
 
 static const char *socket_type = "IPv4";
-static unsigned short port = DEFAULT_PORT;
+static unsigned short server_port = DEFAULT_PORT;
 
 static void resetdefaults(void)
 {
@@ -1054,7 +1054,7 @@ int main(int argc, char *argv[])
       if(argc > arg) {
         char *endptr;
         unsigned long ulnum = strtoul(argv[arg], &endptr, 10);
-        port = util_ultous(ulnum);
+        server_port = util_ultous(ulnum);
         arg++;
       }
     }
@@ -1099,7 +1099,7 @@ int main(int argc, char *argv[])
 
   {
     /* passive daemon style */
-    sock = sockdaemon(sock, &port
+    sock = sockdaemon(sock, &server_port
 #ifdef USE_UNIX_SOCKETS
             , unix_socket
 #endif
@@ -1120,7 +1120,7 @@ int main(int argc, char *argv[])
     logmsg("Listening on Unix socket %s", unix_socket);
   else
 #endif
-  logmsg("Listening on port %hu", port);
+  logmsg("Listening on port %hu", server_port);
 
   wrotepidfile = write_pidfile(pidname);
   if(!wrotepidfile) {
@@ -1128,7 +1128,7 @@ int main(int argc, char *argv[])
   }
 
   if(portname) {
-    wroteportfile = write_portfile(portname, port);
+    wroteportfile = write_portfile(portname, server_port);
     if(!wroteportfile) {
       goto socks5_cleanup;
     }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -137,12 +137,6 @@ static void resetdefaults(void)
   strcpy(config.password, "password");
 }
 
-static unsigned char byteval(char *value)
-{
-  unsigned long num = strtoul(value, NULL, 10);
-  return num & 0xff;
-}
-
 static unsigned short shortval(char *value)
 {
   unsigned long num = strtoul(value, NULL, 10);

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -759,11 +759,8 @@ static bool socksd_incoming(curl_socket_t listenfd)
 }
 
 static curl_socket_t socksd_sockdaemon(curl_socket_t sock,
-                                       unsigned short *listenport
-#ifdef USE_UNIX_SOCKETS
-        , const char *unix_socket
-#endif
-        )
+                                       unsigned short *listenport,
+                                       const char *unix_socket)
 {
   /* passive daemon style */
   srvr_sockaddr_union_t listener;
@@ -774,6 +771,10 @@ static curl_socket_t socksd_sockdaemon(curl_socket_t sock,
   int delay = 20;
   int attempt = 0;
   int error = 0;
+
+#ifndef USE_UNIX_SOCKETS
+  (void)unix_socket;
+#endif
 
   do {
     attempt++;
@@ -921,8 +922,8 @@ int main(int argc, char *argv[])
   int error;
   int arg = 1;
 
-#ifdef USE_UNIX_SOCKETS
   const char *unix_socket = NULL;
+#ifdef USE_UNIX_SOCKETS
   bool unlink_socket = false;
 #endif
 
@@ -1059,11 +1060,7 @@ int main(int argc, char *argv[])
 
   {
     /* passive daemon style */
-    sock = socksd_sockdaemon(sock, &server_port
-#ifdef USE_UNIX_SOCKETS
-            , unix_socket
-#endif
-            );
+    sock = socksd_sockdaemon(sock, &server_port, unix_socket);
     if(CURL_SOCKET_BAD == sock) {
       goto socks5_cleanup;
     }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -121,7 +121,7 @@ static struct configurable config;
 
 static const char *reqlogfile = DEFAULT_REQFILE;
 
-static void resetdefaults(void)
+static void socksd_resetdefaults(void)
 {
   logmsg("Reset to defaults");
   config.version = CONFIG_VERSION;
@@ -146,7 +146,7 @@ static unsigned short shortval(char *value)
 static void socksd_getconfig(void)
 {
   FILE *fp = fopen(configfile, FOPEN_READTEXT);
-  resetdefaults();
+  socksd_resetdefaults();
   if(fp) {
     char buffer[512];
     logmsg("parse config file");

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -950,7 +950,6 @@ int main(int argc, char *argv[])
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
   int wroteportfile = 0;
-  const char *pidname = ".socksd.pid";
   const char *portname = NULL; /* none by default */
   bool juggle_again;
   int error;
@@ -961,6 +960,7 @@ int main(int argc, char *argv[])
   bool unlink_socket = false;
 #endif
 
+  pidname = ".socksd.pid";
   serverlogfile = "log/socksd.log";
   configfile = "socksd.config";
   server_port = 8905;

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -207,25 +207,6 @@ static void getconfig(void)
   }
 }
 
-static void loghex(unsigned char *buffer, ssize_t len)
-{
-  char data[1200];
-  ssize_t i;
-  unsigned char *ptr = buffer;
-  char *optr = data;
-  ssize_t width = 0;
-  int left = sizeof(data);
-
-  for(i = 0; i < len && (left >= 0); i++) {
-    msnprintf(optr, left, "%02x", ptr[i]);
-    width += 2;
-    optr += 2;
-    left -= 2;
-  }
-  if(width)
-    logmsg("'%s'", data);
-}
-
 /* RFC 1928, SOCKS5 byte index */
 #define SOCKS5_VERSION 0
 #define SOCKS5_NMETHODS 1 /* number of methods that is listed */

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -121,8 +121,6 @@ static struct configurable config;
 
 static const char *reqlogfile = DEFAULT_REQFILE;
 
-static const char *socket_type = "IPv4";
-
 static void resetdefaults(void)
 {
   logmsg("Reset to defaults");
@@ -150,8 +148,6 @@ static unsigned short shortval(char *value)
   unsigned long num = strtoul(value, NULL, 10);
   return num & 0xffff;
 }
-
-static int socket_domain = AF_INET;
 
 static void getconfig(void)
 {

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -92,7 +92,7 @@
 static const char *backendaddr = "127.0.0.1";
 static unsigned short backendport = 0; /* default is use client's */
 
-struct configurable {
+struct socksd_configurable {
   unsigned char version; /* initial version byte in the request must match
                             this */
   unsigned char nmethods_min; /* minimum number of nmethods to expect */
@@ -117,7 +117,7 @@ struct configurable {
 #define CONFIG_ADDR backendaddr
 #define CONFIG_CONNECTREP 0
 
-static struct configurable config;
+static struct socksd_configurable config;
 
 static const char *reqlogfile = DEFAULT_REQFILE;
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -760,7 +760,8 @@ static bool socksd_incoming(curl_socket_t listenfd)
 
 static curl_socket_t socksd_sockdaemon(curl_socket_t sock,
                                        unsigned short *listenport,
-                                       const char *unix_socket)
+                                       const char *unix_socket,
+                                       bool bind_only)
 {
   /* passive daemon style */
   srvr_sockaddr_union_t listener;
@@ -896,6 +897,12 @@ static curl_socket_t socksd_sockdaemon(curl_socket_t sock,
       sclose(sock);
       return CURL_SOCKET_BAD;
     }
+  }
+
+  /* bindonly option forces no listening */
+  if(bind_only) {
+    logmsg("instructed to bind port without listening");
+    return sock;
   }
 
   /* start accepting connections */
@@ -1060,7 +1067,7 @@ int main(int argc, char *argv[])
 
   {
     /* passive daemon style */
-    sock = socksd_sockdaemon(sock, &server_port, unix_socket);
+    sock = socksd_sockdaemon(sock, &server_port, unix_socket, FALSE);
     if(CURL_SOCKET_BAD == sock) {
       goto socks5_cleanup;
     }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -85,14 +85,8 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#define DEFAULT_PORT 8905
-
 #ifndef DEFAULT_REQFILE
 #define DEFAULT_REQFILE "log/socksd-request.log"
-#endif
-
-#ifndef DEFAULT_CONFIG
-#define DEFAULT_CONFIG "socksd.config"
 #endif
 
 static const char *backendaddr = "127.0.0.1";
@@ -126,10 +120,8 @@ struct configurable {
 static struct configurable config;
 
 static const char *reqlogfile = DEFAULT_REQFILE;
-static const char *configfile = DEFAULT_CONFIG;
 
 static const char *socket_type = "IPv4";
-static unsigned short server_port = DEFAULT_PORT;
 
 static void resetdefaults(void)
 {
@@ -970,6 +962,8 @@ int main(int argc, char *argv[])
 #endif
 
   serverlogfile = "log/socksd.log";
+  configfile = "socksd.config";
+  server_port = 8905;
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -143,7 +143,7 @@ static unsigned short shortval(char *value)
   return num & 0xffff;
 }
 
-static void getconfig(void)
+static void socksd_getconfig(void)
 {
   FILE *fp = fopen(configfile, FOPEN_READTEXT);
   resetdefaults();
@@ -316,7 +316,7 @@ static curl_socket_t sockit(curl_socket_t fd)
   curl_socket_t connfd = CURL_SOCKET_BAD;
   unsigned short s5port;
 
-  getconfig();
+  socksd_getconfig();
 
   rc = recv(fd, (char *)buffer, sizeof(buffer), 0);
   if(rc <= 0) {

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -85,10 +85,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-#ifndef DEFAULT_REQFILE
-#define DEFAULT_REQFILE "log/socksd-request.log"
-#endif
-
 static const char *backendaddr = "127.0.0.1";
 static unsigned short backendport = 0; /* default is use client's */
 
@@ -119,7 +115,7 @@ struct socksd_configurable {
 
 static struct socksd_configurable config;
 
-static const char *reqlogfile = DEFAULT_REQFILE;
+static const char *reqlogfile = "log/socksd-request.log";
 
 static void socksd_resetdefaults(void)
 {

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -950,7 +950,6 @@ int main(int argc, char *argv[])
   curl_socket_t msgsock = CURL_SOCKET_BAD;
   int wrotepidfile = 0;
   int wroteportfile = 0;
-  const char *portname = NULL; /* none by default */
   bool juggle_again;
   int error;
   int arg = 1;

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -762,8 +762,8 @@ static bool socksd_incoming(curl_socket_t listenfd)
   return TRUE;
 }
 
-static curl_socket_t sockdaemon(curl_socket_t sock,
-                                unsigned short *listenport
+static curl_socket_t socksd_sockdaemon(curl_socket_t sock,
+                                       unsigned short *listenport
 #ifdef USE_UNIX_SOCKETS
         , const char *unix_socket
 #endif
@@ -1063,7 +1063,7 @@ int main(int argc, char *argv[])
 
   {
     /* passive daemon style */
-    sock = sockdaemon(sock, &server_port
+    sock = socksd_sockdaemon(sock, &server_port
 #ifdef USE_UNIX_SOCKETS
             , unix_socket
 #endif

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -626,7 +626,7 @@ static int tunnel(struct perclient *cp, fd_set *fds)
   if sockfd is CURL_SOCKET_BAD, listendfd is a listening socket we must
   accept()
 */
-static bool incoming(curl_socket_t listenfd)
+static bool socksd_incoming(curl_socket_t listenfd)
 {
   fd_set fds_read;
   fd_set fds_write;
@@ -1099,7 +1099,7 @@ int main(int argc, char *argv[])
   }
 
   do {
-    juggle_again = incoming(sock);
+    juggle_again = socksd_incoming(sock);
   } while(juggle_again);
 
 socks5_cleanup:

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -829,7 +829,7 @@ static void init_httprequest(struct httprequest *req)
   req->upgrade_request = 0;
 }
 
-static int send_doc(curl_socket_t sock, struct httprequest *req);
+static int sws_send_doc(curl_socket_t sock, struct httprequest *req);
 
 /* returns 1 if the connection should be serviced again immediately, 0 if there
    is no data waiting, or < 0 if it should be closed */
@@ -843,7 +843,7 @@ static int sws_get_request(curl_socket_t sock, struct httprequest *req)
   if(req->upgrade_request) {
     /* upgraded connection, work it differently until end of connection */
     logmsg("Upgraded connection, this is no longer HTTP/1");
-    send_doc(sock, req);
+    sws_send_doc(sock, req);
 
     /* dump the request received so far to the external file */
     reqbuf[req->offset] = '\0';
@@ -975,7 +975,7 @@ static int sws_get_request(curl_socket_t sock, struct httprequest *req)
 }
 
 /* returns -1 on failure */
-static int send_doc(curl_socket_t sock, struct httprequest *req)
+static int sws_send_doc(curl_socket_t sock, struct httprequest *req)
 {
   ssize_t written;
   size_t count;
@@ -1606,7 +1606,7 @@ static void http_connect(curl_socket_t *infdp,
 
           /* skip this and close the socket if err < 0 */
           if(err >= 0) {
-            err = send_doc(datafd, req2);
+            err = sws_send_doc(datafd, req2);
             if(!err && req2->connect_request) {
               /* sleep to prevent triggering libcurl known bug #39. */
               for(loop = 2; (loop > 0) && !got_exit_signal; loop--)
@@ -1958,7 +1958,7 @@ static int service_connection(curl_socket_t msgsock, struct httprequest *req,
     }
   }
 
-  send_doc(msgsock, req);
+  sws_send_doc(msgsock, req);
   if(got_exit_signal)
     return -1;
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -748,7 +748,7 @@ static int sws_ProcessRequest(struct httprequest *req)
 }
 
 /* store the entire request in a file */
-static void storerequest(const char *reqbuf, size_t totalsize)
+static void sws_storerequest(const char *reqbuf, size_t totalsize)
 {
   int res;
   int error = 0;
@@ -847,7 +847,7 @@ static int sws_get_request(curl_socket_t sock, struct httprequest *req)
 
     /* dump the request received so far to the external file */
     reqbuf[req->offset] = '\0';
-    storerequest(reqbuf, req->offset);
+    sws_storerequest(reqbuf, req->offset);
     req->offset = 0;
 
     /* read websocket traffic */
@@ -897,7 +897,7 @@ static int sws_get_request(curl_socket_t sock, struct httprequest *req)
       logmsg("log the websocket traffic");
       /* dump the incoming websocket traffic to the external file */
       reqbuf[req->offset] = '\0';
-      storerequest(reqbuf, req->offset);
+      sws_storerequest(reqbuf, req->offset);
       req->offset = 0;
     }
     init_httprequest(req);
@@ -936,7 +936,7 @@ static int sws_get_request(curl_socket_t sock, struct httprequest *req)
     if(fail) {
       /* dump the request received so far to the external file */
       reqbuf[req->offset] = '\0';
-      storerequest(reqbuf, req->offset);
+      sws_storerequest(reqbuf, req->offset);
       return -1;
     }
 
@@ -967,7 +967,7 @@ static int sws_get_request(curl_socket_t sock, struct httprequest *req)
 
   /* at the end of a request dump it to an external file */
   if(fail || req->done_processing)
-    storerequest(reqbuf, req->offset);
+    sws_storerequest(reqbuf, req->offset);
   if(got_exit_signal)
     return -1;
 
@@ -2431,7 +2431,7 @@ int main(int argc, char *argv[])
 
             if(req->connmon) {
               const char *keepopen = "[DISCONNECT]\n";
-              storerequest(keepopen, strlen(keepopen));
+              sws_storerequest(keepopen, strlen(keepopen));
             }
 
             if(!req->open)

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -58,7 +58,6 @@
 /* include memdebug.h last */
 #include "memdebug.h"
 
-static int socket_domain = AF_INET;
 static bool use_gopher = FALSE;
 static int serverlogslocked = 0;
 static bool is_proxy = FALSE;
@@ -2024,7 +2023,6 @@ int main(int argc, char *argv[])
   int error;
   int arg = 1;
   const char *connecthost = "127.0.0.1";
-  const char *socket_type = "IPv4";
   char port_str[11];
   const char *location_str = port_str;
   int keepalive_secs = 5;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -100,7 +100,7 @@ struct httprequest {
                      - skip bytes. */
   int rcmd;       /* doing a special command, see defines above */
   int prot_version;  /* HTTP version * 10 */
-  int callcount;  /* times ProcessRequest() gets called */
+  int callcount;  /* times sws_ProcessRequest() gets called */
   bool skipall;   /* skip all incoming data */
   bool noexpect;  /* refuse Expect: (don't read the body) */
   bool connmon;   /* monitor the state of the connection, log disconnects */
@@ -325,7 +325,7 @@ static int parse_servercmd(struct httprequest *req)
   return 0; /* OK! */
 }
 
-static int ProcessRequest(struct httprequest *req)
+static int sws_ProcessRequest(struct httprequest *req)
 {
   char *line = &req->reqbuf[req->checkindex];
   bool chunked = FALSE;
@@ -945,7 +945,7 @@ static int get_request(curl_socket_t sock, struct httprequest *req)
     req->offset += (size_t)got;
     reqbuf[req->offset] = '\0';
 
-    req->done_processing = ProcessRequest(req);
+    req->done_processing = sws_ProcessRequest(req);
     if(got_exit_signal)
       return -1;
   }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -59,7 +59,6 @@
 #include "memdebug.h"
 
 static bool use_gopher = FALSE;
-static int serverlogslocked = 0;
 static bool is_proxy = FALSE;
 
 #undef REQBUFSIZ
@@ -2032,6 +2031,7 @@ int main(int argc, char *argv[])
   pidname = ".http.pid";
   portname = ".http.port";
   serverlogfile = "log/sws.log";
+  serverlogslocked = 0;
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -117,9 +117,6 @@ struct httprequest {
 static curl_socket_t all_sockets[MAX_SOCKETS];
 static size_t num_sockets = 0;
 
-static int ProcessRequest(struct httprequest *req);
-static void storerequest(const char *reqbuf, size_t totalsize);
-
 #define SWSVERSION "curl test suite HTTP server/0.1"
 
 #define REQUEST_DUMP  "server.input"

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -62,6 +62,7 @@ static bool use_gopher = FALSE;
 static int serverlogslocked = 0;
 static bool is_proxy = FALSE;
 
+#undef REQBUFSIZ
 #define REQBUFSIZ (2*1024*1024)
 
 #define MAX_SLEEP_TIME_MS 250

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -221,7 +221,7 @@ static int parse_cmdfile(struct httprequest *req)
 }
 
 /* based on the testno, parse the correct server commands */
-static int parse_servercmd(struct httprequest *req)
+static int sws_parse_servercmd(struct httprequest *req)
 {
   FILE *stream;
   int error;
@@ -506,7 +506,7 @@ static int sws_ProcessRequest(struct httprequest *req)
         req->testno = DOCNUMBER_404;
       }
       else
-        parse_servercmd(req);
+        sws_parse_servercmd(req);
     }
     else if((req->offset >= 3)) {
       unsigned char *l = (unsigned char *)line;
@@ -535,7 +535,7 @@ static int sws_ProcessRequest(struct httprequest *req)
   }
 
   /* find and parse <servercmd> for this test */
-  parse_servercmd(req);
+  sws_parse_servercmd(req);
 
   if(use_gopher) {
     /* when using gopher we cannot check the request until the entire

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -128,8 +128,7 @@ static size_t num_sockets = 0;
 #define RESPONSE_PROXY_DUMP "proxy.response"
 
 /* file in which additional instructions may be found */
-#define DEFAULT_CMDFILE "log/server.cmd"
-static const char *cmdfile = DEFAULT_CMDFILE;
+static const char *cmdfile = "log/server.cmd";
 
 /* very-big-path support */
 #define MAXDOCNAMELEN 140000

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2019,7 +2019,6 @@ int main(int argc, char *argv[])
   const char *unix_socket = NULL;
   bool unlink_socket = false;
 #endif
-  const char *portname = ".http.port";
   struct httprequest *req = NULL;
   int rc = 0;
   int error;
@@ -2035,6 +2034,7 @@ int main(int argc, char *argv[])
   size_t socket_idx;
 
   pidname = ".http.pid";
+  portname = ".http.port";
   serverlogfile = "log/sws.log";
 
   while(argc > arg) {

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -165,7 +165,7 @@ static const char *cmdfile = DEFAULT_CMDFILE;
 static const char *end_of_headers = END_OF_HEADERS;
 
 /* sent as reply to a QUIT */
-static const char *docquit =
+static const char *docquit_sws =
 "HTTP/1.1 200 Goodbye" END_OF_HEADERS;
 
 /* send back this on 404 file not found */
@@ -1027,7 +1027,7 @@ static int sws_send_doc(curl_socket_t sock, struct httprequest *req)
     switch(req->testno) {
     case DOCNUMBER_QUIT:
       logmsg("Replying to QUIT");
-      buffer = docquit;
+      buffer = docquit_sws;
       break;
     case DOCNUMBER_WERULEZ:
       /* we got a "friends?" question, reply back that we sure are */

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -833,7 +833,7 @@ static int send_doc(curl_socket_t sock, struct httprequest *req);
 
 /* returns 1 if the connection should be serviced again immediately, 0 if there
    is no data waiting, or < 0 if it should be closed */
-static int get_request(curl_socket_t sock, struct httprequest *req)
+static int sws_get_request(curl_socket_t sock, struct httprequest *req)
 {
   int fail = 0;
   char *reqbuf = req->reqbuf;
@@ -1597,7 +1597,7 @@ static void http_connect(curl_socket_t *infdp,
 #endif
           init_httprequest(req2);
           while(!req2->done_processing) {
-            err = get_request(datafd, req2);
+            err = sws_get_request(datafd, req2);
             if(err < 0) {
               /* this socket must be closed, done or not */
               break;
@@ -1938,7 +1938,7 @@ static int service_connection(curl_socket_t msgsock, struct httprequest *req,
     return -1;
 
   while(!req->done_processing) {
-    int rc = get_request(msgsock, req);
+    int rc = sws_get_request(msgsock, req);
     if(rc <= 0) {
       /* Nothing further to read now, possibly because the socket was closed */
       return rc;
@@ -2328,8 +2328,8 @@ int main(int argc, char *argv[])
   if(!wroteportfile)
     goto sws_cleanup;
 
-  /* initialization of httprequest struct is done before get_request(), but
-     the pipelining struct field must be initialized previously to FALSE
+  /* initialization of httprequest struct is done before sws_get_request(),
+     but the pipelining struct field must be initialized previously to FALSE
      every time a new connection arrives. */
 
   init_httprequest(req);

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -120,11 +120,6 @@ static size_t num_sockets = 0;
 static int ProcessRequest(struct httprequest *req);
 static void storerequest(const char *reqbuf, size_t totalsize);
 
-#define DEFAULT_PORT 8999
-
-static const char *logdir = "log";
-static char loglockfile[256];
-
 #define SWSVERSION "curl test suite HTTP server/0.1"
 
 #define REQUEST_DUMP  "server.input"
@@ -2019,7 +2014,7 @@ int main(int argc, char *argv[])
   int wrotepidfile = 0;
   int wroteportfile = 0;
   int flag;
-  unsigned short port = DEFAULT_PORT;
+  unsigned short port = 8999;
 #ifdef USE_UNIX_SOCKETS
   const char *unix_socket = NULL;
   bool unlink_socket = false;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -77,7 +77,7 @@ static bool sws_prevbounce = FALSE; /* instructs the server to override the
 #define RCMD_IDLE      1 /* told to sit idle */
 #define RCMD_STREAM    2 /* told to stream */
 
-struct httprequest {
+struct sws_httprequest {
   char reqbuf[REQBUFSIZ]; /* buffer area for the incoming request */
   bool connect_request; /* if a CONNECT */
   unsigned short connect_port; /* the port number CONNECT used */
@@ -204,7 +204,7 @@ static bool socket_domain_is_ip(void)
 #endif
 
 /* parse the file on disk that might have a test number for us */
-static int parse_cmdfile(struct httprequest *req)
+static int parse_cmdfile(struct sws_httprequest *req)
 {
   FILE *f = fopen(cmdfile, FOPEN_READTEXT);
   if(f) {
@@ -222,7 +222,7 @@ static int parse_cmdfile(struct httprequest *req)
 }
 
 /* based on the testno, parse the correct server commands */
-static int sws_parse_servercmd(struct httprequest *req)
+static int sws_parse_servercmd(struct sws_httprequest *req)
 {
   FILE *stream;
   int error;
@@ -326,7 +326,7 @@ static int sws_parse_servercmd(struct httprequest *req)
   return 0; /* OK! */
 }
 
-static int sws_ProcessRequest(struct httprequest *req)
+static int sws_ProcessRequest(struct sws_httprequest *req)
 {
   char *line = &req->reqbuf[req->checkindex];
   bool chunked = FALSE;
@@ -803,7 +803,7 @@ storerequest_cleanup:
            dumpfile, errno, strerror(errno));
 }
 
-static void init_httprequest(struct httprequest *req)
+static void init_httprequest(struct sws_httprequest *req)
 {
   req->checkindex = 0;
   req->offset = 0;
@@ -830,11 +830,11 @@ static void init_httprequest(struct httprequest *req)
   req->upgrade_request = 0;
 }
 
-static int sws_send_doc(curl_socket_t sock, struct httprequest *req);
+static int sws_send_doc(curl_socket_t sock, struct sws_httprequest *req);
 
 /* returns 1 if the connection should be serviced again immediately, 0 if there
    is no data waiting, or < 0 if it should be closed */
-static int sws_get_request(curl_socket_t sock, struct httprequest *req)
+static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
 {
   int fail = 0;
   char *reqbuf = req->reqbuf;
@@ -976,7 +976,7 @@ static int sws_get_request(curl_socket_t sock, struct httprequest *req)
 }
 
 /* returns -1 on failure */
-static int sws_send_doc(curl_socket_t sock, struct httprequest *req)
+static int sws_send_doc(curl_socket_t sock, struct sws_httprequest *req)
 {
   ssize_t written;
   size_t count;
@@ -1578,7 +1578,7 @@ static void http_connect(curl_socket_t *infdp,
         /* a new connection on listener socket (most likely from client) */
         curl_socket_t datafd = accept(rootfd, NULL, NULL);
         if(datafd != CURL_SOCKET_BAD) {
-          static struct httprequest *req2;
+          static struct sws_httprequest *req2;
           int err = 0;
           if(!req2) {
             req2 = malloc(sizeof(*req2));
@@ -1841,7 +1841,7 @@ http_connect_cleanup:
   *infdp = CURL_SOCKET_BAD;
 }
 
-static void http_upgrade(struct httprequest *req)
+static void http_upgrade(struct sws_httprequest *req)
 {
   (void)req;
   logmsg("Upgraded to ... %u", req->upgrade_request);
@@ -1930,7 +1930,8 @@ static curl_socket_t accept_connection(curl_socket_t sock)
 
 /* returns 1 if the connection should be serviced again immediately, 0 if there
    is no data waiting, or < 0 if it should be closed */
-static int service_connection(curl_socket_t msgsock, struct httprequest *req,
+static int service_connection(curl_socket_t msgsock,
+                              struct sws_httprequest *req,
                               curl_socket_t listensock,
                               const char *connecthost,
                               int keepalive_secs)
@@ -2016,7 +2017,7 @@ int main(int argc, char *argv[])
   const char *unix_socket = NULL;
   bool unlink_socket = false;
 #endif
-  struct httprequest *req = NULL;
+  struct sws_httprequest *req = NULL;
   int rc = 0;
   int error;
   int arg = 1;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2019,7 +2019,6 @@ int main(int argc, char *argv[])
   const char *unix_socket = NULL;
   bool unlink_socket = false;
 #endif
-  const char *pidname = ".http.pid";
   const char *portname = ".http.port";
   struct httprequest *req = NULL;
   int rc = 0;
@@ -2035,6 +2034,7 @@ int main(int argc, char *argv[])
   /* a default CONNECT port is basically pointless but still ... */
   size_t socket_idx;
 
+  pidname = ".http.pid";
   serverlogfile = "log/sws.log";
 
   while(argc > arg) {

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -993,7 +993,7 @@ static int do_tftp(struct testcase *test, struct tftphdr *tp, ssize_t size)
 }
 
 /* Based on the testno, parse the correct server commands. */
-static int parse_servercmd(struct testcase *req)
+static int tftpd_parse_servercmd(struct testcase *req)
 {
   FILE *stream;
   int error;
@@ -1107,7 +1107,7 @@ static int validate_access(struct testcase *test,
 
     test->testno = testno;
 
-    (void)parse_servercmd(test);
+    (void)tftpd_parse_servercmd(test);
 
     stream = test2fopen(testno, logdir);
 

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -194,7 +194,6 @@ static curl_socket_t peer = CURL_SOCKET_BAD;
 static unsigned int timeout;
 static unsigned int maxtimeout = 5 * TIMEOUT;
 
-static const char *pidname = ".tftpd.pid";
 static const char *portname = NULL; /* none by default */
 static int serverlogslocked = 0;
 static int wrotepidfile = 0;
@@ -550,6 +549,7 @@ int main(int argc, char **argv)
 
   memset(&test, 0, sizeof(test));
 
+  pidname = ".tftpd.pid";
   serverlogfile = "log/tftpd.log";
 
   while(argc > arg) {

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -194,8 +194,8 @@ static curl_socket_t peer = CURL_SOCKET_BAD;
 static unsigned int timeout;
 static unsigned int maxtimeout = 5 * TIMEOUT;
 
-static int wrotepidfile = 0;
-static int wroteportfile = 0;
+static int tftpd_wrotepidfile = 0;
+static int tftpd_wroteportfile = 0;
 
 #ifdef HAVE_SIGSETJMP
 static sigjmp_buf timeoutbuf;
@@ -270,12 +270,12 @@ static void timer(int signum)
 
   timeout += rexmtval;
   if(timeout >= maxtimeout) {
-    if(wrotepidfile) {
-      wrotepidfile = 0;
+    if(tftpd_wrotepidfile) {
+      tftpd_wrotepidfile = 0;
       unlink(pidname);
     }
-    if(wroteportfile) {
-      wroteportfile = 0;
+    if(tftpd_wroteportfile) {
+      tftpd_wroteportfile = 0;
       unlink(portname);
     }
     if(serverlogslocked) {
@@ -733,15 +733,15 @@ int main(int argc, char **argv)
     }
   }
 
-  wrotepidfile = write_pidfile(pidname);
-  if(!wrotepidfile) {
+  tftpd_wrotepidfile = write_pidfile(pidname);
+  if(!tftpd_wrotepidfile) {
     result = 1;
     goto tftpd_cleanup;
   }
 
   if(portname) {
-    wroteportfile = write_portfile(portname, port);
-    if(!wroteportfile) {
+    tftpd_wroteportfile = write_portfile(portname, port);
+    if(!tftpd_wroteportfile) {
       result = 1;
       goto tftpd_cleanup;
     }
@@ -844,9 +844,9 @@ tftpd_cleanup:
   if(got_exit_signal)
     logmsg("signalled to die");
 
-  if(wrotepidfile)
+  if(tftpd_wrotepidfile)
     unlink(pidname);
-  if(wroteportfile)
+  if(tftpd_wroteportfile)
     unlink(portname);
 
   if(serverlogslocked) {

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -194,7 +194,6 @@ static curl_socket_t peer = CURL_SOCKET_BAD;
 static unsigned int timeout;
 static unsigned int maxtimeout = 5 * TIMEOUT;
 
-static int serverlogslocked = 0;
 static int wrotepidfile = 0;
 static int wroteportfile = 0;
 
@@ -550,6 +549,7 @@ int main(int argc, char **argv)
 
   pidname = ".tftpd.pid";
   serverlogfile = "log/tftpd.log";
+  serverlogslocked = 0;
 
   while(argc > arg) {
     if(!strcmp("--version", argv[arg])) {

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -152,8 +152,6 @@ struct bf {
 
 #define REQUEST_DUMP  "server.input"
 
-#define DEFAULT_PORT 8999 /* UDP */
-
 /*****************************************************************************
 *                              GLOBAL VARIABLES                              *
 *****************************************************************************/
@@ -196,13 +194,6 @@ static curl_socket_t peer = CURL_SOCKET_BAD;
 static unsigned int timeout;
 static unsigned int maxtimeout = 5 * TIMEOUT;
 
-#ifdef USE_IPV6
-static bool use_ipv6 = FALSE;
-#endif
-static const char *ipv_inuse = "IPv4";
-
-static const char *logdir = "log";
-static char loglockfile[256];
 static const char *pidname = ".tftpd.pid";
 static const char *portname = NULL; /* none by default */
 static int serverlogslocked = 0;
@@ -549,7 +540,7 @@ int main(int argc, char **argv)
   struct tftphdr *tp;
   ssize_t n = 0;
   int arg = 1;
-  unsigned short port = DEFAULT_PORT;
+  unsigned short port = 8999; /* UDP */
   curl_socket_t sock = CURL_SOCKET_BAD;
   int flag;
   int rc;

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -183,7 +183,7 @@ static int current;     /* index of buffer in use */
 static int newline = 0;    /* fillbuf: in middle of newline expansion */
 static int prevchar = -1;  /* putbuf: previous char (cr check) */
 
-static tftphdr_storage_t buf;
+static tftphdr_storage_t trsbuf;
 static tftphdr_storage_t ackbuf;
 
 static srvr_sockaddr_union_t from;
@@ -760,7 +760,7 @@ int main(int argc, char **argv)
     else
       fromlen = sizeof(from.sa6);
 #endif
-    n = (ssize_t)recvfrom(sock, &buf.storage[0], sizeof(buf.storage), 0,
+    n = (ssize_t)recvfrom(sock, &trsbuf.storage[0], sizeof(trsbuf.storage), 0,
                           &from.sa, &fromlen);
     if(got_exit_signal)
       break;
@@ -808,7 +808,7 @@ int main(int argc, char **argv)
 
     maxtimeout = 5*TIMEOUT;
 
-    tp = &buf.hdr;
+    tp = &trsbuf.hdr;
     tp->th_opcode = ntohs(tp->th_opcode);
     if(tp->th_opcode == opcode_RRQ || tp->th_opcode == opcode_WRQ) {
       memset(&test, 0, sizeof(test));
@@ -907,7 +907,7 @@ static int do_tftp(struct testcase *test, struct tftphdr *tp, ssize_t size)
   filename = cp;
   do {
     bool endofit = true;
-    while(cp < &buf.storage[size]) {
+    while(cp < &trsbuf.storage[size]) {
       if(*cp == '\0') {
         endofit = false;
         break;
@@ -920,7 +920,7 @@ static int do_tftp(struct testcase *test, struct tftphdr *tp, ssize_t size)
 
     /* before increasing pointer, make sure it is still within the legal
        space */
-    if((cp + 1) < &buf.storage[size]) {
+    if((cp + 1) < &trsbuf.storage[size]) {
       ++cp;
       if(first) {
         /* store the mode since we need it later */
@@ -1315,7 +1315,7 @@ send_ack:
   alarm(rexmtval);
 #endif
   /* normally times out and quits */
-  n = sread(peer, &buf.storage[0], sizeof(buf.storage));
+  n = sread(peer, &trsbuf.storage[0], sizeof(trsbuf.storage));
 #ifdef HAVE_ALARM
   alarm(0);
 #endif
@@ -1345,7 +1345,7 @@ static void nak(int error)
   int length;
   struct errmsg *pe;
 
-  tp = &buf.hdr;
+  tp = &trsbuf.hdr;
   tp->th_opcode = htons(opcode_ERROR);
   tp->th_code = htons((unsigned short)error);
   for(pe = errmsgs; pe->e_code >= 0; pe++)
@@ -1361,6 +1361,6 @@ static void nak(int error)
    * report from glibc with FORTIFY_SOURCE */
   memcpy(tp->th_msg, pe->e_msg, length + 1);
   length += 5;
-  if(swrite(peer, &buf.storage[0], length) != length)
+  if(swrite(peer, &trsbuf.storage[0], length) != length)
     logmsg("nak: fail\n");
 }

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -194,7 +194,6 @@ static curl_socket_t peer = CURL_SOCKET_BAD;
 static unsigned int timeout;
 static unsigned int maxtimeout = 5 * TIMEOUT;
 
-static const char *portname = NULL; /* none by default */
 static int serverlogslocked = 0;
 static int wrotepidfile = 0;
 static int wroteportfile = 0;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -60,6 +60,7 @@
 const char *pidname = NULL;
 const char *portname = NULL; /* none by default */
 const char *serverlogfile = NULL;
+int serverlogslocked;
 const char *configfile = NULL;
 const char *logdir = "log";
 char loglockfile[256];

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -57,6 +57,14 @@
 #include "timediff.h"
 
 const char *serverlogfile = NULL;  /* needs init from main() */
+const char *configfile = NULL;
+const char *logdir = "log";
+char loglockfile[256];
+#ifdef USE_IPV6
+bool use_ipv6 = FALSE;
+#endif
+const char *ipv_inuse = "IPv4";
+unsigned short server_port = 0;
 
 static struct timeval tvnow(void);
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -58,6 +58,7 @@
 
 /* need init from main() */
 const char *pidname = NULL;
+const char *portname = NULL; /* none by default */
 const char *serverlogfile = NULL;
 const char *configfile = NULL;
 const char *logdir = "log";

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -68,6 +68,8 @@ bool use_ipv6 = FALSE;
 #endif
 const char *ipv_inuse = "IPv4";
 unsigned short server_port = 0;
+const char *socket_type = "IPv4";
+int socket_domain = AF_INET;
 
 static struct timeval tvnow(void);
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -150,6 +150,25 @@ void logmsg(const char *msg, ...)
   }
 }
 
+void loghex(unsigned char *buffer, ssize_t len)
+{
+  char data[12000];
+  ssize_t i;
+  unsigned char *ptr = buffer;
+  char *optr = data;
+  ssize_t width = 0;
+  int left = sizeof(data);
+
+  for(i = 0; i < len && (left >= 0); i++) {
+    msnprintf(optr, left, "%02x", ptr[i]);
+    width += 2;
+    optr += 2;
+    left -= 2;
+  }
+  if(width)
+    logmsg("'%s'", data);
+}
+
 #ifdef _WIN32
 /* use instead of perror() on generic Windows */
 static void win32_perror(const char *msg)

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -56,7 +56,9 @@
 #include "timeval.h"
 #include "timediff.h"
 
-const char *serverlogfile = NULL;  /* needs init from main() */
+/* need init from main() */
+const char *pidname = NULL;
+const char *serverlogfile = NULL;
 const char *configfile = NULL;
 const char *logdir = "log";
 char loglockfile[256];

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -170,6 +170,12 @@ void loghex(unsigned char *buffer, ssize_t len)
     logmsg("'%s'", data);
 }
 
+unsigned char byteval(char *value)
+{
+  unsigned long num = strtoul(value, NULL, 10);
+  return num & 0xff;
+}
+
 #ifdef _WIN32
 /* use instead of perror() on generic Windows */
 static void win32_perror(const char *msg)

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -53,7 +53,6 @@
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "util.h"
-#include "timeval.h"
 #include "timediff.h"
 
 /* need init from main() */

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -59,6 +59,14 @@ extern const char *path;
 
 /* global variable, log file name */
 extern const char *serverlogfile;
+extern const char *configfile;
+extern const char *logdir;
+extern char loglockfile[256];
+#ifdef USE_IPV6
+extern bool use_ipv6;
+#endif
+extern const char *ipv_inuse;
+extern unsigned short server_port;
 
 #ifdef _WIN32
 int win32_init(void);

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -51,6 +51,7 @@ enum {
 
 char *data_to_hex(char *data, size_t len);
 void logmsg(const char *msg, ...) CURL_PRINTF(1, 2);
+void loghex(unsigned char *buffer, ssize_t len);
 
 #define SERVERLOGS_LOCKDIR "lock"  /* within logdir */
 

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -54,11 +54,10 @@ void logmsg(const char *msg, ...) CURL_PRINTF(1, 2);
 
 #define SERVERLOGS_LOCKDIR "lock"  /* within logdir */
 
-/* global variable, where to find the 'data' dir */
-extern const char *path;
-
-/* global variable, log file name */
-extern const char *serverlogfile;
+/* global variables */
+extern const char *path;  /* where to find the 'data' dir */
+extern const char *pidname;
+extern const char *serverlogfile;  /* log file name */
 extern const char *configfile;
 extern const char *logdir;
 extern char loglockfile[256];

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -57,6 +57,7 @@ void logmsg(const char *msg, ...) CURL_PRINTF(1, 2);
 /* global variables */
 extern const char *path;  /* where to find the 'data' dir */
 extern const char *pidname;
+extern const char *portname;
 extern const char *serverlogfile;  /* log file name */
 extern const char *configfile;
 extern const char *logdir;

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -52,6 +52,7 @@ enum {
 char *data_to_hex(char *data, size_t len);
 void logmsg(const char *msg, ...) CURL_PRINTF(1, 2);
 void loghex(unsigned char *buffer, ssize_t len);
+unsigned char byteval(char *value);
 
 #define SERVERLOGS_LOCKDIR "lock"  /* within logdir */
 

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -60,6 +60,7 @@ extern const char *path;  /* where to find the 'data' dir */
 extern const char *pidname;
 extern const char *portname;
 extern const char *serverlogfile;  /* log file name */
+extern int serverlogslocked;
 extern const char *configfile;
 extern const char *logdir;
 extern char loglockfile[256];

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -67,6 +67,8 @@ extern bool use_ipv6;
 #endif
 extern const char *ipv_inuse;
 extern unsigned short server_port;
+extern const char *socket_type;
+extern int socket_domain;
 
 #ifdef _WIN32
 int win32_init(void);


### PR DESCRIPTION
General tidy-ups, to identify and reduce duplications and potential
issues, while also making the server modules compile as a single binary.

- ensure unique symbols and no shadowing across server sources, by
  renaming variables.
- move globals common to multiple servers into shared `util` module.
- drop constants with a single use.
- undef macro before re-using them across server sources.
- move common functions into shared `util` module.
- drop redundant static declarations.
- disable IPv6 code when built without IPv6.
- start syncing the 3 almost identical copies of `sockdaemon` function.
- drop unused `timeval.h` header.
- drop `poll()` from `wait_ms()`, for macOS, following an earlier core
  update.
  Follow-up to c72cefea0fadaf4114a0036c86005ee5739ec30a #15096

Follow-up to 9213e4e497d575d2bc2c9265d40da6c5549f526d #16525
Cherry-picked from #15000

---

TODO later:
- merge `sockdaemon()` copies more.
- replace time handling functions in `util.c` with core ones,
  as `Curl_timediff()`, `Curl_now()`.
- replace `strtoul()` with `Curl_str_number()` and ban it.
  This also reduces `errno` use.
- try replacing `wait_ms()` with a better implementation from core
  `Curl_wait_ms()`.
- fix `SOCKERRNO` vs `errno` constant.
