### PR TITLE
vtls: fix compiler warnings seen with gcc 7.3.0 and mbedTLS

### DIFF
--- a/lib/vtls/cipher_suite.c
+++ b/lib/vtls/cipher_suite.c
@@ -786,12 +786,12 @@ static int cs_zip_to_str(const uint8_t zip[6],
 
   /* unzip the 8 indexes */
   indexes[0] = zip[0] >> 2;
-  indexes[1] = ((zip[0] << 4) & 0x3F) | zip[1] >> 4;
-  indexes[2] = ((zip[1] << 2) & 0x3F) | zip[2] >> 6;
+  indexes[1] = (uint8_t)(((zip[0] << 4) & 0x3F) | zip[1] >> 4);
+  indexes[2] = (uint8_t)(((zip[1] << 2) & 0x3F) | zip[2] >> 6);
   indexes[3] = ((zip[2] << 0) & 0x3F);
   indexes[4] = zip[3] >> 2;
-  indexes[5] = ((zip[3] << 4) & 0x3F) | zip[4] >> 4;
-  indexes[6] = ((zip[4] << 2) & 0x3F) | zip[5] >> 6;
+  indexes[5] = (uint8_t)(((zip[3] << 4) & 0x3F) | zip[4] >> 4);
+  indexes[6] = (uint8_t)(((zip[4] << 2) & 0x3F) | zip[5] >> 6);
   indexes[7] = ((zip[5] << 0) & 0x3F);
 
   if(indexes[0] == CS_TXT_IDX_TLS)


### PR DESCRIPTION
Seen with downloaded mingw 7.3.0 when built against MSYS2 mbedTLS 3.6.2:
```
lib/vtls/cipher_suite.c: In function 'cs_zip_to_str':
lib/vtls/cipher_suite.c:789:16: error: conversion to 'uint8_t {aka unsigned char}' from 'int' may alter its value [-Werror=conversion]
   indexes[1] = ((zip[0] << 4) & 0x3F) | zip[1] >> 4;
                ^
lib/vtls/cipher_suite.c:790:16: error: conversion to 'uint8_t {aka unsigned char}' from 'int' may alter its value [-Werror=conversion]
   indexes[2] = ((zip[1] << 2) & 0x3F) | zip[2] >> 6;
                ^
lib/vtls/cipher_suite.c:793:16: error: conversion to 'uint8_t {aka unsigned char}' from 'int' may alter its value [-Werror=conversion]
   indexes[5] = ((zip[3] << 4) & 0x3F) | zip[4] >> 4;
                ^
lib/vtls/cipher_suite.c:794:16: error: conversion to 'uint8_t {aka unsigned char}' from 'int' may alter its value [-Werror=conversion]
   indexes[6] = ((zip[4] << 2) & 0x3F) | zip[5] >> 6;
                ^
```
Ref: https://github.com/curl/curl/actions/runs/13719756989/job/38372409927?pr=16429#step:10:21

Cherry-picked from #16429
