### PR TITLE
curl_setup_once: drop `E*` macro redefines unused (with winsock2)

### DIFF
--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -343,7 +343,6 @@ typedef unsigned int bit;
 #define ENAMETOOLONG     WSAENAMETOOLONG
 #endif
 #define EDQUOT           WSAEDQUOT
-#define EREMOTE          WSAEREMOTE
 #endif
 
 /*

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -340,7 +340,6 @@ typedef unsigned int bit;
 #ifndef ENAMETOOLONG     /* possible previous definition in errno.h */
 #define ENAMETOOLONG     WSAENAMETOOLONG
 #endif
-#define EDQUOT           WSAEDQUOT
 #endif
 
 /*

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -321,67 +321,28 @@ typedef unsigned int bit;
 #define EWOULDBLOCK      WSAEWOULDBLOCK
 #undef  EINPROGRESS      /* override definition in errno.h */
 #define EINPROGRESS      WSAEINPROGRESS
-#undef  EALREADY         /* override definition in errno.h */
-#define EALREADY         WSAEALREADY
-#undef  ENOTSOCK         /* override definition in errno.h */
-#define ENOTSOCK         WSAENOTSOCK
-#undef  EDESTADDRREQ     /* override definition in errno.h */
-#define EDESTADDRREQ     WSAEDESTADDRREQ
 #undef  EMSGSIZE         /* override definition in errno.h */
 #define EMSGSIZE         WSAEMSGSIZE
-#undef  EPROTOTYPE       /* override definition in errno.h */
-#define EPROTOTYPE       WSAEPROTOTYPE
 #undef  ENOPROTOOPT      /* override definition in errno.h */
 #define ENOPROTOOPT      WSAENOPROTOOPT
-#undef  EPROTONOSUPPORT  /* override definition in errno.h */
-#define EPROTONOSUPPORT  WSAEPROTONOSUPPORT
-#define ESOCKTNOSUPPORT  WSAESOCKTNOSUPPORT
-#undef  EOPNOTSUPP       /* override definition in errno.h */
-#define EOPNOTSUPP       WSAEOPNOTSUPP
-#define EPFNOSUPPORT     WSAEPFNOSUPPORT
 #undef  EAFNOSUPPORT     /* override definition in errno.h */
 #define EAFNOSUPPORT     WSAEAFNOSUPPORT
 #undef  EADDRINUSE       /* override definition in errno.h */
 #define EADDRINUSE       WSAEADDRINUSE
 #undef  EADDRNOTAVAIL    /* override definition in errno.h */
 #define EADDRNOTAVAIL    WSAEADDRNOTAVAIL
-#undef  ENETDOWN         /* override definition in errno.h */
-#define ENETDOWN         WSAENETDOWN
-#undef  ENETUNREACH      /* override definition in errno.h */
-#define ENETUNREACH      WSAENETUNREACH
-#undef  ENETRESET        /* override definition in errno.h */
-#define ENETRESET        WSAENETRESET
-#undef  ECONNABORTED     /* override definition in errno.h */
-#define ECONNABORTED     WSAECONNABORTED
 #undef  ECONNRESET       /* override definition in errno.h */
 #define ECONNRESET       WSAECONNRESET
-#undef  ENOBUFS          /* override definition in errno.h */
-#define ENOBUFS          WSAENOBUFS
 #undef  EISCONN          /* override definition in errno.h */
 #define EISCONN          WSAEISCONN
-#undef  ENOTCONN         /* override definition in errno.h */
-#define ENOTCONN         WSAENOTCONN
-#define ESHUTDOWN        WSAESHUTDOWN
-#define ETOOMANYREFS     WSAETOOMANYREFS
 #undef  ETIMEDOUT        /* override definition in errno.h */
 #define ETIMEDOUT        WSAETIMEDOUT
 #undef  ECONNREFUSED     /* override definition in errno.h */
 #define ECONNREFUSED     WSAECONNREFUSED
-#undef  ELOOP            /* override definition in errno.h */
-#define ELOOP            WSAELOOP
 #ifndef ENAMETOOLONG     /* possible previous definition in errno.h */
 #define ENAMETOOLONG     WSAENAMETOOLONG
 #endif
-#define EHOSTDOWN        WSAEHOSTDOWN
-#undef  EHOSTUNREACH     /* override definition in errno.h */
-#define EHOSTUNREACH     WSAEHOSTUNREACH
-#ifndef ENOTEMPTY        /* possible previous definition in errno.h */
-#define ENOTEMPTY        WSAENOTEMPTY
-#endif
-#define EPROCLIM         WSAEPROCLIM
-#define EUSERS           WSAEUSERS
 #define EDQUOT           WSAEDQUOT
-#define ESTALE           WSAESTALE
 #define EREMOTE          WSAEREMOTE
 #endif
 

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -323,8 +323,6 @@ typedef unsigned int bit;
 #define EINPROGRESS      WSAEINPROGRESS
 #undef  EMSGSIZE         /* override definition in errno.h */
 #define EMSGSIZE         WSAEMSGSIZE
-#undef  ENOPROTOOPT      /* override definition in errno.h */
-#define ENOPROTOOPT      WSAENOPROTOOPT
 #undef  EAFNOSUPPORT     /* override definition in errno.h */
 #define EAFNOSUPPORT     WSAEAFNOSUPPORT
 #undef  EADDRINUSE       /* override definition in errno.h */


### PR DESCRIPTION
These were not used in curl sources at all.

Except `EDQUOT` which was used after `mkdir()` in `src/tool_dirhie.c`
for error display. It should not be redefined to a winsock2 error.
This makes the "exceeded your quota" error correctly appear on Windows,
if detected, after operations that create directories.

After this patch there remain 14 `E*` macro redefines on Windows,
down from 40 before this patch.

Bug: https://github.com/curl/curl/pull/16553#issuecomment-2704679377
Ref: #16612
Ref: #16605