### PR TITLE
zlib: bump minimum to 1.2.5.2 (was: 1.2.0.4)

### DIFF
--- a/docs/INTERNALS.md
+++ b/docs/INTERNALS.md
@@ -27,7 +27,7 @@ versions of libs and build tools.
  - OpenSSL      1.0.2a
  - LibreSSL     2.9.1
  - GnuTLS       3.1.10
- - zlib         1.2.0.4
+ - zlib         1.2.5.2
  - libssh2      1.2.8
  - c-ares       1.6.0
  - libssh       0.9.0

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -186,13 +186,7 @@ static CURLcode inflate_stream(struct Curl_easy *data,
     z->next_out = (Bytef *) zp->buffer;
     z->avail_out = DECOMPRESS_BUFFER_SIZE;
 
-#ifdef Z_BLOCK
-    /* Z_BLOCK is only available in zlib ver. >= 1.2.0.5 */
     status = inflate(z, Z_BLOCK);
-#else
-    /* fallback for zlib ver. < 1.2.0.5 */
-    status = inflate(z, Z_SYNC_FLUSH);
-#endif
 
     /* Flush output data if some. */
     if(z->avail_out != DECOMPRESS_BUFFER_SIZE) {

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -72,8 +72,8 @@
 
 #ifdef HAVE_LIBZ
 
-#if !defined(ZLIB_VERNUM) || (ZLIB_VERNUM < 0x1204)
-#error "requires zlib 1.2.0.4 or newer"
+#if !defined(ZLIB_VERNUM) || (ZLIB_VERNUM < 0x1252)
+#error "requires zlib 1.2.5.2 or newer"
 #endif
 
 typedef enum {

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -217,9 +217,7 @@ static CURLcode inflate_stream(struct Curl_easy *data,
       /* some servers seem to not generate zlib headers, so this is an attempt
          to fix and continue anyway */
       if(zp->zlib_init == ZLIB_INIT) {
-        /* Do not use inflateReset2(): only available since zlib 1.2.3.4. */
-        (void) inflateEnd(z);     /* do not care about the return code */
-        if(inflateInit2(z, -MAX_WBITS) == Z_OK) {
+        if(inflateReset2(z, -MAX_WBITS) == Z_OK) {
           z->next_in = orig_in;
           z->avail_in = nread;
           zp->zlib_init = ZLIB_INFLATING;


### PR DESCRIPTION
1.2.5.2 was released on 2011-12-18. (vs. 1.2.0.4 on 2003-08-10)

It allows to:
- use `Z_BLOCK` unconditionally.
- use `inflateReset2()` to replace `inflateEnd()` + `inflateInit2()`
  and save a memory allocation.
- use `Z_CONST` and `z_const` (in a future commit).

Suggested-by: Dan Fandrich
Ref: https://github.com/curl/curl/pull/16142#discussion_r1985449743
