### PR TITLE
setopt: "illegal" CURLOPT_SOCKS5_AUTH should return error

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -689,7 +689,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     data->set.proxy_transfer_mode = (bool)uarg;
     break;
   case CURLOPT_SOCKS5_AUTH:
-    if(data->set.socks5auth & ~(CURLAUTH_BASIC | CURLAUTH_GSSAPI))
+    if(uarg & ~(CURLAUTH_BASIC | CURLAUTH_GSSAPI))
       return CURLE_NOT_BUILT_IN;
     data->set.socks5auth = (unsigned char)uarg;
     break;


### PR DESCRIPTION
The check was just wrong before.

Regression introduced in 30da1f5974d34841b30c4fac3

Bug: https://issues.oss-fuzz.com/issues/401430844