### PR TITLE
runtests: add feature-based filtering

### DIFF
--- a/tests/runtests.md
+++ b/tests/runtests.md
@@ -40,6 +40,11 @@ Prefix a test number with a tilde (~) to still run it, but ignore the results.
 It is also possible to specify tests based on a keyword describing the test(s)
 to run, like `FTPS`. The keywords are strings used in the individual tests.
 
+Features are included as keywords with the `feat:` prefix (e.g., `feat:debug`).
+Specify a feature to run only tests requiring it, or exclude tests using
+`!feat:<feature>`, like `!feat:proxy`, to disable tests which depend on that
+feature.
+
 You can also specify keywords with a leading exclamation point and the keyword
 or phrase, like "!HTTP NTLM auth" to run all tests **except** those using this
 keyword. Remember that the exclamation marks and spaces need to be quoted

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1142,24 +1142,39 @@ sub singletest_shouldrun {
         if(!$info_keywords[0]) {
             $why = "missing the <keywords> section!";
         }
+        # Only evaluate keywords if the section is present.
+        else {
+            # Prefix features with "feat:" and add to keywords list.
+            push @info_keywords, map { "feat:" . lc($_) } getpart("client", "features");
 
-        my $match;
-        for my $k (@info_keywords) {
-            chomp $k;
-            if ($disabled_keywords{lc($k)}) {
-                $why = "disabled by keyword";
+            my $match;
+            for my $k (@info_keywords) {
+                chomp $k;
+                if ($disabled_keywords{lc($k)}) {
+                    if ($k =~ /^feat:/) {
+                        $why = "disabled by feature";
+                    }
+                    else {
+                        $why = "disabled by keyword";
+                    }
+                }
+                elsif ($enabled_keywords{lc($k)}) {
+                    $match = 1;
+                }
+                if ($ignored_keywords{lc($k)}) {
+                    logmsg "Warning: test$testnum result is ignored due to $k\n";
+                    $errorreturncode = 2;
+                }
             }
-            elsif ($enabled_keywords{lc($k)}) {
-                $match = 1;
-            }
-            if ($ignored_keywords{lc($k)}) {
-                logmsg "Warning: test$testnum result is ignored due to $k\n";
-                $errorreturncode = 2;
-            }
-        }
 
-        if(!$why && !$match && %enabled_keywords) {
-            $why = "disabled by missing keyword";
+            if(!$why && !$match && %enabled_keywords) {
+                if (grep { /^feat:/ } keys %enabled_keywords) {
+                    $why = "disabled by missing feature";
+                }
+                else {
+                    $why = "disabled by missing keyword";
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This Pull Request introduces support for features in the test selection process by adding them to the keywords list with the `feat:` prefix. It allows users to specify features to run only tests with them, or exclude tests using `!feat:<feature>`, similar to how keywords are handled.

Closes: #16533