### PR TITLE
curl_setup_once: stop redefining `ENAMETOOLONG` to winsock2 error code

### DIFF
--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -337,9 +337,6 @@ typedef unsigned int bit;
 #define ETIMEDOUT        WSAETIMEDOUT
 #undef  ECONNREFUSED     /* override definition in errno.h */
 #define ECONNREFUSED     WSAECONNREFUSED
-#ifndef ENAMETOOLONG     /* possible previous definition in errno.h */
-#define ENAMETOOLONG     WSAENAMETOOLONG
-#endif
 #endif
 
 /*


### PR DESCRIPTION
The only user is error display code following an `mkdir()` call. In this
case the redefinition didn't cause an issue, but was unnecessary.

Follow-up to d69425ed7d0918aceddd96048b146a9df85638ec #16615
