### PR TITLE
gtls: fix uninitialized variable

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1113,7 +1113,7 @@ CURLcode Curl_gtls_ctx_init(struct gtls_ctx *gctx,
   size_t gtls_alpns_count = 0;
   bool gtls_session_setup = FALSE;
   struct alpn_spec alpns;
-  CURLcode result;
+  CURLcode result = CURLE_OK;
   int rc;
 
   DEBUGASSERT(gctx);


### PR DESCRIPTION
Fix uninitialized variable (warning by MSVC):
```
lib\vtls\gtls.c(1207,1): error C2220: the following warning is treated as an error
lib\vtls\gtls.c(1207,1): warning C4701: potentially uninitialized local variable 'result' used
```
Ref: https://github.com/curl/curl/actions/runs/13733139148/job/38413553053#step:9:31