### PR TITLE
tests/server: sync `wait_ms()` with the libcurl implementation

### DIFF
--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -30,7 +30,6 @@
 #include "urldata.h"
 #include "easyif.h"
 #include "cfilters.h"
-#include "timeval.h"
 #include "multiif.h"
 #include "strcase.h"
 

--- a/lib/select.c
+++ b/lib/select.c
@@ -86,7 +86,7 @@ int Curl_wait_ms(timediff_t timeout_ms)
     timeout_ms = ULONG_MAX-1;
     /* do not use ULONG_MAX, because that is equal to INFINITE */
 #endif
-  Sleep((ULONG)timeout_ms);
+  Sleep((DWORD)timeout_ms);
 #else
   /* avoid using poll() for this since it behaves incorrectly with no sockets
      on Apple operating systems */

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -762,9 +762,9 @@ static curl_socket_t mqttd_sockdaemon(curl_socket_t sock,
         rc = wait_ms(delay);
         if(rc) {
           /* should not happen */
-          error = errno;
+          error = SOCKERRNO;
           logmsg("wait_ms() failed with error (%d) %s",
-                 error, strerror(error));
+                 error, sstrerror(error));
           sclose(sock);
           return CURL_SOCKET_BAD;
         }

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -982,9 +982,9 @@ static int rtspd_send_doc(curl_socket_t sock, struct rtspd_httprequest *req)
               break;
             if(res) {
               /* should not happen */
-              error = errno;
+              error = SOCKERRNO;
               logmsg("wait_ms() failed with error (%d) %s",
-                     error, strerror(error));
+                     error, sstrerror(error));
               break;
             }
           }

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1253,9 +1253,9 @@ static curl_socket_t sockfilt_sockdaemon(curl_socket_t sock,
         rc = wait_ms(delay);
         if(rc) {
           /* should not happen */
-          error = errno;
+          error = SOCKERRNO;
           logmsg("wait_ms() failed with error (%d) %s",
-                 error, strerror(error));
+                 error, sstrerror(error));
           sclose(sock);
           return CURL_SOCKET_BAD;
         }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -790,9 +790,9 @@ static curl_socket_t socksd_sockdaemon(curl_socket_t sock,
         rc = wait_ms(delay);
         if(rc) {
           /* should not happen */
-          error = errno;
+          error = SOCKERRNO;
           logmsg("wait_ms() failed with error (%d) %s",
-                 error, strerror(error));
+                 error, sstrerror(error));
           sclose(sock);
           return CURL_SOCKET_BAD;
         }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -1221,9 +1221,9 @@ retry:
             res = wait_ms(250);
             if(res) {
               /* should not happen */
-              error = errno;
+              error = SOCKERRNO;
               logmsg("wait_ms() failed with error (%d) %s",
-                     error, strerror(error));
+                     error, sstrerror(error));
               break;
             }
           }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -48,7 +48,6 @@
 #include "curlx.h" /* from the private lib dir */
 #include "getpart.h"
 #include "util.h"
-#include "timediff.h"
 
 /* need init from main() */
 const char *pidname = NULL;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -277,7 +277,7 @@ int wait_ms(int timeout_ms)
   if(!timeout_ms)
     return 0;
   if(timeout_ms < 0) {
-    CURL_SETERRNO(EINVAL);
+    SET_SOCKERRNO(SOCKEINVAL);
     return -1;
   }
 #ifdef MSDOS
@@ -298,7 +298,7 @@ int wait_ms(int timeout_ms)
       r = select(0, NULL, NULL, NULL, &pending_tv);
       if(r != -1)
         break;
-      error = errno;
+      error = SOCKERRNO;
       if(error && (error != SOCKEINTR))
         break;
       pending_ms = timeout_ms - (int)timediff(tvnow(), initial_tv);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -248,19 +248,6 @@ FILE *test2fopen(long testno, const char *logdir2)
   return stream;
 }
 
-#if !defined(MSDOS) && !defined(USE_WINSOCK)
-static long timediff(struct timeval newer, struct timeval older)
-{
-  timediff_t diff = newer.tv_sec-older.tv_sec;
-  if(diff >= (LONG_MAX/1000))
-    return LONG_MAX;
-  else if(diff <= (LONG_MIN/1000))
-    return LONG_MIN;
-  return (long)(newer.tv_sec-older.tv_sec)*1000+
-    (long)(newer.tv_usec-older.tv_usec)/1000;
-}
-#endif
-
 /*
  * Portable function used for waiting a specific amount of ms.
  * Waiting indefinitely with this function is not allowed, a
@@ -270,7 +257,7 @@ static long timediff(struct timeval newer, struct timeval older)
  *   -1 = system call error, or invalid timeout value
  *    0 = specified timeout has elapsed
  */
-int wait_ms(int timeout_ms)
+int wait_ms(timediff_t timeout_ms)
 {
   int r = 0;
 
@@ -280,35 +267,31 @@ int wait_ms(int timeout_ms)
     SET_SOCKERRNO(SOCKEINVAL);
     return -1;
   }
-#ifdef MSDOS
-  delay(timeout_ms);
-#elif defined(USE_WINSOCK)
-  Sleep((DWORD)timeout_ms);
+#if defined(MSDOS)
+  delay((unsigned int)timeout_ms);
+#elif defined(_WIN32)
+  /* prevent overflow, timeout_ms is typecast to ULONG/DWORD. */
+#if TIMEDIFF_T_MAX >= ULONG_MAX
+  if(timeout_ms >= ULONG_MAX)
+    timeout_ms = ULONG_MAX-1;
+    /* do not use ULONG_MAX, because that is equal to INFINITE */
+#endif
+  Sleep((ULONG)timeout_ms);
 #else
   /* avoid using poll() for this since it behaves incorrectly with no sockets
      on Apple operating systems */
   {
     struct timeval pending_tv;
-    struct timeval initial_tv = tvnow();
-    int pending_ms = timeout_ms;
-    do {
-      int error;
-      pending_tv.tv_sec = pending_ms / 1000;
-      pending_tv.tv_usec = (pending_ms % 1000) * 1000;
-      r = select(0, NULL, NULL, NULL, &pending_tv);
-      if(r != -1)
-        break;
-      error = SOCKERRNO;
-      if(error && (error != SOCKEINTR))
-        break;
-      pending_ms = timeout_ms - (int)timediff(tvnow(), initial_tv);
-      if(pending_ms <= 0)
-        break;
-    } while(r == -1);
+    r = select(0, NULL, NULL, NULL, curlx_mstotv(&pending_tv, timeout_ms));
   }
-#endif /* USE_WINSOCK */
-  if(r)
-    r = -1;
+#endif /* _WIN32 */
+  if(r) {
+    if((r == -1) && (SOCKERRNO == SOCKEINTR))
+      /* make EINTR from select or poll not a "lethal" error */
+      r = 0;
+    else
+      r = -1;
+  }
   return r;
 }
 

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -276,7 +276,7 @@ int wait_ms(timediff_t timeout_ms)
     timeout_ms = ULONG_MAX-1;
     /* do not use ULONG_MAX, because that is equal to INFINITE */
 #endif
-  Sleep((ULONG)timeout_ms);
+  Sleep((DWORD)timeout_ms);
 #else
   /* avoid using poll() for this since it behaves incorrectly with no sockets
      on Apple operating systems */

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -87,7 +87,7 @@ const char *sstrerror(int err);
 /* fopens the test case file */
 FILE *test2fopen(long testno, const char *logdir);
 
-int wait_ms(int timeout_ms);
+int wait_ms(timediff_t timeout_ms);
 curl_off_t our_getpid(void);
 int write_pidfile(const char *filename);
 int write_portfile(const char *filename, int port);

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -87,6 +87,8 @@ const char *sstrerror(int err);
 /* fopens the test case file */
 FILE *test2fopen(long testno, const char *logdir);
 
+#include "timediff.h"
+
 int wait_ms(timediff_t timeout_ms);
 curl_off_t our_getpid(void);
 int write_pidfile(const char *filename);


### PR DESCRIPTION
It contains a series of bugfixes and updates applied to libcurl's
`Curl_wait_ms()` over the years, but missed from the copy in
`tests/server/util.c`:
- d65321f93916e60f65b89d9bcb502341ea5c5939,
  52e822173aa3cd4f610531d32fbf943f026cdca6,
  5912da253b64de3cb2a1a229558077219b2c8a35
- 4a8f459837e2b7dc146825fc9a864045f7d1ae4a
- 1ad49feb71418f26aa6114c7a20ce1463beb3ea9
- 4a8f459837e2b7dc146825fc9a864045f7d1ae4a
- 1ad49feb71418f26aa6114c7a20ce1463beb3ea9

It fixes `wait_ms()` to check for, and return `SOCKERRNO`. Fixing error
handling on Windows.

Also:
- tests/server: change callers to check `SOCKERRNO`.
- `wait_ms()`: fix to check for the correct error code on Windows.
  Pending for `Curl_wait_ms()`: #16621.
- `Curl_wait_ms()`: tidy-up `Sleep()` argument cast (nit).
- lib/curl_trc: drop an unused header.
