### PR TITLE
lib2302: fix crash due to stack overflow on MSVC and clang Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -350,9 +350,6 @@ jobs:
           if [ '${{ matrix.sys }}' != 'msys' ]; then
             TFLAGS+=' ~612'  # SFTP
           fi
-          if [ '${{ matrix.sys }}' = 'clang64' ]; then
-            TFLAGS+=' ~2302 ~2303 ~2307'  # permafail with clang (and also MSVC) (but works with mingw64 and ucrt64)
-          fi
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -923,7 +920,7 @@ jobs:
         timeout-minutes: 10
         run: |
           export CURL_DIRSUFFIX='${{ matrix.type }}'
-          export TFLAGS='-j8 ${{ matrix.tflags }} ~2302 ~2303 ~2307'
+          export TFLAGS='-j8 ${{ matrix.tflags }}'
           TFLAGS+=' ~2310'  # flaky
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin:/c/Program Files/OpenSSH-Win64"
           PATH="/c/msys64/usr/bin:$PATH"

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -97,28 +97,31 @@ CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
-  struct ws_data ws_data;
 
   global_init(CURL_GLOBAL_ALL);
 
   curl = curl_easy_init();
   if(curl) {
+    struct ws_data ws_data;
     memset(&ws_data, 0, sizeof(ws_data));
     ws_data.easy = curl;
     ws_data.buf = (char *)calloc(LIB2302_BUFSIZE, 1);
-
-    curl_easy_setopt(curl, CURLOPT_URL, URL);
-    /* use the callback style */
-    curl_easy_setopt(curl, CURLOPT_USERAGENT, "webbie-sox/3");
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ws_data);
-    res = curl_easy_perform(curl);
-    fprintf(stderr, "curl_easy_perform() returned %d\n", res);
-    /* always cleanup */
-    curl_easy_cleanup(curl);
-    flush_data(&ws_data);
-    free(ws_data.buf);
+    if(ws_data.buf) {
+      curl_easy_setopt(curl, CURLOPT_URL, URL);
+      /* use the callback style */
+      curl_easy_setopt(curl, CURLOPT_USERAGENT, "webbie-sox/3");
+      curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
+      curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ws_data);
+      res = curl_easy_perform(curl);
+      fprintf(stderr, "curl_easy_perform() returned %d\n", res);
+      /* always cleanup */
+      curl_easy_cleanup(curl);
+      flush_data(&ws_data);
+      free(ws_data.buf);
+    }
+    else
+      res = TEST_ERR_MAJOR_BAD;
   }
   curl_global_cleanup();
   return res;

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -97,31 +97,33 @@ CURLcode test(char *URL)
 {
   CURL *curl;
   CURLcode res = CURLE_OK;
+  struct ws_data ws_data;
+  memset(&ws_data, 0, sizeof(ws_data));
+
+  ws_data.buf = (char *)calloc(LIB2302_BUFSIZE, 1);
+  if(!ws_data.buf)
+    return res;
 
   global_init(CURL_GLOBAL_ALL);
 
   curl = curl_easy_init();
   if(curl) {
-    struct ws_data ws_data;
-    memset(&ws_data, 0, sizeof(ws_data));
     ws_data.easy = curl;
-    ws_data.buf = (char *)calloc(LIB2302_BUFSIZE, 1);
-    if(ws_data.buf) {
-      curl_easy_setopt(curl, CURLOPT_URL, URL);
-      /* use the callback style */
-      curl_easy_setopt(curl, CURLOPT_USERAGENT, "webbie-sox/3");
-      curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-      curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
-      curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ws_data);
-      res = curl_easy_perform(curl);
-      fprintf(stderr, "curl_easy_perform() returned %d\n", res);
-      /* always cleanup */
-      curl_easy_cleanup(curl);
-      flush_data(&ws_data);
-      free(ws_data.buf);
-    }
+
+    curl_easy_setopt(curl, CURLOPT_URL, URL);
+    /* use the callback style */
+    curl_easy_setopt(curl, CURLOPT_USERAGENT, "webbie-sox/3");
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &ws_data);
+    res = curl_easy_perform(curl);
+    fprintf(stderr, "curl_easy_perform() returned %d\n", res);
+    /* always cleanup */
+    curl_easy_cleanup(curl);
+    flush_data(&ws_data);
   }
   curl_global_cleanup();
+  free(ws_data.buf);
   return res;
 }
 

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -120,8 +120,6 @@ CURLcode test(char *URL)
       flush_data(&ws_data);
       free(ws_data.buf);
     }
-    else
-      res = TEST_ERR_MAJOR_BAD;
   }
   curl_global_cleanup();
   return res;

--- a/tests/libtest/lib2302.c
+++ b/tests/libtest/lib2302.c
@@ -28,12 +28,14 @@
 
 struct ws_data {
   CURL *easy;
-  char buf[1024*1024];
+  char *buf;
   size_t blen;
   size_t nwrites;
   int has_meta;
   int meta_flags;
 };
+
+#define LIB2302_BUFSIZE (1024 * 1024)
 
 static void flush_data(struct ws_data *wd)
 {
@@ -66,7 +68,7 @@ static size_t add_data(struct ws_data *wd, const char *buf, size_t blen,
     wd->meta_flags = meta ? meta->flags : 0;
   }
 
-  if(wd->blen + blen > sizeof(wd->buf)) {
+  if(wd->blen + blen > LIB2302_BUFSIZE) {
     return 0;
   }
   memcpy(wd->buf + wd->blen, buf, blen);
@@ -97,13 +99,13 @@ CURLcode test(char *URL)
   CURLcode res = CURLE_OK;
   struct ws_data ws_data;
 
-
   global_init(CURL_GLOBAL_ALL);
 
   curl = curl_easy_init();
   if(curl) {
     memset(&ws_data, 0, sizeof(ws_data));
     ws_data.easy = curl;
+    ws_data.buf = (char *)calloc(LIB2302_BUFSIZE, 1);
 
     curl_easy_setopt(curl, CURLOPT_URL, URL);
     /* use the callback style */
@@ -116,6 +118,7 @@ CURLcode test(char *URL)
     /* always cleanup */
     curl_easy_cleanup(curl);
     flush_data(&ws_data);
+    free(ws_data.buf);
   }
   curl_global_cleanup();
   return res;


### PR DESCRIPTION
It fixes test 2302, 2303, 2307 with MSVC and clang on Windows.
GCC Windows builds were not affected.

Failure was caused by stack overflow due to a 1MB+ sized test struct on
stack. Replace it with dynamic allocation.

Also unignore affected tests in GHA/windows.

As seen under WINE with llvm-mingw:
```
$ wine64 libtests.exe lib2302 ws://127.0.0.1:59964/2302 > stdout2302 2> stderr2302
Test: lib2302
URL: ws://127.0.0.1:59964/2302
wine: Unhandled stack overflow at address 000000014007486A (thread 0024), starting debugger...
Unhandled exception: stack overflow in 64-bit code (0x000000014007486a).
```

Ref: #16629 (discovery)
Ref: 1bd5ac998bbc943dbf812b2824ad0f532201734c #16570

---

- [x] rebase on #16629