### PR TITLE
libssh2: fix memory leak in `SSH_SFTP_REALPATH` state

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -926,8 +926,6 @@ jobs:
           TFLAGS+=' ~612'  # SFTP
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SFTP'
-          elif [[ '${{ matrix.install }}' = *'libssh2'* ]]; then
-            TFLAGS+=' ~615 ~616 ~618 ~620 ~622'  # Leak detected: memory still allocated: 22 bytes, allocated by D:/a/curl/curl/lib/vssh/libssh2.c:2006, sshc->homedir = strdup(sshp->readdir_filename);
           elif [[ '${{ matrix.install }}' = *'libssh '* ]]; then
             TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
           fi

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2003,6 +2003,7 @@ static CURLcode ssh_statemachine(struct Curl_easy *data, bool *block)
       if(rc > 0) {
         /* It seems that this string is not always NULL terminated */
         sshp->readdir_filename[rc] = '\0';
+        Curl_safefree(sshc->homedir);
         sshc->homedir = strdup(sshp->readdir_filename);
         if(!sshc->homedir) {
           state(data, SSH_SFTP_CLOSE);

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2003,7 +2003,7 @@ static CURLcode ssh_statemachine(struct Curl_easy *data, bool *block)
       if(rc > 0) {
         /* It seems that this string is not always NULL terminated */
         sshp->readdir_filename[rc] = '\0';
-        Curl_safefree(sshc->homedir);
+        free(sshc->homedir);
         sshc->homedir = strdup(sshp->readdir_filename);
         if(!sshc->homedir) {
           state(data, SSH_SFTP_CLOSE);


### PR DESCRIPTION
Seen in MSVC libssh2 CI job:
```
test 0615...[SFTP put remote failure]
test 0616...[SFTP retrieval of empty file]
test 0618...[SFTP retrieval of two files]
test 0620...[SFTP retrieval of missing file followed by good file]
test 0622...[SFTP put failure]
  ** MEMORY FAILURE
  Leak detected: memory still allocated: 22 bytes
  At 2ae5b8a7ab8, there's 22 bytes.
   allocated by D:/a/curl/curl/lib/vssh/libssh2.c:2006
```
https://github.com/curl/curl/actions/runs/13752652590/job/38455575042?pr=16636#step:14:3907 https://github.com/curl/curl/actions/runs/13752879003/job/38456075461

Bug: https://github.com/curl/curl/pull/16636#issuecomment-2709086838