### PR TITLE
libssh: fix scp large file upload for 32-bit size_t systems

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1815,9 +1815,10 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         break;
       }
 
-      rc = ssh_scp_push_file(sshc->scp_session, protop->path,
-                             (size_t)data->state.infilesize,
-                             (int)data->set.new_file_perms);
+      rc = ssh_scp_push_file64(sshc->scp_session, protop->path,
+                               (uint64_t)data->state.infilesize,
+                               (int)data->set.new_file_perms);
+
       if(rc != SSH_OK) {
         err_msg = ssh_get_error(sshc->ssh_session);
         failf(data, "%s", err_msg);


### PR DESCRIPTION
- Use ssh_scp_push_file64 instead of ssh_scp_push_file.

The former uses uint64_t for file size and the latter uses size_t which may be 32-bit.

Ref: https://github.com/curl/curl/pull/16194

Closes #xxxx