### PR TITLE
Fixed a warning about comma misuse

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -565,7 +565,8 @@ static CURLcode wait_or_timeout(struct Curl_multi *multi, struct events *ev)
     struct curltime before;
 
     /* populate the fds[] array */
-    for(m = ev->list, f = &fds[0]; m; m = m->next) {
+    f = &fds[0];
+    for(m = ev->list; m; m = m->next) {
       f->fd = m->socket.fd;
       f->events = m->socket.events;
       f->revents = 0;


### PR DESCRIPTION
I build my stuff with a lot of checks and warnings.
So I got this one, where clang complains about the comma misuse.
Why is f initialized in the for and not just before?
Unless there is some special real, I'd like to move it up.

```
.../curl-test/curl/lib/easy.c:568:21: warning: possible misuse of comma operator here [-Wcomma]
  568 |     for(m = ev->list, f = &fds[0]; m; m = m->next) {
      |                     ^
.../curl-test/curl/lib/easy.c:568:9: note: cast expression to void to silence warning
  568 |     for(m = ev->list, f = &fds[0]; m; m = m->next) {
      |         ^~~~~~~~~~~~
      |         (void)(     )
```