### PR TITLE
lib: clear up CURLRES_ASYNCH vs USE_CURL_ASYNC use

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -747,7 +747,7 @@ enum resolve_t Curl_resolv(struct Curl_easy *data,
       int st;
       Curl_set_in_callback(data, TRUE);
       st = data->set.resolver_start(
-#ifdef USE_CURL_ASYNC
+#ifdef CURLRES_ASYNCH
         data->state.async.resolver,
 #else
         NULL,

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2087,7 +2087,7 @@ static CURLMcode state_resolving(struct Curl_multi *multi,
   dns = Curl_fetch_addr(data, hostname, conn->primary.remote_port);
 
   if(dns) {
-#ifdef CURLRES_ASYNCH
+#ifdef USE_CURL_ASYNC
     data->state.async.dns = dns;
     data->state.async.done = TRUE;
 #endif

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -344,7 +344,7 @@ static CURLproxycode do_SOCKS4(struct Curl_cfilter *cf,
     dns = Curl_fetch_addr(data, sx->hostname, conn->primary.remote_port);
 
     if(dns) {
-#ifdef CURLRES_ASYNCH
+#ifdef USE_CURL_ASYNC
       data->state.async.dns = dns;
       data->state.async.done = TRUE;
 #endif
@@ -815,7 +815,7 @@ CONNECT_REQ_INIT:
     dns = Curl_fetch_addr(data, sx->hostname, sx->remote_port);
 
     if(dns) {
-#ifdef CURLRES_ASYNCH
+#ifdef USE_CURL_ASYNC
       data->state.async.dns = dns;
       data->state.async.done = TRUE;
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -569,9 +569,9 @@ struct Curl_async {
   struct Curl_dns_entry *dns;
 #ifdef CURLRES_ASYNCH
   struct thread_data thdata;
-#endif
   void *resolver; /* resolver state, if it is used in the URL state -
                      ares_channel e.g. */
+#endif
   int port;
   BIT(done);  /* set TRUE when the lookup is complete */
 };


### PR DESCRIPTION
CURLRES_ASYNCH - is for when built to use an async name resolver; threaded or c-ares

USE_CURL_ASYNC - is for when built to use either an async name resolver OR DoH

Reported-by: Lars Karlitski
Fixes #16645