### PR TITLE
hostip: don't use alarm() for DoH resolves

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -932,8 +932,9 @@ enum resolve_t Curl_resolv_timeout(struct Curl_easy *data,
   else
     timeout = (timeoutms > LONG_MAX) ? LONG_MAX : (long)timeoutms;
 
-  if(!timeout)
-    /* USE_ALARM_TIMEOUT defined, but no timeout actually requested */
+  if(!timeout || data->set.doh)
+    /* USE_ALARM_TIMEOUT defined, but no timeout actually requested or resolve
+       done using DoH */
     return Curl_resolv(data, hostname, port, TRUE, entry);
 
   if(timeout < 1000) {


### PR DESCRIPTION
When built to use the synch resolver and DoH is used for a transfer, do not use alarm() for timeout since DoH resolving is not blocking.