### PR TITLE
socks: remove bad assert from do_SOCKS5()

### DIFF
--- a/lib/socks.c
+++ b/lib/socks.c
@@ -590,7 +590,6 @@ static CURLproxycode do_SOCKS5(struct Curl_cfilter *cf,
   bool allow_gssapi = FALSE;
   struct Curl_dns_entry *dns = NULL;
 
-  DEBUGASSERT(auth & (CURLAUTH_BASIC | CURLAUTH_GSSAPI));
   switch(sx->state) {
   case CONNECT_SOCKS_INIT:
     if(conn->bits.httpproxy)


### PR DESCRIPTION
It verified the auth bits wrongly. We don't need this assert anymore since the input is verified in *setopt().

Bug: https://issues.oss-fuzz.com/issues/401869346