### PR TITLE
tidy-up: whitespace, tests/server Makefile.inc, timeval in VS project

### DIFF
--- a/projects/generate.bat
+++ b/projects/generate.bat
@@ -153,7 +153,6 @@ rem
     ) else if "!var!" == "CURL_SRC_X_C_FILES" (
       call :element %1 lib "strparse.c" %3
       call :element %1 lib "strcase.c" %3
-      call :element %1 lib "timediff.c" %3
       call :element %1 lib "nonblock.c" %3
       call :element %1 lib "warnless.c" %3
       call :element %1 lib "curl_multibyte.c" %3
@@ -165,7 +164,6 @@ rem
       call :element %1 lib "curl_setup.h" %3
       call :element %1 lib "strparse.h" %3
       call :element %1 lib "strcase.h" %3
-      call :element %1 lib "timediff.h" %3
       call :element %1 lib "nonblock.h" %3
       call :element %1 lib "warnless.h" %3
       call :element %1 lib "curl_ctype.h" %3

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -84,12 +84,14 @@ sockfilt_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 sockfilt_CFLAGS = $(AM_CFLAGS)
 
 socksd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) $(INET_PTON) \
- server_sockaddr.h socksd.c
+ server_sockaddr.h \
+ socksd.c
 socksd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 socksd_CFLAGS = $(AM_CFLAGS)
 
 mqttd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
- server_sockaddr.h mqttd.c
+ server_sockaddr.h \
+ mqttd.c
 mqttd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 mqttd_CFLAGS = $(AM_CFLAGS)
 

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -25,86 +25,86 @@
 noinst_PROGRAMS = resolve rtspd sockfilt sws tftpd socksd disabled mqttd
 
 CURLX_SRCS = \
- ../../lib/mprintf.c \
- ../../lib/nonblock.c \
- ../../lib/strparse.c \
- ../../lib/strequal.c \
- ../../lib/warnless.c \
- ../../lib/timediff.c \
- ../../lib/dynbuf.c \
- ../../lib/strdup.c \
- ../../lib/strcase.c \
- ../../lib/curl_get_line.c \
- ../../lib/curl_multibyte.c
+  ../../lib/mprintf.c \
+  ../../lib/nonblock.c \
+  ../../lib/strparse.c \
+  ../../lib/strequal.c \
+  ../../lib/warnless.c \
+  ../../lib/timediff.c \
+  ../../lib/dynbuf.c \
+  ../../lib/strdup.c \
+  ../../lib/strcase.c \
+  ../../lib/curl_get_line.c \
+  ../../lib/curl_multibyte.c
 
 CURLX_HDRS = \
- ../../lib/curlx.h \
- ../../lib/nonblock.h \
- ../../lib/strcase.h \
- ../../lib/warnless.h \
- ../../lib/timediff.h \
- ../../lib/curl_ctype.h \
- ../../lib/dynbuf.h \
- ../../lib/strcase.h \
- ../../lib/strdup.h \
- ../../lib/curl_get_line.h \
- ../../lib/curl_multibyte.h
+  ../../lib/curlx.h \
+  ../../lib/nonblock.h \
+  ../../lib/strcase.h \
+  ../../lib/warnless.h \
+  ../../lib/timediff.h \
+  ../../lib/curl_ctype.h \
+  ../../lib/dynbuf.h \
+  ../../lib/strcase.h \
+  ../../lib/strdup.h \
+  ../../lib/curl_get_line.h \
+  ../../lib/curl_multibyte.h
 
 UTIL = \
- getpart.c \
- getpart.h \
- util.c \
- util.h \
- server_setup.h \
- ../../lib/base64.c \
- ../../lib/curl_base64.h \
- ../../lib/memdebug.c \
- ../../lib/memdebug.h \
- ../../lib/strerror.c \
- ../../lib/strerror.h
+  getpart.c \
+  getpart.h \
+  util.c \
+  util.h \
+  server_setup.h \
+  ../../lib/base64.c \
+  ../../lib/curl_base64.h \
+  ../../lib/memdebug.c \
+  ../../lib/memdebug.h \
+  ../../lib/strerror.c \
+  ../../lib/strerror.h
 
 INET_PTON = \
- ../../lib/inet_pton.c
+  ../../lib/inet_pton.c
 
 resolve_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
- resolve.c
+  resolve.c
 resolve_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 resolve_CFLAGS = $(AM_CFLAGS)
 
 rtspd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
- server_sockaddr.h \
- rtspd.c
+  server_sockaddr.h \
+  rtspd.c
 rtspd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 rtspd_CFLAGS = $(AM_CFLAGS)
 
 sockfilt_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) $(INET_PTON) \
- server_sockaddr.h \
- sockfilt.c
+  server_sockaddr.h \
+  sockfilt.c
 sockfilt_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 sockfilt_CFLAGS = $(AM_CFLAGS)
 
 socksd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) $(INET_PTON) \
- server_sockaddr.h \
- socksd.c
+  server_sockaddr.h \
+  socksd.c
 socksd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 socksd_CFLAGS = $(AM_CFLAGS)
 
 mqttd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
- server_sockaddr.h \
- mqttd.c
+  server_sockaddr.h \
+  mqttd.c
 mqttd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 mqttd_CFLAGS = $(AM_CFLAGS)
 
 sws_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) $(INET_PTON) \
- server_sockaddr.h \
- sws.c
+  server_sockaddr.h \
+  sws.c
 sws_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 sws_CFLAGS = $(AM_CFLAGS)
 
 tftpd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
- server_sockaddr.h \
- tftpd.c \
- tftp.h
+  server_sockaddr.h \
+  tftpd.c \
+  tftp.h
 tftpd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 tftpd_CFLAGS = $(AM_CFLAGS)
 

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -50,58 +50,56 @@ CURLX_HDRS = \
  ../../lib/curl_get_line.h \
  ../../lib/curl_multibyte.h
 
-USEFUL = \
+UTIL = \
  getpart.c \
  getpart.h \
+ util.c \
+ util.h \
  server_setup.h \
  ../../lib/base64.c \
  ../../lib/curl_base64.h \
  ../../lib/memdebug.c \
- ../../lib/memdebug.h
+ ../../lib/memdebug.h \
+ ../../lib/strerror.c \
+ ../../lib/strerror.h
 
 INET_PTON = \
  ../../lib/inet_pton.c
 
-UTIL = \
- util.c \
- util.h \
- ../../lib/strerror.c \
- ../../lib/strerror.h
-
-resolve_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
+resolve_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
  resolve.c
 resolve_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 resolve_CFLAGS = $(AM_CFLAGS)
 
-rtspd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
+rtspd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
  server_sockaddr.h \
  rtspd.c
 rtspd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 rtspd_CFLAGS = $(AM_CFLAGS)
 
-sockfilt_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) $(INET_PTON) \
+sockfilt_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) $(INET_PTON) \
  server_sockaddr.h \
  sockfilt.c
 sockfilt_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 sockfilt_CFLAGS = $(AM_CFLAGS)
 
-socksd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) $(INET_PTON) \
+socksd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) $(INET_PTON) \
  server_sockaddr.h socksd.c
 socksd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 socksd_CFLAGS = $(AM_CFLAGS)
 
-mqttd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
+mqttd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
  server_sockaddr.h mqttd.c
 mqttd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 mqttd_CFLAGS = $(AM_CFLAGS)
 
-sws_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) $(INET_PTON) \
+sws_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) $(INET_PTON) \
  server_sockaddr.h \
  sws.c
 sws_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 sws_CFLAGS = $(AM_CFLAGS)
 
-tftpd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(USEFUL) $(UTIL) \
+tftpd_SOURCES = $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
  server_sockaddr.h \
  tftpd.c \
  tftp.h

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -860,8 +860,8 @@ static int sws_get_request(curl_socket_t sock, struct sws_httprequest *req)
           logmsg("Got %zu bytes from client", got);
         }
 
-        if((got == -1) && ((SOCKERRNO == EAGAIN) ||
-                           (SOCKERRNO == SOCKEWOULDBLOCK))) {
+        if((got == -1) &&
+           ((SOCKERRNO == EAGAIN) || (SOCKERRNO == SOCKEWOULDBLOCK))) {
           int rc;
           fd_set input;
           fd_set output;


### PR DESCRIPTION
- VS projects: drop unused `timediff`.
  (used by curltool library, but this build method doesn't build that.)
- tests/server/sws: reflow an `if` for greppability.
- tests/server/Makefile.inc: indent, format
- tests/server/Makefile.inc: merge `USEFUL` and `UTIL` lists.
