### PR TITLE
libssh2: try fixing `homedir` memory leak

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3412,6 +3412,7 @@ static CURLcode ssh_done(struct Curl_easy *data, CURLcode status)
     result = status;
 
   Curl_safefree(sshp->path);
+  Curl_safefree(sshc->homedir);
   Curl_dyn_free(&sshp->readdir);
 
   if(Curl_pgrsDone(data))


### PR DESCRIPTION
Seen sometimes with e.g. the 'msvc CM x64-windows openssl' job:
```
test 0618...[SFTP retrieval of two files]

** MEMORY FAILURE
Leak detected: memory still allocated: 22 bytes
At 185a1da6868, there's 22 bytes.
 allocated by D:/a/curl/curl/lib/vssh/libssh2.c:2005
[...]
test 0622...[SFTP put failure]

** MEMORY FAILURE
Leak detected: memory still allocated: 22 bytes
At 1888c5b9928, there's 22 bytes.
 allocated by D:/a/curl/curl/lib/vssh/libssh2.c:2005
```
Ref: https://github.com/curl/curl/actions/runs/13767215160/job/38496623071?pr=16653#step:14:2696

Follow-up to 30739b4d36e8973bab69f13ce43f62346b244565 #16639