### PR TITLE
src: remove Curl_ prefix from tool-specific function

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -3030,7 +3030,7 @@ static CURLcode cacertpaths(struct OperationConfig *config)
   if(!env) {
 #if defined(CURL_CA_SEARCH_SAFE)
     char *cacert = NULL;
-    FILE *cafile = Curl_execpath("curl-ca-bundle.crt", &cacert);
+    FILE *cafile = tool_execpath("curl-ca-bundle.crt", &cacert);
     if(cafile) {
       fclose(cafile);
       config->cacert = strdup(cacert);

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -68,9 +68,9 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
     else {
       char *fullp;
       /* check for .curlrc then _curlrc in the dir of the executable */
-      file = Curl_execpath(".curlrc", &fullp);
+      file = tool_execpath(".curlrc", &fullp);
       if(!file)
-        file = Curl_execpath("_curlrc", &fullp);
+        file = tool_execpath("_curlrc", &fullp);
       if(file)
         /* this is the filename we read from */
         filename = fullp;

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -214,7 +214,7 @@ int tool_ftruncate64(int fd, curl_off_t where)
 #endif /* USE_TOOL_FTRUNCATE */
 
 #if defined(_WIN32) && !defined(UNDER_CE)
-FILE *Curl_execpath(const char *filename, char **pathp)
+FILE *tool_execpath(const char *filename, char **pathp)
 {
   static char filebuffer[512];
   unsigned long len;

--- a/src/tool_util.h
+++ b/src/tool_util.h
@@ -49,7 +49,7 @@ int struplocompare(const char *p1, const char *p2);
 int struplocompare4sort(const void *p1, const void *p2);
 
 #if defined(_WIN32) && !defined(UNDER_CE)
-FILE *Curl_execpath(const char *filename, char **pathp);
+FILE *tool_execpath(const char *filename, char **pathp);
 #endif
 
 #endif /* HEADER_CURL_TOOL_UTIL_H */


### PR DESCRIPTION
Since that's a prefix we use for library-private functions

Curl_execpath is now tool_execpath