### PR TITLE
curl_memrchr: enable in all builds

### DIFF
--- a/lib/curl_memrchr.c
+++ b/lib/curl_memrchr.c
@@ -33,10 +33,6 @@
 #include "memdebug.h"
 
 #ifndef HAVE_MEMRCHR
-#if (!defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_COOKIES)) || \
-  defined(USE_OPENSSL) || \
-  defined(USE_SCHANNEL)
-
 /*
  * Curl_memrchr()
  *
@@ -63,6 +59,4 @@ Curl_memrchr(const void *s, int c, size_t n)
   }
   return NULL;
 }
-
-#endif
 #endif /* HAVE_MEMRCHR */


### PR DESCRIPTION
It is used in the URL parser since bc24c60512

Reported-by: Justin Steventon
Fixes #16661