### PR TITLE
src: s/Curl_safefree/curlx_safefree

### DIFF
--- a/lib/curlx.h
+++ b/lib/curlx.h
@@ -64,4 +64,6 @@
 #include "strparse.h"
 /* The curlx_str_* parsing functions */
 
+#define curlx_safefree(x) Curl_safefree(x)
+
 #endif /* HEADER_CURL_CURLX_H */

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -352,7 +352,7 @@ static char *parse_filename(const char *ptr, size_t len)
   if(q) {
     p = q + 1;
     if(!*p) {
-      Curl_safefree(copy);
+      curlx_safefree(copy);
       return NULL;
     }
   }
@@ -364,7 +364,7 @@ static char *parse_filename(const char *ptr, size_t len)
   if(q) {
     p = q + 1;
     if(!*p) {
-      Curl_safefree(copy);
+      curlx_safefree(copy);
       return NULL;
     }
   }
@@ -385,7 +385,7 @@ static char *parse_filename(const char *ptr, size_t len)
   {
     char *sanitized;
     SANITIZEcode sc = sanitize_file_name(&sanitized, copy, 0);
-    Curl_safefree(copy);
+    curlx_safefree(copy);
     if(sc)
       return NULL;
     copy = sanitized;

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -27,6 +27,7 @@
 #include "tool_formparse.h"
 #include "tool_paramhlp.h"
 #include "tool_main.h"
+#include "curlx.h"
 
 #include "memdebug.h" /* keep this as LAST include */
 
@@ -53,57 +54,57 @@ static void free_config_fields(struct OperationConfig *config)
 {
   struct getout *urlnode;
 
-  Curl_safefree(config->useragent);
-  Curl_safefree(config->altsvc);
-  Curl_safefree(config->hsts);
-  Curl_safefree(config->haproxy_clientip);
+  curlx_safefree(config->useragent);
+  curlx_safefree(config->altsvc);
+  curlx_safefree(config->hsts);
+  curlx_safefree(config->haproxy_clientip);
   curl_slist_free_all(config->cookies);
-  Curl_safefree(config->cookiejar);
+  curlx_safefree(config->cookiejar);
   curl_slist_free_all(config->cookiefiles);
 
   curlx_dyn_free(&config->postdata);
-  Curl_safefree(config->query);
-  Curl_safefree(config->referer);
+  curlx_safefree(config->query);
+  curlx_safefree(config->referer);
 
-  Curl_safefree(config->headerfile);
-  Curl_safefree(config->ftpport);
-  Curl_safefree(config->iface);
+  curlx_safefree(config->headerfile);
+  curlx_safefree(config->ftpport);
+  curlx_safefree(config->iface);
 
-  Curl_safefree(config->range);
+  curlx_safefree(config->range);
 
-  Curl_safefree(config->userpwd);
-  Curl_safefree(config->tls_username);
-  Curl_safefree(config->tls_password);
-  Curl_safefree(config->tls_authtype);
-  Curl_safefree(config->proxy_tls_username);
-  Curl_safefree(config->proxy_tls_password);
-  Curl_safefree(config->proxy_tls_authtype);
-  Curl_safefree(config->proxyuserpwd);
-  Curl_safefree(config->proxy);
+  curlx_safefree(config->userpwd);
+  curlx_safefree(config->tls_username);
+  curlx_safefree(config->tls_password);
+  curlx_safefree(config->tls_authtype);
+  curlx_safefree(config->proxy_tls_username);
+  curlx_safefree(config->proxy_tls_password);
+  curlx_safefree(config->proxy_tls_authtype);
+  curlx_safefree(config->proxyuserpwd);
+  curlx_safefree(config->proxy);
 
-  Curl_safefree(config->dns_ipv6_addr);
-  Curl_safefree(config->dns_ipv4_addr);
-  Curl_safefree(config->dns_interface);
-  Curl_safefree(config->dns_servers);
+  curlx_safefree(config->dns_ipv6_addr);
+  curlx_safefree(config->dns_ipv4_addr);
+  curlx_safefree(config->dns_interface);
+  curlx_safefree(config->dns_servers);
 
-  Curl_safefree(config->noproxy);
+  curlx_safefree(config->noproxy);
 
-  Curl_safefree(config->mail_from);
+  curlx_safefree(config->mail_from);
   curl_slist_free_all(config->mail_rcpt);
-  Curl_safefree(config->mail_auth);
+  curlx_safefree(config->mail_auth);
 
-  Curl_safefree(config->netrc_file);
-  Curl_safefree(config->output_dir);
-  Curl_safefree(config->proto_str);
-  Curl_safefree(config->proto_redir_str);
+  curlx_safefree(config->netrc_file);
+  curlx_safefree(config->output_dir);
+  curlx_safefree(config->proto_str);
+  curlx_safefree(config->proto_redir_str);
 
   urlnode = config->url_list;
   while(urlnode) {
     struct getout *next = urlnode->next;
-    Curl_safefree(urlnode->url);
-    Curl_safefree(urlnode->outfile);
-    Curl_safefree(urlnode->infile);
-    Curl_safefree(urlnode);
+    curlx_safefree(urlnode->url);
+    curlx_safefree(urlnode->outfile);
+    curlx_safefree(urlnode->infile);
+    curlx_safefree(urlnode);
     urlnode = next;
   }
   config->url_list = NULL;
@@ -112,47 +113,47 @@ static void free_config_fields(struct OperationConfig *config)
   config->url_out = NULL;
 
 #ifndef CURL_DISABLE_IPFS
-  Curl_safefree(config->ipfs_gateway);
+  curlx_safefree(config->ipfs_gateway);
 #endif /* !CURL_DISABLE_IPFS */
-  Curl_safefree(config->doh_url);
-  Curl_safefree(config->cipher_list);
-  Curl_safefree(config->proxy_cipher_list);
-  Curl_safefree(config->cipher13_list);
-  Curl_safefree(config->proxy_cipher13_list);
-  Curl_safefree(config->cert);
-  Curl_safefree(config->proxy_cert);
-  Curl_safefree(config->cert_type);
-  Curl_safefree(config->proxy_cert_type);
-  Curl_safefree(config->cacert);
-  Curl_safefree(config->login_options);
-  Curl_safefree(config->proxy_cacert);
-  Curl_safefree(config->capath);
-  Curl_safefree(config->proxy_capath);
-  Curl_safefree(config->crlfile);
-  Curl_safefree(config->pinnedpubkey);
-  Curl_safefree(config->proxy_pinnedpubkey);
-  Curl_safefree(config->proxy_crlfile);
-  Curl_safefree(config->key);
-  Curl_safefree(config->proxy_key);
-  Curl_safefree(config->key_type);
-  Curl_safefree(config->proxy_key_type);
-  Curl_safefree(config->key_passwd);
-  Curl_safefree(config->proxy_key_passwd);
-  Curl_safefree(config->pubkey);
-  Curl_safefree(config->hostpubmd5);
-  Curl_safefree(config->hostpubsha256);
-  Curl_safefree(config->engine);
-  Curl_safefree(config->etag_save_file);
-  Curl_safefree(config->etag_compare_file);
-  Curl_safefree(config->ssl_ec_curves);
-  Curl_safefree(config->request_target);
-  Curl_safefree(config->customrequest);
-  Curl_safefree(config->krblevel);
-  Curl_safefree(config->oauth_bearer);
-  Curl_safefree(config->sasl_authzid);
-  Curl_safefree(config->unix_socket_path);
-  Curl_safefree(config->writeout);
-  Curl_safefree(config->proto_default);
+  curlx_safefree(config->doh_url);
+  curlx_safefree(config->cipher_list);
+  curlx_safefree(config->proxy_cipher_list);
+  curlx_safefree(config->cipher13_list);
+  curlx_safefree(config->proxy_cipher13_list);
+  curlx_safefree(config->cert);
+  curlx_safefree(config->proxy_cert);
+  curlx_safefree(config->cert_type);
+  curlx_safefree(config->proxy_cert_type);
+  curlx_safefree(config->cacert);
+  curlx_safefree(config->login_options);
+  curlx_safefree(config->proxy_cacert);
+  curlx_safefree(config->capath);
+  curlx_safefree(config->proxy_capath);
+  curlx_safefree(config->crlfile);
+  curlx_safefree(config->pinnedpubkey);
+  curlx_safefree(config->proxy_pinnedpubkey);
+  curlx_safefree(config->proxy_crlfile);
+  curlx_safefree(config->key);
+  curlx_safefree(config->proxy_key);
+  curlx_safefree(config->key_type);
+  curlx_safefree(config->proxy_key_type);
+  curlx_safefree(config->key_passwd);
+  curlx_safefree(config->proxy_key_passwd);
+  curlx_safefree(config->pubkey);
+  curlx_safefree(config->hostpubmd5);
+  curlx_safefree(config->hostpubsha256);
+  curlx_safefree(config->engine);
+  curlx_safefree(config->etag_save_file);
+  curlx_safefree(config->etag_compare_file);
+  curlx_safefree(config->ssl_ec_curves);
+  curlx_safefree(config->request_target);
+  curlx_safefree(config->customrequest);
+  curlx_safefree(config->krblevel);
+  curlx_safefree(config->oauth_bearer);
+  curlx_safefree(config->sasl_authzid);
+  curlx_safefree(config->unix_socket_path);
+  curlx_safefree(config->writeout);
+  curlx_safefree(config->proto_default);
 
   curl_slist_free_all(config->quote);
   curl_slist_free_all(config->postquote);
@@ -171,17 +172,17 @@ static void free_config_fields(struct OperationConfig *config)
   curl_slist_free_all(config->resolve);
   curl_slist_free_all(config->connect_to);
 
-  Curl_safefree(config->preproxy);
-  Curl_safefree(config->proxy_service_name);
-  Curl_safefree(config->service_name);
-  Curl_safefree(config->ftp_account);
-  Curl_safefree(config->ftp_alternative_to_user);
-  Curl_safefree(config->aws_sigv4);
-  Curl_safefree(config->proto_str);
-  Curl_safefree(config->proto_redir_str);
-  Curl_safefree(config->ech);
-  Curl_safefree(config->ech_config);
-  Curl_safefree(config->ech_public);
+  curlx_safefree(config->preproxy);
+  curlx_safefree(config->proxy_service_name);
+  curlx_safefree(config->service_name);
+  curlx_safefree(config->ftp_account);
+  curlx_safefree(config->ftp_alternative_to_user);
+  curlx_safefree(config->aws_sigv4);
+  curlx_safefree(config->proto_str);
+  curlx_safefree(config->proto_redir_str);
+  curlx_safefree(config->ech);
+  curlx_safefree(config->ech_config);
+  curlx_safefree(config->ech_public);
 }
 
 void config_free(struct OperationConfig *config)

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -595,7 +595,7 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
   res_len = SearchPath(NULL, bundle_file, NULL, PATH_MAX, buf, &ptr);
   if(res_len > 0) {
     char *mstr = curlx_convert_tchar_to_UTF8(buf);
-    Curl_safefree(config->cacert);
+    curlx_safefree(config->cacert);
     if(mstr)
       config->cacert = strdup(mstr);
     curlx_unicodefree(mstr);

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -171,7 +171,7 @@ static struct tool_mime *tool_mime_new_filedata(struct tool_mime *parent,
     }
     m = tool_mime_new(parent, TOOLMIME_STDIN);
     if(!m)
-      Curl_safefree(data);
+      curlx_safefree(data);
     else {
       m->data = data;
       m->origin = origin;
@@ -192,11 +192,11 @@ void tool_mime_free(struct tool_mime *mime)
       tool_mime_free(mime->subparts);
     if(mime->prev)
       tool_mime_free(mime->prev);
-    Curl_safefree(mime->name);
-    Curl_safefree(mime->filename);
-    Curl_safefree(mime->type);
-    Curl_safefree(mime->encoder);
-    Curl_safefree(mime->data);
+    curlx_safefree(mime->name);
+    curlx_safefree(mime->filename);
+    curlx_safefree(mime->type);
+    curlx_safefree(mime->encoder);
+    curlx_safefree(mime->data);
     curl_slist_free_all(mime->headers);
     free(mime);
   }
@@ -838,7 +838,7 @@ int formparse(struct OperationConfig *config,
                   "error while reading standard input");
             goto fail;
           }
-          Curl_safefree(part->data);
+          curlx_safefree(part->data);
           part->size = -1;
           res = CURLE_OK;
         }
@@ -874,7 +874,7 @@ int formparse(struct OperationConfig *config,
                   "error while reading standard input");
             goto fail;
           }
-          Curl_safefree(part->data);
+          curlx_safefree(part->data);
           part->size = -1;
           res = CURLE_OK;
         }
@@ -916,7 +916,7 @@ int formparse(struct OperationConfig *config,
   }
   err = 0;
 fail:
-  Curl_safefree(contents);
+  curlx_safefree(contents);
   curl_slist_free_all(headers);
   return err;
 }

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -661,7 +661,7 @@ static ParameterError data_urlencode(struct GlobalConfig *global,
   }
   else {
     char *enc = curl_easy_escape(NULL, postdata, (int)size);
-    Curl_safefree(postdata); /* no matter if it worked or not */
+    curlx_safefree(postdata); /* no matter if it worked or not */
     if(enc) {
       char *n;
       replace_url_encoded_space_by_plus(enc);
@@ -955,7 +955,7 @@ static ParameterError set_data(cmdline_t cmd,
   if(!err && curlx_dyn_addn(&config->postdata, postdata, size))
     err = PARAM_NO_MEM;
 
-  Curl_safefree(postdata);
+  curlx_safefree(postdata);
 
   config->postfields = curlx_dyn_ptr(&config->postdata);
   return err;
@@ -1562,7 +1562,7 @@ static ParameterError parse_writeout(struct GlobalConfig *global,
         return PARAM_READ_ERROR;
       }
     }
-    Curl_safefree(config->writeout);
+    curlx_safefree(config->writeout);
     err = file2string(&config->writeout, file);
     if(file && (file != stdin))
       fclose(file);
@@ -1869,7 +1869,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       err = getstr(&config->doh_url, nextarg, ALLOW_BLANK);
       if(!err && config->doh_url && !config->doh_url[0])
         /* if given a blank string, make it NULL again */
-        Curl_safefree(config->doh_url);
+        curlx_safefree(config->doh_url);
       break;
     case C_CIPHERS: /* -- ciphers */
       err = getstr(&config->cipher_list, nextarg, DENY_BLANK);
@@ -2058,7 +2058,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
               a->lname);
       break;
     case C_FTP_PASV: /* --ftp-pasv */
-      Curl_safefree(config->ftpport);
+      curlx_safefree(config->ftpport);
       break;
     case C_SOCKS5: /* --socks5 */
       /*  socks5 proxy to use, and resolves the name locally and passes on the

--- a/src/tool_ipfs.c
+++ b/src/tool_ipfs.c
@@ -43,11 +43,11 @@ static CURLcode ensure_trailing_slash(char **input)
       curlx_dyn_init(&dyn, len + 2);
 
       if(curlx_dyn_addn(&dyn, *input, len)) {
-        Curl_safefree(*input);
+        curlx_safefree(*input);
         return CURLE_OUT_OF_MEMORY;
       }
 
-      Curl_safefree(*input);
+      curlx_safefree(*input);
 
       if(curlx_dyn_addn(&dyn, "/", 1))
         return CURLE_OUT_OF_MEMORY;
@@ -92,7 +92,7 @@ static char *ipfs_gateway(void)
     goto fail;
 
   gateway_file = fopen(gateway_composed_file_path, FOPEN_READTEXT);
-  Curl_safefree(gateway_composed_file_path);
+  curlx_safefree(gateway_composed_file_path);
 
   if(gateway_file) {
     int c;
@@ -118,15 +118,15 @@ static char *ipfs_gateway(void)
     if(!gateway)
       goto fail;
 
-    Curl_safefree(ipfs_path);
+    curlx_safefree(ipfs_path);
 
     return gateway;
   }
 fail:
   if(gateway_file)
     fclose(gateway_file);
-  Curl_safefree(gateway);
-  Curl_safefree(ipfs_path);
+  curlx_safefree(gateway);
+  curlx_safefree(ipfs_path);
   return NULL;
 }
 
@@ -247,7 +247,7 @@ CURLcode ipfs_url_rewrite(CURLU *uh, const char *protocol, char **url,
   }
 
   /* Free whatever it has now, rewriting is next */
-  Curl_safefree(*url);
+  curlx_safefree(*url);
 
   if(curl_url_get(uh, CURLUPART_URL, &cloneurl, CURLU_URLENCODE)) {
     goto clean;

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -197,13 +197,13 @@ static CURLcode main_init(struct GlobalConfig *config)
 
 static void free_globalconfig(struct GlobalConfig *config)
 {
-  Curl_safefree(config->trace_dump);
+  curlx_safefree(config->trace_dump);
 
   if(config->trace_fopened && config->trace_stream)
     fclose(config->trace_stream);
   config->trace_stream = NULL;
 
-  Curl_safefree(config->libcurl);
+  curlx_safefree(config->libcurl);
 }
 
 /*

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -932,7 +932,7 @@ static CURLcode config2setopts(struct GlobalConfig *global,
     if(env) {
       curl_off_t num;
       const char *p = env;
-      if(!Curl_str_number(&p, &num, LONG_MAX))
+      if(!curlx_str_number(&p, &num, LONG_MAX))
         my_setopt(curl, CURLOPT_BUFFERSIZE, (long)num);
     }
     else

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -427,8 +427,8 @@ void single_transfer_cleanup(struct OperationConfig *config)
     struct State *state = &config->state;
     /* Free list of remaining URLs */
     glob_cleanup(&state->urls);
-    Curl_safefree(state->outfiles);
-    Curl_safefree(state->uploadfile);
+    curlx_safefree(state->outfiles);
+    curlx_safefree(state->uploadfile);
     /* Free list of globbed upload files */
     glob_cleanup(&state->inglob);
   }
@@ -743,13 +743,13 @@ skip:
     fclose(per->heads.stream);
 
   if(per->heads.alloc_filename)
-    Curl_safefree(per->heads.filename);
+    curlx_safefree(per->heads.filename);
 
   if(per->etag_save.fopened && per->etag_save.stream)
     fclose(per->etag_save.stream);
 
   if(per->etag_save.alloc_filename)
-    Curl_safefree(per->etag_save.filename);
+    curlx_safefree(per->etag_save.filename);
 
   curl_easy_cleanup(per->curl);
   if(outs->alloc_filename)
@@ -1939,7 +1939,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         if((PARAM_OK == file2string(&etag_from_file, file)) &&
            etag_from_file) {
           header = aprintf("If-None-Match: %s", etag_from_file);
-          Curl_safefree(etag_from_file);
+          curlx_safefree(etag_from_file);
         }
         else
           header = aprintf("If-None-Match: \"\"");
@@ -1955,7 +1955,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
         /* add Etag from file to list of custom headers */
         pe = add2list(&config->headers, header);
-        Curl_safefree(header);
+        curlx_safefree(header);
 
         if(file)
           fclose(file);
@@ -1978,7 +1978,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           if(!newfile) {
             warnf(global, "Failed creating file for saving etags: \"%s\". "
                   "Skip this transfer", config->etag_save_file);
-            Curl_safefree(state->outfiles);
+            curlx_safefree(state->outfiles);
             glob_cleanup(&state->urls);
             return CURLE_OK;
           }
@@ -2015,7 +2015,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           break;
         }
         if(SetHTTPrequest(config, TOOL_HTTPREQ_PUT, &config->httpreq)) {
-          Curl_safefree(per->uploadfile);
+          curlx_safefree(per->uploadfile);
           curl_easy_cleanup(curl);
           result = CURLE_FAILED_INIT;
           break;
@@ -2138,7 +2138,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           /* fill '#1' ... '#9' terms from URL pattern */
           char *storefile = per->outfile;
           result = glob_match_url(&per->outfile, storefile, state->urls);
-          Curl_safefree(storefile);
+          curlx_safefree(storefile);
           if(result) {
             /* bad globbing */
             warnf(global, "bad output glob");
@@ -2334,7 +2334,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         state->urlnum = 0; /* forced reglob of URLs */
         glob_cleanup(&state->urls);
         state->up++;
-        Curl_safefree(state->uploadfile); /* clear it to get the next */
+        curlx_safefree(state->uploadfile); /* clear it to get the next */
       }
     }
     else {
@@ -2344,8 +2344,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
       glob_cleanup(&state->urls);
       state->urlnum = 0;
 
-      Curl_safefree(state->outfiles);
-      Curl_safefree(state->uploadfile);
+      curlx_safefree(state->outfiles);
+      curlx_safefree(state->uploadfile);
       /* Free list of globbed upload files */
       glob_cleanup(&state->inglob);
       state->up = 0;
@@ -2353,7 +2353,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
     }
     break;
   }
-  Curl_safefree(state->outfiles);
+  curlx_safefree(state->outfiles);
 fail:
   if(!*added || result) {
     *added = FALSE;

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -43,10 +43,10 @@ void clean_getout(struct OperationConfig *config)
 
     while(node) {
       next = node->next;
-      Curl_safefree(node->url);
-      Curl_safefree(node->outfile);
-      Curl_safefree(node->infile);
-      Curl_safefree(node);
+      curlx_safefree(node->url);
+      curlx_safefree(node->outfile);
+      curlx_safefree(node->infile);
+      curlx_safefree(node);
       node = next;
     }
     config->url_list = NULL;
@@ -228,7 +228,7 @@ CURLcode get_url_file_name(struct GlobalConfig *global,
       {
         char *sanitized;
         SANITIZEcode sc = sanitize_file_name(&sanitized, *filename, 0);
-        Curl_safefree(*filename);
+        curlx_safefree(*filename);
         if(sc) {
           if(sc == SANITIZE_ERR_OUT_OF_MEMORY)
             return CURLE_OUT_OF_MEMORY;

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -224,7 +224,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       }
 
       if(alloced_param)
-        Curl_safefree(param);
+        curlx_safefree(param);
     }
     curlx_dyn_free(&buf);
     if(file != stdin)

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -415,7 +415,7 @@ static CURLcode libcurl_generate_slist(struct curl_slist *slist, int *slistno)
   }
 
 nomem:
-  Curl_safefree(escaped);
+  curlx_safefree(escaped);
   return ret;
 }
 
@@ -530,7 +530,7 @@ static CURLcode libcurl_generate_mime_part(CURL *curl,
   }
 
 nomem:
-  Curl_safefree(escaped);
+  curlx_safefree(escaped);
   return ret;
 }
 
@@ -712,7 +712,7 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *global,
   }
 
 nomem:
-  Curl_safefree(escaped);
+  curlx_safefree(escaped);
   return ret;
 }
 

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -449,7 +449,7 @@ CURLcode glob_url(struct URLGlob **glob, char *url, curl_off_t *urlnum,
 
   glob_expand = calloc(1, sizeof(struct URLGlob));
   if(!glob_expand) {
-    Curl_safefree(glob_buffer);
+    curlx_safefree(glob_buffer);
     return CURLE_OUT_OF_MEMORY;
   }
   glob_expand->urllen = strlen(url);
@@ -499,13 +499,13 @@ void glob_cleanup(struct URLGlob **globp)
       for(elem = glob->pattern[i].content.Set.size - 1;
           elem >= 0;
           --elem) {
-        Curl_safefree(glob->pattern[i].content.Set.elements[elem]);
+        curlx_safefree(glob->pattern[i].content.Set.elements[elem]);
       }
-      Curl_safefree(glob->pattern[i].content.Set.elements);
+      curlx_safefree(glob->pattern[i].content.Set.elements);
     }
   }
-  Curl_safefree(glob->glob_buffer);
-  Curl_safefree(glob);
+  curlx_safefree(glob->glob_buffer);
+  curlx_safefree(glob);
   *globp = NULL;
 }
 


### PR DESCRIPTION
Towards using curlx_ prefix for all libcurl code that is used in the tool outside of the "real" API.