### PR TITLE
test489: set output dir

### DIFF
--- a/tests/data/test489
+++ b/tests/data/test489
@@ -36,7 +36,7 @@ http
 Download two URLs provided in a file
 </name>
 <command>
---url @%LOGDIR/urls
+--output-dir %LOGDIR --url @%LOGDIR/urls
 </command>
 <file name="%LOGDIR/urls">
 http://%HOSTIP:%HTTPPORT/a


### PR DESCRIPTION
Set output dir to %LOGIDR so that generated files are ignored by git.