### PR TITLE
tests/server: use `curlx_str_numblanks()` to avoid `errno`

### DIFF
--- a/lib/strparse.h
+++ b/lib/strparse.h
@@ -106,5 +106,6 @@ void Curl_str_passblanks(const char **linep);
 #define curlx_str_octal(x,y,z) Curl_str_octal(x,y,z)
 #define curlx_str_single(x,y) Curl_str_single(x,y)
 #define curlx_str_passblanks(x) Curl_str_passblanks(x)
+#define curlx_str_numblanks(x,y) Curl_str_numblanks(x,y)
 
 #endif /* HEADER_CURL_STRPARSE_H */

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -436,23 +436,17 @@ static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
          request including the body before we return. If we've been told to
          ignore the content-length, we will return as soon as all headers
          have been received */
-      char *endptr;
-      char *ptr = line + 15;
-      unsigned long clen = 0;
-      while(*ptr && ISSPACE(*ptr))
-        ptr++;
-      endptr = ptr;
-      CURL_SETERRNO(0);
-      clen = strtoul(ptr, &endptr, 10);
-      if((ptr == endptr) || !ISSPACE(*endptr) || (ERANGE == errno)) {
+      curl_off_t clen;
+      const char *p = line + strlen("Content-Length:");
+      if(curlx_str_numblanks(&p, &clen)) {
         /* this assumes that a zero Content-Length is valid */
-        logmsg("Found invalid Content-Length: (%s) in the request", ptr);
+        logmsg("Found invalid '%s' in the request", line);
         req->open = FALSE; /* closes connection */
         return 1; /* done */
       }
-      req->cl = clen - req->skip;
+      req->cl = (size_t)clen - req->skip;
 
-      logmsg("Found Content-Length: %lu in the request", clen);
+      logmsg("Found Content-Length: %lu in the request", (long)clen);
       if(req->skip)
         logmsg("... but will abort after %zu bytes", req->cl);
       break;

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -446,7 +446,7 @@ static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
       }
       req->cl = (size_t)clen - req->skip;
 
-      logmsg("Found Content-Length: %lu in the request", (long)clen);
+      logmsg("Found Content-Length: %zu in the request", (size_t)clen);
       if(req->skip)
         logmsg("... but will abort after %zu bytes", req->cl);
       break;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -588,26 +588,20 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
          request including the body before we return. If we've been told to
          ignore the content-length, we will return as soon as all headers
          have been received */
-      char *endptr;
-      char *ptr = line + 15;
-      unsigned long clen = 0;
-      while(*ptr && ISSPACE(*ptr))
-        ptr++;
-      endptr = ptr;
-      CURL_SETERRNO(0);
-      clen = strtoul(ptr, &endptr, 10);
-      if((ptr == endptr) || !ISSPACE(*endptr) || (ERANGE == errno)) {
+      curl_off_t clen;
+      const char *p = line + strlen("Content-Length:");
+      if(curlx_str_numblanks(&p, &clen)) {
         /* this assumes that a zero Content-Length is valid */
-        logmsg("Found invalid Content-Length: (%s) in the request", ptr);
+        logmsg("Found invalid '%s' in the request", line);
         req->open = FALSE; /* closes connection */
         return 1; /* done */
       }
       if(req->skipall)
         req->cl = 0;
       else
-        req->cl = clen - req->skip;
+        req->cl = (size_t)clen - req->skip;
 
-      logmsg("Found Content-Length: %lu in the request", clen);
+      logmsg("Found Content-Length: %lu in the request", (long)clen);
       if(req->skip)
         logmsg("... but will abort after %zu bytes", req->cl);
     }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -601,7 +601,7 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
       else
         req->cl = (size_t)clen - req->skip;
 
-      logmsg("Found Content-Length: %lu in the request", (long)clen);
+      logmsg("Found Content-Length: %zu in the request", (size_t)clen);
       if(req->skip)
         logmsg("... but will abort after %zu bytes", req->cl);
     }


### PR DESCRIPTION
Replacing `strtoul()` calls and glue code.