### PR TITLE
curl_setup: drop `ERANGE` (for WinCE), no longer used

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -859,7 +859,6 @@
 #define EEXIST 17
 #define EISDIR 21
 #define ENOSPC 28
-#define ERANGE 34
 #define strerror(x) "?"
 #else
 #define CURL_SETERRNO(x) (errno = (x))


### PR DESCRIPTION
Follow-up to 29ed1f9834047887a232423e715b0f2b72d744e9 #16671