### PR TITLE
Extend docu for openssl engine and provider support

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -856,14 +856,12 @@ toplevel
 TOS
 TPF
 TPM
-tpm
 TrackMemory
 transcode
 Tru
 trurl
 trustless
 Tse
-tss
 Tsujikawa
 TTL
 tvOS

--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -855,12 +855,15 @@ toolset
 toplevel
 TOS
 TPF
+TPM
+tpm
 TrackMemory
 transcode
 Tru
 trurl
 trustless
 Tse
+tss
 Tsujikawa
 TTL
 tvOS

--- a/docs/cmdline-opts/cert.md
+++ b/docs/cmdline-opts/cert.md
@@ -38,6 +38,11 @@ certificate located in a PKCS#11 device. A string beginning with `pkcs11:` is
 interpreted as a PKCS#11 URI. If a PKCS#11 URI is provided, then the --engine
 option is set as `pkcs11` if none was provided and the --cert-type option is
 set as `ENG` or `PROV` if none was provided (depending on OpenSSL version).
+Also the engine tpm2tss or the tpm2 provider can be used for a client
+certificate, where the private key is protected or stored in a TPM 2.0. Provide
+the path to the public part of the client certificate with the --cert option.
+See the --key option for details on how to specify the TPM 2.0 protected
+private key belonging to the client certificate.
 
 If curl is built against GnuTLS library, a PKCS#11 URI can be used to specify
 a certificate located in a PKCS#11 device. A string beginning with `pkcs11:`

--- a/docs/cmdline-opts/cert.md
+++ b/docs/cmdline-opts/cert.md
@@ -38,7 +38,7 @@ certificate located in a PKCS#11 device. A string beginning with `pkcs11:` is
 interpreted as a PKCS#11 URI. If a PKCS#11 URI is provided, then the --engine
 option is set as `pkcs11` if none was provided and the --cert-type option is
 set as `ENG` or `PROV` if none was provided (depending on OpenSSL version).
-Also the engine tpm2tss or the tpm2 provider can be used for a client
+The OpenSSL engine `tpm2tss` or the OpenSSL provider `tpm2`  can be used for a client
 certificate, where the private key is protected or stored in a TPM 2.0. Provide
 the path to the public part of the client certificate with the --cert option.
 See the --key option for details on how to specify the TPM 2.0 protected

--- a/docs/cmdline-opts/engine.md
+++ b/docs/cmdline-opts/engine.md
@@ -22,12 +22,13 @@ list to print a list of build-time supported engines. Note that not all (and
 possibly none) of the engines may be available at runtime.
 
 OpenSSL 1.x used engines, whereas starting from OpenSSL 3.x providers should
-be used and engines are deprecated. curl does not provide an option to load
-OpenSSL providers. However, an OpenSSL config can be used to achieve this.
-Either adjust the system-wide config, usually present under
-`/etc/ssl/openssl.cnf` or point to one via the environment variable before
-calling curl `export OPENSSL_CONF=/your/path/to/openssl.cnf`. A minimum config
-file that loads the tpm2 and the default provider would look the following:
+be used and engines are deprecated. curl does not provide an command line
+option to explicitly load a certain OpenSSL providers. However, an OpenSSL
+config can be used to achieve this. Either adjust the system-wide config,
+usually present under `/etc/ssl/openssl.cnf` or point to one via the
+environment variable before calling curl
+`export OPENSSL_CONF=/your/path/to/openssl.cnf`. A minimum config file that
+loads the `tpm2` and the default provider would look the following:
 
 ```dosini
 openssl_conf = default_conf_section

--- a/docs/cmdline-opts/engine.md
+++ b/docs/cmdline-opts/engine.md
@@ -20,3 +20,32 @@ Example:
 Select the OpenSSL crypto engine to use for cipher operations. Use --engine
 list to print a list of build-time supported engines. Note that not all (and
 possibly none) of the engines may be available at runtime.
+
+OpenSSL 1.x used engines, whereas starting from OpenSSL 3.x providers should
+be used and engines are deprecated. curl does not provide an option to load
+OpenSSL providers. However, an OpenSSL config can be used to achieve this.
+Either adjust the system-wide config, usually present under
+`/etc/ssl/openssl.cnf` or point to one via the environment variable before
+calling curl `export OPENSSL_CONF=/your/path/to/openssl.cnf`. A minimum config
+file that loads the tpm2 and the default provider would look the following:
+
+```dosini
+openssl_conf = default_conf_section
+
+[default_conf_section]
+providers = provider_sect
+alg_section = evp_properties
+
+[provider_sect]
+default = default_sect
+tpm2 = tpm2_sect
+
+[default_sect]
+activate = 1
+
+[tpm2_sect]
+activate = 1
+
+[evp_properties]
+default_properties = ?provider!=tpm2
+```

--- a/docs/cmdline-opts/key.md
+++ b/docs/cmdline-opts/key.md
@@ -28,8 +28,8 @@ interpreted as a PKCS#11 URI. If a PKCS#11 URI is provided, then the --engine
 option is set as `pkcs11` if none was provided and the --key-type option is
 set as `ENG` or `PROV` if none was provided (depending on OpenSSL version).
 OpenSSL 1.x used engines, whereas starting from OpenSSL 3.x providers should
-be used and engines are deprecated. Also the engine tpm2tss or the
-tpm2provider can be used for the private key of a client certificate. curl
+be used and engines are deprecated. The OpenSSL engine `tpm2tss` or the
+OpenSSL provider `tpm2` can be used for the private key of a client certificate. curl
 provides the option --engine to load an OpenSSL engine. Providers have to be
 loaded via the OpenSSL config file. See the --engine option for further
 details. The following examples demonstrate how a client certificate can be

--- a/docs/cmdline-opts/key.md
+++ b/docs/cmdline-opts/key.md
@@ -27,6 +27,26 @@ private key located in a PKCS#11 device. A string beginning with `pkcs11:` is
 interpreted as a PKCS#11 URI. If a PKCS#11 URI is provided, then the --engine
 option is set as `pkcs11` if none was provided and the --key-type option is
 set as `ENG` or `PROV` if none was provided (depending on OpenSSL version).
+OpenSSL 1.x used engines, whereas starting from OpenSSL 3.x providers should
+be used and engines are deprecated. Also the engine tpm2tss or the
+tpm2provider can be used for the private key of a client certificate. curl
+provides the option --engine to load an OpenSSL engine. Providers have to be
+loaded via the OpenSSL config file. See the --engine option for further
+details. The following examples demonstrate how a client certificate can be
+used if the private key is protected or stored in the TPM:
+```bash
+# OpenSSL 1.x and tpm2tss engine
+# mTLS download with TSS key protected by TPM
+curl --engine tpm2tss --key-type ENG --key /path/to/key.tss --cert /path/to/cert.crt https://my-server.com/download/url
+
+# OpenSSL 3.x and tpm2 provider
+# point to an OpenSSL config file that loads the default + tpm2 provider
+export OPENSSL_CONF=/your/path/to/openssl.cnf
+# mTLS download with TSS key protected by TPM
+curl --key /path/to/key.tss --cert /path/to/cert.crt https://my-server.com/download/url
+# mTLS download with key persist in the TPM 
+curl --key handle:0x81000000 --cert /path/to/cert.crt https://my-server.com/download/url
+```
 
 If curl is built against Secure Transport or Schannel then this option is
 ignored for TLS protocols (HTTPS, etc). Those backends expect the private key

--- a/docs/cmdline-opts/key.md
+++ b/docs/cmdline-opts/key.md
@@ -33,7 +33,7 @@ OpenSSL provider `tpm2` can be used for the private key of a client certificate.
 provides the option --engine to load an OpenSSL engine. Providers have to be
 loaded via the OpenSSL config file. See the --engine option for further
 details. The following examples demonstrate how a client certificate can be
-used if the private key is protected or stored in the TPM:
+used if the private key is protected or stored in the TPM 2.0:
 ```bash
 # OpenSSL 1.x and tpm2tss engine
 # mTLS download with TSS key protected by TPM

--- a/docs/cmdline-opts/key.md
+++ b/docs/cmdline-opts/key.md
@@ -44,7 +44,7 @@ curl --engine tpm2tss --key-type ENG --key /path/to/key.tss --cert /path/to/cert
 export OPENSSL_CONF=/your/path/to/openssl.cnf
 # mTLS download with TSS key protected by TPM
 curl --key /path/to/key.tss --cert /path/to/cert.crt https://my-server.com/download/url
-# mTLS download with key persist in the TPM 
+# mTLS download with key persist in the TPM
 curl --key handle:0x81000000 --cert /path/to/cert.crt https://my-server.com/download/url
 ```
 


### PR DESCRIPTION
Added documentation regarding OpenSSL engine and provider support with respect to TPM 2.0.

This addresses issue [https://github.com/curl/curl/issues/16474](url)