### PR TITLE
multi: call protocol handler done() if PROTOCONNECT or later

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -570,7 +570,7 @@ static CURLcode multi_done(struct Curl_easy *data,
   }
 
   /* this calls the protocol-specific function pointer previously set */
-  if(conn->handler->done)
+  if(conn->handler->done && (data->mstate >= MSTATE_PROTOCONNECT))
     result = conn->handler->done(data, status, premature);
   else
     result = status;


### PR DESCRIPTION
The protocol handlers' done() function would previous get called unconditionally in multi_done(), no matter how far the easy handle's state machine has transitioned.

This caused problems in IMAP which in imap_connect() initializes things that the imap_done() function assumes has occured. I think that seems like a correct assumption and we should rather make sure that the done() function is only called if we have reached the DO state.

This problem was found using OSS-Fuzz.

Assisted-by: Catena cyber