### PR TITLE
tool_operate: fix build with --libcurl support disabled

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -342,6 +342,9 @@ static CURLcode pre_transfer(struct GlobalConfig *global,
   curl_off_t uploadfilesize = -1;
   struct_stat fileinfo;
   CURLcode result = CURLE_OK;
+#ifdef CURL_DISABLE_LIBCURL_OPTION
+  (void)global; /* otherwise used in the my_setopt macros */
+#endif
 
   if(per->uploadfile && !stdin_upload(per->uploadfile)) {
     /* VMS Note:


### PR DESCRIPTION
A compiler warning for unused argument.

Reported-by: Marcel Raad