### PR TITLE
runtests: enable the --libcurl feature by default

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -831,6 +831,7 @@ sub checksystemfeatures {
     $feature{"large-time"} = 1;
     $feature{"large-size"} = 1;
     $feature{"sha512-256"} = 1;
+    $feature{"--libcurl"} = 1;
     $feature{"local-http"} = servers::localhttp();
     $feature{"codeset-utf8"} = lc(langinfo(CODESET())) eq "utf-8";
 


### PR DESCRIPTION
Follow-up to a14eb26a585e67309066ac8a2
Reported-by: Viktor Szakats
Fixes #16693