### PR TITLE
cmake: unity mode optimization for non-`CURLDEBUG` `testdeps` targets

### DIFF
--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -27,7 +27,9 @@
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-set_source_files_properties("../../lib/curl_multibyte.c" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+if(ENABLE_CURLDEBUG)
+  set_source_files_properties("../../lib/curl_multibyte.c" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+endif()
 
 add_custom_command(
   OUTPUT "lib1521.c"

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -26,7 +26,9 @@
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-set_source_files_properties("../../lib/memdebug.c" "../../lib/curl_multibyte.c" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+if(ENABLE_CURLDEBUG)
+  set_source_files_properties("../../lib/memdebug.c" "../../lib/curl_multibyte.c" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+endif()
 
 foreach(_target IN LISTS noinst_PROGRAMS)
   set(_target_name "${_target}")


### PR DESCRIPTION
Include more sources in unity mode to optimize libtest and tests/server
builds for non-debug-enabled builds, syncing this pattern with `lib` and
`src`.

It reduces build steps from 62 to 47 (-14, -24%) with test bundles.
Without test bundles, from 680 to 642 (-38, -6%).

Follow-up to de0693f24943cd65f26a7b421a4304cbadb875a0 #16274
Follow-up to 3efba94f773db5d8ae19e33aa749ab7914cafeea #14765
Cherry-picked from #15000

---

w/o ws https://github.com/curl/curl/pull/16695/files?w=1

Before Ninja: https://github.com/curl/curl/actions/runs/13822611417/job/38671285398
After Ninja: https://github.com/curl/curl/actions/runs/13824373179/job/38676553325?pr=16695

Before MSBuild: https://github.com/curl/curl/actions/runs/13822595158/job/38671237831
After MSBuild: https://github.com/curl/curl/actions/runs/13824373179/job/38676551843?pr=16695
