### PR TITLE
memdebug.h: avoid `-Wredundant-decls` with an extra guard

### DIFF
--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -49,6 +49,10 @@
 
 #define CURL_MT_LOGFNAME_BUFSIZE 512
 
+/* Avoid redundant redeclaration warnings with modern compilers, when including
+   this header multiple times. */
+#ifndef HEADER_CURL_MEMDEBUG_H_EXTERNS
+#define HEADER_CURL_MEMDEBUG_H_EXTERNS
 extern FILE *curl_dbg_logfile;
 
 /* memory functions */
@@ -108,6 +112,7 @@ CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fdopen(int filedes, const char *mode,
                                              int line, const char *source);
 
 CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
+#endif /* HEADER_CURL_MEMDEBUG_H_EXTERNS */
 
 #ifndef MEMDEBUG_NODEFINES
 


### PR DESCRIPTION
Add an extra guard for the function and variable declarations to avoid
redundant redeclaration warnings when including this header multiple
times. This can happen in unity builds when including it again after
`curl_memory.h`.

Fixes:
```
bld/tests/server/CMakeFiles/servers.dir/Unity/unity_0_c.c
In file included from lib/mprintf.c:32,
                 from bld/tests/server/CMakeFiles/servers.dir/Unity/unity_0_c.c:7:
lib/memdebug.h:52:14: error: redundant redeclaration of ‘curl_dbg_logfile’ [-Werror=redundant-decls]
   52 | extern FILE *curl_dbg_logfile;                        
      |              ^~~~~~~~~~~~~~~~                         
In file included from tests/server/resolve.c:50,
                 from bld/tests/server/server_bundle.c:7,                     
                 from bld/tests/server/CMakeFiles/servers.dir/Unity/unity_0_c.c:4:
lib/memdebug.h:52:14: note: previous declaration of ‘curl_dbg_logfile’ with type ‘FILE *’
   52 | extern FILE *curl_dbg_logfile;                                        
      |              ^~~~~~~~~~~~~~~~                                         
[...]
lib/memdebug.h:110:17: error: redundant redeclaration of ‘curl_dbg_fclose’ [-Werror=redundant-decls]
  110 | CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
      |                 ^~~~~~~~~~~~~~~
lib/memdebug.h:110:17: note: previous declaration of ‘curl_dbg_fclose’ with type ‘int(FILE *, int,  const char *)’
  110 | CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
      |                 ^~~~~~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/13822010778/job/38669360980#step:39:55

Cherry-picked from #15000

---

```
/home/runner/work/curl/curl/bld/tests/server/CMakeFiles/servers.dir/Unity/unity_0_c.c
In file included from /home/runner/work/curl/curl/lib/mprintf.c:32,
                 from /home/runner/work/curl/curl/bld/tests/server/CMakeFiles/servers.dir/Unity/unity_0_c.c:7:
/home/runner/work/curl/curl/lib/memdebug.h:52:14: error: redundant redeclaration of ‘curl_dbg_logfile’ [-Werror=redundant-decls]
   52 | extern FILE *curl_dbg_logfile;
      |              ^~~~~~~~~~~~~~~~
In file included from /home/runner/work/curl/curl/tests/server/resolve.c:50,
                 from /home/runner/work/curl/curl/bld/tests/server/server_bundle.c:7,
                 from /home/runner/work/curl/curl/bld/tests/server/CMakeFiles/servers.dir/Unity/unity_0_c.c:4:
/home/runner/work/curl/curl/lib/memdebug.h:52:14: note: previous declaration of ‘curl_dbg_logfile’ with type ‘FILE *’
   52 | extern FILE *curl_dbg_logfile;
      |              ^~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:55:44: error: redundant redeclaration of ‘curl_dbg_malloc’ [-Werror=redundant-decls]
   55 | CURL_EXTERN ALLOC_FUNC ALLOC_SIZE(1) void *curl_dbg_malloc(size_t size,
      |                                            ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:55:44: note: previous declaration of ‘curl_dbg_malloc’ with type ‘void *(size_t,  int,  const char *)’ {aka ‘void *(long unsigned int,  int,  const char *)’}
   55 | CURL_EXTERN ALLOC_FUNC ALLOC_SIZE(1) void *curl_dbg_malloc(size_t size,
      |                                            ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:58:48: error: redundant redeclaration of ‘curl_dbg_calloc’ [-Werror=redundant-decls]
   58 | CURL_EXTERN ALLOC_FUNC ALLOC_SIZE2(1, 2) void *curl_dbg_calloc(size_t elements,
      |                                                ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:58:48: note: previous declaration of ‘curl_dbg_calloc’ with type ‘void *(size_t,  size_t,  int,  const char *)’ {aka ‘void *(long unsigned int,  long unsigned int,  int,  const char *)’}
   58 | CURL_EXTERN ALLOC_FUNC ALLOC_SIZE2(1, 2) void *curl_dbg_calloc(size_t elements,
      |                                                ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:60:33: error: redundant redeclaration of ‘curl_dbg_realloc’ [-Werror=redundant-decls]
   60 | CURL_EXTERN ALLOC_SIZE(2) void *curl_dbg_realloc(void *ptr,
      |                                 ^~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:60:33: note: previous declaration of ‘curl_dbg_realloc’ with type ‘void *(void *, size_t,  int,  const char *)’ {aka ‘void *(void *, long unsigned int,  int,  const char *)’}
   60 | CURL_EXTERN ALLOC_SIZE(2) void *curl_dbg_realloc(void *ptr,
      |                                 ^~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:64:18: error: redundant redeclaration of ‘curl_dbg_free’ [-Werror=redundant-decls]
   64 | CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
      |                  ^~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:64:18: note: previous declaration of ‘curl_dbg_free’ with type ‘void(void *, int,  const char *)’
   64 | CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
      |                  ^~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:65:30: error: redundant redeclaration of ‘curl_dbg_strdup’ [-Werror=redundant-decls]
   65 | CURL_EXTERN ALLOC_FUNC char *curl_dbg_strdup(const char *str, int line,
      |                              ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:65:30: note: previous declaration of ‘curl_dbg_strdup’ with type ‘char *(const char *, int,  const char *)’
   65 | CURL_EXTERN ALLOC_FUNC char *curl_dbg_strdup(const char *str, int line,
      |                              ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:73:18: error: redundant redeclaration of ‘curl_dbg_memdebug’ [-Werror=redundant-decls]
   73 | CURL_EXTERN void curl_dbg_memdebug(const char *logname);
      |                  ^~~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:73:18: note: previous declaration of ‘curl_dbg_memdebug’ with type ‘void(const char *)’
   73 | CURL_EXTERN void curl_dbg_memdebug(const char *logname);
      |                  ^~~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:74:18: error: redundant redeclaration of ‘curl_dbg_memlimit’ [-Werror=redundant-decls]
   74 | CURL_EXTERN void curl_dbg_memlimit(long limit);
      |                  ^~~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:74:18: note: previous declaration of ‘curl_dbg_memlimit’ with type ‘void(long int)’
   74 | CURL_EXTERN void curl_dbg_memlimit(long limit);
      |                  ^~~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:75:18: error: redundant redeclaration of ‘curl_dbg_log’ [-Werror=redundant-decls]
   75 | CURL_EXTERN void curl_dbg_log(const char *format, ...) CURL_PRINTF(1, 2);
      |                  ^~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:75:18: note: previous declaration of ‘curl_dbg_log’ with type ‘void(const char *, ...)’
   75 | CURL_EXTERN void curl_dbg_log(const char *format, ...) CURL_PRINTF(1, 2);
      |                  ^~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:78:27: error: redundant redeclaration of ‘curl_dbg_socket’ [-Werror=redundant-decls]
   78 | CURL_EXTERN curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
      |                           ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:78:27: note: previous declaration of ‘curl_dbg_socket’ with type ‘curl_socket_t(int,  int,  int,  int,  const char *)’ {aka ‘int(int,  int,  int,  int,  const char *)’}
   78 | CURL_EXTERN curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
      |                           ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:80:18: error: redundant redeclaration of ‘curl_dbg_mark_sclose’ [-Werror=redundant-decls]
   80 | CURL_EXTERN void curl_dbg_mark_sclose(curl_socket_t sockfd,
      |                  ^~~~~~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:80:18: note: previous declaration of ‘curl_dbg_mark_sclose’ with type ‘void(curl_socket_t,  int,  const char *)’ {aka ‘void(int,  int,  const char *)’}
   80 | CURL_EXTERN void curl_dbg_mark_sclose(curl_socket_t sockfd,
      |                  ^~~~~~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:82:17: error: redundant redeclaration of ‘curl_dbg_sclose’ [-Werror=redundant-decls]
   82 | CURL_EXTERN int curl_dbg_sclose(curl_socket_t sockfd,
      |                 ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:82:17: note: previous declaration of ‘curl_dbg_sclose’ with type ‘int(curl_socket_t,  int,  const char *)’ {aka ‘int(int,  int,  const char *)’}
   82 | CURL_EXTERN int curl_dbg_sclose(curl_socket_t sockfd,
      |                 ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:84:27: error: redundant redeclaration of ‘curl_dbg_accept’ [-Werror=redundant-decls]
   84 | CURL_EXTERN curl_socket_t curl_dbg_accept(curl_socket_t s, void *a, void *alen,
      |                           ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:84:27: note: previous declaration of ‘curl_dbg_accept’ with type ‘curl_socket_t(curl_socket_t,  void *, void *, int,  const char *)’ {aka ‘int(int,  void *, void *, int,  const char *)’}
   84 | CURL_EXTERN curl_socket_t curl_dbg_accept(curl_socket_t s, void *a, void *alen,
      |                           ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:87:17: error: redundant redeclaration of ‘curl_dbg_socketpair’ [-Werror=redundant-decls]
   87 | CURL_EXTERN int curl_dbg_socketpair(int domain, int type, int protocol,
      |                 ^~~~~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:87:17: note: previous declaration of ‘curl_dbg_socketpair’ with type ‘int(int,  int,  int,  curl_socket_t *, int,  const char *)’ {aka ‘int(int,  int,  int,  int *, int,  const char *)’}
   87 | CURL_EXTERN int curl_dbg_socketpair(int domain, int type, int protocol,
      |                 ^~~~~~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:93:28: error: redundant redeclaration of ‘curl_dbg_send’ [-Werror=redundant-decls]
   93 | CURL_EXTERN SEND_TYPE_RETV curl_dbg_send(SEND_TYPE_ARG1 sockfd,
      |                            ^~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:93:28: note: previous declaration of ‘curl_dbg_send’ with type ‘ssize_t(int,  const void *, size_t,  int,  int,  const char *)’ {aka ‘long int(int,  const void *, long unsigned int,  int,  int,  const char *)’}
   93 | CURL_EXTERN SEND_TYPE_RETV curl_dbg_send(SEND_TYPE_ARG1 sockfd,
      |                            ^~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:98:28: error: redundant redeclaration of ‘curl_dbg_recv’ [-Werror=redundant-decls]
   98 | CURL_EXTERN RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd,
      |                            ^~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:98:28: note: previous declaration of ‘curl_dbg_recv’ with type ‘ssize_t(int,  void *, size_t,  int,  int,  const char *)’ {aka ‘long int(int,  void *, long unsigned int,  int,  int,  const char *)’}
   98 | CURL_EXTERN RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd,
      |                            ^~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:105:30: error: redundant redeclaration of ‘curl_dbg_fopen’ [-Werror=redundant-decls]
  105 | CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fopen(const char *file, const char *mode,
      |                              ^~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:105:30: note: previous declaration of ‘curl_dbg_fopen’ with type ‘FILE *(const char *, const char *, int,  const char *)’
  105 | CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fopen(const char *file, const char *mode,
      |                              ^~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:107:30: error: redundant redeclaration of ‘curl_dbg_fdopen’ [-Werror=redundant-decls]
  107 | CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fdopen(int filedes, const char *mode,
      |                              ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:107:30: note: previous declaration of ‘curl_dbg_fdopen’ with type ‘FILE *(int,  const char *, int,  const char *)’
  107 | CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fdopen(int filedes, const char *mode,
      |                              ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:110:17: error: redundant redeclaration of ‘curl_dbg_fclose’ [-Werror=redundant-decls]
  110 | CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
      |                 ^~~~~~~~~~~~~~~
/home/runner/work/curl/curl/lib/memdebug.h:110:17: note: previous declaration of ‘curl_dbg_fclose’ with type ‘int(FILE *, int,  const char *)’
  110 | CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
      |                 ^~~~~~~~~~~~~~~
```
https://github.com/curl/curl/actions/runs/13822010778/job/38669360980#step:39:55
