### PR TITLE
resolve: fix building without Unix sockets and `CURLDEBUG`

### DIFF
--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -94,11 +94,13 @@ void restore_signal_handlers(bool keep_sigalrm);
 
 #include <curl/curl.h> /* for curl_socket_t */
 
+#ifdef USE_UNIX_SOCKETS
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h> /* for sockaddr_un */
 #endif
 int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
                      struct sockaddr_un *sau);
+#endif /* USE_UNIX_SOCKETS */
 
 unsigned short util_ultous(unsigned long ulnum);
 

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -92,14 +92,13 @@ extern HANDLE exit_event;
 void install_signal_handlers(bool keep_sigalrm);
 void restore_signal_handlers(bool keep_sigalrm);
 
-#ifdef USE_UNIX_SOCKETS
 #include <curl/curl.h> /* for curl_socket_t */
+
 #ifdef HAVE_SYS_UN_H
 #include <sys/un.h> /* for sockaddr_un */
 #endif
 int bind_unix_socket(curl_socket_t sock, const char *unix_socket,
                      struct sockaddr_un *sau);
-#endif /* USE_UNIX_SOCKETS */
 
 unsigned short util_ultous(unsigned long ulnum);
 


### PR DESCRIPTION
```
In file included from server_bundle.c:7:
../../../tests/server/resolve.c:110:5: error: unknown type name 'curl_socket_t'; did you mean 'curl_socklen_t'?
    curl_socket_t s = socket(PF_INET6, SOCK_DGRAM, 0);
    ^~~~~~~~~~~~~
    curl_socklen_t
../../../include/curl/system.h:392:38: note: 'curl_socklen_t' declared here
  typedef CURL_TYPEOF_CURL_SOCKLEN_T curl_socklen_t;
                                     ^
In file included from server_bundle.c:7:
../../../tests/server/resolve.c:111:13: error: use of undeclared identifier 'CURL_SOCKET_BAD'
    if(s == CURL_SOCKET_BAD)
            ^
```
Ref: https://github.com/curl/curl/actions/runs/13825438937/job/38679418428?pr=15000#step:14:47

Cherry-picked from #15000
