### PR TITLE
GHA: fix configure disable options

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -185,8 +185,9 @@ jobs:
               --with-openssl --enable-debug --disable-unity
               --disable-dict --disable-gopher --disable-ldap --disable-telnet
               --disable-imap --disable-pop3 --disable-smtp
-              --disable-rtmp --disable-rtsp
-              --disable-scp --disable-sftp --disable-tftp --disable-ftp --disable-file --disable-smb
+              --without-librtmp --disable-rtsp
+              --without-libssh2 --without-libssh --without-wolfssh
+              --disable-tftp --disable-ftp --disable-file --disable-smb
 
           - name: openssl torture !FTP
             install_packages: zlib1g-dev libnghttp2-dev libssh2-1-dev libc-ares-dev

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -94,10 +94,11 @@ jobs:
             configure: >-
               --enable-debug
               --disable-alt-svc --disable-dict --disable-file --disable-ftp --disable-gopher --disable-imap
-              --disable-ldap --disable-pop3 --disable-rtmp --disable-rtsp --disable-scp --disable-sftp
+              --disable-ldap --disable-pop3 --without-librtmp --disable-rtsp
               --disable-shared --disable-smb --disable-smtp --disable-telnet --disable-tftp --disable-unix-sockets
-              --without-brotli --without-gssapi --without-libidn2 --without-libpsl --without-librtmp --without-libssh2
-              --without-nghttp2 --without-ntlm-auth --without-ssl --without-zlib --without-zstd
+              --without-brotli --without-gssapi --without-libidn2 --without-libpsl --without-librtmp
+              --without-libssh2 --without-libssh --without-wolfssh
+              --without-nghttp2 --disable-ntlm --without-ssl --without-zlib --without-zstd
 
             macos-version-min: '10.15'  # Catalina (2019)
           - name: 'SecureTransport libssh2'


### PR DESCRIPTION
Linux AM openssl https-only:
```
configure: WARNING: unrecognized options: --disable-rtmp, --disable-scp, --disable-sftp
```
Ref: https://github.com/curl/curl/actions/runs/13823209634/job/38673119106#step:31:34

macOS AM clang !ssl HTTP-only:
```
configure: WARNING: unrecognized options: --disable-rtmp, --disable-scp, --disable-sftp, --without-ntlm-auth
```
Ref: https://github.com/curl/curl/actions/runs/13823209638/job/38673115560#step:7:54