### PR TITLE
GHA/windows: replace OpenSSH-Windows-Prelease job with standard openssh

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -745,7 +745,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            openssh: 'OpenSSH-Windows-Pre'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_LIBSSH2=ON


### PR DESCRIPTION
After restricting OpenSSH-Windows to a single job, and bumping it to
the pre-release version, that job started hanging then timing out with
reasonable consistency.

Since we saw similar hangs before with OpenSSH-Windows stable, in all
jobs, drop OpenSSH-Windows from CI, and replace it with MSYS openssh.

After this patch, all Windows jobs use MSYS2 or Cygwin openssh.

Follow-up to 0ec72c1ef8d87a29bf2eaa5e36ab173147a4d015 #16672
