### PR TITLE
lib: fix Curl_dyn_free() calls without init

### DIFF
--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -59,6 +59,7 @@ void Curl_dyn_init(struct dynbuf *s, size_t toobig)
 void Curl_dyn_free(struct dynbuf *s)
 {
   DEBUGASSERT(s);
+  DEBUGASSERT(s->init == DYNINIT);
   Curl_safefree(s->bufr);
   s->leng = s->allc = 0;
 }

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -126,7 +126,9 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
                                            host, header, neg_ctx);
 
 #if defined(USE_SSL) && defined(HAVE_GSSAPI)
-  Curl_dyn_free(&neg_ctx->channel_binding_data);
+  if(Curl_conn_is_ssl(conn, FIRSTSOCKET)) {
+    Curl_dyn_free(&neg_ctx->channel_binding_data);
+  }
 #endif
 
   if(result)

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1502,6 +1502,7 @@ static CURLcode imap_connect(struct Curl_easy *data, bool *done)
   Curl_sasl_init(&imapc->sasl, data, &saslimap);
 
   Curl_dyn_init(&imapc->dyn, DYN_IMAP_CMD);
+  imapc->dyninit = TRUE;
   Curl_pp_init(pp);
 
   /* Parse the URL options */
@@ -1705,7 +1706,8 @@ static CURLcode imap_disconnect(struct Curl_easy *data,
 
   /* Disconnect from the server */
   Curl_pp_disconnect(&imapc->pp);
-  Curl_dyn_free(&imapc->dyn);
+  if(imapc->dyninit)
+    Curl_dyn_free(&imapc->dyn);
 
   /* Cleanup the SASL module */
   Curl_sasl_cleanup(conn, imapc->sasl.authused);

--- a/lib/imap.h
+++ b/lib/imap.h
@@ -85,6 +85,7 @@ struct imap_conn {
   BIT(tls_supported);         /* StartTLS capability supported by server */
   BIT(login_disabled);        /* LOGIN command disabled by server */
   BIT(ir_supported);          /* Initial response supported by server */
+  BIT(dyninit);               /* the 'dyn' buf is inited */
 };
 
 extern const struct Curl_handler Curl_handler_imap;

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -856,6 +856,7 @@ static CURLcode choose_mech(struct Curl_easy *data, struct connectdata *conn)
       return CURLE_FAILED_INIT;
     }
     Curl_dyn_init(&conn->in_buffer.buf, CURL_MAX_INPUT_LENGTH);
+    conn->in_buffer.init = TRUE;
   }
 
   infof(data, "Trying mechanism %s...", mech->name);
@@ -921,7 +922,8 @@ Curl_sec_end(struct connectdata *conn)
   if(conn->mech && conn->mech->end)
     conn->mech->end(conn->app_data);
   Curl_safefree(conn->app_data);
-  Curl_dyn_free(&conn->in_buffer.buf);
+  if(conn->in_buffer.init)
+    Curl_dyn_free(&conn->in_buffer.buf);
   conn->in_buffer.index = 0;
   conn->in_buffer.eof_flag = 0;
   conn->sec_complete = 0;

--- a/lib/pingpong.c
+++ b/lib/pingpong.c
@@ -154,6 +154,7 @@ void Curl_pp_init(struct pingpong *pp)
   pp->nread_resp = 0;
   pp->response = Curl_now(); /* start response time-out now! */
   pp->pending_resp = TRUE;
+  pp->init = TRUE;
   Curl_dyn_init(&pp->sendbuf, DYN_PINGPPONG_CMD);
   Curl_dyn_init(&pp->recvbuf, DYN_PINGPPONG_CMD);
 }
@@ -450,8 +451,10 @@ CURLcode Curl_pp_flushsend(struct Curl_easy *data,
 
 CURLcode Curl_pp_disconnect(struct pingpong *pp)
 {
-  Curl_dyn_free(&pp->sendbuf);
-  Curl_dyn_free(&pp->recvbuf);
+  if(pp->init) {
+    Curl_dyn_free(&pp->sendbuf);
+    Curl_dyn_free(&pp->recvbuf);
+  }
   return CURLE_OK;
 }
 

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -70,6 +70,7 @@ struct pingpong {
   CURLcode (*statemachine)(struct Curl_easy *data, struct connectdata *conn);
   bool (*endofresp)(struct Curl_easy *data, struct connectdata *conn,
                     const char *ptr, size_t len, int *code);
+  BIT(init);
 };
 
 #define PINGPONG_SETUP(pp,s,e)                   \

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -249,6 +249,7 @@ struct krb5buffer {
   struct dynbuf buf;
   size_t index;
   BIT(eof_flag);
+  BIT(init);
 };
 
 enum protection_level {


### PR DESCRIPTION
This is currently harmless errors, but it is wrong to assume that it will always work.

See #16725