### PR TITLE
autotools: fix `dllmain.c` in unity builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -609,6 +609,7 @@ curl_cv_cygwin='no'
 case $host_os in
   cygwin*|msys*) curl_cv_cygwin='yes';;
 esac
+AM_CONDITIONAL(DOING_CYGWIN, test "x$curl_cv_cygwin" = xyes)
 
 AM_CONDITIONAL([HAVE_WINDRES],
   [test "$curl_cv_native_windows" = "yes" && test -n "${RC}"])

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -31,9 +31,6 @@ configure_file("curl_config.h.cmake" "${CMAKE_CURRENT_BINARY_DIR}/curl_config.h"
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-# DllMain is added later for DLL builds only.
-list(REMOVE_ITEM CSOURCES "dllmain.c")
-
 list(APPEND HHEADERS "${CMAKE_CURRENT_BINARY_DIR}/curl_config.h")
 
 # The rest of the build

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -175,7 +175,7 @@ endif
 TIDY := clang-tidy
 
 tidy:
-	(_csources=`echo ' $(CSOURCES)' | sed -e 's/ +/ /g' -e 's| | $(srcdir)/|g'`; \
+	(_csources=`echo ' $(CSOURCES)' | sed -E -e 's/ +$//' -e 's/ +/ /g' -e 's| | $(srcdir)/|g'`; \
 	$(TIDY) $$_csources $(TIDYFLAGS) $(CURL_CLANG_TIDYFLAGS) -- $(AM_CPPFLAGS) $(CPPFLAGS) -DHAVE_CONFIG_H)
 
 optiontable:

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -175,7 +175,7 @@ endif
 TIDY := clang-tidy
 
 tidy:
-	(_csources=`echo ' $(CSOURCES)' | sed -E -e 's/ +$//' -e 's/ +/ /g' -e 's| | $(srcdir)/|g'`; \
+	(_csources=`echo ' $(CSOURCES)' | sed -E -e 's/ +$$//' -e 's/ +/ /g' -e 's| | $(srcdir)/|g'`; \
 	$(TIDY) $$_csources $(TIDYFLAGS) $(CURL_CLANG_TIDYFLAGS) -- $(AM_CPPFLAGS) $(CPPFLAGS) -DHAVE_CONFIG_H)
 
 optiontable:

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -68,6 +68,14 @@ AM_CFLAGS =
 # Makefile.inc provides the CSOURCES and HHEADERS defines
 include Makefile.inc
 
+if DOING_NATIVE_WINDOWS
+CSOURCES += dllmain.c
+else
+if DOING_CYGWIN
+CSOURCES += dllmain.c
+endif
+endif
+
 if USE_UNITY
 # Keep these separate to avoid duplicate definitions when linking libtests
 # in static mode.
@@ -76,6 +84,11 @@ if DEBUGBUILD
 # We must compile these sources separately to avoid memdebug.h redefinitions
 # applying to them.
 curl_EXCLUDE += memdebug.c curl_multibyte.c
+endif
+# For Cygwin always compile dllmain.c as a separate unit since it
+# includes windows.h, which should not be included in other units.
+if DOING_CYGWIN
+curl_EXCLUDE += dllmain.c
 endif
 libcurl_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CSOURCES)
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl $(srcdir) $(CSOURCES) --exclude $(curl_EXCLUDE) > libcurl_unity.c

--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -146,7 +146,6 @@ LIB_CFILES =         \
   cw-out.c           \
   cw-pause.c         \
   dict.c             \
-  dllmain.c          \
   doh.c              \
   dynbuf.c           \
   dynhds.c           \


### PR DESCRIPTION
Sync it with cmake to:
- exclude it from all builds except Windows and Cygwin.
- exclude it from unity builds for Cygwin to avoid the included
  `windows.h` header interfere with the rest of the code.

Also:
- fix to trim ending spaces from `CSOURCES` for the `tidy` target.
  The solution requires a non-POSIX `-E` `sed` option. Supported by BSD
  and GNU implementations.
  Follow-up to 37523c91bc418fc734ee54f329677dc7123eb465 #16480

Follow-up to 60c3d0446546332e1645541f2dc2c072cd019fe9 #14815
Follow-up to 7860f575fe9e527ced66b31ec076914bbadd64a4 #12408