### PR TITLE
rustls: cap maximum allowed CRL file size to 8MB

### DIFF
--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -43,7 +43,7 @@ void Curl_dyn_init(struct dynbuf *s, size_t toobig)
 {
   DEBUGASSERT(s);
   DEBUGASSERT(toobig);
-  DEBUGASSERT(toobig < MAX_DYNBUF_SIZE); /* catch crazy mistakes */
+  DEBUGASSERT(toobig <= MAX_DYNBUF_SIZE); /* catch crazy mistakes */
   s->bufr = NULL;
   s->leng = 0;
   s->allc = 0;

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -43,6 +43,7 @@ void Curl_dyn_init(struct dynbuf *s, size_t toobig)
 {
   DEBUGASSERT(s);
   DEBUGASSERT(toobig);
+  DEBUGASSERT(toobig < MAX_DYNBUF_SIZE); /* catch crazy mistakes */
   s->bufr = NULL;
   s->leng = 0;
   s->allc = 0;

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -81,7 +81,7 @@ int Curl_dyn_vprintf(struct dynbuf *dyn, const char *format, va_list ap_save);
 char *Curl_dyn_take(struct dynbuf *s, size_t *plen);
 
 /* Dynamic buffer max sizes */
-#define MAX_DYNBUF_SIZE (100 * 1024 * 1024)
+#define MAX_DYNBUF_SIZE (SIZE_T_MAX/2)
 
 #define DYN_DOH_RESPONSE    3000
 #define DYN_DOH_CNAME       256

--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -81,6 +81,8 @@ int Curl_dyn_vprintf(struct dynbuf *dyn, const char *format, va_list ap_save);
 char *Curl_dyn_take(struct dynbuf *s, size_t *plen);
 
 /* Dynamic buffer max sizes */
+#define MAX_DYNBUF_SIZE (100 * 1024 * 1024)
+
 #define DYN_DOH_RESPONSE    3000
 #define DYN_DOH_CNAME       256
 #define DYN_PAUSE_BUFFER    (64 * 1024 * 1024)
@@ -95,4 +97,5 @@ char *Curl_dyn_take(struct dynbuf *s, size_t *plen);
 #define DYN_PINGPPONG_CMD   (64*1024)
 #define DYN_IMAP_CMD        (64*1024)
 #define DYN_MQTT_RECV       (64*1024)
+#define DYN_CRLFILE_SIZE    8000000
 #endif

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -708,7 +708,7 @@ cr_init_backend(struct Curl_cfilter *cf, struct Curl_easy *data,
 
     if(conn_config->CRLfile) {
       struct dynbuf crl_contents;
-      Curl_dyn_init(&crl_contents, SIZE_MAX);
+      Curl_dyn_init(&crl_contents, DYN_CRLFILE_SIZE);
       if(!read_file_into(conn_config->CRLfile, &crl_contents)) {
         failf(data, "rustls: failed to read revocation list file");
         Curl_dyn_free(&crl_contents);


### PR DESCRIPTION
Allowing 4GB on a 32-bit system is just asking for problems and could in theory cause integer overflow in the dynbuf code.

The dynbuf now has an assert to catch code trying to set a max larger than 100MB, as it seems large enough for most buffers.

Reported-by: Rinku Das