### PR TITLE
tests/server: give global `path` variable a more descriptive name

### DIFF
--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1086,7 +1086,7 @@ int main(int argc, char *argv[])
     else if(!strcmp("--srcdir", argv[arg])) {
       arg++;
       if(argc > arg) {
-        path = argv[arg];
+        srcpath = argv[arg];
         arg++;
       }
     }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2123,7 +2123,7 @@ int main(int argc, char *argv[])
     else if(!strcmp("--srcdir", argv[arg])) {
       arg++;
       if(argc > arg) {
-        path = argv[arg];
+        srcpath = argv[arg];
         arg++;
       }
     }

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -608,7 +608,7 @@ int main(int argc, char **argv)
     else if(!strcmp("--srcdir", argv[arg])) {
       arg++;
       if(argc > arg) {
-        path = argv[arg];
+        srcpath = argv[arg];
         arg++;
       }
     }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -229,7 +229,7 @@ const char *sstrerror(int err)
 #endif  /* _WIN32 */
 
 /* set by the main code to point to where the test dir is */
-const char *path = ".";
+const char *srcpath = ".";
 
 FILE *test2fopen(long testno, const char *logdir2)
 {
@@ -242,7 +242,7 @@ FILE *test2fopen(long testno, const char *logdir2)
     return stream;
 
   /* then try the source version */
-  msnprintf(filename, sizeof(filename), "%s/data/test%ld", path, testno);
+  msnprintf(filename, sizeof(filename), "%s/data/test%ld", srcpath, testno);
   stream = fopen(filename, "rb");
 
   return stream;

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -43,7 +43,7 @@ unsigned char byteval(char *value);
 #define SERVERLOGS_LOCKDIR "lock"  /* within logdir */
 
 /* global variables */
-extern const char *path;  /* where to find the 'data' dir */
+extern const char *srcpath;  /* where to find the 'data' dir */
 extern const char *pidname;
 extern const char *portname;
 extern const char *serverlogfile;  /* log file name */


### PR DESCRIPTION
Use a more descriptive global variable name in server code, also
to avoid colliding with this name used elsewhere in libcurl.

This isn't causing an issue at this time, but makes the code prone
to `-Wshadow` warnings in unity mode, if the global variable is
compiled first. This specific variable could collide with the `path`
argument of the `curlx_win32_stat()` function.

---

```
lib/curl_multibyte.c:317:34: error: declaration of 'path' shadows a global declaration [-Werror=shadow]
  317 | int curlx_win32_stat(const char *path, struct_stat *buffer)
      |                      ~~~~~~~~~~~~^~~~
In file included from tests/server/resolve.c:47,
                 from bld/tests/server/server_bundle.c:7,
                 from bld/tests/server/CMakeFiles/servers.dir/Unity/unity_0_c.c:4:
tests/server/util.h:64:20: note: shadowed declaration is here
   64 | extern const char *path;  /* where to find the 'data' dir */
      |                    ^~~~
```

Seen in these CI jobs while doing tests:
```
AppVeyor / CMake, VS2022, Release, x64, Schannel, Shared, Unicode, DEBUGBUILD, no-CURLDEBUG, Build-tests
Windows / linux-mingw, CM gcc
Windows / mingw, CM i686 schannel R
Windows / mingw, CM ucrt-x86_64 schannel uwp
Windows / msvc, CM x64-windows boringssl
```

https://github.com/curl/curl/actions/runs/13845123447/job/38741731971?pr=15000
https://ci.appveyor.com/project/curlorg/curl/builds/51693340
