### PR TITLE
libtest/lib2311: remove "extra" fclose()

### DIFF
--- a/tests/libtest/lib2311.c
+++ b/tests/libtest/lib2311.c
@@ -56,7 +56,6 @@ static void websocket_frame(CURL *curl, FILE *save, int expected_flags)
       if(result == CURLE_AGAIN)
         /* crude busy-loop */
         continue;
-      fclose(save);
       printf("curl_ws_recv returned %d\n", result);
       return;
     }


### PR DESCRIPTION
Follow-up to 3588df9478d7c27046b34cdb5

Fixes #16721
Reported-by: Viktor Szakats