### PR TITLE
autotools: use `CURLDEBUG` to exclude TrackMemory code from unity

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -86,7 +86,7 @@ if USE_UNITY
 # Keep these separate to avoid duplicate definitions when linking libtests
 # in static mode.
 curl_EXCLUDE = curl_threads.c timediff.c warnless.c
-if DEBUGBUILD
+if CURLDEBUG
 # We must compile these sources separately to avoid memdebug.h redefinitions
 # applying to them.
 curl_EXCLUDE += memdebug.c curl_multibyte.c

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,7 +71,7 @@ CLEANFILES =
 
 if USE_UNITY
 curl_EXCLUDE =
-if DEBUGBUILD
+if CURLDEBUG
 # We must compile this source separately to avoid memdebug.h redefinitions
 # applying to them.
 curl_EXCLUDE += ../lib/curl_multibyte.c


### PR DESCRIPTION
Before this patch, autotools builds excluded TrackMemory sources
(`lib/memdebug.c` and `lib/curl_multibyte.c`) based on the `DEBUGBUILD`
setting. This works in most cases because its value is the same as
`CURLDEBUG` by default, but the correct condition is `CURLDEBUG`.

It should fix `--disable-debug --enable-curldebug --enable-unity`
builds. (not tested in CI)

It also syncs behavior with cmake builds.

Ref: #16705

---

- [x] rebase on #16705
