### PR TITLE
dynbuf: bump the max CRLFILE size to 400MB

### DIFF
--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -97,5 +97,5 @@ char *Curl_dyn_take(struct dynbuf *s, size_t *plen);
 #define DYN_PINGPPONG_CMD   (64*1024)
 #define DYN_IMAP_CMD        (64*1024)
 #define DYN_MQTT_RECV       (64*1024)
-#define DYN_CRLFILE_SIZE    8000000
+#define DYN_CRLFILE_SIZE    (400*1024*1024) /* 400mb */
 #endif


### PR DESCRIPTION
Ref: https://github.com/curl/curl/pull/16716#issuecomment-2724429278

> I have some tooling leftover from when I was implementing CRL support
> in the webpki crate that downloaded every CRL I could find referenced
> in ccadb (without doing any special filtering for defunct CAs/CRLs
> mind you) and found CRLs that spanned the range from very small
> (<1mb), to medium sized (11 .. 22mb) to very large (100mb).

Reported-by: Daniel McCarney