### PR TITLE
http: remove the space requirement after status-code

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3910,9 +3910,9 @@ static CURLcode http_rw_hd(struct Curl_easy *data,
               if(ISDIGIT(p[0]) && ISDIGIT(p[1]) && ISDIGIT(p[2])) {
                 k->httpcode = (p[0] - '0') * 100 + (p[1] - '0') * 10 +
                   (p[2] - '0');
-                p += 3;
-                if(ISBLANK(*p))
-                  fine_statusline = TRUE;
+                /* RFC 9112 requires a single space following the status code,
+                   but the browsers don't so let's not insist */
+                fine_statusline = TRUE;
               }
             }
           }

--- a/tests/data/test2
+++ b/tests/data/test2
@@ -9,8 +9,8 @@ HTTP Basic auth
 #
 # Server-side
 <reply>
-<data>
-HTTP/1.1 200 OK
+<data crlf="yes">
+HTTP/1.1 200
 Date: Tue, 09 Nov 2010 14:49:00 GMT
 Server: test-server/fake swsclose
 Content-Type: text/html


### PR DESCRIPTION
It was introduced in 294136b75411893c5, but not shipped in a release. It has caused problems and after checking, the browsers don't insist on it even if RFC 9112 says it is mandatory.

Adjust test 2 to do a response without the space.