### PR TITLE
GHA/non-native: drop building docs with autotools on emulated CPU

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -146,11 +146,15 @@ jobs:
               pkgconf brotli openldap26-client libidn2 libnghttp2 stunnel py311-impacket
             time autoreconf -fi
             export CC='${{ matrix.compiler }}'
+            if [ '${{ matrix.arch }}' != 'x86_64' ]; then
+              options='--disable-manual --disable-docs'  # Save time on emulated CPU
+            fi
             mkdir bld && cd bld && time ../configure --enable-unity --enable-test-bundles --enable-debug --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
               --with-openssl \
               --with-brotli --enable-ldap --enable-ldaps --with-libidn2 --with-libssh2 --with-nghttp2 --with-gssapi \
               --disable-dependency-tracking \
+              ${options} \
               ${{ matrix.options }} \
               || { tail -n 1000 config.log; false; }
             echo '::group::curl_config.h (raw)'; cat lib/curl_config.h || true; echo '::endgroup::'
@@ -181,6 +185,9 @@ jobs:
             # https://ports.freebsd.org/
             time sudo pkg install -y cmake-core ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2 stunnel py311-impacket
+            if [ '${{ matrix.arch }}' != 'x86_64' ]; then
+              options='-DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF'  # Save time on emulated CPU
+            fi
             time cmake -B bld -G Ninja \
               -DCMAKE_C_COMPILER='${{ matrix.compiler }}' \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
@@ -188,6 +195,7 @@ jobs:
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_USE_GSSAPI=ON \
+              ${options} \
               ${{ matrix.options }} \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -147,7 +147,7 @@ jobs:
             time autoreconf -fi
             export CC='${{ matrix.compiler }}'
             if [ '${{ matrix.arch }}' != 'x86_64' ]; then
-              options='--disable-manual --disable-docs'  # Save time on emulated CPU
+              options='--disable-manual --disable-docs'  # Slow with autotools, skip on emulated CPU
             fi
             mkdir bld && cd bld && time ../configure --enable-unity --enable-test-bundles --enable-debug --enable-warnings --enable-werror \
               --prefix="${HOME}"/install \
@@ -185,9 +185,6 @@ jobs:
             # https://ports.freebsd.org/
             time sudo pkg install -y cmake-core ninja perl5 \
               pkgconf brotli openldap26-client libidn2 libnghttp2 stunnel py311-impacket
-            if [ '${{ matrix.arch }}' != 'x86_64' ]; then
-              options='-DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF'  # Save time on emulated CPU
-            fi
             time cmake -B bld -G Ninja \
               -DCMAKE_C_COMPILER='${{ matrix.compiler }}' \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
@@ -195,7 +192,6 @@ jobs:
               -DENABLE_DEBUG=ON -DCMAKE_BUILD_TYPE=Debug \
               -DCURL_USE_OPENSSL=ON \
               -DCURL_USE_GSSAPI=ON \
-              ${options} \
               ${{ matrix.options }} \
               || { cat bld/CMakeFiles/CMake*.yaml; false; }
             echo '::group::curl_config.h (raw)'; cat bld/lib/curl_config.h || true; echo '::endgroup::'


### PR DESCRIPTION
It saves about 1 minute (10%) per run.
Also reduces log length from 3800 to 2800 lines.

Keep building docs on native CPU.
