### PR TITLE
asyn-thread: drop `free()` on non-heap address

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -444,7 +444,6 @@ static bool init_resolve_thread(struct Curl_easy *data,
   td->start = Curl_now();
 
   if(!init_thread_sync_data(td, hostname, port, hints)) {
-    free(td);
     goto errno_exit;
   }
 


### PR DESCRIPTION
seen with mingw-w64 gcc 14.2.0 while playing with other modifications:
```
lib/asyn-thread.c: In function 'init_resolve_thread':
lib/asyn-thread.c:447:5: warning: 'free' called on pointer 'data' with nonzero offset 3264 [-Wfree-nonheap-object]
  447 |     free(td);
      |     ^~~~~~~~
```

Where `td` is:
```c
  struct thread_data *td = &data->state.async.thdata;
```

Follow-up to d9fc64d3ab289a84548e952183d7eba79ccc846e #16241
