### PR TITLE
GHA/windows: unignore 2310, disable SCP/FTP for vcpkg `libssh2[core]`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -932,7 +932,6 @@ jobs:
         run: |
           export CURL_DIRSUFFIX='${{ matrix.type }}'
           export TFLAGS='-j8 ${{ matrix.tflags }}'
-          TFLAGS+=' ~2310'  # flaky 'WebSockets unknown reserved bit set in frame header', WebSockets
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SCP ~SFTP'  # Fail with all tested openssh servers: curl: (67) Authentication failure
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -933,7 +933,7 @@ jobs:
           export CURL_DIRSUFFIX='${{ matrix.type }}'
           export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
-            TFLAGS+=' ~SCP ~SFTP'  # Fail with all tested openssh servers: curl: (67) Authentication failure
+            TFLAGS+=' !SCP !SFTP'  # Fail with all tested openssh servers: curl: (67) Authentication failure
           fi
           TFLAGS+=' ~612'  # 'SFTP post-quote remove file' SFTP, post-quote
           if [ '${{ matrix.openssh }}' = '' ]; then  # MSYS2 openssh


### PR DESCRIPTION
Skipping these tests saves time and reduces test logs from 11500 lines
to 3800.

Tests are permanently broken due to `curl: (67) Authentication failure`.
This libssh2 is built with WinCNG. Builds using libcrypto from OpenSSL
work fine.

---

- [x] Maybe ignore flaky 498 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET?
  https://github.com/curl/curl/discussions/14854#discussioncomment-12503065 [→ NEXT TIME]
