### PR TITLE
memdebug: set gcc 11+ deallocator attribute, extend alloc attributes to clang

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -444,7 +444,6 @@ static bool init_resolve_thread(struct Curl_easy *data,
   td->start = Curl_now();
 
   if(!init_thread_sync_data(td, hostname, port, hints)) {
-    free(td);
     goto errno_exit;
   }
 

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -444,6 +444,7 @@ static bool init_resolve_thread(struct Curl_easy *data,
   td->start = Curl_now();
 
   if(!init_thread_sync_data(td, hostname, port, hints)) {
+    free(td);
     goto errno_exit;
   }
 

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -128,8 +128,8 @@ static bool countcheck(const char *func, int line, const char *source)
   return FALSE; /* allow this */
 }
 
-ALLOC_FUNC void *curl_dbg_malloc(size_t wantedsize,
-                                 int line, const char *source)
+ALLOC_FUNC(curl_dbg_free)
+void *curl_dbg_malloc(size_t wantedsize, int line, const char *source)
 {
   struct memdebug *mem;
   size_t size;
@@ -155,8 +155,9 @@ ALLOC_FUNC void *curl_dbg_malloc(size_t wantedsize,
   return mem ? mem->mem : NULL;
 }
 
-ALLOC_FUNC void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
-                                 int line, const char *source)
+ALLOC_FUNC(curl_dbg_free)
+void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
+                      int line, const char *source)
 {
   struct memdebug *mem;
   size_t size, user_size;
@@ -183,8 +184,8 @@ ALLOC_FUNC void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
   return mem ? mem->mem : NULL;
 }
 
-ALLOC_FUNC char *curl_dbg_strdup(const char *str,
-                                 int line, const char *source)
+ALLOC_FUNC(curl_dbg_free)
+char *curl_dbg_strdup(const char *str, int line, const char *source)
 {
   char *mem;
   size_t len;
@@ -208,8 +209,8 @@ ALLOC_FUNC char *curl_dbg_strdup(const char *str,
 }
 
 #if defined(_WIN32) && defined(UNICODE)
-ALLOC_FUNC wchar_t *curl_dbg_wcsdup(const wchar_t *str,
-                                    int line, const char *source)
+ALLOC_FUNC(curl_dbg_free)
+wchar_t *curl_dbg_wcsdup(const wchar_t *str, int line, const char *source)
 {
   wchar_t *mem;
   size_t wsiz, bsiz;
@@ -237,7 +238,7 @@ ALLOC_FUNC wchar_t *curl_dbg_wcsdup(const wchar_t *str,
 /* We provide a realloc() that accepts a NULL as pointer, which then
    performs a malloc(). In order to work with ares. */
 void *curl_dbg_realloc(void *ptr, size_t wantedsize,
-                      int line, const char *source)
+                       int line, const char *source)
 {
   struct memdebug *mem = NULL;
 
@@ -393,8 +394,9 @@ int curl_dbg_sclose(curl_socket_t sockfd, int line, const char *source)
   return res;
 }
 
-ALLOC_FUNC FILE *curl_dbg_fopen(const char *file, const char *mode,
-                                int line, const char *source)
+ALLOC_FUNC(curl_dbg_fclose)
+FILE *curl_dbg_fopen(const char *file, const char *mode,
+                     int line, const char *source)
 {
   FILE *res = fopen(file, mode);
 
@@ -405,8 +407,9 @@ ALLOC_FUNC FILE *curl_dbg_fopen(const char *file, const char *mode,
   return res;
 }
 
-ALLOC_FUNC FILE *curl_dbg_fdopen(int filedes, const char *mode,
-                                 int line, const char *source)
+ALLOC_FUNC(curl_dbg_fclose)
+FILE *curl_dbg_fdopen(int filedes, const char *mode,
+                      int line, const char *source)
 {
   FILE *res = fdopen(filedes, mode);
   if(source)

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -34,15 +34,19 @@
 #include "functypes.h"
 
 #if defined(__GNUC__) && __GNUC__ >= 3
-#  define ALLOC_FUNC __attribute__((__malloc__))
-#  define ALLOC_SIZE(s) __attribute__((__alloc_size__(s)))
-#  define ALLOC_SIZE2(n, s) __attribute__((__alloc_size__(n, s)))
+#  if __GNUC__ >= 11
+#    define ALLOC_FUNC(ff)   __attribute__((__malloc__(ff)))
+#  else
+#    define ALLOC_FUNC(ff)   __attribute__((__malloc__))
+#  endif
+#  define ALLOC_SIZE(s)      __attribute__((__alloc_size__(s)))
+#  define ALLOC_SIZE2(n, s)  __attribute__((__alloc_size__(n, s)))
 #elif defined(_MSC_VER)
-#  define ALLOC_FUNC __declspec(restrict)
+#  define ALLOC_FUNC(ff)     __declspec(restrict)
 #  define ALLOC_SIZE(s)
 #  define ALLOC_SIZE2(n, s)
 #else
-#  define ALLOC_FUNC
+#  define ALLOC_FUNC(ff)
 #  define ALLOC_SIZE(s)
 #  define ALLOC_SIZE2(n, s)
 #endif

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -64,10 +64,8 @@ CURL_EXTERN ALLOC_FUNC(curl_dbg_free) ALLOC_SIZE(1)
   void *curl_dbg_malloc(size_t size, int line, const char *source);
 CURL_EXTERN ALLOC_FUNC(curl_dbg_free) ALLOC_SIZE2(1, 2)
   void *curl_dbg_calloc(size_t n, size_t size, int line, const char *source);
-CURL_EXTERN ALLOC_SIZE(2) void *curl_dbg_realloc(void *ptr,
-                                                 size_t size,
-                                                 int line,
-                                                 const char *source);
+CURL_EXTERN ALLOC_SIZE(2)
+  void *curl_dbg_realloc(void *ptr, size_t size, int line, const char *source);
 CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
 CURL_EXTERN ALLOC_FUNC(curl_dbg_free)
   char *curl_dbg_strdup(const char *str, int line, const char *src);

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -33,11 +33,20 @@
 #include <curl/curl.h>
 #include "functypes.h"
 
-#if defined(__GNUC__) && __GNUC__ >= 3
-#  if __GNUC__ >= 11
-#    define ALLOC_FUNC(ff)   __attribute__((__malloc__(ff)))
+#ifdef __clang__
+#  define ALLOC_FUNC(ff)     __attribute__((__malloc__))
+#  if __clang_major__ >= 4
+#  define ALLOC_SIZE(s)      __attribute__((__alloc_size__(s)))
+#  define ALLOC_SIZE2(n, s)  __attribute__((__alloc_size__(n, s)))
 #  else
-#    define ALLOC_FUNC(ff)   __attribute__((__malloc__))
+#  define ALLOC_SIZE(s)
+#  define ALLOC_SIZE2(n, s)
+#  endif
+#elif defined(__GNUC__) && __GNUC__ >= 3
+#  if __GNUC__ >= 11
+#  define ALLOC_FUNC(ff)     __attribute__((__malloc__(ff)))
+#  else
+#  define ALLOC_FUNC(ff)     __attribute__((__malloc__))
 #  endif
 #  define ALLOC_SIZE(s)      __attribute__((__alloc_size__(s)))
 #  define ALLOC_SIZE2(n, s)  __attribute__((__alloc_size__(n, s)))

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -60,22 +60,20 @@
 extern FILE *curl_dbg_logfile;
 
 /* memory functions */
-CURL_EXTERN ALLOC_FUNC ALLOC_SIZE(1) void *curl_dbg_malloc(size_t size,
-                                                           int line,
-                                                           const char *source);
-CURL_EXTERN ALLOC_FUNC ALLOC_SIZE2(1, 2) void *curl_dbg_calloc(size_t elements,
-                                   size_t size, int line, const char *source);
+CURL_EXTERN ALLOC_FUNC(curl_dbg_free) ALLOC_SIZE(1)
+  void *curl_dbg_malloc(size_t size, int line, const char *source);
+CURL_EXTERN ALLOC_FUNC(curl_dbg_free) ALLOC_SIZE2(1, 2)
+  void *curl_dbg_calloc(size_t n, size_t size, int line, const char *source);
 CURL_EXTERN ALLOC_SIZE(2) void *curl_dbg_realloc(void *ptr,
                                                  size_t size,
                                                  int line,
                                                  const char *source);
 CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
-CURL_EXTERN ALLOC_FUNC char *curl_dbg_strdup(const char *str, int line,
-                                             const char *src);
+CURL_EXTERN ALLOC_FUNC(curl_dbg_free)
+  char *curl_dbg_strdup(const char *str, int line, const char *src);
 #if defined(_WIN32) && defined(UNICODE)
-CURL_EXTERN ALLOC_FUNC wchar_t *curl_dbg_wcsdup(const wchar_t *str,
-                                                int line,
-                                                const char *source);
+CURL_EXTERN ALLOC_FUNC(curl_dbg_free)
+  wchar_t *curl_dbg_wcsdup(const wchar_t *str, int line, const char *source);
 #endif
 
 CURL_EXTERN void curl_dbg_memdebug(const char *logname);
@@ -110,10 +108,12 @@ CURL_EXTERN RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd,
                                          const char *source);
 
 /* FILE functions */
-CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fopen(const char *file, const char *mode,
-                                  int line, const char *source);
-CURL_EXTERN ALLOC_FUNC FILE *curl_dbg_fdopen(int filedes, const char *mode,
-                                             int line, const char *source);
+CURL_EXTERN ALLOC_FUNC(curl_dbg_fclose)
+  FILE *curl_dbg_fopen(const char *file, const char *mode,
+                       int line, const char *source);
+CURL_EXTERN ALLOC_FUNC(curl_dbg_fclose)
+  FILE *curl_dbg_fdopen(int filedes, const char *mode,
+                        int line, const char *source);
 
 CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
 #endif /* HEADER_CURL_MEMDEBUG_H_EXTERNS */

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -60,13 +60,13 @@
 extern FILE *curl_dbg_logfile;
 
 /* memory functions */
+CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
 CURL_EXTERN ALLOC_FUNC(curl_dbg_free) ALLOC_SIZE(1)
   void *curl_dbg_malloc(size_t size, int line, const char *source);
 CURL_EXTERN ALLOC_FUNC(curl_dbg_free) ALLOC_SIZE2(1, 2)
   void *curl_dbg_calloc(size_t n, size_t size, int line, const char *source);
 CURL_EXTERN ALLOC_SIZE(2)
   void *curl_dbg_realloc(void *ptr, size_t size, int line, const char *source);
-CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
 CURL_EXTERN ALLOC_FUNC(curl_dbg_free)
   char *curl_dbg_strdup(const char *str, int line, const char *src);
 #if defined(_WIN32) && defined(UNICODE)
@@ -106,6 +106,7 @@ CURL_EXTERN RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd,
                                          const char *source);
 
 /* FILE functions */
+CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
 CURL_EXTERN ALLOC_FUNC(curl_dbg_fclose)
   FILE *curl_dbg_fopen(const char *file, const char *mode,
                        int line, const char *source);
@@ -113,7 +114,6 @@ CURL_EXTERN ALLOC_FUNC(curl_dbg_fclose)
   FILE *curl_dbg_fdopen(int filedes, const char *mode,
                         int line, const char *source);
 
-CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
 #endif /* HEADER_CURL_MEMDEBUG_H_EXTERNS */
 
 #ifndef MEMDEBUG_NODEFINES


### PR DESCRIPTION
To make `-Wfree-nonheap-object` and `-Wmismatched-dealloc` work in
`CURLDEBUG` builds.

Also extend `ALLOC_FUNC` and `ALLOC_SIZE` attribute support
to llvm/clang.

llvm/clang is missing the deallocator attribute, tracked here:
https://github.com/llvm/llvm-project/issues/129068

Ref: https://gcc.gnu.org/onlinedocs/gcc-11.1.0/gcc/Common-Function-Attributes.html#Common-Function-Attributes
Ref: https://www.gnu.org/software/gcc/gcc-11/changes.html
Ref: 6b143d9cc13fcd208480f678dfd06bf97bde4998 #16734

---

w/o ws https://github.com/curl/curl/pull/16737/files?w=1
