### PR TITLE
memdebug: revert setting gcc 11+ deallocator attribute

### DIFF
--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -128,7 +128,7 @@ static bool countcheck(const char *func, int line, const char *source)
   return FALSE; /* allow this */
 }
 
-ALLOC_FUNC(curl_dbg_free)
+ALLOC_FUNC
 void *curl_dbg_malloc(size_t wantedsize, int line, const char *source)
 {
   struct memdebug *mem;
@@ -155,7 +155,7 @@ void *curl_dbg_malloc(size_t wantedsize, int line, const char *source)
   return mem ? mem->mem : NULL;
 }
 
-ALLOC_FUNC(curl_dbg_free)
+ALLOC_FUNC
 void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
                       int line, const char *source)
 {
@@ -184,7 +184,7 @@ void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
   return mem ? mem->mem : NULL;
 }
 
-ALLOC_FUNC(curl_dbg_free)
+ALLOC_FUNC
 char *curl_dbg_strdup(const char *str, int line, const char *source)
 {
   char *mem;
@@ -209,7 +209,7 @@ char *curl_dbg_strdup(const char *str, int line, const char *source)
 }
 
 #if defined(_WIN32) && defined(UNICODE)
-ALLOC_FUNC(curl_dbg_free)
+ALLOC_FUNC
 wchar_t *curl_dbg_wcsdup(const wchar_t *str, int line, const char *source)
 {
   wchar_t *mem;
@@ -394,7 +394,7 @@ int curl_dbg_sclose(curl_socket_t sockfd, int line, const char *source)
   return res;
 }
 
-ALLOC_FUNC(curl_dbg_fclose)
+ALLOC_FUNC
 FILE *curl_dbg_fopen(const char *file, const char *mode,
                      int line, const char *source)
 {
@@ -407,7 +407,7 @@ FILE *curl_dbg_fopen(const char *file, const char *mode,
   return res;
 }
 
-ALLOC_FUNC(curl_dbg_fclose)
+ALLOC_FUNC
 FILE *curl_dbg_fdopen(int filedes, const char *mode,
                       int line, const char *source)
 {

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -34,7 +34,7 @@
 #include "functypes.h"
 
 #ifdef __clang__
-#  define ALLOC_FUNC(ff)     __attribute__((__malloc__))
+#  define ALLOC_FUNC         __attribute__((__malloc__))
 #  if __clang_major__ >= 4
 #  define ALLOC_SIZE(s)      __attribute__((__alloc_size__(s)))
 #  define ALLOC_SIZE2(n, s)  __attribute__((__alloc_size__(n, s)))
@@ -43,19 +43,15 @@
 #  define ALLOC_SIZE2(n, s)
 #  endif
 #elif defined(__GNUC__) && __GNUC__ >= 3
-#  if __GNUC__ >= 11
-#  define ALLOC_FUNC(ff)     __attribute__((__malloc__(ff)))
-#  else
-#  define ALLOC_FUNC(ff)     __attribute__((__malloc__))
-#  endif
+#  define ALLOC_FUNC         __attribute__((__malloc__))
 #  define ALLOC_SIZE(s)      __attribute__((__alloc_size__(s)))
 #  define ALLOC_SIZE2(n, s)  __attribute__((__alloc_size__(n, s)))
 #elif defined(_MSC_VER)
-#  define ALLOC_FUNC(ff)     __declspec(restrict)
+#  define ALLOC_FUNC         __declspec(restrict)
 #  define ALLOC_SIZE(s)
 #  define ALLOC_SIZE2(n, s)
 #else
-#  define ALLOC_FUNC(ff)
+#  define ALLOC_FUNC
 #  define ALLOC_SIZE(s)
 #  define ALLOC_SIZE2(n, s)
 #endif
@@ -70,16 +66,16 @@ extern FILE *curl_dbg_logfile;
 
 /* memory functions */
 CURL_EXTERN void curl_dbg_free(void *ptr, int line, const char *source);
-CURL_EXTERN ALLOC_FUNC(curl_dbg_free) ALLOC_SIZE(1)
+CURL_EXTERN ALLOC_FUNC ALLOC_SIZE(1)
   void *curl_dbg_malloc(size_t size, int line, const char *source);
-CURL_EXTERN ALLOC_FUNC(curl_dbg_free) ALLOC_SIZE2(1, 2)
+CURL_EXTERN ALLOC_FUNC ALLOC_SIZE2(1, 2)
   void *curl_dbg_calloc(size_t n, size_t size, int line, const char *source);
 CURL_EXTERN ALLOC_SIZE(2)
   void *curl_dbg_realloc(void *ptr, size_t size, int line, const char *source);
-CURL_EXTERN ALLOC_FUNC(curl_dbg_free)
+CURL_EXTERN ALLOC_FUNC
   char *curl_dbg_strdup(const char *str, int line, const char *src);
 #if defined(_WIN32) && defined(UNICODE)
-CURL_EXTERN ALLOC_FUNC(curl_dbg_free)
+CURL_EXTERN ALLOC_FUNC
   wchar_t *curl_dbg_wcsdup(const wchar_t *str, int line, const char *source);
 #endif
 
@@ -116,10 +112,10 @@ CURL_EXTERN RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd,
 
 /* FILE functions */
 CURL_EXTERN int curl_dbg_fclose(FILE *file, int line, const char *source);
-CURL_EXTERN ALLOC_FUNC(curl_dbg_fclose)
+CURL_EXTERN ALLOC_FUNC
   FILE *curl_dbg_fopen(const char *file, const char *mode,
                        int line, const char *source);
-CURL_EXTERN ALLOC_FUNC(curl_dbg_fclose)
+CURL_EXTERN ALLOC_FUNC
   FILE *curl_dbg_fdopen(int filedes, const char *mode,
                         int line, const char *source);
 


### PR DESCRIPTION
These attributes were causing unexplained warnings while playing with
PR #16738: In `CURLDEBUG` builds with mingw, gcc (14.2.0), and `-O3`,
while building `libcurlu`. `-O3` is required. May be related to having
the `CURLDEBUG` allocators in the same source file as their callers
(unity mode). PR #16738 moves `memdebug.c` into the main unity unit.
Unclear why it doesn't affect `libcurl`.

E.g. CI job `mingw, CM ucrt-x86_64 schannel R TrackMemory` CI job:
https://github.com/curl/curl/actions/runs/13888662354/job/38856868429

It also reproduces in an isolated example.

Drop this attribute till we learn more about it.

Ref: https://github.com/curl/curl/pull/16737#issuecomment-2727681306
Partial revert of d5b403074ed2b28e41e0c17dcd436252d38adfa3 #16737
