### PR TITLE
[TEST] cmake: drop unity batch exception for libcurlu

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -53,9 +53,6 @@ if(CURL_BUILD_TESTING)
   )
   target_compile_definitions(curlu PUBLIC "UNITTESTS" "CURL_STATICLIB")
   target_link_libraries(curlu PRIVATE ${CURL_LIBS})
-  # There is plenty of parallelism when building the testdeps target.
-  # Override the curlu batch size with the maximum to optimize performance.
-  set_target_properties(curlu PROPERTIES UNITY_BUILD_BATCH_SIZE 0)
 endif()
 
 if(ENABLE_CURLDEBUG)


### PR DESCRIPTION
Follow-up to 29e4eda631f46368c2adf833ba3065b1b46c2a7d #16272