### PR TITLE
memdebug: avoid macro overrides for low-level allocator functions

### DIFF
--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -57,7 +57,6 @@
 #ifdef HEADER_CURL_MEMDEBUG_H
 /* cleanup after memdebug.h */
 
-#ifdef MEMDEBUG_NODEFINES
 #ifdef CURLDEBUG
 
 #undef strdup
@@ -90,7 +89,6 @@
 #undef fdopen
 #undef fclose
 
-#endif /* MEMDEBUG_NODEFINES */
 #endif /* CURLDEBUG */
 
 #undef HEADER_CURL_MEMDEBUG_H

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -197,15 +197,15 @@ struct timeval {
  */
 
 #ifdef HAVE_CLOSESOCKET
-#  define sclose(x)  closesocket((x))
+#  define CURL_SCLOSE(x)  closesocket((x))
 #elif defined(HAVE_CLOSESOCKET_CAMEL)
-#  define sclose(x)  CloseSocket((x))
+#  define CURL_SCLOSE(x)  CloseSocket((x))
 #elif defined(MSDOS)  /* Watt-32 */
-#  define sclose(x)  close_s((x))
+#  define CURL_SCLOSE(x)  close_s((x))
 #elif defined(USE_LWIPSOCK)
-#  define sclose(x)  lwip_close((x))
+#  define CURL_SCLOSE(x)  lwip_close((x))
 #else
-#  define sclose(x)  close((x))
+#  define CURL_SCLOSE(x)  close((x))
 #endif
 
 /*

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -30,8 +30,6 @@
 
 #include "urldata.h"
 
-#define MEMDEBUG_NODEFINES /* do not redefine the standard functions */
-
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -70,7 +70,7 @@ static void curl_dbg_cleanup(void)
   if(curl_dbg_logfile &&
      curl_dbg_logfile != stderr &&
      curl_dbg_logfile != stdout) {
-    fclose(curl_dbg_logfile);
+    (fclose)(curl_dbg_logfile);
   }
   curl_dbg_logfile = NULL;
 }
@@ -80,7 +80,7 @@ void curl_dbg_memdebug(const char *logname)
 {
   if(!curl_dbg_logfile) {
     if(logname && *logname)
-      curl_dbg_logfile = fopen(logname, FOPEN_WRITETEXT);
+      curl_dbg_logfile = (fopen)(logname, FOPEN_WRITETEXT);
     else
       curl_dbg_logfile = stderr;
 #ifdef MEMDEBUG_LOG_SYNC
@@ -309,7 +309,7 @@ curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
   if(countcheck("socket", line, source))
     return CURL_SOCKET_BAD;
 
-  sockfd = socket(domain, type, protocol);
+  sockfd = (socket)(domain, type, protocol);
 
   if(source && (sockfd != CURL_SOCKET_BAD))
     curl_dbg_log("FD %s:%d socket() = %" FMT_SOCKET_T "\n",
@@ -326,7 +326,7 @@ SEND_TYPE_RETV curl_dbg_send(SEND_TYPE_ARG1 sockfd,
   SEND_TYPE_RETV rc;
   if(countcheck("send", line, source))
     return -1;
-  rc = send(sockfd, buf, len, flags);
+  rc = (send)(sockfd, buf, len, flags);
   if(source)
     curl_dbg_log("SEND %s:%d send(%lu) = %ld\n",
                 source, line, (unsigned long)len, (long)rc);
@@ -340,7 +340,7 @@ RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd, RECV_TYPE_ARG2 buf,
   RECV_TYPE_RETV rc;
   if(countcheck("recv", line, source))
     return -1;
-  rc = recv(sockfd, buf, len, flags);
+  rc = (recv)(sockfd, buf, len, flags);
   if(source)
     curl_dbg_log("RECV %s:%d recv(%lu) = %ld\n",
                 source, line, (unsigned long)len, (long)rc);
@@ -352,7 +352,7 @@ int curl_dbg_socketpair(int domain, int type, int protocol,
                        curl_socket_t socket_vector[2],
                        int line, const char *source)
 {
-  int res = socketpair(domain, type, protocol, socket_vector);
+  int res = (socketpair)(domain, type, protocol, socket_vector);
 
   if(source && (0 == res))
     curl_dbg_log("FD %s:%d socketpair() = "
@@ -369,7 +369,7 @@ curl_socket_t curl_dbg_accept(curl_socket_t s, void *saddr, void *saddrlen,
   struct sockaddr *addr = (struct sockaddr *)saddr;
   curl_socklen_t *addrlen = (curl_socklen_t *)saddrlen;
 
-  curl_socket_t sockfd = accept(s, addr, addrlen);
+  curl_socket_t sockfd = (accept)(s, addr, addrlen);
 
   if(source && (sockfd != CURL_SOCKET_BAD))
     curl_dbg_log("FD %s:%d accept() = %" FMT_SOCKET_T "\n",
@@ -389,7 +389,7 @@ void curl_dbg_mark_sclose(curl_socket_t sockfd, int line, const char *source)
 /* this is our own defined way to close sockets on *ALL* platforms */
 int curl_dbg_sclose(curl_socket_t sockfd, int line, const char *source)
 {
-  int res = sclose(sockfd);
+  int res = (sclose)(sockfd);
   curl_dbg_mark_sclose(sockfd, line, source);
   return res;
 }
@@ -398,7 +398,7 @@ ALLOC_FUNC
 FILE *curl_dbg_fopen(const char *file, const char *mode,
                      int line, const char *source)
 {
-  FILE *res = fopen(file, mode);
+  FILE *res = (fopen)(file, mode);
 
   if(source)
     curl_dbg_log("FILE %s:%d fopen(\"%s\",\"%s\") = %p\n",
@@ -411,7 +411,7 @@ ALLOC_FUNC
 FILE *curl_dbg_fdopen(int filedes, const char *mode,
                       int line, const char *source)
 {
-  FILE *res = fdopen(filedes, mode);
+  FILE *res = (fdopen)(filedes, mode);
   if(source)
     curl_dbg_log("FILE %s:%d fdopen(\"%d\",\"%s\") = %p\n",
                  source, line, filedes, mode, (void *)res);
@@ -428,7 +428,7 @@ int curl_dbg_fclose(FILE *file, int line, const char *source)
     curl_dbg_log("FILE %s:%d fclose(%p)\n",
                  source, line, (void *)file);
 
-  res = fclose(file);
+  res = (fclose)(file);
 
   return res;
 }

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -387,7 +387,7 @@ void curl_dbg_mark_sclose(curl_socket_t sockfd, int line, const char *source)
 /* this is our own defined way to close sockets on *ALL* platforms */
 int curl_dbg_sclose(curl_socket_t sockfd, int line, const char *source)
 {
-  int res = (sclose)(sockfd);
+  int res = CURL_SCLOSE(sockfd);
   curl_dbg_mark_sclose(sockfd, line, source);
   return res;
 }

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -184,6 +184,9 @@ CURL_EXTERN ALLOC_FUNC
 #ifndef fake_sclose
 #define fake_sclose(x)  Curl_nop_stmt
 #endif
+#ifndef sclose
+#define sclose(x)  CURL_SCLOSE(x)
+#endif
 
 /*
  * Curl_safefree defined as a macro to allow MemoryTracking feature

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -121,8 +121,6 @@ CURL_EXTERN ALLOC_FUNC
 
 #endif /* HEADER_CURL_MEMDEBUG_H_EXTERNS */
 
-#ifndef MEMDEBUG_NODEFINES
-
 /* Set this symbol on the command-line, recompile all lib-sources */
 #undef strdup
 #define strdup(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
@@ -176,8 +174,6 @@ CURL_EXTERN ALLOC_FUNC
 #undef fdopen
 #define fdopen(file,mode) curl_dbg_fdopen(file,mode,__LINE__,__FILE__)
 #define fclose(file) curl_dbg_fclose(file,__LINE__,__FILE__)
-
-#endif /* MEMDEBUG_NODEFINES */
 
 #endif /* CURLDEBUG */
 

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -25,6 +25,10 @@
  ***************************************************************************/
 #include "server_setup.h"
 
+#ifndef sclose
+#define sclose(x) CURL_SCLOSE(x)
+#endif
+
 enum {
   DOCNUMBER_NOTHING    = -7,
   DOCNUMBER_QUIT       = -6,


### PR DESCRIPTION
To make it resistent to a `memdebug.h` included before compiling it in
`CURLDEBUG` mode, and making the `MEMDEBUG_NODEFINES` hack unnecessary.
Also bringing it a step closer for inclusion in unity builds.

---

- [ ] rebase on #16747