### PR TITLE
GHA/windows: skip flaky test 498

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -344,6 +344,7 @@ jobs:
         run: |
           export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
+            TFLAGS+=' ~498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
             TFLAGS+=' ~612'  # 'SFTP post-quote remove file' SFTP, post-quote
           fi
           TFLAGS+=' ~613'  # 'SFTP directory retrieval' SFTP, directory
@@ -513,6 +514,7 @@ jobs:
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:$PATH"
           export TFLAGS='-j8 ${{ matrix.tflags }}'
+          TFLAGS+=' ~498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -929,6 +931,7 @@ jobs:
         run: |
           export CURL_DIRSUFFIX='${{ matrix.type }}'
           export TFLAGS='-j8 ${{ matrix.tflags }}'
+          TFLAGS+=' ~498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' !SCP !SFTP'  # Fail with all tested openssh servers: curl: (67) Authentication failure
           fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -344,7 +344,7 @@ jobs:
         run: |
           export TFLAGS='-j8 ${{ matrix.tflags }}'
           if [ '${{ matrix.sys }}' != 'msys' ]; then
-            TFLAGS+=' ~498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
+            TFLAGS+=' !498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
             TFLAGS+=' ~612'  # 'SFTP post-quote remove file' SFTP, post-quote
           fi
           TFLAGS+=' ~613'  # 'SFTP directory retrieval' SFTP, directory
@@ -514,7 +514,7 @@ jobs:
         run: |
           PATH="$(cygpath "${USERPROFILE}")/my-cache/${{ matrix.dir }}/bin:$PATH"
           export TFLAGS='-j8 ${{ matrix.tflags }}'
-          TFLAGS+=' ~498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
+          TFLAGS+=' !498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -931,7 +931,7 @@ jobs:
         run: |
           export CURL_DIRSUFFIX='${{ matrix.type }}'
           export TFLAGS='-j8 ${{ matrix.tflags }}'
-          TFLAGS+=' ~498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
+          TFLAGS+=' !498'  # 'Reject too large HTTP response headers on endless redirects' HTTP, HTTP GET (runtests detecting result code 2009 instead of 56 returned by curl)
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' !SCP !SFTP'  # Fail with all tested openssh servers: curl: (67) Authentication failure
           fi


### PR DESCRIPTION
On suspect of strain on the runtime env/pipes, disable this test, which
is flaky due to `runtests` detecting a 2009 result code from curl, while
curl is returning the expected 56:

```
test 0498...[Reject too large HTTP response headers on endless redirects]

curl returned 2009, when expecting 56
 498: exit FAILED
== Contents of files in the log/5/ dir after test 498
[...]
   0     0    0     0    0     0      0      0 --:--:--  0:00:10 --:--:--     0
 curl: (56) Too large response headers: 6144086 > 6144000
```

In such cases the number of log lines for this single test is 4800. In
comparison the total number of log lines for a clear test run is 3800.

Seen with mingw, dl-mingw, msvc CI jobs.

Follow-up to 4911e7af119c1b7efd46a742d47bca44832c3041 #16735
Ref: https://github.com/curl/curl/discussions/14854#discussioncomment-12503065
