### PR TITLE
Fix pluralization of seconds

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -644,9 +644,11 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
         }
       }
       warnf(config->global, "Problem %s. "
-            "Will retry in %ld seconds. "
+            "Will retry in %ld %s. "
             "%ld %s left.",
-            m[retry], sleeptime/1000L, per->retry_remaining,
+            m[retry], sleeptime/1000L,
+            (sleeptime/1000L == 1 ? "second" : "seconds"),
+            per->retry_remaining,
             (per->retry_remaining > 1 ? "retries" : "retry"));
 
       per->retry_remaining--;


### PR DESCRIPTION
This is similar to #16586.

Can be tested with:
```
curl --retry 2 xxx
```

Before:
```
curl: (6) Could not resolve host: xxx
Warning: Problem : timeout. Will retry in 1 seconds. 2 retries left.
curl: (6) Could not resolve host: xxx
Warning: Problem : timeout. Will retry in 2 seconds. 1 retry left.
curl: (6) Could not resolve host: xxx
```

After:
```
curl: (6) Could not resolve host: xxx
Warning: Problem : timeout. Will retry in 1 second. 2 retries left.
curl: (6) Could not resolve host: xxx
Warning: Problem : timeout. Will retry in 2 seconds. 1 retry left.
curl: (6) Could not resolve host: xxx
``