### PR TITLE
lib: add `CURL_NO_UINTPTR_T` `CPPFLAG` to avoid `uintptr_t` type

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -459,9 +459,6 @@
 #include <assert.h>
 
 #ifdef __TANDEM /* for ns*-tandem-nsk systems */
-#  ifndef __NSK_OPTIONAL_TYPES__
-#    define CURL_NO_UINTPTR_T
-#  endif
 #  if ! defined __LP64
 #    include <floss.h> /* FLOSS is only used for 32-bit builds. */
 #  endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -459,6 +459,9 @@
 #include <assert.h>
 
 #ifdef __TANDEM /* for ns*-tandem-nsk systems */
+#  ifndef __NSK_OPTIONAL_TYPES__
+#    define CURL_NO_UINTPTR_T
+#  endif
 #  if ! defined __LP64
 #    include <floss.h> /* FLOSS is only used for 32-bit builds. */
 #  endif

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -69,12 +69,6 @@
 #include <stdint.h>
 #endif
 
-#if defined(__TANDEM) && !defined(__NSK_OPTIONAL_TYPES__)
-#ifndef CURL_NO_UINTPTR_T
-#define CURL_NO_UINTPTR_T
-#endif
-#endif
-
 /* Macro to strip 'const' without triggering a compiler warning.
    Use it for APIs that do not or cannot support the const qualifier. */
 #if defined(HAVE_STDINT_H) && !defined(CURL_NO_UINTPTR_T)

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -71,7 +71,7 @@
 
 /* Macro to strip 'const' without triggering a compiler warning.
    Use it for APIs that do not or cannot support the const qualifier. */
-#ifdef HAVE_STDINT_H
+#if defined(HAVE_STDINT_H) && !defined(CURL_NO_UINTPTR_T)
 #  define CURL_UNCONST(p) ((void *)(uintptr_t)(const void *)(p))
 #elif defined(_WIN32)  /* for VS2008 */
 #  define CURL_UNCONST(p) ((void *)(ULONG_PTR)(const void *)(p))

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -69,6 +69,12 @@
 #include <stdint.h>
 #endif
 
+#if defined(__TANDEM) && !defined(__NSK_OPTIONAL_TYPES__)
+#ifndef CURL_NO_UINTPTR_T
+#define CURL_NO_UINTPTR_T
+#endif
+#endif
+
 /* Macro to strip 'const' without triggering a compiler warning.
    Use it for APIs that do not or cannot support the const qualifier. */
 #if defined(HAVE_STDINT_H) && !defined(CURL_NO_UINTPTR_T)


### PR DESCRIPTION
And set it automatically with NonStop when the type is missing.

Reported-by: Randall
Bug: https://curl.se/mail/lib-2025-03/0013.html
Follow-up to f4e23950c7b1c389cf0dde8b91353d85b8361b64 #16142
