### PR TITLE
config-win32: set `HAVE_STDINT_H` where available

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -61,6 +61,11 @@
 #endif
 #endif
 
+/* Define to 1 if you have the <stdint.h> header file. */
+#if (defined(_MSC_VER) && (_MSC_VER >= 1600)) || defined(__MINGW32__)
+#define HAVE_STDINT_H 1
+#endif
+
 /* Define if you have the <sys/param.h> header file. */
 #ifdef __MINGW32__
 #define HAVE_SYS_PARAM_H 1


### PR DESCRIPTION
Follow-up to 1ecf2f11136f967deff6d2c124127250d2756c48 #16585