### PR TITLE
GHA: extend clang-tidy jobs with more build options, add Windows job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -215,9 +215,9 @@ jobs:
             configure: --without-ssl --enable-debug --disable-http --disable-smtp --disable-imap --disable-unity
 
           - name: clang-tidy
-            install_packages: clang-tidy libssl-dev libssh2-1-dev
-            install_steps: skipall
-            configure: --with-openssl --with-libssh2
+            install_packages: clang-tidy zlib1g-dev libssl-dev libkrb5-dev
+            install_steps: skipall wolfssl-opensslextra wolfssh
+            configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-opensslextra/lib" --with-wolfssl=$HOME/wolfssl-opensslextra --with-wolfssh=$HOME/wolfssh --with-openssl --enable-ech --with-gssapi --enable-ssls-export
             make-custom-target: tidy
 
           - name: scanbuild

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -133,9 +133,9 @@ jobs:
           - name: 'OpenSSL gsasl rtmp AppleIDN'
             install: gsasl rtmpdump
             generate: -DOPENSSL_ROOT_DIR=$(brew --prefix openssl) -DCURL_USE_GSASL=ON -DUSE_LIBRTMP=ON -DUSE_APPLE_IDN=ON
-          - name: 'OpenSSL AppleIDN clang-tidy +examples'
-            install: llvm
-            generate: -DOPENSSL_ROOT_DIR=$(brew --prefix openssl) -DUSE_APPLE_IDN=ON -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=$(brew --prefix llvm)/bin/clang-tidy
+          - name: 'MultiSSL AppleIDN clang-tidy +examples'
+            install: llvm brotli zstd gnutls nettle mbedtls gsasl rtmpdump
+            generate: -DCURL_USE_OPENSSL=ON -DOPENSSL_ROOT_DIR=$(brew --prefix openssl) -DCURL_DEFAULT_SSL_BACKEND=openssl -DCURL_USE_GNUTLS=ON -DCURL_USE_MBEDTLS=ON -DENABLE_ARES=ON -DCURL_USE_GSASL=ON -DUSE_LIBRTMP=ON -DUSE_APPLE_IDN=ON -DUSE_SSLS_EXPORT=ON -DCURL_CLANG_TIDY=ON -DCLANG_TIDY=$(brew --prefix llvm)/bin/clang-tidy
             clang-tidy: true
             chkprefill: _chkprefill
           - name: 'quictls +static libssh +examples'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -563,8 +563,8 @@ jobs:
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             [ -n '${{ matrix.clang-tidy }}' ] && options+=' -DCURL_CLANG_TIDY=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON'
             if [ '${{ matrix.compiler }}' = 'clang' ]; then
-              CCSUFFIX="-$(clang -dumpversion | cut -d '.' -f 1)"
-              options+=" -DCMAKE_C_COMPILER=clang -DCMAKE_RC_COMPILER=llvm-windres${CCSUFFIX}"
+              options+=' -DCMAKE_C_COMPILER=clang'
+              options+=" -DCMAKE_RC_COMPILER=llvm-windres-$(clang -dumpversion | cut -d '.' -f 1)"
             else
               options+=" -DCMAKE_C_COMPILER=${TRIPLET}-gcc"
             fi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -605,7 +605,7 @@ jobs:
         run: find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -exec file '{}' \;
 
       - name: 'build tests'
-        if: ${{ matrix.build == 'cmake' }}  # Save time by skipping this for autotools
+        if: ${{ matrix.build == 'cmake' && !matrix.clang-tidy }}  # Save time by skipping this for autotools and clang-tidy
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target testdeps

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -529,7 +529,7 @@ jobs:
           cmake --build bld --target curl-examples
 
   linux-cross-mingw-w64:
-    name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.name }}"
+    name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -539,16 +539,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { build: 'autotools', compiler: 'gcc'  , name: 'gcc' }
-          - { build: 'cmake'    , compiler: 'gcc'  , name: 'gcc' }
-          - { build: 'cmake'    , compiler: 'clang', clang-tidy: true, name: 'clang-tidy' }
+          - { build: 'autotools', compiler: 'gcc' }
+          - { build: 'cmake'    , compiler: 'gcc' }
+          - { build: 'cmake'    , compiler: 'clang-tidy' }
     steps:
       - name: 'install packages'
         timeout-minutes: 5
         run: |
           sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 \
             ${{ matrix.build == 'cmake' && 'ninja-build' || '' }} \
-            ${{ matrix.compiler == 'clang' && 'clang' || '' }}
+            ${{ matrix.compiler == 'clang-tidy' && 'clang' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -561,8 +561,9 @@ jobs:
       - name: 'configure'
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
-            [ -n '${{ matrix.clang-tidy }}' ] && options+=' -DCURL_CLANG_TIDY=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON'
-            if [ '${{ matrix.compiler }}' = 'clang' ]; then
+            if [ '${{ matrix.compiler }}' = 'clang-tidy' ]; then
+              options+=' -DCURL_CLANG_TIDY=ON'
+              options+=' -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON'
               options+=' -DCMAKE_C_COMPILER=clang'
               options+=" -DCMAKE_RC_COMPILER=llvm-windres-$(clang -dumpversion | cut -d '.' -f 1)"
             else
@@ -605,7 +606,7 @@ jobs:
         run: find . \( -name '*.exe' -o -name '*.dll' -o -name '*.a' \) -exec file '{}' \;
 
       - name: 'build tests'
-        if: ${{ matrix.build == 'cmake' && !matrix.clang-tidy }}  # Save time by skipping this for autotools and clang-tidy
+        if: ${{ matrix.build == 'cmake' && matrix.compiler != 'clang-tidy' }}  # Save time by skipping this for autotools and clang-tidy
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target testdeps
@@ -614,7 +615,7 @@ jobs:
           fi
 
       - name: 'build examples'
-        if: ${{ !matrix.clang-tidy }}  # Save time by skipping this for clang-tidy
+        if: ${{ matrix.compiler != 'clang-tidy' }}  # Save time by skipping this for clang-tidy
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target curl-examples

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -529,7 +529,7 @@ jobs:
           cmake --build bld --target curl-examples
 
   linux-cross-mingw-w64:
-    name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
+    name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.name }}"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -538,12 +538,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build: [autotools, cmake]
-        compiler: [gcc]
+        include:
+          - { build: 'autotools', compiler: 'gcc'  , name: 'gcc' }
+          - { build: 'cmake'    , compiler: 'gcc'  , name: 'gcc' }
+          - { build: 'cmake'    , compiler: 'clang', clang-tidy: true, name: 'clang-tidy' }
     steps:
       - name: 'install packages'
         timeout-minutes: 5
-        run: sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 ${{ matrix.build == 'cmake' && 'ninja-build' || '' }}
+        run: |
+          sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 \
+            ${{ matrix.build == 'cmake' && 'ninja-build' || '' }} \
+            ${{ matrix.compiler == 'clang' && 'clang' || '' }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -556,14 +561,21 @@ jobs:
       - name: 'configure'
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
+            [ -n '${{ matrix.clang-tidy }}' ] && options+=' -DCURL_CLANG_TIDY=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON'
+            if [ '${{ matrix.compiler }}' = 'clang' ]; then
+              CCSUFFIX="-$(clang -dumpversion | cut -d '.' -f 1)"
+              options+=" -DCMAKE_C_COMPILER=clang -DCMAKE_RC_COMPILER=llvm-windres${CCSUFFIX}"
+            else
+              options+=" -DCMAKE_C_COMPILER=${TRIPLET}-gcc"
+            fi
             cmake -B bld -G Ninja \
               -DCMAKE_SYSTEM_NAME=Windows \
               -DCMAKE_C_COMPILER_TARGET="${TRIPLET}" \
-              -DCMAKE_C_COMPILER="${TRIPLET}-gcc" \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \
               -DCURL_USE_SCHANNEL=ON -DUSE_WIN32_IDN=ON \
-              -DCURL_USE_LIBPSL=OFF
+              -DCURL_USE_LIBPSL=OFF \
+              ${options}
           else
             mkdir bld && cd bld && ../configure --enable-unity --enable-test-bundles --enable-warnings --enable-werror \
               --host="${TRIPLET}" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -614,6 +614,7 @@ jobs:
           fi
 
       - name: 'build examples'
+        if: ${{ !matrix.clang-tidy }}  # Save time by skipping this for clang-tidy
         run: |
           if [ '${{ matrix.build }}' = 'cmake' ]; then
             cmake --build bld --target curl-examples

--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -737,13 +737,13 @@ UNITTEST_START
 
     /* suites matched by EDH alias will return the DHE name */
     if(test->id >= 0x0011 && test->id < 0x0017) {
-      if(memcmp(expect, "EDH-", 4) == 0)
+      if(expect && memcmp(expect, "EDH-", 4) == 0)
         expect = (char *) memcpy(strcpy(alt, expect), "DHE-", 4);
-      if(memcmp(expect + 4, "EDH-", 4) == 0)
+      if(expect && memcmp(expect + 4, "EDH-", 4) == 0)
         expect = (char *) memcpy(strcpy(alt, expect) + 4, "DHE-", 4) - 4;
     }
 
-    if(strcmp(buf, expect) != 0) {
+    if(expect && strcmp(buf, expect) != 0) {
       fprintf(stderr, "Curl_cipher_suite_get_str FAILED for 0x%04x, "
                       "result = \"%s\", expected = \"%s\"\n",
                       test->id, buf, expect);

--- a/tests/unit/unit3205.c
+++ b/tests/unit/unit3205.c
@@ -722,7 +722,7 @@ UNITTEST_START
 
     Curl_cipher_suite_get_str(test->id, buf, sizeof(buf), true);
 
-    if(strcmp(buf, expect) != 0) {
+    if(expect && strcmp(buf, expect) != 0) {
       fprintf(stderr, "Curl_cipher_suite_get_str FAILED for 0x%04x, "
                       "result = \"%s\", expected = \"%s\"\n",
                       test->id, buf, expect);


### PR DESCRIPTION
- linux: wolfssl, wolfssh (replacing libssh2), ech, kerberos/GSSAPI,
  ssls-export (libssh2 remains tested on macos.)

- macos: brotli, zstd, c-ares, gnutls, mbedtls, gsasl, rtmp, ssls-export

- windows: new job with schannel, sspi, winidn, winldap, ssls-export

- unit3205: fix/silence remaining NULL dereferences.

Commits fixing the issues found:
cbbccb8b3aa357926131375e7082b2579fa3fe82 #16766
554e4c14bee82a604e08d51767f49fe11580e700 #16777

---

- [x] rebase on fallout fix #16766
- [x] rebase on fallout fix #16777
