### PR TITLE
runtests: fix bundle detection by not looking for `units`

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2514,9 +2514,10 @@ EOHELP
     shift @ARGV;
 }
 
-# Detect a test bundle build
+# Detect a test bundle build.
+# Do not look for unittests because it may be missing depending on build
+# settings.
 if(-e $LIBDIR . "libtests" . exe_ext('TOOL') &&
-   -e $UNITDIR . "units" . exe_ext('TOOL') &&
    -e $SRVDIR . "servers" . exe_ext('SRV')) {
     # use test bundles
     $bundle=1;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2515,8 +2515,7 @@ EOHELP
 }
 
 # Detect a test bundle build.
-# Do not look for unittests because it may be missing depending on build
-# settings.
+# Do not look for 'units' because not all configurations build it.
 if(-e $LIBDIR . "libtests" . exe_ext('TOOL') &&
    -e $SRVDIR . "servers" . exe_ext('SRV')) {
     # use test bundles


### PR DESCRIPTION
`units` may be not be built in certain cases when using autotools.

Fixes:
https://app.circleci.com/pipelines/github/curl/curl/12669/workflows/8516da2b-b351-40b2-bf13-7c4ab4bcdd55/jobs/127197

Bug: https://github.com/curl/curl/pull/16750#issuecomment-2738041943
Follow-up to a9b7cbf34f8db80e8c05ee3680cafdce67ca9430 #16750

---

Confirmed working in Circle CI: https://app.circleci.com/pipelines/github/curl/curl/12670/workflows/5185f6e8-b022-4b7e-83e7-033fd8dad37b/jobs/127205
