### PR TITLE
windows: fix issues detected by clang-tidy, and some more

### DIFF
--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -582,8 +582,10 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
 
     /* Allocate our new context handle */
     digest->http_context = calloc(1, sizeof(CtxtHandle));
-    if(!digest->http_context)
+    if(!digest->http_context) {
+      curlx_unicodefree(spn);
       return CURLE_OUT_OF_MEMORY;
+    }
 
     /* Generate our response message */
     status = Curl_pSecFn->InitializeSecurityContext(&credentials, NULL,

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -584,6 +584,8 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     digest->http_context = calloc(1, sizeof(CtxtHandle));
     if(!digest->http_context) {
       curlx_unicodefree(spn);
+      Curl_sspi_free_identity(p_identity);
+      free(output_token);
       return CURLE_OUT_OF_MEMORY;
     }
 

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1942,7 +1942,6 @@ schannel_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
                                     backend->encdata_offset),
                               size, err);
     if(*err) {
-      nread = -1;
       if(*err == CURLE_AGAIN)
         SCH_DEV(infof(data, "schannel: recv returned CURLE_AGAIN"));
       else if(*err == CURLE_RECV_ERROR)

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -975,7 +975,7 @@ schannel_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
   if(!backend->cred) {
     char *snihost;
     result = schannel_acquire_credential_handle(cf, data);
-    if(result)
+    if(result || !backend->cred)
       return result;
     /* schannel_acquire_credential_handle() sets backend->cred accordingly or
        it returns error otherwise. */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -1631,6 +1631,7 @@ schannel_connect_step3(struct Curl_cfilter *cf, struct Curl_easy *data)
       args.data = data;
       args.idx = 0;
       args.certs_count = certs_count;
+      args.result = CURLE_OK;
       traverse_cert_store(ccert_context, add_cert_to_certinfo, &args);
       result = args.result;
     }

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -399,6 +399,9 @@ static DWORD cert_get_name_string(struct Curl_easy *data,
   (void)Win8_compat;
 #endif
 
+  if(!alt_name_info)
+    return 0;
+
   compute_content = host_names != NULL && length != 0;
 
   /* Initialize default return values. */

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -177,7 +177,6 @@ SANITIZEcode sanitize_file_name(char **const sanitized, const char *file_name,
 
     if(clip) {
       *clip = '\0';
-      len = clip - target;
     }
   }
 

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -153,8 +153,10 @@ HMODULE win32_load_system_library(const TCHAR *filename)
 
   /* if written >= systemdirlen then nothing was written */
   written = GetSystemDirectory(path, (unsigned int)systemdirlen);
-  if(!written || written >= systemdirlen)
+  if(!written || written >= systemdirlen) {
+    free(path);
     return NULL;
+  }
 
   if(path[written - 1] != _T('\\'))
     path[written++] = _T('\\');

--- a/tests/libtest/testutil.c
+++ b/tests/libtest/testutil.c
@@ -141,6 +141,7 @@ HMODULE win32_load_system_library(const TCHAR *filename)
   size_t systemdirlen = GetSystemDirectory(NULL, 0);
   size_t written;
   TCHAR *path;
+  HMODULE module;
 
   if(!filenamelen || filenamelen > 32768 ||
      !systemdirlen || systemdirlen > 32768)
@@ -163,7 +164,11 @@ HMODULE win32_load_system_library(const TCHAR *filename)
 
   _tcscpy(path + written, filename);
 
-  return LoadLibrary(path);
+  module = LoadLibrary(path);
+
+  free(path);
+
+  return module;
 #endif
 }
 #endif


### PR DESCRIPTION
- digest_sspi: memory leak.
- digest_sspi: free buffers on `calloc()` fail.
  (not detected by clang-tidy)
- schannel_verify: avoid a `NULL` `alt_name_info`.
- schannel: fix potential `NULL` deref for `backend→cred`.
- schannel: fix uninitialized result value.
  Follow-up to 7f4c358541fdadcf29ba20bcdff71c5554e5f69c #3197
- schannel: drop unused assigment.
- tool_doswin: drop unused assigment.
- testutil: fix memory leak on error.
- testutil: fix memory leak on non-error.
  (not detected by clang-tidy)

Cherry-picked from #16764
