### PR TITLE
secureserver.pl, genserv.sh: cleanup

### DIFF
--- a/tests/certs/scripts/genserv.sh
+++ b/tests/certs/scripts/genserv.sh
@@ -69,7 +69,7 @@ if [ -z "$CAPREFIX" ]; then
   NOTOK=1
 else
   if [ ! -f "$CAPREFIX-ca.cacert" ]; then
-    echo "No CA certificate file $CAPREFIX-ca.caert"
+    echo "No CA certificate file $CAPREFIX-ca.cacert"
     NOTOK=1
   fi
   if [ ! -f "$CAPREFIX-ca.key" ]; then

--- a/tests/secureserver.pl
+++ b/tests/secureserver.pl
@@ -322,22 +322,11 @@ if($stunnel_version >= 400) {
     if($verbose) {
         print uc($proto) ." server (stunnel $ver_major.$ver_minor)\n";
         print "cmd: $cmd\n";
-        print "CApath = $capath\n";
-        print "cert = $certfile\n";
-        print "debug = $loglevel\n";
-        print "socket = $socketopt\n";
-        if($fips_support) {
-            print "fips = no\n";
-        }
-        if(!$tstunnel_windows) {
-            print "pid = $pidfile\n";
-            print "output = $logfile\n";
-            print "foreground = yes\n";
-        }
+        print "stunnel config at $conffile:\n";
+        open (my $writtenconf, '<', "$conffile") or die "$ssltext could not open the config file after writing\n";
+        print <$writtenconf>;
         print "\n";
-        print "[curltest]\n";
-        print "accept = $host_ip:$accept_port\n";
-        print "connect = $host_ip:$target_port\n";
+        close ($writtenconf);
     }
 }
 


### PR DESCRIPTION
stunnel: print configuration actually in file
Instead of duplicating all the logic of writing the stunnel
configuration, and having to keep it up to date, when running in verbose
mode print the actual contents of the file after writing it.

certs/genserv.sh: Fix typo in error message