### PR TITLE
sshserver: fix excluding obsolete client config lines

### DIFF
--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -999,8 +999,8 @@ push @cfgarr, 'PasswordAuthentication no';
 push @cfgarr, 'PreferredAuthentications publickey';
 push @cfgarr, 'PubkeyAuthentication yes';
 
-# RSA authentication options are not supported by OpenSSH for Windows
-if (!($sshdid =~ /OpenSSH-Windows/ || pathhelp::os_is_win())) {
+# RSA authentication options are deprecated by newer OpenSSH
+if (!($sshid =~ /OpenSSH/) || ($sshvernum <= 730)) {
     push @cfgarr, 'RhostsRSAAuthentication no';
     push @cfgarr, 'RSAAuthentication no';
 }


### PR DESCRIPTION
It was already excluded for OpenSSH-Windows. Extend it to all OpenSSH
above v7.3. Syncing up this logic with the sshd server config.

Fixing, in `sftp_server.log`:
```
log/server/curl_sftp_config line 33: Unsupported option "rhostsrsaauthentication"
log/server/curl_sftp_config line 34: Unsupported option "rsaauthentication"
```

`no` has been the default for these since OpenSSH 3.3 (2002-06-21).
