### PR TITLE
runtests: support running tests under wine or qemu

### DIFF
--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -99,6 +99,7 @@ use testutil qw(
     clearlogs
     logmsg
     runclient
+    exerunner
     shell_quote
     subbase64
     subsha256base64file
@@ -935,6 +936,8 @@ sub singletest_run {
             return (-1, 0, 0, "", "", 0);
         }
 
+        $CMDLINE=exerunner() . $CMDLINE;
+
         if($bundle) {
             $CMDLINE.=" $tool_name";
         }
@@ -971,7 +974,7 @@ sub singletest_run {
     }
 
     if(!$tool) {
-        $CMDLINE=shell_quote($CURL);
+        $CMDLINE=exerunner() . shell_quote($CURL);
         if((!$cmdhash{'option'}) || ($cmdhash{'option'} !~ /no-q/)) {
             $CMDLINE .= " -q";
         }

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -498,7 +498,7 @@ sub checksystemfeatures {
 
     my $curlverout="$LOGDIR/curlverout.log";
     my $curlvererr="$LOGDIR/curlvererr.log";
-    my $versioncmd=shell_quote($CURL) . " --version 1>$curlverout 2>$curlvererr";
+    my $versioncmd=exerunner() . shell_quote($CURL) . " --version 1>$curlverout 2>$curlvererr";
 
     unlink($curlverout);
     unlink($curlvererr);
@@ -2531,7 +2531,7 @@ if(!$randseed) {
     # seed of the month. December 2019 becomes 201912
     $randseed = ($year+1900)*100 + $mon+1;
     print "Using curl: $CURL\n";
-    open(my $curlvh, "-|", shell_quote($CURL) . " --version 2>$dev_null") ||
+    open(my $curlvh, "-|", exerunner() . shell_quote($CURL) . " --version 2>$dev_null") ||
         die "could not get curl version!";
     my @c = <$curlvh>;
     close($curlvh) || die "could not get curl version!";

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -65,6 +65,9 @@ use globalconfig;
 use pathhelp qw(
     exe_ext
     );
+use testutil qw(
+    exerunner
+    );
 
 our $logfile;  # server log file name, for logmsg
 
@@ -251,7 +254,7 @@ sub server_exe {
     else {
         $cmd = $SRVDIR . $name . exe_ext($ext);
     }
-    return "$cmd";
+    return exerunner() . "$cmd";
 }
 
 
@@ -269,6 +272,9 @@ sub server_exe_args {
     }
     else {
         @cmd = ($SRVDIR . $name . exe_ext($ext));
+    }
+    if ($ENV{'CURL_TEST_EXE_RUNNER'}) {
+        unshift @cmd, $ENV{'CURL_TEST_EXE_RUNNER'};
     }
     return @cmd;
 }

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -273,7 +273,7 @@ sub server_exe_args {
     else {
         @cmd = ($SRVDIR . $name . exe_ext($ext));
     }
-    if ($ENV{'CURL_TEST_EXE_RUNNER'}) {
+    if($ENV{'CURL_TEST_EXE_RUNNER'}) {
         unshift @cmd, $ENV{'CURL_TEST_EXE_RUNNER'};
     }
     return @cmd;

--- a/tests/testutil.pm
+++ b/tests/testutil.pm
@@ -213,7 +213,7 @@ sub runclientoutput {
 # Return custom tool (e.g. wine or qemu) to run curl binaries.
 #
 sub exerunner {
-    if ($ENV{'CURL_TEST_EXE_RUNNER'}) {
+    if($ENV{'CURL_TEST_EXE_RUNNER'}) {
         return $ENV{'CURL_TEST_EXE_RUNNER'} . ' ';
     }
     return '';

--- a/tests/testutil.pm
+++ b/tests/testutil.pm
@@ -37,6 +37,7 @@ BEGIN {
         runclient
         runclientoutput
         setlogfunc
+        exerunner
         shell_quote
         subbase64
         subnewlines
@@ -208,6 +209,15 @@ sub runclientoutput {
 #    return @out;
 }
 
+#######################################################################
+# Return custom tool (e.g. wine or qemu) to run curl binaries.
+#
+sub exerunner {
+    if ($ENV{'CURL_TEST_EXE_RUNNER'}) {
+        return $ENV{'CURL_TEST_EXE_RUNNER'} . ' ';
+    }
+    return '';
+}
 
 #######################################################################
 # Quote an argument for passing safely to a Bourne shell


### PR DESCRIPTION
To run curl, tests and servers via `wine`:
```shell
export CURL_TEST_EXE_RUNNER=wine
```
runtests prefixes commands with the specified runner. For systems where
this isn't automatic or supported, e.g. macOS.
