### PR TITLE
cmake: fix typo in ECH config error msg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1081,7 +1081,7 @@ if(USE_ECH)
       message(STATUS "HTTPSRR enabled")
     endif()
   else()
-    message(FATAL_ERROR "ECH requires ECH-enablded OpenSSL, BoringSSL, AWS-LC or wolfSSL")
+    message(FATAL_ERROR "ECH requires ECH-enabled OpenSSL, BoringSSL, AWS-LC or wolfSSL")
   endif()
 endif()
 


### PR DESCRIPTION
:wave: Just a small typo I noticed while working on wiring up rustls-ffi vTLS ECH support.