### PR TITLE
sshserver.pl: adjust `AuthorizedKeysFile2` cutoff version

### DIFF
--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -592,7 +592,7 @@ if ($sshdid =~ /OpenSSH-Windows/) {
 }
 
 push @cfgarr, "AuthorizedKeysFile $clipubkeyf_config";
-if(!($sshdid =~ /OpenSSH/) || ($sshdvernum <= 730)) {
+if(!($sshdid =~ /OpenSSH/) || ($sshdvernum <= 590)) {
     push @cfgarr, "AuthorizedKeysFile2 $clipubkeyf_config";
 }
 push @cfgarr, "HostKey $hstprvkeyf_config";


### PR DESCRIPTION
To avoid in `ssh_server.log`:
```
reprocess config line 6: Deprecated option AuthorizedKeysFile2
```
with openssh 7.1
