### PR TITLE
libssh2: show crypto backend in the verbose connect log

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3742,8 +3742,7 @@ void Curl_ssh_version(char *buffer, size_t buflen)
       crypto_str = "mbedTLS";
       break;
     case libssh2_openssl:
-      /* May mean any OpenSSL fork or wolfSSL. Also mostly the default. */
-      crypto_str = "";
+      crypto_str = "openssl";  /* In lowercase to cover forks and wolfSSL. */
       break;
     case libssh2_os400qc3:
       crypto_str = "os400qc3";

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3742,7 +3742,8 @@ void Curl_ssh_version(char *buffer, size_t buflen)
       crypto_str = "mbedTLS";
       break;
     case libssh2_openssl:
-      crypto_str = "OpenSSL";
+      /* May mean any OpenSSL fork or wolfSSL. Also mostly the default. */
+      crypto_str = "";
       break;
     case libssh2_os400qc3:
       crypto_str = "os400qc3";

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3732,7 +3732,30 @@ void Curl_ssh_cleanup(void)
 
 void Curl_ssh_version(char *buffer, size_t buflen)
 {
-  (void)msnprintf(buffer, buflen, "libssh2/%s", libssh2_version(0));
+  const char *crypto_str = "";
+#if LIBSSH2_VERSION_NUM >= 0x010b00
+  switch(libssh2_crypto_engine()) {
+    case libssh2_gcrypt:
+      crypto_str = "libgcrypt";
+      break;
+    case libssh2_mbedtls:
+      crypto_str = "mbedTLS";
+      break;
+    case libssh2_openssl:
+      crypto_str = "OpenSSL";
+      break;
+    case libssh2_os400qc3:
+      crypto_str = "os400qc3";
+      break;
+    case libssh2_wincng:
+      crypto_str = "WinCNG";
+      break;
+    default:
+      break;
+  }
+#endif
+  (void)msnprintf(buffer, buflen, "libssh2/%s%s%s", libssh2_version(0),
+    crypto_str ? "/" : "", crypto_str);
 }
 
 /* The SSH session is associated with the *CONNECTION* but the callback user

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2299,7 +2299,6 @@ static CURLcode ssh_statemachine(struct Curl_easy *data, bool *block)
     }
 
     case SSH_SFTP_GETINFO:
-    {
       if(data->set.get_filetime) {
         state(data, SSH_SFTP_FILETIME);
       }
@@ -2307,7 +2306,6 @@ static CURLcode ssh_statemachine(struct Curl_easy *data, bool *block)
         state(data, SSH_SFTP_TRANS_INIT);
       }
       break;
-    }
 
     case SSH_SFTP_FILETIME:
     {

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -2030,13 +2030,13 @@ static CURLcode ssh_statemachine(struct Curl_easy *data, bool *block)
         break;
       }
 
-    /* This is the last step in the SFTP connect phase. Do note that while
-       we get the homedir here, we get the "workingpath" in the DO action
-       since the homedir will remain the same between request but the
-       working path will not. */
-    DEBUGF(infof(data, "SSH CONNECT phase done"));
-    state(data, SSH_STOP);
-    break;
+      /* This is the last step in the SFTP connect phase. Do note that while
+         we get the homedir here, we get the "workingpath" in the DO action
+         since the homedir will remain the same between request but the
+         working path will not. */
+      DEBUGF(infof(data, "SSH CONNECT phase done"));
+      state(data, SSH_STOP);
+      break;
 
     case SSH_SFTP_QUOTE_INIT:
 


### PR DESCRIPTION
With libssh2 1.11.0 or newer.

Different crypto backends may offer different features, e.g. in the keys
and algos they support.

Examples:
```
*   Trying 127.0.0.1:22...
* Connected to localhost (127.0.0.1) port 22
* libssh2 crypto backend: openssl compatible
[or]
* libssh2 crypto backend: WinCNG
```

Also fix indentation and drop redundant curly braces.

---

w/o ws https://github.com/curl/curl/pull/16790/files?w=1