### PR TITLE
test613: make it pass on Windows, fix postprocess, unignore in CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -349,7 +349,6 @@ jobs:
               TFLAGS+=' ~SCP ~SFTP'  # Flaky: `-8, Unable to exchange encryption keys`. https://github.com/libssh2/libssh2/issues/804
             fi
           fi
-          TFLAGS+=' ~613'  # 'SFTP directory retrieval' SFTP, directory
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
             TFLAGS+=" -ac $(cygpath "${SYSTEMROOT}/System32/curl.exe")"
           fi
@@ -937,9 +936,7 @@ jobs:
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SCP ~SFTP'  # Flaky: `-8, Unable to exchange encryption keys`. https://github.com/libssh2/libssh2/issues/804
           fi
-          if [ '${{ matrix.openssh }}' = '' ]; then  # MSYS2 openssh
-            TFLAGS+=' ~613'  # 'SFTP directory retrieval' SFTP, directory
-          else  # OpenSSH-Windows
+          if [ -n '${{ matrix.openssh }}' ]; then  # OpenSSH-Windows
             TFLAGS+=' ~601 ~603 ~617 ~619 ~621 ~641 ~665 ~2004'  # SCP
             if [[ '${{ matrix.install }}' = *'libssh '* ]]; then
               TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -752,18 +752,6 @@ jobs:
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
               -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON -DCURL_USE_GSSAPI=ON
 
-          - name: 'openssl WSSHD'
-            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv krb5'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            openssh: 'OpenSSH-Windows-Pre'
-            config: >-
-              -DENABLE_DEBUG=ON
-              -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
-              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON -DCURL_USE_GSSAPI=ON
-
           - name: 'schannel MultiSSL U'
             # GnuTLS is not fully functional with MSVC, build-test only
             # https://github.com/ShiftMediaProject/gnutls/issues/23
@@ -817,22 +805,6 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             chkprefill: '_chkprefill'
-            # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
-            #          read its configuration from, making it vulnerable to attacks on
-            #          Windows. Do not use this component till there is a fix for these.
-            # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
-            config: >-
-              -DENABLE_DEBUG=ON
-              -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
-              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_MBEDTLS=ON
-              -DCURL_USE_GSASL=ON
-
-          - name: 'mbedtls libssh WSSHD'
-            install: 'brotli zlib zstd libpsl nghttp2 mbedtls libssh pkgconf gsasl'
-            arch: 'x64'
-            plat: 'windows'
-            type: 'Debug'
-            openssh: 'OpenSSH-Windows-Pre'
             # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
             #          read its configuration from, making it vulnerable to attacks on
             #          Windows. Do not use this component till there is a fix for these.
@@ -966,7 +938,9 @@ jobs:
           fi
           if [ -n '${{ matrix.openssh }}' ]; then  # OpenSSH-Windows
             TFLAGS+=' ~601 ~603 ~617 ~619 ~621 ~641 ~665 ~2004'  # SCP
-            if [[ '${{ matrix.install }}' = *'libssh2'* ]]; then
+            if [[ '${{ matrix.install }}' = *'libssh '* ]]; then
+              TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
+            else
               TFLAGS+=' ~3022'  # 'SCP correct sha256 host key' SCP, server sha256 key check
             fi
             PATH="$PATH:/c/Program Files/OpenSSH-Win64"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -752,6 +752,18 @@ jobs:
               -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
               -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON -DCURL_USE_GSSAPI=ON
 
+          - name: 'openssl WSSHD'
+            install: 'brotli zlib zstd libpsl nghttp2 nghttp3 openssl libssh2 pkgconf gsasl c-ares libuv krb5'
+            arch: 'x64'
+            plat: 'windows'
+            type: 'Debug'
+            openssh: 'OpenSSH-Windows-Pre'
+            config: >-
+              -DENABLE_DEBUG=ON
+              -DCURL_USE_LIBSSH2=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_OPENSSL=ON -DUSE_OPENSSL_QUIC=ON
+              -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON -DCURL_USE_GSSAPI=ON
+
           - name: 'schannel MultiSSL U'
             # GnuTLS is not fully functional with MSVC, build-test only
             # https://github.com/ShiftMediaProject/gnutls/issues/23
@@ -805,6 +817,22 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             chkprefill: '_chkprefill'
+            # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
+            #          read its configuration from, making it vulnerable to attacks on
+            #          Windows. Do not use this component till there is a fix for these.
+            # https://github.com/curl/curl-for-win/blob/3951808deb04df9489ee17430f236ed54436f81a/libssh.sh#L6-L8
+            config: >-
+              -DENABLE_DEBUG=ON
+              -DCURL_USE_LIBSSH2=OFF -DCURL_USE_LIBSSH=ON
+              -DCURL_USE_SCHANNEL=OFF -DCURL_USE_MBEDTLS=ON
+              -DCURL_USE_GSASL=ON
+
+          - name: 'mbedtls libssh WSSHD'
+            install: 'brotli zlib zstd libpsl nghttp2 mbedtls libssh pkgconf gsasl'
+            arch: 'x64'
+            plat: 'windows'
+            type: 'Debug'
+            openssh: 'OpenSSH-Windows-Pre'
             # WARNING: libssh uses hard-coded world-writable paths (/etc/..., ~/.ssh/) to
             #          read its configuration from, making it vulnerable to attacks on
             #          Windows. Do not use this component till there is a fix for these.
@@ -938,9 +966,7 @@ jobs:
           fi
           if [ -n '${{ matrix.openssh }}' ]; then  # OpenSSH-Windows
             TFLAGS+=' ~601 ~603 ~617 ~619 ~621 ~641 ~665 ~2004'  # SCP
-            if [[ '${{ matrix.install }}' = *'libssh '* ]]; then
-              TFLAGS+=' ~614'  # 'SFTP pre-quote chmod' SFTP, pre-quote, directory
-            else
+            if [[ '${{ matrix.install }}' = *'libssh2'* ]]; then
               TFLAGS+=' ~3022'  # 'SCP correct sha256 host key' SCP, server sha256 key check
             fi
             PATH="$PATH:/c/Program Files/OpenSSH-Win64"

--- a/tests/data/test613
+++ b/tests/data/test613
@@ -11,8 +11,8 @@ directory
 <reply>
 <datacheck>
 d?????????    N U         U               N ???  N NN:NN asubdir
--rw?rw?rw?    1 U         U              37 Jan  1  2000 plainfile.txt
--r-?r-?r-?    1 U         U              47 Dec 31  2000 rofile.txt
+-rw???????    1 U         U              37 Jan  1  2000 plainfile.txt
+-r-???????    1 U         U              47 Dec 31  2000 rofile.txt
 </datacheck>
 </reply>
 

--- a/tests/data/test614
+++ b/tests/data/test614
@@ -12,8 +12,8 @@ directory
 <reply>
 <datacheck>
 d?????????    N U         U               N ???  N NN:NN asubdir
--r-?r-?r-?    1 U         U              37 Jan  1  2000 plainfile.txt
--r-?r-?r-?    1 U         U              47 Dec 31  2000 rofile.txt
+-r-???????    1 U         U              37 Jan  1  2000 plainfile.txt
+-r-???????    1 U         U              47 Dec 31  2000 rofile.txt
 </datacheck>
 </reply>
 

--- a/tests/data/test614
+++ b/tests/data/test614
@@ -31,19 +31,14 @@ sftp
 SFTP pre-quote chmod
 </name>
 <command>
---key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt -Q "chmod 444 %SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt" --list-only sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/ --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/plainfile.txt -Q "-chmod 444 %SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt --insecure
 </command>
-<file name="%LOGDIR/file%TESTNUMBER.txt">
-Dummy test file for chmod test
-</file>
 </client>
 
 #
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
-#%PERL %SRCDIR/libtest/test610.pl rm %PWD/%LOGDIR/file%TESTNUMBER.txt
-%PERL %SRCDIR/libtest/test610.pl rm %PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt
 %PERL %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/curl%TESTNUMBER.out
 </postcheck>
 </verify>

--- a/tests/data/test614
+++ b/tests/data/test614
@@ -12,9 +12,8 @@ directory
 <reply>
 <datacheck>
 d?????????    N U         U               N ???  N NN:NN asubdir
-wr-???????    1 U         U              37 Jan  1  2000 plainfile.txt
+-r-???????    1 U         U              37 Jan  1  2000 plainfile.txt
 -r-???????    1 U         U              47 Dec 31  2000 rofile.txt
--r-???????    1 U         U              37 Jan  1  2000 upload.txt
 </datacheck>
 </reply>
 
@@ -31,7 +30,7 @@ sftp
 SFTP pre-quote chmod
 </name>
 <command>
---key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/plainfile.txt -Q "-chmod 444 %SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "chmod 444 %SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/plainfile.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/ --insecure
 </command>
 </client>
 

--- a/tests/data/test614
+++ b/tests/data/test614
@@ -12,8 +12,9 @@ directory
 <reply>
 <datacheck>
 d?????????    N U         U               N ???  N NN:NN asubdir
--r-???????    1 U         U              37 Jan  1  2000 plainfile.txt
+wr-???????    1 U         U              37 Jan  1  2000 plainfile.txt
 -r-???????    1 U         U              47 Dec 31  2000 rofile.txt
+-r-???????    1 U         U              37 Jan  1  2000 upload.txt
 </datacheck>
 </reply>
 
@@ -30,7 +31,7 @@ sftp
 SFTP pre-quote chmod
 </name>
 <command>
---key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -Q "chmod 444 %SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/plainfile.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/ --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/plainfile.txt -Q "-chmod 444 %SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt --insecure
 </command>
 </client>
 

--- a/tests/data/test614
+++ b/tests/data/test614
@@ -31,14 +31,19 @@ sftp
 SFTP pre-quote chmod
 </name>
 <command>
---key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/plainfile.txt -Q "-chmod 444 %SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt -Q "chmod 444 %SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt" --list-only sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/test%TESTNUMBER.dir/ --insecure
 </command>
+<file name="%LOGDIR/file%TESTNUMBER.txt">
+Dummy test file for chmod test
+</file>
 </client>
 
 #
 # Verify data after the test has been "shot"
 <verify>
 <postcheck>
+#%PERL %SRCDIR/libtest/test610.pl rm %PWD/%LOGDIR/file%TESTNUMBER.txt
+%PERL %SRCDIR/libtest/test610.pl rm %PWD/%LOGDIR/test%TESTNUMBER.dir/upload.txt
 %PERL %SRCDIR/libtest/test613.pl postprocess %PWD/%LOGDIR/test%TESTNUMBER.dir %PWD/%LOGDIR/curl%TESTNUMBER.out
 </postcheck>
 </verify>

--- a/tests/libtest/test613.pl
+++ b/tests/libtest/test613.pl
@@ -75,6 +75,7 @@ elsif ($ARGV[0] eq "postprocess")
     my $logfile = $ARGV[2];
 
     # Clean up the test directory
+    chmod 0666, "$dirname/rofile.txt";
     unlink "$dirname/rofile.txt";
     unlink "$dirname/plainfile.txt";
     rmdir "$dirname/asubdir";
@@ -110,18 +111,11 @@ elsif ($ARGV[0] eq "postprocess")
                 # consistent for across all test systems and filesystems
                 push @canondir, "d?????????    N U         U               N ???  N NN:NN $8\n";
             } elsif ($1 eq "-") {
-                # Replace missing group and other permissions with user
-                # permissions (eg. on Windows) due to them being shown as *
-                my ($u, $g, $o) = ($2, $3, $4);
-                if($g eq "**") {
-                    $g = $u;
-                }
-                if($o eq "**") {
-                    $o = $u;
-                }
+                # Ignore group and other permissions, because these may vary on
+                # some systems (e.g. on Windows)
                 # Erase user and group names, as they are not consistent across
                 # all test systems
-                my $line = sprintf("%s%s?%s?%s?%5d U         U %15d %s %s\n", $1,$u,$g,$o,$5,$6,$7,$8);
+                my $line = sprintf("%s%s???????%5d U         U %15d %s %s\n", $1,$2,$5,$6,$7,$8);
                 push @canondir, $line;
             } else {
                 # Unexpected format; just pass it through and let the test fail


### PR DESCRIPTION
- on native Windows (also when using MSYS2 openssh), the group and other
  permissions do not end up as requested by Perl's chmod:
  ```diff
  --- log/8/check-expected
  +++ log/8/check-generated
  @@ -1,3 +1,3 @@
   d?????????    N U         U               N ???  N NN:NN asubdir[LF]
  --rw?rw?rw?    1 U         U              37 Jan  1  2000 plainfile.txt[LF]
  +-rw?r-?r-?    1 U         U              37 Jan  1  2000 plainfile.txt[LF]
   -r-?r-?r-?    1 U         U              47 Dec 31  2000 rofile.txt[LF]
  ```
  Ref: https://github.com/curl/curl/actions/runs/14004029192/job/39215359241?pr=16781#step:15:1596
  Fix it by ignoring group and other attributes.

- fix failing postprocess cleanup by making the read-only test file
  writeable again before deleting it. Fixing:
  ```
  Directory not empty at ../../tests/libtest/test613.pl line 83.
  ```
  (seen on Windows with Git for Windows `perl.exe`)

- unignore in GHA/windows.
