### PR TITLE
eliminate `conn->now`

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -3777,9 +3777,6 @@ CURLcode Curl_setup_conn(struct Curl_easy *data,
     return result;
   }
 
-  /* set start time here for timeout purposes in the connect procedure, it
-     is later set again for the progress meter purpose */
-  conn->now = Curl_now();
   if(!conn->bits.reuse)
     result = Curl_conn_setup(data, conn, FIRSTSOCKET, conn->dns_entry,
                              CURL_CF_SSL_DEFAULT);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -804,7 +804,6 @@ struct connectdata {
   char *options; /* options string, allocated */
   char *sasl_authzid;     /* authorization identity string, allocated */
   char *oauth_bearer; /* OAUTH2 bearer, allocated */
-  struct curltime now;     /* "current" time */
   struct curltime created; /* creation time */
   struct curltime lastused; /* when returned to the connection poolas idle */
   curl_socket_t sock[2]; /* two sockets, the second is used for the data


### PR DESCRIPTION
it was only used in pingpong.c to check if the overall transfer has timed out and we do that with `Curl_timeleft()` in all other places.