### PR TITLE
rustls: tidy up existing code ahead of new functionality

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -8,6 +8,7 @@
  * Copyright (C) Jacob Hoffman-Andrews,
  * <github@hoffman-andrews.com>
  * Copyright (C) kpcyrd, <kpcyrd@archlinux.org>
+ * Copyright (C) Daniel McCarney, <daniel@binaryparadox.net>
  *
  * This software is licensed as described in the file COPYING, which
  * you should have received as part of this distribution. The terms

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -275,7 +275,6 @@ static CURLcode cr_flush_out(struct Curl_cfilter *cf, struct Curl_easy *data,
   rustls_io_result io_error;
   size_t tlswritten = 0;
   size_t tlswritten_total = 0;
-  CURLcode result = CURLE_OK;
 
   io_ctx.cf = cf;
   io_ctx.data = data;
@@ -301,7 +300,7 @@ static CURLcode cr_flush_out(struct Curl_cfilter *cf, struct Curl_easy *data,
     CURL_TRC_CF(data, cf, "cf_send: wrote %zu TLS bytes", tlswritten);
     tlswritten_total += tlswritten;
   }
-  return result;
+  return CURLE_OK;
 }
 
 /*

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -37,12 +37,8 @@
 #include "vtls.h"
 #include "vtls_int.h"
 #include "rustls.h"
-#include "select.h"
 #include "strerror.h"
-#include "multiif.h"
-#include "connect.h" /* for the connect timeout */
 #include "cipher_suite.h"
-#include "rand.h"
 #include "x509asn1.h"
 
 struct rustls_ssl_backend_data


### PR DESCRIPTION
:wave: Hi folks,

I'm close to cutting an upstream release of `rustls-ffi` that will make it possible to implement some new features in the `curl` vTLS backend. I've prototyped implementing those features with the unreleased code but noticed the logic in `cr_init_backend()` was getting pretty unwieldy, especially w.r.t resource management putting together a client config. Before dropping even more code in there I wanted to do some tidying.

I've done my best to make this easy to review commit-by-commit but would happily squash everything if you'd prefer.