### PR TITLE
test612: SCP `rm` the uploaded remote file (not the local source), unignore in CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -348,7 +348,6 @@ jobs:
             if [[ '${{ matrix.install }}' = *'libssh2-wincng'* ]]; then
               TFLAGS+=' ~SCP ~SFTP'  # Flaky: `-8, Unable to exchange encryption keys`. https://github.com/libssh2/libssh2/issues/804
             fi
-            TFLAGS+=' ~612'  # 'SFTP post-quote remove file' SFTP, post-quote
           fi
           TFLAGS+=' ~613'  # 'SFTP directory retrieval' SFTP, directory
           if [ -x "$(cygpath "${SYSTEMROOT}/System32/curl.exe")" ]; then
@@ -938,7 +937,6 @@ jobs:
           if [[ '${{ matrix.install }}' = *'libssh2[core,zlib]'* ]]; then
             TFLAGS+=' ~SCP ~SFTP'  # Flaky: `-8, Unable to exchange encryption keys`. https://github.com/libssh2/libssh2/issues/804
           fi
-          TFLAGS+=' ~612'  # 'SFTP post-quote remove file' SFTP, post-quote
           if [ '${{ matrix.openssh }}' = '' ]; then  # MSYS2 openssh
             TFLAGS+=' ~613'  # 'SFTP directory retrieval' SFTP, directory
           else  # OpenSSH-Windows

--- a/tests/data/test612
+++ b/tests/data/test612
@@ -24,7 +24,7 @@ sftp
 SFTP post-quote remove file
 </name>
 <command>
---key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt -Q "-rm %SSH_PWD/%LOGDIR/file%TESTNUMBER.txt" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload.%TESTNUMBER  --insecure
+--key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: -T %LOGDIR/file%TESTNUMBER.txt -Q "-rm %SSH_PWD/%LOGDIR/upload.%TESTNUMBER" sftp://%HOSTIP:%SSHPORT%SSH_PWD/%LOGDIR/upload.%TESTNUMBER  --insecure
 </command>
 <file name="%LOGDIR/file%TESTNUMBER.txt">
 Dummy test file for remove test
@@ -34,11 +34,8 @@ Dummy test file for remove test
 #
 # Verify data after the test has been "shot"
 <verify>
-<upload>
-Dummy test file for remove test
-</upload>
 <postcheck>
-%PERL %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/test%TESTNUMBER.txt
+%PERL %SRCDIR/libtest/test610.pl gone %PWD/%LOGDIR/upload.%TESTNUMBER
 </postcheck>
 </verify>
 </testcase>


### PR DESCRIPTION
It accidentally worked on all CI-tested operating systems, except on
native Windows.

Fixing:
```
=== Start of file stderr612
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
[...]
 curl: (21) rm command failed: Operation failed
```
Ref: https://github.com/curl/curl/actions/runs/14004029192/job/39215359241?pr=16781#step:15:1424

Also remove this test from the ignore list in GHA/windows.

---

- test614 is remote `chmod`-ing a file that wasn't uploaded beforehand. It fails with libssh and OpenSSH-Windows. Probably a different issue.
