### PR TITLE
libssh2: fix to ignore `known_hosts` when SHA256 host public key is set

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -796,7 +796,9 @@ static CURLcode ssh_force_knownhost_key_type(struct Curl_easy *data)
   int port = 0;
   bool found = FALSE;
 
-  if(sshc->kh && !data->set.str[STRING_SSH_HOST_PUBLIC_KEY_MD5]) {
+  if(sshc->kh &&
+     !data->set.str[STRING_SSH_HOST_PUBLIC_KEY_MD5] &&
+     !data->set.str[STRING_SSH_HOST_PUBLIC_KEY_SHA256]) {
     /* lets try to find our host in the known hosts file */
     while(!libssh2_knownhost_get(sshc->kh, &store, store)) {
       /* For non-standard ports, the name will be enclosed in */


### PR DESCRIPTION
Syncing behavior with MD5 host public keys.

libcurl first implemented to ignore `known_hosts` when an MD5 host
public key is set. Then later received support for SHA256 host public
keys. This update missed to add new key type to the `known_hosts` logic.

This caused test 3022 to fail if an already existing `known_hosts`
listed the test server IP with a different host key algo.

Follow-up to d1e7d9197b7fe417fb4d62aad5ea8f15a06d906c #7646
Follow-up to 272282a05416e42d2cc4a847a31fd457bc6cc827 #4747
