### PR TITLE
openssl: fix crash on missing cert password

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -935,7 +935,7 @@ static int passwd_callback(char *buf, int num, int encrypting,
 {
   DEBUGASSERT(0 == encrypting);
 
-  if(!encrypting && num >= 0) {
+  if(!encrypting && num >= 0 && global_passwd) {
     int klen = curlx_uztosi(strlen((char *)global_passwd));
     if(num > klen) {
       memcpy(buf, global_passwd, klen + 1);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -931,14 +931,14 @@ static char *ossl_strerror(unsigned long error, char *buf, size_t size)
 }
 
 static int passwd_callback(char *buf, int num, int encrypting,
-                           void *global_passwd)
+                           void *password)
 {
   DEBUGASSERT(0 == encrypting);
 
-  if(!encrypting && num >= 0 && global_passwd) {
-    int klen = curlx_uztosi(strlen((char *)global_passwd));
+  if(!encrypting && num >= 0 && password) {
+    int klen = curlx_uztosi(strlen((char *)password));
     if(num > klen) {
-      memcpy(buf, global_passwd, klen + 1);
+      memcpy(buf, password, klen + 1);
       return klen;
     }
   }


### PR DESCRIPTION
- Return 0 for password length if OpenSSL is expecting a certificate password but the user did not provide one.

Prior to this change libcurl would crash if OpenSSL called the certificate password callback in libcurl but no password was provided (NULL).

Reported-by: Roman Zharkov

Fixes https://github.com/curl/curl/issues/16806
Closes #xxxx