### PR TITLE
eliminate cpool's disconnect callback

### DIFF
--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -48,18 +48,6 @@ void Curl_conn_terminate(struct Curl_easy *data,
                          struct connectdata *conn,
                          bool aborted);
 
-/**
- * Callback invoked when disconnecting connections.
- * @param data    transfer last handling the connection, not attached
- * @param conn    the connection to discard
- * @param aborted if the connection is being aborted
- * @return if the connection is being aborted, e.g. should NOT perform
- *         a shutdown and just close.
- **/
-typedef bool Curl_cpool_disconnect_cb(struct Curl_easy *data,
-                                      struct connectdata *conn,
-                                      bool aborted);
-
 struct cpool {
    /* the pooled connections, bundled per destination */
   struct Curl_hash dest2bundle;
@@ -68,8 +56,7 @@ struct cpool {
   curl_off_t next_easy_id;
   struct curltime last_cleanup;
   struct Curl_easy *idata; /* internal handle for maintenance */
-  struct Curl_share *share; /* != NULL iff pool belongs to share */
-  Curl_cpool_disconnect_cb *disconnect_cb;
+  struct Curl_share *share; /* != NULL if pool belongs to share */
   BIT(locked);
   BIT(initialised);
 };
@@ -78,7 +65,6 @@ struct cpool {
  * returns 1 on error, 0 is fine.
  */
 int Curl_cpool_init(struct cpool *cpool,
-                    Curl_cpool_disconnect_cb *disconnect_cb,
                     struct Curl_easy *idata,
                     struct Curl_share *share,
                     size_t size);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -242,8 +242,7 @@ struct Curl_multi *Curl_multi_handle(size_t ev_hashsize,  /* event hash */
   if(Curl_cshutdn_init(&multi->cshutdn, multi))
     goto error;
 
-  if(Curl_cpool_init(&multi->cpool, Curl_on_disconnect,
-                     multi->admin, NULL, chashsize))
+  if(Curl_cpool_init(&multi->cpool, multi->admin, NULL, chashsize))
     goto error;
 
   if(Curl_ssl_scache_create(sesssize, 2, &multi->ssl_scache))

--- a/lib/share.c
+++ b/lib/share.c
@@ -136,8 +136,7 @@ curl_share_setopt(CURLSH *sh, CURLSHoption option, ...)
     case CURL_LOCK_DATA_CONNECT:
       /* It is safe to set this option several times on a share. */
       if(!share->cpool.initialised) {
-        if(Curl_cpool_init(&share->cpool, Curl_on_disconnect,
-                           share->admin, share, 103))
+        if(Curl_cpool_init(&share->cpool, share->admin, share, 103))
           res = CURLSHE_NOMEM;
       }
       break;

--- a/lib/url.c
+++ b/lib/url.c
@@ -600,52 +600,6 @@ void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
 }
 
 /*
- * Disconnects the given connection. Note the connection may not be the
- * primary connection, like when freeing room in the connection pool or
- * killing of a dead old connection.
- *
- * A connection needs an easy handle when closing down. We support this passed
- * in separately since the connection to get closed here is often already
- * disassociated from an easy handle.
- *
- * This function MUST NOT reset state in the Curl_easy struct if that
- * is not strictly bound to the life-time of *this* particular connection.
- */
-bool Curl_on_disconnect(struct Curl_easy *data,
-                        struct connectdata *conn, bool aborted)
-{
-  /* there must be a connection to close */
-  DEBUGASSERT(conn);
-
-  /* it must be removed from the connection pool */
-  DEBUGASSERT(!conn->bits.in_cpool);
-
-  /* there must be an associated transfer */
-  DEBUGASSERT(data);
-
-  /* the transfer must be detached from the connection */
-  DEBUGASSERT(!data->conn);
-
-  DEBUGF(infof(data, "Curl_disconnect(conn #%" FMT_OFF_T ", aborted=%d)",
-         conn->connection_id, aborted));
-
-  if(conn->dns_entry)
-    Curl_resolv_unlink(data, &conn->dns_entry);
-
-  /* Cleanup NTLM connection-related data */
-  Curl_http_auth_cleanup_ntlm(conn);
-
-  /* Cleanup NEGOTIATE connection-related data */
-  Curl_http_auth_cleanup_negotiate(conn);
-
-  if(conn->connect_only)
-    /* treat the connection as aborted in CONNECT_ONLY situations */
-    aborted = TRUE;
-
-  return aborted;
-}
-
-/*
  * xfer_may_multiplex()
  *
  * Return a TRUE, iff the transfer can be done over an (appropriate)

--- a/lib/url.h
+++ b/lib/url.h
@@ -37,8 +37,6 @@ void Curl_freeset(struct Curl_easy *data);
 CURLcode Curl_uc_to_curlcode(CURLUcode uc);
 CURLcode Curl_close(struct Curl_easy **datap); /* opposite of curl_open() */
 CURLcode Curl_connect(struct Curl_easy *, bool *async, bool *protocol_connect);
-bool Curl_on_disconnect(struct Curl_easy *data,
-                        struct connectdata *, bool aborted);
 CURLcode Curl_setup_conn(struct Curl_easy *data,
                          bool *protocol_done);
 void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn);

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -633,7 +633,9 @@ class TestDownload:
         docname = 'data-10k'
         port = env.port_for(proto)
         url = f'https://{env.domain1}:{port}/{docname}'
-        client = LocalClient(name='hx-download', env=env)
+        run_env = os.environ.copy()
+        run_env['CURL_DEBUG'] = 'multi'
+        client = LocalClient(name='hx-download', env=env, run_env=run_env)
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         r = client.run(args=[
@@ -667,7 +669,9 @@ class TestDownload:
         docname = 'data-10k'
         port = env.port_for(proto)
         url = f'https://{env.domain1}:{port}/{docname}'
-        client = LocalClient(name='hx-download', env=env)
+        run_env = os.environ.copy()
+        run_env['CURL_DEBUG'] = 'multi'
+        client = LocalClient(name='hx-download', env=env, run_env=run_env)
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         r = client.run(args=[


### PR DESCRIPTION
The callback, provided from url.c did the work that the cshutdn functionality also implemented. Remove it.

Change some DEBUGF(infof()) to CURL_TRC_M().