### PR TITLE
GHA/windows: install OpenSSH-Windows manually for transparency

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -946,6 +946,9 @@ jobs:
             PATH="$PATH:/c/Program Files/OpenSSH-Win64"
           fi
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin"
+          ls -1 '/c/Program Files' || true
+          ls -1 '/c/Program Files/OpenSSH-Win64' || true
+          echo "|$PATH|"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -914,7 +914,7 @@ jobs:
           if [ '${{ matrix.openssh }}' = '' ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           else  # OpenSSH-Windows
-            cd "${HOME}" || exit 1
+            cd /d || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
               --location 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/${{ env.openssh_windows-version }}/OpenSSH-Win64.zip' --output bin.zip
             unzip bin.zip
@@ -947,7 +947,7 @@ jobs:
             else
               TFLAGS+=' ~3022'  # 'SCP correct sha256 host key' SCP, server sha256 key check
             fi
-            PATH="$HOME/OpenSSH-Win64:$PATH"
+            PATH="/d/OpenSSH-Win64:$PATH"
           fi
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin"
           ssh.exe -V || true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -950,8 +950,6 @@ jobs:
             PATH="/d/OpenSSH-Win64:$PATH"
           fi
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin"
-          ssh.exe -V || true
-          sshd.exe -V || true
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -919,7 +919,7 @@ jobs:
             [ '${{ matrix.openssh }}' = 'OpenSSH-Windows-Pre' ] && chocopkg+=' --prerelease'
             chocopkg+=' openssh'
           fi
-          /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force ${chocopkg} stunnel || true
+          /c/ProgramData/chocolatey/choco.exe install --yes --verbose --no-progress --limit-output --timeout 180 --force ${chocopkg} stunnel || true
           python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
 
       - name: 'downgrade msys2-runtime'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -920,7 +920,7 @@ jobs:
             unzip bin.zip
             rm -f bin.zip
           fi
-          /c/ProgramData/chocolatey/choco.exe install --yes --verbose --no-progress --limit-output --timeout 180 --force stunnel || true
+          /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
           python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
 
       - name: 'downgrade msys2-runtime'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -943,7 +943,7 @@ jobs:
             else
               TFLAGS+=' ~3022'  # 'SCP correct sha256 host key' SCP, server sha256 key check
             fi
-            PATH="$PATH:/c/Program Files/OpenSSH-Win64"
+            PATH="/c/Program Files/OpenSSH-Win64:$PATH"
           fi
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin"
           ls -1 '/c/Program Files' || true

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -724,6 +724,7 @@ jobs:
       run:
         shell: msys2 {0}
     env:
+      openssh_windows-version: 'v9.8.1.0p1-Preview'
       VCPKG_BINARY_SOURCES: 'clear;x-gha,readwrite'
       VCPKG_DISABLE_METRICS: '1'
     strategy:
@@ -910,15 +911,16 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
-          '/c/Program Files/OpenSSH-Win64/ssh.exe' -V || true
-          ls -1 '/c/Program Files' || true
-          ls -1 '/c/Program Files/OpenSSH-Win64' || true
           if [ '${{ matrix.openssh }}' = '' ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           else  # OpenSSH-Windows
-            chocopkg+=' --prerelease openssh'
+            cd "${HOME}" || exit 1
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
+              --location 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/${{ env.openssh_windows-version }}/OpenSSH-Win64.zip' --output bin.zip
+            unzip -q bin.zip
+            rm -f bin.zip
           fi
-          /c/ProgramData/chocolatey/choco.exe install --yes --verbose --no-progress --limit-output --timeout 180 --force ${chocopkg} stunnel || true
+          /c/ProgramData/chocolatey/choco.exe install --yes --verbose --no-progress --limit-output --timeout 180 --force stunnel || true
           python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
 
       - name: 'downgrade msys2-runtime'
@@ -945,13 +947,11 @@ jobs:
             else
               TFLAGS+=' ~3022'  # 'SCP correct sha256 host key' SCP, server sha256 key check
             fi
-            PATH="/c/Program Files/OpenSSH-Win64:$PATH"
+            PATH="$HOME/OpenSSH-Win64:$PATH"
           fi
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin"
-          '/c/Program Files/OpenSSH-Win64/ssh.exe' -V || true
-          ls -1 '/c/Program Files' || true
-          ls -1 '/c/Program Files/OpenSSH-Win64' || true
-          echo "|$PATH|"
+          ssh.exe -V || true
+          sshd.exe -V || true
           cmake --build bld --config '${{ matrix.type }}' --target test-ci
 
       - name: 'build examples'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -916,8 +916,7 @@ jobs:
           if [ '${{ matrix.openssh }}' = '' ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           else  # OpenSSH-Windows
-            [ '${{ matrix.openssh }}' = 'OpenSSH-Windows-Pre' ] && chocopkg+=' --prerelease'
-            chocopkg+=' openssh'
+            chocopkg+=' --prerelease openssh'
           fi
           /c/ProgramData/chocolatey/choco.exe install --yes --verbose --no-progress --limit-output --timeout 180 --force ${chocopkg} stunnel || true
           python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -910,6 +910,9 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
+          '/c/Program Files/OpenSSH-Win64/ssh.exe' -V || true
+          ls -1 '/c/Program Files' || true
+          ls -1 '/c/Program Files/OpenSSH-Win64' || true
           if [ '${{ matrix.openssh }}' = '' ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           else  # OpenSSH-Windows
@@ -946,6 +949,7 @@ jobs:
             PATH="/c/Program Files/OpenSSH-Win64:$PATH"
           fi
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin"
+          '/c/Program Files/OpenSSH-Win64/ssh.exe' -V || true
           ls -1 '/c/Program Files' || true
           ls -1 '/c/Program Files/OpenSSH-Win64' || true
           echo "|$PATH|"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -917,7 +917,7 @@ jobs:
             cd "${HOME}" || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
               --location 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/${{ env.openssh_windows-version }}/OpenSSH-Win64.zip' --output bin.zip
-            unzip -q bin.zip
+            unzip bin.zip
             rm -f bin.zip
           fi
           /c/ProgramData/chocolatey/choco.exe install --yes --verbose --no-progress --limit-output --timeout 180 --force stunnel || true


### PR DESCRIPTION
To have the current latest version, and to avoid the stale, misleading
versions installed by Chocolatey. It also installs transparently, faster,
and making the source of the binaries clear. Install on drive `D:` for
best performance.

After much detective work it turns out that the OpenSSH Windows versions
installed by Chocolatey aren't what they seem:

- The latest pre-release named 9.5.0-beta20240403:
  https://community.chocolatey.org/packages/openssh/9.5.0-beta20240403
  is in reality 8.6.0.0p1-Beta from 2021-05-27:
  https://github.com/PowerShell/Win32-OpenSSH/releases/download/V8.6.0.0p1-Beta/OpenSSH-Win64.zip

- The latest "stable" version 8.0.0.1 is in reality:
  https://community.chocolatey.org/packages/openssh/8.0.0.1
  is in reality 8.0.0.0p1-Beta:
  https://github.com/PowerShell/Win32-OpenSSH/releases/download/v8.0.0.0p1-Beta/OpenSSH-Win64.zip

Ref: https://github.com/curl/curl/pull/16803#issuecomment-2746365654
Follow-up to 67a7775d1233d702964bff9a0a6b5b9fa036c47a #16704
Follow-up to 0ec72c1ef8d87a29bf2eaa5e36ab173147a4d015 #16672

---

The latest Chocolatey OpenSSH download advertised as 9.5.0-beta20240403, is 
in reality 8.6p1 from 2021-05-27. This fact is hidden inside a "nupkg" package
with a link only shown in verbose mode; within this nupkg (which is an odd .zip file
with "Microsoft OOXML" markup and not recognized by macOS) there is an
`OpenSSH-Win64.zip`, which is this ancient version. There is no URL pointing to
the original URL of this package. This one is less ancient that the "latest stable" from
2019, but now I wonder what version is that one (there is no such release on
the official Microsoft OpenSSH pages, which has changed location once in this time
period.)

Turns out the "stable" Chocolatey OpenSSH 8.0.0.1 actually matches the binary from
https://github.com/PowerShell/Win32-OpenSSH/releases/tag/v8.0.0.0p1-Beta, which
is a *Beta*! (which is the same as "Preview" in Microsoft-speak.) And Chocolatey gave
it a different version number. Sigh.

Shenagians like this cost a lot of time waste downstream. All the song and dance
on "SBOM", when basic stuff like this is so messed up. Figuring out the version and
binary URL (and the matching source code URL) of a package should require ZERO CLICKS,
let alone days of detective work.

Having many year old versions (all betas!) for SSH server and client is bad enough
by itself.

Chocolatey redirect chains, reverse-engineered:

Latest "preview":
https://community.chocolatey.org/packages/openssh/9.5.0-beta20240403
→ https://community.chocolatey.org/api/v2/package/openssh/9.5.0-beta20240403
→ https://packages.chocolatey.org/openssh.9.5.0-beta20240403.nupkg
→ https://github.com/PowerShell/Win32-OpenSSH/releases/tag/V8.6.0.0p1-Beta
→ https://github.com/PowerShell/Win32-OpenSSH/releases/download/V8.6.0.0p1-Beta/OpenSSH-Win64.zip

Latest "stable":
https://community.chocolatey.org/packages/openssh/8.0.0.1
→ https://community.chocolatey.org/api/v2/package/openssh/8.0.0.1
→ https://packages.chocolatey.org/openssh.8.0.0.1.nupkg
→ https://github.com/PowerShell/Win32-OpenSSH/releases/tag/v8.0.0.0p1-Beta
→ https://github.com/PowerShell/Win32-OpenSSH/releases/download/v8.0.0.0p1-Beta/OpenSSH-Win64.zip

Then one can hope these versions do match up with mainline OpenSSH versions.
I haven't checked.
