### PR TITLE
mqtt: convert sendleftovers to dynbuf

### DIFF
--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -97,5 +97,6 @@ char *Curl_dyn_take(struct dynbuf *s, size_t *plen);
 #define DYN_PINGPPONG_CMD   (64*1024)
 #define DYN_IMAP_CMD        (64*1024)
 #define DYN_MQTT_RECV       (64*1024)
+#define DYN_MQTT_SEND       0xFFFFFFF
 #define DYN_CRLFILE_SIZE    (400*1024*1024) /* 400mb */
 #endif

--- a/lib/mqtt.h
+++ b/lib/mqtt.h
@@ -49,15 +49,13 @@ struct mqtt_conn {
 
 /* protocol-specific transfer-related data */
 struct MQTT {
-  char *sendleftovers;
-  size_t nsend; /* size of sendleftovers */
-
+  struct dynbuf sendbuf;
   /* when receiving */
-  size_t npacket; /* byte counter */
-  unsigned char firstbyte;
-  size_t remaining_length;
   struct dynbuf recvbuf;
+  size_t npacket; /* byte counter */
+  size_t remaining_length;
   unsigned char pkt_hd[4]; /* for decoding the arriving packet length */
+  unsigned char firstbyte;
 };
 
 #endif /* HEADER_CURL_MQTT_H */


### PR DESCRIPTION
Avoid frequent strdups/free calls

Reported-by: Ronald Crane