### PR TITLE
GHA/non-native: revert to bare builds for Android 21

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -404,11 +404,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', platform: '21', name: "openssl", install: 'brotli zstd libpsl nghttp2 openssl libssh2',
-              options: '--with-openssl --with-brotli' }
+          - { build: 'autotools', platform: '21', name: "boringssl !zstd",
+              options: '--with-openssl --without-libpsl --without-zstd' }
 
-          - { build: 'cmake'    , platform: '21', name: "openssl", install: 'brotli zstd libpsl nghttp2 openssl libssh2',
-              options: '-DCURL_USE_OPENSSL=ON' }
+          - { build: 'cmake'    , platform: '21', name: "boringssl !zstd",
+              options: '-DCURL_USE_OPENSSL=ON -DOPENSSL_USE_STATIC_LIBS=ON -DCURL_USE_LIBPSL=OFF -DCURL_ZSTD=OFF' }
 
           - { build: 'autotools', platform: '35', name: "openssl", install: 'brotli zstd libpsl nghttp2 openssl libssh2',
               options: '--with-openssl --with-brotli' }

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -404,11 +404,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - { build: 'autotools', platform: '21', name: "boringssl !zstd",
-              options: '--with-openssl --without-libpsl --without-zstd' }
+          - { build: 'autotools', platform: '21', name: "!ssl !zstd",
+              options: '--without-ssl --without-libpsl --without-zstd' }
 
-          - { build: 'cmake'    , platform: '21', name: "boringssl !zstd",
-              options: '-DCURL_USE_OPENSSL=ON -DOPENSSL_USE_STATIC_LIBS=ON -DCURL_USE_LIBPSL=OFF -DCURL_ZSTD=OFF' }
+          - { build: 'cmake'    , platform: '21', name: "!ssl !zstd",
+              options: '-DCURL_ENABLE_SSL=OFF -DCURL_USE_LIBPSL=OFF -DCURL_ZSTD=OFF' }
 
           - { build: 'autotools', platform: '35', name: "openssl", install: 'brotli zstd libpsl nghttp2 openssl libssh2',
               options: '--with-openssl --with-brotli' }


### PR DESCRIPTION
vcpkg requires Android 28 by default after a recent update that's being
deployed onto CI runs (with `libiconv:arm64-android@1.18#1`).

Revert to bare, no-ssl, no-psl configuration for Android 21 jobs to make
them work again.

Bug: https://github.com/curl/curl/pull/16824#issuecomment-2750912507
Ref: https://github.com/microsoft/vcpkg/pull/44424#issuecomment-2753027630

---

Details via https://github.com/microsoft/vcpkg/pull/44424#issuecomment-2752380200:

Possibly this update to libiconv seems to be causing curl CI to fail with Android 21 with both automake and cmake.

Fail: https://github.com/curl/curl/actions/runs/14068719562/job/39397546570?pr=16824
Good: https://github.com/curl/curl/actions/runs/14064094782/job/39382024805 (from a few hours ago, without this vcpkg update)

automake no longer detects openssl due to:
```
ld.lld: error: undefined symbol: __write_chk
```
https://github.com/curl/curl/actions/runs/14068719562/job/39397546570?pr=16824#step:9:2590

cmake fails to link due to missing symbols:
```
ld.lld: error: undefined symbol: nl_langinfo
>>> referenced by psl.c:1819 (../src/0.21.5-062ce9d927.clean/src/psl.c:1819)
>>>               psl.c.o:(psl_str_to_utf8lower) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libpsl.a
>>> referenced by localcharset.c:847
>>>               libunistring_la-localcharset.o:(locale_charset) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libidn2.a

ld.lld: error: undefined symbol: iconv_open
>>> referenced by psl.c:1831 (../src/0.21.5-062ce9d927.clean/src/psl.c:1831)
>>>               psl.c.o:(psl_str_to_utf8lower) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libpsl.a
>>> referenced by striconveh.c:64 (.././../src/v1.2-f6a8d99457.clean/lib/striconveh.c:64)
>>>               libunistring_la-striconveh.o:(libunistring_iconveh_open) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libunistring.a
>>> referenced by striconveh.c:70 (.././../src/v1.2-f6a8d99457.clean/lib/striconveh.c:70)
>>>               libunistring_la-striconveh.o:(libunistring_iconveh_open) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libunistring.a
>>> referenced 1 more times

ld.lld: error: undefined symbol: iconv
>>> referenced by psl.c:1842 (../src/0.21.5-062ce9d927.clean/src/psl.c:1842)
>>>               psl.c.o:(psl_str_to_utf8lower) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libpsl.a
>>> referenced by psl.c:1843 (../src/0.21.5-062ce9d927.clean/src/psl.c:1843)
>>>               psl.c.o:(psl_str_to_utf8lower) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libpsl.a
>>> referenced by striconveh.c:414 (.././../src/v1.2-f6a8d99457.clean/lib/striconveh.c:414)
>>>               libunistring_la-striconveh.o:(mem_cd_iconveh_internal) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libunistring.a
>>> referenced 15 more times

ld.lld: error: undefined symbol: iconv_close
>>> referenced by psl.c:1867 (../src/0.21.5-062ce9d927.clean/src/psl.c:1867)
>>>               psl.c.o:(psl_str_to_utf8lower) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libpsl.a
>>> referenced by striconveh.c:0 (.././../src/v1.2-f6a8d99457.clean/lib/striconveh.c:0)
>>>               libunistring_la-striconveh.o:(libunistring_iconveh_open) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libunistring.a
>>> referenced by striconveh.c:97 (.././../src/v1.2-f6a8d99457.clean/lib/striconveh.c:97)
>>>               libunistring_la-striconveh.o:(libunistring_iconveh_open) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libunistring.a
>>> referenced 6 more times

ld.lld: error: undefined symbol: stderr
>>> referenced by nghttp2_map.c:102 (/usr/local/share/vcpkg/buildtrees/nghttp2/src/v1.65.0-395188afe2.clean/lib/nghttp2_map.c:102)
>>>               nghttp2_map.c.o:(nghttp2_map_print_distance) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libnghttp2.a
>>> referenced by nghttp2_map.c:102 (/usr/local/share/vcpkg/buildtrees/nghttp2/src/v1.65.0-395188afe2.clean/lib/nghttp2_map.c:102)
>>>               nghttp2_map.c.o:(nghttp2_map_print_distance) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libnghttp2.a
>>> referenced by ui_openssl.c:402 (../src/nssl-3.4.1-9e512b8cf5.clean/crypto/ui/ui_openssl.c:402)
>>>               libcrypto-lib-ui_openssl.o:(open_console) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libcrypto.a
>>> referenced 15 more times

ld.lld: error: undefined symbol: __memchr_chk
>>> referenced by string.h:153 (/usr/local/lib/android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/string.h:153)
>>>               libssl-lib-statem_srvr.o:(tls_early_post_process_client_hello) in archive /usr/local/share/vcpkg/installed/arm64-android/debug/lib/libssl.a
>>> referenced by string.h:153 (/usr/local/lib/android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/string.h:153)
>>>               libssl-lib-statem_lib.o:(ssl_has_cert_type) in archive /usr/local/share/vcpkg/installed/arm64-android/debug/lib/libssl.a
>>> referenced by string.h:153 (/usr/local/lib/android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/string.h:153)
>>>               libssl-lib-extensions_srvr.o:(PACKET_contains_zero_byte) in archive /usr/local/share/vcpkg/installed/arm64-android/debug/lib/libssl.a
>>> referenced 6 more times

ld.lld: error: undefined symbol: __poll_chk
>>> referenced by poll.h:59 (/usr/local/lib/android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/poll.h:59)
>>>               libssl-lib-quic_reactor.o:(poll_two_fds) in archive /usr/local/share/vcpkg/installed/arm64-android/debug/lib/libssl.a
>>> referenced by poll.h:59 (/usr/local/lib/android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/poll.h:59)
>>>               session.c.o:(libssh2_poll) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libssh2.a

ld.lld: error: undefined symbol: strchrnul
>>> referenced by lookup.c:561
>>>               lookup.o:(idn2_lookup_u8) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libidn2.a

ld.lld: error: undefined symbol: __write_chk
>>> referenced by unistd.h:202 (/usr/local/lib/android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/unistd.h:202)
>>>               libcrypto-lib-bss_dgram.o:(dgram_write) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libcrypto.a
>>> referenced by unistd.h:202 (/usr/local/lib/android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/unistd.h:202)
>>>               libcrypto-lib-bss_conn.o:(conn_write) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libcrypto.a
>>> referenced by unistd.h:202 (/usr/local/lib/android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/unistd.h:202)
>>>               libcrypto-lib-bss_sock.o:(sock_write) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libcrypto.a
>>> referenced 1 more times

ld.lld: error: undefined symbol: stdin
>>> referenced by ui_openssl.c:400 (../src/nssl-3.4.1-9e512b8cf5.clean/crypto/ui/ui_openssl.c:400)
>>>               libcrypto-lib-ui_openssl.o:(open_console) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libcrypto.a
>>> referenced by ui_openssl.c:400 (../src/nssl-3.4.1-9e512b8cf5.clean/crypto/ui/ui_openssl.c:400)
>>>               libcrypto-lib-ui_openssl.o:(open_console) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libcrypto.a
>>> referenced by ui_openssl.c:556 (../src/nssl-3.4.1-9e512b8cf5.clean/crypto/ui/ui_openssl.c:556)
>>>               libcrypto-lib-ui_openssl.o:(close_console) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libcrypto.a
>>> referenced 1 more times

ld.lld: error: undefined symbol: __fwrite_chk
>>> referenced by stdio.h:120 (/usr/local/lib/android/sdk/ndk/27.2.12479018/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/bits/fortify/stdio.h:120)
>>>               knownhost.c.o:(libssh2_knownhost_writefile) in archive /usr/local/share/vcpkg/installed/arm64-android/lib/pkgconfig/../../lib/libssh2.a
```
https://github.com/curl/curl/actions/runs/14068719562/job/39397547265?pr=16824#step:11:85
