### PR TITLE
configure: tidy up shell completion rules

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -43,20 +43,14 @@ all-local: $(ZSH_COMPLETION_FUNCTION_FILENAME) $(FISH_COMPLETION_FUNCTION_FILENA
 
 if USE_ZSH_COMPLETION
 $(ZSH_COMPLETION_FUNCTION_FILENAME): completion.pl
-	if test -z "$(PERL)"; then \
-	  echo 'No perl: cannot generate completion script'; \
-	else \
-	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell zsh > $@; \
-	fi
+	if test -z "$(PERL)"; then echo 'No perl: cannot generate completion script'; else \
+	$(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell zsh > $@; fi
 endif
 
 if USE_FISH_COMPLETION
 $(FISH_COMPLETION_FUNCTION_FILENAME): completion.pl
-	if test -z "$(PERL)"; then \
-	  echo 'No perl: cannot generate completion script'; \
-	else \
-	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell fish > $@; \
-	fi
+	if test -z "$(PERL)"; then echo 'No perl: cannot generate completion script'; else \
+	$(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell fish > $@; fi
 endif
 
 install-data-local:

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -44,7 +44,7 @@ all-local: $(ZSH_COMPLETION_FUNCTION_FILENAME) $(FISH_COMPLETION_FUNCTION_FILENA
 if USE_ZSH_COMPLETION
 $(ZSH_COMPLETION_FUNCTION_FILENAME): completion.pl
 	if test -z "$(PERL)"; then \
-	  echo "No perl: cannot generate completion script";
+	  echo 'No perl: cannot generate completion script';
 	else \
 	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell zsh > $@;
 	fi
@@ -53,7 +53,7 @@ endif
 if USE_FISH_COMPLETION
 $(FISH_COMPLETION_FUNCTION_FILENAME): completion.pl
 	if test -z "$(PERL)"; then
-	  echo "No perl: cannot generate completion script";
+	  echo 'No perl: cannot generate completion script';
 	else \
 	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell fish > $@;
 	fi
@@ -61,7 +61,7 @@ endif
 
 install-data-local:
 if CROSSCOMPILING
-	@echo "NOTICE: we cannot install completion scripts when cross-compiling"
+	@echo 'NOTICE: we cannot install completion scripts when cross-compiling'
 else # if not cross-compiling:
 if USE_ZSH_COMPLETION
 	if test -n "$(PERL)"; then \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -61,7 +61,7 @@ endif
 
 install-data-local:
 if CROSSCOMPILING
-	@echo "NOTICE: we can't install completion scripts when cross-compiling!"
+	@echo "NOTICE: we cannot install completion scripts when cross-compiling"
 else # if not cross-compiling:
 if USE_ZSH_COMPLETION
 	if test -n "$(PERL)"; then \

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -44,18 +44,18 @@ all-local: $(ZSH_COMPLETION_FUNCTION_FILENAME) $(FISH_COMPLETION_FUNCTION_FILENA
 if USE_ZSH_COMPLETION
 $(ZSH_COMPLETION_FUNCTION_FILENAME): completion.pl
 	if test -z "$(PERL)"; then \
-	  echo 'No perl: cannot generate completion script';
+	  echo 'No perl: cannot generate completion script'; \
 	else \
-	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell zsh > $@;
+	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell zsh > $@; \
 	fi
 endif
 
 if USE_FISH_COMPLETION
 $(FISH_COMPLETION_FUNCTION_FILENAME): completion.pl
-	if test -z "$(PERL)"; then
-	  echo 'No perl: cannot generate completion script';
+	if test -z "$(PERL)"; then \
+	  echo 'No perl: cannot generate completion script'; \
 	else \
-	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell fish > $@;
+	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell fish > $@; \
 	fi
 endif
 
@@ -66,13 +66,13 @@ else # if not cross-compiling:
 if USE_ZSH_COMPLETION
 	if test -n "$(PERL)"; then \
 	  $(MKDIR_P) $(DESTDIR)$(ZSH_FUNCTIONS_DIR); \
-	  $(INSTALL_DATA) $(ZSH_COMPLETION_FUNCTION_FILENAME) $(DESTDIR)$(ZSH_FUNCTIONS_DIR)/$(ZSH_COMPLETION_FUNCTION_FILENAME) ; \
+	  $(INSTALL_DATA) $(ZSH_COMPLETION_FUNCTION_FILENAME) $(DESTDIR)$(ZSH_FUNCTIONS_DIR)/$(ZSH_COMPLETION_FUNCTION_FILENAME); \
 	fi
 endif
 if USE_FISH_COMPLETION
 	if test -n "$(PERL)"; then \
 	  $(MKDIR_P) $(DESTDIR)$(FISH_FUNCTIONS_DIR); \
-	  $(INSTALL_DATA) $(FISH_COMPLETION_FUNCTION_FILENAME) $(DESTDIR)$(FISH_FUNCTIONS_DIR)/$(FISH_COMPLETION_FUNCTION_FILENAME) ; \
+	  $(INSTALL_DATA) $(FISH_COMPLETION_FUNCTION_FILENAME) $(DESTDIR)$(FISH_FUNCTIONS_DIR)/$(FISH_COMPLETION_FUNCTION_FILENAME); \
 	fi
 endif
 endif

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -43,28 +43,20 @@ all-local: $(ZSH_COMPLETION_FUNCTION_FILENAME) $(FISH_COMPLETION_FUNCTION_FILENA
 
 if USE_ZSH_COMPLETION
 $(ZSH_COMPLETION_FUNCTION_FILENAME): completion.pl
-if CROSSCOMPILING
-	@echo "NOTICE: we can't generate zsh completion when cross-compiling!"
-else # if not cross-compiling:
 	if test -z "$(PERL)"; then \
-	  echo "No perl: can't install completion script";
+	  echo "No perl: cannot generate completion script";
 	else \
 	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell zsh > $@;
 	fi
 endif
-endif
 
 if USE_FISH_COMPLETION
 $(FISH_COMPLETION_FUNCTION_FILENAME): completion.pl
-if CROSSCOMPILING
-	@echo "NOTICE: we can't generate fish completion when cross-compiling!"
-else # if not cross-compiling:
 	if test -z "$(PERL)"; then
-	  echo "No perl: can't install completion script";
+	  echo "No perl: cannot generate completion script";
 	else \
 	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell fish > $@;
 	fi
-endif
 endif
 
 install-data-local:

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -22,9 +22,9 @@
 #
 ###########################################################################
 
-EXTRA_DIST = coverage.sh completion.pl firefox-db2pem.sh checksrc.pl    \
- mk-ca-bundle.pl mk-unity.pl schemetable.c cd2nroff nroff2cd cdall cd2cd managen \
- dmaketgz maketgz release-tools.sh verify-release cmakelint.sh mdlinkcheck
+EXTRA_DIST = coverage.sh completion.pl firefox-db2pem.sh checksrc.pl              \
+  mk-ca-bundle.pl mk-unity.pl schemetable.c cd2nroff nroff2cd cdall cd2cd managen \
+  dmaketgz maketgz release-tools.sh verify-release cmakelint.sh mdlinkcheck
 
 ZSH_FUNCTIONS_DIR = @ZSH_FUNCTIONS_DIR@
 FISH_FUNCTIONS_DIR = @FISH_FUNCTIONS_DIR@
@@ -46,8 +46,11 @@ $(ZSH_COMPLETION_FUNCTION_FILENAME): completion.pl
 if CROSSCOMPILING
 	@echo "NOTICE: we can't generate zsh completion when cross-compiling!"
 else # if not cross-compiling:
-	if test -z "$(PERL)"; then echo "No perl: can't install completion script"; else \
-	$(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell zsh > $@ ; fi
+	if test -z "$(PERL)"; then \
+	  echo "No perl: can't install completion script";
+	else \
+	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell zsh > $@;
+	fi
 endif
 endif
 
@@ -56,8 +59,11 @@ $(FISH_COMPLETION_FUNCTION_FILENAME): completion.pl
 if CROSSCOMPILING
 	@echo "NOTICE: we can't generate fish completion when cross-compiling!"
 else # if not cross-compiling:
-	if test -z "$(PERL)"; then echo "No perl: can't install completion script"; else \
-	$(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell fish > $@ ; fi
+	if test -z "$(PERL)"; then
+	  echo "No perl: can't install completion script";
+	else \
+	  $(PERL) $(srcdir)/completion.pl --opts-dir $(top_srcdir)/docs/cmdline-opts --shell fish > $@;
+	fi
 endif
 endif
 


### PR DESCRIPTION
- allow generating completions in cross-builds.
  Follow-up to d055a01ce90510a6f8ff44bb7fceace9b2dbcf97 #16789

- fix warning messages.

- language, quotes, whitespace.
