### PR TITLE
[TEST] runtests: shutdown trace

### DIFF
--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -324,7 +324,7 @@ sub killpid {
     print "killpid: trace-3\n";
     # Allow all signalled processes five seconds to gracefully die.
     if(@signalled) {
-        print "killpid: trace-3a\n";
+        #print "killpid: trace-3a\n";
         my $twentieths = 5 * 20;
         while($twentieths--) {
             for(my $i = scalar(@signalled) - 1; $i >= 0; $i--) {
@@ -348,7 +348,7 @@ sub killpid {
     print "killpid: trace-4\n";
     # Mercilessly SIGKILL processes still alive.
     if(@signalled) {
-        print "killpid: trace-4a\n";
+        #print "killpid: trace-4a\n";
         foreach my $pid (@signalled) {
             if($pid > 0) {
                 print("RUN: Process with pid $pid forced to die with SIGKILL\n")
@@ -364,7 +364,7 @@ sub killpid {
     print "killpid: trace-5\n";
     # Reap processes dead children for sure.
     if(@reapchild) {
-        print "killpid: trace-5a\n";
+        #print "killpid: trace-5a\n";
         foreach my $pid (@reapchild) {
             if($pid > 0) {
                 pidwait($pid, 0);

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -332,10 +332,13 @@ sub killpid {
     print "killpid: trace-3\n";
     # Allow all signalled processes five seconds to gracefully die.
     if(@signalled) {
+        print "killpid: trace-3a\n";
         #print "killpid: trace-3a\n";
         my $twentieths = 5 * 20;
         while($twentieths--) {
+            print "killpid: trace-3a1\n";
             for(my $i = scalar(@signalled) - 1; $i >= 0; $i--) {
+                print "killpid: trace-3a1a\n";
                 my $pid = $signalled[$i];
                 if(!pidexists($pid)) {
                     print("RUN: Process with pid $pid gracefully died\n")

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -283,6 +283,8 @@ sub killpid {
     # The 'pidlist' argument is a string of whitespace separated pids.
     return if(not defined($pidlist));
 
+    print "killpid: trace-1\n";
+
     # Make 'requested' hold the non-duplicate pids from 'pidlist'.
     @requested = split(' ', $pidlist);
     return if(not @requested);
@@ -296,6 +298,7 @@ sub killpid {
     }
 
     # Send a SIGTERM to processes which are alive to gracefully stop them.
+    print "killpid: trace-2\n";
     foreach my $tmp (@requested) {
         chomp $tmp;
         if($tmp =~ /^(\d+)$/) {
@@ -318,8 +321,10 @@ sub killpid {
         }
     }
 
+    print "killpid: trace-3\n";
     # Allow all signalled processes five seconds to gracefully die.
     if(@signalled) {
+        print "killpid: trace-3a\n";
         my $twentieths = 5 * 20;
         while($twentieths--) {
             for(my $i = scalar(@signalled) - 1; $i >= 0; $i--) {
@@ -340,8 +345,10 @@ sub killpid {
         }
     }
 
+    print "killpid: trace-4\n";
     # Mercilessly SIGKILL processes still alive.
     if(@signalled) {
+        print "killpid: trace-4a\n";
         foreach my $pid (@signalled) {
             if($pid > 0) {
                 print("RUN: Process with pid $pid forced to die with SIGKILL\n")
@@ -354,14 +361,17 @@ sub killpid {
         }
     }
 
+    print "killpid: trace-5\n";
     # Reap processes dead children for sure.
     if(@reapchild) {
+        print "killpid: trace-5a\n";
         foreach my $pid (@reapchild) {
             if($pid > 0) {
                 pidwait($pid, 0);
             }
         }
     }
+    print "killpid: trace-6\n";
 }
 
 #######################################################################

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -291,6 +291,8 @@ sub killpid {
     # The 'pidlist' argument is a string of whitespace separated pids.
     return if(not defined($pidlist));
 
+    $verbose = 1;
+
     print "killpid: trace-1\n";
 
     # Make 'requested' hold the non-duplicate pids from 'pidlist'.

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -254,9 +254,10 @@ sub processexists {
     # fetch pid from pidfile
     my $pid = pidfromfile($pidfile);
 
-    print "processexists: trace-1: ", $pid, "\n";
+    print "processexists: trace-1: ", $pid, " <= ", $pidfile, "\n";
 
     if($pid > 0) {
+        print "processexists: trace-1a: ", $pid, "\n";
         # verify if currently alive
         if(pidexists($pid)) {
             print "processexists: trace-2 exists: ", $pid, "\n";

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -403,7 +403,7 @@ sub killsockfilters {
         $pid = processexists($pidfile);
         if($pid > 0) {
             printf("* kill pid for %s-%s => %d\n", $server,
-                ($proto eq 'ftp')?'ctrl':'filt', $pid) if($verbose);
+                ($proto eq 'ftp')?'ctrl':'filt', $pid);
             pidkill($pid);
             pidwait($pid, 0);
         }
@@ -417,7 +417,7 @@ sub killsockfilters {
         $pid = processexists($pidfile);
         if($pid > 0) {
             printf("* kill pid for %s-data => %d\n", $server,
-                $pid) if($verbose);
+                $pid);
             pidkill($pid);
             pidwait($pid, 0);
         }

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -283,8 +283,6 @@ sub killpid {
     # The 'pidlist' argument is a string of whitespace separated pids.
     return if(not defined($pidlist));
 
-    print "killpid: trace-1\n";
-
     # Make 'requested' hold the non-duplicate pids from 'pidlist'.
     @requested = split(' ', $pidlist);
     return if(not @requested);
@@ -298,7 +296,6 @@ sub killpid {
     }
 
     # Send a SIGTERM to processes which are alive to gracefully stop them.
-    print "killpid: trace-2\n";
     foreach my $tmp (@requested) {
         chomp $tmp;
         if($tmp =~ /^(\d+)$/) {
@@ -321,10 +318,8 @@ sub killpid {
         }
     }
 
-    print "killpid: trace-3\n";
     # Allow all signalled processes five seconds to gracefully die.
     if(@signalled) {
-        print "killpid: trace-3a\n";
         my $twentieths = 5 * 20;
         while($twentieths--) {
             for(my $i = scalar(@signalled) - 1; $i >= 0; $i--) {
@@ -345,10 +340,8 @@ sub killpid {
         }
     }
 
-    print "killpid: trace-4\n";
     # Mercilessly SIGKILL processes still alive.
     if(@signalled) {
-        print "killpid: trace-4a\n";
         foreach my $pid (@signalled) {
             if($pid > 0) {
                 print("RUN: Process with pid $pid forced to die with SIGKILL\n")
@@ -361,17 +354,14 @@ sub killpid {
         }
     }
 
-    print "killpid: trace-5\n";
     # Reap processes dead children for sure.
     if(@reapchild) {
-        print "killpid: trace-5a\n";
         foreach my $pid (@reapchild) {
             if($pid > 0) {
                 pidwait($pid, 0);
             }
         }
     }
-    print "killpid: trace-6\n";
 }
 
 #######################################################################

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -252,17 +252,22 @@ sub processexists {
     # fetch pid from pidfile
     my $pid = pidfromfile($pidfile);
 
+    print "processexists: trace-1: ", $pid, "\n";
+
     if($pid > 0) {
         # verify if currently alive
         if(pidexists($pid)) {
+            print "processexists: trace-2 exists: ", $pid, "\n";
             return $pid;
         }
         else {
+            print "processexists: trace-3 miss: ", $pid, "\n";
             # get rid of the certainly invalid pidfile
             unlink($pidfile) if($pid == pidfromfile($pidfile));
             # reap its dead children, if not done yet
             pidwait($pid, &WNOHANG);
             # negative return value means dead process
+            print "processexists: trace-4 returning: ", -$pid, "\n";
             return -$pid;
         }
     }

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -219,6 +219,7 @@ sub pidwait {
         }
         my $start = time;
         my $warn_at = 5;
+        print "pidwait: trace-1: ", $pid, "\n";
         while(pidexists($pid)) {
             if(time - $start > $warn_at) {
                 print "pidwait: still waiting for PID ", $pid, "\n";
@@ -230,6 +231,7 @@ sub pidwait {
             }
             portable_sleep(0.2);
         }
+        print "pidwait: trace-2: ", $pid, "\n";
         return $pid;
     }
 

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -371,8 +371,9 @@ sub killpid {
     print "killpid: trace-5\n";
     # Reap processes dead children for sure.
     if(@reapchild) {
-        #print "killpid: trace-5a\n";
+        print "killpid: trace-5a\n";
         foreach my $pid (@reapchild) {
+            print "killpid: trace-5aa: ", $pid, "\n";
             if($pid > 0) {
                 pidwait($pid, 0);
             }

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1347,8 +1347,8 @@ sub controlleripccall {
     if(!$multiprocess) {
         # Call the remote function here in single process mode
         ipcrecv();
-     }
-     return 0;
+    }
+    return 0;
 }
 
 ###################################################################

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1179,9 +1179,12 @@ sub runner_test_preprocess {
     my ($testnum)=@_;
     my %testtimings;
 
+
     if(clearlogs()) {
         logmsg "Warning: log messages were lost\n";
     }
+
+    print "runner_test_preprocess: trace-2:", $testnum,"\n";
 
     # timestamp test preparation start
     # TODO: this metric now shows only a portion of the prep time; better would
@@ -1193,20 +1196,26 @@ sub runner_test_preprocess {
     # ignore any error here--if there were one, it would have been
     # caught during the selection phase and this test would not be
     # running now
+    print "runner_test_preprocess: trace-3:", $testnum,"\n";
     loadtest("${TESTDIR}/test${testnum}");
+    print "runner_test_preprocess: trace-4:", $testnum,"\n";
     readtestkeywords();
 
     ###################################################################
     # Restore environment variables that were modified in a previous run.
     # Test definition may instruct to (un)set environment vars.
+    print "runner_test_preprocess: trace-5:", $testnum,"\n";
     restore_test_env(1);
 
     ###################################################################
     # Start the servers needed to run this test case
+    print "runner_test_preprocess: trace-6:", $testnum,"\n";
     my ($why, $error) = singletest_startservers($testnum, \%testtimings);
 
+    print "runner_test_preprocess: trace-7:", $testnum,"\n";
     # make sure no locks left for responsive test
     waitlockunlock($defserverlogslocktimeout);
+    print "runner_test_preprocess: trace-8:", $testnum,"\n";
 
     if(!$why) {
 
@@ -1214,16 +1223,21 @@ sub runner_test_preprocess {
         # Generate preprocessed test file
         # This must be done after the servers are started so server
         # variables are available for substitution.
+        print "runner_test_preprocess: trace-9:", $testnum,"\n";
         singletest_preprocess($testnum);
 
         ###############################################################
         # Set up the test environment to run this test case
+        print "runner_test_preprocess: trace-10:", $testnum,"\n";
         singletest_setenv();
 
         ###############################################################
         # Check that the test environment is fine to run this test case
+        print "runner_test_preprocess: trace-11:", $testnum,"\n";
         if (!$listonly) {
+            print "runner_test_preprocess: trace-12:", $testnum,"\n";
             $why = singletest_precheck($testnum);
+            print "runner_test_preprocess: trace-13:", $testnum,"\n";
             $error = -1;
         }
     }

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -399,6 +399,7 @@ sub logslocked {
             push @locks, $1;
         }
     }
+    print "logslocked: trace-1", scalar @locks, "\n";
     return @locks;
 }
 
@@ -413,19 +414,25 @@ sub waitlockunlock {
     # of time until the server removes it, or the given time expires.
     my $serverlogslocktimeout = shift;
 
+    print "waitlockunlock: trace-1 ", $serverlogslocktimeout, "\n";
+
     if($serverlogslocktimeout) {
         my $lockretry = $serverlogslocktimeout * 20;
         my @locks;
+        print "waitlockunlock: trace-2 ", $lockretry, "\n";
         while((@locks = logslocked()) && $lockretry--) {
             portable_sleep(0.05);
         }
+        print "waitlockunlock: trace-3 ", $lockretry, "\n";
         if(($lockretry < 0) &&
            ($serverlogslocktimeout >= $defserverlogslocktimeout)) {
+            print "waitlockunlock: trace-4\n";
             logmsg "Warning: server logs lock timeout ",
                    "($serverlogslocktimeout seconds) expired (locks: " .
                    join(", ", @locks) . ")\n";
         }
     }
+    print "waitlockunlock: trace-5\n";
 }
 
 #######################################################################

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1525,8 +1525,11 @@ sub ipcrecv {
 ###################################################################
 # Kill all server processes
 sub runner_stopservers {
+    print "runner_stopservers: trace-0\n";
     my $error = stopservers($verbose);
+    print "runner_stopservers: trace-1\n";
     my $logs = clearlogs();
+    print "runner_stopservers: trace-2\n";
     return ($error, $logs);
 }
 

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1465,7 +1465,6 @@ sub runnerabort{
 sub ipcrecv {
     my $err;
     my $datalen;
-    print "ipcrecv: trace-1\n";
     while(! defined ($err = sysread($runnerr, $datalen, 4)) || $err <= 0) {
         print "ipcrecv: trace-1a\n";
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {
@@ -1476,10 +1475,8 @@ sub ipcrecv {
         }
         # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
-    print "ipcrecv: trace-2\n";
     my $len=unpack("L", $datalen);
     my $buf;
-    print "ipcrecv: trace-3\n";
     while(! defined ($err = sysread($runnerr, $buf, $len)) || $err <= 0) {
         print "ipcrecv: trace-3a\n";
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {
@@ -1490,7 +1487,6 @@ sub ipcrecv {
         }
         # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
-    print "ipcrecv: trace-4\n";
 
     # Decode the function name and arguments
     my $argsarrayref = thaw $buf;
@@ -1518,13 +1514,11 @@ sub ipcrecv {
     } else {
         die "Unknown IPC function $funcname\n";
     }
-    print "ipcrecv: trace-6\n";
     # print "ipcrecv results\n";
 
     # Marshall the results to return
     $buf = freeze \@res;
 
-    print "ipcrecv: trace-7\n";
     while(! defined ($err = syswrite($runnerw, (pack "L", length($buf)) . $buf)) || $err <= 0) {
         print "ipcrecv: trace-7a\n";
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {
@@ -1535,7 +1529,6 @@ sub ipcrecv {
         }
         # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
-    print "ipcrecv: trace-8\n";
 
     return 0;
 }

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1241,7 +1241,13 @@ sub runner_test_preprocess {
             $error = -1;
         }
     }
-    return ($why, $error, clearlogs(), \%testtimings);
+    print "runner_test_preprocess: trace-14:", $testnum,"\n";
+
+    my $clres = clearlogs();
+
+    print "runner_test_preprocess: trace-15:", $testnum,"\n";
+
+    return ($why, $error, $clres, \%testtimings);
 }
 
 

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1239,9 +1239,13 @@ sub runner_test_preprocess {
 sub runner_test_run {
     my ($testnum)=@_;
 
+    print "runner_test_run: trace-1\n";
+
     if(clearlogs()) {
         logmsg "Warning: log messages were lost\n";
     }
+
+    print "runner_test_run: trace-2\n";
 
     #######################################################################
     # Prepare the test environment to run this test case
@@ -1249,6 +1253,8 @@ sub runner_test_run {
     if($error) {
         return (-2, clearlogs());
     }
+
+    print "runner_test_run: trace-3\n";
 
     #######################################################################
     # Run the test command
@@ -1263,12 +1269,16 @@ sub runner_test_run {
         return (-2, clearlogs(), \%testtimings);
     }
 
+    print "runner_test_run: trace-4\n";
+
     #######################################################################
     # Clean up after test command
     $error = singletest_clean($testnum, $dumped_core, \%testtimings);
     if($error) {
         return ($error, clearlogs(), \%testtimings);
     }
+
+    print "runner_test_run: trace-5\n";
 
     #######################################################################
     # Verify that the postcheck succeeded
@@ -1277,9 +1287,13 @@ sub runner_test_run {
         return ($error, clearlogs(), \%testtimings);
     }
 
+    print "runner_test_run: trace-6\n";
+
     #######################################################################
     # restore environment variables that were modified
     restore_test_env(0);
+
+    print "runner_test_run: trace-7\n";
 
     return (0, clearlogs(), \%testtimings, $cmdres, $CURLOUT, $tool, $usedvalgrind);
 }

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1447,7 +1447,9 @@ sub runnerabort{
 sub ipcrecv {
     my $err;
     my $datalen;
+    print "iprecv: trace-1\n";
     while(! defined ($err = sysread($runnerr, $datalen, 4)) || $err <= 0) {
+        print "iprecv: trace-1a\n";
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {
             # pipe has closed; controller is gone and we must exit
             runnerabort();
@@ -1456,9 +1458,12 @@ sub ipcrecv {
         }
         # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
+    print "iprecv: trace-2\n";
     my $len=unpack("L", $datalen);
     my $buf;
+    print "iprecv: trace-3\n";
     while(! defined ($err = sysread($runnerr, $buf, $len)) || $err <= 0) {
+        print "iprecv: trace-3a\n";
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {
             # pipe has closed; controller is gone and we must exit
             runnerabort();
@@ -1467,6 +1472,7 @@ sub ipcrecv {
         }
         # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
+    print "iprecv: trace-4\n";
 
     # Decode the function name and arguments
     my $argsarrayref = thaw $buf;
@@ -1477,6 +1483,7 @@ sub ipcrecv {
     # print "ipcrecv $funcname\n";
     # Synchronously call the desired function
     my @res;
+    print "iprecv: trace-5\n";
     if($funcname eq "runner_shutdown") {
         runner_shutdown(@$argsarrayref);
         # Special case: no response will be forthcoming
@@ -1493,12 +1500,15 @@ sub ipcrecv {
     } else {
         die "Unknown IPC function $funcname\n";
     }
+    print "iprecv: trace-6\n";
     # print "ipcrecv results\n";
 
     # Marshall the results to return
     $buf = freeze \@res;
 
+    print "iprecv: trace-7\n";
     while(! defined ($err = syswrite($runnerw, (pack "L", length($buf)) . $buf)) || $err <= 0) {
+        print "iprecv: trace-7a\n";
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {
             # pipe has closed; controller is gone and we must exit
             runnerabort();
@@ -1507,6 +1517,7 @@ sub ipcrecv {
         }
         # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
+    print "iprecv: trace-8\n";
 
     return 0;
 }

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1239,13 +1239,13 @@ sub runner_test_preprocess {
 sub runner_test_run {
     my ($testnum)=@_;
 
-    print "runner_test_run: trace-1\n";
+    print "runner_test_run: trace-1:", $testnum,"\n";
 
     if(clearlogs()) {
         logmsg "Warning: log messages were lost\n";
     }
 
-    print "runner_test_run: trace-2\n";
+    print "runner_test_run: trace-2:", $testnum,"\n";
 
     #######################################################################
     # Prepare the test environment to run this test case
@@ -1254,7 +1254,7 @@ sub runner_test_run {
         return (-2, clearlogs());
     }
 
-    print "runner_test_run: trace-3\n";
+    print "runner_test_run: trace-3:", $testnum,"\n";
 
     #######################################################################
     # Run the test command
@@ -1269,7 +1269,7 @@ sub runner_test_run {
         return (-2, clearlogs(), \%testtimings);
     }
 
-    print "runner_test_run: trace-4\n";
+    print "runner_test_run: trace-4:", $testnum,"\n";
 
     #######################################################################
     # Clean up after test command
@@ -1278,7 +1278,7 @@ sub runner_test_run {
         return ($error, clearlogs(), \%testtimings);
     }
 
-    print "runner_test_run: trace-5\n";
+    print "runner_test_run: trace-5:", $testnum,"\n";
 
     #######################################################################
     # Verify that the postcheck succeeded
@@ -1287,15 +1287,19 @@ sub runner_test_run {
         return ($error, clearlogs(), \%testtimings);
     }
 
-    print "runner_test_run: trace-6\n";
+    print "runner_test_run: trace-6:", $testnum,"\n";
 
     #######################################################################
     # restore environment variables that were modified
     restore_test_env(0);
 
-    print "runner_test_run: trace-7\n";
+    print "runner_test_run: trace-7:", $testnum,"\n";
 
-    return (0, clearlogs(), \%testtimings, $cmdres, $CURLOUT, $tool, $usedvalgrind);
+    my $clres := clearlogs()
+
+    print "runner_test_run: trace-8:", $testnum,"\n";
+
+    return (0, $clres, \%testtimings, $cmdres, $CURLOUT, $tool, $usedvalgrind);
 }
 
 # Async call runner_shutdown

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1483,7 +1483,7 @@ sub ipcrecv {
     # print "ipcrecv $funcname\n";
     # Synchronously call the desired function
     my @res;
-    print "iprecv: trace-5\n";
+    print "iprecv: trace-5: $funcname\n";
     if($funcname eq "runner_shutdown") {
         runner_shutdown(@$argsarrayref);
         # Special case: no response will be forthcoming

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1465,9 +1465,9 @@ sub runnerabort{
 sub ipcrecv {
     my $err;
     my $datalen;
-    print "iprecv: trace-1\n";
+    print "ipcrecv: trace-1\n";
     while(! defined ($err = sysread($runnerr, $datalen, 4)) || $err <= 0) {
-        print "iprecv: trace-1a\n";
+        print "ipcrecv: trace-1a\n";
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {
             # pipe has closed; controller is gone and we must exit
             runnerabort();
@@ -1476,12 +1476,12 @@ sub ipcrecv {
         }
         # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
-    print "iprecv: trace-2\n";
+    print "ipcrecv: trace-2\n";
     my $len=unpack("L", $datalen);
     my $buf;
-    print "iprecv: trace-3\n";
+    print "ipcrecv: trace-3\n";
     while(! defined ($err = sysread($runnerr, $buf, $len)) || $err <= 0) {
-        print "iprecv: trace-3a\n";
+        print "ipcrecv: trace-3a\n";
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {
             # pipe has closed; controller is gone and we must exit
             runnerabort();
@@ -1490,7 +1490,7 @@ sub ipcrecv {
         }
         # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
-    print "iprecv: trace-4\n";
+    print "ipcrecv: trace-4\n";
 
     # Decode the function name and arguments
     my $argsarrayref = thaw $buf;
@@ -1501,7 +1501,7 @@ sub ipcrecv {
     # print "ipcrecv $funcname\n";
     # Synchronously call the desired function
     my @res;
-    print "iprecv: trace-5: $funcname\n";
+    print "ipcrecv: trace-5: $funcname\n";
     if($funcname eq "runner_shutdown") {
         runner_shutdown(@$argsarrayref);
         # Special case: no response will be forthcoming
@@ -1518,15 +1518,15 @@ sub ipcrecv {
     } else {
         die "Unknown IPC function $funcname\n";
     }
-    print "iprecv: trace-6\n";
+    print "ipcrecv: trace-6\n";
     # print "ipcrecv results\n";
 
     # Marshall the results to return
     $buf = freeze \@res;
 
-    print "iprecv: trace-7\n";
+    print "ipcrecv: trace-7\n";
     while(! defined ($err = syswrite($runnerw, (pack "L", length($buf)) . $buf)) || $err <= 0) {
-        print "iprecv: trace-7a\n";
+        print "ipcrecv: trace-7a\n";
         if((!defined $err && ! $!{EINTR}) || (defined $err && $err == 0)) {
             # pipe has closed; controller is gone and we must exit
             runnerabort();
@@ -1535,7 +1535,7 @@ sub ipcrecv {
         }
         # system call was interrupted, probably by ^C; restart it so we stay in sync
     }
-    print "iprecv: trace-8\n";
+    print "ipcrecv: trace-8\n";
 
     return 0;
 }

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -1295,7 +1295,7 @@ sub runner_test_run {
 
     print "runner_test_run: trace-7:", $testnum,"\n";
 
-    my $clres := clearlogs()
+    my $clres = clearlogs();
 
     print "runner_test_run: trace-8:", $testnum,"\n";
 

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3086,15 +3086,21 @@ my $sofar = time() - $start;
 # Finish CI Test Run
 citest_finishtestrun();
 
+logmsg "shutdown: trace-1\n";
 # Tests done, stop the servers
 foreach my $runnerid (values %runnerids) {
+    logmsg "shutdown: trace-1a\n";
     runnerac_stopservers($runnerid);
+    logmsg "shutdown: trace-1b\n";
 }
 
 # Wait for servers to stop
 my $unexpected;
+logmsg "shutdown: trace-2\n";
 foreach my $runnerid (values %runnerids) {
+    logmsg "shutdown: trace-2a\n";
     my ($rid, $unexpect, $logs) = runnerar($runnerid);
+    logmsg "shutdown: trace-2b\n";
     $unexpected ||= $unexpect;
     logmsg $logs;
 }
@@ -3103,8 +3109,11 @@ foreach my $runnerid (values %runnerids) {
 # There is a race condition here since we don't know exactly when the runners
 # have each finished shutting themselves down, but we're about to exit so it
 # doesn't make much difference.
+logmsg "shutdown: trace-3\n";
 foreach my $runnerid (values %runnerids) {
+    logmsg "shutdown: trace-3a\n";
     runnerac_shutdown($runnerid);
+    logmsg "shutdown: trace-3b\n";
     sleep 0;  # give runner a context switch so it can shut itself down
 }
 

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2906,9 +2906,13 @@ sub stopservers {
     #
     my $result = 0;
     foreach my $server (keys %serverpidfile) {
+        print "stopservers: trace-3a:", $server, "\n";
         my $pidfile = $serverpidfile{$server};
+        print "stopservers: trace-3b: $pidfile\n";
         my $pid = processexists($pidfile);
+        print "stopservers: trace-3c:", $pid, "\n";
         if($pid > 0) {
+            print "stopservers: trace-3d:", $pid, "\n";
             if($err_unexpected) {
                 logmsg "ERROR: ";
                 $result = -1;
@@ -2917,11 +2921,13 @@ sub stopservers {
                 logmsg "Warning: ";
             }
             logmsg "$server server unexpectedly alive\n";
-            print "stopservers: trace-3a\n";
+            print "stopservers: trace-3e\n";
             killpid($verb, $pid);
-            print "stopservers: trace-3b\n";
+            print "stopservers: trace-3f\n";
         }
+        print "stopservers: trace-3g\n";
         unlink($pidfile) if(-f $pidfile);
+        print "stopservers: trace-3h\n";
     }
     print "stopservers: trace-4\n";
 

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2873,7 +2873,9 @@ sub stopservers {
     #
     # kill sockfilter processes for all pingpong servers
     #
+    print "stopservers: trace-0\n";
     killallsockfilters("$LOGDIR/$PIDDIR", $verb);
+    print "stopservers: trace-1\n";
     #
     # kill all server pids from %run hash clearing them
     #
@@ -2896,7 +2898,9 @@ sub stopservers {
         }
         $runcert{$server} = 0 if($runcert{$server});
     }
+    print "stopservers: trace-2\n";
     killpid($verb, $pidlist);
+    print "stopservers: trace-3\n";
     #
     # cleanup all server pid files
     #
@@ -2913,10 +2917,13 @@ sub stopservers {
                 logmsg "Warning: ";
             }
             logmsg "$server server unexpectedly alive\n";
+            print "stopservers: trace-3a\n";
             killpid($verb, $pid);
+            print "stopservers: trace-3b\n";
         }
         unlink($pidfile) if(-f $pidfile);
     }
+    print "stopservers: trace-4\n";
 
     return $result;
 }

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -2906,13 +2906,13 @@ sub stopservers {
     #
     my $result = 0;
     foreach my $server (keys %serverpidfile) {
-        print "stopservers: trace-3a:", $server, "\n";
+        print "stopservers: trace-3a: $server\n";
         my $pidfile = $serverpidfile{$server};
         print "stopservers: trace-3b: $pidfile\n";
         my $pid = processexists($pidfile);
-        print "stopservers: trace-3c:", $pid, "\n";
+        print "stopservers: trace-3c: ", $pid, "\n";
         if($pid > 0) {
-            print "stopservers: trace-3d:", $pid, "\n";
+            print "stopservers: trace-3d: ", $pid, "\n";
             if($err_unexpected) {
                 logmsg "ERROR: ";
                 $result = -1;


### PR DESCRIPTION
It often happens that Windows jobs hang after finishing all tests:
```
--p-u--em-- OK (1751 out of 1751, remaining: 00:00, took 0.271s, duration: 03:13)
test 3102...[verify certificate chain order with simple HTTPS GET]
--p----em-- OK (1738 out of 1751, remaining: 00:01, took 2.542s, duration: 03:14)
test 3208...[easy_perform, multi_perform, easy_perform the same handle]
--p----em-- OK (1749 out of 1751, remaining: 00:00, took 2.400s, duration: 03:15)
```
Then they time out, with the whole step log disappearing:
https://github.com/curl/curl/actions/runs/14094231429/job/39478083888?pr=16833

```
Thu, 27 Mar 2025 00:44:17 GMT
iprecv: trace-3
Thu, 27 Mar 2025 00:44:17 GMT
iprecv: trace-4
Thu, 27 Mar 2025 00:44:17 GMT
iprecv: trace-5: runner_stopservers
Thu, 27 Mar 2025 00:44:24 GMT
Error: Process completed with exit code 2304.
```
https://github.com/curl/curl/actions/runs/14095548151/job/39484167473?pr=16840#step:15:30934

```
Sat, 29 Mar 2025 13:19:31 GMT
  stopservers: trace-0
Sat, 29 Mar 2025 13:19:31 GMT
  iprecv: trace-2
Sat, 29 Mar 2025 13:19:31 GMT
  iprecv: trace-3
Sat, 29 Mar 2025 13:19:31 GMT
  iprecv: trace-4
Sat, 29 Mar 2025 13:19:31 GMT
  iprecv: trace-5: runner_stopservers
Sat, 29 Mar 2025 13:19:31 GMT
  runner_stopservers: trace-0
Sat, 29 Mar 2025 13:19:31 GMT
  stopservers: trace-0
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-1
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-2
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-1
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-2
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-1
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-2
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-1
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-2
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-1
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-2
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-1
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-2
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-1
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-2
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-1
Sat, 29 Mar 2025 13:19:33 GMT
  stopservers: trace-2
Sat, 29 Mar 2025 13:19:37 GMT
  stopservers: trace-3
Sat, 29 Mar 2025 13:19:37 GMT
Error: Process completed with exit code 2304.
```
https://github.com/curl/curl/actions/runs/14145291245/job/39633296903?pr=16840#step:15:30906

```
Sun, 30 Mar 2025 21:16:37 GMT
test 0292...[HTTP GET with maximum filesize not exceeded]
Sun, 30 Mar 2025 21:16:37 GMT
--pd---e--- OK (247 out of 1555, remaining: 02:08, took 0.194s, iprecv: trace-2
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:37 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:38 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:39 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_run
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_preprocess
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-6
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-7
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-8
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-1
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-2
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-3
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-4
Sun, 30 Mar 2025 21:16:40 GMT
iprecv: trace-5: runner_test_run
[hang/infinite loop]
```
https://github.com/curl/curl/actions/runs/14160007665/job/39664200057?pr=16840

Failing with nothing particular, dl-mingw, CM 9.5.0-x86_64 schannel, greyed step, visible log:
```
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_preprocess: trace-10:1395
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_preprocess: trace-11:1395
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_preprocess: trace-12:1395
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_preprocess: trace-13:1395
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_preprocess: trace-14:1395
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_preprocess: trace-15:1395
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-4:1389
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-5:1389
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-6:1389
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-7:1389
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-8:1389
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-4:1392
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-5:1392
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-6:1392
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-7:1392
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-8:1392
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-4:1390
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-5:1390
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-6:1390
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-7:1390
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-8:1390
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-4:1388
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-5:1388
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-6:1388
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-7:1388
Mon, 31 Mar 2025 08:41:05 GMT
runner_test_run: trace-8:1388
Mon, 31 Mar 2025 08:41:05 GMT
on: 01:54)
Mon, 31 Mar 2025 08:41:05 GMT
test 1338...[HTTP GET with -O -J without Content-Disposition, -D file]
Mon, 31 Mar 2025 08:41:05 GMT
--p---oe--- OK (1119 out of 1556, remaining: 00:44, took 0.254s, duration: 01:54)
Mon, 31 Mar 2025 08:41:05 GMT
test 1321...[IMAP FETCH tunneled through HTTP proxy]
Mon, 31 Mar 2025 08:41:05 GMT
--pd-P-e--- OK (1103 out of 1556, remaining: 00:46, took 1.604s, duration: 01:54)
Mon, 31 Mar 2025 08:41:05 GMT
test 1339...[HTTP GET with -O -J without Content-Disposition, -D stdout]
Mon, 31 Mar 2025 08:41:05 GMT
--p---oe--- OK (1120 out of 1556, remaining: 00:44, took 0.263s, duration: 01:54)
Mon, 31 Mar 2025 08:41:05 GMT
test 1340...[HTTP GET with -O -J and Content-Disposition, -D file]
Mon, 31 Mar 2025 08:41:05 GMT
--p---oe--- OK (1121 out of 1556, remaining: 00:44, took 0.271s, duration: 01:54)
Mon, 31 Mar 2025 08:41:05 GMT
test 1341...[HTTP GET with -O -J and Content-Disposition, -D stdout]
Mon, 31 Mar 2025 08:41:05 GMT
--p---oe--- OK (1122 out of 1556, remaining: 00:44, took 0.298s, duration: 01:54)
Mon, 31 Mar 2025 08:41:05 GMT
test 1342...[HTTP GET with -O -i without Content-Disposition, -D file]
Mon, 31 Mar 2025 08:41:05 GMT
--p---oe--- OK (1123 out of 1556, remaining: 00:44, took 0.359s, duration: 01:54)
Mon, 31 Mar 2025 08:41:05 GMT
test 1343...[HTTP GET with -O -i without Content-Disposition, -D stdout]
Mon, 31 Mar 2025 08:41:05 GMT
--p---oe--- OK (1124 out of 1556, remaining: 00:44, took 0.353s, duration: 01:54)
Mon, 31 Mar 2025 08:41:05 GMT
test 1344...[HTTP GET with -O -i and Content-Disposition, -D file]
```
https://github.com/curl/curl/actions/runs/14162991219/job/39683548984?pr=16840#step:15:32163

msvc, CM x64-windows mbedtls libssh, hung, then the step disappeared:
```
Mon, 31 Mar 2025 10:35:17 GMT
  runner_test_preprocess: trace-12:351
Mon, 31 Mar 2025 10:35:17 GMT
  runner_test_preprocess: trace-13:351
Mon, 31 Mar 2025 10:35:17 GMT
  runner_test_preprocess: trace-14:351
Mon, 31 Mar 2025 10:35:17 GMT
  runner_test_preprocess: trace-15:351
Mon, 31 Mar 2025 10:35:17 GMT
  ipcrecv: trace-5: runner_test_run
Mon, 31 Mar 2025 10:35:17 GMT
  runner_test_run: trace-1:351
Mon, 31 Mar 2025 10:35:17 GMT
  runner_test_run: trace-2:351
Mon, 31 Mar 2025 10:35:17 GMT
  runner_test_run: trace-3:351
Mon, 31 Mar 2025 10:35:17 GMT
  killpid: trace-3a1
Mon, 31 Mar 2025 10:35:17 GMT
  killpid: trace-3a1a
Mon, 31 Mar 2025 10:35:17 GMT
  runner_test_preprocess: trace-7:352
[stall/hang]
```
https://github.com/curl/curl/actions/runs/14162991219/job/39689966056?pr=16840#step:15:10257

msvc, CM x64-windows openssl, final cleanup stage:
```
Mon, 31 Mar 2025 11:44:33 GMT
  RUN: Process with pid 6963 gracefully died
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-4
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-5
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-5a
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-5aa: 4195692
Mon, 31 Mar 2025 11:44:33 GMT
  pidwait: trace-1: 4195692
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1a
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1a
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1a
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1a
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1a
Mon, 31 Mar 2025 11:44:33 GMT
  RUN: Process with pid 5298 gracefully died
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1a
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1a
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1a
Mon, 31 Mar 2025 11:44:33 GMT
  pidwait: trace-2: 4200172
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-5aa: 4201796
Mon, 31 Mar 2025 11:44:33 GMT
  pidwait: trace-1: 4201796
Mon, 31 Mar 2025 11:44:33 GMT
  killpid: trace-3a1
Mon, 31 Mar 2025 11:44:33 GMT
Error: Process completed with exit code 2304.
```
https://github.com/curl/curl/actions/runs/14170605188/job/39693354655?pr=16840#step:15:68134

Ref: #14854
