### PR TITLE
test make, add dependency on build-certs

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -197,7 +197,7 @@ checksrc:
 	(cd server && $(MAKE) checksrc)
 	(cd http && $(MAKE) checksrc)
 
-all-local: $(MANFILES)
+all-local: $(MANFILES) build-certs
 
 distclean:
 	rm -f $(MANFILES)


### PR DESCRIPTION
Just so a `make` inside `tests` builds the certs as well.