### PR TITLE
async-threaded resolver: use ref counter

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -979,7 +979,7 @@ CURLcode Curl_set_dns_local_ip6(struct Curl_easy *data,
 void Curl_resolver_set_result(struct Curl_easy *data,
                               struct Curl_dns_entry *dnsentry)
 {
-  destroy_async_data(data);
+  Curl_resolver_cancel(data);
   data->state.async.dns = dnsentry;
   data->state.async.done = TRUE;
 }

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -975,6 +975,15 @@ CURLcode Curl_set_dns_local_ip6(struct Curl_easy *data,
   return CURLE_NOT_BUILT_IN;
 #endif
 }
+
+void Curl_resolver_set_result(struct Curl_easy *data,
+                              struct Curl_dns_entry *dnsentry)
+{
+  destroy_async_data(data);
+  data->state.async.dns = dnsentry;
+  data->state.async.done = TRUE;
+}
+
 #endif /* CURLRES_ARES */
 
 #endif /* USE_ARES */

--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -51,7 +51,7 @@ struct thread_sync_data {
 #endif
   int port;
   int sock_error;
-  bool done;
+  int ref_count;
 };
 
 struct thread_data {
@@ -59,7 +59,7 @@ struct thread_data {
   unsigned int poll_interval;
   timediff_t interval_end;
   struct curltime start;
-  struct thread_sync_data tsd;
+  struct thread_sync_data *tsd;
   CURLcode result; /* CURLE_OK or error handling response */
 #if defined(USE_HTTPSRR) && defined(USE_ARES)
   struct Curl_https_rrinfo hinfo;
@@ -227,6 +227,13 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
                                                 int port,
                                                 int *waitp);
 
+/*
+ * Set `dnsentry` as result of resolve operation, replacing any
+ * ongoing resolve attempts.
+ */
+void Curl_resolver_set_result(struct Curl_easy *data,
+                              struct Curl_dns_entry *dnsentry);
+
 #ifndef CURLRES_ASYNCH
 /* convert these functions if an asynch resolver is not used */
 #define Curl_resolver_cancel(x) Curl_nop_stmt
@@ -237,6 +244,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
 #define Curl_resolver_init(x,y) CURLE_OK
 #define Curl_resolver_global_init() CURLE_OK
 #define Curl_resolver_global_cleanup() Curl_nop_stmt
+#define Curl_resolver_set_result(x,y) Curl_nop_stmt
 #define Curl_resolver_cleanup(x) Curl_nop_stmt
 #endif
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2086,10 +2086,8 @@ static CURLMcode state_resolving(struct Curl_multi *multi,
   dns = Curl_fetch_addr(data, hostname, conn->primary.remote_port);
 
   if(dns) {
-#ifdef USE_CURL_ASYNC
-    data->state.async.dns = dns;
-    data->state.async.done = TRUE;
-#endif
+    /* Tell a possibly async resolver we no longer need the results. */
+    Curl_resolver_set_result(data, dns);
     result = CURLE_OK;
     infof(data, "Hostname '%s' was found in DNS cache", hostname);
   }

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -344,10 +344,8 @@ static CURLproxycode do_SOCKS4(struct Curl_cfilter *cf,
     dns = Curl_fetch_addr(data, sx->hostname, conn->primary.remote_port);
 
     if(dns) {
-#ifdef USE_CURL_ASYNC
-      data->state.async.dns = dns;
-      data->state.async.done = TRUE;
-#endif
+      /* Tell a possibly async resolver we no longer need the results. */
+      Curl_resolver_set_result(data, dns);
       infof(data, "Hostname '%s' was found", sx->hostname);
       sxstate(sx, data, CONNECT_RESOLVED);
     }
@@ -814,10 +812,8 @@ CONNECT_REQ_INIT:
     dns = Curl_fetch_addr(data, sx->hostname, sx->remote_port);
 
     if(dns) {
-#ifdef USE_CURL_ASYNC
-      data->state.async.dns = dns;
-      data->state.async.done = TRUE;
-#endif
+      /* Tell a possibly async resolver we no longer need the results. */
+      Curl_resolver_set_result(data, dns);
       infof(data, "SOCKS5: hostname '%s' found", sx->hostname);
     }
 


### PR DESCRIPTION
Allocate the data shared between a transfer and an aync resolver thread separately and use a reference counter to determine its release.