### PR TITLE
docs: add rustls --ca-native & CURLSSLOPT_NATIVE_CA

### DIFF
--- a/docs/cmdline-opts/ca-native.md
+++ b/docs/cmdline-opts/ca-native.md
@@ -32,6 +32,11 @@ Fedora, RHEL), macOS, Android and iOS. (Added in 8.3.0)
 
 This option works with GnuTLS. (Added in 8.5.0)
 
+This options works with rustls on Windows, macOS, Android and iOS. On Linux it
+is equivalent to using the Mozilla CA certificate bundle. When used with rustls
+_only_ the native CA store is consulted, not other locations set at run time or
+build time. (Added in 8.13.0)
+
 This option currently has no effect for Schannel or Secure Transport. Those are
 native TLS libraries from Microsoft and Apple, respectively, that by default
 use the native CA store for verification unless overridden by a CA certificate

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -76,6 +76,11 @@ Works with wolfSSL on Windows, Linux (Debian, Ubuntu, Gentoo, Fedora, RHEL),
 macOS, Android and iOS (added in 8.3.0); with GnuTLS (added in 8.5.0) and with
 OpenSSL and its forks (LibreSSL, BoringSSL, etc) on Windows (Added in 7.71.0).
 
+This works with rustls on Windows, macOS, Android and iOS. On Linux it is
+equivalent to using the Mozilla CA certificate bundle. When used with rustls
+_only_ the native CA store is consulted, not other locations set at run time or
+build time. (Added in 8.13.0)
+
 ## CURLSSLOPT_AUTO_CLIENT_CERT
 
 Tell libcurl to automatically locate and use a client certificate for


### PR DESCRIPTION
The one important caveat is that presently _only_ the native platform verifier/CAs are consulted when this option is used w/ rustls.

Follow-up from https://github.com/curl/curl/pull/16828
Resolves https://github.com/curl/curl/issues/16842