### PR TITLE
GHA/linux: move pytests to non-valgrind job variants, drop 2 redundant runs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -156,7 +156,6 @@ jobs:
 
           - name: openssl libssh2 sync-resolver valgrind
             install_packages: zlib1g-dev libssh2-1-dev valgrind
-            install_steps: pytest
             configure: --with-openssl --enable-debug --disable-threaded-resolver --with-libssh2
 
           - name: openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -155,7 +155,7 @@ jobs:
             configure: --with-openssl --enable-debug --disable-unity
 
           - name: openssl libssh2 sync-resolver valgrind
-            install_packages: zlib1g-dev libssh2-1-dev valgrind
+            install_packages: zlib1g-dev libssh2-1-dev libnghttp2-dev libldap-dev valgrind
             configure: --with-openssl --enable-debug --disable-threaded-resolver --with-libssh2
 
           - name: openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,12 +80,12 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
 
           - name: libressl heimdal
-            install_packages: zlib1g-dev heimdal-dev
+            install_packages: zlib1g-dev libnghttp2-dev heimdal-dev
             install_steps: libressl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --with-gssapi --enable-debug
 
           - name: libressl heimdal valgrind
-            install_packages: zlib1g-dev heimdal-dev valgrind
+            install_packages: zlib1g-dev libnghttp2-dev heimdal-dev valgrind
             install_steps: libressl
             generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
 
@@ -266,11 +266,12 @@ jobs:
             tflags: -n --test-duphandle '!TLS-SRP'
 
           - name: rustls valgrind
-            install_packages: valgrind
+            install_packages: libnghttp2-dev valgrind
             install_steps: rust rustls
             configure: --with-rustls --enable-ech --enable-debug
 
           - name: rustls
+            install_packages: libnghttp2-dev
             install_steps: rust rustls skipall pytest
             generate: -DCURL_USE_RUSTLS=ON -DUSE_ECH=ON -DENABLE_DEBUG=ON
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -86,7 +86,7 @@ jobs:
 
           - name: libressl heimdal valgrind
             install_packages: zlib1g-dev heimdal-dev valgrind
-            install_steps: libressl pytest
+            install_steps: libressl
             generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
 
           - name: libressl clang
@@ -106,12 +106,12 @@ jobs:
 
           - name: mbedtls valgrind
             install_packages: libnghttp2-dev valgrind
-            install_steps: mbedtls pytest
+            install_steps: mbedtls
             configure: LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
 
           - name: mbedtls clang
             install_packages: libnghttp2-dev clang
-            install_steps: mbedtls
+            install_steps: mbedtls pytest
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
 
           - name: mbedtls
@@ -267,11 +267,11 @@ jobs:
 
           - name: rustls valgrind
             install_packages: valgrind
-            install_steps: rust rustls pytest
+            install_steps: rust rustls
             configure: --with-rustls --enable-ech --enable-debug
 
           - name: rustls
-            install_steps: rust rustls skipall
+            install_steps: rust rustls skipall pytest
             generate: -DCURL_USE_RUSTLS=ON -DUSE_ECH=ON -DENABLE_DEBUG=ON
 
           - name: IntelC openssl

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,12 +80,12 @@ jobs:
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/bearssl/lib" --with-bearssl=$HOME/bearssl --enable-debug
 
           - name: libressl heimdal
-            install_packages: zlib1g-dev libnghttp2-dev heimdal-dev
+            install_packages: zlib1g-dev libnghttp2-dev libldap-dev heimdal-dev
             install_steps: libressl pytest
             configure: LDFLAGS="-Wl,-rpath,$HOME/libressl/lib" --with-openssl=$HOME/libressl --with-gssapi --enable-debug
 
           - name: libressl heimdal valgrind
-            install_packages: zlib1g-dev libnghttp2-dev heimdal-dev valgrind
+            install_packages: zlib1g-dev libnghttp2-dev libldap-dev heimdal-dev valgrind
             install_steps: libressl
             generate: -DOPENSSL_ROOT_DIR=$HOME/libressl -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
 
@@ -105,12 +105,12 @@ jobs:
             configure: LDFLAGS="-Wl,-rpath,$HOME/wolfssl-opensslextra/lib" --with-wolfssl=$HOME/wolfssl-opensslextra --enable-ech --enable-debug
 
           - name: mbedtls valgrind
-            install_packages: libnghttp2-dev valgrind
+            install_packages: libnghttp2-dev libldap-dev valgrind
             install_steps: mbedtls
             configure: LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
 
           - name: mbedtls clang
-            install_packages: libnghttp2-dev clang
+            install_packages: libnghttp2-dev libldap-dev clang
             install_steps: mbedtls pytest
             configure: CC=clang LDFLAGS="-Wl,-rpath,$HOME/mbedtls/lib" --with-mbedtls=$HOME/mbedtls --enable-debug
 
@@ -266,12 +266,12 @@ jobs:
             tflags: -n --test-duphandle '!TLS-SRP'
 
           - name: rustls valgrind
-            install_packages: libnghttp2-dev valgrind
+            install_packages: libnghttp2-dev libldap-dev valgrind
             install_steps: rust rustls
             configure: --with-rustls --enable-ech --enable-debug
 
           - name: rustls
-            install_packages: libnghttp2-dev
+            install_packages: libnghttp2-dev libldap-dev
             install_steps: rust rustls skipall pytest
             generate: -DCURL_USE_RUSTLS=ON -DUSE_ECH=ON -DENABLE_DEBUG=ON
 


### PR DESCRIPTION
- move pytest from the valgrind variant of the mbedTLS and Rustls jobs
  to their non-valgrind counterpart (they different in C compiler and
  build tool respectively). To parallelize more and finish the workflow
  faster.

- drop pytest from the valgrind variant of the two identical (other than
  the build tool) 'libressl heimdal' jobs. Saves 1.5 minutes CI time.

- drop pytest from the longest valgrind job to make the workflow finish
  almost 2 minutes faster. `sync-resolver` is its unique build propery.
  It wasn't pytested on Azure.

- explicitly install `libnghttp2-dev` and `libldap-dev` to keep them in
  jobs where pytest deps were installing them implicitly before this
  patch.

Before: https://github.com/curl/curl/actions/runs/14118080563
After: https://github.com/curl/curl/actions/runs/14118903372?pr=16851