### PR TITLE
vquic: recv msg buffer size and error handling

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -356,6 +356,7 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
                                  vquic_recv_pkt_cb *recv_cb, void *userp)
 {
 #define MMSG_NUM  16
+#define MMSG_BUFSIZE  (128*1024)
   struct iovec msg_iov[MMSG_NUM];
   struct mmsghdr mmsg[MMSG_NUM];
   uint8_t msg_ctrl[MMSG_NUM * CMSG_SPACE(sizeof(int))];
@@ -368,14 +369,14 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
   size_t pktlen;
   size_t offset, to;
   char *sockbuf = NULL;
-  uint8_t (*bufs)[128*1024] = NULL;
+  uint8_t (*bufs)[MMSG_BUFSIZE] = NULL;
 
   DEBUGASSERT(max_pkts > 0);
   result = Curl_multi_xfer_sockbuf_borrow(data, MMSG_NUM * sizeof(bufs[0]),
                                           &sockbuf);
   if(result)
     goto out;
-  bufs = (uint8_t (*)[64*1024])sockbuf;
+  bufs = (uint8_t (*)[MMSG_BUFSIZE])sockbuf;
 
   total_nread = 0;
   while(pkts < max_pkts) {

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -368,7 +368,7 @@ static CURLcode recvmmsg_packets(struct Curl_cfilter *cf,
   size_t pktlen;
   size_t offset, to;
   char *sockbuf = NULL;
-  uint8_t (*bufs)[64*1024] = NULL;
+  uint8_t (*bufs)[128*1024] = NULL;
 
   DEBUGASSERT(max_pkts > 0);
   result = Curl_multi_xfer_sockbuf_borrow(data, MMSG_NUM * sizeof(bufs[0]),


### PR DESCRIPTION
Use larger buffer sizes in `recv_msg()` and `recv_mmsg()` vquic code.

Treat errno EMSGSIZE as an MTU probing attempt from the other side and do not fail the connection.

refs #16846