### PR TITLE
test313: disable CRL test for Schannel due to lack of support and flakiness

### DIFF
--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -63,7 +63,7 @@
 %if bearssl
 313
 %endif
-# The CRL test doesn't work with Schannel
+# Schannel does not support CRL file
 %if Schannel
 313
 %endif

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -63,6 +63,10 @@
 %if bearssl
 313
 %endif
+# The CRL test doesn't work with Schannel
+%if Schannel
+313
+%endif
 # Secure Transport does not support CRL file
 %if sectransp
 313


### PR DESCRIPTION
The source code and documentation says that CRL is not supported by
curl's Schannel TLS backend.

It's also frequently flaky in CI with both MinGW and MSVC jobs, e.g.:
https://github.com/curl/curl/actions/runs/14134841988/job/39603994164 (Schannel)
https://github.com/curl/curl/actions/runs/14134841988/job/39606336445 (Schannel)
https://github.com/curl/curl/actions/runs/13981383629/job/39147183706 (LibreSSL)

```
curl returned 35, when expecting 60
```

This test was passing with Schannel because it misses the `--insecure`
option and thus always returns 60, regardless of passing `--crlfile` or
not:
```
curl: (60) schannel: CertGetCertificateChain trust error CERT_TRUST_REVOCATION_STATUS_UNKNOWN
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the webpage mentioned above.
```

---

- [x] Question is why it passes test 313 at all? [ANSWERED]
