### PR TITLE
test313: disable via `<features>` for backends without CRL support

### DIFF
--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -55,14 +55,6 @@
 1801
 #
 2043
-# The CRL test doesn't work with wolfSSL
-%if wolfssl
-313
-%endif
-# The CRL test doesn't work with BearSSL
-%if bearssl
-313
-%endif
 %if WinIDN
 165
 %endif

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -63,14 +63,6 @@
 %if bearssl
 313
 %endif
-# Schannel does not support CRL file
-%if Schannel
-313
-%endif
-# Secure Transport does not support CRL file
-%if sectransp
-313
-%endif
 %if WinIDN
 165
 %endif

--- a/tests/data/test313
+++ b/tests/data/test313
@@ -14,8 +14,10 @@ CRL
 <features>
 SSL
 local-http
+!bearssl
 !Schannel
 !sectransp
+!wolfssl
 </features>
 <server>
 https test-localhost.pem

--- a/tests/data/test313
+++ b/tests/data/test313
@@ -14,6 +14,8 @@ CRL
 <features>
 SSL
 local-http
+!Schannel
+!sectransp
 </features>
 <server>
 https test-localhost.pem


### PR DESCRIPTION
Instead of via `tests/data/DISABLED` file.

They are all missing CRL feature support, as opposed to being broken.

Follow-up to 8adee8824cba23b7f3738b551a84101009f8a8d1 #16862
Follow-up to 8b1b5cd4d2df3a8c2c0108d1d2b5d519b7ece23e #16660

---

Ref: #16677
