### PR TITLE
cmake: also build certs when building test executables

### DIFF
--- a/tests/certs/CMakeLists.txt
+++ b/tests/certs/CMakeLists.txt
@@ -31,6 +31,7 @@ add_custom_command(OUTPUT ${GENERATEDCERTS}
   VERBATIM
 )
 add_custom_target(build-certs DEPENDS ${GENERATEDCERTS})
+add_dependencies(testdeps build-certs)
 
 add_custom_target(clean-certs
   COMMAND ${CMAKE_COMMAND} -E remove ${GENERATEDCERTS}


### PR DESCRIPTION
To support running tests directly via `runtests.pl` after building
the test targets. Also to sync with the same update for autotools.

Follow-up to 0c1ad21f978c8f5acf3d0c1708d83a93635d9df3 #16845
