### PR TITLE
genserv.pl: detect `openssl` in `PATH`, omit `command -v`

### DIFF
--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -49,8 +49,8 @@ if(!$CAPREFIX) {
 } elsif(! -f "$CAPREFIX-ca.cacert" ||
         ! -f "$CAPREFIX-ca.key") {
 
-    # find OpenSSL in PATH
-    if($OPENSSL eq basename($OPENSSL)) {  # has no path
+    if($OPENSSL eq basename($OPENSSL)) {  # has no dir component
+        # find openssl in PATH
         foreach(File::Spec->path()) {
             my $file = File::Spec->catfile($_, $OPENSSL);
             if(-f $file) {

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -49,20 +49,18 @@ if(!$CAPREFIX) {
 } elsif(! -f "$CAPREFIX-ca.cacert" ||
         ! -f "$CAPREFIX-ca.key") {
 
-    # Show which openssl we are actually using.
-    if($OPENSSL ne basename($OPENSSL)) {  # has path
-        print "$OPENSSL\n";
-    }
-    else {
+    # find OpenSSL in PATH
+    if($OPENSSL eq basename($OPENSSL)) {  # has no path
         foreach(File::Spec->path()) {
             my $file = File::Spec->catfile($_, $OPENSSL);
             if(-f $file) {
-                print "$file\n";
+                $OPENSSL = $file;
                 last;
             }
         }
     }
 
+    print "$OPENSSL\n";
     system("$OPENSSL version");
 
     $PREFIX = $CAPREFIX;

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -27,6 +27,7 @@ use strict;
 use warnings;
 
 use File::Basename;
+use File::Spec;
 
 my $OPENSSL = 'openssl';
 if(-f '/usr/local/ssl/bin/openssl') {
@@ -48,7 +49,20 @@ if(!$CAPREFIX) {
 } elsif(! -f "$CAPREFIX-ca.cacert" ||
         ! -f "$CAPREFIX-ca.key") {
 
-    system($^O eq 'MSWin32' ? 'which' : 'command -v' ." $OPENSSL");
+    # Show which openssl we are actually using.
+    if($OPENSSL ne basename($OPENSSL)) {  # has path
+        print "$OPENSSL\n";
+    }
+    else {
+        foreach(File::Spec->path()) {
+            my $file = File::Spec->catfile($_, $OPENSSL);
+            if(-f $file) {
+                print "$file\n";
+                last;
+            }
+        }
+    }
+
     system("$OPENSSL version");
 
     $PREFIX = $CAPREFIX;


### PR DESCRIPTION
Before this patch the script relied on Perl `system()` finding `openssl`
in `PATH`, plus tried to display the full path of `openssl` by using
`command -v` (or `which` on Windows). `command -v` did not work in CI
for unknown reasons. To resolve it, this patch detects `openssl` in
`PATH` manually, displays the detected full path and calls `openssl`
with the detected full path, and stops relying on `system` for this.

It also follows how `sshhelp.pm` is detecting executables. Though this
patch uses Perl `-f` instead of `-e && -d` used there .

Silencing this in CI logs:
```
Can't exec "command": No such file or directory at ../../../tests/certs/genserv.pl line 51.
```
Ref: https://github.com/curl/curl/actions/runs/14145795884/job/39632942668?pr=16865#step:39:108

---

- [x] perhaps this should go a step beyond and actually execute the manually detected `openssl`.
