### PR TITLE
curl_trc: provide Curl_trc_dns dummy

### DIFF
--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -612,6 +612,11 @@ void Curl_trc_write(struct Curl_easy *data, const char *fmt, ...)
   (void)data; (void)fmt;
 }
 
+void Curl_trc_dns(struct Curl_easy *data, const char *fmt, ...)
+{
+  (void)data; (void)fmt;
+}
+
 void Curl_trc_read(struct Curl_easy *data, const char *fmt, ...)
 {
   (void)data; (void)fmt;


### PR DESCRIPTION
Follow-up to 19226f9bb106347e21d1dd

For building without verbose output.