### PR TITLE
libtest/first.c: remove the Test: stderr output for unity builds

### DIFF
--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -182,8 +182,6 @@ int main(int argc, char **argv)
       fprintf(stderr, "Test '%s' not found.\n", test_name);
       return 1;
     }
-
-    fprintf(stderr, "Test: %s\n", test_name);
   }
 #else
   basearg = 1;


### PR DESCRIPTION
That makes the output differ between builds which breaks libtests doing stderr comparisons