### PR TITLE
build: drop `build-certs` as a test-run dependency

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,7 +41,7 @@ function(curl_add_runtests _targetname _test_flags)
   if(NOT BUILD_LIBCURL_DOCS)
     string(APPEND _test_flags " !documentation")
   endif()
-  set(_depends "build-certs")
+  set(_depends "")
   # Skip walking through dependent targets before running tests in CI.
   # This avoids: GNU Make doing a slow re-evaluation of all targets and
   # skipping them, MSBuild doing a re-evaluation, and actually rebuilding them.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -160,30 +160,28 @@ perlcheck:
 build-certs:
 	(cd certs && $(MAKE) build-certs)
 
-runtests-pre: perlcheck build-certs
-
-test: runtests-pre all
+test: perlcheck all
 	$(TEST) $(TFLAGS)
 
-quiet-test: runtests-pre all
+quiet-test: perlcheck all
 	$(TEST) $(TEST_Q) $(TFLAGS)
 
-am-test: runtests-pre all
+am-test: perlcheck all
 	$(TEST) $(TEST_AM) $(TFLAGS)
 
-ci-test: runtests-pre all
+ci-test: perlcheck all
 	$(TEST) $(TEST_CI) $(TFLAGS)
 
-full-test: runtests-pre all
+full-test: perlcheck all
 	$(TEST) $(TEST_F) $(TFLAGS)
 
-nonflaky-test: runtests-pre all
+nonflaky-test: perlcheck all
 	$(TEST) $(TEST_NF) $(TFLAGS)
 
-torture-test: runtests-pre all
+torture-test: perlcheck all
 	$(TEST) $(TEST_T) $(TFLAGS)
 
-event-test: runtests-pre all
+event-test: perlcheck all
 	$(TEST) $(TEST_E) $(TFLAGS)
 
 default-pytest: ci-pytest


### PR DESCRIPTION
After adding it as a test executables dependency, it run twice in
MSBuild jobs. Also there is little reason to try building them in both
build and run tests targets.

(The reason MSBuild building it twice, is our use of
`TrackFileAccess=false` to improve build performance.)

https://github.com/curl/curl/actions/runs/14156797251/job/39662914155?pr=16840#step:15:31

Follow-up to 68609f0e334359875a2f62735377174ab6b873dd #16866
Follow-up to 0c1ad21f978c8f5acf3d0c1708d83a93635d9df3 #16845
