### PR TITLE
tests: prefer `--insecure` over `-k`

### DIFF
--- a/tests/data/test1112
+++ b/tests/data/test1112
@@ -91,7 +91,7 @@ ftps
 FTPS download with strict timeout and slow data transfer
 </name>
 <command>
--k --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/%TESTNUMBER -m 5
+--insecure --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/%TESTNUMBER -m 5
 </command>
 </client>
 

--- a/tests/data/test1268
+++ b/tests/data/test1268
@@ -23,13 +23,13 @@ UnixSockets
 filename argument looks like a flag
 </name>
 <command>
---stderr %LOGDIR/moo%TESTNUMBER --unix-socket -k hej://moo
+--stderr %LOGDIR/moo%TESTNUMBER --unix-socket -q hej://moo
 </command>
 </client>
 
 <verify>
 <file name="%LOGDIR/moo%TESTNUMBER" mode="text">
-Warning: The filename argument '-k' looks like a flag.
+Warning: The filename argument '-q' looks like a flag.
 curl: (1) Protocol "hej" not supported
 </file>
 

--- a/tests/data/test1272
+++ b/tests/data/test1272
@@ -29,7 +29,7 @@ gophers
 Gophers index
 </name>
 <command>
--k gophers://%HOSTIP:%GOPHERSPORT/1/%TESTNUMBER
+--insecure gophers://%HOSTIP:%GOPHERSPORT/1/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test1470
+++ b/tests/data/test1470
@@ -44,7 +44,7 @@ socks5unix
 HTTPS GET with host name using SOCKS5h via Unix sockets
 </name>
 <command>
-https://this.is.a.host.name:%HTTPSPORT/%TESTNUMBER -k --proxy socks5h://localhost%SOCKSUNIXPATH
+https://this.is.a.host.name:%HTTPSPORT/%TESTNUMBER --insecure --proxy socks5h://localhost%SOCKSUNIXPATH
 </command>
 </client>
 

--- a/tests/data/test1561
+++ b/tests/data/test1561
@@ -72,7 +72,7 @@ https
 Cookies set over HTTP can't override secure ones
 </name>
 <command>
--k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0001 -L -c %LOGDIR/jar%TESTNUMBER.txt -H "Host: www.example.com"  http://%HOSTIP:%HTTPPORT/%TESTNUMBER0002 -L -c %LOGDIR/jar%TESTNUMBER.txt -H "Host: www.example.com"
+--insecure https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0001 -L -c %LOGDIR/jar%TESTNUMBER.txt -H "Host: www.example.com"  http://%HOSTIP:%HTTPPORT/%TESTNUMBER0002 -L -c %LOGDIR/jar%TESTNUMBER.txt -H "Host: www.example.com"
 </command>
 </client>
 <verify>

--- a/tests/data/test1562
+++ b/tests/data/test1562
@@ -44,7 +44,7 @@ https
 Expire secure cookies over HTTPS
 </name>
 <command>
--k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0001 -H "Host: www.example.com" https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0002 -b "non-existing" https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0001
+--insecure https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0001 -H "Host: www.example.com" https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0002 -b "non-existing" https://%HOSTIP:%HTTPSPORT/%TESTNUMBER0001
 </command>
 </client>
 <verify>

--- a/tests/data/test2400
+++ b/tests/data/test2400
@@ -41,7 +41,7 @@ HTTP/2 GET over HTTPS
 <setenv>
 </setenv>
 <command>
--k --http2 "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER"
+--insecure --http2 "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER"
 </command>
 
 </client>

--- a/tests/data/test2401
+++ b/tests/data/test2401
@@ -38,7 +38,7 @@ HTTP/2 POST over HTTPS
 <setenv>
 </setenv>
 <command>
--k --http2 "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER" -d "moo"
+--insecure --http2 "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER" -d "moo"
 </command>
 
 </client>

--- a/tests/data/test2403
+++ b/tests/data/test2403
@@ -42,7 +42,7 @@ HTTP/2 GET using %{header_json}
 <setenv>
 </setenv>
 <command>
--k --http2 -w '%{header_json}\n' "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER"
+--insecure --http2 -w '%{header_json}\n' "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER"
 </command>
 
 </client>

--- a/tests/data/test2406
+++ b/tests/data/test2406
@@ -40,7 +40,7 @@ HTTP/2 over HTTPS with -f
 <setenv>
 </setenv>
 <command>
--k --http2 -f "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER"
+--insecure --http2 -f "https://%HOSTIP:%HTTP2TLSPORT/%TESTNUMBER"
 </command>
 
 </client>

--- a/tests/data/test2501
+++ b/tests/data/test2501
@@ -38,7 +38,7 @@ HTTP/3 POST
 <setenv>
 </setenv>
 <command>
--k --http3 "https://%HOSTIP:%HTTP3PORT/%TESTNUMBER" -d "moo"
+--insecure --http3 "https://%HOSTIP:%HTTP3PORT/%TESTNUMBER" -d "moo"
 </command>
 
 </client>

--- a/tests/data/test300
+++ b/tests/data/test300
@@ -32,7 +32,7 @@ https
 simple HTTPS GET
 </name>
 <command>
--k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+--insecure https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test300
+++ b/tests/data/test300
@@ -33,7 +33,7 @@ simple HTTPS GET
 </name>
 # Using '-k' over '--insecure' to also test the short form
 <command>
--k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test300
+++ b/tests/data/test300
@@ -31,8 +31,9 @@ https
 <name>
 simple HTTPS GET
 </name>
+# Using '-k' over '--insecure' to also test the short form
 <command>
---insecure https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+-k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test300
+++ b/tests/data/test300
@@ -33,7 +33,7 @@ simple HTTPS GET
 </name>
 # Using '-k' over '--insecure' to also test the short form
 <command>
-https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+-k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test301
+++ b/tests/data/test301
@@ -33,7 +33,7 @@ https
 HTTPS GET with user and password
 </name>
 <command>
--k -u fake:user https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+--insecure -u fake:user https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test302
+++ b/tests/data/test302
@@ -33,7 +33,7 @@ https
 HTTPS GET over HTTP proxy fails
 </name>
 <command>
--k -U fake:user -x %HOSTIP:%HTTPPORT https://bad.fakeurl-to.test:%TESTNUMBER/slash/%TESTNUMBER
+--insecure -U fake:user -x %HOSTIP:%HTTPPORT https://bad.fakeurl-to.test:%TESTNUMBER/slash/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test303
+++ b/tests/data/test303
@@ -37,7 +37,7 @@ https
 HTTPS with 8 secs timeout
 </name>
 <command>
--k https://%HOSTIP:%HTTPSPORT/want/%TESTNUMBER -m 8
+--insecure https://%HOSTIP:%HTTPSPORT/want/%TESTNUMBER -m 8
 </command>
 </client>
 

--- a/tests/data/test304
+++ b/tests/data/test304
@@ -31,7 +31,7 @@ https
 HTTPS multipart formpost
 </name>
 <command>
--k https://%HOSTIP:%HTTPSPORT/we/want/%TESTNUMBER -F name=daniel -F tool=curl -F file=@%LOGDIR/test%TESTNUMBER.txt
+--insecure https://%HOSTIP:%HTTPSPORT/we/want/%TESTNUMBER -F name=daniel -F tool=curl -F file=@%LOGDIR/test%TESTNUMBER.txt
 </command>
 # We create this file before the command is invoked!
 <file name="%LOGDIR/test%TESTNUMBER.txt">

--- a/tests/data/test306
+++ b/tests/data/test306
@@ -45,7 +45,7 @@ https
 HTTPS GET, receive no headers only data!
 </name>
 <command>
--k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER --http0.9
+--insecure https://%HOSTIP:%HTTPSPORT/%TESTNUMBER --http0.9
 </command>
 </client>
 

--- a/tests/data/test307
+++ b/tests/data/test307
@@ -36,7 +36,7 @@ https
 simple HTTPS GET with openssl engine
 </name>
 <command>
---engine openssl -k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+--engine openssl --insecure https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test308
+++ b/tests/data/test308
@@ -21,7 +21,7 @@ https
 simple HTTPS GET with invalid crypto engine
 </name>
 <command>
---engine invalid-crypto-engine-xyzzy -k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+--engine invalid-crypto-engine-xyzzy --insecure https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test309
+++ b/tests/data/test309
@@ -59,7 +59,7 @@ https
 HTTP Location: redirect to HTTPS URL
 </name>
 <command>
--k http://%HOSTIP:%HTTPPORT/want/%TESTNUMBER -L
+--insecure http://%HOSTIP:%HTTPPORT/want/%TESTNUMBER -L
 </command>
 </client>
 

--- a/tests/data/test325
+++ b/tests/data/test325
@@ -42,7 +42,7 @@ https
 HTTPS with attempted redirect to denied HTTP
 </name>
 <command>
--k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER --proto-redir -http --location
+--insecure https://%HOSTIP:%HTTPSPORT/%TESTNUMBER --proto-redir -http --location
 </command>
 </client>
 

--- a/tests/data/test364
+++ b/tests/data/test364
@@ -28,7 +28,7 @@ https
 HTTPS PUT of small file
 </name>
 <command>
--k https://%HOSTIP:%HTTPSPORT/we/want/%TESTNUMBER -T %LOGDIR/test%TESTNUMBER.txt
+--insecure https://%HOSTIP:%HTTPSPORT/we/want/%TESTNUMBER -T %LOGDIR/test%TESTNUMBER.txt
 </command>
 <file name="%LOGDIR/test%TESTNUMBER.txt">
 %repeat[200 x banana]%

--- a/tests/data/test400
+++ b/tests/data/test400
@@ -38,7 +38,7 @@ ftps
 FTPS dir list PASV unencrypted data
 </name>
 <command>
--k --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/
+--insecure --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/
 </command>
 </client>
 

--- a/tests/data/test401
+++ b/tests/data/test401
@@ -28,7 +28,7 @@ works
   so does it?
 </file>
 <command>
--k --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/%TESTNUMBER -T %LOGDIR/test%TESTNUMBER.txt
+--insecure --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/%TESTNUMBER -T %LOGDIR/test%TESTNUMBER.txt
 </command>
 </client>
 

--- a/tests/data/test402
+++ b/tests/data/test402
@@ -19,7 +19,7 @@ ftp
 FTP SSL required on non-SSL server
 </name>
 <command>
--k --ftp-ssl-reqd ftp://%HOSTIP:%FTPPORT/%TESTNUMBER
+--insecure --ftp-ssl-reqd ftp://%HOSTIP:%FTPPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test403
+++ b/tests/data/test403
@@ -40,7 +40,7 @@ ftps
 FTPS with CCC not supported by server
 </name>
 <command>
--k --ftp-ssl-control --ftp-ssl-ccc ftps://%HOSTIP:%FTPSPORT/
+--insecure --ftp-ssl-control --ftp-ssl-ccc ftps://%HOSTIP:%FTPSPORT/
 </command>
 </client>
 

--- a/tests/data/test405
+++ b/tests/data/test405
@@ -19,7 +19,7 @@ ftp
 FTPS operation to FTP port
 </name>
 <command>
--m 5 -k ftps://%HOSTIP:%FTPPORT/path/to/file/%TESTNUMBER
+-m 5 --insecure ftps://%HOSTIP:%FTPPORT/path/to/file/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test406
+++ b/tests/data/test406
@@ -38,7 +38,7 @@ ftps
 FTPS dir list, PORT with specified IP
 </name>
 <command>
--k --ftp-ssl-control -P %CLIENTIP ftps://%HOSTIP:%FTPSPORT/
+--insecure --ftp-ssl-control -P %CLIENTIP ftps://%HOSTIP:%FTPSPORT/
 </command>
 </client>
 

--- a/tests/data/test407
+++ b/tests/data/test407
@@ -29,7 +29,7 @@ ftps
 Get two FTPS files from the same remote dir: no second CWD
 </name>
 <command>
--k --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/a/path/%TESTNUMBER ftps://%HOSTIP:%FTPSPORT/a/path/%TESTNUMBER
+--insecure --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/a/path/%TESTNUMBER ftps://%HOSTIP:%FTPSPORT/a/path/%TESTNUMBER
 </command>
 <stdout>
 data blobb

--- a/tests/data/test408
+++ b/tests/data/test408
@@ -25,7 +25,7 @@ ftps
 FTPS PORT upload with CWD
 </name>
 <command>
--k --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/CWD/STOR/RETR/%TESTNUMBER -T %LOGDIR/upload%TESTNUMBER -P -
+--insecure --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/CWD/STOR/RETR/%TESTNUMBER -T %LOGDIR/upload%TESTNUMBER -P -
 </command>
 <file name="%LOGDIR/upload%TESTNUMBER">
 Moooooooooooo

--- a/tests/data/test409
+++ b/tests/data/test409
@@ -28,7 +28,7 @@ works
   so does it?
 </file>
 <command>
--k --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/%TESTNUMBER -T %LOGDIR/test%TESTNUMBER.txt
+--insecure --ftp-ssl-control ftps://%HOSTIP:%FTPSPORT/%TESTNUMBER -T %LOGDIR/test%TESTNUMBER.txt
 </command>
 </client>
 

--- a/tests/data/test410
+++ b/tests/data/test410
@@ -36,7 +36,7 @@ HTTPS GET with very long request header
 Long: %repeat[3500 x header content]%
 </file>
 <command>
--k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER -H @%LOGDIR/file%TESTNUMBER
+--insecure https://%HOSTIP:%HTTPSPORT/%TESTNUMBER -H @%LOGDIR/file%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test414
+++ b/tests/data/test414
@@ -55,7 +55,7 @@ https
 HTTPS sec-cookie, HTTP redirect, same name cookie, redirect back
 </name>
 <command>
-https://attack.invalid:%HTTPSPORT/a/b/%TESTNUMBER -k -c %LOGDIR/cookie%TESTNUMBER --resolve attack.invalid:%HTTPSPORT:%HOSTIP --resolve attack.invalid:%HTTPPORT:%HOSTIP -L
+https://attack.invalid:%HTTPSPORT/a/b/%TESTNUMBER --insecure -c %LOGDIR/cookie%TESTNUMBER --resolve attack.invalid:%HTTPSPORT:%HOSTIP --resolve attack.invalid:%HTTPPORT:%HOSTIP -L
 </command>
 </client>
 

--- a/tests/data/test445
+++ b/tests/data/test445
@@ -46,7 +46,7 @@ http-proxy
 Refuse tunneling protocols through HTTP proxy
 </name>
 <command>
--x http://%HOSTIP:%PROXYPORT/%TESTNUMBER -p gopher://127.0.0.1 dict://127.0.0.1 http://moo https://example telnet://another ftp://yes ftps://again imap://more ldap://perhaps mqtt://yes pop3://mail rtsp://harder scp://copy sftp://files smb://wird smtp://send -k
+-x http://%HOSTIP:%PROXYPORT/%TESTNUMBER -p gopher://127.0.0.1 dict://127.0.0.1 http://moo https://example telnet://another ftp://yes ftps://again imap://more ldap://perhaps mqtt://yes pop3://mail rtsp://harder scp://copy sftp://files smb://wird smtp://send --insecure
 </command>
 </client>
 

--- a/tests/data/test474
+++ b/tests/data/test474
@@ -38,7 +38,7 @@ https
 -w urle.scheme after HTTP to HTTPS redirect
 </name>
 <command option="no-include">
--k -L http://%HOSTIP:%HTTPPORT/%TESTNUMBER -w "%{num_redirects} %{url_effective} %{urle.scheme}\n"
+--insecure -L http://%HOSTIP:%HTTPPORT/%TESTNUMBER -w "%{num_redirects} %{url_effective} %{urle.scheme}\n"
 </command>
 </client>
 

--- a/tests/data/test628
+++ b/tests/data/test628
@@ -16,7 +16,7 @@ sftp
 SFTP invalid user login (password authentication)
 </name>
 <command>
--u not-a-valid-user: sftp://%HOSTIP:%SSHPORT%SSH_PWD/irrelevant-file  --insecure
+-u not-a-valid-user: sftp://%HOSTIP:%SSHPORT%SSH_PWD/irrelevant-file --insecure
 </command>
 </client>
 

--- a/tests/data/test780
+++ b/tests/data/test780
@@ -53,7 +53,7 @@ this.hsts.example "99991001 04:47:41"
 HSTS with updated expiry in response
 </name>
 <command>
--x http://%HOSTIP:%PROXYPORT http://this.hsts.example:%HTTPSPORT/%TESTNUMBER --hsts %LOGDIR/input%TESTNUMBER -k
+-x http://%HOSTIP:%PROXYPORT http://this.hsts.example:%HTTPSPORT/%TESTNUMBER --hsts %LOGDIR/input%TESTNUMBER --insecure
 </command>
 <disable>
 test-duphandle

--- a/tests/data/test781
+++ b/tests/data/test781
@@ -55,7 +55,7 @@ this.hsts.example "99991001 04:47:41"
 HSTS update expiry, with parent includeSubDomains domain present
 </name>
 <command>
--x http://%HOSTIP:%PROXYPORT http://this.hsts.example:%HTTPSPORT/%TESTNUMBER --hsts %LOGDIR/input%TESTNUMBER -k
+-x http://%HOSTIP:%PROXYPORT http://this.hsts.example:%HTTPSPORT/%TESTNUMBER --hsts %LOGDIR/input%TESTNUMBER --insecure
 </command>
 <disable>
 test-duphandle

--- a/tests/data/test782
+++ b/tests/data/test782
@@ -55,7 +55,7 @@ CURL_TIME=1728465947
 HSTS update expiry, with two includeSubDomains domains present
 </name>
 <command>
--x http://%HOSTIP:%PROXYPORT http://this.hsts.example:%HTTPSPORT/%TESTNUMBER --hsts %LOGDIR/input%TESTNUMBER -k
+-x http://%HOSTIP:%PROXYPORT http://this.hsts.example:%HTTPSPORT/%TESTNUMBER --hsts %LOGDIR/input%TESTNUMBER --insecure
 </command>
 <disable>
 test-duphandle

--- a/tests/data/test783
+++ b/tests/data/test783
@@ -55,7 +55,7 @@ CURL_TIME=1728465947
 HSTS update expiry, removing includesubdomains in update
 </name>
 <command>
--x http://%HOSTIP:%PROXYPORT http://this.hsts.example:%HTTPSPORT/%TESTNUMBER --hsts %LOGDIR/input%TESTNUMBER -k
+-x http://%HOSTIP:%PROXYPORT http://this.hsts.example:%HTTPSPORT/%TESTNUMBER --hsts %LOGDIR/input%TESTNUMBER --insecure
 </command>
 <disable>
 test-duphandle

--- a/tests/data/test987
+++ b/tests/data/test987
@@ -26,7 +26,7 @@ To: another
 body
 </stdin>
 <command>
--k --ssl-reqd --mail-rcpt recipient@example.com --mail-from sender@example.com -T - smtps://%HOSTIP:%SMTPSPORT/%TESTNUMBER
+--insecure --ssl-reqd --mail-rcpt recipient@example.com --mail-from sender@example.com -T - smtps://%HOSTIP:%SMTPSPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test988
+++ b/tests/data/test988
@@ -30,7 +30,7 @@ imaps
 IMAPS FETCH with redundant explicit SSL request
 </name>
 <command>
--k --ssl-reqd -u '"user:sec"ret{' 'imaps://%HOSTIP:%IMAPSPORT/%TESTNUMBER/;MAILINDEX=1'
+--insecure --ssl-reqd -u '"user:sec"ret{' 'imaps://%HOSTIP:%IMAPSPORT/%TESTNUMBER/;MAILINDEX=1'
 </command>
 </client>
 

--- a/tests/data/test989
+++ b/tests/data/test989
@@ -30,7 +30,7 @@ pop3s
 POP3S RETR with redundant explicit SSL request
 </name>
 <command>
--k --ssl-reqd  -u user:secret pop3s://%HOSTIP:%POP3SPORT/%TESTNUMBER
+--insecure --ssl-reqd  -u user:secret pop3s://%HOSTIP:%POP3SPORT/%TESTNUMBER
 </command>
 </client>
 


### PR DESCRIPTION
To make it uniform in all tests, and greppability.

Also:
- replace `-k` flag with `-q` in test 1268. (the actual flag doesn't
  matter in this test)
- keep `-k` in test 300 to test its short form.
  (also verified to fail without a working `-k`)
