### PR TITLE
docs/cmdline-opts: use imperative form

### DIFF
--- a/docs/cmdline-opts/ciphers.md
+++ b/docs/cmdline-opts/ciphers.md
@@ -18,8 +18,8 @@ Example:
 
 # `--ciphers`
 
-Specifies which cipher suites to use in the connection if it negotiates
-TLS 1.2 (1.1, 1.0). The list of ciphers suites must specify valid ciphers.
-Read up on cipher suite details on this URL:
+Specify which cipher suites to use in the connection if it negotiates TLS 1.2
+(1.1, 1.0). The list of ciphers suites must specify valid ciphers. Read up on
+cipher suite details on this URL:
 
 https://curl.se/docs/ssl-ciphers.html

--- a/docs/cmdline-opts/compressed-ssh.md
+++ b/docs/cmdline-opts/compressed-ssh.md
@@ -15,5 +15,5 @@ Example:
 
 # `--compressed-ssh`
 
-Enables built-in SSH compression. This is a request, not an order; the server
-may or may not do it.
+Enable SSH compression. This is a request, not an order; the server may or may
+not do it.

--- a/docs/cmdline-opts/data.md
+++ b/docs/cmdline-opts/data.md
@@ -22,7 +22,7 @@ Example:
 
 # `--data`
 
-Sends the specified data in a POST request to the HTTP server, in the same way
+Send the specified data in a POST request to the HTTP server, in the same way
 that a browser does when a user has filled in an HTML form and presses the
 submit button. This option makes curl pass the data to the server using the
 content-type application/x-www-form-urlencoded. Compare to --form.

--- a/docs/cmdline-opts/digest.md
+++ b/docs/cmdline-opts/digest.md
@@ -18,6 +18,6 @@ Example:
 
 # `--digest`
 
-Enables HTTP Digest authentication. This authentication scheme avoids sending
+Enable HTTP Digest authentication. This authentication scheme avoids sending
 the password over the wire in clear text. Use this in combination with the
 normal --user option to set username and password.

--- a/docs/cmdline-opts/doh-cert-status.md
+++ b/docs/cmdline-opts/doh-cert-status.md
@@ -16,7 +16,7 @@ Example:
 
 Same as --cert-status but used for DoH (DNS-over-HTTPS).
 
-Verifies the status of the DoH servers' certificate by using the Certificate
+Verify the status of the DoH servers' certificate by using the Certificate
 Status Request (aka. OCSP stapling) TLS extension.
 
 If this option is enabled and the DoH server sends an invalid (e.g. expired)

--- a/docs/cmdline-opts/doh-url.md
+++ b/docs/cmdline-opts/doh-url.md
@@ -16,8 +16,8 @@ Example:
 
 # `--doh-url`
 
-Specifies which DNS-over-HTTPS (DoH) server to use to resolve hostnames,
-instead of using the default name resolver mechanism. The URL must be HTTPS.
+Specify which DNS-over-HTTPS (DoH) server to use to resolve hostnames, instead
+of using the default name resolver mechanism. The URL must be HTTPS.
 
 Some SSL options that you set for your transfer also applies to DoH since the
 name lookups take place over SSL. However, the certificate verification

--- a/docs/cmdline-opts/ech.md
+++ b/docs/cmdline-opts/ech.md
@@ -16,7 +16,7 @@ Example:
 
 # `--ech`
 
-Specifies how to do ECH (Encrypted Client Hello).
+Specify how to do ECH (Encrypted Client Hello).
 
 The values allowed for \<config\> can be:
 

--- a/docs/cmdline-opts/ftp-port.md
+++ b/docs/cmdline-opts/ftp-port.md
@@ -20,7 +20,7 @@ Example:
 
 # `--ftp-port`
 
-Reverses the default initiator/listener roles when connecting with FTP. This
+Reverse the default initiator/listener roles when connecting with FTP. This
 option makes curl use active mode. curl then commands the server to connect
 back to the client's specified address and port, while passive mode asks the
 server to setup an IP address and port for it to connect to. \<address\>

--- a/docs/cmdline-opts/ftp-ssl-ccc-mode.md
+++ b/docs/cmdline-opts/ftp-ssl-ccc-mode.md
@@ -16,7 +16,7 @@ Example:
 
 # `--ftp-ssl-ccc-mode`
 
-Sets the CCC mode. The passive mode does not initiate the shutdown, but
-instead waits for the server to do it, and does not reply to the shutdown from
-the server. The active mode initiates the shutdown and waits for a reply from
-the server.
+Set the CCC mode. The passive mode does not initiate the shutdown, but instead
+waits for the server to do it, and does not reply to the shutdown from the
+server. The active mode initiates the shutdown and waits for a reply from the
+server.

--- a/docs/cmdline-opts/happy-eyeballs-timeout-ms.md
+++ b/docs/cmdline-opts/happy-eyeballs-timeout-ms.md
@@ -16,6 +16,8 @@ Example:
 
 # `--happy-eyeballs-timeout-ms`
 
+Set the timeout for Happy Eyeballs.
+
 Happy Eyeballs is an algorithm that attempts to connect to both IPv4 and IPv6
 addresses for dual-stack hosts, giving IPv6 a head-start of the specified
 number of milliseconds. If the IPv6 address cannot be connected to within that

--- a/docs/cmdline-opts/haproxy-clientip.md
+++ b/docs/cmdline-opts/haproxy-clientip.md
@@ -16,7 +16,7 @@ Example:
 
 # `--haproxy-clientip`
 
-Sets a client IP in HAProxy PROXY protocol v1 header at the beginning of the
+Set a client IP in HAProxy PROXY protocol v1 header at the beginning of the
 connection.
 
 For valid requests, IPv4 addresses must be indicated as a series of exactly

--- a/docs/cmdline-opts/http3-only.md
+++ b/docs/cmdline-opts/http3-only.md
@@ -20,7 +20,7 @@ Example:
 
 # `--http3-only`
 
-Instructs curl to use HTTP/3 to the host in the URL, with no fallback to
+Instruct curl to use HTTP/3 to the host in the URL, with no fallback to
 earlier HTTP versions. HTTP/3 can only be used for HTTPS and not for HTTP
 URLs. For HTTP, this option triggers an error.
 

--- a/docs/cmdline-opts/json.md
+++ b/docs/cmdline-opts/json.md
@@ -21,7 +21,7 @@ Example:
 
 # `--json`
 
-Sends the specified JSON data in a POST request to the HTTP server. --json
+Send the specified JSON data in a POST request to the HTTP server. --json
 works as a shortcut for passing on these three options:
 
     --data-binary [arg]

--- a/docs/cmdline-opts/location-trusted.md
+++ b/docs/cmdline-opts/location-trusted.md
@@ -16,7 +16,7 @@ Example:
 
 # `--location-trusted`
 
-Instructs curl to like --location follow HTTP redirects, but permits it to
+Instruct curl to follow HTTP redirects like --location, but permit curl to
 send credentials and other secrets along to other hosts than the initial one.
 
 This may or may not introduce a security breach if the site redirects you to a

--- a/docs/cmdline-opts/mptcp.md
+++ b/docs/cmdline-opts/mptcp.md
@@ -14,7 +14,7 @@ Example:
 
 # `--mptcp`
 
-Enables the use of Multipath TCP (MPTCP) for connections. MPTCP is an extension
+Enable the use of Multipath TCP (MPTCP) for connections. MPTCP is an extension
 to the standard TCP that allows multiple TCP streams over different network
 paths between the same source and destination. This can enhance bandwidth and
 improve reliability by using multiple paths simultaneously.

--- a/docs/cmdline-opts/no-buffer.md
+++ b/docs/cmdline-opts/no-buffer.md
@@ -15,7 +15,7 @@ Example:
 
 # `--no-buffer`
 
-Disables the buffering of the output stream. In normal work situations, curl
+Disable the buffering of the output stream. In normal work situations, curl
 uses a standard buffered output stream that has the effect that it outputs the
 data in chunks, not necessarily exactly when the data arrives. Using this
 option disables that buffering.

--- a/docs/cmdline-opts/no-keepalive.md
+++ b/docs/cmdline-opts/no-keepalive.md
@@ -15,7 +15,7 @@ Example:
 
 # `--no-keepalive`
 
-Disables the use of keepalive messages on the TCP connection. curl otherwise
+Disable the use of keepalive messages on the TCP connection. curl otherwise
 enables them by default.
 
 Note that this is the negated option name documented. You can thus use

--- a/docs/cmdline-opts/parallel.md
+++ b/docs/cmdline-opts/parallel.md
@@ -19,7 +19,7 @@ Example:
 
 # `--parallel`
 
-Makes curl perform all transfers in parallel as compared to the regular serial
+Make curl perform all transfers in parallel as compared to the regular serial
 manner. Parallel transfer means that curl runs up to N concurrent transfers
 simultaneously and if there are more than N transfers to handle, it starts new
 ones when earlier transfers finish.

--- a/docs/cmdline-opts/pass.md
+++ b/docs/cmdline-opts/pass.md
@@ -17,4 +17,4 @@ Example:
 
 # `--pass`
 
-Passphrase for the private key.
+Passphrase for the private key used for SSH or TLS.

--- a/docs/cmdline-opts/remote-time.md
+++ b/docs/cmdline-opts/remote-time.md
@@ -16,6 +16,6 @@ Example:
 
 # `--remote-time`
 
-Makes curl attempt to figure out the timestamp of the remote file that is
+Make curl attempt to figure out the timestamp of the remote file that is
 getting downloaded, and if that is available make the local file get that same
 timestamp.

--- a/docs/cmdline-opts/tls-max.md
+++ b/docs/cmdline-opts/tls-max.md
@@ -22,8 +22,8 @@ Example:
 
 # `--tls-max`
 
-VERSION defines maximum supported TLS version. The minimum acceptable version
-is set by tlsv1.0, tlsv1.1, tlsv1.2 or tlsv1.3.
+Set the maximum allowed TLS version. The minimum acceptable version is set by
+tlsv1.0, tlsv1.1, tlsv1.2 or tlsv1.3.
 
 If the connection is done without TLS, this option has no effect. This
 includes QUIC-using (HTTP/3) transfers.

--- a/docs/cmdline-opts/tls13-ciphers.md
+++ b/docs/cmdline-opts/tls13-ciphers.md
@@ -18,9 +18,9 @@ Example:
 
 # `--tls13-ciphers`
 
-Specifies which cipher suites to use in the connection if it negotiates TLS
-1.3. The list of ciphers suites must specify valid ciphers. Read up on TLS 1.3
-cipher suite details on this URL:
+Set which cipher suites to use in the connection if it negotiates TLS 1.3. The
+list of ciphers suites must specify valid ciphers. Read up on TLS 1.3 cipher
+suite details on this URL:
 
 https://curl.se/docs/ssl-ciphers.html
 

--- a/docs/cmdline-opts/tlsv1.0.md
+++ b/docs/cmdline-opts/tlsv1.0.md
@@ -15,7 +15,7 @@ Example:
 
 # `--tlsv1.0`
 
-Forces curl to use TLS version 1.0 or later when connecting to a remote TLS server.
+Force curl to use TLS version 1.0 or later when connecting to a remote TLS server.
 
 In old versions of curl this option was documented to allow _only_ TLS 1.0.
 That behavior was inconsistent depending on the TLS library. Use --tls-max if

--- a/docs/cmdline-opts/tlsv1.1.md
+++ b/docs/cmdline-opts/tlsv1.1.md
@@ -16,7 +16,7 @@ Example:
 
 # `--tlsv1.1`
 
-Forces curl to use TLS version 1.1 or later when connecting to a remote TLS server.
+Force curl to use TLS version 1.1 or later when connecting to a remote TLS server.
 
 In old versions of curl this option was documented to allow _only_ TLS 1.1.
 That behavior was inconsistent depending on the TLS library. Use --tls-max if

--- a/docs/cmdline-opts/tlsv1.2.md
+++ b/docs/cmdline-opts/tlsv1.2.md
@@ -16,7 +16,7 @@ Example:
 
 # `--tlsv1.2`
 
-Forces curl to use TLS version 1.2 or later when connecting to a remote TLS server.
+Force curl to use TLS version 1.2 or later when connecting to a remote TLS server.
 
 In old versions of curl this option was documented to allow _only_ TLS 1.2.
 That behavior was inconsistent depending on the TLS library. Use --tls-max if

--- a/docs/cmdline-opts/tlsv1.3.md
+++ b/docs/cmdline-opts/tlsv1.3.md
@@ -16,7 +16,7 @@ Example:
 
 # `--tlsv1.3`
 
-Forces curl to use TLS version 1.3 or later when connecting to a remote TLS
+Force curl to use TLS version 1.3 or later when connecting to a remote TLS
 server.
 
 If the connection is done without TLS, this option has no effect. This

--- a/docs/cmdline-opts/trace-ids.md
+++ b/docs/cmdline-opts/trace-ids.md
@@ -16,4 +16,5 @@ Example:
 
 # `--trace-ids`
 
-Prepends the transfer and connection identifiers to each trace or verbose line that curl displays.
+Prepend the transfer and connection identifiers to each trace or verbose line
+that curl displays.

--- a/docs/cmdline-opts/trace-time.md
+++ b/docs/cmdline-opts/trace-time.md
@@ -16,4 +16,4 @@ Example:
 
 # `--trace-time`
 
-Prepends a time stamp to each trace or verbose line that curl displays.
+Prepend a time stamp to each trace or verbose line that curl displays.

--- a/docs/cmdline-opts/verbose.md
+++ b/docs/cmdline-opts/verbose.md
@@ -20,10 +20,11 @@ Example:
 
 # `--verbose`
 
-Makes curl verbose during the operation. Useful for debugging and seeing
-what's going on under the hood. A line starting with \> means header data sent
-by curl, \< means header data received by curl that is hidden in normal cases,
-and a line starting with * means additional info provided by curl.
+Make curl output verbose information during the operation. Useful for
+debugging and seeing what's going on under the hood. A line starting with \>
+means header data sent by curl, \< means header data received by curl that is
+hidden in normal cases, and a line starting with * means additional info
+provided by curl.
 
 If you only want HTTP headers in the output, --show-headers or --dump-header
 might be more suitable options.

--- a/docs/cmdline-opts/version.md
+++ b/docs/cmdline-opts/version.md
@@ -16,7 +16,7 @@ Example:
 
 # `--version`
 
-Displays information about curl and the libcurl version it uses.
+Display information about curl and the libcurl version it uses.
 
 The first line includes the full version of curl, libcurl and other 3rd party
 libraries linked with the executable.

--- a/docs/cmdline-opts/xattr.md
+++ b/docs/cmdline-opts/xattr.md
@@ -16,6 +16,8 @@ Example:
 
 # `--xattr`
 
+Store metadata in the extended file attributes.
+
 When saving output to a file, tell curl to store file metadata in extended
 file attributes. Currently, `curl` is stored in the `creator` attribute,
 the URL is stored in the `xdg.origin.url` attribute and, for HTTP, the content


### PR DESCRIPTION
Use 'set', not 'sets' etc. For consistency.