### PR TITLE
lib: unify conversions to/from hex

### DIFF
--- a/lib/escape.h
+++ b/lib/escape.h
@@ -41,4 +41,8 @@ CURLcode Curl_urldecode(const char *string, size_t length,
 void Curl_hexencode(const unsigned char *src, size_t len, /* input length */
                     unsigned char *out, size_t olen); /* output buffer size */
 
+void Curl_hexbyte(unsigned char *dest, /* must fit two bytes */
+                  unsigned char val,
+                  bool lowercase);
+
 #endif /* HEADER_CURL_ESCAPE_H */

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -537,8 +537,7 @@ static CURLcode canon_string(const char *q, size_t len,
           result = Curl_dyn_addn(dq, "%25", 3);
         break;
       default: {
-        const char hex[] = "0123456789ABCDEF";
-        char out[3]={'%'};
+        unsigned char out[3]={'%'};
 
         if(!found_equals) {
           /* if found_equals is NULL assuming, been in path */
@@ -557,8 +556,7 @@ static CURLcode canon_string(const char *q, size_t len,
           }
         }
         /* URL encode */
-        out[1] = hex[((unsigned char)*q) >> 4];
-        out[2] = hex[*q & 0xf];
+        Curl_hexbyte(&out[1], *q, FALSE);
         result = Curl_dyn_addn(dq, out, 3);
         break;
       }

--- a/lib/strparse.h
+++ b/lib/strparse.h
@@ -102,6 +102,13 @@ int Curl_str_cspn(const char **linep, struct Curl_str *out, const char *cspn);
 void Curl_str_trimblanks(struct Curl_str *out);
 void Curl_str_passblanks(const char **linep);
 
+/* given a hexadecimal letter, return the binary value. '0' returns 0, 'a'
+   returns 10. THIS ONLY WORKS ON VALID HEXADECIMAL LETTER INPUT. Verify
+   before calling this!
+*/
+extern const unsigned char Curl_hexasciitable[];
+#define Curl_hexval(x) (unsigned char)(Curl_hexasciitable[(x) - '0'] & 0x0f)
+
 #define curlx_str_number(x,y,z) Curl_str_number(x,y,z)
 #define curlx_str_octal(x,y,z) Curl_str_octal(x,y,z)
 #define curlx_str_single(x,y) Curl_str_single(x,y)

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -129,7 +129,6 @@ static const char *find_host_sep(const char *url)
 #define cc2cu(x) ((x) == CURLE_TOO_LARGE ? CURLUE_TOO_LARGE :   \
                   CURLUE_OUT_OF_MEMORY)
 
-static const char hexdigits[] = "0123456789abcdef";
 /* urlencode_str() writes data into an output dynbuf and URL-encodes the
  * spaces in the source URL accordingly.
  *
@@ -164,9 +163,8 @@ static CURLUcode urlencode_str(struct dynbuf *o, const char *url,
         result = Curl_dyn_addn(o, "+", 1);
     }
     else if((*iptr < ' ') || (*iptr >= 0x7f)) {
-      char out[3]={'%'};
-      out[1] = hexdigits[*iptr >> 4];
-      out[2] = hexdigits[*iptr & 0xf];
+      unsigned char out[3]={'%'};
+      Curl_hexbyte(&out[1], *iptr, TRUE);
       result = Curl_dyn_addn(o, out, 3);
     }
     else {
@@ -1824,9 +1822,8 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
             return cc2cu(result);
         }
         else {
-          char out[3]={'%'};
-          out[1] = hexdigits[*i >> 4];
-          out[2] = hexdigits[*i & 0xf];
+          unsigned char out[3]={'%'};
+          Curl_hexbyte(&out[1], *i, TRUE);
           result = Curl_dyn_addn(&enc, out, 3);
           if(result)
             return cc2cu(result);

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -32,6 +32,7 @@
 
 #include "keylog.h"
 #include <curl/curl.h>
+#include "escape.h"
 
 /* The last #include files should be: */
 #include "curl_memory.h"
@@ -114,10 +115,9 @@ Curl_tls_keylog_write(const char *label,
                       const unsigned char client_random[CLIENT_RANDOM_SIZE],
                       const unsigned char *secret, size_t secretlen)
 {
-  const char *hex = "0123456789ABCDEF";
   size_t pos, i;
-  char line[KEYLOG_LABEL_MAXLEN + 1 + 2 * CLIENT_RANDOM_SIZE + 1 +
-            2 * SECRET_MAXLEN + 1 + 1];
+  unsigned char line[KEYLOG_LABEL_MAXLEN + 1 + 2 * CLIENT_RANDOM_SIZE + 1 +
+                     2 * SECRET_MAXLEN + 1 + 1];
 
   if(!keylog_file_fp) {
     return FALSE;
@@ -134,22 +134,22 @@ Curl_tls_keylog_write(const char *label,
 
   /* Client Random */
   for(i = 0; i < CLIENT_RANDOM_SIZE; i++) {
-    line[pos++] = hex[client_random[i] >> 4];
-    line[pos++] = hex[client_random[i] & 0xF];
+    Curl_hexbyte(&line[pos], client_random[i], FALSE);
+    pos += 2;
   }
   line[pos++] = ' ';
 
   /* Secret */
   for(i = 0; i < secretlen; i++) {
-    line[pos++] = hex[secret[i] >> 4];
-    line[pos++] = hex[secret[i] & 0xF];
+    Curl_hexbyte(&line[pos], secret[i], FALSE);
+    pos += 2;
   }
   line[pos++] = '\n';
   line[pos] = '\0';
 
   /* Using fputs here instead of fprintf since libcurl's fprintf replacement
      may not be thread-safe. */
-  fputs(line, keylog_file_fp);
+  fputs((char *)line, keylog_file_fp);
   return TRUE;
 }
 

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -26,7 +26,6 @@ TESTUTIL = testutil.c testutil.h
 TSTTRACE = testtrace.c testtrace.h
 WARNLESS = ../../lib/warnless.c ../../lib/warnless.h
 MULTIBYTE = ../../lib/curl_multibyte.c ../../lib/curl_multibyte.h
-INET_PTON = ../../lib/inet_pton.c ../../lib/inet_pton.h
 THREADS = ../../lib/curl_threads.c ../../lib/curl_threads.h
 
 # these files are used in every single test program below
@@ -653,7 +652,7 @@ lib1958_LDADD = $(TESTUTIL_LIBS)
 lib1959_SOURCES = lib1959.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)
 lib1959_LDADD = $(TESTUTIL_LIBS)
 
-lib1960_SOURCES = lib1960.c $(SUPPORTFILES) $(INET_PTON)
+lib1960_SOURCES = lib1960.c $(SUPPORTFILES)
 lib1960_LDADD = $(TESTUTIL_LIBS)
 
 lib1964_SOURCES = lib1964.c $(SUPPORTFILES) $(TESTUTIL) $(WARNLESS)


### PR DESCRIPTION
Curl_hexbyte - output a byte as a two-digit ASCII hex number

Curl_hexval - convert an ASCII hex digit to its binary value

... instead of duplicating similar code and hexdigit strings in numerous places.