### PR TITLE
runtests: fix bundled test invocation with `-g` option

### DIFF
--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -940,7 +940,7 @@ sub singletest_run {
 
         if($bundle) {
             if($gdbthis) {
-                $cmdargs =" $tool_name $cmdargs";
+                $cmdargs =" $tool_name$cmdargs";
             }
             else {
                 $CMDLINE.=" $tool_name";

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -939,7 +939,12 @@ sub singletest_run {
         $CMDLINE=exerunner() . $CMDLINE;
 
         if($bundle) {
-            $CMDLINE.=" $tool_name";
+            if($gdbthis) {
+                $cmdargs =" $tool_name $cmdargs";
+            }
+            else {
+                $CMDLINE.=" $tool_name";
+            }
         }
 
         $DBGCURL=$CMDLINE;


### PR DESCRIPTION
Fixes:
```
$ ./runtests.pl -g 1940
./libtest/libtests lib1940: No such file or directory.
Argument list to give program being debugged when it is started is "http://127.0.0.1:44547/1940".
```

Reported-by: Daniel Stenberg
Fixes #16893
