### PR TITLE
memdebug: switch all macros to use UPPERCASE

### DIFF
--- a/lib/.checksrc
+++ b/lib/.checksrc
@@ -6,3 +6,15 @@ banfunc vsnprint
 banfunc strtoul
 banfunc strtol
 banfunc strtok_r
+# the ones we use UPPERCASE:
+banfunc strdup
+banfunc malloc
+banfunc calloc
+banfunc realloc
+banfunc socket
+banfunc send
+banfunc recv
+banfunc accept
+banfunc fopen
+banfunc fdopen
+banfunc fclose

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -73,9 +73,9 @@ const char *Curl_alpnid2str(enum alpnid id)
 
 static void altsvc_free(struct altsvc *as)
 {
-  free(as->src.host);
-  free(as->dst.host);
-  free(as);
+  FREE(as->src.host);
+  FREE(as->dst.host);
+  FREE(as);
 }
 
 static struct altsvc *altsvc_createid(const char *srchost,
@@ -87,7 +87,7 @@ static struct altsvc *altsvc_createid(const char *srchost,
                                       size_t srcport,
                                       size_t dstport)
 {
-  struct altsvc *as = calloc(1, sizeof(struct altsvc));
+  struct altsvc *as = CALLOC(1, sizeof(struct altsvc));
   if(!as)
     return NULL;
   DEBUGASSERT(hlen);
@@ -223,12 +223,12 @@ static CURLcode altsvc_load(struct altsvcinfo *asi, const char *file)
 
   /* we need a private copy of the filename so that the altsvc cache file
      name survives an easy handle reset */
-  free(asi->filename);
-  asi->filename = strdup(file);
+  FREE(asi->filename);
+  asi->filename = STRDUP(file);
   if(!asi->filename)
     return CURLE_OUT_OF_MEMORY;
 
-  fp = fopen(file, FOPEN_READTEXT);
+  fp = FOPEN(file, FOPEN_READTEXT);
   if(fp) {
     struct dynbuf buf;
     Curl_dyn_init(&buf, MAX_ALTSVC_LINE);
@@ -239,7 +239,7 @@ static CURLcode altsvc_load(struct altsvcinfo *asi, const char *file)
         altsvc_add(asi, lineptr);
     }
     Curl_dyn_free(&buf); /* free the line buffer */
-    fclose(fp);
+    FCLOSE(fp);
   }
   return result;
 }
@@ -299,7 +299,7 @@ static CURLcode altsvc_out(struct altsvc *as, FILE *fp)
  */
 struct altsvcinfo *Curl_altsvc_init(void)
 {
-  struct altsvcinfo *asi = calloc(1, sizeof(struct altsvcinfo));
+  struct altsvcinfo *asi = CALLOC(1, sizeof(struct altsvcinfo));
   if(!asi)
     return NULL;
   Curl_llist_init(&asi->list, NULL);
@@ -350,8 +350,8 @@ void Curl_altsvc_cleanup(struct altsvcinfo **altsvcp)
       n = Curl_node_next(e);
       altsvc_free(as);
     }
-    free(altsvc->filename);
-    free(altsvc);
+    FREE(altsvc->filename);
+    FREE(altsvc);
     *altsvcp = NULL; /* clear the pointer */
   }
 }
@@ -392,14 +392,14 @@ CURLcode Curl_altsvc_save(struct Curl_easy *data,
       if(result)
         break;
     }
-    fclose(out);
+    FCLOSE(out);
     if(!result && tempstore && Curl_rename(tempstore, file))
       result = CURLE_WRITE_ERROR;
 
     if(result && tempstore)
       unlink(tempstore);
   }
-  free(tempstore);
+  FREE(tempstore);
   return result;
 }
 

--- a/lib/amigaos.c
+++ b/lib/amigaos.c
@@ -135,7 +135,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
     LONG h_errnop = 0;
     struct hostent *buf;
 
-    buf = calloc(1, CURL_HOSTENT_SIZE);
+    buf = CALLOC(1, CURL_HOSTENT_SIZE);
     if(buf) {
       h = gethostbyname_r((STRPTR)hostname, buf,
                           (char *)buf + sizeof(struct hostent),
@@ -144,7 +144,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
       if(h) {
         ai = Curl_he2ai(h, port);
       }
-      free(buf);
+      FREE(buf);
     }
   }
   else {

--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -698,7 +698,7 @@ static struct Curl_addrinfo *ares2addr(struct ares_addrinfo_node *node)
     if((size_t)ai->ai_addrlen < ss_size)
       continue;
 
-    ca = malloc(sizeof(struct Curl_addrinfo) + ss_size);
+    ca = MALLOC(sizeof(struct Curl_addrinfo) + ss_size);
     if(!ca) {
       error = EAI_MEMORY;
       break;
@@ -770,7 +770,7 @@ struct Curl_addrinfo *Curl_resolver_getaddrinfo(struct Curl_easy *data,
   struct thread_data *res = &data->state.async.thdata;
   *waitp = 0; /* default to synchronous response */
 
-  res->hostname = strdup(hostname);
+  res->hostname = STRDUP(hostname);
   if(!res->hostname)
     return NULL;
 

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -160,7 +160,7 @@ void destroy_thread_sync_data(struct thread_sync_data *tsd)
 {
   Curl_mutex_destroy(&tsd->mutx);
 
-  free(tsd->hostname);
+  FREE(tsd->hostname);
 
   if(tsd->res)
     Curl_freeaddrinfo(tsd->res);
@@ -218,7 +218,7 @@ int init_thread_sync_data(struct thread_data *td,
   /* Copying hostname string because original can be destroyed by parent
    * thread during gethostbyname execution.
    */
-  tsd->hostname = strdup(hostname);
+  tsd->hostname = STRDUP(hostname);
   if(!tsd->hostname)
     goto err_exit;
 

--- a/lib/base64.c
+++ b/lib/base64.c
@@ -111,7 +111,7 @@ CURLcode Curl_base64_decode(const char *src,
   rawlen = (numQuantums * 3) - padding;
 
   /* Allocate our buffer including room for a null-terminator */
-  newstr = malloc(rawlen + 1);
+  newstr = MALLOC(rawlen + 1);
   if(!newstr)
     return CURLE_OUT_OF_MEMORY;
 
@@ -181,7 +181,7 @@ CURLcode Curl_base64_decode(const char *src,
 
   return CURLE_OK;
 bad:
-  free(newstr);
+  FREE(newstr);
   return CURLE_BAD_CONTENT_ENCODING;
 }
 
@@ -205,7 +205,7 @@ static CURLcode base64_encode(const char *table64,
     return CURLE_OUT_OF_MEMORY;
 #endif
 
-  base64data = output = malloc((insize + 2) / 3 * 4 + 1);
+  base64data = output = MALLOC((insize + 2) / 3 * 4 + 1);
   if(!output)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -162,7 +162,7 @@ static void chunk_list_free(struct buf_chunk **anchor)
   while(*anchor) {
     chunk = *anchor;
     *anchor = chunk->next;
-    free(chunk);
+    FREE(chunk);
   }
 }
 
@@ -192,7 +192,7 @@ static CURLcode bufcp_take(struct bufc_pool *pool,
     return CURLE_OK;
   }
 
-  chunk = calloc(1, sizeof(*chunk) + pool->chunk_size);
+  chunk = CALLOC(1, sizeof(*chunk) + pool->chunk_size);
   if(!chunk) {
     *pchunk = NULL;
     return CURLE_OUT_OF_MEMORY;
@@ -206,7 +206,7 @@ static void bufcp_put(struct bufc_pool *pool,
                       struct buf_chunk *chunk)
 {
   if(pool->spare_count >= pool->spare_max) {
-    free(chunk);
+    FREE(chunk);
   }
   else {
     chunk_reset(chunk);
@@ -320,7 +320,7 @@ static struct buf_chunk *get_spare(struct bufq *q)
     return chunk;
   }
   else {
-    chunk = calloc(1, sizeof(*chunk) + q->chunk_size);
+    chunk = CALLOC(1, sizeof(*chunk) + q->chunk_size);
     if(!chunk)
       return NULL;
     chunk->dlen = q->chunk_size;
@@ -347,7 +347,7 @@ static void prune_head(struct bufq *q)
       /* SOFT_LIMIT allowed us more than max. free spares until
        * we are at max again. Or free them if we are configured
        * to not use spares. */
-      free(chunk);
+      FREE(chunk);
       --q->chunk_count;
     }
     else {
@@ -390,7 +390,7 @@ static void prune_tail(struct bufq *q)
       /* SOFT_LIMIT allowed us more than max. free spares until
        * we are at max again. Or free them if we are configured
        * to not use spares. */
-      free(chunk);
+      FREE(chunk);
       --q->chunk_count;
     }
     else {

--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -117,7 +117,7 @@ static CURLcode tunnel_init(struct Curl_cfilter *cf,
     return CURLE_UNSUPPORTED_PROTOCOL;
   }
 
-  ts = calloc(1, sizeof(*ts));
+  ts = CALLOC(1, sizeof(*ts));
   if(!ts)
     return CURLE_OUT_OF_MEMORY;
 
@@ -196,7 +196,7 @@ static void tunnel_free(struct Curl_cfilter *cf,
       Curl_dyn_free(&ts->rcvbuf);
       Curl_dyn_free(&ts->request_data);
       Curl_httpchunk_free(data, &ts->ch);
-      free(ts);
+      FREE(ts);
       cf->ctx = NULL;
     }
   }
@@ -217,7 +217,7 @@ static CURLcode start_CONNECT(struct Curl_cfilter *cf,
 
     /* This only happens if we have looped here due to authentication
        reasons, and we do not really use the newly cloned URL here
-       then. Just free() it. */
+       then. Just FREE() it. */
   Curl_safefree(data->req.newurl);
 
   result = Curl_http_proxy_create_CONNECT(&req, cf, data, 1);
@@ -301,7 +301,7 @@ static CURLcode on_resp_header(struct Curl_cfilter *cf,
     CURL_TRC_CF(data, cf, "CONNECT: fwd auth header '%s'", header);
     result = Curl_http_input_auth(data, proxy, auth);
 
-    free(auth);
+    FREE(auth);
 
     if(result)
       return result;

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -209,7 +209,7 @@ static void cf_h2_proxy_ctx_free(struct cf_h2_proxy_ctx *ctx)
 {
   if(ctx) {
     cf_h2_proxy_ctx_clear(ctx);
-    free(ctx);
+    FREE(ctx);
   }
 }
 
@@ -945,7 +945,7 @@ static CURLcode proxy_h2_submit(int32_t *pstream_id,
   result = CURLE_OK;
 
 out:
-  free(nva);
+  FREE(nva);
   Curl_dynhds_free(&h2_headers);
   *pstream_id = stream_id;
   return result;
@@ -1643,7 +1643,7 @@ CURLcode Curl_cf_h2_proxy_insert_after(struct Curl_cfilter *cf,
   CURLcode result = CURLE_OUT_OF_MEMORY;
 
   (void)data;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx)
     goto out;
 

--- a/lib/cf-haproxy.c
+++ b/lib/cf-haproxy.c
@@ -61,7 +61,7 @@ static void cf_haproxy_ctx_free(struct cf_haproxy_ctx *ctx)
 {
   if(ctx) {
     Curl_dyn_free(&ctx->data_out);
-    free(ctx);
+    FREE(ctx);
   }
 }
 
@@ -216,7 +216,7 @@ static CURLcode cf_haproxy_create(struct Curl_cfilter **pcf,
   CURLcode result;
 
   (void)data;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;

--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -592,7 +592,7 @@ static CURLcode cf_hc_create(struct Curl_cfilter **pcf,
     return CURLE_FAILED_INIT;
   }
 
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
@@ -612,7 +612,7 @@ static CURLcode cf_hc_create(struct Curl_cfilter **pcf,
 
 out:
   *pcf = result ? NULL : cf;
-  free(ctx);
+  FREE(ctx);
   return result;
 }
 

--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -154,7 +154,7 @@ void Curl_conn_cf_discard_chain(struct Curl_cfilter **pcf,
        */
       cf->next = NULL;
       cf->cft->destroy(cf, data);
-      free(cf);
+      FREE(cf);
       cf = cfn;
     }
   }
@@ -290,7 +290,7 @@ CURLcode Curl_cf_create(struct Curl_cfilter **pcf,
   CURLcode result = CURLE_OUT_OF_MEMORY;
 
   DEBUGASSERT(cft);
-  cf = calloc(1, sizeof(*cf));
+  cf = CALLOC(1, sizeof(*cf));
   if(!cf)
     goto out;
 
@@ -361,7 +361,7 @@ bool Curl_conn_cf_discard_sub(struct Curl_cfilter *cf,
   if(found || destroy_always) {
     discard->next = NULL;
     discard->cft->destroy(discard, data);
-    free(discard);
+    FREE(discard);
   }
   return found;
 }

--- a/lib/config-os400.h
+++ b/lib/config-os400.h
@@ -131,7 +131,7 @@
 
 
 /* The following define is needed on OS400 to enable strcmpi(), stricmp() and
-   strdup(). */
+   STRDUP(). */
 #define __cplusplus__strings__
 
 /* Define if you have the `strcasecmp' function. */

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -93,7 +93,7 @@ static struct cpool_bundle *cpool_bundle_create(const char *dest)
   struct cpool_bundle *bundle;
   size_t dest_len = strlen(dest);
 
-  bundle = calloc(1, sizeof(*bundle) + dest_len);
+  bundle = CALLOC(1, sizeof(*bundle) + dest_len);
   if(!bundle)
     return NULL;
   Curl_llist_init(&bundle->conns, NULL);
@@ -105,7 +105,7 @@ static struct cpool_bundle *cpool_bundle_create(const char *dest)
 static void cpool_bundle_destroy(struct cpool_bundle *bundle)
 {
   DEBUGASSERT(!Curl_llist_count(&bundle->conns));
-  free(bundle);
+  FREE(bundle);
 }
 
 /* Add a connection to a bundle */

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -433,7 +433,7 @@ static CURLcode eyeballer_new(struct eyeballer **pballer,
   struct eyeballer *baller;
 
   *pballer = NULL;
-  baller = calloc(1, sizeof(*baller));
+  baller = CALLOC(1, sizeof(*baller));
   if(!baller)
     return CURLE_OUT_OF_MEMORY;
 
@@ -469,7 +469,7 @@ static void baller_free(struct eyeballer *baller,
 {
   if(baller) {
     baller_close(baller, data);
-    free(baller);
+    FREE(baller);
   }
 }
 
@@ -1168,7 +1168,7 @@ cf_happy_eyeballs_create(struct Curl_cfilter **pcf,
   (void)data;
   (void)conn;
   *pcf = NULL;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
@@ -1420,7 +1420,7 @@ static CURLcode cf_setup_create(struct Curl_cfilter **pcf,
   CURLcode result = CURLE_OK;
 
   (void)data;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
@@ -1437,7 +1437,7 @@ static CURLcode cf_setup_create(struct Curl_cfilter **pcf,
 
 out:
   *pcf = result ? NULL : cf;
-  free(ctx);
+  FREE(ctx);
   return result;
 }
 

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -98,15 +98,15 @@ static voidpf
 zalloc_cb(voidpf opaque, unsigned int items, unsigned int size)
 {
   (void) opaque;
-  /* not a typo, keep it calloc() */
-  return (voidpf) calloc(items, size);
+  /* not a typo, keep it CALLOC() */
+  return (voidpf) CALLOC(items, size);
 }
 
 static void
 zfree_cb(voidpf opaque, voidpf ptr)
 {
   (void) opaque;
-  free(ptr);
+  FREE(ptr);
 }
 
 static CURLcode

--- a/lib/curl_addrinfo.c
+++ b/lib/curl_addrinfo.c
@@ -82,7 +82,7 @@ Curl_freeaddrinfo(struct Curl_addrinfo *cahead)
 
   for(ca = cahead; ca; ca = canext) {
     canext = ca->ai_next;
-    free(ca);
+    FREE(ca);
   }
 }
 
@@ -145,7 +145,7 @@ Curl_getaddrinfo_ex(const char *nodename,
     if((size_t)ai->ai_addrlen < ss_size)
       continue;
 
-    ca = malloc(sizeof(struct Curl_addrinfo) + ss_size + namelen);
+    ca = MALLOC(sizeof(struct Curl_addrinfo) + ss_size + namelen);
     if(!ca) {
       error = EAI_MEMORY;
       break;
@@ -284,7 +284,7 @@ Curl_he2ai(const struct hostent *he, int port)
       ss_size = sizeof(struct sockaddr_in);
 
     /* allocate memory to hold the struct, the address and the name */
-    ai = calloc(1, sizeof(struct Curl_addrinfo) + ss_size + namelen);
+    ai = CALLOC(1, sizeof(struct Curl_addrinfo) + ss_size + namelen);
     if(!ai) {
       result = CURLE_OUT_OF_MEMORY;
       break;
@@ -379,7 +379,7 @@ Curl_ip2addr(int af, const void *inaddr, const char *hostname, int port)
     return NULL;
 
   /* allocate memory to hold the struct, the address and the name */
-  ai = calloc(1, sizeof(struct Curl_addrinfo) + addrsize + namelen);
+  ai = CALLOC(1, sizeof(struct Curl_addrinfo) + addrsize + namelen);
   if(!ai)
     return NULL;
   /* put the address after the struct */
@@ -459,7 +459,7 @@ struct Curl_addrinfo *Curl_unix2addr(const char *path, bool *longpath,
 
   *longpath = FALSE;
 
-  ai = calloc(1, sizeof(struct Curl_addrinfo) + sizeof(struct sockaddr_un));
+  ai = CALLOC(1, sizeof(struct Curl_addrinfo) + sizeof(struct sockaddr_un));
   if(!ai)
     return NULL;
   ai->ai_addr = (void *)((char *)ai + sizeof(struct Curl_addrinfo));
@@ -470,7 +470,7 @@ struct Curl_addrinfo *Curl_unix2addr(const char *path, bool *longpath,
   /* sun_path must be able to store the NUL-terminated path */
   path_len = strlen(path) + 1;
   if(path_len > sizeof(sa_un->sun_path)) {
-    free(ai);
+    FREE(ai);
     *longpath = TRUE;
     return NULL;
   }

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -60,13 +60,13 @@
 #ifdef MEMDEBUG_NODEFINES
 #ifdef CURLDEBUG
 
-#undef strdup
-#undef malloc
-#undef calloc
-#undef realloc
-#undef free
-#undef send
-#undef recv
+#undef STRDUP
+#undef MALLOC
+#undef CALLOC
+#undef REALLOC
+#undef FREE
+#undef SEND
+#undef RECV
 
 #ifdef _WIN32
 #  ifdef UNICODE
@@ -137,16 +137,16 @@ extern curl_wcsdup_callback Curl_cwcsdup;
  * from memdebug.h are the ones that shall be used.
  */
 
-#undef strdup
-#define strdup(ptr) Curl_cstrdup(ptr)
-#undef malloc
-#define malloc(size) Curl_cmalloc(size)
-#undef calloc
-#define calloc(nbelem,size) Curl_ccalloc(nbelem, size)
-#undef realloc
-#define realloc(ptr,size) Curl_crealloc(ptr, size)
-#undef free
-#define free(ptr) Curl_cfree(ptr)
+#undef STRDUP
+#define STRDUP(ptr) Curl_cstrdup(ptr)
+#undef MALLOC
+#define MALLOC(size) Curl_cmalloc(size)
+#undef CALLOC
+#define CALLOC(nbelem,size) Curl_ccalloc(nbelem, size)
+#undef REALLOC
+#define REALLOC(ptr,size) Curl_crealloc(ptr, size)
+#undef FREE
+#define FREE(ptr) Curl_cfree(ptr)
 
 #ifdef _WIN32
 #  ifdef UNICODE

--- a/lib/curl_multibyte.c
+++ b/lib/curl_multibyte.c
@@ -48,11 +48,11 @@ wchar_t *curlx_convert_UTF8_to_wchar(const char *str_utf8)
     int str_w_len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
                                         str_utf8, -1, NULL, 0);
     if(str_w_len > 0) {
-      str_w = malloc(str_w_len * sizeof(wchar_t));
+      str_w = MALLOC(str_w_len * sizeof(wchar_t));
       if(str_w) {
         if(MultiByteToWideChar(CP_UTF8, 0, str_utf8, -1, str_w,
                                str_w_len) == 0) {
-          free(str_w);
+          FREE(str_w);
           return NULL;
         }
       }
@@ -70,11 +70,11 @@ char *curlx_convert_wchar_to_UTF8(const wchar_t *str_w)
     int bytes = WideCharToMultiByte(CP_UTF8, 0, str_w, -1,
                                     NULL, 0, NULL, NULL);
     if(bytes > 0) {
-      str_utf8 = malloc(bytes);
+      str_utf8 = MALLOC(bytes);
       if(str_utf8) {
         if(WideCharToMultiByte(CP_UTF8, 0, str_w, -1, str_utf8, bytes,
                                NULL, NULL) == 0) {
-          free(str_utf8);
+          FREE(str_utf8);
           return NULL;
         }
       }
@@ -136,7 +136,7 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
   if(needed == (size_t)-1 || needed >= max_path_len)
     goto cleanup;
   ++needed; /* for NUL */
-  ibuf = malloc(needed * sizeof(wchar_t));
+  ibuf = MALLOC(needed * sizeof(wchar_t));
   if(!ibuf)
     goto cleanup;
   count = mbstowcs(ibuf, in, needed);
@@ -156,7 +156,7 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
   /* skip paths that are not excessive and do not need modification */
   if(needed <= MAX_PATH)
     goto cleanup;
-  fbuf = malloc(needed * sizeof(wchar_t));
+  fbuf = MALLOC(needed * sizeof(wchar_t));
   if(!fbuf)
     goto cleanup;
   count = (size_t)GetFullPathNameW(in_w, (DWORD)needed, fbuf, NULL);
@@ -189,7 +189,7 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
       if(needed > max_path_len)
         goto cleanup;
 
-      temp = malloc(needed * sizeof(wchar_t));
+      temp = MALLOC(needed * sizeof(wchar_t));
       if(!temp)
         goto cleanup;
 
@@ -202,7 +202,7 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
       if(needed > max_path_len)
         goto cleanup;
 
-      temp = malloc(needed * sizeof(wchar_t));
+      temp = MALLOC(needed * sizeof(wchar_t));
       if(!temp)
         goto cleanup;
 
@@ -210,7 +210,7 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
       wcscpy(temp + 4, fbuf);
     }
 
-    free(fbuf);
+    FREE(fbuf);
     fbuf = temp;
   }
 
@@ -220,7 +220,7 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
   if(needed == (size_t)-1 || needed >= max_path_len)
     goto cleanup;
   ++needed; /* for NUL */
-  obuf = malloc(needed);
+  obuf = MALLOC(needed);
   if(!obuf)
     goto cleanup;
   count = wcstombs(obuf, fbuf, needed);
@@ -234,10 +234,10 @@ static bool fix_excessive_path(const TCHAR *in, TCHAR **out)
 #endif
 
 cleanup:
-  free(fbuf);
+  FREE(fbuf);
 #ifndef _UNICODE
-  free(ibuf);
-  free(obuf);
+  FREE(ibuf);
+  FREE(obuf);
 #endif
   return *out ? true : false;
 }
@@ -279,7 +279,7 @@ int curlx_win32_open(const char *filename, int oflag, ...)
   result = (_open)(target, oflag, pmode);
 #endif
 
-  free(fixed);
+  FREE(fixed);
   return result;
 }
 
@@ -312,7 +312,7 @@ FILE *curlx_win32_fopen(const char *filename, const char *mode)
   result = (fopen)(target, mode);
 #endif
 
-  free(fixed);
+  FREE(fixed);
   return result;
 }
 
@@ -351,7 +351,7 @@ int curlx_win32_stat(const char *path, struct_stat *buffer)
 #endif
 #endif
 
-  free(fixed);
+  FREE(fixed);
   return result;
 }
 

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -435,7 +435,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(const char *password,
   CURLcode result;
   if(len > SIZE_T_MAX/2) /* avoid integer overflow */
     return CURLE_OUT_OF_MEMORY;
-  pw = len ? malloc(len * 2) : (unsigned char *)strdup("");
+  pw = len ? MALLOC(len * 2) : (unsigned char *)STRDUP("");
   if(!pw)
     return CURLE_OUT_OF_MEMORY;
 
@@ -446,7 +446,7 @@ CURLcode Curl_ntlm_core_mk_nt_hash(const char *password,
   if(!result)
     memset(ntbuffer + 16, 0, 21 - 16);
 
-  free(pw);
+  FREE(pw);
 
   return result;
 }
@@ -523,7 +523,7 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_hash(const char *user, size_t userlen,
     return CURLE_OUT_OF_MEMORY;
 
   identity_len = (userlen + domlen) * 2;
-  identity = malloc(identity_len + 1);
+  identity = MALLOC(identity_len + 1);
 
   if(!identity)
     return CURLE_OUT_OF_MEMORY;
@@ -533,7 +533,7 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_hash(const char *user, size_t userlen,
 
   result = Curl_hmacit(&Curl_HMAC_MD5, ntlmhash, 16, identity, identity_len,
                        ntlmv2hash);
-  free(identity);
+  FREE(identity);
 
   return result;
 }
@@ -596,7 +596,7 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
   len = HMAC_MD5_LENGTH + NTLMv2_BLOB_LEN;
 
   /* Allocate the response */
-  ptr = calloc(1, len);
+  ptr = CALLOC(1, len);
   if(!ptr)
     return CURLE_OUT_OF_MEMORY;
 
@@ -619,7 +619,7 @@ CURLcode Curl_ntlm_core_mk_ntlmv2_resp(unsigned char *ntlmv2hash,
   result = Curl_hmacit(&Curl_HMAC_MD5, ntlmv2hash, HMAC_MD5_LENGTH, ptr + 8,
                        NTLMv2_BLOB_LEN + 8, hmac_output);
   if(result) {
-    free(ptr);
+    FREE(ptr);
     return result;
   }
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -89,10 +89,10 @@
 #pragma warning(disable:4127)
 /* Avoid VS2005 and upper complaining about portable C functions. */
 #ifndef _CRT_NONSTDC_NO_DEPRECATE
-#define _CRT_NONSTDC_NO_DEPRECATE  /* for strdup(), write(), etc. */
+#define _CRT_NONSTDC_NO_DEPRECATE  /* for STRDUP(), write(), etc. */
 #endif
 #ifndef _CRT_SECURE_NO_DEPRECATE
-#define _CRT_SECURE_NO_DEPRECATE  /* for fopen(), getenv(), etc. */
+#define _CRT_SECURE_NO_DEPRECATE  /* for FOPEN(), getenv(), etc. */
 #endif
 #endif /* _MSC_VER */
 
@@ -493,7 +493,7 @@
 #  define struct_stat                struct _stati64
 #  define LSEEK_ERROR                (__int64)-1
 #  define open                       curlx_win32_open
-#  define fopen(fname,mode)          curlx_win32_fopen(fname, mode)
+#  define FOPEN(fname,mode)          curlx_win32_fopen(fname, mode)
    int curlx_win32_open(const char *filename, int oflag, ...);
    int curlx_win32_stat(const char *path, struct_stat *buffer);
    FILE *curlx_win32_fopen(const char *filename, const char *mode);
@@ -524,7 +524,7 @@
 #    define stat(fname,stp)            curlx_win32_stat(fname, stp)
 #    define struct_stat                struct _stat
 #    define open                       curlx_win32_open
-#    define fopen(fname,mode)          curlx_win32_fopen(fname, mode)
+#    define FOPEN(fname,mode)          curlx_win32_fopen(fname, mode)
      int curlx_win32_stat(const char *path, struct_stat *buffer);
      int curlx_win32_open(const char *filename, int oflag, ...);
      FILE *curlx_win32_fopen(const char *filename, const char *mode);

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -125,7 +125,7 @@ struct timeval {
 
 /*
  * If we have the MSG_NOSIGNAL define, make sure we use
- * it as the fourth argument of function send()
+ * it as the fourth argument of function SEND()
  */
 
 #ifdef HAVE_MSG_NOSIGNAL
@@ -144,10 +144,10 @@ struct timeval {
 #elif defined(HAVE_RECV)
 /*
  * The definitions for the return type and arguments types
- * of functions recv() and send() belong and come from the
+ * of functions RECV() and SEND() belong and come from the
  * configuration file. Do not define them in any other place.
  *
- * HAVE_RECV is defined if you have a function named recv()
+ * HAVE_RECV is defined if you have a function named RECV()
  * which is used to read incoming data from sockets. If your
  * function has another name then do not define HAVE_RECV.
  *
@@ -155,7 +155,7 @@ struct timeval {
  * RECV_TYPE_ARG3, RECV_TYPE_ARG4 and RECV_TYPE_RETV must also
  * be defined.
  *
- * HAVE_SEND is defined if you have a function named send()
+ * HAVE_SEND is defined if you have a function named SEND()
  * which is used to write outgoing data on a connected socket.
  * If yours has another name then do not define HAVE_SEND.
  *
@@ -164,7 +164,7 @@ struct timeval {
  * SEND_TYPE_RETV must also be defined.
  */
 
-#define sread(x,y,z) (ssize_t)recv((RECV_TYPE_ARG1)(x), \
+#define sread(x,y,z) (ssize_t)RECV((RECV_TYPE_ARG1)(x), \
                                    (RECV_TYPE_ARG2)(y), \
                                    (RECV_TYPE_ARG3)(z), \
                                    (RECV_TYPE_ARG4)(0))
@@ -181,7 +181,7 @@ struct timeval {
                                      (SEND_TYPE_ARG2)CURL_UNCONST(y), \
                                      (SEND_TYPE_ARG3)(z))
 #elif defined(HAVE_SEND)
-#define swrite(x,y,z) (ssize_t)send((SEND_TYPE_ARG1)(x), \
+#define swrite(x,y,z) (ssize_t)SEND((SEND_TYPE_ARG1)(x), \
                               (SEND_QUAL_ARG2 SEND_TYPE_ARG2)CURL_UNCONST(y), \
                                     (SEND_TYPE_ARG3)(z), \
                                     (SEND_TYPE_ARG4)(SEND_4TH_ARG))

--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -184,7 +184,7 @@ CURLcode Curl_create_sspi_identity(const char *userp, const char *passwdp,
   dup_user.tchar_ptr = NULL;
 
   /* Setup the identity's domain and length */
-  dup_domain.tchar_ptr = malloc(sizeof(TCHAR) * (domlen + 1));
+  dup_domain.tchar_ptr = MALLOC(sizeof(TCHAR) * (domlen + 1));
   if(!dup_domain.tchar_ptr) {
     curlx_unicodefree(useranddomain.tchar_ptr);
     return CURLE_OUT_OF_MEMORY;

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -54,7 +54,7 @@ static void *curl_thread_create_thunk(void *arg)
   unsigned int (*func)(void *) = ac->func;
   void *real_arg = ac->arg;
 
-  free(ac);
+  FREE(ac);
 
   (*func)(real_arg);
 
@@ -63,8 +63,8 @@ static void *curl_thread_create_thunk(void *arg)
 
 curl_thread_t Curl_thread_create(unsigned int (*func) (void *), void *arg)
 {
-  curl_thread_t t = malloc(sizeof(pthread_t));
-  struct Curl_actual_call *ac = malloc(sizeof(struct Curl_actual_call));
+  curl_thread_t t = MALLOC(sizeof(pthread_t));
+  struct Curl_actual_call *ac = MALLOC(sizeof(struct Curl_actual_call));
   if(!(ac && t))
     goto err;
 
@@ -77,8 +77,8 @@ curl_thread_t Curl_thread_create(unsigned int (*func) (void *), void *arg)
   return t;
 
 err:
-  free(t);
-  free(ac);
+  FREE(t);
+  FREE(ac);
   return curl_thread_t_null;
 }
 
@@ -86,7 +86,7 @@ void Curl_thread_destroy(curl_thread_t hnd)
 {
   if(hnd != curl_thread_t_null) {
     pthread_detach(*hnd);
-    free(hnd);
+    FREE(hnd);
   }
 }
 
@@ -94,7 +94,7 @@ int Curl_thread_join(curl_thread_t *hnd)
 {
   int ret = (pthread_join(**hnd, NULL) == 0);
 
-  free(*hnd);
+  FREE(*hnd);
   *hnd = curl_thread_t_null;
 
   return ret;

--- a/lib/cw-out.c
+++ b/lib/cw-out.c
@@ -84,7 +84,7 @@ struct cw_out_buf {
 
 static struct cw_out_buf *cw_out_buf_create(cw_out_type otype)
 {
-  struct cw_out_buf *cwbuf = calloc(1, sizeof(*cwbuf));
+  struct cw_out_buf *cwbuf = CALLOC(1, sizeof(*cwbuf));
   if(cwbuf) {
     cwbuf->type = otype;
     Curl_dyn_init(&cwbuf->b, DYN_PAUSE_BUFFER);
@@ -96,7 +96,7 @@ static void cw_out_buf_free(struct cw_out_buf *cwbuf)
 {
   if(cwbuf) {
     Curl_dyn_free(&cwbuf->b);
-    free(cwbuf);
+    FREE(cwbuf);
   }
 }
 

--- a/lib/cw-pause.c
+++ b/lib/cw-pause.c
@@ -53,7 +53,7 @@ struct cw_pause_buf {
 
 static struct cw_pause_buf *cw_pause_buf_create(int type, size_t buflen)
 {
-  struct cw_pause_buf *cwbuf = calloc(1, sizeof(*cwbuf));
+  struct cw_pause_buf *cwbuf = CALLOC(1, sizeof(*cwbuf));
   if(cwbuf) {
     cwbuf->type = type;
     if(type & CLIENTWRITE_BODY)
@@ -69,7 +69,7 @@ static void cw_pause_buf_free(struct cw_pause_buf *cwbuf)
 {
   if(cwbuf) {
     Curl_bufq_free(&cwbuf->b);
-    free(cwbuf);
+    FREE(cwbuf);
   }
 }
 

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -164,7 +164,7 @@ static CURLcode sendf(struct Curl_easy *data, const char *fmt, ...)
       break;
   }
 
-  free(s); /* free the output string */
+  FREE(s); /* free the output string */
 
   return result;
 }
@@ -302,8 +302,8 @@ static CURLcode dict_do(struct Curl_easy *data, bool *done)
   }
 
 error:
-  free(eword);
-  free(path);
+  FREE(eword);
+  FREE(path);
   return result;
 }
 #endif /* CURL_DISABLE_DICT */

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -415,7 +415,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
   DEBUGASSERT(conn);
 
   /* start clean, consider allocating this struct on demand */
-  dohp = data->req.doh = calloc(1, sizeof(struct doh_probes));
+  dohp = data->req.doh = CALLOC(1, sizeof(struct doh_probes));
   if(!dohp)
     return NULL;
 
@@ -465,7 +465,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
                            DNS_TYPE_HTTPS,
                            qname ? qname : hostname, data->set.str[STRING_DOH],
                            data->multi, dohp->req_hds);
-    free(qname);
+    FREE(qname);
     if(result)
       goto error;
     dohp->pending++;
@@ -909,7 +909,7 @@ static CURLcode doh2ai(const struct dohentry *de, const char *hostname,
       addrtype = AF_INET;
     }
 
-    ai = calloc(1, sizeof(struct Curl_addrinfo) + ss_size + hostlen);
+    ai = CALLOC(1, sizeof(struct Curl_addrinfo) + ss_size + hostlen);
     if(!ai) {
       result = CURLE_OUT_OF_MEMORY;
       break;
@@ -1096,7 +1096,7 @@ static CURLcode doh_resp_decode_httpsrr(struct Curl_easy *data,
 #endif
   if(len <= 2)
     return CURLE_BAD_FUNCTION_ARGUMENT;
-  lhrr = calloc(1, sizeof(struct Curl_https_rrinfo));
+  lhrr = CALLOC(1, sizeof(struct Curl_https_rrinfo));
   if(!lhrr)
     return CURLE_OUT_OF_MEMORY;
   lhrr->priority = doh_get16bit(cp, 0);

--- a/lib/dynbuf.c
+++ b/lib/dynbuf.c
@@ -108,7 +108,7 @@ static CURLcode dyn_nappend(struct dynbuf *s,
   if(a != s->allc) {
     /* this logic is not using Curl_saferealloc() to make the tool not have to
        include that as well when it uses this code */
-    void *p = realloc(s->bufr, a);
+    void *p = REALLOC(s->bufr, a);
     if(!p) {
       Curl_dyn_free(s);
       return CURLE_OUT_OF_MEMORY;
@@ -212,7 +212,7 @@ CURLcode Curl_dyn_vaddf(struct dynbuf *s, const char *fmt, va_list ap)
 
   if(str) {
     CURLcode result = dyn_nappend(s, (const unsigned char *)str, strlen(str));
-    free(str);
+    FREE(str);
     return result;
   }
   /* If we failed, we cleanup the whole buffer and return error */

--- a/lib/dynhds.c
+++ b/lib/dynhds.c
@@ -45,7 +45,7 @@ entry_new(const char *name, size_t namelen,
 
   DEBUGASSERT(name);
   DEBUGASSERT(value);
-  e = calloc(1, sizeof(*e) + namelen + valuelen + 2);
+  e = CALLOC(1, sizeof(*e) + namelen + valuelen + 2);
   if(!e)
     return NULL;
   e->name = p = ((char *)e) + sizeof(*e);
@@ -68,7 +68,7 @@ entry_append(struct dynhds_entry *e,
   char *p;
 
   DEBUGASSERT(value);
-  e2 = calloc(1, sizeof(*e) + e->namelen + valuelen2 + 2);
+  e2 = CALLOC(1, sizeof(*e) + e->namelen + valuelen2 + 2);
   if(!e2)
     return NULL;
   e2->name = p = ((char *)e2) + sizeof(*e2);
@@ -85,7 +85,7 @@ entry_append(struct dynhds_entry *e,
 
 static void entry_free(struct dynhds_entry *e)
 {
-  free(e);
+  FREE(e);
 }
 
 void Curl_dynhds_init(struct dynhds *dynhds, size_t max_entries,
@@ -186,7 +186,7 @@ entry = entry_new(name, namelen, value, valuelen, dynhds->opts);
     if(dynhds->max_entries && nallc > dynhds->max_entries)
       nallc = dynhds->max_entries;
 
-    nhds = calloc(nallc, sizeof(struct dynhds_entry *));
+    nhds = CALLOC(nallc, sizeof(struct dynhds_entry *));
     if(!nhds)
       goto out;
     if(dynhds->hds) {
@@ -373,7 +373,7 @@ CURLcode Curl_dynhds_h1_dprint(struct dynhds *dynhds, struct dynbuf *dbuf)
 
 nghttp2_nv *Curl_dynhds_to_nva(struct dynhds *dynhds, size_t *pcount)
 {
-  nghttp2_nv *nva = calloc(1, sizeof(nghttp2_nv) * dynhds->hds_len);
+  nghttp2_nv *nva = CALLOC(1, sizeof(nghttp2_nv) * dynhds->hds_len);
   size_t i;
 
   *pcount = 0;

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -200,7 +200,7 @@ static CURLcode global_init(long flags, bool memoryfuncs)
 #ifdef DEBUGBUILD
   if(getenv("CURL_GLOBAL_INIT"))
     /* alloc data that will leak if *cleanup() is not called! */
-    leakpointer = malloc(1);
+    leakpointer = MALLOC(1);
 #endif
 
   return CURLE_OK;
@@ -299,7 +299,7 @@ void curl_global_cleanup(void)
   Curl_ssh_cleanup();
 
 #ifdef DEBUGBUILD
-  free(leakpointer);
+  FREE(leakpointer);
 #endif
 
   easy_init_flags = 0;
@@ -480,7 +480,7 @@ static int events_socket(CURL *easy,      /* easy handle */
           prev->next = nxt;
         else
           ev->list = nxt;
-        free(m);
+        FREE(m);
         infof(data, "socket cb: socket %" FMT_SOCKET_T " REMOVED", s);
       }
       else {
@@ -506,7 +506,7 @@ static int events_socket(CURL *easy,      /* easy handle */
       DEBUGASSERT(0);
     }
     else {
-      m = malloc(sizeof(struct socketmonitor));
+      m = MALLOC(sizeof(struct socketmonitor));
       if(m) {
         m->next = ev->list;
         m->socket.fd = s;
@@ -918,7 +918,7 @@ static CURLcode dupset(struct Curl_easy *dst, struct Curl_easy *src)
   i = STRING_COPYPOSTFIELDS;
   if(src->set.str[i]) {
     if(src->set.postfieldsize == -1)
-      dst->set.str[i] = strdup(src->set.str[i]);
+      dst->set.str[i] = STRDUP(src->set.str[i]);
     else
       /* postfieldsize is curl_off_t, Curl_memdup() takes a size_t ... */
       dst->set.str[i] = Curl_memdup(src->set.str[i],
@@ -946,7 +946,7 @@ static CURLcode dupset(struct Curl_easy *dst, struct Curl_easy *src)
 CURL *curl_easy_duphandle(CURL *d)
 {
   struct Curl_easy *data = d;
-  struct Curl_easy *outcurl = calloc(1, sizeof(struct Curl_easy));
+  struct Curl_easy *outcurl = CALLOC(1, sizeof(struct Curl_easy));
   if(!outcurl)
     goto fail;
 
@@ -997,14 +997,14 @@ CURL *curl_easy_duphandle(CURL *d)
 #endif
 
   if(data->state.url) {
-    outcurl->state.url = strdup(data->state.url);
+    outcurl->state.url = STRDUP(data->state.url);
     if(!outcurl->state.url)
       goto fail;
     outcurl->state.url_alloc = TRUE;
   }
 
   if(data->state.referer) {
-    outcurl->state.referer = strdup(data->state.referer);
+    outcurl->state.referer = STRDUP(data->state.referer);
     if(!outcurl->state.referer)
       goto fail;
     outcurl->state.referer_alloc = TRUE;
@@ -1078,13 +1078,13 @@ fail:
 
   if(outcurl) {
 #ifndef CURL_DISABLE_COOKIES
-    free(outcurl->cookies);
+    FREE(outcurl->cookies);
 #endif
     Curl_dyn_free(&outcurl->state.headerb);
     Curl_altsvc_cleanup(&outcurl->asi);
     Curl_hsts_cleanup(&outcurl->hsts);
     Curl_freeset(outcurl);
-    free(outcurl);
+    FREE(outcurl);
   }
 
   return NULL;

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -67,7 +67,7 @@ char *curl_easy_escape(CURL *data, const char *string,
 
   length = (inlength ? (size_t)inlength : strlen(string));
   if(!length)
-    return strdup("");
+    return STRDUP("");
 
   Curl_dyn_init(&d, length * 3 + 1);
 
@@ -131,7 +131,7 @@ CURLcode Curl_urldecode(const char *string, size_t length,
   DEBUGASSERT(ctrl >= REJECT_NADA); /* crash on TRUE/FALSE */
 
   alloc = (length ? length : strlen(string));
-  ns = malloc(alloc + 1);
+  ns = MALLOC(alloc + 1);
 
   if(!ns)
     return CURLE_OUT_OF_MEMORY;
@@ -207,7 +207,7 @@ char *curl_easy_unescape(CURL *data, const char *string,
    the library's memory system */
 void curl_free(void *p)
 {
-  free(p);
+  FREE(p);
 }
 
 /*

--- a/lib/file.c
+++ b/lib/file.c
@@ -132,7 +132,7 @@ static CURLcode file_setup_connection(struct Curl_easy *data,
 {
   (void)conn;
   /* allocate the FILE specific struct */
-  data->req.p.file = calloc(1, sizeof(struct FILEPROTO));
+  data->req.p.file = CALLOC(1, sizeof(struct FILEPROTO));
   if(!data->req.p.file)
     return CURLE_OUT_OF_MEMORY;
 
@@ -240,7 +240,7 @@ static CURLcode file_connect(struct Curl_easy *data, bool *done)
   file->path = real_path;
   #endif
 #endif
-  free(file->freepath);
+  FREE(file->freepath);
   file->freepath = real_path; /* free this when done */
 
   file->fd = fd;
@@ -540,7 +540,7 @@ static CURLcode file_do(struct Curl_easy *data, bool *done)
 
   /* The following is a shortcut implementation of file reading
      this is both more efficient than the former call to download() and
-     it avoids problems with select() and recv() on file descriptors
+     it avoids problems with select() and RECV() on file descriptors
      in Winsock */
   if(size_known)
     Curl_pgrsSetDownloadSize(data, expected_size);

--- a/lib/fileinfo.c
+++ b/lib/fileinfo.c
@@ -32,7 +32,7 @@
 
 struct fileinfo *Curl_fileinfo_alloc(void)
 {
-  return calloc(1, sizeof(struct fileinfo));
+  return CALLOC(1, sizeof(struct fileinfo));
 }
 
 void Curl_fileinfo_cleanup(struct fileinfo *finfo)
@@ -41,6 +41,6 @@ void Curl_fileinfo_cleanup(struct fileinfo *finfo)
     return;
 
   Curl_dyn_free(&finfo->buf);
-  free(finfo);
+  FREE(finfo);
 }
 #endif

--- a/lib/fopen.c
+++ b/lib/fopen.c
@@ -102,7 +102,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   char *dir = NULL;
   *tempname = NULL;
 
-  *fh = fopen(filename, FOPEN_WRITETEXT);
+  *fh = FOPEN(filename, FOPEN_WRITETEXT);
   if(!*fh)
     goto fail;
   if(
@@ -114,7 +114,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
      || !S_ISREG(sb.st_mode)) {
     return CURLE_OK;
   }
-  fclose(*fh);
+  FCLOSE(*fh);
   *fh = NULL;
 
   result = Curl_rand_alnum(data, randbuf, sizeof(randbuf));
@@ -126,7 +126,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
     /* The temp filename should not end up too long for the target file
        system */
     tempstore = aprintf("%s%s.tmp", dir, randbuf);
-    free(dir);
+    FREE(dir);
   }
 
   if(!tempstore) {
@@ -144,7 +144,7 @@ CURLcode Curl_fopen(struct Curl_easy *data, const char *filename,
   if(fd == -1)
     goto fail;
 
-  *fh = fdopen(fd, FOPEN_WRITETEXT);
+  *fh = FDOPEN(fd, FOPEN_WRITETEXT);
   if(!*fh)
     goto fail;
 
@@ -157,7 +157,7 @@ fail:
     unlink(tempstore);
   }
 
-  free(tempstore);
+  FREE(tempstore);
   return result;
 }
 

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -81,7 +81,7 @@ AddHttpPost(char *name, size_t namelength,
   if((bufferlength > LONG_MAX) || (namelength > LONG_MAX))
     /* avoid overflow in typecasts below */
     return NULL;
-  post = calloc(1, sizeof(struct curl_httppost));
+  post = CALLOC(1, sizeof(struct curl_httppost));
   if(post) {
     post->name = name;
     post->namelength = (long)namelength;
@@ -132,7 +132,7 @@ static struct FormInfo *AddFormInfo(char *value,
                                     struct FormInfo *parent_form_info)
 {
   struct FormInfo *form_info;
-  form_info = calloc(1, sizeof(struct FormInfo));
+  form_info = CALLOC(1, sizeof(struct FormInfo));
   if(!form_info)
     return NULL;
   if(value)
@@ -222,7 +222,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
   /*
    * We need to allocate the first struct to fill in.
    */
-  first_form = calloc(1, sizeof(struct FormInfo));
+  first_form = CALLOC(1, sizeof(struct FormInfo));
   if(!first_form)
     return CURL_FORMADD_MEMORY;
 
@@ -334,7 +334,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         const char *filename = array_state ?
           array_value : va_arg(params, char *);
         if(filename) {
-          current_form->value = strdup(filename);
+          current_form->value = STRDUP(filename);
           if(!current_form->value)
             return_value = CURL_FORMADD_MEMORY;
           else {
@@ -356,13 +356,13 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         if(current_form->value) {
           if(current_form->flags & HTTPPOST_FILENAME) {
             if(filename) {
-              char *fname = strdup(filename);
+              char *fname = STRDUP(filename);
               if(!fname)
                 return_value = CURL_FORMADD_MEMORY;
               else {
                 form = AddFormInfo(fname, NULL, current_form);
                 if(!form) {
-                  free(fname);
+                  FREE(fname);
                   return_value = CURL_FORMADD_MEMORY;
                 }
                 else {
@@ -380,7 +380,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         }
         else {
           if(filename) {
-            current_form->value = strdup(filename);
+            current_form->value = STRDUP(filename);
             if(!current_form->value)
               return_value = CURL_FORMADD_MEMORY;
             else {
@@ -445,13 +445,13 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         if(current_form->contenttype) {
           if(current_form->flags & HTTPPOST_FILENAME) {
             if(contenttype) {
-              char *type = strdup(contenttype);
+              char *type = STRDUP(contenttype);
               if(!type)
                 return_value = CURL_FORMADD_MEMORY;
               else {
                 form = AddFormInfo(NULL, type, current_form);
                 if(!form) {
-                  free(type);
+                  FREE(type);
                   return_value = CURL_FORMADD_MEMORY;
                 }
                 else {
@@ -469,7 +469,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         }
         else {
           if(contenttype) {
-            current_form->contenttype = strdup(contenttype);
+            current_form->contenttype = STRDUP(contenttype);
             if(!current_form->contenttype)
               return_value = CURL_FORMADD_MEMORY;
             else
@@ -503,7 +503,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         if(current_form->showfilename)
           return_value = CURL_FORMADD_OPTION_TWICE;
         else {
-          current_form->showfilename = strdup(filename);
+          current_form->showfilename = STRDUP(filename);
           if(!current_form->showfilename)
             return_value = CURL_FORMADD_MEMORY;
           else
@@ -578,7 +578,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
           type = FILE_CONTENTTYPE_DEFAULT;
 
         /* our contenttype is missing */
-        form->contenttype = strdup(type);
+        form->contenttype = STRDUP(type);
         if(!form->contenttype) {
           return_value = CURL_FORMADD_MEMORY;
           break;
@@ -676,7 +676,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
      now by the httppost linked list */
   while(first_form) {
     struct FormInfo *ptr = first_form->more;
-    free(first_form);
+    FREE(first_form);
     first_form = ptr;
   }
 
@@ -757,14 +757,14 @@ void curl_formfree(struct curl_httppost *form)
     curl_formfree(form->more);
 
     if(!(form->flags & HTTPPOST_PTRNAME))
-      free(form->name); /* free the name */
+      FREE(form->name); /* free the name */
     if(!(form->flags &
          (HTTPPOST_PTRCONTENTS|HTTPPOST_BUFFER|HTTPPOST_CALLBACK))
       )
-      free(form->contents); /* free the contents */
-    free(form->contenttype); /* free the content type */
-    free(form->showfilename); /* free the faked filename */
-    free(form);       /* free the struct */
+      FREE(form->contents); /* free the contents */
+    FREE(form->contenttype); /* free the content type */
+    FREE(form->showfilename); /* free the faked filename */
+    FREE(form);       /* free the struct */
     form = next;
   } while(form); /* continue */
 }
@@ -782,7 +782,7 @@ static CURLcode setname(curl_mimepart *part, const char *name, size_t len)
   if(!zname)
     return CURLE_OUT_OF_MEMORY;
   res = curl_mime_name(part, zname);
-  free(zname);
+  FREE(zname);
   return res;
 }
 

--- a/lib/ftp.h
+++ b/lib/ftp.h
@@ -124,7 +124,7 @@ struct ftp_conn {
   char *alternative_to_user;
   char *entrypath; /* the PWD reply when we logged on */
   char *file;    /* url-decoded filename (or path) */
-  char **dirs;   /* realloc()ed array for path components */
+  char **dirs;   /* REALLOC()ed array for path components */
   char *newhost; /* the (allocated) IP addr or hostname to connect the data
                     connection to */
   char *prevpath;   /* url-decoded conn->path from the previous transfer */

--- a/lib/ftplistparser.c
+++ b/lib/ftplistparser.c
@@ -208,18 +208,18 @@ void Curl_wildcard_dtor(struct WildcardData **wcp)
   DEBUGASSERT(wc->ftpwc == NULL);
 
   Curl_llist_destroy(&wc->filelist, NULL);
-  free(wc->path);
+  FREE(wc->path);
   wc->path = NULL;
-  free(wc->pattern);
+  FREE(wc->pattern);
   wc->pattern = NULL;
   wc->state = CURLWC_INIT;
-  free(wc);
+  FREE(wc);
   *wcp = NULL;
 }
 
 struct ftp_parselist_data *Curl_ftp_parselist_data_alloc(void)
 {
-  return calloc(1, sizeof(struct ftp_parselist_data));
+  return CALLOC(1, sizeof(struct ftp_parselist_data));
 }
 
 
@@ -228,7 +228,7 @@ void Curl_ftp_parselist_data_free(struct ftp_parselist_data **parserp)
   struct ftp_parselist_data *parser = *parserp;
   if(parser)
     Curl_fileinfo_cleanup(parser->file_data);
-  free(parser);
+  FREE(parser);
   *parserp = NULL;
 }
 

--- a/lib/functypes.h
+++ b/lib/functypes.h
@@ -28,8 +28,8 @@
 
 /* defaults:
 
-   ssize_t recv(int, void *, size_t, int);
-   ssize_t send(int, const void *, size_t, int);
+   ssize_t RECV(int, void *, size_t, int);
+   ssize_t SEND(int, const void *, size_t, int);
 
    If other argument or return types are needed:
 
@@ -39,13 +39,13 @@
 */
 
 #ifdef _WIN32
-/* int recv(SOCKET, char *, int, int) */
+/* int RECV(SOCKET, char *, int, int) */
 #define RECV_TYPE_ARG1 SOCKET
 #define RECV_TYPE_ARG2 char *
 #define RECV_TYPE_ARG3 int
 #define RECV_TYPE_RETV int
 
-/* int send(SOCKET, const char *, int, int); */
+/* int SEND(SOCKET, const char *, int, int); */
 #define SEND_TYPE_ARG1 SOCKET
 #define SEND_TYPE_ARG2 char *
 #define SEND_TYPE_ARG3 int
@@ -53,14 +53,14 @@
 
 #elif defined(__AMIGA__) /* Any AmigaOS flavour */
 
-/* long recv(long, char *, long, long); */
+/* long RECV(long, char *, long, long); */
 #define RECV_TYPE_ARG1 long
 #define RECV_TYPE_ARG2 char *
 #define RECV_TYPE_ARG3 long
 #define RECV_TYPE_ARG4 long
 #define RECV_TYPE_RETV long
 
-/* int send(int, const char *, int, int); */
+/* int SEND(int, const char *, int, int); */
 #define SEND_TYPE_ARG1 int
 #define SEND_QUAL_ARG2
 #define SEND_TYPE_ARG2 char *

--- a/lib/getenv.c
+++ b/lib/getenv.c
@@ -45,9 +45,9 @@ static char *GetEnv(const char *variable)
   const DWORD max = 32768; /* max env var size from MSCRT source */
 
   for(;;) {
-    tmp = realloc(buf, rc);
+    tmp = REALLOC(buf, rc);
     if(!tmp) {
-      free(buf);
+      FREE(buf);
       return NULL;
     }
 
@@ -58,7 +58,7 @@ static char *GetEnv(const char *variable)
        Since getenv does not make that distinction we ignore it as well. */
     rc = GetEnvironmentVariableA(variable, buf, bufsize);
     if(!rc || rc == bufsize || rc > max) {
-      free(buf);
+      FREE(buf);
       return NULL;
     }
 
@@ -70,7 +70,7 @@ static char *GetEnv(const char *variable)
   }
 #else
   char *env = getenv(variable);
-  return (env && env[0]) ? strdup(env) : NULL;
+  return (env && env[0]) ? STRDUP(env) : NULL;
 #endif
 }
 

--- a/lib/getinfo.c
+++ b/lib/getinfo.c
@@ -73,10 +73,10 @@ CURLcode Curl_initinfo(struct Curl_easy *data)
   info->httpauthpicked = 0;
   info->numconnects = 0;
 
-  free(info->contenttype);
+  FREE(info->contenttype);
   info->contenttype = NULL;
 
-  free(info->wouldredirect);
+  FREE(info->wouldredirect);
   info->wouldredirect = NULL;
 
   memset(&info->primary, 0, sizeof(info->primary));
@@ -139,7 +139,7 @@ static CURLcode getinfo_char(struct Curl_easy *data, CURLINFO info,
   case CURLINFO_FTP_ENTRY_PATH:
     /* Return the entrypath string from the most recent connection.
        This pointer was copied from the connectdata structure by FTP.
-       The actual string may be free()ed by subsequent libcurl calls so
+       The actual string may be FREE()ed by subsequent libcurl calls so
        it must be copied to a safer area before the next libcurl call.
        Callers must never free it themselves. */
     *param_charp = data->state.most_recent_ftp_entrypath;

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -155,7 +155,7 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
   if(query)
     gopherpath = aprintf("%s?%s", path, query);
   else
-    gopherpath = strdup(path);
+    gopherpath = STRDUP(path);
 
   if(!gopherpath)
     return CURLE_OUT_OF_MEMORY;
@@ -164,7 +164,7 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
   if(strlen(gopherpath) <= 2) {
     sel = (char *)CURL_UNCONST("");
     len = strlen(sel);
-    free(gopherpath);
+    FREE(gopherpath);
   }
   else {
     char *newp;
@@ -175,7 +175,7 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
 
     /* ... and finally unescape */
     result = Curl_urldecode(newp, 0, &sel, &len, REJECT_ZERO);
-    free(gopherpath);
+    FREE(gopherpath);
     if(result)
       return result;
     sel_org = sel;
@@ -228,7 +228,7 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
     }
   }
 
-  free(sel_org);
+  FREE(sel_org);
 
   if(!result)
     result = Curl_xfer_send(data, "\r\n", 2, FALSE, &amount);

--- a/lib/hash.c
+++ b/lib/hash.c
@@ -115,7 +115,7 @@ hash_elem_create(const void *key, size_t key_len, const void *p,
   struct Curl_hash_element *he;
 
   /* allocate the struct plus memory after it to store the key */
-  he = malloc(sizeof(struct Curl_hash_element) + key_len);
+  he = MALLOC(sizeof(struct Curl_hash_element) + key_len);
   if(he) {
     he->next = NULL;
     /* copy the key */
@@ -145,7 +145,7 @@ static void hash_elem_destroy(struct Curl_hash *h,
                               struct Curl_hash_element *he)
 {
   hash_elem_clear_ptr(h, he);
-  free(he);
+  FREE(he);
 }
 
 static void hash_elem_unlink(struct Curl_hash *h,
@@ -177,7 +177,7 @@ void *Curl_hash_add2(struct Curl_hash *h, void *key, size_t key_len, void *p,
   DEBUGASSERT(h->slots);
   DEBUGASSERT(h->init == HASHINIT);
   if(!h->table) {
-    h->table = calloc(h->slots, sizeof(struct Curl_hash_element *));
+    h->table = CALLOC(h->slots, sizeof(struct Curl_hash_element *));
     if(!h->table)
       return NULL; /* OOM */
   }

--- a/lib/hash_offt.c
+++ b/lib/hash_offt.c
@@ -70,7 +70,7 @@ hash_offt_mk_entry(curl_off_t id, void *value)
   struct Curl_hash_offt_entry *e;
 
   /* allocate the struct for the hash entry */
-  e = malloc(sizeof(*e));
+  e = MALLOC(sizeof(*e));
   if(e) {
     e->id = id;
     e->next = NULL;
@@ -95,7 +95,7 @@ static void hash_offt_entry_destroy(struct Curl_hash_offt *h,
                                     struct Curl_hash_offt_entry *e)
 {
   hash_offt_entry_clear(h, e);
-  free(e);
+  FREE(e);
 }
 
 static void hash_offt_entry_unlink(struct Curl_hash_offt *h,
@@ -126,7 +126,7 @@ bool Curl_hash_offt_set(struct Curl_hash_offt *h, curl_off_t id, void *value)
   DEBUGASSERT(h->slots);
   DEBUGASSERT(h->init == CURL_HASHOFFTINIT);
   if(!h->table) {
-    h->table = calloc(h->slots, sizeof(*he));
+    h->table = CALLOC(h->slots, sizeof(*he));
     if(!h->table)
       return FALSE; /* OOM */
   }

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -314,7 +314,7 @@ CURLcode Curl_headers_push(struct Curl_easy *data, const char *header,
     }
   }
 
-  hs = calloc(1, sizeof(*hs) + hlen);
+  hs = CALLOC(1, sizeof(*hs) + hlen);
   if(!hs)
     return CURLE_OUT_OF_MEMORY;
   memcpy(hs->buffer, header, hlen);
@@ -332,7 +332,7 @@ CURLcode Curl_headers_push(struct Curl_easy *data, const char *header,
     data->state.prevhead = hs;
   }
   else
-    free(hs);
+    FREE(hs);
   return result;
 }
 
@@ -412,7 +412,7 @@ CURLcode Curl_headers_cleanup(struct Curl_easy *data)
   for(e = Curl_llist_head(&data->state.httphdrs); e; e = n) {
     struct Curl_header_store *hs = Curl_node_elem(e);
     n = Curl_node_next(e);
-    free(hs);
+    FREE(hs);
   }
   headers_reset(data);
   return CURLE_OK;

--- a/lib/hmac.c
+++ b/lib/hmac.c
@@ -62,7 +62,7 @@ Curl_HMAC_init(const struct HMAC_params *hashparams,
 
   /* Create HMAC context. */
   i = sizeof(*ctxt) + 2 * hashparams->ctxtsize + hashparams->resultlen;
-  ctxt = malloc(i);
+  ctxt = MALLOC(i);
 
   if(!ctxt)
     return ctxt;
@@ -124,7 +124,7 @@ int Curl_HMAC_final(struct HMAC_context *ctxt, unsigned char *output)
   hashparams->hfinal(output, ctxt->hashctxt1);
   hashparams->hupdate(ctxt->hashctxt2, output, hashparams->resultlen);
   hashparams->hfinal(output, ctxt->hashctxt2);
-  free(ctxt);
+  FREE(ctxt);
   return 0;
 }
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -415,7 +415,7 @@ UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
     struct Curl_addrinfo **nodes;
     infof(data, "Shuffling %i addresses", num_addrs);
 
-    nodes = malloc(num_addrs*sizeof(*nodes));
+    nodes = MALLOC(num_addrs*sizeof(*nodes));
     if(nodes) {
       int i;
       unsigned int *rnd;
@@ -427,7 +427,7 @@ UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
         nodes[i] = nodes[i-1]->ai_next;
       }
 
-      rnd = malloc(rnd_size);
+      rnd = MALLOC(rnd_size);
       if(rnd) {
         /* Fisher-Yates shuffle */
         if(Curl_rand(data, (unsigned char *)rnd, rnd_size) == CURLE_OK) {
@@ -446,11 +446,11 @@ UNITTEST CURLcode Curl_shuffle_addr(struct Curl_easy *data,
           nodes[num_addrs-1]->ai_next = NULL;
           *addr = nodes[0];
         }
-        free(rnd);
+        FREE(rnd);
       }
       else
         result = CURLE_OUT_OF_MEMORY;
-      free(nodes);
+      FREE(nodes);
     }
     else
       result = CURLE_OUT_OF_MEMORY;
@@ -493,7 +493,7 @@ Curl_cache_addr(struct Curl_easy *data,
     hostlen = strlen(hostname);
 
   /* Create a new cache entry */
-  dns = calloc(1, sizeof(struct Curl_dns_entry) + hostlen);
+  dns = CALLOC(1, sizeof(struct Curl_dns_entry) + hostlen);
   if(!dns) {
     return NULL;
   }
@@ -519,7 +519,7 @@ Curl_cache_addr(struct Curl_easy *data,
   dns2 = Curl_hash_add(data->dns.hostcache, entry_id, entry_len + 1,
                        (void *)dns);
   if(!dns2) {
-    free(dns);
+    FREE(dns);
     return NULL;
   }
 
@@ -538,7 +538,7 @@ static struct Curl_addrinfo *get_localhost6(int port, const char *name)
   struct sockaddr_in6 sa6;
   unsigned char ipv6[16];
   unsigned short port16 = (unsigned short)(port & 0xffff);
-  ca = calloc(1, sizeof(struct Curl_addrinfo) + ss_size + hostlen + 1);
+  ca = CALLOC(1, sizeof(struct Curl_addrinfo) + ss_size + hostlen + 1);
   if(!ca)
     return NULL;
 
@@ -587,7 +587,7 @@ static struct Curl_addrinfo *get_localhost(int port, const char *name)
     return NULL;
   memcpy(&sa.sin_addr, &ipv4, sizeof(ipv4));
 
-  ca = calloc(1, sizeof(struct Curl_addrinfo) + ss_size + hostlen + 1);
+  ca = CALLOC(1, sizeof(struct Curl_addrinfo) + ss_size + hostlen + 1);
   if(!ca)
     return NULL;
   ca->ai_flags     = 0;
@@ -628,7 +628,7 @@ bool Curl_ipv6works(struct Curl_easy *data)
   else {
     int ipv6_works = -1;
     /* probe to see if we have a working IPv6 stack */
-    curl_socket_t s = socket(PF_INET6, SOCK_DGRAM, 0);
+    curl_socket_t s = SOCKET(PF_INET6, SOCK_DGRAM, 0);
     if(s == CURL_SOCKET_BAD)
       /* an IPv6 address was requested but we cannot get/use one */
       ipv6_works = 0;
@@ -1085,10 +1085,10 @@ static void hostcache_unlink_entry(void *entry)
 #ifdef USE_HTTPSRR
     if(dns->hinfo) {
       Curl_httpsrr_cleanup(dns->hinfo);
-      free(dns->hinfo);
+      FREE(dns->hinfo);
     }
 #endif
-    free(dns);
+    FREE(dns);
   }
 }
 

--- a/lib/hostip4.c
+++ b/lib/hostip4.c
@@ -154,7 +154,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
    */
   int h_errnop;
 
-  buf = calloc(1, CURL_HOSTENT_SIZE);
+  buf = CALLOC(1, CURL_HOSTENT_SIZE);
   if(!buf)
     return NULL; /* major failure */
   /*
@@ -268,8 +268,8 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
      * Since we do not know how big buffer this particular lookup required,
      * we cannot realloc down the huge alloc without doing closer analysis of
      * the returned data. Thus, we always use CURL_HOSTENT_SIZE for every
-     * name lookup. Fixing this would require an extra malloc() and then
-     * calling Curl_addrinfo_copy() that subsequent realloc()s down the new
+     * name lookup. Fixing this would require an extra MALLOC() and then
+     * calling Curl_addrinfo_copy() that subsequent REALLOC()s down the new
      * memory area to the actually used amount.
      */
   }
@@ -277,7 +277,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
 #endif /* HAVE_...BYNAME_R_5 || HAVE_...BYNAME_R_6 || HAVE_...BYNAME_R_3 */
   {
     h = NULL; /* set return code to NULL */
-    free(buf);
+    FREE(buf);
   }
 #else /* (HAVE_GETADDRINFO && HAVE_GETADDRINFO_THREADSAFE) ||
           HAVE_GETHOSTBYNAME_R */
@@ -295,7 +295,7 @@ struct Curl_addrinfo *Curl_ipv4_resolve_r(const char *hostname,
     ai = Curl_he2ai(h, port);
 
     if(buf) /* used a *_r() function */
-      free(buf);
+      FREE(buf);
   }
 #endif
 

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -74,7 +74,7 @@ static time_t hsts_debugtime(void *unused)
 
 struct hsts *Curl_hsts_init(void)
 {
-  struct hsts *h = calloc(1, sizeof(struct hsts));
+  struct hsts *h = CALLOC(1, sizeof(struct hsts));
   if(h) {
     Curl_llist_init(&h->list, NULL);
   }
@@ -83,8 +83,8 @@ struct hsts *Curl_hsts_init(void)
 
 static void hsts_free(struct stsentry *e)
 {
-  free(CURL_UNCONST(e->host));
-  free(e);
+  FREE(CURL_UNCONST(e->host));
+  FREE(e);
 }
 
 void Curl_hsts_cleanup(struct hsts **hp)
@@ -98,8 +98,8 @@ void Curl_hsts_cleanup(struct hsts **hp)
       n = Curl_node_next(e);
       hsts_free(sts);
     }
-    free(h->filename);
-    free(h);
+    FREE(h->filename);
+    FREE(h);
     *hp = NULL;
   }
 }
@@ -118,13 +118,13 @@ static CURLcode hsts_create(struct hsts *h,
     --hlen;
   if(hlen) {
     char *duphost;
-    struct stsentry *sts = calloc(1, sizeof(struct stsentry));
+    struct stsentry *sts = CALLOC(1, sizeof(struct stsentry));
     if(!sts)
       return CURLE_OUT_OF_MEMORY;
 
     duphost = Curl_memdup0(hostname, hlen);
     if(!duphost) {
-      free(sts);
+      FREE(sts);
       return CURLE_OUT_OF_MEMORY;
     }
 
@@ -380,14 +380,14 @@ CURLcode Curl_hsts_save(struct Curl_easy *data, struct hsts *h,
       if(result)
         break;
     }
-    fclose(out);
+    FCLOSE(out);
     if(!result && tempstore && Curl_rename(tempstore, file))
       result = CURLE_WRITE_ERROR;
 
     if(result && tempstore)
       unlink(tempstore);
   }
-  free(tempstore);
+  FREE(tempstore);
 skipsave:
   if(data->set.hsts_write) {
     /* if there is a write callback */
@@ -518,12 +518,12 @@ static CURLcode hsts_load(struct hsts *h, const char *file)
 
   /* we need a private copy of the filename so that the hsts cache file
      name survives an easy handle reset */
-  free(h->filename);
-  h->filename = strdup(file);
+  FREE(h->filename);
+  h->filename = STRDUP(file);
   if(!h->filename)
     return CURLE_OUT_OF_MEMORY;
 
-  fp = fopen(file, FOPEN_READTEXT);
+  fp = FOPEN(file, FOPEN_READTEXT);
   if(fp) {
     struct dynbuf buf;
     Curl_dyn_init(&buf, MAX_HSTS_LINE);
@@ -541,7 +541,7 @@ static CURLcode hsts_load(struct hsts *h, const char *file)
       hsts_add(h, lineptr);
     }
     Curl_dyn_free(&buf); /* free the line buffer */
-    fclose(fp);
+    FCLOSE(fp);
   }
   return result;
 }

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -179,7 +179,7 @@ static void cf_h2_ctx_free(struct cf_h2_ctx *ctx)
     Curl_hash_offt_destroy(&ctx->streams);
     memset(ctx, 0, sizeof(*ctx));
   }
-  free(ctx);
+  FREE(ctx);
 }
 
 static void cf_h2_ctx_close(struct cf_h2_ctx *ctx)
@@ -229,7 +229,7 @@ static struct h2_stream_ctx *h2_stream_ctx_create(struct cf_h2_ctx *ctx)
   struct h2_stream_ctx *stream;
 
   (void)ctx;
-  stream = calloc(1, sizeof(*stream));
+  stream = CALLOC(1, sizeof(*stream));
   if(!stream)
     return NULL;
 
@@ -252,7 +252,7 @@ static void free_push_headers(struct h2_stream_ctx *stream)
 {
   size_t i;
   for(i = 0; i < stream->push_headers_used; i++)
-    free(stream->push_headers[i]);
+    FREE(stream->push_headers[i]);
   Curl_safefree(stream->push_headers);
   stream->push_headers_used = 0;
 }
@@ -263,7 +263,7 @@ static void h2_stream_ctx_free(struct h2_stream_ctx *stream)
   Curl_h1_req_parse_free(&stream->h1);
   Curl_dynhds_free(&stream->resp_trailers);
   free_push_headers(stream);
-  free(stream);
+  FREE(stream);
 }
 
 static void h2_stream_hash_free(curl_off_t id, void *stream)
@@ -931,7 +931,7 @@ fail:
     return rc;
 
   if(data->state.url_alloc)
-    free(data->state.url);
+    FREE(data->state.url);
   data->state.url_alloc = TRUE;
   data->state.url = url;
   return 0;
@@ -1617,14 +1617,14 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
                                         stream_id, NGHTTP2_PROTOCOL_ERROR);
         rc = NGHTTP2_ERR_CALLBACK_FAILURE;
       }
-      free(check);
+      FREE(check);
       if(rc)
         return rc;
     }
 
     if(!stream->push_headers) {
       stream->push_headers_alloc = 10;
-      stream->push_headers = malloc(stream->push_headers_alloc *
+      stream->push_headers = MALLOC(stream->push_headers_alloc *
                                     sizeof(char *));
       if(!stream->push_headers)
         return NGHTTP2_ERR_CALLBACK_FAILURE;
@@ -1640,7 +1640,7 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
         return NGHTTP2_ERR_CALLBACK_FAILURE;
       }
       stream->push_headers_alloc *= 2;
-      headp = realloc(stream->push_headers,
+      headp = REALLOC(stream->push_headers,
                       stream->push_headers_alloc * sizeof(char *));
       if(!headp) {
         free_push_headers(stream);
@@ -1830,7 +1830,7 @@ CURLcode Curl_http2_request_upgrade(struct dynbuf *req,
                          "Upgrade: %s\r\n"
                          "HTTP2-Settings: %s\r\n",
                          NGHTTP2_CLEARTEXT_PROTO_VERSION_ID, base64);
-  free(base64);
+  FREE(base64);
 
   k->upgr101 = UPGR101_H2;
   data->conn->bits.asks_multiplex = TRUE;
@@ -2834,7 +2834,7 @@ static CURLcode http2_cfilter_add(struct Curl_cfilter **pcf,
   CURLcode result = CURLE_OUT_OF_MEMORY;
 
   DEBUGASSERT(data->conn);
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx)
     goto out;
   cf_h2_ctx_init(ctx, via_h1_upgrade);
@@ -2862,7 +2862,7 @@ static CURLcode http2_cfilter_insert_after(struct Curl_cfilter *cf,
   CURLcode result = CURLE_OUT_OF_MEMORY;
 
   (void)data;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx)
     goto out;
   cf_h2_ctx_init(ctx, via_h1_upgrade);

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -190,12 +190,12 @@ static CURLcode merge_duplicate_headers(struct curl_slist *head)
       if(result)
         return result;
 
-      free(curr->data);
+      FREE(curr->data);
       curr->data = Curl_dyn_ptr(&buf);
 
       curr->next = next->next;
-      free(next->data);
-      free(next);
+      FREE(next->data);
+      FREE(next);
     }
     else {
       curr = curr->next;
@@ -249,7 +249,7 @@ static CURLcode make_headers(struct Curl_easy *data,
     if(fullhost)
       head = Curl_slist_append_nodup(NULL, fullhost);
     if(!head) {
-      free(fullhost);
+      FREE(fullhost);
       goto fail;
     }
   }
@@ -288,13 +288,13 @@ static CURLcode make_headers(struct Curl_easy *data,
       ;
     if(!*ptr && ptr != sep + 1) /* a value of whitespace only */
       continue;
-    dupdata = strdup(l->data);
+    dupdata = STRDUP(l->data);
     if(!dupdata)
       goto fail;
     dupdata[sep - l->data] = ':';
     tmp_head = Curl_slist_append_nodup(head, dupdata);
     if(!tmp_head) {
-      free(dupdata);
+      FREE(dupdata);
       goto fail;
     }
     head = tmp_head;
@@ -900,7 +900,7 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data)
   Curl_strntoupper(&auth_headers[sizeof("Authorization: ") - 1],
                    Curl_str(&provider0), Curl_strlen(&provider0));
 
-  free(data->state.aptr.userpwd);
+  FREE(data->state.aptr.userpwd);
   data->state.aptr.userpwd = auth_headers;
   data->state.authhost.done = TRUE;
   result = CURLE_OK;
@@ -910,12 +910,12 @@ fail:
   Curl_dyn_free(&canonical_path);
   Curl_dyn_free(&canonical_headers);
   Curl_dyn_free(&signed_headers);
-  free(canonical_request);
-  free(request_type);
-  free(credential_scope);
-  free(str_to_sign);
-  free(secret);
-  free(date_header);
+  FREE(canonical_request);
+  FREE(request_type);
+  FREE(credential_scope);
+  FREE(str_to_sign);
+  FREE(secret);
+  FREE(date_header);
   return result;
 }
 

--- a/lib/http_digest.c
+++ b/lib/http_digest.c
@@ -153,21 +153,21 @@ CURLcode Curl_output_digest(struct Curl_easy *data,
     }
   }
   if(!tmp)
-    path = (unsigned char *) strdup((const char *) uripath);
+    path = (unsigned char *) STRDUP((const char *) uripath);
 
   if(!path)
     return CURLE_OUT_OF_MEMORY;
 
   result = Curl_auth_create_digest_http_message(data, userp, passwdp, request,
                                                 path, digest, &response, &len);
-  free(path);
+  FREE(path);
   if(result)
     return result;
 
   *allocuserpwd = aprintf("%sAuthorization: Digest %s\r\n",
                           proxy ? "Proxy-" : "",
                           response);
-  free(response);
+  FREE(response);
   if(!*allocuserpwd)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -205,16 +205,16 @@ CURLcode Curl_output_negotiate(struct Curl_easy *data,
 
     if(proxy) {
 #ifndef CURL_DISABLE_PROXY
-      free(data->state.aptr.proxyuserpwd);
+      FREE(data->state.aptr.proxyuserpwd);
       data->state.aptr.proxyuserpwd = userp;
 #endif
     }
     else {
-      free(data->state.aptr.userpwd);
+      FREE(data->state.aptr.userpwd);
       data->state.aptr.userpwd = userp;
     }
 
-    free(base64);
+    FREE(base64);
 
     if(!userp) {
       return CURLE_OUT_OF_MEMORY;

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -208,11 +208,11 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
       result = Curl_base64_encode((const char *) Curl_bufref_ptr(&ntlmmsg),
                                   Curl_bufref_len(&ntlmmsg), &base64, &len);
       if(!result) {
-        free(*allocuserpwd);
+        FREE(*allocuserpwd);
         *allocuserpwd = aprintf("%sAuthorization: NTLM %s\r\n",
                                 proxy ? "Proxy-" : "",
                                 base64);
-        free(base64);
+        FREE(base64);
         if(!*allocuserpwd)
           result = CURLE_OUT_OF_MEMORY;
       }
@@ -227,11 +227,11 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
       result = Curl_base64_encode((const char *) Curl_bufref_ptr(&ntlmmsg),
                                   Curl_bufref_len(&ntlmmsg), &base64, &len);
       if(!result) {
-        free(*allocuserpwd);
+        FREE(*allocuserpwd);
         *allocuserpwd = aprintf("%sAuthorization: NTLM %s\r\n",
                                 proxy ? "Proxy-" : "",
                                 base64);
-        free(base64);
+        FREE(base64);
         if(!*allocuserpwd)
           result = CURLE_OUT_OF_MEMORY;
         else {

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -299,7 +299,7 @@ out:
     Curl_http_req_free(req);
     req = NULL;
   }
-  free(authority);
+  FREE(authority);
   *preq = req;
   return result;
 }
@@ -407,7 +407,7 @@ static void http_proxy_cf_destroy(struct Curl_cfilter *cf,
 
   (void)data;
   CURL_TRC_CF(data, cf, "destroy");
-  free(ctx);
+  FREE(ctx);
 }
 
 static void http_proxy_cf_close(struct Curl_cfilter *cf,
@@ -462,7 +462,7 @@ CURLcode Curl_cf_http_proxy_insert_after(struct Curl_cfilter *cf_at,
   CURLcode result;
 
   (void)data;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
@@ -474,7 +474,7 @@ CURLcode Curl_cf_http_proxy_insert_after(struct Curl_cfilter *cf_at,
   Curl_conn_cf_insert_after(cf_at, cf);
 
 out:
-  free(ctx);
+  FREE(ctx);
   return result;
 }
 

--- a/lib/httpsrr.c
+++ b/lib/httpsrr.c
@@ -205,7 +205,7 @@ void Curl_dnsrec_done_cb(void *arg, ares_status_t status,
        is in ServiceMode */
     target = ares_dns_rr_get_str(rr, ARES_RR_HTTPS_TARGET);
     if(target && target[0]) {
-      res->hinfo.target = strdup(target);
+      res->hinfo.target = STRDUP(target);
       if(!res->hinfo.target) {
         result = CURLE_OUT_OF_MEMORY;
         goto out;

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -109,7 +109,7 @@ static CURLcode mac_idn_to_ascii(const char *in, char **out)
                                      buffer, sizeof(buffer) - 1, &info, &err);
         uidna_close(idna);
         if(!U_FAILURE(err) && !info.errors) {
-          *out = strdup(buffer);
+          *out = STRDUP(buffer);
           if(*out)
             return CURLE_OK;
           else
@@ -137,7 +137,7 @@ static CURLcode mac_ascii_to_idn(const char *in, char **out)
                                     sizeof(buffer) - 1, &info, &err);
       uidna_close(idna);
       if(!U_FAILURE(err)) {
-        *out = strdup(buffer);
+        *out = STRDUP(buffer);
         if(*out)
           return CURLE_OK;
         else
@@ -180,7 +180,7 @@ static CURLcode win32_idn_to_ascii(const char *in, char **out)
     if(chars) {
       char *mstr = curlx_convert_wchar_to_UTF8(punycode);
       if(mstr) {
-        *out = strdup(mstr);
+        *out = STRDUP(mstr);
         curlx_unicodefree(mstr);
         if(!*out)
           return CURLE_OUT_OF_MEMORY;
@@ -210,7 +210,7 @@ static CURLcode win32_ascii_to_idn(const char *in, char **output)
       /* 'chars' is "the number of characters retrieved" */
       char *mstr = curlx_convert_wchar_to_UTF8(idn);
       if(mstr) {
-        out = strdup(mstr);
+        out = STRDUP(mstr);
         curlx_unicodefree(mstr);
         if(!out)
           return CURLE_OUT_OF_MEMORY;
@@ -315,7 +315,7 @@ CURLcode Curl_idn_decode(const char *input, char **output)
   CURLcode result = idn_decode(input, &d);
 #ifdef USE_LIBIDN2
   if(!result) {
-    char *c = strdup(d);
+    char *c = STRDUP(d);
     idn2_free(d);
     if(c)
       d = c;
@@ -334,7 +334,7 @@ CURLcode Curl_idn_encode(const char *puny, char **output)
   CURLcode result = idn_encode(puny, &d);
 #ifdef USE_LIBIDN2
   if(!result) {
-    char *c = strdup(d);
+    char *c = STRDUP(d);
     idn2_free(d);
     if(c)
       d = c;

--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -209,7 +209,7 @@ if2ip_result_t Curl_if2ip(int af,
   if(len >= sizeof(req.ifr_name))
     return IF2IP_NOT_FOUND;
 
-  dummy = socket(AF_INET, SOCK_STREAM, 0);
+  dummy = SOCKET(AF_INET, SOCK_STREAM, 0);
   if(CURL_SOCKET_BAD == dummy)
     return IF2IP_NOT_FOUND;
 

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -527,8 +527,8 @@ static CURLcode imap_perform_login(struct Curl_easy *data,
   result = imap_sendf(data, "LOGIN %s %s", user ? user : "",
                       passwd ? passwd : "");
 
-  free(user);
-  free(passwd);
+  FREE(user);
+  FREE(passwd);
 
   if(!result)
     imap_state(data, IMAP_LOGIN);
@@ -656,14 +656,14 @@ static CURLcode imap_perform_list(struct Curl_easy *data)
   else {
     /* Make sure the mailbox is in the correct atom format if necessary */
     char *mailbox = imap->mailbox ? imap_atom(imap->mailbox, TRUE)
-                                  : strdup("");
+                                  : STRDUP("");
     if(!mailbox)
       return CURLE_OUT_OF_MEMORY;
 
     /* Send the LIST command */
     result = imap_sendf(data, "LIST \"%s\" *", mailbox);
 
-    free(mailbox);
+    FREE(mailbox);
   }
 
   if(!result)
@@ -704,7 +704,7 @@ static CURLcode imap_perform_select(struct Curl_easy *data)
   /* Send the SELECT command */
   result = imap_sendf(data, "SELECT %s", mailbox);
 
-  free(mailbox);
+  FREE(mailbox);
 
   if(!result)
     imap_state(data, IMAP_SELECT);
@@ -851,7 +851,7 @@ static CURLcode imap_perform_append(struct Curl_easy *data)
 
 cleanup:
   Curl_dyn_free(&flags);
-  free(mailbox);
+  FREE(mailbox);
 
   if(!result)
     imap_state(data, IMAP_APPEND);
@@ -1134,7 +1134,7 @@ static CURLcode imap_state_select_resp(struct Curl_easy *data, int imapcode,
         Curl_dyn_init(&uid, 20);
         if(Curl_dyn_addn(&uid, p, len))
           return CURLE_OUT_OF_MEMORY;
-        free(imapc->mailbox_uidvalidity);
+        FREE(imapc->mailbox_uidvalidity);
         imapc->mailbox_uidvalidity = Curl_dyn_ptr(&uid);
       }
     }
@@ -1149,7 +1149,7 @@ static CURLcode imap_state_select_resp(struct Curl_easy *data, int imapcode,
     else {
       /* Note the currently opened mailbox on this connection */
       DEBUGASSERT(!imapc->mailbox);
-      imapc->mailbox = strdup(imap->mailbox);
+      imapc->mailbox = STRDUP(imap->mailbox);
       if(!imapc->mailbox)
         return CURLE_OUT_OF_MEMORY;
 
@@ -1458,7 +1458,7 @@ static CURLcode imap_init(struct Curl_easy *data)
   CURLcode result = CURLE_OK;
   struct IMAP *imap;
 
-  imap = data->req.p.imap = calloc(1, sizeof(struct IMAP));
+  imap = data->req.p.imap = CALLOC(1, sizeof(struct IMAP));
   if(!imap)
     result = CURLE_OUT_OF_MEMORY;
 
@@ -1859,7 +1859,7 @@ static char *imap_atom(const char *str, bool escape_only)
   nclean = strcspn(str, "() {%*]\\\"");
   if(len == nclean)
     /* nothing to escape, return a strdup */
-    return strdup(str);
+    return STRDUP(str);
 
   Curl_dyn_init(&line, 2000);
 
@@ -2039,7 +2039,7 @@ static CURLcode imap_parse_url_path(struct Curl_easy *data)
     result = Curl_urldecode(begin, ptr - begin, &value, &valuelen,
                             REJECT_CTRL);
     if(result) {
-      free(name);
+      FREE(name);
       return result;
     }
 
@@ -2085,14 +2085,14 @@ static CURLcode imap_parse_url_path(struct Curl_easy *data)
       value = NULL;
     }
     else {
-      free(name);
-      free(value);
+      FREE(name);
+      FREE(value);
 
       return CURLE_URL_MALFORMAT;
     }
 
-    free(name);
-    free(value);
+    FREE(name);
+    FREE(value);
   }
 
   /* Does the URL contain a query parameter? Only valid when we have a mailbox
@@ -2134,7 +2134,7 @@ static CURLcode imap_parse_custom_request(struct Curl_easy *data)
         params++;
 
       if(*params) {
-        imap->custom_params = strdup(params);
+        imap->custom_params = STRDUP(params);
         imap->custom[params - imap->custom] = '\0';
 
         if(!imap->custom_params)

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -185,7 +185,7 @@ krb5_encode(void *app_data, const void *from, int length, int level, void **to)
 
   /* malloc a new buffer, in case gss_release_buffer does not work as
      expected */
-  *to = malloc(enc.length);
+  *to = MALLOC(enc.length);
   if(!*to)
     return -1;
   memcpy(*to, enc.value, enc.length);
@@ -257,7 +257,7 @@ krb5_auth(void *app_data, struct Curl_easy *data, struct connectdata *conn)
     input_buffer.length = strlen(stringp);
     maj = gss_import_name(&min, &input_buffer, GSS_C_NT_HOSTBASED_SERVICE,
                           &gssname);
-    free(stringp);
+    FREE(stringp);
     if(maj != GSS_S_COMPLETE) {
       gss_release_name(&min, &gssname);
       if(service == srv_host) {
@@ -291,7 +291,7 @@ krb5_auth(void *app_data, struct Curl_easy *data, struct connectdata *conn)
                                       NULL);
 
       if(gssresp) {
-        free(_gssresp.value);
+        FREE(_gssresp.value);
         gssresp = NULL;
       }
 
@@ -318,8 +318,8 @@ krb5_auth(void *app_data, struct Curl_easy *data, struct connectdata *conn)
         else
           result = CURLE_OUT_OF_MEMORY;
 
-        free(p);
-        free(cmd);
+        FREE(p);
+        FREE(cmd);
 
         if(result) {
           ret = -2;
@@ -366,7 +366,7 @@ krb5_auth(void *app_data, struct Curl_easy *data, struct connectdata *conn)
     gss_release_buffer(&min, &output_buffer);
 
     if(gssresp)
-      free(_gssresp.value);
+      FREE(_gssresp.value);
 
     if(ret == AUTH_OK || service == srv_host)
       break;
@@ -648,7 +648,7 @@ static void do_sec_send(struct Curl_easy *data, struct connectdata *conn,
     error = Curl_base64_encode(buffer, curlx_sitouz(bytes),
                                &cmd_buffer, &cmd_size);
     if(error) {
-      free(buffer);
+      FREE(buffer);
       return; /* error */
     }
     if(cmd_size > 0) {
@@ -663,7 +663,7 @@ static void do_sec_send(struct Curl_easy *data, struct connectdata *conn,
       socket_write(data, sockindex, "\r\n", 2);
       infof(data, "Send: %s%s", prot_level == PROT_PRIVATE ? enc : mic,
             cmd_buffer);
-      free(cmd_buffer);
+      FREE(cmd_buffer);
     }
   }
   else {
@@ -671,7 +671,7 @@ static void do_sec_send(struct Curl_easy *data, struct connectdata *conn,
     socket_write(data, sockindex, &htonl_bytes, sizeof(htonl_bytes));
     socket_write(data, sockindex, buffer, curlx_sitouz(bytes));
   }
-  free(buffer);
+  FREE(buffer);
 }
 
 static ssize_t sec_write(struct Curl_easy *data, struct connectdata *conn,
@@ -728,7 +728,7 @@ int Curl_sec_read_msg(struct Curl_easy *data, struct connectdata *conn,
     return -1;
 
   if(decoded_sz > (size_t)INT_MAX) {
-    free(buf);
+    FREE(buf);
     return -1;
   }
   decoded_len = curlx_uztosi(decoded_sz);
@@ -736,7 +736,7 @@ int Curl_sec_read_msg(struct Curl_easy *data, struct connectdata *conn,
   decoded_len = conn->mech->decode(conn->app_data, buf, decoded_len,
                                    (int)level, conn);
   if(decoded_len <= 0) {
-    free(buf);
+    FREE(buf);
     return -1;
   }
 
@@ -756,7 +756,7 @@ int Curl_sec_read_msg(struct Curl_easy *data, struct connectdata *conn,
   if(buf[decoded_len - 1] == '\n')
     buf[decoded_len - 1] = '\0';
   strcpy(buffer, buf);
-  free(buf);
+  FREE(buf);
   return ret_code;
 }
 
@@ -840,7 +840,7 @@ static CURLcode choose_mech(struct Curl_easy *data, struct connectdata *conn)
   void *tmp_allocation;
   const struct Curl_sec_client_mech *mech = &Curl_krb5_client_mech;
 
-  tmp_allocation = realloc(conn->app_data, mech->size);
+  tmp_allocation = REALLOC(conn->app_data, mech->size);
   if(!tmp_allocation) {
     failf(data, "Failed realloc of size %zu", mech->size);
     mech = NULL;

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -644,7 +644,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
             if(val_b64_sz > 0) {
               result = Curl_client_write(data, CLIENTWRITE_BODY, val_b64,
                                          val_b64_sz);
-              free(val_b64);
+              FREE(val_b64);
               if(result) {
                 ldap_value_free_len(vals);
                 FREE_ON_WINLDAP(attr);
@@ -809,15 +809,15 @@ static int _ldap_url_parse2(struct Curl_easy *data,
   ludp->lud_host  = conn->host.name;
 
   /* Duplicate the path */
-  p = path = strdup(data->state.up.path + 1);
+  p = path = STRDUP(data->state.up.path + 1);
   if(!path)
     return LDAP_NO_MEMORY;
 
   /* Duplicate the query if present */
   if(data->state.up.query) {
-    q = query = strdup(data->state.up.query);
+    q = query = STRDUP(data->state.up.query);
     if(!query) {
-      free(path);
+      FREE(path);
       return LDAP_NO_MEMORY;
     }
   }
@@ -843,7 +843,7 @@ static int _ldap_url_parse2(struct Curl_easy *data,
     ludp->lud_dn = curlx_convert_UTF8_to_tchar(unescaped);
 
     /* Free the unescaped string as we are done with it */
-    free(unescaped);
+    FREE(unescaped);
 
     if(!ludp->lud_dn) {
       rc = LDAP_NO_MEMORY;
@@ -870,9 +870,9 @@ static int _ldap_url_parse2(struct Curl_easy *data,
 
     /* Allocate our array (+1 for the NULL entry) */
 #if defined(USE_WIN32_LDAP)
-    ludp->lud_attrs = calloc(count + 1, sizeof(TCHAR *));
+    ludp->lud_attrs = CALLOC(count + 1, sizeof(TCHAR *));
 #else
-    ludp->lud_attrs = calloc(count + 1, sizeof(char *));
+    ludp->lud_attrs = CALLOC(count + 1, sizeof(char *));
 #endif
     if(!ludp->lud_attrs) {
       rc = LDAP_NO_MEMORY;
@@ -902,7 +902,7 @@ static int _ldap_url_parse2(struct Curl_easy *data,
       ludp->lud_attrs[i] = curlx_convert_UTF8_to_tchar(unescaped);
 
       /* Free the unescaped string as we are done with it */
-      free(unescaped);
+      FREE(unescaped);
 
       if(!ludp->lud_attrs[i]) {
         rc = LDAP_NO_MEMORY;
@@ -966,7 +966,7 @@ static int _ldap_url_parse2(struct Curl_easy *data,
     ludp->lud_filter = curlx_convert_UTF8_to_tchar(unescaped);
 
     /* Free the unescaped string as we are done with it */
-    free(unescaped);
+    FREE(unescaped);
 
     if(!ludp->lud_filter) {
       rc = LDAP_NO_MEMORY;
@@ -986,8 +986,8 @@ static int _ldap_url_parse2(struct Curl_easy *data,
   }
 
 quit:
-  free(path);
-  free(query);
+  FREE(path);
+  FREE(query);
 
   return rc;
 }
@@ -996,7 +996,7 @@ static int _ldap_url_parse(struct Curl_easy *data,
                            const struct connectdata *conn,
                            LDAPURLDesc **ludpp)
 {
-  LDAPURLDesc *ludp = calloc(1, sizeof(*ludp));
+  LDAPURLDesc *ludp = CALLOC(1, sizeof(*ludp));
   int rc;
 
   *ludpp = NULL;
@@ -1021,8 +1021,8 @@ static void _ldap_free_urldesc(LDAPURLDesc *ludp)
   curlx_unicodefree(ludp->lud_dn);
   curlx_unicodefree(ludp->lud_filter);
 #else
-  free(ludp->lud_dn);
-  free(ludp->lud_filter);
+  FREE(ludp->lud_dn);
+  FREE(ludp->lud_filter);
 #endif
 
   if(ludp->lud_attrs) {
@@ -1031,13 +1031,13 @@ static void _ldap_free_urldesc(LDAPURLDesc *ludp)
 #if defined(USE_WIN32_LDAP)
       curlx_unicodefree(ludp->lud_attrs[i]);
 #else
-      free(ludp->lud_attrs[i]);
+      FREE(ludp->lud_attrs[i]);
 #endif
     }
-    free(ludp->lud_attrs);
+    FREE(ludp->lud_attrs);
   }
 
-  free(ludp);
+  FREE(ludp);
 }
 #endif  /* !HAVE_LDAP_URL_PARSE */
 

--- a/lib/md5.c
+++ b/lib/md5.c
@@ -632,23 +632,23 @@ struct MD5_context *Curl_MD5_init(const struct MD5_params *md5params)
   struct MD5_context *ctxt;
 
   /* Create MD5 context */
-  ctxt = malloc(sizeof(*ctxt));
+  ctxt = MALLOC(sizeof(*ctxt));
 
   if(!ctxt)
     return ctxt;
 
-  ctxt->md5_hashctx = malloc(md5params->md5_ctxtsize);
+  ctxt->md5_hashctx = MALLOC(md5params->md5_ctxtsize);
 
   if(!ctxt->md5_hashctx) {
-    free(ctxt);
+    FREE(ctxt);
     return NULL;
   }
 
   ctxt->md5_hash = md5params;
 
   if((*md5params->md5_init_func)(ctxt->md5_hashctx)) {
-    free(ctxt->md5_hashctx);
-    free(ctxt);
+    FREE(ctxt->md5_hashctx);
+    FREE(ctxt);
     return NULL;
   }
 
@@ -668,8 +668,8 @@ CURLcode Curl_MD5_final(struct MD5_context *context, unsigned char *result)
 {
   (*context->md5_hash->md5_final_func)(result, context->md5_hashctx);
 
-  free(context->md5_hashctx);
-  free(context);
+  FREE(context->md5_hashctx);
+  FREE(context);
 
   return CURLE_OK;
 }

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -70,6 +70,7 @@ static void curl_dbg_cleanup(void)
   if(curl_dbg_logfile &&
      curl_dbg_logfile != stderr &&
      curl_dbg_logfile != stdout) {
+    /* !checksrc! disable BANNEDFUNC 1 : allow fclose() here */
     fclose(curl_dbg_logfile);
   }
   curl_dbg_logfile = NULL;
@@ -80,6 +81,7 @@ void curl_dbg_memdebug(const char *logname)
 {
   if(!curl_dbg_logfile) {
     if(logname && *logname)
+      /* !checksrc! disable BANNEDFUNC 1 : allow fopen() here */
       curl_dbg_logfile = fopen(logname, FOPEN_WRITETEXT);
     else
       curl_dbg_logfile = stderr;
@@ -93,7 +95,7 @@ void curl_dbg_memdebug(const char *logname)
     registered_cleanup = !atexit(curl_dbg_cleanup);
 }
 
-/* This function sets the number of malloc() calls that should return
+/* This function sets the number of MALLOC() calls that should return
    successfully! */
 void curl_dbg_memlimit(long limit)
 {
@@ -148,7 +150,7 @@ void *curl_dbg_malloc(size_t wantedsize, int line, const char *source)
   }
 
   if(source)
-    curl_dbg_log("MEM %s:%d malloc(%zu) = %p\n",
+    curl_dbg_log("MEM %s:%d MALLOC(%zu) = %p\n",
                  source, line, wantedsize,
                  mem ? (void *)mem->mem : (void *)0);
 
@@ -177,7 +179,7 @@ void *curl_dbg_calloc(size_t wanted_elements, size_t wanted_size,
     mem->size = user_size;
 
   if(source)
-    curl_dbg_log("MEM %s:%d calloc(%zu,%zu) = %p\n",
+    curl_dbg_log("MEM %s:%d CALLOC(%zu,%zu) = %p\n",
                  source, line, wanted_elements, wanted_size,
                  mem ? (void *)mem->mem : (void *)0);
 
@@ -202,7 +204,7 @@ char *curl_dbg_strdup(const char *str, int line, const char *source)
     memcpy(mem, str, len);
 
   if(source)
-    curl_dbg_log("MEM %s:%d strdup(%p) (%zu) = %p\n",
+    curl_dbg_log("MEM %s:%d STRDUP(%p) (%zu) = %p\n",
                  source, line, (const void *)str, len, (const void *)mem);
 
   return mem;
@@ -235,8 +237,8 @@ wchar_t *curl_dbg_wcsdup(const wchar_t *str, int line, const char *source)
 }
 #endif
 
-/* We provide a realloc() that accepts a NULL as pointer, which then
-   performs a malloc(). In order to work with ares. */
+/* We provide a REALLOC() that accepts a NULL as pointer, which then
+   performs a MALLOC(). In order to work with ares. */
 void *curl_dbg_realloc(void *ptr, size_t wantedsize,
                        int line, const char *source)
 {
@@ -264,7 +266,7 @@ void *curl_dbg_realloc(void *ptr, size_t wantedsize,
 
   mem = (Curl_crealloc)(mem, size);
   if(source)
-    curl_dbg_log("MEM %s:%d realloc(%p, %zu) = %p\n",
+    curl_dbg_log("MEM %s:%d REALLOC(%p, %zu) = %p\n",
                 source, line, (void *)ptr, wantedsize,
                 mem ? (void *)mem->mem : (void *)0);
 
@@ -298,7 +300,7 @@ void curl_dbg_free(void *ptr, int line, const char *source)
   }
 
   if(source && ptr)
-    curl_dbg_log("MEM %s:%d free(%p)\n", source, line, (void *)ptr);
+    curl_dbg_log("MEM %s:%d FREE(%p)\n", source, line, (void *)ptr);
 }
 
 curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
@@ -309,10 +311,11 @@ curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
   if(countcheck("socket", line, source))
     return CURL_SOCKET_BAD;
 
+  /* !checksrc! disable BANNEDFUNC 1 : allow socket() here */
   sockfd = socket(domain, type, protocol);
 
   if(source && (sockfd != CURL_SOCKET_BAD))
-    curl_dbg_log("FD %s:%d socket() = %" FMT_SOCKET_T "\n",
+    curl_dbg_log("FD %s:%d SOCKET() = %" FMT_SOCKET_T "\n",
                  source, line, sockfd);
 
   return sockfd;
@@ -326,9 +329,10 @@ SEND_TYPE_RETV curl_dbg_send(SEND_TYPE_ARG1 sockfd,
   SEND_TYPE_RETV rc;
   if(countcheck("send", line, source))
     return -1;
+  /* !checksrc! disable BANNEDFUNC 1 : allow send() here */
   rc = send(sockfd, buf, len, flags);
   if(source)
-    curl_dbg_log("SEND %s:%d send(%lu) = %ld\n",
+    curl_dbg_log("SEND %s:%d SEND(%lu) = %ld\n",
                 source, line, (unsigned long)len, (long)rc);
   return rc;
 }
@@ -340,9 +344,10 @@ RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd, RECV_TYPE_ARG2 buf,
   RECV_TYPE_RETV rc;
   if(countcheck("recv", line, source))
     return -1;
+  /* !checksrc! disable BANNEDFUNC 1 : allow recv() here */
   rc = recv(sockfd, buf, len, flags);
   if(source)
-    curl_dbg_log("RECV %s:%d recv(%lu) = %ld\n",
+    curl_dbg_log("RECV %s:%d RECV(%lu) = %ld\n",
                 source, line, (unsigned long)len, (long)rc);
   return rc;
 }
@@ -355,7 +360,7 @@ int curl_dbg_socketpair(int domain, int type, int protocol,
   int res = socketpair(domain, type, protocol, socket_vector);
 
   if(source && (0 == res))
-    curl_dbg_log("FD %s:%d socketpair() = "
+    curl_dbg_log("FD %s:%d SOCKETPAIR() = "
                  "%" FMT_SOCKET_T " %" FMT_SOCKET_T "\n",
                  source, line, socket_vector[0], socket_vector[1]);
 
@@ -369,10 +374,11 @@ curl_socket_t curl_dbg_accept(curl_socket_t s, void *saddr, void *saddrlen,
   struct sockaddr *addr = (struct sockaddr *)saddr;
   curl_socklen_t *addrlen = (curl_socklen_t *)saddrlen;
 
+  /* !checksrc! disable BANNEDFUNC 1 : allow accept() here */
   curl_socket_t sockfd = accept(s, addr, addrlen);
 
   if(source && (sockfd != CURL_SOCKET_BAD))
-    curl_dbg_log("FD %s:%d accept() = %" FMT_SOCKET_T "\n",
+    curl_dbg_log("FD %s:%d ACCEPT() = %" FMT_SOCKET_T "\n",
                  source, line, sockfd);
 
   return sockfd;
@@ -398,10 +404,11 @@ ALLOC_FUNC
 FILE *curl_dbg_fopen(const char *file, const char *mode,
                      int line, const char *source)
 {
+  /* !checksrc! disable BANNEDFUNC 1 : allow fopen() here */
   FILE *res = fopen(file, mode);
 
   if(source)
-    curl_dbg_log("FILE %s:%d fopen(\"%s\",\"%s\") = %p\n",
+    curl_dbg_log("FILE %s:%d FOPEN(\"%s\",\"%s\") = %p\n",
                 source, line, file, mode, (void *)res);
 
   return res;
@@ -411,9 +418,10 @@ ALLOC_FUNC
 FILE *curl_dbg_fdopen(int filedes, const char *mode,
                       int line, const char *source)
 {
+  /* !checksrc! disable BANNEDFUNC 1 : allow fdopen() here */
   FILE *res = fdopen(filedes, mode);
   if(source)
-    curl_dbg_log("FILE %s:%d fdopen(\"%d\",\"%s\") = %p\n",
+    curl_dbg_log("FILE %s:%d FDOPEN(\"%d\",\"%s\") = %p\n",
                  source, line, filedes, mode, (void *)res);
   return res;
 }
@@ -425,9 +433,10 @@ int curl_dbg_fclose(FILE *file, int line, const char *source)
   DEBUGASSERT(file != NULL);
 
   if(source)
-    curl_dbg_log("FILE %s:%d fclose(%p)\n",
+    curl_dbg_log("FILE %s:%d FCLOSE(%p)\n",
                  source, line, (void *)file);
 
+  /* !checksrc! disable BANNEDFUNC 1 : allow fclose() here */
   res = fclose(file);
 
   return res;

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -124,20 +124,20 @@ CURL_EXTERN ALLOC_FUNC
 #ifndef MEMDEBUG_NODEFINES
 
 /* Set this symbol on the command-line, recompile all lib-sources */
-#undef strdup
-#define strdup(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
-#undef malloc
-#define malloc(size) curl_dbg_malloc(size, __LINE__, __FILE__)
-#undef calloc
-#define calloc(nbelem,size) curl_dbg_calloc(nbelem, size, __LINE__, __FILE__)
-#undef realloc
-#define realloc(ptr,size) curl_dbg_realloc(ptr, size, __LINE__, __FILE__)
-#undef free
-#define free(ptr) curl_dbg_free(ptr, __LINE__, __FILE__)
-#undef send
-#define send(a,b,c,d) curl_dbg_send(a,b,c,d, __LINE__, __FILE__)
-#undef recv
-#define recv(a,b,c,d) curl_dbg_recv(a,b,c,d, __LINE__, __FILE__)
+#undef STRDUP
+#define STRDUP(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
+#undef MALLOC
+#define MALLOC(size) curl_dbg_malloc(size, __LINE__, __FILE__)
+#undef CALLOC
+#define CALLOC(nbelem,size) curl_dbg_calloc(nbelem, size, __LINE__, __FILE__)
+#undef REALLOC
+#define REALLOC(ptr,size) curl_dbg_realloc(ptr, size, __LINE__, __FILE__)
+#undef FREE
+#define FREE(ptr) curl_dbg_free(ptr, __LINE__, __FILE__)
+#undef SEND
+#define SEND(a,b,c,d) curl_dbg_send(a,b,c,d, __LINE__, __FILE__)
+#undef RECV
+#define RECV(a,b,c,d) curl_dbg_recv(a,b,c,d, __LINE__, __FILE__)
 
 #ifdef _WIN32
 #  ifdef UNICODE
@@ -153,14 +153,14 @@ CURL_EXTERN ALLOC_FUNC
 #  endif
 #endif
 
-#undef socket
-#define socket(domain,type,protocol)\
+#undef SOCKET
+#define SOCKET(domain,type,protocol)\
  curl_dbg_socket((int)domain, type, protocol, __LINE__, __FILE__)
-#undef accept /* for those with accept as a macro */
-#define accept(sock,addr,len)\
+#undef ACCEPT /* for those with accept as a macro */
+#define ACCEPT(sock,addr,len)\
  curl_dbg_accept(sock, addr, len, __LINE__, __FILE__)
 #ifdef HAVE_SOCKETPAIR
-#define socketpair(domain,type,protocol,socket_vector)\
+#define SOCKETPAIR(domain,type,protocol,socket_vector)\
  curl_dbg_socketpair((int)domain, type, protocol, socket_vector, \
                      __LINE__, __FILE__)
 #endif
@@ -171,11 +171,11 @@ CURL_EXTERN ALLOC_FUNC
 
 #define fake_sclose(sockfd) curl_dbg_mark_sclose(sockfd,__LINE__,__FILE__)
 
-#undef fopen
-#define fopen(file,mode) curl_dbg_fopen(file,mode,__LINE__,__FILE__)
-#undef fdopen
-#define fdopen(file,mode) curl_dbg_fdopen(file,mode,__LINE__,__FILE__)
-#define fclose(file) curl_dbg_fclose(file,__LINE__,__FILE__)
+#undef FOPEN
+#define FOPEN(file,mode) curl_dbg_fopen(file,mode,__LINE__,__FILE__)
+#undef FDOPEN
+#define FDOPEN(file,mode) curl_dbg_fdopen(file,mode,__LINE__,__FILE__)
+#define FCLOSE(file) curl_dbg_fclose(file,__LINE__,__FILE__)
 
 #endif /* MEMDEBUG_NODEFINES */
 
@@ -191,11 +191,11 @@ CURL_EXTERN ALLOC_FUNC
 
 /*
  * Curl_safefree defined as a macro to allow MemoryTracking feature
- * to log free() calls at same location where Curl_safefree is used.
+ * to log FREE() calls at same location where Curl_safefree is used.
  * This macro also assigns NULL to given pointer when free'd.
  */
 
 #define Curl_safefree(ptr) \
-  do { free((ptr)); (ptr) = NULL;} while(0)
+  do { FREE((ptr)); (ptr) = NULL;} while(0)
 
 #endif /* HEADER_CURL_MEMDEBUG_H */

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -158,7 +158,7 @@ curl_off_t VmsRealFileSize(const char *name,
   int ret_stat;
   FILE * file;
 
-  file = fopen(name, FOPEN_READTEXT); /* VMS */
+  file = FOPEN(name, FOPEN_READTEXT); /* VMS */
   if(!file)
     return 0;
 
@@ -169,7 +169,7 @@ curl_off_t VmsRealFileSize(const char *name,
     if(ret_stat)
       count += ret_stat;
   }
-  fclose(file);
+  FCLOSE(file);
 
   return count;
 }
@@ -214,10 +214,10 @@ static FILE * vmsfopenread(const char *file, const char *mode)
   case FAB$C_VAR:
   case FAB$C_VFC:
   case FAB$C_STMCR:
-    return fopen(file, FOPEN_READTEXT); /* VMS */
+    return FOPEN(file, FOPEN_READTEXT); /* VMS */
     break;
   default:
-    return fopen(file, FOPEN_READTEXT, "rfm=stmlf", "ctx=stm");
+    return FOPEN(file, FOPEN_READTEXT, "rfm=stmlf", "ctx=stm");
   }
 }
 
@@ -360,13 +360,13 @@ static char *strippath(const char *fullfile)
 {
   char *filename;
   char *base;
-  filename = strdup(fullfile); /* duplicate since basename() may ruin the
+  filename = STRDUP(fullfile); /* duplicate since basename() may ruin the
                                   buffer it works on */
   if(!filename)
     return NULL;
-  base = strdup(basename(filename));
+  base = STRDUP(basename(filename));
 
-  free(filename); /* free temporary buffer */
+  FREE(filename); /* free temporary buffer */
 
   return base; /* returns an allocated string or NULL ! */
 }
@@ -749,7 +749,7 @@ static void mime_file_free(void *ptr)
   curl_mimepart *part = (curl_mimepart *) ptr;
 
   if(part->fp) {
-    fclose(part->fp);
+    FCLOSE(part->fp);
     part->fp = NULL;
   }
   Curl_safefree(part->data);
@@ -971,7 +971,7 @@ static size_t readback_part(curl_mimepart *part,
         mimesetstate(&part->state, MIMESTATE_END, NULL);
         /* Try sparing open file descriptors. */
         if(part->kind == MIMEKIND_FILE && part->fp) {
-          fclose(part->fp);
+          FCLOSE(part->fp);
           part->fp = NULL;
         }
         FALLTHROUGH();
@@ -1193,9 +1193,9 @@ void curl_mime_free(curl_mime *mime)
       part = mime->firstpart;
       mime->firstpart = part->nextpart;
       Curl_mime_cleanpart(part);
-      free(part);
+      FREE(part);
     }
-    free(mime);
+    FREE(mime);
   }
 }
 
@@ -1285,7 +1285,7 @@ curl_mime *curl_mime_init(void *easy)
 {
   curl_mime *mime;
 
-  mime = (curl_mime *) malloc(sizeof(*mime));
+  mime = (curl_mime *) MALLOC(sizeof(*mime));
 
   if(mime) {
     mime->parent = NULL;
@@ -1297,7 +1297,7 @@ curl_mime *curl_mime_init(void *easy)
                        (unsigned char *) &mime->boundary[MIME_BOUNDARY_DASHES],
                        MIME_RAND_BOUNDARY_CHARS + 1)) {
       /* failed to get random separator, bail out */
-      free(mime);
+      FREE(mime);
       return NULL;
     }
     mimesetstate(&mime->state, MIMESTATE_BEGIN, NULL);
@@ -1322,7 +1322,7 @@ curl_mimepart *curl_mime_addpart(curl_mime *mime)
   if(!mime)
     return NULL;
 
-  part = (curl_mimepart *) malloc(sizeof(*part));
+  part = (curl_mimepart *) MALLOC(sizeof(*part));
 
   if(part) {
     Curl_mime_initpart(part);
@@ -1348,7 +1348,7 @@ CURLcode curl_mime_name(curl_mimepart *part, const char *name)
   Curl_safefree(part->name);
 
   if(name) {
-    part->name = strdup(name);
+    part->name = STRDUP(name);
     if(!part->name)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -1365,7 +1365,7 @@ CURLcode curl_mime_filename(curl_mimepart *part, const char *filename)
   Curl_safefree(part->filename);
 
   if(filename) {
-    part->filename = strdup(filename);
+    part->filename = STRDUP(filename);
     if(!part->filename)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -1418,7 +1418,7 @@ CURLcode curl_mime_filedata(curl_mimepart *part, const char *filename)
     if(stat(filename, &sbuf))
       result = CURLE_READ_ERROR;
     else {
-      part->data = strdup(filename);
+      part->data = STRDUP(filename);
       if(!part->data)
         result = CURLE_OUT_OF_MEMORY;
       else {
@@ -1441,7 +1441,7 @@ CURLcode curl_mime_filedata(curl_mimepart *part, const char *filename)
           result = CURLE_OUT_OF_MEMORY;
         else {
           result = curl_mime_filename(part, base);
-          free(base);
+          FREE(base);
         }
       }
     }
@@ -1458,7 +1458,7 @@ CURLcode curl_mime_type(curl_mimepart *part, const char *mimetype)
   Curl_safefree(part->mimetype);
 
   if(mimetype) {
-    part->mimetype = strdup(mimetype);
+    part->mimetype = STRDUP(mimetype);
     if(!part->mimetype)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -1699,7 +1699,7 @@ CURLcode Curl_mime_add_header(struct curl_slist **slp, const char *fmt, ...)
     if(hdr)
       *slp = hdr;
     else
-      free(s);
+      FREE(s);
   }
 
   return hdr ? CURLE_OK : CURLE_OUT_OF_MEMORY;

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -1125,7 +1125,7 @@ char *curl_mvaprintf(const char *format, va_list ap_save)
   }
   if(Curl_dyn_len(info.b))
     return Curl_dyn_ptr(info.b);
-  return strdup("");
+  return STRDUP("");
 }
 
 char *curl_maprintf(const char *format, ...)

--- a/lib/mqtt.c
+++ b/lib/mqtt.c
@@ -108,7 +108,7 @@ static CURLcode mqtt_setup_conn(struct Curl_easy *data,
   (void)conn;
   DEBUGASSERT(data->req.p.mqtt == NULL);
 
-  mq = calloc(1, sizeof(struct MQTT));
+  mq = CALLOC(1, sizeof(struct MQTT));
   if(!mq)
     return CURLE_OUT_OF_MEMORY;
   Curl_dyn_init(&mq->recvbuf, DYN_MQTT_RECV);
@@ -141,7 +141,7 @@ static CURLcode mqtt_send(struct Curl_easy *data,
   return result;
 }
 
-/* Generic function called by the multi interface to figure out what socket(s)
+/* Generic function called by the multi interface to figure out what SOCKET(s)
    to wait for and for what actions during the DOING and PROTOCONNECT
    states */
 static int mqtt_getsock(struct Curl_easy *data,
@@ -286,7 +286,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
   /* allocating packet */
   if(packetlen > 0xFFFFFFF)
     return CURLE_WEIRD_SERVER_REPLY;
-  packet = calloc(1, packetlen);
+  packet = CALLOC(1, packetlen);
   if(!packet)
     return CURLE_OUT_OF_MEMORY;
 
@@ -336,7 +336,7 @@ static CURLcode mqtt_connect(struct Curl_easy *data)
 
 end:
   if(packet)
-    free(packet);
+    FREE(packet);
   Curl_safefree(data->state.aptr.user);
   Curl_safefree(data->state.aptr.passwd);
   return result;
@@ -451,7 +451,7 @@ static CURLcode mqtt_subscribe(struct Curl_easy *data)
   n = mqtt_encode_len((char *)encodedsize, packetlen);
   packetlen += n + 1; /* add one for the control packet type byte */
 
-  packet = malloc(packetlen);
+  packet = MALLOC(packetlen);
   if(!packet) {
     result = CURLE_OUT_OF_MEMORY;
     goto fail;
@@ -469,8 +469,8 @@ static CURLcode mqtt_subscribe(struct Curl_easy *data)
   result = mqtt_send(data, (const char *)packet, packetlen);
 
 fail:
-  free(topic);
-  free(packet);
+  FREE(topic);
+  FREE(packet);
   return result;
 }
 
@@ -537,7 +537,7 @@ static CURLcode mqtt_publish(struct Curl_easy *data)
   encodelen = mqtt_encode_len(encodedbytes, remaininglength);
 
   /* add the control byte and the encoded remaining length */
-  pkt = malloc(remaininglength + 1 + encodelen);
+  pkt = MALLOC(remaininglength + 1 + encodelen);
   if(!pkt) {
     result = CURLE_OUT_OF_MEMORY;
     goto fail;
@@ -556,8 +556,8 @@ static CURLcode mqtt_publish(struct Curl_easy *data)
   result = mqtt_send(data, (const char *)pkt, i);
 
 fail:
-  free(pkt);
-  free(topic);
+  FREE(pkt);
+  FREE(topic);
   return result;
 }
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -214,7 +214,7 @@ struct Curl_multi *Curl_multi_handle(size_t ev_hashsize,  /* event hash */
                                      size_t dnssize,   /* dns hash */
                                      size_t sesssize)  /* TLS session cache */
 {
-  struct Curl_multi *multi = calloc(1, sizeof(struct Curl_multi));
+  struct Curl_multi *multi = CALLOC(1, sizeof(struct Curl_multi));
 
   if(!multi)
     return NULL;
@@ -285,7 +285,7 @@ error:
     Curl_close(&multi->admin);
   }
 
-  free(multi);
+  FREE(multi);
   return NULL;
 }
 
@@ -956,7 +956,7 @@ void Curl_multi_getsock(struct Curl_easy *data,
     break;
 
   case MSTATE_RATELIMITING:
-    /* we need to let time pass, ignore socket(s) */
+    /* we need to let time pass, ignore SOCKET(s) */
     expect_sockets = FALSE;
     break;
 
@@ -1114,14 +1114,14 @@ CURLMcode curl_multi_waitfds(CURLM *m,
  * be reset this way because an empty datagram would be sent. #9203
  *
  * "On Windows the internal state of FD_WRITE as returned from
- * WSAEnumNetworkEvents is only reset after successful send()."
+ * WSAEnumNetworkEvents is only reset after successful SEND()."
  */
 static void reset_socket_fdwrite(curl_socket_t s)
 {
   int t;
   int l = (int)sizeof(t);
   if(!getsockopt(s, SOL_SOCKET, SO_TYPE, (char *)&t, &l) && t == SOCK_STREAM)
-    send(s, NULL, 0, 0);
+    SEND(s, NULL, 0, 0);
 }
 #endif
 
@@ -1780,7 +1780,7 @@ static CURLMcode state_performing(struct Curl_easy *data,
       data->state.errorbuf = FALSE;
       if(!newurl)
         /* typically for HTTP_1_1_REQUIRED error on first flight */
-        newurl = strdup(data->state.url);
+        newurl = STRDUP(data->state.url);
       /* if we are to retry, set the result to OK and consider the request
          as done */
       retry = TRUE;
@@ -1821,7 +1821,7 @@ static CURLMcode state_performing(struct Curl_easy *data,
       if(!retry) {
         /* if the URL is a follow-location and not just a retried request then
            figure out the URL here */
-        free(newurl);
+        FREE(newurl);
         newurl = data->req.newurl;
         data->req.newurl = NULL;
         follow = FOLLOW_REDIR;
@@ -1842,7 +1842,7 @@ static CURLMcode state_performing(struct Curl_easy *data,
       /* but first check to see if we got a location info even though we are
          not following redirects */
       if(data->req.location) {
-        free(newurl);
+        FREE(newurl);
         newurl = data->req.location;
         data->req.location = NULL;
         result = multi_follow(data, handler, newurl, FOLLOW_FAKE);
@@ -1864,7 +1864,7 @@ static CURLMcode state_performing(struct Curl_easy *data,
        transfers */
     Curl_expire(data, 0, EXPIRE_RUN_NOW);
   }
-  free(newurl);
+  FREE(newurl);
   *resultp = result;
   return rc;
 }
@@ -1994,7 +1994,7 @@ static CURLMcode state_do(struct Curl_easy *data,
         /* Have error handler disconnect conn if we cannot retry */
         *stream_errorp = TRUE;
       }
-      free(newurl);
+      FREE(newurl);
     }
     else {
       /* failure detected */
@@ -2097,9 +2097,9 @@ static CURLMcode state_resolving(struct Curl_multi *multi,
   if(!dns)
     result = Curl_resolv_check(data, &dns);
 
-  /* Update sockets here, because the socket(s) may have been closed and the
+  /* Update sockets here, because the SOCKET(s) may have been closed and the
      application thus needs to be told, even if it is likely that the same
-     socket(s) will again be used further down. If the name has not yet been
+     SOCKET(s) will again be used further down. If the name has not yet been
      resolved, it is likely that new sockets have been opened in an attempt to
      contact another resolver. */
   rc = Curl_multi_ev_assess_xfer(multi, data);
@@ -2755,7 +2755,7 @@ CURLMcode curl_multi_cleanup(CURLM *m)
 #endif
 
     multi_xfer_bufs_free(multi);
-    free(multi);
+    FREE(multi);
 
     return CURLM_OK;
   }
@@ -3489,7 +3489,7 @@ unsigned int Curl_multi_max_concurrent_streams(struct Curl_multi *multi)
 CURL **curl_multi_get_handles(CURLM *m)
 {
   struct Curl_multi *multi = m;
-  CURL **a = malloc(sizeof(struct Curl_easy *) * (multi->num_easy + 1));
+  CURL **a = MALLOC(sizeof(struct Curl_easy *) * (multi->num_easy + 1));
   if(a) {
     unsigned int i = 0;
     struct Curl_llist_node *e;
@@ -3527,13 +3527,13 @@ CURLcode Curl_multi_xfer_buf_borrow(struct Curl_easy *data,
   if(data->multi->xfer_buf &&
      data->set.buffer_size > data->multi->xfer_buf_len) {
     /* not large enough, get a new one */
-    free(data->multi->xfer_buf);
+    FREE(data->multi->xfer_buf);
     data->multi->xfer_buf = NULL;
     data->multi->xfer_buf_len = 0;
   }
 
   if(!data->multi->xfer_buf) {
-    data->multi->xfer_buf = malloc((size_t)data->set.buffer_size);
+    data->multi->xfer_buf = MALLOC((size_t)data->set.buffer_size);
     if(!data->multi->xfer_buf) {
       failf(data, "could not allocate xfer_buf of %zu bytes",
             (size_t)data->set.buffer_size);
@@ -3580,13 +3580,13 @@ CURLcode Curl_multi_xfer_ulbuf_borrow(struct Curl_easy *data,
   if(data->multi->xfer_ulbuf &&
      data->set.upload_buffer_size > data->multi->xfer_ulbuf_len) {
     /* not large enough, get a new one */
-    free(data->multi->xfer_ulbuf);
+    FREE(data->multi->xfer_ulbuf);
     data->multi->xfer_ulbuf = NULL;
     data->multi->xfer_ulbuf_len = 0;
   }
 
   if(!data->multi->xfer_ulbuf) {
-    data->multi->xfer_ulbuf = malloc((size_t)data->set.upload_buffer_size);
+    data->multi->xfer_ulbuf = MALLOC((size_t)data->set.upload_buffer_size);
     if(!data->multi->xfer_ulbuf) {
       failf(data, "could not allocate xfer_ulbuf of %zu bytes",
             (size_t)data->set.upload_buffer_size);
@@ -3627,13 +3627,13 @@ CURLcode Curl_multi_xfer_sockbuf_borrow(struct Curl_easy *data,
 
   if(data->multi->xfer_sockbuf && blen > data->multi->xfer_sockbuf_len) {
     /* not large enough, get a new one */
-    free(data->multi->xfer_sockbuf);
+    FREE(data->multi->xfer_sockbuf);
     data->multi->xfer_sockbuf = NULL;
     data->multi->xfer_sockbuf_len = 0;
   }
 
   if(!data->multi->xfer_sockbuf) {
-    data->multi->xfer_sockbuf = malloc(blen);
+    data->multi->xfer_sockbuf = MALLOC(blen);
     if(!data->multi->xfer_sockbuf) {
       failf(data, "could not allocate xfer_sockbuf of %zu bytes", blen);
       return CURLE_OUT_OF_MEMORY;

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -83,7 +83,7 @@ static void mev_sh_entry_dtor(void *freethis)
   struct mev_sh_entry *entry = (struct mev_sh_entry *)freethis;
   Curl_hash_offt_destroy(&entry->xfers);
   Curl_hash_offt_destroy(&entry->conns);
-  free(entry);
+  FREE(entry);
 }
 
 /* look up a given socket in the socket hash, skip invalid sockets */
@@ -110,7 +110,7 @@ mev_sh_entry_add(struct Curl_hash *sh, curl_socket_t s)
   }
 
   /* not present, add it */
-  check = calloc(1, sizeof(struct mev_sh_entry));
+  check = CALLOC(1, sizeof(struct mev_sh_entry));
   if(!check)
     return NULL; /* major failure */
 
@@ -430,11 +430,11 @@ mev_add_new_pollset(struct Curl_hash_offt *h, curl_off_t id)
 {
   struct easy_pollset *ps;
 
-  ps = calloc(1, sizeof(*ps));
+  ps = CALLOC(1, sizeof(*ps));
   if(!ps)
     return NULL;
   if(!Curl_hash_offt_set(h, id, ps)) {
-    free(ps);
+    FREE(ps);
     return NULL;
   }
   return ps;
@@ -601,7 +601,7 @@ void Curl_multi_ev_conn_done(struct Curl_multi *multi,
 static void mev_hash_pollset_free(curl_off_t id, void *entry)
 {
   (void)id;
-  free(entry);
+  FREE(entry);
 }
 
 void Curl_multi_ev_init(struct Curl_multi *multi, size_t hashsize)

--- a/lib/multihandle.h
+++ b/lib/multihandle.h
@@ -103,7 +103,7 @@ struct Curl_multi {
 
   struct Curl_easy *admin; /* internal easy handle for admin operations */
 
-  /* callback function and user data pointer for the *socket() API */
+  /* callback function and user data pointer for the *SOCKET() API */
   curl_socket_callback socket_cb;
   void *socket_userp;
 
@@ -153,7 +153,7 @@ struct Curl_multi {
   long max_total_connections; /* if >0, a fixed limit of the maximum number
                                  of connections in total */
 
-  /* timer callback and user data pointer for the *socket() API */
+  /* timer callback and user data pointer for the *SOCKET() API */
   curl_multi_timer_callback timer_cb;
   void *timer_userp;
   long last_timeout_ms;        /* the last timeout value set via timer_cb */

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -76,7 +76,7 @@ enum found_state {
 static NETRCcode file2memory(const char *filename, struct dynbuf *filebuf)
 {
   NETRCcode ret = NETRC_FILE_MISSING; /* if it cannot open the file */
-  FILE *file = fopen(filename, FOPEN_READTEXT);
+  FILE *file = FOPEN(filename, FOPEN_READTEXT);
   struct dynbuf linebuf;
   Curl_dyn_init(&linebuf, MAX_NETRC_LINE);
 
@@ -99,7 +99,7 @@ static NETRCcode file2memory(const char *filename, struct dynbuf *filebuf)
 done:
   Curl_dyn_free(&linebuf);
   if(file)
-    fclose(file);
+    FCLOSE(file);
   return ret;
 }
 
@@ -267,8 +267,8 @@ static NETRCcode parsenetrc(struct store_netrc *store,
             our_login = !Curl_timestrcmp(login, tok);
           else {
             our_login = TRUE;
-            free(login);
-            login = strdup(tok);
+            FREE(login);
+            login = STRDUP(tok);
             if(!login) {
               retcode = NETRC_OUT_OF_MEMORY; /* allocation failed */
               goto out;
@@ -278,8 +278,8 @@ static NETRCcode parsenetrc(struct store_netrc *store,
           keyword = NONE;
         }
         else if(keyword == PASSWORD) {
-          free(password);
-          password = strdup(tok);
+          FREE(password);
+          password = STRDUP(tok);
           if(!password) {
             retcode = NETRC_OUT_OF_MEMORY; /* allocation failed */
             goto out;
@@ -336,7 +336,7 @@ out:
   if(!retcode) {
     if(!password && our_login) {
       /* success without a password, set a blank one */
-      password = strdup("");
+      password = STRDUP("");
       if(!password)
         retcode = NETRC_OUT_OF_MEMORY; /* out of memory */
     }
@@ -353,8 +353,8 @@ out:
   else {
     Curl_dyn_free(filebuf);
     if(!specific_login)
-      free(login);
-    free(password);
+      FREE(login);
+    FREE(password);
   }
 
   return retcode;
@@ -430,24 +430,24 @@ NETRCcode Curl_parsenetrc(struct store_netrc *store, const char *host,
 
     filealloc = aprintf("%s%s.netrc", home, DIR_CHAR);
     if(!filealloc) {
-      free(homea);
+      FREE(homea);
       return NETRC_OUT_OF_MEMORY;
     }
     retcode = parsenetrc(store, host, loginp, passwordp, filealloc);
-    free(filealloc);
+    FREE(filealloc);
 #ifdef _WIN32
     if(retcode == NETRC_FILE_MISSING) {
       /* fallback to the old-style "_netrc" file */
       filealloc = aprintf("%s%s_netrc", home, DIR_CHAR);
       if(!filealloc) {
-        free(homea);
+        FREE(homea);
         return NETRC_OUT_OF_MEMORY;
       }
       retcode = parsenetrc(store, host, loginp, passwordp, filealloc);
-      free(filealloc);
+      FREE(filealloc);
     }
 #endif
-    free(homea);
+    FREE(homea);
   }
   else
     retcode = parsenetrc(store, host, loginp, passwordp, netrcfile);

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -519,7 +519,7 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
   (void)done;
 
   DEBUGASSERT(!conn->proto.ldapc);
-  li = calloc(1, sizeof(struct ldapconninfo));
+  li = CALLOC(1, sizeof(struct ldapconninfo));
   if(!li)
     return CURLE_OUT_OF_MEMORY;
   else {
@@ -548,11 +548,11 @@ static CURLcode oldap_connect(struct Curl_easy *data, bool *done)
   if(rc) {
     failf(data, "LDAP local: Cannot connect to %s, %s",
           hosturl, ldap_err2string(rc));
-    free(hosturl);
+    FREE(hosturl);
     return CURLE_COULDNT_CONNECT;
   }
 
-  free(hosturl);
+  FREE(hosturl);
 
 #ifdef CURL_OPENLDAP_DEBUG
   if(do_trace < 0) {
@@ -860,7 +860,7 @@ static CURLcode oldap_disconnect(struct Curl_easy *data,
     }
     Curl_sasl_cleanup(conn, li->sasl.authused);
     conn->proto.ldapc = NULL;
-    free(li);
+    FREE(li);
   }
   return CURLE_OK;
 }
@@ -899,7 +899,7 @@ static CURLcode oldap_do(struct Curl_easy *data, bool *done)
       result = CURLE_LDAP_SEARCH_FAILED;
     }
     else {
-      lr = calloc(1, sizeof(struct ldapreqinfo));
+      lr = CALLOC(1, sizeof(struct ldapreqinfo));
       if(!lr) {
         ldap_abandon_ext(li->ld, msgid, NULL, NULL);
         result = CURLE_OUT_OF_MEMORY;
@@ -932,7 +932,7 @@ static CURLcode oldap_done(struct Curl_easy *data, CURLcode res,
       lr->msgid = 0;
     }
     data->req.p.ldap = NULL;
-    free(lr);
+    FREE(lr);
   }
 
   return CURLE_OK;
@@ -1091,7 +1091,7 @@ static ssize_t oldap_recv(struct Curl_easy *data, int sockindex, char *buf,
           if(!result)
             result = client_write(data, STRCONST(": "), val_b64, val_b64_sz,
                                   STRCONST("\n"));
-          free(val_b64);
+          FREE(val_b64);
         }
         else
           result = client_write(data, STRCONST(" "),

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1133,7 +1133,7 @@ static CURLcode pop3_init(struct Curl_easy *data)
   CURLcode result = CURLE_OK;
   struct POP3 *pop3;
 
-  pop3 = data->req.p.pop3 = calloc(1, sizeof(struct POP3));
+  pop3 = data->req.p.pop3 = CALLOC(1, sizeof(struct POP3));
   if(!pop3)
     result = CURLE_OUT_OF_MEMORY;
 

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -139,7 +139,7 @@ static CURLcode rtsp_setup_connection(struct Curl_easy *data,
     rtspc->initialised = TRUE;
   }
 
-  data->req.p.rtsp = rtsp = calloc(1, sizeof(struct RTSP));
+  data->req.p.rtsp = rtsp = CALLOC(1, sizeof(struct RTSP));
   if(!rtsp)
     return CURLE_OUT_OF_MEMORY;
 
@@ -266,7 +266,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
      to this origin */
 
   if(!data->state.first_host) {
-    data->state.first_host = strdup(conn->host.name);
+    data->state.first_host = STRDUP(conn->host.name);
     if(!data->state.first_host)
       return CURLE_OUT_OF_MEMORY;
 
@@ -355,7 +355,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   if(rtspreq == RTSPREQ_SETUP && !p_transport) {
     /* New Transport: setting? */
     if(data->set.str[STRING_RTSP_TRANSPORT]) {
-      free(data->state.aptr.rtsp_transport);
+      FREE(data->state.aptr.rtsp_transport);
       data->state.aptr.rtsp_transport =
         aprintf("Transport: %s\r\n",
                 data->set.str[STRING_RTSP_TRANSPORT]);
@@ -381,7 +381,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
     /* Accept-Encoding header */
     if(!Curl_checkheaders(data, STRCONST("Accept-Encoding")) &&
        data->set.str[STRING_ENCODING]) {
-      free(data->state.aptr.accept_encoding);
+      FREE(data->state.aptr.accept_encoding);
       data->state.aptr.accept_encoding =
         aprintf("Accept-Encoding: %s\r\n", data->set.str[STRING_ENCODING]);
 
@@ -435,7 +435,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
 
     /* Check to see if there is a range set in the custom headers */
     if(!Curl_checkheaders(data, STRCONST("Range")) && data->state.range) {
-      free(data->state.aptr.rangeline);
+      FREE(data->state.aptr.rangeline);
       data->state.aptr.rangeline = aprintf("Range: %s\r\n", data->state.range);
       p_range = data->state.aptr.rangeline;
     }

--- a/lib/select.c
+++ b/lib/select.c
@@ -419,7 +419,7 @@ void Curl_pollfds_cleanup(struct curl_pollfds *cpfds)
 {
   DEBUGASSERT(cpfds);
   if(cpfds->allocated_pfds) {
-    free(cpfds->pfds);
+    FREE(cpfds->pfds);
   }
   memset(cpfds, 0, sizeof(*cpfds));
 }
@@ -429,13 +429,13 @@ static CURLcode cpfds_increase(struct curl_pollfds *cpfds, unsigned int inc)
   struct pollfd *new_fds;
   unsigned int new_count = cpfds->count + inc;
 
-  new_fds = calloc(new_count, sizeof(struct pollfd));
+  new_fds = CALLOC(new_count, sizeof(struct pollfd));
   if(!new_fds)
     return CURLE_OUT_OF_MEMORY;
 
   memcpy(new_fds, cpfds->pfds, cpfds->count * sizeof(struct pollfd));
   if(cpfds->allocated_pfds)
-    free(cpfds->pfds);
+    FREE(cpfds->pfds);
   cpfds->pfds = new_fds;
   cpfds->count = new_count;
   cpfds->allocated_pfds = TRUE;

--- a/lib/sendf.c
+++ b/lib/sendf.c
@@ -101,7 +101,7 @@ static void cl_reset_writer(struct Curl_easy *data)
   while(writer) {
     data->req.writer_stack = writer->next;
     writer->cwt->do_close(data, writer);
-    free(writer);
+    FREE(writer);
     writer = data->req.writer_stack;
   }
 }
@@ -112,7 +112,7 @@ static void cl_reset_reader(struct Curl_easy *data)
   while(reader) {
     data->req.reader_stack = reader->next;
     reader->crt->do_close(data, reader);
-    free(reader);
+    FREE(reader);
     reader = data->req.reader_stack;
   }
 }
@@ -385,7 +385,7 @@ CURLcode Curl_cwriter_create(struct Curl_cwriter **pwriter,
   void *p;
 
   DEBUGASSERT(cwt->cwriter_size >= sizeof(struct Curl_cwriter));
-  p = calloc(1, cwt->cwriter_size);
+  p = CALLOC(1, cwt->cwriter_size);
   if(!p)
     goto out;
 
@@ -398,7 +398,7 @@ CURLcode Curl_cwriter_create(struct Curl_cwriter **pwriter,
 out:
   *pwriter = result ? NULL : writer;
   if(result)
-    free(writer);
+    FREE(writer);
   return result;
 }
 
@@ -407,7 +407,7 @@ void Curl_cwriter_free(struct Curl_easy *data,
 {
   if(writer) {
     writer->cwt->do_close(data, writer);
-    free(writer);
+    FREE(writer);
   }
 }
 
@@ -927,7 +927,7 @@ CURLcode Curl_creader_create(struct Curl_creader **preader,
   void *p;
 
   DEBUGASSERT(crt->creader_size >= sizeof(struct Curl_creader));
-  p = calloc(1, crt->creader_size);
+  p = CALLOC(1, crt->creader_size);
   if(!p)
     goto out;
 
@@ -940,7 +940,7 @@ CURLcode Curl_creader_create(struct Curl_creader **preader,
 out:
   *preader = result ? NULL : reader;
   if(result)
-    free(reader);
+    FREE(reader);
   return result;
 }
 
@@ -948,7 +948,7 @@ void Curl_creader_free(struct Curl_easy *data, struct Curl_creader *reader)
 {
   if(reader) {
     reader->crt->do_close(data, reader);
-    free(reader);
+    FREE(reader);
   }
 }
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -70,7 +70,7 @@ CURLcode Curl_setstropt(char **charp, const char *s)
     if(strlen(s) > CURL_MAX_INPUT_LENGTH)
       return CURLE_BAD_FUNCTION_ARGUMENT;
 
-    *charp = strdup(s);
+    *charp = STRDUP(s);
     if(!*charp)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -91,7 +91,7 @@ CURLcode Curl_setblobopt(struct curl_blob **blobp,
     if(blob->len > CURL_MAX_INPUT_LENGTH)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     nblob = (struct curl_blob *)
-      malloc(sizeof(struct curl_blob) +
+      MALLOC(sizeof(struct curl_blob) +
              ((blob->flags & CURL_BLOB_COPY) ? blob->len : 0));
     if(!nblob)
       return CURLE_OUT_OF_MEMORY;
@@ -130,10 +130,10 @@ static CURLcode setstropt_userpwd(char *option, char **userp, char **passwdp)
       return result;
   }
 
-  free(*userp);
+  FREE(*userp);
   *userp = user;
 
-  free(*passwdp);
+  FREE(*passwdp);
   *passwdp = passwd;
 
   return CURLE_OK;
@@ -157,13 +157,13 @@ static CURLcode setstropt_interface(char *option, char **devp,
     if(result)
       return result;
   }
-  free(*devp);
+  FREE(*devp);
   *devp = dev;
 
-  free(*ifacep);
+  FREE(*ifacep);
   *ifacep = iface;
 
-  free(*hostp);
+  FREE(*hostp);
   *hostp = host;
 
   return CURLE_OK;
@@ -1732,7 +1732,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
         if(!p)
           return CURLE_OUT_OF_MEMORY;
         else {
-          free(data->set.str[STRING_COPYPOSTFIELDS]);
+          FREE(data->set.str[STRING_COPYPOSTFIELDS]);
           data->set.str[STRING_COPYPOSTFIELDS] = p;
         }
       }
@@ -2151,8 +2151,8 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
       result = Curl_urldecode(p, 0, &data->set.str[STRING_PROXYPASSWORD], NULL,
                               REJECT_ZERO);
     }
-    free(u);
-    free(p);
+    FREE(u);
+    FREE(p);
   }
     break;
   case CURLOPT_PROXYUSERNAME:
@@ -2781,14 +2781,14 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
 
   case CURLOPT_SOCKOPTFUNCTION:
     /*
-     * socket callback function: called after socket() but before connect()
+     * socket callback function: called after SOCKET() but before connect()
      */
     data->set.fsockopt = va_arg(param, curl_sockopt_callback);
     break;
 
   case CURLOPT_OPENSOCKETFUNCTION:
     /*
-     * open/create socket callback function: called instead of socket(),
+     * open/create socket callback function: called instead of SOCKET(),
      * before connect()
      */
     data->set.fopensocket = va_arg(param, curl_opensocket_callback);

--- a/lib/setup-vms.h
+++ b/lib/setup-vms.h
@@ -129,9 +129,9 @@ static char *vms_getenv(const char *envvar)
   result = vms_translate_path(vms_path);
 
   /* note that if you backport this to use VAX C RTL, that the VAX C RTL */
-  /* may do a malloc(2048) for each call to getenv(), so you will need   */
-  /* to add a free(vms_path) */
-  /* Do not do a free() for DEC C RTL builds, which should be used for */
+  /* may do a MALLOC(2048) for each call to getenv(), so you will need   */
+  /* to add a FREE(vms_path) */
+  /* Do not do a FREE() for DEC C RTL builds, which should be used for */
   /* VMS 5.5-2 and later, even if using GCC */
 
   return result;

--- a/lib/share.c
+++ b/lib/share.c
@@ -42,14 +42,14 @@
 CURLSH *
 curl_share_init(void)
 {
-  struct Curl_share *share = calloc(1, sizeof(struct Curl_share));
+  struct Curl_share *share = CALLOC(1, sizeof(struct Curl_share));
   if(share) {
     share->magic = CURL_GOOD_SHARE;
     share->specifier |= (1 << CURL_LOCK_DATA_SHARE);
     Curl_init_dnscache(&share->hostcache, 23);
     share->admin = curl_easy_init();
     if(!share->admin) {
-      free(share);
+      FREE(share);
       return NULL;
     }
     share->admin->state.internal = TRUE;
@@ -271,7 +271,7 @@ curl_share_cleanup(CURLSH *sh)
   if(share->unlockfunc)
     share->unlockfunc(NULL, CURL_LOCK_DATA_SHARE, share->clientdata);
   share->magic = 0;
-  free(share);
+  FREE(share);
 
   return CURLSHE_OK;
 }

--- a/lib/slist.c
+++ b/lib/slist.c
@@ -52,7 +52,7 @@ static struct curl_slist *slist_get_last(struct curl_slist *list)
 /*
  * Curl_slist_append_nodup() appends a string to the linked list. Rather than
  * copying the string in dynamic storage, it takes its ownership. The string
- * should have been malloc()ated. Curl_slist_append_nodup always returns
+ * should have been MALLOC()ated. Curl_slist_append_nodup always returns
  * the address of the first record, so that you can use this function as an
  * initialization function as well as an append function.
  * If an error occurs, NULL is returned and the string argument is NOT
@@ -65,7 +65,7 @@ struct curl_slist *Curl_slist_append_nodup(struct curl_slist *list, char *data)
 
   DEBUGASSERT(data);
 
-  new_item = malloc(sizeof(struct curl_slist));
+  new_item = MALLOC(sizeof(struct curl_slist));
   if(!new_item)
     return NULL;
 
@@ -91,14 +91,14 @@ struct curl_slist *Curl_slist_append_nodup(struct curl_slist *list, char *data)
 struct curl_slist *curl_slist_append(struct curl_slist *list,
                                      const char *data)
 {
-  char *dupdata = strdup(data);
+  char *dupdata = STRDUP(data);
 
   if(!dupdata)
     return NULL;
 
   list = Curl_slist_append_nodup(list, dupdata);
   if(!list)
-    free(dupdata);
+    FREE(dupdata);
 
   return list;
 }
@@ -140,7 +140,7 @@ void curl_slist_free_all(struct curl_slist *list)
   do {
     next = item->next;
     Curl_safefree(item->data);
-    free(item);
+    FREE(item);
     item = next;
   } while(next);
 }

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -418,7 +418,7 @@ static CURLcode smb_setup_connection(struct Curl_easy *data,
   struct smb_request *req;
 
   /* Initialize the request state */
-  data->req.p.smb = req = calloc(1, sizeof(struct smb_request));
+  data->req.p.smb = req = CALLOC(1, sizeof(struct smb_request));
   if(!req)
     return CURLE_OUT_OF_MEMORY;
 
@@ -440,10 +440,10 @@ static CURLcode smb_connect(struct Curl_easy *data, bool *done)
 
   /* Initialize the connection state */
   smbc->state = SMB_CONNECTING;
-  smbc->recv_buf = malloc(MAX_MESSAGE_SIZE);
+  smbc->recv_buf = MALLOC(MAX_MESSAGE_SIZE);
   if(!smbc->recv_buf)
     return CURLE_OUT_OF_MEMORY;
-  smbc->send_buf = malloc(MAX_MESSAGE_SIZE);
+  smbc->send_buf = MALLOC(MAX_MESSAGE_SIZE);
   if(!smbc->send_buf)
     return CURLE_OUT_OF_MEMORY;
 
@@ -457,14 +457,14 @@ static CURLcode smb_connect(struct Curl_easy *data, bool *done)
 
   if(slash) {
     smbc->user = slash + 1;
-    smbc->domain = strdup(conn->user);
+    smbc->domain = STRDUP(conn->user);
     if(!smbc->domain)
       return CURLE_OUT_OF_MEMORY;
     smbc->domain[slash - conn->user] = 0;
   }
   else {
     smbc->user = conn->user;
-    smbc->domain = strdup(conn->host.name);
+    smbc->domain = STRDUP(conn->host.name);
     if(!smbc->domain)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -1172,8 +1172,8 @@ static CURLcode smb_parse_url_path(struct Curl_easy *data,
     return result;
 
   /* Parse the path for the share */
-  smbc->share = strdup((*path == '/' || *path == '\\') ? path + 1 : path);
-  free(path);
+  smbc->share = STRDUP((*path == '/' || *path == '\\') ? path + 1 : path);
+  FREE(path);
   if(!smbc->share)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -563,7 +563,7 @@ static CURLcode smtp_perform_command(struct Curl_easy *data)
                              utf8 ? " SMTPUTF8" : "");
 
       Curl_free_idnconverted_hostname(&host);
-      free(address);
+      FREE(address);
     }
     else {
       /* Establish whether we should report that we support SMTPUTF8 for EXPN
@@ -638,11 +638,11 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data)
          worry about that and reply with a 501 error */
       from = aprintf("<%s>", address);
 
-    free(address);
+    FREE(address);
   }
   else
     /* Null reverse-path, RFC-5321, sect. 3.6.3 */
-    from = strdup("<>");
+    from = STRDUP("<>");
 
   if(!from) {
     result = CURLE_OUT_OF_MEMORY;
@@ -678,11 +678,11 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data)
         /* An invalid mailbox was provided but we will simply let the server
            worry about it */
         auth = aprintf("<%s>", address);
-      free(address);
+      FREE(address);
     }
     else
       /* Empty AUTH, RFC-2554, sect. 5 */
-      auth = strdup("<>");
+      auth = STRDUP("<>");
 
     if(!auth) {
       result = CURLE_OUT_OF_MEMORY;
@@ -764,9 +764,9 @@ static CURLcode smtp_perform_mail(struct Curl_easy *data)
                                : "");          /* included in our envelope  */
 
 out:
-  free(from);
-  free(auth);
-  free(size);
+  FREE(from);
+  FREE(auth);
+  FREE(size);
 
   if(!result)
     smtp_state(data, SMTP_MAIL);
@@ -807,7 +807,7 @@ static CURLcode smtp_perform_rcpt_to(struct Curl_easy *data)
                            address);
 
   Curl_free_idnconverted_hostname(&host);
-  free(address);
+  FREE(address);
 
   if(!result)
     smtp_state(data, SMTP_RCPT);
@@ -1314,7 +1314,7 @@ static CURLcode smtp_init(struct Curl_easy *data)
   CURLcode result = CURLE_OK;
   struct SMTP *smtp;
 
-  smtp = data->req.p.smtp = calloc(1, sizeof(struct SMTP));
+  smtp = data->req.p.smtp = CALLOC(1, sizeof(struct SMTP));
   if(!smtp)
     result = CURLE_OUT_OF_MEMORY;
 
@@ -1744,7 +1744,7 @@ static CURLcode smtp_parse_address(const char *fqma, char **address,
 
   /* Duplicate the fully qualified email address so we can manipulate it,
      ensuring it does not contain the delimiters if specified */
-  char *dup = strdup(fqma[0] == '<' ? fqma + 1  : fqma);
+  char *dup = STRDUP(fqma[0] == '<' ? fqma + 1  : fqma);
   if(!dup)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -145,7 +145,7 @@ int Curl_socketpair(int domain, int type, int protocol,
   (void)type;
   (void)protocol;
 
-  listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+  listener = SOCKET(AF_INET, SOCK_STREAM, IPPROTO_TCP);
   if(listener == CURL_SOCKET_BAD)
     return -1;
 
@@ -179,7 +179,7 @@ int Curl_socketpair(int domain, int type, int protocol,
     goto error;
   if(listen(listener, 1) == -1)
     goto error;
-  socks[0] = socket(AF_INET, SOCK_STREAM, 0);
+  socks[0] = SOCKET(AF_INET, SOCK_STREAM, 0);
   if(socks[0] == CURL_SOCKET_BAD)
     goto error;
   if(connect(socks[0], &a.addr, sizeof(a.inaddr)) == -1)
@@ -192,7 +192,7 @@ int Curl_socketpair(int domain, int type, int protocol,
   pfd[0].events = POLLIN;
   pfd[0].revents = 0;
   (void)Curl_poll(pfd, 1, 1000); /* one second */
-  socks[1] = accept(listener, NULL, NULL);
+  socks[1] = ACCEPT(listener, NULL, NULL);
   if(socks[1] == CURL_SOCKET_BAD)
     goto error;
   else {

--- a/lib/socks.c
+++ b/lib/socks.c
@@ -1113,7 +1113,7 @@ static void socks_proxy_cf_free(struct Curl_cfilter *cf)
 {
   struct socks_state *sxstate = cf->ctx;
   if(sxstate) {
-    free(sxstate);
+    FREE(sxstate);
     cf->ctx = NULL;
   }
 }
@@ -1144,7 +1144,7 @@ static CURLcode socks_proxy_cf_connect(struct Curl_cfilter *cf,
     return result;
 
   if(!sx) {
-    sx = calloc(1, sizeof(*sx));
+    sx = CALLOC(1, sizeof(*sx));
     if(!sx)
       return CURLE_OUT_OF_MEMORY;
     cf->ctx = sx;

--- a/lib/socks_gssapi.c
+++ b/lib/socks_gssapi.c
@@ -153,7 +153,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
                                        (gss_OID) GSS_C_NULL_OID, &server);
   }
   else {
-    service.value = malloc(serviceptr_length +
+    service.value = MALLOC(serviceptr_length +
                            strlen(conn->socks_proxy.host.name) + 2);
     if(!service.value)
       return CURLE_OUT_OF_MEMORY;
@@ -278,7 +278,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     us_length = ntohs(us_length);
 
     gss_recv_token.length = us_length;
-    gss_recv_token.value = malloc(us_length);
+    gss_recv_token.value = MALLOC(us_length);
     if(!gss_recv_token.value) {
       failf(data,
             "Could not allocate memory for GSS-API authentication "
@@ -325,7 +325,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     failf(data, "Failed to determine username.");
     return CURLE_COULDNT_CONNECT;
   }
-  user = malloc(gss_send_token.length + 1);
+  user = MALLOC(gss_send_token.length + 1);
   if(!user) {
     gss_delete_sec_context(&gss_status, &gss_context, NULL);
     gss_release_name(&gss_status, &gss_client_name);
@@ -338,7 +338,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
   gss_release_name(&gss_status, &gss_client_name);
   gss_release_buffer(&gss_status, &gss_send_token);
   infof(data, "SOCKS5 server authenticated user %s with GSS-API.",user);
-  free(user);
+  FREE(user);
   user = NULL;
 
   /* Do encryption */
@@ -475,7 +475,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
   us_length = ntohs(us_length);
 
   gss_recv_token.length = us_length;
-  gss_recv_token.value = malloc(gss_recv_token.length);
+  gss_recv_token.value = MALLOC(gss_recv_token.length);
   if(!gss_recv_token.value) {
     gss_delete_sec_context(&gss_status, &gss_context, NULL);
     return CURLE_OUT_OF_MEMORY;

--- a/lib/socks_sspi.c
+++ b/lib/socks_sspi.c
@@ -102,12 +102,12 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
 
   /* prepare service name */
   if(strchr(service, '/')) {
-    service_name = strdup(service);
+    service_name = STRDUP(service);
     if(!service_name)
       return CURLE_OUT_OF_MEMORY;
   }
   else {
-    service_name = malloc(service_length +
+    service_name = MALLOC(service_length +
                           strlen(conn->socks_proxy.host.name) + 2);
     if(!service_name)
       return CURLE_OUT_OF_MEMORY;
@@ -151,7 +151,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
 
   if(check_sspi_err(data, status, "AcquireCredentialsHandle")) {
     failf(data, "Failed to acquire credentials.");
-    free(service_name);
+    FREE(service_name);
     Curl_pSecFn->FreeCredentialsHandle(&cred_handle);
     return CURLE_COULDNT_CONNECT;
   }
@@ -192,7 +192,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     }
 
     if(check_sspi_err(data, status, "InitializeSecurityContext")) {
-      free(service_name);
+      FREE(service_name);
       Curl_pSecFn->FreeCredentialsHandle(&cred_handle);
       Curl_pSecFn->DeleteSecurityContext(&sspi_context);
       if(sspi_recv_token.pvBuffer)
@@ -211,7 +211,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
                                   &code);
       if(code || (4 != written)) {
         failf(data, "Failed to send SSPI authentication request.");
-        free(service_name);
+        FREE(service_name);
         if(sspi_send_token.pvBuffer)
           Curl_pSecFn->FreeContextBuffer(sspi_send_token.pvBuffer);
         if(sspi_recv_token.pvBuffer)
@@ -226,7 +226,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
                                   sspi_send_token.cbBuffer, FALSE, &code);
       if(code || (sspi_send_token.cbBuffer != (size_t)written)) {
         failf(data, "Failed to send SSPI authentication token.");
-        free(service_name);
+        FREE(service_name);
         if(sspi_send_token.pvBuffer)
           Curl_pSecFn->FreeContextBuffer(sspi_send_token.pvBuffer);
         if(sspi_recv_token.pvBuffer)
@@ -266,7 +266,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     result = Curl_blockread_all(cf, data, (char *)socksreq, 4, &actualread);
     if(result || (actualread != 4)) {
       failf(data, "Failed to receive SSPI authentication response.");
-      free(service_name);
+      FREE(service_name);
       Curl_pSecFn->FreeCredentialsHandle(&cred_handle);
       Curl_pSecFn->DeleteSecurityContext(&sspi_context);
       return CURLE_COULDNT_CONNECT;
@@ -276,7 +276,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     if(socksreq[1] == 255) { /* status / message type */
       failf(data, "User was rejected by the SOCKS5 server (%u %u).",
             (unsigned int)socksreq[0], (unsigned int)socksreq[1]);
-      free(service_name);
+      FREE(service_name);
       Curl_pSecFn->FreeCredentialsHandle(&cred_handle);
       Curl_pSecFn->DeleteSecurityContext(&sspi_context);
       return CURLE_COULDNT_CONNECT;
@@ -285,7 +285,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     if(socksreq[1] != 1) { /* status / message type */
       failf(data, "Invalid SSPI authentication response type (%u %u).",
             (unsigned int)socksreq[0], (unsigned int)socksreq[1]);
-      free(service_name);
+      FREE(service_name);
       Curl_pSecFn->FreeCredentialsHandle(&cred_handle);
       Curl_pSecFn->DeleteSecurityContext(&sspi_context);
       return CURLE_COULDNT_CONNECT;
@@ -295,10 +295,10 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     us_length = ntohs(us_length);
 
     sspi_recv_token.cbBuffer = us_length;
-    sspi_recv_token.pvBuffer = malloc(us_length);
+    sspi_recv_token.pvBuffer = MALLOC(us_length);
 
     if(!sspi_recv_token.pvBuffer) {
-      free(service_name);
+      FREE(service_name);
       Curl_pSecFn->FreeCredentialsHandle(&cred_handle);
       Curl_pSecFn->DeleteSecurityContext(&sspi_context);
       return CURLE_OUT_OF_MEMORY;
@@ -308,7 +308,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
 
     if(result || (actualread != us_length)) {
       failf(data, "Failed to receive SSPI authentication token.");
-      free(service_name);
+      FREE(service_name);
       if(sspi_recv_token.pvBuffer)
         Curl_pSecFn->FreeContextBuffer(sspi_recv_token.pvBuffer);
       Curl_pSecFn->FreeCredentialsHandle(&cred_handle);
@@ -319,7 +319,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     context_handle = &sspi_context;
   }
 
-  free(service_name);
+  FREE(service_name);
 
   /* Everything is good so far, user was authenticated! */
   status = Curl_pSecFn->QueryCredentialsAttributes(&cred_handle,
@@ -406,7 +406,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
 
     sspi_w_token[0].cbBuffer = sspi_sizes.cbSecurityTrailer;
     sspi_w_token[0].BufferType = SECBUFFER_TOKEN;
-    sspi_w_token[0].pvBuffer = malloc(sspi_sizes.cbSecurityTrailer);
+    sspi_w_token[0].pvBuffer = MALLOC(sspi_sizes.cbSecurityTrailer);
 
     if(!sspi_w_token[0].pvBuffer) {
       Curl_pSecFn->DeleteSecurityContext(&sspi_context);
@@ -414,7 +414,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     }
 
     sspi_w_token[1].cbBuffer = 1;
-    sspi_w_token[1].pvBuffer = malloc(1);
+    sspi_w_token[1].pvBuffer = MALLOC(1);
     if(!sspi_w_token[1].pvBuffer) {
       Curl_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
       Curl_pSecFn->DeleteSecurityContext(&sspi_context);
@@ -424,7 +424,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     memcpy(sspi_w_token[1].pvBuffer, &gss_enc, 1);
     sspi_w_token[2].BufferType = SECBUFFER_PADDING;
     sspi_w_token[2].cbBuffer = sspi_sizes.cbBlockSize;
-    sspi_w_token[2].pvBuffer = malloc(sspi_sizes.cbBlockSize);
+    sspi_w_token[2].pvBuffer = MALLOC(sspi_sizes.cbBlockSize);
     if(!sspi_w_token[2].pvBuffer) {
       Curl_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
       Curl_pSecFn->FreeContextBuffer(sspi_w_token[1].pvBuffer);
@@ -446,7 +446,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
     sspi_send_token.cbBuffer = sspi_w_token[0].cbBuffer
       + sspi_w_token[1].cbBuffer
       + sspi_w_token[2].cbBuffer;
-    sspi_send_token.pvBuffer = malloc(sspi_send_token.cbBuffer);
+    sspi_send_token.pvBuffer = MALLOC(sspi_send_token.cbBuffer);
     if(!sspi_send_token.pvBuffer) {
       Curl_pSecFn->FreeContextBuffer(sspi_w_token[0].pvBuffer);
       Curl_pSecFn->FreeContextBuffer(sspi_w_token[1].pvBuffer);
@@ -539,7 +539,7 @@ CURLcode Curl_SOCKS5_gssapi_negotiate(struct Curl_cfilter *cf,
   us_length = ntohs(us_length);
 
   sspi_w_token[0].cbBuffer = us_length;
-  sspi_w_token[0].pvBuffer = malloc(us_length);
+  sspi_w_token[0].pvBuffer = MALLOC(us_length);
   if(!sspi_w_token[0].pvBuffer) {
     Curl_pSecFn->DeleteSecurityContext(&sspi_context);
     return CURLE_OUT_OF_MEMORY;

--- a/lib/strdup.c
+++ b/lib/strdup.c
@@ -47,7 +47,7 @@ char *Curl_strdup(const char *str)
 
   len = strlen(str) + 1;
 
-  newstr = malloc(len);
+  newstr = MALLOC(len);
   if(!newstr)
     return (char *)NULL;
 
@@ -90,7 +90,7 @@ wchar_t *Curl_wcsdup(const wchar_t *src)
  ***************************************************************************/
 void *Curl_memdup(const void *src, size_t length)
 {
-  void *buffer = malloc(length);
+  void *buffer = MALLOC(length);
   if(!buffer)
     return NULL; /* fail */
 
@@ -111,7 +111,7 @@ void *Curl_memdup(const void *src, size_t length)
  ***************************************************************************/
 void *Curl_memdup0(const char *src, size_t length)
 {
-  char *buf = malloc(length + 1);
+  char *buf = MALLOC(length + 1);
   if(!buf)
     return NULL;
   if(length) {
@@ -126,7 +126,7 @@ void *Curl_memdup0(const char *src, size_t length)
  *
  * Curl_saferealloc(ptr, size)
  *
- * Does a normal realloc(), but will free the data pointer if the realloc
+ * Does a normal REALLOC(), but will free the data pointer if the realloc
  * fails. If 'size' is non-zero, it will free the data and return a failure.
  *
  * This convenience function is provided and used to help us avoid a common
@@ -138,9 +138,9 @@ void *Curl_memdup0(const char *src, size_t length)
  ***************************************************************************/
 void *Curl_saferealloc(void *ptr, size_t size)
 {
-  void *datap = realloc(ptr, size);
+  void *datap = REALLOC(ptr, size);
   if(size && !datap)
     /* only free 'ptr' if size was non-zero */
-    free(ptr);
+    FREE(ptr);
   return datap;
 }

--- a/lib/system_win32.c
+++ b/lib/system_win32.c
@@ -220,7 +220,7 @@ HMODULE Curl_load_library(LPCTSTR filename)
       /* Allocate space for the full DLL path (Room for the null terminator
          is included in systemdirlen) */
       size_t filenamelen = _tcslen(filename);
-      TCHAR *path = malloc(sizeof(TCHAR) * (systemdirlen + 1 + filenamelen));
+      TCHAR *path = MALLOC(sizeof(TCHAR) * (systemdirlen + 1 + filenamelen));
       if(path && GetSystemDirectory(path, systemdirlen)) {
         /* Calculate the full DLL path */
         _tcscpy(path + _tcslen(path), TEXT("\\"));
@@ -233,7 +233,7 @@ HMODULE Curl_load_library(LPCTSTR filename)
           LoadLibrary(path);
 
       }
-      free(path);
+      FREE(path);
     }
   }
   return hModule;

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -204,7 +204,7 @@ CURLcode init_telnet(struct Curl_easy *data)
 {
   struct TELNET *tn;
 
-  tn = calloc(1, sizeof(struct TELNET));
+  tn = CALLOC(1, sizeof(struct TELNET));
   if(!tn)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/tftp.c
+++ b/lib/tftp.c
@@ -467,7 +467,7 @@ static CURLcode tftp_send_first(struct tftp_state_data *state,
 
     if(strlen(filename) > (state->blksize - strlen(mode) - 4)) {
       failf(data, "TFTP filename too long");
-      free(filename);
+      FREE(filename);
       return CURLE_TFTP_ILLEGAL; /* too long filename field */
     }
 
@@ -513,7 +513,7 @@ static CURLcode tftp_send_first(struct tftp_state_data *state,
 
       if(result != CURLE_OK) {
         failf(data, "TFTP buffer too small for options");
-        free(filename);
+        FREE(filename);
         return CURLE_TFTP_ILLEGAL;
       }
     }
@@ -533,7 +533,7 @@ static CURLcode tftp_send_first(struct tftp_state_data *state,
       char buffer[STRERROR_LEN];
       failf(data, "%s", Curl_strerror(SOCKERRNO, buffer, sizeof(buffer)));
     }
-    free(filename);
+    FREE(filename);
     break;
 
   case TFTP_EVENT_OACK:
@@ -951,7 +951,7 @@ static CURLcode tftp_disconnect(struct Curl_easy *data,
   if(state) {
     Curl_safefree(state->rpacket.data);
     Curl_safefree(state->spacket.data);
-    free(state);
+    FREE(state);
   }
 
   return CURLE_OK;
@@ -973,7 +973,7 @@ static CURLcode tftp_connect(struct Curl_easy *data, bool *done)
 
   blksize = TFTP_BLKSIZE_DEFAULT;
 
-  state = conn->proto.tftpc = calloc(1, sizeof(struct tftp_state_data));
+  state = conn->proto.tftpc = CALLOC(1, sizeof(struct tftp_state_data));
   if(!state)
     return CURLE_OUT_OF_MEMORY;
 
@@ -988,14 +988,14 @@ static CURLcode tftp_connect(struct Curl_easy *data, bool *done)
     need_blksize = TFTP_BLKSIZE_DEFAULT;
 
   if(!state->rpacket.data) {
-    state->rpacket.data = calloc(1, need_blksize + 2 + 2);
+    state->rpacket.data = CALLOC(1, need_blksize + 2 + 2);
 
     if(!state->rpacket.data)
       return CURLE_OUT_OF_MEMORY;
   }
 
   if(!state->spacket.data) {
-    state->spacket.data = calloc(1, need_blksize + 2 + 2);
+    state->spacket.data = CALLOC(1, need_blksize + 2 + 2);
 
     if(!state->spacket.data)
       return CURLE_OUT_OF_MEMORY;

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -54,7 +54,7 @@
 #endif
 
 #ifndef HAVE_SOCKET
-#error "We cannot compile without socket() support!"
+#error "We cannot compile without SOCKET() support!"
 #endif
 
 #include "urldata.h"
@@ -539,7 +539,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
      is allowed to be changed by the user between transfers */
   if(data->set.uh) {
     CURLUcode uc;
-    free(data->set.str[STRING_SET_URL]);
+    FREE(data->set.str[STRING_SET_URL]);
     uc = curl_url_get(data->set.uh,
                       CURLUPART_URL, &data->set.str[STRING_SET_URL], 0);
     if(uc) {
@@ -631,7 +631,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
     if(data->state.wildcardmatch) {
       struct WildcardData *wc;
       if(!data->wildcard) {
-        data->wildcard = calloc(1, sizeof(struct WildcardData));
+        data->wildcard = CALLOC(1, sizeof(struct WildcardData));
         if(!data->wildcard)
           return CURLE_OUT_OF_MEMORY;
       }
@@ -656,7 +656,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
    * protocol.
    */
   if(data->set.str[STRING_USERAGENT]) {
-    free(data->state.aptr.uagent);
+    FREE(data->state.aptr.uagent);
     data->state.aptr.uagent =
       aprintf("User-Agent: %s\r\n", data->set.str[STRING_USERAGENT]);
     if(!data->state.aptr.uagent)
@@ -688,7 +688,7 @@ CURLcode Curl_pretransfer(struct Curl_easy *data)
 
 /* Returns CURLE_OK *and* sets '*url' if a request retry is wanted.
 
-   NOTE: that the *url is malloc()ed. */
+   NOTE: that the *url is MALLOC()ed. */
 CURLcode Curl_retry_request(struct Curl_easy *data, char **url)
 {
   struct connectdata *conn = data->conn;
@@ -738,7 +738,7 @@ CURLcode Curl_retry_request(struct Curl_easy *data, char **url)
     }
     infof(data, "Connection died, retrying a fresh connect (retry count: %d)",
           data->state.retrycount);
-    *url = strdup(data->state.url);
+    *url = STRDUP(data->state.url);
     if(!*url)
       return CURLE_OUT_OF_MEMORY;
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -56,7 +56,7 @@
 #endif
 
 #ifndef HAVE_SOCKET
-#error "We cannot compile without socket() support!"
+#error "We cannot compile without SOCKET() support!"
 #endif
 
 #include <limits.h>
@@ -254,7 +254,7 @@ CURLcode Curl_close(struct Curl_easy **datap)
                       field! */
 
   if(data->state.rangestringalloc)
-    free(data->state.range);
+    FREE(data->state.range);
 
   /* freed here just in case DONE was not called */
   Curl_req_free(&data->req, data);
@@ -336,7 +336,7 @@ CURLcode Curl_close(struct Curl_easy **datap)
   Curl_freeset(data);
   Curl_headers_cleanup(data);
   Curl_netrc_cleanup(&data->state.netrc);
-  free(data);
+  FREE(data);
   return CURLE_OK;
 }
 
@@ -498,7 +498,7 @@ CURLcode Curl_open(struct Curl_easy **curl)
   struct Curl_easy *data;
 
   /* simple start-up: alloc the struct, init it with zeroes and return */
-  data = calloc(1, sizeof(struct Curl_easy));
+  data = CALLOC(1, sizeof(struct Curl_easy));
   if(!data) {
     /* this is a serious error */
     DEBUGF(fprintf(stderr, "Error: calloc of Curl_easy failed\n"));
@@ -544,7 +544,7 @@ out:
     Curl_dyn_free(&data->state.headerb);
     Curl_freeset(data);
     Curl_req_free(&data->req, data);
-    free(data);
+    FREE(data);
     data = NULL;
   }
   else
@@ -596,7 +596,7 @@ void Curl_conn_free(struct Curl_easy *data, struct connectdata *conn)
 #endif
   Curl_safefree(conn->destination);
 
-  free(conn); /* free all the connection oriented data */
+  FREE(conn); /* free all the connection oriented data */
 }
 
 /*
@@ -1290,7 +1290,7 @@ void Curl_verboseconnect(struct Curl_easy *data,
  */
 static struct connectdata *allocate_conn(struct Curl_easy *data)
 {
-  struct connectdata *conn = calloc(1, sizeof(struct connectdata));
+  struct connectdata *conn = CALLOC(1, sizeof(struct connectdata));
   if(!conn)
     return NULL;
 
@@ -1355,7 +1355,7 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
 
   /* Store the local bind parameters that will be used for this connection */
   if(data->set.str[STRING_DEVICE]) {
-    conn->localdev = strdup(data->set.str[STRING_DEVICE]);
+    conn->localdev = STRDUP(data->set.str[STRING_DEVICE]);
     if(!conn->localdev)
       goto error;
   }
@@ -1375,8 +1375,8 @@ static struct connectdata *allocate_conn(struct Curl_easy *data)
   return conn;
 error:
 
-  free(conn->localdev);
-  free(conn);
+  FREE(conn->localdev);
+  FREE(conn);
   return NULL;
 }
 
@@ -1695,7 +1695,7 @@ static void zonefrom_url(CURLU *uh, struct Curl_easy *data,
     }
 #endif /* HAVE_IF_NAMETOINDEX || _WIN32 */
 
-    free(zoneid);
+    FREE(zoneid);
   }
 }
 #else
@@ -1734,7 +1734,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
     if(!url)
       return CURLE_OUT_OF_MEMORY;
     if(data->state.url_alloc)
-      free(data->state.url);
+      FREE(data->state.url);
     data->state.url = url;
     data->state.url_alloc = TRUE;
   }
@@ -1757,7 +1757,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
     if(uc)
       return Curl_uc_to_curlcode(uc);
     if(data->state.url_alloc)
-      free(data->state.url);
+      FREE(data->state.url);
     data->state.url = newurl;
     data->state.url_alloc = TRUE;
   }
@@ -1791,7 +1791,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   }
 
   /* make sure the connect struct gets its own copy of the hostname */
-  conn->host.rawalloc = strdup(hostname ? hostname : "");
+  conn->host.rawalloc = STRDUP(hostname ? hostname : "");
   if(!conn->host.rawalloc)
     return CURLE_OUT_OF_MEMORY;
   conn->host.name = conn->host.rawalloc;
@@ -1821,7 +1821,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
         return Curl_uc_to_curlcode(uc);
       uc = curl_url_get(uh, CURLUPART_SCHEME, &data->state.up.scheme, 0);
       if(uc) {
-        free(url);
+        FREE(url);
         return Curl_uc_to_curlcode(uc);
       }
       data->state.url = url;
@@ -1884,7 +1884,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   uc = curl_url_get(uh, CURLUPART_OPTIONS, &data->state.up.options,
                     CURLU_URLDECODE);
   if(!uc) {
-    conn->options = strdup(data->state.up.options);
+    conn->options = STRDUP(data->state.up.options);
     if(!conn->options)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -1938,12 +1938,12 @@ static CURLcode setup_range(struct Curl_easy *data)
   s->resume_from = data->set.set_resume_from;
   if(s->resume_from || data->set.str[STRING_SET_RANGE]) {
     if(s->rangestringalloc)
-      free(s->range);
+      FREE(s->range);
 
     if(s->resume_from)
       s->range = aprintf("%" FMT_OFF_T "-", s->resume_from);
     else
-      s->range = strdup(data->set.str[STRING_SET_RANGE]);
+      s->range = STRDUP(data->set.str[STRING_SET_RANGE]);
 
     if(!s->range)
       return CURLE_OUT_OF_MEMORY;
@@ -2216,7 +2216,7 @@ static CURLcode parse_proxy(struct Curl_easy *data,
     goto error;
 
   if(proxyuser || proxypasswd) {
-    free(proxyinfo->user);
+    FREE(proxyinfo->user);
     proxyinfo->user = proxyuser;
     result = Curl_setstropt(&data->state.aptr.proxyuser, proxyuser);
     proxyuser = NULL;
@@ -2224,7 +2224,7 @@ static CURLcode parse_proxy(struct Curl_easy *data,
       goto error;
     Curl_safefree(proxyinfo->passwd);
     if(!proxypasswd) {
-      proxypasswd = strdup("");
+      proxypasswd = STRDUP("");
       if(!proxypasswd) {
         result = CURLE_OUT_OF_MEMORY;
         goto error;
@@ -2245,7 +2245,7 @@ static CURLcode parse_proxy(struct Curl_easy *data,
     const char *p = portptr;
     if(!Curl_str_number(&p, &num, 0xffff))
       port = (int)num;
-    free(portptr);
+    FREE(portptr);
   }
   else {
     if(data->set.proxyport)
@@ -2282,13 +2282,13 @@ static CURLcode parse_proxy(struct Curl_easy *data,
     /* path will be "/", if no path was found */
     if(strcmp("/", path)) {
       is_unix_proxy = TRUE;
-      free(host);
+      FREE(host);
       host = aprintf(UNIX_SOCKET_PREFIX"%s", path);
       if(!host) {
         result = CURLE_OUT_OF_MEMORY;
         goto error;
       }
-      free(proxyinfo->host.rawalloc);
+      FREE(proxyinfo->host.rawalloc);
       proxyinfo->host.rawalloc = host;
       proxyinfo->host.name = host;
       host = NULL;
@@ -2297,7 +2297,7 @@ static CURLcode parse_proxy(struct Curl_easy *data,
 
   if(!is_unix_proxy) {
 #endif
-    free(proxyinfo->host.rawalloc);
+    FREE(proxyinfo->host.rawalloc);
     proxyinfo->host.rawalloc = host;
     if(host[0] == '[') {
       /* this is a numerical IPv6, strip off the brackets */
@@ -2313,12 +2313,12 @@ static CURLcode parse_proxy(struct Curl_easy *data,
 #endif
 
 error:
-  free(proxyuser);
-  free(proxypasswd);
-  free(host);
-  free(scheme);
+  FREE(proxyuser);
+  FREE(proxypasswd);
+  FREE(host);
+  FREE(scheme);
 #ifdef USE_UNIX_SOCKETS
-  free(path);
+  FREE(path);
 #endif
   curl_url_cleanup(uhp);
   return result;
@@ -2336,9 +2336,9 @@ static CURLcode parse_proxy_auth(struct Curl_easy *data,
     data->state.aptr.proxypasswd : "";
   CURLcode result = CURLE_OUT_OF_MEMORY;
 
-  conn->http_proxy.user = strdup(proxyuser);
+  conn->http_proxy.user = STRDUP(proxyuser);
   if(conn->http_proxy.user) {
-    conn->http_proxy.passwd = strdup(proxypasswd);
+    conn->http_proxy.passwd = STRDUP(proxypasswd);
     if(conn->http_proxy.passwd)
       result = CURLE_OK;
     else
@@ -2370,7 +2370,7 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
    * Detect what (if any) proxy to use
    *************************************************************/
   if(data->set.str[STRING_PROXY]) {
-    proxy = strdup(data->set.str[STRING_PROXY]);
+    proxy = STRDUP(data->set.str[STRING_PROXY]);
     /* if global proxy is set, this is it */
     if(!proxy) {
       failf(data, "memory shortage");
@@ -2380,7 +2380,7 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
   }
 
   if(data->set.str[STRING_PRE_PROXY]) {
-    socksproxy = strdup(data->set.str[STRING_PRE_PROXY]);
+    socksproxy = STRDUP(data->set.str[STRING_PRE_PROXY]);
     /* if global socks proxy is set, this is it */
     if(!socksproxy) {
       failf(data, "memory shortage");
@@ -2416,19 +2416,19 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
 #ifdef USE_UNIX_SOCKETS
   /* For the time being do not mix proxy and Unix domain sockets. See #1274 */
   if(proxy && conn->unix_domain_socket) {
-    free(proxy);
+    FREE(proxy);
     proxy = NULL;
   }
 #endif
 
   if(proxy && (!*proxy || (conn->handler->flags & PROTOPT_NONETWORK))) {
-    free(proxy);  /* Do not bother with an empty proxy string or if the
+    FREE(proxy);  /* Do not bother with an empty proxy string or if the
                      protocol does not work with network */
     proxy = NULL;
   }
   if(socksproxy && (!*socksproxy ||
                     (conn->handler->flags & PROTOPT_NONETWORK))) {
-    free(socksproxy);  /* Do not bother with an empty socks proxy string or if
+    FREE(socksproxy);  /* Do not bother with an empty socks proxy string or if
                           the protocol does not work with network */
     socksproxy = NULL;
   }
@@ -2484,7 +2484,7 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
         if(!conn->socks_proxy.user) {
           conn->socks_proxy.user = conn->http_proxy.user;
           conn->http_proxy.user = NULL;
-          free(conn->socks_proxy.passwd);
+          FREE(conn->socks_proxy.passwd);
           conn->socks_proxy.passwd = conn->http_proxy.passwd;
           conn->http_proxy.passwd = NULL;
         }
@@ -2514,8 +2514,8 @@ static CURLcode create_conn_helper_init_proxy(struct Curl_easy *data,
 
 out:
 
-  free(socksproxy);
-  free(proxy);
+  FREE(socksproxy);
+  FREE(proxy);
   return result;
 }
 #endif /* CURL_DISABLE_PROXY */
@@ -2609,8 +2609,8 @@ CURLcode Curl_parse_login_details(const char *login, const size_t len,
   *passwdp = pbuf;
   return CURLE_OK;
 error:
-  free(ubuf);
-  free(pbuf);
+  FREE(ubuf);
+  FREE(pbuf);
   return CURLE_OUT_OF_MEMORY;
 }
 
@@ -2664,8 +2664,8 @@ static CURLcode override_login(struct Curl_easy *data,
   char **optionsp = &conn->options;
 
   if(data->set.str[STRING_OPTIONS]) {
-    free(*optionsp);
-    *optionsp = strdup(data->set.str[STRING_OPTIONS]);
+    FREE(*optionsp);
+    *optionsp = STRDUP(data->set.str[STRING_OPTIONS]);
     if(!*optionsp)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -2719,14 +2719,14 @@ static CURLcode override_login(struct Curl_easy *data,
       }
     }
     if(url_provided) {
-      free(conn->user);
-      conn->user = strdup(*userp);
+      FREE(conn->user);
+      conn->user = STRDUP(*userp);
       if(!conn->user)
         return CURLE_OUT_OF_MEMORY;
     }
     /* no user was set but a password, set a blank user */
     if(!*userp && *passwdp) {
-      *userp = strdup("");
+      *userp = STRDUP("");
       if(!*userp)
         return CURLE_OUT_OF_MEMORY;
     }
@@ -2750,7 +2750,7 @@ static CURLcode override_login(struct Curl_easy *data,
     if(uc)
       return Curl_uc_to_curlcode(uc);
     if(!*userp) {
-      *userp = strdup(data->state.aptr.user);
+      *userp = STRDUP(data->state.aptr.user);
       if(!*userp)
         return CURLE_OUT_OF_MEMORY;
     }
@@ -2767,7 +2767,7 @@ static CURLcode override_login(struct Curl_easy *data,
     if(uc)
       return Curl_uc_to_curlcode(uc);
     if(!*passwdp) {
-      *passwdp = strdup(data->state.aptr.passwd);
+      *passwdp = STRDUP(data->state.aptr.passwd);
       if(!*passwdp)
         return CURLE_OUT_OF_MEMORY;
     }
@@ -2795,14 +2795,14 @@ static CURLcode set_login(struct Curl_easy *data,
   }
   /* Store the default user */
   if(!conn->user) {
-    conn->user = strdup(setuser);
+    conn->user = STRDUP(setuser);
     if(!conn->user)
       return CURLE_OUT_OF_MEMORY;
   }
 
   /* Store the default password */
   if(!conn->passwd) {
-    conn->passwd = strdup(setpasswd);
+    conn->passwd = STRDUP(setpasswd);
     if(!conn->passwd)
       result = CURLE_OUT_OF_MEMORY;
   }
@@ -2837,7 +2837,7 @@ static CURLcode parse_connect_to_host_port(struct Curl_easy *data,
   if(!host || !*host)
     return CURLE_OK;
 
-  host_dup = strdup(host);
+  host_dup = STRDUP(host);
   if(!host_dup)
     return CURLE_OUT_OF_MEMORY;
 
@@ -2899,7 +2899,7 @@ static CURLcode parse_connect_to_host_port(struct Curl_easy *data,
 
   /* now, clone the cleaned hostname */
   DEBUGASSERT(hostptr);
-  *hostname_result = strdup(hostptr);
+  *hostname_result = STRDUP(hostptr);
   if(!*hostname_result) {
     result = CURLE_OUT_OF_MEMORY;
     goto error;
@@ -2908,7 +2908,7 @@ static CURLcode parse_connect_to_host_port(struct Curl_easy *data,
   *port_result = port;
 
 error:
-  free(host_dup);
+  FREE(host_dup);
   return result;
 }
 
@@ -2947,7 +2947,7 @@ static CURLcode parse_connect_to_string(struct Curl_easy *data,
     hostname_to_match_len = strlen(hostname_to_match);
     host_match = strncasecompare(ptr, hostname_to_match,
                                  hostname_to_match_len);
-    free(hostname_to_match);
+    FREE(hostname_to_match);
     ptr += hostname_to_match_len;
 
     host_match = host_match && *ptr == ':';
@@ -3084,7 +3084,7 @@ static CURLcode parse_connect_to_slist(struct Curl_easy *data,
     }
 
     if(hit) {
-      char *hostd = strdup((char *)as->dst.host);
+      char *hostd = STRDUP((char *)as->dst.host);
       if(!hostd)
         return CURLE_OUT_OF_MEMORY;
       conn->conn_to_host.rawalloc = hostd;
@@ -3135,7 +3135,7 @@ static CURLcode resolve_unix(struct Curl_easy *data,
   /* Unix domain sockets are local. The host gets ignored, just use the
    * specified domain socket address. Do not cache "DNS entries". There is
    * no DNS involved and we already have the filesystem path available. */
-  hostaddr = calloc(1, sizeof(struct Curl_dns_entry));
+  hostaddr = CALLOC(1, sizeof(struct Curl_dns_entry));
   if(!hostaddr)
     return CURLE_OUT_OF_MEMORY;
 
@@ -3145,7 +3145,7 @@ static CURLcode resolve_unix(struct Curl_easy *data,
     if(longpath)
       /* Long paths are not supported for now */
       failf(data, "Unix socket path too long: '%s'", unix_path);
-    free(hostaddr);
+    FREE(hostaddr);
     return longpath ? CURLE_COULDNT_RESOLVE_HOST : CURLE_OUT_OF_MEMORY;
   }
 
@@ -3202,7 +3202,7 @@ static CURLcode resolve_server(struct Curl_easy *data,
   }
 
   /* Resolve target host right on */
-  conn->hostname_resolve = strdup(ehost->name);
+  conn->hostname_resolve = STRDUP(ehost->name);
   if(!conn->hostname_resolve)
     return CURLE_OUT_OF_MEMORY;
 
@@ -3238,8 +3238,8 @@ static void reuse_conn(struct Curl_easy *data,
    * be new for this request even when we reuse an existing connection */
   if(temp->user) {
     /* use the new username and password though */
-    free(existing->user);
-    free(existing->passwd);
+    FREE(existing->user);
+    FREE(existing->passwd);
     existing->user = temp->user;
     existing->passwd = temp->passwd;
     temp->user = NULL;
@@ -3250,10 +3250,10 @@ static void reuse_conn(struct Curl_easy *data,
   existing->bits.proxy_user_passwd = temp->bits.proxy_user_passwd;
   if(existing->bits.proxy_user_passwd) {
     /* use the new proxy username and proxy password though */
-    free(existing->http_proxy.user);
-    free(existing->socks_proxy.user);
-    free(existing->http_proxy.passwd);
-    free(existing->socks_proxy.passwd);
+    FREE(existing->http_proxy.user);
+    FREE(existing->socks_proxy.user);
+    FREE(existing->http_proxy.passwd);
+    FREE(existing->socks_proxy.passwd);
     existing->http_proxy.user = temp->http_proxy.user;
     existing->socks_proxy.user = temp->socks_proxy.user;
     existing->http_proxy.passwd = temp->http_proxy.passwd;
@@ -3290,7 +3290,7 @@ static void reuse_conn(struct Curl_easy *data,
   temp->conn_to_host.rawalloc = NULL;
   existing->conn_to_port = temp->conn_to_port;
   existing->remote_port = temp->remote_port;
-  free(existing->hostname_resolve);
+  FREE(existing->hostname_resolve);
   existing->hostname_resolve = temp->hostname_resolve;
   temp->hostname_resolve = NULL;
 
@@ -3363,7 +3363,7 @@ static CURLcode create_conn(struct Curl_easy *data,
     goto out;
 
   if(data->set.str[STRING_SASL_AUTHZID]) {
-    conn->sasl_authzid = strdup(data->set.str[STRING_SASL_AUTHZID]);
+    conn->sasl_authzid = STRDUP(data->set.str[STRING_SASL_AUTHZID]);
     if(!conn->sasl_authzid) {
       result = CURLE_OUT_OF_MEMORY;
       goto out;
@@ -3371,7 +3371,7 @@ static CURLcode create_conn(struct Curl_easy *data,
   }
 
   if(data->set.str[STRING_BEARER]) {
-    conn->oauth_bearer = strdup(data->set.str[STRING_BEARER]);
+    conn->oauth_bearer = STRDUP(data->set.str[STRING_BEARER]);
     if(!conn->oauth_bearer) {
       result = CURLE_OUT_OF_MEMORY;
       goto out;
@@ -3380,7 +3380,7 @@ static CURLcode create_conn(struct Curl_easy *data,
 
 #ifdef USE_UNIX_SOCKETS
   if(data->set.str[STRING_UNIX_SOCKET_PATH]) {
-    conn->unix_domain_socket = strdup(data->set.str[STRING_UNIX_SOCKET_PATH]);
+    conn->unix_domain_socket = STRDUP(data->set.str[STRING_UNIX_SOCKET_PATH]);
     if(!conn->unix_domain_socket) {
       result = CURLE_OUT_OF_MEMORY;
       goto out;
@@ -3844,7 +3844,7 @@ static void priority_remove_child(struct Curl_easy *parent,
   DEBUGASSERT(pnode);
   if(pnode) {
     *pnext = pnode->next;
-    free(pnode);
+    FREE(pnode);
   }
 
   child->set.priority.parent = 0;
@@ -3863,7 +3863,7 @@ CURLcode Curl_data_priority_add_child(struct Curl_easy *parent,
     struct Curl_data_prio_node **tail;
     struct Curl_data_prio_node *pnode;
 
-    pnode = calloc(1, sizeof(*pnode));
+    pnode = CALLOC(1, sizeof(*pnode));
     if(!pnode)
       return CURLE_OUT_OF_MEMORY;
     pnode->data = child;

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -93,16 +93,16 @@ static CURLUcode parseurl_and_replace(const char *url, CURLU *u,
 
 static void free_urlhandle(struct Curl_URL *u)
 {
-  free(u->scheme);
-  free(u->user);
-  free(u->password);
-  free(u->options);
-  free(u->host);
-  free(u->zoneid);
-  free(u->port);
-  free(u->path);
-  free(u->query);
-  free(u->fragment);
+  FREE(u->scheme);
+  FREE(u->user);
+  FREE(u->password);
+  FREE(u->options);
+  FREE(u->host);
+  FREE(u->zoneid);
+  FREE(u->port);
+  FREE(u->path);
+  FREE(u->query);
+  FREE(u->fragment);
 }
 
 /*
@@ -385,17 +385,17 @@ static CURLUcode parse_hostname_login(struct Curl_URL *u,
       result = CURLUE_USER_NOT_ALLOWED;
       goto out;
     }
-    free(u->user);
+    FREE(u->user);
     u->user = userp;
   }
 
   if(passwdp) {
-    free(u->password);
+    FREE(u->password);
     u->password = passwdp;
   }
 
   if(optionsp) {
-    free(u->options);
+    FREE(u->options);
     u->options = optionsp;
   }
 
@@ -405,9 +405,9 @@ static CURLUcode parse_hostname_login(struct Curl_URL *u,
 
 out:
 
-  free(userp);
-  free(passwdp);
-  free(optionsp);
+  FREE(userp);
+  FREE(passwdp);
+  FREE(optionsp);
   u->user = NULL;
   u->password = NULL;
   u->options = NULL;
@@ -460,7 +460,7 @@ UNITTEST CURLUcode Curl_parse_port(struct Curl_URL *u, struct dynbuf *host,
 
     u->portnum = (unsigned short) port;
     /* generate a new port number string to get rid of leading zeroes etc */
-    free(u->port);
+    FREE(u->port);
     u->port = aprintf("%" CURL_FORMAT_CURL_OFF_T, port);
     if(!u->port)
       return CURLUE_OUT_OF_MEMORY;
@@ -498,7 +498,7 @@ static CURLUcode ipv6_parse(struct Curl_URL *u, char *hostname,
       if(!i || (']' != *h))
         return CURLUE_BAD_IPV6;
       zoneid[i] = 0;
-      u->zoneid = strdup(zoneid);
+      u->zoneid = STRDUP(zoneid);
       if(!u->zoneid)
         return CURLUE_OUT_OF_MEMORY;
       hostname[len] = ']'; /* insert end bracket */
@@ -676,7 +676,7 @@ static CURLUcode urldecode_host(struct dynbuf *host)
       return CURLUE_BAD_HOSTNAME;
     Curl_dyn_reset(host);
     result = Curl_dyn_addn(host, decoded, dlen);
-    free(decoded);
+    FREE(decoded);
     if(result)
       return cc2cu(result);
   }
@@ -751,7 +751,7 @@ CURLUcode Curl_url_set_authority(CURLU *u, const char *authority)
   if(result)
     Curl_dyn_free(&host);
   else {
-    free(u->host);
+    FREE(u->host);
     u->host = Curl_dyn_ptr(&host);
   }
   return result;
@@ -895,7 +895,7 @@ end:
     if(Curl_dyn_len(&out))
       *outp = Curl_dyn_ptr(&out);
     else {
-      *outp = strdup("");
+      *outp = STRDUP("");
       if(!*outp)
         return 1;
     }
@@ -941,7 +941,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
     path = &url[5];
     pathlen = urllen - 5;
 
-    u->scheme = strdup("file");
+    u->scheme = STRDUP("file");
     if(!u->scheme) {
       result = CURLUE_OUT_OF_MEMORY;
       goto fail;
@@ -1088,7 +1088,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
     }
 
     if(schemep) {
-      u->scheme = strdup(schemep);
+      u->scheme = STRDUP(schemep);
       if(!u->scheme) {
         result = CURLUE_OUT_OF_MEMORY;
         goto fail;
@@ -1125,7 +1125,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
         else
           schemep = "http";
 
-        u->scheme = strdup(schemep);
+        u->scheme = STRDUP(schemep);
         if(!u->scheme) {
           result = CURLUE_OUT_OF_MEMORY;
           goto fail;
@@ -1198,7 +1198,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
     }
     else {
       /* single byte query */
-      u->query = strdup("");
+      u->query = STRDUP("");
       if(!u->query) {
         result = CURLUE_OUT_OF_MEMORY;
         goto fail;
@@ -1242,7 +1242,7 @@ static CURLUcode parseurl(const char *url, CURLU *u, unsigned int flags)
         goto fail;
       }
       if(dedot) {
-        free(u->path);
+        FREE(u->path);
         u->path = dedot;
       }
     }
@@ -1278,21 +1278,21 @@ static CURLUcode parseurl_and_replace(const char *url, CURLU *u,
  */
 CURLU *curl_url(void)
 {
-  return calloc(1, sizeof(struct Curl_URL));
+  return CALLOC(1, sizeof(struct Curl_URL));
 }
 
 void curl_url_cleanup(CURLU *u)
 {
   if(u) {
     free_urlhandle(u);
-    free(u);
+    FREE(u);
   }
 }
 
 #define DUP(dest, src, name)                    \
   do {                                          \
     if(src->name) {                             \
-      dest->name = strdup(src->name);           \
+      dest->name = STRDUP(src->name);           \
       if(!dest->name)                           \
         goto fail;                              \
     }                                           \
@@ -1300,7 +1300,7 @@ void curl_url_cleanup(CURLU *u)
 
 CURLU *curl_url_dup(const CURLU *in)
 {
-  struct Curl_URL *u = calloc(1, sizeof(struct Curl_URL));
+  struct Curl_URL *u = CALLOC(1, sizeof(struct Curl_URL));
   if(u) {
     DUP(u, in, scheme);
     DUP(u, in, user);
@@ -1529,7 +1529,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
                     u->query ? u->query : "",
                     show_fragment ? "#": "",
                     u->fragment ? u->fragment : "");
-      free(allochost);
+      FREE(allochost);
     }
     if(!url)
       return CURLUE_OUT_OF_MEMORY;
@@ -1560,7 +1560,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
       /* this unconditional rejection of control bytes is documented
          API behavior */
       CURLcode res = Curl_urldecode(*part, 0, &decoded, &dlen, REJECT_CTRL);
-      free(*part);
+      FREE(*part);
       if(res) {
         *part = NULL;
         return CURLUE_URLDECODE;
@@ -1575,7 +1575,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
       uc = urlencode_str(&enc, *part, partlen, TRUE, what == CURLUPART_QUERY);
       if(uc)
         return uc;
-      free(*part);
+      FREE(*part);
       *part = Curl_dyn_ptr(&enc);
     }
     else if(punycode) {
@@ -1588,7 +1588,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
         if(result)
           return (result == CURLE_OUT_OF_MEMORY) ?
             CURLUE_OUT_OF_MEMORY : CURLUE_BAD_HOSTNAME;
-        free(*part);
+        FREE(*part);
         *part = allochost;
 #endif
       }
@@ -1603,7 +1603,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
         if(result)
           return (result == CURLE_OUT_OF_MEMORY) ?
             CURLUE_OUT_OF_MEMORY : CURLUE_BAD_HOSTNAME;
-        free(*part);
+        FREE(*part);
         *part = allochost;
 #endif
       }
@@ -1741,7 +1741,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
       tmp = aprintf("%" CURL_FORMAT_CURL_OFF_T, port);
       if(!tmp)
         return CURLUE_OUT_OF_MEMORY;
-      free(u->port);
+      FREE(u->port);
       u->port = tmp;
       u->portnum = (unsigned short)port;
       return CURLUE_OK;
@@ -1786,7 +1786,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
     DEBUGASSERT(oldurl); /* it is set here */
     /* apply the relative part to create a new URL */
     uc = redirect_url(oldurl, part, u, flags);
-    free(oldurl);
+    FREE(oldurl);
     return uc;
   }
   default:
@@ -1873,7 +1873,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
         if(Curl_dyn_add(&qbuf, newp))
           goto nomem;
         Curl_dyn_free(&enc);
-        free(*storep);
+        FREE(*storep);
         *storep = Curl_dyn_ptr(&qbuf);
         return CURLUE_OK;
 nomem:
@@ -1900,7 +1900,7 @@ nomem:
             Curl_urldecode(newp, n, &decoded, &dlen, REJECT_CTRL);
           if(result || hostname_check(u, decoded, dlen))
             bad = TRUE;
-          free(decoded);
+          FREE(decoded);
         }
         else if(hostname_check(u, (char *)CURL_UNCONST(newp), n))
           bad = TRUE;
@@ -1911,7 +1911,7 @@ nomem:
       }
     }
 
-    free(*storep);
+    FREE(*storep);
     *storep = (char *)CURL_UNCONST(newp);
   }
   return CURLUE_OK;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -515,7 +515,7 @@ struct ConnectBits {
   BIT(abstract_unix_socket);
 #endif
   BIT(sock_accepted); /* TRUE if the SECONDARYSOCKET was created with
-                         accept() */
+                         ACCEPT() */
   BIT(parallel_connect); /* set TRUE when a parallel connect attempt has
                             started (happy eyeballs) */
   BIT(aborted); /* connection was aborted, e.g. in unclean state */
@@ -757,7 +757,7 @@ struct connectdata {
   struct Curl_llist_node cpool_node; /* conncache lists */
   struct Curl_llist_node cshutdn_node; /* cshutdn list */
 
-  curl_closesocket_callback fclosesocket; /* function closing the socket(s) */
+  curl_closesocket_callback fclosesocket; /* function closing the SOCKET(s) */
   void *closesocket_client;
 
   /* This is used by the connection pool logic. If this returns TRUE, this
@@ -1189,7 +1189,7 @@ struct UrlState {
   /* hostname, port number and protocol of the first (not followed) request.
      if set, this should be the hostname that we will sent authorization to,
      no else. Used to make Location: following not keep sending user+password.
-     This is strdup()ed data. */
+     This is STRDUP()ed data. */
   char *first_host;
   int first_remote_port;
   curl_prot_t first_remote_protocol;
@@ -1338,7 +1338,7 @@ struct UrlState {
   BIT(disableexpect);    /* TRUE if Expect: is disabled due to a previous
                             417 response */
   BIT(use_range);
-  BIT(rangestringalloc); /* the range string is malloc()'ed */
+  BIT(rangestringalloc); /* the range string is MALLOC()'ed */
   BIT(done); /* set to FALSE when Curl_init_do() is called and set to TRUE
                 when multi_done() is called, to prevent multi_done() to get
                 invoked twice when the multi interface is used. */
@@ -1349,8 +1349,8 @@ struct UrlState {
 #ifdef CURL_LIST_ONLY_PROTOCOL
   BIT(list_only);      /* list directory contents */
 #endif
-  BIT(url_alloc);   /* URL string is malloc()'ed */
-  BIT(referer_alloc); /* referer string is malloc()ed */
+  BIT(url_alloc);   /* URL string is MALLOC()'ed */
+  BIT(referer_alloc); /* referer string is MALLOC()ed */
   BIT(wildcard_resolve); /* Set to true if any resolve change is a wildcard */
   BIT(upload);         /* upload request */
   BIT(internal); /* internal: true if this easy handle was created for

--- a/lib/vauth/.checksrc
+++ b/lib/vauth/.checksrc
@@ -1,3 +1,20 @@
 banfunc strerror
 banfunc strncpy
 banfunc sscanf
+banfunc snprintf
+banfunc vsnprint
+banfunc strtoul
+banfunc strtol
+banfunc strtok_r
+# the ones we use UPPERCASE:
+banfunc strdup
+banfunc malloc
+banfunc calloc
+banfunc realloc
+banfunc socket
+banfunc send
+banfunc recv
+banfunc accept
+banfunc fopen
+banfunc fdopen
+banfunc fclose

--- a/lib/vauth/cleartext.c
+++ b/lib/vauth/cleartext.c
@@ -79,7 +79,7 @@ CURLcode Curl_auth_create_plain_message(const char *authzid,
     return CURLE_OUT_OF_MEMORY;
   plainlen = zlen + clen + plen + 2;
 
-  plainauth = malloc(plainlen + 1);
+  plainauth = MALLOC(plainlen + 1);
   if(!plainauth)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -176,7 +176,7 @@ static char *auth_digest_string_quoted(const char *source)
     ++s;
   }
 
-  dest = malloc(n);
+  dest = MALLOC(n);
   if(dest) {
     char *d = dest;
     s = source;
@@ -415,7 +415,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   /* Calculate H(A2) */
   ctxt = Curl_MD5_init(&Curl_DIGEST_MD5);
   if(!ctxt) {
-    free(spn);
+    FREE(spn);
 
     return CURLE_OUT_OF_MEMORY;
   }
@@ -433,7 +433,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   /* Now calculate the response hash */
   ctxt = Curl_MD5_init(&Curl_DIGEST_MD5);
   if(!ctxt) {
-    free(spn);
+    FREE(spn);
 
     return CURLE_OUT_OF_MEMORY;
   }
@@ -466,7 +466,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
                      "qop=%s",
                      userp, realm, nonce,
                      cnonce, nonceCount, spn, resp_hash_hex, qop);
-  free(spn);
+  FREE(spn);
   if(!response)
     return CURLE_OUT_OF_MEMORY;
 
@@ -511,8 +511,8 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
     /* Extract a value=content pair */
     if(Curl_auth_digest_get_pair(chlg, value, content, &chlg)) {
       if(strcasecompare(value, "nonce")) {
-        free(digest->nonce);
-        digest->nonce = strdup(content);
+        FREE(digest->nonce);
+        digest->nonce = STRDUP(content);
         if(!digest->nonce)
           return CURLE_OUT_OF_MEMORY;
       }
@@ -523,14 +523,14 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
         }
       }
       else if(strcasecompare(value, "realm")) {
-        free(digest->realm);
-        digest->realm = strdup(content);
+        FREE(digest->realm);
+        digest->realm = STRDUP(content);
         if(!digest->realm)
           return CURLE_OUT_OF_MEMORY;
       }
       else if(strcasecompare(value, "opaque")) {
-        free(digest->opaque);
-        digest->opaque = strdup(content);
+        FREE(digest->opaque);
+        digest->opaque = STRDUP(content);
         if(!digest->opaque)
           return CURLE_OUT_OF_MEMORY;
       }
@@ -556,21 +556,21 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 
         /* Select only auth or auth-int. Otherwise, ignore */
         if(foundAuth) {
-          free(digest->qop);
-          digest->qop = strdup(DIGEST_QOP_VALUE_STRING_AUTH);
+          FREE(digest->qop);
+          digest->qop = STRDUP(DIGEST_QOP_VALUE_STRING_AUTH);
           if(!digest->qop)
             return CURLE_OUT_OF_MEMORY;
         }
         else if(foundAuthInt) {
-          free(digest->qop);
-          digest->qop = strdup(DIGEST_QOP_VALUE_STRING_AUTH_INT);
+          FREE(digest->qop);
+          digest->qop = STRDUP(DIGEST_QOP_VALUE_STRING_AUTH_INT);
           if(!digest->qop)
             return CURLE_OUT_OF_MEMORY;
         }
       }
       else if(strcasecompare(value, "algorithm")) {
-        free(digest->algorithm);
-        digest->algorithm = strdup(content);
+        FREE(digest->algorithm);
+        digest->algorithm = STRDUP(content);
         if(!digest->algorithm)
           return CURLE_OUT_OF_MEMORY;
 
@@ -713,7 +713,7 @@ static CURLcode auth_create_digest_http_message(
       return CURLE_OUT_OF_MEMORY;
 
     result = hash(hashbuf, (unsigned char *) hashthis, strlen(hashthis));
-    free(hashthis);
+    FREE(hashthis);
     if(result)
       return result;
     convert_to_ascii(hashbuf, (unsigned char *)userh);
@@ -736,7 +736,7 @@ static CURLcode auth_create_digest_http_message(
     return CURLE_OUT_OF_MEMORY;
 
   result = hash(hashbuf, (unsigned char *) hashthis, strlen(hashthis));
-  free(hashthis);
+  FREE(hashthis);
   if(result)
     return result;
   convert_to_ascii(hashbuf, ha1);
@@ -748,7 +748,7 @@ static CURLcode auth_create_digest_http_message(
       return CURLE_OUT_OF_MEMORY;
 
     result = hash(hashbuf, (unsigned char *) tmp, strlen(tmp));
-    free(tmp);
+    FREE(tmp);
     if(result)
       return result;
     convert_to_ascii(hashbuf, ha1);
@@ -778,13 +778,13 @@ static CURLcode auth_create_digest_http_message(
 
     result = hash(hashbuf, (const unsigned char *)"", 0);
     if(result) {
-      free(hashthis);
+      FREE(hashthis);
       return result;
     }
     convert_to_ascii(hashbuf, (unsigned char *)hashed);
 
     hashthis2 = aprintf("%s:%s", hashthis, hashed);
-    free(hashthis);
+    FREE(hashthis);
     hashthis = hashthis2;
   }
 
@@ -792,7 +792,7 @@ static CURLcode auth_create_digest_http_message(
     return CURLE_OUT_OF_MEMORY;
 
   result = hash(hashbuf, (unsigned char *) hashthis, strlen(hashthis));
-  free(hashthis);
+  FREE(hashthis);
   if(result)
     return result;
   convert_to_ascii(hashbuf, ha2);
@@ -809,7 +809,7 @@ static CURLcode auth_create_digest_http_message(
     return CURLE_OUT_OF_MEMORY;
 
   result = hash(hashbuf, (unsigned char *) hashthis, strlen(hashthis));
-  free(hashthis);
+  FREE(hashthis);
   if(result)
     return result;
   convert_to_ascii(hashbuf, request_digest);
@@ -833,18 +833,18 @@ static CURLcode auth_create_digest_http_message(
   if(digest->realm)
     realm_quoted = auth_digest_string_quoted(digest->realm);
   else {
-    realm_quoted = malloc(1);
+    realm_quoted = MALLOC(1);
     if(realm_quoted)
       realm_quoted[0] = 0;
   }
   if(!realm_quoted) {
-    free(userp_quoted);
+    FREE(userp_quoted);
     return CURLE_OUT_OF_MEMORY;
   }
   nonce_quoted = auth_digest_string_quoted(digest->nonce);
   if(!nonce_quoted) {
-    free(realm_quoted);
-    free(userp_quoted);
+    FREE(realm_quoted);
+    FREE(userp_quoted);
     return CURLE_OUT_OF_MEMORY;
   }
 
@@ -881,9 +881,9 @@ static CURLcode auth_create_digest_http_message(
                        uripath,
                        request_digest);
   }
-  free(nonce_quoted);
-  free(realm_quoted);
-  free(userp_quoted);
+  FREE(nonce_quoted);
+  FREE(realm_quoted);
+  FREE(userp_quoted);
   if(!response)
     return CURLE_OUT_OF_MEMORY;
 
@@ -893,12 +893,12 @@ static CURLcode auth_create_digest_http_message(
     /* Append the opaque */
     opaque_quoted = auth_digest_string_quoted(digest->opaque);
     if(!opaque_quoted) {
-      free(response);
+      FREE(response);
       return CURLE_OUT_OF_MEMORY;
     }
     tmp = aprintf("%s, opaque=\"%s\"", response, opaque_quoted);
-    free(response);
-    free(opaque_quoted);
+    FREE(response);
+    FREE(opaque_quoted);
     if(!tmp)
       return CURLE_OUT_OF_MEMORY;
 
@@ -908,7 +908,7 @@ static CURLcode auth_create_digest_http_message(
   if(digest->algorithm) {
     /* Append the algorithm */
     tmp = aprintf("%s, algorithm=%s", response, digest->algorithm);
-    free(response);
+    FREE(response);
     if(!tmp)
       return CURLE_OUT_OF_MEMORY;
 
@@ -918,7 +918,7 @@ static CURLcode auth_create_digest_http_message(
   if(digest->userhash) {
     /* Append the userhash */
     tmp = aprintf("%s, userhash=true", response);
-    free(response);
+    FREE(response);
     if(!tmp)
       return CURLE_OUT_OF_MEMORY;
 

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -136,14 +136,14 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   Curl_pSecFn->FreeContextBuffer(SecurityPackage);
 
   /* Allocate our response buffer */
-  output_token = malloc(token_max);
+  output_token = MALLOC(token_max);
   if(!output_token)
     return CURLE_OUT_OF_MEMORY;
 
   /* Generate our SPN */
   spn = Curl_auth_build_spn(service, data->conn->host.name, NULL);
   if(!spn) {
-    free(output_token);
+    FREE(output_token);
     return CURLE_OUT_OF_MEMORY;
   }
 
@@ -151,8 +151,8 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
     /* Populate our identity structure */
     result = Curl_create_sspi_identity(userp, passwdp, &identity);
     if(result) {
-      free(spn);
-      free(output_token);
+      FREE(spn);
+      FREE(output_token);
       return result;
     }
 
@@ -172,8 +172,8 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
 
   if(status != SEC_E_OK) {
     Curl_sspi_free_identity(p_identity);
-    free(spn);
-    free(output_token);
+    FREE(spn);
+    FREE(output_token);
     return CURLE_LOGIN_DENIED;
   }
 
@@ -209,8 +209,8 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
 
     Curl_pSecFn->FreeCredentialsHandle(&credentials);
     Curl_sspi_free_identity(p_identity);
-    free(spn);
-    free(output_token);
+    FREE(spn);
+    FREE(output_token);
 
     if(status == SEC_E_INSUFFICIENT_MEMORY)
       return CURLE_OUT_OF_MEMORY;
@@ -234,7 +234,7 @@ CURLcode Curl_auth_create_digest_md5_message(struct Curl_easy *data,
   Curl_sspi_free_identity(p_identity);
 
   /* Free the SPN */
-  free(spn);
+  FREE(spn);
 
   return result;
 }
@@ -283,7 +283,7 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
             return CURLE_OUT_OF_MEMORY;
           }
 
-          free(identity->Domain);
+          FREE(identity->Domain);
           identity->Domain = dup_domain.tbyte_ptr;
           identity->DomainLength = curlx_uztoul(_tcslen(dup_domain.tchar_ptr));
           dup_domain.tchar_ptr = NULL;
@@ -430,7 +430,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
 
   /* Allocate the output buffer according to the max token size as indicated
      by the security package */
-  output_token = malloc(token_max);
+  output_token = MALLOC(token_max);
   if(!output_token) {
     return CURLE_OUT_OF_MEMORY;
   }
@@ -498,14 +498,14 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     if(userp && *userp) {
       /* Populate our identity structure */
       if(Curl_create_sspi_identity(userp, passwdp, &identity)) {
-        free(output_token);
+        FREE(output_token);
         return CURLE_OUT_OF_MEMORY;
       }
 
       /* Populate our identity domain */
       if(Curl_override_sspi_http_realm((const char *) digest->input_token,
                                        &identity)) {
-        free(output_token);
+        FREE(output_token);
         return CURLE_OUT_OF_MEMORY;
       }
 
@@ -517,19 +517,19 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
       p_identity = NULL;
 
     if(userp) {
-      digest->user = strdup(userp);
+      digest->user = STRDUP(userp);
 
       if(!digest->user) {
-        free(output_token);
+        FREE(output_token);
         return CURLE_OUT_OF_MEMORY;
       }
     }
 
     if(passwdp) {
-      digest->passwd = strdup(passwdp);
+      digest->passwd = STRDUP(passwdp);
 
       if(!digest->passwd) {
-        free(output_token);
+        FREE(output_token);
         Curl_safefree(digest->user);
         return CURLE_OUT_OF_MEMORY;
       }
@@ -543,7 +543,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
                                    &credentials, &expiry);
     if(status != SEC_E_OK) {
       Curl_sspi_free_identity(p_identity);
-      free(output_token);
+      FREE(output_token);
 
       return CURLE_LOGIN_DENIED;
     }
@@ -575,17 +575,17 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
       Curl_pSecFn->FreeCredentialsHandle(&credentials);
 
       Curl_sspi_free_identity(p_identity);
-      free(output_token);
+      FREE(output_token);
 
       return CURLE_OUT_OF_MEMORY;
     }
 
     /* Allocate our new context handle */
-    digest->http_context = calloc(1, sizeof(CtxtHandle));
+    digest->http_context = CALLOC(1, sizeof(CtxtHandle));
     if(!digest->http_context) {
       curlx_unicodefree(spn);
       Curl_sspi_free_identity(p_identity);
-      free(output_token);
+      FREE(output_token);
       return CURLE_OUT_OF_MEMORY;
     }
 
@@ -609,7 +609,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
       Curl_pSecFn->FreeCredentialsHandle(&credentials);
 
       Curl_sspi_free_identity(p_identity);
-      free(output_token);
+      FREE(output_token);
 
       Curl_safefree(digest->http_context);
 
@@ -630,9 +630,9 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
     Curl_sspi_free_identity(p_identity);
   }
 
-  resp = malloc(output_token_len + 1);
+  resp = MALLOC(output_token_len + 1);
   if(!resp) {
-    free(output_token);
+    FREE(output_token);
 
     return CURLE_OUT_OF_MEMORY;
   }
@@ -646,7 +646,7 @@ CURLcode Curl_auth_create_digest_http_message(struct Curl_easy *data,
   *outlen = output_token_len;
 
   /* Free the response buffer */
-  free(output_token);
+  FREE(output_token);
 
   return CURLE_OK;
 }

--- a/lib/vauth/krb5_gssapi.c
+++ b/lib/vauth/krb5_gssapi.c
@@ -120,12 +120,12 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
       Curl_gss_log_error(data, "gss_import_name() failed: ",
                          major_status, minor_status);
 
-      free(spn);
+      FREE(spn);
 
       return CURLE_AUTH_ERROR;
     }
 
-    free(spn);
+    FREE(spn);
   }
 
   if(chlg) {
@@ -257,7 +257,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   messagelen = 4;
   if(authzid)
     messagelen += strlen(authzid);
-  message = malloc(messagelen);
+  message = MALLOC(messagelen);
   if(!message)
     return CURLE_OUT_OF_MEMORY;
 
@@ -284,7 +284,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   if(GSS_ERROR(major_status)) {
     Curl_gss_log_error(data, "gss_wrap() failed: ",
                        major_status, minor_status);
-    free(message);
+    FREE(message);
     return CURLE_AUTH_ERROR;
   }
 
@@ -294,7 +294,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   gss_release_buffer(&unused_status, &output_token);
 
   /* Free the message buffer */
-  free(message);
+  FREE(message);
 
   return result;
 }

--- a/lib/vauth/krb5_sspi.c
+++ b/lib/vauth/krb5_sspi.c
@@ -132,7 +132,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
     Curl_pSecFn->FreeContextBuffer(SecurityPackage);
 
     /* Allocate our response buffer */
-    krb5->output_token = malloc(krb5->token_max);
+    krb5->output_token = MALLOC(krb5->token_max);
     if(!krb5->output_token)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -153,7 +153,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
       krb5->p_identity = NULL;
 
     /* Allocate our credentials handle */
-    krb5->credentials = calloc(1, sizeof(CredHandle));
+    krb5->credentials = CALLOC(1, sizeof(CredHandle));
     if(!krb5->credentials)
       return CURLE_OUT_OF_MEMORY;
 
@@ -167,7 +167,7 @@ CURLcode Curl_auth_create_gssapi_user_message(struct Curl_easy *data,
       return CURLE_LOGIN_DENIED;
 
     /* Allocate our new context handle */
-    krb5->context = calloc(1, sizeof(CtxtHandle));
+    krb5->context = CALLOC(1, sizeof(CtxtHandle));
     if(!krb5->context)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -340,7 +340,7 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   }
 
   /* Allocate the trailer */
-  trailer = malloc(sizes.cbSecurityTrailer);
+  trailer = MALLOC(sizes.cbSecurityTrailer);
   if(!trailer)
     return CURLE_OUT_OF_MEMORY;
 
@@ -348,9 +348,9 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   messagelen = 4;
   if(authzid)
     messagelen += strlen(authzid);
-  message = malloc(messagelen);
+  message = MALLOC(messagelen);
   if(!message) {
-    free(trailer);
+    FREE(trailer);
 
     return CURLE_OUT_OF_MEMORY;
   }
@@ -368,10 +368,10 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
     memcpy(message + 4, authzid, messagelen - 4);
 
   /* Allocate the padding */
-  padding = malloc(sizes.cbBlockSize);
+  padding = MALLOC(sizes.cbBlockSize);
   if(!padding) {
-    free(message);
-    free(trailer);
+    FREE(message);
+    FREE(trailer);
 
     return CURLE_OUT_OF_MEMORY;
   }
@@ -394,9 +394,9 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   status = Curl_pSecFn->EncryptMessage(krb5->context, KERB_WRAP_NO_ENCRYPT,
                                     &wrap_desc, 0);
   if(status != SEC_E_OK) {
-    free(padding);
-    free(message);
-    free(trailer);
+    FREE(padding);
+    FREE(message);
+    FREE(trailer);
 
     if(status == SEC_E_INSUFFICIENT_MEMORY)
       return CURLE_OUT_OF_MEMORY;
@@ -407,11 +407,11 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   /* Allocate the encryption (wrap) buffer */
   appdatalen = wrap_buf[0].cbBuffer + wrap_buf[1].cbBuffer +
                wrap_buf[2].cbBuffer;
-  appdata = malloc(appdatalen);
+  appdata = MALLOC(appdatalen);
   if(!appdata) {
-    free(padding);
-    free(message);
-    free(trailer);
+    FREE(padding);
+    FREE(message);
+    FREE(trailer);
 
     return CURLE_OUT_OF_MEMORY;
   }
@@ -424,9 +424,9 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
   memcpy(appdata + offset, wrap_buf[2].pvBuffer, wrap_buf[2].cbBuffer);
 
   /* Free all of our local buffers */
-  free(padding);
-  free(message);
-  free(trailer);
+  FREE(padding);
+  FREE(message);
+  FREE(trailer);
 
   /* Return the response. */
   Curl_bufref_set(out, appdata, appdatalen, curl_free);
@@ -448,14 +448,14 @@ void Curl_auth_cleanup_gssapi(struct kerberos5data *krb5)
   /* Free our security context */
   if(krb5->context) {
     Curl_pSecFn->DeleteSecurityContext(krb5->context);
-    free(krb5->context);
+    FREE(krb5->context);
     krb5->context = NULL;
   }
 
   /* Free our credentials handle */
   if(krb5->credentials) {
     Curl_pSecFn->FreeCredentialsHandle(krb5->credentials);
-    free(krb5->credentials);
+    FREE(krb5->credentials);
     krb5->credentials = NULL;
   }
 

--- a/lib/vauth/ntlm.c
+++ b/lib/vauth/ntlm.c
@@ -284,7 +284,7 @@ static CURLcode ntlm_decode_type2_target(struct Curl_easy *data,
         return CURLE_BAD_CONTENT_ENCODING;
       }
 
-      free(ntlm->target_info); /* replace any previous data */
+      FREE(ntlm->target_info); /* replace any previous data */
       ntlm->target_info = Curl_memdup(&type2[target_info_offset],
                                       target_info_len);
       if(!ntlm->target_info)
@@ -798,7 +798,7 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
     ntlm_print_hex(stderr, (char *)&ntlmbuf[ntrespoff], ntresplen);
   });
 
-  free(ntlmv2resp);/* Free the dynamic buffer allocated for NTLMv2 */
+  FREE(ntlmv2resp);/* Free the dynamic buffer allocated for NTLMv2 */
 
   DEBUG_OUT({
     fprintf(stderr, "\n   flags=0x%02.2x%02.2x%02.2x%02.2x 0x%08.8x ",

--- a/lib/vauth/ntlm_sspi.c
+++ b/lib/vauth/ntlm_sspi.c
@@ -118,7 +118,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
   Curl_pSecFn->FreeContextBuffer(SecurityPackage);
 
   /* Allocate our output buffer */
-  ntlm->output_token = malloc(ntlm->token_max);
+  ntlm->output_token = MALLOC(ntlm->token_max);
   if(!ntlm->output_token)
     return CURLE_OUT_OF_MEMORY;
 
@@ -138,7 +138,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
     ntlm->p_identity = NULL;
 
   /* Allocate our credentials handle */
-  ntlm->credentials = calloc(1, sizeof(CredHandle));
+  ntlm->credentials = CALLOC(1, sizeof(CredHandle));
   if(!ntlm->credentials)
     return CURLE_OUT_OF_MEMORY;
 
@@ -152,7 +152,7 @@ CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
     return CURLE_LOGIN_DENIED;
 
   /* Allocate our new context handle */
-  ntlm->context = calloc(1, sizeof(CtxtHandle));
+  ntlm->context = CALLOC(1, sizeof(CtxtHandle));
   if(!ntlm->context)
     return CURLE_OUT_OF_MEMORY;
 
@@ -346,14 +346,14 @@ void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm)
   /* Free our security context */
   if(ntlm->context) {
     Curl_pSecFn->DeleteSecurityContext(ntlm->context);
-    free(ntlm->context);
+    FREE(ntlm->context);
     ntlm->context = NULL;
   }
 
   /* Free our credentials handle */
   if(ntlm->credentials) {
     Curl_pSecFn->FreeCredentialsHandle(ntlm->credentials);
-    free(ntlm->credentials);
+    FREE(ntlm->credentials);
     ntlm->credentials = NULL;
   }
 

--- a/lib/vauth/spnego_gssapi.c
+++ b/lib/vauth/spnego_gssapi.c
@@ -128,12 +128,12 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
       Curl_gss_log_error(data, "gss_import_name() failed: ",
                          major_status, minor_status);
 
-      free(spn);
+      FREE(spn);
 
       return CURLE_AUTH_ERROR;
     }
 
-    free(spn);
+    FREE(spn);
   }
 
   if(chlg64 && *chlg64) {

--- a/lib/vauth/spnego_sspi.c
+++ b/lib/vauth/spnego_sspi.c
@@ -142,7 +142,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
     Curl_pSecFn->FreeContextBuffer(SecurityPackage);
 
     /* Allocate our output buffer */
-    nego->output_token = malloc(nego->token_max);
+    nego->output_token = MALLOC(nego->token_max);
     if(!nego->output_token)
       return CURLE_OUT_OF_MEMORY;
  }
@@ -163,7 +163,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
       nego->p_identity = NULL;
 
     /* Allocate our credentials handle */
-    nego->credentials = calloc(1, sizeof(CredHandle));
+    nego->credentials = CALLOC(1, sizeof(CredHandle));
     if(!nego->credentials)
       return CURLE_OUT_OF_MEMORY;
 
@@ -178,7 +178,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
       return CURLE_AUTH_ERROR;
 
     /* Allocate our new context handle */
-    nego->context = calloc(1, sizeof(CtxtHandle));
+    nego->context = CALLOC(1, sizeof(CtxtHandle));
     if(!nego->context)
       return CURLE_OUT_OF_MEMORY;
   }
@@ -254,7 +254,7 @@ CURLcode Curl_auth_decode_spnego_message(struct Curl_easy *data,
                                                   &expiry);
 
   /* Free the decoded challenge as it is not required anymore */
-  free(chlg);
+  FREE(chlg);
 
   if(GSS_ERROR(nego->status)) {
     char buffer[STRERROR_LEN];
@@ -312,7 +312,7 @@ CURLcode Curl_auth_create_spnego_message(struct negotiatedata *nego,
                                        nego->output_token_length, outptr,
                                        outlen);
   if(!result && (!*outptr || !*outlen)) {
-    free(*outptr);
+    FREE(*outptr);
     result = CURLE_REMOTE_ACCESS_DENIED;
   }
 
@@ -334,14 +334,14 @@ void Curl_auth_cleanup_spnego(struct negotiatedata *nego)
   /* Free our security context */
   if(nego->context) {
     Curl_pSecFn->DeleteSecurityContext(nego->context);
-    free(nego->context);
+    FREE(nego->context);
     nego->context = NULL;
   }
 
   /* Free our credentials handle */
   if(nego->credentials) {
     Curl_pSecFn->FreeCredentialsHandle(nego->credentials);
-    free(nego->credentials);
+    FREE(nego->credentials);
     nego->credentials = NULL;
   }
 

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -96,7 +96,7 @@ TCHAR *Curl_auth_build_spn(const char *service, const char *host,
      must be freed by curlx_unicodefree we will dupe the result so that the
      pointer this function returns can be normally free'd. */
   tchar_spn = curlx_convert_UTF8_to_tchar(utf8_spn);
-  free(utf8_spn);
+  FREE(utf8_spn);
   if(!tchar_spn)
     return NULL;
   dupe_tchar_spn = _tcsdup(tchar_spn);

--- a/lib/vquic/.checksrc
+++ b/lib/vquic/.checksrc
@@ -1,5 +1,20 @@
 banfunc strerror
 banfunc strncpy
 banfunc sscanf
+banfunc snprintf
+banfunc vsnprint
 banfunc strtoul
 banfunc strtol
+banfunc strtok_r
+# the ones we use UPPERCASE:
+banfunc strdup
+banfunc malloc
+banfunc calloc
+banfunc realloc
+banfunc socket
+banfunc send
+banfunc recv
+banfunc accept
+banfunc fopen
+banfunc fdopen
+banfunc fclose

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -157,7 +157,7 @@ static void cf_msh3_ctx_free(struct cf_msh3_ctx *ctx)
   if(ctx && ctx->initialized) {
     Curl_hash_offt_destroy(&ctx->streams);
   }
-  free(ctx);
+  FREE(ctx);
 }
 
 static struct cf_msh3_ctx *h3_get_msh3_ctx(struct Curl_easy *data);
@@ -194,7 +194,7 @@ struct stream_ctx {
 static void h3_stream_ctx_free(struct stream_ctx *stream)
 {
   Curl_bufq_free(&stream->recvbuf);
-  free(stream);
+  FREE(stream);
 }
 
 static void h3_stream_hash_free(curl_off_t id, void *stream)
@@ -213,7 +213,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   if(stream)
     return CURLE_OK;
 
-  stream = calloc(1, sizeof(*stream));
+  stream = CALLOC(1, sizeof(*stream));
   if(!stream)
     return CURLE_OUT_OF_MEMORY;
 
@@ -663,7 +663,7 @@ static ssize_t cf_msh3_send(struct Curl_cfilter *cf, struct Curl_easy *data,
     }
 
     nheader = Curl_dynhds_count(&h2_headers);
-    nva = malloc(sizeof(MSH3_HEADER) * nheader);
+    nva = MALLOC(sizeof(MSH3_HEADER) * nheader);
     if(!nva) {
       *err = CURLE_OUT_OF_MEMORY;
       nwritten = -1;
@@ -713,7 +713,7 @@ static ssize_t cf_msh3_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
 out:
   set_quic_expire(cf, data);
-  free(nva);
+  FREE(nva);
   Curl_h1_req_parse_free(&h1);
   Curl_dynhds_free(&h2_headers);
   CF_DATA_RESTORE(cf, save);
@@ -1088,7 +1088,7 @@ CURLcode Curl_cf_msh3_create(struct Curl_cfilter **pcf,
   (void)data;
   (void)conn;
   (void)ai; /* msh3 resolves itself? */
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -182,7 +182,7 @@ static void cf_ngtcp2_ctx_free(struct cf_ngtcp2_ctx *ctx)
     Curl_hash_offt_destroy(&ctx->streams);
     Curl_ssl_peer_cleanup(&ctx->peer);
   }
-  free(ctx);
+  FREE(ctx);
 }
 
 struct pkt_io_ctx;
@@ -221,7 +221,7 @@ static void h3_stream_ctx_free(struct h3_stream_ctx *stream)
 {
   Curl_bufq_free(&stream->sendbuf);
   Curl_h1_req_parse_free(&stream->h1);
-  free(stream);
+  FREE(stream);
 }
 
 static void h3_stream_hash_free(curl_off_t id, void *stream)
@@ -243,7 +243,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   if(stream)
     return CURLE_OK;
 
-  stream = calloc(1, sizeof(*stream));
+  stream = CALLOC(1, sizeof(*stream));
   if(!stream)
     return CURLE_OUT_OF_MEMORY;
 
@@ -1466,7 +1466,7 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
   Curl_h1_req_parse_free(&stream->h1);
 
   nheader = Curl_dynhds_count(&h2_headers);
-  nva = malloc(sizeof(nghttp3_nv) * nheader);
+  nva = MALLOC(sizeof(nghttp3_nv) * nheader);
   if(!nva) {
     *err = CURLE_OUT_OF_MEMORY;
     nwritten = -1;
@@ -1545,7 +1545,7 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
   }
 
 out:
-  free(nva);
+  FREE(nva);
   Curl_dynhds_free(&h2_headers);
   return nwritten;
 }
@@ -2715,7 +2715,7 @@ CURLcode Curl_cf_ngtcp2_create(struct Curl_cfilter **pcf,
   CURLcode result;
 
   (void)data;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -319,10 +319,10 @@ static void cf_osslq_ctx_free(struct cf_osslq_ctx *ctx)
     Curl_bufcp_free(&ctx->stream_bufcp);
     Curl_hash_offt_destroy(&ctx->streams);
     Curl_ssl_peer_cleanup(&ctx->peer);
-    free(ctx->poll_items);
-    free(ctx->curl_items);
+    FREE(ctx->poll_items);
+    FREE(ctx->curl_items);
   }
-  free(ctx);
+  FREE(ctx);
 }
 
 static void cf_osslq_ctx_close(struct cf_osslq_ctx *ctx)
@@ -599,7 +599,7 @@ static void h3_stream_ctx_free(struct h3_stream_ctx *stream)
   Curl_bufq_free(&stream->sendbuf);
   Curl_bufq_free(&stream->recvbuf);
   Curl_h1_req_parse_free(&stream->h1);
-  free(stream);
+  FREE(stream);
 }
 
 static void h3_stream_hash_free(curl_off_t id, void *stream)
@@ -621,7 +621,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   if(stream)
     return CURLE_OK;
 
-  stream = calloc(1, sizeof(*stream));
+  stream = CALLOC(1, sizeof(*stream));
   if(!stream)
     return CURLE_OUT_OF_MEMORY;
 
@@ -1537,18 +1537,18 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
     if(ctx->items_max < Curl_hash_offt_count(&ctx->streams)) {
       size_t nmax = Curl_hash_offt_count(&ctx->streams);
       ctx->items_max = 0;
-      tmpptr = realloc(ctx->poll_items, nmax * sizeof(SSL_POLL_ITEM));
+      tmpptr = REALLOC(ctx->poll_items, nmax * sizeof(SSL_POLL_ITEM));
       if(!tmpptr) {
-        free(ctx->poll_items);
+        FREE(ctx->poll_items);
         ctx->poll_items = NULL;
         res = CURLE_OUT_OF_MEMORY;
         goto out;
       }
       ctx->poll_items = tmpptr;
 
-      tmpptr = realloc(ctx->curl_items, nmax * sizeof(struct Curl_easy *));
+      tmpptr = REALLOC(ctx->curl_items, nmax * sizeof(struct Curl_easy *));
       if(!tmpptr) {
-        free(ctx->curl_items);
+        FREE(ctx->curl_items);
         ctx->curl_items = NULL;
         res = CURLE_OUT_OF_MEMORY;
         goto out;
@@ -1938,7 +1938,7 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
   Curl_h1_req_parse_free(&stream->h1);
 
   nheader = Curl_dynhds_count(&h2_headers);
-  nva = malloc(sizeof(nghttp3_nv) * nheader);
+  nva = MALLOC(sizeof(nghttp3_nv) * nheader);
   if(!nva) {
     *err = CURLE_OUT_OF_MEMORY;
     nwritten = -1;
@@ -2017,7 +2017,7 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
   }
 
 out:
-  free(nva);
+  FREE(nva);
   Curl_dynhds_free(&h2_headers);
   return nwritten;
 }
@@ -2446,7 +2446,7 @@ CURLcode Curl_cf_osslq_create(struct Curl_cfilter **pcf,
   CURLcode result;
 
   (void)data;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -144,7 +144,7 @@ static void cf_quiche_ctx_free(struct cf_quiche_ctx *ctx)
     Curl_bufcp_free(&ctx->stream_bufcp);
     Curl_hash_offt_destroy(&ctx->streams);
   }
-  free(ctx);
+  FREE(ctx);
 }
 
 static void cf_quiche_ctx_close(struct cf_quiche_ctx *ctx)
@@ -186,7 +186,7 @@ static void h3_stream_ctx_free(struct stream_ctx *stream)
 {
   Curl_bufq_free(&stream->recvbuf);
   Curl_h1_req_parse_free(&stream->h1);
-  free(stream);
+  FREE(stream);
 }
 
 static void h3_stream_hash_free(curl_off_t id, void *stream)
@@ -267,7 +267,7 @@ static CURLcode h3_data_setup(struct Curl_cfilter *cf,
   if(stream)
     return CURLE_OK;
 
-  stream = calloc(1, sizeof(*stream));
+  stream = CALLOC(1, sizeof(*stream));
   if(!stream)
     return CURLE_OUT_OF_MEMORY;
 
@@ -1049,7 +1049,7 @@ static ssize_t h3_open_stream(struct Curl_cfilter *cf,
   Curl_h1_req_parse_free(&stream->h1);
 
   nheader = Curl_dynhds_count(&h2_headers);
-  nva = malloc(sizeof(quiche_h3_header) * nheader);
+  nva = MALLOC(sizeof(quiche_h3_header) * nheader);
   if(!nva) {
     *err = CURLE_OUT_OF_MEMORY;
     nwritten = -1;
@@ -1122,7 +1122,7 @@ static ssize_t h3_open_stream(struct Curl_cfilter *cf,
   }
 
 out:
-  free(nva);
+  FREE(nva);
   Curl_dynhds_free(&h2_headers);
   return nwritten;
 }
@@ -1680,7 +1680,7 @@ CURLcode Curl_cf_quiche_create(struct Curl_cfilter **pcf,
 
   (void)data;
   (void)conn;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -185,7 +185,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
 
   *psent = 0;
 
-  while((sent = send(qctx->sockfd,
+  while((sent = SEND(qctx->sockfd,
                      (const char *)pkt, (SEND_TYPE_ARG3)pktlen, 0)) == -1 &&
         SOCKERRNO == SOCKEINTR)
     ;
@@ -195,7 +195,7 @@ static CURLcode do_sendmsg(struct Curl_cfilter *cf,
       return CURLE_AGAIN;
     }
     else {
-      failf(data, "send() returned %zd (errno %d)", sent, SOCKERRNO);
+      failf(data, "SEND() returned %zd (errno %d)", sent, SOCKERRNO);
       if(SOCKERRNO != SOCKEMSGSIZE) {
         return CURLE_SEND_ERROR;
       }

--- a/lib/vssh/.checksrc
+++ b/lib/vssh/.checksrc
@@ -1,3 +1,20 @@
 banfunc strerror
 banfunc strncpy
 banfunc sscanf
+banfunc snprintf
+banfunc vsnprint
+banfunc strtoul
+banfunc strtol
+banfunc strtok_r
+# the ones we use UPPERCASE:
+banfunc strdup
+banfunc malloc
+banfunc calloc
+banfunc realloc
+banfunc socket
+banfunc send
+banfunc recv
+banfunc accept
+banfunc fopen
+banfunc fdopen
+banfunc fclose

--- a/lib/vssh/curl_path.c
+++ b/lib/vssh/curl_path.c
@@ -57,7 +57,7 @@ CURLcode Curl_getworkingpath(struct Curl_easy *data,
      (working_path_len > 3) && (!memcmp(working_path, "/~/", 3))) {
     /* It is referenced to the home directory, so strip the leading '/~/' */
     if(Curl_dyn_addn(&npath, &working_path[3], working_path_len - 3)) {
-      free(working_path);
+      FREE(working_path);
       return CURLE_OUT_OF_MEMORY;
     }
   }
@@ -65,7 +65,7 @@ CURLcode Curl_getworkingpath(struct Curl_easy *data,
           (!strcmp("/~", working_path) ||
            ((working_path_len > 2) && !memcmp(working_path, "/~/", 3)))) {
     if(Curl_dyn_add(&npath, homedir)) {
-      free(working_path);
+      FREE(working_path);
       return CURLE_OUT_OF_MEMORY;
     }
     if(working_path_len > 2) {
@@ -80,14 +80,14 @@ CURLcode Curl_getworkingpath(struct Curl_easy *data,
 
       if(Curl_dyn_addn(&npath,
                        &working_path[copyfrom], working_path_len - copyfrom)) {
-        free(working_path);
+        FREE(working_path);
         return CURLE_OUT_OF_MEMORY;
       }
     }
   }
 
   if(Curl_dyn_len(&npath)) {
-    free(working_path);
+    FREE(working_path);
 
     /* store the pointer for the caller to receive */
     *path = Curl_dyn_ptr(&npath);

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -944,8 +944,8 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         MOVE_TO_ERROR_STATE(CURLE_COULDNT_CONNECT);
         break;
       }
-      free(data->state.most_recent_ftp_entrypath);
-      data->state.most_recent_ftp_entrypath = strdup(sshc->homedir);
+      FREE(data->state.most_recent_ftp_entrypath);
+      data->state.most_recent_ftp_entrypath = STRDUP(sshc->homedir);
       if(!data->state.most_recent_ftp_entrypath)
         return CURLE_OUT_OF_MEMORY;
 
@@ -1157,7 +1157,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
         }
 
         result = Curl_client_write(data, CLIENTWRITE_HEADER, tmp, strlen(tmp));
-        free(tmp);
+        FREE(tmp);
         if(result) {
           state(data, SSH_SFTP_CLOSE);
           sshc->nextstate = SSH_NO_STATE;
@@ -1438,7 +1438,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
           }
           result = Curl_client_write(data, CLIENTWRITE_BODY,
                                      tmpLine, sshc->readdir_len + 1);
-          free(tmpLine);
+          FREE(tmpLine);
 
           if(result) {
             state(data, SSH_STOP);
@@ -1976,7 +1976,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data, bool *block)
 }
 
 
-/* called by the multi interface to figure out what socket(s) to wait for and
+/* called by the multi interface to figure out what SOCKET(s) to wait for and
    for what actions in the DO_DONE, PERFORM and WAITPERFORM states */
 static int myssh_getsock(struct Curl_easy *data,
                          struct connectdata *conn,
@@ -2091,7 +2091,7 @@ static CURLcode myssh_setup_connection(struct Curl_easy *data,
     sshc->initialised = TRUE;
   }
 
-  data->req.p.ssh = ssh = calloc(1, sizeof(struct SSHPROTO));
+  data->req.p.ssh = ssh = CALLOC(1, sizeof(struct SSHPROTO));
   if(!ssh)
     return CURLE_OUT_OF_MEMORY;
 
@@ -2713,7 +2713,7 @@ static void sftp_quote(struct Curl_easy *data)
        current directory can be read very similar to how it is read when
        using ordinary FTP. */
     result = Curl_client_write(data, CLIENTWRITE_HEADER, tmp, strlen(tmp));
-    free(tmp);
+    FREE(tmp);
     if(result) {
       state(data, SSH_SFTP_CLOSE);
       sshc->nextstate = SSH_NO_STATE;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -192,7 +192,7 @@ kbd_callback(const char *name, int name_len, const char *instruction,
 #endif  /* CURL_LIBSSH2_DEBUG */
   if(num_prompts == 1) {
     struct connectdata *conn = data->conn;
-    responses[0].text = strdup(conn->passwd);
+    responses[0].text = STRDUP(conn->passwd);
     responses[0].length =
       responses[0].text == NULL ? 0 : curlx_uztoui(strlen(conn->passwd));
   }
@@ -610,7 +610,7 @@ static CURLcode ssh_check_fingerprint(struct Curl_easy *data)
     size_t b64_pos = 0;
 
 #ifdef LIBSSH2_HOSTKEY_HASH_SHA256
-    /* The fingerprint points to static storage (!), do not free() it. */
+    /* The fingerprint points to static storage (!), do not FREE() it. */
     fingerprint = libssh2_hostkey_hash(sshc->ssh_session,
                                        LIBSSH2_HOSTKEY_HASH_SHA256);
 #else
@@ -671,13 +671,13 @@ static CURLcode ssh_check_fingerprint(struct Curl_easy *data)
       failf(data,
             "Denied establishing ssh session: mismatch sha256 fingerprint. "
             "Remote %s is not equal to %s", fingerprint_b64, pubkey_sha256);
-      free(fingerprint_b64);
+      FREE(fingerprint_b64);
       state(data, SSH_SESSION_FREE);
       sshc->actualcode = CURLE_PEER_FAILED_VERIFICATION;
       return sshc->actualcode;
     }
 
-    free(fingerprint_b64);
+    FREE(fingerprint_b64);
 
     infof(data, "SHA256 checksum match");
   }
@@ -690,7 +690,7 @@ static CURLcode ssh_check_fingerprint(struct Curl_easy *data)
                                        LIBSSH2_HOSTKEY_HASH_MD5);
 
     if(fingerprint) {
-      /* The fingerprint points to static storage (!), do not free() it. */
+      /* The fingerprint points to static storage (!), do not FREE() it. */
       int i;
       for(i = 0; i < 16; i++) {
         msnprintf(&md5buffer[i*2], 3, "%02x", (unsigned char) fingerprint[i]);
@@ -940,7 +940,7 @@ static CURLcode sftp_quote(struct Curl_easy *data,
        current directory can be read very similar to how it is read when
        using ordinary FTP. */
     result = Curl_client_write(data, CLIENTWRITE_HEADER, tmp, strlen(tmp));
-    free(tmp);
+    FREE(tmp);
     if(!result)
       state(data, SSH_SFTP_NEXT_QUOTE);
     return result;
@@ -1251,7 +1251,7 @@ sftp_pkey_init(struct Curl_easy *data,
     sshc->rsa_pub = sshc->rsa = NULL;
 
     if(data->set.str[STRING_SSH_PRIVATE_KEY])
-      sshc->rsa = strdup(data->set.str[STRING_SSH_PRIVATE_KEY]);
+      sshc->rsa = STRDUP(data->set.str[STRING_SSH_PRIVATE_KEY]);
     else {
       /* To ponder about: should really the lib be messing about with the
          HOME environment variable etc? */
@@ -1265,7 +1265,7 @@ sftp_pkey_init(struct Curl_easy *data,
         if(!sshc->rsa)
           out_of_memory = TRUE;
         else if(stat(sshc->rsa, &sbuf)) {
-          free(sshc->rsa);
+          FREE(sshc->rsa);
           sshc->rsa = aprintf("%s/.ssh/id_dsa", home);
           if(!sshc->rsa)
             out_of_memory = TRUE;
@@ -1273,19 +1273,19 @@ sftp_pkey_init(struct Curl_easy *data,
             Curl_safefree(sshc->rsa);
           }
         }
-        free(home);
+        FREE(home);
       }
       if(!out_of_memory && !sshc->rsa) {
         /* Nothing found; try the current dir. */
-        sshc->rsa = strdup("id_rsa");
+        sshc->rsa = STRDUP("id_rsa");
         if(sshc->rsa && stat(sshc->rsa, &sbuf)) {
-          free(sshc->rsa);
-          sshc->rsa = strdup("id_dsa");
+          FREE(sshc->rsa);
+          sshc->rsa = STRDUP("id_dsa");
           if(sshc->rsa && stat(sshc->rsa, &sbuf)) {
-            free(sshc->rsa);
+            FREE(sshc->rsa);
             /* Out of guesses. Set to the empty string to avoid
              * surprising info messages. */
-            sshc->rsa = strdup("");
+            sshc->rsa = STRDUP("");
           }
         }
       }
@@ -1299,7 +1299,7 @@ sftp_pkey_init(struct Curl_easy *data,
     if(data->set.str[STRING_SSH_PUBLIC_KEY]
        /* treat empty string the same way as NULL */
        && data->set.str[STRING_SSH_PUBLIC_KEY][0]) {
-      sshc->rsa_pub = strdup(data->set.str[STRING_SSH_PUBLIC_KEY]);
+      sshc->rsa_pub = STRDUP(data->set.str[STRING_SSH_PUBLIC_KEY]);
       if(!sshc->rsa_pub)
         out_of_memory = TRUE;
     }
@@ -2002,15 +2002,15 @@ static CURLcode ssh_statemachine(struct Curl_easy *data, bool *block)
       if(rc > 0) {
         /* It seems that this string is not always NULL terminated */
         sshp->readdir_filename[rc] = '\0';
-        free(sshc->homedir);
-        sshc->homedir = strdup(sshp->readdir_filename);
+        FREE(sshc->homedir);
+        sshc->homedir = STRDUP(sshp->readdir_filename);
         if(!sshc->homedir) {
           state(data, SSH_SFTP_CLOSE);
           sshc->actualcode = CURLE_OUT_OF_MEMORY;
           break;
         }
-        free(data->state.most_recent_ftp_entrypath);
-        data->state.most_recent_ftp_entrypath = strdup(sshc->homedir);
+        FREE(data->state.most_recent_ftp_entrypath);
+        data->state.most_recent_ftp_entrypath = STRDUP(sshc->homedir);
         if(!data->state.most_recent_ftp_entrypath)
           return CURLE_OUT_OF_MEMORY;
       }
@@ -2287,7 +2287,7 @@ static CURLcode ssh_statemachine(struct Curl_easy *data, bool *block)
         }
 
         result = Curl_client_write(data, CLIENTWRITE_HEADER, tmp, strlen(tmp));
-        free(tmp);
+        FREE(tmp);
         if(result) {
           state(data, SSH_SFTP_CLOSE);
           sshc->nextstate = SSH_NO_STATE;
@@ -2893,7 +2893,7 @@ static CURLcode ssh_statemachine(struct Curl_easy *data, bool *block)
   return result;
 }
 
-/* called by the multi interface to figure out what socket(s) to wait for and
+/* called by the multi interface to figure out what SOCKET(s) to wait for and
    for what actions in the DO_DONE, PERFORM and WAITPERFORM states */
 static int ssh_getsock(struct Curl_easy *data,
                        struct connectdata *conn,
@@ -3030,7 +3030,7 @@ static CURLcode ssh_setup_connection(struct Curl_easy *data,
     sshc->initialised = TRUE;
   }
 
-  data->req.p.ssh = ssh = calloc(1, sizeof(struct SSHPROTO));
+  data->req.p.ssh = ssh = CALLOC(1, sizeof(struct SSHPROTO));
   if(!ssh)
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -342,7 +342,7 @@ static CURLcode wssh_setup_connection(struct Curl_easy *data,
   struct SSHPROTO *ssh;
   (void)conn;
 
-  data->req.p.ssh = ssh = calloc(1, sizeof(struct SSHPROTO));
+  data->req.p.ssh = ssh = CALLOC(1, sizeof(struct SSHPROTO));
   if(!ssh)
     return CURLE_OUT_OF_MEMORY;
 
@@ -876,7 +876,7 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data, bool *block)
           }
           result = Curl_client_write(data, CLIENTWRITE_BODY,
                                      line, strlen(line));
-          free(line);
+          FREE(line);
           if(result) {
             sshc->actualcode = result;
             break;

--- a/lib/vtls/.checksrc
+++ b/lib/vtls/.checksrc
@@ -1,5 +1,20 @@
 banfunc strerror
 banfunc strncpy
 banfunc sscanf
+banfunc snprintf
+banfunc vsnprint
 banfunc strtoul
 banfunc strtol
+banfunc strtok_r
+# the ones we use UPPERCASE:
+banfunc strdup
+banfunc malloc
+banfunc calloc
+banfunc realloc
+banfunc socket
+banfunc send
+banfunc recv
+banfunc accept
+banfunc fopen
+banfunc fdopen
+banfunc fclose

--- a/lib/vtls/bearssl.c
+++ b/lib/vtls/bearssl.c
@@ -130,7 +130,7 @@ static CURLcode load_cafile(struct cafile_source *source,
               || source->type == CAFILE_SOURCE_BLOB);
 
   if(source->type == CAFILE_SOURCE_PATH) {
-    fp = fopen(source->data, "rb");
+    fp = FOPEN(source->data, "rb");
     if(!fp)
       return CURLE_SSL_CACERT_BADFILE;
   }
@@ -187,7 +187,7 @@ static CURLcode load_cafile(struct cafile_source *source,
           goto fail;
         }
         new_anchors_len = ca.anchors_len + 1;
-        new_anchors = realloc(ca.anchors,
+        new_anchors = REALLOC(ca.anchors,
                               new_anchors_len * sizeof(ca.anchors[0]));
         if(!new_anchors) {
           ca.err = CURLE_OUT_OF_MEMORY;
@@ -222,7 +222,7 @@ static CURLcode load_cafile(struct cafile_source *source,
         }
 
         /* fill in trust anchor DN and public key data */
-        ta->dn.data = malloc(ta_size);
+        ta->dn.data = MALLOC(ta_size);
         if(!ta->dn.data) {
           ca.err = CURLE_OUT_OF_MEMORY;
           goto fail;
@@ -255,15 +255,15 @@ static CURLcode load_cafile(struct cafile_source *source,
 
 fail:
   if(fp)
-    fclose(fp);
+    FCLOSE(fp);
   if(ca.err == CURLE_OK) {
     *anchors = ca.anchors;
     *anchors_len = ca.anchors_len;
   }
   else {
     for(i = 0; i < ca.anchors_len; ++i)
-      free(ca.anchors[i].dn.data);
-    free(ca.anchors);
+      FREE(ca.anchors[i].dn.data);
+    FREE(ca.anchors);
   }
 
   return ca.err;
@@ -829,7 +829,7 @@ static CURLcode bearssl_connect_step3(struct Curl_cfilter *cf,
     struct Curl_ssl_session *sc_session;
     br_ssl_session_parameters *session;
 
-    session = malloc(sizeof(*session));
+    session = MALLOC(sizeof(*session));
     if(!session)
       return CURLE_OUT_OF_MEMORY;
     br_ssl_engine_get_session_parameters(&backend->ctx.eng, session);
@@ -1051,7 +1051,7 @@ static void bearssl_close(struct Curl_cfilter *cf, struct Curl_easy *data)
   backend->active = FALSE;
   if(backend->anchors) {
     for(i = 0; i < backend->anchors_len; ++i)
-      free(backend->anchors[i].dn.data);
+      FREE(backend->anchors[i].dn.data);
     Curl_safefree(backend->anchors);
   }
 }

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -207,29 +207,29 @@ static gnutls_datum_t load_file(const char *file)
   long filelen;
   void *ptr;
 
-  f = fopen(file, "rb");
+  f = FOPEN(file, "rb");
   if(!f)
     return loaded_file;
   if(fseek(f, 0, SEEK_END) != 0
      || (filelen = ftell(f)) < 0
      || fseek(f, 0, SEEK_SET) != 0
-     || !(ptr = malloc((size_t)filelen)))
+     || !(ptr = MALLOC((size_t)filelen)))
     goto out;
   if(fread(ptr, 1, (size_t)filelen, f) < (size_t)filelen) {
-    free(ptr);
+    FREE(ptr);
     goto out;
   }
 
   loaded_file.data = ptr;
   loaded_file.size = (unsigned int)filelen;
 out:
-  fclose(f);
+  FCLOSE(f);
   return loaded_file;
 }
 
 static void unload_file(gnutls_datum_t data)
 {
-  free(data.data);
+  FREE(data.data);
 }
 
 
@@ -414,14 +414,14 @@ CURLcode Curl_gtls_shared_creds_create(struct Curl_easy *data,
   int rc;
 
   *pcreds = NULL;
-  shared = calloc(1, sizeof(*shared));
+  shared = CALLOC(1, sizeof(*shared));
   if(!shared)
     return CURLE_OUT_OF_MEMORY;
 
   rc = gnutls_certificate_allocate_credentials(&shared->creds);
   if(rc != GNUTLS_E_SUCCESS) {
     failf(data, "gnutls_cert_all_cred() failed: %s", gnutls_strerror(rc));
-    free(shared);
+    FREE(shared);
     return CURLE_SSL_CONNECT_ERROR;
   }
 
@@ -449,8 +449,8 @@ void Curl_gtls_shared_creds_free(struct gtls_shared_creds **pcreds)
     --shared->refcount;
     if(!shared->refcount) {
       gnutls_certificate_free_credentials(shared->creds);
-      free(shared->CAfile);
-      free(shared);
+      FREE(shared->CAfile);
+      FREE(shared);
     }
   }
 }
@@ -602,7 +602,7 @@ static void gtls_set_cached_creds(struct Curl_cfilter *cf,
     return;
 
   if(conn_config->CAfile) {
-    sc->CAfile = strdup(conn_config->CAfile);
+    sc->CAfile = STRDUP(conn_config->CAfile);
     if(!sc->CAfile)
       return;
   }
@@ -697,7 +697,7 @@ CURLcode Curl_gtls_cache_session(struct Curl_cfilter *cf,
   if(!sdata_len) /* gnutls does this for some version combinations */
     return CURLE_OK;
 
-  sdata = malloc(sdata_len); /* get a buffer for it */
+  sdata = MALLOC(sdata_len); /* get a buffer for it */
   if(!sdata)
     return CURLE_OUT_OF_MEMORY;
 
@@ -711,7 +711,7 @@ CURLcode Curl_gtls_cache_session(struct Curl_cfilter *cf,
   if(quic_tp && quic_tp_len) {
     qtp_clone = Curl_memdup0((char *)quic_tp, quic_tp_len);
     if(!qtp_clone) {
-      free(sdata);
+      FREE(sdata);
       return CURLE_OUT_OF_MEMORY;
     }
   }
@@ -1284,7 +1284,7 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
     if(ret != GNUTLS_E_SHORT_MEMORY_BUFFER || len1 == 0)
       break; /* failed */
 
-    buff1 = malloc(len1);
+    buff1 = MALLOC(len1);
     if(!buff1)
       break; /* failed */
 

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -48,7 +48,7 @@ Curl_tls_keylog_open(void)
   if(!keylog_file_fp) {
     keylog_file_name = curl_getenv("SSLKEYLOGFILE");
     if(keylog_file_name) {
-      keylog_file_fp = fopen(keylog_file_name, FOPEN_APPENDTEXT);
+      keylog_file_fp = FOPEN(keylog_file_name, FOPEN_APPENDTEXT);
       if(keylog_file_fp) {
 #ifdef _WIN32
         if(setvbuf(keylog_file_fp, NULL, _IONBF, 0))
@@ -56,7 +56,7 @@ Curl_tls_keylog_open(void)
         if(setvbuf(keylog_file_fp, NULL, _IOLBF, 4096))
 #endif
         {
-          fclose(keylog_file_fp);
+          FCLOSE(keylog_file_fp);
           keylog_file_fp = NULL;
         }
       }
@@ -69,7 +69,7 @@ void
 Curl_tls_keylog_close(void)
 {
   if(keylog_file_fp) {
-    fclose(keylog_file_fp);
+    FCLOSE(keylog_file_fp);
     keylog_file_fp = NULL;
   }
 }

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -396,7 +396,7 @@ mbed_set_selected_ciphers(struct Curl_easy *data,
   for(i = 0; supported[i] != 0; i++);
   supported_len = i;
 
-  selected = malloc(sizeof(int) * (supported_len + 1));
+  selected = MALLOC(sizeof(int) * (supported_len + 1));
   if(!selected)
     return CURLE_OUT_OF_MEMORY;
 
@@ -474,7 +474,7 @@ add_ciphers:
   selected[count] = 0;
 
   if(count == 0) {
-    free(selected);
+    FREE(selected);
     failf(data, "mbedTLS: no supported cipher in list");
     return CURLE_SSL_CIPHER;
   }
@@ -494,7 +494,7 @@ mbed_dump_cert_info(struct Curl_easy *data, const mbedtls_x509_crt *crt)
   (void) data, (void) crt;
 #else
   const size_t bufsize = 16384;
-  char *p, *buffer = malloc(bufsize);
+  char *p, *buffer = MALLOC(bufsize);
 
   if(buffer && mbedtls_x509_crt_info(buffer, bufsize, " ", crt) > 0) {
     infof(data, "Server certificate:");
@@ -507,7 +507,7 @@ mbed_dump_cert_info(struct Curl_easy *data, const mbedtls_x509_crt *crt)
   else
     infof(data, "Unable to dump certificate information");
 
-  free(buffer);
+  FREE(buffer);
 #endif
 }
 
@@ -628,7 +628,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
       return CURLE_OUT_OF_MEMORY;
     ret = mbedtls_x509_crt_parse(&backend->cacert, newblob,
                                  ca_info_blob->len + 1);
-    free(newblob);
+    FREE(newblob);
     if(ret < 0) {
       mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
       failf(data, "Error importing ca cert blob - mbedTLS: (-0x%04X) %s",
@@ -701,7 +701,7 @@ mbed_connect_step1(struct Curl_cfilter *cf, struct Curl_easy *data)
       return CURLE_OUT_OF_MEMORY;
     ret = mbedtls_x509_crt_parse(&backend->clicert, newblob,
                                  ssl_cert_blob->len + 1);
-    free(newblob);
+    FREE(newblob);
 
     if(ret) {
       mbedtls_strerror(ret, errorbuf, sizeof(errorbuf));
@@ -1053,12 +1053,12 @@ mbed_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
       return CURLE_SSL_PINNEDPUBKEYNOTMATCH;
     }
 
-    p = calloc(1, sizeof(*p));
+    p = CALLOC(1, sizeof(*p));
 
     if(!p)
       return CURLE_OUT_OF_MEMORY;
 
-    pubkey = malloc(PUB_DER_MAX_BYTES);
+    pubkey = MALLOC(PUB_DER_MAX_BYTES);
 
     if(!pubkey) {
       result = CURLE_OUT_OF_MEMORY;
@@ -1101,8 +1101,8 @@ mbed_connect_step2(struct Curl_cfilter *cf, struct Curl_easy *data)
                                   &pubkey[PUB_DER_MAX_BYTES - size], size);
 pinnedpubkey_error:
     mbedtls_x509_crt_free(p);
-    free(p);
-    free(pubkey);
+    FREE(p);
+    FREE(pubkey);
     if(result) {
       return result;
     }
@@ -1158,7 +1158,7 @@ mbed_new_session(struct Curl_cfilter *cf, struct Curl_easy *data)
     goto out;
   }
 
-  sdata = malloc(slen);
+  sdata = MALLOC(slen);
   if(!sdata) {
     result = CURLE_OUT_OF_MEMORY;
     goto out;
@@ -1187,7 +1187,7 @@ mbed_new_session(struct Curl_cfilter *cf, struct Curl_easy *data)
 out:
   if(msession_alloced)
     mbedtls_ssl_session_free(&session);
-  free(sdata);
+  FREE(sdata);
   return result;
 }
 

--- a/lib/vtls/mbedtls_threadlock.c
+++ b/lib/vtls/mbedtls_threadlock.c
@@ -51,7 +51,7 @@ int Curl_mbedtlsthreadlock_thread_setup(void)
 {
   int i;
 
-  mutex_buf = calloc(1, NUMT * sizeof(MBEDTLS_MUTEX_T));
+  mutex_buf = CALLOC(1, NUMT * sizeof(MBEDTLS_MUTEX_T));
   if(!mutex_buf)
     return 0;     /* error, no number of threads defined */
 
@@ -85,7 +85,7 @@ int Curl_mbedtlsthreadlock_thread_cleanup(void)
       return 0; /* CloseHandle failed */
 #endif /* USE_THREADS_POSIX && HAVE_PTHREAD_H */
   }
-  free(mutex_buf);
+  FREE(mutex_buf);
   mutex_buf = NULL;
 
   return 1; /* OK */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -2961,7 +2961,7 @@ CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
       goto out;
     }
 
-    der_session_buf = der_session_ptr = malloc(der_session_size);
+    der_session_buf = der_session_ptr = MALLOC(der_session_size);
     if(!der_session_buf) {
       result = CURLE_OUT_OF_MEMORY;
       goto out;
@@ -2998,7 +2998,7 @@ CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
   }
 
 out:
-  free(der_session_buf);
+  FREE(der_session_buf);
   return result;
 }
 
@@ -3148,7 +3148,7 @@ static CURLcode import_windows_cert_store(struct Curl_easy *data,
        */
       if(CertGetEnhancedKeyUsage(pContext, 0, NULL, &req_size)) {
         if(req_size && req_size > enhkey_usage_size) {
-          void *tmp = realloc(enhkey_usage, req_size);
+          void *tmp = REALLOC(enhkey_usage, req_size);
 
           if(!tmp) {
             failf(data, "SSL: Out of memory allocating for OID list");
@@ -3206,7 +3206,7 @@ static CURLcode import_windows_cert_store(struct Curl_easy *data,
       X509_free(x509);
     }
 
-    free(enhkey_usage);
+    FREE(enhkey_usage);
     CertFreeCertificateContext(pContext);
     CertCloseStore(hStore, 0);
 
@@ -3402,8 +3402,8 @@ static void oss_x509_share_free(void *key, size_t key_len, void *p)
   if(share->store) {
     X509_STORE_free(share->store);
   }
-  free(share->CAfile);
-  free(share);
+  FREE(share->CAfile);
+  FREE(share);
 }
 
 static bool
@@ -3469,14 +3469,14 @@ static void ossl_set_cached_x509_store(struct Curl_cfilter *cf,
                          sizeof(MPROTO_OSSL_X509_KEY)-1);
 
   if(!share) {
-    share = calloc(1, sizeof(*share));
+    share = CALLOC(1, sizeof(*share));
     if(!share)
       return;
     if(!Curl_hash_add2(&multi->proto_hash,
                        CURL_UNCONST(MPROTO_OSSL_X509_KEY),
                        sizeof(MPROTO_OSSL_X509_KEY)-1,
                        share, oss_x509_share_free)) {
-      free(share);
+      FREE(share);
       return;
     }
   }
@@ -3485,7 +3485,7 @@ static void ossl_set_cached_x509_store(struct Curl_cfilter *cf,
     char *CAfile = NULL;
 
     if(conn_config->CAfile) {
-      CAfile = strdup(conn_config->CAfile);
+      CAfile = STRDUP(conn_config->CAfile);
       if(!CAfile) {
         X509_STORE_free(store);
         return;
@@ -3494,7 +3494,7 @@ static void ossl_set_cached_x509_store(struct Curl_cfilter *cf,
 
     if(share->store) {
       X509_STORE_free(share->store);
-      free(share->CAfile);
+      FREE(share->CAfile);
     }
 
     share->time = Curl_now();
@@ -3947,11 +3947,11 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
                                   ech_config_len) != 1) {
         infof(data, "ECH: SSL_ECH_set1_ech_config_list failed");
         if(data->set.tls_ech & CURLECH_HARD) {
-          free(ech_config);
+          FREE(ech_config);
           return CURLE_SSL_CONNECT_ERROR;
         }
       }
-      free(ech_config);
+      FREE(ech_config);
       trying_ech_now = 1;
 # else
       ech_config = (unsigned char *) data->set.str[STRING_ECH_CONFIG];
@@ -4228,7 +4228,7 @@ static void ossl_trace_ech_retry_configs(struct Curl_easy *data, SSL* ssl,
     result = Curl_base64_encode((const char *)rcs, rcl, &b64str, &blen);
     if(!result && b64str) {
       infof(data, "ECH: retry_configs %s", b64str);
-      free(b64str);
+      FREE(b64str);
 #if !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
       rv = SSL_ech_get1_status(ssl, &inner, &outer);
       infof(data, "ECH: retry_configs for %s from %s, %d %d",
@@ -4538,7 +4538,7 @@ static CURLcode ossl_pkp_pin_peer_pubkey(struct Curl_easy *data, X509* cert,
     if(len1 < 1)
       break; /* failed */
 
-    buff1 = temp = malloc(len1);
+    buff1 = temp = MALLOC(len1);
     if(!buff1)
       break; /* failed */
 
@@ -4560,7 +4560,7 @@ static CURLcode ossl_pkp_pin_peer_pubkey(struct Curl_easy *data, X509* cert,
   } while(0);
 
   if(buff1)
-    free(buff1);
+    FREE(buff1);
 
   return result;
 }
@@ -5054,7 +5054,7 @@ static ssize_t ossl_send(struct Curl_cfilter *cf,
                          size_t len,
                          CURLcode *curlcode)
 {
-  /* SSL_write() is said to return 'int' while write() and send() returns
+  /* SSL_write() is said to return 'int' while write() and SEND() returns
      'size_t' */
   int err;
   char error_buffer[256];

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -147,8 +147,8 @@ struct schannel_ssl_backend_data {
   size_t encdata_offset, decdata_offset;
   unsigned char *encdata_buffer, *decdata_buffer;
   /* encdata_is_incomplete: if encdata contains only a partial record that
-     cannot be decrypted without another recv() (that is, status is
-     SEC_E_INCOMPLETE_MESSAGE) then set this true. after an recv() adds
+     cannot be decrypted without another RECV() (that is, status is
+     SEC_E_INCOMPLETE_MESSAGE) then set this true. after an RECV() adds
      more bytes into encdata then set this back to false. */
   bool encdata_is_incomplete;
   unsigned long req_flags, ret_flags;

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -301,7 +301,7 @@ static CURLcode add_certs_file_to_store(HCERTSTORE trust_store,
   }
 
   ca_file_bufsize = (size_t)file_size.QuadPart;
-  ca_file_buffer = (char *)malloc(ca_file_bufsize + 1);
+  ca_file_buffer = (char *)MALLOC(ca_file_bufsize + 1);
   if(!ca_file_buffer) {
     result = CURLE_OUT_OF_MEMORY;
     goto cleanup;
@@ -660,7 +660,7 @@ CURLcode Curl_verify_host(struct Curl_cfilter *cf,
     /* CertGetNameString guarantees that the returned name will not contain
      * embedded null bytes. This appears to be undocumented behavior.
      */
-    cert_hostname_buff = (LPTSTR)malloc(len * sizeof(TCHAR));
+    cert_hostname_buff = (LPTSTR)MALLOC(len * sizeof(TCHAR));
     if(!cert_hostname_buff) {
       result = CURLE_OUT_OF_MEMORY;
       goto cleanup;

--- a/lib/vtls/sectransp.c
+++ b/lib/vtls/sectransp.c
@@ -412,7 +412,7 @@ static CURLcode CopyCertSubject(struct Curl_easy *data,
      use that, else convert it. */
   direct = CFStringGetCStringPtr(c, kCFStringEncodingUTF8);
   if(direct) {
-    *certp = strdup(direct);
+    *certp = STRDUP(direct);
     if(!*certp) {
       failf(data, "SSL: out of memory");
       result = CURLE_OUT_OF_MEMORY;
@@ -420,7 +420,7 @@ static CURLcode CopyCertSubject(struct Curl_easy *data,
   }
   else {
     size_t cbuf_size = ((size_t)CFStringGetLength(c) * 4) + 1;
-    cbuf = calloc(1, cbuf_size);
+    cbuf = CALLOC(1, cbuf_size);
     if(cbuf) {
       if(!CFStringGetCString(c, cbuf, (CFIndex)cbuf_size,
                              kCFStringEncodingUTF8)) {
@@ -437,7 +437,7 @@ static CURLcode CopyCertSubject(struct Curl_easy *data,
     }
   }
   if(result)
-    free(cbuf);
+    FREE(cbuf);
   CFRelease(c);
   return result;
 }
@@ -869,7 +869,7 @@ static SSLCipherSuite * sectransp_get_supported_ciphers(SSLContextRef ssl_ctx,
   if(err != noErr)
     goto failed;
 
-  ciphers = malloc(*len * sizeof(SSLCipherSuite));
+  ciphers = MALLOC(*len * sizeof(SSLCipherSuite));
   if(!ciphers)
     goto failed;
 
@@ -965,7 +965,7 @@ static CURLcode sectransp_set_selected_ciphers(struct Curl_easy *data,
     goto failed;
   }
 
-  selected = malloc(supported_len * sizeof(SSLCipherSuite));
+  selected = MALLOC(supported_len * sizeof(SSLCipherSuite));
   if(!selected) {
     failf(data, "SSL: Failed to allocate memory");
     goto failed;
@@ -1166,7 +1166,7 @@ static CURLcode sectransp_connect_step1(struct Curl_cfilter *cf,
         result = CopyCertSubject(data, cert, &certp);
         if(!result) {
           infof(data, "Client certificate: %s", certp);
-          free(certp);
+          FREE(certp);
         }
 
         CFRelease(cert);
@@ -1423,7 +1423,7 @@ static long pem_to_der(const char *in, unsigned char **out, size_t *outlen)
   sep_end += 5;
 
   len = cert_end - cert_start;
-  b64 = malloc(len + 1);
+  b64 = MALLOC(len + 1);
   if(!b64)
     return -1;
 
@@ -1435,9 +1435,9 @@ static long pem_to_der(const char *in, unsigned char **out, size_t *outlen)
   b64[j] = '\0';
 
   err = Curl_base64_decode((const char *)b64, out, outlen);
-  free(b64);
+  FREE(b64);
   if(err) {
-    free(*out);
+    FREE(*out);
     return -1;
   }
 
@@ -1516,7 +1516,7 @@ static CURLcode append_cert_to_array(struct Curl_easy *data,
         CFRelease(cacert);
         return result;
     }
-    free(certp);
+    FREE(certp);
 
     CFArrayAppendValue(array, cacert);
     CFRelease(cacert);
@@ -1588,7 +1588,7 @@ static CURLcode verify_cert_buf(struct Curl_cfilter *cf,
     }
 
     rc = append_cert_to_array(data, der, derlen, array);
-    free(der);
+    FREE(der);
     if(rc != CURLE_OK) {
       CURL_TRC_CF(data, cf, "append_cert for CA failed");
       result = rc;
@@ -1683,7 +1683,7 @@ static CURLcode verify_cert(struct Curl_cfilter *cf,
 
   result = verify_cert_buf(cf, data, certbuf, buflen, ctx);
   if(free_certbuf)
-    free(certbuf);
+    FREE(certbuf);
   return result;
 }
 
@@ -1782,7 +1782,7 @@ static CURLcode pkp_pin_peer_pubkey(struct Curl_easy *data,
     }
 
     realpubkeylen = pubkeylen + spkiHeaderLength;
-    realpubkey = malloc(realpubkeylen);
+    realpubkey = MALLOC(realpubkeylen);
     if(!realpubkey)
       break;
 
@@ -2163,7 +2163,7 @@ collect_server_cert_single(struct Curl_cfilter *cf, struct Curl_easy *data,
     result = CopyCertSubject(data, server_cert, &certp);
     if(!result) {
       infof(data, "Server certificate: %s", certp);
-      free(certp);
+      FREE(certp);
     }
   }
 #endif

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -93,7 +93,7 @@
 #define CLONE_STRING(var)                    \
   do {                                       \
     if(source->var) {                        \
-      dest->var = strdup(source->var);       \
+      dest->var = STRDUP(source->var);       \
       if(!dest->var)                         \
         return FALSE;                        \
     }                                        \
@@ -115,7 +115,7 @@ static CURLcode blobdup(struct curl_blob **dest,
   if(src) {
     /* only if there is data to dupe! */
     struct curl_blob *d;
-    d = malloc(sizeof(struct curl_blob) + src->len);
+    d = MALLOC(sizeof(struct curl_blob) + src->len);
     if(!d)
       return CURLE_OUT_OF_MEMORY;
     d->len = src->len;
@@ -460,16 +460,16 @@ static struct ssl_connect_data *cf_ctx_new(struct Curl_easy *data,
   struct ssl_connect_data *ctx;
 
   (void)data;
-  ctx = calloc(1, sizeof(*ctx));
+  ctx = CALLOC(1, sizeof(*ctx));
   if(!ctx)
     return NULL;
 
   ctx->ssl_impl = Curl_ssl;
   ctx->alpn = alpn;
   Curl_bufq_init2(&ctx->earlydata, CURL_SSL_EARLY_MAX, 1, BUFQ_OPT_NO_SPARES);
-  ctx->backend = calloc(1, ctx->ssl_impl->sizeof_ssl_backend_data);
+  ctx->backend = CALLOC(1, ctx->ssl_impl->sizeof_ssl_backend_data);
   if(!ctx->backend) {
-    free(ctx);
+    FREE(ctx);
     return NULL;
   }
   return ctx;
@@ -480,8 +480,8 @@ static void cf_ctx_free(struct ssl_connect_data *ctx)
   if(ctx) {
     Curl_safefree(ctx->negotiated.alpn);
     Curl_bufq_free(&ctx->earlydata);
-    free(ctx->backend);
-    free(ctx);
+    FREE(ctx->backend);
+    FREE(ctx);
   }
 }
 
@@ -570,7 +570,7 @@ void Curl_ssl_free_certinfo(struct Curl_easy *data)
       ci->certinfo[i] = NULL;
     }
 
-    free(ci->certinfo); /* free the actual array too */
+    FREE(ci->certinfo); /* free the actual array too */
     ci->certinfo = NULL;
     ci->num_of_certs = 0;
   }
@@ -585,7 +585,7 @@ CURLcode Curl_ssl_init_certinfo(struct Curl_easy *data, int num)
   Curl_ssl_free_certinfo(data);
 
   /* Allocate the required certificate information structures */
-  table = calloc((size_t) num, sizeof(struct curl_slist *));
+  table = CALLOC((size_t) num, sizeof(struct curl_slist *));
   if(!table)
     return CURLE_OUT_OF_MEMORY;
 
@@ -732,7 +732,7 @@ CURLcode Curl_pin_peer_pubkey(struct Curl_easy *data,
     }
 
     /* compute sha256sum of public key */
-    sha256sumdigest = malloc(CURL_SHA256_DIGEST_LENGTH);
+    sha256sumdigest = MALLOC(CURL_SHA256_DIGEST_LENGTH);
     if(!sha256sumdigest)
       return CURLE_OUT_OF_MEMORY;
     encode = Curl_ssl->sha256sum(pubkey, pubkeylen,
@@ -750,7 +750,7 @@ CURLcode Curl_pin_peer_pubkey(struct Curl_easy *data,
     infof(data, " public key hash: sha256//%s", encoded);
 
     /* it starts with sha256//, copy so we can modify it */
-    pinkeycopy = strdup(pinnedpubkey);
+    pinkeycopy = STRDUP(pinnedpubkey);
     if(!pinkeycopy) {
       Curl_safefree(encoded);
       return CURLE_OUT_OF_MEMORY;
@@ -792,7 +792,7 @@ CURLcode Curl_pin_peer_pubkey(struct Curl_easy *data,
     struct dynbuf buf;
     char unsigned *pem_ptr = NULL;
     size_t left;
-    FILE *fp = fopen(pinnedpubkey, "rb");
+    FILE *fp = FOPEN(pinnedpubkey, "rb");
     if(!fp)
       return result;
 
@@ -854,7 +854,7 @@ CURLcode Curl_pin_peer_pubkey(struct Curl_easy *data,
 end:
     Curl_dyn_free(&buf);
     Curl_safefree(pem_ptr);
-    fclose(fp);
+    FCLOSE(fp);
   }
 
   return result;
@@ -1093,7 +1093,7 @@ static int multissl_setup(const struct Curl_ssl *backend)
     for(i = 0; available_backends[i]; i++) {
       if(strcasecompare(env, available_backends[i]->info.name)) {
         Curl_ssl = available_backends[i];
-        free(env);
+        FREE(env);
         return 0;
       }
     }
@@ -1104,7 +1104,7 @@ static int multissl_setup(const struct Curl_ssl *backend)
     if(strcasecompare(CURL_DEFAULT_SSL_BACKEND,
                       available_backends[i]->info.name)) {
       Curl_ssl = available_backends[i];
-      free(env);
+      FREE(env);
       return 0;
     }
   }
@@ -1112,7 +1112,7 @@ static int multissl_setup(const struct Curl_ssl *backend)
 
   /* Fall back to first available backend */
   Curl_ssl = available_backends[0];
-  free(env);
+  FREE(env);
   return 0;
 }
 
@@ -1165,7 +1165,7 @@ void Curl_ssl_peer_cleanup(struct ssl_peer *peer)
 {
   Curl_safefree(peer->sni);
   if(peer->dispname != peer->hostname)
-    free(peer->dispname);
+    FREE(peer->dispname);
   peer->dispname = NULL;
   Curl_safefree(peer->hostname);
   Curl_safefree(peer->scache_key);
@@ -1241,13 +1241,13 @@ CURLcode Curl_ssl_peer_init(struct ssl_peer *peer,
     goto out;
   }
 
-  peer->hostname = strdup(ehostname);
+  peer->hostname = STRDUP(ehostname);
   if(!peer->hostname)
     goto out;
   if(!edispname || !strcmp(ehostname, edispname))
     peer->dispname = peer->hostname;
   else {
-    peer->dispname = strdup(edispname);
+    peer->dispname = STRDUP(edispname);
     if(!peer->dispname)
       goto out;
   }
@@ -1259,7 +1259,7 @@ CURLcode Curl_ssl_peer_init(struct ssl_peer *peer,
     if(len && (peer->hostname[len-1] == '.'))
       len--;
     if(len < USHRT_MAX) {
-      peer->sni = calloc(1, len + 1);
+      peer->sni = CALLOC(1, len + 1);
       if(!peer->sni)
         goto out;
       Curl_strntolower(peer->sni, peer->hostname, len);
@@ -2017,7 +2017,7 @@ CURLcode Curl_alpn_set_negotiated(struct Curl_cfilter *cf,
       result = CURLE_SSL_CONNECT_ERROR;
       goto out;
     }
-    connssl->negotiated.alpn = malloc(proto_len + 1);
+    connssl->negotiated.alpn = MALLOC(proto_len + 1);
     if(!connssl->negotiated.alpn)
       return CURLE_OUT_OF_MEMORY;
     memcpy(connssl->negotiated.alpn, proto, proto_len);

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -112,10 +112,10 @@ static void cf_ssl_scache_sesssion_ldestroy(void *udata, void *obj)
 {
   struct Curl_ssl_session *s = obj;
   (void)udata;
-  free(CURL_UNCONST(s->sdata));
-  free(CURL_UNCONST(s->quic_tp));
-  free((void *)s->alpn);
-  free(s);
+  FREE(CURL_UNCONST(s->sdata));
+  FREE(CURL_UNCONST(s->quic_tp));
+  FREE((void *)s->alpn);
+  FREE(s);
 }
 
 CURLcode
@@ -139,15 +139,15 @@ Curl_ssl_session_create2(void *sdata, size_t sdata_len,
   struct Curl_ssl_session *s;
 
   if(!sdata || !sdata_len) {
-    free(sdata);
+    FREE(sdata);
     return CURLE_BAD_FUNCTION_ARGUMENT;
   }
 
   *psession = NULL;
-  s = calloc(1, sizeof(*s));
+  s = CALLOC(1, sizeof(*s));
   if(!s) {
-    free(sdata);
-    free(quic_tp);
+    FREE(sdata);
+    FREE(quic_tp);
     return CURLE_OUT_OF_MEMORY;
   }
 
@@ -159,7 +159,7 @@ Curl_ssl_session_create2(void *sdata, size_t sdata_len,
   s->quic_tp = quic_tp;
   s->quic_tp_len = quic_tp_len;
   if(alpn) {
-    s->alpn = strdup(alpn);
+    s->alpn = STRDUP(alpn);
     if(!s->alpn) {
       cf_ssl_scache_sesssion_ldestroy(NULL, s);
       return CURLE_OUT_OF_MEMORY;
@@ -239,7 +239,7 @@ cf_ssl_scache_peer_init(struct Curl_ssl_scache_peer *peer,
 
   DEBUGASSERT(!peer->ssl_peer_key);
   if(ssl_peer_key) {
-    peer->ssl_peer_key = strdup(ssl_peer_key);
+    peer->ssl_peer_key = STRDUP(ssl_peer_key);
     if(!peer->ssl_peer_key)
       goto out;
     peer->hmac_set = FALSE;
@@ -254,17 +254,17 @@ cf_ssl_scache_peer_init(struct Curl_ssl_scache_peer *peer,
     goto out;
   }
   if(clientcert) {
-    peer->clientcert = strdup(clientcert);
+    peer->clientcert = STRDUP(clientcert);
     if(!peer->clientcert)
       goto out;
   }
   if(srp_username) {
-    peer->srp_username = strdup(srp_username);
+    peer->srp_username = STRDUP(srp_username);
     if(!peer->srp_username)
       goto out;
   }
   if(srp_password) {
-    peer->srp_password = strdup(srp_password);
+    peer->srp_password = STRDUP(srp_password);
     if(!peer->srp_password)
       goto out;
   }
@@ -323,13 +323,13 @@ CURLcode Curl_ssl_scache_create(size_t max_peers,
   size_t i;
 
   *pscache = NULL;
-  peers = calloc(max_peers, sizeof(*peers));
+  peers = CALLOC(max_peers, sizeof(*peers));
   if(!peers)
     return CURLE_OUT_OF_MEMORY;
 
-  scache = calloc(1, sizeof(*scache));
+  scache = CALLOC(1, sizeof(*scache));
   if(!scache) {
-    free(peers);
+    FREE(peers);
     return CURLE_OUT_OF_MEMORY;
   }
 
@@ -356,8 +356,8 @@ void Curl_ssl_scache_destroy(struct Curl_ssl_scache *scache)
     for(i = 0; i < scache->peer_count; ++i) {
       cf_ssl_scache_clear_peer(&scache->peers[i]);
     }
-    free(scache->peers);
-    free(scache);
+    FREE(scache->peers);
+    FREE(scache);
   }
 }
 
@@ -678,7 +678,7 @@ cf_ssl_find_peer_by_key(struct Curl_easy *data,
         /* remember peer_key for future lookups */
         CURL_TRC_SSLS(data, "peer entry %zu key recovered: %s",
                       i, ssl_peer_key);
-        scache->peers[i].ssl_peer_key = strdup(ssl_peer_key);
+        scache->peers[i].ssl_peer_key = STRDUP(ssl_peer_key);
         if(!scache->peers[i].ssl_peer_key) {
           result = CURLE_OUT_OF_MEMORY;
           goto out;

--- a/lib/vtls/vtls_spack.c
+++ b/lib/vtls/vtls_spack.c
@@ -278,7 +278,7 @@ CURLcode Curl_ssl_session_unpack(struct Curl_easy *data,
     goto out;
   }
 
-  s = calloc(1, sizeof(*s));
+  s = CALLOC(1, sizeof(*s));
   if(!s) {
     r = CURLE_OUT_OF_MEMORY;
     goto out;

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -436,7 +436,7 @@ CURLcode Curl_wssl_cache_session(struct Curl_cfilter *cf,
     result = CURLE_FAILED_INIT;
     goto out;
   }
-  sdata = calloc(1, sdata_len);
+  sdata = CALLOC(1, sdata_len);
   if(!sdata) {
     failf(data, "unable to allocate session buffer of %u bytes", sdata_len);
     result = CURLE_OUT_OF_MEMORY;
@@ -451,7 +451,7 @@ CURLcode Curl_wssl_cache_session(struct Curl_cfilter *cf,
   if(quic_tp && quic_tp_len) {
     qtp_clone = Curl_memdup0((char *)quic_tp, quic_tp_len);
     if(!qtp_clone) {
-      free(sdata);
+      FREE(sdata);
       return CURLE_OUT_OF_MEMORY;
     }
   }
@@ -472,7 +472,7 @@ CURLcode Curl_wssl_cache_session(struct Curl_cfilter *cf,
   }
 
 out:
-  free(sdata);
+  FREE(sdata);
   return result;
 }
 
@@ -705,8 +705,8 @@ static void wssl_x509_share_free(void *key, size_t key_len, void *p)
   if(share->store) {
     wolfSSL_X509_STORE_free(share->store);
   }
-  free(share->CAfile);
-  free(share);
+  FREE(share->CAfile);
+  FREE(share);
 }
 
 static bool
@@ -771,14 +771,14 @@ static void wssl_set_cached_x509_store(struct Curl_cfilter *cf,
                          sizeof(MPROTO_WSSL_X509_KEY)-1);
 
   if(!share) {
-    share = calloc(1, sizeof(*share));
+    share = CALLOC(1, sizeof(*share));
     if(!share)
       return;
     if(!Curl_hash_add2(&multi->proto_hash,
                        CURL_UNCONST(MPROTO_WSSL_X509_KEY),
                        sizeof(MPROTO_WSSL_X509_KEY)-1,
                        share, wssl_x509_share_free)) {
-      free(share);
+      FREE(share);
       return;
     }
   }
@@ -787,7 +787,7 @@ static void wssl_set_cached_x509_store(struct Curl_cfilter *cf,
     char *CAfile = NULL;
 
     if(conn_config->CAfile) {
-      CAfile = strdup(conn_config->CAfile);
+      CAfile = STRDUP(conn_config->CAfile);
       if(!CAfile) {
         wolfSSL_X509_STORE_free(store);
         return;
@@ -796,7 +796,7 @@ static void wssl_set_cached_x509_store(struct Curl_cfilter *cf,
 
     if(share->store) {
       wolfSSL_X509_STORE_free(share->store);
-      free(share->CAfile);
+      FREE(share->CAfile);
     }
 
     share->time = Curl_now();
@@ -1774,7 +1774,7 @@ static CURLcode wssl_handshake(struct Curl_cfilter *cf,
                                     &b64str, &blen);
         if(!result && b64str)
           infof(data, "ECH: (not yet) retry_configs %s", b64str);
-        free(b64str);
+        FREE(b64str);
       }
       return CURLE_SSL_CONNECT_ERROR;
     }

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -1263,7 +1263,7 @@ CURLcode Curl_extract_certinfo(struct Curl_easy *data,
     if(!result)
       result = Curl_dyn_add(&out, "-----END CERTIFICATE-----\n");
   }
-  free(certptr);
+  FREE(certptr);
   if(!result)
     if(data->set.ssl.certinfo)
       result = ssl_push_certinfo_dyn(data, certnum, "Cert", &out);

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -809,11 +809,11 @@ CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req)
     return result;
   DEBUGASSERT(randlen < sizeof(keyval));
   if(randlen >= sizeof(keyval)) {
-    free(randstr);
+    FREE(randstr);
     return CURLE_FAILED_INIT;
   }
   strcpy(keyval, randstr);
-  free(randstr);
+  FREE(randstr);
   for(i = 0; !result && (i < CURL_ARRAYSIZE(heads)); i++) {
     if(!Curl_checkheaders(data, STRCONST(heads[i].name))) {
       result = Curl_dyn_addf(req, "%s %s\r\n", heads[i].name,
@@ -840,7 +840,7 @@ CURLcode Curl_ws_accept(struct Curl_easy *data,
   ws = data->conn->proto.ws;
   if(!ws) {
     size_t chunk_size = WS_CHUNK_SIZE;
-    ws = calloc(1, sizeof(*ws));
+    ws = CALLOC(1, sizeof(*ws));
     if(!ws)
       return CURLE_OUT_OF_MEMORY;
     data->conn->proto.ws = ws;

--- a/src/.checksrc
+++ b/src/.checksrc
@@ -3,3 +3,15 @@ banfunc strncpy
 banfunc sscanf
 banfunc strtol
 banfunc strtoul
+# the ones we use UPPERCASE:
+banfunc strdup
+banfunc malloc
+banfunc calloc
+banfunc realloc
+banfunc socket
+banfunc send
+banfunc recv
+banfunc accept
+banfunc fopen
+banfunc fdopen
+banfunc fclose

--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -97,13 +97,13 @@ HEAD
 static voidpf zalloc_func(voidpf opaque, unsigned int items, unsigned int size)
 {
   (void) opaque;
-  /* not a typo, keep it calloc() */
-  return (voidpf) calloc(items, size);
+  /* not a typo, keep it CALLOC() */
+  return (voidpf) CALLOC(items, size);
 }
 static void zfree_func(voidpf opaque, voidpf ptr)
 {
   (void) opaque;
-  free(ptr);
+  FREE(ptr);
 }
 
 #define HEADERLEN 10
@@ -128,7 +128,7 @@ void hugehelp(void)
   if(inflateInit2(&z, -MAX_WBITS) != Z_OK)
     return;
 
-  buf = malloc(BUF_SIZE);
+  buf = MALLOC(BUF_SIZE);
   if(buf) {
     while(1) {
       z.avail_out = BUF_SIZE;
@@ -142,7 +142,7 @@ void hugehelp(void)
       else
         break;    /* error */
     }
-    free(buf);
+    FREE(buf);
   }
   inflateEnd(&z);
 }
@@ -168,7 +168,7 @@ void showhelp(const char *trigger, const char *arg, const char *endarg)
   if(inflateInit2(&z, -MAX_WBITS) != Z_OK)
     return;
 
-  buf = malloc(BUF_SIZE);
+  buf = MALLOC(BUF_SIZE);
   if(buf) {
     while(1) {
       z.avail_out = BUF_SIZE;
@@ -184,7 +184,7 @@ void showhelp(const char *trigger, const char *arg, const char *endarg)
       else
         break;    /* error */
     }
-    free(buf);
+    FREE(buf);
   }
   inflateEnd(&z);
 }

--- a/src/slist_wc.c
+++ b/src/slist_wc.c
@@ -44,7 +44,7 @@ struct slist_wc *slist_wc_append(struct slist_wc *list,
     return NULL;
 
   if(!list) {
-    list = malloc(sizeof(struct slist_wc));
+    list = MALLOC(sizeof(struct slist_wc));
 
     if(!list) {
       curl_slist_free_all(new_item);
@@ -68,7 +68,7 @@ void slist_wc_free_all(struct slist_wc *list)
     return;
 
   curl_slist_free_all(list->first);
-  free(list);
+  FREE(list);
 }
 
 #endif /* CURL_DISABLE_LIBCURL_OPTION */

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -127,7 +127,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
       /* Ok, this is somewhat hackish but we do it undocumented for now */
       config->trace_stream = tool_stderr;
     else {
-      config->trace_stream = fopen(config->trace_dump, FOPEN_WRITETEXT);
+      config->trace_stream = FOPEN(config->trace_dump, FOPEN_WRITETEXT);
       config->trace_fopened = TRUE;
     }
   }

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -214,14 +214,14 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
           if(filename) {
             if(outs->stream) {
               /* indication of problem, get out! */
-              free(filename);
+              FREE(filename);
               return CURL_WRITEFUNC_ERROR;
             }
 
             if(per->config->output_dir) {
               outs->filename = aprintf("%s/%s", per->config->output_dir,
                                        filename);
-              free(filename);
+              FREE(filename);
               if(!outs->filename)
                 return CURL_WRITEFUNC_ERROR;
             }
@@ -254,7 +254,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
         if(clone) {
           struct curl_slist *old = hdrcbdata->headlist;
           hdrcbdata->headlist = curl_slist_append(old, clone);
-          free(clone);
+          FREE(clone);
           if(!hdrcbdata->headlist) {
             curl_slist_free_all(old);
             return CURL_WRITEFUNC_ERROR;
@@ -327,7 +327,7 @@ static char *parse_filename(const char *ptr, size_t len)
   char  stop = '\0';
 
   /* simple implementation of strndup() */
-  copy = malloc(len + 1);
+  copy = MALLOC(len + 1);
   if(!copy)
     return NULL;
   memcpy(copy, ptr, len);
@@ -442,7 +442,7 @@ void write_linked_location(CURL *curl, const char *location, size_t loclen,
     goto locout;
 
   /* Create a NUL-terminated and whitespace-stripped copy of Location: */
-  copyloc = malloc(llen + 1);
+  copyloc = MALLOC(llen + 1);
   if(!copyloc)
     goto locout;
   memcpy(copyloc, loc, llen);
@@ -486,7 +486,7 @@ locdone:
     curl_free(finalurl);
     curl_free(scheme);
     curl_url_cleanup(u);
-    free(copyloc);
+    FREE(copyloc);
   }
 }
 #endif

--- a/src/tool_cb_soc.c
+++ b/src/tool_cb_soc.c
@@ -28,6 +28,7 @@
 #endif
 
 #include "tool_cb_soc.h"
+#include "memdebug.h"
 
 /*
 ** callback for CURLOPT_OPENSOCKETFUNCTION
@@ -54,5 +55,5 @@ curl_socket_t tool_socket_open_mptcp_cb(void *clientp,
     return CURL_SOCKET_BAD;
 #endif
 
-  return socket(addr->family, addr->socktype, protocol);
+  return SOCKET(addr->family, addr->socktype, protocol);
 }

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -61,7 +61,7 @@ bool tool_create_output_file(struct OutStruct *outs,
      (config->file_clobber_mode == CLOBBER_DEFAULT &&
       !outs->is_cd_filename)) {
     /* open file for writing */
-    file = fopen(fname, "wb");
+    file = FOPEN(fname, "wb");
   }
   else {
     int fd;
@@ -80,7 +80,7 @@ bool tool_create_output_file(struct OutStruct *outs,
         errorf(global, "overflow in filename generation");
         return FALSE;
       }
-      newname = malloc(newlen);
+      newname = MALLOC(newlen);
       if(!newname) {
         errorf(global, "out of memory");
         return FALSE;
@@ -109,7 +109,7 @@ bool tool_create_output_file(struct OutStruct *outs,
        is not needed because we would have failed earlier, in the while loop
        and `fd` would now be -1 */
     if(fd != -1) {
-      file = fdopen(fd, "wb");
+      file = FDOPEN(fd, "wb");
       if(!file)
         close(fd);
     }
@@ -318,14 +318,14 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
       if(!wc_len)
         return CURL_WRITEFUNC_ERROR;
 
-      wc_buf = (wchar_t*) malloc(wc_len * sizeof(wchar_t));
+      wc_buf = (wchar_t*) MALLOC(wc_len * sizeof(wchar_t));
       if(!wc_buf)
         return CURL_WRITEFUNC_ERROR;
 
       wc_len = (DWORD)MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)rbuf, (int)rlen,
                                           wc_buf, (int)wc_len);
       if(!wc_len) {
-        free(wc_buf);
+        FREE(wc_buf);
         return CURL_WRITEFUNC_ERROR;
       }
 
@@ -335,10 +335,10 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
           wc_len,
           &chars_written,
           NULL)) {
-        free(wc_buf);
+        FREE(wc_buf);
         return CURL_WRITEFUNC_ERROR;
       }
-      free(wc_buf);
+      FREE(wc_buf);
     }
 
     rc = bytes;

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -194,7 +194,7 @@ void config_free(struct OperationConfig *config)
     struct OperationConfig *prev = last->prev;
 
     free_config_fields(last);
-    free(last);
+    FREE(last);
 
     last = prev;
   }

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -132,7 +132,7 @@ SANITIZEcode sanitize_file_name(char **const sanitized, const char *file_name,
   if(len > max_sanitized_len)
     return SANITIZE_ERR_INVALID_PATH;
 
-  target = strdup(file_name);
+  target = STRDUP(file_name);
   if(!target)
     return SANITIZE_ERR_OUT_OF_MEMORY;
 
@@ -182,28 +182,28 @@ SANITIZEcode sanitize_file_name(char **const sanitized, const char *file_name,
 
 #ifdef MSDOS
   sc = msdosify(&p, target, flags);
-  free(target);
+  FREE(target);
   if(sc)
     return sc;
   target = p;
   len = strlen(target);
 
   if(len > max_sanitized_len) {
-    free(target);
+    FREE(target);
     return SANITIZE_ERR_INVALID_PATH;
   }
 #endif
 
   if(!(flags & SANITIZE_ALLOW_RESERVED)) {
     sc = rename_if_reserved_dos(&p, target, flags);
-    free(target);
+    FREE(target);
     if(sc)
       return sc;
     target = p;
     len = strlen(target);
 
     if(len > max_sanitized_len) {
-      free(target);
+      FREE(target);
       return SANITIZE_ERR_INVALID_PATH;
     }
   }
@@ -414,7 +414,7 @@ static SANITIZEcode msdosify(char **const sanitized, const char *file_name,
       return SANITIZE_ERR_INVALID_PATH;
   }
 
-  *sanitized = strdup(dos_name);
+  *sanitized = STRDUP(dos_name);
   return *sanitized ? SANITIZE_ERR_OK : SANITIZE_ERR_OUT_OF_MEMORY;
 }
 #endif /* MSDOS */
@@ -456,7 +456,7 @@ static SANITIZEcode rename_if_reserved_dos(char **const sanitized,
 #ifndef MSDOS
   if((flags & SANITIZE_ALLOW_PATH) &&
      file_name[0] == '\\' && file_name[1] == '\\') {
-    *sanitized = strdup(file_name);
+    *sanitized = STRDUP(file_name);
     if(!*sanitized)
       return SANITIZE_ERR_OUT_OF_MEMORY;
     return SANITIZE_ERR_OK;
@@ -543,7 +543,7 @@ static SANITIZEcode rename_if_reserved_dos(char **const sanitized,
   }
 #endif
 
-  *sanitized = strdup(fname);
+  *sanitized = STRDUP(fname);
   return *sanitized ? SANITIZE_ERR_OK : SANITIZE_ERR_OUT_OF_MEMORY;
 }
 
@@ -596,7 +596,7 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
     char *mstr = curlx_convert_tchar_to_UTF8(buf);
     curlx_safefree(config->cacert);
     if(mstr)
-      config->cacert = strdup(mstr);
+      config->cacert = STRDUP(mstr);
     curlx_unicodefree(mstr);
     if(!config->cacert)
       result = CURLE_OUT_OF_MEMORY;

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -180,7 +180,7 @@ void dumpeasysrc(struct GlobalConfig *config)
   FILE *out;
   bool fopened = FALSE;
   if(strcmp(o, "-")) {
-    out = fopen(o, FOPEN_WRITETEXT);
+    out = FOPEN(o, FOPEN_WRITETEXT);
     fopened = TRUE;
   }
   else
@@ -229,7 +229,7 @@ void dumpeasysrc(struct GlobalConfig *config)
       fprintf(out, "%s\n", c);
 
     if(fopened)
-      fclose(out);
+      FCLOSE(out);
   }
 
   easysrc_free();

--- a/src/tool_findfile.c
+++ b/src/tool_findfile.c
@@ -79,7 +79,7 @@ static char *checkhome(const char *home, const char *fname, bool dotscore)
     if(c) {
       int fd = open(c, O_RDONLY);
       if(fd >= 0) {
-        char *path = strdup(c);
+        char *path = STRDUP(c);
         close(fd);
         curl_free(c);
         return path;

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -40,7 +40,7 @@
 static struct tool_mime *tool_mime_new(struct tool_mime *parent,
                                        toolmimekind kind)
 {
-  struct tool_mime *m = (struct tool_mime *) calloc(1, sizeof(*m));
+  struct tool_mime *m = (struct tool_mime *) CALLOC(1, sizeof(*m));
 
   if(m) {
     m->kind = kind;
@@ -64,11 +64,11 @@ static struct tool_mime *tool_mime_new_data(struct tool_mime *parent,
   char *mime_data_copy;
   struct tool_mime *m = NULL;
 
-  mime_data_copy = strdup(mime_data);
+  mime_data_copy = STRDUP(mime_data);
   if(mime_data_copy) {
     m = tool_mime_new(parent, TOOLMIME_DATA);
     if(!m)
-      free(mime_data_copy);
+      FREE(mime_data_copy);
     else
       m->data = mime_data_copy;
   }
@@ -111,11 +111,11 @@ static struct tool_mime *tool_mime_new_filedata(struct tool_mime *parent,
   *errcode = CURLE_OUT_OF_MEMORY;
   if(strcmp(filename, "-")) {
     /* This is a normal file. */
-    char *filedup = strdup(filename);
+    char *filedup = STRDUP(filename);
     if(filedup) {
       m = tool_mime_new(parent, TOOLMIME_FILE);
       if(!m)
-        free(filedup);
+        FREE(filedup);
       else {
         m->data = filedup;
         if(!isremotefile)
@@ -160,7 +160,7 @@ static struct tool_mime *tool_mime_new_filedata(struct tool_mime *parent,
       default:
         if(!stdinsize) {
           /* Zero-length data has been freed. Re-create it. */
-          data = strdup("");
+          data = STRDUP("");
           if(!data)
             return m;
         }
@@ -198,7 +198,7 @@ void tool_mime_free(struct tool_mime *mime)
     curlx_safefree(mime->encoder);
     curlx_safefree(mime->data);
     curl_slist_free_all(mime->headers);
-    free(mime);
+    FREE(mime);
   }
 }
 
@@ -573,14 +573,14 @@ static int get_param_part(struct OperationConfig *config, char endchar,
             endpos--;
         sep = *p;
         *endpos = '\0';
-        fp = fopen(hdrfile, FOPEN_READTEXT);
+        fp = FOPEN(hdrfile, FOPEN_READTEXT);
         if(!fp)
           warnf(config->global, "Cannot read from %s: %s", hdrfile,
                 strerror(errno));
         else {
           int i = read_field_headers(config, hdrfile, fp, &headers);
 
-          fclose(fp);
+          FCLOSE(fp);
           if(i) {
             curl_slist_free_all(headers);
             return -1;
@@ -725,7 +725,7 @@ static int get_param_part(struct OperationConfig *config, char endchar,
 #define SET_TOOL_MIME_PTR(m, field)                                     \
   do {                                                                  \
     if(field) {                                                         \
-      (m)->field = strdup(field);                                       \
+      (m)->field = STRDUP(field);                                       \
       if(!(m)->field)                                                   \
         goto fail;                                                      \
     }                                                                   \
@@ -760,7 +760,7 @@ int formparse(struct OperationConfig *config,
   }
 
   /* Make a copy we can overwrite. */
-  contents = strdup(input);
+  contents = STRDUP(input);
   if(!contents)
     goto fail;
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -51,14 +51,14 @@
 static ParameterError getstr(char **str, const char *val, bool allowblank)
 {
   if(*str) {
-    free(*str);
+    FREE(*str);
     *str = NULL;
   }
   if(val) {
     if(!allowblank && !val[0])
       return PARAM_BLANK_STRING;
 
-    *str = strdup(val);
+    *str = STRDUP(val);
     if(!*str)
       return PARAM_NO_MEM;
   }
@@ -69,14 +69,14 @@ static ParameterError getstrn(char **str, const char *val,
                               size_t len, bool allowblank)
 {
   if(*str) {
-    free(*str);
+    FREE(*str);
     *str = NULL;
   }
   if(val) {
     if(!allowblank && !val[0])
       return PARAM_BLANK_STRING;
 
-    *str = malloc(len + 1);
+    *str = MALLOC(len + 1);
     if(!*str)
       return PARAM_NO_MEM;
 
@@ -405,11 +405,11 @@ void parse_cert_parameter(const char *cert_parameter,
    * means no passphrase was given and no characters escaped */
   if(curl_strnequal(cert_parameter, "pkcs11:", 7) ||
      !strpbrk(cert_parameter, ":\\")) {
-    *certname = strdup(cert_parameter);
+    *certname = STRDUP(cert_parameter);
     return;
   }
   /* deal with escaped chars; find unescaped colon if it exists */
-  certname_place = malloc(param_length + 1);
+  certname_place = MALLOC(param_length + 1);
   if(!certname_place)
     return;
 
@@ -469,7 +469,7 @@ void parse_cert_parameter(const char *cert_parameter,
        * above; if we are still here, this is a separating colon */
       param_place++;
       if(*param_place) {
-        *passphrase = strdup(param_place);
+        *passphrase = STRDUP(param_place);
       }
       goto done;
     }
@@ -512,10 +512,10 @@ GetFileAndPassword(const char *nextarg, char **file, char **password)
   char *certname, *passphrase;
   if(nextarg) {
     parse_cert_parameter(nextarg, &certname, &passphrase);
-    free(*file);
+    FREE(*file);
     *file = certname;
     if(passphrase) {
-      free(*password);
+      FREE(*password);
       *password = passphrase;
     }
   }
@@ -630,7 +630,7 @@ static ParameterError data_urlencode(struct GlobalConfig *global,
       CURL_SET_BINMODE(stdin);
     }
     else {
-      file = fopen(p, "rb");
+      file = FOPEN(p, "rb");
       if(!file) {
         errorf(global, "Failed to open %s", p);
         return PARAM_READ_ERROR;
@@ -640,7 +640,7 @@ static ParameterError data_urlencode(struct GlobalConfig *global,
     err = file2memory(&postdata, &size, file);
 
     if(file && (file != stdin))
-      fclose(file);
+      FCLOSE(file);
     if(err)
       return err;
   }
@@ -654,7 +654,7 @@ static ParameterError data_urlencode(struct GlobalConfig *global,
   if(!postdata) {
     /* no data from the file, point to a zero byte string to make this
        get sent as a POST anyway */
-    postdata = strdup("");
+    postdata = STRDUP("");
     if(!postdata)
       return PARAM_NO_MEM;
     size = 0;
@@ -856,7 +856,7 @@ static ParameterError url_query(const char *nextarg,
 
   if(*nextarg == '+') {
     /* use without encoding */
-    query = strdup(&nextarg[1]);
+    query = STRDUP(&nextarg[1]);
     if(!query)
       err = PARAM_NO_MEM;
   }
@@ -866,11 +866,11 @@ static ParameterError url_query(const char *nextarg,
   if(!err) {
     if(config->query) {
       CURLcode result = curlx_dyn_addf(&dyn, "%s&%s", config->query, query);
-      free(query);
+      FREE(query);
       if(result)
         err = PARAM_NO_MEM;
       else {
-        free(config->query);
+        FREE(config->query);
         config->query = curlx_dyn_ptr(&dyn);
       }
     }
@@ -906,7 +906,7 @@ static ParameterError set_data(cmdline_t cmd,
         CURL_SET_BINMODE(stdin);
     }
     else {
-      file = fopen(nextarg, "rb");
+      file = FOPEN(nextarg, "rb");
       if(!file) {
         errorf(global, "Failed to open %s", nextarg);
         return PARAM_READ_ERROR;
@@ -924,14 +924,14 @@ static ParameterError set_data(cmdline_t cmd,
     }
 
     if(file && (file != stdin))
-      fclose(file);
+      FCLOSE(file);
     if(err)
       return err;
 
     if(!postdata) {
       /* no data from the file, point to a zero byte string to make this
          get sent as a POST anyway */
-      postdata = strdup("");
+      postdata = STRDUP("");
       if(!postdata)
         return PARAM_NO_MEM;
     }
@@ -1107,7 +1107,7 @@ static ParameterError parse_url(struct GlobalConfig *global,
     if(fromstdin)
       f = stdin;
     else
-      f = fopen(&nextarg[1], FOPEN_READTEXT);
+      f = FOPEN(&nextarg[1], FOPEN_READTEXT);
     if(f) {
       curlx_dyn_init(&line, 8092);
       while(my_get_line(f, &line, &error)) {
@@ -1117,7 +1117,7 @@ static ParameterError parse_url(struct GlobalConfig *global,
           break;
       }
       if(!fromstdin)
-        fclose(f);
+        FCLOSE(f);
       curlx_dyn_free(&line);
       if(error || err)
         return PARAM_READ_ERROR;
@@ -1223,7 +1223,7 @@ static ParameterError parse_ech(struct GlobalConfig *global,
         file = stdin;
       }
       else {
-        file = fopen(nextarg, FOPEN_READTEXT);
+        file = FOPEN(nextarg, FOPEN_READTEXT);
       }
       if(!file) {
         warnf(global,
@@ -1234,11 +1234,11 @@ static ParameterError parse_ech(struct GlobalConfig *global,
       }
       err = file2string(&tmpcfg, file);
       if(file != stdin)
-        fclose(file);
+        FCLOSE(file);
       if(err)
         return err;
       config->ech_config = aprintf("ecl:%s",tmpcfg);
-      free(tmpcfg);
+      FREE(tmpcfg);
       if(!config->ech_config)
         return PARAM_NO_MEM;
     } /* file done */
@@ -1261,7 +1261,7 @@ static ParameterError parse_header(struct GlobalConfig *global,
   if(nextarg[0] == '@') {
     /* read many headers from a file or stdin */
     bool use_stdin = !strcmp(&nextarg[1], "-");
-    FILE *file = use_stdin ? stdin : fopen(&nextarg[1], FOPEN_READTEXT);
+    FILE *file = use_stdin ? stdin : FOPEN(&nextarg[1], FOPEN_READTEXT);
     if(!file) {
       errorf(global, "Failed to open %s", &nextarg[1]);
       err = PARAM_READ_ERROR;
@@ -1282,7 +1282,7 @@ static ParameterError parse_header(struct GlobalConfig *global,
         err = PARAM_READ_ERROR;
       curlx_dyn_free(&line);
       if(!use_stdin)
-        fclose(file);
+        FCLOSE(file);
     }
   }
   else {
@@ -1418,8 +1418,8 @@ static ParameterError parse_range(struct GlobalConfig *global,
           "Appending one for you");
     msnprintf(buffer, sizeof(buffer), "%" CURL_FORMAT_CURL_OFF_T "-",
               value);
-    free(config->range);
-    config->range = strdup(buffer);
+    FREE(config->range);
+    config->range = STRDUP(buffer);
     if(!config->range)
       err = PARAM_NO_MEM;
   }
@@ -1503,8 +1503,8 @@ static ParameterError parse_verbose(struct GlobalConfig *global,
   switch(global->verbosity) {
   case 0:
     global->verbosity = 1;
-    free(global->trace_dump);
-    global->trace_dump = strdup("%");
+    FREE(global->trace_dump);
+    global->trace_dump = STRDUP("%");
     if(!global->trace_dump)
       err = PARAM_NO_MEM;
     else {
@@ -1556,7 +1556,7 @@ static ParameterError parse_writeout(struct GlobalConfig *global,
     }
     else {
       fname = nextarg;
-      file = fopen(fname, FOPEN_READTEXT);
+      file = FOPEN(fname, FOPEN_READTEXT);
       if(!file) {
         errorf(global, "Failed to open %s", fname);
         return PARAM_READ_ERROR;
@@ -1565,7 +1565,7 @@ static ParameterError parse_writeout(struct GlobalConfig *global,
     curlx_safefree(config->writeout);
     err = file2string(&config->writeout, file);
     if(file && (file != stdin))
-      fclose(file);
+      FCLOSE(file);
     if(err)
       return err;
     if(!config->writeout)
@@ -2755,7 +2755,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     case C_HELP: /* --help */
       if(toggle) {
         if(*nextarg) {
-          global->help_category = strdup(nextarg);
+          global->help_category = STRDUP(nextarg);
           if(!global->help_category) {
             err = PARAM_NO_MEM;
             break;
@@ -2985,7 +2985,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
 
 error:
   if(nextalloc)
-    free(CURL_UNCONST(nextarg));
+    FREE(CURL_UNCONST(nextarg));
   return err;
 }
 
@@ -3032,7 +3032,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
 
           if(config->url_list && config->url_list->url) {
             /* Allocate the next config */
-            config->next = malloc(sizeof(struct OperationConfig));
+            config->next = MALLOC(sizeof(struct OperationConfig));
             if(config->next) {
               /* Initialise the newly created config */
               config_init(config->next);

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -298,7 +298,7 @@ void tool_help(char *category)
     puts("Unknown category provided, here is a list of all categories:\n");
     get_categories();
   }
-  free(category);
+  FREE(category);
 }
 
 static bool is_debug(void)
@@ -362,7 +362,7 @@ void tool_version_info(void)
 #ifdef CURL_CA_EMBED
     ++feat_ext_count;
 #endif
-    feat_ext = malloc(sizeof(*feature_names) * (feat_ext_count + 1));
+    feat_ext = MALLOC(sizeof(*feature_names) * (feat_ext_count + 1));
     if(feat_ext) {
       memcpy((void *)feat_ext, feature_names,
              sizeof(*feature_names) * feature_count);
@@ -377,7 +377,7 @@ void tool_version_info(void)
       for(builtin = feat_ext; *builtin; ++builtin)
         printf(" %s", *builtin);
       puts(""); /* newline */
-      free((void *)feat_ext);
+      FREE((void *)feat_ext);
     }
   }
   if(strcmp(CURL_VERSION, curlinfo->version)) {

--- a/src/tool_ipfs.c
+++ b/src/tool_ipfs.c
@@ -91,7 +91,7 @@ static char *ipfs_gateway(void)
   if(!gateway_composed_file_path)
     goto fail;
 
-  gateway_file = fopen(gateway_composed_file_path, FOPEN_READTEXT);
+  gateway_file = FOPEN(gateway_composed_file_path, FOPEN_READTEXT);
   curlx_safefree(gateway_composed_file_path);
 
   if(gateway_file) {
@@ -106,7 +106,7 @@ static char *ipfs_gateway(void)
         goto fail;
     }
 
-    fclose(gateway_file);
+    FCLOSE(gateway_file);
     gateway_file = NULL;
 
     if(curlx_dyn_len(&dyn))
@@ -124,7 +124,7 @@ static char *ipfs_gateway(void)
   }
 fail:
   if(gateway_file)
-    fclose(gateway_file);
+    FCLOSE(gateway_file);
   curlx_safefree(gateway);
   curlx_safefree(ipfs_path);
   return NULL;
@@ -172,7 +172,7 @@ CURLcode ipfs_url_rewrite(CURLU *uh, const char *protocol, char **url,
 
     if(!curl_url_set(gatewayurl, CURLUPART_URL, config->ipfs_gateway,
                     CURLU_GUESS_SCHEME)) {
-      gateway = strdup(config->ipfs_gateway);
+      gateway = STRDUP(config->ipfs_gateway);
       if(!gateway) {
         result = CURLE_URL_MALFORMAT;
         goto clean;
@@ -252,8 +252,8 @@ CURLcode ipfs_url_rewrite(CURLU *uh, const char *protocol, char **url,
   if(curl_url_get(uh, CURLUPART_URL, &cloneurl, CURLU_URLENCODE)) {
     goto clean;
   }
-  /* we need to strdup the URL so that we can call free() on it later */
-  *url = strdup(cloneurl);
+  /* we need to strdup the URL so that we can call FREE() on it later */
+  *url = STRDUP(cloneurl);
   curl_free(cloneurl);
   if(!*url)
     goto clean;
@@ -261,7 +261,7 @@ CURLcode ipfs_url_rewrite(CURLU *uh, const char *protocol, char **url,
   result = CURLE_OK;
 
 clean:
-  free(gateway);
+  FREE(gateway);
   curl_free(gwhost);
   curl_free(gwpath);
   curl_free(gwquery);

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -127,7 +127,7 @@ static void memory_tracking_init(void)
     curl_free(env);
     curl_dbg_memdebug(fname);
     /* this weird stuff here is to make curl_free() get called before
-       curl_dbg_memdebug() as otherwise memory tracking will log a free()
+       curl_dbg_memdebug() as otherwise memory tracking will log a FREE()
        without an alloc! */
   }
   /* if CURL_MEMLIMIT is set, this enables fail-on-alloc-number-N feature */
@@ -164,7 +164,7 @@ static CURLcode main_init(struct GlobalConfig *config)
   config->parallel_max = PARALLEL_DEFAULT;
 
   /* Allocate the initial operate config */
-  config->first = config->last = malloc(sizeof(struct OperationConfig));
+  config->first = config->last = MALLOC(sizeof(struct OperationConfig));
   if(config->first) {
     /* Perform the libcurl initialization */
     result = curl_global_init(CURL_GLOBAL_DEFAULT);
@@ -179,12 +179,12 @@ static CURLcode main_init(struct GlobalConfig *config)
       }
       else {
         errorf(config, "error retrieving curl library information");
-        free(config->first);
+        FREE(config->first);
       }
     }
     else {
       errorf(config, "error initializing curl library");
-      free(config->first);
+      FREE(config->first);
     }
   }
   else {
@@ -200,7 +200,7 @@ static void free_globalconfig(struct GlobalConfig *config)
   curlx_safefree(config->trace_dump);
 
   if(config->trace_fopened && config->trace_stream)
-    fclose(config->trace_stream);
+    FCLOSE(config->trace_stream);
   config->trace_stream = NULL;
 
   curlx_safefree(config->libcurl);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -238,8 +238,7 @@ static curl_off_t vms_realfilesize(const char *name,
   int ret_stat;
   FILE * file;
 
-  /* !checksrc! disable FOPENMODE 1 */
-  file = fopen(name, "r"); /* VMS */
+  file = FOPEN(name, "r"); /* VMS */
   if(!file) {
     return 0;
   }
@@ -250,7 +249,7 @@ static curl_off_t vms_realfilesize(const char *name,
     if(ret_stat)
       count += ret_stat;
   }
-  fclose(file);
+  FCLOSE(file);
 
   return count;
 }
@@ -286,7 +285,7 @@ static curl_off_t all_pers;
 static CURLcode add_per_transfer(struct per_transfer **per)
 {
   struct per_transfer *p;
-  p = calloc(1, sizeof(struct per_transfer));
+  p = CALLOC(1, sizeof(struct per_transfer));
   if(!p)
     return CURLE_OUT_OF_MEMORY;
   if(!transfers)
@@ -330,7 +329,7 @@ static struct per_transfer *del_per_transfer(struct per_transfer *per)
   else
     transfersl = p;
 
-  free(per);
+  FREE(per);
   all_pers--;
 
   return n;
@@ -705,7 +704,7 @@ noretry:
 
   /* Close the outs file */
   if(outs->fopened && outs->stream) {
-    rc = fclose(outs->stream);
+    rc = FCLOSE(outs->stream);
     if(!result && rc) {
       /* something went wrong in the writing process */
       result = CURLE_WRITE_ERROR;
@@ -740,25 +739,25 @@ skip:
 
   /* Close function-local opened file descriptors */
   if(per->heads.fopened && per->heads.stream)
-    fclose(per->heads.stream);
+    FCLOSE(per->heads.stream);
 
   if(per->heads.alloc_filename)
     curlx_safefree(per->heads.filename);
 
   if(per->etag_save.fopened && per->etag_save.stream)
-    fclose(per->etag_save.stream);
+    FCLOSE(per->etag_save.stream);
 
   if(per->etag_save.alloc_filename)
     curlx_safefree(per->etag_save.filename);
 
   curl_easy_cleanup(per->curl);
   if(outs->alloc_filename)
-    free(outs->filename);
-  free(per->url);
-  free(per->outfile);
-  free(per->uploadfile);
+    FREE(outs->filename);
+  FREE(per->url);
+  FREE(per->outfile);
+  FREE(per->uploadfile);
   if(global->parallel)
-    free(per->errorbuffer);
+    FREE(per->errorbuffer);
   curl_slist_free_all(per->hdrcbdata.headlist);
   per->hdrcbdata.headlist = NULL;
   return result;
@@ -833,7 +832,7 @@ static CURLcode set_cert_types(struct OperationConfig *config)
     /* Check if config->cert is a PKCS#11 URI and set the config->cert_type if
      * necessary */
     if(config->cert && !config->cert_type && is_pkcs11_uri(config->cert)) {
-      config->cert_type = strdup("ENG");
+      config->cert_type = STRDUP("ENG");
       if(!config->cert_type)
         return CURLE_OUT_OF_MEMORY;
     }
@@ -841,7 +840,7 @@ static CURLcode set_cert_types(struct OperationConfig *config)
     /* Check if config->key is a PKCS#11 URI and set the config->key_type if
      * necessary */
     if(config->key && !config->key_type && is_pkcs11_uri(config->key)) {
-      config->key_type = strdup("ENG");
+      config->key_type = STRDUP("ENG");
       if(!config->key_type)
         return CURLE_OUT_OF_MEMORY;
     }
@@ -850,7 +849,7 @@ static CURLcode set_cert_types(struct OperationConfig *config)
      * config->proxy_type if necessary */
     if(config->proxy_cert && !config->proxy_cert_type &&
        is_pkcs11_uri(config->proxy_cert)) {
-      config->proxy_cert_type = strdup("ENG");
+      config->proxy_cert_type = STRDUP("ENG");
       if(!config->proxy_cert_type)
         return CURLE_OUT_OF_MEMORY;
     }
@@ -859,7 +858,7 @@ static CURLcode set_cert_types(struct OperationConfig *config)
      * config->proxy_key_type if necessary */
     if(config->proxy_key && !config->proxy_key_type &&
        is_pkcs11_uri(config->proxy_key)) {
-      config->proxy_key_type = strdup("ENG");
+      config->proxy_key_type = STRDUP("ENG");
       if(!config->proxy_key_type)
         return CURLE_OUT_OF_MEMORY;
     }
@@ -1768,7 +1767,7 @@ static CURLcode append2query(struct GlobalConfig *global,
       if(uerr)
         result = urlerr_cvt(uerr);
       else {
-        free(per->url); /* free previous URL */
+        FREE(per->url); /* free previous URL */
         per->url = updated; /* use our new URL instead! */
       }
     }
@@ -1843,7 +1842,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
     /* save outfile pattern before expansion */
     if(urlnode->outfile && !state->outfiles) {
-      state->outfiles = strdup(urlnode->outfile);
+      state->outfiles = STRDUP(urlnode->outfile);
       if(!state->outfiles) {
         errorf(global, "out of memory");
         result = CURLE_OUT_OF_MEMORY;
@@ -1916,7 +1915,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         ParameterError pe;
 
         /* open file for reading: */
-        FILE *file = fopen(config->etag_compare_file, FOPEN_READTEXT);
+        FILE *file = FOPEN(config->etag_compare_file, FOPEN_READTEXT);
         if(!file)
           warnf(global, "Failed to open %s: %s", config->etag_compare_file,
                 strerror(errno));
@@ -1931,7 +1930,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
         if(!header) {
           if(file)
-            fclose(file);
+            FCLOSE(file);
           errorf(global,
                  "Failed to allocate memory for custom etag header");
           result = CURLE_OUT_OF_MEMORY;
@@ -1943,7 +1942,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         curlx_safefree(header);
 
         if(file)
-          fclose(file);
+          FCLOSE(file);
         if(pe != PARAM_OK) {
           result = CURLE_OUT_OF_MEMORY;
           break;
@@ -1959,7 +1958,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 
         /* open file for output: */
         if(strcmp(config->etag_save_file, "-")) {
-          FILE *newfile = fopen(config->etag_save_file, "ab");
+          FILE *newfile = FOPEN(config->etag_save_file, "ab");
           if(!newfile) {
             warnf(global, "Failed creating file for saving etags: \"%s\". "
                   "Skip this transfer", config->etag_save_file);
@@ -1988,12 +1987,12 @@ static CURLcode single_transfer(struct GlobalConfig *global,
       if(result) {
         curl_easy_cleanup(curl);
         if(etag_save->fopened)
-          fclose(etag_save->stream);
+          FCLOSE(etag_save->stream);
         break;
       }
       per->etag_save = etag_first; /* copy the whole struct */
       if(state->uploadfile) {
-        per->uploadfile = strdup(state->uploadfile);
+        per->uploadfile = STRDUP(state->uploadfile);
         if(!per->uploadfile) {
           curl_easy_cleanup(curl);
           result = CURLE_OUT_OF_MEMORY;
@@ -2042,11 +2041,11 @@ static CURLcode single_transfer(struct GlobalConfig *global,
               break;
           }
           if(!per->prev || per->prev->config != config) {
-            newfile = fopen(config->headerfile, "wb");
+            newfile = FOPEN(config->headerfile, "wb");
             if(newfile)
-              fclose(newfile);
+              FCLOSE(newfile);
           }
-          newfile = fopen(config->headerfile, "ab");
+          newfile = FOPEN(config->headerfile, "ab");
 
           if(!newfile) {
             errorf(global, "Failed to open %s", config->headerfile);
@@ -2083,7 +2082,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
           break;
       }
       else if(!state->li) {
-        per->url = strdup(urlnode->url);
+        per->url = STRDUP(urlnode->url);
         if(!per->url) {
           result = CURLE_OUT_OF_MEMORY;
           break;
@@ -2095,7 +2094,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         break;
 
       if(state->outfiles) {
-        per->outfile = strdup(state->outfiles);
+        per->outfile = STRDUP(state->outfiles);
         if(!per->outfile) {
           result = CURLE_OUT_OF_MEMORY;
           break;
@@ -2143,7 +2142,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             result = CURLE_WRITE_ERROR;
             break;
           }
-          free(per->outfile);
+          FREE(per->outfile);
           per->outfile = d;
         }
         /* Create the directory hierarchy, if not pre-existent to a multiple
@@ -2189,11 +2188,11 @@ static CURLcode single_transfer(struct GlobalConfig *global,
 #ifdef __VMS
           /* open file for output, forcing VMS output format into stream
              mode which is needed for stat() call above to always work. */
-          FILE *file = fopen(outfile, "ab",
+          FILE *file = FOPEN(outfile, "ab",
                              "ctx=stm", "rfm=stmlf", "rat=cr", "mrs=0");
 #else
           /* open file for output: */
-          FILE *file = fopen(per->outfile, "ab");
+          FILE *file = FOPEN(per->outfile, "ab");
 #endif
           if(!file) {
             errorf(global, "cannot open '%s'", per->outfile);
@@ -2391,7 +2390,7 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
     if(result)
       return result;
 
-    errorbuf = malloc(CURL_ERROR_SIZE);
+    errorbuf = MALLOC(CURL_ERROR_SIZE);
     if(!errorbuf)
       return CURLE_OUT_OF_MEMORY;
 
@@ -2424,7 +2423,7 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
       } while(skipped);
     }
     if(result) {
-      free(errorbuf);
+      FREE(errorbuf);
       return result;
     }
     errorbuf[0] = 0;
@@ -2548,7 +2547,7 @@ static struct contextuv *create_context(curl_socket_t sockfd,
 {
   struct contextuv *c;
 
-  c = (struct contextuv *) malloc(sizeof(*c));
+  c = (struct contextuv *) MALLOC(sizeof(*c));
 
   c->sockfd = sockfd;
   c->uv = uv;
@@ -2562,7 +2561,7 @@ static struct contextuv *create_context(curl_socket_t sockfd,
 static void close_cb(uv_handle_t *handle)
 {
   struct contextuv *c = (struct contextuv *) handle->data;
-  free(c);
+  FREE(c);
 }
 
 static void destroy_context(struct contextuv *c)
@@ -2990,7 +2989,7 @@ static CURLcode cacertpaths(struct OperationConfig *config)
   CURLcode result = CURLE_OUT_OF_MEMORY;
   char *env = curl_getenv("CURL_CA_BUNDLE");
   if(env) {
-    config->cacert = strdup(env);
+    config->cacert = STRDUP(env);
     curl_free(env);
     if(!config->cacert)
       goto fail;
@@ -2998,14 +2997,14 @@ static CURLcode cacertpaths(struct OperationConfig *config)
   else {
     env = curl_getenv("SSL_CERT_DIR");
     if(env) {
-      config->capath = strdup(env);
+      config->capath = STRDUP(env);
       curl_free(env);
       if(!config->capath)
         goto fail;
     }
     env = curl_getenv("SSL_CERT_FILE");
     if(env) {
-      config->cacert = strdup(env);
+      config->cacert = STRDUP(env);
       curl_free(env);
       if(!config->cacert)
         goto fail;
@@ -3018,8 +3017,8 @@ static CURLcode cacertpaths(struct OperationConfig *config)
     char *cacert = NULL;
     FILE *cafile = tool_execpath("curl-ca-bundle.crt", &cacert);
     if(cafile) {
-      fclose(cafile);
-      config->cacert = strdup(cacert);
+      FCLOSE(cafile);
+      config->cacert = STRDUP(cacert);
     }
 #elif !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE) && \
   !defined(CURL_DISABLE_CA_SEARCH)
@@ -3031,7 +3030,7 @@ static CURLcode cacertpaths(struct OperationConfig *config)
 #endif
   return CURLE_OK;
 fail:
-  free(config->capath);
+  FREE(config->capath);
   return result;
 }
 
@@ -3151,7 +3150,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
   CURLcode result = CURLE_OK;
   const char *first_arg;
 #ifdef UNDER_CE
-  first_arg = argc > 1 ? strdup(argv[1]) : NULL;
+  first_arg = argc > 1 ? STRDUP(argv[1]) : NULL;
 #else
   first_arg = argc > 1 ? convert_tchar_to_UTF8(argv[1]) : NULL;
 #endif

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -149,7 +149,7 @@ CURLcode add_file_name_to_url(CURL *curl, char **inurlp, const char *filename)
         if(!newpath)
           goto fail;
         uerr = curl_url_set(uh, CURLUPART_PATH, newpath, 0);
-        free(newpath);
+        FREE(newpath);
         if(uerr) {
           result = urlerr_cvt(uerr);
           goto fail;
@@ -159,7 +159,7 @@ CURLcode add_file_name_to_url(CURL *curl, char **inurlp, const char *filename)
           result = urlerr_cvt(uerr);
           goto fail;
         }
-        free(*inurlp);
+        FREE(*inurlp);
         *inurlp = newurl;
         result = CURLE_OK;
       }
@@ -212,11 +212,11 @@ CURLcode get_url_file_name(struct GlobalConfig *global,
 
       if(pc) {
         /* duplicate the string beyond the slash */
-        *filename = strdup(pc + 1);
+        *filename = STRDUP(pc + 1);
       }
       else {
         /* no slash => empty string, use default */
-        *filename = strdup("curl_response");
+        *filename = STRDUP("curl_response");
         warnf(global, "No remote file name, uses \"%s\"", *filename);
       }
 

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -40,7 +40,7 @@
 
 struct getout *new_getout(struct OperationConfig *config)
 {
-  struct getout *node = calloc(1, sizeof(struct getout));
+  struct getout *node = CALLOC(1, sizeof(struct getout));
   struct getout *last = config->url_last;
   if(node) {
     static int outnum = 0;
@@ -419,7 +419,7 @@ ParameterError proto2num(struct OperationConfig *config,
 
   curlx_dyn_init(&obuf, MAX_PROTOSTRING);
 
-  protoset = malloc((proto_count + 1) * sizeof(*protoset));
+  protoset = MALLOC((proto_count + 1) * sizeof(*protoset));
   if(!protoset)
     return PARAM_NO_MEM;
 
@@ -517,9 +517,9 @@ ParameterError proto2num(struct OperationConfig *config,
   result = curlx_dyn_addn(&obuf, "", 0);
   for(proto = 0; protoset[proto] && !result; proto++)
     result = curlx_dyn_addf(&obuf, "%s,", protoset[proto]);
-  free((char *) protoset);
+  FREE((char *) protoset);
   curlx_dyn_setlen(&obuf, curlx_dyn_len(&obuf) - 1);
-  free(*ostr);
+  FREE(*ostr);
   *ostr = curlx_dyn_ptr(&obuf);
 
   return *ostr ? PARAM_OK : PARAM_NO_MEM;
@@ -606,7 +606,7 @@ static CURLcode checkpasswd(const char *kind, /* for what purpose */
       return CURLE_OUT_OF_MEMORY;
 
     /* return the new string */
-    free(*userpwd);
+    FREE(*userpwd);
     *userpwd = curlx_dyn_ptr(&dyn);
   }
 
@@ -672,7 +672,7 @@ long delegation(struct OperationConfig *config, const char *str)
  */
 static char *my_useragent(void)
 {
-  return strdup(CURL_NAME "/" CURL_VERSION);
+  return STRDUP(CURL_NAME "/" CURL_VERSION);
 }
 
 #define isheadersep(x) ((((x)==':') || ((x)==';')))

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -57,9 +57,9 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
     /* NULL means load .curlrc from homedir! */
     char *curlrc = findfile(".curlrc", CURLRC_DOTSCORE);
     if(curlrc) {
-      file = fopen(curlrc, FOPEN_READTEXT);
+      file = FOPEN(curlrc, FOPEN_READTEXT);
       if(!file) {
-        free(curlrc);
+        FREE(curlrc);
         return 1;
       }
       filename = pathalloc = curlrc;
@@ -79,7 +79,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
   }
   else {
     if(strcmp(filename, "-"))
-      file = fopen(filename, FOPEN_READTEXT);
+      file = FOPEN(filename, FOPEN_READTEXT);
     else
       file = stdin;
   }
@@ -130,7 +130,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       if(*line == '\"') {
         /* quoted parameter, do the quote dance */
         line++;
-        param = malloc(strlen(line) + 1); /* parameter */
+        param = MALLOC(strlen(line) + 1); /* parameter */
         if(!param) {
           /* out of memory */
           rc = 1;
@@ -186,7 +186,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       if(res == PARAM_NEXT_OPERATION) {
         if(operation->url_list && operation->url_list->url) {
           /* Allocate the next config */
-          operation->next = malloc(sizeof(struct OperationConfig));
+          operation->next = MALLOC(sizeof(struct OperationConfig));
           if(operation->next) {
             /* Initialise the newly created config */
             config_init(operation->next);
@@ -228,14 +228,14 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
     }
     curlx_dyn_free(&buf);
     if(file != stdin)
-      fclose(file);
+      FCLOSE(file);
     if(fileerror)
       rc = 1;
   }
   else
     rc = 1; /* could not open the file */
 
-  free(pathalloc);
+  FREE(pathalloc);
   return rc;
 }
 

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -376,7 +376,7 @@ static CURLcode libcurl_generate_slist(struct curl_slist *slist, int *slistno)
     ret = easysrc_addf(&easysrc_data,
                        "slist%d = curl_slist_append(slist%d, \"%s\");",
                        *slistno, *slistno, escaped);
-    free(escaped);
+    FREE(escaped);
   }
 
   return ret;
@@ -430,7 +430,7 @@ static CURLcode libcurl_generate_mime_part(CURL *curl,
         easysrc_addf(&easysrc_code,
                      "curl_mime_data(part%d, \"%s\", CURL_ZERO_TERMINATED);",
                      mimeno, escaped);
-      free(escaped);
+      FREE(escaped);
     }
     break;
 
@@ -443,7 +443,7 @@ static CURLcode libcurl_generate_mime_part(CURL *curl,
       ret = easysrc_addf(&easysrc_code,
                          "curl_mime_filename(part%d, NULL);", mimeno);
     }
-    free(escaped);
+    FREE(escaped);
     break;
   }
 
@@ -468,28 +468,28 @@ static CURLcode libcurl_generate_mime_part(CURL *curl,
     char *escaped = c_escape(part->encoder, ZERO_TERMINATED);
     ret = easysrc_addf(&easysrc_code, "curl_mime_encoder(part%d, \"%s\");",
                        mimeno, escaped);
-    free(escaped);
+    FREE(escaped);
   }
 
   if(!ret && filename) {
     char *escaped = c_escape(filename, ZERO_TERMINATED);
     ret = easysrc_addf(&easysrc_code, "curl_mime_filename(part%d, \"%s\");",
                        mimeno, escaped);
-    free(escaped);
+    FREE(escaped);
   }
 
   if(!ret && part->name) {
     char *escaped = c_escape(part->name, ZERO_TERMINATED);
     ret = easysrc_addf(&easysrc_code, "curl_mime_name(part%d, \"%s\");",
                        mimeno, escaped);
-    free(escaped);
+    FREE(escaped);
   }
 
   if(!ret && part->type) {
     char *escaped = c_escape(part->type, ZERO_TERMINATED);
     ret = easysrc_addf(&easysrc_code, "curl_mime_type(part%d, \"%s\");",
                        mimeno, escaped);
-    free(escaped);
+    FREE(escaped);
   }
 
   if(!ret && part->headers) {
@@ -669,7 +669,7 @@ CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *global,
       if(escaped) {
         ret = easysrc_addf(&easysrc_code, "curl_easy_setopt(hnd, %s, \"%s\");",
                            name, escaped);
-        free(escaped);
+        FREE(escaped);
       }
     }
   }

--- a/src/tool_ssls.c
+++ b/src/tool_ssls.c
@@ -32,6 +32,7 @@
 #include "dynbuf.h"
 #include "curl_base64.h"
 #include "tool_parsecfg.h"
+#include "memdebug.h"
 
 /* The maximum line length for an ecoded session ticket */
 #define MAX_SSLS_LINE (64 * 1024)
@@ -71,7 +72,7 @@ CURLcode tool_ssls_load(struct GlobalConfig *global,
   bool error = FALSE;
 
   curlx_dyn_init(&buf, MAX_SSLS_LINE);
-  fp = fopen(filename, FOPEN_READTEXT);
+  fp = FOPEN(filename, FOPEN_READTEXT);
   if(!fp) { /* ok if it does not exist */
     notef(global, "SSL session file does not exist (yet?): %s", filename);
     goto out;
@@ -128,7 +129,7 @@ out:
   if(easy)
     curl_easy_cleanup(easy);
   if(fp)
-    fclose(fp);
+    FCLOSE(fp);
   curlx_dyn_free(&buf);
   curl_free(shmac);
   curl_free(sdata);
@@ -200,7 +201,7 @@ CURLcode tool_ssls_save(struct GlobalConfig *global,
 
   ctx.global = global;
   ctx.exported = 0;
-  ctx.fp = fopen(filename, FOPEN_WRITETEXT);
+  ctx.fp = FOPEN(filename, FOPEN_WRITETEXT);
   if(!ctx.fp) {
     warnf(global, "Warning: Failed to create SSL session file %s", filename);
     goto out;
@@ -216,6 +217,6 @@ out:
   if(easy)
     curl_easy_cleanup(easy);
   if(ctx.fp)
-    fclose(ctx.fp);
+    FCLOSE(ctx.fp);
   return r;
 }

--- a/src/tool_stderr.c
+++ b/src/tool_stderr.c
@@ -50,12 +50,12 @@ void tool_set_stderr_file(struct GlobalConfig *global, const char *filename)
 
   /* precheck that filename is accessible to lessen the chance that the
      subsequent freopen will fail. */
-  fp = fopen(filename, FOPEN_WRITETEXT);
+  fp = FOPEN(filename, FOPEN_WRITETEXT);
   if(!fp) {
     warnf(global, "Warning: Failed to open %s", filename);
     return;
   }
-  fclose(fp);
+  FCLOSE(fp);
 
   /* freopen the actual stderr (stdio.h stderr) instead of tool_stderr since
      the latter may be set to stdout. */

--- a/src/tool_strdup.c
+++ b/src/tool_strdup.c
@@ -24,7 +24,7 @@
 #include "tool_strdup.h"
 
 #ifndef HAVE_STRDUP
-char *strdup(const char *str)
+char *STRDUP(const char *str)
 {
   size_t len;
   char *newstr;
@@ -34,7 +34,7 @@ char *strdup(const char *str)
 
   len = strlen(str) + 1;
 
-  newstr = malloc(len);
+  newstr = MALLOC(len);
   if(!newstr)
     return (char *)NULL;
 

--- a/src/tool_strdup.h
+++ b/src/tool_strdup.h
@@ -26,7 +26,7 @@
 #include "tool_setup.h"
 
 #ifndef HAVE_STRDUP
-extern char *strdup(const char *str);
+extern char *STRDUP(const char *str);
 #endif
 
 #endif /* HEADER_TOOL_STRDUP_H */

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -43,12 +43,12 @@ static CURLcode glob_fixed(struct URLGlob *glob, char *fixed, size_t len)
   pat->content.Set.ptr_s = 0;
   pat->globindex = -1;
 
-  pat->content.Set.elements = malloc(sizeof(char *));
+  pat->content.Set.elements = MALLOC(sizeof(char *));
 
   if(!pat->content.Set.elements)
     return GLOBERROR("out of memory", 0, CURLE_OUT_OF_MEMORY);
 
-  pat->content.Set.elements[0] = malloc(len + 1);
+  pat->content.Set.elements[0] = MALLOC(len + 1);
   if(!pat->content.Set.elements[0])
     return GLOBERROR("out of memory", 0, CURLE_OUT_OF_MEMORY);
 
@@ -130,7 +130,7 @@ static CURLcode glob_set(struct URLGlob *glob, const char **patternp,
 
       *buf = '\0';
       if(pat->content.Set.elements) {
-        char **new_arr = realloc(pat->content.Set.elements,
+        char **new_arr = REALLOC(pat->content.Set.elements,
                                  (size_t)(pat->content.Set.size + 1) *
                                  sizeof(char *));
         if(!new_arr)
@@ -139,13 +139,13 @@ static CURLcode glob_set(struct URLGlob *glob, const char **patternp,
         pat->content.Set.elements = new_arr;
       }
       else
-        pat->content.Set.elements = malloc(sizeof(char *));
+        pat->content.Set.elements = MALLOC(sizeof(char *));
 
       if(!pat->content.Set.elements)
         return GLOBERROR("out of memory", 0, CURLE_OUT_OF_MEMORY);
 
       pat->content.Set.elements[pat->content.Set.size] =
-        strdup(glob->glob_buffer);
+        STRDUP(glob->glob_buffer);
       if(!pat->content.Set.elements[pat->content.Set.size])
         return GLOBERROR("out of memory", 0, CURLE_OUT_OF_MEMORY);
       ++pat->content.Set.size;
@@ -442,12 +442,12 @@ CURLcode glob_url(struct URLGlob **glob, char *url, curl_off_t *urlnum,
 
   *glob = NULL;
 
-  glob_buffer = malloc(strlen(url) + 1);
+  glob_buffer = MALLOC(strlen(url) + 1);
   if(!glob_buffer)
     return CURLE_OUT_OF_MEMORY;
   glob_buffer[0] = 0;
 
-  glob_expand = calloc(1, sizeof(struct URLGlob));
+  glob_expand = CALLOC(1, sizeof(struct URLGlob));
   if(!glob_expand) {
     curlx_safefree(glob_buffer);
     return CURLE_OUT_OF_MEMORY;
@@ -596,7 +596,7 @@ CURLcode glob_next_url(char **globbed, struct URLGlob *glob)
     }
   }
 
-  *globbed = strdup(glob->glob_buffer);
+  *globbed = STRDUP(glob->glob_buffer);
   if(!*globbed)
     return CURLE_OUT_OF_MEMORY;
 

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -129,7 +129,7 @@ FILE *tool_execpath(const char *filename, char **pathp)
       if(strlen(filename) < remaining - 1) {
         msnprintf(lastdirchar, remaining, "%s%s", DIR_CHAR, filename);
         *pathp = filebuffer;
-        return fopen(filebuffer, FOPEN_READTEXT);
+        return FOPEN(filebuffer, FOPEN_READTEXT);
       }
     }
   }

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -591,13 +591,13 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
               break;
             case VAR_STDOUT:
               if(fclose_stream)
-                fclose(stream);
+                FCLOSE(stream);
               fclose_stream = FALSE;
               stream = stdout;
               break;
             case VAR_STDERR:
               if(fclose_stream)
-                fclose(stream);
+                FCLOSE(stream);
               fclose_stream = FALSE;
               stream = tool_stderr;
               break;
@@ -655,12 +655,12 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
               FILE *stream2;
               memcpy(fname, ptr, flen);
               fname[flen] = 0;
-              stream2 = fopen(fname, append ? FOPEN_APPENDTEXT :
+              stream2 = FOPEN(fname, append ? FOPEN_APPENDTEXT :
                               FOPEN_WRITETEXT);
               if(stream2) {
                 /* only change if the open worked */
                 if(fclose_stream)
-                  fclose(stream);
+                  FCLOSE(stream);
                 stream = stream2;
                 fclose_stream = TRUE;
               }
@@ -703,6 +703,6 @@ void ourWriteOut(struct OperationConfig *config, struct per_transfer *per,
     }
   }
   if(fclose_stream)
-    fclose(stream);
+    FCLOSE(stream);
   curlx_dyn_free(&name);
 }

--- a/src/var.c
+++ b/src/var.c
@@ -44,7 +44,7 @@
 
 static char *Memdup(const char *data, size_t len)
 {
-  char *p = malloc(len + 1);
+  char *p = MALLOC(len + 1);
   if(!p)
     return NULL;
   if(len)
@@ -60,8 +60,8 @@ void varcleanup(struct GlobalConfig *global)
   while(list) {
     struct tool_var *t = list;
     list = list->next;
-    free(CURL_UNCONST(t->content));
-    free(t);
+    FREE(CURL_UNCONST(t->content));
+    FREE(t);
   }
 }
 
@@ -210,7 +210,7 @@ static ParameterError varfunc(struct GlobalConfig *global,
       break;
     }
     if(alloc)
-      free(c);
+      FREE(c);
 
     clen = curlx_dyn_len(out);
     c = Memdup(curlx_dyn_ptr(out), clen);
@@ -221,7 +221,7 @@ static ParameterError varfunc(struct GlobalConfig *global,
     alloc = TRUE;
   }
   if(alloc)
-    free(c);
+    FREE(c);
   if(err)
     curlx_dyn_free(out);
   return err;
@@ -380,7 +380,7 @@ static ParameterError addvariable(struct GlobalConfig *global,
   if(check)
     notef(global, "Overwriting variable '%s'", check->name);
 
-  p = calloc(1, sizeof(struct tool_var) + nlen);
+  p = CALLOC(1, sizeof(struct tool_var) + nlen);
   if(p) {
     memcpy(p->name, name, nlen);
 
@@ -392,7 +392,7 @@ static ParameterError addvariable(struct GlobalConfig *global,
       global->variables = p;
       return PARAM_OK;
     }
-    free(p);
+    FREE(p);
   }
   return PARAM_NO_MEM;
 }
@@ -477,7 +477,7 @@ ParameterError setvariable(struct GlobalConfig *global,
     if(use_stdin)
       file = stdin;
     else {
-      file = fopen(line, "rb");
+      file = FOPEN(line, "rb");
       if(!file) {
         errorf(global, "Failed to open %s: %s", line,
                strerror(errno));
@@ -492,7 +492,7 @@ ParameterError setvariable(struct GlobalConfig *global,
     }
     curlx_dyn_free(&fname);
     if(!use_stdin && file)
-      fclose(file);
+      FCLOSE(file);
     if(err)
       return err;
   }
@@ -520,7 +520,7 @@ ParameterError setvariable(struct GlobalConfig *global,
   err = addvariable(global, name, nlen, content, clen, contalloc);
   if(err) {
     if(contalloc)
-      free(content);
+      FREE(content);
   }
   return err;
 }


### PR DESCRIPTION
All monitored functions are now instead provided using the same name but using uppercase. This, to avoid having to redefine the real symbol names which causes grief occasionally.

This also "bans" the non-uppercase function names with check src to prevent the risk that they accidentally slip in again.

Submitted as a draft as this is more of a discussion starter.