### PR TITLE
GHA/windows: drop GnuTLS-fork from vcpkg MultiSSL job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -779,16 +779,14 @@ jobs:
               -DCURL_USE_GSASL=ON -DENABLE_ARES=ON -DCURL_USE_LIBUV=ON -DCURL_USE_GSSAPI=ON
 
           - name: 'schannel MultiSSL U'
-            # GnuTLS is not fully functional with MSVC, build-test only
-            # https://github.com/ShiftMediaProject/gnutls/issues/23
-            install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl shiftmedia-libgnutls openssl mbedtls wolfssl'
+            install: 'brotli zlib zstd libpsl nghttp2 libssh2[core,zlib] pkgconf gsasl openssl mbedtls wolfssl'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_LIBSSH2=ON
-              -DCURL_USE_SCHANNEL=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_WOLFSSL=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
+              -DCURL_USE_SCHANNEL=ON -DCURL_USE_OPENSSL=ON -DCURL_USE_MBEDTLS=ON -DCURL_USE_WOLFSSL=ON -DCURL_DEFAULT_SSL_BACKEND=schannel
               -DCURL_USE_GSASL=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
 
           - name: 'libressl'


### PR DESCRIPTION
curl now has a working GnuTLS CI job, with tests, with MSYS2.
The MultiSSL build scenario is now tested on macOS.

The vcpkg GnuTLS package seems to have a deep dependency tree with large
packages that need to be rebuilt relatively frequently. Since they can't
fit into to the time limit, these cause CI failures.

To stabilize CI, drop the `shiftmedia-libgnutls` dependency.

Partial revert of e86f99824c4de0024cc90bca53efe205fd1c1dcc #16623
Ref: https://github.com/curl/curl/actions/runs/14192680124/job/39760753274?pr=16902
