### PR TITLE
eventfd: fix feature guards

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -165,14 +165,16 @@ void destroy_thread_sync_data(struct thread_sync_data *tsd)
   if(tsd->res)
     Curl_freeaddrinfo(tsd->res);
 
-#if !defined(CURL_DISABLE_SOCKETPAIR) && !defined(USE_EVENTFD)
+#ifndef CURL_DISABLE_SOCKETPAIR
   /*
    * close one end of the socket pair (may be done in resolver thread);
    * the other end (for reading) is always closed in the parent thread.
    */
+#ifndef USE_EVENTFD
   if(tsd->sock_pair[1] != CURL_SOCKET_BAD) {
     wakeup_close(tsd->sock_pair[1]);
   }
+#endif
 #endif
   memset(tsd, 0, sizeof(*tsd));
 }

--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -170,7 +170,7 @@ void destroy_thread_sync_data(struct thread_sync_data *tsd)
    * close one end of the socket pair (may be done in resolver thread);
    * the other end (for reading) is always closed in the parent thread.
    */
-#ifndef HAVE_EVENTFD
+#if !defined(HAVE_EVENTFD) || !defined(HAVE_SYS_EVENTFD_H)
   if(tsd->sock_pair[1] != CURL_SOCKET_BAD) {
     wakeup_close(tsd->sock_pair[1]);
   }
@@ -293,7 +293,7 @@ CURL_STDCALL getaddrinfo_thread(void *arg)
   else {
 #ifndef CURL_DISABLE_SOCKETPAIR
     if(tsd->sock_pair[1] != CURL_SOCKET_BAD) {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && defined(HAVE_SYS_EVENTFD_H)
       const uint64_t buf[1] = { 1 };
 #else
       const char buf[1] = { 1 };

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -455,6 +455,11 @@
 #  define __NO_NET_API
 #endif
 
+/* Whether to use eventfd() */
+#if defined(HAVE_EVENTFD) && defined(HAVE_SYS_EVENTFD_H)
+#define USE_EVENTFD
+#endif
+
 #include <stdio.h>
 #include <assert.h>
 

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1408,7 +1408,7 @@ CURLMcode curl_multi_wakeup(CURLM *m)
      and before cleanup */
   if(multi->wakeup_pair[1] != CURL_SOCKET_BAD) {
     while(1) {
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && defined(HAVE_SYS_EVENTFD_H)
       /* eventfd has a stringent rule of requiring the 8-byte buffer when
          calling write(2) on it */
       const uint64_t buf[1] = { 1 };

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1408,7 +1408,7 @@ CURLMcode curl_multi_wakeup(CURLM *m)
      and before cleanup */
   if(multi->wakeup_pair[1] != CURL_SOCKET_BAD) {
     while(1) {
-#if defined(HAVE_EVENTFD) && defined(HAVE_SYS_EVENTFD_H)
+#ifdef USE_EVENTFD
       /* eventfd has a stringent rule of requiring the 8-byte buffer when
          calling write(2) on it */
       const uint64_t buf[1] = { 1 };

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2748,7 +2748,7 @@ CURLMcode curl_multi_cleanup(CURLM *m)
 #else
 #ifdef ENABLE_WAKEUP
     wakeup_close(multi->wakeup_pair[0]);
-#ifndef HAVE_EVENTFD
+#ifndef USE_EVENTFD
     wakeup_close(multi->wakeup_pair[1]);
 #endif
 #endif

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -27,10 +27,9 @@
 #include "urldata.h"
 #include "rand.h"
 
-#ifdef HAVE_EVENTFD
-#ifdef HAVE_SYS_EVENTFD_H
+#if defined(HAVE_EVENTFD) && defined(HAVE_SYS_EVENTFD_H)
+
 #include <sys/eventfd.h>
-#endif
 
 int Curl_eventfd(curl_socket_t socks[2], bool nonblocking)
 {
@@ -42,7 +41,9 @@ int Curl_eventfd(curl_socket_t socks[2], bool nonblocking)
   socks[0] = socks[1] = efd;
   return 0;
 }
+
 #elif defined(HAVE_PIPE)
+
 #ifdef HAVE_FCNTL
 #include <fcntl.h>
 #endif
@@ -72,8 +73,8 @@ int Curl_pipe(curl_socket_t socks[2], bool nonblocking)
 
   return 0;
 }
-#endif
 
+#endif /* HAVE_EVENTFD && HAVE_SYS_EVENTFD_H */
 
 #ifndef CURL_DISABLE_SOCKETPAIR
 #ifdef HAVE_SOCKETPAIR

--- a/lib/socketpair.c
+++ b/lib/socketpair.c
@@ -27,7 +27,7 @@
 #include "urldata.h"
 #include "rand.h"
 
-#if defined(HAVE_EVENTFD) && defined(HAVE_SYS_EVENTFD_H)
+#ifdef USE_EVENTFD
 
 #include <sys/eventfd.h>
 
@@ -74,7 +74,7 @@ int Curl_pipe(curl_socket_t socks[2], bool nonblocking)
   return 0;
 }
 
-#endif /* HAVE_EVENTFD && HAVE_SYS_EVENTFD_H */
+#endif /* USE_EVENTFD */
 
 #ifndef CURL_DISABLE_SOCKETPAIR
 #ifdef HAVE_SOCKETPAIR

--- a/lib/socketpair.h
+++ b/lib/socketpair.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#if defined(HAVE_EVENTFD) && defined(HAVE_SYS_EVENTFD_H)
+#ifdef USE_EVENTFD
 
 #define wakeup_write  write
 #define wakeup_read   read
@@ -46,7 +46,7 @@ int Curl_eventfd(curl_socket_t socks[2], bool nonblocking);
 #include <curl/curl.h>
 int Curl_pipe(curl_socket_t socks[2], bool nonblocking);
 
-#else /* !HAVE_EVENTFD && !HAVE_SYS_EVENTFD_H && !HAVE_PIPE */
+#else /* !USE_EVENTFD && !HAVE_PIPE */
 
 #define wakeup_write     swrite
 #define wakeup_read      sread
@@ -69,7 +69,7 @@ int Curl_pipe(curl_socket_t socks[2], bool nonblocking);
 #define wakeup_create(p,nb)\
 Curl_socketpair(SOCKETPAIR_FAMILY, SOCKETPAIR_TYPE, 0, p, nb)
 
-#endif /* HAVE_EVENTFD && HAVE_SYS_EVENTFD_H */
+#endif /* USE_EVENTFD */
 
 #ifndef CURL_DISABLE_SOCKETPAIR
 #include <curl/curl.h>

--- a/lib/socketpair.h
+++ b/lib/socketpair.h
@@ -26,7 +26,7 @@
 
 #include "curl_setup.h"
 
-#ifdef HAVE_EVENTFD
+#if defined(HAVE_EVENTFD) && defined(HAVE_SYS_EVENTFD_H)
 
 #define wakeup_write  write
 #define wakeup_read   read
@@ -46,7 +46,7 @@ int Curl_eventfd(curl_socket_t socks[2], bool nonblocking);
 #include <curl/curl.h>
 int Curl_pipe(curl_socket_t socks[2], bool nonblocking);
 
-#else /* !HAVE_EVENTFD && !HAVE_PIPE */
+#else /* !HAVE_EVENTFD && !HAVE_SYS_EVENTFD_H && !HAVE_PIPE */
 
 #define wakeup_write     swrite
 #define wakeup_read      sread
@@ -69,7 +69,7 @@ int Curl_pipe(curl_socket_t socks[2], bool nonblocking);
 #define wakeup_create(p,nb)\
 Curl_socketpair(SOCKETPAIR_FAMILY, SOCKETPAIR_TYPE, 0, p, nb)
 
-#endif /* HAVE_EVENTFD */
+#endif /* HAVE_EVENTFD && HAVE_SYS_EVENTFD_H */
 
 #ifndef CURL_DISABLE_SOCKETPAIR
 #include <curl/curl.h>


### PR DESCRIPTION
Enable eventfd code consistently when both `HAVE_EVENTFD` and
`HAVE_SYS_EVENTFD_H` macros are defined.

Before this patch `HAVE_EVENTFD` guarded it alone, though the code
also required the header, which was guarded by `HAVE_SYS_EVENTFD_H`.

These should normally be detected in pairs. When they aren't, omit using
`eventfd()` to avoid calling it without a known matching header.

If this disables valid cases (e.g. some system declares this function
via a different header), feature detection and the code may be extended
for those cases. If these are known to come in pairs, always, another
option is detect them both at build stage, and forward a single macro
to C.

Reported-by: Abhinav Singhal
Bug: https://curl.se/mail/lib-2025-04/0000.html
