### PR TITLE
configure: restore link checks

### DIFF
--- a/m4/curl-functions.m4
+++ b/m4/curl-functions.m4
@@ -650,20 +650,39 @@ dnl HAVE_CLOSESOCKET will be defined.
 AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
   AC_REQUIRE([CURL_INCLUDES_WINSOCK2])dnl
   #
+  tst_links_closesocket="unknown"
   tst_proto_closesocket="unknown"
   tst_compi_closesocket="unknown"
   tst_allow_closesocket="unknown"
   #
-  AC_MSG_CHECKING([if closesocket is prototyped])
-  AC_EGREP_CPP([closesocket],[
-    $curl_includes_winsock2
+  AC_MSG_CHECKING([if closesocket can be linked])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+      $curl_includes_winsock2
+    ]],[[
+      if(0 != closesocket(0))
+        return 1;
+    ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_proto_closesocket="yes"
+    tst_links_closesocket="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_proto_closesocket="no"
+    tst_links_closesocket="no"
   ])
+  #
+  if test "$tst_links_closesocket" = "yes"; then
+    AC_MSG_CHECKING([if closesocket is prototyped])
+    AC_EGREP_CPP([closesocket],[
+      $curl_includes_winsock2
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_proto_closesocket="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_proto_closesocket="no"
+    ])
+  fi
   #
   if test "$tst_proto_closesocket" = "yes"; then
     AC_MSG_CHECKING([if closesocket is compilable])
@@ -695,7 +714,8 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET], [
   fi
   #
   AC_MSG_CHECKING([if closesocket might be used])
-  if test "$tst_proto_closesocket" = "yes" &&
+  if test "$tst_links_closesocket" = "yes" &&
+     test "$tst_proto_closesocket" = "yes" &&
      test "$tst_compi_closesocket" = "yes" &&
      test "$tst_allow_closesocket" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -721,11 +741,12 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET_CAMEL], [
   AC_REQUIRE([CURL_INCLUDES_SYS_SOCKET])dnl
   AC_REQUIRE([CURL_INCLUDES_BSDSOCKET])dnl
   #
+  tst_links_closesocket_camel="unknown"
   tst_compi_closesocket_camel="unknown"
   tst_allow_closesocket_camel="unknown"
   #
-  AC_MSG_CHECKING([if CloseSocket is compilable])
-  AC_COMPILE_IFELSE([
+  AC_MSG_CHECKING([if CloseSocket can be linked])
+  AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_bsdsocket
       $curl_includes_sys_socket
@@ -735,11 +756,30 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET_CAMEL], [
     ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_compi_closesocket_camel="yes"
+    tst_links_closesocket_camel="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_compi_closesocket_camel="no"
+    tst_links_closesocket_camel="no"
   ])
+  #
+  if test "$tst_links_closesocket_camel" = "yes"; then
+    AC_MSG_CHECKING([if CloseSocket is compilable])
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[
+        $curl_includes_bsdsocket
+        $curl_includes_sys_socket
+      ]],[[
+        if(0 != CloseSocket(0))
+          return 1;
+      ]])
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_compi_closesocket_camel="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_compi_closesocket_camel="no"
+    ])
+  fi
   #
   if test "$tst_compi_closesocket_camel" = "yes"; then
     AC_MSG_CHECKING([if CloseSocket usage allowed])
@@ -753,7 +793,8 @@ AC_DEFUN([CURL_CHECK_FUNC_CLOSESOCKET_CAMEL], [
   fi
   #
   AC_MSG_CHECKING([if CloseSocket might be used])
-  if test "$tst_compi_closesocket_camel" = "yes" &&
+  if test "$tst_links_closesocket_camel" = "yes" &&
+     test "$tst_compi_closesocket_camel" = "yes" &&
      test "$tst_allow_closesocket_camel" = "yes"; then
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_CLOSESOCKET_CAMEL, 1,
@@ -927,22 +968,42 @@ AC_DEFUN([CURL_CHECK_FUNC_FREEADDRINFO], [
   AC_REQUIRE([CURL_INCLUDES_SYS_SOCKET])dnl
   AC_REQUIRE([CURL_INCLUDES_NETDB])dnl
   #
+  tst_links_freeaddrinfo="unknown"
   tst_proto_freeaddrinfo="unknown"
   tst_compi_freeaddrinfo="unknown"
   tst_allow_freeaddrinfo="unknown"
   #
-  AC_MSG_CHECKING([if freeaddrinfo is prototyped])
-  AC_EGREP_CPP([freeaddrinfo],[
-    $curl_includes_ws2tcpip
-    $curl_includes_sys_socket
-    $curl_includes_netdb
+  AC_MSG_CHECKING([if freeaddrinfo can be linked])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+      $curl_includes_ws2tcpip
+      $curl_includes_sys_socket
+      $curl_includes_netdb
+    ]],[[
+      freeaddrinfo(0);
+    ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_proto_freeaddrinfo="yes"
+    tst_links_freeaddrinfo="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_proto_freeaddrinfo="no"
+    tst_links_freeaddrinfo="no"
   ])
+  #
+  if test "$tst_links_freeaddrinfo" = "yes"; then
+    AC_MSG_CHECKING([if freeaddrinfo is prototyped])
+    AC_EGREP_CPP([freeaddrinfo],[
+      $curl_includes_ws2tcpip
+      $curl_includes_sys_socket
+      $curl_includes_netdb
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_proto_freeaddrinfo="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_proto_freeaddrinfo="no"
+    ])
+  fi
   #
   if test "$tst_proto_freeaddrinfo" = "yes"; then
     AC_MSG_CHECKING([if freeaddrinfo is compilable])
@@ -975,7 +1036,8 @@ AC_DEFUN([CURL_CHECK_FUNC_FREEADDRINFO], [
   fi
   #
   AC_MSG_CHECKING([if freeaddrinfo might be used])
-  if test "$tst_proto_freeaddrinfo" = "yes" &&
+  if test "$tst_links_freeaddrinfo" = "yes" &&
+     test "$tst_proto_freeaddrinfo" = "yes" &&
      test "$tst_compi_freeaddrinfo" = "yes" &&
      test "$tst_allow_freeaddrinfo" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -1215,24 +1277,46 @@ AC_DEFUN([CURL_CHECK_FUNC_GETADDRINFO], [
   AC_REQUIRE([CURL_INCLUDES_NETDB])dnl
   AC_REQUIRE([CURL_CHECK_NATIVE_WINDOWS])dnl
   #
+  tst_links_getaddrinfo="unknown"
   tst_proto_getaddrinfo="unknown"
   tst_compi_getaddrinfo="unknown"
   tst_works_getaddrinfo="unknown"
   tst_allow_getaddrinfo="unknown"
   tst_tsafe_getaddrinfo="unknown"
   #
-  AC_MSG_CHECKING([if getaddrinfo is prototyped])
-  AC_EGREP_CPP([getaddrinfo],[
-    $curl_includes_ws2tcpip
-    $curl_includes_sys_socket
-    $curl_includes_netdb
+  AC_MSG_CHECKING([if getaddrinfo can be linked])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+      $curl_includes_ws2tcpip
+      $curl_includes_sys_socket
+      $curl_includes_netdb
+    ]],[[
+      struct addrinfo *ai = 0;
+      if(0 != getaddrinfo(0, 0, 0, &ai))
+        return 1;
+    ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_proto_getaddrinfo="yes"
+    tst_links_getaddrinfo="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_proto_getaddrinfo="no"
+    tst_links_getaddrinfo="no"
   ])
+  #
+  if test "$tst_links_getaddrinfo" = "yes"; then
+    AC_MSG_CHECKING([if getaddrinfo is prototyped])
+    AC_EGREP_CPP([getaddrinfo],[
+      $curl_includes_ws2tcpip
+      $curl_includes_sys_socket
+      $curl_includes_netdb
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_proto_getaddrinfo="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_proto_getaddrinfo="no"
+    ])
+  fi
   #
   if test "$tst_proto_getaddrinfo" = "yes"; then
     AC_MSG_CHECKING([if getaddrinfo is compilable])
@@ -1564,22 +1648,44 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
   AC_REQUIRE([CURL_INCLUDES_UNISTD])dnl
   AC_REQUIRE([CURL_PREPROCESS_CALLCONV])dnl
   #
+  tst_links_gethostname="unknown"
   tst_proto_gethostname="unknown"
   tst_compi_gethostname="unknown"
   tst_allow_gethostname="unknown"
   #
-  AC_MSG_CHECKING([if gethostname is prototyped])
-  AC_EGREP_CPP([gethostname],[
-    $curl_includes_winsock2
-    $curl_includes_unistd
-    $curl_includes_bsdsocket
+  AC_MSG_CHECKING([if gethostname can be linked])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+      $curl_includes_winsock2
+      $curl_includes_unistd
+      $curl_includes_bsdsocket
+    ]],[[
+      char s[1];
+      if(0 != gethostname((void *)s, 0))
+        return 1;
+    ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_proto_gethostname="yes"
+    tst_links_gethostname="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_proto_gethostname="no"
+    tst_links_gethostname="no"
   ])
+  #
+  if test "$tst_links_gethostname" = "yes"; then
+    AC_MSG_CHECKING([if gethostname is prototyped])
+    AC_EGREP_CPP([gethostname],[
+      $curl_includes_winsock2
+      $curl_includes_unistd
+      $curl_includes_bsdsocket
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_proto_gethostname="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_proto_gethostname="no"
+    ])
+  fi
   #
   if test "$tst_proto_gethostname" = "yes"; then
     AC_MSG_CHECKING([if gethostname is compilable])
@@ -1650,7 +1756,8 @@ AC_DEFUN([CURL_CHECK_FUNC_GETHOSTNAME], [
   fi
   #
   AC_MSG_CHECKING([if gethostname might be used])
-  if test "$tst_proto_gethostname" = "yes" &&
+  if test "$tst_links_gethostname" = "yes" &&
+     test "$tst_proto_gethostname" = "yes" &&
      test "$tst_compi_gethostname" = "yes" &&
      test "$tst_allow_gethostname" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -1677,22 +1784,43 @@ AC_DEFUN([CURL_CHECK_FUNC_GETPEERNAME], [
   AC_REQUIRE([CURL_PREPROCESS_CALLCONV])dnl
   AC_REQUIRE([CURL_INCLUDES_BSDSOCKET])dnl
   #
+  tst_links_getpeername="unknown"
   tst_proto_getpeername="unknown"
   tst_compi_getpeername="unknown"
   tst_allow_getpeername="unknown"
   #
-  AC_MSG_CHECKING([if getpeername is prototyped])
-  AC_EGREP_CPP([getpeername],[
-    $curl_includes_winsock2
-    $curl_includes_bsdsocket
-    $curl_includes_sys_socket
+  AC_MSG_CHECKING([if getpeername can be linked])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+      $curl_includes_winsock2
+      $curl_includes_bsdsocket
+      $curl_includes_sys_socket
+    ]],[[
+      if(0 != getpeername(0, (void *)0, (void *)0))
+        return 1;
+    ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_proto_getpeername="yes"
+    tst_links_getpeername="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_proto_getpeername="no"
+    tst_links_getpeername="no"
   ])
+  #
+  if test "$tst_links_getpeername" = "yes"; then
+    AC_MSG_CHECKING([if getpeername is prototyped])
+    AC_EGREP_CPP([getpeername],[
+      $curl_includes_winsock2
+      $curl_includes_bsdsocket
+      $curl_includes_sys_socket
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_proto_getpeername="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_proto_getpeername="no"
+    ])
+  fi
   #
   if test "$tst_proto_getpeername" = "yes"; then
     AC_MSG_CHECKING([if getpeername is compilable])
@@ -1726,7 +1854,8 @@ AC_DEFUN([CURL_CHECK_FUNC_GETPEERNAME], [
   fi
   #
   AC_MSG_CHECKING([if getpeername might be used])
-  if test "$tst_proto_getpeername" = "yes" &&
+  if test "$tst_links_getpeername" = "yes" &&
+     test "$tst_proto_getpeername" = "yes" &&
      test "$tst_compi_getpeername" = "yes" &&
      test "$tst_allow_getpeername" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -1753,22 +1882,43 @@ AC_DEFUN([CURL_CHECK_FUNC_GETSOCKNAME], [
   AC_REQUIRE([CURL_PREPROCESS_CALLCONV])dnl
   AC_REQUIRE([CURL_INCLUDES_BSDSOCKET])dnl
   #
+  tst_links_getsockname="unknown"
   tst_proto_getsockname="unknown"
   tst_compi_getsockname="unknown"
   tst_allow_getsockname="unknown"
   #
-  AC_MSG_CHECKING([if getsockname is prototyped])
-  AC_EGREP_CPP([getsockname],[
-    $curl_includes_winsock2
-    $curl_includes_bsdsocket
-    $curl_includes_sys_socket
+  AC_MSG_CHECKING([if getsockname can be linked])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+      $curl_includes_winsock2
+      $curl_includes_bsdsocket
+      $curl_includes_sys_socket
+    ]],[[
+      if(0 != getsockname(0, (void *)0, (void *)0))
+        return 1;
+    ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_proto_getsockname="yes"
+    tst_links_getsockname="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_proto_getsockname="no"
+    tst_links_getsockname="no"
   ])
+  #
+  if test "$tst_links_getsockname" = "yes"; then
+    AC_MSG_CHECKING([if getsockname is prototyped])
+    AC_EGREP_CPP([getsockname],[
+      $curl_includes_winsock2
+      $curl_includes_bsdsocket
+      $curl_includes_sys_socket
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_proto_getsockname="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_proto_getsockname="no"
+    ])
+  fi
   #
   if test "$tst_proto_getsockname" = "yes"; then
     AC_MSG_CHECKING([if getsockname is compilable])
@@ -1802,7 +1952,8 @@ AC_DEFUN([CURL_CHECK_FUNC_GETSOCKNAME], [
   fi
   #
   AC_MSG_CHECKING([if getsockname might be used])
-  if test "$tst_proto_getsockname" = "yes" &&
+  if test "$tst_links_getsockname" = "yes" &&
+     test "$tst_proto_getsockname" = "yes" &&
      test "$tst_compi_getsockname" = "yes" &&
      test "$tst_allow_getsockname" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -2578,20 +2729,39 @@ dnl HAVE_IOCTLSOCKET will be defined.
 AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET], [
   AC_REQUIRE([CURL_INCLUDES_WINSOCK2])dnl
   #
+  tst_links_ioctlsocket="unknown"
   tst_proto_ioctlsocket="unknown"
   tst_compi_ioctlsocket="unknown"
   tst_allow_ioctlsocket="unknown"
   #
-  AC_MSG_CHECKING([if ioctlsocket is prototyped])
-  AC_EGREP_CPP([ioctlsocket],[
-    $curl_includes_winsock2
+  AC_MSG_CHECKING([if ioctlsocket can be linked])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+      $curl_includes_winsock2
+    ]],[[
+      if(0 != ioctlsocket(0, 0, 0))
+        return 1;
+    ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_proto_ioctlsocket="yes"
+    tst_links_ioctlsocket="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_proto_ioctlsocket="no"
+    tst_links_ioctlsocket="no"
   ])
+  #
+  if test "$tst_links_ioctlsocket" = "yes"; then
+    AC_MSG_CHECKING([if ioctlsocket is prototyped])
+    AC_EGREP_CPP([ioctlsocket],[
+      $curl_includes_winsock2
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_proto_ioctlsocket="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_proto_ioctlsocket="no"
+    ])
+  fi
   #
   if test "$tst_proto_ioctlsocket" = "yes"; then
     AC_MSG_CHECKING([if ioctlsocket is compilable])
@@ -2623,7 +2793,8 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET], [
   fi
   #
   AC_MSG_CHECKING([if ioctlsocket might be used])
-  if test "$tst_proto_ioctlsocket" = "yes" &&
+  if test "$tst_links_ioctlsocket" = "yes" &&
+     test "$tst_proto_ioctlsocket" = "yes" &&
      test "$tst_compi_ioctlsocket" = "yes" &&
      test "$tst_allow_ioctlsocket" = "yes"; then
     AC_MSG_RESULT([yes])
@@ -2705,11 +2876,12 @@ dnl then HAVE_IOCTLSOCKET_CAMEL will be defined.
 AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL], [
   AC_REQUIRE([CURL_INCLUDES_BSDSOCKET])dnl
   #
+  tst_links_ioctlsocket_camel="unknown"
   tst_compi_ioctlsocket_camel="unknown"
   tst_allow_ioctlsocket_camel="unknown"
   #
-  AC_MSG_CHECKING([if IoctlSocket is compilable])
-  AC_COMPILE_IFELSE([
+  AC_MSG_CHECKING([if IoctlSocket can be linked])
+  AC_LINK_IFELSE([
     AC_LANG_PROGRAM([[
       $curl_includes_bsdsocket
     ]],[[
@@ -2718,11 +2890,29 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL], [
     ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_compi_ioctlsocket_camel="yes"
+    tst_links_ioctlsocket_camel="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_compi_ioctlsocket_camel="no"
+    tst_links_ioctlsocket_camel="no"
   ])
+  #
+  if test "$tst_links_ioctlsocket_camel" = "yes"; then
+    AC_MSG_CHECKING([if IoctlSocket is compilable])
+    AC_COMPILE_IFELSE([
+      AC_LANG_PROGRAM([[
+        $curl_includes_bsdsocket
+      ]],[[
+        if(0 != IoctlSocket(0, 0, 0))
+          return 1;
+      ]])
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_compi_ioctlsocket_camel="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_compi_ioctlsocket_camel="no"
+    ])
+  fi
   #
   if test "$tst_compi_ioctlsocket_camel" = "yes"; then
     AC_MSG_CHECKING([if IoctlSocket usage allowed])
@@ -2736,7 +2926,8 @@ AC_DEFUN([CURL_CHECK_FUNC_IOCTLSOCKET_CAMEL], [
   fi
   #
   AC_MSG_CHECKING([if IoctlSocket might be used])
-  if test "$tst_compi_ioctlsocket_camel" = "yes" &&
+  if test "$tst_links_ioctlsocket_camel" = "yes" &&
+     test "$tst_compi_ioctlsocket_camel" = "yes" &&
      test "$tst_allow_ioctlsocket_camel" = "yes"; then
     AC_MSG_RESULT([yes])
     AC_DEFINE_UNQUOTED(HAVE_IOCTLSOCKET_CAMEL, 1,
@@ -3285,22 +3476,43 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
   AC_REQUIRE([CURL_INCLUDES_WINSOCK2])dnl
   AC_REQUIRE([CURL_INCLUDES_SYS_SOCKET])dnl
   #
+  tst_links_socket="unknown"
   tst_proto_socket="unknown"
   tst_compi_socket="unknown"
   tst_allow_socket="unknown"
   #
-  AC_MSG_CHECKING([if socket is prototyped])
-  AC_EGREP_CPP([socket],[
-    $curl_includes_winsock2
-    $curl_includes_bsdsocket
-    $curl_includes_sys_socket
+  AC_MSG_CHECKING([if socket can be linked])
+  AC_LINK_IFELSE([
+    AC_LANG_PROGRAM([[
+      $curl_includes_winsock2
+      $curl_includes_bsdsocket
+      $curl_includes_sys_socket
+    ]],[[
+      if(0 != socket(0, 0, 0))
+        return 1;
+    ]])
   ],[
     AC_MSG_RESULT([yes])
-    tst_proto_socket="yes"
+    tst_links_socket="yes"
   ],[
     AC_MSG_RESULT([no])
-    tst_proto_socket="no"
+    tst_links_socket="no"
   ])
+  #
+  if test "$tst_links_socket" = "yes"; then
+    AC_MSG_CHECKING([if socket is prototyped])
+    AC_EGREP_CPP([socket],[
+      $curl_includes_winsock2
+      $curl_includes_bsdsocket
+      $curl_includes_sys_socket
+    ],[
+      AC_MSG_RESULT([yes])
+      tst_proto_socket="yes"
+    ],[
+      AC_MSG_RESULT([no])
+      tst_proto_socket="no"
+    ])
+  fi
   #
   if test "$tst_proto_socket" = "yes"; then
     AC_MSG_CHECKING([if socket is compilable])
@@ -3334,7 +3546,8 @@ AC_DEFUN([CURL_CHECK_FUNC_SOCKET], [
   fi
   #
   AC_MSG_CHECKING([if socket might be used])
-  if test "$tst_proto_socket" = "yes" &&
+  if test "$tst_links_socket" = "yes" &&
+     test "$tst_proto_socket" = "yes" &&
      test "$tst_compi_socket" = "yes" &&
      test "$tst_allow_socket" = "yes"; then
     AC_MSG_RESULT([yes])


### PR DESCRIPTION
The omitted link checks were not what I though they were. Omitting one
caused a mis-detection on Solaris, where the compile check alone
mis-detects `CloseSocket` as present.

Restore link checks for these functions:
`closesocket`, `ioctlsocket`, `socket`, `freeaddrinfo`, `getaddrinfo`,
`gethostname`, `getpeername`, `getsockname`,
`CloseSocket` (AmigaOS), `IoctlSocket` (AmigaOS).

Also re-sync link check code snippets with the ones in current master.

Partial revert of, regression from bd9f9b085aa242a5e93be0b2da96ce498d7813c4 #16377
Reported-by: Dagobert Michelsen
Bug: https://curl.se/mail/lib-2025-04/0004.html
Fixes #16915

---

- [x] May break `CloseSocket` detection for AmigaOS. It doesn't. I'm not sure what was I seeing in 2647acc51d6349b22a8005a121210820465cba59, or was it a different build case than the CI one:
```
configure:36301: checking if CloseSocket can be linked
configure:36320: /opt/appveyor/build-agent/opt/amiga/bin/m68k-amigaos-gcc -o conftest -O0 -msoft-float -mcrt=clib2 -Werror-implicit-function-declaration -pedantic -Wall -W -Wpointer-arith -Wwrite-strings -Wunused -Wshadow -Wnested-externs -Wmissing-declarations -Wmissing-prototypes -Wno-long-long -Wbad-function-cast -Wfloat-equal -Wno-multichar -Wsign-compare -Wundef -Wno-format-nonliteral -Wendif-labels -Wstrict-prototypes -Wdeclaration-after-statement -Wold-style-definition -Wcast-qual -Wstrict-aliasing=3 -Wattributes -Wdiv-by-zero -Wformat-security -Wmissing-field-initializers -Wmissing-noreturn -Wunreachable-code -Wunused-parameter -Wpragmas -Wredundant-decls -Wcast-align -Waddress -Wtype-limits -Wold-style-declaration -Wmissing-parameter-type -Wempty-body -Wclobbered -Wignored-qualifiers -Wconversion -Wno-sign-conversion -Wvla -ftree-vrp -Wjump-misses-init -Wdouble-promotion -Wtrampolines -Wformat=2 -Warray-bounds=2 -Wshift-negative-value -Wshift-overflow=2 -Wnull-dereference -fdelete-null-pointer-checks -Wduplicated-cond -Wunused-const-variable -Wno-system-headers -I/opt/appveyor/AmiSSL/Developer/include -L/opt/appveyor/AmiSSL/Developer/lib/AmigaOS3 conftest.c -lamisslstubs -lamisslauto -lnet -lm -latomic >&5
configure:36320: $? = 0
configure:36323: result: yes
configure:36338: checking if CloseSocket is compilable
configure:36357: /opt/appveyor/build-agent/opt/amiga/bin/m68k-amigaos-gcc -c -O0 -msoft-float -mcrt=clib2 -Werror-implicit-function-declaration -pedantic -Wall -W -Wpointer-arith -Wwrite-strings -Wunused -Wshadow -Wnested-externs -Wmissing-declarations -Wmissing-prototypes -Wno-long-long -Wbad-function-cast -Wfloat-equal -Wno-multichar -Wsign-compare -Wundef -Wno-format-nonliteral -Wendif-labels -Wstrict-prototypes -Wdeclaration-after-statement -Wold-style-definition -Wcast-qual -Wstrict-aliasing=3 -Wattributes -Wdiv-by-zero -Wformat-security -Wmissing-field-initializers -Wmissing-noreturn -Wunreachable-code -Wunused-parameter -Wpragmas -Wredundant-decls -Wcast-align -Waddress -Wtype-limits -Wold-style-declaration -Wmissing-parameter-type -Wempty-body -Wclobbered -Wignored-qualifiers -Wconversion -Wno-sign-conversion -Wvla -ftree-vrp -Wjump-misses-init -Wdouble-promotion -Wtrampolines -Wformat=2 -Warray-bounds=2 -Wshift-negative-value -Wshift-overflow=2 -Wnull-dereference -fdelete-null-pointer-checks -Wduplicated-cond -Wunused-const-variable -Wno-system-headers -I/opt/appveyor/AmiSSL/Developer/include conftest.c >&5
configure:36357: $? = 0
configure:36360: result: yes
configure:36375: checking if CloseSocket usage allowed
configure:36378: result: yes
configure:36388: checking if CloseSocket might be used
configure:36393: result: yes
```
https://github.com/curl/curl/actions/runs/14217476047/job/39837408609?pr=16917#step:5:6521

No `curl_config.h` change compared to before this PR: https://github.com/curl/curl/actions/runs/14216552463/job/39834517106
