### PR TITLE
Test client authentication, add https-mtls server

### DIFF
--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -397,6 +397,7 @@ What server(s) this test case requires/uses. Available servers:
 - `http-proxy`
 - `https`
 - `https-proxy`
+- `https-mtls`
 - `httptls+srp`
 - `httptls+srp-ipv6`
 - `http-unix`

--- a/tests/certs/Makefile.inc
+++ b/tests/certs/Makefile.inc
@@ -30,7 +30,8 @@ CERTCONFIGS = \
   test-localhost.nn.prm \
   test-localhost0h.prm \
   test-localhost-san-first.prm \
-  test-localhost-san-last.prm
+  test-localhost-san-last.prm \
+  test-client-cert.prm
 
 GENERATEDCERTS = \
   test-ca.cacert \
@@ -65,7 +66,13 @@ GENERATEDCERTS = \
   test-localhost-san-last.key \
   test-localhost-san-last.pem \
   test-localhost-san-last.pub.der \
-  test-localhost-san-last.pub.pem
+  test-localhost-san-last.pub.pem \
+  test-client-cert.crl \
+  test-client-cert.crt \
+  test-client-cert.key \
+  test-client-cert.pem \
+  test-client-cert.pub.der \
+  test-client-cert.pub.pem
 
 SRPFILES = \
   srp-verifier-conf \

--- a/tests/certs/test-client-cert.prm
+++ b/tests/certs/test-client-cert.prm
@@ -1,0 +1,35 @@
+extensions = x509v3
+
+[ x509v3 ]
+subjectAltName          = DNS:localhost
+keyUsage                = keyEncipherment,digitalSignature,keyAgreement
+extendedKeyUsage        = serverAuth,clientAuth
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid
+basicConstraints        = CA:false
+authorityInfoAccess     = @issuer_info
+crlDistributionPoints   = @crl_info
+
+[ crl_ext ]
+authorityKeyIdentifier  = keyid:always
+authorityInfoAccess     = @issuer_info
+
+[ issuer_info ]
+caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
+
+[ crl_info ]
+URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
+
+[ req ]
+default_bits            = 2048
+distinguished_name      = req_DN
+default_md              = sha256
+string_mask             = utf8only
+
+[ req_DN ]
+countryName             = "Country Name is Northern Nowhere"
+countryName_value       = NN
+organizationName        = "Organization Name"
+organizationName_value  = Edel Curl Arctic Illudium Research Cloud
+commonName              = "Common Name"
+commonName_value        = localhost

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -252,7 +252,7 @@ test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
 test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
-\
+test2088 \
 test2100 test2101 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 \

--- a/tests/data/test2088
+++ b/tests/data/test2088
@@ -1,0 +1,55 @@
+<testcase>
+<info>
+<keywords>
+HTTPS
+HTTP GET
+Client Auth
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 7
+
+MooMoo
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+SSL
+!Schannel
+!sectransp
+!bearssl
+local-http
+</features>
+<server>
+https-mtls
+</server>
+<name>
+HTTPS GET with client authentication (mtls)
+</name>
+<command>
+--cacert %CERTDIR/certs/test-ca.crt --cert %CERTDIR/certs/test-client-cert.crt --key %CERTDIR/certs/test-client-cert.key https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: localhost:%HTTPS-MTLSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -476,6 +476,9 @@ sub parseprotocols {
     # 'http-proxy' is used in test cases to do CONNECT through
     push @protocols, 'http-proxy';
 
+    # 'https-mtls' is used for client certificate auth testing
+    push @protocols, 'https-mtls';
+
     # 'none' is used in test cases to mean no server
     push @protocols, 'none';
 }

--- a/tests/secureserver.pl
+++ b/tests/secureserver.pl
@@ -70,7 +70,6 @@ my $ipvnum = 4;       # default IP version of stunneled server
 my $idnum = 1;        # default stunneled server instance number
 my $proto = 'https';  # default secure server protocol
 my $conffile;         # stunnel configuration file
-my $capath;           # certificate chain PEM folder
 my $certfile;         # certificate chain PEM file
 
 #***************************************************************************
@@ -195,7 +194,6 @@ if(!$logfile) {
 
 $conffile = "$piddir/${proto}_stunnel.conf";
 
-$capath = abs_path($path);
 $certfile = $stuncert ? "certs/$stuncert" : "certs/test-localhost.pem";
 $certfile = abs_path($certfile);
 
@@ -246,7 +244,6 @@ if($stunnel =~ /tstunnel(\.exe)?$/) {
     $tstunnel_windows = 1;
 
     # convert Cygwin/MinGW paths to Windows format
-    $capath = pathhelp::sys_native_abs_path($capath);
     $certfile = pathhelp::sys_native_abs_path($certfile);
 }
 
@@ -292,7 +289,6 @@ if($stunnel_version >= 400) {
     $SIG{TERM} = \&exit_signal_handler;
     # stunnel configuration file
     if(open(my $stunconf, ">", "$conffile")) {
-        print $stunconf "CApath = $capath\n";
         print $stunconf "cert = $certfile\n";
         print $stunconf "debug = $loglevel\n";
         print $stunconf "socket = $socketopt\n";

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -142,7 +142,7 @@ sub servername_str {
 
     $proto = uc($proto) if($proto);
     die "unsupported protocol: '$proto'" unless($proto &&
-        ($proto =~ /^(((FTP|HTTP|HTTP\/2|HTTP\/3|IMAP|POP3|GOPHER|SMTP)S?)|(TFTP|SFTP|SOCKS|SSH|RTSP|HTTPTLS|DICT|SMB|SMBS|TELNET|MQTT))$/));
+        ($proto =~ /^(((FTP|HTTP|HTTP\/2|HTTP\/3|IMAP|POP3|GOPHER|SMTP|HTTPS-MTLS)S?)|(TFTP|SFTP|SOCKS|SSH|RTSP|HTTPTLS|DICT|SMB|SMBS|TELNET|MQTT))$/));
 
     $ipver = (not $ipver) ? 'ipv4' : lc($ipver);
     die "unsupported IP version: '$ipver'" unless($ipver &&


### PR DESCRIPTION
In order to test using mutual TLS (mtls), this adds a new server type, `https-mtls`, which turns on the `verifyChain` in stunnel, which forces client to authenticate using a certificate signed by the CA specified by `CAfile`.
Also generate a client certificate to use when authenticating.

In addition, this removes the `CApath` config since it requires CA files being named with the hash of the subject [1], which isn't done here (if I understand correctly it didn't even point to the certs/ directory).

[1] https://www.stunnel.org/static/stunnel.html#CApath-CA_DIRECTORY

Refs https://github.com/curl/curl/discussions/16804 https://github.com/curl/curl/issues/16686