### PR TITLE
genserv.pl: fail with a message if `openssl` is missing or failing

### DIFF
--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -34,7 +34,7 @@ sub opensslfail {
     exit 1;
 }
 
-my $OPENSSL = './libressl-3.1.0';
+my $OPENSSL = 'openssl';
 if(-f '/usr/local/ssl/bin/openssl') {
     $OPENSSL = '/usr/local/ssl/bin/openssl';
 }

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -30,8 +30,9 @@ use File::Basename;
 use File::Spec;
 
 sub opensslfail {
-    print 'genserv.pl: openssl 1.0.2+ is required to generate test certificates.';
-    exit 1;
+    die "Missing or broken 'openssl' tool. openssl 1.0.2+ is required. ".
+        "Without it, this script cannot generate the necessary certificates ".
+        "the curl test suite needs for all its TLS related tests.";
 }
 
 my $OPENSSL = 'openssl';
@@ -66,8 +67,7 @@ if(!$CAPREFIX) {
             }
         }
         if(!$found) {
-            print 'genserv.pl: openssl not found, but required to generate test certificates.';
-            exit 1;
+            opensslfail();
         }
     }
 

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -29,7 +29,12 @@ use warnings;
 use File::Basename;
 use File::Spec;
 
-my $OPENSSL = 'openssl';
+sub opensslfail {
+    print 'genserv.pl: openssl 1.0.2+ is required to generate test certificates.';
+    exit 1;
+}
+
+my $OPENSSL = './libressl-3.1.0';
 if(-f '/usr/local/ssl/bin/openssl') {
     $OPENSSL = '/usr/local/ssl/bin/openssl';
 }
@@ -44,30 +49,40 @@ my $PREFIX;
 
 my $CAPREFIX = shift @ARGV;
 if(!$CAPREFIX) {
-    print "Usage: genserv.pl <caprefix> [<prefix> ...]\n";
+    print 'Usage: genserv.pl <caprefix> [<prefix> ...]\n';
     exit 1;
 } elsif(! -f "$CAPREFIX-ca.cacert" ||
         ! -f "$CAPREFIX-ca.key") {
 
     if($OPENSSL eq basename($OPENSSL)) {  # has no dir component
         # find openssl in PATH
+        my $found = 0;
         foreach(File::Spec->path()) {
             my $file = File::Spec->catfile($_, $OPENSSL);
             if(-f $file) {
                 $OPENSSL = $file;
+                $found = 1;
                 last;
             }
+        }
+        if(!$found) {
+            print 'genserv.pl: openssl not found. openssl is required to generate test certificates.';
+            exit 1;
         }
     }
 
     print "$OPENSSL\n";
-    system("$OPENSSL version");
+    if(system("$OPENSSL version") != 0) {
+        opensslfail();
+    }
 
     $PREFIX = $CAPREFIX;
     $DURATION = 6000;
 
-    system("$OPENSSL genpkey -algorithm EC -pkeyopt ec_paramgen_curve:$KEYSIZE -pkeyopt ec_param_enc:named_curve " .
-        "-out $PREFIX-ca.key -pass pass:secret");
+    if(system("$OPENSSL genpkey -algorithm EC -pkeyopt ec_paramgen_curve:$KEYSIZE -pkeyopt ec_param_enc:named_curve " .
+        "-out $PREFIX-ca.key -pass pass:secret") != 0) {
+        opensslfail();
+    }
     system("$OPENSSL req -config $SRCDIR/$PREFIX-ca.prm -new -key $PREFIX-ca.key -out $PREFIX-ca.csr -passin pass:secret 2>$dev_null");
     system("$OPENSSL x509 -sha256 -extfile $SRCDIR/$PREFIX-ca.prm -days $DURATION " .
         "-req -signkey $PREFIX-ca.key -in $PREFIX-ca.csr -out $PREFIX-ca.raw-cacert");

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -72,9 +72,7 @@ if(!$CAPREFIX) {
     }
 
     print "$OPENSSL\n";
-    if(system("$OPENSSL version") != 0) {
-        opensslfail();
-    }
+    system("$OPENSSL version")
 
     $PREFIX = $CAPREFIX;
     $DURATION = 6000;

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -72,7 +72,7 @@ if(!$CAPREFIX) {
     }
 
     print "$OPENSSL\n";
-    system("$OPENSSL version")
+    system("$OPENSSL version");
 
     $PREFIX = $CAPREFIX;
     $DURATION = 6000;

--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -66,7 +66,7 @@ if(!$CAPREFIX) {
             }
         }
         if(!$found) {
-            print 'genserv.pl: openssl not found. openssl is required to generate test certificates.';
+            print 'genserv.pl: openssl not found, but required to generate test certificates.';
             exit 1;
         }
     }


### PR DESCRIPTION
Reported-by: Tomas Volf
Fixes #16926
Follow-up to 44341e736a3e2f7a2b25a774be3a9796e81abab9 #16824
Ref: #16928
Co-authored-by: Daniel Stenberg
