### PR TITLE
tests: use a more portable null device path

### DIFF
--- a/tests/certs/genserv.pl
+++ b/tests/certs/genserv.pl
@@ -36,7 +36,7 @@ if(-f '/usr/local/ssl/bin/openssl') {
 
 my $SRCDIR = dirname(__FILE__);
 my $fh;
-my $dev_null = $^O eq 'MSWin32' ? 'NUL' : '/dev/null';
+my $dev_null = File::Spec->devnull();
 
 my $KEYSIZE = 'prime256v1';
 my $DURATION;

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -81,6 +81,9 @@ use Cwd qw(getcwd);
 use testutil qw(
     shell_quote
 );
+use File::Spec qw (
+    devnull
+);
 
 
 #######################################################################
@@ -119,7 +122,7 @@ our $VCURL=$CURL;  # what curl binary to use to verify the servers with
 our $memanalyze="$perl " . shell_quote("$srcdir/memanalyze.pl");
 our $valgrind;     # path to valgrind, or empty if disabled
 our $bundle = 0;   # use bundled server, libtest, unit binaries
-our $dev_null = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
+our $dev_null = File::Spec->devnull();   # null device path, eg: /dev/null
 
 # paths in $LOGDIR
 our $LOCKDIR = "lock";          # root of the server directory with lock files

--- a/tests/http2-server.pl
+++ b/tests/http2-server.pl
@@ -28,6 +28,7 @@
 use Cwd;
 use Cwd 'abs_path';
 use File::Basename;
+use File::Spec;
 
 my $logdir = "log";
 my $pidfile = "$logdir/nghttpx.pid";
@@ -38,7 +39,7 @@ my $listenport2 = 9016;
 my $connect = "127.0.0.1,8990";
 my $conf = "nghttpx.conf";
 my $cert = "test-localhost";
-my $dev_null = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
+my $dev_null = File::Spec->devnull();
 
 #***************************************************************************
 # Process command line options

--- a/tests/http3-server.pl
+++ b/tests/http3-server.pl
@@ -29,6 +29,7 @@
 use Cwd;
 use Cwd 'abs_path';
 use File::Basename;
+use File::Spec;
 
 my $logdir = "log";
 my $pidfile = "$logdir/nghttpx.pid";
@@ -38,7 +39,7 @@ my $listenport = 9017;
 my $connect = "127.0.0.1,8990";
 my $cert = "test-localhost";
 my $conf = "nghttpx.conf";
-my $dev_null = ($^O eq 'MSWin32' ? 'NUL' : '/dev/null');
+my $dev_null = File::Spec->devnull();
 
 #***************************************************************************
 # Process command line options


### PR DESCRIPTION
- Use File::Spec->devnull() to get the null device path.

Prior to this change we used NUL for Windows native perl and /dev/null otherwise.

Bug: https://github.com/curl/curl/pull/16929#discussion_r2025718160
Reported-by: Viktor Szakats

Closes #xxxx