### PR TITLE
conncache: make Curl_cpool_init return void

### DIFF
--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -132,10 +132,10 @@ static void cpool_bundle_free_entry(void *freethis)
   cpool_bundle_destroy((struct cpool_bundle *)freethis);
 }
 
-int Curl_cpool_init(struct cpool *cpool,
-                    struct Curl_easy *idata,
-                    struct Curl_share *share,
-                    size_t size)
+void Curl_cpool_init(struct cpool *cpool,
+                     struct Curl_easy *idata,
+                     struct Curl_share *share,
+                     size_t size)
 {
   Curl_hash_init(&cpool->dest2bundle, size, Curl_hash_str,
                  Curl_str_key_compare, cpool_bundle_free_entry);
@@ -145,7 +145,6 @@ int Curl_cpool_init(struct cpool *cpool,
   cpool->idata = idata;
   cpool->share = share;
   cpool->initialised = TRUE;
-  return 0; /* good */
 }
 
 /* Return the "first" connection in the pool or NULL. */

--- a/lib/conncache.h
+++ b/lib/conncache.h
@@ -62,12 +62,12 @@ struct cpool {
 };
 
 /* Init the pool, pass multi only if pool is owned by it.
- * returns 1 on error, 0 is fine.
+ * Cannot fail.
  */
-int Curl_cpool_init(struct cpool *cpool,
-                    struct Curl_easy *idata,
-                    struct Curl_share *share,
-                    size_t size);
+void Curl_cpool_init(struct cpool *cpool,
+                     struct Curl_easy *idata,
+                     struct Curl_share *share,
+                     size_t size);
 
 /* Destroy all connections and free all members */
 void Curl_cpool_destroy(struct cpool *connc);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -242,8 +242,7 @@ struct Curl_multi *Curl_multi_handle(size_t ev_hashsize,  /* event hash */
   if(Curl_cshutdn_init(&multi->cshutdn, multi))
     goto error;
 
-  if(Curl_cpool_init(&multi->cpool, multi->admin, NULL, chashsize))
-    goto error;
+  Curl_cpool_init(&multi->cpool, multi->admin, NULL, chashsize);
 
   if(Curl_ssl_scache_create(sesssize, 2, &multi->ssl_scache))
     goto error;

--- a/lib/share.c
+++ b/lib/share.c
@@ -136,8 +136,7 @@ curl_share_setopt(CURLSH *sh, CURLSHoption option, ...)
     case CURL_LOCK_DATA_CONNECT:
       /* It is safe to set this option several times on a share. */
       if(!share->cpool.initialised) {
-        if(Curl_cpool_init(&share->cpool, share->admin, share, 103))
-          res = CURLSHE_NOMEM;
+        Curl_cpool_init(&share->cpool, share->admin, share, 103);
       }
       break;
 


### PR DESCRIPTION
Since it cannot fail, removing the return code simplifies the code paths calling this function.