### PR TITLE
tests/README.md: list the openssl tool among the prerequisites

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -45,14 +45,14 @@ SPDX-License-Identifier: curl
 
 ## Requires to run
 
-  - perl (and a Unix-style shell)
-  - python (and a Unix-style shell, for SMB and TELNET tests)
-  - python-impacket (for SMB tests)
-  - diff (when a test fails, a diff is shown)
-  - stunnel (for HTTPS and FTPS tests)
-  - openssl (the command line tool, for generating test server certificates)
-  - OpenSSH or SunSSH (for SCP and SFTP tests)
-  - nghttpx (for HTTP/2 and HTTP/3 tests)
+  - `perl` (and a Unix-style shell)
+  - `python` (and a Unix-style shell, for SMB and TELNET tests)
+  - `python-impacket` (for SMB tests)
+  - `diff` (when a test fails, a diff is shown)
+  - `stunnel` (for HTTPS and FTPS tests)
+  - `openssl` (the command line tool, for generating test server certificates)
+  - `openssh` or `SunSSH` (for SCP and SFTP tests)
+  - `nghttpx` (for HTTP/2 and HTTP/3 tests)
   - An available `en_US.UTF-8` locale
 
 ### Installation of impacket

--- a/tests/README.md
+++ b/tests/README.md
@@ -50,6 +50,7 @@ SPDX-License-Identifier: curl
   - python-impacket (for SMB tests)
   - diff (when a test fails, a diff is shown)
   - stunnel (for HTTPS and FTPS tests)
+  - openssl (the command line tool, for generating test server certificates)
   - OpenSSH or SunSSH (for SCP and SFTP tests)
   - nghttpx (for HTTP/2 and HTTP/3 tests)
   - An available `en_US.UTF-8` locale


### PR DESCRIPTION
Used for test cert generation since 8.13.0