### PR TITLE
asyn-thread: fix build without socketpair

### DIFF
--- a/lib/asyn-thread.c
+++ b/lib/asyn-thread.c
@@ -188,8 +188,10 @@ int init_thread_sync_data(struct thread_data *td,
     return 0;
 
   tsd->port = port;
+#ifndef CURL_DISABLE_SOCKETPAIR
   tsd->sock_pair[0] = CURL_SOCKET_BAD;
   tsd->sock_pair[1] = CURL_SOCKET_BAD;
+#endif
   tsd->ref_count = 0;
 
 #ifdef HAVE_GETADDRINFO


### PR DESCRIPTION
Follow-up to 9b6148e9d95db54a752b03b571296c40d66e97fe