### PR TITLE
rustls: make max size of cert and key reasonable

### DIFF
--- a/lib/dynbuf.h
+++ b/lib/dynbuf.h
@@ -99,4 +99,6 @@ char *Curl_dyn_take(struct dynbuf *s, size_t *plen);
 #define DYN_MQTT_RECV       (64*1024)
 #define DYN_MQTT_SEND       0xFFFFFFF
 #define DYN_CRLFILE_SIZE    (400*1024*1024) /* 400mb */
+#define DYN_CERTFILE_SIZE   (100*1024) /* 100KiB */
+#define DYN_KEYFILE_SIZE    (100*1024) /* 100KiB */
 #endif

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -868,8 +868,8 @@ init_config_builder_client_auth(struct Curl_easy *data,
     return CURLE_SSL_CERTPROBLEM;
   }
 
-  Curl_dyn_init(&cert_contents, SIZE_MAX);
-  Curl_dyn_init(&key_contents, SIZE_MAX);
+  Curl_dyn_init(&cert_contents, DYN_CERTFILE_SIZE);
+  Curl_dyn_init(&key_contents, DYN_KEYFILE_SIZE);
 
   if(!read_file_into(conn_config->clientcert, &cert_contents)) {
     failf(data, "rustls: failed to read client certificate file: '%s'",


### PR DESCRIPTION
SIZE_MAX is an very overkill size for certificates or keys, lower it to 100KiB for both certificate and keys. The default max size of openssl is 100KiB for the entire chain [1], and it seems firefox fails at ~60kb [2].

Found by https://github.com/curl/curl/pull/16923

[0] https://docs.openssl.org/3.2/man3/SSL_CTX_set_max_cert_list/#notes
[2] https://0x00.cl/blog/2024/exploring-tls-certs/