### PR TITLE
winbuild: add the deprecation warning to the README

### DIFF
--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -511,8 +511,9 @@ and therefore ignore the value of `CMAKE_BUILD_TYPE`.
 
 # Migrating from winbuild builds
 
-We recommend CMake to build curl with MSVC. The winbuild build method is
-deprecated and may be dropped in a future release.
+We recommend CMake to build curl with MSVC. The winbuild build system is
+deprecated and will be removed in September 2025 in favor of the CMake build
+system.
 
 In CMake you can customize the path of dependencies by passing the absolute
 header path and the full path of the library via `*_INCLUDE_DIR` and

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -512,8 +512,8 @@ and therefore ignore the value of `CMAKE_BUILD_TYPE`.
 # Migrating from winbuild builds
 
 We recommend CMake to build curl with MSVC. The winbuild build system is
-deprecated and will be removed in September 2025 in favor of the CMake build
-system.
+deprecated and is going to be removed in September 2025 in favor of the CMake
+build system.
 
 In CMake you can customize the path of dependencies by passing the absolute
 header path and the full path of the library via `*_INCLUDE_DIR` and

--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -6,8 +6,8 @@ SPDX-License-Identifier: curl
 
 # Deprecation warning
 
- This winbuild build system is deprecated and will be removed in September 2025
- in favor of the CMake build system.
+ This winbuild build system is deprecated and is going to be removed in
+ September 2025 in favor of the CMake build system.
 
  Please see docs/INSTALL-CMAKE.md : "Migrating from winbuild builds"
 

--- a/winbuild/README.md
+++ b/winbuild/README.md
@@ -4,6 +4,13 @@ Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 SPDX-License-Identifier: curl
 -->
 
+# Deprecation warning
+
+ This winbuild build system is deprecated and will be removed in September 2025
+ in favor of the CMake build system.
+
+ Please see docs/INSTALL-CMAKE.md : "Migrating from winbuild builds"
+
 # Building curl with Visual C++
 
  This document describes how to compile, build and install curl and libcurl


### PR DESCRIPTION
- Mention in README.md and INSTALL-CMAKE.md that the winbuild build system will be removed in September 2025.

Closes #xxxx