### PR TITLE
http2: fix stream window size after unpausing

### DIFF
--- a/docs/libcurl/libcurl-env-dbg.md
+++ b/docs/libcurl/libcurl-env-dbg.md
@@ -147,3 +147,8 @@ Make a blocking, graceful shutdown of all remaining connections when
 a multi handle is destroyed. This implicitly triggers for easy handles
 that are run via easy_perform. The value of the environment variable
 gives the shutdown timeout in milliseconds.
+
+## `CURL_H2_STREAM_WIN_MAX`
+
+Set to a positive 32-bit number to override the HTTP/2 stream window's
+default of 10MB. Used in testing to verify correct window update handling.


### PR DESCRIPTION
When pausing a HTTP/2 transfer, the stream's local window size is reduced to 0 to prevent the server from sending further data which curl cannot write out to the application.

When unpausing again, the stream's window size was not correctly increased again. The attempt to trigger a window update was ignored by nghttp2, the server never received it and the transfer stalled.

Add a debug feature to allow use of small window sizes which reproduces this bug in test_02_21.

refs #16995