### PR TITLE
randdisable: build randomizer

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -25,7 +25,7 @@
 EXTRA_DIST = coverage.sh completion.pl firefox-db2pem.sh checksrc.pl              \
   mk-ca-bundle.pl mk-unity.pl schemetable.c cd2nroff nroff2cd cdall cd2cd managen \
   dmaketgz maketgz release-tools.sh verify-release cmakelint.sh mdlinkcheck       \
-  CMakeLists.txt
+  CMakeLists.txt randdisable
 
 ZSH_FUNCTIONS_DIR = @ZSH_FUNCTIONS_DIR@
 FISH_FUNCTIONS_DIR = @FISH_FUNCTIONS_DIR@

--- a/scripts/randdisable
+++ b/scripts/randdisable
@@ -1,0 +1,78 @@
+#!/usr/bin/env perl
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# SPDX-License-Identifier: curl
+#
+# This script makes a "random" build using configure and verifies that it
+# builds curl correctly. It randomly adds a number of the available
+# --disable-* flags to configure. When it detects a problem the script stops,
+# otherwise it continues trying more combinations.
+#
+# 1. Figure out all existing configure --disable-* options
+# 2. Generate random command line using supported options + random TLS
+# 3. Run configure (exit if problem)
+# 4. run "make -sj10" to build (exit if problem)
+# 5. run curl -V (exit if problem)
+# 6. GOTO 2
+#
+# Tips:
+#
+# - edit the @tls array to include all TLS backends you can build with
+# - do a checkout in a ram-based filesystem
+#
+use List::Util qw/shuffle/;
+
+sub getoptions {
+    my @all = `./configure --help`;
+    for my $o (@all) {
+        chomp $o;
+        if($o =~ /(--disable-[^ ]*)/) {
+            if($1 !~ /FEATURE/) {
+                push @disable, $1;
+            }
+        }
+    }
+}
+
+getoptions();
+
+# options to select a TLS
+my @tls = ("--with-openssl",
+           "--with-wolfssl=/home/daniel/build-wolfssl",
+           "--with-gnutls",
+           "--with-mbedtls");
+
+do {
+
+    # get a random number of disable options
+    my $num = rand(scalar(@disable) - 2) + 2;
+
+    my $c = 0;
+    my $arg;
+    for my $d (shuffle @disable) {
+        $arg .= " $d";
+        if(++$c >= $num) {
+            last;
+        }
+    }
+
+    my @stls = shuffle @tls;
+    $arg.= " ".$stls[0];
+
+    system("make clean");
+    if(system("./configure $arg")) {
+        print STDERR "configure problem\n";
+        print STDERR "./configure $arg\n";
+        exit 1;
+    }
+    if(system("make -sj10")) {
+        print STDERR "Build problem\n";
+        print STDERR "./configure $arg\n";
+        exit 1;
+    }
+    if(system("./src/curl -V 2>/dev/null")) {
+        print STDERR "Running problem\n";
+        print STDERR "./configure $arg\n";
+        exit 1;
+    }
+} while(1);

--- a/scripts/randdisable
+++ b/scripts/randdisable
@@ -38,7 +38,7 @@ getoptions();
 
 # options to select a TLS
 my @tls = ("--with-openssl",
-           "--with-wolfssl=/home/daniel/build-wolfssl",
+           "--with-wolfssl=" . $ENV{'HOME'} . "/build-wolfssl",
            "--with-gnutls",
            "--with-mbedtls");
 


### PR DESCRIPTION
This script makes a "random" build using configure and verifies that it builds curl correctly. It randomly adds a number of the available --disable-* flags to configure. When it detects a problem the script stops, otherwise it continues trying more combinations.