### PR TITLE
lib: update comment on Curl_rand_bytes weak random

### DIFF
--- a/lib/rand.c
+++ b/lib/rand.c
@@ -191,12 +191,11 @@ static CURLcode randit(struct Curl_easy *data, unsigned int *rnd,
  * Curl_rand() stores 'num' number of random unsigned characters in the buffer
  * 'rnd' points to.
  *
- * If libcurl is built without TLS support or with a TLS backend that lacks a
- * proper random API (Rustls or mbedTLS), this function will use "weak"
- * random.
+ * If libcurl is built without TLS support or arc4random, this function will
+ * use "weak" random.
  *
- * When built *with* TLS support and a backend that offers strong random, it
- * will return error if it cannot provide strong random values.
+ * When built *with* TLS support, it will return error if it cannot provide
+ * strong random values.
  *
  * NOTE: 'data' may be passed in as NULL when coming from external API without
  * easy handle!


### PR DESCRIPTION
From what I understand both rustls and mbedTLS expose a strong random function, so as long as you have a TLS library random will be strong.

Followup 89728451234a "vtls/rustls: support strong CSRNG data"
Followup a90a5bccd47b "mbedtls: implement CTR-DRBG and HAVEGE random generators"