### PR TITLE
Implemented ping for MQTT

### DIFF
--- a/docs/internals/MQTT.md
+++ b/docs/internals/MQTT.md
@@ -26,9 +26,8 @@ Example subscribe:
 This sends an MQTT SUBSCRIBE packet for the topic `bedroom/temp` and listen in
 for incoming PUBLISH packets.
 
-You can set upkeep interval ms option to value 30000 to have curl send ping requests to the
-server every 30 seconds to keep the connection permanently. You need to use the
-progress callback to cancel the operation.
+You can set the upkeep interval ms option to make curl send MQTT ping requests to the
+server at an internal, to prevent the connection to get closed because of idleness . You might then need to use the progress callback to cancel the operation.
 
 ### Publishing
 

--- a/docs/internals/MQTT.md
+++ b/docs/internals/MQTT.md
@@ -27,7 +27,8 @@ This sends an MQTT SUBSCRIBE packet for the topic `bedroom/temp` and listen in
 for incoming PUBLISH packets.
 
 You can set the upkeep interval ms option to make curl send MQTT ping requests to the
-server at an internal, to prevent the connection to get closed because of idleness . You might then need to use the progress callback to cancel the operation.
+server at an internal, to prevent the connection to get closed because of idleness.
+You might then need to use the progress callback to cancel the operation.
 
 ### Publishing
 

--- a/docs/internals/MQTT.md
+++ b/docs/internals/MQTT.md
@@ -26,6 +26,10 @@ Example subscribe:
 This sends an MQTT SUBSCRIBE packet for the topic `bedroom/temp` and listen in
 for incoming PUBLISH packets.
 
+You can set upkeep interval ms option to value 30000 to have curl send ping requests to the
+server every 30 seconds to keep the connection permanently. You need to use the
+progress callback to cancel the operation.
+
 ### Publishing
 
 Command usage:

--- a/docs/libcurl/curl_easy_upkeep.md
+++ b/docs/libcurl/curl_easy_upkeep.md
@@ -31,9 +31,12 @@ send some traffic on existing connections in order to keep them alive; this
 can prevent connections from being closed due to overzealous firewalls, for
 example.
 
-Currently the only protocol with a connection upkeep mechanism is HTTP/2: when
+For HTTP/2 we have an upkeep mechanism: when
 the connection upkeep interval is exceeded and curl_easy_upkeep(3)
 is called, an HTTP/2 PING frame is sent on the connection.
+
+For MQTT the upkeep interval defines when to send ping requests to prevent the
+server from disconnecting.
 
 This function must be explicitly called in order to perform the upkeep work.
 The connection upkeep interval is set with

--- a/lib/mqtt.h
+++ b/lib/mqtt.h
@@ -55,6 +55,8 @@ struct MQTT {
   size_t npacket; /* byte counter */
   size_t remaining_length;
   unsigned char pkt_hd[4]; /* for decoding the arriving packet length */
+  struct curltime lastTime; /* last time we sent or received data */
+  bool pingsent; /* 1 while we wait for ping response */
   unsigned char firstbyte;
 };
 


### PR DESCRIPTION
If you subscribe to a topic, the socket gets closed by the server after about 70 to 90 seconds.
By sending ping, we can keep it open.

I currently use the upkeep interval for the ping timeout. You can set it to zero to turn this off.


Replaces older pull request
https://github.com/curl/curl/pull/16140