### PR TITLE
tests/globalconfig.pm: remove the qw

### DIFF
--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -81,9 +81,7 @@ use Cwd qw(getcwd);
 use testutil qw(
     shell_quote
 );
-use File::Spec qw(
-    devnull
-);
+use File::Spec;
 
 
 #######################################################################


### PR DESCRIPTION
Fixes the warning.

Fixes #16976