### PR TITLE
GHA/configure-vs-cmake: dump generated configs to log

### DIFF
--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -58,9 +58,9 @@ jobs:
 
       - name: 'dump generated files'
         run: |
-          for f in lib/curl_config.h libcurl.pc curl-config; do
-            echo "::group::${f}"; cat bld-am/"${f}" || true; echo '::endgroup::'
-            echo "::group::${f}"; cat bld-cm/"${f}" || true; echo '::endgroup::'
+          for f in libcurl.pc curl-config; do
+            echo "::group::AM ${f}"; cat bld-am/"${f}" | grep -v '^#' || true; echo '::endgroup::'
+            echo "::group::CM ${f}"; cat bld-cm/"${f}" | grep -v '^#' || true; echo '::endgroup::'
           done
 
       - name: 'compare generated curl_config.h files'
@@ -108,9 +108,9 @@ jobs:
 
       - name: 'dump generated files'
         run: |
-          for f in lib/curl_config.h libcurl.pc curl-config; do
-            echo "::group::${f}"; cat bld-am/"${f}" || true; echo '::endgroup::'
-            echo "::group::${f}"; cat bld-cm/"${f}" || true; echo '::endgroup::'
+          for f in libcurl.pc curl-config; do
+            echo "::group::AM ${f}"; cat bld-am/"${f}" | grep -v '^#' || true; echo '::endgroup::'
+            echo "::group::CM ${f}"; cat bld-cm/"${f}" | grep -v '^#' || true; echo '::endgroup::'
           done
 
       - name: 'compare generated curl_config.h files'
@@ -155,9 +155,9 @@ jobs:
 
       - name: 'dump generated files'
         run: |
-          for f in lib/curl_config.h libcurl.pc curl-config; do
-            echo "::group::${f}"; cat bld-am/"${f}" || true; echo '::endgroup::'
-            echo "::group::${f}"; cat bld-cm/"${f}" || true; echo '::endgroup::'
+          for f in libcurl.pc curl-config; do
+            echo "::group::AM ${f}"; cat bld-am/"${f}" | grep -v '^#' || true; echo '::endgroup::'
+            echo "::group::CM ${f}"; cat bld-cm/"${f}" | grep -v '^#' || true; echo '::endgroup::'
           done
 
       - name: 'compare generated curl_config.h files'

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -56,6 +56,13 @@ jobs:
       - name: 'cmake log'
         run: cat bld-cm/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
 
+      - name: 'dump generated files'
+        run: |
+          for f in lib/curl_config.h libcurl.pc curl-config; do
+            echo "::group::${f}"; cat bld-am/"${f}" || true; echo '::endgroup::'
+            echo "::group::${f}"; cat bld-cm/"${f}" || true; echo '::endgroup::'
+          done
+
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
 
@@ -99,6 +106,13 @@ jobs:
       - name: 'cmake log'
         run: cat bld-cm/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
 
+      - name: 'dump generated files'
+        run: |
+          for f in lib/curl_config.h libcurl.pc curl-config; do
+            echo "::group::${f}"; cat bld-am/"${f}" || true; echo '::endgroup::'
+            echo "::group::${f}"; cat bld-cm/"${f}" || true; echo '::endgroup::'
+          done
+
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h
 
@@ -138,6 +152,13 @@ jobs:
 
       - name: 'cmake log'
         run: cat bld-cm/CMakeFiles/CMakeConfigureLog.yaml 2>/dev/null || true
+
+      - name: 'dump generated files'
+        run: |
+          for f in lib/curl_config.h libcurl.pc curl-config; do
+            echo "::group::${f}"; cat bld-am/"${f}" || true; echo '::endgroup::'
+            echo "::group::${f}"; cat bld-cm/"${f}" || true; echo '::endgroup::'
+          done
 
       - name: 'compare generated curl_config.h files'
         run: ./.github/scripts/cmp-config.pl bld-am/lib/curl_config.h bld-cm/lib/curl_config.h


### PR DESCRIPTION
Sometimes it's useful to have a look at the generated `libcurl.pc` and
`curl-config` files.

`cmp-config.pl` normalizes them before diffing, thus doesn't show their
original content.
