### PR TITLE
CURLOPT_TRANSFER_ENCODING: accept a -1 value for ignore

### DIFF
--- a/docs/cmdline-opts/raw.md
+++ b/docs/cmdline-opts/raw.md
@@ -17,3 +17,7 @@ Example:
 
 When used, it disables all internal HTTP decoding of content or transfer
 encodings and instead makes them passed on unaltered, raw.
+
+Beware that when ignoring HTTP/1.1 chunked transfer encoding, curl might not
+detect the end of the response body and might instead sit idly waiting for the
+connection to eventually close.

--- a/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.md
+++ b/docs/libcurl/opts/CURLOPT_TRANSFER_ENCODING.md
@@ -40,6 +40,14 @@ to be for the transfer and thus MUST be decoded before the data arrives in the
 client. Traditionally, Transfer-Encoding has been much less used and supported
 by both HTTP clients and HTTP servers.
 
+Setting or leaving this option disabled means *do not ask for compressed
+transfer-encoding*. When disabled, libcurl still recognizes and handles
+chunked encoding if the server sends such in an HTTP/1.1 response.
+
+Starting in 8.14.0, this option can be set to *-1* to make libcurl completely
+ignore the `Transfer-Encoding` header and pretend it does not exist. Such
+behavior might then make it not know when the transfer ends. Beware.
+
 # DEFAULT
 
 0

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -739,6 +739,9 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
   CURLcode result;
   bool has_chunked = FALSE;
 
+  if(data->set.http_trenc == TR_MODE_IGNORE)
+    return CURLE_OK;
+
   do {
     const char *name;
     size_t namelen;
@@ -764,7 +767,8 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
                     strncasecompare(name, "chunked", 7));
       /* if we skip the decoding in this phase, do not look further.
        * Exception is "chunked" transfer-encoding which always must happen */
-      if((is_transfer && !data->set.http_transfer_encoding && !is_chunked) ||
+      if((is_transfer && (data->set.http_trenc == TR_MODE_CHUNKED) &&
+          !is_chunked) ||
          (!is_transfer && data->set.http_ce_skip)) {
         bool is_identity = strncasecompare(name, "identity", 8);
         /* not requested, ignore */

--- a/lib/content_encoding.h
+++ b/lib/content_encoding.h
@@ -25,9 +25,9 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
-#define TR_MODE_IGNORE   0
-#define TR_MODE_CHUNKED  1
-#define TR_MODE_COMPRESS 2
+#define TR_MODE_CHUNKED  0 /* default */
+#define TR_MODE_COMPRESS 1
+#define TR_MODE_IGNORE   2
 
 struct Curl_cwriter;
 

--- a/lib/content_encoding.h
+++ b/lib/content_encoding.h
@@ -25,6 +25,10 @@
  ***************************************************************************/
 #include "curl_setup.h"
 
+#define TR_MODE_IGNORE   0
+#define TR_MODE_CHUNKED  1
+#define TR_MODE_COMPRESS 2
+
 struct Curl_cwriter;
 
 void Curl_all_content_encodings(char *buf, size_t blen);

--- a/lib/http.c
+++ b/lib/http.c
@@ -2611,7 +2611,7 @@ static CURLcode http_firstwrite(struct Curl_easy *data)
 static CURLcode http_transferencode(struct Curl_easy *data)
 {
   if(!Curl_checkheaders(data, STRCONST("TE")) &&
-     data->set.http_transfer_encoding) {
+     (data->set.http_trenc == TR_MODE_COMPRESS)) {
     /* When we are to insert a TE: header in the request, we must also insert
        TE in a Connection: header, so we need to merge the custom provided
        Connection: header and prevent the original to get sent. Note that if
@@ -3323,7 +3323,7 @@ static CURLcode http_header(struct Curl_easy *data,
       result = Curl_build_unencoding_stack(data, v, TRUE);
       if(result)
         return result;
-      if(!k->chunk && data->set.http_transfer_encoding) {
+      if(!k->chunk && (data->set.http_trenc == TR_MODE_COMPRESS)) {
         /* if this is not chunked, only close can signal the end of this
          * transfer as Content-Length is said not to be trusted for
          * transfer-encoding! */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -521,7 +521,18 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     if((arg < -1) || (arg > 1))
       return CURLE_BAD_FUNCTION_ARGUMENT;
     /* see the TR_MODE_* defines */
-    data->set.http_trenc = (unsigned char)(arg + 1);
+    switch(arg) {
+    case -1:
+      data->set.http_trenc = TR_MODE_IGNORE;
+      break;
+    case 1:
+      data->set.http_trenc = TR_MODE_COMPRESS;
+      break;
+    case 0:
+    default:
+      data->set.http_trenc = TR_MODE_CHUNKED;
+      break;
+    }
     break;
 
   case CURLOPT_FOLLOWLOCATION:

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -518,7 +518,10 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     break;
 
   case CURLOPT_TRANSFER_ENCODING:
-    data->set.http_transfer_encoding = enabled;
+    if((arg < -1) || (arg > 1))
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    /* see the TR_MODE_* defines */
+    data->set.http_trenc = (unsigned char)(arg + 1);
     break;
 
   case CURLOPT_FOLLOWLOCATION:

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1728,6 +1728,7 @@ struct UserDefined {
   unsigned char gssapi_delegation;
 #endif
   unsigned char http_follow_mode; /* follow HTTP redirects */
+  unsigned char http_trenc; /* transfer-encoding mode */
   BIT(connect_only); /* make connection/request, then let application use the
                         socket */
   BIT(connect_only_ws); /* special websocket connect-only level */
@@ -1779,7 +1780,6 @@ struct UserDefined {
   BIT(hide_progress);    /* do not use the progress meter */
   BIT(http_fail_on_error);  /* fail on HTTP error codes >= 400 */
   BIT(http_keep_sending_on_error); /* for HTTP status codes >= 300 */
-  BIT(http_transfer_encoding); /* request compressed HTTP transfer-encoding */
   BIT(allow_auth_to_other_hosts);
   BIT(include_header); /* include received protocol headers in data output */
   BIT(http_set_referer); /* is a custom referer used */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1564,7 +1564,9 @@ static CURLcode config2setopts(struct GlobalConfig *global,
   /* curl 7.16.2 */
   if(config->raw) {
     my_setopt_long(curl, CURLOPT_HTTP_CONTENT_DECODING, 0);
-    my_setopt_long(curl, CURLOPT_HTTP_TRANSFER_DECODING, 0);
+
+    /* new value set in 8.14.0 */
+    my_setopt_long(curl, CURLOPT_HTTP_TRANSFER_DECODING, -1);
   }
 
   /* curl 7.17.1 */

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -27,8 +27,6 @@
 # per line.
 # Lines starting with '#' letters are treated as comments.
 #
-# PR #16959 makes Transfer-Encoding stricer and thus --raw broke
-319
 # Uses SRP to "a server not supporting it" but modern stunnel versions
 # will silently accept it and remain happy
 323


### PR DESCRIPTION
The previously supported values 1 and 0 are not good enough for the curl tool's --raw function.

1: asks for compressed transfer-encoding

0: disables the ask for compressed transfer-encoding but keeps support for chunked

-1: is the new option that also disables the support for chunked and passes on data as-is

The curl's raw option then sets -1 from now on. It used to set 0 but that only worked because of previous bugs in libcurl that now have been fixed.