### PR TITLE
CURLOPT_HTTP_TRANSFER_DECODING: fixed

### DIFF
--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -770,7 +770,7 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
         /* not requested, ignore */
         CURL_TRC_WRITE(data, "decoder not requested, ignored: %.*s",
                        (int)namelen, name);
-        if(is_transfer) {
+        if(is_transfer && !data->set.http_te_skip) {
           if(has_chunked)
             failf(data, "A Transfer-Encoding (%.*s) was listed after chunked",
                   (int)namelen, name);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1129,12 +1129,8 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     /*
      * disable libcurl transfer encoding is used
      */
-#ifndef USE_HYPER
     data->set.http_te_skip = !enabled; /* reversed */
     break;
-#else
-    return CURLE_NOT_BUILT_IN; /* hyper does not support */
-#endif
 
   case CURLOPT_HTTP_CONTENT_DECODING:
     /*

--- a/tests/data/DISABLED
+++ b/tests/data/DISABLED
@@ -27,8 +27,6 @@
 # per line.
 # Lines starting with '#' letters are treated as comments.
 #
-# PR #16959 makes Transfer-Encoding stricer and thus --raw broke
-319
 # Uses SRP to "a server not supporting it" but modern stunnel versions
 # will silently accept it and remain happy
 323


### PR DESCRIPTION
The fix in #16959 broke the CURLOPT_HTTP_TRANSFER_DECODING handling a little bit, shown in test 319 and curl's --raw option.

This is a follow-up that restores the functionality.

Enable test 319 again.