### PR TITLE
scripts: completion.pl: sort the completion file for all shells

### DIFF
--- a/scripts/completion.pl
+++ b/scripts/completion.pl
@@ -153,7 +153,7 @@ sub parse_main_opts {
         $b =~ /([^=]*)/; my $mb = $1;
 
         length($mb) <=> length($ma) || $ma cmp $mb
-    } @list if $shell eq 'zsh';
+    } @list;
 
     return @list;
 }


### PR DESCRIPTION
The reproducible builds effort in Debian has caught a regression in curl 8.13.0-rc1 but we were a bit slow to realize it. The ordering of the completion file for fish is not deterministic so it can differ between builds. Since there is no restriction about the order of the completion file for fish, let's just sort it too.