### PR TITLE
make: clean tests better

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -222,3 +222,6 @@ checksrc:
 tidy:
 	(cd src && $(MAKE) tidy)
 	(cd lib && $(MAKE) tidy)
+
+clean-local:
+	(cd tests && $(MAKE) clean)

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -96,11 +96,13 @@ libstubgss_la_LIBADD =
 libstubgss_la_DEPENDENCIES =
 endif
 
+BUNDLE=libtests
+
 if USE_TEST_BUNDLES
 libtest_bundle.c: $(top_srcdir)/tests/mk-bundle.pl Makefile.inc $(FIRSTFILES) lib1521.c
 	@PERL@ $(top_srcdir)/tests/mk-bundle.pl $(srcdir) > libtest_bundle.c
 
-noinst_PROGRAMS = libtests
+noinst_PROGRAMS = $(BUNDLE)
 nodist_libtests_SOURCES = libtest_bundle.c
 libtests_SOURCES = $(TESTUTIL) $(TSTTRACE)
 libtests_LDADD = $(TESTUTIL_LIBS)
@@ -133,3 +135,6 @@ if DEBUGBUILD
 # for debug builds, we scan the sources on all regular make invokes
 all-local: checksrc
 endif
+
+clean-local:
+	rm -f $(BUNDLE)

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -58,12 +58,14 @@ if CURLDEBUG
 AM_CPPFLAGS += -DCURLDEBUG
 endif
 
+BUNDLE=units
+
 if BUILD_UNITTESTS
 if USE_TEST_BUNDLES
 unit_bundle.c: $(top_srcdir)/tests/mk-bundle.pl Makefile.inc
 	@PERL@ $(top_srcdir)/tests/mk-bundle.pl $(srcdir) > unit_bundle.c
 
-noinst_PROGRAMS = units
+noinst_PROGRAMS = $(BUNDLE)
 nodist_units_SOURCES = unit_bundle.c
 CLEANFILES = unit_bundle.c
 else
@@ -85,3 +87,6 @@ checksrc:
 	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) \
 	  -W$(srcdir)/unit_bundle.c \
 	  $(srcdir)/*.[ch])
+
+clean-local:
+	rm -f $(BUNDLE)


### PR DESCRIPTION
1. 'make clean' in the root dir now also invokes 'make clean' in the tests subdir so that it cleans up better recursively. The Makefile.am does not list 'tests' as a normal subdir to avoid building that directory for a normal make invoke.

2. 'make clean' in the tests/libtest and tests/unit directories now *explicitly* remove the unity build executables even if this is not a unit build. This, because those files may be leftovers from previous builds and such leftovers can otherwise linger around and since 'runtests.pl' dynamically acts differently based on the mere *presence* of those files, they can keep you fooled for a while until you realize...