### PR TITLE
docs: fix incorrect shell substitution in docker run example command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 #
 # or get into a shell in the build environment, for example
 #
-#   docker run --rm -it -u $(id -u):$(id -g) -v (pwd):/usr/src -w /usr/src curl/curl bash
+#   docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):/usr/src -w /usr/src curl/curl bash
 #   $ autoreconf -fi
 #   $ ./configure --without-ssl --without-libpsl
 #   $ make


### PR DESCRIPTION
Corrected the volume mount path in the Docker run example by replacing `(pwd)` with the shell substitution syntax `$(pwd)`. This ensures the current working directory is properly mounted into the container.