### PR TITLE
mk-ca-bundle: follow redirects

### DIFF
--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -316,9 +316,9 @@ if(!$opt_n) {
     if($curl) {
       if($curl =~ /^Protocols:.* https( |$)/m) {
         report "Get certdata with curl!";
-        my $proto = !$opt_k ? "--proto =https" : "";
+        my $proto = !$opt_k ? "--proto =https --proto-redir =https" : "";
         my $quiet = $opt_q ? "-s" : "";
-        my @out = `curl -w %{response_code} $proto $quiet -o "$txt" "$url"`;
+        my @out = `curl -w %{response_code} --location $proto $quiet -o "$txt" "$url"`;
         if(!$? && @out && $out[0] == 200) {
           $fetched = 1;
           report "Downloaded $txt";

--- a/scripts/mk-ca-bundle.pl
+++ b/scripts/mk-ca-bundle.pl
@@ -316,7 +316,7 @@ if(!$opt_n) {
     if($curl) {
       if($curl =~ /^Protocols:.* https( |$)/m) {
         report "Get certdata with curl!";
-        my $proto = !$opt_k ? "--proto =https --proto-redir =https" : "";
+        my $proto = !$opt_k ? "--proto =https" : "";
         my $quiet = $opt_q ? "-s" : "";
         my @out = `curl -w %{response_code} --location $proto $quiet -o "$txt" "$url"`;
         if(!$? && @out && $out[0] == 200) {


### PR DESCRIPTION
Mozilla changed its server config to return 302, breaking the script.
Fix it by following redirects.

Reported-by: Harry Sintonen
Ref: https://infosec.exchange/@harrysintonen/114301373628307273
