### PR TITLE
certs: drop unused `default_bits` from `.prm` files

### DIFF
--- a/tests/certs/test-ca.prm
+++ b/tests/certs/test-ca.prm
@@ -19,7 +19,6 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-client-cert.prm
+++ b/tests/certs/test-client-cert.prm
@@ -21,7 +21,6 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-localhost-san-first.prm
+++ b/tests/certs/test-localhost-san-first.prm
@@ -21,7 +21,6 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-localhost-san-first.prm
+++ b/tests/certs/test-localhost-san-first.prm
@@ -21,7 +21,7 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 1024
+default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-localhost-san-last.prm
+++ b/tests/certs/test-localhost-san-last.prm
@@ -21,7 +21,6 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-localhost-san-last.prm
+++ b/tests/certs/test-localhost-san-last.prm
@@ -21,7 +21,7 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 1024
+default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-localhost.nn.prm
+++ b/tests/certs/test-localhost.nn.prm
@@ -21,7 +21,6 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-localhost.nn.prm
+++ b/tests/certs/test-localhost.nn.prm
@@ -21,7 +21,7 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 1024
+default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-localhost.prm
+++ b/tests/certs/test-localhost.prm
@@ -21,7 +21,6 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-localhost0h.prm
+++ b/tests/certs/test-localhost0h.prm
@@ -22,7 +22,6 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only

--- a/tests/certs/test-localhost0h.prm
+++ b/tests/certs/test-localhost0h.prm
@@ -22,7 +22,7 @@ caIssuers;URI.0         = http://test.curl.se/ca/EdelCurlRoot.cer
 URI.0                   = http://test.curl.se/ca/EdelCurlRoot.crl
 
 [ req ]
-default_bits            = 1024
+default_bits            = 2048
 distinguished_name      = req_DN
 default_md              = sha256
 string_mask             = utf8only


### PR DESCRIPTION
Cert generation do not use these default values, some were also low,
and they were RSA-specific, and the generator recently switched to ECC.
