### PR TITLE
openssl: enable builds for *both* engines and providers

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1215,9 +1215,11 @@ struct UrlState {
 #if defined(USE_OPENSSL)
   /* void instead of ENGINE to avoid bleeding OpenSSL into this header */
   void *engine;
-  /* this is just a flag -- we do not need to reference the provider in any
-   * way as OpenSSL takes care of that */
-  BIT(provider);
+  /* void instead of OSSL_PROVIDER */
+  void *provider;
+  void *libctx;
+
+  BIT(provider_loaded);
   BIT(provider_failed);
 #endif /* USE_OPENSSL */
   struct curltime expiretime; /* set this with Curl_expire() only */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1898,8 +1898,8 @@ static CURLcode ossl_set_engine(struct Curl_easy *data, const char *engine)
 #ifndef SET_ENGINE_HANDLED
   (void)engine;
   failf(data, "OpenSSL engine or provider not supported");
-  return CURLE_SSL_ENGINE_NOTFOUND;
 #endif
+  return CURLE_SSL_ENGINE_NOTFOUND;
 }
 
 /* Sets engine as default for all SSL operations

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1888,18 +1888,14 @@ static CURLcode ossl_set_engine(struct Curl_easy *data, const char *engine)
     data->state.engine = e;
     return result;
   }
-#define SET_ENGINE_HANDLED 1
 #endif
 #ifdef OPENSSL_HAS_PROVIDERS
   return ossl_set_provider(data, engine);
-#define SET_ENGINE_HANDLED 1
-#endif
-
-#ifndef SET_ENGINE_HANDLED
+#else
   (void)engine;
-  failf(data, "OpenSSL engine or provider not supported");
-#endif
+  failf(data, "OpenSSL engine not found");
   return CURLE_SSL_ENGINE_NOTFOUND;
+#endif
 }
 
 /* Sets engine as default for all SSL operations

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1896,6 +1896,7 @@ static CURLcode ossl_set_engine(struct Curl_easy *data, const char *engine)
 #endif
 
 #ifndef SET_ENGINE_HANDLED
+  (void)engine;
   failf(data, "OpenSSL engine or provider not supported");
   return CURLE_SSL_ENGINE_NOTFOUND;
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1099,7 +1099,7 @@ static bool is_pkcs11_uri(const char *string)
 #endif
 
 static CURLcode ossl_set_engine(struct Curl_easy *data, const char *engine);
-#if !defined(USE_OPENSSL_ENGINE) && defined(OPENSSL_HAS_PROVIDERS)
+#if defined(OPENSSL_HAS_PROVIDERS)
 static CURLcode ossl_set_provider(struct Curl_easy *data,
                                   const char *provider);
 #endif
@@ -1352,7 +1352,8 @@ int cert_stuff(struct Curl_easy *data,
       }
     }
     break;
-#elif defined(OPENSSL_HAS_PROVIDERS)
+#endif
+#if defined(OPENSSL_HAS_PROVIDERS)
       /* fall through to compatible provider */
     case SSL_FILETYPE_PROVIDER:
     {
@@ -1371,7 +1372,12 @@ int cert_stuff(struct Curl_easy *data,
         OSSL_STORE_CTX *store = NULL;
         OSSL_STORE_INFO *info = NULL;
         X509 *cert = NULL;
+#if 0
         store = OSSL_STORE_open(cert_file, NULL, NULL, NULL, NULL);
+#else
+        store = OSSL_STORE_open_ex(cert_file, data->state.libctx,
+                                   NULL, NULL, NULL, NULL, NULL, NULL);
+#endif
         if(!store) {
           failf(data, "Failed to open OpenSSL store: %s",
                 ossl_strerror(ERR_get_error(), error_buffer,
@@ -1384,22 +1390,13 @@ int cert_stuff(struct Curl_easy *data,
                               sizeof(error_buffer)));
         }
 
-        for(info = OSSL_STORE_load(store);
-            info != NULL;
-            info = OSSL_STORE_load(store)) {
+        info = OSSL_STORE_load(store);
+        if(info) {
           int ossl_type = OSSL_STORE_INFO_get_type(info);
 
-          if(ossl_type == OSSL_STORE_INFO_CERT) {
+          if(ossl_type == OSSL_STORE_INFO_CERT)
             cert = OSSL_STORE_INFO_get1_CERT(info);
-          }
-          else {
-            failf(data, "Ignoring object not matching our type: %d",
-                  ossl_type);
-            OSSL_STORE_INFO_free(info);
-            continue;
-          }
           OSSL_STORE_INFO_free(info);
-          break;
         }
         OSSL_STORE_close(store);
         if(!cert) {
@@ -1423,9 +1420,6 @@ int cert_stuff(struct Curl_easy *data,
       }
     }
     break;
-#else
-    failf(data, "file type ENG nor PROV for certificate not implemented");
-    return 0;
 #endif
 
     case SSL_FILETYPE_PKCS12:
@@ -1615,7 +1609,8 @@ fail:
       }
     }
     break;
-#elif defined(OPENSSL_HAS_PROVIDERS)
+#endif
+#if defined(OPENSSL_HAS_PROVIDERS)
       /* fall through to compatible provider */
     case SSL_FILETYPE_PROVIDER:
     {
@@ -1646,7 +1641,8 @@ fail:
         UI_method_set_reader(ui_method, ssl_ui_reader);
         UI_method_set_writer(ui_method, ssl_ui_writer);
 
-        store = OSSL_STORE_open(key_file, ui_method, NULL, NULL, NULL);
+        store = OSSL_STORE_open_ex(key_file, data->state.libctx, NULL,
+                                   ui_method, NULL, NULL, NULL, NULL);
         if(!store) {
           failf(data, "Failed to open OpenSSL store: %s",
                 ossl_strerror(ERR_get_error(), error_buffer,
@@ -1659,22 +1655,13 @@ fail:
                               sizeof(error_buffer)));
         }
 
-        for(info = OSSL_STORE_load(store);
-            info != NULL;
-            info = OSSL_STORE_load(store)) {
+        info = OSSL_STORE_load(store);
+        if(info) {
           int ossl_type = OSSL_STORE_INFO_get_type(info);
 
-          if(ossl_type == OSSL_STORE_INFO_PKEY) {
+          if(ossl_type == OSSL_STORE_INFO_PKEY)
             priv_key = OSSL_STORE_INFO_get1_PKEY(info);
-          }
-          else {
-            failf(data, "Ignoring object not matching our type: %d",
-                  ossl_type);
-            OSSL_STORE_INFO_free(info);
-            continue;
-          }
           OSSL_STORE_INFO_free(info);
-          break;
         }
         OSSL_STORE_close(store);
         UI_destroy_method(ui_method);
@@ -1700,9 +1687,6 @@ fail:
       }
     }
     break;
-#else
-    failf(data, "file type ENG nor PROV for private key not implemented");
-    return 0;
 #endif
 
     case SSL_FILETYPE_PKCS12:
@@ -1877,36 +1861,42 @@ static void ossl_cleanup(void)
   Curl_tls_keylog_close();
 }
 
-/* Selects an OpenSSL crypto engine
+/* Selects an OpenSSL crypto engine or provider.
  */
 static CURLcode ossl_set_engine(struct Curl_easy *data, const char *engine)
 {
 #ifdef USE_OPENSSL_ENGINE
+  CURLcode result = CURLE_SSL_ENGINE_NOTFOUND;
   ENGINE *e = ENGINE_by_id(engine);
 
-  if(!e) {
-    failf(data, "SSL Engine '%s' not found", engine);
-    return CURLE_SSL_ENGINE_NOTFOUND;
-  }
+  if(e) {
 
-  if(data->state.engine) {
-    ENGINE_finish(data->state.engine);
-    ENGINE_free(data->state.engine);
-    data->state.engine = NULL;
-  }
-  if(!ENGINE_init(e)) {
-    char buf[256];
+    if(data->state.engine) {
+      ENGINE_finish(data->state.engine);
+      ENGINE_free(data->state.engine);
+      data->state.engine = NULL;
+    }
+    if(!ENGINE_init(e)) {
+      char buf[256];
 
-    ENGINE_free(e);
-    failf(data, "Failed to initialise SSL Engine '%s': %s",
-          engine, ossl_strerror(ERR_get_error(), buf, sizeof(buf)));
-    return CURLE_SSL_ENGINE_INITFAILED;
+      ENGINE_free(e);
+      failf(data, "Failed to initialise SSL Engine '%s': %s",
+            engine, ossl_strerror(ERR_get_error(), buf, sizeof(buf)));
+      result = CURLE_SSL_ENGINE_INITFAILED;
+      e = NULL;
+    }
+    data->state.engine = e;
+    return result;
   }
-  data->state.engine = e;
-  return CURLE_OK;
-#else
-  (void)engine;
-  failf(data, "SSL Engine not supported");
+#define SET_ENGINE_HANDLED 1
+#endif
+#ifdef OPENSSL_HAS_PROVIDERS
+  return ossl_set_provider(data, engine);
+#define SET_ENGINE_HANDLED 1
+#endif
+
+#ifndef SET_ENGINE_HANDLED
+  failf(data, "OpenSSL engine or provider not supported");
   return CURLE_SSL_ENGINE_NOTFOUND;
 #endif
 }
@@ -1955,25 +1945,31 @@ static struct curl_slist *ossl_engines_list(struct Curl_easy *data)
   return list;
 }
 
-#if !defined(USE_OPENSSL_ENGINE) && defined(OPENSSL_HAS_PROVIDERS)
+#if defined(OPENSSL_HAS_PROVIDERS)
 /* Selects an OpenSSL crypto provider
  */
-static CURLcode ossl_set_provider(struct Curl_easy *data, const char *provider)
+static CURLcode ossl_set_provider(struct Curl_easy *data, const char *name)
 {
-  OSSL_PROVIDER *pkcs11_provider = NULL;
   char error_buffer[256];
 
-  if(OSSL_PROVIDER_available(NULL, provider)) {
-    /* already loaded through the configuration - no action needed */
-    data->state.provider = TRUE;
-    return CURLE_OK;
-  }
-  if(data->state.provider_failed) {
-    return CURLE_SSL_ENGINE_NOTFOUND;
+  if(!data->state.libctx) {
+    OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
+    if(!libctx)
+      return CURLE_OUT_OF_MEMORY;
+    data->state.libctx = libctx;
   }
 
-  pkcs11_provider = OSSL_PROVIDER_try_load(NULL, provider, 1);
-  if(!pkcs11_provider) {
+  if(OSSL_PROVIDER_available(data->state.libctx, name)) {
+    /* already loaded through the configuration - no action needed */
+    data->state.provider_loaded = TRUE;
+    return CURLE_OK;
+  }
+  if(data->state.provider_failed)
+    return CURLE_SSL_ENGINE_NOTFOUND;
+
+  data->state.provider =
+    OSSL_PROVIDER_try_load(data->state.libctx, name, 1);
+  if(!data->state.provider) {
     failf(data, "Failed to initialize provider: %s",
           ossl_strerror(ERR_get_error(), error_buffer,
                         sizeof(error_buffer)));
@@ -1981,7 +1977,7 @@ static CURLcode ossl_set_provider(struct Curl_easy *data, const char *provider)
     data->state.provider_failed = TRUE;
     return CURLE_SSL_ENGINE_NOTFOUND;
   }
-  data->state.provider = TRUE;
+  data->state.provider_loaded = TRUE;
   return CURLE_OK;
 }
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1948,6 +1948,7 @@ static struct curl_slist *ossl_engines_list(struct Curl_easy *data)
 static CURLcode ossl_set_provider(struct Curl_easy *data, const char *name)
 {
   char error_buffer[256];
+  OSSL_PROVIDER *base;
 
   if(!data->state.libctx) {
     OSSL_LIB_CTX *libctx = OSSL_LIB_CTX_new();
@@ -1974,7 +1975,11 @@ static CURLcode ossl_set_provider(struct Curl_easy *data, const char *name)
     data->state.provider_failed = TRUE;
     return CURLE_SSL_ENGINE_NOTFOUND;
   }
-  data->state.provider_loaded = TRUE;
+  base = OSSL_PROVIDER_try_load(data->state.libctx, "base", 1);
+  if(!base)
+    failf(data, "Failed to load base");
+  else
+    data->state.provider_loaded = TRUE;
   return CURLE_OK;
 }
 #endif

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1679,6 +1679,16 @@ fail:
           EVP_PKEY_free(priv_key);
           return 0;
         }
+        {
+          OSSL_PARAM *p;
+          OSSL_PARAM *p2;
+          if(EVP_PKEY_todata(priv_key, EVP_PKEY_KEY_PARAMETERS, &p) == 1) {
+            ;
+          }
+          if(EVP_PKEY_todata(priv_key, EVP_PKEY_KEYPAIR, &p2) == 1) {
+            ;
+          }
+        }
         EVP_PKEY_free(priv_key); /* we do not need the handle any more... */
       }
       else {


### PR DESCRIPTION
OpenSSL3 can in fact have both enabled at once.

Load the provider and key/cert appropriately

- [ ] make it actually work
- [ ] remove debug leftovers
- [ ] cleanup without leaks
- [ ] documentation