### PR TITLE
tests: require IPv6 for 1247, 1324, 2086

### DIFF
--- a/tests/data/test1265
+++ b/tests/data/test1265
@@ -6,6 +6,7 @@ HTTP proxy
 http_proxy
 NO_PROXY
 noproxy
+IPv6
 </keywords>
 </info>
 
@@ -24,6 +25,10 @@ foo
 
 # Client-side
 <client>
+<features>
+http
+IPv6
+</features>
 <server>
 http-ipv6
 </server>

--- a/tests/data/test1324
+++ b/tests/data/test1324
@@ -3,6 +3,7 @@
 <keywords>
 HTTP
 HTTP GET
+IPv6
 --resolve
 </keywords>
 </info>
@@ -29,6 +30,10 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
+<features>
+http
+IPv6
+</features>
 <server>
 http-ipv6
 </server>

--- a/tests/data/test2086
+++ b/tests/data/test2086
@@ -20,6 +20,10 @@ Content-Length: 0
 
 # Client-side
 <client>
+<features>
+http
+IPv6
+</features>
 <server>
 http-ipv6
 </server>


### PR DESCRIPTION
Fixing:

Linux AM openssl !ipv6 !--libcurl:
```
FAIL 1265: 'NO_PROXY with IPv6 numerical address' HTTP, HTTP proxy, http_proxy, NO_PROXY, noproxy
FAIL 1324: 'HTTP with --resolve and [ipv6address]' HTTP, HTTP GET, --resolve
FAIL 2086: 'Pre-request callback for HTTP IPv6' HTTP, IPv6
```
Ref: https://github.com/curl/curl/actions/runs/14378524385/job/40318328714?pr=17012#step:41:3789

---

Not sure, why this did not come up earlier.
