### PR TITLE
GHA/macos: re-generate gcc-13 hacklayer on macos-15

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -439,9 +439,8 @@ jobs:
 
       - name: 'configure / ${{ matrix.build }}'
         run: |
-          if [ '${{ matrix.compiler }}' = 'gcc-13' ] && \
-             [ '${{ matrix.image }}' = 'macos-15' ] ; then
-            # Ref: https://github.com/Homebrew/homebrew-core/issues/194778
+          if [ '${{ matrix.compiler }}' = 'gcc-13' ] && [ '${{ matrix.image }}' = 'macos-15' ] ; then
+            # Ref: https://github.com/Homebrew/homebrew-core/issues/194778#issuecomment-2793243409
             /opt/homebrew/opt/gcc@13/libexec/gcc/aarch64-apple-darwin24/13/install-tools/mkheaders
           fi
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -439,7 +439,8 @@ jobs:
 
       - name: 'configure / ${{ matrix.build }}'
         run: |
-          if [ '${{ matrix.compiler }}' = 'gcc-13' ]; then
+          if [ '${{ matrix.compiler }}' = 'gcc-13' ] && \
+             [ '${{ matrix.image }}' = 'macos-15' ] ; then
             # Ref: https://github.com/Homebrew/homebrew-core/issues/194778
             /opt/homebrew/opt/gcc@13/libexec/gcc/aarch64-apple-darwin24/13/install-tools/mkheaders
           fi

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -439,6 +439,11 @@ jobs:
 
       - name: 'configure / ${{ matrix.build }}'
         run: |
+          if [ '${{ matrix.compiler }}' = 'gcc-13' ]; then
+            # Ref: https://github.com/Homebrew/homebrew-core/issues/194778
+            /opt/homebrew/opt/gcc@13/libexec/gcc/aarch64-apple-darwin24/13/install-tools/mkheaders
+          fi
+
           if [[ '${{ matrix.compiler }}' = 'gcc'* ]]; then
             sysroot="$("${CC}" --print-sysroot)"  # Must match the SDK gcc was built for
           else


### PR DESCRIPTION
Add workaround for an issue related to the gcc "hacklayer" after the
GitHub macos-15-arm64 runner bumped to 20250408.1231.

Fixes:
```
configure:5175: gcc-13 -o conftest  --sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk  -w conftest.c  >&5
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/_stdio.h:71,
                 from /opt/homebrew/Cellar/gcc@13/13.3.0/lib/gcc/13/gcc/aarch64-apple-darwin24/13/include-fixed/stdio.h:75,
                 from conftest.c:9:
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/_stdio.h: In function 'fmemopen':
/Library/Developer/CommandLineTools/SDKs/MacOSX15.sdk/usr/include/_stdio.h:457:107: error: expected declaration specifiers before '__API_AVAILABLE_GET_MACRO_93585900'
  457 | FILE *fmemopen(void * __restrict __buf _LIBC_SIZE(__size), size_t __size, const char * __restrict __mode) __API_AVAILABLE(macos(10.13), ios(11.0), tvos(11.0), watchos(4.0));
      |                                                                                                           ^~~~~~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/14378524390/job/40316589059?pr=17012#step:7:169

Assisted-by: Bo Anderson
Bug: https://github.com/curl/curl/pull/17012#issuecomment-2792572344
Bug: https://github.com/Homebrew/homebrew-core/issues/194778#issuecomment-2792601570
