### PR TITLE
docs: add missing return statement in examples

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
@@ -47,15 +47,16 @@ struct priv {
 
 static int timerfunc(CURLM *multi, long timeout_ms, void *clientp)
 {
- struct priv *mydata = clientp;
- printf("our ptr: %p\n", mydata->custom);
+  struct priv *mydata = clientp;
+  printf("our ptr: %p\n", mydata->custom);
 
- if(timeout_ms) {
-   /* this is the new single timeout to wait for */
- }
- else {
-   /* delete the timeout, nothing to wait for now */
- }
+  if(timeout_ms) {
+    /* this is the new single timeout to wait for */
+  }
+  else {
+    /* delete the timeout, nothing to wait for now */
+  }
+  return 0;
 }
 
 int main(void)

--- a/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.md
@@ -88,6 +88,7 @@ static int timerfunc(CURLM *multi, long timeout_ms, void *clientp)
   else {
     /* delete the timeout, nothing to wait for now */
   }
+  return 0;
 }
 
 int main(void)


### PR DESCRIPTION
Add missing return statement in `CURLMOPT_TIMERDATA.md` and `CURLMOPT_TIMERFUNCTION.md`.

It's crucial return a value from the timer callback. A value can be set in register by another call and then taken from the same register as return value for timer callback. All in-progress transfers will be aborted in this `curl_multi` if `-1` is returned.