### PR TITLE
tool_parsecfg: make get_line handle lines ending on the buffer boundary

### DIFF
--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -312,6 +312,8 @@ static bool get_line(FILE *input, struct dynbuf *buf, bool *error)
       else if(feof(input))
         return TRUE; /* all good */
     }
+    else if(curlx_dyn_len(buf))
+      return TRUE; /* all good */
     else
       break;
   }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -107,7 +107,7 @@ test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \
 test718 test719 test720 test721 test722 test723 test724 test725 test726 \
 test727 test728 test729 test730 test731 test732 test733 test734 test735 \
-test736 test737 test738 test739 test740 test741 test742 \
+test736 test737 test738 test739 test740 test741 test742 test743 \
 \
 test780 test781 test782 test783 test784 test785 test786 test787 test788 \
 test789 test790 test791 \

--- a/tests/data/test743
+++ b/tests/data/test743
@@ -1,0 +1,60 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+--config
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+--config with a 127 byte line
+</name>
+<file name="%LOGDIR/config" nonewline="yes">
+url localhost
+data = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+</file>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -K %LOGDIR/config
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes" nonewline="yes">
+POST /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+Content-Length: 118
+Content-Type: application/x-www-form-urlencoded
+
+%repeat[118 x x]%
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test743
+++ b/tests/data/test743
@@ -35,7 +35,7 @@ http
 --config with a 127 byte line
 </name>
 <file name="%LOGDIR/config" nonewline="yes">
-url localhost
+-A pointless
 data = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 </file>
 <command>
@@ -49,7 +49,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER -K %LOGDIR/config
 <protocol crlf="yes" nonewline="yes">
 POST /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
-User-Agent: curl/%VERSION
+User-Agent: pointless
 Accept: */*
 Content-Length: 118
 Content-Type: application/x-www-form-urlencoded


### PR DESCRIPTION
Add test 743 to verify.

Fixes #17030
Reported-by: Marius Kleidl