### PR TITLE
curl_get_line: handle lines ending on the buffer boundary

### DIFF
--- a/lib/curl_get_line.c
+++ b/lib/curl_get_line.c
@@ -70,6 +70,8 @@ int Curl_get_line(struct dynbuf *buf, FILE *input)
         return 1; /* all good */
       }
     }
+    else if(Curl_dyn_len(buf))
+      return 1; /* all good */
     else
       break;
   }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -107,7 +107,7 @@ test700 test701 test702 test703 test704 test705 test706 test707 test708 \
 test709 test710 test711 test712 test713 test714 test715 test716 test717 \
 test718 test719 test720 test721 test722 test723 test724 test725 test726 \
 test727 test728 test729 test730 test731 test732 test733 test734 test735 \
-test736 test737 test738 test739 test740 test741 test742 test743 \
+test736 test737 test738 test739 test740 test741 test742 test743 test744 \
 \
 test780 test781 test782 test783 test784 test785 test786 test787 test788 \
 test789 test790 test791 \

--- a/tests/data/test744
+++ b/tests/data/test744
@@ -1,0 +1,78 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+--netrc-file
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</data>
+<connect>
+HTTP/1.1 200 Mighty fine indeed
+
+</connect>
+<datacheck>
+HTTP/1.1 200 Mighty fine indeed
+
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake swsclose
+Content-Type: text/html
+Funny-head: yesyes
+Content-Length: 9
+
+contents
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+http-proxy
+</server>
+<name>
+--netrc-file with a 127 byte line
+</name>
+<file name="%LOGDIR/netrc%TESTNUMBER" nonewline="yes">
+machine foo.host login foo password baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaar
+</file>
+<command>
+http://foo.host:%HTTPPORT/%TESTNUMBER -p --proxy1.0 %HOSTIP:%PROXYPORT -A "" --netrc-file %LOGDIR/netrc%TESTNUMBER
+</command>
+<features>
+proxy
+</features>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<proxy>
+CONNECT foo.host:%HTTPPORT HTTP/1.0
+Host: foo.host:%HTTPPORT
+Proxy-Connection: Keep-Alive
+
+</proxy>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: foo.host:%HTTPPORT
+Authorization: Basic Zm9vOmJhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYWFhYXI=
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>


### PR DESCRIPTION
Very similar to 9f8bdd0eae5c1d441d9d901a7cf917a8ee215c7f, but affects e.g. netrc file parsing.

Suggested-by: Graham Christensen <graham@grahamc.com>

---

~~I opted to write a Perl test for this, since I didn't know how dynamic the `%HOSTIP` is, and triggering this bug requires the netrc line to be exactly 127 characters (so if it changes away from `127.0.0.1` in the future, this test would start to fail).~~

~~I am very far from an experienced Perl author, but I didn't see any examples of `command type="shell"` in the repo, so I just adapted an existing Perl test runner thing.~~