### PR TITLE
GHA/windows: bump Cygwin action, move package store to `D:`

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,12 +55,11 @@ jobs:
     steps:
       - run: git config --global core.autocrlf input
         shell: pwsh
-
-      - uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # v5
+      - uses: cygwin/cygwin-install-action@e67b1f4a359a621ee71cc8f0a96d3b8be1c9a218 # v5
         with:
           platform: ${{ matrix.platform }}
           site: https://mirrors.kernel.org/sourceware/cygwin/
-          install-dir: D:\cygwin
+          work-vol: 'D:'
           # https://cygwin.com/cgi-bin2/package-grep.cgi
           packages: >-
             autoconf libtool gcc-core gcc-g++ binutils


### PR DESCRIPTION
- to benefit from the new download retry mechanism.
  https://github.com/cygwin/cygwin-install-action/pull/26

- to use a new setting that not only moves the Cygwin install target
  directory to the faster `D:` drive, but also the package download
  directory. Expecting a little performance improvement from this for
  the Cygwin install step.
  https://github.com/cygwin/cygwin-install-action/commit/d3a7464b92425a95438e794ec49927871dde78d2
  https://github.com/cygwin/cygwin-install-action/pull/27
