### PR TITLE
GHA/windows: add support for built-in OpenSSH-Windows

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -817,7 +817,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            openssh: 'OpenSSH-Windows-built-in'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_LIBSSH2=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -817,6 +817,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
+            openssh: 'OpenSSH-Windows-built-in'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_LIBSSH2=ON
@@ -937,7 +938,6 @@ jobs:
             # https://learn.microsoft.com/windows-server/administration/openssh/openssh_install_firstuse
             pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Client'
             pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Server'
-            pwsh -Command 'Start-Service sshd'
           else  # OpenSSH-Windows
             cd /d || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -817,6 +817,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
+            openssh: 'OpenSSH-Windows-built-in'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_LIBSSH2=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -817,7 +817,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            openssh: 'OpenSSH-Windows-built-in'
+            openssh: 'OpenSSH-Windows-builtin'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_LIBSSH2=ON
@@ -934,7 +934,7 @@ jobs:
         run: |
           if [ '${{ matrix.openssh }}' = '' ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
-          elif [ '${{ matrix.openssh }}' = 'OpenSSH-Windows-built-in' ]; then
+          elif [ '${{ matrix.openssh }}' = 'OpenSSH-Windows-builtin' ]; then
             # https://learn.microsoft.com/windows-server/administration/openssh/openssh_install_firstuse
             pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.*'  # Client and Server
           else  # OpenSSH-Windows

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -935,8 +935,7 @@ jobs:
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           elif [ '${{ matrix.openssh }}' = 'OpenSSH-Windows-built-in' ]; then
             # https://learn.microsoft.com/windows-server/administration/openssh/openssh_install_firstuse
-            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Client'
-            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Server'
+            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.*'  # Client and Server
           else  # OpenSSH-Windows
             cd /d || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -936,7 +936,8 @@ jobs:
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           elif [ '${{ matrix.openssh }}' = 'OpenSSH-Windows-builtin' ]; then
             # https://learn.microsoft.com/windows-server/administration/openssh/openssh_install_firstuse
-            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.*'  # Client and Server
+            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0'
+            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0'
           else  # OpenSSH-Windows
             cd /d || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -933,6 +933,11 @@ jobs:
         run: |
           if [ '${{ matrix.openssh }}' = '' ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
+          elif [ '${{ matrix.openssh }}' = 'OpenSSH-Windows-built-in' ]; then
+            # https://learn.microsoft.com/windows-server/administration/openssh/openssh_install_firstuse
+            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Client'
+            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Server'
+            pwsh -Command 'Start-Service sshd'
           else  # OpenSSH-Windows
             cd /d || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -817,7 +817,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            openssh: 'OpenSSH-Windows-builtin'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_LIBSSH2=ON


### PR DESCRIPTION
On the windows-2022 runner it installs these client/server versions:
```
ssh client found /c/Windows/System32/OpenSSH/ssh.exe is OpenSSH-Windows 9.5.0
ssh server found /c/Windows/System32/OpenSSH/sshd.exe is OpenSSH-Windows 8.1.0
```

Not currently enabled. Slight downside (when enabled) that Windows needs
over 1 minute to install these two tiny programs.
