### PR TITLE
make: clean tests better (tunits)

### DIFF
--- a/tests/tunit/Makefile.am
+++ b/tests/tunit/Makefile.am
@@ -59,12 +59,14 @@ if CURLDEBUG
 AM_CPPFLAGS += -DCURLDEBUG
 endif
 
+BUNDLE=tunits
+
 if BUILD_UNITTESTS
 if USE_TEST_BUNDLES
 tool_bundle.c: $(top_srcdir)/tests/mk-bundle.pl Makefile.inc
 	@PERL@ $(top_srcdir)/tests/mk-bundle.pl $(srcdir) > tool_bundle.c
 
-noinst_PROGRAMS = tunits
+noinst_PROGRAMS = $(BUNDLE)
 nodist_tunits_SOURCES = tool_bundle.c
 CLEANFILES = tool_bundle.c
 else
@@ -86,3 +88,6 @@ checksrc:
 	$(CHECKSRC)(@PERL@ $(top_srcdir)/scripts/checksrc.pl -D$(srcdir) \
 	  -W$(srcdir)/tool_bundle.c \
 	  $(srcdir)/*.[ch])
+
+clean-local:
+	rm -f $(BUNDLE)


### PR DESCRIPTION
Sync clean target with other test bundles.

Follow-up to d3761bb84013ffd356753f943d687283afe203b5 #16986