### PR TITLE
processhelp.pm: always call `taskkill` with `-f` (force)

### DIFF
--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -168,7 +168,7 @@ sub pidterm {
             $pid -= 4194304;
             if($^O ne 'MSWin32') {
                 # https://ss64.com/nt/taskkill.html
-                my $cmd = "taskkill -t -pid $pid >nul 2>&1";
+                my $cmd = "taskkill -f -t -pid $pid >nul 2>&1";
                 print "Executing: '$cmd'\n";
                 system($cmd);
                 return;


### PR DESCRIPTION
In the hope this avoid a possible hang in `taskkill`.

To kill processes, `runtests` first tries to kill them gently (with
"TERM", or on Windows `taskkill`), then waits some time for them
to disappear and then kills them with `KILL`, or on Windows with
`taskkill -f`. This happens within `killpid()`.

This patch bumps the gentle phase to `taskkill -f`. On the obervation
that a non-forced `taskkill` may hang in cases:

msvc, CM x64-windows wolfssl +examples:
```
  [...]                                                    
  test 3006...[SMTP with multiple invalid (all) --mail-rcpt and --mail-rcpt-allowfails]
  --p----e--- OK (1682 out of 1718, remaining: 00:04, took 0.524s, duration: 03:13)
  test 3005...[SMTP with multiple and invalid (all but one) --mail-rcpt and --mail-rcpt-allowfails]
  --p-u--e-Executing: 'taskkill -t -pid 1196 >nul 2>&1'    
```                                                        
Ref: https://github.com/curl/curl/actions/runs/14445993473/job/40508986059?pr=17051#step:15:4176
                                                           
Cancelling the job worked, resulting in a greyed out status, with the above
step and log entries lost.                                 
                                                           
If this change causes issues or does nothing at all, we may revert it
or limit it to CI runs.
                                                           
Ref: https://github.com/curl/curl/discussions/14854#discussioncomment-12829697                          
