### PR TITLE
cmake: append picky warnings to `CMAKE_REQUIRED_FLAGS` as string

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -40,7 +40,6 @@ set(CURL_TEST_DEFINES "")  # Initialize global variable
 # Return result in variable: CURL_TEST_OUTPUT
 macro(curl_internal_test _curl_test)
   if(NOT DEFINED "${_curl_test}")
-    string(REPLACE ";" " " _cmake_required_flags "${CMAKE_REQUIRED_FLAGS}")
     string(REPLACE ";" " " _cmake_required_definitions "${CMAKE_REQUIRED_DEFINITIONS}")
     set(_curl_test_add_libraries "")
     if(CMAKE_REQUIRED_LIBRARIES)
@@ -53,7 +52,7 @@ macro(curl_internal_test _curl_test)
       ${PROJECT_BINARY_DIR}
       "${CMAKE_CURRENT_SOURCE_DIR}/CMake/CurlTests.c"
       CMAKE_FLAGS
-        "-DCOMPILE_DEFINITIONS:STRING=-D${_curl_test} ${CURL_TEST_DEFINES} ${_cmake_required_flags} ${_cmake_required_definitions}"
+        "-DCOMPILE_DEFINITIONS:STRING=-D${_curl_test} ${CURL_TEST_DEFINES} ${CMAKE_REQUIRED_FLAGS} ${_cmake_required_definitions}"
         "${_curl_test_add_libraries}"
       OUTPUT_VARIABLE CURL_TEST_OUTPUT)
     if(${_curl_test})

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -298,7 +298,7 @@ if(_picky)
   # Apply to all feature checks
   list(REMOVE_ITEM _picky "-pedantic-errors")  # Must not pass to feature checks
   string(REPLACE ";" " " _picky_tmp "${_picky}")
-  list(APPEND CMAKE_REQUIRED_FLAGS "${_picky_tmp}")
+  string(APPEND CMAKE_REQUIRED_FLAGS " ${_picky_tmp}")
 
   unset(_picky)
   unset(_picky_tmp)


### PR DESCRIPTION
Also:
- drop unnecessary type conversion. `CMAKE_REQUIRED_FLAGS` is already
  space-separated.
  https://cmake.org/cmake/help/latest/module/CheckCSourceCompiles.html

Follow-up to e86542038dda88dadf8959584e803895f979310c #17047
