### PR TITLE
easy_reset: fix dohfor_mid member

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -366,6 +366,10 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
   set->postfieldsize = -1;   /* unknown size */
   set->maxredirs = 30;       /* sensible default */
 
+#ifndef CURL_DISABLE_DOH
+  set->dohfor_mid  = -1;
+#endif
+
   set->method = HTTPREQ_GET; /* Default HTTP request */
 #ifndef CURL_DISABLE_RTSP
   set->rtspreq = RTSPREQ_OPTIONS; /* Default RTSP request */


### PR DESCRIPTION
On an easy reset, the dohfor_mid must be reset to -1.

refs #17052