### PR TITLE
dict: move internal defines to dict.c

### DIFF
--- a/lib/dict.c
+++ b/lib/dict.c
@@ -65,6 +65,15 @@
 /* The last #include file should be: */
 #include "memdebug.h"
 
+
+#define DICT_MATCH "/MATCH:"
+#define DICT_MATCH2 "/M:"
+#define DICT_MATCH3 "/FIND:"
+#define DICT_DEFINE "/DEFINE:"
+#define DICT_DEFINE2 "/D:"
+#define DICT_DEFINE3 "/LOOKUP:"
+
+
 /*
  * Forward declarations.
  */

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -95,13 +95,6 @@ typedef unsigned int curl_prot_t;
    in the API */
 #define CURLPROTO_MASK   (0x3ffffff)
 
-#define DICT_MATCH "/MATCH:"
-#define DICT_MATCH2 "/M:"
-#define DICT_MATCH3 "/FIND:"
-#define DICT_DEFINE "/DEFINE:"
-#define DICT_DEFINE2 "/D:"
-#define DICT_DEFINE3 "/LOOKUP:"
-
 #define CURL_DEFAULT_USER "anonymous"
 #define CURL_DEFAULT_PASSWORD "ftp@example.com"
 


### PR DESCRIPTION
Move defines only used in dict.c from urldata.h to implementation.