### PR TITLE
cmake: merge `CURL_WERROR` logic into `PickyWarnings.cmake`

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -287,21 +287,24 @@ endif()
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND MSVC)
   list(APPEND _picky "-Wno-language-extension-token")  # Allow __int64
 
-  set(_picky_tmp "")
-  foreach(_ccopt IN LISTS _picky)
-    # Prefix -Wall, otherwise clang-cl interprets it as an MSVC option and translates it to -Weverything
-    if(_ccopt MATCHES "^-W" AND NOT _ccopt STREQUAL "-Wall")
-      list(APPEND _picky_tmp ${_ccopt})
-    else()
-      list(APPEND _picky_tmp "-clang:${_ccopt}")
-    endif()
+  foreach(_wlist IN ITEMS _picky_nocheck _picky)
+    set(_picky_tmp "")
+    foreach(_ccopt IN LISTS "${_wlist}")
+      # Prefix -Wall, otherwise clang-cl interprets it as an MSVC option and translates it to -Weverything
+      if(_ccopt MATCHES "^-W" AND NOT _ccopt STREQUAL "-Wall")
+        list(APPEND _picky_tmp ${_ccopt})
+      else()
+        list(APPEND _picky_tmp "-clang:${_ccopt}")
+      endif()
+    endforeach()
+    set("${_wlist}" ${_picky_tmp})
   endforeach()
-  set(_picky ${_picky_tmp})
 endif()
 
 if(_picky_nocheck OR _picky)
   set(_picky_tmp "${picky_nocheck}" "${_picky}")
   string(REPLACE ";" " " _picky_tmp "${_picky_tmp}")
+  string(STRIP "${_picky_tmp}" _picky_tmp)
   message(STATUS "Picky compiler options: ${_picky_tmp}")
   set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "${_picky_nocheck}" "${_picky}")
 

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -51,6 +51,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
 endif()
 
 if(MSVC)
+  # Use the highest warning level for Visual Studio.
   string(REGEX REPLACE "[/-]W[0-4]" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
   list(APPEND _picky "-W4")
 elseif(BORLAND)

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -25,12 +25,19 @@ include(CheckCCompilerFlag)
 
 set(_picky "")
 
-if(CURL_WERROR AND
-   ((CMAKE_C_COMPILER_ID STREQUAL "GNU" AND
-     NOT DOS AND  # Watt-32 headers use the '#include_next' GCC extension
-     CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0) OR
-   CMAKE_C_COMPILER_ID MATCHES "Clang"))
-  list(APPEND _picky "-pedantic-errors")
+if(CURL_WERROR)
+  if(MSVC)
+    set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-WX")
+  else()  # llvm/clang and gcc style options
+    set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Werror")
+  endif()
+
+  if((CMAKE_C_COMPILER_ID STREQUAL "GNU" AND
+      NOT DOS AND  # Watt-32 headers use the '#include_next' GCC extension
+      CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0) OR
+     CMAKE_C_COMPILER_ID MATCHES "Clang")
+    list(APPEND _picky "-pedantic-errors")
+  endif()
 endif()
 
 if(APPLE AND

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -24,19 +24,20 @@
 include(CheckCCompilerFlag)
 
 set(_picky "")
+set(_picky_nocheck "")  # not to pass to feature checks
 
 if(CURL_WERROR)
   if(MSVC)
-    set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-WX")
+    list(APPEND _picky_nocheck "-WX")
   else()  # llvm/clang and gcc style options
-    set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Werror")
+    list(APPEND _picky_nocheck "-Werror")
   endif()
 
   if((CMAKE_C_COMPILER_ID STREQUAL "GNU" AND
       NOT DOS AND  # Watt-32 headers use the '#include_next' GCC extension
       CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 5.0) OR
      CMAKE_C_COMPILER_ID MATCHES "Clang")
-    list(APPEND _picky "-pedantic-errors")
+    list(APPEND _picky_nocheck "-pedantic-errors")
   endif()
 endif()
 
@@ -298,13 +299,13 @@ if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND MSVC)
   set(_picky ${_picky_tmp})
 endif()
 
-if(_picky)
-  string(REPLACE ";" " " _picky_tmp "${_picky}")
+if(_picky_nocheck OR _picky)
+  set(_picky_tmp "${picky_nocheck}" "${_picky}")
+  string(REPLACE ";" " " _picky_tmp "${_picky_tmp}")
   message(STATUS "Picky compiler options: ${_picky_tmp}")
-  set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "${_picky}")
+  set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "${_picky_nocheck}" "${_picky}")
 
   # Apply to all feature checks
-  list(REMOVE_ITEM _picky "-pedantic-errors")  # Must not pass to feature checks
   string(REPLACE ";" " " _picky_tmp "${_picky}")
   string(APPEND CMAKE_REQUIRED_FLAGS " ${_picky_tmp}")
 

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -302,7 +302,7 @@ if(CMAKE_C_COMPILER_ID STREQUAL "Clang" AND MSVC)
 endif()
 
 if(_picky_nocheck OR _picky)
-  set(_picky_tmp "${picky_nocheck}" "${_picky}")
+  set(_picky_tmp "${_picky_nocheck}" "${_picky}")
   string(REPLACE ";" " " _picky_tmp "${_picky_tmp}")
   string(STRIP "${_picky_tmp}" _picky_tmp)
   message(STATUS "Picky compiler options: ${_picky_tmp}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2009,14 +2009,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "MSVC")  # MSVC but exclude clang-cl
   set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-MP")  # Parallel compilation
 endif()
 
-if(CURL_WERROR)
-  if(MSVC)
-    set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-WX")
-  else()
-    set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-Werror")  # This assumes clang or gcc style options
-  endif()
-endif()
-
 if(CURL_LTO)
   if(CMAKE_VERSION VERSION_LESS 3.9)
     message(FATAL_ERROR "LTO has been requested, but your cmake version ${CMAKE_VERSION} is to old. You need at least 3.9")


### PR DESCRIPTION
Safe to do this now, as the code no longer relies on setting these
options after feature detection.

Also: Tidy up the way we handle options not to be passed to feature
checks, and make sure to show them in the configure log.

Follow-up to e86542038dda88dadf8959584e803895f979310c #17047
