### PR TITLE
GHA/windows: bump a job to windows-2025

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -172,7 +172,7 @@ jobs:
 
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
-    runs-on: windows-latest
+    runs-on: ${{ matrix.image || 'windows-latest' }}
     timeout-minutes: 20
     defaults:
       run:
@@ -200,7 +200,7 @@ jobs:
           - { build: 'cmake'    , sys: 'clang64', env: 'clang-x86_64', tflags: 'skiprun', config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=OFF -DCURL_USE_OPENSSL=ON  -DENABLE_UNICODE=OFF', install: 'mingw-w64-clang-x86_64-openssl mingw-w64-clang-x86_64-libssh2', type: 'Release', name: 'openssl', chkprefill: '_chkprefill' }
           - { build: 'cmake'    , sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun', config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON', install: 'mingw-w64-ucrt-x86_64-libssh2', type: 'Release', test: 'uwp', name: 'schannel' }
           # { build: 'autotools', sys: 'ucrt64' , env: 'ucrt-x86_64' , tflags: 'skiprun', config: '--without-debug --with-schannel --enable-shared', install: 'mingw-w64-ucrt-x86_64-libssh2', type: 'Release', test: 'uwp', name: 'schannel' }
-          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun', config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCMAKE_VERBOSE_MAKEFILE=ON', install: 'mingw-w64-x86_64-libssh2', type: 'Debug', cflags: '-DCURL_SCHANNEL_DEV_DEBUG', name: 'schannel dev debug' }
+          - { build: 'cmake'    , sys: 'mingw64', env: 'x86_64'      , tflags: 'skiprun', config: '-DENABLE_DEBUG=ON  -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCMAKE_VERBOSE_MAKEFILE=ON', install: 'mingw-w64-x86_64-libssh2', type: 'Debug', cflags: '-DCURL_SCHANNEL_DEV_DEBUG', name: 'schannel dev debug', image: 'windows-2025' }
           - { build: 'cmake'    , sys: 'mingw32', env: 'i686'        , tflags: 'skiprun', config: '-DENABLE_DEBUG=OFF -DBUILD_SHARED_LIBS=ON  -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON', install: 'mingw-w64-i686-libssh2', type: 'Release', name: 'schannel R' }
       fail-fast: false
     steps:
@@ -795,7 +795,6 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
-            image: 'windows-2025'
             openssh: 'OpenSSH-Windows'
             config: >-
               -DENABLE_DEBUG=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -744,7 +744,7 @@ jobs:
 
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
-    runs-on: windows-latest
+    runs-on: ${{ matrix.image || 'windows-latest' }}
     timeout-minutes: 55
     defaults:
       run:
@@ -795,6 +795,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
+            image: 'windows-2025'
             openssh: 'OpenSSH-Windows'
             config: >-
               -DENABLE_DEBUG=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -796,7 +796,7 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             image: 'windows-2025'
-            openssh: 'OpenSSH-Windows'
+            openssh: 'OpenSSH-Windows-builtin'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_LIBSSH2=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -796,7 +796,7 @@ jobs:
             plat: 'windows'
             type: 'Debug'
             image: 'windows-2025'
-            openssh: 'OpenSSH-Windows-builtin'
+            openssh: 'OpenSSH-Windows'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_LIBSSH2=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -937,8 +937,10 @@ jobs:
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           elif [ '${{ matrix.openssh }}' = 'OpenSSH-Windows-builtin' ]; then
             # https://learn.microsoft.com/windows-server/administration/openssh/openssh_install_firstuse
-            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0'
-            pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0'
+            if [ '${{ matrix.image }}' != 'windows-2025' ]; then
+              pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0'
+              pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0'
+            fi
           else  # OpenSSH-Windows
             cd /d || exit 1
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -261,7 +261,7 @@ if(!$sshdid) {
     logmsg "SCP and SFTP tests require OpenSSH 2.9.9 or later\n";
     exit 1;
 }
-logmsg "ssh server found $sshd is $sshdverstr\n" if($verbose);
+print "ssh server found $sshd is $sshdverstr\n";
 
 
 #***************************************************************************
@@ -345,7 +345,7 @@ if(!$sshid) {
     logmsg "SCP and SFTP tests require OpenSSH 2.9.9 or later\n";
     exit 1;
 }
-logmsg "ssh client found $ssh is $sshverstr\n" if($verbose);
+print "ssh client found $ssh is $sshverstr\n";
 
 
 #***************************************************************************

--- a/tests/sshserver.pl
+++ b/tests/sshserver.pl
@@ -261,7 +261,7 @@ if(!$sshdid) {
     logmsg "SCP and SFTP tests require OpenSSH 2.9.9 or later\n";
     exit 1;
 }
-print "ssh server found $sshd is $sshdverstr\n";
+logmsg "ssh server found $sshd is $sshdverstr\n" if($verbose);
 
 
 #***************************************************************************
@@ -345,7 +345,7 @@ if(!$sshid) {
     logmsg "SCP and SFTP tests require OpenSSH 2.9.9 or later\n";
     exit 1;
 }
-print "ssh client found $ssh is $sshverstr\n";
+logmsg "ssh client found $ssh is $sshverstr\n" if($verbose);
 
 
 #***************************************************************************


### PR DESCRIPTION
- bump an MSYS2/mingw job to windows-2025 runner.
  (MSVC is possible, but vcpkg needs to build for windows-2025, and
  can't share these with windows-2022 builds, so not optimal for
  a single canary job.)
- skip installing OpenSSH-Windows-builtin on windows-2025.
  It's preinstalled:
  ```
  ssh client found /c/Windows/System32/OpenSSH/ssh.exe is OpenSSH-Windows 9.5.0
  ssh server found /c/Windows/System32/OpenSSH/sshd.exe is OpenSSH-Windows 9.5.0
  ```
  Still older than the manual preview install (9.8.1), so keep using that.

---

w/o ws https://github.com/curl/curl/pull/17066/files?w=1
