### PR TITLE
cmake: do not install `mk-ca-bundle` script and manpage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2494,13 +2494,6 @@ if(NOT CURL_DISABLE_INSTALL)
       COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/CMake/cmake_uninstall.cmake")
   endif()
 
-  install(FILES "${PROJECT_SOURCE_DIR}/scripts/mk-ca-bundle.pl"
-    DESTINATION ${CMAKE_INSTALL_BINDIR}
-    PERMISSIONS
-      OWNER_READ OWNER_WRITE OWNER_EXECUTE
-      GROUP_READ GROUP_EXECUTE
-      WORLD_READ WORLD_EXECUTE)
-
   # The `-DEV` part is important
   string(REGEX REPLACE "([0-9]+\.[0-9]+)\.([0-9]+.*)" "\\2" CPACK_PACKAGE_VERSION_PATCH "${_curl_version}")
   set(CPACK_GENERATOR "TGZ")

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -39,7 +39,7 @@ if(BUILD_MISC_DOCS)
       VERBATIM
     )
     add_custom_target("curl-generate-${_man_misc}.1" ALL DEPENDS "${_man_target}")
-    if(NOT CURL_DISABLE_INSTALL)
+    if(NOT CURL_DISABLE_INSTALL AND NOT _man_misc STREQUAL "mk-ca-bundle")
       install(FILES "${_man_target}" DESTINATION "${CMAKE_INSTALL_MANDIR}/man1")
     endif()
   endforeach()


### PR DESCRIPTION
To sync with autotools builds.

Reported-by: Daniel Stenberg
Bug: https://github.com/curl/curl/pull/17035#pullrequestreview-2769964979
Follow-up to 5023ffad2c27d4b916ddb91800f99ecc5d3aad07 #13197
