### PR TITLE
doh: reduce the DNS request buffer size

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -115,7 +115,7 @@ UNITTEST DOHcode doh_req_encode(const char *host,
   if(host[hostlen-1]!='.')
     expected_len++;
 
-  if(expected_len > (256 + 16)) /* RFCs 1034, 1035 */
+  if(expected_len > DOH_MAX_DNSREQ_SIZE)
     return DOH_DNS_NAME_TOO_LONG;
 
   if(len < expected_len)

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -59,15 +59,6 @@ typedef enum {
   DNS_TYPE_HTTPS = 65
 } DNStype;
 
-/* one of these for each DoH request */
-struct doh_probe {
-  unsigned int easy_mid; /* multi id of easy handle doing the lookup */
-  DNStype dnstype;
-  unsigned char req_body[512];
-  size_t req_body_len;
-  struct dynbuf resp_body;
-};
-
 enum doh_slot_num {
   /* Explicit values for first two symbols so as to match hard-coded
    * constants in existing code
@@ -91,13 +82,16 @@ enum doh_slot_num {
 
 #define CURL_EZM_DOH_PROBE   "ezm:doh-p"
 
+/* the largest one we can make, based on RFCs 1034, 1035 */
+#define DOH_MAX_DNSREQ_SIZE (256 + 16)
+
 /* each DoH probe request has this
  * as easy meta for CURL_EZM_DOH_PROBE */
 struct doh_request {
+  unsigned char req_body[DOH_MAX_DNSREQ_SIZE];
   struct curl_slist *req_hds;
   struct dynbuf resp_body;
   size_t req_body_len;
-  unsigned char req_body[512];
   DNStype dnstype;
 };
 


### PR DESCRIPTION
No point in having it larger than the largest allowed request size.

Also removed a no longer used struct.