### PR TITLE
GHA/windows: add 2 basic MSVC jobs to restore some CI coverage

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -756,11 +756,36 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: 'zlib libssh2'
+          - name: 'zlib libssh2 +examples'
+            install: 'zlib libssh2[core,zlib]'
+            arch: 'x64'
+            plat: 'uwp'
+            type: 'Debug'
+            tflags: 'skiprun'
+            config: >-
+              -DENABLE_DEBUG=ON
+              -DCURL_USE_SCHANNEL=ON
+              -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
+              -DCURL_USE_LIBPSL=OFF
+
+          - name: 'zlib libssh2 +examples'
             install: 'zlib libssh2[core,zlib]'
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
+            config: >-
+              -DENABLE_DEBUG=ON
+              -DCURL_USE_SCHANNEL=ON
+              -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
+              -DCURL_USE_LIBPSL=OFF
+
+          - name: 'zlib libssh2 +examples'
+            install: 'zlib libssh2[core,zlib]'
+            arch: 'arm64'
+            plat: 'windows'
+            type: 'Debug'
+            image: 'windows-11-arm'
+            openssh: 'OpenSSH-Windows'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_SCHANNEL=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -986,7 +986,9 @@ jobs:
             rm -f bin.zip
           fi
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
-          python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
+          if [ '${{ matrix.image }}' != 'windows-11-arm' ]; then  # save a minute by skipping this, and the single SMB test that needs it
+            python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
+          fi
 
       - name: 'downgrade msys2-runtime'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -977,7 +977,11 @@ jobs:
               pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0'
             fi
           else  # OpenSSH-Windows
-            cd /d || exit 1
+            if [[ '${{ matrix.image }}' = 'windows-11-arm' ]]; then
+              cd /c || exit 1  # There is no D: drive on this runner
+            else
+              cd /d || exit 1
+            fi
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
               --location 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/${{ env.openssh_windows-version }}/OpenSSH-Win64.zip' --output bin.zip
             unzip bin.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -978,11 +978,7 @@ jobs:
               pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0'
             fi
           else  # OpenSSH-Windows
-            if [[ '${{ matrix.image }}' = 'windows-11-arm' ]]; then
-              cd /c || exit 1  # There is no D: drive on this runner
-            else
-              cd /d || exit 1
-            fi
+            cd /c || exit 1  # There is no D: drive on windows-11-arm runners
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
               --location 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/${{ env.openssh_windows-version }}/OpenSSH-Win64.zip' --output bin.zip
             unzip bin.zip
@@ -1015,7 +1011,7 @@ jobs:
             else
               TFLAGS+=' ~3022'  # 'SCP correct sha256 host key' SCP, server sha256 key check
             fi
-            PATH="/d/OpenSSH-Win64:$PATH"
+            PATH="/c/OpenSSH-Win64:$PATH"
           fi
           PATH="$PWD/bld/lib/${{ matrix.type }}:$PATH:/c/Program Files (x86)/stunnel/bin"
           cmake --build bld --config '${{ matrix.type }}' --target test-ci

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -773,6 +773,7 @@ jobs:
             arch: 'x64'
             plat: 'windows'
             type: 'Debug'
+            chkprefill: '_chkprefill'
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_SCHANNEL=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -756,7 +756,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: 'zlib libssh2 +examples'
+          - name: '!ssl +examples'
             install: 'zlib libssh2[core,zlib]'
             arch: 'x64'
             plat: 'uwp'
@@ -769,7 +769,7 @@ jobs:
               -DUSE_WIN32_IDN=ON
               -DCURL_USE_LIBPSL=OFF
 
-          - name: 'zlib libssh2 +examples'
+          - name: 'schannel +examples'
             install: 'zlib libssh2[core,zlib]'
             arch: 'x64'
             plat: 'windows'
@@ -781,7 +781,7 @@ jobs:
               -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_USE_LIBPSL=OFF
 
-          - name: 'zlib libssh2'
+          - name: 'schannel'
             install: 'zlib libssh2[core,zlib]'
             arch: 'arm64'
             plat: 'windows'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -764,7 +764,7 @@ jobs:
             tflags: 'skiprun'
             config: >-
               -DENABLE_DEBUG=ON
-              -DCURL_USE_SCHANNEL=ON
+              -DCURL_ENABLE_SSL=OFF
               -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_USE_LIBPSL=OFF
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -923,6 +923,7 @@ jobs:
               -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
               -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLATION_ROOT/installed" \
               -DVCPKG_TARGET_TRIPLET='${{ matrix.arch }}-${{ matrix.plat }}' \
+              -DCMAKE_C_COMPILER_TARGET='${{ matrix.arch }}-${{ matrix.plat }}' \
               -DCMAKE_C_FLAGS="${cflags}" \
               -DCMAKE_EXE_LINKER_FLAGS="-INCREMENTAL:NO ${ldflags}" \
               -DCMAKE_SHARED_LINKER_FLAGS="-INCREMENTAL:NO ${ldflags}" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -781,7 +781,7 @@ jobs:
               -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_USE_LIBPSL=OFF
 
-          - name: 'schannel'
+          - name: 'schannel U'
             install: 'zlib libssh2[core,zlib]'
             arch: 'arm64'
             plat: 'windows'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -761,6 +761,7 @@ jobs:
             arch: 'x64'
             plat: 'uwp'
             type: 'Debug'
+            image: 'windows-2025'
             tflags: 'skiprun'
             config: >-
               -DENABLE_DEBUG=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -923,7 +923,6 @@ jobs:
               -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
               -DVCPKG_INSTALLED_DIR="$VCPKG_INSTALLATION_ROOT/installed" \
               -DVCPKG_TARGET_TRIPLET='${{ matrix.arch }}-${{ matrix.plat }}' \
-              -DCMAKE_C_COMPILER_TARGET='${{ matrix.arch }}-${{ matrix.plat }}' \
               -DCMAKE_C_FLAGS="${cflags}" \
               -DCMAKE_EXE_LINKER_FLAGS="-INCREMENTAL:NO ${ldflags}" \
               -DCMAKE_SHARED_LINKER_FLAGS="-INCREMENTAL:NO ${ldflags}" \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -780,7 +780,7 @@ jobs:
               -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_USE_LIBPSL=OFF
 
-          - name: 'zlib libssh2 +examples'
+          - name: 'zlib libssh2'
             install: 'zlib libssh2[core,zlib]'
             arch: 'arm64'
             plat: 'windows'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -986,7 +986,7 @@ jobs:
             rm -f bin.zip
           fi
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
-          if [ '${{ matrix.image }}' != 'windows-11-arm' ]; then  # save a minute by skipping this, and the single SMB test that needs it
+          if [ '${{ matrix.image }}' != 'windows-11-arm' ]; then  # save 30-60 seconds, to counteract the slower test run step
             python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
           fi
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -765,7 +765,7 @@ jobs:
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_ENABLE_SSL=OFF
-              -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
+              -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON
               -DCURL_USE_LIBPSL=OFF
 
           - name: 'zlib libssh2 +examples'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -765,7 +765,7 @@ jobs:
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_ENABLE_SSL=OFF
-              -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON
+              -DUSE_WIN32_IDN=ON
               -DCURL_USE_LIBPSL=OFF
 
           - name: 'zlib libssh2 +examples'
@@ -777,7 +777,7 @@ jobs:
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_SCHANNEL=ON
-              -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
+              -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_USE_LIBPSL=OFF
 
           - name: 'zlib libssh2'
@@ -790,7 +790,7 @@ jobs:
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_SCHANNEL=ON
-              -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
+              -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_USE_LIBPSL=OFF
 
           #- name: 'openssl +examples'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -778,7 +778,7 @@ jobs:
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_SCHANNEL=ON
-              -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
+              -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_USE_LIBPSL=OFF
 
           - name: 'schannel'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -979,7 +979,7 @@ jobs:
               pwsh -Command 'Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0'
             fi
           else  # OpenSSH-Windows
-            cd /c || exit 1  # There is no D: drive on windows-11-arm runners
+            cd /c || exit 1  # no D: drive on windows-11-arm runners
             curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
               --location 'https://github.com/PowerShell/Win32-OpenSSH/releases/download/${{ env.openssh_windows-version }}/OpenSSH-Win64.zip' --output bin.zip
             unzip bin.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -765,7 +765,7 @@ jobs:
             config: >-
               -DENABLE_DEBUG=ON
               -DCURL_USE_SCHANNEL=ON
-              -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON -DENABLE_UNICODE=ON -DUSE_SSLS_EXPORT=ON
+              -DCURL_CA_SEARCH_SAFE=ON -DUSE_WIN32_IDN=ON -DUSE_SSLS_EXPORT=ON
               -DCURL_USE_LIBPSL=OFF
 
           - name: 'zlib libssh2 +examples'


### PR DESCRIPTION
To keep testing these with MSVC:
- UWP !ssl
- arm64 build on the `windows-11-arm` runner
- examples
- OpenSSH-Windows (fix install on `windows-11-arm`)
- `windows-2025` runner
- cmake pre-fill checker

Surprise: UWP doesn't support SSPI, which is required by curl's Schannel
backend. Thus, no TLS support for this UWP build. It also suggests
the Schannel UWP mingw-w64 binaries may be broken and just a happy build
accident thanks to mingw-w64 headers being inaccurate.

Building zlib + libssh2 might actually take up to 2+ minutes with vcpkg,
instead of the previously estimated <1.5 minutes.

Follow-up to e3912f0f9fac06d37cd1ab93cef4f01f33809f0b #17086
Follow-up to 15fb1dc7f86ad1832e0386ec7d92542f44ee9c44 #17069
