### PR TITLE
runtests: add retry option to reduce flakiness

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,7 +103,7 @@ curl_add_runtests(test-am        "-a -am")
 curl_add_runtests(test-full      "-a -p -r")
 # ~flaky means that it ignores results of tests using the flaky keyword
 curl_add_runtests(test-nonflaky  "-a -p ~flaky ~timing-dependent")
-curl_add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r -j20")
+curl_add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r --retry=5 -j20")
 curl_add_runtests(test-torture   "-a -t -j20")
 curl_add_runtests(test-event     "-a -e")
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -142,7 +142,7 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r -j20
+TEST_CI = $(TEST_NF) -r --retry=5 -j20
 
 PYTEST = pytest
 endif

--- a/tests/runtests.md
+++ b/tests/runtests.md
@@ -228,6 +228,10 @@ sequence at the end of the initially given one.
 If **-R** option is also used, the scrambling is done after the repeats have
 extended the test sequence.
 
+## `--retry=[num]`
+
+Number of attempts for the whole test run to retry failed tests.
+
 ## `-s`
 
 Shorter output. Speaks less than default.


### PR DESCRIPTION
Add `--retry=<num>` option to tell runtests to retry the first `<num>`
tests that failed. Retries aren't run right away, but added to the end
of the test queue. Once all retry slots are used, test fail as normal.

In CI, typically a single test fails for flakiness, and rarely over 5.

Make the `ci-test` targets default to `--retry=5`.
