### PR TITLE
cf-https-connect: use the passed in dns struct pointer

### DIFF
--- a/lib/cf-https-connect.c
+++ b/lib/cf-https-connect.c
@@ -664,22 +664,22 @@ CURLcode Curl_cf_https_setup(struct Curl_easy *data,
 
   if(conn->bits.tls_enable_alpn) {
 #ifdef USE_HTTPSRR
-    /* Is there a HTTPSRR and if so, do its ALPNs it apply here?
+    /* Is there a HTTPSRR use its ALPNs here.
      * We are here after having selected a connection to a host+port and
      * can no longer change that. Any HTTPSRR advice for other hosts and ports
      * we need to ignore. */
-    if(conn->dns_entry && conn->dns_entry->hinfo &&
-       !conn->dns_entry->hinfo->no_def_alpn &&  /* ALPNs are defaults */
-       (!conn->dns_entry->hinfo->target ||      /* for same host */
-        !conn->dns_entry->hinfo->target[0] ||
-        (conn->dns_entry->hinfo->target[0] == '.' &&
-         !conn->dns_entry->hinfo->target[1])) &&
-       (conn->dns_entry->hinfo->port < 0 ||    /* for same port */
-        conn->dns_entry->hinfo->port == conn->remote_port)) {
+    struct Curl_https_rrinfo *rr = remotehost ? remotehost->hinfo : NULL;
+    if(rr && !rr->no_def_alpn &&  /* ALPNs are defaults */
+       (!rr->target ||      /* for same host */
+        !rr->target[0] ||
+        (rr->target[0] == '.' &&
+         !rr->target[1])) &&
+       (rr->port < 0 ||    /* for same port */
+        rr->port == conn->remote_port)) {
       size_t i;
-      for(i = 0; i < CURL_ARRAYSIZE(conn->dns_entry->hinfo->alpns) &&
+      for(i = 0; i < CURL_ARRAYSIZE(rr->alpns) &&
                  alpn_count < CURL_ARRAYSIZE(alpn_ids); ++i) {
-        enum alpnid alpn = conn->dns_entry->hinfo->alpns[i];
+        enum alpnid alpn = rr->alpns[i];
         if(cf_https_alpns_contain(alpn, alpn_ids, alpn_count))
           continue;
         switch(alpn) {


### PR DESCRIPTION
... instead of digging it out from the connection struct.

Plus: simplify struct referencing in the condition.