### PR TITLE
httpsrr fix

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -1295,7 +1295,7 @@ CURLcode Curl_doh_is_resolved(struct Curl_easy *data,
       if(dns) {
         /* Now add and HTTPSRR information if we have */
 #ifdef USE_HTTPSRR
-        if(de.numhttps_rrs > 0 && result == CURLE_OK && *dnsp) {
+        if(de.numhttps_rrs > 0 && result == CURLE_OK) {
           struct Curl_https_rrinfo *hrr = NULL;
           result = doh_resp_decode_httpsrr(data, de.https_rrs->val,
                                            de.https_rrs->len, &hrr);

--- a/tests/ech_tests.sh
+++ b/tests/ech_tests.sh
@@ -66,7 +66,7 @@ declare -A ech_targets=(
     [draft-13.esni.defo.ie:11413]=""
     [draft-13.esni.defo.ie:12413]=""
     [draft-13.esni.defo.ie:12414]=""
-    [crypto.cloudflare.com]="cdn-cgi/trace"
+    [cloudflare-ech.com]="cdn-cgi/trace"
     [tls-ech.dev]=""
     # this one's gone away for now (possibly temporarily)
     # [epochbelt.com]=""
@@ -361,7 +361,7 @@ do
     then
         case $targ in
             "draft-13.esni.defo.ie:8414" | "tls-ech.dev" | \
-            "crypto.cloudflare.com" | "epochbelt.com")
+            "cloudflare-ech.com" | "epochbelt.com")
                 echo "Skipping $targ 'cause wolf"; continue;;
             *)
                 ;;
@@ -413,7 +413,7 @@ then
             echo "Skipping $targ as ports != 443 seem blocked"
             continue
         fi
-        if [[ "$host" == "crypto.cloudflare.com" ]]
+        if [[ "$host" == "cloudflare-ech.com" ]]
         then
             echo "Skipping $host as they've blocked PN override"
             continue


### PR DESCRIPTION
Small fix to HTTPS RR handling that seems to get ECH working again.

There are also some changes in `tests/ech_test.sh` to reflect ECH-enabled server deployment changes since last time.

With this fix, `./tests/ech_tests.sh` works here and valgrind reports no issues when doing ECH.