### PR TITLE
Clarify that CURLOPT_ERRORBUFFER buffer is read only after curl gains ownership of it

### DIFF
--- a/docs/libcurl/opts/CURLOPT_ERRORBUFFER.md
+++ b/docs/libcurl/opts/CURLOPT_ERRORBUFFER.md
@@ -45,6 +45,10 @@ Since 7.60.0 libcurl initializes the contents of the error buffer to an empty
 string before performing the transfer. For earlier versions if an error code
 was returned but there was no error detail then the buffer was untouched.
 
+Do not attempt to set the contents of the buffer yourself, including in any
+callbacks you write that may be called by libcurl. The library may overwrite
+the buffer after your callback returns.
+
 Consider CURLOPT_VERBOSE(3) and CURLOPT_DEBUGFUNCTION(3) to better debug and
 trace why errors happen.
 


### PR DESCRIPTION
Here is a documentation patch clarifying libcurl's guarantees with regards to the `CURLOPT_ERRORBUFFER` buffer. See #17100.

Tested `make -C docs`.
![image](https://github.com/user-attachments/assets/878276fc-29a4-4b8b-9c02-625bac8a6687)
