### PR TITLE
openssl-quic: avoid potential `-Wnull-dereference`, add assert

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1567,6 +1567,7 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
           idx_count++) {
         if(ctx->poll_items[idx_count].revents & SSL_POLL_EVENT_W) {
           stream = H3_STREAM_CTX(ctx, ctx->curl_items[idx_count]);
+          DEBUGASSERT(stream);
           if(stream) {
             nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
             stream->s.send_blocked = FALSE;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1567,10 +1567,12 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
           idx_count++) {
         if(ctx->poll_items[idx_count].revents & SSL_POLL_EVENT_W) {
           stream = H3_STREAM_CTX(ctx, ctx->curl_items[idx_count]);
-          nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
-          stream->s.send_blocked = FALSE;
-          h3_drain_stream(cf, ctx->curl_items[idx_count]);
-          CURL_TRC_CF(ctx->curl_items[idx_count], cf, "unblocked");
+          if(stream) {
+            nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
+            stream->s.send_blocked = FALSE;
+            h3_drain_stream(cf, ctx->curl_items[idx_count]);
+            CURL_TRC_CF(ctx->curl_items[idx_count], cf, "unblocked");
+          }
           result_count--;
         }
       }

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1567,7 +1567,7 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
           idx_count++) {
         if(ctx->poll_items[idx_count].revents & SSL_POLL_EVENT_W) {
           stream = H3_STREAM_CTX(ctx, ctx->curl_items[idx_count]);
-          DEBUGASSERT(stream);
+          DEBUGASSERT(stream);  /* should still exist */
           if(stream) {
             nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
             stream->s.send_blocked = FALSE;


### PR DESCRIPTION
Seen with curl-for-win, OpenSSL QUIC, gcc 14.2.0, cmake unity mode.

Silences:
```
In file included from _x86-win-ucrt-bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_5_c.c:55:
In function 'cf_osslq_check_and_unblock',
    inlined from 'cf_progress_egress' at lib/vquic/curl_osslq.c:1730:12:
lib/vquic/curl_osslq.c:1581:11: error: potential null pointer dereference [-Werror=null-dereference]
 1581 |           nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lib/vquic/curl_osslq.c:1582:34: error: potential null pointer dereference [-Werror=null-dereference]
 1582 |           stream->s.send_blocked = FALSE;
      |                                  ^
```