### PR TITLE
vquic: consistent name for the stream struct across backends

### DIFF
--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -42,6 +42,7 @@
 #include "../socketpair.h"
 #include "../vtls/vtls.h"
 #include "vquic.h"
+#include "vquic_int.h"
 
 /* The last 3 #include files should be in this order */
 #include "../curl_printf.h"

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -253,9 +253,6 @@ struct h3_stream_ctx {
   BIT(quic_flow_blocked); /* stream is blocked by QUIC flow control */
 };
 
-#define H3_STREAM_CTX(ctx,data)   ((struct h3_stream_ctx *)(\
-            data? Curl_uint_hash_get(&(ctx)->streams, (data)->mid) : NULL))
-
 static void h3_stream_ctx_free(struct h3_stream_ctx *stream)
 {
   Curl_bufq_free(&stream->sendbuf);

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -590,9 +590,6 @@ struct h3_stream_ctx {
   BIT(quic_flow_blocked); /* stream is blocked by QUIC flow control */
 };
 
-#define H3_STREAM_CTX(ctx,data)   ((struct h3_stream_ctx *)(\
-            data? Curl_uint_hash_get(&(ctx)->streams, (data)->mid) : NULL))
-
 static void h3_stream_ctx_free(struct h3_stream_ctx *stream)
 {
   cf_osslq_stream_cleanup(&stream->s);

--- a/lib/vquic/vquic_int.h
+++ b/lib/vquic/vquic_int.h
@@ -51,6 +51,9 @@ struct cf_quic_ctx {
   BIT(no_gso); /* do not use gso on sending */
 };
 
+#define H3_STREAM_CTX(ctx,data)                                         \
+  (data ? Curl_uint_hash_get(&(ctx)->streams, (data)->mid) : NULL)
+
 CURLcode vquic_ctx_init(struct cf_quic_ctx *qctx);
 void vquic_ctx_free(struct cf_quic_ctx *qctx);
 


### PR DESCRIPTION
Now known as `struct h3_stream_ctx` in all four backends.

Also as a bonus: a single definition of the H3_STREAM_CTX macro