### PR TITLE
lib: use BIT() instead of bool in structs more

### DIFF
--- a/lib/altsvc.h
+++ b/lib/altsvc.h
@@ -39,9 +39,9 @@ struct altsvc {
   struct althost src;
   struct althost dst;
   time_t expires;
-  bool persist;
-  unsigned int prio;
   struct Curl_llist_node node;
+  unsigned int prio;
+  BIT(persist);
 };
 
 struct altsvcinfo {

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -43,10 +43,10 @@ struct FormInfo {
   char *userp;        /* pointer for the read callback */
   struct curl_slist *contentheader;
   struct FormInfo *more;
-  bool name_alloc;
-  bool value_alloc;
-  bool contenttype_alloc;
-  bool showfilename_alloc;
+  BIT(name_alloc);
+  BIT(value_alloc);
+  BIT(contenttype_alloc);
+  BIT(showfilename_alloc);
 };
 
 CURLcode Curl_getformdata(CURL *data,

--- a/lib/hsts.h
+++ b/lib/hsts.h
@@ -36,8 +36,8 @@ extern time_t deltatime;
 struct stsentry {
   struct Curl_llist_node node;
   const char *host;
-  bool includeSubDomains;
   curl_off_t expires; /* the timestamp of this entry's expiry */
+  BIT(includeSubDomains);
 };
 
 /* The HSTS cache. Needs to be able to tailmatch hostnames. */

--- a/lib/http1.h
+++ b/lib/http1.h
@@ -42,7 +42,7 @@ struct h1_req_parser {
   const char *line;
   size_t max_line_len;
   size_t line_len;
-  bool done;
+  BIT(done);
 };
 
 void Curl_h1_req_parse_init(struct h1_req_parser *parser, size_t max_line_len);

--- a/lib/httpsrr.h
+++ b/lib/httpsrr.h
@@ -53,7 +53,7 @@ struct Curl_https_rrinfo {
   /* store parsed alpnid entries in the array, end with ALPN_none */
   int port; /* -1 means not set */
   uint16_t priority;
-  bool no_def_alpn; /* keytag = 2 */
+  BIT(no_def_alpn); /* keytag = 2 */
 };
 
 CURLcode Curl_httpsrr_set(struct Curl_easy *data,

--- a/lib/mqtt.h
+++ b/lib/mqtt.h
@@ -56,8 +56,8 @@ struct MQTT {
   size_t remaining_length;
   unsigned char pkt_hd[4]; /* for decoding the arriving packet length */
   struct curltime lastTime; /* last time we sent or received data */
-  bool pingsent; /* 1 while we wait for ping response */
   unsigned char firstbyte;
+  BIT(pingsent); /* 1 while we wait for ping response */
 };
 
 #endif /* HEADER_CURL_MQTT_H */

--- a/lib/pingpong.h
+++ b/lib/pingpong.h
@@ -48,9 +48,6 @@ typedef enum {
  */
 struct pingpong {
   size_t nread_resp;  /* number of bytes currently read of a server response */
-  bool pending_resp;  /* set TRUE when a server response is pending or in
-                         progress, and is cleared once the last response is
-                         read */
   char *sendthis; /* pointer to a buffer that is to be sent to the server */
   size_t sendleft; /* number of bytes left to send from the sendthis buffer */
   size_t sendsize; /* total size of the sendthis buffer */
@@ -71,6 +68,9 @@ struct pingpong {
   bool (*endofresp)(struct Curl_easy *data, struct connectdata *conn,
                     const char *ptr, size_t len, int *code);
   BIT(initialised);
+  BIT(pending_resp);  /* set TRUE when a server response is pending or in
+                         progress, and is cleared once the last response is
+                         read */
 };
 
 #define PINGPONG_SETUP(pp,s,e)                   \

--- a/lib/psl.h
+++ b/lib/psl.h
@@ -34,7 +34,7 @@ struct Curl_easy;
 struct PslCache {
   const psl_ctx_t *psl; /* The PSL. */
   time_t expires; /* Time this PSL life expires. */
-  bool dynamic; /* PSL should be released when no longer needed. */
+  BIT(dynamic); /* PSL should be released when no longer needed. */
 };
 
 const psl_ctx_t *Curl_psl_use(struct Curl_easy *easy);

--- a/lib/sigpipe.h
+++ b/lib/sigpipe.h
@@ -31,7 +31,7 @@
 
 struct sigpipe_ignore {
   struct sigaction old_pipe_act;
-  bool no_signal;
+  BIT(no_signal);
 };
 
 #define SIGPIPE_VARIABLE(x) struct sigpipe_ignore x

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -122,9 +122,9 @@ struct cf_msh3_ctx {
   struct curltime handshake_at;      /* time connect handshake finished */
   struct uint_hash streams;          /* hash `data->mid` to `stream_ctx` */
   /* Flags written by msh3/msquic thread */
-  bool handshake_complete;
-  bool handshake_succeeded;
-  bool connected;
+  BIT(handshake_complete);
+  BIT(handshake_succeeded);
+  BIT(connected);
   BIT(initialized);
   /* Flags written by curl thread */
   BIT(verbose);
@@ -181,11 +181,11 @@ struct stream_ctx {
   uint64_t error3; /* HTTP/3 stream error code */
   int status_code; /* HTTP status code */
   CURLcode recv_error;
-  bool closed;
-  bool reset;
-  bool upload_done;
-  bool firstheader;  /* FALSE until headers arrive */
-  bool recv_header_complete;
+  BIT(closed);
+  BIT(reset);
+  BIT(upload_done);
+  BIT(firstheader);  /* FALSE until headers arrive */
+  BIT(recv_header_complete);
 };
 
 #define H3_STREAM_CTX(ctx,data)   ((struct stream_ctx *)((data && ctx)? \

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -246,10 +246,10 @@ struct h3_stream_ctx {
   curl_off_t upload_left; /* number of request bytes left to upload */
   int status_code; /* HTTP status code */
   CURLcode xfer_result; /* result from xfer_resp_write(_hd) */
-  bool resp_hds_complete; /* we have a complete, final response */
-  bool closed; /* TRUE on stream close */
-  bool reset;  /* TRUE on stream reset */
-  bool send_closed; /* stream is local closed */
+  BIT(resp_hds_complete); /* we have a complete, final response */
+  BIT(closed); /* TRUE on stream close */
+  BIT(reset);  /* TRUE on stream reset */
+  BIT(send_closed); /* stream is local closed */
   BIT(quic_flow_blocked); /* stream is blocked by QUIC flow control */
 };
 

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -583,10 +583,10 @@ struct h3_stream_ctx {
   curl_off_t upload_left; /* number of request bytes left to upload */
   curl_off_t download_recvd; /* number of response DATA bytes received */
   int status_code; /* HTTP status code */
-  bool resp_hds_complete; /* we have a complete, final response */
-  bool closed; /* TRUE on stream close */
-  bool reset;  /* TRUE on stream reset */
-  bool send_closed; /* stream is local closed */
+  BIT(resp_hds_complete); /* we have a complete, final response */
+  BIT(closed); /* TRUE on stream close */
+  BIT(reset);  /* TRUE on stream reset */
+  BIT(send_closed); /* stream is local closed */
   BIT(quic_flow_blocked); /* stream is blocked by QUIC flow control */
 };
 

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -141,9 +141,6 @@ struct ssh_conn {
   const char *passphrase;     /* pass-phrase to use */
   char *rsa_pub;              /* strdup'ed public key file */
   char *rsa;                  /* strdup'ed private key file */
-  bool authed;                /* the connection has been authenticated fine */
-  bool acceptfail;            /* used by the SFTP_QUOTE (continue if
-                                 quote command fails) */
   sshstate state;             /* always use ssh.c:state() to change state! */
   sshstate nextstate;         /* the state to goto after stopping */
   CURLcode actualcode;        /* the actual error code */
@@ -213,6 +210,9 @@ struct ssh_conn {
   curl_off_t offset;
 #endif /* USE_LIBSSH */
   BIT(initialised);
+  BIT(authed);                /* the connection has been authenticated fine */
+  BIT(acceptfail);            /* used by the SFTP_QUOTE (continue if
+                                 quote command fails) */
 };
 
 #ifdef USE_LIBSSH

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -71,7 +71,7 @@ struct ossl_ctx {
 #ifndef HAVE_KEYLOG_CALLBACK
   /* Set to true once a valid keylog entry has been created to avoid dupes.
      This is a bool and not a bitfield because it is passed by address. */
-  BIT(keylog_done);
+  bool keylog_done;
 #endif
   BIT(x509_store_setup);            /* x509 store has been set up */
   BIT(reused_session);              /* session-ID was reused for this */

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -71,7 +71,7 @@ struct ossl_ctx {
 #ifndef HAVE_KEYLOG_CALLBACK
   /* Set to true once a valid keylog entry has been created to avoid dupes.
      This is a bool and not a bitfield because it is passed by address. */
-  bool keylog_done;
+  BIT(keylog_done);
 #endif
   BIT(x509_store_setup);            /* x509 store has been set up */
   BIT(reused_session);              /* session-ID was reused for this */

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -150,17 +150,17 @@ struct schannel_ssl_backend_data {
      cannot be decrypted without another recv() (that is, status is
      SEC_E_INCOMPLETE_MESSAGE) then set this true. after an recv() adds
      more bytes into encdata then set this back to false. */
-  bool encdata_is_incomplete;
   unsigned long req_flags, ret_flags;
   CURLcode recv_unrecoverable_err; /* schannel_recv had an unrecoverable err */
-  bool recv_sspi_close_notify; /* true if connection closed by close_notify */
-  bool recv_connection_closed; /* true if connection closed, regardless how */
-  bool recv_renegotiating;     /* true if recv is doing renegotiation */
-  bool use_alpn; /* true if ALPN is used for this connection */
+  BIT(recv_sspi_close_notify); /* true if connection closed by close_notify */
+  BIT(recv_connection_closed); /* true if connection closed, regardless how */
+  BIT(recv_renegotiating);     /* true if recv is doing renegotiation */
+  BIT(use_alpn); /* true if ALPN is used for this connection */
 #ifdef HAS_MANUAL_VERIFY_API
-  bool use_manual_cred_validation; /* true if manual cred validation is used */
+  BIT(use_manual_cred_validation); /* true if manual cred validation is used */
 #endif
   BIT(sent_shutdown);
+  BIT(encdata_is_incomplete);
 };
 
 /* key to use at `multi->proto_hash` */

--- a/lib/vtls/x509asn1.h
+++ b/lib/vtls/x509asn1.h
@@ -45,7 +45,7 @@ struct Curl_asn1Element {
   const char *end;            /* Pointer to 1st byte after element. */
   unsigned char class;        /* ASN.1 element class. */
   unsigned char tag;          /* ASN.1 element tag. */
-  bool          constructed;  /* Element is constructed. */
+  BIT(constructed);           /* Element is constructed. */
 };
 
 /* X509 certificate: RFC 5280. */


### PR DESCRIPTION
Since it makes use of bitfields on supported platforms, it saves a few bytes memory. Might as well use it consistently.