### PR TITLE
HTTP/2, handling of TE request header

### DIFF
--- a/tests/http/testenv/mod_curltest/mod_curltest.c
+++ b/tests/http/testenv/mod_curltest/mod_curltest.c
@@ -254,6 +254,10 @@ static int curltest_echo_handler(request_rec *r)
   ct = apr_table_get(r->headers_in, "content-type");
   ap_set_content_type(r, ct ? ct : "application/octet-stream");
 
+  if(apr_table_get(r->headers_in, "TE"))
+    apr_table_setn(r->headers_out, "Request-TE",
+                   apr_table_get(r->headers_in, "TE"));
+
   bb = apr_brigade_create(r->pool, c->bucket_alloc);
   /* copy any request body into the response */
   rv = ap_setup_client_block(r, REQUEST_CHUNKED_DECHUNK);


### PR DESCRIPTION
A "TE" request header is allowed in HTTP/2 when it only carries the "trailers" value. RFC 9113 ch. 8.2.2. Check client supplied TE values for the "trailers" token and only pass that one in a HTTP/2 request.

Add test_01_17 to verify.

refs #17122