### PR TITLE
openssl-quic: fix static analyzer complain

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1564,10 +1564,13 @@ static CURLcode cf_osslq_check_and_unblock(struct Curl_cfilter *cf,
           idx_count++) {
         if(ctx->poll_items[idx_count].revents & SSL_POLL_EVENT_W) {
           stream = H3_STREAM_CTX(ctx, ctx->curl_items[idx_count]);
-          nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
-          stream->s.send_blocked = FALSE;
-          h3_drain_stream(cf, ctx->curl_items[idx_count]);
-          CURL_TRC_CF(ctx->curl_items[idx_count], cf, "unblocked");
+          DEBUGASSERT(stream); /* should still exists */
+          if(stream) {
+            nghttp3_conn_unblock_stream(ctx->h3.conn, stream->s.id);
+            stream->s.send_blocked = FALSE;
+            h3_drain_stream(cf, ctx->curl_items[idx_count]);
+            CURL_TRC_CF(ctx->curl_items[idx_count], cf, "unblocked");
+          }
           result_count--;
         }
       }


### PR DESCRIPTION
static analyzer complains abot possible NULL pointer use in hash lookup that were done just before. Add a NULL check to address this.

refs #17131