### PR TITLE
shutdown timer fix

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -171,11 +171,12 @@ void Curl_shutdown_start(struct Curl_easy *data, int sockindex,
     nowp = &now;
   }
   data->conn->shutdown.start[sockindex] = *nowp;
-  data->conn->shutdown.timeout_ms = (timeout_ms >= 0) ?
+  data->conn->shutdown.timeout_ms = (timeout_ms > 0) ?
     (unsigned int)timeout_ms :
     ((data->set.shutdowntimeout > 0) ?
      data->set.shutdowntimeout : DEFAULT_SHUTDOWN_TIMEOUT_MS);
-  if(data->conn->shutdown.timeout_ms)
+  /* Set a timer, unless we operate on the admin handle */
+  if(data->mid && data->conn->shutdown.timeout_ms)
     Curl_expire_ex(data, nowp, data->conn->shutdown.timeout_ms,
                    EXPIRE_SHUTDOWN);
 }


### PR DESCRIPTION
Fix a bug in timeout handling for connection shutdowns that led to default timeout of 2 seconds not being in effect.

Only set the shutdown timeout expiry when operating on a non-admin transfers. Admin handles are only temproarily tied to a connection.

refs #17130