### PR TITLE
cmake: avoid 'target is imported but not globally visible' when consuming libcurl with old cmake

### DIFF
--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -35,6 +35,9 @@ include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 
 # Alias for either shared or static library
 if(NOT TARGET @PROJECT_NAME@::libcurl)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.11 AND CMAKE_VERSION VERSION_LESS 3.18)
+    set_target_properties(@PROJECT_NAME@::@LIB_SELECTED@ PROPERTIES IMPORTED_GLOBAL TRUE)
+  endif()
   add_library(@PROJECT_NAME@::libcurl ALIAS @PROJECT_NAME@::@LIB_SELECTED@)
 endif()
 


### PR DESCRIPTION
Fixes:
```
CMake Error at bld-curl/_pkg/lib/cmake/CURL/CURLConfig.cmake:62 (add_library):
  add_library cannot create ALIAS target "CURL::libcurl" because target
  "CURL::libcurl_shared" is imported but not globally visible.
Call Stack (most recent call first):
  CMakeLists.txt:39 (find_package)
```

tests/cmake reproducer (requires #16973):
```shell
export CMAKE_CONSUMER=/path/to/CMake-3.12.0/bin/cmake
./test.sh find_package
```

I don't understand what this error says, why it happens in certain CMake
versions, and why a workaround is necessary for what seems like
a standard export/consume configuration. This patch is based on internet
suggestions and other projects ending up with this workaround.

Cherry-picked from #16973