### PR TITLE
ws: store protocol context as connection meta data

### DIFF
--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -898,9 +898,6 @@ struct connectdata {
 #ifndef CURL_DISABLE_MQTT
     struct mqtt_conn mqtt;
 #endif
-#ifndef CURL_DISABLE_WEBSOCKETS
-    struct websocket *ws;
-#endif
     unsigned int unused:1; /* avoids empty union */
   } proto;
 

--- a/lib/ws.h
+++ b/lib/ws.h
@@ -27,47 +27,8 @@
 
 #if !defined(CURL_DISABLE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
 
-/* a client-side WS frame decoder, parsing frame headers and
- * payload, keeping track of current position and stats */
-enum ws_dec_state {
-  WS_DEC_INIT,
-  WS_DEC_HEAD,
-  WS_DEC_PAYLOAD
-};
-
-struct ws_decoder {
-  int frame_age;        /* zero */
-  int frame_flags;      /* See the CURLWS_* defines */
-  curl_off_t payload_offset;   /* the offset parsing is at */
-  curl_off_t payload_len;
-  unsigned char head[10];
-  int head_len, head_total;
-  enum ws_dec_state state;
-  int cont_flags;
-};
-
-/* a client-side WS frame encoder, generating frame headers and
- * converting payloads, tracking remaining data in current frame */
-struct ws_encoder {
-  curl_off_t payload_len;  /* payload length of current frame */
-  curl_off_t payload_remain;  /* remaining payload of current */
-  unsigned int xori; /* xor index */
-  unsigned char mask[4]; /* 32-bit mask for this connection */
-  unsigned char firstbyte; /* first byte of frame we encode */
-  BIT(contfragment); /* set TRUE if the previous fragment sent was not final */
-};
-
-/* A websocket connection with en- and decoder that treat frames
- * and keep track of boundaries. */
-struct websocket {
-  struct Curl_easy *data; /* used for write callback handling */
-  struct ws_decoder dec;  /* decode of we frames */
-  struct ws_encoder enc;  /* decode of we frames */
-  struct bufq recvbuf;    /* raw data from the server */
-  struct bufq sendbuf;    /* raw data to be sent to the server */
-  struct curl_ws_frame frame;  /* the current WS FRAME received */
-  size_t sendbuf_payload; /* number of payload bytes in sendbuf */
-};
+/* meta key for storing protocol meta at connection */
+#define CURL_META_PROTO_WS_CONN   "meta:proto:ws:conn"
 
 CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req);
 CURLcode Curl_ws_accept(struct Curl_easy *data, const char *mem, size_t len);


### PR DESCRIPTION
Eliminates union member on struct connectdata. Sample of how other procotols can handle their connection related data.

This avoids potential mix-ups of the `proto` union of a connection with other protocol instances.

Removed ws "disconnect" callback as meta data is automatically destroyed when a connection is destroyed.