### PR TITLE
cmake: fix `fish` install directory detection via `pkg-config`

### DIFF
--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -56,7 +56,7 @@ if(CURL_COMPLETION_FISH OR
           if(NOT CURL_COMPLETION_FISH_DIR)
             find_package(PkgConfig QUIET)
             pkg_get_variable(CURL_COMPLETION_FISH_DIR "fish" "completionsdir")
-            if(NOT _pkg_fish_completionsdir)
+            if(NOT CURL_COMPLETION_FISH_DIR)
               if(CMAKE_INSTALL_DATAROOTDIR)
                 set(CURL_COMPLETION_FISH_DIR "${CMAKE_INSTALL_DATAROOTDIR}/fish/vendor_completions.d")
               endif()


### PR DESCRIPTION
Follow-up to c8b0f0c9ad78eafc6c8f0005113de346ee797c21 #16833