### PR TITLE
init_do(): check result

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1560,10 +1560,15 @@ CURLMcode Curl_multi_add_perform(struct Curl_multi *multi,
   rc = curl_multi_add_handle(multi, data);
   if(!rc) {
     struct SingleRequest *k = &data->req;
+    CURLcode result;
 
     /* pass in NULL for 'conn' here since we do not want to init the
        connection, only this transfer */
-    Curl_init_do(data, NULL);
+    result = Curl_init_do(data, NULL);
+    if(result) {
+      curl_multi_remove_handle(multi, data);
+      return CURLM_INTERNAL_ERROR;
+    }
 
     /* take this handle to the perform state right away */
     multistate(data, MSTATE_PERFORMING);

--- a/tests/libtest/lib1576.c
+++ b/tests/libtest/lib1576.c
@@ -27,7 +27,10 @@
 
 static char testdata[] = "request indicates that the client, which made";
 
-static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
+#ifndef LIB1576_CALLBACKS
+#define LIB1576_CALLBACKS
+
+static size_t t1576_read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t  amount = nmemb * size; /* Total bytes curl wants */
   if(amount < strlen(testdata)) {
@@ -37,6 +40,16 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
   memcpy(ptr, testdata, strlen(testdata));
   return strlen(testdata);
 }
+
+static int t1576_seek_cb(char *ptr, curl_off_t offset, int origin)
+{
+  (void)ptr;
+  (void)offset;
+  if(origin != SEEK_SET)
+    return CURL_SEEKFUNC_FAIL;
+  return CURL_SEEKFUNC_OK;
+}
+#endif
 
 CURLcode test(char *URL)
 {
@@ -61,7 +74,8 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+  test_setopt(curl, CURLOPT_READFUNCTION, t1576_read_cb);
+  test_setopt(curl, CURLOPT_SEEKFUNCTION, t1576_seek_cb);
   test_setopt(curl, CURLOPT_INFILESIZE, (long)strlen(testdata));
 
   test_setopt(curl, CURLOPT_CUSTOMREQUEST, "CURL");

--- a/tests/libtest/lib1576.c
+++ b/tests/libtest/lib1576.c
@@ -27,10 +27,7 @@
 
 static char testdata[] = "request indicates that the client, which made";
 
-#ifndef LIB1576_CALLBACKS
-#define LIB1576_CALLBACKS
-
-static size_t t1576_read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
+static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
 {
   size_t  amount = nmemb * size; /* Total bytes curl wants */
   if(amount < strlen(testdata)) {
@@ -41,7 +38,7 @@ static size_t t1576_read_cb(char *ptr, size_t size, size_t nmemb, void *stream)
   return strlen(testdata);
 }
 
-static int t1576_seek_cb(char *ptr, curl_off_t offset, int origin)
+static int seek_callback(char *ptr, curl_off_t offset, int origin)
 {
   (void)ptr;
   (void)offset;
@@ -49,7 +46,6 @@ static int t1576_seek_cb(char *ptr, curl_off_t offset, int origin)
     return CURL_SEEKFUNC_FAIL;
   return CURL_SEEKFUNC_OK;
 }
-#endif
 
 CURLcode test(char *URL)
 {
@@ -74,8 +70,8 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_UPLOAD, 1L);
-  test_setopt(curl, CURLOPT_READFUNCTION, t1576_read_cb);
-  test_setopt(curl, CURLOPT_SEEKFUNCTION, t1576_seek_cb);
+  test_setopt(curl, CURLOPT_READFUNCTION, read_callback);
+  test_setopt(curl, CURLOPT_SEEKFUNCTION, seek_callback);
   test_setopt(curl, CURLOPT_INFILESIZE, (long)strlen(testdata));
 
   test_setopt(curl, CURLOPT_CUSTOMREQUEST, "CURL");

--- a/tests/libtest/lib1576.c
+++ b/tests/libtest/lib1576.c
@@ -38,7 +38,7 @@ static size_t read_callback(char *ptr, size_t size, size_t nmemb, void *stream)
   return strlen(testdata);
 }
 
-static int seek_callback(char *ptr, curl_off_t offset, int origin)
+static int seek_callback(void *ptr, curl_off_t offset, int origin)
 {
   (void)ptr;
   (void)offset;

--- a/tests/mk-bundle.pl
+++ b/tests/mk-bundle.pl
@@ -78,6 +78,7 @@ my @reused_symbols = (
     "removeFd",
     "rlim2str",
     "run_thread",
+    "seek_callback",
     "send_ping",
     "showem",
     "store_errmsg",


### PR DESCRIPTION
Calls to `Curl_init_do()` did not check on result and missed failures to properly and completely initialize a transfer request.

The main cause of such an init failure is the need to rewind the READFUNCTION without a SEEKFUNCTION registered. Check the failure to "rewind" the upload data immediately make test cases 1576 and friends fail.

refs #17139