### PR TITLE
meta-hash: hash table with static keys

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -192,6 +192,7 @@ LIB_CFILES =         \
   md4.c              \
   md5.c              \
   memdebug.c         \
+  meta-hash.c        \
   mime.c             \
   mprintf.c          \
   mqtt.c             \
@@ -335,6 +336,7 @@ LIB_HFILES =         \
   llist.h            \
   macos.h            \
   memdebug.h         \
+  meta-hash.h        \
   mime.h             \
   mqtt.h             \
   multihandle.h      \

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -86,21 +86,9 @@ static void doh_meta_probe_dtor(const struct meta_key *key, void *value)
   }
 }
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
-static CURLcode doh_meta_probe_print(struct dynbuf *buf,
-                                     const struct meta_key *key,
-                                     void *value)
-{
-  struct doh_request *doh_req = value;
-  (void)key;
-  return Curl_dyn_addf(buf, "DoH request, DNStype=%d", doh_req->dnstype);
-}
-#endif
-
 #define CURL_EZM_DOH_PROBE   "ezm:doh-p"
 static const struct meta_key doh_meta_key_probe =
-  CURL_META_KEY_PTR("meta:doh:probe", doh_meta_probe_dtor,
-                    doh_meta_probe_print);
+  CURL_META_KEY_PTR("meta:doh:probe", doh_meta_probe_dtor);
 #define CURL_META_DOH_PROBE  (&doh_meta_key_probe)
 
 

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -448,11 +448,10 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
   doh->state.internal = TRUE;
   doh->master_mid = data->mid; /* master transfer of this one */
 
-  if(Curl_meta_set(doh, CURL_META_DOH_PROBE, doh_req)) {
-    result = CURLE_OUT_OF_MEMORY;
+  result = Curl_meta_set(doh, CURL_META_DOH_PROBE, doh_req);
+  doh_req = NULL; /* call has taken ownership */
+  if(result)
     goto error;
-  }
-  doh_req = NULL;
 
   /* DoH handles must not inherit private_data. The handles may be passed to
      the user via callbacks and the user will be able to identify them as

--- a/lib/doh.c
+++ b/lib/doh.c
@@ -75,6 +75,35 @@ static const char *doh_strerror(DOHcode code)
 
 #endif /* !CURL_DISABLE_VERBOSE_STRINGS */
 
+static void doh_meta_probe_dtor(const struct meta_key *key, void *value)
+{
+  struct doh_request *doh_req = value;
+  (void)key;
+  if(doh_req) {
+    curl_slist_free_all(doh_req->req_hds);
+    Curl_dyn_free(&doh_req->resp_body);
+    free(doh_req);
+  }
+}
+
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+static CURLcode doh_meta_probe_print(struct dynbuf *buf,
+                                     const struct meta_key *key,
+                                     void *value)
+{
+  struct doh_request *doh_req = value;
+  (void)key;
+  return Curl_dyn_addf(buf, "DoH request, DNStype=%d", doh_req->dnstype);
+}
+#endif
+
+#define CURL_EZM_DOH_PROBE   "ezm:doh-p"
+static const struct meta_key doh_meta_key_probe =
+  CURL_META_KEY_PTR("meta:doh:probe", doh_meta_probe_dtor,
+                    doh_meta_probe_print);
+#define CURL_META_DOH_PROBE  (&doh_meta_key_probe)
+
+
 /* @unittest 1655
  */
 UNITTEST DOHcode doh_req_encode(const char *host,
@@ -179,7 +208,7 @@ doh_probe_write_cb(char *contents, size_t size, size_t nmemb, void *userp)
 {
   size_t realsize = size * nmemb;
   struct Curl_easy *data = userp;
-  struct doh_request *doh_req = Curl_meta_get(data, CURL_EZM_DOH_PROBE);
+  struct doh_request *doh_req = Curl_meta_get(data, CURL_META_DOH_PROBE);
   if(!doh_req)
     return CURL_WRITEFUNC_ERROR;
 
@@ -223,7 +252,7 @@ static void doh_probe_done(struct Curl_easy *data,
   struct doh_probes *dohp = data->state.async.doh;
   DEBUGASSERT(dohp);
   if(dohp) {
-    struct doh_request *doh_req = Curl_meta_get(doh, CURL_EZM_DOH_PROBE);
+    struct doh_request *doh_req = Curl_meta_get(doh, CURL_META_DOH_PROBE);
     int i;
 
     for(i = 0; i < DOH_SLOT_COUNT; ++i) {
@@ -249,7 +278,7 @@ static void doh_probe_done(struct Curl_easy *data,
                                Curl_dyn_len(&doh_req->resp_body));
         Curl_dyn_free(&doh_req->resp_body);
       }
-      Curl_meta_remove(doh, CURL_EZM_DOH_PROBE);
+      Curl_meta_remove(doh, CURL_META_DOH_PROBE);
     }
 
     if(result)
@@ -259,18 +288,6 @@ static void doh_probe_done(struct Curl_easy *data,
       /* DoH completed, run the transfer picking up the results */
       Curl_expire(data, 0, EXPIRE_RUN_NOW);
     }
-  }
-}
-
-static void doh_probe_dtor(void *key, size_t klen, void *e)
-{
-  (void)key;
-  (void)klen;
-  if(e) {
-    struct doh_request *doh_req = e;
-    curl_slist_free_all(doh_req->req_hds);
-    Curl_dyn_free(&doh_req->resp_body);
-    free(e);
   }
 }
 
@@ -431,7 +448,7 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
   doh->state.internal = TRUE;
   doh->master_mid = data->mid; /* master transfer of this one */
 
-  if(Curl_meta_set(doh, CURL_EZM_DOH_PROBE, doh_req, doh_probe_dtor)) {
+  if(Curl_meta_set(doh, CURL_META_DOH_PROBE, doh_req)) {
     result = CURLE_OUT_OF_MEMORY;
     goto error;
   }
@@ -452,7 +469,7 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
 error:
   Curl_close(&doh);
   if(doh_req)
-    doh_probe_dtor(NULL, 0, doh_req);
+    doh_meta_probe_dtor(CURL_META_DOH_PROBE, doh_req);
   return result;
 }
 

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -80,8 +80,6 @@ enum doh_slot_num {
   DOH_SLOT_COUNT
 };
 
-#define CURL_EZM_DOH_PROBE   "ezm:doh-p"
-
 /* the largest one we can make, based on RFCs 1034, 1035 */
 #define DOH_MAX_DNSREQ_SIZE (256 + 16)
 

--- a/lib/meta-hash.c
+++ b/lib/meta-hash.c
@@ -225,19 +225,3 @@ void Curl_meta_hash_destroy(struct meta_hash *h)
   }
   h->slots = 0;
 }
-
-void Curl_meta_str_dtor(const struct meta_key *key, void *value)
-{
-  (void)key;
-  DEBUGASSERT(key->type == CURL_META_STR);
-  free(value);
-}
-
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
-CURLcode Curl_meta_str_print(struct dynbuf *buf,
-                             const struct meta_key *key, void *value)
-{
-  (void)key;
-  return Curl_dyn_add(buf, (const char *)value);
-}
-#endif

--- a/lib/meta-hash.c
+++ b/lib/meta-hash.c
@@ -1,0 +1,250 @@
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+#include <curl/curl.h>
+
+#include "dynbuf.h"
+#include "meta-hash.h"
+#include "curl_memory.h"
+
+/* The last #include file should be: */
+#include "memdebug.h"
+
+/* random patterns for API verification */
+#ifdef DEBUGBUILD
+#define CURL_METAHASHINIT 0x71177117
+#endif
+
+static bool meta_key_same(const struct meta_key *k1,
+                          const struct meta_key *k2)
+{
+  return (k1 == k2) ||
+         ((k1->id_len == k2->id_len) && !strcmp(k1->id, k2->id));
+}
+
+static unsigned int meta_hash_hash(const struct meta_key *key,
+                                   unsigned int slots)
+{
+  const char *key_str = key->id;
+  const char *end = key_str + key->id_len;
+  size_t h = 5381;
+
+  while(key_str < end) {
+    size_t j = (size_t)*key_str++;
+    h += h << 5;
+    h ^= j;
+  }
+
+  return (h % slots);
+}
+
+struct meta_hash_entry {
+  struct meta_hash_entry *next;
+  const struct meta_key *key;
+  void *value;
+};
+
+void Curl_meta_hash_init(struct meta_hash *h, unsigned int slots)
+{
+  DEBUGASSERT(h);
+  DEBUGASSERT(slots);
+
+  h->table = NULL;
+  h->size = 0;
+  h->slots = slots;
+#ifdef DEBUGBUILD
+  h->init = CURL_METAHASHINIT;
+#endif
+}
+
+static struct meta_hash_entry *
+meta_hash_mk_entry(const struct meta_key *key, void *value)
+{
+  struct meta_hash_entry *e = malloc(sizeof(*e));
+  if(e) {
+    e->next = NULL;
+    e->key = key;
+    e->value = value;
+  }
+  return e;
+}
+
+static void meta_hash_entry_clear(struct meta_hash_entry *e)
+{
+  DEBUGASSERT(e->key);
+  if(e->key && e->value) {
+    if(e->key->dtor)
+      e->key->dtor(e->key, e->value);
+    e->value = NULL;
+  }
+}
+
+static void meta_hash_entry_destroy(struct meta_hash_entry *e)
+{
+  meta_hash_entry_clear(e);
+  free(e);
+}
+
+static void meta_hash_entry_unlink(struct meta_hash *h,
+                                   struct meta_hash_entry **he_anchor,
+                                   struct meta_hash_entry *he)
+{
+  *he_anchor = he->next;
+  --h->size;
+}
+
+static void meta_hash_elem_link(struct meta_hash *h,
+                                struct meta_hash_entry **he_anchor,
+                                struct meta_hash_entry *he)
+{
+  he->next = *he_anchor;
+  *he_anchor = he;
+  ++h->size;
+}
+
+#define CURL_META_HASH_SLOT(h,key)  h->table[meta_hash_hash(key, h->slots)]
+#define CURL_META_HASH_SLOT_ADDR(h,key) &CURL_META_HASH_SLOT(h,key)
+
+bool Curl_meta_hash_set(struct meta_hash *h,
+                        const struct meta_key *key, void *value)
+{
+  struct meta_hash_entry *he, **slot;
+
+  DEBUGASSERT(h);
+  DEBUGASSERT(h->slots);
+  DEBUGASSERT(h->init == CURL_METAHASHINIT);
+  if(!h->table) {
+    h->table = calloc(h->slots, sizeof(*he));
+    if(!h->table)
+      return FALSE; /* OOM */
+  }
+
+  slot = CURL_META_HASH_SLOT_ADDR(h, key);
+  for(he = *slot; he; he = he->next) {
+    if(meta_key_same(key, he->key)) {
+      /* existing key entry, overwrite by clearing old pointer */
+      meta_hash_entry_clear(he);
+      he->value = value;
+      return TRUE;
+    }
+  }
+
+  he = meta_hash_mk_entry(key, value);
+  if(!he)
+    return FALSE; /* OOM */
+
+  meta_hash_elem_link(h, slot, he);
+  return TRUE;
+}
+
+bool Curl_meta_hash_remove(struct meta_hash *h, const struct meta_key *key)
+{
+  DEBUGASSERT(h);
+  DEBUGASSERT(h->slots);
+  DEBUGASSERT(h->init == CURL_METAHASHINIT);
+  if(h->table) {
+    struct meta_hash_entry *he, **he_anchor;
+
+    he_anchor = CURL_META_HASH_SLOT_ADDR(h, key);
+    while(*he_anchor) {
+      he = *he_anchor;
+      if(meta_key_same(key, he->key)) {
+        meta_hash_entry_unlink(h, he_anchor, he);
+        meta_hash_entry_destroy(he);
+        return TRUE;
+      }
+      he_anchor = &he->next;
+    }
+  }
+  return FALSE;
+}
+
+void *Curl_meta_hash_get(struct meta_hash *h, const struct meta_key *key)
+{
+  DEBUGASSERT(h);
+  DEBUGASSERT(h->init == CURL_METAHASHINIT);
+  if(h->table) {
+    struct meta_hash_entry *he;
+    DEBUGASSERT(h->slots);
+    he = CURL_META_HASH_SLOT(h, key);
+    while(he) {
+      if(meta_key_same(key, he->key)) {
+        return he->value;
+      }
+      he = he->next;
+    }
+  }
+  return NULL;
+}
+
+static void meta_hash_clear(struct meta_hash *h)
+{
+  if(h && h->table) {
+    struct meta_hash_entry *he, **he_anchor;
+    size_t i;
+    DEBUGASSERT(h->init == CURL_METAHASHINIT);
+    for(i = 0; i < h->slots; ++i) {
+      he_anchor = &h->table[i];
+      while(*he_anchor) {
+        he = *he_anchor;
+        meta_hash_entry_unlink(h, he_anchor, he);
+        meta_hash_entry_destroy(he);
+      }
+    }
+  }
+}
+
+void Curl_meta_hash_clear(struct meta_hash *h)
+{
+  meta_hash_clear(h);
+}
+
+void Curl_meta_hash_destroy(struct meta_hash *h)
+{
+  DEBUGASSERT(h->init == CURL_METAHASHINIT);
+  if(h->table) {
+    meta_hash_clear(h);
+    Curl_safefree(h->table);
+  }
+  DEBUGASSERT(h->size == 0);
+  h->slots = 0;
+}
+
+void Curl_meta_str_dtor(const struct meta_key *key, void *value)
+{
+  (void)key;
+  DEBUGASSERT(key->type == CURL_META_STR);
+  free(value);
+}
+
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+CURLcode Curl_meta_str_print(struct dynbuf *buf,
+                             const struct meta_key *key, void *value)
+{
+  (void)key;
+  return Curl_dyn_add(buf, (const char *)value);
+}
+#endif

--- a/lib/meta-hash.c
+++ b/lib/meta-hash.c
@@ -45,8 +45,7 @@ static bool meta_key_same(const struct meta_key *k1,
          ((k1->id_len == k2->id_len) && !strcmp(k1->id, k2->id));
 }
 
-static unsigned int meta_hash_hash(const struct meta_key *key,
-                                   unsigned int slots)
+static size_t meta_hash_hash(const struct meta_key *key, unsigned int slots)
 {
   const char *key_str = key->id;
   const char *end = key_str + key->id_len;

--- a/lib/meta-hash.h
+++ b/lib/meta-hash.h
@@ -1,0 +1,110 @@
+#ifndef HEADER_CURL_META_HASH_H
+#define HEADER_CURL_META_HASH_H
+/***************************************************************************
+ *                                  _   _ ____  _
+ *  Project                     ___| | | |  _ \| |
+ *                             / __| | | | |_) | |
+ *                            | (__| |_| |  _ <| |___
+ *                             \___|\___/|_| \_\_____|
+ *
+ * Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+ *
+ * This software is licensed as described in the file COPYING, which
+ * you should have received as part of this distribution. The terms
+ * are also available at https://curl.se/docs/copyright.html.
+ *
+ * You may opt to use, copy, modify, merge, publish, distribute and/or sell
+ * copies of the Software, and permit persons to whom the Software is
+ * furnished to do so, under the terms of the COPYING file.
+ *
+ * This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+ * KIND, either express or implied.
+ *
+ * SPDX-License-Identifier: curl
+ *
+ ***************************************************************************/
+
+#include "curl_setup.h"
+
+/* A hash of "meta type" values */
+
+struct dynbuf;
+struct meta_key;
+
+typedef void Curl_meta_hash_dtor(const struct meta_key *key,
+                                 void *value);
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+typedef CURLcode Curl_meta_hash_print(struct dynbuf *buf,
+                                      const struct meta_key *key,
+                                      void *value);
+#endif
+
+typedef enum {
+  CURL_META_STR,    /* value is a C-string */
+  CURL_META_PTR,    /* value is an opaque pointer */
+} meta_type;
+
+/* A meta key for lookups into the hash table.
+ * Lifetime: forever, declared as static */
+struct meta_key {
+  const char *id;
+  size_t id_len;
+  Curl_meta_hash_dtor *dtor;
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+  Curl_meta_hash_print *print;
+#endif
+  meta_type type;
+};
+
+struct meta_hash_entry;
+
+/* Hash for `meta_key` values */
+struct meta_hash {
+  struct meta_hash_entry **table;
+  unsigned int slots;
+  unsigned int size;
+#ifdef DEBUGBUILD
+  int init;
+#endif
+};
+
+
+void Curl_meta_hash_init(struct meta_hash *h, unsigned int slots);
+void Curl_meta_hash_destroy(struct meta_hash *h);
+void Curl_meta_hash_clear(struct meta_hash *h);
+
+bool Curl_meta_hash_remove(struct meta_hash *h, const struct meta_key *key);
+
+/* Set the value for a key. The key is not copied and needs to live
+ * longer than the hash itself.
+ * The call takes ownership of `value` in any outcome, using the
+ * meta key destructor to deallocate it.
+ * Returns TRUE if value was successfully stored in the hash. */
+bool Curl_meta_hash_set(struct meta_hash *h,
+                        const struct meta_key *key, void *value);
+
+void *Curl_meta_hash_get(struct meta_hash *h, const struct meta_key *key);
+
+
+/* Declaring meta keys */
+
+void Curl_meta_str_dtor(const struct meta_key *key, void *value);
+
+
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+CURLcode Curl_meta_str_print(struct dynbuf *buf,
+                             const struct meta_key *key, void *value);
+
+#define CURL_META_KEY_PTR(id, dtor, print) \
+    { STRCONST(id), (dtor), (print), CURL_META_PTR }
+
+#define CURL_META_KEY_STR(id) \
+    { STRCONST(id), Curl_meta_str_dtor, Curl_meta_str_print, CURL_META_STR }
+#else
+#define CURL_META_KEY(id, dtor, print) \
+    { STRCONST(id), (dtor), CURL_META_PTR }
+#define CURL_META_KEY_STR(id) \
+    { STRCONST(id), Curl_meta_str_dtor, CURL_META_STR }
+#endif
+
+#endif /* HEADER_CURL_META_HASH_H */

--- a/lib/meta-hash.h
+++ b/lib/meta-hash.h
@@ -33,11 +33,6 @@ struct meta_key;
 
 typedef void Curl_meta_hash_dtor(const struct meta_key *key,
                                  void *value);
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
-typedef CURLcode Curl_meta_hash_print(struct dynbuf *buf,
-                                      const struct meta_key *key,
-                                      void *value);
-#endif
 
 typedef enum {
   CURL_META_STR,    /* value is a C-string */
@@ -50,9 +45,6 @@ struct meta_key {
   const char *id;
   size_t id_len;
   Curl_meta_hash_dtor *dtor;
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
-  Curl_meta_hash_print *print;
-#endif
   meta_type type;
 };
 
@@ -86,24 +78,7 @@ void *Curl_meta_hash_get(struct meta_hash *h, const struct meta_key *key);
 
 
 /* Declaring meta keys */
-
-void Curl_meta_str_dtor(const struct meta_key *key, void *value);
-
-
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
-CURLcode Curl_meta_str_print(struct dynbuf *buf,
-                             const struct meta_key *key, void *value);
-
-#define CURL_META_KEY_PTR(id, dtor, print) \
-    { STRCONST(id), (dtor), (print), CURL_META_PTR }
-
-#define CURL_META_KEY_STR(id) \
-    { STRCONST(id), Curl_meta_str_dtor, Curl_meta_str_print, CURL_META_STR }
-#else
-#define CURL_META_KEY(id, dtor, print) \
+#define CURL_META_KEY_PTR(id, dtor) \
     { STRCONST(id), (dtor), CURL_META_PTR }
-#define CURL_META_KEY_STR(id) \
-    { STRCONST(id), Curl_meta_str_dtor, CURL_META_STR }
-#endif
 
 #endif /* HEADER_CURL_META_HASH_H */

--- a/lib/meta-hash.h
+++ b/lib/meta-hash.h
@@ -41,7 +41,7 @@ typedef CURLcode Curl_meta_hash_print(struct dynbuf *buf,
 
 typedef enum {
   CURL_META_STR,    /* value is a C-string */
-  CURL_META_PTR,    /* value is an opaque pointer */
+  CURL_META_PTR     /* value is an opaque pointer */
 } meta_type;
 
 /* A meta key for lookups into the hash table.
@@ -62,7 +62,6 @@ struct meta_hash_entry;
 struct meta_hash {
   struct meta_hash_entry **table;
   unsigned int slots;
-  unsigned int size;
 #ifdef DEBUGBUILD
   int init;
 #endif

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -53,28 +53,14 @@ static void mev_meta_pollset_dtor(const struct meta_key *key, void *value)
   free(value);
 }
 
-#ifndef CURL_DISABLE_VERBOSE_STRINGS
-static CURLcode mev_meta_pollset_print(struct dynbuf *buf,
-                                       const struct meta_key *key,
-                                       void *value)
-{
-  struct easy_pollset *ps = value;
-  (void)key;
-  return Curl_dyn_addf(buf, "pollset, %d sockets", ps->num);
-}
-#endif
-
 static const struct meta_key mev_meta_key_pollset =
-  CURL_META_KEY_PTR("meta:mev:ps", mev_meta_pollset_dtor,
-                    mev_meta_pollset_print);
+  CURL_META_KEY_PTR("meta:mev:ps", mev_meta_pollset_dtor);
 #define CURL_META_MEV_POLLSET  (&mev_meta_key_pollset)
 
 static void mev_in_callback(struct Curl_multi *multi, bool value)
 {
   multi->in_callback = value;
 }
-
-#define CURL_MEV_CONN_HASH_SIZE 3
 
 /* Information about a socket for which we inform the libcurl application
  * what to supervise (CURL_POLL_IN/CURL_POLL_OUT/CURL_POLL_REMOVE)

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -484,10 +484,8 @@ mev_add_new_xfer_pollset(struct Curl_easy *data)
   ps = calloc(1, sizeof(*ps));
   if(!ps)
     return NULL;
-  if(Curl_meta_set(data, CURL_META_MEV_POLLSET, ps)) {
-    free(ps);
+  if(Curl_meta_set(data, CURL_META_MEV_POLLSET, ps))
     return NULL;
-  }
   return ps;
 }
 

--- a/lib/multi_ev.c
+++ b/lib/multi_ev.c
@@ -32,6 +32,7 @@
 #include "curl_trc.h"
 #include "multiif.h"
 #include "timeval.h"
+#include "meta-hash.h"
 #include "multi_ev.h"
 #include "select.h"
 #include "uint-bset.h"
@@ -45,6 +46,28 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+
+static void mev_meta_pollset_dtor(const struct meta_key *key, void *value)
+{
+  (void)key;
+  free(value);
+}
+
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+static CURLcode mev_meta_pollset_print(struct dynbuf *buf,
+                                       const struct meta_key *key,
+                                       void *value)
+{
+  struct easy_pollset *ps = value;
+  (void)key;
+  return Curl_dyn_addf(buf, "pollset, %d sockets", ps->num);
+}
+#endif
+
+static const struct meta_key mev_meta_key_pollset =
+  CURL_META_KEY_PTR("meta:mev:ps", mev_meta_pollset_dtor,
+                    mev_meta_pollset_print);
+#define CURL_META_MEV_POLLSET  (&mev_meta_key_pollset)
 
 static void mev_in_callback(struct Curl_multi *multi, bool value)
 {
@@ -438,13 +461,6 @@ static CURLMcode mev_pollset_diff(struct Curl_multi *multi,
   return CURLM_OK;
 }
 
-static void mev_pollset_dtor(void *key, size_t klen, void *entry)
-{
-  (void)key;
-  (void)klen;
-  free(entry);
-}
-
 static struct easy_pollset*
 mev_add_new_conn_pollset(struct connectdata *conn)
 {
@@ -453,7 +469,7 @@ mev_add_new_conn_pollset(struct connectdata *conn)
   ps = calloc(1, sizeof(*ps));
   if(!ps)
     return NULL;
-  if(Curl_conn_meta_set(conn, CURL_META_MEV_POLLSET, ps, mev_pollset_dtor)) {
+  if(Curl_conn_meta_set(conn, CURL_META_MEV_POLLSET, ps)) {
     free(ps);
     return NULL;
   }
@@ -468,7 +484,7 @@ mev_add_new_xfer_pollset(struct Curl_easy *data)
   ps = calloc(1, sizeof(*ps));
   if(!ps)
     return NULL;
-  if(Curl_meta_set(data, CURL_META_MEV_POLLSET, ps, mev_pollset_dtor)) {
+  if(Curl_meta_set(data, CURL_META_MEV_POLLSET, ps)) {
     free(ps);
     return NULL;
   }

--- a/lib/multi_ev.h
+++ b/lib/multi_ev.h
@@ -31,9 +31,6 @@ struct Curl_multi;
 struct easy_pollset;
 struct uint_bset;
 
-/* meta key for event pollset at easy handle or connection */
-#define CURL_META_MEV_POLLSET   "meta:mev:ps"
-
 struct curl_multi_ev {
   struct Curl_hash sh_entries;
 };

--- a/lib/url.h
+++ b/lib/url.h
@@ -44,27 +44,26 @@ CURLcode Curl_parse_login_details(const char *login, const size_t len,
                                   char **userptr, char **passwdptr,
                                   char **optionsptr);
 
-/* Attach/Clear/Get meta data for an easy handle. Needs to provide
- * a destructor, will be automatically called when the easy handle
- * is reset or closed. */
-typedef void Curl_meta_dtor(void *key, size_t key_len, void *meta_data);
-
 /* Set the transfer meta data for the key. Any existing entry for that
  * key will be destroyed.
  * Takes ownership of `meta_data` and destroys it when the call fails. */
-CURLcode Curl_meta_set(struct Curl_easy *data, const char *key,
-                       void *meta_data, Curl_meta_dtor *meta_dtor);
-void Curl_meta_remove(struct Curl_easy *data, const char *key);
-void *Curl_meta_get(struct Curl_easy *data, const char *key);
+CURLcode Curl_meta_set(struct Curl_easy *data,
+                       const struct meta_key *key, void *value);
+void Curl_meta_remove(struct Curl_easy *data,
+                      const struct meta_key *key);
+void *Curl_meta_get(struct Curl_easy *data,
+                    const struct meta_key *key);
 void Curl_meta_reset(struct Curl_easy *data);
 
 /* Set connection meta data for the key. Any existing entry for that
  * key will be destroyed.
  * Takes ownership of `meta_data` and destroys it when the call fails. */
-CURLcode Curl_conn_meta_set(struct connectdata *conn, const char *key,
-                            void *meta_data, Curl_meta_dtor *meta_dtor);
-void Curl_conn_meta_remove(struct connectdata *conn, const char *key);
-void *Curl_conn_meta_get(struct connectdata *conn, const char *key);
+CURLcode Curl_conn_meta_set(struct connectdata *conn,
+                            const struct meta_key *key, void *value);
+void Curl_conn_meta_remove(struct connectdata *conn,
+                           const struct meta_key *key);
+void *Curl_conn_meta_get(struct connectdata *conn,
+                         const struct meta_key *key);
 
 /* Get protocol handler for a URI scheme
  * @param scheme URI scheme, case-insensitive

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -155,6 +155,7 @@ typedef unsigned int curl_prot_t;
 #include "splay.h"
 #include "dynbuf.h"
 #include "dynhds.h"
+#include "meta-hash.h"
 #include "request.h"
 #include "netrc.h"
 
@@ -753,7 +754,7 @@ struct connectdata {
    * with the lifetime of the connection.
    * Elements need to be added with their own destructor to be invoked when
    * the connection is cleaned up (see Curl_hash_add2()).*/
-  struct Curl_hash meta_hash;
+  struct meta_hash meta_hash;
 
   /* 'dns_entry' is the particular host we use. This points to an entry in the
      DNS cache and it will not get pruned while locked. It gets unlocked in
@@ -1870,7 +1871,7 @@ struct Curl_easy {
    * with the lifetime of the easy handle.
    * Elements need to be added with their own destructor to be invoked when
    * the easy handle is cleaned up (see Curl_hash_add2()).*/
-  struct Curl_hash meta_hash;
+  struct meta_hash meta_hash;
 
 #ifdef USE_LIBPSL
   struct PslCache *psl;        /* The associated PSL cache. */

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -48,8 +48,6 @@ my %wl = (
     'Curl_creader_def_read' => 'internal api',
     'Curl_creader_def_total_length' => 'internal api',
     'Curl_meta_reset' => 'internal api',
-    'Curl_meta_str_dtor' => 'internal api',
-    'Curl_meta_str_print' => 'internal api',
     'Curl_trc_dns' => 'internal api',
 );
 

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -48,6 +48,8 @@ my %wl = (
     'Curl_creader_def_read' => 'internal api',
     'Curl_creader_def_total_length' => 'internal api',
     'Curl_meta_reset' => 'internal api',
+    'Curl_meta_str_dtor' => 'internal api',
+    'Curl_meta_str_print' => 'internal api',
     'Curl_trc_dns' => 'internal api',
 );
 


### PR DESCRIPTION
A variation of our hash tables that uses static `meta_key` structs to store/lookup entries. Meta keys define the destructor callback to free values and a "print" function.

Use meta hashes at easy handles and connections to associate values with an easy handle/connection. Store values get auto-destroyed when the easy handle is destroyed or reset or when a connection is freed.

DoH and multi event handling are the first users, but protocols can also make use of this facility. This will
eliminate the `union` of pointers in `connectdata`. 