### PR TITLE
openssl-quic: Add missing include

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -47,6 +47,7 @@
 #include "../http1.h"
 #include "../select.h"
 #include "../inet_pton.h"
+#include "../uint-hash.h"
 #include "vquic.h"
 #include "vquic_int.h"
 #include "vquic-tls.h"


### PR DESCRIPTION
uint_hash, Curl_uint_hash_init and others are used in the file.

Regression of 657aae79c0.