### PR TITLE
Copy missing definition for HTTPSRR_WORKS from asyn-base.c (which may…

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -86,6 +86,13 @@
 #define HAVE_CARES_GETADDRINFO 1
 #endif
 
+#ifdef USE_HTTPSRR
+#if ARES_VERSION < 0x011c00
+#error "requires c-ares 1.28.0 or newer for HTTPSRR"
+#endif
+#define HTTPSRR_WORKS
+#endif
+
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"


### PR DESCRIPTION
… need tidying)

HTTPS RR data retrieved by c-ares was not being saved to relevant struct Curl_dns_entry; 
consequently, TLS session was set up without using ECHConfigList contained in HTTPS RR.

Thanks to sftcd for identifying what needed to be done.

It looks as if definition of HTTPSRR_WORKS in asyn-base.c is never used, so could be removed.
