### PR TITLE
GHA/windows: fixup MSYS2 downgrade step

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -350,7 +350,9 @@ jobs:
         # Downgrade to a known good MSYS2 runtime version to avoid the performance regression
         # causing runtests.pl to run at 2-3x reduced speed.
         run: |
-          [[ "$(uname -a)" = *' 3.5'* ]] && exec /usr/bin/pacman --noconfirm --noprogressbar --upgrade https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.5.4-8-x86_64.pkg.tar.zst
+          if [[ "$(uname -a)" = *' 3.5'* ]]; then
+            exec /usr/bin/pacman --noconfirm --noprogressbar --upgrade https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.5.4-8-x86_64.pkg.tar.zst
+          fi
 
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -522,7 +524,9 @@ jobs:
         # Downgrade to a known good MSYS2 runtime version to avoid the performance regression
         # causing runtests.pl to run at 2-3x reduced speed.
         run: |
-          [[ "$(uname -a)" = *' 3.5'* ]] && exec /usr/bin/pacman --noconfirm --noprogressbar --upgrade https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.5.4-8-x86_64.pkg.tar.zst
+          if [[ "$(uname -a)" = *' 3.5'* ]]; then
+            exec /usr/bin/pacman --noconfirm --noprogressbar --upgrade https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.5.4-8-x86_64.pkg.tar.zst
+          fi
 
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
@@ -998,7 +1002,9 @@ jobs:
         # Downgrade to a known good MSYS2 runtime version to avoid the performance regression
         # causing runtests.pl to run at 2-3x reduced speed.
         run: |
-          [[ "$(uname -a)" = *' 3.5'* ]] && exec /usr/bin/pacman --noconfirm --noprogressbar --upgrade https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.5.4-8-x86_64.pkg.tar.zst
+          if [[ "$(uname -a)" = *' 3.5'* ]]; then
+            exec /usr/bin/pacman --noconfirm --noprogressbar --upgrade https://mirror.msys2.org/msys/x86_64/msys2-runtime-3.5.4-8-x86_64.pkg.tar.zst
+          fi
 
       - name: 'run tests'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}


### PR DESCRIPTION
Fix step failing when 3.6 is detected.
Ref: https://github.com/curl/curl/actions/runs/14620854081/job/41020237740?pr=17157#step:14:8

Follow-up to 20d9d3bcce5efe47ab14e5c9233c2889515fada1 #17151
Follow-up to b06c12b7248592cf001e621d7cd8dc78a827212b #16574
