### PR TITLE
autotools: install shell completion files on cross build

### DIFF
--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -57,9 +57,6 @@ $(FISH_COMPLETION_FUNCTION_FILENAME): completion.pl
 endif
 
 install-data-local:
-if CROSSCOMPILING
-	@echo 'NOTICE: we cannot install completion scripts when cross-compiling'
-else # if not cross-compiling:
 if USE_ZSH_COMPLETION
 	if test -n "$(PERL)"; then \
 	  $(MKDIR_P) $(DESTDIR)$(ZSH_FUNCTIONS_DIR); \
@@ -71,7 +68,6 @@ if USE_FISH_COMPLETION
 	  $(MKDIR_P) $(DESTDIR)$(FISH_FUNCTIONS_DIR); \
 	  $(INSTALL_DATA) $(FISH_COMPLETION_FUNCTION_FILENAME) $(DESTDIR)$(FISH_FUNCTIONS_DIR)/$(FISH_COMPLETION_FUNCTION_FILENAME); \
 	fi
-endif
 endif
 
 distclean:


### PR DESCRIPTION
 Before 8.13.0, it was not possible to generate them as it required
 calling the compiled binary, but this has been fixed.

Forwarding the patch from https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1103938, although the bug mistakenly said this was intentionally done by upstream, Helmut probably missed the fact that 8.13.0 actually solved the root issue, we just need to update the makefiles.

I could not reopen https://github.com/curl/curl/pull/17148, so had to create a new PR.

I've confirmed this solves the issue for autotools build.