### PR TITLE
lib/src/docs/test: improve curl_easy_setopt() calls

### DIFF
--- a/docs/examples/externalsocket.c
+++ b/docs/examples/externalsocket.c
@@ -161,7 +161,7 @@ int main(void)
     /* call this function to set options for the socket */
     curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_callback);
 
-    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1);
+    curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
     res = curl_easy_perform(curl);
 

--- a/docs/examples/ftp-wildcard.c
+++ b/docs/examples/ftp-wildcard.c
@@ -33,10 +33,10 @@ struct callback_data {
 };
 
 static long file_is_coming(struct curl_fileinfo *finfo,
-                           struct callback_data *data,
+                           void *data,
                            int remains);
 
-static long file_is_downloaded(struct callback_data *data);
+static long file_is_downloaded(void *data);
 
 static size_t write_it(char *buff, size_t size, size_t nmemb,
                        void *cb_data);
@@ -93,10 +93,10 @@ int main(int argc, char **argv)
   return (int)rc;
 }
 
-static long file_is_coming(struct curl_fileinfo *finfo,
-                           struct callback_data *data,
+static long file_is_coming(struct curl_fileinfo *finfo, void *input,
                            int remains)
 {
+  struct callback_data *data = input;
   printf("%3d %40s %10luB ", remains, finfo->filename,
          (unsigned long)finfo->size);
 
@@ -128,8 +128,9 @@ static long file_is_coming(struct curl_fileinfo *finfo,
   return CURL_CHUNK_BGN_FUNC_OK;
 }
 
-static long file_is_downloaded(struct callback_data *data)
+static long file_is_downloaded(void *input)
 {
+  struct callback_data *data = input;
   if(data->output) {
     printf("DOWNLOADED\n");
     fclose(data->output);

--- a/docs/examples/ipv6.c
+++ b/docs/examples/ipv6.c
@@ -35,7 +35,7 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
-    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
+    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, (long)CURL_IPRESOLVE_V6);
 
     curl_easy_setopt(curl, CURLOPT_URL, "https://curl.se/");
 

--- a/docs/examples/sftpget.c
+++ b/docs/examples/sftpget.c
@@ -86,7 +86,7 @@ int main(void)
     /* We activate ssh agent. For this to work you need
        to have ssh-agent running (type set | grep SSH_AGENT to check) or
        pageant on Windows (there is an icon in systray if so) */
-    curl_easy_setopt(curl, CURLOPT_SSH_AUTH_TYPES, CURLSSH_AUTH_AGENT);
+    curl_easy_setopt(curl, CURLOPT_SSH_AUTH_TYPES, (long)CURLSSH_AUTH_AGENT);
 #endif
 
     /* Switch on full protocol/debug output */

--- a/docs/examples/sftpuploadresume.c
+++ b/docs/examples/sftpuploadresume.c
@@ -56,10 +56,10 @@ static curl_off_t sftpGetRemoteFileSize(const char *i_remoteFile)
   curl_easy_setopt(curlHandlePtr, CURLOPT_VERBOSE, 1L);
 
   curl_easy_setopt(curlHandlePtr, CURLOPT_URL, i_remoteFile);
-  curl_easy_setopt(curlHandlePtr, CURLOPT_NOPROGRESS, 1);
-  curl_easy_setopt(curlHandlePtr, CURLOPT_NOBODY, 1);
-  curl_easy_setopt(curlHandlePtr, CURLOPT_HEADER, 1);
-  curl_easy_setopt(curlHandlePtr, CURLOPT_FILETIME, 1);
+  curl_easy_setopt(curlHandlePtr, CURLOPT_NOPROGRESS, 1L);
+  curl_easy_setopt(curlHandlePtr, CURLOPT_NOBODY, 1L);
+  curl_easy_setopt(curlHandlePtr, CURLOPT_HEADER, 1L);
+  curl_easy_setopt(curlHandlePtr, CURLOPT_FILETIME, 1L);
 
   result = curl_easy_perform(curlHandlePtr);
   if(CURLE_OK == result) {

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -202,7 +202,7 @@ struct OperationConfig {
                                      0 is valid. default: CURL_HET_DEFAULT. */
   unsigned long timecond;
   HttpReq httpreq;
-  int proxyver;             /* set to CURLPROXY_HTTP* define */
+  long proxyver;             /* set to CURLPROXY_HTTP* define */
   int ftp_ssl_ccc_mode;
   int ftp_filemethod;
   int default_node_flags;   /* default flags to search for each 'node', which

--- a/tests/http/clients/hx-download.c
+++ b/tests/http/clients/hx-download.c
@@ -233,7 +233,7 @@ static int my_progress_cb(void *userdata,
 }
 
 static int setup(CURL *hnd, const char *url, struct transfer *t,
-                 int http_version, struct curl_slist *host,
+                 long http_version, struct curl_slist *host,
                  CURLSH *share, int use_earlydata, int fresh_connect)
 {
   curl_easy_setopt(hnd, CURLOPT_SHARE, share);

--- a/tests/http/clients/hx-upload.c
+++ b/tests/http/clients/hx-upload.c
@@ -252,7 +252,7 @@ static int my_progress_cb(void *userdata,
 }
 
 static int setup(CURL *hnd, const char *url, struct transfer *t,
-                 int http_version, struct curl_slist *host,
+                 long http_version, struct curl_slist *host,
                  CURLSH *share, int use_earlydata, int announce_length)
 {
   curl_easy_setopt(hnd, CURLOPT_SHARE, share);

--- a/tests/http/clients/tls-session-reuse.c
+++ b/tests/http/clients/tls-session-reuse.c
@@ -138,7 +138,7 @@ static size_t write_cb(char *ptr, size_t size, size_t nmemb, void *opaque)
 
 static int add_transfer(CURLM *multi, CURLSH *share,
                         struct curl_slist *resolve,
-                        const char *url, int http_version)
+                        const char *url, long http_version)
 {
   CURL *easy;
   CURLMcode mc;

--- a/tests/http/clients/upload-pausing.c
+++ b/tests/http/clients/upload-pausing.c
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
   struct curl_slist *resolve = NULL;
   char resolve_buf[1024];
   char *url, *host = NULL, *port = NULL;
-  int http_version = CURL_HTTP_VERSION_1_1;
+  long http_version = CURL_HTTP_VERSION_1_1;
   int ch;
 
   while((ch = getopt(argc, argv, "V:")) != -1) {

--- a/tests/libtest/lib1515.c
+++ b/tests/libtest/lib1515.c
@@ -36,7 +36,7 @@
 
 #define TEST_HANG_TIMEOUT 60 * 1000
 
-#define DNS_TIMEOUT 1
+#define DNS_TIMEOUT 1L
 
 static CURLcode do_one_request(CURLM *m, char *URL, char *resolve)
 {

--- a/tests/libtest/lib1525.c
+++ b/tests/libtest/lib1525.c
@@ -75,11 +75,11 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
   test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
   test_setopt(curl, CURLOPT_PROXYHEADER, hhl);
-  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_UNIFIED);
+  test_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_UNIFIED);
   test_setopt(curl, CURLOPT_POST, 0L);
   test_setopt(curl, CURLOPT_UPLOAD, 1L);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  test_setopt(curl, CURLOPT_PROXYTYPE, (long)CURLPROXY_HTTP);
   test_setopt(curl, CURLOPT_HEADER, 1L);
   test_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
   test_setopt(curl, CURLOPT_READFUNCTION, read_callback);

--- a/tests/libtest/lib1526.c
+++ b/tests/libtest/lib1526.c
@@ -78,11 +78,11 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
   test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
   test_setopt(curl, CURLOPT_PROXYHEADER, phl);
-  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
+  test_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_SEPARATE);
   test_setopt(curl, CURLOPT_POST, 0L);
   test_setopt(curl, CURLOPT_UPLOAD, 1L);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  test_setopt(curl, CURLOPT_PROXYTYPE, (long)CURLPROXY_HTTP);
   test_setopt(curl, CURLOPT_HEADER, 1L);
   test_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
   test_setopt(curl, CURLOPT_READFUNCTION, read_callback);

--- a/tests/libtest/lib1527.c
+++ b/tests/libtest/lib1527.c
@@ -80,13 +80,13 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_POST, 0L);
   test_setopt(curl, CURLOPT_UPLOAD, 1L);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  test_setopt(curl, CURLOPT_PROXYTYPE, (long)CURLPROXY_HTTP);
   test_setopt(curl, CURLOPT_HEADER, 1L);
   test_setopt(curl, CURLOPT_WRITEFUNCTION, fwrite);
   test_setopt(curl, CURLOPT_READFUNCTION, read_callback);
   test_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
   test_setopt(curl, CURLOPT_INFILESIZE, (long)strlen(testdata));
-  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_UNIFIED);
+  test_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_UNIFIED);
 
   res = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1528.c
+++ b/tests/libtest/lib1528.c
@@ -57,9 +57,9 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
   test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
   test_setopt(curl, CURLOPT_PROXYHEADER, phl);
-  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
+  test_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_SEPARATE);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  test_setopt(curl, CURLOPT_PROXYTYPE, (long)CURLPROXY_HTTP);
   test_setopt(curl, CURLOPT_HEADER, 1L);
 
   res = curl_easy_perform(curl);

--- a/tests/libtest/lib1529.c
+++ b/tests/libtest/lib1529.c
@@ -49,7 +49,7 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_URL, bURL);
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
-  test_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_HTTP);
+  test_setopt(curl, CURLOPT_PROXYTYPE, (long)CURLPROXY_HTTP);
   test_setopt(curl, CURLOPT_HEADER, 1L);
 
   res = curl_easy_perform(curl);

--- a/tests/libtest/lib1571.c
+++ b/tests/libtest/lib1571.c
@@ -50,7 +50,7 @@ CURLcode test(char *URL)
     test_setopt(curl, CURLOPT_POSTFIELDS, "moo");
   }
   if(testno == 1581) {
-    test_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_301);
+    test_setopt(curl, CURLOPT_POSTREDIR, (long)CURL_REDIR_POST_301);
   }
 
   test_setopt(curl, CURLOPT_CUSTOMREQUEST, "IGLOO");

--- a/tests/libtest/lib1592.c
+++ b/tests/libtest/lib1592.c
@@ -48,7 +48,7 @@ CURLcode test(char *URL)
   CURL *curl = NULL;
   CURLcode res = CURLE_OK;
   CURLMcode mres;
-  int timeout;
+  long timeout;
 
   global_init(CURL_GLOBAL_ALL);
 

--- a/tests/libtest/lib2301.c
+++ b/tests/libtest/lib2301.c
@@ -133,7 +133,7 @@ CURLcode test(char *URL)
     /* use the callback style */
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "webbie-sox/3");
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-    curl_easy_setopt(curl, CURLOPT_WS_OPTIONS, CURLWS_RAW_MODE);
+    curl_easy_setopt(curl, CURLOPT_WS_OPTIONS, (long)CURLWS_RAW_MODE);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writecb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, curl);
     res = curl_easy_perform(curl);

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -103,7 +103,7 @@ test_thread(void *ptr)
 
       curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_memory_callback);
       curl_easy_setopt(curl, CURLOPT_WRITEDATA, ptr);
-      curl_easy_setopt(curl, CURLOPT_VERBOSE, 1);
+      curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
       /* Perform the request, res will get the return code */
       res = curl_easy_perform(curl);

--- a/tests/libtest/lib678.c
+++ b/tests/libtest/lib678.c
@@ -83,7 +83,7 @@ static CURLcode test_cert_blob(const char *url, const char *cafile)
     curl_easy_setopt(curl, CURLOPT_URL,         url);
     curl_easy_setopt(curl, CURLOPT_USERAGENT,   "CURLOPT_CAINFO_BLOB");
     curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS,
-                     CURLSSLOPT_REVOKE_BEST_EFFORT);
+                     (long)CURLSSLOPT_REVOKE_BEST_EFFORT);
 
     blob.data = certdata;
     blob.len = certsize;

--- a/tests/libtest/mk-lib1521.pl
+++ b/tests/libtest/mk-lib1521.pl
@@ -341,6 +341,7 @@ CURLcode test(char *URL)
   curl_mime *mimepost = NULL;
   FILE *stream = stderr;
   struct testdata object;
+  CURLU *curlu = (CURLU *)&object;
   char *charp;
   long val;
   curl_off_t oval;
@@ -495,7 +496,7 @@ MOO
             elsif(($name eq "CURLOPT_POSTFIELDS") ||
                   ($name eq "CURLOPT_COPYPOSTFIELDS")) {
                 # set size to zero to avoid it being "illegal"
-                print $fh "  (void)curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0);\n";
+                print $fh "  (void)curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, 0L);\n";
                 print $fh "${fpref} stringpointerextra);\n$fcheck";
             }
             elsif($name eq "CURLOPT_HTTPPOST") {
@@ -506,6 +507,9 @@ MOO
             }
             elsif($name eq "CURLOPT_STDERR") {
               print $fh "${fpref} stream);\n$fcheck";
+            }
+            elsif($name eq "CURLOPT_CURLU") {
+              print $fh "${fpref} curlu);\n$fcheck";
             }
             else {
               print $fh "${fpref} &object);\n$fcheck";
@@ -595,7 +599,7 @@ MOO
 print $fh <<FOOTER
   )
   /* NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange) */
-  curl_easy_setopt(curl, (CURLoption)1, 0);
+  curl_easy_setopt(curl, (CURLoption)1, 0L);
   res = CURLE_OK;
 test_cleanup:
   curl_easy_cleanup(curl);


### PR DESCRIPTION
Fix invokes where the argument was not the correct type.

Cherry-picked from #17143