### PR TITLE
GHA/windows: limit jobs to 15 minutes

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,7 +39,7 @@ jobs:
   cygwin:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
     runs-on: windows-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
     defaults:
       run:
         shell: D:\cygwin\bin\bash.exe '{0}'
@@ -173,7 +173,7 @@ jobs:
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
     runs-on: ${{ matrix.image || 'windows-latest' }}
-    timeout-minutes: 20
+    timeout-minutes: 15
     defaults:
       run:
         shell: msys2 {0}
@@ -390,7 +390,7 @@ jobs:
   mingw-w64-standalone-downloads:
     name: 'dl-mingw, CM ${{ matrix.ver }}-${{ matrix.env }} ${{ matrix.name }}'
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 15
     defaults:
       run:
         shell: msys2 {0}
@@ -751,7 +751,7 @@ jobs:
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
     runs-on: ${{ matrix.image || 'windows-latest' }}
-    timeout-minutes: 55
+    timeout-minutes: 15
     defaults:
       run:
         shell: msys2 {0}


### PR DESCRIPTION
They typically finish (well) within 10 minutes.

A notable exception was vcpkg jobs when a rebuild was triggered.
With caching lost and reducing them to short builds, this is not
an issue at the moment.

The advantage of shorter timeouts is hung/crashed jobs giving back
control earlier for a manual retry.
