### PR TITLE
build: tidy up internal feature detection variables for wolfSSL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1055,7 +1055,7 @@ if(USE_WOLFSSL)
   curl_openssl_check_exists("wolfSSL_get_peer_certificate" HAVE_WOLFSSL_GET_PEER_CERTIFICATE)
   curl_openssl_check_exists("wolfSSL_UseALPN" HAVE_WOLFSSL_USEALPN)
   curl_openssl_check_exists("wolfSSL_DES_ecb_encrypt" HAVE_WOLFSSL_DES_ECB_ENCRYPT)
-  curl_openssl_check_exists("wolfSSL_BIO_new" HAVE_WOLFSSL_BIO)
+  curl_openssl_check_exists("wolfSSL_BIO_new" HAVE_WOLFSSL_BIO_NEW)
   curl_openssl_check_exists("wolfSSL_BIO_set_shutdown" HAVE_WOLFSSL_FULL_BIO)
 endif()
 
@@ -2179,7 +2179,7 @@ curl_add_if("MultiSSL"      CURL_WITH_MULTI_SSL)
 curl_add_if("HTTPS-proxy"   NOT CURL_DISABLE_PROXY AND _ssl_enabled AND (USE_OPENSSL OR USE_GNUTLS
                             OR USE_SCHANNEL OR USE_RUSTLS OR USE_BEARSSL OR
                             USE_MBEDTLS OR USE_SECTRANSP OR
-                            (USE_WOLFSSL AND HAVE_WOLFSSL_BIO)))
+                            (USE_WOLFSSL AND HAVE_WOLFSSL_BIO_NEW)))
 curl_add_if("Unicode"       ENABLE_UNICODE)
 curl_add_if("threadsafe"    HAVE_ATOMIC OR
                             (USE_THREADS_POSIX AND HAVE_PTHREAD_H) OR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1056,7 +1056,7 @@ if(USE_WOLFSSL)
   curl_openssl_check_exists("wolfSSL_UseALPN" HAVE_WOLFSSL_USEALPN)
   curl_openssl_check_exists("wolfSSL_DES_ecb_encrypt" HAVE_WOLFSSL_DES_ECB_ENCRYPT)
   curl_openssl_check_exists("wolfSSL_BIO_new" HAVE_WOLFSSL_BIO_NEW)
-  curl_openssl_check_exists("wolfSSL_BIO_set_shutdown" HAVE_WOLFSSL_FULL_BIO)
+  curl_openssl_check_exists("wolfSSL_BIO_set_shutdown" HAVE_WOLFSSL_BIO_SET_SHUTDOWN)
 endif()
 
 if(USE_OPENSSL)

--- a/configure.ac
+++ b/configure.ac
@@ -5203,7 +5203,7 @@ if test "x$CURL_DISABLE_NTLM" != "x1"; then
       -o "x$GNUTLS_ENABLED" = "x1" \
       -o "x$SECURETRANSPORT_ENABLED" = "x1" \
       -o "x$USE_WIN32_CRYPTO" = "x1" \
-      -o "x$WOLFSSL_NTLM" = "x1"; then
+      -o "x$HAVE_WOLFSSL_DES_ECB_ENCRYPT" = "x1"; then
     use_curl_ntlm_core=yes
   fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -5247,7 +5247,7 @@ if test "x$CURL_DISABLE_HTTP" != "x1"; then
         -o "x$MBEDTLS_ENABLED" = "x1"; then
       SUPPORT_FEATURES="$SUPPORT_FEATURES HTTPS-proxy"
       AC_MSG_RESULT([yes])
-    elif test "x$WOLFSSL_ENABLED" = "x1" -a "x$WOLFSSL_BIO" = "x1"; then
+    elif test "x$WOLFSSL_ENABLED" = "x1" -a "x$HAVE_WOLFSSL_BIO_NEW" = "x1"; then
       SUPPORT_FEATURES="$SUPPORT_FEATURES HTTPS-proxy"
       AC_MSG_RESULT([yes])
     else

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -487,9 +487,9 @@ Available variables:
 - `HAVE_SSL_SET_QUIC_TLS_CBS`:              `SSL_set_quic_tls_cbs` in OpenSSL.
 - `HAVE_SSL_SET_QUIC_USE_LEGACY_CODEPOINT`: `SSL_set_quic_use_legacy_codepoint` in OpenSSL fork.
 - `HAVE_WOLFSSL_BIO_NEW`:                   `wolfSSL_BIO_new` present in wolfSSL.
+- `HAVE_WOLFSSL_BIO_SET_SHUTDOWN`:          `wolfSSL_BIO_set_shutdown` present in wolfSSL.
 - `HAVE_WOLFSSL_CTX_GENERATEECHCONFIG`:     `wolfSSL_CTX_GenerateEchConfig` present in wolfSSL.
 - `HAVE_WOLFSSL_DES_ECB_ENCRYPT`:           `wolfSSL_DES_ecb_encrypt` present in wolfSSL.
-- `HAVE_WOLFSSL_FULL_BIO`:                  `wolfSSL_BIO_set_shutdown` present in wolfSSL.
 - `HAVE_WOLFSSL_GET_PEER_CERTIFICATE`:      `wolfSSL_get_peer_certificate` present in wolfSSL.
 - `HAVE_WOLFSSL_SET_QUIC_USE_LEGACY_CODEPOINT`:
                                             `wolfSSL_set_quic_use_legacy_codepoint` present in wolfSSL.

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -486,7 +486,7 @@ Available variables:
 - `HAVE_SSL_SET1_ECH_CONFIG_LIST`:          `SSL_set1_ech_config_list` present in OpenSSL (or fork).
 - `HAVE_SSL_SET_QUIC_TLS_CBS`:              `SSL_set_quic_tls_cbs` in OpenSSL.
 - `HAVE_SSL_SET_QUIC_USE_LEGACY_CODEPOINT`: `SSL_set_quic_use_legacy_codepoint` in OpenSSL fork.
-- `HAVE_WOLFSSL_BIO`:                       `wolfSSL_BIO_new` present in wolfSSL.
+- `HAVE_WOLFSSL_BIO_NEW`:                   `wolfSSL_BIO_new` present in wolfSSL.
 - `HAVE_WOLFSSL_CTX_GENERATEECHCONFIG`:     `wolfSSL_CTX_GenerateEchConfig` present in wolfSSL.
 - `HAVE_WOLFSSL_DES_ECB_ENCRYPT`:           `wolfSSL_DES_ecb_encrypt` present in wolfSSL.
 - `HAVE_WOLFSSL_FULL_BIO`:                  `wolfSSL_BIO_set_shutdown` present in wolfSSL.

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -716,7 +716,7 @@ ${SIZEOF_TIME_T_CODE}
 #cmakedefine HAVE_WOLFSSL_BIO_NEW 1
 
 /* if wolfSSL has the wolfSSL_BIO_set_shutdown function. */
-#cmakedefine HAVE_WOLFSSL_FULL_BIO 1
+#cmakedefine HAVE_WOLFSSL_BIO_SET_SHUTDOWN 1
 
 /* if libssh is in use */
 #cmakedefine USE_LIBSSH 1

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -713,7 +713,7 @@ ${SIZEOF_TIME_T_CODE}
 #cmakedefine HAVE_WOLFSSL_DES_ECB_ENCRYPT 1
 
 /* if wolfSSL has the wolfSSL_BIO_new function. */
-#cmakedefine HAVE_WOLFSSL_BIO 1
+#cmakedefine HAVE_WOLFSSL_BIO_NEW 1
 
 /* if wolfSSL has the wolfSSL_BIO_set_shutdown function. */
 #cmakedefine HAVE_WOLFSSL_FULL_BIO 1

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -96,7 +96,7 @@
 #endif
 #endif
 
-#ifdef HAVE_WOLFSSL_BIO
+#ifdef HAVE_WOLFSSL_BIO_NEW
 #define USE_BIO_CHAIN
 #ifdef HAVE_WOLFSSL_FULL_BIO
 #define USE_FULL_BIO
@@ -114,7 +114,7 @@
 #define wolfSSL_BIO_set_retry_read    BIO_set_retry_read
 #endif /* !WOLFSSL_BIO_CTRL_GET_CLOSE */
 
-#else /* HAVE_WOLFSSL_BIO */
+#else /* HAVE_WOLFSSL_BIO_NEW */
 #undef USE_BIO_CHAIN
 #endif
 

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -98,9 +98,9 @@
 
 #ifdef HAVE_WOLFSSL_BIO_NEW
 #define USE_BIO_CHAIN
-#ifdef HAVE_WOLFSSL_FULL_BIO
+#ifdef HAVE_WOLFSSL_BIO_SET_SHUTDOWN
 #define USE_FULL_BIO
-#else /* HAVE_WOLFSSL_FULL_BIO */
+#else /* HAVE_WOLFSSL_BIO_SET_SHUTDOWN */
 #undef USE_FULL_BIO
 #endif
 /* wolfSSL 5.7.4 and older do not have these symbols, but only the

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -143,7 +143,7 @@ if test "x$OPT_WOLFSSL" != xno; then
       dnl if this symbol is present, we want the include path to include the
       dnl OpenSSL API root as well
       if test "x$ac_cv_func_wolfSSL_DES_ecb_encrypt" = 'xyes'; then
-        WOLFSSL_NTLM=1
+        HAVE_WOLFSSL_DES_ECB_ENCRYPT=1
       fi
 
       dnl if this symbol is present, we can make use of BIO filter chains

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -138,7 +138,8 @@ if test "x$OPT_WOLFSSL" != xno; then
       AC_CHECK_FUNCS(wolfSSL_get_peer_certificate \
                      wolfSSL_UseALPN \
                      wolfSSL_DES_ecb_encrypt \
-                     wolfSSL_BIO_new)
+                     wolfSSL_BIO_new \
+                     wolfSSL_BIO_set_shutdown)
 
       dnl if this symbol is present, we want the include path to include the
       dnl OpenSSL API root as well
@@ -152,13 +153,9 @@ if test "x$OPT_WOLFSSL" != xno; then
       fi
 
       dnl if this symbol is present, we have the full BIO feature set
-      AC_CHECK_FUNC(wolfSSL_BIO_set_shutdown,
-        [
-          AC_DEFINE(HAVE_WOLFSSL_FULL_BIO, 1,
-                    [if you have wolfSSL_BIO_set_shutdown])
-          WOLFSSL_FULL_BIO=1
-        ]
-        )
+      if test "x$ac_cv_func_wolfSSL_BIO_set_shutdown" = 'xyes'; then
+        WOLFSSL_FULL_BIO=1
+      fi
 
       if test -n "$wolfssllibpath"; then
         dnl when shared libs were found in a path that the run-time

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -136,17 +136,14 @@ if test "x$OPT_WOLFSSL" != xno; then
       dnl DES* is needed for NTLM support and lives in the OpenSSL compatibility
       dnl layer
       AC_CHECK_FUNCS(wolfSSL_get_peer_certificate \
-                     wolfSSL_UseALPN )
+                     wolfSSL_UseALPN \
+                     wolfSSL_DES_ecb_encrypt)
 
       dnl if this symbol is present, we want the include path to include the
       dnl OpenSSL API root as well
-      AC_CHECK_FUNC(wolfSSL_DES_ecb_encrypt,
-        [
-          AC_DEFINE(HAVE_WOLFSSL_DES_ECB_ENCRYPT, 1,
-                    [if you have wolfSSL_DES_ecb_encrypt])
-          WOLFSSL_NTLM=1
-        ]
-        )
+      if test "x$ac_cv_func_wolfSSL_DES_ecb_encrypt" = 'xyes'; then
+        WOLFSSL_NTLM=1
+      fi
 
       dnl if this symbol is present, we can make use of BIO filter chains
       AC_CHECK_FUNC(wolfSSL_BIO_new,

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -137,7 +137,8 @@ if test "x$OPT_WOLFSSL" != xno; then
       dnl layer
       AC_CHECK_FUNCS(wolfSSL_get_peer_certificate \
                      wolfSSL_UseALPN \
-                     wolfSSL_DES_ecb_encrypt)
+                     wolfSSL_DES_ecb_encrypt \
+                     wolfSSL_BIO_new)
 
       dnl if this symbol is present, we want the include path to include the
       dnl OpenSSL API root as well
@@ -146,13 +147,10 @@ if test "x$OPT_WOLFSSL" != xno; then
       fi
 
       dnl if this symbol is present, we can make use of BIO filter chains
-      AC_CHECK_FUNC(wolfSSL_BIO_new,
-        [
-          AC_DEFINE(HAVE_WOLFSSL_BIO, 1,
-                    [if you have wolfSSL_BIO_new])
-          WOLFSSL_BIO=1
-        ]
-        )
+      if test "x$ac_cv_func_wolfSSL_BIO_new" = 'xyes'; then
+        WOLFSSL_BIO=1
+      fi
+
       dnl if this symbol is present, we have the full BIO feature set
       AC_CHECK_FUNC(wolfSSL_BIO_set_shutdown,
         [

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -135,6 +135,7 @@ if test "x$OPT_WOLFSSL" != xno; then
       dnl wolfSSL needs configure --enable-opensslextra to have *get_peer*
       dnl DES* is needed for NTLM support and lives in the OpenSSL compatibility
       dnl layer
+      dnl if wolfSSL_BIO_set_shutdown is present, we have the full BIO feature set
       AC_CHECK_FUNCS(wolfSSL_get_peer_certificate \
                      wolfSSL_UseALPN \
                      wolfSSL_DES_ecb_encrypt \
@@ -150,11 +151,6 @@ if test "x$OPT_WOLFSSL" != xno; then
       dnl if this symbol is present, we can make use of BIO filter chains
       if test "x$ac_cv_func_wolfSSL_BIO_new" = 'xyes'; then
         HAVE_WOLFSSL_BIO_NEW=1
-      fi
-
-      dnl if this symbol is present, we have the full BIO feature set
-      if test "x$ac_cv_func_wolfSSL_BIO_set_shutdown" = 'xyes'; then
-        WOLFSSL_FULL_BIO=1
       fi
 
       if test -n "$wolfssllibpath"; then

--- a/m4/curl-wolfssl.m4
+++ b/m4/curl-wolfssl.m4
@@ -148,7 +148,7 @@ if test "x$OPT_WOLFSSL" != xno; then
 
       dnl if this symbol is present, we can make use of BIO filter chains
       if test "x$ac_cv_func_wolfSSL_BIO_new" = 'xyes'; then
-        WOLFSSL_BIO=1
+        HAVE_WOLFSSL_BIO_NEW=1
       fi
 
       dnl if this symbol is present, we have the full BIO feature set


### PR DESCRIPTION
Sync them with the function name they detect, and sync them between
cmake and autotools.

- rename `HAVE_WOLFSSL_BIO` to `HAVE_WOLFSSL_BIO_NEW`.
- rename `HAVE_WOLFSSL_FULL_BIO` to `HAVE_WOLFSSL_BIO_SET_SHUTDOWN`.
- autotools: rename `WOLFSSL_NTLM` to `HAVE_WOLFSSL_DES_ECB_ENCRYPT`
  (to sync with cmake).
- autotools: rename `WOLFSSL_BIO` to `HAVE_WOLFSSL_BIO_NEW`
  (to sync with cmake).
- autotools: simplify `HAVE_WOLFSSL_DES_ECB_ENCRYPT` detection.

Cherry-picked from #17082
