### PR TITLE
tool_getparam: allow a blank --aws-sigv4

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -676,8 +676,9 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data)
    * AWS is the default because most of non-amazon providers
    * are still using aws:amz as a prefix.
    */
-  line = data->set.str[STRING_AWS_SIGV4] ?
-    data->set.str[STRING_AWS_SIGV4] : "aws:amz";
+  line = data->set.str[STRING_AWS_SIGV4];
+  if(!line || !*line)
+    line = "aws:amz";
 
   /* provider0[:provider1[:region[:service]]]
 

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2005,7 +2005,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       break;
     case C_AWS_SIGV4: /* --aws-sigv4 */
       config->authtype |= CURLAUTH_AWS_SIGV4;
-      err = getstr(&config->aws_sigv4, nextarg, DENY_BLANK);
+      err = getstr(&config->aws_sigv4, nextarg, ALLOW_BLANK);
       break;
     case C_STDERR: /* --stderr */
       tool_set_stderr_file(global, nextarg);


### PR DESCRIPTION
make sure a zero length sigv4 gets the default value

Reported-by: Arian van Putten
Fixes #17176