### PR TITLE
tests/buildinfo: former "disabled" now provides more info

### DIFF
--- a/tests/server/.gitignore
+++ b/tests/server/.gitignore
@@ -4,8 +4,7 @@
 
 server_bundle.c
 servers
-
-disabled
+buildinfo
 mqttd
 resolve
 rtspd

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -22,7 +22,7 @@
 #
 ###########################################################################
 
-SERVERPROGS = resolve rtspd sockfilt sws tftpd socksd disabled mqttd dnsd
+SERVERPROGS = resolve rtspd sockfilt sws tftpd socksd buildinfo mqttd dnsd
 
 MEMDEBUG = \
   ../../lib/memdebug.c \
@@ -123,4 +123,4 @@ dnsd_SOURCES = $(MEMDEBUG) $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
 dnsd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 dnsd_CFLAGS = $(AM_CFLAGS)
 
-disabled_SOURCES = disabled.c
+buildinfo_SOURCES = buildinfo.c

--- a/tests/server/buildinfo.c
+++ b/tests/server/buildinfo.c
@@ -38,87 +38,195 @@
 #include <stdio.h>
 
 static const char *disabled[]={
+  "bindlocal: "
 #ifdef CURL_DISABLE_BINDLOCAL
-  "bindlocal",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+
+  "cookies: "
 #ifdef CURL_DISABLE_COOKIES
-  "cookies",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+
+  "basic-auth: "
 #ifdef CURL_DISABLE_BASIC_AUTH
-  "basic-auth",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "bearer-auth: "
 #ifdef CURL_DISABLE_BEARER_AUTH
-  "bearer-auth",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "digest-auth: "
 #ifdef CURL_DISABLE_DIGEST_AUTH
-  "digest-auth",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "negotiate-auth: "
 #ifdef CURL_DISABLE_NEGOTIATE_AUTH
-  "negotiate-auth",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "aws: "
 #ifdef CURL_DISABLE_AWS
-  "aws",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "DoH: "
 #ifdef CURL_DISABLE_DOH
-  "DoH",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "HTTP-auth: "
 #ifdef CURL_DISABLE_HTTP_AUTH
-  "HTTP-auth",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "Mime: "
 #ifdef CURL_DISABLE_MIME
-  "Mime",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+
+  "netrc: "
 #ifdef CURL_DISABLE_NETRC
-  "netrc",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "parsedate: "
 #ifdef CURL_DISABLE_PARSEDATE
-  "parsedate",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "proxy: "
 #ifdef CURL_DISABLE_PROXY
-  "proxy",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "shuffle-dns: "
 #ifdef CURL_DISABLE_SHUFFLE_DNS
-  "shuffle-dns",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "typecheck: "
 #ifdef CURL_DISABLE_TYPECHECK
-  "typecheck",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "verbose-strings: "
 #ifdef CURL_DISABLE_VERBOSE_STRINGS
-  "verbose-strings",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "wakeup: "
 #ifndef ENABLE_WAKEUP
-  "wakeup",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "headers-api: "
 #ifdef CURL_DISABLE_HEADERS_API
-  "headers-api",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "xattr: "
 #ifndef USE_XATTR
-  "xattr",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "form-api: "
 #ifdef CURL_DISABLE_FORM_API
-  "form-api",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "large-time: "
 #if (SIZEOF_TIME_T < 5)
-  "large-time",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "large-size: "
 #if (SIZEOF_SIZE_T < 5)
-  "large-size",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
+  "sha512-256: "
 #ifndef CURL_HAVE_SHA512_256
-  "sha512-256",
+  "OFF"
+#else
+  "ON"
 #endif
-#ifdef _WIN32
-#if defined(CURL_WINDOWS_UWP) || \
-  defined(CURL_DISABLE_CA_SEARCH) || defined(CURL_CA_SEARCH_SAFE)
-  "win32-ca-searchpath",
+  ,
+
+  "win32-ca-searchpath: "
+#if !defined(_WIN32) ||                                                 \
+  (defined(CURL_WINDOWS_UWP) ||                                         \
+   defined(CURL_DISABLE_CA_SEARCH) || defined(CURL_CA_SEARCH_SAFE))
+  "OFF"
+#else
+  "ON"
 #endif
-#ifndef CURL_CA_SEARCH_SAFE
-  "win32-ca-search-safe",
+  ,
+  "win32-ca-search-safe: "
+#if !defined(_WIN32) || !defined(CURL_CA_SEARCH_SAFE)
+  "OFF"
+#else
+  "ON"
 #endif
-#endif
+  ,
+
+  "--libcurl: "
 #ifdef CURL_DISABLE_LIBCURL_OPTION
-  "--libcurl",
+  "OFF"
+#else
+  "ON"
 #endif
+  ,
   NULL
 };
 


### PR DESCRIPTION
This tool now contains ON/OFF information about features in the build. This way, runtests gets both positive and negative feature presence with this. Allows for more flexibility and avoids having to duplicate the names.