### PR TITLE
cmake: use `CMAKE_COMPILE_WARNING_AS_ERROR` if available

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -957,7 +957,7 @@ jobs:
 
       - name: 'build'
         timeout-minutes: 5
-        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5
+        run: cmake --build bld --config '${{ matrix.type }}' --parallel 5 --verbose
 
       - name: 'curl version'
         timeout-minutes: 1

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -27,10 +27,14 @@ set(_picky "")
 set(_picky_nocheck "")  # not to pass to feature checks
 
 if(CURL_WERROR)
-  if(MSVC)
-    list(APPEND _picky_nocheck "-WX")
-  else()  # llvm/clang and gcc style options
-    list(APPEND _picky_nocheck "-Werror")
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
+    set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
+  else()
+    if(MSVC)
+      list(APPEND _picky_nocheck "-WX")
+    else()  # llvm/clang and gcc style options
+      list(APPEND _picky_nocheck "-Werror")
+    endif()
   endif()
 
   if((CMAKE_C_COMPILER_ID STREQUAL "GNU" AND

--- a/appveyor.sh
+++ b/appveyor.sh
@@ -86,13 +86,22 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     false
   fi
   echo 'curl_config.h'; grep -F '#define' _bld/lib/curl_config.h | sort || true
+  if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2013' ]; then
+    options=''
+  else
+    options='--verbose'
+  fi
   # shellcheck disable=SC2086
-  if ! time cmake --build _bld --config "${PRJ_CFG}" --parallel 2 -- ${BUILD_OPT:-}; then
+  if ! time cmake --build _bld --config "${PRJ_CFG}" --parallel 2 ${options} -- ${BUILD_OPT:-}; then
     if [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ]; then
       find . -name BuildLog.htm -exec dos2unix '{}' +
       find . -name BuildLog.htm -exec cat '{}' +
     fi
     false
+  fi
+  if [ "${PRJ_GEN}" = 'Visual Studio 9 2008' ]; then
+    find . -name BuildLog.htm -exec dos2unix '{}' +
+    find . -name BuildLog.htm -exec cat '{}' +
   fi
   [ "${SHARED}" = 'ON' ] && PATH="$PWD/_bld/lib/${PRJ_CFG}:$PATH"
   [ "${OPENSSL}" = 'ON' ] && { PATH="${openssl_root}:$PATH"; cp "${openssl_root}"/*.dll "_bld/src/${PRJ_CFG}"; }


### PR DESCRIPTION
Red: https://cmake.org/cmake/help/latest/variable/CMAKE_COMPILE_WARNING_AS_ERROR.html#variable:CMAKE_COMPILE_WARNING_AS_ERROR
