### PR TITLE
tool_paramhlp: avoid integer overflow in secs2ms()

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -328,7 +328,7 @@ ParameterError secs2ms(long *valp, const char *str)
   const unsigned int digs[] = { 1, 10, 100, 1000, 10000, 1000000,
     1000000, 10000000, 100000000 };
   if(!str ||
-     curlx_str_number(&str, &secs, CURL_OFF_T_MAX/100))
+     curlx_str_number(&str, &secs, LONG_MAX/1000 - 1))
     return PARAM_BAD_NUMERIC;
   if(!curlx_str_single(&str, '.')) {
     curl_off_t fracs;

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -107,7 +107,7 @@ test709 test710 test711 test712 test713 test714 test715 test716 test717 \
 test718 test719 test720 test721 test722 test723 test724 test725 test726 \
 test727 test728 test729 test730 test731 test732 test733 test734 test735 \
 test736 test737 test738 test739 test740 test741 test742 test743 test744 \
-test745 \
+test745 test746 \
 \
 test780 test781 test782 test783 test784 test785 test786 test787 test788 \
 test789 test790 test791 \

--- a/tests/data/test746
+++ b/tests/data/test746
@@ -25,7 +25,11 @@ http://neverused.example/ -m 22222242222222222
 </errorcode>
 <stderr mode="text">
 curl: option -m: expected a proper numerical parameter
+%if manual
 curl: try 'curl --help' or 'curl --manual' for more information
+%else
+curl: try 'curl --help' for more information
+%endif
 </stderr>
 </verify>
 </testcase>

--- a/tests/data/test746
+++ b/tests/data/test746
@@ -1,0 +1,31 @@
+<testcase>
+<info>
+<keywords>
+cmdline
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<name>
+too large numerical value passed to -m
+</name>
+<command>
+http://neverused.example/ -m 22222242222222222
+</command>
+</client>
+
+<verify>
+<errorcode>
+2
+</errorcode>
+<stderr mode="text">
+curl: option -m: expected a proper numerical parameter
+curl: try 'curl --help' or 'curl --manual' for more information
+</stderr>
+</verify>
+</testcase>


### PR DESCRIPTION
The previous approach was wrong and could lead to wrong timeout values getting used.

Reported-by: bsr13 on hackerone