### PR TITLE
Fix FTP accept connect

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -2182,6 +2182,7 @@ static CURLcode cf_tcp_accept_connect(struct Curl_cfilter *cf,
     if(error)
       return CURLE_ABORTED_BY_CALLBACK;
   }
+  *done = TRUE;
   return CURLE_OK;
 }
 


### PR DESCRIPTION
When cf_tcp_accept_connect() is called and it sets up a connection it never indicates to the caller that the it's done.