### PR TITLE
buildinfo: move from tests/server/ to src/, call it curlinfo

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -94,6 +94,7 @@ add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
 
 add_executable(
   curlinfo
+  EXCLUDE_FROM_ALL
   curlinfo.c
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,11 @@ target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
 
+add_executable(
+  curlinfo
+  curlinfo.c
+)
+
 add_library(
   curltool  # special libcurltool library just for unittests
   STATIC

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -63,7 +63,7 @@ endif
 
 AM_LDFLAGS =
 if USE_UNICODE
-AM_LDFLAGS += -municode
+UNICODEFLAG = -municode
 endif
 
 include Makefile.inc
@@ -93,7 +93,7 @@ curl_SOURCES += $(CURL_RCFILES)
 $(CURL_RCFILES): tool_version.h
 endif
 
-curl_LDFLAGS = $(AM_LDFLAGS) $(CURL_LDFLAGS_BIN)
+curl_LDFLAGS = $(AM_LDFLAGS) $(CURL_LDFLAGS_BIN) $(UNICODEFLAG)
 
 # This might hold -Werror
 CFLAGS += @CURL_CFLAG_EXTRAS@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,9 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 
 bin_PROGRAMS = curl
 
+curlinfo_SOURCES = curlinfo.c
+noinst_PROGRAMS = curlinfo
+
 if USE_CPPFLAG_CURL_STATICLIB
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif

--- a/src/curlinfo.c
+++ b/src/curlinfo.c
@@ -24,7 +24,7 @@
 
 /*
  * The purpose of this tool is to figure out which, if any, features that are
- * disabled which should otherwise exist and work. These aren't visible in
+ * disabled which should otherwise exist and work. These are not visible in
  * regular curl -V output.
  *
  * Disabled protocols are visible in curl_version_info() and are not included

--- a/src/curlinfo.c
+++ b/src/curlinfo.c
@@ -230,7 +230,20 @@ static const char *disabled[]={
   NULL
 };
 
+/*
+** curlinfo main function.
+*/
+#if defined(_UNICODE) && !defined(UNDER_CE)
+#if defined(__GNUC__) || defined(__clang__)
+/* GCC does not know about wmain() */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#pragma GCC diagnostic ignored "-Wmissing-declarations"
+#endif
+int wmain(int argc, wchar_t *argv[])
+#else
 int main(int argc, char **argv)
+#endif
 {
   int i;
 
@@ -242,3 +255,9 @@ int main(int argc, char **argv)
 
   return 0;
 }
+
+#if defined(_UNICODE) && !defined(UNDER_CE)
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+#endif

--- a/src/curlinfo.c
+++ b/src/curlinfo.c
@@ -230,20 +230,7 @@ static const char *disabled[]={
   NULL
 };
 
-/*
-** curlinfo main function.
-*/
-#if defined(_UNICODE) && !defined(UNDER_CE)
-#if defined(__GNUC__) || defined(__clang__)
-/* GCC does not know about wmain() */
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-#pragma GCC diagnostic ignored "-Wmissing-declarations"
-#endif
-int wmain(int argc, wchar_t *argv[])
-#else
 int main(int argc, char **argv)
-#endif
 {
   int i;
 
@@ -255,9 +242,3 @@ int main(int argc, char **argv)
 
   return 0;
 }
-
-#if defined(_UNICODE) && !defined(UNDER_CE)
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,7 +30,9 @@ mark_as_advanced(TEST_NGHTTPX)
 configure_file("config.in" "${CMAKE_CURRENT_BINARY_DIR}/config" @ONLY)
 
 add_custom_target(testdeps)
-add_dependencies(testdeps curlinfo)
+if(BUILD_CURL_EXE)
+  add_dependencies(testdeps curlinfo)
+endif()
 
 add_subdirectory(http)
 add_subdirectory(http/clients)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,8 @@ mark_as_advanced(TEST_NGHTTPX)
 configure_file("config.in" "${CMAKE_CURRENT_BINARY_DIR}/config" @ONLY)
 
 add_custom_target(testdeps)
+add_dependencies(testdeps curlinfo)
+
 add_subdirectory(http)
 add_subdirectory(http/clients)
 add_subdirectory(server)

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -37,6 +37,7 @@ BEGIN {
         $anyway
         $automakestyle
         $CURL
+        $CURLINFO
         $CURLVERSION
         $CURLVERNUM
         $DATE
@@ -114,7 +115,11 @@ our $UNITDIR=dirsepadd("./unit/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
 our $TUNITDIR=dirsepadd("./tunit/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
 our $SRVDIR=dirsepadd("./server/" . ($ENV{'CURL_DIRSUFFIX'} || ''));
 our $TESTDIR="$srcdir/data";
-our $CURL=dirsepadd("../src/" . ($ENV{'CURL_DIRSUFFIX'} || '')) . "curl".exe_ext('TOOL'); # what curl binary to run on the tests
+our $CURL=dirsepadd("../src/" . ($ENV{'CURL_DIRSUFFIX'} || '')) .
+    "curl".exe_ext('TOOL'); # what curl binary to run on the tests
+our $CURLINFO=dirsepadd("../src/" . ($ENV{'CURL_DIRSUFFIX'} || '')) .
+    "curlinfo".exe_ext('TOOL'); # what curlinfo binary to run on the tests
+
 our $VCURL=$CURL;  # what curl binary to use to verify the servers with
                    # VCURL is handy to set to the system one when the one you
                    # just built hangs or crashes and thus prevent verification

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -518,7 +518,7 @@ sub checksystemfeatures {
     @version = <$versout>;
     close($versout);
 
-    open(my $disabledh, "-|", server_exe('buildinfo', 'TOOL'));
+    open(my $disabledh, "-|", exerunner() . shell_quote($CURLINFO));
     while(<$disabledh>) {
         if($_ =~ /([^:]*): ([ONF]*)/) {
             my ($val, $toggle) = ($1, $2);

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -22,7 +22,7 @@
 #
 ###########################################################################
 
-SERVERPROGS = resolve rtspd sockfilt sws tftpd socksd buildinfo mqttd dnsd
+SERVERPROGS = resolve rtspd sockfilt sws tftpd socksd mqttd dnsd
 
 MEMDEBUG = \
   ../../lib/memdebug.c \
@@ -122,5 +122,3 @@ dnsd_SOURCES = $(MEMDEBUG) $(CURLX_SRCS) $(CURLX_HDRS) $(UTIL) \
   dnsd.c
 dnsd_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 dnsd_CFLAGS = $(AM_CFLAGS)
-
-buildinfo_SOURCES = buildinfo.c

--- a/tests/test1165.pl
+++ b/tests/test1165.pl
@@ -87,13 +87,18 @@ sub scan_cmake_config_h {
     scanconf_cmake(\%disable_cmake_config_h, "$root/lib/curl_config.h.cmake");
 }
 
+my %whitelisted = ("CURL_DISABLE_TYPECHECK" => 1);
+
 sub scan_file {
     my ($source)=@_;
     open F, "<$source";
     while(<F>) {
         while(s/(CURL_DISABLE_[A-Z0-9_]+)//) {
             my ($sym)=($1);
-            $file{$sym} = $source;
+
+            if(!$whitelisted{$sym}) {
+                $file{$sym} = $source;
+            }
         }
     }
     close F;


### PR DESCRIPTION
Since a16485a42ea5dabe6c, the test servers build with a different set of options than the tool/lib - for example a different CURLDEBUG. To make buildinfo better reflect the curl build, move it to src/ and build it here using the local CURLDEBUG.

I chose src/ and not lib/ because the file also uses tool-specific headers.