### PR TITLE
A couple of very basic ECH tests

### DIFF
--- a/docs/ECH.md
+++ b/docs/ECH.md
@@ -476,3 +476,21 @@ and then reuse that in another invocation.
 
 Both our OpenSSL fork and BoringSSL/AWS-LC have APIs for both controlling GREASE
 and accessing and logging ``retry_configs``, it seems wolfSSL has neither.
+
+### Testing ECH
+
+We don't yet have a robust test setup for ECH as that requires an ECH-enabled
+test server.
+
+We have added two basic tests though, aiming to ensure that the client sends a
+GREASE'd or real ECH extension when requested, and reacts correctly to the
+failure of ECH in the latter case. (Given that `stunnel` doesn't support ECH.)
+
+As with other similar tests, those tests require the `stunnel` tool be
+installed. On Ubuntu `sudo apt install stunnel4` achieves that.
+
+The test cases are:
+
+- data/test4000: GREASE ECH, expected result: connection succeeds
+- data/test4001: real ECH, connection fails with error 101 (ech required)
+

--- a/docs/ECH.md
+++ b/docs/ECH.md
@@ -479,12 +479,12 @@ and accessing and logging ``retry_configs``, it seems wolfSSL has neither.
 
 ### Testing ECH
 
-We don't yet have a robust test setup for ECH as that requires an ECH-enabled
+We have yet to add a robust test setup for ECH as that requires an ECH-enabled
 test server.
 
 We have added two basic tests though, aiming to ensure that the client sends a
-GREASE'd or real ECH extension when requested, and reacts correctly to the
-failure of ECH in the latter case. (Given that `stunnel` doesn't support ECH.)
+GREASE or real ECH extension when requested, and reacts correctly to the
+failure of ECH in the latter case. (Given that `stunnel` has no ECH support.)
 
 As with other similar tests, those tests require the `stunnel` tool be
 installed. On Ubuntu `sudo apt install stunnel4` achieves that.
@@ -492,5 +492,4 @@ installed. On Ubuntu `sudo apt install stunnel4` achieves that.
 The test cases are:
 
 - data/test4000: GREASE ECH, expected result: connection succeeds
-- data/test4001: real ECH, connection fails with error 101 (ech required)
-
+- data/test4001: real ECH, connection fails with error 101 (ECH required)

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1011,7 +1011,7 @@ cleanup:
   /* if we base64 decoded, we can free now */
   if(data->set.tls_ech & CURLECH_CLA_CFG
        && data->set.str[STRING_ECH_CONFIG]) {
-      Curl_dyn_free(ech_config);
+      free(ech_config);
   }
   if(dns) {
     Curl_resolv_unlink(data, &dns);

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -961,8 +961,7 @@ init_config_builder_ech(struct Curl_easy *data,
     return CURLE_OK;
   }
 
-  if(data->set.tls_ech & CURLECH_CLA_CFG
-       && data->set.str[STRING_ECH_CONFIG]) {
+  if(data->set.tls_ech & CURLECH_CLA_CFG && data->set.str[STRING_ECH_CONFIG]) {
     const char *b64 = data->set.str[STRING_ECH_CONFIG];
     size_t decode_result;
     if(!b64) {
@@ -1009,8 +1008,7 @@ init_config_builder_ech(struct Curl_easy *data,
   }
 cleanup:
   /* if we base64 decoded, we can free now */
-  if(data->set.tls_ech & CURLECH_CLA_CFG
-       && data->set.str[STRING_ECH_CONFIG]) {
+  if(data->set.tls_ech & CURLECH_CLA_CFG && data->set.str[STRING_ECH_CONFIG]) {
       free(ech_config);
   }
   if(dns) {

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1009,7 +1009,7 @@ init_config_builder_ech(struct Curl_easy *data,
 cleanup:
   /* if we base64 decoded, we can free now */
   if(data->set.tls_ech & CURLECH_CLA_CFG && data->set.str[STRING_ECH_CONFIG]) {
-      free(ech_config);
+    free(ech_config);
   }
   if(dns) {
     Curl_resolv_unlink(data, &dns);

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1008,6 +1008,11 @@ init_config_builder_ech(struct Curl_easy *data,
     goto cleanup;
   }
 cleanup:
+  /* if we base64 decoded, we can free now */
+  if(data->set.tls_ech & CURLECH_CLA_CFG
+       && data->set.str[STRING_ECH_CONFIG]) {
+      Curl_dyn_free(ech_config);
+  }
   if(dns) {
     Curl_resolv_unlink(data, &dns);
   }

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1352,9 +1352,7 @@ CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
       goto out;
     }
     if(data->set.tls_ech == CURLECH_GREASE) {
-      infof(data, "ECH: GREASE'd ECH not yet supported for wolfSSL");
-      result = CURLE_SSL_CONNECT_ERROR;
-      goto out;
+      infof(data, "ECH: GREASE is done by default by wolfSSL: no need to ask");
     }
     if(data->set.tls_ech & CURLECH_CLA_CFG
        && data->set.str[STRING_ECH_CONFIG]) {

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -275,6 +275,8 @@ test3032 \
 test3100 test3101 test3102 test3103 test3104 test3105 \
 \
 test3200 test3201 test3202 test3203 test3204 test3205 test3207 test3208 \
-test3209 test3210 test3211 test3212 test3213
+test3209 test3210 test3211 test3212 test3213 \
+\
+test4000 test4001
 
 EXTRA_DIST = $(TESTCASES) DISABLED

--- a/tests/data/test4000
+++ b/tests/data/test4000
@@ -1,0 +1,51 @@
+<testcase>
+<info>
+<keywords>
+ECH GREASE
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 7
+
+MooMoo
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+ECH
+</features>
+<server>
+https
+</server>
+<name>
+HTTPS GET with ECH GREASE
+</name>
+# Using '-k' over '--insecure' to also test the short form
+# Add ECH grease
+<command>
+--ech grease -k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/data/test4001
+++ b/tests/data/test4001
@@ -1,0 +1,38 @@
+<testcase>
+<info>
+<keywords>
+ECH try real and fail
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+ECH
+</features>
+<server>
+https
+</server>
+<name>
+Make real ECH attempt and fail with "ech required" error (101)
+</name>
+# Using '-k' over '--insecure' to also test the short form
+<command>
+--ech ecl:AEv+DQBHdAAgACCCU49qdxKOUXJPs3wlsM06v/t42sMH5xQOL37MAd3HaAAEAAEAAQAYb3RoZXJwdWJsaWMudGVzdC5kZWZvLmllAAA= -k https://%HOSTIP:%HTTPSPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+101
+</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test4001
+++ b/tests/data/test4001
@@ -32,7 +32,11 @@ Make real ECH attempt and fail with "ech required" error (101)
 # Verify data after the test has been "shot"
 <verify>
 <errorcode>
+%if !wolfssl
 101
+%else
+35
+%endif
 </errorcode>
 </verify>
 </testcase>

--- a/tests/data/test4001
+++ b/tests/data/test4001
@@ -33,7 +33,11 @@ Make real ECH attempt and fail with "ech required" error (101)
 <verify>
 <errorcode>
 %if !wolfssl
+%if !rustls
 101
+$else
+35
+%endif
 %else
 35
 %endif

--- a/tests/data/test4001
+++ b/tests/data/test4001
@@ -35,7 +35,7 @@ Make real ECH attempt and fail with "ech required" error (101)
 %if !wolfssl
 %if !rustls
 101
-$else
+%else
 35
 %endif
 %else

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -710,6 +710,7 @@ sub checksystemfeatures {
             # Thread-safe init
             $feature{"threadsafe"} = $feat =~ /threadsafe/i;
             $feature{"HTTPSRR"} = $feat =~ /HTTPSRR/;
+            $feature{"ECH"} = $feat =~ /ECH/;
         }
         #
         # Test harness currently uses a non-stunnel server in order to


### PR DESCRIPTION
We don't have any built-in tests for ECH, mostly due to the lack of an ECH-enabled TLS server, which'd be a lot of effort to get working, until e.g. there's an upstream Apache that supports ECH. We have seen a couple of times where the ECH functionality has been broken due to other changes.

This PR adds two very basic ECH tests:

1) emit a GREASE'd ECH and check the TLS session succeeds as usual,
2) make a real ECH attempt and check that the session fails as expected (error 101, "ech required")

The tests need `stunnel` installed to run.

I'm not sure how useful these may be in terms of detecting when other changes break ECH, but I guess it's a start. Happy to add more tests that'd improve that if people have ideas.

For no, particular reason, I chose test numbers 4000 and 4001 but if using some other numbers is better, happy to make the change.  