### PR TITLE
cmake: honor individual picky option overrides found in `CMAKE_C_FLAGS`

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -198,7 +198,6 @@ if(PICKY_COMPILER)
         list(APPEND _picky_enable
           -Wjump-misses-init               #             gcc  4.5
         )
-
         if(MINGW)
           list(APPEND _picky_enable
             -Wno-pedantic-ms-format        #             gcc  4.5 (MinGW-only)

--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -245,9 +245,18 @@ if(PICKY_COMPILER)
 
     #
 
+    set(_picky_skipped "")
     foreach(_ccopt IN LISTS _picky_enable)
-      list(APPEND _picky "${_ccopt}")
+      string(REGEX MATCH "-W([a-z0-9-]+)" _ccmatch "${_ccopt}")
+      if(_ccmatch AND CMAKE_C_FLAGS MATCHES "-Wno-${CMAKE_MATCH_1}" AND NOT _ccopt STREQUAL "-Wall" AND NOT _ccopt MATCHES "^-Wno-")
+        string(APPEND _picky_skipped " ${_ccopt}")
+      else()
+        list(APPEND _picky "${_ccopt}")
+      endif()
     endforeach()
+    if(_picky_skipped)
+      message(STATUS "Picky compiler options skipped due to CMAKE_C_FLAGS override:${_picky_skipped}")
+    endif()
 
     foreach(_ccopt IN LISTS _picky_detect)
       # Use a unique variable name 1. for meaningful log output 2. to have a fresh, undefined variable for each detection


### PR DESCRIPTION
Also to sync up with similar `./configure` feature via
`CURL_ADD_COMPILER_WARNINGS()`.

Example: `-DCMAKE_C_FLAGS=-Wno-xor-used-as-pow`

It may be useful as a workaround if a specific build combination hits
a picky warning within curl's source code. If such happens, we do
appreciate a report to fix it in curl itself.

---

w/o ws https://github.com/curl/curl/pull/17197/files?w=1
