### PR TITLE
cmake: extend integration tests

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -167,15 +167,30 @@ jobs:
     name: 'cmake-integration-on-${{ matrix.image }}'
     runs-on: ${{ matrix.image }}
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: ${{ contains(matrix.image, 'windows') && 'msys2 {0}' || 'bash' }}
     env:
-      CC: clang
-      CMAKE_GENERATOR: Ninja
+      CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
+      TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }} ${{ contains(matrix.image, 'windows') && '-DCMAKE_UNITY_BUILD_BATCH_SIZE=30' || '' }}
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-latest, macos-latest]
+        image: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2
+        if: ${{ contains(matrix.image, 'windows') }}
+        with:
+          msystem: mingw64
+          release: false
+          update: false
+          cache: false
+          path-type: inherit
+          install: >-
+            mingw-w64-x86_64-zlib mingw-w64-x86_64-zstd mingw-w64-x86_64-libpsl mingw-w64-x86_64-libssh2 mingw-w64-x86_64-nghttp2 mingw-w64-x86_64-openssl
+
       - name: 'install prereqs'
+        if: ${{ !contains(matrix.image, 'windows') }}
         run: |
           if [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
             sudo rm -f /var/lib/man-db/auto-update
@@ -188,8 +203,8 @@ jobs:
         with:
           persist-credentials: false
       - name: 'via FetchContent'
-        run: ./tests/cmake/test.sh FetchContent
+        run: ./tests/cmake/test.sh FetchContent ${TESTOPTS} -DCURL_USE_OPENSSL=ON
       - name: 'via add_subdirectory'
-        run: ./tests/cmake/test.sh add_subdirectory
+        run: ./tests/cmake/test.sh add_subdirectory ${TESTOPTS} -DCURL_USE_OPENSSL=ON
       - name: 'via find_package'
-        run: ./tests/cmake/test.sh find_package
+        run: ./tests/cmake/test.sh find_package ${TESTOPTS} -DCURL_USE_OPENSSL=ON

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -169,7 +169,6 @@ jobs:
     timeout-minutes: 10
     env:
       CC: clang
-      CMAKE_GENERATOR: Ninja
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -172,7 +172,7 @@ jobs:
         shell: ${{ contains(matrix.image, 'windows') && 'msys2 {0}' || 'bash' }}
     env:
       CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
-      TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }}
+      TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }} ${{ contains(matrix.image, 'windows') && '-DCMAKE_UNITY_BUILD_BATCH_SIZE=30' || '' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -167,30 +167,15 @@ jobs:
     name: 'cmake-integration-on-${{ matrix.image }}'
     runs-on: ${{ matrix.image }}
     timeout-minutes: 10
-    defaults:
-      run:
-        shell: ${{ contains(matrix.image, 'windows') && 'msys2 {0}' || 'bash' }}
     env:
-      CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
-      TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }} ${{ contains(matrix.image, 'windows') && '-DCMAKE_UNITY_BUILD_BATCH_SIZE=30' || '' }}
+      CC: clang
+      CMAKE_GENERATOR: Ninja
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-latest, macos-latest, windows-latest]
+        image: [ubuntu-latest, macos-latest]
     steps:
-      - uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2
-        if: ${{ contains(matrix.image, 'windows') }}
-        with:
-          msystem: mingw64
-          release: false
-          update: false
-          cache: false
-          path-type: inherit
-          install: >-
-            mingw-w64-x86_64-zlib mingw-w64-x86_64-zstd mingw-w64-x86_64-libpsl mingw-w64-x86_64-libssh2 mingw-w64-x86_64-nghttp2 mingw-w64-x86_64-openssl
-
       - name: 'install prereqs'
-        if: ${{ !contains(matrix.image, 'windows') }}
         run: |
           if [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
             sudo rm -f /var/lib/man-db/auto-update
@@ -203,8 +188,8 @@ jobs:
         with:
           persist-credentials: false
       - name: 'via FetchContent'
-        run: ./tests/cmake/test.sh FetchContent ${TESTOPTS} -DCURL_USE_OPENSSL=ON
+        run: ./tests/cmake/test.sh FetchContent
       - name: 'via add_subdirectory'
-        run: ./tests/cmake/test.sh add_subdirectory ${TESTOPTS} -DCURL_USE_OPENSSL=ON
+        run: ./tests/cmake/test.sh add_subdirectory
       - name: 'via find_package'
-        run: ./tests/cmake/test.sh find_package ${TESTOPTS} -DCURL_USE_OPENSSL=ON
+        run: ./tests/cmake/test.sh find_package

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -187,9 +187,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - name: 'via FetchContent'
-        run: ./tests/cmake/test.sh FetchContent
-      - name: 'via add_subdirectory'
-        run: ./tests/cmake/test.sh add_subdirectory
       - name: 'via find_package'
         run: ./tests/cmake/test.sh find_package
+      - name: 'via add_subdirectory'
+        run: ./tests/cmake/test.sh add_subdirectory
+      - name: 'via FetchContent'
+        run: ./tests/cmake/test.sh FetchContent

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -169,6 +169,7 @@ jobs:
     timeout-minutes: 10
     env:
       CC: clang
+      TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -187,8 +188,8 @@ jobs:
         with:
           persist-credentials: false
       - name: 'via FetchContent'
-        run: ./tests/cmake/test.sh FetchContent
+        run: ./tests/cmake/test.sh FetchContent ${TESTOPTS}
       - name: 'via add_subdirectory'
-        run: ./tests/cmake/test.sh add_subdirectory
+        run: ./tests/cmake/test.sh add_subdirectory ${TESTOPTS}
       - name: 'via find_package'
-        run: ./tests/cmake/test.sh find_package
+        run: ./tests/cmake/test.sh find_package ${TESTOPTS}

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -186,9 +186,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-      - name: 'via find_package'
-        run: ./tests/cmake/test.sh find_package
-      - name: 'via add_subdirectory'
-        run: ./tests/cmake/test.sh add_subdirectory
       - name: 'via FetchContent'
         run: ./tests/cmake/test.sh FetchContent
+      - name: 'via add_subdirectory'
+        run: ./tests/cmake/test.sh add_subdirectory
+      - name: 'via find_package'
+        run: ./tests/cmake/test.sh find_package

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -167,15 +167,30 @@ jobs:
     name: 'cmake-integration-on-${{ matrix.image }}'
     runs-on: ${{ matrix.image }}
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: ${{ contains(matrix.image, 'windows') && 'msys2 {0}' || 'bash' }}
     env:
-      CC: clang
+      CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
       TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }}
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-latest, macos-latest]
+        image: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - uses: msys2/setup-msys2@d44ca8e88d8b43d56cf5670f91747359d5537f97 # v2
+        if: ${{ contains(matrix.image, 'windows') }}
+        with:
+          msystem: mingw64
+          release: false
+          update: false
+          cache: false
+          path-type: inherit
+          install: >-
+            mingw-w64-x86_64-zlib mingw-w64-x86_64-zstd mingw-w64-x86_64-libpsl mingw-w64-x86_64-libssh2 mingw-w64-x86_64-nghttp2 mingw-w64-x86_64-openssl
+
       - name: 'install prereqs'
+        if: ${{ !contains(matrix.image, 'windows') }}
         run: |
           if [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
             sudo rm -f /var/lib/man-db/auto-update
@@ -188,8 +203,8 @@ jobs:
         with:
           persist-credentials: false
       - name: 'via FetchContent'
-        run: ./tests/cmake/test.sh FetchContent ${TESTOPTS}
+        run: ./tests/cmake/test.sh FetchContent ${TESTOPTS} -DCURL_USE_OPENSSL=ON
       - name: 'via add_subdirectory'
-        run: ./tests/cmake/test.sh add_subdirectory ${TESTOPTS}
+        run: ./tests/cmake/test.sh add_subdirectory ${TESTOPTS} -DCURL_USE_OPENSSL=ON
       - name: 'via find_package'
-        run: ./tests/cmake/test.sh find_package ${TESTOPTS}
+        run: ./tests/cmake/test.sh find_package ${TESTOPTS} -DCURL_USE_OPENSSL=ON

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.7...3.16 FATAL_ERROR)
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
-project(test-dependent C)
+project(test-consumer C)
 
 option(TEST_INTEGRATION_MODE "Integration mode" "find_package")
 
@@ -35,7 +35,16 @@ if(TEST_INTEGRATION_MODE STREQUAL "FetchContent" AND CMAKE_VERSION VERSION_LESS 
   message(FATAL_ERROR "This test requires CMake 3.14 or upper")
 endif()
 
-if(TEST_INTEGRATION_MODE STREQUAL "find_package")
+if(TEST_INTEGRATION_MODE STREQUAL "ExternalProject")  # Broken
+  include(ExternalProject)
+  ExternalProject_Add(libssh2
+    URL "${FROM_ARCHIVE}" URL_HASH "SHA256=${FROM_HASH}"
+    INSTALL_COMMAND ""
+    DOWNLOAD_EXTRACT_TIMESTAMP ON)
+endif()
+
+if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
+   TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
   find_package(CURL REQUIRED CONFIG)
   find_package(CURL REQUIRED CONFIG)  # Double-inclusion test
   foreach(result_var IN ITEMS
@@ -62,6 +71,8 @@ if(TEST_INTEGRATION_MODE STREQUAL "find_package")
     endif()
   endforeach()
 elseif(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory")
+  set(BUILD_SHARED_LIBS ON CACHE BOOL "")
+  set(BUILD_STATIC_LIBS ON CACHE BOOL "")
   add_subdirectory(curl)
 elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
   include(FetchContent)
@@ -71,15 +82,30 @@ elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
     GIT_REPOSITORY "${FROM_GIT_REPO}"
     GIT_TAG "${FROM_GIT_TAG}"
     GIT_SHALLOW)
+  set(BUILD_SHARED_LIBS ON CACHE BOOL "")
+  set(BUILD_STATIC_LIBS ON CACHE BOOL "")
   FetchContent_MakeAvailable(curl)  # Requires CMake 3.14
 endif()
 
+add_executable(test-consumer-static-ns "test.c")
+target_link_libraries(test-consumer-static-ns PRIVATE "CURL::libcurl_static")
+
+add_executable(test-consumer-shared-ns "test.c")
+target_link_libraries(test-consumer-shared-ns PRIVATE "CURL::libcurl_shared")
+
 # Alias for either shared or static library
-add_executable(test-dependent-selected-ns "test.c")
-target_link_libraries(test-dependent-selected-ns PRIVATE "CURL::libcurl")
+add_executable(test-consumer-selected-ns "test.c")
+target_link_libraries(test-consumer-selected-ns PRIVATE "CURL::libcurl")
 
 if(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory" OR
    TEST_INTEGRATION_MODE STREQUAL "FetchContent")
-  add_executable(test-dependent-selected-bare "test.c")
-  target_link_libraries(test-dependent-selected-bare PRIVATE "libcurl")
+
+  add_executable(test-consumer-static-bare "test.c")
+  target_link_libraries(test-consumer-static-bare PRIVATE "libcurl_static")
+
+  add_executable(test-consumer-shared-bare "test.c")
+  target_link_libraries(test-consumer-shared-bare PRIVATE "libcurl_shared")
+
+  add_executable(test-consumer-selected-bare "test.c")
+  target_link_libraries(test-consumer-selected-bare PRIVATE "libcurl")
 endif()

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -35,7 +35,16 @@ if(TEST_INTEGRATION_MODE STREQUAL "FetchContent" AND CMAKE_VERSION VERSION_LESS 
   message(FATAL_ERROR "This test requires CMake 3.14 or upper")
 endif()
 
-if(TEST_INTEGRATION_MODE STREQUAL "find_package")
+if(TEST_INTEGRATION_MODE STREQUAL "ExternalProject")  # Broken
+  include(ExternalProject)
+  ExternalProject_Add(libssh2
+    URL "${FROM_ARCHIVE}" URL_HASH "SHA256=${FROM_HASH}"
+    INSTALL_COMMAND ""
+    DOWNLOAD_EXTRACT_TIMESTAMP ON)
+endif()
+
+if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
+   TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
   find_package(CURL REQUIRED CONFIG)
   find_package(CURL REQUIRED CONFIG)  # Double-inclusion test
   foreach(result_var IN ITEMS

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.7...3.16 FATAL_ERROR)
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
-project(test-dependent C)
+project(test-consumer C)
 
 option(TEST_INTEGRATION_MODE "Integration mode" "find_package")
 
@@ -87,25 +87,25 @@ elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
   FetchContent_MakeAvailable(curl)  # Requires CMake 3.14
 endif()
 
-add_executable(test-dependent-static-ns "test.c")
-target_link_libraries(test-dependent-static-ns PRIVATE "CURL::libcurl_static")
+add_executable(test-consumer-static-ns "test.c")
+target_link_libraries(test-consumer-static-ns PRIVATE "CURL::libcurl_static")
 
-add_executable(test-dependent-shared-ns "test.c")
-target_link_libraries(test-dependent-shared-ns PRIVATE "CURL::libcurl_shared")
+add_executable(test-consumer-shared-ns "test.c")
+target_link_libraries(test-consumer-shared-ns PRIVATE "CURL::libcurl_shared")
 
 # Alias for either shared or static library
-add_executable(test-dependent-selected-ns "test.c")
-target_link_libraries(test-dependent-selected-ns PRIVATE "CURL::libcurl")
+add_executable(test-consumer-selected-ns "test.c")
+target_link_libraries(test-consumer-selected-ns PRIVATE "CURL::libcurl")
 
 if(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory" OR
    TEST_INTEGRATION_MODE STREQUAL "FetchContent")
 
-  add_executable(test-dependent-static-bare "test.c")
-  target_link_libraries(test-dependent-static-bare PRIVATE "libcurl_static")
+  add_executable(test-consumer-static-bare "test.c")
+  target_link_libraries(test-consumer-static-bare PRIVATE "libcurl_static")
 
-  add_executable(test-dependent-shared-bare "test.c")
-  target_link_libraries(test-dependent-shared-bare PRIVATE "libcurl_shared")
+  add_executable(test-consumer-shared-bare "test.c")
+  target_link_libraries(test-consumer-shared-bare PRIVATE "libcurl_shared")
 
-  add_executable(test-dependent-selected-bare "test.c")
-  target_link_libraries(test-dependent-selected-bare PRIVATE "libcurl")
+  add_executable(test-consumer-selected-bare "test.c")
+  target_link_libraries(test-consumer-selected-bare PRIVATE "libcurl")
 endif()

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -62,6 +62,8 @@ if(TEST_INTEGRATION_MODE STREQUAL "find_package")
     endif()
   endforeach()
 elseif(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory")
+  set(BUILD_SHARED_LIBS ON CACHE BOOL "")
+  set(BUILD_STATIC_LIBS ON CACHE BOOL "")
   add_subdirectory(curl)
 elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
   include(FetchContent)
@@ -71,8 +73,16 @@ elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
     GIT_REPOSITORY "${FROM_GIT_REPO}"
     GIT_TAG "${FROM_GIT_TAG}"
     GIT_SHALLOW)
+  set(BUILD_SHARED_LIBS ON CACHE BOOL "")
+  set(BUILD_STATIC_LIBS ON CACHE BOOL "")
   FetchContent_MakeAvailable(curl)  # Requires CMake 3.14
 endif()
+
+add_executable(test-dependent-static-ns "test.c")
+target_link_libraries(test-dependent-static-ns PRIVATE "CURL::libcurl_static")
+
+add_executable(test-dependent-shared-ns "test.c")
+target_link_libraries(test-dependent-shared-ns PRIVATE "CURL::libcurl_shared")
 
 # Alias for either shared or static library
 add_executable(test-dependent-selected-ns "test.c")
@@ -80,6 +90,13 @@ target_link_libraries(test-dependent-selected-ns PRIVATE "CURL::libcurl")
 
 if(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory" OR
    TEST_INTEGRATION_MODE STREQUAL "FetchContent")
+
+  add_executable(test-dependent-static-bare "test.c")
+  target_link_libraries(test-dependent-static-bare PRIVATE "libcurl_static")
+
+  add_executable(test-dependent-shared-bare "test.c")
+  target_link_libraries(test-dependent-shared-bare PRIVATE "libcurl_shared")
+
   add_executable(test-dependent-selected-bare "test.c")
   target_link_libraries(test-dependent-selected-bare PRIVATE "libcurl")
 endif()

--- a/tests/cmake/CMakeLists.txt
+++ b/tests/cmake/CMakeLists.txt
@@ -25,7 +25,7 @@
 cmake_minimum_required(VERSION 3.7...3.16 FATAL_ERROR)
 message(STATUS "Using CMake version ${CMAKE_VERSION}")
 
-project(test-consumer C)
+project(test-dependent C)
 
 option(TEST_INTEGRATION_MODE "Integration mode" "find_package")
 
@@ -35,16 +35,7 @@ if(TEST_INTEGRATION_MODE STREQUAL "FetchContent" AND CMAKE_VERSION VERSION_LESS 
   message(FATAL_ERROR "This test requires CMake 3.14 or upper")
 endif()
 
-if(TEST_INTEGRATION_MODE STREQUAL "ExternalProject")  # Broken
-  include(ExternalProject)
-  ExternalProject_Add(libssh2
-    URL "${FROM_ARCHIVE}" URL_HASH "SHA256=${FROM_HASH}"
-    INSTALL_COMMAND ""
-    DOWNLOAD_EXTRACT_TIMESTAMP ON)
-endif()
-
-if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
-   TEST_INTEGRATION_MODE STREQUAL "ExternalProject")
+if(TEST_INTEGRATION_MODE STREQUAL "find_package")
   find_package(CURL REQUIRED CONFIG)
   find_package(CURL REQUIRED CONFIG)  # Double-inclusion test
   foreach(result_var IN ITEMS
@@ -71,8 +62,6 @@ if(TEST_INTEGRATION_MODE STREQUAL "find_package" OR
     endif()
   endforeach()
 elseif(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory")
-  set(BUILD_SHARED_LIBS ON CACHE BOOL "")
-  set(BUILD_STATIC_LIBS ON CACHE BOOL "")
   add_subdirectory(curl)
 elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
   include(FetchContent)
@@ -82,30 +71,15 @@ elseif(TEST_INTEGRATION_MODE STREQUAL "FetchContent")
     GIT_REPOSITORY "${FROM_GIT_REPO}"
     GIT_TAG "${FROM_GIT_TAG}"
     GIT_SHALLOW)
-  set(BUILD_SHARED_LIBS ON CACHE BOOL "")
-  set(BUILD_STATIC_LIBS ON CACHE BOOL "")
   FetchContent_MakeAvailable(curl)  # Requires CMake 3.14
 endif()
 
-add_executable(test-consumer-static-ns "test.c")
-target_link_libraries(test-consumer-static-ns PRIVATE "CURL::libcurl_static")
-
-add_executable(test-consumer-shared-ns "test.c")
-target_link_libraries(test-consumer-shared-ns PRIVATE "CURL::libcurl_shared")
-
 # Alias for either shared or static library
-add_executable(test-consumer-selected-ns "test.c")
-target_link_libraries(test-consumer-selected-ns PRIVATE "CURL::libcurl")
+add_executable(test-dependent-selected-ns "test.c")
+target_link_libraries(test-dependent-selected-ns PRIVATE "CURL::libcurl")
 
 if(TEST_INTEGRATION_MODE STREQUAL "add_subdirectory" OR
    TEST_INTEGRATION_MODE STREQUAL "FetchContent")
-
-  add_executable(test-consumer-static-bare "test.c")
-  target_link_libraries(test-consumer-static-bare PRIVATE "libcurl_static")
-
-  add_executable(test-consumer-shared-bare "test.c")
-  target_link_libraries(test-consumer-shared-bare PRIVATE "libcurl_shared")
-
-  add_executable(test-consumer-selected-bare "test.c")
-  target_link_libraries(test-consumer-selected-bare PRIVATE "libcurl")
+  add_executable(test-dependent-selected-bare "test.c")
+  target_link_libraries(test-dependent-selected-bare PRIVATE "libcurl")
 endif()

--- a/tests/cmake/test.c
+++ b/tests/cmake/test.c
@@ -24,8 +24,9 @@
 #include "curl/curl.h"
 #include <stdio.h>
 
-int main(void)
+int main(int argc, char **argv)
 {
-  printf("curl_version(): |%s|\n", curl_version());
+  (void)argc;
+  printf("libcurl test: |%s|%s|\n", argv[0], curl_version());
   return 0;
 }

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -1,39 +1,134 @@
-#!/bin/sh
+#!/bin/sh -x
 # Copyright (C) Viktor Szakats
 #
 # SPDX-License-Identifier: curl
+
+# shellcheck disable=SC2086
 
 set -eu
 
 cd "$(dirname "$0")"
 
-mode="${1:-all}"
+command -v ninja >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
 
-if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
-  rm -rf bld-fetchcontent
-  cmake -B bld-fetchcontent \
+mode="${1:-all}"; shift
+
+cmake_consumer="${CMAKE_CONSUMER:-cmake}"
+cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
+
+# 'modern': supports -S/-B (3.13+), --install (3.15+)
+"${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
+"${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
+
+cmake_opts='-DBUILD_CURL_EXE=OFF -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF'
+
+src='../..'
+
+runresults() {
+  set +x
+  for bin in "$1"/test-consumer*; do
+    file "${bin}" || true
+    ${CURL_TEST_EXE_RUNNER:-} "${bin}" || true
+  done
+  set -x
+}
+
+if [ "${mode}" = 'ExternalProject' ]; then  # Broken
+  (cd "${src}"; git archive --format=tar HEAD) | gzip > source.tar.gz
+  src="${PWD}/source.tar.gz"
+  sha="$(openssl dgst -sha256 "${src}" | grep -a -i -o -E '[0-9a-f]{64}$')"
+  bldc='bld-externalproject'
+  rm -rf "${bldc}"
+  if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
+    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+      -DTEST_INTEGRATION_MODE=ExternalProject \
+      -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
+    "${cmake_consumer}" --build "${bldc}" --verbose
+  else
+    mkdir "${bldc}"; cd "${bldc}"
+    "${cmake_consumer}" .. ${cmake_opts} "$@" \
+      -DTEST_INTEGRATION_MODE=ExternalProject \
+      -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
+    VERBOSE=1 "${cmake_consumer}" --build .
+    cd ..
+  fi
+  runresults "${bldc}"
+fi
+
+if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
+  src="${PWD}/${src}"
+  bldc='bld-fetchcontent'
+  rm -rf "${bldc}"
+  "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
-    -DFROM_GIT_REPO="${PWD}/../.." \
+    -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  cmake --build bld-fetchcontent
+  "${cmake_consumer}" --build "${bldc}" --verbose
+  PATH="${bldc}/_deps/curl-build/lib:${PATH}"
+  runresults "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
-  rm -rf curl; ln -s ../.. curl
-  rm -rf bld-add_subdirectory
-  cmake -B bld-add_subdirectory \
-    -DTEST_INTEGRATION_MODE=add_subdirectory
-  cmake --build bld-add_subdirectory
+  rm -rf curl
+  if ! ln -s "${src}" curl; then
+    rm -rf curl; mkdir curl; (cd "${src}"; git archive --format=tar HEAD) | tar -x --directory=curl  # for MSYS2/Cygwin
+  fi
+  bldc='bld-add_subdirectory'
+  rm -rf "${bldc}"
+  if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
+    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+      -DTEST_INTEGRATION_MODE=add_subdirectory
+    "${cmake_consumer}" --build "${bldc}" --verbose
+  else
+    mkdir "${bldc}"; cd "${bldc}"
+    # Disable `pkg-config` for CMake <= 3.12. These versions cannot propagate
+    # library directories to the consumer project.
+    "${cmake_consumer}" .. ${cmake_opts} -DCURL_USE_PKGCONFIG=OFF "$@" \
+      -DTEST_INTEGRATION_MODE=add_subdirectory
+    VERBOSE=1 "${cmake_consumer}" --build .
+    cd ..
+  fi
+  PATH="${bldc}/curl/lib:${PATH}"
+  runresults "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
-  rm -rf bld-curl
-  cmake ../.. -B bld-curl -DCMAKE_INSTALL_PREFIX="${PWD}/bld-curl/_pkg"
-  cmake --build bld-curl
-  cmake --install bld-curl
-  rm -rf bld-find_package
-  cmake -B bld-find_package \
-    -DTEST_INTEGRATION_MODE=find_package \
-    -DCMAKE_PREFIX_PATH="${PWD}/bld-curl/_pkg/lib/cmake/CURL"
-  cmake --build bld-find_package
+  src="${PWD}/${src}"
+  bldp='bld-curl'
+  prefix="${PWD}/${bldp}/_pkg"
+  rm -rf "${bldp}"
+  if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
+    "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_STATIC_LIBS=ON \
+      -DCMAKE_INSTALL_PREFIX="${prefix}"
+    "${cmake_provider}" --build "${bldp}"
+    "${cmake_provider}" --install "${bldp}"
+  else
+    mkdir "${bldp}"; cd "${bldp}"
+    "${cmake_provider}" "${src}" ${cmake_opts} "$@" \
+      -DBUILD_SHARED_LIBS=ON \
+      -DBUILD_STATIC_LIBS=ON \
+      -DCMAKE_INSTALL_PREFIX="${prefix}"
+    "${cmake_provider}" --build .
+    make install
+    cd ..
+  fi
+  bldc='bld-find_package'
+  rm -rf "${bldc}"
+  if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
+    "${cmake_consumer}" -B "${bldc}" \
+      -DTEST_INTEGRATION_MODE=find_package \
+      -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
+    "${cmake_consumer}" --build "${bldc}" --verbose
+  else
+    mkdir "${bldc}"; cd "${bldc}"
+    "${cmake_consumer}" .. \
+      -DTEST_INTEGRATION_MODE=find_package \
+      -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
+    VERBOSE=1 "${cmake_consumer}" --build .
+    cd ..
+  fi
+  PATH="${prefix}/bin:${PATH}"
+  runresults "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -3,6 +3,14 @@
 #
 # SPDX-License-Identifier: curl
 
+# Recommended options:
+#
+# -DCMAKE_UNITY_BUILD=ON -DBUILD_STATIC_CURL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
+# -D_CURL_PREFILL=ON:       for macOS
+# -DCURL_USE_PKGCONFIG=OFF: for cmake <=3.12 with 'add_subdirectory' tests.
+#                           These old versions can't propagate library
+#                           directories back to the consumer project.
+
 set -eu
 
 cd "$(dirname "$0")"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -1,134 +1,39 @@
-#!/bin/sh -x
+#!/bin/sh
 # Copyright (C) Viktor Szakats
 #
 # SPDX-License-Identifier: curl
-
-# shellcheck disable=SC2086
 
 set -eu
 
 cd "$(dirname "$0")"
 
-command -v ninja >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
+mode="${1:-all}"
 
-mode="${1:-all}"; shift
-
-cmake_consumer="${CMAKE_CONSUMER:-cmake}"
-cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
-
-# 'modern': supports -S/-B (3.13+), --install (3.15+)
-"${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
-"${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
-
-cmake_opts='-DBUILD_CURL_EXE=OFF -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF'
-
-src='../..'
-
-runresults() {
-  set +x
-  for bin in "$1"/test-consumer*; do
-    file "${bin}" || true
-    ${CURL_TEST_EXE_RUNNER:-} "${bin}" || true
-  done
-  set -x
-}
-
-if [ "${mode}" = 'ExternalProject' ]; then  # Broken
-  (cd "${src}"; git archive --format=tar HEAD) | gzip > source.tar.gz
-  src="${PWD}/source.tar.gz"
-  sha="$(openssl dgst -sha256 "${src}" | grep -a -i -o -E '[0-9a-f]{64}$')"
-  bldc='bld-externalproject'
-  rm -rf "${bldc}"
-  if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
-      -DTEST_INTEGRATION_MODE=ExternalProject \
-      -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
-    "${cmake_consumer}" --build "${bldc}" --verbose
-  else
-    mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. ${cmake_opts} "$@" \
-      -DTEST_INTEGRATION_MODE=ExternalProject \
-      -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
-    VERBOSE=1 "${cmake_consumer}" --build .
-    cd ..
-  fi
-  runresults "${bldc}"
-fi
-
-if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
-  src="${PWD}/${src}"
-  bldc='bld-fetchcontent'
-  rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
+  rm -rf bld-fetchcontent
+  cmake -B bld-fetchcontent \
     -DTEST_INTEGRATION_MODE=FetchContent \
-    -DFROM_GIT_REPO="${src}" \
+    -DFROM_GIT_REPO="${PWD}/../.." \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  "${cmake_consumer}" --build "${bldc}" --verbose
-  PATH="${bldc}/_deps/curl-build/lib:${PATH}"
-  runresults "${bldc}"
+  cmake --build bld-fetchcontent
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
-  rm -rf curl
-  if ! ln -s "${src}" curl; then
-    rm -rf curl; mkdir curl; (cd "${src}"; git archive --format=tar HEAD) | tar -x --directory=curl  # for MSYS2/Cygwin
-  fi
-  bldc='bld-add_subdirectory'
-  rm -rf "${bldc}"
-  if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
-      -DTEST_INTEGRATION_MODE=add_subdirectory
-    "${cmake_consumer}" --build "${bldc}" --verbose
-  else
-    mkdir "${bldc}"; cd "${bldc}"
-    # Disable `pkg-config` for CMake <= 3.12. These versions cannot propagate
-    # library directories to the consumer project.
-    "${cmake_consumer}" .. ${cmake_opts} -DCURL_USE_PKGCONFIG=OFF "$@" \
-      -DTEST_INTEGRATION_MODE=add_subdirectory
-    VERBOSE=1 "${cmake_consumer}" --build .
-    cd ..
-  fi
-  PATH="${bldc}/curl/lib:${PATH}"
-  runresults "${bldc}"
+  rm -rf curl; ln -s ../.. curl
+  rm -rf bld-add_subdirectory
+  cmake -B bld-add_subdirectory \
+    -DTEST_INTEGRATION_MODE=add_subdirectory
+  cmake --build bld-add_subdirectory
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
-  src="${PWD}/${src}"
-  bldp='bld-curl'
-  prefix="${PWD}/${bldp}/_pkg"
-  rm -rf "${bldp}"
-  if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
-      -DBUILD_SHARED_LIBS=ON \
-      -DBUILD_STATIC_LIBS=ON \
-      -DCMAKE_INSTALL_PREFIX="${prefix}"
-    "${cmake_provider}" --build "${bldp}"
-    "${cmake_provider}" --install "${bldp}"
-  else
-    mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" ${cmake_opts} "$@" \
-      -DBUILD_SHARED_LIBS=ON \
-      -DBUILD_STATIC_LIBS=ON \
-      -DCMAKE_INSTALL_PREFIX="${prefix}"
-    "${cmake_provider}" --build .
-    make install
-    cd ..
-  fi
-  bldc='bld-find_package'
-  rm -rf "${bldc}"
-  if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" \
-      -DTEST_INTEGRATION_MODE=find_package \
-      -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
-    "${cmake_consumer}" --build "${bldc}" --verbose
-  else
-    mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. \
-      -DTEST_INTEGRATION_MODE=find_package \
-      -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
-    VERBOSE=1 "${cmake_consumer}" --build .
-    cd ..
-  fi
-  PATH="${prefix}/bin:${PATH}"
-  runresults "${bldc}"
+  rm -rf bld-curl
+  cmake ../.. -B bld-curl -DCMAKE_INSTALL_PREFIX="${PWD}/bld-curl/_pkg"
+  cmake --build bld-curl
+  cmake --install bld-curl
+  rm -rf bld-find_package
+  cmake -B bld-find_package \
+    -DTEST_INTEGRATION_MODE=find_package \
+    -DCMAKE_PREFIX_PATH="${PWD}/bld-curl/_pkg/lib/cmake/CURL"
+  cmake --build bld-find_package
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -3,12 +3,6 @@
 #
 # SPDX-License-Identifier: curl
 
-# Recommended options:
-# -D_CURL_PREFILL=ON:       for macOS
-# -DCURL_USE_PKGCONFIG=OFF: for cmake <=3.12 with 'add_subdirectory' tests.
-#                           These old versions can't propagate library
-#                           directories to the consumer project.
-
 # shellcheck disable=SC2086
 
 set -eu
@@ -87,7 +81,9 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. ${cmake_opts} "$@" \
+    # Disable `pkg-config` for CMake <= 3.12. These versions cannot propagate
+    # library directories to the consumer project.
+    "${cmake_consumer}" .. ${cmake_opts} -DCURL_USE_PKGCONFIG=OFF "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     VERBOSE=1 "${cmake_consumer}" --build .
     cd ..

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -7,13 +7,17 @@ set -eu
 
 cd "$(dirname "$0")"
 
-command -v dpkg >/dev/null && export CMAKE_GENERATOR=Ninja
+command -v dpkg >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
 
 mode="${1:-all}"
 shift
 
 cmake_provider="${CMAKE_PROVIDER:-cmake}"
 cmake_consumer="${CMAKE_CONSUMER:-${cmake_provider}}"
+
+# 'modern': supports -S/-B (3.13+), --install (3.15+)
+"${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
+"${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
 
 src='../..'
 

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -21,7 +21,7 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 src='../..'
 
-if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
+if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -26,7 +26,7 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
 "${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
 
-cmake_opts='-DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF'
+cmake_opts='-DBUILD_CURL_EXE=OFF -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF'
 
 src='../..'
 

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -9,8 +9,7 @@ cd "$(dirname "$0")"
 
 command -v dpkg >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
 
-mode="${1:-all}"
-shift
+mode="${1:-all}"; shift
 
 cmake_consumer="${CMAKE_CONSUMER:-cmake}"
 cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -28,7 +28,7 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 src='../..'
 
-runresult() {
+runresults() {
   for bin in "$1"/test-consumer*; do
     "${bin}" || true
   done
@@ -53,7 +53,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runresult "${bldc}"
+  runresults "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
@@ -65,7 +65,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bldc}" --verbose
-  runresult "${bldc}"
+  runresults "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -83,7 +83,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runresult "${bldc}"
+  runresults "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -123,5 +123,5 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runresult "${bldc}"
+  runresults "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -83,16 +83,18 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" -DCMAKE_INSTALL_PREFIX="${prefix}" "$@" \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" "$@" \
       -DBUILD_SHARED_LIBS=ON \
-      -DBUILD_STATIC_LIBS=ON
+      -DBUILD_STATIC_LIBS=ON \
+      -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build "${bldp}"
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" -DCMAKE_INSTALL_PREFIX="${prefix}" "$@" \
+    "${cmake_provider}" "${src}" "$@" \
       -DBUILD_SHARED_LIBS=ON \
-      -DBUILD_STATIC_LIBS=ON
+      -DBUILD_STATIC_LIBS=ON \
+      -DCMAKE_INSTALL_PREFIX="${prefix}"
     "${cmake_provider}" --build .
     make install
     cd ..

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -10,13 +10,14 @@ cd "$(dirname "$0")"
 command -v dpkg >/dev/null && export CMAKE_GENERATOR=Ninja
 
 mode="${1:-all}"
+shift
 
 cmake_provider="${CMAKE_PROVIDER:-cmake}"
 cmake_consumer="${CMAKE_CONSUMER:-${cmake_provider}}"
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
   rm -rf bld-fetchcontent
-  "${cmake_consumer}" -B bld-fetchcontent \
+  "${cmake_consumer}" -B bld-fetchcontent "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${PWD}/../.." \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -26,7 +27,7 @@ fi
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf curl; ln -s ../.. curl
   rm -rf bld-add_subdirectory
-  "${cmake_consumer}" -B bld-add_subdirectory \
+  "${cmake_consumer}" -B bld-add_subdirectory "$@" \
     -DTEST_INTEGRATION_MODE=add_subdirectory
   "${cmake_consumer}" --build bld-add_subdirectory
 fi
@@ -34,13 +35,13 @@ fi
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bld='bld-curl'
   rm -rf "${bld}"
-  "${cmake_provider}" ../.. -B "${bld}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bld}/_pkg" \
+  "${cmake_provider}" ../.. -B "${bld}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bld}/_pkg" "$@" \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_STATIC_LIBS=ON
   "${cmake_provider}" --build "${bld}"
   "${cmake_provider}" --install "${bld}"
   rm -rf bld-find_package
-  "${cmake_consumer}" -B bld-find_package \
+  "${cmake_consumer}" -B bld-find_package "$@" \
     -DTEST_INTEGRATION_MODE=find_package \
     -DCMAKE_PREFIX_PATH="${PWD}/${bld}/_pkg/lib/cmake/CURL"
   "${cmake_consumer}" --build bld-find_package --verbose

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -5,7 +5,7 @@
 
 # Recommended options:
 #
-# -DCMAKE_UNITY_BUILD=ON -DBUILD_STATIC_CURL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
+# -DBUILD_STATIC_CURL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
 # -D_CURL_PREFILL=ON:       for macOS
 # -DCURL_USE_PKGCONFIG=OFF: for cmake <=3.12 with 'add_subdirectory' tests.
 #                           These old versions can't propagate library
@@ -41,7 +41,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   bldc='bld-externalproject'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" "$@" \
+    "${cmake_consumer}" -B "${bldc}" -DCMAKE_UNITY_BUILD=ON "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     "${cmake_consumer}" --build "${bldc}" --verbose
@@ -60,7 +60,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" "$@" \
+  "${cmake_consumer}" -B "${bldc}" -DCMAKE_UNITY_BUILD=ON "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -73,7 +73,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" "$@" \
+    "${cmake_consumer}" -B "${bldc}" -DCMAKE_UNITY_BUILD=ON "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
@@ -92,7 +92,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" "$@" \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" -DCMAKE_UNITY_BUILD=ON "$@" \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_STATIC_LIBS=ON \
       -DCMAKE_INSTALL_PREFIX="${prefix}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -4,7 +4,6 @@
 # SPDX-License-Identifier: curl
 
 # Recommended options:
-#
 # -D_CURL_PREFILL=ON:       for macOS
 # -DCURL_USE_PKGCONFIG=OFF: for cmake <=3.12 with 'add_subdirectory' tests.
 #                           These old versions can't propagate library

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -12,12 +12,12 @@ command -v dpkg >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
 mode="${1:-all}"
 shift
 
-cmake_provider="${CMAKE_PROVIDER:-cmake}"
-cmake_consumer="${CMAKE_CONSUMER:-${cmake_provider}}"
+cmake_consumer="${CMAKE_CONSUMER:-cmake}"
+cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 # 'modern': supports -S/-B (3.13+), --install (3.15+)
-"${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
+"${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
 
 src='../..'
 

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -x
 # Copyright (C) Viktor Szakats
 #
 # SPDX-License-Identifier: curl
@@ -29,7 +29,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  "${cmake_consumer}" --build "${bldc}" --verbose
+  "${cmake_consumer}" --verbose --build "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -38,7 +38,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=add_subdirectory
-  "${cmake_consumer}" --build "${bldc}" --verbose
+  "${cmake_consumer}" --verbose --build "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -56,5 +56,5 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=find_package \
     -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
-  "${cmake_consumer}" --build "${bldc}" --verbose
+  "${cmake_consumer}" --verbose --build "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -16,33 +16,36 @@ cmake_provider="${CMAKE_PROVIDER:-cmake}"
 cmake_consumer="${CMAKE_CONSUMER:-${cmake_provider}}"
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
-  rm -rf bld-fetchcontent
-  "${cmake_consumer}" -B bld-fetchcontent "$@" \
+  bldc='bld-fetchcontent'
+  rm -rf "${bldc}"
+  "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${PWD}/../.." \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  "${cmake_consumer}" --build bld-fetchcontent
+  "${cmake_consumer}" --build "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf curl; ln -s ../.. curl
-  rm -rf bld-add_subdirectory
-  "${cmake_consumer}" -B bld-add_subdirectory "$@" \
+  bldc='bld-add_subdirectory'
+  rm -rf "${bldc}"
+  "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=add_subdirectory
-  "${cmake_consumer}" --build bld-add_subdirectory
+  "${cmake_consumer}" --build "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
-  bld='bld-curl'
-  rm -rf "${bld}"
-  "${cmake_provider}" ../.. -B "${bld}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bld}/_pkg" "$@" \
+  bldp='bld-curl'
+  rm -rf "${bldp}"
+  "${cmake_provider}" ../.. -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bldp}/_pkg" "$@" \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_STATIC_LIBS=ON
-  "${cmake_provider}" --build "${bld}"
-  "${cmake_provider}" --install "${bld}"
-  rm -rf bld-find_package
-  "${cmake_consumer}" -B bld-find_package "$@" \
+  "${cmake_provider}" --build "${bldp}"
+  "${cmake_provider}" --install "${bldp}"
+  bldc='bld-find_package'
+  rm -rf "${bldc}"
+  "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=find_package \
-    -DCMAKE_PREFIX_PATH="${PWD}/${bld}/_pkg/lib/cmake/CURL"
-  "${cmake_consumer}" --build bld-find_package --verbose
+    -DCMAKE_PREFIX_PATH="${PWD}/${bldp}/_pkg/lib/cmake/CURL"
+  "${cmake_consumer}" --build "${bldc}" --verbose
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -55,7 +55,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
     "${cmake_consumer}" .. ${cmake_opts} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
-    "${cmake_consumer}" --verbose --build .
+    VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
   fi
   runresults "${bldc}"
@@ -89,7 +89,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     mkdir "${bldc}"; cd "${bldc}"
     "${cmake_consumer}" .. ${cmake_opts} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
-    "${cmake_consumer}" --verbose --build .
+    VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
   fi
   PATH="${bldc}/curl/lib:${PATH}"
@@ -130,7 +130,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" .. \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
-    "${cmake_consumer}" --verbose --build .
+    VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
   fi
   PATH="${prefix}/bin:${PATH}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -74,7 +74,10 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
-  rm -rf curl; ln -s "${src}" curl
+  rm -rf curl
+  if ! ln -s "${src}" curl; then
+    rm -rf curl; mkdir curl; (cd "${src}"; git archive --format=tar HEAD) | tar -x --directory=curl  # for MSYS2/Cygwin
+  fi
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -25,7 +25,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  "${cmake_consumer}" --build "${bldc}"
+  "${cmake_consumer}" --build "${bldc}" --verbose
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -34,7 +34,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=add_subdirectory
-  "${cmake_consumer}" --build "${bldc}"
+  "${cmake_consumer}" --build "${bldc}" --verbose
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -15,7 +15,7 @@ set -eu
 
 cd "$(dirname "$0")"
 
-command -v dpkg >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
+command -v ninja >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
 
 mode="${1:-all}"; shift
 

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -28,6 +28,13 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 src='../..'
 
+runres() {
+  for bin in "$1"/test-consumer*; do
+    echo "Running '${bin}'...:"
+    "${bin}" || true
+  done
+}
+
 if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   (cd "${src}"; git archive --format=tar HEAD) | gzip > source.tar.gz
   src="${PWD}/source.tar.gz"
@@ -47,6 +54,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  runres "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
@@ -58,6 +66,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bldc}" --verbose
+  runres "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -75,6 +84,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  runres "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -114,4 +124,5 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  runres "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -9,34 +9,37 @@ cd "$(dirname "$0")"
 
 mode="${1:-all}"
 
+cmake_provider="${CMAKE_PROVIDER:-cmake}"
+cmake_consumer="${CMAKE_CONSUMER:-${cmake_provider}}"
+
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
   rm -rf bld-fetchcontent
-  cmake -B bld-fetchcontent \
+  "${cmake_consumer}" -B bld-fetchcontent \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${PWD}/../.." \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  cmake --build bld-fetchcontent
+  "${cmake_consumer}" --build bld-fetchcontent
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   rm -rf curl; ln -s ../.. curl
   rm -rf bld-add_subdirectory
-  cmake -B bld-add_subdirectory \
+  "${cmake_consumer}" -B bld-add_subdirectory \
     -DTEST_INTEGRATION_MODE=add_subdirectory
-  cmake --build bld-add_subdirectory
+  "${cmake_consumer}" --build bld-add_subdirectory
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bld='bld-curl'
   rm -rf "${bld}"
-  cmake ../.. -B "${bld}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bld}/_pkg" \
+  "${cmake_provider}" ../.. -B "${bld}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bld}/_pkg" \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_STATIC_LIBS=ON
-  cmake --build "${bld}"
-  cmake --install "${bld}"
+  "${cmake_provider}" --build "${bld}"
+  "${cmake_provider}" --install "${bld}"
   rm -rf bld-find_package
-  cmake -B bld-find_package \
+  "${cmake_consumer}" -B bld-find_package \
     -DTEST_INTEGRATION_MODE=find_package \
     -DCMAKE_PREFIX_PATH="${PWD}/${bld}/_pkg/lib/cmake/CURL"
-  cmake --build bld-find_package --verbose
+  "${cmake_consumer}" --build bld-find_package --verbose
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -28,7 +28,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
-  "${cmake_consumer}" --verbose --build "${bldc}"
+  "${cmake_consumer}" --build "${bldc}" --verbose
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -38,12 +38,12 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
     "${cmake_consumer}" -B "${bldc}" "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
-    "${cmake_consumer}" --verbose --build "${bldc}"
+    "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
     "${cmake_consumer}" .. "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
-    "${cmake_consumer}" --verbose --build .
+    "${cmake_consumer}" --build . --verbose
     cd ..
   fi
 fi
@@ -74,13 +74,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" -B "${bldc}" "$@" \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
-    "${cmake_consumer}" --verbose --build "${bldc}"
+    "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
     "${cmake_consumer}" .. "$@" \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
-    "${cmake_consumer}" --verbose --build .
+    "${cmake_consumer}" --build . --verbose
     cd ..
   fi
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -70,6 +70,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bldc}" --verbose
+  PATH="${bldc}/_deps/curl-build/lib:${PATH}"
   runresults "${bldc}"
 fi
 
@@ -91,6 +92,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  PATH="${bldc}/curl/lib:${PATH}"
   runresults "${bldc}"
 fi
 
@@ -131,5 +133,6 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
+  PATH="${prefix}/bin:${PATH}"
   runresults "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -15,18 +15,21 @@ shift
 cmake_provider="${CMAKE_PROVIDER:-cmake}"
 cmake_consumer="${CMAKE_CONSUMER:-${cmake_provider}}"
 
+src='../..'
+
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then
+  src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
-    -DFROM_GIT_REPO="${PWD}/../.." \
+    -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
-  rm -rf curl; ln -s ../.. curl
+  rm -rf curl; ln -s "${src}" curl
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" "$@" \
@@ -35,9 +38,11 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
+  src="${PWD}/${src}"
   bldp='bld-curl'
+  prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
-  "${cmake_provider}" ../.. -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bldp}/_pkg" "$@" \
+  "${cmake_provider}" "${src}" -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${prefix}" "$@" \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_STATIC_LIBS=ON
   "${cmake_provider}" --build "${bldp}"
@@ -46,6 +51,6 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   rm -rf "${bldc}"
   "${cmake_consumer}" -B "${bldc}" "$@" \
     -DTEST_INTEGRATION_MODE=find_package \
-    -DCMAKE_PREFIX_PATH="${PWD}/${bldp}/_pkg/lib/cmake/CURL"
+    -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
   "${cmake_consumer}" --build "${bldc}" --verbose
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -51,7 +51,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     mkdir "${bldc}"; cd "${bldc}"
     "${cmake_consumer}" .. "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
-    "${cmake_consumer}" --build . --verbose
+    "${cmake_consumer}" --verbose --build .
     cd ..
   fi
 fi
@@ -88,7 +88,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" .. "$@" \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
-    "${cmake_consumer}" --build . --verbose
+    "${cmake_consumer}" --verbose --build .
     cd ..
   fi
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -28,7 +28,7 @@ cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
 
 src='../..'
 
-runres() {
+runresult() {
   for bin in "$1"/test-consumer*; do
     echo "Running '${bin}'...:"
     "${bin}" || true
@@ -54,7 +54,7 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runres "${bldc}"
+  runresult "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
@@ -66,7 +66,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
   "${cmake_consumer}" --build "${bldc}" --verbose
-  runres "${bldc}"
+  runresult "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
@@ -84,7 +84,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runres "${bldc}"
+  runresult "${bldc}"
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
@@ -124,5 +124,5 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_consumer}" --verbose --build .
     cd ..
   fi
-  runres "${bldc}"
+  runresult "${bldc}"
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -42,7 +42,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bldp='bld-curl'
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
-  "${cmake_provider}" "${src}" -B "${bldp}" -DCMAKE_INSTALL_PREFIX="${prefix}" "$@" \
+  "${cmake_provider}" -B "${bldp}" -S "${src}" -DCMAKE_INSTALL_PREFIX="${prefix}" "$@" \
     -DBUILD_SHARED_LIBS=ON \
     -DBUILD_STATIC_LIBS=ON
   "${cmake_provider}" --build "${bldp}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -27,13 +27,16 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
 fi
 
 if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
-  rm -rf bld-curl
-  cmake ../.. -B bld-curl -DCMAKE_INSTALL_PREFIX="${PWD}/bld-curl/_pkg"
-  cmake --build bld-curl
-  cmake --install bld-curl
+  bld='bld-curl'
+  rm -rf "${bld}"
+  cmake ../.. -B "${bld}" -DCMAKE_INSTALL_PREFIX="${PWD}/${bld}/_pkg" \
+    -DBUILD_SHARED_LIBS=ON \
+    -DBUILD_STATIC_LIBS=ON
+  cmake --build "${bld}"
+  cmake --install "${bld}"
   rm -rf bld-find_package
   cmake -B bld-find_package \
     -DTEST_INTEGRATION_MODE=find_package \
-    -DCMAKE_PREFIX_PATH="${PWD}/bld-curl/_pkg/lib/cmake/CURL"
-  cmake --build bld-find_package
+    -DCMAKE_PREFIX_PATH="${PWD}/${bld}/_pkg/lib/cmake/CURL"
+  cmake --build bld-find_package --verbose
 fi

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -30,7 +30,6 @@ src='../..'
 
 runresult() {
   for bin in "$1"/test-consumer*; do
-    echo "Running '${bin}'...:"
     "${bin}" || true
   done
 }

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -102,13 +102,13 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   bldc='bld-find_package'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" "$@" \
+    "${cmake_consumer}" -B "${bldc}" \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. "$@" \
+    "${cmake_consumer}" .. \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
     "${cmake_consumer}" --verbose --build .

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -7,6 +7,8 @@ set -eu
 
 cd "$(dirname "$0")"
 
+command -v dpkg >/dev/null && export CMAKE_GENERATOR=Ninja
+
 mode="${1:-all}"
 
 cmake_provider="${CMAKE_PROVIDER:-cmake}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -31,9 +31,13 @@ cmake_opts='-DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=
 src='../..'
 
 runresults() {
+  set +x
   for bin in "$1"/test-consumer*; do
+    echo "---- ${bin} ----"
+    file "${bin}" || true
     "${bin}" || true
   done
+  set -x
 }
 
 if [ "${mode}" = 'ExternalProject' ]; then  # Broken

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -33,7 +33,6 @@ src='../..'
 runresults() {
   set +x
   for bin in "$1"/test-consumer*; do
-    echo "---- ${bin} ----"
     file "${bin}" || true
     "${bin}" || true
   done

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -34,7 +34,7 @@ runresults() {
   set +x
   for bin in "$1"/test-consumer*; do
     file "${bin}" || true
-    "${bin}" || true
+    ${CURL_TEST_EXE_RUNNER:-} "${bin}" || true
   done
   set -x
 }


### PR DESCRIPTION
- GHA: add cmake integration tests for Windows.
- make them run faster with prefill, unity, Ninja, omitting curl tool.
- also test static libcurl.
- add old-cmake support with auto-detection.
- auto-detect Ninja.
- run consumer test apps to see if they work.
- add support for Windows.
- make it more verbose.
- re-add `ExternalProject` cmake consumer test. It's broken.
- tidy up terminology.

Cherry-picked from #16973
