### PR TITLE
pull_request_template.md: provide basic instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,9 @@
+Welcome to curl, thanks for contributing!
+
+1. Please submit your PR in *draft mode* and mark it *ready* once the CI jobs
+   are green, you are happy with the PR and want a review and merge.
+2. Expect a few problems in your first submission that need fixing.
+3. When your PR is ready for merge, mark it ready and ask for a review.
+4. If your PR takes a while to complete, be prepared to rebase and force-push
+   it along the way to fix conflicts with things that are merged into master
+   while your PR is developed.


### PR DESCRIPTION
This should appear on GitHub for pull-requests and asks users to submit their PRs as draft to begin with, to help us know when PRs are ready.