### PR TITLE
cfilters: remove assert

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -415,7 +415,6 @@ CURLcode Curl_conn_connect(struct Curl_easy *data,
   DEBUGASSERT(data->conn);
 
   cf = data->conn->cfilter[sockindex];
-  DEBUGASSERT(cf);
   if(!cf) {
     *done = FALSE;
     return CURLE_FAILED_INIT;


### PR DESCRIPTION
The OSS-fuzz probe reaches this, so it can apparently in run-time. There is already a run-time handling of the situation.