### PR TITLE
progress: fix integer overflow check

### DIFF
--- a/lib/progress.c
+++ b/lib/progress.c
@@ -548,7 +548,7 @@ static void progress_meter(struct Curl_easy *data)
     ((p->flags & PGRS_DL_SIZE_KNOWN) ? p->dl.total_size : p->dl.cur_size);
 
   /* integer overflow check */
-  if((CURL_OFF_T_MAX - total_expected_size) > dl_size)
+  if((CURL_OFF_T_MAX - total_expected_size) < dl_size)
     total_expected_size = CURL_OFF_T_MAX; /* capped */
   else
     total_expected_size += dl_size;


### PR DESCRIPTION
- Fix logic typo.

Prior to this change the overflow check was reversed, meaning it did not stop an overflow condition and also if there wasn't an overflow it erroneously set the total expected transfer size to the maximum value.

Follow-up to 69ce9a7f from earlier today.

Closes #xxxx