### PR TITLE
openssl: first unload the provider, then free the context

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1947,9 +1947,6 @@ static struct curl_slist *ossl_engines_list(struct Curl_easy *data)
 
 static void ossl_provider_cleanup(struct Curl_easy *data)
 {
-  OSSL_LIB_CTX_free(data->state.libctx);
-  data->state.libctx = NULL;
-  Curl_safefree(data->state.propq);
   if(data->state.baseprov) {
     OSSL_PROVIDER_unload(data->state.baseprov);
     data->state.baseprov = NULL;
@@ -1958,6 +1955,9 @@ static void ossl_provider_cleanup(struct Curl_easy *data)
     OSSL_PROVIDER_unload(data->state.provider);
     data->state.provider = NULL;
   }
+  OSSL_LIB_CTX_free(data->state.libctx);
+  data->state.libctx = NULL;
+  Curl_safefree(data->state.propq);
   data->state.provider_loaded = FALSE;
 }
 


### PR DESCRIPTION
Doing it in the reversed order causes bad problems inside OpenSSL.