### PR TITLE
CURLOPT_XFERINFOFUNCTION.md: fix the callback return type in example

### DIFF
--- a/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_XFERINFOFUNCTION.md
@@ -85,11 +85,11 @@ struct progress {
   size_t size;
 };
 
-static size_t progress_callback(void *clientp,
-                                curl_off_t dltotal,
-                                curl_off_t dlnow,
-                                curl_off_t ultotal,
-                                curl_off_t ulnow)
+static int xferinfo_callback(void *clientp,
+                             curl_off_t dltotal,
+                             curl_off_t dlnow,
+                             curl_off_t ultotal,
+                             curl_off_t ulnow)
 {
   struct progress *memory = clientp;
   printf("my ptr: %p\n", memory->private);
@@ -111,7 +111,7 @@ int main(void)
     /* enable progress callback getting called */
     curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
 
-    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, progress_callback);
+    curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, xferinfo_callback);
   }
 }
 ~~~


### PR DESCRIPTION
Fixes #17228
Reported-by: gkarracer on github