### PR TITLE
docs/libcurl: fix type and prototype problems in examples

### DIFF
--- a/.github/scripts/verify-examples.pl
+++ b/.github/scripts/verify-examples.pl
@@ -34,7 +34,7 @@ if($files[0] eq "-h") {
 }
 
 sub testcompile {
-    my $rc = system("gcc -c test.c -DCURL_DISABLE_TYPECHECK -DCURL_ALLOW_OLD_MULTI_SOCKET -DCURL_DISABLE_DEPRECATION -Wunused -Werror -Wall -Wno-unused-but-set-variable -I include") >> 8;
+    my $rc = system("gcc -c test.c -DCURL_ALLOW_OLD_MULTI_SOCKET -DCURL_DISABLE_DEPRECATION -Wunused -Werror -Wall -Wno-unused-but-set-variable -I include") >> 8;
     return $rc;
 }
 

--- a/docs/libcurl/curl_easy_recv.md
+++ b/docs/libcurl/curl_easy_recv.md
@@ -76,7 +76,7 @@ int main(void)
     if(res == CURLE_OK) {
       char buf[256];
       size_t nread;
-      long sockfd;
+      curl_socket_t sockfd;
 
       /* Extract the socket from the curl handle - we need it for waiting. */
       res = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);

--- a/docs/libcurl/curl_easy_send.md
+++ b/docs/libcurl/curl_easy_send.md
@@ -69,7 +69,7 @@ int main(void)
     res = curl_easy_perform(curl);
 
     if(res == CURLE_OK) {
-      long sockfd;
+      curl_socket_t sockfd;
       size_t sent;
       /* Extract the socket from the curl handle - we need it for waiting. */
       res = curl_easy_getinfo(curl, CURLINFO_ACTIVESOCKET, &sockfd);

--- a/docs/libcurl/curl_ws_meta.md
+++ b/docs/libcurl/curl_ws_meta.md
@@ -137,7 +137,7 @@ struct customdata {
   void *ptr;
 };
 
-static size_t writecb(unsigned char *buffer,
+static size_t writecb(char *buffer,
                       size_t size, size_t nitems, void *p)
 {
   struct customdata *c = (struct customdata *)p;

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -60,7 +60,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
-    curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, CURLALTSVC_H1);
+    curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, (long)CURLALTSVC_H1);
     curl_easy_setopt(curl, CURLOPT_ALTSVC, "altsvc-cache.txt");
     curl_easy_perform(curl);
   }

--- a/docs/libcurl/opts/CURLOPT_CHUNK_END_FUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CHUNK_END_FUNCTION.md
@@ -53,8 +53,9 @@ struct callback_data {
    FILE *output;
 };
 
-static long file_is_downloaded(struct callback_data *data)
+static long file_is_downloaded(void *ptr)
 {
+  struct callback_data *data = ptr;
   if(data->output) {
     fclose(data->output);
     data->output = 0x0;

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -65,7 +65,7 @@ int main(void)
     /* HTTPS over a proxy makes a separate CONNECT to the proxy, so tell
        libcurl to not send the custom headers to the proxy. Keep them
        separate. */
-    curl_easy_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
+    curl_easy_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_SEPARATE);
     ret = curl_easy_perform(curl);
     curl_slist_free_all(list);
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -66,7 +66,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
     /* of all addresses example.com resolves to, only IPv6 ones are used */
-    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
+    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, (long)CURL_IPRESOLVE_V6);
 
     res = curl_easy_perform(curl);
 

--- a/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
@@ -69,7 +69,7 @@ int main(void)
 
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
-    curl_easy_setopt(curl, CURLOPT_MIME_OPTIONS, CURLMIMEOPT_FORMESCAPE);
+    curl_easy_setopt(curl, CURLOPT_MIME_OPTIONS, (long)CURLMIMEOPT_FORMESCAPE);
 
     form = curl_mime_init(curl);
     if(form) {

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -65,7 +65,7 @@ int main(void)
 
     /* example.com is redirected, so we tell libcurl to send POST on 301,
        302 and 303 HTTP response codes */
-    curl_easy_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
+    curl_easy_setopt(curl, CURLOPT_POSTREDIR, (long)CURL_REDIR_POST_ALL);
 
     curl_easy_perform(curl);
   }

--- a/docs/libcurl/opts/CURLOPT_PROGRESSDATA.md
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSDATA.md
@@ -43,11 +43,11 @@ struct progress {
   size_t size;
 };
 
-static size_t progress_callback(void *clientp,
-                                double dltotal,
-                                double dlnow,
-                                double ultotal,
-                                double ulnow)
+static int progress_callback(void *clientp,
+                             double dltotal,
+                             double dlnow,
+                             double ultotal,
+                             double ulnow)
 {
   struct progress *memory = clientp;
   printf("private: %p\n", memory->private);

--- a/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_PROGRESSFUNCTION.md
@@ -89,11 +89,11 @@ struct progress {
   size_t size;
 };
 
-static size_t progress_callback(void *clientp,
-                                double dltotal,
-                                double dlnow,
-                                double ultotal,
-                                double ulnow)
+static int progress_callback(void *clientp,
+                             double dltotal,
+                             double dlnow,
+                             double ultotal,
+                             double ulnow)
 {
   struct progress *memory = clientp;
   printf("private: %p\n", memory->private);

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
 
     /* only allow HTTP, TFTP and SFTP */
     curl_easy_setopt(curl, CURLOPT_PROTOCOLS,
-                     CURLPROTO_HTTP | CURLPROTO_TFTP | CURLPROTO_SFTP);
+                     (long)CURLPROTO_HTTP | CURLPROTO_TFTP | CURLPROTO_SFTP);
 
     /* Perform the request */
     curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -86,7 +86,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     curl_easy_setopt(curl, CURLOPT_PROXY, "local.example.com:1080");
     /* set the proxy type */
-    curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
+    curl_easy_setopt(curl, CURLOPT_PROXYTYPE, (long)CURLPROXY_SOCKS5);
     ret = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
@@ -116,7 +116,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* ask libcurl to use TLS version 1.0 or later */
-    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, (long)CURL_SSLVERSION_TLSv1);
 
     /* Perform the request */
     curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -105,8 +105,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     curl_easy_setopt(curl, CURLOPT_PROXY, "https://proxy");
     /* weaken TLS only for use with silly proxies */
-    curl_easy_setopt(curl, CURLOPT_PROXY_SSL_OPTIONS, CURLSSLOPT_ALLOW_BEAST |
-                     CURLSSLOPT_NO_REVOKE);
+    curl_easy_setopt(curl, CURLOPT_PROXY_SSL_OPTIONS, (long)
+                     CURLSSLOPT_ALLOW_BEAST | CURLSSLOPT_NO_REVOKE);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
     curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
 
     /* only allow redirects to HTTP and HTTPS URLs */
-    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS,
+    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, (long)
                      CURLPROTO_HTTP | CURLPROTO_HTTPS);
 
     /* Perform the request */

--- a/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
@@ -52,7 +52,7 @@ int main(void)
   if(curl) {
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "sftp://example.com/file");
-    curl_easy_setopt(curl, CURLOPT_SSH_AUTH_TYPES,
+    curl_easy_setopt(curl, CURLOPT_SSH_AUTH_TYPES, (long)
                      CURLSSH_AUTH_PUBLICKEY | CURLSSH_AUTH_KEYBOARD);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);

--- a/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
+++ b/docs/libcurl/opts/CURLOPT_TCP_NODELAY.md
@@ -57,7 +57,7 @@ int main(void)
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
     /* leave Nagle enabled */
-    curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 0);
+    curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 0L);
     curl_easy_perform(curl);
   }
 }

--- a/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_TRAILERFUNCTION.md
@@ -64,6 +64,9 @@ NULL
 
 # EXAMPLE
 ~~~c
+extern size_t read_cb(char *ptr, size_t size,
+                      size_t nmemb, void *userdata);
+
 static int trailer_cb(struct curl_slist **tr, void *data)
 {
   /* libcurl frees the list */
@@ -84,7 +87,7 @@ int main(void)
 
     /* Assuming we have a function that returns the data to be pushed
        Let that function be read_cb */
-    curl_easy_setopt(curl, CURLOPT_READFUNCTION, trailer_cb);
+    curl_easy_setopt(curl, CURLOPT_READFUNCTION, read_cb);
 
     struct curl_slist *headers = NULL;
     headers = curl_slist_append(headers, "Trailer: My-super-awesome-trailer");

--- a/docs/libcurl/opts/CURLOPT_XFERINFODATA.md
+++ b/docs/libcurl/opts/CURLOPT_XFERINFODATA.md
@@ -46,11 +46,11 @@ struct progress {
   size_t size;
 };
 
-static size_t progress_cb(void *clientp,
-                          curl_off_t dltotal,
-                          curl_off_t dlnow,
-                          curl_off_t ultotal,
-                          curl_off_t ulnow)
+static int progress_cb(void *clientp,
+                       curl_off_t dltotal,
+                       curl_off_t dlnow,
+                       curl_off_t ultotal,
+                       curl_off_t ulnow)
 {
   struct progress *memory = clientp;
   printf("private ptr: %p\n", memory->private);


### PR DESCRIPTION
Detected by enabling typechecks for the test compiles.