### PR TITLE
pop3: use meta hashes at easy handle and connection

### DIFF
--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1557,7 +1557,7 @@ static CURLcode pop3_setup_connection(struct Curl_easy *data,
     return CURLE_OUT_OF_MEMORY;
 
   pop3c = calloc(1, sizeof(*pop3c));
-  if(!pop3 ||
+  if(!pop3c ||
     Curl_conn_meta_set(conn, CURL_META_POP3_CONN, pop3c, pop3_conn_dtor))
     return CURLE_OUT_OF_MEMORY;
 

--- a/lib/pop3.h
+++ b/lib/pop3.h
@@ -24,70 +24,7 @@
  *
  ***************************************************************************/
 
-#include "pingpong.h"
-#include "curl_sasl.h"
-
-/****************************************************************************
- * POP3 unique setup
- ***************************************************************************/
-typedef enum {
-  POP3_STOP,         /* do nothing state, stops the state machine */
-  POP3_SERVERGREET,  /* waiting for the initial greeting immediately after
-                        a connect */
-  POP3_CAPA,
-  POP3_STARTTLS,
-  POP3_UPGRADETLS,   /* asynchronously upgrade the connection to SSL/TLS
-                       (multi mode only) */
-  POP3_AUTH,
-  POP3_APOP,
-  POP3_USER,
-  POP3_PASS,
-  POP3_COMMAND,
-  POP3_QUIT,
-  POP3_LAST          /* never used */
-} pop3state;
-
-/* This POP3 struct is used in the Curl_easy. All POP3 data that is
-   connection-oriented must be in pop3_conn to properly deal with the fact that
-   perhaps the Curl_easy is changed between the times the connection is
-   used. */
-struct POP3 {
-  curl_pp_transfer transfer;
-  char *id;               /* Message ID */
-  char *custom;           /* Custom Request */
-};
-
-/* pop3_conn is used for struct connection-oriented data in the connectdata
-   struct */
-struct pop3_conn {
-  struct pingpong pp;
-  pop3state state;        /* Always use pop3.c:state() to change state! */
-  size_t eob;             /* Number of bytes of the EOB (End Of Body) that
-                             have been received so far */
-  size_t strip;           /* Number of bytes from the start to ignore as
-                             non-body */
-  struct SASL sasl;       /* SASL-related storage */
-  char *apoptimestamp;    /* APOP timestamp from the server greeting */
-  unsigned char authtypes; /* Accepted authentication types */
-  unsigned char preftype;  /* Preferred authentication type */
-  BIT(ssldone);           /* Is connect() over SSL done? */
-  BIT(tls_supported);     /* StartTLS capability supported by server */
-};
-
 extern const struct Curl_handler Curl_handler_pop3;
 extern const struct Curl_handler Curl_handler_pop3s;
-
-/* Authentication type flags */
-#define POP3_TYPE_CLEARTEXT (1 << 0)
-#define POP3_TYPE_APOP      (1 << 1)
-#define POP3_TYPE_SASL      (1 << 2)
-
-/* Authentication type values */
-#define POP3_TYPE_NONE      0
-#define POP3_TYPE_ANY       (POP3_TYPE_CLEARTEXT|POP3_TYPE_APOP|POP3_TYPE_SASL)
-
-/* This is the 5-bytes End-Of-Body marker for POP3 */
-#define POP3_EOB "\x0d\x0a\x2e\x0d\x0a"
-#define POP3_EOB_LEN 5
 
 #endif /* HEADER_CURL_POP3_H */

--- a/lib/request.h
+++ b/lib/request.h
@@ -106,7 +106,6 @@ struct SingleRequest {
     struct FTP *ftp;
     struct IMAP *imap;
     struct ldapreqinfo *ldap;
-    struct POP3 *pop3;
     struct RTSP *rtsp;
     struct smb_request *smb;
     struct SMTP *smtp;

--- a/lib/url.c
+++ b/lib/url.c
@@ -85,6 +85,7 @@
 #include "speedcheck.h"
 #include "warnless.h"
 #include "getinfo.h"
+#include "pop3.h"
 #include "urlapi-int.h"
 #include "system_win32.h"
 #include "hsts.h"

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -175,7 +175,6 @@ typedef ssize_t (Curl_recv)(struct Curl_easy *data,   /* transfer */
 
 #include "mime.h"
 #include "imap.h"
-#include "pop3.h"
 #include "smtp.h"
 #include "ftp.h"
 #include "file.h"
@@ -876,9 +875,6 @@ struct connectdata {
 #endif
 #ifndef CURL_DISABLE_IMAP
     struct imap_conn imapc;
-#endif
-#ifndef CURL_DISABLE_POP3
-    struct pop3_conn pop3c;
 #endif
 #ifndef CURL_DISABLE_SMTP
     struct smtp_conn smtpc;


### PR DESCRIPTION
Keep the pop3 related protocol information in the meta hashes at easy handle and connection.

Move the struct definitions inside pop3.c