### PR TITLE
smb: use easy handle/connection meta hash to keep structs

### DIFF
--- a/lib/request.h
+++ b/lib/request.h
@@ -108,7 +108,6 @@ struct SingleRequest {
     struct ldapreqinfo *ldap;
     struct POP3 *pop3;
     struct RTSP *rtsp;
-    struct smb_request *smb;
     struct SMTP *smtp;
     struct SSHPROTO *ssh;
     struct TELNET *telnet;

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -396,7 +396,6 @@ static curl_off_t smb_swap64(curl_off_t x)
 static void conn_state(struct Curl_easy *data, struct smb_conn *smbc,
                        enum smb_conn_state newstate)
 {
-  (void)data;
 #if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
   /* For debug purposes */
   static const char * const names[] = {
@@ -412,7 +411,7 @@ static void conn_state(struct Curl_easy *data, struct smb_conn *smbc,
     infof(data, "SMB conn %p state change from %s to %s",
           (void *)smbc, names[smbc->state], names[newstate]);
 #endif
-
+  (void)data;
   smbc->state = newstate;
 }
 

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -542,15 +542,12 @@ static CURLcode smb_recv_message(struct Curl_easy *data,
                                  struct smb_conn *smbc,
                                  void **msg)
 {
-  char *buf;
+  char *buf = smbc->recv_buf;
   ssize_t bytes_read;
   size_t nbt_size;
   size_t msg_size;
-  size_t len;
+  size_t len = MAX_MESSAGE_SIZE - smbc->got;
   CURLcode result;
-
-  buf = smbc->recv_buf;
-  len = MAX_MESSAGE_SIZE - smbc->got;
 
   result = Curl_xfer_recv(data, buf + smbc->got, len, &bytes_read);
   if(result)

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -396,6 +396,7 @@ static curl_off_t smb_swap64(curl_off_t x)
 static void conn_state(struct Curl_easy *data, struct smb_conn *smbc,
                        enum smb_conn_state newstate)
 {
+  (void)data;
 #if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
   /* For debug purposes */
   static const char * const names[] = {

--- a/lib/smb.h
+++ b/lib/smb.h
@@ -25,30 +25,6 @@
  *
  ***************************************************************************/
 
-enum smb_conn_state {
-  SMB_NOT_CONNECTED = 0,
-  SMB_CONNECTING,
-  SMB_NEGOTIATE,
-  SMB_SETUP,
-  SMB_CONNECTED
-};
-
-struct smb_conn {
-  enum smb_conn_state state;
-  char *user;
-  char *domain;
-  char *share;
-  unsigned char challenge[8];
-  unsigned int session_key;
-  unsigned short uid;
-  char *recv_buf;
-  char *send_buf;
-  size_t upload_size;
-  size_t send_size;
-  size_t sent;
-  size_t got;
-};
-
 #if !defined(CURL_DISABLE_SMB) && defined(USE_CURL_NTLM_CORE) && \
     (SIZEOF_CURL_OFF_T > 4)
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -887,9 +887,6 @@ struct connectdata {
 #ifndef CURL_DISABLE_RTSP
     struct rtsp_conn rtspc;
 #endif
-#ifndef CURL_DISABLE_SMB
-    struct smb_conn smbc;
-#endif
 #ifdef USE_LIBRTMP
     void *rtmp;
 #endif


### PR DESCRIPTION
Keep easy/connection related protoocl structs in the meta hash instead of the unions at request and connectdata.