### PR TITLE
mkhelp: fix to not generate a line-ending space in some cases

### DIFF
--- a/src/mkhelp.pl
+++ b/src/mkhelp.pl
@@ -82,12 +82,14 @@ HEAD
 ;
 
     my $c=0;
-    print " ";
     for(split(//, $gzippedContent)) {
         my $num=ord($_);
+        if(!($c % 12)) {
+            print " ";
+        }
         printf(" 0x%02x,", 0+$num);
         if(!(++$c % 12)) {
-            print "\n ";
+            print "\n";
         }
     }
     print "\n};\n";


### PR DESCRIPTION
Fixing with gcc-15:
```
D:/a/curl/curl/bld/src/tool_hugehelp.c:11739:1: error: trailing whitespace [-Werror=trailing-whitespace=]
```
Ref: https://github.com/curl/curl/actions/runs/14758743743/job/41433794102?pr=17239#step:10:32
