### PR TITLE
ftp: use easy handle and connectin meta data for protocol structs

### DIFF
--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -539,7 +539,7 @@ static CURLcode ftp_initiate_transfer(struct Curl_easy *data,
     Curl_pgrsSetUploadSize(data, data->state.infilesize);
 
     /* set the SO_SNDBUF for the secondary socket for those who need it */
-    Curl_sndbuf_init(conn->sock[SECONDARYSOCKET]);
+    Curl_sndbuf_init(data->conn->sock[SECONDARYSOCKET]);
 
     /* FTP upload, shutdown DATA, ignore shutdown errors, as we rely
      * on the server response on the CONTROL connection. */

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -657,16 +657,15 @@ CURLcode Curl_GetFTPResponse(struct Curl_easy *data,
   int value_to_be_ignored = 0;
 
   CURL_TRC_FTP(data, "getFTPResponse start");
-  if(!ftpc)
-    return CURLE_FAILED_INIT;
-
+  *nreadp = 0;
   if(ftpcode)
     *ftpcode = 0; /* 0 for errors */
   else
     /* make the pointer point to something for the rest of this function */
     ftpcode = &value_to_be_ignored;
 
-  *nreadp = 0;
+  if(!ftpc)
+    return CURLE_FAILED_INIT;
 
   while(!*ftpcode && !result) {
     /* check and reset timeout value every lap */

--- a/lib/ftp.h
+++ b/lib/ftp.h
@@ -37,6 +37,9 @@ extern const struct Curl_handler Curl_handler_ftps;
 
 CURLcode Curl_GetFTPResponse(struct Curl_easy *data, ssize_t *nread,
                              int *ftpcode);
+
+bool ftp_conns_match(struct connectdata *needle, struct connectdata *conn);
+
 #endif /* CURL_DISABLE_FTP */
 
 /****************************************************************************
@@ -162,6 +165,11 @@ struct ftp_conn {
   BIT(wait_data_conn); /* this is set TRUE if data connection is waited */
   BIT(shutdown);    /* connection is being shutdown, e.g. QUIT */
 };
+
+/* meta key for storing `struct FTP` as easy meta data */
+#define CURL_META_FTP_EASY   "meta:proto:ftp:easy"
+/* meta key for storing `struct ftp_conn` as connection meta data */
+#define CURL_META_FTP_CONN   "meta:proto:ftp:conn"
 
 #define DEFAULT_ACCEPT_TIMEOUT   60000 /* milliseconds == one minute */
 

--- a/lib/request.c
+++ b/lib/request.c
@@ -120,7 +120,7 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
 
   /* This is a bit ugly. `req->p` is a union and we assume we can
    * free this safely without leaks. */
-  Curl_safefree(req->p.ftp);
+  Curl_safefree(req->p.file);
   Curl_safefree(req->newurl);
   Curl_client_reset(data);
   if(req->sendbuf_init)
@@ -173,7 +173,7 @@ void Curl_req_free(struct SingleRequest *req, struct Curl_easy *data)
 {
   /* This is a bit ugly. `req->p` is a union and we assume we can
    * free this safely without leaks. */
-  Curl_safefree(req->p.ftp);
+  Curl_safefree(req->p.file);
   Curl_safefree(req->newurl);
   if(req->sendbuf_init)
     Curl_bufq_free(&req->sendbuf);

--- a/lib/request.h
+++ b/lib/request.h
@@ -103,7 +103,6 @@ struct SingleRequest {
      points to data it needs. */
   union {
     struct FILEPROTO *file;
-    struct FTP *ftp;
     struct IMAP *imap;
     struct ldapreqinfo *ldap;
     struct POP3 *pop3;

--- a/lib/url.c
+++ b/lib/url.c
@@ -1046,13 +1046,7 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
 #endif
 #ifndef CURL_DISABLE_FTP
   else if(get_protocol_family(needle->handler) & PROTO_FAMILY_FTP) {
-    /* Also match ACCOUNT, ALTERNATIVE-TO-USER, USE_SSL and CCC options */
-    if(Curl_timestrcmp(needle->proto.ftpc.account,
-                       conn->proto.ftpc.account) ||
-       Curl_timestrcmp(needle->proto.ftpc.alternative_to_user,
-                       conn->proto.ftpc.alternative_to_user) ||
-       (needle->proto.ftpc.use_ssl != conn->proto.ftpc.use_ssl) ||
-       (needle->proto.ftpc.ccc != conn->proto.ftpc.ccc))
+    if(!ftp_conns_match(needle, conn))
       return FALSE;
   }
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -866,9 +866,6 @@ struct connectdata {
 #endif
 
   union {
-#ifndef CURL_DISABLE_FTP
-    struct ftp_conn ftpc;
-#endif
 #ifdef USE_SSH
     struct ssh_conn sshc;
 #endif


### PR DESCRIPTION
- remove data->req.p.ftp and store `struct FTP` as easy meta data
- place `struct ftp_conn` instance in connection meta data