### PR TITLE
multi: fix curl_multi_get_handles to return all handles

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -3568,6 +3568,18 @@ CURL **curl_multi_get_handles(CURLM *m)
       }
       while(Curl_uint_tbl_next(&multi->xfers, mid, &mid, &entry));
     }
+    for(e = Curl_llist_head(&multi->pending); e; e = Curl_node_next(e)) {
+      struct Curl_easy *data = Curl_node_elem(e);
+      DEBUGASSERT(i < multi->num_easy);
+      if(!data->state.internal)
+        a[i++] = data;
+    }
+    for(e = Curl_llist_head(&multi->msgsent); e; e = Curl_node_next(e)) {
+      struct Curl_easy *data = Curl_node_elem(e);
+      DEBUGASSERT(i < multi->num_easy);
+      if(!data->state.internal)
+        a[i++] = data;
+    }
     a[i] = NULL; /* last entry is a NULL */
   }
   return a;


### PR DESCRIPTION
The split of lists for easy handles introduced in #14474 introduced a bug that not all handles were returned from `curl_multi_get_handles`, skipping the ones residing in pending and msgsent lists. This commit fixes it - maybe simplistically, but it works and is similar to `curl_multi_get_handle`.