### PR TITLE
pop3: add null pointer check

### DIFF
--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -311,6 +311,9 @@ static bool pop3_endofresp(struct Curl_easy *data, struct connectdata *conn,
 {
   struct pop3_conn *pop3c = Curl_conn_meta_get(conn, CURL_META_POP3_CONN);
   (void)data;
+  DEBUGASSERT(pop3c);
+  if(!pop3c) /* internal error */
+    return TRUE;
 
   /* Do we have an error response? */
   if(len >= 4 && !memcmp("-ERR", line, 4)) {


### PR DESCRIPTION
Pointed out by Coverity. A precaution to catch internal errors.

Follow-up to 76d13c721bcd992e3e19f52