### PR TITLE
imap: use easy handle/connection meta for proto structs

### DIFF
--- a/lib/imap.c
+++ b/lib/imap.c
@@ -496,7 +496,7 @@ static void imap_state(struct Curl_easy *data,
     infof(data, "IMAP %p state change from %s to %s",
           (void *)imapc, names[imapc->state], names[newstate]);
 #endif
-
+  (void)data;
   imapc->state = newstate;
 }
 

--- a/lib/imap.h
+++ b/lib/imap.h
@@ -27,66 +27,6 @@
 #include "pingpong.h"
 #include "curl_sasl.h"
 
-/****************************************************************************
- * IMAP unique setup
- ***************************************************************************/
-typedef enum {
-  IMAP_STOP,         /* do nothing state, stops the state machine */
-  IMAP_SERVERGREET,  /* waiting for the initial greeting immediately after
-                        a connect */
-  IMAP_CAPABILITY,
-  IMAP_STARTTLS,
-  IMAP_UPGRADETLS,   /* asynchronously upgrade the connection to SSL/TLS
-                       (multi mode only) */
-  IMAP_AUTHENTICATE,
-  IMAP_LOGIN,
-  IMAP_LIST,
-  IMAP_SELECT,
-  IMAP_FETCH,
-  IMAP_FETCH_FINAL,
-  IMAP_APPEND,
-  IMAP_APPEND_FINAL,
-  IMAP_SEARCH,
-  IMAP_LOGOUT,
-  IMAP_LAST          /* never used */
-} imapstate;
-
-/* This IMAP struct is used in the Curl_easy. All IMAP data that is
-   connection-oriented must be in imap_conn to properly deal with the fact that
-   perhaps the Curl_easy is changed between the times the connection is
-   used. */
-struct IMAP {
-  curl_pp_transfer transfer;
-  char *mailbox;          /* Mailbox to select */
-  char *uidvalidity;      /* UIDVALIDITY to check in select */
-  char *uid;              /* Message UID to fetch */
-  char *mindex;           /* Index in mail box of mail to fetch */
-  char *section;          /* Message SECTION to fetch */
-  char *partial;          /* Message PARTIAL to fetch */
-  char *query;            /* Query to search for */
-  char *custom;           /* Custom request */
-  char *custom_params;    /* Parameters for the custom request */
-};
-
-/* imap_conn is used for struct connection-oriented data in the connectdata
-   struct */
-struct imap_conn {
-  struct pingpong pp;
-  struct SASL sasl;           /* SASL-related parameters */
-  struct dynbuf dyn;          /* for the IMAP commands */
-  char *mailbox;              /* The last selected mailbox */
-  char *mailbox_uidvalidity;  /* UIDVALIDITY parsed from select response */
-  imapstate state;            /* Always use imap.c:state() to change state! */
-  char resptag[5];            /* Response tag to wait for */
-  unsigned char preftype;     /* Preferred authentication type */
-  unsigned char cmdid;        /* Last used command ID */
-  BIT(ssldone);               /* Is connect() over SSL done? */
-  BIT(preauth);               /* Is this connection PREAUTH? */
-  BIT(tls_supported);         /* StartTLS capability supported by server */
-  BIT(login_disabled);        /* LOGIN command disabled by server */
-  BIT(ir_supported);          /* Initial response supported by server */
-  BIT(initialised);           /* members have been initialised */
-};
 
 extern const struct Curl_handler Curl_handler_imap;
 extern const struct Curl_handler Curl_handler_imaps;

--- a/lib/request.h
+++ b/lib/request.h
@@ -103,7 +103,6 @@ struct SingleRequest {
      points to data it needs. */
   union {
     struct FILEPROTO *file;
-    struct IMAP *imap;
     struct ldapreqinfo *ldap;
     struct RTSP *rtsp;
     struct SMTP *smtp;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -866,9 +866,6 @@ struct connectdata {
 #ifdef USE_SSH
     struct ssh_conn sshc;
 #endif
-#ifndef CURL_DISABLE_IMAP
-    struct imap_conn imapc;
-#endif
 #ifndef CURL_DISABLE_SMTP
     struct smtp_conn smtpc;
 #endif


### PR DESCRIPTION
Remove the imap protocol structs from connectdata->proto union and data->req.p and use the easy handle/connection meta hash for keeping them.