### PR TITLE
generate.bat: exclude curlinfo.c from legacy VS projects

### DIFF
--- a/projects/generate.bat
+++ b/projects/generate.bat
@@ -145,7 +145,9 @@ rem
     set "var=!var:*:=!"
 
     if "!var!" == "CURL_SRC_C_FILES" (
-      for /f "delims=" %%c in ('dir /b ..\src\*.c') do call :element %1 src "%%c" %3
+      for /f "delims=" %%c in ('dir /b ..\src\*.c') do (
+        if /i "%%c" NEQ "curlinfo.c" call :element %1 src "%%c" %3
+      )
     ) else if "!var!" == "CURL_SRC_H_FILES" (
       for /f "delims=" %%h in ('dir /b ..\src\*.h') do call :element %1 src "%%h" %3
     ) else if "!var!" == "CURL_SRC_RC_FILES" (


### PR DESCRIPTION
- Do not include curlinfo.c as a ClCompile unit when compiling the curl tool.

Prior to this change generate.bat would add curlinfo.c to the source files for the curl tool because it is located in the src directory. That caused ambiguous behavior in legacy versions of Visual Studio which had to guess between two main entry points (one in curlinfo and one in tool_main, the latter being correct).

Closes #xxxx