### PR TITLE
cmake: set `BUILDING_LIBCURL` directly for unit test targets

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -39,9 +39,6 @@ if(CURL_TEST_BUNDLES)
   set(units_SOURCES "unit_bundle.c")
 endif()
 
-# unit tests are small pretend-libcurl-programs
-list(APPEND CURL_DEBUG_MACROS "BUILDING_LIBCURL")
-
 foreach(_target IN LISTS UNITPROGS)
   set(_target_name "${_target}")
   add_executable(${_target_name} EXCLUDE_FROM_ALL ${${_target}_SOURCES})
@@ -54,6 +51,8 @@ foreach(_target IN LISTS UNITPROGS)
     "${PROJECT_SOURCE_DIR}/tests/libtest"
   )
   set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
+  # unit tests are small pretend-libcurl-programs
+  set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "BUILDING_LIBCURL")
   if(CURL_TEST_BUNDLES)
     target_include_directories(${_target_name} PRIVATE "${PROJECT_SOURCE_DIR}/tests/unit")
   endif()


### PR DESCRIPTION
To avoid adding this macro to the global `CURL_DEBUG_MACROS` variable,
which may be used for targets defined after unit tests, and where this
macro may not be necessary.

As of this commit unit tests are defined last, so extending the global
variable did not cause any issue.

Follow-up to 220eda34cdfdcc4316845d2e2bbe5bd8b10305e0 #17259
