### PR TITLE
netrc: avoid NULL deref on weird input

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -247,7 +247,7 @@ static NETRCcode parsenetrc(struct store_netrc *store,
         }
         break;
       case MACDEF:
-        if(!*tok)
+        if(!tok || !*tok)
           state = NOTHING;
         break;
       case HOSTFOUND:


### PR DESCRIPTION
A dynbuf that never gets populated might return a NULL, and Coverity could find a way through like that.