### PR TITLE
GHA/checksrc: check GHA rules with zizmor

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -131,4 +131,4 @@ jobs:
       - name: zizmor
         run: |
           brew install zizmor
-          zizmor .github/workflows/*.yml
+          zizmor --pedantic .github/workflows/*.yml

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -119,7 +119,7 @@ jobs:
           .github/scripts/badwords.pl $(git ls-files -- src lib include)
 
   ghacheck:
-    name: GHA analysis with zizmor
+    name: GHA analysis
     runs-on: macos-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -118,7 +118,8 @@ jobs:
           grep -Ev '(\\bwill| url | dir )' .github/scripts/badwords.txt | \
           .github/scripts/badwords.pl $(git ls-files -- src lib include)
 
-  zizmor:
+  ghacheck:
+    name: GHA analysis with zizmor
     runs-on: macos-latest
     timeout-minutes: 1
     steps:
@@ -127,7 +128,7 @@ jobs:
           persist-credentials: false
         name: checkout
 
-      - name: GHA security check
+      - name: zizmor
         run: |
           brew install zizmor
           zizmor .github/workflows/*.yml

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -123,9 +123,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 # zizmor: ignore[artipacked]
         name: checkout
 
       - name: zizmor

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -123,7 +123,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 # zizmor: ignore[artipacked]
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
         name: checkout
 
       - name: zizmor

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -117,3 +117,17 @@ jobs:
         run: |
           grep -Ev '(\\bwill| url | dir )' .github/scripts/badwords.txt | \
           .github/scripts/badwords.pl $(git ls-files -- src lib include)
+
+  zizmor:
+    runs-on: macos-latest
+    timeout-minutes: 1
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+        name: checkout
+
+      - name: GHA security check
+        run: |
+          brew install zizmor
+          zizmor .github/workflows/*.yml

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -14,7 +14,6 @@ name: Labeler
 
 jobs:
   label:
-
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,7 +10,7 @@
 # https://github.com/actions/labeler
 
 name: Labeler
-'on': [pull_request_target]
+'on': [pull_request_target]  # zizmor: ignore[dangerous-triggers]
 
 jobs:
   label:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,6 +12,8 @@
 name: Labeler
 'on': [pull_request_target]  # zizmor: ignore[dangerous-triggers]
 
+permissions: {}
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -298,6 +298,7 @@ jobs:
     steps:
       - name: 'install prereqs'
         if: matrix.build.container == null && !contains(matrix.build.name, 'i686')
+        # zizmor: ignore[template-injection]
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get -o Dpkg::Use-Pty=0 update
@@ -661,6 +662,7 @@ jobs:
       - name: 'run tests'
         if: ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') }}
         timeout-minutes: ${{ contains(matrix.build.install_packages, 'valgrind') && 30 || 15 }}
+        # zizmor: ignore[template-injection]
         run: |
           export TFLAGS='${{ matrix.build.tflags }}'
           if [ -z '${{ matrix.build.torture }}' ]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -183,6 +183,7 @@ jobs:
         # Run this command with retries because of spurious failures seen
         # while running the tests, for example
         # https://github.com/curl/curl/runs/4095721123?check_suite_focus=true
+        # zizmor: ignore[template-injection]
         run: |
           echo ${{ matrix.build.generate && 'ninja' || 'automake libtool' }} \
             pkgconf libpsl libssh2 \
@@ -311,6 +312,7 @@ jobs:
       - name: 'run tests'
         if: ${{ !matrix.build.clang-tidy }}
         timeout-minutes: ${{ matrix.build.torture && 20 || 10 }}
+        # zizmor: ignore[template-injection]
         run: |
           export TFLAGS='-j20 ${{ matrix.build.tflags }}'
           if [ -z '${{ matrix.build.torture }}' ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -572,6 +572,7 @@ jobs:
     steps:
       - name: 'install packages'
         timeout-minutes: 5
+        # zizmor: ignore[template-injection]
         run: |
           sudo rm -f /var/lib/man-db/auto-update
           sudo apt-get -o Dpkg::Use-Pty=0 install mingw-w64 \


### PR DESCRIPTION
The pedantic level is experimental. If it causes issues, we may just
disable it alongside the ignore comments.

Also:
- silence error:
  ```
   INFO audit: zizmor: completed label.yml
  error[dangerous-triggers]: use of fundamentally insecure workflow trigger
    --> label.yml:13:1
     |
  13 | 'on': [pull_request_target]
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ pull_request_target is almost always used insecurely
     |
     = note: audit confidence → Medium
  ```
- fix pedantic warning:
  ```
   INFO audit: zizmor: completed label.yml
  warning[excessive-permissions]: overly broad permissions
    --> label.yml:1:1
  ...  |
  24 | |         with:
  25 | |           repo-token: '${{ secrets.GITHUB_TOKEN }}'
     | |____________________________________________________- default permissions used due to no permissions: block
     |
     = note: audit confidence → Medium
  ```
- silence `template-injection` false positives like:
  ```
  - note: ${{ matrix.build.torture && 'test-torture' || 'test-ci' }} may expand into attacker-controllable code
  - note: ${{ contains(matrix.build.install_steps, 'pytest') && 'caddy httpd vsftpd' || '' }} may expand into attacker-controllable code
  ```
  It doesn't seem like these could be controlled by an attacker.
  Let me know if I'm missing something.
