### PR TITLE
winbuild: curl_get_line is not used for tool builds

### DIFF
--- a/lib/curlx/curlx.h
+++ b/lib/curlx/curlx.h
@@ -65,6 +65,4 @@
 #include "timeval.h"
 #include "timediff.h"
 
-#include "../curl_get_line.h"
-
 #endif /* HEADER_CURL_CURLX_H */

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -39,7 +39,6 @@ CURLX_SRCS = \
   ../../lib/curlx/dynbuf.c \
   ../../lib/strcase.c \
   ../../lib/strdup.c \
-  ../../lib/curl_get_line.c \
   ../../lib/curlx/multibyte.c \
   ../../lib/version_win32.c
 
@@ -54,7 +53,6 @@ CURLX_HDRS = \
   ../../lib/curlx/dynbuf.h \
   ../../lib/strcase.h \
   ../../lib/strdup.h \
-  ../../lib/curl_get_line.h \
   ../../lib/curlx/multibyte.h \
   ../../lib/version_win32.h
 

--- a/winbuild/MakefileBuild.vc
+++ b/winbuild/MakefileBuild.vc
@@ -697,7 +697,6 @@ CURL_FROM_LIBCURL=\
  $(CURL_DIROBJ)\strcase.obj \
  $(CURL_DIROBJ)\timeval.obj \
  $(CURL_DIROBJ)\warnless.obj \
- $(CURL_DIROBJ)\curl_get_line.obj \
  $(CURL_DIROBJ)\multibyte.obj \
  $(CURL_DIROBJ)\version_win32.obj \
  $(CURL_DIROBJ)\dynbuf.obj \
@@ -726,8 +725,6 @@ $(CURL_DIROBJ)\strcase.obj: ../lib/strcase.c
 	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/strcase.c
 $(CURL_DIROBJ)\timeval.obj: ../lib/curlx/timeval.c
 	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/curlx/timeval.c
-$(CURL_DIROBJ)\curl_get_line.obj: ../lib/curl_get_line.c
-	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/curl_get_line.c
 $(CURL_DIROBJ)\multibyte.obj: ../lib/curlx/multibyte.c
 	$(CURL_CC) $(CURL_CFLAGS) /Fo"$@" ../lib/curlx/multibyte.c
 $(CURL_DIROBJ)\version_win32.obj: ../lib/version_win32.c


### PR DESCRIPTION
Drop it from the build. Also remove it from the tests/server makefile.

Follow-up to d8618f4d8480a8aa245c14f9cf3f1bcab92846c1