### PR TITLE
curlx: simplify the curlx_unicodefree macro

### DIFF
--- a/lib/curlx/multibyte.h
+++ b/lib/curlx/multibyte.h
@@ -81,12 +81,7 @@ typedef union {
 
 #endif /* UNICODE && _WIN32 */
 
-#define curlx_unicodefree(ptr)                          \
-  do {                                                  \
-    if(ptr) {                                           \
-      (free)(CURL_UNCONST(ptr));                        \
-      (ptr) = NULL;                                     \
-    }                                                   \
-  } while(0)
+/* the purpose of this macro is to free() without being traced by memdebug */
+#define curlx_unicodefree(ptr) (free)(ptr)
 
 #endif /* HEADER_CURL_MULTIBYTE_H */

--- a/lib/curlx/multibyte.h
+++ b/lib/curlx/multibyte.h
@@ -82,6 +82,6 @@ typedef union {
 #endif /* UNICODE && _WIN32 */
 
 /* the purpose of this macro is to free() without being traced by memdebug */
-#define curlx_unicodefree(ptr) (free)(ptr)
+#define curlx_unicodefree(ptr) (free)(CURL_UNCONST(ptr))
 
 #endif /* HEADER_CURL_MULTIBYTE_H */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -3063,8 +3063,10 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
                             &used, global, config);
     }
 
-    if(!result)
+    if(!result) {
       unicodefree(orig_opt);
+      orig_opt = NULL;
+    }
   }
 
   if(!result && config->content_disposition) {


### PR DESCRIPTION
Plus:

- ~~remove the unconst~~
- explain its purpose in a comment.