### PR TITLE
src: drop strcase.[ch] from tool builds

### DIFF
--- a/projects/generate.bat
+++ b/projects/generate.bat
@@ -153,15 +153,12 @@ rem
     ) else if "!var!" == "CURL_SRC_RC_FILES" (
       for /f "delims=" %%r in ('dir /b ..\src\*.rc') do call :element %1 src "%%r" %3
     ) else if "!var!" == "CURL_SRC_X_C_FILES" (
-      call :element %1 lib "strcase.c" %3
       call :element %1 lib "nonblock.c" %3
       call :element %1 lib "version_win32.c" %3
     ) else if "!var!" == "CURL_SRC_X_H_FILES" (
       call :element %1 lib "config-win32.h" %3
       call :element %1 lib "curl_setup.h" %3
-      call :element %1 lib "strcase.h" %3
       call :element %1 lib "nonblock.h" %3
-      call :element %1 lib "curl_ctype.h" %3
       call :element %1 lib "version_win32.h" %3
     ) else if "!var!" == "CURL_LIB_C_FILES" (
       for /f "delims=" %%c in ('dir /b ..\lib\*.c') do call :element %1 lib "%%c" %3

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -37,20 +37,17 @@ CURLX_CFILES = \
   ../lib/curlx/dynbuf.c \
   ../lib/nonblock.c \
   ../lib/curlx/strparse.c \
-  ../lib/strcase.c \
   ../lib/curlx/timediff.c \
   ../lib/curlx/timeval.c \
   ../lib/version_win32.c \
   ../lib/curlx/warnless.c
 
 CURLX_HFILES = \
-  ../lib/curl_ctype.h \
   ../lib/curlx/multibyte.h \
   ../lib/curl_setup.h \
   ../lib/curlx/dynbuf.h \
   ../lib/nonblock.h \
   ../lib/curlx/strparse.h \
-  ../lib/strcase.h \
   ../lib/curlx/timediff.h \
   ../lib/curlx/timeval.h \
   ../lib/version_win32.h \


### PR DESCRIPTION
They're not used there anymore.