### PR TITLE
cmake: test integration with old cmake (v3.11.4 2018-03-28)

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -173,7 +173,7 @@ jobs:
     env:
       CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
       TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }} ${{ contains(matrix.image, 'windows') && '-DCMAKE_UNITY_BUILD_BATCH_SIZE=30' || '' }}
-      old-cmake-version: 3.11.4
+      old-cmake-version: 3.7.2
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -173,7 +173,7 @@ jobs:
     env:
       CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
       TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }} ${{ contains(matrix.image, 'windows') && '-DCMAKE_UNITY_BUILD_BATCH_SIZE=30' || '' }}
-      old-cmake-version: 3.7.2
+      old-cmake-version: 3.11.4
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -173,6 +173,7 @@ jobs:
     env:
       CC: ${{ !contains(matrix.image, 'windows') && 'clang' || '' }}
       TESTOPTS: ${{ contains(matrix.image, 'macos') && '-D_CURL_PREFILL=ON' || '' }} ${{ contains(matrix.image, 'windows') && '-DCMAKE_UNITY_BUILD_BATCH_SIZE=30' || '' }}
+      old-cmake-version: 3.11.4
     strategy:
       fail-fast: false
       matrix:
@@ -190,21 +191,56 @@ jobs:
             mingw-w64-x86_64-zlib mingw-w64-x86_64-zstd mingw-w64-x86_64-libpsl mingw-w64-x86_64-libssh2 mingw-w64-x86_64-nghttp2 mingw-w64-x86_64-openssl
 
       - name: 'install prereqs'
-        if: ${{ !contains(matrix.image, 'windows') }}
         run: |
-          if [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
+          if [[ '${{ matrix.image }}' = *'windows'* ]]; then
+            cd "${HOME}" || exit 1
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
+              --location 'https://github.com/Kitware/CMake/releases/download/v${{ env.old-cmake-version }}/cmake-${{ env.old-cmake-version }}-win64-x64.zip' --output bin.zip
+            unzip -q bin.zip
+            rm -f bin.zip
+            printf '%s' "${HOME}/cmake-${{ env.old-cmake-version }}-win64-x64/bin/cmake.exe" > "${HOME}/old-cmake-path.txt"
+          elif [[ '${{ matrix.image }}' = *'ubuntu'* ]]; then
             sudo rm -f /var/lib/man-db/auto-update
             sudo apt-get -o Dpkg::Use-Pty=0 install libpsl-dev libssl-dev
+            cd "${HOME}" || exit 1
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
+              --location https://github.com/Kitware/CMake/releases/download/v${{ env.old-cmake-version }}/cmake-${{ env.old-cmake-version }}-Linux-x86_64.tar.gz | tar -xzf -
+            printf '%s' "$PWD/cmake-${{ env.old-cmake-version }}-Linux-x86_64/bin/cmake" > "${HOME}/old-cmake-path.txt"
           else
             brew install libpsl openssl
+            cd "${HOME}" || exit 1
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
+              --location https://github.com/Kitware/CMake/releases/download/v${{ env.old-cmake-version }}/cmake-${{ env.old-cmake-version }}-Darwin-x86_64.tar.gz | tar -xzf -
+            printf '%s' "$PWD/cmake-${{ env.old-cmake-version }}-Darwin-x86_64/CMake.app/Contents/bin/cmake" > "${HOME}/old-cmake-path.txt"
           fi
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
+
       - name: 'via FetchContent'
         run: ./tests/cmake/test.sh FetchContent ${TESTOPTS} -DCURL_USE_OPENSSL=ON
       - name: 'via add_subdirectory'
         run: ./tests/cmake/test.sh add_subdirectory ${TESTOPTS} -DCURL_USE_OPENSSL=ON
       - name: 'via find_package'
         run: ./tests/cmake/test.sh find_package ${TESTOPTS} -DCURL_USE_OPENSSL=ON
+
+      - name: 'via add_subdirectory OpenSSL (old cmake)'
+        run: |
+          export TEST_CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
+          if [[ '${{ matrix.image }}' = *'windows'* ]]; then
+            export TEST_CMAKE_GENERATOR='MSYS Makefiles'
+            export TEST_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
+          fi
+          ./tests/cmake/test.sh add_subdirectory ${TESTOPTS} -DCURL_USE_OPENSSL=ON ${options}
+
+      - name: 'via find_package OpenSSL (old cmake)'
+        run: |
+          export TEST_CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
+          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
+          if [[ '${{ matrix.image }}' = *'windows'* ]]; then
+            export TEST_CMAKE_GENERATOR='MSYS Makefiles'
+            export TEST_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
+          fi
+          ./tests/cmake/test.sh find_package ${TESTOPTS} -DCURL_USE_OPENSSL=ON ${options}

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -228,7 +228,10 @@ jobs:
       - name: 'via add_subdirectory OpenSSL (old cmake)'
         run: |
           export TEST_CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
-          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
+          if [[ '${{ matrix.image }}' = *'macos'* ]]; then
+            export CFLAGS='-arch arm64'
+            export TEST_CMAKE_FLAGS='-DCURL_USE_LIBPSL=OFF'  # auto-detection does not work with old-cmake
+          fi
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
             export TEST_CMAKE_GENERATOR='MSYS Makefiles'
             export TEST_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'
@@ -238,7 +241,10 @@ jobs:
       - name: 'via find_package OpenSSL (old cmake)'
         run: |
           export TEST_CMAKE_CONSUMER="$(cat "${HOME}/old-cmake-path.txt")"
-          [[ '${{ matrix.image }}' = *'macos'* ]] && export CFLAGS='-arch arm64'
+          if [[ '${{ matrix.image }}' = *'macos'* ]]; then
+            export CFLAGS='-arch arm64'
+            export TEST_CMAKE_FLAGS='-DCURL_USE_LIBPSL=OFF'  # auto-detection does not work with old-cmake
+          fi
           if [[ '${{ matrix.image }}' = *'windows'* ]]; then
             export TEST_CMAKE_GENERATOR='MSYS Makefiles'
             export TEST_CMAKE_FLAGS='-DCMAKE_C_COMPILER=x86_64-w64-mingw32-gcc -DOPENSSL_ROOT_DIR=C:/msys64/mingw64'

--- a/CMake/curl-config.cmake.in
+++ b/CMake/curl-config.cmake.in
@@ -25,7 +25,11 @@
 
 include(CMakeFindDependencyMacro)
 if("@USE_OPENSSL@")
-  find_dependency(OpenSSL "@OPENSSL_VERSION_MAJOR@")
+  if("@OPENSSL_VERSION_MAJOR@")
+    find_dependency(OpenSSL "@OPENSSL_VERSION_MAJOR@")
+  else()
+    find_dependency(OpenSSL)
+  endif()
 endif()
 if("@HAVE_LIBZ@")
   find_dependency(ZLIB "@ZLIB_VERSION_MAJOR@")

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -9,8 +9,6 @@ set -eu
 
 cd "$(dirname "$0")"
 
-command -v ninja >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
-
 mode="${1:-all}"; shift
 
 cmake_consumer="${TEST_CMAKE_CONSUMER:-cmake}"
@@ -19,6 +17,16 @@ cmake_provider="${TEST_CMAKE_PROVIDER:-${cmake_consumer}}"
 # 'modern': supports -S/-B (3.13+), --install (3.15+)
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1
 "${cmake_provider}" --help | grep -q -- '--install' && cmake_provider_modern=1
+
+if [ -n "${TEST_CMAKE_GENERATOR:-}" ]; then
+  gen="${TEST_CMAKE_GENERATOR}"
+elif [ -n "${cmake_consumer_modern:-}" ] && \
+     [ -n "${cmake_provider_modern:-}" ] && \
+     command -v ninja >/dev/null; then
+  gen='Ninja'  # 3.17+
+else
+  gen='Unix Makefiles'
+fi
 
 cmake_opts='-DBUILD_CURL_EXE=OFF -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF'
 

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -48,13 +48,13 @@ if [ "${mode}" = 'ExternalProject' ]; then  # Broken
   bldc='bld-externalproject'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. ${cmake_opts} "$@" \
+    "${cmake_consumer}" .. -G "${gen}" ${cmake_opts} ${TEST_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=ExternalProject \
       -DFROM_ARCHIVE="${src}" -DFROM_HASH="${sha}"
     VERBOSE=1 "${cmake_consumer}" --build .
@@ -67,7 +67,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'FetchContent' ]; then  # 3.14+
   src="${PWD}/${src}"
   bldc='bld-fetchcontent'
   rm -rf "${bldc}"
-  "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+  "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} "$@" \
     -DTEST_INTEGRATION_MODE=FetchContent \
     -DFROM_GIT_REPO="${src}" \
     -DFROM_GIT_TAG="$(git rev-parse HEAD)"
@@ -84,14 +84,14 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'add_subdirectory' ]; then
   bldc='bld-add_subdirectory'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
     # Disable `pkg-config` for CMake <= 3.12. These versions cannot propagate
     # library directories to the consumer project.
-    "${cmake_consumer}" .. ${cmake_opts} -DCURL_USE_PKGCONFIG=OFF "$@" \
+    "${cmake_consumer}" .. -G "${gen}" ${cmake_opts} -DCURL_USE_PKGCONFIG=OFF ${TEST_CMAKE_FLAGS:-} "$@" \
       -DTEST_INTEGRATION_MODE=add_subdirectory
     VERBOSE=1 "${cmake_consumer}" --build .
     cd ..
@@ -106,32 +106,32 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
   prefix="${PWD}/${bldp}/_pkg"
   rm -rf "${bldp}"
   if [ -n "${cmake_provider_modern:-}" ]; then  # 3.15+
-    "${cmake_provider}" -B "${bldp}" -S "${src}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON "$@" \
+    "${cmake_provider}" -B "${bldp}" -S "${src}" -G "${gen}" ${cmake_opts} -DCMAKE_UNITY_BUILD=ON ${TEST_CMAKE_FLAGS:-} "$@" \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_STATIC_LIBS=ON \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
-    "${cmake_provider}" --build "${bldp}"
+    "${cmake_provider}" --build "${bldp}" --verbose
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" ${cmake_opts} "$@" \
+    "${cmake_provider}" "${src}" -G "${gen}" ${cmake_opts} ${TEST_CMAKE_FLAGS:-} "$@" \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_STATIC_LIBS=ON \
       -DCMAKE_INSTALL_PREFIX="${prefix}"
-    "${cmake_provider}" --build .
+    VERBOSE=1 "${cmake_provider}" --build .
     make install
     cd ..
   fi
   bldc='bld-find_package'
   rm -rf "${bldc}"
   if [ -n "${cmake_consumer_modern:-}" ]; then  # 3.15+
-    "${cmake_consumer}" -B "${bldc}" \
+    "${cmake_consumer}" -B "${bldc}" -G "${gen}" ${TEST_CMAKE_FLAGS:-} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
     "${cmake_consumer}" --build "${bldc}" --verbose
   else
     mkdir "${bldc}"; cd "${bldc}"
-    "${cmake_consumer}" .. \
+    "${cmake_consumer}" .. -G "${gen}" ${TEST_CMAKE_FLAGS:-} \
       -DTEST_INTEGRATION_MODE=find_package \
       -DCMAKE_PREFIX_PATH="${prefix}/lib/cmake/CURL"
     VERBOSE=1 "${cmake_consumer}" --build .

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -13,8 +13,8 @@ command -v ninja >/dev/null && export CMAKE_GENERATOR=Ninja  # 3.17+
 
 mode="${1:-all}"; shift
 
-cmake_consumer="${CMAKE_CONSUMER:-cmake}"
-cmake_provider="${CMAKE_PROVIDER:-${cmake_consumer}}"
+cmake_consumer="${TEST_CMAKE_CONSUMER:-cmake}"
+cmake_provider="${TEST_CMAKE_PROVIDER:-${cmake_consumer}}"
 
 # 'modern': supports -S/-B (3.13+), --install (3.15+)
 "${cmake_consumer}" --help | grep -q -- '--install' && cmake_consumer_modern=1

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -114,7 +114,7 @@ if [ "${mode}" = 'all' ] || [ "${mode}" = 'find_package' ]; then
     "${cmake_provider}" --install "${bldp}"
   else
     mkdir "${bldp}"; cd "${bldp}"
-    "${cmake_provider}" "${src}" -G "${gen}" ${cmake_opts} ${TEST_CMAKE_FLAGS:-} "$@" \
+    "${cmake_provider}" "${src}" -G "${gen}" ${cmake_opts} -DCURL_USE_PKGCONFIG=OFF ${TEST_CMAKE_FLAGS:-} "$@" \
       -DBUILD_SHARED_LIBS=ON \
       -DBUILD_STATIC_LIBS=ON \
       -DCMAKE_INSTALL_PREFIX="${prefix}"

--- a/tests/cmake/test.sh
+++ b/tests/cmake/test.sh
@@ -28,7 +28,7 @@ runresults() {
   set +x
   for bin in "$1"/test-consumer*; do
     file "${bin}" || true
-    ${CURL_TEST_EXE_RUNNER:-} "${bin}" || true
+    ${TEST_CMAKE_EXE_RUNNER:-} "${bin}" || true
   done
   set -x
 }


### PR DESCRIPTION
Tests with old cmake are slow. (no Ninja, no unity, and running slower
than recent versions.)

It also revealed that 3.7.2 2017-01-13 is too old to consume curl via
`find_package()` due to:
```
CMake Error at bld-curl/_pkg/lib/cmake/CURL/CURLConfig.cmake:69 (add_library):
  add_library cannot create ALIAS target "CURL::libcurl" because target
  "CURL::libcurl_shared" is IMPORTED.
Call Stack (most recent call first):
  CMakeLists.txt:48 (find_package)

CMake Error at bld-curl/_pkg/lib/cmake/CURL/CURLConfig.cmake:69 (add_library):
  add_library cannot create ALIAS target "CURL::libcurl" because target
  "CURL::libcurl_shared" is IMPORTED.
Call Stack (most recent call first):
  CMakeLists.txt:49 (find_package)
```
The mitigation for this issue requires 3.11.

Also:
- rename a few existing envs to use the `TEST_` prefix.
- make the `find_package` test provider stage verbose.
- fix issue when consuming with cmake 3.7.2 (all platforms):
  ```
  CMake Error at /home/runner/cmake-3.7.2-Linux-x86_64/share/cmake-3.7/Modules/CMakeFindDependencyMacro.cmake:25 (message):
    Invalid arguments to find_dependency.  VERSION is empty
  Call Stack (most recent call first):
    bld-curl/_pkg/lib/cmake/CURL/CURLConfig.cmake:52 (find_dependency)
    CMakeLists.txt:48 (find_package)
  ```
  Ref: https://github.com/curl/curl/actions/runs/14906066962/job/41868621979?pr=17293#step:9:1199
