### PR TITLE
tests/server: stop using libcurl's printf functions

### DIFF
--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -29,14 +29,12 @@ MEMDEBUG = \
   ../../lib/memdebug.h
 
 CURLX_SRCS = \
-  ../../lib/mprintf.c \
   ../../lib/curlx/nonblock.c \
   ../../lib/curlx/strparse.c \
   ../../lib/strequal.c \
   ../../lib/curlx/warnless.c \
   ../../lib/curlx/timediff.c \
   ../../lib/curlx/timeval.c \
-  ../../lib/curlx/dynbuf.c \
   ../../lib/strcase.c \
   ../../lib/curlx/multibyte.c \
   ../../lib/curlx/version_win32.c
@@ -49,7 +47,6 @@ CURLX_HDRS = \
   ../../lib/curlx/warnless.h \
   ../../lib/curlx/timediff.h \
   ../../lib/curlx/timeval.h \
-  ../../lib/curlx/dynbuf.h \
   ../../lib/strcase.h \
   ../../lib/curlx/multibyte.h \
   ../../lib/curlx/version_win32.h

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -121,7 +121,7 @@ static int store_incoming(const unsigned char *data, size_t size,
   *qtype = 0;
   *idp = 0;
 
-  msnprintf(dumpfile, sizeof(dumpfile), "%s/dnsd.input", logdir);
+  snprintf(dumpfile, sizeof(dumpfile), "%s/dnsd.input", logdir);
 
   /* Open request dump file. */
   server = fopen(dumpfile, "ab");
@@ -475,7 +475,7 @@ int main(int argc, char **argv)
     }
   }
 
-  msnprintf(loglockfile, sizeof(loglockfile), "%s/%s/dnsd-%s.lock",
+  snprintf(loglockfile, sizeof(loglockfile), "%s/%s/dnsd-%s.lock",
             logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
 #ifdef _WIN32

--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -24,7 +24,6 @@
 #include "server_setup.h"
 
 #include "getpart.h"
-
 #include <curlx.h> /* from the private lib dir */
 #include "curl_memory.h"
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -157,13 +157,13 @@ static void logprotocol(mqttdir dir,
   int left = sizeof(data);
 
   for(i = 0; i < len && (left >= 0); i++) {
-    msnprintf(optr, left, "%02x", ptr[i]);
+    snprintf(optr, left, "%02x", ptr[i]);
     optr += 2;
     left -= 2;
   }
-  fprintf(output, "%s %s %zx %s\n",
+  fprintf(output, "%s %s %x %s\n",
           dir == FROM_CLIENT ? "client" : "server",
-          prefix, remlen, data);
+          prefix, (int)remlen, data);
 }
 
 
@@ -446,7 +446,7 @@ static curl_socket_t mqttit(curl_socket_t fd)
     'M','Q','T','T',  /* protocol name */
     0x04              /* protocol level */
   };
-  msnprintf(dumpfile, sizeof(dumpfile), "%s/%s", logdir, REQUEST_DUMP);
+  snprintf(dumpfile, sizeof(dumpfile), "%s/%s", logdir, REQUEST_DUMP);
   dump = fopen(dumpfile, "ab");
   if(!dump)
     goto end;
@@ -980,8 +980,8 @@ int main(int argc, char *argv[])
     }
   }
 
-  msnprintf(loglockfile, sizeof(loglockfile), "%s/%s/mqtt-%s.lock",
-            logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
+  snprintf(loglockfile, sizeof(loglockfile), "%s/%s/mqtt-%s.lock",
+           logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
 #ifdef _WIN32
   if(win32_init())

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -721,12 +721,11 @@ static bool mqttd_incoming(curl_socket_t listenfd)
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
-        logmsg("accept(%" FMT_SOCKET_T ", NULL, NULL) "
-               "failed with error (%d) %s", sockfd, error, sstrerror(error));
+        logmsg("accept() failed with error (%d) %s", error, sstrerror(error));
       }
       else {
-        logmsg("====> Client connect, fd %" FMT_SOCKET_T ". "
-               "Read config from %s", newfd, configfile);
+        logmsg("====> Client connect, fd %ld. "
+               "Read config from %s", (long)newfd, configfile);
         set_advisor_read_lock(loglockfile);
         (void)mqttit(newfd); /* until done */
         clear_advisor_read_lock(loglockfile);
@@ -873,8 +872,8 @@ static curl_socket_t mqttd_sockdaemon(curl_socket_t sock,
   rc = listen(sock, 5);
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("listen(%" FMT_SOCKET_T ", 5) failed with error (%d) %s",
-           sock, error, sstrerror(error));
+    logmsg("listen(%ld, 5) failed with error (%d) %s",
+           (long)sock, error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -191,7 +191,6 @@ static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
             &prot_major,
             &prot_minor) == 5) {
     char *ptr;
-    char logbuf[256];
 
     if(!strcmp(prot_str, "HTTP")) {
       req->protocol = RPROT_HTTP;
@@ -214,12 +213,11 @@ static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
     if(ptr) {
       FILE *stream;
       if((strlen(doc) + strlen(request)) < 200)
-        msnprintf(logbuf, sizeof(logbuf), "Got request: %s %s %s/%d.%d",
-                  request, doc, prot_str, prot_major, prot_minor);
+        logmsg("Got request: %s %s %s/%d.%d",
+               request, doc, prot_str, prot_major, prot_minor);
       else
-        msnprintf(logbuf, sizeof(logbuf), "Got a *HUGE* request %s/%d.%d",
-                  prot_str, prot_major, prot_minor);
-      logmsg("%s", logbuf);
+        logmsg("Got a *HUGE* request %s/%d.%d",
+               prot_str, prot_major, prot_minor);
 
       if(!strncmp("/verifiedserver", ptr, 15)) {
         logmsg("Are-we-friendly question received");
@@ -248,9 +246,7 @@ static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
       else
         req->partno = 0;
 
-      msnprintf(logbuf, sizeof(logbuf), "Requested test number %ld part %ld",
-                req->testno, req->partno);
-      logmsg("%s", logbuf);
+      logmsg("Requested test number %ld part %ld", req->testno, req->partno);
 
       stream = test2fopen(req->testno, logdir);
 
@@ -374,10 +370,8 @@ static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
     else {
       if(sscanf(req->reqbuf, "CONNECT %" MAXDOCNAMELEN_TXT "s HTTP/%d.%d",
                 doc, &prot_major, &prot_minor) == 3) {
-        msnprintf(logbuf, sizeof(logbuf),
-                  "Received a CONNECT %s HTTP/%d.%d request",
-                  doc, prot_major, prot_minor);
-        logmsg("%s", logbuf);
+        logmsg("Received a CONNECT %s HTTP/%d.%d request",
+               doc, prot_major, prot_minor);
 
         if(req->prot_version == 10)
           req->open = FALSE; /* HTTP 1.0 closes connection by default */
@@ -564,7 +558,7 @@ static void rtspd_storerequest(char *reqbuf, size_t totalsize)
   FILE *dump;
   char dumpfile[256];
 
-  msnprintf(dumpfile, sizeof(dumpfile), "%s/%s", logdir, REQUEST_DUMP);
+  snprintf(dumpfile, sizeof(dumpfile), "%s/%s", logdir, REQUEST_DUMP);
 
   if(!reqbuf)
     return;
@@ -739,8 +733,7 @@ static int rtspd_send_doc(curl_socket_t sock, struct rtspd_httprequest *req)
   static char weare[256];
   char responsedump[256];
 
-  msnprintf(responsedump, sizeof(responsedump), "%s/%s",
-            logdir, RESPONSE_DUMP);
+  snprintf(responsedump, sizeof(responsedump), "%s/%s", logdir, RESPONSE_DUMP);
 
   logmsg("Send response number %ld part %ld", req->testno, req->partno);
 
@@ -780,12 +773,12 @@ static int rtspd_send_doc(curl_socket_t sock, struct rtspd_httprequest *req)
     case DOCNUMBER_WERULEZ:
       /* we got a "friends?" question, reply back that we sure are */
       logmsg("Identifying ourselves as friends");
-      msnprintf(msgbuf, sizeof(msgbuf), "RTSP_SERVER WE ROOLZ: %"
-                CURL_FORMAT_CURL_OFF_T "\r\n", our_getpid());
+      snprintf(msgbuf, sizeof(msgbuf), "RTSP_SERVER WE ROOLZ: %ld\r\n",
+               (long)our_getpid());
       msglen = strlen(msgbuf);
-      msnprintf(weare, sizeof(weare),
-                "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\n\r\n%s",
-                msglen, msgbuf);
+      snprintf(weare, sizeof(weare),
+               "HTTP/1.1 200 OK\r\nContent-Length: %u\r\n\r\n%s",
+               (unsigned int)msglen, msgbuf);
       buffer = weare;
       break;
     case DOCNUMBER_INTERNAL:
@@ -817,7 +810,7 @@ static int rtspd_send_doc(curl_socket_t sock, struct rtspd_httprequest *req)
     FILE *stream = test2fopen(req->testno, logdir);
     char partbuf[80]="data";
     if(0 != req->partno)
-      msnprintf(partbuf, sizeof(partbuf), "data%ld", req->partno);
+      snprintf(partbuf, sizeof(partbuf), "data%ld", req->partno);
     if(!stream) {
       error = errno;
       logmsg("fopen() failed with error (%d) %s", error, strerror(error));
@@ -1105,8 +1098,8 @@ int main(int argc, char *argv[])
     }
   }
 
-  msnprintf(loglockfile, sizeof(loglockfile), "%s/%s/rtsp-%s.lock",
-            logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
+  snprintf(loglockfile, sizeof(loglockfile), "%s/%s/rtsp-%s.lock",
+           logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
 #ifdef _WIN32
   if(win32_init())

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -359,20 +359,20 @@ static void lograw(unsigned char *buffer, ssize_t len)
   for(i = 0; i < len; i++) {
     switch(ptr[i]) {
     case '\n':
-      msnprintf(optr, left, "\\n");
+      snprintf(optr, left, "\\n");
       width += 2;
       optr += 2;
       left -= 2;
       break;
     case '\r':
-      msnprintf(optr, left, "\\r");
+      snprintf(optr, left, "\\r");
       width += 2;
       optr += 2;
       left -= 2;
       break;
     default:
-      msnprintf(optr, left, "%c", (ISGRAPH(ptr[i]) ||
-                                   ptr[i] == 0x20) ? ptr[i] : '.');
+      snprintf(optr, left, "%c", (ISGRAPH(ptr[i]) ||
+                                  ptr[i] == 0x20) ? ptr[i] : '.');
       width++;
       optr++;
       left--;
@@ -1125,10 +1125,10 @@ static bool juggle(curl_socket_t *sockfdp,
     else if(!memcmp("PORT", buffer, 4)) {
       /* Question asking us what PORT number we are listening to.
          Replies to PORT with "IPv[num]/[port]" */
-      msnprintf((char *)buffer, sizeof(buffer), "%s/%hu\n",
-                ipv_inuse, server_port);
+      snprintf((char *)buffer, sizeof(buffer), "%s/%hu\n",
+               ipv_inuse, server_port);
       buffer_len = (ssize_t)strlen((char *)buffer);
-      msnprintf(data, sizeof(data), "PORT\n%04zx\n", buffer_len);
+      snprintf(data, sizeof(data), "PORT\n%04x\n", (int)buffer_len);
       if(!write_stdout(data, 10))
         return FALSE;
       if(!write_stdout(buffer, buffer_len))
@@ -1203,7 +1203,7 @@ static bool juggle(curl_socket_t *sockfdp,
     nread_socket = sread(sockfd, buffer, sizeof(buffer));
 
     if(nread_socket > 0) {
-      msnprintf(data, sizeof(data), "DATA\n%04zx\n", nread_socket);
+      snprintf(data, sizeof(data), "DATA\n%04x\n", (int)nread_socket);
       if(!write_stdout(data, 10))
         return FALSE;
       if(!write_stdout(buffer, nread_socket))

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1186,8 +1186,7 @@ static bool juggle(curl_socket_t *sockfdp,
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
-        logmsg("accept(%" FMT_SOCKET_T ", NULL, NULL) "
-               "failed with error (%d) %s", sockfd, error, sstrerror(error));
+        logmsg("accept() failed with error (%d) %s", error, sstrerror(error));
       }
       else {
         logmsg("====> Client connect");
@@ -1364,8 +1363,8 @@ static curl_socket_t sockfilt_sockdaemon(curl_socket_t sock,
   rc = listen(sock, 5);
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("listen(%" FMT_SOCKET_T ", 5) failed with error (%d) %s",
-           sock, error, sstrerror(error));
+    logmsg("listen() failed with error (%d) %s",
+           error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -708,14 +708,13 @@ static bool socksd_incoming(curl_socket_t listenfd)
       curl_socket_t newfd = accept(sockfd, NULL, NULL);
       if(CURL_SOCKET_BAD == newfd) {
         error = SOCKERRNO;
-        logmsg("accept(%" FMT_SOCKET_T ", NULL, NULL) "
-               "failed with error (%d) %s",
-               sockfd, error, sstrerror(error));
+        logmsg("accept() failed with error (%d) %s",
+               error, sstrerror(error));
       }
       else {
         curl_socket_t remotefd;
-        logmsg("====> Client connect, fd %" FMT_SOCKET_T ". "
-               "Read config from %s", newfd, configfile);
+        logmsg("====> Client connect, "
+               "Read config from %s", configfile);
         remotefd = sockit(newfd); /* SOCKS until done */
         if(remotefd == CURL_SOCKET_BAD) {
           logmsg("====> Client disconnect");
@@ -906,8 +905,7 @@ static curl_socket_t socksd_sockdaemon(curl_socket_t sock,
   rc = listen(sock, 5);
   if(0 != rc) {
     error = SOCKERRNO;
-    logmsg("listen(%" FMT_SOCKET_T ", 5) failed with error (%d) %s",
-           sock, error, sstrerror(error));
+    logmsg("listen() failed with error (%d) %s", error, sstrerror(error));
     sclose(sock);
     return CURL_SOCKET_BAD;
   }

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -1004,8 +1004,8 @@ int main(int argc, char *argv[])
         unix_socket = argv[arg];
         if(strlen(unix_socket) >= sizeof(sau.sun_path)) {
           fprintf(stderr,
-                  "socksd: socket path must be shorter than %zu chars: %s\n",
-              sizeof(sau.sun_path), unix_socket);
+                  "socksd: socket path must be shorter than %u chars: %s\n",
+                  (unsigned int)sizeof(sau.sun_path), unix_socket);
           return 0;
         }
         socket_domain = AF_UNIX;

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2389,7 +2389,8 @@ int main(int argc, char *argv[])
       curl_socket_t msgsock;
       do {
         msgsock = accept_connection(sock);
-        logmsg("accept_connection %ld returned %ld", (long)sock, (long)msgsock);
+        logmsg("accept_connection %ld returned %ld",
+               (long)sock, (long)msgsock);
         if(CURL_SOCKET_BAD == msgsock)
           goto sws_cleanup;
         if(req->delay)

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2389,8 +2389,7 @@ int main(int argc, char *argv[])
       curl_socket_t msgsock;
       do {
         msgsock = accept_connection(sock);
-        logmsg("accept_connection %" FMT_SOCKET_T
-               " returned %" FMT_SOCKET_T, sock, msgsock);
+        logmsg("accept_connection %ld returned %ld", (long)sock, (long)msgsock);
         if(CURL_SOCKET_BAD == msgsock)
           goto sws_cleanup;
         if(req->delay)

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -330,7 +330,6 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
   char *line = &req->reqbuf[req->checkindex];
   bool chunked = FALSE;
   static char request[REQUEST_KEYWORD_SIZE];
-  char logbuf[456];
   int prot_major = 0;
   int prot_minor = 0;
   char *end = strstr(line, end_of_headers);
@@ -398,12 +397,10 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
       /* get the number after it */
       if(*ptr == '/') {
         if((npath + strlen(request)) < 400)
-          msnprintf(logbuf, sizeof(logbuf), "Got request: %s %.*s HTTP/%d.%d",
-                    request, (int)npath, httppath, prot_major, prot_minor);
+          logmsg("Got request: %s %.*s HTTP/%d.%d",
+                 request, (int)npath, httppath, prot_major, prot_minor);
         else
-          msnprintf(logbuf, sizeof(logbuf), "Got a *HUGE* request HTTP/%d.%d",
-                    prot_major, prot_minor);
-        logmsg("%s", logbuf);
+          logmsg("Got a *HUGE* request HTTP/%d.%d", prot_major, prot_minor);
 
         if(!strncmp("/verifiedserver", ptr, 15)) {
           logmsg("Are-we-friendly question received");
@@ -429,10 +426,7 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
           req->partno = 0;
 
         if(req->testno) {
-
-          msnprintf(logbuf, sizeof(logbuf), "Serve test number %ld part %ld",
-                    req->testno, req->partno);
-          logmsg("%s", logbuf);
+          logmsg("Serve test number %ld part %ld", req->testno, req->partno);
         }
         else {
           logmsg("No test number in path");
@@ -449,10 +443,8 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
                   doc, &prot_major, &prot_minor) == 3) {
           char *portp = NULL;
 
-          msnprintf(logbuf, sizeof(logbuf),
-                    "Received a CONNECT %s HTTP/%d.%d request",
-                    doc, prot_major, prot_minor);
-          logmsg("%s", logbuf);
+          logmsg("Received a CONNECT %s HTTP/%d.%d request",
+                 doc, prot_major, prot_minor);
 
           req->connect_request = TRUE;
 
@@ -561,10 +553,8 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
       else
         req->partno = 0;
 
-      msnprintf(logbuf, sizeof(logbuf),
-                "Requested GOPHER test number %ld part %ld",
-                req->testno, req->partno);
-      logmsg("%s", logbuf);
+      logmsg("Requested GOPHER test number %ld part %ld",
+             req->testno, req->partno);
     }
   }
 
@@ -751,8 +741,8 @@ static void sws_storerequest(const char *reqbuf, size_t totalsize)
   FILE *dump;
   char dumpfile[256];
 
-  msnprintf(dumpfile, sizeof(dumpfile), "%s/%s",
-            logdir, is_proxy ? REQUEST_PROXY_DUMP : REQUEST_DUMP);
+  snprintf(dumpfile, sizeof(dumpfile), "%s/%s",
+           logdir, is_proxy ? REQUEST_PROXY_DUMP : REQUEST_DUMP);
 
   if(!reqbuf)
     return;
@@ -989,8 +979,8 @@ static int sws_send_doc(curl_socket_t sock, struct sws_httprequest *req)
   static char weare[256];
   char responsedump[256];
 
-  msnprintf(responsedump, sizeof(responsedump), "%s/%s",
-            logdir, is_proxy ? RESPONSE_PROXY_DUMP : RESPONSE_DUMP);
+  snprintf(responsedump, sizeof(responsedump), "%s/%s",
+           logdir, is_proxy ? RESPONSE_PROXY_DUMP : RESPONSE_DUMP);
 
   switch(req->rcmd) {
   default:
@@ -1028,15 +1018,15 @@ static int sws_send_doc(curl_socket_t sock, struct sws_httprequest *req)
     case DOCNUMBER_WERULEZ:
       /* we got a "friends?" question, reply back that we sure are */
       logmsg("Identifying ourselves as friends");
-      msnprintf(msgbuf, sizeof(msgbuf), "WE ROOLZ: %"
-                CURL_FORMAT_CURL_OFF_T "\r\n", our_getpid());
+      snprintf(msgbuf, sizeof(msgbuf), "WE ROOLZ: %ld\r\n",
+               (long)our_getpid());
       msglen = strlen(msgbuf);
       if(use_gopher)
-        msnprintf(weare, sizeof(weare), "%s", msgbuf);
+        snprintf(weare, sizeof(weare), "%s", msgbuf);
       else
-        msnprintf(weare, sizeof(weare),
-                  "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\n\r\n%s",
-                  msglen, msgbuf);
+        snprintf(weare, sizeof(weare),
+                 "HTTP/1.1 200 OK\r\nContent-Length: %u\r\n\r\n%s",
+                 (unsigned int)msglen, msgbuf);
       buffer = weare;
       break;
     case DOCNUMBER_404:
@@ -1056,9 +1046,9 @@ static int sws_send_doc(curl_socket_t sock, struct sws_httprequest *req)
     const char *section = req->connect_request ? "connect" : "data";
 
     if(req->partno)
-      msnprintf(partbuf, sizeof(partbuf), "%s%ld", section, req->partno);
+      snprintf(partbuf, sizeof(partbuf), "%s%ld", section, req->partno);
     else
-      msnprintf(partbuf, sizeof(partbuf), "%s", section);
+      snprintf(partbuf, sizeof(partbuf), "%s", section);
 
     logmsg("Send response test%ld section <%s>", req->testno, partbuf);
 
@@ -2094,8 +2084,8 @@ int main(int argc, char *argv[])
         unix_socket = argv[arg];
         if(strlen(unix_socket) >= sizeof(me.sau.sun_path)) {
           fprintf(stderr,
-                  "sws: socket path must be shorter than %zu chars: %s\n",
-                  sizeof(me.sau.sun_path), unix_socket);
+                  "sws: socket path must be shorter than %u chars: %s\n",
+                  (unsigned int)sizeof(me.sau.sun_path), unix_socket);
           return 0;
         }
         socket_type = "unix";
@@ -2172,9 +2162,9 @@ int main(int argc, char *argv[])
     }
   }
 
-  msnprintf(loglockfile, sizeof(loglockfile), "%s/%s/sws-%s%s-%s.lock",
-            logdir, SERVERLOGS_LOCKDIR, protocol_type,
-            is_proxy ? "-proxy" : "", socket_type);
+  snprintf(loglockfile, sizeof(loglockfile), "%s/%s/sws-%s%s-%s.lock",
+           logdir, SERVERLOGS_LOCKDIR, protocol_type,
+           is_proxy ? "-proxy" : "", socket_type);
 
 #ifdef _WIN32
   if(win32_init())
@@ -2294,7 +2284,7 @@ int main(int argc, char *argv[])
 #ifdef USE_UNIX_SOCKETS
   if(socket_domain != AF_UNIX)
 #endif
-    msnprintf(port_str, sizeof(port_str), "port %hu", port);
+    snprintf(port_str, sizeof(port_str), "port %hu", port);
 
   logmsg("Running %s %s version on %s",
          protocol_type, socket_type, location_str);

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -435,7 +435,7 @@ static ssize_t write_behind(struct testcase *test, int convert)
 
   if(!test->ofile) {
     char outfile[256];
-    msnprintf(outfile, sizeof(outfile), "%s/upload.%ld", logdir, test->testno);
+    snprintf(outfile, sizeof(outfile), "%s/upload.%ld", logdir, test->testno);
     test->ofile = open(outfile, O_CREAT|O_RDWR|CURL_O_BINARY, 0777);
     if(test->ofile == -1) {
       logmsg("Couldn't create and/or open file %s for upload!", outfile);
@@ -626,8 +626,8 @@ int main(int argc, char **argv)
     }
   }
 
-  msnprintf(loglockfile, sizeof(loglockfile), "%s/%s/tftp-%s.lock",
-            logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
+  snprintf(loglockfile, sizeof(loglockfile), "%s/%s/tftp-%s.lock",
+           logdir, SERVERLOGS_LOCKDIR, ipv_inuse);
 
 #ifdef _WIN32
   if(win32_init())
@@ -887,7 +887,7 @@ static int do_tftp(struct testcase *test, struct tftphdr *tp, ssize_t size)
   FILE *server;
   char dumpfile[256];
 
-  msnprintf(dumpfile, sizeof(dumpfile), "%s/%s", logdir, REQUEST_DUMP);
+  snprintf(dumpfile, sizeof(dumpfile), "%s/%s", logdir, REQUEST_DUMP);
 
   /* Open request dump file. */
   server = fopen(dumpfile, "ab");
@@ -1065,8 +1065,8 @@ static int validate_access(struct testcase *test,
 
   if(!strncmp("verifiedserver", filename, 14)) {
     char weare[128];
-    size_t count = msnprintf(weare, sizeof(weare), "WE ROOLZ: %"
-                             CURL_FORMAT_CURL_OFF_T "\r\n", our_getpid());
+    size_t count = snprintf(weare, sizeof(weare), "WE ROOLZ: %ld\r\n",
+                            (long)our_getpid());
 
     logmsg("Are-we-friendly question received");
     test->buffer = strdup(weare);
@@ -1111,7 +1111,7 @@ static int validate_access(struct testcase *test,
     stream = test2fopen(testno, logdir);
 
     if(0 != partno)
-      msnprintf(partbuf, sizeof(partbuf), "data%ld", partno);
+      snprintf(partbuf, sizeof(partbuf), "data%ld", partno);
 
     if(!stream) {
       int error = errno;

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -25,25 +25,12 @@
  ***************************************************************************/
 #include "server_setup.h"
 
-#include <curl/mprintf.h>
-
-/* make the test servers use the libcurl *printf family */
-# undef printf
-# undef fprintf
-# undef msnprintf
-# undef vprintf
-# undef vfprintf
-# undef mvsnprintf
-# undef aprintf
-# undef vaprintf
-# define printf curl_mprintf
-# define fprintf curl_mfprintf
-# define msnprintf curl_msnprintf
-# define vprintf curl_mvprintf
-# define vfprintf curl_mvfprintf
-# define mvsnprintf curl_mvsnprintf
-# define aprintf curl_maprintf
-# define vaprintf curl_mvaprintf
+/* adjust for old MSVC */
+#ifdef _MSC_VER
+#  if _MSC_VER < 1900
+#   define snprintf _snprintf
+#  endif
+#endif
 
 enum {
   DOCNUMBER_NOTHING    = -7,


### PR DESCRIPTION
Since the test servers are not built with libcurl the *printf code needed to get built separately, and they are not in the curlx collection.

snprintf() is provided in all modern systems these days.

Also: this change switches off the format-truncation gcc warning that otherwise starts to output lots of false positive warnings with this patch.