### PR TITLE
pytest-xdist: pytest in parallel

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -62,7 +62,7 @@ jobs:
             codespell python3-pip python3-networkx python3-pydot python3-yaml \
             python3-toml python3-markupsafe python3-jinja2 python3-tabulate \
             python3-typing-extensions python3-libcst python3-impacket \
-            python3-websockets python3-pytest
+            python3-websockets python3-pytest python3-filelock python3-pytest-xdist
           python3 -m pip install --break-system-packages cmakelint==1.4.3 pytype==2024.10.11 ruff==0.11.9
 
       - name: spellcheck

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -529,6 +529,7 @@ jobs:
           CURL_TEST_EVENT: 1
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
+          PYTEST_XDIST_AUTO_NUM_WORKERS: 4
         run: |
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -694,6 +694,7 @@ jobs:
         env:
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
+          PYTEST_XDIST_AUTO_NUM_WORKERS: 4
         run: |
           [ -x "$HOME/venv/bin/activate" ] && source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -337,6 +337,7 @@ jobs:
         env:
           CURL_CI: github
           PYTEST_ADDOPTS: '--color=yes'
+          PYTEST_XDIST_AUTO_NUM_WORKERS: 4
         run: |
           source $HOME/venv/bin/activate
           if [ -n '${{ matrix.build.generate }}' ]; then

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -111,5 +111,5 @@ curl_add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r --retry=5 -j
 curl_add_runtests(test-torture   "-a -t -j20")
 curl_add_runtests(test-event     "-a -e")
 
-curl_add_pytests(curl-pytest      "")
-curl_add_pytests(curl-pytest-ci   "-v")
+curl_add_pytests(curl-pytest      "-n auto")
+curl_add_pytests(curl-pytest-ci   "-n auto -v")

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -189,7 +189,7 @@ event-test: perlcheck all
 default-pytest: ci-pytest
 
 ci-pytest: all
-	srcdir=$(srcdir) $(PYTEST) -v $(srcdir)/http
+	srcdir=$(srcdir) $(PYTEST) -n auto -v $(srcdir)/http
 
 checksrc:
 	(cd libtest && $(MAKE) checksrc)

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -26,13 +26,16 @@ import logging
 import os
 import sys
 import platform
-from typing import Generator
+from typing import Generator, Union
 
 import pytest
+
+from testenv.env import EnvConfig
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '.'))
 
 from testenv import Env, Nghttpx, Httpd, NghttpxQuic, NghttpxFwd
+
 
 def pytest_report_header(config):
     # Env inits its base properties only once, we can report them here
@@ -43,20 +46,20 @@ def pytest_report_header(config):
         f'  curl: Version: {env.curl_version_string()}',
         f'  curl: Features: {env.curl_features_string()}',
         f'  curl: Protocols: {env.curl_protocols_string()}',
-        f'  httpd: {env.httpd_version()}, http:{env.http_port} https:{env.https_port}',
-        f'  httpd-proxy: {env.httpd_version()}, http:{env.proxy_port} https:{env.proxys_port}'
+        f'  httpd: {env.httpd_version()}',
+        f'  httpd-proxy: {env.httpd_version()}'
     ]
     if env.have_h3():
         report.extend([
-            f'  nghttpx: {env.nghttpx_version()}, h3:{env.https_port}'
+            f'  nghttpx: {env.nghttpx_version()}'
         ])
     if env.has_caddy():
         report.extend([
-            f'  Caddy: {env.caddy_version()}, http:{env.caddy_http_port} https:{env.caddy_https_port}'
+            f'  Caddy: {env.caddy_version()}'
         ])
     if env.has_vsftpd():
         report.extend([
-            f'  VsFTPD: {env.vsftpd_version()}, ftp:{env.ftp_port}, ftps:{env.ftps_port}'
+            f'  VsFTPD: {env.vsftpd_version()}'
         ])
     buildinfo_fn = os.path.join(env.build_dir, 'buildinfo.txt')
     if os.path.exists(buildinfo_fn):
@@ -67,14 +70,18 @@ def pytest_report_header(config):
                     report.extend([line])
     return '\n'.join(report)
 
-# TODO: remove this and repeat argument everywhere, pytest-repeat can be used to repeat tests
-def pytest_generate_tests(metafunc):
-    if "repeat" in metafunc.fixturenames:
-        metafunc.parametrize('repeat', [0])
 
-@pytest.fixture(scope="package")
-def env(pytestconfig) -> Env:
-    env = Env(pytestconfig=pytestconfig)
+@pytest.fixture(scope='session')
+def env_config(pytestconfig, testrun_uid, worker_id) -> EnvConfig:
+    env_config = EnvConfig(pytestconfig=pytestconfig,
+                           testrun_uid=testrun_uid,
+                           worker_id=worker_id)
+    return env_config
+
+
+@pytest.fixture(scope='session', autouse=True)
+def env(pytestconfig, env_config) -> Env:
+    env = Env(pytestconfig=pytestconfig, env_config=env_config)
     level = logging.DEBUG if env.verbose > 0 else logging.INFO
     logging.getLogger('').setLevel(level=level)
     if not env.curl_has_protocol('http'):
@@ -87,12 +94,8 @@ def env(pytestconfig) -> Env:
     env.setup()
     return env
 
-@pytest.fixture(scope="package", autouse=True)
-def log_global_env_facts(record_testsuite_property, env):
-    record_testsuite_property("http-port", env.http_port)
 
-
-@pytest.fixture(scope='package')
+@pytest.fixture(scope='session')
 def httpd(env) -> Generator[Httpd, None, None]:
     httpd = Httpd(env=env)
     if not httpd.exists():
@@ -104,20 +107,40 @@ def httpd(env) -> Generator[Httpd, None, None]:
     httpd.stop()
 
 
-@pytest.fixture(scope='package')
-def nghttpx(env, httpd) -> Generator[Nghttpx, None, None]:
+@pytest.fixture(scope='session')
+def nghttpx(env, httpd) -> Generator[Union[Nghttpx,bool], None, None]:
     nghttpx = NghttpxQuic(env=env)
-    if nghttpx.exists() and (env.have_h3() or nghttpx.https_port > 0):
+    if nghttpx.exists() and env.have_h3():
         nghttpx.clear_logs()
         assert nghttpx.start()
-    yield nghttpx
-    nghttpx.stop()
+        yield nghttpx
+        nghttpx.stop()
+    else:
+        yield False
 
-@pytest.fixture(scope='package')
-def nghttpx_fwd(env, httpd) -> Generator[Nghttpx, None, None]:
+
+@pytest.fixture(scope='session')
+def nghttpx_fwd(env, httpd) -> Generator[Union[Nghttpx,bool], None, None]:
     nghttpx = NghttpxFwd(env=env)
-    if nghttpx.exists() and (env.have_h3() or nghttpx.https_port > 0):
+    if nghttpx.exists():
         nghttpx.clear_logs()
         assert nghttpx.start()
-    yield nghttpx
-    nghttpx.stop()
+        yield nghttpx
+        nghttpx.stop()
+    else:
+        yield False
+
+
+@pytest.fixture(scope='session')
+def configures_httpd(env, httpd) -> Generator[bool, None, None]:
+    # include this fixture as test parameter if the test configures httpd itself
+    yield True
+
+
+@pytest.fixture(autouse=True, scope='function')
+def server_reset(request, env, httpd):
+    # make sure httpd is in default configuration when a test starts
+    if 'configures_httpd' not in request.node._fixtureinfo.argnames:
+        httpd.clear_extra_configs()
+        httpd.set_proxy_auth(False)
+        httpd.reload_if_config_changed()

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -101,9 +101,7 @@ def httpd(env) -> Generator[Httpd, None, None]:
     if not httpd.exists():
         pytest.skip(f'httpd not found: {env.httpd}')
     httpd.clear_logs()
-    if not httpd.start():
-        httpd.stop()
-        assert httpd.start(), f'failed to start httpd: {env.httpd}'
+    assert httpd.initial_start()
     yield httpd
     httpd.stop()
 
@@ -113,7 +111,7 @@ def nghttpx(env, httpd) -> Generator[Union[Nghttpx,bool], None, None]:
     nghttpx = NghttpxQuic(env=env)
     if nghttpx.exists() and env.have_h3():
         nghttpx.clear_logs()
-        assert nghttpx.start()
+        assert nghttpx.initial_start()
         yield nghttpx
         nghttpx.stop()
     else:
@@ -125,7 +123,7 @@ def nghttpx_fwd(env, httpd) -> Generator[Union[Nghttpx,bool], None, None]:
     nghttpx = NghttpxFwd(env=env)
     if nghttpx.exists():
         nghttpx.clear_logs()
-        assert nghttpx.start()
+        assert nghttpx.initial_start()
         yield nghttpx
         nghttpx.stop()
     else:

--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -102,7 +102,8 @@ def httpd(env) -> Generator[Httpd, None, None]:
         pytest.skip(f'httpd not found: {env.httpd}')
     httpd.clear_logs()
     if not httpd.start():
-        pytest.fail(f'failed to start httpd: {env.httpd}')
+        httpd.stop()
+        assert httpd.start(), f'failed to start httpd: {env.httpd}'
     yield httpd
     httpd.stop()
 

--- a/tests/http/requirements.txt
+++ b/tests/http/requirements.txt
@@ -25,6 +25,8 @@
 #
 pytest
 cryptography
+filelock
 multipart
 websockets
 psutil
+pytest-xdist

--- a/tests/http/scorecard.py
+++ b/tests/http/scorecard.py
@@ -776,11 +776,11 @@ def main():
                 f'httpd not found: {env.httpd}'
             httpd.clear_logs()
             server_docs = httpd.docs_dir
-            assert httpd.start()
+            assert httpd.initial_start()
             if protocol == 'h3':
                 nghttpx = NghttpxQuic(env=env)
                 nghttpx.clear_logs()
-                assert nghttpx.start()
+                assert nghttpx.initial_start()
                 server_descr = f'nghttpx: https:{env.h3_port} [backend httpd: {env.httpd_version()}, https:{env.https_port}]'
                 server_port = env.h3_port
             else:
@@ -803,10 +803,10 @@ def main():
                 assert httpd.exists(), \
                     f'httpd not found: {env.httpd}'
                 httpd.clear_logs()
-                assert httpd.start()
+                assert httpd.initial_start()
             caddy = Caddy(env=env)
             caddy.clear_logs()
-            assert caddy.start()
+            assert caddy.initial_start()
             server_descr = f'Caddy: {env.caddy_version()}, http:{env.caddy_http_port} https:{env.caddy_https_port}{backend}'
             server_port = caddy.port
             server_docs = caddy.docs_dir

--- a/tests/http/test_01_basic.py
+++ b/tests/http/test_01_basic.py
@@ -156,7 +156,7 @@ class TestBasic:
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}' \
-              f'/curltest/tweak?x-hd={48 * 1024}'
+            f'/curltest/tweak?x-hd={48 * 1024}'
         r = curl.http_get(url=url, alpn_proto=proto, extra_args=[])
         r.check_exit_code(0)
         assert len(r.responses) == 1, f'{r.responses}'
@@ -173,7 +173,7 @@ class TestBasic:
         httpd.reload_if_config_changed()
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}' \
-              f'/curltest/tweak?x-hd={128 * 1024}'
+            f'/curltest/tweak?x-hd={128 * 1024}'
         r = curl.http_get(url=url, alpn_proto=proto, extra_args=[])
         r.check_exit_code(0)
         assert len(r.responses) == 1, f'{r.responses}'
@@ -191,7 +191,7 @@ class TestBasic:
         httpd.reload_if_config_changed()
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}' \
-              f'/curltest/tweak?x-hd1={128 * 1024}'
+            f'/curltest/tweak?x-hd1={128 * 1024}'
         r = curl.http_get(url=url, alpn_proto=proto, extra_args=[])
         if proto == 'h2':
             r.check_exit_code(16)  # CURLE_HTTP2
@@ -211,7 +211,7 @@ class TestBasic:
         httpd.reload_if_config_changed()
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}' \
-              f'/curltest/tweak?x-hd={256 * 1024}'
+            f'/curltest/tweak?x-hd={256 * 1024}'
         r = curl.http_get(url=url, alpn_proto=proto, extra_args=[])
         if proto == 'h2':
             r.check_exit_code(16)  # CURLE_HTTP2
@@ -230,7 +230,7 @@ class TestBasic:
         httpd.reload_if_config_changed()
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}' \
-              f'/curltest/tweak?x-hd1={256 * 1024}'
+            f'/curltest/tweak?x-hd1={256 * 1024}'
         r = curl.http_get(url=url, alpn_proto=proto, extra_args=[])
         if proto == 'h2':
             r.check_exit_code(16)  # CURLE_HTTP2

--- a/tests/http/test_03_goaway.py
+++ b/tests/http/test_03_goaway.py
@@ -43,12 +43,13 @@ class TestGoAway:
         proto = 'h2'
         count = 3
         self.r = None
+
         def long_run():
             curl = CurlClient(env=env)
             #  send 10 chunks of 1024 bytes in a response body with 100ms delay in between
             urln = f'https://{env.authority_for(env.domain1, proto)}' \
-                   f'/curltest/tweak?id=[0-{count - 1}]'\
-                   '&chunks=10&chunk_size=1024&chunk_delay=100ms'
+                f'/curltest/tweak?id=[0-{count - 1}]'\
+                '&chunks=10&chunk_size=1024&chunk_delay=100ms'
             self.r = curl.http_download(urls=[urln], alpn_proto=proto)
 
         t = Thread(target=long_run)
@@ -79,12 +80,13 @@ class TestGoAway:
             pytest.skip('OpenSSL QUIC fails here')
         count = 3
         self.r = None
+
         def long_run():
             curl = CurlClient(env=env)
             #  send 10 chunks of 1024 bytes in a response body with 100ms delay in between
             urln = f'https://{env.authority_for(env.domain1, proto)}' \
-                   f'/curltest/tweak?id=[0-{count - 1}]'\
-                   '&chunks=10&chunk_size=1024&chunk_delay=100ms'
+                f'/curltest/tweak?id=[0-{count - 1}]'\
+                '&chunks=10&chunk_size=1024&chunk_delay=100ms'
             self.r = curl.http_download(urls=[urln], alpn_proto=proto)
 
         t = Thread(target=long_run)
@@ -109,13 +111,14 @@ class TestGoAway:
         proto = 'http/1.1'
         count = 3
         self.r = None
+
         def long_run():
             curl = CurlClient(env=env)
             #  send 10 chunks of 1024 bytes in a response body with 100ms delay in between
             # pause 2 seconds between requests
             urln = f'https://{env.authority_for(env.domain1, proto)}' \
-                   f'/curltest/tweak?id=[0-{count - 1}]'\
-                   '&chunks=10&chunk_size=1024&chunk_delay=100ms'
+                f'/curltest/tweak?id=[0-{count - 1}]'\
+                '&chunks=10&chunk_size=1024&chunk_delay=100ms'
             self.r = curl.http_download(urls=[urln], alpn_proto=proto, extra_args=[
                 '--rate', '30/m',
             ])

--- a/tests/http/test_03_goaway.py
+++ b/tests/http/test_03_goaway.py
@@ -38,13 +38,6 @@ log = logging.getLogger(__name__)
 
 class TestGoAway:
 
-    @pytest.fixture(autouse=True, scope='class')
-    def _class_scope(self, env, httpd, nghttpx):
-        if env.have_h3():
-            nghttpx.start_if_needed()
-        httpd.clear_extra_configs()
-        httpd.reload()
-
     # download files sequentially with delay, reload server for GOAWAY
     def test_03_01_h2_goaway(self, env: Env, httpd, nghttpx):
         proto = 'h2'
@@ -99,7 +92,7 @@ class TestGoAway:
         # each request will take a second, reload the server in the middle
         # of the first one.
         time.sleep(1.5)
-        assert nghttpx.reload(timeout=timedelta(seconds=2))
+        assert nghttpx.reload(timeout=timedelta(seconds=30))
         t.join()
         r: ExecResult = self.r
         # this should take `count` seconds to retrieve, maybe a little less

--- a/tests/http/test_03_goaway.py
+++ b/tests/http/test_03_goaway.py
@@ -92,7 +92,7 @@ class TestGoAway:
         # each request will take a second, reload the server in the middle
         # of the first one.
         time.sleep(1.5)
-        assert nghttpx.reload(timeout=timedelta(seconds=30))
+        assert nghttpx.reload(timeout=timedelta(seconds=Env.SERVER_TIMEOUT))
         t.join()
         r: ExecResult = self.r
         # this should take `count` seconds to retrieve, maybe a little less

--- a/tests/http/test_04_stuttered.py
+++ b/tests/http/test_04_stuttered.py
@@ -46,8 +46,8 @@ class TestStuttered:
         count = 1
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
-               f'/curltest/tweak?id=[0-{count - 1}]'\
-               '&chunks=100&chunk_size=100&chunk_delay=10ms'
+            f'/curltest/tweak?id=[0-{count - 1}]'\
+            '&chunks=100&chunk_size=100&chunk_delay=10ms'
         r = curl.http_download(urls=[urln], alpn_proto=proto)
         r.check_response(count=1, http_status=200)
 
@@ -63,8 +63,8 @@ class TestStuttered:
         curl = CurlClient(env=env)
         url1 = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-{warmups-1}]'
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
-               f'/curltest/tweak?id=[0-{count-1}]'\
-               '&chunks=100&chunk_size=100&chunk_delay=10ms'
+            f'/curltest/tweak?id=[0-{count-1}]'\
+            '&chunks=100&chunk_size=100&chunk_delay=10ms'
         r = curl.http_download(urls=[url1, urln], alpn_proto=proto,
                                extra_args=['--parallel'])
         r.check_response(count=warmups+count, http_status=200)
@@ -85,8 +85,8 @@ class TestStuttered:
         curl = CurlClient(env=env)
         url1 = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-{warmups-1}]'
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
-               f'/curltest/tweak?id=[0-{count - 1}]'\
-               '&chunks=1000&chunk_size=10&chunk_delay=100us'
+            f'/curltest/tweak?id=[0-{count - 1}]'\
+            '&chunks=1000&chunk_size=10&chunk_delay=100us'
         r = curl.http_download(urls=[url1, urln], alpn_proto=proto,
                                extra_args=['--parallel'])
         r.check_response(count=warmups+count, http_status=200)
@@ -107,8 +107,8 @@ class TestStuttered:
         curl = CurlClient(env=env)
         url1 = f'https://{env.authority_for(env.domain1, proto)}/data.json?[0-{warmups-1}]'
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
-               f'/curltest/tweak?id=[0-{count - 1}]'\
-               '&chunks=10000&chunk_size=1&chunk_delay=50us'
+            f'/curltest/tweak?id=[0-{count - 1}]'\
+            '&chunks=10000&chunk_size=1&chunk_delay=50us'
         r = curl.http_download(urls=[url1, urln], alpn_proto=proto,
                                extra_args=['--parallel'])
         r.check_response(count=warmups+count, http_status=200)

--- a/tests/http/test_04_stuttered.py
+++ b/tests/http/test_04_stuttered.py
@@ -38,13 +38,6 @@ log = logging.getLogger(__name__)
 @pytest.mark.skipif(condition=Env().ci_run, reason="not suitable for CI runs")
 class TestStuttered:
 
-    @pytest.fixture(autouse=True, scope='class')
-    def _class_scope(self, env, httpd, nghttpx):
-        if env.have_h3():
-            nghttpx.start_if_needed()
-        httpd.clear_extra_configs()
-        httpd.reload()
-
     # download 1 file, check that delayed response works in general
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_04_01_download_1(self, env: Env, httpd, nghttpx, proto):

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -47,8 +47,8 @@ class TestErrors:
         count = 1
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
-               f'/curltest/tweak?id=[0-{count - 1}]'\
-               '&chunks=3&chunk_size=16000&body_error=reset'
+            f'/curltest/tweak?id=[0-{count - 1}]'\
+            '&chunks=3&chunk_size=16000&body_error=reset'
         r = curl.http_download(urls=[urln], alpn_proto=proto, extra_args=[
             '--retry', '0'
         ])
@@ -69,8 +69,8 @@ class TestErrors:
         count = 20
         curl = CurlClient(env=env)
         urln = f'https://{env.authority_for(env.domain1, proto)}' \
-               f'/curltest/tweak?id=[0-{count - 1}]'\
-               '&chunks=5&chunk_size=16000&body_error=reset'
+            f'/curltest/tweak?id=[0-{count - 1}]'\
+            '&chunks=5&chunk_size=16000&body_error=reset'
         r = curl.http_download(urls=[urln], alpn_proto=proto, extra_args=[
             '--retry', '0', '--parallel',
         ])
@@ -114,7 +114,7 @@ class TestErrors:
         count = 10 if proto == 'h2' else 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}'\
-                f'/curltest/shutdown_unclean?id=[0-{count-1}]&chunks=4'
+            f'/curltest/shutdown_unclean?id=[0-{count-1}]&chunks=4'
         r = curl.http_download(urls=[url], alpn_proto=proto, extra_args=[
             '--parallel',
         ])

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -37,13 +37,6 @@ log = logging.getLogger(__name__)
                     reason=f"httpd version too old for this: {Env.httpd_version()}")
 class TestErrors:
 
-    @pytest.fixture(autouse=True, scope='class')
-    def _class_scope(self, env, httpd, nghttpx):
-        if env.have_h3():
-            nghttpx.start_if_needed()
-        httpd.clear_extra_configs()
-        httpd.reload()
-
     # download 1 file, check that we get CURLE_PARTIAL_FILE
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_05_01_partial_1(self, env: Env, httpd, nghttpx, proto):

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -64,6 +64,8 @@ class TestErrors:
     def test_05_02_partial_20(self, env: Env, httpd, nghttpx, proto):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
+        if proto == 'h3' and env.curl_uses_ossl_quic():
+            pytest.skip("openssl-quic is flaky in yielding proper error codes")
         if proto == 'h3' and env.curl_uses_lib('msh3'):
             pytest.skip("msh3 stalls here")
         count = 20

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -30,7 +30,7 @@ import logging
 import os
 import re
 import pytest
-from typing import List
+from typing import List, Union
 
 from testenv import Env, CurlClient, LocalClient, ExecResult
 
@@ -518,7 +518,7 @@ class TestUpload:
         respdata = open(curl.response_file(0)).readlines()
         assert respdata == indata
 
-    def check_download(self, r: ExecResult, count: int, srcfile: str | os.PathLike, curl: CurlClient):
+    def check_download(self, r: ExecResult, count: int, srcfile: Union[str, os.PathLike], curl: CurlClient):
         for i in range(count):
             dfile = curl.download_file(i)
             assert os.path.exists(dfile), f'download {dfile} missing\n{r.dump_logs()}'

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -32,7 +32,7 @@ import re
 import pytest
 from typing import List
 
-from testenv import Env, CurlClient, LocalClient
+from testenv import Env, CurlClient, LocalClient, ExecResult
 
 
 log = logging.getLogger(__name__)
@@ -518,7 +518,7 @@ class TestUpload:
         respdata = open(curl.response_file(0)).readlines()
         assert respdata == indata
 
-    def check_download(self, r, count, srcfile, curl):
+    def check_download(self, r: ExecResult, count: int, srcfile: str | os.PathLike, curl: CurlClient):
         for i in range(count):
             dfile = curl.download_file(i)
             assert os.path.exists(dfile), f'download {dfile} missing\n{r.dump_logs()}'

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -286,7 +286,7 @@ class TestUpload:
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put?id=[0-{count-1}]'
         r = curl.http_put(urls=[url], fdata=fdata, alpn_proto=proto,
-                             extra_args=['--parallel'])
+                          extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
@@ -306,7 +306,7 @@ class TestUpload:
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put?id=[0-{count-1}]&chunk_delay=2ms'
         r = curl.http_put(urls=[url], fdata=fdata, alpn_proto=proto,
-                             extra_args=['--parallel'])
+                          extra_args=['--parallel'])
         r.check_stats(count=count, http_status=200, exitcode=0)
         exp_data = [f'{os.path.getsize(fdata)}']
         r.check_response(count=count, http_status=200)
@@ -543,7 +543,7 @@ class TestUpload:
             pytest.skip(f'example client not built: {client.name}')
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo?id=[0-0]&die_after=0'
         r = client.run(['-V', proto, url])
-        if r.exit_code == 18: # PARTIAL_FILE is always ok
+        if r.exit_code == 18:  # PARTIAL_FILE is always ok
             pass
         elif proto == 'h2':
             # CURLE_HTTP2, CURLE_HTTP2_STREAM
@@ -600,7 +600,7 @@ class TestUpload:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put?'\
             f'id=[0-{count-1}]&max_upload={max_upload}'
         r = curl.http_put(urls=[url], fdata=fdata, alpn_proto=proto,
-                             extra_args=['--trace-config', 'all'])
+                          extra_args=['--trace-config', 'all'])
         r.check_stats(count=count, http_status=413, exitcode=0)
 
     # speed limited on put handler
@@ -648,7 +648,7 @@ class TestUpload:
         read_delay = 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put?id=[0-0]'\
-              f'&read_delay={read_delay}s'
+            f'&read_delay={read_delay}s'
         r = curl.http_put(urls=[url], fdata=fdata, alpn_proto=proto, extra_args=[
             '--expect100-timeout', f'{read_delay+1}'
         ])
@@ -661,7 +661,7 @@ class TestUpload:
         read_delay = 2
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/put?id=[0-0]'\
-              f'&read_delay={read_delay}s'
+            f'&read_delay={read_delay}s'
         r = curl.http_put(urls=[url], fdata=fdata, alpn_proto=proto, extra_args=[
             '--expect100-timeout', f'{read_delay-1}'
         ])

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -44,7 +44,7 @@ class TestCaddy:
     @pytest.fixture(autouse=True, scope='class')
     def caddy(self, env):
         caddy = Caddy(env=env)
-        assert caddy.start()
+        assert caddy.initial_start()
         yield caddy
         caddy.stop()
 

--- a/tests/http/test_08_caddy.py
+++ b/tests/http/test_08_caddy.py
@@ -152,8 +152,8 @@ class TestCaddy:
         if proto == 'h3' and env.curl_uses_lib('msh3'):
             pytest.skip("msh3 itself crashes")
         if proto == 'http/1.1' and env.curl_uses_lib('mbedtls'):
-            pytest.skip("mbedtls 3.6.0 fails on 50 connections with: "\
-                "ssl_handshake returned: (-0x7F00) SSL - Memory allocation failed")
+            pytest.skip("mbedtls 3.6.0 fails on 50 connections with: "
+                        "ssl_handshake returned: (-0x7F00) SSL - Memory allocation failed")
         count = 50
         curl = CurlClient(env=env)
         urln = f'https://{env.domain1}:{caddy.port}/data10.data?[0-{count-1}]'

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -259,7 +259,7 @@ class TestProxy:
         url = f'https://localhost:{env.https_port}/data.json'
         proxy_args = curl.get_proxy_args(tunnel=True, proto=tunnel)
         r1 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
-                               extra_args=proxy_args)
+                                extra_args=proxy_args)
         r1.check_response(count=1, http_status=200)
         assert self.get_tunnel_proto_used(r1) == 'HTTP/2' \
             if tunnel == 'h2' else 'HTTP/1.1'
@@ -268,7 +268,7 @@ class TestProxy:
         x2_args.append('--next')
         x2_args.extend(proxy_args)
         r2 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
-                               extra_args=x2_args)
+                                extra_args=x2_args)
         r2.check_response(count=2, http_status=200)
         assert r2.total_connects == 1
 
@@ -284,7 +284,7 @@ class TestProxy:
         url = f'https://localhost:{env.https_port}/data.json'
         proxy_args = curl.get_proxy_args(tunnel=True, proto=tunnel)
         r1 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
-                               extra_args=proxy_args)
+                                extra_args=proxy_args)
         r1.check_response(count=1, http_status=200)
         assert self.get_tunnel_proto_used(r1) == 'HTTP/2' \
             if tunnel == 'h2' else 'HTTP/1.1'
@@ -294,7 +294,7 @@ class TestProxy:
         x2_args.extend(proxy_args)
         x2_args.extend(['--proxy-tls13-ciphers', 'TLS_AES_256_GCM_SHA384'])
         r2 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
-                               extra_args=x2_args)
+                                extra_args=x2_args)
         r2.check_response(count=2, http_status=200)
         assert r2.total_connects == 2
 
@@ -310,7 +310,7 @@ class TestProxy:
         url = f'http://localhost:{env.http_port}/data.json'
         proxy_args = curl.get_proxy_args(tunnel=True, proto=tunnel)
         r1 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
-                               extra_args=proxy_args)
+                                extra_args=proxy_args)
         r1.check_response(count=1, http_status=200)
         assert self.get_tunnel_proto_used(r1) == 'HTTP/2' \
             if tunnel == 'h2' else 'HTTP/1.1'
@@ -320,7 +320,7 @@ class TestProxy:
         x2_args.extend(proxy_args)
         x2_args.extend(['--proxy-tls13-ciphers', 'TLS_AES_256_GCM_SHA384'])
         r2 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
-                               extra_args=x2_args)
+                                extra_args=x2_args)
         r2.check_response(count=2, http_status=200)
         assert r2.total_connects == 2
 
@@ -336,7 +336,7 @@ class TestProxy:
         url = f'https://localhost:{env.https_port}/data.json'
         proxy_args = curl.get_proxy_args(tunnel=True, proto=tunnel)
         r1 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
-                               extra_args=proxy_args)
+                                extra_args=proxy_args)
         r1.check_response(count=1, http_status=200)
         assert self.get_tunnel_proto_used(r1) == 'HTTP/2' \
             if tunnel == 'h2' else 'HTTP/1.1'
@@ -346,7 +346,7 @@ class TestProxy:
         x2_args.extend(proxy_args)
         x2_args.extend(['--tls13-ciphers', 'TLS_AES_256_GCM_SHA384'])
         r2 = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
-                               extra_args=x2_args)
+                                extra_args=x2_args)
         r2.check_response(count=2, http_status=200)
         assert r2.total_connects == 2
 
@@ -365,7 +365,7 @@ class TestProxy:
                                extra_args=xargs)
         if env.curl_uses_lib('mbedtls') and \
                 not env.curl_lib_version_at_least('mbedtls', '3.5.0'):
-            r.check_exit_code(60) # CURLE_PEER_FAILED_VERIFICATION
+            r.check_exit_code(60)  # CURLE_PEER_FAILED_VERIFICATION
         else:
             r.check_response(count=1, http_status=200,
                              protocol='HTTP/2' if proto == 'h2' else 'HTTP/1.1')

--- a/tests/http/test_11_unix.py
+++ b/tests/http/test_11_unix.py
@@ -37,12 +37,14 @@ from testenv import Env, CurlClient
 
 log = logging.getLogger(__name__)
 
+
 class UDSFaker:
 
     def __init__(self, path):
         self._uds_path = path
         self._done = False
         self._socket = None
+        self._thread = None
 
     @property
     def path(self):

--- a/tests/http/test_13_proxy_auth.py
+++ b/tests/http/test_13_proxy_auth.py
@@ -39,16 +39,9 @@ log = logging.getLogger(__name__)
                     reason=f"missing: {Env.incomplete_reason()}")
 class TestProxyAuth:
 
-    @pytest.fixture(autouse=True, scope='class')
-    def _class_scope(self, env, httpd, nghttpx_fwd):
-        if env.have_nghttpx():
-            nghttpx_fwd.start_if_needed()
-        httpd.clear_extra_configs()
+    def httpd_configure(self, env, httpd):
         httpd.set_proxy_auth(True)
-        httpd.reload()
-        yield
-        httpd.set_proxy_auth(False)
-        httpd.reload()
+        httpd.reload_if_config_changed()
 
     def get_tunnel_proto_used(self, r: ExecResult):
         for line in r.trace_lines:
@@ -59,7 +52,8 @@ class TestProxyAuth:
         return None
 
     # download via http: proxy (no tunnel), no auth
-    def test_13_01_proxy_no_auth(self, env: Env, httpd):
+    def test_13_01_proxy_no_auth(self, env: Env, httpd, configures_httpd):
+        self.httpd_configure(env, httpd)
         curl = CurlClient(env=env)
         url = f'http://localhost:{env.http_port}/data.json'
         r = curl.http_download(urls=[url], alpn_proto='http/1.1', with_stats=True,
@@ -67,7 +61,8 @@ class TestProxyAuth:
         r.check_response(count=1, http_status=407)
 
     # download via http: proxy (no tunnel), auth
-    def test_13_02_proxy_auth(self, env: Env, httpd):
+    def test_13_02_proxy_auth(self, env: Env, httpd, configures_httpd):
+        self.httpd_configure(env, httpd)
         curl = CurlClient(env=env)
         url = f'http://localhost:{env.http_port}/data.json'
         xargs = curl.get_proxy_args(proxys=False)
@@ -79,7 +74,8 @@ class TestProxyAuth:
     @pytest.mark.skipif(condition=not Env.curl_has_feature('HTTPS-proxy'),
                         reason='curl lacks HTTPS-proxy support')
     @pytest.mark.skipif(condition=not Env.have_nghttpx(), reason="no nghttpx available")
-    def test_13_03_proxys_no_auth(self, env: Env, httpd, nghttpx_fwd):
+    def test_13_03_proxys_no_auth(self, env: Env, httpd, configures_httpd, nghttpx_fwd):
+        self.httpd_configure(env, httpd)
         curl = CurlClient(env=env)
         url = f'http://localhost:{env.http_port}/data.json'
         xargs = curl.get_proxy_args(proxys=True)
@@ -90,7 +86,8 @@ class TestProxyAuth:
     @pytest.mark.skipif(condition=not Env.curl_has_feature('HTTPS-proxy'),
                         reason='curl lacks HTTPS-proxy support')
     @pytest.mark.skipif(condition=not Env.have_nghttpx(), reason="no nghttpx available")
-    def test_13_04_proxys_auth(self, env: Env, httpd, nghttpx_fwd):
+    def test_13_04_proxys_auth(self, env: Env, httpd, configures_httpd, nghttpx_fwd):
+        self.httpd_configure(env, httpd)
         curl = CurlClient(env=env)
         url = f'http://localhost:{env.http_port}/data.json'
         xargs = curl.get_proxy_args(proxys=True)
@@ -99,7 +96,8 @@ class TestProxyAuth:
                                extra_args=xargs)
         r.check_response(count=1, http_status=200)
 
-    def test_13_05_tunnel_http_no_auth(self, env: Env, httpd):
+    def test_13_05_tunnel_http_no_auth(self, env: Env, httpd, configures_httpd, nghttpx_fwd):
+        self.httpd_configure(env, httpd)
         curl = CurlClient(env=env)
         url = f'http://localhost:{env.http_port}/data.json'
         xargs = curl.get_proxy_args(proxys=False, tunnel=True)
@@ -108,7 +106,8 @@ class TestProxyAuth:
         # expect "COULD_NOT_CONNECT"
         r.check_response(exitcode=56, http_status=None)
 
-    def test_13_06_tunnel_http_auth(self, env: Env, httpd):
+    def test_13_06_tunnel_http_auth(self, env: Env, httpd, configures_httpd):
+        self.httpd_configure(env, httpd)
         curl = CurlClient(env=env)
         url = f'http://localhost:{env.http_port}/data.json'
         xargs = curl.get_proxy_args(proxys=False, tunnel=True)
@@ -122,7 +121,8 @@ class TestProxyAuth:
                         reason='curl lacks HTTPS-proxy support')
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])
-    def test_13_07_tunnels_no_auth(self, env: Env, httpd, proto, tunnel):
+    def test_13_07_tunnels_no_auth(self, env: Env, httpd, configures_httpd, nghttpx_fwd, proto, tunnel):
+        self.httpd_configure(env, httpd)
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         curl = CurlClient(env=env)
@@ -140,7 +140,8 @@ class TestProxyAuth:
                         reason='curl lacks HTTPS-proxy support')
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])
-    def test_13_08_tunnels_auth(self, env: Env, httpd, proto, tunnel):
+    def test_13_08_tunnels_auth(self, env: Env, httpd, configures_httpd, nghttpx_fwd, proto, tunnel):
+        self.httpd_configure(env, httpd)
         if tunnel == 'h2' and not env.curl_uses_lib('nghttp2'):
             pytest.skip('only supported with nghttp2')
         curl = CurlClient(env=env)
@@ -156,7 +157,8 @@ class TestProxyAuth:
 
     @pytest.mark.skipif(condition=not Env.curl_has_feature('SPNEGO'),
                         reason='curl lacks SPNEGO support')
-    def test_13_09_negotiate_http(self, env: Env, httpd):
+    def test_13_09_negotiate_http(self, env: Env, httpd, configures_httpd):
+        self.httpd_configure(env, httpd)
         run_env = os.environ.copy()
         run_env['https_proxy'] = f'http://127.0.0.1:{env.proxy_port}'
         curl = CurlClient(env=env, run_env=run_env)

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -67,8 +67,7 @@ class TestAuth:
     def test_14_03_digest_put_auth(self, env: Env, httpd, nghttpx, proto):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
-        if proto == 'h3' and not env.curl_uses_lib('ngtcp2') and \
-           env.curl_uses_lib('openssl'):
+        if proto == 'h3' and env.curl_uses_ossl_quic():
             pytest.skip("openssl-quic is flaky in retrying POST")
         data='0123456789'
         curl = CurlClient(env=env)

--- a/tests/http/test_14_auth.py
+++ b/tests/http/test_14_auth.py
@@ -38,11 +38,7 @@ class TestAuth:
 
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env, httpd, nghttpx):
-        if env.have_h3():
-            nghttpx.start_if_needed()
         env.make_data_file(indir=env.gen_dir, fname="data-10m", fsize=10*1024*1024)
-        httpd.clear_extra_configs()
-        httpd.reload()
 
     # download 1 file, not authenticated
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
@@ -71,6 +67,9 @@ class TestAuth:
     def test_14_03_digest_put_auth(self, env: Env, httpd, nghttpx, proto):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
+        if proto == 'h3' and not env.curl_uses_lib('ngtcp2') and \
+           env.curl_uses_lib('openssl'):
+            pytest.skip("openssl-quic is flaky in retrying POST")
         data='0123456789'
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/restricted/digest/data.json'

--- a/tests/http/test_15_tracing.py
+++ b/tests/http/test_15_tracing.py
@@ -89,8 +89,7 @@ class TestTracing:
             m = re.match(r'^([0-9:.]+) \[0-[0x]] .+ \[TCP].+', line)
             if m is not None:
                 found_tcp = True
-        if not found_tcp:
-            assert False, f'TCP filter does not appear in trace "all": {r.stderr}'
+        assert found_tcp, f'TCP filter does not appear in trace "all": {r.stderr}'
 
     # trace all, no TCP, no time
     def test_15_05_trace_all(self, env: Env, httpd):

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -41,16 +41,8 @@ class TestSSLUse:
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env, httpd, nghttpx):
         env.make_data_file(indir=httpd.docs_dir, fname="data-10k", fsize=10*1024)
-        if env.have_h3():
-            nghttpx.start_if_needed()
 
-    @pytest.fixture(autouse=True, scope='function')
-    def _function_scope(self, request, env, httpd):
-        httpd.clear_extra_configs()
-        if 'httpd' not in request.node._fixtureinfo.argnames:
-            httpd.reload_if_config_changed()
-
-    def test_17_01_sslinfo_plain(self, env: Env, nghttpx):
+    def test_17_01_sslinfo_plain(self, env: Env, httpd):
         proto = 'http/1.1'
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/sslinfo'
@@ -61,7 +53,7 @@ class TestSSLUse:
         assert r.json['SSL_SESSION_RESUMED'] == 'Initial', f'{r.json}'
 
     @pytest.mark.parametrize("tls_max", ['1.2', '1.3'])
-    def test_17_02_sslinfo_reconnect(self, env: Env, tls_max):
+    def test_17_02_sslinfo_reconnect(self, env: Env, tls_max, httpd):
         proto = 'http/1.1'
         count = 3
         exp_resumed = 'Resumed'
@@ -102,7 +94,7 @@ class TestSSLUse:
 
     # use host name with trailing dot, verify handshake
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    def test_17_03_trailing_dot(self, env: Env, proto):
+    def test_17_03_trailing_dot(self, env: Env, proto, httpd, nghttpx):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -117,7 +109,7 @@ class TestSSLUse:
 
     # use host name with double trailing dot, verify handshake
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    def test_17_04_double_dot(self, env: Env, proto):
+    def test_17_04_double_dot(self, env: Env, proto, httpd, nghttpx):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -139,7 +131,7 @@ class TestSSLUse:
 
     # use ip address for connect
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    def test_17_05_ip_addr(self, env: Env, proto):
+    def test_17_05_ip_addr(self, env: Env, proto, httpd, nghttpx):
         if env.curl_uses_lib('bearssl'):
             pytest.skip("BearSSL does not support cert verification with IP addresses")
         if env.curl_uses_lib('mbedtls'):
@@ -158,7 +150,7 @@ class TestSSLUse:
 
     # use localhost for connect
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    def test_17_06_localhost(self, env: Env, proto):
+    def test_17_06_localhost(self, env: Env, proto, httpd, nghttpx):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -199,7 +191,7 @@ class TestSSLUse:
         return ret
 
     @pytest.mark.parametrize("tls_proto, ciphers13, ciphers12, succeed13, succeed12", gen_test_17_07_list())
-    def test_17_07_ssl_ciphers(self, env: Env, httpd, tls_proto, ciphers13, ciphers12, succeed13, succeed12):
+    def test_17_07_ssl_ciphers(self, env: Env, httpd, configures_httpd, tls_proto, ciphers13, ciphers12, succeed13, succeed12):
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
             'SSLCipherSuite SSL'
@@ -251,7 +243,7 @@ class TestSSLUse:
             assert r.exit_code != 0, r.dump_logs()
 
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    def test_17_08_cert_status(self, env: Env, proto):
+    def test_17_08_cert_status(self, env: Env, proto, httpd, nghttpx):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         if not env.curl_uses_lib('openssl') and \
@@ -275,7 +267,7 @@ class TestSSLUse:
                 for min_ver in range(-2, 4)]
 
     @pytest.mark.parametrize("tls_proto, max_ver, min_ver", gen_test_17_09_list())
-    def test_17_09_ssl_min_max(self, env: Env, httpd, tls_proto, max_ver, min_ver):
+    def test_17_09_ssl_min_max(self, env: Env, httpd, configures_httpd, tls_proto, max_ver, min_ver):
         httpd.set_extra_config('base', [
             f'SSLProtocol {tls_proto}',
             'SSLCipherSuite ALL:@SECLEVEL=0',
@@ -347,7 +339,7 @@ class TestSSLUse:
 
     # use host name server has no certificate for
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    def test_17_11_wrong_host(self, env: Env, proto):
+    def test_17_11_wrong_host(self, env: Env, proto, httpd, nghttpx):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -358,7 +350,7 @@ class TestSSLUse:
 
     # use host name server has no cert for with --insecure
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
-    def test_17_12_insecure(self, env: Env, proto):
+    def test_17_12_insecure(self, env: Env, proto, httpd, nghttpx):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -372,7 +364,7 @@ class TestSSLUse:
 
     # connect to an expired certificate
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
-    def test_17_14_expired_cert(self, env: Env, proto):
+    def test_17_14_expired_cert(self, env: Env, proto, httpd):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         curl = CurlClient(env=env)
@@ -430,7 +422,7 @@ class TestSSLUse:
 
     # verify the ciphers are ignored when talking TLSv1.3 only
     # see issue #16232
-    def test_17_16_h3_ignore_ciphers12(self, env: Env):
+    def test_17_16_h3_ignore_ciphers12(self, env: Env, httpd, nghttpx):
         proto = 'h3'
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
@@ -443,7 +435,7 @@ class TestSSLUse:
         ])
         assert r.exit_code == 0, f'{r}'
 
-    def test_17_17_h1_ignore_ciphers13(self, env: Env):
+    def test_17_17_h1_ignore_ciphers13(self, env: Env, httpd):
         proto = 'http/1.1'
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/sslinfo'
@@ -471,7 +463,7 @@ class TestSSLUse:
         pytest.param("-GROUP-ALL:+GROUP-X25519", "TLSv1.3", ['TLS_CHACHA20_POLY1305_SHA256'], True, id='TLSv1.3-group-only-X25519'),
         pytest.param("-GROUP-ALL:+GROUP-SECP192R1", "", [], False, id='group-only-SECP192R1'),
         ])
-    def test_17_18_gnutls_priority(self, env: Env, httpd, priority, tls_proto, ciphers, success):
+    def test_17_18_gnutls_priority(self, env: Env, httpd, configures_httpd, priority, tls_proto, ciphers, success):
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
             'SSLCipherSuite SSL'

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -74,7 +74,7 @@ class TestSSLUse:
         curl = CurlClient(env=env, run_env=run_env)
         # tell the server to close the connection after each request
         urln = f'https://{env.authority_for(env.domain1, proto)}/curltest/sslinfo?'\
-               f'id=[0-{count-1}]&close'
+            f'id=[0-{count-1}]&close'
         r = curl.http_download(urls=[urln], alpn_proto=proto, with_stats=True,
                                extra_args=xargs)
         r.check_response(count=count, http_status=200)
@@ -190,15 +190,19 @@ class TestSSLUse:
                     ret.append(pytest.param(tls_proto, ciphers13, ciphers12, succeed13, succeed12, id=id))
         return ret
 
-    @pytest.mark.parametrize("tls_proto, ciphers13, ciphers12, succeed13, succeed12", gen_test_17_07_list())
-    def test_17_07_ssl_ciphers(self, env: Env, httpd, configures_httpd, tls_proto, ciphers13, ciphers12, succeed13, succeed12):
+    @pytest.mark.parametrize(
+        "tls_proto, ciphers13, ciphers12, succeed13, succeed12",
+        gen_test_17_07_list())
+    def test_17_07_ssl_ciphers(self, env: Env, httpd, configures_httpd,
+                               tls_proto, ciphers13, ciphers12,
+                               succeed13, succeed12):
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
             'SSLCipherSuite SSL'
-                ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256'
-                ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
+            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256'
+            ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
             'SSLCipherSuite TLSv1.3'
-                ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
+            ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
             f'SSLProtocol {tls_proto}'
         ])
         httpd.reload_if_config_changed()
@@ -391,7 +395,7 @@ class TestSSLUse:
     def test_17_15_session_export(self, env: Env, httpd):
         proto = 'http/1.1'
         if env.curl_uses_lib('libressl'):
-           pytest.skip('Libressl resumption does not work inTLSv1.3')
+            pytest.skip('Libressl resumption does not work inTLSv1.3')
         if env.curl_uses_lib('rustls-ffi'):
             pytest.skip('rustsls does not expose sessions')
         if env.curl_uses_lib('bearssl'):
@@ -467,10 +471,10 @@ class TestSSLUse:
         # to test setting cipher suites, the AES 256 ciphers are disabled in the test server
         httpd.set_extra_config('base', [
             'SSLCipherSuite SSL'
-                ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256'
-                ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
+            ' ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256'
+            ':ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305',
             'SSLCipherSuite TLSv1.3'
-                ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
+            ' TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256',
         ])
         httpd.reload_if_config_changed()
         proto = 'http/1.1'

--- a/tests/http/test_18_methods.py
+++ b/tests/http/test_18_methods.py
@@ -62,6 +62,6 @@ class TestMethods:
         count = 1
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/tweak?id=[0-{count-1}]'\
-                '&chunks=1&chunk_size=0&chunk_delay=10ms'
+            '&chunks=1&chunk_size=0&chunk_delay=10ms'
         r = curl.http_delete(urls=[url], alpn_proto=proto)
         r.check_stats(count=count, http_status=204, exitcode=0)

--- a/tests/http/test_18_methods.py
+++ b/tests/http/test_18_methods.py
@@ -37,10 +37,6 @@ class TestMethods:
 
     @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env, httpd, nghttpx):
-        if env.have_h3():
-            nghttpx.start_if_needed()
-        httpd.clear_extra_configs()
-        httpd.reload_if_config_changed()
         indir = httpd.docs_dir
         env.make_data_file(indir=indir, fname="data-10k", fsize=10*1024)
         env.make_data_file(indir=indir, fname="data-100k", fsize=100*1024)

--- a/tests/http/test_19_shutdown.py
+++ b/tests/http/test_19_shutdown.py
@@ -100,7 +100,7 @@ class TestShutdown:
         r = curl.http_download(urls=[url], alpn_proto=proto)
         r.check_response(http_status=200, count=count)
         shutdowns = [line for line in r.trace_lines
-                     if re.match(r'.*\[SHUTDOWN\] shutdown, done=1', line)]
+                     if re.match(r'.*\[SHUTDOWN] shutdown, done=1', line)]
         assert len(shutdowns) == count, f'{shutdowns}'
 
     # run downloads with CURLOPT_FORBID_REUSE set, meaning *we* close
@@ -123,7 +123,7 @@ class TestShutdown:
         ])
         r.check_exit_code(0)
         shutdowns = [line for line in r.trace_lines
-                     if re.match(r'.*SHUTDOWN\] shutdown, done=1', line)]
+                     if re.match(r'.*SHUTDOWN] shutdown, done=1', line)]
         assert len(shutdowns) == count, f'{shutdowns}'
 
     # run event-based downloads with CURLOPT_FORBID_REUSE set, meaning *we* close
@@ -148,7 +148,7 @@ class TestShutdown:
         r.check_response(http_status=200, count=count)
         # check that we closed all connections
         closings = [line for line in r.trace_lines
-                    if re.match(r'.*SHUTDOWN\] (force )?closing', line)]
+                    if re.match(r'.*SHUTDOWN] (force )?closing', line)]
         assert len(closings) == count, f'{closings}'
         # check that all connection sockets were removed from event
         removes = [line for line in r.trace_lines
@@ -173,7 +173,7 @@ class TestShutdown:
         r.check_response(http_status=200, count=2)
         # check connection cache closings
         shutdowns = [line for line in r.trace_lines
-                     if re.match(r'.*SHUTDOWN\] shutdown, done=1', line)]
+                     if re.match(r'.*SHUTDOWN] shutdown, done=1', line)]
         assert len(shutdowns) == 1, f'{shutdowns}'
 
     # run connection pressure, many small transfers, not reusing connections,
@@ -192,7 +192,7 @@ class TestShutdown:
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         r = client.run(args=[
-             '-n', f'{count}',  #that many transfers
+             '-n', f'{count}',  # that many transfers
              '-f',  # forbid conn reuse
              '-m', '10',  # max parallel
              '-T', '5',  # max total conns at a time
@@ -201,6 +201,6 @@ class TestShutdown:
         ])
         r.check_exit_code(0)
         shutdowns = [line for line in r.trace_lines
-                     if re.match(r'.*SHUTDOWN\] shutdown, done=1', line)]
+                     if re.match(r'.*SHUTDOWN] shutdown, done=1', line)]
         # we see less clean shutdowns as total limit forces early closes
         assert len(shutdowns) < count, f'{shutdowns}'

--- a/tests/http/test_19_shutdown.py
+++ b/tests/http/test_19_shutdown.py
@@ -83,7 +83,7 @@ class TestShutdown:
         ])
         r.check_response(http_status=200, count=2)
         assert r.tcpdump
-        assert len(r.tcpdump.get_rsts(ports=[port])) == 0, 'Unexpected TCP RSTs packets'
+        assert len(r.tcpdump.get_rsts(ports=[port])) == 0, 'Unexpected TCP RST packets'
 
     # run downloads where the server closes the connection after each request
     @pytest.mark.parametrize("proto", ['http/1.1'])

--- a/tests/http/test_19_shutdown.py
+++ b/tests/http/test_19_shutdown.py
@@ -38,13 +38,6 @@ log = logging.getLogger(__name__)
 class TestShutdown:
 
     @pytest.fixture(autouse=True, scope='class')
-    def _class_scope(self, env, httpd, nghttpx):
-        if env.have_h3():
-            nghttpx.start_if_needed()
-        httpd.clear_extra_configs()
-        httpd.reload()
-
-    @pytest.fixture(autouse=True, scope='class')
     def _class_scope(self, env, httpd):
         indir = httpd.docs_dir
         env.make_data_file(indir=indir, fname="data-10k", fsize=10*1024)
@@ -74,6 +67,8 @@ class TestShutdown:
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     def test_19_02_check_shutdown(self, env: Env, httpd, proto):
+        if env.parallel_testing:
+            pytest.skip('does not work in parallel testing')
         if not env.curl_is_debug():
             pytest.skip('only works for curl debug builds')
         run_env = os.environ.copy()

--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -27,12 +27,15 @@
 import logging
 import os
 import shutil
+import socket
 import subprocess
 import time
 from datetime import datetime, timedelta
+from typing import Dict
 import pytest
 
 from testenv import Env, CurlClient, LocalClient
+from testenv.ports import alloc_ports_and_do
 
 
 log = logging.getLogger(__name__)
@@ -42,9 +45,13 @@ log = logging.getLogger(__name__)
                     reason='curl lacks ws protocol support')
 class TestWebsockets:
 
-    def check_alive(self, env, timeout=5):
+    PORT_SPECS = {
+        'ws': socket.SOCK_STREAM,
+    }
+
+    def check_alive(self, env, port, timeout=5):
         curl = CurlClient(env=env)
-        url = f'http://localhost:{env.ws_port}/'
+        url = f'http://localhost:{port}/'
         end = datetime.now() + timedelta(seconds=timeout)
         while datetime.now() < end:
             r = curl.http_download(urls=[url])
@@ -63,20 +70,36 @@ class TestWebsockets:
 
     @pytest.fixture(autouse=True, scope='class')
     def ws_echo(self, env):
-        run_dir = os.path.join(env.gen_dir, 'ws-echo-server')
-        err_file = os.path.join(run_dir, 'stderr')
-        self._rmrf(run_dir)
-        self._mkpath(run_dir)
+        self.run_dir = os.path.join(env.gen_dir, 'ws-echo-server')
+        err_file = os.path.join(self.run_dir, 'stderr')
+        self._rmrf(self.run_dir)
+        self._mkpath(self.run_dir)
+        self.cmd = os.path.join(env.project_dir,
+                                'tests/http/testenv/ws_echo_server.py')
+        self.wsproc = None
+        self.cerr = None
+
+        def startup(ports: Dict[str, int]) -> bool:
+            wargs = [self.cmd, '--port', str(ports['ws'])]
+            log.info(f'start_ {wargs}')
+            self.wsproc = subprocess.Popen(args=wargs,
+                                           cwd=self.run_dir,
+                                           stderr=self.cerr,
+                                           stdout=self.cerr)
+            if self.check_alive(env, ports['ws']):
+                env.update_ports(ports)
+                return True
+            log.error(f'not alive {wargs}')
+            self.wsproc.terminate()
+            self.wsproc = None
+            return False
 
         with open(err_file, 'w') as cerr:
-            cmd = os.path.join(env.project_dir,
-                               'tests/http/testenv/ws_echo_server.py')
-            args = [cmd, '--port', str(env.ws_port)]
-            p = subprocess.Popen(args=args, cwd=run_dir, stderr=cerr,
-                                 stdout=cerr)
-            assert self.check_alive(env)
+            assert alloc_ports_and_do(TestWebsockets.PORT_SPECS, startup,
+                                      env.gen_root, max_tries=3)
+            assert self.wsproc
             yield
-            p.terminate()
+            self.wsproc.terminate()
 
     def test_20_01_basic(self, env: Env, ws_echo):
         curl = CurlClient(env=env)

--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -147,7 +147,6 @@ class TestWebsockets:
             pytest.skip(f'example client not built: {client.name}')
         url = f'ws://localhost:{env.ws_port}/'
         count = 10
-        large = 512 * 1024
         large = 20000
         r = client.run(args=['-c', str(count), '-m', str(large), url])
         r.check_exit_code(0)

--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -94,7 +94,7 @@ class TestWebsockets:
             self.wsproc = None
             return False
 
-        with open(err_file, 'w') as cerr:
+        with open(err_file, 'w') as self.cerr:
             assert alloc_ports_and_do(TestWebsockets.PORT_SPECS, startup,
                                       env.gen_root, max_tries=3)
             assert self.wsproc

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -141,8 +141,6 @@ class TestVsFTPD:
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_30_06_shutdownh_download(self, env: Env, vsftpd: VsFTPD):
-        if env.parallel_testing:
-            pytest.skip('does not work in parallel testing')
         docname = 'data-1k'
         curl = CurlClient(env=env)
         count = 1
@@ -150,13 +148,15 @@ class TestVsFTPD:
         r = curl.ftp_get(urls=[url], with_stats=True, with_tcpdump=True)
         r.check_stats(count=count, http_status=226)
         assert r.tcpdump
-        assert len(r.tcpdump.stats) == 0, 'Unexpected TCP RSTs packets'
+        # vsftp closes control connection without niceties,
+        # look only at ports from DATA connection.
+        data_ports = vsftpd.get_data_ports(r)
+        assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
 
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_30_07_shutdownh_upload(self, env: Env, vsftpd: VsFTPD):
-        if env.parallel_testing:
-            pytest.skip('does not work in parallel testing')
         docname = 'upload-1k'
         curl = CurlClient(env=env)
         srcfile = os.path.join(env.gen_dir, docname)
@@ -167,7 +167,11 @@ class TestVsFTPD:
         r = curl.ftp_upload(urls=[url], fupload=f'{srcfile}', with_stats=True, with_tcpdump=True)
         r.check_stats(count=count, http_status=226)
         assert r.tcpdump
-        assert len(r.tcpdump.stats) == 0, 'Unexpected TCP RSTs packets'
+        # vsftp closes control connection without niceties,
+        # look only at ports from DATA connection.
+        data_ports = vsftpd.get_data_ports(r)
+        assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
 
     def test_30_08_active_download(self, env: Env, vsftpd: VsFTPD):
         docname = 'data-10k'

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -43,7 +43,7 @@ class TestVsFTPD:
     @pytest.fixture(autouse=True, scope='class')
     def vsftpd(self, env):
         vsftpd = VsFTPD(env=env)
-        assert vsftpd.start()
+        assert vsftpd.initial_start()
         yield vsftpd
         vsftpd.stop()
 

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -152,7 +152,7 @@ class TestVsFTPD:
         # look only at ports from DATA connection.
         data_ports = vsftpd.get_data_ports(r)
         assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
-        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RST packets'
 
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
@@ -171,7 +171,7 @@ class TestVsFTPD:
         # look only at ports from DATA connection.
         data_ports = vsftpd.get_data_ports(r)
         assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
-        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RST packets'
 
     def test_30_08_active_download(self, env: Env, vsftpd: VsFTPD):
         docname = 'data-10k'

--- a/tests/http/test_30_vsftpd.py
+++ b/tests/http/test_30_vsftpd.py
@@ -141,6 +141,8 @@ class TestVsFTPD:
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_30_06_shutdownh_download(self, env: Env, vsftpd: VsFTPD):
+        if env.parallel_testing:
+            pytest.skip('does not work in parallel testing')
         docname = 'data-1k'
         curl = CurlClient(env=env)
         count = 1
@@ -153,6 +155,8 @@ class TestVsFTPD:
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_30_07_shutdownh_upload(self, env: Env, vsftpd: VsFTPD):
+        if env.parallel_testing:
+            pytest.skip('does not work in parallel testing')
         docname = 'upload-1k'
         curl = CurlClient(env=env)
         srcfile = os.path.join(env.gen_dir, docname)

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -148,6 +148,8 @@ class TestVsFTPD:
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_31_06_shutdownh_download(self, env: Env, vsftpds: VsFTPD):
+        if env.parallel_testing:
+            pytest.skip('does not work in parallel testing')
         docname = 'data-1k'
         curl = CurlClient(env=env)
         count = 1
@@ -161,6 +163,8 @@ class TestVsFTPD:
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_31_07_shutdownh_upload(self, env: Env, vsftpds: VsFTPD):
+        if env.parallel_testing:
+            pytest.skip('does not work in parallel testing')
         docname = 'upload-1k'
         curl = CurlClient(env=env)
         srcfile = os.path.join(env.gen_dir, docname)

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -158,7 +158,7 @@ class TestVsFTPD:
         # look only at ports from DATA connection.
         data_ports = vsftpds.get_data_ports(r)
         assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
-        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RST packets'
 
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
@@ -176,7 +176,7 @@ class TestVsFTPD:
         # look only at ports from DATA connection.
         data_ports = vsftpds.get_data_ports(r)
         assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
-        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RST packets'
 
     def test_31_08_upload_ascii(self, env: Env, vsftpds: VsFTPD):
         docname = 'upload-ascii'

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -47,7 +47,7 @@ class TestVsFTPD:
         if not TestVsFTPD.SUPPORTS_SSL:
             pytest.skip('vsftpd does not seem to support SSL')
         vsftpds = VsFTPD(env=env, with_ssl=True)
-        if not vsftpds.start():
+        if not vsftpds.initial_start():
             vsftpds.stop()
             TestVsFTPD.SUPPORTS_SSL = False
             pytest.skip('vsftpd does not seem to support SSL')

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -28,6 +28,7 @@ import difflib
 import filecmp
 import logging
 import os
+import re
 import shutil
 import pytest
 
@@ -160,8 +161,6 @@ class TestFtpsVsFTPD:
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_32_06_shutdownh_download(self, env: Env, vsftpds: VsFTPD):
-        if env.parallel_testing:
-            pytest.skip('does not work in parallel testing')
         docname = 'data-1k'
         curl = CurlClient(env=env)
         count = 1
@@ -169,14 +168,14 @@ class TestFtpsVsFTPD:
         r = curl.ftp_get(urls=[url], with_stats=True, with_tcpdump=True)
         r.check_stats(count=count, http_status=226)
         # vsftp closes control connection without niceties,
-        # disregard RST packets it sent from its port to curl
-        assert len(r.tcpdump.stats_excluding(src_port=env.ftps_port)) == 0, 'Unexpected TCP RSTs packets'
+        # look only at ports from DATA connection.
+        data_ports = vsftpds.get_data_ports(r)
+        assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
 
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_32_07_shutdownh_upload(self, env: Env, vsftpds: VsFTPD):
-        if env.parallel_testing:
-            pytest.skip('does not work in parallel testing')
         docname = 'upload-1k'
         curl = CurlClient(env=env)
         srcfile = os.path.join(env.gen_dir, docname)
@@ -187,8 +186,10 @@ class TestFtpsVsFTPD:
         r = curl.ftp_upload(urls=[url], fupload=f'{srcfile}', with_stats=True, with_tcpdump=True)
         r.check_stats(count=count, http_status=226)
         # vsftp closes control connection without niceties,
-        # disregard RST packets it sent from its port to curl
-        assert len(r.tcpdump.stats_excluding(src_port=env.ftps_port)) == 0, 'Unexpected TCP RSTs packets'
+        # look only at ports from DATA connection.
+        data_ports = vsftpds.get_data_ports(r)
+        assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
 
     def test_32_08_upload_ascii(self, env: Env, vsftpds: VsFTPD):
         docname = 'upload-ascii'

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -47,7 +47,7 @@ class TestFtpsVsFTPD:
         if not TestFtpsVsFTPD.SUPPORTS_SSL:
             pytest.skip('vsftpd does not seem to support SSL')
         vsftpds = VsFTPD(env=env, with_ssl=True, ssl_implicit=True)
-        if not vsftpds.start():
+        if not vsftpds.initial_start():
             vsftpds.stop()
             TestFtpsVsFTPD.SUPPORTS_SSL = False
             pytest.skip('vsftpd does not seem to support SSL')

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -170,7 +170,7 @@ class TestFtpsVsFTPD:
         # look only at ports from DATA connection.
         data_ports = vsftpds.get_data_ports(r)
         assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
-        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RST packets'
 
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
@@ -188,7 +188,7 @@ class TestFtpsVsFTPD:
         # look only at ports from DATA connection.
         data_ports = vsftpds.get_data_ports(r)
         assert len(data_ports), f'unable to find FTP data port connected to\n{r.dump_logs()}'
-        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RSTs packets'
+        assert len(r.tcpdump.get_rsts(ports=data_ports)) == 0, 'Unexpected TCP RST packets'
 
     def test_32_08_upload_ascii(self, env: Env, vsftpds: VsFTPD):
         docname = 'upload-ascii'

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -160,6 +160,8 @@ class TestFtpsVsFTPD:
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_32_06_shutdownh_download(self, env: Env, vsftpds: VsFTPD):
+        if env.parallel_testing:
+            pytest.skip('does not work in parallel testing')
         docname = 'data-1k'
         curl = CurlClient(env=env)
         count = 1
@@ -173,6 +175,8 @@ class TestFtpsVsFTPD:
     # check with `tcpdump` if curl causes any TCP RST packets
     @pytest.mark.skipif(condition=not Env.tcpdump(), reason="tcpdump not available")
     def test_32_07_shutdownh_upload(self, env: Env, vsftpds: VsFTPD):
+        if env.parallel_testing:
+            pytest.skip('does not work in parallel testing')
         docname = 'upload-1k'
         curl = CurlClient(env=env)
         srcfile = os.path.join(env.gen_dir, docname)

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -28,7 +28,6 @@ import difflib
 import filecmp
 import logging
 import os
-import re
 import shutil
 import pytest
 

--- a/tests/http/testenv/caddy.py
+++ b/tests/http/testenv/caddy.py
@@ -85,12 +85,7 @@ class Caddy:
         self._process = subprocess.Popen(args=args, cwd=self._caddy_dir, stderr=caddyerr)
         if self._process.returncode is not None:
             return False
-        return not wait_live or self.wait_live(timeout=timedelta(seconds=5))
-
-    def stop_if_running(self):
-        if self.is_running():
-            return self.stop()
-        return True
+        return not wait_live or self.wait_live(timeout=timedelta(seconds=30))
 
     def stop(self, wait_dead=True):
         self._mkpath(self._tmp_dir)

--- a/tests/http/testenv/caddy.py
+++ b/tests/http/testenv/caddy.py
@@ -26,19 +26,26 @@
 #
 import logging
 import os
+import socket
 import subprocess
 import time
 from datetime import timedelta, datetime
 from json import JSONEncoder
+from typing import Dict
 
 from .curl import CurlClient
 from .env import Env
-
+from .ports import alloc_ports_and_do
 
 log = logging.getLogger(__name__)
 
 
 class Caddy:
+
+    PORT_SPECS = {
+        'caddy': socket.SOCK_STREAM,
+        'caddys': socket.SOCK_STREAM,
+    }
 
     def __init__(self, env: Env):
         self.env = env
@@ -49,6 +56,8 @@ class Caddy:
         self._error_log = os.path.join(self._caddy_dir, 'caddy.log')
         self._tmp_dir = os.path.join(self._caddy_dir, 'tmp')
         self._process = None
+        self._http_port = 0
+        self._https_port = 0
         self._rmf(self._error_log)
 
     @property
@@ -57,7 +66,7 @@ class Caddy:
 
     @property
     def port(self) -> int:
-        return self.env.caddy_https_port
+        return self._https_port
 
     def clear_logs(self):
         self._rmf(self._error_log)
@@ -73,7 +82,24 @@ class Caddy:
             return self.start()
         return True
 
+    def initial_start(self):
+
+        def startup(ports: Dict[str, int]) -> bool:
+            self._http_port = ports['caddy']
+            self._https_port = ports['caddys']
+            if self.start():
+                self.env.update_ports(ports)
+                return True
+            self.stop()
+            self._http_port = 0
+            self._https_port = 0
+            return False
+
+        return alloc_ports_and_do(Caddy.PORT_SPECS, startup,
+                                  self.env.gen_root, max_tries=3)
+
     def start(self, wait_live=True):
+        assert self._http_port > 0 and self._https_port > 0
         self._mkpath(self._tmp_dir)
         if self._process:
             self.stop()
@@ -150,22 +176,25 @@ class Caddy:
         with open(self._conf_file, 'w') as fd:
             conf = [   # base server config
                 '{',
-                f'  http_port {self.env.caddy_http_port}',
-                f'  https_port {self.env.caddy_https_port}',
-                f'  servers :{self.env.caddy_https_port} {{',
+                f'  http_port {self._http_port}',
+                f'  https_port {self._https_port}',
+                f'  servers :{self._https_port} {{',
                 '    protocols h3 h2 h1',
                 '  }',
                 '}',
-                f'{domain1}:{self.env.caddy_https_port} {{',
+                f'{domain1}:{self._https_port} {{',
                 '  file_server * {',
                 f'    root {self._docs_dir}',
                 '  }',
                 f'  tls {creds1.cert_file} {creds1.pkey_file}',
                 '}',
-                f'{domain2} {{',
-                f'  reverse_proxy /* http://localhost:{self.env.http_port} {{',
-                '  }',
-                f'  tls {creds2.cert_file} {creds2.pkey_file}',
-                '}',
             ]
+            if self.env.http_port > 0:
+                conf.extend([
+                    f'{domain2} {{',
+                    f'  reverse_proxy /* http://localhost:{self.env.http_port} {{',
+                    '  }',
+                    f'  tls {creds2.cert_file} {creds2.pkey_file}',
+                    '}',
+                ])
             fd.write("\n".join(conf))

--- a/tests/http/testenv/caddy.py
+++ b/tests/http/testenv/caddy.py
@@ -85,7 +85,7 @@ class Caddy:
         self._process = subprocess.Popen(args=args, cwd=self._caddy_dir, stderr=caddyerr)
         if self._process.returncode is not None:
             return False
-        return not wait_live or self.wait_live(timeout=timedelta(seconds=30))
+        return not wait_live or self.wait_live(timeout=timedelta(seconds=Env.SERVER_TIMEOUT))
 
     def stop(self, wait_dead=True):
         self._mkpath(self._tmp_dir)

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -315,6 +315,8 @@ class EnvConfig:
 
 class Env:
 
+    SERVER_TIMEOUT = 30  # seconds to wait for server to come up/reload
+
     CONFIG = EnvConfig()
 
     @staticmethod
@@ -492,10 +494,6 @@ class Env:
     @property
     def verbose(self) -> int:
         return self._verbose
-
-    @property
-    def parallel_testing(self) -> bool:
-        return Env.CONFIG.worker_id is not None and Env.CONFIG.worker_id != 'master'
 
     @property
     def test_timeout(self) -> Optional[float]:

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -29,7 +29,6 @@ import logging
 import os
 import re
 import shutil
-import socket
 import subprocess
 import tempfile
 from configparser import ConfigParser, ExtendedInterpolation

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -28,16 +28,17 @@ import inspect
 import logging
 import os
 import shutil
+import socket
 import subprocess
 from datetime import timedelta, datetime
 from json import JSONEncoder
 import time
-from typing import List, Union, Optional
+from typing import List, Union, Optional, Dict
 import copy
 
 from .curl import CurlClient, ExecResult
 from .env import Env
-
+from .ports import alloc_ports_and_do
 
 log = logging.getLogger(__name__)
 
@@ -61,6 +62,14 @@ class Httpd:
     ]
 
     MOD_CURLTEST = None
+
+    PORT_SPECS = {
+        'http': socket.SOCK_STREAM,
+        'https': socket.SOCK_STREAM,
+        'https-tcp-only': socket.SOCK_STREAM,
+        'proxy': socket.SOCK_STREAM,
+        'proxys': socket.SOCK_STREAM,
+    }
 
     def __init__(self, env: Env, proxy_auth: bool = False):
         self.env = env
@@ -91,7 +100,8 @@ class Httpd:
             raise Exception('apache modules dir cannot be found')
         if not os.path.exists(self._mods_dir):
             raise Exception(f'apache modules dir does not exist: {self._mods_dir}')
-        self._process = None
+        self._maybe_running = False
+        self.ports = {}
         self._rmf(self._error_log)
         self._init_curltest()
 
@@ -140,8 +150,25 @@ class Httpd:
                 "-k", cmd]
         return self._run(args=args)
 
+    def initial_start(self):
+
+        def startup(ports: Dict[str, int]) -> bool:
+            self.ports.update(ports)
+            if self.start():
+                self.env.update_ports(ports)
+                return True
+            self.stop()
+            self.ports.clear()
+            return False
+
+        return alloc_ports_and_do(Httpd.PORT_SPECS, startup,
+                                  self.env.gen_root, max_tries=3)
+
     def start(self):
-        if self._process:
+        # assure ports are allocated
+        for key, _ in Httpd.PORT_SPECS.items():
+            assert self.ports[key] is not None
+        if self._maybe_running:
             self.stop()
         self._write_config()
         with open(self._error_log, 'a') as fd:
@@ -166,10 +193,6 @@ class Httpd:
         log.fatal(f'stopping httpd failed: {r}')
         return r.exit_code == 0
 
-    def restart(self):
-        self.stop()
-        return self.start()
-
     def reload(self):
         self._write_config()
         r = self._cmd_httpd("graceful")
@@ -185,7 +208,8 @@ class Httpd:
         return self.wait_live(timeout=timedelta(seconds=Env.SERVER_TIMEOUT))
 
     def reload_if_config_changed(self):
-        if self._loaded_extra_configs == self._extra_configs and \
+        if self._maybe_running and \
+                self._loaded_extra_configs == self._extra_configs and \
                 self._loaded_proxy_auth == self._proxy_auth_basic:
             return True
         return self.reload()
@@ -194,8 +218,9 @@ class Httpd:
         curl = CurlClient(env=self.env, run_dir=self._tmp_dir)
         try_until = datetime.now() + timeout
         while datetime.now() < try_until:
-            r = curl.http_get(url=f'http://{self.env.domain1}:{self.env.http_port}/')
+            r = curl.http_get(url=f'http://{self.env.domain1}:{self.ports["http"]}/')
             if r.exit_code != 0:
+                self._maybe_running = False
                 return True
             time.sleep(.1)
         log.debug(f"Server still responding after {timeout}")
@@ -206,8 +231,9 @@ class Httpd:
                           timeout=timeout.total_seconds())
         try_until = datetime.now() + timeout
         while datetime.now() < try_until:
-            r = curl.http_get(url=f'http://{self.env.domain1}:{self.env.http_port}/')
+            r = curl.http_get(url=f'http://{self.env.domain1}:{self.ports["http"]}/')
             if r.exit_code == 0:
+                self._maybe_running = True
                 return True
             time.sleep(.1)
         log.error(f"Server still not responding after {timeout}")
@@ -276,20 +302,17 @@ class Httpd:
                 'ReadBufferSize 16000',
                 'H2MinWorkers 16',
                 'H2MaxWorkers 256',
-                f'Listen {self.env.http_port}',
-                f'Listen {self.env.https_port}',
-                f'Listen {self.env.https_only_tcp_port}',
-                f'Listen {self.env.proxy_port}',
-                f'Listen {self.env.proxys_port}',
                 f'TypesConfig "{self._conf_dir}/mime.types',
                 'SSLSessionCache "shmcb:ssl_gcache_data(32000)"',
                 'AddEncoding x-gzip .gz .tgz .gzip',
                 'AddHandler type-map .var',
             ]
+            conf.extend([f'Listen {port}' for _, port in self.ports.items()])
+
             if 'base' in self._extra_configs:
                 conf.extend(self._extra_configs['base'])
             conf.extend([  # plain http host for domain1
-                f'<VirtualHost *:{self.env.http_port}>',
+                f'<VirtualHost *:{self.ports["http"]}>',
                 f'    ServerName {domain1}',
                 '    ServerAlias localhost',
                 f'    DocumentRoot "{self._docs_dir}"',
@@ -302,7 +325,7 @@ class Httpd:
                 '',
             ])
             conf.extend([  # https host for domain1, h1 + h2
-                f'<VirtualHost *:{self.env.https_port}>',
+                f'<VirtualHost *:{self.ports["https"]}>',
                 f'    ServerName {domain1}',
                 '    ServerAlias localhost',
                 '    Protocols h2 http/1.1',
@@ -319,7 +342,7 @@ class Httpd:
                 '',
             ])
             conf.extend([  # https host for domain1, h1 + h2, tcp only
-                f'<VirtualHost *:{self.env.https_only_tcp_port}>',
+                f'<VirtualHost *:{self.ports["https-tcp-only"]}>',
                 f'    ServerName {domain1}',
                 '    ServerAlias localhost',
                 '    Protocols h2 http/1.1',
@@ -337,7 +360,7 @@ class Httpd:
             ])
             # Alternate to domain1 with BROTLI compression
             conf.extend([  # https host for domain1, h1 + h2
-                f'<VirtualHost *:{self.env.https_port}>',
+                f'<VirtualHost *:{self.ports["https"]}>',
                 f'    ServerName {domain1brotli}',
                 '    Protocols h2 http/1.1',
                 '    SSLEngine on',
@@ -354,7 +377,7 @@ class Httpd:
                 '',
             ])
             conf.extend([  # plain http host for domain2
-                f'<VirtualHost *:{self.env.http_port}>',
+                f'<VirtualHost *:{self.ports["http"]}>',
                 f'    ServerName {domain2}',
                 '    ServerAlias localhost',
                 f'    DocumentRoot "{self._docs_dir}"',
@@ -367,7 +390,7 @@ class Httpd:
             ])
             self._mkpath(os.path.join(self._docs_dir, 'two'))
             conf.extend([  # https host for domain2, no h2
-                f'<VirtualHost *:{self.env.https_port}>',
+                f'<VirtualHost *:{self.ports["https"]}>',
                 f'    ServerName {domain2}',
                 '    Protocols http/1.1',
                 '    SSLEngine on',
@@ -383,7 +406,7 @@ class Httpd:
                 '',
             ])
             conf.extend([  # https host for domain2, no h2, tcp only
-                f'<VirtualHost *:{self.env.https_only_tcp_port}>',
+                f'<VirtualHost *:{self.ports["https-tcp-only"]}>',
                 f'    ServerName {domain2}',
                 '    Protocols http/1.1',
                 '    SSLEngine on',
@@ -400,7 +423,7 @@ class Httpd:
             ])
             self._mkpath(os.path.join(self._docs_dir, 'expired'))
             conf.extend([  # https host for expired domain
-                f'<VirtualHost *:{self.env.https_port}>',
+                f'<VirtualHost *:{self.ports["https"]}>',
                 f'    ServerName {exp_domain}',
                 '    Protocols h2 http/1.1',
                 '    SSLEngine on',
@@ -416,13 +439,13 @@ class Httpd:
                 '',
             ])
             conf.extend([  # http forward proxy
-                f'<VirtualHost *:{self.env.proxy_port}>',
+                f'<VirtualHost *:{self.ports["proxy"]}>',
                 f'    ServerName {proxy_domain}',
                 '    Protocols h2c http/1.1',
                 '    ProxyRequests On',
                 '    H2ProxyRequests On',
                 '    ProxyVia On',
-                f'    AllowCONNECT {self.env.http_port} {self.env.https_port}',
+                f'    AllowCONNECT {self.ports["http"]} {self.ports["https"]}',
             ])
             conf.extend(self._get_proxy_conf())
             conf.extend([
@@ -430,7 +453,7 @@ class Httpd:
                 '',
             ])
             conf.extend([  # https forward proxy
-                f'<VirtualHost *:{self.env.proxys_port}>',
+                f'<VirtualHost *:{self.ports["proxys"]}>',
                 f'    ServerName {proxy_domain}',
                 '    Protocols h2 http/1.1',
                 '    SSLEngine on',
@@ -439,7 +462,7 @@ class Httpd:
                 '    ProxyRequests On',
                 '    H2ProxyRequests On',
                 '    ProxyVia On',
-                f'    AllowCONNECT {self.env.http_port} {self.env.https_port}',
+                f'    AllowCONNECT {self.ports["http"]} {self.ports["https"]}',
             ])
             conf.extend(self._get_proxy_conf())
             conf.extend([

--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -155,14 +155,14 @@ class Httpd:
             return False
         self._loaded_extra_configs = copy.deepcopy(self._extra_configs)
         self._loaded_proxy_auth = self._proxy_auth_basic
-        return self.wait_live(timeout=timedelta(seconds=30))
+        return self.wait_live(timeout=timedelta(seconds=Env.SERVER_TIMEOUT))
 
     def stop(self):
         r = self._cmd_httpd('stop')
         self._loaded_extra_configs = None
         self._loaded_proxy_auth = None
         if r.exit_code == 0:
-            return self.wait_dead(timeout=timedelta(seconds=30))
+            return self.wait_dead(timeout=timedelta(seconds=Env.SERVER_TIMEOUT))
         log.fatal(f'stopping httpd failed: {r}')
         return r.exit_code == 0
 
@@ -182,7 +182,7 @@ class Httpd:
             log.error(f'failed to reload httpd: {r}')
         self._loaded_extra_configs = copy.deepcopy(self._extra_configs)
         self._loaded_proxy_auth = self._proxy_auth_basic
-        return self.wait_live(timeout=timedelta(seconds=30))
+        return self.wait_live(timeout=timedelta(seconds=Env.SERVER_TIMEOUT))
 
     def reload_if_config_changed(self):
         if self._loaded_extra_configs == self._extra_configs and \

--- a/tests/http/testenv/nghttpx.py
+++ b/tests/http/testenv/nghttpx.py
@@ -84,11 +84,6 @@ class Nghttpx:
     def start(self, wait_live=True):
         pass
 
-    def stop_if_running(self):
-        if self.is_running():
-            return self.stop()
-        return True
-
     def stop(self, wait_dead=True):
         self._mkpath(self._tmp_dir)
         if self._process:
@@ -125,7 +120,7 @@ class Nghttpx:
                 os.kill(running.pid, signal.SIGKILL)
                 running.terminate()
                 running.wait(1)
-            return self.wait_live(timeout=timedelta(seconds=5))
+            return self.wait_live(timeout=timedelta(seconds=30))
         return False
 
     def wait_dead(self, timeout: timedelta):
@@ -169,7 +164,6 @@ class Nghttpx:
                 ])
             if r.exit_code == 0:
                 return True
-            log.debug(f'waiting for nghttpx to become responsive: {r}')
             time.sleep(.1)
         log.error(f"Server still not responding after {timeout}")
         return False
@@ -226,7 +220,7 @@ class NghttpxQuic(Nghttpx):
         self._process = subprocess.Popen(args=args, stderr=ngerr)
         if self._process.returncode is not None:
             return False
-        return not wait_live or self.wait_live(timeout=timedelta(seconds=5))
+        return not wait_live or self.wait_live(timeout=timedelta(seconds=30))
 
 
 class NghttpxFwd(Nghttpx):
@@ -258,7 +252,7 @@ class NghttpxFwd(Nghttpx):
         self._process = subprocess.Popen(args=args, stderr=ngerr)
         if self._process.returncode is not None:
             return False
-        return not wait_live or self.wait_live(timeout=timedelta(seconds=5))
+        return not wait_live or self.wait_live(timeout=timedelta(seconds=30))
 
     def wait_dead(self, timeout: timedelta):
         curl = CurlClient(env=self.env, run_dir=self._tmp_dir)
@@ -283,7 +277,6 @@ class NghttpxFwd(Nghttpx):
             ])
             if r.exit_code == 0:
                 return True
-            log.debug(f'waiting for nghttpx-fwd to become responsive: {r}')
             time.sleep(.1)
         log.error(f"Server still not responding after {timeout}")
         return False

--- a/tests/http/testenv/nghttpx.py
+++ b/tests/http/testenv/nghttpx.py
@@ -120,7 +120,7 @@ class Nghttpx:
                 os.kill(running.pid, signal.SIGKILL)
                 running.terminate()
                 running.wait(1)
-            return self.wait_live(timeout=timedelta(seconds=30))
+            return self.wait_live(timeout=timedelta(seconds=Env.SERVER_TIMEOUT))
         return False
 
     def wait_dead(self, timeout: timedelta):
@@ -220,7 +220,7 @@ class NghttpxQuic(Nghttpx):
         self._process = subprocess.Popen(args=args, stderr=ngerr)
         if self._process.returncode is not None:
             return False
-        return not wait_live or self.wait_live(timeout=timedelta(seconds=30))
+        return not wait_live or self.wait_live(timeout=timedelta(seconds=Env.SERVER_TIMEOUT))
 
 
 class NghttpxFwd(Nghttpx):
@@ -252,7 +252,7 @@ class NghttpxFwd(Nghttpx):
         self._process = subprocess.Popen(args=args, stderr=ngerr)
         if self._process.returncode is not None:
             return False
-        return not wait_live or self.wait_live(timeout=timedelta(seconds=30))
+        return not wait_live or self.wait_live(timeout=timedelta(seconds=Env.SERVER_TIMEOUT))
 
     def wait_dead(self, timeout: timedelta):
         curl = CurlClient(env=self.env, run_dir=self._tmp_dir)

--- a/tests/http/testenv/ports.py
+++ b/tests/http/testenv/ports.py
@@ -28,7 +28,7 @@ import logging
 import os
 import socket
 from collections.abc import Callable
-from typing import Dict, List
+from typing import Dict
 
 from filelock import FileLock
 

--- a/tests/http/testenv/ports.py
+++ b/tests/http/testenv/ports.py
@@ -24,16 +24,12 @@
 #
 ###########################################################################
 #
-import json
 import logging
 import os
-import re
 import socket
 from collections.abc import Callable
-from json import JSONEncoder
 from typing import Dict, List
 
-import pytest
 from filelock import FileLock
 
 log = logging.getLogger(__name__)

--- a/tests/http/testenv/ports.py
+++ b/tests/http/testenv/ports.py
@@ -29,6 +29,7 @@ import logging
 import os
 import re
 import socket
+from collections.abc import Callable
 from json import JSONEncoder
 from typing import Dict, List
 
@@ -38,63 +39,29 @@ from filelock import FileLock
 log = logging.getLogger(__name__)
 
 
-def alloc_port_sets(n: int, port_specs: Dict[str, int]) -> List[Dict[str, int]]:
-    port_sets = []
+def alloc_port_set(port_specs: Dict[str, int]) -> Dict[str, int]:
     socks = []
-    for _ in range(n):
-        ports = {}
-        for name, ptype in port_specs.items():
-            try:
-                s = socket.socket(type=ptype)
-                s.bind(('', 0))
-                ports[name] = s.getsockname()[1]
-                socks.append(s)
-            except Exception as e:
-                raise e
-        port_sets.append(ports)
+    ports = {}
+    for name, ptype in port_specs.items():
+        try:
+            s = socket.socket(type=ptype)
+            s.bind(('', 0))
+            ports[name] = s.getsockname()[1]
+            socks.append(s)
+        except Exception as e:
+            raise e
     for s in socks:
         s.close()
-    return port_sets
+    return ports
 
 
-def load_port_file(port_file, testrun_uid):
-    if os.path.exists(port_file):
-        with open(port_file) as f:
-            pjson = json.load(f)
-            try:
-                if 'testrun_uid' in pjson and \
-                        pjson['testrun_uid'] == str(testrun_uid):
-                    return pjson
-            except TypeError:
-                pass
-    return None
-
-
-def alloc_ports(config: pytest.Config,
-                gen_dir,
-                testrun_uid,
-                worker_id : str,
-                port_specs: Dict[str, int]) -> Dict[str, int]:
-    nworkers = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", 1))
-    m = re.match(r'\D+(\d+)', worker_id)
-    idx = int(m.group(1)) if m else 0
-    assert idx < nworkers
-    # several worker processes that need this set of ports. Make
-    # a global locked allocation for all of them, store in a file
-    #
-    # `testrun_uid` is the pytest-xdist generated id of this run.
-    port_file = os.path.join(gen_dir, 'allocated.ports')
-    lock_file = f'{port_file}.lock'
+def alloc_ports_and_do(port_spec: Dict[str, int],
+                       do_func: Callable[[Dict[str, int]], bool],
+                       gen_dir, max_tries=1) -> bool:
+    lock_file = os.path.join(gen_dir, 'ports.lock')
     with FileLock(lock_file):
-        port_json = load_port_file(port_file, testrun_uid)
-        if port_json is None:
-            # generate a complete port set for all workers
-            port_json = {
-                'testrun_uid': str(testrun_uid),
-                'sets': alloc_port_sets(nworkers, port_specs),
-            }
-            with open(port_file, 'w') as fd:
-                fd.write(JSONEncoder().encode(port_json))
-        assert port_json
-        assert len(port_json['sets']) == nworkers
-        return port_json['sets'][idx]
+        for _ in range(max_tries):
+            port_set = alloc_port_set(port_spec)
+            if do_func(port_set):
+                return True
+    return False

--- a/tests/http/testenv/ports.py
+++ b/tests/http/testenv/ports.py
@@ -24,24 +24,75 @@
 #
 ###########################################################################
 #
+import json
 import logging
+import os
+import re
 import socket
-from typing import Dict
+from json import JSONEncoder
+from typing import Dict, List
+
+import pytest
+from filelock import FileLock
 
 log = logging.getLogger(__name__)
 
 
-def alloc_ports(port_specs: Dict[str, int]) -> Dict[str, int]:
-    ports = {}
+def alloc_port_sets(n: int, port_specs: Dict[str, int]) -> List[Dict[str, int]]:
+    port_sets = []
     socks = []
-    for name, ptype in port_specs.items():
-        try:
-            s = socket.socket(type=ptype)
-            s.bind(('', 0))
-            ports[name] = s.getsockname()[1]
-            socks.append(s)
-        except Exception as e:
-            raise e
+    for _ in range(n):
+        ports = {}
+        for name, ptype in port_specs.items():
+            try:
+                s = socket.socket(type=ptype)
+                s.bind(('', 0))
+                ports[name] = s.getsockname()[1]
+                socks.append(s)
+            except Exception as e:
+                raise e
+        port_sets.append(ports)
     for s in socks:
         s.close()
-    return ports
+    return port_sets
+
+
+def alloc_ports(config: pytest.Config,
+                gen_dir,
+                testrun_uid,
+                worker_id : str,
+                port_specs: Dict[str, int]) -> Dict[str, int]:
+    if "PYTEST_XDIST_WORKER_COUNT" in os.environ:
+        nworkers = int(os.environ["PYTEST_XDIST_WORKER_COUNT"])
+    else:
+        nworkers = 1
+    m = re.match(r'\D+(\d+)', worker_id)
+    idx = int(m.group(1)) if m else 0
+    assert idx < nworkers
+    # several worker processes that need this set of ports. Make
+    # a global locked allocation for all of them, store in a file
+    #
+    # `testrun_uid` is the pytest-xdist generated id of this run.
+    lock_file = os.path.join(gen_dir, 'allocated.ports.lock')
+    port_file = os.path.join(gen_dir, 'allocated.ports')
+    with FileLock(lock_file):
+        port_json = None
+        if os.path.exists(port_file):
+            with open(port_file) as fd:
+                port_json = json.load(fd)
+            if 'testrun_uid' not in port_json or \
+                    port_json['testrun_uid'] != str(testrun_uid):
+                # file from other run or garbage file
+                port_json = None
+        if port_json is None:
+            # generate a complete port set for all workers
+            port_json = {
+                'testrun_uid': str(testrun_uid),
+                'sets': alloc_port_sets(nworkers, port_specs),
+            }
+            with open(port_file, 'w') as fd:
+                fd.write(JSONEncoder().encode(port_json))
+
+        assert port_json
+        assert len(port_json['sets']) == nworkers
+        return port_json['sets'][idx]

--- a/tests/http/testenv/vsftpd.py
+++ b/tests/http/testenv/vsftpd.py
@@ -92,11 +92,6 @@ class VsFTPD:
             return self.start()
         return True
 
-    def stop_if_running(self):
-        if self.is_running():
-            return self.stop()
-        return True
-
     def stop(self, wait_dead=True):
         self._mkpath(self._tmp_dir)
         if self._process:
@@ -123,7 +118,7 @@ class VsFTPD:
         self._process = subprocess.Popen(args=args, stderr=procerr)
         if self._process.returncode is not None:
             return False
-        return not wait_live or self.wait_live(timeout=timedelta(seconds=5))
+        return not wait_live or self.wait_live(timeout=timedelta(seconds=30))
 
     def wait_dead(self, timeout: timedelta):
         curl = CurlClient(env=self.env, run_dir=self._tmp_dir)
@@ -148,7 +143,6 @@ class VsFTPD:
             ])
             if r.exit_code == 0:
                 return True
-            log.debug(f'waiting for vsftpd to become responsive: {r}')
             time.sleep(.1)
         log.error(f"Server still not responding after {timeout}")
         return False

--- a/tests/http/testenv/vsftpd.py
+++ b/tests/http/testenv/vsftpd.py
@@ -197,9 +197,5 @@ class VsFTPD:
             fd.write("\n".join(conf))
 
     def get_data_ports(self, r: ExecResult) -> List[int]:
-        data_ports = []
-        for line in r.trace_lines:
-            m = re.match(r'.*Connected 2nd connection to .* port (\d+)', line)
-            if m:
-                data_ports.append(int(m.group(1)))
-        return data_ports
+        return [int(m.group(1)) for line in r.trace_lines if
+                (m := re.match(r'.*Connected 2nd connection to .* port (\d+)', line))]


### PR DESCRIPTION
Require now pytest-xdist from tests/http/requirements.txt and run pytest in 'auto' parallel mode (counts real cpu cores).

On my 10 core intel thingie, the durations shrink accordingly:
```sh
> make pytest
1 worker:   4m17s
10 workers: 0m44s
```

In CI, 2 workers are selected now - images seem to expose 2 cores. We could try to increase that, but local tests show that alignment to cores works pretty well.
