### PR TITLE
tests: stop using libcurl's strdup

### DIFF
--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -38,7 +38,6 @@ CURLX_SRCS = \
   ../../lib/curlx/timeval.c \
   ../../lib/curlx/dynbuf.c \
   ../../lib/strcase.c \
-  ../../lib/strdup.c \
   ../../lib/curlx/multibyte.c \
   ../../lib/curlx/version_win32.c
 
@@ -52,7 +51,6 @@ CURLX_HDRS = \
   ../../lib/curlx/timeval.h \
   ../../lib/curlx/dynbuf.h \
   ../../lib/strcase.h \
-  ../../lib/strdup.h \
   ../../lib/curlx/multibyte.h \
   ../../lib/curlx/version_win32.h
 

--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -66,7 +66,7 @@ curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)system_strdup;
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
 #if defined(_WIN32) && defined(UNICODE)
-curl_wcsdup_callback Curl_cwcsdup = Curl_wcsdup;
+curl_wcsdup_callback Curl_cwcsdup = NULL; /* not use in test code */
 #endif
 
 #if defined(_MSC_VER) && defined(_DLL)

--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -51,8 +51,6 @@
 
 #if defined(UNDER_CE)
 #define system_strdup _strdup
-#elif !defined(HAVE_STRDUP)
-#define system_strdup Curl_strdup
 #else
 #define system_strdup strdup
 #endif


### PR DESCRIPTION
It is not provided as a curlx function so should not be used outside of libcurl.

I strongly suspect that no system we build the test suite on lack strdup so this will not cause any harm.