### PR TITLE
lib: drop curlx_getpid, use fake pid in SMB

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -470,12 +470,6 @@
 #include <curl/stdcheaders.h>
 #endif
 
-#ifdef _WIN32
-#define curlx_getpid() GetCurrentProcessId()
-#else
-#define curlx_getpid() getpid()
-#endif
-
 /*
  * Large file (>2Gb) support using Win32 functions.
  */

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -596,7 +596,7 @@ static void smb_format_message(struct smb_conn *smbc,
                                struct smb_header *h,
                                unsigned char cmd, size_t len)
 {
-  unsigned int pid;
+  const unsigned int pid = 0xbad71d; /* made up */
 
   memset(h, 0, sizeof(*h));
   h->nbt_length = htons((unsigned short) (sizeof(*h) - sizeof(unsigned int) +
@@ -607,7 +607,6 @@ static void smb_format_message(struct smb_conn *smbc,
   h->flags2 = smb_swap16(SMB_FLAGS2_IS_LONG_NAME | SMB_FLAGS2_KNOWS_LONG_NAME);
   h->uid = smb_swap16(smbc->uid);
   h->tid = smb_swap16(req->tid);
-  pid = (unsigned int)curlx_getpid();
   h->pid_high = smb_swap16((unsigned short)(pid >> 16));
   h->pid = smb_swap16((unsigned short) pid);
 }

--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -668,7 +668,7 @@ dnsd_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s dnsd (port: %d pid: %ld) exits with signal (%d)",
-           ipv_inuse, (int)port, (long)curlx_getpid(), exit_signal);
+           ipv_inuse, (int)port, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1354,7 +1354,7 @@ server_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s rtspd (port: %d pid: %ld) exits with signal (%d)",
-           ipv_inuse, (int)port, (long)curlx_getpid(), exit_signal);
+           ipv_inuse, (int)port, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -2511,7 +2511,7 @@ sws_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s sws (%s pid: %ld) exits with signal (%d)",
-           socket_type, location_str, (long)curlx_getpid(), exit_signal);
+           socket_type, location_str, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -857,7 +857,7 @@ tftpd_cleanup:
 
   if(got_exit_signal) {
     logmsg("========> %s tftpd (port: %d pid: %ld) exits with signal (%d)",
-           ipv_inuse, (int)port, (long)curlx_getpid(), exit_signal);
+           ipv_inuse, (int)port, (long)our_getpid(), exit_signal);
     /*
      * To properly set the return status of the process we
      * must raise the same signal SIGINT or SIGTERM that we

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -295,11 +295,15 @@ int wait_ms(timediff_t timeout_ms)
   return r;
 }
 
+#ifdef _WIN32
+#define t_getpid() GetCurrentProcessId()
+#else
+#define t_getpid() getpid()
+#endif
+
 curl_off_t our_getpid(void)
 {
-  curl_off_t pid;
-
-  pid = (curl_off_t)curlx_getpid();
+  curl_off_t pid = (curl_off_t)t_getpid();
 #ifdef _WIN32
   /* store pid + MAX_PID to avoid conflict with Cygwin/msys PIDs, see also:
    * - 2019-01-31: https://cygwin.com/git/?p=newlib-cygwin.git;a=commit;


### PR DESCRIPTION
It was not a function properly exposed in the curlx set. SMB cannot possibly need to send a real pid, now sends a made up number.

The only real users of this function are test servers, so move the logic over there.