### PR TITLE
windows: fix to preserve error code in `curlx_winapi_strerror()`

### DIFF
--- a/lib/curlx/winapi.c
+++ b/lib/curlx/winapi.c
@@ -90,7 +90,7 @@ const char *curlx_get_winapi_error(int err, char *buf, size_t buflen)
 
 const char *curlx_winapi_strerror(DWORD err, char *buf, size_t buflen)
 {
-#ifdef PRESERVE_WINDOWS_ERROR_CODE
+#ifdef _WIN32
   DWORD old_win_err = GetLastError();
 #endif
   int old_errno = errno;
@@ -125,7 +125,7 @@ const char *curlx_winapi_strerror(DWORD err, char *buf, size_t buflen)
   if(errno != old_errno)
     CURL_SETERRNO(old_errno);
 
-#ifdef PRESERVE_WINDOWS_ERROR_CODE
+#ifdef _WIN32
   if(old_win_err != GetLastError())
     SetLastError(old_win_err);
 #endif

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -49,10 +49,6 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
-#ifdef _WIN32
-#define PRESERVE_WINDOWS_ERROR_CODE
-#endif
-
 const char *
 curl_easy_strerror(CURLcode error)
 {
@@ -804,7 +800,7 @@ get_winsock_error(int err, char *buf, size_t len)
  */
 const char *Curl_strerror(int err, char *buf, size_t buflen)
 {
-#ifdef PRESERVE_WINDOWS_ERROR_CODE
+#ifdef _WIN32
   DWORD old_win_err = GetLastError();
 #endif
   int old_errno = errno;
@@ -884,7 +880,7 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
   if(errno != old_errno)
     CURL_SETERRNO(old_errno);
 
-#ifdef PRESERVE_WINDOWS_ERROR_CODE
+#ifdef _WIN32
   if(old_win_err != GetLastError())
     SetLastError(old_win_err);
 #endif
@@ -899,7 +895,7 @@ const char *Curl_strerror(int err, char *buf, size_t buflen)
  */
 const char *Curl_sspi_strerror(int err, char *buf, size_t buflen)
 {
-#ifdef PRESERVE_WINDOWS_ERROR_CODE
+#ifdef _WIN32
   DWORD old_win_err = GetLastError();
 #endif
   int old_errno = errno;
@@ -1032,7 +1028,7 @@ const char *Curl_sspi_strerror(int err, char *buf, size_t buflen)
   if(errno != old_errno)
     CURL_SETERRNO(old_errno);
 
-#ifdef PRESERVE_WINDOWS_ERROR_CODE
+#ifdef _WIN32
   if(old_win_err != GetLastError())
     SetLastError(old_win_err);
 #endif


### PR DESCRIPTION
Drop the interim macro `PRESERVE_WINDOWS_ERROR_CODE` and always preserve
error code for `_WIN32`. To make sure this is always done in
`curlx_winapi_strerror()`.

Follow-up to c74d3e10d2935a9a37ffe6b2f7a4ecb0f81e974f #17299
