### PR TITLE
CURLMOPT_TIMERFUNCTION.md: correct the example

### DIFF
--- a/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
+++ b/docs/libcurl/opts/CURLMOPT_TIMERDATA.md
@@ -50,7 +50,7 @@ static int timerfunc(CURLM *multi, long timeout_ms, void *clientp)
   struct priv *mydata = clientp;
   printf("our ptr: %p\n", mydata->custom);
 
-  if(timeout_ms) {
+  if(timeout_ms >= 0) {
     /* this is the new single timeout to wait for */
   }
   else {

--- a/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.md
+++ b/docs/libcurl/opts/CURLMOPT_TIMERFUNCTION.md
@@ -46,7 +46,8 @@ time *replaces* the former timeout. The application should then effectively
 cancel the old timeout and set a new timeout using this new expire time.
 
 A **timeout_ms** value of -1 passed to this callback means you should delete
-the timer. All other values are valid expire times in number of milliseconds.
+the timer. All other values are valid expire times in number of milliseconds -
+including zero milliseconds.
 
 The **timer_callback** is called when the timeout expire time is changed.
 
@@ -82,8 +83,8 @@ static int timerfunc(CURLM *multi, long timeout_ms, void *clientp)
   struct priv *mydata = clientp;
   printf("our ptr: %p\n", mydata->custom);
 
-  if(timeout_ms) {
-    /* this is the new single timeout to wait for */
+  if(timeout_ms >= 0) {
+    /* this is the new single timeout to wait for, including zero */
   }
   else {
     /* delete the timeout, nothing to wait for now */


### PR DESCRIPTION
Fixes #17301
Reported-by: Dirk Feytons