### PR TITLE
test1621: Improve stripcredentials tests

### DIFF
--- a/tests/data/test1621
+++ b/tests/data/test1621
@@ -15,6 +15,7 @@ none
 <features>
 unittest
 https
+pop3s
 </features>
 <name>
 unit tests for stripcredentials from URL


### PR DESCRIPTION
- add more unusual input cases
- add a valid non-http protocol
- fix tests so an input that should be stripped but isn't is a failure
- fix detection of when stripcredentials() would be available to test
- avoid dereferencing a NULL pointer

Closes #17304