### PR TITLE
curl_version_info.md: clarify ssl_version for MultiSSL

### DIFF
--- a/docs/libcurl/curl_version.md
+++ b/docs/libcurl/curl_version.md
@@ -28,6 +28,10 @@ char *curl_version();
 Returns a human readable string with the version number of libcurl and some of
 its important components (like OpenSSL version).
 
+For MultiSSL builds the string contains all SSL backend names and the inactive
+backend names are in parentheses. For example "(OpenSSL/3.0.8) Schannel" or
+"OpenSSL/3.0.8 (Schannel)".
+
 We recommend using curl_version_info(3) instead.
 
 # %PROTOCOLS%

--- a/docs/libcurl/curl_version_info.md
+++ b/docs/libcurl/curl_version_info.md
@@ -137,7 +137,9 @@ entry. See the list of features names below.
 
 *ssl_version* is an ASCII string for the TLS library name + version used. If
 libcurl has no SSL support, this is NULL. For example "Schannel", "Secure
-Transport" or "OpenSSL/1.1.0g".
+Transport" or "OpenSSL/1.1.0g". For MultiSSL builds the string contains all
+SSL backend names and the inactive backend names are in parentheses. For
+example "(OpenSSL/3.0.8) Schannel" or "OpenSSL/3.0.8 (Schannel)".
 
 *ssl_version_num* is always 0.
 


### PR DESCRIPTION
- Clarify that the ssl_version in MultiSSL builds contains all SSL backend names with the inactive backend names in parentheses.

Closes #xxxx