### PR TITLE
mprintf: provide hex digits for escape.c to use

### DIFF
--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -30,6 +30,12 @@
 #define MERR_MEM       1
 #define MERR_TOO_LARGE 2
 
+/* Lower-case digits.  */
+extern const unsigned char Curl_ldigits[];
+
+/* Upper-case digits.  */
+extern const unsigned char Curl_udigits[];
+
 #ifdef BUILDING_LIBCURL
 
 /*

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -232,9 +232,7 @@ void Curl_hexbyte(unsigned char *dest, /* must fit two bytes */
                   unsigned char val,
                   bool lowercase)
 {
-  const unsigned char uhex[] = "0123456789ABCDEF";
-  const unsigned char lhex[] = "0123456789abcdef";
-  const unsigned char *t = lowercase ? lhex : uhex;
+  const unsigned char *t = lowercase ? Curl_ldigits : Curl_udigits;
   dest[0] = t[val >> 4];
   dest[1] = t[val & 0x0F];
 }

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -68,10 +68,10 @@
 #endif
 
 /* Lower-case digits.  */
-static const char lower_digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+const unsigned char Curl_ldigits[] = "0123456789abcdef";
 
 /* Upper-case digits.  */
-static const char upper_digits[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const unsigned char Curl_udigits[] = "0123456789ABCDEF";
 
 #define OUTCHAR(x)                                      \
   do {                                                  \
@@ -649,7 +649,7 @@ static int formatf(
   va_list ap_save) /* list of parameters */
 {
   static const char nilstr[] = "(nil)";
-  const char *digits = lower_digits;   /* Base-36 digits for numbers.  */
+  const unsigned char *digits = Curl_ldigits;
   int done = 0;   /* number of characters written  */
   int i;
   int ocount = 0; /* number of output segments */
@@ -752,7 +752,7 @@ static int formatf(
       }
       else if(flags & FLAGS_HEX) {
         /* Hexadecimal unsigned integer */
-        digits = (flags & FLAGS_UPPER) ? upper_digits : lower_digits;
+        digits = (flags & FLAGS_UPPER) ? Curl_udigits : Curl_ldigits;
         base = 16;
         is_neg = FALSE;
       }
@@ -781,6 +781,7 @@ number:
 
       /* Put the number in WORK.  */
       w = workend;
+      DEBUGASSERT(base <= 16);
       switch(base) {
       case 10:
         while(num > 0) {
@@ -898,7 +899,7 @@ number:
       if(iptr->val.ptr) {
         /* If the pointer is not NULL, write it as a %#x spec.  */
         base = 16;
-        digits = (flags & FLAGS_UPPER) ? upper_digits : lower_digits;
+        digits = (flags & FLAGS_UPPER) ? Curl_udigits : Curl_ldigits;
         is_alt = TRUE;
         num = (size_t) iptr->val.ptr;
         is_neg = FALSE;


### PR DESCRIPTION
Since they need the exact same set, use the same set. The mprintf string was longer than it had to be.