### PR TITLE
rtsp: remove redundant condition

### DIFF
--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -253,7 +253,7 @@ static CURLcode rtsp_done(struct Curl_easy *data,
 
   httpStatus = Curl_http_done(data, status, premature);
 
-  if(rtsp && !status && !httpStatus) {
+  if(!status && !httpStatus) {
     /* Check the sequence numbers */
     long CSeq_sent = rtsp->CSeq_sent;
     long CSeq_recv = rtsp->CSeq_recv;


### PR DESCRIPTION
'rtsp' always evaluates to true. Spotted by CodeSonar.