### PR TITLE
netrc: avoid strdup NULL

### DIFF
--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -268,7 +268,7 @@ static NETRCcode parsenetrc(struct store_netrc *store,
           else {
             our_login = TRUE;
             free(login);
-            login = strdup(tok);
+            login = strdup(tok ? tok : "");
             if(!login) {
               retcode = NETRC_OUT_OF_MEMORY; /* allocation failed */
               goto out;


### PR DESCRIPTION
Coverity found a code path where this might happen. Avoid it.