### PR TITLE
tests/server: remove TEST use, include <memdebug.h>

### DIFF
--- a/tests/server/dnsd.c
+++ b/tests/server/dnsd.c
@@ -57,7 +57,7 @@
 #include "server_sockaddr.h"
 
 /* include memdebug.h last */
-#include "memdebug.h"
+#include <memdebug.h>
 
 static int dnsd_wrotepidfile = 0;
 static int dnsd_wroteportfile = 0;

--- a/tests/server/getpart.c
+++ b/tests/server/getpart.c
@@ -25,19 +25,11 @@
 
 #include "getpart.h"
 
-#ifdef TEST
-#include "curl/curl.h"
-#include "warnless.h"
-#else
 #include <curlx.h> /* from the private lib dir */
-#endif
-
 #include "curl_memory.h"
 
-#ifndef TEST
 /* include memdebug.h last */
-#include "memdebug.h"
-#endif
+#include <memdebug.h>
 
 #define EAT_SPACE(p) while(*(p) && ISSPACE(*(p))) (p)++
 
@@ -491,29 +483,3 @@ int getpart(char **outbuf, size_t *outlen,
 
   return error;
 }
-
-#ifdef TEST
-#include "../../lib/base64.c"
-#include "../../lib/warnless.c"
-/* Build with:
- * $ gcc getpart.c -DTEST -I../../include -I../../lib -DHAVE_CONFIG_H
- */
-int main(int argc, char **argv)
-{
-  if(argc < 3) {
-    printf("./getpart main sub\n");
-  }
-  else {
-    char  *part;
-    size_t partlen;
-    int rc = getpart(&part, &partlen, argv[1], argv[2], stdin);
-    size_t i;
-    if(rc)
-      return rc;
-    for(i = 0; i < partlen; i++)
-      printf("%c", part[i]);
-    free(part);
-  }
-  return 0;
-}
-#endif

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -60,7 +60,7 @@
 #include "tool_binmode.h"
 
 /* include memdebug.h last */
-#include "memdebug.h"
+#include <memdebug.h>
 
 #define MQTT_MSG_CONNECT    0x10
 #define MQTT_MSG_CONNACK    0x20

--- a/tests/server/resolve.c
+++ b/tests/server/resolve.c
@@ -47,7 +47,7 @@
 #include "util.h"
 
 /* include memdebug.h last */
-#include "memdebug.h"
+#include <memdebug.h>
 
 int main(int argc, char *argv[])
 {

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -54,7 +54,7 @@
 #include "server_sockaddr.h"
 
 /* include memdebug.h last */
-#include "memdebug.h"
+#include <memdebug.h>
 
 #undef REQBUFSIZ
 #define REQBUFSIZ 150000

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -110,7 +110,7 @@
 #include "tool_binmode.h"
 
 /* include memdebug.h last */
-#include "memdebug.h"
+#include <memdebug.h>
 
 /* buffer is this excessively large only to be able to support things like
   test 1003 which tests exceedingly large server response lines */

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -80,7 +80,7 @@
 #include "tool_binmode.h"
 
 /* include memdebug.h last */
-#include "memdebug.h"
+#include <memdebug.h>
 
 static const char *backendaddr = "127.0.0.1";
 static unsigned short backendport = 0; /* default is use client's */

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -56,7 +56,7 @@
 #include "server_sockaddr.h"
 
 /* include memdebug.h last */
-#include "memdebug.h"
+#include <memdebug.h>
 
 static bool use_gopher = FALSE;
 static bool is_proxy = FALSE;

--- a/tests/server/tftpd.c
+++ b/tests/server/tftpd.c
@@ -90,7 +90,7 @@
 #include "tftp.h"
 
 /* include memdebug.h last */
-#include "memdebug.h"
+#include <memdebug.h>
 
 /*****************************************************************************
 *                      STRUCT DECLARATIONS AND DEFINES                       *


### PR DESCRIPTION
- The TEST define is never set, remove its use
- memdebug.h is not in the local dir, use angle bracket include

cherry-picked from #17294