### PR TITLE
tests/server: check for `stream != NULL` in mqttd

### DIFF
--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -583,6 +583,12 @@ static curl_socket_t mqttit(curl_socket_t fd)
 
       logmsg("SUBSCRIBE to '%s' [%d]", topic, packet_id);
       stream = test2fopen(testno, logdir);
+      if(!stream) {
+        error = errno;
+        logmsg("fopen() failed with error (%d) %s", error, strerror(error));
+        logmsg("Couldn't open test file %ld", testno);
+        goto end;
+      }
       error = getpart(&data, &datalen, "reply", "data", stream);
       if(!error) {
         if(!m_config.publish_before_suback) {


### PR DESCRIPTION
To avoid an assert in `fgets()` on MSVC when the test case is missing.

Bug: https://github.com/curl/curl/pull/17294#issuecomment-2867501300
