### PR TITLE
tests/server: stop using libcurl string comparisons

### DIFF
--- a/lib/curlx/strparse.c
+++ b/lib/curlx/strparse.c
@@ -232,13 +232,15 @@ int curlx_str_newline(const char **linep)
   return STRE_NEWLINE;
 }
 
-/* case insensitive compare that the parsed string matches the
-   given string. Returns non-zero on match. */
+#ifndef WITHOUT_LIBCURL
+/* case insensitive compare that the parsed string matches the given string.
+   Returns non-zero on match. */
 int curlx_str_casecompare(struct Curl_str *str, const char *check)
 {
   size_t clen = check ? strlen(check) : 0;
   return ((str->len == clen) && strncasecompare(str->str, check, clen));
 }
+#endif
 
 /* case sensitive string compare. Returns non-zero on match. */
 int curlx_str_cmp(struct Curl_str *str, const char *check)

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -58,6 +58,7 @@ foreach(_target IN LISTS SERVERPROGS)
   if(ENABLE_SERVER_DEBUG)
     set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
   endif()
+  set_property(TARGET ${_target_name} APPEND PROPERTY COMPILE_DEFINITIONS "WITHOUT_LIBCURL")
   # Test servers simply are standalone programs that do not use libcurl
   # library.  For convenience and to ease portability of these servers,
   # some source code files from the libcurl subdirectory are also used

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -57,6 +57,8 @@ AM_CPPFLAGS += -DCURLDEBUG
 endif
 endif
 
+AM_CPPFLAGS += -DWITHOUT_LIBCURL
+
 # Makefile.inc provides neat definitions
 include Makefile.inc
 

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -31,11 +31,9 @@ MEMDEBUG = \
 CURLX_SRCS = \
   ../../lib/curlx/nonblock.c \
   ../../lib/curlx/strparse.c \
-  ../../lib/strequal.c \
   ../../lib/curlx/warnless.c \
   ../../lib/curlx/timediff.c \
   ../../lib/curlx/timeval.c \
-  ../../lib/strcase.c \
   ../../lib/curlx/multibyte.c \
   ../../lib/curlx/version_win32.c
 
@@ -43,11 +41,9 @@ CURLX_HDRS = \
   ../../lib/curlx/curlx.h \
   ../../lib/curl_ctype.h \
   ../../lib/curlx/nonblock.h \
-  ../../lib/strcase.h \
   ../../lib/curlx/warnless.h \
   ../../lib/curlx/timediff.h \
   ../../lib/curlx/timeval.h \
-  ../../lib/strcase.h \
   ../../lib/curlx/multibyte.h \
   ../../lib/curlx/version_win32.h
 

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -425,7 +425,7 @@ static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
     if(got_exit_signal)
       return 1; /* done */
 
-    if((req->cl == 0) && curl_strnequal("Content-Length:", line, 15)) {
+    if((req->cl == 0) && !CURL_STRNICMP("Content-Length:", line, 15)) {
       /* If we don't ignore content-length, we read it and we read the whole
          request including the body before we return. If we've been told to
          ignore the content-length, we will return as soon as all headers
@@ -445,8 +445,8 @@ static int rtspd_ProcessRequest(struct rtspd_httprequest *req)
         logmsg("... but will abort after %zu bytes", req->cl);
       break;
     }
-    else if(curl_strnequal("Transfer-Encoding: chunked", line,
-                            strlen("Transfer-Encoding: chunked"))) {
+    else if(!CURL_STRNICMP("Transfer-Encoding: chunked", line,
+                           strlen("Transfer-Encoding: chunked"))) {
       /* chunked data coming in */
       chunked = TRUE;
     }

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -573,7 +573,7 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
     if(got_exit_signal)
       return 1; /* done */
 
-    if((req->cl == 0) && curl_strnequal("Content-Length:", line, 15)) {
+    if((req->cl == 0) && !CURL_STRNICMP("Content-Length:", line, 15)) {
       /* If we don't ignore content-length, we read it and we read the whole
          request including the body before we return. If we've been told to
          ignore the content-length, we will return as soon as all headers
@@ -595,14 +595,13 @@ static int sws_ProcessRequest(struct sws_httprequest *req)
       if(req->skip)
         logmsg("... but will abort after %zu bytes", req->cl);
     }
-    else if(curl_strnequal("Transfer-Encoding: chunked", line,
-                            strlen("Transfer-Encoding: chunked"))) {
+    else if(!CURL_STRNICMP("Transfer-Encoding: chunked", line,
+                           strlen("Transfer-Encoding: chunked"))) {
       /* chunked data coming in */
       chunked = TRUE;
     }
-    else if(req->noexpect &&
-            curl_strnequal("Expect: 100-continue", line,
-                            strlen("Expect: 100-continue"))) {
+    else if(req->noexpect && !CURL_STRNICMP("Expect: 100-continue", line,
+                                            strlen("Expect: 100-continue"))) {
       if(req->cl)
         req->cl = 0;
       req->skipall = TRUE;

--- a/tests/server/util.h
+++ b/tests/server/util.h
@@ -32,6 +32,21 @@
 #  endif
 #endif
 
+#ifdef _WIN32
+#  define CURL_STRNICMP(p1, p2, n) _strnicmp(p1, p2, n)
+#elif defined(HAVE_STRCASECMP)
+#  ifdef HAVE_STRINGS_H
+#    include <strings.h>
+#  endif
+#  define CURL_STRNICMP(p1, p2, n) strncasecmp(p1, p2, n)
+#elif defined(HAVE_STRCMPI)
+#  define CURL_STRNICMP(p1, p2, n) strncmpi(p1, p2, n)
+#elif defined(HAVE_STRICMP)
+#  define CURL_STRNICMP(p1, p2, n) strnicmp(p1, p2, n)
+#else
+#  error "missing case insensitive comparison function"
+#endif
+
 enum {
   DOCNUMBER_NOTHING    = -7,
   DOCNUMBER_QUIT       = -6,


### PR DESCRIPTION
Further untangle the test server code from curl code. While the string comparison functions are available in the libcurl API, the tests servers don't link with libcurl. Use native functions instead.