### PR TITLE
spacecheck.pl: verify `tests/data/test*` for non-ASCII chars

### DIFF
--- a/.github/scripts/spacecheck.pl
+++ b/.github/scripts/spacecheck.pl
@@ -161,7 +161,7 @@ while(my $filename = <$git_ls_files>) {
     $content =~ s/[$non_ascii_allowed]//g;
 
     if(!fn_match($filename, @non_ascii) &&
-       ($content =~ /([\x80-\xff]+)/ && $content !~ /codeset-utf8|codeset-non-ascii|^Unicode/m)) {
+       ($content =~ /([\x80-\xff]+)/ && $content !~ /^(codeset-utf8|codeset-non-ascii|Unicode)/m)) {
         push @err, "content: has non-ASCII: '$1'";
     }
 

--- a/.github/scripts/spacecheck.pl
+++ b/.github/scripts/spacecheck.pl
@@ -161,7 +161,7 @@ while(my $filename = <$git_ls_files>) {
     $content =~ s/[$non_ascii_allowed]//g;
 
     if(!fn_match($filename, @non_ascii) &&
-       ($content =~ /([\x80-\xff]+)/ && $content !~ /^(codeset-utf8|codeset-non-ascii|Unicode)/m)) {
+       ($content =~ /([\x80-\xff]+)/ && $content !~ /^(codeset-utf8|Unicode|non-ascii)/m)) {
         push @err, "content: has non-ASCII: '$1'";
     }
 

--- a/.github/scripts/spacecheck.pl
+++ b/.github/scripts/spacecheck.pl
@@ -69,7 +69,6 @@ my @non_ascii = (
     "docs/THANKS",
     "docs/THANKS-filter",
     "tests/libtest/lib1560.c",
-    "^tests/data/test",
 );
 
 sub fn_match {
@@ -162,7 +161,7 @@ while(my $filename = <$git_ls_files>) {
     $content =~ s/[$non_ascii_allowed]//g;
 
     if(!fn_match($filename, @non_ascii) &&
-       $content =~ /([\x80-\xff]+)/) {
+       ($content =~ /([\x80-\xff]+)/ && $content !~ /codeset-utf8|codeset-non-ascii|^Unicode/m)) {
         push @err, "content: has non-ASCII: '$1'";
     }
 

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -440,6 +440,7 @@ Features testable here are:
 - `c-ares` - c-ares is used for (all) name resolves
 - `CharConv`
 - `codeset-utf8`. If the running codeset is UTF-8 capable.
+- `codeset-non-ascii`. Quasi-feature: indicates the test uses non-ascii, non-UTF8 characters
 - `cookies`
 - `crypto`
 - `Debug`

--- a/tests/FILEFORMAT.md
+++ b/tests/FILEFORMAT.md
@@ -226,6 +226,10 @@ Tests that have strict timing dependencies have the `timing-dependent` keyword.
 These are intended to eventually be treated specially on CI builds which are
 often run on overloaded machines with unpredictable timing.
 
+Tests using non-7-bit-ASCII characters, and not using features `Unicode` or
+`codeset-utf8`, need to add the `non-ascii` keyword to tell the code checker
+to allow these characters.
+
 ## `<reply>`
 
 ### `<data [nocheck="yes"] [sendzero="yes"] [hex="yes"] [nonewline="yes"] [crlf="yes"]>`
@@ -440,7 +444,6 @@ Features testable here are:
 - `c-ares` - c-ares is used for (all) name resolves
 - `CharConv`
 - `codeset-utf8`. If the running codeset is UTF-8 capable.
-- `codeset-non-ascii`. Quasi-feature: indicates the test uses non-ascii, non-UTF8 characters
 - `cookies`
 - `crypto`
 - `Debug`

--- a/tests/data/test1138
+++ b/tests/data/test1138
@@ -4,6 +4,7 @@
 HTTP
 HTTP GET
 followlocation
+non-ascii
 </keywords>
 </info>
 #
@@ -42,9 +43,6 @@ body
 #
 # Client-side
 <client>
-<features>
-codeset-non-ascii
-</features>
 <server>
 http
 </server>

--- a/tests/data/test1138
+++ b/tests/data/test1138
@@ -42,6 +42,9 @@ body
 #
 # Client-side
 <client>
+<features>
+codeset-non-ascii
+</features>
 <server>
 http
 </server>

--- a/tests/data/test1160
+++ b/tests/data/test1160
@@ -5,6 +5,7 @@
 HTTP
 HTTP GET
 cookies
+non-ascii
 </keywords>
 </info>
 
@@ -33,7 +34,6 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER -c %LOGDIR/cookies%TESTNUMBER.txt
 </command>
 <features>
 cookies
-codeset-non-ascii
 </features>
 </client>
 

--- a/tests/data/test1160
+++ b/tests/data/test1160
@@ -33,6 +33,7 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER -c %LOGDIR/cookies%TESTNUMBER.txt
 </command>
 <features>
 cookies
+codeset-non-ascii
 </features>
 </client>
 

--- a/tests/data/test1631
+++ b/tests/data/test1631
@@ -49,6 +49,7 @@ FTP through HTTPS-proxy
 <features>
 http
 proxy
+codeset-non-ascii
 </features>
 </client>
 

--- a/tests/data/test1631
+++ b/tests/data/test1631
@@ -4,6 +4,7 @@
 FTP
 HTTPS proxy
 flaky
+non-ascii
 </keywords>
 </info>
 
@@ -49,7 +50,6 @@ FTP through HTTPS-proxy
 <features>
 http
 proxy
-codeset-non-ascii
 </features>
 </client>
 

--- a/tests/data/test1632
+++ b/tests/data/test1632
@@ -58,6 +58,7 @@ FTP through HTTPS-proxy, with connection reuse
 <features>
 http
 proxy
+codeset-non-ascii
 </features>
 </client>
 

--- a/tests/data/test1632
+++ b/tests/data/test1632
@@ -4,6 +4,7 @@
 FTP
 HTTPS proxy
 flaky
+non-ascii
 </keywords>
 </info>
 
@@ -58,7 +59,6 @@ FTP through HTTPS-proxy, with connection reuse
 <features>
 http
 proxy
-codeset-non-ascii
 </features>
 </client>
 

--- a/tests/data/test31
+++ b/tests/data/test31
@@ -94,6 +94,7 @@ http://test31.curl:%HTTPPORT/we/want/%TESTNUMBER -b none -c %LOGDIR/jar%TESTNUMB
 <features>
 cookies
 local-http
+codeset-non-ascii
 </features>
 </client>
 

--- a/tests/data/test31
+++ b/tests/data/test31
@@ -5,6 +5,7 @@ HTTP
 HTTP GET
 cookies
 cookiejar
+non-ascii
 </keywords>
 </info>
 # Server-side
@@ -94,7 +95,6 @@ http://test31.curl:%HTTPPORT/we/want/%TESTNUMBER -b none -c %LOGDIR/jar%TESTNUMB
 <features>
 cookies
 local-http
-codeset-non-ascii
 </features>
 </client>
 

--- a/tests/data/test469
+++ b/tests/data/test469
@@ -29,6 +29,7 @@ Funny-head: yesyes
 <client>
 <features>
 !win32
+codeset-non-ascii
 </features>
 <server>
 http

--- a/tests/data/test469
+++ b/tests/data/test469
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 HTTP
+non-ascii
 </keywords>
 </info>
 
@@ -29,7 +30,6 @@ Funny-head: yesyes
 <client>
 <features>
 !win32
-codeset-non-ascii
 </features>
 <server>
 http

--- a/tests/data/test470
+++ b/tests/data/test470
@@ -2,6 +2,7 @@
 <info>
 <keywords>
 HTTP
+non-ascii
 </keywords>
 </info>
 
@@ -27,9 +28,6 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
-<features>
-codeset-non-ascii
-</features>
 <server>
 http
 </server>

--- a/tests/data/test470
+++ b/tests/data/test470
@@ -27,6 +27,9 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
+<features>
+codeset-non-ascii
+</features>
 <server>
 http
 </server>

--- a/tests/data/test497
+++ b/tests/data/test497
@@ -27,6 +27,9 @@ Content-Type: text/html
 #
 # Client-side
 <client>
+<features>
+codeset-non-ascii
+</features>
 <server>
 http
 </server>

--- a/tests/data/test497
+++ b/tests/data/test497
@@ -3,6 +3,7 @@
 <keywords>
 HTTP
 HTTP GET
+non-ascii
 </keywords>
 </info>
 
@@ -27,9 +28,6 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-<features>
-codeset-non-ascii
-</features>
 <server>
 http
 </server>

--- a/tests/data/test498
+++ b/tests/data/test498
@@ -28,6 +28,9 @@ Content-Type: text/html
 #
 # Client-side
 <client>
+<features>
+codeset-non-ascii
+</features>
 <server>
 http
 </server>

--- a/tests/data/test498
+++ b/tests/data/test498
@@ -3,6 +3,7 @@
 <keywords>
 HTTP
 HTTP GET
+non-ascii
 </keywords>
 </info>
 
@@ -28,9 +29,6 @@ Content-Type: text/html
 #
 # Client-side
 <client>
-<features>
-codeset-non-ascii
-</features>
 <server>
 http
 </server>

--- a/tests/data/test649
+++ b/tests/data/test649
@@ -16,6 +16,7 @@ MULTIPART
 <client>
 <features>
 Mime
+codeset-non-ascii
 </features>
 <server>
 smtp

--- a/tests/data/test649
+++ b/tests/data/test649
@@ -3,6 +3,7 @@
 <keywords>
 SMTP
 MULTIPART
+non-ascii
 </keywords>
 </info>
 
@@ -16,7 +17,6 @@ MULTIPART
 <client>
 <features>
 Mime
-codeset-non-ascii
 </features>
 <server>
 smtp

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -823,7 +823,6 @@ sub checksystemfeatures {
     $feature{"crypto"} = $feature{"NTLM"} || $feature{"Kerberos"} || $feature{"SPNEGO"};
     $feature{"local-http"} = servers::localhttp();
     $feature{"codeset-utf8"} = lc(langinfo(CODESET())) eq "utf-8";
-    $feature{"codeset-non-ascii"} = 1;
 
     # make each protocol an enabled "feature"
     for my $p (@protocols) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -823,6 +823,7 @@ sub checksystemfeatures {
     $feature{"crypto"} = $feature{"NTLM"} || $feature{"Kerberos"} || $feature{"SPNEGO"};
     $feature{"local-http"} = servers::localhttp();
     $feature{"codeset-utf8"} = lc(langinfo(CODESET())) eq "utf-8";
+    $feature{"codeset-non-ascii"} = 1;
 
     # make each protocol an enabled "feature"
     for my $p (@protocols) {


### PR DESCRIPTION
Exclude test data files (4 of them) based on existing feature tags:
`codeset-utf8` and `Unicode`.

Add the new keyword `non-ascii` to mark remaining exceptions (9 files).

Follow-up to 838dc53bb7bf52039b23af0e9ccffa51cf9ad7d0 #17247
