### PR TITLE
setopt: provide info for CURLE_BAD_FUNCTION_ARGUMENT

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -3070,9 +3070,7 @@ CURLcode curl_easy_setopt(CURL *d, CURLoption tag, ...)
   result = Curl_vsetopt(data, tag, arg);
 
   va_end(arg);
-#ifdef DEBUGBUILD
   if(result == CURLE_BAD_FUNCTION_ARGUMENT)
-    infof(data, "setopt arg 0x%x returned CURLE_BAD_FUNCTION_ARGUMENT", tag);
-#endif
+    failf(data, "setopt 0x%x got bad argument", tag);
   return result;
 }


### PR DESCRIPTION
If CURLE_BAD_FUNCTION_ARGUMENT is returned and failf() has not provided any details, this adds a generic error string that includes the option number.

This helps debugging for example the curl tool which does a lot of setopt calls and in reading post fact logs it is not always easy to tell exactly which call that failed.

Ref: #17330