### PR TITLE
curl_mprintf.md: remove use of unicode +/-

### DIFF
--- a/.github/scripts/spacecheck.pl
+++ b/.github/scripts/spacecheck.pl
@@ -52,9 +52,7 @@ my @non_ascii_allowed = (
     '\xC3\xA5',          # UTF-8 for https://codepoints.net/U+00E5 LATIN SMALL LETTER A WITH RING ABOVE
     '\xC3\xA4',          # UTF-8 for https://codepoints.net/U+00E4 LATIN SMALL LETTER A WITH DIAERESIS
     '\xC3\xB6',          # UTF-8 for https://codepoints.net/U+00F6 LATIN SMALL LETTER O WITH DIAERESIS
-    '\xC2\xB1',          # UTF-8 for https://codepoints.net/U+00B1 PLUS-MINUS SIGN
     '\xC2\xA7',          # UTF-8 for https://codepoints.net/U+00A7 SECTION SIGN
-    '\xC3\x9F',          # UTF-8 for https://codepoints.net/U+00DF LATIN SMALL LETTER SHARP S
     '\xF0\x9F\x99\x8F',  # UTF-8 for https://codepoints.net/U+1f64f PERSON WITH FOLDED HANDS
 );
 

--- a/docs/libcurl/curl_mprintf.md
+++ b/docs/libcurl/curl_mprintf.md
@@ -226,7 +226,7 @@ printed with an explicit precision 0, the output is empty.
 
 ## e, E
 
-The double argument is rounded and output in the style **"[-]d.ddde±dd"**
+The double argument is rounded and output in the style **"[-]d.ddde[-+]dd"**
 
 ## f, F
 


### PR DESCRIPTION
Also removed the whitelisting of this symbol and LATIN SMALL LETTER SHARP S from spacecheck.pl