### PR TITLE
tests/server/Makefile.inc: cleanup

### DIFF
--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -29,34 +29,33 @@ MEMDEBUG = \
   ../../lib/memdebug.h
 
 CURLX_SRCS = \
+  ../../lib/curlx/base64.c \
+  ../../lib/curlx/multibyte.c \
   ../../lib/curlx/nonblock.c \
   ../../lib/curlx/strparse.c \
-  ../../lib/curlx/warnless.c \
   ../../lib/curlx/timediff.c \
   ../../lib/curlx/timeval.c \
-  ../../lib/curlx/multibyte.c \
-  ../../lib/curlx/version_win32.c
+  ../../lib/curlx/version_win32.c \
+  ../../lib/curlx/warnless.c \
+  ../../lib/curlx/winapi.c
 
 CURLX_HDRS = \
+  ../../lib/curlx/base64.h \
   ../../lib/curlx/curlx.h \
-  ../../lib/curl_ctype.h \
+  ../../lib/curlx/multibyte.h \
   ../../lib/curlx/nonblock.h \
-  ../../lib/curlx/warnless.h \
   ../../lib/curlx/timediff.h \
   ../../lib/curlx/timeval.h \
-  ../../lib/curlx/multibyte.h \
-  ../../lib/curlx/version_win32.h
+  ../../lib/curlx/version_win32.h \
+  ../../lib/curlx/warnless.h \
+  ../../lib/curlx/winapi.h
 
 UTIL = \
   getpart.c \
   getpart.h \
   util.c \
   util.h \
-  server_setup.h \
-  ../../lib/curlx/base64.c \
-  ../../lib/curlx/base64.h \
-  ../../lib/curlx/winapi.c \
-  ../../lib/curlx/winapi.h
+  server_setup.h
 
 FIRSTFILES = \
   first.c \


### PR DESCRIPTION
- drop curl_ctype.h as it is not used by test servers
- list all curlx files in the CURLX_* lists
- sort the lists alphabetically