### PR TITLE
pytest: give better read-/parsable parameterised test names

### DIFF
--- a/tests/http/test_01_basic.py
+++ b/tests/http/test_01_basic.py
@@ -259,13 +259,20 @@ class TestBasic:
         else:
             r.check_exit_code(43)
 
+    TE_IN_17 = [
+        'trailers',
+        'chunked',
+        'gzip, trailers',
+        'gzip ;q=0.2;x="y,x", trailers',
+        'gzip ;x="trailers", chunks',
+    ]
     # http: special handling of TE request header
     @pytest.mark.parametrize("te_in, te_out", [
-        ['trailers', 'trailers'],
-        ['chunked', None],
-        ['gzip, trailers', 'trailers'],
-        ['gzip ;q=0.2;x="y,x", trailers', 'trailers'],
-        ['gzip ;x="trailers", chunks', None],
+        [0, 'trailers'],
+        [1, None],
+        [2, 'trailers'],
+        [3, 'trailers'],
+        [4, None],
     ])
     def test_01_17_TE(self, env: Env, httpd, te_in, te_out):
         proto = 'h2'
@@ -273,7 +280,7 @@ class TestBasic:
         url = f'https://{env.authority_for(env.domain1, proto)}/curltest/echo'
         r = curl.http_download(urls=[url], alpn_proto=proto, with_stats=True,
                                with_headers=True,
-                               extra_args=['-H', f'TE: {te_in}'])
+                               extra_args=['-H', f'TE: {self.TE_IN_17[te_in]}'])
         r.check_response(200)
         if te_out is not None:
             assert r.responses[0]['header']['request-te'] == te_out, f'{r.responses[0]}'

--- a/tests/http/test_07_upload.py
+++ b/tests/http/test_07_upload.py
@@ -694,15 +694,15 @@ class TestUpload:
     # has a limit of 16k it announces
     @pytest.mark.skipif(condition=not Env.have_nghttpx(), reason="no nghttpx")
     @pytest.mark.parametrize("proto,upload_size,exp_early", [
-        ['http/1.1', 100, 203],        # headers+body
-        ['http/1.1', 10*1024, 10345],  # headers+body
-        ['http/1.1', 32*1024, 16384],  # headers+body, limited by server max
-        ['h2', 10*1024, 10378],        # headers+body
-        ['h2', 32*1024, 16384],        # headers+body, limited by server max
-        ['h3', 1024, 1126],            # headers+body (app data)
-        ['h3', 1024 * 1024, 131177],   # headers+body (long app data). The 0RTT
-                                       # size is limited by our sendbuf size
-                                       # of 128K.
+        pytest.param('http/1.1', 100, 203, id='h1-small-body'),
+        pytest.param('http/1.1', 10*1024, 10345, id='h1-medium-body'),
+        pytest.param('http/1.1', 32*1024, 16384, id='h1-limited-body'),
+        pytest.param('h2', 10*1024, 10378, id='h2-medium-body'),
+        pytest.param('h2', 32*1024, 16384, id='h2-limited-body'),
+        pytest.param('h3', 1024, 1126, id='h3-small-body'),
+        pytest.param('h3', 1024 * 1024, 131177, id='h3-limited-body'),
+        # h3: limited+body (long app data). The 0RTT size is limited by
+        # our sendbuf size of 128K.
     ])
     def test_07_70_put_earlydata(self, env: Env, httpd, nghttpx, proto, upload_size, exp_early):
         if not env.curl_can_early_data():

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -190,8 +190,8 @@ class TestSSLUse:
         ret = []
         for tls_id, tls_proto in {
                 'TLSv1.2+3': 'TLSv1.3 +TLSv1.2',
-                'TLSv1.2': 'TLSv1.3',
-                'TLSv1.3': 'TLSv1.2'}.items():
+                'TLSv1.3': 'TLSv1.3',
+                'TLSv1.2': 'TLSv1.2'}.items():
             for [cid13, ciphers13, succeed13] in tls13_tests:
                 for [cid12, ciphers12, succeed12] in tls12_tests:
                     id = f'{tls_id}-{cid13}-{cid12}'

--- a/tests/http/test_31_vsftpds.py
+++ b/tests/http/test_31_vsftpds.py
@@ -223,7 +223,8 @@ class TestVsFTPD:
         self.check_upload(env, vsftpds, docname=docname)
 
     @pytest.mark.parametrize("indata", [
-        '1234567890', ''
+        pytest.param('1234567890', id='10-bytes'),
+        pytest.param('', id='0-bytes'),
     ])
     def test_31_10_upload_stdin(self, env: Env, vsftpds: VsFTPD, indata):
         curl = CurlClient(env=env)

--- a/tests/http/test_32_ftps_vsftpd.py
+++ b/tests/http/test_32_ftps_vsftpd.py
@@ -235,7 +235,8 @@ class TestFtpsVsFTPD:
         self.check_upload(env, vsftpds, docname=docname)
 
     @pytest.mark.parametrize("indata", [
-        '1234567890', ''
+        pytest.param('1234567890', id='10-bytes'),
+        pytest.param('', id='0-bytes'),
     ])
     def test_32_10_upload_stdin(self, env: Env, vsftpds: VsFTPD, indata):
         curl = CurlClient(env=env)


### PR DESCRIPTION
Use parameterised test `id`s for better readability and easier parsing in our test infrastructure.