### PR TITLE
scripts: move the ruff linter command into a script

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -63,7 +63,7 @@ jobs:
             python3-toml python3-markupsafe python3-jinja2 python3-tabulate \
             python3-typing-extensions python3-libcst python3-impacket \
             python3-websockets python3-pytest
-          python3 -m pip install --break-system-packages cmakelint==1.4.3 pytype==2024.9.13 ruff==0.6.8
+          python3 -m pip install --break-system-packages cmakelint==1.4.3 pytype==2024.10.11 ruff==0.11.9
 
       - name: spellcheck
         run: |
@@ -81,7 +81,7 @@ jobs:
         run: find . -name '*.py' -exec pytype -j auto -k {} +
 
       - name: ruff
-        run: ruff check --extend-select=B007,B016,C405,C416,COM818,D200,D213,D204,D401,D415,FURB129,N818,PERF401,PERF403,PIE790,PIE808,PLW0127,Q004,RUF010,SIM101,SIM117,SIM118,TRY400,TRY401
+        run: scripts/pythonlint.sh
 
   reuse:
     runs-on: ubuntu-latest

--- a/scripts/Makefile.am
+++ b/scripts/Makefile.am
@@ -25,7 +25,7 @@
 EXTRA_DIST = coverage.sh completion.pl firefox-db2pem.sh checksrc.pl              \
   mk-ca-bundle.pl mk-unity.pl schemetable.c cd2nroff nroff2cd cdall cd2cd managen \
   dmaketgz maketgz release-tools.sh verify-release cmakelint.sh mdlinkcheck       \
-  CMakeLists.txt randdisable wcurl
+  CMakeLists.txt pythonlint.sh randdisable wcurl
 
 dist_bin_SCRIPTS = wcurl
 

--- a/scripts/pythonlint.sh
+++ b/scripts/pythonlint.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Dan Fandrich, <dan@coneharvesters.com>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
+# Use ruff to perform a style analysis on all Python code in the supplied
+# locations, or all Python files found in the current directory tree by
+# default.
+
+ruff check --extend-select=B007,B016,C405,C416,COM818,D200,D213,D204,D401,D415,FURB129,N818,PERF401,PERF403,PIE790,PIE808,PLW0127,Q004,RUF010,SIM101,SIM117,SIM118,TRY400,TRY401 "$@"


### PR DESCRIPTION
This makes it easier for users to run it with the correct options
locally. Also, update the ruff, pytype and cmakelint versions to the
latest current ones.

Closes #17343