### PR TITLE
libssh: split up the state machine function

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,9 +163,9 @@ jobs:
             install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
-          - name: openssl -O3 valgrind
-            install_packages: zlib1g-dev valgrind
-            configure: CFLAGS=-O3 --with-openssl --enable-debug
+          - name: openssl -O3 libssh valgrind
+            install_packages: zlib1g-dev libssh-dev valgrind
+            configure: CFLAGS=-O3 --with-openssl --enable-debug --with-libssh
 
           - name: openssl clang krb5
             install_packages: zlib1g-dev libkrb5-dev clang


### PR DESCRIPTION
This reduces the "complexity score" for myssh_statemach_act from 160 to 100, taking it down from the most complex function in libcurl to the 5th.

Also fixes a memory leak of the sftp session.