### PR TITLE
tests: add aws feature to the related tests

### DIFF
--- a/tests/data/test1933
+++ b/tests/data/test1933
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 
 <name>

--- a/tests/data/test1934
+++ b/tests/data/test1934
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 
 <name>

--- a/tests/data/test1935
+++ b/tests/data/test1935
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 
 <name>

--- a/tests/data/test1936
+++ b/tests/data/test1936
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 
 <name>

--- a/tests/data/test1937
+++ b/tests/data/test1937
@@ -38,6 +38,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 
 <name>

--- a/tests/data/test1938
+++ b/tests/data/test1938
@@ -38,6 +38,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 
 <name>

--- a/tests/data/test1955
+++ b/tests/data/test1955
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1956
+++ b/tests/data/test1956
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1957
+++ b/tests/data/test1957
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1958
+++ b/tests/data/test1958
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1959
+++ b/tests/data/test1959
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1964
+++ b/tests/data/test1964
@@ -36,6 +36,7 @@ http
 <features>
 SSL
 crypto
+aws
 </features>
 
 <name>

--- a/tests/data/test1970
+++ b/tests/data/test1970
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1971
+++ b/tests/data/test1971
@@ -30,6 +30,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1972
+++ b/tests/data/test1972
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1973
+++ b/tests/data/test1973
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1974
+++ b/tests/data/test1974
@@ -37,6 +37,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1975
+++ b/tests/data/test1975
@@ -30,6 +30,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <setenv>
 CURL_FORCEHOST=1

--- a/tests/data/test1976
+++ b/tests/data/test1976
@@ -26,6 +26,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <name>
 HTTP AWS_SIGV4 canonical request header sorting test

--- a/tests/data/test1978
+++ b/tests/data/test1978
@@ -26,6 +26,7 @@ http
 SSL
 Debug
 crypto
+aws
 </features>
 <name>
 HTTP AWS_SIGV4 canonical request duplicate header test

--- a/tests/data/test439
+++ b/tests/data/test439
@@ -33,6 +33,7 @@ http
 </server>
 <features>
 Debug
+aws
 </features>
 <name>
 aws-sigv4 with query

--- a/tests/data/test472
+++ b/tests/data/test472
@@ -34,6 +34,7 @@ http
 <features>
 Debug
 Unicode
+aws
 </features>
 <name>
 aws-sigv4 with query


### PR DESCRIPTION
Hello.
I tried building curl with --disable-aws configuration option. I noticed that despite the configuration, all tests related to AWS were performed (with errors).
To fix that problem, I added "aws" string to \<feature\> block of every test that involves AWS authentication. With my changes, all tests with aws feature are skipped in case when curl built with --disable-aws.