### PR TITLE
docs/libcurl: mention sensitive data/headers

### DIFF
--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
@@ -57,7 +57,7 @@ pointed to by the char * passed to this function is not null-terminated, but
 is exactly of the *size* as told by the *size* argument.
 
 **WARNING** this callback may receive sensitive contents from headers and
-data.
+data, including information sent as **CURLINFO_TEXT**.
 
 The *clientp* argument is the pointer set with CURLOPT_DEBUGDATA(3).
 

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
@@ -56,7 +56,7 @@ specified in the *type* argument. This function must return 0. The *data*
 pointed to by the char * passed to this function is not null-terminated, but
 is exactly of the *size* as told by the *size* argument.
 
-**WARNING** this callback maye receive sensitive contents from headers and
+**WARNING** this callback may receive sensitive contents from headers and
 data.
 
 The *clientp* argument is the pointer set with CURLOPT_DEBUGDATA(3).

--- a/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_DEBUGFUNCTION.md
@@ -51,11 +51,13 @@ Pass a pointer to your callback function, which should match the prototype
 shown above.
 
 CURLOPT_DEBUGFUNCTION(3) replaces the standard debug function used when
-CURLOPT_VERBOSE(3) is in effect. This callback receives debug
-information, as specified in the *type* argument. This function must
-return 0. The *data* pointed to by the char * passed to this function is
-not null-terminated, but is exactly of the *size* as told by the
-*size* argument.
+CURLOPT_VERBOSE(3) is in effect. This callback receives debug information, as
+specified in the *type* argument. This function must return 0. The *data*
+pointed to by the char * passed to this function is not null-terminated, but
+is exactly of the *size* as told by the *size* argument.
+
+**WARNING** this callback maye receive sensitive contents from headers and
+data.
 
 The *clientp* argument is the pointer set with CURLOPT_DEBUGDATA(3).
 

--- a/docs/libcurl/opts/CURLOPT_VERBOSE.md
+++ b/docs/libcurl/opts/CURLOPT_VERBOSE.md
@@ -28,16 +28,18 @@ CURLcode curl_easy_setopt(CURL *handle, CURLOPT_VERBOSE, long onoff);
 
 # DESCRIPTION
 
-Set the *onoff* parameter to 1 to make the library display a lot of
-verbose information about its operations on this *handle*. Useful for
-libcurl and/or protocol debugging and understanding. The verbose information
-is sent to stderr, or the stream set with CURLOPT_STDERR(3).
+Set the *onoff* parameter to 1 to make the library display a lot of verbose
+information about its operations on this *handle*. Useful for libcurl and/or
+protocol debugging and understanding. The verbose information is sent to
+stderr, or the stream set with CURLOPT_STDERR(3).
 
 You hardly ever want this enabled in production use, you almost always want
 this used when you debug/report problems.
 
 To also get all the protocol data sent and received, consider using the
 CURLOPT_DEBUGFUNCTION(3).
+
+**WARNING** this may show sensitive contents from headers and data.
 
 # DEFAULT
 


### PR DESCRIPTION
In the CURLOPT_DEBUGFUNCTION and CURLOPT_VERBOSE documentation.

Mentioned-by: Gordon Parke
Fixes #17353