### PR TITLE
GHA/curl-for-win: build one job with classic zlib

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -140,7 +140,7 @@ jobs:
             "${DOCKER_IMAGE}" \
             sh -c ./_ci-linux-debian.sh
 
-  win-gcc-libssh-zlibng-x86:
+  win-gcc-libssh-zlibold-x86:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
curl-for-win switched to zlib-ng by default. Switch curl's explicit
zlib-ng job to classic zlib to keep testing that build path.

Ref: https://github.com/curl/curl-for-win/pull/79
Ref: https://github.com/curl/curl-for-win/commit/5aed6363cd1051b560b3f7c57c97e04bf8cd74cb
