### PR TITLE
libssh: add NULL check for Curl_meta_get()

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -2460,7 +2460,7 @@ static CURLcode myssh_done(struct Curl_easy *data,
   CURLcode result = CURLE_OK;
   struct SSHPROTO *sshp = Curl_meta_get(data, CURL_META_SSH_EASY);
 
-  if(!status) {
+  if(!status && sshp) {
     /* run the state-machine */
     result = myssh_block_statemach(data, sshc, sshp, FALSE);
   }


### PR DESCRIPTION
It really cannot return NULL in a working condition, but ...

Pointed out by Coverity.