### PR TITLE
ssh_setopts: free the knownhosts pointer correctly

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -207,7 +207,7 @@ static CURLcode ssh_setopts(struct GlobalConfig *global,
       result = my_setopt_str(curl, CURLOPT_SSH_KNOWNHOSTS, known);
       if(result) {
         global->knownhosts = NULL;
-        curl_free(known);
+        free(known);
         return result;
       }
       /* store it in global to avoid repeated checks */


### PR DESCRIPTION
The string is allocated by tool malloc so curl_free() is wrong. Pointed out by Coverity.