### PR TITLE
remove unneeded guards around PUNY2IDN

### DIFF
--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1493,7 +1493,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
         }
       }
       else if(depunyfy) {
-        if(Curl_is_ASCII_name(u->host) && !strncmp("xn--", u->host, 4)) {
+        if(Curl_is_ASCII_name(u->host)) {
 #ifndef USE_IDN
           return CURLUE_LACKS_IDN;
 #else
@@ -1592,7 +1592,7 @@ CURLUcode curl_url_get(const CURLU *u, CURLUPart what,
       }
     }
     else if(depunyfy) {
-      if(Curl_is_ASCII_name(u->host)  && !strncmp("xn--", u->host, 4)) {
+      if(Curl_is_ASCII_name(u->host)) {
 #ifndef USE_IDN
         return CURLUE_LACKS_IDN;
 #else

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -214,6 +214,12 @@ static const struct testcase get_parts_list[] ={
   {"https://xn--rksmrgs-5wao1o.se",
    "https | [11] | [12] | [13] | r\xc3\xa4ksm\xc3\xb6rg\xc3\xa5s.se | "
    "[15] | / | [16] | [17]", 0, CURLU_PUNY2IDN, CURLUE_OK},
+  {"https://www.xn--rksmrgs-5wao1o.se",
+   "https | [11] | [12] | [13] | www.r\xc3\xa4ksm\xc3\xb6rg\xc3\xa5s.se | "
+   "[15] | / | [16] | [17]", 0, CURLU_PUNY2IDN, CURLUE_OK},
+  {"https://www.r\xc3\xa4ksm\xc3\xb6rg\xc3\xa5s.se",
+   "https | [11] | [12] | [13] | www.r\xc3\xa4ksm\xc3\xb6rg\xc3\xa5s.se | "
+   "[15] | / | [16] | [17]", 0, CURLU_PUNY2IDN, CURLUE_OK},
 #else
   {"https://r\xc3\xa4ksm\xc3\xb6rg\xc3\xa5s.se",
    "https | [11] | [12] | [13] | [30] | [15] | / | [16] | [17]",


### PR DESCRIPTION
This PR removes some guards around IDN which were causing punycode encoded domains starting with `www` (or anything other than `xn--` to fail the conversion. Removing the if statement allows libcurl to pass the urls directly to libidn2 and propagate errors up, instead of trying to detect a bad punycode early.

This came out of  digging in to an issue @dfandrich opened in trurl: https://github.com/curl/trurl/issues/392

I've done tests both with standalone C programs as well as in `trurl`, but I'm happy to try anything folks suspect will break.

Thanks!