### PR TITLE
asnyc-thrdd: pacify coverity warning

### DIFF
--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -319,16 +319,14 @@ static void async_thrdd_destroy(struct Curl_easy *data)
     /* Release our reference to the data shared with the thread. */
     Curl_mutex_acquire(&addr->mutx);
     --addr->ref_count;
-    /* we give up our reference to `addr`, so NULL our pointer.
-     * coverity analyses this as being a potential unsynched write,
-     * assuming two calls to this function could be invoked concurrently.
-     * Which they are never, as the transfer's side runs single-threaded.
-     * So assign only conditionally, hoping it silences coverity. */
-    if(thrdd->addr)
-      thrdd->addr = NULL;
     CURL_TRC_DNS(data, "resolve, destroy async data, shared ref=%d",
                  addr->ref_count);
     done = !addr->ref_count;
+    /* we give up our reference to `addr`, so NULL our pointer.
+     * coverity analyses this as being a potential unsynched write,
+     * assuming two calls to this function could be invoked concurrently.
+     * Which they never are, as the transfer's side runs single-threaded. */
+    thrdd->addr = NULL;
     if(!done) {
       /* thread is still running. Detach the thread while mutexed, it will
        * trigger the cleanup when it releases its reference. */


### PR DESCRIPTION
Coverity assess correctly that a variable write under mutex lock could overwrite values from another thread - if the function were ever called from multiple thread for the same transfer - which it is not.