### PR TITLE
pytest non-debug curl: fix libressl issues

### DIFF
--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -635,6 +635,8 @@ class TestDownload:
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     @pytest.mark.parametrize("max_host_conns", [0, 1, 5])
     def test_02_33_max_host_conns(self, env: Env, httpd, nghttpx, proto, max_host_conns):
+        if not env.curl_is_debug():
+            pytest.skip('only works for curl debug builds')
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 50
@@ -671,6 +673,8 @@ class TestDownload:
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2'])
     @pytest.mark.parametrize("max_total_conns", [0, 1, 5])
     def test_02_34_max_total_conns(self, env: Env, httpd, nghttpx, proto, max_total_conns):
+        if not env.curl_is_debug():
+            pytest.skip('only works for curl debug builds')
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
         count = 50

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -118,10 +118,11 @@ class TestErrors:
         url = f'https://{env.authority_for(env.domain1, proto)}'\
             f'/curltest/shutdown_unclean?id=[0-{count-1}]&chunks=4'
         r = curl.http_download(urls=[url], alpn_proto=proto, extra_args=[
-            '--parallel',
+            '--parallel', '--trace-config', 'ssl'
         ])
         if proto == 'http/1.0' and not env.curl_uses_lib('wolfssl') and \
-                (env.curl_is_debug() or not env.curl_uses_lib('openssl')):
+                (env.curl_is_debug() or
+                not env.curl_uses_any_libs(['openssl', 'libressl'])):
             # we are inconsistent if we fail or not in missing TLS shutdown
             # openssl code ignore such errors intentionally in non-debug builds
             r.check_exit_code(56)

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -33,7 +33,7 @@ import subprocess
 import tempfile
 from configparser import ConfigParser, ExtendedInterpolation
 from datetime import timedelta
-from typing import Optional, Dict
+from typing import Optional, Dict, List
 
 import pytest
 from filelock import FileLock
@@ -329,6 +329,13 @@ class Env:
         return libname.lower() in Env.CONFIG.curl_props['libs']
 
     @staticmethod
+    def curl_uses_any_libs(libs: List[str]) -> bool:
+        for libname in libs:
+            if libname.lower() in Env.CONFIG.curl_props['libs']:
+                return True
+        return False
+
+    @staticmethod
     def curl_uses_ossl_quic() -> bool:
         if Env.have_h3_curl():
             return not Env.curl_uses_lib('ngtcp2') and Env.curl_uses_lib('nghttp3')
@@ -388,10 +395,7 @@ class Env:
 
     @staticmethod
     def curl_can_early_data() -> bool:
-        return Env.curl_uses_lib('gnutls') or \
-            Env.curl_uses_lib('wolfssl') or \
-            Env.curl_uses_lib('quictls') or \
-            Env.curl_uses_lib('openssl')
+        return Env.curl_uses_any_libs(['gnutls', 'wolfssl', 'quictls', 'openssl'])
 
     @staticmethod
     def curl_can_h3_early_data() -> bool:


### PR DESCRIPTION
Some adjustments for running non-debug curl on macos, including fixes for libressl