### PR TITLE
libssh2: remove the 'actualcode' struct field

### DIFF
--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -3654,9 +3654,9 @@ static CURLcode sshc_cleanup(struct ssh_conn *sshc, struct Curl_easy *data,
 
     if(sshc->ssh_channel) {
       rc = libssh2_channel_free(sshc->ssh_channel);
-      if(!block && (rc == LIBSSH2_ERROR_EAGAIN)) {
-        return rc;
-      }
+      if(!block && (rc == LIBSSH2_ERROR_EAGAIN))
+        return CURLE_AGAIN;
+
       if((rc < 0) && data) {
         char *err_msg = NULL;
         (void)libssh2_session_last_error(sshc->ssh_session,
@@ -3669,9 +3669,9 @@ static CURLcode sshc_cleanup(struct ssh_conn *sshc, struct Curl_easy *data,
 
     if(sshc->sftp_session) {
       rc = libssh2_sftp_shutdown(sshc->sftp_session);
-      if(!block && (rc == LIBSSH2_ERROR_EAGAIN)) {
-        return rc;
-      }
+      if(!block && (rc == LIBSSH2_ERROR_EAGAIN))
+        return CURLE_AGAIN;
+
       if((rc < 0) && data)
         infof(data, "Failed to stop libssh2 sftp subsystem");
       sshc->sftp_session = NULL;
@@ -3679,9 +3679,9 @@ static CURLcode sshc_cleanup(struct ssh_conn *sshc, struct Curl_easy *data,
 
     if(sshc->ssh_session) {
       rc = libssh2_session_free(sshc->ssh_session);
-      if(!block && (rc == LIBSSH2_ERROR_EAGAIN)) {
-        return rc;
-      }
+      if(!block && (rc == LIBSSH2_ERROR_EAGAIN))
+        return CURLE_AGAIN;
+
       if((rc < 0) && data) {
         char *err_msg = NULL;
         (void)libssh2_session_last_error(sshc->ssh_session,
@@ -3706,7 +3706,7 @@ static CURLcode sshc_cleanup(struct ssh_conn *sshc, struct Curl_easy *data,
     Curl_safefree(sshc->homedir);
     sshc->initialised = FALSE;
   }
-  return 0;
+  return CURLE_OK;
 }
 
 
@@ -3729,7 +3729,7 @@ static CURLcode scp_disconnect(struct Curl_easy *data,
   }
 
   if(sshc)
-    sshc_cleanup(sshc, data, TRUE);
+    return sshc_cleanup(sshc, data, TRUE);
   return result;
 }
 

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -208,6 +208,7 @@ struct ssh_conn {
   struct libssh2_agent_publickey *sshagent_prev_identity;
   LIBSSH2_KNOWNHOSTS *kh;
 #elif defined(USE_WOLFSSH)
+  CURLcode actualcode;        /* the actual error code */
   WOLFSSH *ssh_session;
   WOLFSSH_CTX *ctx;
   word32 handleSz;

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -148,7 +148,6 @@ struct ssh_conn {
   char *rsa;                  /* strdup'ed private key file */
   sshstate state;             /* always use ssh.c:state() to change state! */
   sshstate nextstate;         /* the state to goto after stopping */
-  CURLcode actualcode;        /* the actual error code */
   struct curl_slist *quote_item; /* for the quote option */
   char *quote_path1;          /* two generic pointers for the QUOTE stuff */
   char *quote_path2;
@@ -164,6 +163,7 @@ struct ssh_conn {
   char *slash_pos;              /* used by the SFTP_CREATE_DIRS state */
 
 #if defined(USE_LIBSSH)
+  CURLcode actualcode;        /* the actual error code */
   char *readdir_linkPath;
   size_t readdir_len;
   struct dynbuf readdir_buf;


### PR DESCRIPTION
Return and use CURLcode to a larger extent to avoid the complicated double return code setup previously used.