### PR TITLE
formdata: cleanup

### DIFF
--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -253,15 +253,9 @@ static CURLFORMcode FormAddCheck(struct FormInfo *first_form,
       form->contenttype_alloc = TRUE;
     }
     if(form->name && form->namelength) {
-      /* Name should not contain nul bytes. */
-      size_t i;
-      for(i = 0; i < form->namelength; i++)
-        if(!form->name[i]) {
-          return_value = CURL_FORMADD_NULL;
-          break;
-        }
-      if(return_value != CURL_FORMADD_OK)
-        break;
+      if(memchr(form->name, 0, form->namelength))
+        return_value = CURL_FORMADD_NULL;
+      break;
     }
     if(!(form->flags & HTTPPOST_PTRNAME) &&
        (form == first_form) ) {

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -64,36 +64,31 @@ struct Curl_easy;
  *
  ***************************************************************************/
 static struct curl_httppost *
-AddHttpPost(char *name, size_t namelength,
-            char *value, curl_off_t contentslength,
-            char *buffer, size_t bufferlength,
-            char *contenttype,
-            long flags,
-            struct curl_slist *contentHeader,
-            char *showfilename, char *userp,
+AddHttpPost(struct FormInfo *src,
             struct curl_httppost *parent_post,
             struct curl_httppost **httppost,
             struct curl_httppost **last_post)
 {
   struct curl_httppost *post;
-  if(!namelength && name)
-    namelength = strlen(name);
-  if((bufferlength > LONG_MAX) || (namelength > LONG_MAX))
+  size_t namelength = src->namelength;
+  if(!namelength && src->name)
+    namelength = strlen(src->name);
+  if((src->bufferlength > LONG_MAX) || (namelength > LONG_MAX))
     /* avoid overflow in typecasts below */
     return NULL;
   post = calloc(1, sizeof(struct curl_httppost));
   if(post) {
-    post->name = name;
+    post->name = src->name;
     post->namelength = (long)namelength;
-    post->contents = value;
-    post->contentlen = contentslength;
-    post->buffer = buffer;
-    post->bufferlength = (long)bufferlength;
-    post->contenttype = contenttype;
-    post->contentheader = contentHeader;
-    post->showfilename = showfilename;
-    post->userp = userp;
-    post->flags = flags | CURL_HTTPPOST_LARGE;
+    post->contents = src->value;
+    post->contentlen = src->contentslength;
+    post->buffer = src->buffer;
+    post->bufferlength = (long)src->bufferlength;
+    post->contenttype = src->contenttype;
+    post->flags = src->flags | CURL_HTTPPOST_LARGE;
+    post->contentheader = src->contentheader;
+    post->showfilename = src->showfilename;
+    post->userp = src->userp;
   }
   else
     return NULL;
@@ -311,14 +306,7 @@ static CURLFORMcode FormAddCheck(struct FormInfo *first_form,
       }
       form->value_alloc = TRUE;
     }
-    post = AddHttpPost(form->name, form->namelength,
-                       form->value, form->contentslength,
-                       form->buffer, form->bufferlength,
-                       form->contenttype, form->flags,
-                       form->contentheader, form->showfilename,
-                       form->userp,
-                       post, httppost,
-                       last_post);
+    post = AddHttpPost(form, post, httppost, last_post);
 
     if(!post) {
       retval = CURL_FORMADD_MEMORY;

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -329,7 +329,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
   CURLFORMcode retval = CURL_FORMADD_OK;
   CURLformoption option;
   struct curl_forms *forms = NULL;
-  char *array_value = NULL; /* value read from an array */
+  char *avalue = NULL; /* value read from an array */
 
   /* This is a state variable, that if TRUE means that we are parsing an
      array that we got passed to us. If FALSE we are parsing the input
@@ -354,7 +354,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
     if(array_state && forms) {
       /* get the upcoming option from the given array */
       option = forms->option;
-      array_value = (char *)CURL_UNCONST(forms->value);
+      avalue = (char *)CURL_UNCONST(forms->value);
 
       forms++; /* advance this to next entry */
       if(CURLFORM_END == option) {
@@ -398,7 +398,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         retval = CURL_FORMADD_OPTION_TWICE;
       else {
         char *name = array_state ?
-          array_value : va_arg(params, char *);
+          avalue : va_arg(params, char *);
         if(name)
           curr->name = name; /* store for the moment */
         else
@@ -410,7 +410,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         retval = CURL_FORMADD_OPTION_TWICE;
       else
         curr->namelength =
-          array_state ? (size_t)array_value : (size_t)va_arg(params, long);
+          array_state ? (size_t)avalue : (size_t)va_arg(params, long);
       break;
 
       /*
@@ -424,7 +424,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         retval = CURL_FORMADD_OPTION_TWICE;
       else {
         char *value =
-          array_state ? array_value : va_arg(params, char *);
+          array_state ? avalue : va_arg(params, char *);
         if(value)
           curr->value = value; /* store for the moment */
         else
@@ -433,13 +433,13 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
       break;
     case CURLFORM_CONTENTSLENGTH:
       curr->contentslength =
-        array_state ? (size_t)array_value : (size_t)va_arg(params, long);
+        array_state ? (size_t)avalue : (size_t)va_arg(params, long);
       break;
 
     case CURLFORM_CONTENTLEN:
       curr->flags |= CURL_HTTPPOST_LARGE;
       curr->contentslength =
-        array_state ? (curl_off_t)(size_t)array_value :
+        array_state ? (curl_off_t)(size_t)avalue :
         va_arg(params, curl_off_t);
       break;
 
@@ -449,7 +449,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         retval = CURL_FORMADD_OPTION_TWICE;
       else {
         const char *filename = array_state ?
-          array_value : va_arg(params, char *);
+          avalue : va_arg(params, char *);
         if(filename) {
           curr->value = strdup(filename);
           if(!curr->value)
@@ -467,7 +467,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
       /* We upload a file */
     case CURLFORM_FILE:
       {
-        const char *filename = array_state ? array_value :
+        const char *filename = array_state ? avalue :
           va_arg(params, char *);
 
         if(curr->value) {
@@ -517,7 +517,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         retval = CURL_FORMADD_OPTION_TWICE;
       else {
         char *buffer =
-          array_state ? array_value : va_arg(params, char *);
+          array_state ? avalue : va_arg(params, char *);
         if(buffer) {
           curr->buffer = buffer; /* store for the moment */
           curr->value = buffer; /* make it non-NULL to be accepted
@@ -533,7 +533,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         retval = CURL_FORMADD_OPTION_TWICE;
       else
         curr->bufferlength =
-          array_state ? (size_t)array_value : (size_t)va_arg(params, long);
+          array_state ? (size_t)avalue : (size_t)va_arg(params, long);
       break;
 
     case CURLFORM_STREAM:
@@ -542,7 +542,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         retval = CURL_FORMADD_OPTION_TWICE;
       else {
         char *userp =
-          array_state ? array_value : va_arg(params, char *);
+          array_state ? avalue : va_arg(params, char *);
         if(userp) {
           curr->userp = userp;
           curr->value = userp; /* this is not strictly true but we
@@ -558,7 +558,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
     case CURLFORM_CONTENTTYPE:
       {
         const char *contenttype =
-          array_state ? array_value : va_arg(params, char *);
+          array_state ? avalue : va_arg(params, char *);
         if(curr->contenttype) {
           if(curr->flags & HTTPPOST_FILENAME) {
             if(contenttype) {
@@ -602,7 +602,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
         /* this "cast increases required alignment of target type" but
            we consider it OK anyway */
         struct curl_slist *list = array_state ?
-          (struct curl_slist *)(void *)array_value :
+          (struct curl_slist *)(void *)avalue :
           va_arg(params, struct curl_slist *);
 
         if(curr->contentheader)
@@ -615,7 +615,7 @@ CURLFORMcode FormAdd(struct curl_httppost **httppost,
     case CURLFORM_FILENAME:
     case CURLFORM_BUFFER:
       {
-        const char *filename = array_state ? array_value :
+        const char *filename = array_state ? avalue :
           va_arg(params, char *);
         if(curr->showfilename)
           retval = CURL_FORMADD_OPTION_TWICE;

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -270,9 +270,10 @@ static CURLFORMcode FormAddCheck(struct FormInfo *first_form,
       form->contenttype_alloc = TRUE;
     }
     if(form->name && form->namelength) {
-      if(memchr(form->name, 0, form->namelength))
+      if(memchr(form->name, 0, form->namelength)) {
         retval = CURL_FORMADD_NULL;
-      break;
+        break;
+      }
     }
     if(!(form->flags & HTTPPOST_PTRNAME) &&
        (form == first_form) ) {

--- a/lib/formdata.h
+++ b/lib/formdata.h
@@ -35,7 +35,6 @@ struct FormInfo {
   char *value;
   curl_off_t contentslength;
   char *contenttype;
-  long flags;
   char *buffer;      /* pointer to existing buffer used for file upload */
   size_t bufferlength;
   char *showfilename; /* The filename to show. If not set, the actual
@@ -43,6 +42,7 @@ struct FormInfo {
   char *userp;        /* pointer for the read callback */
   struct curl_slist *contentheader;
   struct FormInfo *more;
+  unsigned char flags;
   BIT(name_alloc);
   BIT(value_alloc);
   BIT(contenttype_alloc);


### PR DESCRIPTION
- use memchr() instead of for() loop
- add and use free_formlist() instead of duplicate code
- shorten some variable names
- reduce flag struct field from 'long' to 'unsigned char'
- pass in struct pointer, not individual fields, to addhttppost()