### PR TITLE
libtests: define CURL_DISABLE_DEPRECATION first

### DIFF
--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -23,6 +23,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
+#define CURL_DISABLE_DEPRECATION 1
 #include "curl_setup.h"
 #include <curl/curl.h>
 

--- a/tests/libtest/lib1308.c
+++ b/tests/libtest/lib1308.c
@@ -41,60 +41,46 @@ CURLcode test(char *URL)
   size_t total_size = 0;
   char buffer[] = "test buffer";
 
-  CURL_IGNORE_DEPRECATION(
-    rc = curl_formadd(&post, &last, CURLFORM_COPYNAME, "name",
+  rc = curl_formadd(&post, &last, CURLFORM_COPYNAME, "name",
                       CURLFORM_COPYCONTENTS, "content", CURLFORM_END);
-  )
   fail_unless(rc == 0, "curl_formadd returned error");
 
   /* after the first curl_formadd when there's a single entry, both pointers
      should point to the same struct */
   fail_unless(post == last, "post and last weren't the same");
 
-  CURL_IGNORE_DEPRECATION(
-    rc = curl_formadd(&post, &last, CURLFORM_COPYNAME, "htmlcode",
-                      CURLFORM_COPYCONTENTS, "<HTML></HTML>",
-                      CURLFORM_CONTENTTYPE, "text/html", CURLFORM_END);
-  )
+  rc = curl_formadd(&post, &last, CURLFORM_COPYNAME, "htmlcode",
+                    CURLFORM_COPYCONTENTS, "<HTML></HTML>",
+                    CURLFORM_CONTENTTYPE, "text/html", CURLFORM_END);
   fail_unless(rc == 0, "curl_formadd returned error");
 
-  CURL_IGNORE_DEPRECATION(
-    rc = curl_formadd(&post, &last, CURLFORM_COPYNAME, "name_for_ptrcontent",
-                     CURLFORM_PTRCONTENTS, buffer, CURLFORM_END);
-  )
+  rc = curl_formadd(&post, &last, CURLFORM_COPYNAME, "name_for_ptrcontent",
+                    CURLFORM_PTRCONTENTS, buffer, CURLFORM_END);
   fail_unless(rc == 0, "curl_formadd returned error");
 
-  CURL_IGNORE_DEPRECATION(
-    res = curl_formget(post, &total_size, print_httppost_callback);
-  )
+  res = curl_formget(post, &total_size, print_httppost_callback);
   fail_unless(res == 0, "curl_formget returned error");
 
   fail_unless(total_size == 518, "curl_formget got wrong size back");
 
-  CURL_IGNORE_DEPRECATION(
-    curl_formfree(post);
-  )
+  curl_formfree(post);
 
   /* start a new formpost with a file upload and formget */
   post = last = NULL;
 
-  CURL_IGNORE_DEPRECATION(
-    rc = curl_formadd(&post, &last,
-                      CURLFORM_PTRNAME, "name of file field",
-                      CURLFORM_FILE, URL,
-                      CURLFORM_FILENAME, "custom named file",
-                      CURLFORM_END);
-  )
+  rc = curl_formadd(&post, &last,
+                    CURLFORM_PTRNAME, "name of file field",
+                    CURLFORM_FILE, URL,
+                    CURLFORM_FILENAME, "custom named file",
+                    CURLFORM_END);
   fail_unless(rc == 0, "curl_formadd returned error");
 
-  CURL_IGNORE_DEPRECATION(
-    res = curl_formget(post, &total_size, print_httppost_callback);
-  )
+  res = curl_formget(post, &total_size, print_httppost_callback);
+
   fail_unless(res == 0, "curl_formget returned error");
   fail_unless(total_size == 899, "curl_formget got wrong size back");
 
-  CURL_IGNORE_DEPRECATION(
-    curl_formfree(post);
-  )
+  curl_formfree(post);
+
   return CURLE_OK;
 }

--- a/tests/libtest/lib1512.c
+++ b/tests/libtest/lib1512.c
@@ -71,9 +71,7 @@ CURLcode test(char *URL)
     /* include headers */
     easy_setopt(curl[i], CURLOPT_HEADER, 1L);
 
-    CURL_IGNORE_DEPRECATION(
-      easy_setopt(curl[i], CURLOPT_DNS_USE_GLOBAL_CACHE, 1L);
-    )
+    easy_setopt(curl[i], CURLOPT_DNS_USE_GLOBAL_CACHE, 1L);
   }
 
   /* make the first one populate the GLOBAL cache */

--- a/tests/libtest/lib1513.c
+++ b/tests/libtest/lib1513.c
@@ -59,10 +59,8 @@ CURLcode test(char *URL)
   easy_setopt(curl, CURLOPT_URL, URL);
   easy_setopt(curl, CURLOPT_TIMEOUT, (long)7);
   easy_setopt(curl, CURLOPT_NOSIGNAL, (long)1);
-  CURL_IGNORE_DEPRECATION(
-    easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, progressKiller);
-    easy_setopt(curl, CURLOPT_PROGRESSDATA, NULL);
-  )
+  easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, progressKiller);
+  easy_setopt(curl, CURLOPT_PROGRESSDATA, NULL);
   easy_setopt(curl, CURLOPT_NOPROGRESS, (long)0);
 
   res = curl_easy_perform(curl);

--- a/tests/libtest/lib1535.c
+++ b/tests/libtest/lib1535.c
@@ -40,9 +40,8 @@ CURLcode test(char *URL)
   /* Test that protocol is properly initialized on curl_easy_init.
   */
 
-  CURL_IGNORE_DEPRECATION(
-    res = curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
-  )
+  res = curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
+
   if(res) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
@@ -70,9 +69,8 @@ CURLcode test(char *URL)
   /* Test that a protocol is properly set after receiving an HTTP resource.
   */
 
-  CURL_IGNORE_DEPRECATION(
-    res = curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
-  )
+  res = curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
+
   if(res) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
@@ -99,9 +97,8 @@ CURLcode test(char *URL)
     goto test_cleanup;
   }
 
-  CURL_IGNORE_DEPRECATION(
-    res = curl_easy_getinfo(dupe, CURLINFO_PROTOCOL, &protocol);
-  )
+  res = curl_easy_getinfo(dupe, CURLINFO_PROTOCOL, &protocol);
+
   if(res) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",
@@ -122,9 +119,8 @@ CURLcode test(char *URL)
 
   curl_easy_reset(curl);
 
-  CURL_IGNORE_DEPRECATION(
-    res = curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
-  )
+  res = curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
+
   if(res) {
     curl_mfprintf(stderr,
                   "%s:%d curl_easy_getinfo() failed with code %d (%s)\n",

--- a/tests/libtest/lib1545.c
+++ b/tests/libtest/lib1545.c
@@ -35,20 +35,16 @@ CURLcode test(char *URL)
   easy_init(eh);
 
   easy_setopt(eh, CURLOPT_URL, URL);
-  CURL_IGNORE_DEPRECATION(
-    curl_formadd(&m_formpost, &lastptr, CURLFORM_COPYNAME, "file",
-                 CURLFORM_FILE, "missing-file", CURLFORM_END);
-    curl_easy_setopt(eh, CURLOPT_HTTPPOST, m_formpost);
-  )
+  curl_formadd(&m_formpost, &lastptr, CURLFORM_COPYNAME, "file",
+               CURLFORM_FILE, "missing-file", CURLFORM_END);
+  curl_easy_setopt(eh, CURLOPT_HTTPPOST, m_formpost);
 
   (void)curl_easy_perform(eh);
   (void)curl_easy_perform(eh);
 
 test_cleanup:
 
-  CURL_IGNORE_DEPRECATION(
-    curl_formfree(m_formpost);
-  )
+  curl_formfree(m_formpost);
   curl_easy_cleanup(eh);
   curl_global_cleanup();
 

--- a/tests/libtest/lib1555.c
+++ b/tests/libtest/lib1555.c
@@ -64,10 +64,8 @@ CURLcode test(char *URL)
   easy_setopt(curl, CURLOPT_URL, URL);
   easy_setopt(curl, CURLOPT_TIMEOUT, (long)7);
   easy_setopt(curl, CURLOPT_NOSIGNAL, (long)1);
-  CURL_IGNORE_DEPRECATION(
-    easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, progressCallback);
-    easy_setopt(curl, CURLOPT_PROGRESSDATA, NULL);
-  )
+  easy_setopt(curl, CURLOPT_PROGRESSFUNCTION, progressCallback);
+  easy_setopt(curl, CURLOPT_PROGRESSDATA, NULL);
   easy_setopt(curl, CURLOPT_NOPROGRESS, (long)0);
 
   res = curl_easy_perform(curl);

--- a/tests/libtest/lib1558.c
+++ b/tests/libtest/lib1558.c
@@ -44,9 +44,7 @@ CURLcode test(char *URL)
     goto test_cleanup;
   }
 
-  CURL_IGNORE_DEPRECATION(
-    res = curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
-  )
+  res = curl_easy_getinfo(curl, CURLINFO_PROTOCOL, &protocol);
   if(res) {
     curl_mfprintf(stderr, "curl_easy_getinfo() returned %d (%s)\n",
                   res, curl_easy_strerror(res));

--- a/tests/libtest/lib1911.c
+++ b/tests/libtest/lib1911.c
@@ -61,18 +61,16 @@ CURLcode test(char *URL)
       /*
        * Whitelist string options that are safe for abuse
        */
-      CURL_IGNORE_DEPRECATION(
-        switch(o->id) {
-        case CURLOPT_PROXY_TLSAUTH_TYPE:
-        case CURLOPT_TLSAUTH_TYPE:
-        case CURLOPT_RANDOM_FILE:
-        case CURLOPT_EGDSOCKET:
-          continue;
-        default:
-          /* check this */
-          break;
-        }
-      )
+      switch(o->id) {
+      case CURLOPT_PROXY_TLSAUTH_TYPE:
+      case CURLOPT_TLSAUTH_TYPE:
+      case CURLOPT_RANDOM_FILE:
+      case CURLOPT_EGDSOCKET:
+        continue;
+      default:
+        /* check this */
+        break;
+      }
 
       /* This is a string. Make sure that passing in a string longer
          CURL_MAX_INPUT_LENGTH returns an error */

--- a/tests/libtest/lib1912.c
+++ b/tests/libtest/lib1912.c
@@ -40,44 +40,42 @@ CURLcode test(char *URL)
   for(o = curl_easy_option_next(NULL);
       o;
       o = curl_easy_option_next(o)) {
-    CURL_IGNORE_DEPRECATION(
-      /* Test for mismatch OR missing typecheck macros */
-      if(curlcheck_long_option(o->id) !=
-          (o->type == CURLOT_LONG || o->type == CURLOT_VALUES)) {
-        print_err(o->name, "CURLOT_LONG or CURLOT_VALUES");
-        error++;
-      }
-      if(curlcheck_off_t_option(o->id) != (o->type == CURLOT_OFF_T)) {
-        print_err(o->name, "CURLOT_OFF_T");
-        error++;
-      }
-      if(curlcheck_string_option(o->id) != (o->type == CURLOT_STRING)) {
-        print_err(o->name, "CURLOT_STRING");
-        error++;
-      }
-      if(curlcheck_slist_option(o->id) != (o->type == CURLOT_SLIST)) {
-        print_err(o->name, "CURLOT_SLIST");
-        error++;
-      }
-      if(curlcheck_cb_data_option(o->id) != (o->type == CURLOT_CBPTR)) {
-        print_err(o->name, "CURLOT_CBPTR");
-        error++;
-      }
-      /* From here: only test that the type matches if macro is known */
-      if(curlcheck_write_cb_option(o->id) && (o->type != CURLOT_FUNCTION)) {
-        print_err(o->name, "CURLOT_FUNCTION");
-        error++;
-      }
-      if(curlcheck_conv_cb_option(o->id) && (o->type != CURLOT_FUNCTION)) {
-        print_err(o->name, "CURLOT_FUNCTION");
-        error++;
-      }
-      if(curlcheck_postfields_option(o->id) && (o->type != CURLOT_OBJECT)) {
-        print_err(o->name, "CURLOT_OBJECT");
-        error++;
-      }
-      /* Todo: no gcc typecheck for CURLOPTTYPE_BLOB types? */
-    )
+    /* Test for mismatch OR missing typecheck macros */
+    if(curlcheck_long_option(o->id) !=
+       (o->type == CURLOT_LONG || o->type == CURLOT_VALUES)) {
+      print_err(o->name, "CURLOT_LONG or CURLOT_VALUES");
+      error++;
+    }
+    if(curlcheck_off_t_option(o->id) != (o->type == CURLOT_OFF_T)) {
+      print_err(o->name, "CURLOT_OFF_T");
+      error++;
+    }
+    if(curlcheck_string_option(o->id) != (o->type == CURLOT_STRING)) {
+      print_err(o->name, "CURLOT_STRING");
+      error++;
+    }
+    if(curlcheck_slist_option(o->id) != (o->type == CURLOT_SLIST)) {
+      print_err(o->name, "CURLOT_SLIST");
+      error++;
+    }
+    if(curlcheck_cb_data_option(o->id) != (o->type == CURLOT_CBPTR)) {
+      print_err(o->name, "CURLOT_CBPTR");
+      error++;
+    }
+    /* From here: only test that the type matches if macro is known */
+    if(curlcheck_write_cb_option(o->id) && (o->type != CURLOT_FUNCTION)) {
+      print_err(o->name, "CURLOT_FUNCTION");
+      error++;
+    }
+    if(curlcheck_conv_cb_option(o->id) && (o->type != CURLOT_FUNCTION)) {
+      print_err(o->name, "CURLOT_FUNCTION");
+      error++;
+    }
+    if(curlcheck_postfields_option(o->id) && (o->type != CURLOT_OBJECT)) {
+      print_err(o->name, "CURLOT_OBJECT");
+      error++;
+    }
+    /* Todo: no gcc typecheck for CURLOPTTYPE_BLOB types? */
   }
 #endif
   (void)URL;

--- a/tests/libtest/lib516.c
+++ b/tests/libtest/lib516.c
@@ -44,9 +44,7 @@ CURLcode test(char *URL)
 
   /* First set the URL that is about to receive our POST. */
   test_setopt(curl, CURLOPT_URL, URL);
-  CURL_IGNORE_DEPRECATION(
-    test_setopt(curl, CURLOPT_HTTPPOST, NULL);
-  )
+  test_setopt(curl, CURLOPT_HTTPPOST, NULL);
   test_setopt(curl, CURLOPT_VERBOSE, 1L); /* show verbose for debug */
   test_setopt(curl, CURLOPT_HEADER, 1L); /* include header */
 

--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -100,10 +100,9 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_POSTFIELDS, UPLOADTHIS);
 #else
   /* 547 style, which means reading the POST data from a callback */
-  CURL_IGNORE_DEPRECATION(
-    test_setopt(curl, CURLOPT_IOCTLFUNCTION, ioctlcallback);
-    test_setopt(curl, CURLOPT_IOCTLDATA, &counter);
-  )
+  test_setopt(curl, CURLOPT_IOCTLFUNCTION, ioctlcallback);
+  test_setopt(curl, CURLOPT_IOCTLDATA, &counter);
+
   test_setopt(curl, CURLOPT_READFUNCTION, readcallback);
   test_setopt(curl, CURLOPT_READDATA, &counter);
   /* We CANNOT do the POST fine without setting the size (or choose

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -199,9 +199,7 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_WRITEFUNCTION, write_callback);
 
   /* Ioctl function */
-  CURL_IGNORE_DEPRECATION(
-    test_setopt(curl, CURLOPT_IOCTLFUNCTION, ioctl_callback);
-  )
+  test_setopt(curl, CURLOPT_IOCTLFUNCTION, ioctl_callback);
 
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
 

--- a/tests/libtest/lib554.c
+++ b/tests/libtest/lib554.c
@@ -75,27 +75,23 @@ static CURLcode test_once(char *URL, bool oldstyle)
 
   /* Fill in the file upload field */
   if(oldstyle) {
-    CURL_IGNORE_DEPRECATION(
-      formrc = curl_formadd(&formpost,
-                            &lastptr,
-                            CURLFORM_COPYNAME, "sendfile",
-                            CURLFORM_STREAM, &pooh,
-                            CURLFORM_CONTENTSLENGTH, (long)pooh.sizeleft,
-                            CURLFORM_FILENAME, "postit2.c",
-                            CURLFORM_END);
-    )
+    formrc = curl_formadd(&formpost,
+                          &lastptr,
+                          CURLFORM_COPYNAME, "sendfile",
+                          CURLFORM_STREAM, &pooh,
+                          CURLFORM_CONTENTSLENGTH, (long)pooh.sizeleft,
+                          CURLFORM_FILENAME, "postit2.c",
+                          CURLFORM_END);
   }
   else {
-    CURL_IGNORE_DEPRECATION(
-      /* new style */
-      formrc = curl_formadd(&formpost,
-                            &lastptr,
-                            CURLFORM_COPYNAME, "sendfile alternative",
-                            CURLFORM_STREAM, &pooh,
-                            CURLFORM_CONTENTLEN, (curl_off_t)pooh.sizeleft,
-                            CURLFORM_FILENAME, "file name 2",
-                            CURLFORM_END);
-    )
+    /* new style */
+    formrc = curl_formadd(&formpost,
+                          &lastptr,
+                          CURLFORM_COPYNAME, "sendfile alternative",
+                          CURLFORM_STREAM, &pooh,
+                          CURLFORM_CONTENTLEN, (curl_off_t)pooh.sizeleft,
+                          CURLFORM_FILENAME, "file name 2",
+                          CURLFORM_END);
   }
 
   if(formrc)
@@ -107,58 +103,51 @@ static CURLcode test_once(char *URL, bool oldstyle)
   pooh2.readptr = testdata;
   pooh2.sizeleft = strlen(testdata);
 
-  CURL_IGNORE_DEPRECATION(
-    /* Fill in the file upload field */
-    formrc = curl_formadd(&formpost,
-                          &lastptr,
-                          CURLFORM_COPYNAME, "callbackdata",
-                          CURLFORM_STREAM, &pooh2,
-                          CURLFORM_CONTENTSLENGTH, (long)pooh2.sizeleft,
-                          CURLFORM_END);
-  )
+  /* Fill in the file upload field */
+  formrc = curl_formadd(&formpost,
+                        &lastptr,
+                        CURLFORM_COPYNAME, "callbackdata",
+                        CURLFORM_STREAM, &pooh2,
+                        CURLFORM_CONTENTSLENGTH, (long)pooh2.sizeleft,
+                        CURLFORM_END);
+
   if(formrc)
     curl_mprintf("curl_formadd(2) = %d\n", (int)formrc);
 
-  CURL_IGNORE_DEPRECATION(
-    /* Fill in the filename field */
-    formrc = curl_formadd(&formpost,
-                          &lastptr,
-                          CURLFORM_COPYNAME, "filename",
-                          CURLFORM_COPYCONTENTS, "postit2.c",
-                          CURLFORM_END);
-  )
+  /* Fill in the filename field */
+  formrc = curl_formadd(&formpost,
+                        &lastptr,
+                        CURLFORM_COPYNAME, "filename",
+                        CURLFORM_COPYCONTENTS, "postit2.c",
+                        CURLFORM_END);
   if(formrc)
     curl_mprintf("curl_formadd(3) = %d\n", (int)formrc);
 
-  CURL_IGNORE_DEPRECATION(
-    /* Fill in a submit field too */
-    formrc = curl_formadd(&formpost,
-                          &lastptr,
-                          CURLFORM_COPYNAME, "submit",
-                          CURLFORM_COPYCONTENTS, "send",
-                          CURLFORM_CONTENTTYPE, "text/plain",
-                          CURLFORM_END);
-  )
+  /* Fill in a submit field too */
+  formrc = curl_formadd(&formpost,
+                        &lastptr,
+                        CURLFORM_COPYNAME, "submit",
+                        CURLFORM_COPYCONTENTS, "send",
+                        CURLFORM_CONTENTTYPE, "text/plain",
+                        CURLFORM_END);
+
   if(formrc)
     curl_mprintf("curl_formadd(4) = %d\n", (int)formrc);
 
-  CURL_IGNORE_DEPRECATION(
-    formrc = curl_formadd(&formpost, &lastptr,
-                          CURLFORM_COPYNAME, "somename",
-                          CURLFORM_BUFFER, "somefile.txt",
-                          CURLFORM_BUFFERPTR, "blah blah",
-                          CURLFORM_BUFFERLENGTH, (long)9,
-                          CURLFORM_END);
-  )
+  formrc = curl_formadd(&formpost, &lastptr,
+                        CURLFORM_COPYNAME, "somename",
+                        CURLFORM_BUFFER, "somefile.txt",
+                        CURLFORM_BUFFERPTR, "blah blah",
+                        CURLFORM_BUFFERLENGTH, (long)9,
+                        CURLFORM_END);
+
   if(formrc)
     curl_mprintf("curl_formadd(5) = %d\n", (int)formrc);
 
   curl = curl_easy_init();
   if(!curl) {
     curl_mfprintf(stderr, "curl_easy_init() failed\n");
-    CURL_IGNORE_DEPRECATION(
-      curl_formfree(formpost);
-    )
+    curl_formfree(formpost);
     curl_global_cleanup();
     return TEST_ERR_MAJOR_BAD;
   }
@@ -175,10 +164,8 @@ static CURLcode test_once(char *URL, bool oldstyle)
   /* we want to use our own read function */
   test_setopt(curl, CURLOPT_READFUNCTION, read_callback);
 
-  CURL_IGNORE_DEPRECATION(
-    /* send a multi-part formpost */
-    test_setopt(curl, CURLOPT_HTTPPOST, formpost);
-  )
+  /* send a multi-part formpost */
+  test_setopt(curl, CURLOPT_HTTPPOST, formpost);
 
   /* get verbose debug output please */
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
@@ -191,15 +178,11 @@ static CURLcode test_once(char *URL, bool oldstyle)
 
 test_cleanup:
 
-  CURL_IGNORE_DEPRECATION(
-    /* always cleanup */
-    curl_easy_cleanup(curl);
-  )
+  /* always cleanup */
+  curl_easy_cleanup(curl);
 
-  CURL_IGNORE_DEPRECATION(
-    /* now cleanup the formpost chain */
-    curl_formfree(formpost);
-  )
+  /* now cleanup the formpost chain */
+  curl_formfree(formpost);
 
   return res;
 }

--- a/tests/libtest/lib555.c
+++ b/tests/libtest/lib555.c
@@ -95,10 +95,9 @@ CURLcode test(char *URL)
   easy_setopt(curl, CURLOPT_HEADER, 1L);
 
   /* read the POST data from a callback */
-  CURL_IGNORE_DEPRECATION(
-    easy_setopt(curl, CURLOPT_IOCTLFUNCTION, ioctlcallback);
-    easy_setopt(curl, CURLOPT_IOCTLDATA, &counter);
-  )
+  easy_setopt(curl, CURLOPT_IOCTLFUNCTION, ioctlcallback);
+  easy_setopt(curl, CURLOPT_IOCTLDATA, &counter);
+
   easy_setopt(curl, CURLOPT_READFUNCTION, readcallback);
   easy_setopt(curl, CURLOPT_READDATA, &counter);
   /* We CANNOT do the POST fine without setting the size (or choose

--- a/tests/libtest/lib566.c
+++ b/tests/libtest/lib566.c
@@ -51,10 +51,9 @@ CURLcode test(char *URL)
 
   if(!res) {
     FILE *moo;
-    CURL_IGNORE_DEPRECATION(
-      res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD,
-                              &content_length);
-    )
+    res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD,
+                            &content_length);
+
     moo = fopen(libtest_arg2, "wb");
     if(moo) {
       curl_mfprintf(moo, "CL %.0f\n", content_length);

--- a/tests/libtest/lib578.c
+++ b/tests/libtest/lib578.c
@@ -78,10 +78,8 @@ CURLcode test(char *URL)
   test_setopt(curl, CURLOPT_POSTFIELDS, testdata);
 
   /* we want to use our own progress function */
-  CURL_IGNORE_DEPRECATION(
-    test_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-    test_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
-  )
+  test_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+  test_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
 
   /* get verbose debug output please */
   test_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib579.c
+++ b/tests/libtest/lib579.c
@@ -155,9 +155,7 @@ CURLcode test(char *URL)
 
   /* we want to use our own progress function */
   test_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-  CURL_IGNORE_DEPRECATION(
-    test_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
-  )
+  test_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
 
   /* Perform the request, res will get the return code */
   res = curl_easy_perform(curl);

--- a/tests/libtest/lib599.c
+++ b/tests/libtest/lib599.c
@@ -64,9 +64,7 @@ CURLcode test(char *URL)
 
   /* we want to use our own progress function */
   test_setopt(curl, CURLOPT_NOPROGRESS, 0L);
-  CURL_IGNORE_DEPRECATION(
-    test_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
-  )
+  test_setopt(curl, CURLOPT_PROGRESSFUNCTION, progress_callback);
 
   /* get verbose debug output please */
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
@@ -82,10 +80,8 @@ CURLcode test(char *URL)
 
   if(!res) {
     FILE *moo;
-    CURL_IGNORE_DEPRECATION(
-      res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD,
+    res = curl_easy_getinfo(curl, CURLINFO_CONTENT_LENGTH_DOWNLOAD,
                             &content_length);
-    )
     moo = fopen(libtest_arg2, "wb");
     if(moo) {
       curl_mfprintf(moo, "CL %.0f\n", content_length);

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -21,9 +21,11 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
+#define CURL_DISABLE_DEPRECATION 1
 #include "test.h"
 
 #include "memdebug.h"
+
 
 static char testdata[] =
   "this is what we post to the silly web server";
@@ -79,13 +81,11 @@ CURLcode test(char *URL)
     goto test_cleanup;
   }
   headers = headers2;
-  CURL_IGNORE_DEPRECATION(
-    formrc = curl_formadd(&formpost, &lastptr,
-                          CURLFORM_COPYNAME, &testname,
-                          CURLFORM_COPYCONTENTS, &testdata,
-                          CURLFORM_CONTENTHEADER, headers,
-                          CURLFORM_END);
-  )
+  formrc = curl_formadd(&formpost, &lastptr,
+                        CURLFORM_COPYNAME, &testname,
+                        CURLFORM_COPYCONTENTS, &testdata,
+                        CURLFORM_CONTENTHEADER, headers,
+                        CURLFORM_END);
   if(formrc) {
     curl_mprintf("curl_formadd(1) = %d\n", (int) formrc);
     goto test_cleanup;
@@ -93,22 +93,21 @@ CURLcode test(char *URL)
 
   contentlength = (long)(strlen(testdata) - 1);
 
-  CURL_IGNORE_DEPRECATION(
-    /* Use a form array for the non-copy test. */
-    formarray[0].option = CURLFORM_PTRCONTENTS;
-    formarray[0].value = testdata;
-    formarray[1].option = CURLFORM_CONTENTSLENGTH;
-    formarray[1].value = (char *)(size_t)contentlength;
-    formarray[2].option = CURLFORM_END;
-    formarray[2].value = NULL;
-    formrc = curl_formadd(&formpost,
-                          &lastptr,
-                          CURLFORM_PTRNAME, testname,
-                          CURLFORM_NAMELENGTH, strlen(testname) - 1,
-                          CURLFORM_ARRAY, formarray,
-                          CURLFORM_FILENAME, "remotefile.txt",
-                          CURLFORM_END);
-  )
+  /* Use a form array for the non-copy test. */
+  formarray[0].option = CURLFORM_PTRCONTENTS;
+  formarray[0].value = testdata;
+  formarray[1].option = CURLFORM_CONTENTSLENGTH;
+  formarray[1].value = (char *)(size_t)contentlength;
+  formarray[2].option = CURLFORM_END;
+  formarray[2].value = NULL;
+  formrc = curl_formadd(&formpost,
+                        &lastptr,
+                        CURLFORM_PTRNAME, testname,
+                        CURLFORM_NAMELENGTH, strlen(testname) - 1,
+                        CURLFORM_ARRAY, formarray,
+                        CURLFORM_FILENAME, "remotefile.txt",
+                        CURLFORM_END);
+
   if(formrc) {
     curl_mprintf("curl_formadd(2) = %d\n", (int) formrc);
     goto test_cleanup;
@@ -119,65 +118,59 @@ CURLcode test(char *URL)
      CURLOPT_PTRNAME actually copies the name thus we do not test this here. */
   testdata[0]++;
 
-  CURL_IGNORE_DEPRECATION(
-    /* Check multi-files and content type propagation. */
-    formrc = curl_formadd(&formpost,
-                          &lastptr,
-                          CURLFORM_COPYNAME, "multifile",
-                          CURLFORM_FILE, libtest_arg2,    /* Set in first.c. */
-                          CURLFORM_FILE, libtest_arg2,
-                          CURLFORM_CONTENTTYPE, "text/whatever",
-                          CURLFORM_FILE, libtest_arg2,
-                          CURLFORM_END);
-  )
+  /* Check multi-files and content type propagation. */
+  formrc = curl_formadd(&formpost,
+                        &lastptr,
+                        CURLFORM_COPYNAME, "multifile",
+                        CURLFORM_FILE, libtest_arg2,    /* Set in first.c. */
+                        CURLFORM_FILE, libtest_arg2,
+                        CURLFORM_CONTENTTYPE, "text/whatever",
+                        CURLFORM_FILE, libtest_arg2,
+                        CURLFORM_END);
+
   if(formrc) {
     curl_mprintf("curl_formadd(3) = %d\n", (int) formrc);
     goto test_cleanup;
   }
 
-  CURL_IGNORE_DEPRECATION(
-    /* Check data from file content. */
-    formrc = curl_formadd(&formpost,
-                          &lastptr,
-                          CURLFORM_COPYNAME, "filecontents",
-                          CURLFORM_FILECONTENT, libtest_arg2,
-                          CURLFORM_END);
-  )
+  /* Check data from file content. */
+  formrc = curl_formadd(&formpost,
+                        &lastptr,
+                        CURLFORM_COPYNAME, "filecontents",
+                        CURLFORM_FILECONTENT, libtest_arg2,
+                        CURLFORM_END);
   if(formrc) {
     curl_mprintf("curl_formadd(4) = %d\n", (int) formrc);
     goto test_cleanup;
   }
 
-  CURL_IGNORE_DEPRECATION(
-    /* Measure the current form length.
-     * This is done before including stdin data because we want to reuse it
-     * and stdin cannot be rewound.
-     */
-    curl_formget(formpost, (void *) &formlength, count_chars);
-  )
+  /* Measure the current form length.
+   * This is done before including stdin data because we want to reuse it
+   * and stdin cannot be rewound.
+   */
+  curl_formget(formpost, (void *) &formlength, count_chars);
 
   /* Include length in data for external check. */
   curl_msnprintf(flbuf, sizeof(flbuf), "%lu", (unsigned long) formlength);
-  CURL_IGNORE_DEPRECATION(
-    formrc = curl_formadd(&formpost,
-                          &lastptr,
-                          CURLFORM_COPYNAME, "formlength",
-                          CURLFORM_COPYCONTENTS, &flbuf,
-                          CURLFORM_END);
-  )
+
+  formrc = curl_formadd(&formpost,
+                        &lastptr,
+                        CURLFORM_COPYNAME, "formlength",
+                        CURLFORM_COPYCONTENTS, &flbuf,
+                        CURLFORM_END);
+
   if(formrc) {
     curl_mprintf("curl_formadd(5) = %d\n", (int) formrc);
     goto test_cleanup;
   }
 
-  CURL_IGNORE_DEPRECATION(
-    /* Check stdin (may be problematic on some platforms). */
-    formrc = curl_formadd(&formpost,
-                          &lastptr,
-                          CURLFORM_COPYNAME, "standardinput",
-                          CURLFORM_FILE, "-",
-                          CURLFORM_END);
-  )
+  /* Check stdin (may be problematic on some platforms). */
+  formrc = curl_formadd(&formpost,
+                        &lastptr,
+                        CURLFORM_COPYNAME, "standardinput",
+                        CURLFORM_FILE, "-",
+                        CURLFORM_END);
+
   if(formrc) {
     curl_mprintf("curl_formadd(6) = %d\n", (int) formrc);
     goto test_cleanup;
@@ -192,10 +185,8 @@ CURLcode test(char *URL)
   /* First set the URL that is about to receive our POST. */
   test_setopt(curl, CURLOPT_URL, URL);
 
-  CURL_IGNORE_DEPRECATION(
-    /* send a multi-part formpost */
-    test_setopt(curl, CURLOPT_HTTPPOST, formpost);
-  )
+  /* send a multi-part formpost */
+  test_setopt(curl, CURLOPT_HTTPPOST, formpost);
 
   /* get verbose debug output please */
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
@@ -214,10 +205,8 @@ test_cleanup:
   /* always cleanup */
   curl_easy_cleanup(curl);
 
-  CURL_IGNORE_DEPRECATION(
-    /* now cleanup the formpost chain */
-    curl_formfree(formpost);
-  )
+  /* now cleanup the formpost chain */
+  curl_formfree(formpost);
   curl_slist_free_all(headers);
 
   curl_global_cleanup();

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -21,7 +21,6 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#define CURL_DISABLE_DEPRECATION 1
 #include "test.h"
 
 #include "memdebug.h"

--- a/tests/libtest/lib651.c
+++ b/tests/libtest/lib651.c
@@ -49,13 +49,11 @@ CURLcode test(char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  CURL_IGNORE_DEPRECATION(
-    /* Check proper name and data copying. */
-    formrc = curl_formadd(&formpost, &lastptr,
-                          CURLFORM_COPYNAME, "hello",
-                          CURLFORM_COPYCONTENTS, testbuf,
-                          CURLFORM_END);
-  )
+  /* Check proper name and data copying. */
+  formrc = curl_formadd(&formpost, &lastptr,
+                        CURLFORM_COPYNAME, "hello",
+                        CURLFORM_COPYCONTENTS, testbuf,
+                        CURLFORM_END);
   if(formrc)
     curl_mprintf("curl_formadd(1) = %d\n", (int) formrc);
 
@@ -63,9 +61,7 @@ CURLcode test(char *URL)
   curl = curl_easy_init();
   if(!curl) {
     curl_mfprintf(stderr, "curl_easy_init() failed\n");
-    CURL_IGNORE_DEPRECATION(
-      curl_formfree(formpost);
-    )
+    curl_formfree(formpost);
     curl_global_cleanup();
     return TEST_ERR_MAJOR_BAD;
   }
@@ -73,10 +69,8 @@ CURLcode test(char *URL)
   /* First set the URL that is about to receive our POST. */
   test_setopt(curl, CURLOPT_URL, URL);
 
-  CURL_IGNORE_DEPRECATION(
-    /* send a multi-part formpost */
-    test_setopt(curl, CURLOPT_HTTPPOST, formpost);
-  )
+  /* send a multi-part formpost */
+  test_setopt(curl, CURLOPT_HTTPPOST, formpost);
 
   /* get verbose debug output please */
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
@@ -92,10 +86,8 @@ test_cleanup:
   /* always cleanup */
   curl_easy_cleanup(curl);
 
-  CURL_IGNORE_DEPRECATION(
-    /* now cleanup the formpost chain */
-    curl_formfree(formpost);
-  )
+  /* now cleanup the formpost chain */
+  curl_formfree(formpost);
 
   curl_global_cleanup();
 

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -154,14 +154,12 @@ CURLcode test(char *URL)
   if(res == CURLE_OK)
     test_setopt(pooh.easy, CURLOPT_MIMEPOST, mime);
 #else
-  CURL_IGNORE_DEPRECATION(
-    /* Build the form. */
-    formrc = curl_formadd(&formpost, &lastptr,
-                          CURLFORM_COPYNAME, testname,
-                          CURLFORM_STREAM, &pooh,
-                          CURLFORM_CONTENTLEN, (curl_off_t) 2,
-                          CURLFORM_END);
-  )
+  /* Build the form. */
+  formrc = curl_formadd(&formpost, &lastptr,
+                        CURLFORM_COPYNAME, testname,
+                        CURLFORM_STREAM, &pooh,
+                        CURLFORM_CONTENTLEN, (curl_off_t) 2,
+                        CURLFORM_END);
   if(formrc) {
     curl_mfprintf(stderr, "curl_formadd() = %d\n", (int) formrc);
     goto test_cleanup;
@@ -170,10 +168,8 @@ CURLcode test(char *URL)
   /* We want to use our own read function. */
   test_setopt(pooh.easy, CURLOPT_READFUNCTION, read_callback);
 
-  CURL_IGNORE_DEPRECATION(
-    /* Send a multi-part formpost. */
-    test_setopt(pooh.easy, CURLOPT_HTTPPOST, formpost);
-  )
+  /* Send a multi-part formpost. */
+  test_setopt(pooh.easy, CURLOPT_HTTPPOST, formpost);
 #endif
 
 #if defined(LIB670) || defined(LIB672)
@@ -252,9 +248,7 @@ test_cleanup:
 #if defined(LIB670) || defined(LIB671)
   curl_mime_free(mime);
 #else
-  CURL_IGNORE_DEPRECATION(
-    curl_formfree(formpost);
-  )
+  curl_formfree(formpost);
 #endif
 
   curl_global_cleanup();

--- a/tests/libtest/libntlmconnect.c
+++ b/tests/libtest/libntlmconnect.c
@@ -50,9 +50,8 @@ static size_t callback(char *ptr, size_t size, size_t nmemb, void *data)
   ntlm_counter[idx] += (int)(size * nmemb);
 
   /* Get socket being used for this easy handle, otherwise CURL_SOCKET_BAD */
-  CURL_IGNORE_DEPRECATION(
-    code = curl_easy_getinfo(ntlm_easy[idx], CURLINFO_LASTSOCKET, &longdata);
-  )
+  code = curl_easy_getinfo(ntlm_easy[idx], CURLINFO_LASTSOCKET, &longdata);
+
   if(CURLE_OK != code) {
     curl_mfprintf(stderr, "%s:%d curl_easy_getinfo() failed, "
             "with code %d (%s)\n",

--- a/tests/libtest/mk-lib1521.pl
+++ b/tests/libtest/mk-lib1521.pl
@@ -361,7 +361,6 @@ CURLcode test(char *URL)
     goto test_cleanup;
   }
 
-  CURL_IGNORE_DEPRECATION(
 HEADER
     ;
 
@@ -597,7 +596,7 @@ MOO
 
 
 print $fh <<FOOTER
-  )
+
   /* NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange) */
   curl_easy_setopt(curl, (CURLoption)1, 0L);
   res = CURLE_OK;

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -30,6 +30,7 @@
    knowledge about the system we're building this on */
 
 #define CURL_NO_OLDIES
+#define CURL_DISABLE_DEPRECATION 1
 
 #include "curl_setup.h"
 


### PR DESCRIPTION
Instead of using the kludgey ignore macros inline. They make setting break-points in a debugger and single-stepping code impossible.