### PR TITLE
GHA/linux: try restoring native arm job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -163,6 +163,12 @@ jobs:
             install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
+          - name: openssl arm
+            install_packages: zlib1g-dev
+            install_steps: pytest
+            configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
+            image: 'ubuntu-24.04-arm'
+
           - name: openssl -O3 libssh valgrind
             install_packages: zlib1g-dev libssh-dev valgrind
             configure: CFLAGS=-O3 --with-openssl --enable-debug --with-libssh


### PR DESCRIPTION
Previously deleted due to flakiness in package install step for stunnel.

Follow-up to 0005f91259a7c5088ce98e15dbba8e0e70a97e0c #16303