### PR TITLE
pytest tls: extend coverage

### DIFF
--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -179,15 +179,13 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
 #elif defined(USE_WOLFSSL)
   (void)data;
   if(conn_config->verifyhost) {
-    if(peer->sni) {
-      WOLFSSL_X509* cert = wolfSSL_get_peer_certificate(ctx->wssl.ssl);
-      if(wolfSSL_X509_check_host(cert, peer->sni, strlen(peer->sni), 0, NULL)
-            == WOLFSSL_FAILURE) {
-        result = CURLE_PEER_FAILED_VERIFICATION;
-      }
-      wolfSSL_X509_free(cert);
+    char *snihost = peer->sni ? peer->sni : peer->hostname;
+    WOLFSSL_X509* cert = wolfSSL_get_peer_certificate(ctx->wssl.ssl);
+    if(wolfSSL_X509_check_host(cert, snihost, strlen(snihost), 0, NULL)
+          == WOLFSSL_FAILURE) {
+      result = CURLE_PEER_FAILED_VERIFICATION;
     }
-
+    wolfSSL_X509_free(cert);
   }
 #endif
   /* on error, remove any session we might have in the pool */

--- a/tests/http/test_12_reuse.py
+++ b/tests/http/test_12_reuse.py
@@ -41,7 +41,7 @@ class TestReuse:
     # check if HTTP/1.1 handles 'Connection: close' correctly
     @pytest.mark.parametrize("proto", ['http/1.1'])
     def test_12_01_h1_conn_close(self, env: Env, httpd, configures_httpd, nghttpx, proto):
-        httpd.clear_extra_configs()
+        httpd.reset_config()
         httpd.set_extra_config('base', [
             'MaxKeepAliveRequests 1',
         ])
@@ -60,7 +60,7 @@ class TestReuse:
                         reason="httpd 2.5+ handles KeepAlives different")
     @pytest.mark.parametrize("proto", ['http/1.1'])
     def test_12_02_h1_conn_timeout(self, env: Env, httpd, configures_httpd, nghttpx, proto):
-        httpd.clear_extra_configs()
+        httpd.reset_config()
         httpd.set_extra_config('base', [
             'KeepAliveTimeout 1',
         ])

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -144,6 +144,7 @@ class EnvConfig:
         self.expired_domain = f"expired.{self.tld}"
         self.cert_specs = [
             CertificateSpec(domains=[self.domain1, self.domain1brotli, 'localhost', '127.0.0.1'], key_type='rsa2048'),
+            CertificateSpec(name='domain1-no-ip', domains=[self.domain1, self.domain1brotli], key_type='rsa2048'),
             CertificateSpec(domains=[self.domain2], key_type='rsa2048'),
             CertificateSpec(domains=[self.ftp_domain], key_type='rsa2048'),
             CertificateSpec(domains=[self.proxy_domain, '127.0.0.1'], key_type='rsa2048'),


### PR DESCRIPTION
Add possibility to reload QUIC test server with another certificate. Add tests for more coverage of handshakes.