### PR TITLE
cmake: enable `CMAKE_LINK_WARNING_AS_ERROR` with `CURL_WERROR=1`

### DIFF
--- a/CMake/PickyWarnings.cmake
+++ b/CMake/PickyWarnings.cmake
@@ -27,6 +27,9 @@ set(_picky "")
 set(_picky_nocheck "")  # not to pass to feature checks
 
 if(CURL_WERROR)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 4.0)
+    set(CMAKE_LINK_WARNING_AS_ERROR ON)
+  endif()
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.24)
     set(CMAKE_COMPILE_WARNING_AS_ERROR ON)
   else()


### PR DESCRIPTION
Requires CMake 4.0 or upper.

Ref: https://cmake.org/cmake/help/v4.0/variable/CMAKE_LINK_WARNING_AS_ERROR.html

---

Notes:
- this make cmake work a little a differently than autotools, which does not do this.
- may require setting `LDFLAGS=-w` on macOS to silence: 'object file was built for newer macOS version than being linked'
