### PR TITLE
bufq: change read/write signatures

### DIFF
--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -103,27 +103,26 @@ static size_t chunk_unwrite(struct buf_chunk *chunk, size_t len)
   }
 }
 
-static ssize_t chunk_slurpn(struct buf_chunk *chunk, size_t max_len,
-                            Curl_bufq_reader *reader,
-                            void *reader_ctx, CURLcode *err)
+static CURLcode chunk_slurpn(struct buf_chunk *chunk, size_t max_len,
+                             Curl_bufq_reader *reader,
+                             void *reader_ctx, size_t *pnread)
 {
   unsigned char *p = &chunk->x.data[chunk->w_offset];
   size_t n = chunk->dlen - chunk->w_offset; /* free amount */
-  ssize_t nread;
+  CURLcode result;
 
+  *pnread = 0;
   DEBUGASSERT(chunk->dlen >= chunk->w_offset);
-  if(!n) {
-    *err = CURLE_AGAIN;
-    return -1;
-  }
+  if(!n)
+    return CURLE_AGAIN;
   if(max_len && n > max_len)
     n = max_len;
-  nread = reader(reader_ctx, p, n, err);
-  if(nread > 0) {
-    DEBUGASSERT((size_t)nread <= n);
-    chunk->w_offset += nread;
+  result = reader(reader_ctx, p, n, pnread);
+  if(!result) {
+    DEBUGASSERT(*pnread <= n);
+    chunk->w_offset += *pnread;
   }
-  return nread;
+  return result;
 }
 
 static void chunk_peek(const struct buf_chunk *chunk,
@@ -421,48 +420,38 @@ static struct buf_chunk *get_non_full_tail(struct bufq *q)
   return chunk;
 }
 
-ssize_t Curl_bufq_write(struct bufq *q,
-                        const unsigned char *buf, size_t len,
-                        CURLcode *err)
+CURLcode Curl_bufq_write(struct bufq *q,
+                         const unsigned char *buf, size_t len,
+                         size_t *pnwritten)
 {
   struct buf_chunk *tail;
-  ssize_t nwritten = 0;
   size_t n;
 
   DEBUGASSERT(q->max_chunks > 0);
+  *pnwritten = 0;
   while(len) {
     tail = get_non_full_tail(q);
     if(!tail) {
-      if((q->chunk_count < q->max_chunks) || (q->opts & BUFQ_OPT_SOFT_LIMIT)) {
-        *err = CURLE_OUT_OF_MEMORY;
-        return -1;
-      }
+      if((q->chunk_count < q->max_chunks) || (q->opts & BUFQ_OPT_SOFT_LIMIT))
+        /* should have gotten a tail, but did not */
+        return CURLE_OUT_OF_MEMORY;
       break;
     }
     n = chunk_append(tail, buf, len);
     if(!n)
       break;
-    nwritten += n;
+    *pnwritten += n;
     buf += n;
     len -= n;
   }
-  if(nwritten == 0 && len) {
-    *err = CURLE_AGAIN;
-    return -1;
-  }
-  *err = CURLE_OK;
-  return nwritten;
+  return (!*pnwritten && len) ? CURLE_AGAIN : CURLE_OK;
 }
 
 CURLcode Curl_bufq_cwrite(struct bufq *q,
                           const char *buf, size_t len,
                           size_t *pnwritten)
 {
-  ssize_t n;
-  CURLcode result;
-  n = Curl_bufq_write(q, (const unsigned char *)buf, len, &result);
-  *pnwritten = (n < 0) ? 0 : (size_t)n;
-  return result;
+  return Curl_bufq_write(q, (const unsigned char *)buf, len, pnwritten);
 }
 
 CURLcode Curl_bufq_unwrite(struct bufq *q, size_t len)
@@ -474,37 +463,26 @@ CURLcode Curl_bufq_unwrite(struct bufq *q, size_t len)
   return len ? CURLE_AGAIN : CURLE_OK;
 }
 
-ssize_t Curl_bufq_read(struct bufq *q, unsigned char *buf, size_t len,
-                       CURLcode *err)
+CURLcode Curl_bufq_read(struct bufq *q, unsigned char *buf, size_t len,
+                        size_t *pnread)
 {
-  ssize_t nread = 0;
-  size_t n;
-
-  *err = CURLE_OK;
+  *pnread = 0;
   while(len && q->head) {
-    n = chunk_read(q->head, buf, len);
+    size_t n = chunk_read(q->head, buf, len);
     if(n) {
-      nread += n;
+      *pnread += n;
       buf += n;
       len -= n;
     }
     prune_head(q);
   }
-  if(nread == 0) {
-    *err = CURLE_AGAIN;
-    return -1;
-  }
-  return nread;
+  return (!*pnread) ? CURLE_AGAIN : CURLE_OK;
 }
 
 CURLcode Curl_bufq_cread(struct bufq *q, char *buf, size_t len,
                          size_t *pnread)
 {
-  ssize_t n;
-  CURLcode result;
-  n = Curl_bufq_read(q, (unsigned char *)buf, len, &result);
-  *pnread = (n < 0) ? 0 : (size_t)n;
-  return result;
+  return Curl_bufq_read(q, (unsigned char *)buf, len, pnread);
 }
 
 bool Curl_bufq_peek(struct bufq *q,
@@ -556,156 +534,137 @@ void Curl_bufq_skip(struct bufq *q, size_t amount)
   }
 }
 
-ssize_t Curl_bufq_pass(struct bufq *q, Curl_bufq_writer *writer,
-                       void *writer_ctx, CURLcode *err)
+CURLcode Curl_bufq_pass(struct bufq *q, Curl_bufq_writer *writer,
+                        void *writer_ctx, size_t *pwritten)
 {
   const unsigned char *buf;
   size_t blen;
-  ssize_t nwritten = 0;
+  CURLcode result = CURLE_OK;
 
+  *pwritten = 0;
   while(Curl_bufq_peek(q, &buf, &blen)) {
-    ssize_t chunk_written;
+    size_t chunk_written;
 
-    chunk_written = writer(writer_ctx, buf, blen, err);
-    if(chunk_written < 0) {
-      if(!nwritten || *err != CURLE_AGAIN) {
-        /* blocked on first write or real error, fail */
-        nwritten = -1;
+    result = writer(writer_ctx, buf, blen, &chunk_written);
+    if(result) {
+      if((result == CURLE_AGAIN) && *pwritten) {
+        /* blocked on subsequent write, report success */
+        result = CURLE_OK;
       }
       break;
     }
     if(!chunk_written) {
-      if(!nwritten) {
+      if(!*pwritten) {
         /* treat as blocked */
-        *err = CURLE_AGAIN;
-        nwritten = -1;
+        result = CURLE_AGAIN;
       }
       break;
     }
     Curl_bufq_skip(q, (size_t)chunk_written);
-    nwritten += chunk_written;
+    *pwritten += chunk_written;
   }
-  return nwritten;
+  return result;
 }
 
-ssize_t Curl_bufq_write_pass(struct bufq *q,
-                             const unsigned char *buf, size_t len,
-                             Curl_bufq_writer *writer, void *writer_ctx,
-                             CURLcode *err)
+CURLcode Curl_bufq_write_pass(struct bufq *q,
+                              const unsigned char *buf, size_t len,
+                              Curl_bufq_writer *writer, void *writer_ctx,
+                              size_t *pwritten)
 {
-  ssize_t nwritten = 0, n;
+  CURLcode result = CURLE_OK;
 
-  *err = CURLE_OK;
+  *pwritten = 0;
   while(len) {
-    if(Curl_bufq_is_full(q)) {
-      /* try to make room in case we are full */
-      n = Curl_bufq_pass(q, writer, writer_ctx, err);
-      if(n < 0) {
-        if(*err != CURLE_AGAIN) {
-          /* real error, fail */
-          return -1;
-        }
-        /* would block, bufq is full, give up */
-        break;
-      }
-    }
-
-    /* Add whatever is remaining now to bufq */
-    n = Curl_bufq_write(q, buf, len, err);
-    if(n < 0) {
-      if(*err != CURLE_AGAIN) {
+    size_t n;
+    size_t npassed;
+    /* Add to bufq as much as there is room for */
+    result = Curl_bufq_write(q, buf, len, &n);
+    if(result) {
+      if(result != CURLE_AGAIN)
         /* real error, fail */
-        return -1;
-      }
-      /* no room in bufq */
-      break;
+        return result;
+      if((result == CURLE_AGAIN) && *pwritten)
+        /* we did write successfully before */
+        result = CURLE_OK;
+      return result;
     }
-    /* edge case of writer returning 0 (and len is >0)
-     * break or we might enter an infinite loop here */
-    if(n == 0)
+    else if(n == 0)
+      /* edge case of writer returning 0 (and len is >0)
+       * break or we might enter an infinite loop here */
       break;
 
-    /* Maybe only part of `data` has been added, continue to loop */
-    buf += (size_t)n;
-    len -= (size_t)n;
-    nwritten += (size_t)n;
+    /* Track what we added to bufq */
+    buf += n;
+    len -= n;
+    *pwritten += n;
+
+    /* Pass bufq on to the writer */
+    result = Curl_bufq_pass(q, writer, writer_ctx, &npassed);
+    if(result) {
+      if((result == CURLE_AGAIN) && *pwritten) {
+        /* we did add to bufq but could not pass, still success */
+        result = CURLE_OK;
+      }
+      return result;
+    }
   }
 
-  if(!nwritten && len) {
-    *err = CURLE_AGAIN;
-    return -1;
-  }
-  *err = CURLE_OK;
-  return nwritten;
+  return (!*pwritten && len) ? CURLE_AGAIN : CURLE_OK;
 }
 
-ssize_t Curl_bufq_sipn(struct bufq *q, size_t max_len,
-                       Curl_bufq_reader *reader, void *reader_ctx,
-                       CURLcode *err)
+CURLcode Curl_bufq_sipn(struct bufq *q, size_t max_len,
+                        Curl_bufq_reader *reader, void *reader_ctx,
+                        size_t *pnread)
 {
   struct buf_chunk *tail = NULL;
-  ssize_t nread;
 
-  *err = CURLE_AGAIN;
+  *pnread = 0;
   tail = get_non_full_tail(q);
   if(!tail) {
-    if(q->chunk_count < q->max_chunks) {
-      *err = CURLE_OUT_OF_MEMORY;
-      return -1;
-    }
+    if(q->chunk_count < q->max_chunks)
+      return CURLE_OUT_OF_MEMORY;
     /* full, blocked */
-    *err = CURLE_AGAIN;
-    return -1;
+    return CURLE_AGAIN;
   }
 
-  nread = chunk_slurpn(tail, max_len, reader, reader_ctx, err);
-  if(nread < 0) {
-    return -1;
-  }
-  else if(nread == 0) {
-    /* eof */
-    *err = CURLE_OK;
-  }
-  return nread;
+  return chunk_slurpn(tail, max_len, reader, reader_ctx, pnread);
 }
 
 /**
  * Read up to `max_len` bytes and append it to the end of the buffer queue.
  * if `max_len` is 0, no limit is imposed and the call behaves exactly
  * the same as `Curl_bufq_slurp()`.
- * Returns the total amount of buf read (may be 0) or -1 on other
- * reader errors.
- * Note that even in case of a -1 chunks may have been read and
+ * Returns the total amount of buf read (may be 0) in `pnread` or error
+ * Note that even in case of an error chunks may have been read and
  * the buffer queue will have different length than before.
  */
-static ssize_t bufq_slurpn(struct bufq *q, size_t max_len,
-                           Curl_bufq_reader *reader, void *reader_ctx,
-                           CURLcode *err)
+static CURLcode bufq_slurpn(struct bufq *q, size_t max_len,
+                            Curl_bufq_reader *reader, void *reader_ctx,
+                            size_t *pnread)
 {
-  ssize_t nread = 0, n;
+  CURLcode result;
 
-  *err = CURLE_AGAIN;
+  *pnread = 0;
   while(1) {
-
-    n = Curl_bufq_sipn(q, max_len, reader, reader_ctx, err);
-    if(n < 0) {
-      if(!nread || *err != CURLE_AGAIN) {
+    size_t n;
+    result = Curl_bufq_sipn(q, max_len, reader, reader_ctx, &n);
+    if(result) {
+      if(!*pnread || result != CURLE_AGAIN) {
         /* blocked on first read or real error, fail */
-        nread = -1;
+        return result;
       }
-      else
-        *err = CURLE_OK;
+      result = CURLE_OK;
       break;
     }
     else if(n == 0) {
       /* eof */
-      *err = CURLE_OK;
+      result = CURLE_OK;
       break;
     }
-    nread += (size_t)n;
+    *pnread += n;
     if(max_len) {
-      DEBUGASSERT((size_t)n <= max_len);
-      max_len -= (size_t)n;
+      DEBUGASSERT(n <= max_len);
+      max_len -= n;
       if(!max_len)
         break;
     }
@@ -713,11 +672,11 @@ static ssize_t bufq_slurpn(struct bufq *q, size_t max_len,
     if(q->tail && !chunk_is_full(q->tail))
       break;
   }
-  return nread;
+  return result;
 }
 
-ssize_t Curl_bufq_slurp(struct bufq *q, Curl_bufq_reader *reader,
-                        void *reader_ctx, CURLcode *err)
+CURLcode Curl_bufq_slurp(struct bufq *q, Curl_bufq_reader *reader,
+                         void *reader_ctx, size_t *pnread)
 {
-  return bufq_slurpn(q, 0, reader, reader_ctx, err);
+  return bufq_slurpn(q, 0, reader, reader_ctx, pnread);
 }

--- a/lib/bufq.h
+++ b/lib/bufq.h
@@ -163,12 +163,11 @@ bool Curl_bufq_is_full(const struct bufq *q);
 /**
  * Write buf to the end of the buffer queue. The buf is copied
  * and the amount of copied bytes is returned.
- * A return code of -1 indicates an error, setting `err` to the
- * cause. An err of CURLE_AGAIN is returned if the buffer queue is full.
+ * CURLE_AGAIN is returned if the buffer queue is full.
  */
-ssize_t Curl_bufq_write(struct bufq *q,
-                        const unsigned char *buf, size_t len,
-                        CURLcode *err);
+CURLcode Curl_bufq_write(struct bufq *q,
+                         const unsigned char *buf, size_t len,
+                         size_t *pnwritten);
 
 CURLcode Curl_bufq_cwrite(struct bufq *q,
                          const char *buf, size_t len,
@@ -183,11 +182,9 @@ CURLcode Curl_bufq_unwrite(struct bufq *q, size_t len);
 /**
  * Read buf from the start of the buffer queue. The buf is copied
  * and the amount of copied bytes is returned.
- * A return code of -1 indicates an error, setting `err` to the
- * cause. An err of CURLE_AGAIN is returned if the buffer queue is empty.
  */
-ssize_t Curl_bufq_read(struct bufq *q, unsigned char *buf, size_t len,
-                        CURLcode *err);
+CURLcode Curl_bufq_read(struct bufq *q, unsigned char *buf, size_t len,
+                        size_t *pnread);
 
 CURLcode Curl_bufq_cread(struct bufq *q, char *buf, size_t len,
                          size_t *pnread);
@@ -214,9 +211,9 @@ bool Curl_bufq_peek_at(struct bufq *q, size_t offset,
  */
 void Curl_bufq_skip(struct bufq *q, size_t amount);
 
-typedef ssize_t Curl_bufq_writer(void *writer_ctx,
+typedef CURLcode Curl_bufq_writer(void *writer_ctx,
                                  const unsigned char *buf, size_t len,
-                                 CURLcode *err);
+                                 size_t *pwritten);
 /**
  * Passes the chunks in the buffer queue to the writer and returns
  * the amount of buf written. A writer may return -1 and CURLE_AGAIN
@@ -226,24 +223,23 @@ typedef ssize_t Curl_bufq_writer(void *writer_ctx,
  * Note that in case of a -1 chunks may have been written and
  * the buffer queue will have different length than before.
  */
-ssize_t Curl_bufq_pass(struct bufq *q, Curl_bufq_writer *writer,
-                       void *writer_ctx, CURLcode *err);
+CURLcode Curl_bufq_pass(struct bufq *q, Curl_bufq_writer *writer,
+                        void *writer_ctx, size_t *pwritten);
 
-typedef ssize_t Curl_bufq_reader(void *reader_ctx,
-                                 unsigned char *buf, size_t len,
-                                 CURLcode *err);
+typedef CURLcode Curl_bufq_reader(void *reader_ctx,
+                                  unsigned char *buf, size_t len,
+                                  size_t *pnread);
 
 /**
  * Read date and append it to the end of the buffer queue until the
  * reader returns blocking or the queue is full. A reader returns
- * -1 and CURLE_AGAIN to indicate blocking.
- * Returns the total amount of buf read (may be 0) or -1 on other
- * reader errors.
- * Note that in case of a -1 chunks may have been read and
+ * CURLE_AGAIN to indicate blocking.
+ * Returns the total amount of buf read (may be 0) in `pnread` on success.
+ * Note that in case of an error chunks may have been read and
  * the buffer queue will have different length than before.
  */
-ssize_t Curl_bufq_slurp(struct bufq *q, Curl_bufq_reader *reader,
-                        void *reader_ctx, CURLcode *err);
+CURLcode Curl_bufq_slurp(struct bufq *q, Curl_bufq_reader *reader,
+                         void *reader_ctx, size_t *pnread);
 
 /**
  * Read *once* up to `max_len` bytes and append it to the buffer.
@@ -251,9 +247,9 @@ ssize_t Curl_bufq_slurp(struct bufq *q, Curl_bufq_reader *reader,
  * Returns the total amount of buf read (may be 0) or -1 on other
  * reader errors.
  */
-ssize_t Curl_bufq_sipn(struct bufq *q, size_t max_len,
-                       Curl_bufq_reader *reader, void *reader_ctx,
-                       CURLcode *err);
+CURLcode Curl_bufq_sipn(struct bufq *q, size_t max_len,
+                        Curl_bufq_reader *reader, void *reader_ctx,
+                        size_t *pnread);
 
 /**
  * Write buf to the end of the buffer queue.
@@ -262,9 +258,9 @@ ssize_t Curl_bufq_sipn(struct bufq *q, size_t max_len,
  * on or is placed into the buffer, depending on `len` and current
  * amount buffered, chunk size, etc.
  */
-ssize_t Curl_bufq_write_pass(struct bufq *q,
-                             const unsigned char *buf, size_t len,
-                             Curl_bufq_writer *writer, void *writer_ctx,
-                             CURLcode *err);
+CURLcode Curl_bufq_write_pass(struct bufq *q,
+                              const unsigned char *buf, size_t len,
+                              Curl_bufq_writer *writer, void *writer_ctx,
+                              size_t *pwritten);
 
 #endif /* HEADER_CURL_BUFQ_H */

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -1990,15 +1990,13 @@ static CURLcode cr_mime_read(struct Curl_easy *data,
   }
 
   if(!Curl_bufq_is_empty(&ctx->tmpbuf)) {
-    CURLcode result = CURLE_OK;
-    ssize_t n = Curl_bufq_read(&ctx->tmpbuf, (unsigned char *)buf, blen,
-                               &result);
-    if(n < 0) {
+    CURLcode result;
+    result = Curl_bufq_read(&ctx->tmpbuf, (unsigned char *)buf, blen, &nread);
+    if(result) {
       ctx->errored = TRUE;
       ctx->error_result = result;
       return result;
     }
-    nread = (size_t)n;
   }
   else if(blen <= 4) {
     /* Curl_mime_read() may go into an infinite loop when reading
@@ -2008,22 +2006,21 @@ static CURLcode cr_mime_read(struct Curl_easy *data,
     CURL_TRC_READ(data, "cr_mime_read(len=%zu), small read, using tmp", blen);
     nread = Curl_mime_read(tmp, 1, sizeof(tmp), ctx->part);
     if(nread <= sizeof(tmp)) {
-      CURLcode result = CURLE_OK;
-      ssize_t n = Curl_bufq_write(&ctx->tmpbuf, (unsigned char *)tmp, nread,
-                                  &result);
-      if(n < 0) {
+      CURLcode result;
+      size_t n;
+      result = Curl_bufq_write(&ctx->tmpbuf, (unsigned char *)tmp, nread, &n);
+      if(result) {
         ctx->errored = TRUE;
         ctx->error_result = result;
         return result;
       }
       /* stored it, read again */
-      n = Curl_bufq_read(&ctx->tmpbuf, (unsigned char *)buf, blen, &result);
-      if(n < 0) {
+      result = Curl_bufq_cread(&ctx->tmpbuf, buf, blen, &nread);
+      if(result) {
         ctx->errored = TRUE;
         ctx->error_result = result;
         return result;
       }
-      nread = (size_t)n;
     }
   }
   else

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1372,7 +1372,7 @@ static CURLcode ssl_cf_set_earlydata(struct Curl_cfilter *cf,
                                      const void *buf, size_t blen)
 {
   struct ssl_connect_data *connssl = cf->ctx;
-  ssize_t nwritten = 0;
+  size_t nwritten = 0;
   CURLcode result = CURLE_OK;
 
   DEBUGASSERT(connssl->earlydata_state == ssl_earlydata_await);
@@ -1380,10 +1380,10 @@ static CURLcode ssl_cf_set_earlydata(struct Curl_cfilter *cf,
   if(blen) {
     if(blen > connssl->earlydata_max)
       blen = connssl->earlydata_max;
-    nwritten = Curl_bufq_write(&connssl->earlydata, buf, blen, &result);
+    result = Curl_bufq_write(&connssl->earlydata, buf, blen, &nwritten);
     CURL_TRC_CF(data, cf, "ssl_cf_set_earlydata(len=%zu) -> %zd",
                 blen, nwritten);
-    if(nwritten < 0)
+    if(result)
       return result;
   }
   return CURLE_OK;

--- a/tests/unit/unit2601.c
+++ b/tests/unit/unit2601.c
@@ -96,7 +96,8 @@ static void check_bufq(size_t pool_spares,
   struct bufc_pool pool;
   size_t max_len = chunk_size * max_chunks;
   CURLcode result;
-  ssize_t n, i;
+  ssize_t i;
+  size_t n2;
   size_t nwritten, nread;
 
   if(pool_spares > 0) {
@@ -114,18 +115,17 @@ static void check_bufq(size_t pool_spares,
   fail_unless(q.spare == NULL, "init: spare not NULL");
   fail_unless(Curl_bufq_len(&q) == 0, "init: bufq length != 0");
 
-  n = Curl_bufq_write(&q, test_data, wsize, &result);
-  fail_unless(n >= 0, "write: negative size returned");
-  fail_unless((size_t)n <= wsize, "write: wrong size returned");
+  result = Curl_bufq_write(&q, test_data, wsize, &n2);
+  fail_unless(n2 <= wsize, "write: wrong size returned");
   fail_unless(result == CURLE_OK, "write: wrong result returned");
 
   /* write empty bufq full */
   nwritten = 0;
   Curl_bufq_reset(&q);
   while(!Curl_bufq_is_full(&q)) {
-    n = Curl_bufq_write(&q, test_data, wsize, &result);
-    if(n >= 0) {
-      nwritten += (size_t)n;
+    result = Curl_bufq_write(&q, test_data, wsize, &n2);
+    if(!result) {
+      nwritten += n2;
     }
     else if(result != CURLE_AGAIN) {
       fail_unless(result == CURLE_AGAIN, "write-loop: unexpected result");
@@ -142,9 +142,9 @@ static void check_bufq(size_t pool_spares,
   /* read full bufq empty */
   nread = 0;
   while(!Curl_bufq_is_empty(&q)) {
-    n = Curl_bufq_read(&q, test_data, rsize, &result);
-    if(n >= 0) {
-      nread += (size_t)n;
+    result = Curl_bufq_read(&q, test_data, rsize, &n2);
+    if(!result) {
+      nread += n2;
     }
     else if(result != CURLE_AGAIN) {
       fail_unless(result == CURLE_AGAIN, "read-loop: unexpected result");
@@ -163,13 +163,13 @@ static void check_bufq(size_t pool_spares,
   }
 
   for(i = 0; i < 1000; ++i) {
-    n = Curl_bufq_write(&q, test_data, wsize, &result);
-    if(n < 0 && result != CURLE_AGAIN) {
+    result = Curl_bufq_write(&q, test_data, wsize, &n2);
+    if(result && result != CURLE_AGAIN) {
       fail_unless(result == CURLE_AGAIN, "rw-loop: unexpected write result");
       break;
     }
-    n = Curl_bufq_read(&q, test_data, rsize, &result);
-    if(n < 0 && result != CURLE_AGAIN) {
+    result = Curl_bufq_read(&q, test_data, rsize, &n2);
+    if(result && result != CURLE_AGAIN) {
       fail_unless(result == CURLE_AGAIN, "rw-loop: unexpected read result");
       break;
     }
@@ -180,12 +180,12 @@ static void check_bufq(size_t pool_spares,
   Curl_bufq_init2(&q, chunk_size, max_chunks, (opts|BUFQ_OPT_SOFT_LIMIT));
   nwritten = 0;
   while(!Curl_bufq_is_full(&q)) {
-    n = Curl_bufq_write(&q, test_data, wsize, &result);
-    if(n < 0 || (size_t)n != wsize) {
-      fail_unless(n > 0 && (size_t)n == wsize, "write should be complete");
+    result = Curl_bufq_write(&q, test_data, wsize, &n2);
+    if(result || n2 != wsize) {
+      fail_unless(!result && n2 == wsize, "write should be complete");
       break;
     }
-    nwritten += (size_t)n;
+    nwritten += n2;
   }
   if(nwritten < max_len) {
     curl_mfprintf(stderr, "%zu bytes written, but max_len=%zu\n",
@@ -194,18 +194,18 @@ static void check_bufq(size_t pool_spares,
     fail_if(TRUE, "write: bufq full but nwritten wrong");
   }
   /* do one more write on a full bufq, should work */
-  n = Curl_bufq_write(&q, test_data, wsize, &result);
-  fail_unless(n > 0 && (size_t)n == wsize, "write should be complete");
-  nwritten += (size_t)n;
+  result = Curl_bufq_write(&q, test_data, wsize, &n2);
+  fail_unless(!result && n2 == wsize, "write should be complete");
+  nwritten += n2;
   /* see that we get all out again */
   nread = 0;
   while(!Curl_bufq_is_empty(&q)) {
-    n = Curl_bufq_read(&q, test_data, rsize, &result);
-    if(n <= 0) {
-      fail_unless(n > 0, "read-loop: unexpected fail");
+    result = Curl_bufq_read(&q, test_data, rsize, &n2);
+    if(result) {
+      fail_unless(result, "read-loop: unexpected fail");
       break;
     }
-    nread += (size_t)n;
+    nread += n2;
   }
   fail_unless(nread == nwritten, "did not get the same out as put in");
 
@@ -218,8 +218,8 @@ static void check_bufq(size_t pool_spares,
     size_t roffset;
     Curl_bufq_reset(&q);
     while(Curl_bufq_len(&q) < chunk_size) {
-      n = Curl_bufq_write(&q, buf, sizeof(buf), &result);
-      fail_unless(n > 0 && (size_t)n == sizeof(buf), "write incomplete");
+      result = Curl_bufq_write(&q, buf, sizeof(buf), &n2);
+      fail_unless(!result && n2 == sizeof(buf), "write incomplete");
       if(result)
         break;
     }
@@ -227,19 +227,19 @@ static void check_bufq(size_t pool_spares,
     roffset = 0;
     while(!Curl_bufq_is_empty(&q)) {
       unsigned char rbuf[sizeof(buf)];
-      n = Curl_bufq_read(&q, rbuf, sizeof(rbuf), &result);
-      fail_unless(n > 0, "read should work");
+      result = Curl_bufq_read(&q, rbuf, sizeof(rbuf), &n2);
+      fail_unless(!result, "read should work");
       if(result)
         break;
-      if(n != sizeof(rbuf)) {
+      if(n2 != sizeof(rbuf)) {
         fail_unless(Curl_bufq_is_empty(&q), "should be last read");
       }
-      if(memcmp(buf, rbuf, n)) {
+      if(memcmp(buf, rbuf, n2)) {
         curl_mfprintf(stderr, "at offset %zu expected '%.*s', got '%.*s'\n",
-                      roffset, (int)n, buf, (int)n, rbuf);
+                      roffset, (int)n2, buf, (int)n2, rbuf);
         fail("read buf content wrong");
       }
-      roffset += n;
+      roffset += n2;
     }
     Curl_bufq_reset(&q);
   }
@@ -252,13 +252,13 @@ static void check_bufq(size_t pool_spares,
 
 UNITTEST_START
   struct bufq q;
-  ssize_t n;
+  size_t n;
   CURLcode result;
   unsigned char buf[16*1024];
 
   Curl_bufq_init(&q, 8*1024, 12);
-  n = Curl_bufq_read(&q, buf, 128, &result);
-  fail_unless(n < 0 && result == CURLE_AGAIN, "read empty fail");
+  result = Curl_bufq_read(&q, buf, 128, &n);
+  fail_unless(result && result == CURLE_AGAIN, "read empty fail");
   Curl_bufq_free(&q);
 
   check_bufq(0, 1024, 4, 128, 128, BUFQ_OPT_NONE);


### PR DESCRIPTION
Change the `ssize_t Curl_bufq_*(..., CURLcode *err)` functions to use `CURLcode Curl_bufq_*(..., size_t *pn)` instead.

This allows us to write slightly less code and avoids the ssize_t/size_t conversions in many cases.