### PR TITLE
aws-sigv4 cleanups

### DIFF
--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -578,13 +578,6 @@ UNITTEST CURLcode canon_query(const char *query, struct dynbuf *dq)
   size_t num_query_components;
   size_t counted_query_components = 0;
   size_t index;
-  size_t in_key_len;
-  size_t in_value_len;
-  size_t query_part_len;
-  const char *in_key;
-  char *in_value;
-  char *offset;
-  const char *query_part;
 
   if(!query)
     return result;
@@ -599,9 +592,11 @@ UNITTEST CURLcode canon_query(const char *query, struct dynbuf *dq)
     * component */
 
   for(index = 0; index < num_query_components; index++) {
-
-    query_part_len = curlx_dyn_len(&query_array[index]);
-    query_part = curlx_dyn_ptr(&query_array[index]);
+    const char *in_key;
+    size_t in_key_len;
+    char *offset;
+    size_t query_part_len = curlx_dyn_len(&query_array[index]);
+    char *query_part = curlx_dyn_ptr(&query_array[index]);
 
     in_key = query_part;
 
@@ -627,7 +622,8 @@ UNITTEST CURLcode canon_query(const char *query, struct dynbuf *dq)
 
     /* Decode/encode the value if it exists */
     if(offset && offset != (query_part + query_part_len - 1)) {
-      in_value = offset + 1;
+      size_t in_value_len;
+      const char *in_value = offset + 1;
       in_value_len = query_part + query_part_len - (offset + 1);
       result = http_aws_decode_encode(in_value, in_value_len,
                                       &encoded_query_array[index].value);
@@ -667,9 +663,8 @@ UNITTEST CURLcode canon_query(const char *query, struct dynbuf *dq)
         result = curlx_dyn_addf(dq, "%s=", key_ptr);
       }
     }
-    if(result) {
-      goto fail;
-    }
+    if(result)
+      break;
   }
 
 fail:

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -72,7 +72,7 @@ struct pair {
 
 static void dyn_array_free(struct dynbuf *db, size_t num_elements);
 static void pair_array_free(struct pair *pair_array, size_t num_elements);
-static CURLcode split_to_dyn_array(const char *source, char split_by,
+static CURLcode split_to_dyn_array(const char *source,
                                    struct dynbuf db[MAX_QUERY_COMPONENTS],
                                    size_t *num_splits);
 static bool is_reserved_char(const char c);
@@ -582,7 +582,7 @@ UNITTEST CURLcode canon_query(const char *query, struct dynbuf *dq)
   if(!query)
     return result;
 
-  result = split_to_dyn_array(query, '&', &query_array[0],
+  result = split_to_dyn_array(query, &query_array[0],
                               &num_query_components);
   if(result) {
     goto fail;
@@ -1012,12 +1012,14 @@ static void dyn_array_free(struct dynbuf *db, size_t num_elements)
 }
 
 /*
-* Splits source string by split_by, and creates an array of dynbuf in db
-* db is initialized by this function
+* Splits source string by SPLIT_BY, and creates an array of dynbuf in db.
+* db is initialized by this function.
 * Caller is responsible for freeing the array elements with dyn_array_free
 */
 
-static CURLcode split_to_dyn_array(const char *source, char split_by,
+#define SPLIT_BY '&'
+
+static CURLcode split_to_dyn_array(const char *source,
                                    struct dynbuf db[MAX_QUERY_COMPONENTS],
                                    size_t *num_splits_out)
 {
@@ -1029,10 +1031,10 @@ static CURLcode split_to_dyn_array(const char *source, char split_by,
   size_t index = 0;
   size_t num_splits = 0;
 
-  /* Split source_ptr on split_by and store the segment offsets and
-   * length in array */
+  /* Split source_ptr on SPLIT_BY and store the segment offsets and length in
+   * array */
   for(pos = 0; pos < len; pos++) {
-    if(source[pos] == split_by) {
+    if(source[pos] == SPLIT_BY) {
       if(segment_length) {
         curlx_dyn_init(&db[index], segment_length + 1);
         result = curlx_dyn_addn(&db[index], &source[start],

--- a/tests/data/test1979
+++ b/tests/data/test1979
@@ -3,6 +3,7 @@
 <keywords>
 unittest
 canon_string
+aws-sigv4
 </keywords>
 </info>
 

--- a/tests/data/test1980
+++ b/tests/data/test1980
@@ -3,6 +3,7 @@
 <keywords>
 unittest
 canon_query
+aws-sigv4
 </keywords>
 </info>
 

--- a/tests/data/test472
+++ b/tests/data/test472
@@ -33,6 +33,7 @@ http
 </server>
 <features>
 Debug
+Unicode
 aws
 </features>
 <name>

--- a/tests/data/test472
+++ b/tests/data/test472
@@ -33,7 +33,6 @@ http
 </server>
 <features>
 Debug
-Unicode
 aws
 </features>
 <name>


### PR DESCRIPTION
- address Coverity nit
- fix indentation
- narrow some variable scopes
- fix keywords in tests

Follow-up to c19465ca556d2d05a058b4690c27eb228d05f2e6