### PR TITLE
windows: fix builds targeting WinXP, test it in CI

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -52,6 +52,7 @@ if [ "${BUILD_SYSTEM}" = 'CMake' ]; then
     [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
     [[ "${TARGET}" = *'ARM64'* ]] && SKIP_RUN='ARM64 architecture'
     [ -n "${TOOLSET:-}" ] && options+=" -T ${TOOLSET}"
+    [ -n "${WINTARGET:-}" ] && options+=" -DCURL_TARGET_WINDOWS_VERSION=${WINTARGET}"
     [ "${OPENSSL}" = 'ON' ] && options+=" -DOPENSSL_ROOT_DIR=${openssl_root_win}"
     [ -n "${CURLDEBUG:-}" ] && options+=" -DENABLE_CURLDEBUG=${CURLDEBUG}"
     if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2013' ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,6 +74,7 @@ environment:
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2015'
       PRJ_GEN: 'Visual Studio 10 2010'
       TARGET: '-A x64'
+      WINTARGET: 0x0501  # Windows XP
       PRJ_CFG: Debug
       SCHANNEL: 'ON'
       SHARED: 'ON'

--- a/docs/examples/block_ip.c
+++ b/docs/examples/block_ip.c
@@ -41,8 +41,9 @@ int main(void) { printf("Platform not supported.\n"); return 1; }
 #ifndef _CRT_NONSTDC_NO_DEPRECATE
 #define _CRT_NONSTDC_NO_DEPRECATE
 #endif
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0600
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x0600
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600  /* Requires Windows Vista */
 #endif
 #include <winsock2.h>
 #include <ws2tcpip.h>


### PR DESCRIPTION
- appveyor: make a job target Windows XP.

- examples/block_ip: force this specific example to target Vista to make
  it compile when building curl for Windows XP. Fixing:
  ```
  docs\examples\block_ip.c(157): warning C4013: 'inet_pton' undefined; assuming extern returning int
  docs\examples\block_ip.c(272): warning C4013: 'inet_ntop' undefined; assuming extern returning int
  ```
  Ref: https://ci.appveyor.com/project/curlorg/curl/builds/52102142/job/2ajdluhc20r4gmmw#L530

Cherry-picked from #17413
