### PR TITLE
sasl: give help when unable to select AUTH

### DIFF
--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -816,7 +816,7 @@ CURLcode Curl_sasl_is_blocked(struct SASL *sasl, struct Curl_easy *data)
   /* Failing SASL authentication is a pain. Give a helping hand if
    * we were unable to select an AUTH mechanism.
    * `sasl->authmechs` are mechanisms offered by the peer
-   * `sasl->prefmech`  are mechanisms perferred by us */
+   * `sasl->prefmech`  are mechanisms preferred by us */
   unsigned short enabledmechs = sasl->authmechs & sasl->prefmech;
 
   if(!sasl->authmechs)

--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -794,24 +794,24 @@ CURLcode Curl_sasl_is_blocked(struct SASL *sasl, struct Curl_easy *data)
 {
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
 #ifdef USE_KERBEROS5
-  static bool have_kerberos5 = TRUE;
+#define CURL_SASL_KERBEROS5   TRUE
 #else
-  static bool have_kerberos5 = FALSE;
+#define CURL_SASL_KERBEROS5   FALSE
 #endif
 #ifdef USE_GSASL
-  static bool have_gasl = TRUE;
+#define CURL_SASL_GASL        TRUE
 #else
-  static bool have_gasl = FALSE;
+#define CURL_SASL_GASL        FALSE
 #endif
 #ifdef CURL_DISABLE_DIGEST_AUTH
-  static bool have_digest = TRUE;
+#define CURL_SASL_DIGEST      TRUE
 #else
-  static bool have_digest = FALSE;
+#define CURL_SASL_DIGEST      FALSE
 #endif
 #ifndef USE_NTLM
-  static bool have_ntlm = TRUE;
+#define CURL_SASL_NTLM        TRUE
 #else
-  static bool have_ntlm = FALSE;
+#define CURL_SASL_NTLM        FALSE
 #endif
   /* Failing SASL authentication is a pain. Give a helping hand if
    * we were unable to select an AUTH mechanism.
@@ -829,17 +829,17 @@ CURLcode Curl_sasl_is_blocked(struct SASL *sasl, struct Curl_easy *data)
     if((enabledmechs & SASL_MECH_EXTERNAL) && data->conn->passwd[0])
       infof(data, "SASL: auth EXTERNAL not chosen with password");
     sasl_unchosen(data, SASL_MECH_GSSAPI, enabledmechs,
-                  have_kerberos5, Curl_auth_is_gssapi_supported(), NULL);
+                  CURL_SASL_KERBEROS5, Curl_auth_is_gssapi_supported(), NULL);
     sasl_unchosen(data, SASL_MECH_SCRAM_SHA_256, enabledmechs,
-                  have_gasl, FALSE, NULL);
+                  CURL_SASL_GASL, FALSE, NULL);
     sasl_unchosen(data, SASL_MECH_SCRAM_SHA_1, enabledmechs,
-                  have_gasl, FALSE, NULL);
+                  CURL_SASL_GASL, FALSE, NULL);
     sasl_unchosen(data, SASL_MECH_DIGEST_MD5, enabledmechs,
-                  have_digest, Curl_auth_is_digest_supported(), NULL);
+                  CURL_SASL_DIGEST, Curl_auth_is_digest_supported(), NULL);
     sasl_unchosen(data, SASL_MECH_CRAM_MD5, enabledmechs,
-                  have_digest, TRUE, NULL);
+                  CURL_SASL_DIGEST, TRUE, NULL);
     sasl_unchosen(data, SASL_MECH_NTLM, enabledmechs,
-                  have_ntlm, Curl_auth_is_ntlm_supported(), NULL);
+                  CURL_SASL_NTLM, Curl_auth_is_ntlm_supported(), NULL);
     sasl_unchosen(data, SASL_MECH_OAUTHBEARER, enabledmechs,  TRUE, TRUE,
                   data->set.str[STRING_BEARER] ?
                   NULL : "CURLOPT_XOAUTH2_BEARER");

--- a/lib/curl_sasl.h
+++ b/lib/curl_sasl.h
@@ -162,4 +162,6 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
 CURLcode Curl_sasl_continue(struct SASL *sasl, struct Curl_easy *data,
                             int code, saslprogress *progress);
 
+CURLcode Curl_sasl_is_blocked(struct SASL *sasl, struct Curl_easy *data);
+
 #endif /* HEADER_CURL_SASL_H */

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -723,11 +723,8 @@ static CURLcode imap_perform_authentication(struct Curl_easy *data,
     else if(!imapc->login_disabled && (imapc->preftype & IMAP_TYPE_CLEARTEXT))
       /* Perform clear text authentication */
       result = imap_perform_login(data, imapc, data->conn);
-    else {
-      /* Other mechanisms not supported */
-      infof(data, "No known authentication mechanisms supported");
-      result = CURLE_LOGIN_DENIED;
-    }
+    else
+      result = Curl_sasl_is_blocked(&imapc->sasl, data);
   }
 
   return result;

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -491,7 +491,7 @@ static CURLcode oldap_perform_sasl(struct Curl_easy *data)
 
   oldap_state(data, li, OLDAP_SASL);
   if(!result && progress != SASL_INPROGRESS)
-    result = CURLE_LOGIN_DENIED;
+    result = Curl_sasl_is_blocked(&li->sasl, data);
   return result;
 }
 

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -726,11 +726,8 @@ static CURLcode pop3_perform_authentication(struct Curl_easy *data,
     if(pop3c->authtypes & pop3c->preftype & POP3_TYPE_CLEARTEXT)
       /* Perform clear text authentication */
       result = pop3_perform_user(data, conn);
-    else {
-      /* Other mechanisms not supported */
-      infof(data, "No known authentication mechanisms supported");
-      result = CURLE_LOGIN_DENIED;
-    }
+    else
+      result = Curl_sasl_is_blocked(&pop3c->sasl, data);
   }
 
   return result;

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -590,11 +590,8 @@ static CURLcode smtp_perform_authentication(struct Curl_easy *data,
   if(!result) {
     if(progress == SASL_INPROGRESS)
       smtp_state(data, smtpc, SMTP_AUTH);
-    else {
-      /* Other mechanisms not supported */
-      infof(data, "No known authentication mechanisms supported");
-      result = CURLE_LOGIN_DENIED;
-    }
+    else
+      result = Curl_sasl_is_blocked(&smtpc->sasl, data);
   }
 
   return result;

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -167,6 +167,8 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
 
 /* This is used to clean up the NTLM specific data */
 void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm);
+#else
+#define Curl_auth_is_ntlm_supported()     FALSE
 #endif /* USE_NTLM */
 
 /* This is used to generate a base64 encoded OAuth 2.0 message */
@@ -207,6 +209,8 @@ CURLcode Curl_auth_create_gssapi_security_message(struct Curl_easy *data,
 
 /* This is used to clean up the GSSAPI specific data */
 void Curl_auth_cleanup_gssapi(struct kerberos5data *krb5);
+#else
+#define Curl_auth_is_gssapi_supported()       FALSE
 #endif /* USE_KERBEROS5 */
 
 #if defined(USE_SPNEGO)


### PR DESCRIPTION
When SASL is unable to select an AUTH mechanism, give user help in info message why no AUTH could be selected.

refs #17420