### PR TITLE
setopt: create set_ssl_options()

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -410,23 +410,8 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
                        data->set.str[STRING_SSL_EC_CURVES]);
   }
 
-  {
-    long mask =
-      (data->set.ssl.enable_beast ?
-       CURLSSLOPT_ALLOW_BEAST : 0) |
-      (data->set.ssl.no_revoke ?
-       CURLSSLOPT_NO_REVOKE : 0) |
-      (data->set.ssl.no_partialchain ?
-       CURLSSLOPT_NO_PARTIALCHAIN : 0) |
-      (data->set.ssl.revoke_best_effort ?
-       CURLSSLOPT_REVOKE_BEST_EFFORT : 0) |
-      (data->set.ssl.native_ca_store ?
-       CURLSSLOPT_NATIVE_CA : 0) |
-      (data->set.ssl.auto_client_cert ?
-       CURLSSLOPT_AUTO_CLIENT_CERT : 0);
-
-    (void)curl_easy_setopt(doh, CURLOPT_SSL_OPTIONS, mask);
-  }
+  (void)curl_easy_setopt(doh, CURLOPT_SSL_OPTIONS,
+                         (long)data->set.ssl.primary.ssl_options);
 
   doh->state.internal = TRUE;
   doh->master_mid = data->mid; /* master transfer of this one */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -391,6 +391,20 @@ static CURLcode setopt_RTSP_REQUEST(struct Curl_easy *data, long arg)
 }
 #endif /* ! CURL_DISABLE_RTSP */
 
+static void set_ssl_options(struct ssl_config_data *ssl,
+                            struct ssl_primary_config *config,
+                            long arg)
+{
+  config->ssl_options = (unsigned char)(arg & 0xff);
+  ssl->enable_beast = !!(arg & CURLSSLOPT_ALLOW_BEAST);
+  ssl->no_revoke = !!(arg & CURLSSLOPT_NO_REVOKE);
+  ssl->no_partialchain = !!(arg & CURLSSLOPT_NO_PARTIALCHAIN);
+  ssl->revoke_best_effort = !!(arg & CURLSSLOPT_REVOKE_BEST_EFFORT);
+  ssl->native_ca_store = !!(arg & CURLSSLOPT_NATIVE_CA);
+  ssl->auto_client_cert = !!(arg & CURLSSLOPT_AUTO_CLIENT_CERT);
+  ssl->earlydata = !!(arg & CURLSSLOPT_EARLYDATA);
+}
+
 static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
                             long arg)
 {
@@ -1131,29 +1145,12 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     data->set.use_ssl = (unsigned char)arg;
     break;
   case CURLOPT_SSL_OPTIONS:
-    data->set.ssl.primary.ssl_options = (unsigned char)(arg & 0xff);
-    data->set.ssl.enable_beast = !!(arg & CURLSSLOPT_ALLOW_BEAST);
-    data->set.ssl.no_revoke = !!(arg & CURLSSLOPT_NO_REVOKE);
-    data->set.ssl.no_partialchain = !!(arg & CURLSSLOPT_NO_PARTIALCHAIN);
-    data->set.ssl.revoke_best_effort = !!(arg & CURLSSLOPT_REVOKE_BEST_EFFORT);
-    data->set.ssl.native_ca_store = !!(arg & CURLSSLOPT_NATIVE_CA);
-    data->set.ssl.auto_client_cert = !!(arg & CURLSSLOPT_AUTO_CLIENT_CERT);
-    data->set.ssl.earlydata = !!(arg & CURLSSLOPT_EARLYDATA);
-    /* If a setting is added here it should also be added in dohprobe()
-       which sets its own CURLOPT_SSL_OPTIONS based on these settings. */
+    set_ssl_options(&data->set.ssl, &data->set.ssl.primary, arg);
     break;
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSL_OPTIONS:
-    data->set.proxy_ssl.primary.ssl_options = (unsigned char)(arg & 0xff);
-    data->set.proxy_ssl.enable_beast = !!(arg & CURLSSLOPT_ALLOW_BEAST);
-    data->set.proxy_ssl.no_revoke = !!(arg & CURLSSLOPT_NO_REVOKE);
-    data->set.proxy_ssl.no_partialchain = !!(arg & CURLSSLOPT_NO_PARTIALCHAIN);
-    data->set.proxy_ssl.revoke_best_effort =
-      !!(arg & CURLSSLOPT_REVOKE_BEST_EFFORT);
-    data->set.proxy_ssl.native_ca_store = !!(arg & CURLSSLOPT_NATIVE_CA);
-    data->set.proxy_ssl.auto_client_cert =
-      !!(arg & CURLSSLOPT_AUTO_CLIENT_CERT);
+    set_ssl_options(&data->set.proxy_ssl, &data->set.proxy_ssl.primary, arg);
     break;
 #endif
 

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -391,6 +391,7 @@ static CURLcode setopt_RTSP_REQUEST(struct Curl_easy *data, long arg)
 }
 #endif /* ! CURL_DISABLE_RTSP */
 
+#ifdef USE_SSL
 static void set_ssl_options(struct ssl_config_data *ssl,
                             struct ssl_primary_config *config,
                             long arg)
@@ -404,6 +405,7 @@ static void set_ssl_options(struct ssl_config_data *ssl,
   ssl->auto_client_cert = !!(arg & CURLSSLOPT_AUTO_CLIENT_CERT);
   ssl->earlydata = !!(arg & CURLSSLOPT_EARLYDATA);
 }
+#endif
 
 static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
                             long arg)


### PR DESCRIPTION
Used for both CURLOPT_SSL_OPTIONS and CURLOPT_PROXY_SSL_OPTIONS

Also: make the DoH code use the full original argument value instead of each individual flag. Makes it easier to keep all of these in synk.