### PR TITLE
curl: change the struct getout flags field into bitfields

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -231,8 +231,6 @@ struct OperationConfig {
   long proxyver;             /* set to CURLPROXY_HTTP* define */
   int ftp_ssl_ccc_mode;
   int ftp_filemethod;
-  int default_node_flags;   /* default flags to search for each 'node', which
-                               is basically each given URL to transfer */
   enum {
     CLOBBER_DEFAULT, /* Provides compatibility with previous versions of curl,
                         by using the default behavior for -o, -O, and -J.
@@ -244,6 +242,7 @@ struct OperationConfig {
   } file_clobber_mode;
   unsigned char upload_flags; /* Bitmask for --upload-flags */
   unsigned short porttouse;
+  BIT(remote_name_all);   /* --remote-name-all */
   BIT(remote_time);
   BIT(cookiesession);       /* new session? */
   BIT(encoding);            /* Accept-Encoding please */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1045,7 +1045,7 @@ const struct LongShort *findlongopt(const char *opt)
 static ParameterError add_url(struct GlobalConfig *global,
                               struct OperationConfig *config,
                               const char *thisurl,
-                              int extraflags)
+                              bool remote_noglob)
 {
   ParameterError err = PARAM_OK;
   struct getout *url;
@@ -1056,7 +1056,7 @@ static ParameterError add_url(struct GlobalConfig *global,
   if(config->url_get) {
     /* there is a node here, if it already is filled-in continue to find
        an "empty" node */
-    while(config->url_get && (config->url_get->flags & GETOUT_URL))
+    while(config->url_get && config->url_get->urlset)
       config->url_get = config->url_get->next;
   }
 
@@ -1074,7 +1074,9 @@ static ParameterError add_url(struct GlobalConfig *global,
   else {
     /* fill in the URL */
     err = getstr(&url->url, thisurl, DENY_BLANK);
-    url->flags |= GETOUT_URL | extraflags;
+    url->urlset = TRUE;
+    if(remote_noglob)
+      url->useremote = url->noglob = TRUE;
     if(!err && (++config->num_urls > 1) &&
        (config->etag_save_file || config->etag_compare_file)) {
       errorf(global, "The etag options only work on a single URL");
@@ -1104,7 +1106,7 @@ static ParameterError parse_url(struct GlobalConfig *global,
       curlx_dyn_init(&line, 8092);
       while(my_get_line(f, &line, &error)) {
         const char *ptr = curlx_dyn_ptr(&line);
-        err = add_url(global, config, ptr, GETOUT_USEREMOTE | GETOUT_NOGLOB);
+        err = add_url(global, config, ptr, TRUE);
         if(err)
           break;
       }
@@ -1117,7 +1119,7 @@ static ParameterError parse_url(struct GlobalConfig *global,
     }
     return PARAM_READ_ERROR; /* file not found */
   }
-  return add_url(global, config, nextarg, 0);
+  return add_url(global, config, nextarg, FALSE);
 }
 
 
@@ -1298,7 +1300,7 @@ static ParameterError parse_output(struct OperationConfig *config,
   if(config->url_out) {
     /* there is a node here, if it already is filled-in continue to find
        an "empty" node */
-    while(config->url_out && (config->url_out->flags & GETOUT_OUTFILE))
+    while(config->url_out && config->url_out->outset)
       config->url_out = config->url_out->next;
   }
 
@@ -1317,8 +1319,8 @@ static ParameterError parse_output(struct OperationConfig *config,
 
   /* fill in the outfile */
   err = getstr(&url->outfile, nextarg, DENY_BLANK);
-  url->flags &= ~GETOUT_USEREMOTE; /* switch off */
-  url->flags |= GETOUT_OUTFILE;
+  url->useremote = FALSE; /* switch off */
+  url->outset = TRUE;
   return err;
 }
 
@@ -1328,7 +1330,7 @@ static ParameterError parse_remote_name(struct OperationConfig *config,
   ParameterError err = PARAM_OK;
   struct getout *url;
 
-  if(!toggle && !config->default_node_flags)
+  if(!toggle && !config->remote_name_all)
     return err; /* nothing to do */
 
   /* output file */
@@ -1337,7 +1339,7 @@ static ParameterError parse_remote_name(struct OperationConfig *config,
   if(config->url_out) {
     /* there is a node here, if it already is filled-in continue to find
        an "empty" node */
-    while(config->url_out && (config->url_out->flags & GETOUT_OUTFILE))
+    while(config->url_out && config->url_out->outset)
       config->url_out = config->url_out->next;
   }
 
@@ -1355,11 +1357,8 @@ static ParameterError parse_remote_name(struct OperationConfig *config,
     return PARAM_NO_MEM;
 
   url->outfile = NULL; /* leave it */
-  if(toggle)
-    url->flags |= GETOUT_USEREMOTE;  /* switch on */
-  else
-    url->flags &= ~GETOUT_USEREMOTE; /* switch off */
-  url->flags |= GETOUT_OUTFILE;
+  url->useremote = toggle;
+  url->outset = TRUE;
   return PARAM_OK;
 }
 
@@ -1444,7 +1443,7 @@ static ParameterError parse_upload_file(struct OperationConfig *config,
   if(config->url_ul) {
     /* there is a node here, if it already is filled-in continue to find
        an "empty" node */
-    while(config->url_ul && (config->url_ul->flags & GETOUT_UPLOAD))
+    while(config->url_ul && config->url_ul->uploadset)
       config->url_ul = config->url_ul->next;
   }
 
@@ -1460,9 +1459,9 @@ static ParameterError parse_upload_file(struct OperationConfig *config,
   if(!url)
     return PARAM_NO_MEM;
 
-  url->flags |= GETOUT_UPLOAD; /* mark -T used */
+  url->uploadset = TRUE; /* mark -T used */
   if(!*nextarg)
-    url->flags |= GETOUT_NOUPLOAD;
+    url->noupload = TRUE;
   else {
     /* "-" equals stdin, but keep the string around for now */
     err = getstr(&url->infile, nextarg, DENY_BLANK);
@@ -2831,7 +2830,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       config->nobuffer = (bool)(longopt ? !toggle : TRUE);
       break;
     case C_REMOTE_NAME_ALL: /* --remote-name-all */
-      config->default_node_flags = toggle ? GETOUT_USEREMOTE : 0;
+      config->remote_name_all = toggle;
       break;
     case C_OUTPUT_DIR: /* --output-dir */
       err = getstr(&config->output_dir, nextarg, DENY_BLANK);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -850,7 +850,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
     if(!urlnode->url) {
       /* This node has no URL. Free node data without destroying the
          node itself nor modifying next pointer and continue to next */
-      urlnode->flags = 0;
+      urlnode->outset = urlnode->urlset = urlnode->useremote =
+        urlnode->uploadset = urlnode->noupload = urlnode->noglob = FALSE;
       state->up = 0;
       if(!warn_more_options) {
         /* only show this once */
@@ -898,7 +899,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
     }
 
     if(!state->urlnum) {
-      if(!config->globoff && !(urlnode->flags & GETOUT_NOGLOB)) {
+      if(!config->globoff && !urlnode->noglob) {
         /* Unless explicitly shut off, we expand '{...}' and '[...]'
            expressions and return total number of URLs in pattern set */
         result = glob_url(&state->urls, urlnode->url, &state->urlnum,
@@ -1121,7 +1122,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
         }
       }
 
-      if(((urlnode->flags&GETOUT_USEREMOTE) ||
+      if((urlnode->useremote ||
           (per->outfile && strcmp("-", per->outfile)))) {
 
         /*
@@ -1185,8 +1186,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
             *skipped = TRUE;
           }
         }
-        if((urlnode->flags & GETOUT_USEREMOTE)
-           && config->content_disposition) {
+        if(urlnode->useremote && config->content_disposition) {
           /* Our header callback MIGHT set the filename */
           DEBUGASSERT(!outs->filename);
         }
@@ -1309,7 +1309,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
       config->terminal_binary_ok =
         (per->outfile && !strcmp(per->outfile, "-"));
 
-      if(config->content_disposition && (urlnode->flags & GETOUT_USEREMOTE))
+      if(config->content_disposition && urlnode->useremote)
         hdrcbdata->honor_cd_filename = TRUE;
       else
         hdrcbdata->honor_cd_filename = FALSE;
@@ -1344,7 +1344,8 @@ static CURLcode single_transfer(struct GlobalConfig *global,
     else {
       /* Free this URL node data without destroying the
          node itself nor modifying next pointer. */
-      urlnode->flags = 0;
+      urlnode->outset = urlnode->urlset = urlnode->useremote =
+        urlnode->uploadset = urlnode->noupload = urlnode->noglob = FALSE;
       glob_cleanup(&state->urls);
       state->urlnum = 0;
 

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -52,7 +52,7 @@ struct getout *new_getout(struct OperationConfig *config)
     /* move the last pointer */
     config->url_last = node;
 
-    node->flags = config->default_node_flags;
+    node->useremote = config->remote_name_all;
     node->num = outnum++;
   }
   return node;

--- a/src/tool_sdecls.h
+++ b/src/tool_sdecls.h
@@ -64,16 +64,16 @@
 
 struct OutStruct {
   char *filename;
-  BIT(alloc_filename);
-  BIT(is_cd_filename);
-  BIT(s_isreg);
-  BIT(fopened);
   FILE *stream;
   curl_off_t bytes;
   curl_off_t init;
 #ifdef _WIN32
   unsigned char utf8seq[5];
 #endif
+  BIT(alloc_filename);
+  BIT(is_cd_filename);
+  BIT(s_isreg);
+  BIT(fopened);
 };
 
 /*
@@ -87,17 +87,15 @@ struct getout {
   char          *url;       /* the URL we deal with */
   char          *outfile;   /* where to store the output */
   char          *infile;    /* file to upload, if GETOUT_UPLOAD is set */
-  int            flags;     /* options - composed of GETOUT_* bits */
   int            num;       /* which URL number in an invocation */
+
+  BIT(outset);    /* when outfile is set */
+  BIT(urlset);    /* when URL is set */
+  BIT(uploadset); /* when -T is set */
+  BIT(useremote); /* use remote filename locally */
+  BIT(noupload);  /* if set, -T "" has been used */
+  BIT(noglob);    /* disable globbing for this URL */
 };
-
-#define GETOUT_OUTFILE    (1<<0)  /* set when outfile is deemed done */
-#define GETOUT_URL        (1<<1)  /* set when URL is deemed done */
-#define GETOUT_USEREMOTE  (1<<2)  /* use remote filename locally */
-#define GETOUT_UPLOAD     (1<<3)  /* if set, -T has been used */
-#define GETOUT_NOUPLOAD   (1<<4)  /* if set, -T "" has been used */
-#define GETOUT_NOGLOB     (1<<5)  /* disable globbing for this URL */
-
 /*
  * 'trace' enumeration represents curl's output look'n feel possibilities.
  */


### PR DESCRIPTION
As the flags were use mostly as individual booleans anyway, the code gets simpler when we use bitfields instead of manual bitwise operations.