### PR TITLE
Libssh: Use sftp_aio instead of sftp_async for sftp_recv

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -3047,10 +3047,13 @@ static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
         return CURLE_AGAIN;
       else if(nwrite < 0)
         return CURLE_SEND_ERROR;
-      if(sshc->sftp_send_aio) {
-        sftp_aio_free(sshc->sftp_send_aio);
-        sshc->sftp_send_aio = NULL;
-      }
+
+      /*
+       * sftp_aio_wait_write() would free sftp_send_aio and
+       * assign it NULL in all cases except when it returns
+       * SSH_AGAIN.
+       */
+
       sshc->sftp_send_state = 0;
       *pnwritten = (size_t)nwrite;
       return CURLE_OK;

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1460,15 +1460,8 @@ static int myssh_in_SFTP_SHUTDOWN(struct Curl_easy *data,
      before we proceed */
   ssh_set_blocking(sshc->ssh_session, 0);
 #if LIBSSH_VERSION_INT > SSH_VERSION_INT(0, 11, 0)
-  if(sshc->sftp_send_aio) {
-    sftp_aio_free(sshc->sftp_send_aio);
-    sshc->sftp_send_aio = NULL;
-  }
-
-  if(sshc->sftp_recv_aio) {
-    sftp_aio_free(sshc->sftp_recv_aio);
-    sshc->sftp_recv_aio = NULL;
-  }
+  SFTP_AIO_FREE(sshc->sftp_send_aio);
+  SFTP_AIO_FREE(sshc->sftp_recv_aio);
 #endif
 
   if(sshc->sftp_file) {

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -3030,11 +3030,6 @@ static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
   if(!sshc)
     return CURLE_FAILED_INIT;
 
-  /* limit the writes to the maximum specified in Section 3 of
-   * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02
-   */
-  if(len > 32768)
-    len = 32768;
 #if LIBSSH_VERSION_INT > SSH_VERSION_INT(0, 11, 0)
   switch(sshc->sftp_send_state) {
     case 0:
@@ -3067,6 +3062,17 @@ static CURLcode sftp_send(struct Curl_easy *data, int sockindex,
       return CURLE_SEND_ERROR;
   }
 #else
+  /*
+   * limit the writes to the maximum specified in Section 3 of
+   * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02
+   *
+   * libssh started applying appropriate read/write length limits
+   * internally since version 0.11.0, hence such an operation is
+   * not needed for versions after (and including) 0.11.0.
+   */
+  if(len > 32768)
+    len = 32768;
+
   nwrite = sftp_write(sshc->sftp_file, mem, len);
 
   myssh_block2waitfor(conn, sshc, FALSE);

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -180,10 +180,13 @@ struct ssh_conn {
 
   unsigned sftp_recv_state; /* 0 or 1 */
 #if LIBSSH_VERSION_INT > SSH_VERSION_INT(0, 11, 0)
+  sftp_aio sftp_recv_aio;
+
   sftp_aio sftp_send_aio;
   unsigned sftp_send_state; /* 0 or 1 */
-#endif
+#else
   int sftp_file_index; /* for async read */
+#endif
   sftp_attributes readdir_attrs; /* used by the SFTP readdir actions */
   sftp_attributes readdir_link_attrs; /* used by the SFTP readdir actions */
   sftp_attributes quote_attrs; /* used by the SFTP_QUOTE state */

--- a/lib/vssh/ssh.h
+++ b/lib/vssh/ssh.h
@@ -180,7 +180,7 @@ struct ssh_conn {
 
   unsigned sftp_recv_state; /* 0 or 1 */
 #if LIBSSH_VERSION_INT > SSH_VERSION_INT(0, 11, 0)
-  sftp_aio sftp_aio;
+  sftp_aio sftp_send_aio;
   unsigned sftp_send_state; /* 0 or 1 */
 #endif
   int sftp_file_index; /* for async read */


### PR DESCRIPTION
Changes:
1. Use sftp_aio instead of sftp_async API as the latter has been deprecated (since libssh 0.11.0)
2. Remove the write limit capping for the calling code as libssh manages the limit internally (since 0.11.0)

Though this change won't give the full performance benefits that are expected by a proper use of sftp aio API (See 'Using the sftp aio API to speed up a transfer' section here: https://api.libssh.org/stable/libssh_tutor_sftp_aio.html) as the current use of sftp aio API here is as good as using the sync API (single request, single response at a time).

But still, this would provide some performance improvements as:
1. The sftp aio API avoids an extra buffer copy in sftp_async API.
2. The limits used internally by libssh could be more than the protocol specified minimum write limit of 32KB (provided servers support providing this information). Hence removing the write limit applied by curl's calling code, would lead to larger chunks being transferred in one go, potentially leading to faster transfers.

This pull request is a start and would be followed up by a proper use of the sftp aio API for downloading/uploading to increase curl 's performance when using libssh as a backend.