### PR TITLE
curl: only warn once for --manual in manual-disabled build

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2806,10 +2806,6 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       break;
     case C_MANUAL: /* --manual */
       if(toggle) { /* --no-manual shows no manual... */
-#ifndef USE_MANUAL
-        warnf(global,
-              "built-in manual was disabled at build-time");
-#endif
         err = PARAM_MANUAL_REQUESTED;
       }
       break;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -2211,7 +2211,8 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
 #ifdef USE_MANUAL
         hugehelp();
 #else
-        puts("built-in manual was disabled at build-time");
+        warnf(global,
+              "built-in manual was disabled at build-time");
 #endif
       }
       /* Check if we were asked for the version information */


### PR DESCRIPTION
It would previously say it twice.