### PR TITLE
docs: fix typo in retry.md

### DIFF
--- a/docs/cmdline-opts/retry.md
+++ b/docs/cmdline-opts/retry.md
@@ -23,7 +23,7 @@ response code.
 
 When curl is about to retry a transfer, it first waits one second and then for
 all forthcoming retries it doubles the waiting time until it reaches 10
-minutes which then remains delay between the rest of the retries. By using
+minutes which then remains as the delay between the rest of the retries. By using
 --retry-delay you disable this exponential backoff algorithm. See also
 --retry-max-time to limit the total time allowed for retries.
 


### PR DESCRIPTION
I was opening an issue about an issue with the retry parameters and spotted this typo when quoting the manpage.

I assume this is the intended wording there, but feel free to modify it.