### PR TITLE
Remove obsolete reference to local_ip6

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -945,7 +945,6 @@ CURLcode Curl_async_ares_set_dns_local_ip6(struct Curl_easy *data)
   return CURLE_OK;
 #else /* c-ares version too old! */
   (void)data;
-  (void)local_ip6;
   return CURLE_NOT_BUILT_IN;
 #endif
 }


### PR DESCRIPTION
7bf576064c moved local_ip6 from the parameter list to the actual implementation of Curl_async_ares_set_dns_local_ip6. The no-op code for !( defined(HAVE_CARES_SET_LOCAL) && defined(USE_IPV6) ) still had an reference which is removed by this change.