### PR TITLE
follow location: fail early when rewind of input failed

### DIFF
--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -549,6 +549,11 @@ class Httpd:
                 '      SetEnv force-response-1.0 1',
                 '    </Location>',
                 '    SetEnvIf Request_URI "/shutdown_unclean" ssl-unclean=1',
+                '    RewriteEngine on',
+                '    RewriteRule    "^/curltest/put-redir-301$"  "/curltest/put"  [R=301]',
+                '    RewriteRule    "^/curltest/put-redir-302$"  "/curltest/put"  [R=302]',
+                '    RewriteRule    "^/curltest/put-redir-307$"  "/curltest/put"  [R=307]',
+                '    RewriteRule    "^/curltest/put-redir-308$"  "/curltest/put"  [R=308]',
             ])
         if self._auth_digest:
             lines.extend([


### PR DESCRIPTION
When inspecting a possible follow HTTP request, the result of a rewind of the upload data was ignored as it was not clear at that point in time if the request would become a GET.

This initiated the followup, rewound again, which failed again and terminated the follow up.

This was confusing to users as it was not clear of the follow up was done or not.

Fix: fail the early rewind when the request is not converted to GET.

refs #17472