### PR TITLE
cmake: fix missed version number for multi-pkg-config detections

### DIFF
--- a/CMake/FindBrotli.cmake
+++ b/CMake/FindBrotli.cmake
@@ -51,6 +51,7 @@ endif()
 
 if(BROTLI_FOUND)
   set(Brotli_FOUND TRUE)
+  set(BROTLI_VERSION "${BROTLI_libbrotlicommon_VERSION}")
   string(REPLACE ";" " " BROTLI_CFLAGS "${BROTLI_CFLAGS}")
   message(STATUS "Found Brotli (via pkg-config): ${BROTLI_INCLUDE_DIRS} (found version \"${BROTLI_VERSION}\")")
 else()

--- a/CMake/FindLDAP.cmake
+++ b/CMake/FindLDAP.cmake
@@ -50,6 +50,7 @@ if(CURL_USE_PKGCONFIG AND
 endif()
 
 if(LDAP_FOUND)
+  set(LDAP_VERSION "${LDAP_ldap_VERSION}")
   string(REPLACE ";" " " LDAP_CFLAGS "${LDAP_CFLAGS}")
   message(STATUS "Found LDAP (via pkg-config): ${LDAP_INCLUDE_DIRS} (found version \"${LDAP_VERSION}\")")
 else()

--- a/CMake/FindMbedTLS.cmake
+++ b/CMake/FindMbedTLS.cmake
@@ -59,6 +59,7 @@ endif()
 
 if(MBEDTLS_FOUND)
   set(MbedTLS_FOUND TRUE)
+  set(MBEDTLS_VERSION "${MBEDTLS_mbedtls_VERSION}")
   string(REPLACE ";" " " MBEDTLS_CFLAGS "${MBEDTLS_CFLAGS}")
   message(STATUS "Found MbedTLS (via pkg-config): ${MBEDTLS_INCLUDE_DIRS} (found version \"${MBEDTLS_VERSION}\")")
 else()

--- a/CMake/FindNGTCP2.cmake
+++ b/CMake/FindNGTCP2.cmake
@@ -77,6 +77,7 @@ if(CURL_USE_PKGCONFIG AND
 endif()
 
 if(NGTCP2_FOUND)
+  set(NGTCP2_VERSION "${NGTCP2_libngtcp2_VERSION}")
   string(REPLACE ";" " " NGTCP2_CFLAGS "${NGTCP2_CFLAGS}")
   message(STATUS "Found NGTCP2 (via pkg-config): ${NGTCP2_INCLUDE_DIRS} (found version \"${NGTCP2_VERSION}\")")
 else()


### PR DESCRIPTION
It broke cmake builds with OpenSSL 3.5.0 and ngtcp2 1.12.0 or newer,
when detected via `pkg-config`.

For brotli, mbedtls, LDAP, ngtcp2 builds, it caused their version
numbers missing from the configure log when detected via `pkg-config`.

Regression from 01e45f81bddb2fef27fe35b7dd32032062a183f6 #16980
Regression from 3b501976a9adcf20218ffb96d9041806432227e4 #16479

Bug: https://github.com/curl/curl/pull/16980#issuecomment-2916811388
Reported-by: x-xiang on github
