### PR TITLE
Fix typos on docs/*

### DIFF
--- a/docs/cmdline-opts/_ENVIRONMENT.md
+++ b/docs/cmdline-opts/_ENVIRONMENT.md
@@ -40,7 +40,7 @@ accesses the target URL directly, and
 
 accesses the target URL through the proxy.
 
-The list of hostnames can also be include numerical IP addresses, and IPv6
+The list of hostnames can also include numerical IP addresses, and IPv6
 versions should then be given without enclosing brackets.
 
 IP addresses can be specified using CIDR notation: an appended slash and
@@ -106,7 +106,7 @@ BoringSSL, GnuTLS, wolfSSL and Rustls.
 
 ## `USERPROFILE` <dir>
 On Windows, this variable is used when trying to find the home directory. If
-the other, primary, variable are all unset. If set, curl uses the path
+the other, primary, variables are all unset. If set, curl uses the path
 **"$USERPROFILE\Application Data"**.
 
 ## `XDG_CONFIG_HOME` <dir>

--- a/docs/cmdline-opts/_EXITCODES.md
+++ b/docs/cmdline-opts/_EXITCODES.md
@@ -175,7 +175,7 @@ FTP chunk callback reported error.
 ## 89
 No connection available, the session is queued.
 ## 90
-SSL public key does not matched pinned public key.
+SSL public key does not match pinned public key.
 ## 91
 Invalid SSL certificate status.
 ## 92

--- a/docs/cmdline-opts/_PROTOCOLS.md
+++ b/docs/cmdline-opts/_PROTOCOLS.md
@@ -24,11 +24,11 @@ without using TLS.
 ## LDAP(S)
 curl can do directory lookups for you, with or without TLS.
 ## MQTT
-curl supports MQTT version 3. Downloading over MQTT equals subscribe to a
-topic while uploading/posting equals publish on a topic. MQTT over TLS is not
+curl supports MQTT version 3. Downloading over MQTT equals subscribing to a
+topic while uploading/posting equals publishing on a topic. MQTT over TLS is not
 supported (yet).
 ## POP3(S)
-Downloading from a pop3 server means getting a mail. With or without using
+Downloading from a pop3 server means getting an email. With or without using
 TLS.
 ## RTMP(S)
 The **Realtime Messaging Protocol** is primarily used to serve streaming media

--- a/docs/cmdline-opts/_VARIABLES.md
+++ b/docs/cmdline-opts/_VARIABLES.md
@@ -30,7 +30,7 @@ white space with `trim`, it can output the contents as a JSON quoted string
 with `json`, URL encode the string with `url`, base64 encode it with `b64` and
 base64 decode it with `64dec`. To apply functions to a variable expansion, add
 them colon separated to the right side of the variable. Variable content
-holding null bytes that are not encoded when expanded cause error.
+holding null bytes that are not encoded when expanded causes an error.
 
 Example: get the contents of a file called $HOME/.secret into a variable
 called "fix". Make sure that the content is trimmed and percent-encoded when

--- a/docs/cmdline-opts/ca-native.md
+++ b/docs/cmdline-opts/ca-native.md
@@ -32,7 +32,7 @@ Fedora, RHEL), macOS, Android and iOS. (Added in 8.3.0)
 
 This option works with GnuTLS. (Added in 8.5.0)
 
-This options works with rustls on Windows, macOS, Android and iOS. On Linux it
+This option works with rustls on Windows, macOS, Android and iOS. On Linux it
 is equivalent to using the Mozilla CA certificate bundle. When used with rustls
 _only_ the native CA store is consulted, not other locations set at run time or
 build time. (Added in 8.13.0)

--- a/docs/cmdline-opts/capath.md
+++ b/docs/cmdline-opts/capath.md
@@ -19,7 +19,7 @@ Example:
 # `--capath`
 
 Use the specified certificate directory to verify the peer. Multiple paths can
-be provided by separated with colon (`:`) (e.g. `path1:path2:path3`). The
+be provided by separating them with colon (`:`) (e.g. `path1:path2:path3`). The
 certificates must be in PEM format, and if curl is built against OpenSSL, the
 directory must have been processed using the c_rehash utility supplied with
 OpenSSL. Using --capath can allow OpenSSL-powered curl to make SSL-connections

--- a/docs/cmdline-opts/cert.md
+++ b/docs/cmdline-opts/cert.md
@@ -32,14 +32,14 @@ In the \<certificate\> portion of the argument, you must escape the character
 you must escape the double quote character as \" so that it is not recognized
 as an escape character.
 
-If curl is built against OpenSSL library, and the engine pkcs11 or pkcs11
+If curl is built against OpenSSL, and the engine pkcs11 or pkcs11
 provider is available, then a PKCS#11 URI (RFC 7512) can be used to specify a
 certificate located in a PKCS#11 device. A string beginning with `pkcs11:` is
 interpreted as a PKCS#11 URI. If a PKCS#11 URI is provided, then the --engine
 option is set as `pkcs11` if none was provided and the --cert-type option is
 set as `ENG` or `PROV` if none was provided (depending on OpenSSL version).
 
-If curl is built against GnuTLS library, a PKCS#11 URI can be used to specify
+If curl is built against GnuTLS, a PKCS#11 URI can be used to specify
 a certificate located in a PKCS#11 device. A string beginning with `pkcs11:`
 is interpreted as a PKCS#11 URI.
 

--- a/docs/cmdline-opts/connect-to.md
+++ b/docs/cmdline-opts/connect-to.md
@@ -26,7 +26,7 @@ certificate verification) or for the application protocols.
 original hostname and port number.
 
 A hostname specified to this option is compared as a string, so it needs to
-match the name used in request URL. It can be either numerical such as
+match the name used in the request URL. It can be either numerical such as
 `127.0.0.1` or the full host name such as `example.org`.
 
 Example: redirect connects from the example.com hostname to 127.0.0.1

--- a/docs/cmdline-opts/data.md
+++ b/docs/cmdline-opts/data.md
@@ -25,7 +25,7 @@ Example:
 Send the specified data in a POST request to the HTTP server, in the same way
 that a browser does when a user has filled in an HTML form and presses the
 submit button. This option makes curl pass the data to the server using the
-content-type application/x-www-form-urlencoded. Compare to --form.
+content-type application/x-www-form-urlencoded. Compared to --form.
 
 --data-raw is almost the same but does not have a special interpretation of
 the @ character. To post data purely binary, you should instead use the

--- a/docs/cmdline-opts/doh-url.md
+++ b/docs/cmdline-opts/doh-url.md
@@ -19,7 +19,7 @@ Example:
 Specify which DNS-over-HTTPS (DoH) server to use to resolve hostnames, instead
 of using the default name resolver mechanism. The URL must be HTTPS.
 
-Some SSL options that you set for your transfer also applies to DoH since the
+Some SSL options that you set for your transfer also apply to DoH since the
 name lookups take place over SSL. However, the certificate verification
 settings are not inherited but are controlled separately via --doh-insecure
 and --doh-cert-status.

--- a/docs/cmdline-opts/form.md
+++ b/docs/cmdline-opts/form.md
@@ -31,7 +31,7 @@ This enables uploading of binary files etc. To force the 'content' part to be
 a file, prefix the filename with an @ sign. To just get the content part from
 a file, prefix the filename with the symbol \<. The difference between @ and
 \< is then that @ makes a file get attached in the post as a file upload,
-while the \< makes a text field and just get the contents for that text field
+while the \< makes a text field and just gets the contents for that text field
 from a file.
 
 Read content from stdin instead of a file by using a single "-" as filename.
@@ -97,14 +97,14 @@ or
 
     curl -F "submit=OK;headers=@headerfile" example.com
 
-The headers= keyword may appear more that once and above notes about quoting
-apply. When headers are read from a file, Empty lines and lines starting
-with '#' are comments and ignored; each header can be folded by splitting
+The headers= keyword may appear more than once and above notes about quoting
+apply. When headers are read from a file, empty lines and lines starting
+with '#' are ignored; each header can be folded by splitting
 between two words and starting the continuation line with a space; embedded
 carriage-returns and trailing spaces are stripped.
 Here is an example of a header file contents:
 
-    # This file contain two headers.
+    # This file contains two headers.
     X-header-1: this is a header
 
     # The following header is folded.

--- a/docs/cmdline-opts/ftp-ssl-ccc.md
+++ b/docs/cmdline-opts/ftp-ssl-ccc.md
@@ -17,6 +17,6 @@ Example:
 # `--ftp-ssl-ccc`
 
 Use CCC (Clear Command Channel) Shuts down the SSL/TLS layer after
-authenticating. The rest of the control channel communication is be
+authenticating. The rest of the control channel communication is
 unencrypted. This allows NAT routers to follow the FTP transaction. The
 default mode is passive.

--- a/docs/cmdline-opts/haproxy-clientip.md
+++ b/docs/cmdline-opts/haproxy-clientip.md
@@ -26,7 +26,7 @@ permitted in front of numbers in order to avoid any possible confusion
 with octal numbers. IPv6 addresses must be indicated as series of 4 hexadecimal
 digits (upper or lower case) delimited by colons between each other, with the
 acceptance of one double colon sequence to replace the largest acceptable range
-of consecutive zeroes. The total number of decoded bits must exactly be 128.
+of consecutive zeroes. The total number of decoded bits must be exactly 128.
 
 Otherwise, any string can be accepted for the client IP and get sent.
 

--- a/docs/cmdline-opts/hsts.md
+++ b/docs/cmdline-opts/hsts.md
@@ -22,7 +22,7 @@ filename again if it has been modified.
 
 If curl is told to use HTTP:// for a transfer involving a hostname that exists
 in the HSTS cache, it upgrades the transfer to use HTTPS. Each HSTS cache
-entry has an individual life time after which the upgrade is no longer
+entry has an individual lifetime after which the upgrade is no longer
 performed.
 
 Specify a "" filename (zero length) to avoid loading/saving and make curl just

--- a/docs/cmdline-opts/http2-prior-knowledge.md
+++ b/docs/cmdline-opts/http2-prior-knowledge.md
@@ -19,10 +19,10 @@ Example:
 
 # `--http2-prior-knowledge`
 
-Issue a non-TLS HTTP requests using HTTP/2 directly without HTTP/1.1 Upgrade.
+Issue a non-TLS HTTP request using HTTP/2 directly without HTTP/1.1 Upgrade.
 It requires prior knowledge that the server supports HTTP/2 straight away.
 HTTPS requests still do HTTP/2 the standard way with negotiated protocol
-version in the TLS handshake.
+versions in the TLS handshake.
 
 Since 8.10.0 if this option is set for an HTTPS request then the application
 layer protocol version (ALPN) offered to the server is only HTTP/2. Prior to

--- a/docs/cmdline-opts/ipfs-gateway.md
+++ b/docs/cmdline-opts/ipfs-gateway.md
@@ -36,5 +36,5 @@ yourself. With remote gateways there could potentially be malicious actors
 returning you data that does not match the request you made, inspect or even
 interfere with the request. You may not notice this when using curl. A
 mitigation could be to go for a "trustless" gateway. This means you locally
-verify that the data. Consult the docs page on trusted vs trustless:
+verify the data. Consult the docs page on trusted vs trustless:
 https://docs.ipfs.tech/reference/http/gateway/#trusted-vs-trustless

--- a/docs/cmdline-opts/limit-rate.md
+++ b/docs/cmdline-opts/limit-rate.md
@@ -33,5 +33,5 @@ The rate limiting logic works on averaging the transfer speed to no more than
 the set threshold over a period of multiple seconds.
 
 If you also use the --speed-limit option, that option takes precedence and
-might cripple the rate-limiting slightly, to help keeping the speed-limit
+might cripple the rate-limiting slightly, to help keep the speed-limit
 logic working.

--- a/docs/cmdline-opts/max-redirs.md
+++ b/docs/cmdline-opts/max-redirs.md
@@ -16,6 +16,6 @@ Example:
 
 # `--max-redirs`
 
-Set maximum number of redirections to follow. When --location is used, to
+Set the maximum number of redirections to follow. When --location is used, to
 prevent curl from following too many redirects, by default, the limit is
 set to 50 redirects. Set this option to -1 to make it unlimited.

--- a/docs/cmdline-opts/max-time.md
+++ b/docs/cmdline-opts/max-time.md
@@ -18,7 +18,7 @@ Example:
 
 # `--max-time`
 
-Set maximum time in seconds that you allow each transfer to take. Prevents
+Set the maximum time in seconds that you allow each transfer to take. Prevents
 your batch jobs from hanging for hours due to slow networks or links going
 down. This option accepts decimal values (added in 7.32.0).
 

--- a/docs/cmdline-opts/mptcp.md
+++ b/docs/cmdline-opts/mptcp.md
@@ -24,7 +24,7 @@ servers, such as mobile networks where a device may switch between WiFi and
 cellular data or in wired networks with multiple Internet Service Providers.
 
 This option is currently only supported on Linux starting from kernel 5.6. Only
-TCP connections are modified, hence this option does not effect HTTP/3 (QUIC)
+TCP connections are modified, hence this option does not affect HTTP/3 (QUIC)
 or UDP connections.
 
 The server curl connects to must also support MPTCP. If not, the connection

--- a/docs/cmdline-opts/parallel.md
+++ b/docs/cmdline-opts/parallel.md
@@ -24,7 +24,7 @@ manner. Parallel transfer means that curl runs up to N concurrent transfers
 simultaneously and if there are more than N transfers to handle, it starts new
 ones when earlier transfers finish.
 
-With parallel transfers, the progress meter output is different than when
+With parallel transfers, the progress meter output is different from when
 doing serial transfers, as it then displays the transfer status for multiple
 transfers in a single line.
 

--- a/docs/cmdline-opts/proxy-capath.md
+++ b/docs/cmdline-opts/proxy-capath.md
@@ -21,7 +21,7 @@ Example:
 Same as --capath but used in HTTPS proxy context.
 
 Use the specified certificate directory to verify the proxy. Multiple paths
-can be provided by separated with colon (`:`) (e.g. `path1:path2:path3`). The
+can be provided by separating them with colon (`:`) (e.g. `path1:path2:path3`). The
 certificates must be in PEM format, and if curl is built against OpenSSL, the
 directory must have been processed using the c_rehash utility supplied with
 OpenSSL. Using --proxy-capath can allow OpenSSL-powered curl to make

--- a/docs/cmdline-opts/proxy-header.md
+++ b/docs/cmdline-opts/proxy-header.md
@@ -29,7 +29,7 @@ content: do not add newlines or carriage returns, they only mess things up for
 you.
 
 Headers specified with this option are not included in requests that curl
-knows are not be sent to a proxy.
+knows are not to be sent to a proxy.
 
 This option can take an argument in @filename style, which then adds a header
 for each line in the input file (added in 7.55.0). Using @- makes curl read

--- a/docs/cmdline-opts/proxy-user.md
+++ b/docs/cmdline-opts/proxy-user.md
@@ -25,5 +25,5 @@ your environment by specifying a single colon with this option: "-U :".
 On systems where it works, curl hides the given option argument from process
 listings. This is not enough to protect credentials from possibly getting seen
 by other users on the same system as they still are visible for a moment
-before cleared. Such sensitive data should be retrieved from a file instead or
+before being cleared. Such sensitive data should be retrieved from a file instead or
 similar and never used in clear text in a command line.

--- a/docs/cmdline-opts/proxy.md
+++ b/docs/cmdline-opts/proxy.md
@@ -27,7 +27,7 @@ used. (Added in 7.21.7)
 Unix domain sockets are supported for socks proxy. Set localhost for the host
 part. e.g. socks5h://localhost/path/to/socket.sock
 
-HTTPS proxy support works set with the https:// protocol prefix for OpenSSL
+HTTPS proxy support works with the https:// protocol prefix for OpenSSL
 and GnuTLS (added in 7.52.0). It also works for BearSSL, mbedTLS, Rustls,
 Schannel, Secure Transport and wolfSSL (added in 7.87.0).
 

--- a/docs/cmdline-opts/proxytunnel.md
+++ b/docs/cmdline-opts/proxytunnel.md
@@ -17,7 +17,7 @@ Example:
 
 When an HTTP proxy is used --proxy, this option makes curl tunnel the traffic
 through the proxy. The tunnel approach is made with the HTTP proxy CONNECT
-request and requires that the proxy allows direct connect to the remote port
+request and requires that the proxy allows direct connection to the remote port
 number curl wants to tunnel through to.
 
 To suppress proxy CONNECT response headers when curl is set to output headers

--- a/docs/cmdline-opts/rate.md
+++ b/docs/cmdline-opts/rate.md
@@ -41,6 +41,6 @@ more than 1000 per second, it instead runs unrestricted.
 When retrying transfers, enabled with --retry, the separate retry delay logic
 is used and not this setting.
 
-Starting in version 8.10.0, you can specify number of time units in the rate
+Starting in version 8.10.0, you can specify the number of time units in the rate
 expression. Make curl do no more than 5 transfers per 15 seconds with "5/15s"
 or limit it to 3 transfers per 4 hours with "3/4h". No spaces allowed.

--- a/docs/cmdline-opts/remove-on-error.md
+++ b/docs/cmdline-opts/remove-on-error.md
@@ -14,7 +14,7 @@ Example:
 
 # `--remove-on-error`
 
-Remove output file if an error occurs. If curl returns an error when told to
+Remove the output file if an error occurs. If curl returns an error when told to
 save output in a local file. This prevents curl from leaving a partial file in
 the case of an error during transfer.
 

--- a/docs/cmdline-opts/request-target.md
+++ b/docs/cmdline-opts/request-target.md
@@ -21,5 +21,5 @@ URL. Particularly useful when wanting to issue HTTP requests without leading
 slash or other data that does not follow the regular URL pattern, like
 "OPTIONS *".
 
-curl passes on the verbatim string you give it its the request without any
+curl passes on the verbatim string you give it in the request without any
 filter or other safe guards. That includes white space and control characters.

--- a/docs/cmdline-opts/retry-all-errors.md
+++ b/docs/cmdline-opts/retry-all-errors.md
@@ -31,7 +31,7 @@ file, which are not reset. We strongly suggest you do not parse or record
 output via redirect in combination with this option, since you may receive
 duplicate data.
 
-By default curl does not return error for transfers with an HTTP response code
+By default curl does not return an error for transfers with an HTTP response code
 that indicates an HTTP error, if the transfer was successful. For example, if
 a server replies 404 Not Found and the reply is fully received then that is
 not an error. When --retry is used then curl retries on some HTTP response

--- a/docs/cmdline-opts/show-headers.md
+++ b/docs/cmdline-opts/show-headers.md
@@ -27,7 +27,7 @@ the data. --dump-header exists to save headers in a separate stream.
 To view the request headers, consider the --verbose option.
 
 Prior to 7.75.0 curl did not print the headers if --fail was used in
-combination with this option and there was error reported by server.
+combination with this option and there was an error reported by the server.
 
 This option was called --include before 8.10.0. The previous name remains
 functional.

--- a/docs/cmdline-opts/socks4.md
+++ b/docs/cmdline-opts/socks4.md
@@ -18,8 +18,8 @@ Example:
 # `--socks4`
 
 Use the specified SOCKS4 proxy. If the port number is not specified, it is
-assumed at port 1080. Using this socket type make curl resolve the hostname
-and passing the address on to the proxy.
+assumed at port 1080. Using this socket type makes curl resolve the hostname
+and pass the address on to the proxy.
 
 To specify proxy on a Unix domain socket, use localhost for host, e.g.
 `socks4://localhost/path/to/socket.sock`

--- a/docs/cmdline-opts/ssl-sessions.md
+++ b/docs/cmdline-opts/ssl-sessions.md
@@ -18,7 +18,7 @@ Example:
 
 Use the given file to load SSL session tickets into curl's cache before
 starting any transfers. At the end of a successful curl run, the cached
-SSL sessions tickets are save to the file, replacing any previous content.
+SSL sessions tickets are saved to the file, replacing any previous content.
 
 The file does not have to exist, but curl reports an error if it is
 unable to create it. Unused loaded tickets are saved again, unless they
@@ -31,5 +31,5 @@ not provide forward secrecy, e.g. is not as secure.
 
 The SSL session tickets are stored as base64 encoded text, each ticket on
 its own line. The hostnames are cryptographically salted and hashed. While
-this prevents someone to easily see the hosts you contacted, they could still
-check if a specific hostname matches one of the values.
+this prevents someone from easily seeing the hosts you contacted, they could
+still check if a specific hostname matches one of the values.

--- a/docs/cmdline-opts/suppress-connect-headers.md
+++ b/docs/cmdline-opts/suppress-connect-headers.md
@@ -16,7 +16,7 @@ Example:
 
 # `--suppress-connect-headers`
 
-When --proxytunnel is used and a CONNECT request is made do not output proxy
+When --proxytunnel is used and a CONNECT request is made, do not output proxy
 CONNECT response headers. This option is meant to be used with --dump-header
 or --show-headers which are used to show protocol headers in the output. It
 has no effect on debug options such as --verbose or --trace, or any

--- a/docs/cmdline-opts/tcp-fastopen.md
+++ b/docs/cmdline-opts/tcp-fastopen.md
@@ -15,5 +15,5 @@ Example:
 # `--tcp-fastopen`
 
 Enable use of TCP Fast Open (RFC 7413). TCP Fast Open is a TCP extension that
-allows data to get sent earlier over the connection (before the final
+allows data to be sent earlier over the connection (before the final
 handshake ACK) if the client and server have been connected previously.

--- a/docs/cmdline-opts/tftp-no-options.md
+++ b/docs/cmdline-opts/tftp-no-options.md
@@ -15,6 +15,6 @@ Example:
 
 # `--tftp-no-options`
 
-Do not to send TFTP options requests. This improves interop with some legacy
+Do not send TFTP options requests. This improves interop with some legacy
 servers that do not acknowledge or properly implement TFTP options. When this
 option is used --tftp-blksize is ignored.

--- a/docs/cmdline-opts/tls-max.md
+++ b/docs/cmdline-opts/tls-max.md
@@ -29,7 +29,7 @@ If the connection is done without TLS, this option has no effect. This
 includes QUIC-using (HTTP/3) transfers.
 
 ## default
-Use up to recommended TLS version.
+Use up to the recommended TLS version.
 
 ## 1.0
 Use up to TLSv1.0.

--- a/docs/cmdline-opts/url.md
+++ b/docs/cmdline-opts/url.md
@@ -37,7 +37,7 @@ On Windows, `file://` accesses can be converted to network accesses by the
 operating system.
 
 Starting in curl 8.13.0, curl can be told to download URLs provided in a text
-file, one URL per line. It is done by with `--url @filename`: so instead of a
+file, one URL per line. It is done with `--url @filename`: so instead of a
 URL, you specify a filename prefixed with the `@` symbol. It can be told to
 load the list of URLs from stdin by providing an argument like `@-`.
 

--- a/docs/cmdline-opts/user.md
+++ b/docs/cmdline-opts/user.md
@@ -29,8 +29,8 @@ still.
 On systems where it works, curl hides the given option argument from process
 listings. This is not enough to protect credentials from possibly getting seen
 by other users on the same system as they still are visible for a moment
-before cleared. Such sensitive data should be retrieved from a file instead or
-similar and never used in clear text in a command line.
+before being cleared. Such sensitive data should be retrieved from a file
+instead or similar and never used in clear text in a command line.
 
 When using Kerberos V5 with a Windows based server you should include the
 Windows domain name in the username, in order for the server to successfully

--- a/docs/cmdline-opts/variable.md
+++ b/docs/cmdline-opts/variable.md
@@ -61,7 +61,7 @@ When expanding variables, curl supports a set of functions that can make the
 variable contents more convenient to use. You apply a function to a variable
 expansion by adding a colon and then list the desired functions in a
 comma-separated list that is evaluated in a left-to-right order. Variable
-content holding null bytes that are not encoded when expanded, causes an
+content holding null bytes that are not encoded when expanded causes an
 error.
 
 Available functions:

--- a/docs/cmdline-opts/verbose.md
+++ b/docs/cmdline-opts/verbose.md
@@ -37,13 +37,13 @@ verbosity when the option is mentioned in the command line *and* curl config
 files.
 
 Using it twice, e.g. `-vv`, outputs time (--trace-time) and transfer ids
-(--trace-ids), as well as enable tracing for all protocols (--trace-config
+(--trace-ids), as well as enabling tracing for all protocols (--trace-config
 protocol).
 
-Adding a third verbose outputs transfer content (--trace-ascii %) and enable
+Adding a third verbose outputs transfer content (--trace-ascii %) and enables
 tracing of more components (--trace-config read,write,ssl).
 
-A forth time adds tracing of all network components. (--trace-config network).
+A fourth time adds tracing of all network components. (--trace-config network).
 
 Any addition of the verbose option after that has no effect.
 

--- a/docs/cmdline-opts/version.md
+++ b/docs/cmdline-opts/version.md
@@ -28,7 +28,7 @@ particular backend to use for this invocation.
 If curl supports more than one TLS library like this, the ones that are *not*
 selected by default are listed within parentheses. Thus, if you do not specify
 which backend to use (with the `CURL_SSL_BACKEND` environment variable) the
-one listed without parentheses is used. Such builds also has `MultiSSL` set as
+one listed without parentheses is used. Such builds also have `MultiSSL` set as
 a feature.
 
 The second line (starts with `Release-Date:`) shows the release date.

--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -255,7 +255,7 @@ started. `time_redirect` shows the complete execution time for multiple
 redirections. (Added in 7.12.3)
 
 ## `time_starttransfer`
-The time, in seconds, it took from the start until the first byte is received.
+The time, in seconds, it took from the start until the first byte was received.
 This includes time_pretransfer and also the time the server needed to calculate
 the result.
 


### PR DESCRIPTION
 After Gmail called out the typo I fixed on
 532d89a866b5641d380a88144270b1c3ca6ba84e, I've decided to paste the
 whole man page into Google docs and check what other issues it would
 spot.

 I know, it sounds silly, but I've just spent the last hour and a half
 going over each one of them and fixing everything which was a true
 finding and non-controversial.