### PR TITLE
wolfssl: fix sending of early data

### DIFF
--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -574,6 +574,7 @@ wssl_setup_session(struct Curl_cfilter *cf,
             if(result)
               goto  out;
           }
+#ifdef WOLFSSL_EARLY_DATA
           if(do_early_data) {
             unsigned int edmax = (scs->earlydata_max < UINT_MAX) ?
                                  (unsigned int)scs->earlydata_max : UINT_MAX;
@@ -582,6 +583,10 @@ wssl_setup_session(struct Curl_cfilter *cf,
             Curl_alpn_restrict_to(alpns, scs->alpn);
             wolfSSL_set_max_early_data(wss->ssl, edmax);
           }
+#else
+          /* Should never enable when not supported */
+          DEBUGASSERT(!do_early_data);
+#endif
         }
       }
       wolfSSL_SESSION_free(session);

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -575,9 +575,12 @@ wssl_setup_session(struct Curl_cfilter *cf,
               goto  out;
           }
           if(do_early_data) {
+            unsigned int edmax = (scs->earlydata_max < UINT_MAX) ?
+                                 (unsigned int)scs->earlydata_max : UINT_MAX;
             /* We only try the ALPN protocol the session used before,
              * otherwise we might send early data for the wrong protocol */
             Curl_alpn_restrict_to(alpns, scs->alpn);
+            wolfSSL_set_max_early_data(wss->ssl, edmax);
           }
         }
       }
@@ -930,14 +933,6 @@ wssl_legacy_CTX_set_max_proto_version(WOLFSSL_CTX* ctx, int version)
   "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_"               \
   "POLY1305_SHA256:TLS_AES_128_CCM_SHA256"
 #define QUIC_GROUPS "P-256:P-384:P-521"
-
-#if defined(HAVE_SECRET_CALLBACK)
-static void keylog_callback(const WOLFSSL *ssl, const char *line)
-{
-  (void)ssl;
-  Curl_tls_keylog_write_line(line);
-}
-#endif
 
 CURLcode Curl_wssl_ctx_init(struct wssl_ctx *wctx,
                             struct Curl_cfilter *cf,


### PR DESCRIPTION
Early data was reported as being sent, but was not. While everything was aligned with the Gods and early data was reported as accepted, the actual sending required another call to wolfSSL.

refs #17481