### PR TITLE
Test client authentication (mtls) with --insecure

### DIFF
--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -253,7 +253,7 @@ test2056 test2057 test2058 test2059 test2060 test2061 test2062 test2063 \
 test2064 test2065 test2066 test2067 test2068 test2069 test2070 test2071 \
 test2072 test2073 test2074 test2075 test2076 test2077 test2078 test2079 \
 test2080 test2081 test2082 test2083 test2084 test2085 test2086 test2087 \
-test2088 \
+test2088 test2089 \
 test2100 test2101 test2102 \
 \
 test2200 test2201 test2202 test2203 test2204 test2205 \

--- a/tests/data/test2089
+++ b/tests/data/test2089
@@ -1,0 +1,55 @@
+<testcase>
+<info>
+<keywords>
+HTTPS
+HTTP GET
+Client Auth
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data>
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Content-Length: 7
+
+MooMoo
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<features>
+SSL
+!Schannel
+!sectransp
+!bearssl
+local-http
+</features>
+<server>
+https-mtls
+</server>
+<name>
+HTTPS GET with client authentication (mtls) and --insecure
+</name>
+<command>
+--insecure --cert %CERTDIR/certs/test-client-cert.crt --key %CERTDIR/certs/test-client-cert.key https://localhost:%HTTPS-MTLSPORT/%TESTNUMBER
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: localhost:%HTTPS-MTLSPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+</verify>
+</testcase>

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -1024,6 +1024,7 @@ sub verifytelnet {
 
 my %protofunc = ('http' => \&verifyhttp,
                  'https' => \&verifyhttp,
+                 'https-mtls' => \&verifypid,
                  'rtsp' => \&verifyrtsp,
                  'ftp' => \&verifyftp,
                  'pop3' => \&verifyftp,
@@ -2352,7 +2353,7 @@ sub startservers {
         $what =~ s/[^a-z0-9\/-]//g;
 
         my $certfile;
-        if($what =~ /^(ftp|gopher|http|imap|pop3|smtp)s((\d*)(-ipv6|-unix|))$/) {
+        if($what =~ /^(ftp|gopher|http|imap|pop3|smtp)s|https-mtls((\d*)(-ipv6|-unix|))$/) {
             $certfile = ($whatlist[1]) ? $whatlist[1] : 'certs/test-localhost.pem';
         }
 


### PR DESCRIPTION
Doing this I found this issue, described in the first commit:
If there were two tests using the "https-mtls" server there was a perl unbound variable error, since certfile wan't set.
Additionally, once the responsiveserver function was actually called, it failed finding a responsiveness function. For now I made it use the `verifypid` function, since the curl execution in `verifyhttp` doesn't know about client certificates.
