### PR TITLE
system.h: remove some macros

### DIFF
--- a/docs/libcurl/symbols-in-versions
+++ b/docs/libcurl/symbols-in-versions
@@ -68,7 +68,7 @@ CURL_IGNORE_DEPRECATION         7.87.0
 CURL_IPRESOLVE_V4               7.10.8
 CURL_IPRESOLVE_V6               7.10.8
 CURL_IPRESOLVE_WHATEVER         7.10.8
-CURL_ISOCPP                     7.10.2
+CURL_ISOCPP                     7.10.2        -           8.14.1
 CURL_LOCK_ACCESS_NONE           7.10.3
 CURL_LOCK_ACCESS_SHARED         7.10.3
 CURL_LOCK_ACCESS_SINGLE         7.10.3

--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -357,11 +357,11 @@
 
 #else
 /* generic "safe guess" on old 32-bit style */
-#  define CURL_TYPEOF_CURL_OFF_T     long
-#  define CURL_FORMAT_CURL_OFF_T     "ld"
-#  define CURL_FORMAT_CURL_OFF_TU    "lu"
-#  define CURL_SUFFIX_CURL_OFF_T     L
-#  define CURL_SUFFIX_CURL_OFF_TU    UL
+#  define CURL_TYPEOF_CURL_OFF_T     long long
+#  define CURL_FORMAT_CURL_OFF_T     "lld"
+#  define CURL_FORMAT_CURL_OFF_TU    "llu"
+#  define CURL_SUFFIX_CURL_OFF_T     LL
+#  define CURL_SUFFIX_CURL_OFF_TU    ULL
 #  define CURL_TYPEOF_CURL_SOCKLEN_T int
 #endif
 
@@ -397,54 +397,6 @@
 
 #ifdef CURL_TYPEOF_CURL_OFF_T
   typedef CURL_TYPEOF_CURL_OFF_T curl_off_t;
-#endif
-
-/*
- * CURL_ISOCPP and CURL_OFF_T_C definitions are done here in order to allow
- * these to be visible and exported by the external libcurl interface API,
- * while also making them visible to the library internals, simply including
- * curl_setup.h, without actually needing to include curl.h internally.
- * If some day this section would grow big enough, all this should be moved
- * to its own header file.
- */
-
-/*
- * Figure out if we can use the ## preprocessor operator, which is supported
- * by ISO/ANSI C and C++. Some compilers support it without setting __STDC__
- * or  __cplusplus so we need to carefully check for them too.
- */
-
-#if defined(__STDC__) || defined(_MSC_VER) || defined(__cplusplus) || \
-  defined(__HP_aCC) || defined(__BORLANDC__) || defined(__LCC__) || \
-  defined(__POCC__) || defined(__HIGHC__) || \
-  defined(__ILEC400__)
-  /* This compiler is believed to have an ISO compatible preprocessor */
-#define CURL_ISOCPP
-#else
-  /* This compiler is believed NOT to have an ISO compatible preprocessor */
-#undef CURL_ISOCPP
-#endif
-
-/*
- * Macros for minimum-width signed and unsigned curl_off_t integer constants.
- */
-
-#if defined(__BORLANDC__) && (__BORLANDC__ == 0x0551)
-#  define CURLINC_OFF_T_C_HLPR2(x) x
-#  define CURLINC_OFF_T_C_HLPR1(x) CURLINC_OFF_T_C_HLPR2(x)
-#  define CURL_OFF_T_C(Val)  CURLINC_OFF_T_C_HLPR1(Val) ## \
-                             CURLINC_OFF_T_C_HLPR1(CURL_SUFFIX_CURL_OFF_T)
-#  define CURL_OFF_TU_C(Val) CURLINC_OFF_T_C_HLPR1(Val) ## \
-                             CURLINC_OFF_T_C_HLPR1(CURL_SUFFIX_CURL_OFF_TU)
-#else
-#  ifdef CURL_ISOCPP
-#    define CURLINC_OFF_T_C_HLPR2(Val,Suffix) Val ## Suffix
-#  else
-#    define CURLINC_OFF_T_C_HLPR2(Val,Suffix) Val/**/Suffix
-#  endif
-#  define CURLINC_OFF_T_C_HLPR1(Val,Suffix) CURLINC_OFF_T_C_HLPR2(Val,Suffix)
-#  define CURL_OFF_T_C(Val)  CURLINC_OFF_T_C_HLPR1(Val,CURL_SUFFIX_CURL_OFF_T)
-#  define CURL_OFF_TU_C(Val) CURLINC_OFF_T_C_HLPR1(Val,CURL_SUFFIX_CURL_OFF_TU)
 #endif
 
 #endif /* CURLINC_SYSTEM_H */

--- a/lib/curl_ntlm_core.c
+++ b/lib/curl_ntlm_core.c
@@ -466,7 +466,7 @@ struct ms_filetime {
 static void time2filetime(struct ms_filetime *ft, time_t t)
 {
 #if SIZEOF_TIME_T > 4
-  t = (t + CURL_OFF_T_C(11644473600)) * 10000000;
+  t = (t + (curl_off_t)11644473600) * 10000000;
   ft->dwLowDateTime = (unsigned int) (t & 0xFFFFFFFF);
   ft->dwHighDateTime = (unsigned int) (t >> 32);
 #else

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -590,9 +590,9 @@
 #error "too small curl_off_t"
 #else
    /* assume SIZEOF_CURL_OFF_T == 8 */
-#  define CURL_OFF_T_MAX CURL_OFF_T_C(0x7FFFFFFFFFFFFFFF)
+#  define CURL_OFF_T_MAX 0x7FFFFFFFFFFFFFFF
 #endif
-#define CURL_OFF_T_MIN (-CURL_OFF_T_MAX - CURL_OFF_T_C(1))
+#define CURL_OFF_T_MIN (-CURL_OFF_T_MAX - 1)
 
 #if (SIZEOF_CURL_OFF_T != 8)
 #  error "curl_off_t must be exactly 64 bits"

--- a/lib/progress.c
+++ b/lib/progress.c
@@ -44,18 +44,18 @@ static void time2str(char *r, curl_off_t seconds)
     strcpy(r, "--:--:--");
     return;
   }
-  h = seconds / CURL_OFF_T_C(3600);
-  if(h <= CURL_OFF_T_C(99)) {
-    curl_off_t m = (seconds - (h*CURL_OFF_T_C(3600))) / CURL_OFF_T_C(60);
-    curl_off_t s = (seconds - (h*CURL_OFF_T_C(3600))) - (m*CURL_OFF_T_C(60));
+  h = seconds / 3600;
+  if(h <= 99) {
+    curl_off_t m = (seconds - (h * 3600)) / 60;
+    curl_off_t s = (seconds - (h * 3600)) - (m * 60);
     msnprintf(r, 9, "%2" FMT_OFF_T ":%02" FMT_OFF_T ":%02" FMT_OFF_T, h, m, s);
   }
   else {
     /* this equals to more than 99 hours, switch to a more suitable output
        format to fit within the limits. */
-    curl_off_t d = seconds / CURL_OFF_T_C(86400);
-    h = (seconds - (d*CURL_OFF_T_C(86400))) / CURL_OFF_T_C(3600);
-    if(d <= CURL_OFF_T_C(999))
+    curl_off_t d = seconds / 86400;
+    h = (seconds - (d * 86400)) / 3600;
+    if(d <= 999)
       msnprintf(r, 9, "%3" FMT_OFF_T "d %02" FMT_OFF_T "h", d, h);
     else
       msnprintf(r, 9, "%7" FMT_OFF_T "d", d);
@@ -67,39 +67,39 @@ static void time2str(char *r, curl_off_t seconds)
    Add suffix k, M, G when suitable... */
 static char *max5data(curl_off_t bytes, char *max5)
 {
-#define ONE_KILOBYTE  CURL_OFF_T_C(1024)
-#define ONE_MEGABYTE (CURL_OFF_T_C(1024) * ONE_KILOBYTE)
-#define ONE_GIGABYTE (CURL_OFF_T_C(1024) * ONE_MEGABYTE)
-#define ONE_TERABYTE (CURL_OFF_T_C(1024) * ONE_GIGABYTE)
-#define ONE_PETABYTE (CURL_OFF_T_C(1024) * ONE_TERABYTE)
+#define ONE_KILOBYTE (curl_off_t)1024
+#define ONE_MEGABYTE (1024 * ONE_KILOBYTE)
+#define ONE_GIGABYTE (1024 * ONE_MEGABYTE)
+#define ONE_TERABYTE (1024 * ONE_GIGABYTE)
+#define ONE_PETABYTE (1024 * ONE_TERABYTE)
 
-  if(bytes < CURL_OFF_T_C(100000))
+  if(bytes < 100000)
     msnprintf(max5, 6, "%5" FMT_OFF_T, bytes);
 
-  else if(bytes < CURL_OFF_T_C(10000) * ONE_KILOBYTE)
+  else if(bytes < 10000 * ONE_KILOBYTE)
     msnprintf(max5, 6, "%4" FMT_OFF_T "k", bytes/ONE_KILOBYTE);
 
-  else if(bytes < CURL_OFF_T_C(100) * ONE_MEGABYTE)
+  else if(bytes < 100 * ONE_MEGABYTE)
     /* 'XX.XM' is good as long as we are less than 100 megs */
     msnprintf(max5, 6, "%2" FMT_OFF_T ".%0"
               FMT_OFF_T "M", bytes/ONE_MEGABYTE,
-              (bytes%ONE_MEGABYTE) / (ONE_MEGABYTE/CURL_OFF_T_C(10)) );
+              (bytes%ONE_MEGABYTE) / (ONE_MEGABYTE/10) );
 
-  else if(bytes < CURL_OFF_T_C(10000) * ONE_MEGABYTE)
+  else if(bytes < 10000 * ONE_MEGABYTE)
     /* 'XXXXM' is good until we are at 10000MB or above */
     msnprintf(max5, 6, "%4" FMT_OFF_T "M", bytes/ONE_MEGABYTE);
 
-  else if(bytes < CURL_OFF_T_C(100) * ONE_GIGABYTE)
+  else if(bytes < 100 * ONE_GIGABYTE)
     /* 10000 MB - 100 GB, we show it as XX.XG */
     msnprintf(max5, 6, "%2" FMT_OFF_T ".%0"
               FMT_OFF_T "G", bytes/ONE_GIGABYTE,
-              (bytes%ONE_GIGABYTE) / (ONE_GIGABYTE/CURL_OFF_T_C(10)) );
+              (bytes%ONE_GIGABYTE) / (ONE_GIGABYTE/10) );
 
-  else if(bytes < CURL_OFF_T_C(10000) * ONE_GIGABYTE)
+  else if(bytes < 10000 * ONE_GIGABYTE)
     /* up to 10000GB, display without decimal: XXXXG */
     msnprintf(max5, 6, "%4" FMT_OFF_T "G", bytes/ONE_GIGABYTE);
 
-  else if(bytes < CURL_OFF_T_C(10000) * ONE_TERABYTE)
+  else if(bytes < 10000 * ONE_TERABYTE)
     /* up to 10000TB, display without decimal: XXXXT */
     msnprintf(max5, 6, "%4" FMT_OFF_T "T", bytes/ONE_TERABYTE);
 
@@ -296,7 +296,7 @@ timediff_t Curl_pgrsLimitWaitTime(struct pgrs_dir *d,
    * stay below 'limit'.
    */
   if(size < CURL_OFF_T_MAX/1000)
-    minimum = (timediff_t) (CURL_OFF_T_C(1000) * size / speed_limit);
+    minimum = (timediff_t) (1000 * size / speed_limit);
   else {
     minimum = (timediff_t) (size / speed_limit);
     if(minimum < TIMEDIFF_T_MAX/1000)
@@ -455,7 +455,7 @@ static bool progress_calc(struct Curl_easy *data, struct curltime now)
       /* Calculate the average speed the last 'span_ms' milliseconds */
       amount = p->speeder[nowindex]- p->speeder[checkindex];
 
-      if(amount > CURL_OFF_T_C(4294967) /* 0xffffffff/1000 */)
+      if(amount > (0xffffffff/1000))
         /* the 'amount' value is bigger than would fit in 32 bits if
            multiplied with 1000, so we use the double math for this */
         p->current_speed = (curl_off_t)
@@ -463,7 +463,7 @@ static bool progress_calc(struct Curl_easy *data, struct curltime now)
       else
         /* the 'amount' value is small enough to fit within 32 bits even
            when multiplied with 1000 */
-        p->current_speed = amount*CURL_OFF_T_C(1000)/span_ms;
+        p->current_speed = amount * 1000/span_ms;
     }
     else
       /* the first second we use the average */
@@ -482,9 +482,9 @@ struct pgrs_estimate {
 
 static curl_off_t pgrs_est_percent(curl_off_t total, curl_off_t cur)
 {
-  if(total > CURL_OFF_T_C(10000))
-    return cur / (total/CURL_OFF_T_C(100));
-  else if(total > CURL_OFF_T_C(0))
+  if(total > 10000)
+    return cur / (total / 100);
+  else if(total > 0)
     return (cur*100) / total;
   return 0;
 }
@@ -495,7 +495,7 @@ static void pgrs_estimates(struct pgrs_dir *d,
 {
   est->secs = 0;
   est->percent = 0;
-  if(total_known && (d->speed > CURL_OFF_T_C(0))) {
+  if(total_known && (d->speed > 0)) {
     est->secs = d->total_size / d->speed;
     est->percent = pgrs_est_percent(d->total_size, d->cur_size);
   }

--- a/lib/smb.c
+++ b/lib/smb.c
@@ -999,8 +999,8 @@ static CURLcode smb_connection_state(struct Curl_easy *data, bool *done)
  */
 static void get_posix_time(time_t *out, curl_off_t timestamp)
 {
-  if(timestamp >= CURL_OFF_T_C(116444736000000000)) {
-    timestamp -= CURL_OFF_T_C(116444736000000000);
+  if(timestamp >= (curl_off_t)116444736000000000) {
+    timestamp -= (curl_off_t)116444736000000000;
     timestamp /= 10000000;
 #if SIZEOF_TIME_T < SIZEOF_CURL_OFF_T
     if(timestamp > TIME_T_MAX)

--- a/lib/uint-bset.c
+++ b/lib/uint-bset.c
@@ -183,11 +183,11 @@ unsigned int Curl_popcount64(curl_uint64_t x)
   /* Compute the "Hamming Distance" between 'x' and 0,
    * which is the number of set bits in 'x'.
    * See: https://en.wikipedia.org/wiki/Hamming_weight */
-  const curl_uint64_t m1  = CURL_OFF_TU_C(0x5555555555555555); /* 0101+ */
-  const curl_uint64_t m2  = CURL_OFF_TU_C(0x3333333333333333); /* 00110011+ */
-  const curl_uint64_t m4  = CURL_OFF_TU_C(0x0f0f0f0f0f0f0f0f); /* 00001111+ */
+  const curl_uint64_t m1  = 0x5555555555555555LL; /* 0101+ */
+  const curl_uint64_t m2  = 0x3333333333333333LL; /* 00110011+ */
+  const curl_uint64_t m4  = 0x0f0f0f0f0f0f0f0fLL; /* 00001111+ */
    /* 1 + 256^1 + 256^2 + 256^3 + ... + 256^7 */
-  const curl_uint64_t h01 = CURL_OFF_TU_C(0x0101010101010101);
+  const curl_uint64_t h01 = 0x0101010101010101LL;
   x -= (x >> 1) & m1;             /* replace every 2 bits with bits present */
   x = (x & m2) + ((x >> 2) & m2); /* replace every nibble with bits present */
   x = (x + (x >> 4)) & m4;        /* replace every byte with bits present */
@@ -203,11 +203,11 @@ unsigned int Curl_ctz64(curl_uint64_t x)
 {
   /* count trailing zeros in a curl_uint64_t.
    * divide and conquer to find the number of lower 0 bits */
-  const curl_uint64_t ml32 = CURL_OFF_TU_C(0xFFFFFFFF); /* lower 32 bits */
-  const curl_uint64_t ml16 = CURL_OFF_TU_C(0x0000FFFF); /* lower 16 bits */
-  const curl_uint64_t ml8  = CURL_OFF_TU_C(0x000000FF); /* lower 8 bits */
-  const curl_uint64_t ml4  = CURL_OFF_TU_C(0x0000000F); /* lower 4 bits */
-  const curl_uint64_t ml2  = CURL_OFF_TU_C(0x00000003); /* lower 2 bits */
+  const curl_uint64_t ml32 = 0xFFFFFFFF; /* lower 32 bits */
+  const curl_uint64_t ml16 = 0x0000FFFF; /* lower 16 bits */
+  const curl_uint64_t ml8  = 0x000000FF; /* lower 8 bits */
+  const curl_uint64_t ml4  = 0x0000000F; /* lower 4 bits */
+  const curl_uint64_t ml2  = 0x00000003; /* lower 2 bits */
   unsigned int n;
 
   if(!x)

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -937,7 +937,7 @@ CURLcode config2setopts(struct GlobalConfig *global,
   if(config->use_resume)
     my_setopt_offt(curl, CURLOPT_RESUME_FROM_LARGE, config->resume_from);
   else
-    my_setopt_offt(curl, CURLOPT_RESUME_FROM_LARGE, CURL_OFF_T_C(0));
+    my_setopt_offt(curl, CURLOPT_RESUME_FROM_LARGE, 0);
 
   my_setopt_str(curl, CURLOPT_KEYPASSWD, config->key_passwd);
   my_setopt_str(curl, CURLOPT_PROXY_KEYPASSWD, config->proxy_key_passwd);

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -115,7 +115,7 @@ static void fly(struct ProgressData *bar, bool moved)
 #error "too small curl_off_t"
 #else
    /* assume SIZEOF_CURL_OFF_T == 8 */
-#  define CURL_OFF_T_MAX CURL_OFF_T_C(0x7FFFFFFFFFFFFFFF)
+#  define CURL_OFF_T_MAX 0x7FFFFFFFFFFFFFFF
 #endif
 
 static void update_width(struct ProgressData *bar)

--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -49,7 +49,7 @@ int tool_seek_cb(void *userdata, curl_off_t offset, int whence)
    using a 'long' data type offset */
 
 #define OUR_MAX_SEEK_L  2147483647L - 1L
-#define OUR_MAX_SEEK_O  CURL_OFF_T_C(0x7FFFFFFF) - CURL_OFF_T_C(0x1)
+#define OUR_MAX_SEEK_O  0x7FFFFFFF - 0x1
 
   /* The offset check following here is only interesting if curl_off_t is
      larger than off_t and we are not using the Win32 large file support

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -46,9 +46,9 @@ int getfiletime(const char *filename, struct GlobalConfig *global,
   TCHAR *tchar_filename = curlx_convert_UTF8_to_tchar(filename);
 
   hfile = CreateFile(tchar_filename, FILE_READ_ATTRIBUTES,
-                      (FILE_SHARE_READ | FILE_SHARE_WRITE |
-                       FILE_SHARE_DELETE),
-                      NULL, OPEN_EXISTING, 0, NULL);
+                     (FILE_SHARE_READ | FILE_SHARE_WRITE |
+                      FILE_SHARE_DELETE),
+                     NULL, OPEN_EXISTING, 0, NULL);
   curlx_unicodefree(tchar_filename);
   if(hfile != INVALID_HANDLE_VALUE) {
     FILETIME ft;
@@ -56,10 +56,10 @@ int getfiletime(const char *filename, struct GlobalConfig *global,
       curl_off_t converted = (curl_off_t)ft.dwLowDateTime
         | ((curl_off_t)ft.dwHighDateTime) << 32;
 
-      if(converted < CURL_OFF_T_C(116444736000000000))
+      if(converted < 116444736000000000)
         warnf(global, "Failed to get filetime: underflow");
       else {
-        *stamp = (converted - CURL_OFF_T_C(116444736000000000)) / 10000000;
+        *stamp = (converted - 116444736000000000) / 10000000;
         rc = 0;
       }
     }
@@ -101,7 +101,7 @@ void setfiletime(curl_off_t filetime, const char *filename,
 
     /* 910670515199 is the maximum Unix filetime that can be used as a
        Windows FILETIME without overflow: 30827-12-31T23:59:59. */
-    if(filetime > CURL_OFF_T_C(910670515199)) {
+    if(filetime > 910670515199) {
       warnf(global, "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
             " on outfile: overflow", filetime);
       curlx_unicodefree(tchar_filename);
@@ -115,7 +115,7 @@ void setfiletime(curl_off_t filetime, const char *filename,
     curlx_unicodefree(tchar_filename);
     if(hfile != INVALID_HANDLE_VALUE) {
       curl_off_t converted = ((curl_off_t)filetime * 10000000) +
-        CURL_OFF_T_C(116444736000000000);
+        116444736000000000;
       FILETIME ft;
       ft.dwLowDateTime = (DWORD)(converted & 0xFFFFFFFF);
       ft.dwHighDateTime = (DWORD)(converted >> 32);

--- a/src/tool_progress.c
+++ b/src/tool_progress.c
@@ -32,39 +32,39 @@
    Add suffix k, M, G when suitable... */
 static char *max5data(curl_off_t bytes, char *max5)
 {
-#define ONE_KILOBYTE  CURL_OFF_T_C(1024)
-#define ONE_MEGABYTE (CURL_OFF_T_C(1024) * ONE_KILOBYTE)
-#define ONE_GIGABYTE (CURL_OFF_T_C(1024) * ONE_MEGABYTE)
-#define ONE_TERABYTE (CURL_OFF_T_C(1024) * ONE_GIGABYTE)
-#define ONE_PETABYTE (CURL_OFF_T_C(1024) * ONE_TERABYTE)
+#define ONE_KILOBYTE (curl_off_t)1024
+#define ONE_MEGABYTE (1024 * ONE_KILOBYTE)
+#define ONE_GIGABYTE (1024 * ONE_MEGABYTE)
+#define ONE_TERABYTE (1024 * ONE_GIGABYTE)
+#define ONE_PETABYTE (1024 * ONE_TERABYTE)
 
-  if(bytes < CURL_OFF_T_C(100000))
+  if(bytes < 100000)
     msnprintf(max5, 6, "%5" CURL_FORMAT_CURL_OFF_T, bytes);
 
-  else if(bytes < CURL_OFF_T_C(10000) * ONE_KILOBYTE)
+  else if(bytes < 10000 * ONE_KILOBYTE)
     msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "k", bytes/ONE_KILOBYTE);
 
-  else if(bytes < CURL_OFF_T_C(100) * ONE_MEGABYTE)
+  else if(bytes < 100 * ONE_MEGABYTE)
     /* 'XX.XM' is good as long as we are less than 100 megs */
     msnprintf(max5, 6, "%2" CURL_FORMAT_CURL_OFF_T ".%0"
               CURL_FORMAT_CURL_OFF_T "M", bytes/ONE_MEGABYTE,
-              (bytes%ONE_MEGABYTE) / (ONE_MEGABYTE/CURL_OFF_T_C(10)) );
+              (bytes%ONE_MEGABYTE) / (ONE_MEGABYTE/10) );
 
-  else if(bytes < CURL_OFF_T_C(10000) * ONE_MEGABYTE)
+  else if(bytes < 10000 * ONE_MEGABYTE)
     /* 'XXXXM' is good until we are at 10000MB or above */
     msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "M", bytes/ONE_MEGABYTE);
 
-  else if(bytes < CURL_OFF_T_C(100) * ONE_GIGABYTE)
+  else if(bytes < 100 * ONE_GIGABYTE)
     /* 10000 MB - 100 GB, we show it as XX.XG */
     msnprintf(max5, 6, "%2" CURL_FORMAT_CURL_OFF_T ".%0"
               CURL_FORMAT_CURL_OFF_T "G", bytes/ONE_GIGABYTE,
-              (bytes%ONE_GIGABYTE) / (ONE_GIGABYTE/CURL_OFF_T_C(10)) );
+              (bytes%ONE_GIGABYTE) / (ONE_GIGABYTE/10) );
 
-  else if(bytes < CURL_OFF_T_C(10000) * ONE_GIGABYTE)
+  else if(bytes < 10000 * ONE_GIGABYTE)
     /* up to 10000GB, display without decimal: XXXXG */
     msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "G", bytes/ONE_GIGABYTE);
 
-  else if(bytes < CURL_OFF_T_C(10000) * ONE_TERABYTE)
+  else if(bytes < 10000 * ONE_TERABYTE)
     /* up to 10000TB, display without decimal: XXXXT */
     msnprintf(max5, 6, "%4" CURL_FORMAT_CURL_OFF_T "T", bytes/ONE_TERABYTE);
 
@@ -110,19 +110,19 @@ static void time2str(char *r, curl_off_t seconds)
     strcpy(r, "--:--:--");
     return;
   }
-  h = seconds / CURL_OFF_T_C(3600);
-  if(h <= CURL_OFF_T_C(99)) {
-    curl_off_t m = (seconds - (h*CURL_OFF_T_C(3600))) / CURL_OFF_T_C(60);
-    curl_off_t s = (seconds - (h*CURL_OFF_T_C(3600))) - (m*CURL_OFF_T_C(60));
+  h = seconds / 3600;
+  if(h <= 99) {
+    curl_off_t m = (seconds - (h * 3600)) / 60;
+    curl_off_t s = (seconds - (h * 3600)) - (m * 60);
     msnprintf(r, 9, "%2" CURL_FORMAT_CURL_OFF_T ":%02" CURL_FORMAT_CURL_OFF_T
               ":%02" CURL_FORMAT_CURL_OFF_T, h, m, s);
   }
   else {
     /* this equals to more than 99 hours, switch to a more suitable output
        format to fit within the limits. */
-    curl_off_t d = seconds / CURL_OFF_T_C(86400);
-    h = (seconds - (d*CURL_OFF_T_C(86400))) / CURL_OFF_T_C(3600);
-    if(d <= CURL_OFF_T_C(999))
+    curl_off_t d = seconds / 86400;
+    h = (seconds - (d * 86400)) / 3600;
+    if(d <= 999)
       msnprintf(r, 9, "%3" CURL_FORMAT_CURL_OFF_T
                 "d %02" CURL_FORMAT_CURL_OFF_T "h", d, h);
     else

--- a/tests/libtest/lib517.c
+++ b/tests/libtest/lib517.c
@@ -142,7 +142,7 @@ static const struct dcheck dates[] = {
   {"Thu, 31-Dec-1969 23:59:58 GMT", -2 },
   {"Thu, 31-Dec-1969 23:59:59 GMT", 0 }, /* avoids -1 ! */
 #if SIZEOF_TIME_T > 4
-  {"Sun, 06 Nov 2044 08:49:37 GMT", (time_t) CURL_OFF_TU_C(2362034977) },
+  {"Sun, 06 Nov 2044 08:49:37 GMT", (time_t) 2362034977 },
   {"Sun, 06 Nov 3144 08:49:37 GMT", 37074617377 },
 #ifndef HAVE_TIME_T_UNSIGNED
 #if 0

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -46,22 +46,6 @@
 #endif
 #endif
 
-#if (SIZEOF_CURL_OFF_T > SIZEOF_LONG)
-#  define MPRNT_SUFFIX_CURL_OFF_T  LL
-#else
-#  define MPRNT_SUFFIX_CURL_OFF_T  L
-#endif
-
-
-#ifdef CURL_ISOCPP
-#  define MPRNT_OFF_T_C_HELPER2(Val,Suffix) Val ## Suffix
-#else
-#  define MPRNT_OFF_T_C_HELPER2(Val,Suffix) Val/**/Suffix
-#endif
-#define MPRNT_OFF_T_C_HELPER1(Val,Suffix) MPRNT_OFF_T_C_HELPER2(Val,Suffix)
-#define MPRNT_OFF_T_C(Val)  MPRNT_OFF_T_C_HELPER1(Val,MPRNT_SUFFIX_CURL_OFF_T)
-
-
 #define BUFSZ    256
 #define USHORT_TESTS_ARRSZ 1 + 100
 #define SSHORT_TESTS_ARRSZ 1 + 100
@@ -1018,84 +1002,84 @@ static int test_curl_off_t_formatting(void)
   int num_cofft_tests = 0;
   int failed = 0;
 
-  i = 1; co_test[i].num = MPRNT_OFF_T_C(0x7FFFFFFFFFFFFFFF); co_test[i].expected = "9223372036854775807";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x7FFFFFFFFFFFFFFE); co_test[i].expected = "9223372036854775806";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x7FFFFFFFFFFFFFFD); co_test[i].expected = "9223372036854775805";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x7FFFFFFF00000000); co_test[i].expected = "9223372032559808512";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x000000007FFFFFFF); co_test[i].expected = "2147483647";
+  i = 1; co_test[i].num = 0x7FFFFFFFFFFFFFFFLL; co_test[i].expected = "9223372036854775807";
+  i++; co_test[i].num = 0x7FFFFFFFFFFFFFFE; co_test[i].expected = "9223372036854775806";
+  i++; co_test[i].num = 0x7FFFFFFFFFFFFFFD; co_test[i].expected = "9223372036854775805";
+  i++; co_test[i].num = 0x7FFFFFFF00000000; co_test[i].expected = "9223372032559808512";
+  i++; co_test[i].num = 0x000000007FFFFFFF; co_test[i].expected = "2147483647";
 
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x7FFF000000000000); co_test[i].expected = "9223090561878065152";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x00007FFF00000000); co_test[i].expected = "140733193388032";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x000000007FFF0000); co_test[i].expected = "2147418112";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000007FFF); co_test[i].expected = "32767";
+  i++; co_test[i].num = 0x7FFF000000000000; co_test[i].expected = "9223090561878065152";
+  i++; co_test[i].num = 0x00007FFF00000000; co_test[i].expected = "140733193388032";
+  i++; co_test[i].num = 0x000000007FFF0000; co_test[i].expected = "2147418112";
+  i++; co_test[i].num = 0x0000000000007FFF; co_test[i].expected = "32767";
 
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x7F00000000000000); co_test[i].expected = "9151314442816847872";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x007F000000000000); co_test[i].expected = "35747322042253312";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x00007F0000000000); co_test[i].expected = "139637976727552";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000007F00000000); co_test[i].expected = "545460846592";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x000000007F000000); co_test[i].expected = "2130706432";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x00000000007F0000); co_test[i].expected = "8323072";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000007F00); co_test[i].expected = "32512";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x000000000000007F); co_test[i].expected = "127";
+  i++; co_test[i].num = 0x7F00000000000000; co_test[i].expected = "9151314442816847872";
+  i++; co_test[i].num = 0x007F000000000000; co_test[i].expected = "35747322042253312";
+  i++; co_test[i].num = 0x00007F0000000000; co_test[i].expected = "139637976727552";
+  i++; co_test[i].num = 0x0000007F00000000; co_test[i].expected = "545460846592";
+  i++; co_test[i].num = 0x000000007F000000; co_test[i].expected = "2130706432";
+  i++; co_test[i].num = 0x00000000007F0000; co_test[i].expected = "8323072";
+  i++; co_test[i].num = 0x0000000000007F00; co_test[i].expected = "32512";
+  i++; co_test[i].num = 0x000000000000007F; co_test[i].expected = "127";
 
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x7000000000000000); co_test[i].expected = "8070450532247928832";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0700000000000000); co_test[i].expected = "504403158265495552";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0070000000000000); co_test[i].expected = "31525197391593472";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0007000000000000); co_test[i].expected = "1970324836974592";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000700000000000); co_test[i].expected = "123145302310912";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000070000000000); co_test[i].expected = "7696581394432";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000007000000000); co_test[i].expected = "481036337152";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000700000000); co_test[i].expected = "30064771072";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000070000000); co_test[i].expected = "1879048192";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000007000000); co_test[i].expected = "117440512";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000700000); co_test[i].expected = "7340032";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000070000); co_test[i].expected = "458752";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000007000); co_test[i].expected = "28672";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000000700); co_test[i].expected = "1792";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000000070); co_test[i].expected = "112";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000000007); co_test[i].expected = "7";
+  i++; co_test[i].num = 0x7000000000000000; co_test[i].expected = "8070450532247928832";
+  i++; co_test[i].num = 0x0700000000000000; co_test[i].expected = "504403158265495552";
+  i++; co_test[i].num = 0x0070000000000000; co_test[i].expected = "31525197391593472";
+  i++; co_test[i].num = 0x0007000000000000; co_test[i].expected = "1970324836974592";
+  i++; co_test[i].num = 0x0000700000000000; co_test[i].expected = "123145302310912";
+  i++; co_test[i].num = 0x0000070000000000; co_test[i].expected = "7696581394432";
+  i++; co_test[i].num = 0x0000007000000000; co_test[i].expected = "481036337152";
+  i++; co_test[i].num = 0x0000000700000000; co_test[i].expected = "30064771072";
+  i++; co_test[i].num = 0x0000000070000000; co_test[i].expected = "1879048192";
+  i++; co_test[i].num = 0x0000000007000000; co_test[i].expected = "117440512";
+  i++; co_test[i].num = 0x0000000000700000; co_test[i].expected = "7340032";
+  i++; co_test[i].num = 0x0000000000070000; co_test[i].expected = "458752";
+  i++; co_test[i].num = 0x0000000000007000; co_test[i].expected = "28672";
+  i++; co_test[i].num = 0x0000000000000700; co_test[i].expected = "1792";
+  i++; co_test[i].num = 0x0000000000000070; co_test[i].expected = "112";
+  i++; co_test[i].num = 0x0000000000000007; co_test[i].expected = "7";
 
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000000001); co_test[i].expected = "1";
-  i++; co_test[i].num = MPRNT_OFF_T_C(0x0000000000000000); co_test[i].expected = "0";
+  i++; co_test[i].num = 0x0000000000000001; co_test[i].expected = "1";
+  i++; co_test[i].num = 0x0000000000000000; co_test[i].expected = "0";
 
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x7FFFFFFFFFFFFFFF) -MPRNT_OFF_T_C(1); co_test[i].expected = "-9223372036854775808";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x7FFFFFFFFFFFFFFE) -MPRNT_OFF_T_C(1); co_test[i].expected = "-9223372036854775807";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x7FFFFFFFFFFFFFFD) -MPRNT_OFF_T_C(1); co_test[i].expected = "-9223372036854775806";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x7FFFFFFF00000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-9223372032559808513";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x000000007FFFFFFF) -MPRNT_OFF_T_C(1); co_test[i].expected = "-2147483648";
+  i++; co_test[i].num = -0x7FFFFFFFFFFFFFFFLL - 1; co_test[i].expected = "-9223372036854775808";
+  i++; co_test[i].num = -0x7FFFFFFFFFFFFFFE -1; co_test[i].expected = "-9223372036854775807";
+  i++; co_test[i].num = -0x7FFFFFFFFFFFFFFD -1; co_test[i].expected = "-9223372036854775806";
+  i++; co_test[i].num = -0x7FFFFFFF00000000 -1; co_test[i].expected = "-9223372032559808513";
+  i++; co_test[i].num = -0x000000007FFFFFFF -1; co_test[i].expected = "-2147483648";
 
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x7FFF000000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-9223090561878065153";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x00007FFF00000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-140733193388033";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x000000007FFF0000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-2147418113";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000000007FFF) -MPRNT_OFF_T_C(1); co_test[i].expected = "-32768";
+  i++; co_test[i].num = -0x7FFF000000000000 -1; co_test[i].expected = "-9223090561878065153";
+  i++; co_test[i].num = -0x00007FFF00000000 -1; co_test[i].expected = "-140733193388033";
+  i++; co_test[i].num = -0x000000007FFF0000 -1; co_test[i].expected = "-2147418113";
+  i++; co_test[i].num = -0x0000000000007FFF -1; co_test[i].expected = "-32768";
 
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x7F00000000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-9151314442816847873";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x007F000000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-35747322042253313";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x00007F0000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-139637976727553";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000007F00000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-545460846593";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x000000007F000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-2130706433";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x00000000007F0000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-8323073";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000000007F00) -MPRNT_OFF_T_C(1); co_test[i].expected = "-32513";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x000000000000007F) -MPRNT_OFF_T_C(1); co_test[i].expected = "-128";
+  i++; co_test[i].num = -0x7F00000000000000 -1; co_test[i].expected = "-9151314442816847873";
+  i++; co_test[i].num = -0x007F000000000000 -1; co_test[i].expected = "-35747322042253313";
+  i++; co_test[i].num = -0x00007F0000000000 -1; co_test[i].expected = "-139637976727553";
+  i++; co_test[i].num = -0x0000007F00000000 -1; co_test[i].expected = "-545460846593";
+  i++; co_test[i].num = -0x000000007F000000 -1; co_test[i].expected = "-2130706433";
+  i++; co_test[i].num = -0x00000000007F0000 -1; co_test[i].expected = "-8323073";
+  i++; co_test[i].num = -0x0000000000007F00 -1; co_test[i].expected = "-32513";
+  i++; co_test[i].num = -0x000000000000007F -1; co_test[i].expected = "-128";
 
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x7000000000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-8070450532247928833";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0700000000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-504403158265495553";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0070000000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-31525197391593473";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0007000000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-1970324836974593";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000700000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-123145302310913";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000070000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-7696581394433";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000007000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-481036337153";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000700000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-30064771073";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000070000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-1879048193";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000007000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-117440513";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000000700000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-7340033";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000000070000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-458753";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000000007000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-28673";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000000000700) -MPRNT_OFF_T_C(1); co_test[i].expected = "-1793";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000000000070) -MPRNT_OFF_T_C(1); co_test[i].expected = "-113";
-  i++; co_test[i].num = -MPRNT_OFF_T_C(0x0000000000000007) -MPRNT_OFF_T_C(1); co_test[i].expected = "-8";
+  i++; co_test[i].num = -0x7000000000000000 -1; co_test[i].expected = "-8070450532247928833";
+  i++; co_test[i].num = -0x0700000000000000 -1; co_test[i].expected = "-504403158265495553";
+  i++; co_test[i].num = -0x0070000000000000 -1; co_test[i].expected = "-31525197391593473";
+  i++; co_test[i].num = -0x0007000000000000 -1; co_test[i].expected = "-1970324836974593";
+  i++; co_test[i].num = -0x0000700000000000 -1; co_test[i].expected = "-123145302310913";
+  i++; co_test[i].num = -0x0000070000000000 -1; co_test[i].expected = "-7696581394433";
+  i++; co_test[i].num = -0x0000007000000000 -1; co_test[i].expected = "-481036337153";
+  i++; co_test[i].num = -0x0000000700000000 -1; co_test[i].expected = "-30064771073";
+  i++; co_test[i].num = -0x0000000070000000 -1; co_test[i].expected = "-1879048193";
+  i++; co_test[i].num = -0x0000000007000000 -1; co_test[i].expected = "-117440513";
+  i++; co_test[i].num = -0x0000000000700000 -1; co_test[i].expected = "-7340033";
+  i++; co_test[i].num = -0x0000000000070000 -1; co_test[i].expected = "-458753";
+  i++; co_test[i].num = -0x0000000000007000 -1; co_test[i].expected = "-28673";
+  i++; co_test[i].num = -0x0000000000000700 -1; co_test[i].expected = "-1793";
+  i++; co_test[i].num = -0x0000000000000070 -1; co_test[i].expected = "-113";
+  i++; co_test[i].num = -0x0000000000000007 -1; co_test[i].expected = "-8";
 
-  i++; co_test[i].num =  MPRNT_OFF_T_C(0x0000000000000000) -MPRNT_OFF_T_C(1); co_test[i].expected = "-1";
+  i++; co_test[i].num =  0x0000000000000000 -1; co_test[i].expected = "-1";
 
   num_cofft_tests = i;
 


### PR DESCRIPTION
Since curl_off_t is always 64 bit these days, we can simplify and avoid using some macros.