### PR TITLE
docs: tests: Remove mention of hyper

### DIFF
--- a/docs/tests/CI.md
+++ b/docs/tests/CI.md
@@ -58,7 +58,6 @@ GitHub Actions runs the following tests:
 - macOS tests with a variety of different compilation options
 - Fuzz tests ([see the curl-fuzzer repo for more
   info](https://github.com/curl/curl-fuzzer)).
-- curl compiled using the Rust TLS backend with Hyper
 
 These are each configured in different files in `.github/workflows`.
 


### PR DESCRIPTION
In general this section doesn't seem to updated, since github actions runs a lot more jobs now a days. I'm not sure if updating it will make sense, since its the majority of the jobs.