### PR TITLE
test1510: fix expectation

### DIFF
--- a/tests/data/test1510
+++ b/tests/data/test1510
@@ -86,7 +86,6 @@ Accept: */*
 * Connection #0 to host server1.example.com left intact
 * Connection #1 to host server2.example.com left intact
 * Connection #2 to host server3.example.com left intact
-* Closing connection 0
 * Connection #3 to host server4.example.com left intact
 </file>
 <stripfile>


### PR DESCRIPTION
The test had `Closing connection 0` in its expectations, but a stripfile expression that removes such lines. No recent changes, but started failing this morning.

Too little coffee for me? Or what triggered this?