### PR TITLE
curl: upload from '.' fix

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -657,7 +657,7 @@ static void gen_cb_setopts(struct GlobalConfig *global,
                            CURL *curl)
 {
   (void) global; /* for builds without --libcurl */
-
+  (void) config;
   /* where to store */
   my_setopt(curl, CURLOPT_WRITEDATA, per);
   my_setopt(curl, CURLOPT_INTERLEAVEDATA, per);

--- a/tests/data/test1400
+++ b/tests/data/test1400
@@ -82,14 +82,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1401
+++ b/tests/data/test1401
@@ -101,14 +101,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1402
+++ b/tests/data/test1402
@@ -87,14 +87,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1403
+++ b/tests/data/test1403
@@ -82,14 +82,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1404
+++ b/tests/data/test1404
@@ -157,14 +157,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1405
+++ b/tests/data/test1405
@@ -102,14 +102,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1406
+++ b/tests/data/test1406
@@ -93,14 +93,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1407
+++ b/tests/data/test1407
@@ -73,14 +73,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1420
+++ b/tests/data/test1420
@@ -78,14 +78,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1465
+++ b/tests/data/test1465
@@ -90,14 +90,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer

--- a/tests/data/test1481
+++ b/tests/data/test1481
@@ -88,14 +88,14 @@ int main(int argc, char *argv[])
      as source easily. You may choose to either not use them or implement
      them yourself.
 
+  CURLOPT_DEBUGFUNCTION was set to a function pointer
+  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_WRITEDATA was set to an object pointer
   CURLOPT_WRITEFUNCTION was set to a function pointer
   CURLOPT_READDATA was set to an object pointer
   CURLOPT_READFUNCTION was set to a function pointer
   CURLOPT_SEEKDATA was set to an object pointer
   CURLOPT_SEEKFUNCTION was set to a function pointer
-  CURLOPT_DEBUGFUNCTION was set to a function pointer
-  CURLOPT_DEBUGDATA was set to an object pointer
   CURLOPT_HEADERFUNCTION was set to a function pointer
   CURLOPT_HEADERDATA was set to an object pointer
   CURLOPT_ERRORBUFFER was set to an object pointer


### PR DESCRIPTION
CURLOPT_NOPROGRESS is being set twice, if a file is uploaded from '.'.

Fix order of options so that '.' can override the global setting. Without this, the `tool_readbusy_cb()` is never inoked and cannot unpause a transfer waiting for more input.

refs #17513