### PR TITLE
runtests.pl: allow memory tracking tests when threaded

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -871,11 +871,6 @@ sub checksystemfeatures {
         # Only show if not the default for now
         logmsg "* Jobs: $jobs\n";
     }
-    if($feature{"TrackMemory"} && $feature{"threaded-resolver"}) {
-        logmsg("*\n",
-               "*** DISABLES TrackMemory (memory tracking) when using threaded resolver\n",
-               "*\n");
-    }
 
     logmsg sprintf("* Env: %s%s%s%s%s", $valgrind?"Valgrind ":"",
                    $run_duphandle?"test-duphandle ":"",
@@ -884,9 +879,6 @@ sub checksystemfeatures {
                    $nghttpx_h3);
     logmsg sprintf("%s\n", $libtool?"Libtool ":"");
     logmsg ("* Seed: $randseed\n");
-
-    # Disable memory tracking when using threaded resolver
-    $feature{"TrackMemory"} = $feature{"TrackMemory"} && !$feature{"threaded-resolver"};
 
 }
 


### PR DESCRIPTION
Most resources are now allocated/freed on the main thread so they are now less likely to mess up the memory log even when the threaded resolver is used. Originally, resource use in the resolver thread was what made us switch it off.