### PR TITLE
ci: move quictls repository url to new place

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -72,9 +72,9 @@ jobs:
 
       - name: 'cache quictls'
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        id: cache-quictls-no-deprecated
+        id: cache-quictls2-no-deprecated
         env:
-          cache-name: cache-quictls-no-deprecated
+          cache-name: cache-quictls2-no-deprecated
         with:
           path: ~/quictls/build
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
@@ -127,7 +127,7 @@ jobs:
       - id: settings
         if: |
           steps.cache-openssl-http3.outputs.cache-hit != 'true' ||
-          steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true' ||
+          steps.cache-quictls2-no-deprecated.outputs.cache-hit != 'true' ||
           steps.cache-gnutls.outputs.cache-hit != 'true' ||
           steps.cache-wolfssl.outputs.cache-hit != 'true' ||
           steps.cache-nghttp3.outputs.cache-hit != 'true' ||
@@ -163,10 +163,10 @@ jobs:
           make -j1 install_sw
 
       - name: 'build quictls'
-        if: steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true'
+        if: steps.cache-quictls2-no-deprecated.outputs.cache-hit != 'true'
         run: |
           cd $HOME
-          git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl quictls
+          git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/quictls
           cd quictls
           ./config no-deprecated --prefix=$PWD/build --libdir=lib no-makedepend no-apps no-docs no-tests
           make
@@ -359,9 +359,9 @@ jobs:
 
       - name: 'cache quictls'
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        id: cache-quictls-no-deprecated
+        id: cache-quictls2-no-deprecated
         env:
-          cache-name: cache-quictls-no-deprecated
+          cache-name: cache-quictls2-no-deprecated
         with:
           path: ~/quictls/build
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -494,18 +494,18 @@ jobs:
       - name: 'cache quictls'
         if: contains(matrix.build.install_steps, 'quictls')
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        id: cache-quictls
+        id: cache-quictls2
         env:
-          cache-name: cache-quictls
+          cache-name: cache-quictls2
         with:
           path: ~/quictls
           key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ env.quictls-version }}-quic1
 
       - name: 'build quictls'
-        if: contains(matrix.build.install_steps, 'quictls') && steps.cache-quictls.outputs.cache-hit != 'true'
+        if: contains(matrix.build.install_steps, 'quictls') && steps.cache-quictls2.outputs.cache-hit != 'true'
         run: |
-          git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/openssl
-          cd openssl
+          git clone --quiet --depth=1 -b openssl-${{ env.quictls-version }}-quic1 https://github.com/quictls/quictls
+          cd quictls
           ./config --prefix=$HOME/quictls --libdir=lib no-makedepend no-apps no-docs no-tests
           make
           make -j1 install_sw


### PR DESCRIPTION
use `cache-quictls2` as cache prefix to trigger rebuild.