### PR TITLE
cmdline-docs: mention HTTP resumed uploads to be shaky

### DIFF
--- a/docs/cmdline-opts/continue-at.md
+++ b/docs/cmdline-opts/continue-at.md
@@ -25,6 +25,11 @@ the FTP server command SIZE is not used by curl.
 Use "-C -" to instruct curl to automatically find out where/how to resume the
 transfer. It then uses the given output/input files to figure that out.
 
+When using this option for HTTP uploads using POST or PUT, functionality is
+not guaranteed. The HTTP protocol has no standard interoperable resume upload
+and curl uses a set of headers for this purpose that once proved working for
+some servers and have been left for those who find that useful.
+
 This command line option is mutually exclusive with --range: you can only use
 one of them for a single transfer.
 

--- a/docs/cmdline-opts/range.md
+++ b/docs/cmdline-opts/range.md
@@ -57,5 +57,10 @@ FTP and SFTP range downloads only support the simple 'start-stop' syntax
 (optionally with one of the numbers omitted). FTP use depends on the extended
 FTP command SIZE.
 
+When using this option for HTTP uploads using POST or PUT, functionality is
+not guaranteed. The HTTP protocol has no standard interoperable resume upload
+and curl uses a set of headers for this purpose that once proved working for
+some servers and have been left for those who find that useful.
+
 This command line option is mutually exclusive with --continue-at: you can only
 use one of them for a single transfer.


### PR DESCRIPTION
In the documentation for the --continue-at and --range options.

A future version could implement support for the new standard HTTP resumed uploads mechanism.

Ref: #17510