### PR TITLE
cmake: enable `-std=gnu99` for Windows CE CeGCC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,10 @@ elseif(WIN32 AND WINCE AND CMAKE_C_COMPILER_ID STREQUAL "GNU")  # mingw32ce buil
   set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> -O coff <DEFINES> <INCLUDES> <FLAGS> <SOURCE> <OBJECT>")
   enable_language(RC)
 
+  # To compile long long integer literals
+  set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-std=gnu99")
+  string(APPEND CMAKE_REQUIRED_FLAGS " -std=gnu99")
+
   set(CMAKE_C_COMPILE_OPTIONS_PIC "")  # CMake sets it to '-fPIC', confusing the toolchain and breaking builds. Zap it.
 
   set(CMAKE_STATIC_LIBRARY_PREFIX "lib")


### PR DESCRIPTION
To sync with autotools, which auto-detects this option and enables it by
default.

It also makes it possible to compile unsuffixed long long integer
literals correctly, allowing to drop some legacy macros without bumping
into build errors like:
```
lib/vtls/schannel.c: In function 'schannel_send':
lib/vtls/schannel.c:1815: error: integer constant is too large for 'long' type
```
Ref: https://github.com/curl/curl/actions/runs/15374705821/job/43286736583?pr=17498#step:9:20

Bug: https://github.com/curl/curl/pull/17498#issuecomment-2925507481
Reported-by: Daniel Stenberg
