### PR TITLE
autotools: recognize more Linux targets when setting `-D_GNU_SOURCE`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -592,7 +592,7 @@ AM_CONDITIONAL(BUILD_UNITTESTS, test x$supports_unittests = xyes)
 # In order to detect support of sendmmsg() and accept4(), we need to escape the POSIX
 # jail by defining _GNU_SOURCE or <sys/socket.h> will not expose it.
 case $host_os in
-  linux*|cygwin*|msys*)
+  *linux*|cygwin*|msys*)
     CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"
     ;;
 esac


### PR DESCRIPTION
To set `-D_GNU_SOURCE`.

Required to declare `accept4` on uclibc targets. `host_os` can have
the value `uclinux-uclibcgnueabi` in this case.

Fixing:
```
cf-socket.c: In function 'cf_tcp_accept_connect':
cf-socket.c:2141:18: error: implicit declaration of function 'accept4'; did you mean 'accept'? [-Werror=implicit-function-declaration]
 2141 |     s_accepted = accept4(ctx->sock, (struct sockaddr *) &add, &size,
```

Follow-up to 3d02872be7cfe6dcdef4b02321b47af19e1ce268 #16979

Fixes #17512
Reported-by: Kadambini Nema
