### PR TITLE
vtls: OS-provided cert trust validation on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -679,6 +679,7 @@ endif()
 
 if(APPLE)
   cmake_dependent_option(CURL_USE_SECTRANSP "Enable Apple OS native SSL/TLS (Secure Transport)" OFF CURL_ENABLE_SSL OFF)
+  cmake_dependent_option(CURL_USE_APPLE_SECTRUST "Enable Apple OS native certificate validation" ${APPLE} CURL_ENABLE_SSL OFF)
 endif()
 if(WIN32)
   cmake_dependent_option(CURL_USE_SCHANNEL "Enable Windows native SSL/TLS (Schannel)" OFF CURL_ENABLE_SSL OFF)
@@ -739,7 +740,7 @@ if(CURL_WINDOWS_SSPI)
   set(USE_WINDOWS_SSPI ON)
 endif()
 
-if(CURL_USE_SECTRANSP)
+if(CURL_USE_APPLE_SECTRUST OR CURL_USE_SECTRANSP)
   set(_use_core_foundation_and_core_services ON)
 
   find_library(SECURITY_FRAMEWORK NAMES "Security")
@@ -748,7 +749,9 @@ if(CURL_USE_SECTRANSP)
     message(FATAL_ERROR "Security framework not found")
   endif()
   list(APPEND CURL_LIBS "-framework Security")
+endif()
 
+if(CURL_USE_SECTRANSP)
   set(_ssl_enabled ON)
   set(USE_SECTRANSP ON)
 
@@ -757,6 +760,10 @@ if(CURL_USE_SECTRANSP)
   endif()
 
   message(WARNING "Secure Transport does not support TLS 1.3.")
+endif()
+
+if(CURL_USE_APPLE_SECTRUST)
+  set(USE_APPLE_SECTRUST ON)
 endif()
 
 if(_use_core_foundation_and_core_services)

--- a/configure.ac
+++ b/configure.ac
@@ -296,6 +296,12 @@ AS_HELP_STRING([--with-rustls=PATH],[where to look for Rustls, PATH points to th
   fi
 ])
 
+OPT_APPLE_SECTRUST=$curl_cv_apple
+AC_ARG_WITH(apple-certificate-trust,dnl
+AS_HELP_STRING([--without-apple-certificate-trust],[disable Apple OS native SSL/TLS]),[
+  OPT_APPLE_SECTRUST=no
+])
+
 TEST_NGHTTPX=nghttpx
 AC_ARG_WITH(test-nghttpx,dnl
 AS_HELP_STRING([--with-test-nghttpx=PATH],[where to find nghttpx for testing]),
@@ -2126,6 +2132,8 @@ CURL_WITH_MBEDTLS
 CURL_WITH_WOLFSSL
 CURL_WITH_BEARSSL
 CURL_WITH_RUSTLS
+
+CURL_WITH_APPLE_SECTRUST
 
 dnl link required libraries for USE_WIN32_CRYPTO or SCHANNEL_ENABLED
 if test "x$USE_WIN32_CRYPTO" = "x1" -o "x$SCHANNEL_ENABLED" = "x1"; then

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2876,6 +2876,11 @@ CURL_EXTERN void curl_slist_free_all(struct curl_slist *list);
  */
 CURL_EXTERN time_t curl_getdate(const char *p, const time_t *unused);
 
+struct curl_certdata {
+  size_t size;
+  void *data;
+};
+
 /* info about the certificate chain, for SSL backends that support it. Asked
    for with CURLOPT_CERTINFO / CURLINFO_CERTINFO */
 struct curl_certinfo {
@@ -2884,6 +2889,8 @@ struct curl_certinfo {
                                    linked list with textual information for a
                                    certificate in the format "name:content".
                                    eg "Subject:foo", "Issuer:bar", etc. */
+  struct curl_certdata *certdata; /* array of actual DER representation
+                                     of each cert */
 };
 
 /* Information about the SSL library used and the respective internal SSL

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -688,6 +688,9 @@ ${SIZEOF_TIME_T_CODE}
 /* if Secure Transport is enabled */
 #cmakedefine USE_SECTRANSP 1
 
+/* if Apple system certificate validation is enabled */
+#cmakedefine USE_APPLE_SECTRUST 1
+
 /* if SSL session export support is available */
 #cmakedefine USE_SSLS_EXPORT 1
 

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -170,7 +170,7 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
   result = Curl_oss_check_peer_cert(cf, data, &ctx->ossl, peer);
 #elif defined(USE_GNUTLS)
   if(conn_config->verifyhost) {
-    result = Curl_gtls_verifyserver(data, ctx->gtls.session,
+    result = Curl_gtls_verifyserver(cf, data, ctx->gtls.session,
                                     conn_config, &data->set.ssl, peer,
                                     data->set.str[STRING_SSL_PINNEDPUBLICKEY]);
     if(result)

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -100,7 +100,8 @@ CURLcode Curl_gtls_client_trust_setup(struct Curl_cfilter *cf,
                                       struct Curl_easy *data,
                                       struct gtls_ctx *gtls);
 
-CURLcode Curl_gtls_verifyserver(struct Curl_easy *data,
+CURLcode Curl_gtls_verifyserver(struct Curl_cfilter *cf,
+                                struct Curl_easy *data,
                                 gnutls_session_t session,
                                 struct ssl_primary_config *config,
                                 struct ssl_config_data *ssl_config,

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -388,7 +388,8 @@ static CURLcode ossl_certchain(struct Curl_easy *data, SSL *ssl)
 
   sk = SSL_get_peer_cert_chain(ssl);
   if(!sk) {
-    return CURLE_OUT_OF_MEMORY;
+    /* We didn't get a chain from the server; leave 0 certs in the list */
+    return CURLE_OK;
   }
 
   numcerts = sk_X509_num(sk);

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -170,6 +170,12 @@ void Curl_ssl_version(char *buffer, size_t size);
 /* Certificate information list handling. */
 #define CURL_X509_STR_MAX  100000
 
+typedef enum {
+  CURLCV_ACCEPT,
+  CURLCV_REJECT,
+  CURLCV_PASS
+} CURLCVcode;
+
 void Curl_ssl_free_certinfo(struct Curl_easy *data);
 CURLcode Curl_ssl_init_certinfo(struct Curl_easy *data, int num);
 CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data, int certnum,
@@ -179,6 +185,9 @@ CURLcode Curl_ssl_push_certinfo(struct Curl_easy *data, int certnum,
                                 const char *label, const char *value);
 CURLcode Curl_ssl_push_certdata(struct Curl_easy *data, int certnum,
                                 const void *buf, size_t len);
+CURLCVcode Curl_ssl_verify_cb(struct Curl_easy *data,
+                              struct Curl_cfilter *cf,
+                              const void *ocsp_buf, size_t ocsp_len);
 
 /* Functions to be used by SSL library adaptation functions */
 

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -177,6 +177,8 @@ CURLcode Curl_ssl_push_certinfo_len(struct Curl_easy *data, int certnum,
                                     size_t valuelen);
 CURLcode Curl_ssl_push_certinfo(struct Curl_easy *data, int certnum,
                                 const char *label, const char *value);
+CURLcode Curl_ssl_push_certdata(struct Curl_easy *data, int certnum,
+                                const void *buf, size_t len);
 
 /* Functions to be used by SSL library adaptation functions */
 

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -1106,6 +1106,8 @@ CURLcode Curl_extract_certinfo(struct Curl_easy *data,
   const char *ptr;
   int rc;
 
+  Curl_ssl_push_certdata(data, certnum, beg, end - beg);
+
   if(!data->set.ssl.certinfo)
     if(certnum)
       return CURLE_OK;

--- a/m4/curl-secframework.m4
+++ b/m4/curl-secframework.m4
@@ -1,0 +1,58 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+#***************************************************************************
+
+AC_DEFUN([CURL_WITH_APPLE_SECTRUST], [
+AC_MSG_CHECKING([whether to enable Apple OS native certificate validation])
+if test "x$OPT_APPLE_SECTRUST" != xno; then
+  AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([[
+      #include <sys/types.h>
+      #include <TargetConditionals.h>
+    ]],[[
+      #if TARGET_OS_MAC
+        return 0;
+      #else
+      #error Not macOS
+      #endif
+    ]])
+  ],[
+    build_for_apple="yes"
+  ],[
+    build_for_apple="no"
+  ])
+  if test "x$build_for_apple" != "xno"; then
+    AC_MSG_RESULT(yes)
+    AC_DEFINE(USE_APPLE_SECTRUST, 1, [enable Apple OS certificate validation])
+    APPLE_SECTRUST_ENABLED=1
+    APPLE_SECTRUST_LDFLAGS='-framework CoreFoundation -framework CoreServices -framework Security'
+    LDFLAGS="$LDFLAGS $APPLE_SECTRUST_LDFLAGS"
+    LDFLAGSPC="$LDFLAGSPC $APPLE_SECTRUST_LDFLAGS"
+  else
+    AC_MSG_RESULT(no)
+  fi
+else
+  AC_MSG_RESULT(no)
+fi
+
+])

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -397,7 +397,7 @@ class TestSSLUse:
         exp_trace = None
         match_trace = None
         if env.curl_uses_lib('openssl') or env.curl_uses_lib('quictls'):
-            exp_trace = r'.*SSL certificate problem: certificate has expired$'
+            exp_trace = r'.*certificate verify result: certificate has expired \(10\)$'
         elif env.curl_uses_lib('gnutls'):
             exp_trace = r'.*server verification failed: certificate has expired\..*'
         elif env.curl_uses_lib('wolfssl'):

--- a/tests/unit/unit1651.c
+++ b/tests/unit/unit1651.c
@@ -24,6 +24,7 @@
 #include "curlcheck.h"
 
 #include "vtls/x509asn1.h"
+#include "vtls/vtls_int.h"
 
 static CURLcode unit_setup(void)
 {
@@ -360,6 +361,11 @@ UNITTEST_START
 
   data = curl_easy_init();
   if(data) {
+    if(Curl_ssl_init_certinfo(data, 1) != CURLE_OK) {
+      curl_mfprintf(stderr, "Curl_ssl_init_certinfo() failed\n");
+      return TEST_ERR_MAJOR_BAD;
+    }
+
     result = Curl_extract_certinfo(data, 0, beg, end);
 
     fail_unless(result == CURLE_OK, "Curl_extract_certinfo returned error");
@@ -370,6 +376,7 @@ UNITTEST_START
       for(i = 0; i < 45; i++) {
         unsigned char backup = cert[i];
         cert[i] = (unsigned char) (byte & 0xff);
+        (void) Curl_ssl_init_certinfo(data, 1);
         (void) Curl_extract_certinfo(data, 0, beg, end);
         cert[i] = backup;
       }


### PR DESCRIPTION
Since it looks like #17509 won't be merging, and Secure Transport support is being removed, we need *some* way to plug into the system trust store with common TLS providers. This does that by:
- Having the provider expose the raw DER form of each cert in the chain
- Checking in with a callback routine before attempting to use the provider's own validation
  - Cert verification routines can return "accept", "reject", or "pass"; "pass" means that the routine has no opinion this chain, and would like to fall back on the system's or provider's routine. This makes it straightforward to add an application-configured callback routine for cert validation in the future.
  - If `CURLSSLOPT_NATIVE_CA` is set, the OS native trust store is consulted (if available)
  - If no OS implementation is present, the TLS provider's default infrastructure is used

This has a few benefits over the old-style methods of feeding system-derived root CA lists into TLS providers:
- It's compatible with all Apple platforms (except watchOS, which lacks BSD sockets and requires Network.framework); the cert roots aren't directly readable on iOS, tvOS, or visionOS
- It should be straightforwardly possible to adapt for use with essentially any TLS provider (with the possible exception of rustls, which might need some additional FFI routines to be exposed), rather than requiring the provider to add support themselves (which they historically haven't, at least for Apple platforms)
- It allows the system to make more nuanced trust decisions; for instance:
  - The user might have marked an individual leaf certificate as trusted without it being signed by any trusted root
  - The user might have marked an individual leaf certificate as *untrusted* despite it *being* signed by a trusted root
  - The system root program might have specific caveats per-root, such as when the WoSign root was distrusted with an exemption for certificates issued before the trust change ("CA sunsetting")
    - See also: the Mozilla root program only allows the TunTrust CA to issue certificates under the `.tn` TLD
  - The system root program might have specific caveats per-domain, such as Apple de-trusting certificates for `*.sslip.io` that were issued by an otherwise-trusted Comodo root
  - Root programs may make their own decisions about whether to trust a given certificate after its internal expiration date

This draft sketches out a basic working implementation for OpenSSL and GNUTLS; feedback is appreciated.

I think it would be reasonable to provide a build-time option to enable this behavior by default (particularly since it's historically been the default behavior in builds with the Secure Transport provider).

This should also be reasonably straightforward to implement for Windows; there may also be value in adding support for NSS (as Mozilla's root program features some restrictions that don't come across by simply loading a bundle of PEM files).

I intended to skip checking the system trust store when `config->CAfile` or `config->CApath` are set, but currently those can be set by *default* in some situations, and I'm not sure if there's any way to disable them on the CLI. Not sure what the best solution for that will be.