### PR TITLE
curl: make -N handled correctly

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2881,6 +2881,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_OPTION_UNKNOWN;
         break;
       }
+      toggle = !(a->desc & ARG_NO);
     }
     if((a->desc & ARG_TLS) && !feature_ssl) {
       err = PARAM_LIBCURL_DOESNT_SUPPORT;


### PR DESCRIPTION
Options marked ARG_NO should have their 'toggle' value reverted when the short option is used as it implies using the --no- prefix.

-N happens be the only short option flag for a --no- long option.

Reported-by: Stefan Eissing