### PR TITLE
test1117: reduce write delays

### DIFF
--- a/tests/data/test1117
+++ b/tests/data/test1117
@@ -32,7 +32,7 @@ partial body
 </data1>
 
 <servercmd>
-writedelay: 1000
+writedelay: 100
 </servercmd>
 </reply>
 


### PR DESCRIPTION
Test1117 seems to verify that a response, incoming slowly, is read completely before sending another request on the same connection.

The previsou write delay of 1000ms made the test last 23+ seconds. A delay of 100ms seems to achieve the same test on modern machines, but the overall run time is less than 3 seconds.