### PR TITLE
openssl: error on SSL_ERROR_SYSCALL

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5369,6 +5369,10 @@ static ssize_t ossl_recv(struct Curl_cfilter *cf,
           /* logging handling in underlying filter already */
           *curlcode = octx->io_result;
         }
+        else if(connssl->peer_closed) {
+          failf(data, "Connection closed abruptly");
+          *curlcode = CURLE_RECV_ERROR;
+        }
         else {
           /* We should no longer get here nowadays. But handle
            * the error in case of some weirdness in the OSSL stack */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2027,8 +2027,7 @@ static ssize_t wssl_recv(struct Curl_cfilter *cf,
       }
       else if(!wssl->io_result && connssl->peer_closed) {
         CURL_TRC_CF(data, cf, "wssl_recv(len=%zu) -> CLOSED", blen);
-        *curlcode = CURLE_OK;
-        return 0;
+        failf(data, "Connection closed abruptly");
       }
       else {
         char error_buffer[256];

--- a/tests/http/test_05_errors.py
+++ b/tests/http/test_05_errors.py
@@ -120,9 +120,7 @@ class TestErrors:
         r = curl.http_download(urls=[url], alpn_proto=proto, extra_args=[
             '--parallel', '--trace-config', 'ssl'
         ])
-        if proto == 'http/1.0' and not env.curl_uses_lib('wolfssl') and \
-                (env.curl_is_debug() or
-                not env.curl_uses_any_libs(['openssl', 'libressl', 'aws-lc'])):
+        if proto == 'http/1.0':
             # we are inconsistent if we fail or not in missing TLS shutdown
             # openssl code ignore such errors intentionally in non-debug builds
             r.check_exit_code(56)


### PR DESCRIPTION
Convert the debug-only handling of SSL_ERROR_SYSCALL so that it is enabled in all builds with openssl. This should not make a difference in supported OpenSSL versions, but if whatever version or fork we link against *does* return SSL_ERROR_SYSCALL, handle this as a fatal error.

Adapt wolfssl to have the same behaviour. Change test_05_04 to always expect a 56 on http/1.0 unclean close.

refs #17471