### PR TITLE
CI OpenBSD, fix test stall

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -99,7 +99,7 @@ jobs:
           run: |
             # https://openbsd.app/
             # https://www.openbsd.org/faq/faq15.html
-            time sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 python3 py3-impacket
+            time sudo pkg_add cmake ninja brotli openldap-client-- libssh2 libidn2 libpsl nghttp2 py3-six py3-impacket
             time cmake -B bld -G Ninja \
               -DCMAKE_UNITY_BUILD=ON -DCURL_TEST_BUNDLES=ON \
               -DCURL_WERROR=ON \

--- a/tests/http2-server.pl
+++ b/tests/http2-server.pl
@@ -97,7 +97,7 @@ while(@ARGV) {
             shift @ARGV;
         }
     }
-    else {
+    elsif($ARGV[0]) {
         print STDERR "\nWarning: http2-server.pl unknown parameter: $ARGV[0]\n";
     }
     shift @ARGV;


### PR DESCRIPTION
Python package `impacket` could not be used as it requires package `six`. Add that to the install.

Also: fix http2-server.pl warning about an empty argument (wherever that comes from).