### PR TITLE
pytest: adapt for runs with openssl-1.1.1

### DIFF
--- a/tests/http/conftest.py
+++ b/tests/http/conftest.py
@@ -109,7 +109,7 @@ def httpd(env) -> Generator[Httpd, None, None]:
 @pytest.fixture(scope='session')
 def nghttpx(env, httpd) -> Generator[Union[Nghttpx,bool], None, None]:
     nghttpx = NghttpxQuic(env=env)
-    if nghttpx.exists() and env.have_h3():
+    if nghttpx.exists():
         nghttpx.clear_logs()
         assert nghttpx.initial_start()
         yield nghttpx

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -635,8 +635,7 @@ class TestDownload:
             if m:
                 earlydata[int(m.group(1))] = int(m.group(2))
                 continue
-            m = re.match(r'\[1-1] \* SSL reusing session.*', line)
-            if m:
+            if re.match(r'\[1-1] \* SSL reusing session.*', line):
                 reused_session = True
         assert reused_session, 'session was not reused for 2nd transfer'
         assert earlydata[0] == 0, f'{earlydata}'

--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -318,6 +318,9 @@ class TestSSLUse:
             supported = ['TLSv1', 'TLSv1.1', 'TLSv1.2', 'TLSv1.3']
         elif env.curl_uses_lib('aws-lc'):
             supported = ['TLSv1', 'TLSv1.1', 'TLSv1.2', 'TLSv1.3']
+        elif env.curl_uses_lib('openssl') and \
+            env.curl_lib_version_before('openssl', '3.0.0'):
+            supported = ['TLSv1', 'TLSv1.1', 'TLSv1.2', 'TLSv1.3']
         else:  # most SSL backends dropped support for TLSv1.0, TLSv1.1
             supported = [None, None, 'TLSv1.2', 'TLSv1.3']
         # test

--- a/tests/http/testenv/env.py
+++ b/tests/http/testenv/env.py
@@ -387,6 +387,16 @@ class Env:
         return False
 
     @staticmethod
+    def curl_lib_version_before(libname: str, lib_version) -> bool:
+        lversion = Env.curl_lib_version(libname)
+        if lversion != 'unknown':
+            if m := re.match(r'(\d+\.\d+\.\d+).*', lversion):
+                lversion = m.group(1)
+            return Env.CONFIG.versiontuple(lib_version) > \
+                   Env.CONFIG.versiontuple(lversion)
+        return False
+
+    @staticmethod
     def curl_os() -> str:
         return Env.CONFIG.curl_props['os']
 


### PR DESCRIPTION
Fix use of nghttpx fixture to be present even when h3 is not available in curl. Fix TLS protocol versions expectations for older openssl versions.