### PR TITLE
fuzzer: get the deadlock unstuck

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: Fuzzer
+name: Curl-Fuzzer
 
 'on':
   push:


### PR DESCRIPTION
Change the workflow name to change the concurrency lock name so that the invoked Fuzzer workflow does no longer lock the same name.