### PR TITLE
tests/servers.pm: add more ways to figure out current user

### DIFF
--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -209,9 +209,17 @@ sub initserverconfig {
     $USER = $ENV{USER};          # Linux
     if (!$USER) {
         $USER = $ENV{USERNAME};     # Windows
-        if (!$USER) {
-            $USER = $ENV{LOGNAME};  # Some Unix (I think)
-        }
+    }
+    if (!$USER) {
+        $USER = $ENV{LOGNAME};  # Some Unix (I think)
+    }
+    if (!$USER) {
+        $USER = `whoami`;
+        chomp $USER;
+    }
+    if (!$USER) {
+        $USER = `id -un`;
+        chomp $USER;
     }
     init_serverpidfile_hash();
 }


### PR DESCRIPTION
Some CI tests fail due to "Can't start ssh server due to lack of USER name" - add more ways to try to figure it out if no environment variable works: the whoami and id commands.