### PR TITLE
openssl: enable readahead and increase read buffer size (improves download speed)

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4120,6 +4120,20 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
   SSL_CTX_set_options(octx->ssl_ctx, ctx_options);
   SSL_CTX_set_read_ahead(octx->ssl_ctx, 1);
 
+  /* Max TLS1.2 record size 0x4000 + 0x800.
+     OpenSSL supports processing "jumbo TLS record" (8 TLS records) in one go
+     for some algorithms, so match that here.
+     Experimentation shows that a slightly larger buffer is needed
+      to avoid short reads.
+
+     However using a large buffer (8 packets) actually decreases performance.
+     4 packets is better.
+   */
+
+#ifdef HAVE_SSL_CTX_SET_DEFAULT_READ_BUFFER_LEN
+  SSL_CTX_set_default_read_buffer_len(octx->ssl_ctx, 0x401e * 4);
+#endif
+
 #ifdef SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER
   /* We do retry writes sometimes from another buffer address */
   SSL_CTX_set_mode(octx->ssl_ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);


### PR DESCRIPTION
I ran `strace` on `curl` and noticed that it is doing a lot of very short reads, of exactly 5 bytes, followed by a larger read.

<details><summary>strace Before</summary>

```
recvfrom(4, "\27\3\3@\30", 5, 0, NULL, NULL) = 5
recvfrom(4, ")\232\36\234\354'p\247\257\366\301s\2460\372[kr\235\204\205\224I\313*\226e\35\335\373Z\232"..., 16408, 0, NULL, NULL) = 16408
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4096) = 4096
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 12288) = 12288
recvfrom(4, "\27\3\3@\30", 5, 0, NULL, NULL) = 5
recvfrom(4, ")\232\36\234\354'p\250+\350yN^\276\343\260!\257\262e\300\216\343\251\366\35\1\301)\274\224\341"..., 16408, 0, NULL, NULL) = 16408
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4096) = 4096
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 12288) = 12288
```

</details>

I tweaked the OpenSSL context settings in curl, and now `strace` looks much nicer: we read ~64KiB in one go
(writing is still done in several smaller writes, this could be improved in the future).

<details><summary>strace After</summary>


```
recvfrom(4, "\3\3@\30/o\342c\260\r\203S-(\247\240\315\261{\223\250\2004Ne+\37\323\263u\233u"..., 65652, 0, NULL, NULL) = 65652
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4096) = 4096
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 12288) = 12288
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4096) = 4096
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 12288) = 12288
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4096) = 4096
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 12288) = 12288
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 4096) = 4096
write(5, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"..., 12288) = 12288
recvfrom(4, "\3\3@\30/o\342c\260\r\203W\374n(\10:U\332\177u>y\227(\255z\202tzRA"..., 65652, 0, NULL, NULL) = 65652
....
```

</details>

Beyond making `strace` look "nicer" this change of course improves download speed too.
I measured that download time is reduced by  ~13% when downloading a 10GiB file using HTTPS on a 100Gbit/s network link (git hash doesn't match exactly because I amended the commits to include the measurements):
```
ministat -A curl-8_14_1-11-gba407ee43.dat curl-8_14_1-13-g34606f4ad.dat
x curl-8_14_1-11-gba407ee43.dat
+ curl-8_14_1-13-g34606f4ad.dat
    N           Min           Max        Median           Avg        Stddev
x  30      4.596546       5.69831      5.542359     5.4684991    0.29021028
+  30      4.521651      5.151459     4.6656105     4.7356357    0.19006089
Difference at 95.0% confidence
        -0.732863 +/- 0.1268
        -13.4015% +/- 2.10608%
        (Student's t, pooled s = 0.245301)
```

The median speed goes from ~15.5Gbit/s to ~18.4 Gbit/s. 
For reference `iperf3` can do 40Gbit/s (unencrypted obviously) on a single TCP stream (and with 3 streams it can saturate the network link).

The change is tiny: just 2 commits, 1 line each. Although perhaps the buffer size should be configurable (for now I've hardcoded it).

If you want to reproduce the measurements on your own hardware I've included the commands that I've used below, they may need slight tweaks to run on your OS/HW (click to expand the details).

<details><summary>Experimental setup</summary>

```
CPU: 2x 18-core Intel Xeon Gold 6354
NIC: Intel E810-XXV, 100 Gbit/s
Kernel: 6.14.8-300.fc42.x86_64 x86_64
Mem: 251.32 GiB
OS: Fedora Linux 42
openssl version: OpenSSL 3.2.4 11 Feb 2025 (Library: OpenSSL 3.2.4 11 Feb 2025)
```
</details>

<details><summary>Script to put machine into benchmark mode</summary>

Following some of the advice from https://llvm.org/docs/Benchmarking.html.
The BIOS was configured to set the System profile to 'Performance' (this exposes P states to the OS and allows turning off turbo):

```bash
  # Prevent frequency-scaling
  sudo cpupower frequency-set -g performance

  # Prevent entering deep C-states to reduce latency and avoid menu governor bugs (there was one recently)
  # Although if we completely disable C1 then we are going to hit RAPL power limits immediately,
  # which results in a 30% perf hit on single-stream iperf.
  # This particular machine consumes 258W in C0, but RAPL long term limit is 246W and short term 204W
  # Disable just deeper C states, which avoids the big perf hit (although now we're exposed to menu governor bugs)
  sudo cpupower idle-set -D 2

  # Disable Turbo Boost for more stable measurements
  # cpupower set --turbo-boost 0 doesn't work when the driver is intel_pstate instead of cpufreq
  sudo sh -c 'echo 1 >/sys/devices/system/cpu/intel_pstate/no_turbo'

  # AMD
  sudo cpupower set -m passive
  sudo cpupower set --turbo-boost 0

  sudo cpupower -c all set --perf-bias 0

  # Bring system into a consistent state
  sudo tuned-adm profile network-throughput

  # we could use tuned-adm verify, but there is a bug where it tries to read non-existent hung_task_timeout_secs
  # that only fails on network-latency, not network-throughput though
  sudo tuned-adm verify

  # Stop unneessary services (but not NetworkManager!)
  cat >benchmark.target <<EOF
[Unit]
Description=Minimal Benchmarking mode with SSH/getty
Requires=sysinit.target getty.target network.target sshd.service
After=sysinit.target
AllowIsolate=Yes
EOF
  sudo mv benchmark.target /run/systemd/system/
  sudo systemctl daemon-reload
  sudo systemctl isolate benchmark.target
  sudo systemctl list-units --state=running --no-pager
```

</details>

<details><summary>Script to setup benchmark server</summary>

This is part of a larger script that measures also different TLS servers, I've included just the parts needed to measure `curl` with `nginx` (since that appears to be the fastest server in my tests so far).

```bash
  for P in 9443; do
    sudo firewall-cmd --add-port "${P}/tcp"
  done

# Use a single, fixed cipher for consistent tests across different tools
TLS_CIPHERS=ECDHE-RSA-AES256-GCM-SHA384
TLS_PROTO=TLSv1.2

# Use non-root ports
NGINX_PORT=9080
NGINX_TLS_PORT=9443

REPEAT=${REPEAT-30}
TEST_SIZE=${TEST_SIZE-10GiB}

PEM=stunnel.pem
TESTDIR="${PWD}/tmp"
RAMDIR=/dev/shm/stunnel-test
mkdir -p "${RAMDIR}" "${TESTDIR}"

cd "${TESTDIR}"

test -f "${PEM}" || openssl req -new -subj "/C=GB/CN=foo.example.com" -days 10 -x509 -noenc -batch -out "${PEM}" -keyout  "${PEM}" -noenc -batch

truncate --size "${TEST_SIZE}" "${RAMDIR}/${TEST_SIZE}"

cat >nginx.conf <<EOF
error_log stderr error;
pid ${TESTDIR}/nginx.pid;
daemon on;
events { }
http {
    client_body_temp_path "${TESTDIR}/nginx-client_body";
    proxy_temp_path "${TESTDIR}/nginx-proxy";
    fastcgi_temp_path "${TESTDIR}/nginx-fcgi";
    uwsgi_temp_path ${TESTDIR}/nginx-uwsgi";
    scgi_temp_path ${TESTDIR}/nginx-scgi";
    access_log off;
    tcp_nodelay on;
    sendfile on;
    server {
        gzip off;
        listen "${NGINX_PORT}" reuseport;
        listen "${NGINX_TLS_PORT}" reuseport ssl;
        ssl_certificate "${PEM}";
        ssl_certificate_key "${PEM}";
        ssl_protocols "${TLS_PROTO}";
        ssl_ciphers "${TLS_CIPHERS}";
        root "${RAMDIR}";
        location = /hello {
            default_type text/plain;
            return 200 "Hello";
        }
    }
}

killall -v -9 nginx || :

# Start servers
nginx -c "${TESTDIR}/nginx.conf"
EOF
```

</details>
   
<details><summary>Script to benchmark a curl change</summary>

I measure total time instead of download speed, because the correct way to average speeds would be to use a geometric mean, however ministat uses an arithmetic mean, so using ministat to process download speed measurements wouldn't be correct.

```
for i in $(seq 30); do src/curl https://10.70.58.43:9443/10GiB -k -o /dev/null -w '%{time_total}\n'; done >$(git describe).dat
```

</details>

I also measured using 8 TLS records instead of 4, but that was actually slower, and even canceled out the improvement in the first commit (so overall `ministat` said there was no provable difference).
I measured 2 packets instead of 4, but that would've been 5% slower:
```
x tls4.dat
+ tls2.dat
    N           Min           Max        Median           Avg        Stddev
x  30      4.521651      5.151459     4.6656105     4.7356357    0.19006089
+  30      4.476444      5.228927      5.059509     5.0038106    0.20104942
Difference at 95.0% confidence
        0.268175 +/- 0.101125
        5.66291% +/- 2.19331%
        (Student's t, pooled s = 0.195632)
``` 
So 4 packets seems to be the sweet spot, at least on this HW.

P.S.: this change is probably beneficial for most applications using OpenSSL, especially the readahead change, I'll submit similar changes to a few other projects (`socat`, `stunnel`, etc.). Ideally I'd submit the change to OpenSSL itself, but for backwards compatibility reasons they probably cannot change the defaults.