### PR TITLE
GHA/hacktoberfest-accepted: prefer `GH_TOKEN`

### DIFF
--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check whether repo participates in Hacktoberfest
         id: check
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           gh config set prompt disabled && echo "label=$(
             gh repo view --json repositoryTopics --jq '.repositoryTopics[].name' | grep '^hacktoberfest$')" >> "$GITHUB_OUTPUT"
@@ -51,7 +51,7 @@ jobs:
       - name: Search for Number-based PR references
         if: ${{ steps.check.outputs.label == 'hacktoberfest' }}
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           grep -Eo '#([0-9]+)' log | cut -d# -f2 | sort | uniq | xargs -t -n1 -I{} \
             gh pr view {} --json number,createdAt \
@@ -62,7 +62,7 @@ jobs:
       - name: Search for URL-based PR references
         if: ${{ steps.check.outputs.label == 'hacktoberfest' }}
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           grep -Eo 'github.com/(.+)/(.+)/pull/([0-9]+)' log | sort | uniq | xargs -t -n1 -I{} \
             gh pr view 'https://{}' --json number,createdAt \


### PR DESCRIPTION
For the `gh` tool, over `GITHUB_TOKEN`. It accepts both, of which
the former seems to be preferred according to the source code and
documentation.

GHA/appveyor-status already uses `GH_TOKEN`.
