### PR TITLE
auth structs as conn meta

### DIFF
--- a/lib/cshutdn.c
+++ b/lib/cshutdn.c
@@ -54,12 +54,6 @@ static void cshutdn_run_conn_handler(struct Curl_easy *data,
 {
   if(!conn->bits.shutdown_handler) {
 
-    /* Cleanup NTLM connection-related data */
-    Curl_http_auth_cleanup_ntlm(conn);
-
-    /* Cleanup NEGOTIATE connection-related data */
-    Curl_http_auth_cleanup_negotiate(conn);
-
     if(conn->handler && conn->handler->disconnect) {
       /* Some disconnect handlers do a blocking wait on server responses.
        * FTP/IMAP/SMTP and SFTP are among them. When using the internal

--- a/lib/curl_ntlm_core.h
+++ b/lib/curl_ntlm_core.h
@@ -28,6 +28,10 @@
 
 #if defined(USE_CURL_NTLM_CORE)
 
+#include "vauth/vauth.h"
+
+struct ntlmdata;
+
 /* Helpers to generate function byte arguments in little endian order */
 #define SHORTPAIR(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff))
 #define LONGQUARTET(x) ((int)((x) & 0xff)), ((int)(((x) >> 8) & 0xff)), \

--- a/lib/curl_sasl.c
+++ b/lib/curl_sasl.c
@@ -573,8 +573,8 @@ CURLcode Curl_sasl_start(struct SASL *sasl, struct Curl_easy *data,
      sasl_choose_oauth2(data, &sctx) ||
      sasl_choose_plain(data, &sctx) ||
      sasl_choose_login(data, &sctx)) {
-    /* selected one */
-    DEBUGASSERT(sctx.mech);
+    /* selected, either we have a mechanism or a failure */
+    DEBUGASSERT(sctx.mech || sctx.result);
   }
 
   if(!sctx.result && sctx.mech) {

--- a/lib/curl_sasl.h
+++ b/lib/curl_sasl.h
@@ -135,10 +135,6 @@ struct SASL {
   (wordlen == (sizeof(mech) - 1) / sizeof(char) && \
    !memcmp(line, mech, wordlen))
 
-/* This is used to cleanup any libraries or curl modules used by the sasl
-   functions */
-void Curl_sasl_cleanup(struct connectdata *conn, unsigned short authused);
-
 /* Convert a mechanism name to a token */
 unsigned short Curl_sasl_decode_mech(const char *ptr,
                                      size_t maxlen, size_t *len);

--- a/lib/http.c
+++ b/lib/http.c
@@ -3221,8 +3221,10 @@ static CURLcode http_header(struct Curl_easy *data,
     }
 #ifdef USE_SPNEGO
     if(HD_IS(hd, hdlen, "Persistent-Auth:")) {
-      struct negotiatedata *negdata = &conn->negotiate;
+      struct negotiatedata *negdata = Curl_auth_nego_get(conn, FALSE);
       struct auth *authp = &data->state.authhost;
+      if(!negdata)
+        return CURLE_OUT_OF_MEMORY;
       if(authp->picked == CURLAUTH_NEGOTIATE) {
         char *persistentauth = Curl_copy_header_value(hd);
         if(!persistentauth)

--- a/lib/http_negotiate.c
+++ b/lib/http_negotiate.c
@@ -39,6 +39,20 @@
 #include "curl_memory.h"
 #include "memdebug.h"
 
+
+static void http_auth_nego_reset(struct connectdata *conn,
+                                 struct negotiatedata *neg_ctx,
+                                 bool proxy)
+{
+  if(proxy)
+    conn->proxy_negotiate_state = GSS_AUTHNONE;
+  else
+    conn->http_negotiate_state = GSS_AUTHNONE;
+  if(neg_ctx)
+    Curl_auth_cleanup_spnego(neg_ctx);
+}
+
+
 CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
                               bool proxy, const char *header)
 {
@@ -62,7 +76,6 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
     service = data->set.str[STRING_PROXY_SERVICE_NAME] ?
               data->set.str[STRING_PROXY_SERVICE_NAME] : "HTTP";
     host = conn->http_proxy.host.name;
-    neg_ctx = &conn->proxyneg;
     state = conn->proxy_negotiate_state;
 #else
     return CURLE_NOT_BUILT_IN;
@@ -74,9 +87,12 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
     service = data->set.str[STRING_SERVICE_NAME] ?
               data->set.str[STRING_SERVICE_NAME] : "HTTP";
     host = conn->host.name;
-    neg_ctx = &conn->negotiate;
     state = conn->http_negotiate_state;
   }
+
+  neg_ctx = Curl_auth_nego_get(conn, proxy);
+  if(!neg_ctx)
+    return CURLE_OUT_OF_MEMORY;
 
   /* Not set means empty */
   if(!userp)
@@ -94,12 +110,12 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
   if(!len) {
     if(state == GSS_AUTHSUCC) {
       infof(data, "Negotiate auth restarted");
-      Curl_http_auth_cleanup_negotiate(conn);
+      http_auth_nego_reset(conn, neg_ctx, proxy);
     }
     else if(state != GSS_AUTHNONE) {
       /* The server rejected our authentication and has not supplied any more
       negotiation mechanisms */
-      Curl_http_auth_cleanup_negotiate(conn);
+      http_auth_nego_reset(conn, neg_ctx, proxy);
       return CURLE_LOGIN_DENIED;
     }
   }
@@ -116,7 +132,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
     result = Curl_ssl_get_channel_binding(
       data, FIRSTSOCKET, &neg_ctx->channel_binding_data);
     if(result) {
-      Curl_http_auth_cleanup_negotiate(conn);
+      http_auth_nego_reset(conn, neg_ctx, proxy);
       return result;
     }
   }
@@ -134,7 +150,7 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
 #endif
 
   if(result)
-    Curl_http_auth_cleanup_negotiate(conn);
+    http_auth_nego_reset(conn, neg_ctx, proxy);
 
   return result;
 }
@@ -152,7 +168,6 @@ CURLcode Curl_output_negotiate(struct Curl_easy *data,
 
   if(proxy) {
 #ifndef CURL_DISABLE_PROXY
-    neg_ctx = &conn->proxyneg;
     authp = &data->state.authproxy;
     state = &conn->proxy_negotiate_state;
 #else
@@ -160,10 +175,12 @@ CURLcode Curl_output_negotiate(struct Curl_easy *data,
 #endif
   }
   else {
-    neg_ctx = &conn->negotiate;
     authp = &data->state.authhost;
     state = &conn->http_negotiate_state;
   }
+  neg_ctx = Curl_auth_nego_get(conn, proxy);
+  if(!neg_ctx)
+    return CURLE_OUT_OF_MEMORY;
 
   authp->done = FALSE;
 
@@ -184,7 +201,7 @@ CURLcode Curl_output_negotiate(struct Curl_easy *data,
     if(neg_ctx->noauthpersist && *state == GSS_AUTHSUCC) {
       infof(data, "Curl_output_negotiate, "
             "no persistent authentication: cleanup existing context");
-      Curl_http_auth_cleanup_negotiate(conn);
+      http_auth_nego_reset(conn, neg_ctx, proxy);
     }
     if(!neg_ctx->context) {
       result = Curl_input_negotiate(data, conn, proxy, "Negotiate");
@@ -247,15 +264,6 @@ CURLcode Curl_output_negotiate(struct Curl_easy *data,
   neg_ctx->havenegdata = FALSE;
 
   return CURLE_OK;
-}
-
-void Curl_http_auth_cleanup_negotiate(struct connectdata *conn)
-{
-  conn->http_negotiate_state = GSS_AUTHNONE;
-  conn->proxy_negotiate_state = GSS_AUTHNONE;
-
-  Curl_auth_cleanup_spnego(&conn->negotiate);
-  Curl_auth_cleanup_spnego(&conn->proxyneg);
 }
 
 #endif /* !CURL_DISABLE_HTTP && USE_SPNEGO */

--- a/lib/http_negotiate.h
+++ b/lib/http_negotiate.h
@@ -34,10 +34,6 @@ CURLcode Curl_input_negotiate(struct Curl_easy *data, struct connectdata *conn,
 CURLcode Curl_output_negotiate(struct Curl_easy *data,
                                struct connectdata *conn, bool proxy);
 
-void Curl_http_auth_cleanup_negotiate(struct connectdata *conn);
-
-#else /* !CURL_DISABLE_HTTP && USE_SPNEGO */
-#define Curl_http_auth_cleanup_negotiate(x)
 #endif
 
 #endif /* HEADER_CURL_HTTP_NEGOTIATE_H */

--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -60,17 +60,18 @@ CURLcode Curl_input_ntlm(struct Curl_easy *data,
                                                 header */
 {
   /* point to the correct struct with this */
-  struct ntlmdata *ntlm;
   curlntlm *state;
   CURLcode result = CURLE_OK;
   struct connectdata *conn = data->conn;
 
-  ntlm = proxy ? &conn->proxyntlm : &conn->ntlm;
   state = proxy ? &conn->proxy_ntlm_state : &conn->http_ntlm_state;
 
   if(checkprefix("NTLM", header)) {
-    header += strlen("NTLM");
+    struct ntlmdata *ntlm = Curl_auth_ntlm_get(conn, proxy);
+    if(!ntlm)
+      return CURLE_FAILED_INIT;
 
+    header += strlen("NTLM");
     curlx_str_passblanks(&header);
     if(*header) {
       unsigned char *hdr;
@@ -93,11 +94,11 @@ CURLcode Curl_input_ntlm(struct Curl_easy *data,
     else {
       if(*state == NTLMSTATE_LAST) {
         infof(data, "NTLM auth restarted");
-        Curl_http_auth_cleanup_ntlm(conn);
+        Curl_auth_ntlm_remove(conn, proxy);
       }
       else if(*state == NTLMSTATE_TYPE3) {
         infof(data, "NTLM handshake rejected");
-        Curl_http_auth_cleanup_ntlm(conn);
+        Curl_auth_ntlm_remove(conn, proxy);
         *state = NTLMSTATE_NONE;
         return CURLE_REMOTE_ACCESS_DENIED;
       }
@@ -150,7 +151,6 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
     service = data->set.str[STRING_PROXY_SERVICE_NAME] ?
       data->set.str[STRING_PROXY_SERVICE_NAME] : "HTTP";
     hostname = conn->http_proxy.host.name;
-    ntlm = &conn->proxyntlm;
     state = &conn->proxy_ntlm_state;
     authp = &data->state.authproxy;
 #else
@@ -164,10 +164,10 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
     service = data->set.str[STRING_SERVICE_NAME] ?
       data->set.str[STRING_SERVICE_NAME] : "HTTP";
     hostname = conn->host.name;
-    ntlm = &conn->ntlm;
     state = &conn->http_ntlm_state;
     authp = &data->state.authhost;
   }
+  ntlm = Curl_auth_ntlm_get(conn, proxy);
   authp->done = FALSE;
 
   /* not set means empty */
@@ -200,9 +200,9 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
   case NTLMSTATE_TYPE1:
   default: /* for the weird cases we (re)start here */
     /* Create a type-1 message */
-    result = Curl_auth_create_ntlm_type1_message(data, userp, passwdp,
-                                                 service, hostname,
-                                                 ntlm, &ntlmmsg);
+    result = !ntlm ? CURLE_OUT_OF_MEMORY :
+      Curl_auth_create_ntlm_type1_message(data, userp, passwdp, service,
+                                          hostname, ntlm, &ntlmmsg);
     if(!result) {
       DEBUGASSERT(Curl_bufref_len(&ntlmmsg) != 0);
       result = curlx_base64_encode((const char *) Curl_bufref_ptr(&ntlmmsg),
@@ -256,12 +256,6 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
   Curl_bufref_free(&ntlmmsg);
 
   return result;
-}
-
-void Curl_http_auth_cleanup_ntlm(struct connectdata *conn)
-{
-  Curl_auth_cleanup_ntlm(&conn->ntlm);
-  Curl_auth_cleanup_ntlm(&conn->proxyntlm);
 }
 
 #endif /* !CURL_DISABLE_HTTP && USE_NTLM */

--- a/lib/http_ntlm.h
+++ b/lib/http_ntlm.h
@@ -35,10 +35,6 @@ CURLcode Curl_input_ntlm(struct Curl_easy *data, bool proxy,
 /* this is for creating NTLM header output */
 CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy);
 
-void Curl_http_auth_cleanup_ntlm(struct connectdata *conn);
-
-#else /* !CURL_DISABLE_HTTP && USE_NTLM */
-#define Curl_http_auth_cleanup_ntlm(x)
 #endif
 
 #endif /* HEADER_CURL_HTTP_NTLM_H */

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1788,9 +1788,6 @@ static CURLcode imap_disconnect(struct Curl_easy *data,
       if(!imap_perform_logout(data, imapc))
         (void)imap_block_statemach(data, imapc, TRUE); /* ignore errors */
     }
-
-    /* Cleanup the SASL module */
-    Curl_sasl_cleanup(conn, imapc->sasl.authused);
   }
   return CURLE_OK;
 }

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -941,7 +941,6 @@ static CURLcode oldap_disconnect(struct Curl_easy *data,
       ldap_unbind_ext(li->ld, NULL, NULL);
       li->ld = NULL;
     }
-    Curl_sasl_cleanup(conn, li->sasl.authused);
   }
   return CURLE_OK;
 }

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1459,9 +1459,6 @@ static CURLcode pop3_disconnect(struct Curl_easy *data,
   /* Disconnect from the server */
   Curl_pp_disconnect(&pop3c->pp);
 
-  /* Cleanup the SASL module */
-  Curl_sasl_cleanup(conn, pop3c->sasl.authused);
-
   /* Cleanup our connection based variables */
   Curl_safefree(pop3c->apoptimestamp);
 

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1631,8 +1631,6 @@ static CURLcode smtp_disconnect(struct Curl_easy *data,
       (void)smtp_block_statemach(data, smtpc, TRUE); /* ignore on QUIT */
   }
 
-  /* Cleanup the SASL module */
-  Curl_sasl_cleanup(conn, smtpc->sasl.authused);
   CURL_TRC_SMTP(data, "smtp_disconnect(), finished");
   return CURLE_OK;
 }

--- a/lib/vauth/vauth.h
+++ b/lib/vauth/vauth.h
@@ -27,8 +27,10 @@
 #include <curl/curl.h>
 
 #include "../bufref.h"
+#include "../curlx/dynbuf.h"
 
 struct Curl_easy;
+struct connectdata;
 
 #if !defined(CURL_DISABLE_DIGEST_AUTH)
 struct digestdata;
@@ -36,10 +38,6 @@ struct digestdata;
 
 #if defined(USE_NTLM)
 struct ntlmdata;
-#endif
-
-#if defined(USE_KERBEROS5)
-struct kerberos5data;
 #endif
 
 #if (defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)) && defined(USE_SPNEGO)
@@ -50,7 +48,8 @@ struct negotiatedata;
 struct gsasldata;
 #endif
 
-#if defined(USE_WINDOWS_SSPI)
+#ifdef USE_WINDOWS_SSPI
+#include "../curl_sspi.h"
 #define GSS_ERROR(status) ((status) & 0x80000000)
 #endif
 
@@ -120,6 +119,18 @@ void Curl_auth_digest_cleanup(struct digestdata *digest);
 #endif /* !CURL_DISABLE_DIGEST_AUTH */
 
 #ifdef USE_GSASL
+
+/* meta key for storing GSASL meta at connection */
+#define CURL_META_GSASL_CONN   "meta:auth:gsasl:conn"
+
+#include <gsasl.h>
+struct gsasldata {
+  Gsasl *ctx;
+  Gsasl_session *client;
+};
+
+struct gsasldata *Curl_auth_gsasl_get(struct connectdata *conn);
+
 /* This is used to evaluate if MECH is supported by gsasl */
 bool Curl_auth_gsasl_is_supported(struct Curl_easy *data,
                                   const char *mech,
@@ -141,8 +152,45 @@ void Curl_auth_gsasl_cleanup(struct gsasldata *digest);
 #endif
 
 #if defined(USE_NTLM)
+
+/* meta key for storing NTML meta at connection */
+#define CURL_META_NTLM_CONN   "meta:auth:ntml:conn"
+/* meta key for storing NTML-PROXY meta at connection */
+#define CURL_META_NTLM_PROXY_CONN   "meta:auth:ntml-proxy:conn"
+
+struct ntlmdata {
+#ifdef USE_WINDOWS_SSPI
+/* The sslContext is used for the Schannel bindings. The
+ * api is available on the Windows 7 SDK and later.
+ */
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  CtxtHandle *sslContext;
+#endif
+  CredHandle *credentials;
+  CtxtHandle *context;
+  SEC_WINNT_AUTH_IDENTITY identity;
+  SEC_WINNT_AUTH_IDENTITY *p_identity;
+  size_t token_max;
+  BYTE *output_token;
+  BYTE *input_token;
+  size_t input_token_len;
+  TCHAR *spn;
+#else
+  unsigned int flags;
+  unsigned char nonce[8];
+  unsigned int target_info_len;
+  void *target_info; /* TargetInfo received in the NTLM type-2 message */
+#endif
+};
+
 /* This is used to evaluate if NTLM is supported */
 bool Curl_auth_is_ntlm_supported(void);
+
+struct ntlmdata *Curl_auth_ntlm_get(struct connectdata *conn, bool proxy);
+void Curl_auth_ntlm_remove(struct connectdata *conn, bool proxy);
+
+/* This is used to clean up the NTLM specific data */
+void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm);
 
 /* This is used to generate a base64 encoded NTLM type-1 message */
 CURLcode Curl_auth_create_ntlm_type1_message(struct Curl_easy *data,
@@ -165,8 +213,6 @@ CURLcode Curl_auth_create_ntlm_type3_message(struct Curl_easy *data,
                                              struct ntlmdata *ntlm,
                                              struct bufref *out);
 
-/* This is used to clean up the NTLM specific data */
-void Curl_auth_cleanup_ntlm(struct ntlmdata *ntlm);
 #else
 #define Curl_auth_is_ntlm_supported()     FALSE
 #endif /* USE_NTLM */
@@ -184,6 +230,40 @@ CURLcode Curl_auth_create_xoauth_bearer_message(const char *user,
                                                 struct bufref *out);
 
 #if defined(USE_KERBEROS5)
+
+#ifdef HAVE_GSSAPI
+# ifdef HAVE_GSSGNU
+#  include <gss.h>
+# elif defined HAVE_GSSAPI_GSSAPI_H
+#  include <gssapi/gssapi.h>
+# else
+#  include <gssapi.h>
+# endif
+# ifdef HAVE_GSSAPI_GSSAPI_GENERIC_H
+#  include <gssapi/gssapi_generic.h>
+# endif
+#endif
+
+/* meta key for storing KRB5 meta at connection */
+#define CURL_META_KRB5_CONN   "meta:auth:krb5:conn"
+
+struct kerberos5data {
+#if defined(USE_WINDOWS_SSPI)
+  CredHandle *credentials;
+  CtxtHandle *context;
+  TCHAR *spn;
+  SEC_WINNT_AUTH_IDENTITY identity;
+  SEC_WINNT_AUTH_IDENTITY *p_identity;
+  size_t token_max;
+  BYTE *output_token;
+#else
+  gss_ctx_id_t context;
+  gss_name_t spn;
+#endif
+};
+
+struct kerberos5data *Curl_auth_krb5_get(struct connectdata *conn);
+
 /* This is used to evaluate if GSSAPI (Kerberos V5) is supported */
 bool Curl_auth_is_gssapi_supported(void);
 
@@ -213,9 +293,47 @@ void Curl_auth_cleanup_gssapi(struct kerberos5data *krb5);
 #define Curl_auth_is_gssapi_supported()       FALSE
 #endif /* USE_KERBEROS5 */
 
-#if defined(USE_SPNEGO)
-/* This is used to evaluate if SPNEGO (Negotiate) is supported */
+#ifdef USE_SPNEGO
+
 bool Curl_auth_is_spnego_supported(void);
+
+/* meta key for storing NEGO meta at connection */
+#define CURL_META_NEGO_CONN         "meta:auth:nego:conn"
+/* meta key for storing NEGO PROXY meta at connection */
+#define CURL_META_NEGO_PROXY_CONN   "meta:auth:nego-proxy:conn"
+
+/* Struct used for Negotiate (SPNEGO) authentication */
+struct negotiatedata {
+#ifdef HAVE_GSSAPI
+  OM_uint32 status;
+  gss_ctx_id_t context;
+  gss_name_t spn;
+  gss_buffer_desc output_token;
+  struct dynbuf channel_binding_data;
+#else
+#ifdef USE_WINDOWS_SSPI
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+  CtxtHandle *sslContext;
+#endif
+  DWORD status;
+  CredHandle *credentials;
+  CtxtHandle *context;
+  SEC_WINNT_AUTH_IDENTITY identity;
+  SEC_WINNT_AUTH_IDENTITY *p_identity;
+  TCHAR *spn;
+  size_t token_max;
+  BYTE *output_token;
+  size_t output_token_length;
+#endif
+#endif
+  BIT(noauthpersist);
+  BIT(havenoauthpersist);
+  BIT(havenegdata);
+  BIT(havemultiplerequests);
+};
+
+struct negotiatedata *
+Curl_auth_nego_get(struct connectdata *conn, bool proxy);
 
 /* This is used to decode a base64 encoded SPNEGO (Negotiate) challenge
    message */


### PR DESCRIPTION
Move auth structs to conn meta data.

Remove structs for negotiate, krb5, ntlm and gsasl from connectdata and store them as connection meta data with auto cleanup.

De-complexify sasl mech selection by moving code into static  functions.