### PR TITLE
tool_operate: fix return code when --retry is used but not triggered

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -548,8 +548,9 @@ static CURLcode retrycheck(struct OperationConfig *config,
     *retryp = TRUE;
     per->num_retries++;
     *delayms = sleeptime;
+    result = CURLE_OK;
   }
-  return CURLE_OK;
+  return result;
 }
 
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -107,7 +107,7 @@ test709 test710 test711 test712 test713 test714 test715 test716 test717 \
 test718 test719 test720 test721 test722 test723 test724 test725 test726 \
 test727 test728 test729 test730 test731 test732 test733 test734 test735 \
 test736 test737 test738 test739 test740 test741 test742 test743 test744 \
-test745 test746 test747 test748 test749 test750 test751 \
+test745 test746 test747 test748 test749 test750 test751 test752 \
 \
 test780 test781 test782 test783 test784 test785 test786 test787 test788 \
 test789 test790 test791 \

--- a/tests/data/test752
+++ b/tests/data/test752
@@ -1,0 +1,72 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+-f
+--retry
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes">
+HTTP/1.1 404 nopes
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+
+<datacheck crlf="yes">
+HTTP/1.1 404 nopes
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+</datacheck>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+--retry and -f on a HTTP 404 response
+</name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -f --retry 1
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<errorcode>
+22
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
Verify with test 752

Reported-by: fjaell on github
Fixes #17554