### PR TITLE
GHA/non-native: skip OpenBSD WebSocket tests to mitigate job timeouts

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -591,7 +591,6 @@ jobs:
               --without-libpsl \
               --disable-shared
           fi
-          ####
 
       - name: 'configure log'
         if: ${{ !cancelled() }}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -122,7 +122,7 @@ jobs:
             bld/src/curl --disable --version
             if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
               time cmake --build bld --target testdeps
-              export TFLAGS='-j8'
+              export TFLAGS='-j8 !WebSockets'
               time cmake --build bld --target test-ci
             fi
             echo '::group::build examples'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -591,6 +591,7 @@ jobs:
               --without-libpsl \
               --disable-shared
           fi
+          ####
 
       - name: 'configure log'
         if: ${{ !cancelled() }}

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -122,7 +122,7 @@ jobs:
             bld/src/curl --disable --version
             if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
               time cmake --build bld --target testdeps
-              export TFLAGS='-j8 !WebSockets'
+              export TFLAGS='-j8'
               time cmake --build bld --target test-ci
             fi
             echo '::group::build examples'


### PR DESCRIPTION
Trying to avoid the occasional ~6-minute long delays seen in the OpenBSD
since last week. The long delay causes the CI job to timeout and fail:
https://github.com/curl/curl/actions/workflows/non-native.yml?page=2&query=branch%3Amaster

The exact reason is or test number is unknown. I base this attempt on
looking at the first occurrences and possible patches that may be
related.

The issue was first seen in CI within PR #17136:
```
[...]
Wed, 07 May 2025 07:10:30 GMT test 3014...[Check if %{num_headers} returns correct number of headers]
Wed, 07 May 2025 07:10:30 GMT s-p----e--- OK (1743 out of 1778, remaining: 00:02, took 0.195s, duration: 01:43)
Wed, 07 May 2025 07:10:30 GMT test 3016...[GET a directory using file://]
[long delay here]
Wed, 07 May 2025 07:16:17 GMT -------
Wed, 07 May 2025 07:16:17 GMT Error: The operation was canceled.
```
Ref: https://github.com/curl/curl/actions/runs/14877264415/job/41776966626#step:3:5566
Ref: https://github.com/curl/curl/actions/runs/14900320627/job/41850699301#step:3:5561 (next in PR)

Then in master, shortly after merging it via d3594be6531df3d5eafcdd09f84ad9dee1777028:
```
[...]                                                               
Mon, 02 Jun 2025 09:23:55 GMT test 3201...[HTTP GET when PROXY Protocol enabled and spoofed client IP]
Mon, 02 Jun 2025 09:23:55 GMT --p----e--- OK (1777 out of 1788, remaining: 00:00, took 0.222s, duration: 01:42)
Mon, 02 Jun 2025 09:23:55 GMT RUN: failed to start the HTTP/2 server
Mon, 02 Jun 2025 09:23:55 GMT test 3202...[HTTP-IPv6 GET with PROXY protocol with spoofed client IP]
[long delay here]                                                   
Mon, 02 Jun 2025 09:29:48 GMT --p----e--- OK (1778 out of 1788, remaining: 00:00, took 0.1
Mon, 02 Jun 2025 09:29:48 GMT Error: The operation was canceled.    
```                                                                 
Ref: https://github.com/curl/curl/actions/runs/15388587165/job/43292652793#step:3:5097
Ref: https://github.com/curl/curl/actions/runs/15390589464/job/43298911578#step:3:5097 (next in master)

---

/cc @viscruocco

My initial theory was that it may be a regression from:
https://github.com/curl/curl/actions/runs/15380047320
https://github.com/curl/curl/commit/516e9ccab3689d903408e50251f47da8108a9df2 https://github.com/curl/curl/pull/17505

But, that commit merely un-ignored the results of FTP and TFTP tests,
and did not change what tests are run. It means it cannot have caused
these, because there was no extra test executed after that patch.

The first master CI run showing the issue was:
https://github.com/curl/curl/actions/runs/15388587165
d591bc141629d13170e704785609e8482e814f94
```
[...]
Mon, 02 Jun 2025 09:23:55 GMT test 3105...[curl_multi_remove_handle twice]
Mon, 02 Jun 2025 09:23:55 GMT -------e--- OK (1775 out of 1788, remaining: 00:00, took 0.263s, duration: 01:41)
Mon, 02 Jun 2025 09:23:55 GMT test 3201...[HTTP GET when PROXY Protocol enabled and spoofed client IP]
Mon, 02 Jun 2025 09:23:55 GMT --p----e--- OK (1777 out of 1788, remaining: 00:00, took 0.222s, duration: 01:42)
Mon, 02 Jun 2025 09:23:55 GMT RUN: failed to start the HTTP/2 server
Mon, 02 Jun 2025 09:23:55 GMT test 3202...[HTTP-IPv6 GET with PROXY protocol with spoofed client IP]
[long delay here]
Mon, 02 Jun 2025 09:29:48 GMT --p----e--- OK (1778 out of 1788, remaining: 00:00, took 0.1
Mon, 02 Jun 2025 09:29:48 GMT Error: The operation was canceled.
```
Ref: https://github.com/curl/curl/actions/runs/15388587165/job/43292652793#step:3:5095

The next failing CI run for master:
https://github.com/curl/curl/actions/runs/15390589464
for PRs:
https://github.com/curl/curl/actions/runs/15390171846/job/43297624039
https://github.com/curl/curl/actions/runs/15401987362/job/43336552879

A slightly earlier failure but the log is lost:
https://github.com/curl/curl/actions/runs/15292448723/job/43014270033

Earliest long delays here, seen within the WebSocket PR (https://github.com/viscruocco/curl/tree/refs/heads/ws-tests-and-fixes) #17136:
2025-May-08: https://github.com/curl/curl/actions/runs/14900320627/job/41850699301
2025-May-07: https://github.com/curl/curl/actions/runs/14877264415/job/41776966626

The failing commits aren't suspect.

Here are some others leading up the first fail in master:
d3594be6531df3d5eafcdd09f84ad9dee1777028 #17136
04c3895ceb2dbf9e62850080a658f9f26ad2293e
f73809389648ee431f023de5501b9a16660513fc

First I try disabling websockets to see if they fix anything.
