### PR TITLE
curl.h: remove the "RESERVED" error codes

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -645,20 +645,7 @@ typedef enum {
   CURLE_UNRECOVERABLE_POLL,      /* 99 - poll/select returned fatal error */
   CURLE_TOO_LARGE,               /* 100 - a value/data met its maximum */
   CURLE_ECH_REQUIRED,            /* 101 - ECH tried but failed */
-  CURL_LAST, /* never use! */
-
-  CURLE_RESERVED115 = 115,       /* 115-126 - used in tests */
-  CURLE_RESERVED116 = 116,
-  CURLE_RESERVED117 = 117,
-  CURLE_RESERVED118 = 118,
-  CURLE_RESERVED119 = 119,
-  CURLE_RESERVED120 = 120,
-  CURLE_RESERVED121 = 121,
-  CURLE_RESERVED122 = 122,
-  CURLE_RESERVED123 = 123,
-  CURLE_RESERVED124 = 124,
-  CURLE_RESERVED125 = 125,
-  CURLE_RESERVED126 = 126
+  CURL_LAST /* never use! */
 } CURLcode;
 
 #ifndef CURL_NO_OLDIES /* define this to test if your app builds with all

--- a/lib/strerror.c
+++ b/lib/strerror.c
@@ -317,36 +317,7 @@ curl_easy_strerror(CURLcode error)
     return "ECH attempted but failed";
 
     /* error codes not used by current libcurl */
-  case CURLE_OBSOLETE20:
-  case CURLE_OBSOLETE24:
-  case CURLE_OBSOLETE29:
-  case CURLE_OBSOLETE32:
-  case CURLE_OBSOLETE34:
-  case CURLE_OBSOLETE40:
-  case CURLE_OBSOLETE41:
-  case CURLE_OBSOLETE44:
-  case CURLE_OBSOLETE46:
-  case CURLE_OBSOLETE50:
-  case CURLE_OBSOLETE51:
-  case CURLE_OBSOLETE57:
-  case CURLE_OBSOLETE62:
-  case CURLE_OBSOLETE75:
-  case CURLE_OBSOLETE76:
-
-    /* error codes used by curl tests */
-  case CURLE_RESERVED115:
-  case CURLE_RESERVED116:
-  case CURLE_RESERVED117:
-  case CURLE_RESERVED118:
-  case CURLE_RESERVED119:
-  case CURLE_RESERVED120:
-  case CURLE_RESERVED121:
-  case CURLE_RESERVED122:
-  case CURLE_RESERVED123:
-  case CURLE_RESERVED124:
-  case CURLE_RESERVED125:
-  case CURLE_RESERVED126:
-  case CURL_LAST:
+  default:
     break;
   }
   /*

--- a/tests/data/test1511
+++ b/tests/data/test1511
@@ -62,10 +62,10 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 </client>
 
 # Verify data after the test has been "shot"
-# TEST_ERR_SUCCESS is errorcode 120
+# TEST_ERR_SUCCESS is errorcode 41
 <verify>
 <errorcode>
-120
+41
 </errorcode>
 </verify>
 </testcase>

--- a/tests/data/test1533
+++ b/tests/data/test1533
@@ -38,10 +38,10 @@ http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 </client>
 
 # Verify data after the test has been "shot"
-# TEST_ERR_SUCCESS is errorcode 120
+# TEST_ERR_SUCCESS is errorcode 41
 <verify>
 <errorcode>
-120
+41
 </errorcode>
 <protocol nonewline="yes">
 POST /%TESTNUMBER HTTP/1.1

--- a/tests/data/test504
+++ b/tests/data/test504
@@ -37,10 +37,10 @@ http://%HOSTIP:%NOLISTENPORT/%TESTNUMBER %HOSTIP:%NOLISTENPORT
 </client>
 
 # Verify data after the test has been "shot"
-# TEST_ERR_SUCCESS is errorcode 120
+# TEST_ERR_SUCCESS is errorcode 41
 <verify>
 <errorcode>
-120
+41
 </errorcode>
 </verify>
 </testcase>

--- a/tests/data/test538
+++ b/tests/data/test538
@@ -32,10 +32,10 @@ ftp://%HOSTIP:%FTPPORT/%TESTNUMBER
 </client>
 
 # Verify data after the test has been "shot"
-# TEST_ERR_SUCCESS is errorcode 120
+# TEST_ERR_SUCCESS is errorcode 41
 <verify>
 <errorcode>
-120
+41
 </errorcode>
 <protocol>
 USER anonymous

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -89,26 +89,24 @@ extern char *hexdump(const unsigned char *buffer, size_t len);
 extern int unitfail;
 
 /*
-** TEST_ERR_* values must be greater than CURL_LAST CURLcode in order
-** to avoid confusion with any CURLcode or CURLMcode. These TEST_ERR_*
-** codes are returned to signal test specific situations and should
-** not get mixed with CURLcode or CURLMcode values.
-**
+** TEST_ERR_* values must within the CURLcode range to not cause compiler
+** errors.
+
 ** For portability reasons TEST_ERR_* values should be less than 127.
 */
 
-#define TEST_ERR_MAJOR_BAD     CURLE_RESERVED126
-#define TEST_ERR_RUNS_FOREVER  CURLE_RESERVED125
-#define TEST_ERR_EASY_INIT     CURLE_RESERVED124
-#define TEST_ERR_MULTI         CURLE_RESERVED123
-#define TEST_ERR_NUM_HANDLES   CURLE_RESERVED122
-#define TEST_ERR_SELECT        CURLE_RESERVED121
-#define TEST_ERR_SUCCESS       CURLE_RESERVED120
-#define TEST_ERR_FAILURE       CURLE_RESERVED119
-#define TEST_ERR_USAGE         CURLE_RESERVED118
-#define TEST_ERR_FOPEN         CURLE_RESERVED117
-#define TEST_ERR_FSTAT         CURLE_RESERVED116
-#define TEST_ERR_BAD_TIMEOUT   CURLE_RESERVED115
+#define TEST_ERR_MAJOR_BAD     CURLE_OBSOLETE20
+#define TEST_ERR_RUNS_FOREVER  CURLE_OBSOLETE24
+#define TEST_ERR_EASY_INIT     CURLE_OBSOLETE29
+#define TEST_ERR_MULTI         CURLE_OBSOLETE32
+#define TEST_ERR_NUM_HANDLES   CURLE_OBSOLETE34
+#define TEST_ERR_SELECT        CURLE_OBSOLETE40
+#define TEST_ERR_SUCCESS       CURLE_OBSOLETE41
+#define TEST_ERR_FAILURE       CURLE_OBSOLETE44
+#define TEST_ERR_USAGE         CURLE_OBSOLETE46
+#define TEST_ERR_FOPEN         CURLE_OBSOLETE50
+#define TEST_ERR_FSTAT         CURLE_OBSOLETE51
+#define TEST_ERR_BAD_TIMEOUT   CURLE_OBSOLETE57
 
 /*
 ** Macros for test source code readability/maintainability.


### PR DESCRIPTION
Return codes for tests should be kept private. 
Follow-up to 9465327084c920deee7ba5abbcd