### PR TITLE
tool_cb_rea: simplify reading stdin non-blocking

### DIFF
--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -123,6 +123,7 @@ int tool_readbusy_cb(void *clientp,
 {
   struct per_transfer *per = clientp;
   struct OperationConfig *config = per->config;
+  static curl_off_t ulprev;
 
   (void)dltotal;  /* unused */
   (void)dlnow;  /* unused */
@@ -130,33 +131,11 @@ int tool_readbusy_cb(void *clientp,
   (void)ulnow;  /* unused */
 
   if(config->readbusy) {
-    /* lame code to keep the rate down because the input might not deliver
-       anything, get paused again and come back here immediately */
-    static timediff_t rate = 500;
-    static struct curltime prev;
-    static curl_off_t ulprev;
-
-    if(ulprev == ulnow) {
-      /* it did not upload anything since last call */
-      struct curltime now = curlx_now();
-      if(prev.tv_sec)
-        /* get a rolling average rate */
-        rate -= rate/4 - curlx_timediff(now, prev)/4;
-      prev = now;
-    }
-    else {
-      rate = 50;
-      ulprev = ulnow;
-    }
-    if(rate >= 50) {
-      /* keeps the looping down to 20 times per second in the crazy case */
-      config->readbusy = FALSE;
-      curl_easy_pause(per->curl, CURLPAUSE_CONT);
-    }
-    else
-      /* sleep half a period */
-      tool_go_sleep(25);
+    if(ulprev == ulnow)
+      tool_go_sleep(1); /* prevent busy-loop */
+    config->readbusy = FALSE;
+    curl_easy_pause(per->curl, CURLPAUSE_CONT);
   }
-
+  ulprev = ulnow;
   return per->noprogress ? 0 : CURL_PROGRESSFUNC_CONTINUE;
 }


### PR DESCRIPTION
To improve performance at the expense of doing more loops.

Alternative to  #17566, meant to simplify.