### PR TITLE
tool: Implement non-blocking STDIN read on Windows

### DIFF
--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -95,7 +95,7 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
    execute */
   if(!strcmp(per->uploadfile, ".") && per->infd > 0) {
 #ifdef _WIN32
-    rc = recv(per->infd, buffer, sz * nmemb, 0);
+    rc = recv(per->infd, buffer, curlx_uztosi(sz * nmemb), 0);
     if(rc < 0) {
       if(SOCKERRNO == SOCKEWOULDBLOCK) {
         CURL_SETERRNO(0);

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -106,7 +106,8 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
       rc = 0;
     }
 #else
-    warnf(per->config->global, "per->infd != 0: %d", per->infd);
+    warnf(per->config->global, "per->infd != 0: FD == %d. This behavior"
+          " is only supported on desktop Windows", per->infd);
 #endif
   }
   else {

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -94,7 +94,7 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
    On linux per->infd should be STDIN (0) and the block below should not
    execute */
   if(!strcmp(per->uploadfile, ".") && per->infd > 0) {
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
     rc = recv(per->infd, buffer, curlx_uztosi(sz * nmemb), 0);
     if(rc < 0) {
       if(SOCKERRNO == SOCKEWOULDBLOCK) {

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -97,7 +97,7 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 #ifdef _WIN32
     rc = recv(per->infd, buffer, sz * nmemb, 0);
     if(rc < 0) {
-      if(WSAGetLastError() == WSAEWOULDBLOCK) {
+      if(SOCKERRNO == SOCKEWOULDBLOCK) {
         CURL_SETERRNO(0);
         config->readbusy = TRUE;
         return CURL_READFUNC_PAUSE;

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -89,9 +89,9 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   }
 
   /* If we are on Windows, and using `-T .`, then per->infd points to a socket
-   connected to STDIN via a reader thread, and needs to be read with recv()
-   Make sure we are in non-blocking mode and infd is not regular STDIN
-   On linux per->infd should be STDIN (0) and the block below should not
+   connected to stdin via a reader thread, and needs to be read with recv()
+   Make sure we are in non-blocking mode and infd is not regular stdin
+   On Linux per->infd should be stdin (0) and the block below should not
    execute */
   if(!strcmp(per->uploadfile, ".") && per->infd > 0) {
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -32,7 +32,6 @@
 #ifdef _WIN32
 #  include <stdlib.h>
 #  include <tlhelp32.h>
-#  include <ws2tcpip.h>
 #  include "tool_cfgable.h"
 #  include "tool_libinfo.h"
 #endif
@@ -759,7 +758,6 @@ struct win_thread_data {
 static DWORD WINAPI win_stdin_thread_func(void *thread_data)
 {
   struct win_thread_data *tdata = (struct win_thread_data *)thread_data;
-  char clientIp[INET_ADDRSTRLEN];
   DWORD n;
   int nwritten;
   char buffer[BUFSIZ];
@@ -775,8 +773,6 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
     errorf(tdata->global, "accept error: %08lx\n", GetLastError());
     goto ThreadCleanup;
   }
-
-  inet_ntop(AF_INET, &clientAddr.sin_addr, clientIp, INET_ADDRSTRLEN);
 
   closesocket(tdata->socket_l);
   tdata->socket_l = INVALID_SOCKET;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -767,7 +767,7 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
   SOCKADDR_IN clientAddr;
   int clientAddrLen = sizeof(clientAddr);
 
-  SOCKET socket_w = accept(tdata->socket_l, (SOCKADDR*)&clientAddr,
+  curl_socket_t socket_w = accept(tdata->socket_l, (SOCKADDR*)&clientAddr,
                            &clientAddrLen);
 
   if(socket_w == CURL_SOCKET_BAD) {
@@ -812,9 +812,9 @@ ThreadCleanup:
 
 /* The background thread that reads and buffers the true stdin. */
 static HANDLE stdin_thread = NULL;
-static SOCKET socket_r = CURL_SOCKET_BAD;
+static curl_socket_t socket_r = CURL_SOCKET_BAD;
 
-SOCKET win32_stdin_read_thread(struct GlobalConfig *global)
+curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global)
 {
   int result;
   bool r;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -816,7 +816,6 @@ static SOCKET socket_r = INVALID_SOCKET;
 
 SOCKET win32_stdin_read_thread(struct GlobalConfig *global)
 {
-  int stdin_fd;
   int result;
   bool r;
   int rc = 0, socksize = 0;
@@ -911,22 +910,6 @@ SOCKET win32_stdin_read_thread(struct GlobalConfig *global)
     /* Set the stdin handle to read from the socket. */
     if(SetStdHandle(STD_INPUT_HANDLE, (HANDLE)socket_r) == 0) {
       errorf(global, "SetStdHandle error: %08lx", GetLastError());
-      break;
-    }
-
-    /* Need to redirect file descriptor 0 also. _open_osfhandle makes
-       a new file descriptor from an existing handle. Should always be
-       _O_BINARY. CURL_SET_BINMODE(stdin) is called prior to this
-       function. */
-    stdin_fd = _open_osfhandle((intptr_t)GetStdHandle(STD_INPUT_HANDLE),
-        _O_RDONLY | _O_BINARY);
-    if(stdin_fd == -1) {
-      errorf(global, "stdin_fd == -1 \n");
-      break;
-    }
-
-    if(dup2(stdin_fd, STDIN_FILENO) != 0) {
-      errorf(global, "dup2 != 0 \n");
       break;
     }
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -32,12 +32,14 @@
 #ifdef _WIN32
 #  include <stdlib.h>
 #  include <tlhelp32.h>
+#  include <ws2tcpip.h>
 #  include "tool_cfgable.h"
 #  include "tool_libinfo.h"
 #endif
 
 #include "tool_bname.h"
 #include "tool_doswin.h"
+#include "tool_msgs.h"
 
 #include <curlx.h>
 #include <memdebug.h> /* keep this as LAST include */

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -32,7 +32,6 @@
 #ifdef _WIN32
 #  include <stdlib.h>
 #  include <tlhelp32.h>
-#  include <processthreadsapi.h>
 #  include "tool_cfgable.h"
 #  include "tool_libinfo.h"
 #endif

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -771,10 +771,9 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
     errorf(tdata->global, "accept error: %08lx\n", GetLastError());
     goto ThreadCleanup;
   }
+
   char clientIp[INET_ADDRSTRLEN];
-  unsigned short clientPort;
   inet_ntop(AF_INET, &clientAddr.sin_addr, clientIp, INET_ADDRSTRLEN);
-    clientPort = ntohs(clientAddr.sin_port);
 
   closesocket(tdata->socket_l);
   tdata->socket_l = INVALID_SOCKET;
@@ -782,19 +781,19 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
     errorf(tdata->global, "shutdown error: %08lx\n", GetLastError());
     goto ThreadCleanup;
   }
-   for(;;) {
-     r = ReadFile(tdata->stdin_handle, buffer,
+  for(;;) {
+    r = ReadFile(tdata->stdin_handle, buffer,
       sizeof(buffer), &n, NULL);
-     if(r == 0)
-       break;
-     if(n == -1 || n == 0)
-       break;
-     nwritten = send(socket_w, buffer, n, 0);
-     if(nwritten == SOCKET_ERROR)
-       break;
-     if(nwritten != n)
-       break;
-   }
+    if(r == 0)
+      break;
+    if(n == -1 || n == 0)
+      break;
+    nwritten = send(socket_w, buffer, n, 0);
+    if(nwritten == SOCKET_ERROR)
+      break;
+    if(nwritten != n)
+      break;
+  }
 ThreadCleanup:
   CloseHandle(tdata->stdin_handle);
   tdata->stdin_handle = NULL;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -792,7 +792,7 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
     nwritten = send(socket_w, buffer, n, 0);
     if(nwritten == SOCKET_ERROR)
       break;
-    if(nwritten != n)
+    if((DWORD)nwritten != n)
       break;
   }
 ThreadCleanup:

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -838,11 +838,11 @@ SOCKET win32_stdin_read_thread(struct GlobalConfig *global)
     }
     /* Create the listening socket for the thread. When it starts, it will
     * accept our connection and begin writing STDIN data to the connection. */
-    tdata->socket_l = WSASocket(AF_INET, SOCK_STREAM,
+    tdata->socket_l = WSASocketW(AF_INET, SOCK_STREAM,
       IPPROTO_TCP, NULL, 0, WSA_FLAG_OVERLAPPED);
 
     if(tdata->socket_l == INVALID_SOCKET) {
-      errorf(global, "WSASocket error: %08lx", GetLastError());
+      errorf(global, "WSASocketW error: %08lx", GetLastError());
       break;
     }
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -917,12 +917,12 @@ SOCKET win32_stdin_read_thread(struct GlobalConfig *global)
   } while(0);
 
   if(rc != 1) {
-    if(socket_r != INVALID_SOCKET) {
+    if(socket_r != INVALID_SOCKET && tdata) {
       if(GetStdHandle(STD_INPUT_HANDLE) == (HANDLE)socket_r &&
         tdata->stdin_handle) {
-        /* restore STDIN */
-        SetStdHandle(STD_INPUT_HANDLE, tdata->stdin_handle);
-         tdata->stdin_handle = NULL;
+          /* restore STDIN */
+          SetStdHandle(STD_INPUT_HANDLE, tdata->stdin_handle);
+          tdata->stdin_handle = NULL;
         }
 
       closesocket(socket_r);

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -811,7 +811,7 @@ ThreadCleanup:
 static HANDLE stdin_thread = NULL;
 static SOCKET socket_r = INVALID_SOCKET;
 
-int win32_stdin_read_thread(struct GlobalConfig *global)
+SOCKET win32_stdin_read_thread(struct GlobalConfig *global)
 {
   int stdin_fd;
   int result;

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -742,6 +742,7 @@ CURLcode win32_init(void)
   return CURLE_OK;
 }
 
+#if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
 /* The following STDIN non - blocking read techniques are heavily inspired
    by nmap and ncat (https://nmap.org/ncat/) */
 struct win_thread_data {
@@ -945,6 +946,8 @@ SOCKET win32_stdin_read_thread(struct GlobalConfig *global)
   assert(socket_r != INVALID_SOCKET);
   return socket_r;
 }
+
+#endif /* !CURL_WINDOWS_UWP && !UNDER_CE */
 
 #endif /* _WIN32 */
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -32,6 +32,7 @@
 #ifdef _WIN32
 #  include <stdlib.h>
 #  include <tlhelp32.h>
+#  include <processthreadsapi.h>
 #  include "tool_cfgable.h"
 #  include "tool_libinfo.h"
 #endif

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -757,7 +757,9 @@ struct win_thread_data {
 static DWORD WINAPI win_stdin_thread_func(void *thread_data)
 {
   struct win_thread_data *tdata = (struct win_thread_data *)thread_data;
-  DWORD n, nwritten;
+  char clientIp[INET_ADDRSTRLEN];
+  DWORD n;
+  int nwritten;
   char buffer[BUFSIZ];
   BOOL r;
 
@@ -772,7 +774,6 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
     goto ThreadCleanup;
   }
 
-  char clientIp[INET_ADDRSTRLEN];
   inet_ntop(AF_INET, &clientAddr.sin_addr, clientIp, INET_ADDRSTRLEN);
 
   closesocket(tdata->socket_l);
@@ -786,7 +787,7 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
       sizeof(buffer), &n, NULL);
     if(r == 0)
       break;
-    if(n == -1 || n == 0)
+    if(n == 0)
       break;
     nwritten = send(socket_w, buffer, n, 0);
     if(nwritten == SOCKET_ERROR)
@@ -835,10 +836,10 @@ SOCKET win32_stdin_read_thread(struct GlobalConfig *global)
     }
     /* Create the listening socket for the thread. When it starts, it will
     * accept our connection and begin writing STDIN data to the connection. */
-    tdata->socket_l = (int)WSASocket(AF_INET, SOCK_STREAM,
+    tdata->socket_l = WSASocket(AF_INET, SOCK_STREAM,
       IPPROTO_TCP, NULL, 0, WSA_FLAG_OVERLAPPED);
 
-    if(tdata->socket_l == -1) {
+    if(tdata->socket_l == INVALID_SOCKET) {
       errorf(global, "WSASocket error: %08lx", GetLastError());
       break;
     }

--- a/src/tool_doswin.h
+++ b/src/tool_doswin.h
@@ -54,6 +54,7 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
 #endif
 struct curl_slist *GetLoadedModulePaths(void);
 CURLcode win32_init(void);
+SOCKET win32_stdin_read_thread(struct GlobalConfig *global);
 
 #endif /* _WIN32 */
 

--- a/src/tool_doswin.h
+++ b/src/tool_doswin.h
@@ -56,7 +56,7 @@ struct curl_slist *GetLoadedModulePaths(void);
 CURLcode win32_init(void);
 
 #if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
-SOCKET win32_stdin_read_thread(struct GlobalConfig *global);
+curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global);
 #endif /* !CURL_WINDOWS_UWP && !UNDER_CE */
 
 #endif /* _WIN32 */

--- a/src/tool_doswin.h
+++ b/src/tool_doswin.h
@@ -54,7 +54,10 @@ CURLcode FindWin32CACert(struct OperationConfig *config,
 #endif
 struct curl_slist *GetLoadedModulePaths(void);
 CURLcode win32_init(void);
+
+#if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
 SOCKET win32_stdin_read_thread(struct GlobalConfig *global);
+#endif /* !CURL_WINDOWS_UWP && !UNDER_CE */
 
 #endif /* _WIN32 */
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1068,7 +1068,7 @@ static void check_stdin_upload(struct GlobalConfig *global,
 
   CURL_SET_BINMODE(stdin);
   if(!strcmp(per->uploadfile, ".")) {
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
     /* non - blocking stdin behavior on Windows is challenging
        Spawn a new thread that will read from stdin and write
        out to a socket */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1077,9 +1077,10 @@ static void check_stdin_upload(struct GlobalConfig *global,
     if(f == INVALID_SOCKET)
       warnf(global, "win32_stdin_read_thread returned INVALID_SOCKET "
           "will fall back to blocking mode");
-    else if(f > INT_MAX){
+    else if(f > INT_MAX) {
       warnf(global, "win32_stdin_read_thread returned identifier "
           "larger than INT_MAX, will fall back to blocking mode");
+    }
     else
       per->infd = (int)f;
 #endif

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -574,12 +574,14 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
   if(!curl || !config)
     return result;
 
-  if(!strcmp(per->uploadfile, ".") && per->infd > 0) {
+  if(per->uploadfile) {
+    if(!strcmp(per->uploadfile, ".") && per->infd > 0) {
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
-    sclose(per->infd);
+      sclose(per->infd);
 #else
-    warnf(per->config->global, "Closing per->infd != 0: %d", per->infd);
+      warnf(per->config->global, "Closing per->infd != 0: %d", per->infd);
 #endif
+    }
   }
   else {
     if(per->infdopen) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1072,7 +1072,7 @@ static void check_stdin_upload(struct GlobalConfig *global,
     /* non - blocking stdin behavior on Windows is challenging
        Spawn a new thread that will read from stdin and write
        out to a socket */
-    int f = win32_stdin_read_thread(global);
+    int f = (int)win32_stdin_read_thread(global);
 
     if(f == INVALID_SOCKET)
       warnf(global, "win32_stdin_read_thread returned INVALID_SOCKET"

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1084,7 +1084,7 @@ static void check_stdin_upload(struct GlobalConfig *global,
     /* non-blocking stdin behavior on Windows is challenging
        Spawn a new thread that will read from stdin and write
        out to a socket */
-    SOCKET f = win32_stdin_read_thread(global);
+    curl_socket_t f = win32_stdin_read_thread(global);
 
     if(f == CURL_SOCKET_BAD)
       warnf(global, "win32_stdin_read_thread returned INVALID_SOCKET "

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1086,7 +1086,7 @@ static void check_stdin_upload(struct GlobalConfig *global,
        out to a socket */
     SOCKET f = win32_stdin_read_thread(global);
 
-    if(f == INVALID_SOCKET)
+    if(f == CURL_SOCKET_BAD)
       warnf(global, "win32_stdin_read_thread returned INVALID_SOCKET "
             "will fall back to blocking mode");
     else if(f > INT_MAX) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -579,7 +579,9 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
       sclose(per->infd);
 #else
-      warnf(per->config->global, "Closing per->infd != 0: %d", per->infd);
+      warnf(per->config->global, "Closing per->infd != 0: FD == "
+            "%d. This behavior is only supported on desktop "
+            " Windows", per->infd);
 #endif
     }
   }
@@ -1088,10 +1090,13 @@ static void check_stdin_upload(struct GlobalConfig *global,
 
     if(f == CURL_SOCKET_BAD)
       warnf(global, "win32_stdin_read_thread returned INVALID_SOCKET "
-            "will fall back to blocking mode");
+            "falling back to blocking mode");
     else if(f > INT_MAX) {
       warnf(global, "win32_stdin_read_thread returned identifier "
-            "larger than INT_MAX, will fall back to blocking mode");
+            "larger than INT_MAX. This should not happen unless "
+            "the upper 32 bits of a Windows socket have started "
+            "being used for something... falling back to blocking "
+            "mode");
       sclose(f);
     }
     else

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1072,13 +1072,16 @@ static void check_stdin_upload(struct GlobalConfig *global,
     /* non - blocking stdin behavior on Windows is challenging
        Spawn a new thread that will read from stdin and write
        out to a socket */
-    int f = (int)win32_stdin_read_thread(global);
+    SOCKET f = win32_stdin_read_thread(global);
 
     if(f == INVALID_SOCKET)
-      warnf(global, "win32_stdin_read_thread returned INVALID_SOCKET"
+      warnf(global, "win32_stdin_read_thread returned INVALID_SOCKET "
           "will fall back to blocking mode");
+    else if(f > INT_MAX){
+      warnf(global, "win32_stdin_read_thread returned identifier "
+          "larger than INT_MAX, will fall back to blocking mode");
     else
-      per->infd = f;
+      per->infd = (int)f;
 #endif
     if(curlx_nonblock((curl_socket_t)per->infd, TRUE) < 0)
       warnf(global,

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1081,17 +1081,17 @@ static void check_stdin_upload(struct GlobalConfig *global,
   CURL_SET_BINMODE(stdin);
   if(!strcmp(per->uploadfile, ".")) {
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
-    /* non - blocking stdin behavior on Windows is challenging
+    /* non-blocking stdin behavior on Windows is challenging
        Spawn a new thread that will read from stdin and write
        out to a socket */
     SOCKET f = win32_stdin_read_thread(global);
 
     if(f == INVALID_SOCKET)
       warnf(global, "win32_stdin_read_thread returned INVALID_SOCKET "
-          "will fall back to blocking mode");
+            "will fall back to blocking mode");
     else if(f > INT_MAX) {
       warnf(global, "win32_stdin_read_thread returned identifier "
-          "larger than INT_MAX, will fall back to blocking mode");
+            "larger than INT_MAX, will fall back to blocking mode");
       sclose(f);
     }
     else


### PR DESCRIPTION
Implements a seperate read thread for STDIN on Windows when curl is run with -T/--upload-file .

This uses a similar technique to the nmap/ncat project, spawning a seperate thread which creates a loop-back bound socket, sending STDIN into this socket, and reading from the other end of said TCP socket in a non-blocking way in the rest of curl.

Fixes #17451