### PR TITLE
GHA/windows: enable H3 in the MSVC OpenSSL job

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -838,6 +838,8 @@ jobs:
               mingw-w64-ucrt-x86_64-openssl
               mingw-w64-ucrt-x86_64-libssh2
               mingw-w64-ucrt-x86_64-nghttp2
+              mingw-w64-ucrt-x86_64-nghttp3
+              mingw-w64-ucrt-x86_64-ngtcp2
 
             arch: 'x64'
             env: 'ucrt-x86_64'
@@ -846,7 +848,7 @@ jobs:
             chkprefill: '_chkprefill'
             config: >-
               -DENABLE_DEBUG=ON
-              -DCURL_USE_OPENSSL=ON
+              -DCURL_USE_OPENSSL=ON -DUSE_NGTCP2=ON
               -DOPENSSL_INCLUDE_DIR=/ucrt64/include
               -DSSL_EAY_DEBUG=/ucrt64/lib/libssl.dll.a
               -DSSL_EAY_RELEASE=/ucrt64/lib/libssl.dll.a
@@ -864,6 +866,11 @@ jobs:
               -DLIBSSH2_LIBRARY=/ucrt64/lib/libssh2.dll.a
               -DNGHTTP2_INCLUDE_DIR=/ucrt64/include
               -DNGHTTP2_LIBRARY=/ucrt64/lib/libnghttp2.dll.a
+              -DNGHTTP3_INCLUDE_DIR=/ucrt64/include
+              -DNGHTTP3_LIBRARY=/ucrt64/lib/libnghttp3.dll.a
+              -DNGTCP2_INCLUDE_DIR=/ucrt64/include
+              -DNGTCP2_LIBRARY=/ucrt64/lib/libngtcp2.dll.a
+              -DNGTCP2_CRYPTO_OSSL_LIBRARY=/ucrt64/lib/libngtcp2_crypto_ossl.dll.a
 
           - name: 'schannel U'
             install-vcpkg: 'zlib libssh2[core,zlib]'


### PR DESCRIPTION
Requires windows-runner 20250602.1 for ngtcp2 1.13.0.

Follow-up to c129d0b1a8769b352a3cf906fa0d3919b4a8ea3d #17561
Ref: https://github.com/curl/curl/pull/17561#issuecomment-2959583138
