### PR TITLE
cmake: drop never propagated C macros

### DIFF
--- a/lib/config-riscos.h
+++ b/lib/config-riscos.h
@@ -186,9 +186,6 @@
 /* Number of bits in a file offset, on hosts where this is settable. */
 #undef _FILE_OFFSET_BITS
 
-/* Define for large files, on AIX-style hosts. */
-#undef _LARGE_FILES
-
 /* Define to empty if `const' does not conform to ANSI C. */
 #undef const
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -806,12 +806,6 @@ ${SIZEOF_TIME_T_CODE}
 /* define this if you need it to compile thread-safe code */
 #cmakedefine _THREAD_SAFE ${_THREAD_SAFE}
 
-/* Define to empty if `const' does not conform to ANSI C. */
-#cmakedefine const ${const}
-
-/* Define to `unsigned int' if <sys/types.h> does not define. */
-#cmakedefine size_t ${size_t}
-
 /* the signed version of size_t */
 #cmakedefine ssize_t ${ssize_t}
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -800,12 +800,6 @@ ${SIZEOF_TIME_T_CODE}
 /* Number of bits in a file offset, on hosts where this is settable. */
 #cmakedefine _FILE_OFFSET_BITS ${_FILE_OFFSET_BITS}
 
-/* Define for large files, on AIX-style hosts. */
-#cmakedefine _LARGE_FILES ${_LARGE_FILES}
-
-/* define this if you need it to compile thread-safe code */
-#cmakedefine _THREAD_SAFE ${_THREAD_SAFE}
-
 /* the signed version of size_t */
 #cmakedefine ssize_t ${ssize_t}
 


### PR DESCRIPTION
Delete macros from `curl_config.h.cmake` that were never set by
the CMake script: `_LARGE_FILES`, `_THREAD_SAFE`, `const`, `size_t`.

Also:
- lib/config-riscos.h: drop `#undef _LARGE_FILES`. This is an
  IBM-specific macro, no need to unset it on other platforms.

Cherry-picked from #17576