### PR TITLE
http_ntlm: protect against (impossible?) null deref

### DIFF
--- a/lib/http_ntlm.c
+++ b/lib/http_ntlm.c
@@ -168,6 +168,9 @@ CURLcode Curl_output_ntlm(struct Curl_easy *data, bool proxy)
     authp = &data->state.authhost;
   }
   ntlm = Curl_auth_ntlm_get(conn, proxy);
+  DEBUGASSERT(ntlm);
+  if(!ntlm)
+    return CURLE_OUT_OF_MEMORY;
   authp->done = FALSE;
 
   /* not set means empty */


### PR DESCRIPTION
Make code analyzers happy