### PR TITLE
GHA/non-native: skip 2707 instead of all WebSocket tests on OpenBSD

### DIFF
--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -122,7 +122,7 @@ jobs:
             bld/src/curl --disable --version
             if [ "${MATRIX_ARCH}" = 'x86_64' ]; then  # Slow on emulated CPU
               time cmake --build bld --target testdeps
-              export TFLAGS='-j8 !WebSockets'
+              export TFLAGS='-j8 !2707'  # Skip 2707 'ws: Peculiar frame sizes' on suspicion of hangs
               time cmake --build bld --target test-ci
             fi
             echo '::group::build examples'


### PR DESCRIPTION
Narrowing down the test which may be causing the flaky 6-minute long
delays and CI failures.

Suggested-by: Calvin Ruocco
Ref: https://github.com/curl/curl/pull/17562#issuecomment-2961629713

Follow-up to 05db18e0541851a6fa71fb61e9c37bba4f56bce8 #17562
Follow-up to d3594be6531df3d5eafcdd09f84ad9dee1777028 #17136
