### PR TITLE
remove Curl_ssl false_start

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -377,8 +377,6 @@ static CURLcode doh_probe_run(struct Curl_easy *data,
      options should be added to check doh proxy insecure separately,
      CURLOPT_DOH_PROXY_SSL_VERIFYHOST and CURLOPT_DOH_PROXY_SSL_VERIFYPEER.
      */
-  if(data->set.ssl.falsestart)
-    ERROR_CHECK_SETOPT(CURLOPT_SSL_FALSESTART, 1L);
   if(data->set.str[STRING_SSL_CAFILE]) {
     ERROR_CHECK_SETOPT(CURLOPT_CAINFO,
                        data->set.str[STRING_SSL_CAFILE]);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1081,12 +1081,9 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     break;
   case CURLOPT_SSL_FALSESTART:
     /*
-     * Enable TLS false start.
+     * No TLS backends support false start anymore.
      */
-    if(!Curl_ssl_false_start())
-      return CURLE_NOT_BUILT_IN;
-
-    data->set.ssl.falsestart = enabled;
+    return CURLE_NOT_BUILT_IN;
     break;
   case CURLOPT_CERTINFO:
 #ifdef USE_SSL

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -295,7 +295,6 @@ struct ssl_config_data {
   char *key_type; /* format for private key (default: PEM) */
   char *key_passwd; /* plain text private key password */
   BIT(certinfo);     /* gather lots of certificate info */
-  BIT(falsestart);
   BIT(earlydata);    /* use tls1.3 early data */
   BIT(enable_beast); /* allow this flaw for interoperability's sake */
   BIT(no_revoke);    /* disable SSL certificate revocation checks */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -2210,7 +2210,6 @@ const struct Curl_ssl Curl_ssl_gnutls = {
   NULL,                          /* set_engine */
   NULL,                          /* set_engine_default */
   NULL,                          /* engines_list */
-  NULL,                          /* false_start */
   gtls_sha256sum,                /* sha256sum */
   gtls_recv,                     /* recv decrypted data */
   gtls_send,                     /* send data to encrypt */

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1618,7 +1618,6 @@ const struct Curl_ssl Curl_ssl_mbedtls = {
   NULL,                             /* set_engine */
   NULL,                             /* set_engine_default */
   NULL,                             /* engines_list */
-  NULL,                             /* false_start */
   mbedtls_sha256sum,                /* sha256sum */
   mbed_recv,                        /* recv decrypted data */
   mbed_send,                        /* send data to encrypt */

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5667,7 +5667,6 @@ const struct Curl_ssl Curl_ssl_openssl = {
   ossl_set_engine,          /* set_engine or provider */
   ossl_set_engine_default,  /* set_engine_default */
   ossl_engines_list,        /* engines_list */
-  NULL,                     /* false_start */
 #ifndef OPENSSL_NO_SHA256
   ossl_sha256sum,           /* sha256sum */
 #else

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1437,7 +1437,6 @@ const struct Curl_ssl Curl_ssl_rustls = {
   NULL,                            /* set_engine */
   NULL,                            /* set_engine_default */
   NULL,                            /* engines_list */
-  NULL,                            /* false_start */
   NULL,                            /* sha256sum */
   cr_recv,                         /* recv decrypted data */
   cr_send,                         /* send data to encrypt */

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2760,7 +2760,6 @@ const struct Curl_ssl Curl_ssl_schannel = {
   NULL,                              /* set_engine */
   NULL,                              /* set_engine_default */
   NULL,                              /* engines_list */
-  NULL,                              /* false_start */
   schannel_sha256sum,                /* sha256sum */
   schannel_recv,                     /* recv decrypted data */
   schannel_send,                     /* send data to encrypt */

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -876,16 +876,6 @@ bool Curl_ssl_cert_status_request(void)
   return FALSE;
 }
 
-/*
- * Check whether the SSL backend supports false start.
- */
-bool Curl_ssl_false_start(void)
-{
-  if(Curl_ssl->false_start)
-    return Curl_ssl->false_start();
-  return FALSE;
-}
-
 static int multissl_init(void)
 {
   if(multissl_setup(NULL))
@@ -966,7 +956,6 @@ static const struct Curl_ssl Curl_ssl_multi = {
   NULL,                              /* set_engine */
   NULL,                              /* set_engine_default */
   NULL,                              /* engines_list */
-  NULL,                              /* false_start */
   NULL,                              /* sha256sum */
   multissl_recv_plain,               /* recv decrypted data */
   multissl_send_plain,               /* send data to encrypt */

--- a/lib/vtls/vtls.h
+++ b/lib/vtls/vtls.h
@@ -190,8 +190,6 @@ CURLcode Curl_pin_peer_pubkey(struct Curl_easy *data,
 
 bool Curl_ssl_cert_status_request(void);
 
-bool Curl_ssl_false_start(void);
-
 /* The maximum size of the SSL channel binding is 85 bytes, as defined in
  * RFC 5929, Section 4.1. The 'tls-server-end-point:' prefix is 21 bytes long,
  * and SHA-512 is the longest supported hash algorithm, with a digest length of
@@ -274,7 +272,6 @@ extern struct Curl_cftype Curl_cft_ssl_proxy;
 #define Curl_ssl_free_certinfo(x) Curl_nop_stmt
 #define Curl_ssl_random(x,y,z) ((void)x, CURLE_NOT_BUILT_IN)
 #define Curl_ssl_cert_status_request() FALSE
-#define Curl_ssl_false_start() FALSE
 #define Curl_ssl_get_internals(a,b,c,d) NULL
 #define Curl_ssl_supports(a,b) FALSE
 #define Curl_ssl_cfilter_add(a,b,c) CURLE_NOT_BUILT_IN

--- a/lib/vtls/vtls_int.h
+++ b/lib/vtls/vtls_int.h
@@ -175,7 +175,6 @@ struct Curl_ssl {
   CURLcode (*set_engine_default)(struct Curl_easy *data);
   struct curl_slist *(*engines_list)(struct Curl_easy *data);
 
-  bool (*false_start)(void);
   CURLcode (*sha256sum)(const unsigned char *input, size_t inputlen,
                     unsigned char *sha256sum, size_t sha256sumlen);
   ssize_t (*recv_plain)(struct Curl_cfilter *cf, struct Curl_easy *data,

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2285,7 +2285,6 @@ const struct Curl_ssl Curl_ssl_wolfssl = {
   NULL,                            /* set_engine */
   NULL,                            /* set_engine_default */
   NULL,                            /* engines_list */
-  NULL,                            /* false_start */
   wssl_sha256sum,                  /* sha256sum */
   wssl_recv,                       /* recv decrypted data */
   wssl_send,                       /* send data to encrypt */

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -361,9 +361,6 @@ static CURLcode ssl_setopts(struct GlobalConfig *global,
   if(config->doh_verifystatus)
     my_setopt_long(curl, CURLOPT_DOH_SSL_VERIFYSTATUS, 1);
 
-  if(config->falsestart)
-    my_setopt_long(curl, CURLOPT_SSL_FALSESTART, 1);
-
   my_setopt_SSLVERSION(curl, CURLOPT_SSLVERSION,
                        config->ssl_version | config->ssl_version_max);
   if(config->proxy)

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -330,7 +330,6 @@ struct OperationConfig {
   BIT(proxy_ssl_auto_client_cert); /* proxy version of ssl_auto_client_cert */
   BIT(noalpn);                    /* enable/disable TLS ALPN extension */
   BIT(abstract_unix_socket);      /* path to an abstract Unix domain socket */
-  BIT(falsestart);
   BIT(path_as_is);
   BIT(suppress_connect_headers);  /* suppress proxy CONNECT response headers
                                      from user callbacks */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1999,7 +1999,7 @@ static ParameterError opt_bool(struct GlobalConfig *global,
     config->doh_verifystatus = toggle;
     break;
   case C_FALSE_START: /* --false-start */
-    config->falsestart = toggle;
+    opt_depr(global, a);
     break;
   case C_SSL_NO_REVOKE: /* --ssl-no-revoke */
     config->ssl_no_revoke = toggle;


### PR DESCRIPTION
The secure transport vTLS backend was the only `Curl_ssl` struct instance that populated the `false_start` field. Since it was removed in https://github.com/curl/curl/pull/16677, we can now remove that field entirely. This was a protocol feature specific to TLS 1.2 that has been replaced by the more widely adopted TLS 1.3 early data mechanisms. For this reason it seems unlikely anyone would add support to existing backends that lack it today.