### PR TITLE
tool_getparam: drop code handling --false-start

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -361,9 +361,6 @@ static CURLcode ssl_setopts(struct GlobalConfig *global,
   if(config->doh_verifystatus)
     my_setopt_long(curl, CURLOPT_DOH_SSL_VERIFYSTATUS, 1);
 
-  if(config->falsestart)
-    my_setopt_long(curl, CURLOPT_SSL_FALSESTART, 1);
-
   my_setopt_SSLVERSION(curl, CURLOPT_SSLVERSION,
                        config->ssl_version | config->ssl_version_max);
   if(config->proxy)

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -330,7 +330,6 @@ struct OperationConfig {
   BIT(proxy_ssl_auto_client_cert); /* proxy version of ssl_auto_client_cert */
   BIT(noalpn);                    /* enable/disable TLS ALPN extension */
   BIT(abstract_unix_socket);      /* path to an abstract Unix domain socket */
-  BIT(falsestart);
   BIT(path_as_is);
   BIT(suppress_connect_headers);  /* suppress proxy CONNECT response headers
                                      from user callbacks */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1999,7 +1999,7 @@ static ParameterError opt_bool(struct GlobalConfig *global,
     config->doh_verifystatus = toggle;
     break;
   case C_FALSE_START: /* --false-start */
-    config->falsestart = toggle;
+    opt_depr(global, a);
     break;
   case C_SSL_NO_REVOKE: /* --ssl-no-revoke */
     config->ssl_no_revoke = toggle;


### PR DESCRIPTION
No backend supports it anymore, declare it deprecated.