### PR TITLE
lib: rm superfluous setopt break for CURLOPT_SSL_FALSESTART

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1084,7 +1084,6 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      * No TLS backends support false start anymore.
      */
     return CURLE_NOT_BUILT_IN;
-    break;
   case CURLOPT_CERTINFO:
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CERTINFO))


### PR DESCRIPTION
Quick follow-up from https://github.com/curl/curl/pull/17595 pointed out [in this commit-level comment](https://github.com/curl/curl/commit/1e2e808defe6850295baa002d07cde9a129ec791#r159957160) from @forlanm.

Reported-by: 4lan.m
Ref: https://github.com/curl/curl/commit/1e2e808defe6850295baa002d07cde9a129ec791#r159957160
Follow-up to 1e2e808defe6850295baa002d07cde9a129ec791 #17595
