### PR TITLE
warnless: replace `read()`/`write()` wrapper functions with macros (Windows)

### DIFF
--- a/lib/curlx/warnless.c
+++ b/lib/curlx/warnless.c
@@ -296,20 +296,6 @@ size_t curlx_sitouz(int sinum)
 #endif
 }
 
-#ifdef _WIN32
-
-ssize_t curlx_read(int fd, void *buf, size_t count)
-{
-  return (ssize_t)read(fd, buf, curlx_uztoui(count));
-}
-
-ssize_t curlx_write(int fd, const void *buf, size_t count)
-{
-  return (ssize_t)write(fd, buf, curlx_uztoui(count));
-}
-
-#endif /* _WIN32 */
-
 /* Ensure that warnless.h redefinitions continue to have an effect
    in "unity" builds. */
 #undef HEADER_CURL_WARNLESS_H_REDEFS

--- a/lib/curlx/warnless.h
+++ b/lib/curlx/warnless.h
@@ -57,14 +57,6 @@ unsigned short curlx_uitous(unsigned int uinum);
 
 size_t curlx_sitouz(int sinum);
 
-#ifdef _WIN32
-
-ssize_t curlx_read(int fd, void *buf, size_t count);
-
-ssize_t curlx_write(int fd, const void *buf, size_t count);
-
-#endif /* _WIN32 */
-
 #endif /* HEADER_CURL_WARNLESS_H */
 
 #ifndef HEADER_CURL_WARNLESS_H_REDEFS
@@ -72,9 +64,9 @@ ssize_t curlx_write(int fd, const void *buf, size_t count);
 
 #ifdef _WIN32
 #undef  read
-#define read(fd, buf, count)  curlx_read(fd, buf, count)
+#define read(fd, buf, count)  (ssize_t)_read(fd, buf, curlx_uztoui(count))
 #undef  write
-#define write(fd, buf, count) curlx_write(fd, buf, count)
+#define write(fd, buf, count) (ssize_t)_write(fd, buf, curlx_uztoui(count))
 #endif
 
 #endif /* HEADER_CURL_WARNLESS_H_REDEFS */


### PR DESCRIPTION
Map them to `_read()`/`_write()` (with underscore) to avoid recursive
mapping and to use the non-compatibility naming on Windows.

https://learn.microsoft.com/cpp/c-runtime-library/reference/read
https://learn.microsoft.com/cpp/c-runtime-library/reference/write

Follow-up to 6239146e931fd3127f6994975a56d1b4884a708a