### PR TITLE
cmake: make docs depend on support files

### DIFF
--- a/docs/cmdline-opts/CMakeLists.txt
+++ b/docs/cmdline-opts/CMakeLists.txt
@@ -29,7 +29,9 @@ add_custom_command(OUTPUT "${CURL_MANPAGE}" "${CURL_ASCIIPAGE}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" mainpage ${DPAGES} > "${CURL_MANPAGE}"
   COMMAND "${PERL_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/scripts/managen" ascii ${DPAGES} > "${CURL_ASCIIPAGE}"
-  DEPENDS "${PROJECT_SOURCE_DIR}/scripts/managen" ${DPAGES}
+  DEPENDS "${PROJECT_SOURCE_DIR}/scripts/managen" ${DPAGES} ${SUPPORT}
+    "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/mainpage.idx"
   VERBATIM
 )
 


### PR DESCRIPTION
As in autotools.