### PR TITLE
QUIC with v2 support.

### DIFF
--- a/docs/cmdline-opts/http3.md
+++ b/docs/cmdline-opts/http3.md
@@ -7,7 +7,7 @@ Protocols: HTTP
 Added: 7.66.0
 Mutexed: http1.1 http1.0 http2 http2-prior-knowledge http3-only
 Requires: HTTP/3
-Help: Use HTTP/3
+Help: Use HTTP/3 with optional QUIC version (v1 or v2)
 Category: http
 Multi: mutex
 See-also:
@@ -23,6 +23,10 @@ Attempt HTTP/3 to the host in the URL, but fallback to earlier HTTP versions
 if the HTTP/3 connection establishment fails or is slow. HTTP/3 is only
 available for HTTPS and not for HTTP URLs.
 
+This option allows specifying which version of QUIC to use for HTTP/3. Provide
+an argument `v1` (for QUICv1, the default) or `v2` (for QUICv2). If no
+argument is provided, `v1` is used.
+
 This option allows a user to avoid using the Alt-Svc method of upgrading to
 HTTP/3 when you know or suspect that the target speaks HTTP/3 on the given
 host and port.
@@ -33,3 +37,14 @@ still tries to proceed with an older HTTP version. The fallback performs the
 regular negotiation between HTTP/1 and HTTP/2.
 
 Use --http3-only for similar functionality *without* a fallback.
+
+## Examples
+
+To attempt HTTP/3 (QUICv1 by default):
+`curl --http3 https://example.com`
+
+To attempt HTTP/3 with QUICv1 explicitly:
+`curl --http3 v1 https://example.com`
+
+To attempt HTTP/3 with QUICv2:
+`curl --http3 v2 https://example.com`

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -88,6 +88,14 @@ given in the URL, with fallback to earlier HTTP versions if needed.
 server given in the URL and does not downgrade to earlier HTTP version if the
 server does not support HTTP/3.
 
+## CURL_HTTP_VERSION_3_V2
+
+(Added in curl 8.x.x) This option makes libcurl attempt to use HTTP/3 over
+QUICv2 to the host given in the URL. For HTTPS only. For HTTP, this option
+makes libcurl return an error. If QUICv2 is not supported or cannot be
+negotiated, it may fall back to other HTTP versions based on server
+capabilities and curl's configuration.
+
 # DEFAULT
 
 Since curl 7.62.0: CURL_HTTP_VERSION_2TLS

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2315,7 +2315,10 @@ typedef enum {
 #define CURL_HTTP_VERSION_3ONLY 31L /* Use HTTP/3 without fallback. For
                                        HTTPS only. For HTTP, this makes
                                        libcurl return error. */
-#define CURL_HTTP_VERSION_LAST  32L /* *ILLEGAL* http version */
+#define CURL_HTTP_VERSION_3_V2  32L /* Use HTTP/3 over QUICv2. For HTTPS only.
+                                       For HTTP, this makes libcurl return
+                                       error. */
+#define CURL_HTTP_VERSION_LAST  33L /* *ILLEGAL* http version */
 
 /* Convenience definition simple because the name of the version is HTTP/2 and
    not 2.0. The 2_0 version of the enum name was set while the version was

--- a/lib/http.c
+++ b/lib/http.c
@@ -216,6 +216,9 @@ void Curl_http_neg_init(struct Curl_easy *data, struct http_negotiation *neg)
   case CURL_HTTP_VERSION_3ONLY:
     neg->wanted = neg->allowed = (CURL_HTTP_V3x);
     break;
+  case CURL_HTTP_VERSION_3_V2:
+    neg->wanted = neg->allowed = (CURL_HTTP_V3x);
+    break;
   case CURL_HTTP_VERSION_NONE:
   default:
     neg->wanted = (CURL_HTTP_V1x | CURL_HTTP_V2x);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -310,6 +310,7 @@ static CURLcode setopt_HTTP_VERSION(struct Curl_easy *data, long arg)
 #ifdef USE_HTTP3
   case CURL_HTTP_VERSION_3:
   case CURL_HTTP_VERSION_3ONLY:
+  case CURL_HTTP_VERSION_3_V2:  
     /* accepted */
     break;
 #endif

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -260,6 +260,7 @@ test2200 test2201 test2202 test2203 test2204 test2205 \
 \
 test2300 test2301 test2302 test2303 test2304 test2306 \
 test2308 test2309 \
+test2390 test2391 \
 \
 test2400 test2401 test2402 test2403 test2404 test2405 test2406 \
 \

--- a/tests/data/test2390
+++ b/tests/data/test2390
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP/3
+QUICv2
+verbose logs
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+http/3
+</features>
+# No local server needed for this test
+# <server>
+# http/3
+# </server>
+<name>
+HTTP GET over HTTP/3 with QUICv2
+</name>
+<command>
+--http3 v2 https://nghttp2.org/httpbin/get
+</command>
+<verbose/>
+<output>
+{
+  "args": {},
+  "headers": {
+    "Accept": "*/*",
+    "Host": "nghttp2.org",
+    "User-Agent": "curl/%CURL_VERSION_MAJOR.%CURL_VERSION_MINOR.%CURL_VERSION_PATCH"
+  },
+  "origin": "%CLIENTIP",
+  "url": "https://nghttp2.org/httpbin/get"
+}
+</output>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<log>
+# Ensure that some basic HTTP/3 and connection messages appear
+ löytyi
+QUIC connect to .*
+HTTP/3 default connection
+</log>
+# We can't reliably verify QUICv2 negotiation from logs alone without specific server logs or debug output.
+# The main check is that the command doesn't fail and we get the expected output.
+<file name="stdout%TESTNUMBER">
+<jsonconverthtml/>
+<contains>
+  "url": "https://nghttp2.org/httpbin/get"
+</contains>
+<contains>
+  "Host": "nghttp2.org"
+</contains>
+</file>
+<errorcode>0</errorcode>
+</verify>
+</testcase>

--- a/tests/data/test2391
+++ b/tests/data/test2391
@@ -1,0 +1,72 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP/3
+QUICv2
+POST
+verbose logs
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+http/3
+</features>
+<name>
+HTTP POST over HTTP/3 with QUICv2
+</name>
+<command>
+--http3 v2 --data "param1=value1&param2=value2" https://nghttp2.org/httpbin/post
+</command>
+<verbose/>
+<output>
+{
+  "args": {},
+  "data": "param1=value1&param2=value2",
+  "files": {},
+  "form": {
+    "param1": "value1",
+    "param2": "value2"
+  },
+  "headers": {
+    "Accept": "*/*",
+    "Content-Length": "27",
+    "Content-Type": "application/x-www-form-urlencoded",
+    "Host": "nghttp2.org",
+    "User-Agent": "curl/%CURL_VERSION_MAJOR.%CURL_VERSION_MINOR.%CURL_VERSION_PATCH"
+  },
+  "json": null,
+  "origin": "%CLIENTIP",
+  "url": "https://nghttp2.org/httpbin/post"
+}
+</output>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<log>
+# Ensure that some basic HTTP/3 and connection messages appear
+ löytyi
+QUIC connect to .*
+HTTP/3 default connection
+</log>
+<file name="stdout%TESTNUMBER">
+<jsonconverthtml/>
+<contains>
+  "url": "https://nghttp2.org/httpbin/post"
+</contains>
+<contains>
+  "data": "param1=value1&amp;param2=value2"
+</contains>
+<contains>
+    "param1": "value1"
+</contains>
+<contains>
+    "param2": "value2"
+</contains>
+</file>
+<errorcode>0</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
QUIC with V2 support.

V1 test with nginx
```
root@ubuntu:/src/curl# /src/curl/src/curl -vvvv -k -# -o /dev/null --http3 v1  https://127.0.0.1:8443/index.html
05:53:41.991309 [0-x] == Info: [MULTI] [INIT] added to multi, mid=1, running=1, total=2
05:53:41.991462 [0-x] == Info: [MULTI] [INIT] multi_timeout() says this has expired
05:53:41.991590 [0-x] == Info: [MULTI] [INIT] multi_wait(fds=1, timeout=0) tinternal=0
05:53:41.991798 [0-x] == Info: [MULTI] [INIT] -> [SETUP]
05:53:41.991900 [0-x] == Info: [MULTI] [SETUP] -> [CONNECT]
05:53:41.992027 [0-x] == Info: [READ] client_reset, clear readers
05:53:41.992189 [0-0] == Info: [MULTI] [CONNECT] [CPOOL] added connection 0. The cache now contains 1 members
05:53:41.992428 [0-0] == Info: [HTTPS-CONNECT] adding wanted h3
05:53:41.992568 [0-0] == Info: [HTTPS-CONNECT] adding wanted h2
05:53:41.992713 [0-0] == Info: [HTTPS-CONNECT] added
05:53:41.992857 [0-0] == Info: [MULTI] [CONNECT] -> [CONNECTING]
05:53:41.993035 [0-0] == Info: [HTTPS-CONNECT] connect, init
05:53:41.993186 [0-0] == Info: [HTTPS-CONNECT] set next attempt to start in 50ms
05:53:41.993364 [0-0] == Info: [HAPPY-EYEBALLS] created ipv4 (timeout 299999ms)
05:53:41.993587 [0-0] == Info: [HAPPY-EYEBALLS] ipv4 starting (timeout=299999ms)
05:53:41.993814 [0-0] == Info:   Trying 127.0.0.1:8443...
05:53:41.993969 [0-0] == Info: [UDP] cf_socket_open() -> 0, fd=4
05:53:41.994163 [0-0] == Info: [UDP] QUIC socket 4 connected: [127.0.0.1:42729] -> [127.0.0.1:8443]
05:53:41.994402 [0-0] == Info: [UDP] cf_udp_connect(), opened socket=4 (127.0.0.1:42729)
05:53:41.995714 [0-0] == Info: Attempting HTTP/3 QUIC version 1
05:53:41.996662 [0-0] == Info: [SSLS] find peer slot for 127.0.0.1:8443:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G among 25 slots
05:53:41.997001 [0-0] == Info: [SSLS] peer not found for 127.0.0.1:8443:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G
05:53:41.997345 [0-0] == Info: [SSLS] no cached session for 127.0.0.1:8443:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G
05:53:41.998439 [0-0] == Info: [HTTP/3] vquic_send(len=1200, gso=1200) -> 0, sent=1200
05:53:41.998706 [0-0] == Info: [HAPPY-EYEBALLS] ipv4 connect -> 0, connected=0
05:53:41.998933 [0-0] == Info: [HTTPS-CONNECT] connect -> 0, done=0
05:53:41.999116 [0-0] == Info: [HTTPS-CONNECT] Curl_conn_connect(block=0) -> 0, done=0
05:53:41.999347 [0-0] == Info: [UDP] adjust_pollset, !active, POLLIN fd=4
05:53:41.999578 [0-0] == Info: [HAPPY-EYEBALLS] adjust_pollset -> 1 socks
05:53:41.999769 [0-0] == Info: [HTTPS-CONNECT] adjust_pollset -> 1 socks
05:53:41.999966 [0-0] == Info: [MULTI] [CONNECTING] multi_wait pollset[fd=4 IN], timeouts=2
05:53:42.000215 [0-0] == Info: [MULTI] [CONNECTING] multi_wait(fds=2, timeout=43) tinternal=43
05:53:42.002872 [0-0] == Info: [HTTP/3] ossl_populate_x509_store, path=/etc/ssl/certs/ca-certificates.crt, blob=0
05:53:42.003253 [0-0] == Info: [HTTP/3] recvmmsg() -> 2 packets
05:53:42.004359 [0-0] == Info: Server certificate:
05:53:42.004602 [0-0] == Info:  subject: CN=ubuntu
05:53:42.004782 [0-0] == Info:  start date: Mar 14 02:55:49 2025 GMT
05:53:42.004965 [0-0] == Info:  expire date: Mar 12 02:55:49 2035 GMT
05:53:42.005178 [0-0] == Info:  issuer: CN=ubuntu
05:53:42.005359 [0-0] == Info:  SSL certificate verify result: self-signed certificate (18), continuing anyway.
05:53:42.005773 [0-0] == Info:   Certificate level 0: Public key type RSA (2048/112 Bits/secBits), signed using sha256WithRSAEncryption
05:53:42.006249 [0-0] == Info: [HTTP/3] handshake complete after 9ms
05:53:42.006442 [0-0] == Info: [HTTP/3] max bidi streams now 128, used 0
05:53:42.006638 [0-0] == Info: [HTTP/3] ingress, recvmmsg -> EAGAIN
05:53:42.006903 [0-0] == Info: [HTTP/3] recvd 2 packets with 1524 bytes -> 0
05:53:42.007226 [0-0] == Info: [HTTP/3] vquic_send_tail_split: [1200 gso=1200][1406 gso=1406]
05:53:42.007603 [0-0] == Info: [HTTP/3] vquic_send(len=1200, gso=1200) -> 0, sent=1200
05:53:42.007850 [0-0] == Info: [HTTP/3] vquic_send(len=1406, gso=1406) -> 0, sent=1406
05:53:42.008063 [0-0] == Info: [HTTP/3] peer verified
05:53:42.008198 [0-0] == Info: [MULTI] [CONNECTING] set expire[12] in 15000ns
05:53:42.008414 [0-0] == Info: [HTTP/3] connect -> 0, done=1
05:53:42.008574 [0-0] == Info: [HAPPY-EYEBALLS] ipv4 connect -> 0, connected=1
05:53:42.008804 [0-0] == Info: [HAPPY-EYEBALLS] Connected to 127.0.0.1 (127.0.0.1) port 8443
05:53:42.009061 [0-0] == Info: [HTTPS-CONNECT] connect+handshake h3: 15ms, 1st data: 8ms
05:53:42.009313 [0-0] == Info: [HTTPS-CONNECT] connect -> 0, done=1
05:53:42.009496 [0-0] == Info: [HTTPS-CONNECT] Curl_conn_connect(block=0) -> 0, done=1
05:53:42.009801 [0-0] == Info: Connected to 127.0.0.1 (127.0.0.1) port 8443
05:53:42.010122 [0-0] == Info: using HTTP/3
05:53:42.010239 [0-0] == Info: [MULTI] [CONNECTING] -> [PROTOCONNECT]
05:53:42.010489 [0-0] == Info: [MULTI] [PROTOCONNECT] -> [DO]
05:53:42.010643 [0-0] == Info: [HTTP/3] recvmmsg() -> 1 packets
05:53:42.010921 [0-0] == Info: [SSLS] find peer slot for 127.0.0.1:8443:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G among 25 slots
05:53:42.011392 [0-0] == Info: [SSLS] peer not found for 127.0.0.1:8443:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G
05:53:42.011808 [0-0] == Info: [SSLS] added session for 127.0.0.1:8443:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G [proto=0x304, valid_secs=7200, alpn=h3, earlydata=0, quic_tp=yes], peer has 1 sessions now
05:53:42.012511 [0-0] == Info: [SSLS] find peer slot for 127.0.0.1:8443:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G among 25 slots
05:53:42.012895 [0-0] == Info: [SSLS] added session for 127.0.0.1:8443:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G [proto=0x304, valid_secs=7200, alpn=h3, earlydata=0, quic_tp=yes], peer has 2 sessions now
05:53:42.013545 [0-0] == Info: [HTTP/3] [3] read_stream(len=1) -> 1
05:53:42.013799 [0-0] == Info: [HTTP/3] [3] read_stream(len=8) -> 8
05:53:42.014060 [0-0] == Info: [HTTP/3] [7] read_stream(len=1) -> 1
05:53:42.014272 [0-0] == Info: [HTTP/3] ingress, recvmmsg -> EAGAIN
05:53:42.014435 [0-0] == Info: [HTTP/3] recvd 1 packets with 538 bytes -> 0
05:53:42.014714 [0-0] == Info: [HTTP/3] peer idle timeout is 65000ms, set keep-alive to 32500 ms.
05:53:42.015029 [0-0] == Info: [HTTP/3] [0] OPENED stream for https://127.0.0.1:8443/index.html
05:53:42.015399 [0-0] == Info: [HTTP/3] [0] [:method: GET]
05:53:42.015548 [0-0] == Info: [HTTP/3] [0] [:scheme: https]
05:53:42.015719 [0-0] == Info: [HTTP/3] [0] [:authority: 127.0.0.1:8443]
05:53:42.015964 [0-0] == Info: [HTTP/3] [0] [:path: /index.html]
05:53:42.016111 [0-0] == Info: [HTTP/3] [0] [user-agent: curl/8.15.0-DEV]
05:53:42.016327 [0-0] == Info: [HTTP/3] [0] [accept: */*]
05:53:42.016523 [0-0] == Info: [HTTP/3] vquic_send_tail_split: [1444 gso=1444][100 gso=100]
05:53:42.016856 [0-0] == Info: [HTTP/3] vquic_send(len=1444, gso=1444) -> 0, sent=1444
05:53:42.017137 [0-0] == Info: [HTTP/3] vquic_send(len=100, gso=100) -> 0, sent=100
05:53:42.017371 [0-0] == Info: [HTTP/3] [0] cf_send(len=90) -> 0, 90
05:53:42.017582 [0-0] => Send header, 90 bytes (0x5a)
0000: GET /index.html HTTP/3
0018: Host: 127.0.0.1:8443
002e: User-Agent: curl/8.15.0-DEV
004b: Accept: */*
0058:
05:53:42.018060 [0-0] == Info: [MULTI] [DO] -> [DID]
05:53:42.018235 [0-0] == Info: [MULTI] [DID] -> [PERFORMING]
05:53:42.018436 [0-0] == Info: [HTTP/3] ingress, recvmmsg -> EAGAIN
05:53:42.018602 [0-0] == Info: [HTTP/3] [0] cf_recv(blen=102400) -> 81m, 0
05:53:42.018802 [0-0] == Info: Request completely sent off
05:53:42.018950 [0-0] == Info: [MULTI] [PERFORMING] multi_wait pollset[fd=4 IN], timeouts=2
05:53:42.019236 [0-0] == Info: [MULTI] [PERFORMING] multi_wait(fds=2, timeout=4) tinternal=4
05:53:42.019592 [0-0] == Info: [HTTP/3] recvmmsg() -> 10 packets
05:53:42.019817 [0-0] == Info: [HTTP/3] [7] read_stream(len=1) -> 1
05:53:42.020019 [0-0] <= Recv header, 13 bytes (0xd)
0000: HTTP/3 200
05:53:42.020318 [0-0] == Info: [WRITE] [OUT] wrote 13 header bytes -> 13
05:53:42.020557 [0-0] == Info: [WRITE] [PAUSE] writing 13/13 bytes of type c -> 0
05:53:42.020762 [0-0] == Info: [WRITE] download_write header(type=c, blen=13) -> 0
05:53:42.021148 [0-0] == Info: [WRITE] client_write(type=c, len=13) -> 0
05:53:42.021385 [0-0] == Info: [HTTP/3] [0] status: HTTP/3 200

05:53:42.021594 [0-0] == Info: [HTTP/3] [0] header: server: nginx/1.28.0
05:53:42.021856 [0-0] <= Recv header, 22 bytes (0x16)
0000: server: nginx/1.28.0
05:53:42.022093 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=22) -> 0
05:53:42.022377 [0-0] == Info: [WRITE] [OUT] wrote 22 header bytes -> 22
05:53:42.022582 [0-0] == Info: [WRITE] [PAUSE] writing 22/22 bytes of type 4 -> 0
05:53:42.022838 [0-0] == Info: [WRITE] download_write header(type=4, blen=22) -> 0
05:53:42.023095 [0-0] == Info: [WRITE] client_write(type=4, len=22) -> 0
05:53:42.023333 [0-0] == Info: [HTTP/3] [0] header: date: Sun, 15 Jun 2025 05:53:42 GMT
05:53:42.023588 [0-0] <= Recv header, 37 bytes (0x25)
0000: date: Sun, 15 Jun 2025 05:53:42 GMT
05:53:42.023863 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=37) -> 0
05:53:42.024120 [0-0] == Info: [WRITE] [OUT] wrote 37 header bytes -> 37
05:53:42.024403 [0-0] == Info: [WRITE] [PAUSE] writing 37/37 bytes of type 4 -> 0
05:53:42.024686 [0-0] == Info: [WRITE] download_write header(type=4, blen=37) -> 0
05:53:42.024885 [0-0] == Info: [WRITE] client_write(type=4, len=37) -> 0
05:53:42.025114 [0-0] == Info: [HTTP/3] [0] header: content-type: text/html
05:53:42.025311 [0-0] <= Recv header, 25 bytes (0x19)
0000: content-type: text/html
05:53:42.025615 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=25) -> 0
05:53:42.025901 [0-0] == Info: [WRITE] [OUT] wrote 25 header bytes -> 25
05:53:42.026122 [0-0] == Info: [WRITE] [PAUSE] writing 25/25 bytes of type 4 -> 0
05:53:42.026324 [0-0] == Info: [WRITE] download_write header(type=4, blen=25) -> 0
05:53:42.026566 [0-0] == Info: [WRITE] client_write(type=4, len=25) -> 0
05:53:42.026843 [0-0] == Info: [HTTP/3] [0] header: content-length: 10703
05:53:42.027061 [0-0] <= Recv header, 23 bytes (0x17)
0000: content-length: 10703
05:53:42.027373 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=23) -> 0
05:53:42.027616 [0-0] == Info: [WRITE] [OUT] wrote 23 header bytes -> 23
05:53:42.027804 [0-0] == Info: [WRITE] [PAUSE] writing 23/23 bytes of type 4 -> 0
05:53:42.028091 [0-0] == Info: [WRITE] download_write header(type=4, blen=23) -> 0
05:53:42.028359 [0-0] == Info: [WRITE] client_write(type=4, len=23) -> 0
05:53:42.028552 [0-0] == Info: [HTTP/3] [0] header: last-modified: Fri, 14 Mar 2025 02:55:51 GMT
05:53:42.028861 [0-0] <= Recv header, 46 bytes (0x2e)
0000: last-modified: Fri, 14 Mar 2025 02:55:51 GMT
05:53:42.029186 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=46) -> 0
05:53:42.029402 [0-0] == Info: [WRITE] [OUT] wrote 46 header bytes -> 46
05:53:42.029593 [0-0] == Info: [WRITE] [PAUSE] writing 46/46 bytes of type 4 -> 0
05:53:42.029817 [0-0] == Info: [WRITE] download_write header(type=4, blen=46) -> 0
05:53:42.030013 [0-0] == Info: [WRITE] client_write(type=4, len=46) -> 0
05:53:42.030251 [0-0] == Info: [HTTP/3] [0] header: etag: "67d39ab7-29cf"
05:53:42.030499 [0-0] <= Recv header, 23 bytes (0x17)
0000: etag: "67d39ab7-29cf"
05:53:42.030783 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=23) -> 0
05:53:42.031032 [0-0] == Info: [WRITE] [OUT] wrote 23 header bytes -> 23
05:53:42.031307 [0-0] == Info: [WRITE] [PAUSE] writing 23/23 bytes of type 4 -> 0
05:53:42.031646 [0-0] == Info: [WRITE] download_write header(type=4, blen=23) -> 0
05:53:42.031880 [0-0] == Info: [WRITE] client_write(type=4, len=23) -> 0
05:53:42.032136 [0-0] == Info: [HTTP/3] [0] header: alt-svc: h3=":8443"; ma=86400
05:53:42.032375 [0-0] <= Recv header, 31 bytes (0x1f)
0000: alt-svc: h3=":8443"; ma=86400
05:53:42.032734 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=31) -> 0
05:53:42.032979 [0-0] == Info: [WRITE] [OUT] wrote 31 header bytes -> 31
05:53:42.033197 [0-0] == Info: [WRITE] [PAUSE] writing 31/31 bytes of type 4 -> 0
05:53:42.033454 [0-0] == Info: [WRITE] download_write header(type=4, blen=31) -> 0
05:53:42.033713 [0-0] == Info: [WRITE] client_write(type=4, len=31) -> 0
05:53:42.033927 [0-0] == Info: [HTTP/3] [0] header: x-protocol: HTTP/3.0
05:53:42.034194 [0-0] <= Recv header, 22 bytes (0x16)
0000: x-protocol: HTTP/3.0
05:53:42.034528 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=22) -> 0
05:53:42.034725 [0-0] == Info: [WRITE] [OUT] wrote 22 header bytes -> 22
05:53:42.034930 [0-0] == Info: [WRITE] [PAUSE] writing 22/22 bytes of type 4 -> 0
05:53:42.035156 [0-0] == Info: [WRITE] download_write header(type=4, blen=22) -> 0
05:53:42.035378 [0-0] == Info: [WRITE] client_write(type=4, len=22) -> 0
05:53:42.035628 [0-0] == Info: [HTTP/3] [0] header: accept-ranges: bytes
05:53:42.035876 [0-0] <= Recv header, 22 bytes (0x16)
0000: accept-ranges: bytes
05:53:42.036122 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=22) -> 0
05:53:42.036372 [0-0] == Info: [WRITE] [OUT] wrote 22 header bytes -> 22
05:53:42.036526 [0-0] == Info: [WRITE] [PAUSE] writing 22/22 bytes of type 4 -> 0
05:53:42.036794 [0-0] == Info: [WRITE] download_write header(type=4, blen=22) -> 0
05:53:42.037021 [0-0] == Info: [WRITE] client_write(type=4, len=22) -> 0
05:53:42.037283 [0-0] <= Recv header, 2 bytes (0x2)
0000:
05:53:42.037451 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=2) -> 0
05:53:42.037737 [0-0] == Info: [WRITE] [OUT] wrote 2 header bytes -> 2
05:53:42.037992 [0-0] == Info: [WRITE] [PAUSE] writing 2/2 bytes of type 4 -> 0
05:53:42.038221 [0-0] == Info: [WRITE] download_write header(type=4, blen=2) -> 0
05:53:42.038449 [0-0] == Info: [WRITE] client_write(type=4, len=2) -> 0
05:53:42.038680 [0-0] == Info: [HTTP/3] [0] end_headers, status=200
05:53:42.038939 [0-0] <= Recv data, 987 bytes (0x3db)
0000: .<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
0040: "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">.<html
0080:  xmlns="http://www.w3.org/1999/xhtml">.  <head>.    <meta http-e
00c0: quiv="Content-Type" content="text/html; charset=UTF-8" />.    <t
0100: itle>Apache2 Debian Default Page: It works</title>.    <style ty
0140: pe="text/css" media="screen">.  * {.    margin: 0px 0px 0px 0px;
0180: .    padding: 0px 0px 0px 0px;.  }..  body, html {.    padding:
01c0: 3px 3px 3px 3px;..    background-color: #D8DBE2;..    font-famil
0200: y: Verdana, sans-serif;.    font-size: 11pt;.    text-align: cen
0240: ter;.  }..  div.main_page {.    position: relative;.    display:
0280:  table;..    width: 800px;..    margin-bottom: 3px;.    margin-l
02c0: eft: auto;.    margin-right: auto;.    padding: 0px 0px 0px 0px;
0300: ..    border-width: 2px;.    border-color: #212738;.    border-s
0340: tyle: solid;..    background-color: #FFFFFF;..    text-align: ce
0380: nter;.  }..  div.page_header {.    height: 99px;.    width: 100%
03c0: ;..    background-color: #F
05:53:42.042770 [0-0] == Info: [WRITE] [OUT] wrote 987 body bytes -> 987
05:53:42.043052 [0-0] == Info: [WRITE] [PAUSE] writing 987/987 bytes of type 1 -> 0
05:53:42.043290 [0-0] == Info: [WRITE] download_write body(type=1, blen=987) -> 0
05:53:42.043531 [0-0] == Info: [WRITE] client_write(type=1, len=987) -> 0
05:53:42.043747 [0-0] == Info: [WRITE] xfer_write_resp(len=987, eos=0) -> 0
05:53:42.044008 [0-0] == Info: [HTTP/3] [0] ACK 987 bytes of DATA
05:53:42.044194 [0-0] == Info: [HTTP/3] [0] DATA len=987
05:53:42.044331 [0-0] == Info: [HTTP/3] [0] read_stream(len=1147) -> 160
05:53:42.044569 [0-0] <= Recv data, 1156 bytes (0x484)
0000: 5F6F7;.  }..  div.page_header span {.    margin: 15px 0px 0px 50
0040: px;..    font-size: 180%;.    font-weight: bold;.  }..  div.page
0080: _header img {.    margin: 3px 0px 0px 40px;..    border: 0px 0px
00c0:  0px;.  }..  div.table_of_contents {.    clear: left;..    min-w
0100: idth: 200px;..    margin: 3px 3px 3px 3px;..    background-color
0140: : #FFFFFF;..    text-align: left;.  }..  div.table_of_contents_i
0180: tem {.    clear: left;..    width: 100%;..    margin: 4px 0px 0p
01c0: x 0px;..    background-color: #FFFFFF;..    color: #000000;.
0200: text-align: left;.  }..  div.table_of_contents_item a {.    marg
0240: in: 6px 0px 0px 6px;.  }..  div.content_section {.    margin: 3p
0280: x 3px 3px 3px;..    background-color: #FFFFFF;..    text-align:
02c0: left;.  }..  div.content_section_text {.    padding: 4px 8px 4px
0300:  8px;..    color: #000000;.    font-size: 100%;.  }..  div.conte
0340: nt_section_text pre {.    margin: 8px 0px 8px 0px;.    padding:
0380: 8px 8px 8px 8px;..    border-width: 1px;.    border-style: dotte
03c0: d;.    border-color: #000000;..    background-color: #F5F6F7;..
0400:    font-style: italic;.  }..  div.content_section_text p {.    m
0440: argin-bottom: 6px;.  }..  div.content_section_text ul, div.conte
0480: nt_s
05:53:42.048254 [0-0] == Info: [WRITE] [OUT] wrote 1156 body bytes -> 1156
05:53:42.048430 [0-0] == Info: [WRITE] [PAUSE] writing 1156/1156 bytes of type 1 -> 0
05:53:42.048682 [0-0] == Info: [WRITE] download_write body(type=1, blen=1156) -> 0
05:53:42.048913 [0-0] == Info: [WRITE] client_write(type=1, len=1156) -> 0
05:53:42.049103 [0-0] == Info: [WRITE] xfer_write_resp(len=1156, eos=0) -> 0
05:53:42.049295 [0-0] == Info: [HTTP/3] [0] ACK 1156 bytes of DATA
05:53:42.049509 [0-0] == Info: [HTTP/3] [0] DATA len=1156
05:53:42.049704 [0-0] == Info: [HTTP/3] [0] read_stream(len=1156) -> 0
05:53:42.049968 [0-0] <= Recv data, 1156 bytes (0x484)
0000: ection_text li {.    padding: 4px 8px 4px 16px;.  }..  div.secti
0040: on_header {.    padding: 3px 6px 3px 6px;..    background-color:
0080:  #8E9CB2;..    color: #FFFFFF;.    font-weight: bold;.    font-s
00c0: ize: 112%;.    text-align: center;.  }..  div.section_header_red
0100:  {.    background-color: #CD214F;.  }..  div.section_header_grey
0140:  {.    background-color: #9F9386;.  }..  .floating_element {.
0180:  position: relative;.    float: left;.  }..  div.table_of_conten
01c0: ts_item a,.  div.content_section_text a {.    text-decoration: n
0200: one;.    font-weight: bold;.  }..  div.table_of_contents_item a:
0240: link,.  div.table_of_contents_item a:visited,.  div.table_of_con
0280: tents_item a:active {.    color: #000000;.  }..  div.table_of_co
02c0: ntents_item a:hover {.    background-color: #000000;..    color:
0300:  #FFFFFF;.  }..  div.content_section_text a:link,.  div.content_
0340: section_text a:visited,.   div.content_section_text a:active {.
0380:    background-color: #DCDFE6;..    color: #000000;.  }..  div.co
03c0: ntent_section_text a:hover {.    background-color: #000000;..
0400:  color: #DCDFE6;.  }..  div.validator {.  }.    </style>.  </hea
0440: d>.  <body>.    <div class="main_page">.      <div class="page_h
0480: eade
05:53:42.053795 [0-0] == Info: [WRITE] [OUT] wrote 1156 body bytes -> 1156
05:53:42.054034 [0-0] == Info: [WRITE] [PAUSE] writing 1156/1156 bytes of type 1 -> 0
05:53:42.054320 [0-0] == Info: [WRITE] download_write body(type=1, blen=1156) -> 0
05:53:42.054576 [0-0] == Info: [WRITE] client_write(type=1, len=1156) -> 0
05:53:42.054781 [0-0] == Info: [WRITE] xfer_write_resp(len=1156, eos=0) -> 0
05:53:42.055055 [0-0] == Info: [HTTP/3] [0] ACK 1156 bytes of DATA
05:53:42.055279 [0-0] == Info: [HTTP/3] [0] DATA len=1156
05:53:42.055464 [0-0] == Info: [HTTP/3] [0] read_stream(len=1156) -> 0
05:53:42.055701 [0-0] <= Recv data, 1156 bytes (0x484)
0000: r floating_element">.        <img src="/icons/openlogo-75.png" a
0040: lt="Debian Logo" class="floating_element"/>.        <span class=
0080: "floating_element">.          Apache2 Debian Default Page.
00c0:   </span>.      </div>.<!--      <div class="table_of_contents f
0100: loating_element">.        <div class="section_header section_hea
0140: der_grey">.          TABLE OF CONTENTS.        </div>.        <d
0180: iv class="table_of_contents_item floating_element">.          <a
01c0:  href="#about">About</a>.        </div>.        <div class="tabl
0200: e_of_contents_item floating_element">.          <a href="#change
0240: s">Changes</a>.        </div>.        <div class="table_of_conte
0280: nts_item floating_element">.          <a href="#scope">Scope</a>
02c0: .        </div>.        <div class="table_of_contents_item float
0300: ing_element">.          <a href="#files">Config files</a>.
0340:   </div>.      </div>.-->.      <div class="content_section floa
0380: ting_element">...        <div class="section_header section_head
03c0: er_red">.          <div id="about"></div>.          It works!.
0400:       </div>.        <div class="content_section_text">.
0440:   <p>.                This is the default welcome page used to t
0480: est
05:53:42.059613 [0-0] == Info: [WRITE] [OUT] wrote 1156 body bytes -> 1156
05:53:42.059864 [0-0] == Info: [WRITE] [PAUSE] writing 1156/1156 bytes of type 1 -> 0
05:53:42.060123 [0-0] == Info: [WRITE] download_write body(type=1, blen=1156) -> 0
05:53:42.060361 [0-0] == Info: [WRITE] client_write(type=1, len=1156) -> 0
05:53:42.060604 [0-0] == Info: [WRITE] xfer_write_resp(len=1156, eos=0) -> 0
05:53:42.060828 [0-0] == Info: [HTTP/3] [0] ACK 1156 bytes of DATA
05:53:42.061054 [0-0] == Info: [HTTP/3] [0] DATA len=1156
05:53:42.061239 [0-0] == Info: [HTTP/3] [0] read_stream(len=1156) -> 0
05:53:42.061438 [0-0] <= Recv data, 1156 bytes (0x484)
0000: the correct .                operation of the Apache2 server aft
0040: er installation on Debian systems..                If you can re
0080: ad this page, it means that the Apache HTTP server installed at.
00c0:                 this site is working properly. You should <b>rep
0100: lace this file</b> (located at.                <tt>/var/www/html
0140: /index.html</tt>) before continuing to operate your HTTP server.
0180: .          </p>...          <p>.                If you are a nor
01c0: mal user of this web site and don't know what this page is.
0200:            about, this probably means that the site is currently
0240:  unavailable due to.                maintenance..
0280:  If the problem persists, please contact the site's administrato
02c0: r..          </p>..        </div>.        <div class="section_he
0300: ader">.          <div id="changes"></div>.                Config
0340: uration Overview.        </div>.        <div class="content_sect
0380: ion_text">.          <p>.                Debian's Apache2 defaul
03c0: t configuration is different from the.                upstream d
0400: efault configuration, and split into several files optimized for
0440: .                interaction with Debian tools. The configuratio
0480: n sy
05:53:42.065194 [0-0] == Info: [WRITE] [OUT] wrote 1156 body bytes -> 1156
05:53:42.065415 [0-0] == Info: [WRITE] [PAUSE] writing 1156/1156 bytes of type 1 -> 0
05:53:42.065661 [0-0] == Info: [WRITE] download_write body(type=1, blen=1156) -> 0
05:53:42.065898 [0-0] == Info: [WRITE] client_write(type=1, len=1156) -> 0
05:53:42.066126 [0-0] == Info: [WRITE] xfer_write_resp(len=1156, eos=0) -> 0
05:53:42.066368 [0-0] == Info: [HTTP/3] [0] ACK 1156 bytes of DATA
05:53:42.066567 [0-0] == Info: [HTTP/3] [0] DATA len=1156
05:53:42.066735 [0-0] == Info: [HTTP/3] [0] read_stream(len=1156) -> 0
05:53:42.067037 [0-0] <= Recv data, 1156 bytes (0x484)
0000: stem is.                <b>fully documented in.                /
0040: usr/share/doc/apache2/README.Debian.gz</b>. Refer to this for th
0080: e full.                documentation. Documentation for the web
00c0: server itself can be.                found by accessing the <a h
0100: ref="/manual">manual</a> if the <tt>apache2-doc</tt>.
0140:      package was installed on this server...          </p>.
0180:      <p>.                The configuration layout for an Apache2
01c0:  web server installation on Debian systems is as follows:.
0200:     </p>.          <pre>./etc/apache2/.|-- apache2.conf.|
0240: `--  ports.conf.|-- mods-enabled.|       |-- *.load.|       `--
0280: *.conf.|-- conf-enabled.|       `-- *.conf.|-- sites-enabled.|
02c0:      `-- *.conf.          </pre>.          <ul>.
0300:         <li>.                           <tt>apache2.conf</tt> is
0340:  the main configuration.                           file. It puts
0380:  the pieces together by including all remaining configuration.
03c0:                          files when starting up the web server..
0400:                         </li>..                        <li>.
0440:                        <tt>ports.conf</tt> is always included fr
0480: om t
05:53:42.070649 [0-0] == Info: [WRITE] [OUT] wrote 1156 body bytes -> 1156
05:53:42.070948 [0-0] == Info: [WRITE] [PAUSE] writing 1156/1156 bytes of type 1 -> 0
05:53:42.071174 [0-0] == Info: [WRITE] download_write body(type=1, blen=1156) -> 0
05:53:42.071442 [0-0] == Info: [WRITE] client_write(type=1, len=1156) -> 0
05:53:42.071624 [0-0] == Info: [WRITE] xfer_write_resp(len=1156, eos=0) -> 0
05:53:42.071873 [0-0] == Info: [HTTP/3] [0] ACK 1156 bytes of DATA
05:53:42.072030 [0-0] == Info: [HTTP/3] [0] DATA len=1156
05:53:42.072166 [0-0] == Info: [HTTP/3] [0] read_stream(len=1156) -> 0
05:53:42.072389 [0-0] <= Recv data, 1156 bytes (0x484)
0000: he.                           main configuration file. It is use
0040: d to determine the listening ports for.
0080:   incoming connections, and this file can be customized anytime.
00c0: .                        </li>..                        <li>.
0100:                         Configuration files in the <tt>mods-enab
0140: led/</tt>,.                           <tt>conf-enabled/</tt> and
0180:  <tt>sites-enabled/</tt> directories contain.
01c0:         particular configuration snippets which manage modules,
0200: global configuration.                           fragments, or vi
0240: rtual host configurations, respectively..
0280:  </li>..                        <li>.
02c0: They are activated by symlinking available.
0300:       configuration files from their respective.
0340:            *-available/ counterparts. These should be managed.
0380:                          by using our helpers.
03c0:          <tt>.                                a2enmod,.
0400:                        a2dismod,.                           </tt
0440: >.                           <tt>.
0480:   a2
05:53:42.076333 [0-0] == Info: [WRITE] [OUT] wrote 1156 body bytes -> 1156
05:53:42.076534 [0-0] == Info: [WRITE] [PAUSE] writing 1156/1156 bytes of type 1 -> 0
05:53:42.076758 [0-0] == Info: [WRITE] download_write body(type=1, blen=1156) -> 0
05:53:42.077001 [0-0] == Info: [WRITE] client_write(type=1, len=1156) -> 0
05:53:42.077213 [0-0] == Info: [WRITE] xfer_write_resp(len=1156, eos=0) -> 0
05:53:42.077474 [0-0] == Info: [HTTP/3] [0] ACK 1156 bytes of DATA
05:53:42.077676 [0-0] == Info: [HTTP/3] [0] DATA len=1156
05:53:42.077825 [0-0] == Info: [HTTP/3] [0] read_stream(len=1156) -> 0
05:53:42.078069 [0-0] <= Recv data, 1156 bytes (0x484)
0000: ensite,.                                a2dissite,.
0040:                </tt>.                                and.
0080:                     <tt>.                                a2encon
00c0: f,.                                a2disconf.
0100:         </tt>. See their respective man pages for detailed infor
0140: mation..                        </li>..                        <
0180: li>.                           The binary is called apache2. Due
01c0:  to the use of.                           environment variables,
0200:  in the default configuration, apache2 needs to be.
0240:               started/stopped with <tt>/etc/init.d/apache2</tt>
0280: or <tt>apache2ctl</tt>..                           <b>Calling <t
02c0: t>/usr/bin/apache2</tt> directly will not work</b> with the.
0300:                        default configuration..
0340:       </li>.          </ul>.        </div>..        <div class="
0380: section_header">.            <div id="docroot"></div>.
03c0:       Document Roots.        </div>..        <div class="content
0400: _section_text">.            <p>.                By default, Debi
0440: an does not allow access through the web browser to.
0480:
05:53:42.082031 [0-0] == Info: [WRITE] [OUT] wrote 1156 body bytes -> 1156
05:53:42.082232 [0-0] == Info: [WRITE] [PAUSE] writing 1156/1156 bytes of type 1 -> 0
05:53:42.082446 [0-0] == Info: [WRITE] download_write body(type=1, blen=1156) -> 0
05:53:42.082666 [0-0] == Info: [WRITE] client_write(type=1, len=1156) -> 0
05:53:42.082856 [0-0] == Info: [WRITE] xfer_write_resp(len=1156, eos=0) -> 0
05:53:42.083090 [0-0] == Info: [HTTP/3] [0] ACK 1156 bytes of DATA
05:53:42.083252 [0-0] == Info: [HTTP/3] [0] DATA len=1156
05:53:42.083477 [0-0] == Info: [HTTP/3] [0] read_stream(len=1156) -> 0
05:53:42.083719 [0-0] <= Recv data, 1156 bytes (0x484)
0000: <em>any</em> file apart of those located in <tt>/var/www</tt>,.
0040:                <a href="https://httpd.apache.org/docs/2.4/mod/mo
0080: d_userdir.html" rel="nofollow">public_html</a>.                d
00c0: irectories (when enabled) and <tt>/usr/share</tt> (for web.
0100:            applications). If your site is using a web document r
0140: oot.                located elsewhere (such as in <tt>/srv</tt>)
0180:  you may need to whitelist your.                document root di
01c0: rectory in <tt>/etc/apache2/apache2.conf</tt>..            </p>.
0200:             <p>.                The default Debian document root
0240:  is <tt>/var/www/html</tt>. You.                can make your ow
0280: n virtual hosts under /var/www. This is different.
02c0:   to previous releases which provides better security out of the
0300:  box..            </p>.        </div>..        <div class="secti
0340: on_header">.          <div id="bugs"></div>.                Repo
0380: rting Problems.        </div>.        <div class="content_sectio
03c0: n_text">.          <p>.                Please use the <tt>report
0400: bug</tt> tool to report bugs in the.                Apache2 pack
0440: age with Debian. However, check <a.                href="https:/
0480: /bug
05:53:42.087497 [0-0] == Info: [WRITE] [OUT] wrote 1156 body bytes -> 1156
05:53:42.087702 [0-0] == Info: [WRITE] [PAUSE] writing 1156/1156 bytes of type 1 -> 0
05:53:42.087963 [0-0] == Info: [WRITE] download_write body(type=1, blen=1156) -> 0
05:53:42.088193 [0-0] == Info: [WRITE] client_write(type=1, len=1156) -> 0
05:53:42.088392 [0-0] == Info: [WRITE] xfer_write_resp(len=1156, eos=0) -> 0
05:53:42.088586 [0-0] == Info: [HTTP/3] [0] ACK 1156 bytes of DATA
05:53:42.088764 [0-0] == Info: [HTTP/3] [0] DATA len=1156
05:53:42.088926 [0-0] == Info: [HTTP/3] [0] read_stream(len=1156) -> 0
05:53:42.089138 [0-0] <= Recv data, 468 bytes (0x1d4)
0000: s.debian.org/cgi-bin/pkgreport.cgi?ordering=normal;archive=0;src
0040: =apache2;repeatmerged=0".                rel="nofollow">existing
0080:  bug reports</a> before reporting a new bug..          </p>.
00c0:       <p>.                Please report bugs specific to modules
0100:  (such as PHP and others).                to respective packages
0140: , not to the web server itself..          </p>.        </div>...
0180: ..      </div>.    </div>.    <div class="validator">.    </div>
01c0: .  </body>.</html>..
05:53:42.090735 [0-0] == Info: [WRITE] [OUT] wrote 468 body bytes -> 468
05:53:42.090916 [0-0] == Info: [WRITE] [PAUSE] writing 468/468 bytes of type 1 -> 0
05:53:42.091132 [0-0] == Info: [WRITE] download_write body(type=1, blen=468) -> 0
05:53:42.091328 [0-0] == Info: [WRITE] client_write(type=1, len=468) -> 0
05:53:42.091523 [0-0] == Info: [WRITE] xfer_write_resp(len=468, eos=0) -> 0
05:53:42.091764 [0-0] == Info: [HTTP/3] [0] ACK 468 bytes of DATA
05:53:42.091962 [0-0] == Info: [HTTP/3] [0] DATA len=468
05:53:42.092105 [0-0] == Info: [HTTP/3] [0] read_stream(len=468) -> 0
05:53:42.092295 [0-0] == Info: [HTTP/3] [0] read_stream(len=0) -> 0
05:53:42.092512 [0-0] == Info: [HTTP/3] [0] CLOSED
05:53:42.092662 [0-0] == Info: [HTTP/3] [0] quic close(app_error=256) -> 0
05:53:42.092898 [0-0] == Info: [HTTP/3] recvmmsg() -> 2 packets
05:53:42.093071 [0-0] == Info: [HTTP/3] ingress, recvmmsg -> EAGAIN
05:53:42.093289 [0-0] == Info: [HTTP/3] recvd 12 packets with 11399 bytes -> 0
05:53:42.093586 [0-0] == Info: [HTTP/3] vquic_send(len=44, gso=44) -> 0, sent=44
05:53:42.093814 [0-0] == Info: [HTTP/3] [0] cf_recv(blen=102400) -> 0m, 0
05:53:42.094036 [0-0] <= Recv data, 0 bytes (0x0)
05:53:42.094161 [0-0] == Info: [WRITE] [PAUSE] writing 0/0 bytes of type 81 -> 0
05:53:42.094364 [0-0] == Info: [WRITE] download_write body(type=81, blen=0) -> 0
05:53:42.094570 [0-0] == Info: [WRITE] client_write(type=81, len=0) -> 0
05:53:42.094769 [0-0] == Info: [WRITE] xfer_write_resp(len=0, eos=1) -> 0
05:53:42.094952 [0-0] == Info: [MULTI] [PERFORMING] sendrecv_dl() no EAGAIN/pending data, set select_bits=1
################################################################################################################################ 100.0%05:53:42.095680 [0-0] == Info: [MULTI] [PERFORMING] -> [DONE]
05:53:42.095843 [0-0] == Info: [MULTI] [DONE] multi_done: status: 0 prem: 0 done: 0
05:53:42.096063 [0-0] == Info: [WRITE] [OUT] done
05:53:42.096183 [0-0] == Info: [HTTP/3] [0] easy handle is done
05:53:42.096352 [0-0] == Info: [HTTP/3] no active streams, unset keep-alive
05:53:42.096607 [0-0] == Info: [READ] client_reset, clear readers
05:53:42.096858 [0-x] == Info: [MULTI] [DONE] multi_done_locked, in use=0
05:53:42.097071 [0-0] == Info: Connection #0 to host 127.0.0.1 left intact
05:53:42.097320 [0-0] == Info: [MULTI] [DONE] -> [COMPLETED]
05:53:42.097521 [0-0] == Info: [MULTI] [COMPLETED] Expire cleared
05:53:42.097696 [0-0] == Info: [MULTI] [COMPLETED] -> [MSGSENT]
05:53:42.097870 [0-0] == Info: [MULTI] [COMPLETED] removed from multi, mid=1, running=0, total=1
```
V2 test with ngtcp2
```
root@ubuntu:/src/curl# /src/curl/src/curl -vvvv -k -# -o /dev/null --http3 v2  https://127.0.0.1:4434/index.html
05:53:44.422737 [0-x] == Info: [MULTI] [INIT] added to multi, mid=1, running=1, total=2
05:53:44.422955 [0-x] == Info: [MULTI] [INIT] multi_timeout() says this has expired
05:53:44.423155 [0-x] == Info: [MULTI] [INIT] multi_wait(fds=1, timeout=0) tinternal=0
05:53:44.423397 [0-x] == Info: [MULTI] [INIT] -> [SETUP]
05:53:44.423535 [0-x] == Info: [MULTI] [SETUP] -> [CONNECT]
05:53:44.423672 [0-x] == Info: [READ] client_reset, clear readers
05:53:44.423865 [0-0] == Info: [MULTI] [CONNECT] [CPOOL] added connection 0. The cache now contains 1 members
05:53:44.424145 [0-0] == Info: [HTTPS-CONNECT] adding wanted h3
05:53:44.424308 [0-0] == Info: [HTTPS-CONNECT] added
05:53:44.424445 [0-0] == Info: [MULTI] [CONNECT] -> [CONNECTING]
05:53:44.424630 [0-0] == Info: [HTTPS-CONNECT] connect, init
05:53:44.424778 [0-0] == Info: [HAPPY-EYEBALLS] created ipv4 (timeout 299999ms)
05:53:44.424995 [0-0] == Info: [HAPPY-EYEBALLS] ipv4 starting (timeout=299999ms)
05:53:44.425236 [0-0] == Info:   Trying 127.0.0.1:4434...
05:53:44.425386 [0-0] == Info: [UDP] cf_socket_open() -> 0, fd=4
05:53:44.425548 [0-0] == Info: [UDP] QUIC socket 4 connected: [127.0.0.1:48270] -> [127.0.0.1:4434]
05:53:44.425789 [0-0] == Info: [UDP] cf_udp_connect(), opened socket=4 (127.0.0.1:48270)
05:53:44.427172 [0-0] == Info: Attempting HTTP/3 QUIC version 2
05:53:44.428093 [0-0] == Info: [SSLS] find peer slot for 127.0.0.1:4434:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G among 25 slots
05:53:44.428547 [0-0] == Info: [SSLS] peer not found for 127.0.0.1:4434:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G
05:53:44.428850 [0-0] == Info: [SSLS] no cached session for 127.0.0.1:4434:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G
05:53:44.429953 [0-0] == Info: [HTTP/3] vquic_send(len=1200, gso=1200) -> 0, sent=1200
05:53:44.430170 [0-0] == Info: [HAPPY-EYEBALLS] ipv4 connect -> 0, connected=0
05:53:44.430413 [0-0] == Info: [HTTPS-CONNECT] connect -> 0, done=0
05:53:44.430592 [0-0] == Info: [HTTPS-CONNECT] Curl_conn_connect(block=0) -> 0, done=0
05:53:44.430839 [0-0] == Info: [UDP] adjust_pollset, !active, POLLIN fd=4
05:53:44.431032 [0-0] == Info: [HAPPY-EYEBALLS] adjust_pollset -> 1 socks
05:53:44.431236 [0-0] == Info: [HTTPS-CONNECT] adjust_pollset -> 1 socks
05:53:44.431434 [0-0] == Info: [MULTI] [CONNECTING] multi_wait pollset[fd=4 IN], timeouts=1
05:53:44.431696 [0-0] == Info: [MULTI] [CONNECTING] multi_wait(fds=2, timeout=999) tinternal=999
05:53:44.437513 [0-0] == Info: [HTTP/3] ossl_populate_x509_store, path=/etc/ssl/certs/ca-certificates.crt, blob=0
05:53:44.437886 [0-0] == Info: [HTTP/3] recvmmsg() -> 1 packets
05:53:44.439104 [0-0] == Info: Server certificate:
05:53:44.439330 [0-0] == Info:  subject: C=IN; ST=Karnataka; L=Bangalore; O=Cisco Security; OU=SBG; CN=cisco.com
05:53:44.439704 [0-0] == Info:  start date: Jun  9 08:18:34 2025 GMT
05:53:44.439914 [0-0] == Info:  expire date: Jun  7 08:18:34 2035 GMT
05:53:44.440198 [0-0] == Info:  issuer: C=IN; ST=Karnataka; L=Bangalore; O=Cisco Security; OU=SBG; CN=cisco.com
05:53:44.440499 [0-0] == Info:  SSL certificate verify result: self-signed certificate (18), continuing anyway.
05:53:44.440886 [0-0] == Info:   Certificate level 0: Public key type RSA (4096/152 Bits/secBits), signed using sha256WithRSAEncryption
05:53:44.441361 [0-0] == Info: [HTTP/3] handshake complete after 13ms
05:53:44.441639 [0-0] == Info: [HTTP/3] max bidi streams now 100, used 0
05:53:44.441914 [0-0] == Info: [HTTP/3] [3] read_stream(len=18) -> 18
05:53:44.442125 [0-0] == Info: [HTTP/3] [11] read_stream(len=1) -> 1
05:53:44.442284 [0-0] == Info: [HTTP/3] [7] read_stream(len=1) -> 1
05:53:44.442541 [0-0] == Info: [HTTP/3] ingress, recvmmsg -> EAGAIN
05:53:44.442707 [0-0] == Info: [HTTP/3] recvd 3 packets with 3600 bytes -> 0
05:53:44.443149 [0-0] == Info: [HTTP/3] vquic_send_tail_split: [1200 gso=1200][1406 gso=1406]
05:53:44.443447 [0-0] == Info: [HTTP/3] vquic_send(len=1200, gso=1200) -> 0, sent=1200
05:53:44.443679 [0-0] == Info: [HTTP/3] vquic_send(len=1406, gso=1406) -> 0, sent=1406
05:53:44.443865 [0-0] == Info: [HTTP/3] peer verified
05:53:44.443998 [0-0] == Info: [MULTI] [CONNECTING] set expire[12] in 24000ns
05:53:44.444194 [0-0] == Info: [HTTP/3] connect -> 0, done=1
05:53:44.444362 [0-0] == Info: [HAPPY-EYEBALLS] ipv4 connect -> 0, connected=1
05:53:44.444545 [0-0] == Info: [HAPPY-EYEBALLS] Connected to 127.0.0.1 (127.0.0.1) port 4434
05:53:44.444771 [0-0] == Info: [HTTPS-CONNECT] connect+handshake h3: 19ms, 1st data: 11ms
05:53:44.444982 [0-0] == Info: [HTTPS-CONNECT] connect -> 0, done=1
05:53:44.445132 [0-0] == Info: [HTTPS-CONNECT] Curl_conn_connect(block=0) -> 0, done=1
05:53:44.445373 [0-0] == Info: Connected to 127.0.0.1 (127.0.0.1) port 4434
05:53:44.445571 [0-0] == Info: using HTTP/3
05:53:44.445699 [0-0] == Info: [MULTI] [CONNECTING] -> [PROTOCONNECT]
05:53:44.445859 [0-0] == Info: [MULTI] [PROTOCONNECT] -> [DO]
05:53:44.446037 [0-0] == Info: [HTTP/3] recvmmsg() -> 2 packets
05:53:44.446315 [0-0] == Info: [SSLS] find peer slot for 127.0.0.1:4434:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G among 25 slots
05:53:44.446672 [0-0] == Info: [SSLS] peer not found for 127.0.0.1:4434:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G
05:53:44.446984 [0-0] == Info: [SSLS] added session for 127.0.0.1:4434:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G [proto=0x304, valid_secs=7200, alpn=h3, earlydata=4294967295, quic_tp=yes], peer has 1 sessions now
05:53:44.447840 [0-0] == Info: [SSLS] find peer slot for 127.0.0.1:4434:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G among 25 slots
05:53:44.448347 [0-0] == Info: [SSLS] added session for 127.0.0.1:4434:QUIC:NO-VRFY-PEER:NO-VRFY-HOST:IMPL-quictls/3.1.4:G [proto=0x304, valid_secs=7200, alpn=h3, earlydata=4294967295, quic_tp=yes], peer has 2 sessions now
05:53:44.449054 [0-0] == Info: [HTTP/3] ingress, recvmmsg -> EAGAIN
05:53:44.449245 [0-0] == Info: [HTTP/3] recvd 2 packets with 2606 bytes -> 0
05:53:44.449527 [0-0] == Info: [HTTP/3] peer idle timeout is 360000000ms, set keep-alive to 180000000 ms.
05:53:44.449956 [0-0] == Info: [HTTP/3] [0] OPENED stream for https://127.0.0.1:4434/index.html
05:53:44.450236 [0-0] == Info: [HTTP/3] [0] [:method: GET]
05:53:44.450417 [0-0] == Info: [HTTP/3] [0] [:scheme: https]
05:53:44.450636 [0-0] == Info: [HTTP/3] [0] [:authority: 127.0.0.1:4434]
05:53:44.450814 [0-0] == Info: [HTTP/3] [0] [:path: /index.html]
05:53:44.451048 [0-0] == Info: [HTTP/3] [0] [user-agent: curl/8.15.0-DEV]
05:53:44.451270 [0-0] == Info: [HTTP/3] [0] [accept: */*]
05:53:44.451482 [0-0] == Info: [HTTP/3] vquic_send_tail_split: [1444 gso=1444][105 gso=105]
05:53:44.451856 [0-0] == Info: [HTTP/3] vquic_send(len=1444, gso=1444) -> 0, sent=1444
05:53:44.452103 [0-0] == Info: [HTTP/3] vquic_send(len=105, gso=105) -> 0, sent=105
05:53:44.452338 [0-0] == Info: [HTTP/3] [0] cf_send(len=90) -> 0, 90
05:53:44.452547 [0-0] => Send header, 90 bytes (0x5a)
0000: GET /index.html HTTP/3
0018: Host: 127.0.0.1:4434
002e: User-Agent: curl/8.15.0-DEV
004b: Accept: */*
0058:
05:53:44.453036 [0-0] == Info: [MULTI] [DO] -> [DID]
05:53:44.453174 [0-0] == Info: [MULTI] [DID] -> [PERFORMING]
05:53:44.453314 [0-0] == Info: [HTTP/3] ingress, recvmmsg -> EAGAIN
05:53:44.453480 [0-0] == Info: [HTTP/3] [0] cf_recv(blen=102400) -> 81m, 0
05:53:44.453636 [0-0] == Info: Request completely sent off
05:53:44.453769 [0-0] == Info: [MULTI] [PERFORMING] multi_wait pollset[fd=4 IN], timeouts=1
05:53:44.453985 [0-0] == Info: [MULTI] [PERFORMING] multi_wait(fds=2, timeout=15) tinternal=15
05:53:44.454206 [0-0] == Info: [HTTP/3] recvmmsg() -> 2 packets
05:53:44.454383 [0-0] == Info: [HTTP/3] [11] read_stream(len=1) -> 1
05:53:44.454586 [0-0] <= Recv header, 13 bytes (0xd)
0000: HTTP/3 200
05:53:44.454774 [0-0] == Info: [WRITE] [OUT] wrote 13 header bytes -> 13
05:53:44.454969 [0-0] == Info: [WRITE] [PAUSE] writing 13/13 bytes of type c -> 0
05:53:44.455192 [0-0] == Info: [WRITE] download_write header(type=c, blen=13) -> 0
05:53:44.455408 [0-0] == Info: [WRITE] client_write(type=c, len=13) -> 0
05:53:44.455602 [0-0] == Info: [HTTP/3] [0] status: HTTP/3 200

05:53:44.455790 [0-0] == Info: [HTTP/3] [0] header: server: nghttp3/ngtcp2 server
05:53:44.455997 [0-0] <= Recv header, 31 bytes (0x1f)
0000: server: nghttp3/ngtcp2 server
05:53:44.456229 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=31) -> 0
05:53:44.456447 [0-0] == Info: [WRITE] [OUT] wrote 31 header bytes -> 31
05:53:44.456617 [0-0] == Info: [WRITE] [PAUSE] writing 31/31 bytes of type 4 -> 0
05:53:44.456883 [0-0] == Info: [WRITE] download_write header(type=4, blen=31) -> 0
05:53:44.457169 [0-0] == Info: [WRITE] client_write(type=4, len=31) -> 0
05:53:44.457373 [0-0] == Info: [HTTP/3] [0] header: content-type: text/html
05:53:44.457562 [0-0] <= Recv header, 25 bytes (0x19)
0000: content-type: text/html
05:53:44.457886 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=25) -> 0
05:53:44.458160 [0-0] == Info: [WRITE] [OUT] wrote 25 header bytes -> 25
05:53:44.458416 [0-0] == Info: [WRITE] [PAUSE] writing 25/25 bytes of type 4 -> 0
05:53:44.458650 [0-0] == Info: [WRITE] download_write header(type=4, blen=25) -> 0
05:53:44.458844 [0-0] == Info: [WRITE] client_write(type=4, len=25) -> 0
05:53:44.459094 [0-0] == Info: [HTTP/3] [0] header: content-length: 10703
05:53:44.459330 [0-0] <= Recv header, 23 bytes (0x17)
0000: content-length: 10703
05:53:44.459534 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=23) -> 0
05:53:44.459778 [0-0] == Info: [WRITE] [OUT] wrote 23 header bytes -> 23
05:53:44.459987 [0-0] == Info: [WRITE] [PAUSE] writing 23/23 bytes of type 4 -> 0
05:53:44.460202 [0-0] == Info: [WRITE] download_write header(type=4, blen=23) -> 0
05:53:44.460484 [0-0] == Info: [WRITE] client_write(type=4, len=23) -> 0
05:53:44.460707 [0-0] <= Recv header, 2 bytes (0x2)
0000:
05:53:44.460880 [0-0] == Info: [WRITE] header_collect pushed(type=1, len=2) -> 0
05:53:44.461158 [0-0] == Info: [WRITE] [OUT] wrote 2 header bytes -> 2
05:53:44.461375 [0-0] == Info: [WRITE] [PAUSE] writing 2/2 bytes of type 4 -> 0
05:53:44.461586 [0-0] == Info: [WRITE] download_write header(type=4, blen=2) -> 0
05:53:44.461822 [0-0] == Info: [WRITE] client_write(type=4, len=2) -> 0
05:53:44.462044 [0-0] == Info: [HTTP/3] [0] end_headers, status=200
05:53:44.462210 [0-0] == Info: [MULTI] [PERFORMING] set expire[8] in 0ns
05:53:44.462416 [0-0] <= Recv data, 1311 bytes (0x51f)
0000: .<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
0040: "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">.<html
0080:  xmlns="http://www.w3.org/1999/xhtml">.  <head>.    <meta http-e
00c0: quiv="Content-Type" content="text/html; charset=UTF-8" />.    <t
0100: itle>Apache2 Debian Default Page: It works</title>.    <style ty
0140: pe="text/css" media="screen">.  * {.    margin: 0px 0px 0px 0px;
0180: .    padding: 0px 0px 0px 0px;.  }..  body, html {.    padding:
01c0: 3px 3px 3px 3px;..    background-color: #D8DBE2;..    font-famil
0200: y: Verdana, sans-serif;.    font-size: 11pt;.    text-align: cen
0240: ter;.  }..  div.main_page {.    position: relative;.    display:
0280:  table;..    width: 800px;..    margin-bottom: 3px;.    margin-l
02c0: eft: auto;.    margin-right: auto;.    padding: 0px 0px 0px 0px;
0300: ..    border-width: 2px;.    border-color: #212738;.    border-s
0340: tyle: solid;..    background-color: #FFFFFF;..    text-align: ce
0380: nter;.  }..  div.page_header {.    height: 99px;.    width: 100%
03c0: ;..    background-color: #F5F6F7;.  }..  div.page_header span {.
0400:     margin: 15px 0px 0px 50px;..    font-size: 180%;.    font-we
0440: ight: bold;.  }..  div.page_header img {.    margin: 3px 0px 0px
0480:  40px;..    border: 0px 0px 0px;.  }..  div.table_of_contents {.
04c0:     clear: left;..    min-width: 200px;..    margin: 3px 3px 3px
0500:  3px;..    background-color: #F
05:53:44.466503 [0-0] == Info: [WRITE] [OUT] wrote 1311 body bytes -> 1311
05:53:44.466676 [0-0] == Info: [WRITE] [PAUSE] writing 1311/1311 bytes of type 1 -> 0
05:53:44.466918 [0-0] == Info: [WRITE] download_write body(type=1, blen=1311) -> 0
05:53:44.467175 [0-0] == Info: [WRITE] client_write(type=1, len=1311) -> 0
05:53:44.467458 [0-0] == Info: [WRITE] xfer_write_resp(len=1311, eos=0) -> 0
05:53:44.467727 [0-0] == Info: [HTTP/3] [0] ACK 1311 bytes of DATA
05:53:44.467884 [0-0] == Info: [HTTP/3] [0] DATA len=1311
05:53:44.468063 [0-0] == Info: [HTTP/3] [0] read_stream(len=1353) -> 42
05:53:44.468345 [0-0] == Info: [HTTP/3] recvmmsg() -> 1 packets
05:53:44.468628 [0-0] <= Recv data, 1362 bytes (0x552)
0000: FFFFF;..    text-align: left;.  }..  div.table_of_contents_item
0040: {.    clear: left;..    width: 100%;..    margin: 4px 0px 0px 0p
0080: x;..    background-color: #FFFFFF;..    color: #000000;.    text
00c0: -align: left;.  }..  div.table_of_contents_item a {.    margin:
0100: 6px 0px 0px 6px;.  }..  div.content_section {.    margin: 3px 3p
0140: x 3px 3px;..    background-color: #FFFFFF;..    text-align: left
0180: ;.  }..  div.content_section_text {.    padding: 4px 8px 4px 8px
01c0: ;..    color: #000000;.    font-size: 100%;.  }..  div.content_s
0200: ection_text pre {.    margin: 8px 0px 8px 0px;.    padding: 8px
0240: 8px 8px 8px;..    border-width: 1px;.    border-style: dotted;.
0280:    border-color: #000000;..    background-color: #F5F6F7;..    f
02c0: ont-style: italic;.  }..  div.content_section_text p {.    margi
0300: n-bottom: 6px;.  }..  div.content_section_text ul, div.content_s
0340: ection_text li {.    padding: 4px 8px 4px 16px;.  }..  div.secti
0380: on_header {.    padding: 3px 6px 3px 6px;..    background-color:
03c0:  #8E9CB2;..    color: #FFFFFF;.    font-weight: bold;.    font-s
0400: ize: 112%;.    text-align: center;.  }..  div.section_header_red
0440:  {.    background-color: #CD214F;.  }..  div.section_header_grey
0480:  {.    background-color: #9F9386;.  }..  .floating_element {.
04c0:  position: relative;.    float: left;.  }..  div.table_of_conten
0500: ts_item a,.  div.content_section_text a {.    text-decoration: n
0540: one;.    font-weig
05:53:44.473085 [0-0] == Info: [WRITE] [OUT] wrote 1362 body bytes -> 1362
05:53:44.473322 [0-0] == Info: [WRITE] [PAUSE] writing 1362/1362 bytes of type 1 -> 0
05:53:44.473535 [0-0] == Info: [WRITE] download_write body(type=1, blen=1362) -> 0
05:53:44.473753 [0-0] == Info: [WRITE] client_write(type=1, len=1362) -> 0
05:53:44.473975 [0-0] == Info: [WRITE] xfer_write_resp(len=1362, eos=0) -> 0
05:53:44.474180 [0-0] == Info: [HTTP/3] [0] ACK 1362 bytes of DATA
05:53:44.474395 [0-0] == Info: [HTTP/3] [0] DATA len=1362
05:53:44.474570 [0-0] == Info: [HTTP/3] [0] read_stream(len=1362) -> 0
05:53:44.474792 [0-0] <= Recv data, 1362 bytes (0x552)
0000: ht: bold;.  }..  div.table_of_contents_item a:link,.  div.table_
0040: of_contents_item a:visited,.  div.table_of_contents_item a:activ
0080: e {.    color: #000000;.  }..  div.table_of_contents_item a:hove
00c0: r {.    background-color: #000000;..    color: #FFFFFF;.  }..  d
0100: iv.content_section_text a:link,.  div.content_section_text a:vis
0140: ited,.   div.content_section_text a:active {.    background-colo
0180: r: #DCDFE6;..    color: #000000;.  }..  div.content_section_text
01c0:  a:hover {.    background-color: #000000;..    color: #DCDFE6;.
0200:  }..  div.validator {.  }.    </style>.  </head>.  <body>.    <d
0240: iv class="main_page">.      <div class="page_header floating_ele
0280: ment">.        <img src="/icons/openlogo-75.png" alt="Debian Log
02c0: o" class="floating_element"/>.        <span class="floating_elem
0300: ent">.          Apache2 Debian Default Page.        </span>.
0340:   </div>.<!--      <div class="table_of_contents floating_elemen
0380: t">.        <div class="section_header section_header_grey">.
03c0:        TABLE OF CONTENTS.        </div>.        <div class="tabl
0400: e_of_contents_item floating_element">.          <a href="#about"
0440: >About</a>.        </div>.        <div class="table_of_contents_
0480: item floating_element">.          <a href="#changes">Changes</a>
04c0: .        </div>.        <div class="table_of_contents_item float
0500: ing_element">.          <a href="#scope">Scope</a>.        </div
0540: >.        <div cla
05:53:44.509390 [0-0] == Info: [WRITE] [OUT] wrote 1362 body bytes -> 1362
05:53:44.509569 [0-0] == Info: [WRITE] [PAUSE] writing 1362/1362 bytes of type 1 -> 0
05:53:44.509821 [0-0] == Info: [WRITE] download_write body(type=1, blen=1362) -> 0
05:53:44.510011 [0-0] == Info: [WRITE] client_write(type=1, len=1362) -> 0
05:53:44.510262 [0-0] == Info: [WRITE] xfer_write_resp(len=1362, eos=0) -> 0
05:53:44.510455 [0-0] == Info: [HTTP/3] [0] ACK 1362 bytes of DATA
05:53:44.510643 [0-0] == Info: [HTTP/3] [0] DATA len=1362
05:53:44.510810 [0-0] == Info: [HTTP/3] [0] read_stream(len=1362) -> 0
05:53:44.511023 [0-0] <= Recv data, 1362 bytes (0x552)
0000: ss="table_of_contents_item floating_element">.          <a href=
0040: "#files">Config files</a>.        </div>.      </div>.-->.
0080: <div class="content_section floating_element">...        <div cl
00c0: ass="section_header section_header_red">.          <div id="abou
0100: t"></div>.          It works!.        </div>.        <div class=
0140: "content_section_text">.          <p>.                This is th
0180: e default welcome page used to test the correct .
01c0:  operation of the Apache2 server after installation on Debian sy
0200: stems..                If you can read this page, it means that
0240: the Apache HTTP server installed at.                this site is
0280:  working properly. You should <b>replace this file</b> (located
02c0: at.                <tt>/var/www/html/index.html</tt>) before con
0300: tinuing to operate your HTTP server..          </p>...
0340: <p>.                If you are a normal user of this web site an
0380: d don't know what this page is.                about, this proba
03c0: bly means that the site is currently unavailable due to.
0400:         maintenance..                If the problem persists, pl
0440: ease contact the site's administrator..          </p>..        <
0480: /div>.        <div class="section_header">.          <div id="ch
04c0: anges"></div>.                Configuration Overview.        </d
0500: iv>.        <div class="content_section_text">.          <p>.
0540:              Debia
05:53:44.515139 [0-0] == Info: [WRITE] [OUT] wrote 1362 body bytes -> 1362
05:53:44.515343 [0-0] == Info: [WRITE] [PAUSE] writing 1362/1362 bytes of type 1 -> 0
05:53:44.515666 [0-0] == Info: [WRITE] download_write body(type=1, blen=1362) -> 0
05:53:44.515973 [0-0] == Info: [WRITE] client_write(type=1, len=1362) -> 0
05:53:44.516212 [0-0] == Info: [WRITE] xfer_write_resp(len=1362, eos=0) -> 0
05:53:44.516424 [0-0] == Info: [HTTP/3] [0] ACK 1362 bytes of DATA
05:53:44.516599 [0-0] == Info: [HTTP/3] [0] DATA len=1362
05:53:44.516782 [0-0] == Info: [HTTP/3] [0] read_stream(len=1362) -> 0
05:53:44.516980 [0-0] <= Recv data, 1362 bytes (0x552)
0000: n's Apache2 default configuration is different from the.
0040:         upstream default configuration, and split into several f
0080: iles optimized for.                interaction with Debian tools
00c0: . The configuration system is.                <b>fully documente
0100: d in.                /usr/share/doc/apache2/README.Debian.gz</b>
0140: . Refer to this for the full.                documentation. Docu
0180: mentation for the web server itself can be.                found
01c0:  by accessing the <a href="/manual">manual</a> if the <tt>apache
0200: 2-doc</tt>.                package was installed on this server.
0240: ..          </p>.          <p>.                The configuration
0280:  layout for an Apache2 web server installation on Debian systems
02c0:  is as follows:.          </p>.          <pre>./etc/apache2/.|--
0300:  apache2.conf.|       `--  ports.conf.|-- mods-enabled.|       |
0340: -- *.load.|       `-- *.conf.|-- conf-enabled.|       `-- *.conf
0380: .|-- sites-enabled.|       `-- *.conf.          </pre>.
03c0:  <ul>.                        <li>.                           <t
0400: t>apache2.conf</tt> is the main configuration.
0440:          file. It puts the pieces together by including all rema
0480: ining configuration.                           files when starti
04c0: ng up the web server..                        </li>..
0500:              <li>.                           <tt>ports.conf</tt>
0540:  is always include
05:53:44.521955 [0-0] == Info: [WRITE] [OUT] wrote 1362 body bytes -> 1362
05:53:44.522145 [0-0] == Info: [WRITE] [PAUSE] writing 1362/1362 bytes of type 1 -> 0
05:53:44.522390 [0-0] == Info: [WRITE] download_write body(type=1, blen=1362) -> 0
05:53:44.522620 [0-0] == Info: [WRITE] client_write(type=1, len=1362) -> 0
05:53:44.522832 [0-0] == Info: [WRITE] xfer_write_resp(len=1362, eos=0) -> 0
05:53:44.523081 [0-0] == Info: [HTTP/3] [0] ACK 1362 bytes of DATA
05:53:44.523265 [0-0] == Info: [HTTP/3] [0] DATA len=1362
05:53:44.523431 [0-0] == Info: [HTTP/3] [0] read_stream(len=1362) -> 0
05:53:44.523640 [0-0] <= Recv data, 1362 bytes (0x552)
0000: d from the.                           main configuration file. I
0040: t is used to determine the listening ports for.
0080:           incoming connections, and this file can be customized
00c0: anytime..                        </li>..
0100: <li>.                           Configuration files in the <tt>m
0140: ods-enabled/</tt>,.                           <tt>conf-enabled/<
0180: /tt> and <tt>sites-enabled/</tt> directories contain.
01c0:                 particular configuration snippets which manage m
0200: odules, global configuration.                           fragment
0240: s, or virtual host configurations, respectively..
0280:          </li>..                        <li>.
02c0:         They are activated by symlinking available.
0300:               configuration files from their respective.
0340:                    *-available/ counterparts. These should be ma
0380: naged.                           by using our helpers.
03c0:                  <tt>.                                a2enmod,.
0400:                                a2dismod,.
0440:     </tt>.                           <tt>.
0480:           a2ensite,.                                a2dissite,.
04c0:                            </tt>.
0500:  and.                           <tt>.
0540:      a2enconf,.
05:53:44.528196 [0-0] == Info: [WRITE] [OUT] wrote 1362 body bytes -> 1362
05:53:44.528366 [0-0] == Info: [WRITE] [PAUSE] writing 1362/1362 bytes of type 1 -> 0
05:53:44.528601 [0-0] == Info: [WRITE] download_write body(type=1, blen=1362) -> 0
05:53:44.528767 [0-0] == Info: [WRITE] client_write(type=1, len=1362) -> 0
05:53:44.528919 [0-0] == Info: [WRITE] xfer_write_resp(len=1362, eos=0) -> 0
05:53:44.529086 [0-0] == Info: [HTTP/3] [0] ACK 1362 bytes of DATA
05:53:44.529217 [0-0] == Info: [HTTP/3] [0] DATA len=1362
05:53:44.529343 [0-0] == Info: [HTTP/3] [0] read_stream(len=1362) -> 0
05:53:44.529514 [0-0] <= Recv data, 1362 bytes (0x552)
0000:                              a2disconf.
0040:   </tt>. See their respective man pages for detailed information
0080: ..                        </li>..                        <li>.
00c0:                          The binary is called apache2. Due to th
0100: e use of.                           environment variables, in th
0140: e default configuration, apache2 needs to be.
0180:         started/stopped with <tt>/etc/init.d/apache2</tt> or <tt
01c0: >apache2ctl</tt>..                           <b>Calling <tt>/usr
0200: /bin/apache2</tt> directly will not work</b> with the.
0240:                  default configuration..
0280: </li>.          </ul>.        </div>..        <div class="sectio
02c0: n_header">.            <div id="docroot"></div>.
0300: Document Roots.        </div>..        <div class="content_secti
0340: on_text">.            <p>.                By default, Debian doe
0380: s not allow access through the web browser to.                <e
03c0: m>any</em> file apart of those located in <tt>/var/www</tt>,.
0400:              <a href="https://httpd.apache.org/docs/2.4/mod/mod_
0440: userdir.html" rel="nofollow">public_html</a>.                dir
0480: ectories (when enabled) and <tt>/usr/share</tt> (for web.
04c0:          applications). If your site is using a web document roo
0500: t.                located elsewhere (such as in <tt>/srv</tt>) y
0540: ou may need to whi
05:53:44.533630 [0-0] == Info: [WRITE] [OUT] wrote 1362 body bytes -> 1362
05:53:44.533783 [0-0] == Info: [WRITE] [PAUSE] writing 1362/1362 bytes of type 1 -> 0
05:53:44.534006 [0-0] == Info: [WRITE] download_write body(type=1, blen=1362) -> 0
05:53:44.534168 [0-0] == Info: [WRITE] client_write(type=1, len=1362) -> 0
05:53:44.534336 [0-0] == Info: [WRITE] xfer_write_resp(len=1362, eos=0) -> 0
05:53:44.534529 [0-0] == Info: [HTTP/3] [0] ACK 1362 bytes of DATA
05:53:44.534746 [0-0] == Info: [HTTP/3] [0] DATA len=1362
05:53:44.534888 [0-0] == Info: [HTTP/3] [0] read_stream(len=1362) -> 0
05:53:44.535095 [0-0] <= Recv data, 1220 bytes (0x4c4)
0000: telist your.                document root directory in <tt>/etc/
0040: apache2/apache2.conf</tt>..            </p>.            <p>.
0080:             The default Debian document root is <tt>/var/www/htm
00c0: l</tt>. You.                can make your own virtual hosts unde
0100: r /var/www. This is different.                to previous releas
0140: es which provides better security out of the box..            </
0180: p>.        </div>..        <div class="section_header">.
01c0:   <div id="bugs"></div>.                Reporting Problems.
0200:    </div>.        <div class="content_section_text">.          <
0240: p>.                Please use the <tt>reportbug</tt> tool to rep
0280: ort bugs in the.                Apache2 package with Debian. How
02c0: ever, check <a.                href="https://bugs.debian.org/cgi
0300: -bin/pkgreport.cgi?ordering=normal;archive=0;src=apache2;repeatm
0340: erged=0".                rel="nofollow">existing bug reports</a>
0380:  before reporting a new bug..          </p>.          <p>.
03c0:           Please report bugs specific to modules (such as PHP an
0400: d others).                to respective packages, not to the web
0440:  server itself..          </p>.        </div>.....      </div>.
0480:    </div>.    <div class="validator">.    </div>.  </body>.</htm
04c0: l>..
05:53:44.539679 [0-0] == Info: [WRITE] [OUT] wrote 1220 body bytes -> 1220
05:53:44.539889 [0-0] == Info: [WRITE] [PAUSE] writing 1220/1220 bytes of type 1 -> 0
05:53:44.540139 [0-0] == Info: [WRITE] download_write body(type=1, blen=1220) -> 0
05:53:44.540381 [0-0] == Info: [WRITE] client_write(type=1, len=1220) -> 0
05:53:44.540573 [0-0] == Info: [WRITE] xfer_write_resp(len=1220, eos=0) -> 0
05:53:44.540810 [0-0] == Info: [HTTP/3] [0] ACK 1220 bytes of DATA
05:53:44.540999 [0-0] == Info: [HTTP/3] [0] DATA len=1220
05:53:44.541120 [0-0] == Info: [HTTP/3] [0] read_stream(len=1220) -> 0
05:53:44.541307 [0-0] == Info: [HTTP/3] [0] CLOSED
05:53:44.541489 [0-0] == Info: [HTTP/3] [0] quic close(app_error=256) -> 0
05:53:44.541762 [0-0] == Info: [HTTP/3] recvmmsg() -> 4 packets
05:53:44.541924 [0-0] == Info: [HTTP/3] ingress, recvmmsg -> EAGAIN
05:53:44.542137 [0-0] == Info: [HTTP/3] recvd 13 packets with 18392 bytes -> 0
05:53:44.542448 [0-0] == Info: [HTTP/3] vquic_send(len=49, gso=49) -> 0, sent=49
05:53:44.542651 [0-0] == Info: [HTTP/3] [0] cf_recv(blen=102400) -> 0m, 0
05:53:44.542854 [0-0] <= Recv data, 0 bytes (0x0)
05:53:44.542986 [0-0] == Info: [WRITE] [PAUSE] writing 0/0 bytes of type 81 -> 0
05:53:44.543183 [0-0] == Info: [WRITE] download_write body(type=81, blen=0) -> 0
05:53:44.543393 [0-0] == Info: [WRITE] client_write(type=81, len=0) -> 0
05:53:44.543565 [0-0] == Info: [WRITE] xfer_write_resp(len=0, eos=1) -> 0
05:53:44.543750 [0-0] == Info: [MULTI] [PERFORMING] sendrecv_dl() no EAGAIN/pending data, set select_bits=1
################################################################################################################################ 100.0%05:53:44.544471 [0-0] == Info: [MULTI] [PERFORMING] -> [DONE]
05:53:44.544655 [0-0] == Info: [MULTI] [DONE] multi_done: status: 0 prem: 0 done: 0
05:53:44.544885 [0-0] == Info: [WRITE] [OUT] done
05:53:44.545051 [0-0] == Info: [HTTP/3] [0] easy handle is done
05:53:44.545219 [0-0] == Info: [HTTP/3] no active streams, unset keep-alive
05:53:44.545434 [0-0] == Info: [READ] client_reset, clear readers
05:53:44.545622 [0-x] == Info: [MULTI] [DONE] multi_done_locked, in use=0
05:53:44.545825 [0-0] == Info: Connection #0 to host 127.0.0.1 left intact
05:53:44.546014 [0-0] == Info: [MULTI] [DONE] -> [COMPLETED]
05:53:44.546236 [0-0] == Info: [MULTI] [COMPLETED] Expire cleared
05:53:44.546436 [0-0] == Info: [MULTI] [COMPLETED] -> [MSGSENT]
05:53:44.546650 [0-0] == Info: [MULTI] [COMPLETED] removed from multi, mid=1, running=0, total=1

root@ubuntu:/src/curl#
```