### PR TITLE
build: drop memdebug option for test servers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,7 +277,6 @@ if(ENABLE_DEBUG)
   message(WARNING "This curl build is Debug-enabled and insecure, do not use in production.")
 endif()
 option(ENABLE_CURLDEBUG "Enable TrackMemory debug feature" ${ENABLE_DEBUG})
-option(ENABLE_SERVER_DEBUG "Apply curl debug options to test servers" OFF)
 
 set(CURL_DEBUG_MACROS "")
 if(ENABLE_DEBUG)

--- a/configure.ac
+++ b/configure.ac
@@ -579,25 +579,6 @@ case $host_os in
     ;;
 esac
 
-dnl Apply curl debug options to test servers
-OPT_SERVER_DEBUG="default"
-AC_ARG_ENABLE(server-debug,
-AS_HELP_STRING([--enable-server-debug],[Enable debug options for test servers])
-AS_HELP_STRING([--disable-server-debug],[Disable debug options for test servers]),
-OPT_SERVER_DEBUG=$enableval)
-case "$OPT_SERVER_DEBUG" in
-  no)
-    dnl --disable-server-debug option used
-    want_server_debug="no"
-    ;;
-  *)
-    dnl --enable-server-debug option used or not specified
-    want_server_debug="no"
-    ;;
-esac
-AC_MSG_RESULT([$want_server_debug])
-AM_CONDITIONAL(ENABLE_SERVER_DEBUG, test x$want_server_debug = xyes)
-
 dnl **********************************************************************
 dnl Compilation based checks should not be done before this point.
 dnl **********************************************************************

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -248,7 +248,6 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `ENABLE_CURLDEBUG`:                       Enable TrackMemory debug feature. Default: =`ENABLE_DEBUG`
 - `ENABLE_CURL_MANUAL`:                     Build the man page for curl and enable its `-M`/`--manual` option. Default: `ON`
 - `ENABLE_DEBUG`:                           Enable curl debug features (for developing curl itself). Default: `OFF`
-- `ENABLE_SERVER_DEBUG`:                    Apply curl debug options to test servers. Default: `OFF`
 - `IMPORT_LIB_SUFFIX`:                      Import library suffix. Default: `_imp` for MSVC-like toolchains, otherwise empty.
 - `LIBCURL_OUTPUT_NAME`:                    Basename of the curl library. Default: `libcurl`
 - `PICKY_COMPILER`:                         Enable picky compiler options. Default: `ON`

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -22,7 +22,7 @@
 #
 ###########################################################################
 
-# Get BUNDLE, BUNDLE_SRC, FIRSTFILES, UTILS, MEMDEBUG, CURLX_SRCS, TESTFILES variables
+# Get BUNDLE, BUNDLE_SRC, FIRSTFILES, UTILS, CURLX_SRCS, TESTFILES variables
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
@@ -34,11 +34,7 @@ add_custom_command(
     "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc" ${FIRSTFILES} ${TESTFILES}
   VERBATIM)
 
-if(ENABLE_SERVER_DEBUG AND ENABLE_CURLDEBUG)
-  set_source_files_properties("../../lib/memdebug.c" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
-endif()
-
-add_executable(servers EXCLUDE_FROM_ALL ${MEMDEBUG} ${CURLX_SRCS} ${UTILS} "${BUNDLE_SRC}")
+add_executable(servers EXCLUDE_FROM_ALL ${CURLX_SRCS} ${UTILS} "${BUNDLE_SRC}")
 add_dependencies(testdeps servers)
 target_include_directories(servers PRIVATE
   "${PROJECT_BINARY_DIR}/lib"           # for "curl_config.h"
@@ -48,9 +44,6 @@ target_include_directories(servers PRIVATE
   "${PROJECT_SOURCE_DIR}/tests/server"  # for "first.h"
 )
 target_link_libraries(servers ${CURL_LIBS})
-if(ENABLE_SERVER_DEBUG)
-  set_property(TARGET servers APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
-endif()
 set_property(TARGET servers APPEND PROPERTY COMPILE_DEFINITIONS "WITHOUT_LIBCURL" "CURL_NO_OLDIES")
 # Test servers simply are standalone programs that do not use libcurl
 # library.  For convenience and to ease portability of these servers,

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -40,7 +40,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_srcdir)/src            \
               -I$(top_srcdir)/tests/server
 
-# Get BUNDLE, BUNDLE_SRC, FIRSTFILES, UTILS, MEMDEBUG, CURLX_SRCS, TESTFILES variables
+# Get BUNDLE, BUNDLE_SRC, FIRSTFILES, UTILS, CURLX_SRCS, TESTFILES variables
 include Makefile.inc
 
 EXTRA_DIST = CMakeLists.txt .checksrc $(FIRSTFILES) $(UTILS) $(TESTFILES)
@@ -53,29 +53,14 @@ LIBS = $(BLANK_AT_MAKETIME)
 if DOING_NATIVE_WINDOWS
 AM_CPPFLAGS += -DCURL_STATICLIB
 endif
-if ENABLE_SERVER_DEBUG
-if DEBUGBUILD
-AM_CPPFLAGS += -DDEBUGBUILD
-endif
-if CURLDEBUG
-AM_CPPFLAGS += -DCURLDEBUG
-endif
-endif
 
 AM_CPPFLAGS += -DWITHOUT_LIBCURL -DCURL_NO_OLDIES
 
-bundle_EXCLUDE =
-if ENABLE_SERVER_DEBUG
-if CURLDEBUG
-bundle_EXCLUDE += $(MEMDEBUG)
-endif
-endif
 $(BUNDLE_SRC): $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRSTFILES) $(UTILS) $(MEMDEBUG) $(CURLX_SRCS) $(TESTFILES)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS) $(MEMDEBUG) $(CURLX_SRCS) --test $(TESTFILES) --exclude $(bundle_EXCLUDE) > $(BUNDLE_SRC)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS) $(CURLX_SRCS) --test $(TESTFILES) > $(BUNDLE_SRC)
 
 noinst_PROGRAMS = $(BUNDLE)
 nodist_servers_SOURCES = $(BUNDLE_SRC)
-servers_SOURCES = $(bundle_EXCLUDE)
 servers_LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 servers_CFLAGS = $(AM_CFLAGS)
 CLEANFILES = $(BUNDLE_SRC)

--- a/tests/server/Makefile.inc
+++ b/tests/server/Makefile.inc
@@ -32,10 +32,6 @@ FIRSTFILES = first.c first.h
 # Common files used by test programs
 UTILS = getpart.c getpart.h util.c util.h
 
-MEMDEBUG = \
-  ../../lib/memdebug.c \
-  ../../lib/memdebug.h
-
 CURLX_SRCS = \
   ../../lib/curlx/base64.c \
   ../../lib/curlx/inet_pton.c \


### PR DESCRIPTION
I added it just in case when removing enabled-by-default memdebug
from test servers. Apparently it broke after recent changes. It's
probably not a widely used feature and does not seem to be worth fixing.
It creates odd dependencies as the error message indicates:

```
lib/memdebug.c: In function 'curl_dbg_log':
lib/memdebug.c:465:12: error: implicit declaration of function 'mvsnprintf'; did you mean 'vsnprintf'? [-Wimplicit-function-declaration]
  465 |   nchars = mvsnprintf(buf, sizeof(buf), format, ap);
      |            ^~~~~~~~~~
      |            vsnprintf
lib/memdebug.c:465:12: warning: nested extern declaration of 'mvsnprintf' [-Wnested-externs]
```

Follow-up to a16485a42ea5dabe6c327179a1678ad04d1c6b2f #16705
