### PR TITLE
build: tidy up header paths, use srcdir where possible

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -50,6 +50,7 @@ CFLAGS += @CURL_CFLAG_EXTRAS@
 #
 # $(top_srcdir)/include is for libcurl's external include files
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
+# $(srcdir) for the generated unity source to find included sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include   \
               -I$(top_builddir)/lib     \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,11 +79,10 @@ if(BUILD_STATIC_CURL)
 endif()
 
 set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
-  "${PROJECT_BINARY_DIR}/lib"  # for "curl_config.h"
-  "${PROJECT_SOURCE_DIR}/lib"  # for "curl_setup.h"
+  "${PROJECT_BINARY_DIR}/lib"        # for "curl_config.h"
+  "${PROJECT_SOURCE_DIR}/lib"        # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"  # for curlx functions
-  # This is needed as tool_hugehelp.c is generated in the binary dir
-  "${PROJECT_SOURCE_DIR}/src"  # for "tool_hugehelp.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
 add_executable(${EXE_NAME} ${CURL_CFILES} ${_curl_cfiles_gen} ${CURLX_CFILES} ${CURL_HFILES} ${_curl_hfiles_gen})

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,7 +45,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/src          \
               -I$(top_srcdir)/lib            \
               -I$(top_srcdir)/lib/curlx      \
-              -I$(top_srcdir)/src
+              -I$(srcdir)
 
 bin_PROGRAMS = curl
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,7 +38,7 @@ EXTRA_DIST = mk-file-embed.pl mkhelp.pl \
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
 # $(top_builddir)/src is for curl's generated src/curl_config.h file
 # $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
-# $(top_srcdir)/src is for curl's src/tool_setup.h and "curl-private" files
+# $(srcdir) for generated sources to find included sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -47,7 +47,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
-  "${CMAKE_CURRENT_SOURCE_DIR}"          # for "first.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES")
 set_target_properties(${BUNDLE} PROPERTIES OUTPUT_NAME "${BUNDLE}" PROJECT_LABEL "Test ${BUNDLE}" UNITY_BUILD OFF)

--- a/tests/client/Makefile.am
+++ b/tests/client/Makefile.am
@@ -31,6 +31,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 # $(top_srcdir)/include is for libcurl's external include files
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
 # $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
+# $(srcdir) for the generated bundle source to find included test sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
   "${PROJECT_SOURCE_DIR}/src"            # for "tool_binmode.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
   "${PROJECT_SOURCE_DIR}/tests/unit"     # for "curlcheck.h"
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -55,8 +55,8 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
   "${PROJECT_SOURCE_DIR}/src"            # for "tool_binmode.h"
-  "${PROJECT_SOURCE_DIR}/tests/libtest"  # to be able to build generated tests
-  "${PROJECT_SOURCE_DIR}/tests/unit"     # for curlcheck.h
+  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${PROJECT_SOURCE_DIR}/tests/unit"     # for "curlcheck.h"
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES" "CURL_DISABLE_DEPRECATION")

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -31,6 +31,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 # $(top_srcdir)/include is for libcurl's external include files
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
 # $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
+# $(srcdir) for the generated bundle source to find included test sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -37,7 +37,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_srcdir)/lib            \
               -I$(top_srcdir)/lib/curlx      \
               -I$(top_srcdir)/src            \
-              -I$(top_srcdir)/tests/libtest  \
+              -I$(srcdir)                    \
               -I$(top_srcdir)/tests/unit
 
 # Get BUNDLE, BUNDLE_SRC, FIRSTFILES, UTILS, CURLX_SRCS, TESTFILES variables

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -39,11 +39,11 @@ add_executable(${BUNDLE} EXCLUDE_FROM_ALL "${BUNDLE_SRC}")
 add_dependencies(testdeps ${BUNDLE})
 target_link_libraries(${BUNDLE} ${CURL_LIBS})
 target_include_directories(${BUNDLE} PRIVATE
-  "${PROJECT_BINARY_DIR}/lib"           # for "curl_config.h"
-  "${PROJECT_SOURCE_DIR}/lib"           # for "curl_setup.h"
-  "${PROJECT_SOURCE_DIR}/lib/curlx"     # for curlx
-  "${PROJECT_SOURCE_DIR}/src"           # for "tool_binmode.h", "tool_xattr.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}"         # for the generated bundle source to find included test sources
+  "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
+  "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
+  "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
+  "${PROJECT_SOURCE_DIR}/src"            # for "tool_binmode.h", "tool_xattr.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "WITHOUT_LIBCURL")
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES")

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_SOURCE_DIR}/lib"           # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"     # for curlx
   "${PROJECT_SOURCE_DIR}/src"           # for "tool_binmode.h", "tool_xattr.h"
-  "${PROJECT_SOURCE_DIR}/tests/server"  # for "first.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "WITHOUT_LIBCURL")
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES")

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_SOURCE_DIR}/lib"           # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"     # for curlx
   "${PROJECT_SOURCE_DIR}/src"           # for "tool_binmode.h", "tool_xattr.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}"         # for the generated bundle source to find included test sources
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "WITHOUT_LIBCURL")
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES")

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -32,6 +32,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
 # $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
 # $(top_srcdir)/src for "tool_binmode.h", "tool_xattr.h"
+# $(srcdir) for the generated bundle source to find included test sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -38,7 +38,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_srcdir)/lib            \
               -I$(top_srcdir)/lib/curlx      \
               -I$(top_srcdir)/src            \
-              -I$(top_srcdir)/tests/server
+              -I$(srcdir)
 
 # Get BUNDLE, BUNDLE_SRC, FIRSTFILES, UTILS, CURLX_SRCS, TESTFILES variables
 include Makefile.inc

--- a/tests/tunit/CMakeLists.txt
+++ b/tests/tunit/CMakeLists.txt
@@ -40,7 +40,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
-  "${PROJECT_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"            # for tool headers
   "${PROJECT_SOURCE_DIR}/tests/libtest"  # for "first.h"
   "${PROJECT_SOURCE_DIR}/tests/unit"     # for "curlcheck.h"
   "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/tests/tunit/CMakeLists.txt
+++ b/tests/tunit/CMakeLists.txt
@@ -43,7 +43,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_SOURCE_DIR}/src"            # for tool headers
   "${PROJECT_SOURCE_DIR}/tests/libtest"  # for "first.h"
   "${PROJECT_SOURCE_DIR}/tests/unit"     # for "curlcheck.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES" "CURL_DISABLE_DEPRECATION")

--- a/tests/tunit/CMakeLists.txt
+++ b/tests/tunit/CMakeLists.txt
@@ -41,9 +41,9 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
   "${PROJECT_SOURCE_DIR}/src"
-  "${PROJECT_SOURCE_DIR}/tests/libtest"
-  "${PROJECT_SOURCE_DIR}/tests/unit"     # for curlcheck.h
-  "${PROJECT_SOURCE_DIR}/tests/tunit"
+  "${PROJECT_SOURCE_DIR}/tests/libtest"  # for "first.h"
+  "${PROJECT_SOURCE_DIR}/tests/unit"     # for "curlcheck.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES" "CURL_DISABLE_DEPRECATION")

--- a/tests/tunit/Makefile.am
+++ b/tests/tunit/Makefile.am
@@ -39,7 +39,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_srcdir)/src            \
               -I$(top_srcdir)/tests/libtest  \
               -I$(top_srcdir)/tests/unit     \
-              -I$(top_srcdir)/tests/tunit
+              -I$(srcdir)
 
 # Get BUNDLE, BUNDLE_SRC, FIRSTFILES, UTILS, TESTFILES variables
 include Makefile.inc

--- a/tests/tunit/Makefile.am
+++ b/tests/tunit/Makefile.am
@@ -31,6 +31,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 # $(top_srcdir)/include is for libcurl's external include files
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
 # $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
+# $(srcdir) for the generated bundle source to find included test sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
   "${PROJECT_SOURCE_DIR}/src"            # for "tool_binmode.h"
   "${PROJECT_SOURCE_DIR}/tests/libtest"  # for "first.h"
-  "${CMAKE_CURRENT_SOURCE_DIR}"
+  "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES" "CURL_DISABLE_DEPRECATION")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -41,8 +41,8 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
   "${PROJECT_SOURCE_DIR}/src"
-  "${PROJECT_SOURCE_DIR}/tests/libtest"
-  "${PROJECT_SOURCE_DIR}/tests/unit"
+  "${PROJECT_SOURCE_DIR}/tests/libtest"  # for "first.h"
+  "${CMAKE_CURRENT_SOURCE_DIR}"
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES" "CURL_DISABLE_DEPRECATION")

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -40,7 +40,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
-  "${PROJECT_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"            # for "tool_binmode.h"
   "${PROJECT_SOURCE_DIR}/tests/libtest"  # for "first.h"
   "${CMAKE_CURRENT_SOURCE_DIR}"
 )

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -31,6 +31,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 # $(top_srcdir)/include is for libcurl's external include files
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
 # $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
+# $(srcdir) for the generated bundle source to find included test sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -38,7 +38,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_srcdir)/lib/curlx      \
               -I$(top_srcdir)/src            \
               -I$(top_srcdir)/tests/libtest  \
-              -I$(top_srcdir)/tests/unit
+              -I$(srcdir)
 
 # Get BUNDLE, BUNDLE_SRC, FIRSTFILES, UTILS, TESTFILES variables
 include Makefile.inc


### PR DESCRIPTION
To improve readability.

Also add more comments on why each is necessary.
