### PR TITLE
memdebug: include in unity batch

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -59,12 +59,6 @@ if(CURL_BUILD_TESTING)
   set_target_properties(curlu PROPERTIES UNITY_BUILD_BATCH_SIZE 0)
 endif()
 
-if(ENABLE_CURLDEBUG)
-  # We must compile this source separately to avoid memdebug.h redefinitions
-  # applying to it.
-  set_source_files_properties("memdebug.c" PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
-endif()
-
 ## Library definition
 
 if(NOT DEFINED IMPORT_LIB_SUFFIX)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -76,19 +76,13 @@ CSOURCES += dllmain.c
 endif
 
 if USE_UNITY
-curl_EXCLUDE =
-if CURLDEBUG
-# We must compile this source separately to avoid memdebug.h redefinitions
-# applying to it.
-curl_EXCLUDE += memdebug.c
-endif
 libcurl_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CSOURCES)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CSOURCES) --exclude $(curl_EXCLUDE) > libcurl_unity.c
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CSOURCES) > libcurl_unity.c
 
 nodist_libcurl_la_SOURCES = libcurl_unity.c
-libcurl_la_SOURCES = $(curl_EXCLUDE)
+libcurl_la_SOURCES =
 nodist_libcurlu_la_SOURCES = libcurl_unity.c
-libcurlu_la_SOURCES = $(curl_EXCLUDE)
+libcurlu_la_SOURCES =
 CLEANFILES = libcurl_unity.c
 else
 libcurl_la_SOURCES = $(CSOURCES) $(HHEADERS)

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -57,7 +57,6 @@
 #ifdef HEADER_CURL_MEMDEBUG_H
 /* cleanup after memdebug.h */
 
-#ifdef MEMDEBUG_NODEFINES
 #ifdef CURLDEBUG
 
 #undef strdup
@@ -91,7 +90,6 @@
 #undef fdopen
 #undef fclose
 
-#endif /* MEMDEBUG_NODEFINES */
 #endif /* CURLDEBUG */
 
 #undef HEADER_CURL_MEMDEBUG_H

--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -86,6 +86,7 @@
 
 /* sclose is probably already defined, redefine it! */
 #undef sclose
+#define sclose(x)  CURL_SCLOSE(x)
 #undef fopen
 #undef fdopen
 #undef fclose

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -197,16 +197,18 @@ struct timeval {
  */
 
 #ifdef HAVE_CLOSESOCKET
-#  define sclose(x)  closesocket((x))
+#  define CURL_SCLOSE(x)  closesocket((x))
 #elif defined(HAVE_CLOSESOCKET_CAMEL)
-#  define sclose(x)  CloseSocket((x))
+#  define CURL_SCLOSE(x)  CloseSocket((x))
 #elif defined(MSDOS)  /* Watt-32 */
-#  define sclose(x)  close_s((x))
+#  define CURL_SCLOSE(x)  close_s((x))
 #elif defined(USE_LWIPSOCK)
-#  define sclose(x)  lwip_close((x))
+#  define CURL_SCLOSE(x)  lwip_close((x))
 #else
-#  define sclose(x)  close((x))
+#  define CURL_SCLOSE(x)  close((x))
 #endif
+
+#define sclose(x)  CURL_SCLOSE(x)
 
 /*
  * Stack-independent version of fcntl() on sockets:

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -70,7 +70,7 @@ static void curl_dbg_cleanup(void)
   if(curl_dbg_logfile &&
      curl_dbg_logfile != stderr &&
      curl_dbg_logfile != stdout) {
-    fclose(curl_dbg_logfile);
+    (fclose)(curl_dbg_logfile);
   }
   curl_dbg_logfile = NULL;
 }
@@ -80,7 +80,7 @@ void curl_dbg_memdebug(const char *logname)
 {
   if(!curl_dbg_logfile) {
     if(logname && *logname)
-      curl_dbg_logfile = fopen(logname, FOPEN_WRITETEXT);
+      curl_dbg_logfile = (fopen)(logname, FOPEN_WRITETEXT);
     else
       curl_dbg_logfile = stderr;
 #ifdef MEMDEBUG_LOG_SYNC
@@ -309,7 +309,7 @@ curl_socket_t curl_dbg_socket(int domain, int type, int protocol,
   if(countcheck("socket", line, source))
     return CURL_SOCKET_BAD;
 
-  sockfd = socket(domain, type, protocol);
+  sockfd = (socket)(domain, type, protocol);
 
   if(source && (sockfd != CURL_SOCKET_BAD))
     curl_dbg_log("FD %s:%d socket() = %" FMT_SOCKET_T "\n",
@@ -326,7 +326,7 @@ SEND_TYPE_RETV curl_dbg_send(SEND_TYPE_ARG1 sockfd,
   SEND_TYPE_RETV rc;
   if(countcheck("send", line, source))
     return -1;
-  rc = send(sockfd, buf, len, flags);
+  rc = (send)(sockfd, buf, len, flags);
   if(source)
     curl_dbg_log("SEND %s:%d send(%lu) = %ld\n",
                 source, line, (unsigned long)len, (long)rc);
@@ -340,7 +340,7 @@ RECV_TYPE_RETV curl_dbg_recv(RECV_TYPE_ARG1 sockfd, RECV_TYPE_ARG2 buf,
   RECV_TYPE_RETV rc;
   if(countcheck("recv", line, source))
     return -1;
-  rc = recv(sockfd, buf, len, flags);
+  rc = (recv)(sockfd, buf, len, flags);
   if(source)
     curl_dbg_log("RECV %s:%d recv(%lu) = %ld\n",
                 source, line, (unsigned long)len, (long)rc);
@@ -352,7 +352,7 @@ int curl_dbg_socketpair(int domain, int type, int protocol,
                        curl_socket_t socket_vector[2],
                        int line, const char *source)
 {
-  int res = socketpair(domain, type, protocol, socket_vector);
+  int res = (socketpair)(domain, type, protocol, socket_vector);
 
   if(source && (0 == res))
     curl_dbg_log("FD %s:%d socketpair() = "
@@ -369,7 +369,7 @@ curl_socket_t curl_dbg_accept(curl_socket_t s, void *saddr, void *saddrlen,
   struct sockaddr *addr = (struct sockaddr *)saddr;
   curl_socklen_t *addrlen = (curl_socklen_t *)saddrlen;
 
-  curl_socket_t sockfd = accept(s, addr, addrlen);
+  curl_socket_t sockfd = (accept)(s, addr, addrlen);
 
   if(source && (sockfd != CURL_SOCKET_BAD))
     curl_dbg_log("FD %s:%d accept() = %" FMT_SOCKET_T "\n",
@@ -386,7 +386,7 @@ curl_socket_t curl_dbg_accept4(curl_socket_t s, void *saddr, void *saddrlen,
   struct sockaddr *addr = (struct sockaddr *)saddr;
   curl_socklen_t *addrlen = (curl_socklen_t *)saddrlen;
 
-  curl_socket_t sockfd = accept4(s, addr, addrlen, flags);
+  curl_socket_t sockfd = (accept4)(s, addr, addrlen, flags);
 
   if(source && (sockfd != CURL_SOCKET_BAD))
     curl_dbg_log("FD %s:%d accept() = %" FMT_SOCKET_T "\n",
@@ -416,7 +416,7 @@ ALLOC_FUNC
 FILE *curl_dbg_fopen(const char *file, const char *mode,
                      int line, const char *source)
 {
-  FILE *res = fopen(file, mode);
+  FILE *res = (fopen)(file, mode);
 
   if(source)
     curl_dbg_log("FILE %s:%d fopen(\"%s\",\"%s\") = %p\n",
@@ -429,7 +429,7 @@ ALLOC_FUNC
 FILE *curl_dbg_fdopen(int filedes, const char *mode,
                       int line, const char *source)
 {
-  FILE *res = fdopen(filedes, mode);
+  FILE *res = (fdopen)(filedes, mode);
   if(source)
     curl_dbg_log("FILE %s:%d fdopen(\"%d\",\"%s\") = %p\n",
                  source, line, filedes, mode, (void *)res);
@@ -469,7 +469,7 @@ void curl_dbg_log(const char *format, ...)
     nchars = (int)sizeof(buf) - 1;
 
   if(nchars > 0)
-    fwrite(buf, 1, (size_t)nchars, curl_dbg_logfile);
+    (fwrite)(buf, 1, (size_t)nchars, curl_dbg_logfile);
 }
 
 #endif /* CURLDEBUG */

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -446,7 +446,7 @@ int curl_dbg_fclose(FILE *file, int line, const char *source)
     curl_dbg_log("FILE %s:%d fclose(%p)\n",
                  source, line, (void *)file);
 
-  res = fclose(file);
+  res = (fclose)(file);
 
   return res;
 }

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -407,7 +407,7 @@ void curl_dbg_mark_sclose(curl_socket_t sockfd, int line, const char *source)
 /* this is our own defined way to close sockets on *ALL* platforms */
 int curl_dbg_sclose(curl_socket_t sockfd, int line, const char *source)
 {
-  int res = sclose(sockfd);
+  int res = CURL_SCLOSE(sockfd);
   curl_dbg_mark_sclose(sockfd, line, source);
   return res;
 }

--- a/lib/memdebug.c
+++ b/lib/memdebug.c
@@ -30,8 +30,6 @@
 
 #include "urldata.h"
 
-#define MEMDEBUG_NODEFINES /* do not redefine the standard functions */
-
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"
 #include "curl_memory.h"

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -126,8 +126,6 @@ CURL_EXTERN ALLOC_FUNC
 
 #endif /* HEADER_CURL_MEMDEBUG_H_EXTERNS */
 
-#ifndef MEMDEBUG_NODEFINES
-
 /* Set this symbol on the command-line, recompile all lib-sources */
 #undef strdup
 #define strdup(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
@@ -186,8 +184,6 @@ CURL_EXTERN ALLOC_FUNC
 #undef fdopen
 #define fdopen(file,mode) curl_dbg_fdopen(file,mode,__LINE__,__FILE__)
 #define fclose(file) curl_dbg_fclose(file,__LINE__,__FILE__)
-
-#endif /* MEMDEBUG_NODEFINES */
 
 #endif /* CURLDEBUG */
 

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -198,9 +198,6 @@ CURL_EXTERN ALLOC_FUNC
 #ifndef fake_sclose
 #define fake_sclose(x)  Curl_nop_stmt
 #endif
-#fndef sclose
-#define sclose(x)  CURL_SCLOSE(x)
-#endif
 
 /*
  * Curl_safefree defined as a macro to allow MemoryTracking feature

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -198,6 +198,9 @@ CURL_EXTERN ALLOC_FUNC
 #ifndef fake_sclose
 #define fake_sclose(x)  Curl_nop_stmt
 #endif
+#fndef sclose
+#define sclose(x)  CURL_SCLOSE(x)
+#endif
 
 /*
  * Curl_safefree defined as a macro to allow MemoryTracking feature

--- a/scripts/mk-unity.pl
+++ b/scripts/mk-unity.pl
@@ -31,14 +31,11 @@ use strict;
 use warnings;
 
 if(!@ARGV) {
-    die "Usage: $0 [--test <tests>] [--include <include-c-sources>] [--exclude <exclude-c-sources>] [--srcdir <srcdir>] [--embed]\n";
+    die "Usage: $0 [--test <tests>] [--include <include-c-sources>] [--srcdir <srcdir>] [--embed]\n";
 }
 
-# Specific sources to exclude or add as an extra source file
 my @src;
-my %exclude;
 my %include;
-my $in_exclude = 0;
 my $in_include = 0;
 my $srcdir = "";
 my $in_srcdir = 0;
@@ -46,15 +43,9 @@ my $any_test = 0;
 my $embed = 0;
 foreach my $src (@ARGV) {
     if($src eq "--test") {
-        $in_exclude = 0;
-        $in_include = 0;
-    }
-    elsif($src eq "--exclude") {
-        $in_exclude = 1;
         $in_include = 0;
     }
     elsif($src eq "--include") {
-        $in_exclude = 0;
         $in_include = 1;
     }
     elsif($src eq "--embed") {
@@ -66,9 +57,6 @@ foreach my $src (@ARGV) {
     elsif($in_srcdir) {
         $srcdir = $src;
         $in_srcdir = 0;
-    }
-    elsif($in_exclude) {
-        $exclude{$src} = 1;
     }
     elsif($in_include) {
         $include{$src} = 1;
@@ -88,7 +76,7 @@ if($any_test) {
 my $tlist = "";
 
 foreach my $src (@src) {
-    if($src =~ /([a-z0-9]+)\.c$/ && !exists $exclude{$src}) {
+    if($src =~ /([a-z0-9]+)\.c$/) {
         my $name = $1;
         if($embed) {
             my $fn = $src;


### PR DESCRIPTION
Before this patch `memdebug.c` was compiled as a separate source in
unity builds. This was necessary because `memdebug.c` failed to compile
if `memdebug.h` was included before it, in `CURLDEBUG` mode. This patch
fixes this issue and allows to compile `memdebug.c` as part of the unity
source batch. This removes an exception and makes builds perform a notch
better.

- introduce `CURL_SCLOSE()` macro as an immutable synonym of `sclose()`.
- memdebug: replace `sclose()` reference with `CURL_SCLOSE()` to compile
  as expected when `sclose()` is overridden by `memdebug.h`.
- memdebug: make it not break when including `memdebug.h` before it in
  `CURLDEBUG` mode. Do this by calling low-level functions as
  `(function)`.
- autotools, cmake: drop memdebug exception, include it like any other
  source file. This is now possible because `memdebug.c` doesn't break
  if `memdebug.h` was included before it, in `CURLDEBUG` builds.
- mk-unity: drop `--exclude` option. No longer used after this patch.
- drop `MEMDEBUG_NODEFINES` macro hack. No longer necessary.

Ref: #16747
Closes #16746
Closes #16738
