### PR TITLE
autotools: drop no longer necessary `--srcdir` unity options

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -83,7 +83,7 @@ if CURLDEBUG
 curl_EXCLUDE += memdebug.c
 endif
 libcurl_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CSOURCES)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --srcdir $(srcdir) --include $(CSOURCES) --exclude $(curl_EXCLUDE) > libcurl_unity.c
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CSOURCES) --exclude $(curl_EXCLUDE) > libcurl_unity.c
 
 nodist_libcurl_la_SOURCES = libcurl_unity.c
 libcurl_la_SOURCES = $(curl_EXCLUDE)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -113,7 +113,7 @@ libcurltool_la_CFLAGS =
 libcurltool_la_LDFLAGS = -static $(LINKFLAGS)
 if USE_UNITY
 libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curl_CURLX)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --srcdir $(srcdir) --include $(CURL_CFILES) $(curl_CURLX) > libcurltool_unity.c
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curl_CURLX) > libcurltool_unity.c
 
 nodist_libcurltool_la_SOURCES = libcurltool_unity.c
 libcurltool_la_SOURCES =


### PR DESCRIPTION
Follow-up to ee066732963b7051a8d2fd56fa91a4ce0b444bd5 #17628