### PR TITLE
docs: fix documentation of connect_only 2

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
@@ -40,7 +40,7 @@ transfers.
 
 Since 7.86.0, this option can be set to '2' and if WebSocket is used,
 libcurl performs the request and reads all response headers before handing
-over control to the application. For other protocols the behaviour of '2'
+over control to the application. For other protocols the behavior of '2'
 is undefined.
 
 Transfers marked connect only do not reuse any existing connections and

--- a/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
+++ b/docs/libcurl/opts/CURLOPT_CONNECT_ONLY.md
@@ -38,9 +38,10 @@ curl_easy_getinfo(3) as the library can set up the connection and then
 the application can obtain the most recently used socket for special data
 transfers.
 
-Since 7.86.0, this option can be set to '2' and if HTTP or WebSocket are used,
+Since 7.86.0, this option can be set to '2' and if WebSocket is used,
 libcurl performs the request and reads all response headers before handing
-over control to the application.
+over control to the application. For other protocols the behaviour of '2'
+is undefined.
 
 Transfers marked connect only do not reuse any existing connections and
 connections marked connect only are not allowed to get reused.


### PR DESCRIPTION
Setting CURLOPT_CONNECT_ONLY with value 2 is only defined for WebSocket and the effect on other protocols is undetermined. That includes the HTTP urls.

refs #17621