### PR TITLE
multi: fix polling with pending input

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -1069,3 +1069,16 @@ void Curl_pollset_check(struct Curl_easy *data,
   }
   *pwant_read = *pwant_write = FALSE;
 }
+
+bool Curl_pollset_want_read(struct Curl_easy *data,
+                            struct easy_pollset *ps,
+                            curl_socket_t sock)
+{
+  unsigned int i;
+  (void)data;
+  for(i = 0; i < ps->num; ++i) {
+    if((ps->sockets[i] == sock) && (ps->actions[i] & CURL_POLL_IN))
+      return TRUE;
+  }
+  return FALSE;
+}

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -621,6 +621,13 @@ void Curl_pollset_check(struct Curl_easy *data,
                         bool *pwant_read, bool *pwant_write);
 
 /**
+ * Return TRUE if the pollset contains socket with CURL_POLL_IN.
+ */
+bool Curl_pollset_want_read(struct Curl_easy *data,
+                            struct easy_pollset *ps,
+                            curl_socket_t sock);
+
+/**
  * Types and macros used to keep the current easy handle in filter calls,
  * allowing for nested invocations. See #10336.
  *


### PR DESCRIPTION
When multi creates the pollset of a transfer, it checks now if a connection (FIRST/SECONDARY) socket waits on POLLIN and has input data pending in filters (relevant to OpenSSL's new read ahead). If so, it triggers a timeout on the transfer via EXPIRE_RUN_NOW.

This fixes sporadic stalls in test 988 when running event based.