### PR TITLE
http2: do not delay RST send on aborted transfer

### DIFF
--- a/lib/http2.c
+++ b/lib/http2.c
@@ -205,6 +205,9 @@ static void cf_h2_ctx_close(struct cf_h2_ctx *ctx)
   }
 }
 
+static CURLcode nw_out_flush(struct Curl_cfilter *cf,
+                             struct Curl_easy *data);
+
 static CURLcode h2_progress_egress(struct Curl_cfilter *cf,
                                    struct Curl_easy *data);
 
@@ -449,8 +452,10 @@ static void http2_data_done(struct Curl_cfilter *cf, struct Curl_easy *data)
       flush_egress = TRUE;
     }
 
-    if(flush_egress)
-      nghttp2_session_send(ctx->h2);
+    if(flush_egress) {
+      (void)nghttp2_session_send(ctx->h2);
+      (void)nw_out_flush(cf, data);
+    }
   }
 
   Curl_uint_hash_remove(&ctx->streams, data->mid);


### PR DESCRIPTION
When a transfer is done prematurely, a RST is generated to the server, but was not send right away due to send buffering.

Flush the send buffer in a best effort when transfer is done.

refs #17611