### PR TITLE
tests/http/clients: drop hack and use `curl_setup.h` again

### DIFF
--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -21,6 +21,7 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
+
 # Get BUNDLE, BUNDLE_SRC, CURLX_SRCS, FIRSTFILES, TESTFILES variables
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -21,22 +21,30 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-# Get BUNDLE, BUNDLE_SRC, FIRSTFILES, TESTFILES variables
+# Get BUNDLE, BUNDLE_SRC, CURLX_SRCS, FIRSTFILES, TESTFILES variables
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
+set(_bundle_extra "")
+if(LIB_SELECTED STREQUAL LIB_SHARED)
+  list(APPEND _bundle_extra ${CURLX_SRCS})  # Not exported from the libcurl shared build. Build a copy.
+endif()
+
 add_custom_command(
   OUTPUT "${BUNDLE_SRC}"
-  COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" --test ${TESTFILES}
+  COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl"
+    --include ${_bundle_extra} --test ${TESTFILES}
     ${CURL_MK_UNITY_OPTION} --srcdir "${CMAKE_CURRENT_SOURCE_DIR}" > "${BUNDLE_SRC}"
   DEPENDS
-    "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc" ${FIRSTFILES} ${TESTFILES}
+    "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" "${CMAKE_CURRENT_SOURCE_DIR}/Makefile.inc"
+    ${FIRSTFILES} ${_bundle_extra} ${TESTFILES}
   VERBATIM)
 
 add_executable(http-clients EXCLUDE_FROM_ALL "${BUNDLE_SRC}")
 add_dependencies(testdeps http-clients)
 target_include_directories(http-clients PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
+  "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for "first.h"
 )
 target_link_libraries(http-clients ${LIB_SELECTED} ${CURL_LIBS})

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(http-clients EXCLUDE_FROM_ALL "${BUNDLE_SRC}")
 add_dependencies(testdeps http-clients)
 target_include_directories(http-clients PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
+  "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for "first.h"
 )

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -46,7 +46,6 @@ add_dependencies(testdeps http-clients)
 target_include_directories(http-clients PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
-  "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for "first.h"
 )
 target_link_libraries(http-clients ${LIB_SELECTED} ${CURL_LIBS})

--- a/tests/http/clients/CMakeLists.txt
+++ b/tests/http/clients/CMakeLists.txt
@@ -46,6 +46,7 @@ add_dependencies(testdeps http-clients)
 target_include_directories(http-clients PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
+  "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for "first.h"
 )
 target_link_libraries(http-clients ${LIB_SELECTED} ${CURL_LIBS})

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -35,6 +35,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \
               -I$(top_srcdir)/lib            \
+              -I$(top_srcdir)/lib/curlx      \
               -I$(srcdir)
 
 # Get BUNDLE, BUNDLE_SRC, CURLX_SRCS, FIRSTFILES, TESTFILES variables

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -33,9 +33,10 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \
+              -I$(top_srcdir)/lib/curlx      \
               -I$(srcdir)
 
-# Get BUNDLE, BUNDLE_SRC, FIRSTFILES, TESTFILES variables
+# Get BUNDLE, BUNDLE_SRC, CURLX_SRCS, FIRSTFILES, TESTFILES variables
 include Makefile.inc
 
 EXTRA_DIST = CMakeLists.txt $(FIRSTFILES) $(TESTFILES)
@@ -56,8 +57,14 @@ endif
 
 AM_CPPFLAGS += -DCURL_NO_OLDIES
 
-$(BUNDLE_SRC): $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRSTFILES) $(TESTFILES)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --test $(TESTFILES) > $(BUNDLE_SRC)
+bundle_extra =
+if USE_CPPFLAG_CURL_STATICLIB
+else
+# These are part of the libcurl static lib. Add them here when linking shared.
+bundle_extra += $(CURLX_SRCS)
+endif
+$(BUNDLE_SRC): $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRSTFILES) $(bundle_extra) $(TESTFILES)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(bundle_extra) --test $(TESTFILES) > $(BUNDLE_SRC)
 
 noinst_PROGRAMS = $(BUNDLE)
 nodist_clients_SOURCES = $(BUNDLE_SRC)

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -35,7 +35,6 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \
               -I$(top_srcdir)/lib            \
-              -I$(top_srcdir)/lib/curlx      \
               -I$(srcdir)
 
 # Get BUNDLE, BUNDLE_SRC, CURLX_SRCS, FIRSTFILES, TESTFILES variables

--- a/tests/http/clients/Makefile.am
+++ b/tests/http/clients/Makefile.am
@@ -30,9 +30,11 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 #
 # $(top_srcdir)/include is for libcurl's external include files
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
+# $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \
+              -I$(top_srcdir)/lib            \
               -I$(top_srcdir)/lib/curlx      \
               -I$(srcdir)
 

--- a/tests/http/clients/Makefile.inc
+++ b/tests/http/clients/Makefile.inc
@@ -30,6 +30,7 @@ BUNDLE_SRC = clients.c
 FIRSTFILES = first.c first.h
 
 CURLX_SRCS = \
+  ../../../lib/curlx/multibyte.c \
   ../../../lib/curlx/timediff.c \
   ../../../lib/curlx/wait.c
 

--- a/tests/http/clients/Makefile.inc
+++ b/tests/http/clients/Makefile.inc
@@ -29,6 +29,10 @@ BUNDLE_SRC = clients.c
 # Files referenced from the bundle source
 FIRSTFILES = first.c first.h
 
+CURLX_SRCS = \
+  ../../../lib/curlx/timediff.c \
+  ../../../lib/curlx/wait.c
+
 # All test clients
 TESTFILES = \
   h2_pausing.c \

--- a/tests/http/clients/Makefile.inc
+++ b/tests/http/clients/Makefile.inc
@@ -30,9 +30,7 @@ BUNDLE_SRC = clients.c
 FIRSTFILES = first.c first.h
 
 CURLX_SRCS = \
-  ../../../lib/curlx/multibyte.c \
-  ../../../lib/curlx/timediff.c \
-  ../../../lib/curlx/wait.c
+  ../../../lib/curlx/multibyte.c
 
 # All test clients
 TESTFILES = \

--- a/tests/http/clients/first.h
+++ b/tests/http/clients/first.h
@@ -23,9 +23,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#ifdef HAVE_CONFIG_H
-#include "curl_config.h"  /* for CURL_DISABLE_WEBSOCKETS */
-#endif
+#include "curl_setup.h"
 
 typedef int (*entry_func_t)(int, char **);
 

--- a/tests/http/clients/first.h
+++ b/tests/http/clients/first.h
@@ -36,6 +36,8 @@ struct entry_s {
 
 #include <curl/curl.h>
 
+#include "curlx.h"
+
 #include <stdio.h>  /* for fprintf() */
 #include <stdlib.h>  /* for calloc(), free(), strtol() */
 #include <string.h>  /* for strchr(), strcmp() */

--- a/tests/http/clients/first.h
+++ b/tests/http/clients/first.h
@@ -38,10 +38,7 @@ struct entry_s {
 #include <stdlib.h>  /* for calloc(), free(), strtol() */
 #include <string.h>  /* for strchr(), strcmp() */
 
-#ifdef _WIN32
-#include <windows.h>  /* for Sleep() */
-#define strdup _strdup
-#else
+#ifndef _WIN32
 #include <sys/time.h>  /* for usleep() */
 #include <unistd.h>  /* for usleep() */
 #endif
@@ -49,12 +46,6 @@ struct entry_s {
 #ifdef __TANDEM
 #include <cextdecs.h(PROCESS_DELAY_)>  /* for usleep() logic */
 #endif
-
-#if defined(_MSC_VER) && (_MSC_VER <= 1700)
-#pragma warning(disable:4127)  /* "conditional expression is constant" */
-#endif
-
-#define CURL_ARRAYSIZE(A) (sizeof(A)/sizeof((A)[0]))
 
 #define ERR()                                                             \
   do {                                                                    \

--- a/tests/http/clients/first.h
+++ b/tests/http/clients/first.h
@@ -34,8 +34,6 @@ struct entry_s {
 
 #include <curl/curl.h>
 
-#include "curlx.h"
-
 #include <stdio.h>  /* for fprintf() */
 #include <stdlib.h>  /* for calloc(), free(), strtol() */
 #include <string.h>  /* for strchr(), strcmp() */

--- a/tests/http/clients/h2_pausing.c
+++ b/tests/http/clients/h2_pausing.c
@@ -55,8 +55,9 @@ static size_t cb(char *data, size_t size, size_t nmemb, void *clientp)
   (void)data;
   if(curl_easy_getinfo(handle->h, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                        &totalsize) == CURLE_OK)
-    fprintf(stderr, "INFO: [%d] write, Content-Length %"CURL_FORMAT_CURL_OFF_T
-            "\n", (int)handle->idx, totalsize);
+    curl_mfprintf(stderr, "INFO: [%d] write, "
+                  "Content-Length %" CURL_FORMAT_CURL_OFF_T "\n",
+                  (int)handle->idx, totalsize);
 
   if(!handle->resumed) {
     ++handle->paused;

--- a/tests/http/clients/h2_upgrade_extreme.c
+++ b/tests/http/clients/h2_upgrade_extreme.c
@@ -118,19 +118,20 @@ static int test_h2_upgrade_extreme(int argc, char *argv[])
            * re-using a connection */
         }
         else if(msg->data.result) {
-          fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
-                  ": failed with %d\n", xfer_id, msg->data.result);
+          curl_mfprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
+                        ": failed with %d\n", xfer_id, msg->data.result);
           goto cleanup;
         }
         else if(status != 206) {
-          fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
-                  ": wrong http status %ld (expected 206)\n", xfer_id, status);
+          curl_mfprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
+                        ": wrong http status %ld (expected 206)\n", xfer_id,
+                        status);
           goto cleanup;
         }
         curl_multi_remove_handle(multi, msg->easy_handle);
         curl_easy_cleanup(msg->easy_handle);
-        fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T" retiring "
-                "(%d now running)\n", xfer_id, running_handles);
+        curl_mfprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T" retiring "
+                      "(%d now running)\n", xfer_id, running_handles);
       }
     }
 

--- a/tests/http/clients/tls_session_reuse.c
+++ b/tests/http/clients/tls_session_reuse.c
@@ -179,20 +179,21 @@ static int test_tls_session_reuse(int argc, char *argv[])
            * re-using a connection */
         }
         else if(msg->data.result) {
-          fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
-                  ": failed with %d\n", xfer_id, msg->data.result);
+          curl_mfprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
+                        ": failed with %d\n", xfer_id, msg->data.result);
           goto cleanup;
         }
         else if(status != 200) {
-          fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
-                  ": wrong http status %ld (expected 200)\n", xfer_id, status);
+          curl_mfprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T
+                        ": wrong http status %ld (expected 200)\n", xfer_id,
+                        status);
           goto cleanup;
         }
         curl_multi_remove_handle(multi, msg->easy_handle);
         curl_easy_cleanup(msg->easy_handle);
         --ongoing;
-        fprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T" retiring "
-                "(%d now running)\n", xfer_id, running_handles);
+        curl_mfprintf(stderr, "transfer #%" CURL_FORMAT_CURL_OFF_T" retiring "
+                      "(%d now running)\n", xfer_id, running_handles);
       }
     }
 


### PR DESCRIPTION
Sync build properties with libtests.

This allows accessing macros from `curl_config.h`, for feature flags.
Smoothens out platform bumps, allowing to drop local replicas from
client sources. It enables using Windows wrappers, e.g. for `fopen()`.

Also fix client sources to use `curl_mfprintf()` where curl format
strings are used. (To avoid build failure with older mingw-w64, e.g.
6.4.0 in CI.)

Follow-up to 739c09c8a4111b3ee00b0004f5a3f67e00ba3aeb #17627
