### PR TITLE
lib530, 582: smoothen out minor differences

### DIFF
--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -190,7 +190,7 @@ static int t530_checkForCompletion(CURLM *curl, int *success)
     }
     else {
       curl_mfprintf(stderr, "Got an unexpected message from curl: %i\n",
-                    message->msg);
+                    (int)message->msg);
       result = 1;
       *success = 0;
     }

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -373,6 +373,7 @@ test_cleanup:
   /* free local memory */
   free(sockets.read.sockets);
   free(sockets.write.sockets);
+
   return res;
 }
 

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -61,7 +61,7 @@ static void t530_removeFd(struct t530_Sockets *sockets, curl_socket_t fd,
     if(sockets->sockets[i] == fd) {
       if(i < sockets->count - 1)
         memmove(&sockets->sockets[i], &sockets->sockets[i + 1],
-              sizeof(curl_socket_t) * (sockets->count - (i + 1)));
+                sizeof(curl_socket_t) * (sockets->count - (i + 1)));
       --sockets->count;
     }
   }

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -54,7 +54,7 @@ static void t582_removeFd(struct t582_Sockets *sockets, curl_socket_t fd,
     if(sockets->sockets[i] == fd) {
       if(i < sockets->count - 1)
         memmove(&sockets->sockets[i], &sockets->sockets[i + 1],
-              sizeof(curl_socket_t) * (sockets->count - (i + 1)));
+                sizeof(curl_socket_t) * (sockets->count - (i + 1)));
       --sockets->count;
     }
   }

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -329,7 +329,6 @@ static CURLcode test_lib582(char *URL)
       tv.tv_usec = 100000;
     }
 
-    assert(maxFd);
     select_test((int)maxFd, &readSet, &writeSet, NULL, &tv);
 
     /* Check the sockets for reading / writing */

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -329,6 +329,7 @@ static CURLcode test_lib582(char *URL)
       tv.tv_usec = 100000;
     }
 
+    assert(maxFd);
     select_test((int)maxFd, &readSet, &writeSet, NULL, &tv);
 
     /* Check the sockets for reading / writing */

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -272,7 +272,7 @@ static CURLcode test_lib582(char *URL)
   curl_mfprintf(stderr, "Set to upload %d bytes\n", (int)file_info.st_size);
 
   res_global_init(CURL_GLOBAL_ALL);
-  if(res) {
+  if(res != CURLE_OK) {
     fclose(hd_src);
     return res;
   }


### PR DESCRIPTION
Fix indentation, casts, a few other minor difference between these tests
that share a common codebase.

---

This PR originally meant to add `assert(maxFd)` to lib582 (syncing with
lib530), but that broke the test in many CI jobs.
