### PR TITLE
docs: fix broken link in INSTALL.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -340,7 +340,8 @@ environment, therefore, you cannot use the various disable-protocol options of
 the configure utility on this platform.
 
 You can use specific defines to disable specific protocols and features. See
-[CURL-DISABLE](CURL-DISABLE.md) for the full list.
+[CURL-DISABLE](https://github.com/curl/curl/blob/master/docs/CURL-DISABLE.md)
+for the full list.
 
 If you want to set any of these defines you have the following options:
 


### PR DESCRIPTION
In INSTALL.md file, the link that points to CURL-DISABLE was broken, so I fixed this issue changing the link from only "CURL-DISABLE.md" to "https://github.com/curl/curl/blob/master/docs/CURL-DISABLE.md".

Fixes [#427](https://github.com/curl/curl-www/issues/427)  (in curl-www)