### PR TITLE
docs: fix broken link in CODE_REVIEW.md

### DIFF
--- a/docs/CODE_REVIEW.md
+++ b/docs/CODE_REVIEW.md
@@ -170,5 +170,6 @@ used as input to string functions.
 Tightly coupled with a code review is making sure that the commit message is
 good. It is the responsibility of the person who merges the code to make sure
 that the commit message follows our standard (detailed in the
-[CONTRIBUTE](CONTRIBUTE.md) document). This includes making sure the PR
-identifies related issues and giving credit to reporters and helpers.
+[CONTRIBUTE](https://curl.se/dev/contribute.html) document). This includes
+making sure the PR identifies related issues and giving credit to reporters
+and helpers.


### PR DESCRIPTION
In CODE_REVIEW.md file, the link that points to CONTRIBUTE was broken, so I fixed this issue changing the link from only "CONTRIBUTE.md" to "https://curl.se/dev/contribute.html".