### PR TITLE
cmake: move `OUTPUT` argument in the `add_custom_command()` line

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,8 +30,7 @@ set(_curl_definitions "")
 
 if(ENABLE_CURL_MANUAL AND HAVE_MANUAL_TOOLS)
   list(APPEND _curl_definitions "USE_MANUAL")
-  add_custom_command(
-    OUTPUT "tool_hugehelp.c"
+  add_custom_command(OUTPUT "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "#include \"tool_setup.h\"" > "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "/* !checksrc! disable COPYRIGHT all */" >> "tool_hugehelp.c"
     COMMAND ${CMAKE_COMMAND} -E echo "/* !checksrc! disable INCLUDEDUP all */" >> "tool_hugehelp.c"
@@ -54,8 +53,7 @@ endif()
 if(CURL_CA_EMBED_SET)
   if(PERL_FOUND)
     list(APPEND _curl_definitions "CURL_CA_EMBED")
-    add_custom_command(
-      OUTPUT "tool_ca_embed.c"
+    add_custom_command(OUTPUT "tool_ca_embed.c"
       COMMAND "${PERL_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/mk-file-embed.pl" --var curl_ca_embed
         < "${CURL_CA_EMBED}" > "tool_ca_embed.c"
       DEPENDS

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -31,8 +31,7 @@ if(LIB_SELECTED STREQUAL LIB_SHARED)
   list(APPEND _bundle_extra ${CURLX_SRCS})  # Not exported from the libcurl shared build. Build a copy.
 endif()
 
-add_custom_command(
-  OUTPUT "${BUNDLE_SRC}"
+add_custom_command(OUTPUT "${BUNDLE_SRC}"
   COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl"
     --include ${_bundle_extra} --test ${TESTFILES}
     ${CURL_MK_UNITY_OPTION} --srcdir "${CMAKE_CURRENT_SOURCE_DIR}" > "${BUNDLE_SRC}"

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -31,16 +31,14 @@ if(LIB_SELECTED STREQUAL LIB_SHARED)
   list(APPEND _bundle_extra ${CURLX_SRCS})  # Not exported from the libcurl shared build. Build a copy.
 endif()
 
-add_custom_command(
-  OUTPUT "lib1521.c"
+add_custom_command(OUTPUT "lib1521.c"
   COMMAND ${PERL_EXECUTABLE} "${CMAKE_CURRENT_SOURCE_DIR}/mk-lib1521.pl" < "${PROJECT_SOURCE_DIR}/include/curl/curl.h" "lib1521.c"
   DEPENDS
     "${CMAKE_CURRENT_SOURCE_DIR}/mk-lib1521.pl"
     "${PROJECT_SOURCE_DIR}/include/curl/curl.h"
   VERBATIM)
 
-add_custom_command(
-  OUTPUT "${BUNDLE_SRC}"
+add_custom_command(OUTPUT "${BUNDLE_SRC}"
   COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl"
     --include ${UTILS} ${_bundle_extra} --test ${TESTFILES} "lib1521.c"
     ${CURL_MK_UNITY_OPTION} --srcdir "${CMAKE_CURRENT_SOURCE_DIR}" > "${BUNDLE_SRC}"

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -26,8 +26,7 @@
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-add_custom_command(
-  OUTPUT "${BUNDLE_SRC}"
+add_custom_command(OUTPUT "${BUNDLE_SRC}"
   COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl"
     --include ${UTILS} ${CURLX_SRCS} --test ${TESTFILES}
     ${CURL_MK_UNITY_OPTION} --srcdir "${CMAKE_CURRENT_SOURCE_DIR}" > "${BUNDLE_SRC}"

--- a/tests/tunit/CMakeLists.txt
+++ b/tests/tunit/CMakeLists.txt
@@ -26,8 +26,7 @@
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-add_custom_command(
-  OUTPUT "${BUNDLE_SRC}"
+add_custom_command(OUTPUT "${BUNDLE_SRC}"
   COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" --test ${TESTFILES}
     ${CURL_MK_UNITY_OPTION} --srcdir "${CMAKE_CURRENT_SOURCE_DIR}" > "${BUNDLE_SRC}"
   DEPENDS

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -26,8 +26,7 @@
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-add_custom_command(
-  OUTPUT "${BUNDLE_SRC}"
+add_custom_command(OUTPUT "${BUNDLE_SRC}"
   COMMAND ${PERL_EXECUTABLE} "${PROJECT_SOURCE_DIR}/scripts/mk-unity.pl" --test ${TESTFILES}
     ${CURL_MK_UNITY_OPTION} --srcdir "${CMAKE_CURRENT_SOURCE_DIR}" > "${BUNDLE_SRC}"
   DEPENDS


### PR DESCRIPTION
For greppability.

---

```
docs/CMakeLists.txt:    add_custom_command(OUTPUT "${_man_target}"
docs/cmdline-opts/CMakeLists.txt:add_custom_command(OUTPUT "${CURL_MANPAGE}" "${CURL_ASCIIPAGE}"
docs/libcurl/CMakeLists.txt:      add_custom_command(OUTPUT ${_rofffiles}
docs/libcurl/CMakeLists.txt:add_custom_command(OUTPUT "libcurl-symbols.md"
scripts/CMakeLists.txt:      add_custom_command(OUTPUT "${_completion_fish}"
scripts/CMakeLists.txt:      add_custom_command(OUTPUT "${_completion_zsh}"
src/CMakeLists.txt:  add_custom_command(OUTPUT "tool_hugehelp.c"
src/CMakeLists.txt:    add_custom_command(OUTPUT "tool_ca_embed.c"
tests/certs/CMakeLists.txt:add_custom_command(OUTPUT ${GENERATEDCERTS}
tests/client/CMakeLists.txt:add_custom_command(OUTPUT "${BUNDLE_SRC}"
tests/libtest/CMakeLists.txt:add_custom_command(OUTPUT "lib1521.c"
tests/libtest/CMakeLists.txt:add_custom_command(OUTPUT "${BUNDLE_SRC}"
tests/server/CMakeLists.txt:add_custom_command(OUTPUT "${BUNDLE_SRC}"
tests/tunit/CMakeLists.txt:add_custom_command(OUTPUT "${BUNDLE_SRC}"
tests/unit/CMakeLists.txt:add_custom_command(OUTPUT "${BUNDLE_SRC}"
```