### PR TITLE
NULL deref when netrc is enabled

### DIFF
--- a/lib/url.c
+++ b/lib/url.c
@@ -2762,11 +2762,13 @@ static CURLcode parse_remote_port(struct Curl_easy *data,
 
 static bool str_has_ctrl(const char *input)
 {
-  const unsigned char *str = (const unsigned char *)input;
-  while(*str) {
-    if(*str < 0x20)
-      return TRUE;
-    str++;
+  if (input) {
+    const unsigned char *str = (const unsigned char *)input;
+    while(*str) {
+      if(*str < 0x20)
+        return TRUE;
+      str++;
+    }
   }
   return FALSE;
 }


### PR DESCRIPTION
A NULL deref exists in `lib/url.c` that can be triggered when netrc is enabled and a specially crafted netrc-file is given to libcurl.
The bug is in [line 2830](https://github.com/curl/curl/blob/9e3492690b8d15a81f029516ae7e06a2de5863b9/lib/url.c#L2830):
```c
NETRCcode ret = Curl_parsenetrc(&data->state.netrc, conn->host.name,
                                      userp, passwdp,
                                      data->set.str[STRING_NETRC_FILE]);

// ...

if(str_has_ctrl(*userp) || str_has_ctrl(*passwdp)) {

  // ...

}
```
There is a path through `Curl_parsenetrc` that returns `NETRC_OK` but leaves `*userp` as NULL and only sets `*passwdp`, which then later triggers a NULL-deref in `str_has_ctrl(*userp)`.

To reproduce this, use  [this netrc file](https://github.com/user-attachments/files/20787553/netrc.txt) and the following client:
```c
#include "curl/curl.h"

int main (int argc, char** argv) {
    CURL* curl = curl_easy_init();
    curl_easy_setopt(curl, CURLOPT_URL, "ftp://127.0.0.1/");
    curl_easy_setopt(curl, CURLOPT_NETRC, CURL_NETRC_REQUIRED);
    curl_easy_setopt(curl, CURLOPT_NETRC_FILE, "<attached-file>");
    curl_easy_perform(curl);
    curl_easy_cleanup(curl);
}
```
