### PR TITLE
test1596: let test pass after year 2036

### DIFF
--- a/tests/data/test1596
+++ b/tests/data/test1596
@@ -13,9 +13,9 @@ If-Modified-Since
 <reply>
 <data nocheck="yes">
 HTTP/1.1 429 Too Many Requests
-Date: Wed, 31 Dec 2036 02:26:59 GMT
+Date: Wed, 31 Dec 2138 02:26:59 GMT
 Server: test-server/swsclose
-Retry-After: Wed, 31 Dec 2036 02:26:59 GMT
+Retry-After: Wed, 31 Dec 2138 02:26:59 GMT
 
 </data>
 </reply>


### PR DESCRIPTION
Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future. The usual offset is +16 years, because that is how long I expect some software will be used in some places. This showed up failing tests in our package build. See https://reproducible-builds.org/ for why this matters.

I tested that it passes on x86_64 in year 2041 and i586 in year 2037.

(but on i586, I got `TESTFAIL: These test cases failed: 31 46 61 1415` )