### PR TITLE
cmake: use `target_link_options()` when available

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -46,12 +46,8 @@ if(USE_ARES)
 endif()
 
 if(CURL_BUILD_TESTING)
-  add_library(
-    curlu  # special libcurlu library just for unittests
-    STATIC
-    EXCLUDE_FROM_ALL
-    ${HHEADERS} ${CSOURCES}
-  )
+  # special libcurlu library just for unittests
+  add_library(curlu STATIC EXCLUDE_FROM_ALL ${HHEADERS} ${CSOURCES})
   target_compile_definitions(curlu PUBLIC "CURL_STATICLIB" "UNITTESTS")
   target_link_libraries(curlu PRIVATE ${CURL_LIBS})
   # There is plenty of parallelism when building the testdeps target.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,7 +115,7 @@ endif()
 
 if(ENABLE_UNICODE AND MINGW AND NOT MINGW32CE)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
-    target_link_options(${EXE_NAME} "-municode")
+    target_link_options(${EXE_NAME} PRIVATE "-municode")
   else()
     target_link_libraries(${EXE_NAME} "-municode")
   endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -106,7 +106,7 @@ if(ENABLE_UNICODE AND MINGW AND NOT MINGW32CE)
   if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
     target_link_options(${EXE_NAME} PRIVATE "-municode")
   else()
-    target_link_libraries(${EXE_NAME} "-municode")
+    target_link_libraries(${EXE_NAME} PRIVATE "-municode")
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,7 +114,11 @@ if(CURL_HAS_LTO)
 endif()
 
 if(ENABLE_UNICODE AND MINGW AND NOT MINGW32CE)
-  target_link_libraries(${EXE_NAME} "-municode")
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+    target_link_options(${EXE_NAME} "-municode")
+  else()
+    target_link_libraries(${EXE_NAME} "-municode")
+  endif()
 endif()
 
 source_group("curlX source files" FILES ${CURLX_CFILES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -86,26 +86,15 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${PROJECT_SOURCE_DIR}/src"  # for "tool_hugehelp.h"
 )
 
-add_executable(
-  ${EXE_NAME}
-  ${CURL_CFILES} ${_curl_cfiles_gen} ${CURLX_CFILES} ${CURL_HFILES} ${_curl_hfiles_gen}
-)
+add_executable(${EXE_NAME} ${CURL_CFILES} ${_curl_cfiles_gen} ${CURLX_CFILES} ${CURL_HFILES} ${_curl_hfiles_gen})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
 
-add_executable(
-  curlinfo
-  EXCLUDE_FROM_ALL
-  curlinfo.c
-)
+add_executable(curlinfo EXCLUDE_FROM_ALL "curlinfo.c")
 
-add_library(
-  curltool  # special libcurltool library just for unittests
-  STATIC
-  EXCLUDE_FROM_ALL
-  ${CURL_CFILES} ${CURL_HFILES}
-)
+# special libcurltool library just for unittests
+add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURL_HFILES})
 target_compile_definitions(curltool PUBLIC "CURL_STATICLIB" "UNITTESTS")
 target_link_libraries(curltool PRIVATE ${CURL_LIBS})
 


### PR DESCRIPTION
To pass `-municode` to the linker. Before this patch we passed this via
`target_link_libraries()` which is designed to pass libraries. Keep
using it for old CMake versions, where no better alternative existed.

https://cmake.org/cmake/help/latest/command/target_link_options.html

Also:
- also pass `-municode` as `PRIVATE` for old cmake versions.
  (it should not make a difference because no target depends on the curl
  tool, but this seem to be the modern, non-ambiguous syntax.)
- unfold a bunch of split lines for greppability of `add_library()` and
  `add_executable()` commands.
- quote a string.
