### PR TITLE
lib: make `CURLX_SET_BINMODE()` and use it

### DIFF
--- a/lib/Makefile.inc
+++ b/lib/Makefile.inc
@@ -38,6 +38,7 @@ LIB_CURLX_CFILES = \
   curlx/winapi.c
 
 LIB_CURLX_HFILES = \
+  curlx/binmode.h  \
   curlx/base64.h   \
   curlx/curlx.h    \
   curlx/dynbuf.h   \

--- a/lib/curlx/binmode.h
+++ b/lib/curlx/binmode.h
@@ -23,7 +23,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#include "tool_setup.h"
+#include "../curl_setup.h"
 
 #if (defined(HAVE_SETMODE) || defined(HAVE__SETMODE)) && defined(O_BINARY)
 /* Requires io.h and/or fcntl.h when available */
@@ -33,7 +33,7 @@
 #  define CURL_SET_BINMODE(stream)  (void)setmode(fileno(stream), O_BINARY)
 #endif
 #else
-#  define CURL_SET_BINMODE(stream)  (void)stream; tool_nop_stmt
+#  define CURL_SET_BINMODE(stream)  (void)stream; Curl_nop_stmt
 #endif
 
 #endif /* HEADER_CURL_TOOL_BINMODE_H */

--- a/lib/curlx/binmode.h
+++ b/lib/curlx/binmode.h
@@ -28,12 +28,12 @@
 #if (defined(HAVE_SETMODE) || defined(HAVE__SETMODE)) && defined(O_BINARY)
 /* Requires io.h and/or fcntl.h when available */
 #ifdef HAVE__SETMODE
-#  define CURL_SET_BINMODE(stream)  (void)_setmode(fileno(stream), O_BINARY)
+#  define CURLX_SET_BINMODE(stream)  (void)_setmode(fileno(stream), O_BINARY)
 #else
-#  define CURL_SET_BINMODE(stream)  (void)setmode(fileno(stream), O_BINARY)
+#  define CURLX_SET_BINMODE(stream)  (void)setmode(fileno(stream), O_BINARY)
 #endif
 #else
-#  define CURL_SET_BINMODE(stream)  (void)stream; Curl_nop_stmt
+#  define CURLX_SET_BINMODE(stream)  (void)stream; Curl_nop_stmt
 #endif
 
 #endif /* HEADER_CURL_TOOL_BINMODE_H */

--- a/lib/curlx/curlx.h
+++ b/lib/curlx/curlx.h
@@ -31,6 +31,9 @@
  * be.
  */
 
+#include "binmode.h"
+/* "binmode.h" provides macro CURLX_SET_BINMODE() */
+
 #include "nonblock.h"
 /* "nonblock.h" provides curlx_nonblock() */
 

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -44,6 +44,7 @@ CURLX_CFILES = \
   ../lib/curlx/warnless.c
 
 CURLX_HFILES = \
+  ../lib/curlx/binmode.h \
   ../lib/curlx/multibyte.h \
   ../lib/curl_setup.h \
   ../lib/curlx/dynbuf.h \
@@ -104,7 +105,6 @@ CURL_HFILES = \
   config2setopts.h \
   slist_wc.h \
   terminal.h \
-  tool_binmode.h \
   tool_bname.h \
   tool_cb_dbg.h \
   tool_cb_hdr.h \

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -27,7 +27,6 @@
 
 #include "tool_cfgable.h"
 #include "tool_msgs.h"
-#include "tool_binmode.h"
 #include "tool_getparam.h"
 #include "tool_paramhlp.h"
 #include "tool_formparse.h"

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -133,7 +133,7 @@ static struct tool_mime *tool_mime_new_filedata(struct tool_mime *parent,
     curl_off_t origin;
     struct_stat sbuf;
 
-    CURL_SET_BINMODE(stdin);
+    CURLX_SET_BINMODE(stdin);
     origin = ftell(stdin);
     /* If stdin is a regular file, do not buffer data but read it
        when needed. */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -24,7 +24,6 @@
 #include "tool_setup.h"
 
 #include <curlx.h>
-#include "tool_binmode.h"
 #include "tool_cfgable.h"
 #include "tool_cb_prg.h"
 #include "tool_filetime.h"

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -625,7 +625,7 @@ static ParameterError data_urlencode(struct GlobalConfig *global,
     /* a '@' letter, it means that a filename or - (stdin) follows */
     if(!strcmp("-", p)) {
       file = stdin;
-      CURL_SET_BINMODE(stdin);
+      CURLX_SET_BINMODE(stdin);
     }
     else {
       file = fopen(p, "rb");
@@ -901,7 +901,7 @@ static ParameterError set_data(cmdline_t cmd,
     if(!strcmp("-", nextarg)) {
       file = stdin;
       if(cmd == C_DATA_BINARY) /* forced data-binary */
-        CURL_SET_BINMODE(stdin);
+        CURLX_SET_BINMODE(stdin);
     }
     else {
       file = fopen(nextarg, "rb");

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -870,7 +870,7 @@ static CURLcode etag_store(struct GlobalConfig *global,
   }
   else {
     /* always use binary mode for protocol header output */
-    CURL_SET_BINMODE(etag_save->stream);
+    CURLX_SET_BINMODE(etag_save->stream);
   }
   return CURLE_OK;
 }
@@ -884,7 +884,7 @@ static CURLcode setup_headerfile(struct GlobalConfig *global,
   if(!strcmp(config->headerfile, "%")) {
     heads->stream = stderr;
     /* use binary mode for protocol header output */
-    CURL_SET_BINMODE(heads->stream);
+    CURLX_SET_BINMODE(heads->stream);
   }
   else if(strcmp(config->headerfile, "-")) {
     FILE *newfile;
@@ -924,7 +924,7 @@ static CURLcode setup_headerfile(struct GlobalConfig *global,
   }
   else {
     /* always use binary mode for protocol header output */
-    CURL_SET_BINMODE(heads->stream);
+    CURLX_SET_BINMODE(heads->stream);
   }
   return CURLE_OK;
 }
@@ -1066,7 +1066,7 @@ static void check_stdin_upload(struct GlobalConfig *global,
   DEBUGASSERT(per->infdopen == FALSE);
   DEBUGASSERT(per->infd == STDIN_FILENO);
 
-  CURL_SET_BINMODE(stdin);
+  CURLX_SET_BINMODE(stdin);
   if(!strcmp(per->uploadfile, ".")) {
     if(curlx_nonblock((curl_socket_t)per->infd, TRUE) < 0)
       warnf(global,
@@ -1346,7 +1346,7 @@ static CURLcode single_transfer(struct GlobalConfig *global,
          !config->use_ascii) {
         /* We get the output to stdout and we have not got the ASCII/text
            flag, then set stdout to be binary */
-        CURL_SET_BINMODE(stdout);
+        CURLX_SET_BINMODE(stdout);
       }
 
       /* explicitly passed to stdout means okaying binary gunk */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -56,7 +56,6 @@
 
 #include <curlx.h>
 
-#include "tool_binmode.h"
 #include "tool_cfgable.h"
 #include "tool_cb_dbg.h"
 #include "tool_cb_hdr.h"

--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -54,7 +54,6 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
-  "${PROJECT_SOURCE_DIR}/src"            # for "tool_binmode.h"
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
   "${PROJECT_SOURCE_DIR}/tests/unit"     # for "curlcheck.h"
 )

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -37,7 +37,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \
               -I$(top_srcdir)/lib            \
               -I$(top_srcdir)/lib/curlx      \
-              -I$(top_srcdir)/src            \
               -I$(srcdir)                    \
               -I$(top_srcdir)/tests/unit
 

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
   char *env;
   size_t tmp;
 
-  CURL_SET_BINMODE(stdout);
+  CURLX_SET_BINMODE(stdout);
 
   memory_tracking_init();
 

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -27,7 +27,7 @@
 
 #include "memdebug.h"
 #include "curlx/timediff.h"
-#include "tool_binmode.h"
+#include "curlx/binmode.h"
 
 int select_wrapper(int nfds, fd_set *rd, fd_set *wr, fd_set *exc,
                    struct timeval *tv)

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -42,7 +42,6 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
-  "${PROJECT_SOURCE_DIR}/src"            # for "tool_xattr.h"
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "WITHOUT_LIBCURL")

--- a/tests/server/CMakeLists.txt
+++ b/tests/server/CMakeLists.txt
@@ -42,7 +42,7 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
-  "${PROJECT_SOURCE_DIR}/src"            # for "tool_binmode.h", "tool_xattr.h"
+  "${PROJECT_SOURCE_DIR}/src"            # for "tool_xattr.h"
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "WITHOUT_LIBCURL")

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -31,7 +31,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 # $(top_srcdir)/include is for libcurl's external include files
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
 # $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
-# $(top_srcdir)/src for "tool_binmode.h", "tool_xattr.h"
+# $(top_srcdir)/src for "tool_xattr.h"
 # $(srcdir) for the generated bundle source to find included test sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -31,14 +31,12 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 # $(top_srcdir)/include is for libcurl's external include files
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
 # $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
-# $(top_srcdir)/src for "tool_xattr.h"
 # $(srcdir) for the generated bundle source to find included test sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \
               -I$(top_srcdir)/lib            \
               -I$(top_srcdir)/lib/curlx      \
-              -I$(top_srcdir)/src            \
               -I$(srcdir)
 
 # Get BUNDLE, BUNDLE_SRC, FIRSTFILES, UTILS, CURLX_SRCS, TESTFILES variables

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -985,9 +985,9 @@ static int test_mqttd(int argc, char *argv[])
     return 2;
 #endif
 
-  CURL_SET_BINMODE(stdin);
-  CURL_SET_BINMODE(stdout);
-  CURL_SET_BINMODE(stderr);
+  CURLX_SET_BINMODE(stdin);
+  CURLX_SET_BINMODE(stdout);
+  CURLX_SET_BINMODE(stderr);
 
   install_signal_handlers(FALSE);
 

--- a/tests/server/mqttd.c
+++ b/tests/server/mqttd.c
@@ -55,8 +55,6 @@
 #include <curlx.h> /* from the private lib dir */
 #include "getpart.h"
 
-#include "tool_binmode.h"
-
 /* include memdebug.h last */
 #include <memdebug.h>
 

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -106,8 +106,6 @@
 #include "timediff.h"
 #include "warnless.h" /* for read() */
 
-#include "tool_binmode.h"
-
 /* include memdebug.h last */
 #include <memdebug.h>
 

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -102,8 +102,6 @@
 #endif
 
 #include <curlx.h> /* from the private lib dir */
-#include "inet_pton.h"
-#include "timediff.h"
 #include "warnless.h" /* for read() */
 
 /* include memdebug.h last */

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -1495,9 +1495,9 @@ static int test_sockfilt(int argc, char *argv[])
     return 2;
 #endif
 
-  CURL_SET_BINMODE(stdin);
-  CURL_SET_BINMODE(stdout);
-  CURL_SET_BINMODE(stderr);
+  CURLX_SET_BINMODE(stdin);
+  CURLX_SET_BINMODE(stdout);
+  CURLX_SET_BINMODE(stderr);
 
   install_signal_handlers(false);
 

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -75,7 +75,6 @@
 
 #include <curlx.h> /* from the private lib dir */
 #include "inet_pton.h"
-#include "tool_binmode.h"
 
 /* include memdebug.h last */
 #include <memdebug.h>

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -74,7 +74,6 @@
 #endif
 
 #include <curlx.h> /* from the private lib dir */
-#include "inet_pton.h"
 
 /* include memdebug.h last */
 #include <memdebug.h>

--- a/tests/server/socksd.c
+++ b/tests/server/socksd.c
@@ -1043,9 +1043,9 @@ static int test_socksd(int argc, char *argv[])
     return 2;
 #endif
 
-  CURL_SET_BINMODE(stdin);
-  CURL_SET_BINMODE(stdout);
-  CURL_SET_BINMODE(stderr);
+  CURLX_SET_BINMODE(stdin);
+  CURLX_SET_BINMODE(stdout);
+  CURLX_SET_BINMODE(stderr);
 
   install_signal_handlers(false);
 

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -51,7 +51,6 @@
 
 #include <curlx.h> /* from the private lib dir */
 #include "getpart.h"
-#include "inet_pton.h"
 
 /* include memdebug.h last */
 #include <memdebug.h>

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -35,12 +35,11 @@ add_custom_command(OUTPUT "${BUNDLE_SRC}"
 
 add_executable(${BUNDLE} EXCLUDE_FROM_ALL ${UTILS} "${BUNDLE_SRC}")
 add_dependencies(testdeps ${BUNDLE})
-target_link_libraries(${BUNDLE} curltool curlu)
+target_link_libraries(${BUNDLE} curlu)
 target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h"
   "${PROJECT_SOURCE_DIR}/lib/curlx"      # for curlx
-  "${PROJECT_SOURCE_DIR}/src"            # for "tool_binmode.h"
   "${PROJECT_SOURCE_DIR}/tests/libtest"  # for "first.h"
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
 )

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -37,7 +37,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \
               -I$(top_srcdir)/lib            \
               -I$(top_srcdir)/lib/curlx      \
-              -I$(top_srcdir)/src            \
               -I$(top_srcdir)/tests/libtest  \
               -I$(srcdir)
 


### PR DESCRIPTION
Use it from libtests' `first.c` and thus also from units, and tunits.

Also:
- cmake: drop stray `curltool` lib dependency for units.
- units: stop depending on `src` headers.
- tests/server: drop depending on `src` headers.
  (the remaining one listed in the comments, `tool_xattr.h`, was not
  actually used from servers.)
- tests/server: drop duplicate curlx headers.
  (Except `warnless.h`, which is tricky on Windows.)
