### PR TITLE
autotools: drop `$top_builddir/src` from src header path

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,13 +36,11 @@ EXTRA_DIST = mk-file-embed.pl mkhelp.pl \
 #
 # $(top_srcdir)/include is for libcurl's external include files
 # $(top_builddir)/lib is for libcurl's generated lib/curl_config.h file
-# $(top_builddir)/src is for curl's generated src/curl_config.h file
 # $(top_srcdir)/lib for libcurl's lib/curl_setup.h and other "borrowed" files
 # $(srcdir) for generated sources to find included sources
 
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \
-              -I$(top_builddir)/src          \
               -I$(top_srcdir)/lib            \
               -I$(top_srcdir)/lib/curlx      \
               -I$(srcdir)


### PR DESCRIPTION
There is no generated header or source in `$top_builddir/src`, that src
would #include. Also syncing with cmake.
