### PR TITLE
tests: drop useless "nodist_SOURCES" assignments

### DIFF
--- a/tests/client/Makefile.am
+++ b/tests/client/Makefile.am
@@ -64,7 +64,6 @@ $(BUNDLE_SRC): $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRSTFILES) $(cu
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(curlx_src) --test $(TESTFILES) > $(BUNDLE_SRC)
 
 noinst_PROGRAMS = $(BUNDLE)
-nodist_SOURCES = $(BUNDLE_SRC)
 LDADD = $(top_builddir)/lib/libcurl.la
 CLEANFILES = $(BUNDLE_SRC)
 

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -94,7 +94,6 @@ $(BUNDLE_SRC): $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRSTFILES) $(UT
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS) $(curlx_src) --test $(TESTFILES) lib1521.c > $(BUNDLE_SRC)
 
 noinst_PROGRAMS = $(BUNDLE)
-nodist_SOURCES = $(BUNDLE_SRC)
 LDADD = $(top_builddir)/lib/libcurl.la
 CLEANFILES = $(BUNDLE_SRC) lib1521.c
 

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -59,7 +59,6 @@ $(BUNDLE_SRC): $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRSTFILES) $(UT
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS) $(CURLX_CFILES) --test $(TESTFILES) > $(BUNDLE_SRC)
 
 noinst_PROGRAMS = $(BUNDLE)
-nodist_SOURCES = $(BUNDLE_SRC)
 LDADD = @CURL_NETWORK_AND_TIME_LIBS@
 CLEANFILES = $(BUNDLE_SRC)
 


### PR DESCRIPTION
They cause automake warnings and have no effect.