### PR TITLE
top-complexity: lower max allowed complexity threshold to 90

### DIFF
--- a/scripts/top-complexity
+++ b/scripts/top-complexity
@@ -79,10 +79,10 @@ my %whitelist = (
     );
 
 # functions with complexity above this level causes the function to return error
-my $cutoff = 100;
+my $cutoff = 90;
 
 # functions above this complexity level are shown
-my $show = 70;
+my $show = 65;
 
 my $error = 0;
 my %where;


### PR DESCRIPTION
Down from 100. Also make it show all functions with complexity > 65 (down from 70).

## Current output

~~~
./scripts/top-complexity

---- threshold: 90 ----

84    lib/setopt.c:setopt_long
83    src/tool_operate.c:single_transfer
80    src/config2setopts.c:config2setopts
79    lib/setopt.c:setopt_cptr
79    lib/vtls/openssl.c:cert_stuff
75    src/tool_cb_wrt.c:tool_write_cb
73    lib/socks.c:do_SOCKS5
72    lib/vssh/wolfssh.c:wssh_statemach_act
71    lib/vtls/wolfssl.c:Curl_wssl_ctx_init
71    lib/rtsp.c:rtsp_do
71    lib/socks_sspi.c:Curl_SOCKS5_gssapi_negotiate
70    lib/ftp.c:ftp_pp_statemachine
66    lib/http.c:Curl_http
66    lib/urlapi.c:parseurl
