### PR TITLE
libssh: Fix incorrect return value in myssh_in_AUTH_PKEY_INIT

### DIFF
--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -960,7 +960,7 @@ static int myssh_in_AUTH_PKEY_INIT(struct Curl_easy *data,
   int rc;
   if(!(data->set.ssh_auth_types & CURLSSH_AUTH_PUBLICKEY)) {
     rc = myssh_to_GSSAPI_AUTH(data, sshc);
-    return 0;
+    return rc;
   }
 
   /* Two choices, (1) private key was given on CMD,


### PR DESCRIPTION
I was looking into an issue related to using libcurl with libssh, and found this slightly odd return. It _seems_ like it should return an error code but does not. I believe that prior to the recent refactoring of this code in 6f6ee601b9998b1507fff665aeef2b8d0e6d887b, it would have returned an error, not 0.

In the unlikely case that no SSH auth methods are supported, the previous code would return 0 from `myssh_in_AUTH_PKEY_INIT`. However, following the code path, it seems like it should be returning `SSH_ERROR`, as set in `myssh_to_ERROR` (through `myssh_to_GSSAPI_AUTH`, `myssh_to_KEY_AUTH` and `myssh_to_PASSWD_AUTH`).

In actuality, this is unlikely to occur, as the similar code in `myssh_in_AUTHLIST` would have already returned an error in this scenario. However setting a return value and then ignoring it is a bit fishy and should be documented if this is intended.

As an aside, I would like to say that the new function based state machine is much simpler to reason about than the old macros used for authentication. :+1: