### PR TITLE
cmake: omit clang-tidy on internal libs curlu and curltool

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -52,7 +52,7 @@ if(CURL_BUILD_TESTING)
   target_link_libraries(curlu PRIVATE ${CURL_LIBS})
   # There is plenty of parallelism when building the testdeps target.
   # Override the curlu batch size with the maximum to optimize performance.
-  set_target_properties(curlu PROPERTIES UNITY_BUILD_BATCH_SIZE 0)
+  set_target_properties(curlu PROPERTIES UNITY_BUILD_BATCH_SIZE 0 C_CLANG_TIDY "")
 endif()
 
 ## Library definition

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -96,6 +96,7 @@ add_executable(curlinfo EXCLUDE_FROM_ALL "curlinfo.c")
 add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURL_HFILES})
 target_compile_definitions(curltool PUBLIC "CURL_STATICLIB" "UNITTESTS")
 target_link_libraries(curltool PRIVATE ${CURL_LIBS})
+set_target_properties(curltool PROPERTIES C_CLANG_TIDY "")
 
 if(CURL_HAS_LTO)
   set_target_properties(${EXE_NAME} PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)


### PR DESCRIPTION
Skip clang-tidy while compiling curlu and curltool internal libraries.
To save about 1 minute per run. These libraries compile the lib and src
sources a second time, with the `UNITTESTS` macro enabled, which makes
tiny difference, for internal use. I figure it's not worth the extra CI
(and local) time because finding extra issues in these passes is
unlikely, and if found, not critical.

autotools also doesn't check curlu and curltool with clang-tidy.

Ref: https://github.com/curl/curl/pull/17680#issuecomment-2991730158
Ref: https://stackoverflow.com/questions/61867616/ignore-certain-files-when-using-clang-tidy
Ref: https://cmake.org/cmake/help/latest/prop_tgt/LANG_CLANG_TIDY.html

Follow-up to fabfa8e4024473035b3e5c3c30c330be726d9bb4 #15825
