### PR TITLE
tests/server/util.c: include netinet/in6.h

### DIFF
--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -29,6 +29,9 @@
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
 #endif
+#ifdef HAVE_NETINET_IN6_H
+#include <netinet/in6.h>
+#endif
 #ifdef _XOPEN_SOURCE_EXTENDED
 /* This define is "almost" required to build on HP-UX 11 */
 #include <arpa/inet.h>


### PR DESCRIPTION
for sockaddr_in6

Reported-by: Randall S. Becker
Bug: https://curl.se/mail/lib-2025-06/0016.html