### PR TITLE
tests/libtest: drop `TEST_HANG_TIMEOUT` redefinition hack

### DIFF
--- a/tests/libtest/lib1501.c
+++ b/tests/libtest/lib1501.c
@@ -34,7 +34,7 @@ static CURLcode test_lib1501(char *URL)
      conservative to allow old and slow machines to run this test too */
   static const int MAX_BLOCKED_TIME_MS = 500;
 
-  static const int HANG_TIMEOUT = 30 * 1000;
+  static const long HANG_TIMEOUT = 30 * 1000;
 
   CURL *handle = NULL;
   CURLM *mhandle = NULL;

--- a/tests/libtest/lib1501.c
+++ b/tests/libtest/lib1501.c
@@ -28,14 +28,13 @@
 #include "testutil.h"
 #include "memdebug.h"
 
-#undef TEST_HANG_TIMEOUT
-#define TEST_HANG_TIMEOUT 30 * 1000
-
 static CURLcode test_lib1501(char *URL)
 {
   /* 500 milliseconds allowed. An extreme number but lets be really
      conservative to allow old and slow machines to run this test too */
   static const int MAX_BLOCKED_TIME_MS = 500;
+
+  static const int HANG_TIMEOUT = 30 * 1000;
 
   CURL *handle = NULL;
   CURLM *mhandle = NULL;
@@ -57,7 +56,7 @@ static CURLcode test_lib1501(char *URL)
 
   multi_perform(mhandle, &still_running);
 
-  abort_on_test_timeout();
+  abort_on_test_timeout_custom(HANG_TIMEOUT);
 
   while(still_running) {
     struct timeval timeout;
@@ -82,14 +81,14 @@ static CURLcode test_lib1501(char *URL)
 
     select_test(maxfd + 1, &fdread, &fdwrite, &fdexcep, &timeout);
 
-    abort_on_test_timeout();
+    abort_on_test_timeout_custom(HANG_TIMEOUT);
 
     curl_mfprintf(stderr, "ping\n");
     before = tutil_tvnow();
 
     multi_perform(mhandle, &still_running);
 
-    abort_on_test_timeout();
+    abort_on_test_timeout_custom(HANG_TIMEOUT);
 
     after = tutil_tvnow();
     e = tutil_tvdiff(after, before);

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -437,7 +437,7 @@ extern int unitfail;
   tv_test_start = tutil_tvnow(); \
 } while(0)
 
-#define TEST_HANG_TIMEOUT 60 * 1000  /* Set default */
+#define TEST_HANG_TIMEOUT 60 * 1000  /* global default */
 
 #define exe_test_timedout(T,Y,Z) do {                                   \
   long timediff = tutil_tvdiff(tutil_tvnow(), tv_test_start);           \
@@ -501,8 +501,7 @@ extern int unitfail;
     return CURLE_UNSUPPORTED_PROTOCOL;          \
   }
 
-/* global default */
-#define NUM_HANDLES 4
+#define NUM_HANDLES 4  /* global default */
 
 /* ---------------------------------------------------------------- */
 

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -459,6 +459,9 @@ extern int unitfail;
 #define abort_on_test_timeout() \
   chk_test_timedout(TEST_HANG_TIMEOUT, (__FILE__), (__LINE__))
 
+#define abort_on_test_timeout_custom(T) \
+  chk_test_timedout((T), (__FILE__), (__LINE__))
+
 /* ---------------------------------------------------------------- */
 
 #define exe_global_init(A,Y,Z) do {                           \

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -450,14 +450,14 @@ extern int unitfail;
 #define res_test_timedout() \
   exe_test_timedout(TEST_HANG_TIMEOUT, (__FILE__), (__LINE__))
 
-#define chk_test_timedout(Y, Z) do {            \
-    exe_test_timedout(TEST_HANG_TIMEOUT, Y, Z); \
-    if(res)                                     \
-      goto test_cleanup;                        \
+#define chk_test_timedout(T, Y, Z) do { \
+    exe_test_timedout(T, Y, Z);         \
+    if(res)                             \
+      goto test_cleanup;                \
   } while(0)
 
 #define abort_on_test_timeout() \
-  chk_test_timedout((__FILE__), (__LINE__))
+  chk_test_timedout(TEST_HANG_TIMEOUT, (__FILE__), (__LINE__))
 
 /* ---------------------------------------------------------------- */
 

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -437,9 +437,9 @@ extern int unitfail;
   tv_test_start = tutil_tvnow(); \
 } while(0)
 
-#define exe_test_timedout(Y,Z) do {                                     \
+#define exe_test_timedout(T,Y,Z) do {                                   \
   long timediff = tutil_tvdiff(tutil_tvnow(), tv_test_start);           \
-  if(timediff > (TEST_HANG_TIMEOUT)) {                                  \
+  if(timediff > (T)) {                                                  \
     curl_mfprintf(stderr, "%s:%d ABORTING TEST, since it seems "        \
                   "that it would have run forever (%ld ms > %ld ms)\n", \
                   (Y), (Z), timediff, (long) (TEST_HANG_TIMEOUT));      \
@@ -448,12 +448,12 @@ extern int unitfail;
 } while(0)
 
 #define res_test_timedout() \
-  exe_test_timedout((__FILE__), (__LINE__))
+  exe_test_timedout(TEST_HANG_TIMEOUT, (__FILE__), (__LINE__))
 
-#define chk_test_timedout(Y, Z) do { \
-    exe_test_timedout(Y, Z);         \
-    if(res)                          \
-      goto test_cleanup;             \
+#define chk_test_timedout(Y, Z) do {            \
+    exe_test_timedout(TEST_HANG_TIMEOUT, Y, Z); \
+    if(res)                                     \
+      goto test_cleanup;                        \
   } while(0)
 
 #define abort_on_test_timeout() \

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -437,6 +437,8 @@ extern int unitfail;
   tv_test_start = tutil_tvnow(); \
 } while(0)
 
+#define TEST_HANG_TIMEOUT 60 * 1000  /* Set default */
+
 #define exe_test_timedout(T,Y,Z) do {                                   \
   long timediff = tutil_tvdiff(tutil_tvnow(), tv_test_start);           \
   if(timediff > (T)) {                                                  \
@@ -502,7 +504,3 @@ extern int unitfail;
 /* ---------------------------------------------------------------- */
 
 #endif /* HEADER_CURL_TEST_H */
-
-/* Set default that each test may override */
-#undef TEST_HANG_TIMEOUT
-#define TEST_HANG_TIMEOUT 60 * 1000

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -452,6 +452,9 @@ extern int unitfail;
 #define res_test_timedout() \
   exe_test_timedout(TEST_HANG_TIMEOUT, (__FILE__), (__LINE__))
 
+#define res_test_timedout_custom(T) \
+  exe_test_timedout((T), (__FILE__), (__LINE__))
+
 #define chk_test_timedout(T, Y, Z) do { \
     exe_test_timedout(T, Y, Z);         \
     if(res)                             \


### PR DESCRIPTION
Before this patch the code relied on re-initializing TEST_HANG_TIMEOUT
macro before compiling each test, to allow them each to override it to
a custom value for single tests. Thie required re-including `test.h`
into each test.

After this patch this macro becomes a global, immutable, default. Tests
which want to override it can now use alternate macros that do accept
a custom timeout. The only test currently affected is lib1501.

Follow-up to 2c27a67daa1b76859c18d63e4e1f528db05b5e13 #17590
