### PR TITLE
rustls: Don't try printing the not provided file

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -855,7 +855,7 @@ init_config_builder_client_auth(struct Curl_easy *data,
   }
   else if(!conn_config->clientcert && ssl_config->key) {
     failf(data, "rustls: must provide certificate with key '%s'",
-          conn_config->clientcert);
+          ssl_config->key);
     return CURLE_SSL_CERTPROBLEM;
   }
 


### PR DESCRIPTION
Caught by gcc (Ubuntu 12.3.0-1ubuntu1~22.04) 12.3.0:
```
vtls/rustls.c: In function ‘cr_connect’:
vtls/rustls.c:857:61: warning: ‘%s’ directive argument is null [-Wformat-overflow=]
  857 |     failf(data, "rustls: must provide certificate with key '%s'",
      |                                                             ^~
```