### PR TITLE
h2_serverpush: fix file handle leaks reported by clang-tidy

### DIFF
--- a/tests/client/h2_serverpush.c
+++ b/tests/client/h2_serverpush.c
@@ -59,12 +59,12 @@ static int my_trace(CURL *handle, curl_infotype type,
   return 0;
 }
 
-static FILE *out_h2_serverpush_1;
+static FILE *out_download;
 
 static int setup_h2_serverpush(CURL *hnd, const char *url)
 {
-  out_h2_serverpush_1 = fopen("download_0.data", "wb");
-  if(!out_h2_serverpush_1)
+  out_download = fopen("download_0.data", "wb");
+  if(!out_download)
     return 1;  /* failed */
 
   curl_easy_setopt(hnd, CURLOPT_URL, url);
@@ -72,7 +72,7 @@ static int setup_h2_serverpush(CURL *hnd, const char *url)
   curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYPEER, 0L);
   curl_easy_setopt(hnd, CURLOPT_SSL_VERIFYHOST, 0L);
 
-  curl_easy_setopt(hnd, CURLOPT_WRITEDATA, out_h2_serverpush_1);
+  curl_easy_setopt(hnd, CURLOPT_WRITEDATA, out_download);
 
   /* please be verbose */
   curl_easy_setopt(hnd, CURLOPT_VERBOSE, 1L);
@@ -84,7 +84,7 @@ static int setup_h2_serverpush(CURL *hnd, const char *url)
   return 0; /* all is good */
 }
 
-static FILE *out_h2_serverpush_2;
+static FILE *out_push;
 
 /* called when there's an incoming push */
 static int server_push_callback(CURL *parent,
@@ -104,8 +104,8 @@ static int server_push_callback(CURL *parent,
   curl_msnprintf(filename, sizeof(filename) - 1, "push%u", count++);
 
   /* here's a new stream, save it in a new file for each new push */
-  out_h2_serverpush_2 = fopen(filename, "wb");
-  if(!out_h2_serverpush_2) {
+  out_push = fopen(filename, "wb");
+  if(!out_push) {
     /* if we cannot save it, deny it */
     curl_mfprintf(stderr, "Failed to create output file for push\n");
     rv = CURL_PUSH_DENY;
@@ -113,7 +113,7 @@ static int server_push_callback(CURL *parent,
   }
 
   /* write to this file */
-  curl_easy_setopt(easy, CURLOPT_WRITEDATA, out_h2_serverpush_2);
+  curl_easy_setopt(easy, CURLOPT_WRITEDATA, out_push);
 
   curl_mfprintf(stderr, "**** push callback approves stream %u, "
                 "got %lu headers!\n", count, (unsigned long)num_headers);
@@ -160,7 +160,7 @@ static int test_h2_serverpush(int argc, char *argv[])
 
   easy = curl_easy_init();
   if(setup_h2_serverpush(easy, url)) {
-    fclose(out_h2_serverpush_1);
+    fclose(out_download);
     curl_mfprintf(stderr, "failed\n");
     return 1;
   }
@@ -197,9 +197,9 @@ static int test_h2_serverpush(int argc, char *argv[])
 
   curl_multi_cleanup(multi_handle);
 
-  fclose(out_h2_serverpush_1);
-  if(out_h2_serverpush_1)
-    fclose(out_h2_serverpush_2);
+  fclose(out_download);
+  if(out_push)
+    fclose(out_push);
 
   return 0;
 }


### PR DESCRIPTION
clang-tidy (20.1.6) found it locally consistently. Missed in CI.
