### PR TITLE
escape: make hexcode() only do lowercase hex numbers

### DIFF
--- a/lib/curl_printf.h
+++ b/lib/curl_printf.h
@@ -33,9 +33,6 @@
 /* Lower-case digits.  */
 extern const unsigned char Curl_ldigits[];
 
-/* Upper-case digits.  */
-extern const unsigned char Curl_udigits[];
-
 #ifdef BUILDING_LIBCURL
 
 /*

--- a/lib/escape.c
+++ b/lib/escape.c
@@ -85,7 +85,7 @@ char *curl_easy_escape(CURL *data, const char *string,
     else {
       /* encode it */
       unsigned char out[3]={'%'};
-      Curl_hexbyte(&out[1], in, FALSE);
+      Curl_hexbyte(&out[1], in);
       if(curlx_dyn_addn(&d, out, 3))
         return NULL;
     }
@@ -212,7 +212,7 @@ void Curl_hexencode(const unsigned char *src, size_t len, /* input length */
   DEBUGASSERT(src && len && (olen >= 3));
   if(src && len && (olen >= 3)) {
     while(len-- && (olen >= 3)) {
-      Curl_hexbyte(out, *src, TRUE);
+      Curl_hexbyte(out, *src);
       ++src;
       out += 2;
       olen -= 2;
@@ -225,14 +225,11 @@ void Curl_hexencode(const unsigned char *src, size_t len, /* input length */
 
 /* Curl_hexbyte
  *
- * Output a single unsigned char as a two-digit hex number, lowercase or
- * uppercase
+ * Output a single unsigned char as a two-digit lowercase hex number
  */
 void Curl_hexbyte(unsigned char *dest, /* must fit two bytes */
-                  unsigned char val,
-                  bool lowercase)
+                  unsigned char val)
 {
-  const unsigned char *t = lowercase ? Curl_ldigits : Curl_udigits;
-  dest[0] = t[val >> 4];
-  dest[1] = t[val & 0x0F];
+  dest[0] = Curl_ldigits[val >> 4];
+  dest[1] = Curl_ldigits[val & 0x0F];
 }

--- a/lib/escape.h
+++ b/lib/escape.h
@@ -42,7 +42,6 @@ void Curl_hexencode(const unsigned char *src, size_t len, /* input length */
                     unsigned char *out, size_t olen); /* output buffer size */
 
 void Curl_hexbyte(unsigned char *dest, /* must fit two bytes */
-                  unsigned char val,
-                  bool lowercase);
+                  unsigned char val);
 
 #endif /* HEADER_CURL_ESCAPE_H */

--- a/lib/mprintf.c
+++ b/lib/mprintf.c
@@ -66,8 +66,7 @@
 /* Lower-case digits.  */
 const unsigned char Curl_ldigits[] = "0123456789abcdef";
 
-/* Upper-case digits.  */
-const unsigned char Curl_udigits[] = "0123456789ABCDEF";
+static const unsigned char Curl_udigits[] = "0123456789ABCDEF";
 
 #define OUTCHAR(x)                                       \
   do {                                                   \

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -164,7 +164,7 @@ static CURLUcode urlencode_str(struct dynbuf *o, const char *url,
     }
     else if((*iptr < ' ') || (*iptr >= 0x7f)) {
       unsigned char out[3]={'%'};
-      Curl_hexbyte(&out[1], *iptr, TRUE);
+      Curl_hexbyte(&out[1], *iptr);
       result = curlx_dyn_addn(o, out, 3);
     }
     else {
@@ -1861,7 +1861,7 @@ CURLUcode curl_url_set(CURLU *u, CURLUPart what,
         }
         else {
           unsigned char out[3]={'%'};
-          Curl_hexbyte(&out[1], *i, TRUE);
+          Curl_hexbyte(&out[1], *i);
           result = curlx_dyn_addn(&enc, out, 3);
           if(result)
             return cc2cu(result);

--- a/lib/vtls/keylog.c
+++ b/lib/vtls/keylog.c
@@ -134,14 +134,14 @@ Curl_tls_keylog_write(const char *label,
 
   /* Client Random */
   for(i = 0; i < CLIENT_RANDOM_SIZE; i++) {
-    Curl_hexbyte(&line[pos], client_random[i], FALSE);
+    Curl_hexbyte(&line[pos], client_random[i]);
     pos += 2;
   }
   line[pos++] = ' ';
 
   /* Secret */
   for(i = 0; i < secretlen; i++) {
-    Curl_hexbyte(&line[pos], secret[i], FALSE);
+    Curl_hexbyte(&line[pos], secret[i]);
     pos += 2;
   }
   line[pos++] = '\n';

--- a/tests/data/test1015
+++ b/tests/data/test1015
@@ -46,7 +46,7 @@ Accept: */*
 Content-Length: 119
 Content-Type: application/x-www-form-urlencoded
 
-my+name+is+moo%5B%5D&y e s=s_i_r&v_alue=content+to+_%3F%21%23%24%27%7C%3C%3E%0A&content+to+_%3F%21%23%24%27%7C%3C%3E%0A
+my+name+is+moo%5b%5d&y e s=s_i_r&v_alue=content+to+_%3f%21%23%24%27%7c%3c%3e%0a&content+to+_%3f%21%23%24%27%7c%3c%3e%0a
 </protocol>
 </verify>
 </testcase>

--- a/tests/data/test1537
+++ b/tests/data/test1537
@@ -31,8 +31,8 @@ nothing
 # Verify data after the test has been "shot"
 <verify>
 <stdout>
-%2F%3A%3B%3C%3D%3E%3F%91%A2%B3%C4%D5%E6%F7
-%2F%3A%3B%3C%3D%3E%3F%91%A2%B3%C4%D5%E6%F7
+%2f%3a%3b%3c%3d%3e%3f%91%a2%b3%c4%d5%e6%f7
+%2f%3a%3b%3c%3d%3e%3f%91%a2%b3%c4%d5%e6%f7
 outlen == 14
 unescape == original? YES
 [old] outlen == 14

--- a/tests/data/test543
+++ b/tests/data/test543
@@ -29,7 +29,7 @@ curl_easy_escape
 # time/date of the file
 <verify>
 <stdout>
-%9C%26K%3DI%04%A1%01%E0%D8%7C%20%B7%EFS%29%FA%1DW%E1
+%9c%26K%3dI%04%a1%01%e0%d8%7c%20%b7%efS%29%fa%1dW%e1
 IN: '' OUT: ''
 IN: ' 12' OUT: '%2012'
 </stdout>

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -655,7 +655,7 @@ static const struct urltestcase get_url_list[] = {
   {"https://%41%0d", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://%25", "", 0, 0, CURLUE_BAD_HOSTNAME},
   {"https://_%c0_", "https://_\xC0_/", 0, 0, CURLUE_OK},
-  {"https://_%c0_", "https://_%C0_/", 0, CURLU_URLENCODE, CURLUE_OK},
+  {"https://_%c0_", "https://_%c0_/", 0, CURLU_URLENCODE, CURLUE_OK},
 
   /* IPv4 trickeries */
   {"https://16843009", "https://1.1.1.1/", 0, 0, CURLUE_OK},
@@ -668,7 +668,7 @@ static const struct urltestcase get_url_list[] = {
   {"https://1.0xffffff", "https://1.255.255.255/", 0, 0, CURLUE_OK},
   /* IPv4 numerical overflows or syntax errors will not normalize */
   {"https://a127.0.0.1", "https://a127.0.0.1/", 0, 0, CURLUE_OK},
-  {"https://\xff.127.0.0.1", "https://%FF.127.0.0.1/", 0, CURLU_URLENCODE,
+  {"https://\xff.127.0.0.1", "https://%ff.127.0.0.1/", 0, CURLU_URLENCODE,
    CURLUE_OK},
   {"https://127.-0.0.1", "https://127.-0.0.1/", 0, 0, CURLUE_OK},
   {"https://127.0. 1", "https://127.0.0.1/", 0, 0, CURLUE_MALFORMED_INPUT},

--- a/tests/unit/unit1396.c
+++ b/tests/unit/unit1396.c
@@ -69,15 +69,15 @@ static CURLcode test_unit1396(char *arg)
   /* escape, this => that */
   const struct test list2[] = {
     {"a", 1, "a", 1},
-    {"/", 1, "%2F", 3},
-    {"a=b", 3, "a%3Db", 5},
-    {"a=b", 0, "a%3Db", 5},
+    {"/", 1, "%2f", 3},
+    {"a=b", 3, "a%3db", 5},
+    {"a=b", 0, "a%3db", 5},
     {"a=b", 1, "a", 1},
-    {"a=b", 2, "a%3D", 4},
-    {"1/./0", 5, "1%2F.%2F0", 9},
+    {"a=b", 2, "a%3d", 4},
+    {"1/./0", 5, "1%2f.%2f0", 9},
     {"-._~!#%&", 0, "-._~%21%23%25%26", 16},
     {"a", 2, "a%00", 4},
-    {"a\xff\x01g", 4, "a%FF%01g", 8},
+    {"a\xff\x01g", 4, "a%ff%01g", 8},
     {NULL, 0, NULL, 0} /* end of list marker */
   };
   int i;


### PR DESCRIPTION
For consistency in generated output. Lowercase selected because the AWS sigv4 code needs that.

Ref: #17685