### PR TITLE
tests/libtest: call `curlx_now_init()` for unit 1399, 2600 (Windows)

### DIFF
--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -36,6 +36,7 @@ CURLX_CFILES = \
   ../../lib/curlx/multibyte.c \
   ../../lib/curlx/timediff.c \
   ../../lib/curl_threads.c \
+  ../../lib/curlx/version_win32.c \
   ../../lib/curlx/wait.c
 
 # All libtest programs

--- a/tests/libtest/Makefile.inc
+++ b/tests/libtest/Makefile.inc
@@ -35,6 +35,7 @@ CURLX_CFILES = \
   ../../lib/curlx/warnless.c \
   ../../lib/curlx/multibyte.c \
   ../../lib/curlx/timediff.c \
+  ../../lib/curlx/timeval.c \
   ../../lib/curl_threads.c \
   ../../lib/curlx/version_win32.c \
   ../../lib/curlx/wait.c

--- a/tests/libtest/first.c
+++ b/tests/libtest/first.c
@@ -112,6 +112,9 @@ int main(int argc, char **argv)
   CURLX_SET_BINMODE(stdout);
 
   memory_tracking_init();
+#ifdef _WIN32
+  curlx_now_init();
+#endif
 
   /*
    * Setup proper locale from environment. This is needed to enable locale-


### PR DESCRIPTION
Follow-up to 35d0c047ce713298f15771649ffe7662404628f0 #17641