### PR TITLE
asyn-: remove redundant NULL check

### DIFF
--- a/lib/asyn-ares.c
+++ b/lib/asyn-ares.c
@@ -451,8 +451,7 @@ CURLcode Curl_async_await(struct Curl_easy *data,
   /* Operation complete, if the lookup was successful we now have the entry
      in the cache. */
   data->state.async.done = TRUE;
-  if(entry)
-    *entry = data->state.async.dns;
+  *entry = data->state.async.dns;
 
   if(result)
     ares_cancel(ares->channel);


### PR DESCRIPTION
When the code was originally written, `entry = NULL` was supported. However, after 59e351a572956fb99a1c1950b9b309cff5f16fc6 this check has became redundant. It will never succeed because the `*entry = NULL;` statement at the start of the function will segfault earlier.