### PR TITLE
tidy-up: replace `<memdebug.h>` with `"memdebug.h"` (src, units)

### DIFF
--- a/src/slist_wc.c
+++ b/src/slist_wc.c
@@ -29,7 +29,7 @@
 #include "slist_wc.h"
 
 /* The last #include files should be: */
-#include <memdebug.h>
+#include "memdebug.h"
 
 /*
  * slist_wc_append() appends a string to the linked list. This function can be

--- a/src/terminal.c
+++ b/src/terminal.c
@@ -28,7 +28,7 @@
 #endif
 
 #include "terminal.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #ifdef HAVE_TERMIOS_H
 #  include <termios.h>

--- a/src/tool_bname.c
+++ b/src/tool_bname.c
@@ -25,7 +25,7 @@
 
 #include "tool_bname.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #ifndef HAVE_BASENAME
 

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -28,7 +28,7 @@
 #include "tool_cb_dbg.h"
 #include "tool_util.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 static void dump(const char *timebuf, const char *idsbuf, const char *text,
                  FILE *stream, const unsigned char *ptr, size_t size,

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -35,7 +35,7 @@
 #include "tool_operate.h"
 #include "tool_libinfo.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 static char *parse_filename(const char *ptr, size_t len);
 

--- a/src/tool_cb_prg.c
+++ b/src/tool_cb_prg.c
@@ -29,7 +29,7 @@
 #include "tool_operate.h"
 #include "terminal.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #define MAX_BARLENGTH 400
 #define MIN_BARLENGTH 20

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -33,7 +33,7 @@
 #include "tool_util.h"
 #include "tool_msgs.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 /*
 ** callback for CURLOPT_READFUNCTION

--- a/src/tool_cb_see.c
+++ b/src/tool_cb_see.c
@@ -27,7 +27,7 @@
 #include "tool_operate.h"
 #include "tool_cb_see.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 /*
 ** callback for CURLOPT_SEEKFUNCTION

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -35,7 +35,7 @@
 #include "tool_cb_wrt.h"
 #include "tool_operate.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #ifdef _WIN32
 #define OPENMODE S_IREAD | S_IWRITE

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -27,7 +27,7 @@
 #include "tool_formparse.h"
 #include "tool_paramhlp.h"
 #include "tool_main.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 void config_init(struct OperationConfig *config)
 {

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -32,7 +32,7 @@
 #include "tool_dirhie.h"
 #include "tool_msgs.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #if defined(_WIN32) || (defined(MSDOS) && !defined(__DJGPP__))
 #  define mkdir(x,y) (mkdir)((x))

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -40,7 +40,7 @@
 #include "tool_doswin.h"
 #include "tool_msgs.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #ifdef _WIN32
 #  undef  PATH_MAX

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -31,7 +31,7 @@
 #include "tool_easysrc.h"
 #include "tool_msgs.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 /* global variable definitions, for easy-interface source code generation */
 

--- a/src/tool_findfile.c
+++ b/src/tool_findfile.c
@@ -39,7 +39,7 @@
 #include "tool_findfile.h"
 #include "tool_cfgable.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 struct finder {
   const char *env;

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -29,7 +29,7 @@
 #include "tool_paramhlp.h"
 #include "tool_formparse.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 /* tool_mime functions. */
 static struct tool_mime *tool_mime_new(struct tool_mime *parent,

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -38,7 +38,7 @@
 #include "tool_help.h"
 #include "var.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #define ALLOW_BLANK TRUE
 #define DENY_BLANK FALSE

--- a/src/tool_getpass.c
+++ b/src/tool_getpass.c
@@ -55,7 +55,7 @@
 #endif
 #include "tool_getpass.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #ifdef __VMS
 /* VMS implementation */

--- a/src/tool_help.c
+++ b/src/tool_help.c
@@ -33,7 +33,7 @@
 #include "tool_cfgable.h"
 #include "terminal.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 struct category_descriptors {
   const char *opt;

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -27,7 +27,7 @@
 #include "tool_msgs.h"
 #include "tool_getparam.h"
 #include "tool_helpers.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 /*
 ** Helper functions that are used from more than one source file.

--- a/src/tool_ipfs.c
+++ b/src/tool_ipfs.c
@@ -28,7 +28,7 @@
 #include "tool_cfgable.h"
 #include "tool_msgs.h"
 #include "tool_ipfs.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 /* ensure input ends in slash */
 static CURLcode ensure_trailing_slash(char **input)

--- a/src/tool_libinfo.c
+++ b/src/tool_libinfo.c
@@ -24,7 +24,7 @@
 #include "tool_setup.h"
 
 #include "tool_libinfo.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 /* global variable definitions, for libcurl runtime info */
 

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -51,7 +51,7 @@
  * the library level code from this client-side is ugly, but we do this
  * anyway for convenience.
  */
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #ifdef __VMS
 /*

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -28,7 +28,7 @@
 #include "tool_cb_prg.h"
 #include "terminal.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #define WARN_PREFIX "Warning: "
 #define NOTE_PREFIX "Note: "

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -94,7 +94,7 @@
 CURL_EXTERN CURLcode curl_easy_perform_ev(CURL *easy);
 #endif
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #ifdef CURL_CA_EMBED
 #ifndef CURL_DECLARED_CURL_CA_EMBED

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -28,7 +28,7 @@
 #include "tool_doswin.h"
 #include "tool_operhlp.h"
 #include "tool_msgs.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 void clean_getout(struct OperationConfig *config)
 {

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -32,7 +32,7 @@
 #include "tool_util.h"
 #include "tool_version.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 struct getout *new_getout(struct OperationConfig *config)
 {

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -30,7 +30,7 @@
 #include "tool_msgs.h"
 #include "tool_parsecfg.h"
 #include "tool_util.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 /* only acknowledge colon or equals as separators if the option was not
    specified with an initial dash! */

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -29,7 +29,7 @@
 #include "tool_easysrc.h"
 #include "tool_setopt.h"
 #include "tool_msgs.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 /* Lookup tables for converting setopt values back to symbols */
 /* For enums, values may be in any order. */

--- a/src/tool_stderr.c
+++ b/src/tool_stderr.c
@@ -26,7 +26,7 @@
 #include "tool_stderr.h"
 #include "tool_msgs.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 FILE *tool_stderr;
 

--- a/src/tool_urlglob.c
+++ b/src/tool_urlglob.c
@@ -27,7 +27,7 @@
 #include "tool_doswin.h"
 #include "tool_urlglob.h"
 #include "tool_vms.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #define GLOBERROR(string, column, code) \
   glob->error = string, glob->pos = column, code

--- a/src/tool_util.c
+++ b/src/tool_util.c
@@ -24,7 +24,7 @@
 #include "tool_setup.h"
 
 #include "tool_util.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #ifdef _WIN32
 

--- a/src/tool_vms.c
+++ b/src/tool_vms.c
@@ -32,7 +32,7 @@
 
 #include "curlmsg_vms.h"
 #include "tool_vms.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 void decc$__posix_exit(int __status);
 void decc$exit(int __status);

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -26,7 +26,7 @@
 #include "tool_cfgable.h"
 #include "tool_writeout.h"
 #include "tool_writeout_json.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 static int writeTime(FILE *stream, const struct writeoutvar *wovar,
                      struct per_transfer *per, CURLcode per_result,

--- a/src/tool_xattr.c
+++ b/src/tool_xattr.c
@@ -24,7 +24,7 @@
 #include "tool_setup.h"
 #include "tool_xattr.h"
 
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #ifdef USE_XATTR
 

--- a/src/var.c
+++ b/src/var.c
@@ -32,7 +32,7 @@
 #include "tool_paramhlp.h"
 #include "tool_writeout_json.h"
 #include "var.h"
-#include <memdebug.h> /* keep this as LAST include */
+#include "memdebug.h" /* keep this as LAST include */
 
 #define MAX_EXPAND_CONTENT 10000000
 #define MAX_VAR_LEN 128 /* max length of a name */

--- a/tests/unit/unit1602.c
+++ b/tests/unit/unit1602.c
@@ -25,7 +25,7 @@
 
 #include "hash.h"
 
-#include <memdebug.h> /* LAST include file */
+#include "memdebug.h" /* LAST include file */
 
 static void t1602_mydtor(void *p)
 {

--- a/tests/unit/unit1603.c
+++ b/tests/unit/unit1603.c
@@ -25,7 +25,7 @@
 
 #include "hash.h"
 
-#include <memdebug.h> /* LAST include file */
+#include "memdebug.h" /* LAST include file */
 
 static const size_t slots = 3;
 

--- a/tests/unit/unit1616.c
+++ b/tests/unit/unit1616.c
@@ -25,7 +25,7 @@
 
 #include "uint-hash.h"
 
-#include <memdebug.h> /* LAST include file */
+#include "memdebug.h" /* LAST include file */
 
 static void t1616_mydtor(unsigned int id, void *elem)
 {


### PR DESCRIPTION
---

I wonder if there was a reason for that? In `src` it was consistent `<>`,
for `units` it was a few stray `<>`, and for the rest of the codebase it
is `""`.
