### PR TITLE
autotools: detect and link `brotlicommon` library for brotli

### DIFF
--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           autoreconf -fi
           export PKG_CONFIG_DEBUG_SPEW=1
-          mkdir bld-am && cd bld-am && ../configure --enable-static=no --with-openssl --without-libpsl --disable-ldap --with-zstd
+          mkdir bld-am && cd bld-am && ../configure --enable-static=no --with-openssl --without-libpsl --disable-ldap --with-brotli --with-zstd
 
       - name: 'run cmake'
         run: |

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -44,10 +44,10 @@ jobs:
         run: |
           autoreconf -fi
           export PKG_CONFIG_DEBUG_SPEW=1
-          mkdir bld-am && cd bld-am && ../configure --enable-static=no --with-openssl --without-libpsl --without-brotli
+          mkdir bld-am && cd bld-am && ../configure --enable-static=no --with-openssl --without-libpsl
 
       - name: 'run cmake'
-        run: cmake -B bld-cm -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DCURL_BROTLI=OFF
+        run: cmake -B bld-cm -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF
 
       - name: 'configure log'
         run: cat bld-am/config.log 2>/dev/null || true
@@ -96,7 +96,6 @@ jobs:
         run: |
           cmake -B bld-cm -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DCURL_DISABLE_LDAP=ON \
             -DCMAKE_C_COMPILER_TARGET="$(uname -m | sed 's/arm64/aarch64/')-apple-darwin$(uname -r)" \
-            -DCURL_BROTLI=OFF \
             -DCURL_USE_LIBSSH2=OFF
 
       - name: 'configure log'

--- a/configure.ac
+++ b/configure.ac
@@ -1442,9 +1442,17 @@ if test X"$OPT_BROTLI" != Xno; then
         LD_BROTLI=`$PKGCONFIG --libs-only-L libbrotlidec`
         CPP_BROTLI=`$PKGCONFIG --cflags-only-I libbrotlidec`
         version=`$PKGCONFIG --modversion libbrotlidec`
-        DIR_BROTLI=`echo $LD_BROTLI | $SED -e 's/^-L//'`
       fi
 
+      CURL_CHECK_PKGCONFIG(libbrotlicommon)
+
+      if test "$PKGCONFIG" != "no"; then
+        LIB_BROTLI="$LIB_BROTLI `$PKGCONFIG --libs-only-l libbrotlicommon`"
+        LD_BROTLI="$LD_BROTLI `$PKGCONFIG --libs-only-L libbrotlicommon`"
+        CPP_BROTLI="$CPP_BROTLI `$PKGCONFIG --cflags-only-I libbrotlicommon`"
+      fi
+
+      DIR_BROTLI=`echo $LD_BROTLI | $SED -e 's/^-L//'`
       ;;
     off)
       dnl no --with-brotli option given, just check default places
@@ -1457,7 +1465,7 @@ if test X"$OPT_BROTLI" != Xno; then
 
   dnl if given with a prefix, we set -L and -I based on that
   if test -n "$PREFIX_BROTLI"; then
-    LIB_BROTLI="-lbrotlidec"
+    LIB_BROTLI="-lbrotlidec -lbrotlicommon"
     LD_BROTLI=-L${PREFIX_BROTLI}/lib$libsuff
     CPP_BROTLI=-I${PREFIX_BROTLI}/include
     DIR_BROTLI=${PREFIX_BROTLI}/lib$libsuff


### PR DESCRIPTION
`brotlicommon` is necessary when linking brotli statically.
E.g. on Alpine Linux with `PKG_CONFIG='pkg-config --static'`.

It also syncs brotli libs listed in `libcurl.pc` and `curl-config` with
those generated by cmake, which already listed `brotlicommon` there.

Also:
- remove workaround from GHA/configure-vs-cmake CI jobs.

Ref: https://github.com/curl/curl/commit/69cda1b7048ce7651b68040c8c4f14356c93033f
Follow-up to f2adb3b6d73cad0c28ec8a32f5fa969d0f6378a0 #15431
Reported-by: Christopher Boyd
Fixes #17678
