### PR TITLE
build: fix libcurltool with cmake and tunits, related tidy-ups

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,7 +109,7 @@ if(ENABLE_UNICODE AND MINGW AND NOT MINGW32CE)
   endif()
 endif()
 
-source_group("curlX source files" FILES ${CURLX_CFILES})
+source_group("curlx source files" FILES ${CURLX_CFILES})
 source_group("curl source files" FILES ${CURL_CFILES} ${_curl_cfiles_gen})
 source_group("curl header files" FILES ${CURL_HFILES} ${_curl_hfiles_gen})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
-add_executable(${EXE_NAME} ${CURL_CFILES} ${_curlx_cfiles_exe} ${_curl_cfiles_gen})
+add_executable(${EXE_NAME} ${CURL_CFILES} ${CURL_HFILES} ${_curlx_cfiles_exe} ${_curl_cfiles_gen})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
@@ -97,7 +97,7 @@ add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
 add_executable(curlinfo EXCLUDE_FROM_ALL "curlinfo.c")
 
 # special libcurltool library just for unittests
-add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${_curlx_cfiles_lib})
+add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURL_HFILES} ${_curlx_cfiles_lib})
 target_compile_definitions(curltool PUBLIC "CURL_STATICLIB" "UNITTESTS")
 target_link_libraries(curltool PRIVATE ${CURL_LIBS})
 set_target_properties(curltool PROPERTIES C_CLANG_TIDY "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,7 @@ include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 source_group("curl source files" FILES ${CURL_CFILES} ${_curl_cfiles_gen})
 source_group("curl header files" FILES ${CURL_HFILES} ${_curl_hfiles_gen})
 source_group("curlx source files" FILES ${CURLX_CFILES})
+source_group("curlx header files" FILES ${CURLX_HFILES})
 
 if(WIN32)
   list(APPEND CURL_CFILES ${CURL_RCFILES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,7 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
-add_executable(${EXE_NAME} ${CURL_CFILES} ${CURLX_CFILES} ${_curl_cfiles_gen} ${CURL_HFILES} ${_curl_hfiles_gen})
+add_executable(${EXE_NAME} ${CURL_CFILES} ${CURLX_CFILES} ${_curl_cfiles_gen} ${CURL_HFILES} ${CURLX_HFILES} ${_curl_hfiles_gen})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
-add_executable(${EXE_NAME} ${CURL_CFILES} ${CURL_HFILES} ${_curlx_cfiles_exe} ${_curl_cfiles_gen})
+add_executable(${EXE_NAME} ${CURL_CFILES} ${CURL_HFILES} ${_curlx_cfiles_exe} ${_curl_cfiles_gen} ${_curl_hfiles_gen})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,7 +66,7 @@ if(CURL_CA_EMBED_SET)
   endif()
 endif()
 
-# Get CURL_FILES, CURL_CFILES, CURL_HFILES, CURLX_CFILES, CURLX_HFILES, CURL_RCFILES variables
+# Get CURL_CFILES, CURL_HFILES, CURLX_CFILES, CURLX_HFILES, CURL_RCFILES variables
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,8 +92,10 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
+# Build curl executable
 add_executable(${EXE_NAME} ${CURL_CFILES} ${CURL_HFILES} ${_curl_cfiles_gen} ${_curl_hfiles_gen} ${CURLX_CFILES} ${CURLX_HFILES})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
+target_link_libraries(${EXE_NAME} ${LIB_SELECTED_FOR_EXE} ${CURL_LIBS})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
 
@@ -120,9 +122,6 @@ endif()
 source_group("curlx source files" FILES ${CURLX_CFILES})
 source_group("curl source files" FILES ${CURL_CFILES} ${_curl_cfiles_gen})
 source_group("curl header files" FILES ${CURL_HFILES} ${_curl_hfiles_gen})
-
-# Build curl executable
-target_link_libraries(${EXE_NAME} ${LIB_SELECTED_FOR_EXE} ${CURL_LIBS})
 
 ################################################################################
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,9 +70,9 @@ endif()
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
-source_group("curlx source files" FILES ${CURLX_CFILES})
 source_group("curl source files" FILES ${CURL_CFILES} ${_curl_cfiles_gen})
 source_group("curl header files" FILES ${CURL_HFILES} ${_curl_hfiles_gen})
+source_group("curlx source files" FILES ${CURLX_CFILES})
 
 if(WIN32)
   list(APPEND CURL_CFILES ${CURL_RCFILES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,7 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
-add_executable(${EXE_NAME} ${CURL_CFILES} ${_curl_cfiles_gen} ${CURLX_CFILES} ${CURL_HFILES} ${_curl_hfiles_gen})
+add_executable(${EXE_NAME} ${CURL_CFILES} ${CURLX_CFILES} ${_curl_cfiles_gen} ${CURL_HFILES} ${_curl_hfiles_gen})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,8 +74,13 @@ if(WIN32)
   list(APPEND CURL_CFILES ${CURL_RCFILES})
 endif()
 
+set(_curlx_cfiles_exe ${CURLX_CFILES})
 if(BUILD_STATIC_CURL)
-  set(CURLX_CFILES "")
+  set(_curlx_cfiles_exe "")
+endif()
+set(_curlx_cfiles_lib ${CURLX_CFILES})
+if(LIB_SELECTED STREQUAL LIB_STATIC)
+  set(_curlx_cfiles_lib "")
 endif()
 
 set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
@@ -84,7 +89,7 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
-add_executable(${EXE_NAME} ${CURL_CFILES} ${CURLX_CFILES} ${_curl_cfiles_gen})
+add_executable(${EXE_NAME} ${CURL_CFILES} ${_curlx_cfiles_exe} ${_curl_cfiles_gen})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
@@ -92,7 +97,7 @@ add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
 add_executable(curlinfo EXCLUDE_FROM_ALL "curlinfo.c")
 
 # special libcurltool library just for unittests
-add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURLX_CFILES})
+add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${_curlx_cfiles_lib})
 target_compile_definitions(curltool PUBLIC "CURL_STATICLIB" "UNITTESTS")
 target_link_libraries(curltool PRIVATE ${CURL_LIBS})
 set_target_properties(curltool PROPERTIES C_CLANG_TIDY "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,13 +74,14 @@ if(WIN32)
   list(APPEND CURL_CFILES ${CURL_RCFILES})
 endif()
 
-set(_curlx_cfiles_exe ${CURLX_CFILES})
-if(BUILD_STATIC_CURL)
-  set(_curlx_cfiles_exe "")
-endif()
 set(_curlx_cfiles_lib ${CURLX_CFILES})
 if(LIB_SELECTED STREQUAL LIB_STATIC)
   set(_curlx_cfiles_lib "")
+endif()
+
+if(BUILD_STATIC_CURL)
+  set(CURLX_CFILES "")
+  set(CURLX_HFILES "")
 endif()
 
 set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
@@ -89,7 +90,7 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
-add_executable(${EXE_NAME} ${CURL_CFILES} ${CURL_HFILES} ${_curl_cfiles_gen} ${_curl_hfiles_gen} ${_curlx_cfiles_exe})
+add_executable(${EXE_NAME} ${CURL_CFILES} ${CURL_HFILES} ${_curl_cfiles_gen} ${_curl_hfiles_gen} ${CURLX_CFILES} ${CURLX_HFILES})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,7 +92,7 @@ add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
 add_executable(curlinfo EXCLUDE_FROM_ALL "curlinfo.c")
 
 # special libcurltool library just for unittests
-add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURL_HFILES})
+add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURLX_CFILES} ${CURL_HFILES} ${CURLX_HFILES})
 target_compile_definitions(curltool PUBLIC "CURL_STATICLIB" "UNITTESTS")
 target_link_libraries(curltool PRIVATE ${CURL_LIBS})
 set_target_properties(curltool PROPERTIES C_CLANG_TIDY "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,7 +84,7 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
-add_executable(${EXE_NAME} ${CURL_CFILES} ${CURLX_CFILES} ${_curl_cfiles_gen} ${CURL_HFILES} ${CURLX_HFILES} ${_curl_hfiles_gen})
+add_executable(${EXE_NAME} ${CURL_CFILES} ${CURLX_CFILES} ${_curl_cfiles_gen})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
@@ -92,7 +92,7 @@ add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
 add_executable(curlinfo EXCLUDE_FROM_ALL "curlinfo.c")
 
 # special libcurltool library just for unittests
-add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURLX_CFILES} ${CURL_HFILES} ${CURLX_HFILES})
+add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURLX_CFILES})
 target_compile_definitions(curltool PUBLIC "CURL_STATICLIB" "UNITTESTS")
 target_link_libraries(curltool PRIVATE ${CURL_LIBS})
 set_target_properties(curltool PROPERTIES C_CLANG_TIDY "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,7 +89,7 @@ set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES
   "${CMAKE_CURRENT_SOURCE_DIR}"      # for "tool_hugehelp.c"
 )
 
-add_executable(${EXE_NAME} ${CURL_CFILES} ${CURL_HFILES} ${_curlx_cfiles_exe} ${_curl_cfiles_gen} ${_curl_hfiles_gen})
+add_executable(${EXE_NAME} ${CURL_CFILES} ${CURL_HFILES} ${_curl_cfiles_gen} ${_curl_hfiles_gen} ${_curlx_cfiles_exe})
 target_compile_definitions(${EXE_NAME} PRIVATE ${_curl_definitions})
 
 add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,10 @@ endif()
 curl_transform_makefile_inc("Makefile.inc" "${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 include("${CMAKE_CURRENT_BINARY_DIR}/Makefile.inc.cmake")
 
+source_group("curlx source files" FILES ${CURLX_CFILES})
+source_group("curl source files" FILES ${CURL_CFILES} ${_curl_cfiles_gen})
+source_group("curl header files" FILES ${CURL_HFILES} ${_curl_hfiles_gen})
+
 if(WIN32)
   list(APPEND CURL_CFILES ${CURL_RCFILES})
 endif()
@@ -118,10 +122,6 @@ if(ENABLE_UNICODE AND MINGW AND NOT MINGW32CE)
     target_link_libraries(${EXE_NAME} PRIVATE "-municode")
   endif()
 endif()
-
-source_group("curlx source files" FILES ${CURLX_CFILES})
-source_group("curl source files" FILES ${CURL_CFILES} ${_curl_cfiles_gen})
-source_group("curl header files" FILES ${CURL_HFILES} ${_curl_hfiles_gen})
 
 ################################################################################
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,8 +75,10 @@ if(WIN32)
 endif()
 
 set(_curlx_cfiles_lib ${CURLX_CFILES})
+set(_curlx_hfiles_lib ${CURLX_HFILES})
 if(LIB_SELECTED STREQUAL LIB_STATIC)
   set(_curlx_cfiles_lib "")
+  set(_curlx_hfiles_lib "")
 endif()
 
 if(BUILD_STATIC_CURL)
@@ -98,7 +100,7 @@ add_executable(${PROJECT_NAME}::${EXE_NAME} ALIAS ${EXE_NAME})
 add_executable(curlinfo EXCLUDE_FROM_ALL "curlinfo.c")
 
 # special libcurltool library just for unittests
-add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURL_HFILES} ${_curlx_cfiles_lib})
+add_library(curltool STATIC EXCLUDE_FROM_ALL ${CURL_CFILES} ${CURL_HFILES} ${_curlx_cfiles_lib} ${_curlx_hfiles_lib})
 target_compile_definitions(curltool PUBLIC "CURL_STATICLIB" "UNITTESTS")
 target_link_libraries(curltool PRIVATE ${CURL_LIBS})
 set_target_properties(curltool PROPERTIES C_CLANG_TIDY "")

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,7 +26,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 # remove targets if the command fails
 .DELETE_ON_ERROR:
 
-# Get CURL_FILES, CURL_CFILES, CURL_HFILES, CURLX_CFILES, CURLX_HFILES, CURL_RCFILES variables
+# Get CURL_CFILES, CURL_HFILES, CURLX_CFILES, CURLX_HFILES, CURL_RCFILES variables
 include Makefile.inc
 
 EXTRA_DIST = mk-file-embed.pl mkhelp.pl \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,8 +79,8 @@ curlx_src = $(CURLX_CFILES)
 endif
 
 if USE_UNITY
-curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen) > curltool_unity.c
+curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen) $(curl_hfiles_gen)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen) $(curl_hfiles_gen) > curltool_unity.c
 
 nodist_curl_SOURCES = curltool_unity.c
 curl_SOURCES =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -72,21 +72,21 @@ curl_hfiles_gen =
 CLEANFILES =
 
 if USE_CPPFLAG_CURL_STATICLIB
-curlx_src =
+curlx_csrc =
 else
 # These are part of the libcurl static lib. Add them here when linking shared.
-curlx_src = $(CURLX_CFILES)
+curlx_csrc = $(CURLX_CFILES)
 endif
 
 if USE_UNITY
-curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen) $(curl_hfiles_gen)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen) $(curl_hfiles_gen) > curltool_unity.c
+curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curl_cfiles_gen) $(curl_hfiles_gen)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curl_cfiles_gen) $(curl_hfiles_gen) > curltool_unity.c
 
 nodist_curl_SOURCES = curltool_unity.c
 curl_SOURCES =
 CLEANFILES += curltool_unity.c
 else
-curl_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen) $(curl_hfiles_gen)
+curl_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curl_cfiles_gen) $(curl_hfiles_gen)
 endif
 if HAVE_WINDRES
 curl_SOURCES += $(CURL_RCFILES)
@@ -110,14 +110,14 @@ libcurltool_la_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB -DUNITTESTS
 libcurltool_la_CFLAGS =
 libcurltool_la_LDFLAGS = -static $(LIBCURL_PC_LIBS_PRIVATE)
 if USE_UNITY
-libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_src)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) > libcurltool_unity.c
+libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) > libcurltool_unity.c
 
 nodist_libcurltool_la_SOURCES = libcurltool_unity.c
 libcurltool_la_SOURCES =
 CLEANFILES += libcurltool_unity.c
 else
-libcurltool_la_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_src)
+libcurltool_la_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc)
 endif
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,14 +109,14 @@ libcurltool_la_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB -DUNITTESTS
 libcurltool_la_CFLAGS =
 libcurltool_la_LDFLAGS = -static $(LIBCURL_PC_LIBS_PRIVATE)
 if USE_UNITY
-libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curlx_src)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curlx_src) > libcurltool_unity.c
+libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) > libcurltool_unity.c
 
 nodist_libcurltool_la_SOURCES = libcurltool_unity.c
 libcurltool_la_SOURCES =
 CLEANFILES += libcurltool_unity.c
 else
-libcurltool_la_SOURCES = $(CURL_FILES)
+libcurltool_la_SOURCES = $(CURL_CFILES)
 endif
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,14 +79,14 @@ curlx_src = $(CURLX_CFILES)
 endif
 
 if USE_UNITY
-curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curlx_src) $(curl_cfiles_gen)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curlx_src) $(curl_cfiles_gen) > curltool_unity.c
+curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen) > curltool_unity.c
 
 nodist_curl_SOURCES = curltool_unity.c
 curl_SOURCES =
 CLEANFILES += curltool_unity.c
 else
-curl_SOURCES = $(CURL_CFILES) $(curlx_src) $(curl_cfiles_gen) $(curl_hfiles_gen)
+curl_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) $(curl_cfiles_gen) $(curl_hfiles_gen)
 endif
 if HAVE_WINDRES
 curl_SOURCES += $(CURL_RCFILES)
@@ -110,14 +110,14 @@ libcurltool_la_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB -DUNITTESTS
 libcurltool_la_CFLAGS =
 libcurltool_la_LDFLAGS = -static $(LIBCURL_PC_LIBS_PRIVATE)
 if USE_UNITY
-libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curlx_src)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curlx_src) > libcurltool_unity.c
+libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_src)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_src) > libcurltool_unity.c
 
 nodist_libcurltool_la_SOURCES = libcurltool_unity.c
 libcurltool_la_SOURCES =
 CLEANFILES += libcurltool_unity.c
 else
-libcurltool_la_SOURCES = $(CURL_CFILES) $(curlx_src)
+libcurltool_la_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_src)
 endif
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,14 +109,14 @@ libcurltool_la_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB -DUNITTESTS
 libcurltool_la_CFLAGS =
 libcurltool_la_LDFLAGS = -static $(LIBCURL_PC_LIBS_PRIVATE)
 if USE_UNITY
-libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) > libcurltool_unity.c
+libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curlx_src)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curlx_src) > libcurltool_unity.c
 
 nodist_libcurltool_la_SOURCES = libcurltool_unity.c
 libcurltool_la_SOURCES =
 CLEANFILES += libcurltool_unity.c
 else
-libcurltool_la_SOURCES = $(CURL_CFILES)
+libcurltool_la_SOURCES = $(CURL_FILES)
 endif
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -86,7 +86,7 @@ nodist_curl_SOURCES = curltool_unity.c
 curl_SOURCES =
 CLEANFILES += curltool_unity.c
 else
-curl_SOURCES = $(CURL_FILES) $(curl_cfiles_gen) $(curl_hfiles_gen)
+curl_SOURCES = $(CURL_CFILES) $(curlx_src) $(curl_cfiles_gen) $(curl_hfiles_gen)
 endif
 if HAVE_WINDRES
 curl_SOURCES += $(CURL_RCFILES)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,8 +109,8 @@ libcurltool_la_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB -DUNITTESTS
 libcurltool_la_CFLAGS =
 libcurltool_la_LDFLAGS = -static $(LIBCURL_PC_LIBS_PRIVATE)
 if USE_UNITY
-libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_FILES)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_FILES) > libcurltool_unity.c
+libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curlx_src)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curlx_src) > libcurltool_unity.c
 
 nodist_libcurltool_la_SOURCES = libcurltool_unity.c
 libcurltool_la_SOURCES =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,14 +81,14 @@ curlx_hsrc = $(CURLX_HFILES)
 endif
 
 if USE_UNITY
-curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curlx_hsrc) $(curl_cfiles_gen) $(curl_hfiles_gen)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curlx_hsrc) $(curl_cfiles_gen) $(curl_hfiles_gen) > curltool_unity.c
+curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curl_cfiles_gen) $(curl_hfiles_gen) $(curlx_csrc) $(curlx_hsrc)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curl_cfiles_gen) $(curl_hfiles_gen) $(curlx_csrc) $(curlx_hsrc) > curltool_unity.c
 
 nodist_curl_SOURCES = curltool_unity.c
 curl_SOURCES =
 CLEANFILES += curltool_unity.c
 else
-curl_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curlx_hsrc) $(curl_cfiles_gen) $(curl_hfiles_gen)
+curl_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curl_cfiles_gen) $(curl_hfiles_gen) $(curlx_csrc) $(curlx_hsrc)
 endif
 if HAVE_WINDRES
 curl_SOURCES += $(CURL_RCFILES)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,8 +109,8 @@ libcurltool_la_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB -DUNITTESTS
 libcurltool_la_CFLAGS =
 libcurltool_la_LDFLAGS = -static $(LIBCURL_PC_LIBS_PRIVATE)
 if USE_UNITY
-libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curlx_src)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curlx_src) > libcurltool_unity.c
+libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_FILES)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_FILES) > libcurltool_unity.c
 
 nodist_libcurltool_la_SOURCES = libcurltool_unity.c
 libcurltool_la_SOURCES =

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -73,20 +73,22 @@ CLEANFILES =
 
 if USE_CPPFLAG_CURL_STATICLIB
 curlx_csrc =
+curlx_hsrc =
 else
 # These are part of the libcurl static lib. Add them here when linking shared.
 curlx_csrc = $(CURLX_CFILES)
+curlx_hsrc = $(CURLX_HFILES)
 endif
 
 if USE_UNITY
-curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curl_cfiles_gen) $(curl_hfiles_gen)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curl_cfiles_gen) $(curl_hfiles_gen) > curltool_unity.c
+curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curlx_hsrc) $(curl_cfiles_gen) $(curl_hfiles_gen)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curlx_hsrc) $(curl_cfiles_gen) $(curl_hfiles_gen) > curltool_unity.c
 
 nodist_curl_SOURCES = curltool_unity.c
 curl_SOURCES =
 CLEANFILES += curltool_unity.c
 else
-curl_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curl_cfiles_gen) $(curl_hfiles_gen)
+curl_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curlx_hsrc) $(curl_cfiles_gen) $(curl_hfiles_gen)
 endif
 if HAVE_WINDRES
 curl_SOURCES += $(CURL_RCFILES)
@@ -110,14 +112,14 @@ libcurltool_la_CPPFLAGS = $(AM_CPPFLAGS) -DCURL_STATICLIB -DUNITTESTS
 libcurltool_la_CFLAGS =
 libcurltool_la_LDFLAGS = -static $(LIBCURL_PC_LIBS_PRIVATE)
 if USE_UNITY
-libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) > libcurltool_unity.c
+libcurltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curlx_hsrc)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curlx_hsrc) > libcurltool_unity.c
 
 nodist_libcurltool_la_SOURCES = libcurltool_unity.c
 libcurltool_la_SOURCES =
 CLEANFILES += libcurltool_unity.c
 else
-libcurltool_la_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc)
+libcurltool_la_SOURCES = $(CURL_CFILES) $(CURL_HFILES) $(curlx_csrc) $(curlx_hsrc)
 endif
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -71,13 +71,14 @@ curl_cfiles_gen =
 curl_hfiles_gen =
 CLEANFILES =
 
-if USE_UNITY
 if USE_CPPFLAG_CURL_STATICLIB
 curlx_src =
 else
 # These are part of the libcurl static lib. Add them here when linking shared.
 curlx_src = $(CURLX_CFILES)
 endif
+
+if USE_UNITY
 curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curl_cfiles_gen) $(curlx_src)
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curl_cfiles_gen) $(curlx_src) > curltool_unity.c
 
@@ -116,7 +117,7 @@ nodist_libcurltool_la_SOURCES = libcurltool_unity.c
 libcurltool_la_SOURCES =
 CLEANFILES += libcurltool_unity.c
 else
-libcurltool_la_SOURCES = $(CURL_FILES)
+libcurltool_la_SOURCES = $(CURL_CFILES) $(curlx_src)
 endif
 endif
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -79,8 +79,8 @@ curlx_src = $(CURLX_CFILES)
 endif
 
 if USE_UNITY
-curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curl_cfiles_gen) $(curlx_src)
-	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curl_cfiles_gen) $(curlx_src) > curltool_unity.c
+curltool_unity.c: $(top_srcdir)/scripts/mk-unity.pl $(CURL_CFILES) $(curlx_src) $(curl_cfiles_gen)
+	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(CURL_CFILES) $(curlx_src) $(curl_cfiles_gen) > curltool_unity.c
 
 nodist_curl_SOURCES = curltool_unity.c
 curl_SOURCES =

--- a/src/Makefile.inc
+++ b/src/Makefile.inc
@@ -150,6 +150,3 @@ CURL_HFILES = \
   var.h
 
 CURL_RCFILES = curl.rc
-
-# curl_SOURCES is special and gets assigned in src/Makefile.am
-CURL_FILES = $(CURL_CFILES) $(CURLX_CFILES) $(CURL_HFILES)

--- a/tests/tunit/CMakeLists.txt
+++ b/tests/tunit/CMakeLists.txt
@@ -36,7 +36,7 @@ add_custom_command(OUTPUT "${BUNDLE}.c"
 
 add_executable(${BUNDLE} EXCLUDE_FROM_ALL "${BUNDLE}.c")
 add_dependencies(testdeps ${BUNDLE})
-target_link_libraries(${BUNDLE} curltool curlu)
+target_link_libraries(${BUNDLE} curltool ${LIB_SELECTED})
 target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h", curlx

--- a/tests/tunit/Makefile.am
+++ b/tests/tunit/Makefile.am
@@ -65,7 +65,7 @@ ${BUNDLE}.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRSTFILES) $(UTIL
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS) --test $(TESTFILES) > ${BUNDLE}.c
 
 noinst_PROGRAMS = $(BUNDLE)
-LDADD = $(top_builddir)/src/libcurltool.la $(top_builddir)/lib/libcurlu.la
+LDADD = $(top_builddir)/src/libcurltool.la $(top_builddir)/lib/libcurl.la
 CLEANFILES = ${BUNDLE}.c
 else
 noinst_PROGRAMS =

--- a/tests/tunit/Makefile.am
+++ b/tests/tunit/Makefile.am
@@ -65,7 +65,7 @@ ${BUNDLE}.c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRSTFILES) $(UTIL
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --include $(UTILS) --test $(TESTFILES) > ${BUNDLE}.c
 
 noinst_PROGRAMS = $(BUNDLE)
-LDADD = $(top_builddir)/src/libcurltool.la $(top_builddir)/lib/libcurl.la
+LDADD = $(top_builddir)/src/libcurltool.la $(top_builddir)/lib/libcurlu.la
 CLEANFILES = ${BUNDLE}.c
 else
 noinst_PROGRAMS =


### PR DESCRIPTION
Sync how libcurltool is built in different modes and build systems.

cmake:
- build libcurltool with curlx when building shared libcurl.
  To make it possible to use standard libcurl when linking tunits.
  Also syncing this with autotools.
  The remaining difference is that cmake allows to select shared or
  static for curl tool and tests/examples independently.
- fix to link with libcurl instead of libcurlu.
  To sync with autotools and to link with the standard libcurl for
  tool unit tests.
- fix `source_group()` to always include curlx sources.
- add missing 'curlx header files' source group.

autotools:
- build libcurltool without curlx when building static libcurl in
  non-unity builds.
  To avoid double compilation, just to be thrown away at link time.
  Also to sync with unity builds.

both:
- sync source order between autotools and cmake.
- make sure to pass all headers with both autotools and cmake.
  This is a no-op with cmake. Maybe a future patch should make sure
  to not pass those to remove that noise.

Ref: #17696
