### PR TITLE
lib: address singleuse issues

### DIFF
--- a/lib/llist.c
+++ b/lib/llist.c
@@ -181,7 +181,8 @@ void *Curl_node_take_elem(struct Curl_llist_node *e)
 /*
  * @unittest: 1300
  */
-void
+UNITTEST void Curl_node_uremove(struct Curl_llist_node *, void *);
+UNITTEST void
 Curl_node_uremove(struct Curl_llist_node *e, void *user)
 {
   struct Curl_llist *list;

--- a/lib/llist.h
+++ b/lib/llist.h
@@ -57,7 +57,6 @@ void Curl_llist_insert_next(struct Curl_llist *, struct Curl_llist_node *,
                             const void *, struct Curl_llist_node *node);
 void Curl_llist_append(struct Curl_llist *,
                        const void *, struct Curl_llist_node *node);
-void Curl_node_uremove(struct Curl_llist_node *, void *);
 void Curl_node_remove(struct Curl_llist_node *);
 void Curl_llist_destroy(struct Curl_llist *, void *);
 

--- a/lib/uint-bset.c
+++ b/lib/uint-bset.c
@@ -74,14 +74,13 @@ void Curl_uint_bset_destroy(struct uint_bset *bset)
   memset(bset, 0, sizeof(*bset));
 }
 
-
-unsigned int Curl_uint_bset_capacity(struct uint_bset *bset)
+#ifdef UNITTESTS
+UNITTEST unsigned int Curl_uint_bset_capacity(struct uint_bset *bset)
 {
   return bset->nslots * 64;
 }
 
-
-unsigned int Curl_uint_bset_count(struct uint_bset *bset)
+UNITTEST unsigned int Curl_uint_bset_count(struct uint_bset *bset)
 {
   unsigned int i;
   unsigned int n = 0;
@@ -91,7 +90,7 @@ unsigned int Curl_uint_bset_count(struct uint_bset *bset)
   }
   return n;
 }
-
+#endif
 
 bool Curl_uint_bset_empty(struct uint_bset *bset)
 {

--- a/lib/uint-hash.c
+++ b/lib/uint-hash.c
@@ -206,10 +206,12 @@ static void uint_hash_clear(struct uint_hash *h)
   }
 }
 
-void Curl_uint_hash_clear(struct uint_hash *h)
+#ifdef UNITTESTS
+UNITTEST void Curl_uint_hash_clear(struct uint_hash *h)
 {
   uint_hash_clear(h);
 }
+#endif
 
 void Curl_uint_hash_destroy(struct uint_hash *h)
 {

--- a/lib/uint-spbset.c
+++ b/lib/uint-spbset.c
@@ -35,6 +35,9 @@
 #define CURL_UINT_SPBSET_MAGIC  0x70737362
 #endif
 
+/* Clear the bitset, making it empty. */
+UNITTEST void Curl_uint_spbset_clear(struct uint_spbset *bset);
+
 void Curl_uint_spbset_init(struct uint_spbset *bset)
 {
   memset(bset, 0, sizeof(*bset));
@@ -77,7 +80,7 @@ bool Curl_uint_spbset_empty(struct uint_spbset *bset)
   return TRUE;
 }
 
-void Curl_uint_spbset_clear(struct uint_spbset *bset)
+UNITTEST void Curl_uint_spbset_clear(struct uint_spbset *bset)
 {
   struct uint_spbset_chunk *next, *chunk;
 

--- a/lib/uint-spbset.h
+++ b/lib/uint-spbset.h
@@ -64,9 +64,6 @@ unsigned int Curl_uint_spbset_count(struct uint_spbset *bset);
 /* TRUE of bitset is empty */
 bool Curl_uint_spbset_empty(struct uint_spbset *bset);
 
-/* Clear the bitset, making it empty. */
-void Curl_uint_spbset_clear(struct uint_spbset *bset);
-
 /* Add the number `i` to the bitset.
  * Numbers can be added more than once, without making a difference.
  * Returns FALSE if allocations failed. */

--- a/lib/uint-table.c
+++ b/lib/uint-table.c
@@ -34,6 +34,9 @@
 #define CURL_UINT_TBL_MAGIC  0x62757473
 #endif
 
+/* Clear the table, making it empty. */
+UNITTEST void Curl_uint_tbl_clear(struct uint_tbl *tbl);
+
 void Curl_uint_tbl_init(struct uint_tbl *tbl,
                         Curl_uint_tbl_entry_dtor *entry_dtor)
 {
@@ -95,8 +98,7 @@ void Curl_uint_tbl_destroy(struct uint_tbl *tbl)
   memset(tbl, 0, sizeof(*tbl));
 }
 
-
-void Curl_uint_tbl_clear(struct uint_tbl *tbl)
+UNITTEST void Curl_uint_tbl_clear(struct uint_tbl *tbl)
 {
   DEBUGASSERT(tbl->init == CURL_UINT_TBL_MAGIC);
   uint_tbl_clear_rows(tbl, 0, tbl->nrows);

--- a/lib/uint-table.h
+++ b/lib/uint-table.h
@@ -60,9 +60,6 @@ unsigned int Curl_uint_tbl_capacity(struct uint_tbl *tbl);
 /* Get the number of entries in the table. */
 unsigned int Curl_uint_tbl_count(struct uint_tbl *tbl);
 
-/* Clear the table, making it empty. */
-void Curl_uint_tbl_clear(struct uint_tbl *tbl);
-
 /* Get the entry for key or NULL if not present */
 void *Curl_uint_tbl_get(struct uint_tbl *tbl, unsigned int key);
 

--- a/tests/unit/unit1300.c
+++ b/tests/unit/unit1300.c
@@ -25,6 +25,8 @@
 
 #include "llist.h"
 
+UNITTEST void Curl_node_uremove(struct Curl_llist_node *, void *);
+
 static void test_Curl_llist_dtor(void *key, void *value)
 {
   /* used by the llist API, does nothing here */

--- a/tests/unit/unit3212.c
+++ b/tests/unit/unit3212.c
@@ -27,6 +27,8 @@
 #include "uint-table.h"
 #include "curl_trc.h"
 
+UNITTEST void Curl_uint_tbl_clear(struct uint_tbl *tbl);
+
 #define TBL_SIZE    100
 
 static CURLcode t3212_setup(struct uint_tbl *tbl)

--- a/tests/unit/unit3213.c
+++ b/tests/unit/unit3213.c
@@ -27,6 +27,8 @@
 #include "uint-spbset.h"
 #include "curl_trc.h"
 
+UNITTEST void Curl_uint_spbset_clear(struct uint_spbset *bset);
+
 static void check_spbset(const char *name, const unsigned int *s, size_t slen)
 {
   struct uint_spbset bset;


### PR DESCRIPTION
- markup some functions UNITTEST, so that they are static unless in a unit test build

- make some functions #ifdef UNITTESTS as they are only used from unit tests

- adjusted unit tests accordingly to use local prototypes for functions not global in the library