### PR TITLE
docs: Reflect that delimiter-separated capath is OpenSSL specific

### DIFF
--- a/docs/cmdline-opts/capath.md
+++ b/docs/cmdline-opts/capath.md
@@ -18,9 +18,11 @@ Example:
 
 # `--capath`
 
-Use the specified certificate directory to verify the peer. Multiple paths can
-be provided by separating them with colon (`:`) (e.g. `path1:path2:path3`). The
-certificates must be in PEM format, and if curl is built against OpenSSL, the
+Use the specified certificate directory to verify the peer. If curl is built against
+OpenSSL, multiple paths can be provided by separating them with the appropriate platform-specific
+separator (e.g. `path1:path2:path3` on Unix-style platforms for `path1;path2;path3` on Windows).
+
+The certificates must be in PEM format, and if curl is built against OpenSSL, the
 directory must have been processed using the c_rehash utility supplied with
 OpenSSL. Using --capath can allow OpenSSL-powered curl to make SSL-connections
 much more efficiently than using --cacert if the --cacert file contains many


### PR DESCRIPTION
curl passes down the capath directly to the backends. OpenSSL will then delimiter-separate this path internally to support multiple directories (using its certificate hash scheme). However, the other backends (wolfSSL, mbedTLS, gnutls) only expect a single directory (and do not use the hash scheme, preferring to iterate the directory and load all files). This adjusts the `--capath` documentation to reflect that multiple paths is an OpenSSL-specific feature. Alternatively, curl could delimiter-separate these itself, but I'm not sure it's worth it.

Ref https://github.com/JuliaLang/NetworkOptions.jl/issues/41