### PR TITLE
cmake: enable soversion by default for OpenHarmony OS

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -203,6 +203,7 @@ if(BUILD_SHARED_LIBS)
     CMAKE_SYSTEM_NAME STREQUAL "Linux" OR
     CMAKE_SYSTEM_NAME STREQUAL "SunOS" OR
     CMAKE_SYSTEM_NAME STREQUAL "Haiku" OR
+    CMAKE_SYSTEM_NAME STREQUAL "OHOS" OR  # OpenHarmony
     CMAKE_SYSTEM_NAME STREQUAL "GNU/kFreeBSD" OR
     # FreeBSD comes with the a.out and ELF flavours but a.out was supported
     # up to v3.x and ELF from v3.x. I cannot imagine someone running CMake


### PR DESCRIPTION
we are using curl lib in OpenHarmony, so we'd like to contribute the build guide, hope it can help developers.