### PR TITLE
mk-unity: accept and include provided header files

### DIFF
--- a/scripts/mk-unity.pl
+++ b/scripts/mk-unity.pl
@@ -63,7 +63,10 @@ if($any_test) {
 my $tlist = "";
 
 foreach my $src (@src) {
-    if($src =~ /([a-z0-9_]+)\.c$/) {
+    if($src =~ /([a-z0-9_]+)\.h$/) {
+        print "#include \"$src\"\n";
+    }
+    elsif($src =~ /([a-z0-9_]+)\.c$/) {
         my $name = $1;
         print "#include \"$src\"\n";
         if(not exists $include{$src}) {  # register test entry function


### PR DESCRIPTION
Header files provided on the command line are now recognized and included in the generated output. There is one passed in for unit tests at least, that before this change was simply ignored.