### PR TITLE
http: fix build with cookies and HSTS disabled

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -3310,8 +3310,14 @@ static CURLcode http_header_r(struct Curl_easy *data,
 static CURLcode http_header_s(struct Curl_easy *data,
                               const char *hd, size_t hdlen)
 {
+#if !defined(CURL_DISABLE_COOKIES) || !defined(CURL_DISABLE_HSTS)
   struct connectdata *conn = data->conn;
   const char *v;
+#else
+  (void)data;
+  (void)hd;
+  (void)hdlen;
+#endif
 
 #if !defined(CURL_DISABLE_COOKIES)
   v = (data->cookies && data->state.cookie_engine) ?


### PR DESCRIPTION
All arguments and local variables in `http_header_s` were unused when both `CURL_DISABLE_COOKIES` and `CURL_DISABLE_HSTS` were defined.