### PR TITLE
runtests: fix `LD_PRELOAD` detection for cmake-built curl binaries

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -545,7 +545,7 @@ sub checksystemfeatures {
             $curl =~ s/^(.*)(libcurl.*)/$1/g || die "Failure determining curl binary version";
 
             $libcurl = $2;
-            if($curl =~ /linux|bsd|solaris/) {
+            if($curl =~ /linux|bsd|solaris/i) {
                 # system supports LD_PRELOAD/LD_LIBRARY_PATH; may be disabled later
                 $feature{"ld_preload"} = 1;
             }


### PR DESCRIPTION
CMake builds by default don't include a triplet in the `curl -V` output,
but a CMake-specific OS string, which is usually capitalized or stylized,
e.g. "Linux", or "FreeBSD". Make the regexp expression case-insensitive
to handle this.
