### PR TITLE
VULN-DISCLOSURE-POLICY: exclude not installed software

### DIFF
--- a/docs/VULN-DISCLOSURE-POLICY.md
+++ b/docs/VULN-DISCLOSURE-POLICY.md
@@ -253,6 +253,9 @@ Vulnerabilities in features which are off by default (in the build) and
 documented as experimental, or exist only in debug mode, are not eligible for a
 reward and we do not consider them security problems.
 
+The same applies to scripts and software which are not installed by default by
+the make install rule.
+
 ## URL inconsistencies
 
 URL parser inconsistencies between browsers and curl are expected and are not


### PR DESCRIPTION
Flaws in any script or compiled artifact which isn't installed by default is not considered to be security vulnerabilities.