### PR TITLE
tests/libtests: drop a checksrc exception

### DIFF
--- a/tests/libtest/.checksrc
+++ b/tests/libtest/.checksrc
@@ -1,3 +1,2 @@
 disable TYPEDEFSTRUCT
 allowfunc localtime
-allowfunc LoadLibrary


### PR DESCRIPTION
Follow-up to a0a1df5af9b3f11125d1a995c01b7c04cfec54e4 #17414