### PR TITLE
checksrc: reduce exceptions, apply again to curlx

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -48,7 +48,6 @@ path = [
   "lib/vssh/.checksrc",
   "lib/vtls/.checksrc",
   "src/.checksrc",
-  "tests/libtest/.checksrc",
   "tests/server/.checksrc",
 ]
 SPDX-FileCopyrightText = "Daniel Stenberg, <daniel@haxx.se>, et al."

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -47,6 +47,7 @@ path = [
   "lib/vssh/.checksrc",
   "lib/vtls/.checksrc",
   "src/.checksrc",
+  "tests/server/.checksrc",
 ]
 SPDX-FileCopyrightText = "Daniel Stenberg, <daniel@haxx.se>, et al."
 SPDX-License-Identifier = "curl"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -43,6 +43,7 @@ path = [
   # checksrc control files
   "docs/examples/.checksrc",
   "lib/.checksrc",
+  "lib/curlx/.checksrc",
   "lib/vauth/.checksrc",
   "lib/vquic/.checksrc",
   "lib/vssh/.checksrc",

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -48,7 +48,6 @@ path = [
   "lib/vssh/.checksrc",
   "lib/vtls/.checksrc",
   "src/.checksrc",
-  "tests/server/.checksrc",
 ]
 SPDX-FileCopyrightText = "Daniel Stenberg, <daniel@haxx.se>, et al."
 SPDX-License-Identifier = "curl"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -40,7 +40,6 @@ path = [
   "tests/data/test**",
   "tests/valgrind.supp",
   # checksrc control files
-  "docs/examples/.checksrc",
   "lib/.checksrc",
   "lib/curlx/.checksrc",
   "lib/vauth/.checksrc",

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -38,7 +38,6 @@ path = [
   "renovate.json",
   "tests/certs/**",
   "tests/data/test**",
-  "tests/stunnel.pem",
   "tests/valgrind.supp",
   # checksrc control files
   "docs/examples/.checksrc",

--- a/docs/examples/.checksrc
+++ b/docs/examples/.checksrc
@@ -1,3 +1,2 @@
-disable BANNEDFUNC
 disable ERRNOVAR
 disable TYPEDEFSTRUCT

--- a/docs/examples/.checksrc
+++ b/docs/examples/.checksrc
@@ -1,1 +1,0 @@
-disable ERRNOVAR

--- a/docs/examples/.checksrc
+++ b/docs/examples/.checksrc
@@ -1,2 +1,1 @@
 disable ERRNOVAR
-disable TYPEDEFSTRUCT

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -24,8 +24,7 @@
 
 AUTOMAKE_OPTIONS = foreign nostdinc
 
-EXTRA_DIST = README.md Makefile.example CMakeLists.txt \
-  $(COMPLICATED_EXAMPLES) .checksrc
+EXTRA_DIST = README.md Makefile.example CMakeLists.txt $(COMPLICATED_EXAMPLES)
 
 # Specify our include paths here, and do it relative to $(top_srcdir) and
 # $(top_builddir), to ensure that these paths which belong to the library

--- a/docs/examples/Makefile.am
+++ b/docs/examples/Makefile.am
@@ -24,7 +24,7 @@
 
 AUTOMAKE_OPTIONS = foreign nostdinc
 
-EXTRA_DIST = README.md Makefile.example CMakeLists.txt $(COMPLICATED_EXAMPLES)
+EXTRA_DIST = CMakeLists.txt README.md Makefile.example $(COMPLICATED_EXAMPLES)
 
 # Specify our include paths here, and do it relative to $(top_srcdir) and
 # $(top_builddir), to ensure that these paths which belong to the library

--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -55,15 +55,15 @@ static void sighandler(int dummy)
 }
 
 /* resizable buffer */
-typedef struct {
+struct memory {
   char *buf;
   size_t size;
-} memory;
+};
 
 static size_t grow_buffer(void *contents, size_t sz, size_t nmemb, void *ctx)
 {
   size_t realsize = sz * nmemb;
-  memory *mem = (memory*) ctx;
+  struct memory *mem = (struct memory*) ctx;
   char *ptr = realloc(mem->buf, mem->size + realsize);
   if(!ptr) {
     /* out of memory */
@@ -79,14 +79,14 @@ static size_t grow_buffer(void *contents, size_t sz, size_t nmemb, void *ctx)
 static CURL *make_handle(const char *url)
 {
   CURL *handle = curl_easy_init();
-  memory *mem;
+  struct memory *mem;
 
   /* Important: use HTTP2 over HTTPS */
   curl_easy_setopt(handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
   curl_easy_setopt(handle, CURLOPT_URL, url);
 
   /* buffer body */
-  mem = malloc(sizeof(memory));
+  mem = malloc(sizeof(struct memory));
   mem->size = 0;
   mem->buf = malloc(1);
   curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, grow_buffer);
@@ -119,7 +119,8 @@ static CURL *make_handle(const char *url)
 }
 
 /* HREF finder implemented in libxml2 but could be any HTML parser */
-static size_t follow_links(CURLM *multi_handle, memory *mem, const char *url)
+static size_t follow_links(CURLM *multi_handle, struct memory *mem,
+                           const char *url)
 {
   int opts = HTML_PARSE_NOBLANKS | HTML_PARSE_NOERROR | \
              HTML_PARSE_NOWARNING | HTML_PARSE_NONET;
@@ -213,7 +214,7 @@ int main(void)
       if(m->msg == CURLMSG_DONE) {
         CURL *handle = m->easy_handle;
         char *url;
-        memory *mem;
+        struct memory *mem;
         curl_easy_getinfo(handle, CURLINFO_PRIVATE, &mem);
         curl_easy_getinfo(handle, CURLINFO_EFFECTIVE_URL, &url);
         if(m->data.result == CURLE_OK) {

--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -86,7 +86,7 @@ static CURL *make_handle(const char *url)
   curl_easy_setopt(handle, CURLOPT_URL, url);
 
   /* buffer body */
-  mem = malloc(sizeof(struct memory));
+  mem = malloc(sizeof(*mem));
   mem->size = 0;
   mem->buf = malloc(1);
   curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, grow_buffer);

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -90,22 +90,22 @@ struct GlobalInfo {
 
 
 /* Information associated with a specific easy handle */
-typedef struct _ConnInfo {
+struct ConnInfo {
   CURL *easy;
   char *url;
   struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
-} ConnInfo;
+};
 
 
 /* Information associated with a specific socket */
-typedef struct _SockInfo {
+struct SockInfo {
   curl_socket_t sockfd;
   CURL *easy;
   int action;
   long timeout;
   struct GlobalInfo *global;
-} SockInfo;
+};
 
 #define mycase(code) \
   case code: s = __STRING(code)
@@ -174,7 +174,7 @@ static void check_multi_info(struct GlobalInfo *g)
   char *eff_url;
   CURLMsg *msg;
   int msgs_left;
-  ConnInfo *conn;
+  struct ConnInfo *conn;
   CURL *easy;
   CURLcode res;
 
@@ -247,7 +247,7 @@ static void timer_cb(struct GlobalInfo *g, int revents)
 
 
 /* Clean up the SockInfo structure */
-static void remsock(SockInfo *f, struct GlobalInfo *g)
+static void remsock(struct SockInfo *f, struct GlobalInfo *g)
 {
   if(f) {
     if(f->sockfd) {
@@ -262,7 +262,7 @@ static void remsock(SockInfo *f, struct GlobalInfo *g)
 
 
 /* Assign information to a SockInfo structure */
-static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
+static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
                     struct GlobalInfo *g)
 {
   struct epoll_event ev;
@@ -292,7 +292,7 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
 static void addsock(curl_socket_t s, CURL *easy, int action,
                     struct GlobalInfo *g)
 {
-  SockInfo *fdp = (SockInfo*)calloc(1, sizeof(SockInfo));
+  struct SockInfo *fdp = (struct SockInfo*)calloc(1, sizeof(struct SockInfo));
 
   fdp->global = g;
   setsock(fdp, s, easy, action, g);
@@ -303,7 +303,7 @@ static void addsock(curl_socket_t s, CURL *easy, int action,
 static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
   struct GlobalInfo *g = (struct GlobalInfo*) cbp;
-  SockInfo *fdp = (SockInfo*) sockp;
+  struct SockInfo *fdp = (struct SockInfo*) sockp;
   const char *whatstr[]={ "none", "IN", "OUT", "INOUT", "REMOVE" };
 
   fprintf(MSG_OUT,
@@ -342,7 +342,7 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
 static int prog_cb(void *p, double dltotal, double dlnow, double ult,
                    double uln)
 {
-  ConnInfo *conn = (ConnInfo *)p;
+  struct ConnInfo *conn = (struct ConnInfo *)p;
   (void)ult;
   (void)uln;
 
@@ -354,10 +354,10 @@ static int prog_cb(void *p, double dltotal, double dlnow, double ult,
 /* Create a new easy handle, and add it to the global curl_multi */
 static void new_conn(const char *url, struct GlobalInfo *g)
 {
-  ConnInfo *conn;
+  struct ConnInfo *conn;
   CURLMcode rc;
 
-  conn = (ConnInfo*)calloc(1, sizeof(ConnInfo));
+  conn = (struct ConnInfo*)calloc(1, sizeof(*conn));
   conn->error[0] = '\0';
 
   conn->easy = curl_easy_init();

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -160,7 +160,7 @@ static int multi_timer_cb(CURLM *multi, long timeout_ms, struct GlobalInfo *g)
     its.it_value.tv_nsec = 1;
   }
   else {
-    memset(&its, 0, sizeof(struct itimerspec));
+    memset(&its, 0, sizeof(its));
   }
 
   timerfd_settime(g->tfd, /* flags= */0, &its, NULL);
@@ -209,7 +209,7 @@ static void event_cb(struct GlobalInfo *g, int fd, int revents)
   check_multi_info(g);
   if(g->still_running <= 0) {
     fprintf(MSG_OUT, "last transfer done, kill timeout\n");
-    memset(&its, 0, sizeof(struct itimerspec));
+    memset(&its, 0, sizeof(its));
     timerfd_settime(g->tfd, 0, &its, NULL);
   }
 }
@@ -485,7 +485,7 @@ int main(int argc, char **argv)
     return 1;
   }
 
-  memset(&its, 0, sizeof(struct itimerspec));
+  memset(&its, 0, sizeof(its));
   its.it_interval.tv_sec = 0;
   its.it_value.tv_sec = 1;
   timerfd_settime(g.tfd, 0, &its, NULL);

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -514,6 +514,7 @@ int main(int argc, char **argv)
     int err = epoll_wait(g.epfd, events,
                          sizeof(events)/sizeof(struct epoll_event), 10000);
     if(err == -1) {
+      /* !checksrc! disable ERRNOVAR 1 */
       if(errno == EINTR) {
         fprintf(MSG_OUT, "note: wait interrupted\n");
         continue;

--- a/docs/examples/ephiperfifo.c
+++ b/docs/examples/ephiperfifo.c
@@ -79,35 +79,32 @@ callback.
 
 
 /* Global information, common to all connections */
-typedef struct _GlobalInfo
-{
+struct GlobalInfo {
   int epfd;    /* epoll filedescriptor */
   int tfd;     /* timer filedescriptor */
   int fifofd;  /* fifo filedescriptor */
   CURLM *multi;
   int still_running;
   FILE *input;
-} GlobalInfo;
+};
 
 
 /* Information associated with a specific easy handle */
-typedef struct _ConnInfo
-{
+typedef struct _ConnInfo {
   CURL *easy;
   char *url;
-  GlobalInfo *global;
+  struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
 } ConnInfo;
 
 
 /* Information associated with a specific socket */
-typedef struct _SockInfo
-{
+typedef struct _SockInfo {
   curl_socket_t sockfd;
   CURL *easy;
   int action;
   long timeout;
-  GlobalInfo *global;
+  struct GlobalInfo *global;
 } SockInfo;
 
 #define mycase(code) \
@@ -136,12 +133,12 @@ static void mcode_or_die(const char *where, CURLMcode code)
   }
 }
 
-static void timer_cb(GlobalInfo* g, int revents);
+static void timer_cb(struct GlobalInfo *g, int revents);
 
 /* Update the timer after curl_multi library does its thing. Curl informs the
  * application through this callback what it wants the new timeout to be,
  * after it does some work. */
-static int multi_timer_cb(CURLM *multi, long timeout_ms, GlobalInfo *g)
+static int multi_timer_cb(CURLM *multi, long timeout_ms, struct GlobalInfo *g)
 {
   struct itimerspec its;
 
@@ -172,7 +169,7 @@ static int multi_timer_cb(CURLM *multi, long timeout_ms, GlobalInfo *g)
 
 
 /* Check for completed transfers, and remove their easy handles */
-static void check_multi_info(GlobalInfo *g)
+static void check_multi_info(struct GlobalInfo *g)
 {
   char *eff_url;
   CURLMsg *msg;
@@ -198,7 +195,7 @@ static void check_multi_info(GlobalInfo *g)
 }
 
 /* Called by libevent when we get action on a multi socket filedescriptor */
-static void event_cb(GlobalInfo *g, int fd, int revents)
+static void event_cb(struct GlobalInfo *g, int fd, int revents)
 {
   CURLMcode rc;
   struct itimerspec its;
@@ -218,7 +215,7 @@ static void event_cb(GlobalInfo *g, int fd, int revents)
 }
 
 /* Called by main loop when our timeout expires */
-static void timer_cb(GlobalInfo* g, int revents)
+static void timer_cb(struct GlobalInfo *g, int revents)
 {
   CURLMcode rc;
   uint64_t count = 0;
@@ -250,7 +247,7 @@ static void timer_cb(GlobalInfo* g, int revents)
 
 
 /* Clean up the SockInfo structure */
-static void remsock(SockInfo *f, GlobalInfo* g)
+static void remsock(SockInfo *f, struct GlobalInfo *g)
 {
   if(f) {
     if(f->sockfd) {
@@ -266,7 +263,7 @@ static void remsock(SockInfo *f, GlobalInfo* g)
 
 /* Assign information to a SockInfo structure */
 static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
-                    GlobalInfo *g)
+                    struct GlobalInfo *g)
 {
   struct epoll_event ev;
   int kind = ((act & CURL_POLL_IN) ? EPOLLIN : 0) |
@@ -292,7 +289,8 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
 
 
 /* Initialize a new SockInfo structure */
-static void addsock(curl_socket_t s, CURL *easy, int action, GlobalInfo *g)
+static void addsock(curl_socket_t s, CURL *easy, int action,
+                    struct GlobalInfo *g)
 {
   SockInfo *fdp = (SockInfo*)calloc(1, sizeof(SockInfo));
 
@@ -304,7 +302,7 @@ static void addsock(curl_socket_t s, CURL *easy, int action, GlobalInfo *g)
 /* CURLMOPT_SOCKETFUNCTION */
 static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
-  GlobalInfo *g = (GlobalInfo*) cbp;
+  struct GlobalInfo *g = (struct GlobalInfo*) cbp;
   SockInfo *fdp = (SockInfo*) sockp;
   const char *whatstr[]={ "none", "IN", "OUT", "INOUT", "REMOVE" };
 
@@ -354,7 +352,7 @@ static int prog_cb(void *p, double dltotal, double dlnow, double ult,
 
 
 /* Create a new easy handle, and add it to the global curl_multi */
-static void new_conn(const char *url, GlobalInfo *g)
+static void new_conn(const char *url, struct GlobalInfo *g)
 {
   ConnInfo *conn;
   CURLMcode rc;
@@ -391,7 +389,7 @@ static void new_conn(const char *url, GlobalInfo *g)
 }
 
 /* This gets called whenever data is received from the fifo */
-static void fifo_cb(GlobalInfo* g, int revents)
+static void fifo_cb(struct GlobalInfo *g, int revents)
 {
   char s[1024];
   long int rv = 0;
@@ -411,7 +409,7 @@ static void fifo_cb(GlobalInfo* g, int revents)
 
 /* Create a named pipe and tell libevent to monitor it */
 static const char *fifo = "hiper.fifo";
-static int init_fifo(GlobalInfo *g)
+static int init_fifo(struct GlobalInfo *g)
 {
   struct stat st;
   curl_socket_t sockfd;
@@ -447,7 +445,7 @@ static int init_fifo(GlobalInfo *g)
   return 0;
 }
 
-static void clean_fifo(GlobalInfo *g)
+static void clean_fifo(struct GlobalInfo *g)
 {
   epoll_ctl(g->epfd, EPOLL_CTL_DEL, g->fifofd, NULL);
   fclose(g->input);
@@ -464,7 +462,7 @@ void sigint_handler(int signo)
 
 int main(int argc, char **argv)
 {
-  GlobalInfo g;
+  struct GlobalInfo g;
   struct itimerspec its;
   struct epoll_event ev;
   struct epoll_event events[10];
@@ -474,7 +472,7 @@ int main(int argc, char **argv)
   g_should_exit_ = 0;
   signal(SIGINT, sigint_handler);
 
-  memset(&g, 0, sizeof(GlobalInfo));
+  memset(&g, 0, sizeof(g));
   g.epfd = epoll_create1(EPOLL_CLOEXEC);
   if(g.epfd == -1) {
     perror("epoll_create1 failed");

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -90,16 +90,16 @@ struct GlobalInfo {
 
 
 /* Information associated with a specific easy handle */
-typedef struct _ConnInfo {
+struct ConnInfo {
   CURL *easy;
   char *url;
   struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
-} ConnInfo;
+};
 
 
 /* Information associated with a specific socket */
-typedef struct _SockInfo {
+struct SockInfo {
   curl_socket_t sockfd;
   CURL *easy;
   int action;
@@ -107,7 +107,7 @@ typedef struct _SockInfo {
   struct ev_io ev;
   int evset;
   struct GlobalInfo *global;
-} SockInfo;
+};
 
 static void timer_cb(EV_P_ struct ev_timer *w, int revents);
 
@@ -172,7 +172,7 @@ static void check_multi_info(struct GlobalInfo *g)
   char *eff_url;
   CURLMsg *msg;
   int msgs_left;
-  ConnInfo *conn;
+  struct ConnInfo *conn;
   CURL *easy;
   CURLcode res;
 
@@ -232,7 +232,7 @@ static void timer_cb(EV_P_ struct ev_timer *w, int revents)
 }
 
 /* Clean up the SockInfo structure */
-static void remsock(SockInfo *f, struct GlobalInfo *g)
+static void remsock(struct SockInfo *f, struct GlobalInfo *g)
 {
   printf("%s  \n", __PRETTY_FUNCTION__);
   if(f) {
@@ -245,7 +245,7 @@ static void remsock(SockInfo *f, struct GlobalInfo *g)
 
 
 /* Assign information to a SockInfo structure */
-static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
+static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
                     struct GlobalInfo *g)
 {
   int kind = ((act & CURL_POLL_IN) ? EV_READ : 0) |
@@ -270,7 +270,7 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
 static void addsock(curl_socket_t s, CURL *easy, int action,
                     struct GlobalInfo *g)
 {
-  SockInfo *fdp = calloc(1, sizeof(SockInfo));
+  struct SockInfo *fdp = calloc(1, sizeof(struct SockInfo));
 
   fdp->global = g;
   setsock(fdp, s, easy, action, g);
@@ -281,7 +281,7 @@ static void addsock(curl_socket_t s, CURL *easy, int action,
 static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
   struct GlobalInfo *g = (struct GlobalInfo*) cbp;
-  SockInfo *fdp = (SockInfo*) sockp;
+  struct SockInfo *fdp = (struct SockInfo*) sockp;
   const char *whatstr[]={ "none", "IN", "OUT", "INOUT", "REMOVE"};
 
   printf("%s e %p s %i what %i cbp %p sockp %p\n",
@@ -313,7 +313,7 @@ static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
 {
   size_t realsize = size * nmemb;
-  ConnInfo *conn = (ConnInfo*) data;
+  struct ConnInfo *conn = (struct ConnInfo*) data;
   (void)ptr;
   (void)conn;
   return realsize;
@@ -323,7 +323,7 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
 static int xferinfo_cb(void *p, curl_off_t dltotal, curl_off_t dlnow,
                        curl_off_t ult, curl_off_t uln)
 {
-  ConnInfo *conn = (ConnInfo *)p;
+  struct ConnInfo *conn = (struct ConnInfo *)p;
   (void)ult;
   (void)uln;
 
@@ -336,10 +336,10 @@ static int xferinfo_cb(void *p, curl_off_t dltotal, curl_off_t dlnow,
 /* Create a new easy handle, and add it to the global curl_multi */
 static void new_conn(const char *url, struct GlobalInfo *g)
 {
-  ConnInfo *conn;
+  struct ConnInfo *conn;
   CURLMcode rc;
 
-  conn = calloc(1, sizeof(ConnInfo));
+  conn = calloc(1, sizeof(*conn));
   conn->error[0]='\0';
 
   conn->easy = curl_easy_init();

--- a/docs/examples/evhiperfifo.c
+++ b/docs/examples/evhiperfifo.c
@@ -79,43 +79,40 @@ callback.
 
 
 /* Global information, common to all connections */
-typedef struct _GlobalInfo
-{
+struct GlobalInfo {
   struct ev_loop *loop;
   struct ev_io fifo_event;
   struct ev_timer timer_event;
   CURLM *multi;
   int still_running;
   FILE *input;
-} GlobalInfo;
+};
 
 
 /* Information associated with a specific easy handle */
-typedef struct _ConnInfo
-{
+typedef struct _ConnInfo {
   CURL *easy;
   char *url;
-  GlobalInfo *global;
+  struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
 } ConnInfo;
 
 
 /* Information associated with a specific socket */
-typedef struct _SockInfo
-{
+typedef struct _SockInfo {
   curl_socket_t sockfd;
   CURL *easy;
   int action;
   long timeout;
   struct ev_io ev;
   int evset;
-  GlobalInfo *global;
+  struct GlobalInfo *global;
 } SockInfo;
 
 static void timer_cb(EV_P_ struct ev_timer *w, int revents);
 
 /* Update the event timer after curl_multi library calls */
-static int multi_timer_cb(CURLM *multi, long timeout_ms, GlobalInfo *g)
+static int multi_timer_cb(CURLM *multi, long timeout_ms, struct GlobalInfo *g)
 {
   (void)multi;
   printf("%s %li\n", __PRETTY_FUNCTION__, timeout_ms);
@@ -170,7 +167,7 @@ static void mcode_or_die(const char *where, CURLMcode code)
 
 
 /* Check for completed transfers, and remove their easy handles */
-static void check_multi_info(GlobalInfo *g)
+static void check_multi_info(struct GlobalInfo *g)
 {
   char *eff_url;
   CURLMsg *msg;
@@ -200,12 +197,12 @@ static void check_multi_info(GlobalInfo *g)
 /* Called by libevent when we get action on a multi socket */
 static void event_cb(EV_P_ struct ev_io *w, int revents)
 {
-  GlobalInfo *g;
+  struct GlobalInfo *g;
   CURLMcode rc;
   int action;
 
   printf("%s  w %p revents %i\n", __PRETTY_FUNCTION__, (void *)w, revents);
-  g = (GlobalInfo*) w->data;
+  g = (struct GlobalInfo*) w->data;
 
   action = ((revents & EV_READ) ? CURL_POLL_IN : 0) |
            ((revents & EV_WRITE) ? CURL_POLL_OUT : 0);
@@ -221,12 +218,12 @@ static void event_cb(EV_P_ struct ev_io *w, int revents)
 /* Called by libevent when our timeout expires */
 static void timer_cb(EV_P_ struct ev_timer *w, int revents)
 {
-  GlobalInfo *g;
+  struct GlobalInfo *g;
   CURLMcode rc;
 
   printf("%s  w %p revents %i\n", __PRETTY_FUNCTION__, (void *)w, revents);
 
-  g = (GlobalInfo *)w->data;
+  g = (struct GlobalInfo *)w->data;
 
   rc = curl_multi_socket_action(g->multi, CURL_SOCKET_TIMEOUT, 0,
                                 &g->still_running);
@@ -235,7 +232,7 @@ static void timer_cb(EV_P_ struct ev_timer *w, int revents)
 }
 
 /* Clean up the SockInfo structure */
-static void remsock(SockInfo *f, GlobalInfo *g)
+static void remsock(SockInfo *f, struct GlobalInfo *g)
 {
   printf("%s  \n", __PRETTY_FUNCTION__);
   if(f) {
@@ -249,7 +246,7 @@ static void remsock(SockInfo *f, GlobalInfo *g)
 
 /* Assign information to a SockInfo structure */
 static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
-                    GlobalInfo *g)
+                    struct GlobalInfo *g)
 {
   int kind = ((act & CURL_POLL_IN) ? EV_READ : 0) |
              ((act & CURL_POLL_OUT) ? EV_WRITE : 0);
@@ -270,7 +267,8 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
 
 
 /* Initialize a new SockInfo structure */
-static void addsock(curl_socket_t s, CURL *easy, int action, GlobalInfo *g)
+static void addsock(curl_socket_t s, CURL *easy, int action,
+                    struct GlobalInfo *g)
 {
   SockInfo *fdp = calloc(1, sizeof(SockInfo));
 
@@ -282,7 +280,7 @@ static void addsock(curl_socket_t s, CURL *easy, int action, GlobalInfo *g)
 /* CURLMOPT_SOCKETFUNCTION */
 static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
-  GlobalInfo *g = (GlobalInfo*) cbp;
+  struct GlobalInfo *g = (struct GlobalInfo*) cbp;
   SockInfo *fdp = (SockInfo*) sockp;
   const char *whatstr[]={ "none", "IN", "OUT", "INOUT", "REMOVE"};
 
@@ -336,7 +334,7 @@ static int xferinfo_cb(void *p, curl_off_t dltotal, curl_off_t dlnow,
 
 
 /* Create a new easy handle, and add it to the global curl_multi */
-static void new_conn(const char *url, GlobalInfo *g)
+static void new_conn(const char *url, struct GlobalInfo *g)
 {
   ConnInfo *conn;
   CURLMcode rc;
@@ -378,7 +376,7 @@ static void fifo_cb(EV_P_ struct ev_io *w, int revents)
   char s[1024];
   long int rv = 0;
   int n = 0;
-  GlobalInfo *g = (GlobalInfo *)w->data;
+  struct GlobalInfo *g = (struct GlobalInfo *)w->data;
 
   (void)revents;
 
@@ -395,7 +393,7 @@ static void fifo_cb(EV_P_ struct ev_io *w, int revents)
 }
 
 /* Create a named pipe and tell libevent to monitor it */
-static int init_fifo(GlobalInfo *g)
+static int init_fifo(struct GlobalInfo *g)
 {
   struct stat st;
   static const char *fifo = "hiper.fifo";
@@ -429,11 +427,11 @@ static int init_fifo(GlobalInfo *g)
 
 int main(int argc, char **argv)
 {
-  GlobalInfo g;
+  struct GlobalInfo g;
   (void)argc;
   (void)argv;
 
-  memset(&g, 0, sizeof(GlobalInfo));
+  memset(&g, 0, sizeof(g));
   g.loop = ev_default_loop(0);
 
   if(init_fifo(&g))

--- a/docs/examples/ghiper.c
+++ b/docs/examples/ghiper.c
@@ -77,15 +77,15 @@ struct GlobalInfo {
 };
 
 /* Information associated with a specific easy handle */
-typedef struct _ConnInfo {
+struct ConnInfo {
   CURL *easy;
   char *url;
   struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
-} ConnInfo;
+};
 
 /* Information associated with a specific socket */
-typedef struct _SockInfo {
+struct SockInfo {
   curl_socket_t sockfd;
   CURL *easy;
   int action;
@@ -93,7 +93,7 @@ typedef struct _SockInfo {
   GIOChannel *ch;
   guint ev;
   struct GlobalInfo *global;
-} SockInfo;
+};
 
 /* Die if we get a bad CURLMcode somewhere */
 static void mcode_or_die(const char *where, CURLMcode code)
@@ -127,7 +127,7 @@ static void check_multi_info(struct GlobalInfo *g)
       CURL *easy = msg->easy_handle;
       CURLcode res = msg->data.result;
       char *eff_url;
-      ConnInfo *conn;
+      struct ConnInfo *conn;
       curl_easy_getinfo(easy, CURLINFO_PRIVATE, &conn);
       curl_easy_getinfo(easy, CURLINFO_EFFECTIVE_URL, &eff_url);
       MSG_OUT("DONE: %s => (%d) %s\n", eff_url, res, conn->error);
@@ -202,7 +202,7 @@ static gboolean event_cb(GIOChannel *ch, GIOCondition condition, gpointer data)
 }
 
 /* Clean up the SockInfo structure */
-static void remsock(SockInfo *f)
+static void remsock(struct SockInfo *f)
 {
   if(!f) {
     return;
@@ -214,7 +214,7 @@ static void remsock(SockInfo *f)
 }
 
 /* Assign information to a SockInfo structure */
-static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
+static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
                     struct GlobalInfo *g)
 {
   GIOCondition kind =
@@ -234,7 +234,7 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
 static void addsock(curl_socket_t s, CURL *easy, int action,
                     struct GlobalInfo *g)
 {
-  SockInfo *fdp = g_malloc0(sizeof(SockInfo));
+  struct SockInfo *fdp = g_malloc0(sizeof(struct SockInfo));
 
   fdp->global = g;
   fdp->ch = g_io_channel_unix_new(s);
@@ -246,7 +246,7 @@ static void addsock(curl_socket_t s, CURL *easy, int action,
 static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
   struct GlobalInfo *g = (struct GlobalInfo*) cbp;
-  SockInfo *fdp = (SockInfo*) sockp;
+  struct SockInfo *fdp = (struct SockInfo*) sockp;
   static const char *whatstr[]={ "none", "IN", "OUT", "INOUT", "REMOVE" };
 
   MSG_OUT("socket callback: s=%d e=%p what=%s ", s, e, whatstr[what]);
@@ -274,7 +274,7 @@ static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
 {
   size_t realsize = size * nmemb;
-  ConnInfo *conn = (ConnInfo*) data;
+  struct ConnInfo *conn = (struct ConnInfo*) data;
   (void)ptr;
   (void)conn;
   return realsize;
@@ -284,7 +284,7 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
 static int xferinfo_cb(void *p, curl_off_t dltotal, curl_off_t dlnow,
                        curl_off_t ult, curl_off_t uln)
 {
-  ConnInfo *conn = (ConnInfo *)p;
+  struct ConnInfo *conn = (struct ConnInfo *)p;
   (void)ult;
   (void)uln;
 
@@ -296,10 +296,10 @@ static int xferinfo_cb(void *p, curl_off_t dltotal, curl_off_t dlnow,
 /* Create a new easy handle, and add it to the global curl_multi */
 static void new_conn(const char *url, struct GlobalInfo *g)
 {
-  ConnInfo *conn;
+  struct ConnInfo *conn;
   CURLMcode rc;
 
-  conn = g_malloc0(sizeof(ConnInfo));
+  conn = g_malloc0(sizeof(*conn));
   conn->error[0] = '\0';
   conn->easy = curl_easy_init();
   if(!conn->easy) {

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -78,8 +78,7 @@ callback.
 
 
 /* Global information, common to all connections */
-typedef struct _GlobalInfo
-{
+struct GlobalInfo {
   struct event_base *evbase;
   struct event fifo_event;
   struct event timer_event;
@@ -87,28 +86,26 @@ typedef struct _GlobalInfo
   int still_running;
   FILE *input;
   int stopped;
-} GlobalInfo;
+};
 
 
 /* Information associated with a specific easy handle */
-typedef struct _ConnInfo
-{
+typedef struct _ConnInfo {
   CURL *easy;
   char *url;
-  GlobalInfo *global;
+  struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
 } ConnInfo;
 
 
 /* Information associated with a specific socket */
-typedef struct _SockInfo
-{
+typedef struct _SockInfo {
   curl_socket_t sockfd;
   CURL *easy;
   int action;
   long timeout;
   struct event ev;
-  GlobalInfo *global;
+  struct GlobalInfo *global;
 } SockInfo;
 
 #define mycase(code) \
@@ -139,7 +136,7 @@ static void mcode_or_die(const char *where, CURLMcode code)
 
 
 /* Update the event timer after curl_multi library calls */
-static int multi_timer_cb(CURLM *multi, long timeout_ms, GlobalInfo *g)
+static int multi_timer_cb(CURLM *multi, long timeout_ms, struct GlobalInfo *g)
 {
   struct timeval timeout;
   (void)multi;
@@ -163,7 +160,7 @@ static int multi_timer_cb(CURLM *multi, long timeout_ms, GlobalInfo *g)
 
 
 /* Check for completed transfers, and remove their easy handles */
-static void check_multi_info(GlobalInfo *g)
+static void check_multi_info(struct GlobalInfo *g)
 {
   char *eff_url;
   CURLMsg *msg;
@@ -195,7 +192,7 @@ static void check_multi_info(GlobalInfo *g)
 /* Called by libevent when we get action on a multi socket */
 static void event_cb(int fd, short kind, void *userp)
 {
-  GlobalInfo *g = (GlobalInfo*) userp;
+  struct GlobalInfo *g = (struct GlobalInfo*) userp;
   CURLMcode rc;
 
   int action =
@@ -219,7 +216,7 @@ static void event_cb(int fd, short kind, void *userp)
 /* Called by libevent when our timeout expires */
 static void timer_cb(int fd, short kind, void *userp)
 {
-  GlobalInfo *g = (GlobalInfo *)userp;
+  struct GlobalInfo *g = (struct GlobalInfo *)userp;
   CURLMcode rc;
   (void)fd;
   (void)kind;
@@ -247,7 +244,7 @@ static void remsock(SockInfo *f)
 
 /* Assign information to a SockInfo structure */
 static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
-                    GlobalInfo *g)
+                    struct GlobalInfo *g)
 {
   int kind =
      ((act & CURL_POLL_IN) ? EV_READ : 0) |
@@ -266,7 +263,8 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
 
 
 /* Initialize a new SockInfo structure */
-static void addsock(curl_socket_t s, CURL *easy, int action, GlobalInfo *g)
+static void addsock(curl_socket_t s, CURL *easy, int action,
+                    struct GlobalInfo *g)
 {
   SockInfo *fdp = calloc(1, sizeof(SockInfo));
 
@@ -278,7 +276,7 @@ static void addsock(curl_socket_t s, CURL *easy, int action, GlobalInfo *g)
 /* CURLMOPT_SOCKETFUNCTION */
 static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
-  GlobalInfo *g = (GlobalInfo*) cbp;
+  struct GlobalInfo *g = (struct GlobalInfo*) cbp;
   SockInfo *fdp = (SockInfo*) sockp;
   const char *whatstr[]={ "none", "IN", "OUT", "INOUT", "REMOVE" };
 
@@ -329,7 +327,7 @@ static int xferinfo_cb(void *p, curl_off_t dltotal, curl_off_t dlnow,
 
 
 /* Create a new easy handle, and add it to the global curl_multi */
-static void new_conn(const char *url, GlobalInfo *g)
+static void new_conn(const char *url, struct GlobalInfo *g)
 {
   ConnInfo *conn;
   CURLMcode rc;
@@ -369,7 +367,7 @@ static void fifo_cb(int fd, short event, void *arg)
   char s[1024];
   long int rv = 0;
   int n = 0;
-  GlobalInfo *g = (GlobalInfo *)arg;
+  struct GlobalInfo *g = (struct GlobalInfo *)arg;
   (void)fd;
   (void)event;
 
@@ -393,7 +391,7 @@ static void fifo_cb(int fd, short event, void *arg)
 
 /* Create a named pipe and tell libevent to monitor it */
 static const char *fifo = "hiper.fifo";
-static int init_fifo(GlobalInfo *g)
+static int init_fifo(struct GlobalInfo *g)
 {
   struct stat st;
   curl_socket_t sockfd;
@@ -425,7 +423,7 @@ static int init_fifo(GlobalInfo *g)
   return 0;
 }
 
-static void clean_fifo(GlobalInfo *g)
+static void clean_fifo(struct GlobalInfo *g)
 {
     event_del(&g->fifo_event);
     fclose(g->input);
@@ -434,11 +432,11 @@ static void clean_fifo(GlobalInfo *g)
 
 int main(int argc, char **argv)
 {
-  GlobalInfo g;
+  struct GlobalInfo g;
   (void)argc;
   (void)argv;
 
-  memset(&g, 0, sizeof(GlobalInfo));
+  memset(&g, 0, sizeof(g));
   g.evbase = event_base_new();
   if(init_fifo(&g))
     return 1;

--- a/docs/examples/hiperfifo.c
+++ b/docs/examples/hiperfifo.c
@@ -90,23 +90,23 @@ struct GlobalInfo {
 
 
 /* Information associated with a specific easy handle */
-typedef struct _ConnInfo {
+struct ConnInfo {
   CURL *easy;
   char *url;
   struct GlobalInfo *global;
   char error[CURL_ERROR_SIZE];
-} ConnInfo;
+};
 
 
 /* Information associated with a specific socket */
-typedef struct _SockInfo {
+struct SockInfo {
   curl_socket_t sockfd;
   CURL *easy;
   int action;
   long timeout;
   struct event ev;
   struct GlobalInfo *global;
-} SockInfo;
+};
 
 #define mycase(code) \
   case code: s = __STRING(code)
@@ -165,7 +165,7 @@ static void check_multi_info(struct GlobalInfo *g)
   char *eff_url;
   CURLMsg *msg;
   int msgs_left;
-  ConnInfo *conn;
+  struct ConnInfo *conn;
   CURL *easy;
   CURLcode res;
 
@@ -230,7 +230,7 @@ static void timer_cb(int fd, short kind, void *userp)
 
 
 /* Clean up the SockInfo structure */
-static void remsock(SockInfo *f)
+static void remsock(struct SockInfo *f)
 {
   if(f) {
     if(event_initialized(&f->ev)) {
@@ -243,7 +243,7 @@ static void remsock(SockInfo *f)
 
 
 /* Assign information to a SockInfo structure */
-static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
+static void setsock(struct SockInfo *f, curl_socket_t s, CURL *e, int act,
                     struct GlobalInfo *g)
 {
   int kind =
@@ -266,7 +266,7 @@ static void setsock(SockInfo *f, curl_socket_t s, CURL *e, int act,
 static void addsock(curl_socket_t s, CURL *easy, int action,
                     struct GlobalInfo *g)
 {
-  SockInfo *fdp = calloc(1, sizeof(SockInfo));
+  struct SockInfo *fdp = calloc(1, sizeof(struct SockInfo));
 
   fdp->global = g;
   setsock(fdp, s, easy, action, g);
@@ -277,7 +277,7 @@ static void addsock(curl_socket_t s, CURL *easy, int action,
 static int sock_cb(CURL *e, curl_socket_t s, int what, void *cbp, void *sockp)
 {
   struct GlobalInfo *g = (struct GlobalInfo*) cbp;
-  SockInfo *fdp = (SockInfo*) sockp;
+  struct SockInfo *fdp = (struct SockInfo*) sockp;
   const char *whatstr[]={ "none", "IN", "OUT", "INOUT", "REMOVE" };
 
   fprintf(MSG_OUT,
@@ -316,7 +316,7 @@ static size_t write_cb(void *ptr, size_t size, size_t nmemb, void *data)
 static int xferinfo_cb(void *p, curl_off_t dltotal, curl_off_t dlnow,
                        curl_off_t ult, curl_off_t uln)
 {
-  ConnInfo *conn = (ConnInfo *)p;
+  struct ConnInfo *conn = (struct ConnInfo *)p;
   (void)ult;
   (void)uln;
 
@@ -329,10 +329,10 @@ static int xferinfo_cb(void *p, curl_off_t dltotal, curl_off_t dlnow,
 /* Create a new easy handle, and add it to the global curl_multi */
 static void new_conn(const char *url, struct GlobalInfo *g)
 {
-  ConnInfo *conn;
+  struct ConnInfo *conn;
   CURLMcode rc;
 
-  conn = calloc(1, sizeof(ConnInfo));
+  conn = calloc(1, sizeof(*conn));
   conn->error[0] = '\0';
 
   conn->easy = curl_easy_init();

--- a/docs/examples/http2-upload.c
+++ b/docs/examples/http2-upload.c
@@ -158,6 +158,7 @@ int my_trace(CURL *handle, curl_infotype type,
     known_offset = 1;
   }
   secs = epoch_offset + tv.tv_sec;
+  /* !checksrc! disable BANNEDFUNC 1 */
   now = localtime(&secs);  /* not thread safe but we do not care */
   curl_msnprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld",
                  now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -299,8 +299,10 @@ int main(int argc, char *argv[])
 
     /* Calculating time diff between GMT and localtime */
     tt       = time(0);
+    /* !checksrc! disable BANNEDFUNC 1 */
     lt       = localtime(&tt);
     tt_local = mktime(lt);
+    /* !checksrc! disable BANNEDFUNC 1 */
     gmt      = gmtime(&tt);
     tt_gmt   = mktime(gmt);
     tzonediffFloat = difftime(tt_local, tt_gmt);

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -232,10 +232,10 @@ static int conf_init(struct conf *conf)
 {
   int i;
 
-  *conf->http_proxy       = 0;
+  *conf->http_proxy = 0;
   for(i = 0; i < MAX_STRING1; i++)
-    conf->proxy_user[i]     = 0;    /* Clean up password from memory */
-  *conf->timeserver       = 0;
+    conf->proxy_user[i] = 0;    /* Clean up password from memory */
+  *conf->timeserver = 0;
   return 1;
 }
 

--- a/docs/examples/synctime.c
+++ b/docs/examples/synctime.c
@@ -87,12 +87,11 @@
 
 #define SYNCTIME_UA "synctime/1.0"
 
-typedef struct
-{
+struct conf {
   char http_proxy[MAX_STRING1];
   char proxy_user[MAX_STRING1];
   char timeserver[MAX_STRING1];
-} conf_t;
+};
 
 static const char DefaultTimeServer[3][MAX_STRING1] =
 {
@@ -229,7 +228,7 @@ static void showUsage(void)
   return;
 }
 
-static int conf_init(conf_t *conf)
+static int conf_init(struct conf *conf)
 {
   int i;
 
@@ -242,9 +241,9 @@ static int conf_init(conf_t *conf)
 
 int main(int argc, char *argv[])
 {
-  CURL    *curl;
-  conf_t  conf[1];
-  int     RetValue;
+  CURL *curl;
+  struct conf conf[1];
+  int RetValue;
 
   ShowAllHeader   = 0;    /* Do not show HTTP Header */
   AutoSyncTime    = 0;    /* Do not synchronise computer clock */

--- a/docs/examples/xmlstream.c
+++ b/docs/examples/xmlstream.c
@@ -122,7 +122,7 @@ int main(void)
   struct ParserStruct state;
 
   /* Initialize the state structure for parsing. */
-  memset(&state, 0, sizeof(struct ParserStruct));
+  memset(&state, 0, sizeof(state));
   state.ok = 1;
 
   /* Initialize a namespace-aware parser. */

--- a/lib/.checksrc
+++ b/lib/.checksrc
@@ -2,5 +2,4 @@ banfunc strerror
 banfunc sscanf
 banfunc snprintf
 banfunc vsnprint
-banfunc strtoul
 banfunc strtol

--- a/lib/.checksrc
+++ b/lib/.checksrc
@@ -4,4 +4,3 @@ banfunc snprintf
 banfunc vsnprint
 banfunc strtoul
 banfunc strtol
-banfunc strtok_r

--- a/lib/.checksrc
+++ b/lib/.checksrc
@@ -1,5 +1,5 @@
-banfunc strerror
-banfunc sscanf
 banfunc snprintf
-banfunc vsnprint
+banfunc sscanf
+banfunc strerror
 banfunc strtol
+banfunc vsnprint

--- a/lib/.checksrc
+++ b/lib/.checksrc
@@ -1,5 +1,4 @@
 banfunc strerror
-banfunc strncpy
 banfunc sscanf
 banfunc snprintf
 banfunc vsnprint

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -28,8 +28,8 @@ include Makefile.inc
 
 CMAKE_DIST = CMakeLists.txt curl_config.h.cmake
 
-CHECKSRC_DIST = .checksrc vauth/.checksrc vquic/.checksrc vssh/.checksrc \
-  vtls/.checksrc
+CHECKSRC_DIST = .checksrc \
+  curlx/.checksrc vauth/.checksrc vquic/.checksrc vssh/.checksrc vtls/.checksrc
 
 EXTRA_DIST = config-mac.h config-os400.h config-plan9.h config-riscos.h \
   config-win32.h curl_config.h.in $(LIB_RCFILES) libcurl.def            \

--- a/lib/curlx/.checksrc
+++ b/lib/curlx/.checksrc
@@ -1,0 +1,8 @@
+banfunc strerror
+banfunc strncpy
+banfunc sscanf
+banfunc snprintf
+banfunc vsnprint
+banfunc strtoul
+banfunc strtol
+banfunc strtok_r

--- a/lib/curlx/.checksrc
+++ b/lib/curlx/.checksrc
@@ -2,5 +2,4 @@ banfunc strerror
 banfunc sscanf
 banfunc snprintf
 banfunc vsnprint
-banfunc strtoul
 banfunc strtol

--- a/lib/curlx/.checksrc
+++ b/lib/curlx/.checksrc
@@ -4,4 +4,3 @@ banfunc snprintf
 banfunc vsnprint
 banfunc strtoul
 banfunc strtol
-banfunc strtok_r

--- a/lib/curlx/.checksrc
+++ b/lib/curlx/.checksrc
@@ -1,5 +1,5 @@
-banfunc strerror
-banfunc sscanf
 banfunc snprintf
-banfunc vsnprint
+banfunc sscanf
+banfunc strerror
 banfunc strtol
+banfunc vsnprint

--- a/lib/curlx/.checksrc
+++ b/lib/curlx/.checksrc
@@ -1,5 +1,4 @@
 banfunc strerror
-banfunc strncpy
 banfunc sscanf
 banfunc snprintf
 banfunc vsnprint

--- a/lib/vauth/.checksrc
+++ b/lib/vauth/.checksrc
@@ -1,3 +1,2 @@
 banfunc strerror
-banfunc strncpy
 banfunc sscanf

--- a/lib/vauth/.checksrc
+++ b/lib/vauth/.checksrc
@@ -1,2 +1,5 @@
-banfunc strerror
+banfunc snprintf
 banfunc sscanf
+banfunc strerror
+banfunc strtol
+banfunc vsnprint

--- a/lib/vquic/.checksrc
+++ b/lib/vquic/.checksrc
@@ -1,4 +1,3 @@
 banfunc strerror
 banfunc sscanf
-banfunc strtoul
 banfunc strtol

--- a/lib/vquic/.checksrc
+++ b/lib/vquic/.checksrc
@@ -1,3 +1,5 @@
-banfunc strerror
+banfunc snprintf
 banfunc sscanf
+banfunc strerror
 banfunc strtol
+banfunc vsnprint

--- a/lib/vquic/.checksrc
+++ b/lib/vquic/.checksrc
@@ -1,5 +1,4 @@
 banfunc strerror
-banfunc strncpy
 banfunc sscanf
 banfunc strtoul
 banfunc strtol

--- a/lib/vssh/.checksrc
+++ b/lib/vssh/.checksrc
@@ -1,3 +1,2 @@
 banfunc strerror
-banfunc strncpy
 banfunc sscanf

--- a/lib/vssh/.checksrc
+++ b/lib/vssh/.checksrc
@@ -1,2 +1,5 @@
-banfunc strerror
+banfunc snprintf
 banfunc sscanf
+banfunc strerror
+banfunc strtol
+banfunc vsnprint

--- a/lib/vtls/.checksrc
+++ b/lib/vtls/.checksrc
@@ -1,4 +1,3 @@
 banfunc strerror
 banfunc sscanf
-banfunc strtoul
 banfunc strtol

--- a/lib/vtls/.checksrc
+++ b/lib/vtls/.checksrc
@@ -1,3 +1,5 @@
-banfunc strerror
+banfunc snprintf
 banfunc sscanf
+banfunc strerror
 banfunc strtol
+banfunc vsnprint

--- a/lib/vtls/.checksrc
+++ b/lib/vtls/.checksrc
@@ -1,5 +1,4 @@
 banfunc strerror
-banfunc strncpy
 banfunc sscanf
 banfunc strtoul
 banfunc strtol

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -56,6 +56,7 @@ my %banfunc = (
     "vsprintf" => 1,
     "strcat" => 1,
     "strncat" => 1,
+    "strncpy" => 1,
     "_mbscat" => 1,
     "_mbsncat" => 1,
     "_tcscat" => 1,

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -57,6 +57,7 @@ my %banfunc = (
     "strcat" => 1,
     "strncat" => 1,
     "strncpy" => 1,
+    "strtok_r" => 1,
     "_mbscat" => 1,
     "_mbsncat" => 1,
     "_tcscat" => 1,

--- a/scripts/checksrc.pl
+++ b/scripts/checksrc.pl
@@ -58,6 +58,7 @@ my %banfunc = (
     "strncat" => 1,
     "strncpy" => 1,
     "strtok_r" => 1,
+    "strtoul" => 1,
     "_mbscat" => 1,
     "_mbsncat" => 1,
     "_tcscat" => 1,

--- a/src/.checksrc
+++ b/src/.checksrc
@@ -1,3 +1,5 @@
 enable STDERR
+banfunc snprintf
 banfunc sscanf
 banfunc strtol
+banfunc vsnprint

--- a/src/.checksrc
+++ b/src/.checksrc
@@ -1,4 +1,3 @@
 enable STDERR
 banfunc sscanf
 banfunc strtol
-banfunc strtoul

--- a/src/.checksrc
+++ b/src/.checksrc
@@ -1,5 +1,4 @@
 enable STDERR
-banfunc strncpy
 banfunc sscanf
 banfunc strtol
 banfunc strtoul

--- a/tests/libtest/.checksrc
+++ b/tests/libtest/.checksrc
@@ -1,2 +1,1 @@
-disable TYPEDEFSTRUCT
 allowfunc localtime

--- a/tests/libtest/.checksrc
+++ b/tests/libtest/.checksrc
@@ -1,1 +1,0 @@
-allowfunc localtime

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -42,7 +42,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 # Get BUNDLE, FIRST_C, FIRST_H, UTILS_C, UTILS_H, CURLX_C, TESTS_C, STUB_GSS_C, STUB_GSS_H variables
 include Makefile.inc
 
-EXTRA_DIST = CMakeLists.txt .checksrc $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C) \
+EXTRA_DIST = CMakeLists.txt $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C) \
   test307.pl test610.pl test613.pl test1013.pl test1022.pl mk-lib1521.pl
 
 CFLAGS += @CURL_CFLAG_EXTRAS@

--- a/tests/libtest/stub_gssapi.h
+++ b/tests/libtest/stub_gssapi.h
@@ -26,6 +26,8 @@
 
 /* Roughly based on Heimdal's gssapi.h */
 
+/* !checksrc! disable TYPEDEFSTRUCT all */
+
 #include <stdint.h>
 #include <stddef.h>
 

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -108,6 +108,7 @@ int libtest_debug_cb(CURL *handle, curl_infotype type,
       known_offset = 1;
     }
     secs = epoch_offset + tv.tv_sec;
+    /* !checksrc! disable BANNEDFUNC 1 */
     now = localtime(&secs);  /* not thread safe but we don't care */
     curl_msnprintf(timebuf, sizeof(timebuf), "%02d:%02d:%02d.%06ld ",
                    now->tm_hour, now->tm_min, now->tm_sec, (long)tv.tv_usec);

--- a/tests/server/.checksrc
+++ b/tests/server/.checksrc
@@ -1,0 +1,1 @@
+allowfunc strtoul

--- a/tests/server/.checksrc
+++ b/tests/server/.checksrc
@@ -1,1 +1,0 @@
-banfunc strncpy

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -41,7 +41,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 # Get BUNDLE, FIRST_C, FIRST_H, UTILS_C, UTILS_H, CURLX_C, TESTS_C variables
 include Makefile.inc
 
-EXTRA_DIST = CMakeLists.txt .checksrc $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C)
+EXTRA_DIST = CMakeLists.txt $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C)
 
 CFLAGS += @CURL_CFLAG_EXTRAS@
 

--- a/tests/server/Makefile.am
+++ b/tests/server/Makefile.am
@@ -41,7 +41,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 # Get BUNDLE, FIRST_C, FIRST_H, UTILS_C, UTILS_H, CURLX_C, TESTS_C variables
 include Makefile.inc
 
-EXTRA_DIST = CMakeLists.txt $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C)
+EXTRA_DIST = CMakeLists.txt .checksrc $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C)
 
 CFLAGS += @CURL_CFLAG_EXTRAS@
 


### PR DESCRIPTION
- tests/libtest: move exception to `stub_gssapi.h`.
- tests/libtest: move remaining exception to `testtrace.c`.
- tests/server: drop obsolete exception.
- docs/examples: move `BANNEDFUNC` exceptions to local files (3 lines).
- docs/examples: move `ERRNOVAR` exception to `ephiperfifo.c`.
- docs/examples: drop `typedef struct` (8 files).
- lib/curlx: add `.checksrc` with banned funcs copied from lib.
- checksrc: ban `strncpy`, `strtok_r`, `strtoul` by default.
  Drop local bans. Add exception for `strtoul` to `tests/server'.
- lib, src: sync banned funcs.

Also:
- REUSE: drop `stunnel.pem`, it no longer exists.
- docs/examples: formatting.
- docs/examples: simplify some `sizeof()`s.

---

- [x] examples: drop `typedef struct`
- [x] move some banned funcs to the default checksrc list?
