### PR TITLE
firefox-db2pem: avoid use of eval in script

### DIFF
--- a/scripts/firefox-db2pem.sh
+++ b/scripts/firefox-db2pem.sh
@@ -57,5 +57,5 @@ sed -e 's/ *[CcGTPpu]*,[CcGTPpu]*,[CcGTPpu]* *$//' -e 's/\(.*\)/"\1"/' | \
 sort | \
 while read -r nickname; \
  do echo "$nickname" | sed -e "s/Builtin Object Token://g"; \
-eval certutil -d "$db" -L -n "$nickname" -a ; \
+ echo "$nickname" | xargs -I{} certutil -d "$db" -L -a -n {} ; \
 done >> "$out"


### PR DESCRIPTION
This could potentially be exploited by manipulating nicknames in the
cert DB.

Reported-by: behindtheblackwall on hackerone
Closes #17766