### PR TITLE
lib: drop 2 interim macros in favor of native API calls

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -32,7 +32,6 @@
 #include "urldata.h"
 #include "altsvc.h"
 #include "curl_get_line.h"
-#include "strcase.h"
 #include "parsedate.h"
 #include "sendf.h"
 #include "curlx/warnless.h"

--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -416,7 +416,7 @@ static bool hostcompare(const char *host, const char *check)
   if(hlen != clen)
     /* they cannot match if they have different lengths */
     return FALSE;
-  return strncasecompare(host, check, hlen);
+  return curl_strnequal(host, check, hlen);
 }
 
 /* altsvc_flush() removes all alternatives for this source origin from the

--- a/lib/conncache.c
+++ b/lib/conncache.c
@@ -42,7 +42,6 @@
 #include "sigpipe.h"
 #include "connect.h"
 #include "select.h"
-#include "strcase.h"
 #include "curlx/strparse.h"
 #include "uint-table.h"
 

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -78,7 +78,6 @@
 #include "vquic/vquic.h" /* for quic cfilters */
 #include "http_proxy.h"
 #include "socks.h"
-#include "strcase.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -90,15 +90,15 @@
 enum alpnid Curl_alpn2alpnid(const char *name, size_t len)
 {
   if(len == 2) {
-    if(strncasecompare(name, "h1", 2))
+    if(curl_strnequal(name, "h1", 2))
       return ALPN_h1;
-    if(strncasecompare(name, "h2", 2))
+    if(curl_strnequal(name, "h2", 2))
       return ALPN_h2;
-    if(strncasecompare(name, "h3", 2))
+    if(curl_strnequal(name, "h3", 2))
       return ALPN_h3;
   }
   else if(len == 8) {
-    if(strncasecompare(name, "http/1.1", 8))
+    if(curl_strnequal(name, "http/1.1", 8))
       return ALPN_h1;
   }
   return ALPN_none; /* unknown, probably rubbish input */

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -636,7 +636,7 @@ void Curl_all_content_encodings(char *buf, size_t blen)
 
   for(cep = general_unencoders; *cep; cep++) {
     ce = *cep;
-    if(!strcasecompare(ce->name, CONTENT_ENCODING_DEFAULT))
+    if(!curl_strequal(ce->name, CONTENT_ENCODING_DEFAULT))
       len += strlen(ce->name) + 2;
   }
 
@@ -648,7 +648,7 @@ void Curl_all_content_encodings(char *buf, size_t blen)
     char *p = buf;
     for(cep = general_unencoders; *cep; cep++) {
       ce = *cep;
-      if(!strcasecompare(ce->name, CONTENT_ENCODING_DEFAULT)) {
+      if(!curl_strequal(ce->name, CONTENT_ENCODING_DEFAULT)) {
         strcpy(p, ce->name);
         p += strlen(p);
         *p++ = ',';
@@ -713,8 +713,8 @@ static const struct Curl_cwtype *find_unencode_writer(const char *name,
   if(phase == CURL_CW_TRANSFER_DECODE) {
     for(cep = transfer_unencoders; *cep; cep++) {
       const struct Curl_cwtype *ce = *cep;
-      if((strncasecompare(name, ce->name, len) && !ce->name[len]) ||
-         (ce->alias && strncasecompare(name, ce->alias, len)
+      if((curl_strnequal(name, ce->name, len) && !ce->name[len]) ||
+         (ce->alias && curl_strnequal(name, ce->alias, len)
                     && !ce->alias[len]))
         return ce;
     }
@@ -722,8 +722,8 @@ static const struct Curl_cwtype *find_unencode_writer(const char *name,
   /* look among the general decoders */
   for(cep = general_unencoders; *cep; cep++) {
     const struct Curl_cwtype *ce = *cep;
-    if((strncasecompare(name, ce->name, len) && !ce->name[len]) ||
-       (ce->alias && strncasecompare(name, ce->alias, len) && !ce->alias[len]))
+    if((curl_strnequal(name, ce->name, len) && !ce->name[len]) ||
+       (ce->alias && curl_strnequal(name, ce->alias, len) && !ce->alias[len]))
       return ce;
   }
   return NULL;
@@ -761,12 +761,12 @@ CURLcode Curl_build_unencoding_stack(struct Curl_easy *data,
       CURL_TRC_WRITE(data, "looking for %s decoder: %.*s",
                      is_transfer ? "transfer" : "content", (int)namelen, name);
       is_chunked = (is_transfer && (namelen == 7) &&
-                    strncasecompare(name, "chunked", 7));
+                    curl_strnequal(name, "chunked", 7));
       /* if we skip the decoding in this phase, do not look further.
        * Exception is "chunked" transfer-encoding which always must happen */
       if((is_transfer && !data->set.http_transfer_encoding && !is_chunked) ||
          (!is_transfer && data->set.http_ce_skip)) {
-        bool is_identity = strncasecompare(name, "identity", 8);
+        bool is_identity = curl_strnequal(name, "identity", 8);
         /* not requested, ignore */
         CURL_TRC_WRITE(data, "decoder not requested, ignored: %.*s",
                        (int)namelen, name);

--- a/lib/content_encoding.c
+++ b/lib/content_encoding.c
@@ -52,7 +52,6 @@
 #include "http.h"
 #include "content_encoding.h"
 #include "strdup.h"
-#include "strcase.h"
 
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -136,8 +136,8 @@ static bool cookie_tailmatch(const char *cookie_domain,
     return FALSE;
 
   if(!curl_strnequal(cookie_domain,
-                      hostname + hostname_len-cookie_domain_len,
-                      cookie_domain_len))
+                     hostname + hostname_len-cookie_domain_len,
+                     cookie_domain_len))
     return FALSE;
 
   /*

--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -135,7 +135,7 @@ static bool cookie_tailmatch(const char *cookie_domain,
   if(hostname_len < cookie_domain_len)
     return FALSE;
 
-  if(!strncasecompare(cookie_domain,
+  if(!curl_strnequal(cookie_domain,
                       hostname + hostname_len-cookie_domain_len,
                       cookie_domain_len))
     return FALSE;
@@ -409,7 +409,7 @@ static void remove_expired(struct CookieInfo *ci)
 /* Make sure domain contains a dot or is localhost. */
 static bool bad_domain(const char *domain, size_t len)
 {
-  if((len == 9) && strncasecompare(domain, "localhost", 9))
+  if((len == 9) && curl_strnequal(domain, "localhost", 9))
     return FALSE;
   else {
     /* there must be a dot present, but that dot must not be a trailing dot */
@@ -815,7 +815,7 @@ parse_netscape(struct Cookie *co,
        * domain can access the variable. Set TRUE when the cookie says
        * .example.com and to false when the domain is complete www.example.com
        */
-      co->tailmatch = !!strncasecompare(ptr, "TRUE", len);
+      co->tailmatch = !!curl_strnequal(ptr, "TRUE", len);
       break;
     case 2:
       /* The file format allows the path field to remain not filled in */
@@ -842,7 +842,7 @@ parse_netscape(struct Cookie *co,
       FALLTHROUGH();
     case 3:
       co->secure = FALSE;
-      if(strncasecompare(ptr, "TRUE", len)) {
+      if(curl_strnequal(ptr, "TRUE", len)) {
         if(secure || ci->running)
           co->secure = TRUE;
         else
@@ -859,9 +859,9 @@ parse_netscape(struct Cookie *co,
         return CERR_OUT_OF_MEMORY;
       else {
         /* For Netscape file format cookies we check prefix on the name */
-        if(strncasecompare("__Secure-", co->name, 9))
+        if(curl_strnequal("__Secure-", co->name, 9))
           co->prefix_secure = TRUE;
-        else if(strncasecompare("__Host-", co->name, 7))
+        else if(curl_strnequal("__Host-", co->name, 7))
           co->prefix_host = TRUE;
       }
       break;
@@ -954,7 +954,7 @@ replace_existing(struct Curl_easy *data,
       bool matching_domains = FALSE;
 
       if(clist->domain && co->domain) {
-        if(strcasecompare(clist->domain, co->domain))
+        if(curl_strequal(clist->domain, co->domain))
           /* The domains are identical */
           matching_domains = TRUE;
       }
@@ -981,7 +981,7 @@ replace_existing(struct Curl_easy *data,
         else
           cllen = strlen(clist->spath);
 
-        if(strncasecompare(clist->spath, co->spath, cllen)) {
+        if(curl_strnequal(clist->spath, co->spath, cllen)) {
           infof(data, "cookie '%s' for domain '%s' dropped, would "
                 "overlay an existing cookie", co->name, co->domain);
           return CERR_BAD_SECURE;
@@ -993,7 +993,7 @@ replace_existing(struct Curl_easy *data,
       /* the names are identical */
 
       if(clist->domain && co->domain) {
-        if(strcasecompare(clist->domain, co->domain) &&
+        if(curl_strequal(clist->domain, co->domain) &&
           (clist->tailmatch == co->tailmatch))
           /* The domains are identical */
           replace_old = TRUE;
@@ -1005,7 +1005,7 @@ replace_existing(struct Curl_easy *data,
         /* the domains were identical */
 
         if(clist->spath && co->spath &&
-           !strcasecompare(clist->spath, co->spath))
+           !curl_strequal(clist->spath, co->spath))
           replace_old = FALSE;
         else if(!clist->spath != !co->spath)
           replace_old = FALSE;
@@ -1337,7 +1337,7 @@ int Curl_cookie_getlist(struct Curl_easy *data,
       if(!co->domain ||
          (co->tailmatch && !is_ip &&
           cookie_tailmatch(co->domain, strlen(co->domain), host)) ||
-         ((!co->tailmatch || is_ip) && strcasecompare(host, co->domain)) ) {
+         ((!co->tailmatch || is_ip) && curl_strequal(host, co->domain)) ) {
         /*
          * the right part of the host matches the domain stuff in the
          * cookie data

--- a/lib/cshutdn.c
+++ b/lib/cshutdn.c
@@ -40,7 +40,6 @@
 #include "sigpipe.h"
 #include "connect.h"
 #include "select.h"
-#include "strcase.h"
 #include "curlx/strparse.h"
 
 /* The last 3 #include files should be in this order */

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -31,7 +31,6 @@
 #include "easyif.h"
 #include "cfilters.h"
 #include "multiif.h"
-#include "strcase.h"
 
 #include "cf-socket.h"
 #include "connect.h"

--- a/lib/curlx/strparse.c
+++ b/lib/curlx/strparse.c
@@ -238,7 +238,7 @@ int curlx_str_newline(const char **linep)
 int curlx_str_casecompare(struct Curl_str *str, const char *check)
 {
   size_t clen = check ? strlen(check) : 0;
-  return ((str->len == clen) && strncasecompare(str->str, check, clen));
+  return ((str->len == clen) && curl_strnequal(str->str, check, clen));
 }
 #endif
 

--- a/lib/curlx/strparse.c
+++ b/lib/curlx/strparse.c
@@ -23,7 +23,10 @@
  ***************************************************************************/
 
 #include "strparse.h"
-#include "../strcase.h"
+
+#ifndef WITHOUT_LIBCURL
+#include <curl/curl.h>  /* for curl_strnequal() */
+#endif
 
 void curlx_str_init(struct Curl_str *out)
 {

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -60,7 +60,6 @@
 #include "progress.h"
 #include "dict.h"
 #include "curl_printf.h"
-#include "strcase.h"
 #include "curl_memory.h"
 /* The last #include file should be: */
 #include "memdebug.h"

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -198,9 +198,9 @@ static CURLcode dict_do(struct Curl_easy *data, bool *done)
   if(result)
     return result;
 
-  if(strncasecompare(path, DICT_MATCH, sizeof(DICT_MATCH)-1) ||
-     strncasecompare(path, DICT_MATCH2, sizeof(DICT_MATCH2)-1) ||
-     strncasecompare(path, DICT_MATCH3, sizeof(DICT_MATCH3)-1)) {
+  if(curl_strnequal(path, DICT_MATCH, sizeof(DICT_MATCH)-1) ||
+     curl_strnequal(path, DICT_MATCH2, sizeof(DICT_MATCH2)-1) ||
+     curl_strnequal(path, DICT_MATCH3, sizeof(DICT_MATCH3)-1)) {
 
     word = strchr(path, ':');
     if(word) {
@@ -245,9 +245,9 @@ static CURLcode dict_do(struct Curl_easy *data, bool *done)
     }
     Curl_xfer_setup1(data, CURL_XFER_RECV, -1, FALSE); /* no upload */
   }
-  else if(strncasecompare(path, DICT_DEFINE, sizeof(DICT_DEFINE)-1) ||
-          strncasecompare(path, DICT_DEFINE2, sizeof(DICT_DEFINE2)-1) ||
-          strncasecompare(path, DICT_DEFINE3, sizeof(DICT_DEFINE3)-1)) {
+  else if(curl_strnequal(path, DICT_DEFINE, sizeof(DICT_DEFINE)-1) ||
+          curl_strnequal(path, DICT_DEFINE2, sizeof(DICT_DEFINE2)-1) ||
+          curl_strnequal(path, DICT_DEFINE3, sizeof(DICT_DEFINE3)-1)) {
 
     word = strchr(path, ':');
     if(word) {

--- a/lib/dynhds.c
+++ b/lib/dynhds.c
@@ -150,7 +150,7 @@ struct dynhds_entry *Curl_dynhds_get(struct dynhds *dynhds, const char *name,
   size_t i;
   for(i = 0; i < dynhds->hds_len; ++i) {
     if(dynhds->hds[i]->namelen == namelen &&
-       strncasecompare(dynhds->hds[i]->name, name, namelen)) {
+       curl_strnequal(dynhds->hds[i]->name, name, namelen)) {
       return dynhds->hds[i];
     }
   }
@@ -297,7 +297,7 @@ size_t Curl_dynhds_count_name(struct dynhds *dynhds,
     size_t i;
     for(i = 0; i < dynhds->hds_len; ++i) {
       if((namelen == dynhds->hds[i]->namelen) &&
-         strncasecompare(name, dynhds->hds[i]->name, namelen))
+         curl_strnequal(name, dynhds->hds[i]->name, namelen))
         ++n;
     }
   }
@@ -325,7 +325,7 @@ size_t Curl_dynhds_remove(struct dynhds *dynhds,
     size_t i, len;
     for(i = 0; i < dynhds->hds_len; ++i) {
       if((namelen == dynhds->hds[i]->namelen) &&
-         strncasecompare(name, dynhds->hds[i]->name, namelen)) {
+         curl_strnequal(name, dynhds->hds[i]->name, namelen)) {
         ++n;
         --dynhds->hds_len;
         dynhds->strs_len -= (dynhds->hds[i]->namelen +

--- a/lib/easygetopt.c
+++ b/lib/easygetopt.c
@@ -23,7 +23,6 @@
  ***************************************************************************/
 
 #include "curl_setup.h"
-#include "strcase.h"
 #include "easyoptions.h"
 
 #ifndef CURL_DISABLE_GETOPTIONS

--- a/lib/easygetopt.c
+++ b/lib/easygetopt.c
@@ -37,7 +37,7 @@ static const struct curl_easyoption *lookup(const char *name, CURLoption id)
     const struct curl_easyoption *o = &Curl_easyopts[0];
     do {
       if(name) {
-        if(strcasecompare(o->name, name))
+        if(curl_strequal(o->name, name))
           return o;
       }
       else {

--- a/lib/formdata.c
+++ b/lib/formdata.c
@@ -34,7 +34,6 @@ struct Curl_easy;
 #include "urldata.h" /* for struct Curl_easy */
 #include "mime.h"
 #include "vtls/vtls.h"
-#include "strcase.h"
 #include "sendf.h"
 #include "strdup.h"
 #include "rand.h"

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -2989,7 +2989,7 @@ static CURLcode ftp_pp_statemachine(struct Curl_easy *data,
           return CURLE_OUT_OF_MEMORY;
 
         /* Check for special servers here. */
-        if(strcasecompare(os, "OS/400")) {
+        if(curl_strequal(os, "OS/400")) {
           /* Force OS400 name format 1. */
           result = Curl_pp_sendf(data, &ftpc->pp, "%s", "SITE NAMEFMT 1");
           if(result) {

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -26,7 +26,6 @@
 
 #include "urldata.h"
 #include "strdup.h"
-#include "strcase.h"
 #include "sendf.h"
 #include "headers.h"
 #include "curlx/strparse.h"

--- a/lib/headers.c
+++ b/lib/headers.c
@@ -88,7 +88,7 @@ CURLHcode curl_easy_header(CURL *easy,
   /* we need a first round to count amount of this header */
   for(e = Curl_llist_head(&data->state.httphdrs); e; e = Curl_node_next(e)) {
     hs = Curl_node_elem(e);
-    if(strcasecompare(hs->name, name) &&
+    if(curl_strequal(hs->name, name) &&
        (hs->type & type) &&
        (hs->request == request)) {
       amount++;
@@ -107,7 +107,7 @@ CURLHcode curl_easy_header(CURL *easy,
   else {
     for(e = Curl_llist_head(&data->state.httphdrs); e; e = Curl_node_next(e)) {
       hs = Curl_node_elem(e);
-      if(strcasecompare(hs->name, name) &&
+      if(curl_strequal(hs->name, name) &&
          (hs->type & type) &&
          (hs->request == request) &&
          (match++ == nameindex)) {
@@ -173,7 +173,7 @@ struct curl_header *curl_easy_nextheader(CURL *easy,
      the index for the currently selected entry */
   for(e = Curl_llist_head(&data->state.httphdrs); e; e = Curl_node_next(e)) {
     struct Curl_header_store *check = Curl_node_elem(e);
-    if(strcasecompare(hs->name, check->name) &&
+    if(curl_strequal(hs->name, check->name) &&
        (check->request == request) &&
        (check->type & type))
       amount++;

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -730,7 +730,7 @@ static bool tailmatch(const char *full, size_t flen,
 {
   if(plen > flen)
     return FALSE;
-  return strncasecompare(part, &full[flen - plen], plen);
+  return curl_strnequal(part, &full[flen - plen], plen);
 }
 
 static struct Curl_addrinfo *
@@ -872,8 +872,8 @@ CURLcode Curl_resolv(struct Curl_easy *data,
     goto error;
 
   if(!is_ipaddr &&
-     (strcasecompare(hostname, "localhost") ||
-      strcasecompare(hostname, "localhost.") ||
+     (curl_strequal(hostname, "localhost") ||
+      curl_strequal(hostname, "localhost.") ||
       tailmatch(hostname, hostname_len, STRCONST(".localhost")) ||
       tailmatch(hostname, hostname_len, STRCONST(".localhost.")))) {
     addr = get_localhost(port, hostname);

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -155,7 +155,7 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
 
   do {
     curlx_str_passblanks(&p);
-    if(strncasecompare("max-age", p, 7)) {
+    if(curl_strnequal("max-age", p, 7)) {
       bool quoted = FALSE;
       int rc;
 
@@ -185,7 +185,7 @@ CURLcode Curl_hsts_parse(struct hsts *h, const char *hostname,
       }
       gotma = TRUE;
     }
-    else if(strncasecompare("includesubdomains", p, 17)) {
+    else if(curl_strnequal("includesubdomains", p, 17)) {
       if(gotinc)
         return CURLE_BAD_FUNCTION_ARGUMENT;
       subdomains = TRUE;
@@ -272,15 +272,15 @@ struct stsentry *Curl_hsts(struct hsts *h, const char *hostname,
       if((subdomain && sts->includeSubDomains) && (ntail < hlen)) {
         size_t offs = hlen - ntail;
         if((hostname[offs-1] == '.') &&
-           strncasecompare(&hostname[offs], sts->host, ntail) &&
+           curl_strnequal(&hostname[offs], sts->host, ntail) &&
            (ntail > blen)) {
           /* save the tail match with the longest tail */
           bestsub = sts;
           blen = ntail;
         }
       }
-      /* avoid strcasecompare because the host name is not null-terminated */
-      if((hlen == ntail) && strncasecompare(hostname, sts->host, hlen))
+      /* avoid curl_strequal because the host name is not null-terminated */
+      if((hlen == ntail) && curl_strnequal(hostname, sts->host, hlen))
         return sts;
     }
   }

--- a/lib/hsts.c
+++ b/lib/hsts.c
@@ -33,7 +33,6 @@
 #include "llist.h"
 #include "hsts.h"
 #include "curl_get_line.h"
-#include "strcase.h"
 #include "sendf.h"
 #include "parsedate.h"
 #include "fopen.h"

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -36,7 +36,6 @@
 #include "sendf.h"
 #include "select.h"
 #include "curlx/base64.h"
-#include "strcase.h"
 #include "multiif.h"
 #include "url.h"
 #include "urlapi-int.h"

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1598,9 +1598,9 @@ static int on_header(nghttp2_session *session, const nghttp2_frame *frame,
       if(!check)
         /* no memory */
         return NGHTTP2_ERR_CALLBACK_FAILURE;
-      if(!strcasecompare(check, (const char *)value) &&
+      if(!curl_strequal(check, (const char *)value) &&
          ((cf->conn->remote_port != cf->conn->given->defport) ||
-          !strcasecompare(cf->conn->host.name, (const char *)value))) {
+          !curl_strequal(cf->conn->host.name, (const char *)value))) {
         /* This is push is not for the same authority that was asked for in
          * the URL. RFC 7540 section 8.2 says: "A client MUST treat a
          * PUSH_PROMISE for which the server is not authoritative as a stream

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -53,7 +53,7 @@
 static bool hd_name_eq(const char *n1, size_t n1len,
                        const char *n2, size_t n2len)
 {
-  return (n1len == n2len) ? strncasecompare(n1, n2, n1len) : FALSE;
+  return (n1len == n2len) ? curl_strnequal(n1, n2, n1len) : FALSE;
 }
 
 static CURLcode dynhds_add_custom(struct Curl_easy *data,

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -38,7 +38,6 @@
 #include "cf-h1-proxy.h"
 #include "cf-h2-proxy.h"
 #include "connect.h"
-#include "strcase.h"
 #include "vtls/vtls.h"
 #include "transfer.h"
 #include "multiif.h"

--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -53,7 +53,6 @@
 #endif
 
 #include "curlx/inet_ntop.h"
-#include "strcase.h"
 #include "if2ip.h"
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"

--- a/lib/if2ip.c
+++ b/lib/if2ip.c
@@ -117,7 +117,7 @@ if2ip_result_t Curl_if2ip(int af,
     for(iface = head; iface != NULL; iface = iface->ifa_next) {
       if(iface->ifa_addr) {
         if(iface->ifa_addr->sa_family == af) {
-          if(strcasecompare(iface->ifa_name, interf)) {
+          if(curl_strequal(iface->ifa_name, interf)) {
             void *addr;
             const char *ip;
             char scope[12] = "";
@@ -168,7 +168,7 @@ if2ip_result_t Curl_if2ip(int af,
           }
         }
         else if((res == IF2IP_NOT_FOUND) &&
-                strcasecompare(iface->ifa_name, interf)) {
+                curl_strequal(iface->ifa_name, interf)) {
           res = IF2IP_AF_NOT_SUPPORTED;
         }
       }

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -302,7 +302,7 @@ static bool imap_matchresp(const char *line, size_t len, const char *cmd)
 
   /* Does the command name match and is it followed by a space character or at
      the end of line? */
-  if(line + cmd_len <= end && strncasecompare(line, cmd, cmd_len) &&
+  if(line + cmd_len <= end && curl_strnequal(line, cmd, cmd_len) &&
      (line[cmd_len] == ' ' || line + cmd_len + 2 == end))
     return TRUE;
 
@@ -358,16 +358,16 @@ static bool imap_endofresp(struct Curl_easy *data, struct connectdata *conn,
       case IMAP_LIST:
         if((!imap->custom && !imap_matchresp(line, len, "LIST")) ||
            (imap->custom && !imap_matchresp(line, len, imap->custom) &&
-            (!strcasecompare(imap->custom, "STORE") ||
+            (!curl_strequal(imap->custom, "STORE") ||
              !imap_matchresp(line, len, "FETCH")) &&
-            !strcasecompare(imap->custom, "SELECT") &&
-            !strcasecompare(imap->custom, "EXAMINE") &&
-            !strcasecompare(imap->custom, "SEARCH") &&
-            !strcasecompare(imap->custom, "EXPUNGE") &&
-            !strcasecompare(imap->custom, "LSUB") &&
-            !strcasecompare(imap->custom, "UID") &&
-            !strcasecompare(imap->custom, "GETQUOTAROOT") &&
-            !strcasecompare(imap->custom, "NOOP")))
+            !curl_strequal(imap->custom, "SELECT") &&
+            !curl_strequal(imap->custom, "EXAMINE") &&
+            !curl_strequal(imap->custom, "SEARCH") &&
+            !curl_strequal(imap->custom, "EXPUNGE") &&
+            !curl_strequal(imap->custom, "LSUB") &&
+            !curl_strequal(imap->custom, "UID") &&
+            !curl_strequal(imap->custom, "GETQUOTAROOT") &&
+            !curl_strequal(imap->custom, "NOOP")))
           return FALSE;
         break;
 
@@ -1239,7 +1239,7 @@ static CURLcode imap_state_select_resp(struct Curl_easy *data,
   else if(imapcode == IMAP_RESP_OK) {
     /* Check if the UIDVALIDITY has been specified and matches */
     if(imap->uidvalidity && imapc->mailbox_uidvalidity &&
-       !strcasecompare(imap->uidvalidity, imapc->mailbox_uidvalidity)) {
+       !curl_strequal(imap->uidvalidity, imapc->mailbox_uidvalidity)) {
       failf(data, "Mailbox UIDVALIDITY has changed");
       result = CURLE_REMOTE_FILE_NOT_FOUND;
     }
@@ -1690,9 +1690,9 @@ static CURLcode imap_perform(struct Curl_easy *data, bool *connected,
   /* Determine if the requested mailbox (with the same UIDVALIDITY if set)
      has already been selected on this connection */
   if(imap->mailbox && imapc->mailbox &&
-     strcasecompare(imap->mailbox, imapc->mailbox) &&
+     curl_strequal(imap->mailbox, imapc->mailbox) &&
      (!imap->uidvalidity || !imapc->mailbox_uidvalidity ||
-      strcasecompare(imap->uidvalidity, imapc->mailbox_uidvalidity)))
+      curl_strequal(imap->uidvalidity, imapc->mailbox_uidvalidity)))
     selected = TRUE;
 
   /* Start the first command in the DO phase */
@@ -2072,12 +2072,12 @@ static CURLcode imap_parse_url_options(struct connectdata *conn,
     while(*ptr && *ptr != ';')
       ptr++;
 
-    if(strncasecompare(key, "AUTH=+LOGIN", 11)) {
+    if(curl_strnequal(key, "AUTH=+LOGIN", 11)) {
       /* User prefers plaintext LOGIN over any SASL, including SASL LOGIN */
       prefer_login = TRUE;
       imapc->sasl.prefmech = SASL_AUTH_NONE;
     }
-    else if(strncasecompare(key, "AUTH=", 5)) {
+    else if(curl_strnequal(key, "AUTH=", 5)) {
       prefer_login = FALSE;
       result = Curl_sasl_parse_url_auth_option(&imapc->sasl,
                                                value, ptr - value);
@@ -2182,35 +2182,35 @@ static CURLcode imap_parse_url_path(struct Curl_easy *data,
        PARTIAL) stripping of the trailing slash character if it is present.
 
        Note: Unknown parameters trigger a URL_MALFORMAT error. */
-    if(strcasecompare(name, "UIDVALIDITY") && !imap->uidvalidity) {
+    if(curl_strequal(name, "UIDVALIDITY") && !imap->uidvalidity) {
       if(valuelen > 0 && value[valuelen - 1] == '/')
         value[valuelen - 1] = '\0';
 
       imap->uidvalidity = value;
       value = NULL;
     }
-    else if(strcasecompare(name, "UID") && !imap->uid) {
+    else if(curl_strequal(name, "UID") && !imap->uid) {
       if(valuelen > 0 && value[valuelen - 1] == '/')
         value[valuelen - 1] = '\0';
 
       imap->uid = value;
       value = NULL;
     }
-    else if(strcasecompare(name, "MAILINDEX") && !imap->mindex) {
+    else if(curl_strequal(name, "MAILINDEX") && !imap->mindex) {
       if(valuelen > 0 && value[valuelen - 1] == '/')
         value[valuelen - 1] = '\0';
 
       imap->mindex = value;
       value = NULL;
     }
-    else if(strcasecompare(name, "SECTION") && !imap->section) {
+    else if(curl_strequal(name, "SECTION") && !imap->section) {
       if(valuelen > 0 && value[valuelen - 1] == '/')
         value[valuelen - 1] = '\0';
 
       imap->section = value;
       value = NULL;
     }
-    else if(strcasecompare(name, "PARTIAL") && !imap->partial) {
+    else if(curl_strequal(name, "PARTIAL") && !imap->partial) {
       if(valuelen > 0 && value[valuelen - 1] == '/')
         value[valuelen - 1] = '\0';
 

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -56,7 +56,6 @@
 #include "transfer.h"
 #include "curl_krb5.h"
 #include "curlx/warnless.h"
-#include "strcase.h"
 #include "strdup.h"
 
 /* The last 3 #include files should be in this order */

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -88,7 +88,6 @@
 #include "escape.h"
 #include "progress.h"
 #include "transfer.h"
-#include "strcase.h"
 #include "curlx/strparse.h"
 #include "curl_ldap.h"
 #include "curlx/multibyte.h"

--- a/lib/ldap.c
+++ b/lib/ldap.c
@@ -393,7 +393,7 @@ static CURLcode ldap_do(struct Curl_easy *data, bool *done)
     if(conn->ssl_config.verifypeer) {
       /* OpenLDAP SDK supports BASE64 files. */
       if((data->set.ssl.cert_type) &&
-         (!strcasecompare(data->set.ssl.cert_type, "PEM"))) {
+         (!curl_strequal(data->set.ssl.cert_type, "PEM"))) {
         failf(data, "LDAP local: ERROR OpenLDAP only supports PEM cert-type");
         result = CURLE_SSL_CERTPROBLEM;
         goto quit;
@@ -748,15 +748,15 @@ static void _ldap_trace(const char *fmt, ...)
  */
 static int str2scope(const char *p)
 {
-  if(strcasecompare(p, "one"))
+  if(curl_strequal(p, "one"))
     return LDAP_SCOPE_ONELEVEL;
-  if(strcasecompare(p, "onetree"))
+  if(curl_strequal(p, "onetree"))
     return LDAP_SCOPE_ONELEVEL;
-  if(strcasecompare(p, "base"))
+  if(curl_strequal(p, "base"))
     return LDAP_SCOPE_BASE;
-  if(strcasecompare(p, "sub"))
+  if(curl_strequal(p, "sub"))
     return LDAP_SCOPE_SUBTREE;
-  if(strcasecompare(p, "subtree"))
+  if(curl_strequal(p, "subtree"))
     return LDAP_SCOPE_SUBTREE;
   return -1;
 }
@@ -801,7 +801,7 @@ static int _ldap_url_parse2(struct Curl_easy *data,
   if(!data ||
      !data->state.up.path ||
      data->state.up.path[0] != '/' ||
-     !strncasecompare("LDAP", data->state.up.scheme, 4))
+     !curl_strnequal("LDAP", data->state.up.scheme, 4))
     return LDAP_INVALID_SYNTAX;
 
   ludp->lud_scope = LDAP_SCOPE_BASE;

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -336,7 +336,7 @@ static char *match_header(struct curl_slist *hdr, const char *lbl, size_t len)
 {
   char *value = NULL;
 
-  if(strncasecompare(hdr->data, lbl, len) && hdr->data[len] == ':')
+  if(curl_strnequal(hdr->data, lbl, len) && hdr->data[len] == ':')
     for(value = hdr->data + len + 1; *value == ' '; value++)
       ;
   return value;
@@ -1479,7 +1479,7 @@ CURLcode curl_mime_encoder(curl_mimepart *part, const char *encoding)
     return CURLE_OK;    /* Removing current encoder. */
 
   for(mep = encoders; mep->name; mep++)
-    if(strcasecompare(encoding, mep->name)) {
+    if(curl_strequal(encoding, mep->name)) {
       part->encoder = mep;
       result = CURLE_OK;
     }
@@ -1743,7 +1743,7 @@ const char *Curl_mime_contenttype(const char *filename)
     for(i = 0; i < CURL_ARRAYSIZE(ctts); i++) {
       size_t len2 = strlen(ctts[i].extension);
 
-      if(len1 >= len2 && strcasecompare(nameend - len2, ctts[i].extension))
+      if(len1 >= len2 && curl_strequal(nameend - len2, ctts[i].extension))
         return ctts[i].type;
     }
   }
@@ -1753,7 +1753,7 @@ const char *Curl_mime_contenttype(const char *filename)
 static bool content_type_match(const char *contenttype,
                                const char *target, size_t len)
 {
-  if(contenttype && strncasecompare(contenttype, target, len))
+  if(contenttype && curl_strnequal(contenttype, target, len))
     switch(contenttype[len]) {
     case '\0':
     case '\t':
@@ -1826,7 +1826,7 @@ CURLcode Curl_mime_prepare_headers(struct Curl_easy *data,
   if(!search_header(part->userheaders, STRCONST("Content-Disposition"))) {
     if(!disposition)
       if(part->filename || part->name ||
-        (contenttype && !strncasecompare(contenttype, "multipart/", 10)))
+        (contenttype && !curl_strnequal(contenttype, "multipart/", 10)))
           disposition = DISPOSITION_DEFAULT;
     if(disposition && curl_strequal(disposition, "attachment") &&
      !part->name && !part->filename)

--- a/lib/mime.c
+++ b/lib/mime.c
@@ -46,7 +46,6 @@ struct Curl_easy;
 
 #include "rand.h"
 #include "slist.h"
-#include "strcase.h"
 #include "curlx/dynbuf.h"
 /* The last 3 #include files should be in this order */
 #include "curl_printf.h"

--- a/lib/netrc.c
+++ b/lib/netrc.c
@@ -229,12 +229,12 @@ static NETRCcode parsenetrc(struct store_netrc *store,
 
       switch(state) {
       case NOTHING:
-        if(strcasecompare("macdef", tok))
+        if(curl_strequal("macdef", tok))
           /* Define a macro. A macro is defined with the specified name; its
              contents begin with the next .netrc line and continue until a
              null line (consecutive new-line characters) is encountered. */
           state = MACDEF;
-        else if(strcasecompare("machine", tok)) {
+        else if(curl_strequal("machine", tok)) {
           /* the next tok is the machine name, this is in itself the delimiter
              that starts the stuff entered for this machine, after this we
              need to search for 'login' and 'password'. */
@@ -246,7 +246,7 @@ static NETRCcode parsenetrc(struct store_netrc *store,
           if(!specific_login)
             Curl_safefree(login);
         }
-        else if(strcasecompare("default", tok)) {
+        else if(curl_strequal("default", tok)) {
           state = HOSTVALID;
           retcode = NETRC_OK; /* we did find our host */
         }
@@ -256,7 +256,7 @@ static NETRCcode parsenetrc(struct store_netrc *store,
           state = NOTHING;
         break;
       case HOSTFOUND:
-        if(strcasecompare(host, tok)) {
+        if(curl_strequal(host, tok)) {
           /* and yes, this is our host! */
           state = HOSTVALID;
           retcode = NETRC_OK; /* we did find our host */
@@ -293,11 +293,11 @@ static NETRCcode parsenetrc(struct store_netrc *store,
             found |= FOUND_PASSWORD;
           keyword = NONE;
         }
-        else if(strcasecompare("login", tok))
+        else if(curl_strequal("login", tok))
           keyword = LOGIN;
-        else if(strcasecompare("password", tok))
+        else if(curl_strequal("password", tok))
           keyword = PASSWORD;
-        else if(strcasecompare("machine", tok)) {
+        else if(curl_strequal("machine", tok)) {
           /* a new machine here */
           if(found & FOUND_PASSWORD) {
             done = TRUE;
@@ -310,7 +310,7 @@ static NETRCcode parsenetrc(struct store_netrc *store,
           if(!specific_login)
             Curl_safefree(login);
         }
-        else if(strcasecompare("default", tok)) {
+        else if(curl_strequal("default", tok)) {
           state = HOSTVALID;
           retcode = NETRC_OK; /* we did find our host */
           Curl_safefree(password);

--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -27,7 +27,6 @@
 #ifndef CURL_DISABLE_PROXY
 
 #include "curlx/inet_pton.h"
-#include "strcase.h"
 #include "noproxy.h"
 #include "curlx/strparse.h"
 

--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -205,12 +205,12 @@ bool Curl_check_noproxy(const char *name, const char *no_proxy)
           */
           if(tokenlen == namelen)
             /* case A, exact match */
-            match = strncasecompare(token, name, namelen);
+            match = curl_strnequal(token, name, namelen);
           else if(tokenlen < namelen) {
             /* case B, tailmatch domain */
             match = (name[namelen - tokenlen - 1] == '.') &&
-              strncasecompare(token, name + (namelen - tokenlen),
-                              tokenlen);
+              curl_strnequal(token, name + (namelen - tokenlen),
+                             tokenlen);
           }
           /* case C passes through, not a match */
           break;

--- a/lib/noproxy.c
+++ b/lib/noproxy.c
@@ -26,6 +26,7 @@
 
 #ifndef CURL_DISABLE_PROXY
 
+#include <curl/curl.h>  /* for curl_strnequal() */
 #include "curlx/inet_pton.h"
 #include "noproxy.h"
 #include "curlx/strparse.h"

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -224,7 +224,7 @@ static int checkday(const char *check, size_t len)
   for(i = 0; i < 7; i++) {
     size_t ilen = strlen(what[0]);
     if((ilen == len) &&
-       strncasecompare(check, what[0], len))
+       curl_strnequal(check, what[0], len))
       return i;
     what++;
   }
@@ -239,7 +239,7 @@ static int checkmonth(const char *check, size_t len)
     return -1; /* not a month */
 
   for(i = 0; i < 12; i++) {
-    if(strncasecompare(check, what[0], 3))
+    if(curl_strnequal(check, what[0], 3))
       return i;
     what++;
   }
@@ -259,7 +259,7 @@ static int checktz(const char *check, size_t len)
   for(i = 0; i < CURL_ARRAYSIZE(tz); i++) {
     size_t ilen = strlen(what->name);
     if((ilen == len) &&
-       strncasecompare(check, what->name, len))
+       curl_strnequal(check, what->name, len))
       return what->offset*60;
     what++;
   }

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -80,7 +80,6 @@
 #include <limits.h>
 
 #include <curl/curl.h>
-#include "strcase.h"
 #include "curlx/warnless.h"
 #include "parsedate.h"
 #include "curlx/strparse.h"

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -285,7 +285,7 @@ static bool pop3_is_multiline(const char *cmdline)
 {
   size_t i;
   for(i = 0; i < CURL_ARRAYSIZE(pop3cmds); ++i) {
-    if(strncasecompare(pop3cmds[i].name, cmdline, pop3cmds[i].nlen)) {
+    if(curl_strnequal(pop3cmds[i].name, cmdline, pop3cmds[i].nlen)) {
       if(!cmdline[pop3cmds[i].nlen])
         return pop3cmds[i].multiline;
       else if(cmdline[pop3cmds[i].nlen] == ' ')
@@ -1591,11 +1591,11 @@ static CURLcode pop3_parse_url_options(struct connectdata *conn)
     while(*ptr && *ptr != ';')
       ptr++;
 
-    if(strncasecompare(key, "AUTH=", 5)) {
+    if(curl_strnequal(key, "AUTH=", 5)) {
       result = Curl_sasl_parse_url_auth_option(&pop3c->sasl,
                                                value, ptr - value);
 
-      if(result && strncasecompare(value, "+APOP", ptr - value)) {
+      if(result && curl_strnequal(value, "+APOP", ptr - value)) {
         pop3c->preftype = POP3_TYPE_APOP;
         pop3c->sasl.prefmech = SASL_AUTH_NONE;
         result = CURLE_OK;

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -66,7 +66,6 @@
 #include "socks.h"
 #include "pingpong.h"
 #include "pop3.h"
-#include "strcase.h"
 #include "vtls/vtls.h"
 #include "cfilters.h"
 #include "connect.h"

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -1874,23 +1874,23 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     if(!ptr)
       break;
 
-    if(strcasecompare(ptr, "ALL")) {
+    if(curl_strequal(ptr, "ALL")) {
       /* clear all cookies */
       Curl_share_lock(data, CURL_LOCK_DATA_COOKIE, CURL_LOCK_ACCESS_SINGLE);
       Curl_cookie_clearall(data->cookies);
       Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
     }
-    else if(strcasecompare(ptr, "SESS")) {
+    else if(curl_strequal(ptr, "SESS")) {
       /* clear session cookies */
       Curl_share_lock(data, CURL_LOCK_DATA_COOKIE, CURL_LOCK_ACCESS_SINGLE);
       Curl_cookie_clearsess(data->cookies);
       Curl_share_unlock(data, CURL_LOCK_DATA_COOKIE);
     }
-    else if(strcasecompare(ptr, "FLUSH")) {
+    else if(curl_strequal(ptr, "FLUSH")) {
       /* flush cookies to file, takes care of the locking */
       Curl_flush_cookies(data, FALSE);
     }
-    else if(strcasecompare(ptr, "RELOAD")) {
+    else if(curl_strequal(ptr, "RELOAD")) {
       /* reload cookies from file */
       Curl_cookie_loadfiles(data);
       break;
@@ -2554,12 +2554,12 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     return Curl_setstropt(&data->set.str[STRING_TLSAUTH_PASSWORD_PROXY], ptr);
 #endif
   case CURLOPT_TLSAUTH_TYPE:
-    if(ptr && !strcasecompare(ptr, "SRP"))
+    if(ptr && !curl_strequal(ptr, "SRP"))
       return CURLE_BAD_FUNCTION_ARGUMENT;
     break;
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_TLSAUTH_TYPE:
-    if(ptr && !strcasecompare(ptr, "SRP"))
+    if(ptr && !curl_strequal(ptr, "SRP"))
       return CURLE_BAD_FUNCTION_ARGUMENT;
     break;
 #endif

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -68,7 +68,6 @@
 #include "mime.h"
 #include "socks.h"
 #include "smtp.h"
-#include "strcase.h"
 #include "vtls/vtls.h"
 #include "cfilters.h"
 #include "connect.h"

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -1775,7 +1775,7 @@ static CURLcode smtp_parse_url_options(struct connectdata *conn,
     while(*ptr && *ptr != ';')
       ptr++;
 
-    if(strncasecompare(key, "AUTH=", 5))
+    if(curl_strnequal(key, "AUTH=", 5))
       result = Curl_sasl_parse_url_auth_option(&smtpc->sasl,
                                                value, ptr - value);
     else

--- a/lib/strcase.h
+++ b/lib/strcase.h
@@ -26,18 +26,6 @@
 
 #include <curl/curl.h>
 
-/*
- * Only "raw" case insensitive strings. This is meant to be locale independent
- * and only compare strings we know are safe for this.
- *
- * The function is capable of comparing a-z case insensitively.
- *
- * Result is 1 if text matches and 0 if not.
- */
-
-#define strcasecompare(a,b) curl_strequal(a,b)
-#define strncasecompare(a,b,c) curl_strnequal(a,b,c)
-
 char Curl_raw_toupper(char in);
 char Curl_raw_tolower(char in);
 

--- a/lib/strequal.c
+++ b/lib/strequal.c
@@ -65,6 +65,15 @@ static int ncasecompare(const char *first, const char *second, size_t max)
   return Curl_raw_toupper(*first) == Curl_raw_toupper(*second);
 }
 
+/*
+ * Only "raw" case insensitive strings. This is meant to be locale independent
+ * and only compare strings we know are safe for this.
+ *
+ * The function is capable of comparing a-z case insensitively.
+ *
+ * Result is 1 if text matches and 0 if not.
+ */
+
 /* --- public function --- */
 int curl_strequal(const char *first, const char *second)
 {

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -839,7 +839,7 @@ static CURLcode check_telnet_options(struct Curl_easy *data,
       switch(olen) {
       case 5:
         /* Terminal type */
-        if(strncasecompare(option, "TTYPE", 5)) {
+        if(curl_strnequal(option, "TTYPE", 5)) {
           tn->subopt_ttype = arg;
           tn->us_preferred[CURL_TELOPT_TTYPE] = CURL_YES;
           break;
@@ -849,7 +849,7 @@ static CURLcode check_telnet_options(struct Curl_easy *data,
 
       case 8:
         /* Display variable */
-        if(strncasecompare(option, "XDISPLOC", 8)) {
+        if(curl_strnequal(option, "XDISPLOC", 8)) {
           tn->subopt_xdisploc = arg;
           tn->us_preferred[CURL_TELOPT_XDISPLOC] = CURL_YES;
           break;
@@ -859,7 +859,7 @@ static CURLcode check_telnet_options(struct Curl_easy *data,
 
       case 7:
         /* Environment variable */
-        if(strncasecompare(option, "NEW_ENV", 7)) {
+        if(curl_strnequal(option, "NEW_ENV", 7)) {
           beg = curl_slist_append(tn->telnet_vars, arg);
           if(!beg) {
             result = CURLE_OUT_OF_MEMORY;
@@ -874,7 +874,7 @@ static CURLcode check_telnet_options(struct Curl_easy *data,
 
       case 2:
         /* Window Size */
-        if(strncasecompare(option, "WS", 2)) {
+        if(curl_strnequal(option, "WS", 2)) {
           const char *p = arg;
           curl_off_t x = 0;
           curl_off_t y = 0;
@@ -896,7 +896,7 @@ static CURLcode check_telnet_options(struct Curl_easy *data,
 
       case 6:
         /* To take care or not of the 8th bit in data exchange */
-        if(strncasecompare(option, "BINARY", 6)) {
+        if(curl_strnequal(option, "BINARY", 6)) {
           int binary_option = atoi(arg);
           if(binary_option != 1) {
             tn->us_preferred[CURL_TELOPT_BINARY] = CURL_NO;

--- a/lib/telnet.c
+++ b/lib/telnet.c
@@ -57,7 +57,6 @@
 #include "system_win32.h"
 #include "arpa_telnet.h"
 #include "select.h"
-#include "strcase.h"
 #include "curlx/warnless.h"
 #include "curlx/strparse.h"
 

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -106,7 +106,7 @@ char *Curl_checkheaders(const struct Curl_easy *data,
   DEBUGASSERT(thisheader[thislen-1] != ':');
 
   for(head = data->set.headers; head; head = head->next) {
-    if(strncasecompare(head->data, thisheader, thislen) &&
+    if(curl_strnequal(head->data, thisheader, thislen) &&
        Curl_headersep(head->data[thislen]) )
       return head->data;
   }

--- a/lib/transfer.c
+++ b/lib/transfer.c
@@ -79,7 +79,6 @@
 #include "connect.h"
 #include "http2.h"
 #include "mime.h"
-#include "strcase.h"
 #include "hsts.h"
 #include "setopt.h"
 #include "headers.h"

--- a/lib/url.c
+++ b/lib/url.c
@@ -643,7 +643,7 @@ proxy_info_matches(const struct proxy_info *data,
 {
   if((data->proxytype == needle->proxytype) &&
      (data->port == needle->port) &&
-     strcasecompare(data->host.name, needle->host.name))
+     curl_strequal(data->host.name, needle->host.name))
     return TRUE;
 
   return FALSE;
@@ -1128,7 +1128,7 @@ static bool url_match_destination(struct connectdata *conn,
      || !m->needle->bits.httpproxy || m->needle->bits.tunnel_proxy
 #endif
     ) {
-    if(!strcasecompare(m->needle->handler->scheme, conn->handler->scheme)) {
+    if(!curl_strequal(m->needle->handler->scheme, conn->handler->scheme)) {
       /* `needle` and `conn` do not have the same scheme... */
       if(get_protocol_family(conn->handler) != m->needle->handler->protocol) {
         /* and `conn`s protocol family is not the protocol `needle` wants.
@@ -1145,14 +1145,14 @@ static bool url_match_destination(struct connectdata *conn,
     }
 
     /* If needle has "conn_to_*" set, conn must match this */
-    if((m->needle->bits.conn_to_host && !strcasecompare(
+    if((m->needle->bits.conn_to_host && !curl_strequal(
         m->needle->conn_to_host.name, conn->conn_to_host.name)) ||
        (m->needle->bits.conn_to_port &&
          m->needle->conn_to_port != conn->conn_to_port))
       return FALSE;
 
     /* hostname and port must match */
-    if(!strcasecompare(m->needle->host.name, conn->host.name) ||
+    if(!curl_strequal(m->needle->host.name, conn->host.name) ||
        m->needle->remote_port != conn->remote_port)
       return FALSE;
   }
@@ -1714,7 +1714,7 @@ const struct Curl_handler *Curl_getn_scheme_handler(const char *scheme,
     }
 
     h = protocols[c % 67];
-    if(h && strncasecompare(scheme, h->scheme, len) && !h->scheme[len])
+    if(h && curl_strnequal(scheme, h->scheme, len) && !h->scheme[len])
       return h;
   }
   return NULL;
@@ -1888,7 +1888,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
 
   uc = curl_url_get(uh, CURLUPART_HOST, &data->state.up.hostname, 0);
   if(uc) {
-    if(!strcasecompare("file", data->state.up.scheme))
+    if(!curl_strequal("file", data->state.up.scheme))
       return CURLE_OUT_OF_MEMORY;
   }
   else if(strlen(data->state.up.hostname) > MAX_URL_LEN) {
@@ -1925,7 +1925,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
 
 #ifndef CURL_DISABLE_HSTS
   /* HSTS upgrade */
-  if(data->hsts && strcasecompare("http", data->state.up.scheme)) {
+  if(data->hsts && curl_strequal("http", data->state.up.scheme)) {
     /* This MUST use the IDN decoded name */
     if(Curl_hsts(data->hsts, conn->host.name, strlen(conn->host.name), TRUE)) {
       char *url;
@@ -2019,7 +2019,7 @@ static CURLcode parseurlandfillconn(struct Curl_easy *data,
   uc = curl_url_get(uh, CURLUPART_PORT, &data->state.up.port,
                     CURLU_DEFAULT_PORT);
   if(uc) {
-    if(!strcasecompare("file", data->state.up.scheme))
+    if(!curl_strequal("file", data->state.up.scheme))
       return CURLE_OUT_OF_MEMORY;
   }
   else {
@@ -2198,7 +2198,7 @@ static char *detect_proxy(struct Curl_easy *data,
    * This can cause 'internal' http/ftp requests to be
    * arbitrarily redirected by any external attacker.
    */
-  if(!proxy && !strcasecompare("http_proxy", proxy_env)) {
+  if(!proxy && !curl_strequal("http_proxy", proxy_env)) {
     /* There was no lowercase variable, try the uppercase version: */
     Curl_strntoupper(proxy_env, proxy_env, sizeof(proxy_env));
     proxy = curl_getenv(proxy_env);
@@ -2207,10 +2207,10 @@ static char *detect_proxy(struct Curl_easy *data,
   if(!proxy) {
 #ifndef CURL_DISABLE_WEBSOCKETS
     /* websocket proxy fallbacks */
-    if(strcasecompare("ws_proxy", proxy_env)) {
+    if(curl_strequal("ws_proxy", proxy_env)) {
       proxy = curl_getenv("http_proxy");
     }
-    else if(strcasecompare("wss_proxy", proxy_env)) {
+    else if(curl_strequal("wss_proxy", proxy_env)) {
       proxy = curl_getenv("https_proxy");
       if(!proxy)
         proxy = curl_getenv("HTTPS_PROXY");
@@ -2277,22 +2277,22 @@ static CURLcode parse_proxy(struct Curl_easy *data,
       goto error;
     }
 
-    if(strcasecompare("https", scheme)) {
+    if(curl_strequal("https", scheme)) {
       if(proxytype != CURLPROXY_HTTPS2)
         proxytype = CURLPROXY_HTTPS;
       else
         proxytype = CURLPROXY_HTTPS2;
     }
-    else if(strcasecompare("socks5h", scheme))
+    else if(curl_strequal("socks5h", scheme))
       proxytype = CURLPROXY_SOCKS5_HOSTNAME;
-    else if(strcasecompare("socks5", scheme))
+    else if(curl_strequal("socks5", scheme))
       proxytype = CURLPROXY_SOCKS5;
-    else if(strcasecompare("socks4a", scheme))
+    else if(curl_strequal("socks4a", scheme))
       proxytype = CURLPROXY_SOCKS4A;
-    else if(strcasecompare("socks4", scheme) ||
-            strcasecompare("socks", scheme))
+    else if(curl_strequal("socks4", scheme) ||
+            curl_strequal("socks", scheme))
       proxytype = CURLPROXY_SOCKS4;
-    else if(strcasecompare("http", scheme))
+    else if(curl_strequal("http", scheme))
       ; /* leave it as HTTP or HTTP/1.0 */
     else {
       /* Any other xxx:// reject! */
@@ -2393,7 +2393,7 @@ static CURLcode parse_proxy(struct Curl_easy *data,
     goto error;
   }
 #ifdef USE_UNIX_SOCKETS
-  if(sockstype && strcasecompare(UNIX_SOCKET_PREFIX, host)) {
+  if(sockstype && curl_strequal(UNIX_SOCKET_PREFIX, host)) {
     uc = curl_url_get(uhp, CURLUPART_PATH, &path, CURLU_URLDECODE);
     if(uc) {
       result = CURLE_OUT_OF_MEMORY;
@@ -3067,7 +3067,7 @@ static CURLcode parse_connect_to_string(struct Curl_easy *data,
     if(!hostname_to_match)
       return CURLE_OUT_OF_MEMORY;
     hostname_to_match_len = strlen(hostname_to_match);
-    host_match = strncasecompare(ptr, hostname_to_match,
+    host_match = curl_strnequal(ptr, hostname_to_match,
                                  hostname_to_match_len);
     free(hostname_to_match);
     ptr += hostname_to_match_len;
@@ -3601,7 +3601,7 @@ static CURLcode create_conn(struct Curl_easy *data,
    * Do this after the hostnames have been IDN-converted.
    *************************************************************/
   if(conn->bits.conn_to_host &&
-     strcasecompare(conn->conn_to_host.name, conn->host.name)) {
+     curl_strequal(conn->conn_to_host.name, conn->host.name)) {
     conn->bits.conn_to_host = FALSE;
   }
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -3068,7 +3068,7 @@ static CURLcode parse_connect_to_string(struct Curl_easy *data,
       return CURLE_OUT_OF_MEMORY;
     hostname_to_match_len = strlen(hostname_to_match);
     host_match = curl_strnequal(ptr, hostname_to_match,
-                                 hostname_to_match_len);
+                                hostname_to_match_len);
     free(hostname_to_match);
     ptr += hostname_to_match_len;
 

--- a/lib/urlapi.c
+++ b/lib/urlapi.c
@@ -1427,7 +1427,7 @@ static CURLUcode urlget_url(const CURLU *u, char **part, unsigned int flags)
   bool depunyfy = (flags & CURLU_PUNY2IDN) ? 1 : 0;
   bool urlencode = (flags & CURLU_URLENCODE) ? 1 : 0;
   char portbuf[7];
-  if(u->scheme && strcasecompare("file", u->scheme)) {
+  if(u->scheme && curl_strequal("file", u->scheme)) {
     url = aprintf("file://%s%s%s%s%s",
                   u->path,
                   show_query ? "?": "",

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -42,7 +42,6 @@
 #include "../vtls/vtls.h"
 #include "../curlx/warnless.h"
 #include "../curlx/strparse.h"
-#include "../strcase.h"
 #include "../curl_printf.h"
 #include "../rand.h"
 

--- a/lib/vauth/digest.c
+++ b/lib/vauth/digest.c
@@ -510,31 +510,31 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
 
     /* Extract a value=content pair */
     if(Curl_auth_digest_get_pair(chlg, value, content, &chlg)) {
-      if(strcasecompare(value, "nonce")) {
+      if(curl_strequal(value, "nonce")) {
         free(digest->nonce);
         digest->nonce = strdup(content);
         if(!digest->nonce)
           return CURLE_OUT_OF_MEMORY;
       }
-      else if(strcasecompare(value, "stale")) {
-        if(strcasecompare(content, "true")) {
+      else if(curl_strequal(value, "stale")) {
+        if(curl_strequal(content, "true")) {
           digest->stale = TRUE;
           digest->nc = 1; /* we make a new nonce now */
         }
       }
-      else if(strcasecompare(value, "realm")) {
+      else if(curl_strequal(value, "realm")) {
         free(digest->realm);
         digest->realm = strdup(content);
         if(!digest->realm)
           return CURLE_OUT_OF_MEMORY;
       }
-      else if(strcasecompare(value, "opaque")) {
+      else if(curl_strequal(value, "opaque")) {
         free(digest->opaque);
         digest->opaque = strdup(content);
         if(!digest->opaque)
           return CURLE_OUT_OF_MEMORY;
       }
-      else if(strcasecompare(value, "qop")) {
+      else if(curl_strequal(value, "qop")) {
         const char *token = content;
         struct Curl_str out;
         bool foundAuth = FALSE;
@@ -568,28 +568,28 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
             return CURLE_OUT_OF_MEMORY;
         }
       }
-      else if(strcasecompare(value, "algorithm")) {
+      else if(curl_strequal(value, "algorithm")) {
         free(digest->algorithm);
         digest->algorithm = strdup(content);
         if(!digest->algorithm)
           return CURLE_OUT_OF_MEMORY;
 
-        if(strcasecompare(content, "MD5-sess"))
+        if(curl_strequal(content, "MD5-sess"))
           digest->algo = ALGO_MD5SESS;
-        else if(strcasecompare(content, "MD5"))
+        else if(curl_strequal(content, "MD5"))
           digest->algo = ALGO_MD5;
-        else if(strcasecompare(content, "SHA-256"))
+        else if(curl_strequal(content, "SHA-256"))
           digest->algo = ALGO_SHA256;
-        else if(strcasecompare(content, "SHA-256-SESS"))
+        else if(curl_strequal(content, "SHA-256-SESS"))
           digest->algo = ALGO_SHA256SESS;
-        else if(strcasecompare(content, "SHA-512-256")) {
+        else if(curl_strequal(content, "SHA-512-256")) {
 #ifdef CURL_HAVE_SHA512_256
           digest->algo = ALGO_SHA512_256;
 #else  /* ! CURL_HAVE_SHA512_256 */
           return CURLE_NOT_BUILT_IN;
 #endif /* ! CURL_HAVE_SHA512_256 */
         }
-        else if(strcasecompare(content, "SHA-512-256-SESS")) {
+        else if(curl_strequal(content, "SHA-512-256-SESS")) {
 #ifdef CURL_HAVE_SHA512_256
           digest->algo = ALGO_SHA512_256SESS;
 #else  /* ! CURL_HAVE_SHA512_256 */
@@ -599,8 +599,8 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
         else
           return CURLE_BAD_CONTENT_ENCODING;
       }
-      else if(strcasecompare(value, "userhash")) {
-        if(strcasecompare(content, "true")) {
+      else if(curl_strequal(value, "userhash")) {
+        if(curl_strequal(content, "true")) {
           digest->userhash = TRUE;
         }
       }
@@ -771,7 +771,7 @@ static CURLcode auth_create_digest_http_message(
   if(!hashthis)
     return CURLE_OUT_OF_MEMORY;
 
-  if(digest->qop && strcasecompare(digest->qop, "auth-int")) {
+  if(digest->qop && curl_strequal(digest->qop, "auth-int")) {
     /* We do not support auth-int for PUT or POST */
     char hashed[65];
     char *hashthis2;

--- a/lib/vauth/digest_sspi.c
+++ b/lib/vauth/digest_sspi.c
@@ -270,7 +270,7 @@ CURLcode Curl_override_sspi_http_realm(const char *chlg,
 
       /* Extract a value=content pair */
       if(Curl_auth_digest_get_pair(chlg, value, content, &chlg)) {
-        if(strcasecompare(value, "realm")) {
+        if(curl_strequal(value, "realm")) {
 
           /* Setup identity's domain and length */
           domain.tchar_ptr = curlx_convert_UTF8_to_tchar(content);
@@ -345,8 +345,8 @@ CURLcode Curl_auth_decode_digest_http_message(const char *chlg,
       if(!Curl_auth_digest_get_pair(p, value, content, &p))
         break;
 
-      if(strcasecompare(value, "stale") &&
-         strcasecompare(content, "true")) {
+      if(curl_strequal(value, "stale") &&
+         curl_strequal(content, "true")) {
         stale = TRUE;
         break;
       }

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -28,7 +28,6 @@
 
 #include "vauth.h"
 #include "../urldata.h"
-#include "../strcase.h"
 #include "../curlx/multibyte.h"
 #include "../curl_printf.h"
 #include "../url.h"

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -157,7 +157,7 @@ bool Curl_auth_allowed_to_host(struct Curl_easy *data)
   return !data->state.this_is_a_follow ||
          data->set.allow_auth_to_other_hosts ||
          (data->state.first_host &&
-          strcasecompare(data->state.first_host, conn->host.name) &&
+          curl_strequal(data->state.first_host, conn->host.name) &&
           (data->state.first_remote_port == conn->remote_port) &&
           (data->state.first_remote_protocol == conn->handler->protocol));
 }

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -52,7 +52,6 @@
 #include "../strdup.h"
 #include "../rand.h"
 #include "../multiif.h"
-#include "../strcase.h"
 #include "../cfilters.h"
 #include "../cf-socket.h"
 #include "../connect.h"

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -37,7 +37,6 @@
 #include "../strdup.h"
 #include "../rand.h"
 #include "../multiif.h"
-#include "../strcase.h"
 #include "../cfilters.h"
 #include "../cf-socket.h"
 #include "../connect.h"

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -36,7 +36,6 @@
 #include "../sendf.h"
 #include "../strdup.h"
 #include "../rand.h"
-#include "../strcase.h"
 #include "../multiif.h"
 #include "../connect.h"
 #include "../progress.h"

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -363,7 +363,7 @@ static int myssh_is_known(struct Curl_easy *data, struct ssh_conn *sshc)
 
     infof(data, "SSH MD5 fingerprint: %s", md5buffer);
 
-    if(!strcasecompare(md5buffer, pubkey_md5)) {
+    if(!curl_strequal(md5buffer, pubkey_md5)) {
       failf(data,
             "Denied establishing ssh session: mismatch md5 fingerprint. "
             "Remote %s is not equal to %s", md5buffer, pubkey_md5);
@@ -1584,7 +1584,7 @@ static int myssh_in_SFTP_QUOTE(struct Curl_easy *data,
     sshc->acceptfail = TRUE;
   }
 
-  if(strcasecompare("pwd", cmd)) {
+  if(curl_strequal("pwd", cmd)) {
     /* output debug output if that is requested */
     char *tmp = aprintf("257 \"%s\" is current directory.\n", sshp->path);
     if(!tmp) {

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -58,7 +58,6 @@
 #include "../speedcheck.h"
 #include "../getinfo.h"
 #include "../strdup.h"
-#include "../strcase.h"
 #include "../vtls/vtls.h"
 #include "../cfilters.h"
 #include "../connect.h"

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -695,7 +695,7 @@ static CURLcode ssh_check_fingerprint(struct Curl_easy *data,
 
     /* This does NOT verify the length of 'pubkey_md5' separately, which will
        make the comparison below fail unless it is exactly 32 characters */
-    if(!fingerprint || !strcasecompare(md5buffer, pubkey_md5)) {
+    if(!fingerprint || !curl_strequal(md5buffer, pubkey_md5)) {
       if(fingerprint) {
         failf(data,
               "Denied establishing ssh session: mismatch md5 fingerprint. "
@@ -919,7 +919,7 @@ static CURLcode sftp_quote(struct Curl_easy *data,
     sshc->acceptfail = TRUE;
   }
 
-  if(strcasecompare("pwd", cmd)) {
+  if(curl_strequal("pwd", cmd)) {
     /* output debug output if that is requested */
     char *tmp = aprintf("257 \"%s\" is current directory.\n", sshp->path);
     if(!tmp)

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -61,7 +61,6 @@
 #include "../speedcheck.h"
 #include "../getinfo.h"
 #include "../strdup.h"
-#include "../strcase.h"
 #include "../vtls/vtls.h"
 #include "../cfilters.h"
 #include "../connect.h"

--- a/lib/vtls/cipher_suite.c
+++ b/lib/vtls/cipher_suite.c
@@ -26,7 +26,6 @@
 #if defined(USE_MBEDTLS) || defined(USE_RUSTLS)
 #include "cipher_suite.h"
 #include "../curl_printf.h"
-#include "../strcase.h"
 #include <string.h>
 
 /*

--- a/lib/vtls/cipher_suite.c
+++ b/lib/vtls/cipher_suite.c
@@ -561,7 +561,7 @@ static int cs_str_to_zip(const char *cs_str, size_t cs_len,
   size_t len;
 
   /* split the cipher string by '-' or '_' */
-  if(strncasecompare(cs_str, "TLS", 3))
+  if(curl_strnequal(cs_str, "TLS", 3))
     separator = '_';
 
   do {
@@ -576,7 +576,7 @@ static int cs_str_to_zip(const char *cs_str, size_t cs_len,
     /* lookup index for the part (skip empty string at 0) */
     for(idx = 1, entry = cs_txt + 1; idx < CS_TXT_LEN; idx++) {
       size_t elen = strlen(entry);
-      if(elen == len && strncasecompare(entry, cur, len))
+      if(elen == len && curl_strnequal(entry, cur, len))
         break;
       entry += elen + 1;
     }

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -53,7 +53,6 @@
 #include "../connect.h" /* for the connect timeout */
 #include "../progress.h"
 #include "../select.h"
-#include "../strcase.h"
 #include "../strdup.h"
 #include "../curlx/warnless.h"
 #include "x509asn1.h"

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -303,9 +303,9 @@ static gnutls_x509_crt_fmt_t gnutls_do_file_type(const char *type)
 {
   if(!type || !type[0])
     return GNUTLS_X509_FMT_PEM;
-  if(strcasecompare(type, "PEM"))
+  if(curl_strequal(type, "PEM"))
     return GNUTLS_X509_FMT_PEM;
-  if(strcasecompare(type, "DER"))
+  if(curl_strequal(type, "DER"))
     return GNUTLS_X509_FMT_DER;
   return GNUTLS_X509_FMT_PEM; /* default to PEM */
 }
@@ -982,7 +982,7 @@ static CURLcode gtls_client_init(struct Curl_cfilter *cf,
       if(result)
         return result;
     }
-    if(ssl_config->cert_type && strcasecompare(ssl_config->cert_type, "P12")) {
+    if(ssl_config->cert_type && curl_strequal(ssl_config->cert_type, "P12")) {
       rc = gnutls_certificate_set_x509_simple_pkcs12_file(
         gtls->shared_creds->creds, config->clientcert, GNUTLS_X509_FMT_DER,
         ssl_config->key_passwd ? ssl_config->key_passwd : "");

--- a/lib/vtls/hostcheck.c
+++ b/lib/vtls/hostcheck.c
@@ -50,7 +50,7 @@ static bool pmatch(const char *hostname, size_t hostlen,
 {
   if(hostlen != patternlen)
     return FALSE;
-  return strncasecompare(hostname, pattern, hostlen);
+  return curl_strnequal(hostname, pattern, hostlen);
 }
 
 /*

--- a/lib/vtls/hostcheck.c
+++ b/lib/vtls/hostcheck.c
@@ -36,7 +36,6 @@
 #endif
 #include "../curl_memrchr.h"
 #include "hostcheck.h"
-#include "../strcase.h"
 #include "../hostip.h"
 
 #include "../curl_memory.h"

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -57,7 +57,6 @@
 #endif /* MBEDTLS_VERSION_MAJOR >= 2 */
 
 #include "cipher_suite.h"
-#include "../strcase.h"
 #include "../urldata.h"
 #include "../sendf.h"
 #include "../curlx/inet_pton.h"

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -382,7 +382,7 @@ mbed_cipher_suite_walk_str(const char **str, const char **end)
   size_t len = *end - *str;
 
   if(!id) {
-    if(strncasecompare("TLS_ECJPAKE_WITH_AES_128_CCM_8", *str, len))
+    if(curl_strnequal("TLS_ECJPAKE_WITH_AES_128_CCM_8", *str, len))
       id = MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8;
   }
   return id;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1058,15 +1058,15 @@ static int ossl_do_file_type(const char *type)
 {
   if(!type || !type[0])
     return SSL_FILETYPE_PEM;
-  if(strcasecompare(type, "PEM"))
+  if(curl_strequal(type, "PEM"))
     return SSL_FILETYPE_PEM;
-  if(strcasecompare(type, "DER"))
+  if(curl_strequal(type, "DER"))
     return SSL_FILETYPE_ASN1;
-  if(strcasecompare(type, "PROV"))
+  if(curl_strequal(type, "PROV"))
     return SSL_FILETYPE_PROVIDER;
-  if(strcasecompare(type, "ENG"))
+  if(curl_strequal(type, "ENG"))
     return SSL_FILETYPE_ENGINE;
-  if(strcasecompare(type, "P12"))
+  if(curl_strequal(type, "P12"))
     return SSL_FILETYPE_PKCS12;
   return -1;
 }
@@ -1119,7 +1119,7 @@ static int ssl_ui_writer(UI *ui, UI_STRING *uis)
  */
 static bool is_pkcs11_uri(const char *string)
 {
-  return string && strncasecompare(string, "pkcs11:", 7);
+  return string && curl_strnequal(string, "pkcs11:", 7);
 }
 
 #endif
@@ -5520,7 +5520,7 @@ size_t Curl_ossl_version(char *buffer, size_t size)
   size_t count;
   const char *ver = OpenSSL_version(OPENSSL_VERSION);
   const char expected[] = OSSL_PACKAGE " "; /* ie "LibreSSL " */
-  if(strncasecompare(ver, expected, sizeof(expected) - 1)) {
+  if(curl_strnequal(ver, expected, sizeof(expected) - 1)) {
     ver += sizeof(expected) - 1;
   }
   count = msnprintf(buffer, size, "%s/%s", OSSL_PACKAGE, ver);

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -60,7 +60,6 @@
 #include "vtls_scache.h"
 #include "../vauth/vauth.h"
 #include "keylog.h"
-#include "../strcase.h"
 #include "hostcheck.h"
 #include "../multiif.h"
 #include "../curlx/strparse.h"

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -42,7 +42,6 @@
 #include "vtls.h"
 #include "vtls_int.h"
 #include "vtls_scache.h"
-#include "../strcase.h"
 #include "../sendf.h"
 #include "../connect.h" /* for the connect timeout */
 #include "../strerror.h"

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -598,7 +598,7 @@ schannel_acquire_credential_handle(struct Curl_cfilter *cf,
     }
 
     if((fInCert || blob) && (data->set.ssl.cert_type) &&
-       (!strcasecompare(data->set.ssl.cert_type, "P12"))) {
+       (!curl_strequal(data->set.ssl.cert_type, "P12"))) {
       failf(data, "schannel: certificate format compatibility error "
             " for %s",
             blob ? "(memory blob)" : data->set.ssl.primary.clientcert);

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1084,7 +1084,7 @@ static int multissl_setup(const struct Curl_ssl *backend)
 #ifdef CURL_DEFAULT_SSL_BACKEND
   for(i = 0; available_backends[i]; i++) {
     if(curl_strequal(CURL_DEFAULT_SSL_BACKEND,
-                      available_backends[i]->info.name)) {
+                     available_backends[i]->info.name)) {
       Curl_ssl = available_backends[i];
       free(env);
       return 0;

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -207,12 +207,12 @@ match_ssl_primary_config(struct Curl_easy *data,
      !Curl_timestrcmp(c1->username, c2->username) &&
      !Curl_timestrcmp(c1->password, c2->password) &&
 #endif
-     strcasecompare(c1->cipher_list, c2->cipher_list) &&
-     strcasecompare(c1->cipher_list13, c2->cipher_list13) &&
-     strcasecompare(c1->curves, c2->curves) &&
-     strcasecompare(c1->signature_algorithms, c2->signature_algorithms) &&
-     strcasecompare(c1->CRLfile, c2->CRLfile) &&
-     strcasecompare(c1->pinned_key, c2->pinned_key))
+     curl_strequal(c1->cipher_list, c2->cipher_list) &&
+     curl_strequal(c1->cipher_list13, c2->cipher_list13) &&
+     curl_strequal(c1->curves, c2->curves) &&
+     curl_strequal(c1->signature_algorithms, c2->signature_algorithms) &&
+     curl_strequal(c1->CRLfile, c2->CRLfile) &&
+     curl_strequal(c1->pinned_key, c2->pinned_key))
     return TRUE;
 
   return FALSE;
@@ -1073,7 +1073,7 @@ static int multissl_setup(const struct Curl_ssl *backend)
   env = curl_getenv("CURL_SSL_BACKEND");
   if(env) {
     for(i = 0; available_backends[i]; i++) {
-      if(strcasecompare(env, available_backends[i]->info.name)) {
+      if(curl_strequal(env, available_backends[i]->info.name)) {
         Curl_ssl = available_backends[i];
         free(env);
         return 0;
@@ -1083,7 +1083,7 @@ static int multissl_setup(const struct Curl_ssl *backend)
 
 #ifdef CURL_DEFAULT_SSL_BACKEND
   for(i = 0; available_backends[i]; i++) {
-    if(strcasecompare(CURL_DEFAULT_SSL_BACKEND,
+    if(curl_strequal(CURL_DEFAULT_SSL_BACKEND,
                       available_backends[i]->info.name)) {
       Curl_ssl = available_backends[i];
       free(env);
@@ -1110,7 +1110,7 @@ CURLsslset Curl_init_sslset_nolock(curl_sslbackend id, const char *name,
 
   if(Curl_ssl != &Curl_ssl_multi)
     return id == Curl_ssl->info.id ||
-           (name && strcasecompare(name, Curl_ssl->info.name)) ?
+           (name && curl_strequal(name, Curl_ssl->info.name)) ?
            CURLSSLSET_OK :
 #if defined(CURL_WITH_MULTI_SSL)
            CURLSSLSET_TOO_LATE;
@@ -1120,7 +1120,7 @@ CURLsslset Curl_init_sslset_nolock(curl_sslbackend id, const char *name,
 
   for(i = 0; available_backends[i]; i++) {
     if(available_backends[i]->info.id == id ||
-       (name && strcasecompare(available_backends[i]->info.name, name))) {
+       (name && curl_strequal(available_backends[i]->info.name, name))) {
       multissl_setup(available_backends[i]);
       return CURLSSLSET_OK;
     }

--- a/lib/vtls/vtls_scache.c
+++ b/lib/vtls/vtls_scache.c
@@ -646,7 +646,7 @@ cf_ssl_find_peer_by_key(struct Curl_easy *data,
   /* check for entries with known peer_key */
   for(i = 0; scache && i < scache->peer_count; i++) {
     if(scache->peers[i].ssl_peer_key &&
-       strcasecompare(ssl_peer_key, scache->peers[i].ssl_peer_key) &&
+       curl_strequal(ssl_peer_key, scache->peers[i].ssl_peer_key) &&
        cf_ssl_scache_match_auth(&scache->peers[i], conn_config)) {
       /* yes, we have a cached session for this! */
       *ppeer = &scache->peers[i];

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -67,7 +67,6 @@
 #include "../connect.h" /* for the connect timeout */
 #include "../progress.h"
 #include "../select.h"
-#include "../strcase.h"
 #include "../strdup.h"
 #include "x509asn1.h"
 #include "../curl_printf.h"

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -227,9 +227,9 @@ static int wssl_do_file_type(const char *type)
 {
   if(!type || !type[0])
     return WOLFSSL_FILETYPE_PEM;
-  if(strcasecompare(type, "PEM"))
+  if(curl_strequal(type, "PEM"))
     return WOLFSSL_FILETYPE_PEM;
-  if(strcasecompare(type, "DER"))
+  if(curl_strequal(type, "DER"))
     return WOLFSSL_FILETYPE_ASN1;
   return -1;
 }

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -262,7 +262,7 @@ static const struct Curl_OID *searchOID(const char *oid)
 {
   const struct Curl_OID *op;
   for(op = OIDtable; op->numoid; op++)
-    if(!strcmp(op->numoid, oid) || strcasecompare(op->textoid, oid))
+    if(!strcmp(op->numoid, oid) || curl_strequal(op->textoid, oid))
       return op;
 
   return NULL;
@@ -989,7 +989,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
 
   /* Generate all information records for the public key. */
 
-  if(strcasecompare(algo, "ecPublicKey")) {
+  if(curl_strequal(algo, "ecPublicKey")) {
     /*
      * ECC public key is all the data, a value of type BIT STRING mapped to
      * OCTET STRING and should not be parsed as an ASN.1 value.
@@ -1011,7 +1011,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
   if(!getASN1Element(&pk, pubkey->beg + 1, pubkey->end))
     return 1;
 
-  if(strcasecompare(algo, "rsaEncryption")) {
+  if(curl_strequal(algo, "rsaEncryption")) {
     const char *q;
     size_t len;
 
@@ -1046,7 +1046,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
     if(do_pubkey_field(data, certnum, "rsa(e)", &elem))
       return 1;
   }
-  else if(strcasecompare(algo, "dsa")) {
+  else if(curl_strequal(algo, "dsa")) {
     p = getASN1Element(&elem, param->beg, param->end);
     if(p) {
       if(do_pubkey_field(data, certnum, "dsa(p)", &elem))
@@ -1064,7 +1064,7 @@ static int do_pubkey(struct Curl_easy *data, int certnum,
       }
     }
   }
-  else if(strcasecompare(algo, "dhpublicnumber")) {
+  else if(curl_strequal(algo, "dhpublicnumber")) {
     p = getASN1Element(&elem, param->beg, param->end);
     if(p) {
       if(do_pubkey_field(data, certnum, "dh(p)", &elem))

--- a/lib/vtls/x509asn1.c
+++ b/lib/vtls/x509asn1.c
@@ -39,7 +39,6 @@
 
 #include <curl/curl.h>
 #include "../urldata.h"
-#include "../strcase.h"
 #include "../curl_ctype.h"
 #include "hostcheck.h"
 #include "vtls.h"


### PR DESCRIPTION
Drop `strcasecompare` and `strncasecompare` in favor of libcurl API
calls `curl_strequal` and `curl_strnequal` respectively.

Also drop unnecessary `strcase.h` includes. Include `curl/curl.h`
instead where it wasn't included before.
