### PR TITLE
GHA: fix zizmor 1.10.0 warnings, update names

### DIFF
--- a/.github/workflows/appveyor-status.yml
+++ b/.github/workflows/appveyor-status.yml
@@ -15,6 +15,7 @@ permissions: {}
 
 jobs:
   split:
+    name: 'AppVeyor Status Report'
     runs-on: ubuntu-latest
     if: ${{ github.event.sender.login == 'appveyor[bot]' }}
     permissions:

--- a/.github/workflows/appveyor-status.yml
+++ b/.github/workflows/appveyor-status.yml
@@ -29,7 +29,7 @@ jobs:
           APPVEYOR_REPOSITORY: ${{ github.event.repository.full_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo ${APPVEYOR_TARGET_URL} | sed 's/\/project\//\/api\/projects\//' | xargs -t -n1 curl -s | \
+          echo "${APPVEYOR_TARGET_URL}" | sed 's/\/project\//\/api\/projects\//' | xargs -t -n1 curl -s | \
             jq -c '.build.jobs[] | {target_url: ($target_url + "/job/" + .jobId),
                                     context: (.name | sub("^(Environment: )?"; "AppVeyor / ")),
                                     state: (.status | sub("queued"; "pending")
@@ -38,5 +38,5 @@ jobs:
                                                     | sub("failed"; "failure")
                                                     | sub("cancelled"; "error")),
                                     description: .status}' \
-                --arg target_url ${APPVEYOR_TARGET_URL} | tee /dev/stderr | parallel --pipe -j 1 -N 1 \
-              gh api --silent --input - repos/${APPVEYOR_REPOSITORY}/statuses/${APPVEYOR_COMMIT_SHA}
+                --arg target_url "${APPVEYOR_TARGET_URL}" | tee /dev/stderr | parallel --pipe -j 1 -N 1 \
+              gh api --silent --input - "repos/${APPVEYOR_REPOSITORY}/statuses/${APPVEYOR_COMMIT_SHA}"

--- a/.github/workflows/appveyor-status.yml
+++ b/.github/workflows/appveyor-status.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: AppVeyor Status Report
+name: 'AppVeyor Status Report'
 
 'on':
   status
@@ -21,7 +21,7 @@ jobs:
     permissions:
       statuses: write
     steps:
-      - name: Create individual AppVeyor build statuses
+      - name: 'Create individual AppVeyor build statuses'
         if: ${{ github.event.sha && github.event.target_url }}
         env:
           APPVEYOR_COMMIT_SHA: ${{ github.event.sha }}

--- a/.github/workflows/appveyor-status.yml
+++ b/.github/workflows/appveyor-status.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   split:
-    name: 'AppVeyor Status Report'
+    name: 'split'
     runs-on: ubuntu-latest
     if: ${{ github.event.sender.login == 'appveyor[bot]' }}
     permissions:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -134,7 +134,7 @@ jobs:
           # shellcheck disable=SC2046
           .github/scripts/badwords.pl < .github/scripts/badwords.txt $(git ls-files '**.md') docs/TODO docs/KNOWN_BUGS packages/OS400/README.OS400
 
-      - name: 'verify-synopsis'
+      - name: 'verify synopsis'
         run: .github/scripts/verify-synopsis.pl docs/libcurl/curl*.md
 
   man-examples:

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -97,7 +97,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: 'Run mdlinkcheck'
+      - name: 'mdlinkcheck'
         run: ./scripts/mdlinkcheck
 
   spellcheck:
@@ -116,7 +116,7 @@ jobs:
       - name: 'setup the custom wordlist'
         run: grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
 
-      - name: 'Check Spelling'
+      - name: 'check Spelling'
         uses: rojopolis/spellcheck-github-actions@35a02bae020e6999c5c37fabaf447f2eb8822ca7 # v0
         with:
           config_path: .github/scripts/spellcheck.yaml

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -122,7 +122,7 @@ jobs:
           config_path: .github/scripts/spellcheck.yaml
 
   badwords-synopsis:
-    name: 'badwords & synopsis'
+    name: 'badwords, synopsis'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -36,14 +36,15 @@ permissions: {}
 
 jobs:
   #  proselint:
+  #    name: 'proselint'
   #    runs-on: ubuntu-latest
   #    steps:
-  #      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+  #      - name: 'checkout'
+  #        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
   #        with:
   #          persist-credentials: false
-  #        name: checkout
   #
-  #      - name: install prereqs
+  #      - name: 'install prereqs'
   #        run: |
   #          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
   #          sudo apt-get -o Dpkg::Use-Pty=0 update
@@ -51,7 +52,7 @@ jobs:
   #          sudo apt-get -o Dpkg::Use-Pty=0 install python3-proselint
   #
   #      # config file help: https://github.com/amperser/proselint/
-  #      - name: create proselint config
+  #      - name: 'create proselint config'
   #        run: |
   #          cat <<JSON > ~/.proselintrc.json
   #          {
@@ -65,14 +66,14 @@ jobs:
   #          }
   #          JSON
   #
-  #      - name: trim headers off all *.md files
+  #      - name: 'trim headers off all *.md files'
   #        run: git ls-files -z '*.md' | xargs -0 -n1 .github/scripts/trimmarkdownheader.pl
   #
-  #      - name: check prose
+  #      - name: 'check prose'
   #        run: git ls-files -z '*.md' | grep -Evz 'CHECKSRC.md|DISTROS.md|curl_mprintf.md|CURLOPT_INTERFACE.md|interface.md' | xargs -0 proselint README
   #
   #      # This is for CHECKSRC and files with aggressive exclamation mark needs
-  #      - name: create second proselint config
+  #      - name: 'create second proselint config'
   #        run: |
   #          cat <<JSON > ~/.proselintrc.json
   #          {
@@ -86,76 +87,81 @@ jobs:
   #          }
   #          JSON
   #
-  #      - name: check special prose
+  #      - name: 'check special prose'
   #        run: proselint docs/internals/CHECKSRC.md docs/libcurl/curl_mprintf.md docs/libcurl/opts/CURLOPT_INTERFACE.md docs/cmdline-opts/interface.md
 
   linkcheck:
+    name: 'linkcheck'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: Run mdlinkcheck
+      - name: 'Run mdlinkcheck'
         run: ./scripts/mdlinkcheck
 
   spellcheck:
+    name: 'spellcheck'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: trim all *.md files in docs/
+      - name: 'trim all *.md files in docs/'
         run: |
           # shellcheck disable=SC2046
           .github/scripts/cleancmd.pl $(find docs -name '*.md')
 
-      - name: setup the custom wordlist
+      - name: 'setup the custom wordlist'
         run: grep -v '^#' .github/scripts/spellcheck.words > wordlist.txt
 
-      - name: Check Spelling
+      - name: 'Check Spelling'
         uses: rojopolis/spellcheck-github-actions@35a02bae020e6999c5c37fabaf447f2eb8822ca7 # v0
         with:
           config_path: .github/scripts/spellcheck.yaml
 
   badwords-synopsis:
+    name: 'badwords & synopsis'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: badwords
+      - name: 'badwords'
         run: |
           # shellcheck disable=SC2046
           .github/scripts/badwords.pl < .github/scripts/badwords.txt $(git ls-files '**.md') docs/TODO docs/KNOWN_BUGS packages/OS400/README.OS400
 
-      - name: verify-synopsis
+      - name: 'verify-synopsis'
         run: .github/scripts/verify-synopsis.pl docs/libcurl/curl*.md
 
   man-examples:
+    name: 'man-examples'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: verify examples
+      - name: 'verify examples'
         run: .github/scripts/verify-examples.pl docs/libcurl/curl*.md docs/libcurl/opts/*.md
 
   miscchecks:
+    name: 'spacecheck'
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: spacecheck
+      - name: 'spacecheck'
         run: .github/scripts/spacecheck.pl

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -39,8 +39,7 @@ jobs:
   #    name: 'proselint'
   #    runs-on: ubuntu-latest
   #    steps:
-  #      - name: 'checkout'
-  #        uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
+  #      - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
   #        with:
   #          persist-credentials: false
   #
@@ -94,8 +93,7 @@ jobs:
     name: 'linkcheck'
     runs-on: ubuntu-latest
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -106,8 +104,7 @@ jobs:
     name: 'spellcheck'
     runs-on: ubuntu-latest
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -128,8 +125,7 @@ jobs:
     name: 'badwords & synopsis'
     runs-on: ubuntu-latest
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -145,8 +141,7 @@ jobs:
     name: 'man-examples'
     runs-on: ubuntu-latest
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -158,8 +153,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 5
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/checkdocs.yml
+++ b/.github/workflows/checkdocs.yml
@@ -5,7 +5,7 @@
 # This workflow contains tests that operate on documentation files only. Some
 # checks modify the source so they cannot be combined into a single job.
 
-name: Docs
+name: 'Docs'
 
 'on':
   push:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -115,7 +115,7 @@ jobs:
         run: ./scripts/top-complexity
 
   miscchecks:
-    name: 'misc'
+    name: 'misc checks'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -142,7 +142,7 @@ jobs:
           .github/scripts/badwords.pl $(git ls-files -- src lib include)
 
   cicheck:
-    name: 'CI analysis'
+    name: 'CI'
     runs-on: macos-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -44,7 +44,7 @@ jobs:
         run: scripts/checksrc-all.sh
 
   codespell-cmakelint-pytype-ruff:
-    name: 'codespell & cmakelint & pytype & ruff'
+    name: 'codespell, cmakelint, pytype, ruff'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -84,18 +84,18 @@ jobs:
         run: scripts/pythonlint.sh
 
   reuse:
-    name: 'REUSE compliance'
+    name: 'REUSE'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
-      - name: 'REUSE Compliance Check'
+      - name: 'check'
         uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5
 
   complexity:
-    name: 'Cyclomatic complexity'
+    name: 'complexity'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -111,11 +111,11 @@ jobs:
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             pmccabe
 
-      - name: 'check complexity scores'
+      - name: 'check scores'
         run: ./scripts/top-complexity
 
   miscchecks:
-    name: 'Misc checks'
+    name: 'misc'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -156,7 +156,7 @@ jobs:
       - name: 'zizmor GHA'
         run: zizmor --pedantic .github/workflows/*.yml
 
-      - name: 'shellcheck'
+      - name: 'shellcheck GHA'
         run: |
           shellcheck --version
           .github/scripts/shellcheck-ci.sh

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -4,7 +4,7 @@
 
 # This workflow contains checks at the source code level only.
 
-name: Source
+name: 'Source'
 
 'on':
   push:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -95,7 +95,7 @@ jobs:
         uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5
 
   complexity:
-    name: 'REUSE'
+    name: 'Cyclomatic complexity'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -115,7 +115,7 @@ jobs:
         run: ./scripts/top-complexity
 
   miscchecks:
-    name: 'cyclomatic complexity'
+    name: 'Misc checks'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -33,25 +33,27 @@ permissions: {}
 
 jobs:
   checksrc:
+    name: 'checksrc'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: check
+      - name: 'check'
         run: scripts/checksrc-all.sh
 
   codespell-cmakelint-pytype-ruff:
+    name: 'codespell & cmakelint & pytype & ruff'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: install
+      - name: 'install'
         env:
           DEBIAN_FRONTEND: noninteractive
         run: |
@@ -65,7 +67,7 @@ jobs:
             python3-websockets python3-pytest python3-filelock python3-pytest-xdist
           python3 -m pip install --break-system-packages cmakelang==0.6.13 pytype==2024.10.11 ruff==0.11.9
 
-      - name: spellcheck
+      - name: 'spellcheck'
         run: |
           codespell \
             --skip scripts/mk-ca-bundle.pl \
@@ -74,36 +76,38 @@ jobs:
             -I .github/scripts/codespell-ignore.txt \
             CMake include m4 scripts src lib
 
-      - name: cmakelint
+      - name: 'cmakelint'
         run: scripts/cmakelint.sh
 
-      - name: pytype
+      - name: 'pytype'
         run: find . -name '*.py' -exec pytype -j auto -k {} +
 
-      - name: ruff
+      - name: 'ruff'
         run: scripts/pythonlint.sh
 
   reuse:
+    name: 'REUSE compliance'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: REUSE Compliance Check
+      - name: 'REUSE Compliance Check'
         uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542 # v5
 
   complexity:
+    name: 'REUSE'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: install pmccabe
+      - name: 'install pmccabe'
         run: |
           sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
           sudo apt-get -o Dpkg::Use-Pty=0 update
@@ -111,53 +115,54 @@ jobs:
           sudo apt-get -o Dpkg::Use-Pty=0 install \
             pmccabe
 
-      - name: check complexity scores
+      - name: 'check complexity scores'
         run: ./scripts/top-complexity
 
   miscchecks:
+    name: 'cyclomatic complexity'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: shellcheck
+      - name: 'shellcheck'
         run: |
           shellcheck --version
           .github/scripts/shellcheck.sh
 
-      - name: spacecheck
+      - name: 'spacecheck'
         run: .github/scripts/spacecheck.pl
 
-      - name: yamlcheck
+      - name: 'yamlcheck'
         run: .github/scripts/yamlcheck.sh
 
       # we allow some extra in source code
-      - name: badwords
+      - name: 'badwords'
         run: |
           # shellcheck disable=SC2046
           grep -Ev '(\\bwill| url | dir )' .github/scripts/badwords.txt | \
           .github/scripts/badwords.pl $(git ls-files -- src lib include)
 
   cicheck:
-    name: CI analysis
+    name: 'CI analysis'
     runs-on: macos-latest
     timeout-minutes: 1
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-        name: checkout
 
-      - name: install prereqs
+      - name: 'install prereqs'
         run: brew install shellcheck zizmor
 
-      - name: zizmor GHA
+      - name: 'zizmor GHA'
         run: zizmor --pedantic .github/workflows/*.yml
 
-      - name: shellcheck
+      - name: 'shellcheck'
         run: |
           shellcheck --version
           .github/scripts/shellcheck-ci.sh

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -36,8 +36,7 @@ jobs:
     name: 'checksrc'
     runs-on: ubuntu-latest
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -48,8 +47,7 @@ jobs:
     name: 'codespell & cmakelint & pytype & ruff'
     runs-on: ubuntu-latest
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -89,8 +87,7 @@ jobs:
     name: 'REUSE compliance'
     runs-on: ubuntu-latest
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -102,8 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -123,8 +119,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -151,8 +146,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 1
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: configure-vs-cmake
+name: 'configure-vs-cmake'
 'on':
   push:
     branches:

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -34,6 +34,7 @@ permissions: {}
 
 jobs:
   check-linux:
+    name: 'on Linux'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -72,6 +73,7 @@ jobs:
         run: ./.github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config
 
   check-macos:
+    name: 'on macOS'
     runs-on: macos-latest
     steps:
       - name: 'install packages'
@@ -121,6 +123,7 @@ jobs:
         run: ./.github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config
 
   check-windows:
+    name: 'on Windows'
     runs-on: ubuntu-latest
     env:
       TRIPLET: 'x86_64-w64-mingw32'

--- a/.github/workflows/configure-vs-cmake.yml
+++ b/.github/workflows/configure-vs-cmake.yml
@@ -34,7 +34,7 @@ permissions: {}
 
 jobs:
   check-linux:
-    name: 'on Linux'
+    name: 'Linux'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -73,7 +73,7 @@ jobs:
         run: ./.github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config
 
   check-macos:
-    name: 'on macOS'
+    name: 'macOS'
     runs-on: macos-latest
     steps:
       - name: 'install packages'
@@ -123,7 +123,7 @@ jobs:
         run: ./.github/scripts/cmp-pkg-config.sh bld-am/curl-config bld-cm/curl-config
 
   check-windows:
-    name: 'on Windows'
+    name: 'Windows'
     runs-on: ubuntu-latest
     env:
       TRIPLET: 'x86_64-w64-mingw32'

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 ---
-name: curl-for-win
+name: 'curl-for-win'
 
 'on':
   push:

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -43,7 +43,7 @@ env:
 
 jobs:
   linux-glibc-gcc:
-    name: 'linux-glibc-gcc'
+    name: 'Linux gcc glibc'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -72,7 +72,7 @@ jobs:
             sh -c ./_ci-linux-debian.sh
 
   linux-musl-llvm:
-    name: 'linux-musl-llvm'
+    name: 'Linux llvm MUSL'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -99,7 +99,7 @@ jobs:
             sh -c ./_ci-linux-debian.sh
 
   mac-clang:
-    name: 'mac-clang'
+    name: 'macOS clang'
     runs-on: macos-latest
     timeout-minutes: 30
     env:
@@ -119,7 +119,7 @@ jobs:
           sh -c ./_ci-mac-homebrew.sh
 
   win-llvm:
-    name: 'win-llvm'
+    name: 'Windows llvm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -145,7 +145,7 @@ jobs:
             sh -c ./_ci-linux-debian.sh
 
   win-gcc-libssh-zlibold-x86:
-    name: 'win-gcc-libssh-zlibold-x86'
+    name: 'Windows gcc libssh zlib-classic x86'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -43,6 +43,7 @@ env:
 
 jobs:
   linux-glibc-gcc:
+    name: 'linux-glibc-gcc'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -71,6 +72,7 @@ jobs:
             sh -c ./_ci-linux-debian.sh
 
   linux-musl-llvm:
+    name: 'linux-musl-llvm'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -97,6 +99,7 @@ jobs:
             sh -c ./_ci-linux-debian.sh
 
   mac-clang:
+    name: 'mac-clang'
     runs-on: macos-latest
     timeout-minutes: 30
     env:
@@ -116,6 +119,7 @@ jobs:
           sh -c ./_ci-mac-homebrew.sh
 
   win-llvm:
+    name: 'win-llvm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -141,6 +145,7 @@ jobs:
             sh -c ./_ci-linux-debian.sh
 
   win-gcc-libssh-zlibold-x86:
+    name: 'win-gcc-libssh-zlibold-x86'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   maketgz-and-verify-in-tree:
-    name: 'Verify in-tree & maketgz'
+    name: 'verify in-tree & maketgz'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -68,7 +68,7 @@ jobs:
           rm -rf curl-99.98.97
 
   verify-out-of-tree-docs:
-    name: 'Verify out-of-tree docs'
+    name: 'verify out-of-tree docs'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -92,7 +92,7 @@ jobs:
           rm -rf curl-99.98.97
 
   verify-out-of-tree-autotools-debug:
-    name: 'Verify out-of-tree with autotools (debug)'
+    name: 'verify out-of-tree with autotools (debug)'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -116,7 +116,7 @@ jobs:
           scripts/checksrc-all.sh
 
   verify-out-of-tree-cmake:
-    name: 'Verify out-of-tree with CMake'
+    name: 'verify out-of-tree with CMake'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -134,7 +134,7 @@ jobs:
           make -C build
 
   missing-files:
-    name: 'Missing files'
+    name: 'missing files'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: maketgz-and-verify-in-tree
@@ -151,7 +151,7 @@ jobs:
         run: .github/scripts/distfiles.sh curl-99.98.97.tar.gz
 
   reproducible-releases:
-    name: 'Reproducible releases'
+    name: 'reproducible releases'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   maketgz-and-verify-in-tree:
-    name: 'Verify in-tree and maketgz'
+    name: 'Verify in-tree & maketgz'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -53,7 +53,7 @@ jobs:
           path: 'curl-99.98.97.tar.gz'
           retention-days: 1
 
-      - name: 'verify in-tree configure build including install'
+      - name: 'configure build & install'
         run: |
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
@@ -77,7 +77,7 @@ jobs:
         with:
           name: 'release-tgz'
 
-      - name: 'verify out-of-tree configure build including docs'
+      - name: 'verify out-of-tree configure build & docs'
         run: |
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -108,7 +108,7 @@ jobs:
           pushd curl-99.98.97
           mkdir build
           pushd build
-          ../configure --without-ssl --enable-debug --prefix="$PWD"/curl-install --without-libpsl
+          ../configure --prefix="$PWD"/curl-install --without-ssl --enable-debug --without-libpsl
           make
           make test-ci
           make install
@@ -130,7 +130,7 @@ jobs:
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
-          cmake -B build -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF
+          cmake -B build -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF
           cmake --build build
           cmake --install build
 

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -172,7 +172,7 @@ jobs:
           ../scripts/verify-release curl-9.10.11.tar.gz
 
   cmake-integration:
-    name: 'cmake-integration-on-${{ matrix.image }}'
+    name: 'cmake integration on ${{ matrix.image }}'
     runs-on: ${{ matrix.image }}
     timeout-minutes: 10
     defaults:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   maketgz-and-verify-in-tree:
-    name: 'in-tree & maketgz'
+    name: 'AM in-tree & maketgz'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -68,7 +68,7 @@ jobs:
           rm -rf curl-99.98.97
 
   verify-out-of-tree-docs:
-    name: 'out-of-tree docs'
+    name: 'AM out-of-tree docs'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -92,7 +92,7 @@ jobs:
           rm -rf curl-99.98.97
 
   verify-out-of-tree-autotools-debug:
-    name: 'out-of-tree with autotools (debug)'
+    name: 'AM out-of-tree (debug)'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -116,7 +116,7 @@ jobs:
           scripts/checksrc-all.sh
 
   verify-out-of-tree-cmake:
-    name: 'out-of-tree with cmake'
+    name: 'CM out-of-tree'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -173,7 +173,7 @@ jobs:
           ../scripts/verify-release curl-9.10.11.tar.gz
 
   cmake-integration:
-    name: 'cmake integration ${{ matrix.image }}'
+    name: 'CM integration ${{ matrix.image }}'
     runs-on: ${{ matrix.image }}
     timeout-minutes: 10
     defaults:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -116,7 +116,7 @@ jobs:
           scripts/checksrc-all.sh
 
   verify-out-of-tree-cmake:
-    name: 'verify out-of-tree with CMake'
+    name: 'verify out-of-tree with cmake'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: dist
+name: 'dist'
 
 'on':
   push:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -131,7 +131,8 @@ jobs:
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
           cmake -B build -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF
-          make -C build
+          cmake --build build
+          cmake --install build
 
   missing-files:
     name: 'missing files'

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -24,10 +24,12 @@ env:
 
 jobs:
   maketgz-and-verify-in-tree:
+    name: 'Verify in-tree and maketgz'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -67,6 +69,7 @@ jobs:
           rm -rf curl-99.98.97
 
   verify-out-of-tree-docs:
+    name: 'Verify out-of-tree docs'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -90,6 +93,7 @@ jobs:
           rm -rf curl-99.98.97
 
   verify-out-of-tree-autotools-debug:
+    name: 'Verify out-of-tree with autotools (debug)'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -113,6 +117,7 @@ jobs:
           scripts/checksrc-all.sh
 
   verify-out-of-tree-cmake:
+    name: 'Verify out-of-tree with CMake'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -130,11 +135,13 @@ jobs:
           make -C build
 
   missing-files:
+    name: 'Missing files'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: maketgz-and-verify-in-tree
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -146,9 +153,11 @@ jobs:
         run: .github/scripts/distfiles.sh curl-99.98.97.tar.gz
 
   reproducible-releases:
+    name: 'Reproducible releases'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -182,7 +191,8 @@ jobs:
       matrix:
         image: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: msys2/setup-msys2@40677d36a502eb2cf0fb808cc9dec31bf6152638 # v2
+      - name: 'install MSYS2'
+        uses: msys2/setup-msys2@40677d36a502eb2cf0fb808cc9dec31bf6152638 # v2
         if: ${{ contains(matrix.image, 'windows') }}
         with:
           msystem: mingw64
@@ -217,7 +227,8 @@ jobs:
             printf '%s' ~/cmake-"${OLD_CMAKE_VERSION}"-Darwin-x86_64/CMake.app/Contents/bin/cmake > ~/old-cmake-path.txt
           fi
 
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: 'checkout'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   maketgz-and-verify-in-tree:
-    name: 'verify in-tree & maketgz'
+    name: 'in-tree & maketgz'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -68,7 +68,7 @@ jobs:
           rm -rf curl-99.98.97
 
   verify-out-of-tree-docs:
-    name: 'verify out-of-tree docs'
+    name: 'out-of-tree docs'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -77,7 +77,7 @@ jobs:
         with:
           name: 'release-tgz'
 
-      - name: 'verify out-of-tree configure build & docs'
+      - name: 'configure build & docs'
         run: |
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
@@ -92,7 +92,7 @@ jobs:
           rm -rf curl-99.98.97
 
   verify-out-of-tree-autotools-debug:
-    name: 'verify out-of-tree with autotools (debug)'
+    name: 'out-of-tree with autotools (debug)'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -101,7 +101,7 @@ jobs:
         with:
           name: 'release-tgz'
 
-      - name: 'verify out-of-tree autotools debug build'
+      - name: 'build & install'
         run: |
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
@@ -116,7 +116,7 @@ jobs:
           scripts/checksrc-all.sh
 
   verify-out-of-tree-cmake:
-    name: 'verify out-of-tree with cmake'
+    name: 'out-of-tree with cmake'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: maketgz-and-verify-in-tree
@@ -125,7 +125,7 @@ jobs:
         with:
           name: 'release-tgz'
 
-      - name: 'verify out-of-tree cmake build'
+      - name: 'build & install'
         run: |
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -173,7 +173,7 @@ jobs:
           ../scripts/verify-release curl-9.10.11.tar.gz
 
   cmake-integration:
-    name: 'cmake integration on ${{ matrix.image }}'
+    name: 'cmake integration ${{ matrix.image }}'
     runs-on: ${{ matrix.image }}
     timeout-minutes: 10
     defaults:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -28,8 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -140,8 +139,7 @@ jobs:
     timeout-minutes: 5
     needs: maketgz-and-verify-in-tree
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -156,8 +154,7 @@ jobs:
     name: 'Reproducible releases'
     runs-on: ubuntu-latest
     steps:
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -191,8 +188,7 @@ jobs:
       matrix:
         image: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - name: 'install MSYS2'
-        uses: msys2/setup-msys2@40677d36a502eb2cf0fb808cc9dec31bf6152638 # v2
+      - uses: msys2/setup-msys2@40677d36a502eb2cf0fb808cc9dec31bf6152638 # v2
         if: ${{ contains(matrix.image, 'windows') }}
         with:
           msystem: mingw64
@@ -227,8 +223,7 @@ jobs:
             printf '%s' ~/cmake-"${OLD_CMAKE_VERSION}"-Darwin-x86_64/CMake.app/Contents/bin/cmake > ~/old-cmake-path.txt
           fi
 
-      - name: 'checkout'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: Fuzzer
+name: 'Fuzzer'
 
 'on':
   push:

--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: Hacktoberfest
+name: 'Hacktoberfest'
 
 'on':
   # this must not ever run on any other branch than master
@@ -32,7 +32,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 100
 
-      - name: Check whether repo participates in Hacktoberfest
+      - name: 'Check whether repo participates in Hacktoberfest'
         id: check
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -40,7 +40,7 @@ jobs:
           gh config set prompt disabled && echo "label=$(
             gh repo view --json repositoryTopics --jq '.repositoryTopics[].name' | grep '^hacktoberfest$')" >> "$GITHUB_OUTPUT"
 
-      - name: Search relevant commit message lines starting with Closes/Merges
+      - name: 'Search relevant commit message lines starting with Closes/Merges'
         if: ${{ steps.check.outputs.label == 'hacktoberfest' }}
         env:
           GITHUB_EVENT_BEFORE: '${{ github.event.before }}'
@@ -49,7 +49,7 @@ jobs:
           git log --format=email "${GITHUB_EVENT_BEFORE}..${GITHUB_EVENT_AFTER}" | \
             grep -Ei '^Close[sd]? ' | sort | uniq | tee log
 
-      - name: Search for Number-based PR references
+      - name: 'Search for Number-based PR references'
         if: ${{ steps.check.outputs.label == 'hacktoberfest' }}
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
@@ -60,7 +60,7 @@ jobs:
             grep -Eo '^([0-9]+):[0-9]{4}-(09-30T|10-|11-01T)' | cut -d: -f1 | sort | uniq | xargs -t -n1 -I {} \
               gh pr edit {} --add-label 'hacktoberfest-accepted'
 
-      - name: Search for URL-based PR references
+      - name: 'Search for URL-based PR references'
         if: ${{ steps.check.outputs.label == 'hacktoberfest' }}
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -49,7 +49,7 @@ jobs:
           git log --format=email "${GITHUB_EVENT_BEFORE}..${GITHUB_EVENT_AFTER}" | \
             grep -Ei '^Close[sd]? ' | sort | uniq | tee log
 
-      - name: 'Search for Number-based PR references'
+      - name: 'Search for number-based PR references'
         if: ${{ steps.check.outputs.label == 'hacktoberfest' }}
         env:
           GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/hacktoberfest-accepted.yml
+++ b/.github/workflows/hacktoberfest-accepted.yml
@@ -20,6 +20,7 @@ jobs:
   # add hacktoberfest-accepted label to PRs opened starting from September 30th
   # till November 1st which are closed via commit reference from master branch.
   merged:
+    name: 'Add hacktoberfest-accepted label'
     runs-on: ubuntu-latest
     permissions:
       # requires issues AND pull-requests write permissions to edit labels on PRs!

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -58,6 +58,7 @@ env:
 
 jobs:
   build-cache:
+    name: 'Build caches'
     runs-on: ubuntu-latest
 
     steps:
@@ -125,7 +126,7 @@ jobs:
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.NGHTTP2_VERSION }}-${{ env.QUICTLS_VERSION }}-${{ env.NGTCP2_VERSION }}-${{ env.NGHTTP3_VERSION }}
 
       - id: settings
-        if: |
+        if: >-
           ${{ steps.cache-openssl-http3.outputs.cache-hit != 'true' ||
               steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true' ||
               steps.cache-gnutls.outputs.cache-hit != 'true' ||

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: Linux HTTP/3
+name: 'Linux HTTP/3'
 
 'on':
   push:

--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -254,7 +254,7 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: openssl
+          - name: 'openssl'
             PKG_CONFIG_PATH: /home/runner/openssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/openssl/build/lib
@@ -263,7 +263,7 @@ jobs:
               --with-openssl=/home/runner/openssl/build --enable-ssls-export
               --with-libuv
 
-          - name: quictls
+          - name: 'quictls'
             PKG_CONFIG_PATH: /home/runner/quictls/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/quictls/build/lib
@@ -272,7 +272,7 @@ jobs:
               --with-openssl=/home/runner/quictls/build --enable-ssls-export
               --with-libuv
 
-          - name: gnutls
+          - name: 'gnutls'
             PKG_CONFIG_PATH: /home/runner/gnutls/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/gnutls/build/lib
@@ -281,7 +281,7 @@ jobs:
               --with-gnutls=/home/runner/gnutls/build --enable-ssls-export
               --with-libuv
 
-          - name: wolfssl
+          - name: 'wolfssl'
             PKG_CONFIG_PATH: /home/runner/wolfssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/wolfssl/build/lib
@@ -291,7 +291,7 @@ jobs:
               --enable-ech --enable-ssls-export
               --with-libuv
 
-          - name: wolfssl
+          - name: 'wolfssl'
             PKG_CONFIG_PATH: /home/runner/wolfssl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
             generate: >-
               -DCURL_USE_WOLFSSL=ON -DUSE_NGTCP2=ON -DENABLE_DEBUG=ON
@@ -300,7 +300,7 @@ jobs:
               -DUSE_ECH=ON
               -DCURL_USE_LIBUV=ON
 
-          - name: openssl-quic
+          - name: 'openssl-quic'
             PKG_CONFIG_PATH: /home/runner/openssl/build/lib/pkgconfig
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/openssl/build/lib
@@ -310,7 +310,7 @@ jobs:
               --with-nghttp3=/home/runner/nghttp3/build
               --with-libuv
 
-          - name: quiche
+          - name: 'quiche'
             configure: >-
               LDFLAGS=-Wl,-rpath,/home/runner/quiche/target/release
               --with-openssl=/home/runner/quiche/quiche/deps/boringssl/src
@@ -320,7 +320,7 @@ jobs:
               --with-ca-fallback
               --with-libuv
 
-          - name: quiche
+          - name: 'quiche'
             PKG_CONFIG_PATH: /home/runner/quiche/target/release
             generate: >-
               -DOPENSSL_ROOT_DIR=/home/runner/quiche/quiche/deps/boringssl/src -DENABLE_DEBUG=ON

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -16,6 +16,7 @@ permissions: {}
 
 jobs:
   label:
+    name: 'Labeler'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -9,7 +9,7 @@
 # file with configuration.  For more information, see:
 # https://github.com/actions/labeler
 
-name: Labeler
+name: 'Labeler'
 'on': [pull_request_target]  # zizmor: ignore[dangerous-triggers]
 
 permissions: {}

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -16,7 +16,7 @@
 # httrack is one of the smallest downloaders, needed to bootstrap ELTS,
 # and won't conflict with the curl we're building.
 
-name: Old Linux
+name: 'Old Linux'
 
 'on':
   push:
@@ -52,7 +52,7 @@ env:
 
 jobs:
   cmake:
-    name: linux (cmake & autoconf)
+    name: 'linux (cmake & autoconf)'
     runs-on: 'ubuntu-latest'
     container: 'debian:stretch'
 

--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -51,8 +51,8 @@ env:
   DEBIAN_FRONTEND: noninteractive
 
 jobs:
-  cmake:
-    name: 'linux (cmake & autoconf)'
+  cmake-autotools:
+    name: 'cmake & autotools'
     runs-on: 'ubuntu-latest'
     container: 'debian:stretch'
 
@@ -132,18 +132,18 @@ jobs:
             --with-openssl --enable-ares --with-libssh2 --with-zstd --with-gssapi --with-librtmp \
             --prefix="$PWD"/../curl-install-am
 
-      - name: 'autoconf curl_config.h'
+      - name: 'autotools curl_config.h'
         run: |
           echo '::group::raw'; cat bld-am/lib/curl_config.h || true; echo '::endgroup::'
           grep -F '#define' bld-am/lib/curl_config.h | sort || true
 
-      - name: 'autoconf build'
+      - name: 'autotools build'
         run: |
           make -C bld-am
           bld-am/src/curl --disable --version
 
-      - name: 'autoconf install'
+      - name: 'autotools install'
         run: make -C bld-am install
 
-      - name: 'autoconf build tests'
+      - name: 'autotools build tests'
         run: make -C bld-am/tests all

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -73,114 +73,114 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - name: libressl heimdal
+          - name: 'libressl heimdal'
             install_packages: zlib1g-dev libnghttp2-dev libldap-dev heimdal-dev
             install_steps: libressl pytest
             configure: LDFLAGS=-Wl,-rpath,/home/runner/libressl/lib --with-openssl=/home/runner/libressl --with-gssapi --enable-debug
 
-          - name: libressl heimdal valgrind
+          - name: 'libressl heimdal valgrind'
             install_packages: zlib1g-dev libnghttp2-dev libldap-dev heimdal-dev valgrind
             install_steps: libressl
             generate: -DOPENSSL_ROOT_DIR=/home/runner/libressl -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LIBCURL_VERSIONED_SYMBOLS=ON
 
-          - name: libressl clang
+          - name: 'libressl clang'
             install_packages: zlib1g-dev clang
             install_steps: libressl
             configure: CC=clang LDFLAGS=-Wl,-rpath,/home/runner/libressl/lib --with-openssl=/home/runner/libressl --enable-debug
 
-          - name: wolfssl-all
+          - name: 'wolfssl-all'
             install_packages: zlib1g-dev
             install_steps: wolfssl-all
             configure: LDFLAGS=-Wl,-rpath,/home/runner/wolfssl-all/lib --with-wolfssl=/home/runner/wolfssl-all --enable-ech --enable-debug
 
-          - name: wolfssl-opensslextra valgrind
+          - name: 'wolfssl-opensslextra valgrind'
             install_packages: zlib1g-dev valgrind
             install_steps: wolfssl-opensslextra wolfssh
             configure: LDFLAGS=-Wl,-rpath,/home/runner/wolfssl-opensslextra/lib --with-wolfssl=/home/runner/wolfssl-opensslextra --with-wolfssh=/home/runner/wolfssh --enable-ech --enable-debug
 
-          - name: mbedtls valgrind
+          - name: 'mbedtls valgrind'
             install_packages: libnghttp2-dev libldap-dev valgrind
             install_steps: mbedtls
             configure: LDFLAGS=-Wl,-rpath,/home/runner/mbedtls/lib --with-mbedtls=/home/runner/mbedtls --enable-debug
 
-          - name: mbedtls clang
+          - name: 'mbedtls clang'
             install_packages: libnghttp2-dev libldap-dev clang
             install_steps: mbedtls pytest
             configure: CC=clang LDFLAGS=-Wl,-rpath,/home/runner/mbedtls/lib --with-mbedtls=/home/runner/mbedtls --enable-debug
 
-          - name: mbedtls
+          - name: 'mbedtls'
             install_packages: libnghttp2-dev
             install_steps: mbedtls
             PKG_CONFIG_PATH: /home/runner/mbedtls/lib/pkgconfig  # Requires v3.6.0 or v2.28.8
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
 
-          - name: mbedtls-pkg
+          - name: 'mbedtls-pkg'
             install_packages: libnghttp2-dev libmbedtls-dev
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
 
-          - name: mbedtls-pkg !pc
+          - name: 'mbedtls-pkg !pc'
             install_packages: libnghttp2-dev libmbedtls-dev
             install_steps: skipall
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCURL_USE_PKGCONFIG=OFF -DCURL_COMPLETION_FISH=ON -DCURL_COMPLETION_ZSH=ON
 
-          - name: msh3
+          - name: 'msh3'
             install_packages: zlib1g-dev
             install_steps: quictls msh3
             LDFLAGS: -Wl,-rpath,/home/runner/msh3/lib -Wl,-rpath,/home/runner/quictls/lib
             configure: --with-msh3=/home/runner/msh3 --with-openssl=/home/runner/quictls --enable-debug
 
-          - name: msh3
+          - name: 'msh3'
             install_packages: zlib1g-dev
             install_steps: quictls msh3 skipall
             PKG_CONFIG_PATH: /home/runner/msh3/lib/pkgconfig  # Broken as of v0.6.0
             generate: -DOPENSSL_ROOT_DIR=/home/runner/quictls -DUSE_MSH3=ON -DMSH3_INCLUDE_DIR=/home/runner/msh3/include -DMSH3_LIBRARY=/home/runner/msh3/lib/libmsh3.so -DENABLE_DEBUG=ON
 
-          - name: awslc
+          - name: 'awslc'
             install_packages: zlib1g-dev
             install_steps: awslc pytest
             configure: LDFLAGS=-Wl,-rpath,/home/runner/awslc/lib --with-openssl=/home/runner/awslc --enable-ech
 
-          - name: awslc
+          - name: 'awslc'
             install_packages: zlib1g-dev
             install_steps: awslc
             generate: -DOPENSSL_ROOT_DIR=/home/runner/awslc -DUSE_ECH=ON -DCMAKE_UNITY_BUILD=OFF
 
-          - name: openssl default
+          - name: 'openssl default'
             install_steps: pytest
             configure: --with-openssl --enable-debug --disable-unity
 
-          - name: openssl libssh2 sync-resolver valgrind
+          - name: 'openssl libssh2 sync-resolver valgrind'
             install_packages: zlib1g-dev libssh2-1-dev libnghttp2-dev libldap-dev valgrind
             configure: --with-openssl --enable-debug --disable-threaded-resolver --with-libssh2
 
-          - name: openssl
+          - name: 'openssl'
             install_packages: zlib1g-dev
             install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
 
-          - name: openssl arm
+          - name: 'openssl arm'
             install_packages: zlib1g-dev
             install_steps: pytest
             configure: CFLAGS=-std=gnu89 --with-openssl --enable-debug
             image: 'ubuntu-24.04-arm'
 
-          - name: openssl -O3 libssh valgrind
+          - name: 'openssl -O3 libssh valgrind'
             install_packages: zlib1g-dev libssh-dev valgrind
             configure: CFLAGS=-O3 --with-openssl --enable-debug --with-libssh
 
-          - name: openssl clang krb5
+          - name: 'openssl clang krb5'
             install_packages: zlib1g-dev libkrb5-dev clang
             configure: CC=clang --with-openssl --with-gssapi --enable-debug --disable-docs --disable-manual
 
-          - name: openssl clang krb5 LTO
+          - name: 'openssl clang krb5 LTO'
             install_packages: zlib1g-dev libkrb5-dev clang
             install_steps: skipall
             generate: -DCURL_USE_OPENSSL=ON -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LTO=ON
 
-          - name: openssl !ipv6 !--libcurl !--digest-auth
+          - name: 'openssl !ipv6 !--libcurl !--digest-auth'
             configure: --with-openssl --disable-ipv6 --enable-debug --disable-unity --disable-libcurl-option --disable-digest-auth
 
-          - name: openssl https-only
+          - name: 'openssl https-only'
             configure: >-
               --with-openssl --enable-debug --disable-unity
               --disable-dict --disable-gopher --disable-ldap --disable-telnet
@@ -189,19 +189,19 @@ jobs:
               --without-libssh2 --without-libssh --without-wolfssh
               --disable-tftp --disable-ftp --disable-file --disable-smb
 
-          - name: openssl torture !FTP
+          - name: 'openssl torture !FTP'
             install_packages: zlib1g-dev libnghttp2-dev libssh2-1-dev libc-ares-dev
             generate: -DCURL_USE_OPENSSL=ON -DENABLE_DEBUG=ON -DENABLE_ARES=ON
             tflags: -t --shallow=25 !FTP
             torture: true
 
-          - name: openssl torture FTP
+          - name: 'openssl torture FTP'
             install_packages: zlib1g-dev libnghttp2-dev libssh2-1-dev libc-ares-dev
             generate: -DCURL_USE_OPENSSL=ON -DENABLE_DEBUG=ON -DENABLE_ARES=ON
             tflags: -t --shallow=20 FTP
             torture: true
 
-          - name: openssl i686
+          - name: 'openssl i686'
             install_packages: gcc-14-i686-linux-gnu libssl-dev:i386 librtmp-dev:i386 libssh2-1-dev:i386 libidn2-0-dev:i386 libc-ares-dev:i386 zlib1g-dev:i386
             configure: >-
               PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
@@ -214,13 +214,13 @@ jobs:
           - name: '!ssl !http !smtp !imap'
             configure: --without-ssl --enable-debug --disable-http --disable-smtp --disable-imap --disable-unity
 
-          - name: clang-tidy
+          - name: 'clang-tidy'
             install_packages: clang-tidy zlib1g-dev libssl-dev libkrb5-dev
             install_steps: skipall wolfssl-opensslextra wolfssh
             configure: LDFLAGS=-Wl,-rpath,/home/runner/wolfssl-opensslextra/lib --with-wolfssl=/home/runner/wolfssl-opensslextra --with-wolfssh=/home/runner/wolfssh --with-openssl --enable-ech --with-gssapi --enable-ssls-export
             make-custom-target: tidy
 
-          - name: scanbuild
+          - name: 'scanbuild'
             install_packages: clang-tools clang libssl-dev libssh2-1-dev
             install_steps: skipall
             configure: --with-openssl --enable-debug --with-libssh2 --disable-unity
@@ -228,7 +228,7 @@ jobs:
             configure-prefix: scan-build
             make-prefix: scan-build --status-bugs
 
-          - name: address-sanitizer
+          - name: 'address-sanitizer'
             install_packages: zlib1g-dev libssh2-1-dev clang libssl-dev libubsan1 libasan8 libtsan2
             install_steps: pytest randcurl
             CFLAGS: -fsanitize=address,undefined,signed-integer-overflow -fno-sanitize-recover=undefined,integer -Wformat -Werror=format-security -Werror=array-bounds -g
@@ -236,14 +236,14 @@ jobs:
             LIBS: -ldl -lubsan
             configure: CC=clang --with-openssl --enable-debug
 
-          - name: thread-sanitizer
+          - name: 'thread-sanitizer'
             install_packages: zlib1g-dev clang libtsan2
             install_steps: pytest openssl-tsan
             CFLAGS: -fsanitize=thread -g
             LDFLAGS: -fsanitize=thread -Wl,-rpath,/home/runner/openssl/lib
             configure: CC=clang --with-openssl=/home/runner/openssl --enable-debug
 
-          - name: memory-sanitizer
+          - name: 'memory-sanitizer'
             install_packages: clang
             install_steps: randcurl
             CFLAGS: -fsanitize=memory -Wformat -Werror=format-security -Werror=array-bounds -g
@@ -251,43 +251,43 @@ jobs:
             LIBS: -ldl
             configure: CC=clang --without-ssl --without-zlib --without-brotli --without-zstd --without-libpsl --without-nghttp2 --enable-debug
 
-          - name: event-based
+          - name: 'event-based'
             install_packages: libssh-dev
             configure: --enable-debug --disable-shared --disable-threaded-resolver --with-libssh --with-openssl
             tflags: -n --test-event '!TLS-SRP'
 
-          - name: duphandle
+          - name: 'duphandle'
             install_packages: libssh-dev
             configure: --enable-debug --disable-shared --disable-threaded-resolver --with-libssh --with-openssl
             tflags: -n --test-duphandle '!TLS-SRP'
 
-          - name: rustls valgrind
+          - name: 'rustls valgrind'
             install_packages: libnghttp2-dev libldap-dev valgrind
             install_steps: rust rustls
             configure: --with-rustls --enable-ech --enable-debug
 
-          - name: rustls
+          - name: 'rustls'
             install_packages: libnghttp2-dev libldap-dev
             install_steps: rust rustls skipall pytest
             generate: -DCURL_USE_RUSTLS=ON -DUSE_ECH=ON -DENABLE_DEBUG=ON
 
-          - name: IntelC openssl
+          - name: 'IntelC openssl'
             install_packages: zlib1g-dev libssl-dev
             install_steps: intel
             configure: CC=icc --enable-debug --with-openssl
 
-          - name: Slackware openssl gssapi gcc
+          - name: 'Slackware openssl gssapi gcc'
             # These are essentially the same flags used to build the curl Slackware package
             # https://ftpmirror.infania.net/slackware/slackware64-current/source/n/curl/curl.SlackBuild
             configure: --with-openssl --with-libssh2 --with-gssapi --enable-ares --enable-static=no --without-ca-bundle --with-ca-path=/etc/ssl/certs
             # Docker Hub image that `container-job` executes in
             container: 'andy5995/slackware-build-essential:15.0'
 
-          - name: Alpine MUSL https-rr
+          - name: 'Alpine MUSL https-rr'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --enable-threaded-resolver --enable-ares --enable-httpsrr
             container: 'alpine:3.20'
 
-          - name: Alpine MUSL c-ares https-rr
+          - name: 'Alpine MUSL c-ares https-rr'
             configure: --enable-debug --with-ssl --with-libssh2 --with-libidn2 --with-gssapi --enable-ldap --with-libpsl --disable-threaded-resolver --enable-ares --enable-httpsrr --disable-unity
             container: 'alpine:3.20'
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: Linux
+name: 'Linux'
 
 'on':
   push:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -64,7 +64,7 @@ jobs:
       matrix:
         compiler: [clang, llvm@15, gcc-12]
         build:
-          # automake
+          # autotools
           - name: '!ssl !debug brotli zstd'
             compiler: clang
             install: brotli zstd

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: macOS
+name: 'macOS'
 
 'on':
   push:

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: non-native
+name: 'non-native'
 
 'on':
   push:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: curl
 
-name: Windows
+name: 'Windows'
 
 'on':
   push:


### PR DESCRIPTION
Job `name:` now mandatory in zizmor.

Also:
- enclose `name:` values in single-quotes, for uniformity.
- drop `name: checkout` where set, for uniformity.
- dist: also install with cmake.
- dist: replace `make` with `cmake --build` for cmake.
  (to make this make-tool agnostic)
- appveyor-status: double-quote shell arguments.
- tweak existing names to be shorter, to sync terms and style across
  jobs and steps.

Ref: https://github.com/zizmorcore/zizmor/releases/tag/v1.10.0
