### PR TITLE
CURLSHOPT_SHARE.md: mention multi-threading requires callbacks

### DIFF
--- a/docs/libcurl/opts/CURLSHOPT_SHARE.md
+++ b/docs/libcurl/opts/CURLSHOPT_SHARE.md
@@ -35,6 +35,9 @@ CURLSHOPT_SHARE(3) multiple times with different data arguments to have
 the share object share multiple types of data. Unset a type again by setting
 CURLSHOPT_UNSHARE(3).
 
+If any of the data will be shared in multiple threads then mutex callbacks
+must be set as well. See CURLSHOPT_LOCKFUNC(3) and CURLSHOPT_UNLOCKFUNC(3).
+
 ## CURL_LOCK_DATA_COOKIE
 
 Cookie data is shared across the easy handles using this shared object. Note


### PR DESCRIPTION
- Explain that if data is shared in multiple threads then the user must set mutex callbacks.

Reported-by: afengsoft@users.noreply.github.com

Fixes https://github.com/curl/curl/issues/17774
Closes #xxxx