### PR TITLE
ngtcp2: fix coverity warning about result handling

### DIFF
--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1129,7 +1129,7 @@ void curl_easy_reset(CURL *d)
  */
 CURLcode curl_easy_pause(CURL *d, int action)
 {
-  CURLcode result = CURLE_OK, r2;
+  CURLcode result = CURLE_OK;
   bool recursive = FALSE;
   bool changed = FALSE;
   struct Curl_easy *data = d;
@@ -1150,16 +1150,12 @@ CURLcode curl_easy_pause(CURL *d, int action)
 
   if(send_paused != send_paused_new) {
     changed = TRUE;
-    r2 = Curl_xfer_pause_send(data, send_paused_new);
-    if(r2)
-      result = r2;
+    result = Curl_1st_err(result, Curl_xfer_pause_send(data, send_paused_new));
   }
 
   if(recv_paused != recv_paused_new) {
     changed = TRUE;
-    r2 = Curl_xfer_pause_recv(data, recv_paused_new);
-    if(r2)
-      result = r2;
+    result = Curl_1st_err(result, Curl_xfer_pause_recv(data, recv_paused_new));
   }
 
   /* If not completely pausing both directions now, run again in any case. */

--- a/lib/http.c
+++ b/lib/http.c
@@ -3962,9 +3962,8 @@ static CURLcode http_on_response(struct Curl_easy *data,
 out:
   if(last_hd) {
     /* if not written yet, write it now */
-    CURLcode r2 = http_write_header(data, last_hd, last_hd_len);
-    if(!result)
-      result = r2;
+    result = Curl_1st_err(
+      result, http_write_header(data, last_hd, last_hd_len));
   }
   return result;
 }

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -621,7 +621,7 @@ static CURLcode multi_done(struct Curl_easy *data,
                                                 after an error was detected */
                            bool premature)
 {
-  CURLcode result, r2;
+  CURLcode result;
   struct connectdata *conn = data->conn;
   struct multi_done_ctx mdctx;
 
@@ -670,9 +670,7 @@ static CURLcode multi_done(struct Curl_easy *data,
   }
 
   /* Make sure that transfer client writes are really done now. */
-  r2 = Curl_xfer_write_done(data, premature);
-  if(r2 && !result)
-    result = r2;
+  result = Curl_1st_err(result, Curl_xfer_write_done(data, premature));
 
   /* Inform connection filters that this transfer is done */
   Curl_conn_ev_data_done(data, premature);

--- a/lib/url.c
+++ b/lib/url.c
@@ -4099,3 +4099,17 @@ void *Curl_conn_meta_get(struct connectdata *conn, const char *key)
 {
   return Curl_hash_pick(&conn->meta_hash, CURL_UNCONST(key), strlen(key) + 1);
 }
+
+CURLcode Curl_1st_err(CURLcode r1, CURLcode r2)
+{
+  return r1 ? r1 : r2;
+}
+
+CURLcode Curl_1st_fatal(CURLcode r1, CURLcode r2)
+{
+  if(r1 && (r1 != CURLE_AGAIN))
+    return r1;
+  if(r2 && (r2 != CURLE_AGAIN))
+    return r2;
+  return r1;
+}

--- a/lib/url.h
+++ b/lib/url.h
@@ -101,6 +101,19 @@ CURLcode Curl_conn_upkeep(struct Curl_easy *data,
                           struct connectdata *conn,
                           struct curltime *now);
 
+/**
+ * Always eval all arguments, return the first result != CURLE_OK.
+ * A non-short-circuit evaluation.
+ */
+CURLcode Curl_1st_err(CURLcode r1, CURLcode r2);
+
+/**
+ * Always eval all arguments, return the first
+ * result != (CURLE_OK|CURLE_AGAIN) or `r1`.
+ * A non-short-circuit evaluation.
+ */
+CURLcode Curl_1st_fatal(CURLcode r1, CURLcode r2);
+
 #if defined(USE_HTTP2) || defined(USE_HTTP3)
 void Curl_data_priority_clear_state(struct Curl_easy *data);
 #else

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -848,7 +848,7 @@ static CURLcode cf_quiche_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
 {
   struct cf_quiche_ctx *ctx = cf->ctx;
   struct h3_stream_ctx *stream = H3_STREAM_CTX(ctx, data);
-  CURLcode result = CURLE_OK, r2;
+  CURLcode result = CURLE_OK;
 
   *pnread = 0;
   vquic_ctx_update_time(&ctx->q);
@@ -1081,7 +1081,7 @@ static CURLcode cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 {
   struct cf_quiche_ctx *ctx = cf->ctx;
   struct h3_stream_ctx *stream = H3_STREAM_CTX(ctx, data);
-  CURLcode result, r2;
+  CURLcode result;
 
   *pnwritten = 0;
   vquic_ctx_update_time(&ctx->q);

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -896,11 +896,7 @@ static CURLcode cf_quiche_recv(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
 
 out:
-  r2 = cf_flush_egress(cf, data);
-  if(r2) {
-    CURL_TRC_CF(data, cf, "cf_recv, flush egress failed");
-    result = r2;
-  }
+  result = Curl_1st_err(result, cf_flush_egress(cf, data));
   if(*pnread > 0)
     ctx->data_recvd += *pnread;
   CURL_TRC_CF(data, cf, "[%"FMT_PRIu64"] cf_recv(total=%"
@@ -1126,9 +1122,7 @@ static CURLcode cf_quiche_send(struct Curl_cfilter *cf, struct Curl_easy *data,
   }
 
 out:
-  r2 = cf_flush_egress(cf, data);
-  if(r2)
-    result = r2;
+  result = Curl_1st_err(result, cf_flush_egress(cf, data));
 
   CURL_TRC_CF(data, cf, "[%" FMT_PRIu64 "] cf_send(len=%zu) -> %d, %zu",
               stream ? stream->id : (curl_uint64_t)~0, len,


### PR DESCRIPTION
Coverity correctly complained that a `result` assignement from `r2` was overwritten directly afterwards. Fix the issue by using `r2` only where necessary and add a comment about why we have `r2` in the first place.