### PR TITLE
multi: remove careful bounds check as coverity says it is not needed

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -370,8 +370,7 @@ static CURLMcode multi_xfers_add(struct Curl_multi *multi,
       else {
          /* make it a 64 multiple, since our bitsets frow by that and
           * small (easy_multi) grows to at least 64 on first resize. */
-        new_size = CURLMIN((((used + min_unused) + 63) / 64) * 64,
-                           max_capacity);
+        new_size = (((used + min_unused) + 63) / 64) * 64;
       }
     }
   }


### PR DESCRIPTION
And we all hope that future code changes will not make it necessary again or this will all be blamed on you, coverity!