### PR TITLE
socket data_pending: make nop

### DIFF
--- a/lib/cf-h1-proxy.c
+++ b/lib/cf-h1-proxy.c
@@ -374,9 +374,6 @@ static CURLcode recv_CONNECT_resp(struct Curl_cfilter *cf,
   error = SELECT_OK;
   *done = FALSE;
 
-  if(!Curl_conn_data_pending(data, cf->sockindex))
-    return CURLE_OK;
-
   while(ts->keepon) {
     size_t nread;
     char byte;

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1404,17 +1404,6 @@ static void cf_socket_adjust_pollset(struct Curl_cfilter *cf,
   }
 }
 
-static bool cf_socket_data_pending(struct Curl_cfilter *cf,
-                                   const struct Curl_easy *data)
-{
-  struct cf_socket_ctx *ctx = cf->ctx;
-  int readable;
-
-  (void)data;
-  readable = SOCKET_READABLE(ctx->sock, 0);
-  return readable > 0 && (readable & CURL_CSELECT_IN);
-}
-
 #ifdef USE_WINSOCK
 
 #ifndef SIO_IDEAL_SEND_BACKLOG_QUERY
@@ -1750,7 +1739,7 @@ struct Curl_cftype Curl_cft_tcp = {
   cf_socket_close,
   cf_socket_shutdown,
   cf_socket_adjust_pollset,
-  cf_socket_data_pending,
+  Curl_cf_def_data_pending,
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
@@ -1904,7 +1893,7 @@ struct Curl_cftype Curl_cft_udp = {
   cf_socket_close,
   cf_socket_shutdown,
   cf_socket_adjust_pollset,
-  cf_socket_data_pending,
+  Curl_cf_def_data_pending,
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
@@ -1958,7 +1947,7 @@ struct Curl_cftype Curl_cft_unix = {
   cf_socket_close,
   cf_socket_shutdown,
   cf_socket_adjust_pollset,
-  cf_socket_data_pending,
+  Curl_cf_def_data_pending,
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,
@@ -2178,7 +2167,7 @@ struct Curl_cftype Curl_cft_tcp_accept = {
   cf_socket_close,
   cf_socket_shutdown,
   cf_socket_adjust_pollset,
-  cf_socket_data_pending,
+  Curl_cf_def_data_pending,
   cf_socket_send,
   cf_socket_recv,
   cf_socket_cntrl,

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1941,18 +1941,6 @@ out:
   return CURLE_OK;
 }
 
-/*
- * Called from transfer.c:data_pending to know if we should keep looping
- * to receive more data from the connection.
- */
-static bool cf_ngtcp2_data_pending(struct Curl_cfilter *cf,
-                                   const struct Curl_easy *data)
-{
-  (void)cf;
-  (void)data;
-  return FALSE;
-}
-
 static CURLcode h3_data_pause(struct Curl_cfilter *cf,
                               struct Curl_easy *data,
                               bool pause)
@@ -2728,7 +2716,7 @@ struct Curl_cftype Curl_cft_http3 = {
   cf_ngtcp2_close,
   cf_ngtcp2_shutdown,
   cf_ngtcp2_adjust_pollset,
-  cf_ngtcp2_data_pending,
+  Curl_cf_def_data_pending,
   cf_ngtcp2_send,
   cf_ngtcp2_recv,
   cf_ngtcp2_data_event,


### PR DESCRIPTION
Eliminating the socket readability check in the socket connection filters for the 'data_pending' callback. Improves performance of handling of transfers, up to ~30%, depending on parallelism and response size.

Whatever `data_pending()` once was, its semantics are now: "Is there anything buffered in the connection filters that needs receive?" Any checks of the socket's readability are done via `multi_wait()` and friends.

Fix the one place in HTTP/1 proxy code that checked `data_pending()` and did an early return if false. Remove that check and actually try to receive data every time.