### PR TITLE
curlinfo: provide the 'digest' feature

### DIFF
--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -456,6 +456,7 @@ Features testable here are:
 - `cookies`
 - `crypto`
 - `Debug`
+- `digest`
 - `DoH`
 - `getrlimit`
 - `GnuTLS`

--- a/src/curlinfo.c
+++ b/src/curlinfo.c
@@ -70,7 +70,7 @@ static const char *disabled[]={
   "ON"
 #endif
   ,
-  "digest-auth: "
+  "digest: "
 #ifdef CURL_DISABLE_DIGEST_AUTH
   "OFF"
 #else


### PR DESCRIPTION
... since the tests check for the feature using this name, we accidentally had lots tests not run because this provided the `digest-auth` feature that was not checked for.