### PR TITLE
docs,tests: fix english grammar "allow to" -> "allow one to"

### DIFF
--- a/docs/libcurl/opts/CURLOPT_QUICK_EXIT.md
+++ b/docs/libcurl/opts/CURLOPT_QUICK_EXIT.md
@@ -14,7 +14,7 @@ Added-in: 7.87.0
 
 # NAME
 
-CURLOPT_QUICK_EXIT - allow to exit quickly
+CURLOPT_QUICK_EXIT - allow libcurl to exit quickly
 
 # SYNOPSIS
 

--- a/docs/tests/HTTP.md
+++ b/docs/tests/HTTP.md
@@ -141,10 +141,10 @@ The module adds 2 "handlers" to the Apache server (right now). Handler are piece
   * `s`: seconds (the default)
   * `ms`: milliseconds
 
-As you can see, `mod_curltest`'s tweak handler allow to simulate many kinds of
-responses. An example of its use is `test_03_01` where responses are delayed
-using `chunk_delay`. This gives the response a defined duration and the test
-uses that to reload `httpd` in the middle of the first request. A graceful
+As you can see, `mod_curltest`'s tweak handler allows Apache to simulate many
+kinds of responses. An example of its use is `test_03_01` where responses are
+delayed using `chunk_delay`. This gives the response a defined duration and the
+test uses that to reload `httpd` in the middle of the first request. A graceful
 reload in httpd lets ongoing requests finish, but closes the connection
-afterwards and tears down the serving process. The following request then
-needs to open a new connection. This is verified by the test case.
+afterwards and tears down the serving process. The following request then needs
+to open a new connection. This is verified by the test case.

--- a/tests/data/test1933
+++ b/tests/data/test1933
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1934
+++ b/tests/data/test1934
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1935
+++ b/tests/data/test1935
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1936
+++ b/tests/data/test1936
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1937
+++ b/tests/data/test1937
@@ -33,7 +33,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1938
+++ b/tests/data/test1938
@@ -33,7 +33,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1955
+++ b/tests/data/test1955
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1956
+++ b/tests/data/test1956
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1957
+++ b/tests/data/test1957
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1958
+++ b/tests/data/test1958
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1959
+++ b/tests/data/test1959
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1964
+++ b/tests/data/test1964
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 crypto

--- a/tests/data/test1970
+++ b/tests/data/test1970
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1971
+++ b/tests/data/test1971
@@ -25,7 +25,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1972
+++ b/tests/data/test1972
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1973
+++ b/tests/data/test1973
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1974
+++ b/tests/data/test1974
@@ -32,7 +32,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug

--- a/tests/data/test1975
+++ b/tests/data/test1975
@@ -25,7 +25,7 @@ Content-Length: 0
 <server>
 http
 </server>
-# this relies on the debug feature which allow to set the time
+# this relies on the debug feature which allows tests to set the time
 <features>
 SSL
 Debug


### PR DESCRIPTION
This was spotted by Debian's lintian tool. It adds an informational warning at every run, so my OCD was kicking in and I had to fix it :-)