### PR TITLE
tool_getparam: add support for `--longopt=value`

### DIFF
--- a/docs/cmdline-opts/_OPTIONS.md
+++ b/docs/cmdline-opts/_OPTIONS.md
@@ -24,6 +24,9 @@ When --next is used, it resets the parser state and you start again with a
 clean option state, except for the options that are global. Global options
 retain their values and meaning even after --next.
 
+If the long option name ends with an equals sign (`=`), the argument is the
+text following on its right side. (Added in 8.16.0)
+
 The first argument that is exactly two dashes (`--`), marks the end of
 options; any argument after the end of options is interpreted as a URL
 argument even if it starts with a dash.

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2814,6 +2814,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     const char *word = ('-' == flag[0]) ? flag + 2 : flag;
     bool noflagged = FALSE;
     bool expand = FALSE;
+    const char *p;
+    struct Curl_str out;
 
     if(!strncmp(word, "no-", 3)) {
       /* disable this option but ignore the "no-" part when looking for it */
@@ -2827,23 +2829,20 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
       expand = TRUE;
     }
 
-    {
-      const char *p = word;
-      struct Curl_str out;
-      /* is there an '=' ? */
-      if(!curlx_str_until(&p, &out, MAX_OPTION_LEN, '=') &&
-         !curlx_str_single(&p, '=') ) {
-        /* there's an equal sign */
-        char tempword[MAX_OPTION_LEN + 1];
-        memcpy(tempword, curlx_str(&out), curlx_strlen(&out));
-        tempword[curlx_strlen(&out)] = 0;
-        a = findlongopt(tempword);
-        nextarg = p;
-        consumearg = FALSE; /* it is not separate */
-      }
-      else
-        a = findlongopt(word);
+    p = word;
+    /* is there an '=' ? */
+    if(!curlx_str_until(&p, &out, MAX_OPTION_LEN, '=') &&
+       !curlx_str_single(&p, '=') ) {
+      /* there's an equal sign */
+      char tempword[MAX_OPTION_LEN + 1];
+      memcpy(tempword, curlx_str(&out), curlx_strlen(&out));
+      tempword[curlx_strlen(&out)] = 0;
+      a = findlongopt(tempword);
+      nextarg = p;
+      consumearg = FALSE; /* it is not separate */
     }
+    else
+      a = findlongopt(word);
 
     if(a) {
       longopt = TRUE;

--- a/tests/data/test1333
+++ b/tests/data/test1333
@@ -31,7 +31,7 @@ http
 HTTP POST zero length, chunked-encoded
 </name>
 <command>
--d "" --header "Transfer-Encoding: chunked" http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+-d "" --header="Transfer-Encoding: chunked" http://%HOSTIP:%HTTPPORT/%TESTNUMBER
 </command>
 </client>
 

--- a/tests/data/test1335
+++ b/tests/data/test1335
@@ -30,7 +30,7 @@ http
 HTTP GET with -O without Content-Disposition, -D stdout
 </name>
 <command option="no-output,no-include">
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D - --output-dir %LOGDIR
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O -D - --output-dir="%LOGDIR"
 </command>
 </client>
 

--- a/tests/data/test1442
+++ b/tests/data/test1442
@@ -19,7 +19,7 @@ file
 Check --write-out with trailing \
 </name>
 <command>
-file://localhost/%FILE_PWD/%LOGDIR/non-existent-file.txt --write-out '\'
+file://localhost/%FILE_PWD/%LOGDIR/non-existent-file.txt --write-out='\'
 </command>
 </client>
 

--- a/tests/data/test206
+++ b/tests/data/test206
@@ -80,7 +80,7 @@ digest
 HTTP proxy CONNECT auth Digest
 </name>
 <command>
-http://test.remote.haxx.se.%TESTNUMBER:8990/path/%TESTNUMBER0002 --proxy http://%HOSTIP:%HTTPPORT --proxy-user silly:person --proxy-digest --proxytunnel
+http://test.remote.haxx.se.%TESTNUMBER:8990/path/%TESTNUMBER0002 --proxy=http://%HOSTIP:%HTTPPORT --proxy-user=silly:person --proxy-digest --proxytunnel
 </command>
 </client>
 


### PR DESCRIPTION
If the long option name ends with an equals sign (`=`), the argument is the text following on its right side.

This makes the command line parser accept this common style in addition to the existing way to accept option arguments more similar to how other command line tools do.

Example: `curl --user-agent=curl-2000 https://example.com/`

Change a few existing tests to use this syntax: 206, 1333, 1335, 1442