### PR TITLE
curl.h: make CURL_IPRESOLVE_* symbols defined as longs

### DIFF
--- a/docs/examples/ipv6.c
+++ b/docs/examples/ipv6.c
@@ -35,7 +35,7 @@ int main(void)
 
   curl = curl_easy_init();
   if(curl) {
-    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, (long)CURL_IPRESOLVE_V6);
+    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
 
     curl_easy_setopt(curl, CURLOPT_URL, "https://curl.se/");
 

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -66,7 +66,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
     /* of all addresses example.com resolves to, only IPv6 ones are used */
-    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, (long)CURL_IPRESOLVE_V6);
+    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
 
     res = curl_easy_perform(curl);
 

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -2289,10 +2289,10 @@ typedef enum {
   /* Below here follows defines for the CURLOPT_IPRESOLVE option. If a host
      name resolves addresses using more than one IP protocol version, this
      option might be handy to force libcurl to use a specific IP version. */
-#define CURL_IPRESOLVE_WHATEVER 0 /* default, uses addresses to all IP
+#define CURL_IPRESOLVE_WHATEVER 0L /* default, uses addresses to all IP
                                      versions that your system allows */
-#define CURL_IPRESOLVE_V4       1 /* uses only IPv4 addresses/connections */
-#define CURL_IPRESOLVE_V6       2 /* uses only IPv6 addresses/connections */
+#define CURL_IPRESOLVE_V4       1L /* uses only IPv4 addresses/connections */
+#define CURL_IPRESOLVE_V6       2L /* uses only IPv6 addresses/connections */
 
   /* Convenient "aliases" */
 #define CURLOPT_RTSPHEADER CURLOPT_HTTPHEADER

--- a/tests/unit/unit2600.c
+++ b/tests/unit/unit2600.c
@@ -75,7 +75,7 @@ struct test_case {
   int id;
   const char *url;
   const char *resolve_info;
-  unsigned char ip_version;
+  long ip_version;
   timediff_t connect_timeout_ms;
   timediff_t he_timeout_ms;
   timediff_t cf4_fail_delay_ms;
@@ -312,7 +312,7 @@ static void test_connect(CURL *easy, const struct test_case *tc)
   list = curl_slist_append(NULL, tc->resolve_info);
   fail_unless(list, "error allocating resolve list entry");
   curl_easy_setopt(easy, CURLOPT_RESOLVE, list);
-  curl_easy_setopt(easy, CURLOPT_IPRESOLVE, (long)tc->ip_version);
+  curl_easy_setopt(easy, CURLOPT_IPRESOLVE, tc->ip_version);
   curl_easy_setopt(easy, CURLOPT_CONNECTTIMEOUT_MS,
                    (long)tc->connect_timeout_ms);
   curl_easy_setopt(easy, CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS,


### PR DESCRIPTION
... as `curl_easy_setopt()` expects them to be.