### PR TITLE
build: add missing `long` casts for `CURLAUTH_ANY`

### DIFF
--- a/docs/examples/crawler.c
+++ b/docs/examples/crawler.c
@@ -111,9 +111,9 @@ static CURL *make_handle(const char *url)
   curl_easy_setopt(handle, CURLOPT_COOKIEFILE, "");
   curl_easy_setopt(handle, CURLOPT_FILETIME, 1L);
   curl_easy_setopt(handle, CURLOPT_USERAGENT, "mini crawler");
-  curl_easy_setopt(handle, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+  curl_easy_setopt(handle, CURLOPT_HTTPAUTH, (long)CURLAUTH_ANY);
   curl_easy_setopt(handle, CURLOPT_UNRESTRICTED_AUTH, 1L);
-  curl_easy_setopt(handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
+  curl_easy_setopt(handle, CURLOPT_PROXYAUTH, (long)CURLAUTH_ANY);
   curl_easy_setopt(handle, CURLOPT_EXPECT_100_TIMEOUT_MS, 0L);
   return handle;
 }

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -58,7 +58,7 @@ int main(void)
     /* use this proxy */
     curl_easy_setopt(curl, CURLOPT_PROXY, "http://local.example.com:1080");
     /* allow whatever auth the proxy speaks */
-    curl_easy_setopt(curl, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
+    curl_easy_setopt(curl, CURLOPT_PROXYAUTH, (long)CURLAUTH_ANY);
     /* set the proxy credentials */
     curl_easy_setopt(curl, CURLOPT_PROXYUSERPWD, "james:007");
     ret = curl_easy_perform(curl);

--- a/tests/libtest/lib3100.c
+++ b/tests/libtest/lib3100.c
@@ -49,7 +49,7 @@ static CURLcode test_lib3100(char *URL)
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_RTSP_STREAM_URI, URL);
 
-  test_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+  test_setopt(curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_ANY);
   test_setopt(curl, CURLOPT_USERNAME, "user");
   test_setopt(curl, CURLOPT_PASSWORD, "password");
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_DESCRIBE);

--- a/tests/libtest/lib3101.c
+++ b/tests/libtest/lib3101.c
@@ -46,7 +46,7 @@ static CURLcode test_lib3101(char *URL)
   test_setopt(curl, CURLOPT_WRITEDATA, stdout);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
   test_setopt(curl, CURLOPT_URL, URL);
-  test_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
+  test_setopt(curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_ANY);
   test_setopt(curl, CURLOPT_USERNAME, "user");
   test_setopt(curl, CURLOPT_PASSWORD, "password");
   test_setopt(curl, CURLOPT_REDIR_PROTOCOLS_STR, "https");


### PR DESCRIPTION
From `unsigned long`. The size is correct without the cast.

Follow-up to d31da176eb622fb386a3b657d17921403f95e45c,
though this was before casting the components to `unsigned long`
in `curl/curl.h`. The casts on use are possibly no longer necessary.
