### PR TITLE
docs: fix typos in two files

### DIFF
--- a/docs/BUGS.md
+++ b/docs/BUGS.md
@@ -62,7 +62,7 @@ SPDX-License-Identifier: curl
  - what URL you were working with (if possible), at least which protocol
 
  and anything and everything else you think matters. Tell us what you expected
- to happen, tell use what did happen, tell us how you could make it work
+ to happen, tell us what did happen, tell us how you could make it work
  another way. Dig around, try out, test. Then include all the tiny bits and
  pieces in your report. You benefit from this yourself, as it enables us to
  help you quicker and more accurately.

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -34,7 +34,7 @@ A [Test Clutch](https://github.com/dfandrich/testclutch) instance generates
 regular reports on curl CI test results at https://testclutch.curl.se/ as well
 as writing comments on curl pull requests whose tests have failed. The jobs
 are hosted on a Virtuozzo Application Platform PaaS instance and is managed by
-Dan Fandrich. The configuration code is is available and managed at
+Dan Fandrich. The configuration code is available and managed at
 https://github.com/dfandrich/testclutch-curl-web
 
 ## Autobuilds


### PR DESCRIPTION
I need to add this hashtag at the end because I am contributing in a project at my university.