### PR TITLE
cmake/FindGSS: fix processing C header directory options

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -101,7 +101,7 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
     )
     message(STATUS "FindGSS krb5-config --cflags: ${_gss_c_flags}")
     if(NOT _gss_configure_failed)  # 0 means success
-      # Should also work in an odd case when multiple directories are given
+      # Should also work in an odd case when multiple directories are given.
       string(STRIP "${_gss_c_flags}" _gss_c_flags)
       string(REGEX REPLACE " +-(I)" ";-\\1" _gss_c_flags "${_gss_c_flags}")
       string(REGEX REPLACE " +-([^I][^ \\t;]*)" ";-\\1" _gss_c_flags "${_gss_c_flags}")
@@ -125,7 +125,7 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
     message(STATUS "FindGSS krb5-config --libs: ${_gss_lib_flags}")
 
     if(NOT _gss_configure_failed)  # 0 means success
-      # This script gives us libraries and link directories. Blah. We have to deal with it.
+      # This script gives us libraries and link directories.
       string(STRIP "${_gss_lib_flags}" _gss_lib_flags)
       string(REGEX REPLACE " +-(L|l)" ";-\\1" _gss_lib_flags "${_gss_lib_flags}")
       string(REGEX REPLACE " +-([^Ll][^ \\t;]*)" ";-\\1" _gss_lib_flags "${_gss_lib_flags}")

--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -65,6 +65,9 @@ if(NOT GSS_ROOT_DIR AND NOT "$ENV{GSS_ROOT_DIR}")
   endif()
 endif()
 
+set(_GSS_CFLAGS "")
+set(_GSS_LIBRARY_DIRS "")
+
 if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional approach.
   find_file(_gss_configure_script
     NAMES
@@ -86,6 +89,10 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
   )
 
   if(_gss_configure_script)
+
+    set(_GSS_INCLUDE_DIRS "")
+    set(_GSS_LIBRARIES "")
+
     execute_process(
       COMMAND ${_gss_configure_script} "--cflags" "gssapi"
       OUTPUT_VARIABLE _GSS_CFLAGS

--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -95,18 +95,18 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
 
     execute_process(
       COMMAND ${_gss_configure_script} "--cflags" "gssapi"
-      OUTPUT_VARIABLE _GSS_CFLAGS
+      OUTPUT_VARIABLE _gss_c_flags
       RESULT_VARIABLE _gss_configure_failed
       OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    message(STATUS "FindGSS krb5-config --cflags: ${_GSS_CFLAGS}")
+    message(STATUS "FindGSS krb5-config --cflags: ${_gss_c_flags}")
     if(NOT _gss_configure_failed)  # 0 means success
       # Should also work in an odd case when multiple directories are given
-      string(STRIP "${_GSS_CFLAGS}" _GSS_CFLAGS)
-      string(REGEX REPLACE " +-I" ";" _GSS_CFLAGS "${_GSS_CFLAGS}")
-      string(REGEX REPLACE " +-([^I][^ \\t;]*)" ";-\\1" _GSS_CFLAGS "${_GSS_CFLAGS}")
+      string(STRIP "${_gss_c_flags}" _gss_c_flags)
+      string(REGEX REPLACE " +-I" ";" _gss_c_flags "${_gss_c_flags}")
+      string(REGEX REPLACE " +-([^I][^ \\t;]*)" ";-\\1" _gss_c_flags "${_gss_c_flags}")
 
-      foreach(_flag IN LISTS _GSS_CFLAGS)
+      foreach(_flag IN LISTS _gss_c_flags)
         if(_flag MATCHES "^-I")
           string(REGEX REPLACE "^-I" "" _val "${_flag}")
           list(APPEND _GSS_INCLUDE_DIRS "${_val}")

--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -103,7 +103,7 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
     if(NOT _gss_configure_failed)  # 0 means success
       # Should also work in an odd case when multiple directories are given
       string(STRIP "${_gss_c_flags}" _gss_c_flags)
-      string(REGEX REPLACE " +-I" ";" _gss_c_flags "${_gss_c_flags}")
+      string(REGEX REPLACE " +-(I)" ";-\\1" _gss_c_flags "${_gss_c_flags}")
       string(REGEX REPLACE " +-([^I][^ \\t;]*)" ";-\\1" _gss_c_flags "${_gss_c_flags}")
 
       foreach(_flag IN LISTS _gss_c_flags)


### PR DESCRIPTION
When processing `--cflags` received from `krb5-config` for `gssapi`:

- fix to not break on multiple `-I` options. Before this patch only
  the first `-I` option was processed as a header directory, subsequent
  ones ended up in C flags as a raw directory, without the `-I` part.

- fix to not duplicate C flags.
  Regression from 146759716cbacfd453b9fb13d1096f0595424a6c #14430

- initialize results variables.

- tidy up comments.

Ref: https://github.com/curl/curl/issues/17802#issuecomment-3029455984
