### PR TITLE
cmake/FindGSS: initialize result variables

### DIFF
--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -52,6 +52,9 @@ set(_gss_root_hints
   "$ENV{GSS_ROOT_DIR}"
 )
 
+set(_GSS_CFLAGS "")
+set(_GSS_LIBRARY_DIRS "")
+
 # Try to find library using system pkg-config if user did not specify root dir
 if(NOT GSS_ROOT_DIR AND NOT "$ENV{GSS_ROOT_DIR}")
   if(CURL_USE_PKGCONFIG)
@@ -86,6 +89,10 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
   )
 
   if(_gss_configure_script)
+
+    set(_GSS_INCLUDE_DIRS "")
+    set(_GSS_LIBRARIES "")
+
     execute_process(
       COMMAND ${_gss_configure_script} "--cflags" "gssapi"
       OUTPUT_VARIABLE _gss_cflags_raw

--- a/CMake/FindGSS.cmake
+++ b/CMake/FindGSS.cmake
@@ -52,23 +52,23 @@ set(_gss_root_hints
   "$ENV{GSS_ROOT_DIR}"
 )
 
-set(_GSS_CFLAGS "")
-set(_GSS_LIBRARY_DIRS "")
+set(_gss_CFLAGS "")
+set(_gss_LIBRARY_DIRS "")
 
 # Try to find library using system pkg-config if user did not specify root dir
 if(NOT GSS_ROOT_DIR AND NOT "$ENV{GSS_ROOT_DIR}")
   if(CURL_USE_PKGCONFIG)
     find_package(PkgConfig QUIET)
-    pkg_search_module(_GSS ${_gnu_modname} ${_mit_modname} ${_heimdal_modname})
-    list(APPEND _gss_root_hints "${_GSS_PREFIX}")
-    set(_gss_version "${_GSS_VERSION}")
+    pkg_search_module(_gss ${_gnu_modname} ${_mit_modname} ${_heimdal_modname})
+    list(APPEND _gss_root_hints "${_gss_PREFIX}")
+    set(_gss_version "${_gss_VERSION}")
   endif()
   if(WIN32)
     list(APPEND _gss_root_hints "[HKEY_LOCAL_MACHINE\\SOFTWARE\\MIT\\Kerberos;InstallDir]")
   endif()
 endif()
 
-if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional approach.
+if(NOT _gss_FOUND)  # Not found by pkg-config. Let us take more traditional approach.
   find_file(_gss_configure_script
     NAMES
       "krb5-config"
@@ -90,8 +90,8 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
 
   if(_gss_configure_script)
 
-    set(_GSS_INCLUDE_DIRS "")
-    set(_GSS_LIBRARIES "")
+    set(_gss_INCLUDE_DIRS "")
+    set(_gss_LIBRARIES "")
 
     execute_process(
       COMMAND ${_gss_configure_script} "--cflags" "gssapi"
@@ -109,9 +109,9 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
       foreach(_flag IN LISTS _gss_cflags_raw)
         if(_flag MATCHES "^-I")
           string(REGEX REPLACE "^-I" "" _flag "${_flag}")
-          list(APPEND _GSS_INCLUDE_DIRS "${_flag}")
+          list(APPEND _gss_INCLUDE_DIRS "${_flag}")
         else()
-          list(APPEND _GSS_CFLAGS "${_flag}")
+          list(APPEND _gss_CFLAGS "${_flag}")
         endif()
       endforeach()
     endif()
@@ -133,10 +133,10 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
       foreach(_flag IN LISTS _gss_lib_flags)
         if(_flag MATCHES "^-l")
           string(REGEX REPLACE "^-l" "" _flag "${_flag}")
-          list(APPEND _GSS_LIBRARIES "${_flag}")
+          list(APPEND _gss_LIBRARIES "${_flag}")
         elseif(_flag MATCHES "^-L")
           string(REGEX REPLACE "^-L" "" _flag "${_flag}")
-          list(APPEND _GSS_LIBRARY_DIRS "${_flag}")
+          list(APPEND _gss_LIBRARY_DIRS "${_flag}")
         endif()
       endforeach()
     endif()
@@ -173,7 +173,7 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
 
   else()  # Either there is no config script or we are on a platform that does not provide one (Windows?)
 
-    find_path(_GSS_INCLUDE_DIRS NAMES "gssapi/gssapi.h"
+    find_path(_gss_INCLUDE_DIRS NAMES "gssapi/gssapi.h"
       HINTS
         ${_gss_root_hints}
       PATH_SUFFIXES
@@ -181,9 +181,9 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
         "inc"
     )
 
-    if(_GSS_INCLUDE_DIRS)  # jay, we have found something
+    if(_gss_INCLUDE_DIRS)  # jay, we have found something
       cmake_push_check_state()
-      list(APPEND CMAKE_REQUIRED_INCLUDES "${_GSS_INCLUDE_DIRS}")
+      list(APPEND CMAKE_REQUIRED_INCLUDES "${_gss_INCLUDE_DIRS}")
       check_include_files("gssapi/gssapi_generic.h;gssapi/gssapi_krb5.h" _gss_have_mit_headers)
 
       if(_gss_have_mit_headers)
@@ -201,7 +201,7 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
       cmake_pop_check_state()
     else()
       # I am not convinced if this is the right way but this is what autotools do at the moment
-      find_path(_GSS_INCLUDE_DIRS NAMES "gssapi.h"
+      find_path(_gss_INCLUDE_DIRS NAMES "gssapi.h"
         HINTS
           ${_gss_root_hints}
         PATH_SUFFIXES
@@ -209,17 +209,17 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
           "inc"
       )
 
-      if(_GSS_INCLUDE_DIRS)
+      if(_gss_INCLUDE_DIRS)
         set(GSS_FLAVOUR "Heimdal")
       else()
-        find_path(_GSS_INCLUDE_DIRS NAMES "gss.h"
+        find_path(_gss_INCLUDE_DIRS NAMES "gss.h"
           HINTS
             ${_gss_root_hints}
           PATH_SUFFIXES
             "include"
         )
 
-        if(_GSS_INCLUDE_DIRS)
+        if(_gss_INCLUDE_DIRS)
           set(GSS_FLAVOUR "GNU")
           set(GSS_PC_REQUIRES "gss")
         endif()
@@ -230,7 +230,7 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
     if(GSS_FLAVOUR)
       set(_gss_libdir_suffixes "")
       set(_gss_libdir_hints ${_gss_root_hints})
-      get_filename_component(_gss_calculated_potential_root "${_GSS_INCLUDE_DIRS}" DIRECTORY)
+      get_filename_component(_gss_calculated_potential_root "${_gss_INCLUDE_DIRS}" DIRECTORY)
       list(APPEND _gss_libdir_hints ${_gss_calculated_potential_root})
 
       if(WIN32)
@@ -264,7 +264,7 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
         endif()
       endif()
 
-      find_library(_GSS_LIBRARIES NAMES ${_gss_libname}
+      find_library(_gss_LIBRARIES NAMES ${_gss_libname}
         HINTS
           ${_gss_libdir_hints}
         PATH_SUFFIXES
@@ -273,35 +273,35 @@ if(NOT _GSS_FOUND)  # Not found by pkg-config. Let us take more traditional appr
     endif()
   endif()
 else()
-  # _GSS_MODULE_NAME set since CMake 3.16
-  if(_GSS_MODULE_NAME STREQUAL _gnu_modname OR _GSS_${_gnu_modname}_VERSION)
+  # _gss_MODULE_NAME set since CMake 3.16
+  if(_gss_MODULE_NAME STREQUAL _gnu_modname OR _gss_${_gnu_modname}_VERSION)
     set(GSS_FLAVOUR "GNU")
     set(GSS_PC_REQUIRES "gss")
     if(NOT _gss_version)  # for old CMake versions?
-      set(_gss_version ${_GSS_${_gnu_modname}_VERSION})
+      set(_gss_version ${_gss_${_gnu_modname}_VERSION})
     endif()
-  elseif(_GSS_MODULE_NAME STREQUAL _mit_modname OR _GSS_${_mit_modname}_VERSION)
+  elseif(_gss_MODULE_NAME STREQUAL _mit_modname OR _gss_${_mit_modname}_VERSION)
     set(GSS_FLAVOUR "MIT")
     set(GSS_PC_REQUIRES "mit-krb5-gssapi")
     if(NOT _gss_version)  # for old CMake versions?
-      set(_gss_version ${_GSS_${_mit_modname}_VERSION})
+      set(_gss_version ${_gss_${_mit_modname}_VERSION})
     endif()
   else()
     set(GSS_FLAVOUR "Heimdal")
     set(GSS_PC_REQUIRES "heimdal-gssapi")
     if(NOT _gss_version)  # for old CMake versions?
-      set(_gss_version ${_GSS_${_heimdal_modname}_VERSION})
+      set(_gss_version ${_gss_${_heimdal_modname}_VERSION})
     endif()
   endif()
-  message(STATUS "Found GSS/${GSS_FLAVOUR} (via pkg-config): ${_GSS_INCLUDE_DIRS} (found version \"${_gss_version}\")")
+  message(STATUS "Found GSS/${GSS_FLAVOUR} (via pkg-config): ${_gss_INCLUDE_DIRS} (found version \"${_gss_version}\")")
 endif()
 
-string(REPLACE ";" " " _GSS_CFLAGS "${_GSS_CFLAGS}")
+string(REPLACE ";" " " _gss_CFLAGS "${_gss_CFLAGS}")
 
-set(GSS_INCLUDE_DIRS ${_GSS_INCLUDE_DIRS})
-set(GSS_LIBRARIES ${_GSS_LIBRARIES})
-set(GSS_LIBRARY_DIRS ${_GSS_LIBRARY_DIRS})
-set(GSS_CFLAGS ${_GSS_CFLAGS})
+set(GSS_INCLUDE_DIRS ${_gss_INCLUDE_DIRS})
+set(GSS_LIBRARIES ${_gss_LIBRARIES})
+set(GSS_LIBRARY_DIRS ${_gss_LIBRARY_DIRS})
+set(GSS_CFLAGS ${_gss_CFLAGS})
 set(GSS_VERSION ${_gss_version})
 
 if(GSS_FLAVOUR)
@@ -354,12 +354,12 @@ find_package_handle_standard_args(GSS
 )
 
 mark_as_advanced(
-  _GSS_CFLAGS
-  _GSS_FOUND
-  _GSS_INCLUDE_DIRS
-  _GSS_LIBRARIES
-  _GSS_LIBRARY_DIRS
-  _GSS_MODULE_NAME
-  _GSS_PREFIX
+  _gss_CFLAGS
+  _gss_FOUND
+  _gss_INCLUDE_DIRS
+  _gss_LIBRARIES
+  _gss_LIBRARY_DIRS
+  _gss_MODULE_NAME
+  _gss_PREFIX
   _gss_version
 )


### PR DESCRIPTION
Also rename `_GSS*` local variables to `_gss*` to please `clang-lint`,
which emitted new warnings after adding the initializations.

Ref: https://github.com/curl/curl/issues/17802#issuecomment-3029455984

---

- [x] rebase after merging #17805
