### PR TITLE
tool1621: drop unused internal libcurl headers

### DIFF
--- a/tests/tunit/tool1621.c
+++ b/tests/tunit/tool1621.c
@@ -23,9 +23,6 @@
  ***************************************************************************/
 #include "curlcheck.h"
 
-#include "urldata.h"
-#include "url.h"
-
 #include "tool_xattr.h"
 
 #include "memdebug.h" /* LAST include file */


### PR DESCRIPTION
---

- [x] fix `curl_add_clang_tidy_test_target()` to detect header directories
  (perhaps also compile definitions) in dependencies _recursively_.
  To address the root cause seen with PR 16973 applied. → b7d9db30c1bfecf2f1a14a8ff90e9f612409a8c7 → #17812
- [x] rebase on #17812. [It's okay, no need]
