### PR TITLE
cmake: fix `curl_add_clang_tidy_test_target` when no `-D` option

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -141,6 +141,9 @@ macro(curl_add_clang_tidy_test_target _target_clang_tidy _target)
     # Collect macro definitions applying to the target
     get_directory_property(_definitions_d COMPILE_DEFINITIONS)
     get_target_property(_definitions_t ${_target} COMPILE_DEFINITIONS)
+    if(NOT _definitions_t)
+      unset(_definitions_t)
+    endif()
 
     set(_definitions "${_definitions_l};${_definitions_d};${_definitions_t}")
     list(REMOVE_ITEM _definitions "")


### PR DESCRIPTION
Fix `curl_add_clang_tidy_test_target` generating an invalid option for
`clang-tidy` if the tested target has no custom macro definition.

Current build doesn't hit this case, but a pending PR does.

Fixing:
```
[...] -Ilib -Itests/client -DCURL_HIDDEN_SYMBOLS -DHAVE_CONFIG_H -D_definitions_t-NOTFOUND
```
error: ISO C99 requires whitespace after the macro name [clang-diagnostic-c99-extensions,-warnings-as-errors]

Cherry-picked from #17768