### PR TITLE
cmake: `curl_add_clang_tidy_test_target` tidy-ups

### DIFF
--- a/CMake/Macros.cmake
+++ b/CMake/Macros.cmake
@@ -149,8 +149,8 @@ macro(curl_add_clang_tidy_test_target _target_clang_tidy _target)
 
     list(REMOVE_ITEM _definitions "")
     string(REPLACE ";" ";-D" _definitions ";${_definitions}")
-    list(SORT _definitions)  # Sort like CMake does
     list(REMOVE_DUPLICATES _definitions)
+    list(SORT _definitions)  # Sort like CMake does
 
     # Assemble source list
     set(_sources "")


### PR DESCRIPTION
- simplify gathering header directories and compiler definitions
  recursively.

- handle the case when the cmake directory object doesn't define header
  directories or compiler definitions.

- honor more corners cases:
  - `INTERFACE_INCLUDE_DIRECTORIES` of the initial target.
  - handle no header directory for initial target.

- de-duplicate header directories and compiler redefinitions to mimic
  CMake.

- drop unnecessary `unset()`s.

Note that the order of header directories remains different compared to
how CMake passes them to the compiler when building tests. The order is
already different in the test target `INCLUDE_DIRECTORIES` property,
preventing to reproduce the exact CMake order. The distinction between
`-I` and `-isystem` is also missing from target properties.

Cherry-picked from #17768

---

- [x] tested OK with PR #16973.
- [x] tested OK with PR #17768.
