### PR TITLE
doc: warn about lifetime in CURLOPT_CLOSESOCKET*

### DIFF
--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETDATA.md
@@ -31,6 +31,11 @@ Pass a *pointer* that remains untouched by libcurl and passed as the first
 argument in the closesocket callback set with
 CURLOPT_CLOSESOCKETFUNCTION(3).
 
+Note that when using multi/share handles, your callback may get invoked even
+after the easy handle has been cleaned up. The callback and data is
+inherited by a new connection and that connection may live longer
+than the transfer itself in the multi/share handle's connection cache.
+
 # DEFAULT
 
 NULL

--- a/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
+++ b/docs/libcurl/opts/CURLOPT_CLOSESOCKETFUNCTION.md
@@ -42,6 +42,11 @@ The *clientp* pointer is set with
 CURLOPT_CLOSESOCKETDATA(3). *item* is the socket libcurl wants to be
 closed.
 
+Note that when using multi/share handles, your callback may get invoked even
+after the easy handle has been cleaned up. The callback and data is
+inherited by a new connection and that connection may live longer
+than the transfer itself in the multi/share handle's connection cache.
+
 # DEFAULT
 
 Use the standard socket close function.


### PR DESCRIPTION
Callback and data set via CURLOPT_CLOSESOCKETFUNCTION and CURLOPT_CLOSESOCKETDATA may get used after the easy handle has been cleaned up. Inform about that.

refs #17755