### PR TITLE
lib: fix unused parameter/function compiler warnings

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -505,6 +505,8 @@ Curl_dnscache_mk_entry(struct Curl_easy *data,
       return NULL;
     }
   }
+#else
+  (void)data;
 #endif
   if(!hostlen)
     hostlen = strlen(hostname);

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -240,7 +240,7 @@ static CURLcode protocol2num(const char *str, curl_prot_t *val)
   return CURLE_OK;
 }
 
-#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_PROXY)
+#if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_PROXY)
 static CURLcode httpauth(struct Curl_easy *data, bool proxy,
                          unsigned long auth)
 {
@@ -285,7 +285,7 @@ static CURLcode httpauth(struct Curl_easy *data, bool proxy,
     data->set.httpauth = auth;
   return CURLE_OK;
 }
-#endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_PROXY */
+#endif /* !CURL_DISABLE_HTTP || !CURL_DISABLE_PROXY */
 
 #ifndef CURL_DISABLE_HTTP
 static CURLcode setopt_HTTP_VERSION(struct Curl_easy *data, long arg)

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -240,6 +240,7 @@ static CURLcode protocol2num(const char *str, curl_prot_t *val)
   return CURLE_OK;
 }
 
+#ifndef CURL_DISABLE_HTTP
 static CURLcode httpauth(struct Curl_easy *data, bool proxy,
                          unsigned long auth)
 {
@@ -285,7 +286,6 @@ static CURLcode httpauth(struct Curl_easy *data, bool proxy,
   return CURLE_OK;
 }
 
-#ifndef CURL_DISABLE_HTTP
 static CURLcode setopt_HTTP_VERSION(struct Curl_easy *data, long arg)
 {
   /*

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -240,7 +240,7 @@ static CURLcode protocol2num(const char *str, curl_prot_t *val)
   return CURLE_OK;
 }
 
-#ifndef CURL_DISABLE_HTTP
+#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_PROXY)
 static CURLcode httpauth(struct Curl_easy *data, bool proxy,
                          unsigned long auth)
 {
@@ -285,7 +285,9 @@ static CURLcode httpauth(struct Curl_easy *data, bool proxy,
     data->set.httpauth = auth;
   return CURLE_OK;
 }
+#endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_PROXY */
 
+#ifndef CURL_DISABLE_HTTP
 static CURLcode setopt_HTTP_VERSION(struct Curl_easy *data, long arg)
 {
   /*

--- a/lib/url.c
+++ b/lib/url.c
@@ -2760,6 +2760,7 @@ static CURLcode parse_remote_port(struct Curl_easy *data,
   return CURLE_OK;
 }
 
+#ifndef CURL_DISABLE_NETRC
 static bool str_has_ctrl(const char *input)
 {
   if(input) {
@@ -2772,6 +2773,7 @@ static bool str_has_ctrl(const char *input)
   }
   return FALSE;
 }
+#endif
 
 /*
  * Override the login details from the URL with that in the CURLOPT_USERPWD


### PR DESCRIPTION
- hostip: fix unused variable with `CURL_DISABLE_SHUFFLE_DNS`
  ```
  lib/hostip.c: In function 'Curl_dnscache_mk_entry':
  lib/hostip.c:490:42: warning: unused parameter 'data' [-Wunused-parameter]
    490 | Curl_dnscache_mk_entry(struct Curl_easy *data,
        |                        ~~~~~~~~~~~~~~~~~~^~~~
  ```

- setopt: fix unused function with `CURL_DISABLE_HTTP`
  ```
  lib/setopt.c:214:17: warning: 'httpauth' defined but not used [-Wunused-function]
    214 | static CURLcode httpauth(struct Curl_easy *data, bool proxy,
        |                 ^~~~~~~~
  ```

- url: fix unused function with `CURL_DISABLE_NETRC`
  ```
  lib/url.c:2760:13: warning: 'str_has_ctrl' defined but not used [-Wunused-function]
   2760 | static bool str_has_ctrl(const char *input)
        |             ^~~~~~~~~~~~
  ```

Seen with a minimal curl-for-win build:
```
CW_CONFIG=dev-x64-zero-osnotls-osnoidn-nohttp-nocurltool-linux-unity
```
