### PR TITLE
test: output cleanups

### DIFF
--- a/tests/data/test1006
+++ b/tests/data/test1006
@@ -25,7 +25,7 @@ REPLY CWD 250-AAAAAAAAAAAAAAAAAAAAAAAAA\r\n250-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 ftp
 </server>
 <name>
-FTP with excessively large number of server command response lines (boundary condition)
+FTP with large number of command response lines (boundary condition)
 </name>
 <command>
 ftp://%HOSTIP:%FTPPORT/path/%TESTNUMBER

--- a/tests/data/test1114
+++ b/tests/data/test1114
@@ -22,7 +22,7 @@ ftp
 lib576
 </tool>
 <name>
-FTP wildcard download - skip/parser_correctness/CURLOPT_FNMATCH_FUNCTION (DOS)
+FTP wildcard download - skip/correctness/FNMATCH_FUNCTION (DOS)
 </name>
 <command>
 ftp://%HOSTIP:%FTPPORT/fully_simulated/DOS/*

--- a/tests/data/test1181
+++ b/tests/data/test1181
@@ -28,7 +28,7 @@ http
 proxy
 </features>
 <name>
-HTTP GET request with proxy and --proxy-header "Proxy-Connection: Keep-Alive"
+HTTP GET request with proxy and "Proxy-Connection: Keep-Alive"
 </name>
 <command>
 --proxy http://%HOSTIP:%HTTPPORT --proxy-header "Proxy-Connection: Keep-Alive" http://%HOSTIP:%HTTPPORT/%TESTNUMBER

--- a/tests/data/test1248
+++ b/tests/data/test1248
@@ -29,7 +29,7 @@ proxy
 http
 </server>
 <name>
-Access a non-proxied host with using the combination of --proxy option and --noproxy option
+Non-proxied host plus --proxy option and --noproxy option
 </name>
 <command>
 http://user:secret@%HOSTIP:%HTTPPORT/%TESTNUMBER --proxy http://dummy:%NOLISTENPORT/ --noproxy %HOSTIP --max-time 5

--- a/tests/data/test1249
+++ b/tests/data/test1249
@@ -29,7 +29,7 @@ proxy
 http
 </server>
 <name>
-Access a non-proxied host with using the combination of --proxy option and NO_PROXY env var
+Non-proxied plus --proxy option and NO_PROXY env var
 </name>
 <setenv>
 NO_PROXY=%HOSTIP

--- a/tests/data/test1250
+++ b/tests/data/test1250
@@ -27,7 +27,7 @@ foo
 http
 </server>
 <name>
-Access a non-proxied host with using the combination of http_proxy env var and --noproxy option
+Non-proxied host plus http_proxy env var and --noproxy option
 </name>
 <setenv>
 http_proxy=http://dummy:%PROXYPORT/

--- a/tests/data/test1251
+++ b/tests/data/test1251
@@ -27,7 +27,7 @@ foo
 http
 </server>
 <name>
-Access a non-proxied host with using the combination of http_proxy env var and NO_PROXY env var
+Non-proxied host plus http_proxy env var and NO_PROXY env var
 </name>
 <setenv>
 http_proxy=http://dummy:%PROXYPORT/

--- a/tests/data/test1252
+++ b/tests/data/test1252
@@ -30,7 +30,7 @@ proxy
 http
 </server>
 <name>
-Under condition using --proxy, override NO_PROXY by --noproxy and access target URL directly
+--proxy, override NO_PROXY by --noproxy and access target URL directly
 </name>
 <setenv>
 NO_PROXY=example.com

--- a/tests/data/test1253
+++ b/tests/data/test1253
@@ -27,7 +27,7 @@ foo
 http
 </server>
 <name>
-Under condition using --proxy, override NO_PROXY by --noproxy and access target URL through proxy
+--proxy, override NO_PROXY by --noproxy and access target URL through proxy
 </name>
 <setenv>
 NO_PROXY=example.com

--- a/tests/data/test1255
+++ b/tests/data/test1255
@@ -28,7 +28,7 @@ foo
 http
 </server>
 <name>
-Under condition using http_proxy, override NO_PROXY by --noproxy and access target URL directly
+http_proxy, override NO_PROXY by --noproxy and access target URL directly
 </name>
 <setenv>
 http_proxy=http://%HOSTIP:%HTTPPORT

--- a/tests/data/test1256
+++ b/tests/data/test1256
@@ -28,7 +28,7 @@ foo
 http
 </server>
 <name>
-Under condition using http_proxy, override NO_PROXY by --noproxy and access target URL through proxy
+http_proxy, override NO_PROXY by --noproxy and target URL through proxy
 </name>
 <setenv>
 http_proxy=http://%HOSTIP:%HTTPPORT

--- a/tests/data/test1257
+++ b/tests/data/test1257
@@ -28,7 +28,7 @@ foo
 http
 </server>
 <name>
-Under condition using http_proxy, override NO_PROXY by --noproxy and access target URL through proxy
+http_proxy, override NO_PROXY by --noproxy and target URL through proxy
 </name>
 <setenv>
 http_proxy=http://%HOSTIP:%HTTPPORT

--- a/tests/data/test1404
+++ b/tests/data/test1404
@@ -31,7 +31,7 @@ Mime
 http
 </server>
 <name>
---libcurl for HTTP RFC1867-type formposting - -F with 3 files, one with explicit type & encoder
+--libcurl plus -F with 3 files, one with explicit type & encoder
 </name>
 <setenv>
 SSL_CERT_FILE=

--- a/tests/data/test1527
+++ b/tests/data/test1527
@@ -47,7 +47,7 @@ http-proxy
 lib%TESTNUMBER
 </tool>
 <name>
-Check same headers are generated with CURLOPT_HEADEROPT == CURLHEADER_UNIFIED
+Same headers with CURLOPT_HEADEROPT == CURLHEADER_UNIFIED
 </name>
 <command>
  http://the.old.moo.%TESTNUMBER:%HTTPPORT/%TESTNUMBER %HOSTIP:%PROXYPORT

--- a/tests/data/test1557
+++ b/tests/data/test1557
@@ -18,7 +18,7 @@ lib%TESTNUMBER
 </tool>
 
 <name>
-Removing easy handle that's in the pending connections list doesn't leave behind a dangling entry
+Remove easy handle in pending connections doesn't leave dangling entry
 </name>
 <command>
 nothing

--- a/tests/data/test1958
+++ b/tests/data/test1958
@@ -44,7 +44,7 @@ CURL_FORCEHOST=1
 </setenv>
 
 <name>
-HTTP AWS_SIGV4 with X-Xxx-Content-Sha256 of arbitrary payload with whitespace
+HTTP AWS_SIGV4 with X-Xxx-Content-Sha256 with whitespace
 </name>
 <tool>
 lib%TESTNUMBER

--- a/tests/data/test1964
+++ b/tests/data/test1964
@@ -40,7 +40,7 @@ aws
 </features>
 
 <name>
-HTTP AWS_SIGV4 with one provider and auth cred via URL, but X-Xxx-Date header set manually
+HTTP AWS_SIGV4 with X-Xxx-Date header set manually
 </name>
 <tool>
 lib%TESTNUMBER

--- a/tests/data/test2003
+++ b/tests/data/test2003
@@ -55,7 +55,7 @@ file
 tftp
 </server>
 <name>
-HTTP GET followed by FTP RETR followed by FILE followed by TFTP RRQ then again in reverse order
+HTTP GET, FTP RETR, FILE, TFTP RRQ then again in rev order
 </name>
 <command option="no-include">
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001 ftp://%HOSTIP:%FTPPORT/%TESTNUMBER0002 file://localhost%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER0003 tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER0003 file://localhost%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt ftp://%HOSTIP:%FTPPORT/%TESTNUMBER0002 http://%HOSTIP:%HTTPPORT/%TESTNUMBER0001

--- a/tests/data/test2004
+++ b/tests/data/test2004
@@ -27,7 +27,7 @@ tftp
 sftp
 </server>
 <name>
-TFTP RRQ followed by SFTP retrieval followed by FILE followed by SCP retrieval then again in reverse order
+TFTP RRQ, SFTP, FILE, SCP retrieval then in rev order
 </name>
 <command option="no-include">
 --key %LOGDIR/server/curl_client_key --pubkey %LOGDIR/server/curl_client_key.pub -u %USER: tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER sftp://%HOSTIP:%SSHPORT%SFTP_PWD/%LOGDIR/test%TESTNUMBER.txt file://localhost%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt scp://%HOSTIP:%SSHPORT%SCP_PWD/%LOGDIR/test%TESTNUMBER.txt file://localhost%FILE_PWD/%LOGDIR/test%TESTNUMBER.txt sftp://%HOSTIP:%SSHPORT%SFTP_PWD/%LOGDIR/test%TESTNUMBER.txt tftp://%HOSTIP:%TFTPPORT//%TESTNUMBER --insecure

--- a/tests/data/test2050
+++ b/tests/data/test2050
@@ -47,7 +47,7 @@ http
 http-proxy
 </server>
 <name>
-Connect to specific host via HTTP proxy (switch to tunnel mode automatically)
+--connect-to via HTTP proxy (tunnel mode automatically)
 </name>
 
 <command>

--- a/tests/data/test2052
+++ b/tests/data/test2052
@@ -28,7 +28,7 @@ OK
 http
 </server>
 <name>
-Connect to specific host: Do not mix connections with and without a "connect to host"
+--connect-to: do not mix connections with and without a "connect to host"
 </name>
 
 <command>

--- a/tests/data/test2055
+++ b/tests/data/test2055
@@ -49,7 +49,7 @@ http-proxy
 socks5
 </server>
 <name>
-Connect to specific host via SOCKS proxy and HTTP proxy (switch to tunnel mode automatically)
+--connect-to via SOCKS proxy and HTTP proxy (tunnel mode automatically)
 </name>
 <features>
 proxy

--- a/tests/data/test2058
+++ b/tests/data/test2058
@@ -70,7 +70,7 @@ proxy
 digest
 </features>
 <name>
-HTTP POST --digest with PUT, resumed upload, modified method and SHA-256
+HTTP Digest with PUT, resumed upload, modified method and SHA-256
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u auser:apasswd --digest -T %LOGDIR/%TESTNUMBER -x  http://%HOSTIP:%HTTPPORT -C 2 -X GET

--- a/tests/data/test2059
+++ b/tests/data/test2059
@@ -70,7 +70,7 @@ proxy
 digest
 </features>
 <name>
-HTTP POST --digest with PUT, resumed upload, modified method, SHA-256 and userhash=true
+HTTP Digest with PUT, resumed upload, modified method, SHA-256 and userhash
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u auser:apasswd --digest -T %LOGDIR/%TESTNUMBER -x  http://%HOSTIP:%HTTPPORT -C 2 -X GET

--- a/tests/data/test2060
+++ b/tests/data/test2060
@@ -70,7 +70,7 @@ proxy
 sha512-256
 </features>
 <name>
-HTTP POST --digest with PUT, resumed upload, modified method, SHA-512-256 and userhash=false
+HTTP Digest with PUT, resumed upload, SHA-512-256, userhash
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u auser:apasswd --digest -T %LOGDIR/%TESTNUMBER -x  http://%HOSTIP:%HTTPPORT -C 2 -X GET

--- a/tests/data/test2065
+++ b/tests/data/test2065
@@ -57,7 +57,7 @@ crypto
 sha512-256
 </features>
 <name>
-HTTP with RFC7616 Digest authorization with bad password, SHA-512-256 and userhash=false
+HTTP with RFC7616 Digest, bad password, SHA-512-256 and userhash
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u testuser:test2pass --digest

--- a/tests/data/test2066
+++ b/tests/data/test2066
@@ -57,7 +57,7 @@ crypto
 digest
 </features>
 <name>
-HTTP with RFC7616 Digest authorization with bad password, SHA-256 and userhash=true
+HTTP with RFC7616 Digest, bad password, SHA-256 and userhash
 </name>
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -u testuser:test2pass --digest

--- a/tests/data/test2068
+++ b/tests/data/test2068
@@ -55,7 +55,7 @@ crypto
 sha512-256
 </features>
 <name>
-HTTP POST --digest with SHA-512-256, userhash=false and user-specified Content-Length header
+HTTP POST Digest with SHA-512-256, userhash and set Content-Length
 </name>
 # This test is to ensure 'Content-Length: 0' is sent while negotiating auth
 # even when there is a user-specified Content-Length header.

--- a/tests/data/test2069
+++ b/tests/data/test2069
@@ -55,7 +55,7 @@ crypto
 digest
 </features>
 <name>
-HTTP POST --digest with SHA-256, userhash=true and user-specified Content-Length header
+HTTP POST Digest with SHA-256, userhash and set Content-Length header
 </name>
 # This test is to ensure 'Content-Length: 0' is sent while negotiating auth
 # even when there is a user-specified Content-Length header.

--- a/tests/data/test234
+++ b/tests/data/test234
@@ -64,7 +64,7 @@ contents
 http
 </server>
 <name>
-HTTP, proxy, site+proxy auth and Location: to new host using location-trusted
+HTTP, proxy, site+proxy auth and Location: to new host location-trusted
 </name>
 <command>
 http://first.host.it.is/we/want/that/page/%TESTNUMBER -x %HOSTIP:%HTTPPORT --user iam:myself --proxy-user testing:this --location-trusted

--- a/tests/data/test3000
+++ b/tests/data/test3000
@@ -32,7 +32,7 @@ local-http
 https test-localhost-san-first.pem
 </server>
 <name>
-HTTPS GET to localhost, first subject alt name matches, CN does not match
+HTTPS localhost, first subaltname matches, CN does not match
 </name>
 <command>
 -4 --cacert %CERTDIR/certs/test-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER

--- a/tests/data/test3001
+++ b/tests/data/test3001
@@ -32,7 +32,7 @@ local-http
 https test-localhost-san-last.pem
 </server>
 <name>
-HTTPS GET to localhost, last subject alt name matches, CN does not match
+HTTPS localhost, last subject alt name matches, CN does not match
 </name>
 <command>
 -4 --cacert %CERTDIR/certs/test-ca.crt https://localhost:%HTTPSPORT/%TESTNUMBER

--- a/tests/data/test3002
+++ b/tests/data/test3002
@@ -17,7 +17,7 @@ SMTP
 smtp
 </server>
 <name>
-SMTP with multiple and invalid (first) --mail-rcpt and --mail-rcpt-allowfails
+SMTP multiple and invalid (first) --mail-rcpt and --mail-rcpt-allowfails
 </name>
 <stdin>
 From: different

--- a/tests/data/test3003
+++ b/tests/data/test3003
@@ -17,7 +17,7 @@ SMTP
 smtp
 </server>
 <name>
-SMTP with multiple and invalid (last) --mail-rcpt and --mail-rcpt-allowfails
+SMTP multiple and invalid (last) --mail-rcpt and --mail-rcpt-allowfails
 </name>
 <stdin>
 From: different

--- a/tests/data/test3004
+++ b/tests/data/test3004
@@ -17,7 +17,7 @@ SMTP
 smtp
 </server>
 <name>
-SMTP with multiple and invalid (middle) --mail-rcpt and --mail-rcpt-allowfails
+SMTP multiple and invalid (middle) --mail-rcpt and --mail-rcpt-allowfails
 </name>
 <stdin>
 From: different

--- a/tests/data/test3005
+++ b/tests/data/test3005
@@ -17,7 +17,7 @@ SMTP
 smtp
 </server>
 <name>
-SMTP with multiple and invalid (all but one) --mail-rcpt and --mail-rcpt-allowfails
+SMTP multiple invalid (all but one) --mail-rcpt and --mail-rcpt-allowfails
 </name>
 <stdin>
 From: different

--- a/tests/data/test3023
+++ b/tests/data/test3023
@@ -32,7 +32,7 @@ local-http
 https test-localhost-san-first.pem
 </server>
 <name>
-HTTPS GET to localhost, first subject alt name matches, CN does not match (Schannel variant)
+HTTPS localhost, first subaltname matches, CN does not match (Schannel)
 </name>
 <setenv>
 # This test is pointless if we are not using the Schannel backend

--- a/tests/data/test3024
+++ b/tests/data/test3024
@@ -32,7 +32,7 @@ local-http
 https test-localhost-san-last.pem
 </server>
 <name>
-HTTPS GET to localhost, last subject alt name matches, CN does not match (Schannel variant)
+HTTPS localhost, last subaltname matches, CN does not match (Schannel)
 </name>
 <setenv>
 # This test is pointless if we are not using the Schannel backend

--- a/tests/data/test576
+++ b/tests/data/test576
@@ -22,7 +22,7 @@ ftp
 lib%TESTNUMBER
 </tool>
 <name>
-FTP wildcard download - skip/parser_correctness/CURLOPT_FNMATCH_FUNCTION (Unix)
+FTP wildcard - skip/parser_correctness/CURLOPT_FNMATCH_FUNCTION (Unix)
 </name>
 <command>
 ftp://%HOSTIP:%FTPPORT/fully_simulated/UNIX/*

--- a/tests/data/test741
+++ b/tests/data/test741
@@ -23,7 +23,7 @@ http
 HOME=%PWD/%LOGDIR
 </setenv>
 <name>
-IPFS with malformed gateway URL from multiline gateway file, first line no url
+IPFS malformed gw URL from multiline gateway file, first line no url
 </name>
 <command>
 ipfs://bafybeidecnvkrygux6uoukouzps5ofkeevoqland7kopseiod6pzqvjg7u

--- a/tests/data/test849
+++ b/tests/data/test849
@@ -25,7 +25,7 @@ REPLY dXJzZWwAa3VydAB4aXBqM3BsbXE= A002 NO Not authorized
 imap
 </server>
 <name>
-IMAP plain authentication with alternative authorization identity (Not authorized)
+IMAP plain auth with alt authorization identity (Not authorized)
 </name>
 <command>
 'imap://%HOSTIP:%IMAPPORT/%TESTNUMBER/;MAILINDEX=1' -u kurt:xipj3plmq --sasl-authzid ursel

--- a/tests/data/test893
+++ b/tests/data/test893
@@ -27,7 +27,7 @@ REPLY dXJzZWwAa3VydAB4aXBqM3BsbXE= -ERR Not authorized
 pop3
 </server>
 <name>
-POP3 plain authentication with alternative authorization identity (Not authorized)
+POP3 plain auth with alt authorization identity (Not authorized)
 </name>
 <command>
 pop3://%HOSTIP:%POP3PORT/%TESTNUMBER -u kurt:xipj3plmq --sasl-authzid ursel

--- a/tests/data/test954
+++ b/tests/data/test954
@@ -26,7 +26,7 @@ REPLY dXJzZWwAa3VydAB4aXBqM3BsbXE= 501 Not authorized
 smtp
 </server>
 <name>
-SMTP plain authentication with alternative authorization identity (Not authorized)
+SMTP plain auth with alt authorization identity (Not authorized)
 </name>
 <stdin>
 mail body

--- a/tests/data/test957
+++ b/tests/data/test957
@@ -26,7 +26,7 @@ LC_ALL=en_US.UTF-8
 LC_CTYPE=en_US.UTF-8
 </setenv>
 <name>
-SMTP VRFY without SMTPUTF8 support - UTF-8 based recipient (local part only)
+SMTP VRFY without SMTPUTF8 support - UTF-8 recipient (local part only)
 </name>
 <command>
 smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt Anv%hex[%c3%a4]hex%ndaren

--- a/tests/data/test958
+++ b/tests/data/test958
@@ -26,7 +26,7 @@ LC_ALL=en_US.UTF-8
 LC_CTYPE=en_US.UTF-8
 </setenv>
 <name>
-SMTP external VRFY without SMTPUTF8 support - UTF-8 based recipient (local part only)
+SMTP external VRFY without SMTPUTF8 - UTF-8 recipient (local part only)
 </name>
 <command>
 smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt Anv%hex[%c3%a4]hex%ndaren@example.com

--- a/tests/data/test961
+++ b/tests/data/test961
@@ -27,7 +27,7 @@ LC_ALL=en_US.UTF-8
 LC_CTYPE=en_US.UTF-8
 </setenv>
 <name>
-SMTP external VRFY without SMTPUTF8 support - UTF-8 based recipient (host part only)
+SMTP external VRFY without SMTPUTF8 - UTF-8 recipient (host part only)
 </name>
 <command>
 smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt user@%hex[%c3%a5%c3%a4%c3%b6]hex%.se

--- a/tests/data/test963
+++ b/tests/data/test963
@@ -27,7 +27,7 @@ LC_ALL=en_US.UTF-8
 LC_CTYPE=en_US.UTF-8
 </setenv>
 <name>
-SMTP without SMTPUTF8 support (IDN Enabled) - UTF-8 based recipient (host part only)
+SMTP without SMTPUTF8 support (IDN) - UTF-8 recipient (host part only)
 </name>
 <stdin>
 From: different

--- a/tests/data/test964
+++ b/tests/data/test964
@@ -28,7 +28,7 @@ LC_ALL=en_US.UTF-8
 LC_CTYPE=en_US.UTF-8
 </setenv>
 <name>
-SMTP external VRFY without SMTPUTF8 support (IDN Enabled) - UTF-8 based recipient (host part only)
+SMTP external VRFY without SMTPUTF8 (IDN) - UTF-8 recipient (host part)
 </name>
 <command>
 smtp://%HOSTIP:%SMTPPORT/%TESTNUMBER --mail-rcpt user@%hex[%c3%a5%c3%a4%c3%b6]hex%.se

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1199,12 +1199,12 @@ sub singletest_count {
     }
 
     # At this point we've committed to run this test
-    logmsg sprintf("test %04d...", $testnum) if(!$automakestyle);
+    logmsg sprintf("%d: ", $testnum) if(!$automakestyle);
 
     # name of the test
     my $testname= (getpart("client", "name"))[0];
     chomp $testname;
-    logmsg "[$testname]\n" if(!$short);
+    logmsg "$testname\n" if(!$short);
 
     if($listonly) {
         timestampskippedevents($testnum);
@@ -1798,7 +1798,7 @@ sub singletest_success {
     my $duration = sprintf("duration: %02d:%02d",
                            $sofar/60, $sofar%60);
     if(!$automakestyle) {
-        logmsg sprintf("OK (%-3d out of %-3d, %s, took %.3fs, %s)\n",
+        logmsg sprintf("%d/%d, %s, took %.3fs, %s\n",
                        $count, $total, $timeleft, $took, $duration);
     }
     else {


### PR DESCRIPTION
- shorten and simplify several test case names. Keep names within 75 characters
- reduce superfluous letters and simplify terminal output when running runtests

@dfandrich would this second change risk impacting TestClutch?