### PR TITLE
tests/http/requirements: remove multipart

### DIFF
--- a/tests/http/requirements.txt
+++ b/tests/http/requirements.txt
@@ -26,7 +26,6 @@
 pytest
 cryptography
 filelock
-multipart
 websockets
 psutil
 pytest-xdist


### PR DESCRIPTION
This is not actually used.

Reported-by: defnull
https://chaos.social/@defnull/114801392456999379