### PR TITLE
rustls: apply memory function overrides, fixing an ECH buffer free

### DIFF
--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -43,6 +43,10 @@
 #include "cipher_suite.h"
 #include "x509asn1.h"
 
+/* The last #include files should be: */
+#include "../curl_memory.h"
+#include "../memdebug.h"
+
 struct rustls_ssl_backend_data
 {
   const struct rustls_client_config *config;


### PR DESCRIPTION
Fixing:

- a raw `free()` in ECH code that's malloced in lib code, causing
  an invalid free, also reported by valgrind (in non-unity builds).

  And in unity builds adjusted to behave like non-unity via #17827:
  Ref: https://github.com/curl/curl/actions/runs/16093372427/job/45421778472?pr=17827#step:39:3321

- a local pair of `malloc()`/`free()` to use curl's memory allocators,
  and participate in memory tracking when enabled.

Cherry-picked from #17827
