### PR TITLE
curl_memory.h: fix to undefine `accept4`

### DIFF
--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -79,6 +79,9 @@
 
 #undef socket
 #undef accept
+#ifdef HAVE_ACCEPT4
+#undef accept4
+#endif
 #ifdef HAVE_SOCKETPAIR
 #undef socketpair
 #endif


### PR DESCRIPTION
Follow-up to 3d02872be7cfe6dcdef4b02321b47af19e1ce268 #16979

Cherry-picked from #17827