### PR TITLE
memdebug.h: eliminate global macro `CURL_MT_LOGFNAME_BUFSIZE`

### DIFF
--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -56,8 +56,6 @@
 #  define ALLOC_SIZE2(n, s)
 #endif
 
-#define CURL_MT_LOGFNAME_BUFSIZE 512
-
 /* Avoid redundant redeclaration warnings with modern compilers, when including
    this header multiple times. */
 #ifndef HEADER_CURL_MEMDEBUG_H_EXTERNS

--- a/src/tool_main.c
+++ b/src/tool_main.c
@@ -116,9 +116,9 @@ static void memory_tracking_init(void)
   env = curl_getenv("CURL_MEMDEBUG");
   if(env) {
     /* use the value as filename */
-    char fname[CURL_MT_LOGFNAME_BUFSIZE];
-    if(strlen(env) >= CURL_MT_LOGFNAME_BUFSIZE)
-      env[CURL_MT_LOGFNAME_BUFSIZE-1] = '\0';
+    char fname[512];
+    if(strlen(env) >= sizeof(fname))
+      env[sizeof(fname)-1] = '\0';
     strcpy(fname, env);
     curl_free(env);
     curl_dbg_memdebug(fname);


### PR DESCRIPTION
It had a single use in `src/tool_main.c`. Replace with a literal and
`sizeof()`s.

Follow-up to aaab5fa299e13c0c3abba929cb187a8ec3b006f9

Cherry-picked from #17827
