### PR TITLE
GHA/curl-for-win: enable unity batches to improve build perf

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-linux-a64-x64-gcc'
+          export CW_CONFIG='-main-werror-unitybatch-linux-a64-x64-gcc'
           export CW_REVISION="${GITHUB_SHA}"
           DOCKER_IMAGE='debian:bookworm-slim'
           export CW_CCSUFFIX='-15'
@@ -87,7 +87,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-linux-musl-r64-x64'
+          export CW_CONFIG='-main-werror-unitybatch-linux-musl-r64-x64'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default
@@ -116,7 +116,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-mac-x64'
+          export CW_CONFIG='-main-werror-unitybatch-mac-x64'
           export CW_REVISION="${GITHUB_SHA}"
           sh -c ./_ci-mac-homebrew.sh
 
@@ -133,7 +133,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-win-x64'
+          export CW_CONFIG='-main-werror-unitybatch-win-x64'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default
@@ -159,7 +159,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-win-x86-gcc-libssh1-zlibng'
+          export CW_CONFIG='-main-werror-unitybatch-win-x86-gcc-libssh1-zlibng'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default


### PR DESCRIPTION
Job                 | Before |  After |
:------------------ | -----: | -----: |
Linux gcc glibc     |  4m44s |  4m13s |
Linux llvm MUSL     |  4m17s |  4m00s |
macOS clang         |  1m59s |  1m54s |
Windows llvm        |  3m56s |  3m18s |
Windows gcc ... x86 |  3m26s |  3m11s |

Before: https://github.com/curl/curl/actions/runs/16101989848
After: https://github.com/curl/curl/actions/runs/16102353747?pr=17836
