### PR TITLE
windows: drop redundant `curl_wcsdup_callback` callback

### DIFF
--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -121,9 +121,6 @@ extern curl_free_callback Curl_cfree;
 extern curl_realloc_callback Curl_crealloc;
 extern curl_strdup_callback Curl_cstrdup;
 extern curl_calloc_callback Curl_ccalloc;
-#if defined(_WIN32) && defined(UNICODE)
-extern curl_wcsdup_callback Curl_cwcsdup;
-#endif
 
 #ifndef CURLDEBUG
 
@@ -150,7 +147,7 @@ extern curl_wcsdup_callback Curl_cwcsdup;
 #ifdef _WIN32
 #undef _tcsdup
 #ifdef UNICODE
-#define _tcsdup(ptr) Curl_cwcsdup(ptr)
+#define _tcsdup(ptr) Curl_wcsdup(ptr)
 #else
 #define _tcsdup(ptr) Curl_cstrdup(ptr)
 #endif

--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -28,6 +28,7 @@
 
 #include <curl/curl.h>
 #include "curl_sspi.h"
+#include "strdup.h"
 #include "curlx/multibyte.h"
 #include "system_win32.h"
 #include "curlx/version_win32.h"

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -130,7 +130,7 @@ curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)system_strdup;
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
 #if defined(_WIN32) && defined(UNICODE)
-curl_wcsdup_callback Curl_cwcsdup = Curl_wcsdup;
+curl_wcsdup_callback Curl_cwcsdup = (curl_wcsdup_callback)Curl_wcsdup;
 #endif
 
 #if defined(_MSC_VER) && defined(_DLL)
@@ -158,7 +158,7 @@ static CURLcode global_init(long flags, bool memoryfuncs)
     Curl_cstrdup = (curl_strdup_callback)system_strdup;
     Curl_ccalloc = (curl_calloc_callback)calloc;
 #if defined(_WIN32) && defined(UNICODE)
-    Curl_cwcsdup = (curl_wcsdup_callback)_wcsdup;
+    Curl_cwcsdup = (curl_wcsdup_callback)Curl_wcsdup;
 #endif
   }
 

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -129,9 +129,6 @@ curl_free_callback Curl_cfree = (curl_free_callback)free;
 curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)system_strdup;
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
-#if defined(_WIN32) && defined(UNICODE)
-curl_wcsdup_callback Curl_cwcsdup = (curl_wcsdup_callback)Curl_wcsdup;
-#endif
 
 #if defined(_MSC_VER) && defined(_DLL)
 #  pragma warning(pop)
@@ -157,9 +154,6 @@ static CURLcode global_init(long flags, bool memoryfuncs)
     Curl_crealloc = (curl_realloc_callback)realloc;
     Curl_cstrdup = (curl_strdup_callback)system_strdup;
     Curl_ccalloc = (curl_calloc_callback)calloc;
-#if defined(_WIN32) && defined(UNICODE)
-    Curl_cwcsdup = (curl_wcsdup_callback)Curl_wcsdup;
-#endif
   }
 
   if(Curl_trc_init()) {

--- a/lib/setup-win32.h
+++ b/lib/setup-win32.h
@@ -82,9 +82,6 @@
 #  include <windows.h>
 #  include <winerror.h>
 #  include <tchar.h>
-#  ifdef UNICODE
-     typedef wchar_t *(*curl_wcsdup_callback)(const wchar_t *str);
-#  endif
 #endif
 
 /*

--- a/lib/vauth/vauth.c
+++ b/lib/vauth/vauth.c
@@ -27,6 +27,7 @@
 #include <curl/curl.h>
 
 #include "vauth.h"
+#include "../strdup.h"
 #include "../urldata.h"
 #include "../curlx/multibyte.h"
 #include "../curl_printf.h"

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -44,6 +44,7 @@
 #include "vtls_scache.h"
 #include "../sendf.h"
 #include "../connect.h" /* for the connect timeout */
+#include "../strdup.h"
 #include "../strerror.h"
 #include "../select.h" /* for the socket readiness */
 #include "../curlx/inet_pton.h" /* for IP addr SNI check */

--- a/tests/libtest/memptr.c
+++ b/tests/libtest/memptr.c
@@ -40,9 +40,6 @@ curl_free_callback Curl_cfree = (curl_free_callback)free;
 curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)strdup;
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
-#if defined(_WIN32) && defined(UNICODE)
-curl_wcsdup_callback Curl_cwcsdup = (curl_wcsdup_callback)_wcsdup;
-#endif
 
 #if defined(_MSC_VER) && defined(_DLL)
 #  pragma warning(pop)

--- a/tests/libtest/memptr.c
+++ b/tests/libtest/memptr.c
@@ -41,7 +41,7 @@ curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)strdup;
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
 #if defined(_WIN32) && defined(UNICODE)
-curl_wcsdup_callback Curl_cwcsdup = wcsdup;
+curl_wcsdup_callback Curl_cwcsdup = (curl_wcsdup_callback)_wcsdup;
 #endif
 
 #if defined(_MSC_VER) && defined(_DLL)

--- a/tests/server/memptr.c
+++ b/tests/server/memptr.c
@@ -41,9 +41,6 @@ curl_free_callback Curl_cfree = (curl_free_callback)free;
 curl_realloc_callback Curl_crealloc = (curl_realloc_callback)realloc;
 curl_strdup_callback Curl_cstrdup = (curl_strdup_callback)system_strdup;
 curl_calloc_callback Curl_ccalloc = (curl_calloc_callback)calloc;
-#if defined(_WIN32) && defined(UNICODE)
-curl_wcsdup_callback Curl_cwcsdup = NULL; /* not used in test code */
-#endif
 
 #if defined(_MSC_VER) && defined(_DLL)
 #  pragma warning(pop)


### PR DESCRIPTION
This callback was permanently mapped to libcurl's internal
`Curl_wcsdup()`, which always uses the customizable malloc for
allocation, thus making a custom mapping redundant anyway.

To simplify, drop the callback and map `_tcsdup()` in Unicode mode
directly to `Curl_wcsdup()`.

Also fixes:
- `curl_global_init()` which, before this patch, (re)initialized its
  mapping to `_wcsdup()`, returning buffers potentially incompatible
  with a custom allocator.
  Bug: https://github.com/curl/curl/pull/17840#issuecomment-3044361245
  Bug: https://github.com/curl/curl/pull/7540#issuecomment-2380995349
  Co-reported-by: Luca Kellermann

Follow-up to 76e047fc27b3a0b9e6d6d00cacf536e7b7c1b532 #7540
Assisted-by: Jay Satiro

Closes #17843
