### PR TITLE
memory: tidy up `_tcsdup` override

### DIFF
--- a/lib/curl_memory.h
+++ b/lib/curl_memory.h
@@ -68,11 +68,7 @@
 #undef recv
 
 #ifdef _WIN32
-#  ifdef UNICODE
-#    undef _tcsdup
-#  else
-#    undef _tcsdup
-#  endif
+#undef _tcsdup
 #endif
 
 #undef socket
@@ -152,14 +148,13 @@ extern curl_wcsdup_callback Curl_cwcsdup;
 #define free(ptr) Curl_cfree(ptr)
 
 #ifdef _WIN32
-#  ifdef UNICODE
-#    undef _tcsdup
-#    define _tcsdup(ptr) Curl_cwcsdup(ptr)
-#  else
-#    undef _tcsdup
-#    define _tcsdup(ptr) Curl_cstrdup(ptr)
-#  endif
+#undef _tcsdup
+#ifdef UNICODE
+#define _tcsdup(ptr) Curl_cwcsdup(ptr)
+#else
+#define _tcsdup(ptr) Curl_cstrdup(ptr)
 #endif
+#endif /* _WIN32 */
 
 #endif /* CURLDEBUG */
 #endif /* HEADER_CURL_MEMORY_H */

--- a/lib/memdebug.h
+++ b/lib/memdebug.h
@@ -141,14 +141,13 @@ CURL_EXTERN ALLOC_FUNC
 #define recv(a,b,c,d) curl_dbg_recv(a,b,c,d, __LINE__, __FILE__)
 
 #ifdef _WIN32
-#  ifdef UNICODE
-#    undef _tcsdup
-#    define _tcsdup(ptr) curl_dbg_wcsdup(ptr, __LINE__, __FILE__)
-#  else
-#    undef _tcsdup
-#    define _tcsdup(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
-#  endif
+#undef _tcsdup
+#ifdef UNICODE
+#define _tcsdup(ptr) curl_dbg_wcsdup(ptr, __LINE__, __FILE__)
+#else
+#define _tcsdup(ptr) curl_dbg_strdup(ptr, __LINE__, __FILE__)
 #endif
+#endif /* _WIN32 */
 
 #undef socket
 #define socket(domain,type,protocol) \


### PR DESCRIPTION
Follow-up to ef2ccf862f8fbfe5cb86cb716aead57694a95ef5 #17840