### PR TITLE
CI: sync curl download command-line options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,8 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSL_VERSION=5.8.0
             echo "Installing wolfSSL $WOLFSSL_VERSION"
-            curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VERSION-stable.tar.gz
-            tar -xzf v$WOLFSSL_VERSION-stable.tar.gz
+            curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+              --location "https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VERSION-stable.tar.gz" | tar -xz
             cd wolfssl-$WOLFSSL_VERSION-stable
             ./autogen.sh
             ./configure --disable-dependency-tracking --enable-tls13 --enable-all --enable-harden --prefix=$HOME/wssl
@@ -68,8 +68,8 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSH_VERSION=1.4.19
             echo "Installing wolfSSH $WOLFSSH_VERSION"
-            curl -LOsSf --retry 6 --retry-connrefused --max-time 999 https://github.com/wolfSSL/wolfssh/archive/v$WOLFSSH_VERSION-stable.tar.gz
-            tar -xzf v$WOLFSSH_VERSION-stable.tar.gz
+            curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+              --location "https://github.com/wolfSSL/wolfssh/archive/v$WOLFSSH_VERSION-stable.tar.gz" | tar -xz
             cd wolfssh-$WOLFSSH_VERSION-stable
             ./autogen.sh
             ./configure --disable-dependency-tracking --with-wolfssl=$HOME/wssl --prefix=$HOME/wssh --enable-scp --enable-sftp --disable-term --disable-examples

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSL_VERSION=5.8.0
             echo "Installing wolfSSL $WOLFSSL_VERSION"
-            curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+            curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
               --location "https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VERSION-stable.tar.gz" | tar -xz
             cd wolfssl-$WOLFSSL_VERSION-stable
             ./autogen.sh
@@ -68,7 +68,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSH_VERSION=1.4.19
             echo "Installing wolfSSH $WOLFSSH_VERSION"
-            curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+            curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
               --location "https://github.com/wolfSSL/wolfssh/archive/v$WOLFSSH_VERSION-stable.tar.gz" | tar -xz
             cd wolfssh-$WOLFSSH_VERSION-stable
             ./autogen.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSL_VERSION=5.8.0
             echo "Installing wolfSSL $WOLFSSL_VERSION"
-            curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+            curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
               --location "https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VERSION-stable.tar.gz" | tar -xz
             cd wolfssl-$WOLFSSL_VERSION-stable
             ./autogen.sh
@@ -68,7 +68,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSH_VERSION=1.4.19
             echo "Installing wolfSSH $WOLFSSH_VERSION"
-            curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+            curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
               --location "https://github.com/wolfSSL/wolfssh/archive/v$WOLFSSH_VERSION-stable.tar.gz" | tar -xz
             cd wolfssh-$WOLFSSH_VERSION-stable
             ./autogen.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSL_VERSION=5.8.0
             echo "Installing wolfSSL $WOLFSSL_VERSION"
-            curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
               --location "https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VERSION-stable.tar.gz" | tar -xz
             cd wolfssl-$WOLFSSL_VERSION-stable
             ./autogen.sh
@@ -68,7 +68,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSH_VERSION=1.4.19
             echo "Installing wolfSSH $WOLFSSH_VERSION"
-            curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
               --location "https://github.com/wolfSSL/wolfssh/archive/v$WOLFSSH_VERSION-stable.tar.gz" | tar -xz
             cd wolfssh-$WOLFSSH_VERSION-stable
             ./autogen.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSL_VERSION=5.8.0
             echo "Installing wolfSSL $WOLFSSL_VERSION"
-            curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+            curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
               --location "https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VERSION-stable.tar.gz" | tar -xz
             cd wolfssl-$WOLFSSL_VERSION-stable
             ./autogen.sh
@@ -68,7 +68,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSH_VERSION=1.4.19
             echo "Installing wolfSSH $WOLFSSH_VERSION"
-            curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+            curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
               --location "https://github.com/wolfSSL/wolfssh/archive/v$WOLFSSH_VERSION-stable.tar.gz" | tar -xz
             cd wolfssh-$WOLFSSH_VERSION-stable
             ./autogen.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSL_VERSION=5.8.0
             echo "Installing wolfSSL $WOLFSSL_VERSION"
-            curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
               --location "https://github.com/wolfSSL/wolfssl/archive/v$WOLFSSL_VERSION-stable.tar.gz" | tar -xz
             cd wolfssl-$WOLFSSL_VERSION-stable
             ./autogen.sh
@@ -68,7 +68,7 @@ commands:
             # renovate: datasource=github-tags depName=wolfSSL/wolfssh versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
             WOLFSSH_VERSION=1.4.19
             echo "Installing wolfSSH $WOLFSSH_VERSION"
-            curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
               --location "https://github.com/wolfSSL/wolfssh/archive/v$WOLFSSH_VERSION-stable.tar.gz" | tar -xz
             cd wolfssh-$WOLFSSH_VERSION-stable
             ./autogen.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -347,8 +347,8 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl -LsSf --retry 6 --retry-connrefused --max-time 999 \
-            "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
+          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
           cd "libressl-${LIBRESSL_VERSION}"
           ./configure --disable-dependency-tracking --prefix=/home/runner/libressl
           make install
@@ -366,8 +366,8 @@ jobs:
       - name: 'build wolfssl (all)'  # does not support `OPENSSL_COEXIST`
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-all') && steps.cache-wolfssl-all.outputs.cache-hit != 'true' }}
         run: |
-          curl -LsSf --retry 6 --retry-connrefused --max-time 999 \
-            "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
+          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
           ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --enable-all \
@@ -387,8 +387,8 @@ jobs:
       - name: 'build wolfssl (opensslextra)'
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-opensslextra') && steps.cache-wolfssl-opensslextra.outputs.cache-hit != 'true' }}
         run: |
-          curl -LsSf --retry 6 --retry-connrefused --max-time 999 \
-            "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
+          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
           ./configure --disable-dependency-tracking --enable-tls13 --enable-harden --enable-wolfssh --enable-ech --enable-opensslextra \
@@ -408,8 +408,8 @@ jobs:
       - name: 'build wolfssh'
         if: ${{ contains(matrix.build.install_steps, 'wolfssh') && steps.cache-wolfssh.outputs.cache-hit != 'true' }}
         run: |
-          curl -LsSf --retry 6 --retry-connrefused --max-time 999 \
-            "https://github.com/wolfSSL/wolfssh/archive/v${WOLFSSH_VERSION}-stable.tar.gz" | tar -xz
+          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            --location "https://github.com/wolfSSL/wolfssh/archive/v${WOLFSSH_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssh-${WOLFSSH_VERSION}-stable"
           ./autogen.sh
           ./configure --disable-dependency-tracking --with-wolfssl=/home/runner/wolfssl-opensslextra --enable-scp --enable-sftp --disable-term \
@@ -429,8 +429,8 @@ jobs:
       - name: 'build mbedtls'
         if: ${{ contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtls.outputs.cache-hit != 'true' }}
         run: |
-          curl -LsSf --retry 6 --retry-connrefused --max-time 999 \
-            "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${MBEDTLS_VERSION}/mbedtls-${MBEDTLS_VERSION}.tar.bz2" | tar -xj
+          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            --location "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${MBEDTLS_VERSION}/mbedtls-${MBEDTLS_VERSION}.tar.bz2" | tar -xj
           cd "mbedtls-${MBEDTLS_VERSION}"
           ./scripts/config.py set MBEDTLS_THREADING_C
           ./scripts/config.py set MBEDTLS_THREADING_PTHREAD
@@ -509,8 +509,8 @@ jobs:
       - name: 'build awslc'
         if: ${{ contains(matrix.build.install_steps, 'awslc') && steps.cache-awslc.outputs.cache-hit != 'true' }}
         run: |
-          curl -LsSf --retry 6 --retry-connrefused --max-time 999 \
-            "https://github.com/awslabs/aws-lc/archive/refs/tags/v${AWSLC_VERSION}.tar.gz" | tar -xz
+          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            --location "https://github.com/awslabs/aws-lc/archive/refs/tags/v${AWSLC_VERSION}.tar.gz" | tar -xz
           mkdir "aws-lc-${AWSLC_VERSION}-build"
           cd "aws-lc-${AWSLC_VERSION}-build"
           cmake -G Ninja -DCMAKE_INSTALL_PREFIX=/home/runner/awslc "../aws-lc-${AWSLC_VERSION}" -DBUILD_TOOL=OFF -DBUILD_TESTING=OFF
@@ -531,8 +531,8 @@ jobs:
         if: ${{ contains(matrix.build.install_steps, 'rustls') && steps.cache-rustls.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p ~/rustls
-          curl -LsSf --retry 6 --retry-connrefused --max-time 999 \
-            "https://github.com/rustls/rustls-ffi/releases/download/v${RUSTLS_VERSION}/librustls_${RUSTLS_VERSION}_amd64.deb.zip" -o ~/rustls/librustls.zip
+          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            --location "https://github.com/rustls/rustls-ffi/releases/download/v${RUSTLS_VERSION}/librustls_${RUSTLS_VERSION}_amd64.deb.zip" -o ~/rustls/librustls.zip
           unzip ~/rustls/librustls.zip -d ~/rustls
           rm ~/rustls/librustls.zip
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -544,7 +544,8 @@ jobs:
       - name: 'install Intel compilers'
         if: ${{ contains(matrix.build.install_steps, 'intel') }}
         run: |
-          curl --disable --fail --silent --show-error --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+          curl --disable --fail --silent --show-error \
+            --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
             sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get -o Dpkg::Use-Pty=0 install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
           cd "libressl-${LIBRESSL_VERSION}"
           ./configure --disable-dependency-tracking --prefix=/home/runner/libressl
@@ -366,7 +366,7 @@ jobs:
       - name: 'build wolfssl (all)'  # does not support `OPENSSL_COEXIST`
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-all') && steps.cache-wolfssl-all.outputs.cache-hit != 'true' }}
         run: |
-          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -387,7 +387,7 @@ jobs:
       - name: 'build wolfssl (opensslextra)'
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-opensslextra') && steps.cache-wolfssl-opensslextra.outputs.cache-hit != 'true' }}
         run: |
-          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -408,7 +408,7 @@ jobs:
       - name: 'build wolfssh'
         if: ${{ contains(matrix.build.install_steps, 'wolfssh') && steps.cache-wolfssh.outputs.cache-hit != 'true' }}
         run: |
-          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/wolfSSL/wolfssh/archive/v${WOLFSSH_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssh-${WOLFSSH_VERSION}-stable"
           ./autogen.sh
@@ -429,7 +429,7 @@ jobs:
       - name: 'build mbedtls'
         if: ${{ contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtls.outputs.cache-hit != 'true' }}
         run: |
-          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${MBEDTLS_VERSION}/mbedtls-${MBEDTLS_VERSION}.tar.bz2" | tar -xj
           cd "mbedtls-${MBEDTLS_VERSION}"
           ./scripts/config.py set MBEDTLS_THREADING_C
@@ -509,7 +509,7 @@ jobs:
       - name: 'build awslc'
         if: ${{ contains(matrix.build.install_steps, 'awslc') && steps.cache-awslc.outputs.cache-hit != 'true' }}
         run: |
-          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/awslabs/aws-lc/archive/refs/tags/v${AWSLC_VERSION}.tar.gz" | tar -xz
           mkdir "aws-lc-${AWSLC_VERSION}-build"
           cd "aws-lc-${AWSLC_VERSION}-build"
@@ -531,7 +531,7 @@ jobs:
         if: ${{ contains(matrix.build.install_steps, 'rustls') && steps.cache-rustls.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p ~/rustls
-          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/rustls/rustls-ffi/releases/download/v${RUSTLS_VERSION}/librustls_${RUSTLS_VERSION}_amd64.deb.zip" -o ~/rustls/librustls.zip
           unzip ~/rustls/librustls.zip -d ~/rustls
           rm ~/rustls/librustls.zip
@@ -544,7 +544,8 @@ jobs:
       - name: 'install Intel compilers'
         if: ${{ contains(matrix.build.install_steps, 'intel') }}
         run: |
-          curl -sSf --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
+          curl --fail --silent --show-error --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+            sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get -o Dpkg::Use-Pty=0 install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           source /opt/intel/oneapi/setvars.sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
           cd "libressl-${LIBRESSL_VERSION}"
           ./configure --disable-dependency-tracking --prefix=/home/runner/libressl
@@ -366,7 +366,7 @@ jobs:
       - name: 'build wolfssl (all)'  # does not support `OPENSSL_COEXIST`
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-all') && steps.cache-wolfssl-all.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -387,7 +387,7 @@ jobs:
       - name: 'build wolfssl (opensslextra)'
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-opensslextra') && steps.cache-wolfssl-opensslextra.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -408,7 +408,7 @@ jobs:
       - name: 'build wolfssh'
         if: ${{ contains(matrix.build.install_steps, 'wolfssh') && steps.cache-wolfssh.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/wolfSSL/wolfssh/archive/v${WOLFSSH_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssh-${WOLFSSH_VERSION}-stable"
           ./autogen.sh
@@ -429,7 +429,7 @@ jobs:
       - name: 'build mbedtls'
         if: ${{ contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtls.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${MBEDTLS_VERSION}/mbedtls-${MBEDTLS_VERSION}.tar.bz2" | tar -xj
           cd "mbedtls-${MBEDTLS_VERSION}"
           ./scripts/config.py set MBEDTLS_THREADING_C
@@ -509,7 +509,7 @@ jobs:
       - name: 'build awslc'
         if: ${{ contains(matrix.build.install_steps, 'awslc') && steps.cache-awslc.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/awslabs/aws-lc/archive/refs/tags/v${AWSLC_VERSION}.tar.gz" | tar -xz
           mkdir "aws-lc-${AWSLC_VERSION}-build"
           cd "aws-lc-${AWSLC_VERSION}-build"
@@ -531,7 +531,7 @@ jobs:
         if: ${{ contains(matrix.build.install_steps, 'rustls') && steps.cache-rustls.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p ~/rustls
-          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/rustls/rustls-ffi/releases/download/v${RUSTLS_VERSION}/librustls_${RUSTLS_VERSION}_amd64.deb.zip" -o ~/rustls/librustls.zip
           unzip ~/rustls/librustls.zip -d ~/rustls
           rm ~/rustls/librustls.zip

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
           cd "libressl-${LIBRESSL_VERSION}"
           ./configure --disable-dependency-tracking --prefix=/home/runner/libressl
@@ -366,7 +366,7 @@ jobs:
       - name: 'build wolfssl (all)'  # does not support `OPENSSL_COEXIST`
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-all') && steps.cache-wolfssl-all.outputs.cache-hit != 'true' }}
         run: |
-          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -387,7 +387,7 @@ jobs:
       - name: 'build wolfssl (opensslextra)'
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-opensslextra') && steps.cache-wolfssl-opensslextra.outputs.cache-hit != 'true' }}
         run: |
-          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -408,7 +408,7 @@ jobs:
       - name: 'build wolfssh'
         if: ${{ contains(matrix.build.install_steps, 'wolfssh') && steps.cache-wolfssh.outputs.cache-hit != 'true' }}
         run: |
-          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/wolfSSL/wolfssh/archive/v${WOLFSSH_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssh-${WOLFSSH_VERSION}-stable"
           ./autogen.sh
@@ -429,7 +429,7 @@ jobs:
       - name: 'build mbedtls'
         if: ${{ contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtls.outputs.cache-hit != 'true' }}
         run: |
-          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${MBEDTLS_VERSION}/mbedtls-${MBEDTLS_VERSION}.tar.bz2" | tar -xj
           cd "mbedtls-${MBEDTLS_VERSION}"
           ./scripts/config.py set MBEDTLS_THREADING_C
@@ -509,7 +509,7 @@ jobs:
       - name: 'build awslc'
         if: ${{ contains(matrix.build.install_steps, 'awslc') && steps.cache-awslc.outputs.cache-hit != 'true' }}
         run: |
-          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/awslabs/aws-lc/archive/refs/tags/v${AWSLC_VERSION}.tar.gz" | tar -xz
           mkdir "aws-lc-${AWSLC_VERSION}-build"
           cd "aws-lc-${AWSLC_VERSION}-build"
@@ -531,7 +531,7 @@ jobs:
         if: ${{ contains(matrix.build.install_steps, 'rustls') && steps.cache-rustls.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p ~/rustls
-          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/rustls/rustls-ffi/releases/download/v${RUSTLS_VERSION}/librustls_${RUSTLS_VERSION}_amd64.deb.zip" -o ~/rustls/librustls.zip
           unzip ~/rustls/librustls.zip -d ~/rustls
           rm ~/rustls/librustls.zip
@@ -544,7 +544,7 @@ jobs:
       - name: 'install Intel compilers'
         if: ${{ contains(matrix.build.install_steps, 'intel') }}
         run: |
-          curl --fail --silent --show-error --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
+          curl --disable --fail --silent --show-error --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
             sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
           sudo apt-get -o Dpkg::Use-Pty=0 install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -532,7 +532,7 @@ jobs:
         run: |
           mkdir -p ~/rustls
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
-            --location "https://github.com/rustls/rustls-ffi/releases/download/v${RUSTLS_VERSION}/librustls_${RUSTLS_VERSION}_amd64.deb.zip" -o ~/rustls/librustls.zip
+            --location "https://github.com/rustls/rustls-ffi/releases/download/v${RUSTLS_VERSION}/librustls_${RUSTLS_VERSION}_amd64.deb.zip" --output ~/rustls/librustls.zip
           unzip ~/rustls/librustls.zip -d ~/rustls
           rm ~/rustls/librustls.zip
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -544,7 +544,7 @@ jobs:
       - name: 'install Intel compilers'
         if: ${{ contains(matrix.build.install_steps, 'intel') }}
         run: |
-          curl --disable --fail --silent --show-error \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --compressed https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | \
             sudo tee /etc/apt/trusted.gpg.d/intel-sw.asc >/dev/null
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
           cd "libressl-${LIBRESSL_VERSION}"
           ./configure --disable-dependency-tracking --prefix=/home/runner/libressl
@@ -366,7 +366,7 @@ jobs:
       - name: 'build wolfssl (all)'  # does not support `OPENSSL_COEXIST`
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-all') && steps.cache-wolfssl-all.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -387,7 +387,7 @@ jobs:
       - name: 'build wolfssl (opensslextra)'
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-opensslextra') && steps.cache-wolfssl-opensslextra.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -408,7 +408,7 @@ jobs:
       - name: 'build wolfssh'
         if: ${{ contains(matrix.build.install_steps, 'wolfssh') && steps.cache-wolfssh.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
             --location "https://github.com/wolfSSL/wolfssh/archive/v${WOLFSSH_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssh-${WOLFSSH_VERSION}-stable"
           ./autogen.sh
@@ -429,7 +429,7 @@ jobs:
       - name: 'build mbedtls'
         if: ${{ contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtls.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
             --location "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${MBEDTLS_VERSION}/mbedtls-${MBEDTLS_VERSION}.tar.bz2" | tar -xj
           cd "mbedtls-${MBEDTLS_VERSION}"
           ./scripts/config.py set MBEDTLS_THREADING_C
@@ -509,7 +509,7 @@ jobs:
       - name: 'build awslc'
         if: ${{ contains(matrix.build.install_steps, 'awslc') && steps.cache-awslc.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
             --location "https://github.com/awslabs/aws-lc/archive/refs/tags/v${AWSLC_VERSION}.tar.gz" | tar -xz
           mkdir "aws-lc-${AWSLC_VERSION}-build"
           cd "aws-lc-${AWSLC_VERSION}-build"
@@ -531,7 +531,7 @@ jobs:
         if: ${{ contains(matrix.build.install_steps, 'rustls') && steps.cache-rustls.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p ~/rustls
-          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
             --location "https://github.com/rustls/rustls-ffi/releases/download/v${RUSTLS_VERSION}/librustls_${RUSTLS_VERSION}_amd64.deb.zip" -o ~/rustls/librustls.zip
           unzip ~/rustls/librustls.zip -d ~/rustls
           rm ~/rustls/librustls.zip

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
           cd "libressl-${LIBRESSL_VERSION}"
           ./configure --disable-dependency-tracking --prefix=/home/runner/libressl
@@ -366,7 +366,7 @@ jobs:
       - name: 'build wolfssl (all)'  # does not support `OPENSSL_COEXIST`
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-all') && steps.cache-wolfssl-all.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -387,7 +387,7 @@ jobs:
       - name: 'build wolfssl (opensslextra)'
         if: ${{ contains(matrix.build.install_steps, 'wolfssl-opensslextra') && steps.cache-wolfssl-opensslextra.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/wolfSSL/wolfssl/archive/v${WOLFSSL_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssl-${WOLFSSL_VERSION}-stable"
           ./autogen.sh
@@ -408,7 +408,7 @@ jobs:
       - name: 'build wolfssh'
         if: ${{ contains(matrix.build.install_steps, 'wolfssh') && steps.cache-wolfssh.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/wolfSSL/wolfssh/archive/v${WOLFSSH_VERSION}-stable.tar.gz" | tar -xz
           cd "wolfssh-${WOLFSSH_VERSION}-stable"
           ./autogen.sh
@@ -429,7 +429,7 @@ jobs:
       - name: 'build mbedtls'
         if: ${{ contains(matrix.build.install_steps, 'mbedtls') && steps.cache-mbedtls.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/Mbed-TLS/mbedtls/releases/download/mbedtls-${MBEDTLS_VERSION}/mbedtls-${MBEDTLS_VERSION}.tar.bz2" | tar -xj
           cd "mbedtls-${MBEDTLS_VERSION}"
           ./scripts/config.py set MBEDTLS_THREADING_C
@@ -509,7 +509,7 @@ jobs:
       - name: 'build awslc'
         if: ${{ contains(matrix.build.install_steps, 'awslc') && steps.cache-awslc.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/awslabs/aws-lc/archive/refs/tags/v${AWSLC_VERSION}.tar.gz" | tar -xz
           mkdir "aws-lc-${AWSLC_VERSION}-build"
           cd "aws-lc-${AWSLC_VERSION}-build"
@@ -531,7 +531,7 @@ jobs:
         if: ${{ contains(matrix.build.install_steps, 'rustls') && steps.cache-rustls.outputs.cache-hit != 'true' }}
         run: |
           mkdir -p ~/rustls
-          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/rustls/rustls-ffi/releases/download/v${RUSTLS_VERSION}/librustls_${RUSTLS_VERSION}_amd64.deb.zip" -o ~/rustls/librustls.zip
           unzip ~/rustls/librustls.zip -d ~/rustls
           rm ~/rustls/librustls.zip

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -549,11 +549,11 @@ jobs:
         if: ${{ steps.cache-compiler.outputs.cache-hit != 'true' }}
         run: |
           cd ~
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 --retry-connrefused \
             --location "https://github.com/andrewwutw/build-djgpp/releases/download/v${TOOLCHAIN_VERSION}/djgpp-linux64-gcc1220.tar.bz2" | tar -xj
           cd djgpp
           for f in wat3211b.zip zlb13b.zip ssl102ub.zip; do
-            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               "https://www.delorie.com/pub/djgpp/current/v2tk/$f" --output bin.zip
             unzip -q bin.zip
             rm -f bin.zip

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -x
           cd "libressl-${LIBRESSL_VERSION}"
           # FIXME: on the 4.0.1 release, delete '-DHAVE_ENDIAN_H=0'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 999 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -x
           cd "libressl-${LIBRESSL_VERSION}"
           # FIXME: on the 4.0.1 release, delete '-DHAVE_ENDIAN_H=0'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
+          curl --disable --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -x
           cd "libressl-${LIBRESSL_VERSION}"
           # FIXME: on the 4.0.1 release, delete '-DHAVE_ENDIAN_H=0'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+          curl --fail --silent --show-error --retry 6 --retry-connrefused --max-time 999 \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -x
           cd "libressl-${LIBRESSL_VERSION}"
           # FIXME: on the 4.0.1 release, delete '-DHAVE_ENDIAN_H=0'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -x
           cd "libressl-${LIBRESSL_VERSION}"
           # FIXME: on the 4.0.1 release, delete '-DHAVE_ENDIAN_H=0'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -347,7 +347,7 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl --disable --fail --silent --show-error --max-time 120 --retry 6 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -x
           cd "libressl-${LIBRESSL_VERSION}"
           # FIXME: on the 4.0.1 release, delete '-DHAVE_ENDIAN_H=0'

--- a/.github/workflows/non-native.yml
+++ b/.github/workflows/non-native.yml
@@ -347,8 +347,8 @@ jobs:
       - name: 'build libressl'
         if: ${{ contains(matrix.build.install_steps, 'libressl') && steps.cache-libressl.outputs.cache-hit != 'true' }}
         run: |
-          curl -LsSf --retry 6 --retry-connrefused --max-time 999 \
-            "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -x
+          curl -sSf --retry 6 --retry-connrefused --max-time 999 \
+            --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -x
           cd "libressl-${LIBRESSL_VERSION}"
           # FIXME: on the 4.0.1 release, delete '-DHAVE_ENDIAN_H=0'
           cmake -B . -G Ninja \

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -479,7 +479,7 @@ jobs:
           cd /d
           mkdir my-cache
           cd my-cache
-          curl --disable --fail --silent --show-error --retry 3 --retry-connrefused \
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 240 --retry 3 --retry-connrefused \
             --location --proto-redir =https "${MATRIX_URL}" --output pack.bin
           pwd
           7z x -y pack.bin >/dev/null

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -703,8 +703,8 @@ jobs:
         timeout-minutes: 5
         run: |
           cd ~
-          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 --retry-connrefused --proto-redir =https \
-            --location "https://downloads.sourceforge.net/cegcc/cegcc/${TOOLCHAIN_VERSION}/cegcc_mingw32ce_snowleopard_r1397.tar.bz2" | tar -x
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 3 --retry-connrefused \
+            --location --proto-redir =https "https://downloads.sourceforge.net/cegcc/cegcc/${TOOLCHAIN_VERSION}/cegcc_mingw32ce_snowleopard_r1397.tar.bz2" | tar -x
           ls -l
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -479,7 +479,8 @@ jobs:
           cd /d
           mkdir my-cache
           cd my-cache
-          curl --fail --silent --show-error --retry 3 --retry-connrefused --output pack.bin --location --proto-redir =https "${MATRIX_URL}"
+          curl --fail --silent --show-error --retry 3 --retry-connrefused \
+            --location --proto-redir =https "${MATRIX_URL}" --output pack.bin
           pwd
           7z x -y pack.bin >/dev/null
           rm -r -f pack.bin

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -980,7 +980,7 @@ jobs:
             fi
           else  # OpenSSH-Windows
             cd /c  # no D: drive on windows-11-arm runners
-            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 \
+            curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 60 --retry 3 --retry-connrefused \
               --location "https://github.com/PowerShell/Win32-OpenSSH/releases/download/${OPENSSH_WINDOWS_VERSION}/OpenSSH-Win64.zip" --output bin.zip
             unzip bin.zip
             rm -f bin.zip

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -479,7 +479,7 @@ jobs:
           cd /d
           mkdir my-cache
           cd my-cache
-          curl --fail --silent --show-error --retry 3 --retry-connrefused \
+          curl --disable --fail --silent --show-error --retry 3 --retry-connrefused \
             --location --proto-redir =https "${MATRIX_URL}" --output pack.bin
           pwd
           7z x -y pack.bin >/dev/null


### PR DESCRIPTION
- circleci: pipe to tar.
- use long options uniformly.
- sync option order.
- set timeout where missing.
- set retry where missing.
- set `--retry-connrefused` where missing.
- set `--disable` where missing.
- lower 999s timeouts to 120s.
