### PR TITLE
GHA/curl-for-win: reduce job timeout to 10m, apply to Windows jobs

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -47,7 +47,7 @@ jobs:
   linux-glibc-gcc:
     name: 'Linux gcc glibc'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -76,7 +76,7 @@ jobs:
   linux-musl-llvm:
     name: 'Linux llvm MUSL'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -103,7 +103,7 @@ jobs:
   mac-clang:
     name: 'macOS clang'
     runs-on: macos-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     env:
       CW_JOBS: '4'
     steps:
@@ -123,7 +123,7 @@ jobs:
   win-llvm:
     name: 'Windows llvm'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -150,7 +150,7 @@ jobs:
   win-gcc-libssh-zlibold-x86:
     name: 'Windows gcc libssh zlib-classic x86'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -123,6 +123,7 @@ jobs:
   win-llvm:
     name: 'Windows llvm'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
@@ -149,6 +150,7 @@ jobs:
   win-gcc-libssh-zlibold-x86:
     name: 'Windows gcc libssh zlib-classic x86'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:


### PR DESCRIPTION
The timeout was missing from two Windows jobs, making them linger for
a long time due to a command waiting forever.

As seen today with/after `apt update`:
https://github.com/curl/curl/actions/runs/16121485403/job/45488122962?pr=17846
