### PR TITLE
quiche: fix missing include of url.h

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -46,6 +46,7 @@
 #include "vquic-tls.h"
 #include "curl_quiche.h"
 #include "../transfer.h"
+#include "../url.h"
 #include "../curlx/inet_pton.h"
 #include "../vtls/openssl.h"
 #include "../vtls/keylog.h"


### PR DESCRIPTION
No idea how that got past our CI?