### PR TITLE
curl_osslq: fix missing include of url.h

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -44,7 +44,6 @@
 #include "../strerror.h"
 #include "../curlx/dynbuf.h"
 #include "../http1.h"
-#include "../url.h"
 #include "../select.h"
 #include "../curlx/inet_pton.h"
 #include "../uint-hash.h"
@@ -55,6 +54,7 @@
 #include "../vtls/vtls.h"
 #include "../vtls/openssl.h"
 #include "curl_osslq.h"
+#include "../url.h"
 #include "../curlx/warnless.h"
 
 /* The last 3 #include files should be in this order */


### PR DESCRIPTION
Follow-up to 4ccf3a31f596b1055d9f128e45d0a647d59b6f53 #17783
Follow-up to b270fec68dc66c7a3d37a283cc147ba3c6fa7297 #17858
Ref: #17857
