### PR TITLE
tests: fix test 1301, 1308 to fail on error

### DIFF
--- a/tests/libtest/CMakeLists.txt
+++ b/tests/libtest/CMakeLists.txt
@@ -54,7 +54,6 @@ target_include_directories(${BUNDLE} PRIVATE
   "${PROJECT_BINARY_DIR}/lib"            # for "curl_config.h"
   "${PROJECT_SOURCE_DIR}/lib"            # for "curl_setup.h", curlx
   "${CMAKE_CURRENT_SOURCE_DIR}"          # for the generated bundle source to find included test sources
-  "${PROJECT_SOURCE_DIR}/tests/unit"     # for "curlcheck.h"
 )
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
 set_property(TARGET ${BUNDLE} APPEND PROPERTY COMPILE_DEFINITIONS "CURL_NO_OLDIES" "CURL_DISABLE_DEPRECATION")

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -36,8 +36,7 @@ AUTOMAKE_OPTIONS = foreign nostdinc
 AM_CPPFLAGS = -I$(top_srcdir)/include        \
               -I$(top_builddir)/lib          \
               -I$(top_srcdir)/lib            \
-              -I$(srcdir)                    \
-              -I$(top_srcdir)/tests/unit
+              -I$(srcdir)
 
 # Get BUNDLE, FIRST_C, FIRST_H, UTILS_C, UTILS_H, CURLX_C, TESTS_C variables
 include Makefile.inc

--- a/tests/libtest/lib1301.c
+++ b/tests/libtest/lib1301.c
@@ -21,7 +21,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#include "curlcheck.h"
+#include "first.h"
 
 static CURLcode test_lib1301(char *URL)
 {
@@ -29,25 +29,25 @@ static CURLcode test_lib1301(char *URL)
   (void)URL;
 
   rc = curl_strequal("iii", "III");
-  fail_unless(rc != 0, "return code should be non-zero");
+  libtest_fail_unless(rc != 0, "return code should be non-zero");
 
   rc = curl_strequal("iiia", "III");
-  fail_unless(rc == 0, "return code should be zero");
+  libtest_fail_unless(rc == 0, "return code should be zero");
 
   rc = curl_strequal("iii", "IIIa");
-  fail_unless(rc == 0, "return code should be zero");
+  libtest_fail_unless(rc == 0, "return code should be zero");
 
   rc = curl_strequal("iiiA", "IIIa");
-  fail_unless(rc != 0, "return code should be non-zero");
+  libtest_fail_unless(rc != 0, "return code should be non-zero");
 
   rc = curl_strnequal("iii", "III", 3);
-  fail_unless(rc != 0, "return code should be non-zero");
+  libtest_fail_unless(rc != 0, "return code should be non-zero");
 
   rc = curl_strnequal("iiiABC", "IIIcba", 3);
-  fail_unless(rc != 0, "return code should be non-zero");
+  libtest_fail_unless(rc != 0, "return code should be non-zero");
 
   rc = curl_strnequal("ii", "II", 3);
-  fail_unless(rc != 0, "return code should be non-zero");
+  libtest_fail_unless(rc != 0, "return code should be non-zero");
 
   return CURLE_OK;
 }

--- a/tests/libtest/lib1308.c
+++ b/tests/libtest/lib1308.c
@@ -21,7 +21,7 @@
  * SPDX-License-Identifier: curl
  *
  ***************************************************************************/
-#include "curlcheck.h"
+#include "first.h"
 
 static size_t print_httppost_callback(void *arg, const char *buf, size_t len)
 {
@@ -41,25 +41,25 @@ static CURLcode test_lib1308(char *URL)
 
   rc = curl_formadd(&post, &last, CURLFORM_COPYNAME, "name",
                     CURLFORM_COPYCONTENTS, "content", CURLFORM_END);
-  fail_unless(rc == 0, "curl_formadd returned error");
+  libtest_fail_unless(rc == 0, "curl_formadd returned error");
 
   /* after the first curl_formadd when there's a single entry, both pointers
      should point to the same struct */
-  fail_unless(post == last, "post and last weren't the same");
+  libtest_fail_unless(post == last, "post and last weren't the same");
 
   rc = curl_formadd(&post, &last, CURLFORM_COPYNAME, "htmlcode",
                     CURLFORM_COPYCONTENTS, "<HTML></HTML>",
                     CURLFORM_CONTENTTYPE, "text/html", CURLFORM_END);
-  fail_unless(rc == 0, "curl_formadd returned error");
+  libtest_fail_unless(rc == 0, "curl_formadd returned error");
 
   rc = curl_formadd(&post, &last, CURLFORM_COPYNAME, "name_for_ptrcontent",
                     CURLFORM_PTRCONTENTS, buffer, CURLFORM_END);
-  fail_unless(rc == 0, "curl_formadd returned error");
+  libtest_fail_unless(rc == 0, "curl_formadd returned error");
 
   res = curl_formget(post, &total_size, print_httppost_callback);
-  fail_unless(res == 0, "curl_formget returned error");
+  libtest_fail_unless(res == 0, "curl_formget returned error");
 
-  fail_unless(total_size == 518, "curl_formget got wrong size back");
+  libtest_fail_unless(total_size == 518, "curl_formget got wrong size back");
 
   curl_formfree(post);
 
@@ -71,12 +71,12 @@ static CURLcode test_lib1308(char *URL)
                     CURLFORM_FILE, URL,
                     CURLFORM_FILENAME, "custom named file",
                     CURLFORM_END);
-  fail_unless(rc == 0, "curl_formadd returned error");
+  libtest_fail_unless(rc == 0, "curl_formadd returned error");
 
   res = curl_formget(post, &total_size, print_httppost_callback);
 
-  fail_unless(res == 0, "curl_formget returned error");
-  fail_unless(total_size == 899, "curl_formget got wrong size back");
+  libtest_fail_unless(res == 0, "curl_formget returned error");
+  libtest_fail_unless(total_size == 899, "curl_formget got wrong size back");
 
   curl_formfree(post);
 

--- a/tests/libtest/test.h
+++ b/tests/libtest/test.h
@@ -493,6 +493,15 @@ extern int unitfail;
 #define global_init(A) \
   chk_global_init((A), (__FILE__), (__LINE__))
 
+#define libtest_fail_unless(expr, msg)                           \
+  do {                                                           \
+    if(!(expr)) {                                                \
+      curl_mfprintf(stderr, "%s:%d Assertion '%s' FAILED: %s\n", \
+                    __FILE__, __LINE__, #expr, msg);             \
+      return TEST_ERR_FAILURE;                                   \
+    }                                                            \
+  } while(0)
+
 #define NO_SUPPORT_BUILT_IN                     \
   {                                             \
     (void)URL;                                  \


### PR DESCRIPTION
They were using a macro designed for unit tests. It did not fail when
used in libtests. Make similar macro for libtests, that returns with
an error on failure.

Also:
- makes these two tests align with the rest of libtests, by including
  `first.h` instead of `curlcheck.h`.
- since libtests no longer need to depend tests/unit, drop this
  dependency from build scripts.
