### PR TITLE
connection: terminate after goaway

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -540,11 +540,20 @@ static void multi_done_locked(struct connectdata *conn,
 {
   struct multi_done_ctx *mdctx = userdata;
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
-  const char *host = NULL;
-  int port = 0;
-
-  if(Curl_trc_is_verbose(data))
-    Curl_conn_get_current_host(data, FIRSTSOCKET, &host, &port);
+  const char *host =
+#ifndef CURL_DISABLE_PROXY
+        conn->bits.socksproxy ?
+        conn->socks_proxy.host.dispname :
+        conn->bits.httpproxy ? conn->http_proxy.host.dispname :
+#endif
+        conn->bits.conn_to_host ? conn->conn_to_host.dispname :
+        conn->host.dispname;
+  int port =
+#ifndef CURL_DISABLE_PROXY
+        conn->bits.httpproxy ? conn->http_proxy.port :
+#endif
+        conn->bits.conn_to_port ? conn->conn_to_port :
+        conn->remote_port;
 #endif
 
   Curl_detach_connection(data);

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -539,6 +539,13 @@ static void multi_done_locked(struct connectdata *conn,
                               void *userdata)
 {
   struct multi_done_ctx *mdctx = userdata;
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
+  const char *host = NULL;
+  int port = 0;
+
+  if(Curl_trc_is_verbose(data))
+    Curl_conn_get_current_host(data, FIRSTSOCKET, &host, &port);
+#endif
 
   Curl_detach_connection(data);
 
@@ -584,30 +591,27 @@ static void multi_done_locked(struct connectdata *conn,
 #endif
      ) || conn->bits.close
        || (mdctx->premature && !Curl_conn_is_multiplex(conn, FIRSTSOCKET))) {
-    CURL_TRC_M(data, "multi_done, not reusing connection=%"
-                     FMT_OFF_T ", forbid=%d"
-                     ", close=%d, premature=%d, conn_multiplex=%d",
-                     conn->connection_id, data->set.reuse_forbid,
-                     conn->bits.close, mdctx->premature,
-                     Curl_conn_is_multiplex(conn, FIRSTSOCKET));
+    CURL_TRC_M(data, "multi_done, terminating conn #%" FMT_OFF_T " to %s:%d, "
+               "forbid=%d, close=%d, premature=%d, conn_multiplex=%d",
+               conn->connection_id, host, port, data->set.reuse_forbid,
+               conn->bits.close, mdctx->premature,
+               Curl_conn_is_multiplex(conn, FIRSTSOCKET));
     connclose(conn, "disconnecting");
+    Curl_conn_terminate(data, conn, mdctx->premature);
+  }
+  else if(!Curl_conn_get_max_concurrent(data, conn, FIRSTSOCKET)) {
+    CURL_TRC_M(data, "multi_done, conn #%" FMT_OFF_T " to %s:%d was shutdown"
+               " by server, not reusing", conn->connection_id, host, port);
+    connclose(conn, "server shutdown");
     Curl_conn_terminate(data, conn, mdctx->premature);
   }
   else {
     /* the connection is no longer in use by any transfer */
     if(Curl_cpool_conn_now_idle(data, conn)) {
       /* connection kept in the cpool */
-      const char *host =
-#ifndef CURL_DISABLE_PROXY
-        conn->bits.socksproxy ?
-        conn->socks_proxy.host.dispname :
-        conn->bits.httpproxy ? conn->http_proxy.host.dispname :
-#endif
-        conn->bits.conn_to_host ? conn->conn_to_host.dispname :
-        conn->host.dispname;
       data->state.lastconnect_id = conn->connection_id;
-      infof(data, "Connection #%" FMT_OFF_T " to host %s left intact",
-            conn->connection_id, host);
+      infof(data, "Connection #%" FMT_OFF_T " to host %s:%d left intact",
+            conn->connection_id, host, port);
     }
     else {
       /* connection was removed from the cpool and destroyed. */

--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -83,10 +83,10 @@ Accept: */*
 ^Host:.*
 </strip>
 <file name="%LOGDIR/stderr%TESTNUMBER" mode="text">
-* Connection #0 to host server1.example.com left intact
-* Connection #1 to host server2.example.com left intact
-* Connection #2 to host server3.example.com left intact
-* Connection #3 to host server4.example.com left intact
+* Connection #0 to host server1.example.com:%HTTPPORT left intact
+* Connection #1 to host server2.example.com:%HTTPPORT left intact
+* Connection #2 to host server3.example.com:%HTTPPORT left intact
+* Connection #3 to host server4.example.com:%HTTPPORT left intact
 </file>
 <stripfile>
 $_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))

--- a/tests/data/test1510
+++ b/tests/data/test1510
@@ -83,10 +83,10 @@ Accept: */*
 ^Host:.*
 </strip>
 <file name="%LOGDIR/stderr%TESTNUMBER" mode="text">
-* Connection #0 to host server1.example.com left intact
-* Connection #1 to host server2.example.com left intact
-* Connection #2 to host server3.example.com left intact
-* Connection #3 to host server4.example.com left intact
+* Connection #0 to host server1.example.com:%HTTPPORT left intact
+* Connection #1 to host server2.example.com:%HTTPPORT left intact
+* Connection #2 to host server3.example.com:%HTTPPORT left intact
+* Connection #3 to host server4.example.com:%HTTPPORT left intact
 </file>
 <stripfile>
 $_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))

--- a/tests/data/test1542
+++ b/tests/data/test1542
@@ -55,11 +55,11 @@ Accept: */*
 
 </protocol>
 <file name="%LOGDIR/stderr%TESTNUMBER" mode="text">
-== Info: Connection #0 to host %HOSTIP left intact
-== Info: Connection #0 to host %HOSTIP left intact
-== Info: Connection #0 to host %HOSTIP left intact
+== Info: Connection #0 to host %HOSTIP:%HTTPPORT left intact
+== Info: Connection #0 to host %HOSTIP:%HTTPPORT left intact
+== Info: Connection #0 to host %HOSTIP:%HTTPPORT left intact
 == Info: shutting down connection #0
-== Info: Connection #1 to host %HOSTIP left intact
+== Info: Connection #1 to host %HOSTIP:%HTTPPORT left intact
 </file>
 <stripfile>
 $_ = '' if (($_ !~ /left intact/) && ($_ !~ /(closing|shutting down) connection #\d+/))

--- a/tests/data/test2402
+++ b/tests/data/test2402
@@ -96,10 +96,10 @@ Via: 2 nghttpx
 ^Host:.*
 </strip>
 <file name="%LOGDIR/stderr%TESTNUMBER" mode="text">
-* Connection #0 to host localhost left intact
-* Connection #0 to host localhost left intact
-* Connection #0 to host localhost left intact
-* Connection #0 to host localhost left intact
+* Connection #0 to host localhost:%HTTP2TLSPORT left intact
+* Connection #0 to host localhost:%HTTP2TLSPORT left intact
+* Connection #0 to host localhost:%HTTP2TLSPORT left intact
+* Connection #0 to host localhost:%HTTP2TLSPORT left intact
 </file>
 <stripfile>
 $_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))

--- a/tests/data/test2404
+++ b/tests/data/test2404
@@ -96,10 +96,10 @@ Via: 2 nghttpx
 ^Host:.*
 </strip>
 <file name="%LOGDIR/stderr%TESTNUMBER" mode="text">
-* Connection #0 to host localhost left intact
-* Connection #0 to host localhost left intact
-* Connection #0 to host localhost left intact
-* Connection #0 to host localhost left intact
+* Connection #0 to host localhost:%HTTP2TLSPORT left intact
+* Connection #0 to host localhost:%HTTP2TLSPORT left intact
+* Connection #0 to host localhost:%HTTP2TLSPORT left intact
+* Connection #0 to host localhost:%HTTP2TLSPORT left intact
 </file>
 <stripfile>
 $_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))

--- a/tests/data/test2502
+++ b/tests/data/test2502
@@ -91,10 +91,10 @@ Via: 3 nghttpx
 ^Host:.*
 </strip>
 <file name="%LOGDIR/stderr%TESTNUMBER" mode="text">
-== Info: Connection #0 to host localhost left intact
-== Info: Connection #0 to host localhost left intact
-== Info: Connection #0 to host localhost left intact
-== Info: Connection #0 to host localhost left intact
+== Info: Connection #0 to host localhost:%HTTP3PORT left intact
+== Info: Connection #0 to host localhost:%HTTP3PORT left intact
+== Info: Connection #0 to host localhost:%HTTP3PORT left intact
+== Info: Connection #0 to host localhost:%HTTP3PORT left intact
 </file>
 <stripfile>
 $_ = '' if (($_ !~ /left intact/) && ($_ !~ /Closing connection/))


### PR DESCRIPTION
When a multiplex connection (h2/h3) is shutdown by the server, the reported number of parallel transfers allowed drops to 0.

Determine that when the last transfer is done and terminate the connection instead of keeping it in the cache.

We detect the drop to 0 also when we try to reuse such a connection, but if we know this at the time the last transfer is done, we better terminate it right away.

Have a consistent trace logging to this with the connections current hostname and port. Adjust test expectations to carry port numbers.