### PR TITLE
setopt: refactor out the booleans from setopt_long to setopt_bool

### DIFF
--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -440,67 +440,38 @@ static void set_ssl_options(struct ssl_config_data *ssl,
 }
 #endif
 
-static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
-                            long arg)
+static CURLcode setopt_bool(struct Curl_easy *data, CURLoption option,
+                            long arg, bool *set)
 {
   bool enabled = !!arg;
-  unsigned long uarg = (unsigned long)arg;
+  struct UserDefined *s = &data->set;
   switch(option) {
-  case CURLOPT_DNS_CACHE_TIMEOUT:
-    if(arg < -1)
-      return CURLE_BAD_FUNCTION_ARGUMENT;
-    else if(arg > INT_MAX)
-      arg = INT_MAX;
-
-    data->set.dns_cache_timeout = (int)arg;
-    break;
-  case CURLOPT_CA_CACHE_TIMEOUT:
-    if(Curl_ssl_supports(data, SSLSUPP_CA_CACHE)) {
-      if(arg < -1)
-        return CURLE_BAD_FUNCTION_ARGUMENT;
-      else if(arg > INT_MAX)
-        arg = INT_MAX;
-
-      data->set.general_ssl.ca_cache_timeout = (int)arg;
-    }
-    else
-      return CURLE_NOT_BUILT_IN;
-    break;
-  case CURLOPT_MAXCONNECTS:
-    /*
-     * Set the absolute number of maximum simultaneous alive connection that
-     * libcurl is allowed to have.
-     */
-    if(uarg > UINT_MAX)
-      return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.maxconnects = (unsigned int)uarg;
-    break;
   case CURLOPT_FORBID_REUSE:
     /*
      * When this transfer is done, it must not be left to be reused by a
      * subsequent transfer but shall be closed immediately.
      */
-    data->set.reuse_forbid = enabled;
+    s->reuse_forbid = enabled;
     break;
   case CURLOPT_FRESH_CONNECT:
     /*
      * This transfer shall not use a previously cached connection but
      * should be made with a fresh new connect!
      */
-    data->set.reuse_fresh = enabled;
+    s->reuse_fresh = enabled;
     break;
   case CURLOPT_VERBOSE:
     /*
      * Verbose means infof() calls that give a lot of information about
      * the connection and transfer procedures as well as internal choices.
      */
-    data->set.verbose = enabled;
+    s->verbose = enabled;
     break;
   case CURLOPT_HEADER:
     /*
      * Set to include the header in the general data output stream.
      */
-    data->set.include_header = enabled;
+    s->include_header = enabled;
     break;
   case CURLOPT_NOPROGRESS:
     /*
@@ -512,13 +483,13 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     /*
      * Do not include the body part in the output data stream.
      */
-    data->set.opt_no_body = enabled;
+    s->opt_no_body = enabled;
 #ifndef CURL_DISABLE_HTTP
-    if(data->set.opt_no_body)
+    if(s->opt_no_body)
       /* in HTTP lingo, no body means using the HEAD request... */
-      data->set.method = HTTPREQ_HEAD;
-    else if(data->set.method == HTTPREQ_HEAD)
-      data->set.method = HTTPREQ_GET;
+      s->method = HTTPREQ_HEAD;
+    else if(s->method == HTTPREQ_HEAD)
+      s->method = HTTPREQ_GET;
 #endif
     break;
   case CURLOPT_FAILONERROR:
@@ -526,10 +497,10 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      * Do not output the >=400 error code HTML-page, but instead only
      * return error.
      */
-    data->set.http_fail_on_error = enabled;
+    s->http_fail_on_error = enabled;
     break;
   case CURLOPT_KEEP_SENDING_ON_ERROR:
-    data->set.http_keep_sending_on_error = enabled;
+    s->http_keep_sending_on_error = enabled;
     break;
   case CURLOPT_UPLOAD:
   case CURLOPT_PUT:
@@ -537,36 +508,182 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      * We want to sent data to the remote host. If this is HTTP, that equals
      * using the PUT request.
      */
-    if(arg) {
+    if(enabled) {
       /* If this is HTTP, PUT is what's needed to "upload" */
-      data->set.method = HTTPREQ_PUT;
-      data->set.opt_no_body = FALSE; /* this is implied */
+      s->method = HTTPREQ_PUT;
+      s->opt_no_body = FALSE; /* this is implied */
     }
     else
       /* In HTTP, the opposite of upload is GET (unless NOBODY is true as
          then this can be changed to HEAD later on) */
-      data->set.method = HTTPREQ_GET;
+      s->method = HTTPREQ_GET;
     break;
   case CURLOPT_FILETIME:
     /*
      * Try to get the file time of the remote document. The time will
      * later (possibly) become available using curl_easy_getinfo().
      */
-    data->set.get_filetime = enabled;
+    s->get_filetime = enabled;
     break;
-  case CURLOPT_SERVER_RESPONSE_TIMEOUT:
+#ifndef CURL_DISABLE_HTTP
+  case CURLOPT_HTTP09_ALLOWED:
+    s->http09_allowed = enabled;
+    break;
+#if !defined(CURL_DISABLE_COOKIES)
+  case CURLOPT_COOKIESESSION:
     /*
-     * Option that specifies how quickly a server response must be obtained
-     * before it is considered failure. For pingpong protocols.
+     * Set this option to TRUE to start a new "cookie session". It will
+     * prevent the forthcoming read-cookies-from-file actions to accept
+     * cookies that are marked as being session cookies, as they belong to a
+     * previous session.
      */
-    return setopt_set_timeout_sec(&data->set.server_response_timeout, arg);
+    s->cookiesession = enabled;
+    break;
+#endif
+  case CURLOPT_AUTOREFERER:
+    /*
+     * Switch on automatic referer that gets set if curl follows locations.
+     */
+    s->http_auto_referer = enabled;
+    break;
 
-  case CURLOPT_SERVER_RESPONSE_TIMEOUT_MS:
+  case CURLOPT_TRANSFER_ENCODING:
+    s->http_transfer_encoding = enabled;
+    break;
+  case CURLOPT_UNRESTRICTED_AUTH:
     /*
-     * Option that specifies how quickly a server response must be obtained
-     * before it is considered failure. For pingpong protocols.
+     * Send authentication (user+password) when following locations, even when
+     * hostname changed.
      */
-    return setopt_set_timeout_ms(&data->set.server_response_timeout, arg);
+    s->allow_auth_to_other_hosts = enabled;
+    break;
+
+  case CURLOPT_HTTP_TRANSFER_DECODING:
+    /*
+     * disable libcurl transfer encoding is used
+     */
+    s->http_te_skip = !enabled; /* reversed */
+    break;
+
+  case CURLOPT_HTTP_CONTENT_DECODING:
+    /*
+     * raw data passed to the application when content encoding is used
+     */
+    s->http_ce_skip = !enabled; /* reversed */
+    break;
+
+  case CURLOPT_HTTPGET:
+    /*
+     * Set to force us do HTTP GET
+     */
+    if(enabled) {
+      s->method = HTTPREQ_GET;
+      s->opt_no_body = FALSE; /* this is implied */
+    }
+    break;
+  case CURLOPT_POST:
+    /* Does this option serve a purpose anymore? Yes it does, when
+       CURLOPT_POSTFIELDS is not used and the POST data is read off the
+       callback! */
+    if(enabled) {
+      s->method = HTTPREQ_POST;
+      s->opt_no_body = FALSE; /* this is implied */
+    }
+    else
+      s->method = HTTPREQ_GET;
+    break;
+#endif /* ! CURL_DISABLE_HTTP */
+#ifndef CURL_DISABLE_PROXY
+  case CURLOPT_HTTPPROXYTUNNEL:
+    /*
+     * Tunnel operations through the proxy instead of normal proxy use
+     */
+    s->tunnel_thru_httpproxy = enabled;
+    break;
+  case CURLOPT_HAPROXYPROTOCOL:
+    /*
+     * Set to send the HAProxy Proxy Protocol header
+     */
+    s->haproxyprotocol = enabled;
+    break;
+  case CURLOPT_PROXY_SSL_VERIFYPEER:
+    /*
+     * Enable peer SSL verifying for proxy.
+     */
+    s->proxy_ssl.primary.verifypeer = enabled;
+
+    /* Update the current connection proxy_ssl_config. */
+    Curl_ssl_conn_config_update(data, TRUE);
+    break;
+  case CURLOPT_PROXY_SSL_VERIFYHOST:
+    /*
+     * Enable verification of the hostname in the peer certificate for proxy
+     */
+    s->proxy_ssl.primary.verifyhost = enabled;
+
+    /* Update the current connection proxy_ssl_config. */
+    Curl_ssl_conn_config_update(data, TRUE);
+    break;
+  case CURLOPT_PROXY_TRANSFER_MODE:
+    /*
+     * set transfer mode (;type=<a|i>) when doing FTP via an HTTP proxy
+     */
+    s->proxy_transfer_mode = enabled;
+    break;
+#endif /* ! CURL_DISABLE_PROXY */
+#if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
+  case CURLOPT_SOCKS5_GSSAPI_NEC:
+    /*
+     * Set flag for NEC SOCK5 support
+     */
+    s->socks5_gssapi_nec = enabled;
+    break;
+#endif
+#ifdef CURL_LIST_ONLY_PROTOCOL
+  case CURLOPT_DIRLISTONLY:
+    /*
+     * An option that changes the command to one that asks for a list only, no
+     * file info details. Used for FTP, POP3 and SFTP.
+     */
+    s->list_only = enabled;
+    break;
+#endif
+  case CURLOPT_APPEND:
+    /*
+     * We want to upload and append to an existing file. Used for FTP and
+     * SFTP.
+     */
+    s->remote_append = enabled;
+    break;
+#ifndef CURL_DISABLE_FTP
+  case CURLOPT_FTP_USE_EPRT:
+    s->ftp_use_eprt = enabled;
+    break;
+
+  case CURLOPT_FTP_USE_EPSV:
+    s->ftp_use_epsv = enabled;
+    break;
+
+  case CURLOPT_FTP_USE_PRET:
+    s->ftp_use_pret = enabled;
+    break;
+  case CURLOPT_FTP_SKIP_PASV_IP:
+    /*
+     * Enable or disable FTP_SKIP_PASV_IP, which will disable/enable the
+     * bypass of the IP address in PASV responses.
+     */
+    s->ftp_skip_ip = enabled;
+    break;
+  case CURLOPT_WILDCARDMATCH:
+    s->wildcard_enabled = enabled;
+    break;
+#endif
+  case CURLOPT_CRLF:
+    /*
+     * Kludgy option to enable CRLF conversions. Subject for removal.
+     */
+    s->crlf = enabled;
+    break;
 
 #ifndef CURL_DISABLE_TFTP
   case CURLOPT_TFTP_NO_OPTIONS:
@@ -574,8 +691,224 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      * Option that prevents libcurl from sending TFTP option requests to the
      * server.
      */
-    data->set.tftp_no_options = enabled;
+    s->tftp_no_options = enabled;
     break;
+#endif /* ! CURL_DISABLE_TFTP */
+  case CURLOPT_TRANSFERTEXT:
+    /*
+     * This option was previously named 'FTPASCII'. Renamed to work with
+     * more protocols than merely FTP.
+     *
+     * Transfer using ASCII (instead of BINARY).
+     */
+    s->prefer_ascii = enabled;
+    break;
+  case CURLOPT_SSL_VERIFYPEER:
+    /*
+     * Enable peer SSL verifying.
+     */
+    s->ssl.primary.verifypeer = enabled;
+
+    /* Update the current connection ssl_config. */
+    Curl_ssl_conn_config_update(data, FALSE);
+    break;
+#ifndef CURL_DISABLE_DOH
+  case CURLOPT_DOH_SSL_VERIFYPEER:
+    /*
+     * Enable peer SSL verifying for DoH.
+     */
+    s->doh_verifypeer = enabled;
+    break;
+  case CURLOPT_DOH_SSL_VERIFYHOST:
+    /*
+     * Enable verification of the hostname in the peer certificate for DoH
+     */
+    s->doh_verifyhost = enabled;
+    break;
+  case CURLOPT_DOH_SSL_VERIFYSTATUS:
+    /*
+     * Enable certificate status verifying for DoH.
+     */
+    if(!Curl_ssl_cert_status_request())
+      return CURLE_NOT_BUILT_IN;
+
+    s->doh_verifystatus = enabled;
+    break;
+#endif /* ! CURL_DISABLE_DOH */
+  case CURLOPT_SSL_VERIFYHOST:
+    /*
+     * Enable verification of the hostname in the peer certificate
+     */
+
+    /* Obviously people are not reading documentation and too many thought
+       this argument took a boolean when it was not and misused it.
+       Treat 1 and 2 the same */
+    s->ssl.primary.verifyhost = enabled;
+
+    /* Update the current connection ssl_config. */
+    Curl_ssl_conn_config_update(data, FALSE);
+    break;
+  case CURLOPT_SSL_VERIFYSTATUS:
+    /*
+     * Enable certificate status verifying.
+     */
+    if(!Curl_ssl_cert_status_request())
+      return CURLE_NOT_BUILT_IN;
+
+    s->ssl.primary.verifystatus = enabled;
+
+    /* Update the current connection ssl_config. */
+    Curl_ssl_conn_config_update(data, FALSE);
+    break;
+  case CURLOPT_CERTINFO:
+#ifdef USE_SSL
+    if(Curl_ssl_supports(data, SSLSUPP_CERTINFO))
+      s->ssl.certinfo = enabled;
+    else
+#endif
+      return CURLE_NOT_BUILT_IN;
+    break;
+  case CURLOPT_NOSIGNAL:
+    /*
+     * The application asks not to set any signal() or alarm() handlers,
+     * even when using a timeout.
+     */
+    s->no_signal = enabled;
+    break;
+  case CURLOPT_TCP_NODELAY:
+    /*
+     * Enable or disable TCP_NODELAY, which will disable/enable the Nagle
+     * algorithm
+     */
+    s->tcp_nodelay = enabled;
+    break;
+
+  case CURLOPT_IGNORE_CONTENT_LENGTH:
+    s->ignorecl = enabled;
+    break;
+  case CURLOPT_SSL_SESSIONID_CACHE:
+    s->ssl.primary.cache_session = enabled;
+#ifndef CURL_DISABLE_PROXY
+    s->proxy_ssl.primary.cache_session =
+      s->ssl.primary.cache_session;
+#endif
+    break;
+#ifdef USE_SSH
+  case CURLOPT_SSH_COMPRESSION:
+    s->ssh_compression = enabled;
+    break;
+#endif /* ! USE_SSH */
+#ifndef CURL_DISABLE_SMTP
+  case CURLOPT_MAIL_RCPT_ALLOWFAILS:
+    /* allow RCPT TO command to fail for some recipients */
+    s->mail_rcpt_allowfails = enabled;
+    break;
+#endif /* !CURL_DISABLE_SMTP */
+  case CURLOPT_SASL_IR:
+    /* Enable/disable SASL initial response */
+    s->sasl_ir = enabled;
+    break;
+  case CURLOPT_TCP_KEEPALIVE:
+    s->tcp_keepalive = enabled;
+    break;
+  case CURLOPT_TCP_FASTOPEN:
+#if defined(CONNECT_DATA_IDEMPOTENT) || defined(MSG_FASTOPEN) ||        \
+  defined(TCP_FASTOPEN_CONNECT)
+    s->tcp_fastopen = enabled;
+#else
+    return CURLE_NOT_BUILT_IN;
+#endif
+    break;
+  case CURLOPT_SSL_ENABLE_ALPN:
+    s->ssl_enable_alpn = enabled;
+    break;
+  case CURLOPT_PATH_AS_IS:
+    s->path_as_is = enabled;
+    break;
+  case CURLOPT_PIPEWAIT:
+    s->pipewait = enabled;
+    break;
+  case CURLOPT_SUPPRESS_CONNECT_HEADERS:
+    s->suppress_connect_headers = enabled;
+    break;
+#ifndef CURL_DISABLE_SHUFFLE_DNS
+  case CURLOPT_DNS_SHUFFLE_ADDRESSES:
+    s->dns_shuffle_addresses = enabled;
+    break;
+#endif
+  case CURLOPT_DISALLOW_USERNAME_IN_URL:
+    s->disallow_username_in_url = enabled;
+    break;
+  case CURLOPT_QUICK_EXIT:
+    s->quick_exit = enabled;
+    break;
+  default:
+    return CURLE_OK;
+  }
+  if((arg > 1) || (arg < 0))
+    /* reserve other values for future use */
+    infof(data, "boolean setopt(%d) got unsupported argument %ld,"
+          " treated as %d", option, arg, enabled);
+
+  *set = TRUE;
+  return CURLE_OK;
+}
+
+static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
+                            long arg)
+{
+  unsigned long uarg = (unsigned long)arg;
+  bool set = FALSE;
+  CURLcode result = setopt_bool(data, option, arg, &set);
+  struct UserDefined *s = &data->set;
+  if(set || result)
+    return result;
+
+  switch(option) {
+  case CURLOPT_DNS_CACHE_TIMEOUT:
+    if(arg < -1)
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    else if(arg > INT_MAX)
+      arg = INT_MAX;
+
+    s->dns_cache_timeout = (int)arg;
+    break;
+  case CURLOPT_CA_CACHE_TIMEOUT:
+    if(Curl_ssl_supports(data, SSLSUPP_CA_CACHE)) {
+      if(arg < -1)
+        return CURLE_BAD_FUNCTION_ARGUMENT;
+      else if(arg > INT_MAX)
+        arg = INT_MAX;
+
+      s->general_ssl.ca_cache_timeout = (int)arg;
+    }
+    else
+      return CURLE_NOT_BUILT_IN;
+    break;
+  case CURLOPT_MAXCONNECTS:
+    /*
+     * Set the absolute number of maximum simultaneous alive connection that
+     * libcurl is allowed to have.
+     */
+    if(uarg > UINT_MAX)
+      return CURLE_BAD_FUNCTION_ARGUMENT;
+    s->maxconnects = (unsigned int)uarg;
+    break;
+  case CURLOPT_SERVER_RESPONSE_TIMEOUT:
+    /*
+     * Option that specifies how quickly a server response must be obtained
+     * before it is considered failure. For pingpong protocols.
+     */
+    return setopt_set_timeout_sec(&s->server_response_timeout, arg);
+
+  case CURLOPT_SERVER_RESPONSE_TIMEOUT_MS:
+    /*
+     * Option that specifies how quickly a server response must be obtained
+     * before it is considered failure. For pingpong protocols.
+     */
+    return setopt_set_timeout_ms(&s->server_response_timeout, arg);
+
+#ifndef CURL_DISABLE_TFTP
   case CURLOPT_TFTP_BLKSIZE:
     /*
      * TFTP option that specifies the block size to use for data transmission.
@@ -584,7 +917,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
       arg = 512;
     else if(arg > TFTP_BLKSIZE_MAX)
       arg = TFTP_BLKSIZE_MAX;
-    data->set.tftp_blksize = arg;
+    s->tftp_blksize = arg;
     break;
 #endif
 #ifndef CURL_DISABLE_NETRC
@@ -594,18 +927,9 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < CURL_NETRC_IGNORED) || (arg >= CURL_NETRC_LAST))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.use_netrc = (unsigned char)arg;
+    s->use_netrc = (unsigned char)arg;
     break;
 #endif
-  case CURLOPT_TRANSFERTEXT:
-    /*
-     * This option was previously named 'FTPASCII'. Renamed to work with
-     * more protocols than merely FTP.
-     *
-     * Transfer using ASCII (instead of BINARY).
-     */
-    data->set.prefer_ascii = enabled;
-    break;
   case CURLOPT_TIMECONDITION:
     /*
      * Set HTTP time condition. This must be one of the defines in the
@@ -613,14 +937,14 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < CURL_TIMECOND_NONE) || (arg >= CURL_TIMECOND_LAST))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.timecondition = (unsigned char)arg;
+    s->timecondition = (unsigned char)arg;
     break;
   case CURLOPT_TIMEVALUE:
     /*
      * This is the value to compare with the remote document with the
      * method set with CURLOPT_TIMECONDITION
      */
-    data->set.timevalue = (time_t)arg;
+    s->timevalue = (time_t)arg;
     break;
   case CURLOPT_SSLVERSION:
 #ifndef CURL_DISABLE_PROXY
@@ -636,53 +960,23 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     if(arg < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
 
-    if(data->set.postfieldsize < arg &&
-       data->set.postfields == data->set.str[STRING_COPYPOSTFIELDS]) {
+    if(s->postfieldsize < arg &&
+       s->postfields == s->str[STRING_COPYPOSTFIELDS]) {
       /* Previous CURLOPT_COPYPOSTFIELDS is no longer valid. */
-      Curl_safefree(data->set.str[STRING_COPYPOSTFIELDS]);
-      data->set.postfields = NULL;
+      Curl_safefree(s->str[STRING_COPYPOSTFIELDS]);
+      s->postfields = NULL;
     }
 
-    data->set.postfieldsize = arg;
+    s->postfieldsize = arg;
     break;
 #ifndef CURL_DISABLE_HTTP
-#ifndef CURL_DISABLE_COOKIES
-  case CURLOPT_COOKIESESSION:
-    /*
-     * Set this option to TRUE to start a new "cookie session". It will
-     * prevent the forthcoming read-cookies-from-file actions to accept
-     * cookies that are marked as being session cookies, as they belong to a
-     * previous session.
-     */
-    data->set.cookiesession = enabled;
-    break;
-#endif
-  case CURLOPT_AUTOREFERER:
-    /*
-     * Switch on automatic referer that gets set if curl follows locations.
-     */
-    data->set.http_auto_referer = enabled;
-    break;
-
-  case CURLOPT_TRANSFER_ENCODING:
-    data->set.http_transfer_encoding = enabled;
-    break;
-
   case CURLOPT_FOLLOWLOCATION:
     /*
      * Follow Location: header hints on an HTTP-server.
      */
     if(uarg > 3)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.http_follow_mode = (unsigned char)uarg;
-    break;
-
-  case CURLOPT_UNRESTRICTED_AUTH:
-    /*
-     * Send authentication (user+password) when following locations, even when
-     * hostname changed.
-     */
-    data->set.allow_auth_to_other_hosts = enabled;
+    s->http_follow_mode = (unsigned char)uarg;
     break;
 
   case CURLOPT_MAXREDIRS:
@@ -692,7 +986,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if(arg < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.maxredirs = arg;
+    s->maxredirs = arg;
     break;
 
   case CURLOPT_POSTREDIR:
@@ -709,38 +1003,17 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
       /* no return error on too high numbers since the bitmask could be
          extended in a future */
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.keep_post = arg & CURL_REDIR_POST_ALL;
+    s->keep_post = arg & CURL_REDIR_POST_ALL;
     break;
 
-  case CURLOPT_POST:
-    /* Does this option serve a purpose anymore? Yes it does, when
-       CURLOPT_POSTFIELDS is not used and the POST data is read off the
-       callback! */
-    if(arg) {
-      data->set.method = HTTPREQ_POST;
-      data->set.opt_no_body = FALSE; /* this is implied */
-    }
-    else
-      data->set.method = HTTPREQ_GET;
-    break;
   case CURLOPT_HEADEROPT:
     /*
      * Set header option.
      */
-    data->set.sep_headers = !!(arg & CURLHEADER_SEPARATE);
+    s->sep_headers = !!(arg & CURLHEADER_SEPARATE);
     break;
   case CURLOPT_HTTPAUTH:
     return httpauth(data, FALSE, uarg);
-
-  case CURLOPT_HTTPGET:
-    /*
-     * Set to force us do HTTP GET
-     */
-    if(enabled) {
-      data->set.method = HTTPREQ_GET;
-      data->set.opt_no_body = FALSE; /* this is implied */
-    }
-    break;
 
   case CURLOPT_HTTP_VERSION:
     return setopt_HTTP_VERSION(data, arg);
@@ -752,34 +1025,24 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.expect_100_timeout = arg;
+    s->expect_100_timeout = arg;
     break;
 
-  case CURLOPT_HTTP09_ALLOWED:
-    data->set.http09_allowed = enabled;
-    break;
 #endif /* ! CURL_DISABLE_HTTP */
 
 #ifndef CURL_DISABLE_MIME
   case CURLOPT_MIME_OPTIONS:
-    data->set.mime_formescape = !!(arg & CURLMIMEOPT_FORMESCAPE);
+    s->mime_formescape = !!(arg & CURLMIMEOPT_FORMESCAPE);
     break;
 #endif
 #ifndef CURL_DISABLE_PROXY
-  case CURLOPT_HTTPPROXYTUNNEL:
-    /*
-     * Tunnel operations through the proxy instead of normal proxy use
-     */
-    data->set.tunnel_thru_httpproxy = enabled;
-    break;
-
   case CURLOPT_PROXYPORT:
     /*
      * Explicitly set HTTP proxy port number.
      */
     if((arg < 0) || (arg > 65535))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.proxyport = (unsigned short)arg;
+    s->proxyport = (unsigned short)arg;
     break;
 
   case CURLOPT_PROXYAUTH:
@@ -791,73 +1054,15 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < CURLPROXY_HTTP) || (arg > CURLPROXY_SOCKS5_HOSTNAME))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.proxytype = (unsigned char)arg;
+    s->proxytype = (unsigned char)arg;
     break;
 
-  case CURLOPT_PROXY_TRANSFER_MODE:
-    /*
-     * set transfer mode (;type=<a|i>) when doing FTP via an HTTP proxy
-     */
-    if(uarg > 1)
-      /* reserve other values for future use */
-      return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.proxy_transfer_mode = (bool)uarg;
-    break;
   case CURLOPT_SOCKS5_AUTH:
     if(uarg & ~(CURLAUTH_BASIC | CURLAUTH_GSSAPI))
       return CURLE_NOT_BUILT_IN;
-    data->set.socks5auth = (unsigned char)uarg;
-    break;
-  case CURLOPT_HAPROXYPROTOCOL:
-    /*
-     * Set to send the HAProxy Proxy Protocol header
-     */
-    data->set.haproxyprotocol = enabled;
-    break;
-  case CURLOPT_PROXY_SSL_VERIFYPEER:
-    /*
-     * Enable peer SSL verifying for proxy.
-     */
-    data->set.proxy_ssl.primary.verifypeer = enabled;
-
-    /* Update the current connection proxy_ssl_config. */
-    Curl_ssl_conn_config_update(data, TRUE);
-    break;
-  case CURLOPT_PROXY_SSL_VERIFYHOST:
-    /*
-     * Enable verification of the hostname in the peer certificate for proxy
-     */
-    data->set.proxy_ssl.primary.verifyhost = enabled;
-
-    /* Update the current connection proxy_ssl_config. */
-    Curl_ssl_conn_config_update(data, TRUE);
+    s->socks5auth = (unsigned char)uarg;
     break;
 #endif /* ! CURL_DISABLE_PROXY */
-
-#if defined(HAVE_GSSAPI) || defined(USE_WINDOWS_SSPI)
-  case CURLOPT_SOCKS5_GSSAPI_NEC:
-    /*
-     * Set flag for NEC SOCK5 support
-     */
-    data->set.socks5_gssapi_nec = enabled;
-    break;
-#endif
-#ifdef CURL_LIST_ONLY_PROTOCOL
-  case CURLOPT_DIRLISTONLY:
-    /*
-     * An option that changes the command to one that asks for a list only, no
-     * file info details. Used for FTP, POP3 and SFTP.
-     */
-    data->set.list_only = enabled;
-    break;
-#endif
-  case CURLOPT_APPEND:
-    /*
-     * We want to upload and append to an existing file. Used for FTP and
-     * SFTP.
-     */
-    data->set.remote_append = enabled;
-    break;
 
 #ifndef CURL_DISABLE_FTP
   case CURLOPT_FTP_FILEMETHOD:
@@ -866,32 +1071,12 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < CURLFTPMETHOD_DEFAULT) || (arg >= CURLFTPMETHOD_LAST))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.ftp_filemethod = (unsigned char)arg;
+    s->ftp_filemethod = (unsigned char)arg;
     break;
-  case CURLOPT_FTP_USE_EPRT:
-    data->set.ftp_use_eprt = enabled;
-    break;
-
-  case CURLOPT_FTP_USE_EPSV:
-    data->set.ftp_use_epsv = enabled;
-    break;
-
-  case CURLOPT_FTP_USE_PRET:
-    data->set.ftp_use_pret = enabled;
-    break;
-
   case CURLOPT_FTP_SSL_CCC:
     if((arg < CURLFTPSSL_CCC_NONE) || (arg >= CURLFTPSSL_CCC_LAST))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.ftp_ccc = (unsigned char)arg;
-    break;
-
-  case CURLOPT_FTP_SKIP_PASV_IP:
-    /*
-     * Enable or disable FTP_SKIP_PASV_IP, which will disable/enable the
-     * bypass of the IP address in PASV responses.
-     */
-    data->set.ftp_skip_ip = enabled;
+    s->ftp_ccc = (unsigned char)arg;
     break;
 
   case CURLOPT_FTPSSLAUTH:
@@ -900,17 +1085,13 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < CURLFTPAUTH_DEFAULT) || (arg >= CURLFTPAUTH_LAST))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.ftpsslauth = (unsigned char)arg;
+    s->ftpsslauth = (unsigned char)arg;
     break;
   case CURLOPT_ACCEPTTIMEOUT_MS:
     /*
      * The maximum time for curl to wait for FTP server connect
      */
-    return setopt_set_timeout_ms(&data->set.accepttimeout, arg);
-
-  case CURLOPT_WILDCARDMATCH:
-    data->set.wildcard_enabled = enabled;
-    break;
+    return setopt_set_timeout_ms(&s->accepttimeout, arg);
 #endif /* ! CURL_DISABLE_FTP */
 #if !defined(CURL_DISABLE_FTP) || defined(USE_SSH)
   case CURLOPT_FTP_CREATE_MISSING_DIRS:
@@ -921,7 +1102,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     /* reserve other values for future use */
     if((arg < CURLFTP_CREATE_DIR_NONE) || (arg > CURLFTP_CREATE_DIR_RETRY))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.ftp_create_missing_dirs = (unsigned char)arg;
+    s->ftp_create_missing_dirs = (unsigned char)arg;
     break;
 #endif /* ! CURL_DISABLE_FTP || USE_SSH */
   case CURLOPT_INFILESIZE:
@@ -931,7 +1112,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if(arg < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.filesize = arg;
+    s->filesize = arg;
     break;
   case CURLOPT_LOW_SPEED_LIMIT:
     /*
@@ -940,7 +1121,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.low_speed_limit = arg;
+    s->low_speed_limit = arg;
     break;
   case CURLOPT_LOW_SPEED_TIME:
     /*
@@ -949,7 +1130,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.low_speed_time = arg;
+    s->low_speed_time = arg;
     break;
   case CURLOPT_PORT:
     /*
@@ -957,26 +1138,26 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < 0) || (arg > 65535))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.use_port = (unsigned short)arg;
+    s->use_port = (unsigned short)arg;
     break;
   case CURLOPT_TIMEOUT:
     /*
      * The maximum time you allow curl to use for a single transfer
      * operation.
      */
-    return setopt_set_timeout_sec(&data->set.timeout, arg);
+    return setopt_set_timeout_sec(&s->timeout, arg);
 
   case CURLOPT_TIMEOUT_MS:
-    return setopt_set_timeout_ms(&data->set.timeout, arg);
+    return setopt_set_timeout_ms(&s->timeout, arg);
 
   case CURLOPT_CONNECTTIMEOUT:
     /*
      * The maximum time you allow curl to use to connect.
      */
-    return setopt_set_timeout_sec(&data->set.connecttimeout, arg);
+    return setopt_set_timeout_sec(&s->connecttimeout, arg);
 
   case CURLOPT_CONNECTTIMEOUT_MS:
-    return setopt_set_timeout_ms(&data->set.connecttimeout, arg);
+    return setopt_set_timeout_ms(&s->connecttimeout, arg);
 
   case CURLOPT_RESUME_FROM:
     /*
@@ -984,14 +1165,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if(arg < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.set_resume_from = arg;
-    break;
-
-  case CURLOPT_CRLF:
-    /*
-     * Kludgy option to enable CRLF conversions. Subject for removal.
-     */
-    data->set.crlf = enabled;
+    s->set_resume_from = arg;
     break;
 
 #ifndef CURL_DISABLE_BINDLOCAL
@@ -1001,7 +1175,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < 0) || (arg > 65535))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.localport = curlx_sltous(arg);
+    s->localport = curlx_sltous(arg);
     break;
   case CURLOPT_LOCALPORTRANGE:
     /*
@@ -1009,7 +1183,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < 0) || (arg > 65535))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.localportrange = curlx_sltous(arg);
+    s->localportrange = curlx_sltous(arg);
     break;
 #endif
 
@@ -1018,80 +1192,16 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     /*
      * GSS-API credential delegation bitmask
      */
-    data->set.gssapi_delegation = (unsigned char)uarg&
+    s->gssapi_delegation = (unsigned char)uarg&
       (CURLGSSAPI_DELEGATION_POLICY_FLAG|CURLGSSAPI_DELEGATION_FLAG);
     break;
 #endif
-  case CURLOPT_SSL_VERIFYPEER:
-    /*
-     * Enable peer SSL verifying.
-     */
-    data->set.ssl.primary.verifypeer = enabled;
 
-    /* Update the current connection ssl_config. */
-    Curl_ssl_conn_config_update(data, FALSE);
-    break;
-#ifndef CURL_DISABLE_DOH
-  case CURLOPT_DOH_SSL_VERIFYPEER:
-    /*
-     * Enable peer SSL verifying for DoH.
-     */
-    data->set.doh_verifypeer = enabled;
-    break;
-  case CURLOPT_DOH_SSL_VERIFYHOST:
-    /*
-     * Enable verification of the hostname in the peer certificate for DoH
-     */
-    data->set.doh_verifyhost = enabled;
-    break;
-  case CURLOPT_DOH_SSL_VERIFYSTATUS:
-    /*
-     * Enable certificate status verifying for DoH.
-     */
-    if(!Curl_ssl_cert_status_request())
-      return CURLE_NOT_BUILT_IN;
-
-    data->set.doh_verifystatus = enabled;
-    break;
-#endif /* ! CURL_DISABLE_DOH */
-  case CURLOPT_SSL_VERIFYHOST:
-    /*
-     * Enable verification of the hostname in the peer certificate
-     */
-
-    /* Obviously people are not reading documentation and too many thought
-       this argument took a boolean when it was not and misused it.
-       Treat 1 and 2 the same */
-    data->set.ssl.primary.verifyhost = enabled;
-
-    /* Update the current connection ssl_config. */
-    Curl_ssl_conn_config_update(data, FALSE);
-    break;
-  case CURLOPT_SSL_VERIFYSTATUS:
-    /*
-     * Enable certificate status verifying.
-     */
-    if(!Curl_ssl_cert_status_request())
-      return CURLE_NOT_BUILT_IN;
-
-    data->set.ssl.primary.verifystatus = enabled;
-
-    /* Update the current connection ssl_config. */
-    Curl_ssl_conn_config_update(data, FALSE);
-    break;
   case CURLOPT_SSL_FALSESTART:
     /*
      * No TLS backends support false start anymore.
      */
     return CURLE_NOT_BUILT_IN;
-  case CURLOPT_CERTINFO:
-#ifdef USE_SSL
-    if(Curl_ssl_supports(data, SSLSUPP_CERTINFO))
-      data->set.ssl.certinfo = enabled;
-    else
-#endif
-      return CURLE_NOT_BUILT_IN;
-    break;
   case CURLOPT_BUFFERSIZE:
     /*
      * The application kindly asks for a differently sized receive buffer.
@@ -1104,7 +1214,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     else if(arg < READBUFFER_MIN)
       arg = READBUFFER_MIN;
 
-    data->set.buffer_size = (unsigned int)arg;
+    s->buffer_size = (unsigned int)arg;
     break;
 
   case CURLOPT_UPLOAD_BUFFERSIZE:
@@ -1117,23 +1227,16 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     else if(arg < UPLOADBUFFER_MIN)
       arg = UPLOADBUFFER_MIN;
 
-    data->set.upload_buffer_size = (unsigned int)arg;
+    s->upload_buffer_size = (unsigned int)arg;
     break;
 
-  case CURLOPT_NOSIGNAL:
-    /*
-     * The application asks not to set any signal() or alarm() handlers,
-     * even when using a timeout.
-     */
-    data->set.no_signal = enabled;
-    break;
   case CURLOPT_MAXFILESIZE:
     /*
      * Set the maximum size of a file to download.
      */
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.max_filesize = arg;
+    s->max_filesize = arg;
     break;
 
 #ifdef USE_SSL
@@ -1143,15 +1246,15 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < CURLUSESSL_NONE) || (arg >= CURLUSESSL_LAST))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.use_ssl = (unsigned char)arg;
+    s->use_ssl = (unsigned char)arg;
     break;
   case CURLOPT_SSL_OPTIONS:
-    set_ssl_options(&data->set.ssl, &data->set.ssl.primary, arg);
+    set_ssl_options(&s->ssl, &s->ssl.primary, arg);
     break;
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSL_OPTIONS:
-    set_ssl_options(&data->set.proxy_ssl, &data->set.proxy_ssl.primary, arg);
+    set_ssl_options(&s->proxy_ssl, &s->proxy_ssl.primary, arg);
     break;
 #endif
 
@@ -1159,18 +1262,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
   case CURLOPT_IPRESOLVE:
     if((arg < CURL_IPRESOLVE_WHATEVER) || (arg > CURL_IPRESOLVE_V6))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.ipver = (unsigned char) arg;
-    break;
-  case CURLOPT_TCP_NODELAY:
-    /*
-     * Enable or disable TCP_NODELAY, which will disable/enable the Nagle
-     * algorithm
-     */
-    data->set.tcp_nodelay = enabled;
-    break;
-
-  case CURLOPT_IGNORE_CONTENT_LENGTH:
-    data->set.ignorecl = enabled;
+    s->ipver = (unsigned char) arg;
     break;
 
   case CURLOPT_CONNECT_ONLY:
@@ -1181,41 +1273,17 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if(arg > 2)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.connect_only = !!arg;
-    data->set.connect_only_ws = (arg == 2);
+    s->connect_only = !!arg;
+    s->connect_only_ws = (arg == 2);
     break;
 
-  case CURLOPT_SSL_SESSIONID_CACHE:
-    data->set.ssl.primary.cache_session = enabled;
-#ifndef CURL_DISABLE_PROXY
-    data->set.proxy_ssl.primary.cache_session =
-      data->set.ssl.primary.cache_session;
-#endif
-    break;
 
 #ifdef USE_SSH
     /* we only include SSH options if explicitly built to support SSH */
   case CURLOPT_SSH_AUTH_TYPES:
-    data->set.ssh_auth_types = (int)arg;
-    break;
-  case CURLOPT_SSH_COMPRESSION:
-    data->set.ssh_compression = enabled;
+    s->ssh_auth_types = (int)arg;
     break;
 #endif
-
-  case CURLOPT_HTTP_TRANSFER_DECODING:
-    /*
-     * disable libcurl transfer encoding is used
-     */
-    data->set.http_te_skip = !enabled; /* reversed */
-    break;
-
-  case CURLOPT_HTTP_CONTENT_DECODING:
-    /*
-     * raw data passed to the application when content encoding is used
-     */
-    data->set.http_ce_skip = !enabled; /* reversed */
-    break;
 
 #if !defined(CURL_DISABLE_FTP) || defined(USE_SSH)
   case CURLOPT_NEW_FILE_PERMS:
@@ -1224,7 +1292,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < 0) || (arg > 0777))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.new_file_perms = (unsigned int)arg;
+    s->new_file_perms = (unsigned int)arg;
     break;
 #endif
 #ifdef USE_SSH
@@ -1234,7 +1302,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
      */
     if((arg < 0) || (arg > 0777))
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.new_directory_perms = (unsigned int)arg;
+    s->new_directory_perms = (unsigned int)arg;
     break;
 #endif
 #ifdef USE_IPV6
@@ -1248,7 +1316,7 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     if(uarg > UINT_MAX)
       return CURLE_BAD_FUNCTION_ARGUMENT;
 #endif
-    data->set.scope_id = (unsigned int)uarg;
+    s->scope_id = (unsigned int)uarg;
     break;
 #endif
   case CURLOPT_PROTOCOLS:
@@ -1256,26 +1324,16 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
        transfer, which thus helps the app which takes URLs from users or other
        external inputs and want to restrict what protocol(s) to deal with.
        Defaults to CURLPROTO_ALL. */
-    data->set.allowed_protocols = (curl_prot_t)arg;
+    s->allowed_protocols = (curl_prot_t)arg;
     break;
 
   case CURLOPT_REDIR_PROTOCOLS:
     /* set the bitmask for the protocols that libcurl is allowed to follow to,
        as a subset of the CURLOPT_PROTOCOLS ones. That means the protocol
        needs to be set in both bitmasks to be allowed to get redirected to. */
-    data->set.redir_protocols = (curl_prot_t)arg;
+    s->redir_protocols = (curl_prot_t)arg;
     break;
 
-#ifndef CURL_DISABLE_SMTP
-  case CURLOPT_MAIL_RCPT_ALLOWFAILS:
-    /* allow RCPT TO command to fail for some recipients */
-    data->set.mail_rcpt_allowfails = enabled;
-    break;
-#endif /* !CURL_DISABLE_SMTP */
-  case CURLOPT_SASL_IR:
-    /* Enable/disable SASL initial response */
-    data->set.sasl_ir = enabled;
-    break;
 #ifndef CURL_DISABLE_RTSP
   case CURLOPT_RTSP_REQUEST:
     return setopt_RTSP_REQUEST(data, arg);
@@ -1295,82 +1353,50 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
 
 #endif /* ! CURL_DISABLE_RTSP */
 
-  case CURLOPT_TCP_KEEPALIVE:
-    data->set.tcp_keepalive = enabled;
-    break;
   case CURLOPT_TCP_KEEPIDLE:
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     else if(arg > INT_MAX)
       arg = INT_MAX;
-    data->set.tcp_keepidle = (int)arg;
+    s->tcp_keepidle = (int)arg;
     break;
   case CURLOPT_TCP_KEEPINTVL:
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     else if(arg > INT_MAX)
       arg = INT_MAX;
-    data->set.tcp_keepintvl = (int)arg;
+    s->tcp_keepintvl = (int)arg;
     break;
   case CURLOPT_TCP_KEEPCNT:
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
     else if(arg > INT_MAX)
       arg = INT_MAX;
-    data->set.tcp_keepcnt = (int)arg;
-    break;
-  case CURLOPT_TCP_FASTOPEN:
-#if defined(CONNECT_DATA_IDEMPOTENT) || defined(MSG_FASTOPEN) ||        \
-  defined(TCP_FASTOPEN_CONNECT)
-    data->set.tcp_fastopen = enabled;
-#else
-    return CURLE_NOT_BUILT_IN;
-#endif
+    s->tcp_keepcnt = (int)arg;
     break;
   case CURLOPT_SSL_ENABLE_NPN:
-    break;
-  case CURLOPT_SSL_ENABLE_ALPN:
-    data->set.ssl_enable_alpn = enabled;
-    break;
-  case CURLOPT_PATH_AS_IS:
-    data->set.path_as_is = enabled;
-    break;
-  case CURLOPT_PIPEWAIT:
-    data->set.pipewait = enabled;
     break;
   case CURLOPT_STREAM_WEIGHT:
 #if defined(USE_HTTP2) || defined(USE_HTTP3)
     if((arg >= 1) && (arg <= 256))
-      data->set.priority.weight = (int)arg;
+      s->priority.weight = (int)arg;
     break;
 #else
     return CURLE_NOT_BUILT_IN;
 #endif
-  case CURLOPT_SUPPRESS_CONNECT_HEADERS:
-    data->set.suppress_connect_headers = enabled;
-    break;
   case CURLOPT_HAPPY_EYEBALLS_TIMEOUT_MS:
-    return setopt_set_timeout_ms(&data->set.happy_eyeballs_timeout, arg);
-
-#ifndef CURL_DISABLE_SHUFFLE_DNS
-  case CURLOPT_DNS_SHUFFLE_ADDRESSES:
-    data->set.dns_shuffle_addresses = enabled;
-    break;
-#endif
-  case CURLOPT_DISALLOW_USERNAME_IN_URL:
-    data->set.disallow_username_in_url = enabled;
-    break;
+    return setopt_set_timeout_ms(&s->happy_eyeballs_timeout, arg);
 
   case CURLOPT_UPKEEP_INTERVAL_MS:
     if(arg < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.upkeep_interval_ms = arg;
+    s->upkeep_interval_ms = arg;
     break;
   case CURLOPT_MAXAGE_CONN:
-    return setopt_set_timeout_sec(&data->set.conn_max_idle_ms, arg);
+    return setopt_set_timeout_sec(&s->conn_max_idle_ms, arg);
 
   case CURLOPT_MAXLIFETIME_CONN:
-    return setopt_set_timeout_sec(&data->set.conn_max_age_ms, arg);
+    return setopt_set_timeout_sec(&s->conn_max_age_ms, arg);
 
 #ifndef CURL_DISABLE_HSTS
   case CURLOPT_HSTS_CTRL:
@@ -1400,13 +1426,10 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
 #endif /* ! CURL_DISABLE_ALTSVC */
 #ifndef CURL_DISABLE_WEBSOCKETS
   case CURLOPT_WS_OPTIONS:
-    data->set.ws_raw_mode = (bool)(arg & CURLWS_RAW_MODE);
-    data->set.ws_no_auto_pong = (bool)(arg & CURLWS_NOAUTOPONG);
+    s->ws_raw_mode = (bool)(arg & CURLWS_RAW_MODE);
+    s->ws_no_auto_pong = (bool)(arg & CURLWS_NOAUTOPONG);
     break;
 #endif
-  case CURLOPT_QUICK_EXIT:
-    data->set.quick_exit = enabled;
-    break;
   case CURLOPT_DNS_USE_GLOBAL_CACHE:
     /* deprecated */
     break;
@@ -1414,10 +1437,10 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
     /*
      * flag to set engine as default.
      */
-    Curl_safefree(data->set.str[STRING_SSL_ENGINE]);
+    Curl_safefree(s->str[STRING_SSL_ENGINE]);
     return Curl_ssl_set_engine_default(data);
   case CURLOPT_UPLOAD_FLAGS:
-    data->set.upload_flags = (unsigned char)arg;
+    s->upload_flags = (unsigned char)arg;
     break;
   default:
     /* unknown option */
@@ -1430,6 +1453,7 @@ static CURLcode setopt_slist(struct Curl_easy *data, CURLoption option,
                              struct curl_slist *slist)
 {
   CURLcode result = CURLE_OK;
+  struct UserDefined *s = &data->set;
   switch(option) {
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXYHEADER:
@@ -1443,7 +1467,7 @@ static CURLcode setopt_slist(struct Curl_easy *data, CURLoption option,
      *
      * Set this option to NULL to restore the previous behavior.
      */
-    data->set.proxyheaders = slist;
+    s->proxyheaders = slist;
     break;
 #endif
 #ifndef CURL_DISABLE_HTTP
@@ -1451,7 +1475,7 @@ static CURLcode setopt_slist(struct Curl_easy *data, CURLoption option,
     /*
      * Set a list of aliases for HTTP 200 in response header
      */
-    data->set.http200aliases = slist;
+    s->http200aliases = slist;
     break;
 #endif
 #if !defined(CURL_DISABLE_FTP) || defined(USE_SSH)
@@ -1459,19 +1483,19 @@ static CURLcode setopt_slist(struct Curl_easy *data, CURLoption option,
     /*
      * List of RAW FTP commands to use after a transfer
      */
-    data->set.postquote = slist;
+    s->postquote = slist;
     break;
   case CURLOPT_PREQUOTE:
     /*
      * List of RAW FTP commands to use prior to RETR (Wesley Laxton)
      */
-    data->set.prequote = slist;
+    s->prequote = slist;
     break;
   case CURLOPT_QUOTE:
     /*
      * List of RAW FTP commands to use before a transfer
      */
-    data->set.quote = slist;
+    s->quote = slist;
     break;
 #endif
   case CURLOPT_RESOLVE:
@@ -1488,15 +1512,15 @@ static CURLcode setopt_slist(struct Curl_easy *data, CURLoption option,
      * This API can remove any entry from the DNS cache, but only entries
      * that are not actually in use right now will be pruned immediately.
      */
-    data->set.resolve = slist;
-    data->state.resolve = data->set.resolve;
+    s->resolve = slist;
+    data->state.resolve = s->resolve;
     break;
 #if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_MIME)
   case CURLOPT_HTTPHEADER:
     /*
      * Set a list with HTTP headers to use (or replace internals with)
      */
-    data->set.headers = slist;
+    s->headers = slist;
     break;
 #endif
 #ifndef CURL_DISABLE_TELNET
@@ -1504,17 +1528,17 @@ static CURLcode setopt_slist(struct Curl_easy *data, CURLoption option,
     /*
      * Set a linked list of telnet options
      */
-    data->set.telnet_options = slist;
+    s->telnet_options = slist;
     break;
 #endif
 #ifndef CURL_DISABLE_SMTP
   case CURLOPT_MAIL_RCPT:
     /* Set the list of mail recipients */
-    data->set.mail_rcpt = slist;
+    s->mail_rcpt = slist;
     break;
 #endif
   case CURLOPT_CONNECT_TO:
-    data->set.connect_to = slist;
+    s->connect_to = slist;
     break;
   default:
     return CURLE_UNKNOWN_OPTION;
@@ -1527,6 +1551,7 @@ static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
                                 va_list param)
 {
   CURLcode result = CURLE_OK;
+  struct UserDefined *s = &data->set;
   switch(option) {
 #ifndef CURL_DISABLE_HTTP
 #ifndef CURL_DISABLE_FORM_API
@@ -1534,9 +1559,9 @@ static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
     /*
      * Set to make us do HTTP POST. Legacy API-style.
      */
-    data->set.httppost = va_arg(param, struct curl_httppost *);
-    data->set.method = HTTPREQ_POST_FORM;
-    data->set.opt_no_body = FALSE; /* this is implied */
+    s->httppost = va_arg(param, struct curl_httppost *);
+    s->method = HTTPREQ_POST_FORM;
+    s->opt_no_body = FALSE; /* this is implied */
     Curl_mime_cleanpart(data->state.formp);
     Curl_safefree(data->state.formp);
     data->state.mimepost = NULL;
@@ -1550,12 +1575,12 @@ static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
     /*
      * Set to make us do MIME POST
      */
-    result = Curl_mime_set_subparts(&data->set.mimepost,
+    result = Curl_mime_set_subparts(&s->mimepost,
                                     va_arg(param, curl_mime *),
                                     FALSE);
     if(!result) {
-      data->set.method = HTTPREQ_POST_MIME;
-      data->set.opt_no_body = FALSE; /* this is implied */
+      s->method = HTTPREQ_POST_MIME;
+      s->opt_no_body = FALSE; /* this is implied */
 #ifndef CURL_DISABLE_FORM_API
       Curl_mime_cleanpart(data->state.formp);
       Curl_safefree(data->state.formp);
@@ -1570,9 +1595,9 @@ static CURLcode setopt_pointers(struct Curl_easy *data, CURLoption option,
      * Set to a FILE * that should receive all error writes. This
      * defaults to stderr for normal operations.
      */
-    data->set.err = va_arg(param, FILE *);
-    if(!data->set.err)
-      data->set.err = stderr;
+    s->err = va_arg(param, FILE *);
+    if(!s->err)
+      s->err = stderr;
     break;
   case CURLOPT_SHARE:
   {
@@ -1663,18 +1688,19 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
                             char *ptr)
 {
   CURLcode result = CURLE_OK;
+  struct UserDefined *s = &data->set;
   switch(option) {
   case CURLOPT_SSL_CIPHER_LIST:
     if(Curl_ssl_supports(data, SSLSUPP_CIPHER_LIST))
       /* set a list of cipher we want to use in the SSL connection */
-      return Curl_setstropt(&data->set.str[STRING_SSL_CIPHER_LIST], ptr);
+      return Curl_setstropt(&s->str[STRING_SSL_CIPHER_LIST], ptr);
     else
       return CURLE_NOT_BUILT_IN;
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSL_CIPHER_LIST:
     if(Curl_ssl_supports(data, SSLSUPP_CIPHER_LIST)) {
       /* set a list of cipher we want to use in the SSL connection for proxy */
-      return Curl_setstropt(&data->set.str[STRING_SSL_CIPHER_LIST_PROXY],
+      return Curl_setstropt(&s->str[STRING_SSL_CIPHER_LIST_PROXY],
                             ptr);
     }
     else
@@ -1683,7 +1709,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
   case CURLOPT_TLS13_CIPHERS:
     if(Curl_ssl_supports(data, SSLSUPP_TLS13_CIPHERSUITES)) {
       /* set preferred list of TLS 1.3 cipher suites */
-      return Curl_setstropt(&data->set.str[STRING_SSL_CIPHER13_LIST], ptr);
+      return Curl_setstropt(&s->str[STRING_SSL_CIPHER13_LIST], ptr);
     }
     else
       return CURLE_NOT_BUILT_IN;
@@ -1691,7 +1717,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
   case CURLOPT_PROXY_TLS13_CIPHERS:
     if(Curl_ssl_supports(data, SSLSUPP_TLS13_CIPHERSUITES))
       /* set preferred list of TLS 1.3 cipher suites for proxy */
-      return Curl_setstropt(&data->set.str[STRING_SSL_CIPHER13_LIST_PROXY],
+      return Curl_setstropt(&s->str[STRING_SSL_CIPHER13_LIST_PROXY],
                             ptr);
     else
       return CURLE_NOT_BUILT_IN;
@@ -1701,13 +1727,13 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
   case CURLOPT_EGDSOCKET:
     break;
   case CURLOPT_REQUEST_TARGET:
-    return Curl_setstropt(&data->set.str[STRING_TARGET], ptr);
+    return Curl_setstropt(&s->str[STRING_TARGET], ptr);
 #ifndef CURL_DISABLE_NETRC
   case CURLOPT_NETRC_FILE:
     /*
      * Use this file instead of the $HOME/.netrc file
      */
-    return Curl_setstropt(&data->set.str[STRING_NETRC_FILE], ptr);
+    return Curl_setstropt(&s->str[STRING_NETRC_FILE], ptr);
 #endif
 
 #if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_MQTT)
@@ -1717,16 +1743,16 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * If needed, CURLOPT_POSTFIELDSIZE must have been set prior to
      *  CURLOPT_COPYPOSTFIELDS and not altered later.
      */
-    if(!ptr || data->set.postfieldsize == -1)
-      result = Curl_setstropt(&data->set.str[STRING_COPYPOSTFIELDS], ptr);
+    if(!ptr || s->postfieldsize == -1)
+      result = Curl_setstropt(&s->str[STRING_COPYPOSTFIELDS], ptr);
     else {
-      if(data->set.postfieldsize < 0)
+      if(s->postfieldsize < 0)
         return CURLE_BAD_FUNCTION_ARGUMENT;
 #if SIZEOF_CURL_OFF_T > SIZEOF_SIZE_T
       /*
        *  Check that requested length does not overflow the size_t type.
        */
-      else if(data->set.postfieldsize > SIZE_T_MAX)
+      else if(s->postfieldsize > SIZE_T_MAX)
         return CURLE_OUT_OF_MEMORY;
 #endif
       else {
@@ -1735,28 +1761,28 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
            mark that postfields is used rather than read function or form
            data.
         */
-        char *p = Curl_memdup0(ptr, (size_t)data->set.postfieldsize);
+        char *p = Curl_memdup0(ptr, (size_t)s->postfieldsize);
         if(!p)
           return CURLE_OUT_OF_MEMORY;
         else {
-          free(data->set.str[STRING_COPYPOSTFIELDS]);
-          data->set.str[STRING_COPYPOSTFIELDS] = p;
+          free(s->str[STRING_COPYPOSTFIELDS]);
+          s->str[STRING_COPYPOSTFIELDS] = p;
         }
       }
     }
 
-    data->set.postfields = data->set.str[STRING_COPYPOSTFIELDS];
-    data->set.method = HTTPREQ_POST;
+    s->postfields = s->str[STRING_COPYPOSTFIELDS];
+    s->method = HTTPREQ_POST;
     break;
 
   case CURLOPT_POSTFIELDS:
     /*
      * Like above, but use static data instead of copying it.
      */
-    data->set.postfields = ptr;
+    s->postfields = ptr;
     /* Release old copied data. */
-    Curl_safefree(data->set.str[STRING_COPYPOSTFIELDS]);
-    data->set.method = HTTPREQ_POST;
+    Curl_safefree(s->str[STRING_COPYPOSTFIELDS]);
+    s->method = HTTPREQ_POST;
     break;
 #endif /* ! CURL_DISABLE_HTTP || ! CURL_DISABLE_MQTT */
 
@@ -1774,9 +1800,9 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     if(ptr && !*ptr) {
       char all[256];
       Curl_all_content_encodings(all, sizeof(all));
-      return Curl_setstropt(&data->set.str[STRING_ENCODING], all);
+      return Curl_setstropt(&s->str[STRING_ENCODING], all);
     }
-    return Curl_setstropt(&data->set.str[STRING_ENCODING], ptr);
+    return Curl_setstropt(&s->str[STRING_ENCODING], ptr);
 
 #ifndef CURL_DISABLE_AWS
   case CURLOPT_AWS_SIGV4:
@@ -1784,12 +1810,12 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * String that is merged to some authentication
      * parameters are used by the algorithm.
      */
-    result = Curl_setstropt(&data->set.str[STRING_AWS_SIGV4], ptr);
+    result = Curl_setstropt(&s->str[STRING_AWS_SIGV4], ptr);
     /*
      * Basic been set by default it need to be unset here
      */
-    if(data->set.str[STRING_AWS_SIGV4])
-      data->set.httpauth = CURLAUTH_AWS_SIGV4;
+    if(s->str[STRING_AWS_SIGV4])
+      s->httpauth = CURLAUTH_AWS_SIGV4;
     break;
 #endif
   case CURLOPT_REFERER:
@@ -1800,22 +1826,22 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
       Curl_safefree(data->state.referer);
       data->state.referer_alloc = FALSE;
     }
-    result = Curl_setstropt(&data->set.str[STRING_SET_REFERER], ptr);
-    data->state.referer = data->set.str[STRING_SET_REFERER];
+    result = Curl_setstropt(&s->str[STRING_SET_REFERER], ptr);
+    data->state.referer = s->str[STRING_SET_REFERER];
     break;
 
   case CURLOPT_USERAGENT:
     /*
      * String to use in the HTTP User-Agent field
      */
-    return Curl_setstropt(&data->set.str[STRING_USERAGENT], ptr);
+    return Curl_setstropt(&s->str[STRING_USERAGENT], ptr);
 
 #ifndef CURL_DISABLE_COOKIES
   case CURLOPT_COOKIE:
     /*
      * Cookie string to send to the remote server in the request.
      */
-    return Curl_setstropt(&data->set.str[STRING_COOKIE], ptr);
+    return Curl_setstropt(&s->str[STRING_COOKIE], ptr);
 
   case CURLOPT_COOKIEFILE:
     /*
@@ -1856,14 +1882,14 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * Set cookie filename to dump all cookies to when we are done.
      */
-    result = Curl_setstropt(&data->set.str[STRING_COOKIEJAR], ptr);
+    result = Curl_setstropt(&s->str[STRING_COOKIEJAR], ptr);
     if(!result) {
       /*
        * Activate the cookie parser. This may or may not already
        * have been made.
        */
       struct CookieInfo *newcookies =
-        Curl_cookie_init(data, NULL, data->cookies, data->set.cookiesession);
+        Curl_cookie_init(data, NULL, data->cookies, s->cookiesession);
       if(!newcookies)
         result = CURLE_OUT_OF_MEMORY;
       data->cookies = newcookies;
@@ -1927,10 +1953,10 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * Set a custom string to use as request
      */
-    return Curl_setstropt(&data->set.str[STRING_CUSTOMREQUEST], ptr);
+    return Curl_setstropt(&s->str[STRING_CUSTOMREQUEST], ptr);
 
     /* we do not set
-       data->set.method = HTTPREQ_CUSTOM;
+       s->method = HTTPREQ_CUSTOM;
        here, we continue as if we were using the already set type
        and this just changes the actual request keyword */
 
@@ -1946,7 +1972,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Setting it to NULL, means no proxy but allows the environment variables
      * to decide for us (if CURLOPT_SOCKS_PROXY setting it to NULL).
      */
-    return Curl_setstropt(&data->set.str[STRING_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_PROXY], ptr);
 
   case CURLOPT_PRE_PROXY:
     /*
@@ -1955,7 +1981,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * If the proxy is set to "" or NULL we explicitly say that we do not want
      * to use the socks proxy.
      */
-    return Curl_setstropt(&data->set.str[STRING_PRE_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_PRE_PROXY], ptr);
 #endif   /* CURL_DISABLE_PROXY */
 
 #ifndef CURL_DISABLE_PROXY
@@ -1964,58 +1990,58 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * Set proxy authentication service name for Kerberos 5 and SPNEGO
      */
-    return Curl_setstropt(&data->set.str[STRING_PROXY_SERVICE_NAME], ptr);
+    return Curl_setstropt(&s->str[STRING_PROXY_SERVICE_NAME], ptr);
 #endif
   case CURLOPT_SERVICE_NAME:
     /*
      * Set authentication service name for DIGEST-MD5, Kerberos 5 and SPNEGO
      */
-    return Curl_setstropt(&data->set.str[STRING_SERVICE_NAME], ptr);
+    return Curl_setstropt(&s->str[STRING_SERVICE_NAME], ptr);
 
   case CURLOPT_HEADERDATA:
     /*
      * Custom pointer to pass the header write callback function
      */
-    data->set.writeheader = ptr;
+    s->writeheader = ptr;
     break;
   case CURLOPT_READDATA:
     /*
      * FILE pointer to read the file to be uploaded from. Or possibly used as
      * argument to the read callback.
      */
-    data->set.in_set = ptr;
+    s->in_set = ptr;
     break;
   case CURLOPT_WRITEDATA:
     /*
      * FILE pointer to write to. Or possibly used as argument to the write
      * callback.
      */
-    data->set.out = ptr;
+    s->out = ptr;
     break;
   case CURLOPT_DEBUGDATA:
     /*
      * Set to a void * that should receive all error writes. This
      * defaults to CURLOPT_STDERR for normal operations.
      */
-    data->set.debugdata = ptr;
+    s->debugdata = ptr;
     break;
   case CURLOPT_PROGRESSDATA:
     /*
      * Custom client data to pass to the progress callback
      */
-    data->set.progress_client = ptr;
+    s->progress_client = ptr;
     break;
   case CURLOPT_SEEKDATA:
     /*
      * Seek control callback. Might be NULL.
      */
-    data->set.seek_client = ptr;
+    s->seek_client = ptr;
     break;
   case CURLOPT_IOCTLDATA:
     /*
      * I/O control data pointer. Might be NULL.
      */
-    data->set.ioctl_client = ptr;
+    s->ioctl_client = ptr;
     break;
   case CURLOPT_SSL_CTX_DATA:
     /*
@@ -2023,7 +2049,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_SSL_CTX)) {
-      data->set.ssl.fsslctxp = ptr;
+      s->ssl.fsslctxp = ptr;
       break;
     }
     else
@@ -2033,33 +2059,33 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * socket callback data pointer. Might be NULL.
      */
-    data->set.sockopt_client = ptr;
+    s->sockopt_client = ptr;
     break;
   case CURLOPT_OPENSOCKETDATA:
     /*
      * socket callback data pointer. Might be NULL.
      */
-    data->set.opensocket_client = ptr;
+    s->opensocket_client = ptr;
     break;
   case CURLOPT_RESOLVER_START_DATA:
     /*
      * resolver start callback data pointer. Might be NULL.
      */
-    data->set.resolver_start_client = ptr;
+    s->resolver_start_client = ptr;
     break;
   case CURLOPT_CLOSESOCKETDATA:
     /*
      * socket callback data pointer. Might be NULL.
      */
-    data->set.closesocket_client = ptr;
+    s->closesocket_client = ptr;
     break;
   case CURLOPT_TRAILERDATA:
 #ifndef CURL_DISABLE_HTTP
-    data->set.trailer_data = ptr;
+    s->trailer_data = ptr;
 #endif
     break;
   case CURLOPT_PREREQDATA:
-    data->set.prereq_userp = ptr;
+    s->prereq_userp = ptr;
     break;
 
   case CURLOPT_ERRORBUFFER:
@@ -2067,7 +2093,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Error buffer provided by the caller to get the human readable error
      * string in.
      */
-    data->set.errorbuffer = ptr;
+    s->errorbuffer = ptr;
     break;
 
 #ifndef CURL_DISABLE_FTP
@@ -2075,23 +2101,23 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * Use FTP PORT, this also specifies which IP address to use
      */
-    result = Curl_setstropt(&data->set.str[STRING_FTPPORT], ptr);
-    data->set.ftp_use_port = !!(data->set.str[STRING_FTPPORT]);
+    result = Curl_setstropt(&s->str[STRING_FTPPORT], ptr);
+    s->ftp_use_port = !!(s->str[STRING_FTPPORT]);
     break;
 
   case CURLOPT_FTP_ACCOUNT:
-    return Curl_setstropt(&data->set.str[STRING_FTP_ACCOUNT], ptr);
+    return Curl_setstropt(&s->str[STRING_FTP_ACCOUNT], ptr);
 
   case CURLOPT_FTP_ALTERNATIVE_TO_USER:
-    return Curl_setstropt(&data->set.str[STRING_FTP_ALTERNATIVE_TO_USER], ptr);
+    return Curl_setstropt(&s->str[STRING_FTP_ALTERNATIVE_TO_USER], ptr);
 
 #ifdef HAVE_GSSAPI
   case CURLOPT_KRBLEVEL:
     /*
      * A string that defines the kerberos security level.
      */
-    result = Curl_setstropt(&data->set.str[STRING_KRB_LEVEL], ptr);
-    data->set.krb = !!(data->set.str[STRING_KRB_LEVEL]);
+    result = Curl_setstropt(&s->str[STRING_KRB_LEVEL], ptr);
+    s->krb = !!(s->str[STRING_KRB_LEVEL]);
     break;
 #endif
 #endif
@@ -2103,40 +2129,40 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
       Curl_safefree(data->state.url);
       data->state.url_alloc = FALSE;
     }
-    result = Curl_setstropt(&data->set.str[STRING_SET_URL], ptr);
-    data->state.url = data->set.str[STRING_SET_URL];
+    result = Curl_setstropt(&s->str[STRING_SET_URL], ptr);
+    data->state.url = s->str[STRING_SET_URL];
     break;
 
   case CURLOPT_USERPWD:
     /*
      * user:password to use in the operation
      */
-    return setstropt_userpwd(ptr, &data->set.str[STRING_USERNAME],
-                             &data->set.str[STRING_PASSWORD]);
+    return setstropt_userpwd(ptr, &s->str[STRING_USERNAME],
+                             &s->str[STRING_PASSWORD]);
 
   case CURLOPT_USERNAME:
     /*
      * authentication username to use in the operation
      */
-    return Curl_setstropt(&data->set.str[STRING_USERNAME], ptr);
+    return Curl_setstropt(&s->str[STRING_USERNAME], ptr);
 
   case CURLOPT_PASSWORD:
     /*
      * authentication password to use in the operation
      */
-    return Curl_setstropt(&data->set.str[STRING_PASSWORD], ptr);
+    return Curl_setstropt(&s->str[STRING_PASSWORD], ptr);
 
   case CURLOPT_LOGIN_OPTIONS:
     /*
      * authentication options to use in the operation
      */
-    return Curl_setstropt(&data->set.str[STRING_OPTIONS], ptr);
+    return Curl_setstropt(&s->str[STRING_OPTIONS], ptr);
 
   case CURLOPT_XOAUTH2_BEARER:
     /*
      * OAuth 2.0 bearer token to use in the operation
      */
-    return Curl_setstropt(&data->set.str[STRING_BEARER], ptr);
+    return Curl_setstropt(&s->str[STRING_BEARER], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXYUSERPWD: {
@@ -2149,13 +2175,13 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 
     /* URL decode the components */
     if(!result && u) {
-      Curl_safefree(data->set.str[STRING_PROXYUSERNAME]);
-      result = Curl_urldecode(u, 0, &data->set.str[STRING_PROXYUSERNAME], NULL,
+      Curl_safefree(s->str[STRING_PROXYUSERNAME]);
+      result = Curl_urldecode(u, 0, &s->str[STRING_PROXYUSERNAME], NULL,
                               REJECT_ZERO);
     }
     if(!result && p) {
-      Curl_safefree(data->set.str[STRING_PROXYPASSWORD]);
-      result = Curl_urldecode(p, 0, &data->set.str[STRING_PROXYPASSWORD], NULL,
+      Curl_safefree(s->str[STRING_PROXYPASSWORD]);
+      result = Curl_urldecode(p, 0, &s->str[STRING_PROXYPASSWORD], NULL,
                               REJECT_ZERO);
     }
     free(u);
@@ -2166,26 +2192,26 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * authentication username to use in the operation
      */
-    return Curl_setstropt(&data->set.str[STRING_PROXYUSERNAME], ptr);
+    return Curl_setstropt(&s->str[STRING_PROXYUSERNAME], ptr);
 
   case CURLOPT_PROXYPASSWORD:
     /*
      * authentication password to use in the operation
      */
-    return Curl_setstropt(&data->set.str[STRING_PROXYPASSWORD], ptr);
+    return Curl_setstropt(&s->str[STRING_PROXYPASSWORD], ptr);
 
   case CURLOPT_NOPROXY:
     /*
      * proxy exception list
      */
-    return Curl_setstropt(&data->set.str[STRING_NOPROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_NOPROXY], ptr);
 #endif /* ! CURL_DISABLE_PROXY */
 
   case CURLOPT_RANGE:
     /*
      * What range of the file you want to transfer
      */
-    return Curl_setstropt(&data->set.str[STRING_SET_RANGE], ptr);
+    return Curl_setstropt(&s->str[STRING_SET_RANGE], ptr);
 
   case CURLOPT_CURLU:
     /*
@@ -2197,77 +2223,77 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     }
     else
       data->state.url = NULL;
-    Curl_safefree(data->set.str[STRING_SET_URL]);
-    data->set.uh = (CURLU *)ptr;
+    Curl_safefree(s->str[STRING_SET_URL]);
+    s->uh = (CURLU *)ptr;
     break;
   case CURLOPT_SSLCERT:
     /*
      * String that holds filename of the SSL certificate to use
      */
-    return Curl_setstropt(&data->set.str[STRING_CERT], ptr);
+    return Curl_setstropt(&s->str[STRING_CERT], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSLCERT:
     /*
      * String that holds filename of the SSL certificate to use for proxy
      */
-    return Curl_setstropt(&data->set.str[STRING_CERT_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_CERT_PROXY], ptr);
 
 #endif
   case CURLOPT_SSLCERTTYPE:
     /*
      * String that holds file type of the SSL certificate to use
      */
-    return Curl_setstropt(&data->set.str[STRING_CERT_TYPE], ptr);
+    return Curl_setstropt(&s->str[STRING_CERT_TYPE], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSLCERTTYPE:
     /*
      * String that holds file type of the SSL certificate to use for proxy
      */
-    return Curl_setstropt(&data->set.str[STRING_CERT_TYPE_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_CERT_TYPE_PROXY], ptr);
 
 #endif
   case CURLOPT_SSLKEY:
     /*
      * String that holds filename of the SSL key to use
      */
-    return Curl_setstropt(&data->set.str[STRING_KEY], ptr);
+    return Curl_setstropt(&s->str[STRING_KEY], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSLKEY:
     /*
      * String that holds filename of the SSL key to use for proxy
      */
-    return Curl_setstropt(&data->set.str[STRING_KEY_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_KEY_PROXY], ptr);
 
 #endif
   case CURLOPT_SSLKEYTYPE:
     /*
      * String that holds file type of the SSL key to use
      */
-    return Curl_setstropt(&data->set.str[STRING_KEY_TYPE], ptr);
+    return Curl_setstropt(&s->str[STRING_KEY_TYPE], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSLKEYTYPE:
     /*
      * String that holds file type of the SSL key to use for proxy
      */
-    return Curl_setstropt(&data->set.str[STRING_KEY_TYPE_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_KEY_TYPE_PROXY], ptr);
 
 #endif
   case CURLOPT_KEYPASSWD:
     /*
      * String that holds the SSL or SSH private key password.
      */
-    return Curl_setstropt(&data->set.str[STRING_KEY_PASSWD], ptr);
+    return Curl_setstropt(&s->str[STRING_KEY_PASSWD], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_KEYPASSWD:
     /*
      * String that holds the SSL private key password for proxy.
      */
-    return Curl_setstropt(&data->set.str[STRING_KEY_PASSWD_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_KEY_PASSWD_PROXY], ptr);
 
 #endif
   case CURLOPT_SSLENGINE:
@@ -2275,7 +2301,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * String that holds the SSL crypto engine.
      */
     if(ptr && ptr[0]) {
-      result = Curl_setstropt(&data->set.str[STRING_SSL_ENGINE], ptr);
+      result = Curl_setstropt(&s->str[STRING_SSL_ENGINE], ptr);
       if(!result) {
         result = Curl_ssl_set_engine(data, ptr);
       }
@@ -2287,9 +2313,9 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * Set the client IP to send through HAProxy PROXY protocol
      */
-    result = Curl_setstropt(&data->set.str[STRING_HAPROXY_CLIENT_IP], ptr);
+    result = Curl_setstropt(&s->str[STRING_HAPROXY_CLIENT_IP], ptr);
     /* enable the HAProxy protocol */
-    data->set.haproxyprotocol = TRUE;
+    s->haproxyprotocol = TRUE;
     break;
 
 #endif
@@ -2299,9 +2325,9 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * performing an operation and thus what from-IP your connection will use.
      */
     return setstropt_interface(ptr,
-                               &data->set.str[STRING_DEVICE],
-                               &data->set.str[STRING_INTERFACE],
-                               &data->set.str[STRING_BINDHOST]);
+                               &s->str[STRING_DEVICE],
+                               &s->str[STRING_INTERFACE],
+                               &s->str[STRING_BINDHOST]);
 
   case CURLOPT_PINNEDPUBLICKEY:
     /*
@@ -2310,7 +2336,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_PINNEDPUBKEY))
-      return Curl_setstropt(&data->set.str[STRING_SSL_PINNEDPUBLICKEY], ptr);
+      return Curl_setstropt(&s->str[STRING_SSL_PINNEDPUBLICKEY], ptr);
 #endif
     return CURLE_NOT_BUILT_IN;
 
@@ -2322,7 +2348,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_PINNEDPUBKEY))
-      return Curl_setstropt(&data->set.str[STRING_SSL_PINNEDPUBLICKEY_PROXY],
+      return Curl_setstropt(&s->str[STRING_SSL_PINNEDPUBLICKEY_PROXY],
                             ptr);
 #endif
     return CURLE_NOT_BUILT_IN;
@@ -2331,7 +2357,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * Set CA info for SSL connection. Specify filename of the CA certificate
      */
-    return Curl_setstropt(&data->set.str[STRING_SSL_CAFILE], ptr);
+    return Curl_setstropt(&s->str[STRING_SSL_CAFILE], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_CAINFO:
@@ -2339,7 +2365,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Set CA info SSL connection for proxy. Specify filename of the
      * CA certificate
      */
-    return Curl_setstropt(&data->set.str[STRING_SSL_CAFILE_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_SSL_CAFILE_PROXY], ptr);
 
 #endif
   case CURLOPT_CAPATH:
@@ -2350,7 +2376,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CA_PATH))
       /* This does not work on Windows. */
-      return Curl_setstropt(&data->set.str[STRING_SSL_CAPATH], ptr);
+      return Curl_setstropt(&s->str[STRING_SSL_CAPATH], ptr);
 #endif
     return CURLE_NOT_BUILT_IN;
 #ifndef CURL_DISABLE_PROXY
@@ -2362,7 +2388,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CA_PATH))
       /* This does not work on Windows. */
-      return Curl_setstropt(&data->set.str[STRING_SSL_CAPATH_PROXY], ptr);
+      return Curl_setstropt(&s->str[STRING_SSL_CAPATH_PROXY], ptr);
 #endif
     return CURLE_NOT_BUILT_IN;
 #endif
@@ -2371,7 +2397,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Set CRL file info for SSL connection. Specify filename of the CRL
      * to check certificates revocation
      */
-    return Curl_setstropt(&data->set.str[STRING_SSL_CRLFILE], ptr);
+    return Curl_setstropt(&s->str[STRING_SSL_CRLFILE], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_CRLFILE:
@@ -2379,7 +2405,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Set CRL file info for SSL connection for proxy. Specify filename of the
      * CRL to check certificates revocation
      */
-    return Curl_setstropt(&data->set.str[STRING_SSL_CRLFILE_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_SSL_CRLFILE_PROXY], ptr);
 
 #endif
   case CURLOPT_ISSUERCERT:
@@ -2387,7 +2413,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Set Issuer certificate file
      * to check certificates issuer
      */
-    return Curl_setstropt(&data->set.str[STRING_SSL_ISSUERCERT], ptr);
+    return Curl_setstropt(&s->str[STRING_SSL_ISSUERCERT], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_ISSUERCERT:
@@ -2395,14 +2421,14 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Set Issuer certificate file
      * to check certificates issuer
      */
-    return Curl_setstropt(&data->set.str[STRING_SSL_ISSUERCERT_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_SSL_ISSUERCERT_PROXY], ptr);
 
 #endif
   case CURLOPT_PRIVATE:
     /*
      * Set private data pointer.
      */
-    data->set.private_data = ptr;
+    s->private_data = ptr;
     break;
 
 #ifdef USE_SSL
@@ -2411,7 +2437,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Set accepted curves in SSL connection setup.
      * Specify colon-delimited list of curve algorithm names.
      */
-    return Curl_setstropt(&data->set.str[STRING_SSL_EC_CURVES], ptr);
+    return Curl_setstropt(&s->str[STRING_SSL_EC_CURVES], ptr);
 
   case CURLOPT_SSL_SIGNATURE_ALGORITHMS:
     /*
@@ -2419,7 +2445,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Specify colon-delimited list of signature scheme names.
      */
     if(Curl_ssl_supports(data, SSLSUPP_SIGNATURE_ALGORITHMS))
-      return Curl_setstropt(&data->set.str[STRING_SSL_SIGNATURE_ALGORITHMS],
+      return Curl_setstropt(&s->str[STRING_SSL_SIGNATURE_ALGORITHMS],
                             ptr);
     return CURLE_NOT_BUILT_IN;
 #endif
@@ -2428,13 +2454,13 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     /*
      * Use this file instead of the $HOME/.ssh/id_dsa.pub file
      */
-    return Curl_setstropt(&data->set.str[STRING_SSH_PUBLIC_KEY], ptr);
+    return Curl_setstropt(&s->str[STRING_SSH_PUBLIC_KEY], ptr);
 
   case CURLOPT_SSH_PRIVATE_KEYFILE:
     /*
      * Use this file instead of the $HOME/.ssh/id_dsa file
      */
-    return Curl_setstropt(&data->set.str[STRING_SSH_PRIVATE_KEY], ptr);
+    return Curl_setstropt(&s->str[STRING_SSH_PRIVATE_KEY], ptr);
 
 #if defined(USE_LIBSSH2) || defined(USE_LIBSSH)
   case CURLOPT_SSH_HOST_PUBLIC_KEY_MD5:
@@ -2442,19 +2468,19 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Option to allow for the MD5 of the host public key to be checked
      * for validation purposes.
      */
-    return Curl_setstropt(&data->set.str[STRING_SSH_HOST_PUBLIC_KEY_MD5], ptr);
+    return Curl_setstropt(&s->str[STRING_SSH_HOST_PUBLIC_KEY_MD5], ptr);
 
   case CURLOPT_SSH_KNOWNHOSTS:
     /*
      * Store the filename to read known hosts from.
      */
-    return Curl_setstropt(&data->set.str[STRING_SSH_KNOWNHOSTS], ptr);
+    return Curl_setstropt(&s->str[STRING_SSH_KNOWNHOSTS], ptr);
 #endif
   case CURLOPT_SSH_KEYDATA:
     /*
      * Custom client data to pass to the SSH keyfunc callback
      */
-    data->set.ssh_keyfunc_userp = ptr;
+    s->ssh_keyfunc_userp = ptr;
     break;
 #ifdef USE_LIBSSH2
   case CURLOPT_SSH_HOST_PUBLIC_KEY_SHA256:
@@ -2462,47 +2488,47 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Option to allow for the SHA256 of the host public key to be checked
      * for validation purposes.
      */
-    return Curl_setstropt(&data->set.str[STRING_SSH_HOST_PUBLIC_KEY_SHA256],
+    return Curl_setstropt(&s->str[STRING_SSH_HOST_PUBLIC_KEY_SHA256],
                           ptr);
 
   case CURLOPT_SSH_HOSTKEYDATA:
     /*
      * Custom client data to pass to the SSH keyfunc callback
      */
-    data->set.ssh_hostkeyfunc_userp = ptr;
+    s->ssh_hostkeyfunc_userp = ptr;
     break;
 #endif /* USE_LIBSSH2 */
 #endif /* USE_SSH */
   case CURLOPT_PROTOCOLS_STR:
     if(ptr)
-      return protocol2num(ptr, &data->set.allowed_protocols);
+      return protocol2num(ptr, &s->allowed_protocols);
     /* make a NULL argument reset to default */
-    data->set.allowed_protocols = (curl_prot_t) CURLPROTO_ALL;
+    s->allowed_protocols = (curl_prot_t) CURLPROTO_ALL;
     break;
 
   case CURLOPT_REDIR_PROTOCOLS_STR:
     if(ptr)
-      return protocol2num(ptr, &data->set.redir_protocols);
+      return protocol2num(ptr, &s->redir_protocols);
     /* make a NULL argument reset to default */
-    data->set.redir_protocols = (curl_prot_t) CURLPROTO_REDIR;
+    s->redir_protocols = (curl_prot_t) CURLPROTO_REDIR;
     break;
 
   case CURLOPT_DEFAULT_PROTOCOL:
     /* Set the protocol to use when the URL does not include any protocol */
-    return Curl_setstropt(&data->set.str[STRING_DEFAULT_PROTOCOL], ptr);
+    return Curl_setstropt(&s->str[STRING_DEFAULT_PROTOCOL], ptr);
 
 #ifndef CURL_DISABLE_SMTP
   case CURLOPT_MAIL_FROM:
     /* Set the SMTP mail originator */
-    return Curl_setstropt(&data->set.str[STRING_MAIL_FROM], ptr);
+    return Curl_setstropt(&s->str[STRING_MAIL_FROM], ptr);
 
   case CURLOPT_MAIL_AUTH:
     /* Set the SMTP auth originator */
-    return Curl_setstropt(&data->set.str[STRING_MAIL_AUTH], ptr);
+    return Curl_setstropt(&s->str[STRING_MAIL_AUTH], ptr);
 #endif
   case CURLOPT_SASL_AUTHZID:
     /* Authorization identity (identity to act as) */
-    return Curl_setstropt(&data->set.str[STRING_SASL_AUTHZID], ptr);
+    return Curl_setstropt(&s->str[STRING_SASL_AUTHZID], ptr);
 
 #ifndef CURL_DISABLE_RTSP
   case CURLOPT_RTSP_SESSION_ID:
@@ -2510,48 +2536,48 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
      * Set the RTSP Session ID manually. Useful if the application is
      * resuming a previously established RTSP session
      */
-    return Curl_setstropt(&data->set.str[STRING_RTSP_SESSION_ID], ptr);
+    return Curl_setstropt(&s->str[STRING_RTSP_SESSION_ID], ptr);
 
   case CURLOPT_RTSP_STREAM_URI:
     /*
      * Set the Stream URI for the RTSP request. Unless the request is
      * for generic server options, the application will need to set this.
      */
-    return Curl_setstropt(&data->set.str[STRING_RTSP_STREAM_URI], ptr);
+    return Curl_setstropt(&s->str[STRING_RTSP_STREAM_URI], ptr);
 
   case CURLOPT_RTSP_TRANSPORT:
     /*
      * The content of the Transport: header for the RTSP request
      */
-    return Curl_setstropt(&data->set.str[STRING_RTSP_TRANSPORT], ptr);
+    return Curl_setstropt(&s->str[STRING_RTSP_TRANSPORT], ptr);
 
   case CURLOPT_INTERLEAVEDATA:
-    data->set.rtp_out = ptr;
+    s->rtp_out = ptr;
     break;
 #endif /* ! CURL_DISABLE_RTSP */
 #ifndef CURL_DISABLE_FTP
   case CURLOPT_CHUNK_DATA:
-    data->set.wildcardptr = ptr;
+    s->wildcardptr = ptr;
     break;
   case CURLOPT_FNMATCH_DATA:
-    data->set.fnmatch_data = ptr;
+    s->fnmatch_data = ptr;
     break;
 #endif
 #ifdef USE_TLS_SRP
   case CURLOPT_TLSAUTH_USERNAME:
-    return Curl_setstropt(&data->set.str[STRING_TLSAUTH_USERNAME], ptr);
+    return Curl_setstropt(&s->str[STRING_TLSAUTH_USERNAME], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_TLSAUTH_USERNAME:
-    return Curl_setstropt(&data->set.str[STRING_TLSAUTH_USERNAME_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_TLSAUTH_USERNAME_PROXY], ptr);
 
 #endif
   case CURLOPT_TLSAUTH_PASSWORD:
-    return Curl_setstropt(&data->set.str[STRING_TLSAUTH_PASSWORD], ptr);
+    return Curl_setstropt(&s->str[STRING_TLSAUTH_PASSWORD], ptr);
 
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_TLSAUTH_PASSWORD:
-    return Curl_setstropt(&data->set.str[STRING_TLSAUTH_PASSWORD_PROXY], ptr);
+    return Curl_setstropt(&s->str[STRING_TLSAUTH_PASSWORD_PROXY], ptr);
 #endif
   case CURLOPT_TLSAUTH_TYPE:
     if(ptr && !curl_strequal(ptr, "SRP"))
@@ -2566,25 +2592,25 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 #endif
 #ifdef CURLRES_ARES
   case CURLOPT_DNS_SERVERS:
-    result = Curl_setstropt(&data->set.str[STRING_DNS_SERVERS], ptr);
+    result = Curl_setstropt(&s->str[STRING_DNS_SERVERS], ptr);
     if(result)
       return result;
     return Curl_async_ares_set_dns_servers(data);
 
   case CURLOPT_DNS_INTERFACE:
-    result = Curl_setstropt(&data->set.str[STRING_DNS_INTERFACE], ptr);
+    result = Curl_setstropt(&s->str[STRING_DNS_INTERFACE], ptr);
     if(result)
       return result;
     return Curl_async_ares_set_dns_interface(data);
 
   case CURLOPT_DNS_LOCAL_IP4:
-    result = Curl_setstropt(&data->set.str[STRING_DNS_LOCAL_IP4], ptr);
+    result = Curl_setstropt(&s->str[STRING_DNS_LOCAL_IP4], ptr);
     if(result)
       return result;
     return Curl_async_ares_set_dns_local_ip4(data);
 
   case CURLOPT_DNS_LOCAL_IP6:
-    result = Curl_setstropt(&data->set.str[STRING_DNS_LOCAL_IP6], ptr);
+    result = Curl_setstropt(&s->str[STRING_DNS_LOCAL_IP6], ptr);
     if(result)
       return result;
     return Curl_async_ares_set_dns_local_ip6(data);
@@ -2592,27 +2618,27 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 #endif
 #ifdef USE_UNIX_SOCKETS
   case CURLOPT_UNIX_SOCKET_PATH:
-    data->set.abstract_unix_socket = FALSE;
-    return Curl_setstropt(&data->set.str[STRING_UNIX_SOCKET_PATH], ptr);
+    s->abstract_unix_socket = FALSE;
+    return Curl_setstropt(&s->str[STRING_UNIX_SOCKET_PATH], ptr);
 
   case CURLOPT_ABSTRACT_UNIX_SOCKET:
-    data->set.abstract_unix_socket = TRUE;
-    return Curl_setstropt(&data->set.str[STRING_UNIX_SOCKET_PATH], ptr);
+    s->abstract_unix_socket = TRUE;
+    return Curl_setstropt(&s->str[STRING_UNIX_SOCKET_PATH], ptr);
 
 #endif
 
 #ifndef CURL_DISABLE_DOH
   case CURLOPT_DOH_URL:
-    result = Curl_setstropt(&data->set.str[STRING_DOH], ptr);
-    data->set.doh = !!(data->set.str[STRING_DOH]);
+    result = Curl_setstropt(&s->str[STRING_DOH], ptr);
+    s->doh = !!(s->str[STRING_DOH]);
     break;
 #endif
 #ifndef CURL_DISABLE_HSTS
   case CURLOPT_HSTSREADDATA:
-    data->set.hsts_read_userp = ptr;
+    s->hsts_read_userp = ptr;
     break;
   case CURLOPT_HSTSWRITEDATA:
-    data->set.hsts_write_userp = ptr;
+    s->hsts_write_userp = ptr;
     break;
   case CURLOPT_HSTS: {
     struct curl_slist *h;
@@ -2622,7 +2648,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
         return CURLE_OUT_OF_MEMORY;
     }
     if(ptr) {
-      result = Curl_setstropt(&data->set.str[STRING_HSTS], ptr);
+      result = Curl_setstropt(&s->str[STRING_HSTS], ptr);
       if(result)
         return result;
       /* this needs to build a list of filenames to read from, so that it can
@@ -2654,7 +2680,7 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
       if(!data->asi)
         return CURLE_OUT_OF_MEMORY;
     }
-    result = Curl_setstropt(&data->set.str[STRING_ALTSVC], ptr);
+    result = Curl_setstropt(&s->str[STRING_ALTSVC], ptr);
     if(result)
       return result;
     if(ptr)
@@ -2666,35 +2692,35 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
     size_t plen = 0;
 
     if(!ptr) {
-      data->set.tls_ech = CURLECH_DISABLE;
+      s->tls_ech = CURLECH_DISABLE;
       return CURLE_OK;
     }
     plen = strlen(ptr);
     if(plen > CURL_MAX_INPUT_LENGTH) {
-      data->set.tls_ech = CURLECH_DISABLE;
+      s->tls_ech = CURLECH_DISABLE;
       return CURLE_BAD_FUNCTION_ARGUMENT;
     }
     /* set tls_ech flag value, preserving CLA_CFG bit */
     if(!strcmp(ptr, "false"))
-      data->set.tls_ech = CURLECH_DISABLE |
-        (data->set.tls_ech & CURLECH_CLA_CFG);
+      s->tls_ech = CURLECH_DISABLE |
+        (s->tls_ech & CURLECH_CLA_CFG);
     else if(!strcmp(ptr, "grease"))
-      data->set.tls_ech = CURLECH_GREASE |
-        (data->set.tls_ech & CURLECH_CLA_CFG);
+      s->tls_ech = CURLECH_GREASE |
+        (s->tls_ech & CURLECH_CLA_CFG);
     else if(!strcmp(ptr, "true"))
-      data->set.tls_ech = CURLECH_ENABLE |
-        (data->set.tls_ech & CURLECH_CLA_CFG);
+      s->tls_ech = CURLECH_ENABLE |
+        (s->tls_ech & CURLECH_CLA_CFG);
     else if(!strcmp(ptr, "hard"))
-      data->set.tls_ech = CURLECH_HARD |
-        (data->set.tls_ech & CURLECH_CLA_CFG);
+      s->tls_ech = CURLECH_HARD |
+        (s->tls_ech & CURLECH_CLA_CFG);
     else if(plen > 5 && !strncmp(ptr, "ecl:", 4)) {
-      result = Curl_setstropt(&data->set.str[STRING_ECH_CONFIG], ptr + 4);
+      result = Curl_setstropt(&s->str[STRING_ECH_CONFIG], ptr + 4);
       if(result)
         return result;
-      data->set.tls_ech |= CURLECH_CLA_CFG;
+      s->tls_ech |= CURLECH_CLA_CFG;
     }
     else if(plen > 4 && !strncmp(ptr, "pn:", 3)) {
-      result = Curl_setstropt(&data->set.str[STRING_ECH_PUBLIC], ptr + 3);
+      result = Curl_setstropt(&s->str[STRING_ECH_PUBLIC], ptr + 3);
       if(result)
         return result;
     }
@@ -2710,13 +2736,14 @@ static CURLcode setopt_cptr(struct Curl_easy *data, CURLoption option,
 static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
                             va_list param)
 {
+  struct UserDefined *s = &data->set;
   switch(option) {
   case CURLOPT_PROGRESSFUNCTION:
     /*
      * Progress callback function
      */
-    data->set.fprogress = va_arg(param, curl_progress_callback);
-    if(data->set.fprogress)
+    s->fprogress = va_arg(param, curl_progress_callback);
+    if(s->fprogress)
       data->progress.callback = TRUE; /* no longer internal */
     else
       data->progress.callback = FALSE; /* NULL enforces internal */
@@ -2726,8 +2753,8 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
     /*
      * Transfer info callback function
      */
-    data->set.fxferinfo = va_arg(param, curl_xferinfo_callback);
-    if(data->set.fxferinfo)
+    s->fxferinfo = va_arg(param, curl_xferinfo_callback);
+    if(s->fxferinfo)
       data->progress.callback = TRUE; /* no longer internal */
     else
       data->progress.callback = FALSE; /* NULL enforces internal */
@@ -2737,7 +2764,7 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
     /*
      * stderr write callback.
      */
-    data->set.fdebug = va_arg(param, curl_debug_callback);
+    s->fdebug = va_arg(param, curl_debug_callback);
     /*
      * if the callback provided is NULL, it will use the default callback
      */
@@ -2746,41 +2773,41 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
     /*
      * Set header write callback
      */
-    data->set.fwrite_header = va_arg(param, curl_write_callback);
+    s->fwrite_header = va_arg(param, curl_write_callback);
     break;
   case CURLOPT_WRITEFUNCTION:
     /*
      * Set data write callback
      */
-    data->set.fwrite_func = va_arg(param, curl_write_callback);
-    if(!data->set.fwrite_func)
+    s->fwrite_func = va_arg(param, curl_write_callback);
+    if(!s->fwrite_func)
       /* When set to NULL, reset to our internal default function */
-      data->set.fwrite_func = (curl_write_callback)fwrite;
+      s->fwrite_func = (curl_write_callback)fwrite;
     break;
   case CURLOPT_READFUNCTION:
     /*
      * Read data callback
      */
-    data->set.fread_func_set = va_arg(param, curl_read_callback);
-    if(!data->set.fread_func_set) {
-      data->set.is_fread_set = 0;
+    s->fread_func_set = va_arg(param, curl_read_callback);
+    if(!s->fread_func_set) {
+      s->is_fread_set = 0;
       /* When set to NULL, reset to our internal default function */
-      data->set.fread_func_set = (curl_read_callback)fread;
+      s->fread_func_set = (curl_read_callback)fread;
     }
     else
-      data->set.is_fread_set = 1;
+      s->is_fread_set = 1;
     break;
   case CURLOPT_SEEKFUNCTION:
     /*
      * Seek callback. Might be NULL.
      */
-    data->set.seek_func = va_arg(param, curl_seek_callback);
+    s->seek_func = va_arg(param, curl_seek_callback);
     break;
   case CURLOPT_IOCTLFUNCTION:
     /*
      * I/O control callback. Might be NULL.
      */
-    data->set.ioctl_func = va_arg(param, curl_ioctl_callback);
+    s->ioctl_func = va_arg(param, curl_ioctl_callback);
     break;
   case CURLOPT_SSL_CTX_FUNCTION:
     /*
@@ -2788,7 +2815,7 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_SSL_CTX)) {
-      data->set.ssl.fsslctx = va_arg(param, curl_ssl_ctx_callback);
+      s->ssl.fsslctx = va_arg(param, curl_ssl_ctx_callback);
       break;
     }
     else
@@ -2799,7 +2826,7 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
     /*
      * socket callback function: called after socket() but before connect()
      */
-    data->set.fsockopt = va_arg(param, curl_sockopt_callback);
+    s->fsockopt = va_arg(param, curl_sockopt_callback);
     break;
 
   case CURLOPT_OPENSOCKETFUNCTION:
@@ -2807,7 +2834,7 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
      * open/create socket callback function: called instead of socket(),
      * before connect()
      */
-    data->set.fopensocket = va_arg(param, curl_opensocket_callback);
+    s->fopensocket = va_arg(param, curl_opensocket_callback);
     break;
 
   case CURLOPT_CLOSESOCKETFUNCTION:
@@ -2815,7 +2842,7 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
      * close socket callback function: called instead of close()
      * when shutting down a connection
      */
-    data->set.fclosesocket = va_arg(param, curl_closesocket_callback);
+    s->fclosesocket = va_arg(param, curl_closesocket_callback);
     break;
 
   case CURLOPT_RESOLVER_START_FUNCTION:
@@ -2823,21 +2850,21 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
      * resolver start callback function: called before a new resolver request
      * is started
      */
-    data->set.resolver_start = va_arg(param, curl_resolver_start_callback);
+    s->resolver_start = va_arg(param, curl_resolver_start_callback);
     break;
 
 #ifdef USE_SSH
 #ifdef USE_LIBSSH2
   case CURLOPT_SSH_HOSTKEYFUNCTION:
     /* the callback to check the hostkey without the knownhost file */
-    data->set.ssh_hostkeyfunc = va_arg(param, curl_sshhostkeycallback);
+    s->ssh_hostkeyfunc = va_arg(param, curl_sshhostkeycallback);
     break;
 #endif
 
   case CURLOPT_SSH_KEYFUNCTION:
     /* setting to NULL is fine since the ssh.c functions themselves will
        then revert to use the internal default */
-    data->set.ssh_keyfunc = va_arg(param, curl_sshkeycallback);
+    s->ssh_keyfunc = va_arg(param, curl_sshkeycallback);
     break;
 
 #endif /* USE_SSH */
@@ -2845,35 +2872,35 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
 #ifndef CURL_DISABLE_RTSP
   case CURLOPT_INTERLEAVEFUNCTION:
     /* Set the user defined RTP write function */
-    data->set.fwrite_rtp = va_arg(param, curl_write_callback);
+    s->fwrite_rtp = va_arg(param, curl_write_callback);
     break;
 #endif
 #ifndef CURL_DISABLE_FTP
   case CURLOPT_CHUNK_BGN_FUNCTION:
-    data->set.chunk_bgn = va_arg(param, curl_chunk_bgn_callback);
+    s->chunk_bgn = va_arg(param, curl_chunk_bgn_callback);
     break;
   case CURLOPT_CHUNK_END_FUNCTION:
-    data->set.chunk_end = va_arg(param, curl_chunk_end_callback);
+    s->chunk_end = va_arg(param, curl_chunk_end_callback);
     break;
   case CURLOPT_FNMATCH_FUNCTION:
-    data->set.fnmatch = va_arg(param, curl_fnmatch_callback);
+    s->fnmatch = va_arg(param, curl_fnmatch_callback);
     break;
 #endif
 #ifndef CURL_DISABLE_HTTP
   case CURLOPT_TRAILERFUNCTION:
-    data->set.trailer_callback = va_arg(param, curl_trailer_callback);
+    s->trailer_callback = va_arg(param, curl_trailer_callback);
     break;
 #endif
 #ifndef CURL_DISABLE_HSTS
   case CURLOPT_HSTSREADFUNCTION:
-    data->set.hsts_read = va_arg(param, curl_hstsread_callback);
+    s->hsts_read = va_arg(param, curl_hstsread_callback);
     break;
   case CURLOPT_HSTSWRITEFUNCTION:
-    data->set.hsts_write = va_arg(param, curl_hstswrite_callback);
+    s->hsts_write = va_arg(param, curl_hstswrite_callback);
     break;
 #endif
   case CURLOPT_PREREQFUNCTION:
-    data->set.fprereq = va_arg(param, curl_prereq_callback);
+    s->fprereq = va_arg(param, curl_prereq_callback);
     break;
   default:
     return CURLE_UNKNOWN_OPTION;
@@ -2884,13 +2911,14 @@ static CURLcode setopt_func(struct Curl_easy *data, CURLoption option,
 static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
                             curl_off_t offt)
 {
+  struct UserDefined *s = &data->set;
   switch(option) {
   case CURLOPT_TIMEVALUE_LARGE:
     /*
      * This is the value to compare with the remote document with the
      * method set with CURLOPT_TIMECONDITION
      */
-    data->set.timevalue = (time_t)offt;
+    s->timevalue = (time_t)offt;
     break;
 
     /* MQTT "borrows" some of the HTTP options */
@@ -2902,13 +2930,13 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
     if(offt < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
 
-    if(data->set.postfieldsize < offt &&
-       data->set.postfields == data->set.str[STRING_COPYPOSTFIELDS]) {
+    if(s->postfieldsize < offt &&
+       s->postfields == s->str[STRING_COPYPOSTFIELDS]) {
       /* Previous CURLOPT_COPYPOSTFIELDS is no longer valid. */
-      Curl_safefree(data->set.str[STRING_COPYPOSTFIELDS]);
-      data->set.postfields = NULL;
+      Curl_safefree(s->str[STRING_COPYPOSTFIELDS]);
+      s->postfields = NULL;
     }
-    data->set.postfieldsize = offt;
+    s->postfieldsize = offt;
     break;
   case CURLOPT_INFILESIZE_LARGE:
     /*
@@ -2917,7 +2945,7 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
      */
     if(offt < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.filesize = offt;
+    s->filesize = offt;
     break;
   case CURLOPT_MAX_SEND_SPEED_LARGE:
     /*
@@ -2926,7 +2954,7 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
      */
     if(offt < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.max_send_speed = offt;
+    s->max_send_speed = offt;
     break;
   case CURLOPT_MAX_RECV_SPEED_LARGE:
     /*
@@ -2935,7 +2963,7 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
      */
     if(offt < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.max_recv_speed = offt;
+    s->max_recv_speed = offt;
     break;
   case CURLOPT_RESUME_FROM_LARGE:
     /*
@@ -2943,7 +2971,7 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
      */
     if(offt < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.set_resume_from = offt;
+    s->set_resume_from = offt;
     break;
   case CURLOPT_MAXFILESIZE_LARGE:
     /*
@@ -2951,7 +2979,7 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
      */
     if(offt < 0)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    data->set.max_filesize = offt;
+    s->max_filesize = offt;
     break;
 
   default:
@@ -2963,23 +2991,24 @@ static CURLcode setopt_offt(struct Curl_easy *data, CURLoption option,
 static CURLcode setopt_blob(struct Curl_easy *data, CURLoption option,
                             struct curl_blob *blob)
 {
+  struct UserDefined *s = &data->set;
   switch(option) {
   case CURLOPT_SSLCERT_BLOB:
     /*
      * Blob that holds file content of the SSL certificate to use
      */
-    return Curl_setblobopt(&data->set.blobs[BLOB_CERT], blob);
+    return Curl_setblobopt(&s->blobs[BLOB_CERT], blob);
 #ifndef CURL_DISABLE_PROXY
   case CURLOPT_PROXY_SSLCERT_BLOB:
     /*
      * Blob that holds file content of the SSL certificate to use for proxy
      */
-    return Curl_setblobopt(&data->set.blobs[BLOB_CERT_PROXY], blob);
+    return Curl_setblobopt(&s->blobs[BLOB_CERT_PROXY], blob);
   case CURLOPT_PROXY_SSLKEY_BLOB:
     /*
      * Blob that holds file content of the SSL key to use for proxy
      */
-    return Curl_setblobopt(&data->set.blobs[BLOB_KEY_PROXY], blob);
+    return Curl_setblobopt(&s->blobs[BLOB_KEY_PROXY], blob);
   case CURLOPT_PROXY_CAINFO_BLOB:
     /*
      * Blob that holds CA info for SSL connection proxy.
@@ -2987,21 +3016,21 @@ static CURLcode setopt_blob(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CAINFO_BLOB))
-      return Curl_setblobopt(&data->set.blobs[BLOB_CAINFO_PROXY], blob);
+      return Curl_setblobopt(&s->blobs[BLOB_CAINFO_PROXY], blob);
 #endif
     return CURLE_NOT_BUILT_IN;
   case CURLOPT_PROXY_ISSUERCERT_BLOB:
     /*
      * Blob that holds Issuer certificate to check certificates issuer
      */
-    return Curl_setblobopt(&data->set.blobs[BLOB_SSL_ISSUERCERT_PROXY],
+    return Curl_setblobopt(&s->blobs[BLOB_SSL_ISSUERCERT_PROXY],
                            blob);
 #endif
   case CURLOPT_SSLKEY_BLOB:
     /*
      * Blob that holds file content of the SSL key to use
      */
-    return Curl_setblobopt(&data->set.blobs[BLOB_KEY], blob);
+    return Curl_setblobopt(&s->blobs[BLOB_KEY], blob);
   case CURLOPT_CAINFO_BLOB:
     /*
      * Blob that holds CA info for SSL connection.
@@ -3009,14 +3038,14 @@ static CURLcode setopt_blob(struct Curl_easy *data, CURLoption option,
      */
 #ifdef USE_SSL
     if(Curl_ssl_supports(data, SSLSUPP_CAINFO_BLOB))
-      return Curl_setblobopt(&data->set.blobs[BLOB_CAINFO], blob);
+      return Curl_setblobopt(&s->blobs[BLOB_CAINFO], blob);
 #endif
     return CURLE_NOT_BUILT_IN;
   case CURLOPT_ISSUERCERT_BLOB:
     /*
      * Blob that holds Issuer certificate to check certificates issuer
      */
-    return Curl_setblobopt(&data->set.blobs[BLOB_SSL_ISSUERCERT], blob);
+    return Curl_setblobopt(&s->blobs[BLOB_SSL_ISSUERCERT], blob);
 
   default:
     return CURLE_UNKNOWN_OPTION;


### PR DESCRIPTION
- add a warning if a boolean is set to something not 1 or 0 (as it might be made to mean something else in a future)

- use 's->' in all setopt_* functions