### PR TITLE
curl: unify pointer names to global config

### DIFF
--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -80,7 +80,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
                   void *userdata)
 {
   struct OperationConfig *operation = userdata;
-  struct GlobalConfig *config = operation->global;
+  struct GlobalConfig *global = operation->global;
   FILE *output = tool_stderr;
   const char *text;
   struct timeval tv;
@@ -95,7 +95,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
 
   (void)handle; /* not used */
 
-  if(config->tracetime) {
+  if(global->tracetime) {
     tv = tvrealnow();
     msnprintf(timebuf, sizeof(timebuf), "%s.%06ld ",
               hms_for_sec(tv.tv_sec), (long)tv.tv_usec);
@@ -103,7 +103,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
   else
     timebuf[0] = 0;
 
-  if(handle && config->traceids &&
+  if(handle && global->traceids &&
      !curl_easy_getinfo(handle, CURLINFO_XFER_ID, &xfer_id) && xfer_id >= 0) {
     if(!curl_easy_getinfo(handle, CURLINFO_CONN_ID, &conn_id) &&
         conn_id >= 0) {
@@ -117,28 +117,28 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
   else
     idsbuf[0] = 0;
 
-  if(!config->trace_stream) {
+  if(!global->trace_stream) {
     /* open for append */
-    if(!strcmp("-", config->trace_dump))
-      config->trace_stream = stdout;
-    else if(!strcmp("%", config->trace_dump))
+    if(!strcmp("-", global->trace_dump))
+      global->trace_stream = stdout;
+    else if(!strcmp("%", global->trace_dump))
       /* Ok, this is somewhat hackish but we do it undocumented for now */
-      config->trace_stream = tool_stderr;
+      global->trace_stream = tool_stderr;
     else {
-      config->trace_stream = fopen(config->trace_dump, FOPEN_WRITETEXT);
-      config->trace_fopened = TRUE;
+      global->trace_stream = fopen(global->trace_dump, FOPEN_WRITETEXT);
+      global->trace_fopened = TRUE;
     }
   }
 
-  if(config->trace_stream)
-    output = config->trace_stream;
+  if(global->trace_stream)
+    output = global->trace_stream;
 
   if(!output) {
-    warnf(config, "Failed to create/open output");
+    warnf(global, "Failed to create/open output");
     return 0;
   }
 
-  if(config->tracetype == TRACE_PLAIN) {
+  if(global->tracetype == TRACE_PLAIN) {
     static bool newl = FALSE;
     static bool traced_data = FALSE;
 
@@ -181,7 +181,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
            to stderr or stdout, we do not display the alert about the data not
            being shown as the data _is_ shown then just not via this
            function */
-        if(!config->isatty ||
+        if(!global->isatty ||
            ((output != tool_stderr) && (output != stdout))) {
           if(!newl)
             log_line_start(output, timebuf, idsbuf, type);
@@ -228,7 +228,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
   }
 
   dump(timebuf, idsbuf, text, output, (unsigned char *) data, size,
-       config->tracetype, type);
+       global->tracetype, type);
   return 0;
 }
 

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -99,7 +99,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 #ifdef DEBUGBUILD
   if(size * nmemb > (size_t)CURL_MAX_HTTP_HEADER) {
-    warnf(per->config->global, "Header data exceeds single call write limit");
+    warnf(per->config->global, "Header data exceeds write limit");
     return CURL_WRITEFUNC_ERROR;
   }
 #endif

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -152,14 +152,13 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 
   if(config->show_headers) {
     if(bytes > (size_t)CURL_MAX_HTTP_HEADER) {
-      warnf(config->global, "Header data size exceeds single call write "
-            "limit");
+      warnf(config->global, "Header data size exceeds write limit");
       return CURL_WRITEFUNC_ERROR;
     }
   }
   else {
     if(bytes > (size_t)CURL_MAX_WRITE_SIZE) {
-      warnf(config->global, "Data size exceeds single call write limit");
+      warnf(config->global, "Data size exceeds write limit");
       return CURL_WRITEFUNC_ERROR;
     }
   }

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -29,10 +29,14 @@
 #include "tool_main.h"
 #include "memdebug.h" /* keep this as LAST include */
 
-void config_init(struct OperationConfig *config)
+struct OperationConfig *config_alloc(struct GlobalConfig *global)
 {
-  memset(config, 0, sizeof(struct OperationConfig));
+  struct OperationConfig *config =
+    calloc(1, sizeof(struct OperationConfig));
+  if(!config)
+    return NULL;
 
+  config->global = global;
   config->use_httpget = FALSE;
   config->create_dirs = FALSE;
   config->maxredirs = DEFAULT_MAXREDIRS;
@@ -46,6 +50,7 @@ void config_init(struct OperationConfig *config)
   config->file_clobber_mode = CLOBBER_DEFAULT;
   config->upload_flags = CURLULFLAG_SEEN;
   curlx_dyn_init(&config->postdata, MAX_FILE2MEMORY);
+  return config;
 }
 
 static void free_config_fields(struct OperationConfig *config)

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -73,8 +73,7 @@ struct State {
   char *uploadfile;
   curl_off_t infilenum; /* number of files to upload */
   curl_off_t up;        /* upload file counter within a single upload glob */
-  curl_off_t urlnum;    /* how many iterations this single URL has with ranges
-                           etc */
+  curl_off_t urlnum;    /* how many iterations this URL has with ranges etc */
   curl_off_t li;
 };
 
@@ -377,7 +376,7 @@ struct GlobalConfig {
   BIT(isatty);                    /* Updated internally if output is a tty */
 };
 
-void config_init(struct OperationConfig *config);
+struct OperationConfig *config_alloc(struct GlobalConfig *global);
 void config_free(struct OperationConfig *config);
 
 #endif /* HEADER_CURL_TOOL_CFGABLE_H */

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -170,10 +170,10 @@ CURLcode easysrc_cleanup(void)
   return ret;
 }
 
-void dumpeasysrc(struct GlobalConfig *config)
+void dumpeasysrc(struct GlobalConfig *global)
 {
   struct curl_slist *ptr;
-  char *o = config->libcurl;
+  char *o = global->libcurl;
 
   FILE *out;
   bool fopened = FALSE;
@@ -184,7 +184,7 @@ void dumpeasysrc(struct GlobalConfig *config)
   else
     out = stdout;
   if(!out)
-    warnf(config, "Failed to open %s to write libcurl code", o);
+    warnf(global, "Failed to open %s to write libcurl code", o);
   else {
     int i;
     const char *c;

--- a/src/tool_easysrc.h
+++ b/src/tool_easysrc.h
@@ -44,7 +44,7 @@ extern CURLcode easysrc_addf(struct slist_wc **plist,
 extern CURLcode easysrc_perform(void);
 extern CURLcode easysrc_cleanup(void);
 
-void dumpeasysrc(struct GlobalConfig *config);
+void dumpeasysrc(struct GlobalConfig *global);
 
 #else /* CURL_DISABLE_LIBCURL_OPTION is defined */
 

--- a/src/tool_formparse.c
+++ b/src/tool_formparse.c
@@ -223,9 +223,9 @@ size_t tool_mime_stdin_read(char *buffer,
       nitems = fread(buffer, 1, nitems, stdin);
       if(ferror(stdin)) {
         /* Show error only once. */
-        if(sip->config) {
-          warnf(sip->config, "stdin: %s", strerror(errno));
-          sip->config = NULL;
+        if(sip->global) {
+          warnf(sip->global, "stdin: %s", strerror(errno));
+          sip->global = NULL;
         }
         return CURL_READFUNC_ABORT;
       }
@@ -823,7 +823,7 @@ int formparse(struct OperationConfig *config,
           goto fail;
         part->headers = headers;
         headers = NULL;
-        part->config = config->global;
+        part->global = config->global;
         if(res == CURLE_READ_ERROR) {
             /* An error occurred while reading stdin: if read has started,
                issue the error now. Else, delay it until processed by
@@ -859,7 +859,7 @@ int formparse(struct OperationConfig *config,
           goto fail;
         part->headers = headers;
         headers = NULL;
-        part->config = config->global;
+        part->global = config->global;
         if(res == CURLE_READ_ERROR) {
             /* An error occurred while reading stdin: if read has started,
                issue the error now. Else, delay it until processed by

--- a/src/tool_formparse.h
+++ b/src/tool_formparse.h
@@ -55,7 +55,7 @@ struct tool_mime {
   curl_off_t origin;            /* Stdin read origin offset. */
   curl_off_t size;              /* Stdin data size. */
   curl_off_t curpos;            /* Stdin current read position. */
-  struct GlobalConfig *config;  /* For access from callback. */
+  struct GlobalConfig *global;  /* For access from callback. */
 };
 
 size_t tool_mime_stdin_read(char *buffer,

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2989,14 +2989,8 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
 
           if(config->url_list && config->url_list->url) {
             /* Allocate the next config */
-            config->next = malloc(sizeof(struct OperationConfig));
+            config->next = config_alloc(global);
             if(config->next) {
-              /* Initialise the newly created config */
-              config_init(config->next);
-
-              /* Set the global config pointer */
-              config->next->global = global;
-
               /* Update the last config pointer */
               global->last = config->next;
 

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -374,7 +374,7 @@ void parse_cert_parameter(const char *cert_parameter,
                           char **passphrase);
 #endif
 
-ParameterError parse_args(struct GlobalConfig *config, int argc,
+ParameterError parse_args(struct GlobalConfig *global, int argc,
                           argv_item_t argv[]);
 
 #if defined(UNICODE) && defined(_WIN32) && !defined(UNDER_CE)

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -34,19 +34,19 @@
 #define NOTE_PREFIX "Note: "
 #define ERROR_PREFIX "curl: "
 
-static void voutf(struct GlobalConfig *config,
+static void voutf(struct GlobalConfig *global,
                   const char *prefix,
                   const char *fmt,
                   va_list ap) CURL_PRINTF(3, 0);
 
-static void voutf(struct GlobalConfig *config,
+static void voutf(struct GlobalConfig *global,
                   const char *prefix,
                   const char *fmt,
                   va_list ap)
 {
   size_t width = (get_terminal_columns() - strlen(prefix));
   DEBUGASSERT(!strchr(fmt, '\n'));
-  if(!config->silent) {
+  if(!global->silent) {
     size_t len;
     char *ptr;
     char *print_buffer;
@@ -90,12 +90,12 @@ static void voutf(struct GlobalConfig *config,
  * Emit 'note' formatted message on configured 'errors' stream, if verbose was
  * selected.
  */
-void notef(struct GlobalConfig *config, const char *fmt, ...)
+void notef(struct GlobalConfig *global, const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
-  if(config->tracetype)
-    voutf(config, NOTE_PREFIX, fmt, ap);
+  if(global->tracetype)
+    voutf(global, NOTE_PREFIX, fmt, ap);
   va_end(ap);
 }
 
@@ -103,11 +103,11 @@ void notef(struct GlobalConfig *config, const char *fmt, ...)
  * Emit warning formatted message on configured 'errors' stream unless
  * mute (--silent) was selected.
  */
-void warnf(struct GlobalConfig *config, const char *fmt, ...)
+void warnf(struct GlobalConfig *global, const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
-  voutf(config, WARN_PREFIX, fmt, ap);
+  voutf(global, WARN_PREFIX, fmt, ap);
   va_end(ap);
 }
 
@@ -137,12 +137,12 @@ void helpf(FILE *errors, const char *fmt, ...)
  * Emit error message on error stream if not muted. When errors are not tied
  * to command line arguments, use helpf() for such errors.
  */
-void errorf(struct GlobalConfig *config, const char *fmt, ...)
+void errorf(struct GlobalConfig *global, const char *fmt, ...)
 {
-  if(!config->silent || config->showerror) {
+  if(!global->silent || global->showerror) {
     va_list ap;
     va_start(ap, fmt);
-    voutf(config, ERROR_PREFIX, fmt, ap);
+    voutf(global, ERROR_PREFIX, fmt, ap);
     va_end(ap);
   }
 }

--- a/src/tool_msgs.h
+++ b/src/tool_msgs.h
@@ -26,13 +26,13 @@
 #include "tool_setup.h"
 #include "tool_cfgable.h"
 
-void warnf(struct GlobalConfig *config, const char *fmt, ...)
+void warnf(struct GlobalConfig *global, const char *fmt, ...)
   CURL_PRINTF(2, 3);
-void notef(struct GlobalConfig *config, const char *fmt, ...)
+void notef(struct GlobalConfig *global, const char *fmt, ...)
   CURL_PRINTF(2, 3);
 void helpf(FILE *errors, const char *fmt, ...)
   CURL_PRINTF(2, 3);
-void errorf(struct GlobalConfig *config, const char *fmt, ...)
+void errorf(struct GlobalConfig *global, const char *fmt, ...)
   CURL_PRINTF(2, 3);
 
 #endif /* HEADER_CURL_TOOL_MSGS_H */

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -79,7 +79,7 @@ struct per_transfer {
   BIT(skip);  /* considered already done */
 };
 
-CURLcode operate(struct GlobalConfig *config, int argc, argv_item_t argv[]);
+CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[]);
 void single_transfer_cleanup(struct OperationConfig *config);
 
 extern struct per_transfer *transfers; /* first node */

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -181,14 +181,8 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       if(res == PARAM_NEXT_OPERATION) {
         if(operation->url_list && operation->url_list->url) {
           /* Allocate the next config */
-          operation->next = malloc(sizeof(struct OperationConfig));
+          operation->next = config_alloc(global);
           if(operation->next) {
-            /* Initialise the newly created config */
-            config_init(operation->next);
-
-            /* Set the global config pointer */
-            operation->next->global = global;
-
             /* Update the last operation pointer */
             global->last = operation->next;
 

--- a/src/tool_parsecfg.h
+++ b/src/tool_parsecfg.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-int parseconfig(const char *filename, struct GlobalConfig *config);
+int parseconfig(const char *filename, struct GlobalConfig *global);
 
 bool my_get_line(FILE *fp, struct dynbuf *db, bool *error);
 

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -223,7 +223,7 @@ static char *c_escape(const char *str, curl_off_t len)
 }
 
 /* setopt wrapper for enum types */
-CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *global,
                           const char *name, CURLoption tag,
                           const struct NameValue *nvlist, long lval)
 {
@@ -234,7 +234,7 @@ CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
   if(!lval)
     skip = TRUE;
 
-  if(config->libcurl && !skip && !ret) {
+  if(global->libcurl && !skip && !ret) {
     /* we only use this for real if --libcurl was used */
     const struct NameValue *nv = NULL;
     for(nv = nvlist; nv->name; nv++) {
@@ -256,13 +256,13 @@ CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
 
 #ifdef DEBUGBUILD
   if(ret)
-    warnf(config, "option %s returned error (%d)", name, (int)ret);
+    warnf(global, "option %s returned error (%d)", name, (int)ret);
 #endif
   return ret;
 }
 
 /* setopt wrapper for CURLOPT_SSLVERSION */
-CURLcode tool_setopt_SSLVERSION(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_SSLVERSION(CURL *curl, struct GlobalConfig *global,
                                 const char *name, CURLoption tag,
                                 long lval)
 {
@@ -273,7 +273,7 @@ CURLcode tool_setopt_SSLVERSION(CURL *curl, struct GlobalConfig *config,
   if(!lval)
     skip = TRUE;
 
-  if(config->libcurl && !skip && !ret) {
+  if(global->libcurl && !skip && !ret) {
     /* we only use this for real if --libcurl was used */
     const struct NameValue *nv = NULL;
     const struct NameValue *nv2 = NULL;
@@ -301,13 +301,13 @@ CURLcode tool_setopt_SSLVERSION(CURL *curl, struct GlobalConfig *config,
 
 #ifdef DEBUGBUILD
   if(ret)
-    warnf(config, "option %s returned error (%d)", name, (int)ret);
+    warnf(global, "option %s returned error (%d)", name, (int)ret);
 #endif
   return ret;
 }
 
 /* setopt wrapper for bitmasks */
-CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *global,
                              const char *name, CURLoption tag,
                              const struct NameValueUnsigned *nvlist,
                              long lval)
@@ -317,7 +317,7 @@ CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
   if(!lval)
     skip = TRUE;
 
-  if(config->libcurl && !skip && !ret) {
+  if(global->libcurl && !skip && !ret) {
     /* we only use this for real if --libcurl was used */
     char preamble[80];
     unsigned long rest = (unsigned long)lval;
@@ -379,13 +379,13 @@ static CURLcode libcurl_generate_slist(struct curl_slist *slist, int *slistno)
 }
 
 static CURLcode libcurl_generate_mime(CURL *curl,
-                                      struct GlobalConfig *config,
+                                      struct GlobalConfig *global,
                                       struct tool_mime *toolmime,
                                       int *mimeno);     /* Forward. */
 
 /* Wrapper to generate source code for a mime part. */
 static CURLcode libcurl_generate_mime_part(CURL *curl,
-                                           struct GlobalConfig *config,
+                                           struct GlobalConfig *global,
                                            struct tool_mime *part,
                                            int mimeno)
 {
@@ -396,7 +396,7 @@ static CURLcode libcurl_generate_mime_part(CURL *curl,
 
   /* Parts are linked in reverse order. */
   if(part->prev)
-    ret = libcurl_generate_mime_part(curl, config, part->prev, mimeno);
+    ret = libcurl_generate_mime_part(curl, global, part->prev, mimeno);
 
   /* Create the part. */
   if(!ret)
@@ -407,7 +407,7 @@ static CURLcode libcurl_generate_mime_part(CURL *curl,
 
   switch(part->kind) {
   case TOOLMIME_PARTS:
-    ret = libcurl_generate_mime(curl, config, part, &submimeno);
+    ret = libcurl_generate_mime(curl, global, part, &submimeno);
     if(!ret) {
       ret = easysrc_addf(&easysrc_code, "curl_mime_subparts(part%d, mime%d);",
                          mimeno, submimeno);
@@ -507,7 +507,7 @@ static CURLcode libcurl_generate_mime_part(CURL *curl,
 
 /* Wrapper to generate source code for a mime structure. */
 static CURLcode libcurl_generate_mime(CURL *curl,
-                                      struct GlobalConfig *config,
+                                      struct GlobalConfig *global,
                                       struct tool_mime *toolmime,
                                       int *mimeno)
 {
@@ -529,7 +529,7 @@ static CURLcode libcurl_generate_mime(CURL *curl,
   if(toolmime->subparts && !ret) {
     ret = easysrc_addf(&easysrc_decl, "curl_mimepart *part%d;", *mimeno);
     if(!ret)
-      ret = libcurl_generate_mime_part(curl, config,
+      ret = libcurl_generate_mime_part(curl, global,
                                        toolmime->subparts, *mimeno);
   }
 
@@ -537,16 +537,16 @@ static CURLcode libcurl_generate_mime(CURL *curl,
 }
 
 /* setopt wrapper for CURLOPT_MIMEPOST */
-CURLcode tool_setopt_mimepost(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_mimepost(CURL *curl, struct GlobalConfig *global,
                               const char *name, CURLoption tag,
                               curl_mime *mimepost)
 {
   CURLcode ret = curl_easy_setopt(curl, tag, mimepost);
   int mimeno = 0;
 
-  if(!ret && config->libcurl) {
-    ret = libcurl_generate_mime(curl, config,
-                                config->current->mimeroot, &mimeno);
+  if(!ret && global->libcurl) {
+    ret = libcurl_generate_mime(curl, global,
+                                global->current->mimeroot, &mimeno);
 
     if(!ret)
       ret = easysrc_addf(&easysrc_code, "curl_easy_setopt(hnd, %s, mime%d);",
@@ -557,7 +557,7 @@ CURLcode tool_setopt_mimepost(CURL *curl, struct GlobalConfig *config,
 }
 
 /* setopt wrapper for curl_slist options */
-CURLcode tool_setopt_slist(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_slist(CURL *curl, struct GlobalConfig *global,
                            const char *name, CURLoption tag,
                            struct curl_slist *list)
 {
@@ -565,7 +565,7 @@ CURLcode tool_setopt_slist(CURL *curl, struct GlobalConfig *config,
 
   ret = curl_easy_setopt(curl, tag, list);
 
-  if(config->libcurl && list && !ret) {
+  if(global->libcurl && list && !ret) {
     int i;
 
     ret = libcurl_generate_slist(list, &i);

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -75,22 +75,22 @@ extern const struct NameValueUnsigned setopt_nv_CURLHSTS[];
 
 /* Intercept setopt calls for --libcurl */
 
-CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *global,
                           const char *name, CURLoption tag,
                           const struct NameValue *nv, long lval);
-CURLcode tool_setopt_SSLVERSION(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_SSLVERSION(CURL *curl, struct GlobalConfig *global,
                                 const char *name, CURLoption tag,
                                 long lval);
-CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *global,
                            const char *name, CURLoption tag,
                            const struct NameValue *nv, long lval);
-CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *global,
                              const char *name, CURLoption tag,
                              const struct NameValueUnsigned *nv, long lval);
-CURLcode tool_setopt_mimepost(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_mimepost(CURL *curl, struct GlobalConfig *global,
                               const char *name, CURLoption tag,
                               curl_mime *mimepost);
-CURLcode tool_setopt_slist(CURL *curl, struct GlobalConfig *config,
+CURLcode tool_setopt_slist(CURL *curl, struct GlobalConfig *global,
                            const char *name, CURLoption tag,
                            struct curl_slist *list);
 CURLcode tool_setopt_long(CURL *curl, struct GlobalConfig *global,

--- a/tests/data/test96
+++ b/tests/data/test96
@@ -31,6 +31,7 @@ curl memory tracking operational
 # Verify data after the test has been "shot"
 <verify>
 <file name="%LOGDIR/memdump">
+MEM tool_cfgable.c
 MEM tool_paramhlp.c
 MEM tool_cfgable.c
 MEM tool_cfgable.c


### PR DESCRIPTION
Use 'config' for pointing to a OperationConfig

Use 'global' for pointing to GlobalConfig

Bonus: add config_alloc(), an easier way to allocate + init a new OperationConfig struct.