### PR TITLE
tidy-up: `Curl_thread_create()` callback return type

### DIFF
--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -202,7 +202,7 @@ err_exit:
  * For builds without ARES, but with USE_IPV6, create a resolver thread
  * and wait on it.
  */
-static CURL_THREAD_RESULT_T CURL_STDCALL getaddrinfo_thread(void *arg)
+static CURL_THREAD_RETURN_T CURL_STDCALL getaddrinfo_thread(void *arg)
 {
   struct async_thrdd_addr_ctx *addr_ctx = arg;
   char service[12];
@@ -256,7 +256,7 @@ static CURL_THREAD_RESULT_T CURL_STDCALL getaddrinfo_thread(void *arg)
 /*
  * gethostbyname_thread() resolves a name and then exits.
  */
-static CURL_THREAD_RESULT_T CURL_STDCALL gethostbyname_thread(void *arg)
+static CURL_THREAD_RETURN_T CURL_STDCALL gethostbyname_thread(void *arg)
 {
   struct async_thrdd_addr_ctx *addr_ctx = arg;
   bool all_gone;

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -59,7 +59,7 @@ static void *curl_thread_create_thunk(void *arg)
   return 0;
 }
 
-curl_thread_t Curl_thread_create(CURL_THREAD_RESULT_T
+curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
                                  (CURL_STDCALL *func) (void *), void *arg)
 {
   curl_thread_t t = malloc(sizeof(pthread_t));
@@ -102,7 +102,7 @@ int Curl_thread_join(curl_thread_t *hnd)
 
 #elif defined(USE_THREADS_WIN32)
 
-curl_thread_t Curl_thread_create(CURL_THREAD_RESULT_T
+curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
                                  (CURL_STDCALL *func) (void *), void *arg)
 {
 #if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -53,14 +53,14 @@
 #endif
 
 #if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
-#define CURL_THREAD_RESULT_T DWORD
+#define CURL_THREAD_RETURN_T DWORD
 #else
-#define CURL_THREAD_RESULT_T unsigned int
+#define CURL_THREAD_RETURN_T unsigned int
 #endif
 
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
 
-curl_thread_t Curl_thread_create(CURL_THREAD_RESULT_T
+curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
                                  (CURL_STDCALL *func) (void *), void *arg);
 
 void Curl_thread_destroy(curl_thread_t *hnd);

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -68,7 +68,7 @@ static size_t write_memory_callback(char *contents, size_t size,
   return realsize;
 }
 
-static CURL_THREAD_RESULT_T CURL_STDCALL test_thread(void *ptr)
+static CURL_THREAD_RETURN_T CURL_STDCALL test_thread(void *ptr)
 {
   struct Ctx *ctx = (struct Ctx *)ptr;
   CURLcode res = CURLE_OK;


### PR DESCRIPTION
Replace repeat `#ifdef` code with a macro for the return type of
the thread function.

Also:
- always define `CURL_STDCALL`, allowing to use it without guards.
- lib1307: drop single-use macro `CAINFO`.
