### PR TITLE
curl: remove the global argument from many functions

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -520,7 +520,6 @@ static CURLcode http_setopts(struct OperationConfig *config,
 static CURLcode cookie_setopts(struct OperationConfig *config, CURL *curl)
 {
   CURLcode result = CURLE_OK;
-  struct GlobalConfig *global = config->global;
   if(config->cookies) {
     struct dynbuf cookies;
     struct curl_slist *cl;
@@ -535,7 +534,7 @@ static CURLcode cookie_setopts(struct OperationConfig *config, CURL *curl)
         result = curlx_dyn_addf(&cookies, ";%s", cl->data);
 
       if(result) {
-        warnf(global,
+        warnf(config->global,
               "skipped provided cookie, the cookie header "
               "would go over %u bytes", MAX_COOKIE_LINE);
         return result;
@@ -629,8 +628,7 @@ static CURLcode ftp_setopts(struct OperationConfig *config, CURL *curl)
 
 static void gen_trace_setopts(struct OperationConfig *config, CURL *curl)
 {
-  struct GlobalConfig *global = config->global;
-  if(global->tracetype != TRACE_NONE) {
+  if(config->global->tracetype != TRACE_NONE) {
     my_setopt(curl, CURLOPT_DEBUGFUNCTION, tool_debug_cb);
     my_setopt(curl, CURLOPT_DEBUGDATA, config);
     my_setopt_long(curl, CURLOPT_VERBOSE, 1L);
@@ -680,12 +678,11 @@ static void gen_cb_setopts(struct OperationConfig *config,
 
 static CURLcode proxy_setopts(struct OperationConfig *config, CURL *curl)
 {
-  struct GlobalConfig *global = config->global;
   if(config->proxy) {
     CURLcode result = my_setopt_str(curl, CURLOPT_PROXY, config->proxy);
 
     if(result) {
-      errorf(global, "proxy support is disabled in this libcurl");
+      errorf(config->global, "proxy support is disabled in this libcurl");
       config->synthetic_error = TRUE;
       return CURLE_NOT_BUILT_IN;
     }

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -171,10 +171,9 @@ static CURLcode url_proto_and_rewrite(char **url,
   return result;
 }
 
-static CURLcode ssh_setopts(struct GlobalConfig *global,
-                            struct OperationConfig *config,
-                            CURL *curl)
+static CURLcode ssh_setopts(struct OperationConfig *config, CURL *curl)
 {
+  struct GlobalConfig *global = config->global;
   CURLcode result;
 
   /* SSH and SSL private key uses same command-line option */
@@ -231,10 +230,9 @@ extern const unsigned char curl_ca_embed[];
 #endif
 
 /* only called if libcurl supports TLS */
-static CURLcode ssl_setopts(struct GlobalConfig *global,
-                            struct OperationConfig *config,
-                            CURL *curl)
+static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
 {
+  struct GlobalConfig *global = config->global;
   CURLcode result = CURLE_OK;
 
   if(config->cacert)
@@ -461,12 +459,10 @@ static CURLcode ssl_setopts(struct GlobalConfig *global,
 }
 
 /* only called for HTTP transfers */
-static CURLcode http_setopts(struct GlobalConfig *global,
-                             struct OperationConfig *config,
+static CURLcode http_setopts(struct OperationConfig *config,
                              CURL *curl)
 {
   long postRedir = 0;
-  (void) global; /* for builds without --libcurl */
 
   my_setopt_long(curl, CURLOPT_FOLLOWLOCATION,
                  config->followlocation);
@@ -521,11 +517,10 @@ static CURLcode http_setopts(struct GlobalConfig *global,
   return CURLE_OK;
 }
 
-static CURLcode cookie_setopts(struct GlobalConfig *global,
-                               struct OperationConfig *config,
-                               CURL *curl)
+static CURLcode cookie_setopts(struct OperationConfig *config, CURL *curl)
 {
   CURLcode result = CURLE_OK;
+  struct GlobalConfig *global = config->global;
   if(config->cookies) {
     struct dynbuf cookies;
     struct curl_slist *cl;
@@ -568,11 +563,9 @@ static CURLcode cookie_setopts(struct GlobalConfig *global,
   return result;
 }
 
-static CURLcode tcp_setopts(struct GlobalConfig *global,
-                            struct OperationConfig *config,
+static CURLcode tcp_setopts(struct OperationConfig *config,
                             CURL *curl)
 {
-  (void) global; /* for builds without --libcurl */
   if(!config->tcp_nodelay)
     my_setopt_long(curl, CURLOPT_TCP_NODELAY, 0);
 
@@ -597,11 +590,8 @@ static CURLcode tcp_setopts(struct GlobalConfig *global,
   return CURLE_OK;
 }
 
-static CURLcode ftp_setopts(struct GlobalConfig *global,
-                            struct OperationConfig *config,
-                            CURL *curl)
+static CURLcode ftp_setopts(struct OperationConfig *config, CURL *curl)
 {
-  (void) global; /* for builds without --libcurl */
   my_setopt_str(curl, CURLOPT_FTPPORT, config->ftpport);
 
   /* new in libcurl 7.9.2: */
@@ -637,10 +627,9 @@ static CURLcode ftp_setopts(struct GlobalConfig *global,
   return CURLE_OK;
 }
 
-static void gen_trace_setopts(struct GlobalConfig *global,
-                              struct OperationConfig *config,
-                              CURL *curl)
+static void gen_trace_setopts(struct OperationConfig *config, CURL *curl)
 {
+  struct GlobalConfig *global = config->global;
   if(global->tracetype != TRACE_NONE) {
     my_setopt(curl, CURLOPT_DEBUGFUNCTION, tool_debug_cb);
     my_setopt(curl, CURLOPT_DEBUGDATA, config);
@@ -648,12 +637,11 @@ static void gen_trace_setopts(struct GlobalConfig *global,
   }
 }
 
-static void gen_cb_setopts(struct GlobalConfig *global,
-                           struct OperationConfig *config,
+static void gen_cb_setopts(struct OperationConfig *config,
                            struct per_transfer *per,
                            CURL *curl)
 {
-  (void) global; /* for builds without --libcurl */
+  struct GlobalConfig *global = config->global;
   (void) config;
   /* where to store */
   my_setopt(curl, CURLOPT_WRITEDATA, per);
@@ -690,12 +678,9 @@ static void gen_cb_setopts(struct GlobalConfig *global,
   my_setopt(curl, CURLOPT_HEADERDATA, per);
 }
 
-static CURLcode proxy_setopts(struct GlobalConfig *global,
-                              struct OperationConfig *config,
-                              CURL *curl)
+static CURLcode proxy_setopts(struct OperationConfig *config, CURL *curl)
 {
-  (void) global; /* for builds without --libcurl */
-
+  struct GlobalConfig *global = config->global;
   if(config->proxy) {
     CURLcode result = my_setopt_str(curl, CURLOPT_PROXY, config->proxy);
 
@@ -753,11 +738,8 @@ static CURLcode proxy_setopts(struct GlobalConfig *global,
   return CURLE_OK;
 }
 
-static void tls_srp_setopts(struct GlobalConfig *global,
-                            struct OperationConfig *config,
-                            CURL *curl)
+static void tls_srp_setopts(struct OperationConfig *config, CURL *curl)
 {
-  (void) global; /* for builds without --libcurl */
   if(config->tls_username)
     my_setopt_str(curl, CURLOPT_TLSAUTH_USERNAME, config->tls_username);
   if(config->tls_password)
@@ -775,12 +757,12 @@ static void tls_srp_setopts(struct GlobalConfig *global,
                   config->proxy_tls_authtype);
 }
 
-CURLcode config2setopts(struct GlobalConfig *global,
-                        struct OperationConfig *config,
+CURLcode config2setopts(struct OperationConfig *config,
                         struct per_transfer *per,
                         CURL *curl,
                         CURLSH *share)
 {
+  struct GlobalConfig *global = config->global;
   const char *use_proto;
   CURLcode result = url_proto_and_rewrite(&per->url, config, &use_proto);
 
@@ -801,7 +783,7 @@ CURLcode config2setopts(struct GlobalConfig *global,
     return result;
 #endif
 
-  gen_trace_setopts(global, config, curl);
+  gen_trace_setopts(config, curl);
 
   {
 #ifdef DEBUGBUILD
@@ -825,7 +807,7 @@ CURLcode config2setopts(struct GlobalConfig *global,
   my_setopt_long(curl, CURLOPT_NOPROGRESS,
                  global->noprogress || global->silent);
   /* call after the line above. It may override CURLOPT_NOPROGRESS */
-  gen_cb_setopts(global, config, per, curl);
+  gen_cb_setopts(config, per, curl);
 
   if(config->no_body)
     my_setopt_long(curl, CURLOPT_NOBODY, 1);
@@ -833,7 +815,7 @@ CURLcode config2setopts(struct GlobalConfig *global,
   if(config->oauth_bearer)
     my_setopt_str(curl, CURLOPT_XOAUTH2_BEARER, config->oauth_bearer);
 
-  result = proxy_setopts(global, config, curl);
+  result = proxy_setopts(config, curl);
   if(result)
     return result;
 
@@ -913,15 +895,15 @@ CURLcode config2setopts(struct GlobalConfig *global,
   }
 
   if(use_proto == proto_http || use_proto == proto_https) {
-    result = http_setopts(global, config, curl);
+    result = http_setopts(config, curl);
     if(!result)
-      result = cookie_setopts(global, config, curl);
+      result = cookie_setopts(config, curl);
     if(result)
       return result;
   }
 
   if(use_proto == proto_ftp || use_proto == proto_ftps) {
-    result = ftp_setopts(global, config, curl);
+    result = ftp_setopts(config, curl);
     if(result)
       return result;
   }
@@ -940,13 +922,13 @@ CURLcode config2setopts(struct GlobalConfig *global,
   my_setopt_str(curl, CURLOPT_PROXY_KEYPASSWD, config->proxy_key_passwd);
 
   if(use_proto == proto_scp || use_proto == proto_sftp) {
-    result = ssh_setopts(global, config, curl);
+    result = ssh_setopts(config, curl);
     if(result)
       return result;
   }
 
   if(feature_ssl) {
-    result = ssl_setopts(global, config, curl);
+    result = ssl_setopts(config, curl);
     if(result)
       return result;
   }
@@ -1036,7 +1018,7 @@ CURLcode config2setopts(struct GlobalConfig *global,
     my_setopt_long(curl, CURLOPT_HTTP_TRANSFER_DECODING, 0);
   }
 
-  result = tcp_setopts(global, config, curl);
+  result = tcp_setopts(config, curl);
   if(result)
     return result;
 
@@ -1072,7 +1054,7 @@ CURLcode config2setopts(struct GlobalConfig *global,
 
   /* new in 7.21.4 */
   if(feature_tls_srp)
-    tls_srp_setopts(global, config, curl);
+    tls_srp_setopts(config, curl);
 
   /* new in 7.22.0 */
   if(config->gssapi_delegation)

--- a/src/config2setopts.h
+++ b/src/config2setopts.h
@@ -24,8 +24,7 @@
  *
  ***************************************************************************/
 
-CURLcode config2setopts(struct GlobalConfig *global,
-                        struct OperationConfig *config,
+CURLcode config2setopts(struct OperationConfig *config,
                         struct per_transfer *per,
                         CURL *curl,
                         CURLSH *share);

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -365,8 +365,7 @@ const struct LongShort *findshortopt(char letter);
 
 ParameterError getparameter(const char *flag, const char *nextarg,
                             bool *usedarg,
-                            struct GlobalConfig *global,
-                            struct OperationConfig *operation);
+                            struct OperationConfig *config);
 
 #ifdef UNITTESTS
 void parse_cert_parameter(const char *cert_parameter,

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -270,9 +270,10 @@ static CURLcode pre_transfer(struct GlobalConfig *global,
   curl_off_t uploadfilesize = -1;
   struct_stat fileinfo;
   CURLcode result = CURLE_OK;
-  struct OperationConfig *config = global->current;
 #ifdef CURL_DISABLE_LIBCURL_OPTION
   (void)global; /* otherwise used in the my_setopt macros */
+#else
+  struct OperationConfig *config = global->current;
 #endif
 
   if(per->uploadfile && !stdin_upload(per->uploadfile)) {

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -46,7 +46,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
   FILE *file = NULL;
   bool usedarg = FALSE;
   int rc = 0;
-  struct OperationConfig *operation = global->last;
+  struct OperationConfig *config = global->last;
   char *pathalloc = NULL;
 
   if(!filename) {
@@ -156,9 +156,9 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
           case '#': /* comment */
             break;
           default:
-            warnf(operation->global, "%s:%d: warning: '%s' uses unquoted "
+            warnf(config->global, "%s:%d: warning: '%s' uses unquoted "
                   "whitespace", filename, lineno, option);
-            warnf(operation->global, "This may cause side-effects. "
+            warnf(config->global, "This may cause side-effects. "
                   "Consider using double quotes?");
           }
         }
@@ -171,24 +171,24 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
 #ifdef DEBUG_CONFIG
       fprintf(tool_stderr, "PARAM: \"%s\"\n",(param ? param : "(null)"));
 #endif
-      res = getparameter(option, param, &usedarg, global, operation);
-      operation = global->last;
+      res = getparameter(option, param, &usedarg, config);
+      config = global->last;
 
       if(!res && param && *param && !usedarg)
         /* we passed in a parameter that was not used! */
         res = PARAM_GOT_EXTRA_PARAMETER;
 
       if(res == PARAM_NEXT_OPERATION) {
-        if(operation->url_list && operation->url_list->url) {
+        if(config->url_list && config->url_list->url) {
           /* Allocate the next config */
-          operation->next = config_alloc(global);
-          if(operation->next) {
+          config->next = config_alloc(global);
+          if(config->next) {
             /* Update the last operation pointer */
-            global->last = operation->next;
+            global->last = config->next;
 
             /* Move onto the new config */
-            operation->next->prev = operation;
-            operation = operation->next;
+            config->next->prev = config;
+            config = config->next;
           }
           else
             res = PARAM_NO_MEM;
@@ -206,7 +206,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
            res != PARAM_ENGINES_REQUESTED &&
            res != PARAM_CA_EMBED_REQUESTED) {
           const char *reason = param2text(res);
-          errorf(operation->global, "%s:%d: '%s' %s",
+          errorf(config->global, "%s:%d: '%s' %s",
                  filename, lineno, option, reason);
           rc = (int)res;
         }

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -75,60 +75,60 @@ extern const struct NameValueUnsigned setopt_nv_CURLHSTS[];
 
 /* Intercept setopt calls for --libcurl */
 
-CURLcode tool_setopt_enum(CURL *curl, struct GlobalConfig *global,
+CURLcode tool_setopt_enum(CURL *curl, struct OperationConfig *config,
                           const char *name, CURLoption tag,
                           const struct NameValue *nv, long lval);
-CURLcode tool_setopt_SSLVERSION(CURL *curl, struct GlobalConfig *global,
+CURLcode tool_setopt_SSLVERSION(CURL *curl, struct OperationConfig *config,
                                 const char *name, CURLoption tag,
                                 long lval);
-CURLcode tool_setopt_flags(CURL *curl, struct GlobalConfig *global,
+CURLcode tool_setopt_flags(CURL *curl, struct OperationConfig *config,
                            const char *name, CURLoption tag,
                            const struct NameValue *nv, long lval);
-CURLcode tool_setopt_bitmask(CURL *curl, struct GlobalConfig *global,
+CURLcode tool_setopt_bitmask(CURL *curl, struct OperationConfig *config,
                              const char *name, CURLoption tag,
                              const struct NameValueUnsigned *nv, long lval);
-CURLcode tool_setopt_mimepost(CURL *curl, struct GlobalConfig *global,
+CURLcode tool_setopt_mimepost(CURL *curl, struct OperationConfig *config,
                               const char *name, CURLoption tag,
                               curl_mime *mimepost);
-CURLcode tool_setopt_slist(CURL *curl, struct GlobalConfig *global,
+CURLcode tool_setopt_slist(CURL *curl, struct OperationConfig *config,
                            const char *name, CURLoption tag,
                            struct curl_slist *list);
-CURLcode tool_setopt_long(CURL *curl, struct GlobalConfig *global,
+CURLcode tool_setopt_long(CURL *curl, struct OperationConfig *config,
                           const char *name, CURLoption tag,
                           long lval);
-CURLcode tool_setopt_offt(CURL *curl, struct GlobalConfig *global,
+CURLcode tool_setopt_offt(CURL *curl, struct OperationConfig *config,
                           const char *name, CURLoption tag,
                           curl_off_t lval);
-CURLcode tool_setopt(CURL *curl, bool str, struct GlobalConfig *global,
+CURLcode tool_setopt(CURL *curl, bool str,
                      struct OperationConfig *config,
                      const char *name, CURLoption tag, ...);
 
 #define my_setopt(x,y,z) \
-  tool_setopt(x, FALSE, global, config, #y, y, z)
+  tool_setopt(x, FALSE, config, #y, y, z)
 
 #define my_setopt_long(x,y,z) \
-  tool_setopt_long(x, global, #y, y, z)
+  tool_setopt_long(x, config, #y, y, z)
 
 #define my_setopt_offt(x,y,z) \
-  tool_setopt_offt(x, global, #y, y, z)
+  tool_setopt_offt(x, config, #y, y, z)
 
 #define my_setopt_str(x,y,z) \
-  tool_setopt(x, TRUE, global, config, #y, y, z)
+  tool_setopt(x, TRUE, config, #y, y, z)
 
 #define my_setopt_enum(x,y,z) \
-  tool_setopt_enum(x, global, #y, y, setopt_nv_ ## y, z)
+  tool_setopt_enum(x, config, #y, y, setopt_nv_ ## y, z)
 
 #define my_setopt_SSLVERSION(x,y,z) \
-  tool_setopt_SSLVERSION(x, global, #y, y, z)
+  tool_setopt_SSLVERSION(x, config, #y, y, z)
 
 #define my_setopt_bitmask(x,y,z) \
-  tool_setopt_bitmask(x, global, #y, y, setopt_nv_ ## y, z)
+  tool_setopt_bitmask(x, config, #y, y, setopt_nv_ ## y, z)
 
 #define my_setopt_mimepost(x,y,z) \
-  tool_setopt_mimepost(x, global, #y, y, z)
+  tool_setopt_mimepost(x, config, #y, y, z)
 
 #define my_setopt_slist(x,y,z) \
-  tool_setopt_slist(x, global, #y, y, z)
+  tool_setopt_slist(x, config, #y, y, z)
 
 #else /* CURL_DISABLE_LIBCURL_OPTION */
 

--- a/src/tool_ssls.c
+++ b/src/tool_ssls.c
@@ -34,11 +34,11 @@
 #define MAX_SSLS_LINE (64 * 1024)
 
 
-static CURLcode tool_ssls_easy(struct GlobalConfig *global,
-                               struct OperationConfig *config,
+static CURLcode tool_ssls_easy(struct OperationConfig *config,
                                CURLSH *share, CURL **peasy)
 {
   CURLcode result = CURLE_OK;
+  struct GlobalConfig *global = config->global;
 
   *peasy = curl_easy_init();
   if(!*peasy)
@@ -53,8 +53,7 @@ static CURLcode tool_ssls_easy(struct GlobalConfig *global,
   return result;
 }
 
-CURLcode tool_ssls_load(struct GlobalConfig *global,
-                        struct OperationConfig *config,
+CURLcode tool_ssls_load(struct OperationConfig *config,
                         CURLSH *share, const char *filename)
 {
   FILE *fp;
@@ -66,6 +65,7 @@ CURLcode tool_ssls_load(struct GlobalConfig *global,
   CURLcode r = CURLE_OK;
   int i, imported;
   bool error = FALSE;
+  struct GlobalConfig *global = config->global;
 
   curlx_dyn_init(&buf, MAX_SSLS_LINE);
   fp = fopen(filename, FOPEN_READTEXT);
@@ -74,7 +74,7 @@ CURLcode tool_ssls_load(struct GlobalConfig *global,
     goto out;
   }
 
-  r = tool_ssls_easy(global, config, share, &easy);
+  r = tool_ssls_easy(config, share, &easy);
   if(r)
     goto out;
 
@@ -187,23 +187,23 @@ out:
   return r;
 }
 
-CURLcode tool_ssls_save(struct GlobalConfig *global,
-                        struct OperationConfig *config,
+CURLcode tool_ssls_save(struct OperationConfig *config,
                         CURLSH *share, const char *filename)
 {
   struct tool_ssls_ctx ctx;
   CURL *easy = NULL;
   CURLcode r = CURLE_OK;
 
-  ctx.global = global;
+  ctx.global = config->global;
   ctx.exported = 0;
   ctx.fp = fopen(filename, FOPEN_WRITETEXT);
   if(!ctx.fp) {
-    warnf(global, "Warning: Failed to create SSL session file %s", filename);
+    warnf(config->global, "Warning: Failed to create SSL session file %s",
+          filename);
     goto out;
   }
 
-  r = tool_ssls_easy(global, config, share, &easy);
+  r = tool_ssls_easy(config, share, &easy);
   if(r)
     goto out;
 

--- a/src/tool_ssls.h
+++ b/src/tool_ssls.h
@@ -27,11 +27,9 @@
 #include "tool_operate.h"
 
 
-CURLcode tool_ssls_load(struct GlobalConfig *global,
-                        struct OperationConfig *config,
+CURLcode tool_ssls_load(struct OperationConfig *config,
                         CURLSH *share, const char *filename);
-CURLcode tool_ssls_save(struct GlobalConfig *global,
-                        struct OperationConfig *config,
+CURLcode tool_ssls_save(struct OperationConfig *config,
                         CURLSH *share, const char *filename);
 
 #endif /* HEADER_CURL_TOOL_SSLS_H */


### PR DESCRIPTION
Since the config struct has a pointer to it, both pointers don't need to be passed on.