### PR TITLE
test1222: fix for out-of-tree and no-libcurl-manual builds

### DIFF
--- a/tests/data/test1222
+++ b/tests/data/test1222
@@ -17,7 +17,7 @@ Verify deprecation statuses and versions
 </name>
 
 <command type="perl">
-%SRCDIR/test1222.pl %SRCDIR/..
+%SRCDIR/test1222.pl %SRCDIR/.. %PWD/..
 </command>
 </client>
 

--- a/tests/test1222.pl
+++ b/tests/test1222.pl
@@ -255,7 +255,7 @@ while(<$fh>) {
 close($fh);
 
 if(!glob("$libdocdir/*.3")) {
-    print("curl likely built without the libcurl manual. Skipping test 1222.\n");
+    print("curl built without the libcurl manual. Skipping test 1222.\n");
     exit 0;
 }
 

--- a/tests/test1222.pl
+++ b/tests/test1222.pl
@@ -32,10 +32,13 @@ use warnings;
 
 use File::Basename;
 
-my $root=$ARGV[0] || ".";
+my $root = $ARGV[0] || ".";
+my $bldroot = $ARGV[1] || ".";
+
 my $incdir = "$root/include/curl";
-my $docdir = "$root/docs";
+my $docdir = "$bldroot/docs";
 my $libdocdir = "$docdir/libcurl";
+
 my $errcode = 0;
 
 # Symbol-indexed hashes.
@@ -237,8 +240,8 @@ sub scan_man_page {
 
 
 # Read symbols-in-versions.
-open(my $fh, "<", "$libdocdir/symbols-in-versions") ||
-  die "$libdocdir/symbols-in-versions";
+open(my $fh, "<", "$root/docs/libcurl/symbols-in-versions") ||
+  die "$root/docs/libcurl/symbols-in-versions";
 while(<$fh>) {
     if($_ =~ /^((?:CURL|LIBCURL)\S+)\s+\S+\s*(\S*)\s*(\S*)$/) {
         if($3 eq "") {

--- a/tests/test1222.pl
+++ b/tests/test1222.pl
@@ -254,6 +254,11 @@ while(<$fh>) {
 }
 close($fh);
 
+if(!glob("$libdocdir/*.3")) {
+    print("curl likely built without the libcurl manual. Skipping test 1222.\n");
+    exit 0;
+}
+
 # Get header file names,
 opendir(my $dh, $incdir) || die "Can't opendir $incdir";
 my @hfiles = grep { /\.h$/ } readdir($dh);

--- a/tests/test1222.pl
+++ b/tests/test1222.pl
@@ -255,7 +255,7 @@ while(<$fh>) {
 close($fh);
 
 if(!glob("$libdocdir/*.3")) {
-    print("curl built without the libcurl manual. Skipping test 1222.\n");
+    print "curl built without the libcurl manual. Skipping test 1222.\n";
     exit 0;
 }
 


### PR DESCRIPTION
Before this patch this test succeeded silently and unconditionally,
when run on an out-of-tree curl build.

Also fix to exit gracefully if no libcurl manuals are found.

Fixing:
```
readline() on closed filehandle $m at ../../tests/test1222.pl line 153.
```

Cherry-picked from #17877
