### PR TITLE
altsvc: stop `time()` debug override at the end of source

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -665,4 +665,8 @@ bool Curl_altsvc_lookup(struct altsvcinfo *asi,
   return FALSE;
 }
 
+#if defined(DEBUGBUILD) || defined(UNITTESTS)
+#undef time
+#endif
+
 #endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_ALTSVC */


### PR DESCRIPTION
To avoid applying it to all other sources in unity mode.