### PR TITLE
lib/vts: fix a copy-pasted early data comment typo

### DIFF
--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1079,7 +1079,7 @@ static CURLcode gtls_on_session_reuse(struct Curl_cfilter *cf,
   connssl->earlydata_max =
     gnutls_record_get_max_early_data_size(backend->gtls.session);
   if((!connssl->earlydata_max || connssl->earlydata_max == 0xFFFFFFFFUL)) {
-    /* Seems to be GnuTLS way to signal no EarlyData in session */
+    /* Seems to be no GnuTLS way to signal no EarlyData in session */
     CURL_TRC_CF(data, cf, "SSL session does not allow earlydata");
   }
   else if(!Curl_alpn_contains_proto(alpns, scs->alpn)) {

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -517,7 +517,7 @@ static CURLcode wssl_on_session_reuse(struct Curl_cfilter *cf,
 #endif
 
   if(!connssl->earlydata_max) {
-    /* Seems to be GnuTLS way to signal no EarlyData in session */
+    /* Seems to be no WolfSSL way to signal no EarlyData in session */
     CURL_TRC_CF(data, cf, "SSL session does not allow earlydata");
   }
   else if(!Curl_alpn_contains_proto(alpns, scs->alpn)) {


### PR DESCRIPTION
In `gtls.c` there was a typo'd comment that I think was missing the word "no" to indicate there's "no GnuTLS way to signal no EarlyData".

This commit fixes that typo, and also updates a copy-pasted instance that made it into `wolfssl.c` where it should refer to the WolfSSL API missing the capability, not GnuTLS.

In both cases I haven't done any extra legwork to research whether the API limitation mentioned still exists. If someone more invested in GnuTLS and WolfSSL wants to do that instead I'm happy to close this PR!