### PR TITLE
docs: update --ssl-sessions and --tls-earlydata

### DIFF
--- a/docs/cmdline-opts/ssl-sessions.md
+++ b/docs/cmdline-opts/ssl-sessions.md
@@ -33,3 +33,6 @@ The SSL session tickets are stored as base64 encoded text, each ticket on
 its own line. The hostnames are cryptographically salted and hashed. While
 this prevents someone from easily seeing the hosts you contacted, they could
 still check if a specific hostname matches one of the values.
+
+This feature requires that the underlying libcurl was built with the
+experimental SSL session import/export feature (SSLS-EXPORT) enabled.

--- a/docs/cmdline-opts/tls-earlydata.md
+++ b/docs/cmdline-opts/tls-earlydata.md
@@ -20,7 +20,8 @@ Example:
 Enable the use of TLSv1.3 early data, also known as '0RTT' where possible.
 This has security implications for the requests sent that way.
 
-This option is used when curl is built to use GnuTLS.
+This option can be used when curl is built to use GnuTLS, wolfSSL, quictls and
+OpenSSL as a TLS provider (but not BoringSSL, AWS-LC, or rustls).
 
 If a server supports this TLSv1.3 feature, and to what extent, is announced
 as part of the TLS "session" sent back to curl. Until curl has seen such


### PR DESCRIPTION
Two small doc updates:

1. the `--ssl-sessions` arg requires the `libcurl` `SSLS-EXPORT` feature.
2. I believe the `--tls-earlydata` arg supports more vTLS backends than just gnuTLS these days. I think support landed for wolfSSL in https://github.com/curl/curl/pull/16167, and for quictls/openssl in https://github.com/curl/curl/pull/16477 