### PR TITLE
GHA/checksrc: use Linux for CI checks, merge job into misc checks

### DIFF
--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -145,7 +145,7 @@ jobs:
 
   cicheck:
     name: 'CI'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -153,12 +153,15 @@ jobs:
           persist-credentials: false
 
       - name: 'install prereqs'
-        run: brew install shellcheck zizmor
+        run: /home/linuxbrew/.linuxbrew/bin/brew install shellcheck zizmor
 
       - name: 'zizmor GHA'
-        run: zizmor --pedantic .github/workflows/*.yml
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          zizmor --pedantic .github/workflows/*.yml
 
       - name: 'shellcheck GHA'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           shellcheck --version
           .github/scripts/shellcheck-ci.sh

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -133,17 +133,17 @@ jobs:
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           zizmor --pedantic .github/workflows/*.yml
 
-      - name: 'shellcheck'
-        run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          shellcheck --version
-          .github/scripts/shellcheck.sh
-
       - name: 'shellcheck GHA'
         run: |
           eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           shellcheck --version
           .github/scripts/shellcheck-ci.sh
+
+      - name: 'shellcheck'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          shellcheck --version
+          .github/scripts/shellcheck.sh
 
       - name: 'spacecheck'
         run: .github/scripts/spacecheck.pl

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -144,7 +144,7 @@ jobs:
           .github/scripts/badwords.pl $(git ls-files -- src lib include)
 
   cicheck:
-    name: 'CI'
+    name: 'CI checks'
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/checksrc.yml
+++ b/.github/workflows/checksrc.yml
@@ -121,14 +121,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: 'install prereqs'
+        run: /home/linuxbrew/.linuxbrew/bin/brew install shellcheck zizmor
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
+      - name: 'zizmor GHA'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          zizmor --pedantic .github/workflows/*.yml
+
       - name: 'shellcheck'
         run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
           shellcheck --version
           .github/scripts/shellcheck.sh
+
+      - name: 'shellcheck GHA'
+        run: |
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          shellcheck --version
+          .github/scripts/shellcheck-ci.sh
 
       - name: 'spacecheck'
         run: .github/scripts/spacecheck.pl
@@ -142,26 +157,3 @@ jobs:
           # shellcheck disable=SC2046
           grep -Ev '(\\bwill| url | dir )' .github/scripts/badwords.txt | \
           .github/scripts/badwords.pl $(git ls-files -- src lib include)
-
-  cicheck:
-    name: 'CI checks'
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          persist-credentials: false
-
-      - name: 'install prereqs'
-        run: /home/linuxbrew/.linuxbrew/bin/brew install shellcheck zizmor
-
-      - name: 'zizmor GHA'
-        run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          zizmor --pedantic .github/workflows/*.yml
-
-      - name: 'shellcheck GHA'
-        run: |
-          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-          shellcheck --version
-          .github/scripts/shellcheck-ci.sh


### PR DESCRIPTION
CI check used macOS before this patch, but with the help of Linuxbrew,
latest zizmor and shellcheck are also available on Linux.

Also:
- migrate CI checks to the misc check workflow, to make both shellcheck
  use the same, latest, shellcheck version, and to save the overhead of
  an extra workflow.
