### PR TITLE
config-win32: fix default targets, shorten macro logic

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -300,13 +300,7 @@
 
 /* Define some minimum and default build targets for Visual Studio */
 #ifdef _MSC_VER
-   /* Officially, Microsoft's Windows SDK versions 6.X does not support Windows
-      2000 as a supported build target. VS2008 default installations provides
-      an embedded Windows SDK v6.0A along with the claim that Windows 2000 is a
-      valid build target for VS2008. Popular belief is that binaries built with
-      VS2008 using Windows SDK versions v6.X and Windows 2000 as a build target
-      are functional. */
-#  define VS2008_MIN_TARGET 0x0500
+#  define VS2008_MIN_TARGET 0x0501
 
    /* The minimum build target for VS2012 is Vista unless Update 1 is installed
       and the v110_xp toolset is chosen. */

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -301,24 +301,18 @@
 /* Define some minimum and default build targets for Visual Studio */
 #ifdef _MSC_VER
 #  define VS2008_MIN_TARGET 0x0501  /* XP */
-
-   /* The minimum build target for VS2012 is Vista unless Update 1 is installed
-      and the v110_xp toolset is chosen. */
-#  ifdef _USING_V110_SDK71_
-#    define VS2012_MIN_TARGET 0x0501  /* XP */
-#  else
-#    define VS2012_MIN_TARGET 0x0600  /* Vista */
-#  endif
-
    /* VS2008 default build target is Windows Vista. We override default target
       to be Windows XP. */
 #  define VS2008_DEF_TARGET 0x0501  /* XP */
 
-   /* VS2012 default build target is Windows 8 unless Update 1 is installed
-      and the v110_xp toolset is chosen. */
+   /* The minimum and default build targets for VS2012 are Vista and 8,
+      respectively, unless Update 1 is installed and the v110_xp toolset
+      is chosen. */
 #  ifdef _USING_V110_SDK71_
+#    define VS2012_MIN_TARGET 0x0501  /* XP */
 #    define VS2012_DEF_TARGET 0x0501  /* XP */
 #  else
+#    define VS2012_MIN_TARGET 0x0600  /* Vista */
 #    define VS2012_DEF_TARGET 0x0602  /* 8 */
 #  endif
 #endif

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -300,53 +300,51 @@
 
 /* Define some minimum and default build targets for Visual Studio */
 #ifdef _MSC_VER
-#  define VS2008_MIN_TARGET 0x0501  /* XP */
-   /* VS2008 default build target is Windows Vista (0x0600).
-      We override default target to be Windows XP. */
-#  define VS2008_DEF_TARGET 0x0501  /* XP */
-
-   /* The minimum and default build targets for VS2012 are Vista and 8,
-      respectively, unless Update 1 is installed and the v110_xp toolset
-      is chosen. */
-#  ifdef _USING_V110_SDK71_
-#    define VS2012_MIN_TARGET 0x0501  /* XP */
-#    define VS2012_DEF_TARGET 0x0501  /* XP */
-#  else
-#    define VS2012_MIN_TARGET 0x0600  /* Vista */
-#    define VS2012_DEF_TARGET 0x0602  /* 8 */
-#  endif
-#endif
-
-/* VS2008 default target settings and minimum build target check. */
-#if defined(_MSC_VER) && (_MSC_VER <= 1600)
-#  ifndef _WIN32_WINNT
-#  define _WIN32_WINNT VS2008_DEF_TARGET
-#  endif
-#  ifndef WINVER
-#  define WINVER VS2008_DEF_TARGET
-#  endif
-#  if (_WIN32_WINNT < VS2008_MIN_TARGET) || (WINVER < VS2008_MIN_TARGET)
-#    error VS2008 does not support Windows build targets prior to Windows 2000
-#  endif
-#endif
-
-/* VS2012 default target settings and minimum build target check. */
-#if defined(_MSC_VER) && (_MSC_VER >= 1700)
-#  ifndef _WIN32_WINNT
-#  define _WIN32_WINNT VS2012_DEF_TARGET
-#  endif
-#  ifndef WINVER
-#  define WINVER VS2012_DEF_TARGET
-#  endif
-#  if (_WIN32_WINNT < VS2012_MIN_TARGET) || (WINVER < VS2012_MIN_TARGET)
+   /* VS2012 default target settings and minimum build target check. */
+#  if _MSC_VER >= 1700
+     /* The minimum and default build targets for VS2012 are Vista and 8,
+        respectively, unless Update 1 is installed and the v110_xp toolset
+        is chosen. */
 #    ifdef _USING_V110_SDK71_
-#      error VS2012 does not support Windows build targets prior to Windows XP
+#      define VS2012_MIN_TARGET 0x0501  /* XP */
+#      define VS2012_DEF_TARGET 0x0501  /* XP */
 #    else
-#      error VS2012 does not support Windows build targets prior to Windows \
-Vista
+#      define VS2012_MIN_TARGET 0x0600  /* Vista */
+#      define VS2012_DEF_TARGET 0x0602  /* 8 */
+#    endif
+
+#    ifndef _WIN32_WINNT
+#    define _WIN32_WINNT VS2012_DEF_TARGET
+#    endif
+#    ifndef WINVER
+#    define WINVER VS2012_DEF_TARGET
+#    endif
+#    if (_WIN32_WINNT < VS2012_MIN_TARGET) || (WINVER < VS2012_MIN_TARGET)
+#      ifdef _USING_V110_SDK71_
+#        error VS2012 does not support build targets prior to Windows XP
+#      else
+#        error VS2012 does not support build targets prior to Windows Vista
+#      endif
+#    endif
+   /* Default target settings and minimum build target check for
+      VS2008 and VS2010 */
+#  else
+#    define VS2008_MIN_TARGET 0x0501  /* XP */
+     /* VS2008 default build target is Windows Vista (0x0600).
+        We override default target to be Windows XP. */
+#    define VS2008_DEF_TARGET 0x0501  /* XP */
+
+#    ifndef _WIN32_WINNT
+#    define _WIN32_WINNT VS2008_DEF_TARGET
+#    endif
+#    ifndef WINVER
+#    define WINVER VS2008_DEF_TARGET
+#    endif
+#    if (_WIN32_WINNT < VS2008_MIN_TARGET) || (WINVER < VS2008_MIN_TARGET)
+#      error VS2008 does not support build targets prior to Windows 2000
 #    endif
 #  endif
-#endif
+#endif /* _MSC_VER */
 
 #endif /* UNDER_CE */
 

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -341,7 +341,7 @@
 #    define WINVER VS2008_DEF_TARGET
 #    endif
 #    if (_WIN32_WINNT < VS2008_MIN_TARGET) || (WINVER < VS2008_MIN_TARGET)
-#      error VS2008 does not support build targets prior to Windows 2000
+#      error VS2008 does not support build targets prior to Windows XP
 #    endif
 #  endif
 #endif /* _MSC_VER */

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -300,26 +300,26 @@
 
 /* Define some minimum and default build targets for Visual Studio */
 #ifdef _MSC_VER
-#  define VS2008_MIN_TARGET 0x0501
+#  define VS2008_MIN_TARGET 0x0501  /* XP */
 
    /* The minimum build target for VS2012 is Vista unless Update 1 is installed
       and the v110_xp toolset is chosen. */
 #  ifdef _USING_V110_SDK71_
-#    define VS2012_MIN_TARGET 0x0501
+#    define VS2012_MIN_TARGET 0x0501  /* XP */
 #  else
-#    define VS2012_MIN_TARGET 0x0600
+#    define VS2012_MIN_TARGET 0x0600  /* Vista */
 #  endif
 
    /* VS2008 default build target is Windows Vista. We override default target
       to be Windows XP. */
-#  define VS2008_DEF_TARGET 0x0501
+#  define VS2008_DEF_TARGET 0x0501  /* XP */
 
    /* VS2012 default build target is Windows 8 unless Update 1 is installed
       and the v110_xp toolset is chosen. */
 #  ifdef _USING_V110_SDK71_
-#    define VS2012_DEF_TARGET 0x0501
+#    define VS2012_DEF_TARGET 0x0501  /* XP */
 #  else
-#    define VS2012_DEF_TARGET 0x0602
+#    define VS2012_DEF_TARGET 0x0602  /* 8 */
 #  endif
 #endif
 

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -301,8 +301,8 @@
 /* Define some minimum and default build targets for Visual Studio */
 #ifdef _MSC_VER
 #  define VS2008_MIN_TARGET 0x0501  /* XP */
-   /* VS2008 default build target is Windows Vista. We override default target
-      to be Windows XP. */
+   /* VS2008 default build target is Windows Vista (0x0600).
+      We override default target to be Windows XP. */
 #  define VS2008_DEF_TARGET 0x0501  /* XP */
 
    /* The minimum and default build targets for VS2012 are Vista and 8,

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -320,12 +320,12 @@
       to be Windows XP. */
 #  define VS2008_DEF_TARGET 0x0501
 
-   /* VS2012 default build target is Windows Vista unless Update 1 is installed
+   /* VS2012 default build target is Windows 8 unless Update 1 is installed
       and the v110_xp toolset is chosen. */
 #  ifdef _USING_V110_SDK71_
 #    define VS2012_DEF_TARGET 0x0501
 #  else
-#    define VS2012_DEF_TARGET 0x0600
+#    define VS2012_DEF_TARGET 0x0602
 #  endif
 #endif
 


### PR DESCRIPTION
When using winbuild or Visual Studio IDE Project Files.
To simplify and prepare for dropping support for VS2008.

Details:
- fix VS2012 default target to be Windows 8 (was Vista).
  Confirmed by CI:
  ```
  -- The C compiler identification is MSVC 17.0.61030.0
  -- Found _WIN32_WINNT=0x0602
  ```
  Ref: https://ci.appveyor.com/project/curlorg/curl/builds/51594696/job/elbl0w5n7fmoos2f#L45
  It also aligns with the default being Windows 7 for VS2010,
  and Windows Vista for VS2008.
- bump minimum target to XP (was Windows 2000) when using VS2008.
  curl requires XP.
- add Windows release names to comments for clarity.
- add hex Windows version to a comment for clarity.
- merge VS2008/VS2012 minimum/default logic and comments.
- reduce scope of local minimum/default macros.
- shorten comments to fit within line limit.

---

w/o ws https://github.com/curl/curl/pull/17916/files?w=1
