### PR TITLE
altsvc: accept 'clear' without semicolon as well

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -486,8 +486,7 @@ CURLcode Curl_altsvc_parse(struct Curl_easy *data,
   DEBUGASSERT(asi);
 
   /* initial check for "clear" */
-  if(!curlx_str_until(&p, &alpn, MAX_ALTSVC_LINE, ';') &&
-     !curlx_str_single(&p, ';')) {
+  if(!curlx_str_cspn(&p, &alpn, ";\n\r")) {
     curlx_str_trimblanks(&alpn);
     /* "clear" is a magic keyword */
     if(curlx_str_casecompare(&alpn, "clear")) {

--- a/tests/unit/unit1654.c
+++ b/tests/unit/unit1654.c
@@ -95,6 +95,20 @@ static CURLcode test_unit1654(char *arg)
   fail_if(result, "Curl_altsvc_parse(7) failed!");
   fail_unless(Curl_llist_count(&asi->list) == 10, "wrong number of entries");
 
+  result =
+    Curl_altsvc_parse(curl, asi,
+                      "h2=\":443\", h3=\":443\"; "
+                      "persist = \"1\"; ma = 120;\r\n",
+                      ALPN_h1, "curl.se", 80);
+  fail_if(result, "Curl_altsvc_parse(6) failed!");
+  fail_unless(Curl_llist_count(&asi->list) == 12, "wrong number of entries");
+
+  /* clear - without semicolon */
+  result = Curl_altsvc_parse(curl, asi, "clear\r\n",
+                             ALPN_h1, "curl.se", 80);
+  fail_if(result, "Curl_altsvc_parse(7) failed!");
+  fail_unless(Curl_llist_count(&asi->list) == 10, "wrong number of entries");
+
   /* only a non-existing alpn */
   result = Curl_altsvc_parse(curl, asi,
                              "h6=\"example.net:443\"; ma=\"180\";\r\n",


### PR DESCRIPTION
Fixes #17917
Reported-by: Luke Wilde