### PR TITLE
tests: raise two memory limits

### DIFF
--- a/tests/data/test518
+++ b/tests/data/test518
@@ -63,5 +63,8 @@ Accept: */*
 <valgrind>
 disable
 </valgrind>
+<limits>
+Maximum allocated: 1100000
+</limits>
 </verify>
 </testcase>

--- a/tests/data/test537
+++ b/tests/data/test537
@@ -60,5 +60,8 @@ Host: %HOSTIP:%HTTPPORT
 Accept: */*
 
 </protocol>
+<limits>
+Maximum allocated: 3200000
+</limits>
 </verify>
 </testcase>

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1700,7 +1700,7 @@ sub singletest_check {
             }
             my @more=`$memanalyze -v "$logdir/$MEMDUMP"`;
             my $allocs;
-            my $max;
+            my $max = 0;
             for(@more) {
                 if(/^Allocations: (\d+)/) {
                     $allocs = $1;


### PR DESCRIPTION
Runing the tests locally without valgrind test 518 and 537 would run over their limits.

Plus init a variable in runtests.pl to avoid a warning output.