### PR TITLE
http/3: report handshake with version and cipher as for TCP connections

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -468,6 +468,7 @@ static int cf_ngtcp2_handshake_completed(ngtcp2_conn *tconn, void *user_data)
   ctx->handshake_at = curlx_now();
   ctx->tls_handshake_complete = TRUE;
   cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
+  Curl_vquic_report_handshake(&ctx->tls, cf, data);
 
   ctx->tls_vrfy_result = Curl_vquic_tls_verify_peer(&ctx->tls, cf,
                                                     data, &ctx->peer);

--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -221,4 +221,22 @@ bool Curl_vquic_tls_get_ssl_info(struct curl_tls_ctx *ctx,
 #endif
 }
 
+void Curl_vquic_report_handshake(struct curl_tls_ctx *ctx,
+                                 struct Curl_cfilter *cf,
+                                 struct Curl_easy *data)
+{
+  (void)cf;
+#ifdef USE_OPENSSL
+  (void)cf;
+  Curl_ossl_report_handshake(data, &ctx->ossl);
+#elif defined(USE_GNUTLS)
+  Curl_gtls_report_handshake(data, &ctx->gtls);
+#elif defined(USE_WOLFSSL)
+  Curl_wssl_report_handshake(data, &ctx->wssl);
+#else
+  (void)data;
+  (void)ctx;
+#endif
+}
+
 #endif /* !USE_HTTP3 && (USE_OPENSSL || USE_GNUTLS || USE_WOLFSSL) */

--- a/lib/vquic/vquic-tls.h
+++ b/lib/vquic/vquic-tls.h
@@ -111,6 +111,10 @@ bool Curl_vquic_tls_get_ssl_info(struct curl_tls_ctx *ctx,
                                  bool give_ssl_ctx,
                                  struct curl_tlssessioninfo *info);
 
+void Curl_vquic_report_handshake(struct curl_tls_ctx *ctx,
+                                 struct Curl_cfilter *cf,
+                                 struct Curl_easy *data);
+
 #endif /* !USE_HTTP3 && (USE_OPENSSL || USE_GNUTLS || USE_WOLFSSL) */
 
 #endif /* HEADER_CURL_VQUIC_TLS_H */

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -1311,16 +1311,18 @@ void Curl_gtls_report_handshake(struct Curl_easy *data,
                                 struct gtls_ctx *gctx)
 {
 #ifndef CURL_DISABLE_VERBOSE_STRINGS
-  const char *ptr;
-  gnutls_protocol_t version = gnutls_protocol_get_version(gctx->session);
+  if(Curl_trc_is_verbose(data)) {
+    const char *ptr;
+    gnutls_protocol_t version = gnutls_protocol_get_version(gctx->session);
 
-  /* the name of the cipher suite used, e.g. ECDHE_RSA_AES_256_GCM_SHA384. */
-  ptr = gnutls_cipher_suite_get_name(gnutls_kx_get(gctx->session),
-                                     gnutls_cipher_get(gctx->session),
-                                     gnutls_mac_get(gctx->session));
+    /* the name of the cipher suite used, e.g. ECDHE_RSA_AES_256_GCM_SHA384. */
+    ptr = gnutls_cipher_suite_get_name(gnutls_kx_get(gctx->session),
+                                       gnutls_cipher_get(gctx->session),
+                                       gnutls_mac_get(gctx->session));
 
-  infof(data, "SSL connection using %s / %s",
-        gnutls_protocol_get_name(version), ptr);
+    infof(data, "SSL connection using %s / %s",
+          gnutls_protocol_get_name(version), ptr);
+  }
 #else
   (void)data;
   (void)gctx;

--- a/lib/vtls/gtls.h
+++ b/lib/vtls/gtls.h
@@ -117,6 +117,10 @@ CURLcode Curl_gtls_cache_session(struct Curl_cfilter *cf,
                                  unsigned char *quic_tp,
                                  size_t quic_tp_len);
 
+/* Report properties of a successful handshake */
+void Curl_gtls_report_handshake(struct Curl_easy *data,
+                                struct gtls_ctx *gctx);
+
 extern const struct Curl_ssl Curl_ssl_gnutls;
 
 #endif /* USE_GNUTLS */

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -142,5 +142,9 @@ CURLcode Curl_oss_check_peer_cert(struct Curl_cfilter *cf,
                                   struct ossl_ctx *octx,
                                   struct ssl_peer *peer);
 
+/* Report properties of a successful handshake */
+void Curl_ossl_report_handshake(struct Curl_easy *data,
+                                struct ossl_ctx *octx);
+
 #endif /* USE_OPENSSL */
 #endif /* HEADER_CURL_SSLUSE_H */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2097,7 +2097,6 @@ void Curl_wssl_report_handshake(struct Curl_easy *data,
 #else
     infof(data, "SSL connected");
 #endif
-
 }
 
 static CURLcode wssl_connect(struct Curl_cfilter *cf,

--- a/lib/vtls/wolfssl.h
+++ b/lib/vtls/wolfssl.h
@@ -88,6 +88,8 @@ CURLcode Curl_wssl_verify_pinned(struct Curl_cfilter *cf,
                                  struct Curl_easy *data,
                                  struct wssl_ctx *wssl);
 
+void Curl_wssl_report_handshake(struct Curl_easy *data,
+                                struct wssl_ctx *wssl);
 
 #endif /* USE_WOLFSSL */
 #endif /* HEADER_CURL_WOLFSSL_H */


### PR DESCRIPTION
Make reporting into separate functions, to be called from QUIC handshakes as well.