### PR TITLE
test1706: pass include directory to `managen` for out-of-tree builds

### DIFF
--- a/tests/data/test1706
+++ b/tests/data/test1706
@@ -151,7 +151,7 @@ Makes it the equivalent of --socks5-hostname
 </file4>
 
 <command type="perl">
-%SRCDIR/../scripts/managen -d %LOGDIR ascii option1.md option2.md
+%SRCDIR/../scripts/managen -I %SRCDIR/../include -d %LOGDIR ascii option1.md option2.md
 </command>
 </client>
 


### PR DESCRIPTION
Fixing:
```
readline() on closed filehandle INC at ../../curl-99.98.97/tests/../scripts/managen line 1299.
```
Ref: https://github.com/curl/curl/actions/runs/16224106087/job/45811979199?pr=17877#step:3:8545

Cherry-picked from #17877
