### PR TITLE
autotools: stop checking for the `pw32` platform

### DIFF
--- a/m4/xc-lt-iface.m4
+++ b/m4/xc-lt-iface.m4
@@ -74,7 +74,7 @@ fi
 if test "x$xc_lt_want_enable_shared" = 'xyes' &&
   test "x$xc_lt_want_enable_static" = 'xyes'; then
   case $host_os in @%:@ (
-    pw32* | cegcc* | os2* | aix*)
+    cegcc* | os2* | aix*)
       xc_lt_want_enable_static='no'
       ;;
   esac
@@ -265,7 +265,7 @@ elif test "x$allow_undefined_flag" = 'xunsupported'; then
   xc_lt_shlib_use_no_undefined='yes'
 fi
 case $host_os in @%:@ (
-  cygwin* | mingw* | pw32* | cegcc* | os2* | aix*)
+  cygwin* | mingw* | cegcc* | os2* | aix*)
     xc_lt_shlib_use_no_undefined='yes'
     ;;
 esac


### PR DESCRIPTION
It's most likely a reference to Posix-over-Win32 layer:

https://pw32.sourceforge.net/main.html (last updated: 2001-05-01)
https://sourceforge.net/projects/pw32/
https://sourceforge.net/projects/pw32/files/ (latest date: 2001-10-12)
