### PR TITLE
test1560: set locale/codeset with `LC_ALL` (was: `LANG`), test in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -78,7 +78,7 @@ jobs:
       matrix:
         build:
           - name: 'libressl heimdal'
-            install_packages: zlib1g-dev libnghttp2-dev libldap-dev heimdal-dev
+            install_packages: zlib1g-dev libidn2-dev libnghttp2-dev libldap-dev heimdal-dev
             install_steps: libressl pytest
             configure: LDFLAGS=-Wl,-rpath,/home/runner/libressl/lib --with-openssl=/home/runner/libressl --with-gssapi --enable-debug
 
@@ -103,7 +103,7 @@ jobs:
             configure: LDFLAGS=-Wl,-rpath,/home/runner/wolfssl-opensslextra/lib --with-wolfssl=/home/runner/wolfssl-opensslextra --with-wolfssh=/home/runner/wolfssh --enable-ech --enable-debug
 
           - name: 'mbedtls valgrind'
-            install_packages: libnghttp2-dev libldap-dev valgrind
+            install_packages: libnghttp2-dev libidn2-dev libldap-dev valgrind
             install_steps: mbedtls
             configure: LDFLAGS=-Wl,-rpath,/home/runner/mbedtls/lib --with-mbedtls=/home/runner/mbedtls --enable-debug
 
@@ -145,7 +145,7 @@ jobs:
             configure: LDFLAGS=-Wl,-rpath,/home/runner/awslc/lib --with-openssl=/home/runner/awslc --enable-ech
 
           - name: 'awslc'
-            install_packages: zlib1g-dev
+            install_packages: zlib1g-dev libidn2-dev
             install_steps: awslc
             generate: -DOPENSSL_ROOT_DIR=/home/runner/awslc -DUSE_ECH=ON -DCMAKE_UNITY_BUILD=OFF
 
@@ -154,7 +154,7 @@ jobs:
             configure: --with-openssl --enable-debug --disable-unity
 
           - name: 'openssl libssh2 sync-resolver valgrind'
-            install_packages: zlib1g-dev libssh2-1-dev libnghttp2-dev libldap-dev valgrind
+            install_packages: zlib1g-dev libidn2-dev libssh2-1-dev libnghttp2-dev libldap-dev valgrind
             configure: --with-openssl --enable-debug --disable-threaded-resolver --with-libssh2
 
           - name: 'openssl'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -79,7 +79,7 @@ jobs:
         build:
           - name: 'libressl heimdal'
             install_packages: zlib1g-dev libidn2-dev libnghttp2-dev libldap-dev heimdal-dev
-            install_steps: libressl pytest
+            install_steps: libressl pytest codeset-test
             configure: LDFLAGS=-Wl,-rpath,/home/runner/libressl/lib --with-openssl=/home/runner/libressl --with-gssapi --enable-debug
 
           - name: 'libressl heimdal valgrind'
@@ -685,7 +685,7 @@ jobs:
             fi
           fi
           [ -x ~/venv/bin/activate ] && source ~/venv/bin/activate
-          export LC_ALL=C
+          [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test'* ]] && export LC_ALL=C
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target "${TEST_TARGET}"
           else

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -174,7 +174,7 @@ jobs:
 
           - name: 'openssl clang krb5 openldap static'
             install_steps: openldap-static
-            install_packages: zlib1g-dev libkrb5-dev clang libssl-dev
+            install_packages: zlib1g-dev libidn2-dev libkrb5-dev clang libssl-dev
             configure: CC=clang --disable-shared --with-openssl --with-gssapi --enable-debug --disable-docs --disable-manual --with-ldap=/home/runner/openldap-static --with-ldap-lib=ldap --with-lber-lib=lber
 
           - name: 'openssl clang krb5 LTO'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -685,6 +685,7 @@ jobs:
             fi
           fi
           [ -x ~/venv/bin/activate ] && source ~/venv/bin/activate
+          export LC_ALL=C
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target "${TEST_TARGET}"
           else

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -207,7 +207,7 @@ jobs:
             torture: true
 
           - name: 'openssl i686'
-            install_packages: gcc-14-i686-linux-gnu libssl-dev:i386 librtmp-dev:i386 libssh2-1-dev:i386 libidn2-0-dev:i386 libc-ares-dev:i386 zlib1g-dev:i386
+            install_packages: gcc-14-i686-linux-gnu libssl-dev:i386 librtmp-dev:i386 libssh2-1-dev:i386 libidn2-dev:i386 libc-ares-dev:i386 zlib1g-dev:i386
             configure: >-
               PKG_CONFIG_PATH=/usr/lib/i386-linux-gnu/pkgconfig
               CC=i686-linux-gnu-gcc-14

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -296,10 +296,11 @@ jobs:
             install: brotli wolfssl zstd
             install_steps: pytest
             generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON
-          - name: 'mbedTLS !ldap brotli zstd MultiSSL'
+          - name: 'mbedTLS !ldap brotli zstd MultiSSL AppleIDN'
             compiler: llvm@18
             install: brotli mbedtls zstd
-            generate: -DCURL_USE_MBEDTLS=ON -DCURL_DISABLE_LDAP=ON -DCURL_DEFAULT_SSL_BACKEND=mbedtls -DCURL_USE_OPENSSL=ON
+            install_steps: codeset-test
+            generate: -DCURL_USE_MBEDTLS=ON -DCURL_DISABLE_LDAP=ON -DCURL_DEFAULT_SSL_BACKEND=mbedtls -DCURL_USE_OPENSSL=ON -DUSE_APPLE_IDN=ON
           - name: 'GnuTLS !ldap krb5'
             install: gnutls nettle krb5
             generate: -DENABLE_DEBUG=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=/opt/homebrew/opt/krb5 -DCURL_DISABLE_LDAP=ON -DUSE_SSLS_EXPORT=ON
@@ -479,6 +480,10 @@ jobs:
         run: |
           TFLAGS="-j20 ${TFLAGS}"
           source ~/venv/bin/activate
+          if [[ "${MATRIX_INSTALL_STEPS}" = *'codeset-test'* ]]; then
+            export LC_CTYPE=C
+            export LC_NUMERIC=fr_FR.UTF-8
+          fi
           rm -f ~/.curlrc
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             cmake --build bld --verbose --target "${TEST_TARGET}"

--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -13,7 +13,7 @@ urlapi
 none
 </server>
 <setenv>
-LANG=en_US.UTF-8
+LC_ALL=en_US.UTF-8
 </setenv>
 <features>
 file


### PR DESCRIPTION
To fix running test 1560 when `LC_ALL` is set to something unexpected
(e.g. `C`). Also syncing it with the rest of tests.

Also:
- GHA/linux: enable `libidn2` in more jobs.
  Also to enable test 1560 reproducing this issue in more jobs.
- GHA/linux: run tests with `LC_ALL=C` in one of the jobs.
- GHA/linux: switch to the non-deprecated package name for libidn2.
- GHA/macos: run tests with non-default locale settings in one job.
- GHA/macos: enable AppleIDN in that job.

Ref: https://github.com/curl/curl/pull/17933#issuecomment-3074582840
Follow-up to f27262b17965aefa7c6bf41bd40b01b4f97407bd #10196

---

Spec 1997: https://pubs.opengroup.org/onlinepubs/7908799/xbd/envvar.html
Spec 2008: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html

Ref: 4c140a56283703161e5f26ae022bad694a481603
Ref: b4c9982382469398115cc0e3e0747e79db083455 #4743
Ref: 23208e330ac0c2164d59971baf79e87c45da1840 #4738
Ref: 28faaacee287b019bcf2961da3bf2f91d331bcbd #2436
Ref: ecd1d020abdae3c3ce3643ddab3106501e62e7c0

- [ ] move the leveling of `LC_*` variables in tests to another PR.
- [x] limit `LC_ALL=C` GHA/macos to a single job like in Linux.
- [x] undo GHA/macos AppleIDN commit. (job already used libidn2)

`LC_*` values are a bit inconsistent in the rest of tests:
1. 1034, 1035: `LC_ALL=` & `LC_CTYPE=en_US.UTF-8`
2. 1148: `LC_ALL=` & `LC_NUMERIC=en_US.UTF-8`
3. rest: `LC_ALL=en_US.UTF-8` & `LC_CTYPE=en_US.UTF-8`

Method 1 clears `LC_ALL`, to give way to `LC_CTYPE`, and to configure
this without touching `LANG`. Later commits mention errors when `LC_ALL`
is empty, and fill it with the `LC_CTYPE` value, also keeping `LC_CTYPE`.
`LC_CTYPE` is possibly redundant (ignored) when `LC_ALL` is set.
`LC_NUMERIC` in method 2 could be replaced with method 1, I think.

I wonder if all could be replace with a single `LC_ALL=en_US.UTF-8`,
as in 1560 after this patch, because the empty value is doesn't always
work and anything else is ignored if `LC_ALL` is set.
