### PR TITLE
openssl: some small cleanups

### DIFF
--- a/lib/vquic/vquic-tls.c
+++ b/lib/vquic/vquic-tls.c
@@ -167,7 +167,7 @@ CURLcode Curl_vquic_tls_verify_peer(struct curl_tls_ctx *ctx,
 
 #ifdef USE_OPENSSL
   (void)conn_config;
-  result = Curl_oss_check_peer_cert(cf, data, &ctx->ossl, peer);
+  result = Curl_ossl_check_peer_cert(cf, data, &ctx->ossl, peer);
 #elif defined(USE_GNUTLS)
   if(conn_config->verifyhost) {
     result = Curl_gtls_verifyserver(data, ctx->gtls.session,

--- a/lib/vtls/hostcheck.h
+++ b/lib/vtls/hostcheck.h
@@ -26,8 +26,12 @@
 
 #include <curl/curl.h>
 
+#if defined(USE_OPENSSL) || defined(USE_SCHANNEL)
+
 /* returns TRUE if there is a match */
 bool Curl_cert_hostcheck(const char *match_pattern, size_t matchlen,
                          const char *hostname, size_t hostlen);
+
+#endif
 
 #endif /* HEADER_CURL_HOSTCHECK_H */

--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -137,10 +137,10 @@ CURLcode Curl_ossl_add_session(struct Curl_cfilter *cf,
  * ssl config verifypeer or -host is set. Otherwise all this is for
  * informational purposes only!
  */
-CURLcode Curl_oss_check_peer_cert(struct Curl_cfilter *cf,
-                                  struct Curl_easy *data,
-                                  struct ossl_ctx *octx,
-                                  struct ssl_peer *peer);
+CURLcode Curl_ossl_check_peer_cert(struct Curl_cfilter *cf,
+                                   struct Curl_easy *data,
+                                   struct ossl_ctx *octx,
+                                   struct ssl_peer *peer);
 
 /* Report properties of a successful handshake */
 void Curl_ossl_report_handshake(struct Curl_easy *data,


### PR DESCRIPTION
- rename Curl_oss_check_peer_cert() to Curl_ossl_check_peer_cert()
- leave altname match loop after the first success when the match was an ip address
- remove static subj_alt_hostcheck() since it did not really do much
- use length based infof() output of altname, even though it does seem always to be nul terminated