### PR TITLE
curl/system.h: fix for gcc 2.x and older

### DIFF
--- a/include/curl/system.h
+++ b/include/curl/system.h
@@ -336,8 +336,10 @@
 #    define CURL_FORMAT_CURL_OFF_TU    "llu"
 #    define CURL_SUFFIX_CURL_OFF_T     LL
 #    define CURL_SUFFIX_CURL_OFF_TU    ULL
-#    define CURL_POPCOUNT64(x)         __builtin_popcountll(x)
-#    define CURL_CTZ64(x)              __builtin_ctzll(x)
+#    if __GNUC__ >= 3
+#      define CURL_POPCOUNT64(x)       __builtin_popcountll(x)
+#      define CURL_CTZ64(x)            __builtin_ctzll(x)
+#    endif
 #  elif defined(__LP64__) || \
         defined(__x86_64__) || defined(__ppc64__) || defined(__sparc64__) || \
         defined(__e2k__) || \
@@ -348,8 +350,10 @@
 #    define CURL_FORMAT_CURL_OFF_TU    "lu"
 #    define CURL_SUFFIX_CURL_OFF_T     L
 #    define CURL_SUFFIX_CURL_OFF_TU    UL
-#    define CURL_POPCOUNT64(x)         __builtin_popcountl(x)
-#    define CURL_CTZ64(x)              __builtin_ctzl(x)
+#    if __GNUC__ >= 3
+#      define CURL_POPCOUNT64(x)       __builtin_popcountl(x)
+#      define CURL_CTZ64(x)            __builtin_ctzl(x)
+#    endif
 #  endif
 #  define CURL_TYPEOF_CURL_SOCKLEN_T socklen_t
 #  define CURL_PULL_SYS_TYPES_H      1


### PR DESCRIPTION
Follow-up to 909af1a43b5a7fed8b5a4ca145e39f46b2f50325 #16761

Reported-by: Schrijvers Luc
Fixes #17951
