### PR TITLE
GHA/curl-for-win: add minimal build

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -71,7 +71,7 @@ jobs:
             "${DOCKER_IMAGE_STABLE}" \
             sh -c ./_ci-linux-debian.sh
 
-  linux-glibc-gcc-minimal:
+  linux-glibc-gcc-minimal:  # use gcc to minimize installed packages
     name: 'Linux gcc glibc minimal'
     runs-on: ubuntu-latest
     timeout-minutes: 5


### PR DESCRIPTION
A bit more minimal build than the one used for trurl. To stress test
a build with most features disabled.

Costs 40 seconds, of which 6 is the build, rest is installing tools.

Ref: https://github.com/curl/curl-for-win/commit/5b385001d5f89886553cf83aa3f2f24476a865f4
Ref: https://github.com/curl/curl-for-win/commit/3ee10692c73a61522cabb3a4d2e94eb228249250

Follow-up to 5af2457848357141b3b3c67f7a45a4964ec25233 #17818

---

In the future this could be made a permanent combination in `randdisable`.
