### PR TITLE
build: fix build errors/warnings in rare configurations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1068,7 +1068,7 @@ if(USE_SSLS_EXPORT)
   if(_ssl_enabled)
     message(STATUS "SSL export enabled.")
   else()
-    message(FATAL_ERROR "SSL session export requires SSL enabled")
+    message(WARNING "SSL session export requires SSL enabled")
   endif()
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -5146,7 +5146,7 @@ if test "x$want_ssls_export" != "xno"; then
   SSLS_EXPORT_SUPPORT=''
 
   if test "x$SSL_ENABLED" != "x1"; then
-    AC_MSG_ERROR([--enable-ssls-export ignored: No SSL support])
+    AC_MSG_WARN([--enable-ssls-export ignored: No SSL support])
   else
     SSLS_EXPORT_ENABLED=1
     AC_DEFINE(USE_SSLS_EXPORT, 1, [if SSL session export support is available])

--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -24,7 +24,8 @@
 
 #include "curl_setup.h"
 
-#if defined(USE_NGHTTP2) && !defined(CURL_DISABLE_PROXY)
+#if !defined(CURL_DISABLE_HTTP) && !defined(CURL_DISABLE_PROXY) && \
+  defined(USE_NGHTTP2)
 
 #include <nghttp2/nghttp2.h>
 #include "urldata.h"
@@ -1606,4 +1607,4 @@ out:
   return result;
 }
 
-#endif /* defined(USE_NGHTTP2) && !defined(CURL_DISABLE_PROXY) */
+#endif /* !CURL_DISABLE_HTTP && !CURL_DISABLE_PROXY && USE_NGHTTP2 */

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -1195,7 +1195,7 @@ const
 #endif
 struct transport_provider transport_providers[] = {
   { TRNSPRT_TCP, Curl_cf_tcp_create },
-#ifdef USE_HTTP3
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3)
   { TRNSPRT_QUIC, Curl_cf_quic_create },
 #endif
 #ifndef CURL_DISABLE_TFTP

--- a/lib/curl_hmac.h
+++ b/lib/curl_hmac.h
@@ -26,7 +26,7 @@
 
 #if (defined(USE_CURL_NTLM_CORE) && !defined(USE_WINDOWS_SSPI)) ||      \
   !defined(CURL_DISABLE_AWS) || !defined(CURL_DISABLE_DIGEST_AUTH) ||   \
-  defined(USE_SSL)
+  defined(USE_LIBSSH2) || defined(USE_SSL)
 
 #include <curl/curl.h>
 

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -739,10 +739,6 @@
 #if defined(USE_WOLFSSL) && defined(USE_GNUTLS)
 /* Avoid defining unprefixed wolfSSL SHA macros colliding with nettle ones */
 #define NO_OLD_WC_NAMES
-/* Prevent wolfSSL headers including wolfssl/openssl/md4.h, to avoid its
-   MD4_CTX type clashing with the one defined via nettle/md4.h, and used
-   in md4.c when GnuTLS is enabled. */
-#define NO_MD4
 #endif
 
 /* Single point where USE_SPNEGO definition might be defined */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -739,6 +739,10 @@
 #if defined(USE_WOLFSSL) && defined(USE_GNUTLS)
 /* Avoid defining unprefixed wolfSSL SHA macros colliding with nettle ones */
 #define NO_OLD_WC_NAMES
+/* Prevent wolfSSL headers including wolfssl/openssl/md4.h, to avoid its MD4_CTX
+   type clashing with the one defined via nettle/md4.h, and used in md4.c when
+   GnuTLS is enabled. */
+#define NO_MD4
 #endif
 
 /* Single point where USE_SPNEGO definition might be defined */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -739,9 +739,9 @@
 #if defined(USE_WOLFSSL) && defined(USE_GNUTLS)
 /* Avoid defining unprefixed wolfSSL SHA macros colliding with nettle ones */
 #define NO_OLD_WC_NAMES
-/* Prevent wolfSSL headers including wolfssl/openssl/md4.h, to avoid its MD4_CTX
-   type clashing with the one defined via nettle/md4.h, and used in md4.c when
-   GnuTLS is enabled. */
+/* Prevent wolfSSL headers including wolfssl/openssl/md4.h, to avoid its
+   MD4_CTX type clashing with the one defined via nettle/md4.h, and used
+   in md4.c when GnuTLS is enabled. */
 #define NO_MD4
 #endif
 

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -633,7 +633,7 @@ void Curl_trc_smtp(struct Curl_easy *data, const char *fmt, ...)
   (void)data; (void)fmt;
 }
 #endif
-#if !defined(CURL_DISABLE_WEBSOCKETS) || !defined(CURL_DISABLE_HTTP)
+#if !defined(CURL_DISABLE_WEBSOCKETS) && !defined(CURL_DISABLE_HTTP)
 void Curl_trc_ws(struct Curl_easy *data, const char *fmt, ...)
 {
   (void)data; (void)fmt;

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -482,7 +482,7 @@ static struct trc_cft_def trc_cfts[] = {
   { &Curl_cft_haproxy,        TRC_CT_PROXY },
   { &Curl_cft_socks_proxy,    TRC_CT_PROXY },
 #endif /* !CURL_DISABLE_PROXY */
-#ifdef USE_HTTP3
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3)
   { &Curl_cft_http3,          TRC_CT_PROTOCOL },
 #endif
 #if !defined(CURL_DISABLE_HTTP)

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -201,7 +201,6 @@ void Curl_failf(struct Curl_easy *data, const char *fmt, ...)
 
 #if !defined(CURL_DISABLE_VERBOSE_STRINGS)
 
-
 static void trc_infof(struct Curl_easy *data,
                       struct curl_trc_feat *feat,
                       const char *opt_id, int opt_id_idx,
@@ -639,11 +638,12 @@ void Curl_trc_ws(struct Curl_easy *data, const char *fmt, ...)
   (void)data; (void)fmt;
 }
 #endif
-
+#ifdef USE_SSL
 void Curl_trc_ssls(struct Curl_easy *data, const char *fmt, ...)
 {
   (void)data;
   (void)fmt;
 }
+#endif
 
 #endif /* !defined(CURL_DISABLE_VERBOSE_STRINGS) */

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -463,7 +463,7 @@ static struct trc_cft_def trc_cfts[] = {
   { &Curl_cft_tcp_accept,     TRC_CT_NETWORK },
   { &Curl_cft_happy_eyeballs, TRC_CT_NETWORK },
   { &Curl_cft_setup,          TRC_CT_PROTOCOL },
-#ifdef USE_NGHTTP2
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_NGHTTP2)
   { &Curl_cft_nghttp2,        TRC_CT_PROTOCOL },
 #endif
 #ifdef USE_SSL

--- a/lib/curlx/base64.c
+++ b/lib/curlx/base64.c
@@ -26,13 +26,6 @@
 
 #include "../curl_setup.h"
 
-#if !defined(CURL_DISABLE_HTTP_AUTH) || defined(USE_SSH) || \
-  !defined(CURL_DISABLE_LDAP) || \
-  !defined(CURL_DISABLE_SMTP) || \
-  !defined(CURL_DISABLE_POP3) || \
-  !defined(CURL_DISABLE_IMAP) || \
-  !defined(CURL_DISABLE_DIGEST_AUTH) || \
-  !defined(CURL_DISABLE_DOH) || defined(USE_SSL) || !defined(BUILDING_LIBCURL)
 #include <curl/curl.h>
 #include "warnless.h"
 #include "base64.h"
@@ -281,5 +274,3 @@ CURLcode curlx_base64url_encode(const char *inputbuff, size_t insize,
 {
   return base64_encode(base64url, 0, inputbuff, insize, outptr, outlen);
 }
-
-#endif /* no users so disabled */

--- a/lib/easy.c
+++ b/lib/easy.c
@@ -1328,7 +1328,7 @@ CURLcode curl_easy_ssls_import(CURL *d, const char *session_key,
                                const unsigned char *shmac, size_t shmac_len,
                                const unsigned char *sdata, size_t sdata_len)
 {
-#ifdef USE_SSLS_EXPORT
+#if defined(USE_SSL) && defined(USE_SSLS_EXPORT)
   struct Curl_easy *data = d;
   if(!GOOD_EASY_HANDLE(data))
     return CURLE_BAD_FUNCTION_ARGUMENT;
@@ -1349,7 +1349,7 @@ CURLcode curl_easy_ssls_export(CURL *d,
                                curl_ssls_export_cb *export_fn,
                                void *userptr)
 {
-#ifdef USE_SSLS_EXPORT
+#if defined(USE_SSL) && defined(USE_SSLS_EXPORT)
   struct Curl_easy *data = d;
   if(!GOOD_EASY_HANDLE(data))
     return CURLE_BAD_FUNCTION_ARGUMENT;

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -151,6 +151,7 @@ static void _ftp_state(struct Curl_easy *data,
   )
 {
 #if defined(CURL_DISABLE_VERBOSE_STRINGS)
+  (void)data;
 #ifdef DEBUGBUILD
   (void)lineno;
 #endif

--- a/lib/http.c
+++ b/lib/http.c
@@ -1077,7 +1077,9 @@ CURLcode Curl_http_input_auth(struct Curl_easy *data, bool proxy,
   }
   return result;
 #else
-  (void) proxy;
+  (void)data;
+  (void)proxy;
+  (void)auth;
   /* nothing to do when disabled */
   return CURLE_OK;
 #endif

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -24,7 +24,7 @@
 
 #include "curl_setup.h"
 
-#ifdef USE_NGHTTP2
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_NGHTTP2)
 #include <stdint.h>
 #include <nghttp2/nghttp2.h>
 #include "urldata.h"
@@ -3008,7 +3008,7 @@ void *Curl_nghttp2_realloc(void *ptr, size_t size, void *user_data)
   return Curl_crealloc(ptr, size);
 }
 
-#else /* !USE_NGHTTP2 */
+#else /* CURL_DISABLE_HTTP || !USE_NGHTTP2 */
 
 /* Satisfy external references even if http2 is not compiled in. */
 #include <curl/curl.h>
@@ -3027,4 +3027,4 @@ char *curl_pushheader_byname(struct curl_pushheaders *h, const char *header)
   return NULL;
 }
 
-#endif /* USE_NGHTTP2 */
+#endif /* !CURL_DISABLE_HTTP && USE_NGHTTP2 */

--- a/lib/md4.c
+++ b/lib/md4.c
@@ -64,10 +64,8 @@
 #endif
 #endif /* USE_MBEDTLS */
 
-#if defined(USE_GNUTLS)
-#include <nettle/md4.h>
 /* When OpenSSL or wolfSSL is available, we use their MD4 functions. */
-#elif defined(USE_WOLFSSL) && !defined(WOLFSSL_NO_MD4)
+#if defined(USE_WOLFSSL) && !defined(WOLFSSL_NO_MD4)
 #include <wolfssl/openssl/md4.h>
 #elif defined(USE_OPENSSL) && !defined(OPENSSL_NO_MD4)
 #include <openssl/md4.h>
@@ -83,6 +81,8 @@
 #include <CommonCrypto/CommonDigest.h>
 #elif defined(USE_WIN32_CRYPTO)
 #include <wincrypt.h>
+#elif defined(USE_GNUTLS)
+#include <nettle/md4.h>
 #elif(defined(USE_MBEDTLS) && defined(MBEDTLS_MD4_C))
 #include <mbedtls/md4.h>
 #endif
@@ -93,27 +93,7 @@
 #include "memdebug.h"
 
 
-#if defined(USE_GNUTLS)
-
-typedef struct md4_ctx MD4_CTX;
-
-static int MD4_Init(MD4_CTX *ctx)
-{
-  md4_init(ctx);
-  return 1;
-}
-
-static void MD4_Update(MD4_CTX *ctx, const void *data, unsigned long size)
-{
-  md4_update(ctx, size, data);
-}
-
-static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
-{
-  md4_digest(ctx, MD4_DIGEST_SIZE, result);
-}
-
-#elif defined(USE_WOLFSSL) && !defined(WOLFSSL_NO_MD4)
+#if defined(USE_WOLFSSL) && !defined(WOLFSSL_NO_MD4)
 
 #ifdef OPENSSL_COEXIST
   #define MD4_CTX WOLFSSL_MD4_CTX
@@ -191,6 +171,26 @@ static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
 
   if(ctx->hCryptProv)
     CryptReleaseContext(ctx->hCryptProv, 0);
+}
+
+#elif defined(USE_GNUTLS)
+
+typedef struct md4_ctx MD4_CTX;
+
+static int MD4_Init(MD4_CTX *ctx)
+{
+  md4_init(ctx);
+  return 1;
+}
+
+static void MD4_Update(MD4_CTX *ctx, const void *data, unsigned long size)
+{
+  md4_update(ctx, size, data);
+}
+
+static void MD4_Final(unsigned char *result, MD4_CTX *ctx)
+{
+  md4_digest(ctx, MD4_DIGEST_SIZE, result);
 }
 
 #elif(defined(USE_MBEDTLS) && defined(MBEDTLS_MD4_C))

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -357,7 +357,7 @@ static void smtp_state(struct Curl_easy *data,
                        struct smtp_conn *smtpc,
                        smtpstate newstate)
 {
-#if !defined(CURL_DISABLE_VERBOSE_STRINGS)
+#ifndef CURL_DISABLE_VERBOSE_STRINGS
   /* for debug purposes */
   static const char * const names[] = {
     "STOP",
@@ -379,6 +379,8 @@ static void smtp_state(struct Curl_easy *data,
   if(smtpc->state != newstate)
     CURL_TRC_SMTP(data, "state change from %s to %s",
                   names[smtpc->state], names[newstate]);
+#else
+  (void)data;
 #endif
 
   smtpc->state = newstate;

--- a/lib/version.c
+++ b/lib/version.c
@@ -197,7 +197,7 @@ char *curl_version(void)
 #ifdef USE_SSH
   char ssh_version[30];
 #endif
-#ifdef USE_NGHTTP2
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_NGHTTP2)
   char h2_version[30];
 #endif
 #ifdef USE_HTTP3
@@ -258,7 +258,7 @@ char *curl_version(void)
   Curl_ssh_version(ssh_version, sizeof(ssh_version));
   src[i++] = ssh_version;
 #endif
-#ifdef USE_NGHTTP2
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_NGHTTP2)
   Curl_http2_ver(h2_version, sizeof(h2_version));
   src[i++] = h2_version;
 #endif
@@ -488,7 +488,7 @@ static const struct feat features_table[] = {
 #ifndef CURL_DISABLE_HSTS
   FEATURE("HSTS",        NULL,                CURL_VERSION_HSTS),
 #endif
-#if defined(USE_NGHTTP2)
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_NGHTTP2)
   FEATURE("HTTP2",       NULL,                CURL_VERSION_HTTP2),
 #endif
 #if defined(USE_HTTP3)

--- a/lib/version.c
+++ b/lib/version.c
@@ -200,7 +200,7 @@ char *curl_version(void)
 #if !defined(CURL_DISABLE_HTTP) && defined(USE_NGHTTP2)
   char h2_version[30];
 #endif
-#ifdef USE_HTTP3
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3)
   char h3_version[30];
 #endif
 #ifdef USE_LIBRTMP
@@ -262,7 +262,7 @@ char *curl_version(void)
   Curl_http2_ver(h2_version, sizeof(h2_version));
   src[i++] = h2_version;
 #endif
-#ifdef USE_HTTP3
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3)
   Curl_quic_ver(h3_version, sizeof(h3_version));
   src[i++] = h3_version;
 #endif
@@ -491,7 +491,7 @@ static const struct feat features_table[] = {
 #if !defined(CURL_DISABLE_HTTP) && defined(USE_NGHTTP2)
   FEATURE("HTTP2",       NULL,                CURL_VERSION_HTTP2),
 #endif
-#if defined(USE_HTTP3)
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3)
   FEATURE("HTTP3",       NULL,                CURL_VERSION_HTTP3),
 #endif
 #if defined(USE_SSL) && !defined(CURL_DISABLE_PROXY) && \
@@ -673,7 +673,7 @@ curl_version_info_data *curl_version_info(CURLversion stamp)
   }
 #endif
 
-#ifdef USE_HTTP3
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3)
   {
     static char quicbuffer[80];
     Curl_quic_ver(quicbuffer, sizeof(quicbuffer));

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -24,7 +24,7 @@
 
 #include "../curl_setup.h"
 
-#if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_NGTCP2) && defined(USE_NGHTTP3)
 #include <ngtcp2/ngtcp2.h>
 #include <nghttp3/nghttp3.h>
 

--- a/lib/vquic/curl_ngtcp2.h
+++ b/lib/vquic/curl_ngtcp2.h
@@ -26,7 +26,7 @@
 
 #include "../curl_setup.h"
 
-#if defined(USE_NGTCP2) && defined(USE_NGHTTP3)
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_NGTCP2) && defined(USE_NGHTTP3)
 
 #ifdef HAVE_NETINET_UDP_H
 #include <netinet/udp.h>

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -24,7 +24,8 @@
 
 #include "../curl_setup.h"
 
-#if defined(USE_OPENSSL_QUIC) && defined(USE_NGHTTP3)
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_OPENSSL_QUIC) && \
+  defined(USE_NGHTTP3)
 
 #include <openssl/ssl.h>
 #include <openssl/bio.h>
@@ -2443,4 +2444,4 @@ void Curl_osslq_ver(char *p, size_t len)
   (void)msnprintf(p, len, "nghttp3/%s", ht3->version_str);
 }
 
-#endif /* USE_OPENSSL_QUIC && USE_NGHTTP3 */
+#endif /* !CURL_DISABLE_HTTP && USE_OPENSSL_QUIC && USE_NGHTTP3 */

--- a/lib/vquic/curl_osslq.h
+++ b/lib/vquic/curl_osslq.h
@@ -26,7 +26,8 @@
 
 #include "../curl_setup.h"
 
-#if defined(USE_OPENSSL_QUIC) && defined(USE_NGHTTP3)
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_OPENSSL_QUIC) && \
+  defined(USE_NGHTTP3)
 
 #ifdef HAVE_NETINET_UDP_H
 #include <netinet/udp.h>

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -24,7 +24,7 @@
 
 #include "../curl_setup.h"
 
-#ifdef USE_QUICHE
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_QUICHE)
 #include <quiche.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>

--- a/lib/vquic/curl_quiche.h
+++ b/lib/vquic/curl_quiche.h
@@ -26,7 +26,7 @@
 
 #include "../curl_setup.h"
 
-#ifdef USE_QUICHE
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_QUICHE)
 
 #include <quiche.h>
 #include <openssl/ssl.h>

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -52,7 +52,7 @@
 #include "../memdebug.h"
 
 
-#ifdef USE_HTTP3
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3)
 
 #define NW_CHUNK_SIZE     (64 * 1024)
 #define NW_SEND_CHUNKS    2
@@ -728,7 +728,7 @@ CURLcode Curl_conn_may_http3(struct Curl_easy *data,
   return CURLE_OK;
 }
 
-#else /* USE_HTTP3 */
+#else /* CURL_DISABLE_HTTP || !USE_HTTP3 */
 
 CURLcode Curl_conn_may_http3(struct Curl_easy *data,
                              const struct connectdata *conn,
@@ -741,4 +741,4 @@ CURLcode Curl_conn_may_http3(struct Curl_easy *data,
   return CURLE_NOT_BUILT_IN;
 }
 
-#endif /* !USE_HTTP3 */
+#endif /* !CURL_DISABLE_HTTP && USE_HTTP3 */

--- a/lib/vquic/vquic.h
+++ b/lib/vquic/vquic.h
@@ -26,7 +26,7 @@
 
 #include "../curl_setup.h"
 
-#ifdef USE_HTTP3
+#if !defined(CURL_DISABLE_HTTP) && defined(USE_HTTP3)
 struct Curl_cfilter;
 struct Curl_easy;
 struct connectdata;
@@ -51,7 +51,7 @@ extern struct Curl_cftype Curl_cft_http3;
 
 #else
 #define Curl_vquic_init() 1
-#endif /* !USE_HTTP3 */
+#endif /* !CURL_DISABLE_HTTP && USE_HTTP3 */
 
 CURLcode Curl_conn_may_http3(struct Curl_easy *data,
                              const struct connectdata *conn,

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -218,10 +218,10 @@ static CURLcode sftp_error_to_CURLE(int err)
   return CURLE_SSH;
 }
 
-#ifndef DEBUGBUILD
-#define myssh_to(x,y,z) myssh_set_state(x,y,z)
-#else
+#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
 #define myssh_to(x,y,z) myssh_set_state(x,y,z, __LINE__)
+#else
+#define myssh_to(x,y,z) myssh_set_state(x,y,z)
 #endif
 
 /*
@@ -231,7 +231,7 @@ static CURLcode sftp_error_to_CURLE(int err)
 static void myssh_set_state(struct Curl_easy *data,
                             struct ssh_conn *sshc,
                             sshstate nowstate
-#ifdef DEBUGBUILD
+#if defined(DEBUGBUILD) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
                           , int lineno
 #endif
   )

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -137,9 +137,11 @@ static bool blobcmp(struct curl_blob *first, struct curl_blob *second)
 }
 
 #ifdef USE_SSL
+#if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_PROXY)
 static const struct alpn_spec ALPN_SPEC_H11 = {
   { ALPN_HTTP_1_1 }, 1
 };
+#endif /* !CURL_DISABLE_HTTP || !CURL_DISABLE_PROXY */
 #ifdef USE_HTTP2
 static const struct alpn_spec ALPN_SPEC_H2 = {
   { ALPN_H2 }, 1

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -1648,6 +1648,7 @@ static CURLcode cf_ssl_create(struct Curl_cfilter **pcf,
   DEBUGASSERT(data->conn);
 
 #ifdef CURL_DISABLE_HTTP
+  (void)conn;
   /* We only support ALPN for HTTP so far. */
   DEBUGASSERT(!conn->bits.tls_enable_alpn);
   ctx = cf_ctx_new(data, NULL);

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -149,6 +149,7 @@ static const struct alpn_spec ALPN_SPEC_H2_H11 = {
 };
 #endif
 
+#if !defined(CURL_DISABLE_HTTP) || !defined(CURL_DISABLE_PROXY)
 static const struct alpn_spec *
 alpn_get_spec(http_majors allowed, bool use_alpn)
 {
@@ -167,6 +168,7 @@ alpn_get_spec(http_majors allowed, bool use_alpn)
      Avoid "http/1.0" because some servers do not support it. */
   return &ALPN_SPEC_H11;
 }
+#endif /* !CURL_DISABLE_HTTP || !CURL_DISABLE_PROXY */
 #endif /* USE_SSL */
 
 

--- a/lib/vtls/vtls_spack.c
+++ b/lib/vtls/vtls_spack.c
@@ -24,7 +24,7 @@
 
 #include "../curl_setup.h"
 
-#ifdef USE_SSLS_EXPORT
+#if defined(USE_SSL) && defined(USE_SSLS_EXPORT)
 
 #include "../urldata.h"
 #include "../curl_trc.h"
@@ -343,4 +343,4 @@ out:
   return r;
 }
 
-#endif /* USE_SSLS_EXPORT */
+#endif /* USE_SSL && USE_SSLS_EXPORT */

--- a/lib/vtls/vtls_spack.h
+++ b/lib/vtls/vtls_spack.h
@@ -25,7 +25,7 @@
  ***************************************************************************/
 #include "../curl_setup.h"
 
-#ifdef USE_SSLS_EXPORT
+#if defined(USE_SSL) && defined(USE_SSLS_EXPORT)
 
 struct dynbuf;
 struct Curl_ssl_session;
@@ -38,6 +38,6 @@ CURLcode Curl_ssl_session_unpack(struct Curl_easy *data,
                                  const void *bufv, size_t buflen,
                                  struct Curl_ssl_session **ps);
 
-#endif /* USE_SSLS_EXPORT */
+#endif /* USE_SSL && USE_SSLS_EXPORT */
 
 #endif /* HEADER_CURL_VTLS_SPACK_H */

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -1542,6 +1542,7 @@ CURLcode Curl_wssl_verify_pinned(struct Curl_cfilter *cf,
     data->set.str[STRING_SSL_PINNEDPUBLICKEY];
 #else
   const char * const pinnedpubkey = data->set.str[STRING_SSL_PINNEDPUBLICKEY];
+  (void)cf;
 #endif
 
   if(pinnedpubkey) {

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -49,9 +49,6 @@ my %wl = (
     'Curl_creader_def_total_length' => 'internal api',
     'Curl_meta_reset' => 'internal api',
     'Curl_trc_dns' => 'internal api',
-    'curlx_base64_decode' => 'internal api',
-    'curlx_base64_encode' => 'internal api',
-    'curlx_base64url_encode' => 'internal api',
 );
 
 my %api = (

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -49,6 +49,9 @@ my %wl = (
     'Curl_creader_def_total_length' => 'internal api',
     'Curl_meta_reset' => 'internal api',
     'Curl_trc_dns' => 'internal api',
+    'curlx_base64_decode' => 'internal api',
+    'curlx_base64_encode' => 'internal api',
+    'curlx_base64url_encode' => 'internal api',
 );
 
 my %api = (

--- a/tests/certs/CMakeLists.txt
+++ b/tests/certs/CMakeLists.txt
@@ -31,7 +31,11 @@ add_custom_command(OUTPUT ${GENERATEDCERTS}
   VERBATIM
 )
 add_custom_target(build-certs DEPENDS ${GENERATEDCERTS})
-add_dependencies(testdeps build-certs)
+
+option(_CURL_SKIP_BUILD_CERTS "Skip building certs with testdeps" OFF)  # Internal option to increase perf for build tests
+if(NOT _CURL_SKIP_BUILD_CERTS)
+  add_dependencies(testdeps build-certs)
+endif()
 
 add_custom_target(clean-certs
   COMMAND ${CMAKE_COMMAND} -E remove ${GENERATEDCERTS}


### PR DESCRIPTION
- vtls: fix unused variable and symbols.
- ftp: fix unused variable.
- http: fix unused variables.
- smtp: fix unsued variable.
- wolfssl: fix unused variable with !proxy.
- libssh: fix unused argument.
- curl_trc: sync guards between declaration and definition.
- curl_trc: add missing guard for `Curl_trc_ssls` when !verbose.
- curl_trc: fix errors with !http + http3.
- curl_trc: fix missing function with !http + nghttp2.
- cf-h2-proxy: disable when !http + nghttp2, to avoid calling undeclared
  functions.
- sha256: fix missing declaration in rare configs.
- md4: fix symbol conflict when building GnuTLS together with AWS-LC or
  wolfSSL. By prioritizing the latter two. AWS-LC has no option
  to disable the clashing symbol. wolfSSL does, but the most seamless is
  to skip including GnuTLS's standalone `md4.h` to avoid the clash.
- build: fix errors with !http + nghttp2.
- build: catch !ssl + ssls-export combination in source. Convert
  build-level errors to warnings.
- build: fix errors with !http + http3.
- build: fix building curl tool and unit1302 in rare combinations.
  By always compiling base64 curlx functions.
- cmake: add `_CURL_SKIP_BUILD_CERTS` internal option.
  To disable automatically building certs with the testdeps target.
  To improve performance when testing builds.
  (used locally to find the failing builds fixed in this PR.)
