### PR TITLE
cmake: make `runtests` targets build the curl tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,6 +175,7 @@ else()
 endif()
 
 set(LIB_NAME "libcurl")
+set(EXE_NAME "curl")
 
 set_property(DIRECTORY APPEND PROPERTY INCLUDE_DIRECTORIES "${PROJECT_SOURCE_DIR}/include")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
+
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
 
 set(_curl_cfiles_gen "")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,6 @@
 # SPDX-License-Identifier: curl
 #
 ###########################################################################
-set(EXE_NAME curl)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS "${CURL_DEBUG_MACROS}")
 
 set(_curl_cfiles_gen "")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,7 +31,7 @@ configure_file("config.in" "${CMAKE_CURRENT_BINARY_DIR}/config" @ONLY)
 
 add_custom_target(testdeps)
 if(BUILD_CURL_EXE)
-  add_dependencies(testdeps curlinfo)
+  add_dependencies(testdeps ${EXE_NAME} curlinfo)
 endif()
 
 if(CURL_CLANG_TIDY)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,9 +30,6 @@ mark_as_advanced(TEST_NGHTTPX)
 configure_file("config.in" "${CMAKE_CURRENT_BINARY_DIR}/config" @ONLY)
 
 add_custom_target(testdeps)
-if(BUILD_CURL_EXE)
-  add_dependencies(testdeps ${EXE_NAME} curlinfo)
-endif()
 
 if(CURL_CLANG_TIDY)
   add_custom_target(tests-clang-tidy)
@@ -57,7 +54,10 @@ function(curl_add_runtests _targetname _test_flags)
   # This avoids: GNU Make doing a slow re-evaluation of all targets and
   # skipping them, MSBuild doing a re-evaluation, and actually rebuilding them.
   if(NOT _targetname STREQUAL "test-ci")
-    set(_depends "testdeps")
+    if(BUILD_CURL_EXE)
+      list(APPEND _depends ${EXE_NAME} curlinfo)
+    endif()
+    list(APPEND _depends "testdeps")
   endif()
   # Use a special '$TFLAGS' placeholder as last argument which will be
   # replaced by the contents of the environment variable in runtests.pl.
@@ -78,7 +78,10 @@ endfunction()
 function(curl_add_pytests _targetname _test_flags)
   set(_depends "")
   if(NOT _targetname STREQUAL "pytest-ci")
-    set(_depends "clients")
+    if(BUILD_CURL_EXE)
+      list(APPEND _depends ${EXE_NAME})
+    endif()
+    list(APPEND _depends "clients")
   endif()
   string(REPLACE " " ";" _test_flags_list "${_test_flags}")
   add_custom_target(${_targetname}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -53,9 +53,12 @@ function(curl_add_runtests _targetname _test_flags)
   # Skip walking through dependent targets before running tests in CI.
   # This avoids: GNU Make doing a slow re-evaluation of all targets and
   # skipping them, MSBuild doing a re-evaluation, and actually rebuilding them.
+  if(BUILD_CURL_EXE)
+    list(APPEND _depends curlinfo)
+  endif()
   if(NOT _targetname STREQUAL "test-ci")
     if(BUILD_CURL_EXE)
-      list(APPEND _depends ${EXE_NAME} curlinfo)
+      list(APPEND _depends ${EXE_NAME})
     endif()
     list(APPEND _depends "testdeps")
   endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,9 @@ mark_as_advanced(TEST_NGHTTPX)
 configure_file("config.in" "${CMAKE_CURRENT_BINARY_DIR}/config" @ONLY)
 
 add_custom_target(testdeps)
+if(BUILD_CURL_EXE)
+  add_dependencies(testdeps curlinfo)
+endif()
 
 if(CURL_CLANG_TIDY)
   add_custom_target(tests-clang-tidy)
@@ -53,9 +56,6 @@ function(curl_add_runtests _targetname _test_flags)
   # Skip walking through dependent targets before running tests in CI.
   # This avoids: GNU Make doing a slow re-evaluation of all targets and
   # skipping them, MSBuild doing a re-evaluation, and actually rebuilding them.
-  if(BUILD_CURL_EXE)
-    list(APPEND _depends curlinfo)
-  endif()
   if(NOT _targetname STREQUAL "test-ci")
     if(BUILD_CURL_EXE)
       list(APPEND _depends ${EXE_NAME})


### PR DESCRIPTION
To allow running tests just by building the `test-full` (or similar) in
a single step.
