### PR TITLE
pytest: increase server KeepAliveTimeout

### DIFF
--- a/tests/http/testenv/httpd.py
+++ b/tests/http/testenv/httpd.py
@@ -310,6 +310,7 @@ class Httpd:
                 f'LogLevel {self._get_log_level()}',
                 'StartServers 4',
                 'ReadBufferSize 16000',
+                'KeepAliveTimeout 30',  # CI may exceed the default of 5 sec
                 'H2MinWorkers 16',
                 'H2MaxWorkers 256',
                 f'TypesConfig "{self._conf_dir}/mime.types',


### PR DESCRIPTION
When CI is not able to give clients enough cpu, the default Apache KeepAliveTimeout of 5 seconds may trigger and cause tests to fail.

Increase the timeout to 30 seconds for reliability.

refs #17963

e Bitte geben Sie eine Commit-Beschreibung für Ihre Änderungen ein. Zeilen,