### PR TITLE
multissl: initialize when requesting a random number

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,9 +118,9 @@ jobs:
             PKG_CONFIG_PATH: /home/runner/mbedtls/lib/pkgconfig  # Requires v3.6.0 or v2.28.8
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
 
-          - name: 'mbedtls-pkg'
+          - name: 'mbedtls-pkg MultiSSL !debug'
             install_packages: libnghttp2-dev libmbedtls-dev
-            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
+            generate: -DCURL_USE_MBEDTLS=ON -DCURL_DEFAULT_SSL_BACKEND=mbedtls -DCURL_USE_OPENSSL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
 
           - name: 'mbedtls-pkg !pc'
             install_packages: libnghttp2-dev libmbedtls-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -118,9 +118,9 @@ jobs:
             PKG_CONFIG_PATH: /home/runner/mbedtls/lib/pkgconfig  # Requires v3.6.0 or v2.28.8
             generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON
 
-          - name: 'mbedtls-pkg MultiSSL !debug'
+          - name: 'mbedtls-pkg MultiSSL'
             install_packages: libnghttp2-dev libmbedtls-dev
-            generate: -DCURL_USE_MBEDTLS=ON -DCURL_DEFAULT_SSL_BACKEND=mbedtls -DCURL_USE_OPENSSL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
+            generate: -DCURL_USE_MBEDTLS=ON -DENABLE_DEBUG=ON -DCURL_DEFAULT_SSL_BACKEND=mbedtls -DCURL_USE_OPENSSL=ON -DBUILD_LIBCURL_DOCS=OFF -DBUILD_MISC_DOCS=OFF -DENABLE_CURL_MANUAL=OFF
 
           - name: 'mbedtls-pkg !pc'
             install_packages: libnghttp2-dev libmbedtls-dev

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -295,10 +295,10 @@ jobs:
             install: brotli wolfssl zstd
             install_steps: pytest
             generate: -DCURL_USE_WOLFSSL=ON -DCURL_DISABLE_LDAP=ON -DUSE_ECH=ON
-          - name: 'mbedTLS !ldap brotli zstd'
+          - name: 'mbedTLS !ldap brotli zstd MultiSSL'
             compiler: llvm@18
             install: brotli mbedtls zstd
-            generate: -DCURL_USE_MBEDTLS=ON -DCURL_DISABLE_LDAP=ON
+            generate: -DCURL_USE_MBEDTLS=ON -DCURL_DISABLE_LDAP=ON -DCURL_DEFAULT_SSL_BACKEND=mbedtls -DCURL_USE_OPENSSL=ON
           - name: 'GnuTLS !ldap krb5'
             install: gnutls nettle krb5
             generate: -DENABLE_DEBUG=ON -DCURL_USE_GNUTLS=ON -DCURL_USE_OPENSSL=OFF -DCURL_USE_GSSAPI=ON -DGSS_ROOT_DIR=/opt/homebrew/opt/krb5 -DCURL_DISABLE_LDAP=ON -DUSE_SSLS_EXPORT=ON

--- a/lib/vtls/vtls.c
+++ b/lib/vtls/vtls.c
@@ -882,6 +882,14 @@ static int multissl_init(void)
   return 1;
 }
 
+static CURLcode multissl_random(struct Curl_easy *data,
+                                unsigned char *entropy, size_t length)
+{
+  if(multissl_setup(NULL))
+    return CURLE_FAILED_INIT;
+  return Curl_ssl->random(data, entropy, length);
+}
+
 static CURLcode multissl_connect(struct Curl_cfilter *cf,
                                  struct Curl_easy *data, bool *done)
 {
@@ -943,7 +951,7 @@ static const struct Curl_ssl Curl_ssl_multi = {
   multissl_version,                  /* version */
   NULL,                              /* shutdown */
   NULL,                              /* data_pending */
-  NULL,                              /* random */
+  multissl_random,                   /* random */
   NULL,                              /* cert_status_request */
   multissl_connect,                  /* connect */
   multissl_adjust_pollset,           /* adjust_pollset */


### PR DESCRIPTION
To fix test 1308 in MultiSSL builds.

Failure was caused by the random number generator virtual function being
NULL, instead of pointing to the implementation in the runtime-selected
TLS backend. This could happen in MultiSSL builds when a functionality
was asking for a random number without triggering a VTLS function table
initialization first. Such functionality is MIME, or form data via MIME.

The reason CI did not catch it in an earlier MultiSSL GHA/windows job,
is that it was a debug-enabled one. In debug-enabled builds the test
runner was overriding the random number generator for all tests.

Fixed this by moving the override to the tests requiring it, via
1fcf22585fa3d87a50c9dddc688d962978c0c120 #17971, enabling debug builds
to catch this issue.

Enable MultiSSL in two CI jobs, to verify this patch.

Fixing:
```
test 1308...[formpost tests]

libtests returned 44, when expecting 0
 1308: exit FAILED
[...]
=== Start of file stderr1308
 URL: log/3/test-1308
 tests/libtest/lib1308.c:70 Assertion 'res == 0' FAILED: curl_formget returned error
 tests/libtest/lib1308.c:72 Assertion 'total_size == 518' FAILED: curl_formget got wrong size back
 tests/libtest/lib1308.c:88 Assertion 'res == 0' FAILED: curl_formget returned error
 tests/libtest/lib1308.c:89 Assertion 'total_size == 899' FAILED: curl_formget got wrong size back
```
Ref: https://github.com/curl/curl/actions/runs/16387693424/job/46309536359?pr=17963#step:16:2515

Bug: https://github.com/curl/curl/pull/17963#issuecomment-3092282057

---

- [x] merge #17971 first, then re-enable debug for the `mbedtls pkg` job.
