### PR TITLE
tests: set `CURL_ENTROPY` per test, not globally

### DIFF
--- a/tests/data/test1972
+++ b/tests/data/test1972
@@ -39,6 +39,9 @@ Debug
 crypto
 aws
 </features>
+<setenv>
+CURL_ENTROPY=12345678
+</setenv>
 
 <name>
 HTTP AWS_SIGV4 for AWS S3: MIMEPOST

--- a/tests/data/test2300
+++ b/tests/data/test2300
@@ -25,11 +25,14 @@ upgrade
 #
 # Client-side
 <client>
-# for the forced CURL_ENTROPY
+# require Debug for the forced CURL_ENTROPY
 <features>
 Debug
 ws
 </features>
+<setenv>
+CURL_ENTROPY=12345678
+</setenv>
 <server>
 http
 </server>

--- a/tests/data/test2301
+++ b/tests/data/test2301
@@ -32,6 +32,9 @@ upgrade
 Debug
 ws
 </features>
+<setenv>
+CURL_ENTROPY=12345678
+</setenv>
 <server>
 http
 </server>

--- a/tests/data/test2302
+++ b/tests/data/test2302
@@ -32,6 +32,9 @@ upgrade
 Debug
 ws
 </features>
+<setenv>
+CURL_ENTROPY=12345678
+</setenv>
 <server>
 http
 </server>

--- a/tests/data/test2303
+++ b/tests/data/test2303
@@ -25,6 +25,9 @@ hello
 Debug
 ws
 </features>
+<setenv>
+CURL_ENTROPY=12345678
+</setenv>
 <server>
 http
 </server>

--- a/tests/data/test2304
+++ b/tests/data/test2304
@@ -31,6 +31,9 @@ upgrade
 Debug
 ws
 </features>
+<setenv>
+CURL_ENTROPY=12345678
+</setenv>
 <server>
 http
 </server>

--- a/tests/data/test823
+++ b/tests/data/test823
@@ -40,6 +40,9 @@ Debug
 crypto
 digest
 </features>
+<setenv>
+CURL_ENTROPY=12345678
+</setenv>
 <name>
 IMAP DIGEST-MD5 authentication
 </name>

--- a/tests/data/test869
+++ b/tests/data/test869
@@ -42,6 +42,9 @@ Debug
 crypto
 digest
 </features>
+<setenv>
+CURL_ENTROPY=12345678
+</setenv>
 <name>
 POP3 DIGEST-MD5 authentication
 </name>

--- a/tests/data/test907
+++ b/tests/data/test907
@@ -32,6 +32,9 @@ Debug
 crypto
 digest
 </features>
+<setenv>
+CURL_ENTROPY=12345678
+</setenv>
 <name>
 SMTP DIGEST-MD5 authentication
 </name>

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -163,7 +163,6 @@ sub runner_init {
 
     # enable memory debugging if curl is compiled with it
     $ENV{'CURL_MEMDEBUG'} = "$logdir/$MEMDUMP";
-    $ENV{'CURL_ENTROPY'}="12345678";
     $ENV{'CURL_FORCETIME'}=1; # for debug NTLM magic
     $ENV{'CURL_GLOBAL_INIT'}=1; # debug curl_global_init/cleanup use
     $ENV{'HOME'}=$pwd;

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -163,6 +163,7 @@ sub runner_init {
 
     # enable memory debugging if curl is compiled with it
     $ENV{'CURL_MEMDEBUG'} = "$logdir/$MEMDUMP";
+    delete $ENV{'CURL_ENTROPY'} if($ENV{'CURL_ENTROPY'});
     $ENV{'CURL_FORCETIME'}=1; # for debug NTLM magic
     $ENV{'CURL_GLOBAL_INIT'}=1; # debug curl_global_init/cleanup use
     $ENV{'HOME'}=$pwd;


### PR DESCRIPTION
Setting `CURL_ENTROPY` in debug-enabled builds overrides the code paths
responsible for random number generation. To avoid masking issue there,
this patch moves `CURL_ENTROPY` settings to each test that requires it,
and stop setting it by default for all tests (in `runner.pm`).

This makes it possible to catch random generator issues in debug-enabled
builds; extending test coverage.

To keep offering a well-defined state for tests, make `runner.pm` delete
the `CURL_ENTROPY` env, if present.

Ref: #17970
