### PR TITLE
GHA/macos: enable QUIC API with OpenSSL

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -264,8 +264,9 @@ jobs:
             configure: --enable-debug --with-openssl=/opt/homebrew/opt/libressl
           - name: 'OpenSSL'
             compiler: clang
+            install: libnghttp3 libngtcp2
             install_steps: pytest
-            configure: --enable-debug --with-openssl=/opt/homebrew/opt/openssl
+            configure: --enable-debug --with-openssl=/opt/homebrew/opt/openssl --with-ngtcp2
           - name: 'OpenSSL event-based'
             compiler: clang
             configure: --enable-debug --with-openssl=/opt/homebrew/opt/openssl
@@ -277,8 +278,8 @@ jobs:
             macos-version-min: '10.15'
           # cmake
           - name: 'OpenSSL gsasl rtmp AppleIDN'
-            install: gsasl rtmpdump
-            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCURL_USE_GSASL=ON -DUSE_LIBRTMP=ON -DUSE_APPLE_IDN=ON
+            install: libnghttp3 libngtcp2 gsasl rtmpdump
+            generate: -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DCURL_USE_GSASL=ON -DUSE_LIBRTMP=ON -DUSE_APPLE_IDN=ON -DUSE_NGHTTP3=ON -DUSE_NGTCP2=ON
           - name: 'MultiSSL AppleIDN clang-tidy +examples'
             compiler: clang
             install: llvm brotli zstd gnutls nettle mbedtls gsasl rtmpdump fish
@@ -312,13 +313,15 @@ jobs:
             generate: -DENABLE_DEBUG=ON -DCURL_USE_RUSTLS=ON -DUSE_ECH=ON -DCURL_DISABLE_LDAP=ON
           - name: 'OpenSSL torture !FTP'
             compiler: clang
+            install: libnghttp3
             install_steps: torture
-            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl
+            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_OPENSSL_QUIC=ON
             tflags: -t --shallow=25 !FTP
           - name: 'OpenSSL torture FTP'
             compiler: clang
+            install: libnghttp3
             install_steps: torture
-            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl
+            generate: -DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DENABLE_THREADED_RESOLVER=OFF -DOPENSSL_ROOT_DIR=/opt/homebrew/opt/openssl -DUSE_OPENSSL_QUIC=ON
             tflags: -t --shallow=20 FTP
         exclude:
           # opt out jobs from combinations that have the compiler set manually

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -493,6 +493,8 @@ class TestDownload:
     # TODO: just uses a single connection for h2/h3. Not sure how to prevent that
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_26_session_shared_reuse(self, env: Env, proto, httpd, nghttpx):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
         url = f'https://{env.authority_for(env.domain1, proto)}/data-100k'
         client = LocalClient(name='tls_session_reuse', env=env)
         if not client.exists():
@@ -503,6 +505,8 @@ class TestDownload:
     # test on paused transfers, based on issue #11982
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_27a_paused_no_cl(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
         url = f'https://{env.authority_for(env.domain1, proto)}' \
             '/curltest/tweak/?&chunks=6&chunk_size=8000'
         client = LocalClient(env=env, name='h2_pausing')
@@ -512,6 +516,8 @@ class TestDownload:
     # test on paused transfers, based on issue #11982
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_27b_paused_no_cl(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
         url = f'https://{env.authority_for(env.domain1, proto)}' \
             '/curltest/tweak/?error=502'
         client = LocalClient(env=env, name='h2_pausing')
@@ -521,6 +527,8 @@ class TestDownload:
     # test on paused transfers, based on issue #11982
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_27c_paused_no_cl(self, env: Env, httpd, nghttpx, proto):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
         url = f'https://{env.authority_for(env.domain1, proto)}' \
             '/curltest/tweak/?status=200&chunks=1&chunk_size=100'
         client = LocalClient(env=env, name='h2_pausing')
@@ -557,6 +565,8 @@ class TestDownload:
     @pytest.mark.parametrize("pause_offset", [0, 10*1024, 100*1023, 640000])
     @pytest.mark.parametrize("proto", ['http/1.1', 'h2', 'h3'])
     def test_02_29_h2_lib_serial(self, env: Env, httpd, nghttpx, proto, pause_offset):
+        if proto == 'h3' and not env.have_h3():
+            pytest.skip("h3 not supported")
         count = 2
         docname = 'data-10m'
         url = f'https://localhost:{env.https_port}/{docname}'


### PR DESCRIPTION
In one autotools and one cmake job.

Also:
- enable OpenSSL QUIC in two more jobs.
- pytest: add checks to skip h3 tests when there is no h3 server to
  tests 26, 27a, 27b, 27c, 29 in test_02_download. Fixing:
  ```
  FAILED tests/http/test_02_download.py::TestDownload::test_02_26_session_shared_reuse[h3] - AssertionError: expected exit code 0, got 1
  [...]
  ```
  Ref: https://github.com/curl/curl/actions/runs/16392680316/job/46320739635?pr=17973

Ref: https://github.com/Homebrew/homebrew-core/pull/230515
Ref: https://github.com/Homebrew/homebrew-core/commit/6c8e3eed129ed362da8b97b94f1a5372b2289e09
