### PR TITLE
build: enable _GNU_SOURCE on GNU/Hurd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,7 @@ endif()
 
 include(PickyWarnings)
 
-if(CYGWIN OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CYGWIN OR CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
   set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS "_GNU_SOURCE")  # Required for accept4(), pipe2(), sendmmsg()
   list(APPEND CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")  # Apply to all feature checks
 endif()

--- a/configure.ac
+++ b/configure.ac
@@ -574,7 +574,7 @@ AM_CONDITIONAL(BUILD_UNITTESTS, test x$supports_unittests = xyes)
 # In order to detect support of sendmmsg() and accept4(), we need to escape the POSIX
 # jail by defining _GNU_SOURCE or <sys/socket.h> will not expose it.
 case $host_os in
-  *linux*|cygwin*|msys*)
+  *linux*|cygwin*|msys*|gnu*)
     CPPFLAGS="$CPPFLAGS -D_GNU_SOURCE"
     ;;
 esac


### PR DESCRIPTION
Unconditionally enable `_GNU_SOURCE` when building on GNU/Hurd; this way it is possible to properly use/rely on GNU extensions e.g. `accept4()`, `memrchr()`, and the GNU `strerror_r()`.