### PR TITLE
windows: target version macro tidy-ups

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2834,7 +2834,8 @@ AS_HELP_STRING([--without-winidn], [disable Windows native IDN]),
       AC_LANG_PROGRAM([[
         #include <windows.h>
       ]],[[
-        #if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
+        #if (!defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600) && \
+          (!defined(WINVER) || WINVER < 0x600)
         WINBASEAPI int WINAPI IdnToUnicode(DWORD dwFlags,
                                            const WCHAR *lpASCIICharStr,
                                            int cchASCIIChar,

--- a/configure.ac
+++ b/configure.ac
@@ -2834,8 +2834,7 @@ AS_HELP_STRING([--without-winidn], [disable Windows native IDN]),
       AC_LANG_PROGRAM([[
         #include <windows.h>
       ]],[[
-        #if (!defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600) && \
-          (!defined(WINVER) || WINVER < 0x600)
+        #if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
         WINBASEAPI int WINAPI IdnToUnicode(DWORD dwFlags,
                                            const WCHAR *lpASCIICharStr,
                                            int cchASCIIChar,

--- a/configure.ac
+++ b/configure.ac
@@ -5382,7 +5382,7 @@ else
     AC_LANG_PROGRAM([[
       #include <windows.h>
     ]],[[
-      #if _WIN32_WINNT < 0x600
+      #if (_WIN32_WINNT < 0x600)
       #error
       #endif
     ]])

--- a/configure.ac
+++ b/configure.ac
@@ -5381,7 +5381,7 @@ else
     AC_LANG_PROGRAM([[
       #include <windows.h>
     ]],[[
-      #if (WINVER < 0x600) && (_WIN32_WINNT < 0x600)
+      #if _WIN32_WINNT < 0x600
       #error
       #endif
     ]])

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -48,10 +48,7 @@
 #    ifndef _WIN32_WINNT
 #    define _WIN32_WINNT VS2012_DEF_TARGET
 #    endif
-#    ifndef WINVER
-#    define WINVER VS2012_DEF_TARGET
-#    endif
-#    if (_WIN32_WINNT < VS2012_MIN_TARGET) || (WINVER < VS2012_MIN_TARGET)
+#    if _WIN32_WINNT < VS2012_MIN_TARGET
 #      ifdef _USING_V110_SDK71_
 #        error VS2012 does not support build targets prior to Windows XP
 #      else
@@ -69,10 +66,7 @@
 #    ifndef _WIN32_WINNT
 #    define _WIN32_WINNT VS2008_DEF_TARGET
 #    endif
-#    ifndef WINVER
-#    define WINVER VS2008_DEF_TARGET
-#    endif
-#    if (_WIN32_WINNT < VS2008_MIN_TARGET) || (WINVER < VS2008_MIN_TARGET)
+#    if _WIN32_WINNT < VS2008_MIN_TARGET
 #      error VS2008 does not support build targets prior to Windows XP
 #    endif
 #  endif

--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -48,7 +48,10 @@
 #    ifndef _WIN32_WINNT
 #    define _WIN32_WINNT VS2012_DEF_TARGET
 #    endif
-#    if _WIN32_WINNT < VS2012_MIN_TARGET
+#    ifndef WINVER
+#    define WINVER VS2012_DEF_TARGET
+#    endif
+#    if (_WIN32_WINNT < VS2012_MIN_TARGET) || (WINVER < VS2012_MIN_TARGET)
 #      ifdef _USING_V110_SDK71_
 #        error VS2012 does not support build targets prior to Windows XP
 #      else
@@ -66,7 +69,10 @@
 #    ifndef _WIN32_WINNT
 #    define _WIN32_WINNT VS2008_DEF_TARGET
 #    endif
-#    if _WIN32_WINNT < VS2008_MIN_TARGET
+#    ifndef WINVER
+#    define WINVER VS2008_DEF_TARGET
+#    endif
+#    if (_WIN32_WINNT < VS2008_MIN_TARGET) || (WINVER < VS2008_MIN_TARGET)
 #      error VS2008 does not support build targets prior to Windows XP
 #    endif
 #  endif

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -142,8 +142,7 @@ void Curl_thread_destroy(curl_thread_t *hnd)
 
 int Curl_thread_join(curl_thread_t *hnd)
 {
-#if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || \
-    (_WIN32_WINNT < _WIN32_WINNT_VISTA)
+#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < _WIN32_WINNT_VISTA)
   int ret = (WaitForSingleObject(*hnd, INFINITE) == WAIT_OBJECT_0);
 #else
   int ret = (WaitForSingleObjectEx(*hnd, INFINITE, FALSE) == WAIT_OBJECT_0);

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -39,8 +39,7 @@
 #  define curl_mutex_t           CRITICAL_SECTION
 #  define curl_thread_t          HANDLE
 #  define curl_thread_t_null     (HANDLE)0
-#  if !defined(_WIN32_WINNT) || !defined(_WIN32_WINNT_VISTA) || \
-      (_WIN32_WINNT < _WIN32_WINNT_VISTA)
+#  if !defined(_WIN32_WINNT) || (_WIN32_WINNT < _WIN32_WINNT_VISTA)
 #    define Curl_mutex_init(m)   InitializeCriticalSection(m)
 #  else
 #    define Curl_mutex_init(m)   InitializeCriticalSectionEx(m, 0, 1)

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -152,7 +152,8 @@ static CURLcode mac_ascii_to_idn(const char *in, char **out)
 #ifdef USE_WIN32_IDN
 /* using Windows kernel32 and normaliz libraries. */
 
-#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
+#if (!defined(_WIN32_WINNT) || _WIN32_WINNT < _WIN32_WINNT_VISTA) && \
+  (!defined(WINVER) || WINVER < 0x600)
 WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
                                  const WCHAR *lpUnicodeCharStr,
                                  int cchUnicodeChar,

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -152,7 +152,7 @@ static CURLcode mac_ascii_to_idn(const char *in, char **out)
 #ifdef USE_WIN32_IDN
 /* using Windows kernel32 and normaliz libraries. */
 
-#if !defined(_WIN32_WINNT) || _WIN32_WINNT < _WIN32_WINNT_VISTA
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600
 WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
                                  const WCHAR *lpUnicodeCharStr,
                                  int cchUnicodeChar,

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -152,8 +152,7 @@ static CURLcode mac_ascii_to_idn(const char *in, char **out)
 #ifdef USE_WIN32_IDN
 /* using Windows kernel32 and normaliz libraries. */
 
-#if (!defined(_WIN32_WINNT) || _WIN32_WINNT < _WIN32_WINNT_VISTA) && \
-  (!defined(WINVER) || WINVER < _WIN32_WINNT_VISTA)
+#if !defined(_WIN32_WINNT) || _WIN32_WINNT < _WIN32_WINNT_VISTA
 WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
                                  const WCHAR *lpUnicodeCharStr,
                                  int cchUnicodeChar,

--- a/lib/idn.c
+++ b/lib/idn.c
@@ -152,8 +152,8 @@ static CURLcode mac_ascii_to_idn(const char *in, char **out)
 #ifdef USE_WIN32_IDN
 /* using Windows kernel32 and normaliz libraries. */
 
-#if (!defined(_WIN32_WINNT) || _WIN32_WINNT < 0x600) && \
-  (!defined(WINVER) || WINVER < 0x600)
+#if (!defined(_WIN32_WINNT) || _WIN32_WINNT < _WIN32_WINNT_VISTA) && \
+  (!defined(WINVER) || WINVER < _WIN32_WINNT_VISTA)
 WINBASEAPI int WINAPI IdnToAscii(DWORD dwFlags,
                                  const WCHAR *lpUnicodeCharStr,
                                  int cchUnicodeChar,

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -48,7 +48,7 @@
 
 #ifdef _WIN32
 
-#if defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600 && \
+#if defined(_WIN32_WINNT) && _WIN32_WINNT >= _WIN32_WINNT_VISTA && \
   !defined(CURL_WINDOWS_UWP)
 #  define HAVE_WIN_BCRYPTGENRANDOM
 #  include <bcrypt.h>


### PR DESCRIPTION
- autotools: stop checking for `WINVER` to detect thread-safety.
  To sync with implementation in `easy_lock.h` and with cmake.

- replace numeric version with `_WIN32_WINNT_VISTA`.

- `_WIN32_WINNT_VISTA` is always defined via `setup-win32.h`,
  don't check for it.
