### PR TITLE
test428: re-enable for Windows

### DIFF
--- a/tests/data/test428
+++ b/tests/data/test428
@@ -29,14 +29,6 @@ Funny-head: yesyes
 #
 # Client-side
 <client>
-
-# For unknown reasons, a number of CI jobs on Appveyor keep returning NULL to
-# getenv() for the blank environment variable which makes the test fail.
-# Unfortunately, this makes me disable the test completely on Windows.
-
-<features>
-!win32
-</features>
 <server>
 http
 </server>


### PR DESCRIPTION
The unexplained error in AppVeyor CI tests are not hit in CI after
moving those tests to GHA. Re-enable to run this test on Windows.

Revisit if the error is seen again on Windows.

Errors seen earlier in AppVeyor CI:
https://ci.appveyor.com/project/curlorg/curl/builds/49120834
https://ci.appveyor.com/project/curlorg/curl/builds/49123802 (with debug lines)

In these jobs:
CMake, VS2010, Debug, x64, no SSL, Static
CMake, mingw-w64, gcc 7, Debug, x64, Schannel, Static, Unicode
CMake, mingw-w64, gcc 9, Debug, x64, Schannel, Static, Unity
CMake, mingw-w64, gcc 6, Debug, x86, Schannel, Static

Test log from the 'gcc 9` job above (with debug lines):
```
 test 0428...[Expand environment variables within config file]

  428: protocol FAILED!
  There was no content at all in the file log/server.input.
  Server glitch? Total curl failure? Returned: 26
 == Contents of files in the log/ dir after test 428
 === Start of file cmd
  --variable %FUNVALUE
  --variable %VALUE2
  --variable %BLANK
  --variable %curl_NOT_SET=default
  --expand-data 1{{FUNVALUE}}2{{VALUE2}}3{{curl_NOT_SET}}4{{BLANK}}5\{{verbatim}}6{{not.good}}7{{}}
 === End of file cmd
 === Start of file commands.log
  ../src/curl.exe --output log/curl428.out  --include --trace-ascii log/trace428 --trace-time http://127.0.0.1:1593/428 -K log/cmd > log/stdout428 2> log/stderr428
 === End of file commands.log
 === Start of file server.cmd
  Testnum 428
 === End of file server.cmd
 === Start of file stderr428
  getenv of 'FUNVALUE' returned 0xee65d2
  getenv of 'VALUE2' returned 0xee7a42
  getenv of 'BLANK' returned (nil)
  curl: Variable 'BLANK' import fail, not set
  curl: log/cmd:3: '--variable' variable expansion failure
  curl: cannot read config from 'log/cmd'
  curl: option -K: error encountered when reading a file
  curl: try 'curl --help' for more information
 === End of file stderr428
```

Env comparison:
Fail: https://ci.appveyor.com/project/curlorg/curl/builds/49123802/job/2a4w7i21npys9pd3
```
-- curl version=[8.6.1-DEV]
-- The C compiler identification is GNU 9.1.0
-- Found Perl: C:/msys64/usr/bin/perl.exe (found version "5.30.0").
-- Found _WIN32_WINNT=0x0601
* curl 8.6.1-DEV (Windows).
* libcurl/8.6.1-DEV Schannel zlib/1.2.11
* Features: alt-svc AsynchDNS Debug HSTS HTTPS-proxy IPv6 Kerberos Largefile libz NTLM SPNEGO SSL SSPI threadsafe TrackMemory UnixSockets
* Disabled: xattr
* System: MSYS_NT-10.0-14393 APPVYR-WIN 3.0.7-338.x86_64 2019-07-11 10:58 UTC x86_64 Msys
```

OK (this PR): https://github.com/curl/curl/actions/runs/16439564668/job/46456976494
```
-- curl version=[8.15.1-DEV]
-- The C compiler identification is GNU 9.5.0
-- Found Perl: C:/msys64/usr/bin/perl.exe (found version "5.38.4")
-- Found _WIN32_WINNT=0x0601
* curl 8.15.1-DEV (Windows).
* libcurl/8.15.1-DEV Schannel libpsl/0.21.5
* Protocols: dict file ftp ftps gopher gophers http https imap imaps ipfs ipns ldap ldaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp ws wss
* Features: alt-svc AsynchDNS Debug HSTS HTTPS-proxy IPv6 Kerberos Largefile NTLM PSL SPNEGO SSL SSPI threadsafe TrackMemory UnixSockets
* Disabled: xattr, win32-ca-search-safe, override-dns
* System: MINGW64_NT-10.0-20348 runnervm51nrn 3.6.3-ab81aae6.x86_64 2025-07-01 18:20 UTC x86_64 Msys
```

Follow-up to 7cf8414fabc3063cc3d2121eacec4a6daa4164a8
Ref: https://github.com/curl/curl/pull/12862#issuecomment-1929548070
Ref: 0f0edc283c340e8ddddc763b48d2f835b2270ab4 #12862
