### PR TITLE
test1148: drop redundant `LC_NUMBER=` env setting

### DIFF
--- a/tests/data/test1148
+++ b/tests/data/test1148
@@ -37,10 +37,6 @@ progress-bar
 <command>
 http://%HOSTIP:%HTTPPORT/%TESTNUMBER -# --stderr %LOGDIR/stderrlog%TESTNUMBER
 </command>
-<setenv>
-LC_ALL=
-LC_NUMERIC=en_US.UTF-8
-</setenv>
 </client>
 
 #


### PR DESCRIPTION
No longer necessary after a previous change made sure to strip
the '100.0%' number from the result, before checking it. The dot is
a regex character catching any decimal separator.

Follow-up to 17c18fbc3015b5dc0580d16a4ff5bcf2fd88b449 #5194
Ref: #2436
Cherry-picked from #17988
