### PR TITLE
fix name in ssls_import document

### DIFF
--- a/docs/libcurl/curl_easy_ssls_import.md
+++ b/docs/libcurl/curl_easy_ssls_import.md
@@ -20,7 +20,7 @@ Added-in: 8.12.0
 
 # NAME
 
-curl_easy_ssls_export - export SSL sessions
+curl_easy_ssls_import - import SSL sessions
 
 # SYNOPSIS
 


### PR DESCRIPTION
The name of the man page was wrongly given as curl_easy_sssl_export which seems to have confused our HTTML man page generation.

refs curl/curl-www#458