### PR TITLE
Don't insert a node into the splay tree twice

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2772,6 +2772,7 @@ CURLMcode curl_multi_perform(CURLM *m, int *running_handles)
         if(multi_handle_timeout(data, &now, &stream_unused, &result_unused)) {
           infof(data, "PENDING handle timeout");
           move_pending_to_connect(multi, data);
+          continue;
         }
       }
       (void)add_next_timeout(now, multi, Curl_splayget(t));


### PR DESCRIPTION
Specific to multiplexing with PIPEWAIT enabled - when a pending handle times out before its corresponding connecting handle, its timenode is erroneously inserted twice into the multi handle splay tree. This can lead to infinite loops or invalid accesses. 

Here is a simple program that consistently reproduces the issue for me: 
```c++
#include <string>
#include <curl/curl.h>

void makeReq(CURLM* multi, int timeoutMs)
{
    CURL* easy = curl_easy_init();
    curl_easy_setopt(easy, CURLOPT_TIMEOUT_MS, timeoutMs);
    curl_easy_setopt(easy, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2);
    curl_easy_setopt(easy, CURLOPT_PIPEWAIT, 1L);
    // any URL that is guaranteed to time out will work
    std::string url = "http://192.168.1.8:9001/code/" + std::to_string(timeoutMs);
    curl_easy_setopt(easy, CURLOPT_URL, url.c_str());
    curl_easy_setopt(easy, CURLOPT_CUSTOMREQUEST, "GET");
    curl_easy_setopt(easy, CURLOPT_TCP_KEEPALIVE, 1L);
    curl_easy_setopt(easy, CURLOPT_TCP_KEEPIDLE, 60L);
    curl_easy_setopt(easy, CURLOPT_TCP_KEEPINTVL, 60L);
    curl_multi_add_handle(multi, easy);
}

int main()
{
    CURLM* multi = curl_multi_init();
    makeReq(multi, 500);
    makeReq(multi, 300);

    int running;
    do
    {
        curl_multi_perform(multi, &running);
    }
    while (running);
}
```
To verify the duplicate insert, I was running with these changes locally: https://github.com/curl/curl/compare/master...dvdzhuang:curl:checksplaytree

I was thinking that it might be good to have some strong guarantee that the node passed to Curl_splayinsert has a zeroed out time key but would like to know your thoughts. Thanks!