### PR TITLE
windows: drop two unused `curlx/version_win32.h` includes

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -74,7 +74,6 @@
 #include "conncache.h"
 #include "multihandle.h"
 #include "share.h"
-#include "curlx/version_win32.h"
 #include "vquic/vquic.h" /* for quic cfilters */
 #include "http_proxy.h"
 #include "socks.h"

--- a/lib/curl_sspi.c
+++ b/lib/curl_sspi.c
@@ -31,7 +31,6 @@
 #include "strdup.h"
 #include "curlx/multibyte.h"
 #include "system_win32.h"
-#include "curlx/version_win32.h"
 #include "curlx/warnless.h"
 
 /* The last #include files should be: */


### PR DESCRIPTION
- lib/connect.c: unused since:
  71b7e0161032927cdfb4e75ea40f65b8898b3956 #10141 (connect)

- lib/curl_sspi.c: unused since:
  0d71b18153c8edb996738f8a362373fc72d0013b #17413 (curl_sspi)

Cherry-picked from #18009
