### PR TITLE
curl_setup.h: move UWP detection after `config-win32.h` (revert)

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -93,6 +93,30 @@
 #endif
 #endif /* _MSC_VER */
 
+#ifdef _WIN32
+/*
+ * Do not include unneeded stuff in Windows headers to avoid compiler
+ * warnings and macro clashes.
+ * Make sure to define this macro before including any Windows headers.
+ */
+#  ifndef WIN32_LEAN_AND_MEAN
+#  define WIN32_LEAN_AND_MEAN
+#  endif
+#  ifndef NOGDI
+#  define NOGDI
+#  endif
+/* Detect Windows App environment which has a restricted access
+ * to the Win32 APIs. */
+#  if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
+     defined(WINAPI_FAMILY)
+#    include <winapifamily.h>
+#    if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) &&  \
+       !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#      define CURL_WINDOWS_UWP
+#    endif
+#  endif
+#endif
+
 /* Avoid bogus format check warnings with mingw32ce gcc 4.4.0 in
    C99 (-std=gnu99) mode */
 #if defined(__MINGW32CE__) && !defined(CURL_NO_FMT_CHECKS) && \
@@ -138,31 +162,6 @@
 #endif
 
 #endif /* HAVE_CONFIG_H */
-
-/* Keep this section after config-win32.h to honor a _WIN32_WINNT set there */
-#ifdef _WIN32
-/*
- * Do not include unneeded stuff in Windows headers to avoid compiler
- * warnings and macro clashes.
- * Make sure to define this macro before including any Windows headers.
- */
-#  ifndef WIN32_LEAN_AND_MEAN
-#  define WIN32_LEAN_AND_MEAN
-#  endif
-#  ifndef NOGDI
-#  define NOGDI
-#  endif
-/* Detect Windows App environment which has a restricted access
- * to the Win32 APIs. */
-#  if (defined(_WIN32_WINNT) && (_WIN32_WINNT >= 0x0602)) || \
-     defined(WINAPI_FAMILY)
-#    include <winapifamily.h>
-#    if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) &&  \
-       !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-#      define CURL_WINDOWS_UWP
-#    endif
-#  endif
-#endif
 
 /* ================================================================ */
 /* Definition of preprocessor macros/symbols which modify compiler  */


### PR DESCRIPTION
This change wasn't good because `config-win32.h` does rely on the UWP
detection result to set `USE_WIN32_CRYPTO` and LDAP macros. While it
fixed one issue, it created another.

It seems better to revert, and focus on reducing and/or eventually
dropping the logic within `config-win32.h` that alters `_WIN32_WINNT`.
It may not be necessary anymore with a minimum of VS2008 (soon VS2010).
The logic is also absent from cmake builds, without causing issues.

Could affect UWP winbuild/project-file builds. These are theoretical
builds because neither build method is prepared to target UWP.

Reverts 792a61e2047782b85da0332cf298a747ce11e8e6 #17980
Ref: https://github.com/curl/curl/pull/17980#issuecomment-3114462492
