### PR TITLE
DEPRECATE.md: drop support for Windows XP/2003

### DIFF
--- a/docs/DEPRECATE.md
+++ b/docs/DEPRECATE.md
@@ -57,7 +57,7 @@ Previous discussion and details: https://github.com/curl/curl/discussions/15972
 
 ## Windows XP
 
-In Januar 2026, curl drops support for Windows XP and Server 2003. Their
+In January 2026, curl drops support for Windows XP and Server 2003. Their
 "mainstream support" ended in 2014, with final updates on May 14, 2019.
 
 Making the new minimum target Windows version Vista / Server 2008.


### PR DESCRIPTION
Dropped from curl-for-win on August 28, 2022:
https://github.com/curl/curl-for-win/commit/6976612160075c1e9ee967964d5dec1a25c5ac6c

https://en.wikipedia.org/wiki/Windows_XP
https://en.wikipedia.org/wiki/Windows_Server_2003

Ref: #17985