### PR TITLE
curl_ngtcp2: extend callback tables for nghttp3 1.11.0 and ngtcp2 1.14.0

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -833,6 +833,9 @@ static ngtcp2_callbacks ng_callbacks = {
   cb_recv_rx_key,
   NULL, /* recv_tx_key */
   NULL, /* early_data_rejected */
+#ifdef NGTCP2_CALLBACKS_V2
+  NULL, /* begin_path_validation */
+#endif
 };
 
 #if defined(_MSC_VER) && defined(_DLL)
@@ -1182,7 +1185,12 @@ static nghttp3_callbacks ngh3_callbacks = {
   NULL, /* end_stream */
   cb_h3_reset_stream,
   NULL, /* shutdown */
-  NULL /* recv_settings */
+  NULL, /* recv_settings */
+#ifdef NGHTTP3_CALLBACKS_V2
+  NULL, /* recv_origin */
+  NULL, /* end_origin */
+  NULL, /* rand */
+#endif
 };
 
 static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,


### PR DESCRIPTION
An emergency update to initialize callbacks to NULL.

May need further updates, e.g. to provide the recommended random
generator callback for nghttp3.

Fixing potential crashes at runtime in curl-for-win 8.15.0_3, and these
build warnings:
```
/home/appveyor/projects/curl-for-win/curl/lib/vquic/curl_ngtcp2.c:836:1:
warning: missing field 'begin_path_validation' initializer [-Wmissing-field-initializers]
  836 | };
      | ^
/home/appveyor/projects/curl-for-win/curl/lib/vquic/curl_ngtcp2.c:1186:1:
warning: missing field 'recv_origin' initializer [-Wmissing-field-initializers]
 1186 | };
      | ^
2 warnings generated.
```
Ref: https://ci.appveyor.com/project/curlorg/curl-for-win/builds/52462852#L14821

Also causing all `GHA/curl-for-win` jobs to fail:
https://github.com/curl/curl/actions/runs/16523625082?pr=18010

Ref: https://github.com/ngtcp2/nghttp3/releases/tag/v1.11.0
Ref: https://github.com/ngtcp2/ngtcp2/releases/tag/v1.14.0
Ref: https://github.com/curl/curl-for-win/commit/ff788c81e44f998d0d41f362d442a7e97cc0fd46