### PR TITLE
urlapi: allow more path characters "raw" when asked to URL encode

### DIFF
--- a/docs/libcurl/curl_url_set.md
+++ b/docs/libcurl/curl_url_set.md
@@ -184,8 +184,10 @@ course cannot know if the provided scheme is a valid one or not.
 When set, curl_url_set(3) URL encodes the part on entry, except for
 **scheme**, **port** and **URL**.
 
-When setting the path component with URL encoding enabled, the slash character
-is skipped.
+When setting the path component with URL encoding enabled, the following
+characters are left as-is if present:
+
+    ! $ & ' ( ) { } [ ] * + , ; = : @
 
 The query part gets space-to-plus converted before the URL conversion is
 applied.

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -895,6 +895,10 @@ static const struct setgetcase setget_parts_list[] = {
 
 /* !checksrc! disable SPACEBEFORECOMMA 1 */
 static const struct setcase set_parts_list[] = {
+  {"https://example.com/",
+   "path=one /$!$&'()*+;=:@{}[]%,",
+   "https://example.com/one%20/$!$&'()*+;=:@{}[]%25",
+   0, CURLU_URLENCODE, CURLUE_OK, CURLUE_OK},
   {NULL, /* start fresh! */
    "scheme=https,path=/,url=\"\",", /* incomplete url, redirect to "" */
    "https://example.com/",


### PR DESCRIPTION
Setting the path component to contain the letters:

    ! $ & ' ( ) { } [ ] * + , ; = : @

now leaves them un-encoded when CURLU_URLENCODE is used.

Amended test 1560 to verify.

Reported-by: Jeroen Ooms
Fixes #17977