### PR TITLE
vquic: silence `-Wnull-dereference` gcc 9.2.0 warnings

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -44,6 +44,53 @@ env:
   CW_NOPKG: '1'
 
 jobs:
+  linux-musl-debian-testing-gcc:
+    name: 'linux-musl-debian-testing-gcc'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+          path: 'curl'
+          fetch-depth: 8
+      - name: 'build'
+        run: |
+          git clone --depth 1 https://github.com/curl/curl-for-win
+          mv curl-for-win/* .
+          export CW_CONFIG='-werror-linux-a64-r64-x64-musl-gcc'
+          export CW_REVISION="${GITHUB_SHA}"
+          DOCKER_IMAGE='debian:testing-slim'
+          sudo podman image trust set --type reject default
+          sudo podman image trust set --type accept docker.io/library
+          time podman pull "${DOCKER_IMAGE}"
+          podman images --digests
+          time podman run --volume "$(pwd):$(pwd)" --workdir "$(pwd)" \
+            --env-file <(env | grep -a -E \
+              '^(CW_|GITHUB_)') \
+            "${DOCKER_IMAGE}" \
+            sh -c ./_ci-linux-debian.sh
+
+  linux-musl-from-mac:
+    name: 'linux-musl-from-mac'
+    runs-on: macos-latest
+    timeout-minutes: 15
+    env:
+      CW_JOBS: '4'
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          persist-credentials: false
+          path: 'curl'
+          fetch-depth: 8
+      - name: 'build'
+        run: |
+          git clone --depth 1 https://github.com/curl/curl-for-win
+          mv curl-for-win/* .
+          export CW_CONFIG='-werror-linux'
+          export CW_REVISION="${GITHUB_SHA}"
+          sh -c ./_ci-mac-homebrew.sh
+
   linux-glibc-gcc:
     name: 'Linux gcc glibc'
     runs-on: ubuntu-latest

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-werror-linux-a64-r64-x64-musl-gcc'
+          export CW_CONFIG='-werror-linux-x64-musl-gcc'
           export CW_REVISION="${GITHUB_SHA}"
           DOCKER_IMAGE='debian:testing-slim'
           sudo podman image trust set --type reject default

--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-werror-linux-x64-musl-gcc'
+          export CW_CONFIG='-werror-linux-a64-musl-gcc'
           export CW_REVISION="${GITHUB_SHA}"
           DOCKER_IMAGE='debian:testing-slim'
           sudo podman image trust set --type reject default

--- a/lib/http.c
+++ b/lib/http.c
@@ -4370,17 +4370,7 @@ CURLcode Curl_http_req_make(struct httpreq **preq,
   req = calloc(1, sizeof(*req) + m_len);
   if(!req)
     goto out;
-#if defined(__GNUC__) && __GNUC__ >= 13
-#pragma GCC diagnostic push
-/* error: 'memcpy' offset [137, 142] from the object at 'req' is out of
-   the bounds of referenced subobject 'method' with type 'char[1]' at
-   offset 136 */
-#pragma GCC diagnostic ignored "-Warray-bounds"
-#endif
   memcpy(req->method, method, m_len);
-#if defined(__GNUC__) && __GNUC__ >= 13
-#pragma GCC diagnostic pop
-#endif
   if(scheme) {
     req->scheme = Curl_memdup0(scheme, s_len);
     if(!req->scheme)

--- a/lib/http.c
+++ b/lib/http.c
@@ -4370,7 +4370,17 @@ CURLcode Curl_http_req_make(struct httpreq **preq,
   req = calloc(1, sizeof(*req) + m_len);
   if(!req)
     goto out;
+#if defined(__GNUC__) && __GNUC__ >= 13
+#pragma GCC diagnostic push
+/* error: 'memcpy' offset [137, 142] from the object at 'req' is out of
+   the bounds of referenced subobject 'method' with type 'char[1]' at
+   offset 136 */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
   memcpy(req->method, method, m_len);
+#if defined(__GNUC__) && __GNUC__ >= 13
+#pragma GCC diagnostic pop
+#endif
   if(scheme) {
     req->scheme = Curl_memdup0(scheme, s_len);
     if(!req->scheme)

--- a/lib/vquic/curl_msh3.c
+++ b/lib/vquic/curl_msh3.c
@@ -642,10 +642,14 @@ static CURLcode cf_msh3_send(struct Curl_cfilter *cf, struct Curl_easy *data,
 
     for(i = 0; i < nheader; ++i) {
       struct dynhds_entry *e = Curl_dynhds_getn(&h2_headers, i);
-      nva[i].Name = e->name;
-      nva[i].NameLength = e->namelen;
-      nva[i].Value = e->value;
-      nva[i].ValueLength = e->valuelen;
+      if(e) {
+        nva[i].Name = e->name;
+        nva[i].NameLength = e->namelen;
+        nva[i].Value = e->value;
+        nva[i].ValueLength = e->valuelen;
+      }
+      else
+        memset(&nva[i], 0, sizeof(*nva));
     }
 
     CURL_TRC_CF(data, cf, "req: send %zu headers", nheader);

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1506,11 +1506,15 @@ static CURLcode h3_stream_open(struct Curl_cfilter *cf,
 
   for(i = 0; i < nheader; ++i) {
     struct dynhds_entry *e = Curl_dynhds_getn(&h2_headers, i);
-    nva[i].name = (unsigned char *)e->name;
-    nva[i].namelen = e->namelen;
-    nva[i].value = (unsigned char *)e->value;
-    nva[i].valuelen = e->valuelen;
-    nva[i].flags = NGHTTP3_NV_FLAG_NONE;
+    if(e) {
+      nva[i].name = (unsigned char *)e->name;
+      nva[i].namelen = e->namelen;
+      nva[i].value = (unsigned char *)e->value;
+      nva[i].valuelen = e->valuelen;
+      nva[i].flags = NGHTTP3_NV_FLAG_NONE;
+    }
+    else
+      memset(&nva[i], 0, sizeof(*nva));
   }
 
   rc = ngtcp2_conn_open_bidi_stream(ctx->qconn, &sid, data);

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1914,11 +1914,15 @@ static ssize_t h3_stream_open(struct Curl_cfilter *cf,
 
   for(i = 0; i < nheader; ++i) {
     struct dynhds_entry *e = Curl_dynhds_getn(&h2_headers, i);
-    nva[i].name = (unsigned char *)e->name;
-    nva[i].namelen = e->namelen;
-    nva[i].value = (unsigned char *)e->value;
-    nva[i].valuelen = e->valuelen;
-    nva[i].flags = NGHTTP3_NV_FLAG_NONE;
+    if(e) {
+      nva[i].name = (unsigned char *)e->name;
+      nva[i].namelen = e->namelen;
+      nva[i].value = (unsigned char *)e->value;
+      nva[i].valuelen = e->valuelen;
+      nva[i].flags = NGHTTP3_NV_FLAG_NONE;
+    }
+    else
+      memset(&nva[i], 0, sizeof(*nva));
   }
 
   DEBUGASSERT(stream->s.id == -1);

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1009,10 +1009,14 @@ static CURLcode h3_open_stream(struct Curl_cfilter *cf,
 
   for(i = 0; i < nheader; ++i) {
     struct dynhds_entry *e = Curl_dynhds_getn(&h2_headers, i);
-    nva[i].name = (unsigned char *)e->name;
-    nva[i].name_len = e->namelen;
-    nva[i].value = (unsigned char *)e->value;
-    nva[i].value_len = e->valuelen;
+    if(e) {
+      nva[i].name = (unsigned char *)e->name;
+      nva[i].name_len = e->namelen;
+      nva[i].value = (unsigned char *)e->value;
+      nva[i].value_len = e->valuelen;
+    }
+    else
+      memset(&nva[i], 0, sizeof(*nva));
   }
 
   *pnwritten = (size_t)nwritten;


### PR DESCRIPTION
```
In file included from /curl/_x64-linux-musl-bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:472:
/curl/lib/vquic/curl_ngtcp2.c: In function 'cf_ngtcp2_send':
/curl/lib/vquic/curl_ngtcp2.c:1511:38: error: potential null pointer dereference [-Werror=null-dereference]
 1511 |     nva[i].value = (unsigned char *)e->value;
      |                                     ~^~~~~~~
/curl/lib/vquic/curl_ngtcp2.c:1510:23: error: potential null pointer dereference [-Werror=null-dereference]
 1510 |     nva[i].namelen = e->namelen;
      |                      ~^~~~~~~~~
/curl/lib/vquic/curl_ngtcp2.c:1509:37: error: potential null pointer dereference [-Werror=null-dereference]
 1509 |     nva[i].name = (unsigned char *)e->name;
      |                                    ~^~~~~~
/curl/lib/vquic/curl_ngtcp2.c:1512:24: error: potential null pointer dereference [-Werror=null-dereference]
 1512 |     nva[i].valuelen = e->valuelen;
      |                       ~^~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/16527769182/job/46745369854?pr=18025

Ref: #12076
Ref: #12079
