### PR TITLE
curl_ossl: extend callback table for nghttp3 1.11.0

### DIFF
--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1087,7 +1087,12 @@ static nghttp3_callbacks ngh3_callbacks = {
   NULL, /* end_stream */
   cb_h3_reset_stream,
   NULL, /* shutdown */
-  NULL /* recv_settings */
+  NULL, /* recv_settings */
+#ifdef NGHTTP3_CALLBACKS_V2
+  NULL, /* recv_origin */
+  NULL, /* end_origin */
+  NULL, /* rand */
+#endif
 };
 
 static CURLcode cf_osslq_h3conn_init(struct cf_osslq_ctx *ctx, SSL *conn,


### PR DESCRIPTION
```
../../lib/vquic/curl_osslq.c:1091:1: error: missing initializer for field 'recv_origin' of 'nghttp3_callbacks' [-Werror=missing-field-initializers]
 1091 | };
      | ^
In file included from ../../lib/vquic/curl_osslq.c:33:
/home/runner/nghttp3/build/include/nghttp3/nghttp3.h:2082:23: note: 'recv_origin' declared here
 2082 |   nghttp3_recv_origin recv_origin;
      |                       ^~~~~~~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/16527325587/job/46743893924?pr=18021#step:18:35

Follow-up to 1055144063ca5f8c67ae6b7d727f76c9bdad88ba #18019