### PR TITLE
http: silence `-Warray-bounds` with gcc 13+

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -4370,7 +4370,17 @@ CURLcode Curl_http_req_make(struct httpreq **preq,
   req = calloc(1, sizeof(*req) + m_len);
   if(!req)
     goto out;
+#if defined(__GNUC__) && __GNUC__ >= 13
+#pragma GCC diagnostic push
+/* error: 'memcpy' offset [137, 142] from the object at 'req' is out of
+   the bounds of referenced subobject 'method' with type 'char[1]' at
+   offset 136 */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
   memcpy(req->method, method, m_len);
+#if defined(__GNUC__) && __GNUC__ >= 13
+#pragma GCC diagnostic pop
+#endif
   if(scheme) {
     req->scheme = Curl_memdup0(scheme, s_len);
     if(!req->scheme)


### PR DESCRIPTION
This became an issue after promoting curl compiler warnings to errors in
curl-for-win. The code is correct. It over-allocates a struct to store
variable sized data past its length. Similar code is present in
`lib/smb.c`, silenced earlier.

Seen in linux-musl-debian-testing-gcc curl-for-win builds, gcc 14.2.0,
RISC-V (but not amd64/aarch64), unity, debian:testing (trixie):

musl:
```
In file included from /curl/_r64-linux-musl-bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:184:
In function 'Curl_http_req_make',
    inlined from 'Curl_http_proxy_create_CONNECT' at /curl/lib/http_proxy.c:252:12:
/curl/lib/http.c:4373:3: error: 'memcpy' offset [137, 142] from the object at 'req' is out of the bounds of referenced subobject 'method' with type 'char[1]' at offset 136 [-Werror=array-bounds=]
 4373 |   memcpy(req->method, method, m_len);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /curl/lib/urldata.h:182,
                 from /curl/lib/altsvc.c:32,
                 from /curl/_r64-linux-musl-bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_0_c.c:4:
/curl/lib/http.h: In function 'Curl_http_proxy_create_CONNECT':
/curl/lib/http.h:230:8: note: subobject 'method' declared here
  230 |   char method[1];
      |        ^~~~~~
```
Ref: https://github.com/curl/curl/actions/runs/16527769182/job/46745369844?pr=18025#step:3:5798
Ref: https://github.com/curl/curl-for-win/actions/runs/16525969694/job/46739239206#step:3:5958

glibc (with unity batch):
```
In file included from /usr/riscv64-linux-gnu/include/string.h:548,
                 from /curl/lib/curl_setup_once.h:33,
                 from /curl/lib/curl_setup.h:823,
                 from /curl/lib/http.c:25,
                 from /curl/_r64-linux-gnu-bld/lib/CMakeFiles/libcurl_object.dir/Unity/unity_2_c.c:4:
In function 'memcpy',
    inlined from 'Curl_http_req_make' at /curl/lib/http.c:4373:3,
    inlined from 'Curl_http_proxy_create_CONNECT' at /curl/lib/http_proxy.c:252:12:
/usr/riscv64-linux-gnu/include/bits/string_fortified.h:29:10: error: '__builtin_memcpy' offset [137, 142] from the object at 'req' is out of the bounds of referenced subobject 'method' with type 'char[1]' at offset 136 [-Werror=array-bounds=]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /curl/lib/urldata.h:182,
                 from /curl/lib/http.c:50:
/curl/lib/http.h: In function 'Curl_http_proxy_create_CONNECT':
/curl/lib/http.h:230:8: note: subobject 'method' declared here
  230 |   char method[1];
      |        ^~~~~~
```
Ref: https://github.com/curl/curl-for-win/actions/runs/16538174468/job/46775731055#step:3:5936

Ref: https://github.com/curl/curl-for-win/commit/f45df099f38f83f2def8344e335f73cc33eea51b
Follow-up to 14f26f5ee78204c15bf906f3cf7480308e2feb28 #16187
Cherry-picked from #18025
