### PR TITLE
GHA: skip building certs, build more tests, one minor fix

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -661,7 +661,7 @@ jobs:
           fi
 
       - name: 'install test prereqs'
-        if: ${{ !contains(matrix.build.install_steps, 'skipall') && matrix.build.container == null }}
+        if: ${{ !contains(matrix.build.install_steps, 'skipall') && !contains(matrix.build.install_steps, 'skiprun') && matrix.build.container == null }}
         run: |
           [ -x ~/venv/bin/activate ] && source ~/venv/bin/activate
           python3 -m pip install -r tests/requirements.txt

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -227,7 +227,7 @@ jobs:
 
           - name: 'scanbuild'
             install_packages: clang-tools clang libssl-dev libssh2-1-dev
-            install_steps: skiprun
+            install_steps: skipall
             configure: --with-openssl --enable-debug --with-libssh2 --disable-unity
             CC: clang
             configure-prefix: scan-build
@@ -655,9 +655,9 @@ jobs:
         if: ${{ !contains(matrix.build.install_steps, 'skipall') }}
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-            ${MATRIX_MAKE_PREFIX} cmake --build bld --verbose --target testdeps
+            cmake --build bld --verbose --target testdeps
           else
-            ${MATRIX_MAKE_PREFIX} make -C bld V=1 -C tests
+            make -C bld V=1 -C tests
           fi
 
       - name: 'install test prereqs'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -179,7 +179,7 @@ jobs:
 
           - name: 'openssl clang krb5 LTO'
             install_packages: zlib1g-dev libkrb5-dev clang
-            install_steps: skipall
+            install_steps: skiprun
             generate: -DCURL_USE_OPENSSL=ON -DCURL_USE_GSSAPI=ON -DENABLE_DEBUG=ON -DCURL_LTO=ON
 
           - name: 'openssl !ipv6 !--libcurl !--digest-auth'
@@ -227,7 +227,7 @@ jobs:
 
           - name: 'scanbuild'
             install_packages: clang-tools clang libssl-dev libssh2-1-dev
-            install_steps: skipall
+            install_steps: skiprun
             configure: --with-openssl --enable-debug --with-libssh2 --disable-unity
             CC: clang
             configure-prefix: scan-build
@@ -273,7 +273,7 @@ jobs:
 
           - name: 'rustls'
             install_packages: libnghttp2-dev libldap-dev
-            install_steps: rust rustls skipall pytest
+            install_steps: rust rustls skiprun pytest
             generate: -DCURL_USE_RUSTLS=ON -DUSE_ECH=ON -DENABLE_DEBUG=ON
 
           - name: 'IntelC openssl'

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -655,9 +655,9 @@ jobs:
         if: ${{ !contains(matrix.build.install_steps, 'skipall') }}
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
-            cmake --build bld --verbose --target testdeps
+            ${MATRIX_MAKE_PREFIX} cmake --build bld --verbose --target testdeps
           else
-            make -C bld V=1 -C tests
+            ${MATRIX_MAKE_PREFIX} make -C bld V=1 -C tests
           fi
 
       - name: 'install test prereqs'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -423,7 +423,7 @@ jobs:
             env: 'x86_64'
             ver: '15.0.1'
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/15.0.1-snapshot20250406posix-12.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-15.0.1-snapshot20250406-mingw-w64ucrt-12.0.0-r1.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -D_CURL_SKIP_BUILD_CERTS=ON'
             type: 'Release'
             tflags: 'skiprun'
           - name: 'schannel'
@@ -438,7 +438,7 @@ jobs:
             env: 'x86_64'
             ver: '7.3.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_MBEDTLS=ON'
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_MBEDTLS=ON -D_CURL_SKIP_BUILD_CERTS=ON'
             install: mingw-w64-x86_64-mbedtls
             type: 'Release'
             tflags: 'skiprun'
@@ -447,7 +447,7 @@ jobs:
             env: 'i686'
             ver: '6.4.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF'
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -D_CURL_SKIP_BUILD_CERTS=ON'
             type: 'Debug'
             tflags: 'skiprun'
       fail-fast: false
@@ -703,6 +703,7 @@ jobs:
               -DENABLE_DEBUG=ON
               -DCURL_ENABLE_SSL=OFF
               -DUSE_WIN32_IDN=ON
+              -D_CURL_SKIP_BUILD_CERTS=ON
 
           - name: 'openssl +examples'
             install-msys2: >-

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -268,6 +268,7 @@ jobs:
           MATRIX_CONFIG: '${{ matrix.config }}'
           MATRIX_ENV: '${{ matrix.env }}'
           MATRIX_TYPE: '${{ matrix.type }}'
+          TFLAGS: '${{ matrix.tflags }}'
         run: |
           if [ "${MATRIX_TEST}" = 'uwp' ]; then
             CPPFLAGS='-DWINSTORECOMPAT -DWINAPI_FAMILY=WINAPI_FAMILY_APP'
@@ -287,6 +288,7 @@ jobs:
               fi
               [ "${MATRIX_SYS}" = 'msys' ] && options+=' -D_CURL_PREFILL=ON'
               [ "${MATRIX_TEST}" = 'uwp' ] && options+=' -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION=10.0'
+              [ "${TFLAGS}" = 'skiprun' ] && options+=' -D_CURL_SKIP_BUILD_CERTS=ON'
               [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
               cmake -B "bld${_chkprefill}" -G Ninja ${options} \
                 -DCMAKE_INSTALL_PREFIX="${HOME}"/curl-install \
@@ -423,7 +425,7 @@ jobs:
             env: 'x86_64'
             ver: '15.0.1'
             url: 'https://github.com/brechtsanders/winlibs_mingw/releases/download/15.0.1-snapshot20250406posix-12.0.0-ucrt-r1/winlibs-x86_64-posix-seh-gcc-15.0.1-snapshot20250406-mingw-w64ucrt-12.0.0-r1.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -D_CURL_SKIP_BUILD_CERTS=ON'
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF'
             type: 'Release'
             tflags: 'skiprun'
           - name: 'schannel'
@@ -438,7 +440,7 @@ jobs:
             env: 'x86_64'
             ver: '7.3.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-win32/seh/x86_64-7.3.0-release-win32-seh-rt_v5-rev0.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_MBEDTLS=ON -D_CURL_SKIP_BUILD_CERTS=ON'
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=ON -DCURL_USE_MBEDTLS=ON'
             install: mingw-w64-x86_64-mbedtls
             type: 'Release'
             tflags: 'skiprun'
@@ -447,7 +449,7 @@ jobs:
             env: 'i686'
             ver: '6.4.0'
             url: 'https://downloads.sourceforge.net/mingw-w64/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/6.4.0/threads-win32/dwarf/i686-6.4.0-release-win32-dwarf-rt_v5-rev0.7z'
-            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF -D_CURL_SKIP_BUILD_CERTS=ON'
+            config: '-DENABLE_DEBUG=ON -DBUILD_SHARED_LIBS=OFF -DCURL_USE_SCHANNEL=ON -DENABLE_UNICODE=OFF -DCMAKE_UNITY_BUILD=OFF'
             type: 'Debug'
             tflags: 'skiprun'
       fail-fast: false
@@ -498,10 +500,12 @@ jobs:
           MATRIX_CHKPREFILL: '${{ matrix.chkprefill }}'
           MATRIX_CONFIG: '${{ matrix.config }}'
           MATRIX_TYPE: '${{ matrix.type }}'
+          TFLAGS: '${{ matrix.tflags }}'
         run: |
           PATH="/d/my-cache/${MATRIX_DIR}/bin:$PATH"
           for _chkprefill in '' ${MATRIX_CHKPREFILL}; do
             options=''
+            [ "${TFLAGS}" = 'skiprun' ] && options+=' -D_CURL_SKIP_BUILD_CERTS=ON'
             [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
             cmake -B "bld${_chkprefill}" -G Ninja ${options} \
               -DCMAKE_C_COMPILER=gcc \
@@ -624,6 +628,7 @@ jobs:
               -DCURL_WERROR=ON \
               -DCURL_USE_SCHANNEL=ON -DUSE_WIN32_IDN=ON \
               -DCURL_USE_LIBPSL=OFF \
+              -D_CURL_SKIP_BUILD_CERTS=ON \
               ${options}
           else
             mkdir bld && cd bld && ../configure --enable-unity --enable-warnings --enable-werror \
@@ -703,7 +708,6 @@ jobs:
               -DENABLE_DEBUG=ON
               -DCURL_ENABLE_SSL=OFF
               -DUSE_WIN32_IDN=ON
-              -D_CURL_SKIP_BUILD_CERTS=ON
 
           - name: 'openssl +examples'
             install-msys2: >-
@@ -793,6 +797,7 @@ jobs:
         env:
           MATRIX_CHKPREFILL: '${{ matrix.chkprefill }}'
           MATRIX_CONFIG: '${{ matrix.config }}'
+          TFLAGS: '${{ matrix.tflags }}'
         run: |
           [ -f "${MINGW_PREFIX}/include/zconf.h" ] && sed -i -E 's|(# +define +Z_HAVE_UNISTD_H)|/*\1*/|g' "${MINGW_PREFIX}/include/zconf.h"  # Patch MSYS2 zconf.h for MSVC
           for _chkprefill in '' ${MATRIX_CHKPREFILL}; do
@@ -806,6 +811,7 @@ jobs:
             [ "${MATRIX_ARCH}" = 'arm64' ] && options+=' -A ARM64'
             [ "${MATRIX_ARCH}" = 'x64' ] && options+=' -A x64'
             [ "${MATRIX_ARCH}" = 'x86' ] && options+=' -A Win32'
+            [ "${TFLAGS}" = 'skiprun' ] && options+=' -D_CURL_SKIP_BUILD_CERTS=ON'
             [ "${_chkprefill}" = '_chkprefill' ] && options+=' -D_CURL_PREFILL=OFF'
             if [ -n "${MATRIX_INSTALL_VCPKG}" ]; then
               options+=" -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"


### PR DESCRIPTION
- GHA/windows: disable building certs in the MSVC job that's not running
  tests. Saves 4-5 seconds for MSVC, makes logs shorter for the rests.

- GHA/linux: build tests in two more jobs (LTO, CM Rustls), 5s each.

- GHA/linux: skip 'install test prereqs' for `skiprun` jobs.
  (there were no such jobs before this patch.)
