### PR TITLE
doh: rename symbols to avoid collision with mingw-w64 headers

### DIFF
--- a/lib/doh.c
+++ b/lib/doh.c
@@ -484,7 +484,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
   data->sub_xfer_done = doh_probe_done;
 
   /* create IPv4 DoH request */
-  result = doh_probe_run(data, DNS_TYPE_A,
+  result = doh_probe_run(data, CURL_DNS_TYPE_A,
                          hostname, data->set.str[STRING_DOH],
                          data->multi,
                          &dohp->probe_resp[DOH_SLOT_IPV4].probe_mid);
@@ -495,7 +495,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
 #ifdef USE_IPV6
   if((ip_version != CURL_IPRESOLVE_V4) && Curl_ipv6works(data)) {
     /* create IPv6 DoH request */
-    result = doh_probe_run(data, DNS_TYPE_AAAA,
+    result = doh_probe_run(data, CURL_DNS_TYPE_AAAA,
                            hostname, data->set.str[STRING_DOH],
                            data->multi,
                            &dohp->probe_resp[DOH_SLOT_IPV6].probe_mid);
@@ -514,7 +514,7 @@ struct Curl_addrinfo *Curl_doh(struct Curl_easy *data,
       if(!qname)
         goto error;
     }
-    result = doh_probe_run(data, DNS_TYPE_HTTPS,
+    result = doh_probe_run(data, CURL_DNS_TYPE_HTTPS,
                            qname ? qname : hostname, data->set.str[STRING_DOH],
                            data->multi,
                            &dohp->probe_resp[DOH_SLOT_HTTPS_RR].probe_mid);
@@ -581,7 +581,7 @@ static void doh_store_a(const unsigned char *doh, int index,
   /* silently ignore addresses over the limit */
   if(d->numaddr < DOH_MAX_ADDR) {
     struct dohaddr *a = &d->addr[d->numaddr];
-    a->type = DNS_TYPE_A;
+    a->type = CURL_DNS_TYPE_A;
     memcpy(&a->ip.v4, &doh[index], 4);
     d->numaddr++;
   }
@@ -593,7 +593,7 @@ static void doh_store_aaaa(const unsigned char *doh, int index,
   /* silently ignore addresses over the limit */
   if(d->numaddr < DOH_MAX_ADDR) {
     struct dohaddr *a = &d->addr[d->numaddr];
-    a->type = DNS_TYPE_AAAA;
+    a->type = CURL_DNS_TYPE_AAAA;
     memcpy(&a->ip.v6, &doh[index], 16);
     d->numaddr++;
   }
@@ -681,29 +681,29 @@ static DOHcode doh_rdata(const unsigned char *doh,
   DOHcode rc;
 
   switch(type) {
-  case DNS_TYPE_A:
+  case CURL_DNS_TYPE_A:
     if(rdlength != 4)
       return DOH_DNS_RDATA_LEN;
     doh_store_a(doh, index, d);
     break;
-  case DNS_TYPE_AAAA:
+  case CURL_DNS_TYPE_AAAA:
     if(rdlength != 16)
       return DOH_DNS_RDATA_LEN;
     doh_store_aaaa(doh, index, d);
     break;
 #ifdef USE_HTTPSRR
-  case DNS_TYPE_HTTPS:
+  case CURL_DNS_TYPE_HTTPS:
     rc = doh_store_https(doh, index, d, rdlength);
     if(rc)
       return rc;
     break;
 #endif
-  case DNS_TYPE_CNAME:
+  case CURL_DNS_TYPE_CNAME:
     rc = doh_store_cname(doh, dohlen, (unsigned int)index, d);
     if(rc)
       return rc;
     break;
-  case DNS_TYPE_DNAME:
+  case CURL_DNS_TYPE_DNAME:
     /* explicit for clarity; just skip; rely on synthesized CNAME  */
     break;
   default:
@@ -770,8 +770,8 @@ UNITTEST DOHcode doh_resp_decode(const unsigned char *doh,
       return DOH_DNS_OUT_OF_RANGE;
 
     type = doh_get16bit(doh, index);
-    if((type != DNS_TYPE_CNAME)    /* may be synthesized from DNAME */
-       && (type != DNS_TYPE_DNAME) /* if present, accept and ignore */
+    if((type != CURL_DNS_TYPE_CNAME)    /* may be synthesized from DNAME */
+       && (type != CURL_DNS_TYPE_DNAME) /* if present, accept and ignore */
        && (type != dnstype))
       /* Not the same type as was asked for nor CNAME nor DNAME */
       return DOH_DNS_UNEXPECTED_TYPE;
@@ -855,9 +855,10 @@ UNITTEST DOHcode doh_resp_decode(const unsigned char *doh,
     return DOH_DNS_MALFORMAT; /* something is wrong */
 
 #ifdef USE_HTTTPS
-  if((type != DNS_TYPE_NS) && !d->numcname && !d->numaddr && !d->numhttps_rrs)
+  if((type != CURL_DNS_TYPE_NS) && !d->numcname && !d->numaddr &&
+      !d->numhttps_rrs)
 #else
-  if((type != DNS_TYPE_NS) && !d->numcname && !d->numaddr)
+  if((type != CURL_DNS_TYPE_NS) && !d->numcname && !d->numaddr)
 #endif
     /* nothing stored! */
     return DOH_NO_CONTENT;
@@ -873,12 +874,12 @@ static void doh_show(struct Curl_easy *data,
   infof(data, "[DoH] TTL: %u seconds", d->ttl);
   for(i = 0; i < d->numaddr; i++) {
     const struct dohaddr *a = &d->addr[i];
-    if(a->type == DNS_TYPE_A) {
+    if(a->type == CURL_DNS_TYPE_A) {
       infof(data, "[DoH] A: %u.%u.%u.%u",
             a->ip.v4[0], a->ip.v4[1],
             a->ip.v4[2], a->ip.v4[3]);
     }
-    else if(a->type == DNS_TYPE_AAAA) {
+    else if(a->type == CURL_DNS_TYPE_AAAA) {
       int j;
       char buffer[128] = "[DoH] AAAA: ";
       size_t len = strlen(buffer);
@@ -948,7 +949,7 @@ static CURLcode doh2ai(const struct dohentry *de, const char *hostname,
   for(i = 0; i < de->numaddr; i++) {
     size_t ss_size;
     CURL_SA_FAMILY_T addrtype;
-    if(de->addr[i].type == DNS_TYPE_AAAA) {
+    if(de->addr[i].type == CURL_DNS_TYPE_AAAA) {
 #ifndef USE_IPV6
       /* we cannot handle IPv6 addresses */
       continue;
@@ -1025,12 +1026,12 @@ static CURLcode doh2ai(const struct dohentry *de, const char *hostname,
 static const char *doh_type2name(DNStype dnstype)
 {
   switch(dnstype) {
-    case DNS_TYPE_A:
+    case CURL_DNS_TYPE_A:
       return "A";
-    case DNS_TYPE_AAAA:
+    case CURL_DNS_TYPE_AAAA:
       return "AAAA";
 #ifdef USE_HTTPSRR
-    case DNS_TYPE_HTTPS:
+    case CURL_DNS_TYPE_HTTPS:
       return "HTTPS";
 #endif
     default:

--- a/lib/doh.h
+++ b/lib/doh.h
@@ -51,12 +51,12 @@ typedef enum {
 } DOHcode;
 
 typedef enum {
-  DNS_TYPE_A = 1,
-  DNS_TYPE_NS = 2,
-  DNS_TYPE_CNAME = 5,
-  DNS_TYPE_AAAA = 28,
-  DNS_TYPE_DNAME = 39,           /* RFC6672 */
-  DNS_TYPE_HTTPS = 65
+  CURL_DNS_TYPE_A = 1,
+  CURL_DNS_TYPE_NS = 2,
+  CURL_DNS_TYPE_CNAME = 5,
+  CURL_DNS_TYPE_AAAA = 28,
+  CURL_DNS_TYPE_DNAME = 39,           /* RFC6672 */
+  CURL_DNS_TYPE_HTTPS = 65
 } DNStype;
 
 enum doh_slot_num {


### PR DESCRIPTION
It happens when building against mingw-w64 v3 or older while targeting
Vista or newer. `iphlpapi.h` includes `windns.h` in this case, which
defines macros named `DNS_TYPE_*`, colliding with curl doh enums.

The issue was fixed in mingw-w64 v4:
https://github.com/mirror/mingw-w64/commit/ea95d55e3387353e453d6ae8fc5cb8f7503947c2

Fixes:
```
lib/doh.h:54:3: error: expected identifier before numeric constant
   DNS_TYPE_A = 1,
   ^
```
Ref: https://github.com/curl/curl/actions/runs/16551209676/job/46806303365?pr=18009#step:10:17

This workaround seems harmless and generally good practice, but
another option is to require mingw-w64 v4.
