### PR TITLE
hostip: try fixing 'different const qualifiers' warning

### DIFF
--- a/lib/curlx/inet_ntop.h
+++ b/lib/curlx/inet_ntop.h
@@ -26,8 +26,6 @@
 
 #include "../curl_setup.h"
 
-char *curlx_inet_ntop(int af, const void *addr, char *buf, size_t size);
-
 #ifdef HAVE_INET_NTOP
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -46,6 +44,8 @@ char *curlx_inet_ntop(int af, const void *addr, char *buf, size_t size);
 #define curlx_inet_ntop(af,addr,buf,size)                \
   inet_ntop(af, addr, buf, (curl_socklen_t)(size))
 #endif
-#endif
+#else
+char *curlx_inet_ntop(int af, const void *addr, char *buf, size_t size);
+#endif /* HAVE_INET_NTOP */
 
 #endif /* HEADER_CURL_INET_NTOP_H */

--- a/lib/curlx/inet_pton.h
+++ b/lib/curlx/inet_pton.h
@@ -26,8 +26,6 @@
 
 #include "../curl_setup.h"
 
-int curlx_inet_pton(int, const char *, void *);
-
 #ifdef HAVE_INET_PTON
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -43,6 +41,8 @@ int curlx_inet_pton(int, const char *, void *);
 #else
 #define curlx_inet_pton(x,y,z) inet_pton(x,y,z)
 #endif
-#endif
+#else
+int curlx_inet_pton(int, const char *, void *);
+#endif /* HAVE_INET_PTON */
 
 #endif /* HEADER_CURL_INET_PTON_H */


### PR DESCRIPTION
Seen in the VisualStudioSolution (VS2013) job on AppVeyor:
```
3>..\..\..\..\lib\hostip.c(148): warning C4090: 'function' : different 'const' qualifiers [C:\projects\curl\projects\Windows\VC12\lib\libcurl.vcxproj]
3>..\..\..\..\lib\hostip.c(155): warning C4090: 'function' : different 'const' qualifiers [C:\projects\curl\projects\Windows\VC12\lib\libcurl.vcxproj]
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/52470650/job/gslnjrdxnd8b9mtv#L180