### PR TITLE
config-win32.h: do not use system `inet_pton`, `inet_ntop`

### DIFF
--- a/lib/config-win32.h
+++ b/lib/config-win32.h
@@ -264,13 +264,12 @@
 #define HAVE_SNPRINTF 1
 #endif
 
-/* Vista */
-#if (defined(_WIN32_WINNT) && _WIN32_WINNT >= 0x600) && !defined(UNDER_CE)
+/* Keep these disabled regardless of Windows target version. Windows
+   build must use the curl implementations. */
 /* Define to 1 if you have an IPv6 capable working inet_ntop function. */
-#define HAVE_INET_NTOP 1
+#define HAVE_INET_NTOP 0
 /* Define to 1 if you have an IPv6 capable working inet_pton function. */
-#define HAVE_INET_PTON 1
-#endif
+#define HAVE_INET_PTON 0
 
 /* Define to 1 if you have the `basename' function. */
 #ifdef __MINGW32__


### PR DESCRIPTION
Syncing winbuild and VS Project File builds with this fix applied
to the standard builds earlier.

Also fixes these warnings seen in the VisualStudioSolution (VS2013) job
on AppVeyor CI:
```
lib\hostip.c(148): warning C4090: 'function' : different 'const' qualifiers
lib\hostip.c(155): warning C4090: 'function' : different 'const' qualifiers
```
Ref: https://ci.appveyor.com/project/curlorg/curl/builds/52470650/job/gslnjrdxnd8b9mtv#L180

Follow-up to 8537a5b0bcf4565551774c2b2375c49767e405a7 #16577