### PR TITLE
multi: fix assert in multi_getsock()

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -1121,11 +1121,13 @@ void Curl_multi_getsock(struct Curl_easy *data,
                  caller, ps->num, Curl_llist_count(&data->state.timeoutlist));
       break;
   }
-  if(expect_sockets && !ps->num &&
+  if(expect_sockets && !ps->num && data->multi &&
+     !Curl_uint_bset_contains(&data->multi->dirty, data->mid) &&
      !Curl_llist_count(&data->state.timeoutlist) &&
      !Curl_cwriter_is_paused(data) && !Curl_creader_is_paused(data) &&
      Curl_conn_is_ip_connected(data, FIRSTSOCKET)) {
     /* We expected sockets for POLL monitoring, but none are set.
+     * We are not dirty (and run anyway).
      * We are not waiting on any timer.
      * None of the READ/WRITE directions are paused.
      * We are connected to the server on IP level, at least. */


### PR DESCRIPTION
Now that multi keeps the "dirty" bitset, the detection of possibly stalling transfers needs to adapt. Before dirty, transfers needed to expose a socket to poll or a timer to wait for.

Dirty transfer might no longer have a timer, but will run, so do not need to report a socket. Adjust the assert condition.

refs #18046