### PR TITLE
CURLOPT: bump `CURLHEADER_*` macros to `long`, drop casts

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1021,7 +1021,7 @@ typedef enum {
 
 /* bitmask defines for CURLOPT_HEADEROPT */
 #define CURLHEADER_UNIFIED  0L
-#define CURLHEADER_SEPARATE (long)(1<<0)
+#define CURLHEADER_SEPARATE (1L<<0)
 
 /* CURLALTSVC_* are bits for the CURLOPT_ALTSVC_CTRL option */
 #define CURLALTSVC_READONLYFILE (1<<2)

--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1020,8 +1020,8 @@ typedef enum {
 } curl_ftpmethod;
 
 /* bitmask defines for CURLOPT_HEADEROPT */
-#define CURLHEADER_UNIFIED  0
-#define CURLHEADER_SEPARATE (1<<0)
+#define CURLHEADER_UNIFIED  0L
+#define CURLHEADER_SEPARATE (long)(1<<0)
 
 /* CURLALTSVC_* are bits for the CURLOPT_ALTSVC_CTRL option */
 #define CURLALTSVC_READONLYFILE (1<<2)

--- a/tests/libtest/lib1525.c
+++ b/tests/libtest/lib1525.c
@@ -74,7 +74,7 @@ static CURLcode test_lib1525(char *URL)
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
   test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
   test_setopt(curl, CURLOPT_PROXYHEADER, hhl);
-  test_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_UNIFIED);
+  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_UNIFIED);
   test_setopt(curl, CURLOPT_POST, 0L);
   test_setopt(curl, CURLOPT_UPLOAD, 1L);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib1526.c
+++ b/tests/libtest/lib1526.c
@@ -78,7 +78,7 @@ static CURLcode test_lib1526(char *URL)
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
   test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
   test_setopt(curl, CURLOPT_PROXYHEADER, phl);
-  test_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_SEPARATE);
+  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
   test_setopt(curl, CURLOPT_POST, 0L);
   test_setopt(curl, CURLOPT_UPLOAD, 1L);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib1527.c
+++ b/tests/libtest/lib1527.c
@@ -85,7 +85,7 @@ static CURLcode test_lib1527(char *URL)
   test_setopt(curl, CURLOPT_READFUNCTION, t1527_read_cb);
   test_setopt(curl, CURLOPT_HTTPPROXYTUNNEL, 1L);
   test_setopt(curl, CURLOPT_INFILESIZE, (long)strlen(t1527_testdata));
-  test_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_UNIFIED);
+  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_UNIFIED);
 
   res = curl_easy_perform(curl);
 

--- a/tests/libtest/lib1528.c
+++ b/tests/libtest/lib1528.c
@@ -56,7 +56,7 @@ static CURLcode test_lib1528(char *URL)
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);
   test_setopt(curl, CURLOPT_HTTPHEADER, hhl);
   test_setopt(curl, CURLOPT_PROXYHEADER, phl);
-  test_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_SEPARATE);
+  test_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
   test_setopt(curl, CURLOPT_PROXYTYPE, (long)CURLPROXY_HTTP);
   test_setopt(curl, CURLOPT_HEADER, 1L);


### PR DESCRIPTION
This patch bumps the size of these macros from `int` to `long`, while
keeping their actual values the same. It may cause incompatibilities in
user code, requiring the bump of holder variables and/or adding casts:

- CURLHEADER_SEPARATE
- CURLHEADER_UNIFIED

Also:
- keep existing cast within the documentation to make sure it applies
  to older curl versions as well.
