### PR TITLE
_PROTOCOLS.md: mention file:// is only for absolute paths

### DIFF
--- a/docs/cmdline-opts/_PROTOCOLS.md
+++ b/docs/cmdline-opts/_PROTOCOLS.md
@@ -8,7 +8,7 @@ Lets you lookup words using online dictionaries.
 ## FILE
 Read or write local files. curl does not support accessing file:// URL
 remotely, but when running on Microsoft Windows using the native UNC approach
-works.
+works. Only absolute paths.
 ## FTP(S)
 curl supports the File Transfer Protocol with a lot of tweaks and levers. With
 or without using TLS.


### PR DESCRIPTION
... when using curl.

Asked-by: Paul Gilmartin
URL: https://curl.se/mail/archive-2025-07/0018.html