### PR TITLE
delta: fix warnings, fix for non-GNU `date` tool

### DIFF
--- a/scripts/delta
+++ b/scripts/delta
@@ -92,7 +92,7 @@ chomp $branch;
 # Number of files in git
 my $afiles=`git ls-files | wc -l`;
 my $deletes=`git diff-tree --diff-filter=A -r --summary origin/$branch $start 2>/dev/null | wc -l`;
-my $creates=`git diff-tree --diff-filter=D -r --summary origin/$branch $start 2>/dev/null| wc -l`;
+my $creates=`git diff-tree --diff-filter=D -r --summary origin/$branch $start 2>/dev/null | wc -l`;
 
 # Time since that tag
 my $tagged=`git for-each-ref --format="%(refname:short) | %(taggerdate:unix)" refs/tags/* | grep ^$start | cut "-d|" -f2`; # Unix timestamp


### PR DESCRIPTION
It makes the script run on BSD-like envs.

Follow-up to f63bdea79028c30780b3450e5d444c84b63a5434 #18058
Follow-up to 2ec54556d4e3f3ab551b5298adab0c703d85a463 #17877
