### PR TITLE
contrithanks: fix for BSD `sed` tool

### DIFF
--- a/scripts/contrithanks.sh
+++ b/scripts/contrithanks.sh
@@ -79,7 +79,7 @@ tail -n +7 ./docs/THANKS | sed 's/ github/ github/i'  > $rand
   sed 's/, */\n/g'| \
   sed 's/^ *//'
 } | \
-sed -f ./docs/THANKS-filter | \
+LC_ALL=C sed -f ./docs/THANKS-filter | \
 sort -fu | \
 grep -aixvFf ./docs/THANKS >> $rand
 


### PR DESCRIPTION
Fixing on macOS, and possibly other BSDs:
```
sed: 83: ./docs/THANKS-filter: RE error: illegal byte sequence
```
Where line 83 contains `\xED`.

Switch to raw encoding to avoid `sed` evaluating the stream of bytes.

Ref: #18061