### PR TITLE
CURLOPT: bump `CURLALTSVC_*` macros to `long`

### DIFF
--- a/include/curl/curl.h
+++ b/include/curl/curl.h
@@ -1024,10 +1024,10 @@ typedef enum {
 #define CURLHEADER_SEPARATE (1<<0)
 
 /* CURLALTSVC_* are bits for the CURLOPT_ALTSVC_CTRL option */
-#define CURLALTSVC_READONLYFILE (1<<2)
-#define CURLALTSVC_H1           (1<<3)
-#define CURLALTSVC_H2           (1<<4)
-#define CURLALTSVC_H3           (1<<5)
+#define CURLALTSVC_READONLYFILE (1L<<2)
+#define CURLALTSVC_H1           (1L<<3)
+#define CURLALTSVC_H2           (1L<<4)
+#define CURLALTSVC_H3           (1L<<5)
 
 /* bitmask values for CURLOPT_UPLOAD_FLAGS */
 #define CURLULFLAG_ANSWERED (1L<<0)


### PR DESCRIPTION
This patch bumps the size of these macros from `int` to `long`, while
keeping their actual values the same. It may cause incompatibilities in
user code, requiring the bump of holder variables and/or adding casts:

- CURLALTSVC_H1
- CURLALTSVC_H2     
- CURLALTSVC_H3
- CURLALTSVC_READONLYFILE

Also:
- keep existing cast within the documentation to make sure it applies
  to older curl versions as well.
