### PR TITLE
CURLINFO_TLS_SSL_PTR testing

### DIFF
--- a/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
+++ b/docs/libcurl/opts/CURLINFO_TLS_SESSION.md
@@ -36,8 +36,11 @@ was added in 7.48.0. The only reason you would use this option instead is if
 you could be using a version of libcurl earlier than 7.48.0.
 
 This option is exactly the same as CURLINFO_TLS_SSL_PTR(3) except in the
-case of OpenSSL. If the session *backend* is CURLSSLBACKEND_OPENSSL the
-session *internals* pointer varies depending on the option:
+case of OpenSSL and wolfSSL. If the session *backend* is
+CURLSSLBACKEND_OPENSSL the session *internals* pointer varies depending
+on the option:
+
+## OpenSSL:
 
 CURLINFO_TLS_SESSION(3) OpenSSL session *internals* is **SSL_CTX ***.
 
@@ -45,6 +48,17 @@ CURLINFO_TLS_SSL_PTR(3) OpenSSL session *internals* is **SSL ***.
 
 You can obtain an **SSL_CTX** pointer from an SSL pointer using OpenSSL
 function *SSL_get_SSL_CTX(3)*. Therefore unless you need compatibility
+with older versions of libcurl use CURLINFO_TLS_SSL_PTR(3). Refer to
+that document for more information.
+
+## wolfSSL
+
+CURLINFO_TLS_SESSION(3) wolfSSL session *internals* is **WOLFSSL_CTX ***.
+
+CURLINFO_TLS_SSL_PTR(3) wolfSSL session *internals* is **WOLFSSL ***.
+
+You can obtain an **WOLFSSL_CTX** pointer from an SSL pointer using wolfSSL
+function *wolfSSL_get_SSL_CTX(3)*. Therefore unless you need compatibility
 with older versions of libcurl use CURLINFO_TLS_SSL_PTR(3). Refer to
 that document for more information.
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -2658,7 +2658,7 @@ static CURLcode cf_ngtcp2_query(struct Curl_cfilter *cf,
   case CF_QUERY_SSL_CTX_INFO: {
     struct curl_tlssessioninfo *info = pres2;
     if(Curl_vquic_tls_get_ssl_info(&ctx->tls,
-                                   (query == CF_QUERY_SSL_INFO), info))
+                                   (query == CF_QUERY_SSL_CTX_INFO), info))
       return CURLE_OK;
     break;
   }

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -2352,7 +2352,7 @@ static CURLcode cf_osslq_query(struct Curl_cfilter *cf,
   case CF_QUERY_SSL_CTX_INFO: {
     struct curl_tlssessioninfo *info = pres2;
     if(Curl_vquic_tls_get_ssl_info(&ctx->tls,
-                                   (query == CF_QUERY_SSL_INFO), info))
+                                   (query == CF_QUERY_SSL_CTX_INFO), info))
       return CURLE_OK;
     break;
   }

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1551,7 +1551,7 @@ static CURLcode cf_quiche_query(struct Curl_cfilter *cf,
   case CF_QUERY_SSL_CTX_INFO: {
     struct curl_tlssessioninfo *info = pres2;
     if(Curl_vquic_tls_get_ssl_info(&ctx->tls,
-                                   (query == CF_QUERY_SSL_INFO), info))
+                                   (query == CF_QUERY_SSL_CTX_INFO), info))
       return CURLE_OK;
     break;
   }

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -1300,7 +1300,7 @@ cr_get_internals(struct ssl_connect_data *connssl,
   struct rustls_ssl_backend_data *backend =
     (struct rustls_ssl_backend_data *)connssl->backend;
   DEBUGASSERT(backend);
-  return &backend->conn;
+  return backend->conn;
 }
 
 static CURLcode

--- a/lib/vtls/wolfssl.c
+++ b/lib/vtls/wolfssl.c
@@ -2240,12 +2240,12 @@ static CURLcode wssl_sha256sum(const unsigned char *tmp, /* input */
 }
 
 static void *wssl_get_internals(struct ssl_connect_data *connssl,
-                                CURLINFO info UNUSED_PARAM)
+                                CURLINFO info)
 {
   struct wssl_ctx *wssl = (struct wssl_ctx *)connssl->backend;
-  (void)info;
   DEBUGASSERT(wssl);
-  return wssl->ssl;
+  return info == CURLINFO_TLS_SESSION ?
+    (void *)wssl->ssl_ctx : (void *)wssl->ssl;
 }
 
 const struct Curl_ssl Curl_ssl_wolfssl = {

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -132,6 +132,8 @@ static int my_progress_d_cb(void *userdata,
     return 1;
   }
 
+#if defined(USE_QUICHE) || defined(USE_OPENSSL) || defined(USE_WOLFSSL) || \
+  defined(USE_GNUTLS) || defined(USE_MBEDTLS) || defined(USE_RUSTLS)
   if(!t->checked_ssl && dlnow > 0) {
     struct curl_tlssessioninfo *tls;
     CURLcode res;
@@ -202,6 +204,7 @@ static int my_progress_d_cb(void *userdata,
       }
     }
   }
+#endif
   return 0;
 }
 

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -25,6 +25,8 @@
 
 #include "testtrace.h"
 
+#include "curl_mem_undef.h"
+
 #if defined(USE_QUICHE) || defined(USE_OPENSSL)
 #include <openssl/ssl.h>
 #endif

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -24,7 +24,6 @@
 #include "first.h"
 
 #include "testtrace.h"
-#include "memdebug.h"
 
 #if defined(USE_QUICHE) || defined(USE_OPENSSL)
 #include <openssl/ssl.h>
@@ -44,6 +43,7 @@
 #include <rustls.h>
 #endif
 
+#include "memdebug.h"
 
 static int verbose_d = 1;
 

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -26,6 +26,25 @@
 #include "testtrace.h"
 #include "memdebug.h"
 
+#if defined(USE_QUICHE) || defined(USE_OPENSSL)
+#include <openssl/ssl.h>
+#endif
+#ifdef USE_WOLFSSL
+#include <wolfssl/options.h>
+#include <wolfssl/version.h>
+#include <wolfssl/ssl.h>
+#endif
+#ifdef USE_GNUTLS
+#include <gnutls/gnutls.h>
+#endif
+#ifdef USE_MBEDTLS
+#include <mbedtls/ssl.h>
+#endif
+#ifdef USE_RUSTLS
+#include <rustls.h>
+#endif
+
+
 static int verbose_d = 1;
 
 struct transfer_d {
@@ -41,6 +60,7 @@ struct transfer_d {
   int paused;
   int resumed;
   int done;
+  int checked_ssl;
   CURLcode result;
 };
 
@@ -110,6 +130,77 @@ static int my_progress_d_cb(void *userdata,
     curl_mfprintf(stderr, "[t-%d] ABORT by progress_cb at %ld bytes\n",
                   t->idx, (long)dlnow);
     return 1;
+  }
+
+  if(!t->checked_ssl && dlnow > 0) {
+    struct curl_tlssessioninfo *tls;
+    CURLcode res;
+
+    t->checked_ssl = TRUE;
+    res = curl_easy_getinfo(t->easy, CURLINFO_TLS_SSL_PTR, &tls);
+    if(res) {
+      curl_mfprintf(stderr, "[t-%d] info CURLINFO_TLS_SSL_PTR failed: %d\n",
+                    t->idx, res);
+      assert(0);
+    }
+    else {
+      switch(tls->backend) {
+#if defined(USE_QUICHE) || defined(USE_OPENSSL)
+      case CURLSSLBACKEND_OPENSSL: {
+        const char *version = SSL_get_version((SSL*)tls->internals);
+        assert(version);
+        assert(strcmp(version, "unknown"));
+        curl_mfprintf(stderr, "[t-%d] info OpenSSL using %s\n",
+                      t->idx, version);
+        break;
+      }
+#endif
+#ifdef USE_WOLFSSL
+      case CURLSSLBACKEND_WOLFSSL: {
+        const char *version = wolfSSL_get_version((WOLFSSL*)tls->internals);
+        assert(version);
+        assert(strcmp(version, "unknown"));
+        curl_mfprintf(stderr, "[t-%d] info wolfSSL using %s\n",
+                      t->idx, version);
+        break;
+      }
+#endif
+#ifdef USE_GNUTLS
+      case CURLSSLBACKEND_GNUTLS: {
+        int v = gnutls_protocol_get_version((gnutls_session_t)tls->internals);
+        assert(v);
+        curl_mfprintf(stderr, "[t-%d] info GnuTLS using %s\n",
+                      t->idx, gnutls_protocol_get_name(v));
+        break;
+      }
+#endif
+#ifdef USE_MBEDTLS
+      case CURLSSLBACKEND_MBEDTLS: {
+        const char *version = mbedtls_ssl_get_version(
+          (mbedtls_ssl_context*)tls->internals);
+        assert(version);
+        assert(strcmp(version, "unknown"));
+        curl_mfprintf(stderr, "[t-%d] info mbedTLS using %s\n",
+                      t->idx, version);
+        break;
+      }
+#endif
+#ifdef USE_RUSTLS
+      case CURLSSLBACKEND_RUSTLS: {
+        int v = rustls_connection_get_protocol_version(
+          (struct rustls_connection*)tls->internals);
+        assert(v);
+        curl_mfprintf(stderr, "[t-%d] info rustls TLS version 0x%x\n",
+                      t->idx, v);
+        break;
+      }
+#endif
+      default:
+        curl_mfprintf(stderr, "[t-%d] info SSL_PTR backend=%d, ptr=%p\n",
+                      t->idx, tls->backend, (void *)tls->internals);
+        break;
+      }
+    }
   }
   return 0;
 }
@@ -441,6 +532,8 @@ static CURLcode test_cli_hx_download(const char *URL)
     }
     if(t->result)
       result = t->result;
+    else /* on success we expect ssl to have been checked */
+      assert(t->checked_ssl);
   }
   free(transfer_d);
 


### PR DESCRIPTION
Add tests of CURLINFO_TLS_SSL_PTR and its returned value in test client 'hx-download'. Use obtained pointer to look up the negotiated TLS version.

Update manpage of CURLINFO_TLS_SSL_PTR to also describe the behaviour of wolfSSL similar to OpenSSL. Fix the wolfSSl implementation for TCP to behave like that. Update the QUIC queries.

Fix rustls `get_internals()` to return the rustls_connection* and not the address of the pointer.