### PR TITLE
parallel-max: bump the max value to 65535

### DIFF
--- a/docs/cmdline-opts/parallel-max.md
+++ b/docs/cmdline-opts/parallel-max.md
@@ -19,4 +19,4 @@ Example:
 When asked to do parallel transfers, using --parallel, this option controls
 the maximum amount of transfers to do simultaneously.
 
-The default is 50. 300 is the largest supported value.
+The default is 50. 65535 is the largest supported value.

--- a/src/tool_main.h
+++ b/src/tool_main.h
@@ -30,7 +30,7 @@
 #define RETRY_SLEEP_DEFAULT 1000L   /* ms */
 #define RETRY_SLEEP_MAX     600000L /* ms == 10 minutes */
 
-#define MAX_PARALLEL 300 /* conservative */
+#define MAX_PARALLEL 65535
 #define PARALLEL_DEFAULT 50
 
 #endif /* HEADER_CURL_TOOL_MAIN_H */


### PR DESCRIPTION
When doing HTTP/2 and HTTP/3, it could be possible to achieve quite a massive parallelism so limiting this to 300 seems restrictive.

With other protocols, going beyond 300-400 might not be recommended but curl does not have to enforce the limit.