### PR TITLE
tool_operate: simplify single_transfer

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -74,7 +74,7 @@ struct State {
   curl_off_t infilenum; /* number of files to upload */
   curl_off_t up;        /* upload file counter within a single upload glob */
   curl_off_t urlnum;    /* how many iterations this URL has with ranges etc */
-  curl_off_t li;
+  curl_off_t li;        /* index for globbed URLs */
 };
 
 struct OperationConfig {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1145,22 +1145,22 @@ static CURLcode single_transfer(struct OperationConfig *config,
   }
 
   while(state->urlnode) {
-    struct getout *urlnode = state->urlnode;
+    struct getout *u = state->urlnode;
 
-    /* urlnode->url is the full URL or NULL */
-    if(!urlnode->url) {
+    /* u->url is the full URL or NULL */
+    if(!u->url) {
       /* This node has no URL. End of the road. */
       warnf(config->global, "Got more output options than URLs");
       break;
     }
 
     /* save outfile pattern before expansion */
-    if(urlnode->outfile && !state->outfiles)
-      state->outfiles = urlnode->outfile;
+    if(u->outfile && !state->outfiles)
+      state->outfiles = u->outfile;
 
-    if(!config->globoff && urlnode->infile && !state->inglob) {
+    if(!config->globoff && u->infile && !state->inglob) {
       /* Unless explicitly shut off */
-      result = glob_url(&state->inglob, urlnode->infile, &state->infilenum,
+      result = glob_url(&state->inglob, u->infile, &state->infilenum,
                         (!global->silent || global->showerror) ?
                         tool_stderr : NULL);
       if(result)
@@ -1168,7 +1168,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
     }
 
 
-    if(state->up || urlnode->infile) {
+    if(state->up || u->infile) {
       if(!state->uploadfile) {
         if(state->inglob) {
           result = glob_next_url(&state->uploadfile, state->inglob);
@@ -1177,8 +1177,8 @@ static CURLcode single_transfer(struct OperationConfig *config,
         }
         else if(!state->up) {
           /* copy the allocated string */
-          state->uploadfile = urlnode->infile;
-          urlnode->infile = NULL;
+          state->uploadfile = u->infile;
+          u->infile = NULL;
         }
       }
       if(result)
@@ -1186,10 +1186,10 @@ static CURLcode single_transfer(struct OperationConfig *config,
     }
 
     if(!state->urlnum) {
-      if(!config->globoff && !urlnode->noglob) {
+      if(!config->globoff && !u->noglob) {
         /* Unless explicitly shut off, we expand '{...}' and '[...]'
            expressions and return total number of URLs in pattern set */
-        result = glob_url(&state->urls, urlnode->url, &state->urlnum,
+        result = glob_url(&state->urls, u->url, &state->urlnum,
                           (!global->silent || global->showerror) ?
                           tool_stderr : NULL);
         if(result)
@@ -1251,7 +1251,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
       *added = TRUE;
       per->config = config;
       per->curl = curl;
-      per->urlnum = (unsigned int)urlnode->num;
+      per->urlnum = (unsigned int)u->num;
 
       /* default headers output stream is stdout */
       heads = &per->heads;
@@ -1280,7 +1280,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
           return result;
       }
       else if(!state->li) {
-        per->url = strdup(urlnode->url);
+        per->url = strdup(u->url);
         if(!per->url)
           return CURLE_OUT_OF_MEMORY;
       }
@@ -1295,8 +1295,8 @@ static CURLcode single_transfer(struct OperationConfig *config,
           return CURLE_OUT_OF_MEMORY;
       }
 
-      outs->out_null = urlnode->out_null;
-      if(!outs->out_null && (urlnode->useremote ||
+      outs->out_null = u->out_null;
+      if(!outs->out_null && (u->useremote ||
           (per->outfile && strcmp("-", per->outfile)))) {
         result = setup_outfile(config, per, outs, skipped);
         if(result)
@@ -1351,7 +1351,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
       config->terminal_binary_ok =
         (per->outfile && !strcmp(per->outfile, "-"));
 
-      if(config->content_disposition && urlnode->useremote)
+      if(config->content_disposition && u->useremote)
         hdrcbdata->honor_cd_filename = TRUE;
       else
         hdrcbdata->honor_cd_filename = FALSE;
@@ -1384,21 +1384,20 @@ static CURLcode single_transfer(struct OperationConfig *config,
       }
       break;
     }
-    else {
-      /* Free this URL node data without destroying the
-         node itself nor modifying next pointer. */
-      urlnode->outset = urlnode->urlset = urlnode->useremote =
-        urlnode->uploadset = urlnode->noupload = urlnode->noglob = FALSE;
-      glob_cleanup(&state->urls);
-      state->urlnum = 0;
 
-      state->outfiles = NULL;
-      tool_safefree(state->uploadfile);
-      /* Free list of globbed upload files */
-      glob_cleanup(&state->inglob);
-      state->up = 0;
-      state->urlnode = urlnode->next; /* next node */
-    }
+    /* Free this URL node data without destroying the
+       node itself nor modifying next pointer. */
+    u->outset = u->urlset = u->useremote =
+      u->uploadset = u->noupload = u->noglob = FALSE;
+    glob_cleanup(&state->urls);
+    state->urlnum = 0;
+
+    state->outfiles = NULL;
+    tool_safefree(state->uploadfile);
+    /* Free list of globbed upload files */
+    glob_cleanup(&state->inglob);
+    state->up = 0;
+    state->urlnode = u->next; /* next node */
   }
   state->outfiles = NULL;
   return result;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1111,7 +1111,6 @@ static CURLcode single_transfer(struct OperationConfig *config,
                                 bool *skipped)
 {
   CURLcode result = CURLE_OK;
-  struct getout *urlnode;
   struct GlobalConfig *global = config->global;
   bool orig_noprogress = global->noprogress;
   bool orig_isatty = global->isatty;
@@ -1145,7 +1144,8 @@ static CURLcode single_transfer(struct OperationConfig *config,
     state->infilenum = 1;
   }
 
-  while((urlnode = state->urlnode)) {
+  while(state->urlnode) {
+    struct getout *urlnode = state->urlnode;
 
     /* urlnode->url is the full URL or NULL */
     if(!urlnode->url) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1248,7 +1248,6 @@ static CURLcode single_transfer(struct OperationConfig *config,
           return CURLE_FAILED_INIT;
         }
       }
-      *added = TRUE;
       per->config = config;
       per->curl = curl;
       per->urlnum = (unsigned int)u->num;
@@ -1382,6 +1381,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
         state->up++;
         tool_safefree(state->uploadfile); /* clear it to get the next */
       }
+      *added = TRUE;
       break;
     }
 
@@ -2136,10 +2136,8 @@ static CURLcode transfer_per_config(struct OperationConfig *config,
 
   if(!result) {
     result = single_transfer(config, share, added, skipped);
-    if(!*added || result) {
-      *added = FALSE;
+    if(!*added || result)
       single_transfer_cleanup(config);
-    }
   }
 
   return result;

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -45,8 +45,8 @@ void clean_getout(struct OperationConfig *config)
       node = next;
     }
     config->url_list = NULL;
+    single_transfer_cleanup(config);
   }
-  single_transfer_cleanup(config);
 }
 
 bool output_expected(const char *url, const char *uploadfile)


### PR DESCRIPTION
- let the caller do the cleanup on fail
- avoid gotos and use direct returns more
- use while() loop