### PR TITLE
tidy-up: include curlx/curlx.h with double quotes

### DIFF
--- a/src/tool_setup.h
+++ b/src/tool_setup.h
@@ -47,7 +47,7 @@ extern FILE *tool_stderr;
 
 #include <curl/curl.h> /* external interface */
 
-#include <curlx/curlx.h>
+#include "curlx/curlx.h"
 
 /*
  * Platform specific stuff.

--- a/tests/client/first.h
+++ b/tests/client/first.h
@@ -38,7 +38,7 @@ extern const struct entry_s s_entries[];
 
 #include <curl/curl.h>
 
-#include <curlx/curlx.h>
+#include "curlx/curlx.h"
 
 #define ERR()                                                                 \
   do {                                                                        \

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -45,7 +45,7 @@ extern const struct entry_s s_entries[];
 
 extern int unitfail; /* for unittests */
 
-#include <curlx/curlx.h>
+#include "curlx/curlx.h"
 
 #ifdef HAVE_SYS_SELECT_H
 /* since so many tests use select(), we can just as well include it here */

--- a/tests/server/first.h
+++ b/tests/server/first.h
@@ -64,7 +64,7 @@ extern const struct entry_s s_entries[];
 #include <netdb.h>
 #endif
 
-#include <curlx/curlx.h>
+#include "curlx/curlx.h"
 
 /* adjust for old MSVC */
 #if defined(_MSC_VER) && (_MSC_VER < 1900)


### PR DESCRIPTION
For consistency with curlx and internal includes.
