### PR TITLE
schannel: drop old-mingw special case

### DIFF
--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -32,6 +32,7 @@
 
 #if defined(CERT_CHAIN_REVOCATION_CHECK_CHAIN) && !defined(CURL_WINDOWS_UWP)
 #define HAS_MANUAL_VERIFY_API
+#warning "YES, HAS_MANUAL_VERIFY_API"
 #endif
 
 #if defined(CryptStringToBinary) && defined(CRYPT_STRING_HEX) && \

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -30,8 +30,7 @@
 
 #include "vtls.h"
 
-#if (defined(__MINGW32__) || defined(CERT_CHAIN_REVOCATION_CHECK_CHAIN)) && \
-  !defined(CURL_WINDOWS_UWP)
+#if defined(CERT_CHAIN_REVOCATION_CHECK_CHAIN) && !defined(CURL_WINDOWS_UWP)
 #define HAS_MANUAL_VERIFY_API
 #endif
 


### PR DESCRIPTION
mingw-w64 always defines `CERT_CHAIN_REVOCATION_CHECK_CHAIN`.

Follow-up to 38029101e2d78ba125732b3bab6ec267b80a0e72 #11625
