### PR TITLE
windows: document toolchain support for some macros

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -164,6 +164,7 @@ static void nosigpipe(struct Curl_easy *data,
 #define KEEPALIVE_FACTOR(x)
 #endif
 
+/* Offered by mingw-w64 and MS SDK. Latter only when targeting Win7+. */
 #if defined(USE_WINSOCK) && !defined(SIO_KEEPALIVE_VALS)
 #define SIO_KEEPALIVE_VALS    _WSAIOW(IOC_VENDOR,4)
 

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1406,6 +1406,7 @@ static void cf_socket_adjust_pollset(struct Curl_cfilter *cf,
 
 #ifdef USE_WINSOCK
 
+/* Offered by mingw-w64 v13+. MS SDK 7.1A+. */
 #ifndef SIO_IDEAL_SEND_BACKLOG_QUERY
 #define SIO_IDEAL_SEND_BACKLOG_QUERY 0x4004747B
 #endif

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -1406,7 +1406,7 @@ static void cf_socket_adjust_pollset(struct Curl_cfilter *cf,
 
 #ifdef USE_WINSOCK
 
-/* Offered by mingw-w64 v13+. MS SDK 7.1A+. */
+/* Offered by mingw-w64 v13+. MS SDK 7.0A+. */
 #ifndef SIO_IDEAL_SEND_BACKLOG_QUERY
 #define SIO_IDEAL_SEND_BACKLOG_QUERY 0x4004747B
 #endif

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -288,12 +288,15 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #define SEC_E_KDC_CERT_REVOKED                ((HRESULT)0x8009035BL)
 #endif
 #endif /* __MINGW32CE__ */
+/* Offered by mingw-w64 v8+. MS SDK 7.1A+. */
 #ifndef SEC_E_INVALID_PARAMETER
 #define SEC_E_INVALID_PARAMETER               ((HRESULT)0x8009035DL)
 #endif
+/* Offered by mingw-w64 v8+. MS SDK 7.1A+. */
 #ifndef SEC_E_DELEGATION_POLICY
 #define SEC_E_DELEGATION_POLICY               ((HRESULT)0x8009035EL)
 #endif
+/* Offered by mingw-w64 v8+. MS SDK 7.1A+. */
 #ifndef SEC_E_POLICY_NLTM_ONLY
 #define SEC_E_POLICY_NLTM_ONLY                ((HRESULT)0x8009035FL)
 #endif
@@ -325,7 +328,7 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #endif
 #endif /* __MINGW32CE__ */
 
-/* Offered by mingw-w64 v8+. SDK 7.1A+. */
+/* Offered by mingw-w64 v8+. MS SDK 7.1A+. */
 #ifndef SEC_I_SIGNATURE_NEEDED
 #define SEC_I_SIGNATURE_NEEDED                ((HRESULT)0x0009035CL)
 #endif

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -324,6 +324,8 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #define SEC_I_NO_LSA_CONTEXT                  ((HRESULT)0x00090323L)
 #endif
 #endif /* __MINGW32CE__ */
+
+/* Offered by mingw-w64 v8+. SDK 7.1A+. */
 #ifndef SEC_I_SIGNATURE_NEEDED
 #define SEC_I_SIGNATURE_NEEDED                ((HRESULT)0x0009035CL)
 #endif

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -65,7 +65,7 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #define SP_NAME_NEGOTIATE           "Negotiate"
 #define SP_NAME_KERBEROS            "Kerberos"
 
-/* Offered by mingw-w64 v9+. MS SDK 7.1A+. */
+/* Offered by mingw-w64 v9+. MS SDK 7.0A+. */
 #ifndef ISC_REQ_USE_HTTP_STYLE
 #define ISC_REQ_USE_HTTP_STYLE                0x01000000
 #endif
@@ -289,15 +289,15 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #define SEC_E_KDC_CERT_REVOKED                ((HRESULT)0x8009035BL)
 #endif
 #endif /* __MINGW32CE__ */
-/* Offered by mingw-w64 v8+. MS SDK 7.1A+. */
+/* Offered by mingw-w64 v8+. MS SDK 6.0A+. */
 #ifndef SEC_E_INVALID_PARAMETER
 #define SEC_E_INVALID_PARAMETER               ((HRESULT)0x8009035DL)
 #endif
-/* Offered by mingw-w64 v8+. MS SDK 7.1A+. */
+/* Offered by mingw-w64 v8+. MS SDK 6.0A+. */
 #ifndef SEC_E_DELEGATION_POLICY
 #define SEC_E_DELEGATION_POLICY               ((HRESULT)0x8009035EL)
 #endif
-/* Offered by mingw-w64 v8+. MS SDK 7.1A+. */
+/* Offered by mingw-w64 v8+. MS SDK 6.0A+. */
 #ifndef SEC_E_POLICY_NLTM_ONLY
 #define SEC_E_POLICY_NLTM_ONLY                ((HRESULT)0x8009035FL)
 #endif
@@ -329,7 +329,7 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #endif
 #endif /* __MINGW32CE__ */
 
-/* Offered by mingw-w64 v8+. MS SDK 7.1A+. */
+/* Offered by mingw-w64 v8+. MS SDK 6.0A+. */
 #ifndef SEC_I_SIGNATURE_NEEDED
 #define SEC_I_SIGNATURE_NEEDED                ((HRESULT)0x0009035CL)
 #endif

--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -65,6 +65,7 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #define SP_NAME_NEGOTIATE           "Negotiate"
 #define SP_NAME_KERBEROS            "Kerberos"
 
+/* Offered by mingw-w64 v9+. MS SDK 7.1A+. */
 #ifndef ISC_REQ_USE_HTTP_STYLE
 #define ISC_REQ_USE_HTTP_STYLE                0x01000000
 #endif

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -59,7 +59,6 @@
 #  ifndef BCRYPT_USE_SYSTEM_PREFERRED_RNG
 #  define BCRYPT_USE_SYSTEM_PREFERRED_RNG 0x00000002
 #  endif
-   /* Necessary for mingw-w64 */
 #  ifndef STATUS_SUCCESS
 #  define STATUS_SUCCESS ((NTSTATUS)0x00000000L)
 #  endif

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -55,7 +55,7 @@
 #  ifdef _MSC_VER
 #    pragma comment(lib, "bcrypt.lib")
 #  endif
-   /* Offered by mingw-w64 v3+. MS SDK v7.0a (VS2010). */
+   /* Offered by mingw-w64 v3+. MS SDK v7.0a+ (VS2010+). */
 #  ifndef BCRYPT_USE_SYSTEM_PREFERRED_RNG
 #  define BCRYPT_USE_SYSTEM_PREFERRED_RNG 0x00000002
 #  endif

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -55,6 +55,7 @@
 #  ifdef _MSC_VER
 #    pragma comment(lib, "bcrypt.lib")
 #  endif
+   /* Offered by mingw-w64 v3+. MS SDK v7.0a (VS2010). */
 #  ifndef BCRYPT_USE_SYSTEM_PREFERRED_RNG
 #  define BCRYPT_USE_SYSTEM_PREFERRED_RNG 0x00000002
 #  endif

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -59,6 +59,7 @@
 #  ifndef BCRYPT_USE_SYSTEM_PREFERRED_RNG
 #  define BCRYPT_USE_SYSTEM_PREFERRED_RNG 0x00000002
 #  endif
+   /* Necessary for mingw-w64 */
 #  ifndef STATUS_SUCCESS
 #  define STATUS_SUCCESS ((NTSTATUS)0x00000000L)
 #  endif

--- a/lib/rand.c
+++ b/lib/rand.c
@@ -55,7 +55,7 @@
 #  ifdef _MSC_VER
 #    pragma comment(lib, "bcrypt.lib")
 #  endif
-   /* Offered by mingw-w64 v3+. MS SDK v7.0a+ (VS2010+). */
+   /* Offered by mingw-w64 v3+. MS SDK v7.0A+. */
 #  ifndef BCRYPT_USE_SYSTEM_PREFERRED_RNG
 #  define BCRYPT_USE_SYSTEM_PREFERRED_RNG 0x00000002
 #  endif

--- a/lib/sha256.c
+++ b/lib/sha256.c
@@ -191,6 +191,7 @@ struct sha256_ctx {
 };
 typedef struct sha256_ctx my_sha256_ctx;
 
+/* Offered when targeting Vista (XP SP2+) */
 #ifndef CALG_SHA_256
 #define CALG_SHA_256 0x0000800c
 #endif

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -734,7 +734,7 @@ struct connectdata {
 
   /*************** Request - specific items ************/
 #if defined(USE_WINDOWS_SSPI) && defined(SECPKG_ATTR_ENDPOINT_BINDINGS)
-  CtxtHandle *sslContext;
+  CtxtHandle *sslContext;  /* mingw-w64 v9+. MS SDK 7.0A+. */
 #endif
 
 #ifdef USE_NTLM

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -117,6 +117,7 @@
  * #define failf(x, y, ...) printf(y, __VA_ARGS__)
  */
 
+/* Offered when targeting Vista (XP SP2+) */
 #ifndef CALG_SHA_256
 #define CALG_SHA_256 0x0000800c
 #endif
@@ -127,10 +128,12 @@
 #define ALG_CLASS_DHASH ALG_CLASS_HASH
 #endif
 
+/* Offered by mingw-w64 v4+. SDK 7.1A+. */
 #ifndef PKCS12_NO_PERSIST_KEY
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
 
+/* Offered by mingw-w64 v4+. Not by MS SDK 7.1A. */
 #ifndef CERT_FIND_HAS_PRIVATE_KEY
 #define CERT_FIND_HAS_PRIVATE_KEY (21 << CERT_COMPARE_SHIFT)
 #endif
@@ -1672,7 +1675,7 @@ static CURLcode schannel_connect(struct Curl_cfilter *cf,
   if(ssl_connect_done == connssl->connecting_state) {
     connssl->state = ssl_connection_complete;
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+. SDK 7.1A+. */
     /* When SSPI is used in combination with Schannel
      * we need the Schannel context to create the Schannel
      * binding to pass the IIS extended protection checks.

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -128,12 +128,12 @@
 #define ALG_CLASS_DHASH ALG_CLASS_HASH
 #endif
 
-/* Offered by mingw-w64 v4+. MS SDK 7.1A+. */
+/* Offered by mingw-w64 v4+. MS SDK 6.0A+. */
 #ifndef PKCS12_NO_PERSIST_KEY
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
 
-/* Offered by mingw-w64 v4+. Not by MS SDK 7.1A. */
+/* Offered by mingw-w64 v4+. MS SDK ~10+. */
 #ifndef CERT_FIND_HAS_PRIVATE_KEY
 #define CERT_FIND_HAS_PRIVATE_KEY (21 << CERT_COMPARE_SHIFT)
 #endif
@@ -1675,7 +1675,7 @@ static CURLcode schannel_connect(struct Curl_cfilter *cf,
   if(ssl_connect_done == connssl->connecting_state) {
     connssl->state = ssl_connection_complete;
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+. MS SDK 7.1A+. */
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+. MS SDK 7.0A+. */
     /* When SSPI is used in combination with Schannel
      * we need the Schannel context to create the Schannel
      * binding to pass the IIS extended protection checks.

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -128,7 +128,7 @@
 #define ALG_CLASS_DHASH ALG_CLASS_HASH
 #endif
 
-/* Offered by mingw-w64 v4+. SDK 7.1A+. */
+/* Offered by mingw-w64 v4+. MS SDK 7.1A+. */
 #ifndef PKCS12_NO_PERSIST_KEY
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
@@ -1675,7 +1675,7 @@ static CURLcode schannel_connect(struct Curl_cfilter *cf,
   if(ssl_connect_done == connssl->connecting_state) {
     connssl->state = ssl_connection_complete;
 
-#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+. SDK 7.1A+. */
+#ifdef SECPKG_ATTR_ENDPOINT_BINDINGS  /* mingw-w64 v9+. MS SDK 7.1A+. */
     /* When SSPI is used in combination with Schannel
      * we need the Schannel context to create the Schannel
      * binding to pass the IIS extended protection checks.

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -133,7 +133,7 @@
 #define PKCS12_NO_PERSIST_KEY 0x00008000
 #endif
 
-/* Offered by mingw-w64 v4+. MS SDK ~10+. */
+/* Offered by mingw-w64 v4+. MS SDK ~10+/~VS2017+. */
 #ifndef CERT_FIND_HAS_PRIVATE_KEY
 #define CERT_FIND_HAS_PRIVATE_KEY (21 << CERT_COMPARE_SHIFT)
 #endif

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -51,7 +51,7 @@
 #define CERT_STORE_PROV_SYSTEM_W  ((LPCSTR)(size_t)10)
 #endif
 
-/* Offered by mingw-w64 v8+, ~VS2022+ */
+/* Offered by mingw-w64 v8+, MS SDK ~10+/~VS2022+ */
 #ifndef SCH_CREDENTIALS_VERSION
 #define SCH_CREDENTIALS_VERSION  0x00000005
 

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -51,6 +51,7 @@
 #define CERT_STORE_PROV_SYSTEM_W  ((LPCSTR)(size_t)10)
 #endif
 
+/* Offered by mingw-w64 v8+, ~VS2022+ */
 #ifndef SCH_CREDENTIALS_VERSION
 #define SCH_CREDENTIALS_VERSION  0x00000005
 

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -35,9 +35,10 @@
 #define HAS_MANUAL_VERIFY_API
 #endif
 
+/* These two macros are missing from mingw-w64 in UWP mode as of v13 */
 #if defined(CryptStringToBinary) && defined(CRYPT_STRING_HEX) && \
   !defined(DISABLE_SCHANNEL_CLIENT_CERT)
-#define HAS_CLIENT_CERT_PATH  /* missing from mingw-w64 UWP as of v13 */
+#define HAS_CLIENT_CERT_PATH
 #endif
 
 #if defined(_MSC_VER) && (_MSC_VER <= 1600)

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -37,7 +37,7 @@
 
 #if defined(CryptStringToBinary) && defined(CRYPT_STRING_HEX) && \
   !defined(DISABLE_SCHANNEL_CLIENT_CERT)
-#define HAS_CLIENT_CERT_PATH
+#define HAS_CLIENT_CERT_PATH  /* missing from mingw-w64 UWP as of v13 */
 #endif
 
 #if defined(_MSC_VER) && (_MSC_VER <= 1600)

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -94,7 +94,7 @@ struct cert_chain_engine_config_win8 {
   DWORD dwExclusiveFlags;
 };
 
-/* Not defined before mingw-w64 4.0.0 */
+/* Offered by mingw-w64 v4+. MS SDK ~10+. */
 #ifndef CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG
 #define CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG 0x00000001
 #endif

--- a/lib/vtls/schannel_verify.c
+++ b/lib/vtls/schannel_verify.c
@@ -94,7 +94,7 @@ struct cert_chain_engine_config_win8 {
   DWORD dwExclusiveFlags;
 };
 
-/* Offered by mingw-w64 v4+. MS SDK ~10+. */
+/* Offered by mingw-w64 v4+. MS SDK ~10+/~VS2017+. */
 #ifndef CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG
 #define CERT_CHAIN_EXCLUSIVE_ENABLE_CA_FLAG 0x00000001
 #endif


### PR DESCRIPTION
The oldest MS SDK I checked is 6.0A (VS2008). Versions are approximate
beyond 7.1A. I only have two Win10 SDKs to verify:
10.0.16299.0 (VS2017-15.4) and 10.0.22621.0 (VS2022).

Ref: https://en.wikipedia.org/wiki/Microsoft_Windows_SDK
Ref: https://developer.microsoft.com/windows/downloads/sdk-archive/index-legacy (mostly recent versions)

---

- [x] try going back to 6.0a or 7.0a, but so far I did no manage to download these SDK in an unzippable. [DONE]