### PR TITLE
cmake: defer building `unitprotos.h` till a test target needs it

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -55,7 +55,7 @@ if(CURL_BUILD_TESTING)
       ${CSOURCES} > "${CMAKE_CURRENT_BINARY_DIR}/unitprotos.h"
     DEPENDS "${PROJECT_SOURCE_DIR}/scripts/extract-unit-protos" ${CSOURCES}
     VERBATIM)
-  add_custom_target(curlu-unitprotos ALL DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/unitprotos.h")
+  add_custom_target(curlu-unitprotos DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/unitprotos.h")
 endif()
 
 ## Library definition


### PR DESCRIPTION
Follow-up to c9bb9cd165c1b25c2fe005befdcfe479fc9b68e1 #17750
Ref: https://github.com/curl/curl/pull/17750#issuecomment-3133749477