### PR TITLE
unit-tests: build the unitprotos.h from here

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -162,7 +162,7 @@ CHECKSOURCES = checksrc
 endif
 endif
 
-all-local: $(CHECKSOURCES) $(UNITPROTOS)
+all-local: $(CHECKSOURCES)
 
 UNIT_V = $(UNITV_$(V))
 UNITV_0 = @echo "  UNITPR  " $@;

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -60,8 +60,11 @@ endif
 AM_CPPFLAGS += -DBUILDING_LIBCURL
 
 if BUILD_UNITTESTS
-$(BUNDLE).c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(TESTS_C)
+$(BUNDLE).c: $(top_srcdir)/scripts/mk-unity.pl Makefile.inc $(FIRST_C) $(TESTS_C) $(top_builddir)/lib/unitprotos.h
 	@PERL@ $(top_srcdir)/scripts/mk-unity.pl --test $(TESTS_C) > $(BUNDLE).c
+
+$(top_builddir)/lib/unitprotos.h:
+	(cd $(top_builddir)/lib && $(MAKE) unitprotos.h)
 
 noinst_PROGRAMS = $(BUNDLE)
 LDADD = $(top_builddir)/lib/libcurlu.la


### PR DESCRIPTION
Make the bundle depend on the header in the lib dir and built it now if not present.

Reported-by: Todd Gamblin
Fixes #18088