### PR TITLE
windows: drop `CRYPT_E_*` macro fallbacks, limit one to mingw32ce

### DIFF
--- a/lib/curl_sspi.h
+++ b/lib/curl_sspi.h
@@ -328,9 +328,11 @@ extern PSecurityFunctionTable Curl_pSecFn;
 #define SEC_I_SIGNATURE_NEEDED                ((HRESULT)0x0009035CL)
 #endif
 
+#ifdef __MINGW32CE__
 #ifndef CRYPT_E_NOT_IN_REVOCATION_DATABASE
 #define CRYPT_E_NOT_IN_REVOCATION_DATABASE    ((HRESULT)0x80092014L)
 #endif
+#endif /* __MINGW32CE__ */
 
 #ifdef UNICODE
 #  define SECFLAG_WINNT_AUTH_IDENTITY \


### PR DESCRIPTION
They are defined by all mingw-w64 versions and all supported MSVC
versions (VS2008 and up).

Also by OpenWatcom 2:
https://github.com/open-watcom/open-watcom-v2/blob/ce6c37eb29f3fda95f9c4e8e37dee866b8c4e496/bld/w32api/include/winerror.mh

mingw32ce misses `CRYPT_E_NOT_IN_REVOCATION_DATABASE`.