### PR TITLE
schannel: drop fallbacks for 4 macros

### DIFF
--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -40,22 +40,6 @@
 #define HAS_CLIENT_CERT_PATH
 #endif
 
-#ifndef CRYPT_DECODE_NOCOPY_FLAG
-#define CRYPT_DECODE_NOCOPY_FLAG 0x1
-#endif
-
-#ifndef CRYPT_DECODE_ALLOC_FLAG
-#define CRYPT_DECODE_ALLOC_FLAG 0x8000
-#endif
-
-#ifndef CERT_ALT_NAME_DNS_NAME
-#define CERT_ALT_NAME_DNS_NAME 3
-#endif
-
-#ifndef CERT_ALT_NAME_IP_ADDRESS
-#define CERT_ALT_NAME_IP_ADDRESS 8
-#endif
-
 #if defined(_MSC_VER) && (_MSC_VER <= 1600)
 /* Workaround for warning:
    'type cast' : conversion from 'int' to 'LPCSTR' of greater size */

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -40,6 +40,7 @@
 #define HAS_CLIENT_CERT_PATH
 #endif
 
+#ifdef __MINGW32CE__
 #ifndef CRYPT_DECODE_NOCOPY_FLAG
 #define CRYPT_DECODE_NOCOPY_FLAG 0x1
 #endif
@@ -55,6 +56,7 @@
 #ifndef CERT_ALT_NAME_IP_ADDRESS
 #define CERT_ALT_NAME_IP_ADDRESS 8
 #endif
+#endif /* __MINGW32CE__ */
 
 #if defined(_MSC_VER) && (_MSC_VER <= 1600)
 /* Workaround for warning:

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -40,24 +40,6 @@
 #define HAS_CLIENT_CERT_PATH
 #endif
 
-#ifdef __MINGW32CE__
-#ifndef CRYPT_DECODE_NOCOPY_FLAG
-#define CRYPT_DECODE_NOCOPY_FLAG 0x1
-#endif
-
-#ifndef CRYPT_DECODE_ALLOC_FLAG
-#define CRYPT_DECODE_ALLOC_FLAG 0x8000
-#endif
-
-#ifndef CERT_ALT_NAME_DNS_NAME
-#define CERT_ALT_NAME_DNS_NAME 3
-#endif
-
-#ifndef CERT_ALT_NAME_IP_ADDRESS
-#define CERT_ALT_NAME_IP_ADDRESS 8
-#endif
-#endif /* __MINGW32CE__ */
-
 #if defined(_MSC_VER) && (_MSC_VER <= 1600)
 /* Workaround for warning:
    'type cast' : conversion from 'int' to 'LPCSTR' of greater size */

--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -40,6 +40,22 @@
 #define HAS_CLIENT_CERT_PATH
 #endif
 
+#ifndef CRYPT_DECODE_NOCOPY_FLAG
+#define CRYPT_DECODE_NOCOPY_FLAG 0x1
+#endif
+
+#ifndef CRYPT_DECODE_ALLOC_FLAG
+#define CRYPT_DECODE_ALLOC_FLAG 0x8000
+#endif
+
+#ifndef CERT_ALT_NAME_DNS_NAME
+#define CERT_ALT_NAME_DNS_NAME 3
+#endif
+
+#ifndef CERT_ALT_NAME_IP_ADDRESS
+#define CERT_ALT_NAME_IP_ADDRESS 8
+#endif
+
 #if defined(_MSC_VER) && (_MSC_VER <= 1600)
 /* Workaround for warning:
    'type cast' : conversion from 'int' to 'LPCSTR' of greater size */


### PR DESCRIPTION
They are defined by all mingw-w64 versions and all supported MSVC
versions (SDK 7.1A+).

Also by OpenWatcom 2:
https://github.com/open-watcom/open-watcom-v2/blob/ce6c37eb29f3fda95f9c4e8e37dee866b8c4e496/bld/w32api/include/wincrypt.mh

These aren't defined by mingw32ce. And likely defined by MS WinCE SDK,
but curl code doesn't use them in WinCE builds.