### PR TITLE
build: fix mingw-w64 version guard for mingw32ce

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -75,7 +75,7 @@
 #endif
 #endif
 
-#if defined(__MINGW32__) && \
+#if defined(__MINGW32__) && !defined(__MINGW32CE__) && \
   (!defined(__MINGW64_VERSION_MAJOR) || (__MINGW64_VERSION_MAJOR < 3))
 #error "Building curl requires mingw-w64 3.0 or later"
 #endif


### PR DESCRIPTION
Follow-up to a28f5f68b965119d9dd1ab6c2a2ccc66c6ed5d1f #18010
