### PR TITLE
curl: make the URL indexes 64 bit

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1250,7 +1250,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
       }
       per->config = config;
       per->curl = curl;
-      per->urlnum = (unsigned int)u->num;
+      per->urlnum = u->num;
 
       /* default headers output stream is stdout */
       heads = &per->heads;

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -42,7 +42,7 @@ struct per_transfer {
   struct curltime start; /* start of this transfer */
   struct curltime retrystart;
   char *url;
-  unsigned int urlnum; /* the index of the given URL */
+  curl_off_t urlnum; /* the index of the given URL */
   char *outfile;
   int infd;
   struct ProgressData progressbar;

--- a/src/tool_sdecls.h
+++ b/src/tool_sdecls.h
@@ -88,7 +88,7 @@ struct getout {
   char          *url;       /* the URL we deal with */
   char          *outfile;   /* where to store the output */
   char          *infile;    /* file to upload, if GETOUT_UPLOAD is set */
-  int            num;       /* which URL number in an invocation */
+  curl_off_t    num;        /* which URL number in an invocation */
 
   BIT(outset);    /* when outfile is set */
   BIT(urlset);    /* when URL is set */

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -148,7 +148,7 @@ static const struct writeoutvar variables[] = {
   {"urle.scheme", VAR_INPUT_URLESCHEME, CURLINFO_NONE, writeString},
   {"urle.user", VAR_INPUT_URLEUSER, CURLINFO_NONE, writeString},
   {"urle.zoneid", VAR_INPUT_URLEZONEID, CURLINFO_NONE, writeString},
-  {"urlnum", VAR_URLNUM, CURLINFO_NONE, writeLong},
+  {"urlnum", VAR_URLNUM, CURLINFO_NONE, writeOffset},
   {"xfer_id", VAR_EASY_ID, CURLINFO_XFER_ID, writeOffset}
 };
 
@@ -462,12 +462,6 @@ static int writeLong(FILE *stream, const struct writeoutvar *wovar,
       longinfo = (long)per_result;
       valid = true;
       break;
-    case VAR_URLNUM:
-      if(per->urlnum <= INT_MAX) {
-        longinfo = (long)per->urlnum;
-        valid = true;
-      }
-      break;
     default:
       DEBUGASSERT(0);
       break;
@@ -508,7 +502,16 @@ static int writeOffset(FILE *stream, const struct writeoutvar *wovar,
       valid = true;
   }
   else {
-    DEBUGASSERT(0);
+    switch(wovar->id) {
+    case VAR_URLNUM:
+      if(per->urlnum <= INT_MAX) {
+        offinfo = per->urlnum;
+        valid = true;
+      }
+      break;
+    default:
+      DEBUGASSERT(0);
+    }
   }
 
   if(valid) {


### PR DESCRIPTION
Otherwise we could misbehave already at 2 billion URLs and we can't have that. A few of the counters are already correctly using the right type.