### PR TITLE
rand: drop fallback for `BCRYPT_USE_SYSTEM_PREFERRED_RNG` macro

### DIFF
--- a/lib/rand.c
+++ b/lib/rand.c
@@ -55,9 +55,6 @@
 #  ifdef _MSC_VER
 #    pragma comment(lib, "bcrypt.lib")
 #  endif
-#  ifndef BCRYPT_USE_SYSTEM_PREFERRED_RNG
-#  define BCRYPT_USE_SYSTEM_PREFERRED_RNG 0x00000002
-#  endif
 #  ifndef STATUS_SUCCESS
 #  define STATUS_SUCCESS ((NTSTATUS)0x00000000L)
 #  endif


### PR DESCRIPTION
It's supported by mingw-w64 v3+ and MS SDK 7.1A. Only used in Vista+
builds.

Also by OpenWatcom 2:
https://github.com/open-watcom/open-watcom-v2/blob/ce6c37eb29f3fda95f9c4e8e37dee866b8c4e496/bld/w32api/include/bcrypt.mh

Follow-up to a28f5f68b965119d9dd1ab6c2a2ccc66c6ed5d1f #18010