### PR TITLE
tests: fix prechecks to call the bundle libtest tool

### DIFF
--- a/tests/data/test1517
+++ b/tests/data/test1517
@@ -46,7 +46,7 @@ lib%TESTNUMBER
 # precheck is a command line to run before the test, to see if we can execute
 # the test or not
 <precheck>
-./libtest/lib%TESTNUMBER check
+./libtest/libtests %TESTNUMBER check
 </precheck>
 
 <name>

--- a/tests/data/test1960
+++ b/tests/data/test1960
@@ -22,7 +22,7 @@ Content-Length: 0
 # Client-side
 <client>
 <precheck>
-./libtest/lib%TESTNUMBER check
+./libtest/libtests %TESTNUMBER check
 </precheck>
 <server>
 http

--- a/tests/data/test518
+++ b/tests/data/test518
@@ -40,7 +40,7 @@ lib%TESTNUMBER
 # precheck is a command line to run before the test, to see if we can execute
 # the test or not
 <precheck>
-./libtest/lib%TESTNUMBER check
+./libtest/libtests %TESTNUMBER check
 </precheck>
 
 <name>

--- a/tests/data/test537
+++ b/tests/data/test537
@@ -40,7 +40,7 @@ lib%TESTNUMBER
 # precheck is a command line to run before the test, to see if we can execute
 # the test or not
 <precheck>
-./libtest/lib%TESTNUMBER check
+./libtest/libtests %TESTNUMBER check
 </precheck>
 
 <name>

--- a/tests/data/test678
+++ b/tests/data/test678
@@ -41,7 +41,7 @@ https://localhost:%HTTPSPORT/%TESTNUMBER %CERTDIR/certs/test-ca.crt
 </command>
 # Ensure that we're running on localhost because we're checking the host name
 <precheck>
-./libtest/lib%TESTNUMBER check
+./libtest/libtests %TESTNUMBER check
 </precheck>
 </client>
 


### PR DESCRIPTION
Some tests make a hard-coded call to the libtest binary in the pre-check
step. With bundle builds the binary changed name and calling convention.
Before this patch these tests failed the pre-check and did not run.

Fixing, e.g.:
```
test 1517 SKIPPED: precheck command error
```
https://github.com/curl/curl/actions/runs/16611990422/job/46996698437?pr=18039#step:13:4832

Follow-up to 2c27a67daa1b76859c18d63e4e1f528db05b5e13 #17590
Folllow-up to 71cf0d1fca9e1f53524e1545ef0c08d174458d80 #14772
