### PR TITLE
tests: fix perl warnings in http2-server, http3-server

### DIFF
--- a/tests/http2-server.pl
+++ b/tests/http2-server.pl
@@ -33,6 +33,7 @@ use Cwd 'abs_path';
 use File::Basename;
 use File::Spec;
 
+my $verbose = 0;     # set to 1 for debugging
 my $logdir = "log";
 my $pidfile = "$logdir/nghttpx.pid";
 my $logfile = "$logdir/http2.log";
@@ -106,8 +107,8 @@ while(@ARGV) {
     shift @ARGV;
 }
 
-$certfile = abs_path("certs/$cert.pem");
-$keyfile = abs_path("certs/$cert.key");
+my $certfile = abs_path("certs/$cert.pem");
+my $keyfile = abs_path("certs/$cert.key");
 
 my $cmdline="$nghttpx --backend=$connect ".
     "--backend-keep-alive-timeout=500ms ".

--- a/tests/http3-server.pl
+++ b/tests/http3-server.pl
@@ -34,6 +34,7 @@ use Cwd 'abs_path';
 use File::Basename;
 use File::Spec;
 
+my $verbose = 0;     # set to 1 for debugging
 my $logdir = "log";
 my $pidfile = "$logdir/nghttpx.pid";
 my $logfile = "$logdir/http3.log";
@@ -106,8 +107,8 @@ while(@ARGV) {
     shift @ARGV;
 }
 
-$certfile = abs_path("certs/$cert.pem");
-$keyfile = abs_path("certs/$cert.key");
+my $certfile = abs_path("certs/$cert.pem");
+my $keyfile = abs_path("certs/$cert.key");
 
 my $cmdline="$nghttpx --http2-proxy --backend=$connect ".
     "--backend-keep-alive-timeout=500ms ".


### PR DESCRIPTION
AM libressl heimdal:
```
Global symbol "$verbose" requires explicit package name (did you forget to declare "my $verbose"?) at ../../tests/http2-server.pl line 52.
Global symbol "$certfile" requires explicit package name (did you forget to declare "my $certfile"?) at ../../tests/http2-server.pl line 109.
Global symbol "$keyfile" requires explicit package name (did you forget to declare "my $keyfile"?) at ../../tests/http2-server.pl line 110.
Execution of ../../tests/http2-server.pl aborted due to compilation errors.
[...]
```
https://github.com/curl/curl/actions/runs/16622030370/job/47028537336?pr=18099#step:39:3148