### PR TITLE
test1517: enable for Cygwin

### DIFF
--- a/tests/libtest/lib1517.c
+++ b/tests/libtest/lib1517.c
@@ -62,7 +62,7 @@ static CURLcode test_lib1517(const char *URL)
   struct t1517_WriteThis pooh;
 
   if(!strcmp(URL, "check")) {
-#if (defined(_WIN32) || defined(__CYGWIN__))
+#ifdef _WIN32
     curl_mprintf("Windows TCP does not deliver response data but reports "
                  "CONNABORTED\n");
     return TEST_ERR_FAILURE; /* skip since it fails on Windows without


### PR DESCRIPTION
Follow-up to b4b6e4f1fabf0a797c5f4f16f13d8b0f455e7207 #10409

---

The original commit suggests it means to disable for Windows,
but also disabled for Cygwin. Cygwin may behave differently
here than raw winsock.

https://cygwin.com/cygwin-ug-net/highlights.html#ov-hi-sockets

This comment suggests that Cygwin is also affected:
https://github.com/curl/curl/pull/668#issuecomment-186589469
