### PR TITLE
GHA/distcheck: add more tarball builds

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -130,7 +130,7 @@ jobs:
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
-          cmake -B build -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF
+          cmake -B build -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build build
           cmake --install build
 

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -112,6 +112,8 @@ jobs:
           make
           make test-ci
           make install
+          curl-install/curl --disable --version
+          curl-install/curl --manual | wc -l
           popd
           scripts/checksrc-all.pl
 
@@ -138,7 +140,8 @@ jobs:
           ../configure --prefix="$PWD"/curl-install --without-ssl --without-libpsl
           make
           make install
-          find curl-install
+          curl-install/curl --disable --version
+          curl-install/curl --manual | wc -l
           popd
 
   verify-out-of-tree-cmake:
@@ -159,9 +162,8 @@ jobs:
           cmake -B build -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build build
           cmake --install build
-          find curl-install
-          build/src/curl --disable --version
-          build/src/curl --manual | wc -l
+          curl-install/curl --disable --version
+          curl-install/curl --manual | wc -l
 
   verify-in-tree-cmake:
     name: 'CM in-tree'
@@ -181,9 +183,8 @@ jobs:
           cmake . -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build .
           cmake --install .
-          find curl-install
-          src/curl --disable --version
-          src/curl --manual | wc -l
+          curl-install/bin/curl --disable --version
+          curl-install/bin/curl --manual | wc -l
 
   missing-files:
     name: 'missing files'

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -112,8 +112,8 @@ jobs:
           make
           make test-ci
           make install
-          curl-install/curl --disable --version
-          curl-install/curl --manual | wc -l
+          curl-install/bin/curl --disable --version
+          curl-install/bin/curl --manual | wc -l
           popd
           scripts/checksrc-all.pl
 
@@ -140,8 +140,8 @@ jobs:
           ../configure --prefix="$PWD"/curl-install --without-ssl --without-libpsl
           make
           make install
-          curl-install/curl --disable --version
-          curl-install/curl --manual | wc -l
+          curl-install/bin/curl --disable --version
+          curl-install/bin/curl --manual | wc -l
           popd
 
   verify-out-of-tree-cmake:
@@ -162,8 +162,8 @@ jobs:
           cmake -B build -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build build
           cmake --install build
-          curl-install/curl --disable --version
-          curl-install/curl --manual | wc -l
+          curl-install/bin/curl --disable --version
+          curl-install/bin/curl --manual | wc -l
 
   verify-in-tree-cmake:
     name: 'CM in-tree'

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -138,6 +138,7 @@ jobs:
           ../configure --prefix="$PWD"/curl-install --without-ssl --without-libpsl
           make
           make install
+          find curl-install
           popd
 
   verify-out-of-tree-cmake:
@@ -158,6 +159,9 @@ jobs:
           cmake -B build -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build build
           cmake --install build
+          find curl-install
+          build/src/curl --disable --version
+          build/src/curl --manual | wc -l
 
   verify-in-tree-cmake:
     name: 'CM in-tree'
@@ -177,6 +181,9 @@ jobs:
           cmake . -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build .
           cmake --install .
+          find curl-install
+          src/curl --disable --version
+          src/curl --manual | wc -l
 
   missing-files:
     name: 'missing files'

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -209,7 +209,7 @@ jobs:
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
-          cmake . -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
+          cmake . -G Ninja -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build .
           cmake --install .
           export LD_LIBRARY_PATH="$PWD/curl-install/lib:$LD_LIBRARY_PATH"

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -115,6 +115,31 @@ jobs:
           popd
           scripts/checksrc-all.pl
 
+  verify-out-of-tree-autotools-noperl:
+    name: 'AM out-of-tree (!perl)'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: maketgz-and-verify-in-tree
+    steps:
+      - name: 'remove preinstalled perl'
+        run: sudo apt-get -o Dpkg::Use-Pty=0 purge perl
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: 'release-tgz'
+
+      - name: 'build & install'
+        run: |
+          echo "::stop-commands::$(uuidgen)"
+          tar xvf curl-99.98.97.tar.gz
+          pushd curl-99.98.97
+          mkdir build
+          pushd build
+          ../configure --prefix="$PWD"/curl-install --without-ssl --without-libpsl
+          make
+          make install
+          popd
+
   verify-out-of-tree-cmake:
     name: 'CM out-of-tree'
     runs-on: ubuntu-latest

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -127,10 +127,8 @@ jobs:
         with:
           name: 'release-tgz'
 
-      - name: 'remove preinstalled perl'
-        run: |
-          sudo apt-get -o Dpkg::Use-Pty=0 purge perl
-          sudo mv /usr/bin/perl /usr/bin/noperl
+      - name: 'disable preinstalled perl'
+        run: sudo mv "$(command -v perl)" "$(command -v perl)"-disabled
 
       - name: 'build & install'
         run: |
@@ -156,10 +154,8 @@ jobs:
         with:
           name: 'release-tgz'
 
-      - name: 'remove preinstalled perl'
-        run: |
-          sudo apt-get -o Dpkg::Use-Pty=0 purge perl
-          sudo mv /usr/bin/perl /usr/bin/noperl
+      - name: 'disable preinstalled perl'
+        run: sudo mv "$(command -v perl)" "$(command -v perl)"-disabled
 
       - name: 'build & install'
         run: |

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -163,6 +163,8 @@ jobs:
           pushd curl-99.98.97
           cmake -B build -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build build
+          build/src/curl --disable --version
+          build/src/curl --manual | wc -l
           cmake --install build
           curl-install/bin/curl --disable --version
           curl-install/bin/curl --manual | wc -l
@@ -184,6 +186,8 @@ jobs:
           pushd curl-99.98.97
           cmake . -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build .
+          src/curl --disable --version
+          src/curl --manual | wc -l
           cmake --install .
           curl-install/bin/curl --disable --version
           curl-install/bin/curl --manual | wc -l

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -176,7 +176,7 @@ jobs:
           pushd curl-99.98.97
           cmake . -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build .
-          cmake --install
+          cmake --install .
 
   missing-files:
     name: 'missing files'

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -58,7 +58,7 @@ jobs:
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
-          ./configure --prefix="$HOME"/temp --without-ssl --without-libpsl
+          ./configure --prefix="$HOME"/temp --enable-werror --without-ssl --without-libpsl
           make
           make test-ci
           make install
@@ -84,7 +84,7 @@ jobs:
           touch curl-99.98.97/docs/{cmdline-opts,libcurl}/Makefile.inc
           mkdir build
           pushd build
-          ../curl-99.98.97/configure --without-ssl --without-libpsl
+          ../curl-99.98.97/configure --enable-werror --without-ssl --without-libpsl
           make
           make test-ci
           popd
@@ -108,7 +108,7 @@ jobs:
           pushd curl-99.98.97
           mkdir build
           pushd build
-          ../configure --prefix="$PWD"/curl-install --without-ssl --enable-debug --without-libpsl
+          ../configure --prefix="$PWD"/curl-install --enable-werror --without-ssl --enable-debug --without-libpsl
           make
           make test-ci
           make install
@@ -139,7 +139,7 @@ jobs:
           pushd curl-99.98.97
           mkdir build
           pushd build
-          ../configure --prefix="$PWD"/curl-install --without-ssl --without-libpsl --disable-docs
+          ../configure --prefix="$PWD"/curl-install --enable-werror --without-ssl --without-libpsl --disable-docs
           make
           make install
           curl-install/bin/curl --disable --version
@@ -166,7 +166,7 @@ jobs:
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
-          ./configure --prefix="$PWD"/curl-install --without-ssl --without-libpsl --disable-docs
+          ./configure --prefix="$PWD"/curl-install --enable-werror --without-ssl --without-libpsl --disable-docs
           make
           make install
           curl-install/bin/curl --disable --version

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -174,8 +174,8 @@ jobs:
           echo "::stop-commands::$(uuidgen)"
           tar xvf curl-99.98.97.tar.gz
           pushd curl-99.98.97
-          cmake -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
-          cmake --build
+          cmake . -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
+          cmake --build .
           cmake --install
 
   missing-files:

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -123,12 +123,14 @@ jobs:
     timeout-minutes: 10
     needs: maketgz-and-verify-in-tree
     steps:
-      - name: 'remove preinstalled perl'
-        run: sudo apt-get -o Dpkg::Use-Pty=0 purge perl
-
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: 'release-tgz'
+
+      - name: 'remove preinstalled perl'
+        run: |
+          sudo apt-get -o Dpkg::Use-Pty=0 purge perl
+          sudo mv /usr/bin/perl /usr/bin/noperl
 
       - name: 'build & install'
         run: |

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -134,6 +134,25 @@ jobs:
           cmake --build build
           cmake --install build
 
+  verify-in-tree-cmake:
+    name: 'CM in-tree'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: maketgz-and-verify-in-tree
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: 'release-tgz'
+
+      - name: 'build & install'
+        run: |
+          echo "::stop-commands::$(uuidgen)"
+          tar xvf curl-99.98.97.tar.gz
+          pushd curl-99.98.97
+          cmake -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
+          cmake --build
+          cmake --install
+
   missing-files:
     name: 'missing files'
     runs-on: ubuntu-latest

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -173,7 +173,7 @@ jobs:
           curl-install/bin/curl --manual | wc -l
 
   verify-out-of-tree-cmake:
-    name: 'CM out-of-tree'
+    name: 'CM out-of-tree !perl'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: maketgz-and-verify-in-tree
@@ -195,7 +195,7 @@ jobs:
           curl-install/bin/curl --manual | wc -l
 
   verify-in-tree-cmake:
-    name: 'CM in-tree'
+    name: 'CM in-tree !perl'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: maketgz-and-verify-in-tree

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - name: 'remove preinstalled curl libcurl4{-doc}'
+        run: sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
-
-      - name: 'remove preinstalled curl libcurl4{-doc}'
-        run: sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
 
       - name: 'autoreconf'
         run: autoreconf -fi

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -146,6 +146,32 @@ jobs:
           curl-install/bin/curl --manual | wc -l
           popd
 
+  verify-in-tree-autotools-noperl:
+    name: 'AM in-tree (!perl)'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: maketgz-and-verify-in-tree
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: 'release-tgz'
+
+      - name: 'remove preinstalled perl'
+        run: |
+          sudo apt-get -o Dpkg::Use-Pty=0 purge perl
+          sudo mv /usr/bin/perl /usr/bin/noperl
+
+      - name: 'build & install'
+        run: |
+          echo "::stop-commands::$(uuidgen)"
+          tar xvf curl-99.98.97.tar.gz
+          pushd curl-99.98.97
+          ./configure --prefix="$PWD"/curl-install --without-ssl --without-libpsl --disable-docs
+          make
+          make install
+          curl-install/bin/curl --disable --version
+          curl-install/bin/curl --manual | wc -l
+
   verify-out-of-tree-cmake:
     name: 'CM out-of-tree'
     runs-on: ubuntu-latest

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -189,10 +189,7 @@ jobs:
           pushd curl-99.98.97
           cmake -B build -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build build
-          build/src/curl --disable --version
-          build/src/curl --manual | wc -l
           cmake --install build
-          echo "|$LD_LIBRARY_PATH|"
           export LD_LIBRARY_PATH="$PWD/curl-install/lib:$LD_LIBRARY_PATH"
           curl-install/bin/curl --disable --version
           curl-install/bin/curl --manual | wc -l
@@ -214,10 +211,7 @@ jobs:
           pushd curl-99.98.97
           cmake . -DCMAKE_INSTALL_PREFIX="$PWD"/curl-install -DCURL_WERROR=ON -DCURL_USE_LIBPSL=OFF -DPERL_EXECUTABLE=
           cmake --build .
-          src/curl --disable --version
-          src/curl --manual | wc -l
           cmake --install .
-          echo "|$LD_LIBRARY_PATH|"
           export LD_LIBRARY_PATH="$PWD/curl-install/lib:$LD_LIBRARY_PATH"
           curl-install/bin/curl --disable --version
           curl-install/bin/curl --manual | wc -l

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -117,8 +117,8 @@ jobs:
           popd
           scripts/checksrc-all.pl
 
-  verify-out-of-tree-autotools-noperl:
-    name: 'AM out-of-tree (!perl)'
+  verify-out-of-tree-autotools:
+    name: 'AM out-of-tree !perl'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: maketgz-and-verify-in-tree
@@ -146,8 +146,8 @@ jobs:
           curl-install/bin/curl --manual | wc -l
           popd
 
-  verify-in-tree-autotools-noperl:
-    name: 'AM in-tree (!perl)'
+  verify-in-tree-autotools:
+    name: 'AM in-tree !perl'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: maketgz-and-verify-in-tree

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -139,7 +139,7 @@ jobs:
           pushd curl-99.98.97
           mkdir build
           pushd build
-          ../configure --prefix="$PWD"/curl-install --without-ssl --without-libpsl
+          ../configure --prefix="$PWD"/curl-install --without-ssl --without-libpsl --disable-docs
           make
           make install
           curl-install/bin/curl --disable --version

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -28,12 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: 'remove preinstalled curl libcurl4{-doc}'
-        run: sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
+
+      - name: 'remove preinstalled curl libcurl4{-doc}'
+        run: sudo apt-get -o Dpkg::Use-Pty=0 purge curl libcurl4 libcurl4-doc
 
       - name: 'autoreconf'
         run: autoreconf -fi

--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -192,6 +192,8 @@ jobs:
           build/src/curl --disable --version
           build/src/curl --manual | wc -l
           cmake --install build
+          echo "|$LD_LIBRARY_PATH|"
+          export LD_LIBRARY_PATH="$PWD/curl-install/lib:$LD_LIBRARY_PATH"
           curl-install/bin/curl --disable --version
           curl-install/bin/curl --manual | wc -l
 
@@ -215,6 +217,8 @@ jobs:
           src/curl --disable --version
           src/curl --manual | wc -l
           cmake --install .
+          echo "|$LD_LIBRARY_PATH|"
+          export LD_LIBRARY_PATH="$PWD/curl-install/lib:$LD_LIBRARY_PATH"
           curl-install/bin/curl --disable --version
           curl-install/bin/curl --manual | wc -l
 


### PR DESCRIPTION
- add AM out-of-tree no perl job.
- add AM in-tree no perl job.
- make CM out-of-tree job use no perl.
- add CM in-tree no perl job.
- run `curl -V` after builds.
- show the number of `--manual` lines.
- set `--enable-werror` in autotools jobs.

Ref: https://github.com/curl/curl/issues/18088#issuecomment-3135112176

---

- [ ] FIXME: pre-built hugehelp is not picked up and included in the curl tool. (without Perl)
