### PR TITLE
libtests: update format strings to avoid casts, drop some macros

### DIFF
--- a/tests/libtest/cli_h2_pausing.c
+++ b/tests/libtest/cli_h2_pausing.c
@@ -242,8 +242,9 @@ static CURLcode test_cli_h2_pausing(const char *URL)
         for(i = 0; i < CURL_ARRAYSIZE(handles); i++) {
           if(msg->easy_handle == handles[i].h) {
             if(handles[i].paused != 1 || !handles[i].resumed) {
-              curl_mfprintf(stderr, "ERROR: [%zu] done, pauses=%d, resumed=%d, "
-                            "result %d - wtf?\n", i, handles[i].paused,
+              curl_mfprintf(stderr, "ERROR: [%zu] done, paused=%d, "
+                            "resumed=%d, result %d - wtf?\n", i,
+                            handles[i].paused,
                             handles[i].resumed, msg->data.result);
               rc = (CURLcode)1;
               goto out;

--- a/tests/libtest/cli_h2_pausing.c
+++ b/tests/libtest/cli_h2_pausing.c
@@ -58,25 +58,25 @@ static size_t cb(char *data, size_t size, size_t nmemb, void *clientp)
   (void)data;
   if(curl_easy_getinfo(handle->h, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                        &totalsize) == CURLE_OK)
-    curl_mfprintf(stderr, "INFO: [%d] write, "
+    curl_mfprintf(stderr, "INFO: [%zu] write, "
                   "Content-Length %" CURL_FORMAT_CURL_OFF_T "\n",
-                  (int)handle->idx, totalsize);
+                  handle->idx, totalsize);
 
   if(!handle->resumed) {
     ++handle->paused;
-    curl_mfprintf(stderr, "INFO: [%d] write, PAUSING %d time on %lu bytes\n",
-                  (int)handle->idx, handle->paused, (long)realsize);
+    curl_mfprintf(stderr, "INFO: [%zu] write, PAUSING %d time on %zu bytes\n",
+                  handle->idx, handle->paused, realsize);
     assert(handle->paused == 1);
     return CURL_WRITEFUNC_PAUSE;
   }
   if(handle->fail_write) {
     ++handle->errored;
-    curl_mfprintf(stderr, "INFO: [%d] FAIL write of %lu bytes, %d time\n",
-                  (int)handle->idx, (long)realsize, handle->errored);
+    curl_mfprintf(stderr, "INFO: [%zu] FAIL write of %zu bytes, %d time\n",
+                  handle->idx, realsize, handle->errored);
     return CURL_WRITEFUNC_ERROR;
   }
-  curl_mfprintf(stderr, "INFO: [%d] write, accepting %lu bytes\n",
-                (int)handle->idx, (long)realsize);
+  curl_mfprintf(stderr, "INFO: [%zu] write, accepting %zu bytes\n",
+                handle->idx, realsize);
   return realsize;
 }
 
@@ -207,21 +207,21 @@ static CURLcode test_cli_h2_pausing(const char *URL)
       curl_mfprintf(stderr, "INFO: no more handles running\n");
       for(i = 0; i < CURL_ARRAYSIZE(handles); i++) {
         if(!handles[i].paused) {
-          curl_mfprintf(stderr, "ERROR: [%d] NOT PAUSED\n", (int)i);
+          curl_mfprintf(stderr, "ERROR: [%zu] NOT PAUSED\n", i);
           as_expected = 0;
         }
         else if(handles[i].paused != 1) {
-          curl_mfprintf(stderr, "ERROR: [%d] PAUSED %d times!\n",
-                        (int)i, handles[i].paused);
+          curl_mfprintf(stderr, "ERROR: [%zu] PAUSED %d times!\n",
+                        i, handles[i].paused);
           as_expected = 0;
         }
         else if(!handles[i].resumed) {
-          curl_mfprintf(stderr, "ERROR: [%d] NOT resumed!\n", (int)i);
+          curl_mfprintf(stderr, "ERROR: [%zu] NOT resumed!\n", i);
           as_expected = 0;
         }
         else if(handles[i].errored != 1) {
-          curl_mfprintf(stderr, "ERROR: [%d] NOT errored once, %d instead!\n",
-                        (int)i, handles[i].errored);
+          curl_mfprintf(stderr, "ERROR: [%zu] NOT errored once, %d instead!\n",
+                        i, handles[i].errored);
           as_expected = 0;
         }
       }
@@ -242,8 +242,8 @@ static CURLcode test_cli_h2_pausing(const char *URL)
         for(i = 0; i < CURL_ARRAYSIZE(handles); i++) {
           if(msg->easy_handle == handles[i].h) {
             if(handles[i].paused != 1 || !handles[i].resumed) {
-              curl_mfprintf(stderr, "ERROR: [%d] done, pauses=%d, resumed=%d, "
-                            "result %d - wtf?\n", (int)i, handles[i].paused,
+              curl_mfprintf(stderr, "ERROR: [%zu] done, pauses=%d, resumed=%d, "
+                            "result %d - wtf?\n", i, handles[i].paused,
                             handles[i].resumed, msg->data.result);
               rc = (CURLcode)1;
               goto out;
@@ -270,7 +270,7 @@ static CURLcode test_cli_h2_pausing(const char *URL)
     if(resume_round > 0 && rounds == resume_round) {
       /* time to resume */
       for(i = 0; i < CURL_ARRAYSIZE(handles); i++) {
-        curl_mfprintf(stderr, "INFO: [%d] resumed\n", (int)i);
+        curl_mfprintf(stderr, "INFO: [%zu] resumed\n", i);
         handles[i].resumed = 1;
         curl_easy_pause(handles[i].h, CURLPAUSE_CONT);
       }

--- a/tests/libtest/cli_h2_serverpush.c
+++ b/tests/libtest/cli_h2_serverpush.c
@@ -114,8 +114,8 @@ static CURLcode test_cli_h2_serverpush(const char *URL)
   int transfers = 1; /* we start with one */
   struct CURLMsg *m;
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 0;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = FALSE;
 
   if(!URL) {
     curl_mfprintf(stderr, "need URL as argument\n");

--- a/tests/libtest/cli_h2_serverpush.c
+++ b/tests/libtest/cli_h2_serverpush.c
@@ -84,11 +84,11 @@ static int server_push_callback(CURL *parent,
   curl_easy_setopt(easy, CURLOPT_WRITEDATA, out_push);
 
   curl_mfprintf(stderr, "**** push callback approves stream %u, "
-                "got %lu headers!\n", count, (unsigned long)num_headers);
+                "got %zu headers!\n", count, num_headers);
 
   for(i = 0; i < num_headers; i++) {
     headp = curl_pushheader_bynum(headers, i);
-    curl_mfprintf(stderr, "**** header %lu: %s\n", (unsigned long)i, headp);
+    curl_mfprintf(stderr, "**** header %zu: %s\n", i, headp);
   }
 
   headp = curl_pushheader_byname(headers, ":path");

--- a/tests/libtest/cli_hx_download.c
+++ b/tests/libtest/cli_hx_download.c
@@ -65,8 +65,10 @@ static size_t my_write_d_cb(char *buf, size_t nitems, size_t buflen,
   size_t blen = (nitems * buflen);
   size_t nwritten;
 
-  curl_mfprintf(stderr, "[t-%zu] RECV %zu bytes, total=%ld, pause_at=%ld\n",
-                t->idx, blen, (long)t->recv_size, (long)t->pause_at);
+  curl_mfprintf(stderr, "[t-%zu] RECV %zu bytes, "
+                "total=%" CURL_FORMAT_CURL_OFF_T ", "
+                "pause_at=%" CURL_FORMAT_CURL_OFF_T "\n",
+                t->idx, blen, t->recv_size, t->pause_at);
   if(!t->out) {
     curl_msnprintf(t->filename, sizeof(t->filename)-1, "download_%zu.data",
                    t->idx);
@@ -90,8 +92,8 @@ static size_t my_write_d_cb(char *buf, size_t nitems, size_t buflen,
   }
   t->recv_size += (curl_off_t)nwritten;
   if(t->fail_at > 0 && t->recv_size >= t->fail_at) {
-    curl_mfprintf(stderr, "[t-%zu] FAIL by write callback at %ld bytes\n",
-                  t->idx, (long)t->recv_size);
+    curl_mfprintf(stderr, "[t-%zu] FAIL by write callback at "
+                  "%" CURL_FORMAT_CURL_OFF_T " bytes\n", t->idx, t->recv_size);
     return CURL_WRITEFUNC_ERROR;
   }
 
@@ -107,8 +109,8 @@ static int my_progress_d_cb(void *userdata,
   (void)ulnow;
   (void)dltotal;
   if(t->abort_at > 0 && dlnow >= t->abort_at) {
-    curl_mfprintf(stderr, "[t-%zu] ABORT by progress_cb at %ld bytes\n",
-                  t->idx, (long)dlnow);
+    curl_mfprintf(stderr, "[t-%zu] ABORT by progress_cb at "
+                  "%" CURL_FORMAT_CURL_OFF_T " bytes\n", t->idx, dlnow);
     return 1;
   }
   return 0;
@@ -363,8 +365,8 @@ static CURLcode test_cli_hx_download(const char *URL)
           if(use_earlydata) {
             curl_off_t sent;
             curl_easy_getinfo(e, CURLINFO_EARLYDATA_SENT_T, &sent);
-            curl_mfprintf(stderr, "[t-%zu] EarlyData: %ld\n", t->idx,
-                          (long)sent);
+            curl_mfprintf(stderr, "[t-%zu] EarlyData: "
+                          "%" CURL_FORMAT_CURL_OFF_T "\n", t->idx, sent);
           }
         }
         else {

--- a/tests/libtest/cli_hx_upload.c
+++ b/tests/libtest/cli_hx_upload.c
@@ -67,8 +67,10 @@ static size_t my_write_u_cb(char *buf, size_t nitems, size_t buflen,
   size_t blen = (nitems * buflen);
   size_t nwritten;
 
-  curl_mfprintf(stderr, "[t-%zu] RECV %zu bytes, total=%ld, pause_at=%ld\n",
-                t->idx, blen, (long)t->recv_size, (long)t->pause_at);
+  curl_mfprintf(stderr, "[t-%zu] RECV %zu bytes, "
+                "total=%" CURL_FORMAT_CURL_OFF_T ", "
+                "pause_at=%" CURL_FORMAT_CURL_OFF_T "\n",
+                t->idx, blen, t->recv_size, t->pause_at);
   if(!t->out) {
     curl_msnprintf(t->filename, sizeof(t->filename)-1, "download_%zu.data",
                    t->idx);
@@ -100,8 +102,10 @@ static size_t my_read_cb(char *buf, size_t nitems, size_t buflen,
   else
     nread = blen;
 
-  curl_mfprintf(stderr, "[t-%zu] SEND %zu bytes, total=%ld, pause_at=%ld\n",
-                t->idx, nread, (long)t->send_total, (long)t->pause_at);
+  curl_mfprintf(stderr, "[t-%zu] SEND %zu bytes, "
+                "total=%" CURL_FORMAT_CURL_OFF_T ", "
+                "pause_at=%" CURL_FORMAT_CURL_OFF_T "\n",
+                t->idx, nread, t->send_total, t->pause_at);
 
   if(!t->resumed &&
      t->send_size < t->pause_at &&
@@ -114,8 +118,8 @@ static size_t my_read_cb(char *buf, size_t nitems, size_t buflen,
   memset(buf, 'x', nread);
   t->send_size += (curl_off_t)nread;
   if(t->fail_at > 0 && t->send_size >= t->fail_at) {
-    curl_mfprintf(stderr, "[t-%zu] ABORT by read callback at %ld bytes\n",
-                  t->idx, (long)t->send_size);
+    curl_mfprintf(stderr, "[t-%zu] ABORT by read callback at "
+                  "%" CURL_FORMAT_CURL_OFF_T " bytes\n", t->idx, t->send_size);
     return CURL_READFUNC_ABORT;
   }
   return (size_t)nread;
@@ -130,8 +134,8 @@ static int my_progress_u_cb(void *userdata,
   (void)dlnow;
   (void)dltotal;
   if(t->abort_at > 0 && ulnow >= t->abort_at) {
-    curl_mfprintf(stderr, "[t-%zu] ABORT by progress_cb at %ld bytes sent\n",
-                  t->idx, (long)ulnow);
+    curl_mfprintf(stderr, "[t-%zu] ABORT by progress_cb at "
+                  "%" CURL_FORMAT_CURL_OFF_T " bytes sent\n", t->idx, ulnow);
     return 1;
   }
   return 0;
@@ -419,8 +423,8 @@ static CURLcode test_cli_hx_upload(const char *URL)
             if(use_earlydata) {
               curl_off_t sent;
               curl_easy_getinfo(e, CURLINFO_EARLYDATA_SENT_T, &sent);
-              curl_mfprintf(stderr, "[t-%zu] EarlyData: %ld\n", t->idx,
-                            (long)sent);
+              curl_mfprintf(stderr, "[t-%zu] EarlyData: "
+                            "%" CURL_FORMAT_CURL_OFF_T "\n", t->idx, sent);
             }
           }
           else {

--- a/tests/libtest/cli_hx_upload.c
+++ b/tests/libtest/cli_hx_upload.c
@@ -418,7 +418,8 @@ static CURLcode test_cli_hx_upload(const char *URL)
             long res_status;
             curl_easy_getinfo(e, CURLINFO_RESPONSE_CODE, &res_status);
             t->done = 1;
-            curl_mfprintf(stderr, "[t-%zu] FINISHED, result=%d, response=%ld\n",
+            curl_mfprintf(stderr, "[t-%zu] FINISHED, "
+                          "result=%d, response=%ld\n",
                           t->idx, m->data.result, res_status);
             if(use_earlydata) {
               curl_off_t sent;

--- a/tests/libtest/cli_ws_data.c
+++ b/tests/libtest/cli_ws_data.c
@@ -36,19 +36,19 @@ static CURLcode check_recv(const struct curl_ws_frame *frame,
 
   if(frame->flags & CURLWS_CLOSE) {
     curl_mfprintf(stderr, "recv_data: unexpected CLOSE frame from server, "
-                  "got %ld bytes, offset=%ld, rflags %x\n",
-                  (long)nread, (long)r_offset, frame->flags);
+                  "got %zu bytes, offset=%zu, rflags %x\n",
+                  nread, r_offset, frame->flags);
     return CURLE_RECV_ERROR;
   }
   if(!r_offset && !(frame->flags & CURLWS_BINARY)) {
-    curl_mfprintf(stderr, "recv_data: wrong frame, got %ld bytes, offset=%ld, "
+    curl_mfprintf(stderr, "recv_data: wrong frame, got %zu bytes, offset=%zu, "
                   "rflags %x\n",
-                  (long)nread, (long)r_offset, frame->flags);
+                  nread, r_offset, frame->flags);
     return CURLE_RECV_ERROR;
   }
   if(frame->offset != (curl_off_t)r_offset) {
-    curl_mfprintf(stderr, "recv_data: frame offset, expected %ld, got %ld\n",
-                  (long)r_offset, (long)frame->offset);
+    curl_mfprintf(stderr, "recv_data: frame offset, expected %zu, got %ld\n",
+                  r_offset, (long)frame->offset);
     return CURLE_RECV_ERROR;
   }
   if(frame->bytesleft != (curl_off_t)(exp_len - r_offset - nread)) {
@@ -58,8 +58,8 @@ static CURLcode check_recv(const struct curl_ws_frame *frame,
     return CURLE_RECV_ERROR;
   }
   if(r_offset + nread > exp_len) {
-    curl_mfprintf(stderr, "recv_data: data length, expected %ld, now at %ld\n",
-                  (long)exp_len, (long)(r_offset + nread));
+    curl_mfprintf(stderr, "recv_data: data length, expected %zu, now at %zu\n",
+                  exp_len, r_offset + nread);
     return CURLE_RECV_ERROR;
   }
   return CURLE_OK;
@@ -97,9 +97,8 @@ static CURLcode data_echo(CURL *curl, size_t count,
         r = curl_ws_send(curl, sbuf, slen, &nwritten, 0, CURLWS_BINARY);
         sblock = (r == CURLE_AGAIN);
         if(!r || (r == CURLE_AGAIN)) {
-          curl_mfprintf(stderr, "curl_ws_send(len=%ld) -> %d, %ld (%ld/%ld)\n",
-                        (long)slen, r, (long)nwritten,
-                        (long)(len - slen), (long)len);
+          curl_mfprintf(stderr, "curl_ws_send(len=%zu) -> %d, %zu (%ld/%zu)\n",
+                        slen, r, nwritten, (long)(len - slen), len);
           sbuf += nwritten;
           slen -= nwritten;
         }
@@ -118,10 +117,8 @@ static CURLcode data_echo(CURL *curl, size_t count,
                          &nread, &frame);
         if(!r || (r == CURLE_AGAIN)) {
           rblock = (r == CURLE_AGAIN);
-          curl_mfprintf(stderr, "curl_ws_recv(len=%ld) -> %d, %ld (%ld/%ld) "
-                        "\n",
-                        (long)rlen, r, (long)nread, (long)(len - rlen),
-                        (long)len);
+          curl_mfprintf(stderr, "curl_ws_recv(len=%zu) -> %d, %zu (%ld/%zu) "
+                        "\n", rlen, r, nread, (long)(len - rlen), len);
           if(!r) {
             r = check_recv(frame, len - rlen, nread, len);
             if(r)
@@ -216,8 +213,8 @@ static CURLcode test_cli_ws_data(const char *URL)
     plen_max = plen_min;
 
   if(plen_max < plen_min) {
-    curl_mfprintf(stderr, "maxlen must be >= minlen, got %ld-%ld\n",
-                  (long)plen_min, (long)plen_max);
+    curl_mfprintf(stderr, "maxlen must be >= minlen, got %zu-%zu\n",
+                  plen_min, plen_max);
     res = CURLE_BAD_FUNCTION_ARGUMENT;
     goto cleanup;
   }
@@ -240,7 +237,7 @@ static CURLcode test_cli_ws_data(const char *URL)
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
     res = curl_easy_perform(curl);
-    curl_mfprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
+    curl_mfprintf(stderr, "curl_easy_perform() returned %u\n", res);
     if(res == CURLE_OK)
       res = data_echo(curl, count, plen_min, plen_max);
 

--- a/tests/libtest/cli_ws_data.c
+++ b/tests/libtest/cli_ws_data.c
@@ -148,9 +148,9 @@ static CURLcode data_echo(CURL *curl, size_t count,
     if(memcmp(send_buf, recv_buf, len)) {
       curl_mfprintf(stderr, "recv_data: data differs\n");
       debug_dump("", "expected:", stderr,
-                 (const unsigned char *)send_buf, len, 0);
+                 (const unsigned char *)send_buf, len, FALSE);
       debug_dump("", "received:", stderr,
-                 (const unsigned char *)recv_buf, len, 0);
+                 (const unsigned char *)recv_buf, len, FALSE);
       r = CURLE_RECV_ERROR;
       goto out;
     }

--- a/tests/libtest/cli_ws_data.c
+++ b/tests/libtest/cli_ws_data.c
@@ -54,8 +54,9 @@ static CURLcode check_recv(const struct curl_ws_frame *frame,
   }
   if(frame->bytesleft != (curl_off_t)(exp_len - r_offset - nread)) {
     curl_mfprintf(stderr, "recv_data: frame bytesleft, "
-                  "expected %ld, got %" CURL_FORMAT_CURL_OFF_T "\n",
-                  (long)(exp_len - r_offset - nread), frame->bytesleft);
+                  "expected %" CURL_FORMAT_CURL_OFF_T ", "
+                  "got %" CURL_FORMAT_CURL_OFF_T "\n",
+                  (curl_off_t)(exp_len - r_offset - nread), frame->bytesleft);
     return CURLE_RECV_ERROR;
   }
   if(r_offset + nread > exp_len) {
@@ -98,8 +99,9 @@ static CURLcode data_echo(CURL *curl, size_t count,
         r = curl_ws_send(curl, sbuf, slen, &nwritten, 0, CURLWS_BINARY);
         sblock = (r == CURLE_AGAIN);
         if(!r || (r == CURLE_AGAIN)) {
-          curl_mfprintf(stderr, "curl_ws_send(len=%zu) -> %d, %zu (%ld/%zu)\n",
-                        slen, r, nwritten, (long)(len - slen), len);
+          curl_mfprintf(stderr, "curl_ws_send(len=%zu) -> %d, "
+                        "%zu (%" CURL_FORMAT_CURL_OFF_T "/%zu)\n",
+                        slen, r, nwritten, (curl_off_t)(len - slen), len);
           sbuf += nwritten;
           slen -= nwritten;
         }

--- a/tests/libtest/cli_ws_data.c
+++ b/tests/libtest/cli_ws_data.c
@@ -47,14 +47,15 @@ static CURLcode check_recv(const struct curl_ws_frame *frame,
     return CURLE_RECV_ERROR;
   }
   if(frame->offset != (curl_off_t)r_offset) {
-    curl_mfprintf(stderr, "recv_data: frame offset, expected %zu, got %ld\n",
-                  r_offset, (long)frame->offset);
+    curl_mfprintf(stderr, "recv_data: frame offset, expected %zu, "
+                  "got %" CURL_FORMAT_CURL_OFF_T "\n",
+                  r_offset, frame->offset);
     return CURLE_RECV_ERROR;
   }
   if(frame->bytesleft != (curl_off_t)(exp_len - r_offset - nread)) {
     curl_mfprintf(stderr, "recv_data: frame bytesleft, "
-                  "expected %ld, got %ld\n",
-                  (long)(exp_len - r_offset - nread), (long)frame->bytesleft);
+                  "expected %ld, got %" CURL_FORMAT_CURL_OFF_T "\n",
+                  (long)(exp_len - r_offset - nread), frame->bytesleft);
     return CURLE_RECV_ERROR;
   }
   if(r_offset + nread > exp_len) {

--- a/tests/libtest/cli_ws_pingpong.c
+++ b/tests/libtest/cli_ws_pingpong.c
@@ -76,7 +76,7 @@ static CURLcode test_cli_ws_pingpong(const char *URL)
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
     curl_easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L); /* websocket style */
     res = curl_easy_perform(curl);
-    curl_mfprintf(stderr, "curl_easy_perform() returned %u\n", (int)res);
+    curl_mfprintf(stderr, "curl_easy_perform() returned %u\n", res);
     if(res == CURLE_OK)
       res = pingpong(curl, payload);
 

--- a/tests/libtest/first.h
+++ b/tests/libtest/first.h
@@ -193,7 +193,7 @@ void ws_close(CURL *curl);
   if((ec = curl_easy_setopt((A), (B), (C))) != CURLE_OK) {    \
     curl_mfprintf(stderr, "%s:%d curl_easy_setopt() failed, " \
                   "with code %d (%s)\n",                      \
-                  (Y), (Z), (int)ec, curl_easy_strerror(ec)); \
+                  (Y), (Z), ec, curl_easy_strerror(ec));      \
     res = ec;                                                 \
   }                                                           \
 } while(0)
@@ -217,7 +217,7 @@ void ws_close(CURL *curl);
   if((ec = curl_multi_setopt((A), (B), (C))) != CURLM_OK) {    \
     curl_mfprintf(stderr, "%s:%d curl_multi_setopt() failed, " \
                   "with code %d (%s)\n",                       \
-                  (Y), (Z), (int)ec, curl_multi_strerror(ec)); \
+                  (Y), (Z), ec, curl_multi_strerror(ec));      \
     res = TEST_ERR_MULTI;                                      \
   }                                                            \
 } while(0)
@@ -241,7 +241,7 @@ void ws_close(CURL *curl);
   if((ec = curl_multi_add_handle((A), (B))) != CURLM_OK) {         \
     curl_mfprintf(stderr, "%s:%d curl_multi_add_handle() failed, " \
                   "with code %d (%s)\n",                           \
-                  (Y), (Z), (int)ec, curl_multi_strerror(ec));     \
+                  (Y), (Z), ec, curl_multi_strerror(ec));          \
     res = TEST_ERR_MULTI;                                          \
   }                                                                \
 } while(0)
@@ -265,7 +265,7 @@ void ws_close(CURL *curl);
   if((ec = curl_multi_remove_handle((A), (B))) != CURLM_OK) {         \
     curl_mfprintf(stderr, "%s:%d curl_multi_remove_handle() failed, " \
                   "with code %d (%s)\n",                              \
-                  (Y), (Z), (int)ec, curl_multi_strerror(ec));        \
+                  (Y), (Z), ec, curl_multi_strerror(ec));             \
     res = TEST_ERR_MULTI;                                             \
   }                                                                   \
 } while(0)
@@ -290,7 +290,7 @@ void ws_close(CURL *curl);
   if((ec = curl_multi_perform((A), (B))) != CURLM_OK) {                \
     curl_mfprintf(stderr, "%s:%d curl_multi_perform() failed, "        \
                   "with code %d (%s)\n",                               \
-                  (Y), (Z), (int)ec, curl_multi_strerror(ec));         \
+                  (Y), (Z), ec, curl_multi_strerror(ec));              \
     res = TEST_ERR_MULTI;                                              \
   }                                                                    \
   else if(*((B)) < 0) {                                                \
@@ -320,7 +320,7 @@ void ws_close(CURL *curl);
   if((ec = curl_multi_fdset((A), (B), (C), (D), (E))) != CURLM_OK) { \
     curl_mfprintf(stderr, "%s:%d curl_multi_fdset() failed, "        \
                   "with code %d (%s)\n",                             \
-                  (Y), (Z), (int)ec, curl_multi_strerror(ec));       \
+                  (Y), (Z), ec, curl_multi_strerror(ec));            \
     res = TEST_ERR_MULTI;                                            \
   }                                                                  \
   else if(*((E)) < -1) {                                             \
@@ -350,7 +350,7 @@ void ws_close(CURL *curl);
   if((ec = curl_multi_timeout((A), (B))) != CURLM_OK) {            \
     curl_mfprintf(stderr, "%s:%d curl_multi_timeout() failed, "    \
                   "with code %d (%s)\n",                           \
-                  (Y), (Z), (int)ec, curl_multi_strerror(ec));     \
+                  (Y), (Z), ec, curl_multi_strerror(ec));          \
     res = TEST_ERR_BAD_TIMEOUT;                                    \
   }                                                                \
   else if(*((B)) < -1L) {                                          \
@@ -380,7 +380,7 @@ void ws_close(CURL *curl);
   if((ec = curl_multi_poll((A), (B), (C), (D), (E))) != CURLM_OK) { \
     curl_mfprintf(stderr, "%s:%d curl_multi_poll() failed, "        \
                   "with code %d (%s)\n",                            \
-                  (Y), (Z), (int)ec, curl_multi_strerror(ec));      \
+                  (Y), (Z), ec, curl_multi_strerror(ec));           \
     res = TEST_ERR_MULTI;                                           \
   }                                                                 \
   else if(*((E)) < 0) {                                             \
@@ -410,7 +410,7 @@ void ws_close(CURL *curl);
   if((ec = curl_multi_wakeup((A))) != CURLM_OK) {              \
     curl_mfprintf(stderr, "%s:%d curl_multi_wakeup() failed, " \
                   "with code %d (%s)\n",                       \
-                  (Y), (Z), (int)ec, curl_multi_strerror(ec)); \
+                  (Y), (Z), ec, curl_multi_strerror(ec));      \
     res = TEST_ERR_MULTI;                                      \
   }                                                            \
 } while(0)
@@ -495,7 +495,7 @@ void ws_close(CURL *curl);
   if((ec = curl_global_init((A))) != CURLE_OK) {              \
     curl_mfprintf(stderr, "%s:%d curl_global_init() failed, " \
                   "with code %d (%s)\n",                      \
-                  (Y), (Z), (int)ec, curl_easy_strerror(ec)); \
+                  (Y), (Z), ec, curl_easy_strerror(ec));      \
     res = ec;                                                 \
   }                                                           \
 } while(0)

--- a/tests/libtest/lib1485.c
+++ b/tests/libtest/lib1485.c
@@ -68,7 +68,7 @@ static size_t t1485_header_callback(char *ptr, size_t size, size_t nmemb,
       if(clen < 0) {
         curl_mfprintf(stderr,
                       "header_callback, expected known Content-Length, "
-                      "got: %ld\n", (long)clen);
+                      "got: %" CURL_FORMAT_CURL_OFF_T "\n", clen);
         return CURLE_WRITE_ERROR;
       }
     }

--- a/tests/libtest/lib1506.c
+++ b/tests/libtest/lib1506.c
@@ -42,8 +42,8 @@ static CURLcode test_lib1506(const char *URL)
 
   /* Create fake DNS entries for serverX.example.com for all handles */
   for(i = 0; i < CURL_ARRAYSIZE(curl); i++) {
-    curl_msnprintf(dnsentry, sizeof(dnsentry), "server%d.example.com:%s:%s",
-                   (int)i + 1, port, address);
+    curl_msnprintf(dnsentry, sizeof(dnsentry), "server%zu.example.com:%s:%s",
+                   i + 1, port, address);
     curl_mprintf("%s\n", dnsentry);
     slist2 = curl_slist_append(slist, dnsentry);
     if(!slist2) {
@@ -67,8 +67,8 @@ static CURLcode test_lib1506(const char *URL)
     easy_init(curl[i]);
     /* specify target */
     curl_msnprintf(target_url, sizeof(target_url),
-                   "http://server%d.example.com:%s/path/1506%04i",
-                   (int)i + 1, port, (int)i + 1);
+                   "http://server%zu.example.com:%s/path/1506%04zu",
+                   i + 1, port, i + 1);
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl[i], CURLOPT_URL, target_url);
     /* go verbose */

--- a/tests/libtest/lib1507.c
+++ b/tests/libtest/lib1507.c
@@ -25,14 +25,6 @@
 
 #include "memdebug.h"
 
-/*
- * This is the list of basic details you need to tweak to get things right.
- */
-#define USERNAME "user@example.com"
-#define PASSWORD "123qwerty"
-#define RECIPIENT "<1507-recipient@example.com>"
-#define MAILFROM "<1507-realuser@example.com>"
-
 static size_t t1507_read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
 {
   (void)ptr;
@@ -59,19 +51,19 @@ static CURLcode test_lib1507(const char *URL)
 
   multi_init(mcurl);
 
-  rcpt_list = curl_slist_append(rcpt_list, RECIPIENT);
+  rcpt_list = curl_slist_append(rcpt_list, "<1507-recipient@example.com>");
 #if 0
   /* more addresses can be added here */
   rcpt_list = curl_slist_append(rcpt_list, "<others@example.com>");
 #endif
   curl_easy_setopt(curl, CURLOPT_URL, URL);
 #if 0
-  curl_easy_setopt(curl, CURLOPT_USERNAME, USERNAME);
-  curl_easy_setopt(curl, CURLOPT_PASSWORD, PASSWORD);
+  curl_easy_setopt(curl, CURLOPT_USERNAME, "user@example.com");
+  curl_easy_setopt(curl, CURLOPT_PASSWORD, "123qwerty");
 #endif
   curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
   curl_easy_setopt(curl, CURLOPT_READFUNCTION, t1507_read_cb);
-  curl_easy_setopt(curl, CURLOPT_MAIL_FROM, MAILFROM);
+  curl_easy_setopt(curl, CURLOPT_MAIL_FROM, "<1507-realuser@example.com>");
   curl_easy_setopt(curl, CURLOPT_MAIL_RCPT, rcpt_list);
   curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   multi_add_handle(mcurl, curl);

--- a/tests/libtest/lib1512.c
+++ b/tests/libtest/lib1512.c
@@ -60,8 +60,8 @@ static CURLcode test_lib1512(const char *URL)
     easy_init(curl[i]);
     /* specify target */
     curl_msnprintf(target_url, sizeof(target_url),
-                   "http://server.example.curl:%s/path/1512%04i",
-                   port, (int)i + 1);
+                   "http://server.example.curl:%s/path/1512%04zu",
+                   port, i + 1);
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl[i], CURLOPT_URL, target_url);
     /* go verbose */

--- a/tests/libtest/lib1515.c
+++ b/tests/libtest/lib1515.c
@@ -52,8 +52,8 @@ static CURLcode do_one_request(CURLM *m, const char *URL, const char *resolve)
   easy_setopt(curls, CURLOPT_RESOLVE, resolve_list);
   easy_setopt(curls, CURLOPT_DNS_CACHE_TIMEOUT, DNS_TIMEOUT);
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
   easy_setopt(curls, CURLOPT_DEBUGDATA, &debug_config);
   easy_setopt(curls, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(curls, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib1520.c
+++ b/tests/libtest/lib1520.c
@@ -25,12 +25,6 @@
 
 #include "memdebug.h"
 
-/*
- * This is the list of basic details you need to tweak to get things right.
- */
-#define TO "<recipient@example.com>"
-#define FROM "<sender@example.com>"
-
 struct upload_status {
   int lines_read;
 };
@@ -90,16 +84,16 @@ static CURLcode test_lib1520(const char *URL)
     return TEST_ERR_MAJOR_BAD;
   }
 
-  rcpt_list = curl_slist_append(rcpt_list, TO);
-  /* more addresses can be added here
-     rcpt_list = curl_slist_append(rcpt_list, "<others@example.com>");
-  */
-
+  rcpt_list = curl_slist_append(rcpt_list, "<recipient@example.com>");
+#if 0
+  /* more addresses can be added here */
+  rcpt_list = curl_slist_append(rcpt_list, "<others@example.com>");
+#endif
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_UPLOAD, 1L);
   test_setopt(curl, CURLOPT_READFUNCTION, t1520_read_cb);
   test_setopt(curl, CURLOPT_READDATA, &upload_ctx);
-  test_setopt(curl, CURLOPT_MAIL_FROM, FROM);
+  test_setopt(curl, CURLOPT_MAIL_FROM, "<sender@example.com>");
   test_setopt(curl, CURLOPT_MAIL_RCPT, rcpt_list);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
 

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -60,8 +60,8 @@ static CURLcode test_lib1522(const char *URL)
   curl_easy_setopt(curl, CURLOPT_POSTFIELDS, g_Data);
   curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)sizeof(g_Data));
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
   test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
   test_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -83,8 +83,8 @@ static CURLcode test_lib1522(const char *URL)
       curl_mprintf("!!!!!!!!!! PASS\n");
     }
     else {
-      curl_mprintf("sent %d, libcurl says %d\n",
-                   (int)sizeof(g_Data), (int)uploadSize);
+      curl_mprintf("sent %lu, libcurl says %ld\n",
+                   sizeof(g_Data), (long)uploadSize);
     }
   }
   else {

--- a/tests/libtest/lib1522.c
+++ b/tests/libtest/lib1522.c
@@ -77,14 +77,14 @@ static CURLcode test_lib1522(const char *URL)
     curl_off_t uploadSize;
     curl_easy_getinfo(curl, CURLINFO_SIZE_UPLOAD_T, &uploadSize);
 
-    curl_mprintf("uploadSize = %ld\n", (long)uploadSize);
+    curl_mprintf("uploadSize = %" CURL_FORMAT_CURL_OFF_T "\n", uploadSize);
 
     if((size_t) uploadSize == sizeof(g_Data)) {
       curl_mprintf("!!!!!!!!!! PASS\n");
     }
     else {
-      curl_mprintf("sent %lu, libcurl says %ld\n",
-                   sizeof(g_Data), (long)uploadSize);
+      curl_mprintf("sent %zu, libcurl says %" CURL_FORMAT_CURL_OFF_T "\n",
+                   sizeof(g_Data), uploadSize);
     }
   }
   else {

--- a/tests/libtest/lib1538.c
+++ b/tests/libtest/lib1538.c
@@ -45,17 +45,17 @@ static CURLcode test_lib1538(const char *URL)
   curl_url_strerror((CURLUcode)-INT_MAX);
   /* NOLINTEND(clang-analyzer-optin.core.EnumCastOutOfRange) */
   for(easyret = CURLE_OK; easyret <= CURL_LAST; easyret++) {
-    curl_mprintf("e%d: %s\n", (int)easyret, curl_easy_strerror(easyret));
+    curl_mprintf("e%d: %s\n", easyret, curl_easy_strerror(easyret));
   }
   for(multiret = CURLM_CALL_MULTI_PERFORM; multiret <= CURLM_LAST;
       multiret++) {
-    curl_mprintf("m%d: %s\n", (int)multiret, curl_multi_strerror(multiret));
+    curl_mprintf("m%d: %s\n", multiret, curl_multi_strerror(multiret));
   }
   for(shareret = CURLSHE_OK; shareret <= CURLSHE_LAST; shareret++) {
-    curl_mprintf("s%d: %s\n", (int)shareret, curl_share_strerror(shareret));
+    curl_mprintf("s%d: %s\n", shareret, curl_share_strerror(shareret));
   }
   for(urlret = CURLUE_OK; urlret <= CURLUE_LAST; urlret++) {
-    curl_mprintf("u%d: %s\n", (int)urlret, curl_url_strerror(urlret));
+    curl_mprintf("u%d: %s\n", urlret, curl_url_strerror(urlret));
   }
 
   return res;

--- a/tests/libtest/lib1540.c
+++ b/tests/libtest/lib1540.c
@@ -106,8 +106,8 @@ static CURLcode test_lib1540(const char *URL)
   easy_setopt(curls, CURLOPT_XFERINFODATA, &st);
   easy_setopt(curls, CURLOPT_NOPROGRESS, 0L);
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
   test_setopt(curls, CURLOPT_DEBUGDATA, &debug_config);
   easy_setopt(curls, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(curls, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib1542.c
+++ b/tests/libtest/lib1542.c
@@ -46,8 +46,8 @@ static CURLcode test_lib1542(const char *URL)
 
   easy_setopt(easy, CURLOPT_URL, URL);
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 0;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = FALSE;
   easy_setopt(easy, CURLOPT_DEBUGDATA, &debug_config);
   easy_setopt(easy, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(easy, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib1553.c
+++ b/tests/libtest/lib1553.c
@@ -71,8 +71,8 @@ static CURLcode test_lib1553(const char *URL)
   easy_setopt(curls, CURLOPT_XFERINFOFUNCTION, t1553_xferinfo);
   easy_setopt(curls, CURLOPT_NOPROGRESS, 1L);
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
   test_setopt(curls, CURLOPT_DEBUGDATA, &debug_config);
   easy_setopt(curls, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(curls, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib1556.c
+++ b/tests/libtest/lib1556.c
@@ -67,7 +67,7 @@ static CURLcode test_lib1556(const char *URL)
     goto test_cleanup;
   }
 
-  curl_mprintf("Max = %ld\n", (long)info.largest);
+  curl_mprintf("Max = %zu\n", info.largest);
 
 test_cleanup:
 

--- a/tests/libtest/lib1559.c
+++ b/tests/libtest/lib1559.c
@@ -59,13 +59,13 @@ static CURLcode test_lib1559(const char *URL)
   if(u) {
     CURLUcode uc = curl_url_set(u, CURLUPART_URL, longurl, 0);
     curl_mprintf("CURLUPART_URL %d bytes URL == %d (%s)\n",
-                 EXCESSIVE, (int)uc, curl_url_strerror(uc));
+                 EXCESSIVE, uc, curl_url_strerror(uc));
     uc = curl_url_set(u, CURLUPART_SCHEME, longurl, CURLU_NON_SUPPORT_SCHEME);
     curl_mprintf("CURLUPART_SCHEME %d bytes scheme == %d (%s)\n",
-                 EXCESSIVE, (int)uc, curl_url_strerror(uc));
+                 EXCESSIVE, uc, curl_url_strerror(uc));
     uc = curl_url_set(u, CURLUPART_USER, longurl, 0);
     curl_mprintf("CURLUPART_USER %d bytes user == %d (%s)\n",
-                 EXCESSIVE, (int)uc, curl_url_strerror(uc));
+                 EXCESSIVE, uc, curl_url_strerror(uc));
     curl_url_cleanup(u);
   }
 

--- a/tests/libtest/lib1560.c
+++ b/tests/libtest/lib1560.c
@@ -73,7 +73,7 @@ static int checkparts(CURLU *u, const char *in, const char *wanted,
       curl_msnprintf(bufp, len, "%s%s", buf[0]?" | ":"", p);
     }
     else
-      curl_msnprintf(bufp, len, "%s[%d]", buf[0]?" | ":"", (int)rc);
+      curl_msnprintf(bufp, len, "%s[%d]", buf[0]?" | ":"", rc);
 
     n = strlen(bufp);
     bufp += n;
@@ -1198,7 +1198,7 @@ static CURLUcode updateurl(CURLU *u, const char *cmd, unsigned int setflags)
         CURLUPart what = part2id(part);
 #if 0
         /* for debugging this */
-        curl_mfprintf(stderr, "%s = \"%s\" [%d]\n", part, value, (int)what);
+        curl_mfprintf(stderr, "%s = \"%s\" [%d]\n", part, value, what);
 #endif
         if(what > CURLUPART_ZONEID)
           curl_mfprintf(stderr, "UNKNOWN part '%s'\n", part);
@@ -1395,7 +1395,7 @@ static int set_url(void)
       if(rc) {
         curl_mfprintf(stderr, "%s:%d Set URL %s returned %d (%s)\n",
                       __FILE__, __LINE__, set_url_list[i].set,
-                      (int)rc, curl_url_strerror(rc));
+                      rc, curl_url_strerror(rc));
         error++;
       }
       else {
@@ -1403,7 +1403,7 @@ static int set_url(void)
         rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
         if(rc) {
           curl_mfprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
-                        __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                        __FILE__, __LINE__, rc, curl_url_strerror(rc));
           error++;
         }
         else {
@@ -1416,7 +1416,7 @@ static int set_url(void)
     }
     else if(rc != set_url_list[i].ucode) {
       curl_mfprintf(stderr, "Set URL\nin: %s\nreturned %d (expected %d)\n",
-                    set_url_list[i].in, (int)rc, set_url_list[i].ucode);
+                    set_url_list[i].in, rc, set_url_list[i].ucode);
       error++;
     }
     curl_url_cleanup(urlp);
@@ -1455,7 +1455,7 @@ static int setget_parts(bool has_utf8)
         if(uc != setget_parts_list[i].pcode) {
           curl_mfprintf(stderr,
                         "updateurl\nin: %s\nreturned %d (expected %d)\n",
-                        setget_parts_list[i].set, (int)uc,
+                        setget_parts_list[i].set, uc,
                         setget_parts_list[i].pcode);
           error++;
         }
@@ -1470,7 +1470,7 @@ static int setget_parts(bool has_utf8)
       }
       else if(rc != CURLUE_OK) {
         curl_mfprintf(stderr, "Set parts\nin: %s\nreturned %d (expected %d)\n",
-                      setget_parts_list[i].in, (int)rc, 0);
+                      setget_parts_list[i].in, rc, 0);
         error++;
       }
     }
@@ -1503,7 +1503,7 @@ static int set_parts(void)
 
       if(uc != set_parts_list[i].pcode) {
         curl_mfprintf(stderr, "updateurl\nin: %s\nreturned %d (expected %d)\n",
-                      set_parts_list[i].set, (int)uc, set_parts_list[i].pcode);
+                      set_parts_list[i].set, uc, set_parts_list[i].pcode);
         error++;
       }
       if(!uc) {
@@ -1512,7 +1512,7 @@ static int set_parts(void)
 
         if(rc) {
           curl_mfprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
-                        __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                        __FILE__, __LINE__, rc, curl_url_strerror(rc));
           error++;
         }
         else if(checkurl(set_parts_list[i].in, url, set_parts_list[i].out)) {
@@ -1523,7 +1523,7 @@ static int set_parts(void)
     }
     else if(rc != set_parts_list[i].ucode) {
       curl_mfprintf(stderr, "Set parts\nin: %s\nreturned %d (expected %d)\n",
-                    set_parts_list[i].in, (int)rc, set_parts_list[i].ucode);
+                    set_parts_list[i].in, rc, set_parts_list[i].ucode);
       error++;
     }
     curl_url_cleanup(urlp);
@@ -1552,7 +1552,7 @@ static int get_url(bool has_utf8)
 
         if(rc) {
           curl_mfprintf(stderr, "%s:%d returned %d (%s). URL: '%s'\n",
-                        __FILE__, __LINE__, (int)rc, curl_url_strerror(rc),
+                        __FILE__, __LINE__, rc, curl_url_strerror(rc),
                         get_url_list[i].in);
           error++;
         }
@@ -1565,7 +1565,7 @@ static int get_url(bool has_utf8)
       }
       if(rc != get_url_list[i].ucode) {
         curl_mfprintf(stderr, "Get URL\nin: %s\nreturned %d (expected %d)\n",
-                      get_url_list[i].in, (int)rc, get_url_list[i].ucode);
+                      get_url_list[i].in, rc, get_url_list[i].ucode);
         error++;
       }
     }
@@ -1592,7 +1592,7 @@ static int get_parts(bool has_utf8)
                         get_parts_list[i].urlflags);
       if(rc != get_parts_list[i].ucode) {
         curl_mfprintf(stderr, "Get parts\nin: %s\nreturned %d (expected %d)\n",
-                      get_parts_list[i].in, (int)rc, get_parts_list[i].ucode);
+                      get_parts_list[i].in, rc, get_parts_list[i].ucode);
         error++;
       }
       else if(get_parts_list[i].ucode) {
@@ -1649,7 +1649,7 @@ static int append(void)
       ;
     else if(rc != append_list[i].ucode) {
       curl_mfprintf(stderr, "Append\nin: %s\nreturned %d (expected %d)\n",
-                    append_list[i].in, (int)rc, append_list[i].ucode);
+                    append_list[i].in, rc, append_list[i].ucode);
       error++;
     }
     else if(append_list[i].ucode) {
@@ -1660,7 +1660,7 @@ static int append(void)
       rc = curl_url_get(urlp, CURLUPART_URL, &url, 0);
       if(rc) {
         curl_mfprintf(stderr, "%s:%d Get URL returned %d (%s)\n",
-                      __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                      __FILE__, __LINE__, rc, curl_url_strerror(rc));
         error++;
       }
       else {
@@ -1686,7 +1686,7 @@ static int scopeid(void)
                     "https://[fe80::20c:29ff:fe9c:409b%25eth0]/hello.html", 0);
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr, "%s:%d curl_url_set returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -1694,7 +1694,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1705,7 +1705,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_set CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -1713,7 +1713,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1724,7 +1724,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_set CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -1732,7 +1732,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1744,7 +1744,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_set CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -1752,7 +1752,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1763,7 +1763,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_HOST returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1774,7 +1774,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_ZONEID returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1785,7 +1785,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_set CURLUPART_ZONEID returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
 
@@ -1793,7 +1793,7 @@ static int scopeid(void)
   if(rc != CURLUE_OK) {
     curl_mfprintf(stderr,
                   "%s:%d curl_url_get CURLUPART_URL returned %d (%s)\n",
-                  __FILE__, __LINE__, (int)rc, curl_url_strerror(rc));
+                  __FILE__, __LINE__, rc, curl_url_strerror(rc));
     error++;
   }
   else {
@@ -1848,7 +1848,7 @@ static int get_nothing(void)
 
     rc = curl_url_get(u, CURLUPART_ZONEID, &p, 0);
     if(rc != CURLUE_NO_ZONEID)
-      curl_mfprintf(stderr, "unexpected return code %u on line %u\n", (int)rc,
+      curl_mfprintf(stderr, "unexpected return code %u on line %u\n", rc,
                     __LINE__);
 
     curl_url_cleanup(u);

--- a/tests/libtest/lib1565.c
+++ b/tests/libtest/lib1565.c
@@ -132,7 +132,7 @@ static CURLcode test_lib1565(const char *URL)
       else {
         curl_mfprintf(stderr,
                       "%s:%d Got an unexpected message from curl: %i\n",
-                      __FILE__, __LINE__, (int)message->msg);
+                      __FILE__, __LINE__, message->msg);
         res = TEST_ERR_MAJOR_BAD;
         goto test_cleanup;
       }

--- a/tests/libtest/lib1907.c
+++ b/tests/libtest/lib1907.c
@@ -40,8 +40,8 @@ static CURLcode test_lib1907(const char *URL)
   res = curl_easy_perform(curl);
   if(!res)
     curl_mfprintf(stderr, "failure expected, "
-                  "curl_easy_perform returned %ld: <%s>, <%s>\n",
-                  (long) res, curl_easy_strerror(res), error_buffer);
+                  "curl_easy_perform returned %d: <%s>, <%s>\n",
+                  res, curl_easy_strerror(res), error_buffer);
 
   /* print the used url */
   if(!curl_easy_getinfo(curl, CURLINFO_EFFECTIVE_URL, &url_after))

--- a/tests/libtest/lib1911.c
+++ b/tests/libtest/lib1911.c
@@ -49,7 +49,7 @@ static CURLcode test_lib1911(const char *URL)
   memset(testbuf, 'A', MAX_INPUT_LENGTH + 1);
   testbuf[MAX_INPUT_LENGTH + 1] = 0;
 
-  curl_mprintf("string length: %ld\n", (long)strlen(testbuf));
+  curl_mprintf("string length: %zu\n", strlen(testbuf));
 
   for(o = curl_easy_option_next(NULL);
       o;

--- a/tests/libtest/lib1911.c
+++ b/tests/libtest/lib1911.c
@@ -49,7 +49,7 @@ static CURLcode test_lib1911(const char *URL)
   memset(testbuf, 'A', MAX_INPUT_LENGTH + 1);
   testbuf[MAX_INPUT_LENGTH + 1] = 0;
 
-  curl_mprintf("string length: %d\n", (int)strlen(testbuf));
+  curl_mprintf("string length: %ld\n", (long)strlen(testbuf));
 
   for(o = curl_easy_option_next(NULL);
       o;

--- a/tests/libtest/lib1915.c
+++ b/tests/libtest/lib1915.c
@@ -103,8 +103,8 @@ static CURLcode test_lib1915(const char *URL)
 
   global_init(CURL_GLOBAL_ALL);
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
 
   easy_init(hnd);
   easy_setopt(hnd, CURLOPT_URL, URL);

--- a/tests/libtest/lib1940.c
+++ b/tests/libtest/lib1940.c
@@ -59,8 +59,8 @@ static void t1940_showem(CURL *easy, int header_request, unsigned int type)
         size_t index = 0;
         size_t amount = header->amount;
         do {
-          curl_mprintf("- %s == %s (%u/%u)\n", header->name, header->value,
-                       (int)index, (int)amount);
+          curl_mprintf("- %s == %s (%zu/%zu)\n", header->name, header->value,
+                       index, amount);
 
           if(++index == amount)
             break;

--- a/tests/libtest/lib1945.c
+++ b/tests/libtest/lib1945.c
@@ -32,8 +32,8 @@ static void t1945_showem(CURL *easy, unsigned int type)
 
   /* !checksrc! disable EQUALSNULL 1 */
   while((header = curl_easy_nextheader(easy, type, 0, prev)) != NULL) {
-    curl_mprintf(" %s == %s (%u/%u)\n", header->name, header->value,
-                 (int)header->index, (int)header->amount);
+    curl_mprintf(" %s == %s (%zu/%zu)\n", header->name, header->value,
+                 header->index, header->amount);
     prev = header;
   }
 }

--- a/tests/libtest/lib2032.c
+++ b/tests/libtest/lib2032.c
@@ -49,7 +49,7 @@ static size_t callback(char *ptr, size_t size, size_t nmemb, void *data)
   if(CURLE_OK != code) {
     curl_mfprintf(stderr, "%s:%d curl_easy_getinfo() failed, "
                   "with code %d (%s)\n",
-                  __FILE__, __LINE__, (int)code, curl_easy_strerror(code));
+                  __FILE__, __LINE__, code, curl_easy_strerror(code));
     ntlmcb_res = TEST_ERR_MAJOR_BAD;
     return failure;
   }

--- a/tests/libtest/lib2301.c
+++ b/tests/libtest/lib2301.c
@@ -50,8 +50,8 @@ static size_t t2301_write_cb(char *b, size_t size, size_t nitems, void *p)
     0x8a, 0x0
   };
   size_t incoming = nitems;
-  curl_mfprintf(stderr, "Called CURLOPT_WRITEFUNCTION with %d bytes: ",
-                (int)nitems);
+  curl_mfprintf(stderr, "Called CURLOPT_WRITEFUNCTION with %zu bytes: ",
+                nitems);
   for(i = 0; i < nitems; i++)
     curl_mfprintf(stderr, "%02x ", (unsigned char)buffer[i]);
   curl_mfprintf(stderr, "\n");

--- a/tests/libtest/lib2402.c
+++ b/tests/libtest/lib2402.c
@@ -63,8 +63,8 @@ static CURLcode test_lib2402(const char *URL)
     easy_init(curl[i]);
     /* specify target */
     curl_msnprintf(target_url, sizeof(target_url),
-                   "https://localhost:%s/path/2402%04i",
-                   port, (int)i + 1);
+                   "https://localhost:%s/path/2402%04zu",
+                   port, i + 1);
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl[i], CURLOPT_URL, target_url);
     /* go http2 */

--- a/tests/libtest/lib2404.c
+++ b/tests/libtest/lib2404.c
@@ -63,8 +63,8 @@ static CURLcode test_lib2404(const char *URL)
     easy_init(curl[i]);
     /* specify target */
     curl_msnprintf(target_url, sizeof(target_url),
-                   "https://localhost:%s/path/2404%04i",
-                   port, (int)i + 1);
+                   "https://localhost:%s/path/2404%04zu",
+                   port, i + 1);
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl[i], CURLOPT_URL, target_url);
     /* go http2 */

--- a/tests/libtest/lib2502.c
+++ b/tests/libtest/lib2502.c
@@ -75,8 +75,8 @@ static CURLcode test_lib2502(const char *URL)
     /* wait for first connection established to see if we can share it */
     easy_setopt(curl[i], CURLOPT_PIPEWAIT, 1L);
     /* go verbose */
-    debug_config.nohex = 1;
-    debug_config.tracetime = 0;
+    debug_config.nohex = TRUE;
+    debug_config.tracetime = FALSE;
     test_setopt(curl[i], CURLOPT_DEBUGDATA, &debug_config);
     easy_setopt(curl[i], CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
     easy_setopt(curl[i], CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib2502.c
+++ b/tests/libtest/lib2502.c
@@ -64,8 +64,8 @@ static CURLcode test_lib2502(const char *URL)
     easy_init(curl[i]);
     /* specify target */
     curl_msnprintf(target_url, sizeof(target_url),
-                   "https://localhost:%s/path/2502%04i",
-                   port, (int)i + 1);
+                   "https://localhost:%s/path/2502%04zu",
+                   port, i + 1);
     target_url[sizeof(target_url) - 1] = '\0';
     easy_setopt(curl[i], CURLOPT_URL, target_url);
     /* go http2 */

--- a/tests/libtest/lib2700.c
+++ b/tests/libtest/lib2700.c
@@ -222,8 +222,8 @@ static CURLcode test_lib2700(const char *URL)
 
   easy_setopt(curl, CURLOPT_URL, URL);
   easy_setopt(curl, CURLOPT_USERAGENT, "client/test2700");
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
   easy_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
   easy_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -89,7 +89,7 @@ cleanup:
     if(results[i] != CURLE_OK) {
       curl_mfprintf(stderr, "%s:%d thread[%u]: curl_global_init() failed,"
                     "with code %d (%s)\n", __FILE__, __LINE__,
-                    i, (int) results[i], curl_easy_strerror(results[i]));
+                    i, results[i], curl_easy_strerror(results[i]));
       test_failure = TEST_ERR_MAJOR_BAD;
     }
   }
@@ -147,7 +147,7 @@ cleanup:
     if(results[i] != CURLE_OK) {
       curl_mfprintf(stderr, "%s:%d thread[%u]: curl_global_init() failed,"
                     "with code %d (%s)\n", __FILE__, __LINE__,
-                    i, (int) results[i], curl_easy_strerror(results[i]));
+                    i, results[i], curl_easy_strerror(results[i]));
       test_failure = TEST_ERR_MAJOR_BAD;
     }
   }

--- a/tests/libtest/lib3033.c
+++ b/tests/libtest/lib3033.c
@@ -107,8 +107,8 @@ static CURLcode test_lib3033(const char *URL)
   multi_init(multi);
   easy_init(curl);
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
 
   res = t3033_req_test(multi, curl, URL, 0);
   if(res != CURLE_OK)

--- a/tests/libtest/lib3105.c
+++ b/tests/libtest/lib3105.c
@@ -47,7 +47,7 @@ static CURLcode test_lib3105(const char *URL)
   mc += curl_multi_remove_handle(multi, curls);
 
   if(mc) {
-    curl_mfprintf(stderr, "%d was unexpected\n", (int)mc);
+    curl_mfprintf(stderr, "%d was unexpected\n", mc);
     i = CURLE_FAILED_INIT;
   }
 

--- a/tests/libtest/lib500.c
+++ b/tests/libtest/lib500.c
@@ -73,8 +73,8 @@ static CURLcode test_lib500(const char *URL)
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_HEADER, 1L);
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
   test_setopt(curl, CURLOPT_DEBUGDATA, &debug_config);
   test_setopt(curl, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   test_setopt(curl, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -177,7 +177,7 @@ static CURLcode test_lib506(const char *URL)
   int i;
   struct t506_userdata user;
 
-  const char *JAR = libtest_arg2;
+  const char *jar = libtest_arg2;
 
   user.text = "Pigs in space";
   user.counter = 0;
@@ -285,7 +285,7 @@ static CURLcode test_lib506(const char *URL)
   curl_mprintf("CURLOPT_SHARE\n");
   test_setopt(curl, CURLOPT_SHARE,      share);
   curl_mprintf("CURLOPT_COOKIEJAR\n");
-  test_setopt(curl, CURLOPT_COOKIEJAR,  JAR);
+  test_setopt(curl, CURLOPT_COOKIEJAR,  jar);
   curl_mprintf("CURLOPT_COOKIELIST FLUSH\n");
   test_setopt(curl, CURLOPT_COOKIELIST, "FLUSH");
 
@@ -314,7 +314,7 @@ static CURLcode test_lib506(const char *URL)
   curl_mprintf("CURLOPT_COOKIELIST ALL\n");
   test_setopt(curl, CURLOPT_COOKIELIST, "ALL");
   curl_mprintf("CURLOPT_COOKIEJAR\n");
-  test_setopt(curl, CURLOPT_COOKIEFILE, JAR);
+  test_setopt(curl, CURLOPT_COOKIEFILE, jar);
   curl_mprintf("CURLOPT_COOKIELIST RELOAD\n");
   test_setopt(curl, CURLOPT_COOKIELIST, "RELOAD");
 
@@ -328,7 +328,7 @@ static CURLcode test_lib506(const char *URL)
   }
   curl_mprintf("loaded cookies:\n");
   if(!cookies) {
-    curl_mfprintf(stderr, "  reloading cookies from '%s' failed\n", JAR);
+    curl_mfprintf(stderr, "  reloading cookies from '%s' failed\n", jar);
     res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;
   }

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -151,7 +151,7 @@ static void *t506_test_fire(void *ptr)
   if(code) {
     int i = 0;
     curl_mfprintf(stderr, "perform url '%s' repeat %d failed, curlcode %d\n",
-                  tdata->url, i, (int)code);
+                  tdata->url, i, code);
   }
 
   curl_mprintf("CLEANUP\n");
@@ -364,8 +364,7 @@ test_cleanup:
   curl_mprintf("SHARE_CLEANUP\n");
   scode = curl_share_cleanup(share);
   if(scode != CURLSHE_OK)
-    curl_mfprintf(stderr, "curl_share_cleanup failed, code errno %d\n",
-                  (int)scode);
+    curl_mfprintf(stderr, "curl_share_cleanup failed, code errno %d\n", scode);
 
   curl_mprintf("GLOBAL_CLEANUP\n");
   curl_global_cleanup();

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -26,7 +26,6 @@
 #include "testutil.h"
 #include "memdebug.h"
 
-#define JAR libtest_arg2
 #define THREADS 2
 
 /* struct containing data of a thread */
@@ -177,6 +176,8 @@ static CURLcode test_lib506(const char *URL)
   struct curl_slist *next_cookie = NULL;
   int i;
   struct t506_userdata user;
+
+  const char *JAR = libtest_arg2;
 
   user.text = "Pigs in space";
   user.counter = 0;

--- a/tests/libtest/lib526.c
+++ b/tests/libtest/lib526.c
@@ -96,7 +96,7 @@ static CURLcode test_lib526(const char *URL)
         curl[current] = NULL;
       }
       if(++current < CURL_ARRAYSIZE(curl)) {
-        curl_mfprintf(stderr, "Advancing to URL %d\n", (int)current);
+        curl_mfprintf(stderr, "Advancing to URL %zu\n", current);
         if(testnum == 532) {
           /* first remove the only handle we use */
           curl_multi_remove_handle(m, curl[0]);

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -206,7 +206,7 @@ static int t530_checkForCompletion(CURLM *curl, int *success)
     }
     else {
       curl_mfprintf(stderr, "%s got an unexpected message from curl: %i\n",
-                    t530_tag(), (int)message->msg);
+                    t530_tag(), message->msg);
       result = 1;
       *success = 0;
     }

--- a/tests/libtest/lib536.c
+++ b/tests/libtest/lib536.c
@@ -25,9 +25,6 @@
 
 #include "memdebug.h"
 
-#define WITH_PROXY     "http://usingproxy.com/"
-#define WITHOUT_PROXY  libtest_arg2
-
 static void proxystat(CURL *curl)
 {
   long wasproxy;
@@ -42,6 +39,9 @@ static CURLcode test_lib536(const char *URL)
   CURLcode res = CURLE_OK;
   CURL *curl;
   struct curl_slist *host = NULL;
+
+  static const char *url_with_proxy = "http://usingproxy.com/";
+  const char *url_without_proxy = libtest_arg2;
 
   if(curl_global_init(CURL_GLOBAL_ALL) != CURLE_OK) {
     curl_mfprintf(stderr, "curl_global_init() failed\n");
@@ -61,14 +61,14 @@ static CURLcode test_lib536(const char *URL)
 
   test_setopt(curl, CURLOPT_RESOLVE, host);
   test_setopt(curl, CURLOPT_PROXY, URL);
-  test_setopt(curl, CURLOPT_URL, WITH_PROXY);
+  test_setopt(curl, CURLOPT_URL, url_with_proxy);
   test_setopt(curl, CURLOPT_NOPROXY, "goingdirect.com");
   test_setopt(curl, CURLOPT_VERBOSE, 1L);
 
   res = curl_easy_perform(curl);
   if(!res) {
     proxystat(curl);
-    test_setopt(curl, CURLOPT_URL, WITHOUT_PROXY);
+    test_setopt(curl, CURLOPT_URL, url_without_proxy);
     res = curl_easy_perform(curl);
     if(!res)
       proxystat(curl);

--- a/tests/libtest/lib540.c
+++ b/tests/libtest/lib540.c
@@ -34,16 +34,14 @@
 
 #include "memdebug.h"
 
-#define PROXY libtest_arg2
-#define PROXYUSERPWD libtest_arg3
-#define HOST test_argv[4]
-
 static CURL *testeh[2];
 
 static CURLcode init(int num, CURLM *cm, const char *url, const char *userpwd,
                      struct curl_slist *headers)
 {
   CURLcode res = CURLE_OK;
+
+  const char *PROXY = libtest_arg2;
 
   res_easy_init(testeh[num]);
   if(res)
@@ -192,6 +190,9 @@ static CURLcode test_lib540(const char *URL)
   CURLcode res = CURLE_OK;
   size_t i;
 
+  const char *PROXYUSERPWD = libtest_arg3;
+  const char *HOST;
+
   for(i = 0; i < CURL_ARRAYSIZE(testeh); i++)
     testeh[i] = NULL;
 
@@ -200,6 +201,7 @@ static CURLcode test_lib540(const char *URL)
   if(test_argc < 4)
     return TEST_ERR_MAJOR_BAD;
 
+  HOST = test_argv[4];
   curl_msnprintf(buffer, sizeof(buffer), "Host: %s", HOST);
 
   /* now add a custom Host: header */

--- a/tests/libtest/lib540.c
+++ b/tests/libtest/lib540.c
@@ -41,7 +41,7 @@ static CURLcode init(int num, CURLM *cm, const char *url, const char *userpwd,
 {
   CURLcode res = CURLE_OK;
 
-  const char *PROXY = libtest_arg2;
+  const char *proxy = libtest_arg2;
 
   res_easy_init(testeh[num]);
   if(res)
@@ -51,7 +51,7 @@ static CURLcode init(int num, CURLM *cm, const char *url, const char *userpwd,
   if(res)
     goto init_failed;
 
-  res_easy_setopt(testeh[num], CURLOPT_PROXY, PROXY);
+  res_easy_setopt(testeh[num], CURLOPT_PROXY, proxy);
   if(res)
     goto init_failed;
 
@@ -190,8 +190,8 @@ static CURLcode test_lib540(const char *URL)
   CURLcode res = CURLE_OK;
   size_t i;
 
-  const char *PROXYUSERPWD = libtest_arg3;
-  const char *HOST;
+  const char *proxyuserpws = libtest_arg3;
+  const char *host;
 
   for(i = 0; i < CURL_ARRAYSIZE(testeh); i++)
     testeh[i] = NULL;
@@ -201,8 +201,8 @@ static CURLcode test_lib540(const char *URL)
   if(test_argc < 4)
     return TEST_ERR_MAJOR_BAD;
 
-  HOST = test_argv[4];
-  curl_msnprintf(buffer, sizeof(buffer), "Host: %s", HOST);
+  host = test_argv[4];
+  curl_msnprintf(buffer, sizeof(buffer), "Host: %s", host);
 
   /* now add a custom Host: header */
   headers = curl_slist_append(headers, buffer);
@@ -224,13 +224,13 @@ static CURLcode test_lib540(const char *URL)
     return res;
   }
 
-  res = loop(0, cm, URL, PROXYUSERPWD, headers);
+  res = loop(0, cm, URL, proxyuserpws, headers);
   if(res)
     goto test_cleanup;
 
   curl_mfprintf(stderr, "lib540: now we do the request again\n");
 
-  res = loop(1, cm, URL, PROXYUSERPWD, headers);
+  res = loop(1, cm, URL, proxyuserpws, headers);
 
 test_cleanup:
 

--- a/tests/libtest/lib540.c
+++ b/tests/libtest/lib540.c
@@ -171,7 +171,7 @@ static CURLcode loop(int num, CURLM *cm, const char *url, const char *userpwd,
         }
       }
       else
-        curl_mfprintf(stderr, "E: CURLMsg (%d)\n", (int)msg->msg);
+        curl_mfprintf(stderr, "E: CURLMsg (%d)\n", msg->msg);
     }
 
     res_test_timedout();

--- a/tests/libtest/lib544.c
+++ b/tests/libtest/lib544.c
@@ -56,7 +56,7 @@ static CURLcode test_lib544(const char *URL)
   test_setopt(curl, CURLOPT_URL, URL);
 
   if(testnum == 545)
-    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long) sizeof(teststring));
+    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)sizeof(teststring));
 
   test_setopt(curl, CURLOPT_COPYPOSTFIELDS, teststring);
 

--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -30,7 +30,7 @@
 
 #include "memdebug.h"
 
-static const char uploadthis[] = "this is the blurb we want to upload\n";
+static const char t547_uploadthis[] = "this is the blurb we want to upload\n";
 
 static size_t t547_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
 {
@@ -43,10 +43,10 @@ static size_t t547_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
   }
   (*counter)++; /* bump */
 
-  if(size * nmemb >= sizeof(uploadthis)-1) {
+  if(size * nmemb >= sizeof(t547_uploadthis)-1) {
     curl_mfprintf(stderr, "READ!\n");
-    strcpy(ptr, uploadthis);
-    return sizeof(uploadthis)-1;
+    strcpy(ptr, t547_uploadthis);
+    return sizeof(t547_uploadthis)-1;
   }
   curl_mfprintf(stderr, "READ NOT FINE!\n");
   return 0;
@@ -86,7 +86,7 @@ static CURLcode test_lib547(const char *URL)
   test_setopt(curl, CURLOPT_HEADER, 1L);
   if(testnum == 548) {
     /* set the data to POST with a mere pointer to a null-terminated string */
-    test_setopt(curl, CURLOPT_POSTFIELDS, uploadthis);
+    test_setopt(curl, CURLOPT_POSTFIELDS, t547_uploadthis);
   }
   else {
     /* 547 style, which means reading the POST data from a callback */
@@ -97,7 +97,7 @@ static CURLcode test_lib547(const char *URL)
     test_setopt(curl, CURLOPT_READDATA, &counter);
     /* We CANNOT do the POST fine without setting the size (or choose
        chunked)! */
-    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)(sizeof(uploadthis)-1));
+    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)(sizeof(t547_uploadthis)-1));
   }
   test_setopt(curl, CURLOPT_POST, 1L);
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);

--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -30,7 +30,7 @@
 
 #include "memdebug.h"
 
-#define UPLOADTHIS "this is the blurb we want to upload\n"
+static const char uploadthis[] = "this is the blurb we want to upload\n";
 
 static size_t t547_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
 {
@@ -43,10 +43,10 @@ static size_t t547_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
   }
   (*counter)++; /* bump */
 
-  if(size * nmemb >= strlen(UPLOADTHIS)) {
+  if(size * nmemb >= sizeof(uploadthis)-1) {
     curl_mfprintf(stderr, "READ!\n");
-    strcpy(ptr, UPLOADTHIS);
-    return strlen(UPLOADTHIS);
+    strcpy(ptr, uploadthis);
+    return sizeof(uploadthis)-1;
   }
   curl_mfprintf(stderr, "READ NOT FINE!\n");
   return 0;
@@ -86,7 +86,7 @@ static CURLcode test_lib547(const char *URL)
   test_setopt(curl, CURLOPT_HEADER, 1L);
   if(testnum == 548) {
     /* set the data to POST with a mere pointer to a null-terminated string */
-    test_setopt(curl, CURLOPT_POSTFIELDS, UPLOADTHIS);
+    test_setopt(curl, CURLOPT_POSTFIELDS, uploadthis);
   }
   else {
     /* 547 style, which means reading the POST data from a callback */
@@ -97,7 +97,7 @@ static CURLcode test_lib547(const char *URL)
     test_setopt(curl, CURLOPT_READDATA, &counter);
     /* We CANNOT do the POST fine without setting the size (or choose
        chunked)! */
-    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(UPLOADTHIS));
+    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)(sizeof(uploadthis)-1));
   }
   test_setopt(curl, CURLOPT_POST, 1L);
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);

--- a/tests/libtest/lib547.c
+++ b/tests/libtest/lib547.c
@@ -31,6 +31,7 @@
 #include "memdebug.h"
 
 static const char t547_uploadthis[] = "this is the blurb we want to upload\n";
+#define T547_DATALEN (sizeof(t547_uploadthis)-1)
 
 static size_t t547_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
 {
@@ -43,10 +44,10 @@ static size_t t547_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
   }
   (*counter)++; /* bump */
 
-  if(size * nmemb >= sizeof(t547_uploadthis)-1) {
+  if(size * nmemb >= T547_DATALEN) {
     curl_mfprintf(stderr, "READ!\n");
     strcpy(ptr, t547_uploadthis);
-    return sizeof(t547_uploadthis)-1;
+    return T547_DATALEN;
   }
   curl_mfprintf(stderr, "READ NOT FINE!\n");
   return 0;
@@ -97,7 +98,7 @@ static CURLcode test_lib547(const char *URL)
     test_setopt(curl, CURLOPT_READDATA, &counter);
     /* We CANNOT do the POST fine without setting the size (or choose
        chunked)! */
-    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)(sizeof(t547_uploadthis)-1));
+    test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)T547_DATALEN);
   }
   test_setopt(curl, CURLOPT_POST, 1L);
   test_setopt(curl, CURLOPT_PROXY, libtest_arg2);

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -93,7 +93,7 @@ static CURLcode test_lib552(const char *URL)
   test_setopt(curl, CURLOPT_POST, 1L);
 
   /* Setup read callback */
-  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long) sizeof(databuf));
+  test_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)sizeof(databuf));
   test_setopt(curl, CURLOPT_READFUNCTION, t552_read_cb);
 
   /* Write callback */

--- a/tests/libtest/lib552.c
+++ b/tests/libtest/lib552.c
@@ -74,8 +74,8 @@ static CURLcode test_lib552(const char *URL)
   size_t i;
   static const char fill[] = "test data";
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 0;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = FALSE;
 
   global_init(CURL_GLOBAL_ALL);
   easy_init(curl);

--- a/tests/libtest/lib554.c
+++ b/tests/libtest/lib554.c
@@ -95,7 +95,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
   }
 
   if(formrc)
-    curl_mprintf("curl_formadd(1) = %d\n", (int)formrc);
+    curl_mprintf("curl_formadd(1) = %d\n", formrc);
 
   /* Now add the same data with another name and make it not look like
      a file upload but still using the callback */
@@ -112,7 +112,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
                         CURLFORM_END);
 
   if(formrc)
-    curl_mprintf("curl_formadd(2) = %d\n", (int)formrc);
+    curl_mprintf("curl_formadd(2) = %d\n", formrc);
 
   /* Fill in the filename field */
   formrc = curl_formadd(&formpost,
@@ -121,7 +121,7 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
                         CURLFORM_COPYCONTENTS, "postit2.c",
                         CURLFORM_END);
   if(formrc)
-    curl_mprintf("curl_formadd(3) = %d\n", (int)formrc);
+    curl_mprintf("curl_formadd(3) = %d\n", formrc);
 
   /* Fill in a submit field too */
   formrc = curl_formadd(&formpost,
@@ -132,17 +132,17 @@ static CURLcode t554_test_once(const char *URL, bool oldstyle)
                         CURLFORM_END);
 
   if(formrc)
-    curl_mprintf("curl_formadd(4) = %d\n", (int)formrc);
+    curl_mprintf("curl_formadd(4) = %d\n", formrc);
 
   formrc = curl_formadd(&formpost, &lastptr,
                         CURLFORM_COPYNAME, "somename",
                         CURLFORM_BUFFER, "somefile.txt",
                         CURLFORM_BUFFERPTR, "blah blah",
-                        CURLFORM_BUFFERLENGTH, (long)9,
+                        CURLFORM_BUFFERLENGTH, 9L,
                         CURLFORM_END);
 
   if(formrc)
-    curl_mprintf("curl_formadd(5) = %d\n", (int)formrc);
+    curl_mprintf("curl_formadd(5) = %d\n", formrc);
 
   curl = curl_easy_init();
   if(!curl) {

--- a/tests/libtest/lib555.c
+++ b/tests/libtest/lib555.c
@@ -35,6 +35,7 @@
 #include "memdebug.h"
 
 static const char t555_uploadthis[] = "this is the blurb we want to upload\n";
+#define T555_DATALEN (sizeof(t555_uploadthis)-1)
 
 static size_t t555_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
 {
@@ -47,10 +48,10 @@ static size_t t555_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
   }
   (*counter)++; /* bump */
 
-  if(size * nmemb >= sizeof(t555_uploadthis)-1) {
+  if(size * nmemb >= T555_DATALEN) {
     curl_mfprintf(stderr, "READ!\n");
     strcpy(ptr, t555_uploadthis);
-    return sizeof(t555_uploadthis)-1;
+    return T555_DATALEN;
   }
   curl_mfprintf(stderr, "READ NOT FINE!\n");
   return 0;
@@ -93,7 +94,7 @@ static CURLcode test_lib555(const char *URL)
   easy_setopt(curl, CURLOPT_READDATA, &counter);
   /* We CANNOT do the POST fine without setting the size (or choose
      chunked)! */
-  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)(sizeof(t555_uploadthis)-1));
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)T555_DATALEN);
 
   easy_setopt(curl, CURLOPT_POST, 1L);
   easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);

--- a/tests/libtest/lib555.c
+++ b/tests/libtest/lib555.c
@@ -34,7 +34,7 @@
 
 #include "memdebug.h"
 
-static const char uploadthis[] = "this is the blurb we want to upload\n";
+static const char t555_uploadthis[] = "this is the blurb we want to upload\n";
 
 static size_t t555_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
 {
@@ -47,10 +47,10 @@ static size_t t555_read_cb(char *ptr, size_t size, size_t nmemb, void *clientp)
   }
   (*counter)++; /* bump */
 
-  if(size * nmemb >= strlen(uploadthis)) {
+  if(size * nmemb >= sizeof(t555_uploadthis)-1) {
     curl_mfprintf(stderr, "READ!\n");
-    strcpy(ptr, uploadthis);
-    return strlen(uploadthis);
+    strcpy(ptr, t555_uploadthis);
+    return sizeof(t555_uploadthis)-1;
   }
   curl_mfprintf(stderr, "READ NOT FINE!\n");
   return 0;
@@ -93,7 +93,7 @@ static CURLcode test_lib555(const char *URL)
   easy_setopt(curl, CURLOPT_READDATA, &counter);
   /* We CANNOT do the POST fine without setting the size (or choose
      chunked)! */
-  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(uploadthis));
+  easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)(sizeof(t555_uploadthis)-1));
 
   easy_setopt(curl, CURLOPT_POST, 1L);
   easy_setopt(curl, CURLOPT_PROXY, libtest_arg2);

--- a/tests/libtest/lib557.c
+++ b/tests/libtest/lib557.c
@@ -45,13 +45,6 @@
 #endif
 
 #define BUFSZ    256
-#define USHORT_TESTS_ARRSZ 1 + 100
-#define SSHORT_TESTS_ARRSZ 1 + 100
-#define UINT_TESTS_ARRSZ   1 + 100
-#define SINT_TESTS_ARRSZ   1 + 100
-#define ULONG_TESTS_ARRSZ  1 + 100
-#define SLONG_TESTS_ARRSZ  1 + 100
-#define COFFT_TESTS_ARRSZ  1 + 100
 
 
 struct unsshort_st {
@@ -103,13 +96,13 @@ struct curloff_st {
 };
 
 
-static struct unsshort_st us_test[USHORT_TESTS_ARRSZ];
-static struct sigshort_st ss_test[SSHORT_TESTS_ARRSZ];
-static struct unsint_st   ui_test[UINT_TESTS_ARRSZ];
-static struct sigint_st   si_test[SINT_TESTS_ARRSZ];
-static struct unslong_st  ul_test[ULONG_TESTS_ARRSZ];
-static struct siglong_st  sl_test[SLONG_TESTS_ARRSZ];
-static struct curloff_st  co_test[COFFT_TESTS_ARRSZ];
+static struct unsshort_st us_test[1 + 100];
+static struct sigshort_st ss_test[1 + 100];
+static struct unsint_st   ui_test[1 + 100];
+static struct sigint_st   si_test[1 + 100];
+static struct unslong_st  ul_test[1 + 100];
+static struct siglong_st  sl_test[1 + 100];
+static struct curloff_st  co_test[1 + 100];
 
 
 static int test_unsigned_short_formatting(void)

--- a/tests/libtest/lib571.c
+++ b/tests/libtest/lib571.c
@@ -62,8 +62,7 @@ static size_t rtp_write(char *ptr, size_t size, size_t nmemb, void *stream)
   curl_mprintf("RTP: message size %d, channel %d\n", message_size, channel);
   if(message_size != coded_size) {
     curl_mprintf("RTP embedded size (%d) does not match "
-                 "the write size (%d).\n",
-                 coded_size, message_size);
+                 "the write size (%d).\n", coded_size, message_size);
     return failure;
   }
 

--- a/tests/libtest/lib573.c
+++ b/tests/libtest/lib573.c
@@ -53,8 +53,8 @@ static CURLcode test_lib573(const char *URL)
   easy_setopt(c, CURLOPT_HEADER, 1L);
   easy_setopt(c, CURLOPT_URL, URL);
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
   easy_setopt(c, CURLOPT_DEBUGDATA, &debug_config);
   easy_setopt(c, CURLOPT_DEBUGFUNCTION, libtest_debug_cb);
   easy_setopt(c, CURLOPT_VERBOSE, 1L);

--- a/tests/libtest/lib574.c
+++ b/tests/libtest/lib574.c
@@ -54,7 +54,7 @@ static CURLcode test_lib574(const char *URL)
   test_setopt(curl, CURLOPT_URL, URL);
   test_setopt(curl, CURLOPT_WILDCARDMATCH, 1L);
   test_setopt(curl, CURLOPT_FNMATCH_FUNCTION, new_fnmatch);
-  test_setopt(curl, CURLOPT_TIMEOUT_MS, (long) TEST_HANG_TIMEOUT);
+  test_setopt(curl, CURLOPT_TIMEOUT_MS, (long)TEST_HANG_TIMEOUT);
 
   res = curl_easy_perform(curl);
   if(res) {

--- a/tests/libtest/lib576.c
+++ b/tests/libtest/lib576.c
@@ -46,7 +46,7 @@ static long chunk_bgn(const void *f, void *ptr, int remains)
       curl_mprintf(" (parsed => %o)", finfo->perm);
     curl_mprintf("\n");
   }
-  curl_mprintf("Size:         %ldB\n", (long)finfo->size);
+  curl_mprintf("Size:         %" CURL_FORMAT_CURL_OFF_T "B\n", finfo->size);
   if(finfo->strings.user)
     curl_mprintf("User:         %s\n", finfo->strings.user);
   if(finfo->strings.group)

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -44,7 +44,7 @@ static void t582_removeFd(struct t582_Sockets *sockets, curl_socket_t fd,
   int i;
 
   if(mention)
-    curl_mfprintf(stderr, "Remove socket fd %d\n", (int) fd);
+    curl_mfprintf(stderr, "Remove socket fd %d\n", (int)fd);
 
   for(i = 0; i < sockets->count; ++i) {
     if(sockets->sockets[i] == fd) {
@@ -66,7 +66,7 @@ static void t582_addFd(struct t582_Sockets *sockets, curl_socket_t fd,
    * To ensure we only have each file descriptor once, we remove it then add
    * it again.
    */
-  curl_mfprintf(stderr, "Add socket fd %d for %s\n", (int) fd, what);
+  curl_mfprintf(stderr, "Add socket fd %d for %s\n", (int)fd, what);
   t582_removeFd(sockets, fd, 0);
   /*
    * Allocate array storage when required.
@@ -153,7 +153,7 @@ static int t582_checkForCompletion(CURLM *curl, int *success)
     }
     else {
       curl_mfprintf(stderr, "Got an unexpected message from curl: %i\n",
-                    (int)message->msg);
+                    message->msg);
       result = 1;
       *success = 0;
     }
@@ -265,7 +265,8 @@ static CURLcode test_lib582(const char *URL)
     fclose(hd_src);
     return TEST_ERR_FSTAT;
   }
-  curl_mfprintf(stderr, "Set to upload %d bytes\n", (int)file_info.st_size);
+  curl_mfprintf(stderr, "Set to upload %" CURL_FORMAT_CURL_OFF_T " bytes\n",
+                (curl_off_t)file_info.st_size);
 
   res_global_init(CURL_GLOBAL_ALL);
   if(res != CURLE_OK) {

--- a/tests/libtest/lib583.c
+++ b/tests/libtest/lib583.c
@@ -70,8 +70,8 @@ static CURLcode test_lib583(const char *URL)
   curl_mfprintf(stderr, "curl_multi_remove_handle()...\n");
   mres = curl_multi_remove_handle(multiHandle, curl);
   if(mres) {
-    curl_mfprintf(stderr, "curl_multi_remove_handle() failed, "
-                  "with code %d\n", (int)mres);
+    curl_mfprintf(stderr, "curl_multi_remove_handle() failed, with code %d\n",
+                  mres);
     res = TEST_ERR_MULTI;
   }
   else

--- a/tests/libtest/lib586.c
+++ b/tests/libtest/lib586.c
@@ -120,7 +120,7 @@ static void *t586_test_fire(void *ptr)
   if(code != CURLE_OK) {
     int i = 0;
     curl_mfprintf(stderr, "perform url '%s' repeat %d failed, curlcode %d\n",
-                  tdata->url, i, (int)code);
+                  tdata->url, i, code);
   }
 
   curl_mprintf("CLEANUP\n");
@@ -236,7 +236,7 @@ test_cleanup:
   scode = curl_share_cleanup(share);
   if(scode != CURLSHE_OK)
     curl_mfprintf(stderr, "curl_share_cleanup failed, code errno %d\n",
-                  (int)scode);
+                  scode);
 
   curl_mprintf("GLOBAL_CLEANUP\n");
   curl_global_cleanup();

--- a/tests/libtest/lib650.c
+++ b/tests/libtest/lib650.c
@@ -82,7 +82,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_CONTENTHEADER, headers,
                         CURLFORM_END);
   if(formrc) {
-    curl_mprintf("curl_formadd(1) = %d\n", (int) formrc);
+    curl_mprintf("curl_formadd(1) = %d\n", formrc);
     goto test_cleanup;
   }
 
@@ -104,7 +104,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_END);
 
   if(formrc) {
-    curl_mprintf("curl_formadd(2) = %d\n", (int) formrc);
+    curl_mprintf("curl_formadd(2) = %d\n", formrc);
     goto test_cleanup;
   }
 
@@ -124,7 +124,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_END);
 
   if(formrc) {
-    curl_mprintf("curl_formadd(3) = %d\n", (int) formrc);
+    curl_mprintf("curl_formadd(3) = %d\n", formrc);
     goto test_cleanup;
   }
 
@@ -135,7 +135,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_FILECONTENT, libtest_arg2,
                         CURLFORM_END);
   if(formrc) {
-    curl_mprintf("curl_formadd(4) = %d\n", (int) formrc);
+    curl_mprintf("curl_formadd(4) = %d\n", formrc);
     goto test_cleanup;
   }
 
@@ -146,7 +146,7 @@ static CURLcode test_lib650(const char *URL)
   curl_formget(formpost, (void *) &formlength, count_chars);
 
   /* Include length in data for external check. */
-  curl_msnprintf(flbuf, sizeof(flbuf), "%lu", (unsigned long) formlength);
+  curl_msnprintf(flbuf, sizeof(flbuf), "%zu", formlength);
 
   formrc = curl_formadd(&formpost,
                         &lastptr,
@@ -155,7 +155,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_END);
 
   if(formrc) {
-    curl_mprintf("curl_formadd(5) = %d\n", (int) formrc);
+    curl_mprintf("curl_formadd(5) = %d\n", formrc);
     goto test_cleanup;
   }
 
@@ -167,7 +167,7 @@ static CURLcode test_lib650(const char *URL)
                         CURLFORM_END);
 
   if(formrc) {
-    curl_mprintf("curl_formadd(6) = %d\n", (int) formrc);
+    curl_mprintf("curl_formadd(6) = %d\n", formrc);
     goto test_cleanup;
   }
 

--- a/tests/libtest/lib651.c
+++ b/tests/libtest/lib651.c
@@ -55,7 +55,7 @@ static CURLcode test_lib651(const char *URL)
                         CURLFORM_COPYCONTENTS, testbuf,
                         CURLFORM_END);
   if(formrc)
-    curl_mprintf("curl_formadd(1) = %d\n", (int) formrc);
+    curl_mprintf("curl_formadd(1) = %d\n", formrc);
 
 
   curl = curl_easy_init();

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -125,8 +125,8 @@ static CURLcode test_lib670(const char *URL)
     res = curl_mime_name(part, testname);
     if(res != CURLE_OK) {
       curl_mfprintf(stderr,
-              "Something went wrong when building the mime structure: %d\n",
-              res);
+                 "Something went wrong when building the mime structure: %d\n",
+                 res);
       goto test_cleanup;
     }
 

--- a/tests/libtest/lib670.c
+++ b/tests/libtest/lib670.c
@@ -147,7 +147,7 @@ static CURLcode test_lib670(const char *URL)
                           CURLFORM_CONTENTLEN, (curl_off_t) 2,
                           CURLFORM_END);
     if(formrc) {
-      curl_mfprintf(stderr, "curl_formadd() = %d\n", (int) formrc);
+      curl_mfprintf(stderr, "curl_formadd() = %d\n", formrc);
       goto test_cleanup;
     }
 

--- a/tests/libtest/lib677.c
+++ b/tests/libtest/lib677.c
@@ -87,7 +87,7 @@ static CURLcode test_lib677(const char *URL)
         }
         else if(ec) {
           curl_mfprintf(stderr, "curl_easy_send() failed, with code %d (%s)\n",
-                        (int)ec, curl_easy_strerror(ec));
+                        ec, curl_easy_strerror(ec));
           res = ec;
           goto test_cleanup;
         }
@@ -108,7 +108,7 @@ static CURLcode test_lib677(const char *URL)
         }
         else if(ec) {
           curl_mfprintf(stderr, "curl_easy_recv() failed, with code %d (%s)\n",
-                        (int)ec, curl_easy_strerror(ec));
+                        ec, curl_easy_strerror(ec));
           res = ec;
           goto test_cleanup;
         }

--- a/tests/libtest/lib753.c
+++ b/tests/libtest/lib753.c
@@ -107,8 +107,8 @@ static CURLcode test_lib753(const char *URL)
 
   start_test_timing();
 
-  debug_config.nohex = 1;
-  debug_config.tracetime = 1;
+  debug_config.nohex = TRUE;
+  debug_config.tracetime = TRUE;
 
   curl_global_init(CURL_GLOBAL_DEFAULT);
 

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -32,7 +32,7 @@ static int    known_offset; /* for test time tracing */
 
 void debug_dump(const char *timebuf, const char *text,
                 FILE *stream, const unsigned char *ptr,
-                size_t size, int nohex)
+                size_t size, bool nohex)
 {
   size_t i;
   size_t c;

--- a/tests/libtest/testtrace.c
+++ b/tests/libtest/testtrace.c
@@ -221,7 +221,7 @@ int cli_debug_cb(CURL *handle, curl_infotype type,
     if(!traced_data) {
       if(!newl)
         log_line_start(output, idsbuf, type);
-      curl_mfprintf(output, "[%ld bytes data]\n", (long)size);
+      curl_mfprintf(output, "[%zu bytes data]\n", size);
       newl = 0;
       traced_data = 1;
     }

--- a/tests/libtest/testtrace.h
+++ b/tests/libtest/testtrace.h
@@ -27,11 +27,11 @@
 
 void debug_dump(const char *timebuf, const char *text,
                 FILE *stream, const unsigned char *ptr,
-                size_t size, int nohex);
+                size_t size, bool nohex);
 
 struct libtest_trace_cfg {
-  int tracetime;  /* 0 represents FALSE, anything else TRUE */
-  int nohex;      /* 0 represents FALSE, anything else TRUE */
+  bool tracetime;
+  bool nohex;
 };
 
 extern struct libtest_trace_cfg debug_config;

--- a/tests/unit/unit1309.c
+++ b/tests/unit/unit1309.c
@@ -39,8 +39,7 @@ static void splayprint(struct Curl_tree *t, int d, char output)
       printf("  ");
 
   if(output) {
-    printf("%ld.%ld[%d]", (long)t->key.tv_sec,
-           (long)t->key.tv_usec, i);
+    printf("%ld.%ld[%d]", (long)t->key.tv_sec, (long)t->key.tv_usec, i);
   }
 
   for(count = 0, node = t->samen; node != t; node = node->samen, count++)


### PR DESCRIPTION
- bump format strings to show the full value, drop casts.
- drop redundant casts (enum → `%d`).
- drop some single-use macros.
- replace `int` with `bool` in testtrace.
