### PR TITLE
schannel: assume `CERT_CHAIN_REVOCATION_CHECK_CHAIN`

### DIFF
--- a/lib/vtls/schannel_int.h
+++ b/lib/vtls/schannel_int.h
@@ -30,8 +30,7 @@
 
 #include "vtls.h"
 
-#if (defined(__MINGW32CE__) || defined(CERT_CHAIN_REVOCATION_CHECK_CHAIN)) && \
-  !defined(CURL_WINDOWS_UWP)
+#ifndef CURL_WINDOWS_UWP
 #define HAS_MANUAL_VERIFY_API
 #endif
 


### PR DESCRIPTION
Always available in supported mingw-w64 and MSVC compilers, except
in UWP mode. For mingw32ce this macro is defined later in the code.

Also available in OpenWatcom 2.
https://github.com/open-watcom/open-watcom-v2/blob/ce6c37eb29f3fda95f9c4e8e37dee866b8c4e496/bld/w32api/include/winerror.mh

---

Tested OK with:
all MSVC: https://ci.appveyor.com/project/curlorg/curl/builds/52489198
all mingw-w64: https://github.com/curl/curl/actions/runs/16633770364/job/47069670599?pr=18039
