### PR TITLE
curl: make --retry-delay and --retry-max-time accept decimal seconds

### DIFF
--- a/docs/cmdline-opts/retry-delay.md
+++ b/docs/cmdline-opts/retry-delay.md
@@ -19,3 +19,9 @@ Make curl sleep this amount of time before each retry when a transfer has
 failed with a transient error (it changes the default backoff time algorithm
 between retries). This option is only interesting if --retry is also
 used. Setting this delay to zero makes curl use the default backoff time.
+
+By default, curl uses an expontentially increasing timeout between retries.
+
+Staring in curl 8.16.0, this option accepts a time as decimal number for parts
+of seconds. The decimal value needs to be provided using a dot (.) as decimal
+separator - not the local version even if it might be using another separator.

--- a/docs/cmdline-opts/retry-max-time.md
+++ b/docs/cmdline-opts/retry-max-time.md
@@ -16,8 +16,12 @@ Example:
 # `--retry-max-time`
 
 The retry timer is reset before the first transfer attempt. Retries are done
-as usual (see --retry) as long as the timer has not reached this given
-limit. Notice that if the timer has not reached the limit, the request is
-made and while performing, it may take longer than this given time period. To
-limit a single request's maximum time, use --max-time. Set this option to zero
-to not timeout retries.
+as usual (see --retry) as long as the timer has not reached this given limit.
+Notice that if the timer has not reached the limit, the request is made and
+while performing, it may take longer than this given time period. To limit a
+single request's maximum time, use --max-time. Set this option to zero to not
+timeout retries.
+
+Staring in curl 8.16.0, this option accepts a time as decimal number for parts
+of seconds. The decimal value needs to be provided using a dot (.) as decimal
+separator - not the local version even if it might be using another separator.

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -212,8 +212,8 @@ struct OperationConfig {
   long httpversion;
   unsigned long socks5_auth;/* auth bitmask for socks5 proxies */
   long req_retry;           /* number of retries */
-  long retry_delay;         /* delay between retries (in seconds) */
-  long retry_maxtime;       /* maximum time to keep retrying */
+  long retry_delay_ms;      /* delay between retries (in milliseconds) */
+  long retry_maxtime_ms;    /* maximum time to keep retrying */
 
   unsigned long mime_options; /* Mime option flags. */
   long tftp_blksize;        /* TFTP BLKSIZE option */

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2344,10 +2344,10 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     err = str2unum(&config->req_retry, nextarg);
     break;
   case C_RETRY_DELAY: /* --retry-delay */
-    err = str2unummax(&config->retry_delay, nextarg, LONG_MAX/1000);
+    err = secs2ms(&config->retry_delay_ms, nextarg);
     break;
   case C_RETRY_MAX_TIME: /* --retry-max-time */
-    err = str2unummax(&config->retry_maxtime, nextarg, LONG_MAX/1000);
+    err = secs2ms(&config->retry_maxtime_ms, nextarg);
     break;
   case C_FTP_ACCOUNT: /* --ftp-account */
     err = getstr(&config->ftp_account, nextarg, DENY_BLANK);


### PR DESCRIPTION
Like other time options already do.

Reported-by: Alice Lee Poetics
Fixes #18109