### PR TITLE
writeout: add %time{}

### DIFF
--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -528,7 +528,7 @@ The year as a decimal number including the century.
 ## `%z`
 
 The `+hhmm` or `-hhmm` numeric timezone (that is, the hour and minute offset
-from UTC). Since ths time is UTC, this always shows `+0000`.
+from UTC). As time is always UTC, this outputs `+0000`.
 
 ## `%Z`
 

--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -532,4 +532,4 @@ from UTC). As time is always UTC, this outputs `+0000`.
 
 ## `%Z`
 
-The timezone name, meaning `UTC`.
+The timezone name. For some reason `GMT`.

--- a/docs/cmdline-opts/write-out.md
+++ b/docs/cmdline-opts/write-out.md
@@ -220,6 +220,10 @@ From this point on, the --write-out output is written to standard output.
 This is the default, but can be used to switch back after switching to stderr.
 (Added in 7.63.0)
 
+## `time{format}`
+Output the current UTC time using `strftime()` format. See TIME OUTPUT FORMAT
+below for details. (Added in 8.16.0)
+
 ## `time_appconnect`
 The time, in seconds, it took from the start until the SSL/SSH/etc
 connect/handshake to the remote host was completed. (Added in 7.19.0)
@@ -347,3 +351,185 @@ The numerical identifier of the last transfer done. -1 if no transfer has been
 started yet for the handle. The transfer id is unique among all transfers
 performed using the same connection cache.
 (Added in 8.2.0)
+
+##
+
+TIME OUTPUT FORMAT
+
+When showing time with `%time{}`, the following output qualifiers are
+available:
+
+## `%a`
+
+The abbreviated name of the day of the week according to the current locale.
+
+## `%A`
+
+The full name of the day of the week according to the current locale.
+
+## `%b`
+
+The abbreviated month name according to the current locale.
+
+## `%B`
+
+The full month name according to the current locale.
+
+## `%c`
+
+The preferred date and time representation for the current locale. (In the
+POSIX locale this is equivalent to %a %b %e %H:%M:%S %Y.)
+
+## `%C`
+
+The century number (year/100) as a 2-digit integer.
+
+## `%d`
+
+The day of the month as a decimal number (range 01 to 31).
+
+## `%D`
+
+Equivalent to %m/%d/%y. In international contexts, this format is ambiguous
+and should be avoided.)
+
+## `%e`
+
+Like %d, the day of the month as a decimal number, but a leading zero is
+replaced by a space.
+
+## `%f`
+
+The number of microseconds elapsed of the current second. (This a curl special
+code and not a standard one.)
+
+## `%F`
+
+Equivalent to %Y-%m-%d (the ISO 8601 date format).
+
+## `%G`
+
+The ISO 8601 week-based year with century as a decimal number. The 4-digit
+year corresponding to the ISO week number (see %V). This has the same format
+and value as %Y, except that if the ISO week number belongs to the previous or
+next year, that year is used instead.
+
+## `%g`
+
+Like `%G`, but without century, that is, with a 2-digit year (00-99).
+
+## `%h`
+
+Equivalent to `%b`.
+
+## `%H`
+
+The hour as a decimal number using a 24-hour clock (range 00 to 23).
+
+## `%I`
+
+The hour as a decimal number using a 12-hour clock (range 01 to 12).
+
+## `%j`
+
+The day of the year as a decimal number (range 001 to 366).
+
+## `%k`
+
+The hour (24-hour clock) as a decimal number (range 0 to 23); single digits
+are preceded by a blank.
+
+## `%l`
+
+The hour (12-hour clock) as a decimal number (range 1 to 12); single digits
+are preceded by a blank.
+
+## `%m`
+
+The month as a decimal number (range 01 to 12).
+
+## `%M`
+
+The minute as a decimal number (range 00 to 59).
+
+## `%p`
+
+Either "AM" or "PM" according to the given time value, or the corresponding
+strings for the current locale. Noon is treated as "PM" and midnight as "AM".
+
+## `%P`
+
+Like %p but in lowercase: "am" or "pm" or a corresponding string for the
+current locale.
+
+## `%r`
+
+The time in am or pm notation.
+
+## `%R`
+
+The time in 24-hour notation (%H:%M). For a version including the seconds, see
+`%T` below.
+
+## `%s`
+
+The number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
+
+## `%S`
+
+The second as a decimal number (range 00 to 60). (The range is up to 60 to
+allow for occasional leap seconds.)
+
+## `%T`
+
+The time in 24-hour notation (%H:%M:%S).
+
+## `%u`
+
+The day of the week as a decimal, range 1 to 7, Monday being 1.
+
+## `%U`
+
+The week number of the current year as a decimal number, range 00 to 53,
+starting with the first Sunday as the first day of week 01. See also `%V` and
+`%W`.
+
+## `%V`
+
+The ISO 8601 week number (see NOTES) of the current year as a decimal number,
+range 01 to 53, where week 1 is the first week that has at least 4 days in the
+new year. See also `%U` and `%W`.
+
+## `%w`
+
+The day of the week as a decimal, range 0 to 6, Sunday being 0. See also `%u`.
+
+## `%W`
+
+The week number of the current year as a decimal number, range 00 to 53,
+starting with the first Monday as the first day of week 01.
+
+## `%x`
+
+The preferred date representation for the current locale without the time.
+
+## `%X`
+
+The preferred time representation for the current locale without the date.
+
+## `%y`
+
+The year as a decimal number without a century (range 00 to 99).
+
+## `%Y`
+
+The year as a decimal number including the century.
+
+## `%z`
+
+The `+hhmm` or `-hhmm` numeric timezone (that is, the hour and minute offset
+from UTC). Since ths time is UTC, this always shows `+0000`.
+
+## `%Z`
+
+The timezone name, meaning `UTC`.

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -571,11 +571,9 @@ static const char *outtime(const char *ptr, /* %time{ ... */
       const char *timestr = getenv("CURL_TIME");
       if(timestr) {
         curl_off_t val;
-        unsigned int usecs;
         curlx_str_number(&timestr, &val, TIME_T_MAX);
         cnow.tv_sec = (time_t)val;
-        usecs = (unsigned int)(val % 1000000);
-        cnow.tv_usec = usecs;
+        cnow.tv_usec = (unsigned int)(val % 1000000);
       }
     }
 #endif

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -571,9 +571,11 @@ static const char *outtime(const char *ptr, /* %time{ ... */
       const char *timestr = getenv("CURL_TIME");
       if(timestr) {
         curl_off_t val;
+        unsigned int usecs;
         curlx_str_number(&timestr, &val, TIME_T_MAX);
         cnow.tv_sec = (time_t)val;
-        cnow.tv_usec = (unsigned int)(val % 1000000);
+        usecs = (unsigned int)(val % 1000000);
+        cnow.tv_usec = usecs;
       }
     }
 #endif

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -585,11 +585,14 @@ static const char *outtime(const char *ptr, /* %time{ ... */
 
     /* insert sub-seconds for %f */
     /* insert +0000 for %z because it is otherwise not portable */
+    /* insert UTC for %Z because it is otherwise not portable */
     for(i = 0; !result && i < vlen; i++) {
       if((i < vlen - 1) && ptr[i] == '%' &&
-         ((ptr[i + 1] == 'f') || (ptr[i + 1] == 'z'))) {
+         ((ptr[i + 1] == 'f') || ((ptr[i + 1] | 0x20) == 'z'))) {
         if(ptr[i + 1] == 'f')
           result = curlx_dyn_addf(&format, "%06u", usecs);
+        else if(ptr[i + 1] == 'Z')
+          result = curlx_dyn_addn(&format, "UTC", 3);
         else
           result = curlx_dyn_addn(&format, "+0000", 5);
         i++;

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -572,7 +572,7 @@ static const char *outtime(const char *ptr, /* %time{ ... */
       if(timestr) {
         curl_off_t val;
         curlx_str_number(&timestr, &val, TIME_T_MAX);
-#ifdef SIZEOF_TIME_T < 5
+#if SIZEOF_TIME_T < 5
         cnow.tv_sec = (time_t)(val & 0xffffffff);
 #else
         cnow.tv_sec = (time_t)val;

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -573,7 +573,7 @@ static const char *outtime(const char *ptr, /* %time{ ... */
         curl_off_t val;
         curlx_str_number(&timestr, &val, TIME_T_MAX);
         cnow.tv_sec = (time_t)val;
-        cnow.tv_usec = val % 1000000;
+        cnow.tv_usec = (unsigned int)(val % 1000000);
       }
     }
 #endif

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -572,7 +572,7 @@ static const char *outtime(const char *ptr, /* %time{ ... */
       if(timestr) {
         curl_off_t val;
         curlx_str_number(&timestr, &val, TIME_T_MAX);
-        cnow.tv_sec = (time_t)val;
+        cnow.tv_sec = (val < TIME_T_MAX) ? (time_t)val : TIME_T_MAX;
         cnow.tv_usec = (unsigned int)(val % 1000000);
       }
     }

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -584,13 +584,18 @@ static const char *outtime(const char *ptr, /* %time{ ... */
     curlx_dyn_init(&format, 1024);
 
     /* insert sub-seconds for %f */
+    /* insert +0000 for %z because it is otherwise not portable */
     for(i = 0; !result && i < vlen; i++) {
-      if((i < vlen - 1) && ptr[i] == '%' && ptr[i + 1] == 'f') {
-        result = curlx_dyn_addf(&format, "%06u", usecs);
+      if((i < vlen - 1) && ptr[i] == '%' &&
+         ((ptr[i + 1] == 'f') || (ptr[i + 1] == 'z'))) {
+        if(ptr[i + 1] == 'f')
+          result = curlx_dyn_addf(&format, "%06u", usecs);
+        else
+          result = curlx_dyn_addn(&format, "+0000", 5);
         i++;
-        continue;
       }
-      result = curlx_dyn_addn(&format, &ptr[i], 1);
+      else
+        result = curlx_dyn_addn(&format, &ptr[i], 1);
     }
     if(!result) {
       /* !checksrc! disable BANNEDFUNC 1 */

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -572,7 +572,11 @@ static const char *outtime(const char *ptr, /* %time{ ... */
       if(timestr) {
         curl_off_t val;
         curlx_str_number(&timestr, &val, TIME_T_MAX);
-        cnow.tv_sec = (val < TIME_T_MAX) ? (time_t)val : TIME_T_MAX;
+#ifdef SIZEOF_TIME_T < 5
+        cnow.tv_sec = (time_t)(val & 0xffffffff);
+#else
+        cnow.tv_sec = (time_t)val;
+#endif
         cnow.tv_usec = (unsigned int)(val % 1000000);
       }
     }

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -238,7 +238,7 @@ test1933 test1934 test1935 test1936 test1937 test1938 test1939 test1940 \
 test1941 test1942 test1943 test1944 test1945 test1946 test1947 test1948 \
 test1955 test1956 test1957 test1958 test1959 test1960 test1964 \
 test1970 test1971 test1972 test1973 test1974 test1975 test1976 test1977 \
-test1978 test1979 test1980 \
+test1978 test1979 test1980 test1981 \
 \
 test2000 test2001 test2002 test2003 test2004 test2005 \
 \

--- a/tests/data/test1981
+++ b/tests/data/test1981
@@ -56,7 +56,7 @@ Accept: */*
 
 </protocol>
 <stdout mode="text">
-Time: 01/Aug/2025 08:31:43.037103 +0000 GMT
+Time: 01/Aug/2025 08:31:43.037103 +0000 UTC
 </stdout>
 </verify>
 </testcase>

--- a/tests/data/test1981
+++ b/tests/data/test1981
@@ -38,10 +38,10 @@ http
 Debug
 </features>
 <setenv>
-CURL_TIME=1754037100
+CURL_TIME=1754037103
 </setenv>
 <command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER --write-out='Time: %time{%d/%b/%Y %H:%M:%S.%f %z}\n' -s -o %LOGDIR/dump
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --write-out='Time: %time{%d/%b/%Y %H:%M:%S.%f %z %Z}\n' -s -o %LOGDIR/dump
 </command>
 </client>
 
@@ -56,7 +56,7 @@ Accept: */*
 
 </protocol>
 <stdout mode="text">
-Time: 01/Aug/2025 08:31:40.037100 +0000
+Time: 01/Aug/2025 08:31:43.037103 +0000 GMT
 </stdout>
 </verify>
 </testcase>

--- a/tests/data/test1981
+++ b/tests/data/test1981
@@ -1,0 +1,62 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+</keywords>
+</info>
+
+#
+# Server-side
+<reply>
+<data crlf="yes" nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Tue, 13 Jun 2000 12:10:00 GMT
+ETag: "21025-dc7-39462498"
+Accept-Ranges: bytes
+Content-Length: 6
+Connection: close
+Content-Type: text/html
+Funny-head: yesyes
+
+-foo-
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+%time output with --write-out
+</name>
+<features>
+Debug
+</features>
+<setenv>
+CURL_TIME=1754037100
+</setenv>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER --write-out='Time: %time{%d/%b/%Y %H:%M:%S.%f %z}\n' -s -o %LOGDIR/dump
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol crlf="yes">
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<stdout mode="text">
+Time: 01/Aug/2025 08:31:40.037100 +0000
+</stdout>
+</verify>
+</testcase>

--- a/tests/test1486.pl
+++ b/tests/test1486.pl
@@ -54,11 +54,22 @@ sub getsrcvars {
     close($f);
 }
 
+my %special = (
+    'header{name}' => 1,
+    'output{filename}' => 1,
+    'time{format}' => 1,
+    );
+
 sub getdocsvars {
     open(my $f, "<", "$root/../docs/cmdline-opts/write-out.md");
     while(<$f>) {
-        if($_ =~ /^\#\# \`([^\`]*)\`/) {
-            if($1 ne "header{name}" && $1 ne "output{filename}") {
+        chomp;
+        $_ =~ s/[\r\n]//g;
+        if($_ =~ /^\#\# *\z/) {
+            last;
+        }
+        elsif($_ =~ /^\#\# \`([^\`]*)\`/) {
+            if(!$special{$1}) {
                 $indocs{$1} = 1;
             }
         }


### PR DESCRIPTION
Output the current UTC time using strftime format. `%f` is an extra curl specific flag to output the microsecond fraction of the current second.

## TODO

- [X] decide if we want this at all
- [X] is the strftime good enough?
- [X] add test case to verify functionality
- [X] %z works in a portable fashion
- [X] %Z works in a portable fashion
- [X] check `curl -h -w` with this PR as it shows a formatting error not seen in the man page =>  #18139