### PR TITLE
pytest: test very long urls

### DIFF
--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1024,6 +1024,7 @@ static CURLcode h3_open_stream(struct Curl_cfilter *cf,
 
   stream3_id = quiche_h3_send_request(ctx->h3c, ctx->qconn, nva, nheader,
                                       stream->send_closed);
+  CURL_TRC_CF(data, cf, "quiche_send_request() -> %" FMT_PRIu64, stream3_id);
   if(stream3_id < 0) {
     if(QUICHE_H3_ERR_STREAM_BLOCKED == stream3_id) {
       /* quiche seems to report this error if the connection window is

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -761,8 +761,8 @@ class TestDownload:
         if proto == 'h3' and env.curl_uses_lib('quiche'):
             pytest.skip("quiche fails from 16k onwards")
         curl = CurlClient(env=env)
-        url = f'https://{env.authority_for(env.domain1, proto)}/data.json?'
-        url += 'x'*(url_junk)  # url is now longer than 'url_len'
+        # url is longer than 'url_len'
+        url = f'https://{env.authority_for(env.domain1, proto)}/data.json?{"x"*(url_junk)}'
         r = curl.http_download(urls=[url], alpn_proto=proto)
         if url_junk <= 1024:
             r.check_exit_code(0)

--- a/tests/http/test_02_download.py
+++ b/tests/http/test_02_download.py
@@ -758,6 +758,8 @@ class TestDownload:
     def test_02_36_looong_urls(self, env: Env, httpd, nghttpx, proto, url_junk):
         if proto == 'h3' and not env.have_h3():
             pytest.skip("h3 not supported")
+        if proto == 'h3' and env.curl_uses_lib('quiche'):
+            pytest.skip("quiche fails from 16k onwards")
         curl = CurlClient(env=env)
         url = f'https://{env.authority_for(env.domain1, proto)}/data.json?'
         url += 'x'*(url_junk)  # url is now longer than 'url_len'


### PR DESCRIPTION
test_02_36 tests h1/h2/h3 with urls longer than 1/16/32/64K.

Protocols behave the same until the size exceed 64k when h2 frame limits bite and h3 exhibits a different http status.

refs #18121