### PR TITLE
docs: add CURLOPT type change history, drop casts where present

### DIFF
--- a/.github/scripts/spellcheck.words
+++ b/.github/scripts/spellcheck.words
@@ -230,6 +230,7 @@ else's
 encodings
 enctype
 endianness
+enums
 Engler
 enum
 epoll

--- a/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
+++ b/docs/libcurl/opts/CURLINFO_CONDITION_UNMET.md
@@ -54,8 +54,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_TIMEVALUE, 1577833200L);
 
     /* If-Modified-Since the above time stamp */
-    curl_easy_setopt(curl, CURLOPT_TIMECONDITION,
-                     (long)CURL_TIMECOND_IFMODSINCE);
+    curl_easy_setopt(curl, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
 
     /* Perform the request */
     res = curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -69,7 +69,7 @@ int main(void)
 
 # HISTORY
 
-CURLALTSVC_\* macros became `long` types in 8.16.0, prior to this version
+`CURLALTSVC_*` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # FILE FORMAT

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -69,7 +69,7 @@ int main(void)
 
 # HISTORY
 
-`CURLALTSVC_...` macros became `long` types in 8.16.0, prior to this version
+`CURLALTSVC_*` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # FILE FORMAT

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -70,7 +70,7 @@ int main(void)
 # HISTORY
 
 **CURLALTSVC_*** macros became `long` types in 8.16.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # FILE FORMAT
 

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -69,7 +69,7 @@ int main(void)
 
 # HISTORY
 
-`CURLALTSVC_*` macros became `long` types in 8.16.0, prior to this version
+`CURLALTSVC_...` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # FILE FORMAT

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -69,7 +69,7 @@ int main(void)
 
 # HISTORY
 
-`CURLALTSVC_*` macros became `long` types in 8.16.0, prior to this version
+**CURLALTSVC_*** macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # FILE FORMAT

--- a/docs/libcurl/opts/CURLOPT_ALTSVC.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC.md
@@ -60,12 +60,17 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
-    curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, (long)CURLALTSVC_H1);
+    curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, CURLALTSVC_H1);
     curl_easy_setopt(curl, CURLOPT_ALTSVC, "altsvc-cache.txt");
     curl_easy_perform(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURLALTSVC_\* macros became `long` types in 8.16.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # FILE FORMAT
 

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -84,12 +84,17 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
-    curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, (long)CURLALTSVC_H1);
+    curl_easy_setopt(curl, CURLOPT_ALTSVC_CTRL, CURLALTSVC_H1);
     curl_easy_setopt(curl, CURLOPT_ALTSVC, "altsvc-cache.txt");
     curl_easy_perform(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURLALTSVC_\* macros became `long` types in 8.16.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -94,7 +94,7 @@ int main(void)
 # HISTORY
 
 **CURLALTSVC_*** macros became `long` types in 8.16.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -93,7 +93,7 @@ int main(void)
 
 # HISTORY
 
-CURLALTSVC_\* macros became `long` types in 8.16.0, prior to this version
+`CURLALTSVC_*` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -93,7 +93,7 @@ int main(void)
 
 # HISTORY
 
-`CURLALTSVC_*` macros became `long` types in 8.16.0, prior to this version
+`CURLALTSVC_...` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -22,10 +22,10 @@ CURLOPT_ALTSVC_CTRL - control alt-svc behavior
 ~~~c
 #include <curl/curl.h>
 
-#define CURLALTSVC_READONLYFILE (1<<2)
-#define CURLALTSVC_H1           (1<<3)
-#define CURLALTSVC_H2           (1<<4)
-#define CURLALTSVC_H3           (1<<5)
+#define CURLALTSVC_READONLYFILE (1L<<2)
+#define CURLALTSVC_H1           (1L<<3)
+#define CURLALTSVC_H2           (1L<<4)
+#define CURLALTSVC_H3           (1L<<5)
 
 CURLcode curl_easy_setopt(CURL *handle, CURLOPT_ALTSVC_CTRL, long bitmask);
 ~~~

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -93,7 +93,7 @@ int main(void)
 
 # HISTORY
 
-`CURLALTSVC_...` macros became `long` types in 8.16.0, prior to this version
+`CURLALTSVC_*` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_ALTSVC_CTRL.md
@@ -93,7 +93,7 @@ int main(void)
 
 # HISTORY
 
-`CURLALTSVC_*` macros became `long` types in 8.16.0, prior to this version
+**CURLALTSVC_*** macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
@@ -70,7 +70,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTPAUTH_...` enums became `long` types in 8.16.0, prior to this version
+`CURLFTPAUTH_*` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
@@ -70,7 +70,7 @@ int main(void)
 
 # HISTORY
 
-CURLFTPAUTH_\* enums became `long` types in 8.16.0, prior to this version
+`CURLFTPAUTH_*` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
@@ -71,7 +71,7 @@ int main(void)
 # HISTORY
 
 **CURLFTPAUTH_*** enums became `long` types in 8.16.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
@@ -70,7 +70,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTPAUTH_*` enums became `long` types in 8.16.0, prior to this version
+`CURLFTPAUTH_...` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
@@ -70,7 +70,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTPAUTH_*` enums became `long` types in 8.16.0, prior to this version
+**CURLFTPAUTH_*** enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_FTPSSLAUTH.md
@@ -61,12 +61,17 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/file.txt");
     curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_TRY);
     /* funny server, ask for SSL before TLS */
-    curl_easy_setopt(curl, CURLOPT_FTPSSLAUTH, (long)CURLFTPAUTH_SSL);
+    curl_easy_setopt(curl, CURLOPT_FTPSSLAUTH, CURLFTPAUTH_SSL);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURLFTPAUTH_\* enums became `long` types in 8.16.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
@@ -78,7 +78,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTP_CREATE_...` enums became `long` types in 8.16.0, prior to this version
+**CURLFTP_CREATE_*** enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
@@ -79,7 +79,7 @@ int main(void)
 # HISTORY
 
 **CURLFTP_CREATE_*** enums became `long` types in 8.16.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
@@ -67,7 +67,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL,
                      "ftp://example.com/non-existing/new.txt");
     curl_easy_setopt(curl, CURLOPT_FTP_CREATE_MISSING_DIRS,
-                     (long)CURLFTP_CREATE_DIR_RETRY);
+                     CURLFTP_CREATE_DIR_RETRY);
 
     res = curl_easy_perform(curl);
 
@@ -75,6 +75,11 @@ int main(void)
   }
 }
 ~~~
+
+# HISTORY
+
+CURLFTP_CREATE_\* enums became `long` types in 8.16.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
@@ -78,7 +78,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTP_CREATE_*` enums became `long` types in 8.16.0, prior to this version
+`CURLFTP_CREATE_...` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_CREATE_MISSING_DIRS.md
@@ -78,7 +78,7 @@ int main(void)
 
 # HISTORY
 
-CURLFTP_CREATE_\* enums became `long` types in 8.16.0, prior to this version
+`CURLFTP_CREATE_*` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
@@ -79,7 +79,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTPMETHOD_*` enums became `long` types in 8.16.0, prior to this version
+**CURLFTPMETHOD_*** enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
@@ -80,7 +80,7 @@ int main(void)
 # HISTORY
 
 **CURLFTPMETHOD_*** enums became `long` types in 8.16.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
@@ -79,7 +79,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTPMETHOD_*` enums became `long` types in 8.16.0, prior to this version
+`CURLFTPMETHOD_...` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
@@ -79,7 +79,7 @@ int main(void)
 
 # HISTORY
 
-CURLFTPMETHOD_\* enums became `long` types in 8.16.0, prior to this version
+`CURLFTPMETHOD_*` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
@@ -79,7 +79,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTPMETHOD_...` enums became `long` types in 8.16.0, prior to this version
+`CURLFTPMETHOD_*` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_FILEMETHOD.md
@@ -68,8 +68,7 @@ int main(void)
   if(curl) {
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/1/2/3/4/new.txt");
-    curl_easy_setopt(curl, CURLOPT_FTP_FILEMETHOD,
-                     (long)CURLFTPMETHOD_SINGLECWD);
+    curl_easy_setopt(curl, CURLOPT_FTP_FILEMETHOD, CURLFTPMETHOD_SINGLECWD);
 
     res = curl_easy_perform(curl);
 
@@ -77,6 +76,11 @@ int main(void)
   }
 }
 ~~~
+
+# HISTORY
+
+CURLFTPMETHOD_\* enums became `long` types in 8.16.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
@@ -72,7 +72,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTPSSL_...` enums became `long` types in 8.16.0, prior to this version
+`CURLFTPSSL_*` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
@@ -72,7 +72,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTPSSL_*` enums became `long` types in 8.16.0, prior to this version
+`CURLFTPSSL_...` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
@@ -72,7 +72,7 @@ int main(void)
 
 # HISTORY
 
-CURLFTPSSL_\* enums became `long` types in 8.16.0, prior to this version
+`CURLFTPSSL_*` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
@@ -63,12 +63,17 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/file.txt");
     curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_CONTROL);
     /* go back to clear-text FTP after authenticating */
-    curl_easy_setopt(curl, CURLOPT_FTP_SSL_CCC, (long)CURLFTPSSL_CCC_ACTIVE);
+    curl_easy_setopt(curl, CURLOPT_FTP_SSL_CCC, CURLFTPSSL_CCC_ACTIVE);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURLFTPSSL_\* enums became `long` types in 8.16.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
@@ -73,7 +73,7 @@ int main(void)
 # HISTORY
 
 **CURLFTPSSL_*** enums became `long` types in 8.16.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
+++ b/docs/libcurl/opts/CURLOPT_FTP_SSL_CCC.md
@@ -72,7 +72,7 @@ int main(void)
 
 # HISTORY
 
-`CURLFTPSSL_*` enums became `long` types in 8.16.0, prior to this version
+**CURLFTPSSL_*** enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.md
+++ b/docs/libcurl/opts/CURLOPT_GSSAPI_DELEGATION.md
@@ -51,11 +51,16 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     /* delegate if okayed by policy */
     curl_easy_setopt(curl, CURLOPT_GSSAPI_DELEGATION,
-                     (long)CURLGSSAPI_DELEGATION_POLICY_FLAG);
+                     CURLGSSAPI_DELEGATION_POLICY_FLAG);
     ret = curl_easy_perform(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+**CURLGSSAPI_DELEGATION_*** macros became `long` types in 8.16.0, prior to this
+version a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -75,7 +75,7 @@ int main(void)
 
 # HISTORY
 
-`CURLHEADER_...` macros became `long` types in 8.16.0, prior to this version
+`CURLHEADER_*` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -65,13 +65,18 @@ int main(void)
     /* HTTPS over a proxy makes a separate CONNECT to the proxy, so tell
        libcurl to not send the custom headers to the proxy. Keep them
        separate. */
-    curl_easy_setopt(curl, CURLOPT_HEADEROPT, (long)CURLHEADER_SEPARATE);
+    curl_easy_setopt(curl, CURLOPT_HEADEROPT, CURLHEADER_SEPARATE);
     ret = curl_easy_perform(curl);
     curl_slist_free_all(list);
     curl_easy_cleanup(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURLHEADER_\* macros became `long` types in 8.16.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -75,7 +75,7 @@ int main(void)
 
 # HISTORY
 
-CURLHEADER_\* macros became `long` types in 8.16.0, prior to this version
+`CURLHEADER_*` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -76,7 +76,7 @@ int main(void)
 # HISTORY
 
 **CURLHEADER_*** macros became `long` types in 8.16.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -75,7 +75,7 @@ int main(void)
 
 # HISTORY
 
-`CURLHEADER_*` macros became `long` types in 8.16.0, prior to this version
+`CURLHEADER_...` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_HEADEROPT.md
+++ b/docs/libcurl/opts/CURLOPT_HEADEROPT.md
@@ -75,7 +75,7 @@ int main(void)
 
 # HISTORY
 
-`CURLHEADER_*` macros became `long` types in 8.16.0, prior to this version
+**CURLHEADER_*** macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_HSTS_CTRL.md
+++ b/docs/libcurl/opts/CURLOPT_HSTS_CTRL.md
@@ -64,7 +64,7 @@ int main(void)
 {
   CURL *curl = curl_easy_init();
   if(curl) {
-    curl_easy_setopt(curl, CURLOPT_HSTS_CTRL, (long)CURLHSTS_ENABLE);
+    curl_easy_setopt(curl, CURLOPT_HSTS_CTRL, CURLHSTS_ENABLE);
     curl_easy_perform(curl);
   }
 }

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -152,7 +152,7 @@ CURLAUTH_ONLY was added in 7.21.3
 
 CURLAUTH_NTLM_WB was added in 7.22.0
 
-`CURLAUTH_...` macros became `long` types in 7.26.0, prior to this version
+`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 CURLAUTH_BEARER was added in 7.61.0

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -152,7 +152,7 @@ CURLAUTH_ONLY was added in 7.21.3
 
 CURLAUTH_NTLM_WB was added in 7.22.0
 
-CURLAUTH_\* macros became `long` types in 7.26.0, prior to this version
+`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 CURLAUTH_BEARER was added in 7.61.0

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -137,7 +137,7 @@ int main(void)
     CURLcode ret;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     /* allow whatever auth the server speaks */
-    curl_easy_setopt(curl, CURLOPT_HTTPAUTH, (long)CURLAUTH_ANY);
+    curl_easy_setopt(curl, CURLOPT_HTTPAUTH, CURLAUTH_ANY);
     curl_easy_setopt(curl, CURLOPT_USERPWD, "james:bond");
     ret = curl_easy_perform(curl);
   }
@@ -151,6 +151,9 @@ CURLAUTH_DIGEST_IE was added in 7.19.3
 CURLAUTH_ONLY was added in 7.21.3
 
 CURLAUTH_NTLM_WB was added in 7.22.0
+
+CURLAUTH_\* macros became `long` types in 7.26.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 CURLAUTH_BEARER was added in 7.61.0
 

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -152,7 +152,7 @@ CURLAUTH_ONLY was added in 7.21.3
 
 CURLAUTH_NTLM_WB was added in 7.22.0
 
-`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
+`CURLAUTH_...` macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 CURLAUTH_BEARER was added in 7.61.0

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -152,7 +152,7 @@ CURLAUTH_ONLY was added in 7.21.3
 
 CURLAUTH_NTLM_WB was added in 7.22.0
 
-`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
+**CURLAUTH_*** macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 CURLAUTH_BEARER was added in 7.61.0

--- a/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_HTTPAUTH.md
@@ -153,7 +153,7 @@ CURLAUTH_ONLY was added in 7.21.3
 CURLAUTH_NTLM_WB was added in 7.22.0
 
 **CURLAUTH_*** macros became `long` types in 7.26.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 CURLAUTH_BEARER was added in 7.61.0
 

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -117,7 +117,7 @@ int main(void)
 # HISTORY
 
 **CURL_HTTP_VERSION_*** enums became `long` types in 8.13.0, prior to this
-version a `long` cast is necessary when passing to curl_easy_setopt(3).
+version a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -116,7 +116,7 @@ int main(void)
 
 # HISTORY
 
-CURL_HTTP_VERSION_\* enums became `long` types in 8.13.0, prior to this version
+`CURL_HTTP_VERSION_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -116,8 +116,8 @@ int main(void)
 
 # HISTORY
 
-`CURL_HTTP_VERSION_*` enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+**CURL_HTTP_VERSION_*** enums became `long` types in 8.13.0, prior to this
+version a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -116,8 +116,8 @@ int main(void)
 
 # HISTORY
 
-`CURL_HTTP_VERSION_...` enums became `long` types in 8.13.0, prior to this
-version a `long` cast is necessary when passing to curl_easy_setopt(3).
+`CURL_HTTP_VERSION_*` enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -105,7 +105,7 @@ int main(void)
   if(curl) {
     CURLcode ret;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
-    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, (long)CURL_HTTP_VERSION_2TLS);
+    curl_easy_setopt(curl, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_2TLS);
     ret = curl_easy_perform(curl);
     if(ret == CURLE_HTTP_RETURNED_ERROR) {
       /* an HTTP response error problem */
@@ -113,6 +113,11 @@ int main(void)
   }
 }
 ~~~
+
+# HISTORY
+
+CURL_HTTP_VERSION_\* enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
+++ b/docs/libcurl/opts/CURLOPT_HTTP_VERSION.md
@@ -116,8 +116,8 @@ int main(void)
 
 # HISTORY
 
-`CURL_HTTP_VERSION_*` enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+`CURL_HTTP_VERSION_...` enums became `long` types in 8.13.0, prior to this
+version a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -78,7 +78,7 @@ int main(void)
 # HISTORY
 
 **CURL_IPRESOLVE_*** macros became `long` types in 8.15.0, before this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -66,7 +66,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/foo.bin");
 
     /* of all addresses example.com resolves to, only IPv6 ones are used */
-    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, (long)CURL_IPRESOLVE_V6);
+    curl_easy_setopt(curl, CURLOPT_IPRESOLVE, CURL_IPRESOLVE_V6);
 
     res = curl_easy_perform(curl);
 
@@ -74,6 +74,11 @@ int main(void)
   }
 }
 ~~~
+
+# HISTORY
+
+CURL_IPRESOLVE_\* macros became `long` types in 8.15.0, before this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -77,7 +77,7 @@ int main(void)
 
 # HISTORY
 
-CURL_IPRESOLVE_\* macros became `long` types in 8.15.0, before this version
+`CURL_IPRESOLVE_*` macros became `long` types in 8.15.0, before this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -77,7 +77,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_IPRESOLVE_...` macros became `long` types in 8.15.0, before this version
+`CURL_IPRESOLVE_*` macros became `long` types in 8.15.0, before this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -77,7 +77,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_IPRESOLVE_*` macros became `long` types in 8.15.0, before this version
+**CURL_IPRESOLVE_*** macros became `long` types in 8.15.0, before this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
+++ b/docs/libcurl/opts/CURLOPT_IPRESOLVE.md
@@ -77,7 +77,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_IPRESOLVE_*` macros became `long` types in 8.15.0, before this version
+`CURL_IPRESOLVE_...` macros became `long` types in 8.15.0, before this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_MIME_OPTIONS.md
@@ -69,7 +69,7 @@ int main(void)
 
   if(curl) {
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
-    curl_easy_setopt(curl, CURLOPT_MIME_OPTIONS, (long)CURLMIMEOPT_FORMESCAPE);
+    curl_easy_setopt(curl, CURLOPT_MIME_OPTIONS, CURLMIMEOPT_FORMESCAPE);
 
     form = curl_mime_init(curl);
     if(form) {
@@ -90,6 +90,11 @@ int main(void)
   }
 }
 ~~~
+
+# HISTORY
+
+**CURLMIMEOPT_FORMESCAPE** macro became `long` type in 8.16.0, prior to this
+version a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -141,7 +141,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_NETRC_*` enums became `long` types in 8.13.0, prior to this version
+`CURL_NETRC_...` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -141,7 +141,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_NETRC_*` enums became `long` types in 8.13.0, prior to this version
+**CURL_NETRC_*** enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -141,7 +141,7 @@ int main(void)
 
 # HISTORY
 
-CURL_NETRC_\* enums became `long` types in 8.13.0, prior to this version
+`CURL_NETRC_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -141,7 +141,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_NETRC_...` enums became `long` types in 8.13.0, prior to this version
+`CURL_NETRC_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -139,6 +139,11 @@ int main(void)
 }
 ~~~
 
+# HISTORY
+
+CURL_NETRC_\* enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
+
 # %AVAILABILITY%
 
 # RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_NETRC.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC.md
@@ -142,7 +142,7 @@ int main(void)
 # HISTORY
 
 **CURL_NETRC_*** enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
@@ -63,7 +63,7 @@ int main(void)
 # HISTORY
 
 **CURL_NETRC_*** enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
@@ -62,7 +62,7 @@ int main(void)
 
 # HISTORY
 
-CURL_NETRC_\* enums became `long` types in 8.13.0, prior to this version
+`CURL_NETRC_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
@@ -62,7 +62,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_NETRC_*` enums became `long` types in 8.13.0, prior to this version
+**CURL_NETRC_*** enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
@@ -62,7 +62,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_NETRC_...` enums became `long` types in 8.13.0, prior to this version
+`CURL_NETRC_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
@@ -60,6 +60,11 @@ int main(void)
 }
 ~~~
 
+# HISTORY
+
+CURL_NETRC_\* enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
+
 # %AVAILABILITY%
 
 # RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
+++ b/docs/libcurl/opts/CURLOPT_NETRC_FILE.md
@@ -62,7 +62,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_NETRC_*` enums became `long` types in 8.13.0, prior to this version
+`CURL_NETRC_...` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.md
+++ b/docs/libcurl/opts/CURLOPT_POSTFIELDSIZE.md
@@ -54,7 +54,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* size of the POST data */
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long) strlen(data));
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, (long)strlen(data));
 
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, data);
 

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -64,7 +64,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "data=true");
 
     /* example.com is redirected, so we tell libcurl to send POST on 301,
-       302 and 303 HTTP response codes. */
+       302 and 303 HTTP response codes */
     curl_easy_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
 
     curl_easy_perform(curl);

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -78,7 +78,7 @@ This option was known as CURLOPT_POST301 up to 7.19.0 as it only supported the
 301 then. CURL_REDIR_POST_303 was added in 7.26.0.
 
 **CURL_REDIR_*** macros became `long` types in 8.16.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -77,7 +77,7 @@ int main(void)
 This option was known as CURLOPT_POST301 up to 7.19.0 as it only supported the
 301 then. CURL_REDIR_POST_303 was added in 7.26.0.
 
-`CURL_REDIR_...` macros became `long` types in 8.16.0, prior to this version
+`CURL_REDIR_*` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -77,7 +77,7 @@ int main(void)
 This option was known as CURLOPT_POST301 up to 7.19.0 as it only supported the
 301 then. CURL_REDIR_POST_303 was added in 7.26.0.
 
-CURL_REDIR_\* macros became `long` types in 8.16.0, prior to this version
+`CURL_REDIR_*` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -77,7 +77,7 @@ int main(void)
 This option was known as CURLOPT_POST301 up to 7.19.0 as it only supported the
 301 then. CURL_REDIR_POST_303 was added in 7.26.0.
 
-`CURL_REDIR_*` macros became `long` types in 8.16.0, prior to this version
+**CURL_REDIR_*** macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -64,8 +64,8 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_POSTFIELDS, "data=true");
 
     /* example.com is redirected, so we tell libcurl to send POST on 301,
-       302 and 303 HTTP response codes */
-    curl_easy_setopt(curl, CURLOPT_POSTREDIR, (long)CURL_REDIR_POST_ALL);
+       302 and 303 HTTP response codes. */
+    curl_easy_setopt(curl, CURLOPT_POSTREDIR, CURL_REDIR_POST_ALL);
 
     curl_easy_perform(curl);
   }
@@ -76,6 +76,9 @@ int main(void)
 
 This option was known as CURLOPT_POST301 up to 7.19.0 as it only supported the
 301 then. CURL_REDIR_POST_303 was added in 7.26.0.
+
+CURL_REDIR_\* macros became `long` types in 8.16.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_POSTREDIR.md
+++ b/docs/libcurl/opts/CURLOPT_POSTREDIR.md
@@ -77,7 +77,7 @@ int main(void)
 This option was known as CURLOPT_POST301 up to 7.19.0 as it only supported the
 301 then. CURL_REDIR_POST_303 was added in 7.26.0.
 
-`CURL_REDIR_*` macros became `long` types in 8.16.0, prior to this version
+`CURL_REDIR_...` macros became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_PROTOCOLS.md
@@ -88,13 +88,18 @@ int main(int argc, char **argv)
 
     /* only allow HTTP, TFTP and SFTP */
     curl_easy_setopt(curl, CURLOPT_PROTOCOLS,
-                     (long)CURLPROTO_HTTP | CURLPROTO_TFTP | CURLPROTO_SFTP);
+                     CURLPROTO_HTTP | CURLPROTO_TFTP | CURLPROTO_SFTP);
 
     /* Perform the request */
     curl_easy_perform(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+**CURLPROTO_*** macros became `long` types in 8.16.0, prior to this version
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # DEPRECATED
 

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -70,7 +70,7 @@ int main(void)
 # HISTORY
 
 **CURLAUTH_*** macros became `long` types in 7.26.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -69,7 +69,7 @@ int main(void)
 
 # HISTORY
 
-CURLAUTH_\* macros became `long` types in 7.26.0, prior to this version
+`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -69,7 +69,7 @@ int main(void)
 
 # HISTORY
 
-`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
+**CURLAUTH_*** macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -67,6 +67,11 @@ int main(void)
 }
 ~~~
 
+# HISTORY
+
+CURLAUTH_\* macros became `long` types in 7.26.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
+
 # %AVAILABILITY%
 
 # RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -69,7 +69,7 @@ int main(void)
 
 # HISTORY
 
-`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
+`CURLAUTH_...` macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYAUTH.md
@@ -69,7 +69,7 @@ int main(void)
 
 # HISTORY
 
-`CURLAUTH_...` macros became `long` types in 7.26.0, prior to this version
+`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -94,7 +94,7 @@ int main(void)
 
 # HISTORY
 
-`CURLPROXY_*` enums became `long` types in 8.16.0, prior to this version
+**CURLPROXY_*** enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -85,12 +85,17 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     curl_easy_setopt(curl, CURLOPT_PROXY, "local.example.com:1080");
     /* set the proxy type */
-    curl_easy_setopt(curl, CURLOPT_PROXYTYPE, (long)CURLPROXY_SOCKS5);
+    curl_easy_setopt(curl, CURLOPT_PROXYTYPE, CURLPROXY_SOCKS5);
     ret = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURLPROXY_\* enums became `long` types in 8.16.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -94,7 +94,7 @@ int main(void)
 
 # HISTORY
 
-`CURLPROXY_...` enums became `long` types in 8.16.0, prior to this version
+`CURLPROXY_*` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -95,7 +95,7 @@ int main(void)
 # HISTORY
 
 **CURLPROXY_*** enums became `long` types in 8.16.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -94,7 +94,7 @@ int main(void)
 
 # HISTORY
 
-CURLPROXY_\* enums became `long` types in 8.16.0, prior to this version
+`CURLPROXY_*` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
+++ b/docs/libcurl/opts/CURLOPT_PROXYTYPE.md
@@ -94,7 +94,7 @@ int main(void)
 
 # HISTORY
 
-`CURLPROXY_*` enums became `long` types in 8.16.0, prior to this version
+`CURLPROXY_...` enums became `long` types in 8.16.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSLVERSION.md
@@ -116,13 +116,18 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* ask libcurl to use TLS version 1.0 or later */
-    curl_easy_setopt(curl, CURLOPT_SSLVERSION, (long)CURL_SSLVERSION_TLSv1);
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
 
     /* Perform the request */
     curl_easy_perform(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+**CURL_SSLVERSION_*** macros became `long` types in 8.16.0, prior to this
+version a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -119,7 +119,7 @@ int main(void)
 
 # HISTORY
 
-`CURLSSLOPT_*` macros became `long` types in 8.15.0, prior to this version
+`CURLSSLOPT_...` macros became `long` types in 8.15.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -119,7 +119,7 @@ int main(void)
 
 # HISTORY
 
-`CURLSSLOPT_...` macros became `long` types in 8.15.0, prior to this version
+`CURLSSLOPT_*` macros became `long` types in 8.15.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -120,7 +120,7 @@ int main(void)
 # HISTORY
 
 **CURLSSLOPT_*** macros became `long` types in 8.15.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -119,7 +119,7 @@ int main(void)
 
 # HISTORY
 
-`CURLSSLOPT_*` macros became `long` types in 8.15.0, prior to this version
+**CURLSSLOPT_*** macros became `long` types in 8.15.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -109,13 +109,18 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     curl_easy_setopt(curl, CURLOPT_PROXY, "https://proxy");
     /* weaken TLS only for use with silly proxies */
-    curl_easy_setopt(curl, CURLOPT_PROXY_SSL_OPTIONS, (long)
+    curl_easy_setopt(curl, CURLOPT_PROXY_SSL_OPTIONS,
                      CURLSSLOPT_ALLOW_BEAST | CURLSSLOPT_NO_REVOKE);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURLSSLOPT_\* macros became `long` types in 8.15.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_PROXY_SSL_OPTIONS.md
@@ -119,7 +119,7 @@ int main(void)
 
 # HISTORY
 
-CURLSSLOPT_\* macros became `long` types in 8.15.0, prior to this version
+`CURLSSLOPT_*` macros became `long` types in 8.15.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
+++ b/docs/libcurl/opts/CURLOPT_REDIR_PROTOCOLS.md
@@ -97,7 +97,7 @@ int main(int argc, char **argv)
     curl_easy_setopt(curl, CURLOPT_URL, argv[1]);
 
     /* only allow redirects to HTTP and HTTPS URLs */
-    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS, (long)
+    curl_easy_setopt(curl, CURLOPT_REDIR_PROTOCOLS,
                      CURLPROTO_HTTP | CURLPROTO_HTTPS);
 
     /* Perform the request */
@@ -105,6 +105,11 @@ int main(int argc, char **argv)
   }
 }
 ~~~
+
+# HISTORY
+
+**CURLPROTO_*** macros became `long` types in 8.16.0, prior to this version
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # DEPRECATED
 

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
@@ -133,7 +133,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_RTSPREQ_...` enums became `long` types in 8.13.0, prior to this version
+`CURL_RTSPREQ_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
@@ -133,7 +133,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_RTSPREQ_*` enums became `long` types in 8.13.0, prior to this version
+**CURL_RTSPREQ_*** enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
@@ -131,6 +131,11 @@ int main(void)
 }
 ~~~
 
+# HISTORY
+
+CURL_RTSPREQ_\* enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
+
 # %AVAILABILITY%
 
 # RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
@@ -133,7 +133,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_RTSPREQ_*` enums became `long` types in 8.13.0, prior to this version
+`CURL_RTSPREQ_...` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
@@ -134,7 +134,7 @@ int main(void)
 # HISTORY
 
 **CURL_RTSPREQ_*** enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_REQUEST.md
@@ -133,7 +133,7 @@ int main(void)
 
 # HISTORY
 
-CURL_RTSPREQ_\* enums became `long` types in 8.13.0, prior to this version
+`CURL_RTSPREQ_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
@@ -61,7 +61,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_RTSPREQ_*` enums became `long` types in 8.13.0, prior to this version
+`CURL_RTSPREQ_...` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
@@ -62,7 +62,7 @@ int main(void)
 # HISTORY
 
 **CURL_RTSPREQ_*** enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
@@ -61,7 +61,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_RTSPREQ_*` enums became `long` types in 8.13.0, prior to this version
+**CURL_RTSPREQ_*** enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
@@ -59,6 +59,11 @@ int main(void)
 }
 ~~~
 
+# HISTORY
+
+CURL_RTSPREQ_\* enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
+
 # %AVAILABILITY%
 
 # RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
@@ -61,7 +61,7 @@ int main(void)
 
 # HISTORY
 
-CURL_RTSPREQ_\* enums became `long` types in 8.13.0, prior to this version
+`CURL_RTSPREQ_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
+++ b/docs/libcurl/opts/CURLOPT_RTSP_TRANSPORT.md
@@ -61,7 +61,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_RTSPREQ_...` enums became `long` types in 8.13.0, prior to this version
+`CURL_RTSPREQ_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -62,7 +62,7 @@ int main(void)
 
 # HISTORY
 
-`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
+**CURLAUTH_*** macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -62,7 +62,7 @@ int main(void)
 
 # HISTORY
 
-CURLAUTH_\* macros became `long` types in 7.26.0, prior to this version
+`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -62,7 +62,7 @@ int main(void)
 
 # HISTORY
 
-`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
+`CURLAUTH_...` macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -63,7 +63,7 @@ int main(void)
 # HISTORY
 
 **CURLAUTH_*** macros became `long` types in 7.26.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -52,13 +52,18 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_PROXY, "socks5://user:pass@myproxy.com");
 
     /* enable username/password authentication only */
-    curl_easy_setopt(curl, CURLOPT_SOCKS5_AUTH, (long)CURLAUTH_BASIC);
+    curl_easy_setopt(curl, CURLOPT_SOCKS5_AUTH, CURLAUTH_BASIC);
 
     /* Perform the request */
     curl_easy_perform(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURLAUTH_\* macros became `long` types in 7.26.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
+++ b/docs/libcurl/opts/CURLOPT_SOCKS5_AUTH.md
@@ -62,7 +62,7 @@ int main(void)
 
 # HISTORY
 
-`CURLAUTH_...` macros became `long` types in 7.26.0, prior to this version
+`CURLAUTH_*` macros became `long` types in 7.26.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
+++ b/docs/libcurl/opts/CURLOPT_SSH_AUTH_TYPES.md
@@ -52,13 +52,18 @@ int main(void)
   if(curl) {
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "sftp://example.com/file");
-    curl_easy_setopt(curl, CURLOPT_SSH_AUTH_TYPES, (long)
+    curl_easy_setopt(curl, CURLOPT_SSH_AUTH_TYPES,
                      CURLSSH_AUTH_PUBLICKEY | CURLSSH_AUTH_KEYBOARD);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+**CURLSSH_AUTH_*** macros became `long` types in 8.16.0, prior to this version
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_SSLVERSION.md
+++ b/docs/libcurl/opts/CURLOPT_SSLVERSION.md
@@ -127,7 +127,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com");
 
     /* ask libcurl to use TLS version 1.0 or later */
-    curl_easy_setopt(curl, CURLOPT_SSLVERSION, (long)CURL_SSLVERSION_TLSv1);
+    curl_easy_setopt(curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1);
 
     /* Perform the request */
     curl_easy_perform(curl);
@@ -149,6 +149,9 @@ supported with wolfSSL and the other macros did not set a minimum, but
 restricted the TLS version to only the specified one.
 
 Rustls support added in 8.10.0.
+
+**CURL_SSLVERSION_*** macros became `long` types in 8.16.0, prior to this
+version a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -132,7 +132,7 @@ int main(void)
 
 # HISTORY
 
-`CURLSSLOPT_*` macros became `long` types in 8.15.0, prior to this version
+**CURLSSLOPT_*** macros became `long` types in 8.15.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -132,7 +132,7 @@ int main(void)
 
 # HISTORY
 
-`CURLSSLOPT_*` macros became `long` types in 8.15.0, prior to this version
+`CURLSSLOPT_...` macros became `long` types in 8.15.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -122,13 +122,18 @@ int main(void)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     /* weaken TLS only for use with silly servers */
-    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, (long)CURLSSLOPT_ALLOW_BEAST |
+    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_ALLOW_BEAST |
                      CURLSSLOPT_NO_REVOKE);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURLSSLOPT_\* macros became `long` types in 8.15.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -132,7 +132,7 @@ int main(void)
 
 # HISTORY
 
-CURLSSLOPT_\* macros became `long` types in 8.15.0, prior to this version
+`CURLSSLOPT_*` macros became `long` types in 8.15.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -122,8 +122,8 @@ int main(void)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "https://example.com/");
     /* weaken TLS only for use with silly servers */
-    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS, CURLSSLOPT_ALLOW_BEAST |
-                     CURLSSLOPT_NO_REVOKE);
+    curl_easy_setopt(curl, CURLOPT_SSL_OPTIONS,
+                     CURLSSLOPT_ALLOW_BEAST | CURLSSLOPT_NO_REVOKE);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -133,7 +133,7 @@ int main(void)
 # HISTORY
 
 **CURLSSLOPT_*** macros became `long` types in 8.15.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_SSL_OPTIONS.md
@@ -132,7 +132,7 @@ int main(void)
 
 # HISTORY
 
-`CURLSSLOPT_...` macros became `long` types in 8.15.0, prior to this version
+`CURLSSLOPT_*` macros became `long` types in 8.15.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
@@ -66,7 +66,7 @@ int main(void)
 # HISTORY
 
 **CURL_TIMECOND_*** enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
@@ -65,7 +65,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
+`CURL_TIMECOND_...` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
@@ -65,7 +65,7 @@ int main(void)
 
 # HISTORY
 
-CURL_TIMECOND_\* enums became `long` types in 8.13.0, prior to this version
+`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
@@ -55,14 +55,18 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_TIMEVALUE, 1577833200L);
 
     /* If-Modified-Since the above time stamp */
-    curl_easy_setopt(curl, CURLOPT_TIMECONDITION,
-                     (long)CURL_TIMECOND_IFMODSINCE);
+    curl_easy_setopt(curl, CURLOPT_TIMECONDITION, CURL_TIMECOND_IFMODSINCE);
 
     /* Perform the request */
     curl_easy_perform(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+CURL_TIMECOND_\* enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
@@ -65,7 +65,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
+**CURL_TIMECOND_*** enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
+++ b/docs/libcurl/opts/CURLOPT_TIMECONDITION.md
@@ -65,7 +65,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_TIMECOND_...` enums became `long` types in 8.13.0, prior to this version
+`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
@@ -63,7 +63,7 @@ int main(void)
 
 # HISTORY
 
-CURL_TIMECOND_\* enums became `long` types in 8.13.0, prior to this version
+`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
@@ -63,7 +63,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_TIMECOND_...` enums became `long` types in 8.13.0, prior to this version
+`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
@@ -63,7 +63,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
+**CURL_TIMECOND_*** enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
@@ -64,7 +64,7 @@ int main(void)
 # HISTORY
 
 **CURL_TIMECOND_*** enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
@@ -63,7 +63,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
+`CURL_TIMECOND_...` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE.md
@@ -61,6 +61,11 @@ int main(void)
 }
 ~~~
 
+# HISTORY
+
+CURL_TIMECOND_\* enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
+
 # %AVAILABILITY%
 
 # RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
@@ -66,7 +66,7 @@ int main(void)
 # HISTORY
 
 **CURL_TIMECOND_*** enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
@@ -63,6 +63,11 @@ int main(void)
 }
 ~~~
 
+# HISTORY
+
+CURL_TIMECOND_\* enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
+
 # %AVAILABILITY%
 
 # RETURN VALUE

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
@@ -65,7 +65,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
+`CURL_TIMECOND_...` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
@@ -65,7 +65,7 @@ int main(void)
 
 # HISTORY
 
-CURL_TIMECOND_\* enums became `long` types in 8.13.0, prior to this version
+`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
@@ -65,7 +65,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
+**CURL_TIMECOND_*** enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
+++ b/docs/libcurl/opts/CURLOPT_TIMEVALUE_LARGE.md
@@ -65,7 +65,7 @@ int main(void)
 
 # HISTORY
 
-`CURL_TIMECOND_...` enums became `long` types in 8.13.0, prior to this version
+`CURL_TIMECOND_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -84,7 +84,7 @@ int main(void)
 This option was known as CURLOPT_FTP_SSL up to 7.16.4. Supported by LDAP since
 7.81.0. Fully supported by the OpenLDAP backend only.
 
-CURLUSESSL_\* enums became `long` types in 8.13.0, prior to this version
+`CURLUSESSL_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -85,7 +85,7 @@ This option was known as CURLOPT_FTP_SSL up to 7.16.4. Supported by LDAP since
 7.81.0. Fully supported by the OpenLDAP backend only.
 
 **CURLUSESSL_*** enums became `long` types in 8.13.0, prior to this version
-a `long` cast is necessary when passing to curl_easy_setopt(3).
+a `long` cast was necessary when passed to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -84,7 +84,7 @@ int main(void)
 This option was known as CURLOPT_FTP_SSL up to 7.16.4. Supported by LDAP since
 7.81.0. Fully supported by the OpenLDAP backend only.
 
-`CURLUSESSL_*` enums became `long` types in 8.13.0, prior to this version
+**CURLUSESSL_*** enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -84,7 +84,7 @@ int main(void)
 This option was known as CURLOPT_FTP_SSL up to 7.16.4. Supported by LDAP since
 7.81.0. Fully supported by the OpenLDAP backend only.
 
-`CURLUSESSL_...` enums became `long` types in 8.13.0, prior to this version
+`CURLUSESSL_*` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -71,7 +71,7 @@ int main(void)
     curl_easy_setopt(curl, CURLOPT_URL, "ftp://example.com/dir/file.ext");
 
     /* require use of SSL for this, or fail */
-    curl_easy_setopt(curl, CURLOPT_USE_SSL, (long)CURLUSESSL_ALL);
+    curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_ALL);
 
     /* Perform the request */
     curl_easy_perform(curl);
@@ -83,6 +83,9 @@ int main(void)
 
 This option was known as CURLOPT_FTP_SSL up to 7.16.4. Supported by LDAP since
 7.81.0. Fully supported by the OpenLDAP backend only.
+
+CURLUSESSL_\* enums became `long` types in 8.13.0, prior to this version
+a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/docs/libcurl/opts/CURLOPT_USE_SSL.md
+++ b/docs/libcurl/opts/CURLOPT_USE_SSL.md
@@ -84,7 +84,7 @@ int main(void)
 This option was known as CURLOPT_FTP_SSL up to 7.16.4. Supported by LDAP since
 7.81.0. Fully supported by the OpenLDAP backend only.
 
-`CURLUSESSL_*` enums became `long` types in 8.13.0, prior to this version
+`CURLUSESSL_...` enums became `long` types in 8.13.0, prior to this version
 a `long` cast is necessary when passing to curl_easy_setopt(3).
 
 # %AVAILABILITY%

--- a/docs/libcurl/opts/CURLOPT_WS_OPTIONS.md
+++ b/docs/libcurl/opts/CURLOPT_WS_OPTIONS.md
@@ -66,12 +66,18 @@ int main(void)
     CURLcode res;
     curl_easy_setopt(curl, CURLOPT_URL, "ws://example.com/");
     /* tell curl we deal with all the WebSocket magic ourselves */
-    curl_easy_setopt(curl, CURLOPT_WS_OPTIONS, (long)CURLWS_RAW_MODE);
+    curl_easy_setopt(curl, CURLOPT_WS_OPTIONS, CURLWS_RAW_MODE);
     res = curl_easy_perform(curl);
     curl_easy_cleanup(curl);
   }
 }
 ~~~
+
+# HISTORY
+
+**CURLWS_RAW_MODE** and **CURLWS_NOAUTOPONG** macros became `long` types
+in 8.16.0, prior to this version a `long` cast was necessary when passed
+to curl_easy_setopt(3).
 
 # %AVAILABILITY%
 

--- a/tests/test1119.pl
+++ b/tests/test1119.pl
@@ -114,7 +114,7 @@ sub checkmanpage {
         while(s/\W(CURL(AUTH|E|H|MOPT|OPT|SHOPT|UE|M|SSH|SSLBACKEND|HEADER|FORM|FTP|PIPE|MIMEOPT|GSSAPI|ALTSVC|PROTO|PROXY|UPART|USESSL|_READFUNC|_WRITEFUNC|_CSELECT|_FORMADD|_IPRESOLVE|_REDIR|_RTSPREQ|_TIMECOND|_VERSION)_[a-zA-Z0-9_]+)//) {
             my $s = $1;
             # skip two "special" ones
-            if($s !~ /^(CURLE_OBSOLETE|CURLOPT_TEMPLATE)/) {
+            if($s !~ /(^(CURLE_OBSOLETE|CURLOPT_TEMPLATE))|_$/) {
                 push @manrefs, "$1:$m:$line";
             }
         }


### PR DESCRIPTION
Some CURLOPT constants defined in the curl public headers were initially
enums (= ints), or macros with bare numeric values. Recent curl releases
upgraded them to `long` constants, to make them pass correctly to
`curl_easy_setop()` by default, i.e. without requiring a `(long)` cast.

This patch drops such casts from the examples embedded in the docs. At
the same time it documents which curl release made them `long` types,
to keep them useful when working with previous libcurl versions.

Also:
- drop a `(long)` cast that was never necessary.
- CURLOPT_ALTSVC_CTRL.md: bump local copy of macros to long.
- test1119: make it ignore symbols ending with an underscore, to skip
  wildcard, e.g. `**CURLAUTH_***`.

---

- [x] replace `(long)` cast with `L` suffix for `CURLHSTS_*` macros. → moved to separate commit d1da9543f86a1356976e17aa7dc8e8b4fef09e2b
- [x] merge a couple of remaining macro updates and update this PR with them.
  → #18134
  → #18135
  → #18136
  → #18137
