### PR TITLE
CURLOPT: bump `CURLWS_RAW_MODE`, `CURLWS_NOAUTOPONG` macros to `long`

### DIFF
--- a/include/curl/websockets.h
+++ b/include/curl/websockets.h
@@ -73,8 +73,8 @@ CURL_EXTERN CURLcode curl_ws_send(CURL *curl, const void *buffer,
                                   unsigned int flags);
 
 /* bits for the CURLOPT_WS_OPTIONS bitmask: */
-#define CURLWS_RAW_MODE   (1<<0)
-#define CURLWS_NOAUTOPONG (1<<1)
+#define CURLWS_RAW_MODE   (1L<<0)
+#define CURLWS_NOAUTOPONG (1L<<1)
 
 CURL_EXTERN const struct curl_ws_frame *curl_ws_meta(CURL *curl);
 

--- a/tests/libtest/lib2301.c
+++ b/tests/libtest/lib2301.c
@@ -84,7 +84,7 @@ static CURLcode test_lib2301(const char *URL)
     /* use the callback style */
     curl_easy_setopt(curl, CURLOPT_USERAGENT, "webbie-sox/3");
     curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
-    curl_easy_setopt(curl, CURLOPT_WS_OPTIONS, (long)CURLWS_RAW_MODE);
+    curl_easy_setopt(curl, CURLOPT_WS_OPTIONS, CURLWS_RAW_MODE);
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, t2301_write_cb);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, curl);
     res = curl_easy_perform(curl);

--- a/tests/libtest/lib2700.c
+++ b/tests/libtest/lib2700.c
@@ -229,7 +229,7 @@ static CURLcode test_lib2700(const char *URL)
   easy_setopt(curl, CURLOPT_VERBOSE, 1L);
   easy_setopt(curl, CURLOPT_CONNECT_ONLY, 2L);
   if(!getenv("LIB2700_AUTO_PONG"))
-    easy_setopt(curl, CURLOPT_WS_OPTIONS, (long)CURLWS_NOAUTOPONG);
+    easy_setopt(curl, CURLOPT_WS_OPTIONS, CURLWS_NOAUTOPONG);
 
   res = curl_easy_perform(curl);
   if(res) {


### PR DESCRIPTION
This patch bumps the size of these macros from `int` to `long`, while
keeping their actual values the same. It may cause incompatibilities in
user code, requiring the bump of holder variables and/or adding casts:

- CURLWS_RAW_MODE
- CURLWS_NOAUTOPONG

Also:
- keep existing cast within the documentation to make sure it applies
  to older curl versions as well.
