### PR TITLE
libtests: use `FMT_SOCKET_T`, drop more casts

### DIFF
--- a/tests/libtest/lib1485.c
+++ b/tests/libtest/lib1485.c
@@ -59,8 +59,8 @@ static size_t t1485_header_callback(char *ptr, size_t size, size_t nmemb,
     if(st->http_status >= 200 && st->http_status < 300) {
       result = curl_easy_getinfo(st->easy, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T,
                                  &clen);
-      curl_mfprintf(stderr, "header_callback, info Content-Length: %ld, %d\n",
-                    (long)clen, result);
+      curl_mfprintf(stderr, "header_callback, info Content-Length: "
+                    "%" CURL_FORMAT_CURL_OFF_T ", %d\n", clen, result);
       if(result) {
         st->result = result;
         return CURLE_WRITE_ERROR;

--- a/tests/libtest/lib1541.c
+++ b/tests/libtest/lib1541.c
@@ -34,11 +34,10 @@ struct t1541_transfer_status {
 
 #define KN(a)   a, #a
 
-static int t1541_geterr(const char *name, CURLcode val, int lineno)
+static void t1541_geterr(const char *name, CURLcode val, int lineno)
 {
   curl_mprintf("CURLINFO_%s returned %d, \"%s\" on line %d\n",
                name, val, curl_easy_strerror(val), lineno);
-  return (int)val;
 }
 
 static void report_time(const char *key, const char *where, curl_off_t time,

--- a/tests/libtest/lib2032.c
+++ b/tests/libtest/lib2032.c
@@ -67,9 +67,9 @@ static size_t callback(char *ptr, size_t size, size_t nmemb, void *data)
     else if(sock != ntlm_sockets[idx]) {
       /* An easy handle with a socket different to previously
          tracked one, log and fail right away. Known bug #37. */
-      curl_mfprintf(stderr, "Handle %d started on socket %d and "
-                    "moved to %" FMT_SOCKET_T "\n",
-                    curlx_sztosi(idx), (int)ntlm_sockets[idx], sock);
+      curl_mfprintf(stderr, "Handle %d started on socket %" FMT_SOCKET_T
+                    " and moved to %" FMT_SOCKET_T "\n",
+                    curlx_sztosi(idx), ntlm_sockets[idx], sock);
       ntlmcb_res = TEST_ERR_MAJOR_BAD;
       return failure;
     }

--- a/tests/libtest/lib2032.c
+++ b/tests/libtest/lib2032.c
@@ -67,8 +67,9 @@ static size_t callback(char *ptr, size_t size, size_t nmemb, void *data)
     else if(sock != ntlm_sockets[idx]) {
       /* An easy handle with a socket different to previously
          tracked one, log and fail right away. Known bug #37. */
-      curl_mfprintf(stderr, "Handle %d started on socket %d and moved to %d\n",
-                    curlx_sztosi(idx), (int)ntlm_sockets[idx], (int)sock);
+      curl_mfprintf(stderr, "Handle %d started on socket %d and "
+                    "moved to %" FMT_SOCKET_T "\n",
+                    curlx_sztosi(idx), (int)ntlm_sockets[idx], sock);
       ntlmcb_res = TEST_ERR_MAJOR_BAD;
       return failure;
     }

--- a/tests/libtest/lib2304.c
+++ b/tests/libtest/lib2304.c
@@ -33,7 +33,7 @@ static CURLcode recv_any(CURL *curl)
   if(result)
     return result;
 
-  curl_mfprintf(stderr, "recv_any: got %u bytes rflags %x\n", (int)rlen,
+  curl_mfprintf(stderr, "recv_any: got %zu bytes rflags %x\n", rlen,
                 meta->flags);
   return CURLE_OK;
 }

--- a/tests/libtest/lib506.c
+++ b/tests/libtest/lib506.c
@@ -66,7 +66,7 @@ static void t506_test_lock(CURL *handle, curl_lock_data data,
       locknum = 2;
       break;
     default:
-      curl_mfprintf(stderr, "lock: no such data: %d\n", (int)data);
+      curl_mfprintf(stderr, "lock: no such data: %d\n", data);
       return;
   }
 
@@ -102,7 +102,7 @@ static void t506_test_unlock(CURL *handle, curl_lock_data data, void *useptr)
       locknum = 2;
       break;
     default:
-      curl_mfprintf(stderr, "unlock: no such data: %d\n", (int)data);
+      curl_mfprintf(stderr, "unlock: no such data: %d\n", data);
       return;
   }
 

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -75,7 +75,8 @@ static void t530_removeFd(struct t530_Sockets *sockets, curl_socket_t fd,
   int i;
 
   if(mention)
-    curl_mfprintf(stderr, "%s remove socket fd %d\n", t530_tag(), (int)fd);
+    curl_mfprintf(stderr, "%s remove socket fd %" FMT_SOCKET_T "\n",
+                  t530_tag(), fd);
 
   for(i = 0; i < sockets->count; ++i) {
     if(sockets->sockets[i] == fd) {
@@ -98,8 +99,8 @@ static int t530_addFd(struct t530_Sockets *sockets, curl_socket_t fd,
    * To ensure we only have each file descriptor once, we remove it then add
    * it again.
    */
-  curl_mfprintf(stderr, "%s add socket fd %d for %s\n",
-                t530_tag(), (int)fd, what);
+  curl_mfprintf(stderr, "%s add socket fd %" FMT_SOCKET_T " for %s\n",
+                t530_tag(), fd, what);
   t530_removeFd(sockets, fd, 0);
   /*
    * Allocate array storage when required.

--- a/tests/libtest/lib530.c
+++ b/tests/libtest/lib530.c
@@ -250,8 +250,8 @@ static void t530_updateFdSet(struct t530_Sockets *sockets, fd_set* fdset,
   }
 }
 
-static int socket_action(CURLM *curl, curl_socket_t s, int evBitmask,
-                         const char *info)
+static CURLMcode socket_action(CURLM *curl, curl_socket_t s, int evBitmask,
+                               const char *info)
 {
   int numhandles = 0;
   CURLMcode result = curl_multi_socket_action(curl, s, evBitmask, &numhandles);
@@ -259,17 +259,18 @@ static int socket_action(CURLM *curl, curl_socket_t s, int evBitmask,
     curl_mfprintf(stderr, "%s Curl error on %s (%i) %s\n",
                   t530_tag(), info, result, curl_multi_strerror(result));
   }
-  return (int)result;
+  return result;
 }
 
 /**
  * Invoke curl when a file descriptor is set.
  */
-static int t530_checkFdSet(CURLM *curl, struct t530_Sockets *sockets,
-                           fd_set *fdset, int evBitmask, const char *name)
+static CURLMcode t530_checkFdSet(CURLM *curl, struct t530_Sockets *sockets,
+                                 fd_set *fdset, int evBitmask,
+                                 const char *name)
 {
   int i;
-  int result = 0;
+  CURLMcode result = CURLM_OK;
   for(i = 0; i < sockets->count; ++i) {
     if(FD_ISSET(sockets->sockets[i], fdset)) {
       result = socket_action(curl, sockets->sockets[i], evBitmask, name);

--- a/tests/libtest/lib540.c
+++ b/tests/libtest/lib540.c
@@ -159,7 +159,7 @@ static CURLcode loop(int num, CURLM *cm, const char *url, const char *userpwd,
       if(msg->msg == CURLMSG_DONE) {
         size_t i;
         CURL *e = msg->easy_handle;
-        curl_mfprintf(stderr, "R: %d - %s\n", (int)msg->data.result,
+        curl_mfprintf(stderr, "R: %d - %s\n", msg->data.result,
                       curl_easy_strerror(msg->data.result));
         curl_multi_remove_handle(cm, e);
         curl_easy_cleanup(e);

--- a/tests/libtest/lib569.c
+++ b/tests/libtest/lib569.c
@@ -66,7 +66,7 @@ static CURLcode test_lib569(const char *URL)
 
   test_setopt(curl, CURLOPT_RTSP_REQUEST, CURL_RTSPREQ_SETUP);
   res = curl_easy_perform(curl);
-  if(res != (int)CURLE_BAD_FUNCTION_ARGUMENT) {
+  if(res != CURLE_BAD_FUNCTION_ARGUMENT) {
     curl_mfprintf(stderr, "This should have failed. "
                   "Cannot setup without a Transport: header");
     res = TEST_ERR_MAJOR_BAD;

--- a/tests/libtest/lib570.c
+++ b/tests/libtest/lib570.c
@@ -63,7 +63,7 @@ static CURLcode test_lib570(const char *URL)
   stream_uri = NULL;
 
   res = curl_easy_perform(curl);
-  if(res != (int)CURLE_RTSP_CSEQ_ERROR) {
+  if(res != CURLE_RTSP_CSEQ_ERROR) {
     curl_mfprintf(stderr, "Failed to detect CSeq mismatch");
     res = TEST_ERR_MAJOR_BAD;
     goto test_cleanup;

--- a/tests/libtest/lib582.c
+++ b/tests/libtest/lib582.c
@@ -44,7 +44,7 @@ static void t582_removeFd(struct t582_Sockets *sockets, curl_socket_t fd,
   int i;
 
   if(mention)
-    curl_mfprintf(stderr, "Remove socket fd %d\n", (int)fd);
+    curl_mfprintf(stderr, "Remove socket fd %" FMT_SOCKET_T "\n", fd);
 
   for(i = 0; i < sockets->count; ++i) {
     if(sockets->sockets[i] == fd) {
@@ -66,7 +66,7 @@ static void t582_addFd(struct t582_Sockets *sockets, curl_socket_t fd,
    * To ensure we only have each file descriptor once, we remove it then add
    * it again.
    */
-  curl_mfprintf(stderr, "Add socket fd %d for %s\n", (int)fd, what);
+  curl_mfprintf(stderr, "Add socket fd %" FMT_SOCKET_T " for %s\n", fd, what);
   t582_removeFd(sockets, fd, 0);
   /*
    * Allocate array storage when required.

--- a/tests/libtest/lib586.c
+++ b/tests/libtest/lib586.c
@@ -62,7 +62,7 @@ static void t586_test_lock(CURL *handle, curl_lock_data data,
       what = "ssl_session";
       break;
     default:
-      curl_mfprintf(stderr, "lock: no such data: %d\n", (int)data);
+      curl_mfprintf(stderr, "lock: no such data: %d\n", data);
       return;
   }
   curl_mprintf("lock:   %-6s [%s]: %d\n", what, user->text, user->counter);
@@ -89,7 +89,7 @@ static void t586_test_unlock(CURL *handle, curl_lock_data data, void *useptr)
       what = "ssl_session";
       break;
     default:
-      curl_mfprintf(stderr, "unlock: no such data: %d\n", (int)data);
+      curl_mfprintf(stderr, "unlock: no such data: %d\n", data);
       return;
   }
   curl_mprintf("unlock: %-6s [%s]: %d\n", what, user->text, user->counter);

--- a/tests/libtest/lib643.c
+++ b/tests/libtest/lib643.c
@@ -53,7 +53,7 @@ static size_t t643_read_cb(char *ptr, size_t size, size_t nmemb, void *userp)
     return 1;                        /* we return 1 byte at a time! */
   }
 
-  return 0;                         /* no more data left to deliver */
+  return 0;                          /* no more data left to deliver */
 }
 
 static CURLcode t643_test_once(const char *URL, bool oldstyle)


### PR DESCRIPTION
Follow-up to 37913c01a51653d257dc7d57f676504cedbf16f6 #18106
