### PR TITLE
runtests: add `--ci` option, show `Env:` only when non-empty

### DIFF
--- a/docs/runtests.md
+++ b/docs/runtests.md
@@ -96,14 +96,14 @@ Provide a path to a curl binary to talk to APIs (currently only CI test APIs).
 
 Display test results in automake style output (`PASS/FAIL: [number] [name]`).
 
-## `--buildinfo`
-
-Show the content of `buildinfo.txt`.
-
 ## `-c \<curl\>`
 
 Provide a path to a custom curl binary to run the tests with. Default is the
 curl executable in the build tree.
+
+## `--ci`
+
+show extra information useful in for CI runs (e.g. buildinfo.txt dump.)
 
 ## `-d`
 

--- a/docs/runtests.md
+++ b/docs/runtests.md
@@ -96,6 +96,10 @@ Provide a path to a curl binary to talk to APIs (currently only CI test APIs).
 
 Display test results in automake style output (`PASS/FAIL: [number] [name]`).
 
+## `--buildinfo`
+
+Show the content of `buildinfo.txt`.
+
 ## `-c \<curl\>`
 
 Provide a path to a custom curl binary to run the tests with. Default is the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,7 +120,7 @@ curl_add_runtests(test-am        "-a -am")
 curl_add_runtests(test-full      "-a -p -r")
 # ~flaky means that it ignores results of tests using the flaky keyword
 curl_add_runtests(test-nonflaky  "-a -p ~flaky ~timing-dependent")
-curl_add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r --retry=5 -j20")
+curl_add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r --retry=5 -j20 --buildinfo")
 curl_add_runtests(test-torture   "-a -t -j20")
 curl_add_runtests(test-event     "-a -e")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,7 +120,7 @@ curl_add_runtests(test-am        "-a -am")
 curl_add_runtests(test-full      "-a -p -r")
 # ~flaky means that it ignores results of tests using the flaky keyword
 curl_add_runtests(test-nonflaky  "-a -p ~flaky ~timing-dependent")
-curl_add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r --retry=5 -j20 --buildinfo")
+curl_add_runtests(test-ci        "-a -p ~flaky ~timing-dependent -r --retry=5 -j20 --ci")
 curl_add_runtests(test-torture   "-a -t -j20")
 curl_add_runtests(test-event     "-a -e")
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -129,7 +129,7 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r --retry=5 -j20
+TEST_CI = $(TEST_NF) -r --retry=5 -j20 --buildinfo
 
 PYTEST = pytest
 endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -129,7 +129,7 @@ TEST_E = -a -e
 TEST_NF = -a -p ~flaky ~timing-dependent
 
 # special CI target derived from nonflaky with CI-specific flags
-TEST_CI = $(TEST_NF) -r --retry=5 -j20 --buildinfo
+TEST_CI = $(TEST_NF) -r --retry=5 -j20 --ci
 
 PYTEST = pytest
 endif

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -46,7 +46,7 @@ BEGIN {
         $TUNITDIR
         $SRVDIR
         $listonly
-        $buildinfo
+        $ci
         $LOCKDIR
         $LOGDIR
         $memanalyze
@@ -95,7 +95,7 @@ our $verbose;         # 1 to show verbose test output
 our $torture;         # 1 to enable torture testing
 our $proxy_address;   # external HTTP proxy address
 our $listonly;        # only list the tests
-our $buildinfo;       # show the content of buildinfo.txt
+our $ci;              # show extra info useful in CI runs
 our $run_duphandle;   # run curl with --test-duphandle to verify handle duplication
 our $run_event_based; # run curl with --test-event to test the event API
 our $automakestyle;   # use automake-like test status output format

--- a/tests/globalconfig.pm
+++ b/tests/globalconfig.pm
@@ -46,6 +46,7 @@ BEGIN {
         $TUNITDIR
         $SRVDIR
         $listonly
+        $buildinfo
         $LOCKDIR
         $LOGDIR
         $memanalyze
@@ -94,6 +95,7 @@ our $verbose;         # 1 to show verbose test output
 our $torture;         # 1 to enable torture testing
 our $proxy_address;   # external HTTP proxy address
 our $listonly;        # only list the tests
+our $buildinfo;       # show the content of buildinfo.txt
 our $run_duphandle;   # run curl with --test-duphandle to verify handle duplication
 our $run_event_based; # run curl with --test-event to test the event API
 our $automakestyle;   # use automake-like test status output format

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2423,6 +2423,9 @@ while(@ARGV) {
         # lists the test case names only
         $listonly=1;
     }
+    elsif($ARGV[0] eq "--buildinfo") {
+        $buildinfo=1;
+    }
     elsif($ARGV[0] =~ /^-j(.*)/) {
         # parallel jobs
         $jobs=1;
@@ -2476,6 +2479,7 @@ Usage: runtests.pl [options] [test selection(s)]
   -a       continue even if a test fails
   -ac path use this curl only to talk to APIs (currently only CI test APIs)
   -am      automake style output PASS/FAIL: [number] [name]
+  --buildinfo  show the content of buildinfo.txt
   -c path  use this curl executable
   -d       display server debug info
   -e, --test-event  event-based execution
@@ -2664,7 +2668,7 @@ if(!$listonly) {
 #######################################################################
 # Output information about the curl build
 #
-if(!$listonly) {
+if(!$listonly && $buildinfo) {
     if(open(my $fd, "<", "../buildinfo.txt")) {
         while(my $line = <$fd>) {
             chomp $line;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -872,11 +872,13 @@ sub checksystemfeatures {
            "* Features: $feat\n",
            "* Disabled: $dis\n",
            "* Host: $hostname\n",
-           "* System: $hosttype\n",
-           "* OS: $hostos\n",
-           "* Perl: $^V ($^X)\n",
-           "* diff: $havediff\n",
-           "* Args: $args\n");
+           "* System: $hosttype\n");
+    if($buildinfo) {
+        logmsg("* OS: $hostos\n",
+               "* Perl: $^V ($^X)\n",
+               "* diff: $havediff\n");
+    }
+    logmsg("* Args: $args\n");
 
     if($jobs) {
         # Only show if not the default for now

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -873,7 +873,7 @@ sub checksystemfeatures {
            "* Disabled: $dis\n",
            "* Host: $hostname\n",
            "* System: $hosttype\n");
-    if($buildinfo) {
+    if($ci) {
         logmsg("* OS: $hostos\n",
                "* Perl: $^V ($^X)\n",
                "* diff: $havediff\n");
@@ -2426,7 +2426,7 @@ while(@ARGV) {
         $listonly=1;
     }
     elsif($ARGV[0] eq "--ci") {
-        $buildinfo=1;
+        $ci=1;
     }
     elsif($ARGV[0] =~ /^-j(.*)/) {
         # parallel jobs
@@ -2670,7 +2670,7 @@ if(!$listonly) {
 #######################################################################
 # Output information about the curl build
 #
-if(!$listonly && $buildinfo) {
+if(!$listonly && $ci) {
     if(open(my $fd, "<", "../buildinfo.txt")) {
         while(my $line = <$fd>) {
             chomp $line;

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -2425,7 +2425,7 @@ while(@ARGV) {
         # lists the test case names only
         $listonly=1;
     }
-    elsif($ARGV[0] eq "--buildinfo") {
+    elsif($ARGV[0] eq "--ci") {
         $buildinfo=1;
     }
     elsif($ARGV[0] =~ /^-j(.*)/) {
@@ -2481,8 +2481,8 @@ Usage: runtests.pl [options] [test selection(s)]
   -a       continue even if a test fails
   -ac path use this curl only to talk to APIs (currently only CI test APIs)
   -am      automake style output PASS/FAIL: [number] [name]
-  --buildinfo  show the content of buildinfo.txt
   -c path  use this curl executable
+  --ci     show extra info useful in for CI runs (e.g. buildinfo.txt dump)
   -d       display server debug info
   -e, --test-event  event-based execution
   --test-duphandle  duplicate handles before use

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -892,11 +892,15 @@ sub checksystemfeatures {
         $feature{"TrackMemory"} = 0;
     }
 
-    logmsg sprintf("* Env: %s%s%s%s", $valgrind?"Valgrind ":"",
-                   $run_duphandle?"test-duphandle ":"",
-                   $run_event_based?"event-based ":"",
-                   $nghttpx_h3);
-    logmsg sprintf("%s\n", $libtool?"Libtool ":"");
+    my $env = sprintf("%s%s%s%s%s",
+                      $valgrind?"Valgrind ":"",
+                      $run_duphandle?"test-duphandle ":"",
+                      $run_event_based?"event-based ":"",
+                      $nghttpx_h3,
+                      $libtool?"Libtool ":"");
+    if($env) {
+        logmsg "* Env: $env\n";
+    }
     logmsg "* Seed: $randseed\n";
 }
 


### PR DESCRIPTION
To reduce log noise in local test runs:
- move the `buildinfo.txt` output and header info lines
  `OS:`, `Perl:`, `diff:` behind a `--ci` option.
- enable this option for the CI test targets.
- hide `Env:` header info line if empty.
- merge `Env:` output into a single `logmsg()` call.
