### PR TITLE
cmake: fix to restrict `SystemConfiguration` to macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,7 +355,7 @@ if(WIN32)
 endif()
 
 # Override to force-disable or force-enable the use of pkg-config.
-if((UNIX AND NOT ANDROID AND (NOT APPLE OR CMAKE_SYSTEM_NAME MATCHES "Darwin")) OR
+if((UNIX AND NOT ANDROID AND (NOT APPLE OR CMAKE_SYSTEM_NAME STREQUAL "Darwin")) OR
    VCPKG_TOOLCHAIN OR
    (MINGW AND NOT CMAKE_CROSSCOMPILING))
   set(_curl_use_pkgconfig_default ON)
@@ -653,7 +653,7 @@ if(ENABLE_IPV6)
       set(ENABLE_IPV6 OFF CACHE BOOL "Enable IPv6 support" FORCE)  # Force the feature off as we use this name as guard macro
     endif()
 
-    if(APPLE AND NOT ENABLE_ARES)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT ENABLE_ARES)
       set(_use_core_foundation_and_core_services ON)
 
       find_library(SYSTEMCONFIGURATION_FRAMEWORK NAMES "SystemConfiguration")

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -385,8 +385,9 @@
  * performing this task will result in a synthesized IPv6 address.
  */
 #if defined(__APPLE__) && !defined(USE_ARES)
-#  define USE_RESOLVE_ON_IPS 1
-#  if TARGET_OS_OSX && defined(USE_IPV6)
+#define USE_RESOLVE_ON_IPS 1
+#  if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE) && \
+     defined(USE_IPV6)
 #    define CURL_MACOS_CALL_COPYPROXIES 1
 #  endif
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -385,9 +385,8 @@
  * performing this task will result in a synthesized IPv6 address.
  */
 #if defined(__APPLE__) && !defined(USE_ARES)
-#define USE_RESOLVE_ON_IPS 1
-#  if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE) && \
-     defined(USE_IPV6)
+#  define USE_RESOLVE_ON_IPS 1
+#  if TARGET_OS_OSX && defined(USE_IPV6)
 #    define CURL_MACOS_CALL_COPYPROXIES 1
 #  endif
 #endif

--- a/m4/curl-sysconfig.m4
+++ b/m4/curl-sysconfig.m4
@@ -32,7 +32,7 @@ AC_MSG_CHECKING([whether to link macOS CoreFoundation, CoreServices, and SystemC
       #if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
         return 0;
       #else
-      #error Not macOS
+        #error Not macOS
       #endif
     ]])
   ],[

--- a/m4/curl-sysconfig.m4
+++ b/m4/curl-sysconfig.m4
@@ -29,8 +29,8 @@ AC_MSG_CHECKING([whether to link macOS CoreFoundation, CoreServices, and SystemC
       #include <sys/types.h>
       #include <TargetConditionals.h>
     ]],[[
-      #if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
-        return 0;
+      #if TARGET_OS_OSX
+      return 0;
       #else
       #error Not macOS
       #endif

--- a/m4/curl-sysconfig.m4
+++ b/m4/curl-sysconfig.m4
@@ -29,8 +29,8 @@ AC_MSG_CHECKING([whether to link macOS CoreFoundation, CoreServices, and SystemC
       #include <sys/types.h>
       #include <TargetConditionals.h>
     ]],[[
-      #if TARGET_OS_OSX
-      return 0;
+      #if TARGET_OS_MAC && !(defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
+        return 0;
       #else
       #error Not macOS
       #endif


### PR DESCRIPTION
Also fix indentation and tidy up to use `STREQUAL` when checking for
Darwin.

Reported-by: Waldemar Kornewald
Fixes #18149
Regression from 739ef9804d8e1e9b4a8d2a610896babc62c5524b #13713
