### PR TITLE
build: disable `TCP_NODELAY` for emscripten

### DIFF
--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -109,7 +109,7 @@ static void set_ipv6_v6only(curl_socket_t sockfd, int on)
 
 static void tcpnodelay(struct Curl_easy *data, curl_socket_t sockfd)
 {
-#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
+#if defined(TCP_NODELAY) && defined(CURL_TCP_NODELAY_SUPPORTED)
   curl_socklen_t onoff = (curl_socklen_t) 1;
   int level = IPPROTO_TCP;
   char buffer[STRERROR_LEN];

--- a/lib/cf-socket.c
+++ b/lib/cf-socket.c
@@ -109,7 +109,7 @@ static void set_ipv6_v6only(curl_socket_t sockfd, int on)
 
 static void tcpnodelay(struct Curl_easy *data, curl_socket_t sockfd)
 {
-#ifdef TCP_NODELAY
+#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
   curl_socklen_t onoff = (curl_socklen_t) 1;
   int level = IPPROTO_TCP;
   char buffer[STRERROR_LEN];

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -1125,6 +1125,11 @@ int getpwuid_r(uid_t uid, struct passwd *pwd, char *buf,
 #define USE_HTTP3
 #endif
 
+/* WebAssembly builds have TCP_NODELAY, but runtime support is missing. */
+#ifndef __EMSCRIPTEN__
+#define CURL_TCP_NODELAY_SUPPORTED
+#endif
+
 /* Certain Windows implementations are not aligned with what curl expects,
    so always use the local one on this platform. E.g. the mingw-w64
    implementation can return wrong results for non-ASCII inputs. */

--- a/tests/server/rtspd.c
+++ b/tests/server/rtspd.c
@@ -1224,7 +1224,7 @@ static int test_rtspd(int argc, char *argv[])
 
     logmsg("====> Client connect");
 
-#ifdef TCP_NODELAY
+#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
     /*
      * Disable the Nagle algorithm to make it easier to send out a large
      * response in many small segments to torture the clients more.

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -158,7 +158,7 @@ static const char *doc404 = "HTTP/1.1 404 Not Found\r\n"
 /* work around for handling trailing headers */
 static int already_recv_zeroed_chunk = FALSE;
 
-#ifdef TCP_NODELAY
+#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
 /* returns true if the current socket is an IP one */
 static bool socket_domain_is_ip(void)
 {
@@ -1239,7 +1239,7 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
     return CURL_SOCKET_BAD;
   }
 
-#ifdef TCP_NODELAY
+#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
   if(socket_domain_is_ip()) {
     /* Disable the Nagle algorithm */
     curl_socklen_t flag = 1;
@@ -1545,7 +1545,7 @@ static void http_connect(curl_socket_t *infdp,
           }
           memset(req2, 0, sizeof(*req2));
           logmsg("====> Client connect DATA");
-#ifdef TCP_NODELAY
+#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
           if(socket_domain_is_ip()) {
             /* Disable the Nagle algorithm */
             curl_socklen_t flag = 1;
@@ -1871,7 +1871,7 @@ static curl_socket_t accept_connection(curl_socket_t sock)
   all_sockets[num_sockets] = msgsock;
   num_sockets += 1;
 
-#ifdef TCP_NODELAY
+#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
   if(socket_domain_is_ip()) {
     /*
      * Disable the Nagle algorithm to make it easier to send out a large

--- a/tests/server/sws.c
+++ b/tests/server/sws.c
@@ -158,7 +158,7 @@ static const char *doc404 = "HTTP/1.1 404 Not Found\r\n"
 /* work around for handling trailing headers */
 static int already_recv_zeroed_chunk = FALSE;
 
-#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
+#if defined(TCP_NODELAY) && defined(CURL_TCP_NODELAY_SUPPORTED)
 /* returns true if the current socket is an IP one */
 static bool socket_domain_is_ip(void)
 {
@@ -1239,7 +1239,7 @@ static curl_socket_t connect_to(const char *ipaddr, unsigned short port)
     return CURL_SOCKET_BAD;
   }
 
-#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
+#if defined(TCP_NODELAY) && defined(CURL_TCP_NODELAY_SUPPORTED)
   if(socket_domain_is_ip()) {
     /* Disable the Nagle algorithm */
     curl_socklen_t flag = 1;
@@ -1545,7 +1545,7 @@ static void http_connect(curl_socket_t *infdp,
           }
           memset(req2, 0, sizeof(*req2));
           logmsg("====> Client connect DATA");
-#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
+#if defined(TCP_NODELAY) && defined(CURL_TCP_NODELAY_SUPPORTED)
           if(socket_domain_is_ip()) {
             /* Disable the Nagle algorithm */
             curl_socklen_t flag = 1;
@@ -1871,7 +1871,7 @@ static curl_socket_t accept_connection(curl_socket_t sock)
   all_sockets[num_sockets] = msgsock;
   num_sockets += 1;
 
-#if defined(TCP_NODELAY) && !defined(__EMSCRIPTEN__)
+#if defined(TCP_NODELAY) && defined(CURL_TCP_NODELAY_SUPPORTED)
   if(socket_domain_is_ip()) {
     /*
      * Disable the Nagle algorithm to make it easier to send out a large


### PR DESCRIPTION
In WebAssembly, using `TCP_NODELAY` fails with:
```
* Could not set TCP_NODELAY: Protocol not available
```

Add a new feature macro in `curl_setup.h` telling whether `TCP_NODELAY`
is known to be supported at runtime, when defined at compile-time.

Keep `TCP_NODELAY` guards at their current positions to ensure the
necessary headers (e.g. `netinet/tcp.h` and `netinet/in.h`) define it.

Reported-by: Jeroen Ooms
Fixes #17974

---

Can be generalized more in case other platforms also
need this, but for now keep it simple?