### PR TITLE
hostip: do DNS cache pruning in milliseconds

### DIFF
--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -67,7 +67,7 @@ struct Curl_dns_entry {
   struct Curl_https_rrinfo *hinfo;
 #endif
   /* timestamp == 0 -- permanent CURLOPT_RESOLVE entry (does not time out) */
-  time_t timestamp;
+  struct curltime timestamp;
   /* reference counter, entry is freed on reaching 0 */
   size_t refcount;
   /* hostname port number that resolved to addr. */

--- a/lib/setopt.c
+++ b/lib/setopt.c
@@ -868,10 +868,12 @@ static CURLcode setopt_long(struct Curl_easy *data, CURLoption option,
   case CURLOPT_DNS_CACHE_TIMEOUT:
     if(arg < -1)
       return CURLE_BAD_FUNCTION_ARGUMENT;
-    else if(arg > INT_MAX)
-      arg = INT_MAX;
+    else if(arg > INT_MAX/1000)
+      arg = INT_MAX/1000;
 
-    s->dns_cache_timeout = (int)arg;
+    if(arg > 0)
+      arg *= 1000;
+    s->dns_cache_timeout_ms = (int)arg;
     break;
   case CURLOPT_CA_CACHE_TIMEOUT:
     if(Curl_ssl_supports(data, SSLSUPP_CA_CACHE)) {

--- a/lib/url.c
+++ b/lib/url.c
@@ -388,7 +388,7 @@ CURLcode Curl_init_userdefined(struct Curl_easy *data)
   set->ftp_filemethod = FTPFILE_MULTICWD;
   set->ftp_skip_ip = TRUE;    /* skip PASV IP by default */
 #endif
-  set->dns_cache_timeout = 60; /* Timeout every 60 seconds by default */
+  set->dns_cache_timeout_ms = 60000; /* Timeout every 60 seconds by default */
 
   /* Timeout every 24 hours by default */
   set->general_ssl.ca_cache_timeout = 24 * 60 * 60;

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1431,7 +1431,7 @@ struct UserDefined {
   unsigned char socks5auth;/* kind of SOCKS5 authentication to use (bitmask) */
 #endif
   struct ssl_general_config general_ssl; /* general user defined SSL stuff */
-  int dns_cache_timeout; /* DNS cache timeout (seconds) */
+  int dns_cache_timeout_ms; /* DNS cache timeout (milliseconds) */
   unsigned int buffer_size;      /* size of receive buffer to use */
   unsigned int upload_buffer_size; /* size of upload buffer to use,
                                       keep it >= CURL_MAX_WRITE_SIZE */

--- a/tests/unit/unit1607.c
+++ b/tests/unit/unit1607.c
@@ -193,7 +193,7 @@ static CURLcode test_unit1607(const char *arg)
         break;
       }
 
-      if(dns->timestamp && tests[i].permanent) {
+      if(dns->timestamp.tv_sec && tests[i].permanent) {
         curl_mfprintf(stderr,
                       "%s:%d tests[%d] failed. the timestamp is not zero "
                       "but tests[%d].permanent is TRUE\n",
@@ -202,7 +202,7 @@ static CURLcode test_unit1607(const char *arg)
         break;
       }
 
-      if(dns->timestamp == 0 && !tests[i].permanent) {
+      if(dns->timestamp.tv_sec == 0 && !tests[i].permanent) {
         curl_mfprintf(stderr, "%s:%d tests[%d] failed. the timestamp is zero "
                       "but tests[%d].permanent is FALSE\n",
                       __FILE__, __LINE__, i, i);


### PR DESCRIPTION
Instead of using integer seconds. Also: if the cache contains over 30,000 entries after first pruning, it makes another round and removes all entries that are older than half the age of the oldest entry until it goes below 30,000.