### PR TITLE
GHA/windows: give more time for Ubuntu installs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -597,7 +597,7 @@ jobs:
   linux-cross-mingw-w64:
     name: "linux-mingw, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.compiler }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     env:
       MAKEFLAGS: -j 5
       TRIPLET: 'x86_64-w64-mingw32'
@@ -612,7 +612,6 @@ jobs:
           - { build: 'cmake'    , compiler: 'clang-tidy' }
     steps:
       - name: 'install packages'
-        timeout-minutes: 5
         env:
           INSTALL_PACKAGES: ${{ matrix.compiler == 'clang-tidy' && 'clang' || '' }}
         run: |


### PR DESCRIPTION
Recently sometimes the Ubunty package repository is very slow to access.
Remove the time limit for the install step, and bump up the total limit,
aligning with Linux jobs.
