### PR TITLE
secs2ms(): Changes to digs[5] and digs sizeof sizeof

### DIFF
--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -321,7 +321,7 @@ ParameterError secs2ms(long *valp, const char *str)
 {
   curl_off_t secs;
   long ms = 0;
-  const unsigned int digs[] = { 1, 10, 100, 1000, 10000, 1000000,
+  const unsigned int digs[] = { 1, 10, 100, 1000, 10000, 100000,
     1000000, 10000000, 100000000 };
   if(!str ||
      curlx_str_number(&str, &secs, LONG_MAX/1000 - 1))

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -334,7 +334,7 @@ ParameterError secs2ms(long *valp, const char *str)
       return PARAM_NUMBER_TOO_LARGE;
     /* how many milliseconds are in fracs ? */
     len = (str - s);
-    while((len > sizeof(CURL_ARRAYSIZE(digs)) || (fracs > LONG_MAX/100))) {
+    while((len > CURL_ARRAYSIZE(digs) || (fracs > LONG_MAX/100))) {
       fracs /= 10;
       len--;
     }


### PR DESCRIPTION
First commit changes this:
```c
long val;
secs2ms(&val, "1.23456");   // val = 1234 // ok
secs2ms(&val, "1.234567");  // val = 1023 // should be 1234
secs2ms(&val, "1.2345678"); // val = 1234 // ok
```

Second commit would only be an issue if at some point `sizeof(size_t)` becomes larger than `sizeof(digs) / sizeof(digs[0])`.
