### PR TITLE
Use curl_getenv in Curl_qlogdir

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -642,7 +642,7 @@ CURLcode Curl_qlogdir(struct Curl_easy *data,
                       size_t scidlen,
                       int *qlogfdp)
 {
-  const char *qlog_dir = curl_getenv("QLOGDIR");
+  char *qlog_dir = curl_getenv("QLOGDIR");
   *qlogfdp = -1;
   if(qlog_dir) {
     struct dynbuf fname;


### PR DESCRIPTION
`getenv` isn't defined on all platforms, which prevents vquic from building. I specifically ran into this issue building on PlayStation. 