### PR TITLE
Output unescaped utf8 x509 issuer/subject DNs

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1856,8 +1856,10 @@ static CURLcode x509_name_oneline(X509_NAME *a, struct dynbuf *d)
   CURLcode result = CURLE_OUT_OF_MEMORY;
 
   if(bio_out) {
+    unsigned long flags = (XN_FLAG_SEP_SPLUS_SPC | XN_FLAG_ONELINE & \
+                           ~ASN1_STRFLGS_ESC_MSB & ~XN_FLAG_SPC_EQ);
     curlx_dyn_reset(d);
-    rc = X509_NAME_print_ex(bio_out, a, 0, XN_FLAG_SEP_SPLUS_SPC);
+    rc = X509_NAME_print_ex(bio_out, a, 0, flags);
     if(rc != -1) {
       BIO_get_mem_ptr(bio_out, &biomem);
       result = curlx_dyn_addn(d, biomem->data, biomem->length);


### PR DESCRIPTION
What I'm trying to fix: I have certificates where the issuer DN has accented characters (encoded as utf8 strings) and I'd like `curl -v` to render these characters properly, instead of showing `�`.

How I went about it: tweaked the flags [^1] passed to `X509_NAME_print_ex` [^2], keeping the current format (delimit key and value with equal sign, delimit entries with semicolon and a space).

Example:

```sh
# issue cert with accents:
openssl req -nodes -new -x509 -utf8  \
  -keyout temp.key \
  -out cert.crt \
  -subj "/C=CC/ST=Ciudad de México/L=Cuauhtémoc/O=Mi Organización/CN=example.com.mx" \
  -addext "subjectAltName=DNS:example.com.mx,DNS:host.docker.internal,IP:127.0.0.1"
# verify they print fine
openssl x509 -in cert.crt -subject -nameopt oneline,-esc_msb -noout
#> subject=C = CC, ST = Ciudad de México, L = Cuauhtémoc, O = CA, CN = example.com.mx
# start a test server
openssl s_server -key temp.key -cert cert.crt -accept 4430 -www

# test latest macos curl on homebrew on a different session:
/opt/homebrew/Cellar/curl/8.12.1/bin/curl -v https://127.0.0.1:4430 -k 2>&1 | grep issuer
#> *  issuer: C=CC; ST=Ciudad de M�xico; L=Cuauht�moc; O=Mi Organizaci�n;; CN=example.com.mx

# with fix, i.e. a pre-built docker container with `libssl-dev` and `openssl`:
docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):/usr/src -w /usr/src curl/curl bash
# once in container
./configure --with-openssl --without-libpsl --prefix=$HOME --disable-shared
make && make install
LD_LIBRARY_PATH=$HOME/lib/ $HOME/bin/curl -vv https://host.docker.internal:4430 -k 2>&1 | grep issuer
#> 02:57:58.169365 [0-0] *  issuer: C=CC; ST=Ciudad de México; L=Cuauhtémoc; O=Mi Organización; CN=example.com.mx
```

This is my first contribution, and while I've read the style guide and contributing guidelines, i'd be happy to keep working on this if i missed something and it needs more work. 

[^1]: https://docs.openssl.org/3.1/man3/ASN1_STRING_print_ex/#notes
[^2]: https://docs.openssl.org/3.1/man3/X509_NAME_print_ex