### PR TITLE
GHA: pin jobs to windows-2022

### DIFF
--- a/.github/workflows/distcheck.yml
+++ b/.github/workflows/distcheck.yml
@@ -260,7 +260,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [ubuntu-latest, macos-latest, windows-latest]
+        image: [ubuntu-latest, macos-latest, windows-2022]
     steps:
       - uses: msys2/setup-msys2@40677d36a502eb2cf0fb808cc9dec31bf6152638 # v2
         if: ${{ contains(matrix.image, 'windows') }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,7 +43,7 @@ env:
 jobs:
   cygwin:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 15
     defaults:
       run:
@@ -187,7 +187,7 @@ jobs:
 
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
-    runs-on: ${{ matrix.image || 'windows-latest' }}
+    runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: 15
     defaults:
       run:
@@ -414,7 +414,7 @@ jobs:
 
   mingw-w64-standalone-downloads:
     name: 'dl-mingw, CM ${{ matrix.ver }}-${{ matrix.env }} ${{ matrix.name }}'
-    runs-on: windows-latest
+    runs-on: windows-2022
     timeout-minutes: 15
     defaults:
       run:
@@ -697,7 +697,7 @@ jobs:
 
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
-    runs-on: ${{ matrix.image || 'windows-latest' }}
+    runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: 15
     defaults:
       run:


### PR DESCRIPTION
To avoid being bumped to windows-2025 in September, and to stay with
the superior performance offered by windows-2022 runners.

Ref: #18140