### PR TITLE
tool_cb_hrd: remove global pointer from 'struct HdrCbData'

### DIFF
--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -285,11 +285,11 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
     if(!outs->stream && !tool_create_output_file(outs, per->config))
       return CURL_WRITEFUNC_ERROR;
 
-    if(hdrcbdata->global->isatty &&
+    if(hdrcbdata->config->global->isatty &&
 #ifdef _WIN32
        tool_term_has_bold &&
 #endif
-       hdrcbdata->global->styled_output)
+       hdrcbdata->config->global->styled_output)
       value = memchr(ptr, ':', cb);
     if(value) {
       size_t namelen = value - ptr;

--- a/src/tool_cb_hdr.h
+++ b/src/tool_cb_hdr.h
@@ -41,7 +41,6 @@
  */
 
 struct HdrCbData {
-  struct GlobalConfig *global;
   struct OperationConfig *config;
   struct OutStruct *outs;
   struct OutStruct *heads;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1353,7 +1353,6 @@ static CURLcode single_transfer(struct OperationConfig *config,
       hdrcbdata->outs = outs;
       hdrcbdata->heads = heads;
       hdrcbdata->etag_save = etag_save;
-      hdrcbdata->global = global;
       hdrcbdata->config = config;
 
       result = config2setopts(config, per, curl, share);


### PR DESCRIPTION
Not necessary