### PR TITLE
use custom memory functions for nghttp3 and ngtcp2

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1199,8 +1199,6 @@ static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,
                                struct Curl_easy *data)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
-  nghttp3_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
-                     Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
   int64_t ctrl_stream_id, qpack_enc_stream_id, qpack_dec_stream_id;
   int rc;
 
@@ -1214,7 +1212,8 @@ static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,
   rc = nghttp3_conn_client_new(&ctx->h3conn,
                                &ngh3_callbacks,
                                &ctx->h3settings,
-                               &mem, cf);
+                               (nghttp3_mem *)Curl_nghttp3_mem(),
+                               cf);
   if(rc) {
     failf(data, "error creating nghttp3 connection instance");
     return CURLE_OUT_OF_MEMORY;
@@ -2425,8 +2424,6 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
                                  struct pkt_io_ctx *pktx)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
-  ngtcp2_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
-                    Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
   int rc;
   int rv;
   CURLcode result;
@@ -2474,7 +2471,7 @@ static const struct alpn_spec ALPN_SPEC_H3 = {
                               &ctx->connected_path,
                               NGTCP2_PROTO_VER_V1, &ng_callbacks,
                               &ctx->settings, &ctx->transport_params,
-                              &mem, cf);
+                              (ngtcp2_mem *)Curl_ngtcp2_mem(), cf);
   if(rc)
     return CURLE_QUIC_CONNECT_ERROR;
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1208,12 +1208,13 @@ static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,
   }
 
   nghttp3_settings_default(&ctx->h3settings);
+  nghttp3_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
+                     Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
 
   rc = nghttp3_conn_client_new(&ctx->h3conn,
                                &ngh3_callbacks,
                                &ctx->h3settings,
-                               nghttp3_mem_default(),
-                               cf);
+                               &mem, cf);
   if(rc) {
     failf(data, "error creating nghttp3 connection instance");
     return CURLE_OUT_OF_MEMORY;
@@ -2466,12 +2467,14 @@ static const struct alpn_spec ALPN_SPEC_H3 = {
                    ctx->q.local_addrlen);
   ngtcp2_addr_init(&ctx->connected_path.remote,
                    &sockaddr->curl_sa_addr, (socklen_t)sockaddr->addrlen);
+  ngtcp2_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
+                    Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
 
   rc = ngtcp2_conn_client_new(&ctx->qconn, &ctx->dcid, &ctx->scid,
                               &ctx->connected_path,
                               NGTCP2_PROTO_VER_V1, &ng_callbacks,
                               &ctx->settings, &ctx->transport_params,
-                              NULL, cf);
+                              &mem, cf);
   if(rc)
     return CURLE_QUIC_CONNECT_ERROR;
 

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1199,6 +1199,8 @@ static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,
                                struct Curl_easy *data)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
+  nghttp3_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
+                     Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
   int64_t ctrl_stream_id, qpack_enc_stream_id, qpack_dec_stream_id;
   int rc;
 
@@ -1208,8 +1210,6 @@ static CURLcode init_ngh3_conn(struct Curl_cfilter *cf,
   }
 
   nghttp3_settings_default(&ctx->h3settings);
-  nghttp3_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
-                     Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
 
   rc = nghttp3_conn_client_new(&ctx->h3conn,
                                &ngh3_callbacks,
@@ -2425,6 +2425,8 @@ static CURLcode cf_connect_start(struct Curl_cfilter *cf,
                                  struct pkt_io_ctx *pktx)
 {
   struct cf_ngtcp2_ctx *ctx = cf->ctx;
+  ngtcp2_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
+                    Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
   int rc;
   int rv;
   CURLcode result;
@@ -2467,8 +2469,6 @@ static const struct alpn_spec ALPN_SPEC_H3 = {
                    ctx->q.local_addrlen);
   ngtcp2_addr_init(&ctx->connected_path.remote,
                    &sockaddr->curl_sa_addr, (socklen_t)sockaddr->addrlen);
-  ngtcp2_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
-                    Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
 
   rc = ngtcp2_conn_client_new(&ctx->qconn, &ctx->dcid, &ctx->scid,
                               &ctx->connected_path,

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1099,8 +1099,6 @@ static CURLcode cf_osslq_h3conn_init(struct cf_osslq_ctx *ctx, SSL *conn,
                                      void *user_data)
 {
   struct cf_osslq_h3conn *h3 = &ctx->h3;
-  nghttp3_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
-                     Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
   CURLcode result;
   int rc;
 
@@ -1108,7 +1106,7 @@ static CURLcode cf_osslq_h3conn_init(struct cf_osslq_ctx *ctx, SSL *conn,
   rc = nghttp3_conn_client_new(&h3->conn,
                                &ngh3_callbacks,
                                &h3->settings,
-                               &mem,
+                               (nghttp3_mem *)Curl_nghttp3_mem(),
                                user_data);
   if(rc) {
     result = CURLE_OUT_OF_MEMORY;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1099,12 +1099,12 @@ static CURLcode cf_osslq_h3conn_init(struct cf_osslq_ctx *ctx, SSL *conn,
                                      void *user_data)
 {
   struct cf_osslq_h3conn *h3 = &ctx->h3;
+  nghttp3_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
+                     Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
   CURLcode result;
   int rc;
 
   nghttp3_settings_default(&h3->settings);
-  nghttp3_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
-                     Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
   rc = nghttp3_conn_client_new(&h3->conn,
                                &ngh3_callbacks,
                                &h3->settings,

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -1103,10 +1103,12 @@ static CURLcode cf_osslq_h3conn_init(struct cf_osslq_ctx *ctx, SSL *conn,
   int rc;
 
   nghttp3_settings_default(&h3->settings);
+  nghttp3_mem mem = {NULL, Curl_ngtcp2_malloc, Curl_ngtcp2_free,
+                     Curl_ngtcp2_calloc, Curl_ngtcp2_realloc};
   rc = nghttp3_conn_client_new(&h3->conn,
                                &ngh3_callbacks,
                                &h3->settings,
-                               nghttp3_mem_default(),
+                               &mem,
                                user_data);
   if(rc) {
     result = CURLE_OUT_OF_MEMORY;

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -749,6 +749,28 @@ void *Curl_ngtcp2_realloc(void *ptr, size_t size, void *user_data)
   return Curl_crealloc(ptr, size);
 }
 
+#ifdef USE_NGTCP2
+static ngtcp2_mem curl_ngtcp2_mem_ = {
+  NULL,
+  Curl_ngtcp2_malloc,
+  Curl_ngtcp2_free,
+  Curl_ngtcp2_calloc,
+  Curl_ngtcp2_realloc
+};
+void *Curl_ngtcp2_mem(void) { return (void *)&curl_ngtcp2_mem_; }
+#endif
+
+#ifdef USE_NGHTTP3
+static nghttp3_mem curl_nghttp3_mem_ = {
+  NULL,
+  Curl_ngtcp2_malloc,
+  Curl_ngtcp2_free,
+  Curl_ngtcp2_calloc,
+  Curl_ngtcp2_realloc
+};
+void *Curl_nghttp3_mem(void) { return (void *)&curl_nghttp3_mem_; }
+#endif
+
 #endif /* USE_NGTCP2 || USE_NGHTTP3 */
 
 #else /* CURL_DISABLE_HTTP || !USE_HTTP3 */

--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -723,6 +723,34 @@ CURLcode Curl_conn_may_http3(struct Curl_easy *data,
   return CURLE_OK;
 }
 
+#if defined(USE_NGTCP2) || defined(USE_NGHTTP3)
+
+void *Curl_ngtcp2_malloc(size_t size, void *user_data)
+{
+  (void)user_data;
+  return Curl_cmalloc(size);
+}
+
+void Curl_ngtcp2_free(void *ptr, void *user_data)
+{
+  (void)user_data;
+  Curl_cfree(ptr);
+}
+
+void *Curl_ngtcp2_calloc(size_t nmemb, size_t size, void *user_data)
+{
+  (void)user_data;
+  return Curl_ccalloc(nmemb, size);
+}
+
+void *Curl_ngtcp2_realloc(void *ptr, size_t size, void *user_data)
+{
+  (void)user_data;
+  return Curl_crealloc(ptr, size);
+}
+
+#endif /* USE_NGTCP2 || USE_NGHTTP3 */
+
 #else /* CURL_DISABLE_HTTP || !USE_HTTP3 */
 
 CURLcode Curl_conn_may_http3(struct Curl_easy *data,

--- a/lib/vquic/vquic.h
+++ b/lib/vquic/vquic.h
@@ -49,6 +49,15 @@ CURLcode Curl_cf_quic_create(struct Curl_cfilter **pcf,
 
 extern struct Curl_cftype Curl_cft_http3;
 
+#if defined(USE_NGTCP2) || defined(USE_NGHTTP3)
+
+void *Curl_ngtcp2_malloc(size_t size, void *user_data);
+void Curl_ngtcp2_free(void *ptr, void *user_data);
+void *Curl_ngtcp2_calloc(size_t nmemb, size_t size, void *user_data);
+void *Curl_ngtcp2_realloc(void *ptr, size_t size, void *user_data);
+
+#endif /* USE_NGTCP2 || USE_NGHTTP3 */
+
 #else
 #define Curl_vquic_init() 1
 #endif /* !CURL_DISABLE_HTTP && USE_HTTP3 */

--- a/lib/vquic/vquic.h
+++ b/lib/vquic/vquic.h
@@ -56,6 +56,13 @@ void Curl_ngtcp2_free(void *ptr, void *user_data);
 void *Curl_ngtcp2_calloc(size_t nmemb, size_t size, void *user_data);
 void *Curl_ngtcp2_realloc(void *ptr, size_t size, void *user_data);
 
+#ifdef USE_NGTCP2
+void *Curl_ngtcp2_mem(void);
+#endif
+#ifdef USE_NGHTTP3
+void *Curl_nghttp3_mem(void);
+#endif
+
 #endif /* USE_NGTCP2 || USE_NGHTTP3 */
 
 #else


### PR DESCRIPTION
Pass curl's memory functions to the nghttp3 and ngtcp2 functions that allow them. This allows custom memory functions passed by the curl user to be used in nghttp3 and ngtcp2. 

I added these functions in vquic since it's common to both curl_ngtcp2 and curl_osslq, but please let me know if there's a better place to put them. These functions are also the same as those used for nghttp2: https://github.com/curl/curl/commit/9089ef1f4f40ee62edc0b214d95d9c182c07deeb