### PR TITLE
tool_operate: use the correct config pointer

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1756,13 +1756,13 @@ static CURLcode parallel_event(struct parastate *s)
 
 #endif
 
-static CURLcode check_finished(struct GlobalConfig *global,
-                               struct parastate *s)
+static CURLcode check_finished(struct parastate *s)
 {
   CURLcode result = CURLE_OK;
   int rc;
   CURLMsg *msg;
   bool checkmore = FALSE;
+  struct GlobalConfig *global = s->global;
   progress_meter(global, s->multi, &s->start, FALSE);
   do {
     msg = curl_multi_info_read(s->multi, &rc);
@@ -1885,7 +1885,7 @@ static CURLcode parallel_transfers(struct GlobalConfig *global,
       if(!s->mcode)
         s->mcode = curl_multi_perform(s->multi, &s->still_running);
       if(!s->mcode)
-        result = check_finished(global, s);
+        result = check_finished(s);
     }
 
     (void)progress_meter(global, s->multi, &s->start, TRUE);

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -265,9 +265,7 @@ static CURLcode pre_transfer(struct per_transfer *per)
   curl_off_t uploadfilesize = -1;
   struct_stat fileinfo;
   CURLcode result = CURLE_OK;
-#ifdef CURL_DISABLE_LIBCURL_OPTION
-  (void)global; /* otherwise used in the my_setopt macros */
-#else
+#ifndef CURL_DISABLE_LIBCURL_OPTION
   struct OperationConfig *config = per->config;
 #endif
 

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1499,6 +1499,7 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
 }
 
 struct parastate {
+  struct GlobalConfig *global;
   CURLM *multi;
   CURLSH *share;
   CURLMcode mcode;
@@ -1842,6 +1843,7 @@ static CURLcode parallel_transfers(struct GlobalConfig *global,
   s->wrapitup = FALSE;
   s->wrapitup_processed = FALSE;
   s->tick = time(NULL);
+  s->global = global;
   s->multi = curl_multi_init();
   if(!s->multi)
     return CURLE_OUT_OF_MEMORY;


### PR DESCRIPTION
When doing parallel glob transfers.

Reported-by: letshack9707 on hackerone