### PR TITLE
multi: fix bad splay management

### DIFF
--- a/lib/multi.c
+++ b/lib/multi.c
@@ -2793,16 +2793,15 @@ CURLMcode curl_multi_perform(CURLM *m, int *running_handles)
     if(t) {
       /* the removed may have another timeout in queue */
       struct Curl_easy *data = Curl_splayget(t);
+      (void)add_next_timeout(now, multi, data);
       if(data->mstate == MSTATE_PENDING) {
         bool stream_unused;
         CURLcode result_unused;
         if(multi_handle_timeout(data, &now, &stream_unused, &result_unused)) {
           infof(data, "PENDING handle timeout");
           move_pending_to_connect(multi, data);
-          continue;
         }
       }
-      (void)add_next_timeout(now, multi, Curl_splayget(t));
     }
   } while(t);
 


### PR DESCRIPTION
The splay tree is a tree where each easy handle can be added *once*. The expire time for that node is the closes expire time for that easy handle.

Easy handles can however have more expire times queued up, so when the node is removed from the splay tree because it is the next in line to take care of, we must check if there is another expire time in the queue and then add the node back into the splay.

Failing to do the later part, the calling of add_next_timeout after Curl_splaygetbest, would leave the state.expiretime on the previous time stamp, which when could make the next call to Curl_splaygetbest use the wrong time stamp and get a wrong node out, causing trouble.

Reported-by: letshack9707 on hackerone