### PR TITLE
curl: make global truly global

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -87,8 +87,7 @@ static int sockopt_callback(void *clientp, curl_socket_t curlfd,
     }
     if(result < 0) {
       int error = errno;
-      warnf(config->global,
-            "Setting type of service to %d failed with errno %d: %s;\n",
+      warnf("Setting type of service to %d failed with errno %d: %s\n",
             tos, error, strerror(error));
     }
   }
@@ -99,7 +98,7 @@ static int sockopt_callback(void *clientp, curl_socket_t curlfd,
     if(setsockopt(curlfd, SOL_SOCKET, SO_PRIORITY,
       (void *)&priority, sizeof(priority)) != 0) {
       int error = errno;
-      warnf(config->global, "VLAN priority %d failed with errno %d: %s;\n",
+      warnf("VLAN priority %d failed with errno %d: %s\n",
             priority, error, strerror(error));
     }
   }
@@ -173,7 +172,6 @@ static CURLcode url_proto_and_rewrite(char **url,
 
 static CURLcode ssh_setopts(struct OperationConfig *config, CURL *curl)
 {
-  struct GlobalConfig *global = config->global;
   CURLcode result;
 
   /* SSH and SSL private key uses same command-line option */
@@ -213,11 +211,11 @@ static CURLcode ssh_setopts(struct OperationConfig *config, CURL *curl)
       global->knownhosts = known;
     }
     else if(!config->hostpubmd5 && !config->hostpubsha256) {
-      errorf(global, "Couldn't find a known_hosts file");
+      errorf("Couldn't find a known_hosts file");
       return CURLE_FAILED_INIT;
     }
     else
-      warnf(global, "Couldn't find a known_hosts file");
+      warnf("Couldn't find a known_hosts file");
   }
   return CURLE_OK; /* ignore if SHA256 did not work */
 }
@@ -279,7 +277,6 @@ static long tlsversion(unsigned char mintls,
 /* only called if libcurl supports TLS */
 static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
 {
-  struct GlobalConfig *global = config->global;
   CURLcode result = CURLE_OK;
 
   if(config->cacert)
@@ -301,7 +298,7 @@ static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
     if((result == CURLE_NOT_BUILT_IN) ||
        (result == CURLE_UNKNOWN_OPTION)) {
       if(config->proxy_capath) {
-        warnf(global, "ignoring %s, not supported by libcurl with %s",
+        warnf("ignoring %s, not supported by libcurl with %s",
               config->proxy_capath ? "--proxy-capath" : "--capath",
               ssl_backend());
       }
@@ -316,9 +313,7 @@ static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
     blob.data = CURL_UNCONST(curl_ca_embed);
     blob.len = strlen((const char *)curl_ca_embed);
     blob.flags = CURL_BLOB_NOCOPY;
-    notef(config->global,
-          "Using embedded CA bundle (%zu bytes)",
-          blob.len);
+    notef("Using embedded CA bundle (%zu bytes)", blob.len);
     result = curl_easy_setopt(curl, CURLOPT_CAINFO_BLOB, &blob);
     if(result == CURLE_NOT_BUILT_IN) {
       warnf(global, "ignoring %s, not supported by libcurl with %s",
@@ -330,9 +325,7 @@ static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
     blob.data = CURL_UNCONST(curl_ca_embed);
     blob.len = strlen((const char *)curl_ca_embed);
     blob.flags = CURL_BLOB_NOCOPY;
-    notef(config->global,
-          "Using embedded CA bundle, for proxies (%zu bytes)",
-          blob.len);
+    notef("Using embedded CA bundle, for proxies (%zu bytes)", blob.len);
     result = curl_easy_setopt(curl, CURLOPT_PROXY_CAINFO_BLOB, &blob);
     if(result == CURLE_NOT_BUILT_IN) {
       warnf(global, "ignoring %s, not supported by libcurl with %s",
@@ -352,14 +345,14 @@ static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
     result = my_setopt_str(curl, CURLOPT_PINNEDPUBLICKEY,
                            config->pinnedpubkey);
     if(result == CURLE_NOT_BUILT_IN)
-      warnf(global, "ignoring %s, not supported by libcurl with %s",
+      warnf("ignoring %s, not supported by libcurl with %s",
             "--pinnedpubkey", ssl_backend());
   }
   if(config->proxy_pinnedpubkey) {
     result = my_setopt_str(curl, CURLOPT_PROXY_PINNEDPUBLICKEY,
                            config->proxy_pinnedpubkey);
     if(result == CURLE_NOT_BUILT_IN)
-      warnf(global, "ignoring %s, not supported by libcurl with %s",
+      warnf("ignoring %s, not supported by libcurl with %s",
             "--proxy-pinnedpubkey", ssl_backend());
   }
 
@@ -441,28 +434,28 @@ static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
     result = my_setopt_str(curl, CURLOPT_SSL_CIPHER_LIST,
                            config->cipher_list);
     if(result == CURLE_NOT_BUILT_IN)
-      warnf(global, "ignoring %s, not supported by libcurl with %s",
+      warnf("ignoring %s, not supported by libcurl with %s",
             "--ciphers", ssl_backend());
   }
   if(config->proxy_cipher_list) {
     result = my_setopt_str(curl, CURLOPT_PROXY_SSL_CIPHER_LIST,
                            config->proxy_cipher_list);
     if(result == CURLE_NOT_BUILT_IN)
-      warnf(global, "ignoring %s, not supported by libcurl with %s",
+      warnf("ignoring %s, not supported by libcurl with %s",
             "--proxy-ciphers", ssl_backend());
   }
   if(config->cipher13_list) {
     result = my_setopt_str(curl, CURLOPT_TLS13_CIPHERS,
                            config->cipher13_list);
     if(result == CURLE_NOT_BUILT_IN)
-      warnf(global, "ignoring %s, not supported by libcurl with %s",
+      warnf("ignoring %s, not supported by libcurl with %s",
             "--tls13-ciphers", ssl_backend());
   }
   if(config->proxy_cipher13_list) {
     result = my_setopt_str(curl, CURLOPT_PROXY_TLS13_CIPHERS,
                            config->proxy_cipher13_list);
     if(result == CURLE_NOT_BUILT_IN)
-      warnf(global, "ignoring %s, not supported by libcurl with %s",
+      warnf("ignoring %s, not supported by libcurl with %s",
             "--proxy-tls13-ciphers", ssl_backend());
   }
 
@@ -581,8 +574,7 @@ static CURLcode cookie_setopts(struct OperationConfig *config, CURL *curl)
         result = curlx_dyn_addf(&cookies, ";%s", cl->data);
 
       if(result) {
-        warnf(config->global,
-              "skipped provided cookie, the cookie header "
+        warnf("skipped provided cookie, the cookie header "
               "would go over %u bytes", MAX_COOKIE_LINE);
         return result;
       }
@@ -675,7 +667,7 @@ static CURLcode ftp_setopts(struct OperationConfig *config, CURL *curl)
 
 static void gen_trace_setopts(struct OperationConfig *config, CURL *curl)
 {
-  if(config->global->tracetype != TRACE_NONE) {
+  if(global->tracetype != TRACE_NONE) {
     my_setopt(curl, CURLOPT_DEBUGFUNCTION, tool_debug_cb);
     my_setopt(curl, CURLOPT_DEBUGDATA, config);
     my_setopt_long(curl, CURLOPT_VERBOSE, 1L);
@@ -686,8 +678,6 @@ static void gen_cb_setopts(struct OperationConfig *config,
                            struct per_transfer *per,
                            CURL *curl)
 {
-  struct GlobalConfig *global = config->global;
-  (void)config;
   /* where to store */
   my_setopt(curl, CURLOPT_WRITEDATA, per);
   my_setopt(curl, CURLOPT_INTERLEAVEDATA, per);
@@ -729,7 +719,7 @@ static CURLcode proxy_setopts(struct OperationConfig *config, CURL *curl)
     CURLcode result = my_setopt_str(curl, CURLOPT_PROXY, config->proxy);
 
     if(result) {
-      errorf(config->global, "proxy support is disabled in this libcurl");
+      errorf("proxy support is disabled in this libcurl");
       config->synthetic_error = TRUE;
       return CURLE_NOT_BUILT_IN;
     }
@@ -806,7 +796,6 @@ CURLcode config2setopts(struct OperationConfig *config,
                         CURL *curl,
                         CURLSH *share)
 {
-  struct GlobalConfig *global = config->global;
   const char *use_proto;
   CURLcode result = url_proto_and_rewrite(&per->url, config, &use_proto);
 
@@ -887,7 +876,7 @@ CURLcode config2setopts(struct OperationConfig *config,
   switch(config->httpreq) {
   case TOOL_HTTPREQ_SIMPLEPOST:
     if(config->resume_from) {
-      errorf(global, "cannot mix --continue-at with --data");
+      errorf("cannot mix --continue-at with --data");
       result = CURLE_FAILED_INIT;
     }
     else {
@@ -902,7 +891,7 @@ CURLcode config2setopts(struct OperationConfig *config,
     curl_mime_free(config->mimepost);
     config->mimepost = NULL;
     if(config->resume_from) {
-      errorf(global, "cannot mix --continue-at with --form");
+      errorf("cannot mix --continue-at with --form");
       result = CURLE_FAILED_INIT;
     }
     else {
@@ -985,7 +974,7 @@ CURLcode config2setopts(struct OperationConfig *config,
   my_setopt_enum(curl, CURLOPT_TIMECONDITION, config->timecond);
   my_setopt_offt(curl, CURLOPT_TIMEVALUE_LARGE, config->condtime);
   my_setopt_str(curl, CURLOPT_CUSTOMREQUEST, config->customrequest);
-  customrequest_helper(config, config->httpreq, config->customrequest);
+  customrequest_helper(config->httpreq, config->customrequest);
   my_setopt(curl, CURLOPT_STDERR, tool_stderr);
   my_setopt_str(curl, CURLOPT_INTERFACE, config->iface);
   my_setopt_str(curl, CURLOPT_KRBLEVEL, config->krblevel);

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -316,7 +316,7 @@ static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
     notef("Using embedded CA bundle (%zu bytes)", blob.len);
     result = curl_easy_setopt(curl, CURLOPT_CAINFO_BLOB, &blob);
     if(result == CURLE_NOT_BUILT_IN) {
-      warnf(global, "ignoring %s, not supported by libcurl with %s",
+      warnf("ignoring %s, not supported by libcurl with %s",
             "embedded CA bundle", ssl_backend());
     }
   }
@@ -328,7 +328,7 @@ static CURLcode ssl_setopts(struct OperationConfig *config, CURL *curl)
     notef("Using embedded CA bundle, for proxies (%zu bytes)", blob.len);
     result = curl_easy_setopt(curl, CURLOPT_PROXY_CAINFO_BLOB, &blob);
     if(result == CURLE_NOT_BUILT_IN) {
-      warnf(global, "ignoring %s, not supported by libcurl with %s",
+      warnf("ignoring %s, not supported by libcurl with %s",
             "embedded CA bundle", ssl_backend());
     }
   }
@@ -1069,13 +1069,11 @@ CURLcode config2setopts(struct OperationConfig *config,
     my_setopt(curl, CURLOPT_SOCKOPTDATA, config);
 #else
     if(config->ip_tos > 0) {
-      errorf(config->global,
-             "Type of service is not supported in this build.");
+      errorf("Type of service is not supported in this build.");
       result = CURLE_NOT_BUILT_IN;
     }
     if(config->vlan_priority > 0) {
-      errorf(config->global,
-             "VLAN priority is not supported in this build.");
+      errorf("VLAN priority is not supported in this build.");
       result = CURLE_NOT_BUILT_IN;
     }
 #endif

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -87,7 +87,7 @@ static int sockopt_callback(void *clientp, curl_socket_t curlfd,
     }
     if(result < 0) {
       int error = errno;
-      warnf("Setting type of service to %d failed with errno %d: %s\n",
+      warnf("Setting type of service to %d failed with errno %d: %s",
             tos, error, strerror(error));
     }
   }
@@ -96,9 +96,9 @@ static int sockopt_callback(void *clientp, curl_socket_t curlfd,
   if(config->vlan_priority > 0) {
     int priority = (int)config->vlan_priority;
     if(setsockopt(curlfd, SOL_SOCKET, SO_PRIORITY,
-      (void *)&priority, sizeof(priority)) != 0) {
+                  (void *)&priority, sizeof(priority)) != 0) {
       int error = errno;
-      warnf("VLAN priority %d failed with errno %d: %s\n",
+      warnf("VLAN priority %d failed with errno %d: %s",
             priority, error, strerror(error));
     }
   }

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -678,6 +678,8 @@ static void gen_cb_setopts(struct OperationConfig *config,
                            struct per_transfer *per,
                            CURL *curl)
 {
+  (void)config; /* when --libcurl is disabled */
+
   /* where to store */
   my_setopt(curl, CURLOPT_WRITEDATA, per);
   my_setopt(curl, CURLOPT_INTERLEAVEDATA, per);

--- a/src/tool_cb_dbg.c
+++ b/src/tool_cb_dbg.c
@@ -79,8 +79,6 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
                   char *data, size_t size,
                   void *userdata)
 {
-  struct OperationConfig *operation = userdata;
-  struct GlobalConfig *global = operation->global;
   FILE *output = tool_stderr;
   const char *text;
   struct timeval tv;
@@ -94,6 +92,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
   curl_off_t xfer_id, conn_id;
 
   (void)handle; /* not used */
+  (void)userdata;
 
   if(global->tracetime) {
     tv = tvrealnow();
@@ -134,7 +133,7 @@ int tool_debug_cb(CURL *handle, curl_infotype type,
     output = global->trace_stream;
 
   if(!output) {
-    warnf(global, "Failed to create/open output");
+    warnf("Failed to create/open output");
     return 0;
   }
 

--- a/src/tool_cb_hdr.c
+++ b/src/tool_cb_hdr.c
@@ -99,7 +99,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
 
 #ifdef DEBUGBUILD
   if(size * nmemb > (size_t)CURL_MAX_HTTP_HEADER) {
-    warnf(per->config->global, "Header data exceeds write limit");
+    warnf("Header data exceeds write limit");
     return CURL_WRITEFUNC_ERROR;
   }
 #endif
@@ -120,8 +120,7 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
       return rc;
     /* flush the stream to send off what we got earlier */
     if(fflush(heads->stream)) {
-      errorf(per->config->global, "Failed writing headers to %s",
-             per->config->headerfile);
+      errorf("Failed writing headers to %s", per->config->headerfile);
       return CURL_WRITEFUNC_ERROR;
     }
   }
@@ -286,11 +285,11 @@ size_t tool_header_cb(char *ptr, size_t size, size_t nmemb, void *userdata)
     if(!outs->stream && !tool_create_output_file(outs, per->config))
       return CURL_WRITEFUNC_ERROR;
 
-    if(hdrcbdata->config->global->isatty &&
+    if(global->isatty &&
 #ifdef _WIN32
        tool_term_has_bold &&
 #endif
-       hdrcbdata->config->global->styled_output)
+       global->styled_output)
       value = memchr(ptr, ':', cb);
     if(value) {
       size_t namelen = value - ptr;

--- a/src/tool_cb_rea.c
+++ b/src/tool_cb_rea.c
@@ -103,7 +103,7 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
       rc = 0;
     }
 #else
-    warnf(per->config->global, "per->infd != 0: FD == %d. This behavior"
+    warnf("per->infd != 0: FD == %d. This behavior"
           " is only supported on desktop Windows", per->infd);
 #endif
   }
@@ -123,7 +123,7 @@ size_t tool_read_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
      (per->uploadedsofar + rc > per->uploadfilesize)) {
     /* do not allow uploading more than originally set out to do */
     curl_off_t delta = per->uploadedsofar + rc - per->uploadfilesize;
-    warnf(per->config->global, "File size larger in the end than when "
+    warnf("File size larger in the end than when "
           "started. Dropping at least %" CURL_FORMAT_CURL_OFF_T " bytes",
           delta);
     rc = (ssize_t)(per->uploadfilesize - per->uploadedsofar);

--- a/src/tool_cb_wrt.c
+++ b/src/tool_cb_wrt.c
@@ -45,12 +45,10 @@
 bool tool_create_output_file(struct OutStruct *outs,
                              struct OperationConfig *config)
 {
-  struct GlobalConfig *global;
   FILE *file = NULL;
   const char *fname = outs->filename;
   DEBUGASSERT(outs);
   DEBUGASSERT(config);
-  global = config->global;
   DEBUGASSERT(fname && *fname);
 
   if(config->file_clobber_mode == CLOBBER_ALWAYS ||
@@ -101,8 +99,7 @@ bool tool_create_output_file(struct OutStruct *outs,
   }
 
   if(!file) {
-    warnf(global, "Failed to open the file %s: %s", fname,
-          strerror(errno));
+    warnf("Failed to open the file %s: %s", fname, strerror(errno));
     return FALSE;
   }
   outs->s_isreg = TRUE;
@@ -248,7 +245,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   struct OutStruct *outs = &per->outs;
   struct OperationConfig *config = per->config;
   size_t bytes = sz * nmemb;
-  bool is_tty = config->global->isatty;
+  bool is_tty = global->isatty;
 #if defined(_WIN32) && !defined(UNDER_CE)
   CONSOLE_SCREEN_BUFFER_INFO console_info;
   intptr_t fhnd;
@@ -268,13 +265,13 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
 
   if(config->show_headers) {
     if(bytes > (size_t)CURL_MAX_HTTP_HEADER) {
-      warnf(config->global, "Header data size exceeds write limit");
+      warnf("Header data size exceeds write limit");
       return CURL_WRITEFUNC_ERROR;
     }
   }
   else {
     if(bytes > (size_t)CURL_MAX_WRITE_SIZE) {
-      warnf(config->global, "Data size exceeds write limit");
+      warnf("Data size exceeds write limit");
       return CURL_WRITEFUNC_ERROR;
     }
   }
@@ -303,7 +300,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
         check_fails = TRUE;
     }
     if(check_fails) {
-      warnf(config->global, "Invalid output struct data for write callback");
+      warnf("Invalid output struct data for write callback");
       return CURL_WRITEFUNC_ERROR;
     }
   }
@@ -315,7 +312,7 @@ size_t tool_write_cb(char *buffer, size_t sz, size_t nmemb, void *userdata)
   if(is_tty && (outs->bytes < 2000) && !config->terminal_binary_ok) {
     /* binary output to terminal? */
     if(memchr(buffer, 0, bytes)) {
-      warnf(config->global, "Binary output can mess up your terminal. "
+      warnf("Binary output can mess up your terminal. "
             "Use \"--output -\" to tell curl to output it to your terminal "
             "anyway, or consider \"--output <FILE>\" to save to a file.");
       config->synthetic_error = TRUE;

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -27,9 +27,10 @@
 #include "tool_formparse.h"
 #include "tool_paramhlp.h"
 #include "tool_main.h"
+#include "tool_msgs.h"
 #include "memdebug.h" /* keep this as LAST include */
 
-struct GlobalConfig globalconf;
+static struct GlobalConfig globalconf;
 struct GlobalConfig *global;
 
 struct OperationConfig *config_alloc(void)
@@ -203,4 +204,79 @@ void config_free(struct OperationConfig *config)
 
     last = prev;
   }
+}
+
+/*
+ * This is the main global constructor for the app. Call this before
+ * _any_ libcurl usage. If this fails, *NO* libcurl functions may be
+ * used, or havoc may be the result.
+ */
+CURLcode globalconf_init(void)
+{
+  CURLcode result = CURLE_OK;
+  global = &globalconf;
+
+#ifdef __DJGPP__
+  /* stop stat() wasting time */
+  _djstat_flags |= _STAT_INODE | _STAT_EXEC_MAGIC | _STAT_DIRSIZE;
+#endif
+
+  /* Initialise the global config */
+  global->showerror = FALSE;          /* show errors when silent */
+  global->styled_output = TRUE;       /* enable detection */
+  global->parallel_max = PARALLEL_DEFAULT;
+
+  /* Allocate the initial operate config */
+  global->first = global->last = config_alloc();
+  if(global->first) {
+    /* Perform the libcurl initialization */
+    result = curl_global_init(CURL_GLOBAL_DEFAULT);
+    if(!result) {
+      /* Get information about libcurl */
+      result = get_libcurl_info();
+
+      if(result) {
+        errorf("error retrieving curl library information");
+        free(global->first);
+      }
+    }
+    else {
+      errorf("error initializing curl library");
+      free(global->first);
+    }
+  }
+  else {
+    errorf("error initializing curl");
+    result = CURLE_FAILED_INIT;
+  }
+
+  return result;
+}
+
+static void free_globalconfig(void)
+{
+  tool_safefree(global->trace_dump);
+
+  if(global->trace_fopened && global->trace_stream)
+    fclose(global->trace_stream);
+  global->trace_stream = NULL;
+
+  tool_safefree(global->libcurl);
+}
+
+/*
+ * This is the main global destructor for the app. Call this after _all_
+ * libcurl usage is done.
+ */
+void globalconf_free(void)
+{
+  /* Cleanup the easy handle */
+  /* Main cleanup */
+  curl_global_cleanup();
+  free_globalconfig();
+
+  /* Free the OperationConfig structures */
+  config_free(global->last);
+  global->first = NULL;
+  global->last = NULL;
 }

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -29,14 +29,16 @@
 #include "tool_main.h"
 #include "memdebug.h" /* keep this as LAST include */
 
-struct OperationConfig *config_alloc(struct GlobalConfig *global)
+struct GlobalConfig globalconf;
+struct GlobalConfig *global;
+
+struct OperationConfig *config_alloc(void)
 {
   struct OperationConfig *config =
     calloc(1, sizeof(struct OperationConfig));
   if(!config)
     return NULL;
 
-  config->global = global;
   config->use_httpget = FALSE;
   config->create_dirs = FALSE;
   config->maxredirs = DEFAULT_MAXREDIRS;

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -62,7 +62,7 @@
 #define tool_safefree(ptr)                      \
   do { free((ptr)); (ptr) = NULL;} while(0)
 
-struct GlobalConfig;
+extern struct GlobalConfig *global;
 
 struct State {
   struct getout *urlnode;
@@ -188,7 +188,6 @@ struct OperationConfig {
   char *ech;                      /* Config set by --ech keywords */
   char *ech_config;               /* Config set by "--ech esl:" option */
   char *ech_public;               /* Config set by "--ech pn:" option */
-  struct GlobalConfig *global;
   struct OperationConfig *prev;
   struct OperationConfig *next;   /* Always last in the struct */
   curl_off_t condtime;
@@ -377,7 +376,7 @@ struct GlobalConfig {
   BIT(isatty);                    /* Updated internally if output is a tty */
 };
 
-struct OperationConfig *config_alloc(struct GlobalConfig *global);
+struct OperationConfig *config_alloc(void);
 void config_free(struct OperationConfig *config);
 
 #endif /* HEADER_CURL_TOOL_CFGABLE_H */

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -378,5 +378,7 @@ struct GlobalConfig {
 
 struct OperationConfig *config_alloc(void);
 void config_free(struct OperationConfig *config);
+CURLcode globalconf_init(void);
+void globalconf_free(void);
 
 #endif /* HEADER_CURL_TOOL_CFGABLE_H */

--- a/src/tool_dirhie.c
+++ b/src/tool_dirhie.c
@@ -39,39 +39,39 @@
 #  endif
 #endif
 
-static void show_dir_errno(struct GlobalConfig *global, const char *name)
+static void show_dir_errno(const char *name)
 {
   switch(errno) {
 #ifdef EACCES
   /* !checksrc! disable ERRNOVAR 1 */
   case EACCES:
-    errorf(global, "You do not have permission to create %s", name);
+    errorf("You do not have permission to create %s", name);
     break;
 #endif
 #ifdef ENAMETOOLONG
   case ENAMETOOLONG:
-    errorf(global, "The directory name %s is too long", name);
+    errorf("The directory name %s is too long", name);
     break;
 #endif
 #ifdef EROFS
   case EROFS:
-    errorf(global, "%s resides on a read-only file system", name);
+    errorf("%s resides on a read-only file system", name);
     break;
 #endif
 #ifdef ENOSPC
   case ENOSPC:
-    errorf(global, "No space left on the file system that will "
+    errorf("No space left on the file system that will "
            "contain the directory %s", name);
     break;
 #endif
 #ifdef EDQUOT
   case EDQUOT:
-    errorf(global, "Cannot create directory %s because you "
+    errorf("Cannot create directory %s because you "
            "exceeded your quota", name);
     break;
 #endif
   default:
-    errorf(global, "Error creating directory %s", name);
+    errorf("Error creating directory %s", name);
     break;
   }
 }
@@ -90,7 +90,7 @@ static void show_dir_errno(struct GlobalConfig *global, const char *name)
 #define PATH_DELIMITERS DIR_CHAR
 #endif
 
-CURLcode create_dir_hierarchy(const char *outfile, struct GlobalConfig *global)
+CURLcode create_dir_hierarchy(const char *outfile)
 {
   CURLcode result = CURLE_OK;
   size_t outlen = strlen(outfile);
@@ -128,7 +128,7 @@ CURLcode create_dir_hierarchy(const char *outfile, struct GlobalConfig *global)
     /* !checksrc! disable ERRNOVAR 1 */
     if(!skip && (mkdir(curlx_dyn_ptr(&dirbuf), (mode_t)0000750) == -1) &&
        (errno != EACCES) && (errno != EEXIST)) {
-      show_dir_errno(global, curlx_dyn_ptr(&dirbuf));
+      show_dir_errno(curlx_dyn_ptr(&dirbuf));
       result = CURLE_WRITE_ERROR;
       break; /* get out of loop */
     }

--- a/src/tool_dirhie.h
+++ b/src/tool_dirhie.h
@@ -26,7 +26,6 @@
 #include "tool_setup.h"
 #include "tool_cfgable.h"
 
-CURLcode create_dir_hierarchy(const char *outfile,
-                              struct GlobalConfig *global);
+CURLcode create_dir_hierarchy(const char *outfileo);
 
 #endif /* HEADER_CURL_TOOL_DIRHIE_H */

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -768,14 +768,14 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
                            &clientAddrLen);
 
   if(socket_w == CURL_SOCKET_BAD) {
-    errorf("accept error: %08lx\n", GetLastError());
+    errorf("accept error: %08lx", GetLastError());
     goto ThreadCleanup;
   }
 
   closesocket(tdata->socket_l); /* sclose here fails test 1498 */
   tdata->socket_l = CURL_SOCKET_BAD;
   if(shutdown(socket_w, SD_RECEIVE) == SOCKET_ERROR) {
-    errorf("shutdown error: %08lx\n", GetLastError());
+    errorf("shutdown error: %08lx", GetLastError());
     goto ThreadCleanup;
   }
   for(;;) {
@@ -862,7 +862,7 @@ curl_socket_t win32_stdin_read_thread(void)
 
     result = listen(tdata->socket_l, 1);
     if(result == SOCKET_ERROR) {
-      errorf("listen error: %08lx\n", GetLastError());
+      errorf("listen error: %08lx", GetLastError());
       break;
     }
 

--- a/src/tool_doswin.c
+++ b/src/tool_doswin.c
@@ -746,13 +746,11 @@ CURLcode win32_init(void)
    by nmap and ncat (https://nmap.org/ncat/) */
 struct win_thread_data {
   /* This is a copy of the true stdin file handle before any redirection. It is
-      read by the thread. */
+     read by the thread. */
   HANDLE stdin_handle;
   /* This is the listen socket for the thread. It is closed after the first
-      connection. */
+     connection. */
   curl_socket_t socket_l;
-  /* This is the global config - used for printing errors and so forth */
-  struct GlobalConfig *global;
 };
 
 static DWORD WINAPI win_stdin_thread_func(void *thread_data)
@@ -770,14 +768,14 @@ static DWORD WINAPI win_stdin_thread_func(void *thread_data)
                            &clientAddrLen);
 
   if(socket_w == CURL_SOCKET_BAD) {
-    errorf(tdata->global, "accept error: %08lx\n", GetLastError());
+    errorf("accept error: %08lx\n", GetLastError());
     goto ThreadCleanup;
   }
 
   closesocket(tdata->socket_l); /* sclose here fails test 1498 */
   tdata->socket_l = CURL_SOCKET_BAD;
   if(shutdown(socket_w, SD_RECEIVE) == SOCKET_ERROR) {
-    errorf(tdata->global, "shutdown error: %08lx\n", GetLastError());
+    errorf("shutdown error: %08lx\n", GetLastError());
     goto ThreadCleanup;
   }
   for(;;) {
@@ -813,7 +811,7 @@ ThreadCleanup:
 static HANDLE stdin_thread = NULL;
 static curl_socket_t socket_r = CURL_SOCKET_BAD;
 
-curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global)
+curl_socket_t win32_stdin_read_thread(void)
 {
   int result;
   bool r;
@@ -831,7 +829,7 @@ curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global)
     /* Prepare handles for thread */
     tdata = (struct win_thread_data*)calloc(1, sizeof(struct win_thread_data));
     if(!tdata) {
-      errorf(global, "calloc() error");
+      errorf("calloc() error");
       break;
     }
     /* Create the listening socket for the thread. When it starts, it will
@@ -840,7 +838,7 @@ curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global)
                                  IPPROTO_TCP, NULL, 0, WSA_FLAG_OVERLAPPED);
 
     if(tdata->socket_l == CURL_SOCKET_BAD) {
-      errorf(global, "WSASocketW error: %08lx", GetLastError());
+      errorf("WSASocketW error: %08lx", GetLastError());
       break;
     }
 
@@ -851,20 +849,20 @@ curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global)
     /* Bind to any available loopback port */
     result = bind(tdata->socket_l, (SOCKADDR*)&selfaddr, socksize);
     if(result == SOCKET_ERROR) {
-      errorf(global, "bind error: %08lx", GetLastError());
+      errorf("bind error: %08lx", GetLastError());
       break;
     }
 
     /* Bind to any available loopback port */
     result = getsockname(tdata->socket_l, (SOCKADDR*)&selfaddr, &socksize);
     if(result == SOCKET_ERROR) {
-      errorf(global, "getsockname error: %08lx", GetLastError());
+      errorf("getsockname error: %08lx", GetLastError());
       break;
     }
 
     result = listen(tdata->socket_l, 1);
     if(result == SOCKET_ERROR) {
-      errorf(global, "listen error: %08lx\n", GetLastError());
+      errorf("listen error: %08lx\n", GetLastError());
       break;
     }
 
@@ -874,7 +872,7 @@ curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global)
                         0, FALSE, DUPLICATE_SAME_ACCESS);
 
     if(!r) {
-      errorf(global, "DuplicateHandle error: %08lx", GetLastError());
+      errorf("DuplicateHandle error: %08lx", GetLastError());
       break;
     }
 
@@ -885,14 +883,14 @@ curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global)
     stdin_thread = CreateThread(NULL, 0, win_stdin_thread_func,
                                 tdata, 0, NULL);
     if(!stdin_thread) {
-      errorf(global, "CreateThread error: %08lx", GetLastError());
+      errorf("CreateThread error: %08lx", GetLastError());
       break;
     }
 
     /* Connect to the thread and rearrange our own STDIN handles */
     socket_r = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if(socket_r == CURL_SOCKET_BAD) {
-      errorf(global, "socket error: %08lx", GetLastError());
+      errorf("socket error: %08lx", GetLastError());
       break;
     }
 
@@ -900,18 +898,18 @@ curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global)
     setsockopt(socket_r, SOL_SOCKET, SO_DONTLINGER, 0, 0);
 
     if(connect(socket_r, (SOCKADDR*)&selfaddr, socksize) == SOCKET_ERROR) {
-      errorf(global, "connect error: %08lx", GetLastError());
+      errorf("connect error: %08lx", GetLastError());
       break;
     }
 
     if(shutdown(socket_r, SD_SEND) == SOCKET_ERROR) {
-      errorf(global, "shutdown error: %08lx", GetLastError());
+      errorf("shutdown error: %08lx", GetLastError());
       break;
     }
 
     /* Set the stdin handle to read from the socket. */
     if(SetStdHandle(STD_INPUT_HANDLE, (HANDLE)socket_r) == 0) {
-      errorf(global, "SetStdHandle error: %08lx", GetLastError());
+      errorf("SetStdHandle error: %08lx", GetLastError());
       break;
     }
 

--- a/src/tool_doswin.h
+++ b/src/tool_doswin.h
@@ -56,7 +56,7 @@ struct curl_slist *GetLoadedModulePaths(void);
 CURLcode win32_init(void);
 
 #if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
-curl_socket_t win32_stdin_read_thread(struct GlobalConfig *global);
+curl_socket_t win32_stdin_read_thread(void);
 #endif /* !CURL_WINDOWS_UWP && !UNDER_CE */
 
 #endif /* _WIN32 */

--- a/src/tool_easysrc.c
+++ b/src/tool_easysrc.c
@@ -170,7 +170,7 @@ CURLcode easysrc_cleanup(void)
   return ret;
 }
 
-void dumpeasysrc(struct GlobalConfig *global)
+void dumpeasysrc(void)
 {
   struct curl_slist *ptr;
   char *o = global->libcurl;
@@ -184,7 +184,7 @@ void dumpeasysrc(struct GlobalConfig *global)
   else
     out = stdout;
   if(!out)
-    warnf(global, "Failed to open %s to write libcurl code", o);
+    warnf("Failed to open %s to write libcurl code", o);
   else {
     int i;
     const char *c;

--- a/src/tool_easysrc.h
+++ b/src/tool_easysrc.h
@@ -43,8 +43,7 @@ extern CURLcode easysrc_addf(struct slist_wc **plist,
                              const char *fmt, ...) CURL_PRINTF(2, 3);
 extern CURLcode easysrc_perform(void);
 extern CURLcode easysrc_cleanup(void);
-
-void dumpeasysrc(struct GlobalConfig *global);
+void dumpeasysrc(void);
 
 #else /* CURL_DISABLE_LIBCURL_OPTION is defined */
 

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -32,8 +32,7 @@
 #endif
 
 /* Returns 0 on success, non-zero on file problems */
-int getfiletime(const char *filename, struct GlobalConfig *global,
-                curl_off_t *stamp)
+int getfiletime(const char *filename, curl_off_t *stamp)
 {
   int rc = 1;
 
@@ -81,14 +80,13 @@ int getfiletime(const char *filename, struct GlobalConfig *global,
     rc = 0;
   }
   else
-    warnf(global, "Failed to get filetime: %s", strerror(errno));
+    warnf("Failed to get filetime: %s", strerror(errno));
 #endif
   return rc;
 }
 
 #if defined(HAVE_UTIME) || defined(HAVE_UTIMES) || defined(_WIN32)
-void setfiletime(curl_off_t filetime, const char *filename,
-                 struct GlobalConfig *global)
+void setfiletime(curl_off_t filetime, const char *filename)
 {
   if(filetime >= 0) {
 /* Windows utime() may attempt to adjust the Unix GMT file time by a daylight
@@ -136,7 +134,7 @@ void setfiletime(curl_off_t filetime, const char *filename,
     times[0].tv_sec = times[1].tv_sec = (time_t)filetime;
     times[0].tv_usec = times[1].tv_usec = 0;
     if(utimes(filename, times)) {
-      warnf(global, "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
+      warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
             " on '%s': %s", filetime, filename, strerror(errno));
     }
 

--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -55,21 +55,21 @@ int getfiletime(const char *filename, curl_off_t *stamp)
         | ((curl_off_t)ft.dwHighDateTime) << 32;
 
       if(converted < 116444736000000000)
-        warnf(global, "Failed to get filetime: underflow");
+        warnf("Failed to get filetime: underflow");
       else {
         *stamp = (converted - 116444736000000000) / 10000000;
         rc = 0;
       }
     }
     else {
-      warnf(global, "Failed to get filetime: "
+      warnf("Failed to get filetime: "
             "GetFileTime failed: GetLastError %u",
             (unsigned int)GetLastError());
     }
     CloseHandle(hfile);
   }
   else if(GetLastError() != ERROR_FILE_NOT_FOUND) {
-    warnf(global, "Failed to get filetime: "
+    warnf("Failed to get filetime: "
           "CreateFile failed: GetLastError %u",
           (unsigned int)GetLastError());
   }
@@ -99,7 +99,7 @@ void setfiletime(curl_off_t filetime, const char *filename)
     /* 910670515199 is the maximum Unix filetime that can be used as a
        Windows FILETIME without overflow: 30827-12-31T23:59:59. */
     if(filetime > 910670515199) {
-      warnf(global, "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
+      warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
             " on outfile: overflow", filetime);
       curlx_unicodefree(tchar_filename);
       return;
@@ -117,14 +117,14 @@ void setfiletime(curl_off_t filetime, const char *filename)
       ft.dwLowDateTime = (DWORD)(converted & 0xFFFFFFFF);
       ft.dwHighDateTime = (DWORD)(converted >> 32);
       if(!SetFileTime(hfile, NULL, &ft, &ft)) {
-        warnf(global, "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
+        warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
               " on outfile: SetFileTime failed: GetLastError %u",
               filetime, (unsigned int)GetLastError());
       }
       CloseHandle(hfile);
     }
     else {
-      warnf(global, "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
+      warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
             " on outfile: CreateFile failed: GetLastError %u",
             filetime, (unsigned int)GetLastError());
     }
@@ -143,7 +143,7 @@ void setfiletime(curl_off_t filetime, const char *filename)
     times.actime = (time_t)filetime;
     times.modtime = (time_t)filetime;
     if(utime(filename, &times)) {
-      warnf(global, "Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
+      warnf("Failed to set filetime %" CURL_FORMAT_CURL_OFF_T
             " on '%s': %s", filetime, filename, strerror(errno));
     }
 #endif

--- a/src/tool_filetime.h
+++ b/src/tool_filetime.h
@@ -25,15 +25,11 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-struct GlobalConfig;
-
-int getfiletime(const char *filename, struct GlobalConfig *global,
-                curl_off_t *stamp);
+int getfiletime(const char *filename, curl_off_t *stamp);
 
 #if defined(HAVE_UTIME) || defined(HAVE_UTIMES) || \
   (defined(_WIN32) && (SIZEOF_CURL_OFF_T >= 8))
-void setfiletime(curl_off_t filetime, const char *filename,
-                 struct GlobalConfig *global);
+void setfiletime(curl_off_t filetime, const char *filename);
 #else
 #define setfiletime(a,b,c) tool_nop_stmt
 #endif

--- a/src/tool_formparse.h
+++ b/src/tool_formparse.h
@@ -55,15 +55,13 @@ struct tool_mime {
   curl_off_t origin;            /* Stdin read origin offset. */
   curl_off_t size;              /* Stdin data size. */
   curl_off_t curpos;            /* Stdin current read position. */
-  struct GlobalConfig *global;  /* For access from callback. */
 };
 
 size_t tool_mime_stdin_read(char *buffer,
                             size_t size, size_t nitems, void *arg);
 int tool_mime_stdin_seek(void *instream, curl_off_t offset, int whence);
 
-int formparse(struct OperationConfig *config,
-              const char *input,
+int formparse(const char *input,
               struct tool_mime **mimeroot,
               struct tool_mime **mimecurrent,
               bool literal_value);

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2354,8 +2354,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     break;
   case C_LIBCURL: /* --libcurl */
 #ifdef CURL_DISABLE_LIBCURL_OPTION
-    warnf(global,
-          "--libcurl option was disabled at build-time");
+    warnf("--libcurl option was disabled at build-time");
     err = PARAM_OPTION_UNKNOWN;
 #else
     err = getstr(&global->libcurl, nextarg, DENY_BLANK);

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -523,8 +523,7 @@ GetFileAndPassword(const char *nextarg, char **file, char **password)
 /* Get a size parameter for '--limit-rate' or '--max-filesize'.
  * We support a 'G', 'M' or 'K' suffix too.
   */
-static ParameterError GetSizeParameter(struct GlobalConfig *global,
-                                       const char *arg,
+static ParameterError GetSizeParameter(const char *arg,
                                        const char *which,
                                        curl_off_t *value_out)
 {
@@ -532,7 +531,7 @@ static ParameterError GetSizeParameter(struct GlobalConfig *global,
   curl_off_t value;
 
   if(curlx_str_number(&unit, &value, CURL_OFF_T_MAX)) {
-    warnf(global, "invalid number specified for %s", which);
+    warnf("invalid number specified for %s", which);
     return PARAM_BAD_USE;
   }
 
@@ -565,7 +564,7 @@ static ParameterError GetSizeParameter(struct GlobalConfig *global,
     /* for plain bytes, leave as-is */
     break;
   default:
-    warnf(global, "unsupported %s unit. Use G, M, K or B", which);
+    warnf("unsupported %s unit. Use G, M, K or B", which);
     return PARAM_BAD_USE;
   }
   *value_out = value;
@@ -591,8 +590,7 @@ static void cleanarg(char *str)
 #define MAX_DATAURLENCODE (500*1024*1024)
 
 /* --data-urlencode */
-static ParameterError data_urlencode(struct GlobalConfig *global,
-                                     const char *nextarg,
+static ParameterError data_urlencode(const char *nextarg,
                                      char **postp,
                                      size_t *lenp)
 {
@@ -631,7 +629,7 @@ static ParameterError data_urlencode(struct GlobalConfig *global,
     else {
       file = fopen(p, "rb");
       if(!file) {
-        errorf(global, "Failed to open %s", p);
+        errorf("Failed to open %s", p);
         return PARAM_READ_ERROR;
       }
     }
@@ -698,13 +696,12 @@ static void sethttpver(struct OperationConfig *config,
 {
   if(config->httpversion &&
      (config->httpversion != httpversion))
-    warnf(config->global, "Overrides previous HTTP version option");
+    warnf("Overrides previous HTTP version option");
 
   config->httpversion = httpversion;
 }
 
-static CURLcode set_trace_config(struct GlobalConfig *global,
-                                 const char *token)
+static CURLcode set_trace_config(const char *token)
 {
   CURLcode result = CURLE_OK;
   const char *next, *name;
@@ -858,7 +855,7 @@ static ParameterError url_query(const char *nextarg,
       err = PARAM_NO_MEM;
   }
   else
-    err = data_urlencode(config->global, nextarg, &query, &size);
+    err = data_urlencode(nextarg, &query, &size);
 
   if(!err) {
     if(config->query) {
@@ -885,10 +882,9 @@ static ParameterError set_data(cmdline_t cmd,
   FILE *file;
   size_t size = 0;
   ParameterError err = PARAM_OK;
-  struct GlobalConfig *global = config->global;
 
   if(cmd == C_DATA_URLENCODE) { /* --data-urlencode */
-    err = data_urlencode(global, nextarg, &postdata, &size);
+    err = data_urlencode(nextarg, &postdata, &size);
     if(err)
       return err;
   }
@@ -905,7 +901,7 @@ static ParameterError set_data(cmdline_t cmd,
     else {
       file = fopen(nextarg, "rb");
       if(!file) {
-        errorf(global, "Failed to open %s", nextarg);
+        errorf("Failed to open %s", nextarg);
         return PARAM_READ_ERROR;
       }
     }
@@ -958,8 +954,7 @@ static ParameterError set_data(cmdline_t cmd,
   return err;
 }
 
-static ParameterError set_rate(struct GlobalConfig *global,
-                               const char *nextarg)
+static ParameterError set_rate(const char *nextarg)
 {
   /* --rate */
   /* support a few different suffixes, extract the suffix first, then
@@ -1007,14 +1002,14 @@ static ParameterError set_rate(struct GlobalConfig *global,
       numerator = 24*60*60*1000;
       break;
     default:
-      errorf(global, "unsupported --rate unit");
+      errorf("unsupported --rate unit");
       err = PARAM_BAD_USE;
       break;
     }
 
     if((LONG_MAX / numerator) < numunits) {
       /* overflow, too large number */
-      errorf(global, "too large --rate unit");
+      errorf("too large --rate unit");
       err = PARAM_NUMBER_TOO_LARGE;
     }
     /* this typecast is okay based on the check above */
@@ -1076,7 +1071,7 @@ static ParameterError add_url(struct OperationConfig *config,
       url->useremote = url->noglob = TRUE;
     if(!err && (++config->num_urls > 1) &&
        (config->etag_save_file || config->etag_compare_file)) {
-      errorf(config->global, "The etag options only work on a single URL");
+      errorf("The etag options only work on a single URL");
       return PARAM_BAD_USE;
     }
   }
@@ -1159,20 +1154,17 @@ static ParameterError parse_localport(struct OperationConfig *config,
 static ParameterError parse_continue_at(struct OperationConfig *config,
                                         const char *nextarg)
 {
-  struct GlobalConfig *global = config->global;
   ParameterError err = PARAM_OK;
   if(config->range) {
-    errorf(global, "--continue-at is mutually exclusive with --range");
+    errorf("--continue-at is mutually exclusive with --range");
     return PARAM_BAD_USE;
   }
   if(config->rm_partial) {
-    errorf(config->global,
-           "--continue-at is mutually exclusive with --remove-on-error");
+    errorf("--continue-at is mutually exclusive with --remove-on-error");
     return PARAM_BAD_USE;
   }
   if(config->file_clobber_mode == CLOBBER_NEVER) {
-    errorf(config->global,
-           "--continue-at is mutually exclusive with --no-clobber");
+    errorf("--continue-at is mutually exclusive with --no-clobber");
     return PARAM_BAD_USE;
   }
   /* This makes us continue an ftp transfer at given position */
@@ -1216,8 +1208,7 @@ static ParameterError parse_ech(struct OperationConfig *config,
         file = fopen(nextarg, FOPEN_READTEXT);
       }
       if(!file) {
-        warnf(config->global,
-              "Couldn't read file \"%s\" "
+        warnf("Couldn't read file \"%s\" "
               "specified for \"--ech ecl:\" option",
               nextarg);
         return PARAM_BAD_USE; /*  */
@@ -1252,7 +1243,7 @@ static ParameterError parse_header(struct OperationConfig *config,
     bool use_stdin = !strcmp(&nextarg[1], "-");
     FILE *file = use_stdin ? stdin : fopen(&nextarg[1], FOPEN_READTEXT);
     if(!file) {
-      errorf(config->global, "Failed to open %s", &nextarg[1]);
+      errorf("Failed to open %s", &nextarg[1]);
       err = PARAM_READ_ERROR;
     }
     else {
@@ -1392,10 +1383,9 @@ static ParameterError parse_range(struct OperationConfig *config,
   ParameterError err = PARAM_OK;
   curl_off_t value;
   const char *orig = nextarg;
-  struct GlobalConfig *global = config->global;
 
   if(config->use_resume) {
-    errorf(global, "--continue-at is mutually exclusive with --range");
+    errorf("--continue-at is mutually exclusive with --range");
     return PARAM_BAD_USE;
   }
   if(!curlx_str_number(&nextarg, &value, CURL_OFF_T_MAX) &&
@@ -1405,7 +1395,7 @@ static ParameterError parse_range(struct OperationConfig *config,
        claimed that to be a good way, why this code is added to work-around
        it. */
     char buffer[32];
-    warnf(global, "A specified range MUST include at least one dash (-). "
+    warnf("A specified range MUST include at least one dash (-). "
           "Appending one for you");
     msnprintf(buffer, sizeof(buffer), "%" CURL_FORMAT_CURL_OFF_T "-",
               value);
@@ -1418,7 +1408,7 @@ static ParameterError parse_range(struct OperationConfig *config,
     /* byte range requested */
     while(*nextarg) {
       if(!ISDIGIT(*nextarg) && *nextarg != '-' && *nextarg != ',') {
-        warnf(global, "Invalid character is found in given range. "
+        warnf("Invalid character is found in given range. "
               "A specified range MUST have only digits in "
               "\'start\'-\'stop\'. The server's response to this "
               "request is uncertain.");
@@ -1471,8 +1461,7 @@ static ParameterError parse_upload_file(struct OperationConfig *config,
 
 static size_t verbose_nopts;
 
-static ParameterError parse_verbose(struct GlobalConfig *global,
-                                    bool toggle)
+static ParameterError parse_verbose(bool toggle)
 {
   ParameterError err = PARAM_OK;
 
@@ -1480,7 +1469,7 @@ static ParameterError parse_verbose(struct GlobalConfig *global,
    * more than once in the same argument flag, like `-vvv`. */
   if(!toggle) {
     global->verbosity = 0;
-    if(set_trace_config(global, "-all"))
+    if(set_trace_config("-all"))
       err = PARAM_NO_MEM;
     global->tracetype = TRACE_NONE;
     return err;
@@ -1488,7 +1477,7 @@ static ParameterError parse_verbose(struct GlobalConfig *global,
   else if(!verbose_nopts) {
     /* fist `-v` in an argument resets to base verbosity */
     global->verbosity = 0;
-    if(set_trace_config(global, "-all"))
+    if(set_trace_config("-all"))
       return PARAM_NO_MEM;
   }
   /* the '%' thing here will cause the trace get sent to stderr */
@@ -1501,25 +1490,24 @@ static ParameterError parse_verbose(struct GlobalConfig *global,
       err = PARAM_NO_MEM;
     else {
       if(global->tracetype && (global->tracetype != TRACE_PLAIN))
-        warnf(global,
-              "-v, --verbose overrides an earlier trace option");
+        warnf("-v, --verbose overrides an earlier trace option");
       global->tracetype = TRACE_PLAIN;
     }
     break;
   case 1:
     global->verbosity = 2;
-    if(set_trace_config(global, "ids,time,protocol"))
+    if(set_trace_config("ids,time,protocol"))
       err = PARAM_NO_MEM;
     break;
   case 2:
     global->verbosity = 3;
     global->tracetype = TRACE_ASCII;
-    if(set_trace_config(global, "ssl,read,write"))
+    if(set_trace_config("ssl,read,write"))
       err = PARAM_NO_MEM;
     break;
   case 3:
     global->verbosity = 4;
-    if(set_trace_config(global, "network"))
+    if(set_trace_config("network"))
       err = PARAM_NO_MEM;
     break;
   default:
@@ -1549,7 +1537,7 @@ static ParameterError parse_writeout(struct OperationConfig *config,
       fname = nextarg;
       file = fopen(fname, FOPEN_READTEXT);
       if(!file) {
-        errorf(config->global, "Failed to open %s", fname);
+        errorf("Failed to open %s", fname);
         return PARAM_READ_ERROR;
       }
     }
@@ -1560,7 +1548,7 @@ static ParameterError parse_writeout(struct OperationConfig *config,
     if(err)
       return err;
     if(!config->writeout)
-      warnf(config->global, "Failed to read %s", fname);
+      warnf("Failed to read %s", fname);
   }
   else
     err = getstr(&config->writeout, nextarg, ALLOW_BLANK);
@@ -1596,15 +1584,14 @@ static ParameterError parse_time_cond(struct OperationConfig *config,
   if(config->condtime == -1) {
     curl_off_t value;
     /* now let's see if it is a filename to get the time from instead! */
-    int rc = getfiletime(nextarg, config->global, &value);
+    int rc = getfiletime(nextarg, &value);
     if(!rc)
       /* pull the time out from the file */
       config->condtime = value;
     else {
       /* failed, remove time condition */
       config->timecond = CURL_TIMECOND_NONE;
-      warnf(config->global,
-            "Illegal date format for -z, --time-cond (and not "
+      warnf("Illegal date format for -z, --time-cond (and not "
             "a filename). Disabling time condition. "
             "See curl_getdate(3) for valid date syntax.");
     }
@@ -1684,10 +1671,9 @@ static void togglebit(bool toggle, unsigned long *modify, unsigned long bits)
 }
 
 /* opt_depr is the function that handles ARG_DEPR options */
-static void opt_depr(struct GlobalConfig *global,
-                     const struct LongShort *a)
+static void opt_depr(const struct LongShort *a)
 {
-  warnf(global, "--%s is deprecated and has no function anymore", a->lname);
+  warnf("--%s is deprecated and has no function anymore", a->lname);
 }
 
 static ParameterError opt_sslver(struct OperationConfig *config,
@@ -1695,7 +1681,7 @@ static ParameterError opt_sslver(struct OperationConfig *config,
 {
   if(config->ssl_version_max &&
      (config->ssl_version_max < ver)) {
-    errorf(config->global, "Minimum TLS version set higher than max");
+    errorf("Minimum TLS version set higher than max");
     return PARAM_BAD_USE;
   }
   config->ssl_version = ver;
@@ -1787,7 +1773,6 @@ static ParameterError opt_bool(struct OperationConfig *config,
                                const struct LongShort *a,
                                bool toggle)
 {
-  struct GlobalConfig *global = config->global;
   switch(a->cmd) {
   case C_ALPN: /* --alpn */
     config->noalpn = !toggle;
@@ -1864,7 +1849,7 @@ static ParameterError opt_bool(struct OperationConfig *config,
   case C_SSL: /* --ssl */
     config->ftp_ssl = toggle;
     if(config->ftp_ssl)
-      warnf(global, "--%s is an insecure option, consider --ssl-reqd instead",
+      warnf("--%s is an insecure option, consider --ssl-reqd instead",
             a->lname);
     break;
   case C_FTP_SSL_CCC: /* --ftp-ssl-ccc */
@@ -2011,7 +1996,7 @@ static ParameterError opt_bool(struct OperationConfig *config,
     config->doh_verifystatus = toggle;
     break;
   case C_FALSE_START: /* --false-start */
-    opt_depr(global, a);
+    opt_depr(a);
     break;
   case C_SSL_NO_REVOKE: /* --ssl-no-revoke */
     config->ssl_no_revoke = toggle;
@@ -2046,15 +2031,14 @@ static ParameterError opt_bool(struct OperationConfig *config,
   case C_FAIL_WITH_BODY: /* --fail-with-body */
     config->failwithbody = toggle;
     if(config->failonerror && config->failwithbody) {
-      errorf(config->global, "You must select either --fail or "
+      errorf("You must select either --fail or "
              "--fail-with-body, not both.");
       return PARAM_BAD_USE;
     }
     break;
   case C_REMOVE_ON_ERROR: /* --remove-on-error */
     if(config->use_resume && toggle) {
-      errorf(config->global,
-             "--continue-at is mutually exclusive with --remove-on-error");
+      errorf("--continue-at is mutually exclusive with --remove-on-error");
       return PARAM_BAD_USE;
     }
     config->rm_partial = toggle;
@@ -2062,7 +2046,7 @@ static ParameterError opt_bool(struct OperationConfig *config,
   case C_FAIL: /* --fail */
     config->failonerror = toggle;
     if(config->failonerror && config->failwithbody) {
-      errorf(config->global, "You must select either --fail or "
+      errorf("You must select either --fail or "
              "--fail-with-body, not both.");
       return PARAM_BAD_USE;
     }
@@ -2083,7 +2067,7 @@ static ParameterError opt_bool(struct OperationConfig *config,
   case C_HEAD: /* --head */
     config->no_body = toggle;
     config->show_headers = toggle;
-    if(SetHTTPrequest(config, (config->no_body) ? TOOL_HTTPREQ_HEAD :
+    if(SetHTTPrequest((config->no_body) ? TOOL_HTTPREQ_HEAD :
                       TOOL_HTTPREQ_GET, &config->httpreq))
       return PARAM_BAD_USE;
     break;
@@ -2117,8 +2101,7 @@ static ParameterError opt_bool(struct OperationConfig *config,
     break;
   case C_CLOBBER: /* --clobber */
     if(config->use_resume && !toggle) {
-      errorf(config->global,
-             "--continue-at is mutually exclusive with --no-clobber");
+      errorf("--continue-at is mutually exclusive with --no-clobber");
       return PARAM_BAD_USE;
     }
     config->file_clobber_mode = toggle ? CLOBBER_ALWAYS : CLOBBER_NEVER;
@@ -2146,7 +2129,7 @@ static ParameterError opt_bool(struct OperationConfig *config,
     global->showerror = toggle;
     break;
   case C_VERBOSE: /* --verbose */
-    return parse_verbose(global, toggle);
+    return parse_verbose(toggle);
     break;
   case C_VERSION: /* --version */
     if(toggle)    /* --no-version yields no output! */
@@ -2166,12 +2149,12 @@ static ParameterError opt_bool(struct OperationConfig *config,
     FALLTHROUGH();
   case C_LOCATION: /* --location */
     if(config->followlocation == CURLFOLLOW_OBEYCODE)
-      warnf(global, "--location overrides --follow");
+      warnf("--location overrides --follow");
     config->followlocation = toggle ? CURLFOLLOW_ALL : 0;
     break;
   case C_FOLLOW: /* --follow */
     if(config->followlocation == CURLFOLLOW_ALL)
-      warnf(global, "--follow overrides --location");
+      warnf("--follow overrides --location");
     config->followlocation = toggle ? CURLFOLLOW_OBEYCODE : 0;
     break;
   default:
@@ -2189,7 +2172,6 @@ static ParameterError opt_filestring(struct OperationConfig *config,
   ParameterError err = PARAM_OK;
   curl_off_t value;
   long val;
-  struct GlobalConfig *global = config->global;
   static const char *redir_protos[] = {
     "http",
     "https",
@@ -2249,7 +2231,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     err = getstr(&global->trace_dump, nextarg, DENY_BLANK);
     if(!err) {
       if(global->tracetype && (global->tracetype != TRACE_BIN))
-        warnf(global, "--trace overrides an earlier trace/verbose option");
+        warnf("--trace overrides an earlier trace/verbose option");
       global->tracetype = TRACE_BIN;
     }
     break;
@@ -2257,20 +2239,19 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     err = getstr(&global->trace_dump, nextarg, DENY_BLANK);
     if(!err) {
       if(global->tracetype && (global->tracetype != TRACE_ASCII))
-        warnf(global,
-              "--trace-ascii overrides an earlier trace/verbose option");
+        warnf("--trace-ascii overrides an earlier trace/verbose option");
       global->tracetype = TRACE_ASCII;
     }
     break;
   case C_LIMIT_RATE: /* --limit-rate */
-    err = GetSizeParameter(global, nextarg, "rate", &value);
+    err = GetSizeParameter(nextarg, "rate", &value);
     if(!err) {
       config->recvpersecond = value;
       config->sendpersecond = value;
     }
     break;
   case C_RATE:
-    err = set_rate(global, nextarg);
+    err = set_rate(nextarg);
     break;
   case C_CREATE_FILE_MODE: /* --create-file-mode */
     err = oct2nummax(&config->create_file_mode, nextarg, 0777);
@@ -2292,7 +2273,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     err = getstr(&config->aws_sigv4, nextarg, ALLOW_BLANK);
     break;
   case C_STDERR: /* --stderr */
-    tool_set_stderr_file(global, nextarg);
+    tool_set_stderr_file(nextarg);
     break;
   case C_INTERFACE: /* --interface */
     /* interface */
@@ -2309,7 +2290,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     err = getstr(&config->haproxy_clientip, nextarg, DENY_BLANK);
     break;
   case C_MAX_FILESIZE: /* --max-filesize */
-    err = GetSizeParameter(global, nextarg, "max-filesize", &value);
+    err = GetSizeParameter(nextarg, "max-filesize", &value);
     if(!err)
       config->max_filesize = value;
     break;
@@ -2363,7 +2344,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     err = getstr(&config->ftp_account, nextarg, DENY_BLANK);
     break;
   case C_FTP_METHOD: /* --ftp-method */
-    config->ftp_filemethod = ftpfilemethod(config, nextarg);
+    config->ftp_filemethod = ftpfilemethod(nextarg);
     break;
   case C_LOCAL_PORT: /* --local-port */
     err = parse_localport(config, nextarg);
@@ -2407,19 +2388,18 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     break;
   case C_PROTO: /* --proto */
     config->proto_present = TRUE;
-    err = proto2num(config, built_in_protos, &config->proto_str, nextarg);
+    err = proto2num(built_in_protos, &config->proto_str, nextarg);
     break;
   case C_PROTO_REDIR: /* --proto-redir */
     config->proto_redir_present = TRUE;
-    if(proto2num(config, redir_protos, &config->proto_redir_str,
-                 nextarg))
+    if(proto2num(redir_protos, &config->proto_redir_str, nextarg))
       err = PARAM_BAD_USE;
     break;
   case C_RESOLVE: /* --resolve */
     err = add2list(&config->resolve, nextarg);
     break;
   case C_DELEGATION: /* --delegation */
-    config->gssapi_delegation = delegation(config, nextarg);
+    config->gssapi_delegation = delegation(nextarg);
     break;
   case C_MAIL_AUTH: /* --mail-auth */
     err = getstr(&config->mail_auth, nextarg, DENY_BLANK);
@@ -2455,7 +2435,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
   case C_TLS_MAX: /* --tls-max */
     err = str2tls_max(&config->ssl_version_max, nextarg);
     if(!err && (config->ssl_version_max < config->ssl_version)) {
-      errorf(global, "--tls-max set lower than minimum accepted version");
+      errorf("--tls-max set lower than minimum accepted version");
       err = PARAM_BAD_USE;
     }
     break;
@@ -2464,11 +2444,11 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     /* 0 is a valid value for this timeout */
     break;
   case C_TRACE_CONFIG: /* --trace-config */
-    if(set_trace_config(global, nextarg))
+    if(set_trace_config(nextarg))
       err = PARAM_NO_MEM;
     break;
   case C_VARIABLE: /* --variable */
-    err = setvariable(global, nextarg);
+    err = setvariable(nextarg);
     break;
   case C_TLS13_CIPHERS: /* --tls13-ciphers */
     err = getstr(&config->cipher13_list, nextarg, DENY_BLANK);
@@ -2678,7 +2658,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     break;
   case C_ETAG_SAVE: /* --etag-save */
     if(config->num_urls > 1) {
-      errorf(global, "The etag options only work on a single URL");
+      errorf("The etag options only work on a single URL");
       err = PARAM_BAD_USE;
     }
     else
@@ -2686,7 +2666,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     break;
   case C_ETAG_COMPARE: /* --etag-compare */
     if(config->num_urls > 1) {
-      errorf(global, "The etag options only work on a single URL");
+      errorf("The etag options only work on a single URL");
       err = PARAM_BAD_USE;
     }
     else
@@ -2702,13 +2682,10 @@ static ParameterError opt_filestring(struct OperationConfig *config,
   case C_FORM_STRING: /* --form-string */
     /* "form data" simulation, this is a little advanced so lets do our best
        to sort this out slowly and carefully */
-    if(formparse(config,
-                 nextarg,
-                 &config->mimeroot,
-                 &config->mimecurrent,
+    if(formparse(nextarg, &config->mimeroot, &config->mimecurrent,
                  (a->cmd == C_FORM_STRING))) /* literal string */
       err = PARAM_BAD_USE;
-    else if(SetHTTPrequest(config, TOOL_HTTPREQ_MIMEPOST, &config->httpreq))
+    else if(SetHTTPrequest(TOOL_HTTPREQ_MIMEPOST, &config->httpreq))
       err = PARAM_BAD_USE;
     break;
   case C_REQUEST_TARGET: /* --request-target */
@@ -2719,8 +2696,8 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     err = parse_header(config, (cmdline_t)a->cmd, nextarg);
     break;
   case C_CONFIG: /* --config */
-    if(parseconfig(nextarg, global)) {
-      errorf(global, "cannot read config from '%s'", nextarg);
+    if(parseconfig(nextarg)) {
+      errorf("cannot read config from '%s'", nextarg);
       err = PARAM_READ_ERROR;
     }
     break;
@@ -2747,7 +2724,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     break;
   case C_FTP_SSL_CCC_MODE: /* --ftp-ssl-ccc-mode */
     config->ftp_ssl_ccc = TRUE;
-    config->ftp_ssl_ccc_mode = ftpcccmethod(config, nextarg);
+    config->ftp_ssl_ccc_mode = ftpcccmethod(nextarg);
     break;
   case C_QUOTE: /* --quote */
     err = parse_quote(config, nextarg);
@@ -2849,7 +2826,6 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
   bool nextalloc = FALSE; /* if nextarg is allocated */
   bool consumearg = TRUE; /* the argument comes separate */
   const struct LongShort *a = NULL;
-  struct GlobalConfig *global = config->global;
   verbose_nopts = 0; /* options processed in `flag`*/
 
   *usedarg = FALSE; /* default is that we do not use the arg */
@@ -2911,7 +2887,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         err = PARAM_EXPAND_ERROR;
         goto error;
       }
-      err = varexpand(global, nextarg, &nbuf, &replaced);
+      err = varexpand(nextarg, &nbuf, &replaced);
       if(err) {
         curlx_dyn_free(&nbuf);
         goto error;
@@ -2961,18 +2937,18 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         *usedarg = consumearg; /* mark it as used */
       }
       if(a->desc & ARG_DEPR) {
-        opt_depr(global, a);
+        opt_depr(a);
         break;
       }
 
       if((ARGTYPE(a->desc) == ARG_FILE) &&
          (nextarg[0] == '-') && nextarg[1]) {
         /* if the filename looks like a command line option */
-        warnf(global, "The filename argument '%s' looks like a flag.",
+        warnf("The filename argument '%s' looks like a flag.",
               nextarg);
       }
       else if(!strncmp("\xe2\x80\x9c", nextarg, 3)) {
-        warnf(global, "The argument '%s' starts with a Unicode quote where "
+        warnf("The argument '%s' starts with a Unicode quote where "
               "maybe an ASCII \" was intended?",
               nextarg);
       }
@@ -2983,7 +2959,7 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
     }
     else {
       if(a->desc & ARG_DEPR) {
-        opt_depr(global, a);
+        opt_depr(a);
         break;
       }
       /* ARG_NONE | ARG_BOOL */
@@ -3003,8 +2979,7 @@ error:
   return err;
 }
 
-ParameterError parse_args(struct GlobalConfig *global, int argc,
-                          argv_item_t argv[])
+ParameterError parse_args(int argc, argv_item_t argv[])
 {
   int i;
   bool stillflags;
@@ -3045,7 +3020,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
 
           if(config->url_list && config->url_list->url) {
             /* Allocate the next config */
-            config->next = config_alloc(global);
+            config->next = config_alloc();
             if(config->next) {
               /* Update the last config pointer */
               global->last = config->next;
@@ -3058,7 +3033,7 @@ ParameterError parse_args(struct GlobalConfig *global, int argc,
               result = PARAM_NO_MEM;
           }
           else {
-            errorf(global, "missing URL before --next");
+            errorf("missing URL before --next");
             result = PARAM_BAD_USE;
           }
         }

--- a/src/tool_getparam.h
+++ b/src/tool_getparam.h
@@ -360,7 +360,6 @@ typedef enum {
   PARAM_LAST
 } ParameterError;
 
-struct GlobalConfig;
 struct OperationConfig;
 
 const struct LongShort *findlongopt(const char *opt);
@@ -376,8 +375,7 @@ void parse_cert_parameter(const char *cert_parameter,
                           char **passphrase);
 #endif
 
-ParameterError parse_args(struct GlobalConfig *global, int argc,
-                          argv_item_t argv[]);
+ParameterError parse_args(int argc, argv_item_t argv[]);
 
 #if defined(UNICODE) && defined(_WIN32) && !defined(UNDER_CE)
 

--- a/src/tool_helpers.c
+++ b/src/tool_helpers.c
@@ -75,7 +75,7 @@ const char *param2text(ParameterError error)
   }
 }
 
-int SetHTTPrequest(struct OperationConfig *config, HttpReq req, HttpReq *store)
+int SetHTTPrequest(HttpReq req, HttpReq *store)
 {
   /* this mirrors the HttpReq enum in tool_sdecls.h */
   const char *reqname[]= {
@@ -92,15 +92,14 @@ int SetHTTPrequest(struct OperationConfig *config, HttpReq req, HttpReq *store)
     *store = req;
     return 0;
   }
-  warnf(config->global, "You can only select one HTTP request method! "
+  warnf("You can only select one HTTP request method! "
         "You asked for both %s and %s.",
         reqname[req], reqname[*store]);
 
   return 1;
 }
 
-void customrequest_helper(struct OperationConfig *config, HttpReq req,
-                          char *method)
+void customrequest_helper(HttpReq req, char *method)
 {
   /* this mirrors the HttpReq enum in tool_sdecls.h */
   const char *dflt[]= {
@@ -115,12 +114,11 @@ void customrequest_helper(struct OperationConfig *config, HttpReq req,
   if(!method)
     ;
   else if(curl_strequal(method, dflt[req])) {
-    notef(config->global, "Unnecessary use of -X or --request, %s is already "
+    notef("Unnecessary use of -X or --request, %s is already "
           "inferred.", dflt[req]);
   }
   else if(curl_strequal(method, "head")) {
-    warnf(config->global,
-          "Setting custom HTTP method to HEAD with -X/--request may not work "
+    warnf("Setting custom HTTP method to HEAD with -X/--request may not work "
           "the way you want. Consider using -I/--head instead.");
   }
 }

--- a/src/tool_helpers.h
+++ b/src/tool_helpers.h
@@ -26,11 +26,7 @@
 #include "tool_setup.h"
 
 const char *param2text(ParameterError error);
-
-int SetHTTPrequest(struct OperationConfig *config, HttpReq req,
-                   HttpReq *store);
-
-void customrequest_helper(struct OperationConfig *config, HttpReq req,
-                          char *method);
+int SetHTTPrequest(HttpReq req, HttpReq *store);
+void customrequest_helper(HttpReq req, char *method);
 
 #endif /* HEADER_CURL_TOOL_HELPERS_H */

--- a/src/tool_msgs.c
+++ b/src/tool_msgs.c
@@ -34,13 +34,11 @@
 #define NOTE_PREFIX "Note: "
 #define ERROR_PREFIX "curl: "
 
-static void voutf(struct GlobalConfig *global,
-                  const char *prefix,
+static void voutf(const char *prefix,
                   const char *fmt,
-                  va_list ap) CURL_PRINTF(3, 0);
+                  va_list ap) CURL_PRINTF(2, 0);
 
-static void voutf(struct GlobalConfig *global,
-                  const char *prefix,
+static void voutf(const char *prefix,
                   const char *fmt,
                   va_list ap)
 {
@@ -90,12 +88,12 @@ static void voutf(struct GlobalConfig *global,
  * Emit 'note' formatted message on configured 'errors' stream, if verbose was
  * selected.
  */
-void notef(struct GlobalConfig *global, const char *fmt, ...)
+void notef(const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
   if(global->tracetype)
-    voutf(global, NOTE_PREFIX, fmt, ap);
+    voutf(NOTE_PREFIX, fmt, ap);
   va_end(ap);
 }
 
@@ -103,11 +101,11 @@ void notef(struct GlobalConfig *global, const char *fmt, ...)
  * Emit warning formatted message on configured 'errors' stream unless
  * mute (--silent) was selected.
  */
-void warnf(struct GlobalConfig *global, const char *fmt, ...)
+void warnf(const char *fmt, ...)
 {
   va_list ap;
   va_start(ap, fmt);
-  voutf(global, WARN_PREFIX, fmt, ap);
+  voutf(WARN_PREFIX, fmt, ap);
   va_end(ap);
 }
 
@@ -137,12 +135,12 @@ void helpf(FILE *errors, const char *fmt, ...)
  * Emit error message on error stream if not muted. When errors are not tied
  * to command line arguments, use helpf() for such errors.
  */
-void errorf(struct GlobalConfig *global, const char *fmt, ...)
+void errorf(const char *fmt, ...)
 {
   if(!global->silent || global->showerror) {
     va_list ap;
     va_start(ap, fmt);
-    voutf(global, ERROR_PREFIX, fmt, ap);
+    voutf(ERROR_PREFIX, fmt, ap);
     va_end(ap);
   }
 }

--- a/src/tool_msgs.h
+++ b/src/tool_msgs.h
@@ -26,13 +26,13 @@
 #include "tool_setup.h"
 #include "tool_cfgable.h"
 
-void warnf(struct GlobalConfig *global, const char *fmt, ...)
-  CURL_PRINTF(2, 3);
-void notef(struct GlobalConfig *global, const char *fmt, ...)
-  CURL_PRINTF(2, 3);
+void warnf(const char *fmt, ...)
+  CURL_PRINTF(1, 2);
+void notef(const char *fmt, ...)
+  CURL_PRINTF(1, 2);
 void helpf(FILE *errors, const char *fmt, ...)
   CURL_PRINTF(2, 3);
-void errorf(struct GlobalConfig *global, const char *fmt, ...)
-  CURL_PRINTF(2, 3);
+void errorf(const char *fmt, ...)
+  CURL_PRINTF(1, 2);
 
 #endif /* HEADER_CURL_TOOL_MSGS_H */

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -581,7 +581,7 @@ static CURLcode post_per_transfer(struct per_transfer *per,
 #ifdef __VMS
   if(is_vms_shell()) {
     /* VMS DCL shell behavior */
-    if(global.silent && !global.showerror)
+    if(global->silent && !global->showerror)
       vms_show = VMSSTS_HIDE;
   }
   else
@@ -1062,7 +1062,7 @@ static void check_stdin_upload(struct OperationConfig *config,
     /* non-blocking stdin behavior on Windows is challenging
        Spawn a new thread that will read from stdin and write
        out to a socket */
-    curl_socket_t f = win32_stdin_read_thread(global);
+    curl_socket_t f = win32_stdin_read_thread();
 
     if(f == CURL_SOCKET_BAD)
       warnf("win32_stdin_read_thread returned INVALID_SOCKET "

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -114,8 +114,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
                                 CURLSH *share,
                                 bool *added,
                                 bool *skipped);
-static CURLcode create_transfer(struct GlobalConfig *global,
-                                CURLSH *share,
+static CURLcode create_transfer(CURLSH *share,
                                 bool *added,
                                 bool *skipped);
 
@@ -265,9 +264,6 @@ static CURLcode pre_transfer(struct per_transfer *per)
   curl_off_t uploadfilesize = -1;
   struct_stat fileinfo;
   CURLcode result = CURLE_OK;
-#ifndef CURL_DISABLE_LIBCURL_OPTION
-  struct OperationConfig *config = per->config;
-#endif
 
   if(per->uploadfile && !stdin_upload(per->uploadfile)) {
     /* VMS Note:
@@ -467,7 +463,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
 
           if((CURL_OFF_T_MAX - sleeptime < ms) ||
              (ms + sleeptime > config->retry_maxtime_ms)) {
-            warnf(config->global, "The Retry-After: time would "
+            warnf("The Retry-After: time would "
                   "make this command line exceed the maximum allowed time "
                   "for retries.");
             *retryp = FALSE;
@@ -476,7 +472,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
         }
       }
     }
-    warnf(config->global, "Problem %s. "
+    warnf("Problem %s. "
           "Will retry in %ld second%s. "
           "%ld retr%s left.",
           m[retry], sleeptime/1000L,
@@ -506,8 +502,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
         int rc;
         /* We have written data to an output file, we truncate file */
         fflush(outs->stream);
-        notef(config->global,
-              "Throwing away %"  CURL_FORMAT_CURL_OFF_T " bytes",
+        notef("Throwing away %"  CURL_FORMAT_CURL_OFF_T " bytes",
               outs->bytes);
         /* truncate file at the position where we started appending */
 #if defined(HAVE_FTRUNCATE) && !defined(__DJGPP__) && !defined(__AMIGA__) && \
@@ -515,7 +510,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
         if(ftruncate(fileno(outs->stream), outs->init)) {
           /* when truncate fails, we cannot just append as then we will
              create something strange, bail out */
-          errorf(config->global, "Failed to truncate file");
+          errorf("Failed to truncate file");
           return CURLE_WRITE_ERROR;
         }
         /* now seek to the end of the file, the position where we
@@ -529,7 +524,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
         rc = fseek(outs->stream, (long)outs->init, SEEK_SET);
 #endif
         if(rc) {
-          errorf(config->global, "Failed seeking to end of file");
+          errorf("Failed seeking to end of file");
           return CURLE_WRITE_ERROR;
         }
         outs->bytes = 0; /* clear for next round */
@@ -547,8 +542,7 @@ static CURLcode retrycheck(struct OperationConfig *config,
 /*
  * Call this after a transfer has completed.
  */
-static CURLcode post_per_transfer(struct GlobalConfig *global,
-                                  struct per_transfer *per,
+static CURLcode post_per_transfer(struct per_transfer *per,
                                   CURLcode result,
                                   bool *retryp,
                                   long *delay) /* milliseconds! */
@@ -569,7 +563,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
       sclose(per->infd);
 #else
-      warnf(per->config->global, "Closing per->infd != 0: FD == "
+      warnf("Closing per->infd != 0: FD == "
             "%d. This behavior is only supported on desktop "
             " Windows", per->infd);
 #endif
@@ -587,7 +581,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
 #ifdef __VMS
   if(is_vms_shell()) {
     /* VMS DCL shell behavior */
-    if(global->silent && !global->showerror)
+    if(global.silent && !global.showerror)
       vms_show = VMSSTS_HIDE;
   }
   else
@@ -616,7 +610,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
   if(!result && config->xattr && outs->fopened && outs->stream) {
     rc = fwrite_xattr(curl, per->url, fileno(outs->stream));
     if(rc)
-      warnf(config->global, "Error setting extended attributes on '%s': %s",
+      warnf("Error setting extended attributes on '%s': %s",
             outs->filename, strerror(errno));
   }
 
@@ -638,7 +632,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     if(!result && rc) {
       /* something went wrong in the writing process */
       result = CURLE_WRITE_ERROR;
-      errorf(global, "Failed writing body");
+      errorf("Failed writing body");
     }
   }
 
@@ -671,19 +665,19 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     if(!result && rc) {
       /* something went wrong in the writing process */
       result = CURLE_WRITE_ERROR;
-      errorf(config->global, "curl: (%d) Failed writing body", result);
+      errorf("curl: (%d) Failed writing body", result);
     }
     if(result && config->rm_partial) {
       struct_stat st;
       if(!stat(outs->filename, &st) &&
          S_ISREG(st.st_mode)) {
         if(!unlink(outs->filename))
-          notef(global, "Removed output file: %s", outs->filename);
+          notef("Removed output file: %s", outs->filename);
         else
-          warnf(global, "Failed removing: %s", outs->filename);
+          warnf("Failed removing: %s", outs->filename);
       }
       else
-        warnf(global, "Skipping removal; not a regular file: %s",
+        warnf("Skipping removal; not a regular file: %s",
               outs->filename);
     }
   }
@@ -693,7 +687,7 @@ static CURLcode post_per_transfer(struct GlobalConfig *global,
     /* Ask libcurl if we got a remote file time */
     curl_off_t filetime = -1;
     curl_easy_getinfo(curl, CURLINFO_FILETIME_T, &filetime);
-    setfiletime(filetime, outs->filename, global);
+    setfiletime(filetime, outs->filename);
   }
 skip:
   /* Write the --write-out data before cleanup but after result is final */
@@ -778,7 +772,7 @@ static CURLcode append2query(struct OperationConfig *config,
                         CURLU_GUESS_SCHEME);
     if(uerr) {
       result = urlerr_cvt(uerr);
-      errorf(config->global, "(%d) Could not parse the URL, "
+      errorf("(%d) Could not parse the URL, "
              "failed to set query", result);
       config->synthetic_error = TRUE;
     }
@@ -810,7 +804,7 @@ static CURLcode etag_compare(struct OperationConfig *config)
   /* open file for reading: */
   FILE *file = fopen(config->etag_compare_file, FOPEN_READTEXT);
   if(!file)
-    warnf(config->global, "Failed to open %s: %s", config->etag_compare_file,
+    warnf("Failed to open %s: %s", config->etag_compare_file,
           strerror(errno));
 
   if((PARAM_OK == file2string(&etag_from_file, file)) &&
@@ -824,8 +818,7 @@ static CURLcode etag_compare(struct OperationConfig *config)
   if(!header) {
     if(file)
       fclose(file);
-    errorf(config->global,
-           "Failed to allocate memory for custom etag header");
+    errorf("Failed to allocate memory for custom etag header");
     return CURLE_OUT_OF_MEMORY;
   }
 
@@ -845,8 +838,7 @@ static CURLcode etag_store(struct OperationConfig *config,
                            bool *skip)
 {
   if(config->create_dirs) {
-    CURLcode result = create_dir_hierarchy(config->etag_save_file,
-                                           config->global);
+    CURLcode result = create_dir_hierarchy(config->etag_save_file);
     if(result)
       return result;
   }
@@ -856,7 +848,7 @@ static CURLcode etag_store(struct OperationConfig *config,
     FILE *newfile = fopen(config->etag_save_file, "ab");
     if(!newfile) {
       struct State *state = &config->state;
-      warnf(config->global, "Failed creating file for saving etags: \"%s\". "
+      warnf("Failed creating file for saving etags: \"%s\". "
             "Skip this transfer", config->etag_save_file);
       state->outfiles = NULL;
       glob_cleanup(&state->urlglob);
@@ -900,8 +892,7 @@ static CURLcode setup_headerfile(struct OperationConfig *config,
      * that it does not need to be opened/closed for every transfer.
      */
     if(config->create_dirs) {
-      CURLcode result = create_dir_hierarchy(config->headerfile,
-                                             config->global);
+      CURLcode result = create_dir_hierarchy(config->headerfile);
       /* create_dir_hierarchy shows error upon CURLE_WRITE_ERROR */
       if(result)
         return result;
@@ -914,7 +905,7 @@ static CURLcode setup_headerfile(struct OperationConfig *config,
     newfile = fopen(config->headerfile, "ab");
 
     if(!newfile) {
-      errorf(config->global, "Failed to open %s", config->headerfile);
+      errorf("Failed to open %s", config->headerfile);
       return CURLE_WRITE_ERROR;
     }
     else {
@@ -941,13 +932,12 @@ static CURLcode setup_outfile(struct OperationConfig *config,
    * decided we want to use the remote filename.
    */
   struct State *state = &config->state;
-  struct GlobalConfig *global = config->global;
 
   if(!per->outfile) {
     /* extract the filename from the URL */
-    CURLcode result = get_url_file_name(global, &per->outfile, per->url);
+    CURLcode result = get_url_file_name(&per->outfile, per->url);
     if(result) {
-      errorf(global, "Failed to extract a filename"
+      errorf("Failed to extract a filename"
              " from the URL to use for storage");
       return result;
     }
@@ -960,11 +950,11 @@ static CURLcode setup_outfile(struct OperationConfig *config,
     tool_safefree(storefile);
     if(result) {
       /* bad globbing */
-      warnf(global, "bad output glob");
+      warnf("bad output glob");
       return result;
     }
     if(!*per->outfile) {
-      warnf(global, "output glob produces empty string");
+      warnf("output glob produces empty string");
       return CURLE_WRITE_ERROR;
     }
   }
@@ -981,7 +971,7 @@ static CURLcode setup_outfile(struct OperationConfig *config,
      file output call */
 
   if(config->create_dirs) {
-    CURLcode result = create_dir_hierarchy(per->outfile, global);
+    CURLcode result = create_dir_hierarchy(per->outfile);
     /* create_dir_hierarchy shows error upon CURLE_WRITE_ERROR */
     if(result)
       return result;
@@ -991,8 +981,7 @@ static CURLcode setup_outfile(struct OperationConfig *config,
     struct_stat fileinfo;
     if(!stat(per->outfile, &fileinfo)) {
       /* file is present */
-      notef(global, "skips transfer, \"%s\" exists locally",
-            per->outfile);
+      notef("skips transfer, \"%s\" exists locally", per->outfile);
       per->skip = TRUE;
       *skipped = TRUE;
     }
@@ -1022,7 +1011,7 @@ static CURLcode setup_outfile(struct OperationConfig *config,
     FILE *file = fopen(per->outfile, "ab");
 #endif
     if(!file) {
-      errorf(global, "cannot open '%s'", per->outfile);
+      errorf("cannot open '%s'", per->outfile);
       return CURLE_WRITE_ERROR;
     }
     outs->fopened = TRUE;
@@ -1040,7 +1029,6 @@ static CURLcode setup_outfile(struct OperationConfig *config,
 static void check_stdin_upload(struct OperationConfig *config,
                                struct per_transfer *per)
 {
-  struct GlobalConfig *global = config->global;
   /* count to see if there are more than one auth bit set
      in the authtype field */
   int authbits = 0;
@@ -1060,8 +1048,7 @@ static void check_stdin_upload(struct OperationConfig *config,
    * we should warn them.
    */
   if(config->proxyanyauth || (authbits > 1)) {
-    warnf(global,
-          "Using --anyauth or --proxy-anyauth with upload from stdin"
+    warnf("Using --anyauth or --proxy-anyauth with upload from stdin"
           " involves a big risk of it not working. Use a temporary"
           " file or a fixed auth type instead");
   }
@@ -1078,10 +1065,10 @@ static void check_stdin_upload(struct OperationConfig *config,
     curl_socket_t f = win32_stdin_read_thread(global);
 
     if(f == CURL_SOCKET_BAD)
-      warnf(global, "win32_stdin_read_thread returned INVALID_SOCKET "
+      warnf("win32_stdin_read_thread returned INVALID_SOCKET "
             "falling back to blocking mode");
     else if(f > INT_MAX) {
-      warnf(global, "win32_stdin_read_thread returned identifier "
+      warnf("win32_stdin_read_thread returned identifier "
             "larger than INT_MAX. This should not happen unless "
             "the upper 32 bits of a Windows socket have started "
             "being used for something... falling back to blocking "
@@ -1092,8 +1079,7 @@ static void check_stdin_upload(struct OperationConfig *config,
       per->infd = (int)f;
 #endif
     if(curlx_nonblock((curl_socket_t)per->infd, TRUE) < 0)
-      warnf(global,
-            "fcntl failed on fd=%d: %s", per->infd, strerror(errno));
+      warnf("fcntl failed on fd=%d: %s", per->infd, strerror(errno));
   }
 }
 
@@ -1104,7 +1090,6 @@ static CURLcode single_transfer(struct OperationConfig *config,
                                 bool *skipped)
 {
   CURLcode result = CURLE_OK;
-  struct GlobalConfig *global = config->global;
   bool orig_noprogress = global->noprogress;
   bool orig_isatty = global->isatty;
   struct State *state = &config->state;
@@ -1118,12 +1103,12 @@ static CURLcode single_transfer(struct OperationConfig *config,
         /* Use the postfields data for an HTTP get */
         httpgetfields = state->httpgetfields = config->postfields;
         config->postfields = NULL;
-        if(SetHTTPrequest(config, (config->no_body ? TOOL_HTTPREQ_HEAD :
-                                   TOOL_HTTPREQ_GET), &config->httpreq))
+        if(SetHTTPrequest((config->no_body ? TOOL_HTTPREQ_HEAD :
+                           TOOL_HTTPREQ_GET), &config->httpreq))
           return CURLE_FAILED_INIT;
       }
     }
-    else if(SetHTTPrequest(config, TOOL_HTTPREQ_SIMPLEPOST, &config->httpreq))
+    else if(SetHTTPrequest(TOOL_HTTPREQ_SIMPLEPOST, &config->httpreq))
       return CURLE_FAILED_INIT;
   }
 
@@ -1143,7 +1128,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
     /* u->url is the full URL or NULL */
     if(!u->url) {
       /* This node has no URL. End of the road. */
-      warnf(config->global, "Got more output options than URLs");
+      warnf("Got more output options than URLs");
       break;
     }
 
@@ -1166,7 +1151,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
         if(glob_inuse(&state->inglob)) {
           result = glob_next_url(&state->uploadfile, &state->inglob);
           if(result == CURLE_OUT_OF_MEMORY)
-            errorf(global, "out of memory");
+            errorf("out of memory");
         }
         else if(!state->up) {
           /* copy the allocated string */
@@ -1235,7 +1220,7 @@ static CURLcode single_transfer(struct OperationConfig *config,
       if(state->uploadfile) {
         per->uploadfile = strdup(state->uploadfile);
         if(!per->uploadfile ||
-           SetHTTPrequest(config, TOOL_HTTPREQ_PUT, &config->httpreq)) {
+           SetHTTPrequest(TOOL_HTTPREQ_PUT, &config->httpreq)) {
           tool_safefree(per->uploadfile);
           curl_easy_cleanup(curl);
           return CURLE_FAILED_INIT;
@@ -1402,8 +1387,7 @@ static long all_added; /* number of easy handles currently added */
  * to add even after this call returns. sets 'addedp' to TRUE if one or more
  * transfers were added.
  */
-static CURLcode add_parallel_transfers(struct GlobalConfig *global,
-                                       CURLM *multi,
+static CURLcode add_parallel_transfers(CURLM *multi,
                                        CURLSH *share,
                                        bool *morep,
                                        bool *addedp)
@@ -1426,7 +1410,7 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
   if(nxfers < (curl_off_t)(global->parallel_max*2)) {
     bool skipped = FALSE;
     do {
-      result = create_transfer(global, share, addedp, &skipped);
+      result = create_transfer(share, addedp, &skipped);
       if(result)
         return result;
     } while(skipped);
@@ -1476,7 +1460,7 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
       bool getadded = FALSE;
       bool skipped = FALSE;
       do {
-        result = create_transfer(global, share, &getadded, &skipped);
+        result = create_transfer(share, &getadded, &skipped);
         if(result)
           break;
       } while(skipped);
@@ -1497,7 +1481,6 @@ static CURLcode add_parallel_transfers(struct GlobalConfig *global,
 }
 
 struct parastate {
-  struct GlobalConfig *global;
   CURLM *multi;
   CURLSH *share;
   CURLMcode mcode;
@@ -1762,8 +1745,7 @@ static CURLcode check_finished(struct parastate *s)
   int rc;
   CURLMsg *msg;
   bool checkmore = FALSE;
-  struct GlobalConfig *global = s->global;
-  progress_meter(global, s->multi, &s->start, FALSE);
+  progress_meter(s->multi, &s->start, FALSE);
   do {
     msg = curl_multi_info_read(s->multi, &rc);
     if(msg) {
@@ -1781,7 +1763,7 @@ static CURLcode check_finished(struct parastate *s)
                   "Transfer aborted due to critical error "
                   "in another transfer");
       }
-      tres = post_per_transfer(global, ended, tres, &retry, &delay);
+      tres = post_per_transfer(ended, tres, &retry, &delay);
       progress_finalize(ended); /* before it goes away */
       all_added--; /* one fewer added */
       checkmore = TRUE;
@@ -1811,8 +1793,7 @@ static CURLcode check_finished(struct parastate *s)
     }
     if(checkmore) {
       /* one or more transfers completed, add more! */
-      CURLcode tres = add_parallel_transfers(global,
-                                             s->multi, s->share,
+      CURLcode tres = add_parallel_transfers(s->multi, s->share,
                                              &s->more_transfers,
                                              &s->added_transfers);
       if(tres)
@@ -1827,8 +1808,7 @@ static CURLcode check_finished(struct parastate *s)
   return result;
 }
 
-static CURLcode parallel_transfers(struct GlobalConfig *global,
-                                   CURLSH *share)
+static CURLcode parallel_transfers(CURLSH *share)
 {
   CURLcode result;
   struct parastate p;
@@ -1841,12 +1821,11 @@ static CURLcode parallel_transfers(struct GlobalConfig *global,
   s->wrapitup = FALSE;
   s->wrapitup_processed = FALSE;
   s->tick = time(NULL);
-  s->global = global;
   s->multi = curl_multi_init();
   if(!s->multi)
     return CURLE_OUT_OF_MEMORY;
 
-  result = add_parallel_transfers(global, s->multi, s->share,
+  result = add_parallel_transfers(s->multi, s->share,
                                   &s->more_transfers, &s->added_transfers);
   if(result) {
     curl_multi_cleanup(s->multi);
@@ -1858,7 +1837,7 @@ static CURLcode parallel_transfers(struct GlobalConfig *global,
 #ifdef USE_LIBUV
     return parallel_event(s);
 #else
-    errorf(global, "Testing --parallel event-based requires libuv");
+    errorf("Testing --parallel event-based requires libuv");
 #endif
   else
 #endif
@@ -1888,7 +1867,7 @@ static CURLcode parallel_transfers(struct GlobalConfig *global,
         result = check_finished(s);
     }
 
-    (void)progress_meter(global, s->multi, &s->start, TRUE);
+    (void)progress_meter(s->multi, &s->start, TRUE);
   }
 
   /* Make sure to return some kind of error if there was a multi problem */
@@ -1904,8 +1883,7 @@ static CURLcode parallel_transfers(struct GlobalConfig *global,
   return result;
 }
 
-static CURLcode serial_transfers(struct GlobalConfig *global,
-                                 CURLSH *share)
+static CURLcode serial_transfers(CURLSH *share)
 {
   CURLcode returncode = CURLE_OK;
   CURLcode result = CURLE_OK;
@@ -1913,11 +1891,11 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
   bool added = FALSE;
   bool skipped = FALSE;
 
-  result = create_transfer(global, share, &added, &skipped);
+  result = create_transfer(share, &added, &skipped);
   if(result)
     return result;
   if(!added) {
-    errorf(global, "no transfer performed");
+    errorf("no transfer performed");
     return CURLE_READ_ERROR;
   }
   for(per = transfers; per;) {
@@ -1960,7 +1938,7 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
         result = curl_easy_perform(per->curl);
     }
 
-    returncode = post_per_transfer(global, per, result, &retry, &delay_ms);
+    returncode = post_per_transfer(per, result, &retry, &delay_ms);
     if(retry) {
       curlx_wait_ms(delay_ms);
       continue;
@@ -1972,7 +1950,7 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
     else {
       do {
         /* setup the next one just before we delete this */
-        result = create_transfer(global, share, &added, &skipped);
+        result = create_transfer(share, &added, &skipped);
         if(result) {
           returncode = result;
           bailout = TRUE;
@@ -1991,8 +1969,8 @@ static CURLcode serial_transfers(struct GlobalConfig *global,
          milliseconds */
       timediff_t milli = curlx_timediff(curlx_now(), start);
       if(milli < global->ms_per_transfer) {
-        notef(global, "Transfer took %" CURL_FORMAT_CURL_OFF_T " ms, "
-                      "waits %ldms as set by --rate",
+        notef("Transfer took %" CURL_FORMAT_CURL_OFF_T " ms, "
+              "waits %ldms as set by --rate",
               milli, (long)(global->ms_per_transfer - milli));
         /* The transfer took less time than wanted. Wait a little. */
         curlx_wait_ms((long)(global->ms_per_transfer - milli));
@@ -2149,8 +2127,7 @@ static CURLcode transfer_per_config(struct OperationConfig *config,
  * 'create_transfer' gets the details and sets up a new transfer if 'added'
  * returns TRUE.
  */
-static CURLcode create_transfer(struct GlobalConfig *global,
-                                CURLSH *share,
+static CURLcode create_transfer(CURLSH *share,
                                 bool *added,
                                 bool *skipped)
 {
@@ -2168,8 +2145,7 @@ static CURLcode create_transfer(struct GlobalConfig *global,
   return result;
 }
 
-static CURLcode run_all_transfers(struct GlobalConfig *global,
-                                  CURLSH *share,
+static CURLcode run_all_transfers(CURLSH *share,
                                   CURLcode result)
 {
   /* Save the values of noprogress and isatty to restore them later on */
@@ -2180,16 +2156,16 @@ static CURLcode run_all_transfers(struct GlobalConfig *global,
   /* Time to actually do the transfers */
   if(!result) {
     if(global->parallel)
-      result = parallel_transfers(global, share);
+      result = parallel_transfers(share);
     else
-      result = serial_transfers(global, share);
+      result = serial_transfers(share);
   }
 
   /* cleanup if there are any left */
   for(per = transfers; per;) {
     bool retry;
     long delay;
-    CURLcode result2 = post_per_transfer(global, per, result, &retry, &delay);
+    CURLcode result2 = post_per_transfer(per, result, &retry, &delay);
     if(!result)
       /* do not overwrite the original error */
       result = result2;
@@ -2208,7 +2184,7 @@ static CURLcode run_all_transfers(struct GlobalConfig *global,
   return result;
 }
 
-CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
+CURLcode operate(int argc, argv_item_t argv[])
 {
   CURLcode result = CURLE_OK;
   const char *first_arg;
@@ -2228,7 +2204,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
   if((argc == 1) ||
      (first_arg && strncmp(first_arg, "-q", 2) &&
       strcmp(first_arg, "--disable"))) {
-    parseconfig(NULL, global); /* ignore possible failure */
+    parseconfig(NULL); /* ignore possible failure */
 
     /* If we had no arguments then make sure a url was specified in .curlrc */
     if((argc < 2) && (!global->first->url_list)) {
@@ -2241,7 +2217,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
 
   if(!result) {
     /* Parse the command line arguments */
-    ParameterError res = parse_args(global, argc, argv);
+    ParameterError res = parse_args(argc, argv);
     if(res) {
       result = CURLE_OK;
 
@@ -2253,8 +2229,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
 #ifdef USE_MANUAL
         hugehelp();
 #else
-        warnf(global,
-              "built-in manual was disabled at build-time");
+        warnf("built-in manual was disabled at build-time");
 #endif
       }
       /* Check if we were asked for the version information */
@@ -2322,7 +2297,7 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
             global->current = global->first;
 
             /* now run! */
-            result = run_all_transfers(global, share, result);
+            result = run_all_transfers(share, result);
 
             if(global->ssl_sessions && feature_ssls_export) {
               CURLcode r2 = tool_ssls_save(global->first, share,
@@ -2338,16 +2313,16 @@ CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[])
             easysrc_cleanup();
 
             /* Dump the libcurl code if previously enabled */
-            dumpeasysrc(global);
+            dumpeasysrc();
           }
         }
       }
       else
-        errorf(global, "out of memory");
+        errorf("out of memory");
     }
   }
 
-  varcleanup(global);
+  varcleanup();
   curl_free(global->knownhosts);
 
   return result;

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1387,10 +1387,8 @@ static long all_added; /* number of easy handles currently added */
  * to add even after this call returns. sets 'addedp' to TRUE if one or more
  * transfers were added.
  */
-static CURLcode add_parallel_transfers(CURLM *multi,
-                                       CURLSH *share,
-                                       bool *morep,
-                                       bool *addedp)
+static CURLcode add_parallel_transfers(CURLM *multi, CURLSH *share,
+                                       bool *morep, bool *addedp)
 {
   struct per_transfer *per;
   CURLcode result = CURLE_OK;
@@ -1524,8 +1522,7 @@ static void check_multi_info(struct datauv *uv)
     uv->s->result = result;
 
   if(uv->s->more_transfers) {
-    result = add_parallel_transfers(uv->s->global, uv->s->multi,
-                                    uv->s->share,
+    result = add_parallel_transfers(uv->s->multi, uv->s->share,
                                     &uv->s->more_transfers,
                                     &uv->s->added_transfers);
     if(result && !uv->s->result)
@@ -1674,7 +1671,7 @@ static CURLcode parallel_event(struct parastate *s)
   curl_multi_setopt(s->multi, CURLMOPT_TIMERFUNCTION, cb_timeout);
   curl_multi_setopt(s->multi, CURLMOPT_TIMERDATA, &uv);
   curl_multi_setopt(s->multi, CURLMOPT_MAX_HOST_CONNECTIONS,
-                    s->global->parallel_host);
+                    global->parallel_host);
 
   /* kickstart the thing */
   curl_multi_socket_action(s->multi, CURL_SOCKET_TIMEOUT, 0,
@@ -1708,8 +1705,8 @@ static CURLcode parallel_event(struct parastate *s)
     }
 
     if(s->more_transfers) {
-      result = add_parallel_transfers(s->global, s->multi, s->share,
-                                      &s->more_transfers, &s->added_transfers);
+      result = add_parallel_transfers(s->multi, s->share, &s->more_transfers,
+                                      &s->added_transfers);
       if(result && !s->result)
         s->result = result;
     }

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -79,7 +79,7 @@ struct per_transfer {
   BIT(skip);  /* considered already done */
 };
 
-CURLcode operate(struct GlobalConfig *global, int argc, argv_item_t argv[]);
+CURLcode operate(int argc, argv_item_t argv[]);
 void single_transfer_cleanup(struct OperationConfig *config);
 
 extern struct per_transfer *transfers; /* first node */

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -173,8 +173,7 @@ fail:
  * Returns a pointer to a heap-allocated string or NULL if
  * no name part, at location indicated by first argument.
  */
-CURLcode get_url_file_name(struct GlobalConfig *global,
-                           char **filename, const char *url)
+CURLcode get_url_file_name(char **filename, const char *url)
 {
   CURLU *uh = curl_url();
   char *path = NULL;
@@ -212,7 +211,7 @@ CURLcode get_url_file_name(struct GlobalConfig *global,
       else {
         /* no slash => empty string, use default */
         *filename = strdup("curl_response");
-        warnf(global, "No remote file name, uses \"%s\"", *filename);
+        warnf("No remote file name, uses \"%s\"", *filename);
       }
 
       curl_free(path);

--- a/src/tool_operhlp.h
+++ b/src/tool_operhlp.h
@@ -28,16 +28,10 @@
 struct OperationConfig;
 
 void clean_getout(struct OperationConfig *config);
-
 bool output_expected(const char *url, const char *uploadfile);
-
 bool stdin_upload(const char *uploadfile);
-
 CURLcode add_file_name_to_url(CURL *curl, char **inurlp, const char *filename);
-
-CURLcode get_url_file_name(struct GlobalConfig *global,
-                           char **filename, const char *url);
-
+CURLcode get_url_file_name(char **filename, const char *url);
 CURLcode urlerr_cvt(CURLUcode ucode);
 
 #endif /* HEADER_CURL_TOOL_OPERHLP_H */

--- a/src/tool_paramhlp.c
+++ b/src/tool_paramhlp.c
@@ -405,8 +405,7 @@ static void protoset_clear(const char **protoset, const char *proto)
 
 #define MAX_PROTOSTRING (64*11) /* Enough room for 64 10-chars proto names. */
 
-ParameterError proto2num(struct OperationConfig *config,
-                         const char * const *val, char **ostr, const char *str)
+ParameterError proto2num(const char * const *val, char **ostr, const char *str)
 {
   const char **protoset;
   struct dynbuf obuf;
@@ -497,7 +496,7 @@ ParameterError proto2num(struct OperationConfig *config,
            if no protocols are allowed */
         if(action == set)
           protoset[0] = NULL;
-        warnf(config->global, "unrecognized protocol '%s'", buffer);
+        warnf("unrecognized protocol '%s'", buffer);
       }
     }
     if(next)
@@ -620,7 +619,7 @@ ParameterError add2list(struct curl_slist **list, const char *ptr)
   return PARAM_OK;
 }
 
-long ftpfilemethod(struct OperationConfig *config, const char *str)
+long ftpfilemethod(const char *str)
 {
   if(curl_strequal("singlecwd", str))
     return CURLFTPMETHOD_SINGLECWD;
@@ -629,26 +628,24 @@ long ftpfilemethod(struct OperationConfig *config, const char *str)
   if(curl_strequal("multicwd", str))
     return CURLFTPMETHOD_MULTICWD;
 
-  warnf(config->global, "unrecognized ftp file method '%s', using default",
-        str);
+  warnf("unrecognized ftp file method '%s', using default", str);
 
   return CURLFTPMETHOD_MULTICWD;
 }
 
-long ftpcccmethod(struct OperationConfig *config, const char *str)
+long ftpcccmethod(const char *str)
 {
   if(curl_strequal("passive", str))
     return CURLFTPSSL_CCC_PASSIVE;
   if(curl_strequal("active", str))
     return CURLFTPSSL_CCC_ACTIVE;
 
-  warnf(config->global, "unrecognized ftp CCC method '%s', using default",
-        str);
+  warnf("unrecognized ftp CCC method '%s', using default", str);
 
   return CURLFTPSSL_CCC_PASSIVE;
 }
 
-long delegation(struct OperationConfig *config, const char *str)
+long delegation(const char *str)
 {
   if(curl_strequal("none", str))
     return CURLGSSAPI_DELEGATION_NONE;
@@ -657,8 +654,7 @@ long delegation(struct OperationConfig *config, const char *str)
   if(curl_strequal("always", str))
     return CURLGSSAPI_DELEGATION_FLAG;
 
-  warnf(config->global, "unrecognized delegation method '%s', using none",
-        str);
+  warnf("unrecognized delegation method '%s', using none", str);
 
   return CURLGSSAPI_DELEGATION_NONE;
 }
@@ -722,7 +718,7 @@ CURLcode get_args(struct OperationConfig *config, const size_t i)
   if(!result && !config->useragent) {
     config->useragent = my_useragent();
     if(!config->useragent) {
-      errorf(config->global, "out of memory");
+      errorf("out of memory");
       result = CURLE_OUT_OF_MEMORY;
     }
   }

--- a/src/tool_paramhlp.h
+++ b/src/tool_paramhlp.h
@@ -45,24 +45,15 @@ ParameterError str2unum(long *val, const char *str);
 ParameterError oct2nummax(long *val, const char *str, long max);
 ParameterError str2unummax(long *val, const char *str, long max);
 ParameterError secs2ms(long *val, const char *str);
-
-ParameterError proto2num(struct OperationConfig *config,
-                         const char * const *val, char **obuf,
+ParameterError proto2num(const char * const *val, char **obuf,
                          const char *str);
-
 ParameterError check_protocol(const char *str);
-
 ParameterError str2offset(curl_off_t *val, const char *str);
-
 CURLcode get_args(struct OperationConfig *config, const size_t i);
-
 ParameterError add2list(struct curl_slist **list, const char *ptr);
-
-long ftpfilemethod(struct OperationConfig *config, const char *str);
-
-long ftpcccmethod(struct OperationConfig *config, const char *str);
-
-long delegation(struct OperationConfig *config, const char *str);
+long ftpfilemethod(const char *str);
+long ftpcccmethod(const char *str);
+long delegation(const char *str);
 
 ParameterError str2tls_max(unsigned char *val, const char *str);
 

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -41,7 +41,7 @@ static const char *unslashquote(const char *line, char *param);
 #define MAX_CONFIG_LINE_LENGTH (10*1024*1024)
 
 /* return 0 on everything-is-fine, and non-zero otherwise */
-int parseconfig(const char *filename, struct GlobalConfig *global)
+int parseconfig(const char *filename)
 {
   FILE *file = NULL;
   bool usedarg = FALSE;
@@ -156,9 +156,9 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
           case '#': /* comment */
             break;
           default:
-            warnf(config->global, "%s:%d: warning: '%s' uses unquoted "
+            warnf("%s:%d: warning: '%s' uses unquoted "
                   "whitespace", filename, lineno, option);
-            warnf(config->global, "This may cause side-effects. "
+            warnf("This may cause side-effects. "
                   "Consider using double quotes?");
           }
         }
@@ -181,7 +181,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
       if(res == PARAM_NEXT_OPERATION) {
         if(config->url_list && config->url_list->url) {
           /* Allocate the next config */
-          config->next = config_alloc(global);
+          config->next = config_alloc();
           if(config->next) {
             /* Update the last operation pointer */
             global->last = config->next;
@@ -206,7 +206,7 @@ int parseconfig(const char *filename, struct GlobalConfig *global)
            res != PARAM_ENGINES_REQUESTED &&
            res != PARAM_CA_EMBED_REQUESTED) {
           const char *reason = param2text(res);
-          errorf(config->global, "%s:%d: '%s' %s",
+          errorf("%s:%d: '%s' %s",
                  filename, lineno, option, reason);
           rc = (int)res;
         }

--- a/src/tool_parsecfg.h
+++ b/src/tool_parsecfg.h
@@ -25,8 +25,7 @@
  ***************************************************************************/
 #include "tool_setup.h"
 
-int parseconfig(const char *filename, struct GlobalConfig *global);
-
+int parseconfig(const char *filename);
 bool my_get_line(FILE *fp, struct dynbuf *db, bool *error);
 
 #endif /* HEADER_CURL_TOOL_PARSECFG_H */

--- a/src/tool_progress.c
+++ b/src/tool_progress.c
@@ -148,8 +148,7 @@ static struct speedcount speedstore[SPEEDCNT];
   |DL% UL%  Dled  Uled  Xfers  Live Total     Current  Left    Speed
   |  6 --   9.9G     0     2     2   0:00:40  0:00:02  0:00:37 4087M
 */
-bool progress_meter(struct GlobalConfig *global,
-                    CURLM *multi,
+bool progress_meter(CURLM *multi,
                     struct curltime *start,
                     bool final)
 {

--- a/src/tool_progress.h
+++ b/src/tool_progress.h
@@ -31,8 +31,7 @@ int xferinfo_cb(void *clientp,
                 curl_off_t ultotal,
                 curl_off_t ulnow);
 
-bool progress_meter(struct GlobalConfig *global,
-                    CURLM *multi,
+bool progress_meter(CURLM *multi,
                     struct curltime *start,
                     bool final);
 void progress_finalize(struct per_transfer *per);

--- a/src/tool_setopt.c
+++ b/src/tool_setopt.c
@@ -231,8 +231,7 @@ static char *c_escape(const char *str, curl_off_t len)
 }
 
 /* setopt wrapper for enum types */
-CURLcode tool_setopt_enum(CURL *curl, struct OperationConfig *config,
-                          const char *name, CURLoption tag,
+CURLcode tool_setopt_enum(CURL *curl, const char *name, CURLoption tag,
                           const struct NameValue *nvlist, long lval)
 {
   CURLcode ret = CURLE_OK;
@@ -242,7 +241,7 @@ CURLcode tool_setopt_enum(CURL *curl, struct OperationConfig *config,
   if(!lval)
     skip = TRUE;
 
-  if(config->global->libcurl && !skip && !ret) {
+  if(global->libcurl && !skip && !ret) {
     /* we only use this for real if --libcurl was used */
     const struct NameValue *nv = NULL;
     for(nv = nvlist; nv->name; nv++) {
@@ -264,14 +263,13 @@ CURLcode tool_setopt_enum(CURL *curl, struct OperationConfig *config,
 
 #ifdef DEBUGBUILD
   if(ret)
-    warnf(config->global, "option %s returned error (%d)", name, (int)ret);
+    warnf("option %s returned error (%d)", name, (int)ret);
 #endif
   return ret;
 }
 
 /* setopt wrapper for CURLOPT_SSLVERSION */
-CURLcode tool_setopt_SSLVERSION(CURL *curl, struct OperationConfig *config,
-                                const char *name, CURLoption tag,
+CURLcode tool_setopt_SSLVERSION(CURL *curl, const char *name, CURLoption tag,
                                 long lval)
 {
   CURLcode ret = CURLE_OK;
@@ -281,7 +279,7 @@ CURLcode tool_setopt_SSLVERSION(CURL *curl, struct OperationConfig *config,
   if(!lval)
     skip = TRUE;
 
-  if(config->global->libcurl && !skip && !ret) {
+  if(global->libcurl && !skip && !ret) {
     /* we only use this for real if --libcurl was used */
     const struct NameValue *nv = NULL;
     const struct NameValue *nv2 = NULL;
@@ -316,14 +314,13 @@ CURLcode tool_setopt_SSLVERSION(CURL *curl, struct OperationConfig *config,
 
 #ifdef DEBUGBUILD
   if(ret)
-    warnf(config->global, "option %s returned error (%d)", name, (int)ret);
+    warnf("option %s returned error (%d)", name, (int)ret);
 #endif
   return ret;
 }
 
 /* setopt wrapper for bitmasks */
-CURLcode tool_setopt_bitmask(CURL *curl, struct OperationConfig *config,
-                             const char *name, CURLoption tag,
+CURLcode tool_setopt_bitmask(CURL *curl, const char *name, CURLoption tag,
                              const struct NameValueUnsigned *nvlist,
                              long lval)
 {
@@ -332,7 +329,7 @@ CURLcode tool_setopt_bitmask(CURL *curl, struct OperationConfig *config,
   if(!lval)
     skip = TRUE;
 
-  if(config->global->libcurl && !skip && !ret) {
+  if(global->libcurl && !skip && !ret) {
     /* we only use this for real if --libcurl was used */
     char preamble[80];
     unsigned long rest = (unsigned long)lval;
@@ -558,7 +555,7 @@ CURLcode tool_setopt_mimepost(CURL *curl, struct OperationConfig *config,
   CURLcode ret = curl_easy_setopt(curl, tag, mimepost);
   int mimeno = 0;
 
-  if(!ret && config->global->libcurl) {
+  if(!ret && global->libcurl) {
     ret = libcurl_generate_mime(curl, config, config->mimeroot, &mimeno);
 
     if(!ret)
@@ -570,15 +567,14 @@ CURLcode tool_setopt_mimepost(CURL *curl, struct OperationConfig *config,
 }
 
 /* setopt wrapper for curl_slist options */
-CURLcode tool_setopt_slist(CURL *curl, struct OperationConfig *config,
-                           const char *name, CURLoption tag,
+CURLcode tool_setopt_slist(CURL *curl, const char *name, CURLoption tag,
                            struct curl_slist *list)
 {
   CURLcode ret = CURLE_OK;
 
   ret = curl_easy_setopt(curl, tag, list);
 
-  if(config->global->libcurl && list && !ret) {
+  if(global->libcurl && list && !ret) {
     int i;
 
     ret = libcurl_generate_slist(list, &i);
@@ -591,8 +587,7 @@ CURLcode tool_setopt_slist(CURL *curl, struct OperationConfig *config,
 }
 
 /* options that set long */
-CURLcode tool_setopt_long(CURL *curl, struct OperationConfig *config,
-                          const char *name, CURLoption tag,
+CURLcode tool_setopt_long(CURL *curl, const char *name, CURLoption tag,
                           long lval)
 {
   long defval = 0L;
@@ -608,7 +603,7 @@ CURLcode tool_setopt_long(CURL *curl, struct OperationConfig *config,
   }
 
   ret = curl_easy_setopt(curl, tag, lval);
-  if((lval != defval) && config->global->libcurl && !ret) {
+  if((lval != defval) && global->libcurl && !ret) {
     /* we only use this for real if --libcurl was used */
     ret = easysrc_addf(&easysrc_code, "curl_easy_setopt(hnd, %s, %ldL);",
                        name, lval);
@@ -617,15 +612,14 @@ CURLcode tool_setopt_long(CURL *curl, struct OperationConfig *config,
 }
 
 /* options that set curl_off_t */
-CURLcode tool_setopt_offt(CURL *curl, struct OperationConfig *config,
-                          const char *name, CURLoption tag,
+CURLcode tool_setopt_offt(CURL *curl, const char *name, CURLoption tag,
                           curl_off_t lval)
 {
   CURLcode ret = CURLE_OK;
   DEBUGASSERT((tag >= CURLOPTTYPE_OFF_T) && (tag < CURLOPTTYPE_BLOB));
 
   ret = curl_easy_setopt(curl, tag, lval);
-  if(config->global->libcurl && !ret && lval) {
+  if(global->libcurl && !ret && lval) {
     /* we only use this for real if --libcurl was used */
     ret = easysrc_addf(&easysrc_code, "curl_easy_setopt(hnd, %s, (curl_off_t)%"
           CURL_FORMAT_CURL_OFF_T ");", name, lval);
@@ -635,8 +629,9 @@ CURLcode tool_setopt_offt(CURL *curl, struct OperationConfig *config,
 }
 
 /* setopt wrapper for setting object and function pointer options */
-CURLcode tool_setopt(CURL *curl, bool str, struct OperationConfig *config,
-                     const char *name, CURLoption tag, ...)
+CURLcode tool_setopt(CURL *curl, struct OperationConfig *config,
+                     bool str, const char *name, CURLoption tag,
+                     ...)
 {
   va_list arg;
   CURLcode ret = CURLE_OK;
@@ -657,7 +652,7 @@ CURLcode tool_setopt(CURL *curl, bool str, struct OperationConfig *config,
 
   va_end(arg);
 
-  if(config->global->libcurl && pval && !ret) {
+  if(global->libcurl && pval && !ret) {
     /* we only use this if --libcurl was used */
 
     if(!str) {

--- a/src/tool_setopt.h
+++ b/src/tool_setopt.h
@@ -76,60 +76,55 @@ extern const struct NameValueUnsigned setopt_nv_CURLHSTS[];
 
 /* Intercept setopt calls for --libcurl */
 
-CURLcode tool_setopt_enum(CURL *curl, struct OperationConfig *config,
-                          const char *name, CURLoption tag,
+CURLcode tool_setopt_enum(CURL *curl, const char *name, CURLoption tag,
                           const struct NameValue *nv, long lval);
-CURLcode tool_setopt_SSLVERSION(CURL *curl, struct OperationConfig *config,
-                                const char *name, CURLoption tag,
+CURLcode tool_setopt_SSLVERSION(CURL *curl, const char *name, CURLoption tag,
                                 long lval);
 CURLcode tool_setopt_flags(CURL *curl, struct OperationConfig *config,
                            const char *name, CURLoption tag,
                            const struct NameValue *nv, long lval);
-CURLcode tool_setopt_bitmask(CURL *curl, struct OperationConfig *config,
+CURLcode tool_setopt_bitmask(CURL *curl,
                              const char *name, CURLoption tag,
                              const struct NameValueUnsigned *nv, long lval);
 CURLcode tool_setopt_mimepost(CURL *curl, struct OperationConfig *config,
                               const char *name, CURLoption tag,
                               curl_mime *mimepost);
-CURLcode tool_setopt_slist(CURL *curl, struct OperationConfig *config,
-                           const char *name, CURLoption tag,
+CURLcode tool_setopt_slist(CURL *curl, const char *name, CURLoption tag,
                            struct curl_slist *list);
-CURLcode tool_setopt_long(CURL *curl, struct OperationConfig *config,
-                          const char *name, CURLoption tag,
+CURLcode tool_setopt_long(CURL *curl, const char *name, CURLoption tag,
                           long lval);
-CURLcode tool_setopt_offt(CURL *curl, struct OperationConfig *config,
-                          const char *name, CURLoption tag,
+CURLcode tool_setopt_offt(CURL *curl, const char *name, CURLoption tag,
                           curl_off_t lval);
-CURLcode tool_setopt(CURL *curl, bool str,
-                     struct OperationConfig *config,
-                     const char *name, CURLoption tag, ...);
+CURLcode tool_setopt(CURL *curl, struct OperationConfig *config,
+                     bool str, const char *name, CURLoption tag,
+                     ...);
 
 #define my_setopt(x,y,z) \
-  tool_setopt(x, FALSE, config, #y, y, z)
+  tool_setopt(x, config, FALSE, #y, y, z)
 
 #define my_setopt_long(x,y,z) \
-  tool_setopt_long(x, config, #y, y, z)
+  tool_setopt_long(x, #y, y, z)
 
 #define my_setopt_offt(x,y,z) \
-  tool_setopt_offt(x, config, #y, y, z)
+  tool_setopt_offt(x, #y, y, z)
 
 #define my_setopt_str(x,y,z) \
-  tool_setopt(x, TRUE, config, #y, y, z)
+  tool_setopt(x, config, TRUE, #y, y, z)
 
 #define my_setopt_enum(x,y,z) \
-  tool_setopt_enum(x, config, #y, y, setopt_nv_ ## y, z)
+  tool_setopt_enum(x, #y, y, setopt_nv_ ## y, z)
 
 #define my_setopt_SSLVERSION(x,y,z) \
-  tool_setopt_SSLVERSION(x, config, #y, y, z)
+  tool_setopt_SSLVERSION(x, #y, y, z)
 
 #define my_setopt_bitmask(x,y,z) \
-  tool_setopt_bitmask(x, config, #y, y, setopt_nv_ ## y, z)
+  tool_setopt_bitmask(x, #y, y, setopt_nv_ ## y, z)
 
 #define my_setopt_mimepost(x,y,z) \
   tool_setopt_mimepost(x, config, #y, y, z)
 
 #define my_setopt_slist(x,y,z) \
-  tool_setopt_slist(x, config, #y, y, z)
+  tool_setopt_slist(x, #y, y, z)
 
 #else /* CURL_DISABLE_LIBCURL_OPTION */
 

--- a/src/tool_ssls.c
+++ b/src/tool_ssls.c
@@ -38,7 +38,6 @@ static CURLcode tool_ssls_easy(struct OperationConfig *config,
                                CURLSH *share, CURL **peasy)
 {
   CURLcode result = CURLE_OK;
-  struct GlobalConfig *global = config->global;
 
   *peasy = curl_easy_init();
   if(!*peasy)
@@ -65,12 +64,11 @@ CURLcode tool_ssls_load(struct OperationConfig *config,
   CURLcode r = CURLE_OK;
   int i, imported;
   bool error = FALSE;
-  struct GlobalConfig *global = config->global;
 
   curlx_dyn_init(&buf, MAX_SSLS_LINE);
   fp = fopen(filename, FOPEN_READTEXT);
   if(!fp) { /* ok if it does not exist */
-    notef(global, "SSL session file does not exist (yet?): %s", filename);
+    notef("SSL session file does not exist (yet?): %s", filename);
     goto out;
   }
 
@@ -87,14 +85,13 @@ CURLcode tool_ssls_load(struct OperationConfig *config,
 
     c = memchr(line, ':', strlen(line));
     if(!c) {
-      warnf(global, "unrecognized line %d in ssl session file %s",
-            i, filename);
+      warnf("unrecognized line %d in ssl session file %s", i, filename);
       continue;
     }
     *c = '\0';
     r = curlx_base64_decode(line, &shmac, &shmac_len);
     if(r) {
-      warnf(global, "invalid shmax base64 encoding in line %d", i);
+      warnf("invalid shmax base64 encoding in line %d", i);
       continue;
     }
     line = c + 1;
@@ -105,13 +102,13 @@ CURLcode tool_ssls_load(struct OperationConfig *config,
     }
     r = curlx_base64_decode(line, &sdata, &sdata_len);
     if(r) {
-      warnf(global, "invalid sdata base64 encoding in line %d: %s", i, line);
+      warnf("invalid sdata base64 encoding in line %d: %s", i, line);
       continue;
     }
 
     r = curl_easy_ssls_import(easy, NULL, shmac, shmac_len, sdata, sdata_len);
     if(r) {
-      warnf(global, "import of session from line %d rejected(%d)", i, r);
+      warnf("import of session from line %d rejected(%d)", i, r);
       continue;
     }
     ++imported;
@@ -133,7 +130,6 @@ out:
 }
 
 struct tool_ssls_ctx {
-  struct GlobalConfig *global;
   FILE *fp;
   int exported;
 };
@@ -181,8 +177,7 @@ static CURLcode tool_ssls_exp(CURL *easy, void *userptr,
   ctx->exported++;
 out:
   if(r)
-    warnf(ctx->global, "Warning: error saving SSL session for '%s': %d",
-          session_key, r);
+    warnf("Warning: error saving SSL session for '%s': %d", session_key, r);
   curl_free(enc);
   return r;
 }
@@ -194,11 +189,10 @@ CURLcode tool_ssls_save(struct OperationConfig *config,
   CURL *easy = NULL;
   CURLcode r = CURLE_OK;
 
-  ctx.global = config->global;
   ctx.exported = 0;
   ctx.fp = fopen(filename, FOPEN_WRITETEXT);
   if(!ctx.fp) {
-    warnf(config->global, "Warning: Failed to create SSL session file %s",
+    warnf("Warning: Failed to create SSL session file %s",
           filename);
     goto out;
   }

--- a/src/tool_stderr.c
+++ b/src/tool_stderr.c
@@ -36,7 +36,7 @@ void tool_init_stderr(void)
   tool_stderr = stderr;
 }
 
-void tool_set_stderr_file(struct GlobalConfig *global, const char *filename)
+void tool_set_stderr_file(const char *filename)
 {
   FILE *fp;
 
@@ -52,7 +52,7 @@ void tool_set_stderr_file(struct GlobalConfig *global, const char *filename)
      subsequent freopen will fail. */
   fp = fopen(filename, FOPEN_WRITETEXT);
   if(!fp) {
-    warnf(global, "Warning: Failed to open %s", filename);
+    warnf("Warning: Failed to open %s", filename);
     return;
   }
   fclose(fp);

--- a/src/tool_stderr.h
+++ b/src/tool_stderr.h
@@ -27,6 +27,6 @@
 #include "tool_cfgable.h"
 
 void tool_init_stderr(void);
-void tool_set_stderr_file(struct GlobalConfig *global, const char *filename);
+void tool_set_stderr_file(const char *filename);
 
 #endif /* HEADER_CURL_TOOL_STDERR_H */

--- a/src/var.c
+++ b/src/var.c
@@ -39,7 +39,7 @@
 #define MAX_VAR_LEN 128 /* max length of a name */
 
 /* free everything */
-void varcleanup(struct GlobalConfig *global)
+void varcleanup(void)
 {
   struct tool_var *list = global->variables;
   while(list) {
@@ -50,8 +50,7 @@ void varcleanup(struct GlobalConfig *global)
   }
 }
 
-static const struct tool_var *varcontent(struct GlobalConfig *global,
-                                         const char *name, size_t nlen)
+static const struct tool_var *varcontent(const char *name, size_t nlen)
 {
   struct tool_var *list = global->variables;
   while(list) {
@@ -79,8 +78,7 @@ static const struct tool_var *varcontent(struct GlobalConfig *global,
 #define FUNC_64DEC "64dec" /* base64 decode */
 #define FUNC_64DEC_LEN (sizeof(FUNC_64DEC) - 1)
 
-static ParameterError varfunc(struct GlobalConfig *global,
-                              char *c, /* content */
+static ParameterError varfunc(char *c, /* content */
                               size_t clen, /* content length */
                               char *f, /* functions */
                               size_t flen, /* function string length */
@@ -189,8 +187,7 @@ static ParameterError varfunc(struct GlobalConfig *global,
     }
     else {
       /* unsupported function */
-      errorf(global, "unknown variable function in '%.*s'",
-             (int)flen, finput);
+      errorf("unknown variable function in '%.*s'", (int)flen, finput);
       err = PARAM_EXPAND_ERROR;
       break;
     }
@@ -212,8 +209,7 @@ static ParameterError varfunc(struct GlobalConfig *global,
   return err;
 }
 
-ParameterError varexpand(struct GlobalConfig *global,
-                         const char *line, struct dynbuf *out,
+ParameterError varexpand(const char *line, struct dynbuf *out,
                          bool *replaced)
 {
   CURLcode result;
@@ -248,7 +244,7 @@ ParameterError varexpand(struct GlobalConfig *global,
 
       if(!clp) {
         /* uneven braces */
-        warnf(global, "missing close '}}' in '%s'", input);
+        warnf("missing close '}}' in '%s'", input);
         break;
       }
 
@@ -262,7 +258,7 @@ ParameterError varexpand(struct GlobalConfig *global,
       else
         nlen = clp - envp;
       if(!nlen || (nlen >= sizeof(name))) {
-        warnf(global, "bad variable name length '%s'", input);
+        warnf("bad variable name length '%s'", input);
         /* insert the text as-is since this is not an env variable */
         result = curlx_dyn_addn(out, line, clp - line + prefix);
         if(result)
@@ -282,7 +278,7 @@ ParameterError varexpand(struct GlobalConfig *global,
         for(i = 0; (i < nlen) &&
               (ISALNUM(name[i]) || (name[i] == '_')); i++);
         if(i != nlen) {
-          warnf(global, "bad variable name: %s", name);
+          warnf("bad variable name: %s", name);
           /* insert the text as-is since this is not an env variable */
           result = curlx_dyn_addn(out, envp - prefix,
                                   clp - envp + prefix + 2);
@@ -293,7 +289,7 @@ ParameterError varexpand(struct GlobalConfig *global,
           char *value;
           size_t vlen = 0;
           struct dynbuf buf;
-          const struct tool_var *v = varcontent(global, name, nlen);
+          const struct tool_var *v = varcontent(name, nlen);
           if(v) {
             value = (char *)CURL_UNCONST(v->content);
             vlen = v->clen;
@@ -305,8 +301,7 @@ ParameterError varexpand(struct GlobalConfig *global,
           if(funcp) {
             /* apply the list of functions on the value */
             size_t flen = clp - funcp;
-            ParameterError err = varfunc(global, value, vlen, funcp, flen,
-                                         &buf);
+            ParameterError err = varfunc(value, vlen, funcp, flen, &buf);
             if(err)
               return err;
             value = curlx_dyn_ptr(&buf);
@@ -318,7 +313,7 @@ ParameterError varexpand(struct GlobalConfig *global,
                using normal means, this is an error. */
             char *nb = memchr(value, '\0', vlen);
             if(nb) {
-              errorf(global, "variable contains null byte");
+              errorf("variable contains null byte");
               return PARAM_EXPAND_ERROR;
             }
           }
@@ -352,18 +347,17 @@ ParameterError varexpand(struct GlobalConfig *global,
  * that we can improve this if we want better performance when managing many
  * at a later point.
  */
-static ParameterError addvariable(struct GlobalConfig *global,
-                                  const char *name,
+static ParameterError addvariable(const char *name,
                                   size_t nlen,
                                   const char *content,
                                   size_t clen,
                                   bool contalloc)
 {
   struct tool_var *p;
-  const struct tool_var *check = varcontent(global, name, nlen);
+  const struct tool_var *check = varcontent(name, nlen);
   DEBUGASSERT(nlen);
   if(check)
-    notef(global, "Overwriting variable '%s'", check->name);
+    notef("Overwriting variable '%s'", check->name);
 
   p = calloc(1, sizeof(struct tool_var) + nlen);
   if(p) {
@@ -384,8 +378,7 @@ static ParameterError addvariable(struct GlobalConfig *global,
 
 #define MAX_FILENAME 10000
 
-ParameterError setvariable(struct GlobalConfig *global,
-                           const char *input)
+ParameterError setvariable(const char *input)
 {
   const char *name;
   size_t nlen;
@@ -409,7 +402,7 @@ ParameterError setvariable(struct GlobalConfig *global,
     line++;
   nlen = line - name;
   if(!nlen || (nlen >= MAX_VAR_LEN)) {
-    warnf(global, "Bad variable name length (%zd), skipping", nlen);
+    warnf("Bad variable name length (%zd), skipping", nlen);
     return PARAM_OK;
   }
   if(import) {
@@ -424,7 +417,7 @@ ParameterError setvariable(struct GlobalConfig *global,
     ge = getenv(name);
     if(!*line && !ge) {
       /* no assign, no variable, fail */
-      errorf(global, "Variable '%s' import fail, not set", name);
+      errorf("Variable '%s' import fail, not set", name);
       return PARAM_EXPAND_ERROR;
     }
     else if(ge) {
@@ -464,8 +457,7 @@ ParameterError setvariable(struct GlobalConfig *global,
     else {
       file = fopen(line, "rb");
       if(!file) {
-        errorf(global, "Failed to open %s: %s", line,
-               strerror(errno));
+        errorf("Failed to open %s: %s", line, strerror(errno));
         err = PARAM_READ_ERROR;
       }
     }
@@ -499,10 +491,10 @@ ParameterError setvariable(struct GlobalConfig *global,
     }
   }
   else {
-    warnf(global, "Bad --variable syntax, skipping: %s", input);
+    warnf("Bad --variable syntax, skipping: %s", input);
     return PARAM_OK;
   }
-  err = addvariable(global, name, nlen, content, clen, contalloc);
+  err = addvariable(name, nlen, content, clen, contalloc);
   if(err) {
     if(contalloc)
       free(content);

--- a/src/var.h
+++ b/src/var.h
@@ -33,14 +33,11 @@ struct tool_var {
   char name[1]; /* allocated as part of the struct */
 };
 
-struct GlobalConfig;
-
-ParameterError setvariable(struct GlobalConfig *global, const char *input);
-ParameterError varexpand(struct GlobalConfig *global,
-                         const char *line, struct dynbuf *out,
+ParameterError setvariable(const char *input);
+ParameterError varexpand(const char *line, struct dynbuf *out,
                          bool *replaced);
 
 /* free everything */
-void varcleanup(struct GlobalConfig *global);
+void varcleanup(void);
 
 #endif /* HEADER_CURL_VAR_H */

--- a/tests/data/test96
+++ b/tests/data/test96
@@ -36,6 +36,7 @@ MEM tool_paramhlp.c
 MEM tool_cfgable.c
 MEM tool_cfgable.c
 MEM tool_cfgable.c
+MEM tool_cfgable.c
 </file>
 <stripfile>
 $_ = '' if((($_ !~ /tool_paramhlp/) && ($_ !~ /tool_cfgable/)) || ($_ =~ /free\(\(nil\)\)/))


### PR DESCRIPTION
The GlobalConfig only exists in a single instance and it has worked like this since the dawn of time. It is about time we stop passing around pointers to what was already essentially a global object and instead just use a... global.

It simplifies things.