### PR TITLE
eliminate request `getheader` bool, reverse `header` default

### DIFF
--- a/lib/curl_rtmp.c
+++ b/lib/curl_rtmp.c
@@ -299,7 +299,7 @@ static CURLcode rtmp_do(struct Curl_easy *data, bool *done)
     Curl_xfer_setup_send(data, FIRSTSOCKET);
   }
   else
-    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1, FALSE);
+    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1);
   *done = TRUE;
   return CURLE_OK;
 }

--- a/lib/dict.c
+++ b/lib/dict.c
@@ -242,7 +242,7 @@ static CURLcode dict_do(struct Curl_easy *data, bool *done)
       failf(data, "Failed sending DICT request");
       goto error;
     }
-    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1, FALSE);
+    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1);
   }
   else if(curl_strnequal(path, DICT_DEFINE, sizeof(DICT_DEFINE)-1) ||
           curl_strnequal(path, DICT_DEFINE2, sizeof(DICT_DEFINE2)-1) ||
@@ -283,7 +283,7 @@ static CURLcode dict_do(struct Curl_easy *data, bool *done)
       failf(data, "Failed sending DICT request");
       goto error;
     }
-    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1, FALSE);
+    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1);
   }
   else {
 
@@ -305,7 +305,7 @@ static CURLcode dict_do(struct Curl_easy *data, bool *done)
         goto error;
       }
 
-      Curl_xfer_setup_recv(data, FIRSTSOCKET, -1, FALSE);
+      Curl_xfer_setup_recv(data, FIRSTSOCKET, -1);
     }
   }
 

--- a/lib/ftp.c
+++ b/lib/ftp.c
@@ -551,8 +551,7 @@ static CURLcode ftp_initiate_transfer(struct Curl_easy *data,
   }
   else {
     /* FTP download, shutdown, do not ignore errors */
-    Curl_xfer_setup_recv(data, SECONDARYSOCKET,
-                         ftpc->retr_size_saved, FALSE);
+    Curl_xfer_setup_recv(data, SECONDARYSOCKET, ftpc->retr_size_saved);
     Curl_xfer_set_shutdown(data, TRUE, FALSE);
   }
 

--- a/lib/gopher.c
+++ b/lib/gopher.c
@@ -240,7 +240,7 @@ static CURLcode gopher_do(struct Curl_easy *data, bool *done)
   if(result)
     return result;
 
-  Curl_xfer_setup_recv(data, FIRSTSOCKET, -1, FALSE);
+  Curl_xfer_setup_recv(data, FIRSTSOCKET, -1);
   return CURLE_OK;
 }
 #endif /* CURL_DISABLE_GOPHER */

--- a/lib/http.c
+++ b/lib/http.c
@@ -2415,7 +2415,7 @@ static CURLcode http_req_complete(struct Curl_easy *data,
 out:
   if(!result) {
     /* setup variables for the upcoming transfer */
-    Curl_xfer_setup_sendrecv(data, FIRSTSOCKET, -1, TRUE);
+    Curl_xfer_setup_sendrecv(data, FIRSTSOCKET, -1);
   }
   return result;
 }

--- a/lib/imap.c
+++ b/lib/imap.c
@@ -1347,7 +1347,7 @@ static CURLcode imap_state_fetch_resp(struct Curl_easy *data,
     else {
       /* IMAP download */
       data->req.maxdownload = size;
-      Curl_xfer_setup_recv(data, FIRSTSOCKET, size, FALSE);
+      Curl_xfer_setup_recv(data, FIRSTSOCKET, size);
     }
   }
   else {

--- a/lib/openldap.c
+++ b/lib/openldap.c
@@ -993,7 +993,7 @@ static CURLcode oldap_do(struct Curl_easy *data, bool *done)
   }
 
   lr->msgid = msgid;
-  Curl_xfer_setup_recv(data, FIRSTSOCKET, -1, FALSE);
+  Curl_xfer_setup_recv(data, FIRSTSOCKET, -1);
   *done = TRUE;
 
 out:

--- a/lib/pop3.c
+++ b/lib/pop3.c
@@ -1116,7 +1116,7 @@ static CURLcode pop3_state_command_resp(struct Curl_easy *data,
 
   if(pop3->transfer == PPTRANSFER_BODY) {
     /* POP3 download */
-    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1, FALSE);
+    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1);
 
     if(pp->overflow) {
       /* The recv buffer contains data that is actually body content so send

--- a/lib/request.c
+++ b/lib/request.c
@@ -62,7 +62,7 @@ CURLcode Curl_req_soft_reset(struct SingleRequest *req,
   req->shutdown = FALSE;
   req->bytecount = 0;
   req->writebytecount = 0;
-  req->header = TRUE; /* assume header */
+  req->header = FALSE;
   req->headerline = 0;
   req->headerbytecount = 0;
   req->allheadercount =  0;
@@ -161,7 +161,6 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->chunk = FALSE;
   req->ignore_cl = FALSE;
   req->upload_chunky = FALSE;
-  req->getheader = FALSE;
   req->no_body = data->set.opt_no_body;
   req->authneg = FALSE;
   req->shutdown = FALSE;

--- a/lib/request.h
+++ b/lib/request.h
@@ -123,7 +123,6 @@ struct SingleRequest {
   BIT(ignore_cl);     /* ignore content-length */
   BIT(upload_chunky); /* set TRUE if we are doing chunked transfer-encoding
                          on upload */
-  BIT(getheader);    /* TRUE if header parsing is wanted */
   BIT(no_body);      /* the response has no body */
   BIT(authneg);      /* TRUE when the auth phase has started, which means
                         that we are creating a request with an auth header,

--- a/lib/rtsp.c
+++ b/lib/rtsp.c
@@ -100,6 +100,10 @@ static CURLcode rtsp_rtp_write_resp(struct Curl_easy *data,
                                     const char *buf,
                                     size_t blen,
                                     bool is_eos);
+static CURLcode rtsp_rtp_write_resp_hd(struct Curl_easy *data,
+                                       const char *buf,
+                                       size_t blen,
+                                       bool is_eos);
 
 static CURLcode rtsp_setup_connection(struct Curl_easy *data,
                                       struct connectdata *conn);
@@ -141,7 +145,7 @@ const struct Curl_handler Curl_handler_rtsp = {
   ZERO_NULL,                            /* perform_pollset */
   ZERO_NULL,                            /* disconnect */
   rtsp_rtp_write_resp,                  /* write_resp */
-  ZERO_NULL,                            /* write_resp_hd */
+  rtsp_rtp_write_resp_hd,               /* write_resp_hd */
   rtsp_conncheck,                       /* connection_check */
   ZERO_NULL,                            /* attach connection */
   Curl_http_follow,                     /* follow */
@@ -370,7 +374,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   }
 
   if(rtspreq == RTSPREQ_RECEIVE) {
-    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1, TRUE);
+    Curl_xfer_setup_recv(data, FIRSTSOCKET, -1);
     goto out;
   }
 
@@ -636,7 +640,7 @@ static CURLcode rtsp_do(struct Curl_easy *data, bool *done)
   if(result)
     goto out;
 
-  Curl_xfer_setup_sendrecv(data, FIRSTSOCKET, -1, TRUE);
+  Curl_xfer_setup_sendrecv(data, FIRSTSOCKET, -1);
 
   /* issue the request */
   result = Curl_req_send(data, &req_buffer, httpversion);
@@ -933,6 +937,14 @@ out:
     data->req.download_done = TRUE;
   }
   return result;
+}
+
+static CURLcode rtsp_rtp_write_resp_hd(struct Curl_easy *data,
+                                       const char *buf,
+                                       size_t blen,
+                                       bool is_eos)
+{
+  return rtsp_rtp_write_resp(data, buf, blen, is_eos);
 }
 
 static

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -72,11 +72,10 @@ void Curl_xfer_setup_send(struct Curl_easy *data,
                           int sockindex);
 
 /* The transfer receives data on the given socket index, the
- * amount to receive (or -1 if unknown) and if headers are expected */
+ * amount to receive (or -1 if unknown). */
 void Curl_xfer_setup_recv(struct Curl_easy *data,
                           int sockindex,
-                          curl_off_t recv_size,
-                          bool getheader);
+                          curl_off_t recv_size);
 
 /* *After* Curl_xfer_setup_xxx(), tell the transfer to shutdown the
  * connection at the end. Let the transfer either fail or ignore any
@@ -87,13 +86,11 @@ void Curl_xfer_set_shutdown(struct Curl_easy *data,
 
 /**
  * The transfer will use socket 1 to send/recv. `recv_size` is
- * the amount to receive or -1 if unknown. `getheader` indicates
- * response header processing is expected.
+ * the amount to receive or -1 if unknown.
  */
 void Curl_xfer_setup_sendrecv(struct Curl_easy *data,
                               int sockindex,
-                              curl_off_t recv_size,
-                              bool getheader);
+                              curl_off_t recv_size);
 
 /**
  * Multi has set transfer to DONE. Last chance to trigger

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1423,7 +1423,7 @@ static int myssh_in_SFTP_DOWNLOAD_STAT(struct Curl_easy *data,
     myssh_to(data, sshc, SSH_STOP);
     return rc;
   }
-  Curl_xfer_setup_recv(data, FIRSTSOCKET, data->req.size, FALSE);
+  Curl_xfer_setup_recv(data, FIRSTSOCKET, data->req.size);
 
   /* not set by Curl_xfer_setup to preserve keepon bits */
   data->conn->send_idx = 0;
@@ -2279,7 +2279,7 @@ static CURLcode myssh_statemach_act(struct Curl_easy *data,
         /* download data */
         bytecount = ssh_scp_request_get_size(sshc->scp_session);
         data->req.maxdownload = (curl_off_t) bytecount;
-        Curl_xfer_setup_recv(data, FIRSTSOCKET, bytecount, FALSE);
+        Curl_xfer_setup_recv(data, FIRSTSOCKET, bytecount);
 
         /* not set by Curl_xfer_setup to preserve keepon bits */
         conn->send_idx = 0;

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1540,7 +1540,7 @@ sftp_download_stat(struct Curl_easy *data,
     myssh_state(data, sshc, SSH_STOP);
     return CURLE_OK;
   }
-  Curl_xfer_setup_recv(data, FIRSTSOCKET, data->req.size, FALSE);
+  Curl_xfer_setup_recv(data, FIRSTSOCKET, data->req.size);
 
   /* not set by Curl_xfer_setup to preserve keepon bits */
   data->conn->send_idx = 0;
@@ -2460,7 +2460,7 @@ static CURLcode ssh_state_scp_download_init(struct Curl_easy *data,
   /* download data */
   bytecount = (curl_off_t)sb.st_size;
   data->req.maxdownload = (curl_off_t)sb.st_size;
-  Curl_xfer_setup_recv(data, FIRSTSOCKET, bytecount, FALSE);
+  Curl_xfer_setup_recv(data, FIRSTSOCKET, bytecount);
 
   /* not set by Curl_xfer_setup to preserve keepon bits */
   data->conn->send_idx = 0;

--- a/lib/vssh/wolfssh.c
+++ b/lib/vssh/wolfssh.c
@@ -816,7 +816,7 @@ static CURLcode wssh_statemach_act(struct Curl_easy *data,
         wssh_state(data, sshc, SSH_STOP);
         break;
       }
-      Curl_xfer_setup_recv(data, FIRSTSOCKET, data->req.size, FALSE);
+      Curl_xfer_setup_recv(data, FIRSTSOCKET, data->req.size);
 
       /* not set by Curl_xfer_setup to preserve keepon bits */
       conn->send_idx = 0;


### PR DESCRIPTION
Deduce that the transfer response expects headers by the protocol handler implementing `write_resp_hd` callback. This eleminates the `getheader` parameter in the `Curl_xfer_setup_*()` methods.

Add an implementation to RTSP for `write_resp_hd`, joining the HTTP protocol in the only handlers having it.

Reverse the default of request's `header` bit that signals that headers are expected. Default is now FALSE, set to TRUE when setting up the transfer by presence of `write_resp_hd` in the protocol handler.