### PR TITLE
make Curl_conn_get_socket simpler

### DIFF
--- a/lib/cfilters.c
+++ b/lib/cfilters.c
@@ -910,18 +910,19 @@ CURLcode Curl_conn_cf_get_ip_info(struct Curl_cfilter *cf,
   return result;
 }
 
-curl_socket_t Curl_conn_get_socket(struct Curl_easy *data, int sockindex)
+curl_socket_t Curl_conn_get_first_socket(struct Curl_easy *data)
 {
   struct Curl_cfilter *cf;
 
-  cf = (data->conn && CONN_SOCK_IDX_VALID(sockindex)) ?
-       data->conn->cfilter[sockindex] : NULL;
+  if(!data->conn)
+    return CURL_SOCKET_BAD;
+
+  cf = data->conn->cfilter[FIRSTSOCKET];
   /* if the top filter has not connected, ask it (and its sub-filters)
-   * for the socket. Otherwise conn->sock[sockindex] should have it.
-   */
+   * for the socket. Otherwise conn->sock[sockindex] should have it. */
   if(cf && !cf->connected)
     return Curl_conn_cf_get_socket(cf, data);
-  return data->conn ? data->conn->sock[sockindex] : CURL_SOCKET_BAD;
+  return data->conn->sock[FIRSTSOCKET];
 }
 
 const struct Curl_sockaddr_ex *

--- a/lib/cfilters.h
+++ b/lib/cfilters.h
@@ -460,10 +460,11 @@ bool Curl_conn_needs_flush(struct Curl_easy *data, int sockindex);
 CURLcode Curl_conn_flush(struct Curl_easy *data, int sockindex);
 
 /**
- * Return the socket used on data's connection for the index.
+ * Return the socket used on data's connection for FIRSTSOCKET,
+ * querying filters if the whole chain has not connected yet.
  * Returns CURL_SOCKET_BAD if not available.
  */
-curl_socket_t Curl_conn_get_socket(struct Curl_easy *data, int sockindex);
+curl_socket_t Curl_conn_get_first_socket(struct Curl_easy *data);
 
 /* Return a pointer to the connected socket address or NULL. */
 const struct Curl_sockaddr_ex *

--- a/lib/http.c
+++ b/lib/http.c
@@ -1528,8 +1528,7 @@ CURLcode Curl_http_do_pollset(struct Curl_easy *data,
                               struct easy_pollset *ps)
 {
   /* write mode */
-  curl_socket_t sock = Curl_conn_get_socket(data, FIRSTSOCKET);
-  return Curl_pollset_add_out(data, ps, sock);
+  return Curl_pollset_add_out(data, ps, data->conn->sock[FIRSTSOCKET]);
 }
 
 /*

--- a/lib/multi.c
+++ b/lib/multi.c
@@ -912,7 +912,7 @@ static CURLcode mstate_connecting_pollset(struct Curl_easy *data,
                                           struct easy_pollset *ps)
 {
   if(data->conn) {
-    curl_socket_t sockfd = Curl_conn_get_socket(data, FIRSTSOCKET);
+    curl_socket_t sockfd = Curl_conn_get_first_socket(data);
     if(sockfd != CURL_SOCKET_BAD) {
       /* Default is to wait to something from the server */
       return Curl_pollset_change(data, ps, sockfd, CURL_POLL_IN, 0);
@@ -928,7 +928,7 @@ static CURLcode mstate_protocol_pollset(struct Curl_easy *data,
     curl_socket_t sockfd;
     if(data->conn->handler->proto_pollset)
       return data->conn->handler->proto_pollset(data, ps);
-    sockfd = Curl_conn_get_socket(data, FIRSTSOCKET);
+    sockfd = data->conn->sock[FIRSTSOCKET];
     if(sockfd != CURL_SOCKET_BAD) {
       /* Default is to wait to something from the server */
       return Curl_pollset_change(data, ps, sockfd, CURL_POLL_IN, 0);


### PR DESCRIPTION
Since it is only used for the first socket anyway, simplify the function.