### PR TITLE
tool_writeout: check gmtime return code too

### DIFF
--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -603,7 +603,7 @@ static const char *outtime(const char *ptr, /* %time{ ... */
     if(!result) {
       /* !checksrc! disable BANNEDFUNC 1 */
       utc = gmtime(&secs);
-      if(curlx_dyn_len(&format) &&
+      if(curlx_dyn_len(&format) && utc &&
          strftime(output, sizeof(output), curlx_dyn_ptr(&format), utc))
         fputs(output, stream);
       curlx_dyn_free(&format);


### PR DESCRIPTION
If the unlikely event happens that it fails, it returns NULL. CodeSonar is not happy unless we check for it.