### PR TITLE
tool_operate: cleanups

### DIFF
--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -52,6 +52,7 @@ struct OperationConfig *config_alloc(void)
   config->ftp_skip_ip = TRUE;
   config->file_clobber_mode = CLOBBER_DEFAULT;
   config->upload_flags = CURLULFLAG_SEEN;
+  config->retry_delay_ms = RETRY_SLEEP_DEFAULT;
   curlx_dyn_init(&config->postdata, MAX_FILE2MEMORY);
   return config;
 }

--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -68,17 +68,15 @@ struct State {
   struct getout *urlnode;
   struct URLGlob inglob;
   struct URLGlob urlglob;
-  char *outfiles;
   char *httpgetfields;
   char *uploadfile;
-  curl_off_t infilenum; /* number of files to upload */
-  curl_off_t up;        /* upload file counter within a single upload glob */
+  curl_off_t upnum;     /* number of files to upload */
+  curl_off_t upidx;     /* index for upload glob */
   curl_off_t urlnum;    /* how many iterations this URL has with ranges etc */
-  curl_off_t li;        /* index for globbed URLs */
+  curl_off_t urlidx;    /* index for globbed URLs */
 };
 
 struct OperationConfig {
-  struct State state;             /* for create_transfer() */
   struct dynbuf postdata;
   char *useragent;
   struct curl_slist *cookies;  /* cookies to serialize into a single line */
@@ -342,6 +340,7 @@ struct OperationConfig {
 };
 
 struct GlobalConfig {
+  struct State state;             /* for create_transfer() */
   char *trace_dump;               /* file to dump the network trace to */
   FILE *trace_stream;
   char *libcurl;                  /* Output libcurl code to this filename */

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -80,7 +80,7 @@ struct per_transfer {
 };
 
 CURLcode operate(int argc, argv_item_t argv[]);
-void single_transfer_cleanup(struct OperationConfig *config);
+void single_transfer_cleanup(void);
 
 extern struct per_transfer *transfers; /* first node */
 

--- a/src/tool_operhlp.c
+++ b/src/tool_operhlp.c
@@ -45,7 +45,7 @@ void clean_getout(struct OperationConfig *config)
       node = next;
     }
     config->url_list = NULL;
-    single_transfer_cleanup(config);
+    single_transfer_cleanup();
   }
 }
 


### PR DESCRIPTION
- move the state struct from config to global. It is used as a single instance anyway so might as well be a single one to save memory.
- simplify and combine several conditions
- set default retry delay inititally
- use better struct field names to make it easier to understand their purposes
- remove the state->outfiles field as it was not necessary
- remove superfluous glob cleanup call
- move conditions around to remove an indent level
- move the ->url NULL check

Takes single_transfer()'s complexity score down from 78 to 68.