### PR TITLE
upgrade/multiplex handling

### DIFF
--- a/lib/connect.c
+++ b/lib/connect.c
@@ -622,10 +622,10 @@ out:
   return result;
 }
 
-void Curl_conn_set_multiplex(struct connectdata *conn, bool multiplex)
+void Curl_conn_set_multiplex(struct connectdata *conn)
 {
-  if(conn->bits.multiplex != multiplex) {
-    conn->bits.multiplex = multiplex;
+  if(!conn->bits.multiplex) {
+    conn->bits.multiplex = TRUE;
     if(conn->attached_multi) {
       Curl_multi_connchanged(conn->attached_multi);
     }

--- a/lib/connect.c
+++ b/lib/connect.c
@@ -621,3 +621,13 @@ out:
     Curl_resolv_unlink(data, &data->state.dns[sockindex]);
   return result;
 }
+
+void Curl_conn_set_multiplex(struct connectdata *conn, bool multiplex)
+{
+  if(conn->bits.multiplex != multiplex) {
+    conn->bits.multiplex = multiplex;
+    if(conn->attached_multi) {
+      Curl_multi_connchanged(conn->attached_multi);
+    }
+  }
+}

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -123,8 +123,8 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
                          struct Curl_dns_entry *dns,
                          int ssl_mode);
 
-/* Set conn to en-/disable multiplexing. */
-void Curl_conn_set_multiplex(struct connectdata *conn, bool multiplex);
+/* Set conn to allow multiplexing. */
+void Curl_conn_set_multiplex(struct connectdata *conn);
 
 extern struct Curl_cftype Curl_cft_setup;
 

--- a/lib/connect.h
+++ b/lib/connect.h
@@ -123,6 +123,9 @@ CURLcode Curl_conn_setup(struct Curl_easy *data,
                          struct Curl_dns_entry *dns,
                          int ssl_mode);
 
+/* Set conn to en-/disable multiplexing. */
+void Curl_conn_set_multiplex(struct connectdata *conn, bool multiplex);
+
 extern struct Curl_cftype Curl_cft_setup;
 
 #endif /* HEADER_CURL_CONNECT_H */

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -148,7 +148,7 @@
 /* disables SMTP */
 #cmakedefine CURL_DISABLE_SMTP 1
 
-/* disabled WebSockets */
+/* disabled WebSocket */
 #cmakedefine CURL_DISABLE_WEBSOCKETS 1
 
 /* disables use of socketpair for curl_multi_poll */

--- a/lib/http.c
+++ b/lib/http.c
@@ -2622,7 +2622,7 @@ static CURLcode http_check_new_conn(struct Curl_easy *data)
       info_version = "HTTP/2";
       /* There is no ALPN here, but the connection is now definitely h2 */
       conn->httpversion_seen = 20;
-      Curl_conn_set_multiplex(conn, TRUE);
+      Curl_conn_set_multiplex(conn);
     }
     else
       info_version = "HTTP/1.x";

--- a/lib/http.c
+++ b/lib/http.c
@@ -2622,6 +2622,7 @@ static CURLcode http_check_new_conn(struct Curl_easy *data)
       info_version = "HTTP/2";
       /* There is no ALPN here, but the connection is now definitely h2 */
       conn->httpversion_seen = 20;
+      Curl_conn_set_multiplex(conn, TRUE);
     }
     else
       info_version = "HTTP/1.x";

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2699,7 +2699,7 @@ static CURLcode cf_h2_cntrl(struct Curl_cfilter *cf,
   case CF_CTRL_CONN_INFO_UPDATE:
     if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 20;
-      Curl_conn_set_multiplex(cf->conn, TRUE);
+      Curl_conn_set_multiplex(cf->conn);
     }
     break;
   default:

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -2946,7 +2946,7 @@ CURLcode Curl_http2_upgrade(struct Curl_easy *data,
   DEBUGASSERT(cf->cft == &Curl_cft_nghttp2);
   ctx = cf->ctx;
 
-  data->req.httpversion_sent = 20; /* It's an h2 request now */
+  data->req.httpversion_sent = 20; /* it is an h2 request now */
   data->req.header = TRUE; /* we expect the real response to come in h2 */
   data->req.headerline = 0; /* restart the header line counter */
 

--- a/lib/request.c
+++ b/lib/request.c
@@ -139,7 +139,7 @@ void Curl_req_hard_reset(struct SingleRequest *req, struct Curl_easy *data)
   req->offset = 0;
   req->httpcode = 0;
   req->keepon = 0;
-  req->upgr101 = UPGR101_INIT;
+  req->upgr101 = UPGR101_NONE;
   req->sendbuf_hds_len = 0;
   req->timeofdoc = 0;
   req->location = NULL;

--- a/lib/request.h
+++ b/lib/request.h
@@ -45,7 +45,7 @@ enum upgrade101 {
   UPGR101_NONE,               /* default state */
   UPGR101_WS,                 /* upgrade to WebSocket requested */
   UPGR101_H2,                 /* upgrade to HTTP/2 requested */
-  UPGR101_RECEIVED,           /* 101 response received */
+  UPGR101_RECEIVED            /* 101 response received */
 };
 
 

--- a/lib/request.h
+++ b/lib/request.h
@@ -42,11 +42,10 @@ enum expect100 {
 };
 
 enum upgrade101 {
-  UPGR101_INIT,               /* default state */
-  UPGR101_WS,                 /* upgrade to WebSockets requested */
+  UPGR101_NONE,               /* default state */
+  UPGR101_WS,                 /* upgrade to WebSocket requested */
   UPGR101_H2,                 /* upgrade to HTTP/2 requested */
   UPGR101_RECEIVED,           /* 101 response received */
-  UPGR101_WORKING             /* talking upgraded protocol */
 };
 
 

--- a/lib/url.c
+++ b/lib/url.c
@@ -907,8 +907,8 @@ static bool url_match_fully_connected(struct connectdata *conn,
                                       struct url_conn_match *m)
 {
   if(!Curl_conn_is_connected(conn, FIRSTSOCKET) ||
-     conn->bits.asks_multiplex) {
-    /* Not yet connected, or not yet decided if it multiplexes. The later
+     conn->bits.upgrade_in_progress) {
+    /* Not yet connected, or a protocol upgrade is in progress. The later
      * happens for HTTP/2 Upgrade: requests that need a response. */
     if(m->may_multiplex) {
       m->seen_pending_conn = TRUE;
@@ -1268,6 +1268,7 @@ static bool url_match_conn(struct connectdata *conn, void *userdata)
   if(!url_match_connect_config(conn, m))
     return FALSE;
 
+  /* match for destination and protocol? */
   if(!url_match_destination(conn, m))
     return FALSE;
 

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -389,7 +389,7 @@ struct ConnectBits {
 #endif
   BIT(bound); /* set true if bind() has already been done on this socket/
                  connection */
-  BIT(asks_multiplex); /* connection asks for multiplexing, but is not yet */
+  BIT(upgrade_in_progress); /* protocol upgrade is in progress */
   BIT(multiplex); /* connection is multiplexed */
   BIT(tcp_fastopen); /* use TCP Fast Open */
   BIT(tls_enable_alpn); /* TLS ALPN extension? */

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -1990,7 +1990,7 @@ static CURLcode cf_ngtcp2_cntrl(struct Curl_cfilter *cf,
   case CF_CTRL_CONN_INFO_UPDATE:
     if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 30;
-      Curl_conn_set_multiplex(cf->conn, TRUE);
+      Curl_conn_set_multiplex(cf->conn);
     }
     break;
   default:

--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -464,7 +464,6 @@ static int cf_ngtcp2_handshake_completed(ngtcp2_conn *tconn, void *user_data)
 
   ctx->handshake_at = curlx_now();
   ctx->tls_handshake_complete = TRUE;
-  cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
   Curl_vquic_report_handshake(&ctx->tls, cf, data);
 
   ctx->tls_vrfy_result = Curl_vquic_tls_verify_peer(&ctx->tls, cf,
@@ -1989,8 +1988,10 @@ static CURLcode cf_ngtcp2_cntrl(struct Curl_cfilter *cf,
     break;
   }
   case CF_CTRL_CONN_INFO_UPDATE:
-    if(!cf->sockindex && cf->connected)
+    if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 30;
+      Curl_conn_set_multiplex(cf->conn, TRUE);
+    }
     break;
   default:
     break;

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -2204,7 +2204,7 @@ static CURLcode cf_osslq_cntrl(struct Curl_cfilter *cf,
   case CF_CTRL_CONN_INFO_UPDATE:
     if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 30;
-      Curl_conn_set_multiplex(cf->conn, TRUE);
+      Curl_conn_set_multiplex(cf->conn);
     }
     break;
   default:

--- a/lib/vquic/curl_osslq.c
+++ b/lib/vquic/curl_osslq.c
@@ -564,9 +564,6 @@ static CURLcode cf_osslq_verify_peer(struct Curl_cfilter *cf,
                                      struct Curl_easy *data)
 {
   struct cf_osslq_ctx *ctx = cf->ctx;
-
-  cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
-
   return Curl_vquic_tls_verify_peer(&ctx->tls, cf, data, &ctx->peer);
 }
 
@@ -2205,8 +2202,10 @@ static CURLcode cf_osslq_cntrl(struct Curl_cfilter *cf,
     break;
   }
   case CF_CTRL_CONN_INFO_UPDATE:
-    if(!cf->sockindex && cf->connected)
+    if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 30;
+      Curl_conn_set_multiplex(cf->conn, TRUE);
+    }
     break;
   default:
     break;

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1236,7 +1236,7 @@ static CURLcode cf_quiche_cntrl(struct Curl_cfilter *cf,
   case CF_CTRL_CONN_INFO_UPDATE:
     if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 30;
-      Curl_conn_set_multiplex(cf->conn, TRUE);
+      Curl_conn_set_multiplex(cf->conn);
     }
     break;
   default:

--- a/lib/vquic/curl_quiche.c
+++ b/lib/vquic/curl_quiche.c
@@ -1234,8 +1234,10 @@ static CURLcode cf_quiche_cntrl(struct Curl_cfilter *cf,
     break;
   }
   case CF_CTRL_CONN_INFO_UPDATE:
-    if(!cf->sockindex && cf->connected)
+    if(!cf->sockindex && cf->connected) {
       cf->conn->httpversion_seen = 30;
+      Curl_conn_set_multiplex(cf->conn, TRUE);
+    }
     break;
   default:
     break;
@@ -1350,9 +1352,6 @@ static CURLcode cf_quiche_verify_peer(struct Curl_cfilter *cf,
                                       struct Curl_easy *data)
 {
   struct cf_quiche_ctx *ctx = cf->ctx;
-
-  cf->conn->bits.multiplex = TRUE; /* at least potentially multiplexed */
-
   return Curl_vquic_tls_verify_peer(&ctx->tls, cf, data, &ctx->peer);
 }
 

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -582,7 +582,7 @@ static void update_meta(struct websocket *ws,
   ws->recvframe.bytesleft = bytesleft;
 }
 
-/* WebSockets decoding client writer */
+/* WebSocket decoding client writer */
 struct ws_cw_ctx {
   struct Curl_cwriter super;
   struct bufq buf;
@@ -1268,6 +1268,7 @@ CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req)
   }
   data->state.http_hd_upgrade = TRUE;
   k->upgr101 = UPGR101_WS;
+  data->conn->bits.upgrade_in_progress = TRUE;
   return result;
 }
 
@@ -1358,6 +1359,8 @@ CURLcode Curl_ws_accept(struct Curl_easy *data,
   if(result)
     goto out;
   ws_dec_writer = NULL; /* owned by transfer now */
+
+  k->header = FALSE; /* we will not get more response headers */
 
   if(data->set.connect_only) {
     size_t nwritten;
@@ -1806,7 +1809,7 @@ out:
 static CURLcode ws_setup_conn(struct Curl_easy *data,
                               struct connectdata *conn)
 {
-  /* WebSockets is 1.1 only (for now) */
+  /* WebSocket is 1.1 only (for now) */
   data->state.http_neg.accept_09 = FALSE;
   data->state.http_neg.only_10 = FALSE;
   data->state.http_neg.wanted = CURL_HTTP_V1x;


### PR DESCRIPTION
Improvements around HTTP Upgrade: and multiplex hanndling:

* add `Curl_conn_set_multiplex()` to set connection's multiplex bit and trigger "connchanged" events
* call `Curl_conn_set_multiplex()` in filters' `CF_CTRL_CONN_INFO_UPDATE` implementation where other connection properties are updated. This prevents connection updates before the final filter chain is chosen.
* rename enum `UPGR101_INIT` to `UPGR101_NONE`
* rename connection bit `asks_multiplex` to `upgrade_in_progress`
* trigger "connchanged" when `upgrade_in_progress` clears
* rename `WebSockets` to `WebSocket` as it is the common term used in documentation