### PR TITLE
openssl: save and restore OpenSSL error queue in two functions

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4535,6 +4535,10 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
 
   connssl->io_need = CURL_SSL_IO_NEED_NONE;
 
+  ERR_clear_error();
+
+  err = SSL_connect(octx->ssl);
+
   if(!octx->x509_store_setup) {
     /* After having send off the ClientHello, we prepare the x509
      * store to verify the coming certificate from the server */
@@ -4543,10 +4547,6 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
       return result;
     octx->x509_store_setup = TRUE;
   }
-
-  ERR_clear_error();
-
-  err = SSL_connect(octx->ssl);
 
 #ifndef HAVE_KEYLOG_CALLBACK
   /* If key logging is enabled, wait for the handshake to complete and then

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3691,9 +3691,17 @@ CURLcode Curl_ssl_setup_x509_store(struct Curl_cfilter *cf,
                                    struct Curl_easy *data,
                                    SSL_CTX *ssl_ctx)
 {
-  X509_STORE *store = SSL_CTX_get_cert_store(ssl_ctx);
+  CURLcode result;
+  X509_STORE *store;
 
-  return ossl_populate_x509_store(cf, data, store);
+  ERR_set_mark();
+
+  store = SSL_CTX_get_cert_store(ssl_ctx);
+  result = ossl_populate_x509_store(cf, data, store);
+
+  ERR_pop_to_mark();
+
+  return result;
 }
 #endif /* HAVE_SSL_X509_STORE_SHARE */
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -3327,10 +3327,8 @@ static CURLcode import_windows_cert_store(struct Curl_easy *data,
         continue;
 
       x509 = d2i_X509(NULL, &encoded_cert, (long)pContext->cbCertEncoded);
-      if(!x509) {
-        ERR_clear_error();
+      if(!x509)
         continue;
-      }
 
       /* Try to import the certificate. This may fail for legitimate
          reasons such as duplicate certificate, which is allowed by MS but
@@ -4536,9 +4534,6 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
   DEBUGASSERT(octx);
 
   connssl->io_need = CURL_SSL_IO_NEED_NONE;
-  ERR_clear_error();
-
-  err = SSL_connect(octx->ssl);
 
   if(!octx->x509_store_setup) {
     /* After having send off the ClientHello, we prepare the x509
@@ -4548,6 +4543,10 @@ static CURLcode ossl_connect_step2(struct Curl_cfilter *cf,
       return result;
     octx->x509_store_setup = TRUE;
   }
+
+  ERR_clear_error();
+
+  err = SSL_connect(octx->ssl);
 
 #ifndef HAVE_KEYLOG_CALLBACK
   /* If key logging is enabled, wait for the handshake to complete and then


### PR DESCRIPTION
After merging #18228, I reviewed whether the clearing of the error queue
may interfere with preceding code. Turns out there may be a preceding
`SSL_Connect()` call.

This patch replaces the previous fix of clearing the error queue with
saving and restoring it in two functions which may be called between
the connect call and the `SSL_get_error()` call following it:
- `ossl_log_tls12_secret()`
- `Curl_ssl_setup_x509_store()`

The `ERR_set_mark()`, `ERR_pop_to_mark()` functions are present in all
supported OpenSSL and LibreSSL versions. Also in BoringSSL since its
initial commit.
 
OpenSSL may modify its error queue in all API calls that can fail.

Thanks-to: Viktor Dukhovni
Ref: https://github.com/curl/curl/issues/18190#issuecomment-3167702142
Ref: https://github.com/curl/curl/issues/18190#issuecomment-3169211739
Ref: https://github.com/curl/curl/issues/18190#issuecomment-3169988050

Follow-up to 8ec241bc990bc88c4f4f7275d81f9fb75b562a7a #18228 #18190
Ref: e8b00fcd6a0c7ff179cebb3615ccebf1f6790b69 #10432 #10389
Fixes #18190
