### PR TITLE
[TEST] GHA/windows: test some MSYS / CYGWIN env options

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,6 +39,8 @@ permissions: {}
 
 env:
   CURL_CI: github
+  CYGWIN: 'proc_retry:0'
+  MSYS: 'proc_retry:0'
 
 jobs:
   cygwin:

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -875,6 +875,8 @@ sub checksystemfeatures {
            "* System: $hosttype\n");
     if($ci) {
         logmsg("* OS: $hostos\n",
+               "* MSYS: $ENV{'MSYS'}\n",
+               "* CYGWIN: $ENV{'CYGWIN'}\n",
                "* Perl: $^V ($^X)\n",
                "* diff: $havediff\n");
     }


### PR DESCRIPTION
https://cygwin.com/cygwin-ug-net/using-cygwinenv.html

Recently the most frequent Windows-flakiness issue is
a failed fork within the MSYS2 runtime while Perl trying to
load its own Win32.dll, then failing with:
```
0 [main] perl 9788 child_info_fork::abort: unable to map \??\D:\a\_temp\msys64\usr\lib\perl5\core_perl\auto\Win32\Win32.dll (using D:\a\_temp\msys64\usr\lib\perl5\core_perl\auto\Win32\Win32.dll), Win32 error 1114
```

Then Perl waiting forever in a way that's unkillable by the step
watchdog, and killed 5 minutes past (wondering why?)
the workflow time limit, by GitHub Actions.

It'd be nice to find some ways to avoid the infinite loop and
fail and exit perl after a couple of attempts. Even nicer would
be finding why is it "unable to map", but that sounds like
a utopia at this point.

Not expecting much if anything from this test.

https://github.com/curl/curl/discussions/14854#discussioncomment-13562599