### PR TITLE
[tool_parsecfg]: expand tilde-charaters in parameters

### DIFF
--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -211,7 +211,7 @@ int parseconfig(const char *filename)
       if(param && param[0] == '~') {
 #ifdef _WIN32
         const char *home = curl_getenv("UserProfile");
-#elif
+#else
         const char *home = curl_getenv("HOME");
 #endif
         if(home) {

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -234,7 +234,6 @@ int parseconfig(const char *filename)
       }
 
       res = getparameter(option, param, &usedarg, config);
-
       config = global->last;
 
       if(!res && param && *param && !usedarg)

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -214,15 +214,18 @@ int parseconfig(const char *filename)
           char *tparam = strdup(param + 1);
           if(!tparam) {
             rc = 1; /* out of memory */
+            free(tparam);
             break;
           }
           curlx_dyn_reset(&pbuf);
           if(curlx_dyn_add(&pbuf, home)) {
             rc = 1; /* out of memory */
+            free(tparam);
             break;
           }
           if(curlx_dyn_add(&pbuf, tparam)) {
             rc = 1; /* out of memory */
+            free(tparam);
             break;
           }
           free(tparam);

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -209,11 +209,13 @@ int parseconfig(const char *filename)
 
       /* expand tilde-characters to the users home directory */
       if(param && param[0] == '~') {
-#ifdef _WIN32
-        const char *home = curl_getenv("UserProfile");
-#else
-        const char *home = curl_getenv("HOME");
-#endif
+        char *home = curl_getenv("HOME");
+        if(!home)
+          home = curl_getenv("USERPROFILE");
+        if(!home) {
+          rc = 1; /* cannot find home */
+          break;
+        }
         if(home) {
           char *tparam = strdup(param + 1);
           if(!tparam) {

--- a/src/tool_parsecfg.c
+++ b/src/tool_parsecfg.c
@@ -209,7 +209,11 @@ int parseconfig(const char *filename)
 
       /* expand tilde-characters to the users home directory */
       if(param && param[0] == '~') {
+#ifdef _WIN32
+        const char *home = curl_getenv("UserProfile");
+#elif
         const char *home = curl_getenv("HOME");
+#endif
         if(home) {
           char *tparam = strdup(param + 1);
           if(!tparam) {


### PR DESCRIPTION
Tilde-characters in both quoted and unquoted strings will be expanded to the users home-directory. This is a long-standing todo (item 18.19 in the todo file). I tried to keep this as concise as possible, but this is my first dabble with the curl codebase so feedback is very much appreciated!

Fixes #2317 (Edit: To some extent only; this issue asks for env var support while the TODO on the website, which I focused on, only mentions ~)