### PR TITLE
test436: fix running on Windows with `_curlrc` present

### DIFF
--- a/tests/data/test436
+++ b/tests/data/test436
@@ -30,6 +30,7 @@ http
 </server>
 <setenv>
 CURL_HOME=%PWD/%LOGDIR
+USERPROFILE
 XDG_CONFIG_HOME
 </setenv>
 <name>


### PR DESCRIPTION
in the user home directory.

Before this patch, the curl tool found the system curlrc first, ignoring
the custom one set by the test via `CURL_HOME`.
