### PR TITLE
trace if synch resolving is using signals or not

### DIFF
--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1063,11 +1063,10 @@ CURLcode Curl_resolv_timeout(struct Curl_easy *data,
   *entry = NULL;
 
 #ifdef USE_ALARM_TIMEOUT
-  CURL_TRC_DNS(data, "starting resolve of %s:%d, timeout of %"
-               FMT_TIMEDIFF_T "ms",
-               hostname, port, timeoutms);
+  CURL_TRC_DNS(data, "starting resolve of %s:%d, timeout of %" FMT_TIMEDIFF_T
+               "ms", hostname, port, timeoutms);
 #else
-  CURL_TRC_DNS(data, "starting resolve of %s:%d, no ALARM available,
+  CURL_TRC_DNS(data, "starting resolve of %s:%d, no ALARM available, "
                "timeout of %" FMT_TIMEDIFF_T "ms will not apply",
                hostname, port, timeoutms);
 #endif


### PR DESCRIPTION
Add some tracing so we see if sync resolving is obeying timeouts or not.