### PR TITLE
CI: update libstdc++ for linux-old build

### DIFF
--- a/.github/workflows/linux-old.yml
+++ b/.github/workflows/linux-old.yml
@@ -71,10 +71,12 @@ jobs:
           echo 'deb http://deb.freexian.com/extended-lts stretch-lts main contrib non-free' | tee /etc/apt/sources.list.d/extended-lts.list
           apt-get -o Dpkg::Use-Pty=0 update
           apt-get -o Dpkg::Use-Pty=0 install -y --no-install-suggests --no-install-recommends cmake make automake autoconf libtool gcc pkg-config libpsl-dev libzstd-dev zlib1g-dev libssl1.0-dev libssh-dev libssh2-1-dev libc-ares-dev heimdal-dev libldap2-dev librtmp-dev stunnel4 groff
-          # GitHub's actions/checkout needs a newer glibc. This one is the
-          # latest available for buster, the next stable release after stretch.
+          # GitHub's actions/checkout needs newer glibc and libstdc++. The latter also depends on
+          # gcc-8-base, but it doesn't actually seem used in our situation and isn't available in
+          # the main repo, so force the install.
           httrack --get https://deb.freexian.com/extended-lts/pool/main/g/glibc/libc6_2.28-10+deb10u5_amd64.deb
-          dpkg -i libc6_*_amd64.deb
+          httrack --get https://deb.freexian.com/extended-lts/pool/main/g/gcc-8/libstdc++6_8.3.0-6_amd64.deb
+          dpkg -i --force-depends libc6_*_amd64.deb libstdc++6_*_amd64.deb
 
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
         with:


### PR DESCRIPTION
actions/checkout@v5 requires a newer libstdc++ than the container
contains. Update it to a backwards-compatible version just like we
already do for libc6.

Ref: #18250
Closes #18255