### PR TITLE
URL-SYNTAX.md: drop link to codepoints.net to pass linkcheck

### DIFF
--- a/docs/URL-SYNTAX.md
+++ b/docs/URL-SYNTAX.md
@@ -195,8 +195,7 @@ When built with libidn2, curl uses the IDNA 2008 standard. This is equivalent
 to the WHATWG URL spec, but differs from certain browsers that use IDNA 2003
 Transitional Processing. The two standards have a huge overlap but differ
 slightly, perhaps most famously in how they deal with the
-[German "double s"](https://en.wikipedia.org/wiki/%c3%9f)
-([LATIN SMALL LETTER SHARP S](https://codepoints.net/U+00DF)).
+[German "double s"](https://en.wikipedia.org/wiki/%c3%9f).
 
 When WinIDN is used, curl uses IDNA 2003 Transitional Processing, like the rest
 of Windows.


### PR DESCRIPTION
The link works in a browser, but started failing the `mdlinkcheck` test:
```
check https://codepoints.net/U+00DF
FAIL
docs/URL-SYNTAX.md:199 ERROR links to missing URL https://codepoints.net/U+00DF
```
Ref: https://github.com/curl/curl/actions/runs/16902543407/job/47884625446?pr=18254#step:3:22