### PR TITLE
fixing a small issue in test 438

### DIFF
--- a/tests/data/test438
+++ b/tests/data/test438
@@ -46,9 +46,6 @@ CURL_ALTSVC_HTTP="yeah"
 <command>
 --alt-svc "%LOGDIR/altsvc-%TESTNUMBER" "http://%HOSTIP:%HTTPPORT/%TESTNUMBER" "http://%HOSTIP:%HTTPPORT/%TESTNUMBER"
 </command>
-<file name="%LOGDIR/altsvc-%TESTNUMBER">
-h1 %HOSTIP %HTTPPORT h1 %HOST6IP %HTTP6PORT "20290222 22:19:28" 0 0
-</file>
 
 </client>
 


### PR DESCRIPTION
I noticed when trace debugging that this test actually appears to work twice from http ipv6 which seems to not be the intent. 
this should fix that issue and verify that we actually need to get the altsvc from the regular server and only then run the ipv6 on the second request