### PR TITLE
fix threaded resolver shutdown

### DIFF
--- a/docs/libcurl/libcurl-env-dbg.md
+++ b/docs/libcurl/libcurl-env-dbg.md
@@ -83,6 +83,11 @@ When built with c-ares for name resolving, setting this environment variable
 to `[IP:port]` makes libcurl use that DNS server instead of the system
 default. This is used by the curl test suite.
 
+## `CURL_DNS_DELAY_MS`
+
+Delay the DNS resolve by this many milliseconds. This is used in the test
+suite to check proper handling of CURLOPT_CONNECTTIMEOUT(3).
+
 ## `CURL_FTP_PWD_STOP`
 
 When set, the first transfer - when using ftp: - returns before sending

--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -180,6 +180,9 @@ struct async_thrdd_addr_ctx {
   char *hostname;        /* hostname to resolve, Curl_async.hostname
                             duplicate */
   curl_mutex_t mutx;
+#ifdef USE_CURL_COND_T
+  curl_cond_t  cond;
+#endif
 #ifndef CURL_DISABLE_SOCKETPAIR
   curl_socket_t sock_pair[2]; /* eventfd/pipes/socket pair */
 #endif

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -34,6 +34,12 @@
 #  define Curl_mutex_acquire(m)  pthread_mutex_lock(m)
 #  define Curl_mutex_release(m)  pthread_mutex_unlock(m)
 #  define Curl_mutex_destroy(m)  pthread_mutex_destroy(m)
+#  define USE_CURL_COND_T
+#  define curl_cond_t            pthread_cond_t
+#  define Curl_cond_init(c)      pthread_cond_init(c, NULL)
+#  define Curl_cond_destroy(c)   pthread_cond_destroy(c)
+#  define Curl_cond_wait(c, m)   pthread_cond_wait(c, m)
+#  define Curl_cond_signal(c)    pthread_cond_signal(c)
 #elif defined(USE_THREADS_WIN32)
 #  define CURL_STDCALL           __stdcall
 #  define curl_mutex_t           CRITICAL_SECTION
@@ -47,6 +53,14 @@
 #  define Curl_mutex_acquire(m)  EnterCriticalSection(m)
 #  define Curl_mutex_release(m)  LeaveCriticalSection(m)
 #  define Curl_mutex_destroy(m)  DeleteCriticalSection(m)
+#  if defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
+#  define USE_CURL_COND_T
+#  define curl_cond_t            CONDITION_VARIABLE
+#  define Curl_cond_init(c)      InitializeConditionVariable(c)
+#  define Curl_cond_destroy(c)   (void)(c)
+#  define Curl_cond_wait(c, m)   SleepConditionVariableCS(c, m, INFINITE)
+#  define Curl_cond_signal(c)    WakeConditionVariable(c)
+#  endif
 #else
 #  define CURL_STDCALL
 #endif
@@ -65,6 +79,22 @@ curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
 void Curl_thread_destroy(curl_thread_t *hnd);
 
 int Curl_thread_join(curl_thread_t *hnd);
+
+int Curl_thread_cancel(curl_thread_t *hnd);
+
+#if defined(USE_THREADS_POSIX) && defined(PTHREAD_CANCEL_ENABLE)
+#define Curl_thread_push_cleanup(a,b)   pthread_cleanup_push(a,b)
+#define Curl_thread_pop_cleanup()       pthread_cleanup_pop(0)
+#define Curl_thread_enable_cancel()     \
+    pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL)
+#define Curl_thread_disable_cancel()     \
+    pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, NULL)
+#else
+#define Curl_thread_push_cleanup(a,b)   ((void)a,(void)b)
+#define Curl_thread_pop_cleanup()       Curl_nop_stmt
+#define Curl_thread_enable_cancel()     Curl_nop_stmt
+#define Curl_thread_disable_cancel()    Curl_nop_stmt
+#endif
 
 #endif /* USE_THREADS_POSIX || USE_THREADS_WIN32 */
 

--- a/lib/hostip.c
+++ b/lib/hostip.c
@@ -1132,6 +1132,10 @@ CURLcode Curl_resolv_timeout(struct Curl_easy *data,
     prev_alarm = alarm(curlx_sltoui(timeout/1000L));
   }
 
+#ifdef DEBUGBUILD
+  Curl_resolve_test_delay();
+#endif
+
 #else /* USE_ALARM_TIMEOUT */
 #ifndef CURLRES_ASYNCH
   if(timeoutms)
@@ -1634,3 +1638,18 @@ CURLcode Curl_resolver_error(struct Curl_easy *data)
   return result;
 }
 #endif /* USE_CURL_ASYNC */
+
+#ifdef DEBUGBUILD
+#include "curlx/wait.h"
+
+void Curl_resolve_test_delay(void)
+{
+  const char *p = getenv("CURL_DNS_DELAY_MS");
+  if(p) {
+    curl_off_t l;
+    if(!curlx_str_number(&p, &l, TIME_T_MAX) && l) {
+      curlx_wait_ms((timediff_t)l);
+    }
+  }
+}
+#endif

--- a/lib/hostip.h
+++ b/lib/hostip.h
@@ -216,4 +216,8 @@ struct Curl_addrinfo *Curl_sync_getaddrinfo(struct Curl_easy *data,
 
 #endif
 
+#ifdef DEBUGBUILD
+void Curl_resolve_test_delay(void);
+#endif
+
 #endif /* HEADER_CURL_HOSTIP_H */

--- a/scripts/singleuse.pl
+++ b/scripts/singleuse.pl
@@ -51,6 +51,7 @@ my %wl = (
     'Curl_creader_def_read' => 'internal api',
     'Curl_creader_def_total_length' => 'internal api',
     'Curl_meta_reset' => 'internal api',
+    'Curl_thread_destroy' => 'internal api',
     'Curl_trc_dns' => 'internal api',
     'curlx_base64_decode' => 'internal api',
     'curlx_base64_encode' => 'internal api',

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -110,7 +110,7 @@ test736 test737 test738 test739 test740 test741 test742 test743 test744 \
 test745 test746 test747 test748 test749 test750 test751 test752 test753 \
 test754 test755 test756 test757 test758 \
 test780 test781 test782 test783 test784 test785 test786 test787 test788 \
-test789 test790 test791 test792 test793 test794         test796 test797 \
+test789 test790 test791 test792 test793 test794 test795 test796 test797 \
 \
 test799 test800 test801 test802 test803 test804 test805 test806 test807 \
 test808 test809 test810 test811 test812 test813 test814 test815 test816 \

--- a/tests/data/test795
+++ b/tests/data/test795
@@ -1,0 +1,39 @@
+<testcase>
+<info>
+<keywords>
+DNS
+</keywords>
+</info>
+
+# Client-side
+<client>
+<features>
+http
+Debug
+!c-ares
+!win32
+</features>
+<name>
+Delayed resolve --connect-timeout check
+</name>
+<server>
+none
+</server>
+<setenv>
+CURL_DNS_DELAY_MS=5000
+</setenv>
+<command>
+http://test.invalid -v --no-progress-meter --trace-config dns --connect-timeout 1 -w \%{time_total}
+</command>
+</client>
+
+# Verify data after the test has been "shot"
+<verify>
+<errorcode>
+28
+</errorcode>
+<postcheck>
+%SRCDIR/libtest/test795.pl %LOGDIR/stdout%TESTNUMBER 2 >> %LOGDIR/stderr%TESTNUMBER
+</postcheck>
+</verify>
+</testcase>

--- a/tests/libtest/Makefile.am
+++ b/tests/libtest/Makefile.am
@@ -42,7 +42,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include        \
 include Makefile.inc
 
 EXTRA_DIST = CMakeLists.txt $(FIRST_C) $(FIRST_H) $(UTILS_C) $(UTILS_H) $(TESTS_C) \
-  test307.pl test610.pl test613.pl test1013.pl test1022.pl mk-lib1521.pl
+  test307.pl test610.pl test613.pl test795.pl test1013.pl test1022.pl mk-lib1521.pl
 
 CFLAGS += @CURL_CFLAG_EXTRAS@
 

--- a/tests/libtest/test795.pl
+++ b/tests/libtest/test795.pl
@@ -1,0 +1,46 @@
+#!/usr/bin/env perl
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+use strict;
+use warnings;
+
+my $ok = 1;
+my $exp_duration = $ARGV[1] + 0.0;
+
+# Read the output of curl --version
+open(F, $ARGV[0]) || die "Can't open test result from $ARGV[0]\n";
+$_ = <F>;
+chomp;
+/\s*([\.\d]+)\s*/;
+my $duration = $1 + 0.0;
+close F;
+
+if ($duration <= $exp_duration) {
+    print "OK: duration of $duration in expected range\n";
+    $ok = 0;
+}
+else {
+    print "FAILED: duration of $duration is larger than $exp_duration\n";
+}
+exit $ok;


### PR DESCRIPTION
Changed strategy to terminate resolver thread.

When starting up:

Start the thread with mutex acquired, wait for signal from thread that it started and has incremented the ref counter. Thread set pthread_cancel() to disabled before that and only enables cancelling during resolving itself. This assure that the ref counter is correct and the unlinking of the resolve context always happens.

When shutting down resolving:

If ref counting shows thread has finished, join it, free everything. If thread has not finished, try pthread_cancel() (non Windows), but keep the thread handle around.

When destroying resolving:

Shutdown first, then, if the thread is still there and 'quick_exit' is not set, join it and free everything. This might occur a delay if  getaddrinfo() hangs and cannot be interrupted by pthread_cancel().

Destroying resolving happens when another resolve is started on an  easy handle or when the easy handle is closed.

Add test795 to check that connect timeout triggers correctly when resolving is delayed. Add debug env var `CURL_DNS_DELAY_MS` to simulate delays in resolving.
