### PR TITLE
curl: add build option to use the native CA store by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1497,6 +1497,8 @@ endif()
 #
 # CA handling
 #
+option(CURL_CA_NATIVE_BY_DEFAULT "Use native CA store by default in the curl tool" OFF)
+
 if(_curl_ca_bundle_supported)
   set(CURL_CA_BUNDLE "auto" CACHE
     STRING "Path to the CA bundle. Set 'none' to disable or 'auto' for auto-detection. Defaults to 'auto'.")

--- a/configure.ac
+++ b/configure.ac
@@ -2083,6 +2083,26 @@ fi
 
 AM_CONDITIONAL(CURL_CA_EMBED_SET, test "x$CURL_CA_EMBED" != "x")
 
+dnl --------------------------------
+dnl check native CA store by default
+dnl --------------------------------
+
+AC_MSG_CHECKING([whether to use native CA store by default in the curl tool])
+AC_ARG_ENABLE(ca-native,
+AS_HELP_STRING([--enable-ca-native-by-default],[Enable native CA store by default in the curl tool])
+AS_HELP_STRING([--disable-ca-native-by-default],[Disable native CA store by default in the curl tool (default)]),
+[ case "$enableval" in
+  yes)
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(CURL_CA_NATIVE_BY_DEFAULT, 1, [If native CA store by default in the curl tool is enabled])
+    ;;
+  *)
+    AC_MSG_RESULT([no])
+    ;;
+  esac ],
+    AC_MSG_RESULT([no])
+)
+
 dnl ----------------------
 dnl check unsafe CA search
 dnl ----------------------

--- a/docs/INSTALL-CMAKE.md
+++ b/docs/INSTALL-CMAKE.md
@@ -259,6 +259,8 @@ target_link_libraries(my_target PRIVATE CURL::libcurl)
 - `CURL_CA_BUNDLE`:                         Path to the CA bundle. Set `none` to disable or `auto` for auto-detection. Default: `auto`
 - `CURL_CA_EMBED`:                          Path to the CA bundle to embed in the curl tool. Default: (disabled)
 - `CURL_CA_FALLBACK`:                       Use built-in CA store of TLS backend. Default: `OFF`
+- `CURL_CA_NATIVE_BY_DEFAULT`:              Use native CA store by default in the curl tool. Default: `OFF`
+                                            Supported by GnuTLS, OpenSSL (including forks) on Windows, wolfSSL.
 - `CURL_CA_PATH`:                           Location of default CA path. Set `none` to disable or `auto` for auto-detection. Default: `auto`
 - `CURL_CA_SEARCH_SAFE`:                    Enable safe CA bundle search (within the curl tool directory) on Windows. Default: `OFF`
 

--- a/lib/curl_config.h.cmake
+++ b/lib/curl_config.h.cmake
@@ -34,6 +34,9 @@
 /* Default SSL backend */
 #cmakedefine CURL_DEFAULT_SSL_BACKEND "${CURL_DEFAULT_SSL_BACKEND}"
 
+/* Use native CA store by default in curl tool */
+#cmakedefine CURL_CA_NATIVE_BY_DEFAULT 1
+
 /* disables alt-svc */
 #cmakedefine CURL_DISABLE_ALTSVC 1
 

--- a/src/tool_cfgable.c
+++ b/src/tool_cfgable.c
@@ -54,6 +54,10 @@ struct OperationConfig *config_alloc(void)
   config->upload_flags = CURLULFLAG_SEEN;
   config->retry_delay_ms = RETRY_SLEEP_DEFAULT;
   curlx_dyn_init(&config->postdata, MAX_FILE2MEMORY);
+#ifdef CURL_CA_NATIVE_BY_DEFAULT
+  config->native_ca_store = TRUE;
+  config->proxy_native_ca_store = TRUE;
+#endif
   return config;
 }
 


### PR DESCRIPTION
Usage:
- cmake: `-DCURL_CA_NATIVE_BY_DEFAULT=ON`
- autotools: `--enable-ca-native-by-default`
- CPPFLAGS: `-DCURL_CA_NATIVE_BY_DEFAULT`

If enabled a built-time, the native CA be disabled at runtime with
the `--no-ca-native` command-line option.

I'm attempting again, because:
- there is repeat and active interest in this option.
- it helps integrating curl with Windows for those who need this.
- possibly also with macOS: #17525
- it frees applications/user from the task of securely distributing, and
  keeping up-to-date, a CA bundle.
- it frees potentially many curl tool users from configuring a CA bundle
  manually to access HTTPS (and other TLS) URLs. This is traditionally
  difficult on Windows because there is no concept of a protected,
  non-world-writable directory to securely store a CA bundle.

Ref: #16181 (previous attempt)
Ref: https://github.com/curl/curl/discussions/9348
Ref: https://github.com/microsoft/vcpkg/pull/46459#issuecomment-3162068701
