### PR TITLE
runtests: assume `Time::HiRes`, drop Perl Win32 dependency

### DIFF
--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -61,7 +61,7 @@ use getpart qw(
     loadtest
     );
 
-#use processhelp;
+use processhelp;
 
 use serverhelp qw(
     logmsg

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -51,6 +51,7 @@ BEGIN {
 use IPC::Open2;
 use Digest::MD5;
 use File::Basename;
+use Time::HiRes;
 
 use directories;
 
@@ -59,8 +60,6 @@ use getpart qw(
     getpart
     loadtest
     );
-
-use processhelp;
 
 use serverhelp qw(
     logmsg
@@ -484,7 +483,7 @@ sub sendcontrol {
 
         for(@a) {
             sockfilt $_;
-            portable_sleep($ctrldelay);
+            Time::HiRes::sleep($ctrldelay);
         }
     }
     my $log;
@@ -521,7 +520,7 @@ sub senddata {
             # pause between each byte
             for (split(//,$l)) {
                 sockfiltsecondary $_;
-                portable_sleep($datadelay);
+                Time::HiRes::sleep($datadelay);
             }
         }
     }
@@ -3292,7 +3291,7 @@ while(1) {
             logmsg("Sleep for $delay seconds\n");
             my $twentieths = $delay * 20;
             while($twentieths--) {
-                portable_sleep(0.05) unless($got_exit_signal);
+                Time::HiRes::sleep(0.05) unless($got_exit_signal);
             }
         }
 

--- a/tests/ftpserver.pl
+++ b/tests/ftpserver.pl
@@ -61,6 +61,8 @@ use getpart qw(
     loadtest
     );
 
+#use processhelp;
+
 use serverhelp qw(
     logmsg
     $logfile

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -74,7 +74,7 @@ use globalconfig qw(
 # to the classic approach of using select(undef, undef, undef, ...).
 # even though that one is not portable due to being implemented using
 # select on Windows: https://perldoc.perl.org/perlport.html#select
-# Therefore it uses Win32::Sleep on Windows systems instead.
+# Therefore it uses sleep() on Windows systems instead.
 #
 sub portable_sleep {
     my ($seconds) = @_;
@@ -83,7 +83,7 @@ sub portable_sleep {
         Time::HiRes::sleep($seconds);
     }
     elsif(os_is_win()) {
-        Win32::Sleep($seconds*1000);
+        sleep($seconds);
     }
     else {
         select(undef, undef, undef, $seconds);

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -33,7 +33,6 @@ BEGIN {
     use base qw(Exporter);
 
     our @EXPORT = qw(
-        portable_sleep
         pidfromfile
         pidexists
         pidwait
@@ -59,13 +58,6 @@ use pathhelp qw(
 use globalconfig qw(
     $dev_null
     );
-
-#######################################################################
-# portable_sleep uses Time::HiRes::sleep()
-sub portable_sleep {
-    my ($seconds) = @_;
-    Time::HiRes::sleep($seconds);
-}
 
 #######################################################################
 # pidfromfile returns the pid stored in the given pidfile.  The value
@@ -215,7 +207,7 @@ sub pidwait {
                     last;
                 }
             }
-            portable_sleep(0.2);
+            Time::HiRes::sleep(0.2);
         }
         return $pid;
     }
@@ -323,7 +315,7 @@ sub killpid {
             last if(not scalar(@signalled));
             # give any zombies of us a chance to move on to the afterlife
             pidwait(0, &WNOHANG);
-            portable_sleep(0.05);
+            Time::HiRes::sleep(0.05);
         }
     }
 

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -27,6 +27,8 @@ package processhelp;
 use strict;
 use warnings;
 
+use Time::HiRes;
+
 BEGIN {
     use base qw(Exporter);
 
@@ -42,12 +44,6 @@ BEGIN {
         set_advisor_read_lock
         clear_advisor_read_lock
     );
-
-    # portable sleeping needs Time::HiRes
-    eval {
-        no warnings "all";
-        require Time::HiRes;
-    };
 }
 
 use serverhelp qw(
@@ -65,24 +61,10 @@ use globalconfig qw(
     );
 
 #######################################################################
-# portable_sleep uses Time::HiRes::sleep if available and falls back
-# to the classic approach of using select(undef, undef, undef, ...).
-# even though that one is not portable due to being implemented using
-# select on Windows: https://perldoc.perl.org/perlport.html#select
-# Therefore it uses sleep() on Windows systems instead.
-#
+# portable_sleep uses Time::HiRes::sleep()
 sub portable_sleep {
     my ($seconds) = @_;
-
-    if($Time::HiRes::VERSION) {
-        Time::HiRes::sleep($seconds);
-    }
-    elsif(os_is_win()) {
-        sleep($seconds);
-    }
-    else {
-        select(undef, undef, undef, $seconds);
-    }
+    Time::HiRes::sleep($seconds);
 }
 
 #######################################################################

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -48,11 +48,6 @@ BEGIN {
         no warnings "all";
         require Time::HiRes;
     };
-    # portable sleeping falls back to native Sleep on Windows
-    eval {
-        no warnings "all";
-        require Win32;
-    }
 }
 
 use serverhelp qw(

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -39,6 +39,7 @@ use warnings;
 use 5.006;
 
 use File::Basename;
+use Time::HiRes;
 
 BEGIN {
     use base qw(Exporter);
@@ -83,9 +84,6 @@ use Storable qw(
 
 use pathhelp qw(
     exe_ext
-    );
-use processhelp qw(
-    portable_sleep
     );
 use servers qw(
     checkcmd
@@ -419,7 +417,7 @@ sub waitlockunlock {
         my $lockretry = $serverlogslocktimeout * 20;
         my @locks;
         while((@locks = logslocked()) && $lockretry--) {
-            portable_sleep(0.05);
+            Time::HiRes::sleep(0.05);
         }
         if(($lockretry < 0) &&
            ($serverlogslocktimeout >= $defserverlogslocktimeout)) {
@@ -1092,7 +1090,7 @@ sub singletest_clean {
         }
     }
 
-    portable_sleep($postcommanddelay) if($postcommanddelay);
+    Time::HiRes::sleep($postcommanddelay) if($postcommanddelay);
 
     my @killtestservers = getpart("client", "killserver");
     if(@killtestservers) {

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -92,9 +92,6 @@ use pathhelp qw(
     exe_ext
     sys_native_current_path
     );
-use processhelp qw(
-    portable_sleep
-    );
 
 use appveyor;
 use azure;

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -76,7 +76,7 @@ our $logfile;  # server log file name, for logmsg
 # logmsg is general message logging subroutine for our test servers.
 #
 sub logmsg {
-    my ($seconds, $usec) = gettimeofday();
+    my ($seconds, $usec) = Time::HiRes::gettimeofday();
     my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
         localtime($seconds);
     my $now = sprintf("%02d:%02d:%02d.%06d ", $hour, $min, $sec, $usec);

--- a/tests/serverhelp.pm
+++ b/tests/serverhelp.pm
@@ -29,6 +29,8 @@ package serverhelp;
 use strict;
 use warnings;
 
+use Time::HiRes;
+
 BEGIN {
     use base qw(Exporter);
 
@@ -52,13 +54,6 @@ BEGIN {
         datasockf_pidfilename
         datasockf_logfilename
     );
-
-    # sub second timestamping needs Time::HiRes
-    eval {
-        no warnings "all";
-        require Time::HiRes;
-        import  Time::HiRes qw( gettimeofday );
-    }
 }
 
 use globalconfig;
@@ -81,20 +76,10 @@ our $logfile;  # server log file name, for logmsg
 # logmsg is general message logging subroutine for our test servers.
 #
 sub logmsg {
-    my $now;
-    # sub second timestamping needs Time::HiRes
-    if($Time::HiRes::VERSION) {
-        my ($seconds, $usec) = gettimeofday();
-        my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
-            localtime($seconds);
-        $now = sprintf("%02d:%02d:%02d.%06d ", $hour, $min, $sec, $usec);
-    }
-    else {
-        my $seconds = time();
-        my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
-            localtime($seconds);
-        $now = sprintf("%02d:%02d:%02d ", $hour, $min, $sec);
-    }
+    my ($seconds, $usec) = gettimeofday();
+    my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) =
+        localtime($seconds);
+    my $now = sprintf("%02d:%02d:%02d.%06d ", $hour, $min, $sec, $usec);
     # we see warnings on Windows run that $logfile is used uninitialized
     # TODO: not found yet where this comes from
     $logfile = "serverhelp_uninitialized.log" if(!$logfile);

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -380,7 +380,7 @@ sub startnew {
             logmsg "startnew: failed to write fake $pidfile with pid=$child\n";
         }
         # could/should do a while connect fails sleep a bit and loop
-        portable_sleep($timeout);
+        Time::HiRes::sleep($timeout);
         if(checkdied($child)) {
             logmsg "startnew: child process has failed to start\n" if($verbose);
             return (-1,-1);


### PR DESCRIPTION
`Time::HiRes` was already used unconditionally before this patch in
`servers.pm`. This package, and functions used by runtests (`sleep` and
`gettimeofday`) are supported by the minimum Perl version required for
curl:

https://perldoc.perl.org/5.8.0/Time::HiRes

- Drop the `portable_sleep()` wrapper in favor of `Time::HiRes::sleep()`.
- Use `Time::HiRes` unconditionally in `serverhelp.pm`.
- Stop using the `Win32` package where available. It was included
  to provide a Windows fallback for `Time::HiRes::sleep()`. It was never
  actually called (on supported Perl versions), but the dependency may
  have loaded `Win32.dll`, which often appears in failed fork operations
  in GHA logs.
  Ref: a6fed41f6f12f3b71cfe85609f02a294b972d3d3 #5054 #5034
  Ref: https://github.com/curl/curl/discussions/14854

---

Most likely doesn't make a difference in practice.
