### PR TITLE
GHA/linux: skip building examples in valgrind jobs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -706,7 +706,7 @@ jobs:
           ../.github/scripts/randcurl.pl 60 ../bld/src/curl
 
       - name: 'build examples'
-        if: ${{ matrix.build.make-custom-target != 'tidy' }}
+        if: ${{ !contains(matrix.build.install_packages, 'valgrind') && matrix.build.make-custom-target != 'tidy' }}
         run: |
           if [ "${MATRIX_BUILD}" = 'cmake' ]; then
             ${MATRIX_MAKE_PREFIX} cmake --build bld --verbose --target curl-examples-build


### PR DESCRIPTION
To make these long jobs finish a little bit faster.

10s in total for 5 cmake jobs, 11s for 1 autotools job.
