### PR TITLE
GHA/windows: install `Win32::Process*` perl modules

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,7 +51,7 @@ jobs:
     env:
       MAKEFLAGS: -j 5
     steps:
-      - name: 'cache Perl Win32::Process'
+      - name: 'cache perl packages'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         id: cache-perl-win32-pkgs
         env:
@@ -67,7 +67,7 @@ jobs:
           msystem: msys
           install: gcc make
 
-      - name: 'build Perl Win32::Process'
+      - name: 'build perl packages'
         if: ${{ steps.cache-perl-win32-process.outputs.cache-hit != 'true' }}
         run: |
           cd ~
@@ -987,6 +987,16 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' }}
         timeout-minutes: 10
         run: cmake --build bld --config "${MATRIX_TYPE}" --parallel 5 --target testdeps
+
+      - name: 'cache perl packages'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        id: cache-perl-win32-pkgs
+        env:
+          cache-name: cache-perl-win32-pkgs
+        with:
+          path: ~/perl-win32-pkgs
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           cd /d
           mkdir perl-win32-pkgs
-          cd perl-win32-pkgs
+          pushd perl-win32-pkgs
           sed -i.bak 's/#define I_CRYPT//g' /usr/lib/perl5/core_perl/CORE/config.h
 
           # https://metacpan.org/pod/Win32::Process
@@ -81,27 +81,17 @@ jobs:
           cd Win32-Process-0.17
           perl Makefile.PL
           sed -i.bak 's/-lcrypt//g' Makefile
-          make install
-          # Installing /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
-          # Installing /usr/lib/perl5/site_perl/Win32/Process.pm
-          # Installing /usr/share/man/man3/Win32.Process.3pm
-          # Appending installation info to /usr/lib/perl5/core_perl/perllocal.pod
-          cd ..
+          make
+          popd
 
           # https://metacpan.org/pod/Win32::Process::List
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://cpan.metacpan.org/authors/id/R/RP/RPAGITSCH/Win32-Process-List-0.09.tar.gz" | tar -xz
-          cd Win32-Process-List-0.09
+          pushd Win32-Process-List-0.09
           perl Makefile.PL
           sed -i.bak 's/-lcrypt//g' Makefile
-          make install
-          # Installing /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
-          # Installing /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
-          # Installing /usr/lib/perl5/site_perl/Win32/Process/List.pm
-          # Installing /usr/lib/perl5/site_perl/Win32/Process/processes.pl
-          # Installing /usr/share/man/man3/Win32.Process.List.3pm
-          # Appending installation info to /usr/lib/perl5/core_perl/perllocal.pod
-          cd ..
+          make
+          popd
 
   cygwin:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
@@ -1004,12 +994,17 @@ jobs:
         run: |
           pushd /d/perl-win32-pkgs
           pushd Win32-Process-0.17
-          make install
+          install -d blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
+          install -d blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
           popd
           pushd Win32-Process-List-0.09
-          make install
+          install -d blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
+          install -d blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
+          install -d blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
+          install -d blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
           popd
           popd
+
           if [ -z "${MATRIX_OPENSSH}" ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           elif [ "${MATRIX_OPENSSH}" = 'OpenSSH-Windows-builtin' ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -994,17 +994,14 @@ jobs:
         run: |
           pushd /d/perl-win32-pkgs
           pushd Win32-Process-0.17
-          which install
-          find . -type f
-          install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process
-          install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32
+          install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
+          install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
           popd
           pushd Win32-Process-List-0.09
-          find . -type f
-          install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List
-          install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List
-          install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process
-          install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process
+          install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
+          install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
+          install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
+          install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
           popd
           popd
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -241,6 +241,8 @@ jobs:
 
   msys2:  # both msys and mingw-w64
     name: "${{ matrix.sys == 'msys' && 'msys2' || 'mingw' }}, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.env }} ${{ matrix.name }} ${{ matrix.test }}"
+    needs:
+      - build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: 15
     defaults:
@@ -421,7 +423,7 @@ jobs:
           fi
 
       - name: 'cache perl packages'
-        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' && matrix.sys != 'msys' }}
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         id: cache-perl-win32-pkgs
         env:
@@ -434,18 +436,20 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
-          pushd /c/perl-win32-pkgs
-          pushd Win32-Process-0.17
-          install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
-          install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
-          popd
-          pushd Win32-Process-List-0.09
-          install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
-          install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
-          install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
-          install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
-          popd
-          popd
+          if [ -d /c/perl-win32-pkgs ]; then
+            pushd /c/perl-win32-pkgs
+            pushd Win32-Process-0.17
+            install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
+            install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
+            popd
+            pushd Win32-Process-List-0.09
+            install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
+            install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
+            install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
+            install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
+            popd
+            popd
+          fi
 
           /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
@@ -491,6 +495,8 @@ jobs:
 
   mingw-w64-standalone-downloads:
     name: 'dl-mingw, CM ${{ matrix.ver }}-${{ matrix.env }} ${{ matrix.name }}'
+    needs:
+      - build-cache
     runs-on: windows-2022
     timeout-minutes: 15
     defaults:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -994,14 +994,14 @@ jobs:
         run: |
           pushd /d/perl-win32-pkgs
           pushd Win32-Process-0.17
-          install -d blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
-          install -d blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
+          install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process
+          install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32
           popd
           pushd Win32-Process-List-0.09
-          install -d blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
-          install -d blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
-          install -d blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
-          install -d blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
+          install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List
+          install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List
+          install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process
+          install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process
           popd
           popd
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           cache-name: cache-perl-win32-pkgs
         with:
-          path: ~/perl-win32-pkgs
+          path: D:\perl-win32-pkgs
           key: ${{ runner.os }}-build-${{ env.cache-name }}
 
       - name: 'install build prereqs'
@@ -70,7 +70,7 @@ jobs:
       - name: 'build perl packages'
         if: ${{ steps.cache-perl-win32-process.outputs.cache-hit != 'true' }}
         run: |
-          cd ~
+          cd /d
           mkdir perl-win32-pkgs
           cd perl-win32-pkgs
           sed -i.bak 's/#define I_CRYPT//g' /usr/lib/perl5/core_perl/CORE/config.h
@@ -995,20 +995,21 @@ jobs:
         env:
           cache-name: cache-perl-win32-pkgs
         with:
-          path: ~/perl-win32-pkgs
+          path: D:\perl-win32-pkgs
           key: ${{ runner.os }}-build-${{ env.cache-name }}
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
-          cd perl-win32-pkgs
-          cd Win32-Process-0.17
+          pushd /d/perl-win32-pkgs
+          pushd Win32-Process-0.17
           make install
-          cd ..
-          cd Win32-Process-List-0.09
+          popd
+          pushd Win32-Process-List-0.09
           make install
-          cd ..
+          popd
+          popd
           if [ -z "${MATRIX_OPENSSH}" ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           elif [ "${MATRIX_OPENSSH}" = 'OpenSSH-Windows-builtin' ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           cache-name: cache-perl-win32-pkgs
         with:
-          path: D:\perl-win32-pkgs
+          path: C:\perl-win32-pkgs
           key: ${{ runner.os }}-build-${{ env.cache-name }}
 
       - name: 'install build prereqs'
@@ -70,7 +70,7 @@ jobs:
       - name: 'build perl packages'
         if: ${{ steps.cache-perl-win32-pkgs.outputs.cache-hit != 'true' }}
         run: |
-          cd /d
+          cd /c
           mkdir perl-win32-pkgs
           pushd perl-win32-pkgs
           sed -i.bak 's/#define I_CRYPT//g' /usr/lib/perl5/core_perl/CORE/config.h
@@ -985,14 +985,14 @@ jobs:
         env:
           cache-name: cache-perl-win32-pkgs
         with:
-          path: D:\perl-win32-pkgs
+          path: C:\perl-win32-pkgs
           key: ${{ runner.os }}-build-${{ env.cache-name }}
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
-          pushd /d/perl-win32-pkgs
+          pushd /c/perl-win32-pkgs
           pushd Win32-Process-0.17
           install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
           install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,9 +53,6 @@ jobs:
       matrix:
         image: [windows-2022, windows-11-arm]
     steps:
-      - name: 'info'
-        run: echo '${{ runner.name }}|${{ runner.os }}|${{ runner.arch }}|'
-
       - name: 'cache perl packages'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         id: cache-perl-win32-pkgs
@@ -63,7 +60,7 @@ jobs:
           cache-name: cache-perl-win32-pkgs
         with:
           path: C:\perl-win32-pkgs
-          key: ${{ matrix.image }}-build-${{ env.cache-name }}
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}
 
       - name: 'install build prereqs'
         if: ${{ steps.cache-perl-win32-pkgs.outputs.cache-hit != 'true' }}
@@ -423,10 +420,33 @@ jobs:
             mv bld/tests/unit/.libs/*.exe bld/tests/unit || true
           fi
 
+      - name: 'cache perl packages'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        id: cache-perl-win32-pkgs
+        env:
+          cache-name: cache-perl-win32-pkgs
+        with:
+          path: C:\perl-win32-pkgs
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}
+
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
+          pushd /c/perl-win32-pkgs
+          pushd Win32-Process-0.17
+          install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
+          install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
+          popd
+          pushd Win32-Process-List-0.09
+          install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
+          install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
+          install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
+          install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
+          popd
+          popd
+
           /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
 
@@ -619,10 +639,33 @@ jobs:
           PATH="/d/my-cache/${MATRIX_DIR}/bin:$PATH"
           cmake --build bld --target testdeps
 
+      - name: 'cache perl packages'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        id: cache-perl-win32-pkgs
+        env:
+          cache-name: cache-perl-win32-pkgs
+        with:
+          path: C:\perl-win32-pkgs
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}
+
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
+          pushd /c/perl-win32-pkgs
+          pushd Win32-Process-0.17
+          install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
+          install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
+          popd
+          pushd Win32-Process-List-0.09
+          install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
+          install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
+          install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
+          install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
+          popd
+          popd
+
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
           python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
 
@@ -756,7 +799,7 @@ jobs:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
     needs:
       - build-cache
-    runs-on: ${{ matrix.image }}
+    runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: 15
     defaults:
       run:
@@ -802,7 +845,6 @@ jobs:
             env: 'ucrt-x86_64'
             plat: 'windows'
             type: 'Debug'
-            image: 'windows-2022'
             chkprefill: '_chkprefill'
             config: >-
               -DENABLE_DEBUG=ON
@@ -992,7 +1034,7 @@ jobs:
           cache-name: cache-perl-win32-pkgs
         with:
           path: C:\perl-win32-pkgs
-          key: ${{ matrix.image }}-build-${{ env.cache-name }}
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -432,10 +432,10 @@ jobs:
           path: C:\perl-win32-pkgs
           key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}
 
-      - name: 'install test prereqs'
+      - name: 'install test prereqs perl'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
-        run: |
+        run: &perl-win32-pkgs-install |
           if [ -d /c/perl-win32-pkgs ]; then
             cd /c/perl-win32-pkgs
             cd Win32-Process-0.17
@@ -451,6 +451,10 @@ jobs:
             cd ..
           fi
 
+      - name: 'install test prereqs'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        timeout-minutes: 5
+        run: |
           /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
 
@@ -655,23 +659,15 @@ jobs:
           path: C:\perl-win32-pkgs
           key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}
 
+      - name: 'install test prereqs perl'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        timeout-minutes: 5
+        run: *perl-win32-pkgs-install
+
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
-          cd /c/perl-win32-pkgs
-          cd Win32-Process-0.17
-          install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
-          install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
-          cd ..
-          cd Win32-Process-List-0.09
-          install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
-          install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
-          install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
-          install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
-          cd ..
-          cd ..
-
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
           python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
 
@@ -1042,23 +1038,15 @@ jobs:
           path: C:\perl-win32-pkgs
           key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.cache-name }}
 
+      - name: 'install test prereqs perl'
+        if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
+        timeout-minutes: 5
+        run: *perl-win32-pkgs-install
+
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
-          cd /c/perl-win32-pkgs
-          cd Win32-Process-0.17
-          install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
-          install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
-          cd ..
-          cd Win32-Process-List-0.09
-          install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
-          install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
-          install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
-          install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
-          cd ..
-          cd ..
-
           if [ -z "${MATRIX_OPENSSH}" ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           elif [ "${MATRIX_OPENSSH}" = 'OpenSSH-Windows-builtin' ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -68,7 +68,7 @@ jobs:
           install: gcc make
 
       - name: 'build perl packages'
-        if: ${{ steps.cache-perl-win32-process.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-perl-win32-pkgs.outputs.cache-hit != 'true' }}
         run: |
           cd /d
           mkdir perl-win32-pkgs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,6 +53,9 @@ jobs:
       matrix:
         image: [windows-2022, windows-11-arm]
     steps:
+      - name: 'info'
+        run: echo '${{ runner.name }}|${{ runner.os }}|${{ runner.arch }}|'
+
       - name: 'cache perl packages'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         id: cache-perl-win32-pkgs

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -753,7 +753,7 @@ jobs:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
     needs:
       - build-cache
-    runs-on: ${{ matrix.image || 'windows-2022' }}
+    runs-on: ${{ matrix.image }}
     timeout-minutes: 15
     defaults:
       run:
@@ -799,6 +799,7 @@ jobs:
             env: 'ucrt-x86_64'
             plat: 'windows'
             type: 'Debug'
+            image: 'windows-2022'
             chkprefill: '_chkprefill'
             config: >-
               -DENABLE_DEBUG=ON

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -80,20 +80,20 @@ jobs:
           # https://metacpan.org/pod/Win32::Process
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://cpan.metacpan.org/authors/id/J/JD/JDB/Win32-Process-0.17.tar.gz" | tar -xz
-          pushd Win32-Process-0.17
+          cd Win32-Process-0.17
           perl Makefile.PL
           sed -i.bak 's/-lcrypt//g' Makefile
           make
-          popd
+          cd ..
 
           # https://metacpan.org/pod/Win32::Process::List
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://cpan.metacpan.org/authors/id/R/RP/RPAGITSCH/Win32-Process-List-0.09.tar.gz" | tar -xz
-          pushd Win32-Process-List-0.09
+          cd Win32-Process-List-0.09
           perl Makefile.PL
           sed -i.bak 's/-lcrypt//g' Makefile
           make
-          popd
+          cd ..
 
   cygwin:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
@@ -437,18 +437,18 @@ jobs:
         timeout-minutes: 5
         run: |
           if [ -d /c/perl-win32-pkgs ]; then
-            pushd /c/perl-win32-pkgs
-            pushd Win32-Process-0.17
+            cd /c/perl-win32-pkgs
+            cd Win32-Process-0.17
             install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
             install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
-            popd
-            pushd Win32-Process-List-0.09
+            cd ..
+            cd Win32-Process-List-0.09
             install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
             install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
             install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
             install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
-            popd
-            popd
+            cd ..
+            cd ..
           fi
 
           /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
@@ -659,18 +659,18 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
-          pushd /c/perl-win32-pkgs
-          pushd Win32-Process-0.17
+          cd /c/perl-win32-pkgs
+          cd Win32-Process-0.17
           install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
           install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
-          popd
-          pushd Win32-Process-List-0.09
+          cd ..
+          cd Win32-Process-List-0.09
           install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
           install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
           install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
           install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
-          popd
-          popd
+          cd ..
+          cd ..
 
           /c/ProgramData/chocolatey/choco.exe install --yes --no-progress --limit-output --timeout 180 --force stunnel || true
           python3 -m pip --disable-pip-version-check --no-input --no-cache-dir install --progress-bar off --prefer-binary impacket
@@ -1046,18 +1046,18 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
-          pushd /c/perl-win32-pkgs
-          pushd Win32-Process-0.17
+          cd /c/perl-win32-pkgs
+          cd Win32-Process-0.17
           install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
           install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32/Process.pm
-          popd
-          pushd Win32-Process-List-0.09
+          cd ..
+          cd Win32-Process-List-0.09
           install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
           install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
           install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process/List.pm
           install -D blib/lib/Win32/Process/processes.pl           /usr/lib/perl5/site_perl/Win32/Process/processes.pl
-          popd
-          popd
+          cd ..
+          cd ..
 
           if [ -z "${MATRIX_OPENSSH}" ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -994,10 +994,13 @@ jobs:
         run: |
           pushd /d/perl-win32-pkgs
           pushd Win32-Process-0.17
+          which install
+          find . -type f
           install -D blib/arch/auto/Win32/Process/Process.dll      /usr/lib/perl5/site_perl/auto/Win32/Process
           install -D blib/lib/Win32/Process.pm                     /usr/lib/perl5/site_perl/Win32
           popd
           pushd Win32-Process-List-0.09
+          find . -type f
           install -D blib/arch/auto/Win32/Process/List/List.dll    /usr/lib/perl5/site_perl/auto/Win32/Process/List
           install -D blib/lib/auto/Win32/Process/List/autosplit.ix /usr/lib/perl5/site_perl/auto/Win32/Process/List
           install -D blib/lib/Win32/Process/List.pm                /usr/lib/perl5/site_perl/Win32/Process

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -72,13 +72,13 @@ jobs:
         run: |
           cd /c
           mkdir perl-win32-pkgs
-          pushd perl-win32-pkgs
+          cd perl-win32-pkgs
           sed -i.bak 's/#define I_CRYPT//g' /usr/lib/perl5/core_perl/CORE/config.h
 
           # https://metacpan.org/pod/Win32::Process
           curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
             --location "https://cpan.metacpan.org/authors/id/J/JD/JDB/Win32-Process-0.17.tar.gz" | tar -xz
-          cd Win32-Process-0.17
+          pushd Win32-Process-0.17
           perl Makefile.PL
           sed -i.bak 's/-lcrypt//g' Makefile
           make

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -41,6 +41,68 @@ env:
   CURL_CI: github
 
 jobs:
+  build-cache:
+    name: 'Build caches'
+    runs-on: windows-2022
+    timeout-minutes: 15
+    defaults:
+      run:
+        shell: msys2 {0}
+    env:
+      MAKEFLAGS: -j 5
+    steps:
+      - name: 'cache Perl Win32::Process'
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        id: cache-perl-win32-pkgs
+        env:
+          cache-name: cache-perl-win32-pkgs
+        with:
+          path: ~/perl-win32-pkgs
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+      - name: 'install build prereqs'
+        if: ${{ steps.cache-perl-win32-process.outputs.cache-hit != 'true' }}
+        uses: msys2/setup-msys2@40677d36a502eb2cf0fb808cc9dec31bf6152638 # v2
+        with:
+          msystem: msys
+          install: gcc make
+
+      - name: 'build Perl Win32::Process'
+        if: ${{ steps.cache-perl-win32-process.outputs.cache-hit != 'true' }}
+        run: |
+          cd ~
+          mkdir perl-win32-pkgs
+          cd perl-win32-pkgs
+          sed -i.bak 's/#define I_CRYPT//g' /usr/lib/perl5/core_perl/CORE/config.h
+
+          # https://metacpan.org/pod/Win32::Process
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
+            --location "https://cpan.metacpan.org/authors/id/J/JD/JDB/Win32-Process-0.17.tar.gz" | tar -xz
+          cd Win32-Process-0.17
+          perl Makefile.PL
+          sed -i.bak 's/-lcrypt//g' Makefile
+          make install
+          # Installing /usr/lib/perl5/site_perl/auto/Win32/Process/Process.dll
+          # Installing /usr/lib/perl5/site_perl/Win32/Process.pm
+          # Installing /usr/share/man/man3/Win32.Process.3pm
+          # Appending installation info to /usr/lib/perl5/core_perl/perllocal.pod
+          cd ..
+
+          # https://metacpan.org/pod/Win32::Process::List
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
+            --location "https://cpan.metacpan.org/authors/id/R/RP/RPAGITSCH/Win32-Process-List-0.09.tar.gz" | tar -xz
+          cd Win32-Process-List-0.09
+          perl Makefile.PL
+          sed -i.bak 's/-lcrypt//g' Makefile
+          make install
+          # Installing /usr/lib/perl5/site_perl/auto/Win32/Process/List/List.dll
+          # Installing /usr/lib/perl5/site_perl/auto/Win32/Process/List/autosplit.ix
+          # Installing /usr/lib/perl5/site_perl/Win32/Process/List.pm
+          # Installing /usr/lib/perl5/site_perl/Win32/Process/processes.pl
+          # Installing /usr/share/man/man3/Win32.Process.List.3pm
+          # Appending installation info to /usr/lib/perl5/core_perl/perllocal.pod
+          cd ..
+
   cygwin:
     name: "cygwin, ${{ matrix.build == 'cmake' && 'CM' || 'AM' }} ${{ matrix.platform }} ${{ matrix.name }}"
     runs-on: windows-2022
@@ -697,6 +759,8 @@ jobs:
 
   msvc:
     name: 'msvc, CM ${{ matrix.arch }}-${{ matrix.plat }} ${{ matrix.name }}'
+    needs:
+      - build-cache
     runs-on: ${{ matrix.image || 'windows-2022' }}
     timeout-minutes: 15
     defaults:
@@ -928,6 +992,13 @@ jobs:
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}
         timeout-minutes: 5
         run: |
+          cd perl-win32-pkgs
+          cd Win32-Process-0.17
+          make install
+          cd ..
+          cd Win32-Process-List-0.09
+          make install
+          cd ..
           if [ -z "${MATRIX_OPENSSH}" ]; then  # MSYS2 openssh
             /usr/bin/pacman --noconfirm --noprogressbar --sync --needed openssh
           elif [ "${MATRIX_OPENSSH}" = 'OpenSSH-Windows-builtin' ]; then

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,13 +43,15 @@ env:
 jobs:
   build-cache:
     name: 'Build caches'
-    runs-on: windows-2022
+    runs-on: ${{ matrix.image }}
     timeout-minutes: 15
     defaults:
       run:
         shell: msys2 {0}
-    env:
-      MAKEFLAGS: -j 5
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [windows-2022, windows-11-arm]
     steps:
       - name: 'cache perl packages'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
@@ -58,7 +60,7 @@ jobs:
           cache-name: cache-perl-win32-pkgs
         with:
           path: C:\perl-win32-pkgs
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          key: ${{ matrix.image }}-build-${{ env.cache-name }}
 
       - name: 'install build prereqs'
         if: ${{ steps.cache-perl-win32-pkgs.outputs.cache-hit != 'true' }}
@@ -986,7 +988,7 @@ jobs:
           cache-name: cache-perl-win32-pkgs
         with:
           path: C:\perl-win32-pkgs
-          key: ${{ runner.os }}-build-${{ env.cache-name }}
+          key: ${{ matrix.image }}-build-${{ env.cache-name }}
 
       - name: 'install test prereqs'
         if: ${{ matrix.tflags != 'skipall' && matrix.tflags != 'skiprun' }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -61,7 +61,7 @@ jobs:
           key: ${{ runner.os }}-build-${{ env.cache-name }}
 
       - name: 'install build prereqs'
-        if: ${{ steps.cache-perl-win32-process.outputs.cache-hit != 'true' }}
+        if: ${{ steps.cache-perl-win32-pkgs.outputs.cache-hit != 'true' }}
         uses: msys2/setup-msys2@40677d36a502eb2cf0fb808cc9dec31bf6152638 # v2
         with:
           msystem: msys

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -128,11 +128,15 @@ sub pidexists {
         if($pid > 4194304 && os_is_win()) {
             $pid -= 4194304;
             if($^O ne 'MSWin32') {
+print "\n>>>pidexists|$has_win32_process|\n";
                 if($has_win32_process) {
+print ">>>pidexists Win32\n";
                     my %processes = Win32::Process::List->new()->GetProcesses();
                     if(exists $processes{$pid}) {
+print ">>>pidexists Win32 -> YES\n";
                         return -$pid;
                     }
+print ">>>pidexists Win32 -> NO\n";
                 } else {
                     my $filter = "PID eq $pid";
                     # https://ss64.com/nt/tasklist.html
@@ -166,7 +170,9 @@ sub pidterm {
         if($pid > 4194304 && os_is_win()) {
             $pid -= 4194304;
             if($^O ne 'MSWin32') {
+print "\n>>>pidterm|$has_win32_process|\n";
                 if($has_win32_process) {
+print "\n>>>pidterm Win32\n";
                     Win32::Process::KillProcess($pid, 0);
                 } else {
                     # https://ss64.com/nt/taskkill.html
@@ -195,7 +201,9 @@ sub pidkill {
         if($pid > 4194304 && os_is_win()) {
             $pid -= 4194304;
             if($^O ne 'MSWin32') {
+print "\n>>>pidkill|$has_win32_process|\n";
                 if($has_win32_process) {
+print "\n>>>pidkill Win32\n";
                     Win32::Process::KillProcess($pid, 0);
                 } else {
                     # https://ss64.com/nt/taskkill.html

--- a/tests/processhelp.pm
+++ b/tests/processhelp.pm
@@ -128,15 +128,11 @@ sub pidexists {
         if($pid > 4194304 && os_is_win()) {
             $pid -= 4194304;
             if($^O ne 'MSWin32') {
-print "\n>>>pidexists|$has_win32_process|\n";
                 if($has_win32_process) {
-print ">>>pidexists Win32\n";
                     my %processes = Win32::Process::List->new()->GetProcesses();
                     if(exists $processes{$pid}) {
-print ">>>pidexists Win32 -> YES\n";
                         return -$pid;
                     }
-print ">>>pidexists Win32 -> NO\n";
                 } else {
                     my $filter = "PID eq $pid";
                     # https://ss64.com/nt/tasklist.html
@@ -170,9 +166,7 @@ sub pidterm {
         if($pid > 4194304 && os_is_win()) {
             $pid -= 4194304;
             if($^O ne 'MSWin32') {
-print "\n>>>pidterm|$has_win32_process|\n";
                 if($has_win32_process) {
-print "\n>>>pidterm Win32\n";
                     Win32::Process::KillProcess($pid, 0);
                 } else {
                     # https://ss64.com/nt/taskkill.html
@@ -201,9 +195,7 @@ sub pidkill {
         if($pid > 4194304 && os_is_win()) {
             $pid -= 4194304;
             if($^O ne 'MSWin32') {
-print "\n>>>pidkill|$has_win32_process|\n";
                 if($has_win32_process) {
-print "\n>>>pidkill Win32\n";
                     Win32::Process::KillProcess($pid, 0);
                 } else {
                     # https://ss64.com/nt/taskkill.html


### PR DESCRIPTION
To make the CI jobs use native Win32 API calls instead of calling
external tools to look up and kill PIDs of native Windows test server
processes.

Follow-up to 2388b0e5878da030fac0e9d1ad490bc5447e37e0 #18308

---

https://github.com/curl/curl/actions/runs/17003149364/job/48208471991?pr=18296

- [x] rebase on #18308
- [x] de-dupe the install logic