### PR TITLE
cookie: remove expired cookies before listing

### DIFF
--- a/lib/cookie.c
+++ b/lib/cookie.c
@@ -1615,6 +1615,9 @@ static struct curl_slist *cookie_list(struct Curl_easy *data)
   if(!data->cookies || (data->cookies->numcookies == 0))
     return NULL;
 
+  /* at first, remove expired cookies */
+  remove_expired(data->cookies);
+
   for(i = 0; i < COOKIE_HASH_SIZE; i++) {
     for(n = Curl_llist_head(&data->cookies->cookielist[i]); n;
         n = Curl_node_next(n)) {


### PR DESCRIPTION
If the cookie returned by the server is expired, `curl_easy_getinfo(curl, CURLINFO_COOKIELIST, &cookies)` will still retrieve one expired cookie(Only the last one).

Below is the test code:

server code:
```python
#!/usr/bin/env python3

from http.server import BaseHTTPRequestHandler, HTTPServer

name = "127.0.0.1"
port = 8000

text = f"""HTTP/1.1 200 OK
Content-Length: 6
Content-Type: text/plain
Set-Cookie: c1=123; Domain={name}; Path=/; Expires=Thu, 12 Feb 2000 00:00:00 GMT
Set-Cookie: c2=456; Domain={name}; Path=/; Expires=Thu, 12 Feb 2000 00:00:00 GMT;

hello
"""

class myHandler(BaseHTTPRequestHandler):
    def do_GET(self):
        self.wfile.write(text.encode())

if __name__ == '__main__':
    server = HTTPServer((name, port), myHandler)
    print(f'Serving on port {name}:{port}...')
    server.serve_forever()
```

client code
```c
#include <stdio.h>
#include <curl/curl.h>

int main(void)
{
    CURL *curl = curl_easy_init();
    if(curl) {
        CURLcode res;
        curl_easy_setopt(curl, CURLOPT_URL, "http://127.0.0.1:8000");

        /* enable the cookie engine */
        curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");

        res = curl_easy_perform(curl);

        if(!res) {
            /* extract all known cookies */
            struct curl_slist *cookies = NULL;
            res = curl_easy_getinfo(curl, CURLINFO_COOKIELIST, &cookies);
            if(!res && cookies) {
                /* a linked list of cookies in cookie file format */
                struct curl_slist *each = cookies;
                while(each) {
                    printf("%s\n", each->data);
                    each = each->next;
                }
                /* we must free these cookies when we are done */
                curl_slist_free_all(cookies);
            }
        }
        curl_easy_cleanup(curl);
    }
}
```


When using the curl command-line tool, this issue does not occur:  
`curl -c - http://127.0.0.1:8000`  
because it automatically purges expired cookies before retrieving them.

https://github.com/curl/curl/blob/a5f0ab7995bbb6e269feb3a516f804a65c753705/lib/cookie.c#L1512-L1526

This PR aligns libcurl’s behavior with the CLI by clearing expired cookies before users fetch them via `CURLINFO_COOKIELIST`.