### PR TITLE
bufq: simplify condition

### DIFF
--- a/lib/bufq.c
+++ b/lib/bufq.c
@@ -537,7 +537,8 @@ CURLcode Curl_bufq_write_pass(struct bufq *q,
       if(result != CURLE_AGAIN)
         /* real error, fail */
         return result;
-      if((result == CURLE_AGAIN) && *pwritten)
+      /* result == CURLE_AGAIN */
+      if(*pwritten)
         /* we did write successfully before */
         result = CURLE_OK;
       return result;


### PR DESCRIPTION
'result' is always CURLE_AGAIN here

Pointed out by CodeSonar