### PR TITLE
asyn-thrdd: fix Curl_async_pollset without socketpair

### DIFF
--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -655,12 +655,9 @@ CURLcode Curl_async_pollset(struct Curl_easy *data, struct easy_pollset *ps)
     return result;
 
 #ifndef CURL_DISABLE_SOCKETPAIR
-  if(thrdd->addr) {
-    /* return read fd to client for polling the DNS resolution status */
-    result = Curl_pollset_add_in(data, ps, thrdd->addr->sock_pair[0]);
-  }
-  else
-#endif
+  /* return read fd to client for polling the DNS resolution status */
+  result = Curl_pollset_add_in(data, ps, thrdd->addr->sock_pair[0]);
+#else
   {
     timediff_t milli;
     timediff_t ms = curlx_timediff(curlx_now(), thrdd->addr->start);
@@ -674,7 +671,7 @@ CURLcode Curl_async_pollset(struct Curl_easy *data, struct easy_pollset *ps)
       milli = 200;
     Curl_expire(data, milli, EXPIRE_ASYNC_NAME);
   }
-
+#endif
   return result;
 }
 


### PR DESCRIPTION
- remove a superfluous if()
- edit the #ifdef to only do the timeout checks when socketpair support is missing, as that code flow could not be reached otherways anyway

CodeSonar pointed out possible issue that led me to see this.