### PR TITLE
cmake: honor `CMAKE_C_FLAGS` in test 1119 and 1167

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -104,6 +104,7 @@ if(MSVC OR CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Cl
   if(APPLE AND CMAKE_OSX_SYSROOT)
     string(APPEND CURL_CPP " -isysroot ${CMAKE_OSX_SYSROOT}")
   endif()
+  string(APPEND CURL_CPP " ${CMAKE_C_FLAGS}")
   # Add header directories, like autotools builds do.
   get_property(_include_dirs TARGET ${LIB_SELECTED} PROPERTY INCLUDE_DIRECTORIES)
   foreach(_include_dir IN LISTS _include_dirs)


### PR DESCRIPTION
`CMAKE_C_FLAGS` is not set by curl, but may contain custom options
required for a successful compiler run, when invoked by these tests.

One such case is when configuring Visual Studio or clang-cl via compiler
options, instead of envs.

Cherry-picked from #18301
