### PR TITLE
tests: delete unused commands

### DIFF
--- a/tests/data/test1330
+++ b/tests/data/test1330
@@ -23,9 +23,6 @@ TrackMemory
 <name>
 unit tests memory tracking operational
 </name>
-<command>
-nothing
-</command>
 </client>
 
 #

--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -55,7 +55,7 @@ lib%TESTNUMBER
 HTTP GET connection cache limit (CURLMOPT_MAXCONNECTS)
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/path/%TESTNUMBER %HOSTIP %HTTPPORT
+- %HOSTIP %HTTPPORT
 </command>
 </client>
 

--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -54,6 +54,9 @@ lib%TESTNUMBER
 <name>
 HTTP GET connection cache limit (CURLMOPT_MAXCONNECTS)
 </name>
+<command>
+http://%HOSTIP:%HTTPPORT/path/%TESTNUMBER %HOSTIP %HTTPPORT
+</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test1506
+++ b/tests/data/test1506
@@ -54,9 +54,6 @@ lib%TESTNUMBER
 <name>
 HTTP GET connection cache limit (CURLMOPT_MAXCONNECTS)
 </name>
-<command>
-http://%HOSTIP:%HTTPPORT/path/%TESTNUMBER %HOSTIP %HTTPPORT
-</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test1508
+++ b/tests/data/test1508
@@ -17,9 +17,6 @@ lib%TESTNUMBER
 <name>
 Close a multi handle without using it
 </name>
-<command>
-http://%HOSTIP:%NOLISTENPORT/path/%TESTNUMBER
-</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test1510
+++ b/tests/data/test1510
@@ -55,7 +55,7 @@ lib%TESTNUMBER
 HTTP GET connection cache limit (CURLOPT_MAXCONNECTS)
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/path/%TESTNUMBER %HOSTIP %HTTPPORT
+- %HOSTIP %HTTPPORT
 </command>
 </client>
 

--- a/tests/data/test1510
+++ b/tests/data/test1510
@@ -54,9 +54,6 @@ lib%TESTNUMBER
 <name>
 HTTP GET connection cache limit (CURLOPT_MAXCONNECTS)
 </name>
-<command>
-http://%HOSTIP:%HTTPPORT/path/%TESTNUMBER %HOSTIP %HTTPPORT
-</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test1510
+++ b/tests/data/test1510
@@ -54,6 +54,9 @@ lib%TESTNUMBER
 <name>
 HTTP GET connection cache limit (CURLOPT_MAXCONNECTS)
 </name>
+<command>
+http://%HOSTIP:%HTTPPORT/path/%TESTNUMBER %HOSTIP %HTTPPORT
+</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test1512
+++ b/tests/data/test1512
@@ -54,7 +54,7 @@ lib%TESTNUMBER
 GLOBAL CACHE test over two easy performs
 </name>
 <command>
-http://%HOSTIP:%HTTPPORT/path/%TESTNUMBER %HOSTIP %HTTPPORT
+- %HOSTIP %HTTPPORT
 </command>
 </client>
 

--- a/tests/data/test1512
+++ b/tests/data/test1512
@@ -53,6 +53,9 @@ lib%TESTNUMBER
 <name>
 GLOBAL CACHE test over two easy performs
 </name>
+<command>
+http://%HOSTIP:%HTTPPORT/path/%TESTNUMBER %HOSTIP %HTTPPORT
+</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test1512
+++ b/tests/data/test1512
@@ -53,9 +53,6 @@ lib%TESTNUMBER
 <name>
 GLOBAL CACHE test over two easy performs
 </name>
-<command>
-http://%HOSTIP:%HTTPPORT/path/%TESTNUMBER %HOSTIP %HTTPPORT
-</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test1521
+++ b/tests/data/test1521
@@ -18,9 +18,6 @@ lib%TESTNUMBER
 <name>
 Test all curl_easy_setopt and curl_easy_getinfo options
 </name>
-<command>
-unused
-</command>
 </client>
 
 #

--- a/tests/data/test1537
+++ b/tests/data/test1537
@@ -22,9 +22,6 @@ lib%TESTNUMBER
 <name>
 libcurl URL escape/unescape tests
 </name>
-<command>
-nothing
-</command>
 </client>
 
 #

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -23,9 +23,6 @@ lib%TESTNUMBER
 <name>
 libcurl strerror API call tests
 </name>
-<command>
-nothing
-</command>
 </client>
 
 #

--- a/tests/data/test1550
+++ b/tests/data/test1550
@@ -22,8 +22,5 @@ lib%TESTNUMBER
 <name>
 verify setting pipelining blocklisting options
 </name>
-<command>
-http://%HOSTIP:%NOLISTENPORT/%TESTNUMBER
-</command>
 </client>
 </testcase>

--- a/tests/data/test1557
+++ b/tests/data/test1557
@@ -21,7 +21,7 @@ lib%TESTNUMBER
 Remove easy handle in pending connections doesn't leave dangling entry
 </name>
 <command>
-nothing
+hostname.invalid
 </command>
 </client>
 

--- a/tests/data/test1564
+++ b/tests/data/test1564
@@ -24,8 +24,6 @@ lib%TESTNUMBER
 <name>
 wakeup before poll with no easy handles
 </name>
-<command>
-</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test1597
+++ b/tests/data/test1597
@@ -19,9 +19,6 @@ CURLOPT_PROTOCOLS_STR
 <tool>
 lib%TESTNUMBER
 </tool>
-<command>
--
-</command>
 </client>
 
 <verify>

--- a/tests/data/test2402
+++ b/tests/data/test2402
@@ -59,9 +59,6 @@ lib%TESTNUMBER
 <name>
 HTTP GET multiple files over HTTP/2 using HTTPS
 </name>
-<command>
-https://%HOSTIP:%HTTP2TLSPORT/path/%TESTNUMBER %HOSTIP %HTTP2TLSPORT
-</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test2402
+++ b/tests/data/test2402
@@ -59,6 +59,9 @@ lib%TESTNUMBER
 <name>
 HTTP GET multiple files over HTTP/2 using HTTPS
 </name>
+<command>
+- %HOSTIP %HTTP2TLSPORT
+</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test2404
+++ b/tests/data/test2404
@@ -59,6 +59,9 @@ lib%TESTNUMBER
 <name>
 HTTP/2 using STREAM_WEIGHTs
 </name>
+<command>
+- %HOSTIP %HTTP2TLSPORT
+</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test2404
+++ b/tests/data/test2404
@@ -59,9 +59,6 @@ lib%TESTNUMBER
 <name>
 HTTP/2 using STREAM_WEIGHTs
 </name>
-<command>
-https://%HOSTIP:%HTTP2TLSPORT/path/%TESTNUMBER %HOSTIP %HTTP2TLSPORT
-</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test2502
+++ b/tests/data/test2502
@@ -58,9 +58,6 @@ lib%TESTNUMBER
 <name>
 HTTP GET multiple over HTTP/3
 </name>
-<command>
-https://%HOSTIP:%HTTP3PORT/path/%TESTNUMBER %HOSTIP %HTTP3PORT %CERTDIR/certs/test-ca.cacert
-</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test2502
+++ b/tests/data/test2502
@@ -58,6 +58,9 @@ lib%TESTNUMBER
 <name>
 HTTP GET multiple over HTTP/3
 </name>
+<command>
+- %HOSTIP %HTTP3PORT %CERTDIR/certs/test-ca.cacert
+</command>
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test3026
+++ b/tests/data/test3026
@@ -30,9 +30,6 @@ curl_global_init thread-safety
 <tool>
 lib%TESTNUMBER
 </tool>
-<command>
-none
-</command>
 </client>
 
 #

--- a/tests/data/test501
+++ b/tests/data/test501
@@ -25,9 +25,6 @@ lib%TESTNUMBER
 <name>
 simple libcurl attempt operation without URL set
 </name>
-<command>
-http://%HOSTIP:%NOLISTENPORT/%TESTNUMBER
-</command>
 </client>
 
 #

--- a/tests/data/test509
+++ b/tests/data/test509
@@ -25,9 +25,6 @@ lib%TESTNUMBER
 <name>
 initialization with memory callbacks and actual usage
 </name>
-<command>
-nothing
-</command>
 </client>
 
 #

--- a/tests/data/test517
+++ b/tests/data/test517
@@ -23,9 +23,6 @@ lib%TESTNUMBER
 <name>
 curl_getdate() testing
 </name>
-<command>
-nothing
-</command>
 </client>
 
 #

--- a/tests/data/test518
+++ b/tests/data/test518
@@ -46,9 +46,6 @@ lib%TESTNUMBER
 <name>
 HTTP GET with more than FD_SETSIZE descriptors open
 </name>
-<command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER
-</command>
 </client>
 
 #

--- a/tests/data/test518
+++ b/tests/data/test518
@@ -46,6 +46,9 @@ lib%TESTNUMBER
 <name>
 HTTP GET with more than FD_SETSIZE descriptors open
 </name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
 </client>
 
 #

--- a/tests/data/test537
+++ b/tests/data/test537
@@ -46,9 +46,6 @@ lib%TESTNUMBER
 <name>
 HTTP GET with a HUGE number of file descriptors open
 </name>
-<command>
-http://%HOSTIP:%HTTPPORT/%TESTNUMBER
-</command>
 </client>
 
 #

--- a/tests/data/test537
+++ b/tests/data/test537
@@ -46,6 +46,9 @@ lib%TESTNUMBER
 <name>
 HTTP GET with a HUGE number of file descriptors open
 </name>
+<command>
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER
+</command>
 </client>
 
 #

--- a/tests/data/test543
+++ b/tests/data/test543
@@ -17,10 +17,6 @@ lib%TESTNUMBER
 <name>
 curl_easy_escape
 </name>
-<command>
--
-</command>
-
 </client>
 
 # Verify data after the test has been "shot"

--- a/tests/data/test557
+++ b/tests/data/test557
@@ -23,9 +23,6 @@ lib%TESTNUMBER
 <name>
 curl_mprintf() testing
 </name>
-<command>
-nothing
-</command>
 </client>
 
 #

--- a/tests/data/test558
+++ b/tests/data/test558
@@ -27,9 +27,6 @@ lib%TESTNUMBER
 <name>
 libtest memory tracking operational
 </name>
-<command>
-nothing
-</command>
 </client>
 
 #

--- a/tests/data/test751
+++ b/tests/data/test751
@@ -22,7 +22,6 @@ lib%TESTNUMBER
 <name>
 multi - add many easy handles
 </name>
-</file>
 </client>
 
 # 1000 easy handles needs memory

--- a/tests/data/test751
+++ b/tests/data/test751
@@ -22,8 +22,6 @@ lib%TESTNUMBER
 <name>
 multi - add many easy handles
 </name>
-<command>
-</command>
 </file>
 </client>
 


### PR DESCRIPTION
`runtests.pl` defaults to `-` if a command is not set, since
c43ad0f97283a7e25d61a81b9f9f238432ec494b.

Also:
- drop a stray `</file>`.
- replace a `nothing` with a guaranteed invalid hostname.
  Ref: https://github.com/curl/curl/pull/18263/commits/4334033b43acca9b01ba43e08e611c8654feb84d
- replace unused URLs with `-`.
