### PR TITLE
Add header for native-QUIC OpenSSL, non-unity builds.

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -30,6 +30,9 @@
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
+#ifdef USE_NGHTTP3
+#include <nghttp3/nghttp3.h>
+#endif
 #include "../urldata.h"
 #include "../bufq.h"
 #include "../curlx/dynbuf.h"


### PR DESCRIPTION
Fix for https://github.com/curl/curl/issues/18320

Add header for native-QUIC OpenSSL, non-unity builds.