### PR TITLE
vquic: change some curl_ prefixes

### DIFF
--- a/lib/vquic/vquic.c
+++ b/lib/vquic/vquic.c
@@ -726,55 +726,55 @@ CURLcode Curl_conn_may_http3(struct Curl_easy *data,
 
 #if defined(USE_NGTCP2) || defined(USE_NGHTTP3)
 
-static void *Curl_ngtcp2_malloc(size_t size, void *user_data)
+static void *vquic_ngtcp2_malloc(size_t size, void *user_data)
 {
   (void)user_data;
   return Curl_cmalloc(size);
 }
 
-static void Curl_ngtcp2_free(void *ptr, void *user_data)
+static void vquic_ngtcp2_free(void *ptr, void *user_data)
 {
   (void)user_data;
   Curl_cfree(ptr);
 }
 
-static void *Curl_ngtcp2_calloc(size_t nmemb, size_t size, void *user_data)
+static void *vquic_ngtcp2_calloc(size_t nmemb, size_t size, void *user_data)
 {
   (void)user_data;
   return Curl_ccalloc(nmemb, size);
 }
 
-static void *Curl_ngtcp2_realloc(void *ptr, size_t size, void *user_data)
+static void *vquic_ngtcp2_realloc(void *ptr, size_t size, void *user_data)
 {
   (void)user_data;
   return Curl_crealloc(ptr, size);
 }
 
 #ifdef USE_NGTCP2
-static struct ngtcp2_mem curl_ngtcp2_mem = {
+static struct ngtcp2_mem vquic_ngtcp2_mem = {
   NULL,
-  Curl_ngtcp2_malloc,
-  Curl_ngtcp2_free,
-  Curl_ngtcp2_calloc,
-  Curl_ngtcp2_realloc
+  vquic_ngtcp2_malloc,
+  vquic_ngtcp2_free,
+  vquic_ngtcp2_calloc,
+  vquic_ngtcp2_realloc
 };
 struct ngtcp2_mem *Curl_ngtcp2_mem(void)
 {
-  return &curl_ngtcp2_mem;
+  return &vquic_ngtcp2_mem;
 }
 #endif
 
 #ifdef USE_NGHTTP3
-static struct nghttp3_mem curl_nghttp3_mem = {
+static struct nghttp3_mem vquic_nghttp3_mem = {
   NULL,
-  Curl_ngtcp2_malloc,
-  Curl_ngtcp2_free,
-  Curl_ngtcp2_calloc,
-  Curl_ngtcp2_realloc
+  vquic_ngtcp2_malloc,
+  vquic_ngtcp2_free,
+  vquic_ngtcp2_calloc,
+  vquic_ngtcp2_realloc
 };
 struct nghttp3_mem *Curl_nghttp3_mem(void)
 {
-  return &curl_nghttp3_mem;
+  return &vquic_nghttp3_mem;
 }
 #endif
 


### PR DESCRIPTION
curl_ and Curl_ are kind of reserved prefixes with special meaning so avoid using them for file private symbols.

Follow-up to 7dafe10