### PR TITLE
websocket example: cast print values to unsigned int

### DIFF
--- a/docs/examples/websocket.c
+++ b/docs/examples/websocket.c
@@ -89,12 +89,13 @@ retry:
               buffer);
     }
     else if(meta->flags & CURLWS_BINARY) {
-      fprintf(stderr, "ws: received BINARY frame of %u bytes\n", (int)rlen);
+      fprintf(stderr, "ws: received BINARY frame of %u bytes\n",
+              (unsigned int)rlen);
     }
     else {
       /* some other frame arrived. */
-      fprintf(stderr, "ws: received frame of %u bytes rflags %x\n", (int)rlen,
-              meta->flags);
+      fprintf(stderr, "ws: received frame of %u bytes rflags %x\n",
+              (unsigned int)rlen, meta->flags);
       goto retry;
     }
   }


### PR DESCRIPTION
To have not compiler warnings on format checks.

Reported By: Gisle Vanem