### PR TITLE
WebSocket: fix handling of 0-length frames

### DIFF
--- a/docs/libcurl/curl_ws_start_frame.md
+++ b/docs/libcurl/curl_ws_start_frame.md
@@ -46,6 +46,14 @@ the data belonging to the frame.
 The function fails, if a previous frame has not been completely
 read yet. Also it fails in *CURLWS_RAW_MODE*.
 
+The read function in libcurl usually treats a return value of 0
+as the end of file indication and stops any further reads. This
+would prevent sending WebSocket frames of length 0.
+
+If the read function calls `curl_ws_start_frame()` however, a return
+value of 0 is *not* treated as an end of file and libcurl calls
+the read function again.
+
 # FLAGS
 
 Supports all flags documented in curl_ws_meta(3).

--- a/lib/http.c
+++ b/lib/http.c
@@ -4836,8 +4836,7 @@ static const struct Curl_crtype cr_exp100 = {
   Curl_creader_def_needs_rewind,
   Curl_creader_def_total_length,
   Curl_creader_def_resume_from,
-  Curl_creader_def_rewind,
-  Curl_creader_def_unpause,
+  Curl_creader_def_cntrl,
   Curl_creader_def_is_paused,
   cr_exp100_done,
   sizeof(struct cr_exp100_ctx)

--- a/lib/http_chunks.c
+++ b/lib/http_chunks.c
@@ -656,8 +656,7 @@ const struct Curl_crtype Curl_httpchunk_encoder = {
   Curl_creader_def_needs_rewind,
   cr_chunked_total_length,
   Curl_creader_def_resume_from,
-  Curl_creader_def_rewind,
-  Curl_creader_def_unpause,
+  Curl_creader_def_cntrl,
   Curl_creader_def_is_paused,
   Curl_creader_def_done,
   sizeof(struct chunked_reader)

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -50,6 +50,7 @@
 #define CLIENTWRITE_1XX     (1<<5) /* a 1xx response related HEADER */
 #define CLIENTWRITE_TRAILER (1<<6) /* a trailer HEADER */
 #define CLIENTWRITE_EOS     (1<<7) /* End Of transfer download Stream */
+#define CLIENTWRITE_0LEN    (1<<8) /* write even 0-length buffers */
 
 /**
  * Write `len` bytes at `prt` to the client. `type` indicates what

--- a/lib/sendf.h
+++ b/lib/sendf.h
@@ -203,6 +203,11 @@ void Curl_cwriter_def_close(struct Curl_easy *data,
                             struct Curl_cwriter *writer);
 
 
+typedef enum {
+  CURL_CRCNTRL_REWIND,
+  CURL_CRCNTRL_UNPAUSE,
+  CURL_CRCNTRL_CLEAR_EOS
+} Curl_creader_cntrl;
 
 /* Client Reader Type, provides the implementation */
 struct Curl_crtype {
@@ -216,8 +221,8 @@ struct Curl_crtype {
                              struct Curl_creader *reader);
   CURLcode (*resume_from)(struct Curl_easy *data,
                           struct Curl_creader *reader, curl_off_t offset);
-  CURLcode (*rewind)(struct Curl_easy *data, struct Curl_creader *reader);
-  CURLcode (*unpause)(struct Curl_easy *data, struct Curl_creader *reader);
+  CURLcode (*cntrl)(struct Curl_easy *data, struct Curl_creader *reader,
+                    Curl_creader_cntrl opcode);
   bool (*is_paused)(struct Curl_easy *data, struct Curl_creader *reader);
   void (*done)(struct Curl_easy *data,
                struct Curl_creader *reader, int premature);
@@ -265,10 +270,9 @@ curl_off_t Curl_creader_def_total_length(struct Curl_easy *data,
 CURLcode Curl_creader_def_resume_from(struct Curl_easy *data,
                                       struct Curl_creader *reader,
                                       curl_off_t offset);
-CURLcode Curl_creader_def_rewind(struct Curl_easy *data,
-                                 struct Curl_creader *reader);
-CURLcode Curl_creader_def_unpause(struct Curl_easy *data,
-                                  struct Curl_creader *reader);
+CURLcode Curl_creader_def_cntrl(struct Curl_easy *data,
+                                struct Curl_creader *reader,
+                                Curl_creader_cntrl opcode);
 bool Curl_creader_def_is_paused(struct Curl_easy *data,
                                 struct Curl_creader *reader);
 void Curl_creader_def_done(struct Curl_easy *data,
@@ -281,6 +285,10 @@ void Curl_creader_def_done(struct Curl_easy *data,
 CURLcode Curl_creader_read(struct Curl_easy *data,
                            struct Curl_creader *reader,
                            char *buf, size_t blen, size_t *nread, bool *eos);
+
+/* Tell the reader and all below that any EOS state is to be cleared */
+void Curl_creader_clear_eos(struct Curl_easy *data,
+                            struct Curl_creader *reader);
 
 /**
  * Create a new creader instance with given type and phase. Is not

--- a/lib/smtp.c
+++ b/lib/smtp.c
@@ -2069,8 +2069,7 @@ static const struct Curl_crtype cr_eob = {
   Curl_creader_def_needs_rewind,
   cr_eob_total_length,
   Curl_creader_def_resume_from,
-  Curl_creader_def_rewind,
-  Curl_creader_def_unpause,
+  Curl_creader_def_cntrl,
   Curl_creader_def_is_paused,
   Curl_creader_def_done,
   sizeof(struct cr_eob_ctx)

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -947,6 +947,7 @@ static CURLcode cr_ws_read(struct Curl_easy *data,
     if(!Curl_bufq_is_empty(&ws->sendbuf)) {
       /* client_read started a new frame, we disregard any eos reported */
       ctx->read_eos = FALSE;
+      Curl_creader_clear_eos(data, reader->next);
     }
     else if(!nread) {
       /* nothing to convert, return this right away */
@@ -995,8 +996,7 @@ static const struct Curl_crtype ws_cr_encode = {
   Curl_creader_def_needs_rewind,
   Curl_creader_def_total_length,
   Curl_creader_def_resume_from,
-  Curl_creader_def_rewind,
-  Curl_creader_def_unpause,
+  Curl_creader_def_cntrl,
   Curl_creader_def_is_paused,
   Curl_creader_def_done,
   sizeof(struct cr_ws_ctx)

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -474,7 +474,7 @@ static CURLcode ws_dec_read_head(struct ws_decoder *dec,
 static CURLcode ws_dec_pass_payload(struct ws_decoder *dec,
                                     struct Curl_easy *data,
                                     struct bufq *inraw,
-                                    ws_write_payload *write_payload,
+                                    ws_write_payload *write_cb,
                                     void *write_ctx)
 {
   const unsigned char *inbuf;
@@ -487,9 +487,9 @@ static CURLcode ws_dec_pass_payload(struct ws_decoder *dec,
   while(remain && Curl_bufq_peek(inraw, &inbuf, &inlen)) {
     if((curl_off_t)inlen > remain)
       inlen = (size_t)remain;
-    nwritten = write_payload(inbuf, inlen, dec->frame_age, dec->frame_flags,
-                             dec->payload_offset, dec->payload_len,
-                             write_ctx, &result);
+    nwritten = write_cb(inbuf, inlen, dec->frame_age, dec->frame_flags,
+                        dec->payload_offset, dec->payload_len,
+                        write_ctx, &result);
     if(nwritten < 0)
       return result;
     Curl_bufq_skip(inraw, (size_t)nwritten);
@@ -505,7 +505,7 @@ static CURLcode ws_dec_pass_payload(struct ws_decoder *dec,
 static CURLcode ws_dec_pass(struct ws_decoder *dec,
                             struct Curl_easy *data,
                             struct bufq *inraw,
-                            ws_write_payload *write_payload,
+                            ws_write_payload *write_cb,
                             void *write_ctx)
 {
   CURLcode result;
@@ -535,8 +535,8 @@ static CURLcode ws_dec_pass(struct ws_decoder *dec,
       ssize_t nwritten;
       const unsigned char tmp = '\0';
       /* special case of a 0 length frame, need to write once */
-      nwritten = write_payload(&tmp, 0, dec->frame_age, dec->frame_flags,
-                               0, 0, write_ctx, &result);
+      nwritten = write_cb(&tmp, 0, dec->frame_age, dec->frame_flags,
+                          0, 0, write_ctx, &result);
       if(nwritten < 0)
         return result;
       dec->state = WS_DEC_INIT;
@@ -544,7 +544,7 @@ static CURLcode ws_dec_pass(struct ws_decoder *dec,
     }
     FALLTHROUGH();
   case WS_DEC_PAYLOAD:
-    result = ws_dec_pass_payload(dec, data, inraw, write_payload, write_ctx);
+    result = ws_dec_pass_payload(dec, data, inraw, write_cb, write_ctx);
     ws_dec_info(dec, data, "passing");
     if(result)
       return result;
@@ -631,7 +631,8 @@ static ssize_t ws_cw_dec_next(const unsigned char *buf, size_t buflen,
     update_meta(ws, frame_age, frame_flags, payload_offset,
                 payload_len, buflen);
 
-    *err = Curl_cwriter_write(data, ctx->next_writer, ctx->cw_type,
+    *err = Curl_cwriter_write(data, ctx->next_writer,
+                              (ctx->cw_type | CLIENTWRITE_0LEN),
                               (const char *)buf, buflen);
     if(*err)
       return -1;
@@ -943,7 +944,11 @@ static CURLcode cr_ws_read(struct Curl_easy *data,
       return result;
     ctx->read_eos = eos;
 
-    if(!nread) {
+    if(!Curl_bufq_is_empty(&ws->sendbuf)) {
+      /* client_read started a new frame, we disregard any eos reported */
+      ctx->read_eos = FALSE;
+    }
+    else if(!nread) {
       /* nothing to convert, return this right away */
       if(ctx->read_eos)
         ctx->eos = TRUE;
@@ -952,7 +957,7 @@ static CURLcode cr_ws_read(struct Curl_easy *data,
       goto out;
     }
 
-    if(!ws->enc.payload_remain) {
+    if(!ws->enc.payload_remain && Curl_bufq_is_empty(&ws->sendbuf)) {
       /* encode the data as a new BINARY frame */
       result = ws_enc_write_head(data, &ws->enc, CURLWS_BINARY, nread,
                                  &ws->sendbuf);
@@ -1732,7 +1737,7 @@ CURL_EXTERN CURLcode curl_ws_start_frame(CURL *d,
     return CURLE_FAILED_INIT;
   }
 
-  CURL_TRC_WS(data, "curl_start_frame(flags=%x, frame_len=%" FMT_OFF_T,
+  CURL_TRC_WS(data, "curl_ws_start_frame(flags=%x, frame_len=%" FMT_OFF_T,
               flags, frame_len);
 
   if(!data->conn) {

--- a/tests/http/test_20_websockets.py
+++ b/tests/http/test_20_websockets.py
@@ -135,7 +135,7 @@ class TestWebsockets:
         if not client.exists():
             pytest.skip(f'example client not built: {client.name}')
         url = f'ws://localhost:{env.ws_port}/'
-        r = client.run(args=[f'-{model}', '-m', str(0), '-M', str(10), url])
+        r = client.run(args=[f'-{model}', '-m', str(1), '-M', str(10), url])
         r.check_exit_code(0)
 
     @pytest.mark.parametrize("model", [
@@ -191,5 +191,19 @@ class TestWebsockets:
         url = f'ws://localhost:{env.ws_port}/'
         count = 10
         large = 20000
+        r = client.run(args=[f'-{model}', '-c', str(count), '-m', str(large), url])
+        r.check_exit_code(0)
+
+    @pytest.mark.parametrize("model", [
+        pytest.param(1, id='multi_perform'),
+        pytest.param(2, id='curl_ws_send+recv'),
+    ])
+    def test_20_09_data_empty(self, env: Env, ws_echo, model):
+        client = LocalClient(env=env, name='cli_ws_data')
+        if not client.exists():
+            pytest.skip(f'example client not built: {client.name}')
+        url = f'ws://localhost:{env.ws_port}/'
+        count = 10
+        large = 0
         r = client.run(args=[f'-{model}', '-c', str(count), '-m', str(large), url])
         r.check_exit_code(0)


### PR DESCRIPTION
Write out 0-length WebSocket frames to client's WRITEFUNCTION.

From client's READFUNCTION, when curl_ws_start_frame() has been called, do not treat a 0 return value as an EOF. Continue reading frames.

Merge client reader rewind/unpause callbacks into a single "cntrl" callback and define opcodes to trigger the rewind/unpause/eos clearing.

Add pytest case test_20_09 for transmitting 0-length ws frames.