### PR TITLE
openssl: drop redundant version check

### DIFF
--- a/lib/vtls/openssl.h
+++ b/lib/vtls/openssl.h
@@ -51,7 +51,7 @@
 
 /* Check for OpenSSL 1.1.1 which has early data support. */
 #undef HAVE_OPENSSL_EARLYDATA
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L && defined(TLS1_3_VERSION) && \
+#if defined(TLS1_3_VERSION) && \
     !defined(OPENSSL_IS_BORINGSSL) && !defined(OPENSSL_IS_AWSLC)
 #define HAVE_OPENSSL_EARLYDATA
 #endif


### PR DESCRIPTION
It had a typo, but it wasn't causing an issue, because `TLS1_3_VERSION`
is enough to detect this feature and the version check remained unused.

Follow-up to 0d3b5937b38817b6fbd2d60cc178c1df4bd59d0d #16477
Cherry-picked from #18330
