### PR TITLE
appveyor: drop testing with OpenSSL 1.0.2

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -37,8 +37,6 @@ if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
   openssl_root_win="C:/OpenSSL-v34${openssl_suffix}"
 elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2019' ]; then
   openssl_root_win="C:/OpenSSL-v11${openssl_suffix}"
-elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2013' ]; then
-  openssl_root_win="C:/OpenSSL${openssl_suffix}"
 else
   openssl_root_win="C:/OpenSSL-v111${openssl_suffix}"
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,13 +61,12 @@ environment:
       SCHANNEL: 'ON'
       DEBUG: 'OFF'
       CURLDEBUG: 'ON'
-    - job_name: 'CMake, VS2010, Debug, x64, OpenSSL 1.0.2 + Schannel, Shared, Build-tests & examples, XP'
+    - job_name: 'CMake, VS2010, Debug, x64, Schannel, Shared, Build-tests & examples, XP'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2013'
       PRJ_GEN: 'Visual Studio 10 2010'
       TARGET: '-A x64'
       WINTARGET: 0x0501  # Windows XP
       PRJ_CFG: Debug
-      OPENSSL: 'ON'
       SCHANNEL: 'ON'
       SHARED: 'ON'
       EXAMPLES: 'ON'


### PR DESCRIPTION
Cherry-picked from #18330
