### PR TITLE
appveyor: drop testing with OpenSSL 1.1.0

### DIFF
--- a/appveyor.sh
+++ b/appveyor.sh
@@ -35,8 +35,6 @@ esac
 
 if [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2022' ]; then
   openssl_root_win="C:/OpenSSL-v34${openssl_suffix}"
-elif [ "${APPVEYOR_BUILD_WORKER_IMAGE}" = 'Visual Studio 2019' ]; then
-  openssl_root_win="C:/OpenSSL-v11${openssl_suffix}"
 else
   openssl_root_win="C:/OpenSSL-v111${openssl_suffix}"
 fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,7 +101,7 @@ environment:
       OPENSSL: 'ON'
       SHARED: 'ON'
       TFLAGS: 'skipall'
-    - job_name: 'CMake, VS2019, Debug, x64, OpenSSL 1.1.0 + Schannel, Shared, Build-tests'
+    - job_name: 'CMake, VS2019, Debug, x64, OpenSSL 1.1.1 + Schannel, Shared, Build-tests'
       APPVEYOR_BUILD_WORKER_IMAGE: 'Visual Studio 2019'
       PRJ_GEN: 'Visual Studio 16 2019'
       TARGET: '-A x64'


### PR DESCRIPTION
Replace with 1.1.1.

Follow-up to 12a10ca77cedec4bf6f3cebe5c3a883387ccb0d2 #18337
Cherry-picked from #18330
