### PR TITLE
asyn-thrdd: remove condition variable

### DIFF
--- a/lib/asyn.h
+++ b/lib/asyn.h
@@ -180,9 +180,6 @@ struct async_thrdd_addr_ctx {
   char *hostname;        /* hostname to resolve, Curl_async.hostname
                             duplicate */
   curl_mutex_t mutx;
-#ifdef USE_CURL_COND_T
-  curl_cond_t  cond;
-#endif
 #ifndef CURL_DISABLE_SOCKETPAIR
   curl_socket_t sock_pair[2]; /* eventfd/pipes/socket pair */
 #endif
@@ -196,6 +193,7 @@ struct async_thrdd_addr_ctx {
   int port;
   int sock_error;
   int ref_count;
+  BIT(thrd_done);
 };
 
 /* Context for threaded resolver */

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -36,7 +36,7 @@
 
 #include "curl_threads.h"
 #include "curl_memory.h"
-/* The last #include file should be: */
+/* The last #include FILE should be: */
 #include "memdebug.h"
 
 #ifdef USE_THREADS_POSIX

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -34,12 +34,6 @@
 #  define Curl_mutex_acquire(m)  pthread_mutex_lock(m)
 #  define Curl_mutex_release(m)  pthread_mutex_unlock(m)
 #  define Curl_mutex_destroy(m)  pthread_mutex_destroy(m)
-#  define USE_CURL_COND_T
-#  define curl_cond_t            pthread_cond_t
-#  define Curl_cond_init(c)      pthread_cond_init(c, NULL)
-#  define Curl_cond_destroy(c)   pthread_cond_destroy(c)
-#  define Curl_cond_wait(c, m)   pthread_cond_wait(c, m)
-#  define Curl_cond_signal(c)    pthread_cond_signal(c)
 #elif defined(USE_THREADS_WIN32)
 #  define CURL_STDCALL           __stdcall
 #  define curl_mutex_t           CRITICAL_SECTION
@@ -53,14 +47,6 @@
 #  define Curl_mutex_acquire(m)  EnterCriticalSection(m)
 #  define Curl_mutex_release(m)  LeaveCriticalSection(m)
 #  define Curl_mutex_destroy(m)  DeleteCriticalSection(m)
-#  if defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
-#  define USE_CURL_COND_T
-#  define curl_cond_t            CONDITION_VARIABLE
-#  define Curl_cond_init(c)      InitializeConditionVariable(c)
-#  define Curl_cond_destroy(c)   (void)(c)
-#  define Curl_cond_wait(c, m)   SleepConditionVariableCS(c, m, INFINITE)
-#  define Curl_cond_signal(c)    WakeConditionVariable(c)
-#  endif
 #else
 #  define CURL_STDCALL
 #endif


### PR DESCRIPTION
Add a flag `thrd_done` to assess if the resolving thread has finished and only destroy the context when *both* ref_count reaches 0 and thrd_done is true. 

Remove the condition variable and its definitions in `curl_thread.[ch]`.