### PR TITLE
runtests: show still running tests when nothing has happened for a while

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3146,7 +3146,7 @@ while() {
         delete $runnersrunning{$riderror} if(defined $runnersrunning{$riderror});
         $globalabort = 1;
     }
-    if(++$endwaitcnt == (240 + $jobs)) {
+    if(++$endwaitcnt == 60) {
         # Once all tests have been scheduled on a runner at the end of a test
         # run, we just wait for their results to come in. If we're still
         # waiting after a couple of minutes ($endwaitcnt multiplied by

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3048,10 +3048,9 @@ while() {
     # If we could be running more tests, don't wait so we can schedule a new
     # one immediately. If all runners are busy, wait a fraction of a second
     # for one to finish so we can still loop around to check the abort flag.
-    my $runnerwait = scalar(@runnersidle) && scalar(@runtests) ? 0 : 1.0;
+    my $runnerwait = scalar(@runnersidle) && scalar(@runtests) ? 0.1 : 1.0;
     my (@ridsready, $riderror) = runnerar_ready($runnerwait);
     if(@ridsready) {
-        $endwaitcnt = 0;
         for my $ridready (@ridsready) {
             if($ridready && ! defined $runnersrunning{$ridready}) {
                 # On Linux, a closed pipe still shows up as ready instead of error.
@@ -3062,6 +3061,7 @@ while() {
                 undef $ridready;
             }
             if($ridready) {
+                $endwaitcnt = 0;
                 # This runner is ready to be serviced
                 my $testnum = $runnersrunning{$ridready};
                 defined $testnum ||  die "Internal error: test for runner $ridready unknown";
@@ -3146,7 +3146,8 @@ while() {
         delete $runnersrunning{$riderror} if(defined $runnersrunning{$riderror});
         $globalabort = 1;
     }
-    if(++$endwaitcnt == 60) {
+    $endwaitcnt += $runnerwait;
+    if($endwaitcnt >= 5) {
         # Once all tests have been scheduled on a runner at the end of a test
         # run, we just wait for their results to come in. If we're still
         # waiting after a couple of minutes ($endwaitcnt multiplied by

--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -3051,6 +3051,7 @@ while() {
     my $runnerwait = scalar(@runnersidle) && scalar(@runtests) ? 0 : 1.0;
     my (@ridsready, $riderror) = runnerar_ready($runnerwait);
     if(@ridsready) {
+        $endwaitcnt = 0;
         for my $ridready (@ridsready) {
             if($ridready && ! defined $runnersrunning{$ridready}) {
                 # On Linux, a closed pipe still shows up as ready instead of error.
@@ -3145,7 +3146,7 @@ while() {
         delete $runnersrunning{$riderror} if(defined $runnersrunning{$riderror});
         $globalabort = 1;
     }
-    if(!scalar(@runtests) && ++$endwaitcnt == (240 + $jobs)) {
+    if(++$endwaitcnt == (240 + $jobs)) {
         # Once all tests have been scheduled on a runner at the end of a test
         # run, we just wait for their results to come in. If we're still
         # waiting after a couple of minutes ($endwaitcnt multiplied by
@@ -3154,6 +3155,7 @@ while() {
         # likely point to a single test that has hung.
         logmsg "Hmmm, the tests are taking a while to finish. Here is the status:\n";
         catch_usr1();
+        $endwaitcnt = 0;
     }
 }
 


### PR DESCRIPTION
... even if there are tests still pending. To help visualize tests that might be hanging.