### PR TITLE
typecheck-gcc: add type checks for curl_multi_setopt()

### DIFF
--- a/include/curl/typecheck-gcc.h
+++ b/include/curl/typecheck-gcc.h
@@ -193,11 +193,68 @@
       curl_easy_getinfo(handle, info, arg);                             \
     })
 
+#define curl_multi_setopt(handle, option, value)                        \
+  __extension__({                                                       \
+      if(__builtin_constant_p(option)) {                                \
+        if(curlcheck_long_option(option))                               \
+          if(!curlcheck_long(value))                                    \
+            _curl_multi_setopt_err_long();                              \
+        if(curlcheck_off_t_option(option))                              \
+          if(!curlcheck_off_t(value))                                   \
+            _curl_multi_setopt_err_curl_off_t();                        \
+        if(curlcheck_multicb_data_option(option))                       \
+          if(!curlcheck_cb_data(value))                                 \
+            _curl_multi_setopt_err_cb_data();                           \
+        if(curlcheck_charpp_option(option))                             \
+          if(!curlcheck_ptrptr(value, char))                            \
+            _curl_multi_setopt_err_charpp();                            \
+        if((option) == CURLMOPT_PUSHFUNCTION)                           \
+          if(!curlcheck_multipush_cb(value))                            \
+            _curl_multi_setopt_err_pushcb();                            \
+        if((option) == CURLMOPT_SOCKETFUNCTION)                         \
+          if(!curlcheck_multisocket_cb(value))                          \
+            _curl_multi_setopt_err_socketcb();                          \
+        if((option) == CURLMOPT_TIMERFUNCTION)                          \
+          if(!curlcheck_multitimer_cb(value))                           \
+            _curl_multi_setopt_err_timercb();                           \
+      }                                                                 \
+      curl_multi_setopt(handle, option, value);                         \
+    })
+
+/* evaluates to true if the option takes a data argument to pass to a
+   callback */
+#define curlcheck_multicb_data_option(option)                           \
+  ((option) == CURLMOPT_PUSHDATA ||                                     \
+   (option) == CURLMOPT_SOCKETDATA ||                                   \
+   (option) == CURLMOPT_TIMERDATA ||                                    \
+   0)
+
+/* evaluates to true if the option takes a char ** argument */
+#define curlcheck_charpp_option(option)                                 \
+  ((option) == CURLMOPT_PIPELINING_SERVER_BL ||                         \
+   (option) == CURLMOPT_PIPELINING_SITE_BL ||                           \
+   0)
+
+/* evaluates to true if expr is of type curl_multi_timer_callback */
+#define curlcheck_multitimer_cb(expr)                                   \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_multi_timer_callback))
+
+/* evaluates to true if expr is of type curl_socket_callback */
+#define curlcheck_multisocket_cb(expr)                                  \
+  (curlcheck_NULL(expr) ||                                              \
+   curlcheck_cb_compatible((expr), curl_socket_callback))
+
+/* evaluates to true if expr is of type curl_push_callback */
+#define curlcheck_multipush_cb(expr)                                  \
+  (curlcheck_NULL(expr) ||                                            \
+   curlcheck_cb_compatible((expr), curl_push_callback))
+
 /*
  * For now, just make sure that the functions are called with three arguments
  */
 #define curl_share_setopt(share,opt,param) curl_share_setopt(share,opt,param)
-#define curl_multi_setopt(handle,opt,param) curl_multi_setopt(handle,opt,param)
+
 
 /* the actual warnings, triggered by calling the _curl_easy_setopt_err*
  * functions */
@@ -207,6 +264,21 @@
   static void __attribute__((__warning__(message)))                     \
   __attribute__((__unused__)) __attribute__((__noinline__))             \
   id(void) { __asm__(""); }
+
+CURLWARNING(_curl_multi_setopt_err_long,
+            "curl_multi_setopt expects a long argument")
+CURLWARNING(_curl_multi_setopt_err_curl_off_t,
+            "curl_multi_setopt expects a curl_off_t argument")
+CURLWARNING(_curl_multi_setopt_err_cb_data,
+            "curl_multi_setopt expects a 'void *' argument")
+CURLWARNING(_curl_multi_setopt_err_charpp,
+            "curl_multi_setopt expects a 'char **' argument")
+CURLWARNING(_curl_multi_setopt_err_pushcb,
+            "curl_multi_setopt expects a curl_push_callback argument")
+CURLWARNING(_curl_multi_setopt_err_socketcb,
+            "curl_multi_setopt expects a curl_socket_callback argument")
+CURLWARNING(_curl_multi_setopt_err_timercb,
+            "curl_multi_setopt expects a curl_multi_timer_callback argument")
 
 CURLWARNING(_curl_easy_setopt_err_long,
             "curl_easy_setopt expects a long argument")
@@ -533,6 +605,14 @@ CURLWARNING(_curl_easy_getinfo_err_curl_off_t,
   (curlcheck_NULL(expr) ||                                              \
    __builtin_types_compatible_p(__typeof__(expr), type *) ||            \
    __builtin_types_compatible_p(__typeof__(expr), const type *))
+
+/* evaluates to true if expr is type**, const type** or NULL */
+#define curlcheck_ptrptr(expr, type)                                    \
+  (curlcheck_NULL(expr) ||                                              \
+   __builtin_types_compatible_p(__typeof__(expr), type **) ||           \
+   __builtin_types_compatible_p(__typeof__(expr), type *[]) ||          \
+   __builtin_types_compatible_p(__typeof__(expr), const type *[]) ||    \
+   __builtin_types_compatible_p(__typeof__(expr), const type **))
 
 /* evaluates to true if expr is one of type[], type*, NULL or const type* */
 #define curlcheck_arr(expr, type)                                       \

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1514,9 +1514,9 @@ static void on_uv_timeout(uv_timer_t *req)
 }
 
 /* callback from libcurl to update the timeout expiry */
-static int cb_timeout(CURLM *multi, long timeout_ms,
-                      struct datauv *uv)
+static int cb_timeout(CURLM *multi, long timeout_ms, void *userp)
 {
+  struct datauv *uv = userp;
   (void)multi;
 #if DEBUG_UV
   fprintf(tool_stderr, "parallel_event: cb_timeout=%ld\n", timeout_ms);
@@ -1562,11 +1562,11 @@ static void destroy_context(struct contextuv *c)
 
 /* callback from libcurl to update socket activity to wait for */
 static int cb_socket(CURL *easy, curl_socket_t s, int action,
-                     struct datauv *uv,
-                     void *socketp)
+                     void *userp, void *socketp)
 {
   struct contextuv *c;
   int events = 0;
+  struct datauv *uv = userp;
   (void)easy;
 
 #if DEBUG_UV
@@ -1622,7 +1622,7 @@ static CURLcode parallel_event(struct parastate *s)
   curl_multi_setopt(s->multi, CURLMOPT_SOCKETDATA, &uv);
   curl_multi_setopt(s->multi, CURLMOPT_TIMERFUNCTION, cb_timeout);
   curl_multi_setopt(s->multi, CURLMOPT_TIMERDATA, &uv);
-  curl_multi_setopt(s->multi, CURLMOPT_MAX_HOST_CONNECTIONS,
+  curl_multi_setopt(s->multi, CURLMOPT_MAX_HOST_CONNECTIONS, (long)
                     global->parallel_host);
 
   /* kickstart the thing */

--- a/tests/test745.pl
+++ b/tests/test745.pl
@@ -60,6 +60,18 @@ sub getinclude {
     $enum{"CURLOPT_CONV_FROM_UTF8_FUNCTION"}++;
     $enum{"CURLOPT_CONV_TO_NETWORK_FUNCTION"}++;
     close($f);
+
+    open(my $f, "<", "$root/include/curl/multi.h")
+        || die "no curl.h";
+    while(<$f>) {
+        if($_ =~ /\((CURLMOPT[^,]*), (CURLOPTTYPE_[^,]*)/) {
+            my ($opt, $type) = ($1, $2);
+            if($type !~ /LONG|OFF_T/) {
+                $enum{$opt}++;
+            }
+        }
+    }
+    close($f);
 }
 
 gettypecheck();


### PR DESCRIPTION
Test 745 verifies that all options are tested.