### PR TITLE
openssl: drop more legacy cruft

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -135,10 +135,6 @@ static void ossl_provider_cleanup(struct Curl_easy *data);
 #include "../curl_memory.h"
 #include "../memdebug.h"
 
-#ifndef OPENSSL_VERSION_NUMBER
-#error "OPENSSL_VERSION_NUMBER not defined"
-#endif
-
 #if defined(USE_OPENSSL_ENGINE) || defined(OPENSSL_HAS_PROVIDERS)
 #include <openssl/ui.h>
 #endif


### PR DESCRIPTION
- drop `ALLOW_RENEG` undocumented (insecure) build-time option.
- drop unnecessary check for `OPENSSL_VERSION_NUMBER`.
  It's present in all supported OpenSSL versions and forks.

Follow-up to 80c10c5d5dda78c471924b251e9db59d653aba1e #18351
Follow-up to 59311bd3df5da6342312b5dc9b6c91fc2be77d4f #3293 #3283
