### PR TITLE
tool_getparam: let --trace-config override -v

### DIFF
--- a/src/tool_cfgable.h
+++ b/src/tool_cfgable.h
@@ -383,6 +383,7 @@ struct GlobalConfig {
   BIT(silent);                    /* do not show messages, --silent given */
   BIT(noprogress);                /* do not show progress bar */
   BIT(isatty);                    /* Updated internally if output is a tty */
+  BIT(trace_set);                 /* --trace-config has been used */
 };
 
 struct OperationConfig *config_alloc(void);

--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -1477,7 +1477,7 @@ static ParameterError parse_verbose(bool toggle)
   else if(!verbose_nopts) {
     /* fist `-v` in an argument resets to base verbosity */
     global->verbosity = 0;
-    if(set_trace_config("-all"))
+    if(!global->trace_set && set_trace_config("-all"))
       return PARAM_NO_MEM;
   }
   /* the '%' thing here will cause the trace get sent to stderr */
@@ -2443,6 +2443,7 @@ static ParameterError opt_filestring(struct OperationConfig *config,
     /* 0 is a valid value for this timeout */
     break;
   case C_TRACE_CONFIG: /* --trace-config */
+    global->trace_set = TRUE;
     if(set_trace_config(nextarg))
       err = PARAM_NO_MEM;
     break;


### PR DESCRIPTION
If --trace-config is used to set a level before -v is used, don't reset the state on first -v (to "-all") as it otherwise does. This way, --trace-config can be used to set specific trace items before -v on the command line and it still works.

Previously, the first -v use would otherwise reset and undo the earlier --trace-config items.

Fixes #18346