### PR TITLE
acinclude: --with-ca-fallback only works with OpenSSL

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -1242,10 +1242,10 @@ AS_HELP_STRING([--without-ca-path], [Don't use a default CA path]),
     AC_MSG_RESULT([no])
   fi
 
-  AC_MSG_CHECKING([whether to use built-in CA store of SSL library])
+  AC_MSG_CHECKING([whether to use OpenSSL's built-in CA store])
   AC_ARG_WITH(ca-fallback,
-AS_HELP_STRING([--with-ca-fallback], [Use the built-in CA store of the SSL library])
-AS_HELP_STRING([--without-ca-fallback], [Don't use the built-in CA store of the SSL library]),
+AS_HELP_STRING([--with-ca-fallback], [Use OpenSSL's built-in CA store])
+AS_HELP_STRING([--without-ca-fallback], [Don't use OpenSSL's built-in CA store]),
   [
     if test "x$with_ca_fallback" != "xyes" -a "x$with_ca_fallback" != "xno"; then
       AC_MSG_ERROR([--with-ca-fallback only allows yes or no as parameter])
@@ -1254,10 +1254,10 @@ AS_HELP_STRING([--without-ca-fallback], [Don't use the built-in CA store of the 
   [ with_ca_fallback="no"])
   AC_MSG_RESULT([$with_ca_fallback])
   if test "x$with_ca_fallback" = "xyes"; then
-    if test "x$OPENSSL_ENABLED" != "x1" -a "x$GNUTLS_ENABLED" != "x1"; then
-      AC_MSG_ERROR([--with-ca-fallback only works with OpenSSL or GnuTLS])
+    if test "x$OPENSSL_ENABLED" != "x1"; then
+      AC_MSG_ERROR([--with-ca-fallback only works with OpenSSL])
     fi
-    AC_DEFINE_UNQUOTED(CURL_CA_FALLBACK, 1, [define "1" to use built-in CA store of SSL library])
+    AC_DEFINE_UNQUOTED(CURL_CA_FALLBACK, 1, [define "1" to use OpenSSL's built-in CA store])
   fi
 ])
 


### PR DESCRIPTION
Make it error if another TLS backend is used. Also tweaked the documentation for it to make it more clear it is only for OpenSSL.

Follow-up to 9cf47593542c6f

Reported-by: Michael Osipov
Fixes #18362