### PR TITLE
openssl: use `RSA_flags()` again with BoringSSL

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -1798,8 +1798,7 @@ static CURLcode client_cert(struct Curl_easy *data,
       EVP_PKEY_free(pktmp);
     }
 
-#if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_IS_BORINGSSL) &&       \
-  !defined(OPENSSL_NO_DEPRECATED_3_0)
+#if !defined(OPENSSL_NO_RSA) && !defined(OPENSSL_NO_DEPRECATED_3_0)
     {
       /* If RSA is used, do not check the private key if its flags indicate
        * it does not support it. */


### PR DESCRIPTION
Supported since 2017-12-18:
https://github.com/google/boringssl/commit/a0c87adbf0bc23810895ebd7f131790f137d2f6d

Follow-up to cd276c3cca4db23384f3272486468ce41b0a338b #2117
