### PR TITLE
asyn-thrdd: fix no `HAVE_GETADDRINFO` builds

### DIFF
--- a/lib/asyn-thrdd.c
+++ b/lib/asyn-thrdd.c
@@ -346,7 +346,7 @@ static CURL_THREAD_RETURN_T CURL_STDCALL gethostbyname_thread(void *arg)
 #pragma clang diagnostic pop
 #endif
 
-  async_thrd_cleanup(addr_ctx, 0);
+  async_thrd_cleanup(addr_ctx);
   return 0;
 }
 


### PR DESCRIPTION
mingw32ce, CM 4.4.0-arm schannel:
```
lib/asyn-thrdd.c: In function 'gethostbyname_thread':
lib/asyn-thrdd.c:349: error: too many arguments to function 'async_thrd_cleanup'
```
https://github.com/curl/curl/actions/runs/17158865566/job/48682687295?pr=18039#step:9:21