### PR TITLE
tool_operate: bail out better on no URL

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -1119,6 +1119,11 @@ static CURLcode single_transfer(struct OperationConfig *config,
     struct getout *u = state->urlnode;
     FILE *err = (!global->silent || global->showerror) ? tool_stderr : NULL;
 
+    if(!u->url) {
+      /* This node has no URL. End of the road. */
+      warnf("Got more output options than URLs");
+      break;
+    }
     if(u->infile) {
       if(!config->globoff && !glob_inuse(&state->inglob))
         result = glob_url(&state->inglob, u->infile, &state->upnum, err);
@@ -1141,11 +1146,6 @@ static CURLcode single_transfer(struct OperationConfig *config,
       glob_cleanup(&state->inglob);
       state->upidx = 0;
       state->urlnode = u->next; /* next node */
-      if(state->urlnode && !state->urlnode->url) {
-        /* This node has no URL. End of the road. */
-        warnf("Got more output options than URLs");
-        break;
-      }
       continue;
     }
 

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -108,7 +108,7 @@ test718 test719 test720 test721 test722 test723 test724 test725 test726 \
 test727 test728 test729 test730 test731 test732 test733 test734 test735 \
 test736 test737 test738 test739 test740 test741 test742 test743 test744 \
 test745 test746 test747 test748 test749 test750 test751 test752 test753 \
-test754 test755 test756 test757 test758 test759 \
+test754 test755 test756 test757 test758 test759 test760 \
 test780 test781 test782 test783 test784 test785 test786 test787 test788 \
 test789 test790 test791 test792 test793 test794 test795 test796 test797 \
 \

--- a/tests/data/test760
+++ b/tests/data/test760
@@ -1,0 +1,30 @@
+<testcase>
+<info>
+<keywords>
+globbing
+</keywords>
+</info>
+
+#
+# Client-side
+<client>
+<server>
+none
+</server>
+<name>
+more cmdline options than URLs and --next
+</name>
+<command>
+-no1 -no2 --url "Qttp://internal.dxample.lol/status" -: --url "http"
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+# curl: (1) Protocol "qttp" not supported
+<errorcode>
+1
+</errorcode>
+</verify>
+</testcase>


### PR DESCRIPTION
To avoid NULL derferences with many outputs and --next.

Add test 760 to verify

Reported-by: BobodevMm on github
Fixes #18375