### PR TITLE
configure: tidy up internal names in ngtcp2 ossl detection logic

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3310,33 +3310,33 @@ if test "x$USE_NGTCP2" = "x1" -a "x$OPENSSL_ENABLED" = "x1" -a \
   CURL_CHECK_PKGCONFIG(libngtcp2_crypto_ossl, $want_tcp2_path)
 
   if test "$PKGCONFIG" != "no"; then
-    LIB_NGTCP2_CRYPTO_QUICTLS=`CURL_EXPORT_PCDIR([$want_tcp2_path])
+    LIB_NGTCP2_CRYPTO_OSSL=`CURL_EXPORT_PCDIR([$want_tcp2_path])
       $PKGCONFIG --libs-only-l libngtcp2_crypto_ossl`
-    AC_MSG_NOTICE([-l is $LIB_NGTCP2_CRYPTO_QUICTLS])
+    AC_MSG_NOTICE([-l is $LIB_NGTCP2_CRYPTO_OSSL])
 
-    CPP_NGTCP2_CRYPTO_QUICTLS=`CURL_EXPORT_PCDIR([$want_tcp2_path]) dnl
+    CPP_NGTCP2_CRYPTO_OSSL=`CURL_EXPORT_PCDIR([$want_tcp2_path]) dnl
       $PKGCONFIG --cflags-only-I libngtcp2_crypto_ossl`
-    AC_MSG_NOTICE([-I is $CPP_NGTCP2_CRYPTO_QUICTLS])
+    AC_MSG_NOTICE([-I is $CPP_NGTCP2_CRYPTO_OSSL])
 
-    LD_NGTCP2_CRYPTO_QUICTLS=`CURL_EXPORT_PCDIR([$want_tcp2_path])
+    LD_NGTCP2_CRYPTO_OSSL=`CURL_EXPORT_PCDIR([$want_tcp2_path])
       $PKGCONFIG --libs-only-L libngtcp2_crypto_ossl`
-    AC_MSG_NOTICE([-L is $LD_NGTCP2_CRYPTO_QUICTLS])
+    AC_MSG_NOTICE([-L is $LD_NGTCP2_CRYPTO_OSSL])
 
-    LDFLAGS="$LDFLAGS $LD_NGTCP2_CRYPTO_QUICTLS"
-    LDFLAGSPC="$LDFLAGSPC $LD_NGTCP2_CRYPTO_QUICTLS"
-    CPPFLAGS="$CPPFLAGS $CPP_NGTCP2_CRYPTO_QUICTLS"
-    LIBS="$LIB_NGTCP2_CRYPTO_QUICTLS $LIBS"
+    LDFLAGS="$LDFLAGS $LD_NGTCP2_CRYPTO_OSSL"
+    LDFLAGSPC="$LDFLAGSPC $LD_NGTCP2_CRYPTO_OSSL"
+    CPPFLAGS="$CPPFLAGS $CPP_NGTCP2_CRYPTO_OSSL"
+    LIBS="$LIB_NGTCP2_CRYPTO_OSSL $LIBS"
 
     if test "x$cross_compiling" != "xyes"; then
-      DIR_NGTCP2_CRYPTO_QUICTLS=`echo $LD_NGTCP2_CRYPTO_QUICTLS | $SED -e 's/^-L//'`
+      DIR_NGTCP2_CRYPTO_OSSL=`echo $LD_NGTCP2_CRYPTO_OSSL | $SED -e 's/^-L//'`
     fi
     AC_CHECK_LIB(ngtcp2_crypto_ossl, ngtcp2_crypto_recv_client_initial_cb,
       [
         AC_CHECK_HEADERS(ngtcp2/ngtcp2_crypto.h,
           USE_NGTCP2=1
-          CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$DIR_NGTCP2_CRYPTO_QUICTLS"
+          CURL_LIBRARY_PATH="$CURL_LIBRARY_PATH:$DIR_NGTCP2_CRYPTO_OSSL"
           export CURL_LIBRARY_PATH
-          AC_MSG_NOTICE([Added $DIR_NGTCP2_CRYPTO_QUICTLS to CURL_LIBRARY_PATH])
+          AC_MSG_NOTICE([Added $DIR_NGTCP2_CRYPTO_OSSL to CURL_LIBRARY_PATH])
           LIBCURL_PC_REQUIRES_PRIVATE="$LIBCURL_PC_REQUIRES_PRIVATE libngtcp2_crypto_ossl"
           AC_DEFINE(OPENSSL_QUIC_API2, 1, [openssl with new QUIC API])
         )


### PR DESCRIPTION
Replace "quictls" with "ossl".

Follow-up to 5eefdd71a394d135c0ffb56fb8ec117c87dbe4f0 #17027
Cherry-picked from #18377
