### PR TITLE
GHA/http3-linux: build ngtcp2 for LibreSSL too, add LibreSSL jobs

### DIFF
--- a/.github/workflows/http3-linux.yml
+++ b/.github/workflows/http3-linux.yml
@@ -45,6 +45,8 @@ env:
   OPENSSL_VERSION: 3.5.2
   # handled in renovate.json
   QUICTLS_VERSION: 3.3.0
+  # renovate: datasource=github-tags depName=libressl/portable versioning=semver registryUrl=https://github.com
+  LIBRESSL_VERSION: 4.1.0
   # renovate: datasource=github-tags depName=gnutls/gnutls versioning=semver registryUrl=https://github.com
   GNUTLS_VERSION: 3.8.10
   # renovate: datasource=github-tags depName=wolfSSL/wolfssl versioning=semver extractVersion=^v?(?<version>.+)-stable$ registryUrl=https://github.com
@@ -72,6 +74,15 @@ jobs:
         with:
           path: ~/openssl/build
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.OPENSSL_VERSION }}
+
+      - name: 'cache libressl'
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        id: cache-libressl
+        env:
+          cache-name: cache-libressl
+        with:
+          path: ~/libressl/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.LIBRESSL_VERSION }}
 
       - name: 'cache quictls'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
@@ -116,7 +127,7 @@ jobs:
           cache-name: cache-ngtcp2
         with:
           path: ~/ngtcp2/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.NGTCP2_VERSION }}-${{ env.OPENSSL_VERSION }}-${{ env.QUICTLS_VERSION }}-${{ env.GNUTLS_VERSION }}-${{ env.WOLFSSL_VERSION }}
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.NGTCP2_VERSION }}-${{ env.OPENSSL_VERSION }}-${{ env.LIBRESSL_VERSION }}-${{ env.QUICTLS_VERSION }}-${{ env.GNUTLS_VERSION }}-${{ env.WOLFSSL_VERSION }}
 
       - name: 'cache nghttp2'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
@@ -130,6 +141,7 @@ jobs:
       - id: settings
         if: >-
           ${{ steps.cache-openssl-http3.outputs.cache-hit != 'true' ||
+              steps.cache-libressl.outputs.cache-hit != 'true' ||
               steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true' ||
               steps.cache-gnutls.outputs.cache-hit != 'true' ||
               steps.cache-wolfssl.outputs.cache-hit != 'true' ||
@@ -164,6 +176,17 @@ jobs:
           ./config --prefix="$PWD"/build --libdir=lib no-makedepend no-apps no-docs no-tests
           make
           make -j1 install_sw
+
+      - name: 'build libressl'
+        if: ${{ steps.cache-libressl.outputs.cache-hit != 'true' }}
+        run: |
+          cd ~
+          curl --disable --fail --silent --show-error --connect-timeout 15 --max-time 120 --retry 6 --retry-connrefused \
+            --location "https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/libressl-${LIBRESSL_VERSION}.tar.gz" | tar -xz
+          cd "libressl-${LIBRESSL_VERSION}"
+          cmake -B . -G Ninja -DLIBRESSL_APPS=OFF -DLIBRESSL_TESTS=OFF -DCMAKE_INSTALL_PREFIX=/home/runner/libressl/build
+          cmake --build .
+          cmake --install .
 
       - name: 'build quictls'
         if: ${{ steps.cache-quictls-no-deprecated.outputs.cache-hit != 'true' }}
@@ -215,14 +238,18 @@ jobs:
 
       - name: 'build ngtcp2'
         if: ${{ steps.cache-ngtcp2.outputs.cache-hit != 'true' }}
-        # building twice to get crypto libs for ossl and quictls installed
+        # building 3 times to get crypto libs for ossl, libressl and quictls installed
         run: |
           cd ~
           git clone --quiet --depth=1 -b "v${NGTCP2_VERSION}" https://github.com/ngtcp2/ngtcp2
           cd ngtcp2
           autoreconf -fi
           ./configure --disable-dependency-tracking --prefix="$PWD"/build \
-            PKG_CONFIG_PATH=/home/runner/quictls/build/lib/pkgconfig --enable-lib-only --with-quictls
+            PKG_CONFIG_PATH=/home/runner/libressl/build/lib/pkgconfig --enable-lib-only --with-openssl
+          make install
+          make clean
+          ./configure --disable-dependency-tracking --prefix="$PWD"/build \
+            PKG_CONFIG_PATH=/home/runner/quictls/build/lib/pkgconfig --enable-lib-only --with-openssl
           make install
           make clean
           ./configure --disable-dependency-tracking --prefix="$PWD"/build \
@@ -270,6 +297,21 @@ jobs:
               -DOPENSSL_ROOT_DIR=/home/runner/openssl/build
               -DUSE_NGTCP2=ON -DCURL_DISABLE_NTLM=ON
               -DCMAKE_UNITY_BUILD=ON
+
+          - name: 'libressl'
+            install_steps: skipall
+            PKG_CONFIG_PATH: /home/runner/libressl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
+            configure: >-
+              LDFLAGS=-Wl,-rpath,/home/runner/libressl/build/lib
+              --with-ngtcp2 --disable-ntlm
+              --with-openssl=/home/runner/libressl/build --enable-ssls-export
+              --enable-unity
+
+          - name: 'libressl'
+            PKG_CONFIG_PATH: /home/runner/libressl/build/lib/pkgconfig:/home/runner/nghttp3/build/lib/pkgconfig:/home/runner/ngtcp2/build/lib/pkgconfig:/home/runner/nghttp2/build/lib/pkgconfig
+            generate: >-
+              -DOPENSSL_ROOT_DIR=/home/runner/libressl/build
+              -DUSE_NGTCP2=ON -DCURL_DISABLE_NTLM=ON
 
           - name: 'quictls'
             install_steps: skipall
@@ -376,6 +418,16 @@ jobs:
           key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.OPENSSL_VERSION }}
           fail-on-cache-miss: true
 
+      - name: 'cache libressl'
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
+        id: cache-libressl
+        env:
+          cache-name: cache-libressl
+        with:
+          path: ~/libressl/build
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.LIBRESSL_VERSION }}
+          fail-on-cache-miss: true
+
       - name: 'cache quictls'
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4
         id: cache-quictls-no-deprecated
@@ -425,7 +477,7 @@ jobs:
           cache-name: cache-ngtcp2
         with:
           path: ~/ngtcp2/build
-          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.NGTCP2_VERSION }}-${{ env.OPENSSL_VERSION }}-${{ env.QUICTLS_VERSION }}-${{ env.GNUTLS_VERSION }}-${{ env.WOLFSSL_VERSION }}
+          key: ${{ runner.os }}-http3-build-${{ env.cache-name }}-${{ env.NGTCP2_VERSION }}-${{ env.OPENSSL_VERSION }}-${{ env.LIBRESSL_VERSION }}-${{ env.QUICTLS_VERSION }}-${{ env.GNUTLS_VERSION }}-${{ env.WOLFSSL_VERSION }}
           fail-on-cache-miss: true
 
       - name: 'cache nghttp2'


### PR DESCRIPTION
Also: Build LibreSSL with cmake. It's 3x faster (90s -> 30s).

Follow-up to e724259bcbb5cf8b3b12e0ff0fd90d2aa47f8f46 #18379
Follow-up to 31e6798544bf8aafbd8aef61b08623b92312aa42 #18377
Cherry-picked from #18377
