### PR TITLE
openssl: sync an AWS-LC guard with BoringSSL

### DIFF
--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -5580,7 +5580,7 @@ size_t Curl_ossl_version(char *buffer, size_t size)
                    (ssleay_value >> 20) & 0xff,
                    (ssleay_value >> 12) & 0xff,
                    sub);
-#endif /* OPENSSL_IS_BORINGSSL */
+#endif
 }
 
 /* can be called with data == NULL */


### PR DESCRIPTION
BoringSSL always used the same type:
https://boringssl.googlesource.com/boringssl/+/103ed08549a74af9f03363c633028faf9a475066
https://github.com/google/boringssl/commit/103ed08549a74af9f03363c633028faf9a475066

But, this codepath isn't built with BoringSSL, because it defines
`OPENSSL_NO_OCSP` via `opensslconf.h`.

Also drop an out-of-place `#endif` comment.

Ref: 20f4e94eebbdcfe590ae99cb8a3f2ca1b8f970a0 #11568

---

- [x] double-check if this special case is indeed necessary. → it is:
  https://github.com/curl/curl/actions/runs/17179727043/job/48740564761?pr=18384#step:35:41
- [ ] add BoringSSL CI job. → PR
