### PR TITLE
pytest: fix test_17_09_ssl_min_max for BoringSSL

### DIFF
--- a/tests/http/test_17_ssl_use.py
+++ b/tests/http/test_17_ssl_use.py
@@ -313,11 +313,12 @@ class TestSSLUse:
         httpd.reload_if_config_changed()
         # curl's TLS backend supported version
         if env.curl_uses_lib('gnutls') or \
-            env.curl_uses_lib('quiche') or \
-                env.curl_uses_lib('aws-lc'):
+           env.curl_uses_lib('quiche') or \
+           env.curl_uses_lib('aws-lc') or \
+           env.curl_uses_lib('boringssl'):
             curl_supported = [0x301, 0x302, 0x303, 0x304]
         elif env.curl_uses_lib('openssl') and \
-                env.curl_lib_version_before('openssl', '3.0.0'):
+             env.curl_lib_version_before('openssl', '3.0.0'):
             curl_supported = [0x301, 0x302, 0x303, 0x304]
         else:  # most SSL backends dropped support for TLSv1.0, TLSv1.1
             curl_supported = [0x303, 0x304]


### PR DESCRIPTION
Ref: https://github.com/curl/curl/actions/runs/17179514833/job/48740057095

Also fix indent.

Cherry-picked from #18384

---

w/o sp https://github.com/curl/curl/pull/18385/files?w=1
