### PR TITLE
GHA/curl-for-win: drop x86, fix zlib-classic, switch back to libssh

### DIFF
--- a/.github/workflows/curl-for-win.yml
+++ b/.github/workflows/curl-for-win.yml
@@ -147,8 +147,8 @@ jobs:
             "${DOCKER_IMAGE}" \
             sh -c ./_ci-linux-debian.sh
 
-  win-gcc-libssh-zlibold-x86:
-    name: 'Windows gcc libssh zlib-classic (x86)'
+  win-gcc-libssh-zlibold-x64:
+    name: 'Windows gcc libssh zlib-classic (x64)'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -161,7 +161,7 @@ jobs:
         run: |
           git clone --depth 1 https://github.com/curl/curl-for-win
           mv curl-for-win/* .
-          export CW_CONFIG='-main-werror-unitybatch-win-x86-gcc-libssh1-zlibold'
+          export CW_CONFIG='-main-werror-unitybatch-win-x64-gcc-libssh1-zlibold'
           export CW_REVISION="${GITHUB_SHA}"
           . ./_versions.sh
           sudo podman image trust set --type reject default


### PR DESCRIPTION
- switch x86 job to x64. x86 is not longer actively maintained in
  curl-for-win.
  Ref: https://github.com/curl/curl-for-win/discussions/68

- switch back from libssh2 to libssh.
  Reverts af8e1aa4b06e9dc78a559b485348e5464bd5cff5 #18257

- fix to really build with zlib-classic.
  Follow-up to 80768248700ae1e33fdedffd2e8bd78167b793aa #17357
