### PR TITLE
runtests: remove warning message

### DIFF
--- a/tests/runtests.pl
+++ b/tests/runtests.pl
@@ -1921,7 +1921,7 @@ sub singletest {
         my $logdir = getrunnerlogdir($runnerid);
         # first, remove all lingering log & lock files
         if(!cleardir($logdir)) {
-            logmsg "Warning: $runnerid: cleardir($logdir) failed\n";
+            #logmsg "Warning: $runnerid: cleardir($logdir) failed\n";
         }
         if(!cleardir("$logdir/$LOCKDIR")) {
             logmsg "Warning: $runnerid: cleardir($logdir/$LOCKDIR) failed\n";


### PR DESCRIPTION
Every time we first run runtests with -j and then again *without* -j, this message was shown:

  "Warning: $runnerid: cleardir(log) failed"

Not anymore.