### PR TITLE
Add an .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,26 +1,6 @@
-#***************************************************************************
-#                                  _   _ ____  _
-#  Project                     ___| | | |  _ \| |
-#                             / __| | | | |_) | |
-#                            | (__| |_| |  _ <| |___
-#                             \___|\___/|_| \_\_____|
-#
 # Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
 #
-# This software is licensed as described in the file COPYING, which
-# you should have received as part of this distribution. The terms
-# are also available at https://curl.se/docs/copyright.html.
-#
-# You may opt to use, copy, modify, merge, publish, distribute and/or sell
-# copies of the Software, and permit persons to whom the Software is
-# furnished to do so, under the terms of the COPYING file.
-#
-# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
-# KIND, either express or implied.
-#
 # SPDX-License-Identifier: curl
-#
-###########################################################################
 
 root = true
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,27 @@
+#***************************************************************************
+#                                  _   _ ____  _
+#  Project                     ___| | | |  _ \| |
+#                             / __| | | | |_) | |
+#                            | (__| |_| |  _ <| |___
+#                             \___|\___/|_| \_\_____|
+#
+# Copyright (C) Daniel Stenberg, <daniel@haxx.se>, et al.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at https://curl.se/docs/copyright.html.
+#
+# You may opt to use, copy, modify, merge, publish, distribute and/or sell
+# copies of the Software, and permit persons to whom the Software is
+# furnished to do so, under the terms of the COPYING file.
+#
+# This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY
+# KIND, either express or implied.
+#
+# SPDX-License-Identifier: curl
+#
+###########################################################################
+
 root = true
 
 [*.{c,h}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,10 +4,15 @@
 
 root = true
 
-[*.{c,h}]
+[*]
 charset = utf-8
 insert_final_newline = true
 indent_style = space
+trim_trailing_whitespace = true
+
+[*.{c,h}]
 indent_size = 2
 max_line_length = 79
-trim_trailing_whitespace = true
+
+[*.{pl,pm}]
+indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.{c,h}]
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+max_line_length = 79
+trim_trailing_whitespace = true

--- a/Makefile.am
+++ b/Makefile.am
@@ -79,7 +79,7 @@ PLAN9_DIST = plan9/include/mkfile \
  plan9/src/mkfile.inc             \
  plan9/src/mkfile
 
-EXTRA_DIST = CHANGES.md COPYING RELEASE-NOTES Dockerfile \
+EXTRA_DIST = CHANGES.md COPYING RELEASE-NOTES Dockerfile .editorconfig \
  $(CMAKE_DIST) $(VC_DIST) $(WINBUILD_DIST) $(PLAN9_DIST)
 
 DISTCLEANFILES = buildinfo.txt


### PR DESCRIPTION
This allows IDEs that support this standard to automatically use the correct formatting options.