### PR TITLE
requests: fix uninitialized var

### DIFF
--- a/lib/request.c
+++ b/lib/request.c
@@ -308,7 +308,7 @@ static CURLcode req_flush(struct Curl_easy *data)
   }
 
   if(data->req.eos_read && !data->req.eos_sent) {
-    char tmp;
+    char tmp = 0;
     size_t nwritten;
     result = xfer_send(data, &tmp, 0, 0, &nwritten);
     if(result)


### PR DESCRIPTION
init char whose address is passed for a 0-length buffer, clang does not like it

refs #18418