### PR TITLE
curl_setup.h: include `stdint.h` earlier

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -475,6 +475,10 @@
 #include <curl/stdcheaders.h>
 #endif
 
+#if defined(HAVE_STDINT_H) || defined(USE_WOLFSSL)
+#include <stdint.h>
+#endif
+
 #ifdef _WIN32
 #  ifdef HAVE_IO_H
 #  include <io.h>

--- a/lib/curl_setup_once.h
+++ b/lib/curl_setup_once.h
@@ -63,10 +63,6 @@
 #include <unistd.h>
 #endif
 
-#if defined(HAVE_STDINT_H) || defined(USE_WOLFSSL)
-#include <stdint.h>
-#endif
-
 /* Macro to strip 'const' without triggering a compiler warning.
    Use it for APIs that do not or cannot support the const qualifier. */
 #ifdef HAVE_STDINT_H


### PR DESCRIPTION
To have it included by the time checking for `SIZE_MAX` and `SSIZE_MAX`.

Ref: 93f333c18fffc3c091b149f3e0ec2ca02b8dab40 #18426 #18406
