### PR TITLE
curl_ngtcp2 handshake timeout should be equal to --connect-timeout

### DIFF
--- a/lib/vquic/curl_ngtcp2.c
+++ b/lib/vquic/curl_ngtcp2.c
@@ -431,9 +431,9 @@ static void quic_settings(struct cf_ngtcp2_ctx *ctx,
   s->log_printf = NULL;
 #endif
 
-  (void)data;
   s->initial_ts = pktx->ts;
-  s->handshake_timeout = QUIC_HANDSHAKE_TIMEOUT;
+  s->handshake_timeout = (data->set.connecttimeout > 0) ?
+    data->set.connecttimeout * NGTCP2_MILLISECONDS : QUIC_HANDSHAKE_TIMEOUT;
   s->max_window = 100 * ctx->max_stream_window;
   s->max_stream_window = 10 * ctx->max_stream_window;
 


### PR DESCRIPTION
Default handshake timeout is hardcoded (10 seconds) and doesn't respect --connect-timeout parameter. In some cases 10 seconds can be not enough or too long to "establish a connection". Moreover the non-working --connect-timeout parameter for http3 is confusing. This change makes the handshake timeout equal to --connect-timeout, if it's set. Discussion thread is here https://github.com/curl/curl/discussions/18427