### PR TITLE
autotools: make curl-config executable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5536,9 +5536,9 @@ AC_CONFIG_FILES([\
   tests/http/Makefile \
   packages/Makefile \
   packages/vms/Makefile \
-  curl-config \
   libcurl.pc
 ])
+AC_CONFIG_FILES([curl-config], [chmod +x curl-config])
 AC_OUTPUT
 
 SUPPORT_PROTOCOLS_LOWER=`echo "$SUPPORT_PROTOCOLS" | tr A-Z a-z`


### PR DESCRIPTION
This was already done when building using CMake:
https://github.com/curl/curl/blob/fa9151b41ad986e0514d99dd3fe149f26a7a57a3/CMakeLists.txt#L2391-L2394