### PR TITLE
aws-lc: do not use large buffer

### DIFF
--- a/lib/cf-h2-proxy.c
+++ b/lib/cf-h2-proxy.c
@@ -474,7 +474,7 @@ static CURLcode proxy_h2_progress_ingress(struct Curl_cfilter *cf,
                 Curl_bufq_len(&ctx->inbufq), result, nread);
     if(result) {
       if(result != CURLE_AGAIN) {
-        failf(data, "Failed receiving HTTP2 data");
+        failf(data, "Failed receiving HTTP2 proxy data");
         return result;
       }
       break;

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -128,8 +128,7 @@ static void ossl_provider_cleanup(struct Curl_easy *data);
  * with CURL_DBG_SOCK_RBLOCK=50. Looks like a bug on their part.
  */
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L && \
-  !defined(LIBRESSL_VERSION_NUMBER) && !defined(OPENSSL_IS_BORINGSSL) && \
-  !defined(OPENSSL_IS_AWSLC)
+  !defined(LIBRESSL_VERSION_NUMBER) && !defined(HAVE_BORINGSSL_LIKE)
 #define HAVE_SSL_CTX_SET_DEFAULT_READ_BUFFER_LEN 1
 #endif
 

--- a/lib/vtls/openssl.c
+++ b/lib/vtls/openssl.c
@@ -4128,9 +4128,13 @@ CURLcode Curl_ossl_ctx_init(struct ossl_ctx *octx,
 
      However using a large buffer (8 packets) actually decreases performance.
      4 packets is better.
-   */
 
-#ifdef HAVE_SSL_CTX_SET_DEFAULT_READ_BUFFER_LEN
+     AWS-LC seems to run into decryption failures with large buffers.
+     Sporadic failures in test_10_08 with h2 proxy uploads, increased
+     frequency with CURL_DBG_SOCK_RBLOCK=50.
+   */
+#if defined(HAVE_SSL_CTX_SET_DEFAULT_READ_BUFFER_LEN) && \
+    !defined(OPENSSL_IS_AWSLC)
   SSL_CTX_set_default_read_buffer_len(octx->ssl_ctx, 0x401e * 4);
 #endif
 

--- a/tests/http/test_10_proxy.py
+++ b/tests/http/test_10_proxy.py
@@ -226,11 +226,11 @@ class TestProxy:
                              extra_args=xargs)
         assert self.get_tunnel_proto_used(r) == tunnel
         r.check_response(count=count, http_status=200)
+        assert r.total_connects == 1, r.dump_logs()
         indata = open(srcfile).readlines()
         for i in range(count):
             respdata = open(curl.response_file(i)).readlines()
             assert respdata == indata, f'response {i} differs'
-        assert r.total_connects == 1, r.dump_logs()
 
     @pytest.mark.skipif(condition=not Env.have_ssl_curl(), reason="curl without SSL")
     @pytest.mark.parametrize("tunnel", ['http/1.1', 'h2'])


### PR DESCRIPTION
test_10_08, uploading larger files for a h2 proxy, sporadically fails with a decrpytion error on received data in AWS-LC. The frequency can be increased by simulated network receive blocks.

Not setting a 4 * TLS record sized buffer, leaving AWS-LC at its default buffer size seems to mitigate this problem.