### PR TITLE
tool: move the error buffer to the per transfer struct

### DIFF
--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -866,7 +866,7 @@ CURLcode config2setopts(struct OperationConfig *config,
   my_setopt_str(curl, CURLOPT_LOGIN_OPTIONS, config->login_options);
   my_setopt_str(curl, CURLOPT_USERPWD, config->userpwd);
   my_setopt_str(curl, CURLOPT_RANGE, config->range);
-  my_setopt(curl, CURLOPT_ERRORBUFFER, per->errorb);
+  my_setopt(curl, CURLOPT_ERRORBUFFER, per->errorbuffer);
   my_setopt_long(curl, CURLOPT_TIMEOUT_MS, config->timeout_ms);
 
   switch(config->httpreq) {

--- a/src/config2setopts.c
+++ b/src/config2setopts.c
@@ -40,9 +40,6 @@
 
 #define BUFFER_SIZE 102400L
 
-/* When doing serial transfers, we use a single fixed error area */
-static char global_errorbuffer[CURL_ERROR_SIZE];
-
 #ifdef IP_TOS
 static int get_address_family(curl_socket_t sockfd)
 {
@@ -869,10 +866,7 @@ CURLcode config2setopts(struct OperationConfig *config,
   my_setopt_str(curl, CURLOPT_LOGIN_OPTIONS, config->login_options);
   my_setopt_str(curl, CURLOPT_USERPWD, config->userpwd);
   my_setopt_str(curl, CURLOPT_RANGE, config->range);
-  if(!global->parallel) {
-    per->errorbuffer = global_errorbuffer;
-    my_setopt(curl, CURLOPT_ERRORBUFFER, global_errorbuffer);
-  }
+  my_setopt(curl, CURLOPT_ERRORBUFFER, per->errorb);
   my_setopt_long(curl, CURLOPT_TIMEOUT_MS, config->timeout_ms);
 
   switch(config->httpreq) {

--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -580,9 +580,9 @@ static CURLcode post_per_transfer(struct per_transfer *per,
 #endif
     if(!config->synthetic_error && result &&
        (!global->silent || global->showerror)) {
-      const char *msg = per->errorb;
+      const char *msg = per->errorbuffer;
       fprintf(tool_stderr, "curl: (%d) %s\n", result,
-              (msg && msg[0]) ? msg : curl_easy_strerror(result));
+              msg[0] ? msg : curl_easy_strerror(result));
       if(result == CURLE_PEER_FAILED_VERIFICATION)
         fputs(CURL_CA_CERT_ERRORMSG, tool_stderr);
     }
@@ -1388,7 +1388,7 @@ static CURLcode add_parallel_transfers(CURLM *multi, CURLSH *share,
     (void)curl_easy_setopt(per->curl, CURLOPT_XFERINFOFUNCTION, xferinfo_cb);
     (void)curl_easy_setopt(per->curl, CURLOPT_XFERINFODATA, per);
     (void)curl_easy_setopt(per->curl, CURLOPT_NOPROGRESS, 0L);
-    (void)curl_easy_setopt(per->curl, CURLOPT_ERRORBUFFER, per->errorb);
+    (void)curl_easy_setopt(per->curl, CURLOPT_ERRORBUFFER, per->errorbuffer);
 #ifdef DEBUGBUILD
     if(getenv("CURL_FORBID_REUSE"))
       (void)curl_easy_setopt(per->curl, CURLOPT_FORBID_REUSE, 1L);
@@ -1412,7 +1412,7 @@ static CURLcode add_parallel_transfers(CURLM *multi, CURLSH *share,
     if(result)
       return result;
 
-    per->errorb[0] = 0;
+    per->errorbuffer[0] = 0;
     per->added = TRUE;
     all_added++;
     *addedp = TRUE;
@@ -1698,7 +1698,7 @@ static CURLcode check_finished(struct parastate *s)
       curl_multi_remove_handle(s->multi, easy);
 
       if(ended->abort && (tres == CURLE_ABORTED_BY_CALLBACK)) {
-        msnprintf(ended->errorb, CURL_ERROR_SIZE,
+        msnprintf(ended->errorbuffer, CURL_ERROR_SIZE,
                   "Transfer aborted due to critical error "
                   "in another transfer");
       }

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -66,7 +66,7 @@ struct per_transfer {
 
   /* NULL or malloced */
   char *uploadfile;
-  char errorb[CURL_ERROR_SIZE];
+  char errorbuffer[CURL_ERROR_SIZE];
   BIT(infdopen); /* TRUE if infd needs closing */
   BIT(noprogress);
   BIT(was_last_header_empty);

--- a/src/tool_operate.h
+++ b/src/tool_operate.h
@@ -66,8 +66,7 @@ struct per_transfer {
 
   /* NULL or malloced */
   char *uploadfile;
-  char *errorbuffer; /* allocated and assigned while this is used for a
-                        transfer */
+  char errorb[CURL_ERROR_SIZE];
   BIT(infdopen); /* TRUE if infd needs closing */
   BIT(noprogress);
   BIT(was_last_header_empty);

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -361,7 +361,7 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
       break;
     case VAR_ERRORMSG:
       if(per_result) {
-        strinfo = (per->errorb[0]) ? per->errorb :
+        strinfo = (per->errorbuffer[0]) ? per->errorbuffer :
           curl_easy_strerror(per_result);
         valid = true;
       }

--- a/src/tool_writeout.c
+++ b/src/tool_writeout.c
@@ -361,8 +361,8 @@ static int writeString(FILE *stream, const struct writeoutvar *wovar,
       break;
     case VAR_ERRORMSG:
       if(per_result) {
-        strinfo = (per->errorbuffer && per->errorbuffer[0]) ?
-          per->errorbuffer : curl_easy_strerror(per_result);
+        strinfo = (per->errorb[0]) ? per->errorb :
+          curl_easy_strerror(per_result);
         valid = true;
       }
       break;


### PR DESCRIPTION
To avoid having to alloc or manage it separately.