### PR TITLE
tool_filetime: accept setting negative filetime

### DIFF
--- a/src/tool_filetime.c
+++ b/src/tool_filetime.c
@@ -88,7 +88,7 @@ int getfiletime(const char *filename, curl_off_t *stamp)
 #if defined(HAVE_UTIME) || defined(HAVE_UTIMES) || defined(_WIN32)
 void setfiletime(curl_off_t filetime, const char *filename)
 {
-  if(filetime >= 0) {
+  if(filetime) {
 /* Windows utime() may attempt to adjust the Unix GMT file time by a daylight
    saving time offset and since it is GMT that is bad behavior. When we have
    access to a 64-bit type we can bypass utime and set the times directly. */

--- a/tests/data/Makefile.am
+++ b/tests/data/Makefile.am
@@ -108,7 +108,8 @@ test718 test719 test720 test721 test722 test723 test724 test725 test726 \
 test727 test728 test729 test730 test731 test732 test733 test734 test735 \
 test736 test737 test738 test739 test740 test741 test742 test743 test744 \
 test745 test746 test747 test748 test749 test750 test751 test752 test753 \
-test754 test755 test756 test757 test758 test759 test760 test761 \
+test754 test755 test756 test757 test758 test759 test760 test761 test762 \
+\
 test780 test781 test782 test783 test784 test785 test786 test787 test788 \
 test789 test790 test791 test792 test793 test794 test795 test796 test797 \
 \

--- a/tests/data/test762
+++ b/tests/data/test762
@@ -1,0 +1,56 @@
+<testcase>
+<info>
+<keywords>
+HTTP
+HTTP GET
+--remote-time
+</keywords>
+</info>
+
+#
+<reply>
+<data nocheck="yes">
+HTTP/1.1 200 OK
+Date: Tue, 09 Nov 2010 14:49:00 GMT
+Server: test-server/fake
+Last-Modified: Wed, 09 Oct 1940 16:45:49 +0100
+Content-Length: 6
+Connection: close
+
+12345
+</data>
+</reply>
+
+#
+# Client-side
+<client>
+<server>
+http
+</server>
+<name>
+HTTP GET with --remote-time with file date from 1940
+</name>
+<command option="no-output,no-include">
+http://%HOSTIP:%HTTPPORT/%TESTNUMBER -O --remote-time --output-dir %LOGDIR
+</command>
+</client>
+
+#
+# Verify data after the test has been "shot"
+<verify>
+<protocol>
+GET /%TESTNUMBER HTTP/1.1
+Host: %HOSTIP:%HTTPPORT
+User-Agent: curl/%VERSION
+Accept: */*
+
+</protocol>
+<file name="%LOGDIR/%TESTNUMBER">
+12345
+</file>
+# Modify: 1940-10-09 16:45:49.000000000 +0100
+<postcheck>
+%PERL -e 'exit((stat("%LOGDIR/%TESTNUMBER"))[9] != -922349651)'
+</postcheck>
+</verify>
+</testcase>


### PR DESCRIPTION
This allows --remote-time to set dates before 1970.

Due to a minor omission in the API, it will still avoid setting the time if it is indeed exactly epoch 0 (jan 1 1970).

Verified by test 762

Fixes #18424
Reported-by: Terence Eden