### PR TITLE
Curl_http(), decomplexify

### DIFF
--- a/lib/http.c
+++ b/lib/http.c
@@ -2673,7 +2673,7 @@ typedef enum {
 #endif
   H1_HD_CONDITIONALS,
   H1_HD_CUSTOM,
-  H1_HD_LAST, /* not a header, just the last enum value for iterating */
+  H1_HD_LAST  /* not a header, just the last enum value for iterating */
 } http_hd_t;
 
 static CURLcode http_add_hd(struct Curl_easy *data,

--- a/lib/http.h
+++ b/lib/http.h
@@ -106,7 +106,7 @@ CURLcode Curl_add_custom_headers(struct Curl_easy *data, bool is_connect,
 CURLcode Curl_dynhds_add_custom(struct Curl_easy *data, bool is_connect,
                                 struct dynhds *hds);
 
-void Curl_http_method(struct Curl_easy *data, struct connectdata *conn,
+void Curl_http_method(struct Curl_easy *data,
                       const char **method, Curl_HttpReq *);
 
 /* protocol-specific functions set up to be called by the main engine */

--- a/lib/http2.c
+++ b/lib/http2.c
@@ -1820,8 +1820,9 @@ CURLcode Curl_http2_request_upgrade(struct dynbuf *req,
     return result;
   }
 
+  data->state.http_hd_upgrade = TRUE;
+  data->state.http_hd_h2_settings = TRUE;
   result = curlx_dyn_addf(req,
-                          "Connection: Upgrade, HTTP2-Settings\r\n"
                           "Upgrade: %s\r\n"
                           "HTTP2-Settings: %s\r\n",
                           NGHTTP2_CLEARTEXT_PROTO_VERSION_ID, base64);

--- a/lib/http_aws_sigv4.c
+++ b/lib/http_aws_sigv4.c
@@ -775,7 +775,7 @@ CURLcode Curl_output_aws_sigv4(struct Curl_easy *data)
     }
   }
 
-  Curl_http_method(data, conn, &method, &httpreq);
+  Curl_http_method(data, &method, &httpreq);
 
   payload_hash =
     parse_content_sha_hdr(data, curlx_str(&provider1),

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -162,9 +162,8 @@ static CURLcode dynhds_add_custom(struct Curl_easy *data,
                  we will force length zero then */
               hd_name_eq(name, namelen, STRCONST("Content-Length:")))
         ;
-      else if(data->state.aptr.te &&
-              /* when asking for Transfer-Encoding, do not pass on a custom
-                 Connection: */
+      else if(data->state.http_connection_hd_added &&
+              /* when Connection: header has already been added */
               hd_name_eq(name, namelen, STRCONST("Connection:")))
         ;
       else if((httpversion >= 20) &&

--- a/lib/http_proxy.c
+++ b/lib/http_proxy.c
@@ -162,10 +162,6 @@ static CURLcode dynhds_add_custom(struct Curl_easy *data,
                  we will force length zero then */
               hd_name_eq(name, namelen, STRCONST("Content-Length:")))
         ;
-      else if(data->state.http_connection_hd_added &&
-              /* when Connection: header has already been added */
-              hd_name_eq(name, namelen, STRCONST("Connection:")))
-        ;
       else if((httpversion >= 20) &&
               hd_name_eq(name, namelen, STRCONST("Transfer-Encoding:")))
         /* HTTP/2 and HTTP/3 do not support chunked requests */

--- a/lib/url.c
+++ b/lib/url.c
@@ -320,7 +320,6 @@ CURLcode Curl_close(struct Curl_easy **datap)
   Curl_safefree(data->state.aptr.uagent);
   Curl_safefree(data->state.aptr.userpwd);
   Curl_safefree(data->state.aptr.accept_encoding);
-  Curl_safefree(data->state.aptr.te);
   Curl_safefree(data->state.aptr.rangeline);
   Curl_safefree(data->state.aptr.ref);
   Curl_safefree(data->state.aptr.host);

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1177,7 +1177,11 @@ struct UrlState {
                     internal use and the user does not have ownership of the
                     handle. */
   BIT(http_ignorecustom); /* ignore custom method from now */
-  BIT(http_connection_hd_added); /* 'Connection: ' header already added */
+#ifndef CURL_DISABLE_HTTP
+  BIT(http_hd_te); /* Added HTTP header TE: */
+  BIT(http_hd_upgrade); /* Added HTTP header Upgrade: */
+  BIT(http_hd_h2_settings); /* Added HTTP header H2Settings: */
+#endif
 };
 
 /*

--- a/lib/urldata.h
+++ b/lib/urldata.h
@@ -1122,7 +1122,6 @@ struct UrlState {
 #ifndef CURL_DISABLE_RTSP
     char *rtsp_transport;
 #endif
-    char *te; /* TE: request header */
 
     /* transfer credentials */
     char *user;
@@ -1178,6 +1177,7 @@ struct UrlState {
                     internal use and the user does not have ownership of the
                     handle. */
   BIT(http_ignorecustom); /* ignore custom method from now */
+  BIT(http_connection_hd_added); /* 'Connection: ' header already added */
 };
 
 /*

--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1024,11 +1024,6 @@ CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req)
       "Upgrade", "websocket"
     },
     {
-      /* The request MUST contain a |Connection| header field whose value
-         MUST include the "Upgrade" token. */
-      "Connection", "Upgrade",
-    },
-    {
       /* The request MUST include a header field with the name
          |Sec-WebSocket-Version|. The value of this header field MUST be
          13. */
@@ -1043,7 +1038,7 @@ CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req)
       "Sec-WebSocket-Key", NULL,
     }
   };
-  heads[3].val = &keyval[0];
+  heads[2].val = &keyval[0];
 
   /* 16 bytes random */
   result = Curl_rand(data, (unsigned char *)rand, sizeof(rand));
@@ -1065,6 +1060,7 @@ CURLcode Curl_ws_request(struct Curl_easy *data, struct dynbuf *req)
                               heads[i].val);
     }
   }
+  data->state.http_hd_upgrade = TRUE;
   k->upgr101 = UPGR101_WS;
   return result;
 }

--- a/tests/data/test1122
+++ b/tests/data/test1122
@@ -66,8 +66,8 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: TE
 TE: gzip
+Connection: TE
 
 </protocol>
 </verify>

--- a/tests/data/test1123
+++ b/tests/data/test1123
@@ -176,8 +176,8 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: TE
 TE: gzip
+Connection: TE
 
 </protocol>
 </verify>

--- a/tests/data/test1124
+++ b/tests/data/test1124
@@ -67,8 +67,8 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: TE
 TE: gzip
+Connection: TE
 
 </protocol>
 </verify>

--- a/tests/data/test1125
+++ b/tests/data/test1125
@@ -66,8 +66,8 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: close, TE
 TE: gzip
+Connection: close, TE
 
 </protocol>
 </verify>

--- a/tests/data/test1170
+++ b/tests/data/test1170
@@ -66,8 +66,8 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: TE
 TE: gzip
+Connection: TE
 
 </protocol>
 </verify>

--- a/tests/data/test1171
+++ b/tests/data/test1171
@@ -66,8 +66,8 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: TE
 TE: gzip
+Connection: TE
 
 </protocol>
 </verify>

--- a/tests/data/test1277
+++ b/tests/data/test1277
@@ -183,9 +183,9 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: TE
 TE: gzip
 Accept-Encoding: xxx
+Connection: TE
 
 </protocol>
 </verify>

--- a/tests/data/test1546
+++ b/tests/data/test1546
@@ -52,8 +52,8 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: TE
 TE: gzip
+Connection: TE
 
 </protocol>
 <errorcode>

--- a/tests/data/test1704
+++ b/tests/data/test1704
@@ -52,9 +52,9 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: Upgrade, HTTP2-Settings
 Upgrade: h2c
 HTTP2-Settings: AAMAAABkAAQAAQAAAAIAAAAA
+Connection: Upgrade, HTTP2-Settings
 
 </protocol>
 

--- a/tests/data/test1800
+++ b/tests/data/test1800
@@ -47,9 +47,9 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: Upgrade, HTTP2-Settings
 Upgrade: %H2CVER
 HTTP2-Settings: AAMAAABkAAQAAQAAAAIAAAAA
+Connection: Upgrade, HTTP2-Settings
 
 </protocol>
 </verify>

--- a/tests/data/test2300
+++ b/tests/data/test2300
@@ -53,9 +53,9 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
 Upgrade: websocket
-Connection: Upgrade
 Sec-WebSocket-Version: 13
 Sec-WebSocket-Key: NDMyMTUzMjE2MzIxNzMyMQ==
+Connection: Upgrade
 
 </protocol>
 <errorcode>

--- a/tests/data/test2301
+++ b/tests/data/test2301
@@ -58,9 +58,9 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: webbie-sox/3
 Accept: */*
 Upgrade: websocket
-Connection: Upgrade
 Sec-WebSocket-Version: 13
 Sec-WebSocket-Key: NDMyMTUzMjE2MzIxNzMyMQ==
+Connection: Upgrade
 
 %hex[%8a%00]hex%
 </protocol>

--- a/tests/data/test2302
+++ b/tests/data/test2302
@@ -59,9 +59,9 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: webbie-sox/3
 Accept: */*
 Upgrade: websocket
-Connection: Upgrade
 Sec-WebSocket-Version: 13
 Sec-WebSocket-Key: NDMyMTUzMjE2MzIxNzMyMQ==
+Connection: Upgrade
 
 %hex[%8a%808321]hex%
 </protocol>

--- a/tests/data/test2303
+++ b/tests/data/test2303
@@ -49,9 +49,9 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: webbie-sox/3
 Accept: */*
 Upgrade: websocket
-Connection: Upgrade
 Sec-WebSocket-Version: 13
 Sec-WebSocket-Key: NDMyMTUzMjE2MzIxNzMyMQ==
+Connection: Upgrade
 
 </protocol>
 # 22 == CURLE_HTTP_RETURNED_ERROR

--- a/tests/data/test2304
+++ b/tests/data/test2304
@@ -58,9 +58,9 @@ Host: %HOSTIP:%HTTPPORT
 User-Agent: websocket/%TESTNUMBER
 Accept: */*
 Upgrade: websocket
-Connection: Upgrade
 Sec-WebSocket-Version: 13
 Sec-WebSocket-Key: NDMyMTUzMjE2MzIxNzMyMQ==
+Connection: Upgrade
 
 </protocol>
 

--- a/tests/data/test387
+++ b/tests/data/test387
@@ -43,8 +43,8 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: TE
 TE: gzip
+Connection: TE
 
 </protocol>
 

--- a/tests/data/test418
+++ b/tests/data/test418
@@ -51,8 +51,8 @@ GET /%TESTNUMBER HTTP/1.1
 Host: %HOSTIP:%HTTPPORT
 User-Agent: curl/%VERSION
 Accept: */*
-Connection: TE
 TE: gzip
+Connection: TE
 
 </protocol>
 


### PR DESCRIPTION
Split out adding of individual request headers into a switch. Check the connection http version only on fresh connections, use separate methods.

Add TE: header directly without allocation. Add bit for indicating Connection: header has been added and custom headers should not do that again.