### PR TITLE
parsedate: make Curl_getdate_capped able to return epoch

### DIFF
--- a/lib/altsvc.c
+++ b/lib/altsvc.c
@@ -187,13 +187,13 @@ static CURLcode altsvc_add(struct altsvcinfo *asi, const char *line)
   else {
     struct altsvc *as;
     char dbuf[MAX_ALTSVC_DATELEN + 1];
-    time_t expires;
+    time_t expires = 0;
 
     /* The date parser works on a null-terminated string. The maximum length
        is upheld by curlx_str_quotedword(). */
     memcpy(dbuf, curlx_str(&date), curlx_strlen(&date));
     dbuf[curlx_strlen(&date)] = 0;
-    expires = Curl_getdate_capped(dbuf);
+    Curl_getdate_capped(dbuf, &expires);
     as = altsvc_create(&srchost, &dsthost, &srcalpn, &dstalpn,
                        (size_t)srcport, (size_t)dstport);
     if(as) {

--- a/lib/parsedate.c
+++ b/lib/parsedate.c
@@ -589,26 +589,12 @@ time_t curl_getdate(const char *p, const time_t *now)
 
 /* Curl_getdate_capped() differs from curl_getdate() in that this will return
    TIME_T_MAX in case the parsed time value was too big, instead of an
-   error. */
+   error. Returns non-zero on error. */
 
-time_t Curl_getdate_capped(const char *p)
+int Curl_getdate_capped(const char *p, time_t *tp)
 {
-  time_t parsed = -1;
-  int rc = parsedate(p, &parsed);
-
-  switch(rc) {
-  case PARSEDATE_OK:
-    if(parsed == (time_t)-1)
-      /* avoid returning -1 for a working scenario */
-      parsed++;
-    return parsed;
-  case PARSEDATE_LATER:
-    /* this returns the maximum time value */
-    return parsed;
-  default:
-    return -1; /* everything else is fail */
-  }
-  /* UNREACHABLE */
+  int rc = parsedate(p, tp);
+  return (rc == PARSEDATE_FAIL);
 }
 
 /*

--- a/lib/parsedate.h
+++ b/lib/parsedate.h
@@ -29,10 +29,10 @@ extern const char * const Curl_month[12];
 
 CURLcode Curl_gmtime(time_t intime, struct tm *store);
 
-/* Curl_getdate_capped() differs from curl_getdate() in that this will return
+/* Curl_getdate_capped() differs from curl_getdate() in that this returns
    TIME_T_MAX in case the parsed time value was too big, instead of an
    error. */
 
-time_t Curl_getdate_capped(const char *p);
+int Curl_getdate_capped(const char *p, time_t *store);
 
 #endif /* HEADER_CURL_PARSEDATE_H */

--- a/lib/vssh/libssh.c
+++ b/lib/vssh/libssh.c
@@ -1855,9 +1855,9 @@ static int myssh_in_SFTP_QUOTE_STAT(struct Curl_easy *data,
   }
   else if(!strncmp(cmd, "atime", 5) ||
           !strncmp(cmd, "mtime", 5)) {
-    time_t date = Curl_getdate_capped(sshc->quote_path1);
+    time_t date;
     bool fail = FALSE;
-    if(date == -1) {
+    if(Curl_getdate_capped(sshc->quote_path1, &date)) {
       failf(data, "incorrect date format for %.*s", 5, cmd);
       fail = TRUE;
     }

--- a/lib/vssh/libssh2.c
+++ b/lib/vssh/libssh2.c
@@ -1390,16 +1390,16 @@ sftp_quote_stat(struct Curl_easy *data,
   }
   else if(!strncmp(cmd, "atime", 5) ||
           !strncmp(cmd, "mtime", 5)) {
-    time_t date = Curl_getdate_capped(sshc->quote_path1);
+    time_t date;
     bool fail = FALSE;
 
-    if(date == -1) {
+    if(Curl_getdate_capped(sshc->quote_path1, &date)) {
       failf(data, "incorrect date format for %.*s", 5, cmd);
       fail = TRUE;
     }
 #if SIZEOF_TIME_T > SIZEOF_LONG
     if(date > 0xffffffff) {
-      /* if 'long' cannot old >32-bit, this date cannot be sent */
+      /* if 'long' cannot hold >32-bit, this date cannot be sent */
       failf(data, "date overflow");
       fail = TRUE;
     }


### PR DESCRIPTION
By returning error separately on parse errors and avoiding magic numbers, this function can now return 0 or -1 as proper dates when such a date string is provided.