### PR TITLE
tool_filetime: correct the conditions

### DIFF
--- a/src/tool_operate.c
+++ b/src/tool_operate.c
@@ -679,7 +679,8 @@ static CURLcode post_per_transfer(struct per_transfer *per,
     /* Ask libcurl if we got a remote file time */
     curl_off_t filetime = -1;
     curl_easy_getinfo(curl, CURLINFO_FILETIME_T, &filetime);
-    setfiletime(filetime, outs->filename);
+    if(filetime != -1)
+      setfiletime(filetime, outs->filename);
   }
 skip:
   /* Write the --write-out data before cleanup but after result is final */


### PR DESCRIPTION
The libcurl API for CURLINFO_FILETIME_T clearly says it contains -1 if not set. Everything else is a valid time stamp so use that.

Follow-up to 54f1ef05d672453d75a5fc60