### PR TITLE
CURLINFO_FILETIME*.md: correct the examples

### DIFF
--- a/docs/libcurl/opts/CURLINFO_FILETIME.md
+++ b/docs/libcurl/opts/CURLINFO_FILETIME.md
@@ -58,7 +58,7 @@ int main(void)
     if(CURLE_OK == res) {
       long filetime = 0;
       res = curl_easy_getinfo(curl, CURLINFO_FILETIME, &filetime);
-      if((CURLE_OK == res) && (filetime >= 0)) {
+      if((CURLE_OK == res) && (filetime != -1)) {
         time_t file_time = (time_t)filetime;
         printf("filetime: %s", ctime(&file_time));
       }

--- a/docs/libcurl/opts/CURLINFO_FILETIME_T.md
+++ b/docs/libcurl/opts/CURLINFO_FILETIME_T.md
@@ -59,7 +59,7 @@ int main(void)
     if(CURLE_OK == res) {
       curl_off_t filetime;
       res = curl_easy_getinfo(curl, CURLINFO_FILETIME_T, &filetime);
-      if((CURLE_OK == res) && (filetime >= 0)) {
+      if((CURLE_OK == res) && (filetime != -1)) {
         time_t file_time = (time_t)filetime;
         printf("filetime: %s", ctime(&file_time));
       }


### PR DESCRIPTION
Only -1 means bad value, all others are acceptable.

Ref: #18424