### PR TITLE
docs: fix typo (staring -> starting)

### DIFF
--- a/docs/cmdline-opts/retry-delay.md
+++ b/docs/cmdline-opts/retry-delay.md
@@ -23,6 +23,6 @@ used. Setting this delay to zero makes curl use the default backoff time.
 
 By default, curl uses an exponentially increasing timeout between retries.
 
-Staring in curl 8.16.0, this option accepts a time as decimal number for parts
+Starting in curl 8.16.0, this option accepts a time as decimal number for parts
 of seconds. The decimal value needs to be provided using a dot (.) as decimal
 separator - not the local version even if it might be using another separator.

--- a/docs/cmdline-opts/retry-max-time.md
+++ b/docs/cmdline-opts/retry-max-time.md
@@ -23,6 +23,6 @@ while performing, it may take longer than this given time period. To limit a
 single request's maximum time, use --max-time. Set this option to zero to not
 timeout retries.
 
-Staring in curl 8.16.0, this option accepts a time as decimal number for parts
+Starting in curl 8.16.0, this option accepts a time as decimal number for parts
 of seconds. The decimal value needs to be provided using a dot (.) as decimal
 separator - not the local version even if it might be using another separator.

--- a/docs/examples/websocket-updown.c
+++ b/docs/examples/websocket-updown.c
@@ -68,7 +68,7 @@ static size_t readcb(char *buf, size_t nitems, size_t buflen, void *p)
     result = curl_ws_start_frame(ctx->easy, CURLWS_TEXT,
                                  (curl_off_t)ctx->blen);
     if(result) {
-      fprintf(stderr, "error staring frame: %d\n", result);
+      fprintf(stderr, "error starting frame: %d\n", result);
       return CURL_READFUNC_ABORT;
     }
   }

--- a/docs/libcurl/curl_ws_start_frame.md
+++ b/docs/libcurl/curl_ws_start_frame.md
@@ -84,7 +84,7 @@ static size_t readcb(char *buf, size_t nitems, size_t buflen, void *p)
     result = curl_ws_start_frame(ctx->easy, CURLWS_TEXT,
                                  (curl_off_t)ctx->msg_len);
     if(result) {
-      fprintf(stderr, "error staring frame: %d\n", result);
+      fprintf(stderr, "error starting frame: %d\n", result);
       return CURL_READFUNC_ABORT;
     }
   }


### PR DESCRIPTION
I noticed the typo in the [`--retry-max-time` docs](https://curl.se/docs/manpage.html#--retry-max-time) and decide to do a quick search for `staring` which lead to three more places where this typo made its way into the docs.