### PR TITLE
windows: replace `_beginthreadex()` with `CreateThread()`

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -640,6 +640,12 @@
 #endif
 #endif
 
+#if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
+#define CURL_THREAD_RETURN_T DWORD
+#else
+#define CURL_THREAD_RETURN_T unsigned int
+#endif
+
 /*
  * Arg 2 type for gethostname in case it has not been defined in config file.
  */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -642,8 +642,10 @@
 
 #if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
 #define CURL_THREAD_RETURN_T DWORD
+typedef HANDLE curl_win_thread_handle_t;
 #else
 #define CURL_THREAD_RETURN_T unsigned int
+typedef uintptr_t curl_win_thread_handle_t;
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -646,8 +646,10 @@ typedef HANDLE curl_win_thread_handle_t;
 #define CURL_WIN_BEGINTHREAD CreateThread
 #else
 #define CURL_THREAD_RETURN_T unsigned int
+#ifdef _WIN32
 typedef uintptr_t curl_win_thread_handle_t;
 #define CURL_WIN_BEGINTHREAD _beginthreadex
+#endif /* _WIN32 */
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -642,11 +642,13 @@
 
 #if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
 #define CURL_THREAD_RETURN_T DWORD
+#define CURL_WIN_THREADFUNC WINAPI
 typedef HANDLE curl_win_thread_handle_t;
 #define CURL_WIN_BEGINTHREAD CreateThread
 #else
 #define CURL_THREAD_RETURN_T unsigned int
 #ifdef _WIN32
+#define CURL_WIN_THREADFUNC __stdcall
 typedef uintptr_t curl_win_thread_handle_t;
 #define CURL_WIN_BEGINTHREAD _beginthreadex
 #endif /* _WIN32 */

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -643,9 +643,11 @@
 #if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
 #define CURL_THREAD_RETURN_T DWORD
 typedef HANDLE curl_win_thread_handle_t;
+#define CURL_WIN_BEGINTHREAD CreateThread
 #else
 #define CURL_THREAD_RETURN_T unsigned int
 typedef uintptr_t curl_win_thread_handle_t;
+#define CURL_WIN_BEGINTHREAD _beginthreadex
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -642,9 +642,6 @@
 
 #ifdef _WIN32
 #define CURL_THREAD_RETURN_T DWORD
-#define CURL_WIN_THREADFUNC WINAPI
-typedef HANDLE curl_win_thread_handle_t;
-#define CURL_WIN_BEGINTHREAD CreateThread
 #else
 #define CURL_THREAD_RETURN_T unsigned int
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -640,18 +640,13 @@
 #endif
 #endif
 
-#if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
+#ifdef _WIN32
 #define CURL_THREAD_RETURN_T DWORD
 #define CURL_WIN_THREADFUNC WINAPI
 typedef HANDLE curl_win_thread_handle_t;
 #define CURL_WIN_BEGINTHREAD CreateThread
 #else
 #define CURL_THREAD_RETURN_T unsigned int
-#ifdef _WIN32
-#define CURL_WIN_THREADFUNC __stdcall
-typedef uintptr_t curl_win_thread_handle_t;
-#define CURL_WIN_BEGINTHREAD _beginthreadex
-#endif /* _WIN32 */
 #endif
 
 /*

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -640,12 +640,6 @@
 #endif
 #endif
 
-#ifdef _WIN32
-#define CURL_THREAD_RETURN_T DWORD
-#else
-#define CURL_THREAD_RETURN_T unsigned int
-#endif
-
 /*
  * Arg 2 type for gethostname in case it has not been defined in config file.
  */

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -129,9 +129,7 @@ int Curl_thread_cancel(curl_thread_t *hnd)
 curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
                                  (CURL_STDCALL *func) (void *), void *arg)
 {
-  curl_thread_t t;
-  HANDLE thread_handle = CreateThread(NULL, 0, func, arg, 0, NULL);
-  t = (curl_thread_t)thread_handle;
+  curl_thread_t t = CreateThread(NULL, 0, func, arg, 0, NULL);
   if((t == 0) || (t == LongToHandle(-1L))) {
 #ifdef UNDER_CE
     DWORD gle = GetLastError();

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -133,11 +133,6 @@ int Curl_thread_cancel(curl_thread_t *hnd)
 curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
                                  (CURL_STDCALL *func) (void *), void *arg)
 {
-#if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
-  typedef HANDLE curl_win_thread_handle_t;
-#else
-  typedef uintptr_t curl_win_thread_handle_t;
-#endif
   curl_thread_t t;
   curl_win_thread_handle_t thread_handle;
 #if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -26,12 +26,8 @@
 
 #include <curl/curl.h>
 
-#ifdef USE_THREADS_POSIX
-#  ifdef HAVE_PTHREAD_H
-#    include <pthread.h>
-#  endif
-#elif defined(USE_THREADS_WIN32)
-#  include <process.h>
+#if defined(USE_THREADS_POSIX) && defined(HAVE_PTHREAD_H)
+#include <pthread.h>
 #endif
 
 #include "curl_threads.h"
@@ -134,8 +130,7 @@ curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
                                  (CURL_STDCALL *func) (void *), void *arg)
 {
   curl_thread_t t;
-  curl_win_thread_handle_t thread_handle;
-  thread_handle = CURL_WIN_BEGINTHREAD(NULL, 0, func, arg, 0, NULL);
+  HANDLE thread_handle = CreateThread(NULL, 0, func, arg, 0, NULL);
   t = (curl_thread_t)thread_handle;
   if((t == 0) || (t == LongToHandle(-1L))) {
 #ifdef UNDER_CE

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -161,7 +161,7 @@ void Curl_thread_destroy(curl_thread_t *hnd)
 
 int Curl_thread_join(curl_thread_t *hnd)
 {
-#if !defined(_WIN32_WINNT) || (_WIN32_WINNT < _WIN32_WINNT_VISTA)
+#ifdef UNDER_CE
   int ret = (WaitForSingleObject(*hnd, INFINITE) == WAIT_OBJECT_0);
 #else
   int ret = (WaitForSingleObjectEx(*hnd, INFINITE, FALSE) == WAIT_OBJECT_0);

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -130,7 +130,7 @@ curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
                                  (CURL_STDCALL *func) (void *), void *arg)
 {
   curl_thread_t t = CreateThread(NULL, 0, func, arg, 0, NULL);
-  if((t == 0) || (t == LongToHandle(-1L))) {
+  if(!t) {
 #ifdef UNDER_CE
     DWORD gle = GetLastError();
     /* !checksrc! disable ERRNOVAR 1 */

--- a/lib/curl_threads.c
+++ b/lib/curl_threads.c
@@ -135,11 +135,7 @@ curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T
 {
   curl_thread_t t;
   curl_win_thread_handle_t thread_handle;
-#if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
-  thread_handle = CreateThread(NULL, 0, func, arg, 0, NULL);
-#else
-  thread_handle = _beginthreadex(NULL, 0, func, arg, 0, NULL);
-#endif
+  thread_handle = CURL_WIN_BEGINTHREAD(NULL, 0, func, arg, 0, NULL);
   t = (curl_thread_t)thread_handle;
   if((t == 0) || (t == LongToHandle(-1L))) {
 #ifdef UNDER_CE

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -35,7 +35,7 @@
 #  define Curl_mutex_release(m)  pthread_mutex_unlock(m)
 #  define Curl_mutex_destroy(m)  pthread_mutex_destroy(m)
 #elif defined(USE_THREADS_WIN32)
-#  define CURL_STDCALL           __stdcall
+#  define CURL_STDCALL           CURL_WIN_THREADFUNC
 #  define curl_mutex_t           CRITICAL_SECTION
 #  define curl_thread_t          HANDLE
 #  define curl_thread_t_null     (HANDLE)0

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -51,12 +51,6 @@
 #  define CURL_STDCALL
 #endif
 
-#if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
-#define CURL_THREAD_RETURN_T DWORD
-#else
-#define CURL_THREAD_RETURN_T unsigned int
-#endif
-
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
 
 curl_thread_t Curl_thread_create(CURL_THREAD_RETURN_T

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -49,8 +49,6 @@
 #  define Curl_mutex_acquire(m)  EnterCriticalSection(m)
 #  define Curl_mutex_release(m)  LeaveCriticalSection(m)
 #  define Curl_mutex_destroy(m)  DeleteCriticalSection(m)
-#else
-#  define CURL_STDCALL
 #endif
 
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -35,7 +35,7 @@
 #  define Curl_mutex_release(m)  pthread_mutex_unlock(m)
 #  define Curl_mutex_destroy(m)  pthread_mutex_destroy(m)
 #elif defined(USE_THREADS_WIN32)
-#  define CURL_STDCALL           CURL_WIN_THREADFUNC
+#  define CURL_STDCALL           WINAPI
 #  define curl_mutex_t           CRITICAL_SECTION
 #  define curl_thread_t          HANDLE
 #  define curl_thread_t_null     (HANDLE)0

--- a/lib/curl_threads.h
+++ b/lib/curl_threads.h
@@ -26,6 +26,7 @@
 #include "curl_setup.h"
 
 #ifdef USE_THREADS_POSIX
+#  define CURL_THREAD_RETURN_T   unsigned int
 #  define CURL_STDCALL
 #  define curl_mutex_t           pthread_mutex_t
 #  define curl_thread_t          pthread_t *
@@ -35,6 +36,7 @@
 #  define Curl_mutex_release(m)  pthread_mutex_unlock(m)
 #  define Curl_mutex_destroy(m)  pthread_mutex_destroy(m)
 #elif defined(USE_THREADS_WIN32)
+#  define CURL_THREAD_RETURN_T   DWORD
 #  define CURL_STDCALL           WINAPI
 #  define curl_mutex_t           CRITICAL_SECTION
 #  define curl_thread_t          HANDLE

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -26,8 +26,7 @@
 #define NUM_THREADS 100
 
 #ifdef _WIN32
-#include <process.h>
-static CURL_THREAD_RETURN_T CURL_WIN_THREADFUNC t3026_run_thread(void *ptr)
+static CURL_THREAD_RETURN_T WINAPI t3026_run_thread(void *ptr)
 {
   CURLcode *result = ptr;
 
@@ -41,7 +40,7 @@ static CURL_THREAD_RETURN_T CURL_WIN_THREADFUNC t3026_run_thread(void *ptr)
 static CURLcode test_lib3026(const char *URL)
 {
   CURLcode results[NUM_THREADS];
-  curl_win_thread_handle_t thread_handles[NUM_THREADS];
+  HANDLE thread_handles[NUM_THREADS];
   unsigned tid_count = NUM_THREADS, i;
   CURLcode test_failure = CURLE_OK;
   curl_version_info_data *ver;
@@ -56,9 +55,9 @@ static CURLcode test_lib3026(const char *URL)
   }
 
   for(i = 0; i < tid_count; i++) {
-    curl_win_thread_handle_t th;
+    HANDLE th;
     results[i] = CURL_LAST; /* initialize with invalid value */
-    th = CURL_WIN_BEGINTHREAD(NULL, 0, t3026_run_thread, &results[i], 0, NULL);
+    th = CreateThread(NULL, 0, t3026_run_thread, &results[i], 0, NULL);
     if(!th) {
       curl_mfprintf(stderr, "%s:%d Couldn't create thread, errno %lu\n",
                     __FILE__, __LINE__, GetLastError());

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -27,7 +27,7 @@
 
 #ifdef _WIN32
 #include <process.h>
-static CURL_THREAD_RETURN_T WINAPI t3026_run_thread(void *ptr)
+static CURL_THREAD_RETURN_T __stdcall t3026_run_thread(void *ptr)
 {
   CURLcode *result = ptr;
 

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -70,8 +70,8 @@ static CURLcode test_lib3026(const char *URL)
 
 cleanup:
   for(i = 0; i < tid_count; i++) {
-    WaitForSingleObject((HANDLE)thread_handles[i], INFINITE);
-    CloseHandle((HANDLE)thread_handles[i]);
+    WaitForSingleObject(thread_handles[i], INFINITE);
+    CloseHandle(thread_handles[i]);
     if(results[i] != CURLE_OK) {
       curl_mfprintf(stderr, "%s:%d thread[%u]: curl_global_init() failed,"
                     "with code %d (%s)\n", __FILE__, __LINE__,

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -26,7 +26,7 @@
 #define NUM_THREADS 100
 
 #ifdef _WIN32
-static CURL_THREAD_RETURN_T WINAPI t3026_run_thread(void *ptr)
+static DWORD WINAPI t3026_run_thread(void *ptr)
 {
   CURLcode *result = ptr;
 

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -26,12 +26,8 @@
 #define NUM_THREADS 100
 
 #ifdef _WIN32
-#if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
-static DWORD WINAPI t3026_run_thread(LPVOID ptr)
-#else
 #include <process.h>
-static unsigned int WINAPI t3026_run_thread(void *ptr)
-#endif
+static CURL_THREAD_RETURN_T WINAPI t3026_run_thread(void *ptr)
 {
   CURLcode *result = ptr;
 

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -27,7 +27,7 @@
 
 #ifdef _WIN32
 #include <process.h>
-static CURL_THREAD_RETURN_T __stdcall t3026_run_thread(void *ptr)
+static CURL_THREAD_RETURN_T CURL_WIN_THREADFUNC t3026_run_thread(void *ptr)
 {
   CURLcode *result = ptr;
 

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -40,11 +40,6 @@ static CURL_THREAD_RETURN_T __stdcall t3026_run_thread(void *ptr)
 
 static CURLcode test_lib3026(const char *URL)
 {
-#if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
-  typedef HANDLE curl_win_thread_handle_t;
-#else
-  typedef uintptr_t curl_win_thread_handle_t;
-#endif
   CURLcode results[NUM_THREADS];
   curl_win_thread_handle_t thread_handles[NUM_THREADS];
   unsigned tid_count = NUM_THREADS, i;

--- a/tests/libtest/lib3026.c
+++ b/tests/libtest/lib3026.c
@@ -58,11 +58,7 @@ static CURLcode test_lib3026(const char *URL)
   for(i = 0; i < tid_count; i++) {
     curl_win_thread_handle_t th;
     results[i] = CURL_LAST; /* initialize with invalid value */
-#if defined(CURL_WINDOWS_UWP) || defined(UNDER_CE)
-    th = CreateThread(NULL, 0, t3026_run_thread, &results[i], 0, NULL);
-#else
-    th = _beginthreadex(NULL, 0, t3026_run_thread, &results[i], 0, NULL);
-#endif
+    th = CURL_WIN_BEGINTHREAD(NULL, 0, t3026_run_thread, &results[i], 0, NULL);
     if(!th) {
       curl_mfprintf(stderr, "%s:%d Couldn't create thread, errno %lu\n",
                     __FILE__, __LINE__, GetLastError());

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -68,7 +68,11 @@ static size_t write_memory_callback(char *contents, size_t size,
   return realsize;
 }
 
+#if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
 static CURL_THREAD_RETURN_T CURL_STDCALL test_thread(void *ptr)
+#else
+static void test_thread(void *ptr)
+#endif
 {
   struct Ctx *ctx = (struct Ctx *)ptr;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -68,11 +68,13 @@ static size_t write_memory_callback(char *contents, size_t size,
   return realsize;
 }
 
+static
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
-static CURL_THREAD_RETURN_T CURL_STDCALL test_thread(void *ptr)
+CURL_THREAD_RETURN_T CURL_STDCALL
 #else
-static unsigned int test_thread(void *ptr)
+unsigned int
 #endif
+test_thread(void *ptr)
 {
   struct Ctx *ctx = (struct Ctx *)ptr;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -68,13 +68,11 @@ static size_t write_memory_callback(char *contents, size_t size,
   return realsize;
 }
 
-static
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
-CURL_THREAD_RETURN_T CURL_STDCALL
+static CURL_THREAD_RETURN_T CURL_STDCALL test_thread(void *ptr)
 #else
-unsigned int
+static unsigned int test_thread(void *ptr)
 #endif
-test_thread(void *ptr)
 {
   struct Ctx *ctx = (struct Ctx *)ptr;
   CURLcode res = CURLE_OK;

--- a/tests/libtest/lib3207.c
+++ b/tests/libtest/lib3207.c
@@ -71,7 +71,7 @@ static size_t write_memory_callback(char *contents, size_t size,
 #if defined(USE_THREADS_POSIX) || defined(USE_THREADS_WIN32)
 static CURL_THREAD_RETURN_T CURL_STDCALL test_thread(void *ptr)
 #else
-static void test_thread(void *ptr)
+static unsigned int test_thread(void *ptr)
 #endif
 {
   struct Ctx *ctx = (struct Ctx *)ptr;

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -413,7 +413,8 @@ struct select_ws_wait_data {
   HANDLE abort;  /* internal event to abort waiting threads */
 };
 #include <process.h>
-static unsigned int WINAPI select_ws_wait_thread(void *lpParameter)
+static
+unsigned int CURL_WIN_THREADFUNC select_ws_wait_thread(void *lpParameter)
 {
   struct select_ws_wait_data *data;
   HANDLE signal, handle, handles[2];

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -557,7 +557,6 @@ static unsigned int WINAPI select_ws_wait_thread(void *lpParameter)
 
 static HANDLE select_ws_wait(HANDLE handle, HANDLE signal, HANDLE abort)
 {
-  typedef uintptr_t curl_win_thread_handle_t;
   struct select_ws_wait_data *data;
   curl_win_thread_handle_t thread;
 

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -413,8 +413,8 @@ struct select_ws_wait_data {
   HANDLE abort;  /* internal event to abort waiting threads */
 };
 #include <process.h>
-static
-unsigned int CURL_WIN_THREADFUNC select_ws_wait_thread(void *lpParameter)
+static CURL_THREAD_RETURN_T
+CURL_WIN_THREADFUNC select_ws_wait_thread(void *lpParameter)
 {
   struct select_ws_wait_data *data;
   HANDLE signal, handle, handles[2];

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -568,7 +568,8 @@ static HANDLE select_ws_wait(HANDLE handle, HANDLE signal, HANDLE abort)
     data->abort = abort;
 
     /* launch waiting thread */
-    thread = _beginthreadex(NULL, 0, &select_ws_wait_thread, data, 0, NULL);
+    thread = CURL_WIN_BEGINTHREAD(NULL, 0, &select_ws_wait_thread, data, 0,
+                                  NULL);
 
     /* free data if thread failed to launch */
     if(!thread) {

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -557,11 +557,12 @@ static DWORD WINAPI select_ws_wait_thread(void *lpParameter)
 static HANDLE select_ws_wait(HANDLE handle, HANDLE signal, HANDLE abort)
 {
   struct select_ws_wait_data *data;
-  HANDLE thread;
 
   /* allocate internal waiting data structure */
   data = malloc(sizeof(struct select_ws_wait_data));
   if(data) {
+    HANDLE thread;
+
     data->handle = handle;
     data->signal = signal;
     data->abort = abort;
@@ -573,7 +574,7 @@ static HANDLE select_ws_wait(HANDLE handle, HANDLE signal, HANDLE abort)
     if(!thread) {
       free(data);
     }
-    return (HANDLE)thread;
+    return thread;
   }
   return NULL;
 }

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -412,9 +412,7 @@ struct select_ws_wait_data {
   HANDLE signal; /* internal event to signal handle trigger */
   HANDLE abort;  /* internal event to abort waiting threads */
 };
-#include <process.h>
-static CURL_THREAD_RETURN_T
-CURL_WIN_THREADFUNC select_ws_wait_thread(void *lpParameter)
+static CURL_THREAD_RETURN_T WINAPI select_ws_wait_thread(void *lpParameter)
 {
   struct select_ws_wait_data *data;
   HANDLE signal, handle, handles[2];
@@ -559,7 +557,7 @@ CURL_WIN_THREADFUNC select_ws_wait_thread(void *lpParameter)
 static HANDLE select_ws_wait(HANDLE handle, HANDLE signal, HANDLE abort)
 {
   struct select_ws_wait_data *data;
-  curl_win_thread_handle_t thread;
+  HANDLE thread;
 
   /* allocate internal waiting data structure */
   data = malloc(sizeof(struct select_ws_wait_data));
@@ -569,8 +567,7 @@ static HANDLE select_ws_wait(HANDLE handle, HANDLE signal, HANDLE abort)
     data->abort = abort;
 
     /* launch waiting thread */
-    thread = CURL_WIN_BEGINTHREAD(NULL, 0, &select_ws_wait_thread, data, 0,
-                                  NULL);
+    thread = CreateThread(NULL, 0, &select_ws_wait_thread, data, 0, NULL);
 
     /* free data if thread failed to launch */
     if(!thread) {

--- a/tests/server/sockfilt.c
+++ b/tests/server/sockfilt.c
@@ -412,7 +412,7 @@ struct select_ws_wait_data {
   HANDLE signal; /* internal event to signal handle trigger */
   HANDLE abort;  /* internal event to abort waiting threads */
 };
-static CURL_THREAD_RETURN_T WINAPI select_ws_wait_thread(void *lpParameter)
+static DWORD WINAPI select_ws_wait_thread(void *lpParameter)
 {
   struct select_ws_wait_data *data;
   HANDLE signal, handle, handles[2];

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -623,7 +623,7 @@ void install_signal_handlers(bool keep_sigalrm)
 
 #if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
   thread_main_window = CreateThread(NULL, 0, &main_window_loop,
-                                    (void *)GetModuleHandle(NULL), 0,
+                                    GetModuleHandle(NULL), 0,
                                     &thread_main_id);
   if(!thread_main_window || !thread_main_id)
     logmsg("cannot start main window loop");

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -625,8 +625,9 @@ void install_signal_handlers(bool keep_sigalrm)
 #if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
   {
     curl_win_thread_handle_t thread;
-    thread = _beginthreadex(NULL, 0, &main_window_loop,
-                            (void *)GetModuleHandle(NULL), 0, &thread_main_id);
+    thread = CURL_WIN_BEGINTHREAD(NULL, 0, &main_window_loop,
+                                  (void *)GetModuleHandle(NULL), 0,
+                                  &thread_main_id);
     thread_main_window = (HANDLE)thread;
     if(!thread_main_window || !thread_main_id)
       logmsg("cannot start main window loop");

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -624,7 +624,6 @@ void install_signal_handlers(bool keep_sigalrm)
 
 #if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
   {
-    typedef uintptr_t curl_win_thread_handle_t;
     curl_win_thread_handle_t thread;
     thread = _beginthreadex(NULL, 0, &main_window_loop,
                             (void *)GetModuleHandle(NULL), 0, &thread_main_id);

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -509,7 +509,7 @@ static unsigned int WINAPI main_window_loop(void *lpParameter)
                                       CW_USEDEFAULT, CW_USEDEFAULT,
                                       CW_USEDEFAULT, CW_USEDEFAULT,
                                       (HWND)NULL, (HMENU)NULL,
-                                      wc.hInstance, (LPVOID)NULL);
+                                      wc.hInstance, NULL);
   if(!hidden_main_window) {
     win32_perror("CreateWindowEx failed");
     return (DWORD)-1;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -623,8 +623,7 @@ void install_signal_handlers(bool keep_sigalrm)
 
 #if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
   thread_main_window = CreateThread(NULL, 0, &main_window_loop,
-                                    GetModuleHandle(NULL), 0,
-                                    &thread_main_id);
+                                    GetModuleHandle(NULL), 0, &thread_main_id);
   if(!thread_main_window || !thread_main_id)
     logmsg("cannot start main window loop");
 #endif

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -488,7 +488,8 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
 /* Window message queue loop for hidden main window, details see above.
  */
 #include <process.h>
-static CURL_THREAD_RETURN_T WINAPI main_window_loop(void *lpParameter)
+static
+CURL_THREAD_RETURN_T CURL_WIN_THREADFUNC main_window_loop(void *lpParameter)
 {
   WNDCLASS wc;
   BOOL ret;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -350,7 +350,7 @@ static SIGHANDLER_T old_sigbreak_handler = SIG_ERR;
 #endif
 
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
-static CURL_THREAD_RETURN_T thread_main_id = 0;
+static DWORD thread_main_id = 0;
 static HANDLE thread_main_window = NULL;
 static HWND hidden_main_window = NULL;
 #endif
@@ -487,7 +487,7 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
 }
 /* Window message queue loop for hidden main window, details see above.
  */
-static CURL_THREAD_RETURN_T WINAPI main_window_loop(void *lpParameter)
+static DWORD WINAPI main_window_loop(void *lpParameter)
 {
   WNDCLASS wc;
   BOOL ret;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -622,14 +622,11 @@ void install_signal_handlers(bool keep_sigalrm)
 #endif
 
 #if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
-  {
-    HANDLE thread = CreateThread(NULL, 0, &main_window_loop,
-                                 (void *)GetModuleHandle(NULL), 0,
-                                 &thread_main_id);
-    thread_main_window = (HANDLE)thread;
-    if(!thread_main_window || !thread_main_id)
-      logmsg("cannot start main window loop");
-  }
+  thread_main_window = CreateThread(NULL, 0, &main_window_loop,
+                                    (void *)GetModuleHandle(NULL), 0,
+                                    &thread_main_id);
+  if(!thread_main_window || !thread_main_id)
+    logmsg("cannot start main window loop");
 #endif
 #endif
 }

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -350,7 +350,7 @@ static SIGHANDLER_T old_sigbreak_handler = SIG_ERR;
 #endif
 
 #if defined(_WIN32) && !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
-static unsigned int thread_main_id = 0;
+static CURL_THREAD_RETURN_T thread_main_id = 0;
 static HANDLE thread_main_window = NULL;
 static HWND hidden_main_window = NULL;
 #endif
@@ -488,7 +488,7 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
 /* Window message queue loop for hidden main window, details see above.
  */
 #include <process.h>
-static unsigned int WINAPI main_window_loop(void *lpParameter)
+static CURL_THREAD_RETURN_T WINAPI main_window_loop(void *lpParameter)
 {
   WNDCLASS wc;
   BOOL ret;

--- a/tests/server/util.c
+++ b/tests/server/util.c
@@ -487,9 +487,7 @@ static LRESULT CALLBACK main_window_proc(HWND hwnd, UINT uMsg,
 }
 /* Window message queue loop for hidden main window, details see above.
  */
-#include <process.h>
-static
-CURL_THREAD_RETURN_T CURL_WIN_THREADFUNC main_window_loop(void *lpParameter)
+static CURL_THREAD_RETURN_T WINAPI main_window_loop(void *lpParameter)
 {
   WNDCLASS wc;
   BOOL ret;
@@ -625,10 +623,9 @@ void install_signal_handlers(bool keep_sigalrm)
 
 #if !defined(CURL_WINDOWS_UWP) && !defined(UNDER_CE)
   {
-    curl_win_thread_handle_t thread;
-    thread = CURL_WIN_BEGINTHREAD(NULL, 0, &main_window_loop,
-                                  (void *)GetModuleHandle(NULL), 0,
-                                  &thread_main_id);
+    HANDLE thread = CreateThread(NULL, 0, &main_window_loop,
+                                 (void *)GetModuleHandle(NULL), 0,
+                                 &thread_main_id);
     thread_main_window = (HANDLE)thread;
     if(!thread_main_window || !thread_main_id)
       logmsg("cannot start main window loop");


### PR DESCRIPTION
Replace `_beginthreadex()` C runtime calls with native win32 API
`CreateThread()`. The latter was already used in `src/tool_doswin.c`
and in UWP and Windows CE builds before this patch. After this patch
all Windows flavors use it. To drop PP logic and simplify code.

While working on this it turned out that `src/tool_doswin.c` calls
`TerminateThread()`, which isn't recommended by the documentation,
except for "the most extreme cases". This patch makes no attempt
to change that code.
Ref: 9a2663322c330ff11275abafd612e9c99407a94a #17572
Ref: https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-terminatethread

Also:
- use `WaitForSingleObjectEx()` on all desktop Windows.
  Ref: 4be80d5109a340973dc6ce0221ec5c5761587df0
  Ref: https://sourceforge.net/p/curl/feature-requests/82/
  Ref: https://learn.microsoft.com/windows/win32/api/synchapi/nf-synchapi-waitforsingleobjectex
- tests: drop redundant casts.
- lib3207: fix to not rely on thread macros when building without thread
  support.

Assisted-by: Jay Satiro
Assisted-by: Marcel Raad
Assisted-by: Michał Petryka
Follow-up to 38029101e2d78ba125732b3bab6ec267b80a0e72 #11625

---

w/o sp https://github.com/curl/curl/pull/18451/files?w=1
