### PR TITLE
limit-rate revisited

### DIFF
--- a/lib/cf-ip-happy.c
+++ b/lib/cf-ip-happy.c
@@ -767,6 +767,7 @@ static CURLcode cf_ip_happy_connect(struct Curl_cfilter *cf,
         cf->next = ctx->ballers.winner->cf;
         ctx->ballers.winner->cf = NULL;
         cf_ip_happy_ctx_clear(cf, data);
+        Curl_expire_done(data, EXPIRE_HAPPY_EYEBALLS);
 
         if(cf->conn->handler->protocol & PROTO_FAMILY_SSH)
           Curl_pgrsTime(data, TIMER_APPCONNECT); /* we are connected already */

--- a/lib/curl_trc.c
+++ b/lib/curl_trc.c
@@ -273,6 +273,45 @@ struct curl_trc_feat Curl_trc_feat_dns = {
   CURL_LOG_LVL_NONE,
 };
 
+static const char * const Curl_trc_timer_names[]={
+  "100_TIMEOUT",
+  "ASYNC_NAME",
+  "CONNECTTIMEOUT",
+  "DNS_PER_NAME",
+  "DNS_PER_NAME2",
+  "HAPPY_EYEBALLS_DNS",
+  "HAPPY_EYEBALLS",
+  "MULTI_PENDING",
+  "SPEEDCHECK",
+  "TIMEOUT",
+  "TOOFAST",
+  "QUIC",
+  "FTP_ACCEPT",
+  "ALPN_EYEBALLS",
+  "SHUTDOWN",
+};
+
+const char *Curl_trc_timer_name(int tid)
+{
+  if((tid >= 0) && ((size_t)tid < CURL_ARRAYSIZE(Curl_trc_timer_names)))
+    return Curl_trc_timer_names[(size_t)tid];
+  return "UNKNOWN?";
+}
+
+void Curl_trc_multi_timeouts(struct Curl_easy *data)
+{
+  struct Curl_llist_node *e = Curl_llist_head(&data->state.timeoutlist);
+  if(e) {
+    struct curltime now = curlx_now();
+    while(e) {
+      struct time_node *n = Curl_node_elem(e);
+      e = Curl_node_next(e);
+      CURL_TRC_M(data, "[TIMEOUT] %s expires in %" FMT_TIMEDIFF_T "ns",
+                 CURL_TIMER_NAME(n->eid),
+                 curlx_timediff_us(n->time, now));
+    }
+  }
+}
 
 static const char * const Curl_trc_mstate_names[]={
   "INIT",

--- a/lib/curl_trc.h
+++ b/lib/curl_trc.h
@@ -85,6 +85,9 @@ void Curl_trc_cf_infof(struct Curl_easy *data, const struct Curl_cfilter *cf,
 void Curl_trc_multi(struct Curl_easy *data,
                     const char *fmt, ...) CURL_PRINTF(2, 3);
 const char *Curl_trc_mstate_name(int state);
+const char *Curl_trc_timer_name(int tid);
+void Curl_trc_multi_timeouts(struct Curl_easy *data);
+
 void Curl_trc_write(struct Curl_easy *data,
                     const char *fmt, ...) CURL_PRINTF(2, 3);
 void Curl_trc_read(struct Curl_easy *data,
@@ -113,12 +116,15 @@ void Curl_trc_ws(struct Curl_easy *data,
                  const char *fmt, ...) CURL_PRINTF(2, 3);
 #endif
 
+#define CURL_TRC_M_is_verbose(data) \
+  Curl_trc_ft_is_verbose(data, &Curl_trc_feat_multi)
+
 #if defined(CURL_HAVE_C99) && !defined(CURL_DISABLE_VERBOSE_STRINGS)
 #define infof(data, ...) \
   do { if(Curl_trc_is_verbose(data)) \
          Curl_infof(data, __VA_ARGS__); } while(0)
 #define CURL_TRC_M(data, ...) \
-  do { if(Curl_trc_ft_is_verbose(data, &Curl_trc_feat_multi)) \
+  do { if(CURL_TRC_M_is_verbose(data)) \
          Curl_trc_multi(data, __VA_ARGS__); } while(0)
 #define CURL_TRC_CF(data, cf, ...) \
   do { if(Curl_trc_cf_is_verbose(cf, data)) \
@@ -202,6 +208,10 @@ extern struct curl_trc_feat Curl_trc_feat_dns;
             (Curl_trc_is_verbose(data) && \
              (ft)->log_level >= CURL_LOG_LVL_INFO)
 #define CURL_MSTATE_NAME(s)  Curl_trc_mstate_name((int)(s))
+#define CURL_TIMER_NAME(t)   Curl_trc_timer_name((int)(t))
+#define CURL_TRC_M_TIMEOUTS(data) \
+  do { if(CURL_TRC_M_is_verbose(data)) \
+         Curl_trc_multi_timeouts(data); } while(0)
 
 #else /* CURL_DISABLE_VERBOSE_STRINGS */
 /* All informational messages are not compiled in for size savings */
@@ -210,6 +220,8 @@ extern struct curl_trc_feat Curl_trc_feat_dns;
 #define Curl_trc_cf_is_verbose(x,y)   (FALSE)
 #define Curl_trc_ft_is_verbose(x,y)   (FALSE)
 #define CURL_MSTATE_NAME(x)           ((void)(x), "-")
+#define CURL_TIMER_NAME(x)            ((void)(x), "-")
+#define CURL_TRC_M_TIMEOUTS(x)        Curl_nop_stmt
 
 #endif /* !CURL_DISABLE_VERBOSE_STRINGS */
 

--- a/lib/multiif.h
+++ b/lib/multiif.h
@@ -162,5 +162,7 @@ unsigned int Curl_multi_xfers_running(struct Curl_multi *multi);
 /* Mark a transfer as dirty, e.g. to be rerun at earliest convenience.
  * A cheap operation, can be done many times repeatedly. */
 void Curl_multi_mark_dirty(struct Curl_easy *data);
+/* Clear transfer from the dirty set. */
+void Curl_multi_clear_dirty(struct Curl_easy *data);
 
 #endif /* HEADER_CURL_MULTIIF_H */

--- a/lib/transfer.h
+++ b/lib/transfer.h
@@ -143,5 +143,7 @@ bool Curl_xfer_recv_is_paused(struct Curl_easy *data);
 CURLcode Curl_xfer_pause_send(struct Curl_easy *data, bool enable);
 CURLcode Curl_xfer_pause_recv(struct Curl_easy *data, bool enable);
 
+/* Query if transfer has expire timeout TOOFAST set. */
+bool Curl_xfer_is_too_fast(struct Curl_easy *data);
 
 #endif /* HEADER_CURL_TRANSFER_H */

--- a/tests/http/testenv/curl.py
+++ b/tests/http/testenv/curl.py
@@ -582,17 +582,16 @@ class CurlClient:
                       with_profile: bool = False,
                       with_tcpdump: bool = False,
                       no_save: bool = False,
+                      limit_rate: Optional[str] = None,
                       extra_args: Optional[List[str]] = None):
         if extra_args is None:
             extra_args = []
         if no_save:
-            extra_args.extend([
-                '--out-null',
-            ])
+            extra_args.extend(['--out-null'])
         else:
-            extra_args.extend([
-                '-o', 'download_#1.data',
-            ])
+            extra_args.extend(['-o', 'download_#1.data'])
+        if limit_rate:
+            extra_args.extend(['--limit-rate', limit_rate])
         # remove any existing ones
         for i in range(100):
             self._rmf(self.download_file(i))


### PR DESCRIPTION
Tweaks around handling of --limit-rate:

* tracing: trace outstanding timeouts by name
* multi: do not mark transfer as dirty that have an EXPIRE_TOOFAST set
* multi: have one static function to asses speed limits
* multi: when setting EXPIRE_TOOFAST remove the transfers from the dirty set
* progress: rename vars and comment on how speed limit timeouts are calculated, for clarity
* transfer: when speed limiting, exit the receive loop after a quarter of the limit has been received, not on the first chunk received.
* cf-ip-happy.c: clear EXPIRE_HAPPY_EYEBALLS on connect
* scorecard: add --limit-rate parameter to test with speed limits in effect