### PR TITLE
lib: drop `UNUSED_PARAM` macro

### DIFF
--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -786,12 +786,8 @@
 #if defined(__GNUC__) && ((__GNUC__ >= 3) || \
   ((__GNUC__ == 2) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 7)))
 #  define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-#elif defined(__IAR_SYSTEMS_ICC__)
-#  if (__VER__ >= 9040001)
-#    define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-#  else
-#    define WARN_UNUSED_RESULT
-#  endif
+#elif defined(__IAR_SYSTEMS_ICC__) && (__VER__ >= 9040001)
+#  define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #else
 #  define WARN_UNUSED_RESULT
 #endif

--- a/lib/curl_setup.h
+++ b/lib/curl_setup.h
@@ -783,20 +783,16 @@
  * Parameters should of course normally not be unused, but for example when
  * we have multiple implementations of the same interface it may happen.
  */
-
 #if defined(__GNUC__) && ((__GNUC__ >= 3) || \
   ((__GNUC__ == 2) && defined(__GNUC_MINOR__) && (__GNUC_MINOR__ >= 7)))
-#  define UNUSED_PARAM __attribute__((__unused__))
 #  define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #elif defined(__IAR_SYSTEMS_ICC__)
-#  define UNUSED_PARAM __attribute__((__unused__))
 #  if (__VER__ >= 9040001)
 #    define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 #  else
 #    define WARN_UNUSED_RESULT
 #  endif
 #else
-#  define UNUSED_PARAM /* NOTHING */
 #  define WARN_UNUSED_RESULT
 #endif
 

--- a/lib/krb5.c
+++ b/lib/krb5.c
@@ -138,8 +138,7 @@ krb5_check_prot(void *app_data, int level)
 
 static int
 krb5_decode(void *app_data, void *buf, int len,
-            int level UNUSED_PARAM,
-            struct connectdata *conn UNUSED_PARAM)
+            int level, struct connectdata *conn)
 {
   gss_ctx_id_t *context = app_data;
   OM_uint32 maj, min;

--- a/lib/vtls/gtls.c
+++ b/lib/vtls/gtls.c
@@ -2232,7 +2232,7 @@ static bool gtls_cert_status_request(void)
 }
 
 static void *gtls_get_internals(struct ssl_connect_data *connssl,
-                                CURLINFO info UNUSED_PARAM)
+                                CURLINFO info)
 {
   struct gtls_ssl_backend_data *backend =
     (struct gtls_ssl_backend_data *)connssl->backend;

--- a/lib/vtls/mbedtls.c
+++ b/lib/vtls/mbedtls.c
@@ -1458,7 +1458,7 @@ static bool mbedtls_data_pending(struct Curl_cfilter *cf,
 static CURLcode mbedtls_sha256sum(const unsigned char *input,
                                   size_t inputlen,
                                   unsigned char *sha256sum,
-                                  size_t sha256len UNUSED_PARAM)
+                                  size_t sha256len)
 {
   (void)sha256len;
   /* returns 0 on success, otherwise failure */
@@ -1468,7 +1468,7 @@ static CURLcode mbedtls_sha256sum(const unsigned char *input,
 }
 
 static void *mbedtls_get_internals(struct ssl_connect_data *connssl,
-                                   CURLINFO info UNUSED_PARAM)
+                                   CURLINFO info)
 {
   struct mbed_ssl_backend_data *backend =
     (struct mbed_ssl_backend_data *)connssl->backend;

--- a/lib/vtls/rustls.c
+++ b/lib/vtls/rustls.c
@@ -393,9 +393,11 @@ out:
 /* A server certificate verify callback for Rustls that always returns
    RUSTLS_RESULT_OK, or in other words disable certificate verification. */
 static uint32_t
-cr_verify_none(void *userdata UNUSED_PARAM,
-               const rustls_verify_server_cert_params *params UNUSED_PARAM)
+cr_verify_none(void *userdata,
+               const rustls_verify_server_cert_params *params)
 {
+  (void)userdata;
+  (void)params;
   return RUSTLS_RESULT_OK;
 }
 
@@ -1295,10 +1297,11 @@ cr_connect(struct Curl_cfilter *cf,
 
 static void *
 cr_get_internals(struct ssl_connect_data *connssl,
-                 CURLINFO info UNUSED_PARAM)
+                 CURLINFO info)
 {
   struct rustls_ssl_backend_data *backend =
     (struct rustls_ssl_backend_data *)connssl->backend;
+  (void)info;
   DEBUGASSERT(backend);
   return backend->conn;
 }

--- a/lib/vtls/schannel.c
+++ b/lib/vtls/schannel.c
@@ -2583,7 +2583,7 @@ static size_t schannel_version(char *buffer, size_t size)
   return msnprintf(buffer, size, "Schannel");
 }
 
-static CURLcode schannel_random(struct Curl_easy *data UNUSED_PARAM,
+static CURLcode schannel_random(struct Curl_easy *data,
                                 unsigned char *entropy, size_t length)
 {
   (void)data;
@@ -2725,7 +2725,7 @@ static CURLcode schannel_sha256sum(const unsigned char *input,
 }
 
 static void *schannel_get_internals(struct ssl_connect_data *connssl,
-                                    CURLINFO info UNUSED_PARAM)
+                                    CURLINFO info)
 {
   struct schannel_ssl_backend_data *backend =
     (struct schannel_ssl_backend_data *)connssl->backend;


### PR DESCRIPTION
Added in 2011, but has seen little use in the code. The necessary
compiler feature is missing in some compilers (e.g. MSVC), thus in most
places the portable `(void)` cast is used in addition.

Also:
- vtls/rustls: silence unused argument warning with `(void)`.
  Necessary for MSVC, for example.

Ref: ee4ed461288ec74641e3b96d5508628c07f689b0
