### PR TITLE
tool_getparam: warn on all unicode 0xe2 0x80 prefixes

### DIFF
--- a/src/tool_getparam.c
+++ b/src/tool_getparam.c
@@ -2947,8 +2947,8 @@ ParameterError getparameter(const char *flag, /* f or -long-flag */
         warnf("The filename argument '%s' looks like a flag.",
               nextarg);
       }
-      else if(!strncmp("\xe2\x80\x9c", nextarg, 3)) {
-        warnf("The argument '%s' starts with a Unicode quote where "
+      else if(!strncmp("\xe2\x80", nextarg, 2)) {
+        warnf("The argument '%s' starts with a Unicode character where "
               "maybe an ASCII \" was intended?",
               nextarg);
       }


### PR DESCRIPTION
If a string argument is expected and the first two bytes are 0xe2 ex80 that's enough for curl to warn.

Previously we tried to detect and warn only for the unicode double quote, but users might use single quotes, other quotes or even lead the argument with one of the "zero widths" characters. This is an attempt to detect many of those. Without triggering for "normal" IDN hostnames.