### PR TITLE
idn: reject conversions that end up with a zero length hostname

### DIFF
--- a/lib/idn.c
+++ b/lib/idn.c
@@ -323,8 +323,12 @@ CURLcode Curl_idn_decode(const char *input, char **output)
       result = CURLE_OUT_OF_MEMORY;
   }
 #endif
-  if(!result)
-    *output = d;
+  if(!result) {
+    if(!d[0]) /* ended up zero length, not acceptable */
+      result = CURLE_URL_MALFORMAT;
+    else
+      *output = d;
+  }
   return result;
 }
 


### PR DESCRIPTION
Reported-by: RepoRascal on hackerone