### PR TITLE
tests: remove the 'none' server

### DIFF
--- a/docs/tests/FILEFORMAT.md
+++ b/docs/tests/FILEFORMAT.md
@@ -416,7 +416,6 @@ What server(s) this test case requires/uses. Available servers:
 - `http-unix`
 - `imap`
 - `mqtt`
-- `none`
 - `pop3`
 - `rtsp`
 - `rtsp-ipv6`

--- a/tests/data/test1013
+++ b/tests/data/test1013
@@ -13,9 +13,6 @@ curl-config
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Compare curl --version with curl-config --protocols
 </name>

--- a/tests/data/test1014
+++ b/tests/data/test1014
@@ -13,9 +13,6 @@ curl-config
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Compare curl --version with curl-config --features
 </name>

--- a/tests/data/test1016
+++ b/tests/data/test1016
@@ -11,9 +11,6 @@ Range
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 file
 </features>

--- a/tests/data/test1017
+++ b/tests/data/test1017
@@ -12,9 +12,6 @@ Range
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 file
 </features>

--- a/tests/data/test1018
+++ b/tests/data/test1018
@@ -11,9 +11,6 @@ Range
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 file
 </features>

--- a/tests/data/test1019
+++ b/tests/data/test1019
@@ -12,9 +12,6 @@ Range
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 file
 </features>

--- a/tests/data/test1020
+++ b/tests/data/test1020
@@ -12,9 +12,6 @@ Range
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 file
 </features>

--- a/tests/data/test1022
+++ b/tests/data/test1022
@@ -13,9 +13,6 @@ curl-config
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Compare curl --version with curl-config --version
 </name>

--- a/tests/data/test1023
+++ b/tests/data/test1023
@@ -13,9 +13,6 @@ curl-config
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Compare curl --version with curl-config --vernum
 </name>

--- a/tests/data/test1026
+++ b/tests/data/test1026
@@ -16,9 +16,6 @@
 <features>
 manual
 </features>
-<server>
-none
-</server>
 <name>
 curl --manual
 </name>

--- a/tests/data/test1027
+++ b/tests/data/test1027
@@ -13,9 +13,6 @@
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 curl --help
 </name>

--- a/tests/data/test1034
+++ b/tests/data/test1034
@@ -19,9 +19,6 @@ config file
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 IDN
 http

--- a/tests/data/test1035
+++ b/tests/data/test1035
@@ -17,9 +17,6 @@ FAILURE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 IDN
 http

--- a/tests/data/test1063
+++ b/tests/data/test1063
@@ -13,9 +13,6 @@ FAILURE
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 file
 Largefile

--- a/tests/data/test1084
+++ b/tests/data/test1084
@@ -20,9 +20,6 @@ non-existing host
 <features>
 http
 </features>
-<server>
-none
-</server>
 <name>
 HTTP GET with invalid --interface
 </name>

--- a/tests/data/test1085
+++ b/tests/data/test1085
@@ -22,9 +22,6 @@ non-existing host
 http
 IPv6
 </features>
-<server>
-none
-</server>
 <name>
 HTTP-IPv6 GET with invalid --interface
 </name>

--- a/tests/data/test1119
+++ b/tests/data/test1119
@@ -9,10 +9,6 @@ symbols-in-versions
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify that symbols-in-versions and headers are in sync
 </name>

--- a/tests/data/test1132
+++ b/tests/data/test1132
@@ -9,10 +9,6 @@ memory-includes
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify memory #include files in libcurl's C source files
 </name>

--- a/tests/data/test1135
+++ b/tests/data/test1135
@@ -9,10 +9,6 @@ CURL_EXTERN
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 # The VMS and OS/400 builds extract the CURL_EXTERN protos and use in
 # the build. We break binary compatibility by changing order. Only add
 # new entries last or bump the SONAME.

--- a/tests/data/test1139
+++ b/tests/data/test1139
@@ -11,10 +11,6 @@ documentation
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify that all libcurl options have man pages
 </name>

--- a/tests/data/test1140
+++ b/tests/data/test1140
@@ -10,10 +10,6 @@ documentation
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify the nroff of manpages
 </name>

--- a/tests/data/test1165
+++ b/tests/data/test1165
@@ -9,10 +9,6 @@ CURL_DISABLE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify configure.ac and source code CURL_DISABLE_-sync
 </name>

--- a/tests/data/test1167
+++ b/tests/data/test1167
@@ -8,10 +8,6 @@ source analysis
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify curl prefix of public symbols in header files
 </name>

--- a/tests/data/test1169
+++ b/tests/data/test1169
@@ -8,9 +8,6 @@ runtests.pl
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Verify that runtests.pl accepts an -L option
 </name>

--- a/tests/data/test1173
+++ b/tests/data/test1173
@@ -10,10 +10,6 @@ documentation
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Manpage syntax checks
 </name>

--- a/tests/data/test1175
+++ b/tests/data/test1175
@@ -9,10 +9,6 @@ symbols-in-versions
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify that symbols-in-versions and libcurl-errors.3 are in sync
 </name>

--- a/tests/data/test1177
+++ b/tests/data/test1177
@@ -10,10 +10,6 @@ documentation
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify that feature names and CURL_VERSION_* in lib and docs are in sync
 </name>

--- a/tests/data/test1179
+++ b/tests/data/test1179
@@ -14,9 +14,6 @@ wrong option
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 # make this test require manual as the error message is different without it
 <features>
 manual

--- a/tests/data/test1182
+++ b/tests/data/test1182
@@ -8,9 +8,6 @@ runtests.pl
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Verify that runtests.pl accepts an exclude file with the -E option
 </name>

--- a/tests/data/test1185
+++ b/tests/data/test1185
@@ -8,9 +8,6 @@ checksrc
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 checksrc
 </name>

--- a/tests/data/test1222
+++ b/tests/data/test1222
@@ -8,10 +8,6 @@ source analysis
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify deprecation statuses and versions
 </name>

--- a/tests/data/test1234
+++ b/tests/data/test1234
@@ -12,9 +12,6 @@ FAILURE
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 abusing {}-globbing
 </name>

--- a/tests/data/test1236
+++ b/tests/data/test1236
@@ -11,9 +11,6 @@ FAILURE
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 [] globbing overflowing the range counter
 </name>

--- a/tests/data/test1260
+++ b/tests/data/test1260
@@ -12,9 +12,6 @@ HTTP GET
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test1263
+++ b/tests/data/test1263
@@ -13,9 +13,6 @@ HTTP GET
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test1264
+++ b/tests/data/test1264
@@ -12,9 +12,6 @@ HTTP GET
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test1268
+++ b/tests/data/test1268
@@ -13,9 +13,6 @@ warning
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 UnixSockets
 </features>

--- a/tests/data/test1269
+++ b/tests/data/test1269
@@ -13,9 +13,6 @@
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 too large --retry-delay value
 </name>

--- a/tests/data/test1275
+++ b/tests/data/test1275
@@ -9,10 +9,6 @@ markdown
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify capital letters after period in markdown files
 </name>

--- a/tests/data/test1276
+++ b/tests/data/test1276
@@ -9,10 +9,6 @@ documentation
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify lib/optiontable.pl
 </name>

--- a/tests/data/test1279
+++ b/tests/data/test1279
@@ -10,10 +10,6 @@ libcurl.def
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify libcurl.def against CURL_EXTERN declarations
 </name>

--- a/tests/data/test1281
+++ b/tests/data/test1281
@@ -12,9 +12,6 @@ URL
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test1291
+++ b/tests/data/test1291
@@ -15,9 +15,6 @@ HTTP PUT
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Attempt to upload 1000 files but fail immediately
 </name>

--- a/tests/data/test1300
+++ b/tests/data/test1300
@@ -9,9 +9,6 @@ llist
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1301
+++ b/tests/data/test1301
@@ -8,9 +8,6 @@ curl_strequal
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1302
+++ b/tests/data/test1302
@@ -9,9 +9,6 @@ base64
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1303
+++ b/tests/data/test1303
@@ -9,9 +9,6 @@ Curl_timeleft
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1304
+++ b/tests/data/test1304
@@ -9,9 +9,6 @@ netrc
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 netrc

--- a/tests/data/test1305
+++ b/tests/data/test1305
@@ -10,9 +10,6 @@ hash
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1306
+++ b/tests/data/test1306
@@ -10,9 +10,6 @@ hash
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1307
+++ b/tests/data/test1307
@@ -10,9 +10,6 @@ wildcardmatch
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 ftp

--- a/tests/data/test1308
+++ b/tests/data/test1308
@@ -14,9 +14,6 @@ FORM
 http
 form-api
 </features>
-<server>
-none
-</server>
 <name>
 formpost tests
 </name>

--- a/tests/data/test1309
+++ b/tests/data/test1309
@@ -9,9 +9,6 @@ splay
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1323
+++ b/tests/data/test1323
@@ -14,9 +14,6 @@ curlx_tvdiff
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1330
+++ b/tests/data/test1330
@@ -13,9 +13,6 @@ TrackMemory
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 TrackMemory

--- a/tests/data/test1394
+++ b/tests/data/test1394
@@ -8,9 +8,6 @@ unittest
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1395
+++ b/tests/data/test1395
@@ -8,9 +8,6 @@ unittest
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1396
+++ b/tests/data/test1396
@@ -10,9 +10,6 @@ curl_easy_unescape
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1397
+++ b/tests/data/test1397
@@ -9,9 +9,6 @@ Curl_cert_hostcheck
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1398
+++ b/tests/data/test1398
@@ -9,9 +9,6 @@ curl_msnprintf
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1399
+++ b/tests/data/test1399
@@ -9,9 +9,6 @@ Curl_pgrsTime
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1409
+++ b/tests/data/test1409
@@ -10,9 +10,6 @@ FAILURE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Pass in string to -C
 </name>

--- a/tests/data/test1410
+++ b/tests/data/test1410
@@ -10,9 +10,6 @@ FAILURE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Pass in negative number to --max-time
 </name>

--- a/tests/data/test1427
+++ b/tests/data/test1427
@@ -8,9 +8,6 @@ integer overflow
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 too large -m timeout value
 </name>

--- a/tests/data/test1447
+++ b/tests/data/test1447
@@ -13,9 +13,6 @@ FAILURE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 proxy

--- a/tests/data/test1453
+++ b/tests/data/test1453
@@ -13,9 +13,6 @@ FAILURE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 tftp
 </features>

--- a/tests/data/test1461
+++ b/tests/data/test1461
@@ -16,9 +16,6 @@
 <features>
 manual
 </features>
-<server>
-none
-</server>
 <name>
 curl important --help
 </name>

--- a/tests/data/test1462
+++ b/tests/data/test1462
@@ -13,9 +13,6 @@
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 curl invalid category --help
 </name>

--- a/tests/data/test1463
+++ b/tests/data/test1463
@@ -14,9 +14,6 @@ FILE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 file
 </features>

--- a/tests/data/test1464
+++ b/tests/data/test1464
@@ -14,9 +14,6 @@ FILE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 file
 </features>

--- a/tests/data/test1469
+++ b/tests/data/test1469
@@ -9,9 +9,6 @@ FAILURE
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Space in FTP upload URL
 </name>

--- a/tests/data/test1471
+++ b/tests/data/test1471
@@ -14,9 +14,6 @@ FAILURE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test1472
+++ b/tests/data/test1472
@@ -14,9 +14,6 @@ FAILURE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test1474
+++ b/tests/data/test1474
@@ -15,9 +15,6 @@ HTTP GET
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test1477
+++ b/tests/data/test1477
@@ -8,10 +8,6 @@ documentation
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify that error codes in headers and libcurl-errors.3 are in sync
 </name>

--- a/tests/data/test1478
+++ b/tests/data/test1478
@@ -10,10 +10,6 @@ documentation
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 src/tool_listhelp.c is in sync with docs/cmdline-opts
 </name>

--- a/tests/data/test1486
+++ b/tests/data/test1486
@@ -10,10 +10,6 @@ docs
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify that write-out.md and tool_writeout.c are in sync
 </name>

--- a/tests/data/test1488
+++ b/tests/data/test1488
@@ -10,10 +10,6 @@ manpages
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 symbols-in-versions and manpages agree on added-in versions
 </name>

--- a/tests/data/test1508
+++ b/tests/data/test1508
@@ -8,9 +8,6 @@ multi
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1521
+++ b/tests/data/test1521
@@ -8,9 +8,6 @@ curl_easy_setopt
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1530
+++ b/tests/data/test1530
@@ -6,9 +6,6 @@ CURLOPT_OPENSOCKETFUNCTION
 </info>
 
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test1537
+++ b/tests/data/test1537
@@ -12,9 +12,6 @@ URL escape
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1538
+++ b/tests/data/test1538
@@ -13,9 +13,6 @@ verbose logs
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1544
+++ b/tests/data/test1544
@@ -8,10 +8,6 @@ source analysis
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify all string options are translated by OS/400 wrapper
 </name>

--- a/tests/data/test1550
+++ b/tests/data/test1550
@@ -11,9 +11,6 @@ multi
 
 # Client-side
 <client>
-<server>
-none
-</server>
 # tool is what to use instead of 'curl'
 <tool>
 lib%TESTNUMBER

--- a/tests/data/test1557
+++ b/tests/data/test1557
@@ -10,9 +10,6 @@ crash
 </reply>
 
 <client>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1558
+++ b/tests/data/test1558
@@ -10,9 +10,6 @@ CURLINFO_PROTOCOL
 </reply>
 
 <client>
-<server>
-none
-</server>
 <features>
 file
 </features>

--- a/tests/data/test1559
+++ b/tests/data/test1559
@@ -10,9 +10,6 @@ verbose logs
 </reply>
 
 <client>
-<server>
-none
-</server>
 
 # require HTTP so that CURLOPT_POSTFIELDS works as assumed
 <features>

--- a/tests/data/test1560
+++ b/tests/data/test1560
@@ -9,9 +9,6 @@ urlapi
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <setenv>
 LC_ALL=C.UTF-8
 </setenv>

--- a/tests/data/test1564
+++ b/tests/data/test1564
@@ -15,9 +15,6 @@ wakeup
 <features>
 wakeup
 </features>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1592
+++ b/tests/data/test1592
@@ -12,9 +12,6 @@ timing-dependent
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test1597
+++ b/tests/data/test1597
@@ -10,9 +10,6 @@ CURLOPT_PROTOCOLS_STR
 </reply>
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 CURLOPT_PROTOCOLS_STR
 </name>

--- a/tests/data/test1600
+++ b/tests/data/test1600
@@ -9,9 +9,6 @@ NTLM
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 NTLM

--- a/tests/data/test1601
+++ b/tests/data/test1601
@@ -9,9 +9,6 @@ MD5
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1602
+++ b/tests/data/test1602
@@ -9,9 +9,6 @@ hash
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1603
+++ b/tests/data/test1603
@@ -9,9 +9,6 @@ hash
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1604
+++ b/tests/data/test1604
@@ -8,9 +8,6 @@ unittest
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1605
+++ b/tests/data/test1605
@@ -8,9 +8,6 @@ unittest
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1606
+++ b/tests/data/test1606
@@ -9,9 +9,6 @@ speedcheck
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1607
+++ b/tests/data/test1607
@@ -9,9 +9,6 @@ CURLOPT_RESOLVE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1608
+++ b/tests/data/test1608
@@ -9,9 +9,6 @@ curlopt_dns_shuffle_addresses
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 shuffle-dns

--- a/tests/data/test1609
+++ b/tests/data/test1609
@@ -9,9 +9,6 @@ CURLOPT_RESOLVE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1610
+++ b/tests/data/test1610
@@ -9,9 +9,6 @@ SHA256
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1611
+++ b/tests/data/test1611
@@ -9,9 +9,6 @@ MD4
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1612
+++ b/tests/data/test1612
@@ -9,9 +9,6 @@ HMAC
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1614
+++ b/tests/data/test1614
@@ -8,9 +8,6 @@ unittest
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 proxy

--- a/tests/data/test1615
+++ b/tests/data/test1615
@@ -9,9 +9,6 @@ SHA-512/256
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 sha512-256

--- a/tests/data/test1616
+++ b/tests/data/test1616
@@ -9,9 +9,6 @@ uint_hash
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1620
+++ b/tests/data/test1620
@@ -9,9 +9,6 @@ URL
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1621
+++ b/tests/data/test1621
@@ -9,9 +9,6 @@ stripcredentials
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1650
+++ b/tests/data/test1650
@@ -9,9 +9,6 @@ DOH
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 DoH

--- a/tests/data/test1651
+++ b/tests/data/test1651
@@ -9,9 +9,6 @@ x509
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1652
+++ b/tests/data/test1652
@@ -7,9 +7,6 @@ infof
 </info>
 
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1653
+++ b/tests/data/test1653
@@ -7,9 +7,6 @@ urlapi
 </info>
 
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1654
+++ b/tests/data/test1654
@@ -7,9 +7,6 @@ Alt-Svc
 </info>
 
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 alt-svc

--- a/tests/data/test1655
+++ b/tests/data/test1655
@@ -9,9 +9,6 @@ DOH
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 DoH

--- a/tests/data/test1656
+++ b/tests/data/test1656
@@ -9,9 +9,6 @@ Curl_x509_GTime2str
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1657
+++ b/tests/data/test1657
@@ -9,9 +9,6 @@ Curl_x509_getASN1Element
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1658
+++ b/tests/data/test1658
@@ -10,9 +10,6 @@ httpsrr
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 DoH

--- a/tests/data/test1660
+++ b/tests/data/test1660
@@ -7,9 +7,6 @@ HSTS
 </info>
 
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 HSTS

--- a/tests/data/test1661
+++ b/tests/data/test1661
@@ -9,9 +9,6 @@ bufref
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1663
+++ b/tests/data/test1663
@@ -10,9 +10,6 @@ bind
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1664
+++ b/tests/data/test1664
@@ -9,9 +9,6 @@ strparse
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 large-size

--- a/tests/data/test1705
+++ b/tests/data/test1705
@@ -10,9 +10,6 @@ managen
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 
 <name>
 managen makes manpage

--- a/tests/data/test1706
+++ b/tests/data/test1706
@@ -10,9 +10,6 @@ managen
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 
 <name>
 managen makes ASCII page

--- a/tests/data/test1707
+++ b/tests/data/test1707
@@ -11,9 +11,6 @@ curl
 <features>
 manual
 </features>
-<server>
-none
-</server>
 
 <name>
 Verify curl -h --insecure

--- a/tests/data/test1708
+++ b/tests/data/test1708
@@ -11,9 +11,6 @@ curl
 <features>
 manual
 </features>
-<server>
-none
-</server>
 
 <name>
 Verify curl -h -F

--- a/tests/data/test1709
+++ b/tests/data/test1709
@@ -11,9 +11,6 @@ curl
 <features>
 manual
 </features>
-<server>
-none
-</server>
 
 <name>
 Verify curl -h with bad option name

--- a/tests/data/test1710
+++ b/tests/data/test1710
@@ -11,9 +11,6 @@ curl
 <features>
 manual
 </features>
-<server>
-none
-</server>
 
 <name>
 Verify curl -h --no-clobber

--- a/tests/data/test19
+++ b/tests/data/test19
@@ -12,9 +12,6 @@ FAILURE
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test1900
+++ b/tests/data/test1900
@@ -16,9 +16,6 @@ HSTS
 HSTS
 http
 </features>
-<server>
-none
-</server>
 
 <name>
 HSTS curl_easy_duphandle

--- a/tests/data/test1911
+++ b/tests/data/test1911
@@ -11,9 +11,6 @@ curl_easy_option
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 verify that curl_easy_setopt() rejects too long string inputs
 </name>

--- a/tests/data/test1912
+++ b/tests/data/test1912
@@ -12,9 +12,6 @@ typecheck
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Cross validate that gcc-typecheck macros match the option types.
 </name>

--- a/tests/data/test1915
+++ b/tests/data/test1915
@@ -17,9 +17,6 @@ CURLOPT_HSTSREADFUNCTION
 HSTS
 http
 </features>
-<server>
-none
-</server>
 
 <name>
 HSTS read/write callbacks

--- a/tests/data/test1918
+++ b/tests/data/test1918
@@ -13,9 +13,6 @@ curl_easy_option_by_id
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 curl_easy_option_by_name() and curl_easy_option_by_id()
 </name>

--- a/tests/data/test1979
+++ b/tests/data/test1979
@@ -10,9 +10,6 @@ aws-sigv4
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test1980
+++ b/tests/data/test1980
@@ -10,9 +10,6 @@ aws-sigv4
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test20
+++ b/tests/data/test20
@@ -13,9 +13,6 @@ non-existing host
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test2043
+++ b/tests/data/test2043
@@ -12,9 +12,6 @@ HTTP GET
 <features>
 Schannel
 </features>
-<server>
-none
-</server>
 <name>
 Disable certificate revocation checks
 </name>

--- a/tests/data/test2044
+++ b/tests/data/test2044
@@ -8,12 +8,6 @@
 #
 # Client-side
 <client>
-<features>
-none
-</features>
-<server>
-none
-</server>
 <name>
 Attempt to set a default protocol that does not exist
 </name>

--- a/tests/data/test2045
+++ b/tests/data/test2045
@@ -29,9 +29,6 @@ REPLY welcome HTTP/1.1 200 OK\r\nContent-Length: 21\r\n\r\n500 Weird FTP Reply
 #
 # Client-side
 <client>
-<features>
-none
-</features>
 <server>
 ftp
 </server>

--- a/tests/data/test2075
+++ b/tests/data/test2075
@@ -12,9 +12,6 @@ HTTP
 <features>
 http
 </features>
-<server>
-none
-</server>
 <name>
 Verify usernames are not allowed in url
 </name>

--- a/tests/data/test2080
+++ b/tests/data/test2080
@@ -14,9 +14,6 @@ config
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 config file with overly long option
 </name>

--- a/tests/data/test219
+++ b/tests/data/test219
@@ -14,9 +14,6 @@ unsupported scheme
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 proxy

--- a/tests/data/test2600
+++ b/tests/data/test2600
@@ -10,9 +10,6 @@ timing-dependent
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 Debug

--- a/tests/data/test2601
+++ b/tests/data/test2601
@@ -9,9 +9,6 @@ bufq
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test2602
+++ b/tests/data/test2602
@@ -9,9 +9,6 @@ dynhds
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test2603
+++ b/tests/data/test2603
@@ -9,9 +9,6 @@ http1
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test2604
+++ b/tests/data/test2604
@@ -8,9 +8,6 @@ unittest
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 sftp

--- a/tests/data/test288
+++ b/tests/data/test288
@@ -18,9 +18,6 @@ moo
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 file
 </features>

--- a/tests/data/test3026
+++ b/tests/data/test3026
@@ -21,9 +21,6 @@ slow
 threadsafe
 threaded-resolver
 </features>
-<server>
-none
-</server>
 <name>
 curl_global_init thread-safety
 </name>

--- a/tests/data/test3105
+++ b/tests/data/test3105
@@ -9,9 +9,6 @@ curl_multi_remove_handle
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test3200
+++ b/tests/data/test3200
@@ -9,9 +9,6 @@ curl_get_line
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test3205
+++ b/tests/data/test3205
@@ -9,9 +9,6 @@ cipher_suite
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test3211
+++ b/tests/data/test3211
@@ -9,9 +9,6 @@ uint_bset
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test3212
+++ b/tests/data/test3212
@@ -9,9 +9,6 @@ uint_bset
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test3213
+++ b/tests/data/test3213
@@ -9,9 +9,6 @@ uint_spbset
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test3214
+++ b/tests/data/test3214
@@ -9,9 +9,6 @@ size
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 unittest
 </features>

--- a/tests/data/test333
+++ b/tests/data/test333
@@ -13,9 +13,6 @@ cmdline
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Try a non-boolean command line option with --no-
 </name>

--- a/tests/data/test370
+++ b/tests/data/test370
@@ -15,9 +15,6 @@ etag
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 --etag-save with bad path - no transfer
 </name>

--- a/tests/data/test375
+++ b/tests/data/test375
@@ -9,9 +9,6 @@ CURL_DISABLE_PROXY
 <features>
 !proxy
 </features>
-<server>
-none
-</server>
 <name>
 Disabled proxy should make curl fail with --proxy
 </name>

--- a/tests/data/test378
+++ b/tests/data/test378
@@ -14,9 +14,6 @@ HTTP POST
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Reject using -T and -d at once
 </name>

--- a/tests/data/test411
+++ b/tests/data/test411
@@ -13,9 +13,6 @@
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 -K with missing file causes error
 </name>

--- a/tests/data/test422
+++ b/tests/data/test422
@@ -14,9 +14,6 @@ cmdline
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 use --next with missing URL before it
 </name>

--- a/tests/data/test460
+++ b/tests/data/test460
@@ -8,9 +8,6 @@ expand
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 try --expand without an argument
 </name>

--- a/tests/data/test462
+++ b/tests/data/test462
@@ -14,9 +14,6 @@ variables
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Missing environment variables in config file
 </name>

--- a/tests/data/test467
+++ b/tests/data/test467
@@ -8,9 +8,6 @@ cmdline
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 use a bad short option letter that does not exist (after one does exist)
 </name>

--- a/tests/data/test484
+++ b/tests/data/test484
@@ -14,9 +14,6 @@ etag
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Use --etag-compare and -save with more than one URL
 </name>

--- a/tests/data/test485
+++ b/tests/data/test485
@@ -14,9 +14,6 @@ etag
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 Use --etag-compare and -save with more than one URL, URLs specified first
 </name>

--- a/tests/data/test496
+++ b/tests/data/test496
@@ -15,9 +15,6 @@ parallel
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 parallel upload missing file
 </name>

--- a/tests/data/test501
+++ b/tests/data/test501
@@ -11,9 +11,6 @@ missing URL
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test504
+++ b/tests/data/test504
@@ -16,9 +16,6 @@ connect to non-listen
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 proxy

--- a/tests/data/test509
+++ b/tests/data/test509
@@ -11,9 +11,6 @@ memory callbacks
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test517
+++ b/tests/data/test517
@@ -12,9 +12,6 @@ unittest
 
 # Client-side
 <client>
-<server>
-none
-</server>
 # tool is what to use instead of 'curl'
 <tool>
 lib%TESTNUMBER

--- a/tests/data/test543
+++ b/tests/data/test543
@@ -8,9 +8,6 @@ curl_easy_escape
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <tool>
 lib%TESTNUMBER
 </tool>

--- a/tests/data/test557
+++ b/tests/data/test557
@@ -12,9 +12,6 @@ unittest
 
 # Client-side
 <client>
-<server>
-none
-</server>
 # tool is what to use instead of 'curl'
 <tool>
 lib%TESTNUMBER

--- a/tests/data/test558
+++ b/tests/data/test558
@@ -12,9 +12,6 @@ TrackMemory
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 TrackMemory
 IPv6

--- a/tests/data/test632
+++ b/tests/data/test632
@@ -10,9 +10,6 @@ server key check
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 sftp
 </features>

--- a/tests/data/test680
+++ b/tests/data/test680
@@ -13,9 +13,6 @@ netrc
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test686
+++ b/tests/data/test686
@@ -13,9 +13,6 @@ errorcode
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 verify return code for missing URL after --next
 </name>

--- a/tests/data/test697
+++ b/tests/data/test697
@@ -13,9 +13,6 @@ netrc
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test745
+++ b/tests/data/test745
@@ -9,9 +9,6 @@ symbols-in-versions
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 
 <name>
 Verify that typecheck-gcc and curl.h are in sync

--- a/tests/data/test746
+++ b/tests/data/test746
@@ -8,9 +8,6 @@ cmdline
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 too large numerical value passed to -m
 </name>

--- a/tests/data/test748
+++ b/tests/data/test748
@@ -14,9 +14,6 @@
 # Client-side
 <client>
 
-<server>
-none
-</server>
 <name>
 A --config file that uses -h and no URL
 </name>

--- a/tests/data/test75
+++ b/tests/data/test75
@@ -15,9 +15,6 @@ FAILURE
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 http
 </features>

--- a/tests/data/test751
+++ b/tests/data/test751
@@ -11,9 +11,6 @@ MULTI
 
 # Client-side
 <client>
-<server>
-none
-</server>
 # tool is what to use instead of 'curl'
 <tool>
 lib%TESTNUMBER

--- a/tests/data/test759
+++ b/tests/data/test759
@@ -8,9 +8,6 @@ globbing
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 glob '{,'
 </name>

--- a/tests/data/test760
+++ b/tests/data/test760
@@ -8,9 +8,6 @@ globbing
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 more cmdline options than URLs and --next
 </name>

--- a/tests/data/test761
+++ b/tests/data/test761
@@ -8,9 +8,6 @@ globbing
 #
 # Client-side
 <client>
-<server>
-none
-</server>
 <name>
 too many {} globs
 </name>

--- a/tests/data/test795
+++ b/tests/data/test795
@@ -16,9 +16,6 @@ Debug
 <name>
 Delayed resolve --connect-timeout check
 </name>
-<server>
-none
-</server>
 <setenv>
 CURL_DNS_DELAY_MS=5000
 </setenv>

--- a/tests/data/test96
+++ b/tests/data/test96
@@ -12,9 +12,6 @@ TrackMemory
 
 # Client-side
 <client>
-<server>
-none
-</server>
 <features>
 TrackMemory
 </features>

--- a/tests/data/test971
+++ b/tests/data/test971
@@ -9,10 +9,6 @@ options-in-versions
 #
 # Client-side
 <client>
-<server>
-none
-</server>
-
 <name>
 Verify that options-in-versions and docs/cmdline-opts are in sync
 </name>

--- a/tests/runner.pm
+++ b/tests/runner.pm
@@ -609,11 +609,7 @@ sub singletest_startservers {
     my $error;
     if(!$listonly) {
         my @what = getpart("client", "server");
-        if(!$what[0]) {
-            warn "Test case $testnum has no server(s) specified";
-            $why = "no server specified";
-            $error = -1;
-        } else {
+        if($what[0]) {
             my $err;
             ($why, $err) = serverfortest(@what);
             if($err == 1) {

--- a/tests/servers.pm
+++ b/tests/servers.pm
@@ -3028,9 +3028,6 @@ sub startservers {
                 $run{'telnet'}="$pid $pid2";
             }
         }
-        elsif($what eq "none") {
-            logmsg "* starts no server\n" if($verbose);
-        }
         else {
             warn "we don't support a server for $what";
             return ("no server for $what", 4);


### PR DESCRIPTION
Only actually needed servers should be listed and none is then implied if no servers are listed.

Outputs a warning if "none" is still set as a server.