### PR TITLE
websocket: reset upload_done when sending data

### DIFF
--- a/lib/ws.c
+++ b/lib/ws.c
@@ -1200,6 +1200,7 @@ CURLcode Curl_ws_accept(struct Curl_easy *data,
 
       /* start over with sending */
       data->req.eos_read = FALSE;
+      data->req.upload_done = FALSE;
       k->keepon |= KEEP_SEND;
     }
 


### PR DESCRIPTION
Sending websocket data did not clear the "upload_done" flag of the initial HTTP Upgrade request, leading to KEEP_SEND never be cleared. This caused the socket to be polled for INOUT after all the websocket data had been sent. A busy loop.